### PR TITLE
Docs: Fix typo in user protection section

### DIFF
--- a/docs/sources/setup-grafana/configure-security/configure-authentication/_index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/_index.md
@@ -153,7 +153,7 @@ signout_redirect_url =
 
 > **Note:** Available in [Grafana Enterprise]({{< relref "../../../introduction/grafana-enterprise/" >}}) and [Grafana Cloud Advanced]({{< ref "../../../introduction/grafana-cloud" >}}).
 
-By default, after you configure an authorization provider, Grafana will adopt existing users into the new authentication scheme. For example, if you have created a user with basic authentication having the login `jsmith@example.com`, then set up SAML authentication where `jsmith@example.com` is an account, the user's authentication type will be changed to SAML if if they perform a SAML sign-in.
+By default, after you configure an authorization provider, Grafana will adopt existing users into the new authentication scheme. For example, if you have created a user with basic authentication having the login `jsmith@example.com`, then set up SAML authentication where `jsmith@example.com` is an account, the user's authentication type will be changed to SAML if they perform a SAML sign-in.
 
 You can disable this user adoption for certain roles using the `protected_roles` property:
 

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/grafana.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/grafana.md
@@ -128,7 +128,7 @@ signout_redirect_url =
 
 > **Note:** Available in [Grafana Enterprise]({{< relref "../../../introduction/grafana-enterprise" >}}) and [Grafana Cloud Advanced]({{< relref "../../../introduction/grafana-cloud" >}}).
 
-By default, after you configure an authorization provider, Grafana will adopt existing users into the new authentication scheme. For example, if you have created a user with basic authentication having the login `jsmith@example.com`, then set up SAML authentication where `jsmith@example.com` is an account, the user's authentication type will be changed to SAML if if they perform a SAML sign-in.
+By default, after you configure an authorization provider, Grafana will adopt existing users into the new authentication scheme. For example, if you have created a user with basic authentication having the login `jsmith@example.com`, then set up SAML authentication where `jsmith@example.com` is an account, the user's authentication type will be changed to SAML if they perform a SAML sign-in.
 
 You can disable this user adoption for certain roles using the `protected_roles` property:
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a typo from recent PR.
