### PR TITLE
Instrumentation: Fix api/health

### DIFF
--- a/pkg/middleware/request_tracing.go
+++ b/pkg/middleware/request_tracing.go
@@ -49,6 +49,7 @@ var unnamedHandlers = []struct {
 	{handler: "public-assets", pathPattern: regexp.MustCompile("^/public/")},
 	{handler: "/metrics", pathPattern: regexp.MustCompile("^/metrics")},
 	{handler: "/healthz", pathPattern: regexp.MustCompile("^/healthz")},
+	{handler: "/api/health", pathPattern: regexp.MustCompile("^/api/health")},
 	{handler: "/robots.txt", pathPattern: regexp.MustCompile("^/robots.txt$")},
 	// bundle all pprof endpoints under the same handler name
 	{handler: "/debug/pprof-handlers", pathPattern: regexp.MustCompile("^/debug/pprof")},


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
The `api/health` used to be instrumented as unknown. The reason is that this handler [is set as a middleware](https://github.com/grafana/grafana/blob/070d44802f2fd27f01c64a51eeb9477c1e8a646e/pkg/api/http_server.go#L575) rather than being registered to the `routing.RouteRegister`.
The metrics after this fix:
```
grafana_http_request_duration_seconds_bucket{handler="/api/health",method="GET",status_code="200",le="0.005"} 1
grafana_http_request_duration_seconds_bucket{handler="/api/health",method="GET",status_code="200",le="0.01"} 1
grafana_http_request_duration_seconds_bucket{handler="/api/health",method="GET",status_code="200",le="0.025"} 1
grafana_http_request_duration_seconds_bucket{handler="/api/health",method="GET",status_code="200",le="0.05"} 1
grafana_http_request_duration_seconds_bucket{handler="/api/health",method="GET",status_code="200",le="0.1"} 1
grafana_http_request_duration_seconds_bucket{handler="/api/health",method="GET",status_code="200",le="0.25"} 1
grafana_http_request_duration_seconds_bucket{handler="/api/health",method="GET",status_code="200",le="0.5"} 1
grafana_http_request_duration_seconds_bucket{handler="/api/health",method="GET",status_code="200",le="1"} 1
grafana_http_request_duration_seconds_bucket{handler="/api/health",method="GET",status_code="200",le="2.5"} 1
grafana_http_request_duration_seconds_bucket{handler="/api/health",method="GET",status_code="200",le="5"} 1
grafana_http_request_duration_seconds_bucket{handler="/api/health",method="GET",status_code="200",le="10"} 1
grafana_http_request_duration_seconds_bucket{handler="/api/health",method="GET",status_code="200",le="25"} 1
grafana_http_request_duration_seconds_bucket{handler="/api/health",method="GET",status_code="200",le="+Inf"} 1
grafana_http_request_duration_seconds_sum{handler="/api/health",method="GET",status_code="200"} 0.000909165
grafana_http_request_duration_seconds_count{handler="/api/health",method="GET",status_code="200"} 1
```

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes partially #55237

**Special notes for your reviewer**:

