### PR TITLE
elastic: devenv: add nested objects to data generator

### DIFF
--- a/devenv/docker/blocks/elastic/data/data.js
+++ b/devenv/docker/blocks/elastic/data/data.js
@@ -80,6 +80,9 @@ async function elasticSetupIndexTemplate() {
           location: {
             type: 'geo_point',
           },
+          shapes: {
+            type: 'nested',
+          }
         },
       },
     },
@@ -108,6 +111,15 @@ function getRandomLogItem(counter, timestamp) {
     level: chooseRandomElement(['info', 'info', 'error']),
     // location: chooseRandomElement(LOCATIONS),
     location: makeRandomPoint(),
+    shapes: Math.random() < 0.5 ? [
+      {"type": "triangle"},
+      {"type": "square"},
+    ] : [
+      {"type": "triangle"},
+      {"type": "triangle"},
+      {"type": "triangle"},
+      {"type": "square"},
+    ],
   };
 }
 


### PR DESCRIPTION
this adds a nested attribute to the elasticsearch objects generated by the fake data generator. this will help us test & implement features that uses nested aggregations.


how to test:
1. `make devenv sources=elastic`
2. now check out and run this PR: https://github.com/grafana/grafana/pull/47233
3. in explore, in  the UI, choose:
    - Metric: `Count`
    - Group by: `Nested`, field: `shapes`
    - add one more Group by: `Terms`, filed: `shapes.type.keyword`

you should get a table, with a number for `triangle` and a number for `square`, `triangle` should be roughly two times the amount of `square`