### PR TITLE
Docs: Contextualize base64 encoding in Basic Authorization

### DIFF
--- a/docs/sources/developers/http_api/curl-examples.md
+++ b/docs/sources/developers/http_api/curl-examples.md
@@ -22,8 +22,19 @@ The most basic example for a dashboard for which there is no authentication. You
 curl http://localhost:3000/api/search
 ```
 
-Here’s a cURL command that works for getting the home dashboard when you are running Grafana locally with [basic authentication]({{< relref "../../setup-grafana/configure-security/configure-authentication/#basic-auth" >}}) enabled using the default admin credentials:
+Here's a cURL command that works for getting the home dashboard when you are running Grafana locally with [basic authentication]({{< relref "../../setup-grafana/configure-security/configure-authentication/#basic-auth" >}}) enabled using the default admin credentials:
 
 ```
 curl http://admin:admin@localhost:3000/api/search
 ```
+
+To pass a username and password with [HTTP basic authorization]({{< relref "/administration/roles-and-permissions/access-control/manage-rbac-roles/" >}}), encode them as base64.
+You can't use authorization tokens in the request.
+
+For example, to [list permissions associated with roles]({{< relref "/administration/roles-and-permissions/access-control/manage-rbac-roles/" >}}) given a username of `user` and password of `password`, use:
+
+```
+curl --location --request GET '<grafana_url>/api/access-control/builtin-roles' --header 'Authorization: Basic dXNlcjpwYXNzd29yZAo='
+```
+
+where `dXNlcjpwYXNzd29yZAo=` is the base64 encoding of `user:password`.


### PR DESCRIPTION
**What this PR does / why we need it**:

If a user's unfamiliar with HTTP Basic Authorization, it's unclear what the string of encoded characters at the end of our cURL examples using it are. Contextualize this in the cURL examples doc.

**Which issue(s) this PR fixes**:

Fixes grafana/technical-documentation#422