### PR TITLE
RefreshPicker: Fix issue clearing auto refresh

### DIFF
--- a/packages/grafana-ui/src/components/RefreshPicker/RefreshPicker.tsx
+++ b/packages/grafana-ui/src/components/RefreshPicker/RefreshPicker.tsx
@@ -50,7 +50,7 @@ export class RefreshPicker extends PureComponent<Props> {
 
   onChangeSelect = (item: SelectableValue<string>) => {
     const { onIntervalChanged } = this.props;
-    if (onIntervalChanged && item.value) {
+    if (onIntervalChanged && item.value != null) {
       onIntervalChanged(item.value);
     }
   };


### PR DESCRIPTION
Fixes issue where clearing auto refresh is not working.

Caused by https://github.com/grafana/grafana/pull/56544
