### PR TITLE
Alerting/integrations error feedback handle null dates in response 3

### DIFF
--- a/public/app/features/alerting/unified/Receivers.tsx
+++ b/public/app/features/alerting/unified/Receivers.tsx
@@ -3,8 +3,8 @@ import pluralize from 'pluralize';
 import React, { FC, useEffect } from 'react';
 import { Redirect, Route, RouteChildrenProps, Switch, useLocation, useParams } from 'react-router-dom';
 
-import { NavModelItem, GrafanaTheme2} from '@grafana/data';
-import { Alert, LoadingPlaceholder, withErrorBoundary, useStyles2, Icon, Stack} from '@grafana/ui';
+import { NavModelItem, GrafanaTheme2 } from '@grafana/data';
+import { Alert, LoadingPlaceholder, withErrorBoundary, useStyles2, Icon, Stack } from '@grafana/ui';
 import { useDispatch } from 'app/types';
 
 import { AlertManagerPicker } from './components/AlertManagerPicker';

--- a/public/app/features/alerting/unified/api/grafana.ts
+++ b/public/app/features/alerting/unified/api/grafana.ts
@@ -65,13 +65,13 @@ export function fetchContactPointsState(alertManagerSourceName: String): Promise
     //     "integrations": [ // Can be multiple of the same type. Are identified by the index.
     //       {
     //         "lastError": "establish connection to server: dial tcp: lookup smtp.example.org on 8.8.8.8:53: no such host",
-    //         "lastNotify": "2022-07-08 17:42:44.998893 +0000 UTC",
+    //         "lastNotify": "2022-09-19T15:34:40.696Z",
     //         "lastNotifyDuration": "117.2455ms",
     //         "name": "email[0]"
     //       },
     //       {
     //         "lastError": "establish connection to server: dial tcp: lookup smtp.example.org on 8.8.8.8:53: no such host",
-    //         "lastNotify": "2022-07-08 17:42:44.998893 +0000 UTC",
+    //         "lastNotify": "2022-09-19T15:34:40.696Z",
     //         "lastNotifyDuration": "117.2455ms",
     //         "name": "email[1]"
     //       }
@@ -82,7 +82,7 @@ export function fetchContactPointsState(alertManagerSourceName: String): Promise
     //     "active": true, // Whether the contact point is used or not.
     //     "integrations": [ // Can be multiple of the same type. Are identified by the index.
     //       {
-    //         "lastNotify": "2022-07-08 17:42:44.998893 +0000 UTC",
+    //         "lastNotify": "0001-01-01T00:00:00.000Z",
     //         "lastNotifyDuration": "117.2455ms",
     //         "name": "email[0]"
     //       }

--- a/public/app/features/alerting/unified/components/receivers/ReceiversTable.tsx
+++ b/public/app/features/alerting/unified/components/receivers/ReceiversTable.tsx
@@ -134,16 +134,22 @@ interface NotifiersTableProps {
   notifiersState: NotifiersState;
 }
 
-function LastNotify({ lastNotify }: { lastNotify: string }) {
-  const lastNotifyDuration = lastNotify;
-  return (
-    <Stack alignItems="center">
-      <div>{dateTime(lastNotifyDuration).locale('en').fromNow(true)} ago</div>
-      <Icon name="clock-nine" />
-      <div>{dateTimeFormat(lastNotifyDuration, { format: 'YYYY-MM-DD HH:mm:ss' })}</div>
-    </Stack>
-  );
+function LastNotify({ lastNotifyDate }: { lastNotifyDate: string }) {
+  const isLastNotifyNullDate = lastNotifyDate === '0001-01-01T00:00:00.000Z';
+
+  if (isLastNotifyNullDate) {
+    return <>{'-'}</>;
+  } else {
+    return (
+      <Stack alignItems="center">
+        <div>{`${dateTime(lastNotifyDate).locale('en').fromNow(true)} ago`}</div>
+        <Icon name="clock-nine" />
+        <div>{`${dateTimeFormat(lastNotifyDate, { format: 'YYYY-MM-DD HH:mm:ss' })}`}</div>
+      </Stack>
+    );
+  }
 }
+
 function NotifiersTable({ notifiersState }: NotifiersTableProps) {
   function getNotifierColumns(): NotifierTableColumnProps[] {
     return [
@@ -164,7 +170,7 @@ function NotifiersTable({ notifiersState }: NotifiersTableProps) {
       {
         id: 'lastNotify',
         label: 'Last delivery attempt',
-        renderCell: ({ data: { lastNotify } }) => <LastNotify lastNotify={lastNotify} />,
+        renderCell: ({ data: { lastNotify } }) => <LastNotify lastNotifyDate={lastNotify} />,
         size: 3,
       },
       {


### PR DESCRIPTION

**What this PR does / why we need it**:

This PR updates fake response and handles null date in `ReceiversTable`, according to latest changes in the alert manager. See gist : 

https://gist.github.com/santihernandezc/dfce8a61e7e67e46211be715700c56ed/revisions

**Special notes for your reviewer**:

This PR is going to be merged to the `main-branch-for-receivåers-integrations-error-feedback`

