### PR TITLE
Alerting: Append org ID to alert notification URLs

### DIFF
--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -86,6 +86,7 @@ const (
 	// Annotations are actually a set of labels, so technically this is the label name of an annotation.
 	DashboardUIDAnnotation = "__dashboardUid__"
 	PanelIDAnnotation      = "__panelId__"
+	OrgIDAnnotation        = "__orgId__"
 
 	// This isn't a hard-coded secret token, hence the nolint.
 	//nolint:gosec

--- a/pkg/services/ngalert/notifier/channels/default_template_test.go
+++ b/pkg/services/ngalert/notifier/channels/default_template_test.go
@@ -20,11 +20,11 @@ func TestDefaultTemplateString(t *testing.T) {
 			Alert: model.Alert{
 				Labels: model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
 				Annotations: model.LabelSet{
-					"ann1": "annv1", "__dashboardUid__": "dbuid123", "__panelId__": "puid123", "__values__": "{\"A\": 1234}", "__value_string__": "1234",
+					"ann1": "annv1", "__orgId__": "1", "__dashboardUid__": "dbuid123", "__panelId__": "puid123", "__values__": "{\"A\": 1234}", "__value_string__": "1234",
 				},
 				StartsAt:     time.Now(),
 				EndsAt:       time.Now().Add(1 * time.Hour),
-				GeneratorURL: "http://localhost/alert1",
+				GeneratorURL: "http://localhost/alert1?orgId=1",
 			},
 		}, { // Firing without dashboard and panel ID.
 			Alert: model.Alert{
@@ -38,7 +38,7 @@ func TestDefaultTemplateString(t *testing.T) {
 			Alert: model.Alert{
 				Labels: model.LabelSet{"alertname": "alert1", "lbl1": "val3"},
 				Annotations: model.LabelSet{
-					"ann1": "annv3", "__dashboardUid__": "dbuid456", "__panelId__": "puid456", "__values__": "{\"A\": 1234}", "__value_string__": "1234",
+					"ann1": "annv3", "__orgId__": "1", "__dashboardUid__": "dbuid456", "__panelId__": "puid456", "__values__": "{\"A\": 1234}", "__value_string__": "1234",
 				},
 				StartsAt:     time.Now().Add(-1 * time.Hour),
 				EndsAt:       time.Now().Add(-30 * time.Minute),
@@ -97,10 +97,10 @@ Labels:
  - lbl1 = val1
 Annotations:
  - ann1 = annv1
-Source: http://localhost/alert1
+Source: http://localhost/alert1?orgId=1
 Silence: http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1
-Dashboard: http://localhost/grafana/d/dbuid123
-Panel: http://localhost/grafana/d/dbuid123?viewPanel=puid123
+Dashboard: http://localhost/grafana/d/dbuid123?orgId=1
+Panel: http://localhost/grafana/d/dbuid123?orgId=1&viewPanel=puid123
 
 Value: A=1234
 Labels:
@@ -120,10 +120,10 @@ Labels:
  - lbl1 = val3
 Annotations:
  - ann1 = annv3
-Source: http://localhost/alert3
+Source: http://localhost/alert3?orgId=1
 Silence: http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval3
-Dashboard: http://localhost/grafana/d/dbuid456
-Panel: http://localhost/grafana/d/dbuid456?viewPanel=puid456
+Dashboard: http://localhost/grafana/d/dbuid456?orgId=1
+Panel: http://localhost/grafana/d/dbuid456?orgId=1&viewPanel=puid456
 
 Value: A=1234
 Labels:
@@ -147,13 +147,13 @@ Labels:
 Annotations:
  - ann1 = annv1
 
-Source: [http://localhost/alert1](http://localhost/alert1)
+Source: [http://localhost/alert1?orgId=1](http://localhost/alert1?orgId=1)
 
 Silence: [http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1](http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1)
 
-Dashboard: [http://localhost/grafana/d/dbuid123](http://localhost/grafana/d/dbuid123)
+Dashboard: [http://localhost/grafana/d/dbuid123?orgId=1](http://localhost/grafana/d/dbuid123?orgId=1)
 
-Panel: [http://localhost/grafana/d/dbuid123?viewPanel=puid123](http://localhost/grafana/d/dbuid123?viewPanel=puid123)
+Panel: [http://localhost/grafana/d/dbuid123?orgId=1&viewPanel=puid123](http://localhost/grafana/d/dbuid123?orgId=1&viewPanel=puid123)
 
 
 
@@ -182,13 +182,13 @@ Labels:
 Annotations:
  - ann1 = annv3
 
-Source: [http://localhost/alert3](http://localhost/alert3)
+Source: [http://localhost/alert3?orgId=1](http://localhost/alert3?orgId=1)
 
 Silence: [http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval3](http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval3)
 
-Dashboard: [http://localhost/grafana/d/dbuid456](http://localhost/grafana/d/dbuid456)
+Dashboard: [http://localhost/grafana/d/dbuid456?orgId=1](http://localhost/grafana/d/dbuid456?orgId=1)
 
-Panel: [http://localhost/grafana/d/dbuid456?viewPanel=puid456](http://localhost/grafana/d/dbuid456?viewPanel=puid456)
+Panel: [http://localhost/grafana/d/dbuid456?orgId=1&viewPanel=puid456](http://localhost/grafana/d/dbuid456?orgId=1&viewPanel=puid456)
 
 
 

--- a/pkg/services/ngalert/notifier/channels/template_data.go
+++ b/pkg/services/ngalert/notifier/channels/template_data.go
@@ -104,18 +104,9 @@ func extendAlert(alert template.Alert, externalURL string, logger log.Logger) *E
 
 		orgId := alert.Annotations[ngmodels.OrgIDAnnotation]
 		if len(orgId) > 0 {
-			orgIdParam := "orgId=" + orgId
-
-			dashboardUrl.RawQuery = orgIdParam
-			extended.DashboardURL = dashboardUrl.String()
-
-			q := u.Query()
-			q.Add("orgId", orgId)
-			u.RawQuery = q.Encode()
-			extended.PanelURL = u.String()
-
-			generatorUrl.RawQuery = orgIdParam
-			extended.GeneratorURL = generatorUrl.String()
+			extended.DashboardURL = setOrgIdQueryParam(dashboardUrl, orgId)
+			extended.PanelURL = setOrgIdQueryParam(u, orgId)
+			extended.GeneratorURL = setOrgIdQueryParam(generatorUrl, orgId)
 		}
 	}
 
@@ -149,6 +140,14 @@ func extendAlert(alert template.Alert, externalURL string, logger log.Logger) *E
 	extended.SilenceURL = u.String()
 
 	return extended
+}
+
+func setOrgIdQueryParam(url *url.URL, orgId string) string {
+	q := url.Query()
+	q.Set("orgId", orgId)
+	url.RawQuery = q.Encode()
+
+	return url.String()
 }
 
 func ExtendData(data *template.Data, logger log.Logger) *ExtendedData {

--- a/pkg/services/ngalert/notifier/channels/template_data.go
+++ b/pkg/services/ngalert/notifier/channels/template_data.go
@@ -90,15 +90,15 @@ func extendAlert(alert template.Alert, externalURL string, logger log.Logger) *E
 			extended.PanelURL = u.String()
 		}
 
-		generatorUrl, gErr := url.Parse(extended.GeneratorURL)
-		if gErr != nil {
-			logger.Debug("failed to parse generator URL while extending template data", "url", extended.GeneratorURL, "err", gErr.Error())
+		generatorUrl, err := url.Parse(extended.GeneratorURL)
+		if err != nil {
+			logger.Debug("failed to parse generator URL while extending template data", "url", extended.GeneratorURL, "err", err.Error())
 			return extended
 		}
 
-		dashboardUrl, dErr := url.Parse(extended.DashboardURL)
-		if dErr != nil {
-			logger.Debug("failed to parse dashboard URL while extending template data", "url", extended.DashboardURL, "err", dErr.Error())
+		dashboardUrl, err := url.Parse(extended.DashboardURL)
+		if err != nil {
+			logger.Debug("failed to parse dashboard URL while extending template data", "url", extended.DashboardURL, "err", err.Error())
 			return extended
 		}
 

--- a/pkg/services/ngalert/notifier/channels/template_data.go
+++ b/pkg/services/ngalert/notifier/channels/template_data.go
@@ -89,6 +89,16 @@ func extendAlert(alert template.Alert, externalURL string, logger log.Logger) *E
 			u.RawQuery = "viewPanel=" + panelId
 			extended.PanelURL = u.String()
 		}
+
+		orgId := alert.Annotations[ngmodels.OrgIDAnnotation]
+		if len(orgId) > 0 {
+			extended.DashboardURL = extended.DashboardURL + "?orgId=" + orgId
+
+			q := u.Query()
+			q.Add("orgId", orgId)
+			u.RawQuery = q.Encode()
+			extended.PanelURL = u.String()
+		}
 	}
 
 	if alert.Annotations != nil {

--- a/pkg/services/ngalert/notifier/channels/template_data.go
+++ b/pkg/services/ngalert/notifier/channels/template_data.go
@@ -90,14 +90,32 @@ func extendAlert(alert template.Alert, externalURL string, logger log.Logger) *E
 			extended.PanelURL = u.String()
 		}
 
+		generatorUrl, gErr := url.Parse(extended.GeneratorURL)
+		if gErr != nil {
+			logger.Debug("failed to parse generator URL while extending template data", "url", extended.GeneratorURL, "err", gErr.Error())
+			return extended
+		}
+
+		dashboardUrl, dErr := url.Parse(extended.DashboardURL)
+		if dErr != nil {
+			logger.Debug("failed to parse dashboard URL while extending template data", "url", extended.DashboardURL, "err", dErr.Error())
+			return extended
+		}
+
 		orgId := alert.Annotations[ngmodels.OrgIDAnnotation]
 		if len(orgId) > 0 {
-			extended.DashboardURL = extended.DashboardURL + "?orgId=" + orgId
+			orgIdParam := "orgId=" + orgId
+
+			dashboardUrl.RawQuery = orgIdParam
+			extended.DashboardURL = dashboardUrl.String()
 
 			q := u.Query()
 			q.Add("orgId", orgId)
 			u.RawQuery = q.Encode()
 			extended.PanelURL = u.String()
+
+			generatorUrl.RawQuery = orgIdParam
+			extended.GeneratorURL = generatorUrl.String()
 		}
 	}
 

--- a/pkg/services/ngalert/schedule/compat.go
+++ b/pkg/services/ngalert/schedule/compat.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"path"
+	"strconv"
 	"time"
 
 	"github.com/benbjohnson/clock"
@@ -53,6 +54,10 @@ func stateToPostableAlert(alertState *state.State, appURL *url.URL) *models.Post
 
 	if alertState.StateReason != "" {
 		nA[ngModels.StateReasonAnnotation] = alertState.StateReason
+	}
+
+	if alertState.OrgID != 0 {
+		nA[ngModels.OrgIDAnnotation] = strconv.FormatInt(alertState.OrgID, 10)
 	}
 
 	var urlStr string

--- a/pkg/tests/api/alerting/api_notification_channel_test.go
+++ b/pkg/tests/api/alerting/api_notification_channel_test.go
@@ -1612,7 +1612,7 @@ const alertmanagerConfig = `
             }
           }
         ]
-      },   
+      },
 	  {
         "name": "slack_recv2",
         "grafana_managed_receiver_configs": [
@@ -2621,6 +2621,7 @@ var expNonEmailNotifications = map[string][]string{
 			  "grafana_folder": "default"
 			},
 			"annotations": {
+			  "__orgId__":"1",
               "__values__": "{\"A\":1}",
               "__value_string__": "[ var='A' labels={} value=1 ]"
             },


### PR DESCRIPTION
- The orgId field has been appended as query param to the dashboard and panel URL that are sent as part of an alert notification
- Resolves #47424

**What this PR does / why we need it**:

The PR addresses #47424. The dashboard and the panel source URLs that are included in an alert notification currently does not include the orgId reference. If an user is on a different org and tries to land on the dashboard URL included in the alert, then the user will receive an error from UI, as the target dashboard is not within the current org account

![image](https://user-images.githubusercontent.com/47709856/196348101-d0646753-7b83-418a-9e16-8bc4c318c4f9.png)


**Which issue(s) this PR fixes**:

The above issue has been addressed by including the `orgId` as a query param in both the dashboard and the panel URLs that are sent as part of an alert notification.

**After fix**

Below is a sample Discord alert with the updated URLs

![image](https://user-images.githubusercontent.com/47709856/196264246-769581a1-2464-41fd-9440-6fd76daa9bb6.png)

Switched to an org that does not have the source of the alert

![image](https://user-images.githubusercontent.com/47709856/196264657-caf171ee-db56-4443-b5d6-6dca18d180bd.png)

Landing on the dashboard using the URL from the alert

![image](https://user-images.githubusercontent.com/47709856/196264884-f2e32cf8-41d2-4c8c-902f-a221b8aafbb0.png)

Fixes #47424


