### PR TITLE
Alerting: Remove error count in integrations details and show only Error label in  Contact points tab 

### DIFF
--- a/public/app/features/alerting/unified/Receivers.test.tsx
+++ b/public/app/features/alerting/unified/Receivers.test.tsx
@@ -564,12 +564,12 @@ describe('Receivers', () => {
       // expand contact point detail for default 2 emails - 2 errors
       await userEvent.click(ui.contactPointsCollapseToggle.get(receiverRows[0]));
       const defaultDetailTable = screen.getAllByTestId('dynamic-table')[1];
-      expect(byText('1 error').getAll(defaultDetailTable)).toHaveLength(1);
+      expect(byText('Error').getAll(defaultDetailTable)).toHaveLength(1);
 
       // expand contact point detail for slack and pagerduty - 0 errors
       await userEvent.click(ui.contactPointsCollapseToggle.get(receiverRows[1]));
       const criticalDetailTable = screen.getAllByTestId('dynamic-table')[2];
-      expect(byText('1 error').query(criticalDetailTable)).toBeNull();
+      expect(byText('Error').query(criticalDetailTable)).toBeNull();
       expect(byText('OK').getAll(criticalDetailTable)).toHaveLength(2);
     });
     it('Should render no attempt message when there are some points state with null lastNotifyAttempt, and "-" in null values', async () => {
@@ -635,7 +635,7 @@ describe('Receivers', () => {
       // expand contact point detail for default 2 emails - 2 errors
       await userEvent.click(ui.contactPointsCollapseToggle.get(receiverRows[0]));
       const defaultDetailTable = screen.getAllByTestId('dynamic-table')[1];
-      expect(byText('1 error').getAll(defaultDetailTable)).toHaveLength(1);
+      expect(byText('Error').getAll(defaultDetailTable)).toHaveLength(1);
 
       // expand contact point detail for slack and pagerduty - 0 errors
       await userEvent.click(ui.contactPointsCollapseToggle.get(receiverRows[1]));

--- a/public/app/features/alerting/unified/components/receivers/ReceiversTable.tsx
+++ b/public/app/features/alerting/unified/components/receivers/ReceiversTable.tsx
@@ -79,17 +79,12 @@ function ViewAction({ permissions, alertManagerName, receiverName }: ActionProps
 interface ReceiverErrorProps {
   errorCount: number;
   errorDetail?: string;
+  showErrorCount: boolean;
 }
 
-function ReceiverError({ errorCount, errorDetail }: ReceiverErrorProps) {
-  return (
-    <Badge
-      color="orange"
-      icon="exclamation-triangle"
-      text={`${errorCount} ${pluralize('error', errorCount)}`}
-      tooltip={errorDetail ?? 'Error'}
-    />
-  );
+function ReceiverError({ errorCount, errorDetail, showErrorCount }: ReceiverErrorProps) {
+  const text = showErrorCount ? `${errorCount} ${pluralize('error', errorCount)}` : 'Error';
+  return <Badge color="orange" icon="exclamation-triangle" text={text} tooltip={errorDetail ?? 'Error'} />;
 }
 interface NotifierHealthProps {
   errorsByNotifier: number;
@@ -101,7 +96,7 @@ function NotifierHealth({ errorsByNotifier, errorDetail, lastNotify }: NotifierH
   const noErrorsColor = isLastNotifyNullDate(lastNotify) ? 'orange' : 'green';
   const noErrorsText = isLastNotifyNullDate(lastNotify) ? 'No attempts' : 'OK';
   return errorsByNotifier > 0 ? (
-    <ReceiverError errorCount={errorsByNotifier} errorDetail={errorDetail} />
+    <ReceiverError errorCount={errorsByNotifier} errorDetail={errorDetail} showErrorCount={false} />
   ) : (
     <Badge color={noErrorsColor} text={noErrorsText} tooltip="" />
   );
@@ -116,7 +111,7 @@ function ReceiverHealth({ errorsByReceiver, someWithNoAttempt }: ReceiverHealthP
   const noErrorsColor = someWithNoAttempt ? 'orange' : 'green';
   const noErrorsText = someWithNoAttempt ? 'No attempts' : 'OK';
   return errorsByReceiver > 0 ? (
-    <ReceiverError errorCount={errorsByReceiver} />
+    <ReceiverError errorCount={errorsByReceiver} showErrorCount={true} />
   ) : (
     <Badge color={noErrorsColor} text={noErrorsText} tooltip="" />
   );


### PR DESCRIPTION

**What this PR does / why we need it**:

This PR removes error count in integrations detail, as it's always 1 in case of error.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

<img width="1552" alt="Screenshot 2022-10-20 at 08 37 40" src="https://user-images.githubusercontent.com/33540275/196874198-445fd087-85db-4c4d-bbf6-b9a13b0123bb.png">
