### PR TITLE
Storybook Deployment: Strip the local dir from the filePath

### DIFF
--- a/pkg/build/gcloud/storage/gsutil.go
+++ b/pkg/build/gcloud/storage/gsutil.go
@@ -268,8 +268,9 @@ func ListLocalFiles(dir string) ([]File, error) {
 	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 		if !info.IsDir() {
 			files = append(files, File{
-				FullPath:    path,
-				PathTrimmed: info.Name(),
+				FullPath: path,
+				// Strip the dir name from the filepath
+				PathTrimmed: strings.ReplaceAll(path, dir, ""),
 			})
 		}
 		return nil


### PR DESCRIPTION
**What this PR does / why we need it**:

Storybook deployment is faulty, due to every file being stored in the `grafana-storybook/<MODE>` bucket without subdirectories. The way this function used to work, is that if we needed the trimmed name of a file, it returned only the filename, while if we needed the full path it returned the relative path of the file.
What we need is for trimmed paths, to get the filepath without the local dir.
