### PR TITLE
service grafana-server start reports inaccurate failure

### DIFF
--- a/packaging/deb/init.d/grafana-server
+++ b/packaging/deb/init.d/grafana-server
@@ -90,16 +90,18 @@ case "$1" in
 	return=$?
 	if [ $return -eq 0 ]
 	then
-	  sleep 1
-
-    # check if pid file has been written to
-	  if ! [[ -s $PID_FILE ]]; then
-	    log_end_msg 1
-	    exit 1
-	  fi
-
-		i=0
 		timeout=10
+		i=0
+    # check if pid file has been written to
+		until ! [[ -s $PID_FILE ]] >/dev/null 2>&1
+		do
+	    sleep 1
+      if [ $i -gt $timeout ]; then
+        log_end_msg 1
+        exit 1
+      fi
+		done
+		i=0
 		# Wait for the process to be properly started before exiting
 		until { cat "$PID_FILE" | xargs kill -0; } >/dev/null 2>&1
 		do


### PR DESCRIPTION
### OS / Grafana version
```
$ lsb_release -crid
Distributor ID: Debian
Description:    Debian GNU/Linux 11 (bullseye)
Release:        11
Codename:       bullseye

$ cat /etc/apt/sources.list.d/grafana.list 
deb [signed-by=/usr/share/keyrings/grafana.key] https://packages.grafana.com/oss/deb stable main

$ apt list --installed | grep grafana
grafana/stable,now 9.2.0 amd64 [installed]

$ grafana-server -v
Version 9.2.0 (commit: c7eea48209, branch: HEAD)
```

### First attempt to start service after install
I get `Starting Grafana Server: failed!`.

I've `set -x` in the `/etc/init.d/grafana-service` for verbose logs.
```shell
$ service grafana-server start
+ PATH=/bin:/usr/bin:/sbin:/usr/sbin
+ NAME=grafana-server
+ DESC='Grafana Server'
+ DEFAULT=/etc/default/grafana-server
+ GRAFANA_USER=grafana
+ GRAFANA_GROUP=grafana
+ GRAFANA_HOME=/usr/share/grafana
+ CONF_DIR=/etc/grafana
+ WORK_DIR=/usr/share/grafana
+ DATA_DIR=/var/lib/grafana
+ PLUGINS_DIR=/var/lib/grafana/plugins
+ LOG_DIR=/var/log/grafana
+ CONF_FILE=/etc/grafana/grafana.ini
+ PROVISIONING_CFG_DIR=/etc/grafana/provisioning
+ MAX_OPEN_FILES=10000
+ PID_FILE=/var/run/grafana-server.pid
+ DAEMON=/usr/sbin/grafana-server
+ umask 0027
+ '[' '!' -x /usr/sbin/grafana-server ']'
+ . /lib/lsb/init-functions
+++ run-parts --lsbsysinit --list /lib/lsb/init-functions.d
++ for hook in $(run-parts --lsbsysinit --list /lib/lsb/init-functions.d 2>/dev/null)
++ '[' -r /lib/lsb/init-functions.d/00-verbose ']'
++ . /lib/lsb/init-functions.d/00-verbose
++ FANCYTTY=
++ '[' -e /etc/lsb-base-logging.sh ']'
++ true
+ '[' -r /etc/default/rcS ']'
+ '[' -f /etc/default/grafana-server ']'
+ . /etc/default/grafana-server
++ GRAFANA_USER=grafana
++ GRAFANA_GROUP=grafana
++ GRAFANA_HOME=/usr/share/grafana
++ LOG_DIR=/var/log/grafana
++ DATA_DIR=/var/lib/grafana
++ MAX_OPEN_FILES=10000
++ CONF_DIR=/etc/grafana
++ CONF_FILE=/etc/grafana/grafana.ini
++ RESTART_ON_UPGRADE=true
++ PLUGINS_DIR=/var/lib/grafana/plugins
++ PROVISIONING_CFG_DIR=/etc/grafana/provisioning
++ PID_FILE_DIR=/run/grafana
+ DAEMON_OPTS='--pidfile=/var/run/grafana-server.pid --config=/etc/grafana/grafana.ini --packaging=deb cfg:default.paths.provisioning=/etc/grafana/provisioning cfg:default.paths.data=/var/lib/grafana cfg:default.paths.logs=/var/log/grafana cfg:default.paths.plugins=/var/lib/grafana/plugins'
+ case "$1" in
+ checkUser
++ id -u
+ '[' 0 -ne 0 ']'
+ log_daemon_msg 'Starting Grafana Server'
+ '[' -z 'Starting Grafana Server' ']'
+ log_daemon_msg_pre 'Starting Grafana Server'
+ :
+ '[' -z '' ']'
+ echo -n 'Starting Grafana Server:'
Starting Grafana Server:+ return
++ pidofproc -p /var/run/grafana-server.pid grafana
++ local pidfile base status specified pid OPTIND
++ pidfile=
++ specified=
++ OPTIND=1
++ getopts p: opt
++ case "$opt" in
++ pidfile=/var/run/grafana-server.pid
++ specified=specified
++ getopts p: opt
++ shift 2
++ '[' 1 -ne 1 ']'
++ base=grafana
++ '[' '!' specified ']'
++ '[' -n /var/run/grafana-server.pid ']'
++ '[' -e /var/run/grafana-server.pid ']'
++ '[' -x /bin/pidof ']'
++ '[' '!' specified ']'
++ return 3
+ pid=
+ '[' -n '' ']'
+ mkdir -p /var/log/grafana /var/lib/grafana
+ chown grafana:grafana /var/log/grafana /var/lib/grafana
+ touch /var/run/grafana-server.pid
+ chown grafana:grafana /var/run/grafana-server.pid
+ '[' -n 10000 ']'
+ ulimit -n 10000
+ start-stop-daemon --start -b --chdir /usr/share/grafana --user grafana -c grafana --pidfile /var/run/grafana-server.pid --exec /usr/sbin/grafana-server -- --pidfile=/var/run/grafana-server.pid --config=/etc/grafana/grafana.ini --packaging=deb cfg:default.paths.provisioning=/etc/grafana/provisioning cfg:default.paths.data=/var/lib/grafana cfg:default.paths.logs=/var/log/grafana cfg:default.paths.plugins=/var/lib/grafana/plugins
+ return=0
+ '[' 0 -eq 0 ']'
+ sleep 1
+ [[ -s /var/run/grafana-server.pid ]]
+ log_end_msg 1
+ '[' -z 1 ']'
+ local retval
+ retval=1
+ log_end_msg_pre 1
+ :
+ log_use_fancy_output
+ TPUT=/usr/bin/tput
+ EXPR=/usr/bin/expr
+ '[' -t 1 ']'
+ '[' xxterm '!=' x ']'
+ '[' xxterm '!=' xdumb ']'
+ '[' -x /usr/bin/tput ']'
+ '[' -x /usr/bin/expr ']'
+ /usr/bin/tput hpa 60
+ /usr/bin/tput setaf 1
+ '[' -z ']'
+ FANCYTTY=1
+ case "$FANCYTTY" in
+ true
++ /usr/bin/tput setaf 1
+ RED=''
++ /usr/bin/tput setaf 3
+ YELLOW=''
++ /usr/bin/tput op
+ NORMAL=''
+ '[' 1 -eq 0 ']'
+ '[' 1 -eq 255 ']'
+ /bin/echo -e ' failed!'
 failed!
+ log_end_msg_post 1
+ :
+ return 1
+ exit 1
```

### Second attempt to start the service
I get `Starting Grafana Server:Already running..`

```shell
$ service grafana-server start
+ PATH=/bin:/usr/bin:/sbin:/usr/sbin
+ NAME=grafana-server
+ DESC='Grafana Server'
+ DEFAULT=/etc/default/grafana-server
+ GRAFANA_USER=grafana
+ GRAFANA_GROUP=grafana
+ GRAFANA_HOME=/usr/share/grafana
+ CONF_DIR=/etc/grafana
+ WORK_DIR=/usr/share/grafana
+ DATA_DIR=/var/lib/grafana
+ PLUGINS_DIR=/var/lib/grafana/plugins
+ LOG_DIR=/var/log/grafana
+ CONF_FILE=/etc/grafana/grafana.ini
+ PROVISIONING_CFG_DIR=/etc/grafana/provisioning
+ MAX_OPEN_FILES=10000
+ PID_FILE=/var/run/grafana-server.pid
+ DAEMON=/usr/sbin/grafana-server
+ umask 0027
+ '[' '!' -x /usr/sbin/grafana-server ']'
+ . /lib/lsb/init-functions
+++ run-parts --lsbsysinit --list /lib/lsb/init-functions.d
++ for hook in $(run-parts --lsbsysinit --list /lib/lsb/init-functions.d 2>/dev/null)
++ '[' -r /lib/lsb/init-functions.d/00-verbose ']'
++ . /lib/lsb/init-functions.d/00-verbose
++ FANCYTTY=
++ '[' -e /etc/lsb-base-logging.sh ']'
++ true
+ '[' -r /etc/default/rcS ']'
+ '[' -f /etc/default/grafana-server ']'
+ . /etc/default/grafana-server
++ GRAFANA_USER=grafana
++ GRAFANA_GROUP=grafana
++ GRAFANA_HOME=/usr/share/grafana
++ LOG_DIR=/var/log/grafana
++ DATA_DIR=/var/lib/grafana
++ MAX_OPEN_FILES=10000
++ CONF_DIR=/etc/grafana
++ CONF_FILE=/etc/grafana/grafana.ini
++ RESTART_ON_UPGRADE=true
++ PLUGINS_DIR=/var/lib/grafana/plugins
++ PROVISIONING_CFG_DIR=/etc/grafana/provisioning
++ PID_FILE_DIR=/run/grafana
+ DAEMON_OPTS='--pidfile=/var/run/grafana-server.pid --config=/etc/grafana/grafana.ini --packaging=deb cfg:default.paths.provisioning=/etc/grafana/provisioning cfg:default.paths.data=/var/lib/grafana cfg:default.paths.logs=/var/log/grafana cfg:default.paths.plugins=/var/lib/grafana/plugins'
+ case "$1" in
+ checkUser
++ id -u
+ '[' 0 -ne 0 ']'
+ log_daemon_msg 'Starting Grafana Server'
+ '[' -z 'Starting Grafana Server' ']'
+ log_daemon_msg_pre 'Starting Grafana Server'
+ :
+ '[' -z '' ']'
+ echo -n 'Starting Grafana Server:'
Starting Grafana Server:+ return
++ pidofproc -p /var/run/grafana-server.pid grafana
++ local pidfile base status specified pid OPTIND
++ pidfile=
++ specified=
++ OPTIND=1
++ getopts p: opt
++ case "$opt" in
++ pidfile=/var/run/grafana-server.pid
++ specified=specified
++ getopts p: opt
++ shift 2
++ '[' 1 -ne 1 ']'
++ base=grafana
++ '[' '!' specified ']'
++ '[' -n /var/run/grafana-server.pid ']'
++ '[' -e /var/run/grafana-server.pid ']'
++ '[' -r /var/run/grafana-server.pid ']'
++ read pid
++ '[' -n 244 ']'
+++ kill -0 244
++ echo 244
++ return 0
+ pid=244
+ '[' -n 244 ']'
+ log_begin_msg 'Already running.'
+ log_begin_msg_pre 'Already running.'
+ :
+ '[' -z 'Already running.' ']'
+ echo -n 'Already running.'
Already running.+ log_begin_msg_post 'Already running.'
+ :
+ log_end_msg 0
+ '[' -z 0 ']'
+ local retval
+ retval=0
+ log_end_msg_pre 0
+ :
+ log_use_fancy_output
+ TPUT=/usr/bin/tput
+ EXPR=/usr/bin/expr
+ '[' -t 1 ']'
+ '[' xxterm '!=' x ']'
+ '[' xxterm '!=' xdumb ']'
+ '[' -x /usr/bin/tput ']'
+ '[' -x /usr/bin/expr ']'
+ /usr/bin/tput hpa 60
+ /usr/bin/tput setaf 1
+ '[' -z ']'
+ FANCYTTY=1
+ case "$FANCYTTY" in
+ true
++ /usr/bin/tput setaf 1
+ RED=''
++ /usr/bin/tput setaf 3
+ YELLOW=''
++ /usr/bin/tput op
+ NORMAL=''
+ '[' 0 -eq 0 ']'
+ echo .
.
+ log_end_msg_post 0
+ :
+ return 0
+ exit 0
```

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

When provisioning a Debian host with Grafana via `ansible` I noticed that the task to start the `grafana-service` service would fail on first run after a fresh install.
```yaml
    - name: Enable Grafana service
      become: true
      service:
        name: grafana-server
        state: started
        enabled: yes
```
```log
TASK [Enable Grafana service] ******************************************************************
fatal: [raspberrypi]: FAILED! => {"changed": false, "msg": "Starting Grafana Server: failed!\n"}
```

This is due to the upstart script only waiting for 1 second before assuming the process failed to start due to permission issues.

This pull request updates the upstart script to reuse the timeout routine in the same block in order to be more lenient when waiting for the process to start.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

