### PR TITLE
Prometheus: Migrate query_result() queries to use resource calls

### DIFF
--- a/public/app/plugins/datasource/prometheus/datasource.test.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.test.ts
@@ -751,6 +751,7 @@ const time = ({ hours = 0, seconds = 0, minutes = 0 }) => dateTime(hours * HOUR 
 describe('PrometheusDatasource2', () => {
   const instanceSettings = {
     url: 'proxied',
+    id: 1,
     directUrl: 'direct',
     user: 'test',
     password: 'mupp',
@@ -913,7 +914,9 @@ describe('PrometheusDatasource2', () => {
 
   describe('When querying prometheus with one target and instant = true', () => {
     let results: any;
-    const urlExpected = `proxied/api/v1/query?query=${encodeURIComponent('test{job="testjob"}')}&time=123`;
+    const urlExpected = `/api/datasources/1/resources/api/v1/query?query=${encodeURIComponent(
+      'test{job="testjob"}'
+    )}&time=123`;
     const query = {
       range: { from: time({ seconds: 63 }), to: time({ seconds: 123 }) },
       targets: [{ expr: 'test{job="testjob"}', format: 'time_series', instant: true }],

--- a/public/app/plugins/datasource/prometheus/datasource.tsx
+++ b/public/app/plugins/datasource/prometheus/datasource.tsx
@@ -642,10 +642,14 @@ export class PrometheusDatasource
       data['timeout'] = this.queryTimeout;
     }
 
-    return this._request<PromDataSuccessResponse<PromVectorData | PromScalarData>>(url, data, {
-      requestId: query.requestId,
-      headers: query.headers,
-    }).pipe(
+    return this._request<PromDataSuccessResponse<PromVectorData | PromScalarData>>(
+      `/api/datasources/${this.id}/resources${url}`,
+      data,
+      {
+        requestId: query.requestId,
+        headers: query.headers,
+      }
+    ).pipe(
       catchError((err: FetchError<PromDataErrorResponse<PromVectorData | PromScalarData>>) => {
         if (err.cancelled) {
           return of(err);

--- a/public/app/plugins/datasource/prometheus/metric_find_query.test.ts
+++ b/public/app/plugins/datasource/prometheus/metric_find_query.test.ts
@@ -221,7 +221,7 @@ describe('PrometheusMetricFindQuery', () => {
       expect(fetchMock).toHaveBeenCalledTimes(1);
       expect(fetchMock).toHaveBeenCalledWith({
         method: 'GET',
-        url: `proxied/api/v1/query?query=metric&time=${raw.to.unix()}`,
+        url: `/api/datasources/1/resources/api/v1/query?query=metric&time=${raw.to.unix()}`,
         requestId: undefined,
         headers: {},
       });
@@ -243,7 +243,7 @@ describe('PrometheusMetricFindQuery', () => {
       expect(fetchMock).toHaveBeenCalledTimes(1);
       expect(fetchMock).toHaveBeenCalledWith({
         method: 'GET',
-        url: `proxied/api/v1/query?query=1%2B1&time=${raw.to.unix()}`,
+        url: `/api/datasources/1/resources/api/v1/query?query=1%2B1&time=${raw.to.unix()}`,
         requestId: undefined,
         headers: {},
       });


### PR DESCRIPTION
**What this PR does / why we need it**:

Earlier, as part of effort to migrate Prometheus datasource from plugin proxy to own backend (#37784), templating queries were migrated (#48790) from plugin proxy to resource calls but `query_result` wasn't migrated and continues to use plugin proxy endpoint. This makes it broken for Azure authentication.

This PR closes the gap and migrates `query_result` to resource calls as rest of the templating queries.

**Which issue(s) this PR fixes**:

Fixes #57137
Related to #49921, #48790, #37784

**Special notes for your reviewer**:

This fix targets function [queryResultQuery](https://github.com/kostrse/grafana/blob/0de544f3a2bcfacb4d0577f31b394fb29648b90f/public/app/plugins/datasource/prometheus/metric_find_query.ts#L142) but the actual change was made in function `performInstantQuery` ([here](https://github.com/kostrse/grafana/blob/ea2a6106cfc248a8a4def7f794a6fe5f6d263d28/public/app/plugins/datasource/prometheus/datasource.tsx#L646)) which besides the `queryResultQuery` also being used by `runQuery` ([here](https://github.com/kostrse/grafana/blob/ea2a6106cfc248a8a4def7f794a6fe5f6d263d28/public/app/plugins/datasource/prometheus/datasource.tsx#L497)) from `exploreQuery` ([here](https://github.com/kostrse/grafana/blob/ea2a6106cfc248a8a4def7f794a6fe5f6d263d28/public/app/plugins/datasource/prometheus/datasource.tsx#L448)) and `panelsQuery` ([here](https://github.com/kostrse/grafana/blob/ea2a6106cfc248a8a4def7f794a6fe5f6d263d28/public/app/plugins/datasource/prometheus/datasource.tsx#L478)) but those are dead code and never called from [query](https://github.com/kostrse/grafana/blob/ea2a6106cfc248a8a4def7f794a6fe5f6d263d28/public/app/plugins/datasource/prometheus/datasource.tsx#L415) function since `instasnceSettings.access` is always `proxy` and `direct` access mode [isn't allowed](https://github.com/kostrse/grafana/blob/ea2a6106cfc248a8a4def7f794a6fe5f6d263d28/public/app/plugins/datasource/prometheus/datasource.tsx#L164).

