### PR TITLE
PublicDashboards: Validate access token 

### DIFF
--- a/pkg/services/publicdashboards/api/api.go
+++ b/pkg/services/publicdashboards/api/api.go
@@ -61,9 +61,9 @@ func (api *Api) RegisterAPIEndpoints() {
 	// circular dependency
 
 	// public endpoints
-	api.RouteRegister.Get("/api/public/dashboards/:accessToken", RequiredCorrectAccessToken(), routing.Wrap(api.GetPublicDashboard))
-	api.RouteRegister.Post("/api/public/dashboards/:accessToken/panels/:panelId/query", RequiredCorrectAccessToken(), routing.Wrap(api.QueryPublicDashboard))
-	api.RouteRegister.Get("/api/public/dashboards/:accessToken/annotations", RequiredCorrectAccessToken(), routing.Wrap(api.GetAnnotations))
+	api.RouteRegister.Get("/api/public/dashboards/:accessToken", RequiresCorrectAccessToken(), routing.Wrap(api.GetPublicDashboard))
+	api.RouteRegister.Post("/api/public/dashboards/:accessToken/panels/:panelId/query", RequiresCorrectAccessToken(), routing.Wrap(api.QueryPublicDashboard))
+	api.RouteRegister.Get("/api/public/dashboards/:accessToken/annotations", RequiresCorrectAccessToken(), routing.Wrap(api.GetAnnotations))
 
 	// List Public Dashboards
 	api.RouteRegister.Get("/api/dashboards/public", middleware.ReqSignedIn, routing.Wrap(api.ListPublicDashboards))

--- a/pkg/services/publicdashboards/api/api.go
+++ b/pkg/services/publicdashboards/api/api.go
@@ -52,7 +52,7 @@ func ProvideApi(
 	return api
 }
 
-// Registers Endpoints on Grafana Router
+// RegisterAPIEndpoints Registers Endpoints on Grafana Router
 func (api *Api) RegisterAPIEndpoints() {
 	auth := accesscontrol.Middleware(api.AccessControl)
 
@@ -79,7 +79,7 @@ func (api *Api) RegisterAPIEndpoints() {
 		routing.Wrap(api.SavePublicDashboardConfig))
 }
 
-// Gets public dashboard
+// GetPublicDashboard Gets public dashboard
 // GET /api/public/dashboards/:accessToken
 func (api *Api) GetPublicDashboard(c *models.ReqContext) response.Response {
 	accessToken := web.Params(c.Req)[":accessToken"]
@@ -115,7 +115,7 @@ func (api *Api) GetPublicDashboard(c *models.ReqContext) response.Response {
 	return response.JSON(http.StatusOK, dto)
 }
 
-// Gets list of public dashboards for an org
+// ListPublicDashboards Gets list of public dashboards for an org
 // GET /api/dashboards/public
 func (api *Api) ListPublicDashboards(c *models.ReqContext) response.Response {
 	resp, err := api.PublicDashboardService.ListPublicDashboards(c.Req.Context(), c.SignedInUser, c.OrgID)
@@ -125,7 +125,7 @@ func (api *Api) ListPublicDashboards(c *models.ReqContext) response.Response {
 	return response.JSON(http.StatusOK, resp)
 }
 
-// Gets public dashboard configuration for dashboard
+// GetPublicDashboardConfig Gets public dashboard configuration for dashboard
 // GET /api/dashboards/uid/:uid/public-config
 func (api *Api) GetPublicDashboardConfig(c *models.ReqContext) response.Response {
 	pdc, err := api.PublicDashboardService.GetPublicDashboardConfig(c.Req.Context(), c.OrgID, web.Params(c.Req)[":uid"])

--- a/pkg/services/publicdashboards/api/api.go
+++ b/pkg/services/publicdashboards/api/api.go
@@ -3,7 +3,6 @@ package api
 import (
 	"context"
 	"errors"
-	"github.com/grafana/grafana/pkg/services/publicdashboards/internal/tokens"
 	"net/http"
 	"strconv"
 
@@ -18,6 +17,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/publicdashboards"
+	"github.com/grafana/grafana/pkg/services/publicdashboards/internal/tokens"
 	. "github.com/grafana/grafana/pkg/services/publicdashboards/models"
 	"github.com/grafana/grafana/pkg/util"
 	"github.com/grafana/grafana/pkg/web"

--- a/pkg/services/publicdashboards/api/api.go
+++ b/pkg/services/publicdashboards/api/api.go
@@ -61,9 +61,9 @@ func (api *Api) RegisterAPIEndpoints() {
 	// circular dependency
 
 	// public endpoints
-	api.RouteRegister.Get("/api/public/dashboards/:accessToken", routing.Wrap(api.GetPublicDashboard))
-	api.RouteRegister.Post("/api/public/dashboards/:accessToken/panels/:panelId/query", routing.Wrap(api.QueryPublicDashboard))
-	api.RouteRegister.Get("/api/public/dashboards/:accessToken/annotations", routing.Wrap(api.GetAnnotations))
+	api.RouteRegister.Get("/api/public/dashboards/:accessToken", RequiredCorrectAccessToken(), routing.Wrap(api.GetPublicDashboard))
+	api.RouteRegister.Post("/api/public/dashboards/:accessToken/panels/:panelId/query", RequiredCorrectAccessToken(), routing.Wrap(api.QueryPublicDashboard))
+	api.RouteRegister.Get("/api/public/dashboards/:accessToken/annotations", RequiredCorrectAccessToken(), routing.Wrap(api.GetAnnotations))
 
 	// List Public Dashboards
 	api.RouteRegister.Get("/api/dashboards/public", middleware.ReqSignedIn, routing.Wrap(api.ListPublicDashboards))
@@ -135,7 +135,7 @@ func (api *Api) GetPublicDashboardConfig(c *models.ReqContext) response.Response
 	return response.JSON(http.StatusOK, pdc)
 }
 
-// Sets public dashboard configuration for dashboard
+// SavePublicDashboardConfig Sets public dashboard configuration for dashboard
 // POST /api/dashboards/uid/:uid/public-config
 func (api *Api) SavePublicDashboardConfig(c *models.ReqContext) response.Response {
 	// exit if we don't have a valid dashboardUid

--- a/pkg/services/publicdashboards/api/api_test.go
+++ b/pkg/services/publicdashboards/api/api_test.go
@@ -601,21 +601,21 @@ func TestAPIQueryPublicDashboard(t *testing.T) {
 
 	t.Run("Status code is 400 when the panel ID is invalid", func(t *testing.T) {
 		server, _ := setup(true)
-		resp := callAPI(server, http.MethodPost, "/api/public/dashboards/abc123/panels/notanumber/query", strings.NewReader("{}"), t)
+		resp := callAPI(server, http.MethodPost, "/api/public/dashboards/"+validAccessToken+"/panels/notanumber/query", strings.NewReader("{}"), t)
 		require.Equal(t, http.StatusBadRequest, resp.Code)
 	})
 
 	t.Run("Status code is 400 when the intervalMS is lesser than 0", func(t *testing.T) {
 		server, fakeDashboardService := setup(true)
-		fakeDashboardService.On("GetQueryDataResponse", mock.Anything, true, mock.Anything, int64(2), "abc123").Return(&backend.QueryDataResponse{}, ErrPublicDashboardBadRequest)
-		resp := callAPI(server, http.MethodPost, "/api/public/dashboards/abc123/panels/2/query", strings.NewReader(`{"intervalMs":-100,"maxDataPoints":1000}`), t)
+		fakeDashboardService.On("GetQueryDataResponse", mock.Anything, true, mock.Anything, int64(2), validAccessToken).Return(&backend.QueryDataResponse{}, ErrPublicDashboardBadRequest)
+		resp := callAPI(server, http.MethodPost, "/api/public/dashboards/"+validAccessToken+"/panels/2/query", strings.NewReader(`{"intervalMs":-100,"maxDataPoints":1000}`), t)
 		require.Equal(t, http.StatusBadRequest, resp.Code)
 	})
 
 	t.Run("Status code is 400 when the maxDataPoints is lesser than 0", func(t *testing.T) {
 		server, fakeDashboardService := setup(true)
-		fakeDashboardService.On("GetQueryDataResponse", mock.Anything, true, mock.Anything, int64(2), "abc123").Return(&backend.QueryDataResponse{}, ErrPublicDashboardBadRequest)
-		resp := callAPI(server, http.MethodPost, "/api/public/dashboards/abc123/panels/2/query", strings.NewReader(`{"intervalMs":100,"maxDataPoints":-1000}`), t)
+		fakeDashboardService.On("GetQueryDataResponse", mock.Anything, true, mock.Anything, int64(2), validAccessToken).Return(&backend.QueryDataResponse{}, ErrPublicDashboardBadRequest)
+		resp := callAPI(server, http.MethodPost, "/api/public/dashboards/"+validAccessToken+"/panels/2/query", strings.NewReader(`{"intervalMs":100,"maxDataPoints":-1000}`), t)
 		require.Equal(t, http.StatusBadRequest, resp.Code)
 	})
 

--- a/pkg/services/publicdashboards/api/middleware.go
+++ b/pkg/services/publicdashboards/api/middleware.go
@@ -61,6 +61,22 @@ func RequiresExistingAccessToken(publicDashboardService publicdashboards.Service
 	}
 }
 
+// RequiredCorrectAccessToken Middleware to validate that the AccessToken has the correct format before continuing
+func RequiredCorrectAccessToken() func(c *models.ReqContext) {
+	return func(c *models.ReqContext) {
+		accessToken, ok := web.Params(c.Req)[":accessToken"]
+
+		if !ok {
+			c.JsonApiErr(http.StatusBadRequest, "No access token provided", nil)
+			return
+		}
+
+		if !tokens.IsValidAccessToken(accessToken) {
+			c.JsonApiErr(http.StatusBadRequest, "Invalid access token", nil)
+		}
+	}
+}
+
 func CountPublicDashboardRequest() func(c *models.ReqContext) {
 	return func(c *models.ReqContext) {
 		metrics.MPublicDashboardRequestCount.Inc()

--- a/pkg/services/publicdashboards/api/middleware.go
+++ b/pkg/services/publicdashboards/api/middleware.go
@@ -61,8 +61,8 @@ func RequiresExistingAccessToken(publicDashboardService publicdashboards.Service
 	}
 }
 
-// RequiredCorrectAccessToken Middleware to validate that the AccessToken has the correct format before continuing
-func RequiredCorrectAccessToken() func(c *models.ReqContext) {
+// RequiresCorrectAccessToken Middleware to validate that the AccessToken has the correct format before continuing
+func RequiresCorrectAccessToken() func(c *models.ReqContext) {
 	return func(c *models.ReqContext) {
 		accessToken, ok := web.Params(c.Req)[":accessToken"]
 

--- a/pkg/services/publicdashboards/api/middleware.go
+++ b/pkg/services/publicdashboards/api/middleware.go
@@ -61,22 +61,6 @@ func RequiresExistingAccessToken(publicDashboardService publicdashboards.Service
 	}
 }
 
-// RequiresCorrectAccessToken Middleware to validate that the AccessToken has the correct format before continuing
-func RequiresCorrectAccessToken() func(c *models.ReqContext) {
-	return func(c *models.ReqContext) {
-		accessToken, ok := web.Params(c.Req)[":accessToken"]
-
-		if !ok {
-			c.JsonApiErr(http.StatusBadRequest, "No access token provided", nil)
-			return
-		}
-
-		if !tokens.IsValidAccessToken(accessToken) {
-			c.JsonApiErr(http.StatusBadRequest, "Invalid access token", nil)
-		}
-	}
-}
-
 func CountPublicDashboardRequest() func(c *models.ReqContext) {
 	return func(c *models.ReqContext) {
 		metrics.MPublicDashboardRequestCount.Inc()

--- a/pkg/services/publicdashboards/api/middleware.go
+++ b/pkg/services/publicdashboards/api/middleware.go
@@ -34,7 +34,8 @@ func SetPublicDashboardFlag(c *models.ReqContext) {
 }
 
 // RequiresExistingAccessToken Middleware to enforce that a public dashboards exists before continuing to handler. This
-// method will query the database to ensure that
+// method will query the database to ensure that it exists.
+// Use when we want to enforce a public dashboard is valid on an endpoint we do not maintain
 func RequiresExistingAccessToken(publicDashboardService publicdashboards.Service) func(c *models.ReqContext) {
 	return func(c *models.ReqContext) {
 		accessToken, ok := web.Params(c.Req)[":accessToken"]

--- a/pkg/services/publicdashboards/api/middleware.go
+++ b/pkg/services/publicdashboards/api/middleware.go
@@ -10,7 +10,7 @@ import (
 	"github.com/grafana/grafana/pkg/web"
 )
 
-// Adds orgId to context based on org of public dashboard
+// SetPublicDashboardOrgIdOnContext Adds orgId to context based on org of public dashboard
 func SetPublicDashboardOrgIdOnContext(publicDashboardService publicdashboards.Service) func(c *models.ReqContext) {
 	return func(c *models.ReqContext) {
 		accessToken, ok := web.Params(c.Req)[":accessToken"]
@@ -28,14 +28,14 @@ func SetPublicDashboardOrgIdOnContext(publicDashboardService publicdashboards.Se
 	}
 }
 
-// Adds public dashboard flag on context
+// SetPublicDashboardFlag Adds public dashboard flag on context
 func SetPublicDashboardFlag(c *models.ReqContext) {
 	c.IsPublicDashboardView = true
 }
 
-// Middleware to enforce that a public dashboards exists before continuing to
-// handler
-func RequiresValidAccessToken(publicDashboardService publicdashboards.Service) func(c *models.ReqContext) {
+// RequiresExistingAccessToken Middleware to enforce that a public dashboards exists before continuing to handler. This
+// method will query the database to ensure that
+func RequiresExistingAccessToken(publicDashboardService publicdashboards.Service) func(c *models.ReqContext) {
 	return func(c *models.ReqContext) {
 		accessToken, ok := web.Params(c.Req)[":accessToken"]
 

--- a/pkg/services/publicdashboards/api/middleware_test.go
+++ b/pkg/services/publicdashboards/api/middleware_test.go
@@ -20,7 +20,7 @@ import (
 
 var validAccessToken, _ = tokens.GenerateAccessToken()
 
-func TestRequiresValidAccessToken(t *testing.T) {
+func TestRequiresExistingAccessToken(t *testing.T) {
 	tests := []struct {
 		Name                 string
 		Path                 string
@@ -76,7 +76,7 @@ func TestRequiresValidAccessToken(t *testing.T) {
 			publicdashboardService := &publicdashboards.FakePublicDashboardService{}
 			publicdashboardService.On("AccessTokenExists", mock.Anything, mock.Anything).Return(tt.AccessTokenExists, tt.AccessTokenExistsErr)
 			params := map[string]string{":accessToken": tt.AccessToken}
-			mw := RequiresValidAccessToken(publicdashboardService)
+			mw := RequiresExistingAccessToken(publicdashboardService)
 			_, resp := runMw(t, nil, "GET", tt.Path, params, mw)
 			require.Equal(t, tt.ExpectedResponseCode, resp.Code)
 		})

--- a/pkg/services/publicdashboards/internal/tokens/tokens.go
+++ b/pkg/services/publicdashboards/internal/tokens/tokens.go
@@ -6,7 +6,7 @@ import (
 	"github.com/google/uuid"
 )
 
-// generates a uuid formatted without dashes to use as access token
+//GenerateAccessToken generates an uuid formatted without dashes to use as access token
 func GenerateAccessToken() (string, error) {
 	token, err := uuid.NewRandom()
 	if err != nil {
@@ -16,7 +16,7 @@ func GenerateAccessToken() (string, error) {
 	return fmt.Sprintf("%x", token[:]), nil
 }
 
-// asserts that an accessToken is a valid uuid
+//IsValidAccessToken asserts that an accessToken is a valid uuid
 func IsValidAccessToken(token string) bool {
 	_, err := uuid.Parse(token)
 	return err == nil

--- a/pkg/services/publicdashboards/internal/tokens/tokens.go
+++ b/pkg/services/publicdashboards/internal/tokens/tokens.go
@@ -6,17 +6,16 @@ import (
 	"github.com/google/uuid"
 )
 
-//GenerateAccessToken generates an uuid formatted without dashes to use as access token
+// GenerateAccessToken generates an uuid formatted without dashes to use as access token
 func GenerateAccessToken() (string, error) {
 	token, err := uuid.NewRandom()
 	if err != nil {
 		return "", err
 	}
-
 	return fmt.Sprintf("%x", token[:]), nil
 }
 
-//IsValidAccessToken asserts that an accessToken is a valid uuid
+// IsValidAccessToken asserts that an accessToken is a valid uuid
 func IsValidAccessToken(token string) bool {
 	_, err := uuid.Parse(token)
 	return err == nil

--- a/pkg/services/publicdashboards/service/service.go
+++ b/pkg/services/publicdashboards/service/service.go
@@ -25,7 +25,7 @@ import (
 	"github.com/grafana/grafana/pkg/tsdb/legacydata"
 )
 
-// Define the Service Implementation. We're generating mock implementation
+// PublicDashboardServiceImpl Define the Service Implementation. We're generating mock implementation
 // automatically
 type PublicDashboardServiceImpl struct {
 	log                log.Logger
@@ -43,7 +43,7 @@ var LogPrefix = "publicdashboards.service"
 // the interface
 var _ publicdashboards.Service = (*PublicDashboardServiceImpl)(nil)
 
-// Factory for method used by wire to inject dependencies.
+// ProvideService Factory for method used by wire to inject dependencies.
 // builds the service, and api, and configures routes
 func ProvideService(
 	cfg *setting.Cfg,
@@ -63,7 +63,7 @@ func ProvideService(
 	}
 }
 
-// Gets a dashboard by Uid
+// GetDashboard Gets a dashboard by Uid
 func (pd *PublicDashboardServiceImpl) GetDashboard(ctx context.Context, dashboardUid string) (*models.Dashboard, error) {
 	dashboard, err := pd.store.GetDashboard(ctx, dashboardUid)
 
@@ -74,7 +74,7 @@ func (pd *PublicDashboardServiceImpl) GetDashboard(ctx context.Context, dashboar
 	return dashboard, err
 }
 
-// Gets public dashboard via access token
+// GetPublicDashboard Gets public dashboard via access token
 func (pd *PublicDashboardServiceImpl) GetPublicDashboard(ctx context.Context, accessToken string) (*PublicDashboard, *models.Dashboard, error) {
 	pubdash, dash, err := pd.store.GetPublicDashboard(ctx, accessToken)
 	ctxLogger := pd.log.FromContext(ctx)


### PR DESCRIPTION
**What this PR does / why we need it**:
- Adds a validation for the Access Token, to validate the format before querying the database 
  
**Which issue(s) this PR fixes**:  
Fixes https://github.com/grafana/grafana-enterprise/issues/4444

**Special notes for your reviewer**:
* Renamed `RequiresValidAccessToken` to `RequiresExistingAccessToken` as that method will validate that the access token is in the database.
* The validation of the format of the access token was added at the API level, to make it easier for testing. 