### PR TITLE
Canvas: Fix inline edit toggle crash

### DIFF
--- a/public/app/plugins/panel/canvas/CanvasPanel.tsx
+++ b/public/app/plugins/panel/canvas/CanvasPanel.tsx
@@ -168,15 +168,16 @@ export class CanvasPanel extends Component<Props, State> {
     const shouldShowAdvancedTypesSwitched =
       this.props.options.showAdvancedTypes !== nextProps.options.showAdvancedTypes;
     if (shouldUpdateSceneAndPanel || inlineEditingSwitched || shouldShowAdvancedTypesSwitched) {
+      if (inlineEditingSwitched) {
+        // Replace scene div to prevent selecto instance leaks
+        this.scene.revId++;
+      }
+
       this.needsReload = false;
       this.scene.load(nextProps.options.root, nextProps.options.inlineEditing, nextProps.options.showAdvancedTypes);
       this.scene.updateSize(nextProps.width, nextProps.height);
       this.scene.updateData(nextProps.data);
       changed = true;
-
-      if (inlineEditingSwitched && this.props.options.inlineEditing) {
-        this.scene.selecto?.destroy();
-      }
     }
 
     return changed;

--- a/public/app/plugins/panel/canvas/editor/layerEditor.tsx
+++ b/public/app/plugins/panel/canvas/editor/layerEditor.tsx
@@ -32,7 +32,7 @@ export function getLayerEditor(opts: InstanceState): NestedPanelOptions<LayerEdi
         break;
       }
 
-      if (element.parent) {
+      if (element && element.parent) {
         scene.currentLayer = element.parent;
         break;
       }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Address crash that occurred when turning off inline editing

Before 

https://user-images.githubusercontent.com/22381771/190003508-863df473-c6a4-4b78-a9d2-c6e0ea812828.mov


After


https://user-images.githubusercontent.com/22381771/192893543-7992521f-b8f5-49a1-97ce-4d925eadfe9e.mov



**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #55135

