### PR TITLE
Toolkit: Deprecate `component:create` command

### DIFF
--- a/packages/grafana-toolkit/src/cli/index.ts
+++ b/packages/grafana-toolkit/src/cli/index.ts
@@ -115,7 +115,7 @@ export const run = (includeInternalScripts = false) => {
         '[deprecated] Scaffold React components. Optionally add test, story and .mdx files. The components are created in the same dir the script is run from.'
       )
       .action(async () => {
-        chalk.yellow.bold(`⚠️ This command is deprecated , will be removed in v10 and no support will be provided. ⚠️`);
+        chalk.yellow.bold(`⚠️ This command is deprecated and will be removed in v10. No further support will be provided. ⚠️`);
         await execTask(componentCreateTask)({});
       });
   }

--- a/packages/grafana-toolkit/src/cli/index.ts
+++ b/packages/grafana-toolkit/src/cli/index.ts
@@ -115,7 +115,12 @@ export const run = (includeInternalScripts = false) => {
         '[deprecated] Scaffold React components. Optionally add test, story and .mdx files. The components are created in the same dir the script is run from.'
       )
       .action(async () => {
-        chalk.yellow.bold(`⚠️ This command is deprecated and will be removed in v10. No further support will be provided. ⚠️`);
+        chalk.yellow.bold(
+          `⚠️ This command is deprecated and will be removed in v10. No further support will be provided. ⚠️`
+        );
+        console.log(
+          'if you were reliant on this command we recommend https://www.npmjs.com/package/react-gen-component'
+        );
         await execTask(componentCreateTask)({});
       });
   }

--- a/packages/grafana-toolkit/src/cli/index.ts
+++ b/packages/grafana-toolkit/src/cli/index.ts
@@ -115,7 +115,7 @@ export const run = (includeInternalScripts = false) => {
         '[deprecated] Scaffold React components. Optionally add test, story and .mdx files. The components are created in the same dir the script is run from.'
       )
       .action(async () => {
-        chalk.yellow.bold(`⚠️ This command is deprecated and will be removed in v10 ⚠️`);
+        chalk.yellow.bold(`⚠️ This command is deprecated , will be removed in v10 and no support will be provided. ⚠️`);
         await execTask(componentCreateTask)({});
       });
   }

--- a/packages/grafana-toolkit/src/cli/index.ts
+++ b/packages/grafana-toolkit/src/cli/index.ts
@@ -112,9 +112,10 @@ export const run = (includeInternalScripts = false) => {
     program
       .command('component:create')
       .description(
-        'Scaffold React components. Optionally add test, story and .mdx files. The components are created in the same dir the script is run from.'
+        '[deprecated] Scaffold React components. Optionally add test, story and .mdx files. The components are created in the same dir the script is run from.'
       )
       .action(async () => {
+        chalk.yellow.bold(`⚠️ This command is deprecated and will be removed in v10 ⚠️`);
         await execTask(componentCreateTask)({});
       });
   }


### PR DESCRIPTION
Closes: https://github.com/grafana/grafana/issues/55996

Adds a deprecation message to `component:create` that will be later removed in grafana 10.
