### PR TITLE
Alerting: Add frames for all queries and expressions

### DIFF
--- a/pkg/services/ngalert/eval/eval.go
+++ b/pkg/services/ngalert/eval/eval.go
@@ -73,8 +73,8 @@ func (e *invalidEvalResultFormatError) Unwrap() error {
 // ExecutionResults contains the unevaluated results from executing
 // a condition.
 type ExecutionResults struct {
-	// Cond contains the results of the condition
-	Cond data.Frames
+	// Condition contains the results of the condition
+	Condition data.Frames
 
 	// Results contains the results of all queries, reduce and math expressions
 	Results map[string]data.Frames
@@ -275,13 +275,13 @@ func queryDataResponseToExecutionResults(c models.Condition, execResp *backend.Q
 		}
 
 		if refID == c.Condition {
-			result.Cond = res.Frames
+			result.Condition = res.Frames
 		}
 		result.Results[refID] = res.Frames
 	}
 
 	// add capture values as data frame metadata to each result (frame) that has matching labels.
-	for _, frame := range result.Cond {
+	for _, frame := range result.Condition {
 		// classic conditions already have metadata set and only have one value, there's no need to add anything in this case.
 		if frame.Meta != nil && frame.Meta.Custom != nil {
 			if _, ok := frame.Meta.Custom.([]classic.EvalMatch); ok {
@@ -428,12 +428,12 @@ func evaluateExecutionResult(execResults ExecutionResults, ts time.Time) Results
 		return evalResults
 	}
 
-	if len(execResults.Cond) == 0 {
+	if len(execResults.Condition) == 0 {
 		appendNoData(nil)
 		return evalResults
 	}
 
-	for _, f := range execResults.Cond {
+	for _, f := range execResults.Condition {
 		rowLen, err := f.RowLen()
 		if err != nil {
 			appendErrRes(&invalidEvalResultFormatError{refID: f.RefID, reason: "unable to get frame row length", err: err})

--- a/pkg/services/ngalert/eval/eval_test.go
+++ b/pkg/services/ngalert/eval/eval_test.go
@@ -20,7 +20,7 @@ func TestEvaluateExecutionResult(t *testing.T) {
 		{
 			desc: "zero valued single instance is single Normal state result",
 			execResults: ExecutionResults{
-				Cond: []*data.Frame{
+				Condition: []*data.Frame{
 					data.NewFrame("", data.NewField("", nil, []*float64{ptr.Float64(0)})),
 				},
 			},
@@ -34,7 +34,7 @@ func TestEvaluateExecutionResult(t *testing.T) {
 		{
 			desc: "non-zero valued single instance is single Alerting state result",
 			execResults: ExecutionResults{
-				Cond: []*data.Frame{
+				Condition: []*data.Frame{
 					data.NewFrame("", data.NewField("", nil, []*float64{ptr.Float64(1)})),
 				},
 			},
@@ -48,7 +48,7 @@ func TestEvaluateExecutionResult(t *testing.T) {
 		{
 			desc: "nil value single instance is single a NoData state result",
 			execResults: ExecutionResults{
-				Cond: []*data.Frame{
+				Condition: []*data.Frame{
 					data.NewFrame("", data.NewField("", nil, []*float64{nil})),
 				},
 			},
@@ -85,7 +85,7 @@ func TestEvaluateExecutionResult(t *testing.T) {
 		{
 			desc: "frame with no fields produces a NoData state result",
 			execResults: ExecutionResults{
-				Cond: []*data.Frame{
+				Condition: []*data.Frame{
 					data.NewFrame(""),
 				},
 			},
@@ -99,7 +99,7 @@ func TestEvaluateExecutionResult(t *testing.T) {
 		{
 			desc: "empty field produces a NoData state result",
 			execResults: ExecutionResults{
-				Cond: []*data.Frame{
+				Condition: []*data.Frame{
 					data.NewFrame("", data.NewField("", nil, []*float64{})),
 				},
 			},
@@ -113,7 +113,7 @@ func TestEvaluateExecutionResult(t *testing.T) {
 		{
 			desc: "empty field with labels produces a NoData state result with labels",
 			execResults: ExecutionResults{
-				Cond: []*data.Frame{
+				Condition: []*data.Frame{
 					data.NewFrame("", data.NewField("", data.Labels{"a": "b"}, []*float64{})),
 				},
 			},
@@ -128,7 +128,7 @@ func TestEvaluateExecutionResult(t *testing.T) {
 		{
 			desc: "malformed frame (unequal lengths) produces Error state result",
 			execResults: ExecutionResults{
-				Cond: []*data.Frame{
+				Condition: []*data.Frame{
 					data.NewFrame("",
 						data.NewField("", nil, []*float64{ptr.Float64(23)}),
 						data.NewField("", nil, []*float64{}),
@@ -146,7 +146,7 @@ func TestEvaluateExecutionResult(t *testing.T) {
 		{
 			desc: "too many fields produces Error state result",
 			execResults: ExecutionResults{
-				Cond: []*data.Frame{
+				Condition: []*data.Frame{
 					data.NewFrame("",
 						data.NewField("", nil, []*float64{}),
 						data.NewField("", nil, []*float64{}),
@@ -164,7 +164,7 @@ func TestEvaluateExecutionResult(t *testing.T) {
 		{
 			desc: "more than one row produces Error state result",
 			execResults: ExecutionResults{
-				Cond: []*data.Frame{
+				Condition: []*data.Frame{
 					data.NewFrame("",
 						data.NewField("", nil, []*float64{ptr.Float64(2), ptr.Float64(3)}),
 					),
@@ -181,7 +181,7 @@ func TestEvaluateExecutionResult(t *testing.T) {
 		{
 			desc: "time fields (looks like time series) returns error",
 			execResults: ExecutionResults{
-				Cond: []*data.Frame{
+				Condition: []*data.Frame{
 					data.NewFrame("",
 						data.NewField("", nil, []time.Time{}),
 					),
@@ -198,7 +198,7 @@ func TestEvaluateExecutionResult(t *testing.T) {
 		{
 			desc: "non []*float64 field will produce Error state result",
 			execResults: ExecutionResults{
-				Cond: []*data.Frame{
+				Condition: []*data.Frame{
 					data.NewFrame("",
 						data.NewField("", nil, []float64{2}),
 					),
@@ -215,7 +215,7 @@ func TestEvaluateExecutionResult(t *testing.T) {
 		{
 			desc: "duplicate labels produce a single Error state result",
 			execResults: ExecutionResults{
-				Cond: []*data.Frame{
+				Condition: []*data.Frame{
 					data.NewFrame("",
 						data.NewField("", nil, []*float64{ptr.Float64(1)}),
 					),
@@ -235,7 +235,7 @@ func TestEvaluateExecutionResult(t *testing.T) {
 		{
 			desc: "error that produce duplicate empty labels produce a single Error state result",
 			execResults: ExecutionResults{
-				Cond: []*data.Frame{
+				Condition: []*data.Frame{
 					data.NewFrame("",
 						data.NewField("", data.Labels{"a": "b"}, []float64{2}),
 					),
@@ -255,7 +255,7 @@ func TestEvaluateExecutionResult(t *testing.T) {
 		{
 			desc: "certain errors will produce multiple mixed Error and other state results",
 			execResults: ExecutionResults{
-				Cond: []*data.Frame{
+				Condition: []*data.Frame{
 					data.NewFrame("",
 						data.NewField("", nil, []float64{3}),
 					),

--- a/pkg/services/ngalert/eval/eval_test.go
+++ b/pkg/services/ngalert/eval/eval_test.go
@@ -20,7 +20,7 @@ func TestEvaluateExecutionResult(t *testing.T) {
 		{
 			desc: "zero valued single instance is single Normal state result",
 			execResults: ExecutionResults{
-				Results: []*data.Frame{
+				Cond: []*data.Frame{
 					data.NewFrame("", data.NewField("", nil, []*float64{ptr.Float64(0)})),
 				},
 			},
@@ -34,7 +34,7 @@ func TestEvaluateExecutionResult(t *testing.T) {
 		{
 			desc: "non-zero valued single instance is single Alerting state result",
 			execResults: ExecutionResults{
-				Results: []*data.Frame{
+				Cond: []*data.Frame{
 					data.NewFrame("", data.NewField("", nil, []*float64{ptr.Float64(1)})),
 				},
 			},
@@ -48,7 +48,7 @@ func TestEvaluateExecutionResult(t *testing.T) {
 		{
 			desc: "nil value single instance is single a NoData state result",
 			execResults: ExecutionResults{
-				Results: []*data.Frame{
+				Cond: []*data.Frame{
 					data.NewFrame("", data.NewField("", nil, []*float64{nil})),
 				},
 			},
@@ -85,7 +85,7 @@ func TestEvaluateExecutionResult(t *testing.T) {
 		{
 			desc: "frame with no fields produces a NoData state result",
 			execResults: ExecutionResults{
-				Results: []*data.Frame{
+				Cond: []*data.Frame{
 					data.NewFrame(""),
 				},
 			},
@@ -99,7 +99,7 @@ func TestEvaluateExecutionResult(t *testing.T) {
 		{
 			desc: "empty field produces a NoData state result",
 			execResults: ExecutionResults{
-				Results: []*data.Frame{
+				Cond: []*data.Frame{
 					data.NewFrame("", data.NewField("", nil, []*float64{})),
 				},
 			},
@@ -113,7 +113,7 @@ func TestEvaluateExecutionResult(t *testing.T) {
 		{
 			desc: "empty field with labels produces a NoData state result with labels",
 			execResults: ExecutionResults{
-				Results: []*data.Frame{
+				Cond: []*data.Frame{
 					data.NewFrame("", data.NewField("", data.Labels{"a": "b"}, []*float64{})),
 				},
 			},
@@ -128,7 +128,7 @@ func TestEvaluateExecutionResult(t *testing.T) {
 		{
 			desc: "malformed frame (unequal lengths) produces Error state result",
 			execResults: ExecutionResults{
-				Results: []*data.Frame{
+				Cond: []*data.Frame{
 					data.NewFrame("",
 						data.NewField("", nil, []*float64{ptr.Float64(23)}),
 						data.NewField("", nil, []*float64{}),
@@ -146,7 +146,7 @@ func TestEvaluateExecutionResult(t *testing.T) {
 		{
 			desc: "too many fields produces Error state result",
 			execResults: ExecutionResults{
-				Results: []*data.Frame{
+				Cond: []*data.Frame{
 					data.NewFrame("",
 						data.NewField("", nil, []*float64{}),
 						data.NewField("", nil, []*float64{}),
@@ -164,7 +164,7 @@ func TestEvaluateExecutionResult(t *testing.T) {
 		{
 			desc: "more than one row produces Error state result",
 			execResults: ExecutionResults{
-				Results: []*data.Frame{
+				Cond: []*data.Frame{
 					data.NewFrame("",
 						data.NewField("", nil, []*float64{ptr.Float64(2), ptr.Float64(3)}),
 					),
@@ -181,7 +181,7 @@ func TestEvaluateExecutionResult(t *testing.T) {
 		{
 			desc: "time fields (looks like time series) returns error",
 			execResults: ExecutionResults{
-				Results: []*data.Frame{
+				Cond: []*data.Frame{
 					data.NewFrame("",
 						data.NewField("", nil, []time.Time{}),
 					),
@@ -198,7 +198,7 @@ func TestEvaluateExecutionResult(t *testing.T) {
 		{
 			desc: "non []*float64 field will produce Error state result",
 			execResults: ExecutionResults{
-				Results: []*data.Frame{
+				Cond: []*data.Frame{
 					data.NewFrame("",
 						data.NewField("", nil, []float64{2}),
 					),
@@ -215,7 +215,7 @@ func TestEvaluateExecutionResult(t *testing.T) {
 		{
 			desc: "duplicate labels produce a single Error state result",
 			execResults: ExecutionResults{
-				Results: []*data.Frame{
+				Cond: []*data.Frame{
 					data.NewFrame("",
 						data.NewField("", nil, []*float64{ptr.Float64(1)}),
 					),
@@ -235,7 +235,7 @@ func TestEvaluateExecutionResult(t *testing.T) {
 		{
 			desc: "error that produce duplicate empty labels produce a single Error state result",
 			execResults: ExecutionResults{
-				Results: []*data.Frame{
+				Cond: []*data.Frame{
 					data.NewFrame("",
 						data.NewField("", data.Labels{"a": "b"}, []float64{2}),
 					),
@@ -255,7 +255,7 @@ func TestEvaluateExecutionResult(t *testing.T) {
 		{
 			desc: "certain errors will produce multiple mixed Error and other state results",
 			execResults: ExecutionResults{
-				Results: []*data.Frame{
+				Cond: []*data.Frame{
 					data.NewFrame("",
 						data.NewField("", nil, []float64{3}),
 					),


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request is one of two pull requests to make the data frames for all queries and expressions in an alert rule available to the state package for rendering a graph. It renames Result to Cond, and creates an additional field called Results that is a map of Ref ID to data.Frames.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

