### PR TITLE
DashboardFolders: Issue #56402 Fix updating folder in SaveDashboard

### DIFF
--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -110,7 +110,7 @@ export class DashboardModel implements TimeModel {
 
   static nonPersistedProperties: { [str: string]: boolean } = {
     events: true,
-    meta: true,
+    meta: false,
     panels: true, // needs special handling
     templating: true, // needs special handling
     originalTime: true,


### PR DESCRIPTION
Found that when changing folders in the Dashboard GeneralSettings the Folder changes were not being evaluated. Folder change method changes values in the dashboards meta object which was flagged as nonPersisted. Changed meta to false as it is not nonPersisted for folder changes. This allows the folder to be saved in Dashboard Settings.


**What this PR does / why we need it**:
Fixes a current issue and functionality with saving dashboards

**Which issue(s) this PR fixes**:
Fixes #56402 


Fixes #56402 


