### PR TITLE
BarChart: add negY transform to fieldConfig overrides

### DIFF
--- a/public/app/plugins/panel/barchart/bars.ts
+++ b/public/app/plugins/panel/barchart/bars.ts
@@ -353,24 +353,17 @@ export function getConfig(opts: BarsOptions, theme: GrafanaTheme2) {
         let middleShift = isXHorizontal ? 0 : -Math.round(MIDDLE_BASELINE_SHIFT * fontSize);
         let value = rawValue(seriesIdx, dataIdx);
 
-        let xFormedValue = value;
-
-        if (opts.negY?.[seriesIdx] && xFormedValue != null) {
-          xFormedValue *= -1;
+        if (opts.negY?.[seriesIdx] && value != null) {
+          value *= -1;
         }
 
-        if (xFormedValue != null) {
+        if (value != null) {
           // Calculate final co-ordinates for text position
           const x =
-            u.bbox.left +
-            (isXHorizontal ? lft + wid / 2 : xFormedValue < 0 ? lft - labelOffset : lft + wid + labelOffset);
+            u.bbox.left + (isXHorizontal ? lft + wid / 2 : value < 0 ? lft - labelOffset : lft + wid + labelOffset);
           const y =
             u.bbox.top +
-            (isXHorizontal
-              ? xFormedValue < 0
-                ? top + hgt + labelOffset
-                : top - labelOffset
-              : top + hgt / 2 - middleShift);
+            (isXHorizontal ? (value < 0 ? top + hgt + labelOffset : top - labelOffset) : top + hgt / 2 - middleShift);
 
           // Retrieve textMetrics with necessary default values
           // These _shouldn't_ be undefined at this point
@@ -394,7 +387,7 @@ export function getConfig(opts: BarsOptions, theme: GrafanaTheme2) {
 
             // yAdjust only matters when the value isn't negative
             yAdjust =
-              xFormedValue > 0
+              value > 0
                 ? (textMetrics.actualBoundingBoxAscent + textMetrics.actualBoundingBoxDescent) * scaleFactor
                 : 0;
           } else {
@@ -402,7 +395,7 @@ export function getConfig(opts: BarsOptions, theme: GrafanaTheme2) {
             yAdjust = ((textMetrics.actualBoundingBoxAscent + textMetrics.actualBoundingBoxDescent) * scaleFactor) / 2;
 
             // Adjust for baseline being "right" in the x direction
-            xAdjust = xFormedValue < 0 ? textMetrics.width * scaleFactor : 0;
+            xAdjust = value < 0 ? textMetrics.width * scaleFactor : 0;
           }
 
           // Construct final bounding box for the label text
@@ -528,21 +521,16 @@ export function getConfig(opts: BarsOptions, theme: GrafanaTheme2) {
 
       for (const sidx in labels[didx]) {
         const label = labels[didx][sidx];
-        const { text, value, x = 0, y = 0 } = label;
+        const { text, x = 0, y = 0 } = label;
+        let { value } = label;
 
-        let xFormedValue = value;
-
-        if (opts.negY?.[sidx] && xFormedValue != null) {
-          xFormedValue *= -1;
+        if (opts.negY?.[sidx] && value != null) {
+          value *= -1;
         }
 
-        let align: CanvasTextAlign = isXHorizontal
-          ? 'center'
-          : xFormedValue !== null && xFormedValue < 0
-          ? 'right'
-          : 'left';
+        let align: CanvasTextAlign = isXHorizontal ? 'center' : value !== null && value < 0 ? 'right' : 'left';
         let baseline: CanvasTextBaseline = isXHorizontal
-          ? xFormedValue !== null && xFormedValue < 0
+          ? value !== null && value < 0
             ? 'top'
             : 'alphabetic'
           : 'middle';

--- a/public/app/plugins/panel/barchart/module.tsx
+++ b/public/app/plugins/panel/barchart/module.tsx
@@ -64,6 +64,7 @@ export const plugin = new PanelPlugin<PanelOptions, PanelFieldConfig>(BarChartPa
         });
 
       builder.addSelect({
+        category: ['Graph styles'],
         name: 'Transform',
         path: 'transform',
         settings: {

--- a/public/app/plugins/panel/barchart/module.tsx
+++ b/public/app/plugins/panel/barchart/module.tsx
@@ -8,7 +8,7 @@ import {
   VizOrientation,
 } from '@grafana/data';
 import { config } from '@grafana/runtime';
-import { StackingMode, VisibilityMode } from '@grafana/schema';
+import { GraphTransform, StackingMode, VisibilityMode } from '@grafana/schema';
 import { graphFieldOptions, commonOptionsBuilder } from '@grafana/ui';
 
 import { BarChartPanel } from './BarChartPanel';
@@ -62,6 +62,27 @@ export const plugin = new PanelPlugin<PanelOptions, PanelFieldConfig>(BarChartPa
             options: graphFieldOptions.fillGradient,
           },
         });
+
+      builder.addSelect({
+        name: 'Transform',
+        path: 'transform',
+        settings: {
+          options: [
+            {
+              label: 'Constant',
+              value: GraphTransform.Constant,
+              description: 'The first value will be shown as a constant line',
+            },
+            {
+              label: 'Negative Y',
+              value: GraphTransform.NegativeY,
+              description: 'Flip the results to negative values on the y axis',
+            },
+          ],
+          isClearable: true,
+        },
+        hideFromDefaults: true,
+      });
 
       commonOptionsBuilder.addAxisConfig(builder, cfg, false);
       commonOptionsBuilder.addHideFrom(builder);

--- a/public/app/plugins/panel/barchart/utils.ts
+++ b/public/app/plugins/panel/barchart/utils.ts
@@ -18,6 +18,7 @@ import {
 import { maybeSortFrame } from '@grafana/data/src/transformations/transformers/joinDataFrames';
 import {
   AxisPlacement,
+  GraphTransform,
   ScaleDirection,
   ScaleDistribution,
   ScaleOrientation,
@@ -107,6 +108,7 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn<BarChartOptionsEX> = ({
     legend,
     xSpacing: xTickLabelSpacing,
     xTimeAuto: frame.fields[0]?.type === FieldType.time && !frame.fields[0].config.unit?.startsWith('time:'),
+    negY: frame.fields.map((f) => f.config?.custom?.transform === GraphTransform.NegativeY),
   };
 
   const config = getConfig(opts, theme);

--- a/public/app/plugins/panel/barchart/utils.ts
+++ b/public/app/plugins/panel/barchart/utils.ts
@@ -108,7 +108,7 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn<BarChartOptionsEX> = ({
     legend,
     xSpacing: xTickLabelSpacing,
     xTimeAuto: frame.fields[0]?.type === FieldType.time && !frame.fields[0].config.unit?.startsWith('time:'),
-    negY: frame.fields.map((f) => f.config?.custom?.transform === GraphTransform.NegativeY),
+    negY: frame.fields.map((f) => f.config.custom?.transform === GraphTransform.NegativeY),
   };
 
   const config = getConfig(opts, theme);


### PR DESCRIPTION
Fixes #55348

makes negative y transform field override available in BarChart panel; adjusts label positions accordingly.

<details><summary>neg-y-bars.json</summary>

```json
{
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": {
          "type": "grafana",
          "uid": "-- Grafana --"
        },
        "enable": true,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "target": {
          "limit": 100,
          "matchAny": false,
          "tags": [],
          "type": "dashboard"
        },
        "type": "dashboard"
      }
    ]
  },
  "editable": true,
  "fiscalYearStartMonth": 0,
  "graphTooltip": 0,
  "id": 349,
  "links": [],
  "liveNow": false,
  "panels": [
    {
      "datasource": {
        "type": "testdata",
        "uid": "PD8C576611E62080A"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "palette-classic"
          },
          "custom": {
            "axisCenteredZero": false,
            "axisColorMode": "text",
            "axisLabel": "",
            "axisPlacement": "auto",
            "fillOpacity": 30,
            "gradientMode": "none",
            "hideFrom": {
              "legend": false,
              "tooltip": false,
              "viz": false
            },
            "lineWidth": 1,
            "scaleDistribution": {
              "type": "linear"
            }
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": null
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": [
          {
            "matcher": {
              "id": "byName",
              "options": "b"
            },
            "properties": [
              {
                "id": "custom.transform",
                "value": "negative-Y"
              }
            ]
          }
        ]
      },
      "gridPos": {
        "h": 14,
        "w": 12,
        "x": 0,
        "y": 0
      },
      "id": 6,
      "options": {
        "barRadius": 0,
        "barWidth": 0.97,
        "groupWidth": 0.7,
        "legend": {
          "calcs": [],
          "displayMode": "list",
          "placement": "bottom",
          "showLegend": true
        },
        "orientation": "vertical",
        "showValue": "auto",
        "stacking": "none",
        "tooltip": {
          "mode": "single",
          "sort": "none"
        },
        "xField": "time",
        "xTickLabelRotation": 0,
        "xTickLabelSpacing": 0
      },
      "targets": [
        {
          "alias": "a",
          "csvContent": "time,metric,value\n2022-09-01T19:00:00Z, a, 100\n2022-09-01T19:00:00Z, c, 150\n2022-09-01T20:00:00Z, a, 200\n2022-09-01T20:00:00Z, b, 300\n2022-09-01T20:00:00Z, c, 150\n2022-09-01T21:00:00Z, a, 250\n2022-09-01T21:00:00Z, b, 350\n2022-09-01T21:00:00Z, c, 150",
          "datasource": {
            "type": "testdata",
            "uid": "PD8C576611E62080A"
          },
          "refId": "A",
          "scenarioId": "csv_content"
        }
      ],
      "title": "Panel Title",
      "transformations": [
        {
          "id": "prepareTimeSeries",
          "options": {
            "format": "many"
          }
        },
        {
          "id": "prepareTimeSeries",
          "options": {
            "format": "wide"
          }
        },
        {
          "id": "organize",
          "options": {
            "excludeByName": {
              "time": false
            },
            "indexByName": {
              "time": 0,
              "value {metric=\"a\", name=\"a\"}": 1,
              "value {metric=\"b\", name=\"a\"}": 2,
              "value {metric=\"c\", name=\"a\"}": 3
            },
            "renameByName": {
              "value {metric=\"a\", name=\"a\"}": "a",
              "value {metric=\"b\", name=\"a\"}": "b",
              "value {metric=\"c\", name=\"a\"}": "c"
            }
          }
        }
      ],
      "type": "barchart"
    },
    {
      "datasource": {
        "type": "testdata",
        "uid": "PD8C576611E62080A"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "palette-classic"
          },
          "custom": {
            "axisCenteredZero": false,
            "axisColorMode": "text",
            "axisLabel": "",
            "axisPlacement": "auto",
            "fillOpacity": 30,
            "gradientMode": "none",
            "hideFrom": {
              "legend": false,
              "tooltip": false,
              "viz": false
            },
            "lineWidth": 1,
            "scaleDistribution": {
              "type": "linear"
            }
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": null
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": [
          {
            "matcher": {
              "id": "byName",
              "options": "b"
            },
            "properties": [
              {
                "id": "custom.transform",
                "value": "negative-Y"
              }
            ]
          }
        ]
      },
      "gridPos": {
        "h": 15,
        "w": 12,
        "x": 12,
        "y": 0
      },
      "id": 3,
      "options": {
        "barRadius": 0,
        "barWidth": 0.97,
        "groupWidth": 0.7,
        "legend": {
          "calcs": [],
          "displayMode": "list",
          "placement": "bottom",
          "showLegend": true
        },
        "orientation": "auto",
        "showValue": "auto",
        "stacking": "normal",
        "tooltip": {
          "mode": "single",
          "sort": "none"
        },
        "xField": "time",
        "xTickLabelRotation": 0,
        "xTickLabelSpacing": 0
      },
      "targets": [
        {
          "alias": "a",
          "csvContent": "time,metric,value\n2022-09-01T19:00:00Z, a, 100\n2022-09-01T19:00:00Z, c, 150\n2022-09-01T20:00:00Z, a, 200\n2022-09-01T20:00:00Z, b, 300\n2022-09-01T20:00:00Z, c, 150\n2022-09-01T21:00:00Z, a, 250\n2022-09-01T21:00:00Z, b, 350\n2022-09-01T21:00:00Z, c, 150",
          "datasource": {
            "type": "testdata",
            "uid": "PD8C576611E62080A"
          },
          "refId": "A",
          "scenarioId": "csv_content"
        }
      ],
      "title": "Panel Title",
      "transformations": [
        {
          "id": "prepareTimeSeries",
          "options": {
            "format": "many"
          }
        },
        {
          "id": "prepareTimeSeries",
          "options": {
            "format": "wide"
          }
        },
        {
          "id": "organize",
          "options": {
            "excludeByName": {
              "time": false
            },
            "indexByName": {
              "time": 0,
              "value {metric=\"a\", name=\"a\"}": 1,
              "value {metric=\"b\", name=\"a\"}": 2,
              "value {metric=\"c\", name=\"a\"}": 3
            },
            "renameByName": {
              "value {metric=\"a\", name=\"a\"}": "a",
              "value {metric=\"b\", name=\"a\"}": "b",
              "value {metric=\"c\", name=\"a\"}": "c"
            }
          }
        }
      ],
      "type": "barchart"
    },
    {
      "datasource": {
        "type": "testdata",
        "uid": "PD8C576611E62080A"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "palette-classic"
          },
          "custom": {
            "axisCenteredZero": false,
            "axisColorMode": "text",
            "axisLabel": "",
            "axisPlacement": "auto",
            "fillOpacity": 30,
            "gradientMode": "none",
            "hideFrom": {
              "legend": false,
              "tooltip": false,
              "viz": false
            },
            "lineWidth": 1,
            "scaleDistribution": {
              "type": "linear"
            }
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": null
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": [
          {
            "matcher": {
              "id": "byName",
              "options": "b"
            },
            "properties": [
              {
                "id": "custom.transform",
                "value": "negative-Y"
              }
            ]
          }
        ]
      },
      "gridPos": {
        "h": 15,
        "w": 12,
        "x": 0,
        "y": 14
      },
      "id": 5,
      "options": {
        "barRadius": 0,
        "barWidth": 0.97,
        "groupWidth": 0.7,
        "legend": {
          "calcs": [],
          "displayMode": "list",
          "placement": "bottom",
          "showLegend": true
        },
        "orientation": "horizontal",
        "showValue": "auto",
        "stacking": "none",
        "tooltip": {
          "mode": "single",
          "sort": "none"
        },
        "xField": "time",
        "xTickLabelRotation": 0,
        "xTickLabelSpacing": 0
      },
      "targets": [
        {
          "alias": "a",
          "csvContent": "time,metric,value\n2022-09-01T19:00:00Z, a, 100\n2022-09-01T19:00:00Z, c, 150\n2022-09-01T20:00:00Z, a, 200\n2022-09-01T20:00:00Z, b, 300\n2022-09-01T20:00:00Z, c, 150\n2022-09-01T21:00:00Z, a, 250\n2022-09-01T21:00:00Z, b, 350\n2022-09-01T21:00:00Z, c, 150",
          "datasource": {
            "type": "testdata",
            "uid": "PD8C576611E62080A"
          },
          "refId": "A",
          "scenarioId": "csv_content"
        }
      ],
      "title": "Panel Title",
      "transformations": [
        {
          "id": "prepareTimeSeries",
          "options": {
            "format": "many"
          }
        },
        {
          "id": "prepareTimeSeries",
          "options": {
            "format": "wide"
          }
        },
        {
          "id": "organize",
          "options": {
            "excludeByName": {
              "time": false
            },
            "indexByName": {
              "time": 0,
              "value {metric=\"a\", name=\"a\"}": 1,
              "value {metric=\"b\", name=\"a\"}": 2,
              "value {metric=\"c\", name=\"a\"}": 3
            },
            "renameByName": {
              "value {metric=\"a\", name=\"a\"}": "a",
              "value {metric=\"b\", name=\"a\"}": "b",
              "value {metric=\"c\", name=\"a\"}": "c"
            }
          }
        }
      ],
      "type": "barchart"
    },
    {
      "datasource": {
        "type": "testdata",
        "uid": "PD8C576611E62080A"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "palette-classic"
          },
          "custom": {
            "axisCenteredZero": false,
            "axisColorMode": "text",
            "axisLabel": "",
            "axisPlacement": "auto",
            "fillOpacity": 30,
            "gradientMode": "none",
            "hideFrom": {
              "legend": false,
              "tooltip": false,
              "viz": false
            },
            "lineWidth": 1,
            "scaleDistribution": {
              "type": "linear"
            }
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": null
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": [
          {
            "matcher": {
              "id": "byName",
              "options": "b"
            },
            "properties": [
              {
                "id": "custom.transform",
                "value": "negative-Y"
              }
            ]
          }
        ]
      },
      "gridPos": {
        "h": 14,
        "w": 12,
        "x": 12,
        "y": 15
      },
      "id": 4,
      "options": {
        "barRadius": 0,
        "barWidth": 0.97,
        "groupWidth": 0.7,
        "legend": {
          "calcs": [],
          "displayMode": "list",
          "placement": "bottom",
          "showLegend": true
        },
        "orientation": "horizontal",
        "showValue": "auto",
        "stacking": "normal",
        "tooltip": {
          "mode": "single",
          "sort": "none"
        },
        "xField": "time",
        "xTickLabelRotation": 0,
        "xTickLabelSpacing": 0
      },
      "targets": [
        {
          "alias": "a",
          "csvContent": "time,metric,value\n2022-09-01T19:00:00Z, a, 100\n2022-09-01T19:00:00Z, c, 150\n2022-09-01T20:00:00Z, a, 200\n2022-09-01T20:00:00Z, b, 300\n2022-09-01T20:00:00Z, c, 150\n2022-09-01T21:00:00Z, a, 250\n2022-09-01T21:00:00Z, b, 350\n2022-09-01T21:00:00Z, c, 150",
          "datasource": {
            "type": "testdata",
            "uid": "PD8C576611E62080A"
          },
          "refId": "A",
          "scenarioId": "csv_content"
        }
      ],
      "title": "Panel Title",
      "transformations": [
        {
          "id": "prepareTimeSeries",
          "options": {
            "format": "many"
          }
        },
        {
          "id": "prepareTimeSeries",
          "options": {
            "format": "wide"
          }
        },
        {
          "id": "organize",
          "options": {
            "excludeByName": {
              "time": false
            },
            "indexByName": {
              "time": 0,
              "value {metric=\"a\", name=\"a\"}": 1,
              "value {metric=\"b\", name=\"a\"}": 2,
              "value {metric=\"c\", name=\"a\"}": 3
            },
            "renameByName": {
              "value {metric=\"a\", name=\"a\"}": "a",
              "value {metric=\"b\", name=\"a\"}": "b",
              "value {metric=\"c\", name=\"a\"}": "c"
            }
          }
        }
      ],
      "type": "barchart"
    }
  ],
  "refresh": false,
  "schemaVersion": 37,
  "style": "dark",
  "tags": [],
  "templating": {
    "list": []
  },
  "time": {
    "from": "2022-09-01T18:13:18.658Z",
    "to": "2022-09-01T22:07:45.586Z"
  },
  "timepicker": {},
  "timezone": "",
  "title": "test-stack",
  "uid": "piJUyWV4z",
  "version": 11,
  "weekStart": ""
}
```
</details>

![image](https://user-images.githubusercontent.com/43234/192796581-0a2e5912-4871-4470-8de8-3bc03417dd51.png)
