### PR TITLE
Alerting: Remove Put and Reset methods from state manager 

### DIFF
--- a/pkg/services/ngalert/schedule/compat.go
+++ b/pkg/services/ngalert/schedule/compat.go
@@ -134,7 +134,6 @@ func FromAlertStateToPostableAlerts(firingStates []*state.State, stateManager *s
 		alertState.LastSentAt = ts
 		sentAlerts = append(sentAlerts, alertState)
 	}
-	stateManager.Put(sentAlerts)
 	return alerts
 }
 

--- a/pkg/services/ngalert/schedule/compat.go
+++ b/pkg/services/ngalert/schedule/compat.go
@@ -117,9 +117,9 @@ func errorAlert(labels, annotations data.Labels, alertState *state.State, urlStr
 	}
 }
 
-func FromAlertStateToPostableAlerts(firingStates []*state.State, resendDelay time.Duration, appURL *url.URL) apimodels.PostableAlerts {
+func FromAlertStateToPostableAlerts(firingStates []*state.State, resendDelay time.Duration, appURL *url.URL, clock clock.Clock) apimodels.PostableAlerts {
 	alerts := apimodels.PostableAlerts{PostableAlerts: make([]models.PostableAlert, 0, len(firingStates))}
-	ts := time.Now()
+	ts := clock.Now()
 
 	for _, alertState := range firingStates {
 		if !alertState.NeedsSending(resendDelay) {

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -361,7 +361,7 @@ func (sch *schedule) ruleRoutine(grafanaCtx context.Context, key ngmodels.AlertR
 			return
 		}
 		processedStates := sch.stateManager.ProcessEvalResults(ctx, e.scheduledAt, e.rule, results, sch.getRuleExtraLabels(e))
-		alerts := FromAlertStateToPostableAlerts(processedStates, sch.stateManager, sch.appURL)
+		alerts := FromAlertStateToPostableAlerts(processedStates, sch.stateManager.ResendDelay, sch.appURL)
 		if len(alerts.PostableAlerts) > 0 {
 			sch.alertsSender.Send(key, alerts)
 		}

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -361,7 +361,7 @@ func (sch *schedule) ruleRoutine(grafanaCtx context.Context, key ngmodels.AlertR
 			return
 		}
 		processedStates := sch.stateManager.ProcessEvalResults(ctx, e.scheduledAt, e.rule, results, sch.getRuleExtraLabels(e))
-		alerts := FromAlertStateToPostableAlerts(processedStates, sch.stateManager.ResendDelay, sch.appURL)
+		alerts := FromAlertStateToPostableAlerts(processedStates, sch.stateManager.ResendDelay, sch.appURL, sch.clock)
 		if len(alerts.PostableAlerts) > 0 {
 			sch.alertsSender.Send(key, alerts)
 		}

--- a/pkg/services/ngalert/schedule/testing.go
+++ b/pkg/services/ngalert/schedule/testing.go
@@ -65,6 +65,13 @@ func (f *fakeRulesStore) GetAlertRulesForScheduling(ctx context.Context, query *
 	return nil
 }
 
+func (f *fakeRulesStore) ListAlertRules(_ context.Context, q *models.ListAlertRulesQuery) error {
+	for _, rule := range f.rules {
+		q.Result = append(q.Result, rule)
+	}
+	return nil
+}
+
 func (f *fakeRulesStore) PutRule(_ context.Context, rules ...*models.AlertRule) {
 	for _, r := range rules {
 		f.rules[r.UID] = r

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -307,12 +307,6 @@ func (st *Manager) recordMetrics() {
 	}
 }
 
-func (st *Manager) Put(states []*State) {
-	for _, s := range states {
-		st.set(s)
-	}
-}
-
 func (st *Manager) saveState(ctx context.Context, s *State) error {
 	cmd := ngModels.SaveAlertInstanceCommand{
 		RuleOrgID:         s.OrgID,

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -74,7 +74,7 @@ func (st *Manager) Close() {
 
 func (st *Manager) Warm(ctx context.Context) {
 	st.log.Info("warming cache for startup")
-	st.ResetAllStates()
+	st.cache.reset()
 
 	orgIds, err := st.instanceStore.FetchOrgIds(ctx)
 	if err != nil {
@@ -148,11 +148,6 @@ func (st *Manager) set(entry *State) {
 
 func (st *Manager) Get(orgID int64, alertRuleUID, stateId string) (*State, error) {
 	return st.cache.get(orgID, alertRuleUID, stateId)
-}
-
-// ResetAllStates is used to ensure a clean cache on startup.
-func (st *Manager) ResetAllStates() {
-	st.cache.reset()
 }
 
 // ResetStateByRuleUID deletes all entries in the state manager that match the given rule UID.


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR removes two methods from `state.Manager`:
1. Method `Put` basically updates the underlying cache and adds or updates a state.
This method is used in only two places: in 1 test where it is used to pre-set the state https://github.com/grafana/grafana/compare/main...yuri-tceretian:statemanager-put-remove?expand=1#diff-bd46cfcb4ef816c767bb8b9d3637680e1c6ac38f7fd66f4d7635b06adc6d588fL254 and in function `FromAlertStateToPostableAlerts` 
https://github.com/grafana/grafana/blob/385ebea5404a96e6649d17dc54ec97bf33a19bcf/pkg/services/ngalert/schedule/compat.go#L120-L139 , where it is supposed to "update" the state after it was mutated (updated field LastSentAt). This operation is useless because the function is working with the pointers to the state struct, which is already kept in the cache because all states are created via this call https://github.com/grafana/grafana/blob/6d4f3934f85e310e382eaf3d3fe7cf1e51cd6e63/pkg/services/ngalert/state/manager.go#L225 

Therefore, the call of the Put method is not necessary.

2. Method ResetAllStates because it is not used anywhere other than by the manager itself