### PR TITLE
Ignore this PR

### DIFF
--- a/packages/grafana-schema/src/schema/mudball.gen.ts
+++ b/packages/grafana-schema/src/schema/mudball.gen.ts
@@ -483,6 +483,7 @@ export interface TableFieldOptions {
   hidden?: boolean;
   inspect: boolean;
   minWidth?: number;
+  subcol?: boolean;
   width?: number;
 }
 

--- a/packages/grafana-ui/src/components/Table/utils.ts
+++ b/packages/grafana-ui/src/components/Table/utils.ts
@@ -48,6 +48,7 @@ export function getColumns(
   data: DataFrame,
   availableWidth: number,
   columnMinWidth: number,
+  showSpans: boolean,
   footerValues?: FooterItem[]
 ): GrafanaTableColumn[] {
   const columns: GrafanaTableColumn[] = [];
@@ -55,6 +56,10 @@ export function getColumns(
 
   for (const [fieldIndex, field] of data.fields.entries()) {
     const fieldTableOptions = (field.config.custom || {}) as TableFieldOptions;
+
+    if (fieldTableOptions.subcol && !showSpans) {
+      continue;
+    }
 
     if (fieldTableOptions.hidden) {
       continue;

--- a/public/app/plugins/datasource/tempo/resultTransformer.ts
+++ b/public/app/plugins/datasource/tempo/resultTransformer.ts
@@ -658,6 +658,7 @@ export function createTableFrameFromTraceQlQuery(
         name: 'spanID',
         type: FieldType.string,
         config: {
+          custom: { subcol: true },
           unit: 'string',
           displayNameFromDS: 'Span',
           links: [


### PR DESCRIPTION
Currently, after making a TraceQL query, every span for each trace is show in its own row. This can lead to a lot of rows, especially if there are several spans for each trace. Refer to the screenshot below.

![image](https://user-images.githubusercontent.com/48166845/195578930-ab0d9772-cba7-49d7-ba65-31b7ac82b7ef.png)

_Note: the data you see in the table is mock data. The data and the columns in the table will be a little different when using real data from the Tempo API (this is a work in progress, [here's](https://github.com/grafana/grafana/tree/hamas/traceql-populate-table) the branch)._

This PR adds a button that allows you to toggle between showing or hiding the `Span` column. 

This is what the table looks like when the `Span` column is hidden:
![image](https://user-images.githubusercontent.com/48166845/195580055-7732d5cc-f37a-467b-82a9-110a86ae12fe.png)
_Note: this is the default view._

This is what is what the table looks like when the `Span` column is shown:
![image](https://user-images.githubusercontent.com/48166845/195580650-30e8ae9e-d15b-4320-a622-849ae4d81af2.png)

Here's a demo of what this will look like with real data from the API:

https://user-images.githubusercontent.com/48166845/195581226-128771ba-2be9-4e95-a75d-06d2345bf766.mov

Weird quirk: as you can see, the rows for the spans seem to be taking up space when they’re not shown, leading to an empty space between the trace IDs when the `Span` column is hidden. Does anyone (perhaps @grafana/grafana-bi-squad) know why this is?