### PR TITLE
[v9.1.x] TimeSeries: clamp log-y-axis min to 1 when decimals=0 (#55882)

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/config/UPlotScaleBuilder.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotScaleBuilder.ts
@@ -91,6 +91,8 @@ export class UPlotScaleBuilder extends PlotConfigBuilder<ScaleProps, Scale> {
         return minMax;
       }
 
+      let logBase = scale.log ?? 10;
+
       if (scale.distr === 1 || scale.distr === 2) {
         if (centeredZero) {
           let absMin = Math.abs(dataMin!);
@@ -103,12 +105,36 @@ export class UPlotScaleBuilder extends PlotConfigBuilder<ScaleProps, Scale> {
         // @ts-ignore here we may use hardMin / hardMax to make sure any extra padding is computed from a more accurate delta
         minMax = uPlot.rangeNum(hardMinOnly ? hardMin : dataMin, hardMaxOnly ? hardMax : dataMax, rangeConfig);
       } else if (scale.distr === 3) {
-        minMax = uPlot.rangeLog(dataMin!, dataMax!, scale.log ?? 10, true);
+        minMax = uPlot.rangeLog(dataMin!, dataMax!, logBase, true);
       }
 
       if (decimals === 0) {
-        minMax[0] = incrRoundDn(minMax[0]!, 1);
-        minMax[1] = incrRoundUp(minMax[1]!, 1);
+        if (scale.distr === 1 || scale.distr === 2) {
+          minMax[0] = incrRoundDn(minMax[0]!, 1);
+          minMax[1] = incrRoundUp(minMax[1]!, 1);
+        }
+        // log2 or log10 scale min must be clamped to 1
+        else if (scale.distr === 3) {
+          let logFn = scale.log === 2 ? Math.log2 : Math.log10;
+
+          if (minMax[0]! <= 1) {
+            // clamp min
+            minMax[0] = 1;
+          } else {
+            // snap min to nearest mag below
+            let minExp = Math.floor(logFn(minMax[0]!));
+            minMax[0] = logBase ** minExp;
+          }
+
+          // snap max to nearest mag above
+          let maxExp = Math.ceil(logFn(minMax[1]!));
+          minMax[1] = logBase ** maxExp;
+
+          // inflate max by mag if same
+          if (minMax[0] === minMax[1]) {
+            minMax[1] *= logBase;
+          }
+        }
       }
 
       // if all we got were hard limits, treat them as static min/max
@@ -122,7 +148,7 @@ export class UPlotScaleBuilder extends PlotConfigBuilder<ScaleProps, Scale> {
 
       // guard against invalid y ranges
       if (minMax[0]! >= minMax[1]!) {
-        minMax[0] = 0;
+        minMax[0] = scale.distr === 3 ? 1 : 0;
         minMax[1] = 100;
       }
 


### PR DESCRIPTION
Backport https://github.com/grafana/grafana/pull/55882 to v9.1.x

(cherry picked from commit 4ff791703937b773546e8b18dc606cff36716120)