### PR TITLE
CI: Change from `./bin/grabpl` to `./bin/build` for grafana-com subcommand

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3667,6 +3667,13 @@ steps:
   image: byrnedo/alpine-curl:0.1.8
   name: grabpl
 - commands:
+  - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
+  depends_on: []
+  environment:
+    CGO_ENABLED: 0
+  image: golang:1.19.1
+  name: compile-build-cmd
+- commands:
   - ./bin/grabpl publish packages --edition oss --gcp-key /tmp/gcpkey.json ${DRONE_TAG}
   depends_on:
   - grabpl
@@ -3684,7 +3691,7 @@ steps:
   image: grafana/grafana-ci-deploy:1.3.3
   name: publish-packages-oss
 - commands:
-  - ./bin/grabpl publish grafana-com --edition oss ${DRONE_TAG}
+  - ./bin/build publish grafana-com --edition oss ${DRONE_TAG}
   depends_on:
   - publish-packages-oss
   environment:
@@ -3749,6 +3756,13 @@ steps:
   image: byrnedo/alpine-curl:0.1.8
   name: grabpl
 - commands:
+  - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
+  depends_on: []
+  environment:
+    CGO_ENABLED: 0
+  image: golang:1.19.1
+  name: compile-build-cmd
+- commands:
   - ./bin/grabpl publish packages --edition enterprise --gcp-key /tmp/gcpkey.json
     ${DRONE_TAG}
   depends_on:
@@ -3767,7 +3781,7 @@ steps:
   image: grafana/grafana-ci-deploy:1.3.3
   name: publish-packages-enterprise
 - commands:
-  - ./bin/grabpl publish grafana-com --edition enterprise ${DRONE_TAG}
+  - ./bin/build publish grafana-com --edition enterprise ${DRONE_TAG}
   depends_on:
   - publish-packages-enterprise
   environment:
@@ -5236,15 +5250,16 @@ platform:
   os: linux
 steps:
 - commands:
-  - mkdir -p bin
-  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v3.0.11/grabpl
-  - chmod +x bin/grabpl
-  image: byrnedo/alpine-curl:0.1.8
-  name: grabpl
+  - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
+  depends_on: []
+  environment:
+    CGO_ENABLED: 0
+  image: golang:1.19.1
+  name: compile-build-cmd
 - commands:
-  - ./bin/grabpl publish grafana-com --edition oss
+  - ./bin/build publish grafana-com --edition oss
   depends_on:
-  - grabpl
+  - compile-build-cmd
   environment:
     GCP_KEY:
       from_secret: gcp_key
@@ -5324,6 +5339,6 @@ kind: secret
 name: packages_secret_access_key
 ---
 kind: signature
-hmac: 539cf8d41fba415e57c706a53c93b0f92ff3f69c48ba43526ea95ae506690d2d
+hmac: 5ff426194c616a934af92cb113aebbb6cebf06d6317e62a693f4f8d7faa3b4cd
 
 ...

--- a/scripts/drone/events/cron.star
+++ b/scripts/drone/events/cron.star
@@ -1,5 +1,5 @@
 load('scripts/drone/vault.star', 'from_secret', 'pull_secret')
-load('scripts/drone/steps/lib.star', 'publish_image', 'download_grabpl_step')
+load('scripts/drone/steps/lib.star', 'publish_image', 'compile_build_cmd')
 
 aquasec_trivy_image = 'aquasec/trivy:0.21.0'
 
@@ -7,7 +7,7 @@ def cronjobs(edition):
     grafana_com_nightly_pipeline = cron_job_pipeline(
         cronName='grafana-com-nightly',
         name='grafana-com-nightly',
-        steps=[download_grabpl_step(),post_to_grafana_com_step()]
+        steps=[compile_build_cmd(),post_to_grafana_com_step()]
     )
     return [
         scan_docker_image_pipeline(edition, 'latest'),
@@ -93,7 +93,7 @@ def post_to_grafana_com_step():
                 'GRAFANA_COM_API_KEY': from_secret('grafana_api_key'),
                 'GCP_KEY': from_secret('gcp_key'),
             },
-            'depends_on': ['grabpl'],
-            'commands': ['./bin/grabpl publish grafana-com --edition oss'],
+            'depends_on': ['compile-build-cmd'],
+            'commands': ['./bin/build publish grafana-com --edition oss'],
         }
 

--- a/scripts/drone/events/release.star
+++ b/scripts/drone/events/release.star
@@ -404,6 +404,7 @@ def publish_packages_pipeline():
     }
     oss_steps = [
         download_grabpl_step(),
+        compile_build_cmd(),
         publish_packages_step(edition='oss', ver_mode='release'),
         publish_grafanacom_step(edition='oss', ver_mode='release'),
         publish_linux_packages_step(edition='oss'),
@@ -411,6 +412,7 @@ def publish_packages_pipeline():
 
     enterprise_steps = [
         download_grabpl_step(),
+        compile_build_cmd(),
         publish_packages_step(edition='enterprise', ver_mode='release'),
         publish_grafanacom_step(edition='enterprise', ver_mode='release'),
         publish_linux_packages_step(edition='enterprise'),

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -1012,12 +1012,12 @@ def publish_packages_step(edition, ver_mode):
 
 def publish_grafanacom_step(edition, ver_mode):
     if ver_mode == 'release':
-        cmd = './bin/grabpl publish grafana-com --edition {} ${{DRONE_TAG}}'.format(
+        cmd = './bin/build publish grafana-com --edition {} ${{DRONE_TAG}}'.format(
             edition,
         )
     elif ver_mode == 'main':
         build_no = '${DRONE_BUILD_NUMBER}'
-        cmd = './bin/grabpl publish grafana-com --edition {} --build-id {}'.format(
+        cmd = './bin/build publish grafana-com --edition {} --build-id {}'.format(
             edition, build_no,
         )
     else:


### PR DESCRIPTION
**What this PR does / why we need it**:

After `grafana-com` was moved to OSS from `build-pipeline` repo, we forgot to change the binary from which the command should be called. This PR fixes the issue.

**Which issue(s) this PR fixes**:

Fixes: #54440