### PR TITLE
Grafana UI: Make `Collapse` accessible

### DIFF
--- a/packages/grafana-ui/src/components/Collapse/Collapse.tsx
+++ b/packages/grafana-ui/src/components/Collapse/Collapse.tsx
@@ -82,11 +82,11 @@ const getStyles = (theme: GrafanaTheme2) => ({
   headerLabel: css`
     label: collapse__header-label;
     font-weight: ${theme.typography.fontWeightMedium};
+    margin-right: ${theme.spacing(1)};
     font-size: ${theme.typography.size.md};
   `,
   icon: css`
     label: collapse__icon;
-    color: ${theme.colors.text.maxContrast};
     margin: ${theme.spacing(0.25, 1, 0, -1)};
   `,
 });

--- a/packages/grafana-ui/src/components/Collapse/Collapse.tsx
+++ b/packages/grafana-ui/src/components/Collapse/Collapse.tsx
@@ -4,7 +4,7 @@ import React, { FunctionComponent, useState } from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
 
 import { useStyles2 } from '../../themes/ThemeContext';
-import { Icon } from '../Icon/Icon';
+import { IconButton } from '../IconButton/IconButton';
 
 const getStyles = (theme: GrafanaTheme2) => ({
   collapse: css`
@@ -82,11 +82,11 @@ const getStyles = (theme: GrafanaTheme2) => ({
   headerLabel: css`
     label: collapse__header-label;
     font-weight: ${theme.typography.fontWeightMedium};
-    margin-right: ${theme.spacing(1)};
     font-size: ${theme.typography.size.md};
   `,
   icon: css`
     label: collapse__icon;
+    color: ${theme.colors.text.maxContrast};
     margin: ${theme.spacing(0.25, 1, 0, -1)};
   `,
 });
@@ -142,15 +142,25 @@ export const Collapse = ({
   const panelClass = cx([style.collapse, className]);
   const loaderClass = loading ? cx([style.loader, style.loaderActive]) : cx([style.loader]);
   const headerClass = collapsible ? cx([style.header]) : cx([style.headerCollapsed]);
+  const idContent = label?.toString();
 
   return (
     <div className={panelClass}>
       <div className={headerClass} onClick={onClickToggle}>
-        {collapsible && <Icon className={style.icon} name={isOpen ? 'angle-down' : 'angle-right'} />}
-        <div className={cx([style.headerLabel])}>{label}</div>
+        {collapsible && (
+          <IconButton
+            aria-expanded={isOpen}
+            aria-controls={idContent}
+            className={cx([style.icon])}
+            name={isOpen ? 'angle-down' : 'angle-right'}
+          />
+        )}
+        <div className={cx([style.headerLabel])} id={`header-${idContent}`}>
+          {label}
+        </div>
       </div>
       {isOpen && (
-        <div className={cx([style.collapseBody])}>
+        <div id={idContent} aria-labelledby={`header-${idContent}`} className={cx([style.collapseBody])}>
           <div className={loaderClass} />
           <div className={style.bodyContentWrapper}>{children}</div>
         </div>


### PR DESCRIPTION
### What this PR does / why we need it

Currently, the `Collapse` component is not keyboard accessible. The section cannot be focused or collapsed/Extended without a mouse.

This PR turns the `Icon` into an `IconButton` and adds some aria props to specify controls / state / labelled-by...

#### Screenshots

| Area | Before | After |
| ----- | ------- | ----- |
| Azure resource picker | ![Before](https://user-images.githubusercontent.com/42030685/196458377-9637ae41-f864-4d3a-8eae-79dede264d37.png) | ![After](https://user-images.githubusercontent.com/42030685/196458418-e7e1d8f8-7b6c-422a-84f3-94f7227c690c.png) |
| Loki |  ![Screenshot 2022-10-18 at 16 29 01](https://user-images.githubusercontent.com/42030685/196459544-88264231-28bd-48ff-9f7a-1994e0487a53.png) | ![Screenshot 2022-10-18 at 16 28 47](https://user-images.githubusercontent.com/42030685/196459564-fc31b24c-07fd-45af-ab78-b5ff1facd1aa.png) |




### Which issue(s) this PR fixes

Fixes #56558 

### Special notes for your reviewer
This fix was the less intrusive I could find as there are quite a few pages that use the component. But maybe having both the icon and the header focusable would be a better UX?
