### PR TITLE
Navtree: Make it possible to configure standalone plugin pages

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1316,3 +1316,13 @@ full_reindex_interval = 5m
 # Defines the frequency of partial index updates based on recent changes such as dashboard updates.
 # This is a temporary settings that might be removed in the future.
 index_update_interval = 10s
+
+
+# Move an app plugin referenced by its id (including all its pages) to a specific navigation section 
+# Dependencies: needs the `topnav` feature to be enabled
+# Format: <Plugin ID> = <Section ID> <Sort Weight> 
+[navigation.app_sections]
+
+# Move a specific app plugin page (referenced by its `path` field) to a specific navigation section 
+# Format: <Page URL> = <Section ID> <Sort Weight> 
+[navigation.app_standalone_pages]

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -1233,7 +1233,7 @@
 # Dependencies: needs the `topnav` feature to be enabled
 [navigation.app_sections]
 # The following will move an app plugin with the id of `my-app-id` under the `starred` section
-# my-app-id = starred
+# my-app-id = admin
 
 # Move a specific app plugin page (referenced by its `path` field) to a specific navigation section 
 [navigation.app_standalone_pages]

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -1228,3 +1228,14 @@
 
 # Enable or disable loading other base map layers
 ;enable_custom_baselayers = true
+
+# Move an app plugin referenced by its id (including all its pages) to a specific navigation section 
+# Dependencies: needs the `topnav` feature to be enabled
+[navigation.app_sections]
+# The following will move an app plugin with the id of `my-app-id` under the `starred` section
+# my-app-id = starred
+
+# Move a specific app plugin page (referenced by its `path` field) to a specific navigation section 
+[navigation.app_standalone_pages]
+# The following will move the page with the path "/a/my-app-id/starred-content" from `my-app-id` to the `starred` section
+# /a/my-app-id/starred-content = starred

--- a/pkg/services/navtree/navtreeimpl/applinks.go
+++ b/pkg/services/navtree/navtreeimpl/applinks.go
@@ -214,12 +214,13 @@ func (s *ServiceImpl) readNavigationSettings() {
 		"/a/grafana-auth-app": {SectionID: navtree.NavIDCfg, SortWeight: 7},
 	}
 
-	sec := s.cfg.Raw.Section("navigation.apps")
+	appSections := s.cfg.Raw.Section("navigation.app_sections")
+	appStandalonePages := s.cfg.Raw.Section("navigation.app_standalone_pages")
 
-	for _, key := range sec.Keys() {
+	for _, key := range appSections.Keys() {
 		pluginId := key.Name()
 		// Support <id> <weight> value
-		values := util.SplitString(sec.Key(key.Name()).MustString(""))
+		values := util.SplitString(appSections.Key(key.Name()).MustString(""))
 
 		appCfg := &NavigationAppConfig{SectionID: values[0]}
 		if len(values) > 1 {
@@ -229,5 +230,20 @@ func (s *ServiceImpl) readNavigationSettings() {
 		}
 
 		s.navigationAppConfig[pluginId] = *appCfg
+	}
+
+	for _, key := range appStandalonePages.Keys() {
+		url := key.Name()
+		// Support <id> <weight> value
+		values := util.SplitString(appStandalonePages.Key(key.Name()).MustString(""))
+
+		appCfg := &NavigationAppConfig{SectionID: values[0]}
+		if len(values) > 1 {
+			if weight, err := strconv.ParseInt(values[1], 10, 64); err == nil {
+				appCfg.SortWeight = weight
+			}
+		}
+
+		s.navigationAppPathConfig[url] = *appCfg
 	}
 }

--- a/pkg/services/navtree/navtreeimpl/applinks_test.go
+++ b/pkg/services/navtree/navtreeimpl/applinks_test.go
@@ -205,7 +205,7 @@ func TestReadingNavigationSettings(t *testing.T) {
 		require.Equal(t, int64(0), service.navigationAppConfig["grafana-k8s-app"].SortWeight)
 		require.Equal(t, int64(12), service.navigationAppConfig["other-app"].SortWeight)
 
-		require.Equal(t, "admin", service.navigationAppPathConfig["/a/grafana-k8s/foo"].SectionID)
-		require.Equal(t, int64(30), service.navigationAppPathConfig["/a/grafana-k8s/foo"].SortWeight)
+		require.Equal(t, "admin", service.navigationAppPathConfig["/a/grafana-k8s-app/foo"].SectionID)
+		require.Equal(t, int64(30), service.navigationAppPathConfig["/a/grafana-k8s-app/foo"].SortWeight)
 	})
 }

--- a/pkg/services/navtree/navtreeimpl/applinks_test.go
+++ b/pkg/services/navtree/navtreeimpl/applinks_test.go
@@ -180,7 +180,7 @@ func TestReadingNavigationSettings(t *testing.T) {
 			cfg: setting.NewCfg(),
 		}
 
-		_, _ = service.cfg.Raw.NewSection("navigation.apps")
+		_, _ = service.cfg.Raw.NewSection("navigation.app_sections")
 		service.readNavigationSettings()
 
 		require.Equal(t, "monitoring", service.navigationAppConfig["grafana-k8s-app"].SectionID)
@@ -191,9 +191,11 @@ func TestReadingNavigationSettings(t *testing.T) {
 			cfg: setting.NewCfg(),
 		}
 
-		sec, _ := service.cfg.Raw.NewSection("navigation.apps")
-		_, _ = sec.NewKey("grafana-k8s-app", "dashboards")
-		_, _ = sec.NewKey("other-app", "admin 12")
+		appSections, _ := service.cfg.Raw.NewSection("navigation.app_sections")
+		appStandalonePages, _ := service.cfg.Raw.NewSection("navigation.app_standalone_pages")
+		_, _ = appSections.NewKey("grafana-k8s-app", "dashboards")
+		_, _ = appSections.NewKey("other-app", "admin 12")
+		_, _ = appStandalonePages.NewKey("/a/grafana-k8s-app/foo", "admin 30")
 
 		service.readNavigationSettings()
 
@@ -202,5 +204,8 @@ func TestReadingNavigationSettings(t *testing.T) {
 
 		require.Equal(t, int64(0), service.navigationAppConfig["grafana-k8s-app"].SortWeight)
 		require.Equal(t, int64(12), service.navigationAppConfig["other-app"].SortWeight)
+
+		require.Equal(t, "admin", service.navigationAppPathConfig["/a/grafana-k8s/foo"].SectionID)
+		require.Equal(t, int64(30), service.navigationAppPathConfig["/a/grafana-k8s/foo"].SortWeight)
 	})
 }


### PR DESCRIPTION
**Related issue:** https://github.com/grafana/cloud-onboarding/issues/2273

### What changed?

This PR makes it possible to register standalone plugin pages under certain sections using the `[navigation.app_standalone_pages]` config section.