### PR TITLE
[v9.2.x] CI: Stop publishing OSS images for security mode (#56088)

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -7,7 +7,8 @@
 load('scripts/drone/events/pr.star', 'pr_pipelines')
 load('scripts/drone/events/main.star', 'main_pipelines')
 load('scripts/drone/pipelines/docs.star', 'docs_pipelines')
-load('scripts/drone/events/release.star', 'release_pipelines', 'publish_image_pipelines', 'publish_artifacts_pipelines', 'publish_npm_pipelines', 'publish_packages_pipeline', 'artifacts_page_pipeline')
+load('scripts/drone/events/release.star', 'release_pipelines', 'publish_artifacts_pipelines', 'publish_npm_pipelines', 'publish_packages_pipeline', 'artifacts_page_pipeline')
+load('scripts/drone/pipelines/publish_images.star', 'publish_image_pipelines_public', 'publish_image_pipelines_security')
 load('scripts/drone/version.star', 'version_branch_pipelines')
 load('scripts/drone/events/cron.star', 'cronjobs')
 load('scripts/drone/vault.star', 'secrets')
@@ -15,7 +16,7 @@ load('scripts/drone/vault.star', 'secrets')
 def main(ctx):
     edition = 'oss'
     return pr_pipelines(edition=edition) + main_pipelines(edition=edition) + release_pipelines() + \
-        publish_image_pipelines('public') + publish_image_pipelines('security') + \
+        publish_image_pipelines_public() + publish_image_pipelines_security() + \
         publish_artifacts_pipelines('security') + publish_artifacts_pipelines('public') + \
         publish_npm_pipelines('public') + publish_packages_pipeline() + artifacts_page_pipeline() + \
         version_branch_pipelines() + cronjobs(edition=edition) + secrets()

--- a/.drone.yml
+++ b/.drone.yml
@@ -3434,95 +3434,6 @@ depends_on: []
 image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
-name: publish-docker-oss-security
-node:
-  type: no-parallel
-platform:
-  arch: amd64
-  os: linux
-services: []
-steps:
-- commands:
-  - mkdir -p bin
-  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v3.0.10/grabpl
-  - chmod +x bin/grabpl
-  image: byrnedo/alpine-curl:0.1.8
-  name: grabpl
-- commands:
-  - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
-  depends_on: []
-  environment:
-    CGO_ENABLED: 0
-  image: golang:1.19.1
-  name: compile-build-cmd
-- commands:
-  - ./bin/build artifacts docker fetch --edition oss
-  depends_on:
-  - compile-build-cmd
-  environment:
-    DOCKER_PASSWORD:
-      from_secret: docker_password
-    DOCKER_USER:
-      from_secret: docker_username
-    GCP_KEY:
-      from_secret: gcp_key
-  image: google/cloud-sdk
-  name: fetch-images-oss
-  volumes:
-  - name: docker
-    path: /var/run/docker.sock
-- commands:
-  - ./bin/grabpl artifacts docker publish --security --dockerhub-repo grafana --base
-    alpine --base ubuntu --arch amd64 --arch arm64 --arch armv7 --version-tag ${TAG}
-  depends_on:
-  - fetch-images-oss
-  environment:
-    DOCKER_PASSWORD:
-      from_secret: docker_password
-    DOCKER_USER:
-      from_secret: docker_username
-    GCP_KEY:
-      from_secret: gcp_key
-  image: google/cloud-sdk
-  name: publish-images-grafana
-  volumes:
-  - name: docker
-    path: /var/run/docker.sock
-- commands:
-  - ./bin/grabpl artifacts docker publish --security --dockerhub-repo grafana-oss
-    --base alpine --base ubuntu --arch amd64 --arch arm64 --arch armv7 --version-tag
-    ${TAG}
-  depends_on:
-  - fetch-images-oss
-  environment:
-    DOCKER_PASSWORD:
-      from_secret: docker_password
-    DOCKER_USER:
-      from_secret: docker_username
-    GCP_KEY:
-      from_secret: gcp_key
-  image: google/cloud-sdk
-  name: publish-images-grafana-oss
-  volumes:
-  - name: docker
-    path: /var/run/docker.sock
-trigger:
-  event:
-  - promote
-  target:
-  - security
-type: docker
-volumes:
-- host:
-    path: /var/run/docker.sock
-  name: docker
----
-clone:
-  retries: 3
-depends_on: []
-image_pull_secrets:
-- dockerconfigjson
-kind: pipeline
 name: publish-docker-enterprise-security
 node:
   type: no-parallel
@@ -5395,6 +5306,6 @@ kind: secret
 name: packages_secret_access_key
 ---
 kind: signature
-hmac: e272666c636ef5a6c3961293d4a981e801c2e6823c3b8fcf63adad49b53ee32e
+hmac: 65d233993b5149293317b04a1db3d9589dae578a24902ae499e9bd2f417b44b2
 
 ...

--- a/scripts/drone/pipelines/publish_images.star
+++ b/scripts/drone/pipelines/publish_images.star
@@ -1,0 +1,50 @@
+load(
+    'scripts/drone/steps/lib.star',
+    'download_grabpl_step',
+    'publish_images_step',
+    'compile_build_cmd',
+    'fetch_images_step',
+)
+
+load(
+    'scripts/drone/utils/utils.star',
+    'pipeline',
+)
+
+
+def publish_image_steps(edition, mode, docker_repo):
+    additional_docker_repo = ""
+    if edition == 'oss':
+        additional_docker_repo='grafana-oss'
+    steps = [
+        download_grabpl_step(),
+        compile_build_cmd(),
+        fetch_images_step(edition),
+        publish_images_step(edition, 'release', mode, docker_repo),
+    ]
+    if additional_docker_repo != "":
+        steps.extend([publish_images_step(edition, 'release', mode, additional_docker_repo)])
+
+    return steps
+
+def publish_image_pipelines_public():
+    mode='public'
+    trigger = {
+        'event': ['promote'],
+        'target': [mode],
+    }
+    return [pipeline(
+        name='publish-docker-oss-{}'.format(mode), trigger=trigger, steps=publish_image_steps(edition='oss',  mode=mode, docker_repo='grafana'), edition=""
+    ), pipeline(
+        name='publish-docker-enterprise-{}'.format(mode), trigger=trigger, steps=publish_image_steps(edition='enterprise',  mode=mode, docker_repo='grafana-enterprise'), edition=""
+    ),]
+
+def publish_image_pipelines_security():
+    mode='security'
+    trigger = {
+        'event': ['promote'],
+        'target': [mode],
+    }
+    return [pipeline(
+        name='publish-docker-enterprise-{}'.format(mode), trigger=trigger, steps=publish_image_steps(edition='enterprise',  mode=mode, docker_repo='grafana-enterprise'), edition=""
+    ),]

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -796,6 +796,23 @@ def build_docker_images_step(edition, ver_mode, archs=None, ubuntu=False, publis
         },
     }
 
+def fetch_images_step(edition):
+    return {
+        'name': 'fetch-images-{}'.format(edition),
+        'image': 'google/cloud-sdk',
+        'environment': {
+            'GCP_KEY': from_secret('gcp_key'),
+            'DOCKER_USER': from_secret('docker_username'),
+            'DOCKER_PASSWORD': from_secret('docker_password'),
+        },
+        'commands': ['./bin/build artifacts docker fetch --edition {}'.format(edition)],
+        'depends_on': ['compile-build-cmd'],
+        'volumes': [{
+            'name': 'docker',
+            'path': '/var/run/docker.sock'
+        }],
+    }
+
 
 def publish_images_step(edition, ver_mode, mode, docker_repo, trigger=None):
     if mode == 'security':


### PR DESCRIPTION
* No-op: Refactor publish images pipeline struct

* Stop publishing images for OSS

(cherry picked from commit 5cdc932f8c21247dd929ae921e24cc2329b68dd5)

Backport of #56088