### PR TITLE
cloudwatch-logs: use not-deprecated version of type

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchLogsQueryRunner.ts
+++ b/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchLogsQueryRunner.ts
@@ -30,10 +30,10 @@ import {
   ScopedVars,
 } from '@grafana/data';
 import { BackendDataSourceResponse, config, FetchError, FetchResponse, toDataQueryResponse } from '@grafana/runtime';
-import { RowContextOptions } from '@grafana/ui/src/components/Logs/LogRowContextProvider';
 import { TimeSrv } from 'app/features/dashboard/services/TimeSrv';
 import { TemplateSrv } from 'app/features/templating/template_srv';
 
+import { RowContextOptions } from '../../../../features/logs/components/LogRowContextProvider';
 import {
   CloudWatchJsonData,
   CloudWatchLogsQuery,


### PR DESCRIPTION
we are slowly moving certain logs-related things from `grafana-ui` and `grafana-data` back to the main grafana repo (and by "slowly moving" i mean we copy them over, and mark the original as deprecated, will be removed in grafana10). (see https://github.com/grafana/grafana/pull/55041)

this pull-request updates the cloudwatch-logs code to import a type from the new place.