### PR TITLE
Loki Monaco Editor: add component tests

### DIFF
--- a/public/app/plugins/datasource/loki/components/monaco-query-field/MonacoFieldWrapper.test.tsx
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/MonacoFieldWrapper.test.tsx
@@ -27,7 +27,7 @@ function renderComponent({
   );
 }
 
-describe('MonacoQueryField', () => {
+describe('MonacoFieldWrapper', () => {
   test('Renders with no errors', async () => {
     renderComponent();
 

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/MonacoFieldWrapper.test.tsx
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/MonacoFieldWrapper.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import LokiLanguageProvider from '../../LanguageProvider';
+import { createLokiDatasource } from '../../mocks';
+
+import { MonacoQueryFieldWrapper, Props } from './MonacoQueryFieldWrapper';
+
+function renderComponent({
+  initialValue = '',
+  onChange = jest.fn(),
+  onRunQuery = jest.fn(),
+  runQueryOnBlur = false,
+}: Partial<Props> = {}) {
+  const datasource = createLokiDatasource();
+  const languageProvider = new LokiLanguageProvider(datasource);
+
+  render(
+    <MonacoQueryFieldWrapper
+      languageProvider={languageProvider}
+      history={[]}
+      initialValue={initialValue}
+      onChange={onChange}
+      onRunQuery={onRunQuery}
+      runQueryOnBlur={runQueryOnBlur}
+    />
+  );
+}
+
+describe('MonacoQueryField', () => {
+  test('Renders with no errors', async () => {
+    renderComponent();
+
+    expect(await screen.findByText('Loading...')).toBeInTheDocument();
+  });
+});

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/MonacoQueryField.test.tsx
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/MonacoQueryField.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import LokiLanguageProvider from '../../LanguageProvider';
+import { createLokiDatasource } from '../../mocks';
+
+import MonacoQueryField from './MonacoQueryField';
+import { Props } from './MonacoQueryFieldProps';
+
+function renderComponent({ initialValue = '', onRunQuery = jest.fn(), onBlur = jest.fn() }: Partial<Props> = {}) {
+  const datasource = createLokiDatasource();
+  const languageProvider = new LokiLanguageProvider(datasource);
+
+  render(
+    <MonacoQueryField
+      languageProvider={languageProvider}
+      initialValue={initialValue}
+      history={[]}
+      onRunQuery={onRunQuery}
+      onBlur={onBlur}
+    />
+  );
+}
+
+describe('MonacoQueryField', () => {
+  test('Renders with no errors', async () => {
+    renderComponent();
+
+    expect(await screen.findByText('Loading...')).toBeInTheDocument();
+  });
+});

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/MonacoQueryFieldWrapper.tsx
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/MonacoQueryFieldWrapper.tsx
@@ -3,7 +3,7 @@ import React, { useRef } from 'react';
 import { MonacoQueryFieldLazy } from './MonacoQueryFieldLazy';
 import { Props as MonacoProps } from './MonacoQueryFieldProps';
 
-type Props = Omit<MonacoProps, 'onRunQuery' | 'onBlur'> & {
+export type Props = Omit<MonacoProps, 'onRunQuery' | 'onBlur'> & {
   onChange: (query: string) => void;
   onRunQuery: () => void;
   runQueryOnBlur: boolean;


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds missing tests for the components added in the initial PR.

According to https://github.com/suren-atoyan/monaco-react/issues/88, there's no trivial way to render the actual Monaco editor in the test, or to mock it. So adding some simple test to have at least some minimum converage.

**Which issue(s) this PR fixes**:

Part of https://github.com/grafana/grafana/issues/44985

**Special notes for your reviewer**:

