### PR TITLE
CI: Add cronjob mode at switch case

### DIFF
--- a/pkg/build/cmd/genversions.go
+++ b/pkg/build/cmd/genversions.go
@@ -51,6 +51,8 @@ func GenerateMetadata(c *cli.Context) (config.Metadata, error) {
 			return config.Metadata{}, err
 		}
 		releaseMode = mode
+	case config.Cronjob:
+		releaseMode = config.ReleaseMode{Mode: config.CronjobMode}
 	}
 
 	if version == "" {


### PR DESCRIPTION
**What this PR does / why we need it**:

After `grafanacom` subcommand was implemented, we should be starting producing nightlies. 
This PR fixes a bug about cronjob mode, the logic around the cronjobs is there, but we never actually declared a mode as cronjob mode.

**Which issue(s) this PR fixes**:

Fixes: https://github.com/grafana/grafana/issues/54440