### PR TITLE
i18n: Fix unnecessary ampersand escaping

### DIFF
--- a/public/app/features/profile/UserSessions.tsx
+++ b/public/app/features/profile/UserSessions.tsx
@@ -39,7 +39,7 @@ class UserSessions extends PureComponent<Props> {
                       <Trans i18nKey="user-session.ip-column">IP address</Trans>
                     </th>
                     <th>
-                      <Trans i18nKey="user-session.browser-column">Browser &amp; OS</Trans>
+                      <Trans i18nKey="user-session.browser-column">Browser & OS</Trans>
                     </th>
                     <th></th>
                   </tr>

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -277,7 +277,7 @@
     "title": "Edit profile"
   },
   "user-session": {
-    "browser-column": "Browser &amp; OS",
+    "browser-column": "Browser & OS",
     "created-at-column": "Logged on",
     "ip-column": "IP address",
     "revoke": "Revoke user session",

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -277,7 +277,7 @@
     "title": "Ēđįŧ přőƒįľę"
   },
   "user-session": {
-    "browser-column": "ßřőŵşęř &ämp; ØŜ",
+    "browser-column": "ßřőŵşęř & ØŜ",
     "created-at-column": "Ŀőģģęđ őŉ",
     "ip-column": "ĨP äđđřęşş",
     "revoke": "Ŗęvőĸę ūşęř şęşşįőŉ",


### PR DESCRIPTION
**What this PR does / why we need it**:
The text "Browser & OS" was set as "Browser \&amp; OS" in the JSON, but I think manually escaping like that isn't necessary and resulted in the text being escaped twice.

Before:
<img width="596" alt="Screenshot 2022-10-10 at 16 16 45" src="https://user-images.githubusercontent.com/45561153/194900293-d7e208ae-bb2a-497a-915f-a7bf74af0f65.png">

After:
<img width="573" alt="Screenshot 2022-10-10 at 16 17 47" src="https://user-images.githubusercontent.com/45561153/194900309-3ffdc550-cf8a-4f0d-b0dc-8b108cf7fad9.png">

