### PR TITLE
Auth: Add development manual override

### DIFF
--- a/packages/grafana-data/src/types/config.ts
+++ b/packages/grafana-data/src/types/config.ts
@@ -220,4 +220,5 @@ export interface GrafanaConfig {
 export interface AuthSettings {
   OAuthSkipOrgRoleUpdateSync?: boolean;
   SAMLSkipOrgRoleSync?: boolean;
+  ManualOverrideSync?: boolean;
 }

--- a/packages/grafana-data/src/types/config.ts
+++ b/packages/grafana-data/src/types/config.ts
@@ -220,5 +220,5 @@ export interface GrafanaConfig {
 export interface AuthSettings {
   OAuthSkipOrgRoleUpdateSync?: boolean;
   SAMLSkipOrgRoleSync?: boolean;
-  ManualOverrideSync?: boolean;
+  DisableSyncLock?: boolean;
 }

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -140,6 +140,7 @@ func (hs *HTTPServer) getFrontendSettingsMap(c *models.ReqContext) (map[string]i
 		"auth": map[string]interface{}{
 			"OAuthSkipOrgRoleUpdateSync": hs.Cfg.OAuthSkipOrgRoleUpdateSync,
 			"SAMLSkipOrgRoleSync":        hs.Cfg.SectionWithEnvOverrides("auth.saml").Key("skip_org_role_sync").MustBool(false),
+			"ManualOverrideSync":         hs.Cfg.ManualOverrideSync,
 		},
 		"buildInfo": map[string]interface{}{
 			"hideVersion":   hideVersion,

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -140,7 +140,7 @@ func (hs *HTTPServer) getFrontendSettingsMap(c *models.ReqContext) (map[string]i
 		"auth": map[string]interface{}{
 			"OAuthSkipOrgRoleUpdateSync": hs.Cfg.OAuthSkipOrgRoleUpdateSync,
 			"SAMLSkipOrgRoleSync":        hs.Cfg.SectionWithEnvOverrides("auth.saml").Key("skip_org_role_sync").MustBool(false),
-			"ManualOverrideSync":         hs.Cfg.ManualOverrideSync,
+			"DisableSyncLock":            hs.Cfg.DisableSyncLock,
 		},
 		"buildInfo": map[string]interface{}{
 			"hideVersion":   hideVersion,

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -295,7 +295,7 @@ type Cfg struct {
 	AdminUser                    string
 	AdminPassword                string
 	AdminEmail                   string
-	ManualOverrideSync           bool
+	DisableSyncLock              bool
 
 	// AWS Plugin Auth
 	AWSAllowedAuthProviders []string
@@ -1290,7 +1290,7 @@ func readAuthSettings(iniFile *ini.File, cfg *Cfg) (err error) {
 	}
 
 	// Debug setting unlocking frontend auth sync lock. Users will still be reset on their next login.
-	cfg.ManualOverrideSync = auth.Key("manual_override_sync").MustBool(false)
+	cfg.DisableSyncLock = auth.Key("disable_sync_lock").MustBool(false)
 
 	DisableLoginForm = auth.Key("disable_login_form").MustBool(false)
 	DisableSignoutMenu = auth.Key("disable_signout_menu").MustBool(false)

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -295,6 +295,7 @@ type Cfg struct {
 	AdminUser                    string
 	AdminPassword                string
 	AdminEmail                   string
+	ManualOverrideSync           bool
 
 	// AWS Plugin Auth
 	AWSAllowedAuthProviders []string
@@ -1287,6 +1288,9 @@ func readAuthSettings(iniFile *ini.File, cfg *Cfg) (err error) {
 	if cfg.TokenRotationIntervalMinutes < 2 {
 		cfg.TokenRotationIntervalMinutes = 2
 	}
+
+	// Debug setting unlocking frontend auth sync lock. Users will still be reset on their next login.
+	cfg.ManualOverrideSync = auth.Key("manual_override_sync").MustBool(false)
 
 	DisableLoginForm = auth.Key("disable_login_form").MustBool(false)
 	DisableSignoutMenu = auth.Key("disable_signout_menu").MustBool(false)

--- a/public/app/features/admin/UserAdminPage.tsx
+++ b/public/app/features/admin/UserAdminPage.tsx
@@ -112,9 +112,10 @@ export class UserAdminPage extends PureComponent<Props> {
       user?.isExternal && user?.authLabels?.some((r) => SyncedOAuthLabels.includes(r));
     const isSAMLUser = user?.isExternal && user?.authLabels?.includes('SAML');
     const isUserSynced =
-      (user?.isExternal && !(isOAuthUserWithSkippableSync || isSAMLUser)) ||
-      (!config.auth.OAuthSkipOrgRoleUpdateSync && isOAuthUserWithSkippableSync) ||
-      (!config.auth.SAMLSkipOrgRoleSync && isSAMLUser);
+      !config.auth.ManualOverrideSync &&
+      ((user?.isExternal && !(isOAuthUserWithSkippableSync || isSAMLUser)) ||
+        (!config.auth.OAuthSkipOrgRoleUpdateSync && isOAuthUserWithSkippableSync) ||
+        (!config.auth.SAMLSkipOrgRoleSync && isSAMLUser));
 
     const pageNav: NavModelItem = {
       text: user?.login ?? '',

--- a/public/app/features/admin/UserAdminPage.tsx
+++ b/public/app/features/admin/UserAdminPage.tsx
@@ -112,7 +112,7 @@ export class UserAdminPage extends PureComponent<Props> {
       user?.isExternal && user?.authLabels?.some((r) => SyncedOAuthLabels.includes(r));
     const isSAMLUser = user?.isExternal && user?.authLabels?.includes('SAML');
     const isUserSynced =
-      !config.auth.ManualOverrideSync &&
+      !config.auth.DisableSyncLock &&
       ((user?.isExternal && !(isOAuthUserWithSkippableSync || isSAMLUser)) ||
         (!config.auth.OAuthSkipOrgRoleUpdateSync && isOAuthUserWithSkippableSync) ||
         (!config.auth.SAMLSkipOrgRoleSync && isSAMLUser));


### PR DESCRIPTION
**What this PR does / why we need it**:

Add unsupported switch for disabling UI lockdown to allow developers to test resync capabilities