### PR TITLE
[v9.1.x] Add RPM package publishing (#56797)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3554,7 +3554,7 @@ steps:
   - gen-version
   failure: ignore
   image: us.gcr.io/kubernetes-dev/package-publish:latest
-  name: publish-linux-packages
+  name: publish-linux-packages-deb
   privileged: true
   settings:
     access_key_id:
@@ -3567,6 +3567,28 @@ steps:
     gpg_public_key:
       from_secret: packages_gpg_public_key
     package_path: gs://grafana-prerelease/artifacts/downloads/*${DRONE_TAG}/oss/**.deb
+    secret_access_key:
+      from_secret: packages_secret_access_key
+    service_account_json:
+      from_secret: packages_service_account_json
+    target_bucket: grafana-packages
+- depends_on:
+  - gen-version
+  failure: ignore
+  image: us.gcr.io/kubernetes-dev/package-publish:latest
+  name: publish-linux-packages-rpm
+  privileged: true
+  settings:
+    access_key_id:
+      from_secret: packages_access_key_id
+    deb_distribution: stable
+    gpg_passphrase:
+      from_secret: packages_gpg_passphrase
+    gpg_private_key:
+      from_secret: packages_gpg_private_key
+    gpg_public_key:
+      from_secret: packages_gpg_public_key
+    package_path: gs://grafana-prerelease/artifacts/downloads/*${DRONE_TAG}/oss/**.rpm
     secret_access_key:
       from_secret: packages_secret_access_key
     service_account_json:
@@ -3632,7 +3654,7 @@ steps:
   - gen-version
   failure: ignore
   image: us.gcr.io/kubernetes-dev/package-publish:latest
-  name: publish-linux-packages
+  name: publish-linux-packages-deb
   privileged: true
   settings:
     access_key_id:
@@ -3645,6 +3667,28 @@ steps:
     gpg_public_key:
       from_secret: packages_gpg_public_key
     package_path: gs://grafana-prerelease/artifacts/downloads/*${DRONE_TAG}/enterprise/**.deb
+    secret_access_key:
+      from_secret: packages_secret_access_key
+    service_account_json:
+      from_secret: packages_service_account_json
+    target_bucket: grafana-packages
+- depends_on:
+  - gen-version
+  failure: ignore
+  image: us.gcr.io/kubernetes-dev/package-publish:latest
+  name: publish-linux-packages-rpm
+  privileged: true
+  settings:
+    access_key_id:
+      from_secret: packages_access_key_id
+    deb_distribution: stable
+    gpg_passphrase:
+      from_secret: packages_gpg_passphrase
+    gpg_private_key:
+      from_secret: packages_gpg_private_key
+    gpg_public_key:
+      from_secret: packages_gpg_public_key
+    package_path: gs://grafana-prerelease/artifacts/downloads/*${DRONE_TAG}/enterprise/**.rpm
     secret_access_key:
       from_secret: packages_secret_access_key
     service_account_json:
@@ -5164,6 +5208,6 @@ kind: secret
 name: packages_secret_access_key
 ---
 kind: signature
-hmac: c2315645dc460a0b74775ef8f1f6f124daf43d073f4efa496a4c08399756327f
+hmac: 458d9ee826d376913faceeedd7ee2c22b98db438951ccea3bbf9159f4fbfd3a1
 
 ...

--- a/scripts/drone/events/release.star
+++ b/scripts/drone/events/release.star
@@ -404,14 +404,16 @@ def publish_packages_pipeline():
         download_grabpl_step(),
         gen_version_step(ver_mode='release'),
         store_packages_step(edition='oss', ver_mode='release'),
-        publish_linux_packages_step(edition='oss'),
+        publish_linux_packages_step(edition='oss', package_manager='deb'),
+        publish_linux_packages_step(edition='oss', package_manager='rpm'),
     ]
 
     enterprise_steps = [
         download_grabpl_step(),
         gen_version_step(ver_mode='release'),
         store_packages_step(edition='enterprise', ver_mode='release'),
-        publish_linux_packages_step(edition='enterprise'),
+        publish_linux_packages_step(edition='enterprise', package_manager='deb'),
+        publish_linux_packages_step(edition='enterprise', package_manager='rpm'),
     ]
     deps = [
         'publish-artifacts-public',

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -1024,9 +1024,9 @@ def store_packages_step(edition, ver_mode):
         ],
     }
 
-def publish_linux_packages_step(edition):
+def publish_linux_packages_step(edition, package_manager='deb'):
     return {
-        'name': 'publish-linux-packages',
+        'name': 'publish-linux-packages-{}'.format(package_manager),
         # See https://github.com/grafana/deployment_tools/blob/master/docker/package-publish/README.md for docs on that image
         'image': 'us.gcr.io/kubernetes-dev/package-publish:latest',
         'depends_on': [
@@ -1043,7 +1043,7 @@ def publish_linux_packages_step(edition):
             'gpg_passphrase': from_secret('packages_gpg_passphrase'),
             'gpg_public_key': from_secret('packages_gpg_public_key'),
             'gpg_private_key': from_secret('packages_gpg_private_key'),
-            'package_path': 'gs://grafana-prerelease/artifacts/downloads/*${{DRONE_TAG}}/{}/**.deb'.format(edition)
+            'package_path': 'gs://grafana-prerelease/artifacts/downloads/*${{DRONE_TAG}}/{}/**.{}'.format(edition, package_manager)
         }
     }
 


### PR DESCRIPTION
Just tested deb publishing, and confirmed it works. Noticed that RPM packages aren't published though It's the exact same step, targetting the RPM files instead Both steps will run in parallel

Co-authored-by: dsotirakis <dimitrios.sotirakis@grafana.com>
(cherry picked from commit 44ad4ec9d4e63de964fb9e34079deb681da2df3b)

Backport of #56797