### PR TITLE
Legacy Alerting: Fix duration calculation when testing a rule

### DIFF
--- a/pkg/services/alerting/eval_context.go
+++ b/pkg/services/alerting/eval_context.go
@@ -107,7 +107,7 @@ func (c *EvalContext) shouldUpdateAlertState() bool {
 
 // GetDurationMs returns the duration of the alert evaluation.
 func (c *EvalContext) GetDurationMs() float64 {
-	return float64(c.EndTime.Nanosecond()-c.StartTime.Nanosecond()) / float64(1000000)
+	return float64(c.EndTime.Sub(c.StartTime).Nanoseconds()) / float64(time.Millisecond)
 }
 
 // GetNotificationTitle returns the title of the alert rule including alert state.

--- a/pkg/services/alerting/eval_context_test.go
+++ b/pkg/services/alerting/eval_context_test.go
@@ -404,3 +404,18 @@ func TestEvaluateNotificationTemplateFields(t *testing.T) {
 		})
 	}
 }
+
+func TestGetDurationFromEvalContext(t *testing.T) {
+	startTime, err := time.Parse("2006-01-02 15:04:05.999999999 -0700 MST", "2022-10-03 11:33:14.438803 +0200 CEST")
+	require.NoError(t, err)
+
+	endTime, err := time.Parse("2006-01-02 15:04:05.999999999 -0700 MST", "2022-10-03 11:33:15.291075 +0200 CEST")
+	require.NoError(t, err)
+
+	evalContext := EvalContext{
+		StartTime: startTime,
+		EndTime:   endTime,
+	}
+
+	assert.Equal(t, float64(852.272), evalContext.GetDurationMs())
+}


### PR DESCRIPTION
Not sure what is the current status of the code for the Legacy Alerting, but we are still using it in one of our instances mostly for simpler alerts created by users for which the new alerting configuration can be a bit more daunting. If the code is frozen (or similar) feel free to close the PR.

**What this PR does / why we need it**:

We ran into this issue while trying to optimize some Elasticsearch queries used for alerting. 

When testing a rule within the legacy alerting the `timeMs` field could sometimes show negative (and/or wrongly calculated) durations. The previous implementation was relying only on the nanoseconds component of the start/end times.

For instance: In our case it was common to see something like:
![image](https://user-images.githubusercontent.com/1291846/194835744-0c61a40e-9da2-4aa2-89db-fcfa2c14b181.png)

**Special notes for your reviewer**:

A small unit test for the `GetDurationMs()` method was also added.