### PR TITLE
Page: More easily support full height pages

### DIFF
--- a/public/app/core/components/PageNew/Page.tsx
+++ b/public/app/core/components/PageNew/Page.tsx
@@ -82,12 +82,12 @@ export const Page: PageType = ({
               />
             </>
           )}
-          <div className={styles.pageContent}>
+          <div className={styles.pageContainer}>
             <CustomScrollbar autoHeightMin={'100%'} scrollTop={scrollTop} scrollRefCallback={scrollRef}>
               <div className={styles.pageInner}>
                 {pageHeaderNav && <PageHeader navItem={pageHeaderNav} subTitle={subTitle} />}
                 {pageNav && pageNav.children && <PageTabs navItem={pageNav} />}
-                {children}
+                <div className={styles.pageContent}>{children}</div>
               </div>
               <Footer />
             </CustomScrollbar>
@@ -157,6 +157,10 @@ const getStyles = (theme: GrafanaTheme2) => {
         flexDirection: 'row',
       },
     }),
+    pageContainer: css({
+      label: 'page-container',
+      flexGrow: 1,
+    }),
     pageContent: css({
       label: 'page-content',
       flexGrow: 1,
@@ -167,6 +171,8 @@ const getStyles = (theme: GrafanaTheme2) => {
       boxShadow: shadow,
       background: theme.colors.background.primary,
       margin: theme.spacing(2, 2, 2, 1),
+      display: 'flex',
+      flexDirection: 'column',
       flexGrow: 1,
     }),
     canvasContent: css({

--- a/public/app/features/dashboard/components/DashboardSettings/JsonEditorSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/JsonEditorSettings.tsx
@@ -1,9 +1,8 @@
 import { css } from '@emotion/css';
 import React, { useState } from 'react';
-import AutoSizer from 'react-virtualized-auto-sizer';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { Button, CodeEditor, Stack, useStyles2 } from '@grafana/ui';
+import { Button, CodeEditor, useStyles2 } from '@grafana/ui';
 import { Page } from 'app/core/components/PageNew/Page';
 import { dashboardWatcher } from 'app/features/live/dashboard/dashboardWatcher';
 
@@ -13,16 +12,10 @@ import { SettingsPageProps } from './types';
 
 export function JsonEditorSettings({ dashboard, sectionNav }: SettingsPageProps) {
   const [dashboardJson, setDashboardJson] = useState<string>(JSON.stringify(dashboard.getSaveModelClone(), null, 2));
-  const onBlur = (value: string) => {
-    setDashboardJson(value);
-  };
 
-  const onClick = () => {
-    getDashboardSrv()
-      .saveJSONDashboard(dashboardJson)
-      .then(() => {
-        dashboardWatcher.reloadPage();
-      });
+  const onClick = async () => {
+    await getDashboardSrv().saveJSONDashboard(dashboardJson);
+    dashboardWatcher.reloadPage();
   };
 
   const styles = useStyles2(getStyles);
@@ -31,41 +24,35 @@ export function JsonEditorSettings({ dashboard, sectionNav }: SettingsPageProps)
 
   return (
     <Page navModel={sectionNav} subTitle={subTitle}>
-      <div className={styles.fullHeight}>
-        <Stack direction="column" gap={4} flexGrow={1}>
-          <div className={styles.editWrapper}>
-            <AutoSizer>
-              {({ width, height }) => (
-                <CodeEditor
-                  value={dashboardJson}
-                  language="json"
-                  width={width}
-                  height={height}
-                  showMiniMap={true}
-                  showLineNumbers={true}
-                  onBlur={onBlur}
-                />
-              )}
-            </AutoSizer>
-          </div>
+      <div className={styles.wrapper}>
+        <CodeEditor
+          value={dashboardJson}
+          language="json"
+          showMiniMap={true}
+          showLineNumbers={true}
+          onBlur={setDashboardJson}
+          containerStyles={styles.codeEditor}
+        />
+        {dashboard.meta.canSave && (
           <div>
-            {dashboard.meta.canSave && (
-              <Button type="submit" onClick={onClick}>
-                Save changes
-              </Button>
-            )}
+            <Button type="submit" onClick={onClick}>
+              Save changes
+            </Button>
           </div>
-        </Stack>
+        )}
       </div>
     </Page>
   );
 }
 
-const getStyles = (_: GrafanaTheme2) => ({
-  editWrapper: css({ flexGrow: 1 }),
-  fullHeight: css({
-    height: '100%',
+const getStyles = (theme: GrafanaTheme2) => ({
+  wrapper: css({
     display: 'flex',
+    height: '100%',
     flexDirection: 'column',
+    gap: theme.spacing(2),
+  }),
+  codeEditor: css({
+    flexGrow: 1,
   }),
 });

--- a/public/app/features/dashboard/components/DashboardSettings/JsonEditorSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/JsonEditorSettings.tsx
@@ -31,36 +31,41 @@ export function JsonEditorSettings({ dashboard, sectionNav }: SettingsPageProps)
 
   return (
     <Page navModel={sectionNav} subTitle={subTitle}>
-      <div className="dashboard-settings__subheader"></div>
-
-      <Stack direction="column" gap={4} flexGrow={1}>
-        <div className={styles.editWrapper}>
-          <AutoSizer>
-            {({ width, height }) => (
-              <CodeEditor
-                value={dashboardJson}
-                language="json"
-                width={width}
-                height={height}
-                showMiniMap={true}
-                showLineNumbers={true}
-                onBlur={onBlur}
-              />
+      <div className={styles.fullHeight}>
+        <Stack direction="column" gap={4} flexGrow={1}>
+          <div className={styles.editWrapper}>
+            <AutoSizer>
+              {({ width, height }) => (
+                <CodeEditor
+                  value={dashboardJson}
+                  language="json"
+                  width={width}
+                  height={height}
+                  showMiniMap={true}
+                  showLineNumbers={true}
+                  onBlur={onBlur}
+                />
+              )}
+            </AutoSizer>
+          </div>
+          <div>
+            {dashboard.meta.canSave && (
+              <Button type="submit" onClick={onClick}>
+                Save changes
+              </Button>
             )}
-          </AutoSizer>
-        </div>
-        <div>
-          {dashboard.meta.canSave && (
-            <Button type="submit" onClick={onClick}>
-              Save changes
-            </Button>
-          )}
-        </div>
-      </Stack>
+          </div>
+        </Stack>
+      </div>
     </Page>
   );
 }
 
 const getStyles = (_: GrafanaTheme2) => ({
   editWrapper: css({ flexGrow: 1 }),
+  fullHeight: css({
+    height: '100%',
+    display: 'flex',
+    flexDirection: 'column',
+  }),
 });


### PR DESCRIPTION
In https://github.com/grafana/grafana/pull/56278 I removed display: 'flex' from the pageInner div of the Page component as children of Page that had flexGrow (like Alert) did take up the remaining space on some pages. 

Because pageInner also has the page header, and then children for children to use height 100% (of the remaining height subtracting the header) pageInner really needs to be a flex container. 

Think one way to solve this is to add a wrapping div around children instead. This way a child of Page can use css height 100% safely (and get the remaining height left over). 

It's a bit hard to see in the diff, but he new markup is like this:

```tsx
        <div className={styles.pageContainer}>
            <CustomScrollbar autoHeightMin={'100%'} scrollTop={scrollTop} scrollRefCallback={scrollRef}>
              <div className={styles.pageInner}>
                {pageHeaderNav && <PageHeader navItem={pageHeaderNav} subTitle={subTitle} />}
                {pageNav && pageNav.children && <PageTabs navItem={pageNav} />}
                <div className={styles.pageContent}>{children}</div>
              </div>
              <Footer />
            </CustomScrollbar>
          </div>
        </div>
```

Basically the only change is the new addion of the pageContent div wrapping children. I also took the opertunity to rename / change places for the class names so the make better sense (pageContainer used to be named pageContent)

The other option is to pass in a custom pageInnerClass and mix the two but that feels more complex and harder to maintain. But it is close. 