### PR TITLE
@grafana/ui: EditorField tooltip interactive

### DIFF
--- a/packages/grafana-ui/src/components/QueryEditor/EditorField.tsx
+++ b/packages/grafana-ui/src/components/QueryEditor/EditorField.tsx
@@ -17,10 +17,11 @@ interface EditorFieldProps extends ComponentProps<typeof Field> {
   width?: number | string;
   optional?: boolean;
   tooltip?: PopoverContent;
+  tooltipInteractive?: boolean;
 }
 
 export const EditorField: React.FC<EditorFieldProps> = (props) => {
-  const { label, optional, tooltip, children, width, ...fieldProps } = props;
+  const { label, optional, tooltip, tooltipInteractive, children, width, ...fieldProps } = props;
 
   const theme = useTheme2();
   const styles = getStyles(theme, width);
@@ -34,7 +35,7 @@ export const EditorField: React.FC<EditorFieldProps> = (props) => {
         {label}
         {optional && <span className={styles.optional}> - optional</span>}
         {tooltip && (
-          <Tooltip placement="top" content={tooltip} theme="info" interactive>
+          <Tooltip placement="top" content={tooltip} theme="info" interactive={tooltipInteractive}>
             <Icon name="info-circle" size="sm" className={styles.icon} />
           </Tooltip>
         )}

--- a/packages/grafana-ui/src/components/QueryEditor/EditorField.tsx
+++ b/packages/grafana-ui/src/components/QueryEditor/EditorField.tsx
@@ -34,7 +34,7 @@ export const EditorField: React.FC<EditorFieldProps> = (props) => {
         {label}
         {optional && <span className={styles.optional}> - optional</span>}
         {tooltip && (
-          <Tooltip placement="top" content={tooltip} theme="info">
+          <Tooltip placement="top" content={tooltip} theme="info" interactive>
             <Icon name="info-circle" size="sm" className={styles.icon} />
           </Tooltip>
         )}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

I want to add a link in a `EditorField` tooltip and for it to be clickable the tooltip should be `interactive`. AFAIK, there is no harm making it interactive but let me know if this should be an option, I can move the setting to a property.

**Special notes for your reviewer**:

I know there is [a conversation to move (at least part of) this components to @grafana/experimental](https://github.com/grafana/grafana/pull/52421#issuecomment-1266896771) but it's not there yet so I am adding the patch here, hopefully this patch will be migrated as well if needed.