### PR TITLE
LabelFilters: Remove redundant css styling

### DIFF
--- a/public/app/plugins/datasource/prometheus/querybuilder/shared/LabelFilterItem.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/shared/LabelFilterItem.tsx
@@ -58,16 +58,6 @@ export function LabelFilterItem({
     return uniqBy([...selectedOptions, ...labelValues], 'value');
   };
 
-  /**
-   * !important here is necessary to show invalid border on all 4 sides of select.
-   * Without it, the invalid state is only visible on 3 sides as the right side is overridden in InputGroup.
-   */
-  const invalidClassNameOverride = invalidLabel
-    ? css`
-        margin-left: 0 !important;
-      `
-    : '';
-
   return (
     <div data-testid="prometheus-dimensions-filter-item">
       <InputGroup>
@@ -107,7 +97,6 @@ export function LabelFilterItem({
               onChange({ ...item, op: change.value } as any as QueryBuilderLabelFilter);
             }
           }}
-          className={invalidClassNameOverride}
         />
 
         <Select

--- a/public/app/plugins/datasource/prometheus/querybuilder/shared/LabelFilterItem.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/shared/LabelFilterItem.tsx
@@ -1,4 +1,3 @@
-import { css } from '@emotion/css';
 import { uniqBy } from 'lodash';
 import React, { useState } from 'react';
 


### PR DESCRIPTION
**What this PR does / why we need it**:

After proper fix for InputGroup was merged - https://github.com/grafana/grafana/pull/56169 - we don't need invalidClassNameOverride styling override anymore.

The styling looks correct with removed invalidClassNameOverride: 

<img width="823" alt="image" src="https://user-images.githubusercontent.com/30407135/194899523-dd1ec4b4-2c16-4512-bae6-3880012825f4.png">
