### PR TITLE
PanelEdit: Fixes resize pane border and spacing issues  

### DIFF
--- a/public/app/core/components/SplitPaneWrapper/SplitPaneWrapper.tsx
+++ b/public/app/core/components/SplitPaneWrapper/SplitPaneWrapper.tsx
@@ -161,25 +161,6 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
       overflow: hidden;
       width: 100%;
     `,
-    resizerV: cx(
-      resizer,
-      css`
-        cursor: col-resize;
-        width: ${paneSpacing};
-
-        &::before {
-          border-right: 1px solid transparent;
-          height: 100%;
-          left: 50%;
-          transform: translateX(-50%);
-        }
-
-        &::after {
-          height: 200px;
-          width: 4px;
-        }
-      `
-    ),
     resizerH: cx(
       resizer,
       css`

--- a/public/app/core/components/SplitPaneWrapper/SplitView.tsx
+++ b/public/app/core/components/SplitPaneWrapper/SplitView.tsx
@@ -83,7 +83,6 @@ export const SplitView = ({ uiState: { rightPaneSize }, children, minSize = 200,
       minSize={minSize}
       maxSize={width - minSize}
       resizerClassName={useStyles2(getResizerStyles(hasSplit))}
-      paneStyle={{ overflow: 'auto', display: 'flex', flexDirection: 'column', overflowY: 'scroll' }}
       onDragStarted={onDragStarted}
       onDragFinished={(size: number) => onDragFinished(size, onResize)}
     >

--- a/public/app/core/components/SplitPaneWrapper/SplitView.tsx
+++ b/public/app/core/components/SplitPaneWrapper/SplitView.tsx
@@ -31,7 +31,7 @@ const getResizerStyles = (hasSplit: boolean) => (theme: GrafanaTheme2) =>
       content: '';
       position: absolute;
       transition: 0.2s border-color ease-in-out;
-      border-right: 1px solid ${theme.colors.border.weak};
+      border-right: 1px solid transparent;
       height: 100%;
       left: 50%;
       transform: translateX(-50%);


### PR DESCRIPTION
https://github.com/grafana/grafana/pull/54420 broke 3 things in panel edit (2 fixed so far in this PR) it also duplicated the resizer styling and the callbacks so that it's now something we have to maintain in two places (SplitView and SplitViewWrapper), that does not feel ideal. 

* [x] Fixes border bug
* [x] Fixes a spacing bug (left split pane had overflow overflowY added which caused space for a scrollbar which caused unaligned spacing for the visualzation view in pane ledit)
* [ ] Changing size of split pane is not saved like before, reloading panel edit rests it to the default. In 9.1 it still works and it remembers the split size 

Below you see the border (should not be there), and the left side space is not equal to right side (should be 16px spacing between panes but it's 24)
![image](https://user-images.githubusercontent.com/10999/193605130-cf39596d-10ff-43b8-aa98-de2c859927cd.png)


