### PR TITLE
Alerting: Templated URLs for webhook type contact points

### DIFF
--- a/pkg/services/ngalert/notifier/channels/webhook.go
+++ b/pkg/services/ngalert/notifier/channels/webhook.go
@@ -178,6 +178,7 @@ func (wn *WebhookNotifier) Notify(ctx context.Context, as ...*types.Alert) (bool
 
 	if tmplErr != nil {
 		wn.log.Warn("failed to template webhook message", "err", tmplErr.Error())
+		tmplErr = nil
 	}
 
 	body, err := json.Marshal(msg)

--- a/pkg/services/ngalert/notifier/channels/webhook.go
+++ b/pkg/services/ngalert/notifier/channels/webhook.go
@@ -190,8 +190,13 @@ func (wn *WebhookNotifier) Notify(ctx context.Context, as ...*types.Alert) (bool
 		headers["Authorization"] = fmt.Sprintf("%s %s", wn.settings.AuthorizationScheme, wn.settings.AuthorizationCredentials)
 	}
 
+	parsedURL := tmpl(wn.settings.URL)
+	if tmplErr != nil {
+		return false, tmplErr
+	}
+
 	cmd := &models.SendWebhookSync{
-		Url:        wn.settings.URL,
+		Url:        parsedURL,
 		User:       wn.settings.User,
 		Password:   wn.settings.Password,
 		Body:       string(body),


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR makes it possible to build webhook URLs using template functions and variables. This allows custom data to be sent as part of the query string.

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/discussions/49973

**Special notes for your reviewer**:

I've decided to fail on templating errors for two main reasons:
1. We now expose error info for contact points, so details are available in case of failure.
![Screen Shot 2022-10-19 at 14 23 58](https://user-images.githubusercontent.com/41638679/196768151-79e79aa8-7681-4202-a025-0848fb8b7597.png)

2. We can't make assumptions on what the user wants if the URL template fails to parse. Go templates rely on curly braces (example: `{{ len .Alerts }}`), which are considered unsafe ([RFC 1738](https://www.rfc-editor.org/rfc/rfc1738#page-3)). We can easily go down a rabbit hole trying to correctly escape each part of the URL and considering edge cases, and still not get to the user's desired output.

