### PR TITLE
Live: Explicitly reply with http 200

### DIFF
--- a/pkg/services/live/pushhttp/push.go
+++ b/pkg/services/live/pushhttp/push.go
@@ -94,6 +94,8 @@ func (g *Gateway) Handle(ctx *models.ReqContext) {
 			return
 		}
 	}
+
+	ctx.Resp.WriteHeader(http.StatusOK)
 }
 
 func (g *Gateway) HandlePipelinePush(ctx *models.ReqContext) {
@@ -126,4 +128,6 @@ func (g *Gateway) HandlePipelinePush(ctx *models.ReqContext) {
 		ctx.Resp.WriteHeader(http.StatusNotFound)
 		return
 	}
+
+	ctx.Resp.WriteHeader(http.StatusOK)
 }


### PR DESCRIPTION
`pkg/web` triggers a panic when a http handler chain does not return any response to the client.
This has been put in place, because it usually means a middleware along the way did not call the next one.

In this specific case however, the handlers meant to return 200, but did not do so explicitely, instead relying on the default behavior of `net/http`

Fixes https://github.com/grafana/grafana/issues/57404