### PR TITLE
QueryField: Fix wrong cursor position on autocomplete

### DIFF
--- a/packages/grafana-ui/src/slate-plugins/suggestions.tsx
+++ b/packages/grafana-ui/src/slate-plugins/suggestions.tsx
@@ -143,6 +143,8 @@ export function SuggestionsPlugin({
 
         const preserveSuffix = suggestion.kind === 'function';
         const move = suggestion.move || 0;
+        const moveForward = move > 0 ? move : 0;
+        const moveBackward = move < 0 ? -move : 0;
 
         const { typeaheadPrefix, typeaheadText, typeaheadContext } = state;
 
@@ -180,7 +182,8 @@ export function SuggestionsPlugin({
           .deleteBackward(backward)
           .deleteForward(forward)
           .insertText(suggestionText)
-          .moveForward(move)
+          .moveForward(moveForward)
+          .moveBackward(moveBackward)
           .focus();
 
         return editor;


### PR DESCRIPTION
**What this PR does / why we need it**:
A user who selects an auto-complete suggestion in the Loki code query editor for filters will have their cursor placed outside the quotation marks instead of inside.

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/support-escalations/issues/3935

**Special notes for your reviewer**:

Steps to replicate the issue:
1. On https://play.grafana.com/ use the Loki data source on Explore (https://play.grafana.org/goto/JMl5GknVz?orgId=1)
2. Use the code query editor
3. Begin typing any query, e.g. {host="appfelstrudel"}
4. Add a pipe + any filter, e.g. {host="appfelstrudel"} | regexp ""
5. IMPORTANT: to replicate the behavior, when typing out regexp, click the auto-complete suggestion
6. After using the auto-complete suggestion, you'll notice your cursor is automatically placed outside the "" instead of inside, which would be expected

With the fix:

https://user-images.githubusercontent.com/8092184/191526360-ccb91f53-5f0f-43f9-9c73-4db9be7fe805.mov


