### PR TITLE
Explore: Use root datasource if not mixed and adding first query

### DIFF
--- a/public/app/core/utils/explore.ts
+++ b/public/app/core/utils/explore.ts
@@ -268,13 +268,13 @@ export async function generateEmptyQuery(
   let defaultQuery: Partial<DataQuery> | undefined;
 
   // datasource override is if we have switched datasources with no carry-over - we want to create a new query with a datasource we define
+  // it's also used if there's a root datasource and there were no previous queries
   if (dataSourceOverride) {
     datasourceRef = dataSourceOverride;
   } else if (queries.length > 0 && queries[queries.length - 1].datasource) {
     // otherwise use last queries' datasource
     datasourceRef = queries[queries.length - 1].datasource;
   } else {
-    // if neither exists, use the default datasource
     datasourceInstance = await getDataSourceSrv().get();
     defaultQuery = datasourceInstance.getDefaultQuery?.(CoreApp.Explore);
     datasourceRef = datasourceInstance.getRef();


### PR DESCRIPTION
**What this PR does / why we need it**:
The refactoring needed to add the mixed datasources feature added the datasource ref to every query. This missed some logic in the scenario where there were no queries, but we needed to create one and only had the root datasource to go off of. This fixes that error by passing the root datasource in from state as an override if needed.

**Which issue(s) this PR fixes**:
Fixes #56900

