### PR TITLE
Prometheus: (WIP) Stub for version detection BE resource

### DIFF
--- a/pkg/tsdb/prometheus/prometheus.go
+++ b/pkg/tsdb/prometheus/prometheus.go
@@ -6,7 +6,9 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 	"sync"
+	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/datasource"
@@ -19,6 +21,7 @@ import (
 	"github.com/grafana/grafana/pkg/tsdb/prometheus/buffered"
 	"github.com/grafana/grafana/pkg/tsdb/prometheus/querydata"
 	"github.com/grafana/grafana/pkg/tsdb/prometheus/resource"
+	"github.com/patrickmn/go-cache"
 	apiv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/yudai/gojsondiff"
 	"github.com/yudai/gojsondiff/formatter"
@@ -32,9 +35,10 @@ type Service struct {
 }
 
 type instance struct {
-	buffered  *buffered.Buffered
-	queryData *querydata.QueryData
-	resource  *resource.Resource
+	buffered     *buffered.Buffered
+	queryData    *querydata.QueryData
+	resource     *resource.Resource
+	versionCache *cache.Cache
 }
 
 func ProvideService(httpClientProvider httpclient.Provider, cfg *setting.Cfg, features featuremgmt.FeatureToggles, tracer tracing.Tracer) *Service {
@@ -75,9 +79,10 @@ func newInstanceSettings(httpClientProvider httpclient.Provider, cfg *setting.Cf
 		}
 
 		return instance{
-			buffered:  b,
-			queryData: qd,
-			resource:  r,
+			buffered:     b,
+			queryData:    qd,
+			resource:     r,
+			versionCache: cache.New(time.Minute*1, time.Minute*5),
 		}, nil
 	}
 }
@@ -133,6 +138,20 @@ func (s *Service) CallResource(ctx context.Context, req *backend.CallResourceReq
 	i, err := s.getInstance(req.PluginContext)
 	if err != nil {
 		return err
+	}
+
+	if strings.EqualFold(req.Path, "version-detect") {
+		versionObj, found := i.versionCache.Get("version")
+		if found {
+			return sender.Send(versionObj.(*backend.CallResourceResponse))
+		}
+
+		vResp, err := i.resource.DetectVersion(ctx, req)
+		if err != nil {
+			return err
+		}
+		i.versionCache.Set("version", vResp, cache.DefaultExpiration)
+		return sender.Send(vResp)
 	}
 
 	resp, err := i.resource.Execute(ctx, req)

--- a/pkg/tsdb/prometheus/resource/resource.go
+++ b/pkg/tsdb/prometheus/resource/resource.go
@@ -98,3 +98,22 @@ func (r *Resource) Execute(ctx context.Context, req *backend.CallResourceRequest
 
 	return callResponse, err
 }
+
+func (r *Resource) DetectVersion(ctx context.Context, req *backend.CallResourceRequest) (*backend.CallResourceResponse, error) {
+	newReq := &backend.CallResourceRequest{
+		PluginContext: req.PluginContext,
+		Path:          "/api/v1/status/buildinfo",
+	}
+
+	resp, err := r.Execute(ctx, newReq)
+	if err != nil {
+		return nil, err
+	}
+
+	callResponse := &backend.CallResourceResponse{
+		Status: 200,
+		Body:   resp.Body,
+	}
+
+	return callResponse, nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Stubbing out cached Resource endpoint in prometheus datasource to eventually hold version detection.


**Special notes for your reviewer**:
e.g. http://localhost:3000/api/datasources/uid/gdev-prometheus/resources/version-detect currently just passes through response from buildinfo
