### PR TITLE
logs: handle mixed datasources in filters

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -4309,9 +4309,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "7"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "8"]
     ],
-    "public/app/features/explore/state/query.ts:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
-    ],
     "public/app/features/explore/state/time.test.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"],

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -8,7 +8,7 @@ import { Unsubscribable } from 'rxjs';
 
 import { AbsoluteTimeRange, DataQuery, GrafanaTheme2, LoadingState, QueryFixAction, RawTimeRange } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
-import { config } from '@grafana/runtime';
+import { config, getDataSourceSrv } from '@grafana/runtime';
 import { Collapse, CustomScrollbar, ErrorBoundaryAlert, Themeable2, withTheme2, PanelContainer } from '@grafana/ui';
 import { FILTER_FOR_OPERATOR, FILTER_OUT_OPERATOR, FilterItem } from '@grafana/ui/src/components/Table/types';
 import appEvents from 'app/core/app_events';
@@ -174,12 +174,19 @@ export class Explore extends React.PureComponent<Props, ExploreState> {
   };
 
   onModifyQueries = (action: QueryFixAction) => {
-    const { datasourceInstance } = this.props;
-    if (datasourceInstance?.modifyQuery) {
-      const modifier = (queries: DataQuery, modification: QueryFixAction) =>
-        datasourceInstance.modifyQuery!(queries, modification);
-      this.props.modifyQueries(this.props.exploreId, action, modifier);
-    }
+    const modifier = async (query: DataQuery, modification: QueryFixAction) => {
+      const { datasource } = query;
+      if (datasource == null) {
+        return query;
+      }
+      const ds = await getDataSourceSrv().get(datasource);
+      if (ds.modifyQuery) {
+        return ds.modifyQuery(query, modification);
+      } else {
+        return query;
+      }
+    };
+    this.props.modifyQueries(this.props.exploreId, action, modifier);
   };
 
   onResize = (size: { height: number; width: number }) => {

--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -355,14 +355,6 @@ export function modifyQueries(
 
     const nextQueriesRaw = await Promise.all(queries.map((query) => modifier({ ...query }, modification)));
 
-    // we did some async calculations here,
-    // the redux-store could have changed in the meantime.
-    // we will check, and, if changed, we will not apply our changes.
-    const currentQueries = getState().explore[exploreId]?.queries ?? [];
-    if (queries !== currentQueries) {
-      return;
-    }
-
     const nextQueries = nextQueriesRaw.map((nextQuery, i) => {
       return generateNewKeyAndAddRefIdIfMissing(nextQuery, queries, i);
     });

--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -347,6 +347,8 @@ export function modifyQueries(
 ): ThunkResult<void> {
   return async (dispatch, getState) => {
     const state = getState().explore[exploreId];
+
+    // to make typescript happy
     if (state == null) {
       return;
     }

--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -346,12 +346,7 @@ export function modifyQueries(
   modifier: (query: DataQuery, modification: QueryFixAction) => Promise<DataQuery>
 ): ThunkResult<void> {
   return async (dispatch, getState) => {
-    const state = getState().explore[exploreId];
-
-    // to make typescript happy
-    if (state == null) {
-      return;
-    }
+    const state = getState().explore[exploreId]!;
 
     const { queries } = state;
 


### PR DESCRIPTION
when you display logs-data in explore, click on a log-line, and click on the [+] button next to a label, it should modify every query in explore to narrow the query down to that label.

when mixed-datasources are enabled this does not work.
this PR fixes this.

technical details:
with mixed-datasources, there is no single datasource for explore-mode, we always have to find the correct datasource for every query.
the problem is, this process is async (`await getDataSourceSrv().get(query.datasource)`, so the code has to be adjusted,  because the original code ran the modification-calculation inside the redux-reducer, but those must not be async.

the new approach calculates the modified queries in the action-creator, and just sets the final queries into the reducer.


how to test:
1. run `make devenv sources=loki`
2. make sure the mixed-datasources feature flag is enabled
3. go to explore-mode, choose the mixed-dataosurces datasource, and add a loki query: `{place="luna"}`, and run the query
4. open a log line from the result, in the log-labels secrion find the line with `source   data`, click the [+] on that line
5. verify that the original query got modified to be `{place="luna", source="data"}`



( this handles parts of https://github.com/grafana/grafana/issues/56314)