### PR TITLE
Loki: Remove already selected options from next label filter options in builder

### DIFF
--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilder.test.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilder.test.tsx
@@ -51,6 +51,23 @@ describe('LokiQueryBuilder', () => {
     await waitFor(() => expect(screen.getByText('job')).toBeInTheDocument());
   });
 
+  it('does not show already existing label names as option in label filter', async () => {
+    const props = createDefaultProps();
+    props.datasource.getDataSamples = jest.fn().mockResolvedValue([]);
+    props.datasource.languageProvider.fetchSeriesLabels = jest
+      .fn()
+      .mockReturnValue({ job: ['a'], instance: ['b'], baz: ['bar'] });
+
+    render(<LokiQueryBuilder {...props} query={defaultQuery} />);
+    await userEvent.click(screen.getByLabelText('Add'));
+    const labels = screen.getByText(/Label filters/);
+    const selects = getAllByRole(labels.parentElement!.parentElement!.parentElement!, 'combobox');
+    await userEvent.click(selects[3]);
+    await waitFor(() => expect(screen.getByText('job')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText('instance')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getAllByText('baz')).toHaveLength(1));
+  });
+
   it('shows error for query with operations and no stream selector', async () => {
     const query = { labels: [], operations: [{ id: LokiOperationId.Logfmt, params: [] }] };
     render(<LokiQueryBuilder {...createDefaultProps()} query={query} />);

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilder.test.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilder.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, getAllByRole, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
+import { getSelectParent } from 'test/helpers/selectOptionInTest';
 
 import { DataSourceInstanceSettings, DataSourcePluginMeta } from '@grafana/data';
 
@@ -46,7 +47,7 @@ describe('LokiQueryBuilder', () => {
     render(<LokiQueryBuilder {...props} query={defaultQuery} />);
     await userEvent.click(screen.getByLabelText('Add'));
     const labels = screen.getByText(/Label filters/);
-    const selects = getAllByRole(labels.parentElement!.parentElement!.parentElement!, 'combobox');
+    const selects = getAllByRole(getSelectParent(labels)!, 'combobox');
     await userEvent.click(selects[3]);
     await waitFor(() => expect(screen.getByText('job')).toBeInTheDocument());
   });
@@ -61,7 +62,7 @@ describe('LokiQueryBuilder', () => {
     render(<LokiQueryBuilder {...props} query={defaultQuery} />);
     await userEvent.click(screen.getByLabelText('Add'));
     const labels = screen.getByText(/Label filters/);
-    const selects = getAllByRole(labels.parentElement!.parentElement!.parentElement!, 'combobox');
+    const selects = getAllByRole(getSelectParent(labels)!, 'combobox');
     await userEvent.click(selects[3]);
     await waitFor(() => expect(screen.getByText('job')).toBeInTheDocument());
     await waitFor(() => expect(screen.getByText('instance')).toBeInTheDocument());

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilder.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilder.tsx
@@ -54,7 +54,14 @@ export const LokiQueryBuilder = React.memo<Props>(({ datasource, query, onChange
 
     const expr = lokiQueryModeller.renderLabels(labelsToConsider);
     const series = await datasource.languageProvider.fetchSeriesLabels(expr);
-    return Object.keys(series).sort();
+    const labelsNamesToConsider = labelsToConsider.map((l) => l.label);
+
+    const labelNames = Object.keys(series)
+      // Filter out label names that are already selected
+      .filter((name) => !labelsNamesToConsider.includes(name))
+      .sort();
+
+    return labelNames;
   };
 
   const onGetLabelValues = async (forLabel: Partial<QueryBuilderLabelFilter>) => {


### PR DESCRIPTION
**What this PR does / why we need it**:

In the same way, as in code mode in autocomplete we don't offer already selected label names, we are fixing query builder to not show already selected label names.

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/57161

**Special notes for your reviewer**:

To test this
1. run loki data source make `devenv sources=loki`
2. Use Loki query builder
3. Select label filter
4. Click on add label filter button
5. You should not be offered the already selected label name

