### PR TITLE
StateHook: Fun experiment with a state hook pattern / mini framework 

### DIFF
--- a/public/app/core/components/PageNew/Page.tsx
+++ b/public/app/core/components/PageNew/Page.tsx
@@ -80,7 +80,7 @@ export const Page: PageType = ({
       )}
       {layout === PageLayoutType.Canvas && (
         <CustomScrollbar autoHeightMin={'100%'} scrollTop={scrollTop} scrollRefCallback={scrollRef}>
-          <div className={styles.canvasContent}>
+          <div className={styles.dashboardContent}>
             {toolbar}
             {children}
           </div>
@@ -121,16 +121,14 @@ const getStyles = (theme: GrafanaTheme2) => {
         top: theme.spacing(2),
       },
     }),
-    wrapper: css({
-      label: 'page-wrapper',
-      height: '100%',
-      display: 'flex',
-      flex: '1 1 0',
-      flexDirection: 'column',
-      minHeight: 0,
-    }),
+    wrapper: css`
+      height: 100%;
+      display: flex;
+      flex: 1 1 0;
+      flex-direction: column;
+      min-height: 0;
+    `,
     panes: css({
-      label: 'page-panes',
       display: 'flex',
       height: '100%',
       width: '100%',
@@ -142,19 +140,18 @@ const getStyles = (theme: GrafanaTheme2) => {
       },
     }),
     pageContent: css({
-      label: 'page-content',
       flexGrow: 1,
     }),
     pageInner: css({
-      label: 'page-inner',
       padding: theme.spacing(3),
       boxShadow: shadow,
       background: theme.colors.background.primary,
       margin: theme.spacing(2, 2, 2, 1),
+      display: 'flex',
+      flexDirection: 'column',
       flexGrow: 1,
     }),
-    canvasContent: css({
-      label: 'canvas-content',
+    dashboardContent: css({
       display: 'flex',
       flexDirection: 'column',
       padding: theme.spacing(2),

--- a/public/app/core/components/PageNew/state.ts
+++ b/public/app/core/components/PageNew/state.ts
@@ -1,0 +1,61 @@
+import { useEffect, useMemo } from 'react';
+import { BehaviorSubject } from 'rxjs';
+
+import { config } from '@grafana/runtime';
+import { useForceUpdate } from '@grafana/ui';
+import store from 'app/core/store';
+
+export interface PageState {
+  isNavExpanded: boolean;
+}
+
+export function usePageState() {
+  const { state, actions } = useMemo(() => {
+    const isSmallScreenQuery = window.matchMedia(`(max-width: ${config.theme2.breakpoints.values.lg}px)`);
+    const navExpandedPreference = store.getBool('grafana.sectionNav.expanded', true);
+
+    const state = new BehaviorSubject<PageState>({
+      isNavExpanded: !isSmallScreenQuery.matches && navExpandedPreference,
+    });
+
+    // Subscribe to watch
+    const onMediaQueryChange = (e: MediaQueryListEvent) => {
+      state.next({ isNavExpanded: e.matches ? false : store.getBool('grafana.sectionNav.expanded', true) });
+    };
+
+    const onInit = () => {
+      isSmallScreenQuery.addEventListener('change', onMediaQueryChange);
+    };
+
+    const onCleanUp = () => {
+      isSmallScreenQuery.removeEventListener('change', onMediaQueryChange);
+    };
+
+    const onToggleSectionNav = () => {
+      const { isNavExpanded } = state.getValue();
+      state.next({ isNavExpanded: !isNavExpanded });
+    };
+
+    return { state, actions: { onToggleSectionNav, onInit, onCleanUp } };
+  }, []);
+
+  useEffect(() => {
+    actions.onInit();
+    return () => actions.onCleanUp();
+  }, [actions]);
+
+  const latestState = useLatestState(state);
+
+  return { state: latestState, actions };
+}
+
+export function useLatestState<TState>(state: BehaviorSubject<TState>): TState {
+  const forceUpdate = useForceUpdate();
+
+  useEffect(() => {
+    const s = state.subscribe(forceUpdate);
+    return () => s.unsubscribe();
+  }, [state, forceUpdate]);
+
+  return state.getValue();
+}


### PR DESCRIPTION
Just a fun experiment with a state hook pattern & mini framework to help  

* move state and event handlers outside React component render path
* Make all event handlers (actions) memoized & stable by default without any need for useCallback. This is accomplished with a state system and callbacks that are defined together inside a useMemo(fn, []) hook. 
* State changes trigger react re-render via an rxjs Subject 
* Some simple lifecycle actions (probably a stupid idea, this could be handled in the react component instead that then call actions, but kind of nice to have lifecycle actions in the state system, and means not having to deal with useEffect and dependency lists) 
* Actions and lifecycle events can access latest state without need for dependency lists 

This is overall pretty similar to useReducer + redux toolkit but a bit more flexible, easy to add async actions without the complexity and problem of adding typed thunks (which is very messy with useReducer + redux-toolkit).

This would also be an alternative to the class instance-based approach.  https://github.com/grafana/grafana/blob/main/public/app/features/dashboard/components/HelpWizard/SupportSnapshotService.ts#L125 

Main downside with this approach compared to class instance approach is testability. The upside is how it can integrate with some lifecycle actions, but that would be easy to add to class-based approach as well now that I think of it. 
