### PR TITLE
Page Nav: automatically create navModel without a navId

### DIFF
--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -512,27 +512,32 @@ func (s *ServiceImpl) buildDataConnectionsNavLink(c *models.ReqContext) *navtree
 	baseUrl := s.cfg.AppSubURL + "/" + baseId
 
 	children = append(children, &navtree.NavLink{
-		Id:       baseId + "-datasources",
-		Text:     "Data sources",
-		Icon:     "database",
-		SubTitle: "Add and configure data sources",
-		Url:      baseUrl + "/datasources",
+		Id:       baseId + "-your-connections",
+		Text:     "Your connections",
+		SubTitle: "Manage your existing connections",
+		Url:      baseUrl + "/your-connections",
+		Children: []*navtree.NavLink{&navtree.NavLink{
+			Id:       baseId + "-your-connections-datasources",
+			Text:     "Datasources",
+			SubTitle: "Manage your existing datasource connections",
+			Url:      baseUrl + "/your-connections/datasources",
+		}},
 	})
 
 	children = append(children, &navtree.NavLink{
-		Id:       baseId + "-plugins",
-		Text:     "Plugins",
-		Icon:     "plug",
-		SubTitle: "Manage plugins",
-		Url:      baseUrl + "/plugins",
+		Id:       baseId + "-connections",
+		Text:     "Connections",
+		SubTitle: "Browse and create new connections",
+		Url:      baseUrl + "/connections",
+		Children: []*navtree.NavLink{},
 	})
 
 	children = append(children, &navtree.NavLink{
-		Id:       baseId + "-cloud-integrations",
-		Text:     "Cloud integrations",
-		Icon:     "bolt",
-		SubTitle: "Manage your cloud integrations",
-		Url:      baseUrl + "/cloud-integrations",
+		Id:       baseId + "-agent",
+		Text:     "Agent",
+		SubTitle: "Manage your agent setup",
+		Url:      baseUrl + "/agent",
+		Children: []*navtree.NavLink{},
 	})
 
 	navLink = &navtree.NavLink{

--- a/public/app/core/components/Page/usePageNav.ts
+++ b/public/app/core/components/Page/usePageNav.ts
@@ -1,3 +1,4 @@
+import { useLocation } from 'react-router-dom';
 import { createSelector } from 'reselect';
 
 import { NavModel } from '@grafana/data';
@@ -5,24 +6,33 @@ import { getNavModel } from 'app/core/selectors/navModel';
 import { store } from 'app/store/store';
 import { StoreState, useSelector } from 'app/types';
 
-export function usePageNav(navId?: string, oldProp?: NavModel): NavModel | undefined {
-  if (oldProp) {
-    return oldProp;
-  }
+import { getActiveItem } from '../NavBar/utils';
 
-  if (!navId) {
-    return;
+const selectNavModel = createSelector(
+  (state: StoreState) => state.navIndex,
+  (state: StoreState) => state.navBarTree,
+  (state: StoreState, pathname: string, navId: string) => [pathname, navId],
+  (navIndex, navBarTree, [pathname, navId]) => {
+    // Falling back to use `navId` in case the page explicitly specifies it.
+    // Otherwise just find the active item based on the current path.
+    const id = navId || getActiveItem(navBarTree, pathname)?.id || '';
+
+    return getNavModel(navIndex, id);
   }
+);
+
+export function usePageNav(navId?: string, oldProp?: NavModel): NavModel | undefined {
+  const location = useLocation();
 
   // Page component is used in so many tests, this simplifies not having to initialize a full redux store
   if (!store) {
     return;
   }
 
+  // Backwards compatibility: if the page constructs the NavModel on it's own (maybe due to having a custom logic), keep using that
+  if (oldProp) {
+    return oldProp;
+  }
   // eslint-disable-next-line react-hooks/rules-of-hooks
-  return useSelector(createSelector(getNavIndex, (navIndex) => getNavModel(navIndex, navId ?? 'home')));
-}
-
-function getNavIndex(store: StoreState) {
-  return store.navIndex;
+  return useSelector((state) => selectNavModel(state, location.pathname, navId || ''));
 }

--- a/public/app/core/components/PageNew/SectionNavItem.tsx
+++ b/public/app/core/components/PageNew/SectionNavItem.tsx
@@ -19,11 +19,12 @@ export function SectionNavItem({ item }: Props) {
 
   // If first root child is a section skip the bottom margin (as sections have top margin already)
   const noRootMargin = isSectionRoot && Boolean(item.children![0].children?.length);
+  const hasChildren = Boolean(children?.length);
 
   const linkClass = cx({
     [styles.link]: true,
     [styles.activeStyle]: item.active,
-    [styles.isSection]: Boolean(children?.length),
+    [styles.isSection]: hasChildren,
     [styles.hasActiveChild]: hasActiveChild,
     [styles.isSectionRoot]: isSectionRoot,
     [styles.noRootMargin]: noRootMargin,
@@ -46,6 +47,7 @@ export function SectionNavItem({ item }: Props) {
       {children?.map((child, index) => (
         <SectionNavItem item={child} key={index} />
       ))}
+      {hasChildren && <div className={styles.spacing}></div>}
     </>
   );
 }
@@ -108,6 +110,9 @@ const getStyles = (theme: GrafanaTheme2) => {
     }),
     hasActiveChild: css({
       color: theme.colors.text.primary,
+    }),
+    spacing: css({
+      marginTop: theme.spacing(2),
     }),
   };
 };

--- a/public/app/features/connections/ConnectionsPage.tsx
+++ b/public/app/features/connections/ConnectionsPage.tsx
@@ -7,14 +7,11 @@ import { NewDataSource } from 'app/features/datasources/components/NewDataSource
 import { DataSourcesRoutesContext } from 'app/features/datasources/state';
 
 import { ROUTES } from './constants';
-import { useNavModel } from './hooks/useNavModel';
 import { CloudIntegrations } from './tabs/CloudIntegrations';
 import { DataSourcesEdit } from './tabs/DataSourcesEdit';
 import { Plugins } from './tabs/Plugins';
 
 export default function ConnectionsPage() {
-  const navModel = useNavModel();
-
   return (
     <DataSourcesRoutesContext.Provider
       value={{
@@ -24,7 +21,7 @@ export default function ConnectionsPage() {
         Dashboards: ROUTES.DataSourcesDashboards,
       }}
     >
-      <Page navModel={navModel}>
+      <Page>
         <Page.Contents>
           <Switch>
             <Route path={ROUTES.DataSourcesNew} component={NewDataSource} />


### PR DESCRIPTION
### What changed?

**TL;DR**
Removes the need to pass a `navId` or a `navModel` to a `<Page>` component. 

Created a fallback mechanism for generating a `navModel` for `<Page>` components without a `navId` specified. This removes the need to keep track of the currently active sub-page / sub-section in our pages to be able to pass their id down to the `<Page>` component.


https://user-images.githubusercontent.com/9974811/194016124-6c11ec9e-557f-4902-afad-d6b3c208f7b3.mov

