### PR TITLE
Alerting: Make rule evaluation routine to be stateless

### DIFF
--- a/pkg/services/ngalert/state/cache.go
+++ b/pkg/services/ngalert/state/cache.go
@@ -16,8 +16,9 @@ import (
 )
 
 type ruleStates struct {
-	mtx    sync.Mutex
-	states map[string]*State
+	mtx                sync.Mutex
+	currentRuleVersion int64
+	states             map[string]*State
 }
 
 type cache struct {

--- a/pkg/services/ngalert/state/cache.go
+++ b/pkg/services/ngalert/state/cache.go
@@ -36,6 +36,13 @@ func newCache(logger log.Logger, metrics *metrics.State) *cache {
 	}
 }
 
+func (c *cache) getRuleStates(ruleKey ngModels.AlertRuleKey) (*ruleStates, bool) {
+	c.mtxStates.Lock()
+	defer c.mtxStates.Unlock()
+	states, ok := c.states[ruleKey.OrgID][ruleKey.UID]
+	return states, ok
+}
+
 func (c *cache) getOrCreateRuleStates(ruleKey ngModels.AlertRuleKey) *ruleStates {
 	c.mtxStates.Lock()
 	defer c.mtxStates.Unlock()
@@ -273,6 +280,16 @@ func mergeLabels(a, b data.Labels) data.Labels {
 		}
 	}
 	return newLbs
+}
+
+func (c *cache) deleteRuleStates(key ngModels.AlertRuleKey) *ruleStates {
+	c.mtxStates.Lock()
+	defer c.mtxStates.Unlock()
+	ruleStates, ok := c.states[key.OrgID][key.UID]
+	if ok {
+		delete(c.states[key.OrgID], key.UID)
+	}
+	return ruleStates
 }
 
 func (c *cache) deleteEntry(orgID int64, alertRuleUID, cacheID string) {

--- a/pkg/services/ngalert/state/cache.go
+++ b/pkg/services/ngalert/state/cache.go
@@ -161,6 +161,17 @@ func (c *cache) set(entry *State) {
 	rs.states[entry.CacheId] = entry
 }
 
+func (c *cache) setRuleStates(key ngModels.AlertRuleKey, entry *ruleStates) {
+	c.mtxStates.Lock()
+	defer c.mtxStates.Unlock()
+	orgStates, ok := c.states[key.OrgID]
+	if !ok {
+		orgStates = make(map[string]*ruleStates)
+		c.states[key.OrgID] = orgStates
+	}
+	orgStates[key.UID] = entry
+}
+
 func (c *cache) get(orgID int64, alertRuleUID, stateId string) (*State, error) {
 	c.mtxStates.RLock()
 	defer c.mtxStates.RUnlock()

--- a/pkg/services/ngalert/state/cache.go
+++ b/pkg/services/ngalert/state/cache.go
@@ -15,28 +15,41 @@ import (
 	ngModels "github.com/grafana/grafana/pkg/services/ngalert/models"
 )
 
-type cache struct {
-	states      map[int64]map[string]map[string]*State // orgID > alertRuleUID > stateID > state
-	mtxStates   sync.RWMutex
-	log         log.Logger
-	metrics     *metrics.State
-	externalURL *url.URL
+type ruleStates struct {
+	mtx    sync.Mutex
+	states map[string]*State
 }
 
-func newCache(logger log.Logger, metrics *metrics.State, externalURL *url.URL) *cache {
+type cache struct {
+	states    map[int64]map[string]*ruleStates // orgID > alertRuleUID > stateID > state
+	mtxStates sync.RWMutex
+	log       log.Logger
+	metrics   *metrics.State
+}
+
+func newCache(logger log.Logger, metrics *metrics.State) *cache {
 	return &cache{
-		states:      make(map[int64]map[string]map[string]*State),
-		log:         logger,
-		metrics:     metrics,
-		externalURL: externalURL,
+		states:  make(map[int64]map[string]*ruleStates),
+		log:     logger,
+		metrics: metrics,
 	}
 }
 
-func (c *cache) getOrCreate(ctx context.Context, alertRule *ngModels.AlertRule, result eval.Result, extraLabels data.Labels) *State {
+func (c *cache) getOrCreateRuleStates(alertRule *ngModels.AlertRule) *ruleStates {
 	c.mtxStates.Lock()
 	defer c.mtxStates.Unlock()
+	states := c.states[alertRule.OrgID][alertRule.UID]
+	if states == nil {
+		states = &ruleStates{
+			states: make(map[string]*State),
+		}
+		c.states[alertRule.OrgID][alertRule.UID] = states
+	}
+	return states
+}
 
-	ruleLabels, annotations := c.expandRuleLabelsAndAnnotations(ctx, alertRule, result, extraLabels)
+func (s *ruleStates) getOrCreate(ctx context.Context, log log.Logger, alertRule *ngModels.AlertRule, result eval.Result, extraLabels data.Labels, externalURL *url.URL) *State {
+	ruleLabels, annotations := s.expandRuleLabelsAndAnnotations(ctx, log, alertRule, result, extraLabels, externalURL)
 
 	lbs := make(data.Labels, len(extraLabels)+len(ruleLabels)+len(result.Instance))
 	dupes := make(data.Labels)
@@ -53,7 +66,7 @@ func (c *cache) getOrCreate(ctx context.Context, alertRule *ngModels.AlertRule, 
 		}
 	}
 	if len(dupes) > 0 {
-		c.log.Warn("rule declares one or many reserved labels. Those rules labels will be ignored", "labels", dupes)
+		log.Warn("rule declares one or many reserved labels. Those rules labels will be ignored", "labels", dupes)
 	}
 	dupes = make(data.Labels)
 	for key, val := range result.Instance {
@@ -66,23 +79,19 @@ func (c *cache) getOrCreate(ctx context.Context, alertRule *ngModels.AlertRule, 
 		}
 	}
 	if len(dupes) > 0 {
-		c.log.Warn("evaluation result contains either reserved labels or labels declared in the rules. Those labels from the result will be ignored", "labels", dupes)
+		log.Warn("evaluation result contains either reserved labels or labels declared in the rules. Those labels from the result will be ignored", "labels", dupes)
 	}
 
 	il := ngModels.InstanceLabels(lbs)
 	id, err := il.StringKey()
 	if err != nil {
-		c.log.Error("error getting cacheId for entry", "err", err.Error())
+		log.Error("error getting cacheId for entry", "err", err.Error())
 	}
 
-	if _, ok := c.states[alertRule.OrgID]; !ok {
-		c.states[alertRule.OrgID] = make(map[string]map[string]*State)
-	}
-	if _, ok := c.states[alertRule.OrgID][alertRule.UID]; !ok {
-		c.states[alertRule.OrgID][alertRule.UID] = make(map[string]*State)
-	}
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
 
-	if state, ok := c.states[alertRule.OrgID][alertRule.UID][id]; ok {
+	if state, ok := s.states[id]; ok {
 		// Annotations can change over time, however we also want to maintain
 		// certain annotations across evaluations
 		for k, v := range state.Annotations {
@@ -95,7 +104,7 @@ func (c *cache) getOrCreate(ctx context.Context, alertRule *ngModels.AlertRule, 
 			}
 		}
 		state.Annotations = annotations
-		c.states[alertRule.OrgID][alertRule.UID][id] = state
+		s.states[id] = state
 		return state
 	}
 
@@ -109,24 +118,25 @@ func (c *cache) getOrCreate(ctx context.Context, alertRule *ngModels.AlertRule, 
 		Annotations:        annotations,
 		EvaluationDuration: result.EvaluationDuration,
 	}
+
 	if result.State == eval.Alerting {
 		newState.StartsAt = result.EvaluatedAt
 	}
-	c.states[alertRule.OrgID][alertRule.UID][id] = newState
+	s.states[id] = newState
 	return newState
 }
 
-func (c *cache) expandRuleLabelsAndAnnotations(ctx context.Context, alertRule *ngModels.AlertRule, alertInstance eval.Result, extraLabels data.Labels) (data.Labels, data.Labels) {
+func (s *ruleStates) expandRuleLabelsAndAnnotations(ctx context.Context, log log.Logger, alertRule *ngModels.AlertRule, alertInstance eval.Result, extraLabels data.Labels, externalURL *url.URL) (data.Labels, data.Labels) {
 	// use labels from the result and extra labels to expand the labels and annotations declared by the rule
 	templateLabels := mergeLabels(extraLabels, alertInstance.Instance)
 
 	expand := func(original map[string]string) map[string]string {
 		expanded := make(map[string]string, len(original))
 		for k, v := range original {
-			ev, err := expandTemplate(ctx, alertRule.Title, v, templateLabels, alertInstance, c.externalURL)
+			ev, err := expandTemplate(ctx, alertRule.Title, v, templateLabels, alertInstance, externalURL)
 			expanded[k] = ev
 			if err != nil {
-				c.log.Error("error in expanding template", "name", k, "value", v, "err", err.Error())
+				log.Error("error in expanding template", "name", k, "value", v, "err", err.Error())
 				// Store the original template on error.
 				expanded[k] = v
 			}
@@ -141,19 +151,24 @@ func (c *cache) set(entry *State) {
 	c.mtxStates.Lock()
 	defer c.mtxStates.Unlock()
 	if _, ok := c.states[entry.OrgID]; !ok {
-		c.states[entry.OrgID] = make(map[string]map[string]*State)
+		c.states[entry.OrgID] = make(map[string]*ruleStates)
 	}
-	if _, ok := c.states[entry.OrgID][entry.AlertRuleUID]; !ok {
-		c.states[entry.OrgID][entry.AlertRuleUID] = make(map[string]*State)
+	var rs *ruleStates
+	if rs, ok := c.states[entry.OrgID][entry.AlertRuleUID]; !ok {
+		rs = &ruleStates{states: make(map[string]*State)}
+		c.states[entry.OrgID][entry.AlertRuleUID] = rs
 	}
-	c.states[entry.OrgID][entry.AlertRuleUID][entry.CacheId] = entry
+	rs.states[entry.CacheId] = entry
 }
 
 func (c *cache) get(orgID int64, alertRuleUID, stateId string) (*State, error) {
 	c.mtxStates.RLock()
 	defer c.mtxStates.RUnlock()
-	if state, ok := c.states[orgID][alertRuleUID][stateId]; ok {
-		return state, nil
+	if rs, ok := c.states[orgID][alertRuleUID]; ok {
+		state, ok := rs.states[stateId]
+		if ok {
+			return state, nil
+		}
 	}
 	return nil, fmt.Errorf("no entry for %s:%s was found", alertRuleUID, stateId)
 }
@@ -163,7 +178,7 @@ func (c *cache) getAll(orgID int64) []*State {
 	c.mtxStates.RLock()
 	defer c.mtxStates.RUnlock()
 	for _, v1 := range c.states[orgID] {
-		for _, v2 := range v1 {
+		for _, v2 := range v1.states {
 			states = append(states, v2)
 		}
 	}
@@ -174,7 +189,7 @@ func (c *cache) getStatesForRuleUID(orgID int64, alertRuleUID string) []*State {
 	var ruleStates []*State
 	c.mtxStates.RLock()
 	defer c.mtxStates.RUnlock()
-	for _, state := range c.states[orgID][alertRuleUID] {
+	for _, state := range c.states[orgID][alertRuleUID].states {
 		ruleStates = append(ruleStates, state)
 	}
 	return ruleStates
@@ -184,13 +199,16 @@ func (c *cache) getStatesForRuleUID(orgID int64, alertRuleUID string) []*State {
 func (c *cache) removeByRuleUID(orgID int64, uid string) []*State {
 	c.mtxStates.Lock()
 	defer c.mtxStates.Unlock()
-	statesMap := c.states[orgID][uid]
-	delete(c.states[orgID], uid)
-	if statesMap == nil {
+	ruleState, ok := c.states[orgID][uid]
+	if !ok {
 		return nil
 	}
-	states := make([]*State, 0, len(statesMap))
-	for _, state := range statesMap {
+	delete(c.states[orgID], uid)
+	if len(ruleState.states) == 0 {
+		return nil
+	}
+	states := make([]*State, 0, len(ruleState.states))
+	for _, state := range ruleState.states {
 		states = append(states, state)
 	}
 	return states
@@ -199,7 +217,7 @@ func (c *cache) removeByRuleUID(orgID int64, uid string) []*State {
 func (c *cache) reset() {
 	c.mtxStates.Lock()
 	defer c.mtxStates.Unlock()
-	c.states = make(map[int64]map[string]map[string]*State)
+	c.states = make(map[int64]map[string]*ruleStates)
 }
 
 func (c *cache) recordMetrics() {
@@ -219,7 +237,7 @@ func (c *cache) recordMetrics() {
 	for org, orgMap := range c.states {
 		c.metrics.GroupRules.WithLabelValues(fmt.Sprint(org)).Set(float64(len(orgMap)))
 		for _, rule := range orgMap {
-			for _, state := range rule {
+			for _, state := range rule.states {
 				n := ct[state.State]
 				ct[state.State] = n + 1
 			}
@@ -248,5 +266,5 @@ func mergeLabels(a, b data.Labels) data.Labels {
 func (c *cache) deleteEntry(orgID int64, alertRuleUID, cacheID string) {
 	c.mtxStates.Lock()
 	defer c.mtxStates.Unlock()
-	delete(c.states[orgID][alertRuleUID], cacheID)
+	delete(c.states[orgID][alertRuleUID].states, cacheID)
 }

--- a/pkg/services/ngalert/state/cache.go
+++ b/pkg/services/ngalert/state/cache.go
@@ -36,15 +36,15 @@ func newCache(logger log.Logger, metrics *metrics.State) *cache {
 	}
 }
 
-func (c *cache) getOrCreateRuleStates(alertRule *ngModels.AlertRule) *ruleStates {
+func (c *cache) getOrCreateRuleStates(ruleKey ngModels.AlertRuleKey) *ruleStates {
 	c.mtxStates.Lock()
 	defer c.mtxStates.Unlock()
-	states := c.states[alertRule.OrgID][alertRule.UID]
+	states := c.states[ruleKey.OrgID][ruleKey.UID]
 	if states == nil {
 		states = &ruleStates{
 			states: make(map[string]*State),
 		}
-		c.states[alertRule.OrgID][alertRule.UID] = states
+		c.states[ruleKey.OrgID][ruleKey.UID] = states
 	}
 	return states
 }

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -138,9 +138,10 @@ func (st *Manager) Warm(ctx context.Context) {
 	}
 }
 
-func (st *Manager) getOrCreate(ctx context.Context, alertRule *ngModels.AlertRule, result eval.Result, extraLabels data.Labels) *State {
-	return st.cache.getOrCreate(ctx, alertRule, result, extraLabels)
-}
+//
+// func (st *Manager) getOrCreate(ctx context.Context, alertRule *ngModels.AlertRule, result eval.Result, extraLabels data.Labels) *State {
+// 	return st.cache.getOrCreate(ctx, alertRule, result, extraLabels)
+// }
 
 func (st *Manager) set(entry *State) {
 	st.cache.set(entry)

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -189,8 +189,7 @@ func (st *Manager) ProcessEvalResults(ctx context.Context, evaluatedAt time.Time
 	var states []*State
 	processedResults := make(map[string]*State, len(results))
 
-	currentStates := st.cache.getOrCreateRuleStates(alertRule)
-
+	currentStates := st.cache.getOrCreateRuleStates(alertRule.GetKey())
 	currentStates.mtx.Lock()
 
 	var obsoleteStates []*State

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -278,6 +278,12 @@ func (st *Manager) ProcessEvalResults(ctx context.Context, evaluatedAt time.Time
 	resolvedStates := st.staleResultsHandler(ctx, currentStates, evaluatedAt, alertRule, processedResults)
 	currentStates.mtx.Unlock()
 
+	if len(obsoleteStates) > 0 {
+		err := st.instanceStore.DeleteAlertInstancesByRule(ctx, alertRule.GetKey())
+		if err != nil {
+			logger.Error("Failed to delete states that belong to a rule from database")
+		}
+	}
 	if len(states) > 0 {
 		logger.Debug("saving new states to the database", "count", len(states))
 		for _, state := range states {

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -287,8 +287,6 @@ func (st *Manager) setNextState(ctx context.Context, ruleStates *ruleStates, ale
 			"err", err)
 	}
 
-	st.set(currentState)
-
 	shouldUpdateAnnotation := oldState != currentState.State || oldReason != currentState.StateReason
 	if shouldUpdateAnnotation {
 		go st.annotateState(ctx, alertRule, currentState.Labels, result.EvaluatedAt, InstanceStateAndReason{State: currentState.State, Reason: currentState.StateReason}, InstanceStateAndReason{State: oldState, Reason: oldReason})

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -140,15 +140,6 @@ func (st *Manager) Warm(ctx context.Context) {
 	}
 }
 
-//
-// func (st *Manager) getOrCreate(ctx context.Context, alertRule *ngModels.AlertRule, result eval.Result, extraLabels data.Labels) *State {
-// 	return st.cache.getOrCreate(ctx, alertRule, result, extraLabels)
-// }
-
-func (st *Manager) set(entry *State) {
-	st.cache.set(entry)
-}
-
 func (st *Manager) Get(orgID int64, alertRuleUID, stateId string) (*State, error) {
 	return st.cache.get(orgID, alertRuleUID, stateId)
 }
@@ -322,7 +313,7 @@ func (st *Manager) recordMetrics() {
 
 func (st *Manager) Put(states []*State) {
 	for _, s := range states {
-		st.set(s)
+		st.cache.set(s)
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, the actual rule state is split between scheduler (rule routine) and state manger. Rule evaluation routine keeps the version of the rule for which the current state is set and the state manager keeps the actual states. 
Therefore, when a rule is changed the state reset needs to be coordinated with the rule evaluation routine to avoid the races when the state is reset when version X is updated to version Y, and then the rule evaluation routine updates the state processing the rule of version X.

This PR moves the version of the rule the current state is for to the state manager, and updates the method ProcessEvalResults to check the current state version and current alert rule version: 
- if the current state rule version is less than the rule version then all current states get removed, firing states get resolved with state reason "RuleVersionChange" and returned along with new states. Therefore the resolution notification will be sent with information about why the state went from Firing to Normal.
- if the current state version is greater than the rule version then the evaluation results are not processed and a warning log message is emitted. 

This will let us avoid calling scheduler in API when the rule is updated and deleted. Also, it will help our migration to the handling of rules as a group in the scheduler because the scheduler will not need to know about the version of each individual rule.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

NOTE: The pull request is simpler to review by commit. 