### PR TITLE
AdminUser: add reset_admin_every_time_run in cfg security

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -532,7 +532,17 @@ Default is `admin`.
 
 ### admin_password
 
-The password of the default Grafana Admin. Set once on first-run. Default is `admin`.
+The password of the default Grafana Admin.
+Default is `admin`.
+
+> In Grafana < v9.2, only set once on first-run.
+> In Grafana v9.2+, behavior depends on `reset_admin_every_time_run`. When `reset_admin_every_time_run`=`false`, only set once on first-run.
+
+### reset_admin_every_time_run
+
+> Only available in Grafana v9.2+
+
+Reset the admin user and admin password every time start grafana server. Default is `false`.
 
 ### secret_key
 

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -247,6 +247,7 @@ type Cfg struct {
 
 	// Security
 	DisableInitAdminCreation          bool
+	ResetAdminEveryTimeRun            bool
 	DisableBruteForceLoginProtection  bool
 	CookieSecure                      bool
 	CookieSameSiteDisabled            bool
@@ -1292,6 +1293,7 @@ func readSecuritySettings(iniFile *ini.File, cfg *Cfg) error {
 	cfg.DisableInitAdminCreation = security.Key("disable_initial_admin_creation").MustBool(false)
 	cfg.AdminUser = valueAsString(security, "admin_user", "")
 	cfg.AdminPassword = valueAsString(security, "admin_password", "")
+	cfg.ResetAdminEveryTimeRun = security.Key("reset_admin_every_time_run").MustBool(false)
 	cfg.AdminEmail = valueAsString(security, "admin_email", fmt.Sprintf("%s@localhost", cfg.AdminUser))
 
 	return nil


### PR DESCRIPTION
Signed-off-by: BobDu <i@bobdu.cc>

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Now, we can only set admin password once on first-run. It's maybe no problem in orignal deploy method.
But, more and more choices deploy grafana in k8s/docker.
In this way, we need set password with env and ensure password always equal env value.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #49055 

**Special notes for your reviewer**:

