### PR TITLE
Nav: Redirect to /login when user does not have permission to view page

### DIFF
--- a/packages/grafana-ui/src/utils/logger.ts
+++ b/packages/grafana-ui/src/utils/logger.ts
@@ -19,7 +19,7 @@ export interface Logger {
 
 /** @internal */
 export const createLogger = (name: string): Logger => {
-  let LOGGIN_ENABLED = false;
+  let LOGGIN_ENABLED = true;
   return {
     logger: (id: string, throttle = false, ...t: any[]) => {
       if (process.env.NODE_ENV === 'production' || process.env.NODE_ENV === 'test' || !LOGGIN_ENABLED) {

--- a/public/app/AppWrapper.tsx
+++ b/public/app/AppWrapper.tsx
@@ -68,7 +68,7 @@ export class AppWrapper extends React.Component<AppWrapperProps, AppWrapperState
           // TODO[Router]: test this logic
           if (roles?.length) {
             if (!roles.some((r: string) => contextSrv.hasRole(r))) {
-              return <Redirect to="/" />;
+              return <Redirect to="/login" />;
             }
           }
 

--- a/public/app/core/components/NavBar/NavBar.tsx
+++ b/public/app/core/components/NavBar/NavBar.tsx
@@ -55,7 +55,7 @@ export const NavBar = React.memo(() => {
     {
       id: 'home',
       text: 'Home',
-      url: config.bootData.user.isSignedIn ? config.appSubUrl || '/' : '/login',
+      url: config.appSubUrl || '/' ,
       icon: 'grafana',
     },
     menuOpen

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -53,6 +53,7 @@ export function getAppRoutes(): RouteDescriptor[] {
       path: '/',
       pageClass: 'page-dashboard',
       routeName: DashboardRoutes.Home,
+      roles: () => contextSrv.evaluatePermission(() => ['Viewer'], []),
       component: SafeDynamicImport(
         () => import(/* webpackChunkName: "DashboardPage" */ '../features/dashboard/containers/DashboardPage')
       ),


### PR DESCRIPTION
**What this PR does / why we need it**:

This is an attempt to fix #57048 to use the existing roles to redirect users to /login when they don't have permission to view a page. This also fixes an issue with snapshots where you can attempt to go to the homepage, but get a weird 'dashboard init failed' error.

We're unsure if using the existing roles mechanism is the right way to achieve this, but on first glance it seems like a good fit, rather than introducing an additional property on routes. 

 - Should we proceed with this approach? 
 - Should we add roles to _all_ routes?
 - What classic/fallback role should we be adding? What RBAC roles?
 - Are there any unintended side effects we should watch out for?

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #57048

**Special notes for your reviewer**:

@dprokop I see a _very_ long time ago you were doing things about this. Do you have thoughts on this?

@grafana/grafana-authnz-team Do you have thoughts on this?
