### PR TITLE
Loki Monaco Editor: implement extracted label keys

### DIFF
--- a/public/app/plugins/datasource/loki/LanguageProvider.test.ts
+++ b/public/app/plugins/datasource/loki/LanguageProvider.test.ts
@@ -6,7 +6,7 @@ import { TypeaheadInput } from '@grafana/ui';
 import LanguageProvider, { LokiHistoryItem } from './LanguageProvider';
 import { LokiDatasource } from './datasource';
 import { createLokiDatasource, createMetadataRequest } from './mocks';
-import { extractLogParserFromDataFrame } from './responseUtils';
+import { extractLogParserFromDataFrame, extractLabelKeysFromDataFrame } from './responseUtils';
 import { LokiQueryType } from './types';
 
 jest.mock('./responseUtils');
@@ -302,10 +302,13 @@ describe('Query imports', () => {
 
   describe('getParserAndLabelKeys()', () => {
     let datasource: LokiDatasource, languageProvider: LanguageProvider;
-    const extractLogParserFromDataFrameMock = extractLogParserFromDataFrame as jest.Mock;
+    const extractLogParserFromDataFrameMock = jest.mocked(extractLogParserFromDataFrame);
+    const extractedLabelKeys = ['extracted', 'label'];
+
     beforeEach(() => {
       datasource = createLokiDatasource();
       languageProvider = new LanguageProvider(datasource);
+      jest.mocked(extractLabelKeysFromDataFrame).mockReturnValue(extractedLabelKeys);
     });
 
     it('identifies selectors with JSON parser data', async () => {
@@ -313,7 +316,7 @@ describe('Query imports', () => {
       extractLogParserFromDataFrameMock.mockReturnValueOnce({ hasLogfmt: false, hasJSON: true });
 
       expect(await languageProvider.getParserAndLabelKeys('{place="luna"}')).toEqual({
-        extractedLabelKeys: [],
+        extractedLabelKeys,
         hasJSON: true,
         hasLogfmt: false,
       });
@@ -324,7 +327,7 @@ describe('Query imports', () => {
       extractLogParserFromDataFrameMock.mockReturnValueOnce({ hasLogfmt: true, hasJSON: false });
 
       expect(await languageProvider.getParserAndLabelKeys('{place="luna"}')).toEqual({
-        extractedLabelKeys: [],
+        extractedLabelKeys,
         hasJSON: false,
         hasLogfmt: true,
       });

--- a/public/app/plugins/datasource/loki/LanguageProvider.ts
+++ b/public/app/plugins/datasource/loki/LanguageProvider.ts
@@ -12,7 +12,7 @@ import {
 } from 'app/plugins/datasource/prometheus/language_utils';
 
 import { LokiDatasource } from './datasource';
-import { extractLogParserFromDataFrame } from './responseUtils';
+import { extractLabelKeysFromDataFrame, extractLogParserFromDataFrame } from './responseUtils';
 import syntax, { FUNCTIONS, PIPE_PARSERS, PIPE_OPERATORS } from './syntax';
 import { LokiQuery, LokiQueryType } from './types';
 
@@ -474,7 +474,6 @@ export default class LokiLanguageProvider extends LanguageProvider {
 
     const { hasLogfmt, hasJSON } = extractLogParserFromDataFrame(series[0]);
 
-    // TODO: figure out extractedLabelKeys
-    return { extractedLabelKeys: [], hasJSON, hasLogfmt };
+    return { extractedLabelKeys: extractLabelKeysFromDataFrame(series[0]), hasJSON, hasLogfmt };
   }
 }

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.test.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.test.ts
@@ -30,7 +30,7 @@ const history = [
 const labelNames = ['place', 'source'];
 const labelValues = ['moon', 'luna', 'server\\1'];
 // Source is duplicated to test handling duplicated labels
-const extractedLabelKeys = ['extracted', 'label', 'source'];
+const extractedLabelKeys = ['extracted', 'place', 'source'];
 const otherLabels: Label[] = [
   {
     name: 'place',
@@ -103,8 +103,8 @@ const afterSelectorCompletions = [
     type: 'LINE_FILTER',
   },
   {
-    insertText: '| unwrap label',
-    label: 'unwrap label',
+    insertText: '| unwrap place',
+    label: 'unwrap place',
     type: 'LINE_FILTER',
   },
   {
@@ -222,6 +222,12 @@ describe('getCompletions', () => {
 
     expect(completions).toEqual([
       {
+        insertText: 'extracted',
+        label: 'extracted',
+        triggerOnInsert: false,
+        type: 'LABEL_NAME',
+      },
+      {
         insertText: 'place',
         label: 'place',
         triggerOnInsert: false,
@@ -230,18 +236,6 @@ describe('getCompletions', () => {
       {
         insertText: 'source',
         label: 'source',
-        triggerOnInsert: false,
-        type: 'LABEL_NAME',
-      },
-      {
-        insertText: 'extracted',
-        label: 'extracted',
-        triggerOnInsert: false,
-        type: 'LABEL_NAME',
-      },
-      {
-        insertText: 'label',
-        label: 'label',
         triggerOnInsert: false,
         type: 'LABEL_NAME',
       },

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.test.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.test.ts
@@ -98,12 +98,12 @@ const afterSelectorCompletions = [
   },
   {
     insertText: '| unwrap extracted',
-    label: 'unwrap extracted (detected)',
+    label: 'unwrap extracted',
     type: 'LINE_FILTER',
   },
   {
     insertText: '| unwrap label',
-    label: 'unwrap label (detected)',
+    label: 'unwrap label',
     type: 'LINE_FILTER',
   },
   {
@@ -229,13 +229,13 @@ describe('getCompletions', () => {
       },
       {
         insertText: 'extracted',
-        label: 'extracted (extracted)',
+        label: 'extracted',
         triggerOnInsert: false,
         type: 'LABEL_NAME',
       },
       {
         insertText: 'label',
-        label: 'label (extracted)',
+        label: 'label',
         triggerOnInsert: false,
         type: 'LABEL_NAME',
       },

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.test.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.test.ts
@@ -97,6 +97,16 @@ const afterSelectorCompletions = [
     type: 'PARSER',
   },
   {
+    insertText: '| extracted',
+    label: 'extracted (detected)',
+    type: 'LABEL_NAME',
+  },
+  {
+    insertText: '| label',
+    label: 'label (detected)',
+    type: 'LABEL_NAME',
+  },
+  {
     insertText: '| unwrap extracted',
     label: 'unwrap extracted (detected)',
     type: 'LINE_FILTER',

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.test.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.test.ts
@@ -97,16 +97,6 @@ const afterSelectorCompletions = [
     type: 'PARSER',
   },
   {
-    insertText: '| extracted',
-    label: 'extracted (detected)',
-    type: 'LABEL_NAME',
-  },
-  {
-    insertText: '| label',
-    label: 'label (detected)',
-    type: 'LABEL_NAME',
-  },
-  {
     insertText: '| unwrap extracted',
     label: 'unwrap extracted (detected)',
     type: 'LINE_FILTER',
@@ -239,13 +229,13 @@ describe('getCompletions', () => {
       },
       {
         insertText: 'extracted',
-        label: 'extracted (parsed)',
+        label: 'extracted (extracted)',
         triggerOnInsert: false,
         type: 'LABEL_NAME',
       },
       {
         insertText: 'label',
-        label: 'label (parsed)',
+        label: 'label (extracted)',
         triggerOnInsert: false,
         type: 'LABEL_NAME',
       },

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.test.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.test.ts
@@ -29,7 +29,8 @@ const history = [
 
 const labelNames = ['place', 'source'];
 const labelValues = ['moon', 'luna', 'server\\1'];
-const extractedLabelKeys = ['extracted', 'label'];
+// Source is duplicated to test handling duplicated labels
+const extractedLabelKeys = ['extracted', 'label', 'source'];
 const otherLabels: Label[] = [
   {
     name: 'place',
@@ -104,6 +105,11 @@ const afterSelectorCompletions = [
   {
     insertText: '| unwrap label',
     label: 'unwrap label',
+    type: 'LINE_FILTER',
+  },
+  {
+    insertText: '| unwrap source',
+    label: 'unwrap source',
     type: 'LINE_FILTER',
   },
   {

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
@@ -5,7 +5,7 @@ import { AGGREGATION_OPERATORS, RANGE_VEC_FUNCTIONS } from '../../../syntax';
 
 import { CompletionDataProvider } from './CompletionDataProvider';
 import { NeverCaseError } from './NeverCaseError';
-import { Situation, Label, getSituation } from './situation';
+import type { Situation, Label } from './situation';
 
 export type CompletionType =
   | 'HISTORY'
@@ -249,16 +249,9 @@ async function getLabelValuesForMetricCompletions(
 }
 
 export async function getCompletions(
-  query: string,
-  offset: number,
+  situation: Situation,
   dataProvider: CompletionDataProvider
 ): Promise<Completion[]> {
-  const situation = getSituation(query, offset);
-
-  if (!situation) {
-    return [];
-  }
-
   switch (situation.type) {
     case 'EMPTY':
     case 'AT_ROOT':

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
@@ -109,35 +109,6 @@ async function getAllHistoryCompletions(dataProvider: CompletionDataProvider): P
   }));
 }
 
-async function getLabelNamesForCompletions(
-  suffix: string,
-  triggerOnInsert: boolean,
-  addExtractedLabels: boolean,
-  otherLabels: Label[],
-  dataProvider: CompletionDataProvider
-): Promise<Completion[]> {
-  const labels = new Set<string>();
-
-  if (addExtractedLabels) {
-    const { extractedLabelKeys } = await dataProvider.getParserAndLabelKeys(otherLabels);
-    extractedLabelKeys.forEach((label) => {
-      labels.add(label);
-    });
-  } else {
-    const labelNames = await dataProvider.getLabelNames(otherLabels);
-    labelNames.forEach((label) => {
-      labels.add(label);
-    });
-  }
-
-  return Array.from(labels).map((text) => ({
-    type: 'LABEL_NAME',
-    label: text,
-    insertText: `${text}${suffix}`,
-    triggerOnInsert,
-  }));
-}
-
 async function getLabelNamesForSelectorCompletions(
   otherLabels: Label[],
   dataProvider: CompletionDataProvider

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
@@ -5,7 +5,7 @@ import { AGGREGATION_OPERATORS, RANGE_VEC_FUNCTIONS } from '../../../syntax';
 
 import { CompletionDataProvider } from './CompletionDataProvider';
 import { NeverCaseError } from './NeverCaseError';
-import type { Situation, Label } from './situation';
+import { Situation, Label, getSituation } from './situation';
 
 export type CompletionType =
   | 'HISTORY'
@@ -249,9 +249,16 @@ async function getLabelValuesForMetricCompletions(
 }
 
 export async function getCompletions(
-  situation: Situation,
+  query: string,
+  offset: number,
   dataProvider: CompletionDataProvider
 ): Promise<Completion[]> {
+  const situation = getSituation(query, offset);
+
+  if (!situation) {
+    return [];
+  }
+
   switch (situation.type) {
     case 'EMPTY':
     case 'AT_ROOT':

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
@@ -129,7 +129,7 @@ async function getLabelNamesForCompletions(
     extractedLabelKeys.forEach((key) => {
       result.push({
         type: 'LABEL_NAME',
-        label: `${key} (parsed)`,
+        label: `${key} (extracted)`,
         insertText: `${key}${suffix}`,
         triggerOnInsert,
       });
@@ -203,14 +203,6 @@ async function getAfterSelectorCompletions(
 
   extractedLabelKeys.forEach((key) => {
     completions.push({
-      type: 'LABEL_NAME',
-      label: `${key} (detected)`,
-      insertText: `${prefix}${key}`,
-    });
-  });
-
-  extractedLabelKeys.forEach((key) => {
-    completions.push({
       type: 'LINE_FILTER',
       label: `unwrap ${key} (detected)`,
       insertText: `${prefix}unwrap ${key}`,
@@ -261,6 +253,7 @@ export async function getCompletions(
   situation: Situation,
   dataProvider: CompletionDataProvider
 ): Promise<Completion[]> {
+  console.log(situation.type);
   switch (situation.type) {
     case 'EMPTY':
     case 'AT_ROOT':

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
@@ -203,6 +203,14 @@ async function getAfterSelectorCompletions(
 
   extractedLabelKeys.forEach((key) => {
     completions.push({
+      type: 'LABEL_NAME',
+      label: `${key} (detected)`,
+      insertText: `${prefix}${key}`,
+    });
+  });
+
+  extractedLabelKeys.forEach((key) => {
+    completions.push({
       type: 'LINE_FILTER',
       label: `unwrap ${key} (detected)`,
       insertText: `${prefix}unwrap ${key}`,

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
@@ -253,7 +253,6 @@ export async function getCompletions(
   situation: Situation,
   dataProvider: CompletionDataProvider
 ): Promise<Completion[]> {
-  console.log(situation.type);
   switch (situation.type) {
     case 'EMPTY':
     case 'AT_ROOT':

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
@@ -118,14 +118,14 @@ async function getLabelNamesForCompletions(
 ): Promise<Completion[]> {
   const labels = new Set<string>();
 
-  const labelNames = await dataProvider.getLabelNames(otherLabels);
-  labelNames.forEach((label) => {
-    labels.add(label);
-  });
-
   if (addExtractedLabels) {
     const { extractedLabelKeys } = await dataProvider.getParserAndLabelKeys(otherLabels);
     extractedLabelKeys.forEach((label) => {
+      labels.add(label);
+    });
+  } else {
+    const labelNames = await dataProvider.getLabelNames(otherLabels);
+    labelNames.forEach((label) => {
       labels.add(label);
     });
   }
@@ -142,14 +142,28 @@ async function getLabelNamesForSelectorCompletions(
   otherLabels: Label[],
   dataProvider: CompletionDataProvider
 ): Promise<Completion[]> {
-  return getLabelNamesForCompletions('=', true, false, otherLabels, dataProvider);
+  const labelNames = await dataProvider.getLabelNames(otherLabels);
+
+  return labelNames.map((label) => ({
+    type: 'LABEL_NAME',
+    label,
+    insertText: `${label}=`,
+    triggerOnInsert: true,
+  }));
 }
 
 async function getInGroupingCompletions(
   otherLabels: Label[],
   dataProvider: CompletionDataProvider
 ): Promise<Completion[]> {
-  return getLabelNamesForCompletions('', false, true, otherLabels, dataProvider);
+  const { extractedLabelKeys } = await dataProvider.getParserAndLabelKeys(otherLabels);
+
+  return extractedLabelKeys.map((label) => ({
+    type: 'LABEL_NAME',
+    label,
+    insertText: label,
+    triggerOnInsert: false,
+  }));
 }
 
 const PARSERS = ['json', 'logfmt', 'pattern', 'regexp', 'unpack'];

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
@@ -129,7 +129,7 @@ async function getLabelNamesForCompletions(
     extractedLabelKeys.forEach((key) => {
       result.push({
         type: 'LABEL_NAME',
-        label: `${key} (extracted)`,
+        label: `${key}`,
         insertText: `${key}${suffix}`,
         triggerOnInsert,
       });
@@ -204,7 +204,7 @@ async function getAfterSelectorCompletions(
   extractedLabelKeys.forEach((key) => {
     completions.push({
       type: 'LINE_FILTER',
-      label: `unwrap ${key} (detected)`,
+      label: `unwrap ${key}`,
       insertText: `${prefix}unwrap ${key}`,
     });
   });

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
@@ -116,27 +116,26 @@ async function getLabelNamesForCompletions(
   otherLabels: Label[],
   dataProvider: CompletionDataProvider
 ): Promise<Completion[]> {
+  const labels = new Set<string>();
+
   const labelNames = await dataProvider.getLabelNames(otherLabels);
-  const result: Completion[] = labelNames.map((text) => ({
+  labelNames.forEach((label) => {
+    labels.add(label);
+  });
+
+  if (addExtractedLabels) {
+    const { extractedLabelKeys } = await dataProvider.getParserAndLabelKeys(otherLabels);
+    extractedLabelKeys.forEach((label) => {
+      labels.add(label);
+    });
+  }
+
+  return Array.from(labels).map((text) => ({
     type: 'LABEL_NAME',
     label: text,
     insertText: `${text}${suffix}`,
     triggerOnInsert,
   }));
-
-  if (addExtractedLabels) {
-    const { extractedLabelKeys } = await dataProvider.getParserAndLabelKeys(otherLabels);
-    extractedLabelKeys.forEach((key) => {
-      result.push({
-        type: 'LABEL_NAME',
-        label: `${key}`,
-        insertText: `${key}${suffix}`,
-        triggerOnInsert,
-      });
-    });
-  }
-
-  return result;
 }
 
 async function getLabelNamesForSelectorCompletions(

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/index.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/index.ts
@@ -3,7 +3,6 @@ import type { Monaco, monacoTypes } from '@grafana/ui';
 import { CompletionDataProvider } from './CompletionDataProvider';
 import { NeverCaseError } from './NeverCaseError';
 import { getCompletions, CompletionType } from './completions';
-import { getSituation } from './situation';
 
 // from: monacoTypes.languages.CompletionItemInsertTextRule.InsertAsSnippet
 const INSERT_AS_SNIPPET_ENUM_VALUE = 4;
@@ -77,9 +76,8 @@ export function getCompletionProvider(
       column: position.column,
       lineNumber: position.lineNumber,
     };
-    const offset = model.getOffsetAt(positionClone);
-    const situation = getSituation(model.getValue(), offset);
-    const completionsPromise = situation != null ? getCompletions(situation, dataProvider) : Promise.resolve([]);
+    const completionsPromise =
+      getCompletions(model.getValue(), model.getOffsetAt(positionClone), dataProvider) || Promise.resolve([]);
     return completionsPromise.then((items) => {
       // monaco by default alphabetically orders the items.
       // to stop it, we use a number-as-string sortkey,

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/index.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/index.ts
@@ -3,6 +3,7 @@ import type { Monaco, monacoTypes } from '@grafana/ui';
 import { CompletionDataProvider } from './CompletionDataProvider';
 import { NeverCaseError } from './NeverCaseError';
 import { getCompletions, CompletionType } from './completions';
+import { getSituation } from './situation';
 
 // from: monacoTypes.languages.CompletionItemInsertTextRule.InsertAsSnippet
 const INSERT_AS_SNIPPET_ENUM_VALUE = 4;
@@ -76,8 +77,9 @@ export function getCompletionProvider(
       column: position.column,
       lineNumber: position.lineNumber,
     };
-    const completionsPromise =
-      getCompletions(model.getValue(), model.getOffsetAt(positionClone), dataProvider) || Promise.resolve([]);
+    const offset = model.getOffsetAt(positionClone);
+    const situation = getSituation(model.getValue(), offset);
+    const completionsPromise = situation != null ? getCompletions(situation, dataProvider) : Promise.resolve([]);
     return completionsPromise.then((items) => {
       // monaco by default alphabetically orders the items.
       // to stop it, we use a number-as-string sortkey,

--- a/public/app/plugins/datasource/loki/responseUtils.test.ts
+++ b/public/app/plugins/datasource/loki/responseUtils.test.ts
@@ -100,7 +100,7 @@ describe('extractLabelKeysFromDataFrame', () => {
     input.fields[1].values = new ArrayVector([]);
     expect(extractLabelKeysFromDataFrame(input)).toEqual([]);
   });
-  it('returns empty by default', () => {
+  it('extracts label keys', () => {
     const input = cloneDeep(frame);
     expect(extractLabelKeysFromDataFrame(input)).toEqual(['level']);
   });

--- a/public/app/plugins/datasource/loki/responseUtils.test.ts
+++ b/public/app/plugins/datasource/loki/responseUtils.test.ts
@@ -2,7 +2,13 @@ import { cloneDeep } from 'lodash';
 
 import { ArrayVector, DataFrame, FieldType } from '@grafana/data';
 
-import { dataFrameHasLevelLabel, dataFrameHasLokiError, extractLevelLikeLabelFromDataFrame } from './responseUtils';
+import {
+  dataFrameHasLevelLabel,
+  dataFrameHasLokiError,
+  extractLevelLikeLabelFromDataFrame,
+  extractLogParserFromDataFrame,
+  extractLabelKeysFromDataFrame,
+} from './responseUtils';
 
 const frame: DataFrame = {
   length: 1,
@@ -68,5 +74,34 @@ describe('extractLevelLikeLabelFromDataFrame', () => {
     const input = cloneDeep(frame);
     input.fields[1].values = new ArrayVector([{ foo: 'info' }]);
     expect(extractLevelLikeLabelFromDataFrame(input)).toBe(null);
+  });
+});
+
+describe('extractLogParserFromDataFrame', () => {
+  it('returns false by default', () => {
+    const input = cloneDeep(frame);
+    expect(extractLogParserFromDataFrame(input)).toEqual({ hasJSON: false, hasLogfmt: false });
+  });
+  it('identifies JSON', () => {
+    const input = cloneDeep(frame);
+    input.fields[2].values = new ArrayVector(['{"a":"b"}']);
+    expect(extractLogParserFromDataFrame(input)).toEqual({ hasJSON: true, hasLogfmt: false });
+  });
+  it('identifies logfmt', () => {
+    const input = cloneDeep(frame);
+    input.fields[2].values = new ArrayVector(['a=b']);
+    expect(extractLogParserFromDataFrame(input)).toEqual({ hasJSON: false, hasLogfmt: true });
+  });
+});
+
+describe('extractLabelKeysFromDataFrame', () => {
+  it('returns empty by default', () => {
+    const input = cloneDeep(frame);
+    input.fields[1].values = new ArrayVector([]);
+    expect(extractLabelKeysFromDataFrame(input)).toEqual([]);
+  });
+  it('returns empty by default', () => {
+    const input = cloneDeep(frame);
+    expect(extractLabelKeysFromDataFrame(input)).toEqual(['level']);
   });
 });

--- a/public/app/plugins/datasource/loki/responseUtils.ts
+++ b/public/app/plugins/datasource/loki/responseUtils.ts
@@ -36,6 +36,17 @@ export function extractLogParserFromDataFrame(frame: DataFrame): { hasLogfmt: bo
   return { hasLogfmt, hasJSON };
 }
 
+export function extractLabelKeysFromDataFrame(frame: DataFrame): string[] {
+  const labelsArray: Array<{ [key: string]: string }> | undefined =
+    frame?.fields?.find((field) => field.name === 'labels')?.values.toArray() ?? [];
+
+  if (!labelsArray?.length) {
+    return [];
+  }
+
+  return Object.keys(labelsArray[0]);
+}
+
 export function extractHasErrorLabelFromDataFrame(frame: DataFrame): boolean {
   const labelField = frame.fields.find((field) => field.name === 'labels' && field.type === FieldType.other);
   if (labelField == null) {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fills up the missing implementation of extracted label keys, and additionally adds as labels as suggestions.

**Which issue(s) this PR fixes**:

Closes https://github.com/grafana/grafana/issues/44985

**Special notes for your reviewer**:

![imagen](https://user-images.githubusercontent.com/1069378/197002931-5d9484f8-a3ec-4e64-ad11-bd7033381954.png)

A follow up PR will aim to polish the usage of extracted label keys, by suggesting them in more appropriate places based on the current input.