### PR TITLE
Update CODEOWNERS with specific docs responsibilities

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,12 +11,28 @@
 # In each subsection folders are ordered first by depth, then alphabetically.
 # This should make it easy to add new rules without breaking existing ones.
 
-# Documentation owner: Jita Chatterjee
+# Documentation
 /docs/ @grafana/docs-squad
 /contribute/ @grafana/docs-squad
 /docs/sources/developers/plugins/ @grafana/docs-squad @grafana/plugins-platform-frontend @grafana/plugins-platform-backend
 /docs/sources/developers/plugins/backend @grafana/docs-squad @grafana/plugins-platform-backend
+# Enterprise: Ursula Kallio
+# Administration, data sources, querying, release updates: Garrett Guillotte
+# Set up, dashboards/visualization, best practices: Chris Moyer
+# Alerting: Brenda Muir
+/docs/sources/administration/ @gguillotte-grafana
+/docs/sources/alerting @brendamuir
+/docs/sources/best-practices/ @chri2547
+/docs/sources/dashboards/ @chri2547
+/docs/sources/datasources/ @gguillotte-grafana
 /docs/sources/enterprise/ @osg-grafana @grafana/docs-squad
+/docs/sources/explore/ @gguillotte-grafana
+/docs/sources/getting-started/ @chri2547
+/docs/sources/old-alerting @brendamuir
+/docs/sources/panels/ @chri2547
+/docs/sources/release-notes/ @gguillotte-grafana
+/docs/sources/visualization/ @chri2547
+/docs/sources/whatsnew/ @gguillotte-grafana
 
 # Backend code
 *.go @grafana/backend-platform
@@ -67,7 +83,7 @@ go.sum @grafana/backend-platform
 /pkg/services/store/ @grafana/grafana-edge-squad
 /pkg/services/export/ @grafana/grafana-edge-squad
 /pkg/infra/filestore/ @grafana/grafana-edge-squad
-pkg/tsdb/testdatasource/sims/ @grafana/grafana-edge-squad
+/pkg/tsdb/testdatasource/sims/ @grafana/grafana-edge-squad
 
 # Alerting
 /pkg/services/ngalert @grafana/alerting-squad-backend
@@ -75,7 +91,6 @@ pkg/tsdb/testdatasource/sims/ @grafana/grafana-edge-squad
 /pkg/services/alerting @grafana/alerting-squad-backend
 /pkg/tests/api/alerting @grafana/alerting-squad-backend
 /public/app/features/alerting @grafana/alerting-squad-frontend
-/docs/sources/alerting @brendamuir
 
 # Library Services
 /pkg/services/libraryelements @grafana/user-essentials

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,7 +16,6 @@
 /contribute/ @grafana/docs-squad
 /docs/sources/developers/plugins/ @grafana/docs-squad @grafana/plugins-platform-frontend @grafana/plugins-platform-backend
 /docs/sources/developers/plugins/backend @grafana/docs-squad @grafana/plugins-platform-backend
-# Enterprise: Ursula Kallio
 # Administration, data sources, querying, release updates: Garrett Guillotte
 # Set up, dashboards/visualization, best practices: Chris Moyer
 # Alerting: Brenda Muir
@@ -25,7 +24,7 @@
 /docs/sources/best-practices/ @chri2547
 /docs/sources/dashboards/ @chri2547
 /docs/sources/datasources/ @gguillotte-grafana
-/docs/sources/enterprise/ @osg-grafana @grafana/docs-squad
+/docs/sources/enterprise/ @gguillotte-grafana
 /docs/sources/explore/ @gguillotte-grafana
 /docs/sources/getting-started/ @chri2547
 /docs/sources/old-alerting @brendamuir


### PR DESCRIPTION
To improve automation of docs-related GitHub issue assignment, update CODEOWNERS with the writers responsible for specific areas of docs content.