### PR TITLE
RBAC: Make uid for managed role names deterministic during migrations

### DIFF
--- a/pkg/services/sqlstore/migrations/accesscontrol/managed_permission_migrator.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/managed_permission_migrator.go
@@ -106,7 +106,7 @@ func (sp *managedPermissionMigrator) Exec(sess *xorm.Session, mg *migrator.Migra
 			}
 
 			if !ok {
-				uid, err := generateManagedRoleUID(orgID, managedRole)
+				uid, err := GenerateManagedRoleUID(orgID, managedRole)
 				if err != nil {
 					return err
 				}

--- a/pkg/services/sqlstore/migrations/accesscontrol/managed_permission_migrator.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/managed_permission_migrator.go
@@ -106,7 +106,7 @@ func (sp *managedPermissionMigrator) Exec(sess *xorm.Session, mg *migrator.Migra
 			}
 
 			if !ok {
-				uid, err := generateNewRoleUID(sess, orgID)
+				uid, err := generateManagedRoleUID(orgID, managedRole)
 				if err != nil {
 					return err
 				}

--- a/pkg/services/sqlstore/migrations/accesscontrol/permission_migrator.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/permission_migrator.go
@@ -1,6 +1,7 @@
 package accesscontrol
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -10,7 +11,6 @@ import (
 
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
-	"github.com/grafana/grafana/pkg/util"
 )
 
 var (
@@ -137,11 +137,10 @@ func (m *permissionMigrator) createRoles(roles []*accesscontrol.Role) ([]*access
 	args := make([]interface{}, 0, len(roles)*5)
 
 	for i, r := range roles {
-		uid, err := generateNewRoleUID(m.sess, r.OrgID)
+		uid, err := generateManagedRoleUID(r.OrgID, r.Name)
 		if err != nil {
 			return nil, err
 		}
-
 		valueStrings[i] = "(?, ?, ?, 1, ?, ?)"
 		args = append(args, r.OrgID, uid, r.Name, ts, ts)
 	}
@@ -165,11 +164,10 @@ func (m *permissionMigrator) createRolesMySQL(roles []*accesscontrol.Role) ([]*a
 	args := make([]interface{}, 0, len(roles)*2)
 
 	for i := range roles {
-		uid, err := generateNewRoleUID(m.sess, roles[i].OrgID)
+		uid, err := generateManagedRoleUID(roles[i].OrgID, roles[i].Name)
 		if err != nil {
 			return nil, err
 		}
-
 		roles[i].UID = uid
 		roles[i].Created = ts
 		roles[i].Updated = ts
@@ -210,19 +208,10 @@ func batch(count, batchSize int, eachFn func(start, end int) error) error {
 	return nil
 }
 
-func generateNewRoleUID(sess *xorm.Session, orgID int64) (string, error) {
-	for i := 0; i < 3; i++ {
-		uid := util.GenerateShortUID()
-
-		exists, err := sess.Where("org_id=? AND uid=?", orgID, uid).Get(&accesscontrol.Role{})
-		if err != nil {
-			return "", err
-		}
-
-		if !exists {
-			return uid, nil
-		}
+func generateManagedRoleUID(orgID int64, name string) (string, error) {
+	parts := strings.Split(name, ":")
+	if len(parts) != 4 {
+		return "", errors.New(fmt.Sprintf("unexpected role name: %s", name))
 	}
-
-	return "", fmt.Errorf("failed to generate uid")
+	return fmt.Sprintf("managed_%d_%s_%s", orgID, parts[1], parts[2]), nil
 }

--- a/pkg/services/sqlstore/migrations/accesscontrol/permission_migrator.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/permission_migrator.go
@@ -207,6 +207,7 @@ func batch(count, batchSize int, eachFn func(start, end int) error) error {
 	return nil
 }
 
+// generateManagedRoleUID generated a deterministic uid of the form `managed_{org_id}_{type}_{id}`.
 func generateManagedRoleUID(orgID int64, name string) (string, error) {
 	parts := strings.Split(name, ":")
 	if len(parts) != 4 {

--- a/pkg/services/sqlstore/migrations/accesscontrol/permission_migrator.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/permission_migrator.go
@@ -1,7 +1,6 @@
 package accesscontrol
 
 import (
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -211,7 +210,7 @@ func batch(count, batchSize int, eachFn func(start, end int) error) error {
 func generateManagedRoleUID(orgID int64, name string) (string, error) {
 	parts := strings.Split(name, ":")
 	if len(parts) != 4 {
-		return "", errors.New(fmt.Sprintf("unexpected role name: %s", name))
+		return "", fmt.Errorf("unexpected role name: %s", name)
 	}
 	return fmt.Sprintf("managed_%d_%s_%s", orgID, parts[1], parts[2]), nil
 }

--- a/pkg/services/sqlstore/migrations/accesscontrol/permission_migrator.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/permission_migrator.go
@@ -136,7 +136,7 @@ func (m *permissionMigrator) createRoles(roles []*accesscontrol.Role) ([]*access
 	args := make([]interface{}, 0, len(roles)*5)
 
 	for i, r := range roles {
-		uid, err := generateManagedRoleUID(r.OrgID, r.Name)
+		uid, err := GenerateManagedRoleUID(r.OrgID, r.Name)
 		if err != nil {
 			return nil, err
 		}
@@ -163,7 +163,7 @@ func (m *permissionMigrator) createRolesMySQL(roles []*accesscontrol.Role) ([]*a
 	args := make([]interface{}, 0, len(roles)*2)
 
 	for i := range roles {
-		uid, err := generateManagedRoleUID(roles[i].OrgID, roles[i].Name)
+		uid, err := GenerateManagedRoleUID(roles[i].OrgID, roles[i].Name)
 		if err != nil {
 			return nil, err
 		}
@@ -207,8 +207,8 @@ func batch(count, batchSize int, eachFn func(start, end int) error) error {
 	return nil
 }
 
-// generateManagedRoleUID generated a deterministic uid of the form `managed_{org_id}_{type}_{id}`.
-func generateManagedRoleUID(orgID int64, name string) (string, error) {
+// GenerateManagedRoleUID generated a deterministic uid of the form `managed_{org_id}_{type}_{id}`.
+func GenerateManagedRoleUID(orgID int64, name string) (string, error) {
 	parts := strings.Split(name, ":")
 	if len(parts) != 4 {
 		return "", fmt.Errorf("unexpected role name: %s", name)


### PR DESCRIPTION
**What this PR does / why we need it**:
When running rbac permission migrations the uid generated can cause collisions in two ways:

1. There can be collisions with several orgs, the uid unique constraint is only on the uid and not both org id and uid
2. When batching new roles there can be collisions between new uids

To fix this the easiest way is to have a determenistic uid for managed roles that would be `managed_{org_id}_{orgrole/users/teams}_{resource_id}`

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/grafana-enterprise/issues/3961

**Special notes for your reviewer**: