### PR TITLE
CI: Replace json decoder with `io.ReadAll`

### DIFF
--- a/pkg/build/cmd/grafanacom.go
+++ b/pkg/build/cmd/grafanacom.go
@@ -275,10 +275,7 @@ func postRequest(cfg packaging.PublishConfig, pth string, obj interface{}, descr
 		}
 	}()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		var body []byte
-		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
-			return err
-		}
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

During `9.2.1` error, we got a `json: cannot unmarshal object into Go value of type []uint8` when got back the response from `grafana.com` API. That's due to some faulty byte decoding - we can use `io.ReadAll` instead to fix the issue.

**Special notes for your reviewer**:

Tested locally and was able to do a `grafana.com` POST request.

