### PR TITLE
Explore: Fix filtering logs-data in table-display

### DIFF
--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -275,13 +275,13 @@ export class Explore extends React.PureComponent<Props, ExploreState> {
   }
 
   renderTablePanel(width: number) {
-    const { exploreId, datasourceInstance, timeZone } = this.props;
+    const { exploreId, timeZone } = this.props;
     return (
       <TableContainer
         ariaLabel={selectors.pages.Explore.General.table}
         width={width}
         exploreId={exploreId}
-        onCellFilterAdded={datasourceInstance?.modifyQuery ? this.onCellFilterAdded : undefined}
+        onCellFilterAdded={this.onCellFilterAdded}
         timeZone={timeZone}
       />
     );


### PR DESCRIPTION
when using mixed-datasources-mode, filtering data displayed in a table does not work correctly.

the reason is that `TableContainer.onCellFilterAdded` is configured based on whether `datasourceInstance.modifyQuery` exists or not, but that is not the real datasource instance, it's the mixed datasource instance, so it's always missing.

the solution is to just remove the check, and always call `this.onCellFilterAdded`. the reason is, the code will eventually call `this.onModifyQueries`, which will, finally, check whether the specific datasources have `modifyQuery` methods or not.

i'm not 100% sure if this is the best approach here, but the problem is, when we render the table, we do not have the correct datasources at hand, so we cannot just ask them whether they support modifyQueries. if you have a better idea, i'm open to any change.

NOTE: there is a smaller regression here. if your datasource does not support the `modifyQueries` method, then clicking on the [+]/[-] in the table will not do anything, but, it will trigger re-running the queries. in the versions before this change the queries were not run in that case.

how to test:
1. `make devenv sources=elastic`
2. go to explore-mode
3. choose the mixed datasource
4. "inside", choose the elastic datasource
5. switch `Metric` to `Raw Data`
6. find the `label` column in the table, and click [+] next to the value `val2`
7. verify that the `label:"val2"` was added to the `Query`, and also that now you only see `val2` in the label column.

(handles a part of https://github.com/grafana/grafana/issues/56314 )