### PR TITLE
CI: Add `packages-bucket` flag to `publish packages` command

### DIFF
--- a/pkg/build/cmd/main.go
+++ b/pkg/build/cmd/main.go
@@ -1,11 +1,11 @@
 package main
 
 import (
-	"github.com/grafana/grafana/pkg/build/config"
 	"log"
 	"os"
 	"strings"
 
+	"github.com/grafana/grafana/pkg/build/config"
 	"github.com/grafana/grafana/pkg/build/docker"
 	"github.com/grafana/grafana/pkg/build/packaging"
 	"github.com/urfave/cli/v2"

--- a/pkg/build/cmd/main.go
+++ b/pkg/build/cmd/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/grafana/grafana/pkg/build/config"
 	"log"
 	"os"
 	"strings"
@@ -187,7 +188,7 @@ func main() {
 						&gcpKeyFlag,
 						&cli.StringFlag{
 							Name:  "packages-bucket",
-							Value: "grafana-downloads",
+							Value: config.PublicBucket,
 							Usage: "Google Cloud Storage Debian database bucket",
 						},
 						&cli.StringFlag{

--- a/pkg/build/config/versions.go
+++ b/pkg/build/config/versions.go
@@ -1,5 +1,7 @@
 package config
 
+const PublicBucket = "grafana-downloads"
+
 var Versions = VersionMap{
 	PullRequestMode: {
 		Variants: []Variant{


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `packages-bucket` flag, with the `grafana-downloads` bucket being the default.