### PR TITLE
feat(loki-monaco-editor): escape autocompleted label values

### DIFF
--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.test.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.test.ts
@@ -24,7 +24,7 @@ const history = [
 ];
 
 const labelNames = ['place', 'source'];
-const labelValues = ['moon', 'luna'];
+const labelValues = ['moon', 'luna', 'server\\1'];
 const extractedLabelKeys = ['extracted', 'label'];
 const otherLabels: Label[] = [
   {
@@ -244,6 +244,11 @@ describe('getCompletions', () => {
         label: 'luna',
         type: 'LABEL_VALUE',
       },
+      {
+        insertText: '"server\\\\1"',
+        label: 'server\\1',
+        type: 'LABEL_VALUE',
+      },
     ]);
 
     completions = await getCompletions({ ...situation, betweenQuotes: true }, completionProvider);
@@ -257,6 +262,11 @@ describe('getCompletions', () => {
       {
         insertText: 'luna',
         label: 'luna',
+        type: 'LABEL_VALUE',
+      },
+      {
+        insertText: 'server\\\\1',
+        label: 'server\\1',
         type: 'LABEL_VALUE',
       },
     ]);

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
@@ -1,3 +1,4 @@
+import { escapeLabelValueInExactSelector } from '../../../languageUtils';
 import { AGGREGATION_OPERATORS, RANGE_VEC_FUNCTIONS } from '../../../syntax';
 
 import { CompletionDataProvider } from './CompletionDataProvider';
@@ -197,7 +198,7 @@ async function getLabelValuesForMetricCompletions(
   return values.map((text) => ({
     type: 'LABEL_VALUE',
     label: text,
-    insertText: betweenQuotes ? text : `"${text}"`,
+    insertText: betweenQuotes ? escapeLabelValueInExactSelector(text) : `"${escapeLabelValueInExactSelector(text)}"`,
   }));
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Working with the new editor, I saw that when it autocompleted label values, it triggered a query error. So I compared it with the older version, seeing that the previous editor escaped label values.

Adding escaping now.

**Which issue(s) this PR fixes**:

Part of https://github.com/grafana/grafana/issues/44985

**Special notes for your reviewer**:

Old:

https://user-images.githubusercontent.com/1069378/195654924-7af0fcff-4cf6-4779-a592-af767941661c.mov

New:

https://user-images.githubusercontent.com/1069378/195654931-b342e5bd-1585-49b7-90f8-40df92acf8de.mov

