### PR TITLE
Alerting: subscribe to Dashboard refresh interval for alert panels

### DIFF
--- a/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
+++ b/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/css';
 import { sortBy } from 'lodash';
 import React, { useEffect, useMemo } from 'react';
+import { useEffectOnce } from 'react-use';
 
 import { GrafanaTheme2, PanelProps } from '@grafana/data';
 import { TimeRangeUpdatedEvent } from '@grafana/runtime';
@@ -28,6 +29,7 @@ import {
 } from 'app/features/alerting/unified/utils/datasource';
 import { flattenRules, getFirstActiveAt } from 'app/features/alerting/unified/utils/rules';
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
+import { DashboardModel } from 'app/features/dashboard/state';
 import { useDispatch, AccessControlAction } from 'app/types';
 import { PromRuleWithLocation } from 'app/types/unified-alerting';
 import { PromAlertingRuleState } from 'app/types/unified-alerting-dto';
@@ -49,7 +51,11 @@ export function UnifiedAlertList(props: PanelProps<UnifiedAlertListOptions>) {
     props.options.stateFilter.inactive = undefined; // now disable inactive
   }, [props.options.stateFilter]);
 
-  const dashboard = getDashboardSrv().getCurrent();
+  let dashboard: DashboardModel | undefined = undefined;
+
+  useEffectOnce(() => {
+    dashboard = getDashboardSrv().getCurrent();
+  });
 
   useEffect(() => {
     dispatch(fetchAllPromRulesAction());
@@ -57,7 +63,7 @@ export function UnifiedAlertList(props: PanelProps<UnifiedAlertListOptions>) {
     return () => {
       sub?.unsubscribe();
     };
-  }, [dispatch, dashboard?.events]);
+  }, [dispatch, dashboard]);
 
   const promRulesRequests = useUnifiedAlertingSelector((state) => state.promRules);
 

--- a/public/app/plugins/panel/alertlist/UnifiedalertList.test.tsx
+++ b/public/app/plugins/panel/alertlist/UnifiedalertList.test.tsx
@@ -5,7 +5,6 @@ import { Provider } from 'react-redux';
 import { getDefaultTimeRange, LoadingState, PanelProps, FieldConfigSource } from '@grafana/data';
 import { TimeRangeUpdatedEvent } from '@grafana/runtime';
 import { DashboardSrv, setDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
-import { DashboardModel } from 'app/features/dashboard/state';
 import { configureStore } from 'app/store/configureStore';
 
 import { UnifiedAlertList } from './UnifiedAlertList';

--- a/public/app/plugins/panel/alertlist/UnifiedalertList.test.tsx
+++ b/public/app/plugins/panel/alertlist/UnifiedalertList.test.tsx
@@ -1,0 +1,86 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import { Provider } from 'react-redux';
+
+import { getDefaultTimeRange, LoadingState, PanelProps, FieldConfigSource } from '@grafana/data';
+import { TimeRangeUpdatedEvent } from '@grafana/runtime';
+import { DashboardSrv, setDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
+import { DashboardModel } from 'app/features/dashboard/state';
+import { configureStore } from 'app/store/configureStore';
+
+import { UnifiedAlertList } from './UnifiedAlertList';
+import { UnifiedAlertListOptions, SortOrder, GroupMode, ViewMode } from './types';
+
+jest.mock('app/features/alerting/unified/api/alertmanager');
+
+const defaultOptions: UnifiedAlertListOptions = {
+  maxItems: 2,
+  sortOrder: SortOrder.AlphaAsc,
+  dashboardAlerts: true,
+  groupMode: GroupMode.Default,
+  groupBy: [''],
+  alertName: 'test',
+  showInstances: false,
+  folder: { id: 1, title: 'test folder' },
+  stateFilter: { firing: true, pending: false, noData: false, normal: true, error: false },
+  alertInstanceLabelFilter: '',
+  datasource: 'Alertmanager',
+  viewMode: ViewMode.List,
+};
+
+const defaultProps: PanelProps<UnifiedAlertListOptions> = {
+  data: { state: LoadingState.Done, series: [], timeRange: getDefaultTimeRange() },
+  id: 1,
+  timeRange: getDefaultTimeRange(),
+  timeZone: 'utc',
+  options: defaultOptions,
+  eventBus: {
+    subscribe: jest.fn(),
+    getStream: jest.fn(),
+    publish: jest.fn(),
+    removeAllListeners: jest.fn(),
+    newScopedBus: jest.fn(),
+  },
+  fieldConfig: {} as unknown as FieldConfigSource,
+  height: 400,
+  onChangeTimeRange: jest.fn(),
+  onFieldConfigChange: jest.fn(),
+  onOptionsChange: jest.fn(),
+  renderCounter: 1,
+  replaceVariables: jest.fn(),
+  title: 'Alert groups test',
+  transparent: false,
+  width: 320,
+};
+
+const dashboard = {
+  id: 1,
+  formatDate: (time: number) => new Date(time).toISOString(),
+  events: {
+    subscribe: jest.fn(),
+  },
+};
+
+const renderPanel = (options: UnifiedAlertListOptions = defaultOptions) => {
+  const store = configureStore();
+
+  const dashSrv: unknown = { getCurrent: () => dashboard };
+  setDashboardSrv(dashSrv as DashboardSrv);
+
+  defaultProps.options = options;
+  const props = { ...defaultProps };
+
+  return render(
+    <Provider store={store}>
+      <UnifiedAlertList {...props} />
+    </Provider>
+  );
+};
+
+describe('UnifiedAlertList', () => {
+  it('subscribes to the dashboard refresh interval', async () => {
+    await renderPanel();
+    expect(dashboard.events.subscribe).toHaveBeenCalledTimes(1);
+    expect(dashboard.events.subscribe.mock.calls[0][0]).toEqual(TimeRangeUpdatedEvent);
+  });
+});


### PR DESCRIPTION
**What this PR does / why we need it**:

Alerting panels under the Dashboard view are refreshing at a hard set interval of 20s. Instead of that, they should refresh based on the dashboard's interval if set and use that value just as a fallback in case autorefresh is not enabled.

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/47843

![2022-10-05 10 55 57](https://user-images.githubusercontent.com/6271380/194078445-26197c98-ca1d-4d29-8c04-fa39f7d1a96b.gif)

