### PR TITLE
ErrorPage: Fixes the position of text

### DIFF
--- a/public/app/core/navigation/GrafanaRouteError.tsx
+++ b/public/app/core/navigation/GrafanaRouteError.tsx
@@ -51,5 +51,8 @@ export function GrafanaRouteError({ error, errorInfo }: Props) {
 }
 
 const getStyles = stylesFactory(() => {
-  return css``;
+  return css`
+    width: 500px;
+    margin: 64px auto;
+  `;
 });


### PR DESCRIPTION
Noticed when the chunk loading error page is shown (in flashing it trigger reload so you rarely see it for long). 


But noticed it looked like this: 
![Screenshot from 2022-10-06 16-10-05](https://user-images.githubusercontent.com/10999/194335286-fde25c8a-55a5-4212-a3a5-66871b8239f4.png)

This PR fixes so that it's positioned the same as the Error details bit 
![Screenshot from 2022-10-06 16-11-28](https://user-images.githubusercontent.com/10999/194335576-26486ee3-e3f6-4f40-be6d-b08fb5ea098d.png)
