### PR TITLE
Chore: Delete unused db in orgs and use db in datasources

### DIFF
--- a/pkg/services/datasources/service/store.go
+++ b/pkg/services/datasources/service/store.go
@@ -36,7 +36,7 @@ type SqlStore struct {
 	logger log.Logger
 }
 
-func CreateStore(db sqlstore.Store, logger log.Logger) *SqlStore {
+func CreateStore(db db.DB, logger log.Logger) *SqlStore {
 	return &SqlStore{db: db, logger: logger}
 }
 

--- a/pkg/services/org/orgimpl/org.go
+++ b/pkg/services/org/orgimpl/org.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/grafana/grafana/pkg/services/sqlstore/db"
+
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/org"
-	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
 )
@@ -16,11 +17,9 @@ type Service struct {
 	store store
 	cfg   *setting.Cfg
 	log   log.Logger
-	// TODO remove sqlstore and use db.DB
-	sqlStore sqlstore.Store
 }
 
-func ProvideService(db sqlstore.Store, cfg *setting.Cfg) org.Service {
+func ProvideService(db db.DB, cfg *setting.Cfg) org.Service {
 	log := log.New("org service")
 	return &Service{
 		store: &sqlStore{
@@ -29,9 +28,8 @@ func ProvideService(db sqlstore.Store, cfg *setting.Cfg) org.Service {
 			log:     log,
 			cfg:     cfg,
 		},
-		cfg:      cfg,
-		log:      log,
-		sqlStore: db,
+		cfg: cfg,
+		log: log,
 	}
 }
 

--- a/pkg/services/org/orgimpl/org.go
+++ b/pkg/services/org/orgimpl/org.go
@@ -5,10 +5,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/grafana/grafana/pkg/services/sqlstore/db"
-
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/org"
+	"github.com/grafana/grafana/pkg/services/sqlstore/db"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
 )


### PR DESCRIPTION
In order to update sqlstore.* with db.DB in Enterprise, we need to update a few occurrences in OSS.

* Removes unused db in org service.
* Use db in datasources store.