### PR TITLE
Add Alerting API to list of HTTP APIs

### DIFF
--- a/docs/sources/developers/http_api/_index.md
+++ b/docs/sources/developers/http_api/_index.md
@@ -22,6 +22,7 @@ dashboards, creating users, and updating data sources.
 ## HTTP APIs
 
 - [Admin API]({{< relref "admin/" >}})
+- [Alerting API (unstable)](https://editor.swagger.io/?url=https://raw.githubusercontent.com/grafana/grafana/main/pkg/services/ngalert/api/tooling/post.json)
 - [Alerting Provisioning API]({{< relref "alerting_provisioning/" >}})
 - [Annotations API]({{< relref "annotations/" >}})
 - [Authentication API]({{< relref "auth/" >}})


### PR DESCRIPTION
This link has been asked many times and is only viewable on old docs pages.