### PR TITLE
[v9.2.x] CI: Make publish packages depend on compile-build-cmd and run from bin/build (#56713)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1764,10 +1764,10 @@ steps:
   image: alpine:3.15.6
   name: identify-runner
 - commands:
-  - ./bin/grabpl publish packages --edition oss --gcp-key /tmp/gcpkey.json --build-id
+  - ./bin/build publish packages --edition oss --gcp-key /tmp/gcpkey.json --build-id
     ${DRONE_BUILD_NUMBER}
   depends_on:
-  - grabpl
+  - compile-build-cmd
   environment:
     GCP_KEY:
       from_secret: gcp_key
@@ -3795,9 +3795,9 @@ steps:
   image: golang:1.19.2
   name: compile-build-cmd
 - commands:
-  - ./bin/grabpl publish packages --edition oss --gcp-key /tmp/gcpkey.json ${DRONE_TAG}
+  - ./bin/build publish packages --edition oss --gcp-key /tmp/gcpkey.json ${DRONE_TAG}
   depends_on:
-  - grabpl
+  - compile-build-cmd
   environment:
     GCP_KEY:
       from_secret: gcp_key
@@ -3884,10 +3884,9 @@ steps:
   image: golang:1.19.2
   name: compile-build-cmd
 - commands:
-  - ./bin/grabpl publish packages --edition enterprise --gcp-key /tmp/gcpkey.json
-    ${DRONE_TAG}
+  - ./bin/build publish packages --edition enterprise --gcp-key /tmp/gcpkey.json ${DRONE_TAG}
   depends_on:
-  - grabpl
+  - compile-build-cmd
   environment:
     GCP_KEY:
       from_secret: gcp_key
@@ -5569,6 +5568,6 @@ kind: secret
 name: packages_secret_access_key
 ---
 kind: signature
-hmac: f623074e7e0a99a79b521aea9a83f050f760aa6f7633c6a910b6cb077ec01045
+hmac: a28de1c8b49f0e915c5754775a4e5b27a21e0b063232c527690e4535842dc737
 
 ...

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -988,12 +988,12 @@ def upload_packages_step(edition, ver_mode, trigger=None):
 
 def publish_packages_step(edition, ver_mode):
     if ver_mode == 'release':
-        cmd = './bin/grabpl publish packages --edition {} --gcp-key /tmp/gcpkey.json ${{DRONE_TAG}}'.format(
+        cmd = './bin/build publish packages --edition {} --gcp-key /tmp/gcpkey.json ${{DRONE_TAG}}'.format(
             edition,
         )
     elif ver_mode == 'main':
         build_no = '${DRONE_BUILD_NUMBER}'
-        cmd = './bin/grabpl publish packages --edition {} --gcp-key /tmp/gcpkey.json --build-id {}'.format(
+        cmd = './bin/build publish packages --edition {} --gcp-key /tmp/gcpkey.json --build-id {}'.format(
             edition, build_no,
         )
     else:
@@ -1003,7 +1003,7 @@ def publish_packages_step(edition, ver_mode):
         'name': 'publish-packages-{}'.format(edition),
         'image': publish_image,
         'depends_on': [
-            'grabpl',
+            'compile-build-cmd',
         ],
         'environment': {
             'GRAFANA_COM_API_KEY': from_secret('grafana_api_key'),


### PR DESCRIPTION
(cherry picked from commit e25475b9c898ac99a2f015afc113828430556750)

Backport of #56713