### PR TITLE
Docs: adds external Alertmanager config

### DIFF
--- a/docs/sources/alerting/fundamentals/alertmanager.md
+++ b/docs/sources/alerting/fundamentals/alertmanager.md
@@ -35,4 +35,8 @@ Here are two examples of when you may want to configure your own external alertm
 
 Alertmanagers are visible from the drop-down menu on the Alerting Contact Points, Notification Policies, and Silences pages.
 
-For more information on Alertmanager, refer to [Prometheus Alertmanager documentation](https://prometheus.io/docs/alerting/latest/alertmanager/).
+**Useful links**
+
+[Prometheus Alertmanager documentation](https://prometheus.io/docs/alerting/latest/alertmanager/).
+
+[Add an external Alertmanager](https://grafana.com/docs/grafana/latest/alerting/set-up/configure-alertmanager/)

--- a/docs/sources/alerting/set-up/configure-alertmanager/index.md
+++ b/docs/sources/alerting/set-up/configure-alertmanager/index.md
@@ -17,10 +17,10 @@ weight: 100
 
 Set up Grafana to use an external Alertmanager as a single Alertmanager to receive all of your alerts. This external Alertmanager can then be configured and administered from within Grafana itself.
 
-Once you have added the Alertmanager, you can use the Grafana Alerting UI to manage silences, contact points as well as notification policies. A drop-down option in these pages allows you to switch between alertmanagers.
+Once you have added the Alertmanager, you can use the Grafana Alerting UI to manage silences, contact points, and notification policies. A drop-down option in these pages allows you to switch between alertmanagers.
 
 **Note:**
-Starting with release 9.2, the URL configuration of external alertmanagers from the Admin tab on the Alerting page is deprecated. It will be removed in a future release.
+Starting with Grafana 9.2, the URL configuration of external alertmanagers from the Admin tab on the Alerting page is deprecated. It will be removed in a future release.
 
 External alertmanagers should now be configured as data sources using Grafana Configuration from the main Grafana navigation menu. This enables you to manage the contact points and notification policies of external alertmanagers from within Grafana and also encrypts HTTP basic authentication credentials that were previously visible when configuring external alertmanagers by URL.
 

--- a/docs/sources/alerting/set-up/configure-alertmanager/index.md
+++ b/docs/sources/alerting/set-up/configure-alertmanager/index.md
@@ -8,29 +8,29 @@ keywords:
   - alerting
   - set up
   - configure
-  - Alertmanager
-title: Configure Alertmanager
+  - external Alertmanager
+title: Add an external Alertmanager
 weight: 100
 ---
 
-# Configure Alertmanager
+# Add an external Alertmanager
 
-Configure Alertmanager from Grafana Alerting to group and manage alert rules, adding a layer of orchestration on top of your external alerting engine.
+Set up Grafana to use an external Alertmanager as a single Alertmanager to receive all of your alerts. This external Alertmanager can then be configured and administered from within Grafana itself.
 
-## Add a new external Alertmanager
+Once you have added the Alertmanager, you can use the Grafana Alerting UI to manage silences, contact points as well as notification policies. A drop-down option in these pages allows you to switch between alertmanagers.
 
-1. In the Grafana menu, click the Alerting (bell) icon to open the Alerting page listing existing alerts.
-2. Click **Admin** and then scroll down to the External Alertmanager section.
-3. Click **Add Alertmanager** and a modal opens.
-4. Add the URL and the port for the external Alertmanager. You do not need to specify the path suffix, for example, `/api/v(1|2)/alerts`. Grafana automatically adds this.
+**Note:**
+Starting with release 9.2, the URL configuration of external alertmanagers from the Admin tab on the Alerting page is deprecated. It will be removed in a future release.
 
-The external URL is listed in the table with a pending status. Once Grafana verifies that the Alertmanager is discovered, the status changes to active. No requests are made to the external Alertmanager at this point; the verification signals that alerts are ready to be sent.
+External alertmanagers should now be configured as data sources using Grafana Configuration from the main Grafana navigation menu. This enables you to manage the contact points and notification policies of external alertmanagers from within Grafana and also encrypts HTTP basic authentication credentials that were previously visible when configuring external alertmanagers by URL.
 
-### Edit an external Alertmanager
+To add an external Alertmanager, complete the following steps.
 
-1. Click the pen symbol to the right of the Alertmanager row in the table.
-2. When the edit modal opens, you can view all the URLs that were added.
+1. Click Configuration and then Data sources.
+1. Search for Alertmanager.
+1. Choose your Implementation and fill out the fields on the page, as required.
 
-The edited URL will be pending until Grafana verifies it again.
+**Note:**
+Prometheus, Grafana Mimir, and Cortex implementations of Alertmanager are supported. For Prometheus, contact points and notification policies are read-only in the Grafana Alerting UI.
 
-{{< figure max-width="40%" src="/static/img/docs/alerting/unified/ext-alertmanager-active.png" max-width="650px" caption="External Alertmanagers" >}}
+1. Click Save & test.


### PR DESCRIPTION
Updates the steps for adding an external Alertmanager per v9.2. 
Adds a deprecation note for the URL configuration.