### PR TITLE
Prometheus: Add `virtualized` prop to improve memory usage listing Metrics

### DIFF
--- a/public/app/plugins/datasource/prometheus/querybuilder/components/MetricSelect.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/MetricSelect.tsx
@@ -64,6 +64,7 @@ export function MetricSelect({ query, onChange, onGetMetrics }: Props) {
           className={styles.select}
           value={query.metric ? toOption(query.metric) : undefined}
           placeholder="Select metric"
+          virtualized
           allowCustomValue
           formatOptionLabel={formatOptionLabel}
           filterOption={customFilterOption}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds the `virtualized` property to the Select Metric field to reduce memory usage overhead while listing Metrics.

**Which issue(s) this PR fixes**:

Fixes #52171
Escalation https://github.com/grafana/support-escalations/issues/4008
Escalation https://github.com/grafana/support-escalations/issues/4053

**Special notes for your reviewer**:

You need to have several metrics to start to figure out the performance issue. Here's a demo:

- Before add `virtualized` prop:

https://user-images.githubusercontent.com/1680157/194077440-a5ead6cf-ae66-45c9-96cb-94e8156931dc.mov

- After add `virtualized` prop:

https://user-images.githubusercontent.com/1680157/194077733-c007482a-25e4-4fde-87c0-783cba36d55b.mov


