### PR TITLE
Navigation: prevent dashboard list overflowing page boundary 

### DIFF
--- a/public/app/core/components/PageNew/PageContents.tsx
+++ b/public/app/core/components/PageNew/PageContents.tsx
@@ -9,6 +9,8 @@ interface Props {
   className?: string;
 }
 
-export const PageContents: FC<Props> = ({ isLoading, children }) => {
-  return <>{isLoading ? <PageLoader /> : children}</>;
+export const PageContents: FC<Props> = ({ isLoading, children, className }) => {
+  let content = className ? <div className={className}>{children}</div> : children;
+
+  return <>{isLoading ? <PageLoader /> : content}</>;
 };

--- a/public/app/features/search/components/DashboardListPage.tsx
+++ b/public/app/features/search/components/DashboardListPage.tsx
@@ -45,6 +45,7 @@ export const DashboardListPage: FC<Props> = memo(({ match, location }) => {
         className={css`
           display: flex;
           flex-direction: column;
+          height: 100%;
           overflow: hidden;
         `}
       >


### PR DESCRIPTION
alternative to https://github.com/grafana/grafana/pull/56657 

Having Page inner div default to display flex caused issues with elements that have flex grow (like Alert), so opted to have pageContent be a normal block element. But consumers should be able to set height 100% on any child div. Problem was Page.Contents is a noop wrapper in PageNew so the custom styles set did not have any effect when topnav is enabled 

But I am not sure, maybe In https://github.com/grafana/grafana/pull/56524 should be reverted and the pageInner should default to flex and flexDirection column, then any page where this causes issue can just add a wrapping div if they don't want the default flex container 

