### PR TITLE
Docs: removes duplicate sentence in silences

### DIFF
--- a/docs/sources/alerting/silences/_index.md
+++ b/docs/sources/alerting/silences/_index.md
@@ -16,8 +16,6 @@ weight: 450
 
 Use silences to stop notifications from one or more alerting rules. Silences do not prevent alert rules from being evaluated. Nor do they not stop alerting instances from being shown in the user interface. Silences only stop notifications from getting created. A silence lasts for only a specified window of time.
 
-Silences do not prevent alert rules from being evaluated. They also do not stop alert instances from being shown in the user interface. Silences only prevent notifications from being created.
-
 You can configure Grafana managed silences as well as silences for an [external Alertmanager data source]({{< relref "../../datasources/alertmanager/" >}}). For more information, see [Alertmanager]({{< relref "../fundamentals/alertmanager/" >}}).
 
 See also:


### PR DESCRIPTION
The first two paragraphs in this page said the same thing. 