### PR TITLE
Alerting: Add relativeTimeRange from dataSource when using Resample expresions

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
@@ -29,6 +29,7 @@ import {
   updateExpression,
   updateExpressionRefId,
   updateExpressionType,
+  updateExpressionTimeRange,
 } from './reducer';
 
 interface Props {
@@ -118,7 +119,7 @@ export const QueryAndExpressionsStep: FC<Props> = ({ editingExistingRule }) => {
   const onChangeQueries = useCallback(
     (updatedQueries: AlertQuery[]) => {
       dispatch(setDataQueries(updatedQueries));
-
+      dispatch(updateExpressionTimeRange());
       // check if we need to rewire expressions
       updatedQueries.forEach((query, index) => {
         const oldRefId = queries[index].refId;

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/__snapshots__/reducer.test.tsx.snap
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/__snapshots__/reducer.test.tsx.snap
@@ -270,6 +270,10 @@ Object {
       },
       "queryType": "",
       "refId": "B",
+      "relativeTimeRange": Object {
+        "from": 600,
+        "to": 0,
+      },
     },
   ],
 }

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/__snapshots__/reducer.test.tsx.snap
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/__snapshots__/reducer.test.tsx.snap
@@ -270,10 +270,6 @@ Object {
       },
       "queryType": "",
       "refId": "B",
-      "relativeTimeRange": Object {
-        "from": 600,
-        "to": 0,
-      },
     },
   ],
 }

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/reducer.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/reducer.test.tsx
@@ -19,6 +19,7 @@ import {
   setDataQueries,
   updateExpression,
   updateExpressionRefId,
+  updateExpressionTimeRange,
   updateExpressionType,
 } from './reducer';
 
@@ -146,16 +147,31 @@ describe('Query and expressions reducer', () => {
     const newState = queriesAndExpressionsReducer(initialState, updateExpression(newExpression));
     expect(newState).toMatchSnapshot();
   });
-  it('Should update time range for all expressions that have this data source when dispatching updateExpressionTimeRange', () => {
+  it('should use time range from data source when updating an expression', () => {
     const expressionQuery: AlertQuery = {
       refId: 'B',
+      queryType: 'expression',
+      datasourceUid: '-100',
+      relativeTimeRange: { from: 900, to: 1000 },
+      model: {
+        queryType: 'query',
+        datasource: '__expr__',
+        refId: 'B',
+        expression: 'C',
+        type: ExpressionQueryType.classic,
+        window: '10s',
+      } as ExpressionQuery,
+    };
+
+    const expressionQuery2: AlertQuery = {
+      refId: 'C',
       queryType: 'expression',
       datasourceUid: '-100',
       relativeTimeRange: { from: 1, to: 3 },
       model: {
         queryType: 'query',
         datasource: '__expr__',
-        refId: 'B',
+        refId: 'C',
         expression: 'A',
         type: ExpressionQueryType.classic,
         window: '10s',
@@ -170,12 +186,12 @@ describe('Query and expressions reducer', () => {
       queryType: 'query',
     };
     const newExpression: ExpressionQuery = {
-      ...expressionQuery.model,
+      ...expressionQuery2.model,
       type: ExpressionQueryType.resample,
     };
 
     const initialState: QueriesAndExpressionsState = {
-      queries: [queryA, expressionQuery],
+      queries: [queryA, expressionQuery, expressionQuery2],
     };
 
     const newState = queriesAndExpressionsReducer(initialState, updateExpression(newExpression));
@@ -193,20 +209,34 @@ describe('Query and expressions reducer', () => {
           relativeTimeRange: { from: 900, to: 1000 },
           model: {
             datasource: '__expr__',
-            expression: 'A',
+            expression: 'C',
             queryType: 'query',
             refId: 'B',
-            type: 'resample',
+            type: 'classic_conditions',
             window: '10s',
           },
           queryType: 'expression',
           refId: 'B',
         },
+        {
+          datasourceUid: '-100',
+          relativeTimeRange: { from: 900, to: 1000 },
+          model: {
+            datasource: '__expr__',
+            expression: 'A',
+            queryType: 'query',
+            refId: 'C',
+            type: 'resample',
+            window: '10s',
+          },
+          queryType: 'expression',
+          refId: 'C',
+        },
       ],
     });
   });
 
-  it('should use time range from data source when updating an expression', () => {
+  it('Should update time range for all expressions that have this data source when dispatching updateExpressionTimeRange', () => {
     const expressionQuery: AlertQuery = {
       refId: 'B',
       queryType: 'expression',
@@ -229,16 +259,12 @@ describe('Query and expressions reducer', () => {
       model: { refId: 'A' },
       queryType: 'query',
     };
-    const newExpression: ExpressionQuery = {
-      ...expressionQuery.model,
-      type: ExpressionQueryType.resample,
-    };
 
     const initialState: QueriesAndExpressionsState = {
       queries: [queryA, expressionQuery],
     };
 
-    const newState = queriesAndExpressionsReducer(initialState, updateExpression(newExpression));
+    const newState = queriesAndExpressionsReducer(initialState, updateExpressionTimeRange());
     expect(newState).toStrictEqual({
       queries: [
         {
@@ -255,7 +281,7 @@ describe('Query and expressions reducer', () => {
             expression: 'A',
             queryType: 'query',
             refId: 'B',
-            type: 'resample',
+            type: ExpressionQueryType.classic,
             window: '10s',
           },
           queryType: 'expression',

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/reducer.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/reducer.test.tsx
@@ -146,6 +146,66 @@ describe('Query and expressions reducer', () => {
     const newState = queriesAndExpressionsReducer(initialState, updateExpression(newExpression));
     expect(newState).toMatchSnapshot();
   });
+  it('Should update time range for all expressions that have this data source when dispatching updateExpressionTimeRange', () => {
+    const expressionQuery: AlertQuery = {
+      refId: 'B',
+      queryType: 'expression',
+      datasourceUid: '-100',
+      relativeTimeRange: { from: 1, to: 3 },
+      model: {
+        queryType: 'query',
+        datasource: '__expr__',
+        refId: 'B',
+        expression: 'A',
+        type: ExpressionQueryType.classic,
+        window: '10s',
+      } as ExpressionQuery,
+    };
+
+    const queryA: AlertQuery = {
+      refId: 'A',
+      relativeTimeRange: { from: 900, to: 1000 },
+      datasourceUid: 'dsuid',
+      model: { refId: 'A' },
+      queryType: 'query',
+    };
+    const newExpression: ExpressionQuery = {
+      ...expressionQuery.model,
+      type: ExpressionQueryType.resample,
+    };
+
+    const initialState: QueriesAndExpressionsState = {
+      queries: [queryA, expressionQuery],
+    };
+
+    const newState = queriesAndExpressionsReducer(initialState, updateExpression(newExpression));
+    expect(newState).toStrictEqual({
+      queries: [
+        {
+          refId: 'A',
+          relativeTimeRange: { from: 900, to: 1000 },
+          datasourceUid: 'dsuid',
+          model: { refId: 'A' },
+          queryType: 'query',
+        },
+        {
+          datasourceUid: '-100',
+          relativeTimeRange: { from: 900, to: 1000 },
+          model: {
+            datasource: '__expr__',
+            expression: 'A',
+            queryType: 'query',
+            refId: 'B',
+            type: 'resample',
+            window: '10s',
+          },
+          queryType: 'expression',
+          refId: 'B',
+        },
+      ],
+    });
+  });
+
   it('should use time range from data source when updating an expression', () => {
     const expressionQuery: AlertQuery = {
       refId: 'B',

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/reducer.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/reducer.ts
@@ -78,10 +78,13 @@ export const queriesAndExpressionsReducer = createReducer(initialState, (builder
     })
     .addCase(updateExpression, (state, { payload }) => {
       state.queries = state.queries.map((query) => {
+        const dataSource = state.queries.find((alertQuery) => alertQuery.refId === payload.expression);
+        const relativeTimeRange = dataSource ? dataSource.relativeTimeRange : getDefaultRelativeTimeRange();
         return query.refId === payload.refId
           ? {
               ...query,
               model: payload,
+              relativeTimeRange: relativeTimeRange,
             }
           : query;
       });
@@ -138,7 +141,6 @@ const addQuery = (
   queryToAdd: Pick<AlertQuery, 'model' | 'datasourceUid' | 'relativeTimeRange'>
 ): AlertQuery[] => {
   const refId = getNextRefIdChar(queries);
-
   const query: AlertQuery = {
     ...queryToAdd,
     refId,

--- a/public/app/features/alerting/utils/dataSourceFromExpression.ts
+++ b/public/app/features/alerting/utils/dataSourceFromExpression.ts
@@ -1,0 +1,34 @@
+import { ExpressionDatasourceUID } from 'app/features/expressions/ExpressionDatasource';
+import { AlertQuery } from 'app/types/unified-alerting-dto';
+
+export const hasCyclicalReferences = (queries: AlertQuery[]) => {
+  try {
+    JSON.stringify(queries);
+    return false;
+  } catch (e) {
+    return true;
+  }
+};
+
+export const findDataSourceFromExpressionRecursive = (
+  queries: AlertQuery[],
+  alertQuery: AlertQuery
+): AlertQuery | null | undefined => {
+  //Check if this is not cyclical structre
+  if (hasCyclicalReferences(queries)) {
+    return null;
+  }
+  // We have the data source in this dataQuery
+  if (alertQuery.datasourceUid !== ExpressionDatasourceUID) {
+    return alertQuery;
+  }
+  // alertQuery it's an expression, we have to traverse all the tree up to the data source
+  else {
+    const alertQueryReferenced = queries.find((alertQuery_) => alertQuery_.refId === alertQuery.model.expression);
+    if (alertQueryReferenced) {
+      return findDataSourceFromExpressionRecursive(queries, alertQueryReferenced);
+    } else {
+      return null;
+    }
+  }
+};


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds `relativetimeRange` in the `eval` request when using a `Resample` expresion.



