### PR TITLE
QueryEditorRow: Fix broken drag-and-drop reordering

### DIFF
--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -75,6 +75,7 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
   element: HTMLElement | null = null;
   angularScope: AngularQueryComponentScope<TQuery> | null = null;
   angularQueryEditor: AngularComponent | null = null;
+  id = '';
 
   state: State<TQuery> = {
     datasource: null,
@@ -85,8 +86,9 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
   };
 
   componentDidMount() {
-    const { data, query } = this.props;
+    const { data, query, id } = this.props;
     const dataFilteredByRefId = filterPanelDataToQuery(data, query.refId);
+    this.id = uniqueId(id + '_');
     this.setState({ data: dataFilteredByRefId });
 
     this.loadDatasource();
@@ -95,6 +97,12 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
   componentWillUnmount() {
     if (this.angularQueryEditor) {
       this.angularQueryEditor.destroy();
+    }
+  }
+
+  getSnapshotBeforeUpdate(prevProps: Readonly<Props<TQuery>>) {
+    if (prevProps.id !== this.props.id) {
+      this.id = uniqueId(this.props.id + '_');
     }
   }
 
@@ -449,10 +457,9 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
   };
 
   render() {
-    const { query, id, index, visualization } = this.props;
+    const { query, index, visualization } = this.props;
     const { datasource, showingHelp, data } = this.state;
     const isDisabled = query.hide;
-    const generatedUniqueId = uniqueId(id + '_');
 
     const rowClasses = classNames('query-editor-row', {
       'query-editor-row--disabled': isDisabled,
@@ -469,14 +476,14 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
     return (
       <div aria-label={selectors.components.QueryEditorRows.rows}>
         <QueryOperationRow
-          id={generatedUniqueId}
+          id={this.id}
           draggable={true}
           index={index}
           headerElement={this.renderHeader}
           actions={this.renderActions}
           onOpen={this.onOpen}
         >
-          <div className={rowClasses} id={generatedUniqueId}>
+          <div className={rowClasses} id={this.id}>
             <ErrorBoundaryAlert>
               {showingHelp && DatasourceCheatsheet && (
                 <OperationRowHelp>

--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -100,12 +100,6 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
     }
   }
 
-  getSnapshotBeforeUpdate(prevProps: Readonly<Props<TQuery>>) {
-    if (prevProps.id !== this.props.id) {
-      this.id = uniqueId(this.props.id + '_');
-    }
-  }
-
   getAngularQueryComponentScope(): AngularQueryComponentScope<TQuery> {
     const { query, queries } = this.props;
     const { datasource } = this.state;
@@ -166,6 +160,10 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
   componentDidUpdate(prevProps: Props<TQuery>) {
     const { datasource, loadedDataSourceIdentifier } = this.state;
     const { data, query } = this.props;
+
+    if (prevProps.id !== this.props.id) {
+      this.id = uniqueId(this.props.id + '_');
+    }
 
     if (data !== prevProps.data) {
       const dataFilteredByRefId = filterPanelDataToQuery(data, query.refId);


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes an issue preventing query editor rows from being reordered after #55563 was merged.
Basically a new ID was being generated whenever the component re-rendered, which broke `react-beautiful-dnd`, so the unique ID introduced in #55563 is only changed now when the row's name is edited.
