### PR TITLE
Docs: Fix caching.memcached setting name

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/enterprise-configuration.md
+++ b/docs/sources/setup-grafana/configure-grafana/enterprise-configuration.md
@@ -474,7 +474,7 @@ The default is `"grafana"`.
 
 ## [caching.memcached]
 
-### memcached_servers
+### servers
 
 A space-separated list of memcached servers. Example: `memcached-server-1:11211 memcached-server-2:11212 memcached-server-3:11211`. Or if there's only one server: `memcached-server:11211`.
 


### PR DESCRIPTION
**What this PR does / why we need it**:

It updates the Enterprise documentation to fix a setting name that was wrong within the `caching.memcached` section.

**Which issue(s) this PR fixes**:

Related with https://github.com/grafana/grafana-enterprise/pull/3958

Contributes to https://github.com/grafana/grafana-enterprise/issues/3949

**Special notes for your reviewer**:

Note that I've added the `add-to-changelog` label in the Enterprise pull request because it's related with an Enterprise feature, but feel free to add it here as well.

Thanks!
