### PR TITLE
Alerting: Fix migration to create rules with group index 1

### DIFF
--- a/pkg/services/sqlstore/migrations/ualert/alert_rule.go
+++ b/pkg/services/sqlstore/migrations/ualert/alert_rule.go
@@ -122,6 +122,7 @@ func (m *migration) makeAlertRule(cond condition, da dashAlert, folderUID string
 		Updated:         time.Now().UTC(),
 		Annotations:     annotations,
 		Labels:          lbls,
+		RuleGroupIndex:  1,
 	}
 
 	ar.NoDataState, err = transNoData(da.ParsedSettings.NoDataState)

--- a/pkg/services/sqlstore/migrations/ualert/ualert.go
+++ b/pkg/services/sqlstore/migrations/ualert/ualert.go
@@ -839,7 +839,7 @@ func (c updateRulesOrderInGroup) Exec(sess *xorm.Session, migrator *migrator.Mig
 	}
 
 	updated := time.Now()
-	versions := make([]*alertRuleVersion, 0, len(toUpdate))
+	versions := make([]interface{}, 0, len(toUpdate))
 
 	for _, rule := range toUpdate {
 		rule.Updated = updated
@@ -855,8 +855,7 @@ func (c updateRulesOrderInGroup) Exec(sess *xorm.Session, migrator *migrator.Mig
 		migrator.Logger.Debug("updated group index for alert rule", "rule_uid", rule.UID)
 		versions = append(versions, version)
 	}
-
-	_, err := sess.Insert(&versions)
+	_, err := sess.Insert(versions...)
 	if err != nil {
 		migrator.Logger.Error("failed to insert changes to alert_rule_version", "err", err)
 		return fmt.Errorf("unable to update alert rules with group index: %w", err)


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, during migration Grafana creates new records in table `alert_rule` with value 0 in field `rule_group_idx` (default). Then during the next migration steps, Grafana reads the rules with the value 0 in that field and updates it to 1, and also creates a record in table `alert_rule_version`.
This can cause another problem: the migration can fail if there are too many records are inserted into the version table because they are inserted in bulk, and it causes (a bug?) error in XORM "Prepared statement contains too many placeholders".

This PR 
1. fixes the migration to set field rule_group_idx to 1 by default, to avoid unnecessary operations.
2. Updates the command that inserts records to table `alert_rule_version` to do this by a single row.