### PR TITLE
CI: Add `CreateTempDir` func and use it in publish packages logic

### DIFF
--- a/pkg/build/cmd/publishpackages.go
+++ b/pkg/build/cmd/publishpackages.go
@@ -70,7 +70,6 @@ func PublishPackages(c *cli.Context) error {
 	// so should be safe.
 	if cfg.ReleaseMode.Mode == config.TagMode {
 		workDir, err := fsutil.CreateTempDir("")
-		fmt.Println("workDir: ", workDir)
 		if err != nil {
 			return err
 		}
@@ -79,7 +78,7 @@ func PublishPackages(c *cli.Context) error {
 				log.Printf("Failed to remove temporary directory %q: %s\n", workDir, err.Error())
 			}
 		}()
-		if err := updatePkgRepos(cfg, fmt.Sprintf("%s/", workDir)); err != nil {
+		if err := updatePkgRepos(cfg, workDir); err != nil {
 			return err
 		}
 	}

--- a/pkg/build/cmd/publishpackages.go
+++ b/pkg/build/cmd/publishpackages.go
@@ -69,7 +69,8 @@ func PublishPackages(c *cli.Context) error {
 	// In test release mode, the operator should configure different GCS buckets for the package repos,
 	// so should be safe.
 	if cfg.ReleaseMode.Mode == config.TagMode {
-		workDir, err := fsutil.CreateTempFile("")
+		workDir, err := fsutil.CreateTempDir("")
+		fmt.Println("workDir: ", workDir)
 		if err != nil {
 			return err
 		}
@@ -78,7 +79,7 @@ func PublishPackages(c *cli.Context) error {
 				log.Printf("Failed to remove temporary directory %q: %s\n", workDir, err.Error())
 			}
 		}()
-		if err := updatePkgRepos(cfg, workDir); err != nil {
+		if err := updatePkgRepos(cfg, fmt.Sprintf("%s/", workDir)); err != nil {
 			return err
 		}
 	}

--- a/pkg/build/fsutil/createtemp.go
+++ b/pkg/build/fsutil/createtemp.go
@@ -38,13 +38,6 @@ func CreateTempDir(sfx string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer func(path string) {
-		err := os.RemoveAll(path)
-		if err != nil {
-			fmt.Printf("failed to remove %s dir", dir)
-			return
-		}
-	}(dir)
 
 	return dir, nil
 }

--- a/pkg/build/fsutil/createtemp.go
+++ b/pkg/build/fsutil/createtemp.go
@@ -24,3 +24,26 @@ func CreateTempFile(sfx string) (string, error) {
 
 	return f.Name(), nil
 }
+
+// CreateTempDir generates a temp directory, based on the provided suffix.
+// A typical generated path looks like /var/folders/abcd/abcdefg/A/1137975807/.
+func CreateTempDir(sfx string) (string, error) {
+	var suffix string
+	if sfx != "" {
+		suffix = fmt.Sprintf("*-%s", sfx)
+	} else {
+		suffix = sfx
+	}
+	dir, err := os.MkdirTemp("", suffix)
+	if err != nil {
+		return "", err
+	}
+	defer func(path string) {
+		err := os.RemoveAll(path)
+		if err != nil {
+
+		}
+	}(dir)
+
+	return dir, nil
+}

--- a/pkg/build/fsutil/createtemp.go
+++ b/pkg/build/fsutil/createtemp.go
@@ -41,7 +41,8 @@ func CreateTempDir(sfx string) (string, error) {
 	defer func(path string) {
 		err := os.RemoveAll(path)
 		if err != nil {
-
+			fmt.Printf("failed to remove %s dir", dir)
+			return
 		}
 	}(dir)
 

--- a/pkg/build/fsutil/createtemp_test.go
+++ b/pkg/build/fsutil/createtemp_test.go
@@ -26,3 +26,23 @@ func TestCreateTempFile(t *testing.T) {
 		require.Len(t, strings.Split(pathParts[len(pathParts)-1], "-"), 2)
 	})
 }
+
+func TestCreateTempDir(t *testing.T) {
+	t.Run("empty suffix, expects pattern like: /var/folders/abcd/abcdefg/A/1137975807/", func(t *testing.T) {
+		filePath, err := CreateTempFile("")
+		require.NoError(t, err)
+
+		pathParts := strings.Split(filePath, "/")
+		require.Greater(t, len(pathParts), 1)
+		require.Len(t, strings.Split(pathParts[len(pathParts)-1], "-"), 1)
+	})
+
+	t.Run("non-empty suffix, expects /var/folders/abcd/abcdefg/A/1137975807-foobar/", func(t *testing.T) {
+		filePath, err := CreateTempFile("foobar")
+		require.NoError(t, err)
+
+		pathParts := strings.Split(filePath, "/")
+		require.Greater(t, len(pathParts), 1)
+		require.Len(t, strings.Split(pathParts[len(pathParts)-1], "-"), 2)
+	})
+}

--- a/pkg/build/packaging/deb.go
+++ b/pkg/build/packaging/deb.go
@@ -122,7 +122,7 @@ func UpdateDebRepo(cfg PublishConfig, workDir string) error {
 		repoName = "beta"
 	}
 
-	repoRoot, err := fsutil.CreateTempFile("deb-repo")
+	repoRoot, err := fsutil.CreateTempDir("deb-repo")
 	if err != nil {
 		return err
 	}

--- a/pkg/build/packaging/rpm.go
+++ b/pkg/build/packaging/rpm.go
@@ -32,7 +32,7 @@ func UpdateRPMRepo(cfg PublishConfig, workDir string) error {
 		return err
 	}
 
-	repoRoot, err := fsutil.CreateTempFile("rpm-repo")
+	repoRoot, err := fsutil.CreateTempDir("rpm-repo")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

During `v9.2.1` release, we encountered an error where some files couldn't be copied from GCS.
This was due to the destination bucket being wrong, since `os.CreateTempFile`, _obviously_ creates a file and not a directory.
This PR fixes this bug by introducing `os.CreateTempDir`.
