### PR TITLE
Loki/Prometheus: Fix adding of ad hoc filters when jumping from dashboard to explore

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -252,6 +252,22 @@ describe('LokiDatasource', () => {
     });
   });
 
+  describe('when running interpolateVariablesInQueries', () => {
+    it('should call addAdHocFilters', () => {
+      const ds = createLokiDatasource(templateSrvStub);
+      ds.addAdHocFilters = jest.fn();
+      const expr = 'rate({bar="baz", job="foo"} [5m]';
+      const queries = [
+        {
+          refId: 'A',
+          expr,
+        },
+      ];
+      ds.interpolateVariablesInQueries(queries, {});
+      expect(ds.addAdHocFilters).toHaveBeenCalledWith(expr);
+    });
+  });
+
   describe('when performing testDataSource', () => {
     let ds: LokiDatasource;
     beforeEach(() => {

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -272,7 +272,7 @@ export class LokiDatasource
       expandedQueries = queries.map((query) => ({
         ...query,
         datasource: this.getRef(),
-        expr: this.templateSrv.replace(query.expr, scopedVars, this.interpolateQueryExpr),
+        expr: this.addAdHocFilters(this.templateSrv.replace(query.expr, scopedVars, this.interpolateQueryExpr)),
       }));
     }
 

--- a/public/app/plugins/datasource/prometheus/datasource.test.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.test.ts
@@ -622,6 +622,19 @@ describe('PrometheusDatasource', () => {
       expect(templateSrvStub.replace).toBeCalledTimes(2);
       expect(queries[0].interval).toBe(interval);
     });
+
+    it('should call enhanceExprWithAdHocFilters', () => {
+      ds.enhanceExprWithAdHocFilters = jest.fn();
+      const expr = 'rate({bar="baz", job="foo"} [5m]';
+      const queries = [
+        {
+          refId: 'A',
+          expr,
+        },
+      ];
+      ds.interpolateVariablesInQueries(queries, {});
+      expect(ds.enhanceExprWithAdHocFilters).toHaveBeenCalledWith(expr);
+    });
   });
 
   describe('applyTemplateVariables', () => {

--- a/public/app/plugins/datasource/prometheus/datasource.test.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.test.ts
@@ -625,15 +625,14 @@ describe('PrometheusDatasource', () => {
 
     it('should call enhanceExprWithAdHocFilters', () => {
       ds.enhanceExprWithAdHocFilters = jest.fn();
-      const expr = 'rate({bar="baz", job="foo"} [5m]';
       const queries = [
         {
           refId: 'A',
-          expr,
+          expr: 'rate({bar="baz", job="foo"} [5m]',
         },
       ];
       ds.interpolateVariablesInQueries(queries, {});
-      expect(ds.enhanceExprWithAdHocFilters).toHaveBeenCalledWith(expr);
+      expect(ds.enhanceExprWithAdHocFilters).toHaveBeenCalled();
     });
   });
 

--- a/public/app/plugins/datasource/prometheus/datasource.tsx
+++ b/public/app/plugins/datasource/prometheus/datasource.tsx
@@ -1002,7 +1002,9 @@ export class PrometheusDatasource
         const expandedQuery = {
           ...query,
           datasource: this.getRef(),
-          expr: this.templateSrv.replace(query.expr, scopedVars, this.interpolateQueryExpr),
+          expr: this.enhanceExprWithAdHocFilters(
+            this.templateSrv.replace(query.expr, scopedVars, this.interpolateQueryExpr)
+          ),
           interval: this.templateSrv.replace(query.interval, scopedVars),
         };
         return expandedQuery;


### PR DESCRIPTION
**What this PR does / why we need it**:
More context here: https://raintank-corp.slack.com/archives/C02TXB92G6T/p1664283234413199

There is a bug around AdHoc filters and the Explore experience. When you have AdHoc filters (type of dashboards variable) and you jump to Explore, all variables are interpolated, but AdHoc filters are ignored. For consistency, it would make sense to interpolate and include all variables. Not just some of them.

How to reproduce: 
- Apply an ad-hoc filter on a dashboard
- See a panel of results get updated, scoped more tightly by the ad-hoc filter just applied
"Explore" that panel
- Within the explore view, I want to see the same ad-hoc filters still present, and see the same results rendered

This is how it works on this branch - fixed behaviour:

https://user-images.githubusercontent.com/30407135/192767867-94f20b53-921c-4364-8deb-61ca6d948f6d.mov

This is how it is on main:

https://user-images.githubusercontent.com/30407135/192767936-2ae33581-1608-4acb-81f7-59cd19459be8.mov

**Special notes for your reviewer**:

To test the behaviour:
- Create loki/prometheus dashboard
- Create adhoc variables
- Jump to explore
- Observe if ad-hoc filters were added

