### PR TITLE
Alerting: Fix swagger spec for receivers API response

### DIFF
--- a/pkg/services/ngalert/api/api.go
+++ b/pkg/services/ngalert/api/api.go
@@ -50,7 +50,7 @@ type Alertmanager interface {
 	GetAlertGroups(active, silenced, inhibited bool, filter []string, receiver string) (apimodels.AlertGroups, error)
 
 	// Receivers
-	GetReceivers(ctx context.Context) apimodels.Receivers
+	GetReceivers(ctx context.Context) []apimodels.Receiver
 	TestReceivers(ctx context.Context, c apimodels.TestReceiversConfigBodyParams) (*notifier.TestReceiversResult, error)
 }
 

--- a/pkg/services/ngalert/api/tooling/api.json
+++ b/pkg/services/ngalert/api/tooling/api.json
@@ -413,6 +413,9 @@
     "auth_password": {
      "$ref": "#/definitions/Secret"
     },
+    "auth_password_file": {
+     "type": "string"
+    },
     "auth_secret": {
      "$ref": "#/definitions/Secret"
     },
@@ -1160,6 +1163,9 @@
     },
     "smtp_auth_password": {
      "$ref": "#/definitions/Secret"
+    },
+    "smtp_auth_password_file": {
+     "type": "string"
     },
     "smtp_auth_secret": {
      "$ref": "#/definitions/Secret"
@@ -3035,6 +3041,9 @@
      },
      "type": "array"
     },
+    "location": {
+     "type": "string"
+    },
     "months": {
      "items": {
       "type": "string"
@@ -3269,7 +3278,6 @@
    "type": "object"
   },
   "alertGroup": {
-   "description": "AlertGroup alert group",
    "properties": {
     "alerts": {
      "description": "alerts",
@@ -3293,7 +3301,6 @@
    "type": "object"
   },
   "alertGroups": {
-   "description": "AlertGroups alert groups",
    "items": {
     "$ref": "#/definitions/alertGroup"
    },
@@ -3398,7 +3405,6 @@
    "type": "object"
   },
   "gettableAlert": {
-   "description": "GettableAlert gettable alert",
    "properties": {
     "annotations": {
      "$ref": "#/definitions/labelSet"
@@ -3461,7 +3467,6 @@
    "type": "array"
   },
   "gettableSilence": {
-   "description": "GettableSilence gettable silence",
    "properties": {
     "comment": {
      "description": "comment",
@@ -3510,7 +3515,6 @@
    "type": "object"
   },
   "gettableSilences": {
-   "description": "GettableSilences gettable silences",
    "items": {
     "$ref": "#/definitions/gettableSilence"
    },
@@ -4459,6 +4463,17 @@
  "produces": [
   "application/json"
  ],
+ "responses": {
+  "receiversResponse": {
+   "description": "",
+   "schema": {
+    "items": {
+     "$ref": "#/definitions/receiver"
+    },
+    "type": "array"
+   }
+  }
+ },
  "schemes": [
   "http",
   "https"

--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
@@ -144,10 +144,10 @@ import (
 
 // swagger:route GET /api/alertmanager/grafana/config/api/v1/receivers alertmanager RouteGetGrafanaReceivers
 //
-// Get a list of all receivers.
+// Get a list of all receivers
 //
 //     Responses:
-//       200: receivers
+//       200: receiversResponse
 
 // swagger:route POST /api/alertmanager/grafana/config/api/v1/receivers/test alertmanager RoutePostTestGrafanaReceivers
 //
@@ -410,8 +410,11 @@ type AlertGroup = amv2.AlertGroup
 // swagger:model receiver
 type Receiver = amv2.Receiver
 
-// swagger:model receivers
-type Receivers = []amv2.Receiver
+// swagger:response receiversResponse
+type ReceiversResponse struct {
+	// in:body
+	Body []amv2.Receiver
+}
 
 // swagger:model integration
 type Integration = amv2.Integration

--- a/pkg/services/ngalert/api/tooling/post.json
+++ b/pkg/services/ngalert/api/tooling/post.json
@@ -413,6 +413,9 @@
     "auth_password": {
      "$ref": "#/definitions/Secret"
     },
+    "auth_password_file": {
+     "type": "string"
+    },
     "auth_secret": {
      "$ref": "#/definitions/Secret"
     },
@@ -1160,6 +1163,9 @@
     },
     "smtp_auth_password": {
      "$ref": "#/definitions/Secret"
+    },
+    "smtp_auth_password_file": {
+     "type": "string"
     },
     "smtp_auth_secret": {
      "$ref": "#/definitions/Secret"
@@ -3035,6 +3041,9 @@
      },
      "type": "array"
     },
+    "location": {
+     "type": "string"
+    },
     "months": {
      "items": {
       "type": "string"
@@ -3078,7 +3087,6 @@
    "type": "object"
   },
   "URL": {
-   "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use RawPath, an optional field which only gets\nset if the default encoding is different from Path.\n\nURL's String method uses the EscapedPath method to obtain the path. See the\nEscapedPath method for more details.",
    "properties": {
     "ForceQuery": {
      "type": "boolean"
@@ -3114,7 +3122,7 @@
      "$ref": "#/definitions/Userinfo"
     }
    },
-   "title": "A URL represents a parsed URL (technically, a URI reference).",
+   "title": "URL is a custom URL type that allows validation at configuration load time.",
    "type": "object"
   },
   "Userinfo": {
@@ -3270,6 +3278,7 @@
    "type": "object"
   },
   "alertGroup": {
+   "description": "AlertGroup alert group",
    "properties": {
     "alerts": {
      "description": "alerts",
@@ -3293,6 +3302,7 @@
    "type": "object"
   },
   "alertGroups": {
+   "description": "AlertGroups alert groups",
    "items": {
     "$ref": "#/definitions/alertGroup"
    },
@@ -3452,7 +3462,6 @@
    "type": "object"
   },
   "gettableAlerts": {
-   "description": "GettableAlerts gettable alerts",
    "items": {
     "$ref": "#/definitions/gettableAlert"
    },
@@ -3648,6 +3657,7 @@
    "type": "array"
   },
   "postableSilence": {
+   "description": "PostableSilence postable silence",
    "properties": {
     "comment": {
      "description": "comment",
@@ -4182,13 +4192,13 @@
   },
   "/api/alertmanager/grafana/config/api/v1/receivers": {
    "get": {
+    "description": "Get a list of all receivers",
     "operationId": "RouteGetGrafanaReceivers",
     "responses": {
      "200": {
-      "$ref": "#/responses/receivers"
+      "$ref": "#/responses/receiversResponse"
      }
     },
-    "summary": "Get a list of all receivers.",
     "tags": [
      "alertmanager"
     ]
@@ -6307,6 +6317,17 @@
  "produces": [
   "application/json"
  ],
+ "responses": {
+  "receiversResponse": {
+   "description": "",
+   "schema": {
+    "items": {
+     "$ref": "#/definitions/receiver"
+    },
+    "type": "array"
+   }
+  }
+ },
  "schemes": [
   "http",
   "https"

--- a/pkg/services/ngalert/api/tooling/spec.json
+++ b/pkg/services/ngalert/api/tooling/spec.json
@@ -394,14 +394,14 @@
     },
     "/api/alertmanager/grafana/config/api/v1/receivers": {
       "get": {
+        "description": "Get a list of all receivers",
         "tags": [
           "alertmanager"
         ],
-        "summary": "Get a list of all receivers.",
         "operationId": "RouteGetGrafanaReceivers",
         "responses": {
           "200": {
-            "$ref": "#/responses/receivers"
+            "$ref": "#/responses/receiversResponse"
           }
         }
       }
@@ -2951,6 +2951,9 @@
         "auth_password": {
           "$ref": "#/definitions/Secret"
         },
+        "auth_password_file": {
+          "type": "string"
+        },
         "auth_secret": {
           "$ref": "#/definitions/Secret"
         },
@@ -3699,6 +3702,9 @@
         },
         "smtp_auth_password": {
           "$ref": "#/definitions/Secret"
+        },
+        "smtp_auth_password_file": {
+          "type": "string"
         },
         "smtp_auth_secret": {
           "$ref": "#/definitions/Secret"
@@ -5575,6 +5581,9 @@
             "type": "string"
           }
         },
+        "location": {
+          "type": "string"
+        },
         "months": {
           "type": "array",
           "items": {
@@ -5617,9 +5626,8 @@
       }
     },
     "URL": {
-      "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use RawPath, an optional field which only gets\nset if the default encoding is different from Path.\n\nURL's String method uses the EscapedPath method to obtain the path. See the\nEscapedPath method for more details.",
       "type": "object",
-      "title": "A URL represents a parsed URL (technically, a URI reference).",
+      "title": "URL is a custom URL type that allows validation at configuration load time.",
       "properties": {
         "ForceQuery": {
           "type": "boolean"
@@ -5809,6 +5817,7 @@
       }
     },
     "alertGroup": {
+      "description": "AlertGroup alert group",
       "type": "object",
       "required": [
         "alerts",
@@ -5833,6 +5842,7 @@
       "$ref": "#/definitions/alertGroup"
     },
     "alertGroups": {
+      "description": "AlertGroups alert groups",
       "type": "array",
       "items": {
         "$ref": "#/definitions/alertGroup"
@@ -5994,7 +6004,6 @@
       "$ref": "#/definitions/gettableAlert"
     },
     "gettableAlerts": {
-      "description": "GettableAlerts gettable alerts",
       "type": "array",
       "items": {
         "$ref": "#/definitions/gettableAlert"
@@ -6194,6 +6203,7 @@
       }
     },
     "postableSilence": {
+      "description": "PostableSilence postable silence",
       "type": "object",
       "required": [
         "comment",
@@ -6343,6 +6353,17 @@
         "version": {
           "description": "version",
           "type": "string"
+        }
+      }
+    }
+  },
+  "responses": {
+    "receiversResponse": {
+      "description": "",
+      "schema": {
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/receiver"
         }
       }
     }

--- a/pkg/services/ngalert/notifier/receivers.go
+++ b/pkg/services/ngalert/notifier/receivers.go
@@ -199,11 +199,11 @@ func (am *Alertmanager) TestReceivers(ctx context.Context, c apimodels.TestRecei
 	return newTestReceiversResult(testAlert, append(invalid, results...), now), nil
 }
 
-func (am *Alertmanager) GetReceivers(ctx context.Context) apimodels.Receivers {
+func (am *Alertmanager) GetReceivers(ctx context.Context) []apimodels.Receiver {
 	am.reloadConfigMtx.RLock()
 	defer am.reloadConfigMtx.RUnlock()
 
-	var apiReceivers apimodels.Receivers
+	var apiReceivers []apimodels.Receiver
 	for _, rcv := range am.receivers {
 		// Build integrations slice for each receiver.
 		var integrations []*models.Integration

--- a/pkg/tests/api/alerting/api_notification_channel_test.go
+++ b/pkg/tests/api/alerting/api_notification_channel_test.go
@@ -776,7 +776,7 @@ func TestNotificationChannels(t *testing.T) {
 		resp = getRequest(t, receiversURL, http.StatusOK) // nolint
 		b = getBody(t, resp.Body)
 
-		var receivers apimodels.Receivers
+		var receivers []apimodels.Receiver
 		err := json.Unmarshal([]byte(b), &receivers)
 		require.NoError(t, err)
 		for _, rcv := range receivers {
@@ -824,7 +824,7 @@ func TestNotificationChannels(t *testing.T) {
 	resp := getRequest(t, receiversURL, http.StatusOK) // nolint
 	b := getBody(t, resp.Body)
 
-	var receivers apimodels.Receivers
+	var receivers []apimodels.Receiver
 	err := json.Unmarshal([]byte(b), &receivers)
 	require.NoError(t, err)
 	for _, rcv := range receivers {


### PR DESCRIPTION
This PR fixes a broken reference and updates our swagger spec.

The swagger tools fails to parse a slice of AM receivers as a `swagger:model`:
```go
// swagger:model receivers
type Receivers = []amv2.Receiver    // <- This fails to be parsed
```

This leads to a broken reference in our spec. To fix this, I created a new struct to represent a response from the receivers API and used it in the route definition:
```go
// swagger:response receiversResponse
type ReceiversResponse struct {
	// in:body
	Body []amv2.Receiver
}
```