### PR TITLE
Docs: Fix reference to Enterprise licensing restrictions

### DIFF
--- a/docs/sources/administration/enterprise-licensing/_index.md
+++ b/docs/sources/administration/enterprise-licensing/_index.md
@@ -8,6 +8,7 @@ aliases:
   - /docs/grafana/latest/enterprise/license-restrictions/
   - /docs/grafana/latest/enterprise/license/license-restrictions/
   - /docs/grafana/latest/administration/enterprise-licensing/
+  - /docs/grafana/latest/administration/enterprise-licensing/license-restrictions/
 description: Activate and manage a Grafana Enterprise license
 keywords:
   - grafana

--- a/docs/sources/administration/enterprise-licensing/activate-aws-marketplace-license/activate-license-on-ecs/index.md
+++ b/docs/sources/administration/enterprise-licensing/activate-aws-marketplace-license/activate-license-on-ecs/index.md
@@ -111,4 +111,4 @@ In this task you configure Grafana Enterprise to validate the license with AWS i
 1. To restart Grafana and activate your license, update the service running Grafana to use the latest revision of the task definition that you created.
 1. After you update the service, navigate to your Grafana instance, sign in with Grafana Admin credentials, and navigate to the **Statistics and Licensing** page to validate that your license is active.
 
-For more information about validating that your license is active, refer to [Determine the number of active users for each licensed role](../../license-restrictions/#determine-the-number-of-active-users-for-each-licensed-role).
+For more information about validating that your license is active, refer to [Grafana Enterprise license restrictions]({{< relref "../../#grafana-enterprise-license-restrictions" >}}).


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix a 404ing link to Enterprise licensing restrictions in the AWS ECS licensing docs.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

Also adds an alias to /administration/enterprise-licensing/ to redirect similar requests if they exist.