### PR TITLE
Accessibility: turn on `jsx-a11y/no-noninteractive-tabindex` + fix/ignore errors

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -113,7 +113,7 @@
           }
         ],
         "jsx-a11y/no-noninteractive-element-to-interactive-role": "off",
-        "jsx-a11y/no-noninteractive-tabindex": "off",
+        "jsx-a11y/no-noninteractive-tabindex": "error",
         "jsx-a11y/no-redundant-roles": "error",
         "jsx-a11y/no-static-element-interactions": "off",
         "jsx-a11y/role-has-required-aria-props": "error",

--- a/packages/grafana-ui/src/components/DateTimePickers/RelativeTimeRangePicker/RelativeTimeRangePicker.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/RelativeTimeRangePicker/RelativeTimeRangePicker.tsx
@@ -63,7 +63,7 @@ export function RelativeTimeRangePicker(props: RelativeTimeRangePickerProps) {
   };
 
   const onOpen = useCallback(
-    (event: FormEvent<HTMLDivElement>) => {
+    (event: FormEvent<HTMLButtonElement>) => {
       event.stopPropagation();
       event.preventDefault();
       setIsOpen(!isOpen);
@@ -94,7 +94,7 @@ export function RelativeTimeRangePicker(props: RelativeTimeRangePickerProps) {
 
   return (
     <div className={styles.container}>
-      <div tabIndex={0} className={styles.pickerInput} onClick={onOpen}>
+      <button className={styles.pickerInput} onClick={onOpen}>
         <span className={styles.clockIcon}>
           <Icon name="clock-nine" />
         </span>
@@ -104,7 +104,7 @@ export function RelativeTimeRangePicker(props: RelativeTimeRangePickerProps) {
         <span className={styles.caretIcon}>
           <Icon name={isOpen ? 'angle-up' : 'angle-down'} size="lg" />
         </span>
-      </div>
+      </button>
       {isOpen && (
         <ClickOutsideWrapper includeButtonPress={false} onClick={onClose}>
           <div className={styles.content}>

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangeInput.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangeInput.tsx
@@ -51,7 +51,7 @@ export const TimeRangeInput: FC<TimeRangeInputProps> = ({
   const theme = useTheme2();
   const styles = getStyles(theme, disabled);
 
-  const onOpen = (event: FormEvent<HTMLDivElement>) => {
+  const onOpen = (event: FormEvent<HTMLButtonElement>) => {
     event.stopPropagation();
     event.preventDefault();
     if (disabled) {
@@ -78,12 +78,7 @@ export const TimeRangeInput: FC<TimeRangeInputProps> = ({
 
   return (
     <div className={styles.container}>
-      <div
-        tabIndex={0}
-        className={styles.pickerInput}
-        aria-label={selectors.components.TimePicker.openButton}
-        onClick={onOpen}
-      >
+      <button className={styles.pickerInput} aria-label={selectors.components.TimePicker.openButton} onClick={onOpen}>
         {isValidTimeRange(value) ? (
           <TimePickerButtonLabel value={value} timeZone={timeZone} />
         ) : (
@@ -98,7 +93,7 @@ export const TimeRangeInput: FC<TimeRangeInputProps> = ({
             <Icon name={isOpen ? 'angle-up' : 'angle-down'} size="lg" />
           </span>
         )}
-      </div>
+      </button>
       {isOpen && (
         <ClickOutsideWrapper includeButtonPress={false} onClick={onClose}>
           <TimePickerContent

--- a/packages/grafana-ui/src/components/VizLayout/VizLayout.tsx
+++ b/packages/grafana-ui/src/components/VizLayout/VizLayout.tsx
@@ -39,6 +39,8 @@ export const VizLayout: VizLayoutComponentType = ({ width, height, legend, child
   const [legendRef, legendMeasure] = useMeasure<HTMLDivElement>();
 
   if (!legend) {
+    // this is needed for keyboard accessibility in the plot area
+    // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
     return (
       <div tabIndex={0} style={containerStyle} className={styles.viz}>
         {children(width, height)}
@@ -88,9 +90,13 @@ export const VizLayout: VizLayoutComponentType = ({ width, height, legend, child
 
   return (
     <div style={containerStyle}>
-      <div tabIndex={0} className={styles.viz}>
-        {size && children(size.width, size.height)}
-      </div>
+      {
+        // this is needed for keyboard accessibility in the plot area
+        // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+        <div tabIndex={0} className={styles.viz}>
+          {size && children(size.width, size.height)}
+        </div>
+      }
       <div style={legendStyle} ref={legendRef}>
         <CustomScrollbar hideHorizontalTrack>{legend}</CustomScrollbar>
       </div>

--- a/packages/grafana-ui/src/components/VizLayout/VizLayout.tsx
+++ b/packages/grafana-ui/src/components/VizLayout/VizLayout.tsx
@@ -39,12 +39,14 @@ export const VizLayout: VizLayoutComponentType = ({ width, height, legend, child
   const [legendRef, legendMeasure] = useMeasure<HTMLDivElement>();
 
   if (!legend) {
-    // this is needed for keyboard accessibility in the plot area
-    // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
     return (
-      <div tabIndex={0} style={containerStyle} className={styles.viz}>
-        {children(width, height)}
-      </div>
+      <>
+        {/* tabIndex={0} is needed for keyboard accessibility in the plot area */}
+        {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}
+        <div tabIndex={0} style={containerStyle} className={styles.viz}>
+          {children(width, height)}
+        </div>
+      </>
     );
   }
 
@@ -90,13 +92,11 @@ export const VizLayout: VizLayoutComponentType = ({ width, height, legend, child
 
   return (
     <div style={containerStyle}>
-      {
-        // this is needed for keyboard accessibility in the plot area
-        // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
-        <div tabIndex={0} className={styles.viz}>
-          {size && children(size.width, size.height)}
-        </div>
-      }
+      {/* tabIndex={0} is needed for keyboard accessibility in the plot area */}
+      {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}
+      <div tabIndex={0} className={styles.viz}>
+        {size && children(size.width, size.height)}
+      </div>
       <div style={legendStyle} ref={legendRef}>
         <CustomScrollbar hideHorizontalTrack>{legend}</CustomScrollbar>
       </div>

--- a/public/app/core/components/NavBar/NavBarItemMenu.tsx
+++ b/public/app/core/components/NavBar/NavBarItemMenu.tsx
@@ -85,7 +85,7 @@ export function NavBarItemMenu(props: NavBarItemMenuProps): ReactElement | null 
   const menu = [headerComponent, contentComponent];
 
   return (
-    <ul className={styles.menu} ref={ref} {...mergeProps(menuProps, contextMenuProps)} tabIndex={menuHasFocus ? 0 : -1}>
+    <ul className={styles.menu} ref={ref} {...mergeProps(menuProps, contextMenuProps)} tabIndex={-1}>
       {reverseMenuDirection ? menu.reverse() : menu}
     </ul>
   );

--- a/public/app/core/components/TagFilter/TagFilter.tsx
+++ b/public/app/core/components/TagFilter/TagFilter.tsx
@@ -161,9 +161,9 @@ export const TagFilter: FC<Props> = ({
   return (
     <div className={styles.tagFilter}>
       {isClearable && tags.length > 0 && (
-        <span className={styles.clear} onClick={() => onTagChange([])} tabIndex={0}>
+        <button className={styles.clear} onClick={() => onTagChange([])}>
           Clear tags
-        </span>
+        </button>
       )}
       <MultiSelect {...selectOptions} prefix={<Icon name="tag-alt" />} aria-label="Tag filter" />
     </div>
@@ -184,8 +184,11 @@ const getStyles = (theme: GrafanaTheme2) => ({
     }
   `,
   clear: css`
+    background: none;
+    border: none;
     text-decoration: underline;
     font-size: 12px;
+    padding: none;
     position: absolute;
     top: -17px;
     right: 0;

--- a/public/app/features/search/components/DashboardSearch.tsx
+++ b/public/app/features/search/components/DashboardSearch.tsx
@@ -29,7 +29,7 @@ export function DashboardSearch({}: Props) {
   const { onKeyDown, keyboardEvents } = useKeyNavigationListener();
 
   return (
-    <div tabIndex={0} className={styles.overlay}>
+    <div className={styles.overlay}>
       <div className={styles.container}>
         <div className={styles.searchField}>
           <div>
@@ -39,7 +39,6 @@ export function DashboardSearch({}: Props) {
               value={query.query ?? ''}
               onChange={onSearchQueryChange}
               onKeyDown={onKeyDown}
-              tabIndex={0}
               spellCheck={false}
               className={styles.input}
               autoFocus


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

- enables `jsx-a11y/no-noninteractive-tabindex`
- converts a bunch of `div`s to `button`s
- ignores it in 2 places where we need the `div` to be interactive so keyboard users can control the plot with arrow keys

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/56082

**Special notes for your reviewer**:

