### PR TITLE
Search: Sort alphabetically in the folder view, increase the limit of the folder search from 50 to 1000

### DIFF
--- a/public/app/features/search/page/components/FolderView.test.tsx
+++ b/public/app/features/search/page/components/FolderView.test.tsx
@@ -30,13 +30,13 @@ describe('FolderView', () => {
         name: 'kind',
         type: FieldType.string,
         config: {},
-        values: new ArrayVector([DashboardSearchItemType.DashFolder, DashboardSearchItemType.DashFolder]),
+        values: new ArrayVector([DashboardSearchItemType.DashFolder]),
       },
-      { name: 'name', type: FieldType.string, config: {}, values: new ArrayVector(['My folder 1', 'Another folder']) },
-      { name: 'uid', type: FieldType.string, config: {}, values: new ArrayVector(['my-folder-1', 'another-folder']) },
-      { name: 'url', type: FieldType.string, config: {}, values: new ArrayVector(['/my-folder-1', '/another-folder']) },
+      { name: 'name', type: FieldType.string, config: {}, values: new ArrayVector(['My folder 1']) },
+      { name: 'uid', type: FieldType.string, config: {}, values: new ArrayVector(['my-folder-1']) },
+      { name: 'url', type: FieldType.string, config: {}, values: new ArrayVector(['/my-folder-1']) },
     ],
-    length: 2,
+    length: 1,
   };
 
   const mockSearchResult: QueryResponse = {
@@ -120,24 +120,6 @@ describe('FolderView', () => {
       <FolderView onTagSelected={mockOnTagSelected} selection={mockSelection} selectionToggle={mockSelectionToggle} />
     );
     expect(await screen.findByRole('button', { name: 'General' })).toBeInTheDocument();
-  });
-
-  it('sorts folders alphabetically by name by default', async () => {
-    render(
-      <FolderView
-        hidePseudoFolders
-        onTagSelected={mockOnTagSelected}
-        selection={mockSelection}
-        selectionToggle={mockSelectionToggle}
-      />
-    );
-    const testIdPrefix = selectors.components.Search.folderHeader('');
-    const names = (
-      (await screen.findAllByTestId(testIdPrefix, { exact: false })).map((el) =>
-        el.dataset.testid?.replace(testIdPrefix, '')
-      ) as string[]
-    ).sort();
-    expect(names).toEqual(['Another folder', 'General', 'My folder 1']);
   });
 
   describe('when hidePseudoFolders is set', () => {

--- a/public/app/features/search/page/components/FolderView.test.tsx
+++ b/public/app/features/search/page/components/FolderView.test.tsx
@@ -30,13 +30,13 @@ describe('FolderView', () => {
         name: 'kind',
         type: FieldType.string,
         config: {},
-        values: new ArrayVector([DashboardSearchItemType.DashFolder]),
+        values: new ArrayVector([DashboardSearchItemType.DashFolder, DashboardSearchItemType.DashFolder]),
       },
-      { name: 'name', type: FieldType.string, config: {}, values: new ArrayVector(['My folder 1']) },
-      { name: 'uid', type: FieldType.string, config: {}, values: new ArrayVector(['my-folder-1']) },
-      { name: 'url', type: FieldType.string, config: {}, values: new ArrayVector(['/my-folder-1']) },
+      { name: 'name', type: FieldType.string, config: {}, values: new ArrayVector(['My folder 1', 'Another folder']) },
+      { name: 'uid', type: FieldType.string, config: {}, values: new ArrayVector(['my-folder-1', 'another-folder']) },
+      { name: 'url', type: FieldType.string, config: {}, values: new ArrayVector(['/my-folder-1', '/another-folder']) },
     ],
-    length: 1,
+    length: 2,
   };
 
   const mockSearchResult: QueryResponse = {
@@ -120,6 +120,24 @@ describe('FolderView', () => {
       <FolderView onTagSelected={mockOnTagSelected} selection={mockSelection} selectionToggle={mockSelectionToggle} />
     );
     expect(await screen.findByRole('button', { name: 'General' })).toBeInTheDocument();
+  });
+
+  it('sorts folders alphabetically by name by default', async () => {
+    render(
+      <FolderView
+        hidePseudoFolders
+        onTagSelected={mockOnTagSelected}
+        selection={mockSelection}
+        selectionToggle={mockSelectionToggle}
+      />
+    );
+    const testIdPrefix = selectors.components.Search.folderHeader('');
+    const names = (
+      (await screen.findAllByTestId(testIdPrefix, { exact: false })).map((el) =>
+        el.dataset.testid?.replace(testIdPrefix, '')
+      ) as string[]
+    ).sort();
+    expect(names).toEqual(['Another folder', 'General', 'My folder 1']);
   });
 
   describe('when hidePseudoFolders is set', () => {

--- a/public/app/features/search/page/components/FolderView.tsx
+++ b/public/app/features/search/page/components/FolderView.tsx
@@ -50,6 +50,7 @@ export const FolderView = ({
       query: '*',
       kind: ['folder'],
       sort: 'name_sort',
+      limit: 1000,
     });
     for (const row of rsp.view) {
       folders.push({

--- a/public/app/features/search/page/components/FolderView.tsx
+++ b/public/app/features/search/page/components/FolderView.tsx
@@ -46,10 +46,11 @@ export const FolderView = ({
     }
     folders.push({ title: 'General', url: '/dashboards', kind: 'folder', uid: GENERAL_FOLDER_UID });
 
-    const rsp = await getGrafanaSearcher().search({
+    const searcher = getGrafanaSearcher();
+    const rsp = await searcher.search({
       query: '*',
       kind: ['folder'],
-      sort: 'name_sort',
+      sort: searcher.getFolderViewSort(),
       limit: 1000,
     });
     for (const row of rsp.view) {

--- a/public/app/features/search/page/components/FolderView.tsx
+++ b/public/app/features/search/page/components/FolderView.tsx
@@ -49,6 +49,7 @@ export const FolderView = ({
     const rsp = await getGrafanaSearcher().search({
       query: '*',
       kind: ['folder'],
+      sort: 'name_sort',
     });
     for (const row of rsp.view) {
       folders.push({

--- a/public/app/features/search/service/bluge.ts
+++ b/public/app/features/search/service/bluge.ts
@@ -24,6 +24,8 @@ type SearchAPIResponse = {
   frames: DataFrameJSON[];
 };
 
+const folderViewSort = 'name_sort';
+
 export class BlugeSearcher implements GrafanaSearcher {
   constructor(private fallbackSearcher: GrafanaSearcher) {}
 
@@ -75,7 +77,7 @@ export class BlugeSearcher implements GrafanaSearcher {
   // This should eventually be filled by an API call, but hardcoded is a good start
   getSortOptions(): Promise<SelectableValue[]> {
     const opts: SelectableValue[] = [
-      { value: 'name_sort', label: 'Alphabetically (A-Z)' },
+      { value: folderViewSort, label: 'Alphabetically (A-Z)' },
       { value: '-name_sort', label: 'Alphabetically (Z-A)' },
     ];
 
@@ -198,6 +200,10 @@ export class BlugeSearcher implements GrafanaSearcher {
         return index < view.dataFrame.length;
       },
     };
+  }
+
+  getFolderViewSort(): string {
+    return 'name_sort';
   }
 }
 

--- a/public/app/features/search/service/dummy.ts
+++ b/public/app/features/search/service/dummy.ts
@@ -34,4 +34,8 @@ export class DummySearcher implements GrafanaSearcher {
   async tags(query: SearchQuery): Promise<TermCount[]> {
     return Promise.resolve(this.expectedTagsResponse);
   }
+
+  getFolderViewSort(): string {
+    return '';
+  }
 }

--- a/public/app/features/search/service/frontend.ts
+++ b/public/app/features/search/service/frontend.ts
@@ -75,6 +75,10 @@ export class FrontendSearcher implements GrafanaSearcher {
   async tags(query: SearchQuery): Promise<TermCount[]> {
     return this.parent.tags(query);
   }
+
+  getFolderViewSort(): string {
+    return this.parent.getFolderViewSort();
+  }
 }
 
 class FullResultCache {

--- a/public/app/features/search/service/sql.ts
+++ b/public/app/features/search/service/sql.ts
@@ -224,4 +224,9 @@ export class SQLSearcher implements GrafanaSearcher {
       isItemLoaded: (index: number): boolean => true,
     };
   }
+
+  getFolderViewSort = () => {
+    // sorts alphabetically in memory after retrieving the folders from the database
+    return '';
+  };
 }

--- a/public/app/features/search/service/types.ts
+++ b/public/app/features/search/service/types.ts
@@ -72,4 +72,7 @@ export interface GrafanaSearcher {
   tags: (query: SearchQuery) => Promise<TermCount[]>;
   getSortOptions: () => Promise<SelectableValue[]>;
   sortPlaceholder?: string;
+
+  /** Gets the default sort used for the Folder view */
+  getFolderViewSort: () => string;
 }


### PR DESCRIPTION
This PR

-  ensures we are doing what the sort dropdown says - sorting the folders alphabetically by default
<img width="932" alt="image" src="https://user-images.githubusercontent.com/23451458/196166599-d19ecd4d-3365-416d-b727-1b5e1f8bb450.png">

- increases the limit of folder search from 50 to 1000

