### PR TITLE
Alerting: Add title and description to Threema contact point

### DIFF
--- a/pkg/services/ngalert/notifier/channels/threema.go
+++ b/pkg/services/ngalert/notifier/channels/threema.go
@@ -37,6 +37,8 @@ type threemaSettings struct {
 	GatewayID   string `json:"gateway_id,omitempty" yaml:"gateway_id,omitempty"`
 	RecipientID string `json:"recipient_id,omitempty" yaml:"recipient_id,omitempty"`
 	APISecret   string `json:"api_secret,omitempty" yaml:"api_secret,omitempty"`
+	Title       string `json:"title,omitempty" yaml:"title,omitempty"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
 }
 
 func buildThreemaSettings(fc FactoryConfig) (threemaSettings, error) {
@@ -67,6 +69,14 @@ func buildThreemaSettings(fc FactoryConfig) (threemaSettings, error) {
 	if settings.APISecret == "" {
 		return settings, errors.New("could not find Threema API secret in settings")
 	}
+
+	if settings.Description == "" {
+		settings.Description = DefaultMessageEmbed
+	}
+	if settings.Title == "" {
+		settings.Title = DefaultMessageTitleEmbed
+	}
+
 	return settings, nil
 }
 
@@ -106,43 +116,12 @@ func NewThreemaNotifier(fc FactoryConfig) (*ThreemaNotifier, error) {
 func (tn *ThreemaNotifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error) {
 	tn.log.Debug("sending threema alert notification", "from", tn.settings.GatewayID, "to", tn.settings.RecipientID)
 
-	var tmplErr error
-	tmpl, _ := TmplText(ctx, tn.tmpl, as, tn.log, &tmplErr)
-
 	// Set up basic API request data
 	data := url.Values{}
 	data.Set("from", tn.settings.GatewayID)
 	data.Set("to", tn.settings.RecipientID)
 	data.Set("secret", tn.settings.APISecret)
-
-	// Determine emoji
-	stateEmoji := "\u26A0\uFE0F " // Warning sign
-	alerts := types.Alerts(as...)
-	if alerts.Status() == model.AlertResolved {
-		stateEmoji = "\u2705 " // Check Mark Button
-	}
-
-	// Build message
-	message := fmt.Sprintf("%s%s\n\n*Message:*\n%s\n*URL:* %s\n",
-		stateEmoji,
-		tmpl(DefaultMessageTitleEmbed),
-		tmpl(DefaultMessageEmbed),
-		path.Join(tn.tmpl.ExternalURL.String(), "/alerting/list"),
-	)
-
-	_ = withStoredImages(ctx, tn.log, tn.images,
-		func(_ int, image ngmodels.Image) error {
-			if image.URL != "" {
-				message += fmt.Sprintf("*Image:* %s\n", image.URL)
-			}
-			return nil
-		}, as...)
-
-	data.Set("text", message)
-
-	if tmplErr != nil {
-		tn.log.Warn("failed to template Threema message", "error", tmplErr.Error())
-	}
+	data.Set("text", tn.buildMessage(ctx, as...))
 
 	cmd := &models.SendWebhookSync{
 		Url:        ThreemaGwBaseURL,
@@ -162,4 +141,37 @@ func (tn *ThreemaNotifier) Notify(ctx context.Context, as ...*types.Alert) (bool
 
 func (tn *ThreemaNotifier) SendResolved() bool {
 	return !tn.GetDisableResolveMessage()
+}
+
+func (tn *ThreemaNotifier) buildMessage(ctx context.Context, as ...*types.Alert) string {
+	var tmplErr error
+	tmpl, _ := TmplText(ctx, tn.tmpl, as, tn.log, &tmplErr)
+
+	message := fmt.Sprintf("%s%s\n\n*Message:*\n%s\n*URL:* %s\n",
+		selectEmoji(as...),
+		tmpl(tn.settings.Title),
+		tmpl(tn.settings.Description),
+		path.Join(tn.tmpl.ExternalURL.String(), "/alerting/list"),
+	)
+
+	if tmplErr != nil {
+		tn.log.Warn("failed to template Threema message", "error", tmplErr.Error())
+	}
+
+	_ = withStoredImages(ctx, tn.log, tn.images,
+		func(_ int, image ngmodels.Image) error {
+			if image.URL != "" {
+				message += fmt.Sprintf("*Image:* %s\n", image.URL)
+			}
+			return nil
+		}, as...)
+
+	return message
+}
+
+func selectEmoji(as ...*types.Alert) string {
+	if types.Alerts(as...).Status() == model.AlertResolved {
+		return "\u2705 " // Check Mark Button
+	}
+	return "\u26A0\uFE0F " // Warning sign
 }

--- a/pkg/services/ngalert/notifier/channels/threema_test.go
+++ b/pkg/services/ngalert/notifier/channels/threema_test.go
@@ -72,6 +72,25 @@ func TestThreemaNotifier(t *testing.T) {
 			expMsg:      "from=%2A1234567&secret=supersecret&text=%E2%9A%A0%EF%B8%8F+%5BFIRING%3A2%5D++%0A%0A%2AMessage%3A%2A%0A%2A%2AFiring%2A%2A%0A%0AValue%3A+%5Bno+value%5D%0ALabels%3A%0A+-+alertname+%3D+alert1%0A+-+lbl1+%3D+val1%0AAnnotations%3A%0A+-+ann1+%3D+annv1%0ASilence%3A+http%3A%2F%2Flocalhost%2Falerting%2Fsilence%2Fnew%3Falertmanager%3Dgrafana%26matcher%3Dalertname%253Dalert1%26matcher%3Dlbl1%253Dval1%0A%0AValue%3A+%5Bno+value%5D%0ALabels%3A%0A+-+alertname+%3D+alert1%0A+-+lbl1+%3D+val2%0AAnnotations%3A%0A+-+ann1+%3D+annv2%0ASilence%3A+http%3A%2F%2Flocalhost%2Falerting%2Fsilence%2Fnew%3Falertmanager%3Dgrafana%26matcher%3Dalertname%253Dalert1%26matcher%3Dlbl1%253Dval2%0A%0A%2AURL%3A%2A+http%3A%2Flocalhost%2Falerting%2Flist%0A%2AImage%3A%2A+https%3A%2F%2Fwww.example.com%2Ftest-image-1.jpg%0A%2AImage%3A%2A+https%3A%2F%2Fwww.example.com%2Ftest-image-2.jpg%0A&to=87654321",
 			expMsgError: nil,
 		}, {
+			name: "A single alert with an image and custom title and description",
+			settings: `{
+				"gateway_id": "*1234567",
+				"recipient_id": "87654321",
+				"api_secret": "supersecret",
+				"title": "customTitle {{ .Alerts.Firing | len }}",
+				"description": "customDescription"
+			}`,
+			alerts: []*types.Alert{
+				{
+					Alert: model.Alert{
+						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+						Annotations: model.LabelSet{"ann1": "annv1", "__dashboardUid__": "abcd", "__panelId__": "efgh", "__alertImageToken__": "test-image-1"},
+					},
+				},
+			},
+			expMsg:      "from=%2A1234567&secret=supersecret&text=%E2%9A%A0%EF%B8%8F+customTitle+1%0A%0A%2AMessage%3A%2A%0AcustomDescription%0A%2AURL%3A%2A+http%3A%2Flocalhost%2Falerting%2Flist%0A%2AImage%3A%2A+https%3A%2F%2Fwww.example.com%2Ftest-image-1.jpg%0A&to=87654321",
+			expMsgError: nil,
+		}, {
 			name: "Invalid gateway id",
 			settings: `{
 				"gateway_id": "12345678",
@@ -102,19 +121,16 @@ func TestThreemaNotifier(t *testing.T) {
 			settingsJSON, err := simplejson.NewJson([]byte(c.settings))
 			require.NoError(t, err)
 			secureSettings := make(map[string][]byte)
-
-			m := &NotificationChannelConfig{
-				Name:           "threema_testing",
-				Type:           "threema",
-				Settings:       settingsJSON,
-				SecureSettings: secureSettings,
-			}
-
 			webhookSender := mockNotificationService()
 			secretsService := secretsManager.SetupTestService(t, fakes.NewFakeSecretsStore())
 
 			fc := FactoryConfig{
-				Config:              m,
+				Config: &NotificationChannelConfig{
+					Name:           "threema_testing",
+					Type:           "threema",
+					Settings:       settingsJSON,
+					SecureSettings: secureSettings,
+				},
 				NotificationService: webhookSender,
 				ImageStore:          images,
 				Template:            tmpl,

--- a/pkg/services/ngalert/notifier/channels_config/available_channels.go
+++ b/pkg/services/ngalert/notifier/channels_config/available_channels.go
@@ -917,6 +917,22 @@ func GetAvailableNotifiers() []*NotifierPlugin {
 					Required:     true,
 					Secure:       true,
 				},
+				{ // New in 9.3
+					Label:        "Title",
+					Element:      ElementTypeInput,
+					InputType:    InputTypeText,
+					Description:  "Templated title of the message.",
+					PropertyName: "title",
+					Placeholder:  channels.DefaultMessageTitleEmbed,
+				},
+				{ // New in 9.3
+					Label:        "Description",
+					Element:      ElementTypeInput,
+					InputType:    InputTypeText,
+					Description:  "Templated description of the message.",
+					PropertyName: "description",
+					Placeholder:  channels.DefaultMessageEmbed,
+				},
 			},
 		},
 		{


### PR DESCRIPTION
**What this PR does / why we need it**:

It allows users to add a custom title and description for Threema contact points.
It defaults to title and description default messages.