### PR TITLE
AzureMonitor: Correctly update subscriptions value in ARG editor

### DIFF
--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/SubscriptionField.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/SubscriptionField.tsx
@@ -56,9 +56,12 @@ const SubscriptionField: React.FC<SubscriptionFieldProps> = ({
         return;
       }
 
-      query.subscriptions = change.map((c) => c.value ?? '');
+      let newQuery: AzureMonitorQuery = {
+        ...query,
+        subscriptions: change.map((c) => c.value ?? ''),
+      };
 
-      onQueryChange(query);
+      onQueryChange(newQuery);
     },
     [query, onQueryChange]
   );

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/SubscriptionField.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/SubscriptionField.tsx
@@ -56,12 +56,10 @@ const SubscriptionField: React.FC<SubscriptionFieldProps> = ({
         return;
       }
 
-      let newQuery: AzureMonitorQuery = {
+      onQueryChange({
         ...query,
         subscriptions: change.map((c) => c.value ?? ''),
-      };
-
-      onQueryChange(newQuery);
+      });
     },
     [query, onQueryChange]
   );


### PR DESCRIPTION
**What this PR does / why we need it**:

Correctly sets the `subscriptions` property in an Azure Monitor query to allow for multi-select in the variable editor. Query properties cannot be edited directly as they're read-only, a new query must be constructed and updated.

**Which issue(s) this PR fixes**:

Fixes #55190 

**Special notes for your reviewer**:

