### PR TITLE
Panel Menu: Use config explore enabled as an override to access control 

### DIFF
--- a/public/app/core/services/context_srv.ts
+++ b/public/app/core/services/context_srv.ts
@@ -157,7 +157,7 @@ export class ContextSrv {
 
   hasAccessToExplore() {
     if (this.accessControlEnabled()) {
-      return this.hasPermission(AccessControlAction.DataSourcesExplore);
+      return this.hasPermission(AccessControlAction.DataSourcesExplore) && config.exploreEnabled;
     }
     return (this.isEditor || config.viewersCanEdit) && config.exploreEnabled;
   }

--- a/public/app/core/services/context_srv.ts
+++ b/public/app/core/services/context_srv.ts
@@ -159,7 +159,7 @@ export class ContextSrv {
     if (this.accessControlEnabled()) {
       return this.hasPermission(AccessControlAction.DataSourcesExplore) && config.exploreEnabled;
     }
-    return (this.isEditor || config.viewersCanEdit) && !(config.exploreEnabled === false);
+    return (this.isEditor || config.viewersCanEdit) && config.exploreEnabled;
   }
 
   hasAccess(action: string, fallBack: boolean): boolean {

--- a/public/app/core/services/context_srv.ts
+++ b/public/app/core/services/context_srv.ts
@@ -159,7 +159,7 @@ export class ContextSrv {
     if (this.accessControlEnabled()) {
       return this.hasPermission(AccessControlAction.DataSourcesExplore) && config.exploreEnabled;
     }
-    return (this.isEditor || config.viewersCanEdit) && config.exploreEnabled;
+    return (this.isEditor || config.viewersCanEdit) && !(config.exploreEnabled === false);
   }
 
   hasAccess(action: string, fallBack: boolean): boolean {


### PR DESCRIPTION
**What this PR does / why we need it**:
I'm not actually sure this should be correct. But generally if someone has explicitly turned off explore in their config, they will probably intend for that setting to override access control. That said, this might be a discussion where a decision was already made.

If the existing logic is working as designed, please clarify that in the issue ticket. Thank you! 

**Which issue(s) this PR fixes**:
Fixes #56989

**Special notes for your reviewer**:

