### PR TITLE
PublicDashboards: Don't filter datasources from FrontendSettings in a public dashboard

### DIFF
--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -215,21 +215,23 @@ func (hs *HTTPServer) getFrontendSettingsMap(c *models.ReqContext) (map[string]i
 
 func (hs *HTTPServer) getFSDataSources(c *models.ReqContext, enabledPlugins EnabledPlugins) (map[string]plugins.DataSourceDTO, error) {
 	orgDataSources := make([]*datasources.DataSource, 0)
-
 	if c.OrgID != 0 {
 		query := datasources.GetDataSourcesQuery{OrgId: c.OrgID, DataSourceLimit: hs.Cfg.DataSourceLimit}
 		err := hs.DataSourcesService.GetDataSources(c.Req.Context(), &query)
-
 		if err != nil {
 			return nil, err
 		}
 
-		filtered, err := hs.filterDatasourcesByQueryPermission(c.Req.Context(), c.SignedInUser, query.Result)
-		if err != nil {
-			return nil, err
+		if c.IsPublicDashboardView {
+			// If RBAC is enabled, it will filter out all datasources for the anonymous user, so we need to skip it
+			orgDataSources = query.Result
+		} else {
+			filtered, err := hs.filterDatasourcesByQueryPermission(c.Req.Context(), c.SignedInUser, query.Result)
+			if err != nil {
+				return nil, err
+			}
+			orgDataSources = filtered
 		}
-
-		orgDataSources = filtered
 	}
 
 	dataSources := make(map[string]plugins.DataSourceDTO)

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -223,7 +223,7 @@ func (hs *HTTPServer) getFSDataSources(c *models.ReqContext, enabledPlugins Enab
 		}
 
 		if c.IsPublicDashboardView {
-			// If RBAC is enabled, it will filter out all datasources for the anonymous user, so we need to skip it
+			// If RBAC is enabled, it will filter out all datasources for a public user, so we need to skip it
 			orgDataSources = query.Result
 		} else {
 			filtered, err := hs.filterDatasourcesByQueryPermission(c.Req.Context(), c.SignedInUser, query.Result)


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a bug with public dashboards caused by RBAC being enabled. The OSS behavior is to not filter anything, but the Enterprise behavior requires the datasources read and query permissions, which shouldn't be assigned to an anonymous user.
