### PR TITLE
Storybook: Explicitly set init on Registry to fix certain Storybook stories

### DIFF
--- a/packages/grafana-data/src/utils/Registry.ts
+++ b/packages/grafana-data/src/utils/Registry.ts
@@ -41,7 +41,9 @@ export class Registry<T extends RegistryItem> {
   private byId = new Map<string, T>();
   private initialized = false;
 
-  constructor(private init?: () => T[]) {}
+  constructor(private init?: () => T[]) {
+    this.init = init;
+  }
 
   setInit = (init: () => T[]) => {
     if (this.initialized) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Some storybook stories are currently broken due to some weirdness in transpiling the code (https://github.com/grafana/grafana/issues/53684#issuecomment-1245196510). There is a PR to update storybook that seems to fix this, but that is pointing at 9.3.0, so the current fix for 9.2.0 is to explicitly initialise a `Registry` in the constructor

**Which issue(s) this PR fixes**:

Fixes #53684