### PR TITLE
Alerting: Cache result of dashboard ID lookups

### DIFF
--- a/pkg/services/ngalert/state/historian/annotation.go
+++ b/pkg/services/ngalert/state/historian/annotation.go
@@ -55,7 +55,7 @@ func (h *AnnotationStateHistorian) RecordState(ctx context.Context, rule *ngmode
 			return
 		}
 
-		dashID, err := h.dashboards.getId(ctx, rule.OrgID, dashUid)
+		dashID, err := h.dashboards.getID(ctx, rule.OrgID, dashUid)
 		if err != nil {
 			h.log.Error("error getting dashboard for alert annotation", "dashboardUID", dashUid, "alertRuleUID", rule.UID, "err", err.Error())
 			return

--- a/pkg/services/ngalert/state/historian/annotation.go
+++ b/pkg/services/ngalert/state/historian/annotation.go
@@ -61,11 +61,6 @@ func (h *AnnotationStateHistorian) RecordState(ctx context.Context, rule *ngmode
 			return
 		}
 
-		if dashID == dashboardNotFound {
-			h.log.Warn("dashboard referenced by rule does not exist", "dashboardUID", dashUid, "alertRuleUID", rule.UID)
-			return
-		}
-
 		item.PanelId = panelId
 		item.DashboardId = dashID
 	}

--- a/pkg/services/ngalert/state/historian/annotation.go
+++ b/pkg/services/ngalert/state/historian/annotation.go
@@ -61,6 +61,11 @@ func (h *AnnotationStateHistorian) RecordState(ctx context.Context, rule *ngmode
 			return
 		}
 
+		if dashID == dashboardNotFound {
+			h.log.Warn("dashboard referenced by rule does not exist", "dashboardUID", dashUid, "alertRuleUID", rule.UID)
+			return
+		}
+
 		item.PanelId = panelId
 		item.DashboardId = dashID
 	}

--- a/pkg/services/ngalert/state/historian/annotation.go
+++ b/pkg/services/ngalert/state/historian/annotation.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/annotations"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
@@ -19,14 +18,14 @@ import (
 // AnnotationStateHistorian is an implementation of state.Historian that uses Grafana Annotations as the backing datastore.
 type AnnotationStateHistorian struct {
 	annotations annotations.Repository
-	dashboards  dashboards.DashboardService
+	dashboards  *dashboardResolver
 	log         log.Logger
 }
 
 func NewAnnotationHistorian(annotations annotations.Repository, dashboards dashboards.DashboardService, log log.Logger) *AnnotationStateHistorian {
 	return &AnnotationStateHistorian{
 		annotations: annotations,
-		dashboards:  dashboards,
+		dashboards:  newDashboardResolver(dashboards, log, defaultDashboardCacheExpiry),
 		log:         log,
 	}
 }
@@ -56,19 +55,14 @@ func (h *AnnotationStateHistorian) RecordState(ctx context.Context, rule *ngmode
 			return
 		}
 
-		query := &models.GetDashboardQuery{
-			Uid:   dashUid,
-			OrgId: rule.OrgID,
-		}
-
-		err = h.dashboards.GetDashboard(ctx, query)
+		dashID, err := h.dashboards.getId(ctx, rule.OrgID, dashUid)
 		if err != nil {
 			h.log.Error("error getting dashboard for alert annotation", "dashboardUID", dashUid, "alertRuleUID", rule.UID, "err", err.Error())
 			return
 		}
 
 		item.PanelId = panelId
-		item.DashboardId = query.Result.Id
+		item.DashboardId = dashID
 	}
 
 	if err := h.annotations.Save(ctx, item); err != nil {

--- a/pkg/services/ngalert/state/historian/dashboard.go
+++ b/pkg/services/ngalert/state/historian/dashboard.go
@@ -94,11 +94,11 @@ func toQueryResult(cacheVal interface{}, err error) (int64, error) {
 		return 0, err
 	}
 
-	switch cacheVal.(type) {
+	switch cacheVal := cacheVal.(type) {
 	case error:
-		return 0, cacheVal.(error)
+		return 0, cacheVal
 	case int64:
-		return cacheVal.(int64), err
+		return cacheVal, err
 	default:
 		panic(fmt.Sprintf("unexpected value stored in cache: %#v", cacheVal))
 	}

--- a/pkg/services/ngalert/state/historian/dashboard.go
+++ b/pkg/services/ngalert/state/historian/dashboard.go
@@ -1,0 +1,77 @@
+package historian
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/patrickmn/go-cache"
+)
+
+const dashboardNotFound = -1
+
+const defaultDashboardCacheExpiry = 1 * time.Minute
+
+// dashboardResolver resolves dashboard UIDs to IDs with caching.
+type dashboardResolver struct {
+	dashboards dashboards.DashboardService
+	cache      *cache.Cache
+	lock       sync.Mutex
+	log        log.Logger
+}
+
+func newDashboardResolver(dbs dashboards.DashboardService, log log.Logger, expiry time.Duration) *dashboardResolver {
+	return &dashboardResolver{
+		dashboards: dbs,
+		cache:      cache.New(expiry, 2*expiry),
+		log:        log,
+	}
+}
+
+// getId gets the ID of the dashboard with the given uid/orgID combination, or returns dashboardNotFound if the dashboard does not exist.
+func (r *dashboardResolver) getId(ctx context.Context, orgID int64, uid string) (int64, error) {
+	// Optimistically query without acquiring lock. This works because cache.Cache is thread-safe.
+	// That way, we don't block valid queries on unrelated cache misses.
+	// We use a double-checked lock to prevent queries from being needlessly ran.
+	if id, found := r.cache.Get(packCacheKey(orgID, uid)); found {
+		return id.(int64), nil
+	}
+
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	if id, found := r.cache.Get(packCacheKey(orgID, uid)); found {
+		return id.(int64), nil
+	}
+
+	r.log.Debug("dashboard cache miss, querying dashboards", "dashboardUID", uid)
+
+	query := &models.GetDashboardQuery{
+		Uid:   uid,
+		OrgId: orgID,
+	}
+	err := r.dashboards.GetDashboard(ctx, query)
+	if err != nil {
+		return 0, err
+	}
+
+	var id int64
+	if query.Result != nil {
+		id = query.Result.Id
+	} else {
+		id = dashboardNotFound
+	}
+
+	r.cache.Set(packCacheKey(orgID, uid), id, cache.DefaultExpiration)
+
+	return id, nil
+}
+
+func packCacheKey(orgID int64, uid string) string {
+	const base = 10
+	return strconv.FormatInt(orgID, base) + "-" + uid
+}

--- a/pkg/services/ngalert/state/historian/dashboard.go
+++ b/pkg/services/ngalert/state/historian/dashboard.go
@@ -13,11 +13,11 @@ import (
 	"github.com/patrickmn/go-cache"
 )
 
-const dashboardNotFound = int64(-1)
-
-const defaultDashboardCacheExpiry = 1 * time.Minute
-
-const minCleanupInterval = 1 * time.Second
+const (
+	dashboardNotFound           = int64(-1)
+	defaultDashboardCacheExpiry = 1 * time.Minute
+	minCleanupInterval          = 1 * time.Second
+)
 
 // dashboardResolver resolves dashboard UIDs to IDs with caching.
 type dashboardResolver struct {
@@ -36,7 +36,7 @@ func newDashboardResolver(dbs dashboards.DashboardService, log log.Logger, expir
 }
 
 // getId gets the ID of the dashboard with the given uid/orgID combination, or returns dashboardNotFound if the dashboard does not exist.
-func (r *dashboardResolver) getId(ctx context.Context, orgID int64, uid string) (int64, error) {
+func (r *dashboardResolver) getID(ctx context.Context, orgID int64, uid string) (int64, error) {
 	// Optimistically query without acquiring lock. This works because cache.Cache is thread-safe.
 	// That way, we don't block valid queries on unrelated cache misses.
 	// We use a double-checked lock to prevent queries from being needlessly ran.

--- a/pkg/services/ngalert/state/historian/dashboard.go
+++ b/pkg/services/ngalert/state/historian/dashboard.go
@@ -61,12 +61,10 @@ func (r *dashboardResolver) getID(ctx context.Context, orgID int64, uid string) 
 			result = err
 		} else if err != nil {
 			return 0, err
-		}
-
-		if query.Result != nil {
-			result = query.Result.Id
-		} else {
+		} else if query.Result == nil {
 			result = dashboards.ErrDashboardNotFound
+		} else {
+			result = query.Result.Id
 		}
 
 		// By setting the cache inside the singleflighted routine, we avoid any accidental re-queries that could get initiated after the query completes.

--- a/pkg/services/ngalert/state/historian/dashboard_test.go
+++ b/pkg/services/ngalert/state/historian/dashboard_test.go
@@ -1,0 +1,46 @@
+package historian
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDashboardResolver(t *testing.T) {
+	t.Run("fetches dashboards from dashboard service", func(t *testing.T) {
+		dbs := &dashboards.FakeDashboardService{}
+		exp := int64(14)
+		dbs.On("GetDashboard", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+			args.Get(1).(*models.GetDashboardQuery).Result = &models.Dashboard{Id: exp}
+		}).Return(nil)
+		sut := createDashboardResolverSut(dbs)
+
+		id, err := sut.getId(context.Background(), 1, "dashboard-uid")
+
+		require.NoError(t, err)
+		require.Equal(t, exp, id)
+	})
+
+	t.Run("fetches dashboardNotFound if underlying dashboard does not exist", func(t *testing.T) {
+		dbs := &dashboards.FakeDashboardService{}
+		dbs.On("GetDashboard", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+			args.Get(1).(*models.GetDashboardQuery).Result = nil
+		}).Return(dashboards.ErrDashboardNotFound)
+		sut := createDashboardResolverSut(dbs)
+
+		id, err := sut.getId(context.Background(), 1, "not-exist")
+
+		require.NoError(t, err)
+		require.Equal(t, dashboardNotFound, id)
+	})
+}
+
+func createDashboardResolverSut(dbs *dashboards.FakeDashboardService) *dashboardResolver {
+	return newDashboardResolver(dbs, log.NewNopLogger(), 1*time.Nanosecond)
+}

--- a/pkg/services/ngalert/state/historian/dashboard_test.go
+++ b/pkg/services/ngalert/state/historian/dashboard_test.go
@@ -21,7 +21,7 @@ func TestDashboardResolver(t *testing.T) {
 		}).Return(nil)
 		sut := createDashboardResolverSut(dbs)
 
-		id, err := sut.getId(context.Background(), 1, "dashboard-uid")
+		id, err := sut.getID(context.Background(), 1, "dashboard-uid")
 
 		require.NoError(t, err)
 		require.Equal(t, exp, id)
@@ -34,7 +34,7 @@ func TestDashboardResolver(t *testing.T) {
 		}).Return(dashboards.ErrDashboardNotFound)
 		sut := createDashboardResolverSut(dbs)
 
-		id, err := sut.getId(context.Background(), 1, "not-exist")
+		id, err := sut.getID(context.Background(), 1, "not-exist")
 
 		require.NoError(t, err)
 		require.Equal(t, dashboardNotFound, id)

--- a/pkg/services/ngalert/state/historian/dashboard_test.go
+++ b/pkg/services/ngalert/state/historian/dashboard_test.go
@@ -34,10 +34,10 @@ func TestDashboardResolver(t *testing.T) {
 		}).Return(dashboards.ErrDashboardNotFound)
 		sut := createDashboardResolverSut(dbs)
 
-		id, err := sut.getID(context.Background(), 1, "not-exist")
+		_, err := sut.getID(context.Background(), 1, "not-exist")
 
-		require.NoError(t, err)
-		require.Equal(t, dashboardNotFound, id)
+		require.Error(t, err)
+		require.ErrorIs(t, err, dashboards.ErrDashboardNotFound)
 	})
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

When we emit annotations for a rule, we query the dashboards table in order to convert the UID in the rule annotations to a dashboard ID. This happens over and over.

Even if we batch and query once per-rule, there are still a lot of redundant queries. Many rules may share a dashboard, or the same rule can be queried over and over.

This PR caches the results of this lookup in-memory.

I have not benchmarked this yet, so the cache parameters could do with some further tuning. I'll do this next week.

**Which issue(s) this PR fixes**:

Contributes to #54096 

**Special notes for your reviewer**:

