### PR TITLE
ObjectStore: Add folder to kind registry

### DIFF
--- a/pkg/services/store/kind/folder/summary.go
+++ b/pkg/services/store/kind/folder/summary.go
@@ -3,9 +3,9 @@ package folder
 import (
 	"context"
 	"encoding/json"
-	"strings"
 
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/store"
 )
 
 type Model struct {
@@ -29,7 +29,7 @@ func GetObjectSummaryBuilder() models.ObjectSummaryBuilder {
 		}
 
 		if obj.Name == "" {
-			obj.Name = guessNameFromUID(uid)
+			obj.Name = store.GuessNameFromUID(uid)
 		}
 
 		summary := &models.ObjectSummary{
@@ -42,16 +42,4 @@ func GetObjectSummaryBuilder() models.ObjectSummaryBuilder {
 		out, err := json.MarshalIndent(obj, "", "  ")
 		return summary, out, err
 	}
-}
-
-func guessNameFromUID(uid string) string {
-	sidx := strings.LastIndex(uid, "/") + 1
-	didx := strings.LastIndex(uid, ".")
-	if didx > sidx && didx != sidx {
-		return uid[sidx:didx]
-	}
-	if sidx > 0 {
-		return uid[sidx:]
-	}
-	return uid
 }

--- a/pkg/services/store/kind/folder/summary.go
+++ b/pkg/services/store/kind/folder/summary.go
@@ -1,0 +1,57 @@
+package folder
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	"github.com/grafana/grafana/pkg/models"
+)
+
+type Model struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+}
+
+func GetObjectKindInfo() models.ObjectKindInfo {
+	return models.ObjectKindInfo{
+		ID:   models.StandardKindFolder,
+		Name: "Folder",
+	}
+}
+
+func GetObjectSummaryBuilder() models.ObjectSummaryBuilder {
+	return func(ctx context.Context, uid string, body []byte) (*models.ObjectSummary, []byte, error) {
+		obj := &Model{}
+		err := json.Unmarshal(body, obj)
+		if err != nil {
+			return nil, nil, err // unable to read object
+		}
+
+		if obj.Name == "" {
+			obj.Name = guessNameFromUID(uid)
+		}
+
+		summary := &models.ObjectSummary{
+			Kind:        models.StandardKindFolder,
+			Name:        obj.Name,
+			Description: obj.Description,
+			UID:         uid,
+		}
+
+		out, err := json.MarshalIndent(obj, "", "  ")
+		return summary, out, err
+	}
+}
+
+func guessNameFromUID(uid string) string {
+	sidx := strings.LastIndex(uid, "/") + 1
+	didx := strings.LastIndex(uid, ".")
+	if didx > sidx && didx != sidx {
+		return uid[sidx:didx]
+	}
+	if sidx > 0 {
+		return uid[sidx:]
+	}
+	return uid
+}

--- a/pkg/services/store/kind/geojson/summary.go
+++ b/pkg/services/store/kind/geojson/summary.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/store"
 )
 
 func GetObjectKindInfo() models.ObjectKindInfo {
@@ -40,7 +40,7 @@ func GetObjectSummaryBuilder() models.ObjectSummaryBuilder {
 
 		summary := &models.ObjectSummary{
 			Kind: models.StandardKindGeoJSON,
-			Name: guessNameFromUID(uid),
+			Name: store.GuessNameFromUID(uid),
 			UID:  uid,
 			Fields: map[string]interface{}{
 				"type": ftype,
@@ -56,16 +56,4 @@ func GetObjectSummaryBuilder() models.ObjectSummaryBuilder {
 
 		return summary, body, nil
 	}
-}
-
-func guessNameFromUID(uid string) string {
-	sidx := strings.LastIndex(uid, "/") + 1
-	didx := strings.LastIndex(uid, ".")
-	if didx > sidx && didx != sidx {
-		return uid[sidx:didx]
-	}
-	if sidx > 0 {
-		return uid[sidx:]
-	}
-	return uid
 }

--- a/pkg/services/store/kind/playlist/summary.go
+++ b/pkg/services/store/kind/playlist/summary.go
@@ -34,8 +34,9 @@ func summaryBuilder(ctx context.Context, uid string, body []byte) (*models.Objec
 		obj.Items = &temp
 	}
 
+	obj.Uid = uid // make sure they are consistent
 	summary := &models.ObjectSummary{
-		UID:         obj.Uid,
+		UID:         uid,
 		Name:        obj.Name,
 		Description: fmt.Sprintf("%d items, refreshed every %s", len(*obj.Items), obj.Interval),
 	}

--- a/pkg/services/store/kind/playlist/summary.go
+++ b/pkg/services/store/kind/playlist/summary.go
@@ -62,6 +62,6 @@ func summaryBuilder(ctx context.Context, uid string, body []byte) (*models.Objec
 		}
 	}
 
-	out, err := json.Marshal(obj)
+	out, err := json.MarshalIndent(obj, "", "  ")
 	return summary, out, err
 }

--- a/pkg/services/store/kind/png/summary.go
+++ b/pkg/services/store/kind/png/summary.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"context"
 	"image/png"
-	"strings"
 
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/store"
 )
 
 func GetObjectKindInfo() models.ObjectKindInfo {
@@ -31,7 +31,7 @@ func GetObjectSummaryBuilder() models.ObjectSummaryBuilder {
 		size := img.Bounds().Size()
 		summary := &models.ObjectSummary{
 			Kind: models.StandardKindSVG,
-			Name: guessNameFromUID(uid),
+			Name: store.GuessNameFromUID(uid),
 			UID:  uid,
 			Fields: map[string]interface{}{
 				"width":  int64(size.X),
@@ -40,16 +40,4 @@ func GetObjectSummaryBuilder() models.ObjectSummaryBuilder {
 		}
 		return summary, body, nil
 	}
-}
-
-func guessNameFromUID(uid string) string {
-	sidx := strings.LastIndex(uid, "/") + 1
-	didx := strings.LastIndex(uid, ".")
-	if didx > sidx && didx != sidx {
-		return uid[sidx:didx]
-	}
-	if sidx > 0 {
-		return uid[sidx:]
-	}
-	return uid
 }

--- a/pkg/services/store/kind/registry.go
+++ b/pkg/services/store/kind/registry.go
@@ -9,6 +9,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/rendering"
 	"github.com/grafana/grafana/pkg/services/store/kind/dashboard"
 	"github.com/grafana/grafana/pkg/services/store/kind/dummy"
+	"github.com/grafana/grafana/pkg/services/store/kind/folder"
 	"github.com/grafana/grafana/pkg/services/store/kind/geojson"
 	"github.com/grafana/grafana/pkg/services/store/kind/playlist"
 	"github.com/grafana/grafana/pkg/services/store/kind/png"
@@ -32,6 +33,10 @@ func NewKindRegistry() KindRegistry {
 	kinds[models.StandardKindDashboard] = &kindValues{
 		info:    dashboard.GetObjectKindInfo(),
 		builder: dashboard.GetObjectSummaryBuilder(),
+	}
+	kinds[models.StandardKindFolder] = &kindValues{
+		info:    folder.GetObjectKindInfo(),
+		builder: folder.GetObjectSummaryBuilder(),
 	}
 	kinds[models.StandardKindPNG] = &kindValues{
 		info:    png.GetObjectKindInfo(),

--- a/pkg/services/store/kind/registry_test.go
+++ b/pkg/services/store/kind/registry_test.go
@@ -21,6 +21,7 @@ func TestKindRegistry(t *testing.T) {
 	require.Equal(t, []string{
 		"dashboard",
 		"dummy",
+		"folder",
 		"geojson",
 		"kind1",
 		"kind2",

--- a/pkg/services/store/utils.go
+++ b/pkg/services/store/utils.go
@@ -7,6 +7,18 @@ import (
 	"github.com/grafana/grafana/pkg/web"
 )
 
+func GuessNameFromUID(uid string) string {
+	sidx := strings.LastIndex(uid, "/") + 1
+	didx := strings.LastIndex(uid, ".")
+	if didx > sidx && didx != sidx {
+		return uid[sidx:didx]
+	}
+	if sidx > 0 {
+		return uid[sidx:]
+	}
+	return uid
+}
+
 func splitFirstSegment(path string) (string, string) {
 	idx := strings.Index(path, "/")
 	if idx == 0 {

--- a/pkg/services/store/utils_test.go
+++ b/pkg/services/store/utils_test.go
@@ -7,6 +7,12 @@ import (
 )
 
 func TestUtils(t *testing.T) {
+	require.Equal(t, "name", GuessNameFromUID("hello/name.xyz"))
+	require.Equal(t, "name", GuessNameFromUID("name.xyz"))
+	require.Equal(t, "name", GuessNameFromUID("name"))
+	require.Equal(t, "name", GuessNameFromUID("name."))
+	require.Equal(t, "name", GuessNameFromUID("/name."))
+
 	a, b := splitFirstSegment("")
 	require.Equal(t, "", a)
 	require.Equal(t, "", b)


### PR DESCRIPTION
This adds folders  to the object store kind registry.

It also removes or resets the uids stored within object payloads (they should be managed by the container!)