### PR TITLE
Geomap: Fix tooltip display option

### DIFF
--- a/public/app/core/components/OptionsUI/registry.tsx
+++ b/public/app/core/components/OptionsUI/registry.tsx
@@ -81,7 +81,8 @@ export const getAllOptionEditors = () => {
     name: 'Boolean',
     description: 'Allows boolean values input',
     editor(props) {
-      return <Switch {...props} onChange={(e) => props.onChange(e.currentTarget.checked)} />;
+      const { id, ...rest } = props; // Remove id from properties passed into switch
+      return <Switch {...rest} onChange={(e) => props.onChange(e.currentTarget.checked)} />;
     },
   };
 


### PR DESCRIPTION
What this PR does / why we need it:
When collapsing or expanding panel editor category menus, tooltip control becomes disabled. This is caused by cleanup routine in navigation (https://github.com/grafana/grafana/blob/main/public/app/core/navigation/GrafanaRoute.tsx#L78-L86) removing elements of id 'tooltip'.

Before:
![Sep-28-2022 08-59-16](https://user-images.githubusercontent.com/60050885/192871193-a9b88a06-03c5-4490-9da8-4d49b056a51b.gif)

After:
![Sep-28-2022 13-01-24](https://user-images.githubusercontent.com/60050885/192877568-e23d82a4-8e48-427a-9aed-cbfa942fa2b5.gif)

Fixes #55125 