### PR TITLE
Auth: Log a more useful msg if no OAuth provider configured

### DIFF
--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -154,8 +154,11 @@ func (hs *HTTPServer) tryOAuthAutoLogin(c *models.ReqContext) bool {
 		return false
 	}
 	oauthInfos := hs.SocialService.GetOAuthInfoProviders()
-	if len(oauthInfos) != 1 {
+	if len(oauthInfos) > 1 {
 		c.Logger.Warn("Skipping OAuth auto login because multiple OAuth providers are configured")
+		return false
+	} else if len(oauthInfos) == 0 {
+		c.Logger.Warn("Skipping OAuth auto login because no OAuth providers are configured")
 		return false
 	}
 	for key := range oauthInfos {


### PR DESCRIPTION
When a user doesn't configure an OAuth provider and uses auto login, Grafana currently logs a misleading message indicating that he has multiple providers configured instead.