### PR TITLE
CI: Introduce `lint-backend` pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -153,12 +153,6 @@ steps:
   image: alpine:3.15.6
   name: identify-runner
 - commands:
-  - mkdir -p bin
-  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v3.0.7/grabpl
-  - chmod +x bin/grabpl
-  image: byrnedo/alpine-curl:0.1.8
-  name: grabpl
-- commands:
   - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
   depends_on: []
   environment:
@@ -181,14 +175,6 @@ steps:
   image: grafana/build-container:1.6.2
   name: wire-install
 - commands:
-  - make lint-go
-  depends_on:
-  - wire-install
-  environment:
-    CGO_ENABLED: "1"
-  image: grafana/build-container:1.6.2
-  name: lint-backend
-- commands:
   - go test -short -covermode=atomic -timeout=30m ./pkg/...
   depends_on:
   - wire-install
@@ -200,6 +186,66 @@ steps:
   - wire-install
   image: grafana/build-container:1.6.2
   name: test-backend-integration
+trigger:
+  event:
+  - pull_request
+  paths:
+    exclude:
+    - docs/**
+    - '*.md'
+    include:
+    - pkg/**
+    - packaging/**
+    - .drone.yml
+    - conf/**
+    - go.sum
+    - go.mod
+    - public/app/plugins/**/plugin.json
+    - devenv/**
+type: docker
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
+---
+clone:
+  retries: 3
+depends_on: []
+image_pull_secrets:
+- dockerconfigjson
+kind: pipeline
+name: pr-lint-backend
+node:
+  type: no-parallel
+platform:
+  arch: amd64
+  os: linux
+services: []
+steps:
+- commands:
+  - echo $DRONE_RUNNER_NAME
+  image: alpine:3.15.6
+  name: identify-runner
+- commands:
+  - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
+  depends_on: []
+  environment:
+    CGO_ENABLED: 0
+  image: golang:1.19.1
+  name: compile-build-cmd
+- commands:
+  - make gen-go
+  depends_on: []
+  image: grafana/build-container:1.6.2
+  name: wire-install
+- commands:
+  - make lint-go
+  depends_on:
+  - wire-install
+  environment:
+    CGO_ENABLED: "1"
+  image: grafana/build-container:1.6.2
+  name: lint-backend
 trigger:
   event:
   - pull_request
@@ -909,12 +955,6 @@ steps:
   image: alpine:3.15.6
   name: identify-runner
 - commands:
-  - mkdir -p bin
-  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v3.0.7/grabpl
-  - chmod +x bin/grabpl
-  image: byrnedo/alpine-curl:0.1.8
-  name: grabpl
-- commands:
   - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
   depends_on: []
   environment:
@@ -937,14 +977,6 @@ steps:
   image: grafana/build-container:1.6.2
   name: wire-install
 - commands:
-  - make lint-go
-  depends_on:
-  - wire-install
-  environment:
-    CGO_ENABLED: "1"
-  image: grafana/build-container:1.6.2
-  name: lint-backend
-- commands:
   - go test -short -covermode=atomic -timeout=30m ./pkg/...
   depends_on:
   - wire-install
@@ -956,6 +988,59 @@ steps:
   - wire-install
   image: grafana/build-container:1.6.2
   name: test-backend-integration
+trigger:
+  branch: main
+  event:
+  - push
+  paths:
+    exclude:
+    - '*.md'
+    - docs/**
+    - latest.json
+type: docker
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
+---
+clone:
+  retries: 3
+depends_on: []
+image_pull_secrets:
+- dockerconfigjson
+kind: pipeline
+name: main-lint-backend
+node:
+  type: no-parallel
+platform:
+  arch: amd64
+  os: linux
+services: []
+steps:
+- commands:
+  - echo $DRONE_RUNNER_NAME
+  image: alpine:3.15.6
+  name: identify-runner
+- commands:
+  - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
+  depends_on: []
+  environment:
+    CGO_ENABLED: 0
+  image: golang:1.19.1
+  name: compile-build-cmd
+- commands:
+  - make gen-go
+  depends_on: []
+  image: grafana/build-container:1.6.2
+  name: wire-install
+- commands:
+  - make lint-go
+  depends_on:
+  - wire-install
+  environment:
+    CGO_ENABLED: "1"
+  image: grafana/build-container:1.6.2
+  name: lint-backend
 - commands:
   - ./bin/build verify-drone
   depends_on:
@@ -5178,6 +5263,6 @@ kind: secret
 name: packages_secret_access_key
 ---
 kind: signature
-hmac: b08cb03f133c943a789bf6abf7f2645536598e4d8a5a86b34b9231db8afc8ff4
+hmac: b5ee6e9533a47ff6b790790a091bfc21ed27fd4fe12006bd3967530acfab1d05
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -239,12 +239,13 @@ steps:
   image: grafana/build-container:1.6.2
   name: wire-install
 - commands:
+  - apt-get update && apt-get install make
   - make lint-go
   depends_on:
   - wire-install
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.6.2
+  image: golang:1.19.1
   name: lint-backend
 trigger:
   event:
@@ -1034,12 +1035,13 @@ steps:
   image: grafana/build-container:1.6.2
   name: wire-install
 - commands:
+  - apt-get update && apt-get install make
   - make lint-go
   depends_on:
   - wire-install
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.6.2
+  image: golang:1.19.1
   name: lint-backend
 - commands:
   - ./bin/build verify-drone
@@ -2200,12 +2202,13 @@ steps:
   image: golang:1.19.1
   name: compile-build-cmd
 - commands:
+  - apt-get update && apt-get install make
   - make lint-go
   depends_on:
   - wire-install
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.6.2
+  image: golang:1.19.1
   name: lint-backend
 - commands:
   - yarn run prettier:check
@@ -2857,12 +2860,13 @@ steps:
   image: grafana/build-container:1.6.2
   name: verify-gen-cue
 - commands:
+  - apt-get update && apt-get install make
   - make lint-go
   depends_on:
   - wire-install
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.6.2
+  image: golang:1.19.1
   name: lint-backend
 - commands:
   - yarn run prettier:check
@@ -2896,12 +2900,13 @@ steps:
   image: grafana/build-container:1.6.2
   name: test-frontend
 - commands:
+  - apt-get update && apt-get install make
   - make lint-go
   depends_on:
   - wire-install
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.6.2
+  image: golang:1.19.1
   name: lint-backend-enterprise2
 - commands:
   - go test -tags=pro -covermode=atomic -timeout=30m ./pkg/...
@@ -4165,12 +4170,13 @@ steps:
   image: golang:1.19.1
   name: compile-build-cmd
 - commands:
+  - apt-get update && apt-get install make
   - make lint-go
   depends_on:
   - wire-install
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.6.2
+  image: golang:1.19.1
   name: lint-backend
 - commands:
   - yarn run prettier:check
@@ -4786,12 +4792,13 @@ steps:
   image: grafana/build-container:1.6.2
   name: verify-gen-cue
 - commands:
+  - apt-get update && apt-get install make
   - make lint-go
   depends_on:
   - wire-install
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.6.2
+  image: golang:1.19.1
   name: lint-backend
 - commands:
   - yarn run prettier:check
@@ -4825,12 +4832,13 @@ steps:
   image: grafana/build-container:1.6.2
   name: test-frontend
 - commands:
+  - apt-get update && apt-get install make
   - make lint-go
   depends_on:
   - wire-install
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.6.2
+  image: golang:1.19.1
   name: lint-backend-enterprise2
 - commands:
   - go test -tags=pro -covermode=atomic -timeout=30m ./pkg/...
@@ -5263,6 +5271,6 @@ kind: secret
 name: packages_secret_access_key
 ---
 kind: signature
-hmac: b5ee6e9533a47ff6b790790a091bfc21ed27fd4fe12006bd3967530acfab1d05
+hmac: a37b4d779d7265b5ebedd51201d333bd5cdd422badae90abed2b7aa295aca7dd
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -257,7 +257,6 @@ trigger:
     include:
     - pkg/**
     - packaging/**
-    - .drone.yml
     - conf/**
     - go.sum
     - go.mod
@@ -5271,6 +5270,6 @@ kind: secret
 name: packages_secret_access_key
 ---
 kind: signature
-hmac: a37b4d779d7265b5ebedd51201d333bd5cdd422badae90abed2b7aa295aca7dd
+hmac: a17adc518f8ba4ea5c123bf440adf9aceec5e7ba5d9fdae9e467dbd1ec91fd46
 
 ...

--- a/scripts/drone/events/main.star
+++ b/scripts/drone/events/main.star
@@ -47,6 +47,11 @@ load(
     'enterprise_downstream_pipeline',
 )
 
+load(
+    'scripts/drone/pipelines/lint_backend.star',
+    'lint_backend_pipeline',
+)
+
 load('scripts/drone/vault.star', 'from_secret')
 
 
@@ -84,6 +89,7 @@ def main_pipelines(edition):
         docs_pipelines(edition, ver_mode, trigger_docs_main()),
         test_frontend(trigger, ver_mode),
         test_backend(trigger, ver_mode),
+        lint_backend_pipeline(trigger, ver_mode),
         build_e2e(trigger, ver_mode, edition),
         integration_tests(trigger, ver_mode, edition),
         windows(trigger, edition, ver_mode),

--- a/scripts/drone/events/pr.star
+++ b/scripts/drone/events/pr.star
@@ -64,7 +64,7 @@ def pr_pipelines(edition):
         verify_drone(get_pr_trigger(include_paths=['scripts/drone/**', '.drone.yml', '.drone.star']), ver_mode),
         test_frontend(get_pr_trigger(exclude_paths=['pkg/**', 'packaging/**', 'go.sum', 'go.mod']), ver_mode),
         test_backend(get_pr_trigger(include_paths=['pkg/**', 'packaging/**', '.drone.yml', 'conf/**', 'go.sum', 'go.mod', 'public/app/plugins/**/plugin.json', 'devenv/**']), ver_mode),
-        lint_backend_pipeline(get_pr_trigger(include_paths=['pkg/**', 'packaging/**', '.drone.yml', 'conf/**', 'go.sum', 'go.mod', 'public/app/plugins/**/plugin.json', 'devenv/**']), ver_mode),
+        lint_backend_pipeline(get_pr_trigger(include_paths=['pkg/**', 'packaging/**', 'conf/**', 'go.sum', 'go.mod', 'public/app/plugins/**/plugin.json', 'devenv/**']), ver_mode),
         build_e2e(trigger, ver_mode, edition),
         integration_tests(get_pr_trigger(include_paths=['pkg/**', 'packaging/**', '.drone.yml', 'conf/**', 'go.sum', 'go.mod', 'public/app/plugins/**/plugin.json']), ver_mode, edition),
         docs_pipelines(edition, ver_mode, trigger_docs_pr()),

--- a/scripts/drone/events/pr.star
+++ b/scripts/drone/events/pr.star
@@ -39,6 +39,11 @@ load(
     'shellcheck_pipeline',
 )
 
+load(
+    'scripts/drone/pipelines/lint_backend.star',
+    'lint_backend_pipeline',
+)
+
 ver_mode = 'pr'
 trigger = {
     'event': [
@@ -59,6 +64,7 @@ def pr_pipelines(edition):
         verify_drone(get_pr_trigger(include_paths=['scripts/drone/**', '.drone.yml', '.drone.star']), ver_mode),
         test_frontend(get_pr_trigger(exclude_paths=['pkg/**', 'packaging/**', 'go.sum', 'go.mod']), ver_mode),
         test_backend(get_pr_trigger(include_paths=['pkg/**', 'packaging/**', '.drone.yml', 'conf/**', 'go.sum', 'go.mod', 'public/app/plugins/**/plugin.json', 'devenv/**']), ver_mode),
+        lint_backend_pipeline(get_pr_trigger(include_paths=['pkg/**', 'packaging/**', '.drone.yml', 'conf/**', 'go.sum', 'go.mod', 'public/app/plugins/**/plugin.json', 'devenv/**']), ver_mode),
         build_e2e(trigger, ver_mode, edition),
         integration_tests(get_pr_trigger(include_paths=['pkg/**', 'packaging/**', '.drone.yml', 'conf/**', 'go.sum', 'go.mod', 'public/app/plugins/**/plugin.json']), ver_mode, edition),
         docs_pipelines(edition, ver_mode, trigger_docs_pr()),

--- a/scripts/drone/pipelines/lint_backend.star
+++ b/scripts/drone/pipelines/lint_backend.star
@@ -1,0 +1,31 @@
+load(
+    'scripts/drone/steps/lib.star',
+    'identify_runner_step',
+    'wire_install_step',
+    'lint_backend_step',
+    'lint_drone_step',
+    'compile_build_cmd',
+)
+
+load(
+    'scripts/drone/utils/utils.star',
+    'pipeline',
+)
+
+def lint_backend_pipeline(trigger, ver_mode):
+    wire_step = wire_install_step()
+    wire_step.update({ 'depends_on': [] })
+    init_steps = [
+        identify_runner_step(),
+        compile_build_cmd(),
+        wire_step,
+    ]
+    test_steps = [
+        lint_backend_step(edition="oss"),
+    ]
+    if ver_mode == 'main':
+        test_steps.extend([lint_drone_step()])
+
+    return pipeline(
+        name='{}-lint-backend'.format(ver_mode), edition="oss", trigger=trigger, services=[], steps=init_steps + test_steps,
+    )

--- a/scripts/drone/pipelines/test_backend.star
+++ b/scripts/drone/pipelines/test_backend.star
@@ -1,10 +1,7 @@
 load(
     'scripts/drone/steps/lib.star',
     'identify_runner_step',
-    'download_grabpl_step',
     'wire_install_step',
-    'lint_backend_step',
-    'lint_drone_step',
     'test_backend_step',
     'test_backend_integration_step',
     'verify_gen_cue_step',
@@ -19,18 +16,14 @@ load(
 def test_backend(trigger, ver_mode):
     init_steps = [
         identify_runner_step(),
-        download_grabpl_step(),
         compile_build_cmd(),
         verify_gen_cue_step(edition="oss"),
         wire_install_step(),
     ]
     test_steps = [
-        lint_backend_step(edition="oss"),
         test_backend_step(edition="oss"),
         test_backend_integration_step(edition="oss"),
     ]
-    if ver_mode == 'main':
-        test_steps.extend([lint_drone_step()])
 
     return pipeline(
         name='{}-test-backend'.format(ver_mode), edition="oss", trigger=trigger, services=[], steps=init_steps + test_steps,

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -207,7 +207,7 @@ def enterprise_downstream_step(edition, ver_mode):
 def lint_backend_step(edition):
     return {
         'name': 'lint-backend' + enterprise2_suffix(edition),
-        'image': build_image,
+        'image': go_image,
         'environment': {
             # We need CGO because of go-sqlite3
             'CGO_ENABLED': '1',
@@ -216,6 +216,7 @@ def lint_backend_step(edition):
             'wire-install',
         ],
         'commands': [
+            'apt-get update && apt-get install make',
             # Don't use Make since it will re-download the linters
             'make lint-go',
         ],


### PR DESCRIPTION
**What this PR does / why we need it**:

Introduces `lint-backend` pipeline. Currently our backend lint checks happen inside the `test-backend` pipeline. 
This PR extracts lint steps from the `test-backend` pipeline and puts them in the new `lint-backend` pipeline.
