### PR TITLE
Chore: Switch over to team.Service instead of sqlstore

### DIFF
--- a/pkg/api/annotations_test.go
+++ b/pkg/api/annotations_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/services/sqlstore/mockstore"
+	"github.com/grafana/grafana/pkg/services/team/teamtest"
 )
 
 func TestAnnotationsAPIEndpoint(t *testing.T) {
@@ -922,7 +923,7 @@ func setUpACL() {
 	viewerRole := org.RoleViewer
 	editorRole := org.RoleEditor
 	store := mockstore.NewSQLStoreMock()
-	store.ExpectedTeamsByUser = []*models.TeamDTO{}
+	teamSvc := &teamtest.FakeService{}
 	dashSvc := &dashboards.FakeDashboardService{}
 	dashSvc.On("GetDashboardACLInfoList", mock.Anything, mock.AnythingOfType("*models.GetDashboardACLInfoListQuery")).Run(func(args mock.Arguments) {
 		q := args.Get(1).(*models.GetDashboardACLInfoListQuery)
@@ -932,7 +933,7 @@ func setUpACL() {
 		}
 	}).Return(nil)
 
-	guardian.InitLegacyGuardian(store, dashSvc)
+	guardian.InitLegacyGuardian(store, dashSvc, teamSvc)
 }
 
 func setUpRBACGuardian(t *testing.T) {

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -58,7 +58,7 @@ func (hs *HTTPServer) registerRoutes() {
 	reqGrafanaAdmin := middleware.ReqGrafanaAdmin
 	reqEditorRole := middleware.ReqEditorRole
 	reqOrgAdmin := middleware.ReqOrgAdmin
-	reqOrgAdminDashOrFolderAdminOrTeamAdmin := middleware.OrgAdminDashOrFolderAdminOrTeamAdmin(hs.SQLStore, hs.DashboardService)
+	reqOrgAdminDashOrFolderAdminOrTeamAdmin := middleware.OrgAdminDashOrFolderAdminOrTeamAdmin(hs.SQLStore, hs.DashboardService, hs.teamService)
 	reqCanAccessTeams := middleware.AdminOrEditorAndFeatureEnabled(hs.Cfg.EditorsCanAdmin)
 	reqSnapshotPublicModeOrSignedIn := middleware.SnapshotPublicModeOrSignedIn(hs.Cfg)
 	redirectFromLegacyPanelEditURL := middleware.RedirectFromLegacyPanelEditURL(hs.Cfg)

--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/quota/quotaimpl"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/services/sqlstore/mockstore"
+	"github.com/grafana/grafana/pkg/services/team/teamtest"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/web"
@@ -129,6 +130,7 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 		fakeDash.HasACL = false
 		fakeDashboardVersionService := dashvertest.NewDashboardVersionServiceFake()
 		fakeDashboardVersionService.ExpectedDashboardVersion = &dashver.DashboardVersion{}
+		teamService := &teamtest.FakeService{}
 		dashboardService := dashboards.NewFakeDashboardService(t)
 		dashboardService.On("GetDashboard", mock.Anything, mock.AnythingOfType("*models.GetDashboardQuery")).Run(func(args mock.Arguments) {
 			q := args.Get(1).(*models.GetDashboardQuery)
@@ -157,7 +159,7 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 					{Role: &editorRole, Permission: models.PERMISSION_EDIT},
 				}
 			}).Return(nil)
-			guardian.InitLegacyGuardian(mockSQLStore, dashboardService)
+			guardian.InitLegacyGuardian(mockSQLStore, dashboardService, teamService)
 		}
 
 		// This tests two scenarios:
@@ -235,6 +237,7 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 		fakeDash.HasACL = true
 		fakeDashboardVersionService := dashvertest.NewDashboardVersionServiceFake()
 		fakeDashboardVersionService.ExpectedDashboardVersion = &dashver.DashboardVersion{}
+		teamService := &teamtest.FakeService{}
 		dashboardService := dashboards.NewFakeDashboardService(t)
 		dashboardService.On("GetDashboard", mock.Anything, mock.AnythingOfType("*models.GetDashboardQuery")).Run(func(args mock.Arguments) {
 			q := args.Get(1).(*models.GetDashboardQuery)
@@ -274,7 +277,7 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 				setting.ViewersCanEdit = origCanEdit
 			})
 			setting.ViewersCanEdit = false
-			guardian.InitLegacyGuardian(mockSQLStore, dashboardService)
+			guardian.InitLegacyGuardian(mockSQLStore, dashboardService, teamService)
 		}
 
 		// This tests six scenarios:
@@ -378,7 +381,7 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 						{OrgId: 1, DashboardId: 2, UserId: 1, Permission: models.PERMISSION_EDIT},
 					}
 				}).Return(nil)
-				guardian.InitLegacyGuardian(mockSQLStore, dashboardService)
+				guardian.InitLegacyGuardian(mockSQLStore, dashboardService, teamService)
 			}
 
 			loggedInUserScenarioWithRole(t, "When calling GET on", "GET", "/api/dashboards/uid/abcdefghi",
@@ -440,7 +443,7 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 						{OrgId: 1, DashboardId: 2, UserId: 1, Permission: models.PERMISSION_VIEW},
 					}
 				}).Return(nil)
-				guardian.InitLegacyGuardian(mockSQLStore, dashboardService)
+				guardian.InitLegacyGuardian(mockSQLStore, dashboardService, teamService)
 			}
 
 			loggedInUserScenarioWithRole(t, "When calling GET on", "GET", "/api/dashboards/uid/abcdefghi", "/api/dashboards/uid/:uid", role, func(sc *scenarioContext) {
@@ -480,7 +483,7 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 						{OrgId: 1, DashboardId: 2, UserId: 1, Permission: models.PERMISSION_ADMIN},
 					}
 				}).Return(nil)
-				guardian.InitLegacyGuardian(mockSQLStore, dashboardService)
+				guardian.InitLegacyGuardian(mockSQLStore, dashboardService, teamService)
 			}
 
 			loggedInUserScenarioWithRole(t, "When calling GET on", "GET", "/api/dashboards/uid/abcdefghi", "/api/dashboards/uid/:uid", role, func(sc *scenarioContext) {
@@ -533,7 +536,7 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 						{OrgId: 1, DashboardId: 2, UserId: 1, Permission: models.PERMISSION_VIEW},
 					}
 				}).Return(nil)
-				guardian.InitLegacyGuardian(mockSQLStore, dashboardService)
+				guardian.InitLegacyGuardian(mockSQLStore, dashboardService, teamService)
 			}
 
 			loggedInUserScenarioWithRole(t, "When calling GET on", "GET", "/api/dashboards/uid/abcdefghi", "/api/dashboards/uid/:uid", role, func(sc *scenarioContext) {
@@ -743,9 +746,10 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 		}
 		sqlmock := mockstore.SQLStoreMock{}
 		setUp := func() {
+			teamSvc := &teamtest.FakeService{}
 			dashSvc := dashboards.NewFakeDashboardService(t)
 			dashSvc.On("GetDashboardACLInfoList", mock.Anything, mock.AnythingOfType("*models.GetDashboardACLInfoListQuery")).Return(nil)
-			guardian.InitLegacyGuardian(&sqlmock, dashSvc)
+			guardian.InitLegacyGuardian(&sqlmock, dashSvc, teamSvc)
 		}
 
 		cmd := dtos.CalculateDiffOptions{
@@ -861,6 +865,7 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 		dashboardStore := dashboards.NewFakeDashboardStore(t)
 		dashboardStore.On("GetProvisionedDataByDashboardID", mock.Anything).Return(&models.DashboardProvisioning{ExternalId: "/dashboard1.json"}, nil).Once()
 
+		teamService := &teamtest.FakeService{}
 		dashboardService := dashboards.NewFakeDashboardService(t)
 
 		dataValue, err := simplejson.NewJson([]byte(`{"id": 1, "editable": true, "style": "dark"}`))
@@ -873,7 +878,7 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 			q := args.Get(1).(*models.GetDashboardACLInfoListQuery)
 			q.Result = []*models.DashboardACLInfoDTO{{OrgId: testOrgID, DashboardId: 1, UserId: testUserID, Permission: models.PERMISSION_EDIT}}
 		}).Return(nil)
-		guardian.InitLegacyGuardian(mockSQLStore, dashboardService)
+		guardian.InitLegacyGuardian(mockSQLStore, dashboardService, teamService)
 
 		loggedInUserScenarioWithRole(t, "When calling GET on", "GET", "/api/dashboards/uid/dash", "/api/dashboards/uid/:uid", org.RoleEditor, func(sc *scenarioContext) {
 			fakeProvisioningService := provisioning.NewProvisioningServiceMock(context.Background())

--- a/pkg/api/folder_test.go
+++ b/pkg/api/folder_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/guardian"
 	"github.com/grafana/grafana/pkg/services/quota/quotatest"
 	"github.com/grafana/grafana/pkg/services/sqlstore/mockstore"
+	"github.com/grafana/grafana/pkg/services/team/teamtest"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/web/webtest"
@@ -237,13 +238,14 @@ func createFolderScenario(t *testing.T, desc string, url string, routePattern st
 	setUpRBACGuardian(t)
 	t.Run(fmt.Sprintf("%s %s", desc, url), func(t *testing.T) {
 		aclMockResp := []*models.DashboardACLInfoDTO{}
+		teamSvc := &teamtest.FakeService{}
 		dashSvc := &dashboards.FakeDashboardService{}
 		dashSvc.On("GetDashboardACLInfoList", mock.Anything, mock.AnythingOfType("*models.GetDashboardACLInfoListQuery")).Run(func(args mock.Arguments) {
 			q := args.Get(1).(*models.GetDashboardACLInfoListQuery)
 			q.Result = aclMockResp
 		}).Return(nil)
 		store := mockstore.NewSQLStoreMock()
-		guardian.InitLegacyGuardian(store, dashSvc)
+		guardian.InitLegacyGuardian(store, dashSvc, teamSvc)
 		hs := HTTPServer{
 			AccessControl: acmock.New(),
 			folderService: folderService,

--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -84,6 +84,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/services/star"
 	"github.com/grafana/grafana/pkg/services/store"
+	"github.com/grafana/grafana/pkg/services/team"
 	"github.com/grafana/grafana/pkg/services/teamguardian"
 	tempUser "github.com/grafana/grafana/pkg/services/temp_user"
 	"github.com/grafana/grafana/pkg/services/thumbs"
@@ -189,6 +190,7 @@ type HTTPServer struct {
 	dashboardThumbsService dashboardThumbs.Service
 	loginAttemptService    loginAttempt.Service
 	orgService             org.Service
+	teamService            team.Service
 	accesscontrolService   accesscontrol.Service
 	annotationsRepo        annotations.Repository
 }
@@ -228,7 +230,8 @@ func ProvideHTTPServer(opts ServerOptions, cfg *setting.Cfg, routeRegister routi
 	playlistService playlist.Service, apiKeyService apikey.Service, kvStore kvstore.KVStore,
 	secretsMigrator secrets.Migrator, secretsPluginManager plugins.SecretsPluginManager, secretsService secrets.Service,
 	secretsPluginMigrator spm.SecretMigrationProvider, secretsStore secretsKV.SecretsKVStore,
-	publicDashboardsApi *publicdashboardsApi.Api, userService user.Service, tempUserService tempUser.Service, loginAttemptService loginAttempt.Service, orgService org.Service,
+	publicDashboardsApi *publicdashboardsApi.Api, userService user.Service, tempUserService tempUser.Service,
+	loginAttemptService loginAttempt.Service, orgService org.Service, teamService team.Service,
 	accesscontrolService accesscontrol.Service, dashboardThumbsService dashboardThumbs.Service, annotationRepo annotations.Repository,
 ) (*HTTPServer, error) {
 	web.Env = cfg.Env
@@ -324,6 +327,7 @@ func ProvideHTTPServer(opts ServerOptions, cfg *setting.Cfg, routeRegister routi
 		dashboardThumbsService:       dashboardThumbsService,
 		loginAttemptService:          loginAttemptService,
 		orgService:                   orgService,
+		teamService:                  teamService,
 		accesscontrolService:         accesscontrolService,
 		annotationsRepo:              annotationRepo,
 	}

--- a/pkg/api/org_users_test.go
+++ b/pkg/api/org_users_test.go
@@ -185,9 +185,9 @@ func TestOrgUsersAPIEndpoint_LegacyAccessControl_TeamAdmin(t *testing.T) {
 	setInitCtxSignedInViewer(sc.initCtx)
 
 	// Setup store teams
-	team1, err := sc.db.CreateTeam("testteam1", "testteam1@example.org", testOrgID)
+	team1, err := sc.teamService.CreateTeam("testteam1", "testteam1@example.org", testOrgID)
 	require.NoError(t, err)
-	err = sc.db.AddTeamMember(testUserID, testOrgID, team1.Id, false, models.PERMISSION_ADMIN)
+	err = sc.teamService.AddTeamMember(testUserID, testOrgID, team1.Id, false, models.PERMISSION_ADMIN)
 	require.NoError(t, err)
 
 	response := callAPI(sc.server, http.MethodGet, "/api/org/users/lookup", nil, t)

--- a/pkg/api/team.go
+++ b/pkg/api/team.go
@@ -33,7 +33,7 @@ func (hs *HTTPServer) CreateTeam(c *models.ReqContext) response.Response {
 		return response.Error(403, "Not allowed to create team.", nil)
 	}
 
-	team, err := hs.SQLStore.CreateTeam(cmd.Name, cmd.Email, c.OrgID)
+	team, err := hs.teamService.CreateTeam(cmd.Name, cmd.Email, c.OrgID)
 	if err != nil {
 		if errors.Is(err, models.ErrTeamNameTaken) {
 			return response.Error(409, "Team name taken", err)
@@ -88,7 +88,7 @@ func (hs *HTTPServer) UpdateTeam(c *models.ReqContext) response.Response {
 		}
 	}
 
-	if err := hs.SQLStore.UpdateTeam(c.Req.Context(), &cmd); err != nil {
+	if err := hs.teamService.UpdateTeam(c.Req.Context(), &cmd); err != nil {
 		if errors.Is(err, models.ErrTeamNameTaken) {
 			return response.Error(400, "Team name taken", err)
 		}
@@ -122,7 +122,7 @@ func (hs *HTTPServer) DeleteTeamByID(c *models.ReqContext) response.Response {
 		}
 	}
 
-	if err := hs.SQLStore.DeleteTeam(c.Req.Context(), &models.DeleteTeamCommand{OrgId: orgId, Id: teamId}); err != nil {
+	if err := hs.teamService.DeleteTeam(c.Req.Context(), &models.DeleteTeamCommand{OrgId: orgId, Id: teamId}); err != nil {
 		if errors.Is(err, models.ErrTeamNotFound) {
 			return response.Error(404, "Failed to delete Team. ID not found", nil)
 		}
@@ -167,7 +167,7 @@ func (hs *HTTPServer) SearchTeams(c *models.ReqContext) response.Response {
 		HiddenUsers:  hs.Cfg.HiddenUsers,
 	}
 
-	if err := hs.SQLStore.SearchTeams(c.Req.Context(), &query); err != nil {
+	if err := hs.teamService.SearchTeams(c.Req.Context(), &query); err != nil {
 		return response.Error(500, "Failed to search Teams", err)
 	}
 
@@ -231,7 +231,7 @@ func (hs *HTTPServer) GetTeamByID(c *models.ReqContext) response.Response {
 		UserIdFilter: userIdFilter,
 	}
 
-	if err := hs.SQLStore.GetTeamById(c.Req.Context(), &query); err != nil {
+	if err := hs.teamService.GetTeamById(c.Req.Context(), &query); err != nil {
 		if errors.Is(err, models.ErrTeamNotFound) {
 			return response.Error(404, "Team not found", err)
 		}

--- a/pkg/api/team_members.go
+++ b/pkg/api/team_members.go
@@ -42,7 +42,7 @@ func (hs *HTTPServer) GetTeamMembers(c *models.ReqContext) response.Response {
 		}
 	}
 
-	if err := hs.SQLStore.GetTeamMembers(c.Req.Context(), &query); err != nil {
+	if err := hs.teamService.GetTeamMembers(c.Req.Context(), &query); err != nil {
 		return response.Error(500, "Failed to get Team Members", err)
 	}
 
@@ -94,7 +94,7 @@ func (hs *HTTPServer) AddTeamMember(c *models.ReqContext) response.Response {
 		}
 	}
 
-	isTeamMember, err := hs.SQLStore.IsTeamMember(c.OrgID, cmd.TeamId, cmd.UserId)
+	isTeamMember, err := hs.teamService.IsTeamMember(c.OrgID, cmd.TeamId, cmd.UserId)
 	if err != nil {
 		return response.Error(500, "Failed to add team member.", err)
 	}
@@ -143,7 +143,7 @@ func (hs *HTTPServer) UpdateTeamMember(c *models.ReqContext) response.Response {
 		}
 	}
 
-	isTeamMember, err := hs.SQLStore.IsTeamMember(orgId, teamId, userId)
+	isTeamMember, err := hs.teamService.IsTeamMember(orgId, teamId, userId)
 	if err != nil {
 		return response.Error(500, "Failed to update team member.", err)
 	}

--- a/pkg/api/user.go
+++ b/pkg/api/user.go
@@ -254,7 +254,7 @@ func (hs *HTTPServer) GetUserTeams(c *models.ReqContext) response.Response {
 func (hs *HTTPServer) getUserTeamList(c *models.ReqContext, orgID int64, userID int64) response.Response {
 	query := models.GetTeamsByUserQuery{OrgId: orgID, UserId: userID, SignedInUser: c.SignedInUser}
 
-	if err := hs.SQLStore.GetTeamsByUser(c.Req.Context(), &query); err != nil {
+	if err := hs.teamService.GetTeamsByUser(c.Req.Context(), &query); err != nil {
 		return response.Error(500, "Failed to get user teams", err)
 	}
 

--- a/pkg/cmd/grafana-cli/runner/wire.go
+++ b/pkg/cmd/grafana-cli/runner/wire.go
@@ -116,6 +116,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/star/starimpl"
 	"github.com/grafana/grafana/pkg/services/store"
 	"github.com/grafana/grafana/pkg/services/store/sanitizer"
+	"github.com/grafana/grafana/pkg/services/team/teamimpl"
 	"github.com/grafana/grafana/pkg/services/teamguardian"
 	teamguardianDatabase "github.com/grafana/grafana/pkg/services/teamguardian/database"
 	teamguardianManager "github.com/grafana/grafana/pkg/services/teamguardian/manager"
@@ -319,6 +320,7 @@ var wireSet = wire.NewSet(
 	publicdashboardsApi.ProvideApi,
 	userimpl.ProvideService,
 	orgimpl.ProvideService,
+	teamimpl.ProvideService,
 	userauthimpl.ProvideService,
 	ngmetrics.ProvideServiceForTest,
 	wire.Bind(new(sqlstore.TeamStore), new(*sqlstore.SQLStore)),

--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
+	"github.com/grafana/grafana/pkg/services/team"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/web"
 )
@@ -193,7 +194,7 @@ func shouldForceLogin(c *models.ReqContext) bool {
 	return forceLogin
 }
 
-func OrgAdminDashOrFolderAdminOrTeamAdmin(ss sqlstore.Store, ds dashboards.DashboardService) func(c *models.ReqContext) {
+func OrgAdminDashOrFolderAdminOrTeamAdmin(ss sqlstore.Store, ds dashboards.DashboardService, ts team.Service) func(c *models.ReqContext) {
 	return func(c *models.ReqContext) {
 		if c.OrgRole == org.RoleAdmin {
 			return
@@ -209,7 +210,7 @@ func OrgAdminDashOrFolderAdminOrTeamAdmin(ss sqlstore.Store, ds dashboards.Dashb
 		}
 
 		isAdminOfTeamsQuery := models.IsAdminOfTeamsQuery{SignedInUser: c.SignedInUser}
-		if err := ss.IsAdminOfTeams(c.Req.Context(), &isAdminOfTeamsQuery); err != nil {
+		if err := ts.IsAdminOfTeams(c.Req.Context(), &isAdminOfTeamsQuery); err != nil {
 			c.JsonApiErr(500, "Failed to check if user is a team admin", err)
 		}
 

--- a/pkg/services/dashboards/service/dashboard_service_integration_test.go
+++ b/pkg/services/dashboards/service/dashboard_service_integration_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/guardian"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
+	"github.com/grafana/grafana/pkg/services/team/teamtest"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 )
@@ -826,7 +827,7 @@ func permissionScenario(t *testing.T, desc string, canSave bool, fn permissionSc
 			accesscontrolmock.NewMockedPermissionsService(),
 			accesscontrolmock.New(),
 		)
-		guardian.InitLegacyGuardian(sqlStore, service)
+		guardian.InitLegacyGuardian(sqlStore, service, &teamtest.FakeService{})
 
 		savedFolder := saveTestFolder(t, "Saved folder", testOrgID, sqlStore)
 		savedDashInFolder := saveTestDashboard(t, "Saved dash in folder", testOrgID, savedFolder.Id, sqlStore)

--- a/pkg/services/guardian/guardian.go
+++ b/pkg/services/guardian/guardian.go
@@ -9,6 +9,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
+	"github.com/grafana/grafana/pkg/services/team"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 )
@@ -48,6 +49,7 @@ type dashboardGuardianImpl struct {
 	ctx              context.Context
 	store            sqlstore.Store
 	dashboardService dashboards.DashboardService
+	teamService      team.Service
 }
 
 // New factory for creating a new dashboard guardian instance
@@ -56,7 +58,7 @@ var New = func(ctx context.Context, dashId int64, orgId int64, user *user.Signed
 	panic("no guardian factory implementation provided")
 }
 
-func newDashboardGuardian(ctx context.Context, dashId int64, orgId int64, user *user.SignedInUser, store sqlstore.Store, dashSvc dashboards.DashboardService) *dashboardGuardianImpl {
+func newDashboardGuardian(ctx context.Context, dashId int64, orgId int64, user *user.SignedInUser, store sqlstore.Store, dashSvc dashboards.DashboardService, teamSvc team.Service) *dashboardGuardianImpl {
 	return &dashboardGuardianImpl{
 		user:             user,
 		dashId:           dashId,
@@ -65,6 +67,7 @@ func newDashboardGuardian(ctx context.Context, dashId int64, orgId int64, user *
 		ctx:              ctx,
 		store:            store,
 		dashboardService: dashSvc,
+		teamService:      teamSvc,
 	}
 }
 
@@ -276,7 +279,7 @@ func (g *dashboardGuardianImpl) getTeams() ([]*models.TeamDTO, error) {
 	}
 
 	query := models.GetTeamsByUserQuery{OrgId: g.orgId, UserId: g.user.UserID, SignedInUser: g.user}
-	err := g.store.GetTeamsByUser(g.ctx, &query)
+	err := g.teamService.GetTeamsByUser(g.ctx, &query)
 
 	g.teams = query.Result
 	return query.Result, err

--- a/pkg/services/guardian/guardian_test.go
+++ b/pkg/services/guardian/guardian_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/sqlstore/mockstore"
+	"github.com/grafana/grafana/pkg/services/team/teamtest"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 )
@@ -706,7 +707,7 @@ func TestGuardianGetHiddenACL(t *testing.T) {
 				UserID: 1,
 				Login:  "user1",
 			}
-			g := newDashboardGuardian(context.Background(), dashboardID, orgID, user, store, dashSvc)
+			g := newDashboardGuardian(context.Background(), dashboardID, orgID, user, store, dashSvc, &teamtest.FakeService{})
 
 			hiddenACL, err := g.GetHiddenACL(cfg)
 			require.NoError(t, err)
@@ -722,7 +723,7 @@ func TestGuardianGetHiddenACL(t *testing.T) {
 				Login:          "user1",
 				IsGrafanaAdmin: true,
 			}
-			g := newDashboardGuardian(context.Background(), dashboardID, orgID, user, store, &dashboards.FakeDashboardService{})
+			g := newDashboardGuardian(context.Background(), dashboardID, orgID, user, store, &dashboards.FakeDashboardService{}, &teamtest.FakeService{})
 
 			hiddenACL, err := g.GetHiddenACL(cfg)
 			require.NoError(t, err)
@@ -756,7 +757,7 @@ func TestGuardianGetACLWithoutDuplicates(t *testing.T) {
 				UserID: 1,
 				Login:  "user1",
 			}
-			g := newDashboardGuardian(context.Background(), dashboardID, orgID, user, store, dashSvc)
+			g := newDashboardGuardian(context.Background(), dashboardID, orgID, user, store, dashSvc, &teamtest.FakeService{})
 
 			acl, err := g.GetACLWithoutDuplicates()
 			require.NoError(t, err)

--- a/pkg/services/guardian/provider.go
+++ b/pkg/services/guardian/provider.go
@@ -6,6 +6,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
+	"github.com/grafana/grafana/pkg/services/team"
 	"github.com/grafana/grafana/pkg/services/user"
 )
 
@@ -14,20 +15,20 @@ type Provider struct{}
 func ProvideService(
 	store *sqlstore.SQLStore, ac accesscontrol.AccessControl,
 	folderPermissionsService accesscontrol.FolderPermissionsService, dashboardPermissionsService accesscontrol.DashboardPermissionsService,
-	dashboardService dashboards.DashboardService,
+	dashboardService dashboards.DashboardService, teamService team.Service,
 ) *Provider {
 	if !ac.IsDisabled() {
 		// TODO: Fix this hack, see https://github.com/grafana/grafana-enterprise/issues/2935
 		InitAccessControlGuardian(store, ac, folderPermissionsService, dashboardPermissionsService, dashboardService)
 	} else {
-		InitLegacyGuardian(store, dashboardService)
+		InitLegacyGuardian(store, dashboardService, teamService)
 	}
 	return &Provider{}
 }
 
-func InitLegacyGuardian(store sqlstore.Store, dashSvc dashboards.DashboardService) {
+func InitLegacyGuardian(store sqlstore.Store, dashSvc dashboards.DashboardService, teamSvc team.Service) {
 	New = func(ctx context.Context, dashId int64, orgId int64, user *user.SignedInUser) DashboardGuardian {
-		return newDashboardGuardian(ctx, dashId, orgId, user, store, dashSvc)
+		return newDashboardGuardian(ctx, dashId, orgId, user, store, dashSvc, teamSvc)
 	}
 }
 

--- a/pkg/services/libraryelements/libraryelements_test.go
+++ b/pkg/services/libraryelements/libraryelements_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/services/sqlstore/mockstore"
+	"github.com/grafana/grafana/pkg/services/team/teamtest"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/web"
@@ -378,7 +379,7 @@ func validateAndUnMarshalArrayResponse(t *testing.T, resp response.Response) lib
 func scenarioWithPanel(t *testing.T, desc string, fn func(t *testing.T, sc scenarioContext)) {
 	t.Helper()
 	store := mockstore.NewSQLStoreMock()
-	guardian.InitLegacyGuardian(store, &dashboards.FakeDashboardService{})
+	guardian.InitLegacyGuardian(store, &dashboards.FakeDashboardService{}, &teamtest.FakeService{})
 
 	testScenario(t, desc, func(t *testing.T, sc scenarioContext) {
 		command := getCreatePanelCommand(sc.folder.Id, "Text - Library Panel")
@@ -415,7 +416,7 @@ func testScenario(t *testing.T, desc string, fn func(t *testing.T, sc scenarioCo
 			sqlStore.Cfg, dashboardStore, nil,
 			features, folderPermissions, dashboardPermissions, ac,
 		)
-		guardian.InitLegacyGuardian(sqlStore, dashboardService)
+		guardian.InitLegacyGuardian(sqlStore, dashboardService, &teamtest.FakeService{})
 		service := LibraryElementService{
 			Cfg:      sqlStore.Cfg,
 			SQLStore: sqlStore,

--- a/pkg/services/librarypanels/librarypanels_test.go
+++ b/pkg/services/librarypanels/librarypanels_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/services/sqlstore/mockstore"
+	"github.com/grafana/grafana/pkg/services/team/teamtest"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 )
@@ -1441,7 +1442,7 @@ func updateFolderACL(t *testing.T, dashboardStore *database.DashboardStore, fold
 
 func scenarioWithLibraryPanel(t *testing.T, desc string, fn func(t *testing.T, sc scenarioContext)) {
 	store := mockstore.NewSQLStoreMock()
-	guardian.InitLegacyGuardian(store, &dashboards.FakeDashboardService{})
+	guardian.InitLegacyGuardian(store, &dashboards.FakeDashboardService{}, &teamtest.FakeService{})
 	t.Helper()
 
 	testScenario(t, desc, func(t *testing.T, sc scenarioContext) {

--- a/pkg/services/sqlstore/store.go
+++ b/pkg/services/sqlstore/store.go
@@ -30,18 +30,6 @@ type Store interface {
 	GetSignedInUser(ctx context.Context, query *models.GetSignedInUserQuery) error
 	UpdateUserPermissions(userID int64, isAdmin bool) error
 	SetUserHelpFlag(ctx context.Context, cmd *models.SetUserHelpFlagCommand) error
-	CreateTeam(name, email string, orgID int64) (models.Team, error)
-	UpdateTeam(ctx context.Context, cmd *models.UpdateTeamCommand) error
-	DeleteTeam(ctx context.Context, cmd *models.DeleteTeamCommand) error
-	SearchTeams(ctx context.Context, query *models.SearchTeamsQuery) error
-	GetTeamById(ctx context.Context, query *models.GetTeamByIdQuery) error
-	GetTeamsByUser(ctx context.Context, query *models.GetTeamsByUserQuery) error
-	AddTeamMember(userID, orgID, teamID int64, isExternal bool, permission models.PermissionType) error
-	UpdateTeamMember(ctx context.Context, cmd *models.UpdateTeamMemberCommand) error
-	IsTeamMember(orgId int64, teamId int64, userId int64) (bool, error)
-	RemoveTeamMember(ctx context.Context, cmd *models.RemoveTeamMemberCommand) error
-	GetUserTeamMemberships(ctx context.Context, orgID, userID int64, external bool) ([]*models.TeamMemberDTO, error)
-	GetTeamMembers(ctx context.Context, query *models.GetTeamMembersQuery) error
 	NewSession(ctx context.Context) *DBSession
 	WithDbSession(ctx context.Context, callback DBTransactionFunc) error
 	GetOrgQuotaByTarget(ctx context.Context, query *models.GetOrgQuotaByTargetQuery) error
@@ -64,6 +52,5 @@ type Store interface {
 	Quote(value string) string
 	GetDBHealthQuery(ctx context.Context, query *models.GetDBHealthQuery) error
 	SearchOrgs(ctx context.Context, query *models.SearchOrgsQuery) error
-	IsAdminOfTeams(ctx context.Context, query *models.IsAdminOfTeamsQuery) error
 	GetSqlxSession() *session.SessionDB
 }

--- a/pkg/services/team/teamtest/team.go
+++ b/pkg/services/team/teamtest/team.go
@@ -1,0 +1,67 @@
+package teamtest
+
+import (
+	"context"
+
+	"github.com/grafana/grafana/pkg/models"
+)
+
+type FakeService struct {
+	ExpectedTeam        models.Team
+	ExpectedTeamsByUser []*models.TeamDTO
+	ExpectedMembers     []*models.TeamMemberDTO
+	ExpectedError       error
+}
+
+func (s *FakeService) CreateTeam(name, email string, orgID int64) (models.Team, error) {
+	return s.ExpectedTeam, s.ExpectedError
+}
+
+func (s *FakeService) UpdateTeam(ctx context.Context, cmd *models.UpdateTeamCommand) error {
+	return s.ExpectedError
+}
+
+func (s *FakeService) DeleteTeam(ctx context.Context, cmd *models.DeleteTeamCommand) error {
+	return s.ExpectedError
+}
+
+func (s *FakeService) SearchTeams(ctx context.Context, query *models.SearchTeamsQuery) error {
+	return s.ExpectedError
+}
+
+func (s *FakeService) GetTeamById(ctx context.Context, query *models.GetTeamByIdQuery) error {
+	return s.ExpectedError
+}
+
+func (s *FakeService) GetTeamsByUser(ctx context.Context, query *models.GetTeamsByUserQuery) error {
+	query.Result = s.ExpectedTeamsByUser
+	return s.ExpectedError
+}
+
+func (s *FakeService) AddTeamMember(userID, orgID, teamID int64, isExternal bool, permission models.PermissionType) error {
+	return s.ExpectedError
+}
+
+func (s *FakeService) UpdateTeamMember(ctx context.Context, cmd *models.UpdateTeamMemberCommand) error {
+	return s.ExpectedError
+}
+
+func (s *FakeService) IsTeamMember(orgId int64, teamId int64, userId int64) (bool, error) {
+	return false, s.ExpectedError
+}
+
+func (s *FakeService) RemoveTeamMember(ctx context.Context, cmd *models.RemoveTeamMemberCommand) error {
+	return s.ExpectedError
+}
+
+func (s *FakeService) GetUserTeamMemberships(ctx context.Context, orgID, userID int64, external bool) ([]*models.TeamMemberDTO, error) {
+	return s.ExpectedMembers, s.ExpectedError
+}
+
+func (s *FakeService) GetTeamMembers(ctx context.Context, query *models.GetTeamMembersQuery) error {
+	return s.ExpectedError
+}
+
+func (s *FakeService) IsAdminOfTeams(ctx context.Context, query *models.IsAdminOfTeamsQuery) error {
+	return s.ExpectedError
+}

--- a/pkg/services/teamguardian/database/database.go
+++ b/pkg/services/teamguardian/database/database.go
@@ -5,18 +5,20 @@ import (
 
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
+	"github.com/grafana/grafana/pkg/services/team"
 )
 
 type TeamGuardianStoreImpl struct {
-	sqlStore sqlstore.Store
+	sqlStore    sqlstore.Store
+	teamService team.Service
 }
 
-func ProvideTeamGuardianStore(sqlStore sqlstore.Store) *TeamGuardianStoreImpl {
-	return &TeamGuardianStoreImpl{sqlStore: sqlStore}
+func ProvideTeamGuardianStore(sqlStore sqlstore.Store, teamService team.Service) *TeamGuardianStoreImpl {
+	return &TeamGuardianStoreImpl{sqlStore: sqlStore, teamService: teamService}
 }
 
 func (t *TeamGuardianStoreImpl) GetTeamMembers(ctx context.Context, query models.GetTeamMembersQuery) ([]*models.TeamMemberDTO, error) {
-	if err := t.sqlStore.GetTeamMembers(ctx, &query); err != nil {
+	if err := t.teamService.GetTeamMembers(ctx, &query); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Related to #46522 this switches API package and middleware to use team.Service instead of sqlstore.Store