### PR TITLE
Alerting: Get feedback on if this is needed

### DIFF
--- a/pkg/expr/classic/classic_test.go
+++ b/pkg/expr/classic/classic_test.go
@@ -372,6 +372,76 @@ func TestConditionsCmdExecute(t *testing.T) {
 			},
 		},
 		{
+			name: "single query with no data and other query with data",
+			vars: mathexp.Vars{
+				"A": mathexp.Results{
+					Values: []mathexp.Value{mathexp.NoData{}.New()},
+				},
+				"B": mathexp.Results{
+					Values: []mathexp.Value{valBasedSeries(ptr.Float64(10), ptr.Float64(20))},
+				},
+			},
+			conditionsCmd: &ConditionsCmd{
+				Conditions: []condition{
+					{
+						InputRefID: "A",
+						Reducer:    reducer("avg"),
+						Operator:   "and",
+						Evaluator:  &thresholdEvaluator{"gt", 1},
+					},
+					{
+						InputRefID: "B",
+						Reducer:    reducer("avg"),
+						Operator:   "and",
+						Evaluator:  &thresholdEvaluator{"gt", 5},
+					},
+				},
+			},
+			resultNumber: func() mathexp.Number {
+				v := valBasedNumber(ptr.Float64(0))
+				v.SetMeta([]EvalMatch{
+					{Metric: "NoData"},
+					{Metric: "", Value: ptr.Float64(15)},
+				})
+				return v
+			},
+		},
+		{
+			name: "single query with data and other query with no data",
+			vars: mathexp.Vars{
+				"A": mathexp.Results{
+					Values: []mathexp.Value{valBasedSeries(ptr.Float64(10), ptr.Float64(20))},
+				},
+				"B": mathexp.Results{
+					Values: []mathexp.Value{mathexp.NoData{}.New()},
+				},
+			},
+			conditionsCmd: &ConditionsCmd{
+				Conditions: []condition{
+					{
+						InputRefID: "A",
+						Reducer:    reducer("avg"),
+						Operator:   "and",
+						Evaluator:  &thresholdEvaluator{"gt", 5},
+					},
+					{
+						InputRefID: "B",
+						Reducer:    reducer("avg"),
+						Operator:   "and",
+						Evaluator:  &thresholdEvaluator{"gt", 1},
+					},
+				},
+			},
+			resultNumber: func() mathexp.Number {
+				v := valBasedNumber(ptr.Float64(0))
+				v.SetMeta([]EvalMatch{
+					{Metric: "", Value: ptr.Float64(15)},
+					{Metric: "NoData"},
+				})
+				return v
+			},
+		},
+		{
 			name: "should accept numbers",
 			vars: mathexp.Vars{
 				"A": mathexp.Results{


### PR DESCRIPTION
**What this PR does / why we need it**:

I was able to remove this line of code without breaking tests. I am unsure if it is correct and think we should remove it.

The line of code that was deleted meant that a Classic Condition will evaluate to No Data iff the last condition in the Classic Condition is No Data. This line ignores the fact that No Data for all other conditions in the Classic Condition must be compared against the left hand side condition.

For example, before this change, if we have the following Classic Condition:

	A (No Data) or B (Data)  --> No Data
	A (Data) or B (No Data)  --> No Data
	A (No Data) and B (Data) --> Data
	A (Data) and B (No Data) --> No Data

and after this change:

	A (No Data) or B (Data)  --> No Data
	A (Data) or B (No Data)  --> No Data
	A (No Data) and B (Data) --> Data
	A (Data) and B (No Data) --> Data

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
