### PR TITLE
Explore: Notify when compact URL is used

### DIFF
--- a/packages/grafana-data/src/types/explore.ts
+++ b/packages/grafana-data/src/types/explore.ts
@@ -11,6 +11,7 @@ export interface ExploreUrlState<T extends DataQuery = AnyQuery> {
   range: RawTimeRange;
   context?: string;
   panelsState?: ExplorePanelsState;
+  isFromCompactUrl?: boolean;
 }
 
 export interface ExplorePanelsState extends Partial<Record<PreferredVisualisationType, {}>> {

--- a/public/app/core/utils/explore.ts
+++ b/public/app/core/utils/explore.ts
@@ -234,7 +234,8 @@ export function parseUrlState(initial: string | undefined): ExploreUrlState {
   }
 
   if (!Array.isArray(parsed)) {
-    return parsed;
+    const urlState = { ...parsed, isFromCompactUrl: false };
+    return urlState;
   }
 
   if (parsed.length <= ParseUrlStateIndex.SegmentsStart) {
@@ -251,7 +252,7 @@ export function parseUrlState(initial: string | undefined): ExploreUrlState {
   const queries = parsedSegments.filter((segment) => !isSegment(segment, 'ui', 'mode', '__panelsState'));
 
   const panelsState = parsedSegments.find((segment) => isSegment(segment, '__panelsState'))?.__panelsState;
-  return { datasource, queries, range, panelsState };
+  return { datasource, queries, range, panelsState, isFromCompactUrl: true };
 }
 
 export function generateKey(index = 0): string {

--- a/public/app/features/explore/Explore.test.tsx
+++ b/public/app/features/explore/Explore.test.tsx
@@ -83,6 +83,7 @@ const dummyProps: Props = {
   splitOpen: (() => {}) as any,
   changeGraphStyle: () => {},
   graphStyle: 'lines',
+  isFromCompactUrl: false,
 };
 
 jest.mock('@grafana/runtime/src/services/dataSourceSrv', () => {

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -8,6 +8,7 @@ import { Unsubscribable } from 'rxjs';
 
 import { AbsoluteTimeRange, DataQuery, GrafanaTheme2, LoadingState, QueryFixAction, RawTimeRange } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
+import { reportInteraction } from '@grafana/runtime';
 import {
   Collapse,
   CustomScrollbar,
@@ -79,7 +80,6 @@ const getStyles = (theme: GrafanaTheme2) => {
 
 export interface ExploreProps extends Themeable2 {
   exploreId: ExploreId;
-  isFromCompactUrl: boolean;
   theme: GrafanaTheme2;
 }
 
@@ -238,6 +238,7 @@ export class Explore extends React.PureComponent<Props, ExploreState> {
   }
 
   renderCompactUrlWarning() {
+    reportInteraction('grafana_explore_compact_notice');
     return (
       <FadeIn in={true} duration={100}>
         <Alert severity="warning" title="Compact URL Deprecation Notice" topSpacing={2}>
@@ -464,6 +465,7 @@ function mapStateToProps(state: StoreState, { exploreId }: ExploreProps) {
     showNodeGraph,
     loading,
     graphStyle,
+    isFromCompactUrl,
   } = item;
 
   return {
@@ -484,6 +486,7 @@ function mapStateToProps(state: StoreState, { exploreId }: ExploreProps) {
     showNodeGraph,
     loading,
     graphStyle,
+    isFromCompactUrl: isFromCompactUrl || false,
   };
 }
 
@@ -504,5 +507,4 @@ const connector = connect(mapStateToProps, mapDispatchToProps);
 
 export default compose(connector, withTheme2)(Explore) as React.ComponentType<{
   exploreId: ExploreId;
-  isFromCompactUrl: boolean;
 }>;

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -8,9 +8,18 @@ import { Unsubscribable } from 'rxjs';
 
 import { AbsoluteTimeRange, DataQuery, GrafanaTheme2, LoadingState, QueryFixAction, RawTimeRange } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
-import { Collapse, CustomScrollbar, ErrorBoundaryAlert, Themeable2, withTheme2, PanelContainer } from '@grafana/ui';
+import {
+  Collapse,
+  CustomScrollbar,
+  ErrorBoundaryAlert,
+  Themeable2,
+  withTheme2,
+  PanelContainer,
+  Alert,
+} from '@grafana/ui';
 import { FILTER_FOR_OPERATOR, FILTER_OUT_OPERATOR, FilterItem } from '@grafana/ui/src/components/Table/types';
 import appEvents from 'app/core/app_events';
+import { FadeIn } from 'app/core/components/Animations/FadeIn';
 import { supportedFeatures } from 'app/core/history/richHistoryStorageProvider';
 import { getNodeGraphDataFrames } from 'app/plugins/panel/nodeGraph/utils';
 import { StoreState } from 'app/types';
@@ -70,6 +79,7 @@ const getStyles = (theme: GrafanaTheme2) => {
 
 export interface ExploreProps extends Themeable2 {
   exploreId: ExploreId;
+  isFromCompactUrl: boolean;
   theme: GrafanaTheme2;
 }
 
@@ -227,6 +237,17 @@ export class Explore extends React.PureComponent<Props, ExploreState> {
     return <NoData />;
   }
 
+  renderCompactUrlWarning() {
+    return (
+      <FadeIn in={true} duration={100}>
+        <Alert severity="warning" title="Compact URL Deprecation Notice" topSpacing={2}>
+          The URL that brought you here was a compact URL - this format will soon be deprecated. Please replace the URL
+          previously saved with the URL available now.
+        </Alert>
+      </FadeIn>
+    );
+  }
+
   renderGraphPanel(width: number) {
     const { graphResult, absoluteRange, timeZone, splitOpen, queryResponse, loading, theme, graphStyle } = this.props;
     const spacing = parseInt(theme.spacing(2).slice(0, -2), 10);
@@ -329,6 +350,7 @@ export class Explore extends React.PureComponent<Props, ExploreState> {
       showTrace,
       showNodeGraph,
       timeZone,
+      isFromCompactUrl,
     } = this.props;
     const { openDrawer } = this.state;
     const styles = getStyles(theme);
@@ -353,6 +375,7 @@ export class Explore extends React.PureComponent<Props, ExploreState> {
         scrollRefCallback={(scrollElement) => (this.scrollElement = scrollElement || undefined)}
       >
         <ExploreToolbar exploreId={exploreId} onChangeTime={this.onChangeTime} topOfViewRef={this.topOfViewRef} />
+        {isFromCompactUrl ? this.renderCompactUrlWarning() : null}
         {datasourceMissing ? this.renderEmptyState(styles.exploreContainer) : null}
         {datasourceInstance && (
           <div className={cx(styles.exploreContainer)}>
@@ -479,4 +502,7 @@ const mapDispatchToProps = {
 
 const connector = connect(mapStateToProps, mapDispatchToProps);
 
-export default compose(connector, withTheme2)(Explore) as React.ComponentType<{ exploreId: ExploreId }>;
+export default compose(connector, withTheme2)(Explore) as React.ComponentType<{
+  exploreId: ExploreId;
+  isFromCompactUrl: boolean;
+}>;

--- a/public/app/features/explore/ExplorePaneContainer.tsx
+++ b/public/app/features/explore/ExplorePaneContainer.tsx
@@ -71,7 +71,16 @@ class ExplorePaneContainerUnconnected extends React.PureComponent<Props> {
   }
 
   async componentDidMount() {
-    const { initialized, exploreId, initialDatasource, initialQueries, initialRange, panelsState, orgId } = this.props;
+    const {
+      initialized,
+      exploreId,
+      initialDatasource,
+      initialQueries,
+      initialRange,
+      panelsState,
+      orgId,
+      isFromCompactUrl,
+    } = this.props;
     const width = this.el?.offsetWidth ?? 0;
     // initialize the whole explore first time we mount and if browser history contains a change in datasource
     if (!initialized) {
@@ -116,7 +125,8 @@ class ExplorePaneContainerUnconnected extends React.PureComponent<Props> {
         initialRange,
         width,
         this.exploreEvents,
-        panelsState
+        panelsState,
+        isFromCompactUrl
       );
     }
   }
@@ -144,12 +154,12 @@ class ExplorePaneContainerUnconnected extends React.PureComponent<Props> {
   };
 
   render() {
-    const { theme, split, exploreId, initialized, isFromCompactUrl } = this.props;
+    const { theme, split, exploreId, initialized } = this.props;
     const styles = getStyles(theme);
     const exploreClass = cx(styles.explore, split && styles.exploreSplit);
     return (
       <div className={exploreClass} ref={this.getRef} data-testid={selectors.pages.Explore.General.container}>
-        {initialized && <Explore exploreId={exploreId} isFromCompactUrl={isFromCompactUrl} />}
+        {initialized && <Explore exploreId={exploreId} />}
       </div>
     );
   }

--- a/public/app/features/explore/ExplorePaneContainer.tsx
+++ b/public/app/features/explore/ExplorePaneContainer.tsx
@@ -144,12 +144,12 @@ class ExplorePaneContainerUnconnected extends React.PureComponent<Props> {
   };
 
   render() {
-    const { theme, split, exploreId, initialized } = this.props;
+    const { theme, split, exploreId, initialized, isFromCompactUrl } = this.props;
     const styles = getStyles(theme);
     const exploreClass = cx(styles.explore, split && styles.exploreSplit);
     return (
       <div className={exploreClass} ref={this.getRef} data-testid={selectors.pages.Explore.General.container}>
-        {initialized && <Explore exploreId={exploreId} />}
+        {initialized && <Explore exploreId={exploreId} isFromCompactUrl={isFromCompactUrl} />}
       </div>
     );
   }
@@ -175,6 +175,7 @@ function mapStateToProps(state: StoreState, props: OwnProps) {
     initialRange,
     panelsState,
     orgId: state.user.orgId,
+    isFromCompactUrl: urlState.isFromCompactUrl || false,
   };
 }
 

--- a/public/app/features/explore/state/explorePane.ts
+++ b/public/app/features/explore/state/explorePane.ts
@@ -99,6 +99,7 @@ export interface InitializeExplorePayload {
   range: TimeRange;
   history: HistoryItem[];
   datasourceInstance?: DataSourceApi;
+  isFromCompactUrl?: boolean;
 }
 export const initializeExploreAction = createAction<InitializeExplorePayload>('explore/initializeExplore');
 
@@ -147,7 +148,8 @@ export function initializeExplore(
   range: TimeRange,
   containerWidth: number,
   eventBridge: EventBusExtended,
-  panelsState?: ExplorePanelsState
+  panelsState?: ExplorePanelsState,
+  isFromCompactUrl?: boolean
 ): ThunkResult<void> {
   return async (dispatch, getState) => {
     const exploreDatasources = getDataSourceSrv().getList();
@@ -170,6 +172,7 @@ export function initializeExplore(
         range,
         datasourceInstance: instance,
         history,
+        isFromCompactUrl,
       })
     );
     if (panelsState !== undefined) {
@@ -292,7 +295,8 @@ export const paneReducer = (state: ExploreItemState = makeExplorePaneState(), ac
   }
 
   if (initializeExploreAction.match(action)) {
-    const { containerWidth, eventBridge, queries, range, datasourceInstance, history } = action.payload;
+    const { containerWidth, eventBridge, queries, range, datasourceInstance, history, isFromCompactUrl } =
+      action.payload;
 
     return {
       ...state,
@@ -307,6 +311,7 @@ export const paneReducer = (state: ExploreItemState = makeExplorePaneState(), ac
       datasourceMissing: !datasourceInstance,
       queryResponse: createEmptyQueryResponse(),
       cache: [],
+      isFromCompactUrl: isFromCompactUrl || false,
     };
   }
 

--- a/public/app/types/explore.ts
+++ b/public/app/types/explore.ts
@@ -184,6 +184,8 @@ export interface ExploreItemState {
   /* explore graph style */
   graphStyle: ExploreGraphStyle;
   panelsState: ExplorePanelsState;
+
+  isFromCompactUrl?: boolean;
 }
 
 export interface ExploreUpdateState {


### PR DESCRIPTION
**What this PR does / why we need it**:
We would like to deprecate compact URLs, but many times people have links to explore in bookmarks or embedded in dashboards and don't realize it. We need a way of notifying users navigating to explore from a compact URL to know this is happening so they can edit the source of their URL. We need to balance being annoying without being too annoying, and being comprehensive so people know what to do without being overly verbose. This is a starting point for that.

We have an internal technical document about this. Reach out if you'd like it.

The reason this was implemented with a state variable is due to needing to keep the boolean even when the URL changes. Attaching it to the pane gets re-written when the URL is changed from a compact to normal URL, and then the warning disappears. In this implementation, the variable is only set on initialize and then stored. To see the implementation without state, see the "Round one" commit on this branch.

TODO: Feature flag on alert, notification in data links 

**Which issue(s) this PR fixes**:
Fixes #51277

**Special notes for your reviewer**:
An example of a compact URL is `http://localhost:3000/explore?orgId=1&left=[%22now-1h%22,%22now%22,%22gdev-loki%22,{%22expr%22:%22{place=\%22luna\%22}%22,%22refId%22:%22A%22}]`

