### PR TITLE
CI: Remove `grabpl` dependency from `yarn-install`

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -79,8 +79,7 @@ steps:
   name: grabpl
 - commands:
   - yarn install --immutable
-  depends_on:
-  - grabpl
+  depends_on: []
   image: grafana/build-container:1.6.3
   name: yarn-install
 - commands:
@@ -352,8 +351,7 @@ steps:
   name: wire-install
 - commands:
   - yarn install --immutable
-  depends_on:
-  - grabpl
+  depends_on: []
   image: grafana/build-container:1.6.3
   name: yarn-install
 - commands:
@@ -420,6 +418,7 @@ steps:
 - commands:
   - ./bin/build build-frontend-packages --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
+  - compile-build-cmd
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
@@ -428,6 +427,7 @@ steps:
 - commands:
   - ./bin/build  build-plugins --jobs 8 --edition oss
   depends_on:
+  - compile-build-cmd
   - yarn-install
   environment: null
   image: grafana/build-container:1.6.3
@@ -736,8 +736,7 @@ steps:
   name: identify-runner
 - commands:
   - yarn install --immutable
-  depends_on:
-  - grabpl
+  depends_on: []
   image: grafana/build-container:1.6.3
   name: yarn-install
 - commands:
@@ -850,8 +849,7 @@ steps:
   name: identify-runner
 - commands:
   - yarn install --immutable
-  depends_on:
-  - grabpl
+  depends_on: []
   image: grafana/build-container:1.6.3
   name: yarn-install
 - commands:
@@ -922,8 +920,7 @@ steps:
   name: grabpl
 - commands:
   - yarn install --immutable
-  depends_on:
-  - grabpl
+  depends_on: []
   image: grafana/build-container:1.6.3
   name: yarn-install
 - commands:
@@ -1182,8 +1179,7 @@ steps:
   name: wire-install
 - commands:
   - yarn install --immutable
-  depends_on:
-  - grabpl
+  depends_on: []
   image: grafana/build-container:1.6.3
   name: yarn-install
 - commands:
@@ -1237,6 +1233,7 @@ steps:
 - commands:
   - ./bin/build build-frontend-packages --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
+  - compile-build-cmd
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
@@ -1245,6 +1242,7 @@ steps:
 - commands:
   - ./bin/build  build-plugins --jobs 8 --edition oss
   depends_on:
+  - compile-build-cmd
   - yarn-install
   environment:
     GRAFANA_API_KEY:
@@ -1958,8 +1956,7 @@ steps:
   name: wire-install
 - commands:
   - yarn install --immutable
-  depends_on:
-  - grabpl
+  depends_on: []
   image: grafana/build-container:1.6.3
   name: yarn-install
 - commands:
@@ -1988,6 +1985,7 @@ steps:
 - commands:
   - ./bin/build build-frontend-packages --jobs 8 --edition oss ${DRONE_TAG}
   depends_on:
+  - compile-build-cmd
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
@@ -1996,6 +1994,7 @@ steps:
 - commands:
   - ./bin/build  build-plugins --jobs 8 --edition oss
   depends_on:
+  - compile-build-cmd
   - yarn-install
   environment:
     GRAFANA_API_KEY:
@@ -2248,8 +2247,7 @@ steps:
   name: grabpl
 - commands:
   - yarn install --immutable
-  depends_on:
-  - grabpl
+  depends_on: []
   image: grafana/build-container:1.6.3
   name: yarn-install
 - commands:
@@ -2620,6 +2618,7 @@ steps:
 - commands:
   - ./bin/build build-frontend-packages --jobs 8 --edition enterprise ${DRONE_TAG}
   depends_on:
+  - compile-build-cmd
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
@@ -2628,6 +2627,7 @@ steps:
 - commands:
   - ./bin/build  build-plugins --jobs 8 --edition enterprise
   depends_on:
+  - compile-build-cmd
   - yarn-install
   environment:
     GRAFANA_API_KEY:
@@ -2919,7 +2919,7 @@ steps:
 - commands:
   - yarn install --immutable
   depends_on:
-  - grabpl
+  - init-enterprise
   image: grafana/build-container:1.6.3
   name: yarn-install
 - commands:
@@ -3731,8 +3731,7 @@ steps:
   name: grabpl
 - commands:
   - yarn install --immutable
-  depends_on:
-  - grabpl
+  depends_on: []
   image: grafana/build-container:1.6.3
   name: yarn-install
 - commands:
@@ -4029,8 +4028,7 @@ steps:
   name: wire-install
 - commands:
   - yarn install --immutable
-  depends_on:
-  - grabpl
+  depends_on: []
   image: grafana/build-container:1.6.3
   name: yarn-install
 - commands:
@@ -4059,6 +4057,7 @@ steps:
 - commands:
   - ./bin/build build-frontend-packages --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
+  - compile-build-cmd
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
@@ -4067,6 +4066,7 @@ steps:
 - commands:
   - ./bin/build  build-plugins --jobs 8 --edition oss
   depends_on:
+  - compile-build-cmd
   - yarn-install
   environment:
     GRAFANA_API_KEY:
@@ -4291,8 +4291,7 @@ steps:
   name: grabpl
 - commands:
   - yarn install --immutable
-  depends_on:
-  - grabpl
+  depends_on: []
   image: grafana/build-container:1.6.3
   name: yarn-install
 - commands:
@@ -4644,6 +4643,7 @@ steps:
 - commands:
   - ./bin/build build-frontend-packages --jobs 8 --edition enterprise --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
+  - compile-build-cmd
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
@@ -4652,6 +4652,7 @@ steps:
 - commands:
   - ./bin/build  build-plugins --jobs 8 --edition enterprise
   depends_on:
+  - compile-build-cmd
   - yarn-install
   environment:
     GRAFANA_API_KEY:
@@ -4935,7 +4936,7 @@ steps:
 - commands:
   - yarn install --immutable
   depends_on:
-  - grabpl
+  - init-enterprise
   image: grafana/build-container:1.6.3
   name: yarn-install
 - commands:
@@ -5602,6 +5603,6 @@ kind: secret
 name: packages_secret_access_key
 ---
 kind: signature
-hmac: d5d39719ea023fdedb6cfa303ed2acac29fe23060c9679c0c40511b3cc215738
+hmac: b4e9ae069d6557aeb32126291f2b06a1a0df3311e609acbe0d3c3810f1606312
 
 ...

--- a/scripts/drone/events/release.star
+++ b/scripts/drone/events/release.star
@@ -308,7 +308,7 @@ def get_enterprise_pipelines(trigger, ver_mode):
         ]
     }
 
-    for step in [wire_install_step(), yarn_install_step(), verify_gen_cue_step(edition)]:
+    for step in [wire_install_step(), yarn_install_step(edition), verify_gen_cue_step(edition)]:
         step.update(deps_on_clone_enterprise_step)
         init_steps.extend([step])
 

--- a/scripts/drone/pipelines/test_frontend.star
+++ b/scripts/drone/pipelines/test_frontend.star
@@ -22,7 +22,7 @@ def test_frontend(trigger, ver_mode, edition="oss"):
     init_steps.extend([
         identify_runner_step(),
         download_grabpl_step(),
-        yarn_install_step(),
+        yarn_install_step(edition),
     ])
     test_steps = [
         betterer_frontend_step(edition),

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -36,16 +36,17 @@ def slack_step(channel, template, secret):
         },
     }
 
-def yarn_install_step():
+def yarn_install_step(edition="oss"):
+    deps = []
+    if edition == 'enterprise':
+        deps = ['init-enterprise']
     return {
         'name': 'yarn-install',
         'image': build_image,
         'commands': [
             'yarn install --immutable',
         ],
-        'depends_on': [
-            'grabpl',
-        ],
+        'depends_on': deps,
     }
 
 
@@ -449,6 +450,7 @@ def build_frontend_package_step(edition, ver_mode):
             'NODE_OPTIONS': '--max_old_space_size=8192',
         },
         'depends_on': [
+            'compile-build-cmd',
             'yarn-install',
         ],
         'commands': cmds,
@@ -467,6 +469,7 @@ def build_plugins_step(edition, ver_mode):
         'image': build_image,
         'environment': env,
         'depends_on': [
+            'compile-build-cmd',
             'yarn-install',
         ],
         'commands': [


### PR DESCRIPTION
**What this PR does / why we need it**:

`yarn-install` has no longer to do anything with `grabpl` after we moved the specific parts of the code that were needed in the past. We can safely remove it from `yarn-install` step's dependencies and add a conditional `init-enterprise` dependency.