### PR TITLE
Azure Monitor: Fix subscription selector when changing data sources

### DIFF
--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/ArgQueryEditor/ArgQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/ArgQueryEditor/ArgQueryEditor.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import createMockDatasource from '../../__mocks__/datasource';
+import createMockQuery from '../../__mocks__/query';
+
+import ArgQueryEditor from './ArgQueryEditor';
+
+jest.mock('@grafana/runtime', () => ({
+  ...(jest.requireActual('@grafana/runtime') as unknown as object),
+  getTemplateSrv: () => ({
+    replace: (val: string) => {
+      return val;
+    },
+  }),
+}));
+
+const variableOptionGroup = {
+  label: 'Template variables',
+  options: [],
+};
+
+const defaultProps = {
+  query: createMockQuery(),
+  datasource: createMockDatasource(),
+  variableOptionGroup: variableOptionGroup,
+  onChange: jest.fn(),
+  setError: jest.fn(),
+};
+
+describe('ArgQueryEditor', () => {
+  it('should render', async () => {
+    render(<ArgQueryEditor {...defaultProps} />);
+    expect(await screen.findByTestId('azure-monitor-arg-query-editor-with-experimental-ui')).toBeInTheDocument();
+  });
+
+  it('should select a subscription from the fetched array', async () => {
+    const datasource = createMockDatasource({
+      getSubscriptions: jest.fn().mockResolvedValue([{ value: 'foo' }]),
+    });
+    const onChange = jest.fn();
+    render(<ArgQueryEditor {...defaultProps} datasource={datasource} onChange={onChange} />);
+    expect(await screen.findByTestId('azure-monitor-arg-query-editor-with-experimental-ui')).toBeInTheDocument();
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ subscriptions: ['foo'] }));
+  });
+
+  it('should select a subscription from existing query', async () => {
+    const onChange = jest.fn();
+    const query = createMockQuery({
+      subscriptions: ['bar'],
+    });
+    render(<ArgQueryEditor {...defaultProps} onChange={onChange} query={query} />);
+    expect(await screen.findByTestId('azure-monitor-arg-query-editor-with-experimental-ui')).toBeInTheDocument();
+    expect(onChange).not.toHaveBeenCalledWith(expect.objectContaining({ subscriptions: ['foo'] }));
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ subscriptions: ['bar'] }));
+  });
+
+  it('should change the subscription if the selected one is not part of the fetched array', async () => {
+    const onChange = jest.fn();
+    const datasource = createMockDatasource({
+      getSubscriptions: jest.fn().mockResolvedValue([{ value: 'foo' }]),
+    });
+    const query = createMockQuery({
+      subscriptions: ['bar'],
+    });
+    render(<ArgQueryEditor {...defaultProps} datasource={datasource} onChange={onChange} query={query} />);
+    expect(await screen.findByTestId('azure-monitor-arg-query-editor-with-experimental-ui')).toBeInTheDocument();
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ subscriptions: ['foo'] }));
+    expect(onChange).not.toHaveBeenCalledWith(expect.objectContaining({ subscriptions: ['bar'] }));
+  });
+});

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/ArgQueryEditor/ArgQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/ArgQueryEditor/ArgQueryEditor.test.tsx
@@ -51,7 +51,6 @@ describe('ArgQueryEditor', () => {
     });
     render(<ArgQueryEditor {...defaultProps} onChange={onChange} query={query} />);
     expect(await screen.findByTestId('azure-monitor-arg-query-editor-with-experimental-ui')).toBeInTheDocument();
-    expect(onChange).not.toHaveBeenCalledWith(expect.objectContaining({ subscriptions: ['foo'] }));
     expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ subscriptions: ['bar'] }));
   });
 

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/ArgQueryEditor/ArgQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/ArgQueryEditor/ArgQueryEditor.test.tsx
@@ -68,4 +68,18 @@ describe('ArgQueryEditor', () => {
     expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ subscriptions: ['foo'] }));
     expect(onChange).not.toHaveBeenCalledWith(expect.objectContaining({ subscriptions: ['bar'] }));
   });
+
+  it('should keep a subset of subscriptions if the new list does not contain all the query subscriptions', async () => {
+    const onChange = jest.fn();
+    const datasource = createMockDatasource({
+      getSubscriptions: jest.fn().mockResolvedValue([{ value: 'foo' }, { value: 'bar' }]),
+    });
+    const query = createMockQuery({
+      subscriptions: ['foo', 'bar', 'foobar'],
+    });
+    render(<ArgQueryEditor {...defaultProps} datasource={datasource} onChange={onChange} query={query} />);
+    expect(await screen.findByTestId('azure-monitor-arg-query-editor-with-experimental-ui')).toBeInTheDocument();
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ subscriptions: ['foo', 'bar'] }));
+    expect(onChange).not.toHaveBeenCalledWith(expect.objectContaining({ subscriptions: ['foo', 'bar', 'foobar'] }));
+  });
 });

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/ArgQueryEditor/ArgQueryEditor.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/ArgQueryEditor/ArgQueryEditor.tsx
@@ -32,9 +32,11 @@ function selectSubscriptions(
   if (querySubscriptions.length === 0 && fetchedSubscriptions.length) {
     querySubscriptions = [fetchedSubscriptions[0]];
   }
-  if (fetchedSubscriptions.length && intersection(querySubscriptions, fetchedSubscriptions).length === 0) {
-    // If the current subscriptions are not in the fetched subscriptions, use the first one
-    querySubscriptions = [fetchedSubscriptions[0]];
+  const commonSubscriptions = intersection(querySubscriptions, fetchedSubscriptions);
+  if (fetchedSubscriptions.length && querySubscriptions.length > commonSubscriptions.length) {
+    // If not all of the query subscriptions are in the list of fetched subscriptions, then
+    // select only the ones present (or the first one if none is present)
+    querySubscriptions = commonSubscriptions.length > 0 ? commonSubscriptions : [fetchedSubscriptions[0]];
   }
   return querySubscriptions;
 }

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/ArgQueryEditor/ArgQueryEditor.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/ArgQueryEditor/ArgQueryEditor.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState, useRef } from 'react';
+import { intersection } from 'lodash';
+import React, { useState, useMemo } from 'react';
 
 import { EditorFieldGroup, EditorRow, EditorRows } from '@grafana/ui';
 
@@ -18,6 +19,25 @@ interface ArgQueryEditorProps {
 }
 
 const ERROR_SOURCE = 'arg-subscriptions';
+
+function selectSubscriptions(
+  fetchedSubscriptions: string[],
+  currentSubscriptions?: string[],
+  currentSubscription?: string
+) {
+  let querySubscriptions = currentSubscriptions || [];
+  if (querySubscriptions.length === 0 && currentSubscription) {
+    querySubscriptions = [currentSubscription];
+  }
+  if (querySubscriptions.length === 0 && fetchedSubscriptions.length) {
+    querySubscriptions = [fetchedSubscriptions[0]];
+  }
+  if (fetchedSubscriptions.length && intersection(querySubscriptions, fetchedSubscriptions).length === 0) {
+    querySubscriptions = [fetchedSubscriptions[0]];
+  }
+  return querySubscriptions;
+}
+
 const ArgQueryEditor: React.FC<ArgQueryEditorProps> = ({
   query,
   datasource,
@@ -26,15 +46,8 @@ const ArgQueryEditor: React.FC<ArgQueryEditorProps> = ({
   onChange,
   setError,
 }) => {
-  const fetchedRef = useRef(false);
   const [subscriptions, setSubscriptions] = useState<AzureMonitorOption[]>([]);
-
-  useEffect(() => {
-    if (fetchedRef.current) {
-      return;
-    }
-
-    fetchedRef.current = true;
+  useMemo(() => {
     datasource
       .getSubscriptions()
       .then((results) => {
@@ -42,15 +55,19 @@ const ArgQueryEditor: React.FC<ArgQueryEditorProps> = ({
         setSubscriptions(fetchedSubscriptions);
         setError(ERROR_SOURCE, undefined);
 
-        if (!query.subscriptions?.length && fetchedSubscriptions?.length) {
-          onChange({
-            ...query,
-            subscriptions: [query.subscription ?? fetchedSubscriptions[0].value],
-          });
-        }
+        onChange({
+          ...query,
+          subscriptions: selectSubscriptions(
+            fetchedSubscriptions.map((v) => v.value),
+            query.subscriptions,
+            query.subscription
+          ),
+        });
       })
       .catch((err) => setError(ERROR_SOURCE, err));
-  }, [datasource, onChange, query, setError]);
+    // We are only interested in re-fetching subscriptions if the data source changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [datasource]);
 
   return (
     <span data-testid="azure-monitor-arg-query-editor-with-experimental-ui">

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/ArgQueryEditor/ArgQueryEditor.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/ArgQueryEditor/ArgQueryEditor.tsx
@@ -33,6 +33,7 @@ function selectSubscriptions(
     querySubscriptions = [fetchedSubscriptions[0]];
   }
   if (fetchedSubscriptions.length && intersection(querySubscriptions, fetchedSubscriptions).length === 0) {
+    // If the current subscriptions are not in the fetched subscriptions, use the first one
     querySubscriptions = [fetchedSubscriptions[0]];
   }
   return querySubscriptions;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

When changing the data source, the list of subscriptions will change. This PR includes two fixes to adapt the Azure Resource Graph editor to that situation:

 - `useRef` does not change when using the editor in the template variable section (because the editor does not get re-mounted). I have changed that solution to use `useMemo` instead.
 - I changed the logic so if the new list of subscriptions does not contain the ones in the query, it removes the ones that are not available.

[Screencast from 04-10-22 12:47:35.webm](https://user-images.githubusercontent.com/4025665/193802774-9dfbe07e-7898-4c8e-ac3e-113f869bdf11.webm)


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #55193

**Special notes for your reviewer**:

