### PR TITLE
LogContext: Change line highlighting to match the hover state

### DIFF
--- a/public/app/features/logs/components/LogRow.tsx
+++ b/public/app/features/logs/components/LogRow.tsx
@@ -166,6 +166,7 @@ class UnThemedLogRow extends PureComponent<Props, State> {
     const { errorMessage, hasError } = checkLogsError(row);
     const logRowBackground = cx(style.logsRow, {
       [styles.errorLogRow]: hasError,
+      [style.contextBackground]: showContext,
     });
 
     const processedRow =

--- a/public/app/features/logs/components/LogRowMessage.tsx
+++ b/public/app/features/logs/components/LogRowMessage.tsx
@@ -173,7 +173,8 @@ class UnThemedLogRowMessage extends PureComponent<Props> {
           <div
             className={cx(
               { [styles.positionRelative]: wrapLogMessage },
-              { [styles.horizontalScroll]: !wrapLogMessage }
+              { [styles.horizontalScroll]: !wrapLogMessage },
+              { [styles.rowWithContext]: contextIsOpen }
             )}
           >
             {contextIsOpen && context && (
@@ -192,7 +193,7 @@ class UnThemedLogRowMessage extends PureComponent<Props> {
                 }}
               />
             )}
-            <span className={cx(styles.positionRelative, { [styles.rowWithContext]: contextIsOpen })}>
+            <span className={cx(styles.positionRelative)}>
               {renderLogMessage(hasAnsi, restructuredEntry, row.searchWords, style.logsRowMatchHighLight)}
             </span>
           </div>

--- a/public/app/features/logs/components/LogRowMessage.tsx
+++ b/public/app/features/logs/components/LogRowMessage.tsx
@@ -44,6 +44,7 @@ const getStyles = (theme: GrafanaTheme2, showContextButton: boolean, isInDashboa
       label: rowWithContext;
       z-index: 1;
       outline: 9999px solid ${outlineColor};
+      display: inherit;
     `,
     horizontalScroll: css`
       label: verticalScroll;
@@ -173,8 +174,7 @@ class UnThemedLogRowMessage extends PureComponent<Props> {
           <div
             className={cx(
               { [styles.positionRelative]: wrapLogMessage },
-              { [styles.horizontalScroll]: !wrapLogMessage },
-              { [styles.rowWithContext]: contextIsOpen }
+              { [styles.horizontalScroll]: !wrapLogMessage }
             )}
           >
             {contextIsOpen && context && (
@@ -193,7 +193,7 @@ class UnThemedLogRowMessage extends PureComponent<Props> {
                 }}
               />
             )}
-            <span className={cx(styles.positionRelative)}>
+            <span className={cx(styles.positionRelative, { [styles.rowWithContext]: contextIsOpen })}>
               {renderLogMessage(hasAnsi, restructuredEntry, row.searchWords, style.logsRowMatchHighLight)}
             </span>
           </div>

--- a/public/app/features/logs/components/getLogRowStyles.ts
+++ b/public/app/features/logs/components/getLogRowStyles.ts
@@ -45,6 +45,9 @@ export const getLogRowStyles = (theme: GrafanaTheme2, logLevel?: LogLevel) => {
       font-size: ${theme.typography.bodySmall.fontSize};
       width: 100%;
     `,
+    contextBackground: css`
+      background: ${hoverBgColor};
+    `,
     logsRow: css`
       label: logs-row;
       width: 100%;
@@ -56,6 +59,8 @@ export const getLogRowStyles = (theme: GrafanaTheme2, logLevel?: LogLevel) => {
           visibility: visible;
           z-index: 1;
         }
+
+        background: ${hoverBgColor};
       }
 
       td:not(.log-row-menu-cell):last-child {
@@ -68,10 +73,6 @@ export const getLogRowStyles = (theme: GrafanaTheme2, logLevel?: LogLevel) => {
         border-top: 1px solid transparent;
         border-bottom: 1px solid transparent;
         height: 100%;
-      }
-
-      &:hover {
-        background: ${hoverBgColor};
       }
     `,
     logsRowDuplicates: css`


### PR DESCRIPTION
**What this PR does / why we need it**:

Log lines with an open context should be better visible to the user. This PR sets the same background color to loglines with an open context as if they were hovered.

**Which issue(s) this PR fixes**:

Fixes #56384

**Special notes for your reviewer**:

Before:
![image](https://user-images.githubusercontent.com/8092184/195362598-81d98d95-efc8-4e05-b01f-f414a09b52a3.png)

Now: 
![image](https://user-images.githubusercontent.com/8092184/195381278-80bc1956-1a2e-4cae-b158-ba12b97e0653.png)
