### PR TITLE
InfluxDB: Interpolate ad-hoc filters from Dashboard to Explore

### DIFF
--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -319,9 +319,9 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
     const adhocFilters = this.templateSrv.getAdhocFilters(this.name);
     const adhocFiltersFromDashboard = options.targets.flatMap((target: InfluxQuery) => target.adhocFilters ?? []);
     if (adhocFilters?.length || adhocFiltersFromDashboard?.length) {
-      const ahfilters = adhocFilters?.length ? adhocFilters : adhocFiltersFromDashboard;
+      const ahFilters = adhocFilters?.length ? adhocFilters : adhocFiltersFromDashboard;
       const tmpQuery = new InfluxQueryModel({ refId: 'A' }, this.templateSrv, scopedVars);
-      timeFilter += ' AND ' + tmpQuery.renderAdhocFilters(ahfilters);
+      timeFilter += ' AND ' + tmpQuery.renderAdhocFilters(ahFilters);
     }
     // replace grafana variables
     scopedVars.timeFilter = { value: timeFilter };

--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -317,11 +317,12 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
 
     // add global adhoc filters to timeFilter
     const adhocFilters = this.templateSrv.getAdhocFilters(this.name);
-    if (adhocFilters.length > 0) {
+    const adhocFiltersFromDashboard = options.targets.flatMap((target: InfluxQuery) => target.adhocFilters ?? []);
+    if (adhocFilters?.length || adhocFiltersFromDashboard?.length) {
+      const ahfilters = adhocFilters?.length ? adhocFilters : adhocFiltersFromDashboard;
       const tmpQuery = new InfluxQueryModel({ refId: 'A' }, this.templateSrv, scopedVars);
-      timeFilter += ' AND ' + tmpQuery.renderAdhocFilters(adhocFilters);
+      timeFilter += ' AND ' + tmpQuery.renderAdhocFilters(ahfilters);
     }
-
     // replace grafana variables
     scopedVars.timeFilter = { value: timeFilter };
 
@@ -506,6 +507,7 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
 
     return {
       ...expandedQuery,
+      adhocFilters: this.templateSrv.getAdhocFilters(this.name) ?? [],
       query: this.templateSrv.replace(query.query ?? '', rest, 'regex'), // The raw query text
       alias: this.templateSrv.replace(query.alias ?? '', scopedVars),
       limit: this.templateSrv.replace(query.limit?.toString() ?? '', scopedVars, 'regex'),

--- a/public/app/plugins/datasource/influxdb/specs/datasource.test.ts
+++ b/public/app/plugins/datasource/influxdb/specs/datasource.test.ts
@@ -210,7 +210,18 @@ describe('InfluxDataSource', () => {
       $interpolationVar: text,
       $interpolationVar2: text2,
     };
+    const adhocFilters = [
+      {
+        key: 'adhoc',
+        operator: '=',
+        value: 'val',
+        condition: '',
+      },
+    ];
     const templateSrv: any = {
+      getAdhocFilters: jest.fn((name: string) => {
+        return adhocFilters;
+      }),
       replace: jest.fn((target?: string, scopedVars?: ScopedVars, format?: string | Function): string => {
         if (!format) {
           return variableMap[target!] || '';
@@ -252,6 +263,7 @@ describe('InfluxDataSource', () => {
           },
         ],
       ],
+      adhocFilters,
     };
 
     function influxChecks(query: any) {
@@ -265,6 +277,7 @@ describe('InfluxDataSource', () => {
       expect(query.tags![0].value).toBe(textWithFormatRegex);
       expect(query.groupBy![0].params![0]).toBe(textWithFormatRegex);
       expect(query.select![0][0].params![0]).toBe(textWithFormatRegex);
+      expect(query.adhocFilters[0].key).toBe(adhocFilters[0].key);
     }
 
     describe('when interpolating query variables for dashboard->explore', () => {

--- a/public/app/plugins/datasource/influxdb/types.ts
+++ b/public/app/plugins/datasource/influxdb/types.ts
@@ -1,4 +1,4 @@
-import { DataQuery, DataSourceJsonData } from '@grafana/data';
+import { DataQuery, DataSourceJsonData, AdHocVariableFilter } from '@grafana/data';
 
 export enum InfluxVersion {
   InfluxQL = 'InfluxQL',
@@ -70,4 +70,5 @@ export interface InfluxQuery extends DataQuery {
   titleColumn?: string;
   name?: string;
   textEditor?: boolean;
+  adhocFilters?: AdHocVariableFilter[];
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds support to ad-hoc filters interpolation when navigating from Dashboard to Explore

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/55917

**Special notes for your reviewer**:

https://user-images.githubusercontent.com/1680157/195869683-4e7fe928-e9cb-469f-b71c-3d93e68c6067.mov

