### PR TITLE
CI: Replace `armhf` with `armhfp` for RPMs

### DIFF
--- a/pkg/build/config/variant.go
+++ b/pkg/build/config/variant.go
@@ -31,12 +31,13 @@ var AllVariants = []Variant{
 type Architecture string
 
 const (
-	ArchAMD64 Architecture = "amd64"
-	ArchARMv6 Architecture = "armv6"
-	ArchARMv7 Architecture = "armv7"
-	ArchARM64 Architecture = "arm64"
-	ArchARMHF Architecture = "armhf"
-	ArchARM   Architecture = "arm"
+	ArchAMD64  Architecture = "amd64"
+	ArchARMv6  Architecture = "armv6"
+	ArchARMv7  Architecture = "armv7"
+	ArchARM64  Architecture = "arm64"
+	ArchARMHF  Architecture = "armhf"
+	ArchARMHFP Architecture = "armhfp"
+	ArchARM    Architecture = "arm"
 )
 
 type OS string

--- a/pkg/build/grafana/variant.go
+++ b/pkg/build/grafana/variant.go
@@ -81,7 +81,7 @@ var variantArgs = map[config.Variant]BuildArgs{
 			CC:         compilers.Armv7,
 		},
 		DebArch: config.ArchARMHF,
-		RPMArch: config.ArchARMHF,
+		RPMArch: config.ArchARMHFP,
 	},
 	config.VariantArmV7Musl: {
 		BuildOpts: golangutils.BuildOpts{


### PR DESCRIPTION
**What this PR does / why we need it**:

While `9.2.0-beta1` release was in progress, we encountered an error where the `armhfp` RPM packages couldn't be found, and we had to manually move/rename packages.
That's due to an error that was introduced while we were moving things from `grabpl` to OSS.
This PR fixes this issue, by adding `armhfp` suffix to align with what we already give to our customers in our previous Grafana releases.

**Needs backporting**.