### PR TITLE
Browse: Fix General folder not showing in FolderPicker

### DIFF
--- a/public/app/core/components/Select/FolderPicker.test.tsx
+++ b/public/app/core/components/Select/FolderPicker.test.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import selectEvent from 'react-select-event';
 
 import { selectors } from '@grafana/e2e-selectors';
+import { contextSrv } from 'app/core/core';
 import * as api from 'app/features/manage-dashboards/state/actions';
 
 import { DashboardSearchHit } from '../../../features/search/types';
@@ -73,6 +74,69 @@ describe('FolderPicker', () => {
     await waitFor(() => {
       expect(screen.getByText(newFolder.title)).toBeInTheDocument();
     });
+  });
+
+  it('should show the General folder by default for editors', async () => {
+    jest
+      .spyOn(api, 'searchFolders')
+      .mockResolvedValue([
+        { title: 'Dash 1', id: 1 } as DashboardSearchHit,
+        { title: 'Dash 2', id: 2 } as DashboardSearchHit,
+      ]);
+
+    jest.spyOn(contextSrv, 'hasAccess').mockReturnValue(true);
+
+    const onChangeFn = jest.fn();
+    render(<FolderPicker onChange={onChangeFn} />);
+    expect(await screen.findByTestId(selectors.components.FolderPicker.containerV2)).toBeInTheDocument();
+    const pickerContainer = screen.getByLabelText(selectors.components.FolderPicker.input);
+    selectEvent.openMenu(pickerContainer);
+
+    const pickerOptions = await screen.findAllByLabelText('Select option');
+
+    expect(pickerOptions[0]).toHaveTextContent('General');
+  });
+
+  it('should not show the General folder by default if showRoot is false', async () => {
+    jest
+      .spyOn(api, 'searchFolders')
+      .mockResolvedValue([
+        { title: 'Dash 1', id: 1 } as DashboardSearchHit,
+        { title: 'Dash 2', id: 2 } as DashboardSearchHit,
+      ]);
+
+    jest.spyOn(contextSrv, 'hasAccess').mockReturnValue(true);
+
+    const onChangeFn = jest.fn();
+    render(<FolderPicker onChange={onChangeFn} showRoot={false} />);
+    expect(await screen.findByTestId(selectors.components.FolderPicker.containerV2)).toBeInTheDocument();
+    const pickerContainer = screen.getByLabelText(selectors.components.FolderPicker.input);
+    selectEvent.openMenu(pickerContainer);
+
+    const pickerOptions = await screen.findAllByLabelText('Select option');
+
+    expect(pickerOptions[0]).not.toHaveTextContent('General');
+  });
+
+  it('should not show the General folder by default for not editors', async () => {
+    jest
+      .spyOn(api, 'searchFolders')
+      .mockResolvedValue([
+        { title: 'Dash 1', id: 1 } as DashboardSearchHit,
+        { title: 'Dash 2', id: 2 } as DashboardSearchHit,
+      ]);
+
+    jest.spyOn(contextSrv, 'hasAccess').mockReturnValue(false);
+
+    const onChangeFn = jest.fn();
+    render(<FolderPicker onChange={onChangeFn} />);
+    expect(await screen.findByTestId(selectors.components.FolderPicker.containerV2)).toBeInTheDocument();
+    const pickerContainer = screen.getByLabelText(selectors.components.FolderPicker.input);
+    selectEvent.openMenu(pickerContainer);
+
+    const pickerOptions = await screen.findAllByLabelText('Select option');
+
+    expect(pickerOptions[0]).not.toHaveTextContent('General');
   });
 });
 

--- a/public/app/core/components/Select/FolderPicker.tsx
+++ b/public/app/core/components/Select/FolderPicker.tsx
@@ -68,10 +68,10 @@ export function FolderPicker(props: Props) {
     onClear,
     enableReset,
     initialFolderId,
-    initialTitle,
-    permissionLevel,
-    rootName,
-    showRoot,
+    initialTitle = '',
+    permissionLevel = PermissionLevelString.Edit,
+    rootName = 'General',
+    showRoot = true,
     skipInitialLoad,
     accessControlMetadata,
     customAdd,
@@ -106,7 +106,7 @@ export function FolderPicker(props: Props) {
         initialTitle !== '' &&
         !options.find((option) => option.label === initialTitle)
       ) {
-        Boolean(initialTitle) && options.unshift({ label: initialTitle, value: initialFolderId });
+        options.unshift({ label: initialTitle, value: initialFolderId });
       }
       if (enableCreateNew && Boolean(customAdd)) {
         return [...options, { value: VALUE_FOR_ADD, label: ADD_NEW_FOLER_OPTION, title: query }];


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the General folder back into the `FolderPicker`.

**Which issue(s) this PR fixes**:

Fixes #57111

**Special notes for your reviewer**:

