### PR TITLE
Alerting: Fix mathexp.NoData for ConditionsCmd

### DIFF
--- a/pkg/expr/classic/classic.go
+++ b/pkg/expr/classic/classic.go
@@ -82,6 +82,11 @@ func (cmd *ConditionsCmd) Execute(_ context.Context, vars mathexp.Vars) (mathexp
 			var reducedNum mathexp.Number
 			var name string
 			switch v := val.(type) {
+			case mathexp.NoData:
+				// To keep this code as simple as possible we translate mathexp.NoData into a
+				// mathexp.Number with a nil value so number.GetFloat64Value() returns nil
+				reducedNum = mathexp.NewNumber("no data", nil)
+				reducedNum.SetValue(nil)
 			case mathexp.Series:
 				reducedNum = c.Reducer.Reduce(v)
 				name = v.GetName()

--- a/pkg/expr/classic/classic_test.go
+++ b/pkg/expr/classic/classic_test.go
@@ -328,6 +328,29 @@ func TestConditionsCmdExecute(t *testing.T) {
 			name: "single query with no data",
 			vars: mathexp.Vars{
 				"A": mathexp.Results{
+					Values: []mathexp.Value{mathexp.NoData{}.New()},
+				},
+			},
+			conditionsCmd: &ConditionsCmd{
+				Conditions: []condition{
+					{
+						InputRefID: "A",
+						Reducer:    reducer("avg"),
+						Operator:   "and",
+						Evaluator:  &thresholdEvaluator{"gt", 1},
+					},
+				},
+			},
+			resultNumber: func() mathexp.Number {
+				v := valBasedNumber(nil)
+				v.SetMeta([]EvalMatch{{Metric: "NoData"}})
+				return v
+			},
+		},
+		{
+			name: "single query with no values",
+			vars: mathexp.Vars{
+				"A": mathexp.Results{
 					Values: []mathexp.Value{},
 				},
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit fixes an issue where mathexp.NoData would return an error in ConditionsCmd (Classic Condition) instead of no data. It is a simpler version of #56812 that does not including a refactoring of the `Execute` method.

**Which issue(s) this PR fixes**:

Fixes #55085

**Special notes for your reviewer**:

