### PR TITLE
I18n: Add lint rule to enforce correct i18n imports

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -20,13 +20,18 @@
       }
     ],
     "no-restricted-imports": [
-      "warn",
+      "error",
       {
         "paths": [
           {
             "name": "react-redux",
             "importNames": ["useDispatch", "useSelector"],
             "message": "Please import from app/types instead."
+          },
+          {
+            "name": "react-i18next",
+            "importNames": ["Trans", "t"],
+            "message": "Please import from app/core/internationalization instead"
           }
         ]
       }

--- a/packages/grafana-ui/.eslintrc
+++ b/packages/grafana-ui/.eslintrc
@@ -1,6 +1,18 @@
 {
   "rules": {
-    "no-restricted-imports": ["error", { "patterns": ["@grafana/runtime", "@grafana/data/*", "@grafana/ui", "@grafana/e2e"] }]
+    "no-restricted-imports": [
+      "error",
+      {
+        "patterns": ["@grafana/runtime", "@grafana/data/*", "@grafana/ui", "@grafana/e2e"],
+        "paths": [
+          {
+            "name": "react-i18next",
+            "importNames": ["Trans", "t"],
+            "message": "Please import from grafana-ui/src/utils/i18n instead"
+          }
+        ]
+      }
+    ]
   },
   "overrides": [
     {

--- a/packages/grafana-ui/src/utils/i18n.tsx
+++ b/packages/grafana-ui/src/utils/i18n.tsx
@@ -1,6 +1,6 @@
 import i18next from 'i18next';
 import React from 'react';
-import { Trans as I18NextTrans, initReactI18next } from 'react-i18next';
+import { Trans as I18NextTrans, initReactI18next } from 'react-i18next'; // eslint-disable-line no-restricted-imports
 
 // We want to translate grafana-ui without introducing any breaking changes for consumers
 // who use grafana-ui outside of grafana (such as grafana.com self serve). The other struggle

--- a/public/app/core/internationalization/index.tsx
+++ b/public/app/core/internationalization/index.tsx
@@ -1,6 +1,6 @@
 import i18n, { BackendModule, ResourceKey } from 'i18next';
 import React from 'react';
-import { Trans as I18NextTrans, initReactI18next } from 'react-i18next';
+import { Trans as I18NextTrans, initReactI18next } from 'react-i18next'; // eslint-disable-line no-restricted-imports
 
 import { DEFAULT_LOCALE, ENGLISH_US, FRENCH_FRANCE, SPANISH_SPAIN, PSEUDO_LOCALE, VALID_LOCALES } from './constants';
 
@@ -21,7 +21,6 @@ const loadTranslations: BackendModule = {
       return callback(new Error('No message loader available for ' + language), null);
     }
 
-    // TODO: namespace??
     const messages = await loader();
     callback(null, messages);
   },


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a lint rule to enforce our i18n wrappers are called instead of those from the library.

![image](https://user-images.githubusercontent.com/46142/194361861-84d97a65-21a3-4a11-a857-f628747b957f.png)


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Part of #56303

**Special notes for your reviewer**:

