### PR TITLE
RBAC: Add primary key to seed_assignment table

### DIFF
--- a/pkg/services/sqlstore/migrations/accesscontrol/seed_assignment.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/seed_assignment.go
@@ -75,6 +75,9 @@ func (m *seedAssignmentPrimaryKeyMigrator) Exec(sess *xorm.Session, mig *migrato
 			role_name TEXT
 		);
 	`)
+	if err != nil {
+		return err
+	}
 
 	// copy data to temp table
 	_, err = sess.Exec("INSERT INTO seed_assignment_temp (builtin_role, action, scope, role_name) SELECT * FROM seed_assignment;")

--- a/pkg/services/sqlstore/migrations/accesscontrol/seed_assignment.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/seed_assignment.go
@@ -1,0 +1,38 @@
+package accesscontrol
+
+import "github.com/grafana/grafana/pkg/services/sqlstore/migrator"
+
+const migSQLITERoleNameNullable = `ALTER TABLE seed_assignment ADD COLUMN tmp_role_name VARCHAR(190) DEFAULT NULL;
+UPDATE seed_assignment SET tmp_role_name = role_name;
+ALTER TABLE seed_assignment DROP COLUMN role_name;
+ALTER TABLE seed_assignment RENAME COLUMN tmp_role_name TO role_name;`
+
+func AddSeedAssignmentMigrations(mg *migrator.Migrator) {
+	seedAssignmentTable := migrator.Table{Name: "seed_assignment"}
+
+	mg.AddMigration("add action column to seed_assignment",
+		migrator.NewAddColumnMigration(seedAssignmentTable,
+			&migrator.Column{Name: "action", Type: migrator.DB_Varchar, Length: 190, Nullable: true}))
+
+	mg.AddMigration("add scope column to seed_assignment",
+		migrator.NewAddColumnMigration(seedAssignmentTable,
+			&migrator.Column{Name: "scope", Type: migrator.DB_Varchar, Length: 190, Nullable: true}))
+
+	mg.AddMigration("remove unique index builtin_role_role_name before nullable update",
+		migrator.NewDropIndexMigration(seedAssignmentTable,
+			&migrator.Index{Cols: []string{"builtin_role", "role_name"}, Type: migrator.UniqueIndex}))
+
+	mg.AddMigration("update seed_assignment role_name column to nullable",
+		migrator.NewRawSQLMigration("").
+			SQLite(migSQLITERoleNameNullable).
+			Postgres("ALTER TABLE `seed_assignment` ALTER COLUMN role_name DROP NOT NULL;").
+			Mysql("ALTER TABLE seed_assignment MODIFY role_name VARCHAR(190) DEFAULT NULL;"))
+
+	mg.AddMigration("add unique index builtin_role_name back",
+		migrator.NewAddIndexMigration(seedAssignmentTable,
+			&migrator.Index{Cols: []string{"builtin_role", "role_name"}, Type: migrator.UniqueIndex}))
+
+	mg.AddMigration("add unique index builtin_role_action_scope",
+		migrator.NewAddIndexMigration(seedAssignmentTable,
+			&migrator.Index{Cols: []string{"builtin_role", "action", "scope"}, Type: migrator.UniqueIndex}))
+}

--- a/pkg/services/sqlstore/migrations/migrations.go
+++ b/pkg/services/sqlstore/migrations/migrations.go
@@ -98,6 +98,7 @@ func (*OSSMigrations) AddMigration(mg *Migrator) {
 	ualert.UpdateRuleGroupIndexMigration(mg)
 	accesscontrol.AddManagedFolderAlertActionsRepeatMigration(mg)
 	accesscontrol.AddAdminOnlyMigration(mg)
+	accesscontrol.AddSeedAssignmentMigrations(mg)
 }
 
 func addMigrationLogMigrations(mg *Migrator) {


### PR DESCRIPTION
**What this PR does / why we need it**:
We have some open escalations related to missing primary key on seed_assignment causing problems, mainly when using percona fork of mysql, but can also affect [oracle mysql](https://dev.mysql.com/blog-archive/enforce-primary-key-constraints-on-replication/) .

For mysql and postgres this is trivial to add but sqlite does not allow adding constraints to already existing table. To solve that we need to craete a new temporary table with desired columns, copy data over, drop old table, rename temp to old name and recreate indices. 

This pr also include moving some migrations from enterprise to oss. This table is only used when running enterprise with license that includes rbac

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana-enterprise/issues/3907

**Special notes for your reviewer**:

