### PR TITLE
coremodels: Always take runtime arg for NewBase()

### DIFF
--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -64,7 +64,7 @@ func TestGetHomeDashboard(t *testing.T) {
 		SQLStore:                mockstore.NewSQLStoreMock(),
 		preferenceService:       prefService,
 		dashboardVersionService: dashboardVersionService,
-		Coremodels:              registry.NewBase(),
+		Coremodels:              registry.NewBase(nil),
 	}
 
 	tests := []struct {
@@ -148,7 +148,7 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 			Features:                featuremgmt.WithFeatures(),
 			DashboardService:        dashboardService,
 			dashboardVersionService: fakeDashboardVersionService,
-			Coremodels:              registry.NewBase(),
+			Coremodels:              registry.NewBase(nil),
 		}
 
 		setUp := func() {
@@ -270,7 +270,7 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 			DashboardService:        dashboardService,
 			dashboardVersionService: fakeDashboardVersionService,
 			Features:                featuremgmt.WithFeatures(),
-			Coremodels:              registry.NewBase(),
+			Coremodels:              registry.NewBase(nil),
 		}
 
 		setUp := func() {
@@ -913,7 +913,7 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 				AccessControl:                accesscontrolmock.New(),
 				DashboardService:             dashboardService,
 				Features:                     featuremgmt.WithFeatures(),
-				Coremodels:                   registry.NewBase(),
+				Coremodels:                   registry.NewBase(nil),
 			}
 			hs.callGetDashboard(sc)
 
@@ -968,7 +968,7 @@ func getDashboardShouldReturn200WithConfig(t *testing.T, sc *scenarioContext, pr
 		),
 		DashboardService: dashboardService,
 		Features:         featuremgmt.WithFeatures(),
-		Coremodels:       registry.NewBase(),
+		Coremodels:       registry.NewBase(nil),
 	}
 
 	hs.callGetDashboard(sc)
@@ -1034,7 +1034,7 @@ func postDashboardScenario(t *testing.T, desc string, url string, routePattern s
 			DashboardService:      dashboardService,
 			folderService:         folderService,
 			Features:              featuremgmt.WithFeatures(),
-			Coremodels:            registry.NewBase(),
+			Coremodels:            registry.NewBase(nil),
 		}
 
 		sc := setupScenarioContext(t, url)
@@ -1067,7 +1067,7 @@ func postDiffScenario(t *testing.T, desc string, url string, routePattern string
 			SQLStore:                sqlmock,
 			dashboardVersionService: fakeDashboardVersionService,
 			Features:                featuremgmt.WithFeatures(),
-			Coremodels:              registry.NewBase(),
+			Coremodels:              registry.NewBase(nil),
 		}
 
 		sc := setupScenarioContext(t, url)
@@ -1106,7 +1106,7 @@ func restoreDashboardVersionScenario(t *testing.T, desc string, url string, rout
 			SQLStore:                sqlStore,
 			Features:                featuremgmt.WithFeatures(),
 			dashboardVersionService: fakeDashboardVersionService,
-			Coremodels:              registry.NewBase(),
+			Coremodels:              registry.NewBase(nil),
 		}
 
 		sc := setupScenarioContext(t, url)

--- a/pkg/framework/coremodel/registry/assignability_test.go
+++ b/pkg/framework/coremodel/registry/assignability_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestSchemaAssignability(t *testing.T) {
-	reg := registry.NewBase()
+	reg := registry.NewBase(nil)
 
 	for _, cm := range reg.All() {
 		tcm := cm

--- a/pkg/framework/coremodel/registry/provide.go
+++ b/pkg/framework/coremodel/registry/provide.go
@@ -14,34 +14,22 @@ var CoremodelSet = wire.NewSet(
 	NewBase,
 )
 
-// NewBase provides a registry of all coremodels, without any composition of
-// plugin-defined schemas.
-//
-// The returned registry will use Grafana's singleton [thema.Runtime],
-// returned from [cuectx.GrafanaThemaRuntime].
-func NewBase() *Base {
-	return provideBase(nil)
-}
-
-// NewBaseWithRuntime is the same as NewBase, but allows control over the
-// [thema.Runtime] used to initialize the underlying coremodels.
-//
-// Prefer NewBase unless you absolutely need this control.
-//
-// TODO it's OK to export this if it's ever actually needed
-func NewBaseWithRuntime(rt *thema.Runtime) *Base {
-	return provideBase(rt)
-}
-
 var (
 	baseOnce    sync.Once
 	defaultBase *Base
 )
 
-func provideBase(rt *thema.Runtime) *Base {
-	if rt == nil {
+// NewBase provides a registry of all coremodels, without any composition of
+// plugin-defined schemas.
+//
+// All calling code within grafana/grafana is expected to use Grafana's
+// singleton [thema.Runtime], returned from [cuectx.GrafanaThemaRuntime]. If nil
+// is passed, the singleton will be used.
+func NewBase(rt *thema.Runtime) *Base {
+	allrt := cuectx.GrafanaThemaRuntime()
+	if rt == nil || rt == allrt {
 		baseOnce.Do(func() {
-			defaultBase = doProvideBase(cuectx.GrafanaThemaRuntime())
+			defaultBase = doProvideBase(allrt)
 		})
 		return defaultBase
 	}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Gets rid of `registry.NewBaseWithRuntime()` in favor of just making `registry.NewBase()` take a `*thema.Runtime`. The only loss here is that it's now possible for someone to make a call within grafana/grafana with the wrong `thema.Runtime`, but that's pretty easily corrected, should fail hard, and won't happen when wire is in play, anyway.

cc @malcolmholmes 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

