### PR TITLE
Alerting: use virtualized list of namespaces / groups for cloud rules

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -3333,9 +3333,6 @@ exports[`better eslint`] = {
     "public/app/features/alerting/unified/components/rule-editor/RuleInspector.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
-    "public/app/features/alerting/unified/components/rule-editor/SelectWIthAdd.tsx:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"]
-    ],
     "public/app/features/alerting/unified/components/rules/RuleDetailsDataSources.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],

--- a/packages/grafana-ui/src/components/Select/SelectMenu.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectMenu.tsx
@@ -63,11 +63,12 @@ export const VirtualizedSelectMenu: FC<MenuListProps<SelectableValue>> = ({
 
   const longestOption = max(options.map((option) => option.label?.length)) ?? 0;
   const widthEstimate = longestOption * VIRTUAL_LIST_WIDTH_ESTIMATE_MULTIPLIER;
+  const heightEstimate = Math.min(options.length * VIRTUAL_LIST_ITEM_HEIGHT, maxHeight);
 
   return (
     <List
       className={styles.menu}
-      height={maxHeight}
+      height={heightEstimate}
       width={widthEstimate}
       aria-label="Select options menu"
       itemCount={children.length}

--- a/public/app/features/alerting/unified/components/rule-editor/GroupAndNamespaceFields.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/GroupAndNamespaceFields.tsx
@@ -1,16 +1,15 @@
 import { css } from '@emotion/css';
-import React, { FC, useEffect, useMemo, useState } from 'react';
+import React, { FC, useEffect, useMemo } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import { GrafanaTheme2, SelectableValue } from '@grafana/data';
-import { Field, InputControl, useStyles2 } from '@grafana/ui';
+import { Field, InputControl, useStyles2, VirtualizedSelect } from '@grafana/ui';
 import { useDispatch } from 'app/types';
 
 import { useUnifiedAlertingSelector } from '../../hooks/useUnifiedAlertingSelector';
 import { fetchRulerRulesAction } from '../../state/actions';
 import { RuleFormValues } from '../../types/rule-form';
 
-import { SelectWithAdd } from './SelectWIthAdd';
 import { checkForPathSeparator } from './util';
 
 interface Props {
@@ -26,8 +25,6 @@ export const GroupAndNamespaceFields: FC<Props> = ({ rulesSourceName }) => {
   } = useFormContext<RuleFormValues>();
 
   const style = useStyles2(getStyle);
-
-  const [customGroup, setCustomGroup] = useState(false);
 
   const rulerRequests = useUnifiedAlertingSelector((state) => state.rulerRules);
   const dispatch = useDispatch();
@@ -61,15 +58,13 @@ export const GroupAndNamespaceFields: FC<Props> = ({ rulesSourceName }) => {
       >
         <InputControl
           render={({ field: { onChange, ref, ...field } }) => (
-            <SelectWithAdd
+            <VirtualizedSelect
               {...field}
+              allowCustomValue
               className={style.input}
               onChange={(value) => {
                 setValue('group', ''); //reset if namespace changes
-                onChange(value);
-              }}
-              onCustomChange={(custom: boolean) => {
-                custom && setCustomGroup(true);
+                onChange(value.value);
               }}
               options={namespaceOptions}
               width={42}
@@ -88,7 +83,16 @@ export const GroupAndNamespaceFields: FC<Props> = ({ rulesSourceName }) => {
       <Field data-testid="group-picker" label="Group" error={errors.group?.message} invalid={!!errors.group?.message}>
         <InputControl
           render={({ field: { ref, ...field } }) => (
-            <SelectWithAdd {...field} options={groupOptions} width={42} custom={customGroup} className={style.input} />
+            <VirtualizedSelect
+              {...field}
+              allowCustomValue
+              options={groupOptions}
+              width={42}
+              onChange={(value) => {
+                setValue('group', value.value ?? '');
+              }}
+              className={style.input}
+            />
           )}
           name="group"
           control={control}

--- a/public/app/features/alerting/unified/components/rule-editor/SelectWIthAdd.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/SelectWIthAdd.tsx
@@ -1,7 +1,7 @@
-import React, { FC, useEffect, useMemo, useState } from 'react';
+import React, { FC } from 'react';
 
 import { SelectableValue } from '@grafana/data';
-import { Input, Select } from '@grafana/ui';
+import { VirtualizedSelect } from '@grafana/ui';
 
 interface Props {
   onChange: (value: string) => void;
@@ -24,61 +24,23 @@ export const SelectWithAdd: FC<Props> = ({
   className,
   placeholder,
   width,
-  custom,
-  onCustomChange,
   disabled = false,
-  addLabel = '+ Add new',
   'aria-label': ariaLabel,
 }) => {
-  const [isCustom, setIsCustom] = useState(custom);
-
-  useEffect(() => {
-    if (custom) {
-      setIsCustom(custom);
-    }
-  }, [custom]);
-
-  const _options = useMemo(
-    (): Array<SelectableValue<string>> => [...options, { value: '__add__', label: addLabel }],
-    [options, addLabel]
+  return (
+    <VirtualizedSelect
+      aria-label={ariaLabel}
+      width={width}
+      options={options}
+      allowCustomValue
+      value={value}
+      className={className}
+      placeholder={placeholder}
+      disabled={disabled}
+      onChange={(val: SelectableValue) => {
+        const value = val?.value;
+        onChange(value);
+      }}
+    />
   );
-
-  if (isCustom) {
-    return (
-      <Input
-        aria-label={ariaLabel}
-        width={width}
-        autoFocus={!custom}
-        value={value || ''}
-        placeholder={placeholder}
-        className={className}
-        disabled={disabled}
-        onChange={(e) => onChange((e.target as HTMLInputElement).value)}
-      />
-    );
-  } else {
-    return (
-      <Select
-        aria-label={ariaLabel}
-        width={width}
-        options={_options}
-        value={value}
-        className={className}
-        placeholder={placeholder}
-        disabled={disabled}
-        onChange={(val: SelectableValue) => {
-          const value = val?.value;
-          if (value === '__add__') {
-            setIsCustom(true);
-            if (onCustomChange) {
-              onCustomChange(true);
-            }
-            onChange('');
-          } else {
-            onChange(value);
-          }
-        }}
-      />
-    );
-  }
 };

--- a/public/app/features/alerting/unified/components/rule-editor/SelectWIthAdd.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/SelectWIthAdd.tsx
@@ -1,7 +1,7 @@
-import React, { FC } from 'react';
+import React, { FC, useEffect, useMemo, useState } from 'react';
 
 import { SelectableValue } from '@grafana/data';
-import { VirtualizedSelect } from '@grafana/ui';
+import { Input, Select } from '@grafana/ui';
 
 interface Props {
   onChange: (value: string) => void;
@@ -24,23 +24,61 @@ export const SelectWithAdd: FC<Props> = ({
   className,
   placeholder,
   width,
+  custom,
+  onCustomChange,
   disabled = false,
+  addLabel = '+ Add new',
   'aria-label': ariaLabel,
 }) => {
-  return (
-    <VirtualizedSelect
-      aria-label={ariaLabel}
-      width={width}
-      options={options}
-      allowCustomValue
-      value={value}
-      className={className}
-      placeholder={placeholder}
-      disabled={disabled}
-      onChange={(val: SelectableValue) => {
-        const value = val?.value;
-        onChange(value);
-      }}
-    />
+  const [isCustom, setIsCustom] = useState(custom);
+
+  useEffect(() => {
+    if (custom) {
+      setIsCustom(custom);
+    }
+  }, [custom]);
+
+  const _options = useMemo(
+    (): Array<SelectableValue<string>> => [...options, { value: '__add__', label: addLabel }],
+    [options, addLabel]
   );
+
+  if (isCustom) {
+    return (
+      <Input
+        aria-label={ariaLabel}
+        width={width}
+        autoFocus={!custom}
+        value={value || ''}
+        placeholder={placeholder}
+        className={className}
+        disabled={disabled}
+        onChange={(e) => onChange(e.currentTarget.value)}
+      />
+    );
+  } else {
+    return (
+      <Select
+        aria-label={ariaLabel}
+        width={width}
+        options={_options}
+        value={value}
+        className={className}
+        placeholder={placeholder}
+        disabled={disabled}
+        onChange={(val: SelectableValue) => {
+          const value = val?.value;
+          if (value === '__add__') {
+            setIsCustom(true);
+            if (onCustomChange) {
+              onCustomChange(true);
+            }
+            onChange('');
+          } else {
+            onChange(value);
+          }
+        }}
+      />
+    );
+  }
 };


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR uses a virtualized list for selecting namespaces / groups when authoring Mimir or Loki alert or recording rules.

It also removed a separate "Add new item" option from the bottom of the list as it's not compatible with large lists – instead I've added the `allowCustomValue` property that allows creating custom values by typing in the `Select` component.

**Special notes for your reviewer**:

This also adds a small fix to the `VirtualizedList` when the amount of options is smaller than `maxHeight`.

