### PR TITLE
CI: Introduce `lint-frontend` pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -91,17 +91,6 @@ steps:
   image: golang:1.19.1
   name: compile-build-cmd
 - commands:
-  - yarn run prettier:check
-  - yarn run lint
-  - yarn run i18n:compile
-  - yarn run typecheck
-  depends_on:
-  - yarn-install
-  environment:
-    TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.6.2
-  name: lint-frontend
-- commands:
   - yarn betterer ci
   depends_on:
   - yarn-install
@@ -116,6 +105,58 @@ steps:
     TEST_MAX_WORKERS: 50%
   image: grafana/build-container:1.6.2
   name: test-frontend
+trigger:
+  event:
+  - pull_request
+  paths:
+    exclude:
+    - docs/**
+    - '*.md'
+    - pkg/**
+    - packaging/**
+    - go.sum
+    - go.mod
+    include: []
+type: docker
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
+---
+clone:
+  retries: 3
+depends_on: []
+image_pull_secrets:
+- dockerconfigjson
+kind: pipeline
+name: pr-lint-frontend
+node:
+  type: no-parallel
+platform:
+  arch: amd64
+  os: linux
+services: []
+steps:
+- commands:
+  - echo $DRONE_RUNNER_NAME
+  image: alpine:3.15.6
+  name: identify-runner
+- commands:
+  - yarn install --immutable
+  depends_on: []
+  image: grafana/build-container:1.6.2
+  name: yarn-install
+- commands:
+  - yarn run prettier:check
+  - yarn run lint
+  - yarn run i18n:compile
+  - yarn run typecheck
+  depends_on:
+  - yarn-install
+  environment:
+    TEST_MAX_WORKERS: 50%
+  image: grafana/build-container:1.6.2
+  name: lint-frontend
 trigger:
   event:
   - pull_request
@@ -896,17 +937,6 @@ steps:
   image: golang:1.19.1
   name: compile-build-cmd
 - commands:
-  - yarn run prettier:check
-  - yarn run lint
-  - yarn run i18n:compile
-  - yarn run typecheck
-  depends_on:
-  - yarn-install
-  environment:
-    TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.6.2
-  name: lint-frontend
-- commands:
   - yarn betterer ci
   depends_on:
   - yarn-install
@@ -921,6 +951,55 @@ steps:
     TEST_MAX_WORKERS: 50%
   image: grafana/build-container:1.6.2
   name: test-frontend
+trigger:
+  branch: main
+  event:
+  - push
+  paths:
+    exclude:
+    - '*.md'
+    - docs/**
+    - latest.json
+type: docker
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
+---
+clone:
+  retries: 3
+depends_on: []
+image_pull_secrets:
+- dockerconfigjson
+kind: pipeline
+name: main-lint-frontend
+node:
+  type: no-parallel
+platform:
+  arch: amd64
+  os: linux
+services: []
+steps:
+- commands:
+  - echo $DRONE_RUNNER_NAME
+  image: alpine:3.15.6
+  name: identify-runner
+- commands:
+  - yarn install --immutable
+  depends_on: []
+  image: grafana/build-container:1.6.2
+  name: yarn-install
+- commands:
+  - yarn run prettier:check
+  - yarn run lint
+  - yarn run i18n:compile
+  - yarn run typecheck
+  depends_on:
+  - yarn-install
+  environment:
+    TEST_MAX_WORKERS: 50%
+  image: grafana/build-container:1.6.2
+  name: lint-frontend
 trigger:
   branch: main
   event:
@@ -5270,6 +5349,6 @@ kind: secret
 name: packages_secret_access_key
 ---
 kind: signature
-hmac: a17adc518f8ba4ea5c123bf440adf9aceec5e7ba5d9fdae9e467dbd1ec91fd46
+hmac: 51941c93ec6753cf788db7ecefc8ffc63549ec675b23ae98fc27bcd7a22cddbb
 
 ...

--- a/scripts/drone/events/main.star
+++ b/scripts/drone/events/main.star
@@ -52,6 +52,11 @@ load(
     'lint_backend_pipeline',
 )
 
+load(
+    'scripts/drone/pipelines/lint_frontend.star',
+    'lint_frontend_pipeline',
+)
+
 load('scripts/drone/vault.star', 'from_secret')
 
 
@@ -88,6 +93,7 @@ def main_pipelines(edition):
     pipelines = [
         docs_pipelines(edition, ver_mode, trigger_docs_main()),
         test_frontend(trigger, ver_mode),
+        lint_frontend_pipeline(trigger, ver_mode),
         test_backend(trigger, ver_mode),
         lint_backend_pipeline(trigger, ver_mode),
         build_e2e(trigger, ver_mode, edition),

--- a/scripts/drone/events/pr.star
+++ b/scripts/drone/events/pr.star
@@ -44,6 +44,11 @@ load(
     'lint_backend_pipeline',
 )
 
+load(
+    'scripts/drone/pipelines/lint_frontend.star',
+    'lint_frontend_pipeline',
+)
+
 ver_mode = 'pr'
 trigger = {
     'event': [
@@ -63,6 +68,7 @@ def pr_pipelines(edition):
     return [
         verify_drone(get_pr_trigger(include_paths=['scripts/drone/**', '.drone.yml', '.drone.star']), ver_mode),
         test_frontend(get_pr_trigger(exclude_paths=['pkg/**', 'packaging/**', 'go.sum', 'go.mod']), ver_mode),
+        lint_frontend_pipeline(get_pr_trigger(exclude_paths=['pkg/**', 'packaging/**', 'go.sum', 'go.mod']), ver_mode),
         test_backend(get_pr_trigger(include_paths=['pkg/**', 'packaging/**', '.drone.yml', 'conf/**', 'go.sum', 'go.mod', 'public/app/plugins/**/plugin.json', 'devenv/**']), ver_mode),
         lint_backend_pipeline(get_pr_trigger(include_paths=['pkg/**', 'packaging/**', 'conf/**', 'go.sum', 'go.mod', 'public/app/plugins/**/plugin.json', 'devenv/**']), ver_mode),
         build_e2e(trigger, ver_mode, edition),

--- a/scripts/drone/pipelines/lint_frontend.star
+++ b/scripts/drone/pipelines/lint_frontend.star
@@ -1,0 +1,25 @@
+load(
+    'scripts/drone/steps/lib.star',
+    'identify_runner_step',
+    'yarn_install_step',
+    'lint_frontend_step',
+)
+
+load(
+    'scripts/drone/utils/utils.star',
+    'pipeline',
+)
+
+def lint_frontend_pipeline(trigger, ver_mode):
+    yarn_step = yarn_install_step()
+    yarn_step.update({ 'depends_on': [] })
+    init_steps = [
+        identify_runner_step(),
+        yarn_step,
+    ]
+    test_steps = [
+        lint_frontend_step(),
+    ]
+    return pipeline(
+        name='{}-lint-frontend'.format(ver_mode), edition="oss", trigger=trigger, services=[], steps=init_steps + test_steps,
+    )

--- a/scripts/drone/pipelines/test_frontend.star
+++ b/scripts/drone/pipelines/test_frontend.star
@@ -3,7 +3,6 @@ load(
     'identify_runner_step',
     'download_grabpl_step',
     'yarn_install_step',
-    'lint_frontend_step',
     'betterer_frontend_step',
     'test_frontend_step',
     'compile_build_cmd',
@@ -22,7 +21,6 @@ def test_frontend(trigger, ver_mode):
         compile_build_cmd(),
     ]
     test_steps = [
-        lint_frontend_step(),
         betterer_frontend_step(),
         test_frontend_step(),
     ]


### PR DESCRIPTION
**What this PR does / why we need it**:

Extracts lint steps from `test-frontend` pipeline and puts them into a new pipeline which will get triggered when `test-frontend` is triggered.