### PR TITLE
Alerting: Exposes channels.WebhookMessage

### DIFF
--- a/pkg/services/ngalert/notifier/channels/webhook.go
+++ b/pkg/services/ngalert/notifier/channels/webhook.go
@@ -123,8 +123,8 @@ func buildWebhookNotifier(factoryConfig FactoryConfig) (*WebhookNotifier, error)
 	}, nil
 }
 
-// webhookMessage defines the JSON object send to webhook endpoints.
-type webhookMessage struct {
+// WebhookMessage defines the JSON object send to webhook endpoints.
+type WebhookMessage struct {
 	*ExtendedData
 
 	// The protocol version.
@@ -161,7 +161,7 @@ func (wn *WebhookNotifier) Notify(ctx context.Context, as ...*types.Alert) (bool
 		},
 		as...)
 
-	msg := &webhookMessage{
+	msg := &WebhookMessage{
 		Version:         "1",
 		ExtendedData:    data,
 		GroupKey:        groupKey.String(),

--- a/pkg/services/ngalert/notifier/channels/webhook_test.go
+++ b/pkg/services/ngalert/notifier/channels/webhook_test.go
@@ -31,7 +31,7 @@ func TestWebhookNotifier(t *testing.T) {
 		settings string
 		alerts   []*types.Alert
 
-		expMsg        *webhookMessage
+		expMsg        *WebhookMessage
 		expUrl        string
 		expUsername   string
 		expPassword   string
@@ -53,7 +53,7 @@ func TestWebhookNotifier(t *testing.T) {
 			},
 			expUrl:        "http://localhost/test",
 			expHttpMethod: "POST",
-			expMsg: &webhookMessage{
+			expMsg: &WebhookMessage{
 				ExtendedData: &ExtendedData{
 					Receiver: "my_receiver",
 					Status:   "firing",
@@ -126,7 +126,7 @@ func TestWebhookNotifier(t *testing.T) {
 			expHttpMethod: "PUT",
 			expUsername:   "user1",
 			expPassword:   "mysecret",
-			expMsg: &webhookMessage{
+			expMsg: &WebhookMessage{
 				ExtendedData: &ExtendedData{
 					Receiver: "my_receiver",
 					Status:   "firing",
@@ -191,7 +191,7 @@ func TestWebhookNotifier(t *testing.T) {
 					},
 				},
 			},
-			expMsg: &webhookMessage{
+			expMsg: &WebhookMessage{
 				ExtendedData: &ExtendedData{
 					Receiver: "my_receiver",
 					Status:   "firing",


### PR DESCRIPTION
Fixes #48972 - Allows for re-use of structus in webhook reciever

Tests all pass, though I guess functionally its a question of if anyone else other than @pmenglund  and myself would use it or if you would prefer to keep it private for ease of maintenance?