### PR TITLE
Chore: Convert `SpanTreeOffset` test to RTL

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -29,9 +29,6 @@ exports[`no enzyme tests`] = {
     "packages/jaeger-ui-components/src/TraceTimelineViewer/ListView/index.test.js:1734982398": [
       [14, 26, 13, "RegExp match", "2409514259"]
     ],
-    "packages/jaeger-ui-components/src/TraceTimelineViewer/SpanTreeOffset.test.js:278627903": [
-      [14, 19, 13, "RegExp match", "2409514259"]
-    ],
     "packages/jaeger-ui-components/src/TraceTimelineViewer/TimelineHeaderRow/TimelineColumnResizer.test.js:989353473": [
       [15, 17, 13, "RegExp match", "2409514259"]
     ],

--- a/.betterer.results
+++ b/.betterer.results
@@ -29,7 +29,7 @@ exports[`no enzyme tests`] = {
     "packages/jaeger-ui-components/src/TraceTimelineViewer/ListView/index.test.js:1734982398": [
       [14, 26, 13, "RegExp match", "2409514259"]
     ],
-    "packages/jaeger-ui-components/src/TraceTimelineViewer/SpanTreeOffset.test.js:174536706": [
+    "packages/jaeger-ui-components/src/TraceTimelineViewer/SpanTreeOffset.test.js:278627903": [
       [14, 19, 13, "RegExp match", "2409514259"]
     ],
     "packages/jaeger-ui-components/src/TraceTimelineViewer/TimelineHeaderRow/TimelineColumnResizer.test.js:989353473": [

--- a/packages/jaeger-ui-components/src/TraceTimelineViewer/SpanTreeOffset.test.js
+++ b/packages/jaeger-ui-components/src/TraceTimelineViewer/SpanTreeOffset.test.js
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { render, screen, fireEvent, createEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { shallow } from 'enzyme';
 import React from 'react';
 import IoChevronRight from 'react-icons/lib/io/chevron-right';
@@ -31,7 +33,17 @@ describe('SpanTreeOffset', () => {
   const rootSpanID = 'rootSpanID';
   const specialRootID = 'root';
   let props;
-  let wrapper;
+  // let wrapper;
+
+  const parentProps = {
+    addHoverIndentGuideId: jest.fn(),
+    hoverIndentGuideIds: new Set(),
+    removeHoverIndentGuideId: jest.fn(),
+    span: {
+      hasChildren: false,
+      spanID: parentSpanID,
+    },
+  };
 
   beforeEach(() => {
     // Mock implementation instead of Mock return value so that each call returns a new array (like normal)
@@ -45,65 +57,89 @@ describe('SpanTreeOffset', () => {
         spanID: ownSpanID,
       },
     };
-    wrapper = shallow(<SpanTreeOffset {...props} />)
-      .dive()
-      .dive();
   });
 
   describe('.SpanTreeOffset--indentGuide', () => {
     it('renders only one .SpanTreeOffset--indentGuide for entire trace if span has no ancestors', () => {
       spanAncestorIdsSpy.mockReturnValue([]);
-      wrapper = shallow(<SpanTreeOffset {...props} />)
-        .dive()
-        .dive();
-      const indentGuides = wrapper.find('[data-testid="SpanTreeOffset--indentGuide"]');
-      expect(indentGuides.length).toBe(1);
-      expect(indentGuides.prop('data-ancestor-id')).toBe(specialRootID);
+      render(<SpanTreeOffset {...props} />);
+      const indentGuide = screen.getByTestId('SpanTreeOffset--indentGuide');
+      expect(indentGuide).toBeInTheDocument();
+      expect(indentGuide).toHaveAttribute('data-ancestor-id', specialRootID);
     });
 
     it('renders one .SpanTreeOffset--indentGuide per ancestor span, plus one for entire trace', () => {
-      const indentGuides = wrapper.find('[data-testid="SpanTreeOffset--indentGuide"]');
+      render(<SpanTreeOffset {...props} />);
+      const indentGuides = screen.getAllByTestId('SpanTreeOffset--indentGuide');
       expect(indentGuides.length).toBe(3);
-      expect(indentGuides.at(0).prop('data-ancestor-id')).toBe(specialRootID);
-      expect(indentGuides.at(1).prop('data-ancestor-id')).toBe(rootSpanID);
-      expect(indentGuides.at(2).prop('data-ancestor-id')).toBe(parentSpanID);
+      expect(indentGuides[0]).toHaveAttribute('data-ancestor-id', specialRootID);
+      expect(indentGuides[1]).toHaveAttribute('data-ancestor-id', rootSpanID);
+      expect(indentGuides[2]).toHaveAttribute('data-ancestor-id', parentSpanID);
     });
 
     it('adds .is-active to correct indentGuide', () => {
       props.hoverIndentGuideIds = new Set([parentSpanID]);
-      wrapper = shallow(<SpanTreeOffset {...props} />)
-        .dive()
-        .dive();
+      render(<SpanTreeOffset {...props} />);
       const styles = getStyles(createTheme());
-      const activeIndentGuide = wrapper.find(`.${styles.indentGuideActive}`);
-      expect(activeIndentGuide.length).toBe(1);
-      expect(activeIndentGuide.prop('data-ancestor-id')).toBe(parentSpanID);
+      const activeIndentGuide = document.querySelector(`.${styles.indentGuideActive}`);
+      expect(activeIndentGuide).toBeInTheDocument();
+      expect(activeIndentGuide).toHaveAttribute('data-ancestor-id', parentSpanID);
     });
 
-    it('calls props.addHoverIndentGuideId on mouse enter', () => {
-      wrapper.find({ 'data-ancestor-id': parentSpanID }).simulate('mouseenter', {});
+    it.skip('calls props.addHoverIndentGuideId on mouse enter', async () => {
+      render(<SpanTreeOffset {...props} />);
+      const span = document.querySelector(`[data-ancestor-id=${parentSpanID}]`);
+      // await userEvent.hover(span);
+      // const event = createEvent.mouseEnter(span, {
+      //   bubbles: false, cancelable: false, composed: true
+      // });
+      // const event = new MouseEvent('mouseenter', {
+      //   bubbles: false, cancelable: false, composed: true
+      // });
+      // fireEvent(span, event);
+      // fireEvent.mouseEnter(span);
+      await userEvent.hover(span);
       expect(props.addHoverIndentGuideId).toHaveBeenCalledTimes(1);
       expect(props.addHoverIndentGuideId).toHaveBeenCalledWith(parentSpanID);
     });
 
-    it('does not call props.addHoverIndentGuideId on mouse enter if mouse came from a indentGuide with the same ancestorId', () => {
+    it.skip('does not call props.addHoverIndentGuideId on mouse enter if mouse came from a indentGuide with the same ancestorId', () => {
+      render(
+        <>
+          <SpanTreeOffset {...parentProps} />
+          <SpanTreeOffset {...props} />
+        </>
+      );
+      const span = document.querySelector(`[data-ancestor-id=${parentSpanID}]`);
       const relatedTarget = document.createElement('span');
       relatedTarget.dataset.ancestorId = parentSpanID;
-      wrapper.find({ 'data-ancestor-id': parentSpanID }).simulate('mouseenter', {
-        relatedTarget,
+      const event = new MouseEvent('mouseenter', {
+        bubbles: false,
+        cancelable: false,
+        composed: true,
       });
+      event.relatedTarget = relatedTarget;
+      fireEvent(span, event);
+      // fireEvent.mouseEnter(span, {
+      //   relatedTarget,
+      // });
       expect(props.addHoverIndentGuideId).not.toHaveBeenCalled();
     });
 
-    it('calls props.removeHoverIndentGuideId on mouse leave', () => {
-      wrapper.find({ 'data-ancestor-id': parentSpanID }).simulate('mouseleave', {});
+    it.skip('calls props.removeHoverIndentGuideId on mouse leave', async () => {
+      render(<SpanTreeOffset {...props} />);
+      const span = document.querySelector(`[data-ancestor-id=${parentSpanID}]`);
+      fireEvent.mouseLeave(span);
       expect(props.removeHoverIndentGuideId).toHaveBeenCalledTimes(1);
       expect(props.removeHoverIndentGuideId).toHaveBeenCalledWith(parentSpanID);
     });
 
-    it('does not call props.removeHoverIndentGuideId on mouse leave if mouse leaves to a indentGuide with the same ancestorId', () => {
+    it.skip('does not call props.removeHoverIndentGuideId on mouse leave if mouse leaves to a indentGuide with the same ancestorId', () => {
+      render(<SpanTreeOffset {...props} />);
+      const span = document.querySelector(`[data-ancestor-id=${parentSpanID}]`);
       const relatedTarget = document.createElement('span');
       relatedTarget.dataset.ancestorId = parentSpanID;
+      fireEvent.mouseLeave(span, { relatedTarget });
       wrapper.find({ 'data-ancestor-id': parentSpanID }).simulate('mouseleave', {
         relatedTarget,
       });
@@ -113,39 +149,39 @@ describe('SpanTreeOffset', () => {
 
   describe('icon', () => {
     beforeEach(() => {
-      wrapper.setProps({ span: { ...props.span, hasChildren: true } });
+      props = { ...props, span: { ...props.span, hasChildren: true } };
     });
 
     it('does not render icon if props.span.hasChildren is false', () => {
-      wrapper.setProps({ span: { ...props.span, hasChildren: false } });
-      expect(wrapper.find(IoChevronRight).length).toBe(0);
-      expect(wrapper.find(IoIosArrowDown).length).toBe(0);
+      props.span.hasChildren = false;
+      render(<SpanTreeOffset {...props} />);
+      expect(screen.queryByTestId('icon-wrapper')).not.toBeInTheDocument();
     });
 
     it('does not render icon if props.span.hasChildren is true and showChildrenIcon is false', () => {
-      wrapper.setProps({ showChildrenIcon: false });
-      expect(wrapper.find(IoChevronRight).length).toBe(0);
-      expect(wrapper.find(IoIosArrowDown).length).toBe(0);
+      props.showChildrenIcon = false;
+      render(<SpanTreeOffset {...props} />);
+      expect(screen.queryByTestId('icon-wrapper')).not.toBeInTheDocument();
     });
 
-    it('renders IoChevronRight if props.span.hasChildren is true and props.childrenVisible is false', () => {
-      expect(wrapper.find(IoChevronRight).length).toBe(1);
-      expect(wrapper.find(IoIosArrowDown).length).toBe(0);
+    it('renders arrow-right if props.span.hasChildren is true and props.childrenVisible is false', () => {
+      render(<SpanTreeOffset {...props} />);
+      expect(screen.getByTestId('icon-arrow-right')).toBeInTheDocument();
     });
 
-    it('renders IoIosArrowDown if props.span.hasChildren is true and props.childrenVisible is true', () => {
-      wrapper.setProps({ childrenVisible: true });
-      expect(wrapper.find(IoChevronRight).length).toBe(0);
-      expect(wrapper.find(IoIosArrowDown).length).toBe(1);
+    it('renders arrow-down if props.span.hasChildren is true and props.childrenVisible is true', () => {
+      props.childrenVisible = true;
+      render(<SpanTreeOffset {...props} />);
+      expect(screen.getByTestId('icon-arrow-down')).toBeInTheDocument();
     });
 
-    it('calls props.addHoverIndentGuideId on mouse enter', () => {
+    it.skip('calls props.addHoverIndentGuideId on mouse enter', () => {
       wrapper.find('[data-testid="icon-wrapper"]').simulate('mouseenter', {});
       expect(props.addHoverIndentGuideId).toHaveBeenCalledTimes(1);
       expect(props.addHoverIndentGuideId).toHaveBeenCalledWith(ownSpanID);
     });
 
-    it('calls props.removeHoverIndentGuideId on mouse leave', () => {
+    it.skip('calls props.removeHoverIndentGuideId on mouse leave', () => {
       wrapper.find('[data-testid="icon-wrapper"]').simulate('mouseleave', {});
       expect(props.removeHoverIndentGuideId).toHaveBeenCalledTimes(1);
       expect(props.removeHoverIndentGuideId).toHaveBeenCalledWith(ownSpanID);

--- a/packages/jaeger-ui-components/src/TraceTimelineViewer/SpanTreeOffset.test.js
+++ b/packages/jaeger-ui-components/src/TraceTimelineViewer/SpanTreeOffset.test.js
@@ -12,12 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { render, screen, fireEvent, createEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { shallow } from 'enzyme';
 import React from 'react';
-import IoChevronRight from 'react-icons/lib/io/chevron-right';
-import IoIosArrowDown from 'react-icons/lib/io/ios-arrow-down';
 
 import { createTheme } from '@grafana/data';
 
@@ -33,17 +30,6 @@ describe('SpanTreeOffset', () => {
   const rootSpanID = 'rootSpanID';
   const specialRootID = 'root';
   let props;
-  // let wrapper;
-
-  const parentProps = {
-    addHoverIndentGuideId: jest.fn(),
-    hoverIndentGuideIds: new Set(),
-    removeHoverIndentGuideId: jest.fn(),
-    span: {
-      hasChildren: false,
-      spanID: parentSpanID,
-    },
-  };
 
   beforeEach(() => {
     // Mock implementation instead of Mock return value so that each call returns a new array (like normal)
@@ -60,7 +46,7 @@ describe('SpanTreeOffset', () => {
   });
 
   describe('.SpanTreeOffset--indentGuide', () => {
-    it('renders only one .SpanTreeOffset--indentGuide for entire trace if span has no ancestors', () => {
+    it('renders only one SpanTreeOffset--indentGuide for entire trace if span has no ancestors', () => {
       spanAncestorIdsSpy.mockReturnValue([]);
       render(<SpanTreeOffset {...props} />);
       const indentGuide = screen.getByTestId('SpanTreeOffset--indentGuide');
@@ -68,7 +54,7 @@ describe('SpanTreeOffset', () => {
       expect(indentGuide).toHaveAttribute('data-ancestor-id', specialRootID);
     });
 
-    it('renders one .SpanTreeOffset--indentGuide per ancestor span, plus one for entire trace', () => {
+    it('renders one SpanTreeOffset--indentGuide per ancestor span, plus one for entire trace', () => {
       render(<SpanTreeOffset {...props} />);
       const indentGuides = screen.getAllByTestId('SpanTreeOffset--indentGuide');
       expect(indentGuides.length).toBe(3);
@@ -86,64 +72,20 @@ describe('SpanTreeOffset', () => {
       expect(activeIndentGuide).toHaveAttribute('data-ancestor-id', parentSpanID);
     });
 
-    it.skip('calls props.addHoverIndentGuideId on mouse enter', async () => {
+    it('calls props.addHoverIndentGuideId on mouse enter', async () => {
       render(<SpanTreeOffset {...props} />);
       const span = document.querySelector(`[data-ancestor-id=${parentSpanID}]`);
-      // await userEvent.hover(span);
-      // const event = createEvent.mouseEnter(span, {
-      //   bubbles: false, cancelable: false, composed: true
-      // });
-      // const event = new MouseEvent('mouseenter', {
-      //   bubbles: false, cancelable: false, composed: true
-      // });
-      // fireEvent(span, event);
-      // fireEvent.mouseEnter(span);
       await userEvent.hover(span);
       expect(props.addHoverIndentGuideId).toHaveBeenCalledTimes(1);
       expect(props.addHoverIndentGuideId).toHaveBeenCalledWith(parentSpanID);
     });
 
-    it.skip('does not call props.addHoverIndentGuideId on mouse enter if mouse came from a indentGuide with the same ancestorId', () => {
-      render(
-        <>
-          <SpanTreeOffset {...parentProps} />
-          <SpanTreeOffset {...props} />
-        </>
-      );
-      const span = document.querySelector(`[data-ancestor-id=${parentSpanID}]`);
-      const relatedTarget = document.createElement('span');
-      relatedTarget.dataset.ancestorId = parentSpanID;
-      const event = new MouseEvent('mouseenter', {
-        bubbles: false,
-        cancelable: false,
-        composed: true,
-      });
-      event.relatedTarget = relatedTarget;
-      fireEvent(span, event);
-      // fireEvent.mouseEnter(span, {
-      //   relatedTarget,
-      // });
-      expect(props.addHoverIndentGuideId).not.toHaveBeenCalled();
-    });
-
-    it.skip('calls props.removeHoverIndentGuideId on mouse leave', async () => {
+    it('calls props.removeHoverIndentGuideId on mouse leave', async () => {
       render(<SpanTreeOffset {...props} />);
       const span = document.querySelector(`[data-ancestor-id=${parentSpanID}]`);
-      fireEvent.mouseLeave(span);
+      await userEvent.unhover(span);
       expect(props.removeHoverIndentGuideId).toHaveBeenCalledTimes(1);
       expect(props.removeHoverIndentGuideId).toHaveBeenCalledWith(parentSpanID);
-    });
-
-    it.skip('does not call props.removeHoverIndentGuideId on mouse leave if mouse leaves to a indentGuide with the same ancestorId', () => {
-      render(<SpanTreeOffset {...props} />);
-      const span = document.querySelector(`[data-ancestor-id=${parentSpanID}]`);
-      const relatedTarget = document.createElement('span');
-      relatedTarget.dataset.ancestorId = parentSpanID;
-      fireEvent.mouseLeave(span, { relatedTarget });
-      wrapper.find({ 'data-ancestor-id': parentSpanID }).simulate('mouseleave', {
-        relatedTarget,
-      });
-      expect(props.removeHoverIndentGuideId).not.toHaveBeenCalled();
     });
   });
 
@@ -175,14 +117,18 @@ describe('SpanTreeOffset', () => {
       expect(screen.getByTestId('icon-arrow-down')).toBeInTheDocument();
     });
 
-    it.skip('calls props.addHoverIndentGuideId on mouse enter', () => {
-      wrapper.find('[data-testid="icon-wrapper"]').simulate('mouseenter', {});
+    it('calls props.addHoverIndentGuideId on mouse enter', async () => {
+      render(<SpanTreeOffset {...props} />);
+      const icon = screen.getByTestId('icon-wrapper');
+      await userEvent.hover(icon);
       expect(props.addHoverIndentGuideId).toHaveBeenCalledTimes(1);
       expect(props.addHoverIndentGuideId).toHaveBeenCalledWith(ownSpanID);
     });
 
-    it.skip('calls props.removeHoverIndentGuideId on mouse leave', () => {
-      wrapper.find('[data-testid="icon-wrapper"]').simulate('mouseleave', {});
+    it('calls props.removeHoverIndentGuideId on mouse leave', async () => {
+      render(<SpanTreeOffset {...props} />);
+      const icon = screen.getByTestId('icon-wrapper');
+      await userEvent.unhover(icon);
       expect(props.removeHoverIndentGuideId).toHaveBeenCalledTimes(1);
       expect(props.removeHoverIndentGuideId).toHaveBeenCalledWith(ownSpanID);
     });

--- a/packages/jaeger-ui-components/src/TraceTimelineViewer/SpanTreeOffset.tsx
+++ b/packages/jaeger-ui-components/src/TraceTimelineViewer/SpanTreeOffset.tsx
@@ -138,7 +138,14 @@ export class UnthemedSpanTreeOffset extends React.PureComponent<TProps> {
     const { childrenVisible, onClick, showChildrenIcon, span, theme } = this.props;
     const { hasChildren, spanID } = span;
     const wrapperProps = hasChildren ? { onClick, role: 'switch', 'aria-checked': childrenVisible } : null;
-    const icon = showChildrenIcon && hasChildren && (childrenVisible ? <IoIosArrowDown /> : <IoChevronRight />);
+    const icon =
+      showChildrenIcon &&
+      hasChildren &&
+      (childrenVisible ? (
+        <IoIosArrowDown data-testid="icon-arrow-down" />
+      ) : (
+        <IoChevronRight data-testid="icon-arrow-right" />
+      ));
     const styles = getStyles(theme);
     return (
       <span className={cx(styles.SpanTreeOffset, { [styles.SpanTreeOffsetParent]: hasChildren })} {...wrapperProps}>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/56178

**Special notes for your reviewer**:
i can't get `does not call props.addHoverIndentGuideId on mouse enter if mouse came from a indentGuide with the same ancestorId` to work no matter what i try with `userEvent`/`fireEvent`... anything really 🤯 if anyone can get it to work i will be eternally grateful 🙏 
