### PR TITLE
Configuration page: Fix dropdown menus keyboard a11y

### DIFF
--- a/public/app/core/components/PageHeader/PageHeader.tsx
+++ b/public/app/core/components/PageHeader/PageHeader.tsx
@@ -22,17 +22,16 @@ const SelectNav = ({ children, customCss }: { children: NavModelItem[]; customCs
 
   return (
     <div className={`gf-form-select-wrapper width-20 ${customCss}`}>
-      <div role="menu" className="dropdown">
+      <div className="dropdown">
         <button
           type="button"
-          role="option"
-          aria-selected
           className="gf-form-input dropdown-toggle"
           data-toggle="dropdown"
+          style={{ textAlign: 'left' }}
         >
           {defaultSelectedItem?.text}
         </button>
-        <ul className="dropdown-menu dropdown-menu--menu">
+        <ul role="menu" className="dropdown-menu dropdown-menu--menu">
           {children.map((navItem: NavModelItem) => {
             if (navItem.hideFromTabs) {
               // TODO: Rename hideFromTabs => hideFromNav

--- a/public/app/core/components/PageHeader/PageHeader.tsx
+++ b/public/app/core/components/PageHeader/PageHeader.tsx
@@ -22,10 +22,16 @@ const SelectNav = ({ children, customCss }: { children: NavModelItem[]; customCs
 
   return (
     <div className={`gf-form-select-wrapper width-20 ${customCss}`}>
-      <div className="dropdown">
-        <div className="gf-form-input dropdown-toggle" data-toggle="dropdown">
+      <div role="menu" className="dropdown">
+        <button
+          type="button"
+          role="option"
+          aria-selected
+          className="gf-form-input dropdown-toggle"
+          data-toggle="dropdown"
+        >
           {defaultSelectedItem?.text}
-        </div>
+        </button>
         <ul className="dropdown-menu dropdown-menu--menu">
           {children.map((navItem: NavModelItem) => {
             if (navItem.hideFromTabs) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

### What this PR does / why we need it
The configuration page have a responsive UI:
The tabs (data sources / users / teams / plugins ...) turn into a dropdown when the screen width is too small, however, this dropdown is not keyboard accessible (you cannot access the menu dropdown without a mouse).
See the screenshot bellow - the purple area

This PR provides a quick fix for it : it uses a `button` for the selected item. 

| Before | After |
| ------------- | ------------- |
| ![Screenshot 2022-10-14 at 14 42 50](https://user-images.githubusercontent.com/42030685/195849763-daa2bf54-251d-41c0-a117-3afa6f120ce8.png) | ![Screenshot 2022-10-14 at 15 48 13](https://user-images.githubusercontent.com/42030685/195862908-2b855e08-3cd4-4bfa-beb0-645225fea8e2.png) |


### Which issue(s) this PR fixes

Fixes #56559 

### Special notes for your reviewer

I think a better long term solution would be to use a `Dropdown` or `Select` component instead of a `div` acting as dropdown. Happy to work on that but I thought I would go with a quick fix first as I don't know what the future is for this responsive element; I had never noticed it before testing things with the inspector open 😉 

~~I could also left align the text to make it look more like the before screenshot if you'd rather?~~ Done ✅ 

