### PR TITLE
TimeSeries: clamp log-y-axis min to 1 when decimals=0

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/config/UPlotScaleBuilder.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotScaleBuilder.ts
@@ -130,23 +130,26 @@ export class UPlotScaleBuilder extends PlotConfigBuilder<ScaleProps, Scale> {
         else if (scale.distr === 3) {
           let logFn = scale.log === 2 ? Math.log2 : Math.log10;
 
-          // min
-          if (minMax[0]! < 1) {
+          if (minMax[0]! <= 1) {
+            // clamp min
             minMax[0] = 1;
           } else {
+            // snap min to nearest mag below
             let minExp = Math.floor(logFn(minMax[0]!));
             minMax[0] = logBase ** minExp;
           }
 
-          // max
+          // snap max to nearest mag above
           let maxExp = Math.ceil(logFn(minMax[1]!));
           minMax[1] = logBase ** maxExp;
 
+          // inflate max by mag if same
           if (minMax[0] === minMax[1]) {
             minMax[1] *= logBase;
           }
         }
-        // TODO: this should be better. symlog values can be <= 0, but should also be rounded to log2 or log10 boundaries
+        // TODO: this should be better. symlog values can be <= 0, but should also be snapped to log2 or log10 boundaries
+        // for now we just do same as linear snapping above, so may have non-neat range and ticks at edges
         else if (scale.distr === 4) {
           minMax[0] = incrRoundDn(minMax[0]!, 1);
           minMax[1] = incrRoundUp(minMax[1]!, 1);

--- a/packages/grafana-ui/src/components/uPlot/config/UPlotScaleBuilder.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotScaleBuilder.ts
@@ -122,6 +122,11 @@ export class UPlotScaleBuilder extends PlotConfigBuilder<ScaleProps, Scale> {
       if (decimals === 0) {
         minMax[0] = incrRoundDn(minMax[0]!, 1);
         minMax[1] = incrRoundUp(minMax[1]!, 1);
+
+        // clamp log scales' min to 1
+        if (scale.distr === 3 && minMax[0] < 1) {
+          minMax[0] = 1;
+        }
       }
 
       // if all we got were hard limits, treat them as static min/max


### PR DESCRIPTION
Fixes #55520

when decimals=0, this prevents log scales' mins from rounding down to 0 (or less), and also better snaps them to full magnitude boundaries.

<details><summary>log-zero-dec.json</summary>

```json
{
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": {
          "type": "grafana",
          "uid": "-- Grafana --"
        },
        "enable": true,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "target": {
          "limit": 100,
          "matchAny": false,
          "tags": [],
          "type": "dashboard"
        },
        "type": "dashboard"
      }
    ]
  },
  "editable": true,
  "fiscalYearStartMonth": 0,
  "graphTooltip": 0,
  "id": 351,
  "links": [],
  "liveNow": false,
  "panels": [
    {
      "datasource": {
        "type": "testdata",
        "uid": "PD8C576611E62080A"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "palette-classic"
          },
          "custom": {
            "axisCenteredZero": false,
            "axisColorMode": "text",
            "axisLabel": "",
            "axisPlacement": "auto",
            "barAlignment": 0,
            "drawStyle": "line",
            "fillOpacity": 0,
            "gradientMode": "none",
            "hideFrom": {
              "legend": false,
              "tooltip": false,
              "viz": false
            },
            "lineInterpolation": "linear",
            "lineWidth": 1,
            "pointSize": 5,
            "scaleDistribution": {
              "log": 10,
              "type": "log"
            },
            "showPoints": "auto",
            "spanNulls": false,
            "stacking": {
              "group": "A",
              "mode": "none"
            },
            "thresholdsStyle": {
              "mode": "area"
            }
          },
          "decimals": 0,
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "transparent",
                "value": null
              },
              {
                "color": "red",
                "value": 30
              }
            ]
          }
        },
        "overrides": []
      },
      "gridPos": {
        "h": 16,
        "w": 12,
        "x": 0,
        "y": 0
      },
      "id": 2,
      "options": {
        "legend": {
          "calcs": [],
          "displayMode": "list",
          "placement": "bottom",
          "showLegend": true
        },
        "tooltip": {
          "mode": "single",
          "sort": "none"
        }
      },
      "targets": [
        {
          "datasource": {
            "type": "testdata",
            "uid": "PD8C576611E62080A"
          },
          "refId": "A",
          "scenarioId": "csv_metric_values",
          "stringInput": ".25,60"
        }
      ],
      "title": "Panel Title",
      "type": "timeseries"
    },
    {
      "datasource": {
        "type": "testdata",
        "uid": "PD8C576611E62080A"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "palette-classic"
          },
          "custom": {
            "axisCenteredZero": false,
            "axisColorMode": "text",
            "axisLabel": "",
            "axisPlacement": "auto",
            "barAlignment": 0,
            "drawStyle": "line",
            "fillOpacity": 0,
            "gradientMode": "none",
            "hideFrom": {
              "legend": false,
              "tooltip": false,
              "viz": false
            },
            "lineInterpolation": "linear",
            "lineWidth": 1,
            "pointSize": 5,
            "scaleDistribution": {
              "log": 10,
              "type": "log"
            },
            "showPoints": "auto",
            "spanNulls": false,
            "stacking": {
              "group": "A",
              "mode": "none"
            },
            "thresholdsStyle": {
              "mode": "area"
            }
          },
          "decimals": 0,
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "transparent",
                "value": null
              },
              {
                "color": "red",
                "value": 30
              }
            ]
          }
        },
        "overrides": []
      },
      "gridPos": {
        "h": 16,
        "w": 12,
        "x": 12,
        "y": 0
      },
      "id": 5,
      "options": {
        "legend": {
          "calcs": [],
          "displayMode": "list",
          "placement": "bottom",
          "showLegend": true
        },
        "tooltip": {
          "mode": "single",
          "sort": "none"
        }
      },
      "targets": [
        {
          "datasource": {
            "type": "testdata",
            "uid": "PD8C576611E62080A"
          },
          "refId": "A",
          "scenarioId": "csv_metric_values",
          "stringInput": ".25,200"
        }
      ],
      "title": "Panel Title",
      "type": "timeseries"
    },
    {
      "datasource": {
        "type": "testdata",
        "uid": "PD8C576611E62080A"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "palette-classic"
          },
          "custom": {
            "axisCenteredZero": false,
            "axisColorMode": "text",
            "axisLabel": "",
            "axisPlacement": "auto",
            "barAlignment": 0,
            "drawStyle": "line",
            "fillOpacity": 0,
            "gradientMode": "none",
            "hideFrom": {
              "legend": false,
              "tooltip": false,
              "viz": false
            },
            "lineInterpolation": "linear",
            "lineWidth": 1,
            "pointSize": 5,
            "scaleDistribution": {
              "log": 10,
              "type": "log"
            },
            "showPoints": "auto",
            "spanNulls": false,
            "stacking": {
              "group": "A",
              "mode": "none"
            },
            "thresholdsStyle": {
              "mode": "area"
            }
          },
          "decimals": 0,
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "transparent",
                "value": null
              },
              {
                "color": "red",
                "value": 30
              }
            ]
          }
        },
        "overrides": []
      },
      "gridPos": {
        "h": 16,
        "w": 12,
        "x": 0,
        "y": 16
      },
      "id": 3,
      "options": {
        "legend": {
          "calcs": [],
          "displayMode": "list",
          "placement": "bottom",
          "showLegend": true
        },
        "tooltip": {
          "mode": "single",
          "sort": "none"
        }
      },
      "targets": [
        {
          "datasource": {
            "type": "testdata",
            "uid": "PD8C576611E62080A"
          },
          "refId": "A",
          "scenarioId": "csv_metric_values",
          "stringInput": ".25,15"
        }
      ],
      "title": "Panel Title",
      "type": "timeseries"
    },
    {
      "datasource": {
        "type": "testdata",
        "uid": "PD8C576611E62080A"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "palette-classic"
          },
          "custom": {
            "axisCenteredZero": false,
            "axisColorMode": "text",
            "axisLabel": "",
            "axisPlacement": "auto",
            "barAlignment": 0,
            "drawStyle": "line",
            "fillOpacity": 0,
            "gradientMode": "none",
            "hideFrom": {
              "legend": false,
              "tooltip": false,
              "viz": false
            },
            "lineInterpolation": "linear",
            "lineWidth": 1,
            "pointSize": 5,
            "scaleDistribution": {
              "log": 10,
              "type": "log"
            },
            "showPoints": "auto",
            "spanNulls": false,
            "stacking": {
              "group": "A",
              "mode": "none"
            },
            "thresholdsStyle": {
              "mode": "area"
            }
          },
          "decimals": 0,
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "transparent",
                "value": null
              },
              {
                "color": "red",
                "value": 30
              }
            ]
          }
        },
        "overrides": []
      },
      "gridPos": {
        "h": 16,
        "w": 12,
        "x": 12,
        "y": 16
      },
      "id": 4,
      "options": {
        "legend": {
          "calcs": [],
          "displayMode": "list",
          "placement": "bottom",
          "showLegend": true
        },
        "tooltip": {
          "mode": "single",
          "sort": "none"
        }
      },
      "targets": [
        {
          "datasource": {
            "type": "testdata",
            "uid": "PD8C576611E62080A"
          },
          "refId": "A",
          "scenarioId": "csv_metric_values",
          "stringInput": ".25,7"
        }
      ],
      "title": "Panel Title",
      "type": "timeseries"
    }
  ],
  "schemaVersion": 37,
  "style": "dark",
  "tags": [],
  "templating": {
    "list": []
  },
  "time": {
    "from": "now-6h",
    "to": "now"
  },
  "timepicker": {},
  "timezone": "",
  "title": "log-zero-dec",
  "uid": "k1Cn6Z4Vk",
  "version": 7,
  "weekStart": ""
}
```
</details>

![image](https://user-images.githubusercontent.com/43234/192700587-71c1a663-9ef2-40c8-9459-e16481b72837.png)
