### PR TITLE
TimeSeries: fix log-y-axis tick label skipping when decimals=0

### DIFF
--- a/packages/grafana-ui/src/components/TimeSeries/utils.ts
+++ b/packages/grafana-ui/src/components/TimeSeries/utils.ts
@@ -276,6 +276,7 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn<{
             theme,
             grid: { show: customConfig.axisGridShow },
             decimals: field.config.decimals,
+            distr: customConfig.scaleDistribution?.type,
             ...axisColorOpts,
           },
           field

--- a/packages/grafana-ui/src/components/uPlot/config/UPlotAxisBuilder.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotAxisBuilder.ts
@@ -10,7 +10,7 @@ import {
   systemDateFormats,
   TimeZone,
 } from '@grafana/data';
-import { AxisPlacement } from '@grafana/schema';
+import { AxisPlacement, ScaleDistribution } from '@grafana/schema';
 
 import { measureText } from '../../../utils/measureText';
 import { PlotConfigBuilder } from '../types';
@@ -39,6 +39,7 @@ export interface AxisProps {
   color?: uPlot.Axis.Stroke;
   border?: uPlot.Axis.Border;
   decimals?: DecimalCount;
+  distr?: ScaleDistribution;
 }
 
 export const UPLOT_AXIS_FONT_SIZE = 12;
@@ -121,6 +122,7 @@ export class UPlotAxisBuilder extends PlotConfigBuilder<AxisProps, Axis> {
       color,
       border,
       decimals,
+      distr = ScaleDistribution.Linear,
     } = this.props;
 
     const font = `${UPLOT_AXIS_FONT_SIZE}px ${theme.typography.fontFamily}`;
@@ -131,7 +133,7 @@ export class UPlotAxisBuilder extends PlotConfigBuilder<AxisProps, Axis> {
       splits = [0, 1];
     }
 
-    if (decimals === 0) {
+    if (decimals === 0 && distr === ScaleDistribution.Linear) {
       filter = (u, splits) => splits.map((v) => (Number.isInteger(v) ? v : null));
     }
 


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/55867

(follow-up to https://github.com/grafana/grafana/pull/54679)

this avoids overriding the built-in tick value filter when decimals=0 and we have non-linear y scale.

<details><summary>log-ticks-collide.json</summary>

```json
{
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": {
          "type": "grafana",
          "uid": "-- Grafana --"
        },
        "enable": true,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "target": {
          "limit": 100,
          "matchAny": false,
          "tags": [],
          "type": "dashboard"
        },
        "type": "dashboard"
      }
    ]
  },
  "editable": true,
  "fiscalYearStartMonth": 0,
  "graphTooltip": 0,
  "id": 348,
  "links": [],
  "liveNow": false,
  "panels": [
    {
      "datasource": {
        "type": "testdata",
        "uid": "PD8C576611E62080A"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "palette-classic"
          },
          "custom": {
            "axisCenteredZero": false,
            "axisColorMode": "text",
            "axisLabel": "",
            "axisPlacement": "auto",
            "barAlignment": 0,
            "drawStyle": "line",
            "fillOpacity": 0,
            "gradientMode": "none",
            "hideFrom": {
              "legend": false,
              "tooltip": false,
              "viz": false
            },
            "lineInterpolation": "linear",
            "lineWidth": 1,
            "pointSize": 5,
            "scaleDistribution": {
              "log": 10,
              "type": "log"
            },
            "showPoints": "auto",
            "spanNulls": false,
            "stacking": {
              "group": "A",
              "mode": "none"
            },
            "thresholdsStyle": {
              "mode": "off"
            }
          },
          "decimals": 0,
          "mappings": [],
          "max": 100000,
          "min": 10,
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": null
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          },
          "unit": "ms"
        },
        "overrides": []
      },
      "gridPos": {
        "h": 12,
        "w": 12,
        "x": 0,
        "y": 0
      },
      "id": 2,
      "options": {
        "legend": {
          "calcs": [],
          "displayMode": "list",
          "placement": "bottom",
          "showLegend": true
        },
        "tooltip": {
          "mode": "single",
          "sort": "none"
        }
      },
      "targets": [
        {
          "datasource": {
            "type": "testdata",
            "uid": "PD8C576611E62080A"
          },
          "refId": "A",
          "scenarioId": "csv_metric_values",
          "stringInput": "10,100000"
        }
      ],
      "title": "Panel Title",
      "type": "timeseries"
    }
  ],
  "schemaVersion": 37,
  "style": "dark",
  "tags": [],
  "templating": {
    "list": []
  },
  "time": {
    "from": "now-6h",
    "to": "now"
  },
  "timepicker": {},
  "timezone": "",
  "title": "log-ticks-collide",
  "uid": "5hGjrm44z",
  "version": 1,
  "weekStart": ""
}
```
</details>

before:

![image](https://user-images.githubusercontent.com/43234/192616610-4a261b14-c31a-47aa-a71f-61762919d4a3.png)

after:

![image](https://user-images.githubusercontent.com/43234/192616394-3743c396-6208-4339-88c7-5b62f19e8d5d.png)