### PR TITLE
Graphite: Fix Meta Data tab condition when not data

### DIFF
--- a/public/app/plugins/datasource/graphite/components/MetricTankMetaInspector.tsx
+++ b/public/app/plugins/datasource/graphite/components/MetricTankMetaInspector.tsx
@@ -96,7 +96,7 @@ export class MetricTankMetaInspector extends PureComponent<Props, State> {
     const seriesMetas: Record<string, MetricTankSeriesMeta> = {};
 
     for (const series of data) {
-      if (series.meta && series.meta.custom) {
+      if (series?.meta?.custom?.seriesMetaList) {
         for (const metaItem of series.meta.custom.seriesMetaList as MetricTankSeriesMeta[]) {
           // key is to dedupe as many series will have identitical meta
           const key = `${JSON.stringify(metaItem)}`;


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR improves metadata checks to avoid throwing UI rendering errors when there are no data available to build the series meta array.

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/observability-metrics-squad/issues/4

**Special notes for your reviewer**:

Before this change:
<img width="65%" alt="Screen Shot 2022-10-10 at 10 41 40" src="https://user-images.githubusercontent.com/1680157/194880349-b4325435-67f3-4096-a787-6f539e601e55.png">

After this change:
<img width="65%" alt="Screen Shot 2022-10-10 at 10 41 21" src="https://user-images.githubusercontent.com/1680157/194880374-a9de75df-e9a7-4666-bed4-91e69f154bc5.png">

