### PR TITLE
chore: bump code coverage action version

### DIFF
--- a/.github/workflows/cloud-data-sources-code-coverage.yml
+++ b/.github/workflows/cloud-data-sources-code-coverage.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   workflow-call:
-    uses: grafana/code-coverage/.github/workflows/code-coverage.yml@v0.1.11
+    uses: grafana/code-coverage/.github/workflows/code-coverage.yml@v0.1.12
     with:
       frontend-path-regexp: public\/app\/plugins\/datasource\/(grafana-azure-monitor-datasource|cloud-monitoring|cloudwatch)
       backend-path-regexp: pkg\/tsdb\/(azuremonitor|cloudmonitoring|cloudwatch)

--- a/.github/workflows/ox-code-coverage.yml
+++ b/.github/workflows/ox-code-coverage.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   workflow-call:
-    uses: grafana/code-coverage/.github/workflows/code-coverage.yml@v0.1.11
+    uses: grafana/code-coverage/.github/workflows/code-coverage.yml@v0.1.12
     with:
       frontend-path-regexp: public\/app\/features\/(explore|correlations)
       backend-path-regexp: pkg\/services\/(queryhistory)


### PR DESCRIPTION
bumps `grafana/code-coverage` workflow to `v0.1.12`