### PR TITLE
Theme: Change body line-height to fix alignment issue

### DIFF
--- a/packages/grafana-data/src/themes/createTypography.ts
+++ b/packages/grafana-data/src/themes/createTypography.ts
@@ -115,8 +115,8 @@ export function createTypography(colors: ThemeColors, typographyInput: ThemeTypo
     h4: buildVariant(fontWeightRegular, 18, 1.235, 0.25),
     h5: buildVariant(fontWeightRegular, 16, 1.334, 0),
     h6: buildVariant(fontWeightMedium, 14, 1.6, 0.15),
-    body: buildVariant(fontWeightRegular, 14, 1.5, 0.15),
-    bodySmall: buildVariant(fontWeightRegular, 12, 1.5, 0.15),
+    body: buildVariant(fontWeightRegular, 14, 1.57142857143, 0.15),
+    bodySmall: buildVariant(fontWeightRegular, 12, 1.57142857143, 0.15),
   };
 
   const size = {

--- a/packages/grafana-data/src/themes/createTypography.ts
+++ b/packages/grafana-data/src/themes/createTypography.ts
@@ -115,8 +115,10 @@ export function createTypography(colors: ThemeColors, typographyInput: ThemeTypo
     h4: buildVariant(fontWeightRegular, 18, 1.235, 0.25),
     h5: buildVariant(fontWeightRegular, 16, 1.334, 0),
     h6: buildVariant(fontWeightMedium, 14, 1.6, 0.15),
-    body: buildVariant(fontWeightRegular, 14, 1.57142857143, 0.15),
-    bodySmall: buildVariant(fontWeightRegular, 12, 1.57142857143, 0.15),
+    // The line-height of 1.5714285714285714 results in a real line-height of 22px for the default font size. Which is an even number and result in more perfect vertical alignment
+    body: buildVariant(fontWeightRegular, fontSize, 1.5714285714285714, 0.15),
+    // The line-height of 1.5 results in a real line height of 18px for the font size of 12px
+    bodySmall: buildVariant(fontWeightRegular, 12, 1.5, 0.15),
   };
 
   const size = {

--- a/public/sass/_variables.generated.scss
+++ b/public/sass/_variables.generated.scss
@@ -112,7 +112,7 @@ $font-size-md: 14px !default;
 $font-size-sm: 12px !default;
 $font-size-xs: 10px !default;
 
-$line-height-base: 1.57142857143 !default;
+$line-height-base: 1.5714285714285714 !default;
 
 $font-weight-regular: 400 !default;
 $font-weight-semi-bold: 500 !default;
@@ -124,7 +124,7 @@ $font-size-h4: 1.2857142857142858rem !default;
 $font-size-h5: 1.1428571428571428rem !default;
 $font-size-h6: 1rem !default;
 
-$headings-line-height: 1.57142857143 !default;
+$headings-line-height: 1.5 !default;
 
 // Components
 //

--- a/public/sass/_variables.generated.scss
+++ b/public/sass/_variables.generated.scss
@@ -112,7 +112,7 @@ $font-size-md: 14px !default;
 $font-size-sm: 12px !default;
 $font-size-xs: 10px !default;
 
-$line-height-base: 1.5 !default;
+$line-height-base: 1.57142857143 !default;
 
 $font-weight-regular: 400 !default;
 $font-weight-semi-bold: 500 !default;
@@ -124,7 +124,7 @@ $font-size-h4: 1.2857142857142858rem !default;
 $font-size-h5: 1.1428571428571428rem !default;
 $font-size-h6: 1rem !default;
 
-$headings-line-height: 1.5 !default;
+$headings-line-height: 1.57142857143 !default;
 
 // Components
 //


### PR DESCRIPTION
@ashharrison90 discovered that our line-height which is 1.5 results in an odd line-height with our default font size (1.5*14 = 21). This makes some elements feel unaligned (not perfectly vertically centered).

If we change it to to 1.57142857143 then line-height * default font size is an even number. This makes vertical alignment pixel-perfect. 

Among many alignment issues it fixes is the placeholder and value text alignment in all our Selects! Been bugging me for ages! 

Before:
![Screenshot from 2022-10-06 09-46-45](https://user-images.githubusercontent.com/10999/194248795-10771124-a40b-4102-bf44-21197531e707.png)

After:
![Screenshot from 2022-10-06 09-46-55](https://user-images.githubusercontent.com/10999/194248808-3e28ad08-3518-4bb4-8fa6-0610ff2109dd.png)

