### PR TITLE
fix: update gazetteer Brazil coordinates

### DIFF
--- a/public/gazetteer/countries.json
+++ b/public/gazetteer/countries.json
@@ -187,8 +187,8 @@
   },
   {
     "keys": ["BR", "BRA"],
-    "latitude": -14.235004,
-    "longitude": -51.92528,
+    "latitude": -15.72155,
+    "longitude": -48.0808851,
     "name": "Brazil"
   },
   {


### PR DESCRIPTION
This pull request update Gazetter coordinates for Brazil location.
