### PR TITLE
Expressions: make reduce inputs compacter

### DIFF
--- a/public/app/features/expressions/components/Reduce.tsx
+++ b/public/app/features/expressions/components/Reduce.tsx
@@ -67,17 +67,21 @@ export const Reduce: FC<Props> = ({ labelWidth = 'auto', onChange, refIds, query
   };
 
   return (
-    <InlineFieldRow>
-      <InlineField label="Function" labelWidth={labelWidth}>
-        <Select options={reducerTypes} value={reducer} onChange={onSelectReducer} width={25} />
-      </InlineField>
-      <InlineField label="Input" labelWidth={labelWidth}>
-        <Select onChange={onRefIdChange} options={refIds} value={query.expression} width={20} />
-      </InlineField>
-      <InlineField label="Mode" labelWidth={labelWidth}>
-        <Select onChange={onModeChanged} options={reducerMode} value={mode} width={25} />
-      </InlineField>
-      {replaceWithNumber()}
-    </InlineFieldRow>
+    <>
+      <InlineFieldRow>
+        <InlineField label="Function" labelWidth={labelWidth}>
+          <Select options={reducerTypes} value={reducer} onChange={onSelectReducer} width={20} />
+        </InlineField>
+        <InlineField label="Input" labelWidth={labelWidth}>
+          <Select onChange={onRefIdChange} options={refIds} value={query.expression} width={'auto'} />
+        </InlineField>
+      </InlineFieldRow>
+      <InlineFieldRow>
+        <InlineField label="Mode" labelWidth={labelWidth}>
+          <Select onChange={onModeChanged} options={reducerMode} value={mode} width={25} />
+        </InlineField>
+        {replaceWithNumber()}
+      </InlineFieldRow>
+    </>
   );
 };


### PR DESCRIPTION
**What this PR does / why we need it**:

When the new `topnav` feature flag is enabled we have a bit less horizontal screen real estate to work with – this change introduces a separate inline field row so we can fit at least two expressions in the alert creation flow while not impacting how it's working in the existing panel edit view.

**Alert creation**
<img width="391" alt="image" src="https://user-images.githubusercontent.com/868844/194089375-efe9a46e-2c46-4dba-a13d-e41ee09d33e9.png">

**Panel edit**
<img width="842" alt="image" src="https://user-images.githubusercontent.com/868844/194089559-cdb8d1f0-e278-486e-b206-0d761d156ab2.png">


