### PR TITLE
CloudWatch: Avoid limit of 50 Log Groups

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -53,7 +53,7 @@ exports[`no enzyme tests`] = {
     "public/app/features/dimensions/editors/ThresholdsEditor/ThresholdsEditor.test.tsx:145048794": [
       [0, 17, 13, "RegExp match", "2409514259"]
     ],
-    "public/app/plugins/datasource/cloudwatch/components/ConfigEditor.test.tsx:2983010995": [
+    "public/app/plugins/datasource/cloudwatch/components/ConfigEditor.test.tsx:3802768530": [
       [1, 19, 13, "RegExp match", "2409514259"]
     ]
   }`

--- a/pkg/tsdb/cloudwatch/cloudwatch_test.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch_test.go
@@ -325,6 +325,81 @@ func TestQuery_ResourceRequest_DescribeAllLogGroups(t *testing.T) {
 			"group_a", "group_b", "group_c", "group_x", "group_y", "group_z",
 		}), suggestDataResponse)
 	})
+
+	t.Run("Should call api with LogGroupNamePrefix if passed in resource call", func(t *testing.T) {
+		cli = fakeCWLogsClient{
+			logGroups: []cloudwatchlogs.DescribeLogGroupsOutput{
+				{LogGroups: []*cloudwatchlogs.LogGroup{}},
+			},
+		}
+
+		im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
+			return datasourceInfo{}, nil
+		})
+
+		executor := newExecutor(im, newTestConfig(), &fakeSessionCache{}, featuremgmt.WithFeatures())
+
+		req := &backend.CallResourceRequest{
+			Method: "GET",
+			Path:   "/all-log-groups?logGroupNamePrefix=test",
+			PluginContext: backend.PluginContext{
+				DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{
+					ID: 0,
+				},
+				PluginID: "cloudwatch",
+			},
+		}
+		err := executor.CallResource(context.Background(), req, sender)
+
+		require.NoError(t, err)
+		sent := sender.Response
+		require.NotNil(t, sent)
+		require.Equal(t, http.StatusOK, sent.Status)
+
+		assert.Equal(t, []*cloudwatchlogs.DescribeLogGroupsInput{
+			{
+				Limit:              aws.Int64(defaultLogGroupLimit),
+				LogGroupNamePrefix: aws.String("test"),
+			},
+		}, cli.calls.describeLogGroups)
+	})
+
+	t.Run("Should call api without LogGroupNamePrefix if not passed in resource call", func(t *testing.T) {
+		cli = fakeCWLogsClient{
+			logGroups: []cloudwatchlogs.DescribeLogGroupsOutput{
+				{LogGroups: []*cloudwatchlogs.LogGroup{}},
+			},
+		}
+
+		im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
+			return datasourceInfo{}, nil
+		})
+
+		executor := newExecutor(im, newTestConfig(), &fakeSessionCache{}, featuremgmt.WithFeatures())
+
+		req := &backend.CallResourceRequest{
+			Method: "GET",
+			Path:   "/all-log-groups",
+			PluginContext: backend.PluginContext{
+				DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{
+					ID: 0,
+				},
+				PluginID: "cloudwatch",
+			},
+		}
+		err := executor.CallResource(context.Background(), req, sender)
+
+		require.NoError(t, err)
+		sent := sender.Response
+		require.NotNil(t, sent)
+		require.Equal(t, http.StatusOK, sent.Status)
+
+		assert.Equal(t, []*cloudwatchlogs.DescribeLogGroupsInput{
+			{
+				Limit: aws.Int64(50),
+			},
+		}, cli.calls.describeLogGroups)
+	})
 }
 
 func TestQuery_ResourceRequest_DescribeLogGroups(t *testing.T) {

--- a/pkg/tsdb/cloudwatch/metric_find_query.go
+++ b/pkg/tsdb/cloudwatch/metric_find_query.go
@@ -699,11 +699,15 @@ func (e *cloudWatchExecutor) handleGetAllLogGroups(pluginCtx backend.PluginConte
 	var response *cloudwatchlogs.DescribeLogGroupsOutput
 	result := make([]suggestData, 0)
 	for {
-		response, err = logsClient.DescribeLogGroups(&cloudwatchlogs.DescribeLogGroupsInput{
-			LogGroupNamePrefix: aws.String(logGroupNamePrefix),
-			NextToken:          nextToken,
-			Limit:              aws.Int64(defaultLogGroupLimit),
-		})
+		input := &cloudwatchlogs.DescribeLogGroupsInput{
+			Limit:     aws.Int64(defaultLogGroupLimit),
+			NextToken: nextToken,
+		}
+		if len(logGroupNamePrefix) > 0 {
+			input.LogGroupNamePrefix = aws.String(logGroupNamePrefix)
+		}
+
+		response, err = logsClient.DescribeLogGroups(input)
 		if err != nil || response == nil {
 			return nil, err
 		}

--- a/public/app/plugins/datasource/cloudwatch/__mocks__/CloudWatchDataSource.ts
+++ b/public/app/plugins/datasource/cloudwatch/__mocks__/CloudWatchDataSource.ts
@@ -76,7 +76,7 @@ export function setupMockedDataSource({
   const timeSrv = getTimeSrv();
   const datasource = new CloudWatchDatasource(CloudWatchSettings, templateService, timeSrv);
   datasource.getVariables = () => ['test'];
-  datasource.api.describeLogGroups = jest.fn().mockResolvedValue([]);
+  datasource.api.describeAllLogGroups = jest.fn().mockResolvedValue([]);
   datasource.api.getNamespaces = jest.fn().mockResolvedValue([]);
   datasource.api.getRegions = jest.fn().mockResolvedValue([]);
   datasource.logsQueryRunner.defaultLogGroups = [];

--- a/public/app/plugins/datasource/cloudwatch/components/ConfigEditor.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/ConfigEditor.test.tsx
@@ -14,7 +14,7 @@ jest.mock('app/features/plugins/datasource_srv', () => ({
   getDatasourceSrv: () => ({
     loadDatasource: jest.fn().mockResolvedValue({
       api: {
-        describeLogGroups: jest.fn().mockResolvedValue(['logGroup-foo', 'logGroup-bar'].map(toOption)),
+        describeAllLogGroups: jest.fn().mockResolvedValue(['logGroup-foo', 'logGroup-bar'].map(toOption)),
         getRegions: jest.fn().mockResolvedValue([
           {
             label: 'ap-east-1',

--- a/public/app/plugins/datasource/cloudwatch/components/LogGroupSelector.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/LogGroupSelector.test.tsx
@@ -27,7 +27,7 @@ describe('LogGroupSelector', () => {
   });
 
   it('updates upstream query log groups on region change', async () => {
-    ds.datasource.api.describeLogGroups = jest.fn().mockImplementation(async (params: DescribeLogGroupsRequest) => {
+    ds.datasource.api.describeAllLogGroups = jest.fn().mockImplementation(async (params: DescribeLogGroupsRequest) => {
       if (params.region === 'region1') {
         return Promise.resolve(['log_group_1'].map(toOption));
       } else {
@@ -50,7 +50,7 @@ describe('LogGroupSelector', () => {
   });
 
   it('does not update upstream query log groups if saved is false', async () => {
-    ds.datasource.api.describeLogGroups = jest.fn().mockImplementation(async (params: DescribeLogGroupsRequest) => {
+    ds.datasource.api.describeAllLogGroups = jest.fn().mockImplementation(async (params: DescribeLogGroupsRequest) => {
       if (params.region === 'region1') {
         return Promise.resolve(['log_group_1'].map(toOption));
       } else {
@@ -96,7 +96,7 @@ describe('LogGroupSelector', () => {
     ];
     const testLimit = 10;
 
-    ds.datasource.api.describeLogGroups = jest.fn().mockImplementation(async (params: DescribeLogGroupsRequest) => {
+    ds.datasource.api.describeAllLogGroups = jest.fn().mockImplementation(async (params: DescribeLogGroupsRequest) => {
       const theLogGroups = allLogGroups
         .filter((logGroupName) => logGroupName.startsWith(params.logGroupNamePrefix ?? ''))
         .slice(0, Math.max(params.limit ?? testLimit, testLimit));
@@ -125,7 +125,7 @@ describe('LogGroupSelector', () => {
 
   it('should render template variables a selectable option', async () => {
     lodash.debounce = jest.fn().mockImplementation((fn) => fn);
-    ds.datasource.api.describeLogGroups = jest.fn().mockResolvedValue([]);
+    ds.datasource.api.describeAllLogGroups = jest.fn().mockResolvedValue([]);
     const onChange = jest.fn();
     const props = {
       ...defaultProps,

--- a/public/app/plugins/datasource/cloudwatch/components/LogGroupSelector.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/LogGroupSelector.tsx
@@ -47,12 +47,12 @@ export const LogGroupSelector: React.FC<LogGroupSelectorProps> = ({
   );
 
   const fetchLogGroupOptions = useCallback(
-    async (region: string, logGroupNamePrefix?: string) => {
+    async (region: string, logGroupNamePrefix = '') => {
       if (!datasource) {
         return [];
       }
       try {
-        const logGroups = await datasource.api.describeLogGroups({
+        const logGroups = await datasource.api.describeAllLogGroups({
           refId,
           region,
           logGroupNamePrefix,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Avoids the limit imposed by the AWS API which only returns 50 log groups per request. The frontend now calls `describeAllLogGroups` to have the backend repeatedly call the AWS API until the end of the log group list is reached. 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #55700

**Special notes for your reviewer**:

To quickly generate 60 log groups, I used the following CloudFormation template. To deploy: `aws cloudformation deploy --template-file <file.yaml> --stack-name test-log-groups --region <region>`.

<details><summary>Expand</summary>
<p>

```yaml
AWSTemplateFormatVersion: 2010-09-09
Description: Test stack to quickly create 60 log groups 

Resources:
  logGroup1:
    Type: AWS::Logs::LogGroup
    Properties:
      LogGroupName: testloggroup1
      RetentionInDays: 1

  logGroup2:
    Type: AWS::Logs::LogGroup
    Properties:
      LogGroupName: testloggroup2
      RetentionInDays: 1

  logGroup3:
    Type: AWS::Logs::LogGroup
    Properties:
      LogGroupName: testloggroup3
      RetentionInDays: 1

  logGroup4:
    Type: AWS::Logs::LogGroup
    Properties:
      LogGroupName: testloggroup4
      RetentionInDays: 1

  logGroup5:
    Type: AWS::Logs::LogGroup
    Properties:
      LogGroupName: testloggroup5
      RetentionInDays: 1

  logGroup6:
    Type: AWS::Logs::LogGroup
    Properties:
      LogGroupName: testloggroup6
      RetentionInDays: 1

  logGroup7:
    Type: AWS::Logs::LogGroup
    Properties:
      LogGroupName: testloggroup7
      RetentionInDays: 1

  logGroup8:
    Type: AWS::Logs::LogGroup
    Properties:
      LogGroupName: testloggroup8
      RetentionInDays: 1

  logGroup9:
    Type: AWS::Logs::LogGroup
    Properties:
      LogGroupName: testloggroup9
      RetentionInDays: 1

  logGroup10:
    Type: AWS::Logs::LogGroup
    Properties:
      LogGroupName: testloggroup10
      RetentionInDays: 1

  logGroup11:
    Type: AWS::Logs::LogGroup
    Properties:
      LogGroupName: testloggroup11
      RetentionInDays: 1

  logGroup12:
    Type: AWS::Logs::LogGroup
    Properties:
      LogGroupName: testloggroup12
      RetentionInDays: 1

  logGroup13:
    Type: AWS::Logs::LogGroup
    Properties:
      LogGroupName: testloggroup13
      RetentionInDays: 1

  logGroup14:
    Type: AWS::Logs::LogGroup
    Properties:
      LogGroupName: testloggroup14
      RetentionInDays: 1

  logGroup15:
    Type: AWS::Logs::LogGroup
    Properties:
      LogGroupName: testloggroup15
      RetentionInDays: 1

  logGroup16:
    Type: AWS::Logs::LogGroup
    Properties:
      LogGroupName: testloggroup16
      RetentionInDays: 1

  logGroup17:
    Type: AWS::Logs::LogGroup
    Properties:
      LogGroupName: testloggroup17
      RetentionInDays: 1

  logGroup18:
    Type: AWS::Logs::LogGroup
    Properties:
      LogGroupName: testloggroup18
      RetentionInDays: 1

  logGroup19:
    Type: AWS::Logs::LogGroup
    Properties:
      LogGroupName: testloggroup19
      RetentionInDays: 1

  logGroup20:
    Type: AWS::Logs::LogGroup
    Properties:
      LogGroupName: testloggroup20
      RetentionInDays: 1

  logGroup21:
    Type: AWS::Logs::LogGroup
    Properties:
      LogGroupName: testloggroup21
      RetentionInDays: 1

  logGroup22:
    Type: AWS::Logs::LogGroup
    Properties:
      LogGroupName: testloggroup22
      RetentionInDays: 1

  logGroup23:
    Type: AWS::Logs::LogGroup
    Properties:
      LogGroupName: testloggroup23
      RetentionInDays: 1

  logGroup24:
    Type: AWS::Logs::LogGroup
    Properties:
      LogGroupName: testloggroup24
      RetentionInDays: 1

  logGroup25:
    Type: AWS::Logs::LogGroup
    Properties:
      LogGroupName: testloggroup25
      RetentionInDays: 1

  logGroup26:
    Type: AWS::Logs::LogGroup
    Properties:
      LogGroupName: testloggroup26
      RetentionInDays: 1

  logGroup27:
    Type: AWS::Logs::LogGroup
    Properties:
      LogGroupName: testloggroup27
      RetentionInDays: 1

  logGroup28:
    Type: AWS::Logs::LogGroup
    Properties:
      LogGroupName: testloggroup28
      RetentionInDays: 1

  logGroup29:
    Type: AWS::Logs::LogGroup
    Properties:
      LogGroupName: testloggroup29
      RetentionInDays: 1

  logGroup30:
    Type: AWS::Logs::LogGroup
    Properties:
      LogGroupName: testloggroup30
      RetentionInDays: 1

  logGroup31:
    Type: AWS::Logs::LogGroup
    Properties:
      LogGroupName: testloggroup31
      RetentionInDays: 1

  logGroup32:
    Type: AWS::Logs::LogGroup
    Properties:
      LogGroupName: testloggroup32
      RetentionInDays: 1

  logGroup33:
    Type: AWS::Logs::LogGroup
    Properties:
      LogGroupName: testloggroup33
      RetentionInDays: 1

  logGroup34:
    Type: AWS::Logs::LogGroup
    Properties:
      LogGroupName: testloggroup34
      RetentionInDays: 1

  logGroup35:
    Type: AWS::Logs::LogGroup
    Properties:
      LogGroupName: testloggroup35
      RetentionInDays: 1

  logGroup36:
    Type: AWS::Logs::LogGroup
    Properties:
      LogGroupName: testloggroup36
      RetentionInDays: 1

  logGroup37:
    Type: AWS::Logs::LogGroup
    Properties:
      LogGroupName: testloggroup37
      RetentionInDays: 1

  logGroup38:
    Type: AWS::Logs::LogGroup
    Properties:
      LogGroupName: testloggroup38
      RetentionInDays: 1

  logGroup39:
    Type: AWS::Logs::LogGroup
    Properties:
      LogGroupName: testloggroup39
      RetentionInDays: 1

  logGroup40:
    Type: AWS::Logs::LogGroup
    Properties:
      LogGroupName: testloggroup40
      RetentionInDays: 1

  logGroup41:
    Type: AWS::Logs::LogGroup
    Properties:
      LogGroupName: testloggroup41
      RetentionInDays: 1

  logGroup42:
    Type: AWS::Logs::LogGroup
    Properties:
      LogGroupName: testloggroup42
      RetentionInDays: 1

  logGroup43:
    Type: AWS::Logs::LogGroup
    Properties:
      LogGroupName: testloggroup43
      RetentionInDays: 1

  logGroup44:
    Type: AWS::Logs::LogGroup
    Properties:
      LogGroupName: testloggroup44
      RetentionInDays: 1

  logGroup45:
    Type: AWS::Logs::LogGroup
    Properties:
      LogGroupName: testloggroup45
      RetentionInDays: 1

  logGroup46:
    Type: AWS::Logs::LogGroup
    Properties:
      LogGroupName: testloggroup46
      RetentionInDays: 1

  logGroup47:
    Type: AWS::Logs::LogGroup
    Properties:
      LogGroupName: testloggroup47
      RetentionInDays: 1

  logGroup48:
    Type: AWS::Logs::LogGroup
    Properties:
      LogGroupName: testloggroup48
      RetentionInDays: 1

  logGroup49:
    Type: AWS::Logs::LogGroup
    Properties:
      LogGroupName: testloggroup49
      RetentionInDays: 1

  logGroup50:
    Type: AWS::Logs::LogGroup
    Properties:
      LogGroupName: testloggroup50
      RetentionInDays: 1

  logGroup51:
    Type: AWS::Logs::LogGroup
    Properties:
      LogGroupName: testloggroup51
      RetentionInDays: 1

  logGroup52:
    Type: AWS::Logs::LogGroup
    Properties:
      LogGroupName: testloggroup52
      RetentionInDays: 1

  logGroup53:
    Type: AWS::Logs::LogGroup
    Properties:
      LogGroupName: testloggroup53
      RetentionInDays: 1

  logGroup54:
    Type: AWS::Logs::LogGroup
    Properties:
      LogGroupName: testloggroup54
      RetentionInDays: 1

  logGroup55:
    Type: AWS::Logs::LogGroup
    Properties:
      LogGroupName: testloggroup55
      RetentionInDays: 1

  logGroup56:
    Type: AWS::Logs::LogGroup
    Properties:
      LogGroupName: testloggroup56
      RetentionInDays: 1

  logGroup57:
    Type: AWS::Logs::LogGroup
    Properties:
      LogGroupName: testloggroup57
      RetentionInDays: 1

  logGroup58:
    Type: AWS::Logs::LogGroup
    Properties:
      LogGroupName: testloggroup58
      RetentionInDays: 1

  logGroup59:
    Type: AWS::Logs::LogGroup
    Properties:
      LogGroupName: testloggroup59
      RetentionInDays: 1

  logGroup60:
    Type: AWS::Logs::LogGroup
    Properties:
      LogGroupName: testloggroup60
      RetentionInDays: 1

```

</p>
</details>

