### PR TITLE
Alerting: Refactor dingding, discord, email notifiers to use encoding/json to parse settings instead of simplejson

### DIFF
--- a/pkg/services/ngalert/notifier/channels/dingding_test.go
+++ b/pkg/services/ngalert/notifier/channels/dingding_test.go
@@ -156,7 +156,12 @@ func TestDingdingNotifier(t *testing.T) {
 			}
 
 			webhookSender := mockNotificationService()
-			cfg, err := NewDingDingConfig(m)
+			fc := FactoryConfig{
+				Config:              m,
+				NotificationService: webhookSender,
+				Template:            tmpl,
+			}
+			pn, err := buildDingDingNotifier(fc)
 			if c.expInitError != "" {
 				require.Equal(t, c.expInitError, err.Error())
 				return
@@ -165,7 +170,6 @@ func TestDingdingNotifier(t *testing.T) {
 
 			ctx := notify.WithGroupKey(context.Background(), "alertname")
 			ctx = notify.WithGroupLabels(ctx, model.LabelSet{"alertname": ""})
-			pn := NewDingDingNotifier(cfg, webhookSender, tmpl)
 			ok, err := pn.Notify(ctx, c.alerts...)
 			if c.expMsgError != nil {
 				require.False(t, ok)

--- a/pkg/services/ngalert/notifier/channels/discord_test.go
+++ b/pkg/services/ngalert/notifier/channels/discord_test.go
@@ -270,17 +270,22 @@ func TestDiscordNotifier(t *testing.T) {
 			}
 
 			webhookSender := mockNotificationService()
-			cfg, err := NewDiscordConfig(m)
+			fc := FactoryConfig{
+				Config:              m,
+				ImageStore:          &UnavailableImageStore{},
+				NotificationService: webhookSender,
+				Template:            tmpl,
+			}
+
+			dn, err := buildDiscordNotifier(fc)
 			if c.expInitError != "" {
 				require.Equal(t, c.expInitError, err.Error())
 				return
 			}
 			require.NoError(t, err)
-			imageStore := &UnavailableImageStore{}
 
 			ctx := notify.WithGroupKey(context.Background(), "alertname")
 			ctx = notify.WithGroupLabels(ctx, model.LabelSet{"alertname": ""})
-			dn := NewDiscordNotifier(cfg, webhookSender, imageStore, tmpl)
 			ok, err := dn.Notify(ctx, c.alerts...)
 			if c.expMsgError != nil {
 				require.False(t, ok)


### PR DESCRIPTION
**What this PR does / why we need it**:

Instead of using `simplejson` to loosely parse notifier settings which is [bug-prone](https://github.com/grafana/grafana/issues/55139), this PR instead makes notifiers declare a well-defined struct for their settings.

This has some benefits:
- Improves validation for all settings fields and eliminates bugs (see attached issue)
- The total set of fields for each notifier is now clear and obvious. Settings are easier to reason about.
- Simplifies notifier construction logic by removing a layer of indirection
- Eliminates repetition/mapping of settings fields, which was a vector for bugs
- Makes our notifiers more in-line with [Prometheus's notifiers](https://github.com/prometheus/alertmanager/blob/3d624c0552e173aa57bbdad52a55788e38744252/notify/slack/slack.go). They also use settings structs.

**Which issue(s) this PR fixes**:

Contributes to https://github.com/grafana/grafana/issues/55139
