### PR TITLE
GrafanaUI: Expose data links context types externally

### DIFF
--- a/packages/grafana-ui/src/components/DataLinks/DataLinksContextMenu.tsx
+++ b/packages/grafana-ui/src/components/DataLinks/DataLinksContextMenu.tsx
@@ -9,7 +9,7 @@ import { WithContextMenu } from '../ContextMenu/WithContextMenu';
 import { MenuGroup, MenuItemsGroup } from '../Menu/MenuGroup';
 import { MenuItem } from '../Menu/MenuItem';
 
-interface DataLinksContextMenuProps {
+export interface DataLinksContextMenuProps {
   children: (props: DataLinksContextMenuApi) => JSX.Element;
   links: () => LinkModel[];
   style?: CSSProperties;

--- a/packages/grafana-ui/src/components/index.ts
+++ b/packages/grafana-ui/src/components/index.ts
@@ -156,7 +156,11 @@ export { MenuItem, type MenuItemProps } from './Menu/MenuItem';
 export { WithContextMenu } from './ContextMenu/WithContextMenu';
 export { DataLinksInlineEditor } from './DataLinks/DataLinksInlineEditor/DataLinksInlineEditor';
 export { DataLinkInput } from './DataLinks/DataLinkInput';
-export { DataLinksContextMenu } from './DataLinks/DataLinksContextMenu';
+export {
+  DataLinksContextMenu,
+  type DataLinksContextMenuProps,
+  type DataLinksContextMenuApi,
+} from './DataLinks/DataLinksContextMenu';
 export { SeriesIcon } from './VizLegend/SeriesIcon';
 export { InfoBox } from './InfoBox/InfoBox';
 export { FeatureBadge, FeatureInfoBox } from './InfoBox/FeatureInfoBox';


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR will expose all the types that are referenced as part of the `DataLinksContextMenu` component. Exposing all parts of the public API is a good practice for the following reasons (to mention some of them):

- If you want to extend or wrap the component outside of Grafana core it gets difficult since you can't get hold of the `DataLinksContextMenuProps` (in this case).
- It is more explicit that both the `DataLinksContextMenuProps` and `DataLinksContextMenuApi` are part of the public API if they also are exported.

**Special notes for your reviewer**:
Noticed this when trying to implement `DataLinksContextMenu` in a panel plugin.

https://github.com/grafana/grafana-plugin-examples/pull/97
