### PR TITLE
NavTree: Don't add license and stats page unless your a Grafana Admin

### DIFF
--- a/pkg/services/licensing/oss.go
+++ b/pkg/services/licensing/oss.go
@@ -55,6 +55,10 @@ func ProvideService(cfg *setting.Cfg, hooksService *hooks.HooksService) *OSSLice
 		HooksService: hooksService,
 	}
 	l.HooksService.AddIndexDataHook(func(indexData *dtos.IndexViewData, req *models.ReqContext) {
+		if !req.IsGrafanaAdmin {
+			return
+		}
+
 		if adminNode := indexData.NavTree.FindById(navtree.NavIDAdmin); adminNode != nil {
 			adminNode.Children = append(adminNode.Children, &navtree.NavLink{
 				Text: "Stats and license",


### PR DESCRIPTION
After https://github.com/grafana/grafana/pull/55484 the admin and server admin sections are added always even if there are no children during the first phase of navtree building.

The reason for that is that here are multiple subsequent steps that can add things to those sections (in enterprise). The sections are removed if there are no child pages in them as a last step.

But after this step the stats and license page is now always added even for users who have no access to this page (Viewers for example). There was no permission
check when adding this page, it sort of piggy packed on other permission checks by just checking if the admin section exists in the navtree.

Not sure what the permission check should be. The the URL for the page is requiring Grafana Admin permission


