### PR TITLE
RBAC: Fetch service account actions in oss

### DIFF
--- a/pkg/services/accesscontrol/acimpl/service.go
+++ b/pkg/services/accesscontrol/acimpl/service.go
@@ -76,7 +76,7 @@ func (s *Service) GetUsageStats(_ context.Context) map[string]interface{} {
 }
 
 var actionsToFetch = append(
-	ossaccesscontrol.TeamAdminActions, append(ossaccesscontrol.DashboardAdminActions, ossaccesscontrol.FolderAdminActions...)...,
+	ossaccesscontrol.TeamAdminActions, append(ossaccesscontrol.DashboardAdminActions, append(ossaccesscontrol.FolderAdminActions, ossaccesscontrol.ServiceAccountAdminActions...)...)...,
 )
 
 // GetUserPermissions returns user permissions based on built-in roles


### PR DESCRIPTION
**What this PR does / why we need it**:
In https://github.com/grafana/grafana/pull/51818 we added managed permissions for service accounts but did not add those actions to the "allowed" action list used for oss. 

This pr just appends those actions so that users/teams with permissions to a service account can edit them
Fixes https://github.com/grafana/grafana-enterprise/issues/3842

**Special notes for your reviewer**:

