### PR TITLE
Grafana UI: Export prop types for queryfield, modal and field components

### DIFF
--- a/docs/sources/developers/plugins/migration-guide.md
+++ b/docs/sources/developers/plugins/migration-guide.md
@@ -68,7 +68,7 @@ This guide helps you identify the steps required to update a plugin from the Gra
 
 ### React and React-dom as peer dependencies
 
-In earlier versions of Grafana packages react and react-dom were installed during a `yarn install` regardless of a plugins dependencies. In 9.2.0 the `@grafana` packages declare these react packages as peerDependencies and will need adding to a plugins `package.json` file for test commands to continue to run successfully.
+In earlier versions of Grafana packages `react` and `react-dom` were installed during a `yarn install` regardless of a plugins dependencies. In 9.2.0 the `@grafana` packages declare these react packages as peerDependencies and will need adding to a plugins `package.json` file for test commands to continue to run successfully.
 
 Example:
 

--- a/docs/sources/developers/plugins/migration-guide.md
+++ b/docs/sources/developers/plugins/migration-guide.md
@@ -18,7 +18,9 @@ This guide helps you identify the steps required to update a plugin from the Gra
   - [Introduction](#introduction)
   - [Table of contents](#table-of-contents)
   - [From version 9.1.x to 9.2.x](#from-version-91x-to-92x)
+    - [React and React-dom as peer dependencies](#react-and-react-dom-as-peer-dependencies)
     - [NavModelItem requires a valid icon name](#navmodelitem-requires-a-valid-icon-name)
+    - [Additional type availability](#additional-type-availability)
   - [From version 8.x to 9.x](#from-version-8x-to-9x)
     - [9.0 breaking changes](#90-breaking-changes)
       - [theme.visualization.getColorByName replaces getColorForTheme](#themevisualizationgetcolorbyname-replaces-getcolorfortheme)
@@ -64,6 +66,29 @@ This guide helps you identify the steps required to update a plugin from the Gra
 
 ## From version 9.1.x to 9.2.x
 
+### React and React-dom as peer dependencies
+
+In earlier versions of Grafana packages react and react-dom were installed during a `yarn install` regardless of a plugins dependencies. In 9.2.0 the `@grafana` packages declare these react packages as peerDependencies and will need adding to a plugins `package.json` file for test commands to continue to run successfully.
+
+Example:
+
+```json
+// before
+"dependencies": {
+  "@grafana/data": "9.1.0",
+  "@grafana/ui": "9.1.0",
+},
+
+// after
+"dependencies": {
+  "@grafana/data": "9.2.0",
+  "@grafana/ui": "9.2.0",
+  "react": "17.0.2",
+  "react-dom": "17.0.2"
+},
+
+```
+
 ### NavModelItem requires a valid icon name
 
 The typings of the `NavModelItem` have improved to only allow a valid `IconName` for the icon property. You can find the complete list of valid icons [here](https://github.com/grafana/grafana/blob/v9.2.0-beta1/packages/grafana-data/src/types/icon.ts). The icons specified in the list will work for older versions of Grafana 9.
@@ -86,6 +111,16 @@ const model: NavModelItem = {
   icon: 'cog',
   url: `${baseUrl}/settings`,
 };
+```
+
+### Additional type availability
+
+FieldProps, ModalProps, and QueryFieldProps are now exposed from `@grafana/ui`. They can be imported in the same way as other types.
+
+Example:
+
+```ts
+import { FieldProps, ModalProps, QueryFieldProps } from '@grafana/ui';
 ```
 
 ## From version 8.x to 9.x

--- a/packages/grafana-ui/src/components/index.ts
+++ b/packages/grafana-ui/src/components/index.ts
@@ -49,7 +49,7 @@ export { TagList } from './Tags/TagList';
 export { FilterPill } from './FilterPill/FilterPill';
 
 export { ConfirmModal, type ConfirmModalProps } from './ConfirmModal/ConfirmModal';
-export { QueryField } from './QueryField/QueryField';
+export { QueryField, type QueryFieldProps } from './QueryField/QueryField';
 
 export { CodeEditor } from './Monaco/CodeEditor';
 
@@ -66,7 +66,7 @@ export {
 export { variableSuggestionToCodeEditorSuggestion } from './Monaco/utils';
 
 // TODO: namespace
-export { Modal } from './Modal/Modal';
+export { Modal, type Props as ModalProps } from './Modal/Modal';
 export { ModalHeader } from './Modal/ModalHeader';
 export { ModalTabsHeader } from './Modal/ModalTabsHeader';
 export { ModalTabContent } from './Modal/ModalTabContent';
@@ -198,7 +198,7 @@ export { fieldMatchersUI } from './MatchersUI/fieldMatchersUI';
 export { Link } from './Link/Link';
 
 export { Label } from './Forms/Label';
-export { Field } from './Forms/Field';
+export { Field, type FieldProps } from './Forms/Field';
 export { Legend } from './Forms/Legend';
 export { FieldSet } from './Forms/FieldSet';
 export { FieldValidationMessage } from './Forms/FieldValidationMessage';


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Follow up to #51517 which removed the private types from the bundle. This PR adds the "missing" types that cs.github.com suggests are in use.


**Special notes for your reviewer**:
I've also updated the migration-guide explaining both the additional types and the react/react-dom peerDependencies change introduced in 9.2.0.
