### PR TITLE
HeatmapPanel: Fix tooltip y range

### DIFF
--- a/public/app/plugins/panel/heatmap/HeatmapHoverView.tsx
+++ b/public/app/plugins/panel/heatmap/HeatmapHoverView.tsx
@@ -48,16 +48,29 @@ const HeatmapHoverCell = ({ data, hover, showHistogram }: Props) => {
 
   // labeled buckets
   const meta = readHeatmapRowsCustomMeta(data.heatmap);
-  const yDispSrc = meta.yOrdinalDisplay ?? yVals;
   const yDisp = yField?.display ? (v: any) => formattedValueToString(yField.display!(v)) : (v: any) => `${v}`;
 
   const yValueIdx = index % data.yBucketCount! ?? 0;
 
-  const yMinIdx = data.yLayout === HeatmapCellLayout.le ? yValueIdx - 1 : yValueIdx;
-  const yMaxIdx = data.yLayout === HeatmapCellLayout.le ? yValueIdx : yValueIdx + 1;
+  let yBucketMin: string;
+  let yBucketMax: string;
 
-  const yBucketMin = yDispSrc?.[yMinIdx];
-  const yBucketMax = yDispSrc?.[yMaxIdx];
+  if (meta.yOrdinalDisplay) {
+    const yMinIdx = data.yLayout === HeatmapCellLayout.le ? yValueIdx - 1 : yValueIdx;
+    const yMaxIdx = data.yLayout === HeatmapCellLayout.le ? yValueIdx : yValueIdx + 1;
+    yBucketMin = `${meta.yOrdinalDisplay[yMinIdx]}`;
+    yBucketMax = `${meta.yOrdinalDisplay[yMaxIdx]}`;
+  } else {
+    if (data.yLayout === HeatmapCellLayout.le) {
+      const value = yVals?.[yValueIdx];
+      yBucketMax = `${value}`;
+      yBucketMin = `${value - data.yBucketSize!}`;
+    } else {
+      const value = yVals?.[yValueIdx];
+      yBucketMin = `${value}`;
+      yBucketMax = `${value + data.yBucketSize!}`;
+    }
+  }
 
   let xBucketMin: number;
   let xBucketMax: number;


### PR DESCRIPTION
Before this, y range on calculated, non-ordinal heatmap was broken by out-of-bound array access:

- On ge layout, at topmost buckets, max value was wrapped to lowest value from next group of y values
- On le layout, at bottom buckets, min value was `undefined` by accessing array[-1]

This fixes it by calculating range with bucket size on calculated heatmap.

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

