### PR TITLE
Alerting: cache general folder in migration based on org id

### DIFF
--- a/pkg/services/sqlstore/migrations/ualert/ualert.go
+++ b/pkg/services/sqlstore/migrations/ualert/ualert.go
@@ -257,6 +257,8 @@ func (m *migration) Exec(sess *xorm.Session, mg *migrator.Migrator) error {
 
 	// cache for folders created for dashboards that have custom permissions
 	folderCache := make(map[string]*dashboard)
+	// cache for the general folders
+	generalFolderCache := make(map[int64]*dashboard)
 
 	// Store of newly created rules to later create routes
 	rulesPerOrg := make(map[int64]map[string]dashAlert)
@@ -333,7 +335,7 @@ func (m *migration) Exec(sess *xorm.Session, mg *migrator.Migrator) error {
 			}
 			folder = &f
 		default:
-			f, ok := folderCache[GENERAL_FOLDER]
+			f, ok := generalFolderCache[dash.OrgId]
 			if !ok {
 				// get or create general folder
 				f, err = folderHelper.getOrCreateGeneralFolder(dash.OrgId)
@@ -343,7 +345,7 @@ func (m *migration) Exec(sess *xorm.Session, mg *migrator.Migrator) error {
 						AlertId: da.Id,
 					}
 				}
-				folderCache[GENERAL_FOLDER] = f
+				generalFolderCache[dash.OrgId] = f
 			}
 			// No need to assign default permissions to general folder
 			// because they are included to the query result if it's a folder with no permissions


### PR DESCRIPTION
Currently, we are caching the first general folder that will be created during migration. When reading the cache, we do not check that the folder has the right org ID. This was fixed by introducing a separate cache for the general folder with the org ID as the key.

I haven't found a good way to write a test for this that wouldn't take too long to implement. If someone has any ideas, feel free to suggest them while reviewing.