### PR TITLE
Alerting: Fix email image embedding on Windows.

### DIFF
--- a/pkg/services/ngalert/notifier/channels/email.go
+++ b/pkg/services/ngalert/notifier/channels/email.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"path/filepath"
 
 	"github.com/prometheus/alertmanager/template"
 	"github.com/prometheus/alertmanager/types"
@@ -116,7 +117,7 @@ func (en *EmailNotifier) Notify(ctx context.Context, alerts ...*types.Alert) (bo
 			} else if len(image.Path) != 0 {
 				_, err := os.Stat(image.Path)
 				if err == nil {
-					data.Alerts[index].EmbeddedImage = path.Base(image.Path)
+					data.Alerts[index].EmbeddedImage = filepath.Base(image.Path)
 					embeddedFiles = append(embeddedFiles, image.Path)
 				} else {
 					en.log.Warn("failed to get image file for email attachment", "file", image.Path, "err", err)


### PR DESCRIPTION
The email notifier was incorrectly handling Windows filepaths. This is fixed by using the `path/filepath` package.

**Special notes for your reviewer**: I have not yet tested the build directly on windows. I'm working on massaging the build scripts to let me do that easily outside of the CI job.

