### PR TITLE
Alerting: Improve UI for making more clear that evaluation interval belongs to the group

### DIFF
--- a/public/app/features/alerting/unified/RuleEditor.test.tsx
+++ b/public/app/features/alerting/unified/RuleEditor.test.tsx
@@ -24,6 +24,7 @@ import { discoverFeatures } from './api/buildInfo';
 import { fetchRulerRules, fetchRulerRulesGroup, fetchRulerRulesNamespace, setRulerRuleGroup } from './api/ruler';
 import { ExpressionEditorProps } from './components/rule-editor/ExpressionEditor';
 import { disableRBAC, mockDataSource, MockDataSourceSrv, mockFolder } from './mocks';
+import { fetchRulerRulesIfNotFetchedYet } from './state/actions';
 import * as config from './utils/config';
 import { DataSourceType, GRAFANA_RULES_SOURCE_NAME } from './utils/datasource';
 import { getDefaultQueries } from './utils/rule-form';
@@ -57,6 +58,7 @@ const mocks = {
     setRulerRuleGroup: jest.mocked(setRulerRuleGroup),
     fetchRulerRulesNamespace: jest.mocked(fetchRulerRulesNamespace),
     fetchRulerRules: jest.mocked(fetchRulerRules),
+    fetchRulerRulesIfNotFetchedYet: jest.mocked(fetchRulerRulesIfNotFetchedYet),
   },
 };
 
@@ -226,7 +228,7 @@ describe.skip('RuleEditor', () => {
       rules: [],
     });
     mocks.api.fetchRulerRules.mockResolvedValue({
-      namespace1: [
+      'Folder A': [
         {
           name: 'group1',
           rules: [],
@@ -270,9 +272,9 @@ describe.skip('RuleEditor', () => {
 
     const folderInput = await ui.inputs.folder.find();
     await clickSelectOption(folderInput, 'Folder A');
-
-    const groupInput = screen.getByRole('textbox', { name: /^Group/ });
-    await userEvent.type(groupInput, 'my group');
+    const groupInput = await ui.inputs.group.find();
+    await userEvent.click(byRole('combobox').get(groupInput));
+    await clickSelectOption(groupInput, 'group1 (1m)');
 
     await userEvent.type(ui.inputs.annotationValue(0).get(), 'some summary');
     await userEvent.type(ui.inputs.annotationValue(1).get(), 'some description');
@@ -293,7 +295,7 @@ describe.skip('RuleEditor', () => {
       'Folder A',
       {
         interval: '1m',
-        name: 'my group',
+        name: 'group1',
         rules: [
           {
             annotations: { description: 'some description', summary: 'some summary' },

--- a/public/app/features/alerting/unified/components/rule-editor/AlertRuleForm.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AlertRuleForm.tsx
@@ -213,8 +213,12 @@ export const AlertRuleForm: FC<Props> = ({ existing }) => {
               <QueryAndExpressionsStep editingExistingRule={!!existing} />
               {showStep2 && (
                 <>
-                  {type === RuleFormType.grafana ? <GrafanaEvaluationBehavior /> : <CloudEvaluationBehavior />}
-                  <DetailsStep initialFolder={defaultValues.folder} />
+                  {type === RuleFormType.grafana ? (
+                    <GrafanaEvaluationBehavior initialFolder={defaultValues.folder} />
+                  ) : (
+                    <CloudEvaluationBehavior />
+                  )}
+                  <DetailsStep />
                   <NotificationsStep />
                 </>
               )}

--- a/public/app/features/alerting/unified/components/rule-editor/AlertRuleForm.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AlertRuleForm.tsx
@@ -19,6 +19,7 @@ import { RuleFormType, RuleFormValues } from '../../types/rule-form';
 import { initialAsyncRequestState } from '../../utils/redux';
 import { getDefaultFormValues, getDefaultQueries, rulerRuleToFormValues } from '../../utils/rule-form';
 import * as ruleId from '../../utils/rule-id';
+import { parseDurationToMilliseconds } from '../../utils/time';
 
 import { CloudEvaluationBehavior } from './CloudEvaluationBehavior';
 import { DetailsStep } from './DetailsStep';
@@ -136,6 +137,7 @@ export const AlertRuleForm: FC<Props> = ({ existing }) => {
         },
         existing,
         redirectOnSave: exitOnSave ? returnTo : undefined,
+        initialAlertRuleName: defaultValues.name,
       })
     );
   };
@@ -214,7 +216,11 @@ export const AlertRuleForm: FC<Props> = ({ existing }) => {
               {showStep2 && (
                 <>
                   {type === RuleFormType.grafana ? (
-                    <GrafanaEvaluationBehavior initialFolder={defaultValues.folder} />
+                    <GrafanaEvaluationBehavior
+                      initialFolder={defaultValues.folder}
+                      initialRuleName={defaultValues.name}
+                      initialEvaluateEvery={parseDurationToMilliseconds(defaultValues.evaluateEvery)}
+                    />
                   ) : (
                     <CloudEvaluationBehavior />
                   )}

--- a/public/app/features/alerting/unified/components/rule-editor/AlertRuleForm.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AlertRuleForm.tsx
@@ -19,7 +19,6 @@ import { RuleFormType, RuleFormValues } from '../../types/rule-form';
 import { initialAsyncRequestState } from '../../utils/redux';
 import { getDefaultFormValues, getDefaultQueries, rulerRuleToFormValues } from '../../utils/rule-form';
 import * as ruleId from '../../utils/rule-id';
-import { parseDurationToMilliseconds } from '../../utils/time';
 
 import { CloudEvaluationBehavior } from './CloudEvaluationBehavior';
 import { DetailsStep } from './DetailsStep';
@@ -77,6 +76,8 @@ const AlertRuleNameInput = () => {
   );
 };
 
+export const MINUTE = '1m';
+
 type Props = {
   existing?: RuleWithLocation;
 };
@@ -87,6 +88,7 @@ export const AlertRuleForm: FC<Props> = ({ existing }) => {
   const notifyApp = useAppNotification();
   const [queryParams] = useQueryParams();
   const [showEditYaml, setShowEditYaml] = useState(false);
+  const [evaluateEvery, setEvaluateEvery] = useState(existing?.group.interval ?? MINUTE);
 
   const returnTo: string = (queryParams['returnTo'] as string | undefined) ?? '/alerting/list';
   const [showDeleteModal, setShowDeleteModal] = useState<boolean>(false);
@@ -101,8 +103,9 @@ export const AlertRuleForm: FC<Props> = ({ existing }) => {
       condition: 'C',
       ...(queryParams['defaults'] ? JSON.parse(queryParams['defaults'] as string) : {}),
       type: RuleFormType.grafana,
+      evaluateEvery: evaluateEvery,
     };
-  }, [existing, queryParams]);
+  }, [existing, queryParams, evaluateEvery]);
 
   const formAPI = useForm<RuleFormValues>({
     mode: 'onSubmit',
@@ -138,6 +141,7 @@ export const AlertRuleForm: FC<Props> = ({ existing }) => {
         existing,
         redirectOnSave: exitOnSave ? returnTo : undefined,
         initialAlertRuleName: defaultValues.name,
+        evaluateEvery: evaluateEvery,
       })
     );
   };
@@ -218,8 +222,8 @@ export const AlertRuleForm: FC<Props> = ({ existing }) => {
                   {type === RuleFormType.grafana ? (
                     <GrafanaEvaluationBehavior
                       initialFolder={defaultValues.folder}
-                      initialRuleName={defaultValues.name}
-                      initialEvaluateEvery={parseDurationToMilliseconds(defaultValues.evaluateEvery)}
+                      evaluateEvery={evaluateEvery}
+                      setEvaluateEvery={setEvaluateEvery}
                     />
                   ) : (
                     <CloudEvaluationBehavior />

--- a/public/app/features/alerting/unified/components/rule-editor/AnnotationsField.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AnnotationsField.tsx
@@ -99,7 +99,7 @@ const AnnotationsField = () => {
 
 const getStyles = (theme: GrafanaTheme2) => ({
   annotationValueInput: css`
-    width: 426px;
+    width: 394px;
   `,
   textarea: css`
     height: 76px;

--- a/public/app/features/alerting/unified/components/rule-editor/DetailsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/DetailsStep.tsx
@@ -1,29 +1,32 @@
 import { css } from '@emotion/css';
-import classNames from 'classnames';
-import React, { useCallback } from 'react';
+import React from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { Stack } from '@grafana/experimental';
-import { useStyles2, Field, Input, InputControl, Label, Tooltip, Icon } from '@grafana/ui';
-import { FolderPickerFilter } from 'app/core/components/Select/FolderPicker';
-import { contextSrv } from 'app/core/services/context_srv';
-import { DashboardSearchHit } from 'app/features/search/types';
-import { AccessControlAction } from 'app/types';
+import { useStyles2, Field, Input } from '@grafana/ui';
 
-import { RuleForm, RuleFormType, RuleFormValues } from '../../types/rule-form';
+import { RuleFormType, RuleFormValues } from '../../types/rule-form';
 
 import AnnotationsField from './AnnotationsField';
 import { GroupAndNamespaceFields } from './GroupAndNamespaceFields';
 import { RuleEditorSection } from './RuleEditorSection';
-import { RuleFolderPicker, Folder, containsSlashes } from './RuleFolderPicker';
 import { checkForPathSeparator } from './util';
 
+<<<<<<< HEAD
 interface DetailsStepProps {
   initialFolder: RuleForm | null;
 }
 
 export const DetailsStep = ({ initialFolder }: DetailsStepProps) => {
+=======
+const recordingRuleNameValidationPattern = {
+  message:
+    'Recording rule name must be valid metric name. It may only contain letters, numbers, and colons. It may not contain whitespace.',
+  value: /^[a-zA-Z_:][a-zA-Z0-9_:]*$/,
+};
+
+export function DetailsStep() {
+>>>>>>> feb800ed51 (Move folder and group fields to the evaluation section in the alert form)
   const {
     register,
     watch,
@@ -35,8 +38,6 @@ export const DetailsStep = ({ initialFolder }: DetailsStepProps) => {
   const ruleFormType = watch('type');
   const dataSourceName = watch('dataSourceName');
   const type = watch('type');
-
-  const folderFilter = useRuleFolderFilter(initialFolder);
 
   return (
     <RuleEditorSection
@@ -53,119 +54,17 @@ export const DetailsStep = ({ initialFolder }: DetailsStepProps) => {
       {(ruleFormType === RuleFormType.cloudRecording || ruleFormType === RuleFormType.cloudAlerting) &&
         dataSourceName && <GroupAndNamespaceFields rulesSourceName={dataSourceName} />}
 
-      {ruleFormType === RuleFormType.grafana && (
-        <div className={classNames([styles.flexRow, styles.alignBaseline])}>
-          <Field
-            label={
-              <Label htmlFor="folder" description={'Select a folder to store your rule.'}>
-                <Stack gap={0.5}>
-                  Folder
-                  <Tooltip
-                    placement="top"
-                    content={
-                      <div>
-                        Each folder has unique folder permission. When you store multiple rules in a folder, the folder
-                        access permissions get assigned to the rules.
-                      </div>
-                    }
-                  >
-                    <Icon name="info-circle" size="xs" />
-                  </Tooltip>
-                </Stack>
-              </Label>
-            }
-            className={styles.formInput}
-            error={errors.folder?.message}
-            invalid={!!errors.folder?.message}
-            data-testid="folder-picker"
-          >
-            <InputControl
-              render={({ field: { ref, ...field } }) => (
-                <RuleFolderPicker
-                  inputId="folder"
-                  {...field}
-                  enableCreateNew={contextSrv.hasPermission(AccessControlAction.FoldersCreate)}
-                  enableReset={true}
-                  filter={folderFilter}
-                  dissalowSlashes={true}
-                />
-              )}
-              name="folder"
-              rules={{
-                required: { value: true, message: 'Please select a folder' },
-                validate: {
-                  pathSeparator: (folder: Folder) => checkForPathSeparator(folder.title),
-                },
-              }}
-            />
-          </Field>
-          <Field
-            label="Group"
-            data-testid="group-picker"
-            description="Rules within the same group are evaluated after the same time interval."
-            className={styles.formInput}
-            error={errors.group?.message}
-            invalid={!!errors.group?.message}
-          >
-            <Input
-              id="group"
-              {...register('group', {
-                required: { value: true, message: 'Must enter a group name' },
-              })}
-            />
-          </Field>
-        </div>
-      )}
       {type !== RuleFormType.cloudRecording && <AnnotationsField />}
     </RuleEditorSection>
   );
-};
-
-const useRuleFolderFilter = (existingRuleForm: RuleForm | null) => {
-  const isSearchHitAvailable = useCallback(
-    (hit: DashboardSearchHit) => {
-      const rbacDisabledFallback = contextSrv.hasEditPermissionInFolders;
-
-      const canCreateRuleInFolder = contextSrv.hasAccessInMetadata(
-        AccessControlAction.AlertingRuleCreate,
-        hit,
-        rbacDisabledFallback
-      );
-
-      const canUpdateInCurrentFolder =
-        existingRuleForm &&
-        hit.folderId === existingRuleForm.id &&
-        contextSrv.hasAccessInMetadata(AccessControlAction.AlertingRuleUpdate, hit, rbacDisabledFallback);
-      return canCreateRuleInFolder || canUpdateInCurrentFolder;
-    },
-    [existingRuleForm]
-  );
-
-  return useCallback<FolderPickerFilter>(
-    (folderHits) =>
-      folderHits
-        .filter(isSearchHitAvailable)
-        .filter((value: DashboardSearchHit) => !containsSlashes(value.title ?? '')),
-    [isSearchHitAvailable]
-  );
-};
+}
 
 const getStyles = (theme: GrafanaTheme2) => ({
-  alignBaseline: css`
-    align-items: baseline;
-    margin-bottom: ${theme.spacing(3)};
-  `,
   formInput: css`
     width: 275px;
 
     & + & {
       margin-left: ${theme.spacing(3)};
     }
-  `,
-  flexRow: css`
-    display: flex;
-    flex-direction: row;
-    justify-content: flex-start;
-    align-items: end;
   `,
 });

--- a/public/app/features/alerting/unified/components/rule-editor/DetailsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/DetailsStep.tsx
@@ -1,39 +1,14 @@
-import { css } from '@emotion/css';
 import React from 'react';
 import { useFormContext } from 'react-hook-form';
-
-import { GrafanaTheme2 } from '@grafana/data';
-import { useStyles2, Field, Input } from '@grafana/ui';
 
 import { RuleFormType, RuleFormValues } from '../../types/rule-form';
 
 import AnnotationsField from './AnnotationsField';
 import { GroupAndNamespaceFields } from './GroupAndNamespaceFields';
 import { RuleEditorSection } from './RuleEditorSection';
-import { checkForPathSeparator } from './util';
-
-<<<<<<< HEAD
-interface DetailsStepProps {
-  initialFolder: RuleForm | null;
-}
-
-export const DetailsStep = ({ initialFolder }: DetailsStepProps) => {
-=======
-const recordingRuleNameValidationPattern = {
-  message:
-    'Recording rule name must be valid metric name. It may only contain letters, numbers, and colons. It may not contain whitespace.',
-  value: /^[a-zA-Z_:][a-zA-Z0-9_:]*$/,
-};
 
 export function DetailsStep() {
->>>>>>> feb800ed51 (Move folder and group fields to the evaluation section in the alert form)
-  const {
-    register,
-    watch,
-    formState: { errors },
-  } = useFormContext<RuleFormValues & { location?: string }>();
-
-  const styles = useStyles2(getStyles);
+  const { watch } = useFormContext<RuleFormValues & { location?: string }>();
 
   const ruleFormType = watch('type');
   const dataSourceName = watch('dataSourceName');
@@ -58,13 +33,3 @@ export function DetailsStep() {
     </RuleEditorSection>
   );
 }
-
-const getStyles = (theme: GrafanaTheme2) => ({
-  formInput: css`
-    width: 275px;
-
-    & + & {
-      margin-left: ${theme.spacing(3)};
-    }
-  `,
-});

--- a/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
@@ -1,5 +1,4 @@
 import { css } from '@emotion/css';
-import classNames from 'classnames';
 import React, { useState, useRef, useEffect, useCallback, useMemo } from 'react';
 import { useFormContext } from 'react-hook-form';
 
@@ -122,7 +121,7 @@ export function FolderAndGroup({ initialFolder }: FolderAndGroupProps) {
   );
 
   return (
-    <div className={classNames([styles.flexRow, styles.alignBaseline])}>
+    <div className={styles.container}>
       <Field
         label={
           <Label htmlFor="folder" description={'Select a folder to store your rule.'}>
@@ -211,19 +210,15 @@ export function FolderAndGroup({ initialFolder }: FolderAndGroupProps) {
   );
 }
 const getStyles = (theme: GrafanaTheme2) => ({
-  flexRow: css`
+  container: css`
     display: flex;
     flex-direction: row;
-    justify-content: flex-start;
-    align-items: flex-start;
-  `,
-  alignBaseline: css`
     align-items: baseline;
-    margin-bottom: ${theme.spacing(1)};
+    max-width: ${theme.breakpoints.values.sm}px;
+    justify-content: space-between;
   `,
   formInput: css`
     width: 275px;
-
     & + & {
       margin-left: ${theme.spacing(3)};
     }

--- a/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
@@ -116,7 +116,7 @@ export function FolderAndGroup({ initialFolder }: FolderAndGroupProps) {
       setSelectedGroup('');
     }
     initialRender.current = false;
-  }, [initialRender, folder, setSelectedGroup, group]);
+  }, [group, folder?.title]);
 
   const groupIsInGroupOptions = useCallback(
     (group_: string) => {
@@ -124,15 +124,6 @@ export function FolderAndGroup({ initialFolder }: FolderAndGroupProps) {
     },
     [groupOptions]
   );
-  const folderTilte = folder?.title ?? '';
-
-  useEffect(() => {
-    if (folderTilte && groupOptions && !groupIsInGroupOptions(selectedGroup)) {
-      setIsAddingGroup(false);
-      resetGroup();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [folderTilte]);
 
   return (
     <div className={classNames([styles.flexRow, styles.alignBaseline])}>
@@ -163,6 +154,13 @@ export function FolderAndGroup({ initialFolder }: FolderAndGroupProps) {
               enableReset={true}
               filter={folderFilter}
               dissalowSlashes={true}
+              onChange={({ title, id }) => {
+                field.onChange({ title, id });
+                if (!groupIsInGroupOptions(selectedGroup)) {
+                  setIsAddingGroup(false);
+                  resetGroup();
+                }
+              }}
             />
           )}
           name="folder"
@@ -189,6 +187,7 @@ export function FolderAndGroup({ initialFolder }: FolderAndGroupProps) {
               <LoadingPlaceholder text="Loading..." />
             ) : (
               <SelectWithAdd
+                key={`my_unique_select_key__${folder?.title ?? ''}`}
                 {...field}
                 options={groupOptions}
                 getOptionLabel={(option: SelectableValue<string>) =>

--- a/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
@@ -188,7 +188,6 @@ export function FolderAndGroup({ initialFolder }: FolderAndGroupProps) {
                 getOptionLabel={(option: SelectableValue<string>) =>
                   `${option.label}  (${getIntervalForGroup(groupsForFolder, option.label ?? '', folder?.title ?? '')})`
                 }
-                width={42}
                 value={selectedGroup}
                 custom={isAddingGroup}
                 onCustomChange={(custom: boolean) => setIsAddingGroup(custom)}

--- a/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
@@ -149,8 +149,8 @@ export function FolderAndGroup({ initialFolder }: FolderAndGroupProps) {
               enableReset={true}
               filter={folderFilter}
               dissalowSlashes={true}
-              onChange={({ title, id }) => {
-                field.onChange({ title, id });
+              onChange={({ title, uid }) => {
+                field.onChange({ title, uid });
                 if (!groupIsInGroupOptions(selectedGroup)) {
                   setIsAddingGroup(false);
                   resetGroup();

--- a/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
@@ -5,7 +5,7 @@ import { useFormContext } from 'react-hook-form';
 
 import { GrafanaTheme2, SelectableValue } from '@grafana/data';
 import { Stack } from '@grafana/experimental';
-import { Field, Icon, InputControl, Label, LoadingPlaceholder, Tooltip, useStyles2 } from '@grafana/ui';
+import { Field, InputControl, Label, LoadingPlaceholder, useStyles2 } from '@grafana/ui';
 import { FolderPickerFilter } from 'app/core/components/Select/FolderPicker';
 import { contextSrv } from 'app/core/core';
 import { DashboardSearchHit } from 'app/features/search/types';
@@ -16,6 +16,7 @@ import { useUnifiedAlertingSelector } from '../../hooks/useUnifiedAlertingSelect
 import { fetchRulerRulesIfNotFetchedYet } from '../../state/actions';
 import { RuleForm, RuleFormValues } from '../../types/rule-form';
 import { GRAFANA_RULES_SOURCE_NAME } from '../../utils/datasource';
+import { InfoIcon } from '../InfoIcon';
 
 import { getIntervalForGroup } from './GrafanaEvaluationBehavior';
 import { containsSlashes, Folder, RuleFolderPicker } from './RuleFolderPicker';
@@ -80,13 +81,6 @@ const useRuleFolderFilter = (existingRuleForm: RuleForm | null) => {
     [isSearchHitAvailable]
   );
 };
-function InfoIcon({ text }: { text: string }) {
-  return (
-    <Tooltip placement="top" content={<div>{text}</div>}>
-      <Icon name="info-circle" size="xs" />
-    </Tooltip>
-  );
-}
 
 export function FolderAndGroup({ initialFolder }: FolderAndGroupProps) {
   const {
@@ -96,8 +90,8 @@ export function FolderAndGroup({ initialFolder }: FolderAndGroupProps) {
   } = useFormContext<RuleFormValues>();
 
   const styles = useStyles2(getStyles);
-  const folderFilter = useRuleFolderFilter(initialFolder);
   const dispatch = useDispatch();
+  const folderFilter = useRuleFolderFilter(initialFolder);
   const [isAddingGroup, setIsAddingGroup] = useState(false);
 
   const folder = watch('folder');
@@ -107,11 +101,11 @@ export function FolderAndGroup({ initialFolder }: FolderAndGroupProps) {
 
   const { groupOptions, groupsForFolder, loading } = useGetGroupOptionsFromFolder(folder?.title ?? '');
 
+  useEffect(() => setSelectedGroup(group), [group, setSelectedGroup]);
+
   useEffect(() => {
     dispatch(fetchRulerRulesIfNotFetchedYet(GRAFANA_RULES_SOURCE_NAME));
   }, [dispatch]);
-
-  useEffect(() => setSelectedGroup(group), [group, setSelectedGroup]);
 
   const resetGroup = useCallback(() => {
     if (group && !initialRender.current && folder?.title) {

--- a/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
@@ -191,6 +191,7 @@ export function FolderAndGroup({ initialFolder }: FolderAndGroupProps) {
                 value={selectedGroup}
                 custom={isAddingGroup}
                 onCustomChange={(custom: boolean) => setIsAddingGroup(custom)}
+                placeholder="Evaluation group name"
                 onChange={(value: string) => {
                   field.onChange(value);
                   setSelectedGroup(value);

--- a/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
@@ -129,7 +129,7 @@ export function FolderAndGroup({ initialFolder }: FolderAndGroupProps) {
               Folder
               <InfoIcon
                 text={
-                  'Each folder has unique folder permission. When you store multiple rules in a folder, the folder access permissions get assigned to the rules.'
+                  'Each folder has unique folder permission. When you store multiple rules in a folder, the folder access permissions are assigned to the rules.'
                 }
               />
             </Stack>
@@ -160,7 +160,7 @@ export function FolderAndGroup({ initialFolder }: FolderAndGroupProps) {
           )}
           name="folder"
           rules={{
-            required: { value: true, message: 'Please select a folder' },
+            required: { value: true, message: 'Select a folder' },
             validate: {
               pathSeparator: (folder: Folder) => checkForPathSeparator(folder.title),
             },

--- a/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
@@ -111,6 +111,8 @@ export function FolderAndGroup({ initialFolder }: FolderAndGroupProps) {
     dispatch(fetchRulerRulesIfNotFetchedYet(GRAFANA_RULES_SOURCE_NAME));
   }, [dispatch]);
 
+  useEffect(() => setSelectedGroup(group), [group, setSelectedGroup]);
+
   const resetGroup = useCallback(() => {
     if (group && !initialRender.current && folder?.title) {
       setSelectedGroup('');

--- a/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
@@ -40,7 +40,7 @@ interface FolderAndGroupProps {
   initialFolder: RuleForm | null;
 }
 
-const useGetGroupOptionsFromFolder = (folderTilte: string) => {
+export const useGetGroupOptionsFromFolder = (folderTilte: string) => {
   const rulerRuleRequests = useUnifiedAlertingSelector((state) => state.rulerRules);
 
   const groupfoldersForGrafana = rulerRuleRequests[GRAFANA_RULES_SOURCE_NAME];

--- a/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
@@ -1,0 +1,236 @@
+import { css } from '@emotion/css';
+import classNames from 'classnames';
+import React, { useState, useRef, useEffect, useCallback, useMemo } from 'react';
+import { useFormContext } from 'react-hook-form';
+
+import { GrafanaTheme2, SelectableValue } from '@grafana/data';
+import { Stack } from '@grafana/experimental';
+import { Field, Icon, InputControl, Label, LoadingPlaceholder, Tooltip, useStyles2 } from '@grafana/ui';
+import { FolderPickerFilter } from 'app/core/components/Select/FolderPicker';
+import { contextSrv } from 'app/core/core';
+import { DashboardSearchHit } from 'app/features/search/types';
+import { AccessControlAction, useDispatch } from 'app/types';
+import { RulerRuleDTO, RulerRuleGroupDTO, RulerRulesConfigDTO } from 'app/types/unified-alerting-dto';
+
+import { useUnifiedAlertingSelector } from '../../hooks/useUnifiedAlertingSelector';
+import { fetchRulerRulesIfNotFetchedYet } from '../../state/actions';
+import { RuleForm, RuleFormValues } from '../../types/rule-form';
+import { GRAFANA_RULES_SOURCE_NAME } from '../../utils/datasource';
+
+import { getIntervalForGroup } from './GrafanaEvaluationBehavior';
+import { containsSlashes, Folder, RuleFolderPicker } from './RuleFolderPicker';
+import { SelectWithAdd } from './SelectWIthAdd';
+import { checkForPathSeparator } from './util';
+
+const useGetGroups = (groupfoldersForGrafana: RulerRulesConfigDTO | null | undefined, folderName: string) => {
+  const groupOptions = useMemo(() => {
+    const groupsForFolderResult: Array<RulerRuleGroupDTO<RulerRuleDTO>> = groupfoldersForGrafana
+      ? groupfoldersForGrafana[folderName] ?? []
+      : [];
+    return groupsForFolderResult.map((group) => group.name);
+  }, [groupfoldersForGrafana, folderName]);
+
+  return groupOptions;
+};
+
+function mapGroupsToOptions(groups: string[]): Array<SelectableValue<string>> {
+  return groups.map((group) => ({ label: group, value: group }));
+}
+interface FolderAndGroupProps {
+  initialFolder: RuleForm | null;
+}
+
+const useGetGroupOptionsFromFolder = (folderTilte: string) => {
+  const rulerRuleRequests = useUnifiedAlertingSelector((state) => state.rulerRules);
+
+  const groupfoldersForGrafana = rulerRuleRequests[GRAFANA_RULES_SOURCE_NAME];
+
+  const groupOptions: Array<SelectableValue<string>> = mapGroupsToOptions(
+    useGetGroups(groupfoldersForGrafana?.result, folderTilte)
+  );
+  const groupsForFolder = groupfoldersForGrafana?.result;
+  return { groupOptions, groupsForFolder, loading: groupfoldersForGrafana?.loading };
+};
+
+const useRuleFolderFilter = (existingRuleForm: RuleForm | null) => {
+  const isSearchHitAvailable = useCallback(
+    (hit: DashboardSearchHit) => {
+      const rbacDisabledFallback = contextSrv.hasEditPermissionInFolders;
+
+      const canCreateRuleInFolder = contextSrv.hasAccessInMetadata(
+        AccessControlAction.AlertingRuleCreate,
+        hit,
+        rbacDisabledFallback
+      );
+
+      const canUpdateInCurrentFolder =
+        existingRuleForm &&
+        hit.folderId === existingRuleForm.id &&
+        contextSrv.hasAccessInMetadata(AccessControlAction.AlertingRuleUpdate, hit, rbacDisabledFallback);
+      return canCreateRuleInFolder || canUpdateInCurrentFolder;
+    },
+    [existingRuleForm]
+  );
+
+  return useCallback<FolderPickerFilter>(
+    (folderHits) =>
+      folderHits
+        .filter(isSearchHitAvailable)
+        .filter((value: DashboardSearchHit) => !containsSlashes(value.title ?? '')),
+    [isSearchHitAvailable]
+  );
+};
+function InfoIcon({ text }: { text: string }) {
+  return (
+    <Tooltip placement="top" content={<div>{text}</div>}>
+      <Icon name="info-circle" size="xs" />
+    </Tooltip>
+  );
+}
+
+export function FolderAndGroup({ initialFolder }: FolderAndGroupProps) {
+  const {
+    formState: { errors },
+    watch,
+    control,
+  } = useFormContext<RuleFormValues>();
+
+  const styles = useStyles2(getStyles);
+  const folderFilter = useRuleFolderFilter(initialFolder);
+  const dispatch = useDispatch();
+  const [isAddingGroup, setIsAddingGroup] = useState(false);
+
+  const folder = watch('folder');
+  const group = watch('group');
+  const [selectedGroup, setSelectedGroup] = useState(group);
+  const initialRender = useRef(true);
+
+  const { groupOptions, groupsForFolder, loading } = useGetGroupOptionsFromFolder(folder?.title ?? '');
+
+  useEffect(() => {
+    dispatch(fetchRulerRulesIfNotFetchedYet(GRAFANA_RULES_SOURCE_NAME));
+  }, [dispatch]);
+
+  const resetGroup = useCallback(() => {
+    if (group && !initialRender.current && folder?.title) {
+      setSelectedGroup('');
+    }
+    initialRender.current = false;
+  }, [initialRender, folder, setSelectedGroup, group]);
+
+  const groupIsInGroupOptions = useCallback(
+    (group_: string) => {
+      return groupOptions.includes((groupInList: SelectableValue<string>) => groupInList.label === group_);
+    },
+    [groupOptions]
+  );
+  const folderTilte = folder?.title ?? '';
+
+  useEffect(() => {
+    if (folderTilte && groupOptions && !groupIsInGroupOptions(selectedGroup)) {
+      setIsAddingGroup(false);
+      resetGroup();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [folderTilte]);
+
+  return (
+    <div className={classNames([styles.flexRow, styles.alignBaseline])}>
+      <Field
+        label={
+          <Label htmlFor="folder" description={'Select a folder to store your rule.'}>
+            <Stack gap={0.5}>
+              Folder
+              <InfoIcon
+                text={
+                  'Each folder has unique folder permission. When you store multiple rules in a folder, the folder access permissions get assigned to the rules.'
+                }
+              />
+            </Stack>
+          </Label>
+        }
+        className={styles.formInput}
+        error={errors.folder?.message}
+        invalid={!!errors.folder?.message}
+        data-testid="folder-picker"
+      >
+        <InputControl
+          render={({ field: { ref, ...field } }) => (
+            <RuleFolderPicker
+              inputId="folder"
+              {...field}
+              enableCreateNew={contextSrv.hasPermission(AccessControlAction.FoldersCreate)}
+              enableReset={true}
+              filter={folderFilter}
+              dissalowSlashes={true}
+            />
+          )}
+          name="folder"
+          rules={{
+            required: { value: true, message: 'Please select a folder' },
+            validate: {
+              pathSeparator: (folder: Folder) => checkForPathSeparator(folder.title),
+            },
+          }}
+        />
+      </Field>
+
+      <Field
+        label="Group (evaluation interval)"
+        data-testid="group-picker"
+        description="Rules within the same group are evaluated after the same time interval."
+        className={styles.formInput}
+        error={errors.group?.message}
+        invalid={!!errors.group?.message}
+      >
+        <InputControl
+          render={({ field: { ref, ...field } }) =>
+            loading ? (
+              <LoadingPlaceholder text="Loading..." />
+            ) : (
+              <SelectWithAdd
+                {...field}
+                options={groupOptions}
+                getOptionLabel={(option: SelectableValue<string>) =>
+                  `${option.label}  (${getIntervalForGroup(groupsForFolder, option.label ?? '', folder?.title ?? '')})`
+                }
+                width={42}
+                value={selectedGroup}
+                custom={isAddingGroup}
+                onCustomChange={(custom: boolean) => setIsAddingGroup(custom)}
+                onChange={(value: string) => {
+                  field.onChange(value);
+                  setSelectedGroup(value);
+                }}
+              />
+            )
+          }
+          name="group"
+          control={control}
+          rules={{
+            required: { value: true, message: 'Must enter a group name' },
+          }}
+        />
+      </Field>
+    </div>
+  );
+}
+const getStyles = (theme: GrafanaTheme2) => ({
+  flexRow: css`
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-start;
+    align-items: flex-start;
+  `,
+  alignBaseline: css`
+    align-items: baseline;
+    margin-bottom: ${theme.spacing(1)};
+  `,
+  formInput: css`
+    width: 275px;
+
+    & + & {
+      margin-left: ${theme.spacing(3)};
+    }
+  `,
+});

--- a/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
@@ -169,7 +169,7 @@ export function FolderAndGroup({ initialFolder }: FolderAndGroupProps) {
       </Field>
 
       <Field
-        label="Group (evaluation interval)"
+        label="Evaluation group (interval)"
         data-testid="group-picker"
         description="Rules within the same group are evaluated after the same time interval."
         className={styles.formInput}

--- a/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
@@ -124,7 +124,7 @@ export function FolderAndGroup({ initialFolder }: FolderAndGroupProps) {
     <div className={styles.container}>
       <Field
         label={
-          <Label htmlFor="folder" description={'Select a folder to store your rule.'}>
+          <Label htmlFor="folder" description={'Select a folder for your rule.'}>
             <Stack gap={0.5}>
               Folder
               <InfoIcon
@@ -171,7 +171,7 @@ export function FolderAndGroup({ initialFolder }: FolderAndGroupProps) {
       <Field
         label="Evaluation group (interval)"
         data-testid="group-picker"
-        description="Rules within the same group are evaluated after the same time interval."
+        description="Select a group to evaluate all rules in the same group over the same time interval."
         className={styles.formInput}
         error={errors.group?.message}
         invalid={!!errors.group?.message}

--- a/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
@@ -309,7 +309,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
     display: flex;
     align-items: center;
     justify-content: right;
-    margin-top: -${theme.spacing(4)};
   `,
   bold: css`
     font-weight: bold;

--- a/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
@@ -185,7 +185,7 @@ function ForInput({ evaluateEvery }: { evaluateEvery: string }) {
       <InlineLabel
         htmlFor={evaluateForId}
         width={7}
-        tooltip='Once condition is breached, alert will go into pending state. If it is pending for longer than the "for" value, it will become a firing alert.'
+        tooltip='Once the condition is breached, the alert goes into pending state. If the alert is pending longer than the "for" value, it becomes a firing alert.'
       >
         for
       </InlineLabel>

--- a/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from '@emotion/css';
+import { css } from '@emotion/css';
 import React, { useState, useEffect } from 'react';
 import { RegisterOptions, useFormContext } from 'react-hook-form';
 
@@ -172,7 +172,10 @@ function FolderGroupAndEvaluationInterval({
     editInterval && setFocus('evaluateEvery');
   }, [editInterval, setFocus]);
 
-  const intervalHasChanged = initialEvaluateEvery !== parseDurationToMilliseconds(evaluateEvery);
+  const intervalHasChanged =
+    parseDurationToMilliseconds(getIntervalForGroup(groupfoldersForGrafana?.result, group, folder?.title ?? '')) !==
+    parseDurationToMilliseconds(evaluateEvery);
+
   return (
     <div>
       <FolderAndGroup initialFolder={initialFolder} />
@@ -189,11 +192,11 @@ function FolderGroupAndEvaluationInterval({
           someRulesBelongToThisGroup(initialRuleName, groupfoldersForGrafana?.result, group, folder?.title ?? '') ? (
             <>
               <div className={styles.intervalChangedLabel}>
-                <Icon name="exclamation-triangle" size="xs" className={cx('text-warning', styles.warningIcon)} />
+                <Icon name="exclamation-triangle" size="xs" className={styles.warningIcon} />
                 {`More alert rules belong to this group.You are going to update evaluation interval for group '${group}' with this new value: `}
-                <span className={cx('text-warning')}>{evaluateEvery}</span>
+                <span className={styles.warningMessage}>{evaluateEvery}</span>
               </div>
-              <div className={cx('text-warning')}>
+              <div className={styles.warningMessage}>
                 You should review the For duration, for all alerts that belong to this group
               </div>
             </>
@@ -202,7 +205,7 @@ function FolderGroupAndEvaluationInterval({
             !editInterval && (
               <div className={styles.intervalChangedLabel}>
                 {`Evaluation interval for group '${group}' will be updated with: `}
-                <span className={cx('text-warning')}>{evaluateEvery}</span>
+                <span className={styles.warningMessage}>{evaluateEvery}</span>
               </div>
             )
           )}
@@ -213,6 +216,7 @@ function FolderGroupAndEvaluationInterval({
               type="button"
               variant="secondary"
               disabled={groupfoldersForGrafana?.loading}
+              className={styles.editButton}
               onClick={() => {
                 setEditInterval(true);
               }}
@@ -388,5 +392,12 @@ const getStyles = (theme: GrafanaTheme2) => ({
   warningIcon: css`
     justify-self: center;
     margin-right: ${theme.spacing(1)};
+    color: ${theme.colors.warning.text};
+  `,
+  warningMessage: css`
+    color: ${theme.colors.warning.text};
+  `,
+  editButton: css`
+    margin-top: ${theme.spacing(1)};
   `,
 });

--- a/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
@@ -128,45 +128,46 @@ function FolderGroupAndEvaluationInterval({
           folderAndGroupReadOnly
         />
       )}
+      {folder && group && (
+        <Card className={styles.cardContainer}>
+          <Card.Heading>Evaluation behaviour</Card.Heading>
+          <Card.Meta>
+            <div className={styles.evaluationDescription}>
+              <div className={styles.evaluateLabel}>
+                {`Alert rules in`} <span className={styles.bold}>{group}</span> are evaluated every{' '}
+                <span className={styles.bold}>{evaluateEvery}</span>.
+              </div>
 
-      <Card className={styles.cardContainer}>
-        <Card.Heading>Evaluation behaviour</Card.Heading>
-        <Card.Meta>
-          <div className={styles.evaluationDescription}>
-            <div className={styles.evaluateLabel}>
-              {`Alert rules in`} <span className={styles.bold}>{group}</span> are evaluated every{' '}
-              <span className={styles.bold}>{evaluateEvery}</span>.
-            </div>
-
-            <br />
-            {!isNewGroup && (
-              <div className={styles.evaluateLabelEnd}>
-                {`Evaluation interval applies to every rule within a group. 
+              <br />
+              {!isNewGroup && (
+                <div className={styles.evaluateLabelEnd}>
+                  {`Evaluation interval applies to every rule within a group. 
           It can overwrite the interval of an existing alert rule.`}
-              </div>
-            )}
-            <br />
-          </div>
-        </Card.Meta>
-        <Card.Actions>
-          <div className={styles.editGroup}>
-            {isNewGroup && (
-              <div className={styles.warningMessage}>
-                New group must be saved before being able to edit the evaluation interval.
-              </div>
-            )}
-            <Button
-              icon={'edit'}
-              type="button"
-              variant="secondary"
-              disabled={editGroupDisabled}
-              onClick={onOpenEditGroupModal}
-            >
-              <span>{'Edit evaluation group'}</span>
-            </Button>
-          </div>
-        </Card.Actions>
-      </Card>
+                </div>
+              )}
+              <br />
+            </div>
+          </Card.Meta>
+          <Card.Actions>
+            <div className={styles.editGroup}>
+              {isNewGroup && (
+                <div className={styles.warningMessage}>
+                  New group must be saved before being able to edit the evaluation interval.
+                </div>
+              )}
+              <Button
+                icon={'edit'}
+                type="button"
+                variant="secondary"
+                disabled={editGroupDisabled}
+                onClick={onOpenEditGroupModal}
+              >
+                <span>{'Edit evaluation group'}</span>
+              </Button>
+            </div>
+          </Card.Actions>
+        </Card>
+      )}
     </div>
   );
 }

--- a/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
@@ -1,6 +1,6 @@
 import { css, cx } from '@emotion/css';
 import classNames from 'classnames';
-import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { RegisterOptions, useFormContext } from 'react-hook-form';
 
 import { durationToMilliseconds, GrafanaTheme2, parseDuration, SelectableValue } from '@grafana/data';
@@ -36,6 +36,7 @@ import { EvaluationIntervalLimitExceeded } from '../InvalidIntervalWarning';
 import { GrafanaAlertStatePicker } from './GrafanaAlertStatePicker';
 import { RuleEditorSection } from './RuleEditorSection';
 import { containsSlashes, Folder, RuleFolderPicker } from './RuleFolderPicker';
+import { SelectWithAdd } from './SelectWIthAdd';
 import { checkForPathSeparator } from './util';
 
 const MIN_TIME_RANGE_STEP_S = 10; // 10 seconds
@@ -51,7 +52,6 @@ const useGetGroups = (groupfoldersForGrafana: AsyncRequestState<RuleNamespace[]>
       return [];
     }
   }, [groupfoldersForGrafana, folderName]);
-
   return groupOptions;
 };
 
@@ -134,11 +134,21 @@ interface FolderAndGroupProps {
   initialFolder: RuleForm | null;
 }
 
+const useGetGroupOptionsFromFolder = (folderTilte: string) => {
+  const promRules = useUnifiedAlertingSelector((state) => state.promRules);
+  const groupfoldersForGrafana = promRules[GRAFANA_RULES_SOURCE_NAME];
+
+  const groupOptions: Array<SelectableValue<string>> = mapGroupsToOptions(
+    useGetGroups(groupfoldersForGrafana, folderTilte)
+  );
+  return groupOptions;
+};
+
 function FolderAndGroup({ initialFolder }: FolderAndGroupProps) {
   const {
-    register,
     formState: { errors },
     watch,
+    control,
   } = useFormContext<RuleFormValues>();
 
   const styles = useStyles2(getStyles);
@@ -146,16 +156,37 @@ function FolderAndGroup({ initialFolder }: FolderAndGroupProps) {
   const dispatch = useDispatch();
 
   const folder = watch('folder');
-  const promRules = useUnifiedAlertingSelector((state) => state.promRules);
-  const groupfoldersForGrafana = promRules[GRAFANA_RULES_SOURCE_NAME];
+  const group = watch('group');
+  const [selectedGroup, setSelectedGroup] = useState(group);
+  const initialRender = useRef(true);
 
-  const groupOptions: Array<SelectableValue<string>> = mapGroupsToOptions(
-    useGetGroups(groupfoldersForGrafana, folder?.title ?? '')
-  );
+  const groupOptions = useGetGroupOptionsFromFolder(folder?.title ?? '');
 
   useEffect(() => {
     dispatch(fetchAllPromRulesAction());
   }, [dispatch]);
+
+  const resetGroup = useCallback(() => {
+    if (group && !initialRender.current && folder?.title) {
+      setSelectedGroup('');
+    }
+    initialRender.current = false;
+  }, [initialRender, folder, setSelectedGroup, group]);
+
+  const groupIsInGroupOptions = useCallback(
+    (group_: string) => {
+      return groupOptions.includes((groupInList: SelectableValue<string>) => groupInList.label === group_);
+    },
+    [groupOptions]
+  );
+  const folderTilte = folder?.title ?? '';
+
+  useEffect(() => {
+    if (folderTilte && groupOptions && !groupIsInGroupOptions(selectedGroup)) {
+      resetGroup();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [folderTilte]);
 
   return (
     <div className={classNames([styles.flexRow, styles.alignBaseline])}>
@@ -205,11 +236,26 @@ function FolderAndGroup({ initialFolder }: FolderAndGroupProps) {
         error={errors.group?.message}
         invalid={!!errors.group?.message}
       >
-        <Input
-          id="group"
-          {...register('group', {
+        <InputControl
+          render={({ field: { ref, ...field } }) => (
+            <SelectWithAdd
+              {...field}
+              options={groupOptions}
+              width={42}
+              custom={false}
+              value={selectedGroup}
+              onChange={(value: string) => {
+                console.log('changing dins', value);
+                field.onChange(value);
+                setSelectedGroup(value);
+              }}
+            />
+          )}
+          name="group"
+          control={control}
+          rules={{
             required: { value: true, message: 'Must enter a group name' },
-          })}
+          }}
         />
       </Field>
     </div>

--- a/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
@@ -124,7 +124,7 @@ function FolderGroupAndEvaluationInterval({
             </div>
 
             <br />
-            <div>
+            <div className={styles.evaluateLabelEnd}>
               {`Evaluation interval applies to every rule within a group. 
           It can overwrite the interval of an existing alert rule.`}
             </div>
@@ -139,7 +139,6 @@ function FolderGroupAndEvaluationInterval({
               type="button"
               variant="secondary"
               disabled={groupfoldersForGrafana?.loading}
-              className={styles.editButton}
               onClick={onOpenEditGroupModal}
             >
               <span>{'Edit group'}</span>
@@ -271,9 +270,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
     align-self: left;
     margin-right: ${theme.spacing(1)};
   `,
-  evaluateInput: css`
-    margin-right: ${theme.spacing(1)};
-  `,
   cardContainer: css`
     max-width: ${theme.breakpoints.values.sm}px;
   `,
@@ -288,13 +284,14 @@ const getStyles = (theme: GrafanaTheme2) => ({
   warningMessage: css`
     color: ${theme.colors.warning.text};
   `,
-  editButton: css`
-    margin-top: ${theme.spacing(1)};
-  `,
   editGroup: css`
     display: flex;
     align-items: center;
     justify-content: space-between;
+    margin-top: -${theme.spacing(4)};
+  `,
+  evaluateLabelEnd: css`
+    margin-top: -${theme.spacing(2)};
   `,
   bold: css`
     font-weight: bold;

--- a/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
@@ -140,7 +140,7 @@ function FolderGroupAndEvaluationInterval({
 
               <br />
               {!isNewGroup && (
-                <div className={styles.evaluateLabelEnd}>
+                <div>
                   {`Evaluation group interval applies to every rule within a group. It overwrites intervals defined for existing alert rules.`}
                 </div>
               )}
@@ -310,9 +310,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
     align-items: center;
     justify-content: right;
     margin-top: -${theme.spacing(4)};
-  `,
-  evaluateLabelEnd: css`
-    margin-top: -${theme.spacing(2)};
   `,
   bold: css`
     font-weight: bold;

--- a/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
@@ -151,7 +151,7 @@ function FolderGroupAndEvaluationInterval({
             <div className={styles.editGroup}>
               {isNewGroup && (
                 <div className={styles.warningMessage}>
-                  {`Save the ${group} evaluation group in order to edit the evaluation group interval.`}
+                  {`To edit the evaluation group interval, save the alert rule.`}
                 </div>
               )}
               <Button

--- a/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
@@ -1,9 +1,9 @@
-import { css } from '@emotion/css';
-import React, { useState } from 'react';
+import { css, cx } from '@emotion/css';
+import React, { FC, useState, useEffect } from 'react';
 import { RegisterOptions, useFormContext } from 'react-hook-form';
 
-import { GrafanaTheme2 } from '@grafana/data';
-import { Field, InlineLabel, Input, InputControl, useStyles2 } from '@grafana/ui';
+import { durationToMilliseconds, GrafanaTheme2, parseDuration } from '@grafana/data';
+import { Button, Field, InlineLabel, Input, InputControl, useStyles2 } from '@grafana/ui';
 
 import { RuleFormValues } from '../../types/rule-form';
 import { checkEvaluationIntervalGlobalLimit } from '../../utils/config';
@@ -51,43 +51,127 @@ export const forValidationOptions = (evaluateEvery: string): RegisterOptions => 
   },
 });
 
-export const evaluateEveryValidationOptions: RegisterOptions = {
-  required: {
-    value: true,
-    message: 'Required.',
-  },
-  validate: (value: string) => {
-    try {
-      const duration = parsePrometheusDuration(value);
-
-      if (duration < MIN_TIME_RANGE_STEP_S * 1000) {
-        return `Cannot be less than ${MIN_TIME_RANGE_STEP_S} seconds.`;
-      }
-
-      if (duration % (MIN_TIME_RANGE_STEP_S * 1000) !== 0) {
-        return `Must be a multiple of ${MIN_TIME_RANGE_STEP_S} seconds.`;
-      }
-
-      return true;
-    } catch (error) {
-      return error instanceof Error ? error.message : 'Failed to parse duration';
-    }
-  },
-};
-
-export const GrafanaEvaluationBehavior = () => {
+function EvaluationIntervalInput() {
   const styles = useStyles2(getStyles);
-  const [showErrorHandling, setShowErrorHandling] = useState(false);
+  const [editInterval, setEditInterval] = useState(false);
+  const {
+    setFocus,
+    register,
+    formState: { errors },
+    watch,
+  } = useFormContext<RuleFormValues>();
+
+  const group = watch('group');
+  const evaluateEveryId = 'eval-every-input';
+
+  const onBlur = () => setEditInterval(false);
+  const evaluateEveryValidationOptions: RegisterOptions = {
+    required: {
+      value: true,
+      message: 'Required.',
+    },
+    pattern: positiveDurationValidationPattern,
+    validate: (value: string) => {
+      const duration = parseDuration(value);
+      if (Object.keys(duration).length) {
+        const diff = durationToMilliseconds(duration);
+        if (diff < MIN_TIME_RANGE_STEP_S * 1000) {
+          return `Cannot be less than ${MIN_TIME_RANGE_STEP_S} seconds.`;
+        }
+        if (diff % (MIN_TIME_RANGE_STEP_S * 1000) !== 0) {
+          return `Must be a multiple of ${MIN_TIME_RANGE_STEP_S} seconds.`;
+        }
+      }
+      return true;
+    },
+  };
+
+  useEffect(() => {
+    editInterval && setFocus('evaluateEvery');
+  }, [editInterval, setFocus]);
+
+  return (
+    <div>
+      <div className={styles.flexRow}>
+        <div className={styles.evaluateLabel}>{`Alert rules in '${group}' are evaluated every`}</div>
+        <Field
+          className={styles.inlineField}
+          error={errors.evaluateEvery?.message}
+          invalid={!!errors.evaluateEvery}
+          validationMessageHorizontalOverflow={true}
+        >
+          <Input
+            id={evaluateEveryId}
+            width={8}
+            {...register('evaluateEvery', evaluateEveryValidationOptions)}
+            readOnly={!editInterval}
+            onBlur={onBlur}
+            className={styles.evaluateInput}
+          />
+        </Field>
+        <Button
+          icon={editInterval ? 'exclamation-circle' : 'edit'}
+          type="button"
+          variant="secondary"
+          disabled={editInterval}
+          onClick={() => {
+            if (!editInterval) {
+              setFocus('evaluateEvery');
+              setEditInterval(true);
+            }
+            editInterval && setEditInterval(false);
+          }}
+        >
+          <span className={cx(editInterval && 'text-warning')}>
+            {editInterval ? `You are updating evaluation interval for the group '${group}'` : 'Edit group behaviour'}
+          </span>
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function ForInput() {
+  const styles = useStyles2(getStyles);
   const {
     register,
     formState: { errors },
     watch,
   } = useFormContext<RuleFormValues>();
 
-  const { exceedsLimit: exceedsGlobalEvaluationLimit } = checkEvaluationIntervalGlobalLimit(watch('evaluateEvery'));
-
-  const evaluateEveryId = 'eval-every-input';
   const evaluateForId = 'eval-for-input';
+
+  return (
+    <div className={styles.flexRow}>
+      <InlineLabel
+        htmlFor={evaluateForId}
+        width={7}
+        tooltip='Once condition is breached, alert will go into pending state. If it is pending for longer than the "for" value, it will become a firing alert.'
+      >
+        for
+      </InlineLabel>
+      <Field
+        className={styles.inlineField}
+        error={errors.evaluateFor?.message}
+        invalid={!!errors.evaluateFor?.message}
+        validationMessageHorizontalOverflow={true}
+      >
+        <Input
+          id={evaluateForId}
+          width={8}
+          {...register('evaluateFor', forValidationOptions(watch('evaluateEvery')))}
+        />
+      </Field>
+    </div>
+  );
+}
+
+export const GrafanaEvaluationBehavior: FC = () => {
+  const styles = useStyles2(getStyles);
+  const [showErrorHandling, setShowErrorHandling] = useState(false);
+  const { watch } = useFormContext<RuleFormValues>();
+
+  const { exceedsLimit: exceedsGlobalEvaluationLimit } = checkEvaluationIntervalGlobalLimit(watch('evaluateEvery'));
 
   return (
     // TODO remove "and alert condition" for recording rules
@@ -96,42 +180,9 @@ export const GrafanaEvaluationBehavior = () => {
         label="Evaluate"
         description="Evaluation interval applies to every rule within a group. It can overwrite the interval of an existing alert rule."
       >
-        <div className={styles.flexRow}>
-          <InlineLabel
-            htmlFor={evaluateEveryId}
-            width={16}
-            tooltip="How often the alert will be evaluated to see if it fires"
-          >
-            Evaluate every
-          </InlineLabel>
-          <Field
-            className={styles.inlineField}
-            error={errors.evaluateEvery?.message}
-            invalid={!!errors.evaluateEvery}
-            validationMessageHorizontalOverflow={true}
-          >
-            <Input id={evaluateEveryId} width={8} {...register('evaluateEvery', evaluateEveryValidationOptions)} />
-          </Field>
-
-          <InlineLabel
-            htmlFor={evaluateForId}
-            width={7}
-            tooltip='Once condition is breached, alert will go into pending state. If it is pending for longer than the "for" value, it will become a firing alert.'
-          >
-            for
-          </InlineLabel>
-          <Field
-            className={styles.inlineField}
-            error={errors.evaluateFor?.message}
-            invalid={!!errors.evaluateFor?.message}
-            validationMessageHorizontalOverflow={true}
-          >
-            <Input
-              id={evaluateForId}
-              width={8}
-              {...register('evaluateFor', forValidationOptions(watch('evaluateEvery')))}
-            />
-          </Field>
+        <div className={styles.flexColumn}>
+          <EvaluationIntervalInput />
+          <ForInput />
         </div>
       </Field>
       {exceedsGlobalEvaluationLimit && <EvaluationIntervalLimitExceeded />}
@@ -183,16 +234,30 @@ const getStyles = (theme: GrafanaTheme2) => ({
   inlineField: css`
     margin-bottom: 0;
   `,
+  flexColumn: css`
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    align-items: flex-start;
+  `,
   flexRow: css`
     display: flex;
     flex-direction: row;
     justify-content: flex-start;
     align-items: flex-start;
+    margin-bottom: ${theme.spacing(1)};
   `,
   collapseToggle: css`
     margin: ${theme.spacing(2, 0, 2, -1)};
   `,
   globalLimitValue: css`
     font-weight: ${theme.typography.fontWeightBold};
+  `,
+  evaluateLabel: css`
+    align-self: center;
+    margin-right: ${theme.spacing(1)};
+  `,
+  evaluateInput: css`
+    margin-right: ${theme.spacing(1)};
   `,
 });

--- a/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
@@ -130,19 +130,18 @@ function FolderGroupAndEvaluationInterval({
       )}
       {folder && group && (
         <Card className={styles.cardContainer}>
-          <Card.Heading>Evaluation behaviour</Card.Heading>
+          <Card.Heading>Evaluation behavior</Card.Heading>
           <Card.Meta>
             <div className={styles.evaluationDescription}>
               <div className={styles.evaluateLabel}>
-                {`Alert rules in`} <span className={styles.bold}>{group}</span> are evaluated every{' '}
+                {`Alert rules in the `} <span className={styles.bold}>{group}</span> group are evaluated every{' '}
                 <span className={styles.bold}>{evaluateEvery}</span>.
               </div>
 
               <br />
               {!isNewGroup && (
                 <div className={styles.evaluateLabelEnd}>
-                  {`Evaluation interval applies to every rule within a group. 
-          It can overwrite the interval of an existing alert rule.`}
+                  {`Evaluation group interval applies to every rule within a group. It overwrites intervals defined for existing alert rules.`}
                 </div>
               )}
               <br />
@@ -152,7 +151,7 @@ function FolderGroupAndEvaluationInterval({
             <div className={styles.editGroup}>
               {isNewGroup && (
                 <div className={styles.warningMessage}>
-                  New group must be saved before being able to edit the evaluation interval.
+                  {`Save the ${group} evaluation group in order to edit the evaluation group interval.`}
                 </div>
               )}
               <Button

--- a/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
@@ -4,7 +4,19 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { RegisterOptions, useFormContext } from 'react-hook-form';
 
 import { durationToMilliseconds, GrafanaTheme2, parseDuration } from '@grafana/data';
-import { Button, Field, Icon, InlineLabel, Input, InputControl, Label, Stack, Tooltip, useStyles2 } from '@grafana/ui';
+import {
+  Button,
+  Card,
+  Field,
+  Icon,
+  InlineLabel,
+  Input,
+  InputControl,
+  Label,
+  Stack,
+  Tooltip,
+  useStyles2,
+} from '@grafana/ui';
 import { FolderPickerFilter } from 'app/core/components/Select/FolderPicker';
 import { contextSrv } from 'app/core/core';
 import { DashboardSearchHit } from 'app/features/search/types';
@@ -86,6 +98,14 @@ const useRuleFolderFilter = (existingRuleForm: RuleForm | null) => {
   );
 };
 
+function InfoIcon({ text }: { text: string }) {
+  return (
+    <Tooltip placement="top" content={<div>{text}</div>}>
+      <Icon name="info-circle" size="xs" />
+    </Tooltip>
+  );
+}
+
 interface FolderAndGroupProps {
   initialFolder: RuleForm | null;
 }
@@ -105,17 +125,11 @@ function FolderAndGroup({ initialFolder }: FolderAndGroupProps) {
           <Label htmlFor="folder" description={'Select a folder to store your rule.'}>
             <Stack gap={0.5}>
               Folder
-              <Tooltip
-                placement="top"
-                content={
-                  <div>
-                    Each folder has unique folder permission. When you store multiple rules in a folder, the folder
-                    access permissions get assigned to the rules.
-                  </div>
+              <InfoIcon
+                text={
+                  'Each folder has unique folder permission. When you store multiple rules in a folder, the folder access permissions get assigned to the rules.'
                 }
-              >
-                <Icon name="info-circle" size="xs" />
-              </Tooltip>
+              />
             </Stack>
           </Label>
         }
@@ -205,41 +219,50 @@ function EvaluationIntervalInput({ initialFolder }: { initialFolder: RuleForm | 
   return (
     <div>
       <FolderAndGroup initialFolder={initialFolder} />
-      <div className={styles.flexRow}>
-        <div className={styles.evaluateLabel}>{`Alert rules in '${group}' are evaluated every`}</div>
-        <Field
-          className={styles.inlineField}
-          error={errors.evaluateEvery?.message}
-          invalid={!!errors.evaluateEvery}
-          validationMessageHorizontalOverflow={true}
-        >
-          <Input
-            id={evaluateEveryId}
-            width={8}
-            {...register('evaluateEvery', evaluateEveryValidationOptions)}
-            readOnly={!editInterval}
-            onBlur={onBlur}
-            className={styles.evaluateInput}
-          />
-        </Field>
-        <Button
-          icon={editInterval ? 'exclamation-circle' : 'edit'}
-          type="button"
-          variant="secondary"
-          disabled={editInterval}
-          onClick={() => {
-            if (!editInterval) {
-              setFocus('evaluateEvery');
-              setEditInterval(true);
-            }
-            editInterval && setEditInterval(false);
-          }}
-        >
-          <span className={cx(editInterval && 'text-warning')}>
-            {editInterval ? `You are updating evaluation interval for the group '${group}'` : 'Edit group behaviour'}
-          </span>
-        </Button>
-      </div>
+      <Card className={styles.cardContainer}>
+        <Card.Heading>Group behaviour</Card.Heading>
+        <Card.Meta>
+          {`Evaluation interval applies to every rule within a group. 
+            It can overwrite the interval of an existing alert rule. 
+            Click on 'Edit group behaviour' button to edit this group value.`}
+        </Card.Meta>
+        <Card.Actions>
+          <div className={styles.flexRow}>
+            <div className={styles.evaluateLabel}>{`Alert rules in '${group}' are evaluated every`}</div>
+            <Field
+              className={styles.inlineField}
+              error={errors.evaluateEvery?.message}
+              invalid={!!errors.evaluateEvery}
+              validationMessageHorizontalOverflow={true}
+            >
+              <Input
+                id={evaluateEveryId}
+                width={8}
+                {...register('evaluateEvery', evaluateEveryValidationOptions)}
+                readOnly={!editInterval}
+                onBlur={onBlur}
+                className={styles.evaluateInput}
+              />
+            </Field>
+            {editInterval ? (
+              <span className={cx('text-warning', styles.evalEditingLabel)}>
+                {`You are updating evaluation interval for the group '${group}'`}
+              </span>
+            ) : (
+              <Button
+                icon={editInterval ? 'exclamation-circle' : 'edit'}
+                type="button"
+                variant="secondary"
+                onClick={() => {
+                  setEditInterval(true);
+                }}
+              >
+                <span className={cx(editInterval && 'text-warning')}>{'Edit group behaviour'}</span>
+              </Button>
+            )}
+          </div>
+        </Card.Actions>
+      </Card>
     </div>
   );
 }
@@ -354,7 +377,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
     flex-direction: row;
     justify-content: flex-start;
     align-items: flex-start;
-    margin-bottom: ${theme.spacing(1)};
   `,
   collapseToggle: css`
     margin: ${theme.spacing(2, 0, 2, -1)};
@@ -371,7 +393,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
   `,
   alignBaseline: css`
     align-items: baseline;
-    margin-bottom: ${theme.spacing(3)};
+    margin-bottom: ${theme.spacing(1)};
   `,
   formInput: css`
     width: 275px;
@@ -379,5 +401,12 @@ const getStyles = (theme: GrafanaTheme2) => ({
     & + & {
       margin-left: ${theme.spacing(3)};
     }
+  `,
+  evalEditingLabel: css`
+    align-self: baseline;
+    margin-left: ${theme.spacing(1)};
+  `,
+  cardContainer: css`
+    max-width: ${theme.breakpoints.values.sm}px;
   `,
 });

--- a/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
@@ -113,30 +113,39 @@ function FolderGroupAndEvaluationInterval({
           onClose={() => closeEditGroupModal()}
         />
       )}
+
       <Card className={styles.cardContainer}>
         <Card.Heading>Group behaviour</Card.Heading>
+        <Card.Meta>
+          <div className={styles.evaluationDescription}>
+            <div className={styles.evaluateLabel}>
+              {`Alert rules in`} <span className={styles.bold}>{group}</span> are evaluated every{' '}
+              <span className={styles.bold}>{evaluateEvery}</span>.
+            </div>
 
-        <div className={styles.evaluateLabel}>
-          {`Alert rules in`} <span className={styles.bold}>{group}</span> are evaluated every{' '}
-          <span className={styles.bold}>{evaluateEvery}</span>.
-        </div>
-        <br />
-        {`Evaluation interval applies to every rule within a group. 
-              It can overwrite the interval of an existing alert rule.`}
-        <br />
-        <div className={styles.editGroup}>
-          {`Click on Edit group button to edit this value `}
-          <Button
-            icon={'edit'}
-            type="button"
-            variant="secondary"
-            disabled={groupfoldersForGrafana?.loading}
-            className={styles.editButton}
-            onClick={onOpenEditGroupModal}
-          >
-            <span>{'Edit group'}</span>
-          </Button>
-        </div>
+            <br />
+            <div>
+              {`Evaluation interval applies to every rule within a group. 
+          It can overwrite the interval of an existing alert rule.`}
+            </div>
+            <br />
+          </div>
+        </Card.Meta>
+        <Card.Actions>
+          <div className={styles.editGroup}>
+            {`Click on Edit group button to edit this value `}
+            <Button
+              icon={'edit'}
+              type="button"
+              variant="secondary"
+              disabled={groupfoldersForGrafana?.loading}
+              className={styles.editButton}
+              onClick={onOpenEditGroupModal}
+            >
+              <span>{'Edit group'}</span>
+            </Button>
+          </div>
+        </Card.Actions>
       </Card>
     </div>
   );
@@ -259,7 +268,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     margin: ${theme.spacing(2, 0, 2, -1)};
   `,
   evaluateLabel: css`
-    align-self: center;
+    align-self: left;
     margin-right: ${theme.spacing(1)};
   `,
   evaluateInput: css`
@@ -289,5 +298,9 @@ const getStyles = (theme: GrafanaTheme2) => ({
   `,
   bold: css`
     font-weight: bold;
+  `,
+  evaluationDescription: css`
+    display: flex;
+    flex-direction: column;
   `,
 });

--- a/public/app/features/alerting/unified/components/rule-editor/SelectWIthAdd.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/SelectWIthAdd.tsx
@@ -15,6 +15,7 @@ interface Props {
   width?: number;
   disabled?: boolean;
   'aria-label'?: string;
+  getOptionLabel?: ((item: SelectableValue<string>) => React.ReactNode) | undefined;
 }
 
 export const SelectWithAdd: FC<Props> = ({
@@ -29,6 +30,7 @@ export const SelectWithAdd: FC<Props> = ({
   disabled = false,
   addLabel = '+ Add new',
   'aria-label': ariaLabel,
+  getOptionLabel,
 }) => {
   const [isCustom, setIsCustom] = useState(custom);
 
@@ -65,6 +67,7 @@ export const SelectWithAdd: FC<Props> = ({
         value={value}
         className={className}
         placeholder={placeholder}
+        getOptionLabel={getOptionLabel}
         disabled={disabled}
         onChange={(val: SelectableValue) => {
           const value = val?.value;

--- a/public/app/features/alerting/unified/components/rule-editor/SelectWIthAdd.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/SelectWIthAdd.tsx
@@ -35,9 +35,10 @@ export const SelectWithAdd: FC<Props> = ({
   const [isCustom, setIsCustom] = useState(custom);
 
   useEffect(() => {
-    if (custom) {
-      setIsCustom(custom);
-    }
+    //not sure why do we need this if
+    // if (custom) {
+    setIsCustom(custom);
+    //  }
   }, [custom]);
 
   const _options = useMemo(

--- a/public/app/features/alerting/unified/components/rule-editor/SelectWIthAdd.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/SelectWIthAdd.tsx
@@ -35,10 +35,7 @@ export const SelectWithAdd: FC<Props> = ({
   const [isCustom, setIsCustom] = useState(custom);
 
   useEffect(() => {
-    //not sure why do we need this if
-    // if (custom) {
     setIsCustom(custom);
-    //  }
   }, [custom]);
 
   const _options = useMemo(

--- a/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
+++ b/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
@@ -318,7 +318,7 @@ export function EditCloudGroupModal(props: ModalProps): React.ReactElement {
     <Modal
       className={styles.modal}
       isOpen={true}
-      title="Edit namespace or evaluation group"
+      title={folderAndGroupReadOnly ? 'Edit evaluation group' : `Edit ${nameSpaceLabel} or evaluation group`}
       onDismiss={onClose}
       onClickBackdrop={onClose}
     >

--- a/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
+++ b/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
@@ -199,6 +199,7 @@ interface ModalProps {
   sourceName: string;
   groupInterval: string;
   onClose: (saved?: boolean) => void;
+  folderAndGroupReadOnly?: boolean;
 }
 
 interface FormValues {
@@ -213,6 +214,7 @@ export function EditCloudGroupModal(props: ModalProps): React.ReactElement {
     onClose,
     groupInterval,
     sourceName,
+    folderAndGroupReadOnly,
   } = props;
 
   const styles = useStyles2(getStyles);
@@ -233,7 +235,16 @@ export function EditCloudGroupModal(props: ModalProps): React.ReactElement {
 
   const isGrafanaManagedGroup = sourceName === GRAFANA_RULES_SOURCE_NAME;
   const nameSpaceLabel = isGrafanaManagedGroup ? 'Folder' : 'Namespace';
+  const nameSpaceInfoIconLabelEditable = isGrafanaManagedGroup
+    ? 'Folder name can be updated to a non-existing folder name'
+    : 'Name space can be updated to a non-existing name space';
+  const nameSpaceInfoIconLabelNonEditable = isGrafanaManagedGroup
+    ? 'Folder name can be updated in folder view'
+    : 'Name space can be updated folder view';
 
+  const spaceNameInfoIconLabel = folderAndGroupReadOnly
+    ? nameSpaceInfoIconLabelNonEditable
+    : nameSpaceInfoIconLabelEditable;
   // close modal if successfully saved
   useEffect(() => {
     if (dispatched && !loading && !error) {
@@ -242,7 +253,6 @@ export function EditCloudGroupModal(props: ModalProps): React.ReactElement {
   }, [dispatched, loading, onClose, error]);
 
   useCleanup((state) => (state.unifiedAlerting.updateLotexNamespaceAndGroup = initialAsyncRequestState));
-
   const onSubmit = (values: FormValues) => {
     dispatch(
       updateLotexNamespaceAndGroupAction({
@@ -320,34 +330,31 @@ export function EditCloudGroupModal(props: ModalProps): React.ReactElement {
                 <Label htmlFor="namespaceName">
                   <Stack gap={0.5}>
                     {nameSpaceLabel}
-                    {isGrafanaManagedGroup ? (
-                      <InfoIcon text={'Folder name can be updated on Folder view.'} />
-                    ) : (
-                      <InfoIcon text={'Name space can be updated'} />
-                    )}
+                    <InfoIcon text={spaceNameInfoIconLabel} />
                   </Stack>
                 </Label>
               }
               invalid={!!errors.namespaceName}
               error={errors.namespaceName?.message}
             >
-              {isGrafanaManagedGroup ? (
-                <>{nameSpaceName}</>
-              ) : (
-                <Input
-                  id="namespaceName"
-                  {...register('namespaceName', {
-                    required: 'Namespace name is required.',
-                  })}
-                />
-              )}
+              <Input
+                id="namespaceName"
+                readOnly={folderAndGroupReadOnly}
+                {...register('namespaceName', {
+                  required: 'Namespace name is required.',
+                })}
+              />
             </Field>
             <Field
               label={
                 <Label htmlFor="groupName">
                   <Stack gap={0.5}>
                     Evaluation group
-                    <InfoIcon text={'Group name can be updated'} />
+                    {isGrafanaManagedGroup ? (
+                      <InfoIcon text={'Group name can be updated on Group view.'} />
+                    ) : (
+                      <InfoIcon text={'Group name can be updated to a non existing group name.'} />
+                    )}
                   </Stack>
                 </Label>
               }
@@ -356,6 +363,7 @@ export function EditCloudGroupModal(props: ModalProps): React.ReactElement {
             >
               <Input
                 id="groupName"
+                readOnly={folderAndGroupReadOnly}
                 {...register('groupName', {
                   required: 'Evaluation group name is required.',
                 })}

--- a/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
+++ b/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
@@ -14,6 +14,7 @@ import { RulerRulesConfigDTO, RulerRuleGroupDTO, RulerRuleDTO } from 'app/types/
 import { useUnifiedAlertingSelector } from '../../hooks/useUnifiedAlertingSelector';
 import { rulesInSameGroupHaveInvalidFor, updateLotexNamespaceAndGroupAction } from '../../state/actions';
 import { checkEvaluationIntervalGlobalLimit } from '../../utils/config';
+import { GRAFANA_RULES_SOURCE_NAME } from '../../utils/datasource';
 import { initialAsyncRequestState } from '../../utils/redux';
 import { isAlertingRulerRule, isGrafanaRulerRule } from '../../utils/rules';
 import { parsePrometheusDuration } from '../../utils/time';
@@ -230,6 +231,9 @@ export function EditCloudGroupModal(props: ModalProps): React.ReactElement {
     [nameSpaceName, groupName, groupInterval]
   );
 
+  const isGrafanaManagedGroup = sourceName === GRAFANA_RULES_SOURCE_NAME;
+  const nameSpaceLabel = isGrafanaManagedGroup ? 'Folder' : 'Namespace';
+
   // close modal if successfully saved
   useEffect(() => {
     if (dispatched && !loading && !error) {
@@ -315,20 +319,28 @@ export function EditCloudGroupModal(props: ModalProps): React.ReactElement {
               label={
                 <Label htmlFor="namespaceName">
                   <Stack gap={0.5}>
-                    NameSpace
-                    <InfoIcon text={'Name space can be updated'} />
+                    {nameSpaceLabel}
+                    {isGrafanaManagedGroup ? (
+                      <InfoIcon text={'Folder name can be updated on Folder view.'} />
+                    ) : (
+                      <InfoIcon text={'Name space can be updated'} />
+                    )}
                   </Stack>
                 </Label>
               }
               invalid={!!errors.namespaceName}
               error={errors.namespaceName?.message}
             >
-              <Input
-                id="namespaceName"
-                {...register('namespaceName', {
-                  required: 'Namespace name is required.',
-                })}
-              />
+              {isGrafanaManagedGroup ? (
+                <>{nameSpaceName}</>
+              ) : (
+                <Input
+                  id="namespaceName"
+                  {...register('namespaceName', {
+                    required: 'Namespace name is required.',
+                  })}
+                />
+              )}
             </Field>
             <Field
               label={

--- a/public/app/features/alerting/unified/components/rules/RulesGroup.tsx
+++ b/public/app/features/alerting/unified/components/rules/RulesGroup.tsx
@@ -13,7 +13,7 @@ import { useFolder } from '../../hooks/useFolder';
 import { useHasRuler } from '../../hooks/useHasRuler';
 import { deleteRulesGroupAction } from '../../state/actions';
 import { useRulesAccess } from '../../utils/accessControlHooks';
-import { GRAFANA_RULES_SOURCE_NAME, isCloudRulesSource } from '../../utils/datasource';
+import { getRulesSourceName, GRAFANA_RULES_SOURCE_NAME, isCloudRulesSource } from '../../utils/datasource';
 import { makeFolderLink } from '../../utils/misc';
 import { isFederatedRuleGroup, isGrafanaRulerRule } from '../../utils/rules';
 import { CollapseToggle } from '../CollapseToggle';
@@ -224,7 +224,14 @@ export const RulesGroup: FC<Props> = React.memo(({ group, namespace, expandAll, 
       {!isCollapsed && (
         <RulesTable showSummaryColumn={true} className={styles.rulesTable} showGuidelines={true} rules={group.rules} />
       )}
-      {isEditingGroup && <EditCloudGroupModal group={group} namespace={namespace} onClose={() => closeEditModal()} />}
+      {isEditingGroup && (
+        <EditCloudGroupModal
+          groupInterval={group.interval ?? ''}
+          nameSpaceAndGroup={{ group: group, namespace: namespace }}
+          sourceName={getRulesSourceName(namespace.rulesSource)}
+          onClose={() => closeEditModal()}
+        />
+      )}
       {isReorderingGroup && (
         <ReorderCloudGroupModal group={group} namespace={namespace} onClose={() => setIsReorderingGroup(false)} />
       )}

--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -774,7 +774,9 @@ export const rulesInSameGroupHaveInvalidFor = (
 
   return rulesSameGroup.filter((rule: RulerRuleDTO) => {
     const { forDuration } = getAlertInfo(rule, everyDuration);
-    return safeParseDurationstr(forDuration) < safeParseDurationstr(everyDuration);
+    const forNumber = safeParseDurationstr(forDuration);
+    const everyNumber = safeParseDurationstr(everyDuration);
+    return forNumber !== 0 && forNumber < everyNumber;
   });
 };
 

--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -27,7 +27,6 @@ import {
 import {
   PostableRulerRuleGroupDTO,
   PromApplication,
-  RulerGrafanaRuleDTO,
   RulerRuleDTO,
   RulerRulesConfigDTO,
 } from 'app/types/unified-alerting-dto';
@@ -436,8 +435,6 @@ export function deleteRuleAction(
     );
   };
 }
-
-export const isRulerGrafanaRuleDTO = (rule: RulerRuleDTO): rule is RulerGrafanaRuleDTO => 'grafana_alert' in rule;
 
 export const saveRuleFormAction = createAsyncThunk(
   'unifiedalerting/saveRuleForm',

--- a/public/app/features/alerting/unified/types/rule-form.ts
+++ b/public/app/features/alerting/unified/types/rule-form.ts
@@ -27,7 +27,6 @@ export interface RuleFormValues {
   noDataState: GrafanaAlertStateDecision;
   execErrState: GrafanaAlertStateDecision;
   folder: RuleForm | null;
-  evaluateEvery: string;
   evaluateFor: string;
 
   // cortex / loki rules

--- a/public/app/features/alerting/unified/utils/rule-form.ts
+++ b/public/app/features/alerting/unified/utils/rule-form.ts
@@ -59,7 +59,6 @@ export const getDefaultFormValues = (): RuleFormValues => {
     condition: '',
     noDataState: GrafanaAlertStateDecision.NoData,
     execErrState: GrafanaAlertStateDecision.Error,
-    evaluateEvery: '1m',
     evaluateFor: '5m',
 
     // cortex / loki
@@ -126,7 +125,6 @@ export function rulerRuleToFormValues(ruleWithLocation: RuleWithLocation): RuleF
         type: RuleFormType.grafana,
         group: group.name,
         evaluateFor: rule.for || '0',
-        evaluateEvery: group.interval || defaultFormValues.evaluateEvery,
         noDataState: ga.no_data_state,
         execErrState: ga.exec_err_state,
         queries: ga.data,

--- a/public/app/features/alerting/unified/utils/rulerClient.ts
+++ b/public/app/features/alerting/unified/utils/rulerClient.ts
@@ -22,8 +22,8 @@ import {
 export interface RulerClient {
   findEditableRule(ruleIdentifier: RuleIdentifier): Promise<RuleWithLocation | null>;
   deleteRule(ruleWithLocation: RuleWithLocation): Promise<void>;
-  saveLotexRule(values: RuleFormValues, existing?: RuleWithLocation): Promise<RuleIdentifier>;
-  saveGrafanaRule(values: RuleFormValues, existing?: RuleWithLocation): Promise<RuleIdentifier>;
+  saveLotexRule(values: RuleFormValues, evaluateEvery: string, existing?: RuleWithLocation): Promise<RuleIdentifier>;
+  saveGrafanaRule(values: RuleFormValues, evaluateEvery: string, existing?: RuleWithLocation): Promise<RuleIdentifier>;
 }
 
 export function getRulerClient(rulerConfig: RulerDataSourceConfig): RulerClient {
@@ -95,7 +95,11 @@ export function getRulerClient(rulerConfig: RulerDataSourceConfig): RulerClient 
     });
   };
 
-  const saveLotexRule = async (values: RuleFormValues, existing?: RuleWithLocation): Promise<RuleIdentifier> => {
+  const saveLotexRule = async (
+    values: RuleFormValues,
+    evaluateEvery: string,
+    existing?: RuleWithLocation
+  ): Promise<RuleIdentifier> => {
     const { dataSourceName, group, namespace } = values;
     const formRule = formValuesToRulerRuleDTO(values);
     if (dataSourceName && group && namespace) {
@@ -116,6 +120,7 @@ export function getRulerClient(rulerConfig: RulerDataSourceConfig): RulerClient 
             rules: freshExisting.group.rules.map((existingRule) =>
               existingRule === freshExisting.rule ? formRule : existingRule
             ),
+            evaluateEvery: evaluateEvery,
           };
           await setRulerRuleGroup(rulerConfig, namespace, payload);
           return ruleId.fromRulerRule(dataSourceName, namespace, group, formRule);
@@ -143,8 +148,12 @@ export function getRulerClient(rulerConfig: RulerDataSourceConfig): RulerClient 
     }
   };
 
-  const saveGrafanaRule = async (values: RuleFormValues, existingRule?: RuleWithLocation): Promise<RuleIdentifier> => {
-    const { folder, group, evaluateEvery } = values;
+  const saveGrafanaRule = async (
+    values: RuleFormValues,
+    evaluateEvery: string,
+    existingRule?: RuleWithLocation
+  ): Promise<RuleIdentifier> => {
+    const { folder, group } = values;
     if (!folder) {
       throw new Error('Folder must be specified');
     }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR improves the alert rule form (only for grafana-managed alert rules)regarding evaluation interval concept. It makes more clear that the evaluation interval does not belong to the alert rule but to the group.

This PR adds the following changes: 

- Folder, group and evaluation interval has been moved to the same section (as they have to be handled as a block)
- Group becomes a drop-down list with the list of groups belonging to the current selected folder in the form.
- Evaluation interval by default it's not an editable field (as it belongs to the group, not to the alert). 
- But it can be updated by clicking on the 'Edit group' button. This button will open the `EditRuleGroupModal`, and in this case, user only can update the evaluation field.
- New groups, created from this form, have to be saved before being able to edit this evaluation interval.
- As we need to fetch ruler rules for these validations and for populating the groups drop-down, in case this response takes too much time, we will show this loading spinner without blocking the rest of the UI: 

Fixes #50290 
Fixes https://github.com/grafana/alerting-squad/issues/375

**Special notes for your reviewer**:

https://user-images.githubusercontent.com/33540275/200881209-4febeabb-65b7-4ac5-bfd5-c2f7c704fe44.mp4


@brendamuir changes have been done in these sections: 

<img width="746" alt="Screenshot 2022-11-09 at 16 55 24" src="https://user-images.githubusercontent.com/33540275/200878072-cd7fc442-b7fc-41c1-b782-3c5a0a6e8e93.png">


<img width="702" alt="Screenshot 2022-11-09 at 16 55 31" src="https://user-images.githubusercontent.com/33540275/200878096-8315b0e5-237f-443d-b2ce-d4b7b25561ce.png">


<img width="673" alt="Screenshot 2022-11-09 at 16 55 42" src="https://user-images.githubusercontent.com/33540275/200878155-ba641f80-82c0-4d79-8a5f-001431e35984.png">

<img width="420" alt="Screenshot 2022-11-09 at 16 55 47" src="https://user-images.githubusercontent.com/33540275/200878228-ff0dd7fa-a533-46f4-b862-34dcdf822b6e.png">


<img width="525" alt="Screenshot 2022-11-09 at 16 55 52" src="https://user-images.githubusercontent.com/33540275/200878261-7d48ff0a-f20a-4b4c-b35a-e5366c6b04af.png">

