### PR TITLE
Documentation: clarify label matching

### DIFF
--- a/docs/sources/alerting/fundamentals/annotation-label/labels-and-label-matchers.md
+++ b/docs/sources/alerting/fundamentals/annotation-label/labels-and-label-matchers.md
@@ -30,7 +30,7 @@ A label matchers consists of 3 distinct parts, the **label**, the **value** and 
 | `=~`     | Select labels that regex-match the value.          |
 | `!~`     | Select labels that do not regex-match the value.   |
 
-In case of multiple label matchers, they are combined using AND logical operator, meaning all matchers need to match in order to link a rule to a policy.
+If you are using multiple label matchers, they are combined using the AND logical operator. This means that all matchers must match in order to link a rule to a policy.
 
 ## Example of a label matcher
 

--- a/docs/sources/alerting/fundamentals/annotation-label/labels-and-label-matchers.md
+++ b/docs/sources/alerting/fundamentals/annotation-label/labels-and-label-matchers.md
@@ -38,10 +38,10 @@ If you define the following set of labels for your alert:
 
 `{ foo=bar, baz=qux, id=12 }`
 
-In this situation,
+then:
 
-- A label matcher defined as `foo=bar` will match this alert rule.
-- A label matcher defined as `foo!=bar` will _not_ match this alert rule.
-- A label matcher defined as `id=~[0-9]+` will match this alert rule.
-- A label matcher defined as `baz!~[0-9]+` will match this alert rule.
-- Two label matchers defined as `foo=bar` and `id=~[0-9]+` will match this alert rule.
+- A label matcher defined as `foo=bar` matches this alert rule.
+- A label matcher defined as `foo!=bar` does _not_ match this alert rule.
+- A label matcher defined as `id=~[0-9]+` matches this alert rule.
+- A label matcher defined as `baz!~[0-9]+` matches this alert rule.
+- Two label matchers defined as `foo=bar` and `id=~[0-9]+` match this alert rule.

--- a/docs/sources/alerting/fundamentals/annotation-label/labels-and-label-matchers.md
+++ b/docs/sources/alerting/fundamentals/annotation-label/labels-and-label-matchers.md
@@ -32,9 +32,9 @@ A label matchers consists of 3 distinct parts, the **label**, the **value** and 
 
 If you are using multiple label matchers, they are combined using the AND logical operator. This means that all matchers must match in order to link a rule to a policy.
 
-## Example of a label matcher
+## Example scenario
 
-Imagine we've defined the following set of labels for our alert.
+If you define the following set of labels for your alert:
 
 `{ foo=bar, baz=qux, id=12 }`
 

--- a/docs/sources/alerting/fundamentals/annotation-label/labels-and-label-matchers.md
+++ b/docs/sources/alerting/fundamentals/annotation-label/labels-and-label-matchers.md
@@ -30,6 +30,8 @@ A label matchers consists of 3 distinct parts, the **label**, the **value** and 
 | `=~`     | Select labels that regex-match the value.          |
 | `!~`     | Select labels that do not regex-match the value.   |
 
+In case of multiple label matchers, they are combined using AND logical operator, meaning all matchers need to match in order to link a rule to a policy.
+
 ## Example of a label matcher
 
 Imagine we've defined the following set of labels for our alert.
@@ -42,3 +44,4 @@ In this situation,
 - A label matcher defined as `foo!=bar` will _not_ match this alert rule.
 - A label matcher defined as `id=~[0-9]+` will match this alert rule.
 - A label matcher defined as `baz!~[0-9]+` will match this alert rule.
+- Two label matchers defined as `foo=bar` and `id=~[0-9]+` will match this alert rule.


### PR DESCRIPTION
Behaviour in case of multiple matchers is not documented, but my experiments show they are reduced using logical AND. Please validate the updated description.