### PR TITLE
Default to flame graph

### DIFF
--- a/public/app/features/explore/AddToDashboard/addToDashboard.test.ts
+++ b/public/app/features/explore/AddToDashboard/addToDashboard.test.ts
@@ -110,11 +110,12 @@ describe('addPanelToDashboard', () => {
         expectedPanel: string;
       };
       it.each`
-        framesType           | expectedPanel
-        ${'logsFrames'}      | ${'logs'}
-        ${'graphFrames'}     | ${'timeseries'}
-        ${'nodeGraphFrames'} | ${'nodeGraph'}
-        ${'traceFrames'}     | ${'traces'}
+        framesType            | expectedPanel
+        ${'logsFrames'}       | ${'logs'}
+        ${'graphFrames'}      | ${'timeseries'}
+        ${'nodeGraphFrames'}  | ${'nodeGraph'}
+        ${'flameGraphFrames'} | ${'flamegraph'}
+        ${'traceFrames'}      | ${'traces'}
       `(
         'Sets visualization to $expectedPanel if there are $frameType frames',
         async ({ framesType, expectedPanel }: TestArgs) => {

--- a/public/app/features/explore/AddToDashboard/addToDashboard.ts
+++ b/public/app/features/explore/AddToDashboard/addToDashboard.ts
@@ -63,8 +63,10 @@ const hasRefId = (refId: DataFrame['refId']) => (frame: DataFrame) => frame.refI
 
 function getPanelType(queries: DataQuery[], queryResponse: ExplorePanelData) {
   for (const { refId } of queries.filter(isVisible)) {
-    // traceview is not supported in dashboards, skipping it for now.
     const hasQueryRefId = hasRefId(refId);
+    if (queryResponse.flameGraphFrames.some(hasQueryRefId)) {
+      return 'flamegraph';
+    }
     if (queryResponse.graphFrames.some(hasQueryRefId)) {
       return 'timeseries';
     }


### PR DESCRIPTION
**What this PR does / why we need it**:

Default to flame graph when going from explore to dashboard.