### PR TITLE
Themes: Add color-scheme attribute to :root

### DIFF
--- a/packages/grafana-ui/src/themes/GlobalStyles/elements.ts
+++ b/packages/grafana-ui/src/themes/GlobalStyles/elements.ts
@@ -16,6 +16,10 @@ export function getElementStyles(theme: GrafanaTheme2) {
       font-kerning: normal;
     }
 
+    :root {
+      color-scheme: ${theme.colors.mode};
+    }
+
     body {
       height: 100%;
       width: 100%;
@@ -167,7 +171,7 @@ export function getElementStyles(theme: GrafanaTheme2) {
 export function getVariantStyles(variant: ThemeTypographyVariant) {
   return `
     margin: 0;
-    font-size: ${variant.fontSize};    
+    font-size: ${variant.fontSize};
     line-height: ${variant.lineHeight};
     font-weight: ${variant.fontWeight};
     letter-spacing: ${variant.letterSpacing};


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the `color-scheme` attribute to the `:root` pseudo-element, with the appropriate value depending on the current theme.

This fixes an issue on macs where scrollbars would be quite difficult to see on the dark theme if a user has scrollbars set to only appear when scrolling.

Before:
<img width="759" alt="Screenshot 2022-10-14 at 16 04 12" src="https://user-images.githubusercontent.com/45561153/195879894-47a1bad5-f1c0-4312-a3f8-54c755b2158e.png">

After:
<img width="755" alt="Screenshot 2022-10-14 at 16 02 53" src="https://user-images.githubusercontent.com/45561153/195879908-cbee7b6f-89fd-466a-8131-b0a9fa297e83.png">