### PR TITLE
Docs: Note end of release notes publication

### DIFF
--- a/docs/sources/release-notes/_index.md
+++ b/docs/sources/release-notes/_index.md
@@ -7,12 +7,13 @@ weight: 10000
 
 # Release notes
 
-Here you can find detailed release notes that list everything that is included in past releases as well as notices
-about deprecations, breaking changes, and changes related to plugin development.
+Here you can find detailed release notes that list everything included in past releases,
+as well as notices about deprecations, breaking changes, and changes related to plugin development.
 
-> **Note:** As of Grafana v9.2, we no longer publish release notes.
-> For lists of changes to Grafana, with links to pull requests and related issues when available, see the [CHANGELOG](https://github.com/grafana/grafana/blob/main/CHANGELOG.md).
-> For details about new features, deprecations, and breaking changes, see [What's New in Grafana]({{< relref "../whatsnew/" >}}).
+> **Note:** As of Grafana v9.2 we no longer publish release notes, which are redundant with other release lists that we publish:
+>
+> - For details about new features, deprecations, and breaking changes in new Grafana releases, see [What's New in Grafana]({{< relref "../whatsnew/" >}}).
+> - For lists of changes to Grafana, with links to pull requests and related issues when available, see the [Changelog](https://github.com/grafana/grafana/blob/main/CHANGELOG.md).
 
 - [Release notes for 9.1.7]({{< relref "release-notes-9-1-7" >}})
 - [Release notes for 9.1.6]({{< relref "release-notes-9-1-6" >}})

--- a/docs/sources/release-notes/_index.md
+++ b/docs/sources/release-notes/_index.md
@@ -7,8 +7,12 @@ weight: 10000
 
 # Release notes
 
-Here you can find detailed release notes that list everything that is included in every release as well as notices
-about deprecations, breaking changes as well as changes that relate to plugin development.
+Here you can find detailed release notes that list everything that is included in past releases as well as notices
+about deprecations, breaking changes, and changes related to plugin development.
+
+> **Note:** As of Grafana v9.2, we no longer publish release notes.
+> For lists of changes to Grafana, with links to pull requests and related issues when available, see the [CHANGELOG](https://github.com/grafana/grafana/blob/main/CHANGELOG.md).
+> For details about new features, deprecations, and breaking changes, see [What's New in Grafana]({{< relref "../whatsnew/" >}}).
 
 - [Release notes for 9.1.7]({{< relref "release-notes-9-1-7" >}})
 - [Release notes for 9.1.6]({{< relref "release-notes-9-1-6" >}})

--- a/docs/sources/setup-grafana/upgrade-grafana.md
+++ b/docs/sources/setup-grafana/upgrade-grafana.md
@@ -19,8 +19,8 @@ In order to make this a reality, Grafana upgrades are backward compatible and th
 
 Upgrading between many minor versions and one major version is generally safe, and dashboards and graphs will look the same.
 There might be minor breaking changes in some releases.
-We outline these in the [What's New overviews]({{< relref "../../whatsnew/" >}}) for each release.
-For versions of Grafana prior to v9.2, we also published additional information in the [Release Notes]({{< relref "../../release-notes/" >}}).
+We outline these in the [What's New overviews]({{< relref "../whatsnew/" >}}) for each release.
+For versions of Grafana prior to v9.2, we also published additional information in the [Release Notes]({{< relref "../release-notes/" >}}).
 We also list all changes, with links to pull requests or issues when availble, in the [Changelog](https://github.com/grafana/grafana/blob/main/CHANGELOG.md).
 
 ## Backup

--- a/docs/sources/setup-grafana/upgrade-grafana.md
+++ b/docs/sources/setup-grafana/upgrade-grafana.md
@@ -17,7 +17,11 @@ weight: 500
 We recommend that you upgrade Grafana often to stay up to date with the latest fixes and enhancements.
 In order to make this a reality, Grafana upgrades are backward compatible and the upgrade process is simple and quick.
 
-Upgrading is generally safe (between many minor and one major version) and dashboards and graphs will look the same. There may be minor breaking changes in some edge cases, which are outlined in the [Release Notes](https://grafana.com/docs/grafana/latest/release-notes/) and [Changelog](https://github.com/grafana/grafana/blob/main/CHANGELOG.md)
+Upgrading between many minor versions and one major version is generally safe, and dashboards and graphs will look the same.
+There might be minor breaking changes in some releases.
+We outline these in the [What's New overviews]({{< relref "../../whatsnew/" >}}) for each release.
+For versions of Grafana prior to v9.2, we also published additional information in the [Release Notes]({{< relref "../../release-notes/" >}}).
+We also list all changes, with links to pull requests or issues when availble, in the [Changelog](https://github.com/grafana/grafana/blob/main/CHANGELOG.md).
 
 ## Backup
 
@@ -200,7 +204,7 @@ Grafana will fall back to using the database as a shared cache.
 
 ### Upgrading Elasticsearch to v7.0+
 
-The semantics of `max concurrent shard requests` changed in Elasticsearch v7.0, see [release notes](https://www.elastic.co/guide/en/elasticsearch/reference/7.0/breaking-changes-7.0.html#semantics-changed-max-concurrent-shared-requests) for reference.
+The semantics of `max concurrent shard requests` changed in Elasticsearch v7.0. See its [release notes](https://www.elastic.co/guide/en/elasticsearch/reference/7.0/breaking-changes-7.0.html#semantics-changed-max-concurrent-shared-requests) for reference.
 
 If you upgrade Elasticsearch to v7.0+ you should make sure to update the data source configuration in Grafana so that version
 is `7.0+` and `max concurrent shard requests` properly configured. 256 was the default in pre v7.0 versions. In v7.0 and above 5 is the default.

--- a/docs/sources/setup-grafana/upgrade-grafana.md
+++ b/docs/sources/setup-grafana/upgrade-grafana.md
@@ -21,7 +21,7 @@ Upgrading between many minor versions and one major version is generally safe, a
 There might be minor breaking changes in some releases.
 We outline these in the [What's New overviews]({{< relref "../whatsnew/" >}}) for each release.
 For versions of Grafana prior to v9.2, we also published additional information in the [Release Notes]({{< relref "../release-notes/" >}}).
-We also list all changes, with links to pull requests or issues when availble, in the [Changelog](https://github.com/grafana/grafana/blob/main/CHANGELOG.md).
+We also list all changes, with links to pull requests or issues when available, in the [Changelog](https://github.com/grafana/grafana/blob/main/CHANGELOG.md).
 
 ## Backup
 

--- a/docs/sources/whatsnew/_index.md
+++ b/docs/sources/whatsnew/_index.md
@@ -60,8 +60,11 @@ weight: 1
 
 # What's new in Grafana
 
-Grafana is changing all the time. For release highlights checkout links below, if you want a complete list of every change, as well
-as info on deprecations, breaking changes and plugin development read the [release notes]({{< relref "../release-notes/" >}}).
+For release highlights, deprecations, and breaking changes in Grafana releases, refer to these "What's new" pages for each version.
+
+> **Note:** For Grafana versions prior to v9.2, additional information might also be available in the archive of [release notes]({{< relref "../release-notes/" >}}).
+
+For a complete list of every change, with links to pull requests and related issues when available, see the [CHANGELOG](https://github.com/grafana/grafana/blob/main/CHANGELOG.md).
 
 ## Grafana 9
 

--- a/docs/sources/whatsnew/_index.md
+++ b/docs/sources/whatsnew/_index.md
@@ -64,7 +64,7 @@ For release highlights, deprecations, and breaking changes in Grafana releases, 
 
 > **Note:** For Grafana versions prior to v9.2, additional information might also be available in the archive of [release notes]({{< relref "../release-notes/" >}}).
 
-For a complete list of every change, with links to pull requests and related issues when available, see the [CHANGELOG](https://github.com/grafana/grafana/blob/main/CHANGELOG.md).
+For a complete list of every change, with links to pull requests and related issues when available, see the [Changelog](https://github.com/grafana/grafana/blob/main/CHANGELOG.md).
 
 ## Grafana 9
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Per #55471, implemented by grafana/grafana-github-actions#106, we've stopped publishing release notes for Grafana releases. The Changelog provides the list of changes with issue/PR links, and the What's New document provides authored announcements of features, deprecations, fixes, and breaking changes.

Update links to the release notes and add context for this change to the release notes and What's New indices.

**Which issue(s) this PR fixes**:

Fixes grafana/technical-documentation#477.

**Special notes for your reviewer**:

N/A