### PR TITLE
codegen: Fix prefix dropper in Go code generator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -254,6 +254,7 @@ require (
 	github.com/google/go-github/v45 v45.2.0
 	github.com/grafana/dskit v0.0.0-20211011144203-3a88ec0b675f
 	github.com/jmoiron/sqlx v1.3.5
+	github.com/matryer/is v1.4.0
 	github.com/urfave/cli v1.22.5
 	go.etcd.io/etcd/api/v3 v3.5.4
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.31.0

--- a/pkg/codegen/astmanip_test.go
+++ b/pkg/codegen/astmanip_test.go
@@ -1,0 +1,263 @@
+package codegen
+
+import (
+	"bytes"
+	"go/format"
+	"go/parser"
+	"go/token"
+	"testing"
+
+	"github.com/matryer/is"
+	"golang.org/x/tools/go/ast/astutil"
+)
+
+func TestPrefixDropper(t *testing.T) {
+	tt := map[string]struct {
+		in, out string
+		skip    bool
+	}{
+		"basic": {
+			in: `package foo
+
+type Foo struct {
+	Id int64
+	Ref FooThing
+}
+
+type FooThing struct {
+	Id int64
+}`,
+			out: `package foo
+
+type Model struct {
+	Id  int64
+	Ref Thing
+}
+
+type Thing struct {
+	Id int64
+}
+`,
+		},
+		"pointer": {
+			in: `package foo
+
+type Foo struct {
+	Id int64
+	Ref *FooThing
+}
+
+type FooThing struct {
+	Id int64
+}`,
+			out: `package foo
+
+type Model struct {
+	Id  int64
+	Ref *Thing
+}
+
+type Thing struct {
+	Id int64
+}
+`,
+		},
+		"sliceref": {
+			in: `package foo
+
+type Foo struct {
+	Id int64
+	Ref []FooThing
+	PRef []*FooThing
+	SPRef *[]FooThing
+}
+
+type FooThing struct {
+	Id int64
+}`,
+			out: `package foo
+
+type Model struct {
+	Id    int64
+	Ref   []Thing
+	PRef  []*Thing
+	SPRef *[]Thing
+}
+
+type Thing struct {
+	Id int64
+}
+`,
+		},
+		"mapref": {
+			in: `package foo
+
+type Foo struct {
+	Id int64
+	KeyRef map[FooThing]string
+	ValRef map[string]FooThing
+	BothRef map[FooThing]FooThing
+}
+
+type FooThing struct {
+	Id int64
+}`,
+			out: `package foo
+
+type Model struct {
+	Id      int64
+	KeyRef  map[Thing]string
+	ValRef  map[string]Thing
+	BothRef map[Thing]Thing
+}
+
+type Thing struct {
+	Id int64
+}
+`,
+		},
+		"pmapref": {
+			in: `package foo
+
+type Foo struct {
+	Id int64
+	KeyRef map[*FooThing]string
+	ValRef map[string]*FooThing
+	BothRef map[*FooThing]*FooThing
+	PKeyRef *map[*FooThing]string
+}
+
+type FooThing struct {
+	Id int64
+}`,
+			out: `package foo
+
+type Model struct {
+	Id      int64
+	KeyRef  map[*Thing]string
+	ValRef  map[string]*Thing
+	BothRef map[*Thing]*Thing
+	PKeyRef *map[*Thing]string
+}
+
+type Thing struct {
+	Id int64
+}
+`,
+		},
+		"ignore-fieldname": {
+			in: `package foo
+
+type Foo struct {
+	Id int64
+	FooRef []string
+}`,
+			out: `package foo
+
+type Model struct {
+	Id     int64
+	FooRef []string
+}
+`,
+		},
+		"const": {
+			in: `package foo
+
+const one FooThing = "boop"
+
+const (
+	two   FooThing = "boop"
+	three FooThing = "boop"
+)
+
+type FooThing string
+`,
+			out: `package foo
+
+const one Thing = "boop"
+
+const (
+	two   Thing = "boop"
+	three Thing = "boop"
+)
+
+type Thing string
+`,
+		},
+		"var": {
+			in: `package foo
+
+var one FooThing = "boop"
+
+var (
+	two   FooThing = "boop"
+	three FooThing = "boop"
+)
+
+type FooThing string
+`,
+			out: `package foo
+
+var one Thing = "boop"
+
+var (
+	two   Thing = "boop"
+	three Thing = "boop"
+)
+
+type Thing string
+`,
+		},
+		"varp": {
+			in: `package foo
+
+var one *FooThing = "boop"
+
+var (
+	two   []FooThing = []FooThing{"boop"}
+	three map[FooThing]string = map[FooThing]string{ "beep": "boop" }
+)
+
+type FooThing string
+`,
+			out: `package foo
+
+var one *Thing = "boop"
+
+var (
+	two   []Thing = []Thing{"boop"}
+	three map[Thing]string = map[Thing]string{ "beep": "boop" }
+)
+
+type Thing string
+`,
+			// Skip this one for now - there's currently no codegen that constructs instances
+			// of objects, only types, so we shouldn't encounter this case.
+			skip: true,
+		},
+	}
+
+	for name, it := range tt {
+		item := it
+		t.Run(name, func(t *testing.T) {
+			if item.skip {
+				t.Skip()
+			}
+			is := is.New(t)
+			fset := token.NewFileSet()
+			inf, err := parser.ParseFile(fset, "input.go", item.in, parser.ParseComments)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			drop := makePrefixDropper("Foo", "Model")
+			astutil.Apply(inf, drop, nil)
+			buf := new(bytes.Buffer)
+			err = format.Node(buf, fset, inf)
+			if err != nil {
+				t.Fatal(err)
+			}
+			is.Equal(item.out, buf.String())
+		})
+	}
+}

--- a/pkg/codegen/util_go.go
+++ b/pkg/codegen/util_go.go
@@ -3,7 +3,6 @@ package codegen
 import (
 	"bytes"
 	"fmt"
-	"go/ast"
 	"go/format"
 	"go/parser"
 	"go/token"
@@ -11,12 +10,13 @@ import (
 	"path/filepath"
 	"strings"
 
+	"golang.org/x/tools/go/ast/astutil"
 	"golang.org/x/tools/imports"
 )
 
 type genGoFile struct {
 	path   string
-	walker ast.Visitor
+	walker astutil.ApplyFunc
 	in     []byte
 }
 
@@ -30,7 +30,7 @@ func postprocessGoFile(cfg genGoFile) ([]byte, error) {
 	}
 
 	if cfg.walker != nil {
-		ast.Walk(cfg.walker, gf)
+		astutil.Apply(gf, cfg.walker, nil)
 
 		err = format.Node(buf, fset, gf)
 		if err != nil {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This fixes some issues with the Go code generator around the AST manipulation it performs to remove redundant parts of names in generated Go types and fields.

The problems were originally identified in #55622, but this commit is being re-hoisted for #55960 and another branch i have, and the fix is just generally better and correct, so it's worth just getting it in on its own.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

