### PR TITLE
Packaging: Change from `0750` to `0755` folder permissions when packaging

### DIFF
--- a/pkg/build/packaging/grafana.go
+++ b/pkg/build/packaging/grafana.go
@@ -102,7 +102,7 @@ func packageGrafana(
 	if !exists {
 		log.Printf("directory %s doesn't exist - creating...", distDir)
 		//nolint
-		if err := os.MkdirAll(distDir, 0755); err != nil {
+		if err := os.MkdirAll(distDir, 0o755); err != nil {
 			return fmt.Errorf("couldn't create dist: %w", err)
 		}
 	}
@@ -305,7 +305,7 @@ func createPackage(srcDir string, options linuxPackageOptions) error {
 	} {
 		dpath := filepath.Join(packageRoot, dname)
 		//nolint
-		if err := os.MkdirAll(dpath, 0755); err != nil {
+		if err := os.MkdirAll(dpath, 0o755); err != nil {
 			return fmt.Errorf("failed to make directory %q: %w", dpath, err)
 		}
 	}
@@ -334,7 +334,7 @@ func createPackage(srcDir string, options linuxPackageOptions) error {
 		return fmt.Errorf("failed to remove %q: %w", homeBinDir, err)
 	}
 	//nolint
-	if err := os.MkdirAll(homeBinDir, 0755); err != nil {
+	if err := os.MkdirAll(homeBinDir, 0o755); err != nil {
 		return fmt.Errorf("failed to make directory %q: %w", homeBinDir, err)
 	}
 	// The grafana-cli binary is exposed through a wrapper to ensure a proper
@@ -448,7 +448,7 @@ func copyPubDir(grafanaDir, tmpDir string) error {
 func copyBinaries(grafanaDir, tmpDir string, args grafana.BuildArgs, edition config.Edition) error {
 	tgtDir := filepath.Join(tmpDir, "bin")
 	//nolint
-	if err := os.MkdirAll(tgtDir, 0755); err != nil {
+	if err := os.MkdirAll(tgtDir, 0o755); err != nil {
 		return fmt.Errorf("failed to make directory %q: %w", tgtDir, err)
 	}
 
@@ -478,7 +478,7 @@ func copyBinaries(grafanaDir, tmpDir string, args grafana.BuildArgs, edition con
 // copyScripts copies scripts from grafanaDir into tmpDir.
 func copyScripts(grafanaDir, tmpDir string) error {
 	//nolint
-	if err := os.MkdirAll(filepath.Join(tmpDir, "scripts"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(tmpDir, "scripts"), 0o755); err != nil {
 		return fmt.Errorf("failed to create dir %q: %w", filepath.Join(tmpDir, "scripts"), err)
 	}
 	scriptsDir := filepath.Join(grafanaDir, "scripts")
@@ -515,7 +515,7 @@ func copyScripts(grafanaDir, tmpDir string) error {
 // copyConfFiles copies configuration files from grafanaDir into tmpDir.
 func copyConfFiles(grafanaDir, tmpDir string) error {
 	//nolint:gosec
-	if err := os.MkdirAll(filepath.Join(tmpDir, "conf"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(tmpDir, "conf"), 0o755); err != nil {
 		return fmt.Errorf("failed to create dir %q: %w", filepath.Join(tmpDir, "conf"), err)
 	}
 
@@ -551,7 +551,7 @@ func copyPlugins(ctx context.Context, v config.Variant, grafanaDir, tmpDir strin
 	}
 	if !exists {
 		//nolint:gosec
-		if err := os.MkdirAll(tgtDir, 0755); err != nil {
+		if err := os.MkdirAll(tgtDir, 0o755); err != nil {
 			return err
 		}
 	}
@@ -650,7 +650,7 @@ func copyInternalPlugins(pluginsDir, tmpDir string) error {
 		return err
 	}
 	if !exists {
-		if err := os.MkdirAll(tgtDir, 0755); err != nil {
+		if err := os.MkdirAll(tgtDir, 0o755); err != nil {
 			return err
 		}
 	}
@@ -728,7 +728,7 @@ func realPackageVariant(ctx context.Context, v config.Variant, edition config.Ed
 
 	if v == config.VariantWindowsAmd64 {
 		toolsDir := filepath.Join(tmpDir, "tools")
-		if err := os.MkdirAll(toolsDir, 0755); err != nil {
+		if err := os.MkdirAll(toolsDir, 0o755); err != nil {
 			return fmt.Errorf("failed to create tools dir %q: %w", toolsDir, err)
 		}
 
@@ -901,7 +901,7 @@ func createArchive(srcDir string, edition config.Edition, v config.Variant, vers
 	}
 	if !exists {
 		log.Printf("directory %s doesn't exist - creating...", distDir)
-		if err := os.MkdirAll(distDir, 0755); err != nil {
+		if err := os.MkdirAll(distDir, 0o755); err != nil {
 			return fmt.Errorf("couldn't create dist: %w", err)
 		}
 	}

--- a/pkg/build/packaging/grafana.go
+++ b/pkg/build/packaging/grafana.go
@@ -650,6 +650,7 @@ func copyInternalPlugins(pluginsDir, tmpDir string) error {
 		return err
 	}
 	if !exists {
+		//nolint:gosec
 		if err := os.MkdirAll(tgtDir, 0o755); err != nil {
 			return err
 		}
@@ -728,6 +729,7 @@ func realPackageVariant(ctx context.Context, v config.Variant, edition config.Ed
 
 	if v == config.VariantWindowsAmd64 {
 		toolsDir := filepath.Join(tmpDir, "tools")
+		//nolint:gosec
 		if err := os.MkdirAll(toolsDir, 0o755); err != nil {
 			return fmt.Errorf("failed to create tools dir %q: %w", toolsDir, err)
 		}
@@ -901,6 +903,7 @@ func createArchive(srcDir string, edition config.Edition, v config.Variant, vers
 	}
 	if !exists {
 		log.Printf("directory %s doesn't exist - creating...", distDir)
+		//nolint:gosec
 		if err := os.MkdirAll(distDir, 0o755); err != nil {
 			return fmt.Errorf("couldn't create dist: %w", err)
 		}

--- a/pkg/build/packaging/grafana.go
+++ b/pkg/build/packaging/grafana.go
@@ -102,7 +102,7 @@ func packageGrafana(
 	if !exists {
 		log.Printf("directory %s doesn't exist - creating...", distDir)
 		//nolint
-		if err := os.MkdirAll(distDir, 0750); err != nil {
+		if err := os.MkdirAll(distDir, 0755); err != nil {
 			return fmt.Errorf("couldn't create dist: %w", err)
 		}
 	}
@@ -305,7 +305,7 @@ func createPackage(srcDir string, options linuxPackageOptions) error {
 	} {
 		dpath := filepath.Join(packageRoot, dname)
 		//nolint
-		if err := os.MkdirAll(dpath, 0750); err != nil {
+		if err := os.MkdirAll(dpath, 0755); err != nil {
 			return fmt.Errorf("failed to make directory %q: %w", dpath, err)
 		}
 	}
@@ -334,7 +334,7 @@ func createPackage(srcDir string, options linuxPackageOptions) error {
 		return fmt.Errorf("failed to remove %q: %w", homeBinDir, err)
 	}
 	//nolint
-	if err := os.MkdirAll(homeBinDir, 0750); err != nil {
+	if err := os.MkdirAll(homeBinDir, 0755); err != nil {
 		return fmt.Errorf("failed to make directory %q: %w", homeBinDir, err)
 	}
 	// The grafana-cli binary is exposed through a wrapper to ensure a proper
@@ -448,7 +448,7 @@ func copyPubDir(grafanaDir, tmpDir string) error {
 func copyBinaries(grafanaDir, tmpDir string, args grafana.BuildArgs, edition config.Edition) error {
 	tgtDir := filepath.Join(tmpDir, "bin")
 	//nolint
-	if err := os.MkdirAll(tgtDir, 0750); err != nil {
+	if err := os.MkdirAll(tgtDir, 0755); err != nil {
 		return fmt.Errorf("failed to make directory %q: %w", tgtDir, err)
 	}
 
@@ -478,7 +478,7 @@ func copyBinaries(grafanaDir, tmpDir string, args grafana.BuildArgs, edition con
 // copyScripts copies scripts from grafanaDir into tmpDir.
 func copyScripts(grafanaDir, tmpDir string) error {
 	//nolint
-	if err := os.MkdirAll(filepath.Join(tmpDir, "scripts"), 0750); err != nil {
+	if err := os.MkdirAll(filepath.Join(tmpDir, "scripts"), 0755); err != nil {
 		return fmt.Errorf("failed to create dir %q: %w", filepath.Join(tmpDir, "scripts"), err)
 	}
 	scriptsDir := filepath.Join(grafanaDir, "scripts")
@@ -515,7 +515,7 @@ func copyScripts(grafanaDir, tmpDir string) error {
 // copyConfFiles copies configuration files from grafanaDir into tmpDir.
 func copyConfFiles(grafanaDir, tmpDir string) error {
 	//nolint:gosec
-	if err := os.MkdirAll(filepath.Join(tmpDir, "conf"), 0750); err != nil {
+	if err := os.MkdirAll(filepath.Join(tmpDir, "conf"), 0755); err != nil {
 		return fmt.Errorf("failed to create dir %q: %w", filepath.Join(tmpDir, "conf"), err)
 	}
 
@@ -551,7 +551,7 @@ func copyPlugins(ctx context.Context, v config.Variant, grafanaDir, tmpDir strin
 	}
 	if !exists {
 		//nolint:gosec
-		if err := os.MkdirAll(tgtDir, 0750); err != nil {
+		if err := os.MkdirAll(tgtDir, 0755); err != nil {
 			return err
 		}
 	}
@@ -650,7 +650,7 @@ func copyInternalPlugins(pluginsDir, tmpDir string) error {
 		return err
 	}
 	if !exists {
-		if err := os.MkdirAll(tgtDir, 0750); err != nil {
+		if err := os.MkdirAll(tgtDir, 0755); err != nil {
 			return err
 		}
 	}
@@ -728,7 +728,7 @@ func realPackageVariant(ctx context.Context, v config.Variant, edition config.Ed
 
 	if v == config.VariantWindowsAmd64 {
 		toolsDir := filepath.Join(tmpDir, "tools")
-		if err := os.MkdirAll(toolsDir, 0750); err != nil {
+		if err := os.MkdirAll(toolsDir, 0755); err != nil {
 			return fmt.Errorf("failed to create tools dir %q: %w", toolsDir, err)
 		}
 
@@ -901,7 +901,7 @@ func createArchive(srcDir string, edition config.Edition, v config.Variant, vers
 	}
 	if !exists {
 		log.Printf("directory %s doesn't exist - creating...", distDir)
-		if err := os.MkdirAll(distDir, 0750); err != nil {
+		if err := os.MkdirAll(distDir, 0755); err != nil {
 			return fmt.Errorf("couldn't create dist: %w", err)
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

We've seen that after `9.2.0-beta1` and [this](https://github.com/grafana/grafana/pull/55651) particular PR, users weren't able to access `/usr/share/grafana/conf` folder to access configuration files. This happens because while packaging Grafana, we created the `conf` folder using `0750` permissions, so the "others" group didn't have any access to some certain folders.
This PR changes this by going from `0750` folder permissions to `0755` so "others" group can read and execute.
