### PR TITLE
Toolkit: Put back publishConfig access public

### DIFF
--- a/packages/grafana-toolkit/package.json
+++ b/packages/grafana-toolkit/package.json
@@ -18,6 +18,9 @@
   "bin": {
     "grafana-toolkit": "./bin/grafana-toolkit.js"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "files": [
     "config",
     "src",


### PR DESCRIPTION
**What this PR does / why we need it**:
Puts back toolkits package.json field `publishConfig.access` set to [public](https://docs.npmjs.com/cli/v8/using-npm/config#access).