### PR TITLE
Datasources: Support mixed datasources in a single query

### DIFF
--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -54,7 +54,7 @@ func (hs *HTTPServer) QueryMetricsV2(c *models.ReqContext) response.Response {
 
 	reqDTO.HTTPRequest = c.Req
 
-	resp, err := hs.queryDataService.QueryData(c.Req.Context(), c.SignedInUser, c.SkipCache, reqDTO, true)
+	resp, err := hs.queryDataService.QueryData(c.Req.Context(), c.SignedInUser, c.SkipCache, reqDTO)
 	if err != nil {
 		return hs.handleQueryMetricsError(err)
 	}

--- a/pkg/services/live/live.go
+++ b/pkg/services/live/live.go
@@ -590,7 +590,7 @@ func (g *GrafanaLive) handleOnRPC(client *centrifuge.Client, e centrifuge.RPCEve
 	if err != nil {
 		return centrifuge.RPCReply{}, centrifuge.ErrorBadRequest
 	}
-	resp, err := g.queryDataService.QueryData(client.Context(), user, false, req, true)
+	resp, err := g.queryDataService.QueryData(client.Context(), user, false, req)
 	if err != nil {
 		logger.Error("Error query data", "user", client.UserID(), "client", client.ID(), "method", e.Method, "error", err)
 		if errors.Is(err, datasources.ErrDataSourceAccessDenied) {

--- a/pkg/services/publicdashboards/queries/dashboard_queries.go
+++ b/pkg/services/publicdashboards/queries/dashboard_queries.go
@@ -76,21 +76,6 @@ func HasExpressionQuery(queries []*simplejson.Json) bool {
 	return false
 }
 
-func GroupQueriesByDataSource(queries []*simplejson.Json) (result [][]*simplejson.Json) {
-	byDataSource := make(map[string][]*simplejson.Json)
-
-	for _, query := range queries {
-		uid := GetDataSourceUidFromJson(query)
-		byDataSource[uid] = append(byDataSource[uid], query)
-	}
-
-	for _, queries := range byDataSource {
-		result = append(result, queries)
-	}
-
-	return
-}
-
 func GetDataSourceUidFromJson(query *simplejson.Json) string {
 	uid := query.Get("datasource").Get("uid").MustString()
 

--- a/pkg/services/publicdashboards/queries/dashboard_queries_test.go
+++ b/pkg/services/publicdashboards/queries/dashboard_queries_test.go
@@ -361,7 +361,7 @@ func TestGroupQueriesByPanelId(t *testing.T) {
 		queries := GroupQueriesByPanelId(json)
 
 		panelId := int64(2)
-		queriesByDatasource := GroupQueriesByDataSource(queries[panelId])
+		queriesByDatasource := groupQueriesByDataSource(t, queries[panelId])
 		require.Len(t, queriesByDatasource[0], 1)
 	})
 	t.Run("will delete exemplar property from target if exists", func(t *testing.T) {
@@ -370,7 +370,7 @@ func TestGroupQueriesByPanelId(t *testing.T) {
 		queries := GroupQueriesByPanelId(json)
 
 		panelId := int64(2)
-		queriesByDatasource := GroupQueriesByDataSource(queries[panelId])
+		queriesByDatasource := groupQueriesByDataSource(t, queries[panelId])
 		for _, query := range queriesByDatasource[0] {
 			_, ok := query.CheckGet("exemplar")
 			require.False(t, ok)
@@ -382,7 +382,7 @@ func TestGroupQueriesByPanelId(t *testing.T) {
 		queries := GroupQueriesByPanelId(json)
 
 		panelId := int64(2)
-		queriesByDatasource := GroupQueriesByDataSource(queries[panelId])
+		queriesByDatasource := groupQueriesByDataSource(t, queries[panelId])
 		require.Len(t, queriesByDatasource[0], 2)
 	})
 	t.Run("can extract no queries from empty dashboard", func(t *testing.T) {
@@ -487,7 +487,7 @@ func TestGroupQueriesByDataSource(t *testing.T) {
 			}`)),
 		}
 
-		queriesByDatasource := GroupQueriesByDataSource(queries)
+		queriesByDatasource := groupQueriesByDataSource(t, queries)
 		require.Len(t, queriesByDatasource, 2)
 		require.Contains(t, queriesByDatasource, []*simplejson.Json{simplejson.MustJson([]byte(`{
             "datasource": {
@@ -564,4 +564,20 @@ func TestSanitizeMetadataFromQueryData(t *testing.T) {
 			}
 		}
 	})
+}
+
+func groupQueriesByDataSource(t *testing.T, queries []*simplejson.Json) (result [][]*simplejson.Json) {
+	t.Helper()
+	byDataSource := make(map[string][]*simplejson.Json)
+
+	for _, query := range queries {
+		uid := GetDataSourceUidFromJson(query)
+		byDataSource[uid] = append(byDataSource[uid], query)
+	}
+
+	for _, queries := range byDataSource {
+		result = append(result, queries)
+	}
+
+	return
 }

--- a/pkg/services/publicdashboards/service/service.go
+++ b/pkg/services/publicdashboards/service/service.go
@@ -205,7 +205,7 @@ func (pd *PublicDashboardServiceImpl) GetQueryDataResponse(ctx context.Context, 
 		return nil, err
 	}
 
-	res, err := pd.QueryDataService.QueryDataMultipleSources(ctx, anonymousUser, skipCache, metricReq, true)
+	res, err := pd.QueryDataService.QueryData(ctx, anonymousUser, skipCache, metricReq)
 
 	reqDatasources := metricReq.GetUniqueDatasourceTypes()
 	if err != nil {

--- a/pkg/services/query/errors.go
+++ b/pkg/services/query/errors.go
@@ -7,6 +7,5 @@ import (
 var (
 	ErrNoQueriesFound        = errutil.NewBase(errutil.StatusBadRequest, "query.noQueries", errutil.WithPublicMessage("No queries found")).Errorf("no queries found")
 	ErrInvalidDatasourceID   = errutil.NewBase(errutil.StatusBadRequest, "query.invalidDatasourceId", errutil.WithPublicMessage("Query does not contain a valid data source identifier")).Errorf("invalid data source identifier")
-	ErrMultipleDatasources   = errutil.NewBase(errutil.StatusBadRequest, "query.differentDatasources", errutil.WithPublicMessage("All queries must use the same datasource")).Errorf("all queries must use the same datasource")
 	ErrMissingDataSourceInfo = errutil.NewBase(errutil.StatusBadRequest, "query.missingDataSourceInfo").MustTemplate("query missing datasource info: {{ .Public.RefId }}", errutil.WithPublic("Query {{ .Public.RefId }} is missing datasource information"))
 )

--- a/pkg/services/query/query.go
+++ b/pkg/services/query/query.go
@@ -81,7 +81,7 @@ func (s *Service) QueryData(ctx context.Context, user *user.SignedInUser, skipCa
 	}
 	// If there is only one datasource, query it and return
 	if len(parsedReq.parsedQueries) == 1 {
-		return s.handleQueryData(ctx, user, parsedReq)
+		return s.handleQuerySingleDatasource(ctx, user, parsedReq)
 	}
 	// If there are multiple datasources, handle their queries concurrently and return the aggregate result
 	byDataSource := parsedReq.parsedQueries
@@ -158,8 +158,8 @@ func (s *Service) handleExpressions(ctx context.Context, user *user.SignedInUser
 	return qdr, nil
 }
 
-// handleQueryData handles one or more queries to a single datasource.
-func (s *Service) handleQueryData(ctx context.Context, user *user.SignedInUser, parsedReq *parsedRequest) (*backend.QueryDataResponse, error) {
+// handleQuerySingleDatasource handles one or more queries to a single datasource
+func (s *Service) handleQuerySingleDatasource(ctx context.Context, user *user.SignedInUser, parsedReq *parsedRequest) (*backend.QueryDataResponse, error) {
 	queries := parsedReq.getFlattenedQueries()
 	ds := queries[0].datasource
 	if err := s.pluginRequestValidator.Validate(ds.Url, nil); err != nil {

--- a/pkg/services/query/query_test.go
+++ b/pkg/services/query/query_test.go
@@ -1,4 +1,4 @@
-package query_test
+package query
 
 import (
 	"context"
@@ -9,6 +9,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana/pkg/expr"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
 
@@ -21,13 +22,152 @@ import (
 	fakeDatasources "github.com/grafana/grafana/pkg/services/datasources/fakes"
 	dsSvc "github.com/grafana/grafana/pkg/services/datasources/service"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
-	"github.com/grafana/grafana/pkg/services/query"
 	"github.com/grafana/grafana/pkg/services/secrets/fakes"
 	secretskvs "github.com/grafana/grafana/pkg/services/secrets/kvstore"
 	secretsmng "github.com/grafana/grafana/pkg/services/secrets/manager"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/services/user"
 )
+
+func TestParseMetricRequest(t *testing.T) {
+	tc := setup(t)
+
+	t.Run("Test a simple single datasource query", func(t *testing.T) {
+		mr := metricRequestWithQueries(t, `{
+			"refId": "A",
+			"datasource": {
+				"uid": "gIEkMvIVz",
+				"type": "postgres"
+			}
+		}`, `{
+			"refId": "B",
+			"datasource": {
+				"uid": "gIEkMvIVz",
+				"type": "postgres"
+			}
+		}`)
+		parsedReq, err := tc.queryService.parseMetricRequest(context.Background(), tc.signedInUser, true, mr)
+		require.NoError(t, err)
+		require.NotNil(t, parsedReq)
+		assert.False(t, parsedReq.hasExpression)
+		assert.Len(t, parsedReq.parsedQueries, 1)
+		assert.Contains(t, parsedReq.parsedQueries, "gIEkMvIVz")
+		assert.Len(t, parsedReq.getFlattenedQueries(), 2)
+	})
+
+	t.Run("Test a single datasource query with expressions", func(t *testing.T) {
+		mr := metricRequestWithQueries(t, `{
+			"refId": "A",
+			"datasource": {
+				"uid": "gIEkMvIVz",
+				"type": "postgres"
+			}
+		}`, `{
+			"refId": "B",
+			"datasource": {
+				"type": "__expr__",
+				"uid": "__expr__",
+				"name": "Expression"
+			},
+			"type": "math",
+			"expression": "$A - 50"
+		}`)
+		parsedReq, err := tc.queryService.parseMetricRequest(context.Background(), tc.signedInUser, true, mr)
+		require.NoError(t, err)
+		require.NotNil(t, parsedReq)
+		assert.True(t, parsedReq.hasExpression)
+		assert.Len(t, parsedReq.parsedQueries, 2)
+		assert.Contains(t, parsedReq.parsedQueries, "gIEkMvIVz")
+		assert.Len(t, parsedReq.getFlattenedQueries(), 2)
+		// Make sure we end up with something valid
+		_, err = tc.queryService.handleExpressions(context.Background(), tc.signedInUser, parsedReq)
+		assert.NoError(t, err)
+	})
+
+	t.Run("Test a simple mixed datasource query", func(t *testing.T) {
+		mr := metricRequestWithQueries(t, `{
+			"refId": "A",
+			"datasource": {
+				"uid": "gIEkMvIVz",
+				"type": "postgres"
+			}
+		}`, `{
+			"refId": "B",
+			"datasource": {
+				"uid": "sEx6ZvSVk",
+				"type": "testdata"
+			}
+		}`)
+		parsedReq, err := tc.queryService.parseMetricRequest(context.Background(), tc.signedInUser, true, mr)
+		require.NoError(t, err)
+		require.NotNil(t, parsedReq)
+		assert.False(t, parsedReq.hasExpression)
+		assert.Len(t, parsedReq.parsedQueries, 2)
+		assert.Contains(t, parsedReq.parsedQueries, "gIEkMvIVz")
+		assert.Contains(t, parsedReq.parsedQueries, "sEx6ZvSVk")
+		assert.Len(t, parsedReq.getFlattenedQueries(), 2)
+	})
+
+	t.Run("Test a mixed datasource query with expressions", func(t *testing.T) {
+		mr := metricRequestWithQueries(t, `{
+			"refId": "A",
+			"datasource": {
+				"uid": "gIEkMvIVz",
+				"type": "postgres"
+			}
+		}`, `{
+			"refId": "B",
+			"datasource": {
+				"uid": "sEx6ZvSVk",
+				"type": "testdata"
+			}
+		}`, `{
+			"refId": "A_resample",
+			"datasource": {
+				"type": "__expr__",
+				"uid": "__expr__",
+				"name": "Expression"
+			},
+			"expression": "A",
+			"type": "resample",
+			"downsampler": "mean",
+			"upsampler": "fillna",
+			"window": "10s"
+		}`, `{
+			"refId": "B_resample",
+			"datasource": {
+				"type": "__expr__",
+				"uid": "__expr__",
+				"name": "Expression"
+			},
+			"expression": "B",
+			"type": "resample",
+			"downsampler": "mean",
+			"upsampler": "fillna",
+			"window": "10s"
+		}`, `{
+			"refId": "C",
+			"datasource": {
+				"type": "__expr__",
+				"uid": "__expr__",
+				"name": "Expression"
+			},
+			"type": "math",
+			"expression": "$A_resample + $B_resample"
+		}`)
+		parsedReq, err := tc.queryService.parseMetricRequest(context.Background(), tc.signedInUser, true, mr)
+		require.NoError(t, err)
+		require.NotNil(t, parsedReq)
+		assert.True(t, parsedReq.hasExpression)
+		assert.Len(t, parsedReq.parsedQueries, 3)
+		assert.Contains(t, parsedReq.parsedQueries, "gIEkMvIVz")
+		assert.Contains(t, parsedReq.parsedQueries, "sEx6ZvSVk")
+		assert.Len(t, parsedReq.getFlattenedQueries(), 5)
+		// Make sure we end up with something valid
+		_, err = tc.queryService.handleExpressions(context.Background(), tc.signedInUser, parsedReq)
+		assert.NoError(t, err)
+	})
+}
 
 func TestQueryDataMultipleSources(t *testing.T) {
 	t.Run("can query multiple datasources", func(t *testing.T) {
@@ -215,6 +355,7 @@ func TestQueryData(t *testing.T) {
 }
 
 func setup(t *testing.T) *testContext {
+	t.Helper()
 	pc := &fakePluginClient{}
 	dc := &fakeDataSourceCache{ds: &datasources.DataSource{}}
 	tc := &fakeOAuthTokenService{}
@@ -230,8 +371,7 @@ func setup(t *testing.T) *testContext {
 		SimulatePluginFailure: false,
 	}
 	exprService := expr.ProvideService(&setting.Cfg{ExpressionsEnabled: true}, pc, fakeDatasourceService)
-	queryService := query.ProvideService(nil, dc, exprService, rv, ds, pc, tc)
-
+	queryService := ProvideService(nil, dc, exprService, rv, ds, pc, tc) // provider belonging to this package
 	return &testContext{
 		pluginContext:          pc,
 		secretStore:            ss,
@@ -249,7 +389,7 @@ type testContext struct {
 	dataSourceCache        *fakeDataSourceCache
 	oauthTokenService      *fakeOAuthTokenService
 	pluginRequestValidator *fakePluginRequestValidator
-	queryService           *query.Service
+	queryService           *Service // implementation belonging to this package
 	signedInUser           *user.SignedInUser
 }
 
@@ -259,6 +399,22 @@ func metricRequest() dtos.MetricRequest {
 		From:    "",
 		To:      "",
 		Queries: []*simplejson.Json{q},
+		Debug:   false,
+	}
+}
+
+func metricRequestWithQueries(t *testing.T, rawQueries ...string) dtos.MetricRequest {
+	t.Helper()
+	queries := make([]*simplejson.Json, 0)
+	for _, q := range rawQueries {
+		json, err := simplejson.NewJson([]byte(q))
+		require.NoError(t, err)
+		queries = append(queries, json)
+	}
+	return dtos.MetricRequest{
+		From:    "now-1h",
+		To:      "now",
+		Queries: queries,
 		Debug:   false,
 	}
 }

--- a/pkg/services/query/query_test.go
+++ b/pkg/services/query/query_test.go
@@ -59,7 +59,7 @@ func TestQueryDataMultipleSources(t *testing.T) {
 			HTTPRequest:                nil,
 		}
 
-		_, err = tc.queryService.QueryDataMultipleSources(context.Background(), nil, true, reqDTO, false)
+		_, err = tc.queryService.QueryData(context.Background(), nil, true, reqDTO)
 
 		require.NoError(t, err)
 	})
@@ -108,7 +108,7 @@ func TestQueryDataMultipleSources(t *testing.T) {
 			HTTPRequest:                nil,
 		}
 
-		_, err = tc.queryService.QueryDataMultipleSources(context.Background(), nil, true, reqDTO, false)
+		_, err = tc.queryService.QueryData(context.Background(), nil, true, reqDTO)
 
 		require.NoError(t, err)
 	})
@@ -145,7 +145,7 @@ func TestQueryDataMultipleSources(t *testing.T) {
 			HTTPRequest:                nil,
 		}
 
-		_, err := tc.queryService.QueryDataMultipleSources(context.Background(), nil, true, reqDTO, false)
+		_, err := tc.queryService.QueryData(context.Background(), nil, true, reqDTO)
 
 		require.Error(t, err)
 	})
@@ -163,7 +163,7 @@ func TestQueryData(t *testing.T) {
 		tc.oauthTokenService.passThruEnabled = true
 		tc.oauthTokenService.token = token
 
-		_, err := tc.queryService.QueryData(context.Background(), nil, true, metricRequest(), false)
+		_, err := tc.queryService.QueryData(context.Background(), nil, true, metricRequest())
 		require.Nil(t, err)
 
 		expected := map[string]string{
@@ -183,7 +183,7 @@ func TestQueryData(t *testing.T) {
 		httpReq, err := http.NewRequest(http.MethodGet, "/", nil)
 		require.NoError(t, err)
 		metricReq.HTTPRequest = httpReq
-		_, err = tc.queryService.QueryData(context.Background(), nil, true, metricReq, false)
+		_, err = tc.queryService.QueryData(context.Background(), nil, true, metricReq)
 		require.NoError(t, err)
 
 		require.Empty(t, tc.pluginContext.req.Headers)
@@ -204,7 +204,7 @@ func TestQueryData(t *testing.T) {
 		httpReq.AddCookie(&http.Cookie{Name: "foo", Value: "oof"})
 		httpReq.AddCookie(&http.Cookie{Name: "c"})
 		metricReq.HTTPRequest = httpReq
-		_, err = tc.queryService.QueryData(context.Background(), nil, true, metricReq, false)
+		_, err = tc.queryService.QueryData(context.Background(), nil, true, metricReq)
 		require.NoError(t, err)
 
 		require.Equal(t, map[string]string{"Cookie": "bar=rab; foo=oof"}, tc.pluginContext.req.Headers)


### PR DESCRIPTION
**What this PR does / why we need it**:
For public dashboards, the team created a new endpoint that could gracefully handle mixed queries to multiple datasources in a single backend query. This PR merges that new endpoint and the existing /ds/query endpoint to create a single endpoint that handles everything (single datasources, mixed datasources, and expression queries).

It also removes the `handleExpressions` argument passed into the `QueryData` function, as we couldn't think of a scenario where queries have expressions but we wouldn't want to evaluate them.

Fixes https://github.com/grafana/grafana-partnerships-team/issues/405

**Special notes for your reviewer**:
Tested on my laptop with four different panel types:
- Single db without expressions (not pictured)
- Single db with expressions
- Mixed db without expressions
- Mixed dbs with expressions

**Regular dashboard**
![image](https://user-images.githubusercontent.com/41969079/195451840-d08b690c-da90-440c-878b-76a840c66ab6.png)

**Public dashboard**
![image](https://user-images.githubusercontent.com/41969079/195451933-26f7a592-16ea-49b1-bfde-506561f97604.png)

Verified that the query results look the same (although they are rendered a little differently for some reason). I still highly recommend that someone with a bit more experience test this out and look for odd behavior
