### PR TITLE
Docs: Updating Public Dashboard documentation

### DIFF
--- a/docs/sources/dashboards/dashboard-public.md
+++ b/docs/sources/dashboards/dashboard-public.md
@@ -59,5 +59,5 @@ publicDashboards = true
 - Exemplars will be omitted from the panel.
 - Annotations will not be displayed in public dashboards.
 - Grafana Live and real-time event streams are not supported.
-
-We are excited to share this enhancement with you and we’d love your feedback! Please check out the [Github](https://github.com/grafana/grafana/discussions/49253) discussion and join the conversation.
+- Library panels are currently not supported, but are planned to be in the future.
+- We are excited to share this enhancement with you and we’d love your feedback! Please check out the [Github](https://github.com/grafana/grafana/discussions/49253) discussion and join the conversation.

--- a/docs/sources/dashboards/dashboard-public.md
+++ b/docs/sources/dashboards/dashboard-public.md
@@ -60,4 +60,5 @@ publicDashboards = true
 - Annotations will not be displayed in public dashboards.
 - Grafana Live and real-time event streams are not supported.
 - Library panels are currently not supported, but are planned to be in the future.
-- We are excited to share this enhancement with you and we’d love your feedback! Please check out the [Github](https://github.com/grafana/grafana/discussions/49253) discussion and join the conversation.
+
+We are excited to share this enhancement with you and we’d love your feedback! Please check out the [Github](https://github.com/grafana/grafana/discussions/49253) discussion and join the conversation.


### PR DESCRIPTION
Update Public Dashboard documentation to state that we currently not support Library Panels