### PR TITLE
Geomap: Fix tooltip display option

### DIFF
--- a/packages/grafana-data/src/geo/layer.ts
+++ b/packages/grafana-data/src/geo/layer.ts
@@ -68,7 +68,7 @@ export interface MapLayerOptions<TConfig = any> {
   opacity?: number;
 
   // Check tooltip (defaults to true)
-  tooltip?: boolean;
+  tooltipGeomap?: boolean;
 }
 
 /**

--- a/public/app/plugins/panel/geomap/GeomapPanel.tsx
+++ b/public/app/plugins/panel/geomap/GeomapPanel.tsx
@@ -375,7 +375,7 @@ export class GeomapPanel extends Component<Props, State> {
     let { ttip, ttipOpen, topRight1, legends, topRight2 } = this.state;
     const { options } = this.props;
     const showScale = options.controls.showScale;
-    if (!ttipOpen && options.tooltip?.mode === TooltipMode.None) {
+    if (!ttipOpen && options.tooltipGeomap?.mode === TooltipMode.None) {
       ttip = undefined;
     }
 

--- a/public/app/plugins/panel/geomap/editor/layerEditor.tsx
+++ b/public/app/plugins/panel/geomap/editor/layerEditor.tsx
@@ -56,7 +56,6 @@ export function getLayerEditor(opts: LayerEditorOptions): NestedPanelOptions<Map
       if (!opts.state) {
         return;
       }
-
       const { handler, options } = opts.state;
       const layer = geomapLayerRegistry.getIfExists(options?.type);
 
@@ -115,7 +114,7 @@ export function getLayerEditor(opts: LayerEditorOptions): NestedPanelOptions<Map
           });
         }
         builder.addBooleanSwitch({
-          path: 'tooltip',
+          path: 'tooltipGeomap',
           name: 'Display tooltip',
           description: 'Show the tooltip for layer',
           defaultValue: true,

--- a/public/app/plugins/panel/geomap/layers/data/dayNightLayer.tsx
+++ b/public/app/plugins/panel/geomap/layers/data/dayNightLayer.tsx
@@ -47,7 +47,7 @@ export const defaultDayNightConfig: MapLayerOptions<DayNightConfig> = {
   type: DAY_NIGHT_LAYER_ID,
   name: '', // will get replaced
   config: defaultConfig,
-  tooltip: true,
+  tooltipGeomap: true,
 };
 
 /**

--- a/public/app/plugins/panel/geomap/layers/data/markersLayer.tsx
+++ b/public/app/plugins/panel/geomap/layers/data/markersLayer.tsx
@@ -42,7 +42,7 @@ export const defaultMarkersConfig: MapLayerOptions<MarkersConfig> = {
   location: {
     mode: FrameGeometrySourceMode.Auto,
   },
-  tooltip: true,
+  tooltipGeomap: true,
 };
 
 /**

--- a/public/app/plugins/panel/geomap/layers/data/routeLayer.tsx
+++ b/public/app/plugins/panel/geomap/layers/data/routeLayer.tsx
@@ -52,7 +52,8 @@ export const defaultRouteConfig: MapLayerOptions<RouteConfig> = {
   location: {
     mode: FrameGeometrySourceMode.Auto,
   },
-  tooltip: false,
+  // change
+  tooltipGeomap: false,
 };
 
 /**

--- a/public/app/plugins/panel/geomap/layers/data/routeLayer.tsx
+++ b/public/app/plugins/panel/geomap/layers/data/routeLayer.tsx
@@ -52,7 +52,6 @@ export const defaultRouteConfig: MapLayerOptions<RouteConfig> = {
   location: {
     mode: FrameGeometrySourceMode.Auto,
   },
-  // change
   tooltipGeomap: false,
 };
 

--- a/public/app/plugins/panel/geomap/migrations.ts
+++ b/public/app/plugins/panel/geomap/migrations.ts
@@ -47,7 +47,7 @@ export function worldmapToGeomapOptions(angular: any): { fieldConfig: FieldConfi
     layers: [
       // TODO? depends on current configs
     ],
-    tooltip: { mode: TooltipMode.Details },
+    tooltipGeomap: { mode: TooltipMode.Details },
   };
 
   let v = asNumber(angular.decimals);

--- a/public/app/plugins/panel/geomap/module.tsx
+++ b/public/app/plugins/panel/geomap/module.tsx
@@ -134,7 +134,7 @@ export const plugin = new PanelPlugin<GeomapPanelOptions>(GeomapPanel)
       })
       .addRadio({
         category,
-        path: 'tooltip.mode',
+        path: 'tooltipGeomap.mode',
         name: 'Tooltip',
         defaultValue: TooltipMode.Details,
         settings: {

--- a/public/app/plugins/panel/geomap/types.ts
+++ b/public/app/plugins/panel/geomap/types.ts
@@ -73,7 +73,7 @@ export interface GeomapPanelOptions {
   controls: ControlsOptions;
   basemap: MapLayerOptions;
   layers: MapLayerOptions[];
-  tooltip: TooltipOptions;
+  tooltipGeomap: TooltipOptions;
 }
 
 export interface FeatureStyleConfig {

--- a/public/app/plugins/panel/geomap/utils/actions.ts
+++ b/public/app/plugins/panel/geomap/utils/actions.ts
@@ -50,7 +50,7 @@ export const getActions = (panel: GeomapPanel) => {
           name: getNextLayerName(panel),
           config: cloneDeep(item.defaultOptions),
           location: item.showLocation ? { mode: FrameGeometrySourceMode.Auto } : undefined,
-          tooltip: true,
+          tooltipGeomap: true,
         },
         false
       ).then((lyr) => {

--- a/public/app/plugins/panel/geomap/utils/tootltip.ts
+++ b/public/app/plugins/panel/geomap/utils/tootltip.ts
@@ -89,7 +89,7 @@ export const pointerMoveListener = (evt: MapBrowserEvent<UIEvent>, panel: Geomap
     {
       layerFilter: (l) => {
         const hoverLayerState = getMapLayerState(l);
-        return hoverLayerState?.options?.tooltip !== false;
+        return hoverLayerState?.options?.tooltipGeomap !== false;
       },
     }
   );


### PR DESCRIPTION
What this PR does / why we need it:
When collapsing or expanding panel editor category menus, tooltip control becomes disabled. This is caused by cleanup routine in navigation (https://github.com/grafana/grafana/blob/main/public/app/core/navigation/GrafanaRoute.tsx#L78-L86) removing elements of id 'tooltip'.

Before:
![Sep-28-2022 08-59-16](https://user-images.githubusercontent.com/60050885/192871193-a9b88a06-03c5-4490-9da8-4d49b056a51b.gif)

After:
![Sep-28-2022 12-28-38](https://user-images.githubusercontent.com/60050885/192871653-d402db19-5f35-431b-8272-0acb55b6b048.gif)

Fixes #55125 