### PR TITLE
LDAP: Add `skip_org_role_sync` configuration option

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -632,6 +632,7 @@ allow_assign_grafana_admin = false
 enabled = false
 config_file = /etc/grafana/ldap.toml
 allow_sign_up = true
+skip_org_role_sync = false
 
 # LDAP background sync (Enterprise only)
 # At 1 am every day

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -624,6 +624,8 @@
 ;enabled = false
 ;config_file = /etc/grafana/ldap.toml
 ;allow_sign_up = true
+# prevent synchronizing ldap users organization roles
+;skip_org_role_sync = false
 
 # LDAP background sync (Enterprise only)
 # At 1 am every day

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/ldap.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/ldap.md
@@ -36,8 +36,8 @@ enabled = true
 # Path to the LDAP specific configuration file (default: `/etc/grafana/ldap.toml`)
 config_file = /etc/grafana/ldap.toml
 
-# Allow sign up should almost always be true (default) to allow new Grafana users to be created (if LDAP authentication is ok). If set to
-# false only pre-existing Grafana users will be able to login (if LDAP authentication is ok).
+# Allow sign-up should be `true` (default) to allow Grafana to create users on successful LDAP authentication.
+# If set to `false` only already existing Grafana users will be able to login.
 allow_sign_up = true
 ```
 
@@ -54,11 +54,11 @@ enabled = true
 # Path to the LDAP specific configuration file (default: `/etc/grafana/ldap.toml`)
 config_file = /etc/grafana/ldap.toml
 
-# Allow sign up should almost always be true (default) to allow new Grafana users to be created (if LDAP authentication is ok). If set to
-# false only pre-existing Grafana users will be able to login (if LDAP authentication is ok).
+# Allow sign-up should be `true` (default) to allow Grafana to create users on successful LDAP authentication.
+# If set to `false` only already existing Grafana users will be able to login.
 allow_sign_up = true
 
-# prevent synchronizing ldap users organization roles
+# Prevent synchronizing ldap users organization roles
 skip_org_role_sync = true
 ```
 

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/ldap.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/ldap.md
@@ -28,7 +28,7 @@ This means that you should be able to configure LDAP integration using any compl
 In order to use LDAP integration you'll first need to enable LDAP in the [main config file]({{< relref "../../configure-grafana/" >}}) as well as specify the path to the LDAP
 specific configuration file (default: `/etc/grafana/ldap.toml`).
 
-```bash
+```ini
 [auth.ldap]
 # Set to `true` to enable LDAP integration (default: `false`)
 enabled = true
@@ -39,6 +39,27 @@ config_file = /etc/grafana/ldap.toml
 # Allow sign up should almost always be true (default) to allow new Grafana users to be created (if LDAP authentication is ok). If set to
 # false only pre-existing Grafana users will be able to login (if LDAP authentication is ok).
 allow_sign_up = true
+```
+
+## Disable org role synchronization
+
+If LDAP is used to authenticate users but you don't need any role mapping and prefer manually assigning organization
+and roles, you can use the `skip_org_role_sync` configuration option.
+
+```ini
+[auth.ldap]
+# Set to `true` to enable LDAP integration (default: `false`)
+enabled = true
+
+# Path to the LDAP specific configuration file (default: `/etc/grafana/ldap.toml`)
+config_file = /etc/grafana/ldap.toml
+
+# Allow sign up should almost always be true (default) to allow new Grafana users to be created (if LDAP authentication is ok). If set to
+# false only pre-existing Grafana users will be able to login (if LDAP authentication is ok).
+allow_sign_up = true
+
+# prevent synchronizing ldap users organization roles
+skip_org_role_sync = true
 ```
 
 ## Grafana LDAP Configuration

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/ldap.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/ldap.md
@@ -43,7 +43,7 @@ allow_sign_up = true
 
 ## Disable org role synchronization
 
-If LDAP is used to authenticate users but you don't need any role mapping and prefer manually assigning organization
+If you are using LDAP to authenticate users but don't use role mapping and prefer manually assigning organizations
 and roles, you can use the `skip_org_role_sync` configuration option.
 
 ```ini

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/ldap.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/ldap.md
@@ -43,7 +43,7 @@ allow_sign_up = true
 
 ## Disable org role synchronization
 
-If you are using LDAP to authenticate users but don't use role mapping and prefer manually assigning organizations
+If you use LDAP to authenticate users but don't use role mapping, and prefer to manually assign organizations
 and roles, you can use the `skip_org_role_sync` configuration option.
 
 ```ini

--- a/packages/grafana-data/src/types/config.ts
+++ b/packages/grafana-data/src/types/config.ts
@@ -220,5 +220,6 @@ export interface GrafanaConfig {
 export interface AuthSettings {
   OAuthSkipOrgRoleUpdateSync?: boolean;
   SAMLSkipOrgRoleSync?: boolean;
+  LDAPSkipOrgRoleSync?: boolean;
   DisableSyncLock?: boolean;
 }

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -146,6 +146,7 @@ func (hs *HTTPServer) getFrontendSettingsMap(c *models.ReqContext) (map[string]i
 		"auth": map[string]interface{}{
 			"OAuthSkipOrgRoleUpdateSync": hs.Cfg.OAuthSkipOrgRoleUpdateSync,
 			"SAMLSkipOrgRoleSync":        hs.Cfg.SectionWithEnvOverrides("auth.saml").Key("skip_org_role_sync").MustBool(false),
+			"LDAPSkipOrgRoleSync":        hs.Cfg.LDAPSkipOrgRoleSync,
 			"DisableSyncLock":            hs.Cfg.DisableSyncLock,
 		},
 		"buildInfo": map[string]interface{}{

--- a/pkg/services/ldap/settings.go
+++ b/pkg/services/ldap/settings.go
@@ -76,6 +76,10 @@ func IsEnabled() bool {
 	return setting.LDAPEnabled
 }
 
+func SkipOrgRoleSync() bool {
+	return setting.LDAPSkipOrgRoleSync
+}
+
 // ReloadConfig reads the config from the disk and caches it.
 func ReloadConfig() error {
 	if !IsEnabled() {

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -147,6 +147,7 @@ var (
 
 	// LDAP
 	LDAPEnabled           bool
+	LDAPSkipOrgRoleSync   bool
 	LDAPConfigFile        string
 	LDAPSyncCron          string
 	LDAPAllowSignup       bool
@@ -413,8 +414,9 @@ type Cfg struct {
 	FeedbackLinksEnabled                bool
 
 	// LDAP
-	LDAPEnabled     bool
-	LDAPAllowSignup bool
+	LDAPEnabled         bool
+	LDAPSkipOrgRoleSync bool
+	LDAPAllowSignup     bool
 
 	Quota QuotaSettings
 
@@ -1131,6 +1133,8 @@ func (cfg *Cfg) readLDAPConfig() {
 	LDAPSyncCron = ldapSec.Key("sync_cron").String()
 	LDAPEnabled = ldapSec.Key("enabled").MustBool(false)
 	cfg.LDAPEnabled = LDAPEnabled
+	LDAPSkipOrgRoleSync = ldapSec.Key("skip_org_role_sync").MustBool(false)
+	cfg.LDAPSkipOrgRoleSync = LDAPSkipOrgRoleSync
 	LDAPActiveSyncEnabled = ldapSec.Key("active_sync_enabled").MustBool(false)
 	LDAPAllowSignup = ldapSec.Key("allow_sign_up").MustBool(true)
 	cfg.LDAPAllowSignup = LDAPAllowSignup

--- a/public/app/features/admin/UserAdminPage.tsx
+++ b/public/app/features/admin/UserAdminPage.tsx
@@ -105,7 +105,7 @@ export class UserAdminPage extends PureComponent<Props> {
 
   render() {
     const { user, orgs, sessions, ldapSyncInfo, isLoading } = this.props;
-    const isLDAPUser = user && user.isExternal && user.authLabels && user.authLabels.includes('LDAP');
+    const isLDAPUser = user?.isExternal && user?.authLabels?.includes('LDAP');
     const canReadSessions = contextSrv.hasPermission(AccessControlAction.UsersAuthTokenList);
     const canReadLDAPStatus = contextSrv.hasPermission(AccessControlAction.LDAPStatusRead);
     const isOAuthUserWithSkippableSync =
@@ -113,9 +113,10 @@ export class UserAdminPage extends PureComponent<Props> {
     const isSAMLUser = user?.isExternal && user?.authLabels?.includes('SAML');
     const isUserSynced =
       !config.auth.DisableSyncLock &&
-      ((user?.isExternal && !(isOAuthUserWithSkippableSync || isSAMLUser)) ||
+      ((user?.isExternal && !(isOAuthUserWithSkippableSync || isSAMLUser || isLDAPUser)) ||
         (!config.auth.OAuthSkipOrgRoleUpdateSync && isOAuthUserWithSkippableSync) ||
-        (!config.auth.SAMLSkipOrgRoleSync && isSAMLUser));
+        (!config.auth.SAMLSkipOrgRoleSync && isSAMLUser) ||
+        (!config.auth.LDAPSkipOrgRoleSync && isLDAPUser));
 
     const pageNav: NavModelItem = {
       text: user?.login ?? '',
@@ -137,9 +138,13 @@ export class UserAdminPage extends PureComponent<Props> {
                 onUserEnable={this.onUserEnable}
                 onPasswordChange={this.onPasswordChange}
               />
-              {isLDAPUser && featureEnabled('ldapsync') && ldapSyncInfo && canReadLDAPStatus && (
-                <UserLdapSyncInfo ldapSyncInfo={ldapSyncInfo} user={user} onUserSync={this.onUserSync} />
-              )}
+              {!config.auth.LDAPSkipOrgRoleSync &&
+                isLDAPUser &&
+                featureEnabled('ldapsync') &&
+                ldapSyncInfo &&
+                canReadLDAPStatus && (
+                  <UserLdapSyncInfo ldapSyncInfo={ldapSyncInfo} user={user} onUserSync={this.onUserSync} />
+                )}
               <UserPermissions isGrafanaAdmin={user.isGrafanaAdmin} onGrafanaAdminChange={this.onGrafanaAdminChange} />
             </>
           )}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
With https://github.com/grafana/grafana/pull/52160, we locked the UI because we had confused users, that wondered why their manually changed user roles were being reset.

This has the side effect of preventing users using LDAP from manually setting the organization and roles of their users even if they had no Group -> Organization Role mapping defined in their toml.

To solve this issue we had multiple options:
1. Add a new config option to skip org role sync (that applies to all ldap server configured).
2. Assume that no mapping defined in the ldap toml meant that admins expect to manage organization and roles manually.
3. Reuse the `active_sync_enabled` config option.

With 2, we could have an edge case with multiple ldap servers defined in the toml, some with groups, some without groups. In such a case, we'd have to make a call on locking/unlocking the UI. Unless we somehow manage to tell the frontend that a users has been logged in thanks to a groupless ldap config. This seemed like a hustle.

3, could be confusing to our users, since the configuration option targets the background synchronization of users but it doesn't mean that upon login, org roles shouldn't be reset.

In this PR we hence chose to go with 1.

With `skip_org_role_sync` off:
![before](https://user-images.githubusercontent.com/5232696/195057019-0dd4ab19-60f5-4b27-9e89-d996e1460ea2.gif)

With `skip_org_role_sync` on:
![after](https://user-images.githubusercontent.com/5232696/195057049-361ad787-26f2-4e40-9492-426c8c594e9a.gif)

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/55719

**Special notes for your reviewer**:

