### PR TITLE
Drone: Always have `image_pull_secrets`

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2,6 +2,8 @@
 clone:
   retries: 3
 depends_on: []
+image_pull_secrets:
+- dockerconfigjson
 kind: pipeline
 name: pr-verify-drone
 node:
@@ -54,6 +56,8 @@ volumes:
 clone:
   retries: 3
 depends_on: []
+image_pull_secrets:
+- dockerconfigjson
 kind: pipeline
 name: pr-test-frontend
 node:
@@ -133,6 +137,8 @@ volumes:
 clone:
   retries: 3
 depends_on: []
+image_pull_secrets:
+- dockerconfigjson
 kind: pipeline
 name: pr-test-backend
 node:
@@ -219,6 +225,8 @@ volumes:
 clone:
   retries: 3
 depends_on: []
+image_pull_secrets:
+- dockerconfigjson
 kind: pipeline
 name: pr-build-e2e
 node:
@@ -466,6 +474,8 @@ volumes:
 clone:
   retries: 3
 depends_on: []
+image_pull_secrets:
+- dockerconfigjson
 kind: pipeline
 name: pr-integration-tests
 node:
@@ -589,6 +599,8 @@ volumes:
 clone:
   retries: 3
 depends_on: []
+image_pull_secrets:
+- dockerconfigjson
 kind: pipeline
 name: pr-docs
 node:
@@ -673,6 +685,8 @@ volumes:
 clone:
   retries: 3
 depends_on: []
+image_pull_secrets:
+- dockerconfigjson
 kind: pipeline
 name: pr-shellcheck
 node:
@@ -714,6 +728,8 @@ volumes:
 clone:
   retries: 3
 depends_on: []
+image_pull_secrets:
+- dockerconfigjson
 kind: pipeline
 name: main-docs
 node:
@@ -799,6 +815,8 @@ volumes:
 clone:
   retries: 3
 depends_on: []
+image_pull_secrets:
+- dockerconfigjson
 kind: pipeline
 name: main-test-frontend
 node:
@@ -875,6 +893,8 @@ volumes:
 clone:
   retries: 3
 depends_on: []
+image_pull_secrets:
+- dockerconfigjson
 kind: pipeline
 name: main-test-backend
 node:
@@ -960,6 +980,8 @@ volumes:
 clone:
   retries: 3
 depends_on: []
+image_pull_secrets:
+- dockerconfigjson
 kind: pipeline
 name: main-build-e2e-publish
 node:
@@ -1367,6 +1389,8 @@ volumes:
 clone:
   retries: 3
 depends_on: []
+image_pull_secrets:
+- dockerconfigjson
 kind: pipeline
 name: main-integration-tests
 node:
@@ -1488,6 +1512,8 @@ depends_on:
 - main-test-backend
 - main-build-e2e-publish
 - main-integration-tests
+image_pull_secrets:
+- dockerconfigjson
 kind: pipeline
 name: main-windows
 platform:
@@ -1586,6 +1612,8 @@ depends_on:
 - main-build-e2e-publish
 - main-integration-tests
 - main-windows
+image_pull_secrets:
+- dockerconfigjson
 kind: pipeline
 name: main-publish
 node:
@@ -1651,6 +1679,8 @@ clone:
   retries: 3
 depends_on:
 - main-publish
+image_pull_secrets:
+- dockerconfigjson
 kind: pipeline
 name: main-trigger-downstream
 node:
@@ -1727,6 +1757,8 @@ type: docker
 clone:
   retries: 3
 depends_on: []
+image_pull_secrets:
+- dockerconfigjson
 kind: pipeline
 name: release-oss-build-e2e-publish
 node:
@@ -2033,6 +2065,8 @@ volumes:
 clone:
   retries: 3
 depends_on: []
+image_pull_secrets:
+- dockerconfigjson
 kind: pipeline
 name: release-oss-test
 node:
@@ -2137,6 +2171,8 @@ volumes:
 clone:
   retries: 3
 depends_on: []
+image_pull_secrets:
+- dockerconfigjson
 kind: pipeline
 name: release-oss-integration-tests
 node:
@@ -2250,6 +2286,8 @@ depends_on:
 - release-oss-build-e2e-publish
 - release-oss-test
 - release-oss-integration-tests
+image_pull_secrets:
+- dockerconfigjson
 kind: pipeline
 name: release-oss-windows
 platform:
@@ -3050,6 +3088,8 @@ volumes:
 clone:
   retries: 3
 depends_on: []
+image_pull_secrets:
+- dockerconfigjson
 kind: pipeline
 name: publish-docker-oss-public
 node:
@@ -3136,6 +3176,8 @@ volumes:
 clone:
   retries: 3
 depends_on: []
+image_pull_secrets:
+- dockerconfigjson
 kind: pipeline
 name: publish-docker-enterprise-public
 node:
@@ -3205,6 +3247,8 @@ volumes:
 clone:
   retries: 3
 depends_on: []
+image_pull_secrets:
+- dockerconfigjson
 kind: pipeline
 name: publish-docker-oss-security
 node:
@@ -3292,6 +3336,8 @@ volumes:
 clone:
   retries: 3
 depends_on: []
+image_pull_secrets:
+- dockerconfigjson
 kind: pipeline
 name: publish-docker-enterprise-security
 node:
@@ -3362,6 +3408,8 @@ volumes:
 clone:
   retries: 3
 depends_on: []
+image_pull_secrets:
+- dockerconfigjson
 kind: pipeline
 name: publish-artifacts-security
 node:
@@ -3402,6 +3450,8 @@ volumes:
 clone:
   retries: 3
 depends_on: []
+image_pull_secrets:
+- dockerconfigjson
 kind: pipeline
 name: publish-artifacts-public
 node:
@@ -3442,6 +3492,8 @@ volumes:
 clone:
   retries: 3
 depends_on: []
+image_pull_secrets:
+- dockerconfigjson
 kind: pipeline
 name: publish-npm-packages-public
 node:
@@ -3502,6 +3554,8 @@ depends_on:
 - publish-artifacts-public
 - publish-docker-oss-public
 - publish-docker-enterprise-public
+image_pull_secrets:
+- dockerconfigjson
 kind: pipeline
 name: publish-packages-oss
 node:
@@ -3581,6 +3635,8 @@ depends_on:
 - publish-artifacts-public
 - publish-docker-oss-public
 - publish-docker-enterprise-public
+image_pull_secrets:
+- dockerconfigjson
 kind: pipeline
 name: publish-packages-enterprise
 node:
@@ -3658,6 +3714,8 @@ volumes:
 clone:
   retries: 3
 depends_on: []
+image_pull_secrets:
+- dockerconfigjson
 kind: pipeline
 name: publish-artifacts-page
 node:
@@ -3695,6 +3753,8 @@ volumes:
 clone:
   retries: 3
 depends_on: []
+image_pull_secrets:
+- dockerconfigjson
 kind: pipeline
 name: release-branch-oss-build-e2e-publish
 node:
@@ -3970,6 +4030,8 @@ volumes:
 clone:
   retries: 3
 depends_on: []
+image_pull_secrets:
+- dockerconfigjson
 kind: pipeline
 name: release-branch-oss-test
 node:
@@ -4068,6 +4130,8 @@ volumes:
 clone:
   retries: 3
 depends_on: []
+image_pull_secrets:
+- dockerconfigjson
 kind: pipeline
 name: release-branch-oss-integration-tests
 node:
@@ -4175,6 +4239,8 @@ depends_on:
 - release-branch-oss-build-e2e-publish
 - release-branch-oss-test
 - release-branch-oss-integration-tests
+image_pull_secrets:
+- dockerconfigjson
 kind: pipeline
 name: release-branch-oss-windows
 platform:
@@ -5112,6 +5178,6 @@ kind: secret
 name: packages_secret_access_key
 ---
 kind: signature
-hmac: 3298924f36cbab63be3873f763ead9406f47dc8b98142678d69ea83b4012541c
+hmac: b08cb03f133c943a789bf6abf7f2645536598e4d8a5a86b34b9231db8afc8ff4
 
 ...

--- a/scripts/drone/utils/utils.star
+++ b/scripts/drone/utils/utils.star
@@ -50,6 +50,7 @@ def pipeline(
             },
         }],
         'depends_on': depends_on,
+        'image_pull_secrets': [pull_secret],
     }
     if environment:
         pipeline.update({
@@ -60,7 +61,6 @@ def pipeline(
     pipeline.update(platform_conf)
 
     if edition in ('enterprise', 'enterprise2'):
-        pipeline['image_pull_secrets'] = [pull_secret]
         # We have a custom clone step for enterprise
         pipeline['clone'] = {
             'disable': True,


### PR DESCRIPTION
Having it doesn't prevent pulling any images, so it's easier if it's everywhere. This should fix the failures that the new linux package publishing step is throwing
