### PR TITLE
Cloud Monitoring: Fix missing data when result is paginated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,3 +182,4 @@ public/locales/**/*.js
 deployment_tools_config.json
 
 .betterer.cache
+conf/provisioning/datasources/stackdriver.yml

--- a/.gitignore
+++ b/.gitignore
@@ -182,4 +182,3 @@ public/locales/**/*.js
 deployment_tools_config.json
 
 .betterer.cache
-conf/provisioning/datasources/stackdriver.yml

--- a/pkg/tsdb/cloudmonitoring/time_series_filter.go
+++ b/pkg/tsdb/cloudmonitoring/time_series_filter.go
@@ -40,7 +40,6 @@ func (timeSeriesFilter *cloudMonitoringTimeSeriesFilter) run(ctx context.Context
 	d := cloudMonitoringResponse{}
 
 	for first || d.NextPageToken != "" {
-		timeSeriesFilter.Params["pageSize"] = []string{"5000"}
 		if (d.NextPageToken != "") {
 			timeSeriesFilter.Params["pageToken"] = []string{d.NextPageToken}
 		} 

--- a/pkg/tsdb/cloudmonitoring/time_series_filter.go
+++ b/pkg/tsdb/cloudmonitoring/time_series_filter.go
@@ -18,7 +18,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/tracing"
 )
 
-func doRequestPage(r *http.Request, dsInfo datasourceInfo, timeSeriesFilter *cloudMonitoringTimeSeriesFilter, tracer tracing.Tracer, dr *backend.DataResponse, ctx context.Context, req *backend.QueryDataRequest) (cloudMonitoringResponse, error) {
+func doRequestFilterPage(r *http.Request, dsInfo datasourceInfo, timeSeriesFilter *cloudMonitoringTimeSeriesFilter, tracer tracing.Tracer, dr *backend.DataResponse, ctx context.Context, req *backend.QueryDataRequest) (cloudMonitoringResponse, error) {
 	r.URL.RawQuery = timeSeriesFilter.Params.Encode()
 	alignmentPeriod, ok := r.URL.Query()["aggregation.alignmentPeriod"]
 	if ok {
@@ -80,8 +80,7 @@ func (timeSeriesFilter *cloudMonitoringTimeSeriesFilter) run(ctx context.Context
 		return dr, cloudMonitoringResponse{}, "", nil
 	}
 
-	timeSeriesFilter.Params["pageSize"] = []string{"30000"}
-	d, err := doRequestPage(r, dsInfo, timeSeriesFilter, tracer, dr, ctx, req)
+	d, err := doRequestFilterPage(r, dsInfo, timeSeriesFilter, tracer, dr, ctx, req)
 	if err != nil {
 		dr.Error = err
 		return dr, cloudMonitoringResponse{}, "", nil
@@ -89,7 +88,7 @@ func (timeSeriesFilter *cloudMonitoringTimeSeriesFilter) run(ctx context.Context
 	nextPageToken := d.NextPageToken
 	for nextPageToken != "" {
 		timeSeriesFilter.Params["pageToken"] = []string{d.NextPageToken}
-		nextPage, err := doRequestPage(r, dsInfo, timeSeriesFilter, tracer, dr, ctx, req)
+		nextPage, err := doRequestFilterPage(r, dsInfo, timeSeriesFilter, tracer, dr, ctx, req)
 		if err != nil {
 			dr.Error = err
 			return dr, cloudMonitoringResponse{}, "", nil

--- a/pkg/tsdb/cloudmonitoring/time_series_filter.go
+++ b/pkg/tsdb/cloudmonitoring/time_series_filter.go
@@ -40,9 +40,9 @@ func (timeSeriesFilter *cloudMonitoringTimeSeriesFilter) run(ctx context.Context
 	d := cloudMonitoringResponse{}
 
 	for first || d.NextPageToken != "" {
-		if (d.NextPageToken != "") {
+		if d.NextPageToken != "" {
 			timeSeriesFilter.Params["pageToken"] = []string{d.NextPageToken}
-		} 
+		}
 		r.URL.RawQuery = timeSeriesFilter.Params.Encode()
 		alignmentPeriod, ok := r.URL.Query()["aggregation.alignmentPeriod"]
 
@@ -86,7 +86,7 @@ func (timeSeriesFilter *cloudMonitoringTimeSeriesFilter) run(ctx context.Context
 			return dr, cloudMonitoringResponse{}, "", nil
 		}
 
-		if(first) {
+		if first {
 			d = dnext
 			first = false
 		} else {

--- a/pkg/tsdb/cloudmonitoring/time_series_query.go
+++ b/pkg/tsdb/cloudmonitoring/time_series_query.go
@@ -75,15 +75,15 @@ func (timeSeriesQuery cloudMonitoringTimeSeriesQuery) run(ctx context.Context, r
 	timeFormat := "2006/01/02-15:04:05"
 	timeSeriesQuery.Query += fmt.Sprintf(" | within d'%s', d'%s'", from.UTC().Format(timeFormat), to.UTC().Format(timeFormat))
 	p := path.Join("/v3/projects", projectName, "timeSeries:query")
-	
+
 	ctx, span := tracer.Start(ctx, "cloudMonitoring MQL query")
 	span.SetAttributes("query", timeSeriesQuery.Query, attribute.Key("query").String(timeSeriesQuery.Query))
 	span.SetAttributes("from", req.Queries[0].TimeRange.From, attribute.Key("from").String(req.Queries[0].TimeRange.From.String()))
 	span.SetAttributes("until", req.Queries[0].TimeRange.To, attribute.Key("until").String(req.Queries[0].TimeRange.To.String()))
 	defer span.End()
-	
+
 	requestBody := map[string]interface{}{
-		"query": timeSeriesQuery.Query,
+		"query":    timeSeriesQuery.Query,
 		"pageSize": 10,
 	}
 	r, err := s.createRequest(ctx, &dsInfo, p, bytes.NewBuffer([]byte{}))
@@ -101,9 +101,9 @@ func (timeSeriesQuery cloudMonitoringTimeSeriesQuery) run(ctx context.Context, r
 	}
 	for d.NextPageToken != "" {
 		requestBody := map[string]interface{}{
-			"query": timeSeriesQuery.Query,
+			"query":     timeSeriesQuery.Query,
 			"pageToken": d.NextPageToken,
-		}	
+		}
 		nextPage, err := doRequestQueryPage(requestBody, r, dsInfo)
 		if err != nil {
 			dr.Error = err

--- a/pkg/tsdb/cloudmonitoring/time_series_query.go
+++ b/pkg/tsdb/cloudmonitoring/time_series_query.go
@@ -60,7 +60,7 @@ func (timeSeriesQuery cloudMonitoringTimeSeriesQuery) run(ctx context.Context, r
 
 	for first || d.NextPageToken != "" {
 		requestBody := map[string]interface{}{
-			"query":    timeSeriesQuery.Query,
+			"query": timeSeriesQuery.Query,
 		}
 		if (d.NextPageToken != "") {
 			requestBody["pageToken"] = d.NextPageToken
@@ -105,7 +105,6 @@ func (timeSeriesQuery cloudMonitoringTimeSeriesQuery) run(ctx context.Context, r
 			d.TimeSeriesData = append(d.TimeSeriesData, dnext.TimeSeriesData...)
 			d.NextPageToken = dnext.NextPageToken
 		}
-
 	}
 
 	return dr, d, timeSeriesQuery.Query, nil

--- a/pkg/tsdb/cloudmonitoring/time_series_query.go
+++ b/pkg/tsdb/cloudmonitoring/time_series_query.go
@@ -56,17 +56,14 @@ func (timeSeriesQuery cloudMonitoringTimeSeriesQuery) run(ctx context.Context, r
 	timeFormat := "2006/01/02-15:04:05"
 	timeSeriesQuery.Query += fmt.Sprintf(" | within d'%s', d'%s'", from.UTC().Format(timeFormat), to.UTC().Format(timeFormat))
 	first := true
-	pageToken := ""
 	d := cloudMonitoringResponse{}
 
-	for first || pageToken != "" {
+	for first || d.NextPageToken != "" {
 		requestBody := map[string]interface{}{
 			"query":    timeSeriesQuery.Query,
-			//"pageSize": 1,
-			//"pageToken": "CIKopIu6uenQ5wESoAEqFmNsb3VkLW1vbml0b3JpbmcucXVlcnkyhQFqFwoHcHJvamVjdBoMNDE3OTY1NTE0MTMzahsKCGxvY2F0aW9uGg9ldXJvcGUtbm9ydGgxLWFqIgoLcmVzb3VyY2VfaWQaEzY2MzYzNzc3ODYyNTIzNDI5NTVyKQoVbWV0cmljOi9pbnN0YW5jZV9uYW1lGhBzdGFja2RyaXZlci10ZXN0",
 		}
-		if (pageToken != "") {
-			requestBody["pageToken"] = pageToken
+		if (d.NextPageToken != "") {
+			requestBody["pageToken"] = d.NextPageToken
 		}
 
 		buf, err := json.Marshal(requestBody)
@@ -103,12 +100,12 @@ func (timeSeriesQuery cloudMonitoringTimeSeriesQuery) run(ctx context.Context, r
 
 		if(first) {
 			d = dnext
+			first = false
 		} else {
-			d.TimeSeries = append(d.TimeSeries, dnext.TimeSeries...)
+			d.TimeSeriesData = append(d.TimeSeriesData, dnext.TimeSeriesData...)
+			d.NextPageToken = dnext.NextPageToken
 		}
 
-		pageToken = dnext.NextPageToken[0:len(dnext.NextPageToken)-1]
-		first = false
 	}
 
 	return dr, d, timeSeriesQuery.Query, nil

--- a/pkg/tsdb/cloudmonitoring/time_series_query.go
+++ b/pkg/tsdb/cloudmonitoring/time_series_query.go
@@ -62,7 +62,7 @@ func (timeSeriesQuery cloudMonitoringTimeSeriesQuery) run(ctx context.Context, r
 		requestBody := map[string]interface{}{
 			"query": timeSeriesQuery.Query,
 		}
-		if (d.NextPageToken != "") {
+		if d.NextPageToken != "" {
 			requestBody["pageToken"] = d.NextPageToken
 		}
 
@@ -98,7 +98,7 @@ func (timeSeriesQuery cloudMonitoringTimeSeriesQuery) run(ctx context.Context, r
 			return dr, cloudMonitoringResponse{}, "", nil
 		}
 
-		if(first) {
+		if first {
 			d = dnext
 			first = false
 		} else {

--- a/pkg/tsdb/cloudmonitoring/time_series_query.go
+++ b/pkg/tsdb/cloudmonitoring/time_series_query.go
@@ -83,7 +83,7 @@ func (timeSeriesQuery cloudMonitoringTimeSeriesQuery) run(ctx context.Context, r
 	defer span.End()
 
 	requestBody := map[string]interface{}{
-		"query":    timeSeriesQuery.Query,
+		"query": timeSeriesQuery.Query,
 	}
 	r, err := s.createRequest(ctx, &dsInfo, p, bytes.NewBuffer([]byte{}))
 	if err != nil {

--- a/pkg/tsdb/cloudmonitoring/time_series_query.go
+++ b/pkg/tsdb/cloudmonitoring/time_series_query.go
@@ -57,7 +57,8 @@ func (timeSeriesQuery cloudMonitoringTimeSeriesQuery) run(ctx context.Context, r
 	timeSeriesQuery.Query += fmt.Sprintf(" | within d'%s', d'%s'", from.UTC().Format(timeFormat), to.UTC().Format(timeFormat))
 
 	buf, err := json.Marshal(map[string]interface{}{
-		"query": timeSeriesQuery.Query,
+		"query":    timeSeriesQuery.Query,
+		"pageSize": 1,
 	})
 	if err != nil {
 		dr.Error = err
@@ -89,6 +90,42 @@ func (timeSeriesQuery cloudMonitoringTimeSeriesQuery) run(ctx context.Context, r
 		dr.Error = err
 		return dr, cloudMonitoringResponse{}, "", nil
 	}
+
+	// fmt.Println("response", string(d.NextPageToken))
+	// finished := d.NextPageToken
+	// for finished != "" {
+	// 	fmt.Println("from loop", string(d.NextPageToken))
+	// 	buf, err := json.Marshal(map[string]interface{}{
+	// 		"query": timeSeriesQuery.Query,
+	// 		"pageToken": d.NextPageToken,
+	// 	})
+	// 	if err != nil {
+	// 		dr.Error = err
+	// 		return dr, cloudMonitoringResponse{}, "", nil
+	// 	}
+	// 	r, err := s.createRequest(ctx, &dsInfo, path.Join("/v3/projects", projectName, "timeSeries:query"), bytes.NewBuffer(buf))
+	// 	if err != nil {
+	// 		dr.Error = err
+	// 		return dr, cloudMonitoringResponse{}, "", nil
+	// 	}
+	// 	defer span.End()
+	// 	tracer.Inject(ctx, r.Header, span)
+
+	// 	r = r.WithContext(ctx)
+	// 	res, err := dsInfo.services[cloudMonitor].client.Do(r)
+	// 	if err != nil {
+	// 		dr.Error = err
+	// 		return dr, cloudMonitoringResponse{}, "", nil
+	// 	}
+
+	// 	dnext, err := unmarshalResponse(res)
+	// 	if err != nil {
+	// 		dr.Error = err
+	// 		return dr, cloudMonitoringResponse{}, "", nil
+	// 	}
+	// 	d.TimeSeries = append(d.TimeSeries, dnext.TimeSeries...)
+	// 	finished = dnext.NextPageToken
+	// }
 
 	return dr, d, timeSeriesQuery.Query, nil
 }

--- a/pkg/tsdb/cloudmonitoring/time_series_query.go
+++ b/pkg/tsdb/cloudmonitoring/time_series_query.go
@@ -84,7 +84,6 @@ func (timeSeriesQuery cloudMonitoringTimeSeriesQuery) run(ctx context.Context, r
 
 	requestBody := map[string]interface{}{
 		"query":    timeSeriesQuery.Query,
-		"pageSize": 10,
 	}
 	r, err := s.createRequest(ctx, &dsInfo, p, bytes.NewBuffer([]byte{}))
 	if err != nil {

--- a/pkg/tsdb/cloudmonitoring/types.go
+++ b/pkg/tsdb/cloudmonitoring/types.go
@@ -100,6 +100,7 @@ type (
 		TimeSeriesDescriptor timeSeriesDescriptor `json:"timeSeriesDescriptor"`
 		TimeSeriesData       timeSeriesData       `json:"timeSeriesData"`
 		Unit                 string               `json:"unit"`
+		NextPageToken        string               `json:"nextPageToken"`
 	}
 )
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
If a Cloud Monitoring returns paginated results the existing code only returns the first page of data.

This PR adds a loop to keep querying until the `nextPageToken` is empty : 
- in `time_series_queries` (code editor)
- in `time_series_filter` (builder)

**Which issue(s) this PR fixes**:

Fixes #51395

**Special notes for your reviewer**:

