### PR TITLE
Page: Refine responsive paddings and margins

### DIFF
--- a/public/app/core/components/PageNew/Page.tsx
+++ b/public/app/core/components/PageNew/Page.tsx
@@ -124,13 +124,21 @@ const getStyles = (theme: GrafanaTheme2) => {
     }),
     pageInner: css({
       label: 'page-inner',
-      padding: theme.spacing(3),
+      padding: theme.spacing(2),
       boxShadow: shadow,
       background: theme.colors.background.primary,
-      margin: theme.spacing(2, 2, 2, 1),
       display: 'flex',
       flexDirection: 'column',
       flexGrow: 1,
+      margin: theme.spacing(0, 0, 0, 0),
+
+      [theme.breakpoints.up('sm')]: {
+        margin: theme.spacing(0, 1, 1, 1),
+      },
+      [theme.breakpoints.up('md')]: {
+        margin: theme.spacing(2, 2, 2, 1),
+        padding: theme.spacing(3),
+      },
     }),
     canvasContent: css({
       label: 'canvas-content',

--- a/public/app/core/components/PageNew/SectionNav.tsx
+++ b/public/app/core/components/PageNew/SectionNav.tsx
@@ -71,37 +71,39 @@ const getStyles = (theme: GrafanaTheme2) => {
       background: theme.colors.background.canvas,
       flexShrink: 0,
       transition: theme.transitions.create(['width', 'max-height']),
+      maxHeight: 0,
       [theme.breakpoints.up('md')]: {
         width: 0,
-      },
-      [theme.breakpoints.down('md')]: {
-        maxHeight: 0,
+        maxHeight: 'unset',
       },
     }),
     navExpanded: css({
+      maxHeight: '50vh',
       [theme.breakpoints.up('md')]: {
         width: '250px',
-      },
-      [theme.breakpoints.down('md')]: {
-        maxHeight: '50vh',
+        maxHeight: 'unset',
       },
     }),
     items: css({
       display: 'flex',
       flexDirection: 'column',
-      padding: theme.spacing(4.5, 1, 2, 2),
+      padding: theme.spacing(2, 1, 2, 2),
       minWidth: '250px',
+      [theme.breakpoints.up('md')]: {
+        padding: theme.spacing(4.5, 1, 2, 2),
+      },
     }),
     collapseIcon: css({
       border: `1px solid ${theme.colors.border.weak}`,
-      transform: 'translateX(50%)',
-      top: theme.spacing(8),
-      right: theme.spacing(-1),
+      left: '50%',
+      transform: 'translate(-50%, 50%) rotate(90deg)',
+      top: theme.spacing(0),
 
-      [theme.breakpoints.down('md')]: {
-        left: '50%',
-        transform: 'translate(-50%, 50%) rotate(90deg)',
-        top: theme.spacing(2),
+      [theme.breakpoints.up('md')]: {
+        transform: 'translateX(50%)',
+        top: theme.spacing(8),
+        left: theme.spacing(1),
+        right: theme.spacing(-1),
       },
     }),
   };

--- a/public/app/core/components/PageNew/SectionNavToggle.tsx
+++ b/public/app/core/components/PageNew/SectionNavToggle.tsx
@@ -17,6 +17,7 @@ export const SectionNavToggle = ({ className, isExpanded, onClick }: Props) => {
 
   return (
     <IconButton
+      tooltip={'Toggle section navigation'}
       aria-label={isExpanded ? 'Close section navigation' : 'Open section navigation'}
       name={isExpanded ? 'angle-left' : 'angle-right'}
       className={classnames(className, styles.icon)}


### PR DESCRIPTION
Refines the margins and paddings on smaller screens. Aligns on using mobile first media queries (ie start with mobile and using up rules)

sm (mobile) 
* No margins (canvas showing)
* Smaller inner paddings (16px) (2)  
* Smaller top padding for section nav (when expanded) 
* move expand/collapse icon to the edge of the page container (similar to how it is when on the left side) 
* Add tooltip to expand/collapse toggle 

sm up 
* small margin (8px) (1)

md up
* inner paddings 24px (3)

md
<img width="753" alt="Screenshot 2022-10-17 at 17 07 04" src="https://user-images.githubusercontent.com/10999/196284012-89ecbf81-105b-41d4-8c8b-8fa2bc01b1a7.png">

sm
<img width="481" alt="Screenshot 2022-10-17 at 17 07 14" src="https://user-images.githubusercontent.com/10999/196284023-760606af-af8e-46dc-93fc-789bc801938c.png">

