### PR TITLE
Prometheus: Update onblur ref with value of last changed monaco editor

### DIFF
--- a/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryField.tsx
+++ b/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryField.tsx
@@ -203,9 +203,9 @@ const MonacoQueryField = (props: Props) => {
           updateElementHeight();
 
           // Whenever the editor changes, lets save the last value so the next query for this editor will be up-to-date.
-          // This change is being introduced to fix a bug where you can submit a query via shift+enter, 
-          // but if you just clicked into another field and haven't un-blurred the active field, 
-          // then the query that is run will be stale, as the reference is only updated 
+          // This change is being introduced to fix a bug where you can submit a query via shift+enter,
+          // but if you just clicked into another field and haven't un-blurred the active field,
+          // then the query that is run will be stale, as the reference is only updated
           // with the value of the last blurred input.
           editor.getModel()?.onDidChangeContent(() => {
             onChangeRef.current(editor.getValue());

--- a/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryField.tsx
+++ b/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryField.tsx
@@ -203,8 +203,8 @@ const MonacoQueryField = (props: Props) => {
           updateElementHeight();
 
           // Whenever the editor changes, lets save the last value so the next query for this editor will be up-to-date.
-          // This change is being introduced to fix a bug where you can submit a query via shift+enter,
-          // but if you just clicked into another field and haven't un-blurred the active field,
+          // This change is being introduced to fix a bug where you can submit a query via shift+enter:
+          // If you clicked into another field and haven't un-blurred the active field,
           // then the query that is run will be stale, as the reference is only updated
           // with the value of the last blurred input.
           editor.getModel()?.onDidChangeContent(() => {

--- a/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryField.tsx
+++ b/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryField.tsx
@@ -203,7 +203,10 @@ const MonacoQueryField = (props: Props) => {
           updateElementHeight();
 
           // Whenever the editor changes, lets save the last value so the next query for this editor will be up-to-date.
-          // This change is being introduced to fix a bug where you can submit a query via shift+enter, but if you just clicked into another field and haven't un-blurred the active field, then the query that is run will be stale, as the reference is only updated with the value of the last blurred input.
+          // This change is being introduced to fix a bug where you can submit a query via shift+enter, 
+          // but if you just clicked into another field and haven't un-blurred the active field, 
+          // then the query that is run will be stale, as the reference is only updated 
+          // with the value of the last blurred input.
           editor.getModel()?.onDidChangeContent(() => {
             onChangeRef.current(editor.getValue());
           });

--- a/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryField.tsx
+++ b/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryField.tsx
@@ -90,12 +90,13 @@ const MonacoQueryField = (props: Props) => {
   // we need only one instance of `overrideServices` during the lifetime of the react component
   const overrideServicesRef = useRef(getOverrideServices());
   const containerRef = useRef<HTMLDivElement>(null);
-  const { languageProvider, history, onBlur, onRunQuery, initialValue, placeholder } = props;
+  const { languageProvider, history, onBlur, onRunQuery, initialValue, placeholder, onChange } = props;
 
   const lpRef = useLatest(languageProvider);
   const historyRef = useLatest(history);
   const onRunQueryRef = useLatest(onRunQuery);
   const onBlurRef = useLatest(onBlur);
+  const onChangeRef = useLatest(onChange);
 
   const autocompleteDisposeFun = useRef<(() => void) | null>(null);
 
@@ -201,10 +202,10 @@ const MonacoQueryField = (props: Props) => {
           editor.onDidContentSizeChange(updateElementHeight);
           updateElementHeight();
 
-          // If every change event triggers adding the current editor value to the onBlurRef then we're assured to have the correct value when we eventually run the query
+          // Whenever the editor changes, lets save the last value so the next query for this editor will be up-to-date.
           // This change is being introduced to fix a bug where you can submit a query via shift+enter, but if you just clicked into another field and haven't un-blurred the active field, then the query that is run will be stale, as the reference is only updated with the value of the last blurred input.
           editor.getModel()?.onDidChangeContent(() => {
-            onBlurRef.current(editor.getValue());
+            onChangeRef.current(editor.getValue());
           });
 
           // handle: shift + enter

--- a/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryField.tsx
+++ b/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryField.tsx
@@ -201,6 +201,12 @@ const MonacoQueryField = (props: Props) => {
           editor.onDidContentSizeChange(updateElementHeight);
           updateElementHeight();
 
+          // If every change event triggers adding the current editor value to the onBlurRef then we're assured to have the correct value when we eventually run the query
+          // This change is being introduced to fix a bug where you can submit a query via shift+enter, but if you just clicked into another field and haven't un-blurred the active field, then the query that is run will be stale, as the reference is only updated with the value of the last blurred input.
+          editor.getModel()?.onDidChangeContent(() => {
+            onBlurRef.current(editor.getValue());
+          });
+
           // handle: shift + enter
           // FIXME: maybe move this functionality into CodeEditor?
           editor.addCommand(monaco.KeyMod.Shift | monaco.KeyCode.Enter, () => {

--- a/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryFieldProps.ts
+++ b/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryFieldProps.ts
@@ -14,4 +14,6 @@ export type Props = {
   placeholder: string;
   onRunQuery: (value: string) => void;
   onBlur: (value: string) => void;
+  // onChange will never initiate a query, it just denotes that a query value has been changed
+  onChange: (value: string) => void;
 };

--- a/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryFieldWrapper.tsx
+++ b/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryFieldWrapper.tsx
@@ -30,5 +30,13 @@ export const MonacoQueryFieldWrapper = (props: Props) => {
     }
   };
 
-  return <MonacoQueryFieldLazy onRunQuery={handleRunQuery} onBlur={handleBlur} {...rest} />;
+  /**
+   * Handles changes without running any queries
+   * @param value
+   */
+  const handleChange = (value: string) => {
+    onChange(value);
+  };
+
+  return <MonacoQueryFieldLazy onChange={handleChange} onRunQuery={handleRunQuery} onBlur={handleBlur} {...rest} />;
 };


### PR DESCRIPTION
Add new monaco callback to update onBlurRef with current value on monaco editor change.

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Fixes bug when submitting queries via the keyboard when using multiple queries in prometheus. Currently only the last editor input that is un-blurred will get run when the user presses shift+enter, so if you make changes in a query editor, and press shift+enter without clicking on something else first, the updates to your query will not be sent to the datasource API, and you will instead see the results of the old (unchanged) query populating the UI.

**Which issue(s) this PR fixes**:
https://github.com/grafana/grafana/issues/55387

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/55387 

**Special notes for your reviewer**:
What am I breaking this time?
