### PR TITLE
Docs: Note issue #13399 in database install docs

### DIFF
--- a/docs/sources/setup-grafana/installation/_index.md
+++ b/docs/sources/setup-grafana/installation/_index.md
@@ -59,7 +59,7 @@ Grafana will support the versions of these databases that are officially support
 
 > **Note:** PostgreSQL versions 10.9, 11.4, and 12-beta2 are affected by a bug (tracked by the PostgreSQL project as [bug #15865](https://www.postgresql.org/message-id/flat/15865-17940eacc8f8b081%40postgresql.org)) which prevents those versions from being used with Grafana. The bug has been fixed in more recent versions of PostgreSQL.
 >
-> Grafana can report errors when relying on read-only MySQL servers, such as in high-availability failover scenarios or serverless products like AWS Aurora MySQL. This is a known issue; for more information, see [issue #13399](https://github.com/grafana/grafana/issues/13399).
+> Grafana can report errors when relying on read-only MySQL servers, such as in high-availability failover scenarios or serverless AWS Aurora MySQL. This is a known issue; for more information, see [issue #13399](https://github.com/grafana/grafana/issues/13399).
 
 ## Supported web browsers
 

--- a/docs/sources/setup-grafana/installation/_index.md
+++ b/docs/sources/setup-grafana/installation/_index.md
@@ -58,6 +58,8 @@ By default, Grafana installs with and uses SQLite, which is an embedded database
 Grafana will support the versions of these databases that are officially supported by the project at the time of a Grafana version's release. When a version becomes unsupported, Grafana may also drop support for that version. See the links above for the support policies for each project.
 
 > **Note:** PostgreSQL versions 10.9, 11.4, and 12-beta2 are affected by a bug (tracked by the PostgreSQL project as [bug #15865](https://www.postgresql.org/message-id/flat/15865-17940eacc8f8b081%40postgresql.org)) which prevents those versions from being used with Grafana. The bug has been fixed in more recent versions of PostgreSQL.
+>
+> Grafana can report errors when relying on read-only MySQL servers, such as in high-availability failover scenarios or serverless products like AWS Aurora MySQL. This is a known issue; for more information, see [issue #13399](https://github.com/grafana/grafana/issues/13399).
 
 ## Supported web browsers
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Known issue #13399 can cause Grafana to emit errors when a read-only MySQL database is used as a backend, such as in a high-availability failover scenario (#13399) or using a product that deploys read-only servers such as [severless AWS Aurora MySQL](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless-v2.html). Note this known issue to help prevent users from proceeding with potentially incompatible database backends.

**Which issue(s) this PR fixes**:

None.

**Special notes for your reviewer**:

Per discussion with @shawnmadden, @rondutt, @techgnosis 