### PR TITLE
Graphite: Fix queries with repeated references

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -6425,12 +6425,11 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "16"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "17"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "18"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "19"],
-      [0, 0, 0, "Do not use any type assertions.", "20"],
+      [0, 0, 0, "Do not use any type assertions.", "19"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "20"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "21"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "22"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "23"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "24"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "23"]
     ],
     "public/app/plugins/datasource/graphite/lexer.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],

--- a/public/app/plugins/datasource/graphite/graphite_query.ts
+++ b/public/app/plugins/datasource/graphite/graphite_query.ts
@@ -212,19 +212,10 @@ export default class GraphiteQuery {
     let targetWithNestedQueries = target.target;
 
     // Use ref count to track circular references
-    function countTargetRefs(targetsByRefId: any, refId: string) {
-      let refCount = 0;
-      each(targetsByRefId, (t, id) => {
-        if (id !== refId) {
-          const match = nestedSeriesRefRegex.exec(t.target);
-          const count = match && match.length ? match.length - 1 : 0;
-          refCount += count;
-        }
-      });
-      targetsByRefId[refId].refCount = refCount;
-    }
     each(targetsByRefId, (t, id) => {
-      countTargetRefs(targetsByRefId, id);
+      const regex = RegExp(`\#(${id})`, 'g');
+      const refMatches = targetWithNestedQueries.match(regex);
+      t.refCount = refMatches?.length ?? 0;
     });
 
     // Keep interpolating until there are no query references

--- a/public/app/plugins/datasource/graphite/specs/graphite_query.test.ts
+++ b/public/app/plugins/datasource/graphite/specs/graphite_query.test.ts
@@ -39,6 +39,20 @@ describe('Graphite query model', () => {
       expect(ctx.queryModel.target.targetFull).toBe(targetFullExpected);
     });
 
+    it('targetFull should include nested queries with repeated subqueries', () => {
+      ctx.target = { refId: 'C', target: 'scale(asPercent(diffSeries(#B, #A), #B), 100)' };
+      ctx.targets = [
+        { refId: 'A', target: 'first.query.count' },
+        { refId: 'B', target: 'second.query.count' },
+        { refId: 'C', target: 'scale(asPercent(diffSeries(#B, #A), #B), 100)' },
+      ];
+      ctx.queryModel = new GraphiteQuery(ctx.datasource, ctx.target, ctx.templateSrv);
+      ctx.queryModel.updateRenderedTarget(ctx.target, ctx.targets);
+      const targetFullExpected =
+        'scale(asPercent(diffSeries(second.query.count, first.query.count), second.query.count), 100)';
+      expect(ctx.queryModel.target.targetFull).toBe(targetFullExpected);
+    });
+
     it('should not hang on circular references', () => {
       ctx.target.target = 'asPercent(#A, #B)';
       ctx.targets = [


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes the interpolation parser system in queries with repeated subqueries references to ensure that all of them will be replaced by the original query target. 

Before this change, the parsing was not properly counting the circular references on each subquery and [deleting the query object reference](https://github.com/grafana/grafana/blob/main/public/app/plugins/datasource/graphite/graphite_query.ts#L241) before processing all references in the query string.

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/42623

**Special notes for your reviewer**:

You can also test it by creating Alerts, Expressions, and composing queries (query #C in the screenshot). 

<img width="65%" alt="Screen Shot 2022-10-06 at 14 11 01" src="https://user-images.githubusercontent.com/1680157/194376313-3896bd4e-8073-48fc-916b-a2c08b54c5ee.png">
