### PR TITLE
Alerting: handle 0s last notify duration notification error feedback

### DIFF
--- a/public/app/features/alerting/unified/components/receivers/ReceiversTable.tsx
+++ b/public/app/features/alerting/unified/components/receivers/ReceiversTable.tsx
@@ -169,6 +169,7 @@ function LastNotify({ lastNotifyDate }: { lastNotifyDate: string }) {
 }
 
 function NotifiersTable({ notifiersState }: NotifiersTableProps) {
+  const durationIsNull = (duration: string) => duration === '0s';
   function getNotifierColumns(): NotifierTableColumnProps[] {
     return [
       {
@@ -200,7 +201,9 @@ function NotifiersTable({ notifiersState }: NotifiersTableProps) {
       {
         id: 'lastNotifyDuration',
         label: 'Last duration',
-        renderCell: ({ data: { lastNotifyDuration } }) => <>{lastNotifyDuration}</>,
+        renderCell: ({ data: { lastNotifyDuration } }) => (
+          <>{durationIsNull(lastNotifyDuration) ? '-' : lastNotifyDuration}</>
+        ),
         size: 1,
       },
       {

--- a/public/app/features/alerting/unified/components/receivers/ReceiversTable.tsx
+++ b/public/app/features/alerting/unified/components/receivers/ReceiversTable.tsx
@@ -168,8 +168,10 @@ function LastNotify({ lastNotifyDate }: { lastNotifyDate: string }) {
   }
 }
 
+const possibleNullDurations = ['', '0', '0ms', '0s', '0m', '0h', '0d', '0w', '0y'];
+const durationIsNull = (duration: string) => possibleNullDurations.includes(duration);
+
 function NotifiersTable({ notifiersState }: NotifiersTableProps) {
-  const durationIsNull = (duration: string) => duration === '0s';
   function getNotifierColumns(): NotifierTableColumnProps[] {
     return [
       {


### PR DESCRIPTION

**What this PR does / why we need it**:
This PR shows '-' instead of '0s' in the notifiers table, when we get '0s' in `lastNotifyAttemptDuration`) in receivers response. 
It also adds some test for 'no attempt' and for this '0s' use cases in Receivers and Notifiers table

**Special notes for your reviewer**:
<img width="1535" alt="Screenshot 2022-10-07 at 13 00 55" src="https://user-images.githubusercontent.com/33540275/194538582-ec99b491-2a77-4649-b259-5cf726eb0d88.png">

