### PR TITLE
SceneObjects: Support for state defaults 

### DIFF
--- a/public/app/features/scenes/components/SceneFlexLayout.tsx
+++ b/public/app/features/scenes/components/SceneFlexLayout.tsx
@@ -2,18 +2,28 @@ import React, { CSSProperties } from 'react';
 
 import { Field, RadioButtonGroup } from '@grafana/ui';
 
-import { SceneObjectBase } from '../core/SceneObjectBase';
+import { Defaultize, SceneObjectBase } from '../core/SceneObjectBase';
 import { SceneObjectSize, SceneLayoutState, SceneComponentProps, SceneLayoutChild } from '../core/types';
 
 export type FlexLayoutDirection = 'column' | 'row';
-
 interface SceneFlexLayoutState extends SceneLayoutState {
-  direction?: FlexLayoutDirection;
+  direction: FlexLayoutDirection;
 }
+
+const defaultProps = {
+  direction: 'row' as const,
+};
 
 export class SceneFlexLayout extends SceneObjectBase<SceneFlexLayoutState> {
   static Component = FlexLayoutRenderer;
   static Editor = FlexLayoutEditor;
+
+  constructor(state: Defaultize<SceneFlexLayoutState, typeof defaultProps>) {
+    super({
+      ...defaultProps,
+      ...state,
+    });
+  }
 
   toggleDirection() {
     this.setState({
@@ -23,7 +33,7 @@ export class SceneFlexLayout extends SceneObjectBase<SceneFlexLayoutState> {
 }
 
 function FlexLayoutRenderer({ model, isEditing }: SceneComponentProps<SceneFlexLayout>) {
-  const { direction = 'row', children } = model.useState();
+  const { direction, children } = model.useState();
 
   return (
     <div style={{ flexGrow: 1, flexDirection: direction, display: 'flex', gap: '8px' }}>

--- a/public/app/features/scenes/core/SceneObjectBase.tsx
+++ b/public/app/features/scenes/core/SceneObjectBase.tsx
@@ -18,6 +18,13 @@ import {
   SceneLayoutChild,
 } from './types';
 
+type InexactPartial<T> = { [K in keyof T]?: T[K] | undefined };
+
+export type Defaultize<TState, TDefaults> = Pick<TState, Exclude<keyof TState, keyof TDefaults>> &
+  InexactPartial<Pick<TState, Extract<keyof TState, keyof TDefaults>>>;
+
+export type ExtractDefaultPropsType<T> = T extends { defaultProps: infer D } ? D : {};
+
 export abstract class SceneObjectBase<TState extends SceneObjectState = {}> implements SceneObject<TState> {
   subject = new Subject<TState>();
   state: TState;
@@ -26,6 +33,8 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = {}> impl
   isActive?: boolean;
   events = new EventBusSrv();
 
+  // this is not working
+  // constructor(state: Defaultize<TState, ExtractDefaultPropsType<this>>) {
   constructor(state: TState) {
     if (!state.key) {
       state.key = uuidv4();

--- a/public/app/features/scenes/scenes/demo.tsx
+++ b/public/app/features/scenes/scenes/demo.tsx
@@ -15,7 +15,6 @@ export function getFlexLayoutTest(): Scene {
   const scene = new Scene({
     title: 'Flex layout test',
     layout: new SceneFlexLayout({
-      direction: 'row',
       children: [
         new VizPanel({
           pluginId: 'timeseries',


### PR DESCRIPTION
Just exploring typescript ideas for default state. Have not been able to get it to work with a generic typing solution similar to how it works for react components. 

Been looking how they type that: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L3105 

but not sure how they infer / use that for the constructor type (I don't think they do), they only use that for the generated JSX code I think. 

But I am not sure doing this is a good idea in the end, that is using default props that change the constructor state type so that props that defined in the default props get's transformed into to optional props. 

It does make type errors (for missing required props) look like this:
<img width="930" alt="Screenshot 2022-10-15 at 14 23 13" src="https://user-images.githubusercontent.com/10999/196002374-8605fc69-3a71-41d4-97e9-2d762c880842.png">

But maybe that is worth it.
