### PR TITLE
CI: Add `edition` as environment var

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1922,6 +1922,8 @@ type: docker
 clone:
   retries: 3
 depends_on: []
+environment:
+  EDITION: OSS
 image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
@@ -2230,6 +2232,8 @@ volumes:
 clone:
   retries: 3
 depends_on: []
+environment:
+  EDITION: OSS
 image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
@@ -2337,6 +2341,8 @@ volumes:
 clone:
   retries: 3
 depends_on: []
+environment:
+  EDITION: OSS
 image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
@@ -2452,6 +2458,8 @@ depends_on:
 - release-oss-build-e2e-publish
 - release-oss-test
 - release-oss-integration-tests
+environment:
+  EDITION: OSS
 image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
@@ -2513,6 +2521,8 @@ volumes:
 clone:
   disable: true
 depends_on: []
+environment:
+  EDITION: ENTERPRISE
 image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
@@ -2861,6 +2871,8 @@ volumes:
 clone:
   disable: true
 depends_on: []
+environment:
+  EDITION: ENTERPRISE
 image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
@@ -3010,6 +3022,8 @@ volumes:
 clone:
   disable: true
 depends_on: []
+environment:
+  EDITION: ENTERPRISE
 image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
@@ -3175,6 +3189,8 @@ depends_on:
 - release-enterprise-build-e2e-publish
 - release-enterprise-test
 - release-enterprise-integration-tests
+environment:
+  EDITION: ENTERPRISE
 image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
@@ -3923,6 +3939,8 @@ volumes:
 clone:
   retries: 3
 depends_on: []
+environment:
+  EDITION: OSS
 image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
@@ -4200,6 +4218,8 @@ volumes:
 clone:
   retries: 3
 depends_on: []
+environment:
+  EDITION: OSS
 image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
@@ -4301,6 +4321,8 @@ volumes:
 clone:
   retries: 3
 depends_on: []
+environment:
+  EDITION: OSS
 image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
@@ -4410,6 +4432,8 @@ depends_on:
 - release-branch-oss-build-e2e-publish
 - release-branch-oss-test
 - release-branch-oss-integration-tests
+environment:
+  EDITION: OSS
 image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
@@ -4461,6 +4485,8 @@ volumes:
 clone:
   disable: true
 depends_on: []
+environment:
+  EDITION: ENTERPRISE
 image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
@@ -4798,6 +4824,8 @@ volumes:
 clone:
   disable: true
 depends_on: []
+environment:
+  EDITION: ENTERPRISE
 image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
@@ -4938,6 +4966,8 @@ volumes:
 clone:
   disable: true
 depends_on: []
+environment:
+  EDITION: ENTERPRISE
 image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
@@ -5094,6 +5124,8 @@ depends_on:
 - release-branch-enterprise-build-e2e-publish
 - release-branch-enterprise-test
 - release-branch-enterprise-integration-tests
+environment:
+  EDITION: ENTERPRISE
 image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
@@ -5381,6 +5413,6 @@ kind: secret
 name: packages_secret_access_key
 ---
 kind: signature
-hmac: 774fd382b75b0860cc64326952818257df858a0f59144ad9ed978c984b94fd0e
+hmac: 49387e58319c5c9d4069d95213b8fa6023b8e44622433ebbea6063203a3ba4f4
 
 ...

--- a/scripts/drone/events/release.star
+++ b/scripts/drone/events/release.star
@@ -153,6 +153,7 @@ def publish_image_pipelines(mode):
     ),]
 
 def get_oss_pipelines(trigger, ver_mode):
+    environment = {'EDITION': 'OSS'}
     edition = 'oss'
     services = integration_test_services(edition=edition)
     volumes = integration_test_services_volumes()
@@ -230,13 +231,13 @@ def get_oss_pipelines(trigger, ver_mode):
         steps=[identify_runner_step('windows')] + windows_package_steps,
         platform='windows', depends_on=[
             'oss-build{}-publish-{}'.format(get_e2e_suffix(), ver_mode),
-        ],
+        ], environment=environment,
     )
     pipelines = [
         pipeline(
             name='{}-oss-build{}-publish'.format(ver_mode, get_e2e_suffix()), edition=edition, trigger=trigger, services=[],
             steps=init_steps + build_steps + package_steps + publish_steps,
-            volumes=volumes,
+            environment=environment, volumes=volumes,
         ),
     ]
     if not disable_tests:
@@ -244,12 +245,12 @@ def get_oss_pipelines(trigger, ver_mode):
             pipeline(
                 name='{}-oss-test'.format(ver_mode), edition=edition, trigger=trigger, services=[],
                 steps=init_steps + test_steps,
-                volumes=[],
+                environment=environment, volumes=[],
             ),
             pipeline(
                 name='{}-oss-integration-tests'.format(ver_mode), edition=edition, trigger=trigger, services=services,
                 steps=[download_grabpl_step(), identify_runner_step(), verify_gen_cue_step(edition), wire_install_step(), ] + integration_test_steps,
-                volumes=volumes,
+                environment=environment, volumes=volumes,
             )
         ])
         deps = {
@@ -265,6 +266,7 @@ def get_oss_pipelines(trigger, ver_mode):
     return pipelines
 
 def get_enterprise_pipelines(trigger, ver_mode):
+    environment = {'EDITION': 'ENTERPRISE'}
     edition = 'enterprise'
     services = integration_test_services(edition=edition)
     volumes = integration_test_services_volumes()
@@ -371,12 +373,12 @@ def get_enterprise_pipelines(trigger, ver_mode):
         steps=[identify_runner_step('windows')] + windows_package_steps,
         platform='windows', depends_on=[
             'enterprise-build{}-publish-{}'.format(get_e2e_suffix(), ver_mode),
-        ],
+        ], environment=environment,
     )
     pipelines = [
         pipeline(
             name='{}-enterprise-build{}-publish'.format(ver_mode, get_e2e_suffix()), edition=edition, trigger=trigger, services=[],
-            steps=init_steps + build_steps + package_steps + publish_steps,
+            steps=init_steps + build_steps + package_steps + publish_steps, environment=environment,
             volumes=volumes,
         ),
     ]
@@ -384,13 +386,13 @@ def get_enterprise_pipelines(trigger, ver_mode):
         pipelines.extend([
             pipeline(
                 name='{}-enterprise-test'.format(ver_mode), edition=edition, trigger=trigger, services=[],
-                steps=init_steps + test_steps,
+                steps=init_steps + test_steps, environment=environment,
                 volumes=[],
             ),
             pipeline(
                 name='{}-enterprise-integration-tests'.format(ver_mode), edition=edition, trigger=trigger, services=services,
                 steps=[download_grabpl_step(), identify_runner_step(), clone_enterprise_step(ver_mode), init_enterprise_step(ver_mode), verify_gen_cue_step(edition), wire_install_step()] + integration_test_steps + [redis_integration_tests_step(), memcached_integration_tests_step()],
-                volumes=volumes,
+                environment=environment, volumes=volumes,
             ),
         ])
         deps = {


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds 
```
environment:
  EDITION: OSS/ENTERPRISE
```
on the pipeline level, so we can decide what edition each pipeline is for, at any step.

Related: #55151