### PR TITLE
Alerting/integrations error feedback handle 404 state not available

### DIFF
--- a/public/app/features/alerting/unified/Receivers.tsx
+++ b/public/app/features/alerting/unified/Receivers.tsx
@@ -36,7 +36,7 @@ const NotificationError: FC<NotificationErrorProps> = ({ errorCount }: Notificat
   const styles = useStyles2(getStyles);
 
   return (
-    <div className={styles.warning}>
+    <div className={styles.warning} data-testid="receivers-notification-error">
       <Stack alignItems="flex-end" direction="column">
         <Stack alignItems="center">
           <Icon name="exclamation-triangle" />

--- a/public/app/features/alerting/unified/api/grafana.ts
+++ b/public/app/features/alerting/unified/api/grafana.ts
@@ -1,5 +1,10 @@
-import { getBackendSrv } from '@grafana/runtime';
+import { lastValueFrom } from 'rxjs';
+
+import { FetchError, getBackendSrv } from '@grafana/runtime';
 import { ContactPointsState, NotifierDTO, ReceiversStateDTO } from 'app/types';
+
+import { isFetchError } from '../../../../../../packages/grafana-runtime/src/services/backendSrv';
+import { getDatasourceAPIUid } from '../utils/datasource';
 
 export function fetchNotifiers(): Promise<NotifierDTO[]> {
   return getBackendSrv().get(`/api/alert-notifiers`);
@@ -56,42 +61,73 @@ export const contactPointsStateDtoToModel = (receiversStateDto: ReceiversStateDT
 export const getIntegrationType = (integrationName: string): string | undefined =>
   parseIntegrationName(integrationName)?.type;
 
-export function fetchContactPointsState(alertManagerSourceName: String): Promise<ContactPointsState> {
-  return new Promise<ContactPointsState>((resolve) => {
-    // Response EXAMPLE
-    //    const fakeResponse = [
-    //   {
-    //     "active": true, // Whether the contact point is used or not.
-    //     "integrations": [ // Can be multiple of the same type. Are identified by the index.
-    //       {
-    //         "lastError": "establish connection to server: dial tcp: lookup smtp.example.org on 8.8.8.8:53: no such host",
-    //         "lastNotify": "2022-09-19T15:34:40.696Z",
-    //         "lastNotifyDuration": "117.2455ms",
-    //         "name": "email[0]"
-    //       },
-    //       {
-    //         "lastError": "establish connection to server: dial tcp: lookup smtp.example.org on 8.8.8.8:53: no such host",
-    //         "lastNotify": "2022-09-19T15:34:40.696Z",
-    //         "lastNotifyDuration": "117.2455ms",
-    //         "name": "email[1]"
-    //       }
-    //     ],
-    //     "name": "multiple3"
-    //   },
-    //   {
-    //     "active": true, // Whether the contact point is used or not.
-    //     "integrations": [ // Can be multiple of the same type. Are identified by the index.
-    //       {
-    //         "lastNotify": "0001-01-01T00:00:00.000Z",
-    //         "lastNotifyDuration": "117.2455ms",
-    //         "name": "email[0]"
-    //       }
-    //     ],
-    //     "name": "grafana-default-email"
-    //   },
-    // ]
+function isContactPointsStateNotAvailable(error: FetchError) {
+  return error.status === 404;
+}
 
-    const fakeState: ContactPointsState = contactPointsStateDtoToModel([]);
+export async function fetchContactPointsState(alertManagerSourceName: string): Promise<ContactPointsState | undefined> {
+  try {
+    const response = await lastValueFrom(
+      getBackendSrv().fetch<ReceiversStateDTO[]>({
+        url: `/api/alertmanager/${getDatasourceAPIUid(alertManagerSourceName)}/config/api/v1/receivers`,
+        showErrorAlert: false,
+        showSuccessAlert: false,
+      })
+    );
+    return contactPointsStateDtoToModel(response.data);
+  } catch (error) {
+    if (isFetchError(error)) {
+      if (!isContactPointsStateNotAvailable(error)) {
+        return contactPointsStateDtoToModel([]);
+      } else {
+        throw error;
+      }
+    } else {
+      throw error;
+    }
+  }
+}
+
+// This method will be removed
+export function fetchContactPointsState_(alertManagerSourceName: String): Promise<ContactPointsState> {
+  return new Promise<ContactPointsState>((resolve, reject) => {
+    // Response EXAMPLE
+    const fakeResponse = [
+      {
+        active: true, // Whether the contact point is used or not.
+        integrations: [
+          // Can be multiple of the same type. Are identified by the index.
+          {
+            lastError: 'establish connection to server: dial tcp: lookup smtp.example.org on 8.8.8.8:53: no such host',
+            lastNotify: '2022-09-19T15:34:40.696Z',
+            lastNotifyDuration: '117.2455ms',
+            name: 'email[0]',
+          },
+          {
+            lastError: 'establish connection to server: dial tcp: lookup smtp.example.org on 8.8.8.8:53: no such host',
+            lastNotify: '2022-09-19T15:34:40.696Z',
+            lastNotifyDuration: '117.2455ms',
+            name: 'email[1]',
+          },
+        ],
+        name: 'multiple3',
+      },
+      {
+        active: true, // Whether the contact point is used or not.
+        integrations: [
+          // Can be multiple of the same type. Are identified by the index.
+          {
+            lastNotify: '0001-01-01T00:00:00.000Z',
+            lastNotifyDuration: '117.2455ms',
+            name: 'email[0]',
+          },
+        ],
+        name: 'grafana-default-email',
+      },
+    ];
+
+    const fakeState: ContactPointsState = contactPointsStateDtoToModel(fakeResponse);
+
     setTimeout(() => {
       resolve(fakeState);
     }, 1000);

--- a/public/app/features/alerting/unified/api/grafana.ts
+++ b/public/app/features/alerting/unified/api/grafana.ts
@@ -65,7 +65,7 @@ function isContactPointsStateNotAvailable(error: FetchError) {
   return error.status === 404;
 }
 
-export async function fetchContactPointsState(alertManagerSourceName: string): Promise<ContactPointsState | undefined> {
+export async function fetchContactPointsState(alertManagerSourceName: string): Promise<ContactPointsState> {
   try {
     const response = await lastValueFrom(
       getBackendSrv().fetch<ReceiversStateDTO[]>({

--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -456,7 +456,7 @@ export const fetchGrafanaNotifiersAction = createAsyncThunk(
 
 export const fetchContactPointsStateAction = createAsyncThunk(
   'unifiedalerting/fetchContactPointsState',
-  (alertManagerSourceName: String): Promise<ContactPointsState> =>
+  (alertManagerSourceName: string): Promise<ContactPointsState | undefined> =>
     withSerializedError(fetchContactPointsState(alertManagerSourceName))
 );
 

--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -456,7 +456,7 @@ export const fetchGrafanaNotifiersAction = createAsyncThunk(
 
 export const fetchContactPointsStateAction = createAsyncThunk(
   'unifiedalerting/fetchContactPointsState',
-  (alertManagerSourceName: string): Promise<ContactPointsState | undefined> =>
+  (alertManagerSourceName: string): Promise<ContactPointsState> =>
     withSerializedError(fetchContactPointsState(alertManagerSourceName))
 );
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR creates the new `fetchContactPointsState` using the actual endpoint `/api/alertmanager/${getDatasourceAPIUid(alertManagerSourceName)}/config/api/v1/receivers` handling 404 error when no state is available.

**Special notes for your reviewer**:
This PR adds tests for showing or not `NotificationError` in `Receivers` component.