### PR TITLE
CI: Fix `update-changelog.yml` version input

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -35,9 +35,9 @@ jobs:
           token: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
           metricsWriteAPIKey: ${{ secrets.GRAFANA_MISC_STATS_API_KEY }}
       - name: Run update changelog (workflow invoked)
-        if: ${{ inputs.version_call != '' }}
+        if: ${{ inputs.version != '' }}
         uses: ./actions/update-changelog
         with:
-          version_call: ${{ inputs.version_call }}
+          version_call: ${{ inputs.version }}
           token: ${{ secrets.token }}
           metricsWriteAPIKey: ${{ secrets.metricsWriteAPIKey }}


### PR DESCRIPTION
**What this PR does / why we need it**:

After https://github.com/grafana/grafana/pull/55893, some tweaks were needed in the `update-changelog.yml` file, regarding the version input.