### PR TITLE
BUG-REPORT:UID columns in MySQL database are case insensitive, preventing migration from 8 to 9.

### DIFF
--- a/pkg/services/sqlstore/migrator/mysql_dialect.go
+++ b/pkg/services/sqlstore/migrator/mysql_dialect.go
@@ -87,7 +87,12 @@ func (db *MySQLDialect) SQLType(c *Column) string {
 
 	switch c.Type {
 	case DB_Char, DB_Varchar, DB_NVarchar, DB_TinyText, DB_Text, DB_MediumText, DB_LongText:
-		res += " CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"
+		switch c.Name {
+		case "uid":
+			res += " CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_as_cs"
+		default:
+			res += " CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"
+		}
 	}
 
 	return res


### PR DESCRIPTION
**Which issue(s) this PR fixes**: Issue fixed : https://github.com/grafana/grafana/issues/56471.
This issue prevent migration from Grafana 8.x to 9.x due to duplicate keys that are actually two different keys in case insensitive.

Fixes #56471


