### PR TITLE
OAuth: Fix misleading warn log related to oauth and increase logged content

### DIFF
--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -195,10 +195,15 @@ func (hs *HTTPServer) OAuthLogin(ctx *models.ReqContext) {
 	token.TokenType = "Bearer"
 
 	if hs.Cfg.Env != setting.Dev {
-		oauthLogger.Debug("OAuthLogin: got token", "expiry", fmt.Sprintf("%v", token.Expiry))
+		oauthLogger.Debug("OAuthLogin: got token",
+			"expiry", fmt.Sprintf("%v", token.Expiry),
+			"type", token.TokenType,
+			"has_refresh_token", token.RefreshToken != "",
+		)
 	} else {
 		oauthLogger.Debug("OAuthLogin: got token",
 			"expiry", fmt.Sprintf("%v", token.Expiry),
+			"type", token.TokenType,
 			"access_token", fmt.Sprintf("%v", token.AccessToken),
 			"refresh_token", fmt.Sprintf("%v", token.RefreshToken),
 		)

--- a/pkg/login/social/azuread_oauth_test.go
+++ b/pkg/login/social/azuread_oauth_test.go
@@ -54,7 +54,7 @@ func TestSocialAzureAD_UserInfo(t *testing.T) {
 				ID:                "1234",
 			},
 			fields: fields{
-				SocialBase: newSocialBase("azuread", &oauth2.Config{}, &OAuthInfo{}, "Viewer"),
+				SocialBase: newSocialBase("azuread", &oauth2.Config{}, &OAuthInfo{}, "Viewer", false),
 			},
 			want: &BasicUserInfo{
 				Id:     "1234",
@@ -93,7 +93,7 @@ func TestSocialAzureAD_UserInfo(t *testing.T) {
 				ID:                "1234",
 			},
 			fields: fields{
-				SocialBase: newSocialBase("azuread", &oauth2.Config{}, &OAuthInfo{}, "Viewer"),
+				SocialBase: newSocialBase("azuread", &oauth2.Config{}, &OAuthInfo{}, "Viewer", false),
 			},
 			want: &BasicUserInfo{
 				Id:     "1234",
@@ -143,7 +143,7 @@ func TestSocialAzureAD_UserInfo(t *testing.T) {
 		{
 			name: "Only other roles",
 			fields: fields{
-				SocialBase: newSocialBase("azuread", &oauth2.Config{}, &OAuthInfo{}, "Viewer"),
+				SocialBase: newSocialBase("azuread", &oauth2.Config{}, &OAuthInfo{}, "Viewer", false),
 			},
 			claims: &azureClaims{
 				Email:             "me@example.com",
@@ -171,7 +171,7 @@ func TestSocialAzureAD_UserInfo(t *testing.T) {
 				ID:                "1234",
 			},
 			fields: fields{
-				SocialBase: newSocialBase("azuread", &oauth2.Config{}, &OAuthInfo{}, "Editor"),
+				SocialBase: newSocialBase("azuread", &oauth2.Config{}, &OAuthInfo{}, "Editor", false),
 			},
 			want: &BasicUserInfo{
 				Id:     "1234",
@@ -220,7 +220,7 @@ func TestSocialAzureAD_UserInfo(t *testing.T) {
 		},
 		{
 			name:   "Grafana Admin but setting is disabled",
-			fields: fields{SocialBase: newSocialBase("azuread", &oauth2.Config{}, &OAuthInfo{AllowAssignGrafanaAdmin: false}, "Editor")},
+			fields: fields{SocialBase: newSocialBase("azuread", &oauth2.Config{}, &OAuthInfo{AllowAssignGrafanaAdmin: false}, "Editor", false)},
 			claims: &azureClaims{
 				Email:             "me@example.com",
 				PreferredUsername: "",
@@ -242,7 +242,7 @@ func TestSocialAzureAD_UserInfo(t *testing.T) {
 			name: "Editor roles in claim and GrafanaAdminAssignment enabled",
 			fields: fields{
 				SocialBase: newSocialBase("azuread",
-					&oauth2.Config{}, &OAuthInfo{AllowAssignGrafanaAdmin: true}, "")},
+					&oauth2.Config{}, &OAuthInfo{AllowAssignGrafanaAdmin: true}, "", false)},
 			claims: &azureClaims{
 				Email:             "me@example.com",
 				PreferredUsername: "",
@@ -263,7 +263,7 @@ func TestSocialAzureAD_UserInfo(t *testing.T) {
 		{
 			name: "Grafana Admin and Editor roles in claim",
 			fields: fields{SocialBase: newSocialBase("azuread",
-				&oauth2.Config{}, &OAuthInfo{AllowAssignGrafanaAdmin: true}, "")},
+				&oauth2.Config{}, &OAuthInfo{AllowAssignGrafanaAdmin: true}, "", false)},
 			claims: &azureClaims{
 				Email:             "me@example.com",
 				PreferredUsername: "",
@@ -302,7 +302,7 @@ func TestSocialAzureAD_UserInfo(t *testing.T) {
 			fields: fields{
 				allowedGroups: []string{"foo", "bar"},
 				SocialBase: newSocialBase("azuread",
-					&oauth2.Config{}, &OAuthInfo{AllowAssignGrafanaAdmin: false}, "Viewer"),
+					&oauth2.Config{}, &OAuthInfo{AllowAssignGrafanaAdmin: false}, "Viewer", false),
 			},
 			claims: &azureClaims{
 				Email:             "me@example.com",
@@ -324,7 +324,7 @@ func TestSocialAzureAD_UserInfo(t *testing.T) {
 		{
 			name: "Fetch groups when ClaimsNames and ClaimsSources is set",
 			fields: fields{
-				SocialBase: newSocialBase("azuread", &oauth2.Config{}, &OAuthInfo{}, ""),
+				SocialBase: newSocialBase("azuread", &oauth2.Config{}, &OAuthInfo{}, "", false),
 			},
 			claims: &azureClaims{
 				ID:                "1",
@@ -349,7 +349,7 @@ func TestSocialAzureAD_UserInfo(t *testing.T) {
 		{
 			name: "Fetch groups when forceUseGraphAPI is set",
 			fields: fields{
-				SocialBase:       newSocialBase("azuread", &oauth2.Config{}, &OAuthInfo{}, ""),
+				SocialBase:       newSocialBase("azuread", &oauth2.Config{}, &OAuthInfo{}, "", false),
 				forceUseGraphAPI: true,
 			},
 			claims: &azureClaims{
@@ -376,7 +376,7 @@ func TestSocialAzureAD_UserInfo(t *testing.T) {
 		{
 			name: "Fetch empty role when strict attribute role is true and no match",
 			fields: fields{
-				SocialBase: newSocialBase("azuread", &oauth2.Config{}, &OAuthInfo{RoleAttributeStrict: true}, ""),
+				SocialBase: newSocialBase("azuread", &oauth2.Config{}, &OAuthInfo{RoleAttributeStrict: true}, "", false),
 			},
 			claims: &azureClaims{
 				Email:             "me@example.com",
@@ -392,7 +392,7 @@ func TestSocialAzureAD_UserInfo(t *testing.T) {
 		{
 			name: "Fetch empty role when strict attribute role is true and no role claims returned",
 			fields: fields{
-				SocialBase: newSocialBase("azuread", &oauth2.Config{}, &OAuthInfo{RoleAttributeStrict: true}, ""),
+				SocialBase: newSocialBase("azuread", &oauth2.Config{}, &OAuthInfo{RoleAttributeStrict: true}, "", false),
 			},
 			claims: &azureClaims{
 				Email:             "me@example.com",
@@ -416,7 +416,7 @@ func TestSocialAzureAD_UserInfo(t *testing.T) {
 			}
 
 			if tt.fields.SocialBase == nil {
-				s.SocialBase = newSocialBase("azuread", &oauth2.Config{}, &OAuthInfo{}, "")
+				s.SocialBase = newSocialBase("azuread", &oauth2.Config{}, &OAuthInfo{}, "", false)
 			}
 
 			key := []byte("secret")

--- a/pkg/login/social/github_oauth_test.go
+++ b/pkg/login/social/github_oauth_test.go
@@ -202,7 +202,7 @@ func TestSocialGitHub_UserInfo(t *testing.T) {
 
 			s := &SocialGithub{
 				SocialBase: newSocialBase("github", &oauth2.Config{},
-					&OAuthInfo{RoleAttributePath: tt.roleAttributePath}, tt.autoAssignOrgRole),
+					&OAuthInfo{RoleAttributePath: tt.roleAttributePath}, tt.autoAssignOrgRole, false),
 				allowedOrganizations: []string{},
 				apiUrl:               server.URL + "/user",
 				teamIds:              []int{},


### PR DESCRIPTION
**What this PR does / why we need it**:

- Fix misleading warn log related to oauth
- Only emit warning if instance is concerned
- Log presence of refresh token