### PR TITLE
RBAC: Allow to list users for dashboard / folder admins

### DIFF
--- a/pkg/services/accesscontrol/resourcepermissions/models.go
+++ b/pkg/services/accesscontrol/resourcepermissions/models.go
@@ -22,11 +22,12 @@ type SetResourcePermissionsCommand struct {
 }
 
 type GetResourcePermissionsQuery struct {
-	Actions           []string
-	Resource          string
-	ResourceID        string
-	ResourceAttribute string
-	OnlyManaged       bool
-	InheritedScopes   []string
-	User              *user.SignedInUser
+	Actions              []string
+	Resource             string
+	ResourceID           string
+	ResourceAttribute    string
+	OnlyManaged          bool
+	InheritedScopes      []string
+	EnforceAccessControl bool
+	User                 *user.SignedInUser
 }

--- a/pkg/services/accesscontrol/resourcepermissions/service.go
+++ b/pkg/services/accesscontrol/resourcepermissions/service.go
@@ -125,13 +125,14 @@ func (s *Service) GetPermissions(ctx context.Context, user *user.SignedInUser, r
 	}
 
 	return s.store.GetResourcePermissions(ctx, user.OrgID, GetResourcePermissionsQuery{
-		User:              user,
-		Actions:           s.actions,
-		Resource:          s.options.Resource,
-		ResourceID:        resourceID,
-		ResourceAttribute: s.options.ResourceAttribute,
-		InheritedScopes:   inheritedScopes,
-		OnlyManaged:       s.options.OnlyManaged,
+		User:                 user,
+		Actions:              s.actions,
+		Resource:             s.options.Resource,
+		ResourceID:           resourceID,
+		ResourceAttribute:    s.options.ResourceAttribute,
+		InheritedScopes:      inheritedScopes,
+		OnlyManaged:          s.options.OnlyManaged,
+		EnforceAccessControl: s.license.FeatureEnabled("accesscontrol.enforcement"),
 	})
 }
 

--- a/pkg/services/accesscontrol/resourcepermissions/store.go
+++ b/pkg/services/accesscontrol/resourcepermissions/store.go
@@ -351,13 +351,15 @@ func (s *store) getResourcePermissions(sess *sqlstore.DBSession, orgID int64, qu
 	}
 
 	initialLength := len(args)
-
-	userFilter, err := accesscontrol.Filter(query.User, "u.id", "users:id:", accesscontrol.ActionOrgUsersRead)
-	if err != nil {
-		return nil, err
+	userQuery := userSelect + userFrom + where
+	if query.EnforceAccessControl {
+		userFilter, err := accesscontrol.Filter(query.User, "u.id", "users:id:", accesscontrol.ActionOrgUsersRead)
+		if err != nil {
+			return nil, err
+		}
+		userQuery += " AND " + userFilter.Where
+		args = append(args, userFilter.Args...)
 	}
-	user := userSelect + userFrom + where + " AND " + userFilter.Where
-	args = append(args, userFilter.Args...)
 
 	teamFilter, err := accesscontrol.Filter(query.User, "t.id", "teams:id:", accesscontrol.ActionTeamsRead)
 	if err != nil {
@@ -371,7 +373,7 @@ func (s *store) getResourcePermissions(sess *sqlstore.DBSession, orgID int64, qu
 	builtin := builtinSelect + builtinFrom + where
 	args = append(args, args[:initialLength]...)
 
-	sql := user + " UNION " + team + " UNION " + builtin
+	sql := userQuery + " UNION " + team + " UNION " + builtin
 	queryResults := make([]flatResourcePermission, 0)
 	if err := sess.SQL(sql, args...).Find(&queryResults); err != nil {
 		return nil, err

--- a/pkg/services/accesscontrol/resourcepermissions/store_test.go
+++ b/pkg/services/accesscontrol/resourcepermissions/store_test.go
@@ -336,14 +336,10 @@ func TestIntegrationStore_SetResourcePermissions(t *testing.T) {
 }
 
 type getResourcePermissionsTest struct {
-	desc              string
-	user              *user.SignedInUser
-	numUsers          int
-	actions           []string
-	resource          string
-	resourceID        string
-	resourceAttribute string
-	onlyManaged       bool
+	desc     string
+	user     *user.SignedInUser
+	numUsers int
+	query    GetResourcePermissionsQuery
 }
 
 func TestIntegrationStore_GetResourcePermissions(t *testing.T) {
@@ -355,11 +351,13 @@ func TestIntegrationStore_GetResourcePermissions(t *testing.T) {
 				Permissions: map[int64]map[string][]string{
 					1: {accesscontrol.ActionOrgUsersRead: {accesscontrol.ScopeUsersAll}},
 				}},
-			numUsers:          3,
-			actions:           []string{"datasources:query"},
-			resource:          "datasources",
-			resourceID:        "1",
-			resourceAttribute: "uid",
+			numUsers: 3,
+			query: GetResourcePermissionsQuery{
+				Actions:           []string{"datasources:query"},
+				Resource:          "datasources",
+				ResourceID:        "1",
+				ResourceAttribute: "uid",
+			},
 		},
 		{
 			desc: "should return manage permissions for all resource ids",
@@ -368,22 +366,24 @@ func TestIntegrationStore_GetResourcePermissions(t *testing.T) {
 				Permissions: map[int64]map[string][]string{
 					1: {accesscontrol.ActionOrgUsersRead: {accesscontrol.ScopeUsersAll}},
 				}},
-			numUsers:          3,
-			actions:           []string{"datasources:query"},
-			resource:          "datasources",
-			resourceID:        "1",
-			resourceAttribute: "uid",
-			onlyManaged:       true,
+			numUsers: 3,
+			query: GetResourcePermissionsQuery{
+				Actions:           []string{"datasources:query"},
+				Resource:          "datasources",
+				ResourceID:        "1",
+				ResourceAttribute: "uid",
+				OnlyManaged:       true,
+			},
 		},
 	}
 
-	for _, test := range tests {
-		t.Run(test.desc, func(t *testing.T) {
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
 			store, sql := setupTestEnv(t)
 
 			err := sql.WithDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
 				role := &accesscontrol.Role{
-					OrgID:   test.user.OrgID,
+					OrgID:   tt.user.OrgID,
 					UID:     "seeded",
 					Name:    "seeded",
 					Updated: time.Now(),
@@ -416,20 +416,14 @@ func TestIntegrationStore_GetResourcePermissions(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			seedResourcePermissions(t, store, sql, test.actions, test.resource, test.resourceID, test.resourceAttribute, test.numUsers)
+			seedResourcePermissions(t, store, sql, tt.query.Actions, tt.query.Resource, tt.query.ResourceID, tt.query.ResourceAttribute, tt.numUsers)
 
-			permissions, err := store.GetResourcePermissions(context.Background(), test.user.OrgID, GetResourcePermissionsQuery{
-				User:              test.user,
-				Actions:           test.actions,
-				Resource:          test.resource,
-				ResourceID:        test.resourceID,
-				ResourceAttribute: test.resourceAttribute,
-				OnlyManaged:       test.onlyManaged,
-			})
+			tt.query.User = tt.user
+			permissions, err := store.GetResourcePermissions(context.Background(), tt.user.OrgID, tt.query)
 			require.NoError(t, err)
 
-			expectedLen := test.numUsers
-			if !test.onlyManaged {
+			expectedLen := tt.numUsers
+			if !tt.query.OnlyManaged {
 				expectedLen += 1
 			}
 			assert.Len(t, permissions, expectedLen)


### PR DESCRIPTION
**What this PR does / why we need it**:
When running grafana without `accesscontrol.enforcement` license flag we should not filter our users. This would allow admins for either team, dashboard or folder to see what users has permission on the resource. If the `accesscontrol.enforcement` is set we only return users that the caller can see.

**Which issue(s) this PR fixes**:
Fixes #56462

**Special notes for your reviewer**:

