### PR TITLE
Auth: Write the redirect cookie if denied - do not write a blank redirect

### DIFF
--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -64,15 +64,13 @@ func writeRedirectCookie(c *models.ReqContext) {
 		redirectTo = setting.AppSubUrl + c.Req.RequestURI
 	}
 
-	if redirectTo != "/" {
-		if setting.AppSubUrl != "" && !strings.HasPrefix(redirectTo, setting.AppSubUrl) {
-			redirectTo = setting.AppSubUrl + c.Req.RequestURI
-		}
-
-		// remove any forceLogin=true params
-		redirectTo = removeForceLoginParams(redirectTo)
-		cookies.WriteCookie(c.Resp, "redirect_to", url.QueryEscape(redirectTo), 0, nil)
+	if redirectTo == "/" {
+		return
 	}
+
+	// remove any forceLogin=true params
+	redirectTo = removeForceLoginParams(redirectTo)
+	cookies.WriteCookie(c.Resp, "redirect_to", url.QueryEscape(redirectTo), 0, nil)
 }
 
 var forceLoginParamsRegexp = regexp.MustCompile(`&?forceLogin=true`)

--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -64,10 +64,15 @@ func writeRedirectCookie(c *models.ReqContext) {
 		redirectTo = setting.AppSubUrl + c.Req.RequestURI
 	}
 
-	// remove any forceLogin=true params
-	redirectTo = removeForceLoginParams(redirectTo)
+	if redirectTo != "/" {
+		if setting.AppSubUrl != "" && !strings.HasPrefix(redirectTo, setting.AppSubUrl) {
+			redirectTo = setting.AppSubUrl + c.Req.RequestURI
+		}
 
-	cookies.WriteCookie(c.Resp, "redirect_to", url.QueryEscape(redirectTo), 0, nil)
+		// remove any forceLogin=true params
+		redirectTo = removeForceLoginParams(redirectTo)
+		cookies.WriteCookie(c.Resp, "redirect_to", url.QueryEscape(redirectTo), 0, nil)
+	}
 }
 
 var forceLoginParamsRegexp = regexp.MustCompile(`&?forceLogin=true`)

--- a/pkg/services/accesscontrol/middleware.go
+++ b/pkg/services/accesscontrol/middleware.go
@@ -84,6 +84,7 @@ func deny(c *models.ReqContext, evaluator Evaluator, err error) {
 
 	if !c.IsApiRequest() {
 		// TODO(emil): I'd like to show a message after this redirect, not sure how that can be done?
+		writeRedirectCookie(c)
 		c.Redirect(setting.AppSubUrl + "/")
 		return
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
As written, no routes that had used the access control authorize function would redirect properly after login. This was caused by the cookie not being written in the first place, and then, after being redirected to '/', it was overwritten when the normal auth middleware kicked in and overwritten to be '/'.

This writes the redirect even if access was denied, and then does not save a redirect cookie if it is only the root directory. 

**Which issue(s) this PR fixes**:
Fixes #56827

**Special notes for your reviewer**:
This is not my normal area of expertise so feel free to make any recommendations or modifications necessary.

Any paths using the authorize function here will run into the bug https://github.com/grafana/grafana/blob/main/pkg/api/api.go#L83


