### PR TITLE
Elasticsearch: Fix trimEdges delete logic in alert mode

### DIFF
--- a/pkg/tsdb/elasticsearch/response_parser.go
+++ b/pkg/tsdb/elasticsearch/response_parser.go
@@ -537,10 +537,14 @@ func (rp *responseParser) trimDatapoints(queryResult backend.DataResponse, targe
 	for _, frame := range frames {
 		for _, field := range frame.Fields {
 			if field.Len() > trimEdges*2 {
-				for i := 0; i < field.Len(); i++ {
-					if i < trimEdges || i >= field.Len()-trimEdges {
-						field.Delete(i)
-					}
+				// first we delete the first "trim" items
+				for i := 0; i < trimEdges; i++ {
+					field.Delete(0)
+				}
+
+				// then we delete the last "trim" items
+				for i := 0; i < trimEdges; i++ {
+					field.Delete(field.Len() - 1)
 				}
 			}
 		}

--- a/pkg/tsdb/elasticsearch/testdata/trimedges_string.golden.jsonc
+++ b/pkg/tsdb/elasticsearch/testdata/trimedges_string.golden.jsonc
@@ -1,0 +1,68 @@
+//  🌟 This was machine generated.  Do not edit. 🌟
+//  
+//  Frame[0] {
+//      "custom": null
+//  }
+//  Name: 
+//  Dimensions: 2 Fields by 3 Rows
+//  +-------------------------------+------------------+
+//  | Name: time                    | Name: value      |
+//  | Labels:                       | Labels:          |
+//  | Type: []time.Time             | Type: []*float64 |
+//  +-------------------------------+------------------+
+//  | 1970-01-01 00:00:04 +0000 UTC | 40               |
+//  | 1970-01-01 00:00:05 +0000 UTC | 50               |
+//  | 1970-01-01 00:00:06 +0000 UTC | 60               |
+//  +-------------------------------+------------------+
+//  
+//  
+//  🌟 This was machine generated.  Do not edit. 🌟
+{
+  "frames": [
+    {
+      "schema": {
+        "meta": {
+          "custom": null
+        },
+        "fields": [
+          {
+            "name": "time",
+            "type": "time",
+            "typeInfo": {
+              "frame": "time.Time"
+            },
+            "config": {
+              "displayNameFromDS": "Count"
+            }
+          },
+          {
+            "name": "value",
+            "type": "number",
+            "typeInfo": {
+              "frame": "float64",
+              "nullable": true
+            },
+            "labels": {},
+            "config": {
+              "displayNameFromDS": "Count"
+            }
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            4000,
+            5000,
+            6000
+          ],
+          [
+            40,
+            50,
+            60
+          ]
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
the current `trimEdges` functionality, when running in backend-mode (currently that means running in alert-mode) is incorrect, because the algorithm mutates an array while looping over it.

the code was changed to a different approach.
i added a snapshot-based test for this case, i think those can be useful in the future too (they were very useful when working on loki&prometheus).

how to test:
1. `make devenv sources=elastic`
2. go to the alerting-section, start creating an elastic alert-query. i recommend setting the time-range to last-10-minutes, and then in the loki-query-editor's group-by-date-histogram settings, choose a fixed `1m` interval-value. this will guarantee you to get 11 data-points
3. run the query
4. you should get back 11 data-points (in alerting-view the first data point may be "off screen to the left). you can verify the count by inspecting the ajax-request-response, just find the dataframe-data, it should have 11 values.
5. now set `trimEdges` to `1`. run the query again, verify you get back 9 data-points
6. now set `trimEdges` to `3`, run the query again, verify you get back 5 data-points