### PR TITLE
[v9.1.x] Alerting: Mark all tests that interact with the database as Integration tests.

### DIFF
--- a/pkg/services/ngalert/models/testing.go
+++ b/pkg/services/ngalert/models/testing.go
@@ -58,14 +58,14 @@ func AlertRuleGen(mutators ...AlertRuleMutator) func() *AlertRule {
 		}
 
 		rule := &AlertRule{
-			ID:              rand.Int63(),
-			OrgID:           rand.Int63(),
+			ID:              rand.Int63n(1 << 30),
+			OrgID:           rand.Int63n(1 << 30),
 			Title:           "TEST-ALERT-" + util.GenerateShortUID(),
 			Condition:       "A",
 			Data:            []AlertQuery{GenerateAlertQuery()},
 			Updated:         time.Now().Add(-time.Duration(rand.Intn(100) + 1)),
 			IntervalSeconds: rand.Int63n(60) + 1,
-			Version:         rand.Int63(),
+			Version:         rand.Int63n(1 << 30),
 			UID:             util.GenerateShortUID(),
 			NamespaceUID:    util.GenerateShortUID(),
 			DashboardUID:    dashUID,

--- a/pkg/services/ngalert/models/testing.go
+++ b/pkg/services/ngalert/models/testing.go
@@ -71,7 +71,7 @@ func AlertRuleGen(mutators ...AlertRuleMutator) func() *AlertRule {
 			DashboardUID:    dashUID,
 			PanelID:         panelID,
 			RuleGroup:       "TEST-GROUP-" + util.GenerateShortUID(),
-			RuleGroupIndex:  rand.Int(),
+			RuleGroupIndex:  rand.Intn(1 << 30),
 			NoDataState:     randNoDataState(),
 			ExecErrState:    randErrState(),
 			For:             forInterval,
@@ -115,7 +115,7 @@ func WithUniqueGroupIndex() AlertRuleMutator {
 	usedIdx := make(map[int]struct{})
 	return func(rule *AlertRule) {
 		for {
-			idx := rand.Int()
+			idx := rand.Intn(1 << 30)
 			if _, ok := usedIdx[idx]; !ok {
 				usedIdx[idx] = struct{}{}
 				rule.RuleGroupIndex = idx

--- a/pkg/services/ngalert/ngalert_test.go
+++ b/pkg/services/ngalert/ngalert_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func Test_subscribeToFolderChanges(t *testing.T) {
-	orgID := rand.Int63()
+	orgID := rand.Int63n(30)
 	folder := &models2.Folder{
 		Id:    0,
 		Uid:   util.GenerateShortUID(),

--- a/pkg/services/ngalert/store/alert_rule_test.go
+++ b/pkg/services/ngalert/store/alert_rule_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/grafana/grafana/pkg/util"
 )
 
-func TestUpdateAlertRules(t *testing.T) {
+func TestIntegrationUpdateAlertRules(t *testing.T) {
 	sqlStore := sqlstore.InitTestDB(t)
 	store := DBstore{
 		SQLStore: sqlStore,
@@ -25,7 +25,6 @@ func TestUpdateAlertRules(t *testing.T) {
 		},
 	}
 	createRule := func(t *testing.T) *models.AlertRule {
-		t.Helper()
 		rule := models.AlertRuleGen(withIntervalMatching(store.Cfg.BaseInterval))()
 		err := sqlStore.WithDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
 			_, err := sess.Table(models.AlertRule{}).InsertOne(rule)

--- a/pkg/services/ngalert/store/provisioning_store_test.go
+++ b/pkg/services/ngalert/store/provisioning_store_test.go
@@ -14,7 +14,7 @@ import (
 
 const testAlertingIntervalSeconds = 10
 
-func TestProvisioningStore(t *testing.T) {
+func TestIntegrationProvisioningStore(t *testing.T) {
 	store := createProvisioningStoreSut(tests.SetupTestEnv(t, testAlertingIntervalSeconds))
 
 	t.Run("Default provenance of a known type is None", func(t *testing.T) {


### PR DESCRIPTION
Previously, two tests were not explicitly marked as integration tests and so were not run against all 3 supported databases in the CI environment.

(cherry picked from commit 7312a2dab0c9fad6faee29bb6133a0485df11b4b)
