### PR TITLE
Alerting: Fix no data for PostgreSQL queries

### DIFF
--- a/pkg/expr/nodes.go
+++ b/pkg/expr/nodes.go
@@ -248,7 +248,7 @@ func (dn *DSNode) Execute(ctx context.Context, vars mathexp.Vars, s *Service) (m
 		if len(qr.Frames) == 1 {
 			frame := qr.Frames[0]
 			// Handle Untyped NoData
-			if len(frame.Fields) == 0 {
+			if len(frame.Fields) == 0 || frame.Fields[0].Len() == 0 {
 				return mathexp.Results{Values: mathexp.Values{mathexp.NoData{Frame: frame}}}, nil
 			}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit fixes an issue where queries to PostgreSQL that returned no rows would cause an error 'no float64 value found in frame' instead of returning NoData. This is because the PostgreSQL datasource plugin returns a frame with two fields but no values.


**Which issue(s) this PR fixes**:

Fixes #55661

**Special notes for your reviewer**:

