### PR TITLE
Search: Reduce requests in folder view

### DIFF
--- a/public/app/features/search/page/components/FolderSection.tsx
+++ b/public/app/features/search/page/components/FolderSection.tsx
@@ -82,7 +82,7 @@ export const FolderSection: FC<SectionHeaderProps> = ({
       folderTitle,
     }));
     return v;
-  }, [sectionExpanded, section, tags]);
+  }, [sectionExpanded, tags]);
 
   const onSectionExpand = () => {
     setSectionExpanded(!sectionExpanded);


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR aims to reduce the number of requests in the Folder Section.
This section is performing 3 requests to retrieve dashboards from this folder


<img width="729" alt="Captura de Tela 2022-09-26 às 22 22 36" src="https://user-images.githubusercontent.com/3681977/192658007-0bafae6d-de93-4c4a-8112-a238a8654136.png">

And every time we check or uncheck the checkbox for any dashboard in the folder it is performed a request for retrieve dashboards 
<img width="724" alt="Captura de Tela 2022-09-26 às 22 48 55" src="https://user-images.githubusercontent.com/3681977/192657946-21e3e5bb-dace-4e1c-a381-6afc1599af67.png">

I think all  of these requests are not necessary and after the change in the `useAsync` to not observe change state in section the number of requests reduce by 1 when loading the folder and the checkbox does not perform a request for retrieve dashboards anymore.

<img width="734" alt="Captura de Tela 2022-09-26 às 22 23 33" src="https://user-images.githubusercontent.com/3681977/192658806-eec64cd1-9d8c-45f1-b5a6-d75ac828701b.png">


After the
**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/55234

**Special notes for your reviewer**:

Hi reviewer!
Im new to the codebase, but I would like to contribute. 
Can you check if this change make sense ? 
Thanks

