### PR TITLE
Graphite: Never escape asPercent function params as string

### DIFF
--- a/public/app/plugins/datasource/graphite/gfunc.test.ts
+++ b/public/app/plugins/datasource/graphite/gfunc.test.ts
@@ -1,4 +1,4 @@
-import gfunc from './gfunc';
+import gfunc, { FuncInstance } from './gfunc';
 
 describe('gfunc', () => {
   const INDEX = {
@@ -19,5 +19,36 @@ describe('gfunc', () => {
       defaultParams: [''],
       unknown: true,
     });
+  });
+
+  it('renders the version < .9 asPercent function parameters by not escaping them as a string', () => {
+    // this function is returned from the graphite functions endpoint
+    const asPercentDef = {
+      name: 'asPercent',
+      description: 'Calculates a percentage.',
+      category: 'Combine',
+      params: [
+        {
+          name: 'total',
+          type: 'string',
+          optional: true,
+          multiple: false,
+        },
+        {
+          name: 'nodes',
+          type: 'node_or_tag',
+          optional: true,
+          multiple: true,
+          options: [],
+        },
+      ],
+      defaultParams: [],
+    };
+
+    const asPercent = new FuncInstance(asPercentDef);
+
+    const asPercentRendered = asPercent.render('#A', () => '#A');
+
+    expect(asPercentRendered).toEqual('asPercent(#A)');
   });
 });

--- a/public/app/plugins/datasource/graphite/gfunc.ts
+++ b/public/app/plugins/datasource/graphite/gfunc.ts
@@ -1028,13 +1028,13 @@ export class FuncInstance {
       }
 
       // param types that should never be quoted
-      if (includes(['value_or_series', 'boolean', 'int', 'float', 'node', 'int_or_infinity'], paramType)) {
-        return value;
-      }
+      const neverQuotedParams = ['value_or_series', 'boolean', 'int', 'float', 'node', 'int_or_infinity'];
 
       // functions that should not have param types quoted
       // https://github.com/grafana/grafana/issues/54924
-      if (includes(['asPercent'], this.def.name)) {
+      const neverQuotedFunctions = ['asPercent'];
+      // params or functions that should never be quoted
+      if (includes(neverQuotedParams, paramType) || includes(neverQuotedFunctions, this.def.name)) {
         return value;
       }
 

--- a/public/app/plugins/datasource/graphite/gfunc.ts
+++ b/public/app/plugins/datasource/graphite/gfunc.ts
@@ -1032,6 +1032,12 @@ export class FuncInstance {
         return value;
       }
 
+      // functions that should not have param types quoted
+      // https://github.com/grafana/grafana/issues/54924
+      if (includes(['asPercent'], this.def.name)) {
+        return value;
+      }
+
       const valueInterpolated = isString(value) ? replaceVariables(value) : value;
 
       // param types that might be quoted


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/54924

In older versions of Graphite we call the endpoint for a list of functions. In this list, the asPercent function has parameters defined as types strings and we escape them as strings, which breaks series-refs. in Grafana for Graphite > v0.9 we populate an updated list of functions where the params are typed as 'series-ref' and we don't escape them as strings. 

This fix assumes that asPercent has params of 'series-ref' and does not escape the params as strings.
