### PR TITLE
Alerting: Use Prometheus' format for notification attempts durations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -371,4 +371,4 @@ replace xorm.io/xorm => github.com/grafana/xorm v0.8.3-0.20220614223926-2fcda756
 
 // Use our fork of the upstream alertmanagers.
 // This is required in order to get notification delivery errors from the receivers API.
-replace github.com/prometheus/alertmanager => github.com/grafana/prometheus-alertmanager v0.24.1-0.20221006171631-7f1ce00421dc
+replace github.com/prometheus/alertmanager => github.com/grafana/prometheus-alertmanager v0.24.1-0.20221012142027-823cd9150293

--- a/go.sum
+++ b/go.sum
@@ -1374,12 +1374,10 @@ github.com/grafana/grafana-google-sdk-go v0.0.0-20211104130251-b190293eaf58/go.m
 github.com/grafana/grafana-plugin-sdk-go v0.114.0/go.mod h1:D7x3ah+1d4phNXpbnOaxa/osSaZlwh9/ZUnGGzegRbk=
 github.com/grafana/grafana-plugin-sdk-go v0.139.0 h1:2RQKM2QpSaWTtaGN6sK+R7LO7zykOeTYF0QkAMA7JsI=
 github.com/grafana/grafana-plugin-sdk-go v0.139.0/go.mod h1:Y+Ps2sesZ62AyCnX+hzrYnyDQYe/ZZl+A8yKLOBm12c=
-github.com/grafana/prometheus-alertmanager v0.24.1-0.20221006171631-7f1ce00421dc h1:FFso22Qq3ULTBiFRnbkqmf8UbUhnPALK5ebns1EQ278=
-github.com/grafana/prometheus-alertmanager v0.24.1-0.20221006171631-7f1ce00421dc/go.mod h1:HVHqK+BVPa/tmL8EMhLCCrPt2a1GdJpEyxr5hgur2UI=
+github.com/grafana/prometheus-alertmanager v0.24.1-0.20221012142027-823cd9150293 h1:dJIdfHqu+XjKz+w9zXLqXKPdp6Jjx/UPSOwdeSfWdeQ=
+github.com/grafana/prometheus-alertmanager v0.24.1-0.20221012142027-823cd9150293/go.mod h1:HVHqK+BVPa/tmL8EMhLCCrPt2a1GdJpEyxr5hgur2UI=
 github.com/grafana/saml v0.4.9-0.20220727151557-61cd9c9353fc h1:1PY8n+rXuBNr3r1JQhoytWDCpc+pq+BibxV0SZv+Cr4=
 github.com/grafana/saml v0.4.9-0.20220727151557-61cd9c9353fc/go.mod h1:9Zh6dWPtB3MSzTRt8fIFH60Z351QQ+s7hCU3J/tTlA4=
-github.com/grafana/thema v0.0.0-20220817114012-ebeee841c104 h1:dYpwFYIChrMfpq3wDa/ZBxAbUGSW5NYmYBeSezhaoao=
-github.com/grafana/thema v0.0.0-20220817114012-ebeee841c104/go.mod h1:fCV1rqv6XRQg2GfIQ7pU9zdxd5fLRcEBCnrDVwlK+ZY=
 github.com/grafana/thema v0.0.0-20220929145912-2c7c4a7bb20b h1:OEGzlaj04LE6Eq7aGMOh0bCplGW5rXNeSSSwgamPBEY=
 github.com/grafana/thema v0.0.0-20220929145912-2c7c4a7bb20b/go.mod h1:i3/NX50sNrwsPSAQAj56ckjQTb4biaYG/6y+zyKgpb0=
 github.com/grafana/xorm v0.8.3-0.20220614223926-2fcda7565af6 h1:I9dh1MXGX0wGyxdV/Sl7+ugnki4Dfsy8lv2s5Yf887o=

--- a/pkg/tests/api/alerting/api_notification_channel_test.go
+++ b/pkg/tests/api/alerting/api_notification_channel_test.go
@@ -857,8 +857,8 @@ func TestNotificationChannels(t *testing.T) {
 
 					// If the receiver is not active, no attempts to send notifications should be registered.
 					if expActive {
+						// Prometheus' durations get rounded down, so we might end up with "0s" if we have values smaller than 1ms.
 						require.NotZero(t, integration.LastNotifyAttempt)
-						require.NotEqual(t, "0s", integration.LastNotifyAttemptDuration)
 					} else {
 						require.Zero(t, integration.LastNotifyAttempt)
 						require.Equal(t, "0s", integration.LastNotifyAttemptDuration)

--- a/public/app/features/alerting/unified/components/receivers/ReceiversTable.tsx
+++ b/public/app/features/alerting/unified/components/receivers/ReceiversTable.tsx
@@ -203,8 +203,8 @@ function NotifiersTable({ notifiersState }: NotifiersTableProps) {
       {
         id: 'lastNotifyDuration',
         label: 'Last duration',
-        renderCell: ({ data: { lastNotifyDuration } }) => (
-          <>{durationIsNull(lastNotifyDuration) ? '-' : lastNotifyDuration}</>
+        renderCell: ({ data: { lastNotify, lastNotifyDuration } }) => (
+          <>{isLastNotifyNullDate(lastNotify) && durationIsNull(lastNotifyDuration) ? '-' : lastNotifyDuration}</>
         ),
         size: 1,
       },


### PR DESCRIPTION
**What this PR does / why we need it**:

Our Receivers API is using the Go format for the `lastAttemptDuration` field. This goes against what Prometheus uses for other durations.
Excerpt from the [docs](https://prometheus.io/docs/alerting/latest/configuration/#configuration-file):

> <duration>: a duration matching the regular expression ((([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?|0), e.g. 1d, 1h30m, 5m, 10s

<details>
<summary>Sample JSON response</summary>
<br/>

```json
[
    {
        "active": true,
        "integrations": [
            {
                "lastNotifyAttempt": "0001-01-01T00:00:00.000Z",
                "lastNotifyAttemptDuration": "0s",
                "name": "email",
                "sendResolved": true
            }
        ],
        "name": "grafana-default-email"
    },
    {
        "active": true,
        "integrations": [
            {
                "lastNotifyAttempt": "2022-10-13T10:14:56.916-03:00",
                "lastNotifyAttemptDuration": "0s",
                "lastNotifyAttemptError": "SMTP not configured, check your grafana.ini config file's [smtp] section",
                "name": "email",
                "sendResolved": true
            }
        ],
        "name": "email2"
    },
    {
        "active": true,
        "integrations": [
            {
                "lastNotifyAttempt": "2022-10-13T10:14:56.917-03:00",
                "lastNotifyAttemptDuration": "8ms",
                "lastNotifyAttemptError": "Post \"http://localhost:1919\": dial tcp [::1]:1919: connect: connection refused",
                "name": "webhook",
                "sendResolved": true
            }
        ],
        "name": "Webhook Fail"
    }
]
```
</details>

**Special notes for your reviewer**:

There's a trade-off in using Prometheus style durations: durations get rounded down, so we get less precision. It's normal that we end up with `0s` when the attempt takes less than 1ms.

<details>
<summary>Screenshot</summary>
<br/>

![Screen Shot 2022-10-12 at 13 44 32](https://user-images.githubusercontent.com/41638679/195402491-abd7d427-5560-43da-bd05-530b4ae9976e.png)

</details>
