### PR TITLE
Explore: Remove camel case from tracking labels

### DIFF
--- a/public/app/AppWrapper.tsx
+++ b/public/app/AppWrapper.tsx
@@ -105,7 +105,7 @@ export class AppWrapper extends React.Component<AppWrapperProps, AppWrapperState
     navigationLogger('AppWrapper', false, 'rendering');
 
     const commandPaletteActionSelected = (action: Action) => {
-      reportInteraction('commandPalette_action_selected', {
+      reportInteraction('command_palette_action_selected', {
         actionId: action.id,
         actionName: action.name,
       });

--- a/public/app/features/commandPalette/CommandPalette.tsx
+++ b/public/app/features/commandPalette/CommandPalette.tsx
@@ -55,7 +55,7 @@ export const CommandPalette = () => {
 
   useEffect(() => {
     if (showing) {
-      reportInteraction('commandPalette_opened');
+      reportInteraction('command_palette_opened');
 
       // Do dashboard search on demand
       getDashboardNavActions('go/dashboard').then((dashAct) => {

--- a/public/app/features/explore/AddToDashboard/AddToDashboardModal.tsx
+++ b/public/app/features/explore/AddToDashboard/AddToDashboardModal.tsx
@@ -97,7 +97,7 @@ export const AddToDashboardModal = ({ onClose, exploreId }: Props) => {
     setSubmissionError(undefined);
     const dashboardUid = data.saveTarget === SaveTarget.ExistingDashboard ? data.dashboardUid : undefined;
 
-    reportInteraction('e2d_submit', {
+    reportInteraction('e_2_d_submit', {
       newTab: openInNewTab,
       saveTarget: data.saveTarget,
       queries: exploreItem.queries.length,
@@ -144,7 +144,7 @@ export const AddToDashboardModal = ({ onClose, exploreId }: Props) => {
   };
 
   useEffect(() => {
-    reportInteraction('e2d_open');
+    reportInteraction('e_2_d_open');
   }, []);
 
   return (

--- a/public/app/features/explore/ExploreToolbar.tsx
+++ b/public/app/features/explore/ExploreToolbar.tsx
@@ -77,13 +77,13 @@ class UnConnectedExploreToolbar extends PureComponent<Props> {
   onOpenSplitView = () => {
     const { split } = this.props;
     split();
-    reportInteraction('grafana_explore_splitView_opened');
+    reportInteraction('grafana_explore_split_view_opened');
   };
 
   onCloseSplitView = () => {
     const { closeSplit, exploreId } = this.props;
     closeSplit(exploreId);
-    reportInteraction('grafana_explore_splitView_closed');
+    reportInteraction('grafana_explore_split_view_closed');
   };
 
   renderRefreshPicker = (showSmallTimePicker: boolean) => {


### PR DESCRIPTION
Adds to #52231

**Reason for changes:**
Tracking labels which contain camel case are being transferred to snake case while being saved. So the query has to contain the snake case version of the label.
In order to avoid confusion I adjusted affected labels. 

