### PR TITLE
Grafana-UI: chore(Collapse) - add child type, ts complierOptions add …

### DIFF
--- a/packages/grafana-ui/src/components/Collapse/Collapse.tsx
+++ b/packages/grafana-ui/src/components/Collapse/Collapse.tsx
@@ -104,6 +104,8 @@ export interface Props {
   onToggle?: (isOpen: boolean) => void;
   /** Additional class name for the root element */
   className?: string;
+  /** Element child component */
+  children?: React.ReactNode;
 }
 
 export const ControlledCollapse: FunctionComponent<Props> = ({ isOpen, onToggle, ...otherProps }) => {

--- a/packages/grafana-ui/tsconfig.json
+++ b/packages/grafana-ui/tsconfig.json
@@ -4,7 +4,8 @@
     "declarationDir": "./compiled",
     "emitDeclarationOnly": true,
     "isolatedModules": true,
-    "rootDirs": ["."]
+    "rootDirs": ["."],
+    "jsx": "react"
   },
   "exclude": ["dist/**/*"],
   "extends": "@grafana/tsconfig",


### PR DESCRIPTION
**What this PR does / why we need it**:
* Adds a typescript type for React children nodes passed to the Collapse component.
* Adds jsx:react to TS complierOptions

**This PR fixes**:
* Typescript errors when importing collapse `import { Collapse } from '@grafana/ui';`
![Screen Shot 2022-10-12 at 11 09 20 AM](https://user-images.githubusercontent.com/114438185/195455213-a61c7a07-2f00-44ec-abdd-8ff554b004d4.png)
* Typescript errors when running the project locally
![Screen Shot 2022-10-12 at 2 56 05 PM](https://user-images.githubusercontent.com/114438185/195455432-dacc1705-23b5-4c76-9615-92f3a0cf8b5b.png)


