### PR TITLE
CloudWatch: Refactor to extract DataQuery grouping by region out of request parsing 

### DIFF
--- a/pkg/tsdb/cloudwatch/mocks/cloudwatch_metric_api.go
+++ b/pkg/tsdb/cloudwatch/mocks/cloudwatch_metric_api.go
@@ -5,6 +5,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
 	"github.com/aws/aws-sdk-go/service/cloudwatch/cloudwatchiface"
+	"github.com/stretchr/testify/mock"
 )
 
 type FakeMetricsAPI struct {
@@ -55,4 +56,15 @@ func chunkSlice(slice []*cloudwatch.Metric, chunkSize int) [][]*cloudwatch.Metri
 	}
 
 	return chunks
+}
+
+type MetricsClient struct {
+	cloudwatchiface.CloudWatchAPI
+	mock.Mock
+}
+
+func (m *MetricsClient) GetMetricDataWithContext(ctx aws.Context, input *cloudwatch.GetMetricDataInput, opts ...request.Option) (*cloudwatch.GetMetricDataOutput, error) {
+	args := m.Called(ctx, input, opts)
+
+	return args.Get(0).(*cloudwatch.GetMetricDataOutput), args.Error(1)
 }

--- a/pkg/tsdb/cloudwatch/models/request_parser.go
+++ b/pkg/tsdb/cloudwatch/models/request_parser.go
@@ -25,29 +25,30 @@ type metricsDataQuery struct {
 	Datasource        map[string]string      `json:"datasource,omitempty"`
 	Dimensions        map[string]interface{} `json:"dimensions,omitempty"`
 	Expression        string                 `json:"expression,omitempty"`
-	Id                string                 `json:"id,omitempty"`
-	Label             *string                `json:"label,omitempty"`
-	MatchExact        *bool                  `json:"matchExact,omitempty"`
-	MaxDataPoints     int                    `json:"maxDataPoints,omitempty"`
-	MetricEditorMode  *int                   `json:"metricEditorMode,omitempty"`
-	MetricName        string                 `json:"metricName,omitempty"`
-	MetricQueryType   MetricQueryType        `json:"metricQueryType,omitempty"`
-	Namespace         string                 `json:"namespace,omitempty"`
-	Period            string                 `json:"period,omitempty"`
-	RefId             string                 `json:"refId,omitempty"`
-	Region            string                 `json:"region,omitempty"`
-	SqlExpression     string                 `json:"sqlExpression,omitempty"`
-	Statistic         *string                `json:"statistic,omitempty"`
-	Statistics        []*string              `json:"statistics,omitempty"`
-	TimezoneUTCOffset string                 `json:"timezoneUTCOffset,omitempty"`
-	QueryType         string                 `json:"type,omitempty"`
-	Hide              *bool                  `json:"hide,omitempty"`
-	Alias             string                 `json:"alias,omitempty"`
+	Id                string          `json:"id,omitempty"`
+	Label             *string         `json:"label,omitempty"`
+	MatchExact        *bool           `json:"matchExact,omitempty"`
+	MaxDataPoints     int             `json:"maxDataPoints,omitempty"`
+	MetricEditorMode  *int            `json:"metricEditorMode,omitempty"`
+	MetricName        string          `json:"metricName,omitempty"`
+	MetricQueryType   MetricQueryType `json:"metricQueryType,omitempty"`
+	Namespace         string          `json:"namespace,omitempty"`
+	Period            string          `json:"period,omitempty"`
+	RefId             string          `json:"refId,omitempty"`
+	Region            string          `json:"region,omitempty"`
+	SqlExpression     string          `json:"sqlExpression,omitempty"`
+	Statistic         *string         `json:"statistic,omitempty"`
+	Statistics        []*string       `json:"statistics,omitempty"`
+	TimezoneUTCOffset string          `json:"timezoneUTCOffset,omitempty"`
+	QueryType         string          `json:"type,omitempty"`
+	Hide              *bool           `json:"hide,omitempty"`
+	Alias             string          `json:"alias,omitempty"`
 }
 
-// ParseQueries parses the json queries and returns a map of cloudWatchQueries by region. The cloudWatchQuery has a 1 to 1 mapping to a query editor row
-func ParseQueries(queries []backend.DataQuery, startTime time.Time, endTime time.Time, dynamicLabelsEnabled bool) (map[string][]*CloudWatchQuery, error) {
-	result := make(map[string][]*CloudWatchQuery)
+// ParseQueries decodes the metric data queries json, validates, sets default values and returns an array of CloudWatchQueries.
+// The CloudWatchQuery has a 1 to 1 mapping to a query editor row
+func ParseQueries(queries []backend.DataQuery, startTime time.Time, endTime time.Time, dynamicLabelsEnabled bool) ([]*CloudWatchQuery, error) {
+	var result []*CloudWatchQuery
 	migratedQueries, err := migrateLegacyQuery(queries, dynamicLabelsEnabled)
 	if err != nil {
 		return nil, err
@@ -70,16 +71,12 @@ func ParseQueries(queries []backend.DataQuery, startTime time.Time, endTime time
 			metricsDataQuery.MatchExact = &trueBooleanValue
 		}
 
-		refID := query.RefID
-		query, err := parseRequestQuery(metricsDataQuery, refID, startTime, endTime)
+		refID := metricsDataQuery.RefId
+		cwQuery, err := parseRequestQuery(metricsDataQuery, refID, startTime, endTime)
 		if err != nil {
 			return nil, &QueryError{Err: err, RefID: refID}
 		}
-
-		if _, exist := result[query.Region]; !exist {
-			result[query.Region] = []*CloudWatchQuery{}
-		}
-		result[query.Region] = append(result[query.Region], query)
+		result = append(result, cwQuery)
 	}
 
 	return result, nil

--- a/pkg/tsdb/cloudwatch/models/request_parser.go
+++ b/pkg/tsdb/cloudwatch/models/request_parser.go
@@ -71,7 +71,7 @@ func ParseQueries(queries []backend.DataQuery, startTime time.Time, endTime time
 			metricsDataQuery.MatchExact = &trueBooleanValue
 		}
 
-		refID := metricsDataQuery.RefId
+		refID := query.RefID
 		cwQuery, err := parseRequestQuery(metricsDataQuery, refID, startTime, endTime)
 		if err != nil {
 			return nil, &QueryError{Err: err, RefID: refID}

--- a/pkg/tsdb/cloudwatch/models/request_parser.go
+++ b/pkg/tsdb/cloudwatch/models/request_parser.go
@@ -45,9 +45,9 @@ type metricsDataQuery struct {
 	Alias             string                 `json:"alias,omitempty"`
 }
 
-// ParseQueries decodes the metric data queries json, validates, sets default values and returns an array of CloudWatchQueries.
+// ParseMetricDataQueries decodes the metric data queries json, validates, sets default values and returns an array of CloudWatchQueries.
 // The CloudWatchQuery has a 1 to 1 mapping to a query editor row
-func ParseQueries(queries []backend.DataQuery, startTime time.Time, endTime time.Time, dynamicLabelsEnabled bool) ([]*CloudWatchQuery, error) {
+func ParseMetricDataQueries(queries []backend.DataQuery, startTime time.Time, endTime time.Time, dynamicLabelsEnabled bool) ([]*CloudWatchQuery, error) {
 	var result []*CloudWatchQuery
 	migratedQueries, err := migrateLegacyQuery(queries, dynamicLabelsEnabled)
 	if err != nil {

--- a/pkg/tsdb/cloudwatch/models/request_parser.go
+++ b/pkg/tsdb/cloudwatch/models/request_parser.go
@@ -25,24 +25,24 @@ type metricsDataQuery struct {
 	Datasource        map[string]string      `json:"datasource,omitempty"`
 	Dimensions        map[string]interface{} `json:"dimensions,omitempty"`
 	Expression        string                 `json:"expression,omitempty"`
-	Id                string          `json:"id,omitempty"`
-	Label             *string         `json:"label,omitempty"`
-	MatchExact        *bool           `json:"matchExact,omitempty"`
-	MaxDataPoints     int             `json:"maxDataPoints,omitempty"`
-	MetricEditorMode  *int            `json:"metricEditorMode,omitempty"`
-	MetricName        string          `json:"metricName,omitempty"`
-	MetricQueryType   MetricQueryType `json:"metricQueryType,omitempty"`
-	Namespace         string          `json:"namespace,omitempty"`
-	Period            string          `json:"period,omitempty"`
-	RefId             string          `json:"refId,omitempty"`
-	Region            string          `json:"region,omitempty"`
-	SqlExpression     string          `json:"sqlExpression,omitempty"`
-	Statistic         *string         `json:"statistic,omitempty"`
-	Statistics        []*string       `json:"statistics,omitempty"`
-	TimezoneUTCOffset string          `json:"timezoneUTCOffset,omitempty"`
-	QueryType         string          `json:"type,omitempty"`
-	Hide              *bool           `json:"hide,omitempty"`
-	Alias             string          `json:"alias,omitempty"`
+	Id                string                 `json:"id,omitempty"`
+	Label             *string                `json:"label,omitempty"`
+	MatchExact        *bool                  `json:"matchExact,omitempty"`
+	MaxDataPoints     int                    `json:"maxDataPoints,omitempty"`
+	MetricEditorMode  *int                   `json:"metricEditorMode,omitempty"`
+	MetricName        string                 `json:"metricName,omitempty"`
+	MetricQueryType   MetricQueryType        `json:"metricQueryType,omitempty"`
+	Namespace         string                 `json:"namespace,omitempty"`
+	Period            string                 `json:"period,omitempty"`
+	RefId             string                 `json:"refId,omitempty"`
+	Region            string                 `json:"region,omitempty"`
+	SqlExpression     string                 `json:"sqlExpression,omitempty"`
+	Statistic         *string                `json:"statistic,omitempty"`
+	Statistics        []*string              `json:"statistics,omitempty"`
+	TimezoneUTCOffset string                 `json:"timezoneUTCOffset,omitempty"`
+	QueryType         string                 `json:"type,omitempty"`
+	Hide              *bool                  `json:"hide,omitempty"`
+	Alias             string                 `json:"alias,omitempty"`
 }
 
 // ParseQueries decodes the metric data queries json, validates, sets default values and returns an array of CloudWatchQueries.

--- a/pkg/tsdb/cloudwatch/time_series_query.go
+++ b/pkg/tsdb/cloudwatch/time_series_query.go
@@ -31,7 +31,7 @@ func (e *cloudWatchExecutor) executeTimeSeriesQuery(ctx context.Context, req *ba
 		return nil, fmt.Errorf("invalid time range: start time must be before end time")
 	}
 
-	requestQueries, err := models.ParseQueries(req.Queries, startTime, endTime, e.features.IsEnabled(featuremgmt.FlagCloudWatchDynamicLabels))
+	requestQueries, err := models.ParseMetricDataQueries(req.Queries, startTime, endTime, e.features.IsEnabled(featuremgmt.FlagCloudWatchDynamicLabels))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tsdb/cloudwatch/time_series_query.go
+++ b/pkg/tsdb/cloudwatch/time_series_query.go
@@ -31,13 +31,21 @@ func (e *cloudWatchExecutor) executeTimeSeriesQuery(ctx context.Context, req *ba
 		return nil, fmt.Errorf("invalid time range: start time must be before end time")
 	}
 
-	requestQueriesByRegion, err := models.ParseQueries(req.Queries, startTime, endTime, e.features.IsEnabled(featuremgmt.FlagCloudWatchDynamicLabels))
+	requestQueries, err := models.ParseQueries(req.Queries, startTime, endTime, e.features.IsEnabled(featuremgmt.FlagCloudWatchDynamicLabels))
 	if err != nil {
 		return nil, err
 	}
 
-	if len(requestQueriesByRegion) == 0 {
+	if len(requestQueries) == 0 {
 		return backend.NewQueryDataResponse(), nil
+	}
+
+	requestQueriesByRegion := make(map[string][]*models.CloudWatchQuery)
+	for _, query := range requestQueries {
+		if _, exist := requestQueriesByRegion[query.Region]; !exist {
+			requestQueriesByRegion[query.Region] = []*models.CloudWatchQuery{}
+		}
+		requestQueriesByRegion[query.Region] = append(requestQueriesByRegion[query.Region], query)
 	}
 
 	resultChan := make(chan *responseWrapper, len(req.Queries))

--- a/pkg/tsdb/cloudwatch/time_series_query_test.go
+++ b/pkg/tsdb/cloudwatch/time_series_query_test.go
@@ -10,9 +10,11 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
 	"github.com/aws/aws-sdk-go/service/cloudwatch/cloudwatchiface"
+	"github.com/grafana/grafana-aws-sdk/pkg/awsds"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/datasource"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/mocks"
@@ -137,6 +139,135 @@ func TestTimeSeriesQuery(t *testing.T) {
 			To:   now.Add(time.Hour * -1),
 		}}}})
 		assert.EqualError(t, err, "invalid time range: start time must be before end time")
+	})
+}
+
+func Test_executeTimeSeriesQuery_getCWClient_is_called_once_per_region_and_GetMetricData_is_called_once_per_grouping_of_queries_by_region(t *testing.T) {
+	/* TODO: This test aims to verify the logic to group regions which has been extracted from ParseQueries.
+	It should be replaced by a test at a lower level when grouping by regions is incorporated into a separate business logic layer */
+	origNewCWClient := NewCWClient
+	t.Cleanup(func() {
+		NewCWClient = origNewCWClient
+	})
+
+	var mockMetricClient mocks.MetricsClient
+	NewCWClient = func(sess *session.Session) cloudwatchiface.CloudWatchAPI {
+		return &mockMetricClient
+	}
+
+	im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
+		return datasourceInfo{}, nil
+	})
+
+	t.Run("Queries with the same region should call GetSession with that region 1 time and call GetMetricDataWithContext 1 time", func(t *testing.T) {
+		mockSessionCache := &mockSessionCache{}
+		mockSessionCache.On("GetSession", mock.MatchedBy(
+			func(config awsds.SessionConfig) bool { return config.Settings.Region == "us-east-1" })). // region from queries is asserted here
+			Return(&session.Session{Config: &aws.Config{}}, nil).Once()
+		mockMetricClient = mocks.MetricsClient{}
+		mockMetricClient.On("GetMetricDataWithContext", mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
+
+		executor := newExecutor(im, newTestConfig(), mockSessionCache, featuremgmt.WithFeatures())
+		_, err := executor.QueryData(context.Background(), &backend.QueryDataRequest{
+			PluginContext: backend.PluginContext{
+				DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{},
+			},
+			Queries: []backend.DataQuery{
+				{
+					RefID:     "A",
+					TimeRange: backend.TimeRange{From: time.Now().Add(time.Hour * -2), To: time.Now().Add(time.Hour * -1)},
+					JSON: json.RawMessage(`{
+						"type":      "timeSeriesQuery",
+						"namespace": "AWS/EC2",
+						"metricName": "NetworkOut",
+						"region": "us-east-1",
+						"statistic": "Maximum",
+						"period": "300"
+					}`),
+				},
+				{
+					RefID:     "B",
+					TimeRange: backend.TimeRange{From: time.Now().Add(time.Hour * -2), To: time.Now().Add(time.Hour * -1)},
+					JSON: json.RawMessage(`{
+						"type":      "timeSeriesQuery",
+						"namespace": "AWS/EC2",
+						"metricName": "NetworkIn",
+						"region": "us-east-1",
+						"statistic": "Maximum",
+						"period": "300"
+					}`),
+				},
+			},
+		})
+
+		require.NoError(t, err)
+		mockSessionCache.AssertExpectations(t) // method is defined to only return "Once()",
+		// AssertExpectations will fail if those methods were not called Once(), so expected number of calls is asserted by this line
+		mockMetricClient.AssertNumberOfCalls(t, "GetMetricDataWithContext", 1)
+		// GetMetricData is asserted to have been called 1 time for the 1 region present in the queries
+	})
+
+	t.Run("3 queries with 2 regions calls GetSession 2 times and calls GetMetricDataWithContext 2 times", func(t *testing.T) {
+		sessionCache := &mockSessionCache{}
+		sessionCache.On("GetSession", mock.MatchedBy(
+			func(config awsds.SessionConfig) bool { return config.Settings.Region == "us-east-1" })).
+			Return(&session.Session{Config: &aws.Config{}}, nil, nil).Once()
+		sessionCache.On("GetSession", mock.MatchedBy(
+			func(config awsds.SessionConfig) bool { return config.Settings.Region == "us-east-2" })).
+			Return(&session.Session{Config: &aws.Config{}}, nil, nil).Once()
+		mockMetricClient = mocks.MetricsClient{}
+		mockMetricClient.On("GetMetricDataWithContext", mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
+
+		executor := newExecutor(im, newTestConfig(), sessionCache, featuremgmt.WithFeatures())
+		_, err := executor.QueryData(context.Background(), &backend.QueryDataRequest{
+			PluginContext: backend.PluginContext{
+				DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{},
+			},
+			Queries: []backend.DataQuery{
+				{
+					RefID:     "A",
+					TimeRange: backend.TimeRange{From: time.Now().Add(time.Hour * -2), To: time.Now().Add(time.Hour * -1)},
+					JSON: json.RawMessage(`{
+						"type":      "timeSeriesQuery",
+						"namespace": "AWS/EC2",
+						"metricName": "NetworkOut",
+						"region": "us-east-2",
+						"statistic": "Maximum",
+						"period": "300"
+					}`),
+				},
+				{
+					RefID:     "A2",
+					TimeRange: backend.TimeRange{From: time.Now().Add(time.Hour * -2), To: time.Now().Add(time.Hour * -1)},
+					JSON: json.RawMessage(`{
+						"type":      "timeSeriesQuery",
+						"namespace": "AWS/EC2",
+						"metricName": "NetworkOut",
+						"region": "us-east-2",
+						"statistic": "Maximum",
+						"period": "300"
+					}`),
+				},
+				{
+					RefID:     "B",
+					TimeRange: backend.TimeRange{From: time.Now().Add(time.Hour * -2), To: time.Now().Add(time.Hour * -1)},
+					JSON: json.RawMessage(`{
+						"type":      "timeSeriesQuery",
+						"namespace": "AWS/EC2",
+						"metricName": "NetworkIn",
+						"region": "us-east-1",
+						"statistic": "Maximum",
+						"period": "300"
+					}`),
+				},
+			},
+		})
+
+		require.NoError(t, err)
+		sessionCache.AssertExpectations(t) // method is defined to only return "Once()" for each region.
+		// AssertExpectations will fail if those methods were not called Once(), so expected number of calls is asserted by this line
+		mockMetricClient.AssertNumberOfCalls(t, "GetMetricDataWithContext", 2)
+		// GetMetricData is asserted to have been called 2 times, presumably once for each group of regions (2 regions total)
 	})
 }
 

--- a/pkg/tsdb/cloudwatch/time_series_query_test.go
+++ b/pkg/tsdb/cloudwatch/time_series_query_test.go
@@ -143,7 +143,7 @@ func TestTimeSeriesQuery(t *testing.T) {
 }
 
 func Test_executeTimeSeriesQuery_getCWClient_is_called_once_per_region_and_GetMetricData_is_called_once_per_grouping_of_queries_by_region(t *testing.T) {
-	/* TODO: This test aims to verify the logic to group regions which has been extracted from ParseQueries.
+	/* TODO: This test aims to verify the logic to group regions which has been extracted from ParseMetricDataQueries.
 	It should be replaced by a test at a lower level when grouping by regions is incorporated into a separate business logic layer */
 	origNewCWClient := NewCWClient
 	t.Cleanup(func() {

--- a/pkg/tsdb/cloudwatch/utils_test.go
+++ b/pkg/tsdb/cloudwatch/utils_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grafana/grafana-aws-sdk/pkg/awsds"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/stretchr/testify/mock"
 )
 
 type fakeCWLogsClient struct {
@@ -188,6 +189,15 @@ func (c fakeCheckHealthClient) DescribeLogGroups(input *cloudwatchlogs.DescribeL
 
 func newTestConfig() *setting.Cfg {
 	return &setting.Cfg{AWSAllowedAuthProviders: []string{"default"}, AWSAssumeRoleEnabled: true, AWSListMetricsPageLimit: 1000}
+}
+
+type mockSessionCache struct {
+	mock.Mock
+}
+
+func (c *mockSessionCache) GetSession(config awsds.SessionConfig) (*session.Session, error) {
+	args := c.Called(config)
+	return args.Get(0).(*session.Session), args.Error(1)
 }
 
 type fakeSessionCache struct {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
In the plan to refactor the metric data query parsing, the grouping of queries by region should be extracted from this ParseQueries function, see the small comment exchange here https://github.com/grafana/grafana/pull/57165#discussion_r1000376792

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Contributes to https://github.com/grafana/cloud-data-sources/issues/62 and https://github.com/grafana/grafana/issues/57146

**Special notes for your reviewer**:

I added tests which *provide evidence* that regions are still being grouped, but I believe these tests could be easier to read and stronger at a lower level (directly asserting the grouping of the regions, not just checking that we are getting a certain number of clients per region and making a certain number of outgoing calls). 

As stated in the discussion https://github.com/grafana/grafana/pull/57165#discussion_r1000222183, the extraction of this "business logic" will happen in a subsequent PR. I believe at this time the tests should be rewritten and more direct assertions can be made. 

I've added comments explaining usage of the testify/mock library assertions to help understand what assertions I'm trying to provide about the region grouping. Any improvements or other ideas are welcome!

The region grouping was previously tested indirectly in all tests at the `ParseQueries` level, but not that exhaustively, I think.