### PR TITLE
AzureAD: Add option to force fetch the groups from the Graph API

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -544,6 +544,7 @@ allowed_domains =
 allowed_groups =
 role_attribute_strict = false
 allow_assign_grafana_admin = false
+force_use_graph_api = false
 
 #################################### Okta OAuth #######################
 [auth.okta]

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/azuread.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/azuread.md
@@ -225,3 +225,11 @@ Grafana attempts to retrieve the user's group membership by calling the included
 
 > Note: The token must include the `GroupMember.Read.All` permission for group overage claim calls to succeed.
 > Admin consent may be required for this permission.
+
+### Force fetching groups from Microsoft graph API
+
+To force fetching groups from Microsoft Graph API instead of the `id_token`. You can use the force_use_graph_api config option.
+
+```
+force_use_graph_api = true
+```

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/azuread.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/azuread.md
@@ -228,7 +228,7 @@ Grafana attempts to retrieve the user's group membership by calling the included
 
 ### Force fetching groups from Microsoft graph API
 
-To force fetching groups from Microsoft Graph API instead of the `id_token`. You can use the force_use_graph_api config option.
+To force fetching groups from Microsoft Graph API instead of the `id_token`. You can use the `force_use_graph_api` config option.
 
 ```
 force_use_graph_api = true

--- a/pkg/login/social/azuread_oauth.go
+++ b/pkg/login/social/azuread_oauth.go
@@ -17,7 +17,8 @@ import (
 
 type SocialAzureAD struct {
 	*SocialBase
-	allowedGroups []string
+	allowedGroups    []string
+	forceUseGraphAPI bool
 }
 
 type azureClaims struct {
@@ -76,7 +77,7 @@ func (s *SocialAzureAD) UserInfo(client *http.Client, token *oauth2.Token) (*Bas
 
 	logger.Debug("AzureAD OAuth: extracted role", "email", email, "role", role)
 
-	groups, err := extractGroups(client, claims, token)
+	groups, err := s.extractGroups(client, claims, token)
 	if err != nil {
 		return nil, fmt.Errorf("failed to extract groups: %w", err)
 	}
@@ -166,39 +167,26 @@ type getAzureGroupResponse struct {
 	Value []string `json:"value"`
 }
 
-func extractGroups(client *http.Client, claims azureClaims, token *oauth2.Token) ([]string, error) {
-	if len(claims.Groups) > 0 {
-		return claims.Groups, nil
-	}
-
-	if claims.ClaimNames.Groups == "" {
-		return []string{}, nil
-	}
-
-	// If user groups exceeds 200 no groups will be found in claims.
-	// See https://docs.microsoft.com/en-us/azure/active-directory/develop/id-tokens#groups-overage-claim
-	endpoint := claims.ClaimSources[claims.ClaimNames.Groups].Endpoint
-
-	// If the endpoints provided in _claim_source is pointing to the deprecated "graph.windows.net" api
-	// replace with handcrafted url to graph.microsoft.com
-	// See https://docs.microsoft.com/en-us/graph/migrate-azure-ad-graph-overview
-	if strings.Contains(endpoint, "graph.windows.net") {
-		tenantID := claims.TenantID
-		// If tenantID wasn't found in the id_token, parse access token
-		if tenantID == "" {
-			parsedToken, err := jwt.ParseSigned(token.AccessToken)
-			if err != nil {
-				return nil, fmt.Errorf("error parsing access token: %w", err)
-			}
-
-			var accessClaims azureAccessClaims
-			if err := parsedToken.UnsafeClaimsWithoutVerification(&accessClaims); err != nil {
-				return nil, fmt.Errorf("error getting claims from access token: %w", err)
-			}
-			tenantID = accessClaims.TenantID
+// extractGroups retrieves groups from the claims.
+// Note: If user groups exceeds 200 no groups will be found in claims and URL to target the Graph API will be
+// given instead.
+// See https://docs.microsoft.com/en-us/azure/active-directory/develop/id-tokens#groups-overage-claim
+func (s *SocialAzureAD) extractGroups(client *http.Client, claims azureClaims, token *oauth2.Token) ([]string, error) {
+	if !s.forceUseGraphAPI {
+		logger.Debug("checking the claim for groups")
+		if len(claims.Groups) > 0 {
+			return claims.Groups, nil
 		}
 
-		endpoint = fmt.Sprintf("https://graph.microsoft.com/v1.0/%s/users/%s/getMemberObjects", tenantID, claims.ID)
+		if claims.ClaimNames.Groups == "" {
+			return []string{}, nil
+		}
+	}
+
+	// Fallback to the Graph API
+	endpoint, errBuildGraphURI := s.groupsGraphAPIURL(claims, token)
+	if errBuildGraphURI != nil {
+		return nil, errBuildGraphURI
 	}
 
 	data, err := json.Marshal(&getAzureGroupRequest{SecurityEnabledOnly: false})
@@ -233,4 +221,39 @@ func extractGroups(client *http.Client, claims azureClaims, token *oauth2.Token)
 	}
 
 	return body.Value, nil
+}
+
+// groupsGraphAPIURL retrieves the Microsoft Graph API URL to fetch user groups from the _claim_sources if present
+// otherwise it generates an handcrafted URL.
+func (*SocialAzureAD) groupsGraphAPIURL(claims azureClaims, token *oauth2.Token) (string, error) {
+	var endpoint string
+	// First check if an endpoint was specified in the claims
+	if claims.ClaimNames.Groups != "" {
+		endpoint = claims.ClaimSources[claims.ClaimNames.Groups].Endpoint
+		logger.Debug(fmt.Sprintf("endpoint to fetch groups specified in the claims: %s", endpoint))
+	}
+
+	// If no endpoint was specified or if the endpoints provided in _claim_source is pointing to the deprecated
+	// "graph.windows.net" api, use an handcrafted url to graph.microsoft.com
+	// See https://docs.microsoft.com/en-us/graph/migrate-azure-ad-graph-overview
+	if endpoint == "" || strings.Contains(endpoint, "graph.windows.net") {
+		tenantID := claims.TenantID
+		// If tenantID wasn't found in the id_token, parse access token
+		if tenantID == "" {
+			parsedToken, err := jwt.ParseSigned(token.AccessToken)
+			if err != nil {
+				return "", fmt.Errorf("error parsing access token: %w", err)
+			}
+
+			var accessClaims azureAccessClaims
+			if err := parsedToken.UnsafeClaimsWithoutVerification(&accessClaims); err != nil {
+				return "", fmt.Errorf("error getting claims from access token: %w", err)
+			}
+			tenantID = accessClaims.TenantID
+		}
+
+		endpoint = fmt.Sprintf("https://graph.microsoft.com/v1.0/%s/users/%s/getMemberObjects", tenantID, claims.ID)
+		logger.Debug(fmt.Sprintf("handcrafted endpoint to fetch groups: %s", endpoint))
+	}
+	return endpoint, nil
 }

--- a/pkg/login/social/azuread_oauth.go
+++ b/pkg/login/social/azuread_oauth.go
@@ -184,7 +184,7 @@ func (s *SocialAzureAD) extractGroups(client *http.Client, claims azureClaims, t
 	}
 
 	// Fallback to the Graph API
-	endpoint, errBuildGraphURI := s.groupsGraphAPIURL(claims, token)
+	endpoint, errBuildGraphURI := groupsGraphAPIURL(claims, token)
 	if errBuildGraphURI != nil {
 		return nil, errBuildGraphURI
 	}
@@ -225,7 +225,7 @@ func (s *SocialAzureAD) extractGroups(client *http.Client, claims azureClaims, t
 
 // groupsGraphAPIURL retrieves the Microsoft Graph API URL to fetch user groups from the _claim_sources if present
 // otherwise it generates an handcrafted URL.
-func (*SocialAzureAD) groupsGraphAPIURL(claims azureClaims, token *oauth2.Token) (string, error) {
+func groupsGraphAPIURL(claims azureClaims, token *oauth2.Token) (string, error) {
 	var endpoint string
 	// First check if an endpoint was specified in the claims
 	if claims.ClaimNames.Groups != "" {

--- a/pkg/login/social/azuread_oauth_test.go
+++ b/pkg/login/social/azuread_oauth_test.go
@@ -27,8 +27,9 @@ func falseBoolPtr() *bool {
 
 func TestSocialAzureAD_UserInfo(t *testing.T) {
 	type fields struct {
-		SocialBase    *SocialBase
-		allowedGroups []string
+		SocialBase       *SocialBase
+		allowedGroups    []string
+		forceUseGraphAPI bool
 	}
 	type args struct {
 		client *http.Client
@@ -346,6 +347,33 @@ func TestSocialAzureAD_UserInfo(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "Fetch groups when forceUseGraphAPI is set",
+			fields: fields{
+				SocialBase:       newSocialBase("azuread", &oauth2.Config{}, &OAuthInfo{}, ""),
+				forceUseGraphAPI: true,
+			},
+			claims: &azureClaims{
+				ID:                "1",
+				Name:              "test",
+				PreferredUsername: "test",
+				Email:             "test@test.com",
+				Roles:             []string{"Viewer"},
+				ClaimNames:        claimNames{Groups: "src1"},
+				ClaimSources:      nil,                    // set by the test
+				Groups:            []string{"foo", "bar"}, // must be ignored
+			},
+			settingAutoAssignOrgRole: "",
+			want: &BasicUserInfo{
+				Id:     "1",
+				Name:   "test",
+				Email:  "test@test.com",
+				Login:  "test@test.com",
+				Role:   "Viewer",
+				Groups: []string{"from_server"},
+			},
+			wantErr: false,
+		},
+		{
 			name: "Fetch empty role when strict attribute role is true and no match",
 			fields: fields{
 				SocialBase: newSocialBase("azuread", &oauth2.Config{}, &OAuthInfo{RoleAttributeStrict: true}, ""),
@@ -382,8 +410,9 @@ func TestSocialAzureAD_UserInfo(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := &SocialAzureAD{
-				SocialBase:    tt.fields.SocialBase,
-				allowedGroups: tt.fields.allowedGroups,
+				SocialBase:       tt.fields.SocialBase,
+				allowedGroups:    tt.fields.allowedGroups,
+				forceUseGraphAPI: tt.fields.forceUseGraphAPI,
 			}
 
 			if tt.fields.SocialBase == nil {
@@ -405,7 +434,7 @@ func TestSocialAzureAD_UserInfo(t *testing.T) {
 
 			var raw string
 			if tt.claims != nil {
-				if tt.claims.ClaimNames.Groups != "" {
+				if tt.claims.ClaimNames.Groups != "" || tt.fields.forceUseGraphAPI {
 					server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 						tokenParts := strings.Split(request.Header.Get("Authorization"), " ")
 						require.Len(t, tokenParts, 2)

--- a/pkg/login/social/azuread_oauth_test.go
+++ b/pkg/login/social/azuread_oauth_test.go
@@ -434,7 +434,7 @@ func TestSocialAzureAD_UserInfo(t *testing.T) {
 
 			var raw string
 			if tt.claims != nil {
-				if tt.claims.ClaimNames.Groups != "" || tt.fields.forceUseGraphAPI {
+				if tt.claims.ClaimNames.Groups != "" {
 					server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 						tokenParts := strings.Split(request.Header.Get("Authorization"), " ")
 						require.Len(t, tokenParts, 2)

--- a/pkg/login/social/social.go
+++ b/pkg/login/social/social.go
@@ -167,8 +167,9 @@ func ProvideService(cfg *setting.Cfg) *SocialService {
 		// AzureAD.
 		if name == "azuread" {
 			ss.socialMap["azuread"] = &SocialAzureAD{
-				SocialBase:    newSocialBase(name, &config, info, cfg.AutoAssignOrgRole),
-				allowedGroups: util.SplitString(sec.Key("allowed_groups").String()),
+				SocialBase:       newSocialBase(name, &config, info, cfg.AutoAssignOrgRole),
+				allowedGroups:    util.SplitString(sec.Key("allowed_groups").String()),
+				forceUseGraphAPI: sec.Key("force_use_graph_api").MustBool(false),
 			}
 		}
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

With https://github.com/grafana/support-escalations/issues/4005, we noticed that some of our Users have groups created with `SecurityEnabled` set to `false`, thus these groups are not being returned with the `id_token.groups` list.
However these groups can still be fetched through the Graph API.

This PR adds an option `force_use_graph_api` that bypasses checking the `id_token` for groups and fetches them from the Graph API instead.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/support-escalations/issues/4005

**Special notes for your reviewer**:

