### PR TITLE
Accessibility: enable `jsx-a11y/no-autofocus`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -101,7 +101,12 @@
         "jsx-a11y/media-has-caption": "error",
         "jsx-a11y/mouse-events-have-key-events": "off",
         "jsx-a11y/no-access-key": "error",
-        "jsx-a11y/no-autofocus": "off",
+        "jsx-a11y/no-autofocus": [
+          "error",
+          {
+            "ignoreNonDOM": true
+          }
+        ],
         "jsx-a11y/no-distracting-elements": "error",
         "jsx-a11y/no-interactive-element-to-noninteractive-role": "error",
         "jsx-a11y/no-noninteractive-element-interactions": [

--- a/packages/grafana-ui/src/components/Segment/SegmentInput.tsx
+++ b/packages/grafana-ui/src/components/Segment/SegmentInput.tsx
@@ -74,6 +74,8 @@ export function SegmentInput<T>({
     <input
       {...rest}
       ref={ref}
+      // this needs to autofocus, but it's ok as it's only rendered by choice
+      // eslint-disable-next-line jsx-a11y/no-autofocus
       autoFocus
       className={cx(`gf-form gf-form-input`, inputWidthStyle)}
       value={value}

--- a/public/app/features/search/components/DashboardSearch.tsx
+++ b/public/app/features/search/components/DashboardSearch.tsx
@@ -41,7 +41,6 @@ export function DashboardSearch({}: Props) {
               onKeyDown={onKeyDown}
               spellCheck={false}
               className={styles.input}
-              autoFocus
             />
           </div>
 

--- a/public/app/features/search/components/DashboardSearchModal.tsx
+++ b/public/app/features/search/components/DashboardSearchModal.tsx
@@ -70,7 +70,6 @@ export function DashboardSearchModal({ isOpen }: Props) {
                   tabIndex={0}
                   spellCheck={false}
                   className={styles.input}
-                  autoFocus
                 />
               </div>
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

- enables `jsx-a11y/no-autofocus`
  - this uses the [`ignoreNonDOM` option](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-autofocus.md#rule-details)
    - we have several components (e.g. `DataSourcePicker`, `Cascader` internally and `FocusScope` externally) that have an `autoFocus` prop - i think it would cause too much confusion to mark all these as errors and explicitly require `// eslint-disable-next-line` comments everywhere. 
    - by using `ignoreNonDOM`, we restrict it to checking only DOM nodes, e.g. `<input>`, `<a>`, `<div>`, etc.
- removes `autoFocus` from the search modals
  - the `<input>` is the first interactive element so receives focus anyway
- keeps `autoFocus` in `SegmentInput` (ignored with `// eslint-disable-next-line`)
  - think `autoFocus` actually makes senes here since it's only ever explicitly added by pressing the `add` button. wdyt? 🤔 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/56286

**Special notes for your reviewer**:

