### PR TITLE
CI: Use `io.ReadAll` instead of `json.Decode` for reading the response body

### DIFF
--- a/pkg/build/cmd/grafanacom.go
+++ b/pkg/build/cmd/grafanacom.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"net/url"
@@ -224,8 +225,8 @@ func getSHA256(u string) ([]byte, error) {
 		return nil, fmt.Errorf("failed downloading %s: %s", u, resp.Status)
 	}
 
-	var sha256 []byte
-	if err := json.NewDecoder(resp.Body).Decode(&sha256); err != nil {
+	sha256, err := io.ReadAll(resp.Body)
+	if err != nil {
 		return nil, err
 	}
 	return sha256, nil


### PR DESCRIPTION
**What this PR does / why we need it**:

There is a bug when using `json.NewDecoded(...).Decode(...)`, returning `invalid character 'b' looking for beginning of value`. This must be due to faulty decoding of the `ReadCloser` to bytes.

`io.ReadAll` is simpler and cleaner, and we can use that to read the body and return it.