### PR TITLE
OutsideRangePlugin: Exclude leading and trailing null values when checking limits

### DIFF
--- a/public/app/plugins/panel/timeseries/plugins/OutsideRangePlugin.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/OutsideRangePlugin.tsx
@@ -34,10 +34,20 @@ export const OutsideRangePlugin: React.FC<ThresholdControlsPluginProps> = ({ con
   }
 
   // Time values are always sorted for uPlot to work
-  const first = timevalues[0];
-  const last = timevalues[timevalues.length - 1];
+  const first = timevalues[0] !== null ? timevalues[0] : timevalues.find((v) => v !== null);
+  const last =
+    timevalues[timevalues.length - 1] !== null
+      ? timevalues[timevalues.length - 1]
+      : timevalues
+          .slice()
+          .reverse()
+          .find((v) => v !== null);
   const fromX = timeRange.min;
   const toX = timeRange.max;
+
+  if (first === undefined || last === undefined) {
+    return null;
+  }
 
   // (StartA <= EndB) and (EndA >= StartB)
   if (first <= toX && last >= fromX) {

--- a/public/app/plugins/panel/timeseries/plugins/OutsideRangePlugin.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/OutsideRangePlugin.tsx
@@ -37,7 +37,7 @@ export const OutsideRangePlugin: React.FC<ThresholdControlsPluginProps> = ({ con
   let i = 0,
     j = timevalues.length - 1;
 
-  while (i < timevalues.length && timevalues[i] == null) {
+  while (i <= j && timevalues[i] == null) {
     i++;
   }
 

--- a/public/app/plugins/panel/timeseries/plugins/OutsideRangePlugin.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/OutsideRangePlugin.tsx
@@ -34,18 +34,23 @@ export const OutsideRangePlugin: React.FC<ThresholdControlsPluginProps> = ({ con
   }
 
   // Time values are always sorted for uPlot to work
-  const first = timevalues[0] !== null ? timevalues[0] : timevalues.find((v) => v !== null);
-  const last =
-    timevalues[timevalues.length - 1] !== null
-      ? timevalues[timevalues.length - 1]
-      : timevalues
-          .slice()
-          .reverse()
-          .find((v) => v !== null);
+  let i = 0,
+    j = timevalues.length - 1;
+
+  while (i < timevalues.length && timevalues[i] == null) {
+    i++;
+  }
+
+  while (j >= 0 && timevalues[j] == null) {
+    j--;
+  }
+
+  const first = timevalues[i];
+  const last = timevalues[j];
   const fromX = timeRange.min;
   const toX = timeRange.max;
 
-  if (first === undefined || last === undefined) {
+  if (first == null || last == null) {
     return null;
   }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Fixes the `OutsideRangePlugin` to ignore null boundary values when calculating timerange. Before this, the plugin would appear erroneously and clicking `Zoom to data` would result in an invalid timerange since one of the values would be `null`.

**Which issue(s) this PR fixes**:

<!--
