### PR TITLE
influxdb: influxdb version 1 fails to connect when bucket is empty

### DIFF
--- a/pkg/tsdb/influxdb/healthcheck.go
+++ b/pkg/tsdb/influxdb/healthcheck.go
@@ -100,6 +100,11 @@ func CheckInfluxQLHealth(ctx context.Context, dsInfo *models.DatasourceInfo, s *
 		if res.Error != nil {
 			return getHealthCheckMessage(s, "error reading influxDB", res.Error)
 		}
+
+		if len(res.Frames) == 0 {
+			return getHealthCheckMessage(s, "0 measurements found", nil)
+		}
+
 		if len(res.Frames) > 0 && len(res.Frames[0].Fields) > 0 {
 			return getHealthCheckMessage(s, fmt.Sprintf("%d measurements found", res.Frames[0].Fields[0].Len()), nil)
 		}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Right now we're showing an error that we are unable to connect to influx when influx is just returning no results, so users that haven't hooked up telegraf or added any measurements to their bucket are led to believe that influx isn't connected properly, this PR simply returns a successful message when 0 results are returned.

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/grafana/issues/55707

**Special notes for your reviewer**:
I am inexperienced with go!
