### PR TITLE
Plugins: Display "renderer" and "secretsmanager" plugin types under plugin catalog "Application" filter

### DIFF
--- a/public/app/features/plugins/admin/pages/Browse.test.tsx
+++ b/public/app/features/plugins/admin/pages/Browse.test.tsx
@@ -145,6 +145,7 @@ describe('Browse list of plugins', () => {
         getCatalogPluginMock({ id: 'plugin-1', name: 'Plugin 1', type: PluginType.app }),
         getCatalogPluginMock({ id: 'plugin-2', name: 'Plugin 2', type: PluginType.datasource }),
         getCatalogPluginMock({ id: 'plugin-3', name: 'Plugin 3', type: PluginType.panel }),
+        getCatalogPluginMock({ id: 'plugin-4', name: 'Plugin 4', type: PluginType.secretsmanager }),
       ]);
 
       await waitFor(() => expect(queryByText('Plugin 2')).toBeInTheDocument());
@@ -152,6 +153,7 @@ describe('Browse list of plugins', () => {
       // Other plugin types shouldn't be shown
       expect(queryByText('Plugin 1')).not.toBeInTheDocument();
       expect(queryByText('Plugin 3')).not.toBeInTheDocument();
+      expect(queryByText('Plugin 4')).not.toBeInTheDocument();
     });
 
     it('should list only panel plugins when filtering by panel', async () => {
@@ -159,6 +161,7 @@ describe('Browse list of plugins', () => {
         getCatalogPluginMock({ id: 'plugin-1', name: 'Plugin 1', type: PluginType.app }),
         getCatalogPluginMock({ id: 'plugin-2', name: 'Plugin 2', type: PluginType.datasource }),
         getCatalogPluginMock({ id: 'plugin-3', name: 'Plugin 3', type: PluginType.panel }),
+        getCatalogPluginMock({ id: 'plugin-4', name: 'Plugin 4', type: PluginType.secretsmanager }),
       ]);
 
       await waitFor(() => expect(queryByText('Plugin 3')).toBeInTheDocument());
@@ -166,6 +169,7 @@ describe('Browse list of plugins', () => {
       // Other plugin types shouldn't be shown
       expect(queryByText('Plugin 1')).not.toBeInTheDocument();
       expect(queryByText('Plugin 2')).not.toBeInTheDocument();
+      expect(queryByText('Plugin 4')).not.toBeInTheDocument();
     });
 
     it('should list only app plugins when filtering by app', async () => {
@@ -180,6 +184,16 @@ describe('Browse list of plugins', () => {
       // Other plugin types shouldn't be shown
       expect(queryByText('Plugin 2')).not.toBeInTheDocument();
       expect(queryByText('Plugin 3')).not.toBeInTheDocument();
+    });
+
+    it('should also list secretsmanager and renderer plugins when filtering by app', async () => {
+      const { queryByText } = renderBrowse('/plugins?filterBy=all&filterByType=app', [
+        getCatalogPluginMock({ id: 'plugin-1', name: 'Plugin 1', type: PluginType.secretsmanager }),
+        getCatalogPluginMock({ id: 'plugin-2', name: 'Plugin 2', type: PluginType.renderer }),
+      ]);
+
+      await waitFor(() => expect(queryByText('Plugin 1')).toBeInTheDocument());
+      await waitFor(() => expect(queryByText('Plugin 2')).toBeInTheDocument());
     });
   });
 

--- a/public/app/features/plugins/admin/pages/Browse.test.tsx
+++ b/public/app/features/plugins/admin/pages/Browse.test.tsx
@@ -146,6 +146,7 @@ describe('Browse list of plugins', () => {
         getCatalogPluginMock({ id: 'plugin-2', name: 'Plugin 2', type: PluginType.datasource }),
         getCatalogPluginMock({ id: 'plugin-3', name: 'Plugin 3', type: PluginType.panel }),
         getCatalogPluginMock({ id: 'plugin-4', name: 'Plugin 4', type: PluginType.secretsmanager }),
+        getCatalogPluginMock({ id: 'plugin-5', name: 'Plugin 5', type: PluginType.renderer }),
       ]);
 
       await waitFor(() => expect(queryByText('Plugin 2')).toBeInTheDocument());
@@ -154,6 +155,7 @@ describe('Browse list of plugins', () => {
       expect(queryByText('Plugin 1')).not.toBeInTheDocument();
       expect(queryByText('Plugin 3')).not.toBeInTheDocument();
       expect(queryByText('Plugin 4')).not.toBeInTheDocument();
+      expect(queryByText('Plugin 5')).not.toBeInTheDocument();
     });
 
     it('should list only panel plugins when filtering by panel', async () => {
@@ -162,6 +164,7 @@ describe('Browse list of plugins', () => {
         getCatalogPluginMock({ id: 'plugin-2', name: 'Plugin 2', type: PluginType.datasource }),
         getCatalogPluginMock({ id: 'plugin-3', name: 'Plugin 3', type: PluginType.panel }),
         getCatalogPluginMock({ id: 'plugin-4', name: 'Plugin 4', type: PluginType.secretsmanager }),
+        getCatalogPluginMock({ id: 'plugin-5', name: 'Plugin 5', type: PluginType.renderer }),
       ]);
 
       await waitFor(() => expect(queryByText('Plugin 3')).toBeInTheDocument());
@@ -170,6 +173,7 @@ describe('Browse list of plugins', () => {
       expect(queryByText('Plugin 1')).not.toBeInTheDocument();
       expect(queryByText('Plugin 2')).not.toBeInTheDocument();
       expect(queryByText('Plugin 4')).not.toBeInTheDocument();
+      expect(queryByText('Plugin 5')).not.toBeInTheDocument();
     });
 
     it('should list only app plugins when filtering by app', async () => {

--- a/public/app/features/plugins/admin/pages/Browse.tsx
+++ b/public/app/features/plugins/admin/pages/Browse.tsx
@@ -16,7 +16,7 @@ import { SearchField } from '../components/SearchField';
 import { Sorters } from '../helpers';
 import { useHistory } from '../hooks/useHistory';
 import { useGetAllWithFilters, useIsRemotePluginsAvailable, useDisplayMode } from '../state/hooks';
-import { PluginListDisplayMode } from '../types';
+import { PluginListDisplayMode, PluginTypeFilterOption } from '../types';
 
 export default function Browse({ route }: GrafanaRouteComponentProps): ReactElement | null {
   const location = useLocation();
@@ -28,7 +28,7 @@ export default function Browse({ route }: GrafanaRouteComponentProps): ReactElem
   const remotePluginsAvailable = useIsRemotePluginsAvailable();
   const query = (locationSearch.q as string) || '';
   const filterBy = (locationSearch.filterBy as string) || 'installed';
-  const filterByType = (locationSearch.filterByType as string) || 'all';
+  const filterByType: PluginTypeFilterOption = (locationSearch.filterByType as PluginTypeFilterOption) || 'all';
   const sortBy = (locationSearch.sortBy as Sorters) || Sorters.nameAsc;
   const { isLoading, error, plugins } = useGetAllWithFilters({
     query,
@@ -49,7 +49,7 @@ export default function Browse({ route }: GrafanaRouteComponentProps): ReactElem
     history.push({ query: { filterBy: value } });
   };
 
-  const onFilterByTypeChange = (value: string) => {
+  const onFilterByTypeChange = (value: PluginTypeFilterOption) => {
     history.push({ query: { filterByType: value } });
   };
 
@@ -71,7 +71,7 @@ export default function Browse({ route }: GrafanaRouteComponentProps): ReactElem
           <HorizontalGroup wrap className={styles.actionBar}>
             {/* Filter by type */}
             <div>
-              <RadioButtonGroup
+              <RadioButtonGroup<PluginTypeFilterOption>
                 value={filterByType}
                 onChange={onFilterByTypeChange}
                 options={[

--- a/public/app/features/plugins/admin/state/hooks.ts
+++ b/public/app/features/plugins/admin/state/hooks.ts
@@ -4,7 +4,7 @@ import { PluginError } from '@grafana/data';
 import { useDispatch, useSelector } from 'app/types';
 
 import { sortPlugins, Sorters } from '../helpers';
-import { CatalogPlugin, PluginListDisplayMode } from '../types';
+import { CatalogPlugin, PluginListDisplayMode, PluginTypeFilterOption } from '../types';
 
 import { fetchAll, fetchDetails, fetchRemotePlugins, install, uninstall } from './actions';
 import { setDisplayMode } from './reducer';
@@ -22,7 +22,7 @@ import {
 type Filters = {
   query?: string; // Note: this will be an escaped regex string as it comes from `FilterInput`
   filterBy?: string;
-  filterByType?: string;
+  filterByType?: PluginTypeFilterOption;
   sortBy?: Sorters;
 };
 

--- a/public/app/features/plugins/admin/state/selectors.ts
+++ b/public/app/features/plugins/admin/state/selectors.ts
@@ -1,6 +1,6 @@
 import { createSelector } from '@reduxjs/toolkit';
 
-import { PluginError, PluginErrorCode, unEscapeStringFromRegex } from '@grafana/data';
+import { PluginError, PluginErrorCode, PluginType, unEscapeStringFromRegex } from '@grafana/data';
 
 import { RequestStatus, PluginCatalogStoreState, PluginTypeFilterOption } from '../types';
 
@@ -21,8 +21,17 @@ const selectInstalled = (filterBy: string) =>
 
 const findByInstallAndType = (filterBy: string, filterByType: PluginTypeFilterOption) =>
   createSelector(selectInstalled(filterBy), (plugins) =>
-    plugins.filter((plugin) => filterByType === 'all' || plugin.type === filterByType)
+    plugins.filter(
+      (plugin) =>
+        filterByType === 'all' ||
+        plugin.type === filterByType ||
+        (filterByType === 'app' && isAppPluginType(plugin.type))
+    )
   );
+
+const isAppPluginType = (type: PluginType | undefined) => {
+  return type === PluginType.renderer || type === PluginType.secretsmanager;
+};
 
 const findByKeyword = (searchBy: string) =>
   createSelector(selectAll, (plugins) => {

--- a/public/app/features/plugins/admin/state/selectors.ts
+++ b/public/app/features/plugins/admin/state/selectors.ts
@@ -30,7 +30,7 @@ const findByInstallAndType = (filterBy: string, filterByType: PluginTypeFilterOp
   );
 
 const isAppPluginType = (type: PluginType | undefined) => {
-  return type === PluginType.renderer || type === PluginType.secretsmanager;
+  return type === PluginType.renderer || type === PluginType.secretsmanager || type === PluginType.app;
 };
 
 const findByKeyword = (searchBy: string) =>

--- a/public/app/features/plugins/admin/state/selectors.ts
+++ b/public/app/features/plugins/admin/state/selectors.ts
@@ -2,7 +2,7 @@ import { createSelector } from '@reduxjs/toolkit';
 
 import { PluginError, PluginErrorCode, unEscapeStringFromRegex } from '@grafana/data';
 
-import { RequestStatus, PluginCatalogStoreState } from '../types';
+import { RequestStatus, PluginCatalogStoreState, PluginTypeFilterOption } from '../types';
 
 import { pluginsAdapter } from './reducer';
 
@@ -19,7 +19,7 @@ const selectInstalled = (filterBy: string) =>
     plugins.filter((plugin) => (filterBy === 'installed' ? plugin.isInstalled : !plugin.isCore))
   );
 
-const findByInstallAndType = (filterBy: string, filterByType: string) =>
+const findByInstallAndType = (filterBy: string, filterByType: PluginTypeFilterOption) =>
   createSelector(selectInstalled(filterBy), (plugins) =>
     plugins.filter((plugin) => filterByType === 'all' || plugin.type === filterByType)
   );
@@ -44,7 +44,7 @@ const findByKeyword = (searchBy: string) =>
     });
   });
 
-export const find = (searchBy: string, filterBy: string, filterByType: string) =>
+export const find = (searchBy: string, filterBy: string, filterByType: PluginTypeFilterOption) =>
   createSelector(
     findByInstallAndType(filterBy, filterByType),
     findByKeyword(searchBy),

--- a/public/app/features/plugins/admin/types.ts
+++ b/public/app/features/plugins/admin/types.ts
@@ -12,6 +12,7 @@ import { IconName } from '@grafana/ui';
 import { StoreState, PluginsState } from 'app/types';
 
 export type PluginTypeCode = 'app' | 'panel' | 'datasource';
+export type PluginTypeFilterOption = PluginTypeCode | 'all';
 
 export enum PluginListDisplayMode {
   Grid = 'grid',


### PR DESCRIPTION
**What this PR does / why we need it**:
Augments the "Application" filter in the plugin catalog UI to show both Renderer and SecretsManager plugins, which currently only show up under the "All" filter.

<img width="1034" alt="image" src="https://user-images.githubusercontent.com/41969079/191615023-9ce9ee80-04a1-4eec-a67c-80e4e43ff586.png">

A side-effect of this change is to add some additional type-safety around plugin filters instead of just using strings.

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/52959

