### PR TITLE
Search: fix cache in the frontend search engine

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -6136,43 +6136,6 @@ exports[`better eslint`] = {
     "public/app/plugins/datasource/elasticsearch/hooks/useStatelessReducer.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
-    "public/app/plugins/datasource/elasticsearch/language_provider.ts:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "3"]
-    ],
-    "public/app/plugins/datasource/elasticsearch/query_builder.ts:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "3"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "4"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "5"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "6"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "7"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "8"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "9"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "10"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "11"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "12"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "13"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "14"],
-      [0, 0, 0, "Do not use any type assertions.", "15"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "16"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "17"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "18"]
-    ],
-    "public/app/plugins/datasource/elasticsearch/specs/query_builder.test.ts:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "3"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "4"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "5"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "6"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "7"]
-    ],
     "public/app/plugins/datasource/elasticsearch/test-helpers/render.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],

--- a/public/app/features/search/service/frontend.ts
+++ b/public/app/features/search/service/frontend.ts
@@ -4,7 +4,7 @@ import { TermCount } from 'app/core/components/TagFilter/TagFilter';
 import { DashboardQueryResult, GrafanaSearcher, QueryResponse, SearchQuery } from '.';
 
 export class FrontendSearcher implements GrafanaSearcher {
-  readonly cache = new Map<string, FullResultCache>();
+  readonly cache = new Map<string, Promise<FullResultCache>>();
 
   constructor(private parent: GrafanaSearcher) {}
 
@@ -29,20 +29,26 @@ export class FrontendSearcher implements GrafanaSearcher {
   }
 
   async getCache(kind?: string[]): Promise<FullResultCache> {
-    const key = kind ? kind.join(',') : '*';
-    let res = this.cache.get(key);
-    if (res) {
-      return Promise.resolve(res);
+    const key = kind ? kind.sort().join(',') : '*';
+
+    const cacheHit = this.cache.get(key);
+    if (cacheHit) {
+      return cacheHit;
     }
 
-    const v = await this.parent.search({
-      kind, // match the request
-      limit: 5000, // max for now
-    });
-
-    res = new FullResultCache(v.view);
-    this.cache.set(key, res);
-    return res;
+    const resultPromise = this.parent
+      .search({
+        kind, // match the request
+        limit: 5000, // max for now
+      })
+      .then((res) => new FullResultCache(res.view))
+      .catch((err) => {
+        // TODO we need to refetch on error
+        console.error(err);
+        return new FullResultCache(new DataFrameView({ name: 'error', fields: [], length: 0 }));
+      });
+    this.cache.set(key, resultPromise);
+    return resultPromise;
   }
 
   async starred(query: SearchQuery): Promise<QueryResponse> {


### PR DESCRIPTION
This PR fixes changes the cache value from a resolved `FullResultCache` to `Promise<FullResultCache>` so we avoid issuing N parallel requests to get all the dashboards. 

In the folder view, Grafana issues a separate search request for each expanded folder (https://github.com/grafana/grafana/pull/55169#issuecomment-1247087310). Before this PR, all those requests resulted in a cache miss, as we were setting the cache value only after the completion of the first request, which could take a while for ~2000 dashboards.