### PR TITLE
Dashboard: Add dashboard validation warning to save drawer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,8 @@ $(SPEC_TARGET): $(SWAGGER) ## Generate API Swagger specification
 	SWAGGER_GENERATE_EXTENSION=false $(SWAGGER) generate spec -m -w pkg/server -o $(SPEC_TARGET) \
 	-x "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions" \
 	-x "github.com/prometheus/alertmanager" \
-	-i pkg/api/swagger_tags.json
+	-i pkg/api/swagger_tags.json \
+	--exclude-tag=alpha
 
 swagger-api-spec: gen-go $(SPEC_TARGET) $(MERGED_SPEC_TARGET) validate-api-spec
 

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -74,5 +74,6 @@ export interface FeatureToggles {
   increaseInMemDatabaseQueryCache?: boolean;
   newPanelChromeUI?: boolean;
   queryLibrary?: boolean;
+  showDashboardValidationWarnings?: boolean;
   mysqlAnsiQuotes?: boolean;
 }

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -469,6 +469,7 @@ func (hs *HTTPServer) registerRoutes() {
 			})
 
 			dashboardRoute.Post("/calculate-diff", authorize(reqSignedIn, ac.EvalPermission(dashboards.ActionDashboardsWrite)), routing.Wrap(hs.CalculateDashboardDiff))
+			dashboardRoute.Post("/validate", authorize(reqSignedIn, ac.EvalPermission(dashboards.ActionDashboardsWrite)), routing.Wrap(hs.ValidateDashboard))
 			dashboardRoute.Post("/trim", routing.Wrap(hs.TrimDashboard))
 
 			dashboardRoute.Post("/db", authorize(reqSignedIn, ac.EvalAny(ac.EvalPermission(dashboards.ActionDashboardsCreate), ac.EvalPermission(dashboards.ActionDashboardsWrite))), routing.Wrap(hs.PostDashboard))

--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -752,7 +752,7 @@ func (hs *HTTPServer) GetDashboardVersion(c *models.ReqContext) response.Respons
 	return response.JSON(http.StatusOK, dashVersionMeta)
 }
 
-// swagger:route POST /dashboards/validate dashboards validateDashboard
+// swagger:route POST /dashboards/validate dashboards alpha validateDashboard
 //
 // Validates a dashboard JSON against the schema.
 //

--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -752,17 +752,20 @@ func (hs *HTTPServer) GetDashboardVersion(c *models.ReqContext) response.Respons
 	return response.JSON(http.StatusOK, dashVersionMeta)
 }
 
-type ValidateDashboardResponse struct {
-	IsValid bool   `json:"isValid"`
-	Message string `json:"message,omitempty"`
-}
-
-type ValidateDashboardCommandLol struct {
-	Dashboard string `json:"dashboard" binding:"Required"`
-}
-
+// swagger:route POST /dashboards/validate dashboards validateDashboard
+//
+// Validates a dashboard JSON against the schema
+//
+// Produces:
+// - application/json
+//
+// Responses:
+// 200: validateDashboardResponse
+// 401: unauthorisedError
+// 403: forbiddenError
+// 500: internalServerError
 func (hs *HTTPServer) ValidateDashboard(c *models.ReqContext) response.Response {
-	cmd := ValidateDashboardCommandLol{}
+	cmd := models.ValidateDashboardCommand{}
 
 	if err := web.Bind(c.Req, &cmd); err != nil {
 		return response.Error(http.StatusBadRequest, "bad request data", err)
@@ -770,6 +773,8 @@ func (hs *HTTPServer) ValidateDashboard(c *models.ReqContext) response.Response 
 
 	cm := hs.Coremodels.Dashboard()
 
+	// POST api recieves dashboard as a string of json (so line numbers for errors stay consistent),
+	// but we need to parse the schema version out of it
 	dashboardBytes := []byte(cmd.Dashboard)
 	dashboardJson, err := simplejson.NewJson(dashboardBytes)
 	if err != nil {
@@ -1238,4 +1243,10 @@ type DashboardVersionsResponse struct {
 type DashboardVersionResponse struct {
 	// in: body
 	Body *dashver.DashboardVersionMeta `json:"body"`
+}
+
+// swagger:response validateDashboardResponse
+type ValidateDashboardResponse struct {
+	IsValid bool   `json:"isValid"`
+	Message string `json:"message,omitempty"`
 }

--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -808,6 +808,8 @@ func (hs *HTTPServer) ValidateDashboard(c *models.ReqContext) response.Response 
 		Message: validationMessage,
 	}
 
+	// We respond with StatusOK even when the dashboard failed validation we were
+	// able to "task failed successfully" on an invalid dashboard
 	return response.JSON(http.StatusOK, respData)
 }
 

--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -773,7 +773,7 @@ func (hs *HTTPServer) ValidateDashboard(c *models.ReqContext) response.Response 
 
 	cm := hs.Coremodels.Dashboard()
 
-	// POST api recieves dashboard as a string of json (so line numbers for errors stay consistent),
+	// POST api receives dashboard as a string of json (so line numbers for errors stay consistent),
 	// but we need to parse the schema version out of it
 	dashboardBytes := []byte(cmd.Dashboard)
 	dashboardJson, err := simplejson.NewJson(dashboardBytes)

--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -813,8 +813,6 @@ func (hs *HTTPServer) ValidateDashboard(c *models.ReqContext) response.Response 
 		Message: validationMessage,
 	}
 
-	// We respond with StatusOK even when the dashboard failed validation we were
-	// able to "task failed successfully" on an invalid dashboard
 	return response.JSON(statusCode, respData)
 }
 

--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -777,8 +777,7 @@ func (hs *HTTPServer) ValidateDashboard(c *models.ReqContext) response.Response 
 
 	// POST api receives dashboard as a string of json (so line numbers for errors stay consistent),
 	// but we need to parse the schema version out of it
-	dashboardBytes := []byte(cmd.Dashboard)
-	dashboardJson, err := simplejson.NewJson(dashboardBytes)
+	dashboardJson, err := simplejson.NewJson(cmd.Dashboard)
 	if err != nil {
 		return response.Error(http.StatusBadRequest, "unable to parse dashboard", err)
 	}
@@ -794,7 +793,7 @@ func (hs *HTTPServer) ValidateDashboard(c *models.ReqContext) response.Response 
 	// work), or if schemaVersion is absent (which will happen once the Thema
 	// schema becomes canonical).
 	if err != nil || schemaVersion >= dashboard.HandoffSchemaVersion {
-		v, _ := cuectx.JSONtoCUE("dashboard.json", dashboardBytes)
+		v, _ := cuectx.JSONtoCUE("dashboard.json", cmd.Dashboard)
 		_, validationErr := cm.CurrentSchema().Validate(v)
 
 		if validationErr == nil {

--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -754,7 +754,7 @@ func (hs *HTTPServer) GetDashboardVersion(c *models.ReqContext) response.Respons
 
 // swagger:route POST /dashboards/validate dashboards validateDashboard
 //
-// # Validates a dashboard JSON against the schema
+// Validates a dashboard JSON against the schema.
 //
 // Produces:
 // - application/json
@@ -774,10 +774,11 @@ func (hs *HTTPServer) ValidateDashboard(c *models.ReqContext) response.Response 
 	}
 
 	cm := hs.Coremodels.Dashboard()
+	dashboardBytes := []byte(cmd.Dashboard)
 
 	// POST api receives dashboard as a string of json (so line numbers for errors stay consistent),
 	// but we need to parse the schema version out of it
-	dashboardJson, err := simplejson.NewJson(cmd.Dashboard)
+	dashboardJson, err := simplejson.NewJson(dashboardBytes)
 	if err != nil {
 		return response.Error(http.StatusBadRequest, "unable to parse dashboard", err)
 	}
@@ -793,7 +794,7 @@ func (hs *HTTPServer) ValidateDashboard(c *models.ReqContext) response.Response 
 	// work), or if schemaVersion is absent (which will happen once the Thema
 	// schema becomes canonical).
 	if err != nil || schemaVersion >= dashboard.HandoffSchemaVersion {
-		v, _ := cuectx.JSONtoCUE("dashboard.json", cmd.Dashboard)
+		v, _ := cuectx.JSONtoCUE("dashboard.json", dashboardBytes)
 		_, validationErr := cm.CurrentSchema().Validate(v)
 
 		if validationErr == nil {

--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -733,7 +733,7 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 
 		t.Run("When an invalid dashboard json is posted", func(t *testing.T) {
 			cmd := models.ValidateDashboardCommand{
-				Dashboard: "{\"hello\": \"world\"}",
+				Dashboard: []byte("{\"hello\": \"world\"}"),
 			}
 
 			role := org.RoleAdmin
@@ -749,7 +749,7 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 
 		t.Run("When a dashboard with a too-low schema version is posted", func(t *testing.T) {
 			cmd := models.ValidateDashboardCommand{
-				Dashboard: "{\"schemaVersion\": 1}",
+				Dashboard: []byte("{\"schemaVersion\": 1}"),
 			}
 
 			role := org.RoleAdmin
@@ -768,7 +768,7 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 			assert.Empty(t, readErr)
 
 			cmd := models.ValidateDashboardCommand{
-				Dashboard: string(devenvDashboard),
+				Dashboard: devenvDashboard,
 			}
 
 			role := org.RoleAdmin

--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -1120,7 +1120,7 @@ func postValidateScenario(t *testing.T, desc string, url string, routePattern st
 			LibraryElementService: &mockLibraryElementService{},
 			SQLStore:              sqlmock,
 			Features:              featuremgmt.WithFeatures(),
-			Coremodels:            registry.NewBase(),
+			Coremodels:            registry.NewBase(nil),
 		}
 
 		sc := setupScenarioContext(t, url)

--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -741,7 +741,7 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 				callPostDashboard(sc)
 
 				result := sc.ToJSON()
-				assert.Equal(t, 200, sc.resp.Code)
+				assert.Equal(t, 422, sc.resp.Code)
 				assert.False(t, result.Get("isValid").MustBool())
 				assert.NotEmpty(t, result.Get("message").MustString())
 			}, &sqlmock)
@@ -757,7 +757,7 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 				callPostDashboard(sc)
 
 				result := sc.ToJSON()
-				assert.Equal(t, 200, sc.resp.Code)
+				assert.Equal(t, 412, sc.resp.Code)
 				assert.False(t, result.Get("isValid").MustBool())
 				assert.Equal(t, "invalid schema version", result.Get("message").MustString())
 			}, &sqlmock)

--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -733,7 +733,7 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 
 		t.Run("When an invalid dashboard json is posted", func(t *testing.T) {
 			cmd := models.ValidateDashboardCommand{
-				Dashboard: []byte("{\"hello\": \"world\"}"),
+				Dashboard: "{\"hello\": \"world\"}",
 			}
 
 			role := org.RoleAdmin
@@ -749,7 +749,7 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 
 		t.Run("When a dashboard with a too-low schema version is posted", func(t *testing.T) {
 			cmd := models.ValidateDashboardCommand{
-				Dashboard: []byte("{\"schemaVersion\": 1}"),
+				Dashboard: "{\"schemaVersion\": 1}",
 			}
 
 			role := org.RoleAdmin
@@ -768,7 +768,7 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 			assert.Empty(t, readErr)
 
 			cmd := models.ValidateDashboardCommand{
-				Dashboard: devenvDashboard,
+				Dashboard: string(devenvDashboard),
 			}
 
 			role := org.RoleAdmin

--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"os"
 	"testing"
@@ -728,6 +729,62 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 		})
 	})
 
+	t.Run("Given a dashboard to validate", func(t *testing.T) {
+		sqlmock := mockstore.SQLStoreMock{}
+
+		t.Run("When an invalid dashboard json is posted", func(t *testing.T) {
+			cmd := models.ValidateDashboardCommand{
+				Dashboard: "{\"hello\": \"world\"}",
+			}
+
+			role := org.RoleAdmin
+			postValidateScenario(t, "When calling POST on", "/api/dashboards/validate", "/api/dashboards/validate", cmd, role, func(sc *scenarioContext) {
+				callPostDashboard(sc)
+
+				result := sc.ToJSON()
+				assert.Equal(t, 200, sc.resp.Code)
+				assert.False(t, result.Get("isValid").MustBool())
+				assert.NotEmpty(t, result.Get("message").MustString())
+			}, &sqlmock)
+		})
+
+		t.Run("When a dashboard with a too-low schema version is posted", func(t *testing.T) {
+
+			cmd := models.ValidateDashboardCommand{
+				Dashboard: "{\"schemaVersion\": 1}",
+			}
+
+			role := org.RoleAdmin
+			postValidateScenario(t, "When calling POST on", "/api/dashboards/validate", "/api/dashboards/validate", cmd, role, func(sc *scenarioContext) {
+				callPostDashboard(sc)
+
+				result := sc.ToJSON()
+				assert.Equal(t, 200, sc.resp.Code)
+				assert.False(t, result.Get("isValid").MustBool())
+				assert.Equal(t, "invalid schema version", result.Get("message").MustString())
+			}, &sqlmock)
+		})
+
+		t.Run("When a valid dashboard is posted", func(t *testing.T) {
+			devenvDashboard, readErr := ioutil.ReadFile("../../devenv/dev-dashboards/home.json")
+
+			assert.Empty(t, readErr)
+
+			cmd := models.ValidateDashboardCommand{
+				Dashboard: string(devenvDashboard),
+			}
+
+			role := org.RoleAdmin
+			postValidateScenario(t, "When calling POST on", "/api/dashboards/validate", "/api/dashboards/validate", cmd, role, func(sc *scenarioContext) {
+				callPostDashboard(sc)
+
+				result := sc.ToJSON()
+				assert.Equal(t, 200, sc.resp.Code)
+				assert.True(t, result.Get("isValid").MustBool())
+			}, &sqlmock)
+		})
+	})
+
 	t.Run("Given two dashboards being compared", func(t *testing.T) {
 		fakeDashboardVersionService := dashvertest.NewDashboardVersionServiceFake()
 		fakeDashboardVersionService.ExpectedDashboardVersions = []*dashver.DashboardVersion{
@@ -1045,6 +1102,42 @@ func postDashboardScenario(t *testing.T, desc string, url string, routePattern s
 			sc.context.SignedInUser = &user.SignedInUser{OrgID: cmd.OrgId, UserID: cmd.UserId}
 
 			return hs.PostDashboard(c)
+		})
+
+		sc.m.Post(routePattern, sc.defaultHandler)
+
+		fn(sc)
+	})
+}
+
+func postValidateScenario(t *testing.T, desc string, url string, routePattern string, cmd models.ValidateDashboardCommand,
+	role org.RoleType, fn scenarioFunc, sqlmock sqlstore.Store) {
+	t.Run(fmt.Sprintf("%s %s", desc, url), func(t *testing.T) {
+		cfg := setting.NewCfg()
+		hs := HTTPServer{
+			Cfg:                   cfg,
+			ProvisioningService:   provisioning.NewProvisioningServiceMock(context.Background()),
+			Live:                  newTestLive(t, sqlstore.InitTestDB(t)),
+			QuotaService:          &quotaimpl.Service{Cfg: cfg},
+			LibraryPanelService:   &mockLibraryPanelService{},
+			LibraryElementService: &mockLibraryElementService{},
+			SQLStore:              sqlmock,
+			Features:              featuremgmt.WithFeatures(),
+			Coremodels:            registry.NewBase(),
+		}
+
+		sc := setupScenarioContext(t, url)
+		sc.defaultHandler = routing.Wrap(func(c *models.ReqContext) response.Response {
+			c.Req.Body = mockRequestBody(cmd)
+			c.Req.Header.Add("Content-Type", "application/json")
+			sc.context = c
+			sc.context.SignedInUser = &user.SignedInUser{
+				OrgID:  testOrgID,
+				UserID: testUserID,
+			}
+			sc.context.OrgRole = role
+
+			return hs.ValidateDashboard(c)
 		})
 
 		sc.m.Post(routePattern, sc.defaultHandler)

--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"testing"
@@ -765,7 +764,7 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 		})
 
 		t.Run("When a valid dashboard is posted", func(t *testing.T) {
-			devenvDashboard, readErr := ioutil.ReadFile("../../devenv/dev-dashboards/home.json")
+			devenvDashboard, readErr := os.ReadFile("../../devenv/dev-dashboards/home.json")
 			assert.Empty(t, readErr)
 
 			cmd := models.ValidateDashboardCommand{

--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -749,7 +749,6 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 		})
 
 		t.Run("When a dashboard with a too-low schema version is posted", func(t *testing.T) {
-
 			cmd := models.ValidateDashboardCommand{
 				Dashboard: "{\"schemaVersion\": 1}",
 			}
@@ -767,7 +766,6 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 
 		t.Run("When a valid dashboard is posted", func(t *testing.T) {
 			devenvDashboard, readErr := ioutil.ReadFile("../../devenv/dev-dashboards/home.json")
-
 			assert.Empty(t, readErr)
 
 			cmd := models.ValidateDashboardCommand{

--- a/pkg/models/dashboards.go
+++ b/pkg/models/dashboards.go
@@ -224,6 +224,10 @@ type SaveDashboardCommand struct {
 	Result *Dashboard `json:"-"`
 }
 
+type ValidateDashboardCommand struct {
+	Dashboard *simplejson.Json `json:"dashboard" binding:"Required"`
+}
+
 type TrimDashboardCommand struct {
 	Dashboard *simplejson.Json `json:"dashboard" binding:"Required"`
 	Meta      *simplejson.Json `json:"meta"`

--- a/pkg/models/dashboards.go
+++ b/pkg/models/dashboards.go
@@ -225,7 +225,7 @@ type SaveDashboardCommand struct {
 }
 
 type ValidateDashboardCommand struct {
-	Dashboard *simplejson.Json `json:"dashboard" binding:"Required"`
+	Dashboard string `json:"dashboard" binding:"Required"`
 }
 
 type TrimDashboardCommand struct {

--- a/pkg/models/dashboards.go
+++ b/pkg/models/dashboards.go
@@ -225,7 +225,7 @@ type SaveDashboardCommand struct {
 }
 
 type ValidateDashboardCommand struct {
-	Dashboard string `json:"dashboard" binding:"Required"`
+	Dashboard []byte `json:"dashboard" binding:"Required"`
 }
 
 type TrimDashboardCommand struct {

--- a/pkg/models/dashboards.go
+++ b/pkg/models/dashboards.go
@@ -225,7 +225,7 @@ type SaveDashboardCommand struct {
 }
 
 type ValidateDashboardCommand struct {
-	Dashboard []byte `json:"dashboard" binding:"Required"`
+	Dashboard string `json:"dashboard" binding:"Required"`
 }
 
 type TrimDashboardCommand struct {

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -323,6 +323,10 @@ var (
 			RequiresDevMode: true,
 		},
 		{
+			Name:        "showDashboardValidationWarnings",
+			Description: "Show warnings when Dashboards do not validate against the schema",
+		},
+		{
 			Name:        "mysqlAnsiQuotes",
 			Description: "Use double quote to escape keyword in Mysql query",
 			State:       FeatureStateAlpha,

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -239,6 +239,10 @@ const (
 	// Reusable query library
 	FlagQueryLibrary = "queryLibrary"
 
+	// FlagShowDashboardValidationWarnings
+	// Show warnings when Dashboards do not validate against the schema
+	FlagShowDashboardValidationWarnings = "showDashboardValidationWarnings"
+
 	// FlagMysqlAnsiQuotes
 	// Use double quote to escape keyword in Mysql query
 	FlagMysqlAnsiQuotes = "mysqlAnsiQuotes"

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -3926,32 +3926,6 @@
         }
       }
     },
-    "/dashboards/validate": {
-      "post": {
-        "description": "Validates a dashboard JSON against the schema",
-        "produces": [
-          "application/json"
-        ],
-        "tags": [
-          "dashboards"
-        ],
-        "operationId": "validateDashboard",
-        "responses": {
-          "200": {
-            "$ref": "#/responses/validateDashboardResponse"
-          },
-          "401": {
-            "$ref": "#/responses/unauthorisedError"
-          },
-          "403": {
-            "$ref": "#/responses/forbiddenError"
-          },
-          "500": {
-            "$ref": "#/responses/internalServerError"
-          }
-        }
-      }
-    },
     "/datasources": {
       "get": {
         "description": "If you are running Grafana Enterprise and have Fine-grained access control enabled\nyou need to have a permission with action: `datasources:read` and scope: `datasources:*`.",

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -121,22 +121,6 @@
         ],
         "summary": "Update a custom role.",
         "operationId": "updateRole",
-        "parameters": [
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/UpdateRoleCommand"
-            }
-          },
-          {
-            "type": "string",
-            "name": "roleUID",
-            "in": "path",
-            "required": true
-          }
-        ],
         "responses": {
           "200": {
             "$ref": "#/responses/getRoleResponse"
@@ -163,24 +147,6 @@
         ],
         "summary": "Delete a custom role.",
         "operationId": "deleteRole",
-        "parameters": [
-          {
-            "type": "boolean",
-            "name": "force",
-            "in": "query"
-          },
-          {
-            "type": "boolean",
-            "name": "global",
-            "in": "query"
-          },
-          {
-            "type": "string",
-            "name": "roleUID",
-            "in": "path",
-            "required": true
-          }
-        ],
         "responses": {
           "200": {
             "$ref": "#/responses/okResponse"
@@ -206,14 +172,6 @@
         ],
         "summary": "Get role assignments.",
         "operationId": "getRoleAssignments",
-        "parameters": [
-          {
-            "type": "string",
-            "name": "roleUID",
-            "in": "path",
-            "required": true
-          }
-        ],
         "responses": {
           "200": {
             "$ref": "#/responses/getRoleAssignmentsResponse"
@@ -237,22 +195,6 @@
         ],
         "summary": "Set role assignments.",
         "operationId": "setRoleAssignments",
-        "parameters": [
-          {
-            "type": "string",
-            "name": "roleUID",
-            "in": "path",
-            "required": true
-          },
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/SetRoleAssignmentsCommand"
-            }
-          }
-        ],
         "responses": {
           "200": {
             "$ref": "#/responses/setRoleAssignmentsResponse"
@@ -3919,6 +3861,32 @@
           },
           "404": {
             "$ref": "#/responses/notFoundError"
+          },
+          "500": {
+            "$ref": "#/responses/internalServerError"
+          }
+        }
+      }
+    },
+    "/dashboards/validate": {
+      "post": {
+        "description": "Validates a dashboard JSON against the schema",
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "dashboards"
+        ],
+        "operationId": "validateDashboard",
+        "responses": {
+          "200": {
+            "$ref": "#/responses/validateDashboardResponse"
+          },
+          "401": {
+            "$ref": "#/responses/unauthorisedError"
+          },
+          "403": {
+            "$ref": "#/responses/forbiddenError"
           },
           "500": {
             "$ref": "#/responses/internalServerError"
@@ -16009,35 +15977,6 @@
         }
       }
     },
-    "RoleAssignmentsDTO": {
-      "type": "object",
-      "properties": {
-        "role_uid": {
-          "type": "string"
-        },
-        "service_accounts": {
-          "type": "array",
-          "items": {
-            "type": "integer",
-            "format": "int64"
-          }
-        },
-        "teams": {
-          "type": "array",
-          "items": {
-            "type": "integer",
-            "format": "int64"
-          }
-        },
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "integer",
-            "format": "int64"
-          }
-        }
-      }
-    },
     "RoleDTO": {
       "type": "object",
       "properties": {
@@ -16594,32 +16533,6 @@
           "type": "string",
           "format": "date-time",
           "example": "2022-03-21T14:35:33Z"
-        }
-      }
-    },
-    "SetRoleAssignmentsCommand": {
-      "type": "object",
-      "properties": {
-        "service_accounts": {
-          "type": "array",
-          "items": {
-            "type": "integer",
-            "format": "int64"
-          }
-        },
-        "teams": {
-          "type": "array",
-          "items": {
-            "type": "integer",
-            "format": "int64"
-          }
-        },
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "integer",
-            "format": "int64"
-          }
         }
       }
     },
@@ -19596,12 +19509,6 @@
         }
       }
     },
-    "getRoleAssignmentsResponse": {
-      "description": "(empty)",
-      "schema": {
-        "$ref": "#/definitions/RoleAssignmentsDTO"
-      }
-    },
     "getRoleResponse": {
       "description": "(empty)",
       "schema": {
@@ -20007,12 +19914,6 @@
         "$ref": "#/definitions/SearchUserQueryResult"
       }
     },
-    "setRoleAssignmentsResponse": {
-      "description": "(empty)",
-      "schema": {
-        "$ref": "#/definitions/RoleAssignmentsDTO"
-      }
-    },
     "testAlertResponse": {
       "description": "(empty)",
       "schema": {
@@ -20074,6 +19975,17 @@
       "description": "(empty)",
       "schema": {
         "$ref": "#/definitions/UserProfileDTO"
+      }
+    },
+    "validateDashboardResponse": {
+      "description": "(empty)",
+      "headers": {
+        "isValid": {
+          "type": "boolean"
+        },
+        "message": {
+          "type": "string"
+        }
       }
     }
   },

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -121,6 +121,22 @@
         ],
         "summary": "Update a custom role.",
         "operationId": "updateRole",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UpdateRoleCommand"
+            }
+          },
+          {
+            "type": "string",
+            "name": "roleUID",
+            "in": "path",
+            "required": true
+          }
+        ],
         "responses": {
           "200": {
             "$ref": "#/responses/getRoleResponse"
@@ -147,6 +163,24 @@
         ],
         "summary": "Delete a custom role.",
         "operationId": "deleteRole",
+        "parameters": [
+          {
+            "type": "boolean",
+            "name": "force",
+            "in": "query"
+          },
+          {
+            "type": "boolean",
+            "name": "global",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "name": "roleUID",
+            "in": "path",
+            "required": true
+          }
+        ],
         "responses": {
           "200": {
             "$ref": "#/responses/okResponse"
@@ -172,6 +206,14 @@
         ],
         "summary": "Get role assignments.",
         "operationId": "getRoleAssignments",
+        "parameters": [
+          {
+            "type": "string",
+            "name": "roleUID",
+            "in": "path",
+            "required": true
+          }
+        ],
         "responses": {
           "200": {
             "$ref": "#/responses/getRoleAssignmentsResponse"
@@ -195,6 +237,22 @@
         ],
         "summary": "Set role assignments.",
         "operationId": "setRoleAssignments",
+        "parameters": [
+          {
+            "type": "string",
+            "name": "roleUID",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SetRoleAssignmentsCommand"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "$ref": "#/responses/setRoleAssignmentsResponse"
@@ -15977,6 +16035,35 @@
         }
       }
     },
+    "RoleAssignmentsDTO": {
+      "type": "object",
+      "properties": {
+        "role_uid": {
+          "type": "string"
+        },
+        "service_accounts": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        "teams": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      }
+    },
     "RoleDTO": {
       "type": "object",
       "properties": {
@@ -16533,6 +16620,32 @@
           "type": "string",
           "format": "date-time",
           "example": "2022-03-21T14:35:33Z"
+        }
+      }
+    },
+    "SetRoleAssignmentsCommand": {
+      "type": "object",
+      "properties": {
+        "service_accounts": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        "teams": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "int64"
+          }
         }
       }
     },
@@ -19509,6 +19622,12 @@
         }
       }
     },
+    "getRoleAssignmentsResponse": {
+      "description": "(empty)",
+      "schema": {
+        "$ref": "#/definitions/RoleAssignmentsDTO"
+      }
+    },
     "getRoleResponse": {
       "description": "(empty)",
       "schema": {
@@ -19912,6 +20031,12 @@
       "description": "(empty)",
       "schema": {
         "$ref": "#/definitions/SearchUserQueryResult"
+      }
+    },
+    "setRoleAssignmentsResponse": {
+      "description": "(empty)",
+      "schema": {
+        "$ref": "#/definitions/RoleAssignmentsDTO"
       }
     },
     "testAlertResponse": {

--- a/public/api-spec.json
+++ b/public/api-spec.json
@@ -121,6 +121,22 @@
         ],
         "summary": "Update a custom role.",
         "operationId": "updateRole",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UpdateRoleCommand"
+            }
+          },
+          {
+            "type": "string",
+            "name": "roleUID",
+            "in": "path",
+            "required": true
+          }
+        ],
         "responses": {
           "200": {
             "$ref": "#/responses/getRoleResponse"
@@ -147,6 +163,24 @@
         ],
         "summary": "Delete a custom role.",
         "operationId": "deleteRole",
+        "parameters": [
+          {
+            "type": "boolean",
+            "name": "force",
+            "in": "query"
+          },
+          {
+            "type": "boolean",
+            "name": "global",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "name": "roleUID",
+            "in": "path",
+            "required": true
+          }
+        ],
         "responses": {
           "200": {
             "$ref": "#/responses/okResponse"
@@ -172,6 +206,14 @@
         ],
         "summary": "Get role assignments.",
         "operationId": "getRoleAssignments",
+        "parameters": [
+          {
+            "type": "string",
+            "name": "roleUID",
+            "in": "path",
+            "required": true
+          }
+        ],
         "responses": {
           "200": {
             "$ref": "#/responses/getRoleAssignmentsResponse"
@@ -195,6 +237,22 @@
         ],
         "summary": "Set role assignments.",
         "operationId": "setRoleAssignments",
+        "parameters": [
+          {
+            "type": "string",
+            "name": "roleUID",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SetRoleAssignmentsCommand"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "$ref": "#/responses/setRoleAssignmentsResponse"
@@ -13369,6 +13427,35 @@
         }
       }
     },
+    "RoleAssignmentsDTO": {
+      "type": "object",
+      "properties": {
+        "role_uid": {
+          "type": "string"
+        },
+        "service_accounts": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        "teams": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      }
+    },
     "RoleDTO": {
       "type": "object",
       "properties": {
@@ -13669,6 +13756,32 @@
           "type": "string",
           "format": "date-time",
           "example": "2022-03-21T14:35:33Z"
+        }
+      }
+    },
+    "SetRoleAssignmentsCommand": {
+      "type": "object",
+      "properties": {
+        "service_accounts": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        "teams": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "int64"
+          }
         }
       }
     },
@@ -15549,6 +15662,12 @@
         }
       }
     },
+    "getRoleAssignmentsResponse": {
+      "description": "",
+      "schema": {
+        "$ref": "#/definitions/RoleAssignmentsDTO"
+      }
+    },
     "getRoleResponse": {
       "description": "",
       "schema": {
@@ -15952,6 +16071,12 @@
       "description": "",
       "schema": {
         "$ref": "#/definitions/SearchUserQueryResult"
+      }
+    },
+    "setRoleAssignmentsResponse": {
+      "description": "",
+      "schema": {
+        "$ref": "#/definitions/RoleAssignmentsDTO"
       }
     },
     "testAlertResponse": {

--- a/public/api-spec.json
+++ b/public/api-spec.json
@@ -121,22 +121,6 @@
         ],
         "summary": "Update a custom role.",
         "operationId": "updateRole",
-        "parameters": [
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/UpdateRoleCommand"
-            }
-          },
-          {
-            "type": "string",
-            "name": "roleUID",
-            "in": "path",
-            "required": true
-          }
-        ],
         "responses": {
           "200": {
             "$ref": "#/responses/getRoleResponse"
@@ -163,24 +147,6 @@
         ],
         "summary": "Delete a custom role.",
         "operationId": "deleteRole",
-        "parameters": [
-          {
-            "type": "boolean",
-            "name": "force",
-            "in": "query"
-          },
-          {
-            "type": "boolean",
-            "name": "global",
-            "in": "query"
-          },
-          {
-            "type": "string",
-            "name": "roleUID",
-            "in": "path",
-            "required": true
-          }
-        ],
         "responses": {
           "200": {
             "$ref": "#/responses/okResponse"
@@ -206,14 +172,6 @@
         ],
         "summary": "Get role assignments.",
         "operationId": "getRoleAssignments",
-        "parameters": [
-          {
-            "type": "string",
-            "name": "roleUID",
-            "in": "path",
-            "required": true
-          }
-        ],
         "responses": {
           "200": {
             "$ref": "#/responses/getRoleAssignmentsResponse"
@@ -237,22 +195,6 @@
         ],
         "summary": "Set role assignments.",
         "operationId": "setRoleAssignments",
-        "parameters": [
-          {
-            "type": "string",
-            "name": "roleUID",
-            "in": "path",
-            "required": true
-          },
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/SetRoleAssignmentsCommand"
-            }
-          }
-        ],
         "responses": {
           "200": {
             "$ref": "#/responses/setRoleAssignmentsResponse"
@@ -3272,6 +3214,32 @@
           },
           "404": {
             "$ref": "#/responses/notFoundError"
+          },
+          "500": {
+            "$ref": "#/responses/internalServerError"
+          }
+        }
+      }
+    },
+    "/dashboards/validate": {
+      "post": {
+        "description": "Validates a dashboard JSON against the schema",
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "dashboards"
+        ],
+        "operationId": "validateDashboard",
+        "responses": {
+          "200": {
+            "$ref": "#/responses/validateDashboardResponse"
+          },
+          "401": {
+            "$ref": "#/responses/unauthorisedError"
+          },
+          "403": {
+            "$ref": "#/responses/forbiddenError"
           },
           "500": {
             "$ref": "#/responses/internalServerError"
@@ -13401,35 +13369,6 @@
         }
       }
     },
-    "RoleAssignmentsDTO": {
-      "type": "object",
-      "properties": {
-        "role_uid": {
-          "type": "string"
-        },
-        "service_accounts": {
-          "type": "array",
-          "items": {
-            "type": "integer",
-            "format": "int64"
-          }
-        },
-        "teams": {
-          "type": "array",
-          "items": {
-            "type": "integer",
-            "format": "int64"
-          }
-        },
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "integer",
-            "format": "int64"
-          }
-        }
-      }
-    },
     "RoleDTO": {
       "type": "object",
       "properties": {
@@ -13730,32 +13669,6 @@
           "type": "string",
           "format": "date-time",
           "example": "2022-03-21T14:35:33Z"
-        }
-      }
-    },
-    "SetRoleAssignmentsCommand": {
-      "type": "object",
-      "properties": {
-        "service_accounts": {
-          "type": "array",
-          "items": {
-            "type": "integer",
-            "format": "int64"
-          }
-        },
-        "teams": {
-          "type": "array",
-          "items": {
-            "type": "integer",
-            "format": "int64"
-          }
-        },
-        "users": {
-          "type": "array",
-          "items": {
-            "type": "integer",
-            "format": "int64"
-          }
         }
       }
     },
@@ -15636,12 +15549,6 @@
         }
       }
     },
-    "getRoleAssignmentsResponse": {
-      "description": "",
-      "schema": {
-        "$ref": "#/definitions/RoleAssignmentsDTO"
-      }
-    },
     "getRoleResponse": {
       "description": "",
       "schema": {
@@ -16047,12 +15954,6 @@
         "$ref": "#/definitions/SearchUserQueryResult"
       }
     },
-    "setRoleAssignmentsResponse": {
-      "description": "",
-      "schema": {
-        "$ref": "#/definitions/RoleAssignmentsDTO"
-      }
-    },
     "testAlertResponse": {
       "description": "",
       "schema": {
@@ -16114,6 +16015,17 @@
       "description": "",
       "schema": {
         "$ref": "#/definitions/UserProfileDTO"
+      }
+    },
+    "validateDashboardResponse": {
+      "description": "",
+      "headers": {
+        "isValid": {
+          "type": "boolean"
+        },
+        "message": {
+          "type": "string"
+        }
       }
     }
   },

--- a/public/api-spec.json
+++ b/public/api-spec.json
@@ -3279,32 +3279,6 @@
         }
       }
     },
-    "/dashboards/validate": {
-      "post": {
-        "description": "Validates a dashboard JSON against the schema",
-        "produces": [
-          "application/json"
-        ],
-        "tags": [
-          "dashboards"
-        ],
-        "operationId": "validateDashboard",
-        "responses": {
-          "200": {
-            "$ref": "#/responses/validateDashboardResponse"
-          },
-          "401": {
-            "$ref": "#/responses/unauthorisedError"
-          },
-          "403": {
-            "$ref": "#/responses/forbiddenError"
-          },
-          "500": {
-            "$ref": "#/responses/internalServerError"
-          }
-        }
-      }
-    },
     "/datasources": {
       "get": {
         "description": "If you are running Grafana Enterprise and have Fine-grained access control enabled\nyou need to have a permission with action: `datasources:read` and scope: `datasources:*`.",

--- a/public/app/features/dashboard/components/SaveDashboard/DashboardValidation.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/DashboardValidation.tsx
@@ -1,0 +1,63 @@
+import { css } from '@emotion/css';
+import React from 'react';
+import { useAsync } from 'react-use';
+
+import { GrafanaTheme2 } from '@grafana/data';
+import { Alert, useStyles2 } from '@grafana/ui';
+import { backendSrv } from 'app/core/services/backend_srv';
+
+import { DashboardModel } from '../../state';
+
+interface DashboardValidationProps {
+  dashboard: DashboardModel;
+}
+
+function DashboardValidation({ dashboard }: DashboardValidationProps) {
+  const styles = useStyles2(getStyles);
+
+  const { loading, value, error } = useAsync(async () => {
+    const saveModel = dashboard.getSaveModelClone();
+    const validationResponse = await backendSrv.validateDashboard(saveModel);
+    return validationResponse;
+  }, [dashboard]);
+
+  let alert: React.ReactNode;
+
+  if (loading) {
+    alert = <Alert severity="info" title="Checking dashboard validity" />;
+  } else if (value) {
+    if (!value.isValid) {
+      alert = (
+        <Alert severity="warning" title="Dashboard failed validation">
+          <div className={styles.error}>{value.message}</div>
+        </Alert>
+      );
+    }
+  } else {
+    const errorMessage = error?.message ?? error?.toString?.() ?? 'Unknown error';
+    alert = (
+      <Alert severity="info" title="Error checking dashboard validity">
+        <div className={styles.error}>{errorMessage}</div>
+      </Alert>
+    );
+  }
+
+  if (alert) {
+    return <div className={styles.root}>{alert}</div>;
+  }
+
+  return null;
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  root: css({
+    marginTop: theme.spacing(1),
+  }),
+  error: css({
+    whiteSpace: 'pre-wrap',
+    overflowX: 'auto',
+    maxWidth: '100%',
+  }),
+});
+
+export default DashboardValidation;

--- a/public/app/features/dashboard/components/SaveDashboard/DashboardValidation.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/DashboardValidation.tsx
@@ -26,18 +26,24 @@ function DashboardValidation({ dashboard }: DashboardValidationProps) {
   if (loading) {
     alert = <Alert severity="info" title="Checking dashboard validity" />;
   } else if (value) {
+    // API will respond with status 200 even if the dashboard is invalid.
     if (!value.isValid) {
       alert = (
-        <Alert severity="warning" title="Dashboard failed validation">
+        <Alert severity="warning" title="Dashboard failed schema validation">
+          <p>
+            Validation is provided for development purposes and should be safe to ignore. If you are a Grafana
+            developer, consider checking and updating the dashboard schema
+          </p>
           <div className={styles.error}>{value.message}</div>
         </Alert>
       );
     }
   } else {
+    // non-200 response from the API. This shouldn't happen normally
     const errorMessage = error?.message ?? error?.toString?.() ?? 'Unknown error';
     alert = (
       <Alert severity="info" title="Error checking dashboard validity">
-        <div className={styles.error}>{errorMessage}</div>
+        <p className={styles.error}>{errorMessage}</p>
       </Alert>
     );
   }
@@ -54,6 +60,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     marginTop: theme.spacing(1),
   }),
   error: css({
+    fontFamily: theme.typography.fontFamilyMonospace,
     whiteSpace: 'pre-wrap',
     overflowX: 'auto',
     maxWidth: '100%',

--- a/public/app/features/dashboard/components/SaveDashboard/DashboardValidation.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/DashboardValidation.tsx
@@ -53,9 +53,8 @@ function DashboardValidation({ dashboard }: DashboardValidationProps) {
       );
     }
   } else {
-    console.log('error', error);
     // non-200 response from the API. This shouldn't happen normally
-    const errorMessage = error?.message ?? error?.toString?.() ?? 'Unknown error';
+    const errorMessage = error?.message ?? 'Unknown error';
     alert = (
       <Alert severity="info" title="Error checking dashboard validity">
         <p className={styles.error}>{errorMessage}</p>

--- a/public/app/features/dashboard/components/SaveDashboard/SaveDashboardDrawer.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/SaveDashboardDrawer.tsx
@@ -7,6 +7,7 @@ import { backendSrv } from 'app/core/services/backend_srv';
 
 import { jsonDiff } from '../VersionHistory/utils';
 
+import DashboardValidation from './DashboardValidation';
 import { SaveDashboardDiff } from './SaveDashboardDiff';
 import { SaveDashboardErrorProxy } from './SaveDashboardErrorProxy';
 import { SaveDashboardAsForm } from './forms/SaveDashboardAsForm';
@@ -68,7 +69,7 @@ export const SaveDashboardDrawer = ({ dashboard, onDismiss, onSaveSuccess, isCop
       }
     : onDismiss;
 
-  const renderBody = () => {
+  const renderSaveBody = () => {
     if (showDiff) {
       return <SaveDashboardDiff diff={data.diff} oldValue={previous.value} newValue={data.clone} />;
     }
@@ -161,7 +162,9 @@ export const SaveDashboardDrawer = ({ dashboard, onDismiss, onSaveSuccess, isCop
       expandable
       scrollableContent
     >
-      {renderBody()}
+      {renderSaveBody()}
+
+      {config.featureToggles.showDashboardValidationWarnings && <DashboardValidation dashboard={dashboard} />}
     </Drawer>
   );
 };

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -1731,6 +1731,21 @@
           }
         },
         "description": "(empty)"
+      },
+      "validateDashboardResponse": {
+        "description": "(empty)",
+        "headers": {
+          "isValid": {
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          "message": {
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
       }
     },
     "schemas": {
@@ -14510,6 +14525,29 @@
         "summary": "Get a specific dashboard version using UID.",
         "tags": [
           "dashboard_versions"
+        ]
+      }
+    },
+    "/dashboards/validate": {
+      "post": {
+        "description": "Validates a dashboard JSON against the schema",
+        "operationId": "validateDashboard",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/validateDashboardResponse"
+          },
+          "401": {
+            "$ref": "#/components/responses/unauthorisedError"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbiddenError"
+          },
+          "500": {
+            "$ref": "#/components/responses/internalServerError"
+          }
+        },
+        "tags": [
+          "dashboards"
         ]
       }
     },

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -14528,29 +14528,6 @@
         ]
       }
     },
-    "/dashboards/validate": {
-      "post": {
-        "description": "Validates a dashboard JSON against the schema",
-        "operationId": "validateDashboard",
-        "responses": {
-          "200": {
-            "$ref": "#/components/responses/validateDashboardResponse"
-          },
-          "401": {
-            "$ref": "#/components/responses/unauthorisedError"
-          },
-          "403": {
-            "$ref": "#/components/responses/forbiddenError"
-          },
-          "500": {
-            "$ref": "#/components/responses/internalServerError"
-          }
-        },
-        "tags": [
-          "dashboards"
-        ]
-      }
-    },
     "/datasources": {
       "get": {
         "description": "If you are running Grafana Enterprise and have Fine-grained access control enabled\nyou need to have a permission with action: `datasources:read` and scope: `datasources:*`.",


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds a warning to the Save Dashboard drawer when a dashboard does not pass cue schema validation. See #55684 for more context.

 - Adds a feature flag showDashboardValidationWarnings
 - Adds a new API endpoint `POST /api/dashboards/validate` to return the validation status for a dashboard JSON
 - Adds component to validate and show warning when a dashboard does not pass schema validation, gated behind showDashboardValidationWarnings feature flag
   - In a later PR (soon hopefully!) we will enable this feature flag by default during development

![image](https://user-images.githubusercontent.com/46142/192256541-71ffcae6-aef6-4a0c-98f4-0649c39a9c1f.png)

![image](https://user-images.githubusercontent.com/46142/192256635-ec376c1e-6f47-4674-bbcc-59815b79309d.png)

**Which issue(s) this PR fixes**:

Part of #55684

**Special notes for your reviewer**:

Happy for feedback on the warning message in the frontend. Currently it reads:

> Validation is provided for development purposes and should be safe to ignore. If you are a Grafana developer, consider checking and updating the dashboard schema

Because the goal is to turn this on by default for all developers, I want to try and avoid people thinking they're blocked by this if you're not working on dashboard model/schema things. Eventually, I think we could include a link to a Github issue/discussion for people to share invalid dashboards?

Not sure what to do about, or how to approach, tests for the backend? Would appreciate some pointers here

