### PR TITLE
Alerting: Remove the alert manager selection from the data source configuration

### DIFF
--- a/packages/grafana-ui/src/components/DataSourceSettings/AlertingSettings.test.tsx
+++ b/packages/grafana-ui/src/components/DataSourceSettings/AlertingSettings.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { AlertingSettings } from '@grafana/ui';
+
+import { Props, AlertingConfig } from './AlertingSettings';
+
+const setup = (propOverrides?: object) => {
+  const onOptionsChange = jest.fn();
+  const props: Props<AlertingConfig> = {
+    options: {
+      id: 4,
+      uid: 'x',
+      orgId: 1,
+      name: 'test',
+      type: 'test',
+      typeName: 'test',
+      typeLogoUrl: '',
+      access: 'direct',
+      url: 'http://localhost:8086',
+      user: 'grafana',
+      database: 'site',
+      basicAuth: false,
+      basicAuthUser: '',
+      withCredentials: false,
+      isDefault: false,
+      jsonData: {},
+      secureJsonData: {
+        password: true,
+      },
+      secureJsonFields: {},
+      readOnly: true,
+    },
+    onOptionsChange,
+    ...propOverrides,
+  };
+
+  render(<AlertingSettings {...props} />);
+};
+
+describe('Alerting Settings', () => {
+  //see https://github.com/grafana/grafana/issues/51417
+  it('should not show the option to select alertmanager data sources', () => {
+    setup();
+    expect(screen.queryByText('Alertmanager data source')).toBeNull();
+  });
+
+  it('should show the option to Manage alerts via Alerting UI', () => {
+    setup();
+    expect(screen.getByText('Manage alerts via Alerting UI')).toBeVisible();
+  });
+});

--- a/packages/grafana-ui/src/components/DataSourceSettings/AlertingSettings.test.tsx
+++ b/packages/grafana-ui/src/components/DataSourceSettings/AlertingSettings.test.tsx
@@ -5,7 +5,7 @@ import { AlertingSettings } from '@grafana/ui';
 
 import { Props, AlertingConfig } from './AlertingSettings';
 
-const setup = (propOverrides?: object) => {
+const setup = () => {
   const onOptionsChange = jest.fn();
   const props: Props<AlertingConfig> = {
     options: {
@@ -32,7 +32,6 @@ const setup = (propOverrides?: object) => {
       readOnly: true,
     },
     onOptionsChange,
-    ...propOverrides,
   };
 
   render(<AlertingSettings {...props} />);

--- a/packages/grafana-ui/src/components/DataSourceSettings/AlertingSettings.tsx
+++ b/packages/grafana-ui/src/components/DataSourceSettings/AlertingSettings.tsx
@@ -5,10 +5,10 @@ import { DataSourceJsonData, DataSourcePluginOptionsEditorProps } from '@grafana
 import { InlineSwitch } from '../../components/Switch/Switch';
 import { InlineField } from '../Forms/InlineField';
 
-interface Props<T extends DataSourceJsonData>
+export interface Props<T extends DataSourceJsonData>
   extends Pick<DataSourcePluginOptionsEditorProps<T>, 'options' | 'onOptionsChange'> {}
 
-interface AlertingConfig extends DataSourceJsonData {
+export interface AlertingConfig extends DataSourceJsonData {
   manageAlerts?: boolean;
 }
 

--- a/packages/grafana-ui/src/components/DataSourceSettings/AlertingSettings.tsx
+++ b/packages/grafana-ui/src/components/DataSourceSettings/AlertingSettings.tsx
@@ -1,37 +1,18 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 
-import { DataSourceInstanceSettings, DataSourceJsonData, DataSourcePluginOptionsEditorProps } from '@grafana/data';
+import { DataSourceJsonData, DataSourcePluginOptionsEditorProps } from '@grafana/data';
 
 import { InlineSwitch } from '../../components/Switch/Switch';
 import { InlineField } from '../Forms/InlineField';
-import { InlineFieldRow } from '../Forms/InlineFieldRow';
-import { Select } from '../Select/Select';
 
 interface Props<T extends DataSourceJsonData>
-  extends Pick<DataSourcePluginOptionsEditorProps<T>, 'options' | 'onOptionsChange'> {
-  alertmanagerDataSources: Array<DataSourceInstanceSettings<DataSourceJsonData>>;
-}
+  extends Pick<DataSourcePluginOptionsEditorProps<T>, 'options' | 'onOptionsChange'> {}
 
 interface AlertingConfig extends DataSourceJsonData {
   manageAlerts?: boolean;
 }
 
-export function AlertingSettings<T extends AlertingConfig>({
-  alertmanagerDataSources,
-  options,
-  onOptionsChange,
-}: Props<T>): JSX.Element {
-  const alertmanagerOptions = useMemo(
-    () =>
-      alertmanagerDataSources.map((ds) => ({
-        label: ds.name,
-        value: ds.uid,
-        imgUrl: ds.meta.info.logos.small,
-        meta: ds.meta,
-      })),
-    [alertmanagerDataSources]
-  );
-
+export function AlertingSettings<T extends AlertingConfig>({ options, onOptionsChange }: Props<T>): JSX.Element {
   return (
     <>
       <h3 className="page-heading">Alerting</h3>
@@ -51,22 +32,6 @@ export function AlertingSettings<T extends AlertingConfig>({
             </InlineField>
           </div>
         </div>
-        <InlineFieldRow>
-          <InlineField
-            tooltip="The alertmanager that manages alerts for this data source"
-            label="Alertmanager data source"
-            labelWidth={26}
-          >
-            <Select
-              width={29}
-              options={alertmanagerOptions}
-              onChange={(value) =>
-                onOptionsChange({ ...options, jsonData: { ...options.jsonData, alertmanagerUid: value?.value } })
-              }
-              value={options.jsonData.alertmanagerUid}
-            />
-          </InlineField>
-        </InlineFieldRow>
       </div>
     </>
   );

--- a/public/app/plugins/datasource/loki/configuration/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/loki/configuration/ConfigEditor.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 
 import { DataSourcePluginOptionsEditorProps, DataSourceSettings } from '@grafana/data';
 import { AlertingSettings, DataSourceHttpSettings } from '@grafana/ui';
-import { getAllAlertmanagerDataSources } from 'app/features/alerting/unified/utils/alertmanager';
 
 import { LokiOptions } from '../types';
 
@@ -28,7 +27,6 @@ const setDerivedFields = makeJsonUpdater('derivedFields');
 
 export const ConfigEditor = (props: Props) => {
   const { options, onOptionsChange } = props;
-  const alertmanagers = getAllAlertmanagerDataSources();
 
   return (
     <>
@@ -39,11 +37,7 @@ export const ConfigEditor = (props: Props) => {
         onChange={onOptionsChange}
       />
 
-      <AlertingSettings<LokiOptions>
-        alertmanagerDataSources={alertmanagers}
-        options={options}
-        onOptionsChange={onOptionsChange}
-      />
+      <AlertingSettings<LokiOptions> options={options} onOptionsChange={onOptionsChange} />
 
       <div className="gf-form-group">
         <div className="gf-form-inline">

--- a/public/app/plugins/datasource/prometheus/configuration/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/configuration/ConfigEditor.tsx
@@ -4,7 +4,6 @@ import { SIGV4ConnectionConfig } from '@grafana/aws-sdk';
 import { DataSourcePluginOptionsEditorProps, DataSourceSettings } from '@grafana/data';
 import { AlertingSettings, DataSourceHttpSettings, Alert } from '@grafana/ui';
 import { config } from 'app/core/config';
-import { getAllAlertmanagerDataSources } from 'app/features/alerting/unified/utils/alertmanager';
 
 import { PromOptions } from '../types';
 
@@ -15,7 +14,6 @@ import { PromSettings } from './PromSettings';
 export type Props = DataSourcePluginOptionsEditorProps<PromOptions>;
 export const ConfigEditor = (props: Props) => {
   const { options, onOptionsChange } = props;
-  const alertmanagers = getAllAlertmanagerDataSources();
   // use ref so this is evaluated only first time it renders and the select does not disappear suddenly.
   const showAccessOptions = useRef(props.options.access === 'direct');
 
@@ -45,11 +43,7 @@ export const ConfigEditor = (props: Props) => {
         renderSigV4Editor={<SIGV4ConnectionConfig {...props}></SIGV4ConnectionConfig>}
       />
 
-      <AlertingSettings<PromOptions>
-        alertmanagerDataSources={alertmanagers}
-        options={options}
-        onOptionsChange={onOptionsChange}
-      />
+      <AlertingSettings<PromOptions> options={options} onOptionsChange={onOptionsChange} />
 
       <PromSettings options={options} onOptionsChange={onOptionsChange} />
     </>


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes the option to bind an alert manager to a data source.

We want to remove it as the configuration in the UI may not reflect correctly the configuration of the data source which may be a source of confusion and problems for users

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/51417

**Before:**

<img width="826" alt="image" src="https://user-images.githubusercontent.com/6271380/197020991-9c0c1f86-e9ab-45c4-af84-a01d55cfa3de.png">

**After:** 

<img width="802" alt="image" src="https://user-images.githubusercontent.com/6271380/197021036-a60778c6-e539-4a58-9ec1-9ddc6653f65f.png">

