### PR TITLE
CI: Move `CreateTempFile` - use it for `rpm`/`deb` packages

### DIFF
--- a/pkg/build/cmd/publishpackages.go
+++ b/pkg/build/cmd/publishpackages.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/grafana/grafana/pkg/build/config"
+	"github.com/grafana/grafana/pkg/build/fsutil"
 	"github.com/grafana/grafana/pkg/build/gcloud"
 	"github.com/grafana/grafana/pkg/build/gpg"
 	"github.com/grafana/grafana/pkg/build/packaging"
@@ -68,7 +69,10 @@ func PublishPackages(c *cli.Context) error {
 	// In test release mode, the operator should configure different GCS buckets for the package repos,
 	// so should be safe.
 	if cfg.ReleaseMode.Mode == config.TagMode {
-		workDir := os.TempDir()
+		workDir, err := fsutil.CreateTempFile("")
+		if err != nil {
+			return err
+		}
 		defer func() {
 			if err := os.RemoveAll(workDir); err != nil {
 				log.Printf("Failed to remove temporary directory %q: %s\n", workDir, err.Error())

--- a/pkg/build/fsutil/createtempfile.go
+++ b/pkg/build/fsutil/createtempfile.go
@@ -1,0 +1,26 @@
+package fsutil
+
+import (
+	"fmt"
+	"os"
+)
+
+// CreateTempFile generates a temp filepath, based on the provided suffix.
+// A typical generated path looks like /var/folders/abcd/abcdefg/A/1137975807.
+func CreateTempFile(sfx string) (string, error) {
+	var suffix string
+	if sfx != "" {
+		suffix = fmt.Sprintf("*-%s", sfx)
+	} else {
+		suffix = sfx
+	}
+	f, err := os.CreateTemp("", suffix)
+	if err != nil {
+		return "", err
+	}
+	if err := f.Close(); err != nil {
+		return "", err
+	}
+
+	return f.Name(), nil
+}

--- a/pkg/build/fsutil/createtempfile_test.go
+++ b/pkg/build/fsutil/createtempfile_test.go
@@ -1,0 +1,28 @@
+package fsutil
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateTempFile(t *testing.T) {
+	t.Run("empty suffix, expects pattern like: /var/folders/abcd/abcdefg/A/1137975807", func(t *testing.T) {
+		filePath, err := CreateTempFile("")
+		require.NoError(t, err)
+
+		pathParts := strings.Split(filePath, "/")
+		require.Len(t, pathParts, 7)
+		require.Len(t, strings.Split(pathParts[len(pathParts)-1], "-"), 1)
+	})
+
+	t.Run("non-empty suffix, expects /var/folders/abcd/abcdefg/A/1137975807-foobar", func(t *testing.T) {
+		filePath, err := CreateTempFile("foobar")
+		require.NoError(t, err)
+
+		pathParts := strings.Split(filePath, "/")
+		require.Len(t, pathParts, 7)
+		require.Len(t, strings.Split(pathParts[len(pathParts)-1], "-"), 2)
+	})
+}

--- a/pkg/build/fsutil/createtempfile_test.go
+++ b/pkg/build/fsutil/createtempfile_test.go
@@ -13,7 +13,7 @@ func TestCreateTempFile(t *testing.T) {
 		require.NoError(t, err)
 
 		pathParts := strings.Split(filePath, "/")
-		require.Len(t, pathParts, 7)
+		require.Greater(t, len(pathParts), 1)
 		require.Len(t, strings.Split(pathParts[len(pathParts)-1], "-"), 1)
 	})
 
@@ -22,7 +22,7 @@ func TestCreateTempFile(t *testing.T) {
 		require.NoError(t, err)
 
 		pathParts := strings.Split(filePath, "/")
-		require.Len(t, pathParts, 7)
+		require.Greater(t, len(pathParts), 1)
 		require.Len(t, strings.Split(pathParts[len(pathParts)-1], "-"), 2)
 	})
 }

--- a/pkg/build/gpg/gpg.go
+++ b/pkg/build/gpg/gpg.go
@@ -7,34 +7,23 @@ import (
 	"os"
 
 	"github.com/grafana/grafana/pkg/build/config"
+	"github.com/grafana/grafana/pkg/build/fsutil"
 )
-
-func createTempFile(sfx string) (string, error) {
-	f, err := os.CreateTemp("", fmt.Sprintf("*-%s", sfx))
-	if err != nil {
-		return "", err
-	}
-	if err := f.Close(); err != nil {
-		return "", err
-	}
-
-	return f.Name(), nil
-}
 
 // LoadGPGKeys loads GPG key pair and password from the environment and writes them to corresponding files.
 //
 // The passed config's GPG fields also get updated. Make sure to call RemoveGPGFiles at application exit.
 func LoadGPGKeys(cfg *config.Config) error {
 	var err error
-	cfg.GPGPrivateKey, err = createTempFile("priv.key")
+	cfg.GPGPrivateKey, err = fsutil.CreateTempFile("priv.key")
 	if err != nil {
 		return err
 	}
-	cfg.GPGPublicKey, err = createTempFile("pub.key")
+	cfg.GPGPublicKey, err = fsutil.CreateTempFile("pub.key")
 	if err != nil {
 		return err
 	}
-	cfg.GPGPassPath, err = createTempFile("")
+	cfg.GPGPassPath, err = fsutil.CreateTempFile("")
 	if err != nil {
 		return err
 	}

--- a/pkg/build/packaging/deb.go
+++ b/pkg/build/packaging/deb.go
@@ -5,11 +5,11 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"strings"
 
 	"github.com/grafana/grafana/pkg/build/config"
+	"github.com/grafana/grafana/pkg/build/fsutil"
 	"github.com/grafana/grafana/pkg/infra/fs"
 	"github.com/urfave/cli/v2"
 )
@@ -122,7 +122,10 @@ func UpdateDebRepo(cfg PublishConfig, workDir string) error {
 		repoName = "beta"
 	}
 
-	repoRoot := path.Join(os.TempDir(), "deb-repo")
+	repoRoot, err := fsutil.CreateTempFile("rpm-repo")
+	if err != nil {
+		return err
+	}
 	defer func() {
 		if err := os.RemoveAll(repoRoot); err != nil {
 			log.Printf("Failed to remove temporary directory %q: %s\n", repoRoot, err.Error())

--- a/pkg/build/packaging/deb.go
+++ b/pkg/build/packaging/deb.go
@@ -122,7 +122,7 @@ func UpdateDebRepo(cfg PublishConfig, workDir string) error {
 		repoName = "beta"
 	}
 
-	repoRoot, err := fsutil.CreateTempFile("rpm-repo")
+	repoRoot, err := fsutil.CreateTempFile("deb-repo")
 	if err != nil {
 		return err
 	}

--- a/pkg/build/packaging/rpm.go
+++ b/pkg/build/packaging/rpm.go
@@ -7,11 +7,11 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"strings"
 
 	"github.com/grafana/grafana/pkg/build/config"
+	"github.com/grafana/grafana/pkg/build/fsutil"
 	"github.com/grafana/grafana/pkg/infra/fs"
 	"golang.org/x/crypto/openpgp"
 	"golang.org/x/crypto/openpgp/armor"
@@ -32,7 +32,10 @@ func UpdateRPMRepo(cfg PublishConfig, workDir string) error {
 		return err
 	}
 
-	repoRoot := path.Join(os.TempDir(), "rpm-repo")
+	repoRoot, err := fsutil.CreateTempFile("rpm-repo")
+	if err != nil {
+		return err
+	}
 	defer func() {
 		if err := os.RemoveAll(repoRoot); err != nil {
 			log.Printf("Failed to remove %q: %s\n", repoRoot, err.Error())


### PR DESCRIPTION
**What this PR does / why we need it**:

Moves `CreateTempFile` from `gpg.go` to be also used in other places.
The problem appeared when we switched over from using `ioutil.TempDir("", "")` in the `build-pipeline` repo, which produced `/var/folders/abc/def/G/1234567` path, to `os.TempDir()` which produced `/var/folders/abc/def/G/`, so filepaths got messed up and expected files weren't in the right places.
`CreateTempFile` follows a constant pattern, similar to `ioutil`.
