### PR TITLE
RBAC: Improve performance of dashboard filter query

### DIFF
--- a/pkg/services/accesscontrol/database/database.go
+++ b/pkg/services/accesscontrol/database/database.go
@@ -9,10 +9,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 )
 
-const (
-	globalOrgID = 0
-)
-
 func ProvideService(sql db.DB) *AccessControlStore {
 	return &AccessControlStore{sql}
 }

--- a/pkg/services/accesscontrol/database/database.go
+++ b/pkg/services/accesscontrol/database/database.go
@@ -29,7 +29,7 @@ func (s *AccessControlStore) GetUserPermissions(ctx context.Context, query acces
 			return nil
 		}
 
-		filter, params := userRolesFilter(query.OrgID, query.UserID, query.TeamIDs, query.Roles)
+		filter, params := accesscontrol.UserRolesFilter(query.OrgID, query.UserID, query.TeamIDs, query.Roles)
 
 		q := `
 		SELECT
@@ -57,57 +57,6 @@ func (s *AccessControlStore) GetUserPermissions(ctx context.Context, query acces
 	})
 
 	return result, err
-}
-
-func userRolesFilter(orgID, userID int64, teamIDs []int64, roles []string) (string, []interface{}) {
-	var params []interface{}
-	builder := strings.Builder{}
-
-	// This is an additional security. We should never have permissions granted to userID 0.
-	// Only allow real users to get user/team permissions (anonymous/apikeys)
-	if userID > 0 {
-		builder.WriteString(`
-			SELECT ur.role_id
-			FROM user_role AS ur
-			WHERE ur.user_id = ?
-			AND (ur.org_id = ? OR ur.org_id = ?)
-		`)
-		params = []interface{}{userID, orgID, globalOrgID}
-	}
-
-	if len(teamIDs) > 0 {
-		if builder.Len() > 0 {
-			builder.WriteString("UNION")
-		}
-		builder.WriteString(`
-			SELECT tr.role_id FROM team_role as tr
-			WHERE tr.team_id IN(?` + strings.Repeat(", ?", len(teamIDs)-1) + `)
-			AND tr.org_id = ?
-		`)
-		for _, id := range teamIDs {
-			params = append(params, id)
-		}
-		params = append(params, orgID)
-	}
-
-	if len(roles) != 0 {
-		if builder.Len() > 0 {
-			builder.WriteString("UNION")
-		}
-
-		builder.WriteString(`
-			SELECT br.role_id FROM builtin_role AS br
-			WHERE br.role IN (?` + strings.Repeat(", ?", len(roles)-1) + `)
-			AND (br.org_id = ? OR br.org_id = ?)
-		`)
-		for _, role := range roles {
-			params = append(params, role)
-		}
-
-		params = append(params, orgID, globalOrgID)
-	}
-
-	return "INNER JOIN (" + builder.String() + ") as all_role ON role.id = all_role.role_id", params
 }
 
 func (s *AccessControlStore) DeleteUserPermissions(ctx context.Context, orgID, userID int64) error {

--- a/pkg/services/annotations/annotationsimpl/xorm_store_test.go
+++ b/pkg/services/annotations/annotationsimpl/xorm_store_test.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -407,6 +409,7 @@ func TestIntegrationAnnotationListingWithRBAC(t *testing.T) {
 		t.Skip("skipping integration test")
 	}
 	sql := db.InitTestDB(t)
+
 	var maximumTagsLength int64 = 60
 	repo := xormRepositoryImpl{db: sql, cfg: setting.NewCfg(), log: log.New("annotation.test"), tagService: tagimpl.ProvideService(sql, sql.Cfg), maximumTagsLength: maximumTagsLength}
 	dashboardStore := dashboardstore.ProvideDashboardStore(sql, sql.Cfg, featuremgmt.WithFeatures(), tagimpl.ProvideService(sql, sql.Cfg))
@@ -459,6 +462,7 @@ func TestIntegrationAnnotationListingWithRBAC(t *testing.T) {
 		UserID: 1,
 		OrgID:  1,
 	}
+	role := setupRBACRole(t, repo, user)
 
 	type testStruct struct {
 		description           string
@@ -519,6 +523,8 @@ func TestIntegrationAnnotationListingWithRBAC(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
 			user.Permissions = map[int64]map[string][]string{1: tc.permissions}
+			setupRBACPermission(t, repo, role, user)
+
 			results, err := repo.Get(context.Background(), &annotations.ItemQuery{
 				OrgId:        1,
 				SignedInUser: user,
@@ -534,4 +540,63 @@ func TestIntegrationAnnotationListingWithRBAC(t *testing.T) {
 			}
 		})
 	}
+}
+
+func setupRBACRole(t *testing.T, repo xormRepositoryImpl, user *user.SignedInUser) *accesscontrol.Role {
+	t.Helper()
+	var role *accesscontrol.Role
+	err := repo.db.WithDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
+		role = &accesscontrol.Role{
+			OrgID:   user.OrgID,
+			UID:     "test_role",
+			Name:    "test:role",
+			Updated: time.Now(),
+			Created: time.Now(),
+		}
+		_, err := sess.Insert(role)
+		if err != nil {
+			return err
+		}
+
+		_, err = sess.Insert(accesscontrol.UserRole{
+			OrgID:   role.OrgID,
+			RoleID:  role.ID,
+			UserID:  user.UserID,
+			Created: time.Now(),
+		})
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+
+	require.NoError(t, err)
+	return role
+}
+
+func setupRBACPermission(t *testing.T, repo xormRepositoryImpl, role *accesscontrol.Role, user *user.SignedInUser) {
+	t.Helper()
+	err := repo.db.WithDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
+
+		if _, err := sess.Exec("DELETE FROM permission WHERE role_id = ?", role.ID); err != nil {
+			return err
+		}
+
+		var acPermission []accesscontrol.Permission
+		for action, scopes := range user.Permissions[user.OrgID] {
+			for _, scope := range scopes {
+				acPermission = append(acPermission, accesscontrol.Permission{
+					RoleID: role.ID, Action: action, Scope: scope, Created: time.Now(), Updated: time.Now(),
+				})
+			}
+		}
+
+		if _, err := sess.InsertMulti(&acPermission); err != nil {
+			return err
+		}
+
+		return nil
+	})
+
+	require.NoError(t, err)
 }

--- a/pkg/services/annotations/annotationsimpl/xorm_store_test.go
+++ b/pkg/services/annotations/annotationsimpl/xorm_store_test.go
@@ -415,8 +415,9 @@ func TestIntegrationAnnotationListingWithRBAC(t *testing.T) {
 	dashboardStore := dashboardstore.ProvideDashboardStore(sql, sql.Cfg, featuremgmt.WithFeatures(), tagimpl.ProvideService(sql, sql.Cfg))
 
 	testDashboard1 := models.SaveDashboardCommand{
-		UserId: 1,
-		OrgId:  1,
+		UserId:   1,
+		OrgId:    1,
+		IsFolder: false,
 		Dashboard: simplejson.NewFromAny(map[string]interface{}{
 			"title": "Dashboard 1",
 		}),

--- a/pkg/services/annotations/annotationsimpl/xorm_store_test.go
+++ b/pkg/services/annotations/annotationsimpl/xorm_store_test.go
@@ -577,7 +577,6 @@ func setupRBACRole(t *testing.T, repo xormRepositoryImpl, user *user.SignedInUse
 func setupRBACPermission(t *testing.T, repo xormRepositoryImpl, role *accesscontrol.Role, user *user.SignedInUser) {
 	t.Helper()
 	err := repo.db.WithDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
-
 		if _, err := sess.Exec("DELETE FROM permission WHERE role_id = ?", role.ID); err != nil {
 			return err
 		}

--- a/pkg/services/sqlstore/permissions/dashboard.go
+++ b/pkg/services/sqlstore/permissions/dashboard.go
@@ -133,13 +133,13 @@ func (f AccessControlDashboardPermissionFilter) Where() (string, []interface{}) 
 		}
 
 		if len(actionsToCheck) > 0 {
-			builder.WriteString("(dashboard.uid IN (SELECT substr(scope, 16) FROM permission WHERE action IN (?" + strings.Repeat(", ?", len(actionsToCheck)-1) + ") AND scope LIKE 'dashboards:uid:%' " + rolesFilter + " GROUP BY role_id, scope HAVING COUNT(scope) = ?) AND NOT dashboard.is_folder)")
+			builder.WriteString("(dashboard.uid IN (SELECT substr(scope, 16) FROM permission WHERE action IN (?" + strings.Repeat(", ?", len(actionsToCheck)-1) + ") AND scope LIKE 'dashboards:uid:%' " + rolesFilter + " GROUP BY role_id, scope HAVING COUNT(action) = ?) AND NOT dashboard.is_folder)")
 			args = append(args, actionsToCheck...)
 			args = append(args, params...)
 			args = append(args, len(actionsToCheck))
 
 			builder.WriteString(" OR ")
-			builder.WriteString("(dashboard.folder_id IN (SELECT id FROM dashboard as d WHERE d.uid IN (SELECT substr(scope, 13) FROM permission WHERE action IN (?" + strings.Repeat(", ?", len(actionsToCheck)-1) + ") AND scope LIKE 'folders:uid:%' " + rolesFilter + " GROUP BY role_id, scope HAVING COUNT(scope) = ?)) AND NOT dashboard.is_folder)")
+			builder.WriteString("(dashboard.folder_id IN (SELECT id FROM dashboard as d WHERE d.uid IN (SELECT substr(scope, 13) FROM permission WHERE action IN (?" + strings.Repeat(", ?", len(actionsToCheck)-1) + ") AND scope LIKE 'folders:uid:%' " + rolesFilter + " GROUP BY role_id, scope HAVING COUNT(action) = ?)) AND NOT dashboard.is_folder)")
 			args = append(args, actionsToCheck...)
 			args = append(args, params...)
 			args = append(args, len(actionsToCheck))
@@ -168,7 +168,7 @@ func (f AccessControlDashboardPermissionFilter) Where() (string, []interface{}) 
 		}
 
 		if len(actionsToCheck) > 0 {
-			builder.WriteString("(dashboard.uid IN (SELECT substr(scope, 13) FROM permission WHERE action IN (?" + strings.Repeat(", ?", len(actionsToCheck)-1) + ") AND scope LIKE 'folders:uid:%' " + rolesFilter + " GROUP BY role_id, scope HAVING COUNT(scope) = ?) AND dashboard.is_folder)")
+			builder.WriteString("(dashboard.uid IN (SELECT substr(scope, 13) FROM permission WHERE action IN (?" + strings.Repeat(", ?", len(actionsToCheck)-1) + ") AND scope LIKE 'folders:uid:%' " + rolesFilter + " GROUP BY role_id, scope HAVING COUNT(action) = ?) AND dashboard.is_folder)")
 			args = append(args, actionsToCheck...)
 			args = append(args, params...)
 			args = append(args, len(actionsToCheck))

--- a/pkg/services/sqlstore/permissions/dashboard.go
+++ b/pkg/services/sqlstore/permissions/dashboard.go
@@ -153,7 +153,7 @@ func (f AccessControlDashboardPermissionFilter) Where() (string, []interface{}) 
 			builder.WriteString(" OR ")
 		}
 
-		actionsToCheck := make([]interface{}, 0, len(f.dashboardActions))
+		actionsToCheck := make([]interface{}, 0, len(f.folderActions))
 		for _, action := range f.folderActions {
 			var hasWildcard bool
 			for _, scope := range f.user.Permissions[f.user.OrgID][action] {

--- a/pkg/services/sqlstore/permissions/dashboard.go
+++ b/pkg/services/sqlstore/permissions/dashboard.go
@@ -119,8 +119,6 @@ func (f AccessControlDashboardPermissionFilter) Where() (string, []interface{}) 
 	builder.WriteRune('(')
 	if len(f.dashboardActions) > 0 {
 		actionsToCheck := make([]interface{}, 0, len(f.dashboardActions))
-		// dashboards:read dashboards:uid:1 and dashboards:write dashboard:*
-		// *, dashboards:*, dashboards:uid:*
 		for _, action := range f.dashboardActions {
 			var hasWildcard bool
 			for _, scope := range f.user.Permissions[f.user.OrgID][action] {
@@ -156,8 +154,6 @@ func (f AccessControlDashboardPermissionFilter) Where() (string, []interface{}) 
 		}
 
 		actionsToCheck := make([]interface{}, 0, len(f.dashboardActions))
-		// dashboards:read dashboards:uid:1 and dashboards:write dashboard:*
-		// *, dashboards:*, dashboards:uid:*
 		for _, action := range f.folderActions {
 			var hasWildcard bool
 			for _, scope := range f.user.Permissions[f.user.OrgID][action] {
@@ -182,6 +178,5 @@ func (f AccessControlDashboardPermissionFilter) Where() (string, []interface{}) 
 
 	}
 	builder.WriteRune(')')
-
 	return builder.String(), args
 }

--- a/pkg/services/sqlstore/permissions/dashboard.go
+++ b/pkg/services/sqlstore/permissions/dashboard.go
@@ -111,7 +111,7 @@ func (f AccessControlDashboardPermissionFilter) Where() (string, []interface{}) 
 		return "(1 = 0)", nil
 	}
 	dashWildcards := accesscontrol.WildcardsFromPrefix(dashboards.ScopeDashboardsPrefix)
-	folderWildcards := accesscontrol.WildcardsFromPrefix(dashboards.ScopeDashboardsPrefix)
+	folderWildcards := accesscontrol.WildcardsFromPrefix(dashboards.ScopeFoldersPrefix)
 
 	filter, params := accesscontrol.UserRolesFilter(f.user.OrgID, f.user.UserID, f.user.Teams, accesscontrol.GetOrgRoles(f.user))
 	rolesFilter := "AND role_id IN(SELECT distinct id FROM role " + filter + ")"

--- a/pkg/services/sqlstore/permissions/dashboard.go
+++ b/pkg/services/sqlstore/permissions/dashboard.go
@@ -175,7 +175,6 @@ func (f AccessControlDashboardPermissionFilter) Where() (string, []interface{}) 
 		} else {
 			builder.WriteString("dashboard.is_folder")
 		}
-
 	}
 	builder.WriteRune(')')
 	return builder.String(), args

--- a/pkg/services/sqlstore/permissions/dashboard.go
+++ b/pkg/services/sqlstore/permissions/dashboard.go
@@ -124,6 +124,7 @@ func (f AccessControlDashboardPermissionFilter) Where() (string, []interface{}) 
 			if dashWildcards.Contains(scope) || folderWildcards.Contains(scope) {
 				hasWildcard = true
 				builder.WriteString("(1 = 1 AND NOT dashboard.is_folder)")
+				break
 			}
 		}
 
@@ -148,6 +149,7 @@ func (f AccessControlDashboardPermissionFilter) Where() (string, []interface{}) 
 			if folderWildcards.Contains(scope) {
 				hasWildcard = true
 				builder.WriteString("(1 = 1 AND dashboard.is_folder)")
+				break
 			}
 		}
 		if !hasWildcard {

--- a/pkg/services/sqlstore/permissions/dashboard.go
+++ b/pkg/services/sqlstore/permissions/dashboard.go
@@ -129,11 +129,9 @@ func (f AccessControlDashboardPermissionFilter) Where() (string, []interface{}) 
 		}
 
 		if !hasWildcard {
-			builder.WriteRune('(')
-			builder.WriteString("dashboard.uid IN (SELECT SUBSTR(scope, 16) as uid FROM permission WHERE action = ? AND scope LIKE 'dashboards:uid:%'  " + rolesFilter + " )")
+			builder.WriteString("(dashboard.uid IN (SELECT SUBSTR(scope, 16) as uid FROM permission WHERE action = ? AND scope LIKE 'dashboards:uid:%'  " + rolesFilter + " ) AND NOT dashboard.is_folder)")
 			builder.WriteString(" OR ")
-			builder.WriteString("dashboard.folder_id IN (SELECT id FROM dashboard as d WHERE d.uid IN (SELECT SUBSTR(scope, 13) as uid FROM permission WHERE action = ? AND scope LIKE 'folders:uid:%' " + rolesFilter + " ))")
-			builder.WriteString(" AND NOT dashboard.is_folder)")
+			builder.WriteString("(dashboard.folder_id IN (SELECT id FROM dashboard as d WHERE d.uid IN (SELECT SUBSTR(scope, 13) as uid FROM permission WHERE action = ? AND scope LIKE 'folders:uid:%' " + rolesFilter + " )) AND NOT dashboard.is_folder)")
 			args = append(args, f.dashboardAction)
 			args = append(args, params...)
 			args = append(args, f.dashboardAction)

--- a/pkg/services/sqlstore/permissions/dashboard.go
+++ b/pkg/services/sqlstore/permissions/dashboard.go
@@ -99,7 +99,7 @@ func NewAccessControlDashboardPermissionFilter(user *user.SignedInUser, permissi
 		folderAction = dashboards.ActionFoldersRead
 		dashboardAction = dashboards.ActionDashboardsRead
 		if needEdit {
-			folderAction = dashboards.ActionFoldersWrite
+			folderAction = dashboards.ActionDashboardsCreate
 			dashboardAction = dashboards.ActionDashboardsWrite
 		}
 	}

--- a/pkg/services/sqlstore/permissions/dashboard.go
+++ b/pkg/services/sqlstore/permissions/dashboard.go
@@ -133,7 +133,7 @@ func (f AccessControlDashboardPermissionFilter) Where() (string, []interface{}) 
 		}
 
 		if len(actionsToCheck) > 0 {
-			builder.WriteString("(dashboard.uid IN (SELECT p.uid FROM (SELECT role_id, substr(scope, 16) as uid FROM permission WHERE action IN (?" + strings.Repeat(", ?", len(actionsToCheck)-1) + ") AND scope LIKE 'dashboards:uid:%' " + rolesFilter + ") as p GROUP BY p.role_id, p.uid HAVING COUNT(p.uid) = ?) AND NOT dashboard.is_folder)")
+			builder.WriteString("(dashboard.uid IN (SELECT substr(scope, 16) FROM permission WHERE action IN (?" + strings.Repeat(", ?", len(actionsToCheck)-1) + ") AND scope LIKE 'dashboards:uid:%' " + rolesFilter + " GROUP BY role_id, scope HAVING COUNT(scope) = ?) AND NOT dashboard.is_folder)")
 			args = append(args, actionsToCheck...)
 			args = append(args, params...)
 			args = append(args, len(actionsToCheck))

--- a/pkg/services/sqlstore/permissions/dashboard.go
+++ b/pkg/services/sqlstore/permissions/dashboard.go
@@ -129,9 +129,11 @@ func (f AccessControlDashboardPermissionFilter) Where() (string, []interface{}) 
 		}
 
 		if !hasWildcard {
-			builder.WriteString("(dashboard.uid IN (SELECT SUBSTR(scope, 16) as uid FROM permission WHERE action = ? AND scope LIKE 'dashboards:uid:%'  " + rolesFilter + " )")
+			builder.WriteRune('(')
+			builder.WriteString("dashboard.uid IN (SELECT SUBSTR(scope, 16) as uid FROM permission WHERE action = ? AND scope LIKE 'dashboards:uid:%'  " + rolesFilter + " )")
 			builder.WriteString(" OR ")
-			builder.WriteString("dashboard.folder_id IN (SELECT id FROM dashboard as d WHERE d.uid IN (SELECT SUBSTR(scope, 13) as uid FROM permission WHERE action = ? AND scope LIKE 'folders:uid:%' " + rolesFilter + " )))")
+			builder.WriteString("dashboard.folder_id IN (SELECT id FROM dashboard as d WHERE d.uid IN (SELECT SUBSTR(scope, 13) as uid FROM permission WHERE action = ? AND scope LIKE 'folders:uid:%' " + rolesFilter + " ))")
+			builder.WriteString(" AND NOT dashboard.is_folder)")
 			args = append(args, f.dashboardAction)
 			args = append(args, params...)
 			args = append(args, f.dashboardAction)
@@ -145,7 +147,7 @@ func (f AccessControlDashboardPermissionFilter) Where() (string, []interface{}) 
 		}
 
 		var hasWildcard bool
-		for _, scope := range f.user.Permissions[f.user.OrgID][f.dashboardAction] {
+		for _, scope := range f.user.Permissions[f.user.OrgID][f.folderAction] {
 			if folderWildcards.Contains(scope) {
 				hasWildcard = true
 				builder.WriteString("(1 = 1 AND dashboard.is_folder)")
@@ -153,7 +155,7 @@ func (f AccessControlDashboardPermissionFilter) Where() (string, []interface{}) 
 			}
 		}
 		if !hasWildcard {
-			builder.WriteString("(dashboard.uid IN (SELECT SUBSTR(scope, 13) as uid FROM permission WHERE action = ? AND scope LIKE 'folders:uid:%' " + rolesFilter + "))")
+			builder.WriteString("(dashboard.uid IN (SELECT SUBSTR(scope, 13) as uid FROM permission WHERE action = ? AND scope LIKE 'folders:uid:%' " + rolesFilter + ") AND dashboard.is_folder)")
 			args = append(args, f.folderAction)
 			args = append(args, params...)
 		}

--- a/pkg/services/sqlstore/permissions/dashboard.go
+++ b/pkg/services/sqlstore/permissions/dashboard.go
@@ -139,7 +139,7 @@ func (f AccessControlDashboardPermissionFilter) Where() (string, []interface{}) 
 			args = append(args, len(actionsToCheck))
 
 			builder.WriteString(" OR ")
-			builder.WriteString("(dashboard.folder_id IN (SELECT id FROM dashboard as d WHERE d.uid IN (SELECT p.uid FROM (SELECT role_id, substr(scope, 13) as uid FROM permission WHERE action IN (?" + strings.Repeat(", ?", len(actionsToCheck)-1) + ") AND scope LIKE 'folders:uid:%' " + rolesFilter + ") as p GROUP BY p.role_id, p.uid HAVING COUNT(p.uid) = ?)) AND NOT dashboard.is_folder)")
+			builder.WriteString("(dashboard.folder_id IN (SELECT id FROM dashboard as d WHERE d.uid IN (SELECT substr(scope, 13) FROM permission WHERE action IN (?" + strings.Repeat(", ?", len(actionsToCheck)-1) + ") AND scope LIKE 'folders:uid:%' " + rolesFilter + " GROUP BY role_id, scope HAVING COUNT(scope) = ?)) AND NOT dashboard.is_folder)")
 			args = append(args, actionsToCheck...)
 			args = append(args, params...)
 			args = append(args, len(actionsToCheck))
@@ -168,7 +168,7 @@ func (f AccessControlDashboardPermissionFilter) Where() (string, []interface{}) 
 		}
 
 		if len(actionsToCheck) > 0 {
-			builder.WriteString("(dashboard.uid IN (SELECT p.uid FROM (SELECT role_id, substr(scope, 13) as uid FROM permission WHERE action IN (?" + strings.Repeat(", ?", len(actionsToCheck)-1) + ") AND scope LIKE 'folders:uid:%' " + rolesFilter + ") as p GROUP BY p.role_id, p.uid HAVING COUNT(p.uid) = ?) AND dashboard.is_folder)")
+			builder.WriteString("(dashboard.uid IN (SELECT substr(scope, 13) FROM permission WHERE action IN (?" + strings.Repeat(", ?", len(actionsToCheck)-1) + ") AND scope LIKE 'folders:uid:%' " + rolesFilter + " GROUP BY role_id, scope HAVING COUNT(scope) = ?) AND dashboard.is_folder)")
 			args = append(args, actionsToCheck...)
 			args = append(args, params...)
 			args = append(args, len(actionsToCheck))

--- a/pkg/services/sqlstore/permissions/dashboard_bench_test.go
+++ b/pkg/services/sqlstore/permissions/dashboard_bench_test.go
@@ -1,0 +1,1 @@
+package permissions_test

--- a/pkg/services/sqlstore/permissions/dashboard_bench_test.go
+++ b/pkg/services/sqlstore/permissions/dashboard_bench_test.go
@@ -1,1 +1,0 @@
-package permissions_test

--- a/pkg/services/sqlstore/permissions/dashboard_test.go
+++ b/pkg/services/sqlstore/permissions/dashboard_test.go
@@ -53,7 +53,7 @@ func TestIntegration_DashboardPermissionFilter(t *testing.T) {
 			desc:       "Should be able to view a subset of dashboards with dashboard scopes",
 			permission: models.PERMISSION_VIEW,
 			permissions: []accesscontrol.Permission{
-				{Action: dashboards.ActionDashboardsRead, Scope: "dashboards:uid:11"},
+				{Action: dashboards.ActionDashboardsRead, Scope: "dashboards:uid:110"},
 				{Action: dashboards.ActionDashboardsRead, Scope: "dashboards:uid:40"},
 				{Action: dashboards.ActionDashboardsRead, Scope: "dashboards:uid:22"},
 				{Action: dashboards.ActionDashboardsRead, Scope: "dashboards:uid:13"},
@@ -66,8 +66,8 @@ func TestIntegration_DashboardPermissionFilter(t *testing.T) {
 			desc:       "Should be able to view a subset of dashboards with dashboard action and folder scope",
 			permission: models.PERMISSION_VIEW,
 			permissions: []accesscontrol.Permission{
-				{Action: dashboards.ActionDashboardsRead, Scope: "folders:uid:2"},
-				{Action: dashboards.ActionDashboardsRead, Scope: "folders:uid:1"},
+				{Action: dashboards.ActionDashboardsRead, Scope: "folders:uid:8"},
+				{Action: dashboards.ActionDashboardsRead, Scope: "folders:uid:10"},
 			},
 			expectedResult: 20,
 		},
@@ -83,7 +83,7 @@ func TestIntegration_DashboardPermissionFilter(t *testing.T) {
 			desc:       "Should be able to view a subset folders",
 			permission: models.PERMISSION_VIEW,
 			permissions: []accesscontrol.Permission{
-				{Action: dashboards.ActionFoldersRead, Scope: "folders:uid:2"},
+				{Action: dashboards.ActionFoldersRead, Scope: "folders:uid:3"},
 				{Action: dashboards.ActionFoldersRead, Scope: "folders:uid:6"},
 				{Action: dashboards.ActionFoldersRead, Scope: "folders:uid:9"},
 			},
@@ -93,8 +93,8 @@ func TestIntegration_DashboardPermissionFilter(t *testing.T) {
 			desc:       "Should return folders and dashboard with 'edit' permission",
 			permission: models.PERMISSION_EDIT,
 			permissions: []accesscontrol.Permission{
-				{Action: dashboards.ActionFoldersRead, Scope: "folders:uid:2"},
-				{Action: dashboards.ActionDashboardsCreate, Scope: "folders:uid:2"},
+				{Action: dashboards.ActionFoldersRead, Scope: "folders:uid:3"},
+				{Action: dashboards.ActionDashboardsCreate, Scope: "folders:uid:3"},
 				{Action: dashboards.ActionDashboardsRead, Scope: "dashboards:uid:33"},
 				{Action: dashboards.ActionDashboardsWrite, Scope: "dashboards:uid:33"},
 			},
@@ -105,8 +105,8 @@ func TestIntegration_DashboardPermissionFilter(t *testing.T) {
 			permission: models.PERMISSION_VIEW,
 			queryType:  searchstore.TypeAlertFolder,
 			permissions: []accesscontrol.Permission{
-				{Action: dashboards.ActionFoldersRead, Scope: "folders:uid:2"},
-				{Action: accesscontrol.ActionAlertingRuleRead, Scope: "folders:uid:2"},
+				{Action: dashboards.ActionFoldersRead, Scope: "folders:uid:3"},
+				{Action: accesscontrol.ActionAlertingRuleRead, Scope: "folders:uid:3"},
 				{Action: dashboards.ActionFoldersRead, Scope: "folders:uid:8"},
 				{Action: accesscontrol.ActionAlertingRuleRead, Scope: "folders:uid:8"},
 			},
@@ -118,7 +118,7 @@ func TestIntegration_DashboardPermissionFilter(t *testing.T) {
 			queryType:  searchstore.TypeAlertFolder,
 			permissions: []accesscontrol.Permission{
 				{Action: dashboards.ActionFoldersRead, Scope: "*"},
-				{Action: accesscontrol.ActionAlertingRuleRead, Scope: "folders:uid:2"},
+				{Action: accesscontrol.ActionAlertingRuleRead, Scope: "folders:uid:3"},
 				{Action: accesscontrol.ActionAlertingRuleRead, Scope: "folders:uid:8"},
 			},
 			expectedResult: 2,

--- a/pkg/services/sqlstore/permissions/dashboard_test.go
+++ b/pkg/services/sqlstore/permissions/dashboard_test.go
@@ -45,7 +45,7 @@ func TestIntegration_DashboardPermissionFilter(t *testing.T) {
 			expectedResult: 100,
 		},
 		{
-			desc: "Should be able to view a subset of dashboards scopes",
+			desc: "Should be able to view a subset of dashboards with dashboard scopes",
 			permissions: []accesscontrol.Permission{
 				{Action: dashboards.ActionDashboardsRead, Scope: "dashboards:uid:11"},
 				{Action: dashboards.ActionDashboardsRead, Scope: "dashboards:uid:40"},
@@ -57,7 +57,7 @@ func TestIntegration_DashboardPermissionFilter(t *testing.T) {
 			expectedResult: 6,
 		},
 		{
-			desc: "Should be able to view a subset of folder scopes with dashboard action",
+			desc: "Should be able to view a subset of dashboards with dashboard action and folder scope",
 			permissions: []accesscontrol.Permission{
 				{Action: dashboards.ActionDashboardsRead, Scope: "folders:uid:2"},
 				{Action: dashboards.ActionDashboardsRead, Scope: "folders:uid:8"},
@@ -70,6 +70,15 @@ func TestIntegration_DashboardPermissionFilter(t *testing.T) {
 				{Action: dashboards.ActionFoldersRead, Scope: "folders:uid:*"},
 			},
 			expectedResult: 10,
+		},
+		{
+			desc: "Should be able to view a subset folders",
+			permissions: []accesscontrol.Permission{
+				{Action: dashboards.ActionFoldersRead, Scope: "folders:uid:2"},
+				{Action: dashboards.ActionFoldersRead, Scope: "folders:uid:6"},
+				{Action: dashboards.ActionFoldersRead, Scope: "folders:uid:9"},
+			},
+			expectedResult: 3,
 		},
 	}
 

--- a/pkg/services/sqlstore/permissions/dashboard_test.go
+++ b/pkg/services/sqlstore/permissions/dashboard_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
+	"github.com/grafana/grafana/pkg/services/sqlstore/db"
 	"github.com/grafana/grafana/pkg/services/sqlstore/permissions"
 	"github.com/grafana/grafana/pkg/services/sqlstore/searchstore"
 	"github.com/grafana/grafana/pkg/services/user"
@@ -144,7 +145,7 @@ func TestIntegration_DashboardPermissionFilter(t *testing.T) {
 	}
 }
 
-func setupTest(t *testing.T, numFolders, numDashboards int, permissions []accesscontrol.Permission) *sqlstore.SQLStore {
+func setupTest(t *testing.T, numFolders, numDashboards int, permissions []accesscontrol.Permission) db.DB {
 	store := sqlstore.InitTestDB(t)
 	err := store.WithDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
 		dashes := make([]models.Dashboard, 0, numFolders+numDashboards)

--- a/pkg/services/sqlstore/permissions/dashboard_test.go
+++ b/pkg/services/sqlstore/permissions/dashboard_test.go
@@ -170,6 +170,7 @@ func setup(t *testing.T, numFolders, numDashboards int, permissions []accesscont
 			}
 			dashes = append(dashes, models.Dashboard{
 				OrgId:    1,
+				IsFolder: false,
 				FolderId: int64(folderID),
 				Uid:      str,
 				Slug:     str,

--- a/pkg/services/sqlstore/permissions/dashboard_test.go
+++ b/pkg/services/sqlstore/permissions/dashboard_test.go
@@ -127,7 +127,7 @@ func TestIntegration_DashboardPermissionFilter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			store := setup(t, 10, 100, tt.permissions)
+			store := setupTest(t, 10, 100, tt.permissions)
 			usr := &user.SignedInUser{OrgID: 1, OrgRole: org.RoleViewer, Permissions: map[int64]map[string][]string{1: accesscontrol.GroupScopesByAction(tt.permissions)}}
 			filter := permissions.NewAccessControlDashboardPermissionFilter(usr, tt.permission, tt.queryType)
 
@@ -144,7 +144,7 @@ func TestIntegration_DashboardPermissionFilter(t *testing.T) {
 	}
 }
 
-func setup(t *testing.T, numFolders, numDashboards int, permissions []accesscontrol.Permission) *sqlstore.SQLStore {
+func setupTest(t *testing.T, numFolders, numDashboards int, permissions []accesscontrol.Permission) *sqlstore.SQLStore {
 	store := sqlstore.InitTestDB(t)
 	err := store.WithDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
 		dashes := make([]models.Dashboard, 0, numFolders+numDashboards)

--- a/pkg/services/sqlstore/permissions/dashboard_test.go
+++ b/pkg/services/sqlstore/permissions/dashboard_test.go
@@ -67,7 +67,7 @@ func TestIntegration_DashboardPermissionFilter(t *testing.T) {
 			permission: models.PERMISSION_VIEW,
 			permissions: []accesscontrol.Permission{
 				{Action: dashboards.ActionDashboardsRead, Scope: "folders:uid:2"},
-				{Action: dashboards.ActionDashboardsRead, Scope: "folders:uid:8"},
+				{Action: dashboards.ActionDashboardsRead, Scope: "folders:uid:1"},
 			},
 			expectedResult: 20,
 		},
@@ -93,7 +93,9 @@ func TestIntegration_DashboardPermissionFilter(t *testing.T) {
 			desc:       "Should return folders and dashboard with 'edit' permission",
 			permission: models.PERMISSION_EDIT,
 			permissions: []accesscontrol.Permission{
+				{Action: dashboards.ActionFoldersRead, Scope: "folders:uid:2"},
 				{Action: dashboards.ActionDashboardsCreate, Scope: "folders:uid:2"},
+				{Action: dashboards.ActionDashboardsRead, Scope: "dashboards:uid:33"},
 				{Action: dashboards.ActionDashboardsWrite, Scope: "dashboards:uid:33"},
 			},
 			expectedResult: 2,
@@ -103,6 +105,19 @@ func TestIntegration_DashboardPermissionFilter(t *testing.T) {
 			permission: models.PERMISSION_VIEW,
 			queryType:  searchstore.TypeAlertFolder,
 			permissions: []accesscontrol.Permission{
+				{Action: dashboards.ActionFoldersRead, Scope: "folders:uid:2"},
+				{Action: accesscontrol.ActionAlertingRuleRead, Scope: "folders:uid:2"},
+				{Action: dashboards.ActionFoldersRead, Scope: "folders:uid:8"},
+				{Action: accesscontrol.ActionAlertingRuleRead, Scope: "folders:uid:8"},
+			},
+			expectedResult: 2,
+		},
+		{
+			desc:       "Should return folders that users can read alerts when user has read wildcard",
+			permission: models.PERMISSION_VIEW,
+			queryType:  searchstore.TypeAlertFolder,
+			permissions: []accesscontrol.Permission{
+				{Action: dashboards.ActionFoldersRead, Scope: "*"},
 				{Action: accesscontrol.ActionAlertingRuleRead, Scope: "folders:uid:2"},
 				{Action: accesscontrol.ActionAlertingRuleRead, Scope: "folders:uid:8"},
 			},

--- a/pkg/services/sqlstore/permissions/dashboard_test.go
+++ b/pkg/services/sqlstore/permissions/dashboard_test.go
@@ -7,12 +7,12 @@ import (
 	"time"
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
-	"github.com/grafana/grafana/pkg/services/sqlstore/db"
 	"github.com/grafana/grafana/pkg/services/sqlstore/permissions"
 	"github.com/grafana/grafana/pkg/services/sqlstore/searchstore"
 	"github.com/grafana/grafana/pkg/services/user"
@@ -146,7 +146,7 @@ func TestIntegration_DashboardPermissionFilter(t *testing.T) {
 }
 
 func setupTest(t *testing.T, numFolders, numDashboards int, permissions []accesscontrol.Permission) db.DB {
-	store := sqlstore.InitTestDB(t)
+	store := db.InitTestDB(t)
 	err := store.WithDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
 		dashes := make([]models.Dashboard, 0, numFolders+numDashboards)
 		for i := 1; i <= numFolders; i++ {

--- a/pkg/services/sqlstore/permissions/dashboard_test.go
+++ b/pkg/services/sqlstore/permissions/dashboard_test.go
@@ -1,71 +1,176 @@
-package permissions
+package permissions_test
 
 import (
-	"fmt"
+	"context"
+	"strconv"
 	"testing"
+	"time"
 
-	"github.com/stretchr/testify/require"
-
+	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/dashboards"
-	"github.com/grafana/grafana/pkg/services/sqlstore/searchstore"
+	"github.com/grafana/grafana/pkg/services/org"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
+	"github.com/grafana/grafana/pkg/services/sqlstore/permissions"
 	"github.com/grafana/grafana/pkg/services/user"
-	"github.com/grafana/grafana/pkg/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestNewAccessControlDashboardPermissionFilter(t *testing.T) {
-	randomType := "random_" + util.GenerateShortUID()
-	testCases := []struct {
-		permission              models.PermissionType
-		queryType               string
-		expectedDashboardAction string
-		expectedFolderAction    string
-	}{
+func TestIntegration_DashboardPermissionFilter(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	type testCase struct {
+		desc           string
+		permissions    []accesscontrol.Permission
+		expectedResult int
+	}
+
+	tests := []testCase{
 		{
-			queryType:               searchstore.TypeAlertFolder,
-			permission:              models.PERMISSION_ADMIN,
-			expectedDashboardAction: "",
-			expectedFolderAction:    accesscontrol.ActionAlertingRuleCreate,
+			desc: "Should be able to view all dashboards with wildcard scope",
+			permissions: []accesscontrol.Permission{
+				{Action: dashboards.ActionDashboardsRead, Scope: dashboards.ScopeDashboardsAll},
+			},
+			expectedResult: 100,
 		},
 		{
-			queryType:               searchstore.TypeAlertFolder,
-			permission:              models.PERMISSION_EDIT,
-			expectedDashboardAction: "",
-			expectedFolderAction:    accesscontrol.ActionAlertingRuleCreate,
+			desc: "Should be able to view all dashboards with folder wildcard scope",
+			permissions: []accesscontrol.Permission{
+				{Action: dashboards.ActionDashboardsRead, Scope: dashboards.ScopeFoldersAll},
+			},
+			expectedResult: 100,
 		},
 		{
-			queryType:               searchstore.TypeAlertFolder,
-			permission:              models.PERMISSION_VIEW,
-			expectedDashboardAction: "",
-			expectedFolderAction:    accesscontrol.ActionAlertingRuleRead,
+			desc: "Should be able to view a subset of dashboards scopes",
+			permissions: []accesscontrol.Permission{
+				{Action: dashboards.ActionDashboardsRead, Scope: "dashboards:uid:11"},
+				{Action: dashboards.ActionDashboardsRead, Scope: "dashboards:uid:40"},
+				{Action: dashboards.ActionDashboardsRead, Scope: "dashboards:uid:22"},
+				{Action: dashboards.ActionDashboardsRead, Scope: "dashboards:uid:13"},
+				{Action: dashboards.ActionDashboardsRead, Scope: "dashboards:uid:55"},
+				{Action: dashboards.ActionDashboardsRead, Scope: "dashboards:uid:99"},
+			},
+			expectedResult: 6,
 		},
 		{
-			queryType:               randomType,
-			permission:              models.PERMISSION_ADMIN,
-			expectedDashboardAction: dashboards.ActionDashboardsWrite,
-			expectedFolderAction:    dashboards.ActionDashboardsCreate,
+			desc: "Should be able to view a subset of folder scopes with dashboard action",
+			permissions: []accesscontrol.Permission{
+				{Action: dashboards.ActionDashboardsRead, Scope: "folders:uid:2"},
+				{Action: dashboards.ActionDashboardsRead, Scope: "folders:uid:8"},
+			},
+			expectedResult: 20,
 		},
 		{
-			queryType:               randomType,
-			permission:              models.PERMISSION_EDIT,
-			expectedDashboardAction: dashboards.ActionDashboardsWrite,
-			expectedFolderAction:    dashboards.ActionDashboardsCreate,
-		},
-		{
-			queryType:               randomType,
-			permission:              models.PERMISSION_VIEW,
-			expectedDashboardAction: dashboards.ActionDashboardsRead,
-			expectedFolderAction:    dashboards.ActionFoldersRead,
+			desc: "Should be able to view all folders with folder wildcard",
+			permissions: []accesscontrol.Permission{
+				{Action: dashboards.ActionFoldersRead, Scope: "folders:uid:*"},
+			},
+			expectedResult: 10,
 		},
 	}
 
-	for _, testCase := range testCases {
-		t.Run(fmt.Sprintf("query type %s, permissions %s", testCase.queryType, testCase.permission), func(t *testing.T) {
-			filters := NewAccessControlDashboardPermissionFilter(&user.SignedInUser{}, testCase.permission, testCase.queryType)
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			store := setup(t, tt.permissions)
+			filter := permissions.NewAccessControlDashboardPermissionFilter(&user.SignedInUser{
+				OrgID: 1, OrgRole: org.RoleViewer, Permissions: map[int64]map[string][]string{1: accesscontrol.GroupScopesByAction(tt.permissions)},
+			}, models.PERMISSION_VIEW, "")
 
-			require.Equal(t, testCase.expectedDashboardAction, filters.dashboardAction)
-			require.Equal(t, testCase.expectedFolderAction, filters.folderAction)
+			var result int
+			err := store.WithDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
+				q, params := filter.Where()
+				_, err := sess.SQL("SELECT COUNT(*) FROM dashboard WHERE "+q, params...).Get(&result)
+				return err
+			})
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.expectedResult, result)
 		})
 	}
+}
+
+func setup(t *testing.T, permissions []accesscontrol.Permission) *sqlstore.SQLStore {
+	store := sqlstore.InitTestDB(t)
+	err := store.WithDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
+		dashes := make([]models.Dashboard, 0, 110)
+		for i := 1; i <= 10; i++ {
+			str := strconv.Itoa(i)
+			dashes = append(dashes, models.Dashboard{
+				OrgId:    1,
+				Slug:     str,
+				Uid:      str,
+				Title:    str,
+				IsFolder: true,
+				Data:     simplejson.New(),
+				Created:  time.Now(),
+				Updated:  time.Now(),
+			})
+		}
+		// Seed 100 dashboard
+		for i := 11; i <= 110; i++ {
+			str := strconv.Itoa(i)
+			folderID := 10
+			if i%10 != 0 {
+				folderID = i % 10
+			}
+			dashes = append(dashes, models.Dashboard{
+				OrgId:    1,
+				FolderId: int64(folderID),
+				Uid:      str,
+				Slug:     str,
+				Title:    str,
+				Data:     simplejson.New(),
+				Created:  time.Now(),
+				Updated:  time.Now(),
+			})
+		}
+
+		_, err := sess.InsertMulti(&dashes)
+		if err != nil {
+			return err
+		}
+
+		role := &accesscontrol.Role{
+			OrgID:   0,
+			UID:     "basic_viewer",
+			Name:    "basic:viewer",
+			Updated: time.Now(),
+			Created: time.Now(),
+		}
+		_, err = sess.Insert(role)
+		if err != nil {
+			return err
+		}
+
+		_, err = sess.Insert(accesscontrol.BuiltinRole{
+			OrgID:   0,
+			RoleID:  role.ID,
+			Role:    "Viewer",
+			Created: time.Now(),
+			Updated: time.Now(),
+		})
+		if err != nil {
+			return err
+		}
+
+		for i := range permissions {
+			permissions[i].RoleID = role.ID
+			permissions[i].Created = time.Now()
+			permissions[i].Updated = time.Now()
+		}
+		if len(permissions) > 0 {
+			_, err = sess.InsertMulti(&permissions)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+	require.NoError(t, err)
+	return store
 }

--- a/pkg/services/sqlstore/permissions/dashboard_test.go
+++ b/pkg/services/sqlstore/permissions/dashboard_test.go
@@ -44,13 +44,13 @@ func TestNewAccessControlDashboardPermissionFilter(t *testing.T) {
 			queryType:               randomType,
 			permission:              models.PERMISSION_ADMIN,
 			expectedDashboardAction: dashboards.ActionDashboardsWrite,
-			expectedFolderAction:    dashboards.ActionFoldersWrite,
+			expectedFolderAction:    dashboards.ActionDashboardsCreate,
 		},
 		{
 			queryType:               randomType,
 			permission:              models.PERMISSION_EDIT,
 			expectedDashboardAction: dashboards.ActionDashboardsWrite,
-			expectedFolderAction:    dashboards.ActionFoldersWrite,
+			expectedFolderAction:    dashboards.ActionDashboardsCreate,
 		},
 		{
 			queryType:               randomType,

--- a/pkg/services/sqlstore/permissions/dashboard_test.go
+++ b/pkg/services/sqlstore/permissions/dashboard_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/models"
@@ -18,73 +17,46 @@ import (
 func TestNewAccessControlDashboardPermissionFilter(t *testing.T) {
 	randomType := "random_" + util.GenerateShortUID()
 	testCases := []struct {
-		permission               models.PermissionType
-		queryType                string
-		expectedDashboardActions []string
-		expectedFolderActions    []string
+		permission              models.PermissionType
+		queryType               string
+		expectedDashboardAction string
+		expectedFolderAction    string
 	}{
 		{
-			queryType:                searchstore.TypeAlertFolder,
-			permission:               models.PERMISSION_ADMIN,
-			expectedDashboardActions: nil,
-			expectedFolderActions: []string{
-				dashboards.ActionFoldersRead,
-				accesscontrol.ActionAlertingRuleRead,
-				accesscontrol.ActionAlertingRuleCreate,
-			},
+			queryType:               searchstore.TypeAlertFolder,
+			permission:              models.PERMISSION_ADMIN,
+			expectedDashboardAction: "",
+			expectedFolderAction:    accesscontrol.ActionAlertingRuleCreate,
 		},
 		{
-			queryType:                searchstore.TypeAlertFolder,
-			permission:               models.PERMISSION_EDIT,
-			expectedDashboardActions: nil,
-			expectedFolderActions: []string{
-				dashboards.ActionFoldersRead,
-				accesscontrol.ActionAlertingRuleRead,
-				accesscontrol.ActionAlertingRuleCreate,
-			},
+			queryType:               searchstore.TypeAlertFolder,
+			permission:              models.PERMISSION_EDIT,
+			expectedDashboardAction: "",
+			expectedFolderAction:    accesscontrol.ActionAlertingRuleCreate,
 		},
 		{
-			queryType:                searchstore.TypeAlertFolder,
-			permission:               models.PERMISSION_VIEW,
-			expectedDashboardActions: nil,
-			expectedFolderActions: []string{
-				dashboards.ActionFoldersRead,
-				accesscontrol.ActionAlertingRuleRead,
-			},
+			queryType:               searchstore.TypeAlertFolder,
+			permission:              models.PERMISSION_VIEW,
+			expectedDashboardAction: "",
+			expectedFolderAction:    accesscontrol.ActionAlertingRuleRead,
 		},
 		{
-			queryType:  randomType,
-			permission: models.PERMISSION_ADMIN,
-			expectedDashboardActions: []string{
-				dashboards.ActionDashboardsRead,
-				dashboards.ActionDashboardsWrite,
-			},
-			expectedFolderActions: []string{
-				dashboards.ActionFoldersRead,
-				dashboards.ActionDashboardsCreate,
-			},
+			queryType:               randomType,
+			permission:              models.PERMISSION_ADMIN,
+			expectedDashboardAction: dashboards.ActionDashboardsWrite,
+			expectedFolderAction:    dashboards.ActionFoldersWrite,
 		},
 		{
-			queryType:  randomType,
-			permission: models.PERMISSION_EDIT,
-			expectedDashboardActions: []string{
-				dashboards.ActionDashboardsRead,
-				dashboards.ActionDashboardsWrite,
-			},
-			expectedFolderActions: []string{
-				dashboards.ActionFoldersRead,
-				dashboards.ActionDashboardsCreate,
-			},
+			queryType:               randomType,
+			permission:              models.PERMISSION_EDIT,
+			expectedDashboardAction: dashboards.ActionDashboardsWrite,
+			expectedFolderAction:    dashboards.ActionFoldersWrite,
 		},
 		{
-			queryType:  randomType,
-			permission: models.PERMISSION_VIEW,
-			expectedDashboardActions: []string{
-				dashboards.ActionDashboardsRead,
-			},
-			expectedFolderActions: []string{
-				dashboards.ActionFoldersRead,
-			},
+			queryType:               randomType,
+			permission:              models.PERMISSION_VIEW,
+			expectedDashboardAction: dashboards.ActionDashboardsRead,
+			expectedFolderAction:    dashboards.ActionFoldersRead,
 		},
 	}
 
@@ -92,57 +64,8 @@ func TestNewAccessControlDashboardPermissionFilter(t *testing.T) {
 		t.Run(fmt.Sprintf("query type %s, permissions %s", testCase.queryType, testCase.permission), func(t *testing.T) {
 			filters := NewAccessControlDashboardPermissionFilter(&user.SignedInUser{}, testCase.permission, testCase.queryType)
 
-			require.Equal(t, testCase.expectedDashboardActions, filters.dashboardActions)
-			require.Equal(t, testCase.expectedFolderActions, filters.folderActions)
-		})
-	}
-}
-
-func TestAccessControlDashboardPermissionFilter_Where(t *testing.T) {
-	testCases := []struct {
-		title            string
-		dashboardActions []string
-		folderActions    []string
-		expectedResult   string
-	}{
-		{
-			title:            "folder and dashboard actions are defined",
-			dashboardActions: []string{"test"},
-			folderActions:    []string{"test"},
-			expectedResult:   "((( 1 = 0 OR dashboard.folder_id IN(SELECT id FROM dashboard WHERE  1 = 0)) AND NOT dashboard.is_folder) OR ( 1 = 0 AND dashboard.is_folder))",
-		},
-		{
-			title:            "folder actions are defined but not dashboard actions",
-			dashboardActions: nil,
-			folderActions:    []string{"test"},
-			expectedResult:   "(( 1 = 0 AND dashboard.is_folder))",
-		},
-		{
-			title:            "dashboard actions are defined but not folder actions",
-			dashboardActions: []string{"test"},
-			folderActions:    nil,
-			expectedResult:   "((( 1 = 0 OR dashboard.folder_id IN(SELECT id FROM dashboard WHERE  1 = 0)) AND NOT dashboard.is_folder))",
-		},
-		{
-			title:            "dashboard actions are defined but not folder actions",
-			dashboardActions: nil,
-			folderActions:    nil,
-			expectedResult:   "()",
-		},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(testCase.title, func(t *testing.T) {
-			filter := AccessControlDashboardPermissionFilter{
-				User:             &user.SignedInUser{Permissions: map[int64]map[string][]string{}},
-				dashboardActions: testCase.dashboardActions,
-				folderActions:    testCase.folderActions,
-			}
-
-			query, args := filter.Where()
-
-			assert.Empty(t, args)
-			assert.Equal(t, testCase.expectedResult, query)
+			require.Equal(t, testCase.expectedDashboardAction, filters.dashboardAction)
+			require.Equal(t, testCase.expectedFolderAction, filters.folderAction)
 		})
 	}
 }

--- a/pkg/services/sqlstore/permissions/dashboards_bench_test.go
+++ b/pkg/services/sqlstore/permissions/dashboards_bench_test.go
@@ -1,0 +1,142 @@
+package permissions_test
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/services/org"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
+	"github.com/grafana/grafana/pkg/services/sqlstore/permissions"
+	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func benchmarkDashboardPermissionFilter(b *testing.B, numUsers, numDashboards int) {
+	store := setupBenchMark(b, numUsers, numDashboards)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		usr := &user.SignedInUser{UserID: 1, OrgID: 1, OrgRole: org.RoleViewer, Permissions: map[int64]map[string][]string{1: {}}}
+		filter := permissions.NewAccessControlDashboardPermissionFilter(usr, models.PERMISSION_VIEW, "")
+		var result int
+		err := store.WithDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
+			q, params := filter.Where()
+			_, err := sess.SQL("SELECT COUNT(*) FROM dashboard WHERE "+q, params...).Get(&result)
+			return err
+		})
+		require.NoError(b, err)
+		assert.Equal(b, numDashboards, result)
+	}
+}
+
+func setupBenchMark(b *testing.B, numUsers, numDashboards int) *sqlstore.SQLStore {
+	store := sqlstore.InitTestDB(b)
+	now := time.Now()
+	err := store.WithDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
+		dashes := make([]models.Dashboard, 0, numDashboards)
+		for i := 1; i <= numDashboards; i++ {
+			str := strconv.Itoa(i)
+			dashes = append(dashes, models.Dashboard{
+				OrgId:    1,
+				IsFolder: false,
+				Uid:      str,
+				Slug:     str,
+				Title:    str,
+				Data:     simplejson.New(),
+				Created:  now,
+				Updated:  now,
+			})
+		}
+
+		err := batch(len(dashes), 1000, func(start, end int) error {
+			_, err := sess.InsertMulti(dashes[start:end])
+			return err
+		})
+		require.NoError(b, err)
+
+		roles := make([]accesscontrol.Role, 0, numUsers)
+		assignments := make([]accesscontrol.UserRole, 0, numUsers)
+		permissions := make([]accesscontrol.Permission, 0, numUsers*numDashboards)
+		for i := 1; i <= numUsers; i++ {
+			name := fmt.Sprintf("managed_%d", i)
+			roles = append(roles, accesscontrol.Role{
+				UID:     name,
+				Name:    name,
+				Updated: now,
+				Created: now,
+			})
+			assignments = append(assignments, accesscontrol.UserRole{
+				RoleID:  int64(i),
+				UserID:  int64(i),
+				Created: now,
+			})
+			for _, dash := range dashes {
+				permissions = append(permissions, accesscontrol.Permission{
+					RoleID:  int64(i),
+					Action:  dashboards.ActionDashboardsRead,
+					Scope:   dashboards.ScopeDashboardsProvider.GetResourceScopeUID(dash.Uid),
+					Updated: now,
+					Created: now,
+				})
+			}
+		}
+
+		err = batch(len(roles), 1000, func(start, end int) error {
+			_, err := sess.InsertMulti(roles[start:end])
+			return err
+		})
+		require.NoError(b, err)
+
+		err = batch(len(assignments), 1000, func(start, end int) error {
+			_, err := sess.InsertMulti(assignments[start:end])
+			return err
+		})
+		require.NoError(b, err)
+
+		err = batch(len(permissions), 500, func(start, end int) error {
+			_, err := sess.InsertMulti(permissions[start:end])
+			return err
+		})
+		require.NoError(b, err)
+		return nil
+	})
+
+	require.NoError(b, err)
+	return store
+}
+
+func BenchmarkDashboardPermissionFilter_100_100(b *testing.B) {
+	benchmarkDashboardPermissionFilter(b, 100, 100)
+}
+
+func BenchmarkDashboardPermissionFilter_1000_1000(b *testing.B) {
+	benchmarkDashboardPermissionFilter(b, 1000, 1000)
+}
+
+func BenchmarkDashboardPermissionFilter_1000_10000(b *testing.B) {
+	benchmarkDashboardPermissionFilter(b, 1000, 10000)
+}
+
+func batch(count, batchSize int, eachFn func(start, end int) error) error {
+	for i := 0; i < count; {
+		end := i + batchSize
+		if end > count {
+			end = count
+		}
+
+		if err := eachFn(i, end); err != nil {
+			return err
+		}
+
+		i = end
+	}
+
+	return nil
+}

--- a/pkg/services/sqlstore/permissions/dashboards_bench_test.go
+++ b/pkg/services/sqlstore/permissions/dashboards_bench_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
+	"github.com/grafana/grafana/pkg/services/sqlstore/db"
 	"github.com/grafana/grafana/pkg/services/sqlstore/permissions"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/stretchr/testify/assert"
@@ -36,7 +37,7 @@ func benchmarkDashboardPermissionFilter(b *testing.B, numUsers, numDashboards in
 	}
 }
 
-func setupBenchMark(b *testing.B, numUsers, numDashboards int) *sqlstore.SQLStore {
+func setupBenchMark(b *testing.B, numUsers, numDashboards int) db.DB {
 	store := sqlstore.InitTestDB(b)
 	now := time.Now()
 	err := store.WithDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
@@ -88,19 +89,19 @@ func setupBenchMark(b *testing.B, numUsers, numDashboards int) *sqlstore.SQLStor
 			}
 		}
 
-		err = batch(len(roles), 1000, func(start, end int) error {
+		err = batch(len(roles), 10000, func(start, end int) error {
 			_, err := sess.InsertMulti(roles[start:end])
 			return err
 		})
 		require.NoError(b, err)
 
-		err = batch(len(assignments), 1000, func(start, end int) error {
+		err = batch(len(assignments), 10000, func(start, end int) error {
 			_, err := sess.InsertMulti(assignments[start:end])
 			return err
 		})
 		require.NoError(b, err)
 
-		err = batch(len(permissions), 500, func(start, end int) error {
+		err = batch(len(permissions), 10000, func(start, end int) error {
 			_, err := sess.InsertMulti(permissions[start:end])
 			return err
 		})
@@ -116,12 +117,12 @@ func BenchmarkDashboardPermissionFilter_100_100(b *testing.B) {
 	benchmarkDashboardPermissionFilter(b, 100, 100)
 }
 
-func BenchmarkDashboardPermissionFilter_1000_1000(b *testing.B) {
-	benchmarkDashboardPermissionFilter(b, 1000, 1000)
+func BenchmarkDashboardPermissionFilter_100_1000(b *testing.B) {
+	benchmarkDashboardPermissionFilter(b, 100, 1000)
 }
 
-func BenchmarkDashboardPermissionFilter_1000_10000(b *testing.B) {
-	benchmarkDashboardPermissionFilter(b, 1000, 10000)
+func BenchmarkDashboardPermissionFilter_300_10000(b *testing.B) {
+	benchmarkDashboardPermissionFilter(b, 300, 10000)
 }
 
 func batch(count, batchSize int, eachFn func(start, end int) error) error {

--- a/pkg/services/sqlstore/permissions/dashboards_bench_test.go
+++ b/pkg/services/sqlstore/permissions/dashboards_bench_test.go
@@ -8,12 +8,12 @@ import (
 	"time"
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
-	"github.com/grafana/grafana/pkg/services/sqlstore/db"
 	"github.com/grafana/grafana/pkg/services/sqlstore/permissions"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/stretchr/testify/assert"
@@ -38,7 +38,7 @@ func benchmarkDashboardPermissionFilter(b *testing.B, numUsers, numDashboards in
 }
 
 func setupBenchMark(b *testing.B, numUsers, numDashboards int) db.DB {
-	store := sqlstore.InitTestDB(b)
+	store := db.InitTestDB(b)
 	now := time.Now()
 	err := store.WithDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
 		dashes := make([]models.Dashboard, 0, numDashboards)

--- a/pkg/services/sqlstore/permissions/dashboards_bench_test.go
+++ b/pkg/services/sqlstore/permissions/dashboards_bench_test.go
@@ -89,19 +89,19 @@ func setupBenchMark(b *testing.B, numUsers, numDashboards int) db.DB {
 			}
 		}
 
-		err = batch(len(roles), 10000, func(start, end int) error {
+		err = batch(len(roles), 5000, func(start, end int) error {
 			_, err := sess.InsertMulti(roles[start:end])
 			return err
 		})
 		require.NoError(b, err)
 
-		err = batch(len(assignments), 10000, func(start, end int) error {
+		err = batch(len(assignments), 5000, func(start, end int) error {
 			_, err := sess.InsertMulti(assignments[start:end])
 			return err
 		})
 		require.NoError(b, err)
 
-		err = batch(len(permissions), 10000, func(start, end int) error {
+		err = batch(len(permissions), 5000, func(start, end int) error {
 			_, err := sess.InsertMulti(permissions[start:end])
 			return err
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:
The old dashboard filter query, used in search, when using RBAC computed all permission on grafana side and provided them to the sql store as parameters.

This does not scale at all, so we need to move the RBAC check to sql.

First we check if user has a wildcard scope for both folders and dashboards, if they do we do not apply any filter. If user has no wildcard we resolve all dashboard and folder permission for a user using a sub query.

I tested this on a mysql database with 20k dashboards.

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/grafana-enterprise/issues/3960

**Special notes for your reviewer**:

