### PR TITLE
Azure Monitor: Fix empty Logs response for Alerting

### DIFF
--- a/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
@@ -187,10 +187,11 @@ func (e *AzureLogAnalyticsDatasource) executeQuery(ctx context.Context, query *A
 		return dataResponseErrorWithExecuted(err)
 	}
 
-	frame, err := ResponseTableToFrame(t, logResponse)
+	frame, err := ResponseTableToFrame(t, query.RefID, query.Params.Get("query"))
 	if err != nil {
 		return dataResponseErrorWithExecuted(err)
 	}
+	appendErrorNotice(frame, logResponse.Error)
 
 	model, err := simplejson.NewJson(query.JSON)
 	if err != nil {
@@ -220,6 +221,12 @@ func (e *AzureLogAnalyticsDatasource) executeQuery(ctx context.Context, query *A
 
 	dataResponse.Frames = data.Frames{frame}
 	return dataResponse
+}
+
+func appendErrorNotice(frame *data.Frame, err *AzureLogAnalyticsAPIError) {
+	if err != nil {
+		frame.AppendNotices(apiErrorToNotice(err))
+	}
 }
 
 func (e *AzureLogAnalyticsDatasource) createRequest(ctx context.Context, dsInfo types.DatasourceInfo, url string) (*http.Request, error) {

--- a/pkg/tsdb/azuremonitor/loganalytics/azure-response-table-frame.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/azure-response-table-frame.go
@@ -43,7 +43,16 @@ func apiErrorToNotice(err *AzureLogAnalyticsAPIError) data.Notice {
 }
 
 // ResponseTableToFrame converts an AzureResponseTable to a data.Frame.
-func ResponseTableToFrame(table *types.AzureResponseTable, res AzureLogAnalyticsResponse) (*data.Frame, error) {
+func ResponseTableToFrame(table *types.AzureResponseTable, refID string, executedQuery string) (*data.Frame, error) {
+	if len(table.Rows) == 0 {
+		return &data.Frame{
+			RefID: refID,
+			Meta: &data.FrameMeta{
+				ExecutedQueryString: executedQuery,
+			},
+		}, nil
+	}
+
 	converterFrame, err := converterFrameForTable(table)
 	if err != nil {
 		return nil, err
@@ -55,10 +64,6 @@ func ResponseTableToFrame(table *types.AzureResponseTable, res AzureLogAnalytics
 				return nil, err
 			}
 		}
-	}
-
-	if res.Error != nil {
-		converterFrame.Frame.AppendNotices(apiErrorToNotice(res.Error))
 	}
 
 	return converterFrame.Frame, nil

--- a/pkg/tsdb/azuremonitor/loganalytics/azure-response-table-frame_test.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/azure-response-table-frame_test.go
@@ -169,12 +169,25 @@ func TestLogTableToFrame(t *testing.T) {
 				return frame
 			},
 		},
+		{
+			name:     "empty data response",
+			testFile: "loganalytics/11-log-analytics-response-empty.json",
+			expectedFrame: func() *data.Frame {
+				return &data.Frame{
+					RefID: "A",
+					Meta: &data.FrameMeta{
+						ExecutedQueryString: "query",
+					},
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			res := loadLogAnalyticsTestFileWithNumber(t, tt.testFile)
-			frame, err := ResponseTableToFrame(&res.Tables[0], res)
+			frame, err := ResponseTableToFrame(&res.Tables[0], "A", "query")
+			appendErrorNotice(frame, res.Error)
 			require.NoError(t, err)
 
 			if diff := cmp.Diff(tt.expectedFrame(), frame, data.FrameTestCompareOptions()...); diff != "" {

--- a/pkg/tsdb/azuremonitor/resourcegraph/azure-resource-graph-datasource.go
+++ b/pkg/tsdb/azuremonitor/resourcegraph/azure-resource-graph-datasource.go
@@ -188,7 +188,7 @@ func (e *AzureResourceGraphDatasource) executeQuery(ctx context.Context, query *
 		return dataResponseErrorWithExecuted(err)
 	}
 
-	frame, err := loganalytics.ResponseTableToFrame(&argResponse.Data, loganalytics.AzureLogAnalyticsResponse{})
+	frame, err := loganalytics.ResponseTableToFrame(&argResponse.Data, query.RefID, query.InterpolatedQuery)
 	if err != nil {
 		return dataResponseErrorWithExecuted(err)
 	}

--- a/pkg/tsdb/azuremonitor/testdata/loganalytics/11-log-analytics-response-empty.json
+++ b/pkg/tsdb/azuremonitor/testdata/loganalytics/11-log-analytics-response-empty.json
@@ -1,0 +1,19 @@
+{
+  "tables": [
+    {
+      "name": "PrimaryResult",
+      "columns": [
+        {
+          "name": "OperationName",
+          "type": "string"
+        },
+        {
+          "name": "Level",
+          "type": "string"
+        }
+      ],
+      "rows": []
+    }
+  ]
+}
+  


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Unified Alerting require empty frames to include no `data` field so I modified Azure Monitor Logs to check if there are rows in the response to return an empty frame.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #48072

**Special notes for your reviewer**:

`ResponseTableToFrame` is being used both in Azure Monitor Logs and Azure Resource Graph but the signature was dependendant of a Logs response so I refactored it a bit to be generic.

