### PR TITLE
Grafana UI: Prevent built storybook being bundled with package

### DIFF
--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -25,10 +25,11 @@
     "access": "public"
   },
   "files": [
-    "dist",
+    "./dist",
+    "!./dist/storybook",
     "./README.md",
     "./CHANGELOG.md",
-    "LICENSE_APACHE2"
+    "./LICENSE_APACHE2"
   ],
   "scripts": {
     "build": "tsc -p ./tsconfig.build.json && rollup -c rollup.config.ts",


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
When packaging grafana/ui it seems the storybook dist build is also being added to the npm package. These can be seen in [drone builds](https://drone.grafana.net/grafana/grafana/81491/5/28): 

```
npm notice 9.1kB   dist/storybook/public/img/rendering_plugin_not_installed.png                                    
npm notice 3.4kB   dist/storybook/public/img/rendering_timeout_dark.png                                            
npm notice 10.9kB  dist/storybook/public/img/rendering_timeout_light.png                                           
npm notice 70B     dist/storybook/public/img/transparent.png                                                       
npm notice 1.5kB   dist/storybook/public/img/user_profile.png                                                      
npm notice 1.5kB   dist/storybook/public/img/warn-tiny.svg                                                         
npm notice 2.2kB   dist/storybook/public/img/warn.svg                                                              
npm notice 173B    dist/storybook/public/lib/monaco-languages/index.ts                                             
npm notice 1.8kB   dist/storybook/public/lib/monaco-languages/kusto.ts                                             
npm notice 18.7kB  dist/storybook/react-monaco-editor.b86ed172.iframe.bundle.js                                    
npm notice 4.2kB   dist/storybook/runtime~main.5f6708ab18b153ae428f.manager.bundle.js                              
npm notice 4.2kB   dist/storybook/runtime~main.466c9d7e.iframe.bundle.js                                           
npm notice 6.3kB   package.json                                                                                    
npm notice === Tarball Details === 
npm notice name:          @grafana/ui                             
npm notice version:       9.3.0-81491pre                          
npm notice filename:      @grafana/ui-9.3.0-81491pre.tgz          
npm notice package size:  10.7 MB                                 
npm notice unpacked size: 28.1 MB <--- 😱😱😱
npm notice shasum:        687c732b43356784dcc99abab05aab093a3e47d0
npm notice integrity:     sha512-ZWg/1kbvPzgAU[...]v1eH/b41i1k/Q==
npm notice total files:   2846                                    
npm notice 
npm notice Publishing to https://registry.npmjs.org/
+ @grafana/ui@9.3.0-81491pre
```

This PR negates the storybook directory preventing it from being included during packing.
