### PR TITLE
Chore: Add `last` downsampling function to Resample expression

### DIFF
--- a/pkg/expr/mathexp/resample.go
+++ b/pkg/expr/mathexp/resample.go
@@ -54,6 +54,8 @@ func (s Series) Resample(refID string, interval time.Duration, downsampler strin
 			default:
 				return s, fmt.Errorf("upsampling %v not implemented", upsampler)
 			}
+		} else if len(vals) == 1 {
+			value = vals[0]
 		} else { // downsampling
 			fVec := data.NewField("", s.GetLabels(), vals)
 			ff := Float64Field(*fVec)
@@ -67,6 +69,8 @@ func (s Series) Resample(refID string, interval time.Duration, downsampler strin
 				tmp = Min(&ff)
 			case "max":
 				tmp = Max(&ff)
+			case "last":
+				tmp = Last(&ff)
 			default:
 				return s, fmt.Errorf("downsampling %v not implemented", downsampler)
 			}

--- a/pkg/expr/mathexp/resample_test.go
+++ b/pkg/expr/mathexp/resample_test.go
@@ -245,6 +245,48 @@ func TestResampleSeries(t *testing.T) {
 				time.Unix(10, 0), nil,
 			}),
 		},
+		{
+			name:        "resample series: downsampling (last / pad )",
+			interval:    time.Second * 3,
+			downsampler: "last",
+			upsampler:   "pad",
+			timeRange: backend.TimeRange{
+				From: time.Unix(0, 0),
+				To:   time.Unix(11, 0),
+			},
+			seriesToResample: makeSeries("", nil, tp{
+				time.Unix(0, 0), float64Pointer(0),
+			}, tp{
+				time.Unix(1, 0), float64Pointer(1),
+			}, tp{
+				time.Unix(2, 0), float64Pointer(3),
+			}, tp{
+				time.Unix(3, 0), float64Pointer(1),
+			}, tp{
+				time.Unix(4, 0), float64Pointer(1),
+			}, tp{
+				time.Unix(5, 0), float64Pointer(1),
+			}, tp{
+				time.Unix(6, 0), float64Pointer(0),
+			}, tp{
+				time.Unix(7, 0), float64Pointer(1),
+			}, tp{
+				time.Unix(8, 0), float64Pointer(1),
+			}, tp{
+				time.Unix(9, 0), float64Pointer(1),
+			}, tp{
+				time.Unix(10, 0), float64Pointer(1),
+			}),
+			series: makeSeries("", nil, tp{
+				time.Unix(0, 0), float64Pointer(0),
+			}, tp{
+				time.Unix(3, 0), float64Pointer(3),
+			}, tp{
+				time.Unix(6, 0), float64Pointer(0),
+			}, tp{
+				time.Unix(9, 0), float64Pointer(1),
+			}),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/expr/mathexp/resample_test.go
+++ b/pkg/expr/mathexp/resample_test.go
@@ -257,34 +257,24 @@ func TestResampleSeries(t *testing.T) {
 			seriesToResample: makeSeries("", nil, tp{
 				time.Unix(0, 0), float64Pointer(0),
 			}, tp{
-				time.Unix(1, 0), float64Pointer(1),
+				time.Unix(2, 0), float64Pointer(2),
 			}, tp{
-				time.Unix(2, 0), float64Pointer(3),
+				time.Unix(4, 0), float64Pointer(3),
 			}, tp{
-				time.Unix(3, 0), float64Pointer(1),
+				time.Unix(6, 0), float64Pointer(4),
 			}, tp{
-				time.Unix(4, 0), float64Pointer(1),
-			}, tp{
-				time.Unix(5, 0), float64Pointer(1),
-			}, tp{
-				time.Unix(6, 0), float64Pointer(0),
-			}, tp{
-				time.Unix(7, 0), float64Pointer(1),
-			}, tp{
-				time.Unix(8, 0), float64Pointer(1),
-			}, tp{
-				time.Unix(9, 0), float64Pointer(1),
+				time.Unix(8, 0), float64Pointer(0),
 			}, tp{
 				time.Unix(10, 0), float64Pointer(1),
 			}),
 			series: makeSeries("", nil, tp{
 				time.Unix(0, 0), float64Pointer(0),
 			}, tp{
-				time.Unix(3, 0), float64Pointer(3),
+				time.Unix(3, 0), float64Pointer(2),
 			}, tp{
-				time.Unix(6, 0), float64Pointer(0),
+				time.Unix(6, 0), float64Pointer(4),
 			}, tp{
-				time.Unix(9, 0), float64Pointer(1),
+				time.Unix(9, 0), float64Pointer(0),
 			}),
 		},
 	}

--- a/public/app/features/expressions/types.ts
+++ b/public/app/features/expressions/types.ts
@@ -75,6 +75,7 @@ export const reducerMode: Array<SelectableValue<ReducerMode>> = [
 ];
 
 export const downsamplingTypes: Array<SelectableValue<string>> = [
+  { value: ReducerID.last, label: 'Last', description: 'Fill with the last value' },
   { value: ReducerID.min, label: 'Min', description: 'Fill with the minimum value' },
   { value: ReducerID.max, label: 'Max', description: 'Fill with the maximum value' },
   { value: ReducerID.mean, label: 'Mean', description: 'Fill with the average value' },


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
The Resample server-side expression supports all down-sampling functions but `last`. This PR adds support for that function.


**Which issue(s) this PR fixes**:
Related to https://github.com/grafana/grafana/pull/57318