### PR TITLE
@grafana/ui: Render PageToolbar Go Back icon for smaller window size

### DIFF
--- a/packages/grafana-ui/src/components/PageLayout/PageToolbar.tsx
+++ b/packages/grafana-ui/src/components/PageLayout/PageToolbar.tsx
@@ -164,7 +164,7 @@ const getStyles = (theme: GrafanaTheme2) => {
     `,
     pageIcon: css`
       display: none;
-      ${theme.breakpoints.up('md')} {
+      ${theme.breakpoints.up('sm')} {
         display: flex;
         padding-right: ${theme.spacing(1)};
         align-items: center;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

The "Go back" icon dissappears when there is still plenty of space in the nav header. With this PR it dissapears when it's a bit smaller (before the breakpoint was at 769px, not it's at 544px):

[Screencast from 23-09-22 12:44:59.webm](https://user-images.githubusercontent.com/4025665/191947648-42a3c521-db76-4bd5-b1b8-c35d010e540c.webm)

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/35618

**Special notes for your reviewer**:

It's helpful to have this button when analyzing the "Network" tab in the browser console.

