### PR TITLE
Elasticsearch: Fix calculation of trimEdges in alert mode

### DIFF
--- a/pkg/tsdb/elasticsearch/response_parser.go
+++ b/pkg/tsdb/elasticsearch/response_parser.go
@@ -538,7 +538,7 @@ func (rp *responseParser) trimDatapoints(queryResult backend.DataResponse, targe
 		for _, field := range frame.Fields {
 			if field.Len() > trimEdges*2 {
 				for i := 0; i < field.Len(); i++ {
-					if i < trimEdges || i > field.Len()-trimEdges {
+					if i < trimEdges || i >= field.Len()-trimEdges {
 						field.Delete(i)
 					}
 				}

--- a/pkg/tsdb/elasticsearch/response_parser_test.go
+++ b/pkg/tsdb/elasticsearch/response_parser_test.go
@@ -691,17 +691,17 @@ func TestResponseParser(t *testing.T) {
 			frame := dataframes[0]
 			require.Len(t, frame.Fields, 2)
 			require.Equal(t, frame.Fields[0].Name, "time")
-			require.Equal(t, frame.Fields[0].Len(), 2)
+			require.Equal(t, frame.Fields[0].Len(), 1)
 			require.Equal(t, frame.Fields[1].Name, "value")
-			require.Equal(t, frame.Fields[1].Len(), 2)
+			require.Equal(t, frame.Fields[1].Len(), 1)
 			assert.Equal(t, frame.Fields[1].Config.DisplayNameFromDS, "Average")
 
 			frame = dataframes[1]
 			require.Len(t, frame.Fields, 2)
 			require.Equal(t, frame.Fields[0].Name, "time")
-			require.Equal(t, frame.Fields[0].Len(), 2)
+			require.Equal(t, frame.Fields[0].Len(), 1)
 			require.Equal(t, frame.Fields[1].Name, "value")
-			require.Equal(t, frame.Fields[1].Len(), 2)
+			require.Equal(t, frame.Fields[1].Len(), 1)
 			assert.Equal(t, frame.Fields[1].Config.DisplayNameFromDS, "Count")
 		})
 

--- a/pkg/tsdb/elasticsearch/response_parser_test.go
+++ b/pkg/tsdb/elasticsearch/response_parser_test.go
@@ -634,7 +634,7 @@ func TestResponseParser(t *testing.T) {
 			assert.Equal(t, frame.Fields[1].Config.DisplayNameFromDS, "@metric:logins.count")
 		})
 
-		t.Run("With dropfirst and last aggregation", func(t *testing.T) {
+		t.Run("With drop first and last aggregation (numeric)", func(t *testing.T) {
 			targets := map[string]string{
 				"A": `{
 					"timeField": "@timestamp",
@@ -645,6 +645,77 @@ func TestResponseParser(t *testing.T) {
 							"field": "@timestamp",
 							"id": "2",
 							"settings": { "trimEdges": 1 }
+						}
+					]
+				}`,
+			}
+			response := `{
+        "responses": [
+          {
+            "aggregations": {
+              "2": {
+                "buckets": [
+                  {
+                    "1": { "value": 1000 },
+                    "key": 1,
+                    "doc_count": 369
+                  },
+                  {
+                    "1": { "value": 2000 },
+                    "key": 2,
+                    "doc_count": 200
+                  },
+                  {
+                    "1": { "value": 2000 },
+                    "key": 3,
+                    "doc_count": 200
+                  }
+                ]
+              }
+            }
+          }
+        ]
+			}`
+			rp, err := newResponseParserForTest(targets, response)
+			require.NoError(t, err)
+			result, err := rp.getTimeSeries()
+			require.NoError(t, err)
+			require.Len(t, result.Responses, 1)
+
+			queryRes := result.Responses["A"]
+			require.NotNil(t, queryRes)
+			dataframes := queryRes.Frames
+			require.NoError(t, err)
+			require.Len(t, dataframes, 2)
+
+			frame := dataframes[0]
+			require.Len(t, frame.Fields, 2)
+			require.Equal(t, frame.Fields[0].Name, "time")
+			require.Equal(t, frame.Fields[0].Len(), 1)
+			require.Equal(t, frame.Fields[1].Name, "value")
+			require.Equal(t, frame.Fields[1].Len(), 1)
+			assert.Equal(t, frame.Fields[1].Config.DisplayNameFromDS, "Average")
+
+			frame = dataframes[1]
+			require.Len(t, frame.Fields, 2)
+			require.Equal(t, frame.Fields[0].Name, "time")
+			require.Equal(t, frame.Fields[0].Len(), 1)
+			require.Equal(t, frame.Fields[1].Name, "value")
+			require.Equal(t, frame.Fields[1].Len(), 1)
+			assert.Equal(t, frame.Fields[1].Config.DisplayNameFromDS, "Count")
+		})
+
+		t.Run("With drop first and last aggregation (string)", func(t *testing.T) {
+			targets := map[string]string{
+				"A": `{
+					"timeField": "@timestamp",
+					"metrics": [{ "type": "avg", "id": "1" }, { "type": "count" }],
+          "bucketAggs": [
+						{
+							"type": "date_histogram",
+							"field": "@timestamp",
+							"id": "2",
+							"settings": { "trimEdges": "1" }
 						}
 					]
 				}`,


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes the handling of the `trimEdges` option in the Elasticsearch go backend. This option was ignored by the backend which is used by the alerting component.

**Which issue(s) this PR fixes**:

This was reported on #39414, and considering that both we reproduced this with both the legacy and unified alerting.

Fixes #39414 (already closed)

**Special notes for your reviewer**:

When `trimEdges` is set to `n` it should drop `n` datapoints from both the beginning and the end of the frames fields, but it was always ignoring 1 element from the end. When `n=1` it was not dropping any sample from the end.

The second bug happens because within the panel JSON the `trimEdges` is stored as a quoted number (string) rather than an actual number:  https://github.com/grafana/grafana/blob/23956557d8c6a119b7de5be5c42024e29634d002/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/aggregations.ts#L20

```json
"bucketAggs": [
  {
    "field": "@timestamp",
    "id": "2",
    "settings": {
      "interval": "1m",
      "trimEdges": "1"
    },
    "type": "date_histogram"
  }
],
```

When this value was read in the backend `simplejson` failed to coerce it into an integer, which silently failed due to the early return of the function. Since `simplejson` is deprecated, a new function (`castToInt`) that handles this case was added, similar to the existing `castToFloat`. 