### PR TITLE
PublicDashboards: Resolve interval for public dashboard data source

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -3920,11 +3920,10 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
     ],
     "public/app/features/dashboard/services/PublicDashboardDataSource.ts:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
+      [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "3"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "4"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "3"]
     ],
     "public/app/features/dashboard/services/TimeSrv.test.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
@@ -5066,9 +5065,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "4"],
       [0, 0, 0, "Do not use any type assertions.", "5"],
       [0, 0, 0, "Do not use any type assertions.", "6"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "7"],
-      [0, 0, 0, "Do not use any type assertions.", "8"],
-      [0, 0, 0, "Do not use any type assertions.", "9"]
+      [0, 0, 0, "Do not use any type assertions.", "7"]
     ],
     "public/app/features/query/state/runRequest.test.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]

--- a/.betterer.results
+++ b/.betterer.results
@@ -3921,9 +3921,8 @@ exports[`better eslint`] = {
     ],
     "public/app/features/dashboard/services/PublicDashboardDataSource.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
-      [0, 0, 0, "Do not use any type assertions.", "1"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "3"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "2"]
     ],
     "public/app/features/dashboard/services/TimeSrv.test.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
@@ -5063,9 +5062,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "2"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "3"],
       [0, 0, 0, "Do not use any type assertions.", "4"],
-      [0, 0, 0, "Do not use any type assertions.", "5"],
-      [0, 0, 0, "Do not use any type assertions.", "6"],
-      [0, 0, 0, "Do not use any type assertions.", "7"]
+      [0, 0, 0, "Do not use any type assertions.", "5"]
     ],
     "public/app/features/query/state/runRequest.test.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]

--- a/pkg/services/publicdashboards/api/middleware.go
+++ b/pkg/services/publicdashboards/api/middleware.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"net/http"
+	"strconv"
 
 	"github.com/grafana/grafana/pkg/infra/metrics"
 	"github.com/grafana/grafana/pkg/models"
@@ -11,6 +12,12 @@ import (
 
 func SetPublicDashboardFlag() func(c *models.ReqContext) {
 	return func(c *models.ReqContext) {
+		// TODO: Find a better place to set this, or rename this function
+		orgIDValue := c.Req.URL.Query().Get("orgId")
+		orgID, err := strconv.ParseInt(orgIDValue, 10, 64)
+		if err == nil && orgID > 0 && orgID != c.OrgID {
+			c.OrgID = orgID
+		}
 		c.IsPublicDashboardView = true
 	}
 }

--- a/public/app/features/dashboard/services/PublicDashboardDataSource.test.ts
+++ b/public/app/features/dashboard/services/PublicDashboardDataSource.test.ts
@@ -4,7 +4,7 @@ import { DataQueryRequest, DataSourceInstanceSettings, DataSourceRef } from '@gr
 import { BackendSrvRequest, BackendSrv, DataSourceWithBackend } from '@grafana/runtime';
 import { MIXED_DATASOURCE_NAME } from 'app/plugins/datasource/mixed/MixedDataSource';
 
-import { PublicDashboardDataSource, PUBLIC_DATASOURCE } from './PublicDashboardDataSource';
+import { PublicDashboardDataSource, PUBLIC_DATASOURCE, DEFAULT_INTERVAL } from './PublicDashboardDataSource';
 
 const mockDatasourceRequest = jest.fn();
 
@@ -92,5 +92,36 @@ describe('PublicDashboardDatasource', () => {
   test('isMixedDatasource returns false when datasource is null', () => {
     let ds = new PublicDashboardDataSource(null);
     expect(ds.meta.mixed).toBeFalsy();
+  });
+
+  test('returns default datasource interval when datasource passed in is null', () => {
+    let ds = new PublicDashboardDataSource(null);
+    expect(ds.interval).toBe(DEFAULT_INTERVAL);
+  });
+
+  test('returns default datasource interval when datasource passed in is a string', () => {
+    let ds = new PublicDashboardDataSource('theDatasourceUid');
+    expect(ds.interval).toBe(DEFAULT_INTERVAL);
+  });
+
+  test('returns default datasource interval when datasource passed in is a DataSourceRef implementation', () => {
+    const datasource = { type: 'datasource', uid: 'abc123' };
+    let ds = new PublicDashboardDataSource(datasource);
+    expect(ds.interval).toBe(DEFAULT_INTERVAL);
+  });
+
+  test('returns default datasource interval when datasource passed in is a DatasourceApi instance that has no interval', () => {
+    const settings: DataSourceInstanceSettings = { id: 1, uid: 'abc123' } as DataSourceInstanceSettings;
+    const datasource = new DataSourceWithBackend(settings);
+    let ds = new PublicDashboardDataSource(datasource);
+    expect(ds.interval).toBe(DEFAULT_INTERVAL);
+  });
+
+  test('returns datasource interval when datasource passed in is a DatasourceApi instance that has interval', () => {
+    const settings: DataSourceInstanceSettings = { id: 1, uid: 'abc123' } as DataSourceInstanceSettings;
+    const datasource = new DataSourceWithBackend(settings);
+    datasource.interval = 'abc123';
+    let ds = new PublicDashboardDataSource(datasource);
+    expect(ds.interval).toBe('abc123');
   });
 });

--- a/public/app/features/dashboard/services/PublicDashboardDataSource.ts
+++ b/public/app/features/dashboard/services/PublicDashboardDataSource.ts
@@ -5,6 +5,7 @@ import {
   DataQueryRequest,
   DataQueryResponse,
   DataSourceApi,
+  DataSourceJsonData,
   DataSourcePluginMeta,
   DataSourceRef,
 } from '@grafana/data';
@@ -13,8 +14,9 @@ import { BackendDataSourceResponse, getBackendSrv, toDataQueryResponse } from '@
 import { MIXED_DATASOURCE_NAME } from '../../../plugins/datasource/mixed/MixedDataSource';
 
 export const PUBLIC_DATASOURCE = '-- Public --';
+export const DEFAULT_INTERVAL = '1min';
 
-export class PublicDashboardDataSource extends DataSourceApi<any> {
+export class PublicDashboardDataSource extends DataSourceApi<DataQuery, DataSourceJsonData, {}> {
   constructor(datasource: DataSourceRef | string | DataSourceApi | null) {
     let meta = {} as DataSourcePluginMeta;
     if (PublicDashboardDataSource.isMixedDatasource(datasource)) {
@@ -32,7 +34,7 @@ export class PublicDashboardDataSource extends DataSourceApi<any> {
       readOnly: true,
     });
 
-    this.interval = '1min';
+    this.interval = PublicDashboardDataSource.resolveInterval(datasource);
   }
 
   /**
@@ -54,10 +56,18 @@ export class PublicDashboardDataSource extends DataSourceApi<any> {
     return datasource?.uid === MIXED_DATASOURCE_NAME;
   }
 
+  private static resolveInterval(datasource: DataSourceRef | string | DataSourceApi | null): string {
+    if (typeof datasource === 'string' || datasource === null) {
+      return DEFAULT_INTERVAL;
+    }
+
+    return (datasource as DataSourceApi)?.interval ?? DEFAULT_INTERVAL;
+  }
+
   /**
    * Ideally final -- any other implementation may not work as expected
    */
-  query(request: DataQueryRequest<any>): Observable<DataQueryResponse> {
+  query(request: DataQueryRequest<DataQuery>): Observable<DataQueryResponse> {
     const { intervalMs, maxDataPoints, requestId, publicDashboardAccessToken, panelId } = request;
     let queries: DataQuery[];
 

--- a/public/app/features/dashboard/services/PublicDashboardDataSource.ts
+++ b/public/app/features/dashboard/services/PublicDashboardDataSource.ts
@@ -61,7 +61,9 @@ export class PublicDashboardDataSource extends DataSourceApi<DataQuery, DataSour
       return DEFAULT_INTERVAL;
     }
 
-    return (datasource as DataSourceApi)?.interval ?? DEFAULT_INTERVAL;
+    const interval = 'interval' in datasource ? datasource.interval : undefined;
+
+    return interval ?? DEFAULT_INTERVAL;
   }
 
   /**

--- a/public/app/features/query/state/PanelQueryRunner.ts
+++ b/public/app/features/query/state/PanelQueryRunner.ts
@@ -370,8 +370,8 @@ async function getDataSource(
   scopedVars: ScopedVars,
   publicDashboardAccessToken?: string
 ): Promise<DataSourceApi> {
-  if (!publicDashboardAccessToken && datasource && (datasource as DataSourceApi).query) {
-    return datasource as DataSourceApi;
+  if (!publicDashboardAccessToken && datasource && typeof datasource === 'object' && 'query' in datasource) {
+    return datasource;
   }
 
   const ds = await getDatasourceSrv().get(datasource, scopedVars);

--- a/public/app/features/query/state/PanelQueryRunner.ts
+++ b/public/app/features/query/state/PanelQueryRunner.ts
@@ -370,13 +370,14 @@ async function getDataSource(
   scopedVars: ScopedVars,
   publicDashboardAccessToken?: string
 ): Promise<DataSourceApi> {
-  if (publicDashboardAccessToken) {
-    return new PublicDashboardDataSource(datasource);
-  }
-
-  if (datasource && (datasource as any).query) {
+  if (!publicDashboardAccessToken && datasource && (datasource as DataSourceApi).query) {
     return datasource as DataSourceApi;
   }
 
-  return await getDatasourceSrv().get(datasource as string, scopedVars);
+  const ds = await getDatasourceSrv().get(datasource, scopedVars);
+  if (publicDashboardAccessToken) {
+    return new PublicDashboardDataSource(ds);
+  }
+
+  return ds;
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This pull request adds a call to `getDatasourceSrv().get()` on the `PanelQueryRunner` `getDataSource` function to retrieve the datasource data before passing it as an argument to `PublicDashboardDataSource`, this way the `PublicDashboardDataSource` can call the newly created function `resolveInterval` to determine the interval of the datasource, fixing the issue with data granularity discrepancies between private and public dashboards.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/55304

**Special notes for your reviewer**:

Look issue for exmaple pictures.