### PR TITLE
JS Agent: remove user email and add session id

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -2772,11 +2772,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"]
     ],
-    "public/app/core/mod_defs.d.ts:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "2"]
-    ],
     "public/app/core/navigation/GrafanaRoute.test.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"],

--- a/public/app/core/services/echo/backends/grafana-javascript-agent/GrafanaJavascriptAgentBackend.test.ts
+++ b/public/app/core/services/echo/backends/grafana-javascript-agent/GrafanaJavascriptAgentBackend.test.ts
@@ -115,7 +115,6 @@ describe('GrafanaJavascriptAgentEchoBackend', () => {
     expect(mockedSetUser).toHaveBeenCalledTimes(1);
     expect(mockedSetUser).toHaveBeenCalledWith({
       id: '504',
-      email: 'darth.vader@sith.glx',
       attributes: {
         orgId: '1',
       },

--- a/public/app/core/services/echo/backends/grafana-javascript-agent/GrafanaJavascriptAgentBackend.ts
+++ b/public/app/core/services/echo/backends/grafana-javascript-agent/GrafanaJavascriptAgentBackend.ts
@@ -1,6 +1,7 @@
 import { BaseTransport } from '@grafana/agent-core';
 import {
   initializeAgent,
+  defaultMetas,
   BrowserConfig,
   ErrorsInstrumentation,
   ConsoleInstrumentation,
@@ -63,12 +64,20 @@ export class GrafanaJavascriptAgentBackend
         'ResizeObserver loop completed',
         'Non-Error exception captured with keys',
       ],
+      metas: [
+        ...defaultMetas,
+        {
+          session: {
+            // new session id for every page load
+            id: (Math.random() + 1).toString(36).substring(2),
+          },
+        },
+      ],
     };
     this.agentInstance = initializeAgent(grafanaJavaScriptAgentOptions);
 
     if (options.user) {
       this.agentInstance.api.setUser({
-        email: options.user.email,
         id: options.user.id,
         attributes: {
           orgId: String(options.user.orgId) || '',


### PR DESCRIPTION
As we're adding user activity tracking using the [Grafana Javascript Agent](https://github.com/grafana/grafana-javascript-agent), we noted the user email address was being sent by default. As this is sensitive information, this PR removes as it doesn't seem to be used for anything in particular.

Also, we're setting the session id to the agent so that we can obtain more meaningful data (same way as done here https://github.com/grafana/incident/blob/main/plugin/src/agent.tsx#L23-L31).

Part of https://github.com/grafana/grafana/issues/54904

