### PR TITLE
Chore: Reduce test timeouts to 5 minutes

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -216,13 +216,13 @@ steps:
   image: grafana/build-container:1.6.3
   name: wire-install
 - commands:
-  - go test -short -covermode=atomic -timeout=30m ./pkg/...
+  - go test -short -covermode=atomic -timeout=5m ./pkg/...
   depends_on:
   - wire-install
   image: grafana/build-container:1.6.3
   name: test-backend
 - commands:
-  - go test -run Integration -covermode=atomic -timeout=30m ./pkg/...
+  - go test -run Integration -covermode=atomic -timeout=5m ./pkg/...
   depends_on:
   - wire-install
   image: grafana/build-container:1.6.3
@@ -631,7 +631,7 @@ steps:
   - psql -p 5432 -h postgres -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql
   - go clean -testcache
   - go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic
-    -timeout=30m {}'
+    -timeout=5m {}'
   depends_on:
   - wire-install
   environment:
@@ -648,7 +648,7 @@ steps:
     -prootpass
   - go clean -testcache
   - go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic
-    -timeout=30m {}'
+    -timeout=5m {}'
   depends_on:
   - wire-install
   environment:
@@ -1056,13 +1056,13 @@ steps:
   image: grafana/build-container:1.6.3
   name: wire-install
 - commands:
-  - go test -short -covermode=atomic -timeout=30m ./pkg/...
+  - go test -short -covermode=atomic -timeout=5m ./pkg/...
   depends_on:
   - wire-install
   image: grafana/build-container:1.6.3
   name: test-backend
 - commands:
-  - go test -run Integration -covermode=atomic -timeout=30m ./pkg/...
+  - go test -run Integration -covermode=atomic -timeout=5m ./pkg/...
   depends_on:
   - wire-install
   image: grafana/build-container:1.6.3
@@ -1624,7 +1624,7 @@ steps:
   - psql -p 5432 -h postgres -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql
   - go clean -testcache
   - go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic
-    -timeout=30m {}'
+    -timeout=5m {}'
   depends_on:
   - wire-install
   environment:
@@ -1641,7 +1641,7 @@ steps:
     -prootpass
   - go clean -testcache
   - go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic
-    -timeout=30m {}'
+    -timeout=5m {}'
   depends_on:
   - wire-install
   environment:
@@ -2304,13 +2304,13 @@ steps:
   image: grafana/build-container:1.6.3
   name: lint-frontend
 - commands:
-  - go test -short -covermode=atomic -timeout=30m ./pkg/...
+  - go test -short -covermode=atomic -timeout=5m ./pkg/...
   depends_on:
   - wire-install
   image: grafana/build-container:1.6.3
   name: test-backend
 - commands:
-  - go test -run Integration -covermode=atomic -timeout=30m ./pkg/...
+  - go test -run Integration -covermode=atomic -timeout=5m ./pkg/...
   depends_on:
   - wire-install
   image: grafana/build-container:1.6.3
@@ -2406,7 +2406,7 @@ steps:
   - psql -p 5432 -h postgres -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql
   - go clean -testcache
   - go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic
-    -timeout=30m {}'
+    -timeout=5m {}'
   depends_on:
   - wire-install
   environment:
@@ -2423,7 +2423,7 @@ steps:
     -prootpass
   - go clean -testcache
   - go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic
-    -timeout=30m {}'
+    -timeout=5m {}'
   depends_on:
   - wire-install
   environment:
@@ -2970,13 +2970,13 @@ steps:
   image: grafana/build-container:1.6.3
   name: lint-frontend
 - commands:
-  - go test -short -covermode=atomic -timeout=30m ./pkg/...
+  - go test -short -covermode=atomic -timeout=5m ./pkg/...
   depends_on:
   - wire-install
   image: grafana/build-container:1.6.3
   name: test-backend
 - commands:
-  - go test -run Integration -covermode=atomic -timeout=30m ./pkg/...
+  - go test -run Integration -covermode=atomic -timeout=5m ./pkg/...
   depends_on:
   - wire-install
   image: grafana/build-container:1.6.3
@@ -2999,7 +2999,7 @@ steps:
   image: golang:1.19.2
   name: lint-backend-enterprise2
 - commands:
-  - go test -tags=pro -covermode=atomic -timeout=30m ./pkg/...
+  - go test -tags=pro -covermode=atomic -timeout=5m ./pkg/...
   depends_on:
   - wire-install
   image: grafana/build-container:1.6.3
@@ -3119,7 +3119,7 @@ steps:
   - psql -p 5432 -h postgres -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql
   - go clean -testcache
   - go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic
-    -timeout=30m {}'
+    -timeout=5m {}'
   depends_on:
   - wire-install
   environment:
@@ -3136,7 +3136,7 @@ steps:
     -prootpass
   - go clean -testcache
   - go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic
-    -timeout=30m {}'
+    -timeout=5m {}'
   depends_on:
   - wire-install
   environment:
@@ -4215,13 +4215,13 @@ steps:
   image: grafana/build-container:1.6.3
   name: lint-frontend
 - commands:
-  - go test -short -covermode=atomic -timeout=30m ./pkg/...
+  - go test -short -covermode=atomic -timeout=5m ./pkg/...
   depends_on:
   - wire-install
   image: grafana/build-container:1.6.3
   name: test-backend
 - commands:
-  - go test -run Integration -covermode=atomic -timeout=30m ./pkg/...
+  - go test -run Integration -covermode=atomic -timeout=5m ./pkg/...
   depends_on:
   - wire-install
   image: grafana/build-container:1.6.3
@@ -4311,7 +4311,7 @@ steps:
   - psql -p 5432 -h postgres -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql
   - go clean -testcache
   - go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic
-    -timeout=30m {}'
+    -timeout=5m {}'
   depends_on:
   - wire-install
   environment:
@@ -4328,7 +4328,7 @@ steps:
     -prootpass
   - go clean -testcache
   - go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic
-    -timeout=30m {}'
+    -timeout=5m {}'
   depends_on:
   - wire-install
   environment:
@@ -4845,13 +4845,13 @@ steps:
   image: grafana/build-container:1.6.3
   name: lint-frontend
 - commands:
-  - go test -short -covermode=atomic -timeout=30m ./pkg/...
+  - go test -short -covermode=atomic -timeout=5m ./pkg/...
   depends_on:
   - wire-install
   image: grafana/build-container:1.6.3
   name: test-backend
 - commands:
-  - go test -run Integration -covermode=atomic -timeout=30m ./pkg/...
+  - go test -run Integration -covermode=atomic -timeout=5m ./pkg/...
   depends_on:
   - wire-install
   image: grafana/build-container:1.6.3
@@ -4874,7 +4874,7 @@ steps:
   image: golang:1.19.2
   name: lint-backend-enterprise2
 - commands:
-  - go test -tags=pro -covermode=atomic -timeout=30m ./pkg/...
+  - go test -tags=pro -covermode=atomic -timeout=5m ./pkg/...
   depends_on:
   - wire-install
   image: grafana/build-container:1.6.3
@@ -4985,7 +4985,7 @@ steps:
   - psql -p 5432 -h postgres -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql
   - go clean -testcache
   - go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic
-    -timeout=30m {}'
+    -timeout=5m {}'
   depends_on:
   - wire-install
   environment:
@@ -5002,7 +5002,7 @@ steps:
     -prootpass
   - go clean -testcache
   - go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic
-    -timeout=30m {}'
+    -timeout=5m {}'
   depends_on:
   - wire-install
   environment:
@@ -5339,6 +5339,6 @@ kind: secret
 name: packages_secret_access_key
 ---
 kind: signature
-hmac: cbcc3bfd12e065c989418a384df74322d4a2f9836032cb9b256c6d1274389ba3
+hmac: 74e91fca99550f9a5c85b01f1e8ab58629a1fff4e55ca07be3163d26e5f291bb
 
 ...

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -485,7 +485,7 @@ def test_backend_step(edition):
                 'wire-install',
             ],
             'commands': [
-                'go test -tags=pro -covermode=atomic -timeout=30m ./pkg/...',
+                'go test -tags=pro -covermode=atomic -timeout=5m ./pkg/...',
             ],
         }
     else:
@@ -496,7 +496,7 @@ def test_backend_step(edition):
                 'wire-install',
             ],
             'commands': [
-                'go test -short -covermode=atomic -timeout=30m ./pkg/...',
+                'go test -short -covermode=atomic -timeout=5m ./pkg/...',
             ],
         }
 
@@ -510,7 +510,7 @@ def test_backend_integration_step(edition):
             'wire-install',
         ],
         'commands': [
-            'go test -run Integration -covermode=atomic -timeout=30m ./pkg/...',
+            'go test -run Integration -covermode=atomic -timeout=5m ./pkg/...',
         ],
     }
 
@@ -859,7 +859,7 @@ def postgres_integration_tests_step(edition, ver_mode):
             'devenv/docker/blocks/postgres_tests/setup.sql',
             # Make sure that we don't use cached results for another database
             'go clean -testcache',
-            "go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic -timeout=30m {}'",
+            "go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic -timeout=5m {}'",
         ]
     return {
         'name': 'postgres-integration-tests',
@@ -882,7 +882,7 @@ def mysql_integration_tests_step(edition, ver_mode):
             'cat devenv/docker/blocks/mysql_tests/setup.sql | mysql -h mysql -P 3306 -u root -prootpass',
             # Make sure that we don't use cached results for another database
             'go clean -testcache',
-            "go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic -timeout=30m {}'",
+            "go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic -timeout=5m {}'",
         ]
     return {
         'name': 'mysql-integration-tests',


### PR DESCRIPTION
Experimental attempt to reduce test timeouts. Currently, we use a test timeout of 30 minutes _per package_. This encourages writing slow tests and is very annoying if a deadlock happens during the CI.

This PR reduces the timeouts down to 5m (currently alerting tests are the longest and take ~3 min).
So, let there me more failures due to the timeout! (or not? I leave it to RelEng best judgement -- feel free to close this PR if you find it too risky).