### PR TITLE
(WIP) allow the user to edit invalid AM configuration

### DIFF
--- a/pkg/services/ngalert/api/api_alertmanager.go
+++ b/pkg/services/ngalert/api/api_alertmanager.go
@@ -128,6 +128,14 @@ func (srv AlertmanagerSrv) RouteGetAlertingConfig(c *models.ReqContext) response
 	return response.JSON(http.StatusOK, config)
 }
 
+func (srv AlertmanagerSrv) RouteGetRawAlertmanagerConfig(c *models.ReqContext) response.Response {
+	rawConfig, err := srv.mam.GetRawAlertmanagerConfiguration(c.Req.Context(), c.OrgID)
+	if err != nil {
+		return ErrResp(http.StatusNotFound, err, "")
+	}
+	return response.JSON(http.StatusOK, rawConfig)
+}
+
 func (srv AlertmanagerSrv) RouteGetAMAlertGroups(c *models.ReqContext) response.Response {
 	am, errResp := srv.AlertmanagerFor(c.OrgID)
 	if errResp != nil {

--- a/pkg/services/ngalert/api/authorization.go
+++ b/pkg/services/ngalert/api/authorization.go
@@ -151,6 +151,9 @@ func (api *API) authorize(method, path string) web.Handler {
 	case http.MethodGet + "/api/alertmanager/grafana/config/api/v1/alerts":
 		fallback = middleware.ReqEditorRole
 		eval = ac.EvalPermission(ac.ActionAlertingNotificationsRead)
+	case http.MethodGet + "/api/alertmanager/grafana/config/api/v1/raw":
+		fallback = middleware.ReqEditorRole
+		eval = ac.EvalPermission(ac.ActionAlertingNotificationsRead)
 	case http.MethodGet + "/api/alertmanager/grafana/api/v2/status":
 		eval = ac.EvalPermission(ac.ActionAlertingNotificationsRead)
 	case http.MethodPost + "/api/alertmanager/grafana/config/api/v1/alerts":

--- a/pkg/services/ngalert/api/forking_alertmanager.go
+++ b/pkg/services/ngalert/api/forking_alertmanager.go
@@ -168,6 +168,10 @@ func (f *AlertmanagerApiHandler) handleRouteGetGrafanaAlertingConfig(ctx *models
 	return f.GrafanaSvc.RouteGetAlertingConfig(ctx)
 }
 
+func (f *AlertmanagerApiHandler) handleRouteGetGrafanaRawAlertmanagerConfig(ctx *models.ReqContext) response.Response {
+	return f.GrafanaSvc.RouteGetRawAlertmanagerConfig(ctx)
+}
+
 func (f *AlertmanagerApiHandler) handleRouteGetGrafanaSilence(ctx *models.ReqContext, id string) response.Response {
 	return f.GrafanaSvc.RouteGetSilence(ctx, id)
 }

--- a/pkg/services/ngalert/api/generated_base_api_alertmanager.go
+++ b/pkg/services/ngalert/api/generated_base_api_alertmanager.go
@@ -33,6 +33,7 @@ type AlertmanagerApi interface {
 	RouteGetGrafanaAMAlerts(*models.ReqContext) response.Response
 	RouteGetGrafanaAMStatus(*models.ReqContext) response.Response
 	RouteGetGrafanaAlertingConfig(*models.ReqContext) response.Response
+	RouteGetGrafanaRawAlertmanagerConfig(*models.ReqContext) response.Response
 	RouteGetGrafanaReceivers(*models.ReqContext) response.Response
 	RouteGetGrafanaSilence(*models.ReqContext) response.Response
 	RouteGetGrafanaSilences(*models.ReqContext) response.Response
@@ -114,6 +115,9 @@ func (f *AlertmanagerApiHandler) RouteGetGrafanaAMStatus(ctx *models.ReqContext)
 }
 func (f *AlertmanagerApiHandler) RouteGetGrafanaAlertingConfig(ctx *models.ReqContext) response.Response {
 	return f.handleRouteGetGrafanaAlertingConfig(ctx)
+}
+func (f *AlertmanagerApiHandler) RouteGetGrafanaRawAlertmanagerConfig(ctx *models.ReqContext) response.Response {
+	return f.handleRouteGetGrafanaRawAlertmanagerConfig(ctx)
 }
 func (f *AlertmanagerApiHandler) RouteGetGrafanaReceivers(ctx *models.ReqContext) response.Response {
 	return f.handleRouteGetGrafanaReceivers(ctx)
@@ -331,6 +335,16 @@ func (api *API) RegisterAlertmanagerApiEndpoints(srv AlertmanagerApi, m *metrics
 				http.MethodGet,
 				"/api/alertmanager/grafana/config/api/v1/alerts",
 				srv.RouteGetGrafanaAlertingConfig,
+				m,
+			),
+		)
+		group.Get(
+			toMacaronPath("/api/alertmanager/grafana/config/api/v1/raw"),
+			api.authorize(http.MethodGet, "/api/alertmanager/grafana/config/api/v1/raw"),
+			metrics.Instrument(
+				http.MethodGet,
+				"/api/alertmanager/grafana/config/api/v1/raw",
+				srv.RouteGetGrafanaRawAlertmanagerConfig,
 				m,
 			),
 		)

--- a/pkg/services/ngalert/api/tooling/api.json
+++ b/pkg/services/ngalert/api/tooling/api.json
@@ -1060,6 +1060,14 @@
    },
    "type": "object"
   },
+  "GettableRawAlertmanagerConfig": {
+   "properties": {
+    "raw_alertmanager_config": {
+     "type": "string"
+    }
+   },
+   "type": "object"
+  },
   "GettableRuleGroupConfig": {
    "properties": {
     "interval": {
@@ -3293,7 +3301,6 @@
    "type": "object"
   },
   "alertGroups": {
-   "description": "AlertGroups alert groups",
    "items": {
     "$ref": "#/definitions/alertGroup"
    },
@@ -3398,7 +3405,6 @@
    "type": "object"
   },
   "gettableAlert": {
-   "description": "GettableAlert gettable alert",
    "properties": {
     "annotations": {
      "$ref": "#/definitions/labelSet"
@@ -3510,13 +3516,13 @@
    "type": "object"
   },
   "gettableSilences": {
-   "description": "GettableSilences gettable silences",
    "items": {
     "$ref": "#/definitions/gettableSilence"
    },
    "type": "array"
   },
   "integration": {
+   "description": "Integration integration",
    "properties": {
     "lastNotifyAttempt": {
      "description": "A timestamp indicating the last attempt to deliver a notification regardless of the outcome.\nFormat: date-time",
@@ -3689,6 +3695,7 @@
    "type": "object"
   },
   "receiver": {
+   "description": "Receiver receiver",
    "properties": {
     "active": {
      "description": "active",

--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
@@ -48,6 +48,14 @@ import (
 //       200: GettableUserConfig
 //       400: ValidationError
 
+// swagger:route GET /api/alertmanager/grafana/config/api/v1/raw alertmanager RouteGetGrafanaRawAlertmanagerConfig
+//
+// gets the alertmanager config as plain text
+//
+//     Responses:
+//       200: GettableRawAlertmanagerConfig
+//       404: NotFound
+
 // swagger:route GET /api/alertmanager/{DatasourceUID}/config/api/v1/alerts alertmanager RouteGetAlertingConfig
 //
 // gets an Alerting config
@@ -591,6 +599,11 @@ type GettableUserConfig struct {
 	// This enables circumventing the underlying alertmanager secret type
 	// which redacts itself during encoding.
 	amSimple map[string]interface{} `yaml:"-" json:"-"`
+}
+
+// swagger:model
+type GettableRawAlertmanagerConfig struct {
+	RawAlertmanagerConfig string `yaml:"raw_alertmanager_config" json:"raw_alertmanager_config"`
 }
 
 func (c *GettableUserConfig) UnmarshalYAML(value *yaml.Node) error {

--- a/pkg/services/ngalert/api/tooling/post.json
+++ b/pkg/services/ngalert/api/tooling/post.json
@@ -1060,6 +1060,14 @@
    },
    "type": "object"
   },
+  "GettableRawAlertmanagerConfig": {
+   "properties": {
+    "raw_alertmanager_config": {
+     "type": "string"
+    }
+   },
+   "type": "object"
+  },
   "GettableRuleGroupConfig": {
    "properties": {
     "interval": {
@@ -3078,7 +3086,6 @@
    "type": "object"
   },
   "URL": {
-   "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use RawPath, an optional field which only gets\nset if the default encoding is different from Path.\n\nURL's String method uses the EscapedPath method to obtain the path. See the\nEscapedPath method for more details.",
    "properties": {
     "ForceQuery": {
      "type": "boolean"
@@ -3114,7 +3121,7 @@
      "$ref": "#/definitions/Userinfo"
     }
    },
-   "title": "A URL represents a parsed URL (technically, a URI reference).",
+   "title": "URL is a custom URL type that allows validation at configuration load time.",
    "type": "object"
   },
   "Userinfo": {
@@ -3513,7 +3520,6 @@
    "type": "array"
   },
   "integration": {
-   "description": "Integration integration",
    "properties": {
     "lastNotifyAttempt": {
      "description": "A timestamp indicating the last attempt to deliver a notification regardless of the outcome.\nFormat: date-time",
@@ -4172,6 +4178,29 @@
       "description": "ValidationError",
       "schema": {
        "$ref": "#/definitions/ValidationError"
+      }
+     }
+    },
+    "tags": [
+     "alertmanager"
+    ]
+   }
+  },
+  "/api/alertmanager/grafana/config/api/v1/raw": {
+   "get": {
+    "description": "gets the alertmanager config as plain text",
+    "operationId": "RouteGetGrafanaRawAlertmanagerConfig",
+    "responses": {
+     "200": {
+      "description": "GettableRawAlertmanagerConfig",
+      "schema": {
+       "$ref": "#/definitions/GettableRawAlertmanagerConfig"
+      }
+     },
+     "404": {
+      "description": "NotFound",
+      "schema": {
+       "$ref": "#/definitions/NotFound"
       }
      }
     },

--- a/pkg/services/ngalert/api/tooling/spec.json
+++ b/pkg/services/ngalert/api/tooling/spec.json
@@ -392,6 +392,29 @@
         }
       }
     },
+    "/api/alertmanager/grafana/config/api/v1/raw": {
+      "get": {
+        "description": "gets the alertmanager config as plain text",
+        "tags": [
+          "alertmanager"
+        ],
+        "operationId": "RouteGetGrafanaRawAlertmanagerConfig",
+        "responses": {
+          "200": {
+            "description": "GettableRawAlertmanagerConfig",
+            "schema": {
+              "$ref": "#/definitions/GettableRawAlertmanagerConfig"
+            }
+          },
+          "404": {
+            "description": "NotFound",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        }
+      }
+    },
     "/api/alertmanager/grafana/config/api/v1/receivers": {
       "get": {
         "tags": [
@@ -3598,6 +3621,14 @@
         }
       }
     },
+    "GettableRawAlertmanagerConfig": {
+      "type": "object",
+      "properties": {
+        "raw_alertmanager_config": {
+          "type": "string"
+        }
+      }
+    },
     "GettableRuleGroupConfig": {
       "type": "object",
       "properties": {
@@ -5617,9 +5648,8 @@
       }
     },
     "URL": {
-      "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use RawPath, an optional field which only gets\nset if the default encoding is different from Path.\n\nURL's String method uses the EscapedPath method to obtain the path. See the\nEscapedPath method for more details.",
       "type": "object",
-      "title": "A URL represents a parsed URL (technically, a URI reference).",
+      "title": "URL is a custom URL type that allows validation at configuration load time.",
       "properties": {
         "ForceQuery": {
           "type": "boolean"
@@ -6058,7 +6088,6 @@
       "$ref": "#/definitions/gettableSilences"
     },
     "integration": {
-      "description": "Integration integration",
       "type": "object",
       "required": [
         "name",

--- a/pkg/services/ngalert/notifier/alertmanager_config.go
+++ b/pkg/services/ngalert/notifier/alertmanager_config.go
@@ -89,6 +89,17 @@ func (moa *MultiOrgAlertmanager) GetAlertmanagerConfiguration(ctx context.Contex
 	return result, nil
 }
 
+func (moa *MultiOrgAlertmanager) GetRawAlertmanagerConfiguration(ctx context.Context, org int64) (definitions.GettableRawAlertmanagerConfig, error) {
+	query := models.GetLatestAlertmanagerConfigurationQuery{OrgID: org}
+	err := moa.configStore.GetLatestAlertmanagerConfiguration(ctx, &query)
+	if err != nil {
+		return definitions.GettableRawAlertmanagerConfig{}, fmt.Errorf("failed to get latest configuration: %w", err)
+	}
+	return definitions.GettableRawAlertmanagerConfig{
+		RawAlertmanagerConfig: query.Result.AlertmanagerConfiguration,
+	}, nil
+}
+
 func (moa *MultiOrgAlertmanager) ApplyAlertmanagerConfiguration(ctx context.Context, org int64, config definitions.PostableUserConfig) error {
 	// Get the last known working configuration
 	query := models.GetLatestAlertmanagerConfigurationQuery{OrgID: org}

--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -5,6 +5,7 @@ import { locationService, logInfo } from '@grafana/runtime';
 import {
   AlertmanagerAlert,
   AlertManagerCortexConfig,
+  RawAlertmanagerConfig,
   AlertmanagerGroup,
   ExternalAlertmanagerConfig,
   ExternalAlertmanagersResponse,
@@ -45,6 +46,7 @@ import {
   fetchExternalAlertmanagers,
   fetchSilences,
   fetchStatus,
+  fetchRawAlertmanagerConfig,
   testReceivers,
   updateAlertManagerConfig,
 } from '../api/alertmanager';
@@ -165,6 +167,13 @@ export const fetchAlertManagerConfigAction = createAsyncThunk(
           });
       })()
     )
+);
+
+export const fetchRawAlertmanagerConfigAction = createAsyncThunk(
+  'unifiedAlerting/fetchRawAmConfig',
+  (alertManagerSourceName: string): Promise<RawAlertmanagerConfig> => {
+    return withSerializedError(fetchRawAlertmanagerConfig(alertManagerSourceName));
+  }
 );
 
 export const fetchExternalAlertmanagersAction = createAsyncThunk(

--- a/public/app/features/alerting/unified/state/reducers.ts
+++ b/public/app/features/alerting/unified/state/reducers.ts
@@ -15,6 +15,7 @@ import {
   fetchGrafanaAnnotationsAction,
   fetchGrafanaNotifiersAction,
   fetchPromRulesAction,
+  fetchRawAlertmanagerConfigAction,
   fetchRulerRulesAction,
   fetchRulesSourceBuildInfoAction,
   fetchSilencesAction,
@@ -36,6 +37,11 @@ export const reducer = combineReducers({
   amConfigs: createAsyncMapSlice(
     'amConfigs',
     fetchAlertManagerConfigAction,
+    (alertManagerSourceName) => alertManagerSourceName
+  ).reducer,
+  rawAlertmanagerConfig: createAsyncMapSlice(
+    'rawAlertmanagerConfig',
+    fetchRawAlertmanagerConfigAction,
     (alertManagerSourceName) => alertManagerSourceName
   ).reducer,
   silences: createAsyncMapSlice('silences', fetchSilencesAction, (alertManagerSourceName) => alertManagerSourceName)

--- a/public/app/plugins/datasource/alertmanager/types.ts
+++ b/public/app/plugins/datasource/alertmanager/types.ts
@@ -152,6 +152,10 @@ export type AlertmanagerConfig = {
   muteTimeProvenances?: Record<string, string>;
 };
 
+export type RawAlertmanagerConfig = {
+  raw_alertmanager_config: string;
+};
+
 export type Matcher = {
   name: string;
   value: string;


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR addresses the need to modify a currently invalid Alertmanager configuration. It adds a new endpoint that returns the AM configuration as a string without any pre-processing or attempts to marshal it into a valid config object.

Instead of just returning a `500` error hoping that the user has access to their database and is able to modify their AM configuration there, the front end sends a `GET` request to fetch the raw configuration in case of failure. The user is then able to use the UI editor to fix their config and save it (or simply resetting it to the default config).

<details>
<summary>Example</summary>
<br>

![Screen Shot 2022-10-03 at 20 30 43](https://user-images.githubusercontent.com/41638679/193704470-bafacd8e-a3ee-4a60-8fdb-f5a9548c39f6.png)

</details>


<details>
<summary>A more realistic example (reference to an undefined receiver)</summary>
<br>

![Screen Shot 2022-10-03 at 20 46 36](https://user-images.githubusercontent.com/41638679/193705322-2273c896-821c-4813-8bef-4be6e79949de.png)

</details>

**Which issue(s) this PR fixes**:

https://github.com/grafana/grafana/issues/54505

**Special notes for your reviewer**:

Even though recently added safeguards make it more difficult to end up with a corrupted state for the AM config, it's impossible to be 100% sure that this won't happen anymore.

Solutions like letting the user choose from a list of their previously saved configurations for the Alertmanager could be implemented in addition to this.