### PR TITLE
Explore: Prevent panes from disappearing when resizing window in split view

### DIFF
--- a/public/app/features/explore/Wrapper.tsx
+++ b/public/app/features/explore/Wrapper.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { inRange } from 'lodash';
+import { debounce, inRange } from 'lodash';
 import React, { PureComponent } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 
@@ -41,6 +41,7 @@ interface OwnProps {}
 
 interface WrapperState {
   rightPaneWidth?: number;
+  windowWidth?: number;
 }
 
 const mapStateToProps = (state: StoreState) => {
@@ -68,6 +69,7 @@ class WrapperUnconnected extends PureComponent<Props, WrapperState> {
     super(props);
     this.state = {
       rightPaneWidth: undefined,
+      windowWidth: undefined,
     };
   }
 
@@ -82,6 +84,8 @@ class WrapperUnconnected extends PureComponent<Props, WrapperState> {
     if (Boolean(right)) {
       this.props.cleanupPaneAction({ exploreId: ExploreId.right });
     }
+
+    window.removeEventListener('resize', this.windowResizeListener);
   }
 
   componentDidMount() {
@@ -106,6 +110,8 @@ class WrapperUnconnected extends PureComponent<Props, WrapperState> {
     if (searchParams.from || searchParams.to) {
       locationService.partial({ from: undefined, to: undefined }, true);
     }
+
+    window.addEventListener('resize', this.windowResizeListener);
   }
 
   componentDidUpdate() {
@@ -118,6 +124,25 @@ class WrapperUnconnected extends PureComponent<Props, WrapperState> {
     document.title = documentTitle;
   }
 
+  windowResizeListener = debounce(() => {
+    let rightPaneRatio = 0.5;
+    const windowWidth = window.innerWidth;
+    // get the ratio of the previous rightPane to the window width
+    if (this.state.rightPaneWidth && this.state.windowWidth) {
+      rightPaneRatio = this.state.rightPaneWidth / this.state.windowWidth;
+    }
+    let newRightPaneWidth = Math.floor(windowWidth * rightPaneRatio);
+    if (newRightPaneWidth < this.minWidth) {
+      // if right pane is too narrow, make min width
+      newRightPaneWidth = this.minWidth;
+    } else if (windowWidth - newRightPaneWidth < this.minWidth) {
+      // if left pane is too narrow, make right pane = window - minWidth
+      newRightPaneWidth = windowWidth - this.minWidth;
+    }
+
+    this.setState({ windowWidth, rightPaneWidth: newRightPaneWidth });
+  }, 500);
+
   updateSplitSize = (rightPaneWidth: number) => {
     const evenSplitWidth = window.innerWidth / 2;
     const areBothSimilar = inRange(rightPaneWidth, evenSplitWidth - 100, evenSplitWidth + 100);
@@ -129,7 +154,7 @@ class WrapperUnconnected extends PureComponent<Props, WrapperState> {
       });
     }
 
-    this.setState({ rightPaneWidth });
+    this.setState({ ...this.state, rightPaneWidth });
   };
 
   render() {


### PR DESCRIPTION
**What this PR does / why we need it**:
Resizing the browser window can push window panes to be more narrow than what is allowed. This PR looks for window resize events so it can ensure the ratio of panes is kept and neither pane goes under the minimum width.

The pane resizing is easier to see when you manually resize by dragging a window corner, but entering and exiting fullscreen can move panes around in ways that are not obvious.

**Which issue(s) this PR fixes**:
Fixes #55693 

