### PR TITLE
Alerting: Rounding to single unit in alert rule

### DIFF
--- a/packages/grafana-data/src/datetime/durationutil.ts
+++ b/packages/grafana-data/src/datetime/durationutil.ts
@@ -143,3 +143,29 @@ export function isValidGoDuration(durationString: string): boolean {
 
   return true;
 }
+
+/**
+ * parseIntervalSecondsSingleUnit parses duration number in seconds into single unit string
+ * For example '650s', '1m', '10m', '70m', '2h'
+ * @param duration - number in seconds to convert. For example 60, 120, 3600
+ *
+ * @public
+ */
+export function parseIntervalSecondsSingleUnit(duration?: number): string | undefined {
+  const timeUnits = [
+    { unit: 's', value: 1 },
+    { unit: 'm', value: 60 },
+    { unit: 'h', value: 3600 },
+    { unit: 'd', value: 86400 },
+    { unit: 'w', value: 604800 },
+  ];
+  if (duration) {
+    for (const item of timeUnits.reverse()) {
+      let rounded = duration % item.value;
+      if (rounded === 0) {
+        return duration / item.value + item.unit;
+      }
+    }
+  }
+  return undefined;
+}

--- a/packages/grafana-data/src/datetime/durationutil.ts
+++ b/packages/grafana-data/src/datetime/durationutil.ts
@@ -161,8 +161,8 @@ export function parseIntervalSecondsSingleUnit(duration?: number): string | unde
   ];
   if (duration) {
     for (const item of timeUnits.reverse()) {
-      let reminder = duration % item.value;
-      if (reminder === 0) {
+      let remainder = duration % item.value;
+      if (remainder === 0) {
         return duration / item.value + item.unit;
       }
     }

--- a/packages/grafana-data/src/datetime/durationutil.ts
+++ b/packages/grafana-data/src/datetime/durationutil.ts
@@ -161,8 +161,8 @@ export function parseIntervalSecondsSingleUnit(duration?: number): string | unde
   ];
   if (duration) {
     for (const item of timeUnits.reverse()) {
-      let rounded = duration % item.value;
-      if (rounded === 0) {
+      let reminder = duration % item.value;
+      if (reminder === 0) {
         return duration / item.value + item.unit;
       }
     }

--- a/public/app/features/alerting/unified/utils/rule-form.ts
+++ b/public/app/features/alerting/unified/utils/rule-form.ts
@@ -7,6 +7,7 @@ import {
   RelativeTimeRange,
   ScopedVars,
   TimeRange,
+  parseIntervalSecondsSingleUnit,
 } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 import { ExpressionDatasourceRef } from '@grafana/runtime/src/utils/DataSourceWithBackend';
@@ -124,7 +125,7 @@ export function rulerRuleToFormValues(ruleWithLocation: RuleWithLocation): RuleF
         type: RuleFormType.grafana,
         group: group.name,
         evaluateFor: rule.for || '0',
-        evaluateEvery: group.interval || defaultFormValues.evaluateEvery,
+        evaluateEvery: parseIntervalSecondsSingleUnit(ga.intervalSeconds) || defaultFormValues.evaluateEvery,
         noDataState: ga.no_data_state,
         execErrState: ga.exec_err_state,
         queries: ga.data,

--- a/public/app/types/unified-alerting-dto.ts
+++ b/public/app/types/unified-alerting-dto.ts
@@ -197,6 +197,7 @@ export interface GrafanaRuleDefinition extends PostableGrafanaRuleDefinition {
   namespace_uid: string;
   namespace_id: number;
   provenance?: string;
+  intervalSeconds?: number;
 }
 
 export interface RulerGrafanaRuleDTO {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Suggestion to fix the alerting rule interval when saving a number that is not multiple of a single unit. For example: 70s will keep 70s instead of 1m10s

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/55649

**Special notes for your reviewer**:
Hey, this PR is a suggestion to fix the issue https://github.com/grafana/grafana/issues/55649 i'm not sure if this is right approach, so I would like a review from a Grafana code-owner. 
I'm willing to write some tests as soon as the PR is reviewed :)
