### PR TITLE
Docs: adds note about org_role being case sensitive

### DIFF
--- a/docs/sources/setup-grafana/configure-security/configure-authentication/ldap.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/ldap.md
@@ -190,7 +190,7 @@ org_role = "Viewer"
 | Setting         | Required | Description                                                                                                                                                              | Default              |
 | --------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------- |
 | `group_dn`      | Yes      | LDAP distinguished name (DN) of LDAP group. If you want to match all (or no LDAP groups) then you can use wildcard (`"*"`)                                               |
-| `org_role`      | Yes      | Assign users of `group_dn` the organization role `"Admin"`, `"Editor"` or `"Viewer"`                                                                                     |
+| `org_role`      | Yes      | Assign users of `group_dn` the organization role `Admin`, `Editor`, or `Viewer`. The organization role name is case sensitive.                                           |
 | `org_id`        | No       | The Grafana organization database id. Setting this allows for multiple group_dn's to be assigned to the same `org_role` provided the `org_id` differs                    | `1` (default org id) |
 | `grafana_admin` | No       | When `true` makes user of `group_dn` Grafana server admin. A Grafana server admin has admin access over all organizations and users. Available in Grafana v5.3 and above | `false`              |
 


### PR DESCRIPTION
This PR solves a customer issue by explaining that the org_role setting is case-sensitive.