### PR TITLE
Toolkit: Fix `Cannot use import statement outside...` error in tests

### DIFF
--- a/packages/grafana-toolkit/src/cli/tasks/toolkit.build.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/toolkit.build.ts
@@ -30,6 +30,7 @@ const copyFiles = () => {
     'src/config/tsconfig.plugin.local.json',
     'src/config/eslint.plugin.js',
     'src/config/styles.mock.js',
+    'src/config/jest.babel.config.js',
     'src/config/jest.plugin.config.local.js',
     'src/config/matchMedia.js',
     'src/config/react-inlinesvg.tsx',

--- a/packages/grafana-toolkit/src/config/jest.babel.config.js
+++ b/packages/grafana-toolkit/src/config/jest.babel.config.js
@@ -1,0 +1,2 @@
+// Transform es modules to prevent `SyntaxError: Cannot use import statement outside a module`
+module.exports = { presets: [['@babel/preset-env', { targets: { esmodules: false, node: 'current' } }]] };

--- a/packages/grafana-toolkit/src/config/jest.plugin.config.ts
+++ b/packages/grafana-toolkit/src/config/jest.plugin.config.ts
@@ -83,7 +83,10 @@ export const jestConfig = (baseDir: string = process.cwd()) => {
       '<rootDir>/spec/**/*.{spec,test,jest}.{js,jsx,ts,tsx}',
     ],
     transform: {
-      '^.+\\.jsx?$': require.resolve('babel-jest'),
+      '^.+\\.(js|jsx|mjs)$': [
+        require.resolve('babel-jest'),
+        { configFile: path.resolve(__dirname, './jest.babel.config.js') },
+      ],
       '^.+\\.tsx?$': require.resolve('ts-jest'),
     },
     transformIgnorePatterns: [


### PR DESCRIPTION

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
It appears our jest config in toolkit needed an update to work correctly with the introduction of grafana/ui, data, rutime esm builds in 9.2.0. This PR adds the necessary transformation so tests continue to run as expected without a plugin developer needing to make changes.

| Before | After |
| --- | --- |
| <img width="1127" alt="Screenshot 2022-10-17 at 11 46 46" src="https://user-images.githubusercontent.com/73201/196146381-4fae1c25-ff99-4816-8599-ec2428a32b73.png"> | <img width="1026" alt="Screenshot 2022-10-17 at 11 44 33" src="https://user-images.githubusercontent.com/73201/196146397-6bbfcac6-fa7c-4856-90cd-123d1e203301.png"> |


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #57070

**Special notes for your reviewer**:
To test this with a plugin, try cloning, bumping the `@grafana` dependencies to 9.2.0 then run the tests (`yarn test`). They should fail with `SyntaxError: Cannot use import statement outside a module`. Now bump the toolkit dependency to `9.2.1-toolkit-jest-fix`, run `yarn` and `yarn test` again. Tests should now pass.
