### PR TITLE
Alerting: Fix migration to not add label "alertname"

### DIFF
--- a/pkg/services/ngalert/state/cache.go
+++ b/pkg/services/ngalert/state/cache.go
@@ -56,16 +56,18 @@ func (rs *ruleStates) getOrCreate(ctx context.Context, log log.Logger, alertRule
 		lbs[key] = val
 	}
 	for key, val := range ruleLabels {
-		_, ok := lbs[key]
+		ruleVal, ok := lbs[key]
 		// if duplicate labels exist, reserved label will take precedence
 		if ok {
-			dupes[key] = val
+			if ruleVal != val {
+				dupes[key] = val
+			}
 		} else {
 			lbs[key] = val
 		}
 	}
 	if len(dupes) > 0 {
-		log.Warn("rule declares one or many reserved labels. Those rules labels will be ignored", "labels", dupes)
+		log.Warn("Rule declares one or many reserved labels. Those rules labels will be ignored", "labels", dupes)
 	}
 	dupes = make(data.Labels)
 	for key, val := range result.Instance {

--- a/pkg/services/sqlstore/migrations/ualert/alert_rule.go
+++ b/pkg/services/sqlstore/migrations/ualert/alert_rule.go
@@ -100,7 +100,6 @@ func addMigrationInfo(da *dashAlert) (map[string]string, map[string]string) {
 func (m *migration) makeAlertRule(cond condition, da dashAlert, folderUID string) (*alertRule, error) {
 	lbls, annotations := addMigrationInfo(&da)
 	name := normalizeRuleName(da.Name)
-	lbls["alertname"] = name
 	annotations["message"] = da.Message
 	var err error
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The migration from legacy to the new Grafana Alerting adds a label `alertname` to the rule. That label gets overridden by the state manager when it calculates the state because the label is reserved. The state manager emits a warning log when there are labels that are overridden. This creates an avalanche of warning logs.

This PR updates migration to not add the label (because it is overridden anyway). 
Also, it updates state manager logic to compare values of the same label and to emit a warning only if values are different.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/55670

**Special notes for your reviewer**:

