### PR TITLE
Cloudwatch: Fix bug with opening dashboards with over 50 log group names

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/components/ConfigEditor.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/ConfigEditor.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { Provider } from 'react-redux';
 import selectEvent from 'react-select-event';
@@ -20,6 +20,10 @@ jest.mock('app/features/plugins/datasource_srv', () => ({
           {
             label: 'ap-east-1',
             value: 'ap-east-1',
+          },
+          {
+            label: 'us-east-1',
+            value: 'us-east-1',
           },
         ]),
       },
@@ -80,7 +84,7 @@ const props: Props = {
   onOptionsChange: jest.fn(),
 };
 
-const setup = (optionOverrides?: Partial<Props['options']>) => {
+const setup = async (optionOverrides?: Partial<Props['options']>) => {
   const store = configureStore();
   const newProps = {
     ...props,
@@ -95,6 +99,9 @@ const setup = (optionOverrides?: Partial<Props['options']>) => {
       <ConfigEditor {...newProps} />
     </Provider>
   );
+
+  // wait for log groups fetch to finish
+  await waitFor(() => expect(screen.getByText('Choose Log Groups')).toBeInTheDocument());
 };
 
 describe('Render', () => {
@@ -106,11 +113,11 @@ describe('Render', () => {
     putMock.mockImplementation(async () => ({ datasource: setupMockedDataSource().datasource }));
   });
 
-  it('should render component without blowing up', () => {
+  it('should render component without blowing up', async () => {
     expect(() => setup()).not.toThrow();
   });
 
-  it('should disable access key id field', () => {
+  it('should disable access key id field', async () => {
     setup({
       secureJsonFields: {
         secretKey: true,
@@ -148,7 +155,7 @@ describe('Render', () => {
   });
 
   it('should load log groups when multiselect is opened', async () => {
-    setup();
+    await setup();
     const multiselect = await screen.findByLabelText('Log Groups');
     selectEvent.openMenu(multiselect);
     expect(await screen.findByText('logGroup-foo')).toBeInTheDocument();

--- a/public/app/plugins/datasource/cloudwatch/components/LogGroupSelector.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/LogGroupSelector.test.tsx
@@ -1,148 +1,130 @@
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import lodash from 'lodash'; // eslint-disable-line lodash/import-scope
 import React from 'react';
-import { openMenu, select } from 'react-select-event';
+import { openMenu } from 'react-select-event';
 
-import { toOption } from '@grafana/data';
+import { LogGroupSelector } from './LogGroupSelector';
 
-import { setupMockedDataSource } from '../__mocks__/CloudWatchDataSource';
-import { DescribeLogGroupsRequest } from '../types';
-
-import { LogGroupSelector, LogGroupSelectorProps } from './LogGroupSelector';
-
-const ds = setupMockedDataSource();
+jest.mock('lodash/debounce');
 
 describe('LogGroupSelector', () => {
-  const onChange = jest.fn();
-  const defaultProps: LogGroupSelectorProps = {
-    region: 'region1',
-    datasource: ds.datasource,
-    selectedLogGroups: [],
-    onChange,
-  };
+  it('shows previously saved log groups', () => {
+    render(
+      <LogGroupSelector
+        selectedLogGroups={['previously/selected/log/group/names']}
+        onChange={jest.fn()}
+        describeLogGroups={jest.fn()}
+      />
+    );
 
-  beforeEach(() => {
-    jest.resetAllMocks();
+    expect(screen.getByText('previously/selected/log/group/names')).toBeInTheDocument();
   });
 
-  it('updates upstream query log groups on region change', async () => {
-    ds.datasource.api.describeLogGroups = jest.fn().mockImplementation(async (params: DescribeLogGroupsRequest) => {
-      if (params.region === 'region1') {
-        return Promise.resolve(['log_group_1'].map(toOption));
-      } else {
-        return Promise.resolve(['log_group_2'].map(toOption));
-      }
-    });
-    const props = {
-      ...defaultProps,
-      selectedLogGroups: ['log_group_1'],
-    };
+  it('fetches new log groups on menu open', async () => {
+    const describeLogGroups = jest.fn(() =>
+      Promise.resolve([
+        {
+          label: 'fetched/log/group/name',
+          value: 'fetched/log/group/name',
+          text: 'fetched/log/group/name',
+        },
+      ])
+    );
+    render(
+      <LogGroupSelector
+        selectedLogGroups={['previously/selected/log/group/names']}
+        onChange={jest.fn()}
+        describeLogGroups={describeLogGroups}
+      />
+    );
 
-    const { rerender } = render(<LogGroupSelector {...props} />);
-    await waitFor(() => expect(onChange).toHaveBeenCalledTimes(1));
-    expect(onChange).toHaveBeenLastCalledWith(['log_group_1']);
-    expect(await screen.findByText('log_group_1')).toBeInTheDocument();
-
-    act(() => rerender(<LogGroupSelector {...props} region="region2" />));
-    await waitFor(() => expect(onChange).toHaveBeenCalledTimes(1));
-    expect(onChange).toHaveBeenLastCalledWith([]);
-  });
-
-  it('does not update upstream query log groups if saved is false', async () => {
-    ds.datasource.api.describeLogGroups = jest.fn().mockImplementation(async (params: DescribeLogGroupsRequest) => {
-      if (params.region === 'region1') {
-        return Promise.resolve(['log_group_1'].map(toOption));
-      } else {
-        return Promise.resolve(['log_group_2'].map(toOption));
-      }
-    });
-    const props = {
-      ...defaultProps,
-      selectedLogGroups: ['log_group_1'],
-    };
-
-    const { rerender } = render(<LogGroupSelector {...props} />);
-    await waitFor(() => expect(onChange).toHaveBeenCalledTimes(1));
-    expect(onChange).toHaveBeenLastCalledWith(['log_group_1']);
-    expect(await screen.findByText('log_group_1')).toBeInTheDocument();
-
-    act(() => rerender(<LogGroupSelector {...props} region="region2" saved={false} />));
-    await waitFor(() => expect(onChange).toHaveBeenCalledTimes(1));
-    expect(onChange).toHaveBeenLastCalledWith(['log_group_1']);
-  });
-
-  it('should merge results of remote log groups search with existing results', async () => {
-    lodash.debounce = jest.fn().mockImplementation((fn) => fn);
-    const allLogGroups = [
-      'AmazingGroup',
-      'AmazingGroup2',
-      'AmazingGroup3',
-      'BeautifulGroup',
-      'BeautifulGroup2',
-      'BeautifulGroup3',
-      'CrazyGroup',
-      'CrazyGroup2',
-      'CrazyGroup3',
-      'DeliciousGroup',
-      'DeliciousGroup2',
-      'DeliciousGroup3',
-      'VelvetGroup',
-      'VelvetGroup2',
-      'VelvetGroup3',
-      'WaterGroup',
-      'WaterGroup2',
-      'WaterGroup3',
-    ];
-    const testLimit = 10;
-
-    ds.datasource.api.describeLogGroups = jest.fn().mockImplementation(async (params: DescribeLogGroupsRequest) => {
-      const theLogGroups = allLogGroups
-        .filter((logGroupName) => logGroupName.startsWith(params.logGroupNamePrefix ?? ''))
-        .slice(0, Math.max(params.limit ?? testLimit, testLimit));
-      return Promise.resolve(theLogGroups.map(toOption));
-    });
-    const props = {
-      ...defaultProps,
-    };
-    render(<LogGroupSelector {...props} />);
-    const multiselect = await screen.findByLabelText('Log Groups');
-
-    // Adds the 3 Water groups to the 10 loaded in initially
-    await userEvent.type(multiselect, 'Water');
-    // The 3 Water groups + the create option
-    expect(screen.getAllByLabelText('Select option').length).toBe(4);
-    await userEvent.clear(multiselect);
-    expect(screen.getAllByLabelText('Select option').length).toBe(testLimit + 3);
-
-    // Adds the three Velvet groups to the previous 13
-    await userEvent.type(multiselect, 'Velv');
-    // The 3 Velvet groups + the create option
-    expect(screen.getAllByLabelText('Select option').length).toBe(4);
-    await userEvent.clear(multiselect);
-    expect(screen.getAllByLabelText('Select option').length).toBe(testLimit + 6);
-  });
-
-  it('should render template variables a selectable option', async () => {
-    lodash.debounce = jest.fn().mockImplementation((fn) => fn);
-    ds.datasource.api.describeLogGroups = jest.fn().mockResolvedValue([]);
-    const onChange = jest.fn();
-    const props = {
-      ...defaultProps,
-      onChange,
-    };
-    render(<LogGroupSelector {...props} />);
-
+    // on menu open describe log groups is called
     const logGroupSelector = await screen.findByLabelText('Log Groups');
-    expect(logGroupSelector).toBeInTheDocument();
+    openMenu(logGroupSelector);
+    await screen.findByText('fetched/log/group/name');
 
-    await openMenu(logGroupSelector);
-    const templateVariableSelector = await screen.findByText('Template Variables');
-    expect(templateVariableSelector).toBeInTheDocument();
+    expect(describeLogGroups).toBeCalledTimes(1);
+  });
 
-    userEvent.click(templateVariableSelector);
-    await select(await screen.findByLabelText('Select option'), 'test');
+  it('shows previously selected log groups even if they are not returned by describeLogGroups', async () => {
+    const describeLogGroups = jest.fn(() =>
+      Promise.resolve([
+        {
+          label: 'fetched/log/group/name',
+          value: 'fetched/log/group/name',
+          text: 'fetched/log/group/name',
+        },
+      ])
+    );
+    render(
+      <LogGroupSelector
+        selectedLogGroups={['previously/selected/log/group/names']}
+        onChange={jest.fn()}
+        describeLogGroups={describeLogGroups}
+      />
+    );
 
-    expect(onChange).toBeCalledWith(['test']);
+    // on menu open describe log groups is called
+    const logGroupSelector = await screen.findByLabelText('Log Groups');
+    openMenu(logGroupSelector);
+    await screen.findByText('fetched/log/group/name');
+
+    expect(screen.getByText('previously/selected/log/group/names')).toBeInTheDocument();
+    expect(screen.getByText('fetched/log/group/name')).toBeInTheDocument();
+  });
+
+  it('searches for new log groups with a prefix when users start typing', async () => {
+    const describeLogGroups = jest.fn((prefix?: string) => {
+      if (prefix) {
+        return Promise.resolve([
+          {
+            label: 'just/log/group/names/that/start/with/prefix',
+            value: 'just/log/group/names/that/start/with/prefix',
+            text: 'just/log/group/names/that/start/with/prefix',
+          },
+        ]);
+      }
+      return Promise.resolve([
+        {
+          label: 'fetched/log/group/name',
+          value: 'fetched/log/group/name',
+          text: 'fetched/log/group/name',
+        },
+      ]);
+    });
+    render(
+      <LogGroupSelector
+        selectedLogGroups={['previously/selected/log/group/names']}
+        onChange={jest.fn()}
+        describeLogGroups={describeLogGroups}
+      />
+    );
+
+    // on menu open describe log groups is called
+    const logGroupSelector = await screen.findByLabelText('Log Groups');
+    openMenu(logGroupSelector);
+    await screen.findByText('fetched/log/group/name');
+    await userEvent.type(logGroupSelector, 'j');
+    await screen.findByText('just/log/group/names/that/start/with/prefix');
+
+    expect(describeLogGroups).toHaveBeenCalledWith('j');
+  });
+
+  it('can handle errors', async () => {
+    const describeLogGroups = jest.fn(() => {
+      return Promise.reject('server exploded!');
+    });
+    render(
+      <LogGroupSelector
+        selectedLogGroups={['previously/selected/log/group/names']}
+        onChange={jest.fn()}
+        describeLogGroups={describeLogGroups}
+      />
+    );
+
+    // on menu open describe log groups is called
+    const logGroupSelector = await screen.findByLabelText('Log Groups');
+    openMenu(logGroupSelector);
+    await waitFor(() => expect(screen.getByText('No log groups available')).toBeInTheDocument());
   });
 });

--- a/public/app/plugins/datasource/cloudwatch/components/LogsQueryField.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/LogsQueryField.tsx
@@ -113,7 +113,7 @@ export class CloudWatchLogsQueryField extends React.PureComponent<CloudWatchLogs
 
   render() {
     const { onRunQuery, onChange, ExtraFieldElement, data, query, datasource } = this.props;
-    const { region, refId, expression, logGroupNames } = query;
+    const { region, expression, logGroupNames } = query;
     const { hint } = this.state;
 
     const showError = data && data.error && data.error.refId === query.refId;
@@ -135,14 +135,20 @@ export class CloudWatchLogsQueryField extends React.PureComponent<CloudWatchLogs
             className="flex-grow-1"
             inputEl={
               <LogGroupSelector
-                region={region}
                 selectedLogGroups={logGroupNames ?? datasource.logsQueryRunner.defaultLogGroups}
-                datasource={datasource}
                 onChange={function (logGroups: string[]): void {
                   onChange({ ...query, logGroupNames: logGroups });
                 }}
-                onRunQuery={onRunQuery}
-                refId={refId}
+                describeLogGroups={(logGroupNamePrefix?: string) => {
+                  if (!datasource?.api?.describeLogGroups) {
+                    return;
+                  }
+                  return datasource.api.describeLogGroups({
+                    logGroupNamePrefix,
+                    region: region,
+                  });
+                }}
+                onBlur={onRunQuery}
               />
             }
           />


### PR DESCRIPTION
**What this PR does / why we need it**:
Right now if you have more than 50 cloudwatch log group names, make a dashboard, save that dashboard and then try to edit it later you'll run into some bugs. The main gist is that we attempt to smartly clear the log group names if the log group names are no longer valid options, and we are incorrectly deciding that if a log group name does not return in the initial fetch it must be an invalid name. 

[One proposed community solution](https://github.com/grafana/grafana/pull/56185) was to instead fetch all group names when we load the component. This is likely to be a very effective solution for many use cases, but it does seem likely that it won't scale well for accounts that have say thousands of log groups. However there were additional tests in that pr which we should probably consider cherry picking! 

This proposed solution will instead not clear the log group names, even if they are no longer valid (ex: you change regions). While it is a bit less slick from a ui perspective, I think ultimately what we thought was a feature (to remove log group names when regions are changed) may actually be a bug and pain point, as uses may have log groups named the same thing from region to region and not want to have to reselect it every time. 

Another factor here is that Log Group names are selected on the Config Page in Cloudwatch. This adds its own complexity in the code to determine if changes have been made to the connection details and whether or not the cloudwatch logs selection should reset or not. We also used to force a save on open of the log group names, so as to ensure we had up to date credential information to which to make a request for log groups. In the interest of trying to simplify the code and make the user experience more predictable, I'm proposing adding a "save" button after connection config that is disabled by default and then enabled when credentials change, indicating to the user that they need to save these configuration settings before making future selections like default log groups. This allows us to move any logic around "saved" vs not saved out of log group selection, and keep that in the config component. It does add one more button for users to have to click, but I'm hoping it is more intuitive than saving when opening the log group names selection.

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/55700

**Special notes for your reviewer**:
- I started writing some tests but not as many as I'd like. But I also feel like this is a fairly painful bug for users that we should fix sooner rather than later so it might be best to merge with what we've got (assuming we're ok with the solution!) and make a ticket to add some more tests later. 

