### PR TITLE
EchoSrv: Remove $.ajax for loading scripts

### DIFF
--- a/public/app/core/services/echo/backends/analytics/ApplicationInsightsBackend.ts
+++ b/public/app/core/services/echo/backends/analytics/ApplicationInsightsBackend.ts
@@ -1,5 +1,3 @@
-import $ from 'jquery';
-
 import {
   EchoBackend,
   EchoEventType,
@@ -31,11 +29,11 @@ export class ApplicationInsightsBackend implements EchoBackend<PageviewEchoEvent
   supportedEvents = [EchoEventType.Pageview, EchoEventType.Interaction];
 
   constructor(public options: ApplicationInsightsBackendOptions) {
-    $.ajax({
-      url: 'https://js.monitor.azure.com/scripts/b/ai.2.min.js',
-      dataType: 'script',
-      cache: true,
-    }).done(function () {
+    fetch('https://js.monitor.azure.com/scripts/b/ai.2.min.js', {
+      headers: {
+        Accept: 'text/javascript',
+      },
+    }).then(function () {
       const applicationInsightsOpts = {
         config: {
           connectionString: options.connectionString,

--- a/public/app/core/services/echo/backends/analytics/ApplicationInsightsBackend.ts
+++ b/public/app/core/services/echo/backends/analytics/ApplicationInsightsBackend.ts
@@ -7,6 +7,8 @@ import {
   PageviewEchoEvent,
 } from '@grafana/runtime';
 
+import { loadScript } from '../../utils';
+
 interface ApplicationInsights {
   trackPageView: () => void;
   trackEvent: (event: { name: string; properties?: Record<string, any> }) => void;
@@ -29,12 +31,6 @@ export class ApplicationInsightsBackend implements EchoBackend<PageviewEchoEvent
   supportedEvents = [EchoEventType.Pageview, EchoEventType.Interaction];
 
   constructor(public options: ApplicationInsightsBackendOptions) {
-    const url = 'https://js.monitor.azure.com/scripts/b/ai.2.min.js'
-
-    const script = document.createElement('script');
-    script.src = url;
-    document.head.appendChild(script)
-
     const applicationInsightsOpts = {
       config: {
         connectionString: options.connectionString,
@@ -42,8 +38,11 @@ export class ApplicationInsightsBackend implements EchoBackend<PageviewEchoEvent
       },
     };
 
-    const init = new (window as any).Microsoft.ApplicationInsights.ApplicationInsights(applicationInsightsOpts);
-    (window as any).applicationInsights = init.loadAppInsights();
+    const url = 'https://js.monitor.azure.com/scripts/b/ai.2.min.js';
+    loadScript(url).then(() => {
+      const init = new (window as any).Microsoft.ApplicationInsights.ApplicationInsights(applicationInsightsOpts);
+      (window as any).applicationInsights = init.loadAppInsights();
+    });
   }
 
   addEvent = (e: PageviewEchoEvent | InteractionEchoEvent) => {

--- a/public/app/core/services/echo/backends/analytics/ApplicationInsightsBackend.ts
+++ b/public/app/core/services/echo/backends/analytics/ApplicationInsightsBackend.ts
@@ -29,21 +29,21 @@ export class ApplicationInsightsBackend implements EchoBackend<PageviewEchoEvent
   supportedEvents = [EchoEventType.Pageview, EchoEventType.Interaction];
 
   constructor(public options: ApplicationInsightsBackendOptions) {
-    fetch('https://js.monitor.azure.com/scripts/b/ai.2.min.js', {
-      headers: {
-        Accept: 'text/javascript',
-      },
-    }).then(function () {
-      const applicationInsightsOpts = {
-        config: {
-          connectionString: options.connectionString,
-          endpointUrl: options.endpointUrl,
-        },
-      };
+    const url = 'https://js.monitor.azure.com/scripts/b/ai.2.min.js'
 
-      const init = new (window as any).Microsoft.ApplicationInsights.ApplicationInsights(applicationInsightsOpts);
-      (window as any).applicationInsights = init.loadAppInsights();
-    });
+    const script = document.createElement('script');
+    script.src = url;
+    document.head.appendChild(script)
+
+    const applicationInsightsOpts = {
+      config: {
+        connectionString: options.connectionString,
+        endpointUrl: options.endpointUrl,
+      },
+    };
+
+    const init = new (window as any).Microsoft.ApplicationInsights.ApplicationInsights(applicationInsightsOpts);
+    (window as any).applicationInsights = init.loadAppInsights();
   }
 
   addEvent = (e: PageviewEchoEvent | InteractionEchoEvent) => {

--- a/public/app/core/services/echo/backends/analytics/GA4Backend.ts
+++ b/public/app/core/services/echo/backends/analytics/GA4Backend.ts
@@ -1,7 +1,7 @@
 import { CurrentUserDTO } from '@grafana/data';
 import { EchoBackend, EchoEventType, PageviewEchoEvent } from '@grafana/runtime';
 
-import { getUserIdentifier } from '../../utils';
+import { getUserIdentifier, loadScript } from '../../utils';
 
 declare global {
   interface Window {
@@ -20,10 +20,7 @@ export class GA4EchoBackend implements EchoBackend<PageviewEchoEvent, GA4EchoBac
 
   constructor(public options: GA4EchoBackendOptions) {
     const url = `https://www.googletagmanager.com/gtag/js?id=${options.googleAnalyticsId}`;
-
-    const script = document.createElement('script');
-    script.src = url;
-    document.head.appendChild(script)
+    loadScript(url);
 
     window.dataLayer = window.dataLayer || [];
     window.gtag = function gtag() {

--- a/public/app/core/services/echo/backends/analytics/GA4Backend.ts
+++ b/public/app/core/services/echo/backends/analytics/GA4Backend.ts
@@ -1,5 +1,3 @@
-import $ from 'jquery';
-
 import { CurrentUserDTO } from '@grafana/data';
 import { EchoBackend, EchoEventType, PageviewEchoEvent } from '@grafana/runtime';
 
@@ -23,10 +21,10 @@ export class GA4EchoBackend implements EchoBackend<PageviewEchoEvent, GA4EchoBac
   constructor(public options: GA4EchoBackendOptions) {
     const url = `https://www.googletagmanager.com/gtag/js?id=${options.googleAnalyticsId}`;
 
-    $.ajax({
-      url,
-      dataType: 'script',
-      cache: true,
+    fetch(url, {
+      headers: {
+        Accept: 'text/javascript',
+      },
     });
 
     window.dataLayer = window.dataLayer || [];

--- a/public/app/core/services/echo/backends/analytics/GA4Backend.ts
+++ b/public/app/core/services/echo/backends/analytics/GA4Backend.ts
@@ -21,11 +21,9 @@ export class GA4EchoBackend implements EchoBackend<PageviewEchoEvent, GA4EchoBac
   constructor(public options: GA4EchoBackendOptions) {
     const url = `https://www.googletagmanager.com/gtag/js?id=${options.googleAnalyticsId}`;
 
-    fetch(url, {
-      headers: {
-        Accept: 'text/javascript',
-      },
-    });
+    const script = document.createElement('script');
+    script.src = url;
+    document.head.appendChild(script)
 
     window.dataLayer = window.dataLayer || [];
     window.gtag = function gtag() {

--- a/public/app/core/services/echo/backends/analytics/GABackend.ts
+++ b/public/app/core/services/echo/backends/analytics/GABackend.ts
@@ -1,5 +1,3 @@
-import $ from 'jquery';
-
 import { EchoBackend, EchoEventType, PageviewEchoEvent } from '@grafana/runtime';
 
 export interface GAEchoBackendOptions {
@@ -14,10 +12,10 @@ export class GAEchoBackend implements EchoBackend<PageviewEchoEvent, GAEchoBacke
   constructor(public options: GAEchoBackendOptions) {
     const url = `https://www.google-analytics.com/analytics${options.debug ? '_debug' : ''}.js`;
 
-    $.ajax({
-      url,
-      dataType: 'script',
-      cache: true,
+    fetch(url, {
+      headers: {
+        Accept: 'text/javascript',
+      },
     });
 
     const ga = (window.ga =

--- a/public/app/core/services/echo/backends/analytics/GABackend.ts
+++ b/public/app/core/services/echo/backends/analytics/GABackend.ts
@@ -1,5 +1,7 @@
 import { EchoBackend, EchoEventType, PageviewEchoEvent } from '@grafana/runtime';
 
+import { loadScript } from '../../utils';
+
 export interface GAEchoBackendOptions {
   googleAnalyticsId: string;
   debug?: boolean;
@@ -11,10 +13,7 @@ export class GAEchoBackend implements EchoBackend<PageviewEchoEvent, GAEchoBacke
 
   constructor(public options: GAEchoBackendOptions) {
     const url = `https://www.google-analytics.com/analytics${options.debug ? '_debug' : ''}.js`;
-
-    const script = document.createElement('script');
-    script.src = url;
-    document.head.appendChild(script)
+    loadScript(url);
 
     const ga = (window.ga =
       window.ga ||

--- a/public/app/core/services/echo/backends/analytics/GABackend.ts
+++ b/public/app/core/services/echo/backends/analytics/GABackend.ts
@@ -12,11 +12,9 @@ export class GAEchoBackend implements EchoBackend<PageviewEchoEvent, GAEchoBacke
   constructor(public options: GAEchoBackendOptions) {
     const url = `https://www.google-analytics.com/analytics${options.debug ? '_debug' : ''}.js`;
 
-    fetch(url, {
-      headers: {
-        Accept: 'text/javascript',
-      },
-    });
+    const script = document.createElement('script');
+    script.src = url;
+    document.head.appendChild(script)
 
     const ga = (window.ga =
       window.ga ||

--- a/public/app/core/services/echo/backends/analytics/RudderstackBackend.ts
+++ b/public/app/core/services/echo/backends/analytics/RudderstackBackend.ts
@@ -1,4 +1,3 @@
-import $ from 'jquery';
 import type { identify, load, page, track } from 'rudder-sdk-js'; // SDK is loaded dynamically from config, so we only import types from the SDK package
 
 import { CurrentUserDTO } from '@grafana/data';
@@ -42,10 +41,10 @@ export class RudderstackBackend implements EchoBackend<PageviewEchoEvent, Rudder
   constructor(public options: RudderstackBackendOptions) {
     const url = options.sdkUrl || `https://cdn.rudderlabs.com/v1/rudder-analytics.min.js`;
 
-    $.ajax({
-      url,
-      dataType: 'script',
-      cache: true,
+    fetch(url, {
+      headers: {
+        Accept: 'text/javascript',
+      },
     });
 
     const tempRudderstack = ((window as any).rudderanalytics = []);

--- a/public/app/core/services/echo/backends/analytics/RudderstackBackend.ts
+++ b/public/app/core/services/echo/backends/analytics/RudderstackBackend.ts
@@ -41,11 +41,9 @@ export class RudderstackBackend implements EchoBackend<PageviewEchoEvent, Rudder
   constructor(public options: RudderstackBackendOptions) {
     const url = options.sdkUrl || `https://cdn.rudderlabs.com/v1/rudder-analytics.min.js`;
 
-    fetch(url, {
-      headers: {
-        Accept: 'text/javascript',
-      },
-    });
+    const script = document.createElement('script');
+    script.src = url;
+    document.head.appendChild(script)
 
     const tempRudderstack = ((window as any).rudderanalytics = []);
 

--- a/public/app/core/services/echo/backends/analytics/RudderstackBackend.ts
+++ b/public/app/core/services/echo/backends/analytics/RudderstackBackend.ts
@@ -10,7 +10,7 @@ import {
   PageviewEchoEvent,
 } from '@grafana/runtime';
 
-import { getUserIdentifier } from '../../utils';
+import { getUserIdentifier, loadScript } from '../../utils';
 
 interface Rudderstack {
   identify: typeof identify;
@@ -40,10 +40,7 @@ export class RudderstackBackend implements EchoBackend<PageviewEchoEvent, Rudder
 
   constructor(public options: RudderstackBackendOptions) {
     const url = options.sdkUrl || `https://cdn.rudderlabs.com/v1/rudder-analytics.min.js`;
-
-    const script = document.createElement('script');
-    script.src = url;
-    document.head.appendChild(script)
+    loadScript(url);
 
     const tempRudderstack = ((window as any).rudderanalytics = []);
 

--- a/public/app/core/services/echo/utils.ts
+++ b/public/app/core/services/echo/utils.ts
@@ -14,6 +14,15 @@ export function getUserIdentifier(user: CurrentUserDTO) {
   return user.email;
 }
 
+export function loadScript(url: string) {
+  return new Promise((resolve) => {
+    const script = document.createElement('script');
+    script.onload = resolve;
+    script.src = url;
+    document.head.appendChild(script);
+  });
+}
+
 /** @internal */
 export const echoLogger = createLogger('EchoSrv');
 export const echoLog = echoLogger.logger;


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes jquery.ajax for loading scripts in EchoSrv backends, in favor of appending a `<script />`

**Which issue(s) this PR fixes**:


Fixes #56366


**Special notes for your reviewer**:

