### PR TITLE
Search: Sort alphabetically in the folder view, increase the limit of the folder search from 50 to 1000

### DIFF
--- a/public/app/features/search/page/components/FolderView.tsx
+++ b/public/app/features/search/page/components/FolderView.tsx
@@ -49,9 +49,12 @@ export const FolderView = ({
     }
     folders.push({ title: 'General', url: '/dashboards', kind: 'folder', uid: GENERAL_FOLDER_UID });
 
-    const rsp = await getGrafanaSearcher().search({
+    const searcher = getGrafanaSearcher();
+    const rsp = await searcher.search({
       query: '*',
       kind: ['folder'],
+      sort: searcher.getFolderViewSort(),
+      limit: 1000,
     });
     for (const row of rsp.view) {
       folders.push({

--- a/public/app/features/search/service/bluge.ts
+++ b/public/app/features/search/service/bluge.ts
@@ -14,6 +14,8 @@ import { DashboardQueryResult, GrafanaSearcher, QueryResponse, SearchQuery, Sear
 // and that it can not serve any search requests. We are temporarily using the old SQL Search API as a fallback when that happens.
 const loadingFrameName = 'Loading';
 
+const folderViewSort = 'name_sort';
+
 export class BlugeSearcher implements GrafanaSearcher {
   constructor(private fallbackSearcher: GrafanaSearcher) {}
 
@@ -74,7 +76,7 @@ export class BlugeSearcher implements GrafanaSearcher {
   // This should eventually be filled by an API call, but hardcoded is a good start
   getSortOptions(): Promise<SelectableValue[]> {
     const opts: SelectableValue[] = [
-      { value: 'name_sort', label: 'Alphabetically (A-Z)' },
+      { value: folderViewSort, label: 'Alphabetically (A-Z)' },
       { value: '-name_sort', label: 'Alphabetically (Z-A)' },
     ];
 
@@ -216,6 +218,10 @@ export class BlugeSearcher implements GrafanaSearcher {
         return index < view.dataFrame.length;
       },
     };
+  }
+
+  getFolderViewSort(): string {
+    return 'name_sort';
   }
 }
 

--- a/public/app/features/search/service/sql.ts
+++ b/public/app/features/search/service/sql.ts
@@ -224,4 +224,9 @@ export class SQLSearcher implements GrafanaSearcher {
       isItemLoaded: (index: number): boolean => true,
     };
   }
+
+  getFolderViewSort = () => {
+    // sorts alphabetically in memory after retrieving the folders from the database
+    return '';
+  };
 }

--- a/public/app/features/search/service/types.ts
+++ b/public/app/features/search/service/types.ts
@@ -72,4 +72,7 @@ export interface GrafanaSearcher {
   starred: (query: SearchQuery) => Promise<QueryResponse>;
   tags: (query: SearchQuery) => Promise<TermCount[]>;
   getSortOptions: () => Promise<SelectableValue[]>;
+
+  /** Gets the default sort used for the Folder view */
+  getFolderViewSort: () => string;
 }


### PR DESCRIPTION
manual backport of https://github.com/grafana/grafana/pull/57078 to v9.1.9