### PR TITLE
Alerting: Add title and description to VictorOps contact point

### DIFF
--- a/pkg/services/ngalert/notifier/channels/victorops.go
+++ b/pkg/services/ngalert/notifier/channels/victorops.go
@@ -31,6 +31,8 @@ const (
 type victorOpsSettings struct {
 	URL         string `json:"url,omitempty" yaml:"url,omitempty"`
 	MessageType string `json:"messageType,omitempty" yaml:"messageType,omitempty"`
+	Title       string `json:"title,omitempty" yaml:"title,omitempty"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
 }
 
 func buildVictorOpsSettings(fc FactoryConfig) (victorOpsSettings, error) {
@@ -44,6 +46,12 @@ func buildVictorOpsSettings(fc FactoryConfig) (victorOpsSettings, error) {
 	}
 	if settings.MessageType == "" {
 		settings.MessageType = victoropsAlertStateCritical
+	}
+	if settings.Title == "" {
+		settings.Title = DefaultMessageTitleEmbed
+	}
+	if settings.Description == "" {
+		settings.Description = DefaultMessageEmbed
 	}
 	return settings, nil
 }
@@ -101,15 +109,7 @@ func (vn *VictoropsNotifier) Notify(ctx context.Context, as ...*types.Alert) (bo
 	var tmplErr error
 	tmpl, _ := TmplText(ctx, vn.tmpl, as, vn.log, &tmplErr)
 
-	messageType := strings.ToUpper(tmpl(vn.settings.MessageType))
-	if messageType == "" {
-		vn.log.Warn("expansion of message type template resulted in an empty string. Using fallback", "fallback", victoropsAlertStateCritical, "template", vn.settings.MessageType)
-		messageType = victoropsAlertStateCritical
-	}
-	alerts := types.Alerts(as...)
-	if alerts.Status() == model.AlertResolved {
-		messageType = victoropsAlertStateRecovery
-	}
+	messageType := buildMessageType(vn.log, tmpl, vn.settings.MessageType, as...)
 
 	groupKey, err := notify.ExtractGroupKey(ctx)
 	if err != nil {
@@ -119,9 +119,9 @@ func (vn *VictoropsNotifier) Notify(ctx context.Context, as ...*types.Alert) (bo
 	bodyJSON := map[string]interface{}{
 		"message_type":        messageType,
 		"entity_id":           groupKey.Hash(),
-		"entity_display_name": tmpl(DefaultMessageTitleEmbed),
+		"entity_display_name": tmpl(vn.settings.Title),
 		"timestamp":           time.Now().Unix(),
-		"state_message":       tmpl(DefaultMessageEmbed),
+		"state_message":       tmpl(vn.settings.Description),
 		"monitoring_tool":     "Grafana v" + setting.BuildVersion,
 	}
 
@@ -168,4 +168,15 @@ func (vn *VictoropsNotifier) Notify(ctx context.Context, as ...*types.Alert) (bo
 
 func (vn *VictoropsNotifier) SendResolved() bool {
 	return !vn.GetDisableResolveMessage()
+}
+
+func buildMessageType(l log.Logger, tmpl func(string) string, msgType string, as ...*types.Alert) string {
+	if types.Alerts(as...).Status() == model.AlertResolved {
+		return victoropsAlertStateRecovery
+	}
+	if messageType := strings.ToUpper(tmpl(msgType)); messageType != "" {
+		return messageType
+	}
+	l.Warn("expansion of message type template resulted in an empty string. Using fallback", "fallback", victoropsAlertStateCritical, "template", msgType)
+	return victoropsAlertStateCritical
 }

--- a/pkg/services/ngalert/notifier/channels/victorops_test.go
+++ b/pkg/services/ngalert/notifier/channels/victorops_test.go
@@ -105,6 +105,31 @@ func TestVictoropsNotifier(t *testing.T) {
 			},
 			expMsgError: nil,
 		}, {
+			name:     "Custom title and description",
+			settings: `{"url": "http://localhost", "title": "Alerts firing: {{ len .Alerts.Firing }}", "description": "customDescription"}`,
+			alerts: []*types.Alert{
+				{
+					Alert: model.Alert{
+						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+						Annotations: model.LabelSet{"ann1": "annv1"},
+					},
+				}, {
+					Alert: model.Alert{
+						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val2"},
+						Annotations: model.LabelSet{"ann1": "annv2"},
+					},
+				},
+			},
+			expMsg: map[string]interface{}{
+				"alert_url":           "http://localhost/alerting/list",
+				"entity_display_name": "Alerts firing: 2",
+				"entity_id":           "6e3538104c14b583da237e9693b76debbc17f0f8058ef20492e5853096cf8733",
+				"message_type":        "CRITICAL",
+				"monitoring_tool":     "Grafana v" + setting.BuildVersion,
+				"state_message":       "customDescription",
+			},
+			expMsgError: nil,
+		}, {
 			name:     "Missing field in template",
 			settings: `{"url": "http://localhost", "messageType": "custom template {{ .NotAField }} bad template"}`,
 			alerts: []*types.Alert{

--- a/pkg/services/ngalert/notifier/channels_config/available_channels.go
+++ b/pkg/services/ngalert/notifier/channels_config/available_channels.go
@@ -300,7 +300,7 @@ func GetAvailableNotifiers() []*NotifierPlugin {
 					Label:        "Title",
 					Element:      ElementTypeInput,
 					InputType:    InputTypeText,
-					Description:  "Templated title to display.",
+					Description:  "Templated title to display",
 					PropertyName: "title",
 					Placeholder:  channels.DefaultMessageTitleEmbed,
 				},

--- a/pkg/services/ngalert/notifier/channels_config/available_channels.go
+++ b/pkg/services/ngalert/notifier/channels_config/available_channels.go
@@ -296,6 +296,22 @@ func GetAvailableNotifiers() []*NotifierPlugin {
 						},
 					},
 				},
+				{ // New in 9.3.
+					Label:        "Title",
+					Element:      ElementTypeInput,
+					InputType:    InputTypeText,
+					Description:  "Templated title to display.",
+					PropertyName: "title",
+					Placeholder:  channels.DefaultMessageTitleEmbed,
+				},
+				{ // New in 9.3.
+					Label:        "Description",
+					Element:      ElementTypeInput,
+					InputType:    InputTypeText,
+					Description:  "Templated description of the message",
+					PropertyName: "description",
+					Placeholder:  channels.DefaultMessageEmbed,
+				},
 			},
 		},
 		{


### PR DESCRIPTION
**What this PR does / why we need it**:

It allows users to add a custom title and description for VictorOps contact points.
It defaults to title and description default messages.