### PR TITLE
GRPC Server: Use QueryDataMultipleSources

### DIFF
--- a/pkg/services/grpcserver/query.go
+++ b/pkg/services/grpcserver/query.go
@@ -2,20 +2,18 @@ package grpcserver
 
 import (
 	"context"
-	"fmt"
+	"strconv"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/genproto/pluginv2"
+	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/components/simplejson"
-	"github.com/grafana/grafana/pkg/expr"
 	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/plugins"
-	"github.com/grafana/grafana/pkg/plugins/adapters"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/org"
+	"github.com/grafana/grafana/pkg/services/query"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
-	"github.com/grafana/grafana/pkg/tsdb/grafanads"
 )
 
 type QueryDataService struct {
@@ -23,10 +21,10 @@ type QueryDataService struct {
 	server *queryDataServer
 }
 
-func ProvideQueryDataService(cfg *setting.Cfg, grpcServerProvider Provider, pluginsClient plugins.Client, dataSourceCache datasources.CacheService, dataSourceService datasources.DataSourceService) (*QueryDataService, error) {
+func ProvideQueryDataService(cfg *setting.Cfg, grpcServerProvider Provider, queryService *query.Service, dataSourceCache datasources.CacheService, dataSourceService datasources.DataSourceService) (*QueryDataService, error) {
 	server := &queryDataServer{
 		logger:            log.New("grpc-server-query-data"),
-		pluginClient:      pluginsClient,
+		queryService:      queryService,
 		dataSourceCache:   dataSourceCache,
 		dataSourceService: dataSourceService,
 	}
@@ -39,7 +37,7 @@ func ProvideQueryDataService(cfg *setting.Cfg, grpcServerProvider Provider, plug
 
 type queryDataServer struct {
 	logger            log.Logger
-	pluginClient      plugins.Client
+	queryService      *query.Service
 	dataSourceCache   datasources.CacheService
 	dataSourceService datasources.DataSourceService
 }
@@ -54,112 +52,26 @@ func (s *queryDataServer) QueryData(ctx context.Context, in *pluginv2.QueryDataR
 	user := signedInUserFromBackendUser(req.PluginContext.User)
 	user.OrgID = req.PluginContext.OrgID
 
-	// split incoming queries into new QueryDataRequests based on the datasourceUID
-	requests, err := s.buildRequests(ctx, user, req)
+	metricReq := dtos.MetricRequest{
+		From:    strconv.FormatInt(req.Queries[0].TimeRange.From.UnixMilli(), 10),
+		To:      strconv.FormatInt(req.Queries[0].TimeRange.To.UnixMilli(), 10),
+		Queries: make([]*simplejson.Json, 0),
+	}
+
+	for _, q := range req.Queries {
+		sj, err := simplejson.NewJson(q.JSON)
+		if err != nil {
+			return nil, err
+		}
+		metricReq.Queries = append(metricReq.Queries, sj)
+	}
+
+	response, err := s.queryService.QueryDataMultipleSources(ctx, user, false, metricReq, true)
 	if err != nil {
 		return nil, err
 	}
 
-	response := backend.NewQueryDataResponse()
-
-	// execute each request and merge the backend.DataResponse into a single QueryDataResponse
-	for _, req := range requests {
-		res, err := s.pluginClient.QueryData(ctx, req)
-		if err != nil {
-			return nil, err
-		}
-		for refID, res := range res.Responses {
-			response.Responses[refID] = res
-		}
-	}
-
 	return backend.ToProto().QueryDataResponse(response)
-}
-
-// TODO: can this be shared with the query service?
-func (s *queryDataServer) getDataSourceFromQuery(ctx context.Context, signedInUser *user.SignedInUser, skipCache bool, query *simplejson.Json) (*datasources.DataSource, error) {
-	uid := query.Get("datasource").Get("uid").MustString()
-
-	// before 8.3 special types could be sent as datasource (expr)
-	if uid == "" {
-		uid = query.Get("datasource").MustString()
-	}
-
-	if expr.IsDataSource(uid) {
-		return expr.DataSourceModel(), nil
-	}
-
-	if uid == grafanads.DatasourceUID {
-		return grafanads.DataSourceModel(signedInUser.OrgID), nil
-	}
-
-	// use datasourceId if it exists
-	id := query.Get("datasourceId").MustInt64(0)
-	if id > 0 {
-		ds, err := s.dataSourceCache.GetDatasource(ctx, id, signedInUser, skipCache)
-		if err != nil {
-			return nil, err
-		}
-		return ds, nil
-	}
-
-	if uid != "" {
-		ds, err := s.dataSourceCache.GetDatasourceByUID(ctx, uid, signedInUser, skipCache)
-		if err != nil {
-			return nil, err
-		}
-		return ds, nil
-	}
-
-	return nil, fmt.Errorf("missing data source ID/UID")
-}
-
-// buildRequests splits the incoming queries into new QueryDataRequests based on the datasourceUID
-func (s *queryDataServer) buildRequests(ctx context.Context, u *user.SignedInUser, req *backend.QueryDataRequest) ([]*backend.QueryDataRequest, error) {
-	requests := make(map[string]*backend.QueryDataRequest)
-	for _, query := range req.Queries {
-		sj, err := simplejson.NewJson(query.JSON)
-		if err != nil {
-			return nil, err
-		}
-
-		ds, err := s.getDataSourceFromQuery(ctx, u, false, sj)
-		if err != nil {
-			return nil, err
-		}
-
-		r, ok := requests[ds.Uid]
-		if !ok {
-			instanceSettings, err := adapters.ModelToInstanceSettings(ds, s.decryptSecureJsonDataFn(ctx))
-			if err != nil {
-				return nil, err
-			}
-			r = &backend.QueryDataRequest{
-				PluginContext: req.PluginContext,
-				Headers:       req.Headers,
-				Queries:       make([]backend.DataQuery, 0),
-			}
-			r.PluginContext.PluginID = ds.Type
-			r.PluginContext.DataSourceInstanceSettings = instanceSettings
-			requests[ds.Uid] = r
-		}
-
-		requests[ds.Uid].Queries = append(r.Queries, query)
-	}
-
-	reqs := make([]*backend.QueryDataRequest, 0)
-	for _, req := range requests {
-		reqs = append(reqs, req)
-	}
-
-	return reqs, nil
-}
-
-// TODO: can this be shared with the query service?
-func (s *queryDataServer) decryptSecureJsonDataFn(ctx context.Context) func(ds *datasources.DataSource) (map[string]string, error) {
-	return func(ds *datasources.DataSource) (map[string]string, error) {
-		return s.dataSourceService.DecryptedValues(ctx, ds)
-	}
 }
 
 // SignedInUserFromBackendUser converts the backend plugin's model to Grafana's SignedInUser model


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

https://github.com/grafana/grafana/pull/55781 was sitting on a branch stale for months, and I had an approach to split queries into separate `QueryDataRequest`s and merge responses, but during PR review, I noticed `query.QueryDataMultipleSources` was added recently that does something similar.

It would be great to remove the custom code, but it seems like there are some things to resolve before that is possible:
* [ ] `QueryDataMultipleSources` seems to be only for public dashboards, and there is custom behavior related to that use case. I don't have a lot of context about why modifications like https://github.com/grafana/grafana/pull/54933 are needed, but it seems like that might be a blocker for using this for the queries outside of that use case.
* [ ]  `DataQuery` seems like a semi-parsed version of the `MetricRequest` query JSON, so I need to do more investigation on how to convert the `DataQuery` back into a `MetricRequest` JSON.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

