### PR TITLE
Fix 46977 more permanently

### DIFF
--- a/package.json
+++ b/package.json
@@ -424,7 +424,7 @@
     ]
   },
   "engines": {
-    "node": ">= 16"
+    "node": ">= 16.14.2"
   },
   "packageManager": "yarn@3.2.3"
 }


### PR DESCRIPTION
Fixes #46977 which has been marked as closed, but still caused me problems.

In order to avoid getting stuck at "94% sealing after seal" when running `yarn start`, we need to be running node 16.14.2 (LTS) or higher.
