### PR TITLE
NodeGraph: Fix rendering issues when values of arc are over 1

### DIFF
--- a/public/app/plugins/panel/nodeGraph/Node.tsx
+++ b/public/app/plugins/panel/nodeGraph/Node.tsx
@@ -123,7 +123,7 @@ export const Node = memo(function Node(props: {
  */
 function ColorCircle(props: { node: NodeDatum }) {
   const { node } = props;
-  const fullStat = node.arcSections.find((s) => s.values.get(node.dataFrameRowIndex) === 1);
+  const fullStat = node.arcSections.find((s) => s.values.get(node.dataFrameRowIndex) >= 1);
   const theme = useTheme2();
 
   if (fullStat) {
@@ -159,6 +159,7 @@ function ColorCircle(props: { node: NodeDatum }) {
     (acc, section) => {
       const color = section.config.color?.fixedColor || '';
       const value = section.values.get(node.dataFrameRowIndex);
+
       const el = (
         <ArcSection
           key={color}
@@ -166,7 +167,13 @@ function ColorCircle(props: { node: NodeDatum }) {
           x={node.x!}
           y={node.y!}
           startPercent={acc.percent}
-          percent={value}
+          percent={
+            value + acc.percent > 1
+              ? // If the values aren't correct and add up to more than 100% lets still render correctly the amounts we
+                // already have and cap it at 100%
+                1 - acc.percent
+              : value
+          }
           color={theme.visualization.getColorByName(color)}
           strokeWidth={2}
         />


### PR DESCRIPTION
Fixes: https://github.com/grafana/grafana/issues/54683

If the arc values that define the parts of the colored circles in node graph are >1 we rendered the arcs in a weird way:
![Screenshot from 2022-10-21 17-04-35](https://user-images.githubusercontent.com/1014802/197228840-dcd4ef80-f4ec-488d-895f-27a9780a73f0.png)

^ this is when the value is 1.1. Also if multiple section added to more than 1 we just kept circling and overwriting previous arc section:
![Screenshot from 2022-10-21 17-03-59](https://user-images.githubusercontent.com/1014802/197229048-b8c55898-c29a-4b68-936f-7e07c3a54d8e.png)

^ here it's 0.9 success and 0.2 error rate.

This makes sure we always render max 100% of the arc and stop there.