### PR TITLE
TimeSeries: Fix stacking when first value is negative zero

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/utils.test.ts
+++ b/packages/grafana-ui/src/components/uPlot/utils.test.ts
@@ -1061,6 +1061,11 @@ describe('auto stacking groups', () => {
           values: [0, 0, 0],
           config: { custom: { stacking: { mode: StackingMode.Normal } } },
         },
+        {
+          name: 'd',
+          values: [-0, -10, -20],
+          config: { custom: { stacking: { mode: StackingMode.Normal } } },
+        },
       ],
     });
 
@@ -1070,6 +1075,7 @@ describe('auto stacking groups', () => {
           "dir": -1,
           "series": Array [
             1,
+            4,
           ],
         },
         Object {

--- a/packages/grafana-ui/src/components/uPlot/utils.test.ts
+++ b/packages/grafana-ui/src/components/uPlot/utils.test.ts
@@ -1108,6 +1108,11 @@ describe('auto stacking groups', () => {
           values: [0, 0, 0],
           config: { custom: { stacking: { mode: StackingMode.Normal } } },
         },
+        {
+          name: 'd',
+          values: [-0, null, 3],
+          config: { custom: { stacking: { mode: StackingMode.Normal }, transform: GraphTransform.NegativeY } },
+        },
       ],
     });
 
@@ -1119,6 +1124,7 @@ describe('auto stacking groups', () => {
             1,
             2,
             3,
+            4,
           ],
         },
       ]

--- a/packages/grafana-ui/src/components/uPlot/utils.ts
+++ b/packages/grafana-ui/src/components/uPlot/utils.ts
@@ -117,18 +117,7 @@ export function getStackingGroups(frame: DataFrame) {
     let vals = values.toArray();
     let transform = custom.transform;
     let firstValue = vals.find((v) => v != null);
-    let stackDir =
-      transform === GraphTransform.Constant
-        ? firstValue >= 0
-          ? StackDirection.Pos
-          : StackDirection.Neg
-        : transform === GraphTransform.NegativeY
-        ? firstValue >= 0
-          ? StackDirection.Neg
-          : StackDirection.Pos
-        : firstValue >= 0
-        ? StackDirection.Pos
-        : StackDirection.Neg;
+    let stackDir = getStackDirection(transform, firstValue);
 
     let drawStyle = custom.drawStyle as GraphDrawStyle;
     let drawStyle2 =
@@ -350,6 +339,19 @@ export function findMidPointYPosition(u: uPlot, idx: number) {
   }
 
   return y;
+}
+
+function getStackDirection(transform: GraphTransform, firstValue: number) {
+  if (transform === GraphTransform.Constant) {
+    return firstValue >= 0 ? StackDirection.Pos : StackDirection.Neg;
+  }
+
+  if (transform === GraphTransform.NegativeY) {
+    return firstValue >= 0 ? StackDirection.Neg : StackDirection.Pos;
+  }
+
+  // Check if first value is negative zero. This can happen with a binary operation transform.
+  return !Object.is(firstValue, -0) && firstValue >= 0 ? StackDirection.Pos : StackDirection.Neg;
 }
 
 // Dev helpers

--- a/packages/grafana-ui/src/components/uPlot/utils.ts
+++ b/packages/grafana-ui/src/components/uPlot/utils.ts
@@ -342,16 +342,12 @@ export function findMidPointYPosition(u: uPlot, idx: number) {
 }
 
 function getStackDirection(transform: GraphTransform, firstValue: number) {
-  if (transform === GraphTransform.Constant) {
-    return firstValue >= 0 ? StackDirection.Pos : StackDirection.Neg;
-  }
-
-  if (transform === GraphTransform.NegativeY) {
-    return firstValue >= 0 ? StackDirection.Neg : StackDirection.Pos;
-  }
-
   // Check if first value is negative zero. This can happen with a binary operation transform.
-  return !Object.is(firstValue, -0) && firstValue >= 0 ? StackDirection.Pos : StackDirection.Neg;
+  const isNegativeZero = Object.is(firstValue, -0);
+  if (transform === GraphTransform.NegativeY) {
+    return !isNegativeZero && firstValue >= 0 ? StackDirection.Neg : StackDirection.Pos;
+  }
+  return !isNegativeZero && firstValue >= 0 ? StackDirection.Pos : StackDirection.Neg;
 }
 
 // Dev helpers


### PR DESCRIPTION
**What this PR does / why we need it**:

Use the dashboard from Leon's comment to reproduce the issue. https://github.com/grafana/grafana/issues/55348#issuecomment-1260359105

It turned out that the first value we checked was -0 and the comparison didn't work.

**Which issue(s) this PR fixes**:

Fixes #55348

