### PR TITLE
Candlestick: re-init config when series length changes

### DIFF
--- a/public/app/plugins/panel/candlestick/CandlestickPanel.tsx
+++ b/public/app/plugins/panel/candlestick/CandlestickPanel.tsx
@@ -47,7 +47,7 @@ export const CandlestickPanel: React.FC<CandlestickPanelProps> = ({
   const theme = useTheme2();
 
   const info = useMemo(() => {
-    return prepareCandlestickFields(data?.series, options, theme, timeRange);
+    return prepareCandlestickFields(data.series, options, theme, timeRange);
   }, [data, options, theme, timeRange]);
 
   const { renderers, tweakScale, tweakAxis } = useMemo(() => {
@@ -212,7 +212,7 @@ export const CandlestickPanel: React.FC<CandlestickPanelProps> = ({
       tweakAxis,
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [options, data.structureRev]);
+  }, [options, data.structureRev, data.series.length]);
 
   if (!info) {
     return (


### PR DESCRIPTION
Fixes https://github.com/grafana/support-escalations/issues/4182

the Candlestick panel is really just a TimeSeries panel with additional renderers that get hooked up when we detect the correct data shape on init. but it looks like the way snapshots work is by first initializing the panels with no data, and then feeding in the embedded data. this commit will re-init the config when we go from no data at init -> data (follow-up update).