### PR TITLE
QueryEditorRow: Only pass error to query editor if panel is not in a loading state

### DIFF
--- a/public/app/features/query/components/QueryEditorRow.test.ts
+++ b/public/app/features/query/components/QueryEditorRow.test.ts
@@ -109,6 +109,21 @@ describe('filterPanelDataToQuery', () => {
     const panelDataA = filterPanelDataToQuery(loadingData, 'A');
     expect(panelDataA?.state).toBe(LoadingState.Loading);
   });
+
+  it('should not set the state to error if the frame is still loading', () => {
+    const loadingData: PanelData = {
+      state: LoadingState.Loading,
+      series: [],
+      error: {
+        refId: 'B',
+        message: 'Error',
+      },
+      timeRange: { from: dateTime(), to: dateTime(), raw: { from: 'now-1d', to: 'now' } },
+    };
+
+    const panelDataA = filterPanelDataToQuery(loadingData, 'A');
+    expect(panelDataA?.state).toBe(LoadingState.Loading);
+  });
 });
 
 describe('frame results with warnings', () => {

--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -534,8 +534,8 @@ export interface AngularQueryComponentScope<TQuery extends DataQuery> {
 export function filterPanelDataToQuery(data: PanelData, refId: string): PanelData | undefined {
   const series = data.series.filter((series) => series.refId === refId);
 
-  // If there was an error with no data, pass it to the QueryEditors
-  if (data.error && !data.series.length) {
+  // If there was an error with no data and the panel is not in a loading state, pass it to the QueryEditors
+  if (data.state !== LoadingState.Loading && data.error && !data.series.length) {
     return {
       ...data,
       state: LoadingState.Error,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Currently if a query is rerun and there was previously an error and no data, then the result from the last run of the query is passed to the query editor: https://github.com/grafana/grafana/blob/8950d86141e344e040b74d25d5f79a5ac93abbe0/public/app/features/query/state/runRequest.ts#L223-L233

The `filterPanelDataToQuery` function in `QueryEditorRow` returns an error state even if the query is currently in a loading state because the previous result contains an error object and there is no data: https://github.com/grafana/grafana/blob/8950d86141e344e040b74d25d5f79a5ac93abbe0/public/app/features/query/components/QueryEditorRow.tsx#L537-L543

Downstream, if a component is relying on the loading state, then it would just see the previous error state instead of the current loading state.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

