### PR TITLE
Alerting: Start ticker only when scheduler starts

### DIFF
--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -40,7 +40,6 @@ type ScheduleService interface {
 	// the following are used by tests only used for tests
 	evalApplied(ngmodels.AlertRuleKey, time.Time)
 	stopApplied(ngmodels.AlertRuleKey)
-	overrideCfg(cfg SchedulerCfg)
 }
 
 // AlertsSender is an interface for a service that is responsible for sending notifications to the end-user.

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -67,8 +67,6 @@ type schedule struct {
 
 	clock clock.Clock
 
-	ticker *ticker.T
-
 	// evalApplied is only used for tests: test code can set it to non-nil
 	// function, and then it'll be called from the event loop whenever the
 	// message from evalApplied is handled.
@@ -117,15 +115,12 @@ type SchedulerCfg struct {
 
 // NewScheduler returns a new schedule.
 func NewScheduler(cfg SchedulerCfg, appURL *url.URL, stateManager *state.Manager) *schedule {
-	ticker := ticker.New(cfg.C, cfg.Cfg.BaseInterval, cfg.Metrics.Ticker)
-
 	sch := schedule{
 		registry:              alertRuleInfoRegistry{alertRuleInfo: make(map[ngmodels.AlertRuleKey]*alertRuleInfo)},
 		maxAttempts:           cfg.Cfg.MaxAttempts,
 		clock:                 cfg.C,
 		baseInterval:          cfg.Cfg.BaseInterval,
 		log:                   cfg.Logger,
-		ticker:                ticker,
 		evalAppliedFunc:       cfg.EvalAppliedFunc,
 		stopAppliedFunc:       cfg.StopAppliedFunc,
 		evaluator:             cfg.Evaluator,
@@ -143,9 +138,10 @@ func NewScheduler(cfg SchedulerCfg, appURL *url.URL, stateManager *state.Manager
 }
 
 func (sch *schedule) Run(ctx context.Context) error {
-	defer sch.ticker.Stop()
+	t := ticker.New(sch.clock, sch.baseInterval, sch.metrics.Ticker)
+	defer t.Stop()
 
-	if err := sch.schedulePeriodic(ctx); err != nil {
+	if err := sch.schedulePeriodic(ctx, t); err != nil {
 		sch.log.Error("failure while running the rule evaluation loop", "err", err)
 	}
 	return nil
@@ -184,11 +180,11 @@ func (sch *schedule) DeleteAlertRule(keys ...ngmodels.AlertRuleKey) {
 	sch.metrics.SchedulableAlertRulesHash.Set(float64(hashUIDs(alertRules)))
 }
 
-func (sch *schedule) schedulePeriodic(ctx context.Context) error {
+func (sch *schedule) schedulePeriodic(ctx context.Context, t *ticker.T) error {
 	dispatcherGroup, ctx := errgroup.WithContext(ctx)
 	for {
 		select {
-		case tick := <-sch.ticker.C:
+		case tick := <-t.C:
 			// We use Round(0) on the start time to remove the monotonic clock.
 			// This is required as ticks from the ticker and time.Now() can have
 			// a monotonic clock that when subtracted do not represent the delta
@@ -440,16 +436,6 @@ func (sch *schedule) ruleRoutine(grafanaCtx context.Context, key ngmodels.AlertR
 			return nil
 		}
 	}
-}
-
-// overrideCfg is only used on tests.
-func (sch *schedule) overrideCfg(cfg SchedulerCfg) {
-	sch.clock = cfg.C
-	sch.baseInterval = cfg.Cfg.BaseInterval
-	sch.ticker.Stop()
-	sch.ticker = ticker.New(cfg.C, cfg.Cfg.BaseInterval, cfg.Metrics.Ticker)
-	sch.evalAppliedFunc = cfg.EvalAppliedFunc
-	sch.stopAppliedFunc = cfg.StopAppliedFunc
 }
 
 // evalApplied is only used on tests.


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
The current ticker implementation starts it when it is created and it immediately starts producing ticks. If ticks are not consumed from ticker it "piles up" ticks and then when ticks are consumed it tries to catch up.
The only consumer of the ticker is the scheduler (legacy or new one). The ngalert scheduler creates a ticker in the constructor 

https://github.com/grafana/grafana/blob/4163f31d7613df6b1a9e1e46d7ea57602d13c945/pkg/services/ngalert/schedule/schedule.go#L119-L120

However, there can be a very substantial gap between the scheduler is created and the scheduler is started (i.e. starts consuming ticks)
https://github.com/grafana/grafana/blob/ba97b268d0429b3f2adaf06ea04010ea590fba31/pkg/services/ngalert/schedule/schedule.go#L145

Therefore, if scheduler is started more than 10 seconds after it was created, it will start evaluating rules very fast until ticker catches up to the current time. 

One of those situations is the provisioning. Currently, it can take many minutes

This PR changes the time when ticker is initialized to when the scheduler starts. This will make the ticker to be consumed by the scheduler as fast as possible.