### PR TITLE
devenv: change default elasticsearch datasources

### DIFF
--- a/devenv/datasources.yaml
+++ b/devenv/datasources.yaml
@@ -129,18 +129,8 @@ datasources:
       logLevelField: level
       logMessageField: line
       esVersion: 8.1.4
-      
-  - name: gdev-elasticsearch-v8-logs
-    type: elasticsearch
-    access: proxy
-    database: "[logs-]YYYY.MM.DD"
-    url: http://localhost:9200
-    jsonData:
-      interval: Daily
-      timeField: "@timestamp"
-      esVersion: 8.1.4
 
-  - name: gdev-elasticsearch-v8-filebeat
+  - name: gdev-elasticsearch-filebeat
     type: elasticsearch
     access: proxy
     database: "[filebeat-]YYYY.MM.DD"
@@ -153,7 +143,7 @@ datasources:
       logMessageField: message
       logLevelField: fields.level
 
-  - name: gdev-elasticsearch-v8-metricbeat
+  - name: gdev-elasticsearch-metricbeat
     type: elasticsearch
     access: proxy
     database: "[metricbeat-]YYYY.MM.DD"

--- a/devenv/datasources.yaml
+++ b/devenv/datasources.yaml
@@ -129,17 +129,6 @@ datasources:
       logLevelField: level
       logMessageField: line
       esVersion: 8.1.4
-
-  - name: gdev-elasticsearch-v8-metrics
-    type: elasticsearch
-    access: proxy
-    database: "[metrics-]YYYY.MM.DD"
-    url: http://localhost:9200
-    jsonData:
-      timeInterval: 10s
-      interval: Daily
-      timeField: "@timestamp"
-      esVersion: 8.1.4
       
   - name: gdev-elasticsearch-v8-logs
     type: elasticsearch

--- a/devenv/datasources.yaml
+++ b/devenv/datasources.yaml
@@ -16,6 +16,10 @@ deleteDatasources:
   - name: gdev-elasticsearch-v6-metrics
   - name: gdev-elasticsearch-v6-logs
   - name: gdev-elasticsearch-v6-filebeat
+  - name: gdev-elasticsearch-v7-metrics
+  - name: gdev-elasticsearch-v7-logs
+  - name: gdev-elasticsearch-v7-filebeat
+  - name: gdev-elasticsearch-v7-metricbeat
 
 datasources:
   - name: gdev-graphite
@@ -124,51 +128,51 @@ datasources:
       timeField: "@timestamp"
       logLevelField: level
       logMessageField: line
-      esVersion: 8.0.0
+      esVersion: 8.1.4
 
-  - name: gdev-elasticsearch-v7-metrics
+  - name: gdev-elasticsearch-v8-metrics
     type: elasticsearch
     access: proxy
     database: "[metrics-]YYYY.MM.DD"
-    url: http://localhost:12200
+    url: http://localhost:9200
     jsonData:
       timeInterval: 10s
       interval: Daily
       timeField: "@timestamp"
-      esVersion: 7.10.0
-
-  - name: gdev-elasticsearch-v7-logs
+      esVersion: 8.1.4
+      
+  - name: gdev-elasticsearch-v8-logs
     type: elasticsearch
     access: proxy
     database: "[logs-]YYYY.MM.DD"
-    url: http://localhost:12200
+    url: http://localhost:9200
     jsonData:
       interval: Daily
       timeField: "@timestamp"
-      esVersion: 7.10.0
+      esVersion: 8.1.4
 
-  - name: gdev-elasticsearch-v7-filebeat
+  - name: gdev-elasticsearch-v8-filebeat
     type: elasticsearch
     access: proxy
     database: "[filebeat-]YYYY.MM.DD"
-    url: http://localhost:12200
+    url: http://localhost:9200
     jsonData:
       interval: Daily
       timeField: "@timestamp"
-      esVersion: 7.10.0
+      esVersion: 8.1.4
       timeInterval: "10s"
       logMessageField: message
       logLevelField: fields.level
 
-  - name: gdev-elasticsearch-v7-metricbeat
+  - name: gdev-elasticsearch-v8-metricbeat
     type: elasticsearch
     access: proxy
     database: "[metricbeat-]YYYY.MM.DD"
-    url: http://localhost:12200
+    url: http://localhost:9200
     jsonData:
       interval: Daily
       timeField: "@timestamp"
-      esVersion: 7.10.0
+      esVersion: 8.1.4
       timeInterval: "10s"
 
   - name: gdev-mysql

--- a/devenv/datasources_docker.yaml
+++ b/devenv/datasources_docker.yaml
@@ -1,6 +1,12 @@
 
 apiVersion: 1
 
+deleteDatasources:
+  - name: gdev-elasticsearch-v7-metrics
+  - name: gdev-elasticsearch-v7-logs
+  - name: gdev-elasticsearch-v7-metricbeat
+  - name: gdev-elasticsearch-v7-filebeat
+
 datasources:
   - name: gdev-graphite
     type: graphite
@@ -61,49 +67,38 @@ datasources:
       tsdbResolution: 1
       tsdbVersion: 1
 
-  - name: gdev-elasticsearch-v7-metrics
-    type: elasticsearch
-    access: proxy
-    database: "[metrics-]YYYY.MM.DD"
-    url: http://elasticsearch7:9200
-    jsonData:
-      timeInterval: 10s
-      interval: Daily
-      timeField: "@timestamp"
-      esVersion: 70
-
-  - name: gdev-elasticsearch-v7-logs
+  - name: gdev-elasticsearch
     type: elasticsearch
     access: proxy
     database: "[logs-]YYYY.MM.DD"
-    url: http://elasticsearch7:9200
+    url: http://elasticsearch:9200
     jsonData:
       interval: Daily
       timeField: "@timestamp"
-      esVersion: 70
+      esVersion: 8.1.4
 
-  - name: gdev-elasticsearch-v7-filebeat
+  - name: gdev-elasticsearch-filebeat
     type: elasticsearch
     access: proxy
     database: "[filebeat-]YYYY.MM.DD"
-    url: http://elasticsearch7:9200
+    url: http://elasticsearch:9200
     jsonData:
       interval: Daily
       timeField: "@timestamp"
-      esVersion: 70
+      esVersion: 8.1.4
       timeInterval: "10s"
       logMessageField: message
       logLevelField: fields.level
 
-  - name: gdev-elasticsearch-v7-metricbeat
+  - name: gdev-elasticsearch-metricbeat
     type: elasticsearch
     access: proxy
     database: "[metricbeat-]YYYY.MM.DD"
-    url: http://elasticsearch7:9200
+    url: http://elasticsearch:9200
     jsonData:
       interval: Daily
       timeField: "@timestamp"
-      esVersion: 70
+      esVersion: 8.1.4
       timeInterval: "10s"
 
   - name: gdev-mysql


### PR DESCRIPTION
Followup of #55402 to have the correct datasources setup for the new Docker blocks.

I tried also porting the dev-dashboards but would skip this for now, since the metrics used for the dashboards are not present in metricbeat.