### PR TITLE
[Alerting] - replace label inputs with dropdowns

### DIFF
--- a/public/app/features/alerting/unified/Receivers.test.tsx
+++ b/public/app/features/alerting/unified/Receivers.test.tsx
@@ -233,8 +233,8 @@ describe('Receivers', () => {
     // enter custom annotations and labels
     await clickSelectOption(ui.contactPointAnnotationSelect(0).get(), 'Description');
     await userEvent.type(ui.contactPointAnnotationValue(0).get(), 'Test contact point');
-    await userEvent.type(ui.contactPointLabelKey(0).get(), 'foo');
-    await userEvent.type(ui.contactPointLabelValue(0).get(), 'bar');
+    await userEvent.type(within(ui.contactPointLabelKey(0).get()).getByRole('combobox'), 'foo{enter}');
+    await userEvent.type(within(ui.contactPointLabelValue(0).get()).getByRole('combobox'), 'bar{enter}');
     await userEvent.click(ui.testContactPoint.get());
 
     await waitFor(() => expect(mocks.api.testReceivers).toHaveBeenCalled());

--- a/public/app/features/alerting/unified/RuleEditor.test.tsx
+++ b/public/app/features/alerting/unified/RuleEditor.test.tsx
@@ -100,6 +100,8 @@ const ui = {
   },
 };
 
+const getLabelInput = (selector: HTMLElement) => within(selector).getByRole('combobox');
+
 describe('RuleEditor', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -175,10 +177,10 @@ describe('RuleEditor', () => {
     // TODO remove skipPointerEventsCheck once https://github.com/jsdom/jsdom/issues/3232 is fixed
     await userEvent.click(ui.buttons.addLabel.get(), { pointerEventsCheck: PointerEventsCheckLevel.Never });
 
-    await userEvent.type(ui.inputs.labelKey(0).get(), 'severity');
-    await userEvent.type(ui.inputs.labelValue(0).get(), 'warn');
-    await userEvent.type(ui.inputs.labelKey(1).get(), 'team');
-    await userEvent.type(ui.inputs.labelValue(1).get(), 'the a-team');
+    await userEvent.type(getLabelInput(ui.inputs.labelKey(0).get()), 'severity{enter}');
+    await userEvent.type(getLabelInput(ui.inputs.labelValue(0).get()), 'warn{enter}');
+    await userEvent.type(getLabelInput(ui.inputs.labelKey(1).get()), 'team{enter}');
+    await userEvent.type(getLabelInput(ui.inputs.labelValue(1).get()), 'the a-team{enter}');
 
     // save and check what was sent to backend
     await userEvent.click(ui.buttons.save.get());
@@ -276,10 +278,10 @@ describe('RuleEditor', () => {
     // TODO remove skipPointerEventsCheck once https://github.com/jsdom/jsdom/issues/3232 is fixed
     await userEvent.click(ui.buttons.addLabel.get(), { pointerEventsCheck: PointerEventsCheckLevel.Never });
 
-    await userEvent.type(ui.inputs.labelKey(0).get(), 'severity');
-    await userEvent.type(ui.inputs.labelValue(0).get(), 'warn');
-    await userEvent.type(ui.inputs.labelKey(1).get(), 'team');
-    await userEvent.type(ui.inputs.labelValue(1).get(), 'the a-team');
+    await userEvent.type(getLabelInput(ui.inputs.labelKey(0).get()), 'severity{enter}');
+    await userEvent.type(getLabelInput(ui.inputs.labelValue(0).get()), 'warn{enter}');
+    await userEvent.type(getLabelInput(ui.inputs.labelKey(1).get()), 'team{enter}');
+    await userEvent.type(getLabelInput(ui.inputs.labelValue(1).get()), 'the a-team{enter}');
 
     // save and check what was sent to backend
     await userEvent.click(ui.buttons.save.get());
@@ -370,8 +372,8 @@ describe('RuleEditor', () => {
     // TODO remove skipPointerEventsCheck once https://github.com/jsdom/jsdom/issues/3232 is fixed
     await userEvent.click(ui.buttons.addLabel.get(), { pointerEventsCheck: PointerEventsCheckLevel.Never });
 
-    await userEvent.type(ui.inputs.labelKey(1).get(), 'team');
-    await userEvent.type(ui.inputs.labelValue(1).get(), 'the a-team');
+    await userEvent.type(getLabelInput(ui.inputs.labelKey(1).get()), 'team{enter}');
+    await userEvent.type(getLabelInput(ui.inputs.labelValue(1).get()), 'the a-team{enter}');
 
     // try to save, find out that recording rule name is invalid
     await userEvent.click(ui.buttons.save.get());
@@ -502,8 +504,8 @@ describe('RuleEditor', () => {
     await userEvent.type(ui.inputs.annotationValue(2).get(), 'value');
 
     //add a label
-    await userEvent.type(ui.inputs.labelKey(2).get(), 'custom');
-    await userEvent.type(ui.inputs.labelValue(2).get(), 'value');
+    await userEvent.type(getLabelInput(ui.inputs.labelKey(2).get()), 'custom{enter}');
+    await userEvent.type(getLabelInput(ui.inputs.labelValue(2).get()), 'value{enter}');
 
     // save and check what was sent to backend
     await userEvent.click(ui.buttons.save.get());

--- a/public/app/features/alerting/unified/components/AlertLabelDropdown.tsx
+++ b/public/app/features/alerting/unified/components/AlertLabelDropdown.tsx
@@ -1,0 +1,35 @@
+import React, { FC } from 'react';
+
+import { SelectableValue } from '@grafana/data';
+import { Select, Field } from '@grafana/ui';
+
+export interface AlertLabelDropdownProps {
+  onChange: (newValue: SelectableValue<string>) => void;
+  options: SelectableValue[];
+  defaultValue?: SelectableValue;
+  type: 'key' | 'value';
+}
+
+const AlertLabelDropdown: FC<AlertLabelDropdownProps> = React.forwardRef(function labelPicker(
+  { onChange, options, defaultValue, type },
+  ref
+) {
+  return (
+    <Field disabled={false} data-testid={`alertlabel-${type}-picker`}>
+      <Select
+        placeholder={'Choose key'}
+        width={29}
+        className="ds-picker select-container"
+        backspaceRemovesValue={false}
+        onChange={onChange}
+        options={options}
+        maxMenuHeight={500}
+        noOptionsMessage="No labels found"
+        defaultValue={defaultValue}
+        allowCustomValue
+      />
+    </Field>
+  );
+});
+
+export default AlertLabelDropdown;

--- a/public/app/features/alerting/unified/components/AlertLabelDropdown.tsx
+++ b/public/app/features/alerting/unified/components/AlertLabelDropdown.tsx
@@ -10,26 +10,27 @@ export interface AlertLabelDropdownProps {
   type: 'key' | 'value';
 }
 
-const AlertLabelDropdown: FC<AlertLabelDropdownProps> = React.forwardRef(function labelPicker(
-  { onChange, options, defaultValue, type },
-  ref
-) {
-  return (
-    <Field disabled={false} data-testid={`alertlabel-${type}-picker`}>
-      <Select
-        placeholder={'Choose key'}
-        width={29}
-        className="ds-picker select-container"
-        backspaceRemovesValue={false}
-        onChange={onChange}
-        options={options}
-        maxMenuHeight={500}
-        noOptionsMessage="No labels found"
-        defaultValue={defaultValue}
-        allowCustomValue
-      />
-    </Field>
-  );
-});
+const AlertLabelDropdown: FC<AlertLabelDropdownProps> = React.forwardRef<HTMLDivElement, AlertLabelDropdownProps>(
+  function labelPicker({ onChange, options, defaultValue, type }, ref) {
+    return (
+      <div ref={ref}>
+        <Field disabled={false} data-testid={`alertlabel-${type}-picker`}>
+          <Select
+            placeholder={'Choose key'}
+            width={29}
+            className="ds-picker select-container"
+            backspaceRemovesValue={false}
+            onChange={onChange}
+            options={options}
+            maxMenuHeight={500}
+            noOptionsMessage="No labels found"
+            defaultValue={defaultValue}
+            allowCustomValue
+          />
+        </Field>
+      </div>
+    );
+  }
+);
 
 export default AlertLabelDropdown;

--- a/public/app/features/alerting/unified/components/AlertLabelDropdown.tsx
+++ b/public/app/features/alerting/unified/components/AlertLabelDropdown.tsx
@@ -16,7 +16,7 @@ const AlertLabelDropdown: FC<AlertLabelDropdownProps> = React.forwardRef<HTMLDiv
       <div ref={ref}>
         <Field disabled={false} data-testid={`alertlabel-${type}-picker`}>
           <Select
-            placeholder={'Choose key'}
+            placeholder={`Choose ${type}`}
             width={29}
             className="ds-picker select-container"
             backspaceRemovesValue={false}

--- a/public/app/features/alerting/unified/components/rule-editor/LabelsField.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/LabelsField.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { Provider } from 'react-redux';
+
+import { configureStore } from 'app/store/configureStore';
+
+import LabelsField from './LabelsField';
+
+const labels = [
+  { key: 'key1', value: 'value1' },
+  { key: 'key2', value: 'value2' },
+];
+
+const FormProviderWrapper: React.FC = ({ children }) => {
+  const methods = useForm({ defaultValues: { labels } });
+  return <FormProvider {...methods}>{children}</FormProvider>;
+};
+
+function renderAlertLabelsPicker() {
+  const store = configureStore({});
+
+  render(
+    <Provider store={store}>
+      <LabelsField />
+    </Provider>,
+    { wrapper: FormProviderWrapper }
+  );
+}
+
+describe('AlertLabelsPicker', () => {
+  it('Should display two dropdowns with the existing labels', async () => {
+    renderAlertLabelsPicker();
+
+    expect(screen.getAllByTestId('alertlabel-key-picker')).toHaveLength(2);
+
+    expect(screen.getByTestId('label-key-0').textContent).toBe('key1');
+    expect(screen.getByTestId('label-key-1').textContent).toBe('key2');
+
+    expect(screen.getAllByTestId('alertlabel-value-picker')).toHaveLength(2);
+
+    expect(screen.getByTestId('label-value-0').textContent).toBe('value1');
+    expect(screen.getByTestId('label-value-1').textContent).toBe('value2');
+  });
+
+  it('Should delete a key-value combination', async () => {
+    renderAlertLabelsPicker();
+
+    expect(screen.getAllByTestId('alertlabel-key-picker')).toHaveLength(2);
+    expect(screen.getAllByTestId('alertlabel-value-picker')).toHaveLength(2);
+
+    await userEvent.click(screen.getByTestId('delete-label-1'));
+
+    expect(screen.getAllByTestId('alertlabel-key-picker')).toHaveLength(1);
+    expect(screen.getAllByTestId('alertlabel-value-picker')).toHaveLength(1);
+  });
+
+  it('Should add new key-value dropdowns', async () => {
+    renderAlertLabelsPicker();
+
+    await userEvent.click(screen.getByText('Add label'));
+
+    expect(screen.getAllByTestId('alertlabel-key-picker')).toHaveLength(3);
+
+    expect(screen.getByTestId('label-key-0').textContent).toBe('key1');
+    expect(screen.getByTestId('label-key-1').textContent).toBe('key2');
+    expect(screen.getByTestId('label-key-2').textContent).toBe('');
+
+    expect(screen.getAllByTestId('alertlabel-value-picker')).toHaveLength(3);
+
+    expect(screen.getByTestId('label-value-0').textContent).toBe('value1');
+    expect(screen.getByTestId('label-value-1').textContent).toBe('value2');
+    expect(screen.getByTestId('label-value-2').textContent).toBe('');
+  });
+
+  it('Should be able to write new keys and values using the dropdowns', async () => {
+    renderAlertLabelsPicker();
+
+    await userEvent.click(screen.getByText('Add label'));
+
+    const LastKeyDropdown = within(screen.getByTestId('label-key-2'));
+    const LastValueDropdown = within(screen.getByTestId('label-value-2'));
+
+    await userEvent.type(LastKeyDropdown.getByRole('combobox'), 'key3{enter}');
+    await userEvent.type(LastValueDropdown.getByRole('combobox'), 'value3{enter}');
+
+    expect(screen.getByTestId('label-key-2').textContent).toBe('key3');
+    expect(screen.getByTestId('label-value-2').textContent).toBe('value3');
+  });
+});

--- a/public/app/features/alerting/unified/components/rule-editor/LabelsField.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/LabelsField.tsx
@@ -62,7 +62,7 @@ const LabelsField: FC<Props> = ({ className }) => {
                         {...register(`labels.${index}.key`, {
                           required: { value: !!labels[index]?.value, message: 'Required.' },
                         })}
-                        defaultValue={{ label: field.key, value: field.key }}
+                        defaultValue={field.key ? { label: field.key, value: field.key } : undefined}
                         options={keys}
                         onChange={(newValue: SelectableValue) => setValue(`labels.${index}.key`, newValue.value)}
                         type="key"
@@ -79,7 +79,7 @@ const LabelsField: FC<Props> = ({ className }) => {
                         {...register(`labels.${index}.value`, {
                           required: { value: !!labels[index]?.key, message: 'Required.' },
                         })}
-                        defaultValue={{ label: field.value, value: field.value }}
+                        defaultValue={field.value ? { label: field.value, value: field.value } : undefined}
                         options={values}
                         onChange={(newValue: SelectableValue) => setValue(`labels.${index}.value`, newValue.value)}
                         type="value"

--- a/public/app/features/alerting/unified/components/rule-editor/LabelsField.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/LabelsField.tsx
@@ -30,7 +30,7 @@ const LabelsField: FC<Props> = ({ className }) => {
     type: AlertLabelDropdownProps['type']
   ) =>
     [...new Set(fields.map((field) => field[type]))]
-      .filter((field) => !!field)
+      .filter((field) => Boolean(field))
       .map((field) => ({ label: field, value: field }));
 
   const keys = useMemo(() => {
@@ -54,13 +54,13 @@ const LabelsField: FC<Props> = ({ className }) => {
                   <div className={cx(styles.flexRow, styles.centerAlignRow)}>
                     <Field
                       className={styles.labelInput}
-                      invalid={!!errors.labels?.[index]?.key?.message}
+                      invalid={Boolean(errors.labels?.[index]?.key?.message)}
                       error={errors.labels?.[index]?.key?.message}
                       data-testid={`label-key-${index}`}
                     >
                       <AlertLabelDropdown
                         {...register(`labels.${index}.key`, {
-                          required: { value: !!labels[index]?.value, message: 'Required.' },
+                          required: { value: Boolean(labels[index]?.value), message: 'Required.' },
                         })}
                         defaultValue={field.key ? { label: field.key, value: field.key } : undefined}
                         options={keys}
@@ -71,13 +71,13 @@ const LabelsField: FC<Props> = ({ className }) => {
                     <InlineLabel className={styles.equalSign}>=</InlineLabel>
                     <Field
                       className={styles.labelInput}
-                      invalid={!!errors.labels?.[index]?.value?.message}
+                      invalid={Boolean(errors.labels?.[index]?.value?.message)}
                       error={errors.labels?.[index]?.value?.message}
                       data-testid={`label-value-${index}`}
                     >
                       <AlertLabelDropdown
                         {...register(`labels.${index}.value`, {
-                          required: { value: !!labels[index]?.key, message: 'Required.' },
+                          required: { value: Boolean(labels[index]?.key), message: 'Required.' },
                         })}
                         defaultValue={field.value ? { label: field.value, value: field.value } : undefined}
                         options={values}


### PR DESCRIPTION
This PR is the first of a series of work where we improve the labels creation/selection in Alerting. It won't be merged to `main` until all following items are complete:

- [x]  Replace label inputs with dropdowns, maintaining the same adding/removing functionality

![2022-10-14 14 55 00](https://user-images.githubusercontent.com/6271380/195910769-dad05391-c129-4f18-98c2-b64ff5ff04a8.gif)

The next steps will involve:
- [ ]  Populate these dropdowns with existing custom labels data to provide previous values for users to select.
- [ ]  Let users know this is not the full list of labels, there are more that we can't obtain at the point when creating an alert rule.


Part of https://github.com/grafana/grafana/issues/45455



