### PR TITLE
Loki: Add new range operation rate_counter

### DIFF
--- a/package.json
+++ b/package.json
@@ -257,7 +257,7 @@
     "@grafana/e2e-selectors": "workspace:*",
     "@grafana/experimental": "^0.0.2-canary.36",
     "@grafana/google-sdk": "0.0.3",
-    "@grafana/lezer-logql": "0.1.0",
+    "@grafana/lezer-logql": "0.1.1",
     "@grafana/runtime": "workspace:*",
     "@grafana/schema": "workspace:*",
     "@grafana/ui": "workspace:*",

--- a/public/app/plugins/datasource/loki/querybuilder/operations.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/operations.ts
@@ -47,6 +47,7 @@ export function getOperationDefinitions(): QueryBuilderOperationDef[] {
 
   const list: QueryBuilderOperationDef[] = [
     createRangeOperation(LokiOperationId.Rate),
+    createRangeOperation(LokiOperationId.RateCounter),
     createRangeOperation(LokiOperationId.CountOverTime),
     createRangeOperation(LokiOperationId.SumOverTime),
     createRangeOperation(LokiOperationId.BytesRate),

--- a/public/app/plugins/datasource/loki/querybuilder/types.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/types.ts
@@ -41,6 +41,7 @@ export enum LokiOperationId {
   LineFormat = 'line_format',
   LabelFormat = 'label_format',
   Rate = 'rate',
+  RateCounter = 'rate_counter',
   CountOverTime = 'count_over_time',
   SumOverTime = 'sum_over_time',
   AvgOverTime = 'avg_over_time',

--- a/yarn.lock
+++ b/yarn.lock
@@ -5408,12 +5408,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grafana/lezer-logql@npm:0.1.0":
-  version: 0.1.0
-  resolution: "@grafana/lezer-logql@npm:0.1.0"
+"@grafana/lezer-logql@npm:0.1.1":
+  version: 0.1.1
+  resolution: "@grafana/lezer-logql@npm:0.1.1"
   peerDependencies:
     "@lezer/lr": ^1.0.0
-  checksum: 77c8a75c211cfdebe99eaf892d07673c52531fdb696c463a9dade74c25d919b87561b2f97c716d1d710c95da7c49edcffb6c98e0d4b635d0aa91d40cc5167f9e
+  checksum: b0d71e5670c54d92fbc4bd92fe72cfb27469cc9797d5595b284f9d2b86782584cb1a9b8bac51af07648b807a9287e7159dcdd0e1fc3e32a2e79d52b3a7700e4b
   languageName: node
   linkType: hard
 
@@ -22434,7 +22434,7 @@ __metadata:
     "@grafana/eslint-config": 5.0.0
     "@grafana/experimental": ^0.0.2-canary.36
     "@grafana/google-sdk": 0.0.3
-    "@grafana/lezer-logql": 0.1.0
+    "@grafana/lezer-logql": 0.1.1
     "@grafana/runtime": "workspace:*"
     "@grafana/schema": "workspace:*"
     "@grafana/toolkit": "workspace:*"


### PR DESCRIPTION
Following up on https://github.com/grafana/lezer-logql/pull/21 and new `rate_counter` range aggregation in Loki, this PR adds new `rate_counter` to Loki operations list and updates `@grafana/lezer-logql`