### PR TITLE
Playlist: allow using object store as the backend

### DIFF
--- a/pkg/services/playlist/playlistimpl/object_store.go
+++ b/pkg/services/playlist/playlistimpl/object_store.go
@@ -1,0 +1,139 @@
+package playlistimpl
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/playlist"
+	"github.com/grafana/grafana/pkg/services/store/object"
+)
+
+// This is a playlist implementation that will:
+// 1. CREATE/UPDATE/DELETE everythign with existing direct SQL store
+// 2. CREATE/UPDATE/DELETE same items to the object store
+// 3. Use the object store for all read operations
+// This givs us a safe test bed to work with the store but still roll back without any lost work
+type objectStoreImpl struct {
+	backup store // raw SQL store
+	server object.ObjectStoreServer
+}
+
+var _ playlist.Service = &objectStoreImpl{}
+
+func (s *objectStoreImpl) sync() {
+	// TODO? need to get a user for each org
+}
+
+func (s *objectStoreImpl) Create(ctx context.Context, cmd *playlist.CreatePlaylistCommand) (*playlist.Playlist, error) {
+	rsp, err := s.backup.Insert(ctx, cmd)
+	if err == nil && rsp != nil {
+		body, err := json.Marshal(rsp)
+		if err != nil {
+			return rsp, fmt.Errorf("unable to write playlist to store")
+		}
+		_, err = s.server.Write(ctx, &object.WriteObjectRequest{
+			UID:  rsp.UID,
+			Kind: models.StandardKindPlaylist,
+			Body: body,
+		})
+		if err != nil {
+			return rsp, fmt.Errorf("unable to write playlist to store")
+		}
+	}
+	return rsp, err
+}
+
+func (s *objectStoreImpl) Update(ctx context.Context, cmd *playlist.UpdatePlaylistCommand) (*playlist.PlaylistDTO, error) {
+	rsp, err := s.backup.Update(ctx, cmd)
+	if err == nil {
+		body, err := json.Marshal(rsp)
+		if err != nil {
+			return rsp, fmt.Errorf("unable to write playlist to store")
+		}
+		_, err = s.server.Write(ctx, &object.WriteObjectRequest{
+			UID:  rsp.Uid,
+			Kind: models.StandardKindPlaylist,
+			Body: body,
+		})
+		if err != nil {
+			return rsp, fmt.Errorf("unable to write playlist to store")
+		}
+	}
+	return rsp, err
+}
+
+func (s *objectStoreImpl) Delete(ctx context.Context, cmd *playlist.DeletePlaylistCommand) error {
+	err := s.backup.Delete(ctx, cmd)
+	if err == nil {
+		_, err = s.server.Delete(ctx, &object.DeleteObjectRequest{
+			UID:  cmd.UID,
+			Kind: models.StandardKindPlaylist,
+		})
+		if err != nil {
+			return fmt.Errorf("unable to delete playlist to store")
+		}
+	}
+	return err
+}
+
+//------------------------------------------------------
+// Read access is managed entirely by the object store
+//------------------------------------------------------
+
+func (s *objectStoreImpl) GetWithoutItems(ctx context.Context, q *playlist.GetPlaylistByUidQuery) (*playlist.Playlist, error) {
+	p, err := s.Get(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+	return &playlist.Playlist{
+		UID:      p.Uid,
+		Name:     p.Name,
+		Interval: p.Interval,
+	}, nil
+}
+
+func (s *objectStoreImpl) Get(ctx context.Context, q *playlist.GetPlaylistByUidQuery) (*playlist.PlaylistDTO, error) {
+	rsp, err := s.server.Read(ctx, &object.ReadObjectRequest{
+		UID:      q.UID,
+		Kind:     models.StandardKindPlaylist,
+		WithBody: true,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if rsp.Object == nil || rsp.Object.Body == nil {
+		return nil, fmt.Errorf("missing object")
+	}
+
+	// Get the object from payload
+	found := &playlist.PlaylistDTO{}
+	err = json.Unmarshal(rsp.Object.Body, found)
+	return found, err
+}
+
+func (s *objectStoreImpl) Search(ctx context.Context, q *playlist.GetPlaylistsQuery) (playlist.Playlists, error) {
+	playlists := make(playlist.Playlists, 0)
+
+	rsp, err := s.server.Search(ctx, &object.ObjectSearchRequest{
+		Kind:     []string{models.StandardKindPlaylist},
+		WithBody: true,
+		Limit:    1000,
+	})
+	if err != nil {
+		return nil, err
+	}
+	for _, res := range rsp.Results {
+		found := &playlist.PlaylistDTO{}
+		if res.Body != nil {
+			err = json.Unmarshal(res.Body, found)
+		}
+		playlists = append(playlists, &playlist.Playlist{
+			UID:      res.UID,
+			Name:     res.Name,
+			Interval: found.Interval,
+		})
+	}
+	return playlists, err
+}

--- a/pkg/services/playlist/playlistimpl/playlist.go
+++ b/pkg/services/playlist/playlistimpl/playlist.go
@@ -33,9 +33,9 @@ func ProvideService(db db.DB, toggles featuremgmt.FeatureToggles, objserver obje
 	// FlagObjectStore is only supported in development mode
 	if toggles.IsEnabled(featuremgmt.FlagObjectStore) {
 		impl := &objectStoreImpl{
-			backup: svc,
-			server: objserver,
-			sess:   db.GetSqlxSession(),
+			sqlimpl:     svc,
+			objectstore: objserver,
+			sess:        db.GetSqlxSession(),
 		}
 		impl.sync() // load everythign from the existing SQL setup into the new object store
 		return impl

--- a/pkg/services/playlist/playlistimpl/playlist.go
+++ b/pkg/services/playlist/playlistimpl/playlist.go
@@ -34,6 +34,7 @@ func ProvideService(db db.DB, toggles featuremgmt.FeatureToggles, objserver obje
 		impl := &objectStoreImpl{
 			backup: sqlstore,
 			server: objserver,
+			sess:   db.GetSqlxSession(),
 		}
 		impl.sync() // load everythign from the existing SQL setup into the new object store
 		return impl

--- a/pkg/services/playlist/playlistimpl/playlist.go
+++ b/pkg/services/playlist/playlistimpl/playlist.go
@@ -28,11 +28,12 @@ func ProvideService(db db.DB, toggles featuremgmt.FeatureToggles, objserver obje
 			db: db,
 		}
 	}
+	svc := &Service{store: sqlstore}
 
 	// This is currently a developement only feature toggle
 	if toggles.IsEnabled(featuremgmt.FlagObjectStore) {
 		impl := &objectStoreImpl{
-			backup: sqlstore,
+			backup: svc,
 			server: objserver,
 			sess:   db.GetSqlxSession(),
 		}
@@ -40,7 +41,7 @@ func ProvideService(db db.DB, toggles featuremgmt.FeatureToggles, objserver obje
 		return impl
 	}
 
-	return &Service{store: sqlstore}
+	return svc
 }
 
 func (s *Service) Create(ctx context.Context, cmd *playlist.CreatePlaylistCommand) (*playlist.Playlist, error) {

--- a/pkg/services/playlist/playlistimpl/playlist.go
+++ b/pkg/services/playlist/playlistimpl/playlist.go
@@ -30,7 +30,7 @@ func ProvideService(db db.DB, toggles featuremgmt.FeatureToggles, objserver obje
 	}
 	svc := &Service{store: sqlstore}
 
-	// This is currently a developement only feature toggle
+	// FlagObjectStore is only supported in development mode
 	if toggles.IsEnabled(featuremgmt.FlagObjectStore) {
 		impl := &objectStoreImpl{
 			backup: svc,

--- a/pkg/services/playlist/playlistimpl/playlist.go
+++ b/pkg/services/playlist/playlistimpl/playlist.go
@@ -4,27 +4,42 @@ import (
 	"context"
 
 	"github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/playlist"
-	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/services/store/object"
 )
 
 type Service struct {
 	store store
 }
 
-func ProvideService(db db.DB, cfg *setting.Cfg) playlist.Service {
-	if cfg.IsFeatureToggleEnabled("newDBLibrary") {
-		return &Service{
-			store: &sqlxStore{
-				sess: db.GetSqlxSession(),
-			},
+var _ playlist.Service = &Service{}
+
+func ProvideService(db db.DB, toggles featuremgmt.FeatureToggles, objserver object.ObjectStoreServer) playlist.Service {
+	var sqlstore store
+
+	// 🐢🐢🐢 pick the store
+	if toggles.IsEnabled("newDBLibrary") { // hymmm not a registered feature flag
+		sqlstore = &sqlxStore{
+			sess: db.GetSqlxSession(),
+		}
+	} else {
+		sqlstore = &sqlStore{
+			db: db,
 		}
 	}
-	return &Service{
-		store: &sqlStore{
-			db: db,
-		},
+
+	// This is currently a developement only feature toggle
+	if toggles.IsEnabled(featuremgmt.FlagObjectStore) {
+		impl := &objectStoreImpl{
+			backup: sqlstore,
+			server: objserver,
+		}
+		impl.sync() // load everythign from the existing SQL setup into the new object store
+		return impl
 	}
+
+	return &Service{store: sqlstore}
 }
 
 func (s *Service) Create(ctx context.Context, cmd *playlist.CreatePlaylistCommand) (*playlist.Playlist, error) {

--- a/pkg/services/store/object/dummy/dummy_server.go
+++ b/pkg/services/store/object/dummy/dummy_server.go
@@ -351,14 +351,24 @@ func (i dummyObjectServer) Search(ctx context.Context, r *object.ObjectSearchReq
 
 	searchResults := make([]*object.ObjectSearchResult, 0)
 	for _, o := range objects {
+		builder := i.kinds.GetSummaryBuilder(o.Object.Kind)
+		if builder == nil {
+			continue
+		}
+		summary, clean, e2 := builder(ctx, o.Object.UID, o.Object.Body)
+		if e2 != nil {
+			continue
+		}
+
 		searchResults = append(searchResults, &object.ObjectSearchResult{
-			UID:       o.Object.UID,
-			Kind:      o.Object.Kind,
-			Version:   o.Object.Version,
-			Updated:   o.Object.Updated,
-			UpdatedBy: o.Object.UpdatedBy,
-			Name:      "? name from summary",
-			Body:      o.Object.Body,
+			UID:         o.Object.UID,
+			Kind:        o.Object.Kind,
+			Version:     o.Object.Version,
+			Updated:     o.Object.Updated,
+			UpdatedBy:   o.Object.UpdatedBy,
+			Name:        summary.Name,
+			Description: summary.Description,
+			Body:        clean,
 		})
 	}
 


### PR DESCRIPTION
This updates the playlist implementation so that when object store is enabled (devmode only), we write to both the existing SQL tables and the new object store.

This will let us roll-back to SQL without any loss