### PR TITLE
Search: load dashboards optimization

### DIFF
--- a/pkg/services/searchV2/index.go
+++ b/pkg/services/searchV2/index.go
@@ -815,6 +815,75 @@ func newSQLDashboardLoader(sql *sqlstore.SQLStore, tracer tracing.Tracer, settin
 	return &sqlDashboardLoader{sql: sql, logger: log.New("sqlDashboardLoader"), tracer: tracer, settings: settings}
 }
 
+type dashboardsRes struct {
+	dashboards []*dashboardQueryResult
+	err        error
+	end        bool
+}
+
+func (l sqlDashboardLoader) loadAllDashboards(ctx context.Context, limit int, orgID int64, dashboardUID string) chan *dashboardsRes {
+	ch := make(chan *dashboardsRes, 3)
+
+	go func() {
+		var lastID int64
+		for {
+			select {
+			case <-ctx.Done():
+				break
+			default:
+			}
+
+			dashboardQueryCtx, dashboardQuerySpan := l.tracer.Start(ctx, "sqlDashboardLoader dashboardQuery")
+			dashboardQuerySpan.SetAttributes("orgID", orgID, attribute.Key("orgID").Int64(orgID))
+			dashboardQuerySpan.SetAttributes("dashboardUID", dashboardUID, attribute.Key("dashboardUID").String(dashboardUID))
+			dashboardQuerySpan.SetAttributes("lastID", lastID, attribute.Key("lastID").Int64(lastID))
+
+			rows := make([]*dashboardQueryResult, 0)
+			err := l.sql.WithDbSession(dashboardQueryCtx, func(sess *sqlstore.DBSession) error {
+				sess.Table("dashboard").
+					Where("org_id = ?", orgID)
+
+				if lastID > 0 {
+					sess.Where("id > ?", lastID)
+				}
+
+				if dashboardUID != "" {
+					sess.Where("uid = ?", dashboardUID)
+				}
+
+				sess.Cols("id", "uid", "is_folder", "folder_id", "data", "slug", "created", "updated")
+
+				sess.OrderBy("id ASC")
+				sess.Limit(limit)
+
+				return sess.Find(&rows)
+			})
+
+			dashboardQuerySpan.End()
+
+			if err != nil || len(rows) < limit || dashboardUID != "" {
+				ch <- &dashboardsRes{
+					dashboards: rows,
+					err:        err,
+					end:        true,
+				}
+				break
+			}
+
+			ch <- &dashboardsRes{
+				dashboards: rows,
+				end:        false,
+			}
+
+			if len(rows) > 0 {
+				lastID = rows[len(rows)-1].Id
+			}
+		}
+	}()
+
+	return ch
+}
+
 func (l sqlDashboardLoader) LoadDashboards(ctx context.Context, orgID int64, dashboardUID string) ([]dashboard, error) {
 	ctx, span := l.tracer.Start(ctx, "sqlDashboardLoader LoadDashboards")
 	span.SetAttributes("orgID", orgID, attribute.Key("orgID").Int64(orgID))
@@ -856,41 +925,19 @@ func (l sqlDashboardLoader) LoadDashboards(ctx context.Context, orgID int64, das
 	}
 	loadDatasourceSpan.End()
 
-	var lastID int64
+	loadingDashboardCtx, cancelLoadingDashboardCtx := context.WithCancel(ctx)
+	defer cancelLoadingDashboardCtx()
+
+	dashboardsChannel := l.loadAllDashboards(loadingDashboardCtx, limit, orgID, dashboardUID)
 
 	for {
-		dashboardQueryCtx, dashboardQuerySpan := l.tracer.Start(ctx, "sqlDashboardLoader dashboardQuery")
-		dashboardQuerySpan.SetAttributes("orgID", orgID, attribute.Key("orgID").Int64(orgID))
-		dashboardQuerySpan.SetAttributes("dashboardUID", dashboardUID, attribute.Key("dashboardUID").String(dashboardUID))
-		dashboardQuerySpan.SetAttributes("lastID", lastID, attribute.Key("lastID").Int64(lastID))
-
-		rows := make([]dashboardQueryResult, 0, limit)
-
-		err = l.sql.WithDbSession(dashboardQueryCtx, func(sess *sqlstore.DBSession) error {
-			sess.Table("dashboard").
-				Where("org_id = ?", orgID)
-
-			if lastID > 0 {
-				sess.Where("id > ?", lastID)
-			}
-
-			if dashboardUID != "" {
-				sess.Where("uid = ?", dashboardUID)
-			}
-
-			sess.Cols("id", "uid", "is_folder", "folder_id", "data", "slug", "created", "updated")
-
-			sess.OrderBy("id ASC")
-			sess.Limit(limit)
-
-			return sess.Find(&rows)
-		})
-
-		if err != nil {
-			dashboardQuerySpan.End()
-			return nil, err
+		res := <-dashboardsChannel
+		if res.err != nil {
+			l.logger.Error("Error when loading dashboards", "error", err, "orgID", orgID, "dashboardUID", dashboardUID)
+			break
 		}
-		dashboardQuerySpan.End()
+
+		rows := res.dashboards
 
 		_, readDashboardSpan := l.tracer.Start(ctx, "sqlDashboardLoader readDashboard")
 		readDashboardSpan.SetAttributes("orgID", orgID, attribute.Key("orgID").Int64(orgID))
@@ -914,11 +961,10 @@ func (l sqlDashboardLoader) LoadDashboards(ctx context.Context, orgID int64, das
 				updated:  row.Updated,
 				summary:  summary,
 			})
-			lastID = row.Id
 		}
 		readDashboardSpan.End()
 
-		if len(rows) < limit || dashboardUID != "" {
+		if res.end {
 			break
 		}
 	}

--- a/pkg/services/searchV2/index.go
+++ b/pkg/services/searchV2/index.go
@@ -830,6 +830,13 @@ func (l sqlDashboardLoader) loadAllDashboards(ctx context.Context, limit int, or
 		for {
 			select {
 			case <-ctx.Done():
+				err := ctx.Err()
+				if err != nil {
+					ch <- &dashboardsRes{
+						dashboards: nil,
+						err:        err,
+					}
+				}
 				return
 			default:
 			}

--- a/pkg/services/searchV2/index.go
+++ b/pkg/services/searchV2/index.go
@@ -829,7 +829,7 @@ func (l sqlDashboardLoader) loadAllDashboards(ctx context.Context, limit int, or
 		for {
 			select {
 			case <-ctx.Done():
-				break
+				return
 			default:
 			}
 

--- a/pkg/services/searchV2/index.go
+++ b/pkg/services/searchV2/index.go
@@ -955,7 +955,6 @@ func (l sqlDashboardLoader) LoadDashboards(ctx context.Context, orgID int64, das
 
 		reader := kdash.NewStaticDashboardSummaryBuilder(lookup)
 
-		time.Sleep(1 * time.Second)
 		for _, row := range rows {
 			summary, _, err := reader(ctx, row.Uid, row.Data)
 			if err != nil {


### PR DESCRIPTION
<img width="834" alt="image" src="https://user-images.githubusercontent.com/23451458/195801176-d3854a7f-010f-4be1-9c18-7dcc7a03f33b.png">

Small indexing time performance improvement. The _read dashboards_ section can take up to 50ms per batch, which blocks loading the next batch of dashboards from the database. This PR creates a separate goroutine that continuously loads batches (up to 3) of dashboards in the background, and sends them over to the parsing code via a channel




------

.... next low hanging fruit - xorm! 
<img width="711" alt="image" src="https://user-images.githubusercontent.com/23451458/195810717-37fe2896-54b5-4c2a-87ec-b447ad2689c3.png">
