### PR TITLE
LogContext: Fix scroll behavior in context modal

### DIFF
--- a/public/app/features/logs/components/LogRowContext.tsx
+++ b/public/app/features/logs/components/LogRowContext.tsx
@@ -76,6 +76,10 @@ const getLogRowContextStyles = (theme: GrafanaTheme2, wrapLogMessage?: boolean) 
     logs: css`
       height: ${logsHeight}px;
       padding: 10px;
+
+      .scrollbar-view {
+        overscroll-behavior: contain;
+      }
     `,
     afterContext,
     beforeContext,


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently if a user scrolls in a context-group of the show-context modal, the user will also scroll the main window if the modal reaches the end. With this PR the scroll behaviour acts only on the context-groups.

**Special notes for your reviewer**:

Without the fix:

https://user-images.githubusercontent.com/8092184/193233043-6144a426-24f1-43a2-969b-44ce97518a3f.mov

1. Open a context modal and scroll inside a group
2. Notice that you will eventually scroll the whole window and lose the show-context modal.


With the fix:

https://user-images.githubusercontent.com/8092184/193232967-74e98b31-846f-4b45-91d3-8f5ee73211c5.mov

1. Open a context modal and scroll inside a group
2. Scrolling will stop if the user scrolls in a group modal
