### PR TITLE
CLI: allow specifying user-id for password reset

### DIFF
--- a/pkg/cmd/grafana-cli/commands/commands.go
+++ b/pkg/cmd/grafana-cli/commands/commands.go
@@ -158,6 +158,11 @@ var adminCommands = []*cli.Command{
 				Usage: "Read the password from stdin",
 				Value: false,
 			},
+			&cli.Int64Flag{
+				Name:  "user-id",
+				Usage: "User ID to reset password for",
+				Value: 1,
+			},
 		},
 	},
 	{

--- a/pkg/cmd/grafana-cli/commands/reset_password_command.go
+++ b/pkg/cmd/grafana-cli/commands/reset_password_command.go
@@ -15,8 +15,6 @@ import (
 	"github.com/grafana/grafana/pkg/util"
 )
 
-const AdminUserId = 1
-
 func resetPasswordCommand(c utils.CommandLine, runner runner.Runner) error {
 	newPassword := ""
 
@@ -40,11 +38,12 @@ func resetPasswordCommand(c utils.CommandLine, runner runner.Runner) error {
 		return fmt.Errorf("new password is too short")
 	}
 
-	userQuery := user.GetUserByIDQuery{ID: AdminUserId}
+	adminUserId := c.Int64("user-id")
+	userQuery := user.GetUserByIDQuery{ID: adminUserId}
 
 	usr, err := runner.UserService.GetByID(context.Background(), &userQuery)
 	if err != nil {
-		return fmt.Errorf("could not read user from database. Error: %v", err)
+		return fmt.Errorf("could not read user (id: %d) from database. Error: %v", adminUserId, err)
 	}
 
 	passwordHashed, err := util.EncodePassword(newPassword, usr.Salt)
@@ -53,7 +52,7 @@ func resetPasswordCommand(c utils.CommandLine, runner runner.Runner) error {
 	}
 
 	cmd := user.ChangeUserPasswordCommand{
-		UserID:      AdminUserId,
+		UserID:      adminUserId,
 		NewPassword: passwordHashed,
 	}
 

--- a/pkg/cmd/grafana-cli/utils/command_line.go
+++ b/pkg/cmd/grafana-cli/utils/command_line.go
@@ -14,6 +14,7 @@ type CommandLine interface {
 	Args() cli.Args
 	Bool(name string) bool
 	Int(name string) int
+	Int64(name string) int64
 	String(name string) string
 	StringSlice(name string) []string
 	FlagNames() (names []string)


### PR DESCRIPTION
Fixes #55976 - Allow specifying user-id for password reset

Happy to also update if the preference would be to search for the first admin-user in the DB, although, done this way it seemed more confiurable and less likely to cause unexpected results

Had to introduce the interface `CommandLine.Int64` to prevent narrowing/widening conversions.