### PR TITLE
Docs: rectify incorrect alert provisioning API hyperlink being used in the alerting provisioning Docs

### DIFF
--- a/docs/sources/alerting/set-up/provision-alerting-resources/file-provisioning/index.md
+++ b/docs/sources/alerting/set-up/provision-alerting-resources/file-provisioning/index.md
@@ -30,7 +30,7 @@ Provisioning takes place during the initial set up of your Grafana system, but y
 Create or delete alert rules in your Grafana instance(s).
 
 1. Create an alert rule in Grafana.
-1. Use the [Alerting provisioning API](https://grafana.com/docs/grafana/latest/developers/http_api/admin/#reload-provisioning-configurations) to extract the alert rule.
+1. Use the [Alerting provisioning API](https://grafana.com/docs/grafana/latest/developers/http_api/alerting/#get-alerts) to extract the alert rule.
 1. Copy the contents into a YAML or JSON configuration file.
 
    Example configuration files can be found below.


### PR DESCRIPTION
Hi,

this is to rectify incorrect hyperlinks for alerting http_api used.  The current hyperlink used is of admin API. however, it has to be alerting API

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**: rectify incorrect alert provisioning API hyperlink being used in the alerting provisioning Docs

**Which issue(s) this PR fixes**:  incorrect alert provisioning API hyperlink being used in the alerting provisioning Docs

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

