### PR TITLE
Loki: Fix showing of history of querying in query editor

### DIFF
--- a/public/app/plugins/datasource/loki/components/AnnotationsQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/AnnotationsQueryEditor.tsx
@@ -18,7 +18,7 @@ type Props = LokiQueryEditorProps & {
 };
 
 export const LokiAnnotationsQueryEditor = memo(function LokiAnnotationQueryEditor(props: Props) {
-  const { annotation, onAnnotationChange } = props;
+  const { annotation, onAnnotationChange, history } = props;
 
   // this should never happen, but we want to keep typescript happy
   if (annotation === undefined || onAnnotationChange === undefined) {
@@ -56,7 +56,7 @@ export const LokiAnnotationsQueryEditor = memo(function LokiAnnotationQueryEdito
           onChange={onChangeQuery}
           onRunQuery={() => {}}
           onBlur={() => {}}
-          history={[]}
+          history={history}
           ExtraFieldElement={
             <LokiOptionFields
               lineLimitValue={queryWithRefId?.maxLines?.toString() || ''}

--- a/public/app/plugins/datasource/loki/components/LokiQueryEditorForAlerting.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryEditorForAlerting.tsx
@@ -4,7 +4,7 @@ import { LokiQueryField } from './LokiQueryField';
 import { LokiQueryEditorProps } from './types';
 
 export function LokiQueryEditorForAlerting(props: LokiQueryEditorProps) {
-  const { query, data, datasource, onChange, onRunQuery } = props;
+  const { query, data, datasource, onChange, onRunQuery, history } = props;
 
   return (
     <LokiQueryField
@@ -13,7 +13,7 @@ export function LokiQueryEditorForAlerting(props: LokiQueryEditorProps) {
       onChange={onChange}
       onRunQuery={onRunQuery}
       onBlur={onRunQuery}
-      history={[]}
+      history={history}
       data={data}
       placeholder="Enter a Loki query"
       data-testid={testIds.editor}

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryCodeEditor.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryCodeEditor.tsx
@@ -14,7 +14,17 @@ type Props = LokiQueryEditorProps & {
   showExplain: boolean;
 };
 
-export function LokiQueryCodeEditor({ query, datasource, range, onRunQuery, onChange, data, app, showExplain }: Props) {
+export function LokiQueryCodeEditor({
+  query,
+  datasource,
+  range,
+  onRunQuery,
+  onChange,
+  data,
+  app,
+  showExplain,
+  history,
+}: Props) {
   const styles = useStyles2(getStyles);
 
   // the inner QueryField works like this when a blur event happens:
@@ -35,7 +45,7 @@ export function LokiQueryCodeEditor({ query, datasource, range, onRunQuery, onCh
         onRunQuery={onRunQuery}
         onChange={onChange}
         onBlur={onBlur}
-        history={[]}
+        history={history}
         data={data}
         app={app}
         data-testid={testIds.editor}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes passing of history to Loki query editor input. We get history as a part of `QueryEditorProps`, so we only need to pass it to QueryField. Not sure why this was missing.

Keep in mind that retrieving history is currently only implemented in Explore, therefore it is only going to be visible in Explore. 

<img width="1001" alt="image" src="https://user-images.githubusercontent.com/30407135/196932201-3a272526-6538-40b0-9976-6d391b472979.png">

Moreover, this only fixes it in Monaco editor. I tried to fix it in Slate, but the issue is that with click, Slate by design doesn't trigger `onTypehead`.So considering that we are removing slate support and hat this feature didn't work in slate for years, I've decided to keep it simple and only fix passing of history to LokiQueryField. 

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/56465#issuecomment-1285262078

**Special notes for your reviewer**:

To test:
1. Run Loki data source `make devenv sources=loki`
2. Go to explore and choose loki data source
3. Choose code mode
4. Click into query input
5. You should see query history suggestions
