### PR TITLE
Alerting: Decouple state package from store

### DIFF
--- a/pkg/services/ngalert/state/manager_private_test.go
+++ b/pkg/services/ngalert/state/manager_private_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
 	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
-	"github.com/grafana/grafana/pkg/services/ngalert/store"
 )
 
 // Not for parallel tests.
@@ -95,7 +94,7 @@ func Test_maybeNewImage(t *testing.T) {
 		t.Run(test.description, func(t *testing.T) {
 			imageService := &CountingImageService{}
 			mgr := NewManager(log.NewNopLogger(), &metrics.State{}, nil,
-				&store.FakeRuleStore{}, &FakeInstanceStore{},
+				&FakeRuleReader{}, &FakeInstanceStore{},
 				&dashboards.FakeDashboardService{}, imageService, clock.NewMock(), annotationstest.NewFakeAnnotationsRepo())
 			err := mgr.maybeTakeScreenshot(context.Background(), &ngmodels.AlertRule{}, test.state, test.oldState)
 			require.NoError(t, err)

--- a/pkg/services/ngalert/state/testing.go
+++ b/pkg/services/ngalert/state/testing.go
@@ -35,3 +35,9 @@ func (f *FakeInstanceStore) DeleteAlertInstance(_ context.Context, _ int64, _, _
 func (f *FakeInstanceStore) DeleteAlertInstancesByRule(ctx context.Context, key models.AlertRuleKey) error {
 	return nil
 }
+
+type FakeRuleReader struct{}
+
+func (f *FakeRuleReader) ListAlertRules(_ context.Context, q *models.ListAlertRulesQuery) error {
+	return nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

In the previous PR https://github.com/grafana/grafana/pull/55776 that broke up the RuleStore interface, `state` only ended up depending on a small slice of that functionality. It got a small, very focused `RuleReader` interface instead that only captures the minimal functionality that `state` needs to operate.

This PR adjusts the tests to similarly use a minimal fake. The smaller interface means that `state`'s fake can be extremely simplistic, and not the [400-line behemoth](https://github.com/grafana/grafana/pull/55776) that used to serve all these use cases.

This was the final usage of `store` in the `state` package - it's fully decoupled now.

**Which issue(s) this PR fixes**:

Contributes to https://github.com/grafana/grafana/issues/55770

**Special notes for your reviewer**:

