### PR TITLE
@grafana/ui: Add index to EditorList items

### DIFF
--- a/packages/grafana-ui/src/components/QueryEditor/EditorList.tsx
+++ b/packages/grafana-ui/src/components/QueryEditor/EditorList.tsx
@@ -9,7 +9,8 @@ interface EditorListProps<T> {
   renderItem: (
     item: Partial<T>,
     onChangeItem: (item: Partial<T>) => void,
-    onDeleteItem: () => void
+    onDeleteItem: () => void,
+    index: number
   ) => React.ReactElement;
   onChange: (items: Array<Partial<T>>) => void;
 }
@@ -39,7 +40,8 @@ export function EditorList<T>({ items, renderItem, onChange }: EditorListProps<T
           {renderItem(
             item,
             (newItem) => onChangeItem(index, newItem),
-            () => onDeleteItem(index)
+            () => onDeleteItem(index),
+            index
           )}
         </div>
       ))}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

When using `EditorList` in my plugin, I want to be able to conditionally render an element depending on the item index. In this example, I am adding the text "OR" for all items but the last:

![Screenshot from 2022-09-23 11-39-52](https://user-images.githubusercontent.com/4025665/191934516-ea91e25f-8856-4960-861e-98e761b5d1eb.png)

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

I have not created an issue yet, let me know if you prefer that.

**Special notes for your reviewer**:

- Currently, in my plugin, I had to workaround it adding the item index in the type `T`.
- Another possibility, for my specific case, would be to add an optional parameter to render an element to join items but I think that having an index may still be useful for other cases (like rendering the actual index in the list, limit the amount of items, modify the last element...).
- I also checked this is not a breaking change. My plugin can render EditorLists with and without the `index` parameter in the modified function.
- It seems that this package has no tests, should I add some?

Thoughts?