### PR TITLE
Explore: Logs volume histogram: always start Y axis from zero

### DIFF
--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -244,6 +244,7 @@ export class Explore extends React.PureComponent<Props, ExploreState> {
           annotations={queryResponse.annotations}
           splitOpenFn={splitOpen}
           loadingState={queryResponse.state}
+          anchorToZero={false}
         />
       </Collapse>
     );

--- a/public/app/features/explore/ExploreGraph.tsx
+++ b/public/app/features/explore/ExploreGraph.tsx
@@ -53,6 +53,7 @@ interface Props {
   splitOpenFn?: SplitOpen;
   onChangeTime: (timeRange: AbsoluteTimeRange) => void;
   graphStyle: ExploreGraphStyle;
+  anchorToZero: boolean;
 }
 
 export function ExploreGraph({
@@ -68,6 +69,7 @@ export function ExploreGraph({
   splitOpenFn,
   graphStyle,
   tooltipDisplayMode = TooltipDisplayMode.Single,
+  anchorToZero,
 }: Props) {
   const theme = useTheme2();
   const [showAllTimeSeries, setShowAllTimeSeries] = useState(false);
@@ -80,6 +82,7 @@ export function ExploreGraph({
 
   const [fieldConfig, setFieldConfig] = useState<FieldConfigSource>({
     defaults: {
+      min: anchorToZero ? 0 : undefined,
       color: {
         mode: FieldColorModeId.PaletteClassic,
       },

--- a/public/app/features/explore/LogsVolumePanel.tsx
+++ b/public/app/features/explore/LogsVolumePanel.tsx
@@ -130,6 +130,7 @@ export function LogsVolumePanel(props: Props) {
           splitOpenFn={splitOpen}
           tooltipDisplayMode={TooltipDisplayMode.Multi}
           onHiddenSeriesChanged={onHiddenSeriesChanged}
+          anchorToZero
         />
       );
     } else {


### PR DESCRIPTION
fixes https://github.com/grafana/grafana/issues/56159

currently, when the Logs volume histogram is shown, in some situations the Y-axis does not start at zero.

after looking at multiple situations,we decided that anchoring it to zero is the right way to go.

(we are using the same `<ExploreGraph/>` component that the rest of explore-mode is using, and in the non-logs-volume situations we do not want to anchor the Y-axis to zero, so i had to introduce a new prop to make this configurable)


how to test:

1. run a logs-producing datasource, go to explore, run a query that produces the histogram
2. start zooming in into the histogram, to a point where there is a single "bar" displayed only
3. the Y-axis should still start at `0`. (in main-branch this is the point where it does not start at `0`)