### PR TITLE
QueryLibrary: Fix null pointer

### DIFF
--- a/pkg/services/querylibrary/tests/api_client.go
+++ b/pkg/services/querylibrary/tests/api_client.go
@@ -53,11 +53,12 @@ func (q *queryLibraryAPIClient) update(ctx context.Context, query *querylibrary.
 	req.Header.Set("Content-Type", "application/json")
 	client := &http.Client{}
 	resp, err := client.Do(req)
-	defer func() {
-		_ = resp.Body.Close()
-	}()
+	if err != nil {
+		return err
+	}
 
-	return err
+	_ = resp.Body.Close()
+	return nil
 }
 
 func (q *queryLibraryAPIClient) delete(ctx context.Context, uid string) error {


### PR DESCRIPTION
`_ = resp.Body.Close()` sometimes panics in tests because if we have any error, `resp` is null.