### PR TITLE
Public Dashboards: Add Grafana logo to public dashboards

### DIFF
--- a/public/app/features/dashboard/components/PubdashFooter/PubdashFooter.tsx
+++ b/public/app/features/dashboard/components/PubdashFooter/PubdashFooter.tsx
@@ -34,6 +34,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
   `,
   logoImg: css`
     height: 100%;
-    padding: 2px 0 4px 0;
+    padding: ${theme.spacing(0.25, 0, 0.5, 0)};
   `,
 });

--- a/public/app/features/dashboard/components/PubdashFooter/PubdashFooter.tsx
+++ b/public/app/features/dashboard/components/PubdashFooter/PubdashFooter.tsx
@@ -30,7 +30,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     z-index: 100000;
   `,
   logoText: css`
-    margin-right: 5px;
+    margin-right: ${theme.spacing(1)};
   `,
   logoImg: css`
     height: 100%;

--- a/public/app/features/dashboard/components/PubdashFooter/PubdashFooter.tsx
+++ b/public/app/features/dashboard/components/PubdashFooter/PubdashFooter.tsx
@@ -10,7 +10,7 @@ export default function PubdashFooter() {
   return (
     <div className={styles.footer}>
       <span className={styles.logoText}>
-        <a href="https://grafana.com/" target="blank">
+        <a href="https://grafana.com/" target="_blank"  rel="noreferrer noopener">
           powered by Grafana <img className={styles.logoImg} src="public/img/grafana_icon.svg"></img>
         </a>
       </span>

--- a/public/app/features/dashboard/components/PubdashFooter/PubdashFooter.tsx
+++ b/public/app/features/dashboard/components/PubdashFooter/PubdashFooter.tsx
@@ -4,30 +4,30 @@ import React from 'react';
 import { GrafanaTheme2, colorManipulator } from '@grafana/data';
 import { useStyles2 } from '@grafana/ui';
 
-export default function PubdashFooter() {
+export const PubdashFooter = function () {
   const styles = useStyles2(getStyles);
 
   return (
     <div className={styles.footer}>
       <span className={styles.logoText}>
-        <a href="https://grafana.com/" target="_blank"  rel="noreferrer noopener">
+        <a href="https://grafana.com/" target="_blank" rel="noreferrer noopener">
           powered by Grafana <img className={styles.logoImg} src="public/img/grafana_icon.svg"></img>
         </a>
       </span>
     </div>
   );
-}
+};
 
 const getStyles = (theme: GrafanaTheme2) => ({
   footer: css`
     position: absolute;
-    height: 2rem;
+    height: 30px;
     bottom: 0;
     width: 100%;
     background-color: ${colorManipulator.alpha(theme.colors.background.canvas, 0.7)};
     text-align: right;
     font-size: ${theme.typography.body.fontSize};
-    z-index: 100000;
+    z-index: ${theme.zIndex.navbarFixed};
   `,
   logoText: css`
     margin-right: ${theme.spacing(1)};

--- a/public/app/features/dashboard/components/PubdashFooter/PubdashFooter.tsx
+++ b/public/app/features/dashboard/components/PubdashFooter/PubdashFooter.tsx
@@ -26,7 +26,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     width: 100%;
     background-color: ${colorManipulator.alpha(theme.colors.background.canvas, 0.7)};
     text-align: right;
-    font-size: 1rem;
+    font-size: ${theme.typography.body.fontSize};
     z-index: 100000;
   `,
   logoText: css`

--- a/public/app/features/dashboard/components/PubdashFooter/PubdashFooter.tsx
+++ b/public/app/features/dashboard/components/PubdashFooter/PubdashFooter.tsx
@@ -10,7 +10,9 @@ export default function PubdashFooter() {
   return (
     <div className={styles.footer}>
       <span className={styles.logoText}>
-        powered by Grafana <img className={styles.logoImg} src="public/img/grafana_icon.svg"></img>
+        <a href="https://grafana.com/" target="blank">
+          powered by Grafana <img className={styles.logoImg} src="public/img/grafana_icon.svg"></img>
+        </a>
       </span>
     </div>
   );

--- a/public/app/features/dashboard/components/PubdashFooter/PubdashFooter.tsx
+++ b/public/app/features/dashboard/components/PubdashFooter/PubdashFooter.tsx
@@ -21,12 +21,12 @@ export default function PubdashFooter() {
 const getStyles = (theme: GrafanaTheme2) => ({
   footer: css`
     position: absolute;
-    height: 30px;
-    bottom: 0px;
+    height: 2rem;
+    bottom: 0;
     width: 100%;
     background-color: ${colorManipulator.alpha(theme.colors.background.canvas, 0.7)};
     text-align: right;
-    font-size: 1em;
+    font-size: 1rem;
     z-index: 100000;
   `,
   logoText: css`

--- a/public/app/features/dashboard/components/PubdashFooter/PubdashFooter.tsx
+++ b/public/app/features/dashboard/components/PubdashFooter/PubdashFooter.tsx
@@ -1,0 +1,37 @@
+import { css } from '@emotion/css';
+import React from 'react';
+
+import { GrafanaTheme2, colorManipulator } from '@grafana/data';
+import { useStyles2 } from '@grafana/ui';
+
+export default function PubdashFooter() {
+  const styles = useStyles2(getStyles);
+
+  return (
+    <div className={styles.footer}>
+      <span className={styles.logoText}>
+        powered by Grafana <img className={styles.logoImg} src="public/img/grafana_icon.svg"></img>
+      </span>
+    </div>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  footer: css`
+    position: absolute;
+    height: 30px;
+    bottom: 0px;
+    width: 100%;
+    background-color: ${colorManipulator.alpha(theme.colors.background.canvas, 0.7)};
+    text-align: right;
+    font-size: 1em;
+    z-index: 100000;
+  `,
+  logoText: css`
+    margin-right: 5px;
+  `,
+  logoImg: css`
+    height: 100%;
+    padding: 2px 0 4px 0;
+  `,
+});

--- a/public/app/features/dashboard/components/PubdashFooter/index.ts
+++ b/public/app/features/dashboard/components/PubdashFooter/index.ts
@@ -1,2 +1,0 @@
-import PubdashFooter from './PubdashFooter';
-export { PubdashFooter };

--- a/public/app/features/dashboard/components/PubdashFooter/index.ts
+++ b/public/app/features/dashboard/components/PubdashFooter/index.ts
@@ -1,0 +1,2 @@
+import PubdashFooter from './PubdashFooter';
+export { PubdashFooter };

--- a/public/app/features/dashboard/containers/DashboardPage.tsx
+++ b/public/app/features/dashboard/containers/DashboardPage.tsx
@@ -28,7 +28,7 @@ import { DashboardPrompt } from '../components/DashboardPrompt/DashboardPrompt';
 import { DashboardSettings } from '../components/DashboardSettings';
 import { PanelInspector } from '../components/Inspector/PanelInspector';
 import { PanelEditor } from '../components/PanelEditor/PanelEditor';
-import { PubdashFooter } from '../components/PubdashFooter';
+import { PubdashFooter } from '../components/PubdashFooter/PubdashFooter';
 import { SubMenu } from '../components/SubMenu/SubMenu';
 import { DashboardGrid } from '../dashgrid/DashboardGrid';
 import { liveTimer } from '../dashgrid/liveTimer';

--- a/public/app/features/dashboard/containers/DashboardPage.tsx
+++ b/public/app/features/dashboard/containers/DashboardPage.tsx
@@ -402,7 +402,10 @@ export class UnthemedDashboardPage extends PureComponent<Props, State> {
             sectionNav={sectionNav}
           />
         )}
-        {isPublic && <PubdashFooter />}
+        {
+          // TODO: assess if there are other places where we may want a footer, which may reveal a better place to add this
+          isPublic && <PubdashFooter />
+        }
       </>
     );
   }

--- a/public/app/features/dashboard/containers/DashboardPage.tsx
+++ b/public/app/features/dashboard/containers/DashboardPage.tsx
@@ -28,6 +28,7 @@ import { DashboardPrompt } from '../components/DashboardPrompt/DashboardPrompt';
 import { DashboardSettings } from '../components/DashboardSettings';
 import { PanelInspector } from '../components/Inspector/PanelInspector';
 import { PanelEditor } from '../components/PanelEditor/PanelEditor';
+import { PubdashFooter } from '../components/PubdashFooter';
 import { SubMenu } from '../components/SubMenu/SubMenu';
 import { DashboardGrid } from '../dashgrid/DashboardGrid';
 import { liveTimer } from '../dashgrid/liveTimer';
@@ -266,7 +267,7 @@ export class UnthemedDashboardPage extends PureComponent<Props, State> {
         updatedState.panelNotFound = true;
       }
     }
-    // Leaving view mode
+    // Leaving view modex
     else if (state.viewPanel && !urlViewPanelId) {
       // This mutable state feels wrong to have in getDerivedStateFromProps
       // Should move this state out of dashboard in the future
@@ -401,6 +402,7 @@ export class UnthemedDashboardPage extends PureComponent<Props, State> {
             sectionNav={sectionNav}
           />
         )}
+        {isPublic && <PubdashFooter />}
       </>
     );
   }

--- a/public/app/features/dashboard/containers/DashboardPage.tsx
+++ b/public/app/features/dashboard/containers/DashboardPage.tsx
@@ -267,7 +267,7 @@ export class UnthemedDashboardPage extends PureComponent<Props, State> {
         updatedState.panelNotFound = true;
       }
     }
-    // Leaving view modex
+    // Leaving view mode
     else if (state.viewPanel && !urlViewPanelId) {
       // This mutable state feels wrong to have in getDerivedStateFromProps
       // Should move this state out of dashboard in the future


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a Grafana logo to the footer of public dashboards:

<img width="1455" alt="image" src="https://user-images.githubusercontent.com/41969079/191832544-514a6ae3-c4b8-4d2d-ba35-ce83a4c1042d.png">

How it looks with overlap:

<img width="1229" alt="image" src="https://user-images.githubusercontent.com/41969079/191832673-0b29c324-fb6d-4c4c-a5ed-c05c590e1328.png">

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana-enterprise/issues/4474

**Special notes for your reviewer**:

Please make sure this looks good with your own dashboards!
