### PR TITLE
Devenv: add dashboard showing timeseries out of range points

### DIFF
--- a/devenv/dev-dashboards/panel-timeseries/timeseries-out-of-rage.json
+++ b/devenv/dev-dashboards/panel-timeseries/timeseries-out-of-rage.json
@@ -1,0 +1,513 @@
+{
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": {
+            "type": "grafana",
+            "uid": "-- Grafana --"
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "target": {
+            "limit": 100,
+            "matchAny": false,
+            "tags": [],
+            "type": "dashboard"
+          },
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": 1435,
+    "links": [],
+    "liveNow": false,
+    "panels": [
+      {
+        "datasource": {
+          "type": "testdata",
+          "uid": "PD8C576611E62080A"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "fixedColor": "blue",
+              "mode": "fixed"
+            },
+            "custom": {
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 10,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 9,
+          "w": 8,
+          "x": 0,
+          "y": 0
+        },
+        "id": 3,
+        "maxDataPoints": 6,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "9.3.0-pre",
+        "targets": [
+          {
+            "csvContent": "Time,Value,Name\n2022-09-01T05:00:00Z,100,Before\n2022-09-01T06:00:00Z,100,Middle",
+            "datasource": {
+              "type": "testdata",
+              "uid": "PD8C576611E62080A"
+            },
+            "refId": "B",
+            "scenarioId": "csv_content"
+          }
+        ],
+        "title": "Before + Middle",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "testdata",
+          "uid": "PD8C576611E62080A"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "fixedColor": "blue",
+              "mode": "fixed"
+            },
+            "custom": {
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 10,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 9,
+          "w": 8,
+          "x": 8,
+          "y": 0
+        },
+        "id": 2,
+        "maxDataPoints": 6,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "9.3.0-pre",
+        "targets": [
+          {
+            "csvContent": "Time,Value,Name\n2022-09-01T05:00:00Z,100,Before\n2022-09-01T07:00:00Z,100,After\n",
+            "datasource": {
+              "type": "testdata",
+              "uid": "PD8C576611E62080A"
+            },
+            "refId": "B",
+            "scenarioId": "csv_content"
+          }
+        ],
+        "title": "Before + After",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "testdata",
+          "uid": "PD8C576611E62080A"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "fixedColor": "blue",
+              "mode": "fixed"
+            },
+            "custom": {
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 10,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 9,
+          "w": 8,
+          "x": 16,
+          "y": 0
+        },
+        "id": 4,
+        "maxDataPoints": 6,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "9.3.0-pre",
+        "targets": [
+          {
+            "csvContent": "Time,Value,Name\n2022-09-01T06:00:00Z,100,Middle\n2022-09-01T07:00:00Z,100,After\n",
+            "datasource": {
+              "type": "testdata",
+              "uid": "PD8C576611E62080A"
+            },
+            "refId": "B",
+            "scenarioId": "csv_content"
+          }
+        ],
+        "title": "Middle + After",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "testdata",
+          "uid": "PD8C576611E62080A"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "fixedColor": "blue",
+              "mode": "fixed"
+            },
+            "custom": {
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 10,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 9,
+          "w": 12,
+          "x": 0,
+          "y": 9
+        },
+        "id": 5,
+        "maxDataPoints": 6,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "9.3.0-pre",
+        "targets": [
+          {
+            "csvContent": "Time,Value,Name\n2022-09-01T04:00:00Z,100,Before1\n2022-09-01T05:00:00Z,100,Before2\n",
+            "datasource": {
+              "type": "testdata",
+              "uid": "PD8C576611E62080A"
+            },
+            "refId": "B",
+            "scenarioId": "csv_content"
+          }
+        ],
+        "title": "Two points before (show zoom button)",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "testdata",
+          "uid": "PD8C576611E62080A"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "fixedColor": "blue",
+              "mode": "fixed"
+            },
+            "custom": {
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 10,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 9,
+          "w": 12,
+          "x": 12,
+          "y": 9
+        },
+        "id": 6,
+        "maxDataPoints": 6,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "9.3.0-pre",
+        "targets": [
+          {
+            "csvContent": "Time,Value,Name\n2022-09-01T07:00:00Z,100,After1\n2022-09-01T08:00:00Z,100,After2\n",
+            "datasource": {
+              "type": "testdata",
+              "uid": "PD8C576611E62080A"
+            },
+            "refId": "B",
+            "scenarioId": "csv_content"
+          }
+        ],
+        "title": "Two points after (show zoom button)",
+        "type": "timeseries"
+      }
+    ],
+    "refresh": false,
+    "schemaVersion": 37,
+    "style": "dark",
+    "tags": [
+        "gdev",
+        "panel-tests",
+        "graph-ng"
+    ],
+    "templating": {
+        "list": []
+    },
+    "time": {
+        "from": "now-6h",
+        "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "",
+    "title": "Panel Tests - Timeseries - Out of range",
+    "uid": "pqnrfd4Vz",
+    "version": 1,
+    "weekStart": ""
+  }

--- a/pkg/services/searchV2/object/testdata/dash_labels.jsonc
+++ b/pkg/services/searchV2/object/testdata/dash_labels.jsonc
@@ -2,7 +2,7 @@
 //  
 //  Frame[0] 
 //  Name: labels
-//  Dimensions: 3 Fields by 209 Rows
+//  Dimensions: 3 Fields by 212 Rows
 //  +-----------------------------------------------------+-----------------+----------------+
 //  | Name: uid                                           | Name: key       | Name: value    |
 //  | Labels:                                             | Labels:         | Labels:        |
@@ -250,6 +250,9 @@
             "panel-timeline/timeline-modes.json",
             "panel-timeline/timeline-modes.json",
             "panel-timeline/timeline-modes.json",
+            "panel-timeseries/timeseries-out-of-rage.json",
+            "panel-timeseries/timeseries-out-of-rage.json",
+            "panel-timeseries/timeseries-out-of-rage.json",
             "scenarios/time_zone_support.json",
             "scenarios/time_zone_support.json",
             "scenarios/time_zone_support.json",
@@ -462,6 +465,9 @@
             "graph-ng",
             "panel-tests",
             "gdev",
+            "graph-ng",
+            "panel-tests",
+            "gdev",
             "graph",
             "panel-tests",
             "table",
@@ -476,6 +482,9 @@
             "transform"
           ],
           [
+            "",
+            "",
+            "",
             "",
             "",
             "",

--- a/pkg/services/searchV2/object/testdata/dash_raw.jsonc
+++ b/pkg/services/searchV2/object/testdata/dash_raw.jsonc
@@ -2,7 +2,7 @@
 //  
 //  Frame[0] 
 //  Name: raw
-//  Dimensions: 4 Fields by 96 Rows
+//  Dimensions: 4 Fields by 97 Rows
 //  +---------------------------------------------------------+----------------+---------------+----------------------------------+
 //  | Name: uid                                               | Name: kind     | Name: size    | Name: etag                       |
 //  | Labels:                                                 | Labels:        | Labels:       | Labels:                          |
@@ -150,6 +150,7 @@
             "panel-text/text-options.json",
             "panel-timeline/timeline-demo.json",
             "panel-timeline/timeline-modes.json",
+            "panel-timeseries/timeseries-out-of-rage.json",
             "scenarios/slow_queries_and_annotations.json",
             "scenarios/time_zone_support.json",
             "transforms/config-from-query.json",
@@ -159,6 +160,7 @@
             "transforms/rows-to-fields.json"
           ],
           [
+            "",
             "",
             "",
             "",
@@ -346,6 +348,7 @@
             7122,
             10777,
             8674,
+            13368,
             24166,
             15128,
             13876,
@@ -444,6 +447,7 @@
             "f6ea799109bb78d2f2954947a188d7b6",
             "dfcd599be6b6df94aef3b6da9d8ac3fb",
             "21dd0f87426cf7afc030d688d5516178",
+            "45294c2260bda5bba87039a18a98576d",
             "727c2c46deddeb164cd9ce36a0ec1567",
             "f517e61f40152e16f3291e72c27f606d",
             "c1cbaf503457216461032844f47ac065",

--- a/pkg/services/searchV2/object/testdata/dash_references.jsonc
+++ b/pkg/services/searchV2/object/testdata/dash_references.jsonc
@@ -2,7 +2,7 @@
 //  
 //  Frame[0] 
 //  Name: references
-//  Dimensions: 4 Fields by 291 Rows
+//  Dimensions: 4 Fields by 293 Rows
 //  +-------------------------------+----------------+----------------+----------------+
 //  | Name: uid                     | Name: kind     | Name: type     | Name: uid      |
 //  | Labels:                       | Labels:        | Labels:        | Labels:        |
@@ -328,6 +328,8 @@
             "panel-timeline/timeline-modes.json",
             "panel-timeline/timeline-modes.json",
             "panel-timeline/timeline-modes.json",
+            "panel-timeseries/timeseries-out-of-rage.json",
+            "panel-timeseries/timeseries-out-of-rage.json",
             "scenarios/slow_queries_and_annotations.json",
             "scenarios/slow_queries_and_annotations.json",
             "scenarios/time_zone_support.json",
@@ -627,6 +629,8 @@
             "panel",
             "ds",
             "panel",
+            "ds",
+            "panel",
             "panel",
             "panel",
             "ds",
@@ -914,6 +918,8 @@
             "default.type",
             "state-timeline",
             "status-history",
+            "default.type",
+            "timeseries",
             "default.type",
             "graph",
             "default.type",
@@ -1206,6 +1212,8 @@
             "",
             "default.uid",
             "",
+            "",
+            "default.uid",
             "",
             "default.uid",
             "",

--- a/pkg/services/searchV2/object/testdata/dash_summary.jsonc
+++ b/pkg/services/searchV2/object/testdata/dash_summary.jsonc
@@ -2,7 +2,7 @@
 //  
 //  Frame[0] 
 //  Name: summary
-//  Dimensions: 3 Fields by 96 Rows
+//  Dimensions: 3 Fields by 97 Rows
 //  +---------------------------------------------------------+----------------------------------------------+--------------------------+
 //  | Name: uid                                               | Name: name                                   | Name: fields             |
 //  | Labels:                                                 | Labels:                                      | Labels:                  |
@@ -143,6 +143,7 @@
             "panel-text/text-options.json",
             "panel-timeline/timeline-demo.json",
             "panel-timeline/timeline-modes.json",
+            "panel-timeseries/timeseries-out-of-rage.json",
             "scenarios/slow_queries_and_annotations.json",
             "scenarios/time_zone_support.json",
             "transforms/config-from-query.json",
@@ -241,6 +242,7 @@
             "Text options",
             "Timeline Demo",
             "Timeline Modes",
+            "Panel Tests - Timeseries - Out of range",
             "Panel tests - Slow Queries \u0026 Annotations",
             "Panel Tests - Time zone support",
             "Transforms - Config from query",
@@ -401,6 +403,7 @@
             {
               "hasTemplateVars": true
             },
+            {},
             {},
             {},
             {},


### PR DESCRIPTION
This adds a new dev dashboard showing out-of range data

![image](https://user-images.githubusercontent.com/705951/193342271-2fd70a01-3afa-4700-b8de-f68588634a53.png)

This creates a new folder for timeseries panel -- they used to be in the "graph" folder, but I think we are mature enough now to have its own folder :). In the next PR will move the others