### PR TITLE
i18n: Update crowdin.yml: Removal of unused parameter by Crowdin-GitHub connector

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,7 +1,6 @@
 files:
   - source: /public/locales/en-US/messages.po
     translation: /public/locales/%locale%/%original_file_name%
-    export_only_approved: true
 
 pull_request_title: 'I18n: Crowdin sync'
 pull_request_labels:


### PR DESCRIPTION
Export options (e.g. `export_only_approved`) are applicable to Crowdin CLI or Crowdin GitHub Action (https://github.com/crowdin/github-action) only: https://developer.crowdin.com/configuration-file/#export-options

To export only approved translations, please set "Export strings that passed workflow" option in your project settings and ensure that "Proofreading" is the last step in your project's workflow

**What this PR does / why we need it**: The current parameter is not considered by the integration, therefore non-approved translations may be delivered to your repository. Please configure export options within Crowdin project to export approved only translations.

**Which issue(s) this PR fixes**: Export of approved-only translations