### PR TITLE
Opentsdb: Allow template variables for filter keys

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -6568,13 +6568,11 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "50"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "51"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "52"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "53"],
+      [0, 0, 0, "Do not use any type assertions.", "53"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "54"],
-      [0, 0, 0, "Do not use any type assertions.", "55"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "55"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "56"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "57"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "58"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "59"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "57"]
     ],
     "public/app/plugins/datasource/opentsdb/migrations.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]

--- a/public/app/plugins/datasource/opentsdb/components/FilterSection.tsx
+++ b/public/app/plugins/datasource/opentsdb/components/FilterSection.tsx
@@ -146,6 +146,8 @@ export function FilterSection({
               className="gf-form-input"
               value={curFilterKey ? toOption(curFilterKey) : undefined}
               placeholder="key"
+              allowCustomValue
+              filterOption={customFilterOption}
               onOpenMenu={async () => {
                 updKeyIsLoading(true);
                 const tKs = await suggestTagKeys(query);

--- a/public/app/plugins/datasource/opentsdb/datasource.ts
+++ b/public/app/plugins/datasource/opentsdb/datasource.ts
@@ -541,13 +541,7 @@ export default class OpenTsDatasource extends DataSourceApi<OpenTsdbQuery, OpenT
       query.filters = cloneDeep(target.filters);
 
       if (query.filters) {
-        for (const filterKey in query.filters) {
-          query.filters[filterKey].filter = this.templateSrv.replace(
-            query.filters[filterKey].filter,
-            options.scopedVars,
-            'pipe'
-          );
-        }
+        this.interpolateVariablesInFilters(query, options);
       }
     } else {
       query.tags = cloneDeep(target.tags);
@@ -564,6 +558,23 @@ export default class OpenTsDatasource extends DataSourceApi<OpenTsdbQuery, OpenT
     }
 
     return query;
+  }
+
+  // eslint-disable-next-line  @typescript-eslint/no-explicit-any
+  interpolateVariablesInFilters(query: any, options: any) {
+    for (const filterKey in query.filters) {
+      query.filters[filterKey].tagk = this.templateSrv.replace(
+        query.filters[filterKey].tagk,
+        options.scopedVars,
+        'pipe'
+      );
+
+      query.filters[filterKey].filter = this.templateSrv.replace(
+        query.filters[filterKey].filter,
+        options.scopedVars,
+        'pipe'
+      );
+    }
   }
 
   mapMetricsToTargets(metrics: any, options: any, tsdbVersion: number) {

--- a/public/app/plugins/datasource/opentsdb/specs/datasource.test.ts
+++ b/public/app/plugins/datasource/opentsdb/specs/datasource.test.ts
@@ -126,18 +126,55 @@ describe('opentsdb', () => {
       expect(ds.interpolateVariablesInQueries([], {})).toHaveLength(0);
     });
 
-    it('should replace correct variables', () => {
+    it('should replace metric variable', () => {
       const { ds, templateSrv } = getTestcontext();
-      const variableName = 'someVar';
       const logQuery: OpenTsdbQuery = {
         refId: 'someRefId',
-        metric: `$${variableName}`,
+        metric: '$someVar',
+        filters: [
+          {
+            type: 'type',
+            tagk: 'someTagk',
+            filter: 'someTagv',
+            groupBy: true,
+          },
+        ],
       };
 
       ds.interpolateVariablesInQueries([logQuery], {});
 
       expect(templateSrv.replace).toHaveBeenCalledWith('$someVar', {});
       expect(templateSrv.replace).toHaveBeenCalledTimes(1);
+    });
+
+    it('should replace filter tag key and value', () => {
+      const { ds, templateSrv } = getTestcontext();
+      let logQuery: OpenTsdbQuery = {
+        refId: 'A',
+        datasource: {
+          type: 'opentsdb',
+          uid: 'P311D5F9D9B165031',
+        },
+        aggregator: 'sum',
+        downsampleAggregator: 'avg',
+        downsampleFillPolicy: 'none',
+        metric: 'logins.count',
+        filters: [
+          {
+            type: 'iliteral_or',
+            tagk: '$someTagk',
+            filter: '$someTagv',
+            groupBy: false,
+          },
+        ],
+      };
+
+      ds.interpolateVariablesInFilters(logQuery, {});
+
+      expect(templateSrv.replace).toHaveBeenCalledWith('$someTagk', undefined, 'pipe');
+      expect(templateSrv.replace).toHaveBeenCalledWith('$someTagv', undefined, 'pipe');
+
+      expect(templateSrv.replace).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/public/app/plugins/datasource/opentsdb/specs/datasource.test.ts
+++ b/public/app/plugins/datasource/opentsdb/specs/datasource.test.ts
@@ -1,5 +1,6 @@
 import { of } from 'rxjs';
 
+import { DataQueryRequest, dateTime } from '@grafana/data';
 import { backendSrv } from 'app/core/services/backend_srv'; // will use the version in __mocks__
 
 import { createFetchResponse } from '../../../../../test/helpers/createFetchResponse';
@@ -169,10 +170,50 @@ describe('opentsdb', () => {
         ],
       };
 
-      ds.interpolateVariablesInFilters(logQuery, {});
+      const scopedVars = {
+        __interval: {
+          text: '20s',
+          value: '20s',
+        },
+        __interval_ms: {
+          text: '20000',
+          value: 20000,
+        },
+      };
 
-      expect(templateSrv.replace).toHaveBeenCalledWith('$someTagk', undefined, 'pipe');
-      expect(templateSrv.replace).toHaveBeenCalledWith('$someTagv', undefined, 'pipe');
+      const dataQR: DataQueryRequest<OpenTsdbQuery> = {
+        app: 'dashboard',
+        requestId: 'Q103',
+        timezone: 'browser',
+        panelId: 2,
+        dashboardId: 189,
+        dashboardUID: 'tyzmfPIVz',
+        publicDashboardAccessToken: '',
+        range: {
+          from: dateTime('2022-10-19T08:55:18.430Z'),
+          to: dateTime('2022-10-19T14:55:18.431Z'),
+          raw: {
+            from: 'now-6h',
+            to: 'now',
+          },
+        },
+        timeInfo: '',
+        interval: '20s',
+        intervalMs: 20000,
+        targets: [logQuery],
+        maxDataPoints: 909,
+        scopedVars: scopedVars,
+        startTime: 1666191318431,
+        rangeRaw: {
+          from: 'now-6h',
+          to: 'now',
+        },
+      };
+
+      ds.interpolateVariablesInFilters(logQuery, dataQR);
+
+      expect(templateSrv.replace).toHaveBeenCalledWith('$someTagk', scopedVars, 'pipe');
+      expect(templateSrv.replace).toHaveBeenCalledWith('$someTagv', scopedVars, 'pipe');
 
       expect(templateSrv.replace).toHaveBeenCalledTimes(2);
     });


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/56060

This allows customers to add template variables to the filter keys in OpenTSDB.

<img width="676" alt="Screen Shot 2022-10-18 at 4 18 35 PM" src="https://user-images.githubusercontent.com/25674746/196547365-23390f2f-b24b-472a-ab48-fbc1ee63ad08.png">

To test this, add a template variable with the OpenTSDB datasource > 2.3 and use `suggest_tagk()` as the query.
<img width="405" alt="Screen Shot 2022-10-18 at 4 25 50 PM" src="https://user-images.githubusercontent.com/25674746/196548132-07746364-bc25-46fc-9088-214d8ad86238.png">

Then interpolate the variable in the tag key section by typing $<variable_name>
