### PR TITLE
GrafanaUI: InputGroup: Fix invalid children borders

### DIFF
--- a/packages/grafana-ui/src/components/QueryEditor/InputGroup.story.internal.tsx
+++ b/packages/grafana-ui/src/components/QueryEditor/InputGroup.story.internal.tsx
@@ -1,0 +1,70 @@
+import { ComponentMeta } from '@storybook/react';
+import React from 'react';
+
+import { Stack } from '..';
+import { withCenteredStory } from '../../utils/storybook/withCenteredStory';
+import { Input } from '../Input/Input';
+import { Select } from '../Select/Select';
+
+import { AccessoryButton } from './AccessoryButton';
+import { InputGroup } from './InputGroup';
+
+const meta: ComponentMeta<typeof InputGroup> = {
+  title: 'Experimental/InputGroup',
+  component: InputGroup,
+  decorators: [withCenteredStory],
+  // parameters: {
+  //   controls: {
+  //     exclude: ['onClick', 'href', 'heading', 'description', 'className'],
+  //   },
+  // },
+};
+
+export function WithTextInputs() {
+  return (
+    <InputGroup>
+      <Input placeholder="One" />
+      <Input placeholder="Two" />
+    </InputGroup>
+  );
+}
+
+export function WithAccessoryButton() {
+  return (
+    <InputGroup>
+      <Select value={selectOptions[0]} options={selectOptions} onChange={() => {}} />
+      <AccessoryButton aria-label="Remove group by column" icon="times" variant="secondary" />
+    </InputGroup>
+  );
+}
+
+export function WithSelectsAndInput() {
+  return (
+    <Stack direction="column">
+      <InputGroup>
+        <Input invalid placeholder="LHS" />
+        <Select value={comparitorOptions[0]} options={comparitorOptions} onChange={() => {}} />
+        <Input placeholder="RHS" />
+      </InputGroup>
+      <InputGroup>
+        <Input placeholder="LHS" />
+        <Select invalid value={comparitorOptions[0]} options={comparitorOptions} onChange={() => {}} />
+        <Input placeholder="RHS" />
+      </InputGroup>
+      <InputGroup>
+        <Input placeholder="LHS" />
+        <Select value={comparitorOptions[0]} options={comparitorOptions} onChange={() => {}} />
+        <Input invalid placeholder="RHS" />
+      </InputGroup>
+    </Stack>
+  );
+}
+
+const selectOptions = [{ label: 'Prometheus', value: 1 }];
+const comparitorOptions = [
+  { label: '=', value: 1 },
+  { label: '<', value: 2 },
+  { label: '>', value: 3 },
+];
+
+export default meta;

--- a/packages/grafana-ui/src/components/QueryEditor/InputGroup.story.internal.tsx
+++ b/packages/grafana-ui/src/components/QueryEditor/InputGroup.story.internal.tsx
@@ -13,11 +13,6 @@ const meta: ComponentMeta<typeof InputGroup> = {
   title: 'Experimental/InputGroup',
   component: InputGroup,
   decorators: [withCenteredStory],
-  // parameters: {
-  //   controls: {
-  //     exclude: ['onClick', 'href', 'heading', 'description', 'className'],
-  //   },
-  // },
 };
 
 export function WithTextInputs() {

--- a/packages/grafana-ui/src/components/QueryEditor/InputGroup.tsx
+++ b/packages/grafana-ui/src/components/QueryEditor/InputGroup.tsx
@@ -24,7 +24,7 @@ export const InputGroup = ({ children }: InputGroupProps) => {
   return <div className={styles.root}>{modifiedChildren}</div>;
 };
 
-// The lower in the array the higher the priority for showing that element's border
+// The later in the array the higher the priority for showing that element's border
 const borderPriority = [
   '' as const, // lowest priority
   'base' as const,

--- a/packages/grafana-ui/src/components/QueryEditor/InputGroup.tsx
+++ b/packages/grafana-ui/src/components/QueryEditor/InputGroup.tsx
@@ -24,10 +24,16 @@ export const InputGroup = ({ children }: InputGroupProps) => {
   return <div className={styles.root}>{modifiedChildren}</div>;
 };
 
+// The lower in the array the higher the priority for showing that element's border
+const borderPriority = [
+  '' as const, // lowest priority
+  'base' as const,
+  'hovered' as const,
+  'invalid' as const,
+  'focused' as const, // highest priority
+];
+
 const getStyles = () => ({
-  invalidChild: css({
-    zIndex: 3,
-  }),
   root: css({
     display: 'flex',
 
@@ -54,16 +60,20 @@ const getStyles = () => ({
 
       //
       position: 'relative',
-      zIndex: 1,
+      zIndex: borderPriority.indexOf('base'),
 
       // Adjacent borders are overlapping, so raise children up when hovering etc
       // so all that child's borders are visible.
       '&:hover': {
-        zIndex: 2,
+        zIndex: borderPriority.indexOf('hovered'),
       },
       '&:focus-within': {
-        zIndex: 4,
+        zIndex: borderPriority.indexOf('focused'),
       },
     },
+  }),
+
+  invalidChild: css({
+    zIndex: borderPriority.indexOf('invalid'),
   }),
 });

--- a/packages/grafana-ui/src/components/QueryEditor/InputGroup.tsx
+++ b/packages/grafana-ui/src/components/QueryEditor/InputGroup.tsx
@@ -3,9 +3,10 @@ import React, { Children, cloneElement, isValidElement, ReactElement } from 'rea
 
 import { useStyles2 } from '../../themes';
 
+type Child = string | undefined | ReactElement<{ className?: string; invalid?: unknown }>;
 interface InputGroupProps {
   // we type the children props so we can test them later on
-  children: Array<ReactElement<{ className?: string; invalid?: unknown }>>;
+  children: Child | Child[];
 }
 
 export const InputGroup = ({ children }: InputGroupProps) => {

--- a/packages/grafana-ui/src/components/QueryEditor/InputGroup.tsx
+++ b/packages/grafana-ui/src/components/QueryEditor/InputGroup.tsx
@@ -1,17 +1,33 @@
-import { css } from '@emotion/css';
-import React from 'react';
+import { css, cx } from '@emotion/css';
+import React, { Children, cloneElement, isValidElement, ReactElement } from 'react';
 
 import { useStyles2 } from '../../themes';
 
-interface InputGroupProps {}
+interface InputGroupProps {
+  // we type the children props so we can test them later on
+  children: Array<ReactElement<{ className?: string; invalid?: unknown }>>;
+}
 
-export const InputGroup: React.FC<InputGroupProps> = ({ children }) => {
+export const InputGroup = ({ children }: InputGroupProps) => {
   const styles = useStyles2(getStyles);
 
-  return <div className={styles.root}>{children}</div>;
+  // Find children with an invalid prop, and set a class name to raise their z-index so all
+  // of the invalid border is visible
+  const modifiedChildren = Children.map(children, (child) => {
+    if (isValidElement(child) && child.props.invalid) {
+      return cloneElement(child, { className: cx(child.props.className, styles.invalidChild) });
+    }
+
+    return child;
+  });
+
+  return <div className={styles.root}>{modifiedChildren}</div>;
 };
 
 const getStyles = () => ({
+  invalidChild: css({
+    zIndex: 3,
+  }),
   root: css({
     display: 'flex',
 
@@ -40,11 +56,13 @@ const getStyles = () => ({
       position: 'relative',
       zIndex: 1,
 
+      // Adjacent borders are overlapping, so raise children up when hovering etc
+      // so all that child's borders are visible.
       '&:hover': {
         zIndex: 2,
       },
       '&:focus-within': {
-        zIndex: 2,
+        zIndex: 4,
       },
     },
   }),


### PR DESCRIPTION
**What this PR does / why we need it**:

This updates the experimental InputGroup component to support children with "invalid" borders.

This is a bit of a tricky one - to collapse adjacent borders inside an input group, children have a negative left margin to overlap the borders, and then we raise the z-index when hovering so all of the hovered element's borders are visible.

The tricky part is how to raise the z-index of invalid children. I initially tried with putting a `data-invalid` attribute on individual components when they're invalid, and targeting that in InputGroups's CSS, but I couldn't get the attribute to on the Select component.

Instead, I went with inspecting children's props to look for `invalid` and use `cloneElement` to apply an extra className to the child if it's invalid. I'm not totally enthusiastic about this, but so far it's the only approach I've really found. Really open to other ideas here. This does create requirements on "invalid" children though - they must have an `invalid` prop, and accept a `className`,
 
![image](https://user-images.githubusercontent.com/46142/193563568-b8725948-2536-4a9b-83c5-bbb006b5edf6.png)

![image](https://user-images.githubusercontent.com/46142/193563739-764d2979-2fed-485d-8517-6aba6cee0fe7.png)

![image](https://user-images.githubusercontent.com/46142/193563848-0ab696fd-7cd6-4f9a-bfc9-74c59f7ad204.png)

![image](https://user-images.githubusercontent.com/46142/193564029-67a18d3b-560c-45d2-93e8-ffd7619ef3e5.png)


**Which issue(s) this PR fixes**:

Fixes #56006

**Special notes for your reviewer**:

