### PR TITLE
Devenv: Fix InfluxDB Templated dashboard

### DIFF
--- a/devenv/dev-dashboards/datasource-influxdb/influxdb-templated.json
+++ b/devenv/dev-dashboards/datasource-influxdb/influxdb-templated.json
@@ -292,7 +292,7 @@
         "type": "interval"
       },
       {
-        "datasource": "InfluxDB",
+        "datasource": "gdev-influxdb1-influxql",
         "filters": [],
         "hide": 0,
         "label": null,


### PR DESCRIPTION
**What this PR does / why we need it**:
In InfluxDB Templated dashboard, for ad hoc filters we've had the old data source name that doesn't exist anymore. This PR fixes it and uses the gdev-influxdb1-influxql datasource as rest of this dashboard. 

**Special notes for your reviewer**:

On main branch:
1. Run `make devenv sources=influxdb1`
2. Go to Grafana and open `InfluxDB Templated` dashboard
3. Go to variables and open `adhoc` variable
4. See that it says `InfluxDB not found` 
5. If you manually change it to `gdev-influxdb1-influxql` ad hoc filters work
6. 
<img width="1139" alt="image" src="https://user-images.githubusercontent.com/30407135/195291966-27dfc072-7970-4b5a-ba85-57218fb3108e.png">
<img width="891" alt="image" src="https://user-images.githubusercontent.com/30407135/195291898-4b90531e-5e72-4457-8bbe-8e346289b661.png">


Switch branch to this one:
1. Run `cd devenv` ` ./setup.sh ` 
2. Go to Grafana and open `InfluxDB Templated` dashboard
3. Adhoc filters work as expected
<img width="1381" alt="image" src="https://user-images.githubusercontent.com/30407135/195291533-041f1f8f-5e5d-47cf-a7d3-7e29abcb5b57.png">
<img width="1062" alt="image" src="https://user-images.githubusercontent.com/30407135/195291582-dfc5fe0c-b200-48d8-9efa-123dcca08431.png">



