### PR TITLE
LogsContext: Added button to load 10 more log lines

### DIFF
--- a/public/app/features/logs/components/LogRowContext.tsx
+++ b/public/app/features/logs/components/LogRowContext.tsx
@@ -2,7 +2,7 @@ import { css, cx } from '@emotion/css';
 import React, { useRef, useState, useLayoutEffect, useEffect } from 'react';
 
 import { GrafanaTheme2, DataQueryError, LogRowModel, textUtil, LogsSortOrder } from '@grafana/data';
-import { useStyles2, Alert, ClickOutsideWrapper, CustomScrollbar, List } from '@grafana/ui';
+import { useStyles2, Alert, ClickOutsideWrapper, CustomScrollbar, List, Button } from '@grafana/ui';
 
 import { LogMessageAnsi } from './LogMessageAnsi';
 import { LogRowContextRows, LogRowContextQueryErrors, HasMoreContextRows } from './LogRowContextProvider';
@@ -31,12 +31,15 @@ const getLogRowContextStyles = (theme: GrafanaTheme2, wrapLogMessage?: boolean) 
    * We also adjust width to 75%.
    */
 
+  const headerHeight = 40;
+  const logsHeight = 220;
+  const contextHeight = headerHeight + logsHeight;
   const afterContext = wrapLogMessage
     ? css`
-        top: -250px;
+        top: -${contextHeight}px;
       `
     : css`
-        margin-top: -250px;
+        margin-top: -${contextHeight}px;
         width: 75%;
       `;
 
@@ -51,7 +54,7 @@ const getLogRowContextStyles = (theme: GrafanaTheme2, wrapLogMessage?: boolean) 
   return {
     commonStyles: css`
       position: absolute;
-      height: 250px;
+      height: ${contextHeight};
       z-index: ${theme.zIndex.dropdown};
       overflow: hidden;
       background: ${theme.colors.background.primary};
@@ -61,14 +64,17 @@ const getLogRowContextStyles = (theme: GrafanaTheme2, wrapLogMessage?: boolean) 
       width: 100%;
     `,
     header: css`
-      height: 30px;
+      height: ${headerHeight}px;
       padding: 0 10px;
       display: flex;
       align-items: center;
       background: ${theme.colors.background.secondary};
     `,
+    headerButton: css`
+      margin-left: 8px;
+    `,
     logs: css`
-      height: 220px;
+      height: ${logsHeight}px;
       padding: 10px;
     `,
     afterContext,
@@ -101,7 +107,7 @@ const LogRowContextGroupHeader: React.FunctionComponent<LogRowContextGroupHeader
   groupPosition,
   logsSortOrder,
 }) => {
-  const { header } = useStyles2(getLogRowContextStyles);
+  const { header, headerButton } = useStyles2(getLogRowContextStyles);
 
   // determine the position in time for this LogGroup by taking the ordering of
   // logs and position of the component itself into account.
@@ -124,18 +130,9 @@ const LogRowContextGroupHeader: React.FunctionComponent<LogRowContextGroupHeader
         Showing {rows.length} lines {logGroupPosition} match.
       </span>
       {(rows.length >= 10 || (rows.length > 10 && rows.length % 10 !== 0)) && canLoadMoreRows && (
-        <span
-          className={css`
-            margin-left: 10px;
-            &:hover {
-              text-decoration: underline;
-              cursor: pointer;
-            }
-          `}
-          onClick={onLoadMoreContext}
-        >
-          Load 10 more
-        </span>
+        <Button className={headerButton} variant="secondary" size="sm" onClick={onLoadMoreContext}>
+          Load 10 more lines
+        </Button>
       )}
     </div>
   );

--- a/public/app/features/logs/components/LogRowContext.tsx
+++ b/public/app/features/logs/components/LogRowContext.tsx
@@ -54,7 +54,7 @@ const getLogRowContextStyles = (theme: GrafanaTheme2, wrapLogMessage?: boolean) 
   return {
     commonStyles: css`
       position: absolute;
-      height: ${contextHeight};
+      height: ${contextHeight}px;
       z-index: ${theme.zIndex.dropdown};
       overflow: hidden;
       background: ${theme.colors.background.primary};


### PR DESCRIPTION
**What this PR does / why we need it**:
Changed the text-link which loads 10 more log lines to a button.

I added 8px top/bottom-margin to the button and not 16px as suggested in https://github.com/grafana/grafana/issues/50270 / https://user-images.githubusercontent.com/88372197/173810560-fc6116c5-da3f-4361-9222-76219ca527ba.png

**Which issue(s) this PR fixes**:

Fixes #55919

**Special notes for your reviewer**:
Previous:
![Screenshot 2022-09-28 at 13 57 42](https://user-images.githubusercontent.com/8092184/192777088-46fe80bd-f32d-407e-a10f-b6e33065e10a.png)

Now:
![Screenshot 2022-09-28 at 14 19 39](https://user-images.githubusercontent.com/8092184/192777108-7f7220c9-c841-4ad7-8cf3-fa0b9ee5d6c7.png)


