### PR TITLE
DevEnv: Adds docker block for clickhouse

### DIFF
--- a/devenv/docker/blocks/clickhouse/docker-compose.yaml
+++ b/devenv/docker/blocks/clickhouse/docker-compose.yaml
@@ -1,0 +1,5 @@
+  clickhouse:
+    image: clickhouse/clickhouse-server:latest
+    container_name: clickhouse
+    ports:
+      - "8123:8123"


### PR DESCRIPTION
Been a couple bug tickets related to the Clickhouse datasource, so added a docker-compose block for it so we can set it up locally quickly.

Fixes https://github.com/grafana/grafana-partnerships-team/issues/370