### PR TITLE
Alerting: Refactor alertmanager notifier to use encoding/json to parse settings instead of simplejson

### DIFF
--- a/pkg/services/ngalert/notifier/channels/alertmanager.go
+++ b/pkg/services/ngalert/notifier/channels/alertmanager.go
@@ -48,9 +48,6 @@ func buildAlertmanagerNotifier(fc channels.FactoryConfig) (*AlertmanagerNotifier
 		return nil, fmt.Errorf("failed to unmarshal settings: %w", err)
 	}
 
-	if len(settings.URL) == 0 {
-		return nil, errors.New("could not find url property in settings")
-	}
 	urls := make([]*url.URL, 0, len(settings.URL))
 	for _, uS := range settings.URL {
 		uS = strings.TrimSpace(uS)
@@ -63,6 +60,9 @@ func buildAlertmanagerNotifier(fc channels.FactoryConfig) (*AlertmanagerNotifier
 			return nil, fmt.Errorf("invalid url property in settings: %w", err)
 		}
 		urls = append(urls, u)
+	}
+	if len(settings.URL) == 0 || len(urls) == 0 {
+		return nil, errors.New("could not find url property in settings")
 	}
 	settings.Password = fc.DecryptFunc(context.Background(), fc.Config.SecureSettings, "basicAuthPassword", settings.Password)
 

--- a/pkg/services/ngalert/notifier/channels/alertmanager_test.go
+++ b/pkg/services/ngalert/notifier/channels/alertmanager_test.go
@@ -56,12 +56,12 @@ func TestNewAlertmanagerNotifier(t *testing.T) {
 				return fallback
 			}
 
-			fc := FactoryConfig{
+			fc := channels.FactoryConfig{
 				Config:      m,
 				DecryptFunc: decryptFn,
-				ImageStore:  &UnavailableImageStore{},
+				ImageStore:  &channels.UnavailableImageStore{},
 				Template:    tmpl,
-				Logger:      &FakeLogger{},
+				Logger:      &channels.FakeLogger{},
 			}
 			sn, err := buildAlertmanagerNotifier(fc)
 			if c.expectedInitError != "" {
@@ -159,12 +159,12 @@ func TestAlertmanagerNotifier_Notify(t *testing.T) {
 			decryptFn := func(ctx context.Context, sjd map[string][]byte, key string, fallback string) string {
 				return fallback
 			}
-			fc := FactoryConfig{
+			fc := channels.FactoryConfig{
 				Config:      m,
 				DecryptFunc: decryptFn,
 				ImageStore:  images,
 				Template:    tmpl,
-				Logger:      &FakeLogger{},
+				Logger:      &channels.FakeLogger{},
 			}
 			sn, err := buildAlertmanagerNotifier(fc)
 			require.NoError(t, err)

--- a/pkg/services/ngalert/notifier/channels/alertmanager_test.go
+++ b/pkg/services/ngalert/notifier/channels/alertmanager_test.go
@@ -40,6 +40,30 @@ func TestNewAlertmanagerNotifier(t *testing.T) {
 			expectedInitError: `invalid url property in settings: parse "://alertmanager.com/api/v1/alerts": missing protocol scheme`,
 			receiverName:      "Alertmanager",
 		},
+		{
+			name: "Error in initing: empty URL",
+			settings: `{
+				"url": ""
+			}`,
+			expectedInitError: `could not find url property in settings`,
+			receiverName:      "Alertmanager",
+		},
+		{
+			name: "Error in initing: null URL",
+			settings: `{
+				"url": null
+			}`,
+			expectedInitError: `could not find url property in settings`,
+			receiverName:      "Alertmanager",
+		},
+		{
+			name: "Error in initing: one of multiple URLs is invalid",
+			settings: `{
+				"url": "https://alertmanager-01.com,://url"
+			}`,
+			expectedInitError: "invalid url property in settings: parse \"://url/api/v1/alerts\": missing protocol scheme",
+			receiverName:      "Alertmanager",
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/pkg/services/ngalert/notifier/channels/util.go
+++ b/pkg/services/ngalert/notifier/channels/util.go
@@ -20,7 +20,6 @@ import (
 	"github.com/prometheus/common/model"
 
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
-	"github.com/grafana/grafana/pkg/util"
 )
 
 var (
@@ -151,7 +150,7 @@ var sendHTTPRequest = func(ctx context.Context, url *url.URL, cfg httpCfg, logge
 		return nil, fmt.Errorf("failed to create HTTP request: %w", err)
 	}
 	if cfg.user != "" && cfg.password != "" {
-		request.Header.Set("Authorization", util.GetBasicAuthHeader(cfg.user, cfg.password))
+		request.SetBasicAuth(cfg.user, cfg.password)
 	}
 
 	request.Header.Set("Content-Type", "application/json")


### PR DESCRIPTION
**What this PR does / why we need it**:

Instead of using `simplejson` to loosely parse notifier settings which is [bug-prone](https://github.com/grafana/grafana/issues/55139), this PR instead makes notifiers declare a well-defined struct for their settings.

This has some benefits:
- Improves validation for all settings fields and eliminates bugs (see attached issue)
- The total set of fields for each notifier is now clear and obvious. Settings are easier to reason about.
- Simplifies notifier construction logic by removing a layer of indirection
- Eliminates repetition/mapping of settings fields, which was a vector for bugs
- Makes our notifiers more in-line with [Prometheus's notifiers](https://github.com/prometheus/alertmanager/blob/3d624c0552e173aa57bbdad52a55788e38744252/notify/slack/slack.go). They also use settings structs.

**Which issue(s) this PR fixes**:

Contributes to https://github.com/grafana/grafana/issues/55139