### PR TITLE
CI: Split release test pipelines

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4233,7 +4233,7 @@ depends_on: []
 image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
-name: release-branch-test-frontend
+name: release-branch-oss-test-frontend
 node:
   type: no-parallel
 platform:
@@ -4296,7 +4296,7 @@ environment:
 image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
-name: release-branch-test-backend
+name: release-branch-oss-test-backend
 node:
   type: no-parallel
 platform:
@@ -4861,7 +4861,7 @@ depends_on: []
 image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
-name: release-branch-test-frontend
+name: release-branch-enterprise-test-frontend
 node:
   type: no-parallel
 platform:
@@ -4924,7 +4924,7 @@ environment:
 image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
-name: release-branch-test-backend
+name: release-branch-enterprise-test-backend
 node:
   type: no-parallel
 platform:
@@ -4987,7 +4987,7 @@ environment:
 image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
-name: release-branch-test-backend
+name: release-branch-enterprise2-test-backend
 node:
   type: no-parallel
 platform:
@@ -5494,6 +5494,6 @@ kind: secret
 name: packages_secret_access_key
 ---
 kind: signature
-hmac: 9ba807a4d05f8cdd13e763174e4fc91e8004df02d58cbcf8b36da5ffe11616ea
+hmac: 0a4cc4cfd81481dbb25b9ccfc22ddd4ad23bbaa1b775e5c64aba2533ccfe1676
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -178,6 +178,8 @@ volumes:
 clone:
   retries: 3
 depends_on: []
+environment:
+  EDITION: oss
 image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
@@ -1018,6 +1020,8 @@ volumes:
 clone:
   retries: 3
 depends_on: []
+environment:
+  EDITION: oss
 image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
@@ -1923,7 +1927,7 @@ clone:
   retries: 3
 depends_on: []
 environment:
-  EDITION: OSS
+  EDITION: oss
 image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
@@ -2232,12 +2236,10 @@ volumes:
 clone:
   retries: 3
 depends_on: []
-environment:
-  EDITION: OSS
 image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
-name: release-oss-test
+name: release-oss-test-frontend
 node:
   type: no-parallel
 platform:
@@ -2256,21 +2258,6 @@ steps:
   image: byrnedo/alpine-curl:0.1.8
   name: grabpl
 - commands:
-  - '# It is required that code generated from Thema/CUE be committed and in sync
-    with its inputs.'
-  - '# The following command will fail if running code generators produces any diff
-    in output.'
-  - CODEGEN_VERIFY=1 make gen-cue
-  depends_on: []
-  image: grafana/build-container:1.6.3
-  name: verify-gen-cue
-- commands:
-  - make gen-go
-  depends_on:
-  - verify-gen-cue
-  image: grafana/build-container:1.6.3
-  name: wire-install
-- commands:
   - yarn install --immutable
   depends_on:
   - grabpl
@@ -2284,37 +2271,12 @@ steps:
   image: golang:1.19.2
   name: compile-build-cmd
 - commands:
-  - apt-get update && apt-get install make
-  - make lint-go
-  depends_on:
-  - wire-install
-  environment:
-    CGO_ENABLED: "1"
-  image: golang:1.19.2
-  name: lint-backend
-- commands:
-  - yarn run prettier:check
-  - yarn run lint
-  - yarn run i18n:compile
-  - yarn run typecheck
+  - yarn betterer ci
   depends_on:
   - yarn-install
-  environment:
-    TEST_MAX_WORKERS: 50%
+  failure: ignore
   image: grafana/build-container:1.6.3
-  name: lint-frontend
-- commands:
-  - go test -short -covermode=atomic -timeout=5m ./pkg/...
-  depends_on:
-  - wire-install
-  image: grafana/build-container:1.6.3
-  name: test-backend
-- commands:
-  - go test -run Integration -covermode=atomic -timeout=5m ./pkg/...
-  depends_on:
-  - wire-install
-  image: grafana/build-container:1.6.3
-  name: test-backend-integration
+  name: betterer-frontend
 - commands:
   - yarn run ci:test-frontend
   depends_on:
@@ -2342,7 +2304,76 @@ clone:
   retries: 3
 depends_on: []
 environment:
-  EDITION: OSS
+  EDITION: oss
+image_pull_secrets:
+- dockerconfigjson
+kind: pipeline
+name: release-oss-test-backend
+node:
+  type: no-parallel
+platform:
+  arch: amd64
+  os: linux
+services: []
+steps:
+- commands:
+  - echo $DRONE_RUNNER_NAME
+  image: alpine:3.15.6
+  name: identify-runner
+- commands:
+  - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
+  depends_on: []
+  environment:
+    CGO_ENABLED: 0
+  image: golang:1.19.2
+  name: compile-build-cmd
+- commands:
+  - '# It is required that code generated from Thema/CUE be committed and in sync
+    with its inputs.'
+  - '# The following command will fail if running code generators produces any diff
+    in output.'
+  - CODEGEN_VERIFY=1 make gen-cue
+  depends_on: []
+  image: grafana/build-container:1.6.3
+  name: verify-gen-cue
+- commands:
+  - make gen-go
+  depends_on:
+  - verify-gen-cue
+  image: grafana/build-container:1.6.3
+  name: wire-install
+- commands:
+  - go test -short -covermode=atomic -timeout=5m ./pkg/...
+  depends_on:
+  - wire-install
+  image: grafana/build-container:1.6.3
+  name: test-backend
+- commands:
+  - go test -run Integration -covermode=atomic -timeout=5m ./pkg/...
+  depends_on:
+  - wire-install
+  image: grafana/build-container:1.6.3
+  name: test-backend-integration
+trigger:
+  event:
+    exclude:
+    - promote
+  ref:
+  - refs/tags/v*
+  repo:
+    exclude:
+    - grafana/grafana
+type: docker
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
+---
+clone:
+  retries: 3
+depends_on: []
+environment:
+  EDITION: oss
 image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
@@ -2459,7 +2490,7 @@ depends_on:
 - release-oss-test
 - release-oss-integration-tests
 environment:
-  EDITION: OSS
+  EDITION: oss
 image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
@@ -2522,7 +2553,7 @@ clone:
   disable: true
 depends_on: []
 environment:
-  EDITION: ENTERPRISE
+  EDITION: enterprise
 image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
@@ -2871,12 +2902,10 @@ volumes:
 clone:
   disable: true
 depends_on: []
-environment:
-  EDITION: ENTERPRISE
 image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
-name: release-enterprise-test
+name: release-enterprise-test-frontend
 node:
   type: no-parallel
 platform:
@@ -2885,102 +2914,35 @@ platform:
 services: []
 steps:
 - commands:
+  - echo $DRONE_RUNNER_NAME
+  image: alpine:3.15.6
+  name: identify-runner
+- commands:
   - mkdir -p bin
   - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v3.0.11/grabpl
   - chmod +x bin/grabpl
   image: byrnedo/alpine-curl:0.1.8
   name: grabpl
 - commands:
-  - echo $DRONE_RUNNER_NAME
-  image: alpine:3.15.6
-  name: identify-runner
-- commands:
-  - git clone "https://$${GITHUB_TOKEN}@github.com/grafana/grafana-enterprise.git"
-  - cd grafana-enterprise
-  - git checkout ${DRONE_TAG}
-  environment:
-    GITHUB_TOKEN:
-      from_secret: github_token
-  image: grafana/build-container:1.6.3
-  name: clone-enterprise
-- commands:
-  - mv bin/grabpl /tmp/
-  - rmdir bin
-  - mv grafana-enterprise /tmp/
-  - /tmp/grabpl init-enterprise --github-token $${GITHUB_TOKEN} /tmp/grafana-enterprise
-    ${DRONE_TAG}
-  - mv /tmp/grafana-enterprise/deployment_tools_config.json deployment_tools_config.json
-  - mkdir bin
-  - mv /tmp/grabpl bin/
+  - yarn install --immutable
   depends_on:
-  - clone-enterprise
-  environment:
-    GITHUB_TOKEN:
-      from_secret: github_token
+  - grabpl
   image: grafana/build-container:1.6.3
-  name: init-enterprise
+  name: yarn-install
 - commands:
   - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
-  depends_on:
-  - init-enterprise
+  depends_on: []
   environment:
     CGO_ENABLED: 0
   image: golang:1.19.2
   name: compile-build-cmd
 - commands:
-  - make gen-go
-  depends_on:
-  - init-enterprise
-  image: grafana/build-container:1.6.3
-  name: wire-install
-- commands:
-  - yarn install --immutable
-  depends_on:
-  - init-enterprise
-  image: grafana/build-container:1.6.3
-  name: yarn-install
-- commands:
-  - '# It is required that code generated from Thema/CUE be committed and in sync
-    with its inputs.'
-  - '# The following command will fail if running code generators produces any diff
-    in output.'
-  - CODEGEN_VERIFY=1 make gen-cue
-  depends_on:
-  - init-enterprise
-  image: grafana/build-container:1.6.3
-  name: verify-gen-cue
-- commands:
-  - apt-get update && apt-get install make
-  - make lint-go
-  depends_on:
-  - wire-install
-  environment:
-    CGO_ENABLED: "1"
-  image: golang:1.19.2
-  name: lint-backend
-- commands:
-  - yarn run prettier:check
-  - yarn run lint
-  - yarn run i18n:compile
-  - yarn run typecheck
+  - yarn betterer ci
   depends_on:
   - yarn-install
-  environment:
-    TEST_MAX_WORKERS: 50%
+  failure: ignore
   image: grafana/build-container:1.6.3
-  name: lint-frontend
-- commands:
-  - go test -short -covermode=atomic -timeout=5m ./pkg/...
-  depends_on:
-  - wire-install
-  image: grafana/build-container:1.6.3
-  name: test-backend
-- commands:
-  - go test -run Integration -covermode=atomic -timeout=5m ./pkg/...
-  depends_on:
-  - wire-install
-  image: grafana/build-container:1.6.3
-  name: test-backend-integration
+  name: betterer-frontend
 - commands:
   - yarn run ci:test-frontend
   depends_on:
@@ -2989,21 +2951,6 @@ steps:
     TEST_MAX_WORKERS: 50%
   image: grafana/build-container:1.6.3
   name: test-frontend
-- commands:
-  - apt-get update && apt-get install make
-  - make lint-go
-  depends_on:
-  - wire-install
-  environment:
-    CGO_ENABLED: "1"
-  image: golang:1.19.2
-  name: lint-backend-enterprise2
-- commands:
-  - go test -tags=pro -covermode=atomic -timeout=5m ./pkg/...
-  depends_on:
-  - wire-install
-  image: grafana/build-container:1.6.3
-  name: test-backend-enterprise2
 trigger:
   event:
     exclude:
@@ -3023,7 +2970,145 @@ clone:
   disable: true
 depends_on: []
 environment:
-  EDITION: ENTERPRISE
+  EDITION: enterprise
+image_pull_secrets:
+- dockerconfigjson
+kind: pipeline
+name: release-enterprise-test-backend
+node:
+  type: no-parallel
+platform:
+  arch: amd64
+  os: linux
+services: []
+steps:
+- commands:
+  - echo $DRONE_RUNNER_NAME
+  image: alpine:3.15.6
+  name: identify-runner
+- commands:
+  - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
+  depends_on: []
+  environment:
+    CGO_ENABLED: 0
+  image: golang:1.19.2
+  name: compile-build-cmd
+- commands:
+  - '# It is required that code generated from Thema/CUE be committed and in sync
+    with its inputs.'
+  - '# The following command will fail if running code generators produces any diff
+    in output.'
+  - CODEGEN_VERIFY=1 make gen-cue
+  depends_on: []
+  image: grafana/build-container:1.6.3
+  name: verify-gen-cue
+- commands:
+  - make gen-go
+  depends_on:
+  - verify-gen-cue
+  image: grafana/build-container:1.6.3
+  name: wire-install
+- commands:
+  - go test -short -covermode=atomic -timeout=5m ./pkg/...
+  depends_on:
+  - wire-install
+  image: grafana/build-container:1.6.3
+  name: test-backend
+- commands:
+  - go test -run Integration -covermode=atomic -timeout=5m ./pkg/...
+  depends_on:
+  - wire-install
+  image: grafana/build-container:1.6.3
+  name: test-backend-integration
+trigger:
+  event:
+    exclude:
+    - promote
+  ref:
+  - refs/tags/v*
+  repo:
+    exclude:
+    - grafana/grafana
+type: docker
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
+---
+clone:
+  disable: true
+depends_on: []
+environment:
+  EDITION: enterprise2
+image_pull_secrets:
+- dockerconfigjson
+kind: pipeline
+name: release-enterprise2-test-backend
+node:
+  type: no-parallel
+platform:
+  arch: amd64
+  os: linux
+services: []
+steps:
+- commands:
+  - echo $DRONE_RUNNER_NAME
+  image: alpine:3.15.6
+  name: identify-runner
+- commands:
+  - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
+  depends_on: []
+  environment:
+    CGO_ENABLED: 0
+  image: golang:1.19.2
+  name: compile-build-cmd
+- commands:
+  - '# It is required that code generated from Thema/CUE be committed and in sync
+    with its inputs.'
+  - '# The following command will fail if running code generators produces any diff
+    in output.'
+  - CODEGEN_VERIFY=1 make gen-cue
+  depends_on: []
+  image: grafana/build-container:1.6.3
+  name: verify-gen-cue
+- commands:
+  - make gen-go
+  depends_on:
+  - verify-gen-cue
+  image: grafana/build-container:1.6.3
+  name: wire-install
+- commands:
+  - go test -tags=pro -covermode=atomic -timeout=5m ./pkg/...
+  depends_on:
+  - wire-install
+  image: grafana/build-container:1.6.3
+  name: test-backend-enterprise2
+- commands:
+  - go test -run Integration -covermode=atomic -timeout=5m ./pkg/...
+  depends_on:
+  - wire-install
+  image: grafana/build-container:1.6.3
+  name: test-backend-integration
+trigger:
+  event:
+    exclude:
+    - promote
+  ref:
+  - refs/tags/v*
+  repo:
+    exclude:
+    - grafana/grafana
+type: docker
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
+---
+clone:
+  disable: true
+depends_on: []
+environment:
+  EDITION: enterprise
 image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
@@ -3190,7 +3275,7 @@ depends_on:
 - release-enterprise-test
 - release-enterprise-integration-tests
 environment:
-  EDITION: ENTERPRISE
+  EDITION: enterprise
 image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
@@ -3865,7 +3950,7 @@ clone:
   retries: 3
 depends_on: []
 environment:
-  EDITION: OSS
+  EDITION: oss
 image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
@@ -4143,12 +4228,10 @@ volumes:
 clone:
   retries: 3
 depends_on: []
-environment:
-  EDITION: OSS
 image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
-name: release-branch-oss-test
+name: release-branch-test-frontend
 node:
   type: no-parallel
 platform:
@@ -4167,21 +4250,6 @@ steps:
   image: byrnedo/alpine-curl:0.1.8
   name: grabpl
 - commands:
-  - '# It is required that code generated from Thema/CUE be committed and in sync
-    with its inputs.'
-  - '# The following command will fail if running code generators produces any diff
-    in output.'
-  - CODEGEN_VERIFY=1 make gen-cue
-  depends_on: []
-  image: grafana/build-container:1.6.3
-  name: verify-gen-cue
-- commands:
-  - make gen-go
-  depends_on:
-  - verify-gen-cue
-  image: grafana/build-container:1.6.3
-  name: wire-install
-- commands:
   - yarn install --immutable
   depends_on:
   - grabpl
@@ -4195,37 +4263,12 @@ steps:
   image: golang:1.19.2
   name: compile-build-cmd
 - commands:
-  - apt-get update && apt-get install make
-  - make lint-go
-  depends_on:
-  - wire-install
-  environment:
-    CGO_ENABLED: "1"
-  image: golang:1.19.2
-  name: lint-backend
-- commands:
-  - yarn run prettier:check
-  - yarn run lint
-  - yarn run i18n:compile
-  - yarn run typecheck
+  - yarn betterer ci
   depends_on:
   - yarn-install
-  environment:
-    TEST_MAX_WORKERS: 50%
+  failure: ignore
   image: grafana/build-container:1.6.3
-  name: lint-frontend
-- commands:
-  - go test -short -covermode=atomic -timeout=5m ./pkg/...
-  depends_on:
-  - wire-install
-  image: grafana/build-container:1.6.3
-  name: test-backend
-- commands:
-  - go test -run Integration -covermode=atomic -timeout=5m ./pkg/...
-  depends_on:
-  - wire-install
-  image: grafana/build-container:1.6.3
-  name: test-backend-integration
+  name: betterer-frontend
 - commands:
   - yarn run ci:test-frontend
   depends_on:
@@ -4247,7 +4290,70 @@ clone:
   retries: 3
 depends_on: []
 environment:
-  EDITION: OSS
+  EDITION: oss
+image_pull_secrets:
+- dockerconfigjson
+kind: pipeline
+name: release-branch-test-backend
+node:
+  type: no-parallel
+platform:
+  arch: amd64
+  os: linux
+services: []
+steps:
+- commands:
+  - echo $DRONE_RUNNER_NAME
+  image: alpine:3.15.6
+  name: identify-runner
+- commands:
+  - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
+  depends_on: []
+  environment:
+    CGO_ENABLED: 0
+  image: golang:1.19.2
+  name: compile-build-cmd
+- commands:
+  - '# It is required that code generated from Thema/CUE be committed and in sync
+    with its inputs.'
+  - '# The following command will fail if running code generators produces any diff
+    in output.'
+  - CODEGEN_VERIFY=1 make gen-cue
+  depends_on: []
+  image: grafana/build-container:1.6.3
+  name: verify-gen-cue
+- commands:
+  - make gen-go
+  depends_on:
+  - verify-gen-cue
+  image: grafana/build-container:1.6.3
+  name: wire-install
+- commands:
+  - go test -short -covermode=atomic -timeout=5m ./pkg/...
+  depends_on:
+  - wire-install
+  image: grafana/build-container:1.6.3
+  name: test-backend
+- commands:
+  - go test -run Integration -covermode=atomic -timeout=5m ./pkg/...
+  depends_on:
+  - wire-install
+  image: grafana/build-container:1.6.3
+  name: test-backend-integration
+trigger:
+  ref:
+  - refs/heads/v[0-9]*
+type: docker
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
+---
+clone:
+  retries: 3
+depends_on: []
+environment:
+  EDITION: oss
 image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
@@ -4358,7 +4464,7 @@ depends_on:
 - release-branch-oss-test
 - release-branch-oss-integration-tests
 environment:
-  EDITION: OSS
+  EDITION: oss
 image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
@@ -4411,7 +4517,7 @@ clone:
   disable: true
 depends_on: []
 environment:
-  EDITION: ENTERPRISE
+  EDITION: enterprise
 image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
@@ -4749,12 +4855,10 @@ volumes:
 clone:
   disable: true
 depends_on: []
-environment:
-  EDITION: ENTERPRISE
 image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
-name: release-branch-enterprise-test
+name: release-branch-test-frontend
 node:
   type: no-parallel
 platform:
@@ -4763,99 +4867,35 @@ platform:
 services: []
 steps:
 - commands:
+  - echo $DRONE_RUNNER_NAME
+  image: alpine:3.15.6
+  name: identify-runner
+- commands:
   - mkdir -p bin
   - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v3.0.11/grabpl
   - chmod +x bin/grabpl
   image: byrnedo/alpine-curl:0.1.8
   name: grabpl
 - commands:
-  - echo $DRONE_RUNNER_NAME
-  image: alpine:3.15.6
-  name: identify-runner
-- commands:
-  - git clone "https://$${GITHUB_TOKEN}@github.com/grafana/grafana-enterprise.git"
-  - cd grafana-enterprise
-  - git checkout ${DRONE_BRANCH}
-  environment:
-    GITHUB_TOKEN:
-      from_secret: github_token
-  image: grafana/build-container:1.6.3
-  name: clone-enterprise
-- commands:
-  - mv bin/grabpl /tmp/
-  - rmdir bin
-  - mv grafana-enterprise /tmp/
-  - /tmp/grabpl init-enterprise  /tmp/grafana-enterprise
-  - mv /tmp/grafana-enterprise/deployment_tools_config.json deployment_tools_config.json
-  - mkdir bin
-  - mv /tmp/grabpl bin/
+  - yarn install --immutable
   depends_on:
-  - clone-enterprise
-  environment: {}
+  - grabpl
   image: grafana/build-container:1.6.3
-  name: init-enterprise
+  name: yarn-install
 - commands:
   - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
-  depends_on:
-  - init-enterprise
+  depends_on: []
   environment:
     CGO_ENABLED: 0
   image: golang:1.19.2
   name: compile-build-cmd
 - commands:
-  - make gen-go
-  depends_on:
-  - init-enterprise
-  image: grafana/build-container:1.6.3
-  name: wire-install
-- commands:
-  - yarn install --immutable
-  depends_on:
-  - init-enterprise
-  image: grafana/build-container:1.6.3
-  name: yarn-install
-- commands:
-  - '# It is required that code generated from Thema/CUE be committed and in sync
-    with its inputs.'
-  - '# The following command will fail if running code generators produces any diff
-    in output.'
-  - CODEGEN_VERIFY=1 make gen-cue
-  depends_on:
-  - init-enterprise
-  image: grafana/build-container:1.6.3
-  name: verify-gen-cue
-- commands:
-  - apt-get update && apt-get install make
-  - make lint-go
-  depends_on:
-  - wire-install
-  environment:
-    CGO_ENABLED: "1"
-  image: golang:1.19.2
-  name: lint-backend
-- commands:
-  - yarn run prettier:check
-  - yarn run lint
-  - yarn run i18n:compile
-  - yarn run typecheck
+  - yarn betterer ci
   depends_on:
   - yarn-install
-  environment:
-    TEST_MAX_WORKERS: 50%
+  failure: ignore
   image: grafana/build-container:1.6.3
-  name: lint-frontend
-- commands:
-  - go test -short -covermode=atomic -timeout=5m ./pkg/...
-  depends_on:
-  - wire-install
-  image: grafana/build-container:1.6.3
-  name: test-backend
-- commands:
-  - go test -run Integration -covermode=atomic -timeout=5m ./pkg/...
-  depends_on:
-  - wire-install
-  image: grafana/build-container:1.6.3
-  name: test-backend-integration
+  name: betterer-frontend
 - commands:
   - yarn run ci:test-frontend
   depends_on:
@@ -4864,21 +4904,6 @@ steps:
     TEST_MAX_WORKERS: 50%
   image: grafana/build-container:1.6.3
   name: test-frontend
-- commands:
-  - apt-get update && apt-get install make
-  - make lint-go
-  depends_on:
-  - wire-install
-  environment:
-    CGO_ENABLED: "1"
-  image: golang:1.19.2
-  name: lint-backend-enterprise2
-- commands:
-  - go test -tags=pro -covermode=atomic -timeout=5m ./pkg/...
-  depends_on:
-  - wire-install
-  image: grafana/build-container:1.6.3
-  name: test-backend-enterprise2
 trigger:
   ref:
   - refs/heads/v[0-9]*
@@ -4892,7 +4917,133 @@ clone:
   disable: true
 depends_on: []
 environment:
-  EDITION: ENTERPRISE
+  EDITION: enterprise
+image_pull_secrets:
+- dockerconfigjson
+kind: pipeline
+name: release-branch-test-backend
+node:
+  type: no-parallel
+platform:
+  arch: amd64
+  os: linux
+services: []
+steps:
+- commands:
+  - echo $DRONE_RUNNER_NAME
+  image: alpine:3.15.6
+  name: identify-runner
+- commands:
+  - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
+  depends_on: []
+  environment:
+    CGO_ENABLED: 0
+  image: golang:1.19.2
+  name: compile-build-cmd
+- commands:
+  - '# It is required that code generated from Thema/CUE be committed and in sync
+    with its inputs.'
+  - '# The following command will fail if running code generators produces any diff
+    in output.'
+  - CODEGEN_VERIFY=1 make gen-cue
+  depends_on: []
+  image: grafana/build-container:1.6.3
+  name: verify-gen-cue
+- commands:
+  - make gen-go
+  depends_on:
+  - verify-gen-cue
+  image: grafana/build-container:1.6.3
+  name: wire-install
+- commands:
+  - go test -short -covermode=atomic -timeout=5m ./pkg/...
+  depends_on:
+  - wire-install
+  image: grafana/build-container:1.6.3
+  name: test-backend
+- commands:
+  - go test -run Integration -covermode=atomic -timeout=5m ./pkg/...
+  depends_on:
+  - wire-install
+  image: grafana/build-container:1.6.3
+  name: test-backend-integration
+trigger:
+  ref:
+  - refs/heads/v[0-9]*
+type: docker
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
+---
+clone:
+  disable: true
+depends_on: []
+environment:
+  EDITION: enterprise2
+image_pull_secrets:
+- dockerconfigjson
+kind: pipeline
+name: release-branch-test-backend
+node:
+  type: no-parallel
+platform:
+  arch: amd64
+  os: linux
+services: []
+steps:
+- commands:
+  - echo $DRONE_RUNNER_NAME
+  image: alpine:3.15.6
+  name: identify-runner
+- commands:
+  - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
+  depends_on: []
+  environment:
+    CGO_ENABLED: 0
+  image: golang:1.19.2
+  name: compile-build-cmd
+- commands:
+  - '# It is required that code generated from Thema/CUE be committed and in sync
+    with its inputs.'
+  - '# The following command will fail if running code generators produces any diff
+    in output.'
+  - CODEGEN_VERIFY=1 make gen-cue
+  depends_on: []
+  image: grafana/build-container:1.6.3
+  name: verify-gen-cue
+- commands:
+  - make gen-go
+  depends_on:
+  - verify-gen-cue
+  image: grafana/build-container:1.6.3
+  name: wire-install
+- commands:
+  - go test -tags=pro -covermode=atomic -timeout=5m ./pkg/...
+  depends_on:
+  - wire-install
+  image: grafana/build-container:1.6.3
+  name: test-backend-enterprise2
+- commands:
+  - go test -run Integration -covermode=atomic -timeout=5m ./pkg/...
+  depends_on:
+  - wire-install
+  image: grafana/build-container:1.6.3
+  name: test-backend-integration
+trigger:
+  ref:
+  - refs/heads/v[0-9]*
+type: docker
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
+---
+clone:
+  disable: true
+depends_on: []
+environment:
+  EDITION: enterprise
 image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
@@ -5050,7 +5201,7 @@ depends_on:
 - release-branch-enterprise-test
 - release-branch-enterprise-integration-tests
 environment:
-  EDITION: ENTERPRISE
+  EDITION: enterprise
 image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
@@ -5339,6 +5490,6 @@ kind: secret
 name: packages_secret_access_key
 ---
 kind: signature
-hmac: 74e91fca99550f9a5c85b01f1e8ab58629a1fff4e55ca07be3163d26e5f291bb
+hmac: 975d7fa9e21991017d3b176aede1025b0aff8721adc1029ae234221b8b40ef19
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -2487,7 +2487,8 @@ clone:
   retries: 3
 depends_on:
 - release-oss-build-e2e-publish
-- release-oss-test
+- release-oss-test-frontend
+- release-oss-test-backend
 - release-oss-integration-tests
 environment:
   EDITION: oss
@@ -3272,7 +3273,8 @@ clone:
   disable: true
 depends_on:
 - release-enterprise-build-e2e-publish
-- release-enterprise-test
+- release-enterprise-test-frontend
+- release-enterprise-test-backend
 - release-enterprise-integration-tests
 environment:
   EDITION: enterprise
@@ -4461,7 +4463,8 @@ clone:
   retries: 3
 depends_on:
 - release-branch-oss-build-e2e-publish
-- release-branch-oss-test
+- release-branch-oss-test-frontend
+- release-branch-oss-test-backend
 - release-branch-oss-integration-tests
 environment:
   EDITION: oss
@@ -5198,7 +5201,8 @@ clone:
   disable: true
 depends_on:
 - release-branch-enterprise-build-e2e-publish
-- release-branch-enterprise-test
+- release-branch-enterprise-test-frontend
+- release-branch-enterprise-test-backend
 - release-branch-enterprise-integration-tests
 environment:
   EDITION: enterprise
@@ -5490,6 +5494,6 @@ kind: secret
 name: packages_secret_access_key
 ---
 kind: signature
-hmac: 975d7fa9e21991017d3b176aede1025b0aff8721adc1029ae234221b8b40ef19
+hmac: 9ba807a4d05f8cdd13e763174e4fc91e8004df02d58cbcf8b36da5ffe11616ea
 
 ...

--- a/scripts/drone/events/release.star
+++ b/scripts/drone/events/release.star
@@ -61,6 +61,16 @@ load(
     'drone_change_template',
 )
 
+load(
+    'scripts/drone/pipelines/test_frontend.star',
+    'test_frontend',
+)
+
+load(
+    'scripts/drone/pipelines/test_backend.star',
+    'test_backend',
+)
+
 load('scripts/drone/vault.star', 'from_secret', 'github_token', 'pull_secret', 'drone_token', 'prerelease_bucket')
 
 def store_npm_packages_step():
@@ -113,7 +123,7 @@ def release_npm_packages_step():
     }
 
 def get_oss_pipelines(trigger, ver_mode):
-    environment = {'EDITION': 'OSS'}
+    environment = {'EDITION': 'oss'}
     edition = 'oss'
     services = integration_test_services(edition=edition)
     volumes = integration_test_services_volumes()
@@ -129,16 +139,6 @@ def get_oss_pipelines(trigger, ver_mode):
         yarn_install_step(),
         compile_build_cmd(),
     ]
-
-    test_steps = []
-
-    test_steps.extend([
-        lint_backend_step(edition=edition),
-        lint_frontend_step(),
-        test_backend_step(edition=edition),
-        test_backend_integration_step(edition=edition),
-        test_frontend_step(),
-    ])
 
     build_steps = [
         build_backend_step(edition=edition, ver_mode=ver_mode),
@@ -202,11 +202,8 @@ def get_oss_pipelines(trigger, ver_mode):
     ]
     if not disable_tests:
         pipelines.extend([
-            pipeline(
-                name='{}-oss-test'.format(ver_mode), edition=edition, trigger=trigger, services=[],
-                steps=init_steps + test_steps,
-                environment=environment, volumes=[],
-            ),
+            test_frontend(trigger, ver_mode),
+            test_backend(trigger, ver_mode),
             pipeline(
                 name='{}-oss-integration-tests'.format(ver_mode), edition=edition, trigger=trigger, services=services,
                 steps=[download_grabpl_step(), identify_runner_step(), verify_gen_cue_step(edition), wire_install_step(), ] + integration_test_steps,
@@ -226,7 +223,7 @@ def get_oss_pipelines(trigger, ver_mode):
     return pipelines
 
 def get_enterprise_pipelines(trigger, ver_mode):
-    environment = {'EDITION': 'ENTERPRISE'}
+    environment = {'EDITION': 'enterprise'}
     edition = 'enterprise'
     services = integration_test_services(edition=edition)
     volumes = integration_test_services_volumes()
@@ -244,16 +241,6 @@ def get_enterprise_pipelines(trigger, ver_mode):
         compile_build_cmd(edition),
     ]
 
-    test_steps = []
-
-    test_steps.extend([
-        lint_backend_step(edition=edition),
-        lint_frontend_step(),
-        test_backend_step(edition=edition),
-        test_backend_integration_step(edition=edition),
-        test_frontend_step(),
-    ])
-
     build_steps = [
         build_backend_step(edition=edition, ver_mode=ver_mode),
         build_frontend_step(edition=edition, ver_mode=ver_mode),
@@ -267,10 +254,6 @@ def get_enterprise_pipelines(trigger, ver_mode):
     ]
 
     if include_enterprise:
-        test_steps.extend([
-            lint_backend_step(edition=edition2),
-            test_backend_step(edition=edition2),
-        ])
         build_steps.extend([
             build_backend_step(edition=edition2, ver_mode=ver_mode, variants=['linux-amd64']),
         ])
@@ -344,11 +327,9 @@ def get_enterprise_pipelines(trigger, ver_mode):
     ]
     if not disable_tests:
         pipelines.extend([
-            pipeline(
-                name='{}-enterprise-test'.format(ver_mode), edition=edition, trigger=trigger, services=[],
-                steps=init_steps + test_steps, environment=environment,
-                volumes=[],
-            ),
+            test_frontend(trigger, ver_mode, edition),
+            test_backend(trigger, ver_mode, edition),
+            test_backend(trigger, ver_mode, edition2),
             pipeline(
                 name='{}-enterprise-integration-tests'.format(ver_mode), edition=edition, trigger=trigger, services=services,
                 steps=[download_grabpl_step(), identify_runner_step(), clone_enterprise_step(ver_mode), init_enterprise_step(ver_mode), verify_gen_cue_step(edition), wire_install_step()] + integration_test_steps + [redis_integration_tests_step(), memcached_integration_tests_step()],

--- a/scripts/drone/events/release.star
+++ b/scripts/drone/events/release.star
@@ -213,7 +213,8 @@ def get_oss_pipelines(trigger, ver_mode):
         deps = {
             'depends_on': [
                 '{}-oss-build{}-publish'.format(ver_mode, get_e2e_suffix()),
-                '{}-oss-test'.format(ver_mode),
+                '{}-oss-test-frontend'.format(ver_mode),
+                '{}-oss-test-backend'.format(ver_mode),
                 '{}-oss-integration-tests'.format(ver_mode)
             ]
         }
@@ -339,7 +340,8 @@ def get_enterprise_pipelines(trigger, ver_mode):
         deps = {
             'depends_on': [
                 '{}-enterprise-build{}-publish'.format(ver_mode, get_e2e_suffix()),
-                '{}-enterprise-test'.format(ver_mode),
+                '{}-enterprise-test-frontend'.format(ver_mode),
+                '{}-enterprise-test-backend'.format(ver_mode),
                 '{}-enterprise-integration-tests'.format(ver_mode)
             ]
         }

--- a/scripts/drone/pipelines/test_backend.star
+++ b/scripts/drone/pipelines/test_backend.star
@@ -13,7 +13,8 @@ load(
     'pipeline',
 )
 
-def test_backend(trigger, ver_mode):
+def test_backend(trigger, ver_mode, edition="oss"):
+    environment = {'EDITION': edition}
     init_steps = [
         identify_runner_step(),
         compile_build_cmd(),
@@ -21,10 +22,13 @@ def test_backend(trigger, ver_mode):
         wire_install_step(),
     ]
     test_steps = [
-        test_backend_step(edition="oss"),
-        test_backend_integration_step(edition="oss"),
+        test_backend_step(edition),
+        test_backend_integration_step(edition),
     ]
 
+    pipeline_name = '{}-test-backend'.format(ver_mode)
+    if ver_mode == 'release':
+        pipeline_name = '{}-{}-test-backend'.format(ver_mode, edition)
     return pipeline(
-        name='{}-test-backend'.format(ver_mode), edition="oss", trigger=trigger, services=[], steps=init_steps + test_steps,
+        name=pipeline_name, edition=edition, trigger=trigger, services=[], steps=init_steps + test_steps, environment=environment
     )

--- a/scripts/drone/pipelines/test_backend.star
+++ b/scripts/drone/pipelines/test_backend.star
@@ -27,7 +27,7 @@ def test_backend(trigger, ver_mode, edition="oss"):
     ]
 
     pipeline_name = '{}-test-backend'.format(ver_mode)
-    if ver_mode == 'release':
+    if ver_mode in ("release-branch", "release"):
         pipeline_name = '{}-{}-test-backend'.format(ver_mode, edition)
     return pipeline(
         name=pipeline_name, edition=edition, trigger=trigger, services=[], steps=init_steps + test_steps, environment=environment

--- a/scripts/drone/pipelines/test_frontend.star
+++ b/scripts/drone/pipelines/test_frontend.star
@@ -13,7 +13,8 @@ load(
     'pipeline',
 )
 
-def test_frontend(trigger, ver_mode):
+def test_frontend(trigger, ver_mode, edition="oss"):
+    environment = {'EDITION': edition}
     init_steps = [
         identify_runner_step(),
         download_grabpl_step(),
@@ -24,6 +25,9 @@ def test_frontend(trigger, ver_mode):
         betterer_frontend_step(),
         test_frontend_step(),
     ]
+    pipeline_name = '{}-test-frontend'.format(ver_mode)
+    if ver_mode == 'release':
+        pipeline_name = '{}-{}-test-frontend'.format(ver_mode, edition)
     return pipeline(
-        name='{}-test-frontend'.format(ver_mode), edition="oss", trigger=trigger, services=[], steps=init_steps + test_steps,
+        name=pipeline_name, edition=edition, trigger=trigger, services=[], steps=init_steps + test_steps,
     )

--- a/scripts/drone/pipelines/test_frontend.star
+++ b/scripts/drone/pipelines/test_frontend.star
@@ -26,7 +26,7 @@ def test_frontend(trigger, ver_mode, edition="oss"):
         test_frontend_step(),
     ]
     pipeline_name = '{}-test-frontend'.format(ver_mode)
-    if ver_mode == 'release':
+    if ver_mode in ("release-branch", "release"):
         pipeline_name = '{}-{}-test-frontend'.format(ver_mode, edition)
     return pipeline(
         name=pipeline_name, edition=edition, trigger=trigger, services=[], steps=init_steps + test_steps,


### PR DESCRIPTION
**What this PR does / why we need it**:

Similar to what already exist in PR/main pipelines. We are splitting the test pipeline to frontend and backend tests.
For releases, we decide to on run the linters.

**Which issue(s) this PR fixes**:

Fixes #56531

