### PR TITLE
CI: Remove `build-frontend-packages` step from docs pipelines

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -766,13 +766,6 @@ steps:
   - cd /hugo && make prod
   image: grafana/docs-base:latest
   name: build-docs-website
-- commands:
-  - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
-  depends_on: []
-  environment:
-    CGO_ENABLED: 0
-  image: golang:1.19.2
-  name: compile-build-cmd
 trigger:
   event:
   - pull_request
@@ -887,13 +880,6 @@ steps:
   - cd /hugo && make prod
   image: grafana/docs-base:latest
   name: build-docs-website
-- commands:
-  - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
-  depends_on: []
-  environment:
-    CGO_ENABLED: 0
-  image: golang:1.19.2
-  name: compile-build-cmd
 trigger:
   branch: main
   event:
@@ -5616,6 +5602,6 @@ kind: secret
 name: packages_secret_access_key
 ---
 kind: signature
-hmac: f91a8f7c107dc4c9248ecb85000d148f3489a77c42f4048be9ff35ba98589f60
+hmac: d5d39719ea023fdedb6cfa303ed2acac29fe23060c9679c0c40511b3cc215738
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -761,14 +761,6 @@ steps:
   image: grafana/build-container:1.6.3
   name: lint-docs
 - commands:
-  - ./bin/build build-frontend-packages --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
-  depends_on:
-  - yarn-install
-  environment:
-    NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.6.3
-  name: build-frontend-packages
-- commands:
   - mkdir -p /hugo/content/docs/grafana
   - cp -r docs/sources/* /hugo/content/docs/grafana/latest/
   - cd /hugo && make prod
@@ -889,14 +881,6 @@ steps:
     NODE_OPTIONS: --max_old_space_size=8192
   image: grafana/build-container:1.6.3
   name: lint-docs
-- commands:
-  - ./bin/build build-frontend-packages --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
-  depends_on:
-  - yarn-install
-  environment:
-    NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.6.3
-  name: build-frontend-packages
 - commands:
   - mkdir -p /hugo/content/docs/grafana
   - cp -r docs/sources/* /hugo/content/docs/grafana/latest/
@@ -5632,6 +5616,6 @@ kind: secret
 name: packages_secret_access_key
 ---
 kind: signature
-hmac: a8e4587efd7da775019ed2812c5980fb43fdb9ef5da50e2ac7e5c73151b6a685
+hmac: f91a8f7c107dc4c9248ecb85000d148f3489a77c42f4048be9ff35ba98589f60
 
 ...

--- a/scripts/drone/pipelines/docs.star
+++ b/scripts/drone/pipelines/docs.star
@@ -9,7 +9,6 @@ load(
     'test_frontend_step',
     'build_storybook_step',
     'build_docs_website_step',
-    'compile_build_cmd',
 )
 
 load(
@@ -40,7 +39,6 @@ def docs_pipelines(edition, ver_mode, trigger):
         codespell_step(),
         lint_docs(),
         build_docs_website_step(),
-        compile_build_cmd(),
     ]
 
     return pipeline(

--- a/scripts/drone/pipelines/docs.star
+++ b/scripts/drone/pipelines/docs.star
@@ -8,7 +8,6 @@ load(
     'codespell_step',
     'test_frontend_step',
     'build_storybook_step',
-    'build_frontend_package_step',
     'build_docs_website_step',
     'compile_build_cmd',
 )
@@ -40,7 +39,6 @@ def docs_pipelines(edition, ver_mode, trigger):
         yarn_install_step(),
         codespell_step(),
         lint_docs(),
-        build_frontend_package_step(edition=edition, ver_mode=ver_mode),
         build_docs_website_step(),
         compile_build_cmd(),
     ]


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes `build-frontend-packages` step from docs pipelines as it's not needed. `lint-docs` step should take care of the markdown files which exist there.

