### PR TITLE
Theme: make buildVariant easier to read + enforce integer multiples of 2

### DIFF
--- a/packages/grafana-data/src/themes/createTypography.ts
+++ b/packages/grafana-data/src/themes/createTypography.ts
@@ -99,26 +99,31 @@ export function createTypography(colors: ThemeColors, typographyInput: ThemeTypo
     lineHeight: number,
     letterSpacing: number,
     casing?: object
-  ): ThemeTypographyVariant => ({
-    fontFamily,
-    fontWeight,
-    fontSize: pxToRem(size),
-    lineHeight,
-    ...(fontFamily === defaultFontFamily ? { letterSpacing: `${round(letterSpacing / size)}em` } : {}),
-    ...casing,
-  });
+  ): ThemeTypographyVariant => {
+    if (lineHeight % 2 !== 0 || size % 2 !== 0) {
+      throw new Error('Font size and line height should be integer multiples of 2 to prevent issues with alignment');
+    }
 
+    return {
+      fontFamily,
+      fontWeight,
+      fontSize: pxToRem(size),
+      lineHeight: lineHeight / size,
+      ...(fontFamily === defaultFontFamily ? { letterSpacing: `${round(letterSpacing / size)}em` } : {}),
+      ...casing,
+    };
+  };
+
+  // All our fonts/line heights should be integer multiples of 2 to prevent issues with alignment
   const variants = {
-    h1: buildVariant(fontWeightRegular, 28, 1.167, -0.25),
-    h2: buildVariant(fontWeightRegular, 24, 1.2, 0),
-    h3: buildVariant(fontWeightRegular, 21, 1.167, 0),
-    h4: buildVariant(fontWeightRegular, 18, 1.235, 0.25),
-    h5: buildVariant(fontWeightRegular, 16, 1.334, 0),
-    h6: buildVariant(fontWeightMedium, 14, 1.6, 0.15),
-    // The line-height of 1.5714285714285714 results in a real line-height of 22px for the default font size. Which is an even number and result in more perfect vertical alignment
-    body: buildVariant(fontWeightRegular, fontSize, 1.5714285714285714, 0.15),
-    // The line-height of 1.5 results in a real line height of 18px for the font size of 12px
-    bodySmall: buildVariant(fontWeightRegular, 12, 1.5, 0.15),
+    h1: buildVariant(fontWeightRegular, 28, 32, -0.25),
+    h2: buildVariant(fontWeightRegular, 24, 28, 0),
+    h3: buildVariant(fontWeightRegular, 22, 24, 0),
+    h4: buildVariant(fontWeightRegular, 18, 22, 0.25),
+    h5: buildVariant(fontWeightRegular, 16, 22, 0),
+    h6: buildVariant(fontWeightMedium, 14, 22, 0.15),
+    body: buildVariant(fontWeightRegular, fontSize, 22, 0.15),
+    bodySmall: buildVariant(fontWeightRegular, 12, 18, 0.15),
   };
 
   const size = {

--- a/public/sass/_variables.generated.scss
+++ b/public/sass/_variables.generated.scss
@@ -119,7 +119,7 @@ $font-weight-semi-bold: 500 !default;
 
 $font-size-h1: 2rem !default;
 $font-size-h2: 1.7142857142857142rem !default;
-$font-size-h3: 1.5rem !default;
+$font-size-h3: 1.5714285714285714rem !default;
 $font-size-h4: 1.2857142857142858rem !default;
 $font-size-h5: 1.1428571428571428rem !default;
 $font-size-h6: 1rem !default;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

- adjusts `buildVariant` to accept a px value for line-height which will then be converted to a ratio based on the size passed in
- throws an error if we don't pass integer multiples of 2 for either `size` or `line-height`

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
@torkelo dunno if you want to merge this into the inter branch, or try and keep it separate. will leave as draft for now to discuss 