### PR TITLE
RBAC: Cleaup team api rbac tests

### DIFF
--- a/pkg/api/common_test.go
+++ b/pkg/api/common_test.go
@@ -410,7 +410,7 @@ func setupHTTPServerWithCfgDb(
 		Live:                   newTestLive(t, db),
 		QuotaService:           &quotaimpl.Service{Cfg: cfg},
 		RouteRegister:          routeRegister,
-		SQLStore:               store,
+		SQLStore:               db,
 		License:                &licensing.OSSLicensingService{},
 		AccessControl:          ac,
 		accesscontrolService:   acService,

--- a/pkg/api/common_test.go
+++ b/pkg/api/common_test.go
@@ -348,7 +348,7 @@ func setupSimpleHTTPServer(features *featuremgmt.FeatureManager) *HTTPServer {
 		Cfg:             cfg,
 		Features:        features,
 		License:         &licensing.OSSLicensingService{},
-		AccessControl:   accesscontrolmock.New().WithDisabled(),
+		AccessControl:   acimpl.ProvideAccessControl(cfg),
 		annotationsRepo: annotationstest.NewFakeAnnotationsRepo(),
 	}
 }
@@ -488,12 +488,14 @@ type APITestServerOption func(hs *HTTPServer)
 // option(s).
 func SetupAPITestServer(t *testing.T, opts ...APITestServerOption) *webtest.Server {
 	t.Helper()
+	cfg := setting.NewCfg()
+	cfg.RBACEnabled = false
 
 	hs := &HTTPServer{
 		RouteRegister:      routing.NewRouteRegister(),
-		Cfg:                setting.NewCfg(),
+		Cfg:                cfg,
 		License:            &licensing.OSSLicensingService{},
-		AccessControl:      accesscontrolmock.New().WithDisabled(),
+		AccessControl:      acimpl.ProvideAccessControl(cfg),
 		Features:           featuremgmt.WithFeatures(),
 		searchUsersService: &searchusers.OSSService{},
 	}

--- a/pkg/api/common_test.go
+++ b/pkg/api/common_test.go
@@ -46,6 +46,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/org/orgtest"
 	"github.com/grafana/grafana/pkg/services/preference/preftest"
 	"github.com/grafana/grafana/pkg/services/quota/quotaimpl"
+	"github.com/grafana/grafana/pkg/services/quota/quotatest"
 	"github.com/grafana/grafana/pkg/services/rendering"
 	"github.com/grafana/grafana/pkg/services/search"
 	"github.com/grafana/grafana/pkg/services/searchusers"
@@ -499,6 +500,7 @@ func SetupAPITestServer(t *testing.T, opts ...APITestServerOption) *webtest.Serv
 		RouteRegister:      routing.NewRouteRegister(),
 		License:            &licensing.OSSLicensingService{},
 		Features:           featuremgmt.WithFeatures(),
+		QuotaService:       quotatest.NewQuotaServiceFake(),
 		searchUsersService: &searchusers.OSSService{},
 	}
 

--- a/pkg/api/common_test.go
+++ b/pkg/api/common_test.go
@@ -492,8 +492,6 @@ type APITestServerOption func(hs *HTTPServer)
 // option(s).
 func SetupAPITestServer(t *testing.T, opts ...APITestServerOption) *webtest.Server {
 	t.Helper()
-	cfg := setting.NewCfg()
-	cfg.RBACEnabled = false
 
 	hs := &HTTPServer{
 		RouteRegister:      routing.NewRouteRegister(),

--- a/pkg/api/common_test.go
+++ b/pkg/api/common_test.go
@@ -493,15 +493,22 @@ func SetupAPITestServer(t *testing.T, opts ...APITestServerOption) *webtest.Serv
 
 	hs := &HTTPServer{
 		RouteRegister:      routing.NewRouteRegister(),
-		Cfg:                cfg,
 		License:            &licensing.OSSLicensingService{},
-		AccessControl:      acimpl.ProvideAccessControl(cfg),
 		Features:           featuremgmt.WithFeatures(),
 		searchUsersService: &searchusers.OSSService{},
 	}
 
 	for _, opt := range opts {
 		opt(hs)
+	}
+
+	if hs.Cfg == nil {
+		hs.Cfg = setting.NewCfg()
+		hs.Cfg.RBACEnabled = false
+	}
+
+	if hs.AccessControl == nil {
+		hs.AccessControl = acimpl.ProvideAccessControl(hs.Cfg)
 	}
 
 	hs.registerRoutes()

--- a/pkg/api/common_test.go
+++ b/pkg/api/common_test.go
@@ -372,7 +372,6 @@ func setupHTTPServerWithCfgDb(
 	store sqlstore.Store, features *featuremgmt.FeatureManager, options ...APITestServerOption,
 ) accessControlScenarioContext {
 	t.Helper()
-
 	license := &licensing.OSSLicensingService{}
 	routeRegister := routing.NewRouteRegister()
 	teamService := teamimpl.ProvideService(db, cfg)
@@ -415,7 +414,7 @@ func setupHTTPServerWithCfgDb(
 		Live:                   newTestLive(t, db),
 		QuotaService:           &quotaimpl.Service{Cfg: cfg},
 		RouteRegister:          routeRegister,
-		SQLStore:               db,
+		SQLStore:               store,
 		License:                &licensing.OSSLicensingService{},
 		AccessControl:          ac,
 		accesscontrolService:   acService,

--- a/pkg/api/common_test.go
+++ b/pkg/api/common_test.go
@@ -315,6 +315,10 @@ func setAccessControlPermissions(acmock *accesscontrolmock.Mock, perms []accessc
 		}
 }
 
+func userWithPermissions(orgID int64, permissions []accesscontrol.Permission) *user.SignedInUser {
+	return &user.SignedInUser{OrgID: orgID, Permissions: map[int64]map[string][]string{orgID: accesscontrol.GroupScopesByAction(permissions)}}
+}
+
 // setInitCtxSignedInUser sets a copy of the user in initCtx
 func setInitCtxSignedInUser(initCtx *models.ReqContext, user user.SignedInUser) {
 	initCtx.IsSignedIn = true

--- a/pkg/api/team_test.go
+++ b/pkg/api/team_test.go
@@ -175,6 +175,7 @@ func TestTeamAPIEndpoint_CreateTeam_LegacyAccessControl(t *testing.T) {
 		res, err := server.SendJSON(req)
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, res.StatusCode)
+		require.NoError(t, res.Body.Close())
 	})
 
 	input = strings.NewReader(fmt.Sprintf(teamCmd, 2))
@@ -184,6 +185,7 @@ func TestTeamAPIEndpoint_CreateTeam_LegacyAccessControl(t *testing.T) {
 		res, err := server.SendJSON(req)
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusForbidden, res.StatusCode)
+		require.NoError(t, res.Body.Close())
 	})
 }
 
@@ -203,6 +205,7 @@ func TestTeamAPIEndpoint_CreateTeam_LegacyAccessControl_EditorsCanAdmin(t *testi
 		res, err := server.SendJSON(req)
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, res.StatusCode)
+		require.NoError(t, res.Body.Close())
 	})
 }
 
@@ -219,6 +222,7 @@ func TestTeamAPIEndpoint_CreateTeam_RBAC(t *testing.T) {
 		res, err := server.SendJSON(req)
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, res.StatusCode)
+		require.NoError(t, res.Body.Close())
 	})
 
 	input = strings.NewReader(fmt.Sprintf(teamCmd, 2))
@@ -228,6 +232,7 @@ func TestTeamAPIEndpoint_CreateTeam_RBAC(t *testing.T) {
 		res, err := server.SendJSON(req)
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusForbidden, res.StatusCode)
+		require.NoError(t, res.Body.Close())
 	})
 }
 
@@ -243,6 +248,7 @@ func TestTeamAPIEndpoint_SearchTeams_RBAC(t *testing.T) {
 		res, err := server.Send(req)
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusForbidden, res.StatusCode)
+		require.NoError(t, res.Body.Close())
 	})
 
 	t.Run("Access control allows searching for teams with the correct permissions", func(t *testing.T) {
@@ -253,6 +259,7 @@ func TestTeamAPIEndpoint_SearchTeams_RBAC(t *testing.T) {
 		res, err := server.Send(req)
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, res.StatusCode)
+		require.NoError(t, res.Body.Close())
 	})
 }
 
@@ -270,6 +277,7 @@ func TestTeamAPIEndpoint_GetTeamByID_RBAC(t *testing.T) {
 		res, err := server.Send(req)
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusForbidden, res.StatusCode)
+		require.NoError(t, res.Body.Close())
 	})
 
 	t.Run("Access control allows getting a team with the correct permissions", func(t *testing.T) {
@@ -280,6 +288,7 @@ func TestTeamAPIEndpoint_GetTeamByID_RBAC(t *testing.T) {
 		res, err := server.Send(req)
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, res.StatusCode)
+		require.NoError(t, res.Body.Close())
 	})
 
 	t.Run("Access control allows getting a team with wildcard scope", func(t *testing.T) {
@@ -290,6 +299,7 @@ func TestTeamAPIEndpoint_GetTeamByID_RBAC(t *testing.T) {
 		res, err := server.Send(req)
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, res.StatusCode)
+		require.NoError(t, res.Body.Close())
 	})
 }
 
@@ -314,6 +324,7 @@ func TestTeamAPIEndpoint_UpdateTeam_RBAC(t *testing.T) {
 		}))
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, res.StatusCode)
+		require.NoError(t, res.Body.Close())
 	})
 
 	t.Run("Access control allows updating teams with the wildcard scope", func(t *testing.T) {
@@ -322,6 +333,7 @@ func TestTeamAPIEndpoint_UpdateTeam_RBAC(t *testing.T) {
 		}))
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, res.StatusCode)
+		require.NoError(t, res.Body.Close())
 	})
 
 	t.Run("Access control prevent updating a team with wrong scope", func(t *testing.T) {
@@ -330,6 +342,7 @@ func TestTeamAPIEndpoint_UpdateTeam_RBAC(t *testing.T) {
 		}))
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusForbidden, res.StatusCode)
+		require.NoError(t, res.Body.Close())
 	})
 }
 
@@ -345,7 +358,7 @@ func TestTeamAPIEndpoint_DeleteTeam_RBAC(t *testing.T) {
 	request := func(teamID int64, user *user.SignedInUser) (*http.Response, error) {
 		req := server.NewRequest(http.MethodDelete, fmt.Sprintf(detailTeamURL, teamID), http.NoBody)
 		req = webtest.RequestWithSignedInUser(req, user)
-		return server.SendJSON(req)
+		return server.Send(req)
 	}
 
 	t.Run("Access control prevents deleting teams with the incorrect permissions", func(t *testing.T) {
@@ -354,6 +367,7 @@ func TestTeamAPIEndpoint_DeleteTeam_RBAC(t *testing.T) {
 		}))
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusForbidden, res.StatusCode)
+		require.NoError(t, res.Body.Close())
 	})
 
 	t.Run("Access control allows deleting teams with the correct permissions", func(t *testing.T) {
@@ -362,6 +376,7 @@ func TestTeamAPIEndpoint_DeleteTeam_RBAC(t *testing.T) {
 		}))
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, res.StatusCode)
+		require.NoError(t, res.Body.Close())
 	})
 }
 
@@ -377,7 +392,7 @@ func TestTeamAPIEndpoint_GetTeamPreferences_RBAC(t *testing.T) {
 	request := func(teamID int64, user *user.SignedInUser) (*http.Response, error) {
 		req := server.NewGetRequest(fmt.Sprintf(detailTeamPreferenceURL, teamID))
 		req = webtest.RequestWithSignedInUser(req, user)
-		return server.SendJSON(req)
+		return server.Send(req)
 	}
 
 	t.Run("Access control allows getting team preferences with the correct permissions", func(t *testing.T) {
@@ -386,6 +401,7 @@ func TestTeamAPIEndpoint_GetTeamPreferences_RBAC(t *testing.T) {
 		}))
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, res.StatusCode)
+		require.NoError(t, res.Body.Close())
 	})
 
 	t.Run("Access control prevents getting team preferences with the incorrect permissions", func(t *testing.T) {
@@ -394,6 +410,7 @@ func TestTeamAPIEndpoint_GetTeamPreferences_RBAC(t *testing.T) {
 		}))
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusForbidden, res.StatusCode)
+		require.NoError(t, res.Body.Close())
 	})
 }
 
@@ -418,6 +435,7 @@ func TestTeamAPIEndpoint_UpdateTeamPreferences_RBAC(t *testing.T) {
 		}))
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, res.StatusCode)
+		require.NoError(t, res.Body.Close())
 	})
 
 	t.Run("Access control prevents updating team preferences with the incorrect permissions", func(t *testing.T) {
@@ -426,5 +444,6 @@ func TestTeamAPIEndpoint_UpdateTeamPreferences_RBAC(t *testing.T) {
 		}))
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusForbidden, res.StatusCode)
+		require.NoError(t, res.Body.Close())
 	})
 }

--- a/pkg/api/team_test.go
+++ b/pkg/api/team_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/org"
 	pref "github.com/grafana/grafana/pkg/services/preference"
 	"github.com/grafana/grafana/pkg/services/preference/preftest"
-	"github.com/grafana/grafana/pkg/services/quota/quotatest"
 	"github.com/grafana/grafana/pkg/services/sqlstore/mockstore"
 	"github.com/grafana/grafana/pkg/services/team/teamimpl"
 	"github.com/grafana/grafana/pkg/services/team/teamtest"
@@ -167,7 +166,6 @@ const (
 func TestTeamAPIEndpoint_CreateTeam_LegacyAccessControl(t *testing.T) {
 	server := SetupAPITestServer(t, func(hs *HTTPServer) {
 		hs.teamService = teamtest.NewFakeService()
-		hs.QuotaService = quotatest.NewQuotaServiceFake()
 	})
 
 	input := strings.NewReader(fmt.Sprintf(teamCmd, 1))
@@ -190,106 +188,108 @@ func TestTeamAPIEndpoint_CreateTeam_LegacyAccessControl(t *testing.T) {
 }
 
 func TestTeamAPIEndpoint_CreateTeam_LegacyAccessControl_EditorsCanAdmin(t *testing.T) {
-	cfg := setting.NewCfg()
-	cfg.RBACEnabled = false
-	cfg.EditorsCanAdmin = true
-	sc := setupHTTPServerWithCfg(t, true, cfg)
+	server := SetupAPITestServer(t, func(hs *HTTPServer) {
+		cfg := setting.NewCfg()
+		cfg.RBACEnabled = false
+		cfg.EditorsCanAdmin = true
+		hs.Cfg = cfg
+		hs.teamService = teamtest.NewFakeService()
+	})
 
-	setInitCtxSignedInEditor(sc.initCtx)
-	input := strings.NewReader(fmt.Sprintf(teamCmd, 1))
 	t.Run("Editors can create a team if editorsCanAdmin is set to true", func(t *testing.T) {
-		response := callAPI(sc.server, http.MethodPost, createTeamURL, input, t)
-		assert.Equal(t, http.StatusOK, response.Code)
+		input := strings.NewReader(fmt.Sprintf(teamCmd, 1))
+		req := server.NewPostRequest(createTeamURL, input)
+		req = webtest.RequestWithSignedInUser(req, &user.SignedInUser{OrgRole: org.RoleAdmin})
+		res, err := server.SendJSON(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, res.StatusCode)
 	})
 }
 
 func TestTeamAPIEndpoint_CreateTeam_RBAC(t *testing.T) {
-	sc := setupHTTPServer(t, true)
+	server := SetupAPITestServer(t, func(hs *HTTPServer) {
+		hs.Cfg = setting.NewCfg()
+		hs.teamService = teamtest.NewFakeService()
+	})
 
-	setInitCtxSignedInViewer(sc.initCtx)
 	input := strings.NewReader(fmt.Sprintf(teamCmd, 1))
 	t.Run("Access control allows creating teams with the correct permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []accesscontrol.Permission{{Action: accesscontrol.ActionTeamsCreate}}, 1)
-		response := callAPI(sc.server, http.MethodPost, createTeamURL, input, t)
-		assert.Equal(t, http.StatusOK, response.Code)
+		req := server.NewPostRequest(createTeamURL, input)
+		req = webtest.RequestWithSignedInUser(req, userWithPermissions(1, []accesscontrol.Permission{{Action: accesscontrol.ActionTeamsCreate}}))
+		res, err := server.SendJSON(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, res.StatusCode)
 	})
 
 	input = strings.NewReader(fmt.Sprintf(teamCmd, 2))
 	t.Run("Access control prevents creating teams with the incorrect permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []accesscontrol.Permission{{Action: "teams:invalid"}}, accesscontrol.GlobalOrgID)
-		response := callAPI(sc.server, http.MethodPost, createTeamURL, input, t)
-		assert.Equal(t, http.StatusForbidden, response.Code)
+		req := server.NewPostRequest(createTeamURL, input)
+		req = webtest.RequestWithSignedInUser(req, userWithPermissions(1, []accesscontrol.Permission{}))
+		res, err := server.SendJSON(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusForbidden, res.StatusCode)
 	})
 }
 
 func TestTeamAPIEndpoint_SearchTeams_RBAC(t *testing.T) {
-	sc := setupHTTPServer(t, true)
-	// Seed three teams
-	for i := 1; i <= 3; i++ {
-		_, err := sc.teamService.CreateTeam(fmt.Sprintf("team%d", i), fmt.Sprintf("team%d@example.org", i), 1)
-		require.NoError(t, err)
-	}
-
-	setInitCtxSignedInViewer(sc.initCtx)
+	server := SetupAPITestServer(t, func(hs *HTTPServer) {
+		hs.Cfg = setting.NewCfg()
+		hs.teamService = teamtest.NewFakeService()
+	})
 
 	t.Run("Access control prevents searching for teams with the incorrect permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []accesscontrol.Permission{{Action: accesscontrol.ActionTeamsDelete, Scope: "teams:id:*"}}, 1)
-		response := callAPI(sc.server, http.MethodGet, searchTeamsURL, http.NoBody, t)
-		assert.Equal(t, http.StatusForbidden, response.Code)
+		req := server.NewGetRequest(searchTeamsURL)
+		req = webtest.RequestWithSignedInUser(req, userWithPermissions(1, []accesscontrol.Permission{}))
+		res, err := server.Send(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusForbidden, res.StatusCode)
 	})
 
 	t.Run("Access control allows searching for teams with the correct permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []accesscontrol.Permission{{Action: accesscontrol.ActionTeamsRead, Scope: "teams:id:*"}}, 1)
-		response := callAPI(sc.server, http.MethodGet, searchTeamsURL, http.NoBody, t)
-		assert.Equal(t, http.StatusOK, response.Code)
-
-		res := &models.SearchTeamQueryResult{}
-		err := json.Unmarshal(response.Body.Bytes(), res)
+		req := server.NewGetRequest(searchTeamsURL)
+		req = webtest.RequestWithSignedInUser(req, userWithPermissions(1, []accesscontrol.Permission{
+			{Action: accesscontrol.ActionTeamsRead, Scope: accesscontrol.ScopeTeamsAll},
+		}))
+		res, err := server.Send(req)
 		require.NoError(t, err)
-		require.Len(t, res.Teams, 3, "expected all teams to have been returned")
-		require.Equal(t, res.TotalCount, int64(3), "expected count to match teams length")
-	})
-
-	t.Run("Access control filters teams based on user permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []accesscontrol.Permission{{Action: accesscontrol.ActionTeamsRead, Scope: "teams:id:1"}, {Action: accesscontrol.ActionTeamsRead, Scope: "teams:id:3"}}, 1)
-		response := callAPI(sc.server, http.MethodGet, searchTeamsURL, http.NoBody, t)
-		assert.Equal(t, http.StatusOK, response.Code)
-
-		res := &models.SearchTeamQueryResult{}
-		err := json.Unmarshal(response.Body.Bytes(), res)
-		require.NoError(t, err)
-		require.Len(t, res.Teams, 2, "expected a subset of teams to have been returned")
-		require.Equal(t, res.TotalCount, int64(2), "expected count to match teams length")
-		for _, team := range res.Teams {
-			require.NotEqual(t, team.Name, "team2", "expected team2 to have been filtered")
-		}
+		assert.Equal(t, http.StatusOK, res.StatusCode)
 	})
 }
 
 func TestTeamAPIEndpoint_GetTeamByID_RBAC(t *testing.T) {
-	sc := setupHTTPServer(t, true)
-	sc.db = db.InitTestDB(t)
+	server := SetupAPITestServer(t, func(hs *HTTPServer) {
+		hs.Cfg = setting.NewCfg()
+		hs.teamService = &teamtest.FakeService{ExpectedTeamDTO: &models.TeamDTO{}}
+	})
 
-	_, err := sc.teamService.CreateTeam("team1", "team1@example.org", 1)
-	require.NoError(t, err)
+	url := fmt.Sprintf(detailTeamURL, 1)
 
-	setInitCtxSignedInViewer(sc.initCtx)
-
-	t.Run("Access control prevents getting a team with the incorrect permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []accesscontrol.Permission{{Action: accesscontrol.ActionTeamsRead, Scope: "teams:id:2"}}, 1)
-		response := callAPI(sc.server, http.MethodGet, fmt.Sprintf(detailTeamURL, 1), http.NoBody, t)
-		assert.Equal(t, http.StatusForbidden, response.Code)
+	t.Run("Access control prevents getting a team when missing permissions", func(t *testing.T) {
+		req := server.NewGetRequest(url)
+		req = webtest.RequestWithSignedInUser(req, userWithPermissions(1, []accesscontrol.Permission{}))
+		res, err := server.Send(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusForbidden, res.StatusCode)
 	})
 
 	t.Run("Access control allows getting a team with the correct permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []accesscontrol.Permission{{Action: accesscontrol.ActionTeamsRead, Scope: "teams:id:1"}}, 1)
-		response := callAPI(sc.server, http.MethodGet, fmt.Sprintf(detailTeamURL, 1), http.NoBody, t)
-		assert.Equal(t, http.StatusOK, response.Code)
-
-		res := &models.TeamDTO{}
-		err := json.Unmarshal(response.Body.Bytes(), res)
+		req := server.NewGetRequest(url)
+		req = webtest.RequestWithSignedInUser(req, userWithPermissions(1, []accesscontrol.Permission{
+			{Action: accesscontrol.ActionTeamsRead, Scope: "teams:id:1"},
+		}))
+		res, err := server.Send(req)
 		require.NoError(t, err)
-		assert.Equal(t, "team1", res.Name)
+		assert.Equal(t, http.StatusOK, res.StatusCode)
+	})
+
+	t.Run("Access control allows getting a team with wildcard scope", func(t *testing.T) {
+		req := server.NewGetRequest(url)
+		req = webtest.RequestWithSignedInUser(req, userWithPermissions(1, []accesscontrol.Permission{
+			{Action: accesscontrol.ActionTeamsRead, Scope: "teams:id:*"},
+		}))
+		res, err := server.Send(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, res.StatusCode)
 	})
 }
 
@@ -297,48 +297,39 @@ func TestTeamAPIEndpoint_GetTeamByID_RBAC(t *testing.T) {
 // Then the endpoint should return 200 if the user has accesscontrol.ActionTeamsWrite with teams:id:1 scope
 // else return 403
 func TestTeamAPIEndpoint_UpdateTeam_RBAC(t *testing.T) {
-	sc := setupHTTPServer(t, true)
-	sc.db = db.InitTestDB(t)
-	_, err := sc.teamService.CreateTeam("team1", "", 1)
-
-	require.NoError(t, err)
-
-	setInitCtxSignedInViewer(sc.initCtx)
-
-	input := strings.NewReader(fmt.Sprintf(teamCmd, 1))
-	t.Run("Access control allows updating teams with the correct permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []accesscontrol.Permission{{Action: accesscontrol.ActionTeamsWrite, Scope: "teams:id:1"}}, 1)
-		response := callAPI(sc.server, http.MethodPut, fmt.Sprintf(detailTeamURL, 1), input, t)
-		assert.Equal(t, http.StatusOK, response.Code)
-
-		teamQuery := &models.GetTeamByIdQuery{OrgId: 1, SignedInUser: sc.initCtx.SignedInUser, Id: 1, Result: &models.TeamDTO{}}
-		err := sc.teamService.GetTeamById(context.Background(), teamQuery)
-		require.NoError(t, err)
-		assert.Equal(t, "MyTestTeam1", teamQuery.Result.Name)
+	server := SetupAPITestServer(t, func(hs *HTTPServer) {
+		hs.Cfg = setting.NewCfg()
+		hs.teamService = &teamtest.FakeService{ExpectedTeamDTO: &models.TeamDTO{}}
 	})
 
-	input = strings.NewReader(fmt.Sprintf(teamCmd, 2))
-	t.Run("Access control allows updating teams with the correct global permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []accesscontrol.Permission{{Action: accesscontrol.ActionTeamsWrite, Scope: "teams:id:*"}}, 1)
-		response := callAPI(sc.server, http.MethodPut, fmt.Sprintf(detailTeamURL, 1), input, t)
-		assert.Equal(t, http.StatusOK, response.Code)
+	request := func(teamID int64, user *user.SignedInUser) (*http.Response, error) {
+		req := server.NewRequest(http.MethodPut, fmt.Sprintf(detailTeamURL, teamID), strings.NewReader(teamCmd))
+		req = webtest.RequestWithSignedInUser(req, user)
+		return server.SendJSON(req)
+	}
 
-		teamQuery := &models.GetTeamByIdQuery{OrgId: 1, SignedInUser: sc.initCtx.SignedInUser, Id: 1, Result: &models.TeamDTO{}}
-		err := sc.teamService.GetTeamById(context.Background(), teamQuery)
+	t.Run("Access control allows updating team with the correct permissions", func(t *testing.T) {
+		res, err := request(1, userWithPermissions(1, []accesscontrol.Permission{
+			{Action: accesscontrol.ActionTeamsWrite, Scope: "teams:id:1"},
+		}))
 		require.NoError(t, err)
-		assert.Equal(t, "MyTestTeam2", teamQuery.Result.Name)
+		assert.Equal(t, http.StatusOK, res.StatusCode)
 	})
 
-	input = strings.NewReader(fmt.Sprintf(teamCmd, 3))
-	t.Run("Access control prevents updating teams with the incorrect permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []accesscontrol.Permission{{Action: accesscontrol.ActionTeamsWrite, Scope: "teams:id:2"}}, 1)
-		response := callAPI(sc.server, http.MethodPut, fmt.Sprintf(detailTeamURL, 1), input, t)
-		assert.Equal(t, http.StatusForbidden, response.Code)
+	t.Run("Access control allows updating teams with the wildcard scope", func(t *testing.T) {
+		res, err := request(1, userWithPermissions(1, []accesscontrol.Permission{
+			{Action: accesscontrol.ActionTeamsWrite, Scope: "teams:*"},
+		}))
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, res.StatusCode)
+	})
 
-		teamQuery := &models.GetTeamByIdQuery{OrgId: 1, SignedInUser: sc.initCtx.SignedInUser, Id: 1, Result: &models.TeamDTO{}}
-		err := sc.teamService.GetTeamById(context.Background(), teamQuery)
-		assert.NoError(t, err)
-		assert.Equal(t, "MyTestTeam2", teamQuery.Result.Name)
+	t.Run("Access control prevent updating a team with wrong scope", func(t *testing.T) {
+		res, err := request(1, userWithPermissions(1, []accesscontrol.Permission{
+			{Action: accesscontrol.ActionTeamsWrite, Scope: "teams:id:2"},
+		}))
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusForbidden, res.StatusCode)
 	})
 }
 
@@ -346,31 +337,31 @@ func TestTeamAPIEndpoint_UpdateTeam_RBAC(t *testing.T) {
 // Then the endpoint should return 200 if the user has accesscontrol.ActionTeamsDelete with teams:id:1 scope
 // else return 403
 func TestTeamAPIEndpoint_DeleteTeam_RBAC(t *testing.T) {
-	sc := setupHTTPServer(t, true)
-	sc.db = db.InitTestDB(t)
-	_, err := sc.teamService.CreateTeam("team1", "", 1)
-	require.NoError(t, err)
+	server := SetupAPITestServer(t, func(hs *HTTPServer) {
+		hs.Cfg = setting.NewCfg()
+		hs.teamService = &teamtest.FakeService{ExpectedTeamDTO: &models.TeamDTO{}}
+	})
 
-	setInitCtxSignedInViewer(sc.initCtx)
+	request := func(teamID int64, user *user.SignedInUser) (*http.Response, error) {
+		req := server.NewRequest(http.MethodDelete, fmt.Sprintf(detailTeamURL, teamID), http.NoBody)
+		req = webtest.RequestWithSignedInUser(req, user)
+		return server.SendJSON(req)
+	}
 
 	t.Run("Access control prevents deleting teams with the incorrect permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []accesscontrol.Permission{{Action: accesscontrol.ActionTeamsDelete, Scope: "teams:id:7"}}, 1)
-		response := callAPI(sc.server, http.MethodDelete, fmt.Sprintf(detailTeamURL, 1), http.NoBody, t)
-		assert.Equal(t, http.StatusForbidden, response.Code)
-
-		teamQuery := &models.GetTeamByIdQuery{OrgId: 1, SignedInUser: sc.initCtx.SignedInUser, Id: 1, Result: &models.TeamDTO{}}
-		err := sc.teamService.GetTeamById(context.Background(), teamQuery)
+		res, err := request(1, userWithPermissions(1, []accesscontrol.Permission{
+			{Action: accesscontrol.ActionTeamsDelete, Scope: "teams:id:2"},
+		}))
 		require.NoError(t, err)
+		assert.Equal(t, http.StatusForbidden, res.StatusCode)
 	})
 
 	t.Run("Access control allows deleting teams with the correct permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []accesscontrol.Permission{{Action: accesscontrol.ActionTeamsDelete, Scope: "teams:id:1"}}, 1)
-		response := callAPI(sc.server, http.MethodDelete, fmt.Sprintf(detailTeamURL, 1), http.NoBody, t)
-		assert.Equal(t, http.StatusOK, response.Code)
-
-		teamQuery := &models.GetTeamByIdQuery{OrgId: 1, SignedInUser: sc.initCtx.SignedInUser, Id: 1, Result: &models.TeamDTO{}}
-		err := sc.teamService.GetTeamById(context.Background(), teamQuery)
-		require.ErrorIs(t, err, models.ErrTeamNotFound)
+		res, err := request(1, userWithPermissions(1, []accesscontrol.Permission{
+			{Action: accesscontrol.ActionTeamsDelete, Scope: "teams:id:1"},
+		}))
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, res.StatusCode)
 	})
 }
 
@@ -378,32 +369,31 @@ func TestTeamAPIEndpoint_DeleteTeam_RBAC(t *testing.T) {
 // Then the endpoint should return 200 if the user has accesscontrol.ActionTeamsRead with teams:id:1 scope
 // else return 403
 func TestTeamAPIEndpoint_GetTeamPreferences_RBAC(t *testing.T) {
-	sc := setupHTTPServer(t, true)
-	sc.db = db.InitTestDB(t)
-	_, err := sc.teamService.CreateTeam("team1", "", 1)
+	server := SetupAPITestServer(t, func(hs *HTTPServer) {
+		hs.Cfg = setting.NewCfg()
+		hs.preferenceService = &preftest.FakePreferenceService{ExpectedPreference: &pref.Preference{}}
+	})
 
-	sqlstore := mockstore.NewSQLStoreMock()
-	sc.hs.SQLStore = sqlstore
-
-	prefService := preftest.NewPreferenceServiceFake()
-	prefService.ExpectedPreference = &pref.Preference{}
-	sc.hs.preferenceService = prefService
-
-	require.NoError(t, err)
-
-	setInitCtxSignedInViewer(sc.initCtx)
+	request := func(teamID int64, user *user.SignedInUser) (*http.Response, error) {
+		req := server.NewGetRequest(fmt.Sprintf(detailTeamPreferenceURL, teamID))
+		req = webtest.RequestWithSignedInUser(req, user)
+		return server.SendJSON(req)
+	}
 
 	t.Run("Access control allows getting team preferences with the correct permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock,
-			[]accesscontrol.Permission{{Action: accesscontrol.ActionTeamsRead, Scope: "teams:id:1"}}, 1)
-		response := callAPI(sc.server, http.MethodGet, fmt.Sprintf(detailTeamPreferenceURL, 1), http.NoBody, t)
-		assert.Equal(t, http.StatusOK, response.Code)
+		res, err := request(1, userWithPermissions(1, []accesscontrol.Permission{
+			{Action: accesscontrol.ActionTeamsRead, Scope: "teams:id:1"},
+		}))
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, res.StatusCode)
 	})
 
 	t.Run("Access control prevents getting team preferences with the incorrect permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []accesscontrol.Permission{{Action: accesscontrol.ActionTeamsRead, Scope: "teams:id:2"}}, 1)
-		response := callAPI(sc.server, http.MethodGet, fmt.Sprintf(detailTeamPreferenceURL, 1), http.NoBody, t)
-		assert.Equal(t, http.StatusForbidden, response.Code)
+		res, err := request(1, userWithPermissions(1, []accesscontrol.Permission{
+			{Action: accesscontrol.ActionTeamsRead, Scope: "teams:id:2"},
+		}))
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusForbidden, res.StatusCode)
 	})
 }
 
@@ -411,41 +401,30 @@ func TestTeamAPIEndpoint_GetTeamPreferences_RBAC(t *testing.T) {
 // Then the endpoint should return 200 if the user has accesscontrol.ActionTeamsWrite with teams:id:1 scope
 // else return 403
 func TestTeamAPIEndpoint_UpdateTeamPreferences_RBAC(t *testing.T) {
-	sc := setupHTTPServer(t, true)
-	sqlStore := db.InitTestDB(t)
-	sc.db = sqlStore
-
-	prefService := preftest.NewPreferenceServiceFake()
-	prefService.ExpectedPreference = &pref.Preference{Theme: "dark"}
-	sc.hs.preferenceService = prefService
-
-	_, err := sc.teamService.CreateTeam("team1", "", 1)
-
-	require.NoError(t, err)
-
-	setInitCtxSignedInViewer(sc.initCtx)
-
-	input := strings.NewReader(teamPreferenceCmd)
-	t.Run("Access control allows updating team preferences with the correct permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []accesscontrol.Permission{{Action: accesscontrol.ActionTeamsWrite, Scope: "teams:id:1"}}, 1)
-		response := callAPI(sc.server, http.MethodPut, fmt.Sprintf(detailTeamPreferenceURL, 1), input, t)
-		assert.Equal(t, http.StatusOK, response.Code)
-
-		prefQuery := &pref.GetPreferenceQuery{OrgID: 1, TeamID: 1}
-		preference, err := prefService.Get(context.Background(), prefQuery)
-		require.NoError(t, err)
-		assert.Equal(t, "dark", preference.Theme)
+	server := SetupAPITestServer(t, func(hs *HTTPServer) {
+		hs.Cfg = setting.NewCfg()
+		hs.preferenceService = &preftest.FakePreferenceService{ExpectedPreference: &pref.Preference{}}
 	})
 
-	input = strings.NewReader(teamPreferenceCmdLight)
-	t.Run("Access control prevents updating team preferences with the incorrect permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []accesscontrol.Permission{{Action: accesscontrol.ActionTeamsWrite, Scope: "teams:id:2"}}, 1)
-		response := callAPI(sc.server, http.MethodPut, fmt.Sprintf(detailTeamPreferenceURL, 1), input, t)
-		assert.Equal(t, http.StatusForbidden, response.Code)
+	request := func(teamID int64, user *user.SignedInUser) (*http.Response, error) {
+		req := server.NewRequest(http.MethodPut, fmt.Sprintf(detailTeamPreferenceURL, teamID), strings.NewReader(teamPreferenceCmd))
+		req = webtest.RequestWithSignedInUser(req, user)
+		return server.SendJSON(req)
+	}
 
-		prefQuery := &pref.GetPreferenceQuery{OrgID: 1, TeamID: 1}
-		preference, err := prefService.Get(context.Background(), prefQuery)
-		assert.NoError(t, err)
-		assert.Equal(t, "dark", preference.Theme)
+	t.Run("Access control allows updating team preferences with the correct permissions", func(t *testing.T) {
+		res, err := request(1, userWithPermissions(1, []accesscontrol.Permission{
+			{Action: accesscontrol.ActionTeamsWrite, Scope: "teams:id:1"},
+		}))
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, res.StatusCode)
+	})
+
+	t.Run("Access control prevents updating team preferences with the incorrect permissions", func(t *testing.T) {
+		res, err := request(1, userWithPermissions(1, []accesscontrol.Permission{
+			{Action: accesscontrol.ActionTeamsWrite, Scope: "teams:id:2"},
+		}))
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusForbidden, res.StatusCode)
 	})
 }

--- a/pkg/services/accesscontrol/actest/fake.go
+++ b/pkg/services/accesscontrol/actest/fake.go
@@ -39,22 +39,3 @@ func (f FakeService) RegisterFixedRoles(ctx context.Context) error {
 func (f FakeService) IsDisabled() bool {
 	return f.ExpectedDisabled
 }
-
-var _ accesscontrol.AccessControl = new(FakeAccessControl)
-
-type FakeAccessControl struct {
-	ExpectedErr      error
-	ExpectedDisabled bool
-	ExpectedEvaluate bool
-}
-
-func (f FakeAccessControl) Evaluate(ctx context.Context, user *user.SignedInUser, evaluator accesscontrol.Evaluator) (bool, error) {
-	return f.ExpectedEvaluate, f.ExpectedErr
-}
-
-func (f FakeAccessControl) RegisterScopeAttributeResolver(prefix string, resolver accesscontrol.ScopeAttributeResolver) {
-}
-
-func (f FakeAccessControl) IsDisabled() bool {
-	return f.ExpectedDisabled
-}

--- a/pkg/services/accesscontrol/actest/fake.go
+++ b/pkg/services/accesscontrol/actest/fake.go
@@ -39,3 +39,22 @@ func (f FakeService) RegisterFixedRoles(ctx context.Context) error {
 func (f FakeService) IsDisabled() bool {
 	return f.ExpectedDisabled
 }
+
+var _ accesscontrol.AccessControl = new(FakeAccessControl)
+
+type FakeAccessControl struct {
+	ExpectedErr      error
+	ExpectedDisabled bool
+	ExpectedEvaluate bool
+}
+
+func (f FakeAccessControl) Evaluate(ctx context.Context, user *user.SignedInUser, evaluator accesscontrol.Evaluator) (bool, error) {
+	return f.ExpectedEvaluate, f.ExpectedErr
+}
+
+func (f FakeAccessControl) RegisterScopeAttributeResolver(prefix string, resolver accesscontrol.ScopeAttributeResolver) {
+}
+
+func (f FakeAccessControl) IsDisabled() bool {
+	return f.ExpectedDisabled
+}

--- a/pkg/services/accesscontrol/mock/mock.go
+++ b/pkg/services/accesscontrol/mock/mock.go
@@ -53,6 +53,7 @@ type Mock struct {
 // Ensure the mock stays in line with the interface
 var _ fullAccessControl = New()
 
+// Deprecated: use fake service and real access control evaluator instead
 func New() *Mock {
 	mock := &Mock{
 		Calls:          Calls{},

--- a/pkg/services/team/teamtest/team.go
+++ b/pkg/services/team/teamtest/team.go
@@ -8,6 +8,7 @@ import (
 
 type FakeService struct {
 	ExpectedTeam        models.Team
+	ExpectedTeamDTO     *models.TeamDTO
 	ExpectedTeamsByUser []*models.TeamDTO
 	ExpectedMembers     []*models.TeamMemberDTO
 	ExpectedError       error
@@ -34,6 +35,7 @@ func (s *FakeService) SearchTeams(ctx context.Context, query *models.SearchTeams
 }
 
 func (s *FakeService) GetTeamById(ctx context.Context, query *models.GetTeamByIdQuery) error {
+	query.Result = s.ExpectedTeamDTO
 	return s.ExpectedError
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The access control mock is used in many places and we want to get rid of it and use the real evaluation logic instead
This pr rewrites all team api RBAC tests to not use mock but the real implementation instead.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

