### PR TITLE
Cloudwatch: Refactor datasource instance factory method

### DIFF
--- a/pkg/tsdb/cloudwatch/annotation_query_test.go
+++ b/pkg/tsdb/cloudwatch/annotation_query_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend/datasource"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -31,7 +32,7 @@ func TestQuery_AnnotationQuery(t *testing.T) {
 	t.Run("DescribeAlarmsForMetric is called with minimum parameters", func(t *testing.T) {
 		client = fakeCWAnnotationsClient{describeAlarmsForMetricOutput: &cloudwatch.DescribeAlarmsForMetricOutput{}}
 		im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-			return datasourceInfo{}, nil
+			return DataSource{Settings: &models.CloudWatchSettings{}}, nil
 		})
 
 		executor := newExecutor(im, newTestConfig(), &fakeSessionCache{}, featuremgmt.WithFeatures())
@@ -65,7 +66,7 @@ func TestQuery_AnnotationQuery(t *testing.T) {
 	t.Run("DescribeAlarms is called when prefixMatching is true", func(t *testing.T) {
 		client = fakeCWAnnotationsClient{describeAlarmsOutput: &cloudwatch.DescribeAlarmsOutput{}}
 		im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-			return datasourceInfo{}, nil
+			return DataSource{Settings: &models.CloudWatchSettings{}}, nil
 		})
 
 		executor := newExecutor(im, newTestConfig(), &fakeSessionCache{}, featuremgmt.WithFeatures())

--- a/pkg/tsdb/cloudwatch/log_actions.go
+++ b/pkg/tsdb/cloudwatch/log_actions.go
@@ -110,12 +110,12 @@ func (e *cloudWatchExecutor) executeLogActions(ctx context.Context, req *backend
 }
 
 func (e *cloudWatchExecutor) executeLogAction(ctx context.Context, model LogQueryJson, query backend.DataQuery, pluginCtx backend.PluginContext) (*data.Frame, error) {
-	dsInfo, err := e.getDSInfo(pluginCtx)
+	instance, err := e.getInstance(pluginCtx)
 	if err != nil {
 		return nil, err
 	}
 
-	region := dsInfo.region
+	region := instance.Settings.Region
 	if model.Region != "" {
 		region = model.Region
 	}

--- a/pkg/tsdb/cloudwatch/log_actions_test.go
+++ b/pkg/tsdb/cloudwatch/log_actions_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/models"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -82,7 +83,7 @@ func TestQuery_GetLogEvents(t *testing.T) {
 			cli = fakeCWLogsClient{}
 
 			im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-				return datasourceInfo{}, nil
+				return DataSource{Settings: &models.CloudWatchSettings{}}, nil
 			})
 
 			executor := newExecutor(im, newTestConfig(), &fakeSessionCache{}, featuremgmt.WithFeatures())
@@ -140,7 +141,7 @@ func TestQuery_GetLogGroupFields(t *testing.T) {
 	const refID = "A"
 
 	im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-		return datasourceInfo{}, nil
+		return DataSource{Settings: &models.CloudWatchSettings{}}, nil
 	})
 
 	executor := newExecutor(im, newTestConfig(), &fakeSessionCache{}, featuremgmt.WithFeatures())
@@ -221,7 +222,7 @@ func TestQuery_StartQuery(t *testing.T) {
 		}
 
 		im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-			return datasourceInfo{}, nil
+			return DataSource{Settings: &models.CloudWatchSettings{}}, nil
 		})
 
 		executor := newExecutor(im, newTestConfig(), &fakeSessionCache{}, featuremgmt.WithFeatures())
@@ -274,7 +275,7 @@ func TestQuery_StartQuery(t *testing.T) {
 		}
 
 		im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-			return datasourceInfo{}, nil
+			return DataSource{Settings: &models.CloudWatchSettings{}}, nil
 		})
 
 		executor := newExecutor(im, newTestConfig(), &fakeSessionCache{}, featuremgmt.WithFeatures())
@@ -332,7 +333,7 @@ func Test_executeStartQuery(t *testing.T) {
 	t.Run("successfully parses information from JSON to StartQueryWithContext", func(t *testing.T) {
 		cli = fakeCWLogsClient{}
 		im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-			return datasourceInfo{}, nil
+			return DataSource{Settings: &models.CloudWatchSettings{}}, nil
 		})
 		executor := newExecutor(im, newTestConfig(), &fakeSessionCache{}, featuremgmt.WithFeatures())
 
@@ -368,7 +369,7 @@ func Test_executeStartQuery(t *testing.T) {
 	t.Run("does not populate StartQueryInput.limit when no limit provided", func(t *testing.T) {
 		cli = fakeCWLogsClient{}
 		im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-			return datasourceInfo{}, nil
+			return DataSource{Settings: &models.CloudWatchSettings{}}, nil
 		})
 		executor := newExecutor(im, newTestConfig(), &fakeSessionCache{}, featuremgmt.WithFeatures())
 
@@ -424,7 +425,7 @@ func TestQuery_StopQuery(t *testing.T) {
 	}
 
 	im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-		return datasourceInfo{}, nil
+		return DataSource{Settings: &models.CloudWatchSettings{}}, nil
 	})
 
 	timeRange := backend.TimeRange{
@@ -519,7 +520,7 @@ func TestQuery_GetQueryResults(t *testing.T) {
 	}
 
 	im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-		return datasourceInfo{}, nil
+		return DataSource{Settings: &models.CloudWatchSettings{}}, nil
 	})
 
 	executor := newExecutor(im, newTestConfig(), &fakeSessionCache{}, featuremgmt.WithFeatures())

--- a/pkg/tsdb/cloudwatch/metric_find_query_test.go
+++ b/pkg/tsdb/cloudwatch/metric_find_query_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/constants"
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/mocks"
+	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -52,7 +53,7 @@ func TestQuery_Metrics(t *testing.T) {
 		}
 
 		im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-			return datasourceInfo{}, nil
+			return DataSource{Settings: &models.CloudWatchSettings{}}, nil
 		})
 
 		executor := newExecutor(im, newTestConfig(), &fakeSessionCache{}, featuremgmt.WithFeatures())
@@ -92,7 +93,7 @@ func TestQuery_Regions(t *testing.T) {
 		}
 
 		im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-			return datasourceInfo{}, nil
+			return DataSource{Settings: &models.CloudWatchSettings{}}, nil
 		})
 
 		executor := newExecutor(im, newTestConfig(), &fakeSessionCache{}, featuremgmt.WithFeatures())
@@ -159,7 +160,7 @@ func TestQuery_InstanceAttributes(t *testing.T) {
 		}
 
 		im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-			return datasourceInfo{}, nil
+			return DataSource{Settings: &models.CloudWatchSettings{}}, nil
 		})
 
 		filterMap := map[string][]string{
@@ -242,7 +243,7 @@ func TestQuery_EBSVolumeIDs(t *testing.T) {
 		}
 
 		im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-			return datasourceInfo{}, nil
+			return DataSource{Settings: &models.CloudWatchSettings{}}, nil
 		})
 
 		executor := newExecutor(im, newTestConfig(), &fakeSessionCache{}, featuremgmt.WithFeatures())
@@ -302,7 +303,7 @@ func TestQuery_ResourceARNs(t *testing.T) {
 		}
 
 		im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-			return datasourceInfo{}, nil
+			return DataSource{Settings: &models.CloudWatchSettings{}}, nil
 		})
 
 		tagMap := map[string][]string{
@@ -338,7 +339,7 @@ func TestQuery_ResourceARNs(t *testing.T) {
 func TestQuery_GetAllMetrics(t *testing.T) {
 	t.Run("all metrics in all namespaces are being returned", func(t *testing.T) {
 		im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-			return datasourceInfo{}, nil
+			return DataSource{Settings: &models.CloudWatchSettings{}}, nil
 		})
 
 		executor := newExecutor(im, newTestConfig(), &fakeSessionCache{}, featuremgmt.WithFeatures())

--- a/pkg/tsdb/cloudwatch/models/settings.go
+++ b/pkg/tsdb/cloudwatch/models/settings.go
@@ -1,0 +1,36 @@
+package models
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/grafana/grafana-aws-sdk/pkg/awsds"
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+)
+
+type CloudWatchSettings struct {
+	awsds.AWSDatasourceSettings
+	Namespace string `json:"customMetricsNamespaces"`
+}
+
+func LoadCloudWatchSettings(config backend.DataSourceInstanceSettings) (*CloudWatchSettings, error) {
+	instance := &CloudWatchSettings{}
+	if config.JSONData != nil && len(config.JSONData) > 1 {
+		if err := json.Unmarshal(config.JSONData, instance); err != nil {
+			return nil, fmt.Errorf("could not unmarshal DatasourceSettings json: %w", err)
+		}
+	}
+
+	if instance.Region == "default" || instance.Region == "" {
+		instance.Region = instance.DefaultRegion
+	}
+
+	if instance.Profile == "" {
+		instance.Profile = config.Database
+	}
+
+	instance.AccessKey = config.DecryptedSecureJSONData["accessKey"]
+	instance.SecretKey = config.DecryptedSecureJSONData["secretKey"]
+
+	return instance, nil
+}

--- a/pkg/tsdb/cloudwatch/models/settings_test.go
+++ b/pkg/tsdb/cloudwatch/models/settings_test.go
@@ -1,0 +1,74 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/grafana/grafana-aws-sdk/pkg/awsds"
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Settings_LoadCloudWatchSettings(t *testing.T) {
+	t.Run("Should parse keys query type", func(t *testing.T) {
+		settings := backend.DataSourceInstanceSettings{
+			ID: 33,
+			JSONData: []byte(`{
+			"authType": "keys",
+			"assumeRoleArn": "arn:aws:iam::123456789012:role/grafana",
+			"customMetricsNamespaces": "AWS/EC2,AWS/ELB",
+			"defaultRegion": "us-east-1",
+			"externalId": "123456789012",
+			"profile": "default",
+			"endpoint": "https://monitoring.us-east-1.amazonaws.com"
+		  }`),
+			DecryptedSecureJSONData: map[string]string{
+				"accessKey": "AKIAIOSFODNN7EXAMPLE",
+				"secretKey": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+			},
+		}
+
+		s, err := LoadCloudWatchSettings(settings)
+		require.NoError(t, err)
+		assert.Equal(t, awsds.AuthTypeKeys, s.AuthType)
+		assert.Equal(t, "arn:aws:iam::123456789012:role/grafana", s.AssumeRoleARN)
+		assert.Equal(t, "AWS/EC2,AWS/ELB", s.Namespace)
+		assert.Equal(t, "us-east-1", s.Region)
+		assert.Equal(t, "123456789012", s.ExternalID)
+		assert.Equal(t, "default", s.Profile)
+		assert.Equal(t, "https://monitoring.us-east-1.amazonaws.com", s.Endpoint)
+		assert.Equal(t, "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY", s.SecretKey)
+		assert.Equal(t, "AKIAIOSFODNN7EXAMPLE", s.AccessKey)
+	})
+
+	t.Run("Should handle legacy auth type arn as default", func(t *testing.T) {
+		settings := backend.DataSourceInstanceSettings{
+			ID: 33,
+			JSONData: []byte(`{
+			"authType": "arn",
+			"assumeRoleArn": "arn:aws:iam::123456789012:role/grafana",
+			"customMetricsNamespaces": "AWS/EC2,AWS/ELB",
+			"defaultRegion": "us-east-1",
+			"externalId": "123456789012",
+			"profile": "default",
+			"endpoint": "https://monitoring.us-east-1.amazonaws.com"
+		  }`),
+			DecryptedSecureJSONData: map[string]string{
+				"accessKey": "AKIAIOSFODNN7EXAMPLE",
+				"secretKey": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+			},
+		}
+
+		s, err := LoadCloudWatchSettings(settings)
+		require.NoError(t, err)
+		assert.Equal(t, awsds.AuthTypeDefault, s.AuthType)
+		assert.Equal(t, "arn:aws:iam::123456789012:role/grafana", s.AssumeRoleARN)
+		assert.Equal(t, "AWS/EC2,AWS/ELB", s.Namespace)
+		assert.Equal(t, "us-east-1", s.Region)
+		assert.Equal(t, "123456789012", s.ExternalID)
+		assert.Equal(t, "default", s.Profile)
+		assert.Equal(t, "https://monitoring.us-east-1.amazonaws.com", s.Endpoint)
+		assert.Equal(t, "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY", s.SecretKey)
+		assert.Equal(t, "AKIAIOSFODNN7EXAMPLE", s.AccessKey)
+	})
+}

--- a/pkg/tsdb/cloudwatch/time_series_query_test.go
+++ b/pkg/tsdb/cloudwatch/time_series_query_test.go
@@ -56,7 +56,7 @@ func TestTimeSeriesQuery(t *testing.T) {
 		}
 
 		im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-			return datasourceInfo{}, nil
+			return DataSource{Settings: &models.CloudWatchSettings{}}, nil
 		})
 
 		executor := newExecutor(im, newTestConfig(), &fakeSessionCache{}, featuremgmt.WithFeatures())
@@ -348,7 +348,7 @@ func Test_QueryData_timeSeriesQuery_GetMetricDataWithContext(t *testing.T) {
 	}
 
 	im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-		return datasourceInfo{}, nil
+		return DataSource{Settings: &models.CloudWatchSettings{}}, nil
 	})
 
 	t.Run("passes query label as GetMetricData label when dynamic labels feature toggle is enabled", func(t *testing.T) {
@@ -446,7 +446,7 @@ func Test_QueryData_response_data_frame_names(t *testing.T) {
 		},
 	}
 	im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-		return datasourceInfo{}, nil
+		return DataSource{Settings: &models.CloudWatchSettings{}}, nil
 	})
 	executor := newExecutor(im, newTestConfig(), &fakeSessionCache{}, featuremgmt.WithFeatures())
 

--- a/pkg/tsdb/cloudwatch/time_series_query_test.go
+++ b/pkg/tsdb/cloudwatch/time_series_query_test.go
@@ -156,7 +156,7 @@ func Test_executeTimeSeriesQuery_getCWClient_is_called_once_per_region_and_GetMe
 	}
 
 	im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-		return datasourceInfo{}, nil
+		return DataSource{Settings: &models.CloudWatchSettings{}}, nil
 	})
 
 	t.Run("Queries with the same region should call GetSession with that region 1 time and call GetMetricDataWithContext 1 time", func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR refactors the ds instance factory method. It now follows the same pattern as all the other AWS plugins. The ds instance settings is now moved to models package, which is a prerequisite for an upcoming PR.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Part of https://github.com/grafana/grafana/issues/57146

