### PR TITLE
AuthNZ: Security fixes for CVE-2022-35957 and CVE-2022-36062

### DIFF
--- a/pkg/api/datasources_test.go
+++ b/pkg/api/datasources_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/api/routing"
+	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/models"
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/datasources"
@@ -82,6 +83,7 @@ func TestAddDataSource_InvalidURL(t *testing.T) {
 	sc := setupScenarioContext(t, "/api/datasources")
 	hs := &HTTPServer{
 		DataSourcesService: &dataSourcesServiceMock{},
+		Cfg:                setting.NewCfg(),
 	}
 
 	sc.m.Post(sc.url, routing.Wrap(func(c *models.ReqContext) response.Response {
@@ -108,6 +110,7 @@ func TestAddDataSource_URLWithoutProtocol(t *testing.T) {
 		DataSourcesService: &dataSourcesServiceMock{
 			expectedDatasource: &models.DataSource{},
 		},
+		Cfg: setting.NewCfg(),
 	}
 
 	sc := setupScenarioContext(t, "/api/datasources")
@@ -127,10 +130,42 @@ func TestAddDataSource_URLWithoutProtocol(t *testing.T) {
 	assert.Equal(t, 200, sc.resp.Code)
 }
 
+// Using a custom header whose name matches the name specified for auth proxy header should fail
+func TestAddDataSource_InvalidJSONData(t *testing.T) {
+	hs := &HTTPServer{
+		DataSourcesService: &dataSourcesServiceMock{},
+		Cfg:                setting.NewCfg(),
+	}
+
+	sc := setupScenarioContext(t, "/api/datasources")
+
+	hs.Cfg = setting.NewCfg()
+	hs.Cfg.AuthProxyEnabled = true
+	hs.Cfg.AuthProxyHeaderName = "X-AUTH-PROXY-HEADER"
+	jsonData := simplejson.New()
+	jsonData.Set("httpHeaderName1", hs.Cfg.AuthProxyHeaderName)
+
+	sc.m.Post(sc.url, routing.Wrap(func(c *models.ReqContext) response.Response {
+		c.Req.Body = mockRequestBody(models.AddDataSourceCommand{
+			Name:     "Test",
+			Url:      "localhost:5432",
+			Access:   "direct",
+			Type:     "test",
+			JsonData: jsonData,
+		})
+		return hs.AddDataSource(c)
+	}))
+
+	sc.fakeReqWithParams("POST", sc.url, map[string]string{}).exec()
+
+	assert.Equal(t, 400, sc.resp.Code)
+}
+
 // Updating data sources with invalid URLs should lead to an error.
 func TestUpdateDataSource_InvalidURL(t *testing.T) {
 	hs := &HTTPServer{
 		DataSourcesService: &dataSourcesServiceMock{},
+		Cfg:                setting.NewCfg(),
 	}
 	sc := setupScenarioContext(t, "/api/datasources/1234")
 
@@ -149,6 +184,35 @@ func TestUpdateDataSource_InvalidURL(t *testing.T) {
 	assert.Equal(t, 400, sc.resp.Code)
 }
 
+// Using a custom header whose name matches the name specified for auth proxy header should fail
+func TestUpdateDataSource_InvalidJSONData(t *testing.T) {
+	hs := &HTTPServer{
+		DataSourcesService: &dataSourcesServiceMock{},
+		Cfg:                setting.NewCfg(),
+	}
+	sc := setupScenarioContext(t, "/api/datasources/1234")
+
+	hs.Cfg.AuthProxyEnabled = true
+	hs.Cfg.AuthProxyHeaderName = "X-AUTH-PROXY-HEADER"
+	jsonData := simplejson.New()
+	jsonData.Set("httpHeaderName1", hs.Cfg.AuthProxyHeaderName)
+
+	sc.m.Put(sc.url, routing.Wrap(func(c *models.ReqContext) response.Response {
+		c.Req.Body = mockRequestBody(models.AddDataSourceCommand{
+			Name:     "Test",
+			Url:      "localhost:5432",
+			Access:   "direct",
+			Type:     "test",
+			JsonData: jsonData,
+		})
+		return hs.AddDataSource(c)
+	}))
+
+	sc.fakeReqWithParams("PUT", sc.url, map[string]string{}).exec()
+
+	assert.Equal(t, 400, sc.resp.Code)
+}
+
 // Updating data sources with URLs not specifying protocol should work.
 func TestUpdateDataSource_URLWithoutProtocol(t *testing.T) {
 	const name = "Test"
@@ -158,6 +222,7 @@ func TestUpdateDataSource_URLWithoutProtocol(t *testing.T) {
 		DataSourcesService: &dataSourcesServiceMock{
 			expectedDatasource: &models.DataSource{},
 		},
+		Cfg: setting.NewCfg(),
 	}
 
 	sc := setupScenarioContext(t, "/api/datasources/1234")

--- a/pkg/services/query/query_test.go
+++ b/pkg/services/query/query_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/services/query"
 	"github.com/grafana/grafana/pkg/services/secrets"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/stretchr/testify/require"
 )
 
@@ -64,7 +65,7 @@ func setup() *testContext {
 		dataSourceCache:        dc,
 		oauthTokenService:      tc,
 		pluginRequestValidator: rv,
-		queryService:           query.ProvideService(nil, dc, nil, rv, sc, pc, tc),
+		queryService:           query.ProvideService(setting.NewCfg(), dc, nil, rv, sc, pc, tc),
 	}
 }
 

--- a/pkg/services/sqlstore/migrations/accesscontrol/admin_only.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/admin_only.go
@@ -1,0 +1,100 @@
+package accesscontrol
+
+import (
+	"strings"
+
+	"xorm.io/xorm"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
+)
+
+func AddAdminOnlyMigration(mg *migrator.Migrator) {
+	mg.AddMigration("admin only folder/dashboard permission", &adminOnlyMigrator{})
+}
+
+type adminOnlyMigrator struct {
+	migrator.MigrationBase
+}
+
+func (m *adminOnlyMigrator) SQL(dialect migrator.Dialect) string {
+	return CodeMigrationSQL
+}
+
+func (m *adminOnlyMigrator) Exec(sess *xorm.Session, mg *migrator.Migrator) error {
+	logger := log.New("admin-permissions-only-migrator")
+	type model struct {
+		UID      string `xorm:"uid"`
+		OrgID    int64  `xorm:"org_id"`
+		IsFolder bool   `xorm:"is_folder"`
+	}
+	var models []model
+
+	// Find all dashboards and folders that should have only admin permission in acl
+	// When a dashboard or folder only has admin permission the acl table should be empty and the has_acl set to true
+	sql := `
+	SELECT res.uid, res.is_folder, res.org_id
+	FROM (SELECT dashboard.id, dashboard.uid, dashboard.is_folder, dashboard.org_id, count(dashboard_acl.id) as count
+		  FROM dashboard
+				LEFT JOIN dashboard_acl ON dashboard.id = dashboard_acl.dashboard_id
+		  WHERE dashboard.has_acl IS TRUE
+		  GROUP BY dashboard.id) as res
+	WHERE res.count = 0
+	`
+
+	if err := sess.SQL(sql).Find(&models); err != nil {
+		return err
+	}
+
+	for _, model := range models {
+		var scope string
+
+		// set scope based on type
+		if model.IsFolder {
+			scope = "folders:uid:" + model.UID
+		} else {
+			scope = "dashboards:uid:" + model.UID
+		}
+
+		// Find all managed editor and viewer permissions with scopes to folder or dashboard
+		sql = `
+		SELECT r.id
+		FROM role r
+			LEFT JOIN permission p on r.id = p.role_id
+		WHERE p.scope = ?
+		AND r.org_id = ?
+		AND r.name IN ('managed:builtins:editor:permissions', 'managed:builtins:viewer:permissions')
+		GROUP BY r.id
+		`
+
+		var roleIDS []int64
+		if err := sess.SQL(sql, scope, model.OrgID).Find(&roleIDS); err != nil {
+			return err
+		}
+
+		if len(roleIDS) == 0 {
+			continue
+		}
+
+		msg := "removing viewer and editor permissions on "
+		if model.IsFolder {
+			msg += "folder"
+		} else {
+			msg += "dashboard"
+		}
+
+		logger.Info(msg, "uid", model.UID)
+
+		// Remove managed permission for editors and viewers if there was any
+		removeSQL := `DELETE FROM permission WHERE scope = ? AND role_id IN(?` + strings.Repeat(", ?", len(roleIDS)-1) + `) `
+		params := []interface{}{removeSQL, scope}
+		for _, id := range roleIDS {
+			params = append(params, id)
+		}
+		if _, err := sess.Exec(params...); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/services/sqlstore/migrations/accesscontrol/dashboard_permissions.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/dashboard_permissions.go
@@ -69,6 +69,7 @@ type dashboard struct {
 	FolderID int64 `xorm:"folder_id"`
 	OrgID    int64 `xorm:"org_id"`
 	IsFolder bool
+	HasAcl   bool `xorm:"has_acl"`
 }
 
 func (m dashboardPermissionsMigrator) Exec(sess *xorm.Session, migrator *migrator.Migrator) error {
@@ -76,8 +77,8 @@ func (m dashboardPermissionsMigrator) Exec(sess *xorm.Session, migrator *migrato
 	m.dialect = migrator.Dialect
 
 	var dashboards []dashboard
-	if err := m.sess.SQL("SELECT id, is_folder, folder_id, org_id FROM dashboard").Find(&dashboards); err != nil {
-		return err
+	if err := m.sess.SQL("SELECT id, is_folder, folder_id, org_id, has_acl FROM dashboard").Find(&dashboards); err != nil {
+		return fmt.Errorf("failed to list dashboards: %w", err)
 	}
 
 	var acl []models.DashboardAcl
@@ -108,7 +109,7 @@ func (m dashboardPermissionsMigrator) migratePermissions(dashboards []dashboard,
 			permissionMap[d.OrgID] = map[string][]*ac.Permission{}
 		}
 
-		if (d.IsFolder || d.FolderID == 0) && len(acls) == 0 {
+		if (d.IsFolder || d.FolderID == 0) && len(acls) == 0 && !d.HasAcl {
 			permissionMap[d.OrgID]["managed:builtins:editor:permissions"] = append(
 				permissionMap[d.OrgID]["managed:builtins:editor:permissions"],
 				m.mapPermission(d.ID, models.PERMISSION_EDIT, d.IsFolder)...,

--- a/pkg/services/sqlstore/migrations/migrations.go
+++ b/pkg/services/sqlstore/migrations/migrations.go
@@ -91,7 +91,13 @@ func (*OSSMigrations) AddMigration(mg *Migrator) {
 			addCommentMigrations(mg)
 		}
 	}
-	accesscontrol.AddManagedFolderAlertActionsMigration(mg)
+
+	if mg.Cfg != nil && mg.Cfg.IsFeatureToggleEnabled != nil {
+		if mg.Cfg.IsFeatureToggleEnabled(featuremgmt.FlagAccesscontrol) {
+			accesscontrol.AddManagedFolderAlertActionsMigration(mg)
+			accesscontrol.AddAdminOnlyMigration(mg)
+		}
+	}
 }
 
 func addMigrationLogMigrations(mg *Migrator) {


### PR DESCRIPTION
Security patches for [CVE-2022-35957](https://github.com/grafana/grafana/security/advisories/GHSA-ff5c-938w-8c9q) and [CVE-2022-36062](https://github.com/grafana/grafana/security/advisories/GHSA-p978-56hq-r492).

[CVE-2022-35957](https://github.com/grafana/grafana/security/advisories/GHSA-ff5c-938w-8c9q) allowed escalating user permissions from admin to server admin by using a combination of auth proxy and data source proxy. This issue was fixed by not allowing to use custom data source header with a key matching auth proxy's header.

[CVE-2022-36062](https://github.com/grafana/grafana/security/advisories/GHSA-p978-56hq-r492) added Viewer and Editor permissions to dashboards and folders with only Admin permissions set after RBAC was enabled. This was fixed by removing Viewer and Editor permissions from the impacted dashboards and folders.