### PR TITLE
TimeSeries: fix negative stacked percent y-axis range

### DIFF
--- a/packages/grafana-ui/src/components/TimeSeries/utils.ts
+++ b/packages/grafana-ui/src/components/TimeSeries/utils.ts
@@ -223,7 +223,14 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn<{
           softMin: customConfig.axisSoftMin,
           softMax: customConfig.axisSoftMax,
           centeredZero: customConfig.axisCenteredZero,
-          range: customConfig.stacking?.mode === StackingMode.Percent ? [0, 1] : undefined,
+          range:
+            customConfig.stacking?.mode === StackingMode.Percent
+              ? (u: uPlot, dataMin: number, dataMax: number) => {
+                  dataMin = dataMin < 0 ? -1 : 0;
+                  dataMax = dataMax > 0 ? 1 : 0;
+                  return [dataMin, dataMax];
+                }
+              : undefined,
           decimals: field.config.decimals,
         },
         field


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/57352

i regressed this in https://github.com/grafana/grafana/pull/54197