### PR TITLE
LogContext: Fix scroll position in upper context group

### DIFF
--- a/public/app/features/logs/components/LogRowContext.tsx
+++ b/public/app/features/logs/components/LogRowContext.tsx
@@ -164,7 +164,7 @@ export const LogRowContextGroup: React.FunctionComponent<LogRowContextGroupProps
   const prevScrollHeight = usePrevious(scrollHeight);
 
   /**
-   * This hook is responsible to keep the right scroll position of the top
+   * This hook is responsible of keeping the right scroll position of the top
    * context when rows are added. Since rows are added at the top of the DOM,
    * the scroll position changes and we need to adjust the scrollTop.
    */

--- a/public/app/features/logs/components/LogRowContext.tsx
+++ b/public/app/features/logs/components/LogRowContext.tsx
@@ -159,6 +159,7 @@ export const LogRowContextGroup: React.FunctionComponent<LogRowContextGroupProps
   const [scrollHeight, setScrollHeight] = useState(0);
 
   const listContainerRef = useRef<HTMLDivElement>(null);
+  const prevRows = usePrevious(rows);
   const prevScrollTop = usePrevious(scrollTop);
   const prevScrollHeight = usePrevious(scrollHeight);
 
@@ -172,6 +173,7 @@ export const LogRowContextGroup: React.FunctionComponent<LogRowContextGroupProps
       return;
     }
 
+    const previousRowsLength = prevRows?.length ?? 0;
     const previousScrollHeight = prevScrollHeight ?? 0;
     const previousScrollTop = prevScrollTop ?? 0;
     const scrollElement = listContainerRef.current.parentElement;
@@ -182,10 +184,10 @@ export const LogRowContextGroup: React.FunctionComponent<LogRowContextGroupProps
       setScrollHeight(currentScrollHeight);
     }
 
-    if (currentScrollHeight > previousScrollHeight) {
+    if (rows.length > previousRowsLength && currentScrollHeight > previousScrollHeight) {
       setScrollTop(previousScrollTop + (currentScrollHeight - previousScrollHeight));
     }
-  }, [shouldScrollToBottom, prevScrollTop, prevScrollHeight]);
+  }, [shouldScrollToBottom, rows, prevRows, prevScrollTop, prevScrollHeight]);
 
   /**
    * Keeps track of the scroll position of the list container.

--- a/public/app/features/logs/components/LogRowContext.tsx
+++ b/public/app/features/logs/components/LogRowContext.tsx
@@ -1,11 +1,12 @@
 import { css, cx } from '@emotion/css';
-import React, { useRef, useState, useLayoutEffect, useEffect } from 'react';
+import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import usePrevious from 'react-use/lib/usePrevious';
 
-import { GrafanaTheme2, DataQueryError, LogRowModel, textUtil, LogsSortOrder } from '@grafana/data';
-import { useStyles2, Alert, ClickOutsideWrapper, CustomScrollbar, List, Button } from '@grafana/ui';
+import { DataQueryError, GrafanaTheme2, LogRowModel, LogsSortOrder, textUtil } from '@grafana/data';
+import { Alert, Button, ClickOutsideWrapper, CustomScrollbar, List, useStyles2 } from '@grafana/ui';
 
 import { LogMessageAnsi } from './LogMessageAnsi';
-import { LogRowContextRows, LogRowContextQueryErrors, HasMoreContextRows } from './LogRowContextProvider';
+import { HasMoreContextRows, LogRowContextQueryErrors, LogRowContextRows } from './LogRowContextProvider';
 
 export enum LogGroupPosition {
   Bottom = 'bottom',
@@ -155,15 +156,46 @@ export const LogRowContextGroup: React.FunctionComponent<LogRowContextGroupProps
 }) => {
   const { commonStyles, logs } = useStyles2(getLogRowContextStyles);
   const [scrollTop, setScrollTop] = useState(0);
-  const listContainerRef = useRef<HTMLDivElement>(null);
+  const [scrollHeight, setScrollHeight] = useState(0);
 
+  const listContainerRef = useRef<HTMLDivElement>(null);
+  const prevScrollTop = usePrevious(scrollTop);
+  const prevScrollHeight = usePrevious(scrollHeight);
+
+  /**
+   * This hook is responsible to keep the right scroll position of the top
+   * context when rows are added. Since rows are added at the top of the DOM,
+   * the scroll position changes and we need to adjust the scrollTop.
+   */
   useLayoutEffect(() => {
-    // We want to scroll to bottom only when we receive first 10 log lines
-    const shouldScrollRows = rows.length > 0 && rows.length <= 10;
-    if (shouldScrollToBottom && shouldScrollRows && listContainerRef.current) {
-      setScrollTop(listContainerRef.current.offsetHeight);
+    if (!shouldScrollToBottom || !listContainerRef.current) {
+      return;
     }
-  }, [shouldScrollToBottom, rows]);
+
+    const previousScrollHeight = prevScrollHeight ?? 0;
+    const previousScrollTop = prevScrollTop ?? 0;
+    const scrollElement = listContainerRef.current.parentElement;
+    let currentScrollHeight = 0;
+
+    if (scrollElement) {
+      currentScrollHeight = scrollElement.scrollHeight - scrollElement.clientHeight;
+      setScrollHeight(currentScrollHeight);
+    }
+
+    if (currentScrollHeight > previousScrollHeight) {
+      setScrollTop(previousScrollTop + (currentScrollHeight - previousScrollHeight));
+    }
+  }, [shouldScrollToBottom, prevScrollTop, prevScrollHeight]);
+
+  /**
+   * Keeps track of the scroll position of the list container.
+   */
+  const updateScroll = () => {
+    const scrollElement = listContainerRef.current?.parentElement;
+    if (scrollElement) {
+      setScrollTop(listContainerRef.current?.parentElement.scrollTop);
+    }
+  };
 
   const headerProps = {
     row,
@@ -179,7 +211,7 @@ export const LogRowContextGroup: React.FunctionComponent<LogRowContextGroupProps
       {/* When displaying "after" context */}
       {shouldScrollToBottom && !error && <LogRowContextGroupHeader {...headerProps} />}
       <div className={logs}>
-        <CustomScrollbar autoHide scrollTop={scrollTop} autoHeightMin={'210px'}>
+        <CustomScrollbar autoHide onScroll={updateScroll} scrollTop={scrollTop} autoHeightMin={'210px'}>
           <div ref={listContainerRef}>
             {!error && (
               <List

--- a/public/app/features/logs/components/LogRowContextProvider.tsx
+++ b/public/app/features/logs/components/LogRowContextProvider.tsx
@@ -96,7 +96,11 @@ export const getRowContexts = async (
           // counts.
           // We add the refId of the original dataFrame, since uids contain those now and the uids in the context-dataframe
           // do not have a refid.
-          if (`${idField.values.get(fieldIndex)}${row.dataFrame.refId}` === row.uid) {
+          // To be compatible to other datasources we check for both IDs with and without refId.
+          if (
+            idField.values.get(fieldIndex) === row.uid ||
+            `${idField.values.get(fieldIndex)}${row.dataFrame.refId}` === row.uid
+          ) {
             continue;
           }
         } else {

--- a/public/app/features/logs/components/LogRowContextProvider.tsx
+++ b/public/app/features/logs/components/LogRowContextProvider.tsx
@@ -94,13 +94,7 @@ export const getRowContexts = async (
           // we will show those as if they came after. This is not strictly correct but seems better than losing them
           // and making this correct would mean quite a bit of complexity to shuffle things around and messing up
           // counts.
-          // We add the refId of the original dataFrame, since uids contain those now and the uids in the context-dataframe
-          // do not have a refid.
-          // To be compatible to other datasources we check for both IDs with and without refId.
-          if (
-            idField.values.get(fieldIndex) === row.uid ||
-            `${idField.values.get(fieldIndex)}${row.dataFrame.refId}` === row.uid
-          ) {
+          if (idField.values.get(fieldIndex) === row.uid) {
             continue;
           }
         } else {

--- a/public/app/features/logs/components/LogRowContextProvider.tsx
+++ b/public/app/features/logs/components/LogRowContextProvider.tsx
@@ -93,8 +93,10 @@ export const getRowContexts = async (
           // ns which came before but they come in the response that search for logs after. This means right now
           // we will show those as if they came after. This is not strictly correct but seems better than losing them
           // and making this correct would mean quite a bit of complexity to shuffle things around and messing up
-          //counts.
-          if (idField.values.get(fieldIndex) === row.uid) {
+          // counts.
+          // We add the refId of the original dataFrame, since uids contain those now and the uids in the context-dataframe
+          // do not have a refid.
+          if (`${idField.values.get(fieldIndex)}${row.dataFrame.refId}` === row.uid) {
             continue;
           }
         } else {

--- a/public/app/features/logs/components/LogRowContextProvider.tsx
+++ b/public/app/features/logs/components/LogRowContextProvider.tsx
@@ -1,14 +1,14 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import useAsync from 'react-use/lib/useAsync';
 
 import {
-  LogRowModel,
-  toDataFrame,
+  DataQueryError,
+  DataQueryResponse,
   Field,
   FieldCache,
+  LogRowModel,
   LogsSortOrder,
-  DataQueryResponse,
-  DataQueryError,
+  toDataFrame,
 } from '@grafana/data';
 
 export interface RowContextOptions {
@@ -111,7 +111,10 @@ export const getRowContexts = async (
         const lineField: Field<string> = dataFrame.fields.filter((field) => field.name === 'line')[0];
         const line = lineField.values.get(fieldIndex); // assuming that both fields have same length
 
-        data.push(line);
+        // since we request limit+1 logs, we occasionally get one extra log in the response
+        if (data.length < limit) {
+          data.push(line);
+        }
       }
     }
 

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -590,7 +590,7 @@ export class LokiDatasource
     const query: LokiQuery = {
       expr: `{${expr}}`,
       queryType: LokiQueryType.Range,
-      refId: '',
+      refId: row.dataFrame.refId ?? '',
       maxLines: limit,
       direction: queryDirection,
     };


### PR DESCRIPTION
**What this PR does / why we need it**:
The scroll position of the upper context group does currently not keep the correct position. It should initially scroll to the bottom and also keep at the current scroll position.

Initially this was fixed in #50600 however that fix was only working if less or equal than 10 rows were added. However with the change of the IDs of logrows in https://github.com/grafana/grafana/pull/53932 we accidentally added more than 10 rows to the upper context. The PR fixes that issue by adding the correct refid to the comparison and adds a check to only add the requested amount of loglines.

Furthermore the PR improves the handling of the scroll position, such that the position will be maintained also if further lines are loaded.

**Which issue(s) this PR fixes**:

Fixes #56122

**Special notes for your reviewer**:


https://user-images.githubusercontent.com/8092184/194031849-a68dd78d-484d-4f11-90f6-76fb98e7f2c1.mov

