### PR TITLE
Chore: Make NewCookieOptions exported in cookies.go

### DIFF
--- a/pkg/middleware/cookies/cookies.go
+++ b/pkg/middleware/cookies/cookies.go
@@ -16,7 +16,7 @@ type CookieOptions struct {
 	SameSiteMode     http.SameSite
 }
 
-func newCookieOptions() CookieOptions {
+func NewCookieOptions() CookieOptions {
 	path := "/"
 	if len(setting.AppSubUrl) > 0 {
 		path = setting.AppSubUrl
@@ -37,7 +37,7 @@ func DeleteCookie(w http.ResponseWriter, name string, getCookieOptions getCookie
 
 func WriteCookie(w http.ResponseWriter, name string, value string, maxAge int, getCookieOptions getCookieOptionsFunc) {
 	if getCookieOptions == nil {
-		getCookieOptions = newCookieOptions
+		getCookieOptions = NewCookieOptions
 	}
 
 	options := getCookieOptions()


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR make the NewCookieOptions function exported to be able to use this as a source for specifying custom cookie settings.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

