### PR TITLE
Docs: Add CODEOWNER to setup docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,6 +30,7 @@
 /docs/sources/old-alerting @brendamuir
 /docs/sources/panels/ @chri2547
 /docs/sources/release-notes/ @gguillotte-grafana
+/docs/sources/setup-grafana/ @chri2547
 /docs/sources/visualization/ @chri2547
 /docs/sources/whatsnew/ @gguillotte-grafana
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Set @chri2547 as the CODEOWNER of the setup docs so PRs get assigned appropriately.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

N/A