### PR TITLE
SQLX: Expose sqlxdb query functions

### DIFF
--- a/pkg/services/sqlstore/session/session.go
+++ b/pkg/services/sqlstore/session/session.go
@@ -30,6 +30,10 @@ func (gs *SessionDB) Select(ctx context.Context, dest interface{}, query string,
 	return gs.sqlxdb.SelectContext(ctx, dest, gs.sqlxdb.Rebind(query), args...)
 }
 
+func (gs *SessionDB) Query(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error) {
+	return gs.sqlxdb.QueryContext(ctx, gs.sqlxdb.Rebind(query), args...)
+}
+
 func (gs *SessionDB) Exec(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
 	return gs.sqlxdb.ExecContext(ctx, gs.sqlxdb.Rebind(query), args...)
 }
@@ -78,6 +82,10 @@ func (gtx *SessionTx) NamedExec(ctx context.Context, query string, arg interface
 
 func (gtx *SessionTx) Exec(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
 	return gtx.sqlxtx.ExecContext(ctx, gtx.sqlxtx.Rebind(query), args...)
+}
+
+func (gtx *SessionTx) Query(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error) {
+	return gtx.sqlxtx.QueryContext(ctx, gtx.sqlxtx.Rebind(query), args...)
 }
 
 func (gtx *SessionTx) Get(ctx context.Context, dest interface{}, query string, args ...interface{}) error {

--- a/pkg/services/sqlstore/session_test.go
+++ b/pkg/services/sqlstore/session_test.go
@@ -64,7 +64,7 @@ func TestRetryingOnFailures(t *testing.T) {
 	sess := store.GetSqlxSession()
 	rows, err := sess.Query(context.Background(), `SELECT "hello",2.3,4`)
 	require.NoError(t, err)
-	require.True(t, rows.Next()) // single row
+	require.True(t, rows.Next()) // first row
 
 	str1 := ""
 	val2 := float64(100.1)
@@ -74,4 +74,5 @@ func TestRetryingOnFailures(t *testing.T) {
 	require.Equal(t, "hello", str1)
 	require.Equal(t, 2.3, val2)
 	require.Equal(t, int64(4), val3)
+	require.False(t, rows.Next()) // no more rows
 }

--- a/pkg/services/sqlstore/session_test.go
+++ b/pkg/services/sqlstore/session_test.go
@@ -59,4 +59,19 @@ func TestRetryingOnFailures(t *testing.T) {
 			require.Equal(t, i, store.dbCfg.QueryRetries+1)
 		})
 	}
+
+	// Check SQL query
+	sess := store.GetSqlxSession()
+	rows, err := sess.Query(context.Background(), `SELECT "hello",2.3,4`)
+	require.NoError(t, err)
+	require.True(t, rows.Next()) // single row
+
+	str1 := ""
+	val2 := float64(100.1)
+	val3 := int64(200)
+	err = rows.Scan(&str1, &val2, &val3)
+	require.NoError(t, err)
+	require.Equal(t, "hello", str1)
+	require.Equal(t, 2.3, val2)
+	require.Equal(t, int64(4), val3)
 }


### PR DESCRIPTION
In https://github.com/grafana/grafana/pull/56348, I am exploring how to implement storage with the least magical SQL binding possible.  `*sql.Rows#Scan(...)` seems pretty simple -- and lets you explicitly fill up values that may be mixed in multiple structs 🎉   If there is a better approach, please let me know!

This PR adds the query flavors and a very simple test.  I don't see any other tests that use `GetSqlxSession` so again, please let me know if I am missing something.

