### PR TITLE
Docs: Add missing documentation for enterprise features (#56753)

### DIFF
--- a/docs/sources/enterprise/_index.md
+++ b/docs/sources/enterprise/_index.md
@@ -54,6 +54,10 @@ With [enhanced LDAP integration]({{< relref "../setup-grafana/configure-security
 
 [SAML authentication]({{< relref "../setup-grafana/configure-security/configure-authentication/saml/" >}}) enables users to authenticate with single sign-on services that use Security Assertion Markup Language (SAML).
 
+### Protected roles
+
+With [protected roles]({{< relref "../setup-grafana/configure-security/configure-authentication/#protected-roles" >}}), you can define user roles that are exempt from being converted from one authentication type to another when changing auth providers.
+
 ## Enterprise features
 
 Grafana Enterprise adds the following features:
@@ -65,10 +69,11 @@ Grafana Enterprise adds the following features:
 - [Export dashboard as PDF]({{< relref "export-pdf/" >}})
 - [Custom branding]({{< relref "../setup-grafana/configure-grafana/configure-custom-branding/" >}}) to customize Grafana from the brand and logo to the footer links.
 - [Usage insights]({{< relref "usage-insights/" >}}) to understand how your Grafana instance is used.
+- [Recorded queries]({{< relref "recorded-queries" >}}) to see trends over time for your data sources.
 - [Vault integration]({{< relref "../setup-grafana/configure-security/configure-database-encryption/integrate-with-hashicorp-vault/" >}}) to manage your configuration or provisioning secrets with Vault.
 - [Auditing]({{< relref "../setup-grafana/configure-security/audit-grafana/" >}}) tracks important changes to your Grafana instance to help you manage and mitigate suspicious activity and meet compliance requirements.
 - [Request security]({{< relref "../setup-grafana/configure-security/configure-request-security/" >}}) makes it possible to restrict outgoing requests from the Grafana server.
-- [Settings updates at runtime]({{< relref "settings-updates/" >}}) allows you to update Grafana settings at runtime without requiring a restart.
+- [Settings updates at runtime]({{< relref "settings-updates" >}}) allows you to update Grafana settings at runtime without requiring a restart.
 
 ## Enterprise data sources
 

--- a/docs/sources/introduction/grafana-enterprise.md
+++ b/docs/sources/introduction/grafana-enterprise.md
@@ -45,6 +45,10 @@ With [enhanced LDAP integration]({{< relref "../setup-grafana/configure-security
 
 [SAML authentication]({{< relref "../setup-grafana/configure-security/configure-authentication/saml/" >}}) enables users to authenticate with single sign-on services that use Security Assertion Markup Language (SAML).
 
+### Protected roles
+
+With [protected roles]({{< relref "../setup-grafana/configure-security/configure-authentication/#protected-roles" >}}), you can define user roles that are exempt from being converted from one authentication type to another when changing auth providers.
+
 ## Enterprise features
 
 Grafana Enterprise adds the following features:
@@ -56,6 +60,7 @@ Grafana Enterprise adds the following features:
 - [Export dashboard as PDF]({{< relref "../enterprise/export-pdf.md" >}})
 - [Custom branding]({{< relref "../setup-grafana/configure-grafana/configure-custom-branding/" >}}) to customize Grafana from the brand and logo to the footer links.
 - [Usage insights]({{< relref "../enterprise/usage-insights/" >}}) to understand how your Grafana instance is used.
+- [Recorded queries]({{< relref "../enterprise/recorded-queries" >}}) to see trends over time for your data sources.
 - [Vault integration]({{< relref "../setup-grafana/configure-security/configure-database-encryption/encrypt-secrets-using-hashicorp-key-vault/" >}}) to manage your configuration or provisioning secrets with Vault.
 - [Auditing]({{< relref "../setup-grafana/configure-security/audit-grafana/" >}}) tracks important changes to your Grafana instance to help you manage and mitigate suspicious activity and meet compliance requirements.
 - [Request security]({{< relref "../setup-grafana/configure-security/configure-request-security/" >}}) makes it possible to restrict outgoing requests from the Grafana server.

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/_index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/_index.md
@@ -148,3 +148,18 @@ URL to redirect the user to after signing out from Grafana. This can for example
 [auth]
 signout_redirect_url =
 ```
+
+### Protected roles
+
+> **Note:** Available in [Grafana Enterprise]({{< relref "../../../introduction/grafana-enterprise/" >}}) and [Grafana Cloud Advanced]({{< ref "../../../introduction/grafana-cloud" >}}).
+
+By default, after you configure an authorization provider, Grafana will adopt existing users into the new authentication scheme. For example, if you have created a user with basic authentication having the login `jsmith@example.com`, then set up SAML authentication where `jsmith@example.com` is an account, the user's authentication type will be changed to SAML if if they perform a SAML sign-in.
+
+You can disable this user adoption for certain roles using the `protected_roles` property:
+
+```bash
+[auth.security]
+protected_roles = server_admins org_admins
+```
+
+The value of `protected_roles` should be a list of roles to protect, separated by spaces. Valid roles are `viewers`, `editors`, `org_admins`, `server_admins`, and `all` (a superset of the other roles).

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/grafana.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/grafana.md
@@ -123,3 +123,18 @@ URL to redirect the user to after signing out from Grafana. This can for example
 [auth]
 signout_redirect_url =
 ```
+
+### Protected roles
+
+> **Note:** Available in [Grafana Enterprise]({{< relref "../../../introduction/grafana-enterprise" >}}) and [Grafana Cloud Advanced]({{< relref "../../../introduction/grafana-cloud" >}}).
+
+By default, after you configure an authorization provider, Grafana will adopt existing users into the new authentication scheme. For example, if you have created a user with basic authentication having the login `jsmith@example.com`, then set up SAML authentication where `jsmith@example.com` is an account, the user's authentication type will be changed to SAML if if they perform a SAML sign-in.
+
+You can disable this user adoption for certain roles using the `protected_roles` property:
+
+```bash
+[auth.security]
+protected_roles = server_admins org_admins
+```
+
+The value of `protected_roles` should be a list of roles to protect, separated by spaces. Valid roles are `viewers`, `editors`, `org_admins`, `server_admins`, and `all` (a superset of the other roles).

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/ldap.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/ldap.md
@@ -115,6 +115,10 @@ To use the debug view:
 
 {{< figure src="/static/img/docs/ldap_debug_mapping_testing.png" class="docs-image--no-shadow" max-width="600px" >}}
 
+[Grafana Enterprise]({{< relref "../../../introduction/grafana-enterprise" >}}) users with [enhanced LDAP integration]({{< relref "enhanced_ldap" >}}) enabled can also see sync status in the debug view. This requires the `ldap.status:read` permission.
+
+{{< figure src="/static/img/docs/ldap_sync_debug.png" class="docs-image--no-shadow" max-width="600px" >}}
+
 ### Bind
 
 #### Bind and Bind Password


### PR DESCRIPTION
**What this PR does / why we need it**:
Manual backport of https://github.com/grafana/grafana/pull/56753

* add documentation about protected roles

* add section about sync debug

* add link to recorded queries to main enterprise pages

* Update docs/sources/setup-grafana/configure-security/configure-authentication/ldap.md

Co-authored-by: Eve Meelan <81647476+Eve832@users.noreply.github.com>

* fixes from pr review

* add missing char

* Apply suggestions from code review

Co-authored-by: Eve Meelan <81647476+Eve832@users.noreply.github.com>

* fix other incorrect lines to match review

Co-authored-by: Eve Meelan <81647476+Eve832@users.noreply.github.com>
(cherry picked from commit 6827ca01a06e7210cf9c41c8b773553220f1f180)


