### PR TITLE
Alerting: fix alert supported warning when editing data source name

### DIFF
--- a/public/app/features/datasources/components/BasicSettings.test.tsx
+++ b/public/app/features/datasources/components/BasicSettings.test.tsx
@@ -11,6 +11,7 @@ const setup = () => {
     isDefault: false,
     onDefaultChange: jest.fn(),
     onNameChange: jest.fn(),
+    alertingSupported: false,
   };
 
   return render(<BasicSettings {...props} />);

--- a/public/app/features/datasources/components/BasicSettings.tsx
+++ b/public/app/features/datasources/components/BasicSettings.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
-import { getDataSourceSrv } from '@grafana/runtime';
 import { InlineField, InlineSwitch, Input, Badge, useStyles2 } from '@grafana/ui';
 
 export interface Props {
@@ -11,16 +10,13 @@ export interface Props {
   isDefault: boolean;
   onNameChange: (name: string) => void;
   onDefaultChange: (value: boolean) => void;
+  alertingSupported: boolean;
 }
 
-export function BasicSettings({ dataSourceName, isDefault, onDefaultChange, onNameChange }: Props) {
-  const ds = getDataSourceSrv()?.getInstanceSettings(dataSourceName);
-  const hasAlertingEnabled = Boolean(ds?.meta?.alerting ?? false);
-  const isAlertManagerDatasource = ds?.type === 'alertmanager';
-
+export function BasicSettings({ dataSourceName, isDefault, onDefaultChange, onNameChange, alertingSupported }: Props) {
   return (
     <>
-      {<AlertingEnabled enabled={hasAlertingEnabled || isAlertManagerDatasource} />}
+      {<AlertingEnabled enabled={alertingSupported} />}
       <div className="gf-form-group" aria-label="Datasource settings page basic settings">
         <div className="gf-form-inline">
           {/* Name */}

--- a/public/app/features/datasources/components/EditDataSource.tsx
+++ b/public/app/features/datasources/components/EditDataSource.tsx
@@ -2,6 +2,7 @@ import { AnyAction } from '@reduxjs/toolkit';
 import React from 'react';
 
 import { DataSourcePluginMeta, DataSourceSettings as DataSourceSettingsType } from '@grafana/data';
+import { getDataSourceSrv } from '@grafana/runtime';
 import PageLoader from 'app/core/components/PageLoader/PageLoader';
 import { DataSourceSettingsState, useDispatch } from 'app/types';
 
@@ -106,9 +107,14 @@ export function EditDataSourceView({
   const { readOnly, hasWriteRights, hasDeleteRights } = dataSourceRights;
   const hasDataSource = dataSource.id > 0;
 
+  const ds = getDataSourceSrv()?.getInstanceSettings(dataSource.uid);
+
+  const hasAlertingEnabled = Boolean(ds?.meta?.alerting ?? false);
+  const isAlertManagerDatasource = ds?.type === 'alertmanager';
+  const alertingSupported = hasAlertingEnabled || isAlertManagerDatasource;
+
   const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-
     await onUpdate({ ...dataSource });
 
     onTest();
@@ -144,6 +150,7 @@ export function EditDataSourceView({
         isDefault={dataSource.isDefault}
         onDefaultChange={onDefaultChange}
         onNameChange={onNameChange}
+        alertingSupported={alertingSupported}
       />
 
       {plugin && (


### PR DESCRIPTION

**What this PR does / why we need it**:

This PR fixes alerting supported warning in data source edit view being re-calculated while editing data source name.


