### PR TITLE
devenv: fix loki&elastic naming conflict

### DIFF
--- a/devenv/docker/blocks/elastic/docker-compose.yaml
+++ b/devenv/docker/blocks/elastic/docker-compose.yaml
@@ -1,6 +1,6 @@
 # You need to run 'sysctl -w vm.max_map_count=262144' on the host machine
 
-  elasticsearch:
+  elastic:
     image: docker.elastic.co/elasticsearch/elasticsearch:${elastic_version}
     command: elasticsearch
     environment:
@@ -10,11 +10,11 @@
     ports:
       - "9200:9200"
 
-  data:
+  elastic-data:
     build: docker/blocks/elastic/data
-    command: node /home/node/data.js http://elasticsearch:9200
+    command: node /home/node/data.js http://elastic:9200
     depends_on:
-      - elasticsearch
+      - elastic
     # elastic starts slowly, the first couple start of data.js
     # might fail, so we auto-restart it on failure.
     restart: "on-failure"

--- a/devenv/docker/blocks/loki/docker-compose.yaml
+++ b/devenv/docker/blocks/loki/docker-compose.yaml
@@ -3,7 +3,7 @@
     ports:
       - "3100:3100"
 
-  data:
+  loki-data:
     build: docker/blocks/loki/data
     command: node /home/node/data.js http://loki:3100
     depends_on:


### PR DESCRIPTION
if you run `make devenv sources=loki,elastic`, then it does not work correctly, because there is a name-conflict:
the command runs 4 docker containers:
- loki
- a container feeding fake data into loki, named "data"
- elastic
- a container feeding fake data into elastic, named "data"

as you can see, two containers with the same name, that does not work well. so in this PR:
- i renamed loki's "data" to "loki-data"
- i renamed elastic's "data" to "elastic-data"
- while i was there, i made naming consistent in the "elastic" docker-compose.yaml, until now it was a mix of "elastic" (filename) and "elasticsearch" (inside the file), now it's "elastic" everywhere


how to test:
- `make devenv sources=loki.elastic`
- make sure both loki and elastic have data in them:
    - go to grafan-explore
    - query the elastic datasource, see that it has data
    - query the loki datasource (for example `{place="luna"}`), see that it has data