### PR TITLE
Inspect: Handle JSON tab crash when the provided object is too big to stringify.

### DIFF
--- a/public/app/features/inspector/InspectJSONTab.tsx
+++ b/public/app/features/inspector/InspectJSONTab.tsx
@@ -217,5 +217,18 @@ export class InspectJSONTab extends PureComponent<Props, State> {
 }
 
 function getPrettyJSON(obj: any): string {
-  return JSON.stringify(obj, null, 2);
+  let r = '';
+  try {
+    r = JSON.stringify(obj, null, 2);
+  } catch (e) {
+    if (
+      e instanceof Error &&
+      (e.toString().includes('RangeError') || e.toString().includes('allocation size overflow'))
+    ) {
+      appEvents.emit(AppEvents.alertError, [e.toString(), 'possibly too much data, try setting a lower line limit']);
+    } else {
+      appEvents.emit(AppEvents.alertError, [e instanceof Error ? e.toString() : e]);
+    }
+  }
+  return r;
 }

--- a/public/app/features/inspector/InspectJSONTab.tsx
+++ b/public/app/features/inspector/InspectJSONTab.tsx
@@ -225,7 +225,7 @@ function getPrettyJSON(obj: any): string {
       e instanceof Error &&
       (e.toString().includes('RangeError') || e.toString().includes('allocation size overflow'))
     ) {
-      appEvents.emit(AppEvents.alertError, [e.toString(), 'possibly too much data, try setting a lower line limit']);
+      appEvents.emit(AppEvents.alertError, [e.toString(), 'Cannot display JSON, the object is too big.']);
     } else {
       appEvents.emit(AppEvents.alertError, [e instanceof Error ? e.toString() : e]);
     }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->
**Which issue(s) this PR fixes**:
As per [this](https://github.com/grafana/grafana/issues/54188#issue-1350020111), inspector crushes if fed with too much data (needs to manual set line limit to something high ex. 3000). This PR is a proposal for addressing this crash by catching the error and handling it.
More specifically it will try to stringify the data and in case of error it will return an empty string and display an error message.
<!--
- Automatically closes linked issue when the Pull Request is merged.
Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"
-->
Fixes #54188
**Special notes for your reviewer**:
Don’t really know if that’s an acceptable error handling/ user experience in Grafana, so I am open to suggestions/ feedback.
