### PR TITLE
Search: Fix tags query

### DIFF
--- a/pkg/services/searchV2/http.go
+++ b/pkg/services/searchV2/http.go
@@ -63,11 +63,12 @@ func (s *searchHTTPService) doQuery(c *models.ReqContext) response.Response {
 		return response.Error(500, "error handling search request", resp.Error)
 	}
 
-	if len(resp.Frames) != 1 {
-		return response.Error(500, "invalid search response", errors.New("invalid search response"))
+	if len(resp.Frames) == 0 {
+		msg := "invalid search response"
+		return response.Error(500, msg, errors.New(msg))
 	}
 
-	bytes, err := resp.Frames[0].MarshalJSON()
+	bytes, err := resp.MarshalJSON()
 	if err != nil {
 		return response.Error(500, "error marshalling response", err)
 	}

--- a/public/app/features/search/service/bluge.ts
+++ b/public/app/features/search/service/bluge.ts
@@ -1,6 +1,7 @@
 import {
   ArrayVector,
   DataFrame,
+  DataFrameJSON,
   DataFrameView,
   getDisplayProcessor,
   SelectableValue,
@@ -20,7 +21,7 @@ const loadingFrameName = 'Loading';
 const searchURI = 'api/search-v2';
 
 type SearchAPIResponse = {
-  frames: unknown[];
+  frames: DataFrameJSON[];
 };
 
 export class BlugeSearcher implements GrafanaSearcher {


### PR DESCRIPTION
Fix bug introduced in https://github.com/grafana/grafana/pull/55634

the tags query is returning two data frames that weren't accounted for in the new endpoint

<img width="739" alt="image" src="https://user-images.githubusercontent.com/23451458/192572094-14517cbe-b08d-44e3-9fc1-f069a98785d6.png">
