### PR TITLE
CloudWatch: Move hard coded metrics, namespaces and dimensions to its own package

### DIFF
--- a/pkg/tsdb/cloudwatch/constants/metrics.go
+++ b/pkg/tsdb/cloudwatch/constants/metrics.go
@@ -1,6 +1,6 @@
-package cloudwatch
+package constants
 
-var metricsMap = map[string][]string{
+var NamespaceMetricsMap = map[string][]string{
 	"AWS/ACMPrivateCA":            {"CRLGenerated", "Failure", "MisconfiguredCRLBucket", "Success", "Time"},
 	"AWS/AmazonMQ":                {"AckRate", "BurstBalance", "ChannelCount", "ConfirmRate", "ConnectionCount", "ConsumerCount", "CpuCreditBalance", "CpuUtilization", "CurrentConnectionsCount", "DequeueCount", "DispatchCount", "EnqueueCount", "EnqueueTime", "EstablishedConnectionsCount", "ExchangeCount", "ExpiredCount", "HeapUsage", "InactiveDurableTopicSubscribersCount", "InFlightCount", "JobSchedulerStorePercentUsage", "JournalFilesForFastRecovery", "JournalFilesForFullRecovery", "MemoryUsage", "MessageCount", "MessageReadyCount", "MessageUnacknowledgedCount", "NetworkIn", "NetworkOut", "OpenTransactionCount", "ProducerCount", "PublishRate", "QueueCount", "QueueSize", "RabbitMQDiskFree", "RabbitMQDiskFreeLimit", "RabbitMQFdUsed", "RabbitMQMemLimit", "RabbitMQMemUsed", "ReceiveCount", "StorePercentUsage", "SystemCpuUtilization", "TempPercentUsage", "TotalConsumerCount", "TotalDequeueCount", "TotalEnqueueCount", "TotalMessageCount", "TotalProducerCount", "VolumeReadOps", "VolumeWriteOps"},
 	"AWS/ApiGateway":              {"4xx", "4XXError", "5xx", "5XXError", "CacheHitCount", "CacheMissCount", "ClientError", "Count", "ConnectCount", "DataProcessed", "ExecutionError", "IntegrationError", "IntegrationLatency", "Latency", "MessageCount"},
@@ -404,7 +404,7 @@ var metricsMap = map[string][]string{
 	"CloudWatchSynthetics":     {"SuccessPercent", "Duration", "2xx", "4xx", "5xx", "Failed", "Failed requests", "VisualMonitoringSuccessPercent", "VisualMonitoringTotalComparisons"},
 }
 
-var dimensionsMap = map[string][]string{
+var NamespaceDimensionKeysMap = map[string][]string{
 	"AWS/ACMPrivateCA":            {},
 	"AWS/AmazonMQ":                {"Broker", "NetworkConnector", "Queue", "Topic", "Node", "Virtual host"},
 	"AWS/ApiGateway":              {"ApiId", "ApiName", "Method", "Resource", "Route", "Stage"},
@@ -522,7 +522,7 @@ var dimensionsMap = map[string][]string{
 }
 
 // Known AWS regions.
-var knownRegions = []string{
+var Regions = []string{
 	"af-south-1", "ap-east-1", "ap-northeast-1", "ap-northeast-2", "ap-northeast-3", "ap-south-1", "ap-southeast-1",
 	"ap-southeast-2", "ap-southeast-3", "ca-central-1", "cn-north-1", "cn-northwest-1", "eu-central-1", "eu-north-1", "eu-south-1", "eu-west-1",
 	"eu-west-2", "eu-west-3", "me-south-1", "sa-east-1", "us-east-1", "us-east-2", "us-gov-east-1", "us-gov-west-1",

--- a/pkg/tsdb/cloudwatch/constants/metrics.go
+++ b/pkg/tsdb/cloudwatch/constants/metrics.go
@@ -521,7 +521,6 @@ var NamespaceDimensionKeysMap = map[string][]string{
 	"CloudWatchSynthetics":        {"CanaryName"},
 }
 
-// Known AWS regions.
 var Regions = []string{
 	"af-south-1", "ap-east-1", "ap-northeast-1", "ap-northeast-2", "ap-northeast-3", "ap-south-1", "ap-southeast-1",
 	"ap-southeast-2", "ap-southeast-3", "ca-central-1", "cn-north-1", "cn-northwest-1", "eu-central-1", "eu-north-1", "eu-south-1", "eu-west-1",

--- a/pkg/tsdb/cloudwatch/metric_find_query.go
+++ b/pkg/tsdb/cloudwatch/metric_find_query.go
@@ -20,6 +20,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana/pkg/infra/metrics"
+	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/constants"
 )
 
 type suggestData struct {
@@ -71,7 +72,7 @@ func (e *cloudWatchExecutor) handleGetRegions(pluginCtx backend.PluginContext, p
 	if err != nil {
 		return nil, err
 	}
-	regions := knownRegions
+	regions := constants.Regions
 	r, err := client.DescribeRegions(&ec2.DescribeRegionsInput{})
 	if err != nil {
 		// ignore error for backward compatibility
@@ -105,7 +106,7 @@ func (e *cloudWatchExecutor) handleGetRegions(pluginCtx backend.PluginContext, p
 
 func (e *cloudWatchExecutor) handleGetNamespaces(pluginCtx backend.PluginContext, parameters url.Values) ([]suggestData, error) {
 	var keys []string
-	for key := range metricsMap {
+	for key := range constants.NamespaceMetricsMap {
 		keys = append(keys, key)
 	}
 
@@ -135,7 +136,7 @@ func (e *cloudWatchExecutor) handleGetMetrics(pluginCtx backend.PluginContext, p
 	var namespaceMetrics []string
 	if !isCustomMetrics(namespace) {
 		var exists bool
-		if namespaceMetrics, exists = metricsMap[namespace]; !exists {
+		if namespaceMetrics, exists = constants.NamespaceMetricsMap[namespace]; !exists {
 			return nil, fmt.Errorf("unable to find namespace %q", namespace)
 		}
 	} else {
@@ -157,7 +158,7 @@ func (e *cloudWatchExecutor) handleGetMetrics(pluginCtx backend.PluginContext, p
 // handleGetAllMetrics returns a slice of suggestData structs with metric and its namespace
 func (e *cloudWatchExecutor) handleGetAllMetrics(pluginCtx backend.PluginContext, parameters url.Values) ([]suggestData, error) {
 	result := make([]suggestData, 0)
-	for namespace, metrics := range metricsMap {
+	for namespace, metrics := range constants.NamespaceMetricsMap {
 		for _, metric := range metrics {
 			result = append(result, suggestData{Text: namespace, Value: metric, Label: namespace})
 		}
@@ -244,7 +245,7 @@ func (e *cloudWatchExecutor) handleGetDimensionKeys(pluginCtx backend.PluginCont
 			}
 		} else {
 			var exists bool
-			if dimensionValues, exists = dimensionsMap[namespace]; !exists {
+			if dimensionValues, exists = constants.NamespaceDimensionKeysMap[namespace]; !exists {
 				return nil, fmt.Errorf("unable to find dimension %q", namespace)
 			}
 		}
@@ -732,7 +733,7 @@ func isDuplicate(nameList []string, target string) bool {
 }
 
 func isCustomMetrics(namespace string) bool {
-	if _, ok := metricsMap[namespace]; ok {
+	if _, ok := constants.NamespaceMetricsMap[namespace]; ok {
 		return false
 	}
 	return true

--- a/pkg/tsdb/cloudwatch/metric_find_query_test.go
+++ b/pkg/tsdb/cloudwatch/metric_find_query_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/constants"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -140,7 +141,7 @@ func TestQuery_Regions(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		expRegions := append(knownRegions, regionName)
+		expRegions := append(constants.Regions, regionName)
 		expFrame := data.NewFrame(
 			"",
 			data.NewField("text", nil, expRegions),
@@ -148,7 +149,7 @@ func TestQuery_Regions(t *testing.T) {
 		)
 		expFrame.Meta = &data.FrameMeta{
 			Custom: map[string]interface{}{
-				"rowCount": len(knownRegions) + 1,
+				"rowCount": len(constants.Regions) + 1,
 			},
 		}
 
@@ -387,7 +388,7 @@ func TestQuery_GetAllMetrics(t *testing.T) {
 		require.NoError(t, err)
 
 		metricCount := 0
-		for _, metrics := range metricsMap {
+		for _, metrics := range constants.NamespaceMetricsMap {
 			metricCount += len(metrics)
 		}
 
@@ -467,7 +468,7 @@ func TestQuery_GetDimensionKeys(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		expValues := dimensionsMap["AWS/EC2"]
+		expValues := constants.NamespaceDimensionKeysMap["AWS/EC2"]
 		expResponse := []suggestData{}
 		for _, val := range expValues {
 			expResponse = append(expResponse, suggestData{val, val, val})
@@ -477,7 +478,7 @@ func TestQuery_GetDimensionKeys(t *testing.T) {
 	})
 }
 func Test_isCustomMetrics(t *testing.T) {
-	metricsMap = map[string][]string{
+	constants.NamespaceMetricsMap = map[string][]string{
 		"AWS/EC2": {"ExampleMetric"},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR moves hard coded metrics, namespaces and dimensions to its own package. 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #https://github.com/grafana/grafana/issues/57088


