### PR TITLE
Alert: Remove flex grow from alert

### DIFF
--- a/packages/grafana-ui/src/components/Alert/Alert.tsx
+++ b/packages/grafana-ui/src/components/Alert/Alert.tsx
@@ -110,7 +110,6 @@ const getStyles = (
 
   return {
     alert: css`
-      flex-grow: 1;
       position: relative;
       border-radius: ${borderRadius};
       display: flex;

--- a/public/app/core/components/PageNew/Page.tsx
+++ b/public/app/core/components/PageNew/Page.tsx
@@ -65,7 +65,7 @@ export const Page: PageType = ({
       )}
       {layout === PageLayoutType.Canvas && (
         <CustomScrollbar autoHeightMin={'100%'} scrollTop={scrollTop} scrollRefCallback={scrollRef}>
-          <div className={styles.dashboardContent}>
+          <div className={styles.canvasContent}>
             {toolbar}
             {children}
           </div>
@@ -94,14 +94,16 @@ const getStyles = (theme: GrafanaTheme2) => {
     : '0 0.6px 1.5px -1px rgb(0 0 0 / 8%),0 2px 4px rgb(0 0 0 / 6%),0 5px 10px -1px rgb(0 0 0 / 5%)';
 
   return {
-    wrapper: css`
-      height: 100%;
-      display: flex;
-      flex: 1 1 0;
-      flex-direction: column;
-      min-height: 0;
-    `,
+    wrapper: css({
+      label: 'page-wrapper',
+      height: '100%',
+      display: 'flex',
+      flex: '1 1 0',
+      flexDirection: 'column',
+      minHeight: 0,
+    }),
     panes: css({
+      label: 'page-panes',
       display: 'flex',
       height: '100%',
       width: '100%',
@@ -113,9 +115,11 @@ const getStyles = (theme: GrafanaTheme2) => {
       },
     }),
     pageContent: css({
+      label: 'page-content',
       flexGrow: 1,
     }),
     pageInner: css({
+      label: 'page-inner',
       padding: theme.spacing(3),
       boxShadow: shadow,
       background: theme.colors.background.primary,
@@ -124,7 +128,8 @@ const getStyles = (theme: GrafanaTheme2) => {
       flexDirection: 'column',
       flexGrow: 1,
     }),
-    dashboardContent: css({
+    canvasContent: css({
+      label: 'canvas-content',
       display: 'flex',
       flexDirection: 'column',
       padding: theme.spacing(2),


### PR DESCRIPTION
The Alert component is sometimes a direct child of Page component and the flex-grow set on the Alert is making it take up all available space on the page.

Not sure an Alert box should by default grow and take all space. I guess it makes some sense if it's in a flex direction row container. Hmm....

![Screenshot from 2022-10-04 09-18-44](https://user-images.githubusercontent.com/10999/193758298-1f3097dc-3bf7-489c-8707-030c29355856.png)

It looks like it breaks the app alerts, which are no longer same width. That is the only Alert that I have seen affected by this change in core but there are probably more and in plugins that could be affected by this css change. 

