### PR TITLE
Chore: expose grpc server address

### DIFF
--- a/pkg/server/test_env.go
+++ b/pkg/server/test_env.go
@@ -1,16 +1,18 @@
 package server
 
 import (
+	"github.com/grafana/grafana/pkg/services/grpcserver"
 	"github.com/grafana/grafana/pkg/services/notifications"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 )
 
-func ProvideTestEnv(server *Server, store *sqlstore.SQLStore, ns *notifications.NotificationServiceMock) (*TestEnv, error) {
-	return &TestEnv{server, store, ns}, nil
+func ProvideTestEnv(server *Server, store *sqlstore.SQLStore, ns *notifications.NotificationServiceMock, grpcServer grpcserver.Provider) (*TestEnv, error) {
+	return &TestEnv{server, store, ns, grpcServer}, nil
 }
 
 type TestEnv struct {
 	Server              *Server
 	SQLStore            *sqlstore.SQLStore
 	NotificationService *notifications.NotificationServiceMock
+	GRPCServer          grpcserver.Provider
 }

--- a/pkg/services/grpcserver/service.go
+++ b/pkg/services/grpcserver/service.go
@@ -21,12 +21,14 @@ import (
 type Provider interface {
 	registry.BackgroundService
 	GetServer() *grpc.Server
+	GetAddress() string
 }
 
 type GPRCServerService struct {
-	cfg    *setting.Cfg
-	logger log.Logger
-	server *grpc.Server
+	cfg     *setting.Cfg
+	logger  log.Logger
+	server  *grpc.Server
+	address string
 }
 
 func ProvideService(cfg *setting.Cfg, apiKey apikey.Service, userService user.Service) (Provider, error) {
@@ -62,6 +64,8 @@ func (s *GPRCServerService) Run(ctx context.Context) error {
 		return fmt.Errorf("GRPC server: failed to listen: %w", err)
 	}
 
+	s.address = listener.Addr().String()
+
 	serveErr := make(chan error, 1)
 	go func() {
 		s.logger.Info("GRPC server: starting")
@@ -92,4 +96,8 @@ func (s *GPRCServerService) IsDisabled() bool {
 
 func (s *GPRCServerService) GetServer() *grpc.Server {
 	return s.server
+}
+
+func (s *GPRCServerService) GetAddress() string {
+	return s.address
 }

--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -311,6 +311,12 @@ func CreateGrafDir(t *testing.T, opts ...GrafanaOpts) (string, string) {
 			_, err = logSection.NewKey("enabled", "false")
 			require.NoError(t, err)
 		}
+		if o.GRPCServerAddress != "" {
+			logSection, err := getOrCreateSection("grpc_server")
+			require.NoError(t, err)
+			_, err = logSection.NewKey("address", o.GRPCServerAddress)
+			require.NoError(t, err)
+		}
 	}
 
 	cfgPath := filepath.Join(cfgDir, "test.ini")
@@ -341,4 +347,5 @@ type GrafanaOpts struct {
 	EnableUnifiedAlerting                 bool
 	UnifiedAlertingDisabledOrgs           []int64
 	EnableLog                             bool
+	GRPCServerAddress                     string
 }


### PR DESCRIPTION
This PR:
- makes it possible to configure GRPC address/port in integration tests
- exposes GRPC address and makes it available in integration tests

This will allow the tests to retrieve the dynamic port chosen automatically after setting the address to `127.0.0.1:0` https://github.com/golang/go/blob/master/src/net/dial.go#L699-L703