### PR TITLE
Library panels: Add backend route

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -155,6 +155,7 @@ func (hs *HTTPServer) registerRoutes() {
 	r.Get("/playlists/*", reqSignedIn, hs.Index)
 	r.Get("/alerting/", reqSignedIn, hs.Index)
 	r.Get("/alerting/*", reqSignedIn, hs.Index)
+	r.Get("/library-panels/", reqSignedIn, hs.Index)
 
 	// sign up
 	r.Get("/verify", hs.Index)


### PR DESCRIPTION
Fixes https://github.com/grafana/support-escalations/issues/4065

We were missing backend route for `/library-panels` causing 404 being thrown on when accessing library panels page by url (not as a consequence of navigation in grafana).