### PR TITLE
User: Fix externalUserId not being populated

### DIFF
--- a/pkg/services/user/model.go
+++ b/pkg/services/user/model.go
@@ -198,7 +198,7 @@ type SignedInUser struct {
 	OrgName            string
 	OrgRole            roletype.RoleType
 	ExternalAuthModule string
-	ExternalAuthID     string
+	ExternalAuthID     string `xorm:"external_auth_id"`
 	Login              string
 	Name               string
 	Email              string


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes `grafanaBootData.user.externalUserId` from not being populated.

Problem was caused by xorm incorrectly unmarshalling the SQL results. the SQL is `user_auth.auth_id     as external_auth_id`. Because `id` is just one 'word', it needs to be unpacked into a property named `ExternalAuthId`.


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #56975

**Special notes for your reviewer**:

