### PR TITLE
Fix broken image links

### DIFF
--- a/docs/sources/datasources/prometheus.md
+++ b/docs/sources/datasources/prometheus.md
@@ -90,7 +90,7 @@ The "Validate selector" button will check with Prometheus how many time series a
 
 #### Options
 
-![Options](/static/img/docs/prometheus/options-9-1.png 'Options')
+![Options](/static/img/docs/prometheus/options-8-5.png 'Options')
 
 | Name        | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -148,7 +148,7 @@ In same cases the query editor can detect which operations would be most appropr
 
 ### Explain
 
-![Explain mode](/static/img/docs/prometheus/explain-9-1.png 'Explain mode')
+![Explain mode](/static/img/docs/prometheus/explain-9-1.gif 'Explain mode')
 
 Explain mode helps with understanding the query. It shows a step by step explanation of all query parts and the operations.
 


### PR DESCRIPTION
See 404s below:
![image](https://user-images.githubusercontent.com/820946/197306437-6e7a76f5-95d3-4e5f-8f20-f93f1bba38a6.png)

This is fixing above that was introduced in this PR: https://github.com/grafana/grafana/pull/53062/files
Specifically 
- https://github.com/grafana/grafana/pull/53062/files#diff-94bbcaec653f06a96ef581b5a4f4a79cfb9d4e3792890451f4b183626a044e3cR151
- https://github.com/grafana/grafana/pull/53062/files#diff-94bbcaec653f06a96ef581b5a4f4a79cfb9d4e3792890451f4b183626a044e3cR93
See what we have: https://github.com/grafana/website/tree/master/static/static/img/docs/prometheus

