### PR TITLE
Alerting: Stop flushing state when Grafana stops

### DIFF
--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -307,7 +307,7 @@ func (sch *schedule) schedulePeriodic(ctx context.Context) error {
 			// waiting for all rule evaluation routines to stop
 			waitErr := dispatcherGroup.Wait()
 			// close the state manager and flush the state
-			sch.stateManager.Close(ctx)
+			sch.stateManager.Close()
 			return waitErr
 		}
 	}

--- a/pkg/services/ngalert/state/manager_private_test.go
+++ b/pkg/services/ngalert/state/manager_private_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
 	"github.com/benbjohnson/clock"
@@ -16,7 +15,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/annotations/annotationstest"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
-	"github.com/grafana/grafana/pkg/services/ngalert/image"
 	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/store"
@@ -151,44 +149,4 @@ func TestIsItStale(t *testing.T) {
 			require.Equal(t, tc.expectedResult, isItStale(now, tc.lastEvaluation, intervalSeconds))
 		})
 	}
-}
-
-func TestClose(t *testing.T) {
-	instanceStore := &store.FakeInstanceStore{}
-	clk := clock.New()
-	st := NewManager(log.New("test_state_manager"), metrics.NewNGAlert(prometheus.NewPedanticRegistry()).GetStateMetrics(), nil, nil, instanceStore, &dashboards.FakeDashboardService{}, &image.NotAvailableImageService{}, clk, annotationstest.NewFakeAnnotationsRepo())
-
-	_, rules := ngmodels.GenerateUniqueAlertRules(10, ngmodels.AlertRuleGen())
-	for _, rule := range rules {
-		results := eval.GenerateResults(rand.Intn(4)+1, eval.ResultGen(eval.WithEvaluatedAt(clk.Now())))
-		_ = st.ProcessEvalResults(context.Background(), clk.Now(), rule, results, ngmodels.GenerateAlertLabels(rand.Intn(4), "extra_"))
-	}
-	var states []*State
-	for _, org := range st.cache.states {
-		for _, rule := range org {
-			for _, state := range rule {
-				states = append(states, state)
-			}
-		}
-	}
-
-	instanceStore.RecordedOps = nil
-	st.Close(context.Background())
-
-	t.Run("should flush the state to store", func(t *testing.T) {
-		savedStates := make(map[string]ngmodels.SaveAlertInstanceCommand)
-		for _, op := range instanceStore.RecordedOps {
-			switch q := op.(type) {
-			case ngmodels.SaveAlertInstanceCommand:
-				cacheId, err := q.Labels.StringKey()
-				require.NoError(t, err)
-				savedStates[cacheId] = q
-			}
-		}
-
-		require.Len(t, savedStates, len(states))
-		for _, s := range states {
-			require.Contains(t, savedStates, s.CacheId)
-		}
-	})
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
After a few refactorings and fixes (https://github.com/grafana/grafana/pull/53919, https://github.com/grafana/grafana/pull/55265, https://github.com/grafana/grafana/pull/53852) it becomes clear that the saving the entire state when Grafana stops did not really work before (before PR https://github.com/grafana/grafana/pull/53919 and https://github.com/grafana/grafana/pull/53919/files#diff-1fe393768892c6c76a43e1ac0ea9ca69ec72d2124d6d80abbede394dd49077aeL399 in particular).
On other hand, this went unnoticed because the state is saved every time a rule is evaluated (https://github.com/grafana/grafana/pull/53852/files#diff-6420fa5148996efbf754b18838902601c17b758ab7da6279dc019b5b143fd5c2R175-R182) and therefore the entire state is kept in sync with the database during the runtime. 
It is worth mentioning that there is a field that is updated after the state is saved to the database
https://github.com/grafana/grafana/blob/6844ac987936dd72fe2a1c803e385691ab20ded6/pkg/services/ngalert/schedule/compat.go#L127-L130. However, this field is not persisted in the database and therefore the state is basically the same (even put command is not necessary because state slice contains pointers to original states in the cache.)

This PR removes saving the states to the database when Alerting service is stopped (i.e. Grafana is stopped)


Supersedes: https://github.com/grafana/grafana/pull/55265