### PR TITLE
Elasticsearch: Use buttons in editor instead of submit buttons

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/QueryEditorRow.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/QueryEditorRow.tsx
@@ -35,6 +35,7 @@ export const QueryEditorRow = ({
                 aria-pressed={hidden}
                 aria-label="hide metric"
                 className={styles.icon}
+                type="button"
               />
             )}
             <IconButton
@@ -44,6 +45,7 @@ export const QueryEditorRow = ({
               onClick={onRemoveClick || noop}
               disabled={!onRemoveClick}
               aria-label="remove metric"
+              type="button"
             />
           </span>
         </InlineLabel>

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/SettingsEditorContainer.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/SettingsEditorContainer.tsx
@@ -47,6 +47,7 @@ export const SettingsEditorContainer = ({ label, children, hidden = false }: Pro
           className={cx('gf-form-label query-part', styles.button, segmentStyles)}
           onClick={() => setOpen(!open)}
           aria-expanded={open}
+          type="button"
         >
           <Icon name={open ? 'angle-down' : 'angle-right'} aria-hidden="true" className={styles.icon} />
           {label}


### PR DESCRIPTION
A few buttons in the ES query editor didn't have a `type` attribute, making the editor submit when used in other places (ie. correlation settings page).

this PR just changes said button to use `type=button`