### PR TITLE
MSSQL/MySQL: Add correct refId when fetching variable query results

### DIFF
--- a/public/app/features/plugins/sql/datasource/SqlDatasource.ts
+++ b/public/app/features/plugins/sql/datasource/SqlDatasource.ts
@@ -113,6 +113,11 @@ export abstract class SqlDatasource extends DataSourceWithBackend<SQLQuery, SQLO
   }
 
   async metricFindQuery(query: string, optionalOptions?: MetricFindQueryOptions): Promise<MetricFindValue[]> {
+    let refId = 'tempvar';
+    if (optionalOptions && optionalOptions.variable && optionalOptions.variable.name) {
+      refId = optionalOptions.variable.name;
+    }
+
     const rawSql = this.templateSrv.replace(
       query,
       getSearchFilterScopedVar({ query, wildcardChar: '%', options: optionalOptions }),
@@ -120,7 +125,7 @@ export abstract class SqlDatasource extends DataSourceWithBackend<SQLQuery, SQLO
     );
 
     const interpolatedQuery: SQLQuery = {
-      refId: 'tempvar',
+      refId: refId,
       datasource: this.getRef(),
       rawSql,
       format: QueryFormat.Table,
@@ -207,4 +212,5 @@ interface RunSQLOptions extends MetricFindQueryOptions {
 
 interface MetricFindQueryOptions extends SearchFilterOptions {
   range?: TimeRange;
+  variable?: VariableWithMultiSupport;
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Fixes issue where query multi variables would not be fetched on dashboard load. The variable would default to `All` value, which would be empty, since the query would fail. Because of this, dashboards would crash, but the selected variable would appear to be `All`, which would suggest there are values in it.


