### PR TITLE
docs: moves canvas to proper directory, corrects relref

### DIFF
--- a/docs/sources/panels-visualizations/visualizations/canvas/index.md
+++ b/docs/sources/panels-visualizations/visualizations/canvas/index.md
@@ -2,6 +2,7 @@
 aliases:
   - /docs/grafana/latest/features/panels/canvas/
   - /docs/grafana/latest/visualizations/canvas/
+  - /docs/grafana/latest/panels-visualizations/visualizations/canvas/
 description: Canvas visualization documentation
 keywords:
   - grafana

--- a/docs/sources/whatsnew/whats-new-in-v9-2.md
+++ b/docs/sources/whatsnew/whats-new-in-v9-2.md
@@ -42,7 +42,7 @@ Canvas visualizations are extensible form-built panels that allow you to explici
 
 For example, you can place image layers and then overlay text that's updated by Grafana data sources, and display icons that can change color conditionally based on data.
 
-We've planned additional features and design elements for future releases to make Canvas panels even more powerful tools for creating custom, interactive, data-driven visualizations. To learn more about the Canvas panel, see the [documentation]({{< relref "../visualizations/canvas/" >}}).
+We've planned additional features and design elements for future releases to make Canvas panels even more powerful tools for creating custom, interactive, data-driven visualizations. To learn more about the Canvas panel, see the [documentation]({{< relref "../panels-visualizations/visualizations/canvas" >}}).
 
 {{< video-embed src="/static/img/docs/canvas-panel/canvas-beta-overview-9-2-0.mp4" max-width="750px" caption="Canvas panel beta overview" >}}
 


### PR DESCRIPTION
This PR moves the canvas docs to visualizations/canvas/index and corrects the relref in the what's new in v9.2 doc.