### PR TITLE
Grafana UI: Clean up bundle

### DIFF
--- a/packages/grafana-ui/src/components/FilterInput/FilterInput.tsx
+++ b/packages/grafana-ui/src/components/FilterInput/FilterInput.tsx
@@ -2,8 +2,10 @@ import React, { HTMLProps } from 'react';
 
 import { escapeStringForRegex, unEscapeStringFromRegex } from '@grafana/data';
 
-import { Button, Icon, Input } from '..';
 import { useCombinedRefs } from '../../utils/useCombinedRefs';
+import { Button } from '../Button';
+import { Icon } from '../Icon/Icon';
+import { Input } from '../Input/Input';
 
 export interface Props extends Omit<HTMLProps<HTMLInputElement>, 'onChange'> {
   value: string | undefined;

--- a/packages/grafana-ui/src/components/Select/resetSelectStyles.ts
+++ b/packages/grafana-ui/src/components/Select/resetSelectStyles.ts
@@ -13,7 +13,7 @@ export default function resetSelectStyles(theme: GrafanaTheme2) {
     groupHeading: () => ({}),
     indicatorsContainer: () => ({}),
     indicatorSeparator: () => ({}),
-    input: function (originalStyles: CSSObjectWithLabel) {
+    input: function (originalStyles: CSSObjectWithLabel): CSSObjectWithLabel {
       return {
         ...originalStyles,
         color: 'inherit',
@@ -34,7 +34,7 @@ export default function resetSelectStyles(theme: GrafanaTheme2) {
     multiValueRemove: () => ({}),
     noOptionsMessage: () => ({}),
     option: () => ({}),
-    placeholder: (originalStyles: CSSObjectWithLabel) => ({
+    placeholder: (originalStyles: CSSObjectWithLabel): CSSObjectWithLabel => ({
       ...originalStyles,
       color: theme.colors.text.disabled,
     }),

--- a/packages/grafana-ui/src/components/index.ts
+++ b/packages/grafana-ui/src/components/index.ts
@@ -273,7 +273,6 @@ export { useGraphNGContext } from './GraphNG/hooks';
 export { preparePlotFrame, buildScaleKey } from './GraphNG/utils';
 export { type GraphNGLegendEvent } from './GraphNG/types';
 export * from './PanelChrome/types';
-export { EmotionPerfTest } from './ThemeDemos/EmotionPerfTest';
 export { Label as BrowserLabel } from './BrowserLabel/Label';
 export { PanelContainer } from './PanelContainer/PanelContainer';
 export * from './QueryEditor';

--- a/public/app/features/sandbox/BenchmarksPage.tsx
+++ b/public/app/features/sandbox/BenchmarksPage.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react';
 
-import { EmotionPerfTest, VerticalGroup } from '@grafana/ui';
+import { VerticalGroup } from '@grafana/ui';
+import { EmotionPerfTest } from '@grafana/ui/src/components/ThemeDemos/EmotionPerfTest';
 
 export const BenchmarksPage: FC = () => {
   return (


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Whilst working on storybook updates I noticed the `EmotionPerfTest.tsx` is being bundled in `@grafana/ui`. I'm not sure this is necessary to expose this in the NPM bundle as it's only used in Storybook and Grafana core. As such this PR removes it from the `components/index.ts`. This is a breaking change but I don't think we have any consumers of `ui` actually using this.

There's a rather nasty circular dep in FilterInput.tsx that causes the following warning. This PR addresses this by removing the import of `components/index.ts` in favour of pointing directly to the imports locations.

```(!) Export "FilterInput" of module src/components/FilterInput/FilterInput.tsx was reexported through module src/components/index.ts while both modules are dependencies of each other and will end up in different chunks by current Rollup settings. This scenario is not well supported at the moment as it will produce a circular dependency between chunks and will likely lead to broken execution order.
Either change the import in src/components/DateTimePickers/TimeRangePicker/TimePickerContent.tsx to point directly to the exporting module or do not use "preserveModules" to ensure these modules end up in the same chunk.
(!) Export "FilterInput" of module src/components/FilterInput/FilterInput.tsx was reexported through module src/components/index.ts while both modules are dependencies of each other and will end up in different chunks by current Rollup settings. This scenario is not well supported at the moment as it will produce a circular dependency between chunks and will likely lead to broken execution order.
Either change the import in src/components/Table/FilterList.tsx to point directly to the exporting module or do not use "preserveModules" to ensure these modules end up in the same chunk.
```

Lastly this PR changes the inferred types of resetSelectStyles to remove the expansion of `CSSObjectWithLabel` which halves the file size of `index.d.ts`. This will likely cause Levitate to complain but shouldn't actually be a breaking change as the `CSSObjectWithLabel` contains all css properties.

**Special notes for your reviewer**:
~Not sure whether to aim this at 9.2.0 release and backport.~ 🤔 After discussing with @academo decided best to leave this for the 9.3.0 release.

# Release notice breaking change
`EmotionPerfTest` is no longer exported from the `@grafana/ui` bundle. 