### PR TITLE
CI: Add `clone-enterprise` and `init-enterprise` steps to enterprise test release pipelines

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -84,13 +84,6 @@ steps:
   image: grafana/build-container:1.6.3
   name: yarn-install
 - commands:
-  - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
-  depends_on: []
-  environment:
-    CGO_ENABLED: 0
-  image: golang:1.19.2
-  name: compile-build-cmd
-- commands:
   - yarn betterer ci
   depends_on:
   - yarn-install
@@ -931,13 +924,6 @@ steps:
   - grabpl
   image: grafana/build-container:1.6.3
   name: yarn-install
-- commands:
-  - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
-  depends_on: []
-  environment:
-    CGO_ENABLED: 0
-  image: golang:1.19.2
-  name: compile-build-cmd
 - commands:
   - yarn betterer ci
   depends_on:
@@ -2264,13 +2250,6 @@ steps:
   image: grafana/build-container:1.6.3
   name: yarn-install
 - commands:
-  - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
-  depends_on: []
-  environment:
-    CGO_ENABLED: 0
-  image: golang:1.19.2
-  name: compile-build-cmd
-- commands:
   - yarn betterer ci
   depends_on:
   - yarn-install
@@ -2931,13 +2910,6 @@ steps:
   image: grafana/build-container:1.6.3
   name: yarn-install
 - commands:
-  - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
-  depends_on: []
-  environment:
-    CGO_ENABLED: 0
-  image: golang:1.19.2
-  name: compile-build-cmd
-- commands:
   - yarn betterer ci
   depends_on:
   - yarn-install
@@ -2984,12 +2956,38 @@ platform:
 services: []
 steps:
 - commands:
+  - git clone "https://$${GITHUB_TOKEN}@github.com/grafana/grafana-enterprise.git"
+  - cd grafana-enterprise
+  - git checkout ${DRONE_TAG}
+  environment:
+    GITHUB_TOKEN:
+      from_secret: github_token
+  image: grafana/build-container:1.6.3
+  name: clone-enterprise
+- commands:
+  - mv bin/grabpl /tmp/
+  - rmdir bin
+  - mv grafana-enterprise /tmp/
+  - /tmp/grabpl init-enterprise --github-token $${GITHUB_TOKEN} /tmp/grafana-enterprise
+    ${DRONE_TAG}
+  - mv /tmp/grafana-enterprise/deployment_tools_config.json deployment_tools_config.json
+  - mkdir bin
+  - mv /tmp/grabpl bin/
+  depends_on:
+  - clone-enterprise
+  environment:
+    GITHUB_TOKEN:
+      from_secret: github_token
+  image: grafana/build-container:1.6.3
+  name: init-enterprise
+- commands:
   - echo $DRONE_RUNNER_NAME
   image: alpine:3.15.6
   name: identify-runner
 - commands:
   - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
-  depends_on: []
+  depends_on:
+  - init-enterprise
   environment:
     CGO_ENABLED: 0
   image: golang:1.19.2
@@ -3052,6 +3050,31 @@ platform:
   os: linux
 services: []
 steps:
+- commands:
+  - git clone "https://$${GITHUB_TOKEN}@github.com/grafana/grafana-enterprise.git"
+  - cd grafana-enterprise
+  - git checkout ${DRONE_TAG}
+  environment:
+    GITHUB_TOKEN:
+      from_secret: github_token
+  image: grafana/build-container:1.6.3
+  name: clone-enterprise
+- commands:
+  - mv bin/grabpl /tmp/
+  - rmdir bin
+  - mv grafana-enterprise /tmp/
+  - /tmp/grabpl init-enterprise --github-token $${GITHUB_TOKEN} /tmp/grafana-enterprise
+    ${DRONE_TAG}
+  - mv /tmp/grafana-enterprise/deployment_tools_config.json deployment_tools_config.json
+  - mkdir bin
+  - mv /tmp/grabpl bin/
+  depends_on:
+  - clone-enterprise
+  environment:
+    GITHUB_TOKEN:
+      from_secret: github_token
+  image: grafana/build-container:1.6.3
+  name: init-enterprise
 - commands:
   - echo $DRONE_RUNNER_NAME
   image: alpine:3.15.6
@@ -4258,13 +4281,6 @@ steps:
   image: grafana/build-container:1.6.3
   name: yarn-install
 - commands:
-  - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
-  depends_on: []
-  environment:
-    CGO_ENABLED: 0
-  image: golang:1.19.2
-  name: compile-build-cmd
-- commands:
   - yarn betterer ci
   depends_on:
   - yarn-install
@@ -4886,13 +4902,6 @@ steps:
   image: grafana/build-container:1.6.3
   name: yarn-install
 - commands:
-  - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
-  depends_on: []
-  environment:
-    CGO_ENABLED: 0
-  image: golang:1.19.2
-  name: compile-build-cmd
-- commands:
   - yarn betterer ci
   depends_on:
   - yarn-install
@@ -4933,12 +4942,35 @@ platform:
 services: []
 steps:
 - commands:
+  - git clone "https://$${GITHUB_TOKEN}@github.com/grafana/grafana-enterprise.git"
+  - cd grafana-enterprise
+  - git checkout ${DRONE_BRANCH}
+  environment:
+    GITHUB_TOKEN:
+      from_secret: github_token
+  image: grafana/build-container:1.6.3
+  name: clone-enterprise
+- commands:
+  - mv bin/grabpl /tmp/
+  - rmdir bin
+  - mv grafana-enterprise /tmp/
+  - /tmp/grabpl init-enterprise  /tmp/grafana-enterprise
+  - mv /tmp/grafana-enterprise/deployment_tools_config.json deployment_tools_config.json
+  - mkdir bin
+  - mv /tmp/grabpl bin/
+  depends_on:
+  - clone-enterprise
+  environment: {}
+  image: grafana/build-container:1.6.3
+  name: init-enterprise
+- commands:
   - echo $DRONE_RUNNER_NAME
   image: alpine:3.15.6
   name: identify-runner
 - commands:
   - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
-  depends_on: []
+  depends_on:
+  - init-enterprise
   environment:
     CGO_ENABLED: 0
   image: golang:1.19.2
@@ -4995,6 +5027,28 @@ platform:
   os: linux
 services: []
 steps:
+- commands:
+  - git clone "https://$${GITHUB_TOKEN}@github.com/grafana/grafana-enterprise.git"
+  - cd grafana-enterprise
+  - git checkout ${DRONE_BRANCH}
+  environment:
+    GITHUB_TOKEN:
+      from_secret: github_token
+  image: grafana/build-container:1.6.3
+  name: clone-enterprise
+- commands:
+  - mv bin/grabpl /tmp/
+  - rmdir bin
+  - mv grafana-enterprise /tmp/
+  - /tmp/grabpl init-enterprise  /tmp/grafana-enterprise
+  - mv /tmp/grafana-enterprise/deployment_tools_config.json deployment_tools_config.json
+  - mkdir bin
+  - mv /tmp/grabpl bin/
+  depends_on:
+  - clone-enterprise
+  environment: {}
+  image: grafana/build-container:1.6.3
+  name: init-enterprise
 - commands:
   - echo $DRONE_RUNNER_NAME
   image: alpine:3.15.6
@@ -5494,6 +5548,6 @@ kind: secret
 name: packages_secret_access_key
 ---
 kind: signature
-hmac: 0a4cc4cfd81481dbb25b9ccfc22ddd4ad23bbaa1b775e5c64aba2533ccfe1676
+hmac: 82dedf98f127a4d16c71b668d9a2df17502c109cc6ff0ab01e770547250135e7
 
 ...

--- a/scripts/drone/pipelines/test_backend.star
+++ b/scripts/drone/pipelines/test_backend.star
@@ -6,6 +6,8 @@ load(
     'test_backend_integration_step',
     'verify_gen_cue_step',
     'compile_build_cmd',
+    'clone_enterprise_step',
+    'init_enterprise_step',
 )
 
 load(
@@ -15,12 +17,15 @@ load(
 
 def test_backend(trigger, ver_mode, edition="oss"):
     environment = {'EDITION': edition}
-    init_steps = [
+    init_steps = []
+    if edition != 'oss':
+        init_steps.extend([clone_enterprise_step(ver_mode), init_enterprise_step(ver_mode),])
+    init_steps.extend([
         identify_runner_step(),
-        compile_build_cmd(),
+        compile_build_cmd(edition),
         verify_gen_cue_step(edition="oss"),
         wire_install_step(),
-    ]
+    ])
     test_steps = [
         test_backend_step(edition),
         test_backend_integration_step(edition),

--- a/scripts/drone/pipelines/test_frontend.star
+++ b/scripts/drone/pipelines/test_frontend.star
@@ -5,7 +5,6 @@ load(
     'yarn_install_step',
     'betterer_frontend_step',
     'test_frontend_step',
-    'compile_build_cmd',
 )
 
 load(
@@ -19,7 +18,6 @@ def test_frontend(trigger, ver_mode, edition="oss"):
         identify_runner_step(),
         download_grabpl_step(),
         yarn_install_step(),
-        compile_build_cmd(),
     ]
     test_steps = [
         betterer_frontend_step(),


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds necessary missing dependencies in enterprise release pipelines.

**Which issue(s) this PR fixes**:

Fixes #56531
