### PR TITLE
Loki: Show invalid fields in label filter

### DIFF
--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilder.test.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilder.test.tsx
@@ -4,10 +4,11 @@ import React from 'react';
 
 import { DataSourceInstanceSettings, DataSourcePluginMeta } from '@grafana/data';
 
+import { MISSING_LABEL_FILTER_ERROR_MESSAGE } from '../../../prometheus/querybuilder/shared/LabelFilters';
 import { LokiDatasource } from '../../datasource';
 import { LokiOperationId, LokiVisualQuery } from '../types';
 
-import { MISSING_LABEL_FILTER_ERROR_MESSAGE, LokiQueryBuilder } from './LokiQueryBuilder';
+import { LokiQueryBuilder } from './LokiQueryBuilder';
 import { EXPLAIN_LABEL_FILTER_CONTENT } from './LokiQueryBuilderExplained';
 
 const defaultQuery: LokiVisualQuery = {

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilder.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilder.tsx
@@ -31,8 +31,6 @@ export interface Props {
   onChange: (update: LokiVisualQuery) => void;
   onRunQuery: () => void;
 }
-export const MISSING_LABEL_FILTER_ERROR_MESSAGE = 'Select at least 1 label filter (label and value)';
-
 export const LokiQueryBuilder = React.memo<Props>(({ datasource, query, onChange, onRunQuery, showExplain }) => {
   const [sampleData, setSampleData] = useState<PanelData>();
   const [highlightedOp, setHighlightedOp] = useState<QueryBuilderOperation | undefined>(undefined);
@@ -77,16 +75,16 @@ export const LokiQueryBuilder = React.memo<Props>(({ datasource, query, onChange
     return values ? values.map((v) => escapeLabelValueInSelector(v, forLabel.op)) : []; // Escape values in return
   };
 
-  const labelFilterError: string | undefined = useMemo(() => {
+  const labelFilterRequiredError: boolean = useMemo(() => {
     const { labels, operations: op } = query;
     if (!labels.length && op.length) {
-      // We don't want to show error for initial state with empty line contains operation
+      // Filter is required when operations are present (line contains operation is exception)
       if (op.length === 1 && op[0].id === LokiOperationId.LineContains && op[0].params[0] === '') {
-        return undefined;
+        return false;
       }
-      return MISSING_LABEL_FILTER_ERROR_MESSAGE;
+      return true;
     }
-    return undefined;
+    return false;
   }, [query]);
 
   useEffect(() => {
@@ -113,7 +111,7 @@ export const LokiQueryBuilder = React.memo<Props>(({ datasource, query, onChange
           }
           labelsFilters={query.labels}
           onChange={onChangeLabels}
-          error={labelFilterError}
+          labelFilterRequired={labelFilterRequired}
         />
       </EditorRow>
       {showExplain && (

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilder.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilder.tsx
@@ -75,7 +75,7 @@ export const LokiQueryBuilder = React.memo<Props>(({ datasource, query, onChange
     return values ? values.map((v) => escapeLabelValueInSelector(v, forLabel.op)) : []; // Escape values in return
   };
 
-  const labelFilterRequiredError: boolean = useMemo(() => {
+  const labelFilterRequired: boolean = useMemo(() => {
     const { labels, operations: op } = query;
     if (!labels.length && op.length) {
       // Filter is required when operations are present (line contains operation is exception)

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilder.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilder.tsx
@@ -78,7 +78,7 @@ export const LokiQueryBuilder = React.memo<Props>(({ datasource, query, onChange
   const labelFilterRequired: boolean = useMemo(() => {
     const { labels, operations: op } = query;
     if (!labels.length && op.length) {
-      // Filter is required when operations are present (line contains operation is exception)
+      // Filter is required when operations are present (empty line contains operation is exception)
       if (op.length === 1 && op[0].id === LokiOperationId.LineContains && op[0].params[0] === '') {
         return false;
       }

--- a/public/app/plugins/datasource/prometheus/querybuilder/shared/LabelFilterItem.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/shared/LabelFilterItem.tsx
@@ -58,7 +58,10 @@ export function LabelFilterItem({
     return uniqBy([...selectedOptions, ...labelValues], 'value');
   };
 
-  // This is necessary to show invalid state on the value in label input
+  /**
+   * !important here is necessary to show invalid border on all 4 sides of select.
+   * Without it, the invalid state is only visible on 3 sides as the right side is overridden in InputGroup.
+   */
   const invalidClassNameOverride = invalidLabel
     ? css`
         margin-left: 0 !important;

--- a/public/app/plugins/datasource/prometheus/querybuilder/shared/LabelFilterItem.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/shared/LabelFilterItem.tsx
@@ -1,3 +1,4 @@
+import { css } from '@emotion/css';
 import { uniqBy } from 'lodash';
 import React, { useState } from 'react';
 
@@ -14,9 +15,20 @@ export interface Props {
   onGetLabelNames: (forLabel: Partial<QueryBuilderLabelFilter>) => Promise<SelectableValue[]>;
   onGetLabelValues: (forLabel: Partial<QueryBuilderLabelFilter>) => Promise<SelectableValue[]>;
   onDelete: () => void;
+  invalidLabel?: boolean;
+  invalidValue?: boolean;
 }
 
-export function LabelFilterItem({ item, defaultOp, onChange, onDelete, onGetLabelNames, onGetLabelValues }: Props) {
+export function LabelFilterItem({
+  item,
+  defaultOp,
+  onChange,
+  onDelete,
+  onGetLabelNames,
+  onGetLabelValues,
+  invalidLabel,
+  invalidValue,
+}: Props) {
   const [state, setState] = useState<{
     labelNames?: SelectableValue[];
     labelValues?: SelectableValue[];
@@ -46,6 +58,13 @@ export function LabelFilterItem({ item, defaultOp, onChange, onDelete, onGetLabe
     return uniqBy([...selectedOptions, ...labelValues], 'value');
   };
 
+  // This is necessary to show invalid state on the value in label input
+  const invalidClassNameOverride = invalidLabel
+    ? css`
+        margin-left: 0 !important;
+      `
+    : '';
+
   return (
     <div data-testid="prometheus-dimensions-filter-item">
       <InputGroup>
@@ -72,6 +91,7 @@ export function LabelFilterItem({ item, defaultOp, onChange, onDelete, onGetLabe
               } as any as QueryBuilderLabelFilter);
             }
           }}
+          invalid={invalidLabel}
         />
 
         <Select
@@ -84,6 +104,7 @@ export function LabelFilterItem({ item, defaultOp, onChange, onDelete, onGetLabe
               onChange({ ...item, op: change.value } as any as QueryBuilderLabelFilter);
             }
           }}
+          className={invalidClassNameOverride}
         />
 
         <Select
@@ -121,6 +142,7 @@ export function LabelFilterItem({ item, defaultOp, onChange, onDelete, onGetLabe
               onChange({ ...item, value: changes, op: item.op ?? defaultOp } as any as QueryBuilderLabelFilter);
             }
           }}
+          invalid={invalidValue}
         />
         <AccessoryButton aria-label="remove" icon="times" variant="secondary" onClick={onDelete} />
       </InputGroup>

--- a/public/app/plugins/datasource/prometheus/querybuilder/shared/LabelFilters.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/shared/LabelFilters.tsx
@@ -8,15 +8,24 @@ import { QueryBuilderLabelFilter } from '../shared/types';
 
 import { LabelFilterItem } from './LabelFilterItem';
 
+export const MISSING_LABEL_FILTER_ERROR_MESSAGE = 'Select at least 1 label filter (label and value)';
+
 export interface Props {
   labelsFilters: QueryBuilderLabelFilter[];
   onChange: (labelFilters: QueryBuilderLabelFilter[]) => void;
   onGetLabelNames: (forLabel: Partial<QueryBuilderLabelFilter>) => Promise<SelectableValue[]>;
   onGetLabelValues: (forLabel: Partial<QueryBuilderLabelFilter>) => Promise<SelectableValue[]>;
-  error?: string;
+  /** If set to true, component will show error message until at least 1 filter is selected */
+  labelFilterRequired?: boolean;
 }
 
-export function LabelFilters({ labelsFilters, onChange, onGetLabelNames, onGetLabelValues, error }: Props) {
+export function LabelFilters({
+  labelsFilters,
+  onChange,
+  onGetLabelNames,
+  onGetLabelValues,
+  labelFilterRequired,
+}: Props) {
   const defaultOp = '=';
   const [items, setItems] = useState<Array<Partial<QueryBuilderLabelFilter>>>([{ op: defaultOp }]);
 
@@ -38,9 +47,15 @@ export function LabelFilters({ labelsFilters, onChange, onGetLabelNames, onGetLa
     }
   };
 
+  const hasLabelFilter = items.some((item) => item.label && item.value);
+
   return (
     <EditorFieldGroup>
-      <EditorField label="Label filters" error={error} invalid={!!error}>
+      <EditorField
+        label="Label filters"
+        error={MISSING_LABEL_FILTER_ERROR_MESSAGE}
+        invalid={labelFilterRequired && !hasLabelFilter}
+      >
         <EditorList
           items={items}
           onChange={onLabelsChange}
@@ -52,6 +67,8 @@ export function LabelFilters({ labelsFilters, onChange, onGetLabelNames, onGetLa
               onDelete={onDelete}
               onGetLabelNames={onGetLabelNames}
               onGetLabelValues={onGetLabelValues}
+              invalidLabel={labelFilterRequired && !item.label}
+              invalidValue={labelFilterRequired && !item.value}
             />
           )}
         />


### PR DESCRIPTION
**What this PR does / why we need it**:
In this PR, we are:
- refactoring the way how we show _Select at least 1 label filter (label and value)_ message and make it reusable for other data sources that can use `LabelFilters` component
- add invalid borders for label/value if they are not selected

Currently this component is used both in Prometheus and Loki, but only in Loki we need a way to set this as query without label filters is invalid. In Prometheus, query without label filters is valid.
 
This is final part of changes related to Query patterns. It is relevant to query patterns, because **the main reason** to have it is to notify users that besides query pattern, they still need to select label filter.  However, we want to display it every time when we add any operation, with exception of empty line contains.

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/grafana/issues/52090

**Special notes for your reviewer**:
1. Run `make devenv sources=loki`
2. Go to Explore and choose `gdev-loki` data source
3. Switch to builder mode
4. Add operations/remove operations and observe if label filter error message correctly appears

https://user-images.githubusercontent.com/30407135/192301372-2823a248-f222-45e7-8634-7d270136e269.mov

