### PR TITLE
Docs: Update RSS feed in security page

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,4 +16,4 @@ Grafana Labs will send you a response indicating the next steps in handling your
 
 We will post a summary, remediation, and mitigation details for any patch containing security fixes on the Grafana blog. The security announcement blog posts will be tagged with the [security tag](https://grafana.com/tags/security/).
 
-You can also track announcements via the [RSS feed](https://grafana.com/tags/security/index.xml).
+You can also track security announcements via the [RSS feed](https://grafana.com/tags/security/index.xml).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,6 @@ Grafana Labs will send you a response indicating the next steps in handling your
 
 ## Security announcements
 
-We maintain a category on the community site called [Security Announcements](https://community.grafana.com/c/support/security-announcements),
-where we will post a summary, remediation, and mitigation details for any patch containing security fixes.
+We will post a summary, remediation, and mitigation details for any patch containing security fixes on the Grafana blog. The security announcement blog posts will be tagged with the [security tag](https://grafana.com/tags/security/).
 
-You can also subscribe to email updates to this category if you have a grafana.com account and sign on to the community site or track updates via an [RSS feed](https://grafana.com/tags/security/index.xml).
+You can also track announcements via the [RSS feed](https://grafana.com/tags/security/index.xml).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,4 +17,4 @@ Grafana Labs will send you a response indicating the next steps in handling your
 We maintain a category on the community site called [Security Announcements](https://community.grafana.com/c/support/security-announcements),
 where we will post a summary, remediation, and mitigation details for any patch containing security fixes.
 
-You can also subscribe to email updates to this category if you have a grafana.com account and sign on to the community site or track updates via an [RSS feed](https://community.grafana.com/c/support/security-announcements.rss).
+You can also subscribe to email updates to this category if you have a grafana.com account and sign on to the community site or track updates via an [RSS feed](https://grafana.com/tags/security/index.xml).


### PR DESCRIPTION
**What this PR does / why we need it**: 
https://github.com/grafana/grafana/security/policy points to an outdated RSS feed

**Which issue(s) this PR fixes**:
https://grafana.zendesk.com/agent/tickets/64101/conversations/508d881a-441b-11ed-a087-f6899348700d

**Special notes for your reviewer**:
Confirmed by @RichiH at https://raintank-corp.slack.com/archives/C011GT1NESU/p1665040120584659?thread_ts=1664911964.995819&cid=C011GT1NESU
