### PR TITLE
PanelHeader: Add deadzone to panel header click/drag detection

### DIFF
--- a/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeaderMenuTrigger.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeaderMenuTrigger.tsx
@@ -17,7 +17,7 @@ export const PanelHeaderMenuTrigger: FC<Props> = ({ children, ...divProps }) => 
 
   const onMenuToggle = useCallback(
     (event: MouseEvent<HTMLDivElement>) => {
-      if (!isClick(clickCoordinates, { x: event.clientX, y: event.clientY })) {
+      if (!isClick(clickCoordinates, eventToClickCoordinates(event))) {
         return;
       }
 
@@ -41,6 +41,8 @@ export const PanelHeaderMenuTrigger: FC<Props> = ({ children, ...divProps }) => 
 };
 
 function isClick(current: CartesianCoords2D, clicked: CartesianCoords2D, deadZone = 3.5): boolean {
+  // A "deadzone" radius is added so that if the cursor is moved within this radius
+  // between mousedown and mouseup, it's still considered a click and not a drag.
   const clickDistance = Math.sqrt((current.x - clicked.x) ** 2 + (current.y - clicked.y) ** 2);
   return clickDistance <= deadZone;
 }

--- a/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeaderMenuTrigger.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeaderMenuTrigger.tsx
@@ -17,7 +17,7 @@ export const PanelHeaderMenuTrigger: FC<Props> = ({ children, ...divProps }) => 
 
   const onMenuToggle = useCallback(
     (event: MouseEvent<HTMLDivElement>) => {
-      if (!isClick(clickCoordinates, eventToClickCoordinates(event))) {
+      if (!isClick(clickCoordinates, { x: event.clientX, y: event.clientY })) {
         return;
       }
 
@@ -40,13 +40,14 @@ export const PanelHeaderMenuTrigger: FC<Props> = ({ children, ...divProps }) => 
   );
 };
 
-function isClick(current: CartesianCoords2D, clicked: CartesianCoords2D): boolean {
-  return clicked.x === current.x && clicked.y === current.y;
+function isClick(current: CartesianCoords2D, clicked: CartesianCoords2D, deadZone = 3.5): boolean {
+  const clickDistance = Math.sqrt((current.x - clicked.x) ** 2 + (current.y - clicked.y) ** 2);
+  return clickDistance <= deadZone;
 }
 
 function eventToClickCoordinates(event: MouseEvent<HTMLDivElement>): CartesianCoords2D {
   return {
-    x: Math.floor(event.clientX),
-    y: Math.floor(event.clientY),
+    x: event.clientX,
+    y: event.clientY,
   };
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Solves an annoyance where a user goes to click the panel header in order to make the panel menu visible, but if the mouse is moved even 1 pixel it's considered a drag event and the menu isn't made visible.
A "deadzone" radius of 3.5 pixels is added so that if the cursor is moved within this radius between mousedown and mouseup, it's still considered a click and not a drag. Also solves some e2e flakiness with #55373.

https://user-images.githubusercontent.com/45561153/191292287-755e5ef7-896c-4f4b-bf20-d34be659daba.mp4
