### PR TITLE
PublicDashboards: Allow disabling an existent public dashboard if it …

### DIFF
--- a/pkg/services/publicdashboards/service/service.go
+++ b/pkg/services/publicdashboards/service/service.go
@@ -96,12 +96,8 @@ func (pd *PublicDashboardServiceImpl) GetPublicDashboardConfig(ctx context.Conte
 // SavePublicDashboardConfig is a helper method to persist the sharing config
 // to the database. It handles validations for sharing config and persistence
 func (pd *PublicDashboardServiceImpl) SavePublicDashboardConfig(ctx context.Context, u *user.SignedInUser, dto *SavePublicDashboardConfigDTO) (*PublicDashboard, error) {
+	// validate if the dashboard exists
 	dashboard, err := pd.GetDashboard(ctx, dto.DashboardUid)
-	if err != nil {
-		return nil, err
-	}
-
-	err = validation.ValidateSavePublicDashboard(dto, dashboard)
 	if err != nil {
 		return nil, err
 	}
@@ -120,6 +116,10 @@ func (pd *PublicDashboardServiceImpl) SavePublicDashboardConfig(ctx context.Cont
 	// save changes
 	var pubdashUid string
 	if existingPubdash == nil {
+		err = validation.ValidateSavePublicDashboard(dto, dashboard)
+		if err != nil {
+			return nil, err
+		}
 		pubdashUid, err = pd.savePublicDashboardConfig(ctx, dto)
 	} else {
 		pubdashUid, err = pd.updatePublicDashboardConfig(ctx, dto)

--- a/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/Configuration.tsx
+++ b/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/Configuration.tsx
@@ -13,14 +13,12 @@ import { getTimeRange } from 'app/features/dashboard/utils/timeRange';
 export const Configuration = ({
   disabled,
   isPubDashEnabled,
-  hasTemplateVariables,
   onToggleEnabled,
   dashboard,
 }: {
   disabled: boolean;
   isPubDashEnabled?: boolean;
   onToggleEnabled: () => void;
-  hasTemplateVariables: boolean;
   dashboard: DashboardModel;
 }) => {
   const selectors = e2eSelectors.pages.ShareDashboardModal.PublicDashboard;
@@ -41,7 +39,6 @@ export const Configuration = ({
           <Layout orientation={isDesktop ? 0 : 1} spacing="xs" justify="space-between">
             <Label description="Configures whether current dashboard can be available publicly">Enabled</Label>
             <Switch
-              disabled={hasTemplateVariables}
               data-testid={selectors.EnableSwitch}
               value={isPubDashEnabled}
               onChange={() => {

--- a/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/SharePublicDashboard.tsx
+++ b/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/SharePublicDashboard.tsx
@@ -160,7 +160,7 @@ export const SharePublicDashboard = (props: Props) => {
               ) : (
                 dashboardHasTemplateVariables(dashboardVariables) && (
                   <Alert
-                    title="If you make this dashboard public it won't work because it has template variables"
+                    title="This public dashboard may not work since it uses template variables"
                     severity="warning"
                   />
                 )

--- a/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/SharePublicDashboard.tsx
+++ b/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/SharePublicDashboard.tsx
@@ -5,8 +5,6 @@ import { GrafanaTheme2 } from '@grafana/data/src';
 import { selectors as e2eSelectors } from '@grafana/e2e-selectors/src';
 import { reportInteraction } from '@grafana/runtime/src';
 import { Alert, Button, ClipboardButton, Field, HorizontalGroup, Input, useStyles2, Spinner } from '@grafana/ui/src';
-import { notifyApp } from 'app/core/actions';
-import { createErrorNotification } from 'app/core/copy/appNotification';
 import { contextSrv } from 'app/core/services/context_srv';
 import { useGetConfigQuery, useSaveConfigMutation } from 'app/features/dashboard/api/publicDashboardApi';
 import { AcknowledgeCheckboxes } from 'app/features/dashboard/components/ShareModal/SharePublicDashboard/AcknowledgeCheckboxes';
@@ -20,7 +18,6 @@ import {
 } from 'app/features/dashboard/components/ShareModal/SharePublicDashboard/SharePublicDashboardUtils';
 import { ShareModalTabProps } from 'app/features/dashboard/components/ShareModal/types';
 import { isOrgAdmin } from 'app/features/plugins/admin/permissions';
-import { dispatch } from 'app/store/store';
 import { AccessControlAction } from 'app/types';
 
 interface Props extends ShareModalTabProps {}
@@ -81,13 +78,6 @@ export const SharePublicDashboard = (props: Props) => {
   const onSavePublicConfig = () => {
     reportInteraction('grafana_dashboards_public_create_clicked');
 
-    if (dashboardHasTemplateVariables(dashboardVariables)) {
-      dispatch(
-        notifyApp(createErrorNotification('This dashboard cannot be made public because it has template variables'))
-      );
-      return;
-    }
-
     saveConfig({
       dashboard: props.dashboard,
       payload: { ...publicDashboard!, isEnabled: enabledSwitch.isEnabled },
@@ -111,7 +101,7 @@ export const SharePublicDashboard = (props: Props) => {
         {isFetchingLoading && <Spinner />}
       </HorizontalGroup>
       <div className={styles.content}>
-        {dashboardHasTemplateVariables(dashboardVariables) ? (
+        {dashboardHasTemplateVariables(dashboardVariables) && !publicDashboardPersisted(publicDashboard) ? (
           <Alert
             severity="warning"
             title="dashboard cannot be public"
@@ -140,7 +130,6 @@ export const SharePublicDashboard = (props: Props) => {
               onToggleEnabled={() =>
                 setEnabledSwitch((prevState) => ({ isEnabled: !prevState.isEnabled, wasTouched: true }))
               }
-              hasTemplateVariables={dashboardHasTemplateVariables(dashboardVariables)}
             />
             {publicDashboardPersisted(publicDashboard) && enabledSwitch.isEnabled && (
               <Field label="Link URL" className={styles.publicUrl}>
@@ -163,11 +152,18 @@ export const SharePublicDashboard = (props: Props) => {
               </Field>
             )}
             {hasWritePermissions ? (
-              props.dashboard.hasUnsavedChanges() && (
+              props.dashboard.hasUnsavedChanges() ? (
                 <Alert
                   title="Please save your dashboard changes before updating the public configuration"
                   severity="warning"
                 />
+              ) : (
+                dashboardHasTemplateVariables(dashboardVariables) && (
+                  <Alert
+                    title="If you make this dashboard public it won't work because it has template variables"
+                    severity="warning"
+                  />
+                )
               )
             ) : (
               <Alert title="You don't have permissions to create or update a public dashboard" severity="warning" />


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
If a template variable is added after creating a public dashboard there is no way to disable it.
We remove validations allowing a user to update the public dashboard config and added an Alert indicating that the public dashboard won't work
We still are not allowing to create a new public dashboard if the original dashboard has template variables

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana-enterprise/issues/4449

**Special notes for your reviewer**:
New Alert only for updating an existent public dashboard
![image](https://user-images.githubusercontent.com/20256983/190501173-f185b003-75c4-490b-90da-9a4928286a74.png)

Same behavior for public dashboard creation
![image](https://user-images.githubusercontent.com/20256983/190501326-0743c491-96c7-4159-aeb4-495dda979622.png)

