### PR TITLE
@grafana/ui: adds a virtualized options for the Select component

### DIFF
--- a/packages/grafana-ui/src/components/Select/Select.story.tsx
+++ b/packages/grafana-ui/src/components/Select/Select.story.tsx
@@ -10,7 +10,7 @@ import { getAvailableIcons } from '../../types';
 import { withCenteredStory, withHorizontallyCenteredStory } from '../../utils/storybook/withCenteredStory';
 
 import mdx from './Select.mdx';
-import { generateOptions } from './mockOptions';
+import { generateOptions, generateThousandsOfOptions } from './mockOptions';
 import { SelectCommonProps } from './types';
 
 const meta: Meta = {
@@ -95,6 +95,24 @@ export const Basic: Story<StoryProps> = (args) => {
     <>
       <Select
         options={generateOptions()}
+        value={value}
+        onChange={(v) => {
+          setValue(v);
+          action('onChange')(v);
+        }}
+        {...args}
+      />
+    </>
+  );
+};
+export const BasicVirtualizedList: Story<StoryProps> = (args) => {
+  const [value, setValue] = useState<SelectableValue<string>>();
+
+  return (
+    <>
+      <Select
+        options={generateThousandsOfOptions()}
+        virtualized
         value={value}
         onChange={(v) => {
           setValue(v);

--- a/packages/grafana-ui/src/components/Select/Select.tsx
+++ b/packages/grafana-ui/src/components/Select/Select.tsx
@@ -4,7 +4,7 @@ import { SelectableValue } from '@grafana/data';
 
 import { SelectBase } from './SelectBase';
 import { SelectContainer, SelectContainerProps } from './SelectContainer';
-import { SelectCommonProps, MultiSelectCommonProps, SelectAsyncProps } from './types';
+import { SelectCommonProps, MultiSelectCommonProps, SelectAsyncProps, VirtualizedSelectProps } from './types';
 
 export function Select<T>(props: SelectCommonProps<T>) {
   return <SelectBase {...props} />;
@@ -22,6 +22,10 @@ export interface AsyncSelectProps<T> extends Omit<SelectCommonProps<T>, 'options
 
 export function AsyncSelect<T>(props: AsyncSelectProps<T>) {
   return <SelectBase {...props} />;
+}
+
+export function VirtualizedSelect<T>(props: VirtualizedSelectProps<T>) {
+  return <SelectBase virtualized {...props} />;
 }
 
 interface AsyncMultiSelectProps<T> extends Omit<MultiSelectCommonProps<T>, 'options'>, SelectAsyncProps<T> {

--- a/packages/grafana-ui/src/components/Select/SelectBase.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectBase.tsx
@@ -22,7 +22,7 @@ import { ValueContainer } from './ValueContainer';
 import { getSelectStyles } from './getSelectStyles';
 import { useCustomSelectStyles } from './resetSelectStyles';
 import { ActionMeta, SelectBaseProps } from './types';
-import { cleanValue, findSelectedValue } from './utils';
+import { cleanValue, findSelectedValue, omitDescriptions } from './utils';
 
 interface ExtraValuesIndicatorProps {
   maxVisibleValues?: number | undefined;
@@ -242,7 +242,7 @@ export function SelectBase<T>({
     onFocus,
     formatOptionLabel,
     openMenuOnFocus,
-    options,
+    options: virtualized ? omitDescriptions(options) : options,
     placeholder,
     prefix,
     renderControl,

--- a/packages/grafana-ui/src/components/Select/SelectBase.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectBase.tsx
@@ -15,7 +15,7 @@ import { IndicatorsContainer } from './IndicatorsContainer';
 import { InputControl } from './InputControl';
 import { MultiValueContainer, MultiValueRemove } from './MultiValue';
 import { SelectContainer } from './SelectContainer';
-import { SelectMenu, SelectMenuOptions } from './SelectMenu';
+import { SelectMenu, SelectMenuOptions, VirtualizedSelectMenu } from './SelectMenu';
 import { SelectOptionGroup } from './SelectOptionGroup';
 import { SingleValue } from './SingleValue';
 import { ValueContainer } from './ValueContainer';
@@ -139,6 +139,7 @@ export function SelectBase<T>({
   showAllSelectedWhenOpen = true,
   tabSelectsValue = true,
   value,
+  virtualized = false,
   width,
   isValidNewOption,
   formatOptionLabel,
@@ -268,12 +269,14 @@ export function SelectBase<T>({
     };
   }
 
+  const SelectMenuComponent = virtualized ? VirtualizedSelectMenu : SelectMenu;
+
   return (
     <>
       <ReactSelectComponent
         ref={reactSelectRef}
         components={{
-          MenuList: SelectMenu,
+          MenuList: SelectMenuComponent,
           Group: SelectOptionGroup,
           ValueContainer,
           IndicatorsContainer(props: any) {

--- a/packages/grafana-ui/src/components/Select/SelectMenu.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectMenu.tsx
@@ -1,5 +1,7 @@
 import { cx } from '@emotion/css';
 import React, { FC, RefCallback } from 'react';
+import { MenuListProps } from 'react-select';
+import { FixedSizeList as List } from 'react-window';
 
 import { SelectableValue, toIconName } from '@grafana/data';
 
@@ -29,6 +31,44 @@ export const SelectMenu: FC<SelectMenuProps> = ({ children, maxHeight, innerRef,
 };
 
 SelectMenu.displayName = 'SelectMenu';
+
+const VIRTUAL_LIST_ITEM_HEIGHT = 32;
+
+// a virtualize version of the SelectMenu, descriptions for SelectableValue options not supported since those are of a variable height
+// and are hidden by an overflow style
+export const VirtualizedSelectMenu: FC<MenuListProps<SelectableValue>> = ({
+  children,
+  maxHeight,
+  options,
+  getValue,
+}) => {
+  const theme = useTheme2();
+  const styles = getSelectStyles(theme);
+  const [value] = getValue();
+
+  const valueIndex = value ? options.findIndex((option: SelectableValue<unknown>) => option.value === value.value) : 0;
+  const initialOffset = valueIndex * VIRTUAL_LIST_ITEM_HEIGHT;
+
+  if (!Array.isArray(children)) {
+    return null;
+  }
+
+  return (
+    <List
+      className={styles.menu}
+      height={maxHeight}
+      width="100%"
+      aria-label="Select options menu"
+      itemCount={children.length}
+      itemSize={VIRTUAL_LIST_ITEM_HEIGHT}
+      initialScrollOffset={initialOffset}
+    >
+      {({ index, style }) => <div style={{ ...style, overflow: 'hidden' }}>{children[index]}</div>}
+    </List>
+  );
+};
+
+VirtualizedSelectMenu.displayName = 'VirtualizedSelectMenu';
 
 interface SelectMenuOptionProps<T> {
   isDisabled: boolean;

--- a/packages/grafana-ui/src/components/Select/mockOptions.tsx
+++ b/packages/grafana-ui/src/components/Select/mockOptions.tsx
@@ -32,3 +32,13 @@ export const generateOptions = (desc = false) => {
     description: desc ? `This is a description of ${name}` : undefined,
   }));
 };
+
+export const generateThousandsOfOptions = () => {
+  const options: Array<SelectableValue<string>> = new Array(10000).fill(null).map((_, index) => ({
+    value: String(index),
+    label: 'Option ' + index,
+    description: 'This is option number ' + index,
+  }));
+
+  return options;
+};

--- a/packages/grafana-ui/src/components/Select/types.ts
+++ b/packages/grafana-ui/src/components/Select/types.ts
@@ -107,10 +107,7 @@ export interface SelectAsyncProps<T> {
 
 /** The VirtualizedSelect component uses a slightly different SelectableValue, description and other props are not supported */
 export interface VirtualizedSelectProps<T> extends Omit<SelectCommonProps<T>, 'virtualized'> {
-  options?: Array<{
-    value: T;
-    label: string;
-  }>;
+  options?: Array<Pick<SelectableValue<T>, 'label' | 'value'>>;
 }
 
 export interface MultiSelectCommonProps<T> extends Omit<SelectCommonProps<T>, 'onChange' | 'isMulti' | 'value'> {

--- a/packages/grafana-ui/src/components/Select/types.ts
+++ b/packages/grafana-ui/src/components/Select/types.ts
@@ -105,6 +105,14 @@ export interface SelectAsyncProps<T> {
   loadingMessage?: string;
 }
 
+/** The VirtualizedSelect component uses a slightly different SelectableValue, description and other props are not supported */
+export interface VirtualizedSelectProps<T> extends Omit<SelectCommonProps<T>, 'virtualized'> {
+  options?: Array<{
+    value: T;
+    label: string;
+  }>;
+}
+
 export interface MultiSelectCommonProps<T> extends Omit<SelectCommonProps<T>, 'onChange' | 'isMulti' | 'value'> {
   value?: Array<SelectableValue<T>> | T[];
   onChange: (item: Array<SelectableValue<T>>) => {} | void;

--- a/packages/grafana-ui/src/components/Select/types.ts
+++ b/packages/grafana-ui/src/components/Select/types.ts
@@ -77,6 +77,8 @@ export interface SelectCommonProps<T> {
   renderControl?: ControlComponent<T>;
   tabSelectsValue?: boolean;
   value?: T | SelectValue<T> | null;
+  /** Will wrap the MenuList in a react-window FixedSizeVirtualList for improved performance, does not support options with "description" properties */
+  virtualized?: boolean;
   /** Sets the width to a multiple of 8px. Should only be used with inline forms. Setting width of the container is preferred in other cases.*/
   width?: number | 'auto';
   isOptionDisabled?: () => boolean;

--- a/packages/grafana-ui/src/components/Select/utils.ts
+++ b/packages/grafana-ui/src/components/Select/utils.ts
@@ -43,3 +43,10 @@ export const findSelectedValue = (
 
   return null;
 };
+
+/**
+ * Omit descriptions from an array of options
+ */
+export const omitDescriptions = (options: SelectableValue[]): SelectableValue[] => {
+  return options.map(({ description, ...rest }) => rest);
+};


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR introduces the option to use a virtualized list for the `<Select />` component. I've opted to make it optional instead of the default because there are a couple of things that aren't supported with the virtual list, most notably:

* The `maxHeight` property isn't supported properly and effectively sets the height of the drop-down menu to a fixed height.

* The `description` property for a `SelectableValue` isn't supported since those are variable height depending on how wide the `<Select />` component is.

Using the default `<Select />` component with anything near a few thousand options is currently _very_ slow and un-usable.

**Which issue(s) this PR fixes**:

We have some customers and users with a _very_ large number of Alerting groups and we use the default `<Select />` component to allow picking any one of them.

**Special notes for your reviewer**:

More than happy to take another approach to this or help figure out how to solve the aforementioned unsupported features so we can make this the default for all instances of the `<Select />` component.

