### PR TITLE
Alerting: Allow created by to be manually set when there's no creator for silences

### DIFF
--- a/public/app/features/alerting/unified/components/silences/SilencesEditor.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilencesEditor.tsx
@@ -164,6 +164,7 @@ export const SilencesEditor: FC<Props> = ({ silence, alertManagerSourceName }) =
     700,
     [clearErrors, duration, endsAt, prevDuration, setValue, startsAt]
   );
+  const userLogged = Boolean(config.bootData.user.isSignedIn && config.bootData.user.name);
 
   return (
     <FormProvider {...formAPI}>
@@ -206,18 +207,20 @@ export const SilencesEditor: FC<Props> = ({ silence, alertManagerSourceName }) =
               placeholder="Details about the silence"
             />
           </Field>
-          <Field
-            className={cx(styles.field, styles.createdBy)}
-            label="Created By"
-            required
-            error={formState.errors.createdBy?.message}
-            invalid={!!formState.errors.createdBy}
-          >
-            <Input
-              {...register('createdBy', { required: { value: true, message: 'Required.' } })}
-              placeholder="Who's creating the silence"
-            />
-          </Field>
+          {!userLogged && (
+            <Field
+              className={cx(styles.field, styles.createdBy)}
+              label="Created By"
+              required
+              error={formState.errors.createdBy?.message}
+              invalid={!!formState.errors.createdBy}
+            >
+              <Input
+                {...register('createdBy', { required: { value: true, message: 'Required.' } })}
+                placeholder="Who's creating the silence"
+              />
+            </Field>
+          )}
           <MatchedSilencedRules />
         </FieldSet>
         <div className={styles.flexRow}>

--- a/public/app/features/alerting/unified/components/silences/SilencesEditor.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilencesEditor.tsx
@@ -206,6 +206,18 @@ export const SilencesEditor: FC<Props> = ({ silence, alertManagerSourceName }) =
               placeholder="Details about the silence"
             />
           </Field>
+          <Field
+            className={cx(styles.field, styles.createdBy)}
+            label="Created By"
+            required
+            error={formState.errors.createdBy?.message}
+            invalid={!!formState.errors.createdBy}
+          >
+            <Input
+              {...register('createdBy', { required: { value: true, message: 'Required.' } })}
+              placeholder="Who's creating the silence"
+            />
+          </Field>
           <MatchedSilencedRules />
         </FieldSet>
         <div className={styles.flexRow}>


### PR DESCRIPTION
Grafana has a mode that allows unauthenticated interaction, typically the created by field of a silence is inferred from the current logged user. When this is not present, the field is left black and thus the silence creation fails.

This allows us to set the created by when it is not possible to infer it from the current user.

- [x] Ideally, I would like the form to only show when `createdBy` is undefined. However, my javascript foo is way to rusty to even begin to attempt doing that - could I get some help?

fixes https://github.com/grafana/grafana/issues/55948
