### PR TITLE
Number formatting: Strip trailing zeros after decimal point when decimals=auto

### DIFF
--- a/packages/grafana-data/src/field/displayProcessor.test.ts
+++ b/packages/grafana-data/src/field/displayProcessor.test.ts
@@ -333,6 +333,13 @@ describe('Format value', () => {
     expect(disp.suffix).toEqual(' Mil');
   });
 
+  it('with value 15000000 and unit locale', () => {
+    const value = 1500000;
+    const instance = getDisplayProcessorFromConfig({ decimals: null, unit: 'locale' });
+    const disp = instance(value);
+    expect(disp.text).toEqual('1,500,000');
+  });
+
   it('with value 128000000 and unit bytes', () => {
     const value = 1280000125;
     const instance = getDisplayProcessorFromConfig({ decimals: null, unit: 'bytes' });

--- a/packages/grafana-data/src/field/displayProcessor.test.ts
+++ b/packages/grafana-data/src/field/displayProcessor.test.ts
@@ -305,7 +305,7 @@ describe('Format value', () => {
     const value = 1200;
     const instance = getDisplayProcessorFromConfig({ decimals: null, unit: 'short' });
     const disp = instance(value);
-    expect(disp.text).toEqual('1.20');
+    expect(disp.text).toEqual('1.2');
     expect(disp.suffix).toEqual(' K');
   });
 
@@ -329,7 +329,7 @@ describe('Format value', () => {
     const value = 1500000;
     const instance = getDisplayProcessorFromConfig({ decimals: null, unit: 'short' });
     const disp = instance(value);
-    expect(disp.text).toEqual('1.50');
+    expect(disp.text).toEqual('1.5');
     expect(disp.suffix).toEqual(' Mil');
   });
 

--- a/packages/grafana-data/src/field/displayProcessor.ts
+++ b/packages/grafana-data/src/field/displayProcessor.ts
@@ -72,6 +72,9 @@ export function getDisplayProcessor(options?: DisplayProcessorOptions): DisplayP
     unit = 'string';
   }
 
+  const hasBoolUnit = unit === 'bool';
+  const isNumType = field.type === FieldType.number;
+
   const formatFunc = getValueFormat(unit || 'none');
   const scaleFunc = getScaleCalculator(field, options.theme);
 
@@ -117,7 +120,7 @@ export function getDisplayProcessor(options?: DisplayProcessorOptions): DisplayP
         // this is needed because we may have determined the minimum required `decimals` for y tick increments based on
         // e.g. 'seconds' field unit (0.15s, 0.20s, 0.25s), but then formatFunc decided to return milli or nanos (150, 200, 250)
         // so we end up with excess precision: 150.00, 200.00, 250.00
-        if (field.type === FieldType.number && config.decimals == null) {
+        if (!hasDateUnit && !hasBoolUnit && isNumType && config.decimals == null) {
           v.text = +v.text + '';
         }
 

--- a/packages/grafana-data/src/field/displayProcessor.ts
+++ b/packages/grafana-data/src/field/displayProcessor.ts
@@ -74,7 +74,9 @@ export function getDisplayProcessor(options?: DisplayProcessorOptions): DisplayP
 
   const hasBoolUnit = unit === 'bool';
   const isNumType = field.type === FieldType.number;
-  const shouldTrimTrailingDecimalZeros = !hasDateUnit && !hasBoolUnit && isNumType && config.decimals == null;
+  const isLocaleFormat = unit === 'locale';
+  const shouldTrimTrailingDecimalZeros =
+    !hasDateUnit && !hasBoolUnit && !isLocaleFormat && isNumType && config.decimals == null;
 
   const formatFunc = getValueFormat(unit || 'none');
   const scaleFunc = getScaleCalculator(field, options.theme);

--- a/packages/grafana-data/src/field/displayProcessor.ts
+++ b/packages/grafana-data/src/field/displayProcessor.ts
@@ -74,6 +74,7 @@ export function getDisplayProcessor(options?: DisplayProcessorOptions): DisplayP
 
   const hasBoolUnit = unit === 'bool';
   const isNumType = field.type === FieldType.number;
+  const shouldTrimTrailingDecimalZeros = !hasDateUnit && !hasBoolUnit && isNumType && config.decimals == null;
 
   const formatFunc = getValueFormat(unit || 'none');
   const scaleFunc = getScaleCalculator(field, options.theme);
@@ -120,7 +121,7 @@ export function getDisplayProcessor(options?: DisplayProcessorOptions): DisplayP
         // this is needed because we may have determined the minimum required `decimals` for y tick increments based on
         // e.g. 'seconds' field unit (0.15s, 0.20s, 0.25s), but then formatFunc decided to return milli or nanos (150, 200, 250)
         // so we end up with excess precision: 150.00, 200.00, 250.00
-        if (!hasDateUnit && !hasBoolUnit && isNumType && config.decimals == null) {
+        if (shouldTrimTrailingDecimalZeros) {
           v.text = +v.text + '';
         }
 

--- a/packages/grafana-data/src/field/displayProcessor.ts
+++ b/packages/grafana-data/src/field/displayProcessor.ts
@@ -109,9 +109,18 @@ export function getDisplayProcessor(options?: DisplayProcessorOptions): DisplayP
       }
     }
 
-    if (!isNaN(numeric)) {
+    if (!Number.isNaN(numeric)) {
       if (text == null && !isBoolean(value)) {
         const v = formatFunc(numeric, decimals ?? config.decimals, null, options.timeZone, showMs);
+
+        // if no explicit decimals config, we strip trailing zeros e.g. 60.00 -> 60
+        // this is needed because we may have determined the minimum required `decimals` for y tick increments based on
+        // e.g. 'seconds' field unit (0.15s, 0.20s, 0.25s), but then formatFunc decided to return milli or nanos (150, 200, 250)
+        // so we end up with excess precision: 150.00, 200.00, 250.00
+        if (field.type === FieldType.number && config.decimals == null) {
+          v.text = +v.text + '';
+        }
+
         text = v.text;
         suffix = v.suffix;
         prefix = v.prefix;


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/57337

this technically fixes the original complaint that caused us to recommend decimals=0 (see image in the linked issue). additional context: https://raintank-corp.slack.com/archives/C036J5B39/p1666251746227509

i don't believe that it's logically possible to force decimals to be 0 and expect never to lose precision (imagine a case when min=0.0000000235s an max=0.00134678s. you'd have to switch to nano, femto or attosecond units to have any hope of rendering whole integers without decimals, and/or rounding to some unspecified precision). additional complications to this are mentioned in https://github.com/grafana/grafana/issues/57337#issuecomment-1285488416

this situation is a side-effect of using the displayProcessor for auto-formatting y ticks: https://github.com/grafana/grafana/pull/52912. unfortunately this slightly changes the way that `displayProcessor` works. the default is `.toPrecision(3)`, which renders `1.50 Mil` will now render `1.5 Mil`. it will still correctly render `1.51 Mil` because we're not rounding here, we're just stripping trailing zeros. the alternative is to gate this on any pre-determined `decimals` also being passed down, but this is a pretty :exploding_head: proxy for "are we using this to determine y tick rendering", which feels waaay too specific.

EDIT: re-targeted for 9.3.0 and removed 9.2.x backport to avoid subtle behavior changes in a patch release