### PR TITLE
Loki: Fix the name of exported component from LokiQueryEditor.tsx

### DIFF
--- a/public/app/plugins/datasource/loki/components/LokiQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryEditor.test.tsx
@@ -10,7 +10,7 @@ import { LokiDatasource } from '../datasource';
 import { EXPLAIN_LABEL_FILTER_CONTENT } from '../querybuilder/components/LokiQueryBuilderExplained';
 import { LokiQuery, LokiQueryType } from '../types';
 
-import { LokiQueryEditorSelector } from './LokiQueryEditor';
+import { LokiQueryEditor } from './LokiQueryEditor';
 
 jest.mock('@grafana/runtime', () => {
   return {
@@ -65,13 +65,13 @@ const defaultProps = {
 describe('LokiQueryEditorSelector', () => {
   it('shows code editor if expr and nothing else', async () => {
     // We opt for showing code editor for queries created before this feature was added
-    render(<LokiQueryEditorSelector {...defaultProps} />);
+    render(<LokiQueryEditor {...defaultProps} />);
     expectCodeEditor();
   });
 
   it('shows builder if new query', async () => {
     render(
-      <LokiQueryEditorSelector
+      <LokiQueryEditor
         {...defaultProps}
         query={{
           refId: 'A',
@@ -146,7 +146,7 @@ describe('LokiQueryEditorSelector', () => {
     });
     await switchToMode(QueryEditorMode.Builder);
     rerender(
-      <LokiQueryEditorSelector
+      <LokiQueryEditor
         {...defaultProps}
         query={{
           refId: 'A',
@@ -170,7 +170,7 @@ function renderWithProps(overrides?: Partial<LokiQuery>) {
   const query = defaultsDeep(overrides ?? {}, cloneDeep(defaultQuery));
   const onChange = jest.fn();
 
-  const stuff = render(<LokiQueryEditorSelector {...defaultProps} query={query} onChange={onChange} />);
+  const stuff = render(<LokiQueryEditor {...defaultProps} query={query} onChange={onChange} />);
   return { onChange, ...stuff };
 }
 

--- a/public/app/plugins/datasource/loki/components/LokiQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryEditor.tsx
@@ -27,7 +27,7 @@ export const testIds = {
   editor: 'loki-editor',
 };
 
-export const LokiQueryEditorSelector = React.memo<LokiQueryEditorProps>((props) => {
+export const LokiQueryEditor = React.memo<LokiQueryEditorProps>((props) => {
   const { onChange, onRunQuery, onAddQuery, data, app, queries } = props;
   const [parseModalOpen, setParseModalOpen] = useState(false);
   const [queryPatternsModalOpen, setQueryPatternsModalOpen] = useState(false);
@@ -162,4 +162,4 @@ export const LokiQueryEditorSelector = React.memo<LokiQueryEditorProps>((props) 
   );
 });
 
-LokiQueryEditorSelector.displayName = 'LokiQueryEditorSelector';
+LokiQueryEditor.displayName = 'LokiQueryEditor';

--- a/public/app/plugins/datasource/loki/components/LokiQueryEditorByApp.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryEditorByApp.tsx
@@ -2,7 +2,7 @@ import React, { memo } from 'react';
 
 import { CoreApp } from '@grafana/data';
 
-import { LokiQueryEditorSelector } from './LokiQueryEditor';
+import { LokiQueryEditor } from './LokiQueryEditor';
 import { LokiQueryEditorForAlerting } from './LokiQueryEditorForAlerting';
 import { LokiQueryEditorProps } from './types';
 
@@ -13,7 +13,7 @@ export function LokiQueryEditorByApp(props: LokiQueryEditorProps) {
     case CoreApp.CloudAlerting:
       return <LokiQueryEditorForAlerting {...props} />;
     default:
-      return <LokiQueryEditorSelector {...props} />;
+      return <LokiQueryEditor {...props} />;
   }
 }
 


### PR DESCRIPTION
Fixes issue introduced in https://github.com/grafana/grafana/pull/57192 where I renamed filte `LokiQueryEditorSelector` -> `LokiQueryEditor`, but the name of component wasn't changed. This PR fixes it. 