### PR TITLE
PublicDashboards: Add PubDash support to Angular panel plugins

### DIFF
--- a/public/app/angular/panel/metrics_panel_ctrl.ts
+++ b/public/app/angular/panel/metrics_panel_ctrl.ts
@@ -200,6 +200,7 @@ class MetricsPanelCtrl extends PanelCtrl {
       timeRange: this.range,
       maxDataPoints: panel.maxDataPoints || this.width,
       minInterval: panel.interval,
+      publicDashboardAccessToken: this.dashboard.meta.publicDashboardAccessToken,
       scopedVars: panel.scopedVars,
       cacheTimeout: panel.cacheTimeout,
       transformations: panel.transformations,


### PR DESCRIPTION
**What this PR does / why we need it**:
Panel plugins that extend the angular MetricsPanelCtrl type will attempt to issue queries to the normal /ds/query endpoint, resulting in an unauthorized error. This PR adds support for pubdash to this panel type.

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/grafana-enterprise/issues/4424

**Other notes**:
While Angular will be removed next year, we found this while investigating https://github.com/grafana/grafana/issues/55685 and decided to fix it since it was a small change. 
