### PR TITLE
Login: Use normal login url for login and use referrer to set redirect_to cookie

### DIFF
--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -77,7 +77,18 @@ func (hs *HTTPServer) CookieOptionsFromCfg() cookies.CookieOptions {
 	}
 }
 
+func (hs *HTTPServer) setLoginRedirectToCookie(c *models.ReqContext) {
+	referrer := c.Req.Header.Get("Referer")
+
+	if referrer != "" && strings.HasPrefix(referrer, hs.Cfg.AppURL) {
+		relativeUrl := hs.Cfg.AppSubURL + "/" + strings.TrimPrefix(referrer, hs.Cfg.AppURL)
+		cookies.WriteCookie(c.Resp, "redirect_to", url.QueryEscape(relativeUrl), 0, nil)
+	}
+}
+
 func (hs *HTTPServer) LoginView(c *models.ReqContext) {
+	hs.setLoginRedirectToCookie(c)
+
 	viewData, err := setIndexViewData(hs, c)
 	if err != nil {
 		c.Handle(hs.Cfg, 500, "Failed to get settings", err)

--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -3,7 +3,6 @@ package middleware
 import (
 	"errors"
 	"net/url"
-	"regexp"
 	"strconv"
 	"strings"
 
@@ -64,16 +63,7 @@ func writeRedirectCookie(c *models.ReqContext) {
 		redirectTo = setting.AppSubUrl + c.Req.RequestURI
 	}
 
-	// remove any forceLogin=true params
-	redirectTo = removeForceLoginParams(redirectTo)
-
 	cookies.WriteCookie(c.Resp, "redirect_to", url.QueryEscape(redirectTo), 0, nil)
-}
-
-var forceLoginParamsRegexp = regexp.MustCompile(`&?forceLogin=true`)
-
-func removeForceLoginParams(str string) string {
-	return forceLoginParamsRegexp.ReplaceAllString(str, "")
 }
 
 func EnsureEditorOrViewerCanEdit(c *models.ReqContext) {
@@ -101,14 +91,12 @@ func Auth(options *AuthOptions) web.Handler {
 	return func(c *models.ReqContext) {
 		forceLogin := false
 		if c.AllowAnonymous {
-			forceLogin = shouldForceLogin(c)
-			if !forceLogin {
-				orgIDValue := c.Req.URL.Query().Get("orgId")
-				orgID, err := strconv.ParseInt(orgIDValue, 10, 64)
-				if err == nil && orgID > 0 && orgID != c.OrgID {
-					forceLogin = true
-				}
+			orgIDValue := c.Req.URL.Query().Get("orgId")
+			orgID, err := strconv.ParseInt(orgIDValue, 10, 64)
+			if err == nil && orgID > 0 && orgID != c.OrgID {
+				forceLogin = true
 			}
+
 		}
 
 		requireLogin := !c.AllowAnonymous || forceLogin || options.ReqNoAnonynmous

--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -125,6 +125,18 @@ func (s *ServiceImpl) GetNavTree(c *models.ReqContext, hasEditPerm bool, prefs *
 		treeRoot.AddSection(s.getProfileNode(c))
 	}
 
+	if !c.IsSignedIn {
+		treeRoot.AddSection(&navtree.NavLink{
+			Text:       "Sign in",
+			Id:         "signin",
+			Icon:       "signout",
+			Section:    navtree.NavSectionConfig,
+			SortWeight: navtree.WeightProfile,
+			Url:        s.cfg.AppSubURL + "/login",
+			Target:     "_self",
+		})
+	}
+
 	_, uaIsDisabledForOrg := s.cfg.UnifiedAlerting.DisabledOrgs[c.OrgID]
 	uaVisibleForOrg := s.cfg.UnifiedAlerting.IsEnabled() && !uaIsDisabledForOrg
 

--- a/public/app/core/components/AppChrome/TopBar/TopNavBarMenu.tsx
+++ b/public/app/core/components/AppChrome/TopBar/TopNavBarMenu.tsx
@@ -2,7 +2,6 @@ import { css } from '@emotion/css';
 import { i18n } from '@lingui/core';
 import { cloneDeep } from 'lodash';
 import React from 'react';
-import { useLocation } from 'react-router-dom';
 
 import { GrafanaTheme2, NavModelItem } from '@grafana/data';
 import { Menu, MenuItem, useStyles2 } from '@grafana/ui';
@@ -16,8 +15,7 @@ export interface TopNavBarMenuProps {
 
 export function TopNavBarMenu({ node: nodePlain }: TopNavBarMenuProps) {
   const styles = useStyles2(getStyles);
-  const location = useLocation();
-  const enriched = enrichConfigItems([cloneDeep(nodePlain)], location);
+  const enriched = enrichConfigItems([cloneDeep(nodePlain)]);
   const node = enrichWithInteractionTracking(enriched[0], false);
 
   if (!node) {

--- a/public/app/core/components/AppChrome/TopSearchBar.tsx
+++ b/public/app/core/components/AppChrome/TopSearchBar.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import React from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { Dropdown, Icon, Tooltip, useStyles2 } from '@grafana/ui';
+import { Dropdown, Icon, useStyles2 } from '@grafana/ui';
 import { contextSrv } from 'app/core/core';
 import { useSelector } from 'app/types';
 
@@ -17,7 +17,6 @@ export function TopSearchBar() {
 
   const helpNode = navIndex['help'];
   const profileNode = navIndex['profile'];
-  const signInNode = navIndex['signin'];
 
   return (
     <div className={styles.container}>
@@ -38,12 +37,10 @@ export function TopSearchBar() {
           </Dropdown>
         )}
         <NewsContainer buttonCss={styles.actionItem} />
-        {signInNode && (
-          <Tooltip placement="bottom" content="Sign in">
-            <a className={styles.actionItem} href={signInNode.url} target={signInNode.target}>
-              {signInNode.icon && <Icon name={signInNode.icon} size="lg" />}
-            </a>
-          </Tooltip>
+        {!contextSrv.user.isSignedIn && (
+          <a className={styles.signIn} href="login" target="_self">
+            Sign in
+          </a>
         )}
         {profileNode && (
           <Dropdown overlay={<TopNavBarMenu node={profileNode} />}>
@@ -73,11 +70,13 @@ const getStyles = (theme: GrafanaTheme2) => {
     logo: css({
       display: 'flex',
     }),
+    signIn: css({}),
     searchWrapper: css({}),
     searchInput: css({}),
     actions: css({
       display: 'flex',
       gap: theme.spacing(1),
+      alignItems: 'center',
       justifyContent: 'flex-end',
     }),
     actionItem: css({

--- a/public/app/core/components/MegaMenu/MegaMenu.tsx
+++ b/public/app/core/components/MegaMenu/MegaMenu.tsx
@@ -31,8 +31,7 @@ export const MegaMenu = React.memo<Props>(({ onClose, searchBarHidden }) => {
     .filter((item) => item.section === NavSection.Plugin)
     .map((item) => enrichWithInteractionTracking(item, true));
   const configItems = enrichConfigItems(
-    navTree.filter((item) => item.section === NavSection.Config && item && item.id !== 'help' && item.id !== 'profile'),
-    location
+    navTree.filter((item) => item.section === NavSection.Config && item && item.id !== 'help' && item.id !== 'profile')
   ).map((item) => enrichWithInteractionTracking(item, true));
 
   const navItems = [...coreItems, ...pluginItems, ...configItems];

--- a/public/app/core/components/NavBar/NavBar.tsx
+++ b/public/app/core/components/NavBar/NavBar.tsx
@@ -69,10 +69,9 @@ export const NavBar = React.memo(() => {
   const pluginItems = navTree
     .filter((item) => item.section === NavSection.Plugin)
     .map((item) => enrichWithInteractionTracking(item, menuOpen));
-  const configItems = enrichConfigItems(
-    navTree.filter((item) => item.section === NavSection.Config),
-    location
-  ).map((item) => enrichWithInteractionTracking(item, menuOpen));
+  const configItems = enrichConfigItems(navTree.filter((item) => item.section === NavSection.Config)).map((item) =>
+    enrichWithInteractionTracking(item, menuOpen)
+  );
 
   const activeItem = isSearchActive(location) ? searchItem : getActiveItem(navTree, location.pathname);
 

--- a/public/app/core/components/NavBar/utils.test.ts
+++ b/public/app/core/components/NavBar/utils.test.ts
@@ -1,47 +1,14 @@
-import { Location } from 'history';
-
 import { GrafanaConfig, locationUtil, NavModelItem } from '@grafana/data';
 import { ContextSrv, setContextSrv } from 'app/core/services/context_srv';
 
-import { updateConfig } from '../../config';
-
-import { enrichConfigItems, getActiveItem, getForcedLoginUrl, isMatchOrChildMatch, isSearchActive } from './utils';
+import { enrichConfigItems, getActiveItem, isMatchOrChildMatch, isSearchActive } from './utils';
 
 jest.mock('../../app_events', () => ({
   publish: jest.fn(),
 }));
 
-describe('getForcedLoginUrl', () => {
-  it.each`
-    appSubUrl          | url                    | expected
-    ${''}              | ${'/whatever?a=1&b=2'} | ${'/whatever?a=1&b=2&forceLogin=true'}
-    ${'/grafana'}      | ${'/whatever?a=1&b=2'} | ${'/grafana/whatever?a=1&b=2&forceLogin=true'}
-    ${'/grafana/test'} | ${'/whatever?a=1&b=2'} | ${'/grafana/test/whatever?a=1&b=2&forceLogin=true'}
-    ${'/grafana'}      | ${''}                  | ${'/grafana?forceLogin=true'}
-    ${'/grafana'}      | ${'/whatever'}         | ${'/grafana/whatever?forceLogin=true'}
-    ${'/grafana'}      | ${'/whatever/'}        | ${'/grafana/whatever/?forceLogin=true'}
-  `(
-    "when appUrl set to '$appUrl' and appSubUrl set to '$appSubUrl' then result should be '$expected'",
-    ({ appSubUrl, url, expected }) => {
-      updateConfig({
-        appSubUrl,
-      });
-
-      const result = getForcedLoginUrl(url);
-
-      expect(result).toBe(expected);
-    }
-  );
-});
-
 describe('enrichConfigItems', () => {
   let mockItems: NavModelItem[];
-  const mockLocation: Location<unknown> = {
-    hash: '',
-    pathname: '/',
-    search: '',
-    state: '',
-  };
 
   beforeEach(() => {
     mockItems = [
@@ -62,7 +29,7 @@ describe('enrichConfigItems', () => {
     const contextSrv = new ContextSrv();
     contextSrv.user.isSignedIn = false;
     setContextSrv(contextSrv);
-    const enrichedConfigItems = enrichConfigItems(mockItems, mockLocation);
+    const enrichedConfigItems = enrichConfigItems(mockItems);
     const signInNode = enrichedConfigItems.find((item) => item.id === 'signin');
     expect(signInNode).toBeDefined();
   });
@@ -71,7 +38,7 @@ describe('enrichConfigItems', () => {
     const contextSrv = new ContextSrv();
     contextSrv.user.isSignedIn = true;
     setContextSrv(contextSrv);
-    const enrichedConfigItems = enrichConfigItems(mockItems, mockLocation);
+    const enrichedConfigItems = enrichConfigItems(mockItems);
     const signInNode = enrichedConfigItems.find((item) => item.id === 'signin');
     expect(signInNode).toBeDefined();
   });
@@ -80,7 +47,7 @@ describe('enrichConfigItems', () => {
     const contextSrv = new ContextSrv();
     contextSrv.user.orgCount = 1;
     setContextSrv(contextSrv);
-    const enrichedConfigItems = enrichConfigItems(mockItems, mockLocation);
+    const enrichedConfigItems = enrichConfigItems(mockItems);
     const profileNode = enrichedConfigItems.find((item) => item.id === 'profile');
     expect(profileNode!.children).toBeUndefined();
   });
@@ -89,7 +56,7 @@ describe('enrichConfigItems', () => {
     const contextSrv = new ContextSrv();
     contextSrv.user.orgCount = 2;
     setContextSrv(contextSrv);
-    const enrichedConfigItems = enrichConfigItems(mockItems, mockLocation);
+    const enrichedConfigItems = enrichConfigItems(mockItems);
     const profileNode = enrichedConfigItems.find((item) => item.id === 'profile');
     expect(profileNode!.children).toContainEqual(
       expect.objectContaining({
@@ -101,7 +68,7 @@ describe('enrichConfigItems', () => {
   it('enhances the help node with extra child links', () => {
     const contextSrv = new ContextSrv();
     setContextSrv(contextSrv);
-    const enrichedConfigItems = enrichConfigItems(mockItems, mockLocation);
+    const enrichedConfigItems = enrichConfigItems(mockItems);
     const helpNode = enrichedConfigItems.find((item) => item.id === 'help');
     expect(helpNode!.children).toContainEqual(
       expect.objectContaining({

--- a/public/app/core/components/NavBar/utils.ts
+++ b/public/app/core/components/NavBar/utils.ts
@@ -1,8 +1,7 @@
 import { Location } from 'history';
 
-import { locationUtil, NavModelItem, NavSection } from '@grafana/data';
+import { locationUtil, NavModelItem } from '@grafana/data';
 import { reportInteraction } from '@grafana/runtime';
-import { getConfig } from 'app/core/config';
 import { contextSrv } from 'app/core/services/context_srv';
 
 import { ShowModalReactEvent } from '../../../types/events';
@@ -16,15 +15,8 @@ export const NAV_MENU_PORTAL_CONTAINER_ID = 'navbar-menu-portal-container';
 
 export const getNavMenuPortalContainer = () => document.getElementById(NAV_MENU_PORTAL_CONTAINER_ID) ?? document.body;
 
-export const getForcedLoginUrl = (url: string) => {
-  const queryParams = new URLSearchParams(url.split('?')[1]);
-  queryParams.append('forceLogin', 'true');
-
-  return `${getConfig().appSubUrl}${url.split('?')[0]}?${queryParams.toString()}`;
-};
-
-export const enrichConfigItems = (items: NavModelItem[], location: Location<unknown>) => {
-  const { isSignedIn, user } = contextSrv;
+export const enrichConfigItems = (items: NavModelItem[]) => {
+  const { user } = contextSrv;
   const onOpenShortcuts = () => {
     appEvents.publish(new ShowModalReactEvent({ component: HelpModal }));
   };
@@ -39,19 +31,6 @@ export const enrichConfigItems = (items: NavModelItem[], location: Location<unkn
       profileNode.showOrgSwitcher = true;
       profileNode.subTitle = `Organization: ${user?.orgName}`;
     }
-  }
-
-  if (!isSignedIn) {
-    const forcedLoginUrl = getForcedLoginUrl(location.pathname + location.search);
-
-    items.unshift({
-      icon: 'signout',
-      id: 'signin',
-      section: NavSection.Config,
-      target: '_self',
-      text: 'Sign in',
-      url: forcedLoginUrl,
-    });
   }
 
   items.forEach((link) => {
@@ -81,6 +60,7 @@ export const enrichConfigItems = (items: NavModelItem[], location: Location<unkn
       ];
     }
   });
+
   return items;
 };
 


### PR DESCRIPTION
Currently, the login URL is any url you are at with the `forceLogin=true` query parameter appended. This means the login url needs to be constantly updated in the frontend every time the URL changes. This query parameter is then checked in a backend http middleware. 

This removes that and just uses a normal login url but checks the referror http header, with strict validation that it needs to be part from Grafana (there is also existing validation on using redirect_to cookie) 

This is probably a bad idea, but it looks to have the same security implications given the validation we have for redirect_to cookie.

It simplies the frontend a great deal where the login link can just be a simple login link to `/login` instead of having to be constantly re-rendered every time any part of the url changes. 


