### PR TITLE
Logs: Show LogRowMenu also for long logs and wrap-lines turned off

### DIFF
--- a/public/app/features/logs/components/LogRowMessage.tsx
+++ b/public/app/features/logs/components/LogRowMessage.tsx
@@ -73,7 +73,7 @@ const getStyles = (theme: GrafanaTheme2, showContextButton: boolean, isInDashboa
     `,
     logRowMenuCell: css`
       position: absolute;
-      right: ${isInDashboard ? '155px' : '163px'};
+      right: ${isInDashboard ? '40px' : '163px'};
       margin-top: -1px;
     `,
   };
@@ -165,7 +165,11 @@ class UnThemedLogRowMessage extends PureComponent<Props> {
           // When context is open, the position has to be NOT relative. // Setting the postion as inline-style to
           // overwrite the more sepecific style definition from `style.logsRowMessage`.
         }
-        <td ref={this.logRowRef} style={contextIsOpen ? { position: 'unset' } : undefined} className={style.logsRowMessage}>
+        <td
+          ref={this.logRowRef}
+          style={contextIsOpen ? { position: 'unset' } : undefined}
+          className={style.logsRowMessage}
+        >
           <div
             className={cx(
               { [styles.positionRelative]: wrapLogMessage },

--- a/public/app/features/logs/components/LogRowMessage.tsx
+++ b/public/app/features/logs/components/LogRowMessage.tsx
@@ -73,7 +73,7 @@ const getStyles = (theme: GrafanaTheme2, showContextButton: boolean, isInDashboa
     `,
     logRowMenuCell: css`
       position: absolute;
-      right: ${isInDashboard ? '40px' : '163px'};
+      right: ${isInDashboard ? '40px' : `calc(75px + ${theme.spacing()} + ${showContextButton ? '80px' : '40px'})`};
       margin-top: -1px;
     `,
   };

--- a/public/app/features/logs/components/LogRowMessage.tsx
+++ b/public/app/features/logs/components/LogRowMessage.tsx
@@ -61,7 +61,6 @@ const getStyles = (theme: GrafanaTheme2, showContextButton: boolean, isInDashboa
       justify-content: space-evenly;
       align-items: center;
       position: absolute;
-      right: ${isInDashboard ? '0px' : '-8px'};
       top: 0;
       bottom: auto;
       height: 36px;
@@ -71,6 +70,11 @@ const getStyles = (theme: GrafanaTheme2, showContextButton: boolean, isInDashboa
       z-index: 100;
       visibility: hidden;
       width: ${showContextButton ? '80px' : '40px'};
+    `,
+    logRowMenuCell: css`
+      position: absolute;
+      right: ${isInDashboard ? '155px' : '163px'};
+      margin-top: -1px;
     `,
   };
 };
@@ -156,36 +160,41 @@ class UnThemedLogRowMessage extends PureComponent<Props> {
     const styles = getStyles(theme, shouldShowContextToggle, app === CoreApp.Dashboard);
 
     return (
-      // When context is open, the position has to be NOT relative.
-      // Setting the postion as inline-style to overwrite the more sepecific style definition from `style.logsRowMessage`.
-      <td
-        ref={this.logRowRef}
-        style={contextIsOpen ? { position: 'unset' } : undefined}
-        className={style.logsRowMessage}
-      >
-        <div
-          className={cx({ [styles.positionRelative]: wrapLogMessage }, { [styles.horizontalScroll]: !wrapLogMessage })}
-        >
-          {contextIsOpen && context && (
-            <LogRowContext
-              row={row}
-              context={context}
-              errors={errors}
-              wrapLogMessage={wrapLogMessage}
-              hasMoreContextRows={hasMoreContextRows}
-              onOutsideClick={onToggleContext}
-              logsSortOrder={logsSortOrder}
-              onLoadMoreContext={() => {
-                if (updateLimit) {
-                  updateLimit();
-                }
-              }}
-            />
-          )}
-          <span className={cx(styles.positionRelative, { [styles.rowWithContext]: contextIsOpen })}>
-            {renderLogMessage(hasAnsi, restructuredEntry, row.searchWords, style.logsRowMatchHighLight)}
-          </span>
-          {showRowMenu && (
+      <>
+        {
+          // When context is open, the position has to be NOT relative. // Setting the postion as inline-style to
+          // overwrite the more sepecific style definition from `style.logsRowMessage`.
+        }
+        <td ref={this.logRowRef} style={contextIsOpen ? { position: 'unset' } : undefined} className={style.logsRowMessage}>
+          <div
+            className={cx(
+              { [styles.positionRelative]: wrapLogMessage },
+              { [styles.horizontalScroll]: !wrapLogMessage }
+            )}
+          >
+            {contextIsOpen && context && (
+              <LogRowContext
+                row={row}
+                context={context}
+                errors={errors}
+                wrapLogMessage={wrapLogMessage}
+                hasMoreContextRows={hasMoreContextRows}
+                onOutsideClick={onToggleContext}
+                logsSortOrder={logsSortOrder}
+                onLoadMoreContext={() => {
+                  if (updateLimit) {
+                    updateLimit();
+                  }
+                }}
+              />
+            )}
+            <span className={cx(styles.positionRelative, { [styles.rowWithContext]: contextIsOpen })}>
+              {renderLogMessage(hasAnsi, restructuredEntry, row.searchWords, style.logsRowMatchHighLight)}
+            </span>
+          </div>
+        </td>
+        {showRowMenu && (
+          <td className={cx('log-row-menu-cell', styles.logRowMenuCell)}>
             <span className={cx('log-row-menu', styles.rowMenu)} onClick={(e) => e.stopPropagation()}>
               {shouldShowContextToggle && (
                 <Tooltip placement="top" content={'Show context'}>
@@ -200,9 +209,9 @@ class UnThemedLogRowMessage extends PureComponent<Props> {
                 />
               </Tooltip>
             </span>
-          )}
-        </div>
-      </td>
+          </td>
+        )}
+      </>
     );
   }
 }

--- a/public/app/features/logs/components/getLogRowStyles.ts
+++ b/public/app/features/logs/components/getLogRowStyles.ts
@@ -58,11 +58,11 @@ export const getLogRowStyles = (theme: GrafanaTheme2, logLevel?: LogLevel) => {
         }
       }
 
-      td:last-child {
+      td:not(.log-row-menu-cell):last-child {
         width: 100%;
       }
 
-      > td {
+      > td:not(.log-row-menu-cell) {
         position: relative;
         padding-right: ${theme.spacing(1)};
         border-top: 1px solid transparent;

--- a/public/app/features/logs/components/getLogRowStyles.ts
+++ b/public/app/features/logs/components/getLogRowStyles.ts
@@ -122,6 +122,7 @@ export const getLogRowStyles = (theme: GrafanaTheme2, logLevel?: LogLevel) => {
       label: logs-row__message;
       white-space: pre-wrap;
       word-break: break-all;
+      width: 100%;
     `,
     //Log details specific CSS
     logDetailsContainer: css`


### PR DESCRIPTION
**What this PR does / why we need it**:
As mentioned in https://github.com/grafana/grafana/issues/55951 the menu in a LogRow containing the copy button and show-context button is not visible if there are long LogRows and wrap-lines toggled off.

This PR fixes this issue by moving the menu into a new table cell.

**Which issue(s) this PR fixes**:

Fixes #55951

**Special notes for your reviewer**:
1. You need long log entries to reproduce this. Best is to change the https://github.com/grafana/grafana/blob/d0fa81fe91aa334354aeabf240e77dc7663645f7/devenv/docker/blocks/loki/data/data.js#L73 file to ingest long lines into loki.
2. Toggle wrap-lines off.
3. Without this PR you won't see the LogRowMenu.

