### PR TITLE
Loki: Fix redundant escaping in adhoc filter with regex match

### DIFF
--- a/devenv/docker/blocks/loki/data/data.js
+++ b/devenv/docker/blocks/loki/data/data.js
@@ -125,8 +125,8 @@ async function main() {
     await sleep(getNextSineWaveSleepDuration());
     const timestampMs = new Date().getTime();
     const item = getRandomLogItem(step + 1)
-    lokiSendLogLine(timestampMs, JSON.stringify(item), {place:'moon', source: 'data', instance: 'server//1', job: '"grafana/data"'});
-    lokiSendLogLine(timestampMs, logFmtLine(item), {place:'luna', source: 'data', instance: 'server//2', job: '"grafana/data"'});
+    lokiSendLogLine(timestampMs, JSON.stringify(item), {place:'moon', source: 'data', instance: 'server\\1', job: '"grafana/data"'});
+    lokiSendLogLine(timestampMs, logFmtLine(item), {place:'luna', source: 'data', instance: 'server\\2', job: '"grafana/data"'});
   }
 }
 

--- a/devenv/docker/blocks/loki/data/data.js
+++ b/devenv/docker/blocks/loki/data/data.js
@@ -125,8 +125,8 @@ async function main() {
     await sleep(getNextSineWaveSleepDuration());
     const timestampMs = new Date().getTime();
     const item = getRandomLogItem(step + 1)
-    lokiSendLogLine(timestampMs, JSON.stringify(item), {place:'moon', source: 'data'});
-    lokiSendLogLine(timestampMs, logFmtLine(item), {place:'luna', source: 'data'});
+    lokiSendLogLine(timestampMs, JSON.stringify(item), {place:'moon', source: 'data', instance: 'server//1', job: '"grafana/data"'});
+    lokiSendLogLine(timestampMs, logFmtLine(item), {place:'luna', source: 'data', instance: 'server//2', job: '"grafana/data"'});
   }
 }
 

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -201,7 +201,7 @@ describe('LokiDatasource', () => {
         },
       ]);
       expect(ds.applyTemplateVariables(query, {}).expr).toBe(
-        `rate({bar="baz", job="foo", k1=~"v.*", k2=~"v\\\\'.*"} |= "bar" [5m])`
+        'rate({bar="baz", job="foo", k1=~"v.*", k2=~"v\\\\\'.*"} |= "bar" [5m])'
       );
     });
   });

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -201,7 +201,7 @@ describe('LokiDatasource', () => {
         },
       ]);
       expect(ds.applyTemplateVariables(query, {}).expr).toBe(
-        'rate({bar="baz", job="foo", k1=~"v\\\\.\\\\*", k2=~"v\'\\\\.\\\\*"} |= "bar" [5m])'
+        `rate({bar=\"baz\", job=\"foo\", k1=~\"v.*\", k2=~\"v\\\\'.*\"} |= \"bar\" [5m])`
       );
     });
   });

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -665,10 +665,15 @@ describe('LokiDatasource', () => {
 
   describe('addAdHocFilters', () => {
     let ds: LokiDatasource;
-    let adHocFilters: AdHocFilter[];
+    const createTemplateSrvMock = (options: { adHocFilters: AdHocFilter[] }) => {
+      return {
+        getAdhocFilters: (): AdHocFilter[] => options.adHocFilters,
+        replace: (a: string) => a,
+      } as unknown as TemplateSrv;
+    };
     describe('when called with "=" operator', () => {
       beforeEach(() => {
-        adHocFilters = [
+        const defaultAdHocFilters: AdHocFilter[] = [
           {
             condition: '',
             key: 'job',
@@ -676,11 +681,7 @@ describe('LokiDatasource', () => {
             value: 'grafana',
           },
         ];
-        const templateSrvMock = {
-          getAdhocFilters: (): AdHocFilter[] => adHocFilters,
-          replace: (a: string) => a,
-        } as unknown as TemplateSrv;
-        ds = createLokiDatasource(templateSrvMock);
+        ds = createLokiDatasource(createTemplateSrvMock({ adHocFilters: defaultAdHocFilters }));
       });
       describe('and query has no parser', () => {
         it('then the correct label should be added for logs query', () => {
@@ -706,6 +707,21 @@ describe('LokiDatasource', () => {
         it('then the correct label should be added for metrics query with empty selector and variable', () => {
           assertAdHocFilters('rate({}[$__interval])', 'rate({job="grafana"}[$__interval])', ds);
         });
+        it('should correctly escape special characters in ad hoc filter', () => {
+          const ds = createLokiDatasource(
+            createTemplateSrvMock({
+              adHocFilters: [
+                {
+                  condition: '',
+                  key: 'instance',
+                  operator: '=',
+                  value: '"test"',
+                },
+              ],
+            })
+          );
+          assertAdHocFilters('{job="grafana"}', '{job="grafana", instance="\\"test\\""}', ds);
+        });
       });
       describe('and query has parser', () => {
         it('then the correct label should be added for logs query', () => {
@@ -719,7 +735,7 @@ describe('LokiDatasource', () => {
 
     describe('when called with "!=" operator', () => {
       beforeEach(() => {
-        adHocFilters = [
+        const defaultAdHocFilters: AdHocFilter[] = [
           {
             condition: '',
             key: 'job',
@@ -727,11 +743,7 @@ describe('LokiDatasource', () => {
             value: 'grafana',
           },
         ];
-        const templateSrvMock = {
-          getAdhocFilters: (): AdHocFilter[] => adHocFilters,
-          replace: (a: string) => a,
-        } as unknown as TemplateSrv;
-        ds = createLokiDatasource(templateSrvMock);
+        ds = createLokiDatasource(createTemplateSrvMock({ adHocFilters: defaultAdHocFilters }));
       });
       describe('and query has no parser', () => {
         it('then the correct label should be added for logs query', () => {
@@ -749,6 +761,23 @@ describe('LokiDatasource', () => {
         it('then the correct label should be added for metrics query', () => {
           assertAdHocFilters('rate({bar="baz"} | logfmt [5m])', 'rate({bar="baz"} | logfmt | job!=`grafana` [5m])', ds);
         });
+      });
+    });
+
+    describe('when called with regex operator', () => {
+      beforeEach(() => {
+        const defaultAdHocFilters: AdHocFilter[] = [
+          {
+            condition: '',
+            key: 'instance',
+            operator: '=~',
+            value: '.*',
+          },
+        ];
+        ds = createLokiDatasource(createTemplateSrvMock({ adHocFilters: defaultAdHocFilters }));
+      });
+      it('should not escape special characters in ad hoc filter', () => {
+        assertAdHocFilters('{job="grafana"}', '{job="grafana", instance=~".*"}', ds);
       });
     });
   });

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -201,7 +201,7 @@ describe('LokiDatasource', () => {
         },
       ]);
       expect(ds.applyTemplateVariables(query, {}).expr).toBe(
-        `rate({bar=\"baz\", job=\"foo\", k1=~\"v.*\", k2=~\"v\\\\'.*\"} |= \"bar\" [5m])`
+        `rate({bar="baz", job="foo", k1=~"v.*", k2=~"v\\\\'.*"} |= "bar" [5m])`
       );
     });
   });


### PR DESCRIPTION
**What this PR does / why we need it**:

When using adhoc filters with regex match, we were incorrectly escaping the regex part, which made it unusable. This PR fixes it. 

Moreover, to our testing data, I have added 2 more labels with special characters `"` and `/`, so for the future cases it is easier to test escaping PRs. 

**Which issue(s) this PR fixes**:

Internally reported by @srclosson. 

**Special notes for your reviewer**:
Here is how I tested this + the tests haven't changed, only in 1 case where it makes sense. 

**MAIN BRANCH (BROKEN)**
Fixed adhoc filters with regex match don't work:
<img width="1909" alt="image" src="https://user-images.githubusercontent.com/30407135/194274580-baba9e1b-39a7-4f66-a8aa-6ade926038dd.png">

Working modify query with special characters works correctly (escaping is needed): 
<img width="1896" alt="image" src="https://user-images.githubusercontent.com/30407135/194274879-e74cd5c2-4343-4f6f-bf57-081aa6f97b65.png">


**THIS BRANCH (FIXED)**
Fixed adhoc filters with regex match  now work:
<img width="1912" alt="image" src="https://user-images.githubusercontent.com/30407135/194271629-c7ae4c8a-8697-4a86-ada2-8a30b5e0b60f.png">

Modify query with special characters still works (escaping is needed):

https://user-images.githubusercontent.com/30407135/194273862-cd5df754-2cd0-4574-a624-3f8f1a49af25.mov






