### PR TITLE
Chore: Convert Wrapper to function component

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -4416,8 +4416,7 @@ exports[`better eslint`] = {
     "public/app/features/explore/state/main.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"],
-      [0, 0, 0, "Do not use any type assertions.", "2"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "3"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "2"]
     ],
     "public/app/features/explore/state/query.test.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],

--- a/public/app/features/explore/ExplorePaneContainer.tsx
+++ b/public/app/features/explore/ExplorePaneContainer.tsx
@@ -26,7 +26,7 @@ import { getFiscalYearStartMonth, getTimeZone } from '../profile/state/selectors
 
 import Explore from './Explore';
 import { initializeExplore, refreshExplore } from './state/explorePane';
-import { lastSavedUrl, cleanupPaneAction, stateSave } from './state/main';
+import { lastSavedUrl, stateSave } from './state/main';
 import { importQueries } from './state/query';
 import { loadAndInitDatasource } from './state/utils';
 
@@ -178,7 +178,6 @@ function mapStateToProps(state: StoreState, props: OwnProps) {
 const mapDispatchToProps = {
   initializeExplore,
   refreshExplore,
-  cleanupPaneAction,
   importQueries,
   stateSave,
 };

--- a/public/app/features/explore/Wrapper.tsx
+++ b/public/app/features/explore/Wrapper.tsx
@@ -1,28 +1,23 @@
 import { css } from '@emotion/css';
+import { useResizeObserver } from '@react-aria/utils';
 import { debounce, inRange } from 'lodash';
-import React, { PureComponent } from 'react';
-import { connect, ConnectedProps } from 'react-redux';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 import { locationService } from '@grafana/runtime';
 import { ErrorBoundaryAlert } from '@grafana/ui';
 import { SplitView } from 'app/core/components/SplitPaneWrapper/SplitView';
-import { GrafanaContext } from 'app/core/context/GrafanaContext';
+import { useGrafana } from 'app/core/context/GrafanaContext';
+import { useNavModel } from 'app/core/hooks/useNavModel';
 import { GrafanaRouteComponentProps } from 'app/core/navigation/types';
-import { StoreState } from 'app/types';
+import { isTruthy } from 'app/core/utils/types';
+import { useSelector, useDispatch } from 'app/types';
 import { ExploreId, ExploreQueryParams } from 'app/types/explore';
 
 import { Branding } from '../../core/components/Branding/Branding';
-import { getNavModel } from '../../core/selectors/navModel';
 
 import { ExploreActions } from './ExploreActions';
 import { ExplorePaneContainer } from './ExplorePaneContainer';
-import {
-  lastSavedUrl,
-  resetExploreAction,
-  richHistoryUpdatedAction,
-  cleanupPaneAction,
-  splitSizeUpdateAction,
-} from './state/main';
+import { lastSavedUrl, resetExploreAction, splitSizeUpdateAction } from './state/main';
 
 const styles = {
   pageScrollbarWrapper: css`
@@ -36,64 +31,31 @@ const styles = {
   `,
 };
 
-interface RouteProps extends GrafanaRouteComponentProps<{}, ExploreQueryParams> {}
-interface OwnProps {}
+const MIN_PANE_WIDTH = 200;
+function Wrapper(props: GrafanaRouteComponentProps<{}, ExploreQueryParams>) {
+  useExplorePageTitle();
+  const { maxedExploreId, evenSplitPanes } = useSelector((state) => state.explore);
+  const [rightPaneWidth, setRightPaneWidth] = useState<number>();
+  const [prevWindowWidth, setWindowWidth] = useState<number>();
+  const dispatch = useDispatch();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const queryParams = props.queryParams;
+  const { keybindings, chrome } = useGrafana();
+  const navModel = useNavModel('explore');
 
-interface WrapperState {
-  rightPaneWidth?: number;
-  windowWidth?: number;
-}
-
-const mapStateToProps = (state: StoreState) => {
-  return {
-    navModel: getNavModel(state.navIndex, 'explore'),
-    exploreState: state.explore,
-  };
-};
-
-const mapDispatchToProps = {
-  resetExploreAction,
-  richHistoryUpdatedAction,
-  cleanupPaneAction,
-  splitSizeUpdateAction,
-};
-
-const connector = connect(mapStateToProps, mapDispatchToProps);
-
-type Props = OwnProps & RouteProps & ConnectedProps<typeof connector>;
-class WrapperUnconnected extends PureComponent<Props, WrapperState> {
-  minWidth = 200;
-  static contextType = GrafanaContext;
-
-  constructor(props: Props) {
-    super(props);
-    this.state = {
-      rightPaneWidth: undefined,
-      windowWidth: undefined,
-    };
-  }
-
-  componentWillUnmount() {
-    const { left, right } = this.props.queryParams;
-    this.props.resetExploreAction({});
-
-    if (Boolean(left)) {
-      this.props.cleanupPaneAction({ exploreId: ExploreId.left });
-    }
-
-    if (Boolean(right)) {
-      this.props.cleanupPaneAction({ exploreId: ExploreId.right });
-    }
-
-    window.removeEventListener('resize', this.windowResizeListener);
-  }
-
-  componentDidMount() {
+  useEffect(() => {
     //This is needed for breadcrumbs and topnav.
     //We should probably abstract this out at some point
-    this.context.chrome.update({ sectionNav: this.props.navModel.node });
-    this.context.keybindings.setupTimeRangeBindings(false);
+    chrome.update({ sectionNav: navModel.node });
+  }, [chrome, navModel]);
 
+  useEffect(() => {
+    // FIXME: after cloasing the split view, changing time via keyboard causes an error (happens also on main)
+    // will create a separate issue for this.
+    keybindings.setupTimeRangeBindings(false);
+  }, [keybindings]);
+
+  useEffect(() => {
     lastSavedUrl.left = undefined;
     lastSavedUrl.right = undefined;
 
@@ -111,90 +73,101 @@ class WrapperUnconnected extends PureComponent<Props, WrapperState> {
       locationService.partial({ from: undefined, to: undefined }, true);
     }
 
-    window.addEventListener('resize', this.windowResizeListener);
-  }
+    return () => {
+      // Cleaning up Explore state so that when navigating back to Explore it starts from a blank state
+      dispatch(resetExploreAction());
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- dispatch is stable, doesn't need to be in the deps array
+  }, []);
 
-  componentDidUpdate() {
-    const { left, right } = this.props.queryParams;
-    const hasSplit = Boolean(left) && Boolean(right);
-    const datasourceTitle = hasSplit
-      ? `${this.props.exploreState.left.datasourceInstance?.name} | ${this.props.exploreState.right?.datasourceInstance?.name}`
-      : `${this.props.exploreState.left.datasourceInstance?.name}`;
-    const documentTitle = `${this.props.navModel.main.text} - ${datasourceTitle} - ${Branding.AppTitle}`;
-    document.title = documentTitle;
-  }
-
-  windowResizeListener = debounce(() => {
+  const debouncedFunctionRef = useRef((prevWindowWidth?: number, rightPaneWidth?: number) => {
     let rightPaneRatio = 0.5;
-    const windowWidth = window.innerWidth;
+    if (!containerRef.current) {
+      return;
+    }
+    const windowWidth = containerRef.current.clientWidth;
     // get the ratio of the previous rightPane to the window width
-    if (this.state.rightPaneWidth && this.state.windowWidth) {
-      rightPaneRatio = this.state.rightPaneWidth / this.state.windowWidth;
+    if (rightPaneWidth && prevWindowWidth) {
+      rightPaneRatio = rightPaneWidth / prevWindowWidth;
     }
     let newRightPaneWidth = Math.floor(windowWidth * rightPaneRatio);
-    if (newRightPaneWidth < this.minWidth) {
+    if (newRightPaneWidth < MIN_PANE_WIDTH) {
       // if right pane is too narrow, make min width
-      newRightPaneWidth = this.minWidth;
-    } else if (windowWidth - newRightPaneWidth < this.minWidth) {
+      newRightPaneWidth = MIN_PANE_WIDTH;
+    } else if (windowWidth - newRightPaneWidth < MIN_PANE_WIDTH) {
       // if left pane is too narrow, make right pane = window - minWidth
-      newRightPaneWidth = windowWidth - this.minWidth;
+      newRightPaneWidth = windowWidth - MIN_PANE_WIDTH;
     }
 
-    this.setState({ windowWidth, rightPaneWidth: newRightPaneWidth });
-  }, 500);
+    setRightPaneWidth(newRightPaneWidth);
+    setWindowWidth(windowWidth);
+  });
 
-  updateSplitSize = (rightPaneWidth: number) => {
+  // eslint needs the callback to be inline to analyze the dependencies, but we need to use debounce from lodash
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const onResize = useCallback(
+    debounce(() => debouncedFunctionRef.current(prevWindowWidth, rightPaneWidth), 500),
+    [prevWindowWidth, rightPaneWidth]
+  );
+
+  const updateSplitSize = (rightPaneWidth: number) => {
     const evenSplitWidth = window.innerWidth / 2;
     const areBothSimilar = inRange(rightPaneWidth, evenSplitWidth - 100, evenSplitWidth + 100);
     if (areBothSimilar) {
-      this.props.splitSizeUpdateAction({ largerExploreId: undefined });
+      dispatch(splitSizeUpdateAction({ largerExploreId: undefined }));
     } else {
-      this.props.splitSizeUpdateAction({
-        largerExploreId: rightPaneWidth > evenSplitWidth ? ExploreId.right : ExploreId.left,
-      });
+      dispatch(
+        splitSizeUpdateAction({
+          largerExploreId: rightPaneWidth > evenSplitWidth ? ExploreId.right : ExploreId.left,
+        })
+      );
     }
 
-    this.setState({ ...this.state, rightPaneWidth });
+    setRightPaneWidth(rightPaneWidth);
   };
 
-  render() {
-    const { left, right } = this.props.queryParams;
-    const { maxedExploreId, evenSplitPanes } = this.props.exploreState;
-    const hasSplit = Boolean(left) && Boolean(right);
-    let widthCalc = 0;
+  useResizeObserver({ onResize, ref: containerRef });
+  const hasSplit = Boolean(queryParams.left) && Boolean(queryParams.right);
+  let widthCalc = 0;
 
-    if (hasSplit) {
-      if (!evenSplitPanes && maxedExploreId) {
-        widthCalc = maxedExploreId === ExploreId.right ? window.innerWidth - this.minWidth : this.minWidth;
-      } else if (evenSplitPanes) {
-        widthCalc = Math.floor(window.innerWidth / 2);
-      } else if (this.state.rightPaneWidth !== undefined) {
-        widthCalc = this.state.rightPaneWidth;
-      }
+  if (hasSplit) {
+    if (!evenSplitPanes && maxedExploreId) {
+      widthCalc = maxedExploreId === ExploreId.right ? window.innerWidth - MIN_PANE_WIDTH : MIN_PANE_WIDTH;
+    } else if (evenSplitPanes) {
+      widthCalc = Math.floor(window.innerWidth / 2);
+    } else if (rightPaneWidth !== undefined) {
+      widthCalc = rightPaneWidth;
     }
-
-    const splitSizeObj = { rightPaneSize: widthCalc };
-
-    return (
-      <div className={styles.pageScrollbarWrapper}>
-        <ExploreActions exploreIdLeft={ExploreId.left} exploreIdRight={ExploreId.right} />
-        <div className={styles.exploreWrapper}>
-          <SplitView uiState={splitSizeObj} minSize={this.minWidth} onResize={this.updateSplitSize}>
-            <ErrorBoundaryAlert style="page" key="LeftPane">
-              <ExplorePaneContainer split={hasSplit} exploreId={ExploreId.left} urlQuery={left} />
-            </ErrorBoundaryAlert>
-            {hasSplit && (
-              <ErrorBoundaryAlert style="page" key="RightPane">
-                <ExplorePaneContainer split={hasSplit} exploreId={ExploreId.right} urlQuery={right} />
-              </ErrorBoundaryAlert>
-            )}
-          </SplitView>
-        </div>
-      </div>
-    );
   }
+
+  const splitSizeObj = { rightPaneSize: widthCalc };
+  return (
+    <div className={styles.pageScrollbarWrapper} ref={containerRef}>
+      <ExploreActions exploreIdLeft={ExploreId.left} exploreIdRight={ExploreId.right} />
+      <div className={styles.exploreWrapper}>
+        <SplitView uiState={splitSizeObj} minSize={MIN_PANE_WIDTH} onResize={updateSplitSize}>
+          <ErrorBoundaryAlert style="page" key="LeftPane">
+            <ExplorePaneContainer split={hasSplit} exploreId={ExploreId.left} urlQuery={queryParams.left} />
+          </ErrorBoundaryAlert>
+          {hasSplit && (
+            <ErrorBoundaryAlert style="page" key="RightPane">
+              <ExplorePaneContainer split={hasSplit} exploreId={ExploreId.right} urlQuery={queryParams.right} />
+            </ErrorBoundaryAlert>
+          )}
+        </SplitView>
+      </div>
+    </div>
+  );
 }
 
-const Wrapper = connector(WrapperUnconnected);
+const useExplorePageTitle = () => {
+  const navModel = useNavModel('explore');
+  const datasources = useSelector((state) =>
+    [state.explore.left.datasourceInstance?.name, state.explore.right?.datasourceInstance?.name].filter(isTruthy)
+  );
+
+  const documentTitle = `${navModel.main.text} - ${datasources.join(' | ')} - ${Branding.AppTitle}`;
+  document.title = documentTitle;
+};
 
 export default Wrapper;

--- a/public/app/features/explore/Wrapper.tsx
+++ b/public/app/features/explore/Wrapper.tsx
@@ -50,8 +50,6 @@ function Wrapper(props: GrafanaRouteComponentProps<{}, ExploreQueryParams>) {
   }, [chrome, navModel]);
 
   useEffect(() => {
-    // FIXME: after cloasing the split view, changing time via keyboard causes an error (happens also on main)
-    // will create a separate issue for this.
     keybindings.setupTimeRangeBindings(false);
   }, [keybindings]);
 

--- a/public/app/features/explore/state/explorePane.ts
+++ b/public/app/features/explore/state/explorePane.ts
@@ -192,8 +192,8 @@ export function initializeExplore(
  */
 export function refreshExplore(exploreId: ExploreId, newUrlQuery: string): ThunkResult<void> {
   return async (dispatch, getState) => {
-    const itemState = getState().explore[exploreId]!;
-    if (!itemState.initialized) {
+    const itemState = getState().explore[exploreId];
+    if (!itemState?.initialized) {
       return;
     }
 


### PR DESCRIPTION
Convert Explore's `Wrapper.tsx` to a function component and refactor some logic. There are some easily achievable optimizations left, will create a follow-up PR, but opening this for review now to unblock @ifrost 