### PR TITLE
[9.2.x] Alerting: Start ticker only when scheduler starts (#56339)

### DIFF
--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -41,7 +41,6 @@ type ScheduleService interface {
 	// the following are used by tests only used for tests
 	evalApplied(ngmodels.AlertRuleKey, time.Time)
 	stopApplied(ngmodels.AlertRuleKey)
-	overrideCfg(cfg SchedulerCfg)
 }
 
 // AlertsSender is an interface for a service that is responsible for sending notifications to the end-user.
@@ -67,8 +66,6 @@ type schedule struct {
 	maxAttempts int64
 
 	clock clock.Clock
-
-	ticker *alerting.Ticker
 
 	// evalApplied is only used for tests: test code can set it to non-nil
 	// function, and then it'll be called from the event loop whenever the
@@ -119,15 +116,12 @@ type SchedulerCfg struct {
 
 // NewScheduler returns a new schedule.
 func NewScheduler(cfg SchedulerCfg, appURL *url.URL, stateManager *state.Manager) *schedule {
-	ticker := alerting.NewTicker(cfg.C, cfg.Cfg.BaseInterval, cfg.Metrics.Ticker)
-
 	sch := schedule{
 		registry:              alertRuleInfoRegistry{alertRuleInfo: make(map[ngmodels.AlertRuleKey]*alertRuleInfo)},
 		maxAttempts:           cfg.Cfg.MaxAttempts,
 		clock:                 cfg.C,
 		baseInterval:          cfg.Cfg.BaseInterval,
 		log:                   cfg.Logger,
-		ticker:                ticker,
 		evalAppliedFunc:       cfg.EvalAppliedFunc,
 		stopAppliedFunc:       cfg.StopAppliedFunc,
 		evaluator:             cfg.Evaluator,
@@ -145,9 +139,10 @@ func NewScheduler(cfg SchedulerCfg, appURL *url.URL, stateManager *state.Manager
 }
 
 func (sch *schedule) Run(ctx context.Context) error {
-	defer sch.ticker.Stop()
+	t := alerting.NewTicker(sch.clock, sch.baseInterval, sch.metrics.Ticker)
+	defer t.Stop()
 
-	if err := sch.schedulePeriodic(ctx); err != nil {
+	if err := sch.schedulePeriodic(ctx, t); err != nil {
 		sch.log.Error("failure while running the rule evaluation loop", "err", err)
 	}
 	return nil
@@ -186,11 +181,11 @@ func (sch *schedule) DeleteAlertRule(keys ...ngmodels.AlertRuleKey) {
 	sch.metrics.SchedulableAlertRulesHash.Set(float64(hashUIDs(alertRules)))
 }
 
-func (sch *schedule) schedulePeriodic(ctx context.Context) error {
+func (sch *schedule) schedulePeriodic(ctx context.Context, t *alerting.Ticker) error {
 	dispatcherGroup, ctx := errgroup.WithContext(ctx)
 	for {
 		select {
-		case tick := <-sch.ticker.C:
+		case tick := <-t.C:
 			// We use Round(0) on the start time to remove the monotonic clock.
 			// This is required as ticks from the ticker and time.Now() can have
 			// a monotonic clock that when subtracted do not represent the delta
@@ -442,16 +437,6 @@ func (sch *schedule) ruleRoutine(grafanaCtx context.Context, key ngmodels.AlertR
 			return nil
 		}
 	}
-}
-
-// overrideCfg is only used on tests.
-func (sch *schedule) overrideCfg(cfg SchedulerCfg) {
-	sch.clock = cfg.C
-	sch.baseInterval = cfg.Cfg.BaseInterval
-	sch.ticker.Stop()
-	sch.ticker = alerting.NewTicker(cfg.C, cfg.Cfg.BaseInterval, cfg.Metrics.Ticker)
-	sch.evalAppliedFunc = cfg.EvalAppliedFunc
-	sch.stopAppliedFunc = cfg.StopAppliedFunc
 }
 
 // evalApplied is only used on tests.


### PR DESCRIPTION
This is a backport of PR https://github.com/grafana/grafana/pull/56339 to 9.2.x branch


### Changelog ###
Alerting: the scheduler is fixed to not accumulate pending evaluations if the Grafana startup takes a long time (10s+).