### PR TITLE
Docs: Remove Beta tag from 9.2 What's New post-release

### DIFF
--- a/docs/sources/whatsnew/whats-new-in-v9-2.md
+++ b/docs/sources/whatsnew/whats-new-in-v9-2.md
@@ -14,7 +14,7 @@ title: What's new in Grafana v9.2
 weight: -33
 ---
 
-# What's new in Grafana v9.2 (Beta)
+# What's new in Grafana v9.2
 
 Welcome to Grafana v9.2, a hefty minor release with a swath of improvements that help you create and share dashboards and alerts.
 Read on to learn about progress on public dashboards, our new panel help menu, custom branding in Grafana Enterprise, and improvements to access control.


### PR DESCRIPTION
**What this PR does / why we need it**:

Grafana v9.2 has shipped. Remove the Beta tag from the v9.2 What's New.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

N/A