### PR TITLE
Docs: Add missing alias for field options

### DIFF
--- a/docs/sources/panels-visualizations/configure-standard-options/index.md
+++ b/docs/sources/panels-visualizations/configure-standard-options/index.md
@@ -1,5 +1,7 @@
 ---
 aliases:
+  - /docs/grafana/latest/panels/field-options/
+  - /docs/grafana/latest/panels/field-options/standard-field-options/
   - /docs/grafana/latest/panels/working-with-panels/format-standard-fields/
   - /docs/grafana/latest/panels/reference-standard-field-definitions/
   - /docs/grafana/latest/panels/standard-field-definitions/


### PR DESCRIPTION
**What this PR does / why we need it**:

Add a missing alias for the Grafana docs content on standard field options, which were originally at .../panels/field-options/ and .../panels/field-options/standard-field-options/, but are now located at .../panels-visualizations/configure-standard-options/.

**Which issue(s) this PR fixes**:

Mitigate broken links from plugins that still point to old docs URLs, such as the Wavefront data source.