### PR TITLE
Alerting: Remove dead functionality from alert instance store

### DIFF
--- a/pkg/services/ngalert/models/instance.go
+++ b/pkg/services/ngalert/models/instance.go
@@ -56,16 +56,6 @@ type SaveAlertInstanceCommand struct {
 	CurrentStateEnd   time.Time
 }
 
-// GetAlertInstanceQuery is the query for retrieving/deleting an alert definition by ID.
-// nolint:unused
-type GetAlertInstanceQuery struct {
-	RuleOrgID int64
-	RuleUID   string
-	Labels    InstanceLabels
-
-	Result *AlertInstance
-}
-
 // ListAlertInstancesQuery is the query list alert Instances.
 type ListAlertInstancesQuery struct {
 	RuleOrgID   int64 `json:"-"`

--- a/pkg/services/ngalert/store/instance_database.go
+++ b/pkg/services/ngalert/store/instance_database.go
@@ -2,45 +2,11 @@ package store
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 )
-
-// GetAlertInstance is a handler for retrieving an alert instance based on OrgId, AlertDefintionID, and
-// the hash of the labels.
-func (st DBstore) GetAlertInstance(ctx context.Context, cmd *models.GetAlertInstanceQuery) error {
-	return st.SQLStore.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
-		instance := models.AlertInstance{}
-		s := strings.Builder{}
-		s.WriteString(`SELECT * FROM alert_instance
-			WHERE
-				rule_org_id=? AND
-				rule_uid=? AND
-				labels_hash=?
-		`)
-
-		_, hash, err := cmd.Labels.StringAndHash()
-		if err != nil {
-			return err
-		}
-
-		params := append(make([]interface{}, 0), cmd.RuleOrgID, cmd.RuleUID, hash)
-
-		has, err := sess.SQL(s.String(), params...).Get(&instance)
-		if !has {
-			return fmt.Errorf("instance not found for labels %v (hash: %v), alert rule %v (org %v)", cmd.Labels, hash, cmd.RuleUID, cmd.RuleOrgID)
-		}
-		if err != nil {
-			return err
-		}
-
-		cmd.Result = &instance
-		return nil
-	})
-}
 
 // ListAlertInstances is a handler for retrieving alert instances within specific organisation
 // based on various filters.

--- a/pkg/services/ngalert/store/instance_database_test.go
+++ b/pkg/services/ngalert/store/instance_database_test.go
@@ -44,19 +44,18 @@ func TestIntegrationAlertInstanceOperations(t *testing.T) {
 		err := dbstore.SaveAlertInstance(ctx, saveCmd)
 		require.NoError(t, err)
 
-		getCmd := &models.GetAlertInstanceQuery{
+		listCmd := &models.ListAlertInstancesQuery{
 			RuleOrgID: saveCmd.RuleOrgID,
 			RuleUID:   saveCmd.RuleUID,
-			Labels:    models.InstanceLabels{"test": "testValue"},
 		}
-
-		err = dbstore.GetAlertInstance(ctx, getCmd)
+		err = dbstore.ListAlertInstances(ctx, listCmd)
 		require.NoError(t, err)
 
-		require.Equal(t, saveCmd.Labels, getCmd.Result.Labels)
-		require.Equal(t, alertRule1.OrgID, getCmd.Result.RuleOrgID)
-		require.Equal(t, alertRule1.UID, getCmd.Result.RuleUID)
-		require.Equal(t, saveCmd.StateReason, getCmd.Result.CurrentReason)
+		require.Len(t, listCmd.Result, 1)
+		require.Equal(t, saveCmd.Labels, listCmd.Result[0].Labels)
+		require.Equal(t, alertRule1.OrgID, listCmd.Result[0].RuleOrgID)
+		require.Equal(t, alertRule1.UID, listCmd.Result[0].RuleUID)
+		require.Equal(t, saveCmd.StateReason, listCmd.Result[0].CurrentReason)
 	})
 
 	t.Run("can save and read new alert instance with no labels", func(t *testing.T) {
@@ -69,17 +68,18 @@ func TestIntegrationAlertInstanceOperations(t *testing.T) {
 		err := dbstore.SaveAlertInstance(ctx, saveCmd)
 		require.NoError(t, err)
 
-		getCmd := &models.GetAlertInstanceQuery{
+		listCmd := &models.ListAlertInstancesQuery{
 			RuleOrgID: saveCmd.RuleOrgID,
 			RuleUID:   saveCmd.RuleUID,
 		}
 
-		err = dbstore.GetAlertInstance(ctx, getCmd)
+		err = dbstore.ListAlertInstances(ctx, listCmd)
 		require.NoError(t, err)
 
-		require.Equal(t, alertRule2.OrgID, getCmd.Result.RuleOrgID)
-		require.Equal(t, alertRule2.UID, getCmd.Result.RuleUID)
-		require.Equal(t, saveCmd.Labels, getCmd.Result.Labels)
+		require.Len(t, listCmd.Result, 1)
+		require.Equal(t, alertRule2.OrgID, listCmd.Result[0].RuleOrgID)
+		require.Equal(t, alertRule2.UID, listCmd.Result[0].RuleUID)
+		require.Equal(t, saveCmd.Labels, listCmd.Result[0].Labels)
 	})
 
 	t.Run("can save two instances with same org_id, uid and different labels", func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Previous PR https://github.com/grafana/grafana/pull/55772 uncovered some functionality in the instance store that is unused (GetAlertInstance) aside from tests on it. The newer `ListAlertInstances` is nearly superset of the functionality as it still offers filtering. This PR removes the dead, older API.

**Which issue(s) this PR fixes**:

Contributes to https://github.com/grafana/grafana/issues/55770

**Special notes for your reviewer**:

