### PR TITLE
Loki: Propagate additional headers from Grafana to Loki when querying data

### DIFF
--- a/pkg/tsdb/loki/loki.go
+++ b/pkg/tsdb/loki/loki.go
@@ -173,24 +173,10 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 	return queryData(ctx, req, dsInfo, s.plog, s.tracer)
 }
 
-func getAuthHeadersForQueryData(headers map[string]string) map[string]string {
-	data := make(map[string]string)
-
-	if auth := headers["Authorization"]; auth != "" {
-		data["Authorization"] = auth
-	}
-
-	if cookie := headers["Cookie"]; cookie != "" {
-		data["Cookie"] = cookie
-	}
-
-	return data
-}
-
 func queryData(ctx context.Context, req *backend.QueryDataRequest, dsInfo *datasourceInfo, plog log.Logger, tracer tracing.Tracer) (*backend.QueryDataResponse, error) {
 	result := backend.NewQueryDataResponse()
 
-	api := newLokiAPI(dsInfo.HTTPClient, dsInfo.URL, plog, getAuthHeadersForQueryData(req.Headers))
+	api := newLokiAPI(dsInfo.HTTPClient, dsInfo.URL, plog, req.Headers)
 
 	queries, err := parseQuery(req)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, the Loki datasource only forwards two headers in the main QueryData handler - `Authorization` and `Cookie`.

This is in contrast to Prometheus, which forwards _all_ headers coming from Grafana:
https://github.com/grafana/grafana/blob/1ca5c347d376985042cf12a52a712edd77375467/pkg/tsdb/prometheus/querydata/request.go#L88

There are often additional headers in the QueryDataRequest that Grafana expects to be forwarded - for example, a header is added to all alert queries which allows traceability of where the queries originated.

This PR changes the Loki datasource to forward all specified request headers, same as Prometheus.

After digging through the git history, I see no historical reasons why we _shouldn't_ do this.

**Which issue(s) this PR fixes**:

n/a

**Special notes for your reviewer**:

I only applied this change to the core QueryData operation, not CallResource. Prometheus has some [different behavior](https://github.com/grafana/grafana/blob/1ca5c347d376985042cf12a52a712edd77375467/pkg/tsdb/prometheus/resource/resource.go#L40-L50) for CallResource that we may want to consider mirroring. In particular, it filters out cookie headers, where the current Loki implementation explicitly _includes_ cookie headers - so I felt that did not apply here. QueryData is the main concern here, but please feel free to comment if you think we should do something similar for CallResource.

