### PR TITLE
TraceView: Fix broken rendering when scrolling in Dashboard panel in Firefox

### DIFF
--- a/packages/jaeger-ui-components/src/TraceTimelineViewer/ListView/index.tsx
+++ b/packages/jaeger-ui-components/src/TraceTimelineViewer/ListView/index.tsx
@@ -215,7 +215,7 @@ export default class ListView extends React.Component<TListViewProps> {
     }
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(prevProps: TListViewProps) {
     if (this._itemHolderElm) {
       this._scanItemHeights();
     }

--- a/packages/jaeger-ui-components/src/TraceTimelineViewer/ListView/index.tsx
+++ b/packages/jaeger-ui-components/src/TraceTimelineViewer/ListView/index.tsx
@@ -219,6 +219,16 @@ export default class ListView extends React.Component<TListViewProps> {
     if (this._itemHolderElm) {
       this._scanItemHeights();
     }
+    // When windowScroller is set to false, we can continue to handle scrollElement
+    if (this.props.windowScroller) {
+      return;
+    }
+    // check if the scrollElement changes and update its scroll listener
+    if (prevProps.scrollElement !== this.props.scrollElement) {
+      prevProps.scrollElement?.removeEventListener('scroll', this._onScroll);
+      this._wrapperElm = this.props.scrollElement;
+      this._wrapperElm?.addEventListener('scroll', this._onScroll);
+    }
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Because the value of scrollElement is undefined, the trace viewer displays 100 spans when scrolling
In order to solve this issues, we obtains asynchronously the correct value of the scrollElement in the component mount phase.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #54949

**Special notes for your reviewer**:
After executing the callback of setScrollRef in the ancestor component, we can correctly obtain the new value of scrollElement

@mellieA  @aocenas I really appreciate your attention and review code in previous PR which is #55708 . I wish someone can check the code for me as soon as possible