### PR TITLE
refactor public dashboards middleware testing

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -143,7 +143,7 @@ func (hs *HTTPServer) registerRoutes() {
 	if hs.Features.IsEnabled(featuremgmt.FlagPublicDashboards) {
 		r.Get("/public-dashboards/:accessToken",
 			publicdashboardsapi.SetPublicDashboardFlag,
-			publicdashboardsapi.SetPublicDashboardOrgIdOnContext,
+			publicdashboardsapi.SetPublicDashboardOrgIdOnContext(hs.PublicDashboardsApi.PublicDashboardService),
 			publicdashboardsapi.CountPublicDashboardRequest(),
 			hs.Index,
 		)

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -141,7 +141,12 @@ func (hs *HTTPServer) registerRoutes() {
 	}
 
 	if hs.Features.IsEnabled(featuremgmt.FlagPublicDashboards) {
-		r.Get("/public-dashboards/:accessToken", publicdashboardsapi.SetPublicDashboardFlag(), publicdashboardsapi.CountPublicDashboardRequest(), hs.Index)
+		r.Get("/public-dashboards/:accessToken",
+			publicdashboardsapi.SetPublicDashboardFlag,
+			publicdashboardsapi.SetPublicDashboardOrgIdOnContext,
+			publicdashboardsapi.CountPublicDashboardRequest(),
+			hs.Index,
+		)
 	}
 
 	r.Get("/explore", authorize(func(c *models.ReqContext) {

--- a/pkg/services/publicdashboards/api/middleware.go
+++ b/pkg/services/publicdashboards/api/middleware.go
@@ -6,6 +6,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/metrics"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/publicdashboards"
+	"github.com/grafana/grafana/pkg/services/publicdashboards/internal/tokens"
 	"github.com/grafana/grafana/pkg/web"
 )
 
@@ -40,7 +41,7 @@ func RequiresValidAccessToken(publicDashboardService publicdashboards.Service) f
 		accessToken, ok := web.Params(c.Req)[":accessToken"]
 
 		// Check access token is present on the request
-		if !ok || accessToken == "" {
+		if !ok || !tokens.IsValidAccessToken(accessToken) {
 			c.JsonApiErr(http.StatusNotFound, "Invalid access token", nil)
 			return
 		}
@@ -54,7 +55,7 @@ func RequiresValidAccessToken(publicDashboardService publicdashboards.Service) f
 		}
 
 		if !exists {
-			c.JsonApiErr(http.StatusBadRequest, "Invalid access token", nil)
+			c.JsonApiErr(http.StatusNotFound, "Invalid access token", nil)
 			return
 		}
 	}

--- a/pkg/services/publicdashboards/api/middleware.go
+++ b/pkg/services/publicdashboards/api/middleware.go
@@ -31,10 +31,8 @@ func SetPublicDashboardOrgIdOnContext(publicDashboardService publicdashboards.Se
 }
 
 // Adds public dashboard flag on context
-func SetPublicDashboardFlag() func(c *models.ReqContext) {
-	return func(c *models.ReqContext) {
-		c.IsPublicDashboardView = true
-	}
+func SetPublicDashboardFlag(c *models.ReqContext) {
+	c.IsPublicDashboardView = true
 }
 
 func RequiresValidAccessToken(publicDashboardService publicdashboards.Service) func(c *models.ReqContext) {
@@ -43,7 +41,7 @@ func RequiresValidAccessToken(publicDashboardService publicdashboards.Service) f
 
 		// Check access token is present on the request
 		if !ok || accessToken == "" {
-			c.JsonApiErr(http.StatusBadRequest, "Invalid access token", nil)
+			c.JsonApiErr(http.StatusNotFound, "Invalid access token", nil)
 			return
 		}
 

--- a/pkg/services/publicdashboards/api/middleware_test.go
+++ b/pkg/services/publicdashboards/api/middleware_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/publicdashboards"
+	"github.com/grafana/grafana/pkg/services/publicdashboards/internal/tokens"
 	. "github.com/grafana/grafana/pkg/services/publicdashboards/models"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/web"
@@ -15,6 +16,8 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
+
+var validAccessToken, _ = tokens.GenerateAccessToken()
 
 func TestRequiresValidAccessToken(t *testing.T) {
 	tests := []struct {
@@ -38,25 +41,31 @@ func TestRequiresValidAccessToken(t *testing.T) {
 			Path:                 "/api/public/ma/events/myAccesstoken",
 			AccessTokenExists:    true,
 			AccessTokenExistsErr: nil,
-			AccessToken:          "myaccesstoken",
+			AccessToken:          validAccessToken,
 			ExpectedResponseCode: http.StatusOK,
 		},
-
-		// OWEN should this be a 404?
 		{
-			Name:                 "Returns 400 when public dashboard with access token does not exist",
+			Name:                 "Returns 404 when public dashboard with access token does not exist",
 			Path:                 "/api/public/ma/events/myAccesstoken",
 			AccessTokenExists:    false,
 			AccessTokenExistsErr: nil,
-			AccessToken:          "myaccesstoken",
-			ExpectedResponseCode: http.StatusBadRequest,
+			AccessToken:          validAccessToken,
+			ExpectedResponseCode: http.StatusNotFound,
+		},
+		{
+			Name:                 "Returns 404 when invalid access token",
+			Path:                 "/api/public/ma/events/myAccesstoken",
+			AccessTokenExists:    false,
+			AccessTokenExistsErr: nil,
+			AccessToken:          "invalidAccessToken",
+			ExpectedResponseCode: http.StatusNotFound,
 		},
 		{
 			Name:                 "Returns 500 when public dashboard service gives an error",
 			Path:                 "/api/public/ma/events/myAccesstoken",
 			AccessTokenExists:    false,
 			AccessTokenExistsErr: fmt.Errorf("error not found"),
-			AccessToken:          "myaccesstoken",
+			AccessToken:          validAccessToken,
 			ExpectedResponseCode: http.StatusInternalServerError,
 		},
 	}

--- a/pkg/services/publicdashboards/api/middleware_test.go
+++ b/pkg/services/publicdashboards/api/middleware_test.go
@@ -1,22 +1,15 @@
 package api
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
-	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana/pkg/models"
-	"github.com/grafana/grafana/pkg/services/contexthandler/ctxkey"
-	fakeDatasources "github.com/grafana/grafana/pkg/services/datasources/fakes"
 	"github.com/grafana/grafana/pkg/services/publicdashboards"
 	. "github.com/grafana/grafana/pkg/services/publicdashboards/models"
-	publicdashboardsService "github.com/grafana/grafana/pkg/services/publicdashboards/service"
-	"github.com/grafana/grafana/pkg/services/query"
 	"github.com/grafana/grafana/pkg/services/user"
-	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/web"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -24,160 +17,119 @@ import (
 )
 
 func TestRequiresValidAccessToken(t *testing.T) {
-	t.Run("Returns 404 when access token is empty", func(t *testing.T) {
-		publicdashboardService := &publicdashboards.FakePublicDashboardService{}
-		publicdashboardService.On("GetPublicDashboard", mock.Anything, mock.Anything).Return(
-			&PublicDashboard{OrgId: 7, IsEnabled: true},
-			nil,
-			nil,
-		)
+	tests := []struct {
+		Name                 string
+		Path                 string
+		AccessTokenExists    bool
+		AccessTokenExistsErr error
+		AccessToken          string
+		ExpectedResponseCode int
+	}{
+		{
+			Name:                 "Returns 404 when access token is empty",
+			Path:                 "/api/public/ma/events/",
+			AccessTokenExists:    false,
+			AccessTokenExistsErr: nil,
+			AccessToken:          "",
+			ExpectedResponseCode: http.StatusNotFound,
+		},
+		{
+			Name:                 "Returns 200 when public dashboard with access token exists",
+			Path:                 "/api/public/ma/events/myAccesstoken",
+			AccessTokenExists:    true,
+			AccessTokenExistsErr: nil,
+			AccessToken:          "myaccesstoken",
+			ExpectedResponseCode: http.StatusOK,
+		},
 
-		params := map[string]string{":accessToken": ""}
-		mw := RequiresValidAccessToken(publicdashboardService)
-		ctx := runMw(t, nil, "/api/public/ma/events/myAccesstoken", params, mw)
-		require.Equal(t, http.StatusNotFound, ctx.Req.Response.Status)
+		// OWEN should this be a 404?
+		{
+			Name:                 "Returns 400 when public dashboard with access token does not exist",
+			Path:                 "/api/public/ma/events/myAccesstoken",
+			AccessTokenExists:    false,
+			AccessTokenExistsErr: nil,
+			AccessToken:          "myaccesstoken",
+			ExpectedResponseCode: http.StatusBadRequest,
+		},
+		{
+			Name:                 "Returns 500 when public dashboard service gives an error",
+			Path:                 "/api/public/ma/events/myAccesstoken",
+			AccessTokenExists:    false,
+			AccessTokenExistsErr: fmt.Errorf("error not found"),
+			AccessToken:          "myaccesstoken",
+			ExpectedResponseCode: http.StatusInternalServerError,
+		},
+	}
 
-		//request, err := http.NewRequest("GET", "/api/public/ma/events/", nil)
-		//require.NoError(t, err)
-		//resp := runMiddleware(request, mockAccessTokenExistsResponse(false, nil))
-		//require.Equal(t, http.StatusNotFound, resp.Code)
-	})
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			publicdashboardService := &publicdashboards.FakePublicDashboardService{}
+			publicdashboardService.On("AccessTokenExists", mock.Anything, mock.Anything).Return(tt.AccessTokenExists, tt.AccessTokenExistsErr)
+			params := map[string]string{":accessToken": tt.AccessToken}
+			mw := RequiresValidAccessToken(publicdashboardService)
+			_, resp := runMw(t, nil, "GET", tt.Path, params, mw)
+			require.Equal(t, tt.ExpectedResponseCode, resp.Code)
+		})
 
-	t.Run("Returns 200 when public dashboard with access token exists", func(t *testing.T) {
-		request, err := http.NewRequest("GET", "/api/public/ma/events/myAccessToken", nil)
-		require.NoError(t, err)
-
-		resp := runMiddleware(request, mockAccessTokenExistsResponse(true, nil))
-
-		require.Equal(t, http.StatusOK, resp.Code)
-	})
-
-	t.Run("Returns 400 when public dashboard with access token does not exist", func(t *testing.T) {
-		request, err := http.NewRequest("GET", "/api/public/ma/events/myAccessToken", nil)
-		require.NoError(t, err)
-
-		resp := runMiddleware(request, mockAccessTokenExistsResponse(false, nil))
-
-		require.Equal(t, http.StatusBadRequest, resp.Code)
-	})
-
-	t.Run("Returns 500 when public dashboard service gives an error", func(t *testing.T) {
-		request, err := http.NewRequest("GET", "/api/public/ma/events/myAccessToken", nil)
-		require.NoError(t, err)
-
-		resp := runMiddleware(request, mockAccessTokenExistsResponse(false, fmt.Errorf("error not found")))
-
-		require.Equal(t, http.StatusInternalServerError, resp.Code)
-	})
+	}
 }
 
 func TestSetPublicDashboardOrgIdOnContext(t *testing.T) {
-	t.Run("Adds orgId for enabled public dashboard", func(t *testing.T) {
-		accessToken := "abc123"
+	tests := []struct {
+		Name                    string
+		AccessToken             string
+		PublicDashboardResponse *PublicDashboard
+		OrgId                   int64
+	}{
+		{
+			Name:                    "Adds orgId for enabled public dashboard",
+			AccessToken:             "abc123",
+			PublicDashboardResponse: &PublicDashboard{OrgId: 7, IsEnabled: true},
+			OrgId:                   7,
+		},
+		{
+			Name:                    "Does not set orgId or fail with disabled public dashboard",
+			AccessToken:             "abc123",
+			PublicDashboardResponse: &PublicDashboard{OrgId: 7, IsEnabled: false},
+			OrgId:                   0,
+		},
+		{
+			Name:                    "Does not set orgId or fail with missing public dashboard",
+			AccessToken:             "incorrectAccesstoken",
+			PublicDashboardResponse: nil,
+			OrgId:                   0,
+		},
+	}
 
+	for _, tt := range tests {
 		publicdashboardService := &publicdashboards.FakePublicDashboardService{}
-		publicdashboardService.On("GetPublicDashboard", mock.Anything, accessToken).Return(
-			&PublicDashboard{OrgId: 7, IsEnabled: true},
+		publicdashboardService.On("GetPublicDashboard", mock.Anything, tt.AccessToken).Return(
+			tt.PublicDashboardResponse,
 			nil,
 			nil,
 		)
 
-		params := map[string]string{":accessToken": accessToken}
+		params := map[string]string{":accessToken": tt.AccessToken}
 		mw := SetPublicDashboardOrgIdOnContext(publicdashboardService)
-		ctx := runMw(t, nil, "/public-dashboard/myaccesstoken", params, mw)
-		assert.True(t, ctx.OrgID == 7)
-	})
-
-	t.Run("Does not set orgId or fail with disabled public dashboard", func(t *testing.T) {
-		accessToken := "abc123"
-
-		publicdashboardService := &publicdashboards.FakePublicDashboardService{}
-		publicdashboardService.On("GetPublicDashboard", mock.Anything, accessToken).Return(
-			&PublicDashboard{OrgId: 7, IsEnabled: false},
-			nil,
-			nil,
-		)
-
-		params := map[string]string{":accessToken": accessToken}
-		mw := SetPublicDashboardOrgIdOnContext(publicdashboardService)
-		ctx := runMw(t, nil, "/public-dashboard/myaccesstoken", params, mw)
-		assert.False(t, ctx.OrgID == 7)
-	})
-
-	t.Run("Does not set orgId or fail with missing public dashboard", func(t *testing.T) {
-		publicdashboardService := &publicdashboards.FakePublicDashboardService{}
-		publicdashboardService.On("GetPublicDashboard", mock.Anything, mock.Anything).Return(
-			nil,
-			nil,
-			nil,
-		)
-
-		params := map[string]string{":accessToken": "incorrectAccessToken"}
-		mw := SetPublicDashboardOrgIdOnContext(publicdashboardService)
-		ctx := runMw(t, nil, "/public-dashboard/myaccesstoken", params, mw)
-		assert.False(t, ctx.OrgID == 7)
-	})
+		ctx, _ := runMw(t, nil, "GET", "/public-dashboard/myaccesstoken", params, mw)
+		assert.Equal(t, tt.OrgId, ctx.OrgID)
+	}
 }
 
 func TestSetPublicDashboardFlag(t *testing.T) {
 	t.Run("Adds context.IsPublicDashboardView=true to request", func(t *testing.T) {
-		f := SetPublicDashboardFlag()
 		ctx := &models.ReqContext{}
-		f(ctx)
+		SetPublicDashboardFlag(ctx)
 		assert.True(t, ctx.IsPublicDashboardView)
 	})
 }
 
-func mockAccessTokenExistsResponse(returnArguments ...interface{}) *publicdashboardsService.PublicDashboardServiceImpl {
-	fakeStore := &publicdashboards.FakePublicDashboardStore{}
-	fakeStore.On("AccessTokenExists", mock.Anything, mock.Anything).Return(returnArguments[0], returnArguments[1])
-
-	qds := query.ProvideService(
-		nil,
-		nil,
-		nil,
-		&fakePluginRequestValidator{},
-		&fakeDatasources.FakeDataSourceService{},
-		&fakePluginClient{
-			QueryDataHandlerFunc: func(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
-				resp := backend.Responses{
-					"A": backend.DataResponse{
-						Error: fmt.Errorf("query failed"),
-					},
-				}
-				return &backend.QueryDataResponse{Responses: resp}, nil
-			},
-		},
-		&fakeOAuthTokenService{},
-	)
-
-	return publicdashboardsService.ProvideService(setting.NewCfg(), fakeStore, qds)
-}
-
-func runMiddleware(request *http.Request, pubdashService *publicdashboardsService.PublicDashboardServiceImpl) *httptest.ResponseRecorder {
-	recorder := httptest.NewRecorder()
-	m := web.New()
-	initCtx := &models.ReqContext{}
-	m.Use(func(c *web.Context) {
-		initCtx.Context = c
-		c.Req = c.Req.WithContext(ctxkey.Set(c.Req.Context(), initCtx))
-	})
-	m.Get("/api/public/ma/events/:accessToken", RequiresValidAccessToken(pubdashService), mockValidRequestHandler)
-	m.ServeHTTP(recorder, request)
-
-	return recorder
-}
-
-func mockValidRequestHandler(c *models.ReqContext) {
-	resp := make(map[string]interface{})
-	resp["message"] = "Valid request"
-	c.JSON(http.StatusOK, resp)
-}
-
 // This is a helper to test middleware. It handles creating a
-// proper models.ReqContext, setting web parameters, and executing
-// middleware.
-func runMw(t *testing.T, ctx *models.ReqContext, path string, webparams map[string]string, mw func(c *models.ReqContext)) *models.ReqContext {
+// proper models.ReqContext, setting web parameters, executing middleware, and
+// returning a response. Response will default to result of
+// httptest.NewRecorder() return value and will only change if modified by the
+// middlware as this will no accept a handler method
+func runMw(t *testing.T, ctx *models.ReqContext, httpmethod string, path string, webparams map[string]string, mw func(c *models.ReqContext)) (*models.ReqContext, *httptest.ResponseRecorder) {
 	// create valid request context and set 0 values if they don't exist
 	if ctx == nil {
 		ctx = &models.ReqContext{}
@@ -190,12 +142,18 @@ func runMw(t *testing.T, ctx *models.ReqContext, path string, webparams map[stri
 	}
 
 	// create request and add params
-	request, err := http.NewRequest("GET", path, nil)
+	request, err := http.NewRequest(httpmethod, path, nil)
 	require.NoError(t, err)
 	request = web.SetURLParams(request, webparams)
 	ctx.Req = request
 
+	// setup response recorder to return
+	response := httptest.NewRecorder()
+	ctx.Context.Resp = web.NewResponseWriter("GET", response)
+
 	// run middleware
 	mw(ctx)
-	return ctx
+
+	// return result
+	return ctx, response
 }

--- a/pkg/services/publicdashboards/api/middleware_test.go
+++ b/pkg/services/publicdashboards/api/middleware_test.go
@@ -12,22 +12,35 @@ import (
 	"github.com/grafana/grafana/pkg/services/contexthandler/ctxkey"
 	fakeDatasources "github.com/grafana/grafana/pkg/services/datasources/fakes"
 	"github.com/grafana/grafana/pkg/services/publicdashboards"
+	. "github.com/grafana/grafana/pkg/services/publicdashboards/models"
 	publicdashboardsService "github.com/grafana/grafana/pkg/services/publicdashboards/service"
 	"github.com/grafana/grafana/pkg/services/query"
+	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/web"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
 func TestRequiresValidAccessToken(t *testing.T) {
 	t.Run("Returns 404 when access token is empty", func(t *testing.T) {
-		request, err := http.NewRequest("GET", "/api/public/ma/events/", nil)
-		require.NoError(t, err)
+		publicdashboardService := &publicdashboards.FakePublicDashboardService{}
+		publicdashboardService.On("GetPublicDashboard", mock.Anything, mock.Anything).Return(
+			&PublicDashboard{OrgId: 7, IsEnabled: true},
+			nil,
+			nil,
+		)
 
-		resp := runMiddleware(request, mockAccessTokenExistsResponse(false, nil))
+		params := map[string]string{":accessToken": ""}
+		mw := RequiresValidAccessToken(publicdashboardService)
+		ctx := runMw(t, nil, "/api/public/ma/events/myAccesstoken", params, mw)
+		require.Equal(t, http.StatusNotFound, ctx.Req.Response.Status)
 
-		require.Equal(t, http.StatusNotFound, resp.Code)
+		//request, err := http.NewRequest("GET", "/api/public/ma/events/", nil)
+		//require.NoError(t, err)
+		//resp := runMiddleware(request, mockAccessTokenExistsResponse(false, nil))
+		//require.Equal(t, http.StatusNotFound, resp.Code)
 	})
 
 	t.Run("Returns 200 when public dashboard with access token exists", func(t *testing.T) {
@@ -55,6 +68,63 @@ func TestRequiresValidAccessToken(t *testing.T) {
 		resp := runMiddleware(request, mockAccessTokenExistsResponse(false, fmt.Errorf("error not found")))
 
 		require.Equal(t, http.StatusInternalServerError, resp.Code)
+	})
+}
+
+func TestSetPublicDashboardOrgIdOnContext(t *testing.T) {
+	t.Run("Adds orgId for enabled public dashboard", func(t *testing.T) {
+		accessToken := "abc123"
+
+		publicdashboardService := &publicdashboards.FakePublicDashboardService{}
+		publicdashboardService.On("GetPublicDashboard", mock.Anything, accessToken).Return(
+			&PublicDashboard{OrgId: 7, IsEnabled: true},
+			nil,
+			nil,
+		)
+
+		params := map[string]string{":accessToken": accessToken}
+		mw := SetPublicDashboardOrgIdOnContext(publicdashboardService)
+		ctx := runMw(t, nil, "/public-dashboard/myaccesstoken", params, mw)
+		assert.True(t, ctx.OrgID == 7)
+	})
+
+	t.Run("Does not set orgId or fail with disabled public dashboard", func(t *testing.T) {
+		accessToken := "abc123"
+
+		publicdashboardService := &publicdashboards.FakePublicDashboardService{}
+		publicdashboardService.On("GetPublicDashboard", mock.Anything, accessToken).Return(
+			&PublicDashboard{OrgId: 7, IsEnabled: false},
+			nil,
+			nil,
+		)
+
+		params := map[string]string{":accessToken": accessToken}
+		mw := SetPublicDashboardOrgIdOnContext(publicdashboardService)
+		ctx := runMw(t, nil, "/public-dashboard/myaccesstoken", params, mw)
+		assert.False(t, ctx.OrgID == 7)
+	})
+
+	t.Run("Does not set orgId or fail with missing public dashboard", func(t *testing.T) {
+		publicdashboardService := &publicdashboards.FakePublicDashboardService{}
+		publicdashboardService.On("GetPublicDashboard", mock.Anything, mock.Anything).Return(
+			nil,
+			nil,
+			nil,
+		)
+
+		params := map[string]string{":accessToken": "incorrectAccessToken"}
+		mw := SetPublicDashboardOrgIdOnContext(publicdashboardService)
+		ctx := runMw(t, nil, "/public-dashboard/myaccesstoken", params, mw)
+		assert.False(t, ctx.OrgID == 7)
+	})
+}
+
+func TestSetPublicDashboardFlag(t *testing.T) {
+	t.Run("Adds context.IsPublicDashboardView=true to request", func(t *testing.T) {
+		f := SetPublicDashboardFlag()
+		ctx := &models.ReqContext{}
+		f(ctx)
+		assert.True(t, ctx.IsPublicDashboardView)
 	})
 }
 
@@ -102,4 +172,30 @@ func mockValidRequestHandler(c *models.ReqContext) {
 	resp := make(map[string]interface{})
 	resp["message"] = "Valid request"
 	c.JSON(http.StatusOK, resp)
+}
+
+// This is a helper to test middleware. It handles creating a
+// proper models.ReqContext, setting web parameters, and executing
+// middleware.
+func runMw(t *testing.T, ctx *models.ReqContext, path string, webparams map[string]string, mw func(c *models.ReqContext)) *models.ReqContext {
+	// create valid request context and set 0 values if they don't exist
+	if ctx == nil {
+		ctx = &models.ReqContext{}
+	}
+	if ctx.Context == nil {
+		ctx.Context = &web.Context{}
+	}
+	if ctx.SignedInUser == nil {
+		ctx.SignedInUser = &user.SignedInUser{}
+	}
+
+	// create request and add params
+	request, err := http.NewRequest("GET", path, nil)
+	require.NoError(t, err)
+	request = web.SetURLParams(request, webparams)
+	ctx.Req = request
+
+	// run middleware
+	mw(ctx)
+	return ctx
 }

--- a/pkg/services/publicdashboards/api/middleware_test.go
+++ b/pkg/services/publicdashboards/api/middleware_test.go
@@ -80,7 +80,6 @@ func TestRequiresValidAccessToken(t *testing.T) {
 			_, resp := runMw(t, nil, "GET", tt.Path, params, mw)
 			require.Equal(t, tt.ExpectedResponseCode, resp.Code)
 		})
-
 	}
 }
 

--- a/pkg/services/publicdashboards/database/database.go
+++ b/pkg/services/publicdashboards/database/database.go
@@ -53,7 +53,8 @@ func (d *PublicDashboardStoreImpl) GetDashboard(ctx context.Context, dashboardUi
 	return dashboard, err
 }
 
-// Retrieves public dashboard configuration
+// Retrieves public dashboard. This method makes 2 queries to the db so that in the
+// even that the underlying dashboard is missing it will return a 404.
 func (d *PublicDashboardStoreImpl) GetPublicDashboard(ctx context.Context, accessToken string) (*PublicDashboard, *models.Dashboard, error) {
 	if accessToken == "" {
 		return nil, nil, ErrPublicDashboardIdentifierNotSet

--- a/pkg/services/publicdashboards/database/database.go
+++ b/pkg/services/publicdashboards/database/database.go
@@ -207,7 +207,7 @@ func (d *PublicDashboardStoreImpl) UpdatePublicDashboardConfig(ctx context.Conte
 	return err
 }
 
-//Responds true if public dashboard for a dashboard exists and isEnabled
+// Responds true if public dashboard for a dashboard exists and isEnabled
 func (d *PublicDashboardStoreImpl) PublicDashboardEnabled(ctx context.Context, dashboardUid string) (bool, error) {
 	hasPublicDashboard := false
 	err := d.sqlStore.WithDbSession(ctx, func(dbSession *sqlstore.DBSession) error {
@@ -244,4 +244,21 @@ func (d *PublicDashboardStoreImpl) AccessTokenExists(ctx context.Context, access
 	})
 
 	return hasPublicDashboard, err
+}
+
+// Responds with OrgId from if exists and isEnabled.
+func (d *PublicDashboardStoreImpl) GetPublicDashboardOrgId(ctx context.Context, accessToken string) (int64, error) {
+	var orgId int64
+	err := d.sqlStore.WithDbSession(ctx, func(dbSession *sqlstore.DBSession) error {
+		sql := "SELECT org_id FROM dashboard_public WHERE access_token=? AND is_enabled=true"
+
+		_, err := dbSession.SQL(sql, accessToken).Get(&orgId)
+		if err != nil {
+			return err
+		}
+
+		return err
+	})
+
+	return orgId, err
 }

--- a/pkg/services/publicdashboards/database/database.go
+++ b/pkg/services/publicdashboards/database/database.go
@@ -181,7 +181,7 @@ func (d *PublicDashboardStoreImpl) SavePublicDashboardConfig(ctx context.Context
 	return err
 }
 
-// updates existing public dashboard configuration
+// Updates existing public dashboard configuration
 func (d *PublicDashboardStoreImpl) UpdatePublicDashboardConfig(ctx context.Context, cmd SavePublicDashboardConfigCommand) error {
 	err := d.sqlStore.WithTransactionalDbSession(ctx, func(sess *sqlstore.DBSession) error {
 		timeSettingsJSON, err := json.Marshal(cmd.PublicDashboard.TimeSettings)
@@ -206,6 +206,7 @@ func (d *PublicDashboardStoreImpl) UpdatePublicDashboardConfig(ctx context.Conte
 	return err
 }
 
+//Responds true if public dashboard for a dashboard exists and isEnabled
 func (d *PublicDashboardStoreImpl) PublicDashboardEnabled(ctx context.Context, dashboardUid string) (bool, error) {
 	hasPublicDashboard := false
 	err := d.sqlStore.WithDbSession(ctx, func(dbSession *sqlstore.DBSession) error {
@@ -224,6 +225,8 @@ func (d *PublicDashboardStoreImpl) PublicDashboardEnabled(ctx context.Context, d
 	return hasPublicDashboard, err
 }
 
+// Responds true if accessToken exists and isEnabled. May be renamed in the
+// future
 func (d *PublicDashboardStoreImpl) AccessTokenExists(ctx context.Context, accessToken string) (bool, error) {
 	hasPublicDashboard := false
 	err := d.sqlStore.WithDbSession(ctx, func(dbSession *sqlstore.DBSession) error {

--- a/pkg/services/publicdashboards/database/database_test.go
+++ b/pkg/services/publicdashboards/database/database_test.go
@@ -98,7 +98,7 @@ func TestIntegrationAccessTokenExists(t *testing.T) {
 }
 
 // PublicDashboardEnabled
-func TestIntegrationGetPublicDashboard(t *testing.T) {
+func TestIntegrationPublicDashboardEnabled(t *testing.T) {
 	var sqlStore *sqlstore.SQLStore
 	var dashboardStore *dashboardsDB.DashboardStore
 	var publicdashboardStore *PublicDashboardStoreImpl
@@ -156,7 +156,7 @@ func TestIntegrationGetPublicDashboard(t *testing.T) {
 	})
 }
 
-// GetPublicDashboardWithDashboard
+// GetPublicDashboard
 func TestIntegrationGetPublicDashboard(t *testing.T) {
 	var sqlStore *sqlstore.SQLStore
 	var dashboardStore *dashboardsDB.DashboardStore
@@ -220,7 +220,7 @@ func TestIntegrationGetPublicDashboard(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		_, _, err = publicdashboardStore.GetPublicDashboardWithDashboard(context.Background(), "abc1234")
+		_, _, err = publicdashboardStore.GetPublicDashboard(context.Background(), "abc1234")
 		require.Error(t, dashboards.ErrDashboardNotFound, err)
 	})
 }

--- a/pkg/services/publicdashboards/database/database_test.go
+++ b/pkg/services/publicdashboards/database/database_test.go
@@ -52,8 +52,8 @@ func TestIntegrationGetDashboard(t *testing.T) {
 	})
 }
 
-// GetPublicDashboard
-func TestIntegrationGetPublicDashboard(t *testing.T) {
+// AccessTokenExists
+func TestIntegrationAccessTokenExists(t *testing.T) {
 	var sqlStore *sqlstore.SQLStore
 	var dashboardStore *dashboardsDB.DashboardStore
 	var publicdashboardStore *PublicDashboardStoreImpl
@@ -95,6 +95,21 @@ func TestIntegrationGetPublicDashboard(t *testing.T) {
 		require.NoError(t, err)
 		require.False(t, res)
 	})
+}
+
+// PublicDashboardEnabled
+func TestIntegrationGetPublicDashboardWithDashboard(t *testing.T) {
+	var sqlStore *sqlstore.SQLStore
+	var dashboardStore *dashboardsDB.DashboardStore
+	var publicdashboardStore *PublicDashboardStoreImpl
+	var savedDashboard *models.Dashboard
+
+	setup := func() {
+		sqlStore = sqlstore.InitTestDB(t)
+		dashboardStore = dashboardsDB.ProvideDashboardStore(sqlStore, featuremgmt.WithFeatures(), tagimpl.ProvideService(sqlStore))
+		publicdashboardStore = ProvideStore(sqlStore)
+		savedDashboard = insertTestDashboard(t, dashboardStore, "testDashie", 1, 0, true)
+	}
 
 	t.Run("PublicDashboardEnabled Will return true when dashboard has at least one enabled public dashboard", func(t *testing.T) {
 		setup()
@@ -139,6 +154,21 @@ func TestIntegrationGetPublicDashboard(t *testing.T) {
 
 		require.False(t, res)
 	})
+}
+
+// GetPublicDashboardWithDashboard
+func TestIntegrationGetPublicDashboard(t *testing.T) {
+	var sqlStore *sqlstore.SQLStore
+	var dashboardStore *dashboardsDB.DashboardStore
+	var publicdashboardStore *PublicDashboardStoreImpl
+	var savedDashboard *models.Dashboard
+
+	setup := func() {
+		sqlStore = sqlstore.InitTestDB(t)
+		dashboardStore = dashboardsDB.ProvideDashboardStore(sqlStore, featuremgmt.WithFeatures(), tagimpl.ProvideService(sqlStore))
+		publicdashboardStore = ProvideStore(sqlStore)
+		savedDashboard = insertTestDashboard(t, dashboardStore, "testDashie", 1, 0, true)
+	}
 
 	t.Run("returns PublicDashboard and Dashboard", func(t *testing.T) {
 		setup()
@@ -190,7 +220,7 @@ func TestIntegrationGetPublicDashboard(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		_, _, err = publicdashboardStore.GetPublicDashboard(context.Background(), "abc1234")
+		_, _, err = publicdashboardStore.GetPublicDashboardWithDashboard(context.Background(), "abc1234")
 		require.Error(t, dashboards.ErrDashboardNotFound, err)
 	})
 }
@@ -310,6 +340,7 @@ func TestIntegrationSavePublicDashboardConfig(t *testing.T) {
 	})
 }
 
+// UpdatePublicDashboardConfig
 func TestIntegrationUpdatePublicDashboard(t *testing.T) {
 	var sqlStore *sqlstore.SQLStore
 	var dashboardStore *dashboardsDB.DashboardStore
@@ -389,6 +420,7 @@ func TestIntegrationUpdatePublicDashboard(t *testing.T) {
 	})
 }
 
+// helper function insertTestDashboard
 func insertTestDashboard(t *testing.T, dashboardStore *dashboardsDB.DashboardStore, title string, orgId int64,
 	folderId int64, isFolder bool, tags ...interface{}) *models.Dashboard {
 	t.Helper()

--- a/pkg/services/publicdashboards/database/database_test.go
+++ b/pkg/services/publicdashboards/database/database_test.go
@@ -98,7 +98,7 @@ func TestIntegrationAccessTokenExists(t *testing.T) {
 }
 
 // PublicDashboardEnabled
-func TestIntegrationGetPublicDashboardWithDashboard(t *testing.T) {
+func TestIntegrationGetPublicDashboard(t *testing.T) {
 	var sqlStore *sqlstore.SQLStore
 	var dashboardStore *dashboardsDB.DashboardStore
 	var publicdashboardStore *PublicDashboardStoreImpl

--- a/pkg/services/publicdashboards/database/database_test.go
+++ b/pkg/services/publicdashboards/database/database_test.go
@@ -504,7 +504,6 @@ func TestIntegrationGetPublicDashboardOrgId(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotEqual(t, savedDashboard.OrgId, orgId)
 	})
-
 }
 
 // helper function insertTestDashboard

--- a/pkg/services/publicdashboards/database/database_test.go
+++ b/pkg/services/publicdashboards/database/database_test.go
@@ -87,6 +87,28 @@ func TestIntegrationAccessTokenExists(t *testing.T) {
 		require.True(t, res)
 	})
 
+	t.Run("AccessTokenExists will return false when IsEnabled=false", func(t *testing.T) {
+		setup()
+
+		err := publicdashboardStore.SavePublicDashboardConfig(context.Background(), SavePublicDashboardConfigCommand{
+			PublicDashboard: PublicDashboard{
+				IsEnabled:    false,
+				Uid:          "abc123",
+				DashboardUid: savedDashboard.Uid,
+				OrgId:        savedDashboard.OrgId,
+				CreatedAt:    time.Now(),
+				CreatedBy:    7,
+				AccessToken:  "accessToken",
+			},
+		})
+		require.NoError(t, err)
+
+		res, err := publicdashboardStore.AccessTokenExists(context.Background(), "accessToken")
+		require.NoError(t, err)
+
+		require.False(t, res)
+	})
+
 	t.Run("AccessTokenExists will return false when no public dashboard has matching access token", func(t *testing.T) {
 		setup()
 
@@ -418,6 +440,71 @@ func TestIntegrationUpdatePublicDashboard(t *testing.T) {
 		assert.NotEqual(t, updatedPublicDashboard.UpdatedAt, pdNotUpdatedRetrieved.UpdatedAt)
 		assert.NotEqual(t, updatedPublicDashboard.IsEnabled, pdNotUpdatedRetrieved.IsEnabled)
 	})
+}
+
+// GetPublicDashboardOrgId
+func TestIntegrationGetPublicDashboardOrgId(t *testing.T) {
+	var sqlStore *sqlstore.SQLStore
+	var dashboardStore *dashboardsDB.DashboardStore
+	var publicdashboardStore *PublicDashboardStoreImpl
+	var savedDashboard *models.Dashboard
+
+	setup := func() {
+		sqlStore = sqlstore.InitTestDB(t)
+		dashboardStore = dashboardsDB.ProvideDashboardStore(sqlStore, featuremgmt.WithFeatures(), tagimpl.ProvideService(sqlStore))
+		publicdashboardStore = ProvideStore(sqlStore)
+		savedDashboard = insertTestDashboard(t, dashboardStore, "testDashie", 1, 0, true)
+	}
+	t.Run("GetPublicDashboardOrgId will OrgId when enabled", func(t *testing.T) {
+		setup()
+
+		err := publicdashboardStore.SavePublicDashboardConfig(context.Background(), SavePublicDashboardConfigCommand{
+			PublicDashboard: PublicDashboard{
+				IsEnabled:    true,
+				Uid:          "abc123",
+				DashboardUid: savedDashboard.Uid,
+				OrgId:        savedDashboard.OrgId,
+				CreatedAt:    time.Now(),
+				CreatedBy:    7,
+				AccessToken:  "accessToken",
+			},
+		})
+		require.NoError(t, err)
+
+		orgId, err := publicdashboardStore.GetPublicDashboardOrgId(context.Background(), "accessToken")
+		require.NoError(t, err)
+
+		assert.Equal(t, savedDashboard.OrgId, orgId)
+	})
+
+	t.Run("GetPublicDashboardOrgId will return 0 when IsEnabled=false", func(t *testing.T) {
+		setup()
+
+		err := publicdashboardStore.SavePublicDashboardConfig(context.Background(), SavePublicDashboardConfigCommand{
+			PublicDashboard: PublicDashboard{
+				IsEnabled:    false,
+				Uid:          "abc123",
+				DashboardUid: savedDashboard.Uid,
+				OrgId:        savedDashboard.OrgId,
+				CreatedAt:    time.Now(),
+				CreatedBy:    7,
+				AccessToken:  "accessToken",
+			},
+		})
+		require.NoError(t, err)
+		orgId, err := publicdashboardStore.GetPublicDashboardOrgId(context.Background(), "accessToken")
+		require.NoError(t, err)
+		assert.NotEqual(t, savedDashboard.OrgId, orgId)
+	})
+
+	t.Run("GetPublicDashboardOrgId will return 0 when no public dashboard has matching access token", func(t *testing.T) {
+		setup()
+
+		orgId, err := publicdashboardStore.GetPublicDashboardOrgId(context.Background(), "nonExistentAccessToken")
+		require.NoError(t, err)
+		assert.NotEqual(t, savedDashboard.OrgId, orgId)
+	})
+
 }
 
 // helper function insertTestDashboard

--- a/pkg/services/publicdashboards/database/database_test.go
+++ b/pkg/services/publicdashboards/database/database_test.go
@@ -128,7 +128,7 @@ func TestIntegrationPublicDashboardEnabled(t *testing.T) {
 
 	setup := func() {
 		sqlStore = sqlstore.InitTestDB(t)
-		dashboardStore = dashboardsDB.ProvideDashboardStore(sqlStore, featuremgmt.WithFeatures(), tagimpl.ProvideService(sqlStore))
+		dashboardStore = dashboardsDB.ProvideDashboardStore(sqlStore, featuremgmt.WithFeatures(), tagimpl.ProvideService(sqlStore, sqlStore.Cfg))
 		publicdashboardStore = ProvideStore(sqlStore)
 		savedDashboard = insertTestDashboard(t, dashboardStore, "testDashie", 1, 0, true)
 	}
@@ -187,7 +187,7 @@ func TestIntegrationGetPublicDashboard(t *testing.T) {
 
 	setup := func() {
 		sqlStore = sqlstore.InitTestDB(t)
-		dashboardStore = dashboardsDB.ProvideDashboardStore(sqlStore, featuremgmt.WithFeatures(), tagimpl.ProvideService(sqlStore))
+		dashboardStore = dashboardsDB.ProvideDashboardStore(sqlStore, featuremgmt.WithFeatures(), tagimpl.ProvideService(sqlStore, sqlStore.Cfg))
 		publicdashboardStore = ProvideStore(sqlStore)
 		savedDashboard = insertTestDashboard(t, dashboardStore, "testDashie", 1, 0, true)
 	}
@@ -451,7 +451,7 @@ func TestIntegrationGetPublicDashboardOrgId(t *testing.T) {
 
 	setup := func() {
 		sqlStore = sqlstore.InitTestDB(t)
-		dashboardStore = dashboardsDB.ProvideDashboardStore(sqlStore, featuremgmt.WithFeatures(), tagimpl.ProvideService(sqlStore))
+		dashboardStore = dashboardsDB.ProvideDashboardStore(sqlStore, featuremgmt.WithFeatures(), tagimpl.ProvideService(sqlStore, sqlStore.Cfg))
 		publicdashboardStore = ProvideStore(sqlStore)
 		savedDashboard = insertTestDashboard(t, dashboardStore, "testDashie", 1, 0, true)
 	}

--- a/pkg/services/publicdashboards/internal/tokens/tokens.go
+++ b/pkg/services/publicdashboards/internal/tokens/tokens.go
@@ -1,0 +1,27 @@
+package tokens
+
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+// generates a uuid formatted without dashes to use as access token
+func GenerateAccessToken() (string, error) {
+	token, err := uuid.NewRandom()
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%x", token[:]), nil
+}
+
+// asserts that an accessToken is a valid uuid
+func IsValidAccessToken(token string) bool {
+	_, err := uuid.Parse(token)
+	if err != nil {
+		return false
+	}
+
+	return true
+}

--- a/pkg/services/publicdashboards/internal/tokens/tokens.go
+++ b/pkg/services/publicdashboards/internal/tokens/tokens.go
@@ -19,9 +19,5 @@ func GenerateAccessToken() (string, error) {
 // asserts that an accessToken is a valid uuid
 func IsValidAccessToken(token string) bool {
 	_, err := uuid.Parse(token)
-	if err != nil {
-		return false
-	}
-
-	return true
+	return err == nil
 }

--- a/pkg/services/publicdashboards/internal/tokens/tokens_test.go
+++ b/pkg/services/publicdashboards/internal/tokens/tokens_test.go
@@ -1,0 +1,38 @@
+package tokens
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateAccessToken(t *testing.T) {
+	accessToken, err := GenerateAccessToken()
+
+	t.Run("length", func(t *testing.T) {
+		require.NoError(t, err)
+		assert.Equal(t, 32, len(accessToken))
+	})
+
+	t.Run("no - ", func(t *testing.T) {
+		assert.False(t, strings.Contains("-", accessToken))
+	})
+}
+
+func TestValidAccessToken(t *testing.T) {
+	t.Run("true", func(t *testing.T) {
+		uuid, _ := GenerateAccessToken()
+		assert.True(t, IsValidAccessToken(uuid))
+	})
+
+	t.Run("false when blank", func(t *testing.T) {
+		assert.False(t, IsValidAccessToken(""))
+	})
+
+	t.Run("false when can't be parsed by uuid lib", func(t *testing.T) {
+		// too long
+		assert.False(t, IsValidAccessToken("0123456789012345678901234567890123456789"))
+	})
+}

--- a/pkg/services/publicdashboards/public_dashboard_service_mock.go
+++ b/pkg/services/publicdashboards/public_dashboard_service_mock.go
@@ -168,6 +168,27 @@ func (_m *FakePublicDashboardService) GetPublicDashboardConfig(ctx context.Conte
 	return r0, r1
 }
 
+// GetPublicDashboardOrgId provides a mock function with given fields: ctx, accessToken
+func (_m *FakePublicDashboardService) GetPublicDashboardOrgId(ctx context.Context, accessToken string) (int64, error) {
+	ret := _m.Called(ctx, accessToken)
+
+	var r0 int64
+	if rf, ok := ret.Get(0).(func(context.Context, string) int64); ok {
+		r0 = rf(ctx, accessToken)
+	} else {
+		r0 = ret.Get(0).(int64)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, accessToken)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetQueryDataResponse provides a mock function with given fields: ctx, skipCache, reqDTO, panelId, accessToken
 func (_m *FakePublicDashboardService) GetQueryDataResponse(ctx context.Context, skipCache bool, reqDTO publicdashboardsmodels.PublicDashboardQueryDTO, panelId int64, accessToken string) (*backend.QueryDataResponse, error) {
 	ret := _m.Called(ctx, skipCache, reqDTO, panelId, accessToken)

--- a/pkg/services/publicdashboards/public_dashboard_store_mock.go
+++ b/pkg/services/publicdashboards/public_dashboard_store_mock.go
@@ -161,6 +161,27 @@ func (_m *FakePublicDashboardStore) GetPublicDashboardConfig(ctx context.Context
 	return r0, r1
 }
 
+// GetPublicDashboardOrgId provides a mock function with given fields: ctx, accessToken
+func (_m *FakePublicDashboardStore) GetPublicDashboardOrgId(ctx context.Context, accessToken string) (int64, error) {
+	ret := _m.Called(ctx, accessToken)
+
+	var r0 int64
+	if rf, ok := ret.Get(0).(func(context.Context, string) int64); ok {
+		r0 = rf(ctx, accessToken)
+	} else {
+		r0 = ret.Get(0).(int64)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, accessToken)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // PublicDashboardEnabled provides a mock function with given fields: ctx, dashboardUid
 func (_m *FakePublicDashboardStore) PublicDashboardEnabled(ctx context.Context, dashboardUid string) (bool, error) {
 	ret := _m.Called(ctx, dashboardUid)

--- a/pkg/services/publicdashboards/public_dashboard_store_mock.go
+++ b/pkg/services/publicdashboards/public_dashboard_store_mock.go
@@ -84,7 +84,7 @@ func (_m *FakePublicDashboardStore) GetDashboard(ctx context.Context, dashboardU
 }
 
 // GetPublicDashboard provides a mock function with given fields: ctx, accessToken
-func (_m *FakePublicDashboardStore) GetPublicDashboard(ctx context.Context, accessToken string) (*publicdashboardsmodels.PublicDashboard, error) {
+func (_m *FakePublicDashboardStore) GetPublicDashboard(ctx context.Context, accessToken string) (*publicdashboardsmodels.PublicDashboard, *models.Dashboard, error) {
 	ret := _m.Called(ctx, accessToken)
 
 	var r0 *publicdashboardsmodels.PublicDashboard
@@ -96,14 +96,23 @@ func (_m *FakePublicDashboardStore) GetPublicDashboard(ctx context.Context, acce
 		}
 	}
 
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+	var r1 *models.Dashboard
+	if rf, ok := ret.Get(1).(func(context.Context, string) *models.Dashboard); ok {
 		r1 = rf(ctx, accessToken)
 	} else {
-		r1 = ret.Error(1)
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*models.Dashboard)
+		}
 	}
 
-	return r0, r1
+	var r2 error
+	if rf, ok := ret.Get(2).(func(context.Context, string) error); ok {
+		r2 = rf(ctx, accessToken)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
 }
 
 // GetPublicDashboardByUid provides a mock function with given fields: ctx, uid
@@ -130,7 +139,7 @@ func (_m *FakePublicDashboardStore) GetPublicDashboardByUid(ctx context.Context,
 }
 
 // GetPublicDashboardConfig provides a mock function with given fields: ctx, orgId, dashboardUid
-func (_m *FakePublicDashboardStore) GetPublicDashboardConfig(ctx context.Context, orgId int64, dashboardUid string) (*publicdashboardsmodels.PublicDashboard, *models.Dashboard, error) {
+func (_m *FakePublicDashboardStore) GetPublicDashboardConfig(ctx context.Context, orgId int64, dashboardUid string) (*publicdashboardsmodels.PublicDashboard, error) {
 	ret := _m.Called(ctx, orgId, dashboardUid)
 
 	var r0 *publicdashboardsmodels.PublicDashboard
@@ -142,23 +151,14 @@ func (_m *FakePublicDashboardStore) GetPublicDashboardConfig(ctx context.Context
 		}
 	}
 
-	var r1 *models.Dashboard
-	if rf, ok := ret.Get(1).(func(context.Context, int64, string) *models.Dashboard); ok {
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, int64, string) error); ok {
 		r1 = rf(ctx, orgId, dashboardUid)
 	} else {
-		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(*models.Dashboard)
-		}
+		r1 = ret.Error(1)
 	}
 
-	var r2 error
-	if rf, ok := ret.Get(2).(func(context.Context, int64, string) error); ok {
-		r2 = rf(ctx, orgId, dashboardUid)
-	} else {
-		r2 = ret.Error(2)
-	}
-
-	return r0, r1, r2
+	return r0, r1
 }
 
 // PublicDashboardEnabled provides a mock function with given fields: ctx, dashboardUid

--- a/pkg/services/publicdashboards/public_dashboard_store_mock.go
+++ b/pkg/services/publicdashboards/public_dashboard_store_mock.go
@@ -84,7 +84,7 @@ func (_m *FakePublicDashboardStore) GetDashboard(ctx context.Context, dashboardU
 }
 
 // GetPublicDashboard provides a mock function with given fields: ctx, accessToken
-func (_m *FakePublicDashboardStore) GetPublicDashboard(ctx context.Context, accessToken string) (*publicdashboardsmodels.PublicDashboard, *models.Dashboard, error) {
+func (_m *FakePublicDashboardStore) GetPublicDashboard(ctx context.Context, accessToken string) (*publicdashboardsmodels.PublicDashboard, error) {
 	ret := _m.Called(ctx, accessToken)
 
 	var r0 *publicdashboardsmodels.PublicDashboard
@@ -96,23 +96,14 @@ func (_m *FakePublicDashboardStore) GetPublicDashboard(ctx context.Context, acce
 		}
 	}
 
-	var r1 *models.Dashboard
-	if rf, ok := ret.Get(1).(func(context.Context, string) *models.Dashboard); ok {
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
 		r1 = rf(ctx, accessToken)
 	} else {
-		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(*models.Dashboard)
-		}
+		r1 = ret.Error(1)
 	}
 
-	var r2 error
-	if rf, ok := ret.Get(2).(func(context.Context, string) error); ok {
-		r2 = rf(ctx, accessToken)
-	} else {
-		r2 = ret.Error(2)
-	}
-
-	return r0, r1, r2
+	return r0, r1
 }
 
 // GetPublicDashboardByUid provides a mock function with given fields: ctx, uid
@@ -139,7 +130,7 @@ func (_m *FakePublicDashboardStore) GetPublicDashboardByUid(ctx context.Context,
 }
 
 // GetPublicDashboardConfig provides a mock function with given fields: ctx, orgId, dashboardUid
-func (_m *FakePublicDashboardStore) GetPublicDashboardConfig(ctx context.Context, orgId int64, dashboardUid string) (*publicdashboardsmodels.PublicDashboard, error) {
+func (_m *FakePublicDashboardStore) GetPublicDashboardConfig(ctx context.Context, orgId int64, dashboardUid string) (*publicdashboardsmodels.PublicDashboard, *models.Dashboard, error) {
 	ret := _m.Called(ctx, orgId, dashboardUid)
 
 	var r0 *publicdashboardsmodels.PublicDashboard
@@ -151,14 +142,23 @@ func (_m *FakePublicDashboardStore) GetPublicDashboardConfig(ctx context.Context
 		}
 	}
 
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, int64, string) error); ok {
+	var r1 *models.Dashboard
+	if rf, ok := ret.Get(1).(func(context.Context, int64, string) *models.Dashboard); ok {
 		r1 = rf(ctx, orgId, dashboardUid)
 	} else {
-		r1 = ret.Error(1)
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*models.Dashboard)
+		}
 	}
 
-	return r0, r1
+	var r2 error
+	if rf, ok := ret.Get(2).(func(context.Context, int64, string) error); ok {
+		r2 = rf(ctx, orgId, dashboardUid)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
 }
 
 // PublicDashboardEnabled provides a mock function with given fields: ctx, dashboardUid

--- a/pkg/services/publicdashboards/publicdashboard.go
+++ b/pkg/services/publicdashboards/publicdashboard.go
@@ -30,9 +30,9 @@ type Store interface {
 	AccessTokenExists(ctx context.Context, accessToken string) (bool, error)
 	GenerateNewPublicDashboardUid(ctx context.Context) (string, error)
 	GetDashboard(ctx context.Context, dashboardUid string) (*models.Dashboard, error)
-	GetPublicDashboard(ctx context.Context, accessToken string) (*PublicDashboard, error)
+	GetPublicDashboard(ctx context.Context, accessToken string) (*PublicDashboard, *models.Dashboard, error)
 	GetPublicDashboardByUid(ctx context.Context, uid string) (*PublicDashboard, error)
-	GetPublicDashboardConfig(ctx context.Context, orgId int64, dashboardUid string) (*PublicDashboard, *models.Dashboard, error)
+	GetPublicDashboardConfig(ctx context.Context, orgId int64, dashboardUid string) (*PublicDashboard, error)
 	PublicDashboardEnabled(ctx context.Context, dashboardUid string) (bool, error)
 	SavePublicDashboardConfig(ctx context.Context, cmd SavePublicDashboardConfigCommand) error
 	UpdatePublicDashboardConfig(ctx context.Context, cmd SavePublicDashboardConfigCommand) error

--- a/pkg/services/publicdashboards/publicdashboard.go
+++ b/pkg/services/publicdashboards/publicdashboard.go
@@ -16,9 +16,9 @@ import (
 type Service interface {
 	AccessTokenExists(ctx context.Context, accessToken string) (bool, error)
 	BuildAnonymousUser(ctx context.Context, dashboard *models.Dashboard) (*user.SignedInUser, error)
-	GetPublicDashboard(ctx context.Context, accessToken string) (*PublicDashboard, *models.Dashboard, error)
 	GetDashboard(ctx context.Context, dashboardUid string) (*models.Dashboard, error)
 	GetMetricRequest(ctx context.Context, dashboard *models.Dashboard, publicDashboard *PublicDashboard, panelId int64, reqDTO PublicDashboardQueryDTO) (dtos.MetricRequest, error)
+	GetPublicDashboard(ctx context.Context, accessToken string) (*PublicDashboard, *models.Dashboard, error)
 	GetPublicDashboardConfig(ctx context.Context, orgId int64, dashboardUid string) (*PublicDashboard, error)
 	GetQueryDataResponse(ctx context.Context, skipCache bool, reqDTO PublicDashboardQueryDTO, panelId int64, accessToken string) (*backend.QueryDataResponse, error)
 	PublicDashboardEnabled(ctx context.Context, dashboardUid string) (bool, error)
@@ -28,11 +28,11 @@ type Service interface {
 //go:generate mockery --name Store --structname FakePublicDashboardStore --inpackage --filename public_dashboard_store_mock.go
 type Store interface {
 	AccessTokenExists(ctx context.Context, accessToken string) (bool, error)
-	GetDashboard(ctx context.Context, dashboardUid string) (*models.Dashboard, error)
 	GenerateNewPublicDashboardUid(ctx context.Context) (string, error)
-	GetPublicDashboard(ctx context.Context, accessToken string) (*PublicDashboard, *models.Dashboard, error)
+	GetDashboard(ctx context.Context, dashboardUid string) (*models.Dashboard, error)
+	GetPublicDashboard(ctx context.Context, accessToken string) (*PublicDashboard, error)
 	GetPublicDashboardByUid(ctx context.Context, uid string) (*PublicDashboard, error)
-	GetPublicDashboardConfig(ctx context.Context, orgId int64, dashboardUid string) (*PublicDashboard, error)
+	GetPublicDashboardConfig(ctx context.Context, orgId int64, dashboardUid string) (*PublicDashboard, *models.Dashboard, error)
 	PublicDashboardEnabled(ctx context.Context, dashboardUid string) (bool, error)
 	SavePublicDashboardConfig(ctx context.Context, cmd SavePublicDashboardConfigCommand) error
 	UpdatePublicDashboardConfig(ctx context.Context, cmd SavePublicDashboardConfigCommand) error

--- a/pkg/services/publicdashboards/publicdashboard.go
+++ b/pkg/services/publicdashboards/publicdashboard.go
@@ -20,6 +20,7 @@ type Service interface {
 	GetMetricRequest(ctx context.Context, dashboard *models.Dashboard, publicDashboard *PublicDashboard, panelId int64, reqDTO PublicDashboardQueryDTO) (dtos.MetricRequest, error)
 	GetPublicDashboard(ctx context.Context, accessToken string) (*PublicDashboard, *models.Dashboard, error)
 	GetPublicDashboardConfig(ctx context.Context, orgId int64, dashboardUid string) (*PublicDashboard, error)
+	GetPublicDashboardOrgId(ctx context.Context, accessToken string) (int64, error)
 	GetQueryDataResponse(ctx context.Context, skipCache bool, reqDTO PublicDashboardQueryDTO, panelId int64, accessToken string) (*backend.QueryDataResponse, error)
 	PublicDashboardEnabled(ctx context.Context, dashboardUid string) (bool, error)
 	SavePublicDashboardConfig(ctx context.Context, u *user.SignedInUser, dto *SavePublicDashboardConfigDTO) (*PublicDashboard, error)
@@ -33,6 +34,7 @@ type Store interface {
 	GetPublicDashboard(ctx context.Context, accessToken string) (*PublicDashboard, *models.Dashboard, error)
 	GetPublicDashboardByUid(ctx context.Context, uid string) (*PublicDashboard, error)
 	GetPublicDashboardConfig(ctx context.Context, orgId int64, dashboardUid string) (*PublicDashboard, error)
+	GetPublicDashboardOrgId(ctx context.Context, accessToken string) (int64, error)
 	PublicDashboardEnabled(ctx context.Context, dashboardUid string) (bool, error)
 	SavePublicDashboardConfig(ctx context.Context, cmd SavePublicDashboardConfigCommand) error
 	UpdatePublicDashboardConfig(ctx context.Context, cmd SavePublicDashboardConfigCommand) error

--- a/pkg/services/publicdashboards/service/service.go
+++ b/pkg/services/publicdashboards/service/service.go
@@ -5,13 +5,13 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/publicdashboards"
+	"github.com/grafana/grafana/pkg/services/publicdashboards/internal/tokens"
 	. "github.com/grafana/grafana/pkg/services/publicdashboards/models"
 	"github.com/grafana/grafana/pkg/services/publicdashboards/queries"
 	"github.com/grafana/grafana/pkg/services/publicdashboards/validation"
@@ -147,7 +147,7 @@ func (pd *PublicDashboardServiceImpl) savePublicDashboardConfig(ctx context.Cont
 		return "", err
 	}
 
-	accessToken, err := GenerateAccessToken()
+	accessToken, err := tokens.GenerateAccessToken()
 	if err != nil {
 		return "", err
 	}
@@ -290,16 +290,6 @@ func (pd *PublicDashboardServiceImpl) PublicDashboardEnabled(ctx context.Context
 
 func (pd *PublicDashboardServiceImpl) AccessTokenExists(ctx context.Context, accessToken string) (bool, error) {
 	return pd.store.AccessTokenExists(ctx, accessToken)
-}
-
-// generates a uuid formatted without dashes to use as access token
-func GenerateAccessToken() (string, error) {
-	token, err := uuid.NewRandom()
-	if err != nil {
-		return "", err
-	}
-
-	return fmt.Sprintf("%x", token[:]), nil
 }
 
 // intervalMS and maxQueryData values are being calculated on the frontend for regular dashboards

--- a/pkg/services/publicdashboards/service/service.go
+++ b/pkg/services/publicdashboards/service/service.go
@@ -292,6 +292,10 @@ func (pd *PublicDashboardServiceImpl) AccessTokenExists(ctx context.Context, acc
 	return pd.store.AccessTokenExists(ctx, accessToken)
 }
 
+func (pd *PublicDashboardServiceImpl) GetPublicDashboardOrgId(ctx context.Context, accessToken string) (int64, error) {
+	return pd.store.GetPublicDashboardOrgId(ctx, accessToken)
+}
+
 // intervalMS and maxQueryData values are being calculated on the frontend for regular dashboards
 // we are doing the same for public dashboards but because this access would be public, we need a way to keep this
 // values inside reasonable bounds to avoid an attack that could hit data sources with a small interval and a big

--- a/pkg/services/publicdashboards/validation/validation.go
+++ b/pkg/services/publicdashboards/validation/validation.go
@@ -4,12 +4,13 @@ import (
 	"fmt"
 
 	"github.com/grafana/grafana/pkg/models"
-	publicDashboardModels "github.com/grafana/grafana/pkg/services/publicdashboards/models"
+	. "github.com/grafana/grafana/pkg/services/publicdashboards/models"
+	"github.com/grafana/grafana/pkg/util"
 )
 
-func ValidateSavePublicDashboard(dto *publicDashboardModels.SavePublicDashboardConfigDTO, dashboard *models.Dashboard) error {
+func ValidateSavePublicDashboard(dto *SavePublicDashboardConfigDTO, dashboard *models.Dashboard) error {
 	if hasTemplateVariables(dashboard) {
-		return publicDashboardModels.ErrPublicDashboardHasTemplateVariables
+		return ErrPublicDashboardHasTemplateVariables
 	}
 
 	return nil
@@ -21,7 +22,7 @@ func hasTemplateVariables(dashboard *models.Dashboard) bool {
 	return len(templateVariables) > 0
 }
 
-func ValidateQueryPublicDashboardRequest(req publicDashboardModels.PublicDashboardQueryDTO) error {
+func ValidateQueryPublicDashboardRequest(req PublicDashboardQueryDTO) error {
 	if req.IntervalMs < 0 {
 		return fmt.Errorf("intervalMS should be greater than 0")
 	}
@@ -31,4 +32,12 @@ func ValidateQueryPublicDashboardRequest(req publicDashboardModels.PublicDashboa
 	}
 
 	return nil
+}
+
+func ValidAccesStoken(token string) bool {
+	if token == "" || !util.IsValidShortUID(token) {
+		return false
+	}
+
+	return true
 }

--- a/pkg/services/publicdashboards/validation/validation.go
+++ b/pkg/services/publicdashboards/validation/validation.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/grafana/grafana/pkg/models"
 	. "github.com/grafana/grafana/pkg/services/publicdashboards/models"
-	"github.com/grafana/grafana/pkg/util"
 )
 
 func ValidateSavePublicDashboard(dto *SavePublicDashboardConfigDTO, dashboard *models.Dashboard) error {
@@ -32,12 +31,4 @@ func ValidateQueryPublicDashboardRequest(req PublicDashboardQueryDTO) error {
 	}
 
 	return nil
-}
-
-func ValidAccesStoken(token string) bool {
-	if token == "" || !util.IsValidShortUID(token) {
-		return false
-	}
-
-	return true
 }

--- a/pkg/services/publicdashboards/validation/validation_test.go
+++ b/pkg/services/publicdashboards/validation/validation_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/models"
-	publicdashboardModels "github.com/grafana/grafana/pkg/services/publicdashboards/models"
+	. "github.com/grafana/grafana/pkg/services/publicdashboards/models"
 	"github.com/stretchr/testify/require"
 )
 
@@ -22,10 +22,10 @@ func TestValidateSavePublicDashboard(t *testing.T) {
 		}`)
 		dashboardData, _ := simplejson.NewJson(templateVars)
 		dashboard := models.NewDashboardFromJson(dashboardData)
-		dto := &publicdashboardModels.SavePublicDashboardConfigDTO{DashboardUid: "abc123", OrgId: 1, UserId: 1, PublicDashboard: nil}
+		dto := &SavePublicDashboardConfigDTO{DashboardUid: "abc123", OrgId: 1, UserId: 1, PublicDashboard: nil}
 
 		err := ValidateSavePublicDashboard(dto, dashboard)
-		require.ErrorContains(t, err, publicdashboardModels.ErrPublicDashboardHasTemplateVariables.Reason)
+		require.ErrorContains(t, err, ErrPublicDashboardHasTemplateVariables.Reason)
 	})
 
 	t.Run("Returns no validation error when dashboard has no template variables", func(t *testing.T) {
@@ -36,7 +36,7 @@ func TestValidateSavePublicDashboard(t *testing.T) {
 		}`)
 		dashboardData, _ := simplejson.NewJson(templateVars)
 		dashboard := models.NewDashboardFromJson(dashboardData)
-		dto := &publicdashboardModels.SavePublicDashboardConfigDTO{DashboardUid: "abc123", OrgId: 1, UserId: 1, PublicDashboard: nil}
+		dto := &SavePublicDashboardConfigDTO{DashboardUid: "abc123", OrgId: 1, UserId: 1, PublicDashboard: nil}
 
 		err := ValidateSavePublicDashboard(dto, dashboard)
 		require.NoError(t, err)


### PR DESCRIPTION
This PR refactors middleware SetPublicDashboardOrgIdOnContext and SetPublicDashboardFlag along with a refactored test library for middleware.

Additionally some other test cleanup 

Fixes #55304
Fixes https://github.com/grafana/grafana-partnerships-team/issues/412

Originally this PR was a fix for and the hotfix https://github.com/grafana/grafana/issues/55304, however, a hotfix was released in https://github.com/grafana/grafana/pull/55489. 
