### PR TITLE
Logs: Add feature tracking to the load more button in log row context

### DIFF
--- a/public/app/features/logs/components/LogRowContextProvider.test.tsx
+++ b/public/app/features/logs/components/LogRowContextProvider.test.tsx
@@ -8,6 +8,11 @@ import { createLogRow } from './__mocks__/logRow';
 
 const row = createLogRow({ entry: '4', timeEpochMs: 4 });
 
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  reportInteraction: jest.fn(),
+}));
+
 describe('getRowContexts', () => {
   describe('when called with a DataFrame and results are returned', () => {
     it('then the result should be in correct format and filtered', async () => {

--- a/public/app/features/logs/components/LogRowContextProvider.tsx
+++ b/public/app/features/logs/components/LogRowContextProvider.tsx
@@ -10,6 +10,7 @@ import {
   LogsSortOrder,
   toDataFrame,
 } from '@grafana/data';
+import { reportInteraction } from '@grafana/runtime';
 
 export interface RowContextOptions {
   direction?: 'BACKWARD' | 'FORWARD';
@@ -210,7 +211,15 @@ export const LogRowContextProvider: React.FunctionComponent<LogRowContextProvide
       after: result ? result.errors[1] : undefined,
     },
     hasMoreContextRows,
-    updateLimit: () => setLimit(limit + 10),
+    updateLimit: () => {
+      setLimit(limit + 10);
+
+      const { datasourceType, uid: logRowUid } = row;
+      reportInteraction('grafana_explore_logs_log_context_load_more_clicked', {
+        datasourceType,
+        logRowUid,
+      });
+    },
     limit,
     logsSortOrder,
   });

--- a/public/app/features/logs/components/LogRowContextProvider.tsx
+++ b/public/app/features/logs/components/LogRowContextProvider.tsx
@@ -218,6 +218,7 @@ export const LogRowContextProvider: React.FunctionComponent<LogRowContextProvide
       reportInteraction('grafana_explore_logs_log_context_load_more_clicked', {
         datasourceType,
         logRowUid,
+        newLimit: limit + 10,
       });
     },
     limit,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
It adds feature tracking to the `Load X more lines` button in the log row context

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Adds to #54377

**Special notes for your reviewer**:
Adding `console.log(interactionName, properties)` in `packages/grafana-runtime/src/utils/analytics.ts` `Line 46` will help you verify the functionality of this pr.
