### PR TITLE
CI: Add `nightly-grafana-com` cronjob on CI

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -9,7 +9,7 @@ load('scripts/drone/events/main.star', 'main_pipelines')
 load('scripts/drone/pipelines/docs.star', 'docs_pipelines')
 load('scripts/drone/events/release.star', 'release_pipelines', 'publish_image_pipelines', 'publish_artifacts_pipelines', 'publish_npm_pipelines', 'publish_packages_pipeline', 'artifacts_page_pipeline')
 load('scripts/drone/version.star', 'version_branch_pipelines')
-load('scripts/drone/events/cron.star', 'cronjobs')
+load('scripts/drone/events/cron.star', 'cronjobs', 'post_to_grafana_com_pipeline')
 load('scripts/drone/vault.star', 'secrets')
 
 def main(ctx):
@@ -18,4 +18,4 @@ def main(ctx):
         publish_image_pipelines('public') + publish_image_pipelines('security') + \
         publish_artifacts_pipelines('security') + publish_artifacts_pipelines('public') + \
         publish_npm_pipelines('public') + publish_packages_pipeline() + artifacts_page_pipeline() + \
-        version_branch_pipelines() + cronjobs(edition=edition) + secrets()
+        version_branch_pipelines() + cronjobs(edition=edition) + [post_to_grafana_com_pipeline()]+ secrets()

--- a/.drone.star
+++ b/.drone.star
@@ -9,7 +9,7 @@ load('scripts/drone/events/main.star', 'main_pipelines')
 load('scripts/drone/pipelines/docs.star', 'docs_pipelines')
 load('scripts/drone/events/release.star', 'release_pipelines', 'publish_image_pipelines', 'publish_artifacts_pipelines', 'publish_npm_pipelines', 'publish_packages_pipeline', 'artifacts_page_pipeline')
 load('scripts/drone/version.star', 'version_branch_pipelines')
-load('scripts/drone/events/cron.star', 'cronjobs', 'post_to_grafana_com_pipeline')
+load('scripts/drone/events/cron.star', 'cronjobs')
 load('scripts/drone/vault.star', 'secrets')
 
 def main(ctx):
@@ -18,4 +18,4 @@ def main(ctx):
         publish_image_pipelines('public') + publish_image_pipelines('security') + \
         publish_artifacts_pipelines('security') + publish_artifacts_pipelines('public') + \
         publish_npm_pipelines('public') + publish_packages_pipeline() + artifacts_page_pipeline() + \
-        version_branch_pipelines() + cronjobs(edition=edition) + [post_to_grafana_com_pipeline()]+ secrets()
+        version_branch_pipelines() + cronjobs(edition=edition) + secrets()

--- a/.drone.yml
+++ b/.drone.yml
@@ -5284,6 +5284,36 @@ trigger:
   event: cron
 type: docker
 ---
+clone:
+  retries: 3
+kind: pipeline
+name: grafana-com-nightly
+platform:
+  arch: amd64
+  os: linux
+steps:
+- commands:
+  - mkdir -p bin
+  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v3.0.10/grabpl
+  - chmod +x bin/grabpl
+  image: byrnedo/alpine-curl:0.1.8
+  name: grabpl
+- commands:
+  - ./bin/grabpl publish grafana-com --edition oss
+  depends_on:
+  - grabpl
+  environment:
+    GCP_KEY:
+      from_secret: gcp_key
+    GRAFANA_COM_API_KEY:
+      from_secret: grafana_api_key
+  image: grafana/grafana-ci-deploy:1.3.3
+  name: post-to-grafana-com
+trigger:
+  cron: grafana-com-nightly
+  event: cron
+type: docker
+---
 get:
   name: .dockerconfigjson
   path: secret/data/common/gcr
@@ -5351,6 +5381,6 @@ kind: secret
 name: packages_secret_access_key
 ---
 kind: signature
-hmac: d30e53c2f89e9e08cb75b2f003c11aeb0f8391e6bf3ea2be65cdeb5a33ab4d43
+hmac: 774fd382b75b0860cc64326952818257df858a0f59144ad9ed978c984b94fd0e
 
 ...

--- a/scripts/drone/events/cron.star
+++ b/scripts/drone/events/cron.star
@@ -4,11 +4,17 @@ load('scripts/drone/steps/lib.star', 'publish_image', 'download_grabpl_step')
 aquasec_trivy_image = 'aquasec/trivy:0.21.0'
 
 def cronjobs(edition):
+    grafana_com_nightly_pipeline = cron_job_pipeline(
+        cronName='grafana-com-nightly',
+        name='grafana-com-nightly',
+        steps=[download_grabpl_step(),post_to_grafana_com_step()]
+    )
     return [
         scan_docker_image_pipeline(edition, 'latest'),
         scan_docker_image_pipeline(edition, 'main'),
         scan_docker_image_pipeline(edition, 'latest-ubuntu'),
         scan_docker_image_pipeline(edition, 'main-ubuntu'),
+        grafana_com_nightly_pipeline,
     ]
 
 def cron_job_pipeline(cronName, name, steps):
@@ -90,13 +96,4 @@ def post_to_grafana_com_step():
             'depends_on': ['grabpl'],
             'commands': ['./bin/grabpl publish grafana-com --edition oss'],
         }
-
-def post_to_grafana_com_pipeline():
-    return cron_job_pipeline(
-            cronName='grafana-com-nightly',
-            name='grafana-com-nightly',
-            steps=[
-                download_grabpl_step(),
-                post_to_grafana_com_step(),
-            ])
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes `nightly` Grafana builds. At the moment our `nightly` Grafana builds are broken and are not updated.
We setup a cronjob to post to grafana.com every night with the latest Grafana version on main. 

**Which issue(s) this PR fixes**:

https://github.com/grafana/grafana/issues/54440

