### PR TITLE
first draft: SetGrafanaUserMiddleware

### DIFF
--- a/pkg/infra/httpclient/httpclientprovider/grafana_user_middleware.go
+++ b/pkg/infra/httpclient/httpclientprovider/grafana_user_middleware.go
@@ -1,0 +1,27 @@
+package httpclientprovider
+
+import (
+	"net/http"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+)
+
+// SetGrafanaUserMiddlewareName is the middleware name associated with SetGrafanaUserMiddleware.
+const SetGrafanaUserMiddlewareName = "grafana-user"
+
+// SetGrafanaUserMiddlewareName is middleware that sets the HTTP header X-Grafana-User on the outgoing request.
+// If Grafana-User already set, it will not be overridden by this middleware.
+func SetGrafanaUserMiddleware(login string) httpclient.Middleware {
+	return httpclient.NamedMiddlewareFunc(SetGrafanaUserMiddlewareName, func(opts httpclient.Options, next http.RoundTripper) http.RoundTripper {
+		if login == "" {
+			return next
+		}
+
+		return httpclient.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			if req.Header.Get("X-Grafana-User") == "" {
+				req.Header.Set("X-Grafana-User", login)
+			}
+			return next.RoundTrip(req)
+		})
+	})
+}

--- a/pkg/infra/httpclient/httpclientprovider/grafana_user_middleware_test.go
+++ b/pkg/infra/httpclient/httpclientprovider/grafana_user_middleware_test.go
@@ -1,0 +1,73 @@
+package httpclientprovider
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetGrafanUserMiddleware(t *testing.T) {
+	t.Run("Applies header to request", func(t *testing.T) {
+		ctx := &testContext{}
+		finalRoundTripper := ctx.createRoundTripper("finalrt")
+		mw := SetGrafanaUserMiddleware("grafanista")
+		rt := mw.CreateMiddleware(httpclient.Options{}, finalRoundTripper)
+		require.NotNil(t, rt)
+		middlewareName, ok := mw.(httpclient.MiddlewareName)
+		require.True(t, ok)
+		require.Equal(t, SetGrafanaUserMiddlewareName, middlewareName.MiddlewareName())
+
+		req, err := http.NewRequest(http.MethodGet, "http://", nil)
+		require.NoError(t, err)
+		res, err := rt.RoundTrip(req)
+		require.NoError(t, err)
+		require.NotNil(t, res)
+		if res.Body != nil {
+			require.NoError(t, res.Body.Close())
+		}
+		require.Equal(t, "grafanista", req.Header.Get("X-Grafana-User"))
+	})
+
+	t.Run("Does not override existing header", func(t *testing.T) {
+		ctx := &testContext{}
+		finalRoundTripper := ctx.createRoundTripper("finalrt")
+		mw := SetGrafanaUserMiddleware("grafanista")
+		rt := mw.CreateMiddleware(httpclient.Options{}, finalRoundTripper)
+		require.NotNil(t, rt)
+		middlewareName, ok := mw.(httpclient.MiddlewareName)
+		require.True(t, ok)
+		require.Equal(t, SetGrafanaUserMiddlewareName, middlewareName.MiddlewareName())
+
+		req, err := http.NewRequest(http.MethodGet, "http://", nil)
+		require.NoError(t, err)
+		req.Header.Set("X-Grafana-User", "barfolomew")
+		res, err := rt.RoundTrip(req)
+		require.NoError(t, err)
+		require.NotNil(t, res)
+		if res.Body != nil {
+			require.NoError(t, res.Body.Close())
+		}
+		require.Equal(t, "barfolomew", req.Header.Get("X-Grafana-User"))
+	})
+
+	t.Run("Should return next http.RoundTripper when login is empty", func(t *testing.T) {
+		ctx := &testContext{}
+		finalRoundTripper := ctx.createRoundTripper("finalrt")
+		mw := SetGrafanaUserMiddleware("")
+		rt := mw.CreateMiddleware(httpclient.Options{}, finalRoundTripper)
+		require.NotNil(t, rt)
+
+		req, err := http.NewRequest(http.MethodGet, "http://", nil)
+		require.NoError(t, err)
+		res, err := rt.RoundTrip(req)
+		require.NoError(t, err)
+		require.NotNil(t, res)
+		if res.Body != nil {
+			require.NoError(t, res.Body.Close())
+		}
+		require.Len(t, ctx.callChain, 1)
+		require.ElementsMatch(t, []string{"finalrt"}, ctx.callChain)
+	})
+}


### PR DESCRIPTION
The `X-Grafana-User` header (set when the user is signed in and the config option `set_user_header is true`) is only set on datasource requests routed though the datasource proxy. The Loki & Prometheus datasources no longer route through the proxy and did not otherwise implement this feature, so this PR is an attempt to move it to a slightly more general location.

I made this a middleware instead of directly applying the header in query.go because I wasn't sure if there are more places this heading should be added. I don't even know if this is the best approach, but the header requires the signed in user's information so that seemed like my best choice. 

Right now I'm mostly interesting in hearing if this is the right direction or if I'm entirely in the wrong area, but any and all comments are welcome.

Addresses https://github.com/grafana/grafana/issues/54159