### PR TITLE
Gtk grafana/support escalations/4008/out of memory

### DIFF
--- a/public/app/plugins/datasource/prometheus/querybuilder/components/MetricSelect.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/MetricSelect.tsx
@@ -73,7 +73,7 @@ export function MetricSelect({ query, onChange, onGetMetrics }: Props) {
           onOpenMenu={async () => {
             setState({ isLoading: true });
             // const metrics = await onGetMetrics();
-            const metrics = new Array(1000000).fill(getFakeMetric());
+            const metrics = new Array(100000).fill(getFakeMetric());
             setState({ metrics, isLoading: undefined });
           }}
           isLoading={state.isLoading}

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/MetricSelect.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/MetricSelect.tsx
@@ -15,6 +15,13 @@ export interface Props {
   onChange: (query: PromVisualQuery) => void;
   onGetMetrics: () => Promise<SelectableValue[]>;
 }
+const getFakeMetric = (i: number) => {
+  return {
+    label: `LABEL_${i}`,
+    title: `TITLE_${i}`,
+    value: `VALUE_${i}`,
+  };
+};
 
 export function MetricSelect({ query, onChange, onGetMetrics }: Props) {
   const styles = useStyles2(getStyles);
@@ -61,25 +68,19 @@ export function MetricSelect({ query, onChange, onGetMetrics }: Props) {
       <EditorField label="Metric">
         <Select
           inputId="prometheus-metric-select"
-          className={styles.select}
-          value={query.metric ? toOption(query.metric) : undefined}
           placeholder="Select metric"
           virtualized
-          allowCustomValue
-          formatOptionLabel={formatOptionLabel}
-          filterOption={customFilterOption}
           onOpenMenu={async () => {
             setState({ isLoading: true });
-            const metrics = await onGetMetrics();
+            // const metrics = await onGetMetrics();
+            const metrics = new Array(1000000).fill(getFakeMetric(0));
+            console.log('METRRIC SAMPLE', metrics);
+            // metrics.splice(0, metrics.length - 100000)
             setState({ metrics, isLoading: undefined });
           }}
           isLoading={state.isLoading}
           options={state.metrics}
-          onChange={({ value }) => {
-            if (value) {
-              onChange({ ...query, metric: value });
-            }
-          }}
+          onChange={({ value }) => {}}
         />
       </EditorField>
     </EditorFieldGroup>

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/MetricSelect.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/MetricSelect.tsx
@@ -73,7 +73,7 @@ export function MetricSelect({ query, onChange, onGetMetrics }: Props) {
           onOpenMenu={async () => {
             setState({ isLoading: true });
             // const metrics = await onGetMetrics();
-            const metrics = new Array(100000).fill(getFakeMetric());
+            const metrics = new Array(1000000).fill(getFakeMetric());
             setState({ metrics, isLoading: undefined });
           }}
           isLoading={state.isLoading}

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/MetricSelect.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/MetricSelect.tsx
@@ -15,11 +15,11 @@ export interface Props {
   onChange: (query: PromVisualQuery) => void;
   onGetMetrics: () => Promise<SelectableValue[]>;
 }
-const getFakeMetric = (i: number) => {
+const getFakeMetric = () => {
   return {
-    label: `LABEL_${i}`,
-    title: `TITLE_${i}`,
-    value: `VALUE_${i}`,
+    label: `LABEL`,
+    title: `TITLE`,
+    value: `VALUE`,
   };
 };
 
@@ -73,9 +73,7 @@ export function MetricSelect({ query, onChange, onGetMetrics }: Props) {
           onOpenMenu={async () => {
             setState({ isLoading: true });
             // const metrics = await onGetMetrics();
-            const metrics = new Array(1000000).fill(getFakeMetric(0));
-            console.log('METRRIC SAMPLE', metrics);
-            // metrics.splice(0, metrics.length - 100000)
+            const metrics = new Array(1000000).fill(getFakeMetric());
             setState({ metrics, isLoading: undefined });
           }}
           isLoading={state.isLoading}


### PR DESCRIPTION
This is just a stripped down implementation of the virtualized select component in prometheus, with some mock code to generate 100k options. I chose 100k because it doesn't always crash my browser and I can still sometimes get a memory profile in, but 250k+ will consistently crash my browser.