### PR TITLE
Thresholds: fix line rendering with multiple y axes

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/config/UPlotThresholds.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotThresholds.ts
@@ -24,7 +24,7 @@ export function getThresholdsDrawHook(options: UPlotThresholdOptions) {
       ? [10, 10]
       : null;
 
-  function addLines(u: uPlot, steps: Threshold[], theme: GrafanaTheme2, xMin: number, xMax: number, yScaleKey: string) {
+  function addLines(u: uPlot, yScaleKey: string, steps: Threshold[], theme: GrafanaTheme2) {
     let ctx = u.ctx;
 
     // Thresholds below a transparent threshold is treated like "less than", and line drawn previous threshold
@@ -61,9 +61,9 @@ export function getThresholdsDrawHook(options: UPlotThresholdOptions) {
         color.setAlpha(0.7);
       }
 
-      let x0 = Math.round(u.valToPos(xMin!, 'x', true));
+      let x0 = Math.round(u.bbox.left);
       let y0 = Math.round(u.valToPos(step.value, yScaleKey, true));
-      let x1 = Math.round(u.valToPos(xMax!, 'x', true));
+      let x1 = Math.round(u.bbox.left + u.bbox.width);
       let y1 = Math.round(u.valToPos(step.value, yScaleKey, true));
 
       ctx.beginPath();
@@ -75,12 +75,12 @@ export function getThresholdsDrawHook(options: UPlotThresholdOptions) {
     }
   }
 
-  function addAreas(u: uPlot, steps: Threshold[], theme: GrafanaTheme2) {
+  function addAreas(u: uPlot, yScaleKey: string, steps: Threshold[], theme: GrafanaTheme2) {
     let ctx = u.ctx;
 
     let grd = scaleGradient(
       u,
-      u.series[1].scale!,
+      yScaleKey,
       steps.map((step) => {
         let color = tinycolor(theme.visualization.getColorByName(step.color));
 
@@ -125,15 +125,15 @@ export function getThresholdsDrawHook(options: UPlotThresholdOptions) {
     switch (config.mode) {
       case GraphTresholdsStyleMode.Line:
       case GraphTresholdsStyleMode.Dashed:
-        addLines(u, steps, theme, xMin, xMax, scaleKey);
+        addLines(u, scaleKey, steps, theme);
         break;
       case GraphTresholdsStyleMode.Area:
-        addAreas(u, steps, theme);
+        addAreas(u, scaleKey, steps, theme);
         break;
       case GraphTresholdsStyleMode.LineAndArea:
       case GraphTresholdsStyleMode.DashedAndArea:
-        addAreas(u, steps, theme);
-        addLines(u, steps, theme, xMin, xMax, scaleKey);
+        addAreas(u, scaleKey, steps, theme);
+        addLines(u, scaleKey, steps, theme);
     }
 
     ctx.restore();


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/56459

this looks like something i missed in the original refactor. without this PR, threshold lines were always drawn using the first/left y axis, but filled areas were drawn correctly :grimacing: 

<details><summary>thresholds-no-axis.json</summary>

```json
{
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": {
          "type": "grafana",
          "uid": "-- Grafana --"
        },
        "enable": true,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "target": {
          "limit": 100,
          "matchAny": false,
          "tags": [],
          "type": "dashboard"
        },
        "type": "dashboard"
      }
    ]
  },
  "editable": true,
  "fiscalYearStartMonth": 0,
  "graphTooltip": 0,
  "id": 452,
  "links": [],
  "liveNow": false,
  "panels": [
    {
      "datasource": {
        "type": "testdata",
        "uid": "PD8C576611E62080A"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "palette-classic"
          },
          "custom": {
            "axisCenteredZero": false,
            "axisColorMode": "text",
            "axisLabel": "",
            "axisPlacement": "auto",
            "barAlignment": 0,
            "drawStyle": "line",
            "fillOpacity": 0,
            "gradientMode": "none",
            "hideFrom": {
              "legend": false,
              "tooltip": false,
              "viz": false
            },
            "lineInterpolation": "linear",
            "lineWidth": 1,
            "pointSize": 5,
            "scaleDistribution": {
              "type": "linear"
            },
            "showPoints": "auto",
            "spanNulls": false,
            "stacking": {
              "group": "A",
              "mode": "none"
            },
            "thresholdsStyle": {
              "mode": "line+area"
            }
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": null
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": [
          {
            "matcher": {
              "id": "byName",
              "options": "B-series"
            },
            "properties": [
              {
                "id": "unit",
                "value": "short"
              }
            ]
          }
        ]
      },
      "gridPos": {
        "h": 13,
        "w": 11,
        "x": 0,
        "y": 0
      },
      "id": 2,
      "options": {
        "legend": {
          "calcs": [],
          "displayMode": "list",
          "placement": "bottom",
          "showLegend": true
        },
        "tooltip": {
          "mode": "single",
          "sort": "none"
        }
      },
      "targets": [
        {
          "datasource": {
            "type": "testdata",
            "uid": "PD8C576611E62080A"
          },
          "refId": "A",
          "scenarioId": "csv_metric_values",
          "stringInput": "1,20,90,30,5,0"
        },
        {
          "datasource": {
            "type": "testdata",
            "uid": "PD8C576611E62080A"
          },
          "refId": "B",
          "scenarioId": "csv_metric_values",
          "stringInput": "25,100,200,700,100,0"
        }
      ],
      "title": "Panel Title",
      "type": "timeseries"
    }
  ],
  "schemaVersion": 37,
  "style": "dark",
  "tags": [],
  "templating": {
    "list": []
  },
  "time": {
    "from": "now-6h",
    "to": "now"
  },
  "timepicker": {},
  "timezone": "",
  "title": "thresholds-no-axis",
  "uid": "pPJeowVVz",
  "version": 2,
  "weekStart": ""
}
```
</details>