### PR TITLE
TopNav: Fix pages import dashboard and create new folder

### DIFF
--- a/public/app/features/folders/components/NewDashboardsFolder.tsx
+++ b/public/app/features/folders/components/NewDashboardsFolder.tsx
@@ -1,6 +1,8 @@
 import React, { PureComponent } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 
+import { NavModelItem } from '@grafana/data';
+import { config } from '@grafana/runtime';
 import { Button, Input, Form, Field } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 
@@ -39,11 +41,17 @@ export class NewDashboardsFolder extends PureComponent<Props> {
       });
   };
 
+  pageNav: NavModelItem = {
+    text: 'Create a new folder',
+    subTitle: 'Folders provide a way to group dashboards and alert rules.',
+    breadcrumbs: [{ title: 'Dashboards', url: 'dashboards' }],
+  };
+
   render() {
     return (
-      <Page navId="dashboards/folder/new">
+      <Page navId="dashboards/browse" pageNav={this.pageNav}>
         <Page.Contents>
-          <h3>New dashboard folder</h3>
+          {!config.featureToggles.topnav && <h3>New dashboard folder</h3>}
           <Form defaultValues={initialFormModel} onSubmit={this.onSubmit}>
             {({ register, errors }) => (
               <>

--- a/public/app/features/manage-dashboards/DashboardImportPage.tsx
+++ b/public/app/features/manage-dashboards/DashboardImportPage.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import React, { FormEvent, PureComponent } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 
-import { AppEvents, GrafanaTheme2, LoadingState } from '@grafana/data';
+import { AppEvents, GrafanaTheme2, LoadingState, NavModelItem } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { reportInteraction } from '@grafana/runtime';
 import {
@@ -187,11 +187,17 @@ class UnthemedDashboardImport extends PureComponent<Props> {
     );
   }
 
+  pageNav: NavModelItem = {
+    text: 'Import dashboard',
+    subTitle: 'Import dashboard from file or Grafana.com"',
+    breadcrumbs: [{ title: 'Dashboards', url: 'dashboards' }],
+  };
+
   render() {
     const { loadingState } = this.props;
 
     return (
-      <Page navId="dashboards/import">
+      <Page navId="dashboards/browse" pageNav={this.pageNav}>
         <Page.Contents>
           {loadingState === LoadingState.Loading && (
             <VerticalGroup justify="center">


### PR DESCRIPTION
Fixes some issues with Import dashboard and Create folder, they both showed "Page not found" in the breadcrumb and page header as the nav nodes don't exist in navtree when topnav is enabled.
