### PR TITLE
GrafanaData: Deprecate the LogsParser type

### DIFF
--- a/packages/grafana-data/src/types/logs.ts
+++ b/packages/grafana-data/src/types/logs.ts
@@ -110,6 +110,7 @@ export enum LogsDedupStrategy {
   signature = 'signature',
 }
 
+/** @deprecated will be removed in the next major version */
 export interface LogsParser {
   /**
    * Value-agnostic matcher for a field label.

--- a/public/app/features/logs/utils.ts
+++ b/public/app/features/logs/utils.ts
@@ -7,7 +7,6 @@ import {
   LogLevel,
   LogRowModel,
   LogLabelStatsModel,
-  LogsParser,
   LogsModel,
   LogsSortOrder,
 } from '@grafana/data';
@@ -74,6 +73,34 @@ export function addLogLevelToSeries(series: DataFrame, lineIndex: number): DataF
       },
     ],
   };
+}
+
+interface LogsParser {
+  /**
+   * Value-agnostic matcher for a field label.
+   * Used to filter rows, and first capture group contains the value.
+   */
+  buildMatcher: (label: string) => RegExp;
+
+  /**
+   * Returns all parsable substrings from a line, used for highlighting
+   */
+  getFields: (line: string) => string[];
+
+  /**
+   * Gets the label name from a parsable substring of a line
+   */
+  getLabelFromField: (field: string) => string;
+
+  /**
+   * Gets the label value from a parsable substring of a line
+   */
+  getValueFromField: (field: string) => string;
+  /**
+   * Function to verify if this is a valid parser for the given line.
+   * The parser accepts the line if it returns true.
+   */
+  test: (line: string) => boolean;
 }
 
 export const LogsParsers: { [name: string]: LogsParser } = {


### PR DESCRIPTION
we are moving the `LogsParser` type from `grafana-data` to the main grafana package, to make maintenance easier on it, also it does not fit that well in `grafana-data` . to keep backward compatibility, we copy it to main grafana package, and mark it as deprecated in `grafana-data`, and we can delete it in grafana10.


# Deprecation notice

The interface type `LogsParser` in `grafana-data` is deprecated.