### PR TITLE
logs: better JSON detected fields handling

### DIFF
--- a/public/app/core/utils/types.test.ts
+++ b/public/app/core/utils/types.test.ts
@@ -1,0 +1,18 @@
+import { isNotNullish } from './types';
+
+describe('isNotNullish()', () => {
+  it('handles various data-types correctly', () => {
+    expect(isNotNullish(null)).toBe(false);
+    expect(isNotNullish(undefined)).toBe(false);
+    expect(isNotNullish(0)).toBe(true);
+    expect(isNotNullish(42)).toBe(true);
+    expect(isNotNullish('')).toBe(true);
+    expect(isNotNullish('test')).toBe(true);
+    expect(isNotNullish(false)).toBe(true);
+    expect(isNotNullish(true)).toBe(true);
+    expect(isNotNullish([])).toBe(true);
+    expect(isNotNullish([1, 2, 3])).toBe(true);
+    expect(isNotNullish({})).toBe(true);
+    expect(isNotNullish({ a: 1 })).toBe(true);
+  });
+});

--- a/public/app/core/utils/types.ts
+++ b/public/app/core/utils/types.ts
@@ -1,3 +1,10 @@
 type Truthy<T> = T extends false | '' | 0 | null | undefined ? never : T;
 
 export const isTruthy = <T>(value: T): value is Truthy<T> => Boolean(value);
+
+type NotNullish<T> = T extends null | undefined ? never : T;
+
+/**
+ * return `false` for `null` and `undefined`, and return `true` for everything else
+ */
+export const isNotNullish = <T>(value: T): value is NotNullish<T> => value != null; // this covers both `null` and `undefined`


### PR DESCRIPTION
fixes https://github.com/grafana/grafana/issues/52357

the important commits: 
- https://github.com/grafana/grafana/commit/c396318b58c692a0f3c6a2a5256de24906d4d7f2 refactors the `buildMatcher` API, so that we can replace the internal implementation
- https://github.com/grafana/grafana/commit/c7c509c02da95f94711b08564e70932da4d5dec7 switches `buildMatcher` from regexp-based to `JSON.parse`-based . ( it also adjusts the rest of the functions there, to remove code-duplication)