### PR TITLE
AzureMonitor: Add region params

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -2772,11 +2772,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"]
     ],
-    "public/app/core/mod_defs.d.ts:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "2"]
-    ],
     "public/app/core/navigation/GrafanaRoute.test.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"],

--- a/.betterer.results
+++ b/.betterer.results
@@ -2772,6 +2772,11 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"]
     ],
+    "public/app/core/mod_defs.d.ts:5381": [
+      [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "2"]
+    ],
     "public/app/core/navigation/GrafanaRoute.test.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"],

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/resourcePicker/resourcePickerData.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/resourcePicker/resourcePickerData.ts
@@ -350,7 +350,7 @@ export default class ResourcePickerData extends DataSourceWithBackend<AzureMonit
         {
           resourceUri: `/subscriptions/${subscription.id}`,
         },
-        false
+        true
       );
       if (namespaces) {
         const namespaceVals = namespaces.map((namespace) => `"${namespace.value.toLocaleLowerCase()}"`);


### PR DESCRIPTION
Quick fix for a bug introduced in #53203 which prevents resources from being loaded in the resource picker.