### PR TITLE
Loki: Fix double stringified log-lines when copied via Copy button

### DIFF
--- a/public/app/features/logs/components/LogRowMessage.tsx
+++ b/public/app/features/logs/components/LogRowMessage.tsx
@@ -207,11 +207,7 @@ class UnThemedLogRowMessage extends PureComponent<Props> {
                 </Tooltip>
               )}
               <Tooltip placement="top" content={'Copy'}>
-                <IconButton
-                  size="md"
-                  name="copy"
-                  onClick={() => navigator.clipboard.writeText(JSON.stringify(restructuredEntry))}
-                />
+                <IconButton size="md" name="copy" onClick={() => navigator.clipboard.writeText(restructuredEntry)} />
               </Tooltip>
             </span>
           </td>


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a bug, where log-lines where stringified even though there are already strings.

**Which issue(s) this PR fixes**:

Fixes #57093


