### PR TITLE
CI: Add `node` as a parameter in pipeline function

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -6,8 +6,6 @@ image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
 name: pr-verify-drone
-node:
-  type: no-parallel
 platform:
   arch: amd64
   os: linux
@@ -175,8 +173,6 @@ image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
 name: pr-test-backend
-node:
-  type: no-parallel
 platform:
   arch: amd64
   os: linux
@@ -249,8 +245,6 @@ image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
 name: pr-lint-backend
-node:
-  type: no-parallel
 platform:
   arch: amd64
   os: linux
@@ -591,8 +585,6 @@ image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
 name: pr-integration-tests
-node:
-  type: no-parallel
 platform:
   arch: amd64
   os: linux
@@ -716,8 +708,6 @@ image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
 name: pr-docs
-node:
-  type: no-parallel
 platform:
   arch: amd64
   os: linux
@@ -786,8 +776,6 @@ image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
 name: pr-shellcheck
-node:
-  type: no-parallel
 platform:
   arch: amd64
   os: linux
@@ -829,8 +817,6 @@ image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
 name: main-docs
-node:
-  type: no-parallel
 platform:
   arch: amd64
   os: linux
@@ -1009,8 +995,6 @@ image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
 name: main-test-backend
-node:
-  type: no-parallel
 platform:
   arch: amd64
   os: linux
@@ -1076,8 +1060,6 @@ image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
 name: main-lint-backend
-node:
-  type: no-parallel
 platform:
   arch: amd64
   os: linux
@@ -1518,8 +1500,6 @@ image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
 name: main-integration-tests
-node:
-  type: no-parallel
 platform:
   arch: amd64
   os: linux
@@ -1741,8 +1721,6 @@ image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
 name: main-publish
-node:
-  type: no-parallel
 platform:
   arch: amd64
   os: linux
@@ -1808,8 +1786,6 @@ image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
 name: main-trigger-downstream
-node:
-  type: no-parallel
 platform:
   arch: amd64
   os: linux
@@ -1888,8 +1864,6 @@ image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
 name: release-oss-build-e2e-publish
-node:
-  type: no-parallel
 platform:
   arch: amd64
   os: linux
@@ -2251,8 +2225,6 @@ image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
 name: release-oss-test-backend
-node:
-  type: no-parallel
 platform:
   arch: amd64
   os: linux
@@ -2317,8 +2289,6 @@ image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
 name: release-oss-integration-tests
-node:
-  type: no-parallel
 platform:
   arch: amd64
   os: linux
@@ -2492,8 +2462,6 @@ image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
 name: release-enterprise-build-e2e-publish
-node:
-  type: no-parallel
 platform:
   arch: amd64
   os: linux
@@ -2924,8 +2892,6 @@ image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
 name: release-enterprise-test-backend
-node:
-  type: no-parallel
 platform:
   arch: amd64
   os: linux
@@ -3023,8 +2989,6 @@ image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
 name: release-enterprise2-test-backend
-node:
-  type: no-parallel
 platform:
   arch: amd64
   os: linux
@@ -3122,8 +3086,6 @@ image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
 name: release-enterprise-integration-tests
-node:
-  type: no-parallel
 platform:
   arch: amd64
   os: linux
@@ -3365,8 +3327,6 @@ image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
 name: publish-docker-oss-public
-node:
-  type: no-parallel
 platform:
   arch: amd64
   os: linux
@@ -3453,8 +3413,6 @@ image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
 name: publish-docker-enterprise-public
-node:
-  type: no-parallel
 platform:
   arch: amd64
   os: linux
@@ -3524,8 +3482,6 @@ image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
 name: publish-docker-enterprise-security
-node:
-  type: no-parallel
 platform:
   arch: amd64
   os: linux
@@ -3596,8 +3552,6 @@ image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
 name: publish-artifacts-security
-node:
-  type: no-parallel
 platform:
   arch: amd64
   os: linux
@@ -3638,8 +3592,6 @@ image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
 name: publish-artifacts-public
-node:
-  type: no-parallel
 platform:
   arch: amd64
   os: linux
@@ -3680,8 +3632,6 @@ image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
 name: publish-npm-packages-public
-node:
-  type: no-parallel
 platform:
   arch: amd64
   os: linux
@@ -3741,8 +3691,6 @@ image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
 name: publish-packages-oss
-node:
-  type: no-parallel
 platform:
   arch: amd64
   os: linux
@@ -3852,8 +3800,6 @@ image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
 name: publish-packages-enterprise
-node:
-  type: no-parallel
 platform:
   arch: amd64
   os: linux
@@ -3960,8 +3906,6 @@ image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
 name: publish-artifacts-page
-node:
-  type: no-parallel
 platform:
   arch: amd64
   os: linux
@@ -4001,8 +3945,6 @@ image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
 name: release-branch-oss-build-e2e-publish
-node:
-  type: no-parallel
 platform:
   arch: amd64
   os: linux
@@ -4333,8 +4275,6 @@ image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
 name: release-branch-oss-test-backend
-node:
-  type: no-parallel
 platform:
   arch: amd64
   os: linux
@@ -4396,8 +4336,6 @@ image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
 name: release-branch-oss-integration-tests
-node:
-  type: no-parallel
 platform:
   arch: amd64
   os: linux
@@ -4561,8 +4499,6 @@ image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
 name: release-branch-enterprise-build-e2e-publish
-node:
-  type: no-parallel
 platform:
   arch: amd64
   os: linux
@@ -4983,8 +4919,6 @@ image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
 name: release-branch-enterprise-test-backend
-node:
-  type: no-parallel
 platform:
   arch: amd64
   os: linux
@@ -5078,8 +5012,6 @@ image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
 name: release-branch-enterprise2-test-backend
-node:
-  type: no-parallel
 platform:
   arch: amd64
   os: linux
@@ -5173,8 +5105,6 @@ image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
 name: release-branch-enterprise-integration-tests
-node:
-  type: no-parallel
 platform:
   arch: amd64
   os: linux
@@ -5618,6 +5548,6 @@ kind: secret
 name: packages_secret_access_key
 ---
 kind: signature
-hmac: 015389b7bbd46fbb8042817bd41a320c71744023710a1bdfb815b9cb28ddd7e3
+hmac: f7f4d8346976a28a74add8c7a6881de079111eaf767534b16603e6c4f2b783e9
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -173,6 +173,8 @@ image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
 name: pr-test-backend
+node:
+  type: no-parallel
 platform:
   arch: amd64
   os: linux
@@ -995,6 +997,8 @@ image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
 name: main-test-backend
+node:
+  type: no-parallel
 platform:
   arch: amd64
   os: linux
@@ -2225,6 +2229,8 @@ image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
 name: release-oss-test-backend
+node:
+  type: no-parallel
 platform:
   arch: amd64
   os: linux
@@ -2892,6 +2898,8 @@ image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
 name: release-enterprise-test-backend
+node:
+  type: no-parallel
 platform:
   arch: amd64
   os: linux
@@ -2989,6 +2997,8 @@ image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
 name: release-enterprise2-test-backend
+node:
+  type: no-parallel
 platform:
   arch: amd64
   os: linux
@@ -4275,6 +4285,8 @@ image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
 name: release-branch-oss-test-backend
+node:
+  type: no-parallel
 platform:
   arch: amd64
   os: linux
@@ -4919,6 +4931,8 @@ image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
 name: release-branch-enterprise-test-backend
+node:
+  type: no-parallel
 platform:
   arch: amd64
   os: linux
@@ -5012,6 +5026,8 @@ image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
 name: release-branch-enterprise2-test-backend
+node:
+  type: no-parallel
 platform:
   arch: amd64
   os: linux
@@ -5548,6 +5564,6 @@ kind: secret
 name: packages_secret_access_key
 ---
 kind: signature
-hmac: f7f4d8346976a28a74add8c7a6881de079111eaf767534b16603e6c4f2b783e9
+hmac: dd2b6fb51f9f5db036fbb02d284f42b1414b5a04b95a8758ac6478bdb323c6a5
 
 ...

--- a/scripts/drone/pipelines/build.star
+++ b/scripts/drone/pipelines/build.star
@@ -102,5 +102,5 @@ def build_e2e(trigger, ver_mode, edition):
         publish_suffix = '-publish'
 
     return pipeline(
-        name='{}-build-e2e{}'.format(ver_mode, publish_suffix), edition="oss", trigger=trigger, services=[], steps=init_steps + build_steps,
+        name='{}-build-e2e{}'.format(ver_mode, publish_suffix), edition="oss", trigger=trigger, services=[], steps=init_steps + build_steps, node='no-parallel',
     )

--- a/scripts/drone/pipelines/lint_frontend.star
+++ b/scripts/drone/pipelines/lint_frontend.star
@@ -21,5 +21,5 @@ def lint_frontend_pipeline(trigger, ver_mode):
         lint_frontend_step(),
     ]
     return pipeline(
-        name='{}-lint-frontend'.format(ver_mode), edition="oss", trigger=trigger, services=[], steps=init_steps + test_steps,
+        name='{}-lint-frontend'.format(ver_mode), edition="oss", trigger=trigger, services=[], steps=init_steps + test_steps, node='node-parallel'
     )

--- a/scripts/drone/pipelines/lint_frontend.star
+++ b/scripts/drone/pipelines/lint_frontend.star
@@ -21,5 +21,5 @@ def lint_frontend_pipeline(trigger, ver_mode):
         lint_frontend_step(),
     ]
     return pipeline(
-        name='{}-lint-frontend'.format(ver_mode), edition="oss", trigger=trigger, services=[], steps=init_steps + test_steps, node='node-parallel'
+        name='{}-lint-frontend'.format(ver_mode), edition="oss", trigger=trigger, services=[], steps=init_steps + test_steps, node='no-parallel'
     )

--- a/scripts/drone/pipelines/test_backend.star
+++ b/scripts/drone/pipelines/test_backend.star
@@ -36,5 +36,5 @@ def test_backend(trigger, ver_mode, edition="oss"):
     if ver_mode in ("release-branch", "release"):
         pipeline_name = '{}-{}-test-backend'.format(ver_mode, edition)
     return pipeline(
-        name=pipeline_name, edition=edition, trigger=trigger, services=[], steps=init_steps + test_steps, environment=environment
+        name=pipeline_name, edition=edition, trigger=trigger, services=[], steps=init_steps + test_steps, environment=environment, node='no-parallel'
     )

--- a/scripts/drone/pipelines/test_frontend.star
+++ b/scripts/drone/pipelines/test_frontend.star
@@ -32,5 +32,5 @@ def test_frontend(trigger, ver_mode, edition="oss"):
     if ver_mode in ("release-branch", "release"):
         pipeline_name = '{}-{}-test-frontend'.format(ver_mode, edition)
     return pipeline(
-        name=pipeline_name, edition=edition, trigger=trigger, services=[], steps=init_steps + test_steps,
+        name=pipeline_name, edition=edition, trigger=trigger, services=[], steps=init_steps + test_steps, node='no-parallel',
     )

--- a/scripts/drone/utils/utils.star
+++ b/scripts/drone/utils/utils.star
@@ -10,8 +10,7 @@ failure_template = 'Build {{build.number}} failed for commit: <https://github.co
 drone_change_template = '`.drone.yml` and `starlark` files have been changed on the OSS repo, by: {{build.author}}. \nBranch: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ build.branch }}>\nCommit hash: <https://github.com/{{repo.owner}}/{{repo.name}}/commit/{{build.commit}}|{{ truncate build.commit 8 }}>'
 
 def pipeline(
-    name, edition, trigger, steps, services=[], platform='linux', depends_on=[], environment=None, volumes=[],
-    ):
+    name, edition, trigger, steps, services=[], platform='linux', depends_on=[], environment=None, volumes=[], node=''):
     if platform != 'windows':
         platform_conf = {
             'platform': {
@@ -20,10 +19,13 @@ def pipeline(
             },
             # A shared cache is used on the host
             # To avoid issues with parallel builds, we run this repo on single build agents
-            'node': {
-                'type': 'no-parallel'
-            }
         }
+        if node != '':
+            platform_conf.update({
+                'node': {
+                    'type': 'no-parallel'
+                },
+            })
     else:
         platform_conf = {
             'platform': {


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds node type as an argument in the pipeline function in `utils.star`. This helps us decide between `parallel` and `no-parallel` runners. For parallel runners, we don't need to explicitly provide a node type, since they are the default ones.

**Which issue(s) this PR fixes**:

Fixes #57075

