### PR TITLE
Revert data links code for sorted vector case

### DIFF
--- a/packages/grafana-data/src/vector/SortedVector.ts
+++ b/packages/grafana-data/src/vector/SortedVector.ts
@@ -16,10 +16,6 @@ export class SortedVector<T = any> implements Vector<T> {
     return this.source.get(this.order[index]);
   }
 
-  getOrderIndex(index: number): number {
-    return this.order[index];
-  }
-
   toArray(): T[] {
     return vectorToArray(this);
   }

--- a/public/app/plugins/panel/timeseries/plugins/ContextMenuPlugin.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/ContextMenuPlugin.tsx
@@ -2,15 +2,7 @@ import { css as cssCore, Global } from '@emotion/react';
 import React, { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useClickAway } from 'react-use';
 
-import {
-  CartesianCoords2D,
-  DataFrame,
-  getFieldDisplayName,
-  InterpolateFunction,
-  SortedVector,
-  TimeZone,
-  ValueLinkConfig,
-} from '@grafana/data';
+import { CartesianCoords2D, DataFrame, getFieldDisplayName, InterpolateFunction, TimeZone } from '@grafana/data';
 import {
   ContextMenu,
   GraphContextMenuHeader,

--- a/public/app/plugins/panel/timeseries/plugins/ContextMenuPlugin.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/ContextMenuPlugin.tsx
@@ -257,27 +257,23 @@ export const ContextMenuView: React.FC<ContextMenuViewProps> = ({
 
       const hasLinks = field.config.links && field.config.links.length > 0;
 
-      const valueLinkConfig: ValueLinkConfig = {};
-
-      if (field.values instanceof SortedVector) {
-        valueLinkConfig.valueRowIndex = field.values.getOrderIndex(dataIdx);
-      } else {
-        valueLinkConfig.valueRowIndex = dataIdx;
-      }
-
       if (hasLinks) {
         if (field.getLinks) {
           items.push({
-            items: field.getLinks(valueLinkConfig).map<MenuItemProps>((link) => {
-              return {
-                label: link.title,
-                ariaLabel: link.title,
-                url: link.href,
-                target: link.target,
-                icon: link.target === '_self' ? 'link' : 'external-link-alt',
-                onClick: link.onClick,
-              };
-            }),
+            items: field
+              .getLinks({
+                valueRowIndex: dataIdx,
+              })
+              .map<MenuItemProps>((link) => {
+                return {
+                  label: link.title,
+                  ariaLabel: link.title,
+                  url: link.href,
+                  target: link.target,
+                  icon: link.target === '_self' ? 'link' : 'external-link-alt',
+                  onClick: link.onClick,
+                };
+              }),
           });
         }
       }


### PR DESCRIPTION
Revert redundant code that fixes data links showing correct values on variables. It's already fixed by calling `getLinksSupplier` on the timeseries aligned dataframe in this [PR](https://github.com/grafana/grafana/pull/56729/files#diff-30abe700e102e32f2d74ff8c04f2788d0e62e053c95b70537301c2068fd811b4) 