### PR TITLE
Docs: Fix broken InfluxDB starting guide links

### DIFF
--- a/docs/sources/getting-started/get-started-grafana-influxdb.md
+++ b/docs/sources/getting-started/get-started-grafana-influxdb.md
@@ -75,8 +75,8 @@ Grafana displays a list of possible series. Click one to select it, and Grafana 
 
 Create a simple Flux query.
 
-1. [Add a panel](../panels/add-a-panel.md).
-1. In the query editor, select your InfluxDB-Flux data source. For more information, refer to [Queries](../panels/queries.md).
+1. [Add a panel]({{< relref "../dashboards/build-dashboards/create-dashboard/" >}}).
+1. In the query editor, select your InfluxDB-Flux data source. For more information, refer to [Queries]({{< relref "../panels-visualizations/query-transform-data/" >}}).
 1. Select the **Table** visualization.
 1. In the query editor text field, enter `buckets()` and then click outside of the query editor.
 

--- a/docs/sources/getting-started/get-started-grafana-influxdb.md
+++ b/docs/sources/getting-started/get-started-grafana-influxdb.md
@@ -96,7 +96,7 @@ You can also create Flux queries in the InfluxDB Explore view.
 
    ![InfluxDB Explore Script Editor](/static/img/docs/influxdb/explore-query-text-7-5.png)
 
-1. In Grafana, [add a panel](../panels/add-a-panel.md) and then paste your Flux code into the query editor.
+1. In Grafana, [add a panel]({{< relref "../dashboards/build-dashboards/create-dashboard/" >}}) and then paste your Flux code into the query editor.
 1. Click **Apply**. Your new panel should be visible with data from your Flux query.
 
 #### Check InfluxDB metrics in Grafana Explore


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix 404ing links in the Getting Started with Grafana and InfluxDB doc.

**Which issue(s) this PR fixes**:

N/A