### PR TITLE
Alerting: Move stray model structs in store package to model package

### DIFF
--- a/pkg/services/ngalert/api/api_ruler.go
+++ b/pkg/services/ngalert/api/api_ruler.go
@@ -359,11 +359,11 @@ func (srv RulerSrv) updateAlertRulesInGroup(c *models.ReqContext, groupKey ngmod
 		logger.Debug("updating database with the authorized changes", "add", len(finalChanges.New), "update", len(finalChanges.New), "delete", len(finalChanges.Delete))
 
 		if len(finalChanges.Update) > 0 || len(finalChanges.New) > 0 {
-			updates := make([]store.UpdateRule, 0, len(finalChanges.Update))
+			updates := make([]ngmodels.UpdateRule, 0, len(finalChanges.Update))
 			inserts := make([]ngmodels.AlertRule, 0, len(finalChanges.New))
 			for _, update := range finalChanges.Update {
 				logger.Debug("updating rule", "rule_uid", update.New.UID, "diff", update.Diff.String())
-				updates = append(updates, store.UpdateRule{
+				updates = append(updates, ngmodels.UpdateRule{
 					Existing: update.Existing,
 					New:      *update.New,
 				})

--- a/pkg/services/ngalert/api/persist.go
+++ b/pkg/services/ngalert/api/persist.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/grafana/grafana/pkg/models"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
-	"github.com/grafana/grafana/pkg/services/ngalert/store"
 	"github.com/grafana/grafana/pkg/services/user"
 )
 
@@ -19,7 +18,7 @@ type RuleStore interface {
 	// InsertAlertRules will insert all alert rules passed into the function
 	// and return the map of uuid to id.
 	InsertAlertRules(ctx context.Context, rule []ngmodels.AlertRule) (map[string]int64, error)
-	UpdateAlertRules(ctx context.Context, rule []store.UpdateRule) error
+	UpdateAlertRules(ctx context.Context, rule []ngmodels.UpdateRule) error
 	DeleteAlertRulesByUID(ctx context.Context, orgID int64, ruleUID ...string) error
 
 	// IncreaseVersionForAllRulesInNamespace Increases version for all rules that have specified namespace. Returns all rules that belong to the namespace

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -379,6 +379,11 @@ type ListOrgRuleGroupsQuery struct {
 	Result [][]string
 }
 
+type UpdateRule struct {
+	Existing *AlertRule
+	New      AlertRule
+}
+
 // Condition contains backend expressions and queries and the RefID
 // of the query or expression that will be evaluated.
 type Condition struct {

--- a/pkg/services/ngalert/provisioning/alert_rules.go
+++ b/pkg/services/ngalert/provisioning/alert_rules.go
@@ -143,14 +143,14 @@ func (service *AlertRuleService) UpdateRuleGroup(ctx context.Context, orgID int6
 		if err != nil {
 			return fmt.Errorf("failed to list alert rules: %w", err)
 		}
-		updateRules := make([]store.UpdateRule, 0, len(query.Result))
+		updateRules := make([]models.UpdateRule, 0, len(query.Result))
 		for _, rule := range query.Result {
 			if rule.IntervalSeconds == intervalSeconds {
 				continue
 			}
 			newRule := *rule
 			newRule.IntervalSeconds = intervalSeconds
-			updateRules = append(updateRules, store.UpdateRule{
+			updateRules = append(updateRules, models.UpdateRule{
 				Existing: rule,
 				New:      newRule,
 			})
@@ -216,7 +216,7 @@ func (service *AlertRuleService) ReplaceRuleGroup(ctx context.Context, orgID int
 			}
 		}
 
-		updates := make([]store.UpdateRule, 0, len(delta.Update))
+		updates := make([]models.UpdateRule, 0, len(delta.Update))
 		for _, update := range delta.Update {
 			// check that provenance is not changed in a invalid way
 			storedProvenance, err := service.provenanceStore.GetProvenance(ctx, update.New, orgID)
@@ -226,7 +226,7 @@ func (service *AlertRuleService) ReplaceRuleGroup(ctx context.Context, orgID int
 			if storedProvenance != provenance && storedProvenance != models.ProvenanceNone {
 				return fmt.Errorf("cannot update with provided provenance '%s', needs '%s'", provenance, storedProvenance)
 			}
-			updates = append(updates, store.UpdateRule{
+			updates = append(updates, models.UpdateRule{
 				Existing: update.Existing,
 				New:      *update.New,
 			})
@@ -281,7 +281,7 @@ func (service *AlertRuleService) UpdateAlertRule(ctx context.Context, rule model
 		return models.AlertRule{}, err
 	}
 	err = service.xact.InTransaction(ctx, func(ctx context.Context) error {
-		err := service.ruleStore.UpdateAlertRules(ctx, []store.UpdateRule{
+		err := service.ruleStore.UpdateAlertRules(ctx, []models.UpdateRule{
 			{
 				Existing: &storedRule,
 				New:      rule,

--- a/pkg/services/ngalert/provisioning/persist.go
+++ b/pkg/services/ngalert/provisioning/persist.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
-	"github.com/grafana/grafana/pkg/services/ngalert/store"
 	"github.com/grafana/grafana/pkg/services/quota"
 )
 
@@ -40,7 +39,7 @@ type RuleStore interface {
 	ListAlertRules(ctx context.Context, query *models.ListAlertRulesQuery) error
 	GetRuleGroupInterval(ctx context.Context, orgID int64, namespaceUID string, ruleGroup string) (int64, error)
 	InsertAlertRules(ctx context.Context, rule []models.AlertRule) (map[string]int64, error)
-	UpdateAlertRules(ctx context.Context, rule []store.UpdateRule) error
+	UpdateAlertRules(ctx context.Context, rule []models.UpdateRule) error
 	DeleteAlertRulesByUID(ctx context.Context, orgID int64, ruleUID ...string) error
 	GetAlertRulesGroupByRuleUID(ctx context.Context, query *models.GetAlertRulesGroupByRuleUIDQuery) error
 }

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/guardian"
-	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/services/sqlstore/searchstore"
@@ -21,17 +20,6 @@ const AlertRuleMaxTitleLength = 190
 
 // AlertRuleMaxRuleGroupNameLength is the maximum length of the alert rule group name
 const AlertRuleMaxRuleGroupNameLength = 190
-
-type UpdateRuleGroupCmd struct {
-	OrgID           int64
-	NamespaceUID    string
-	RuleGroupConfig apimodels.PostableRuleGroupConfig
-}
-
-type UpdateRule struct {
-	Existing *ngmodels.AlertRule
-	New      ngmodels.AlertRule
-}
 
 var (
 	ErrAlertRuleGroupNotFound = errors.New("rulegroup not found")
@@ -185,7 +173,7 @@ func (st DBstore) InsertAlertRules(ctx context.Context, rules []ngmodels.AlertRu
 }
 
 // UpdateAlertRules is a handler for updating alert rules.
-func (st DBstore) UpdateAlertRules(ctx context.Context, rules []UpdateRule) error {
+func (st DBstore) UpdateAlertRules(ctx context.Context, rules []ngmodels.UpdateRule) error {
 	return st.SQLStore.WithTransactionalDbSession(ctx, func(sess *sqlstore.DBSession) error {
 		ruleVersions := make([]ngmodels.AlertRuleVersion, 0, len(rules))
 		for _, r := range rules {

--- a/pkg/services/ngalert/store/alert_rule_test.go
+++ b/pkg/services/ngalert/store/alert_rule_test.go
@@ -52,7 +52,7 @@ func TestUpdateAlertRules(t *testing.T) {
 		rule := createRule(t)
 		newRule := models.CopyRule(rule)
 		newRule.Title = util.GenerateShortUID()
-		err := store.UpdateAlertRules(context.Background(), []UpdateRule{{
+		err := store.UpdateAlertRules(context.Background(), []models.UpdateRule{{
 			Existing: rule,
 			New:      *newRule,
 		},
@@ -77,7 +77,7 @@ func TestUpdateAlertRules(t *testing.T) {
 		newRule := models.CopyRule(rule)
 		newRule.Title = util.GenerateShortUID()
 
-		err := store.UpdateAlertRules(context.Background(), []UpdateRule{{
+		err := store.UpdateAlertRules(context.Background(), []models.UpdateRule{{
 			Existing: rule,
 			New:      *newRule,
 		},

--- a/pkg/services/ngalert/store/testing.go
+++ b/pkg/services/ngalert/store/testing.go
@@ -320,7 +320,7 @@ func (f *FakeRuleStore) GetNamespaceByUID(_ context.Context, uid string, orgID i
 	return nil, fmt.Errorf("not found")
 }
 
-func (f *FakeRuleStore) UpdateAlertRules(_ context.Context, q []UpdateRule) error {
+func (f *FakeRuleStore) UpdateAlertRules(_ context.Context, q []models.UpdateRule) error {
 	f.mtx.Lock()
 	defer f.mtx.Unlock()
 	f.RecordedOps = append(f.RecordedOps, q)


### PR DESCRIPTION
**What this PR does / why we need it**:

We currently define all the "command" type models in the `model` package - structs like `SaveXCmd`. We currently have maybe 10-20 of these structs in `model`.

This is a good place for them, because it allows the store's interface to be decoupled from the store's implementation.

However, there were two stray definitions living directly in the `store` package. One was dead code, I deleted it. The other is moved to `model` to match the rest.

Now, the rule storage interface is no longer coupled to the store implementation.

**Which issue(s) this PR fixes**:

Contributes to https://github.com/grafana/grafana/issues/55770

**Special notes for your reviewer**:

