### PR TITLE
LogContext: Fix wrong margin for context

### DIFF
--- a/public/app/features/logs/components/LogRowContext.tsx
+++ b/public/app/features/logs/components/LogRowContext.tsx
@@ -48,7 +48,7 @@ const getLogRowContextStyles = (theme: GrafanaTheme2, wrapLogMessage?: boolean) 
         top: 100%;
       `
     : css`
-        margin-top: 40px;
+        margin-top: 20px;
         width: 75%;
       `;
   return {


### PR DESCRIPTION
**What this PR does / why we need it**:
With some of the styling in the previous PRs regarding the show context, the margin the lower context has when lines are not wrapped, is wrong.

Wrong:
![Screenshot 2022-09-29 at 16 01 41](https://user-images.githubusercontent.com/8092184/193053265-27c305cc-4f07-4fa0-b001-92ac47c762ba.png)

With this PR:
![Screenshot 2022-09-29 at 16 03 10](https://user-images.githubusercontent.com/8092184/193053243-35e5cf3a-1548-414d-8b01-d2f44a1a6134.png)


