### PR TITLE
Loki: Fix label-value escaping in context query

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -49,7 +49,7 @@ import LanguageProvider from './LanguageProvider';
 import { LiveStreams, LokiLiveTarget } from './LiveStreams';
 import { transformBackendResult } from './backendResultTransformer';
 import { LokiAnnotationsQueryEditor } from './components/AnnotationsQueryEditor';
-import { escapeLabelValueInSelector, isRegexSelector } from './languageUtils';
+import { escapeLabelValueInExactSelector, escapeLabelValueInSelector, isRegexSelector } from './languageUtils';
 import { labelNamesRegex, labelValuesRegex } from './migrations/variableQueryMigrations';
 import {
   addLabelFormatToQuery,
@@ -581,7 +581,7 @@ export class LokiDatasource
       .map((label: string) => {
         if (labels.includes(label)) {
           // escape backslashes in label as users can't escape them by themselves
-          return `${label}="${row.labels[label].replace(/\\/g, '\\\\')}"`;
+          return `${label}="${escapeLabelValueInExactSelector(row.labels[label])}"`;
         }
         return '';
       })


### PR DESCRIPTION
**What this PR does / why we need it**:
Label values main contain special characters which need to be escaped. Current queries are only escaping `/` but also need to escape further characters. This PR uses a convenience method to escape the known special characters.

**Special notes for your reviewer**:

1. Can be tested with the current loki devenv
