### PR TITLE
Alerting: Pass metric name and values to notification templates

### DIFF
--- a/pkg/expr/classic/classic.go
+++ b/pkg/expr/classic/classic.go
@@ -93,9 +93,7 @@ func (cmd *ConditionsCmd) Execute(_ context.Context, _ time.Time, vars mathexp.V
 				name = v.GetName()
 			case mathexp.Number:
 				reducedNum = v
-				if len(v.Frame.Fields) > 0 {
-					name = v.Frame.Fields[0].Name
-				}
+				name = v.GetName()
 			default:
 				return newRes, fmt.Errorf("can only reduce type series, got type %v", val.Type())
 			}

--- a/pkg/expr/commands.go
+++ b/pkg/expr/commands.go
@@ -165,7 +165,7 @@ func (gr *ReduceCommand) Execute(_ context.Context, _ time.Time, vars mathexp.Va
 			}
 			newRes.Values = append(newRes.Values, num)
 		case mathexp.Number: // if incoming vars is just a number, any reduce op is just a noop, add it as it is
-			copyV := mathexp.NewNumber(gr.refID, v.GetLabels())
+			copyV := mathexp.NewNumber(v.GetName(), v.GetLabels())
 			copyV.SetValue(v.GetFloat64Value())
 			copyV.AddNotice(data.Notice{
 				Severity: data.NoticeSeverityWarning,
@@ -270,7 +270,7 @@ func (gr *ResampleCommand) Execute(_ context.Context, now time.Time, vars mathex
 		if !ok {
 			return newRes, fmt.Errorf("can only resample type series, got type %v", val.Type())
 		}
-		num, err := series.Resample(gr.refID, gr.Window, gr.Downsampler, gr.Upsampler, timeRange.From, timeRange.To)
+		num, err := series.Resample(gr.Window, gr.Downsampler, gr.Upsampler, timeRange.From, timeRange.To)
 		if err != nil {
 			return newRes, err
 		}

--- a/pkg/expr/mathexp/funcs.go
+++ b/pkg/expr/mathexp/funcs.go
@@ -202,8 +202,9 @@ func perFloat(e *State, val Value, floatF func(x float64) float64) (Value, error
 	var newVal Value
 	switch val.Type() {
 	case parse.TypeNumberSet:
-		n := NewNumber(e.RefID, val.GetLabels())
-		f := val.(Number).GetFloat64Value()
+		number := val.(Number)
+		n := NewNumber(number.GetName(), val.GetLabels())
+		f := number.GetFloat64Value()
 		nF := math.NaN()
 		if f != nil {
 			nF = floatF(*f)
@@ -219,7 +220,7 @@ func perFloat(e *State, val Value, floatF func(x float64) float64) (Value, error
 		newVal = NewScalar(e.RefID, &nF)
 	case parse.TypeSeriesSet:
 		resSeries := val.(Series)
-		newSeries := NewSeries(e.RefID, resSeries.GetLabels(), resSeries.Len())
+		newSeries := NewSeries(resSeries.GetName(), resSeries.GetLabels(), resSeries.Len())
 		for i := 0; i < resSeries.Len(); i++ {
 			t, f := resSeries.GetPoint(i)
 			nF := math.NaN()
@@ -252,7 +253,7 @@ func perNullableFloat(e *State, val Value, floatF func(x *float64) *float64) (Va
 		newVal = NewScalar(e.RefID, floatF(f))
 	case parse.TypeSeriesSet:
 		resSeries := val.(Series)
-		newSeries := NewSeries(e.RefID, resSeries.GetLabels(), resSeries.Len())
+		newSeries := NewSeries(resSeries.GetName(), resSeries.GetLabels(), resSeries.Len())
 		for i := 0; i < resSeries.Len(); i++ {
 			t, f := resSeries.GetPoint(i)
 			newSeries.SetPoint(i, t, floatF(f))

--- a/pkg/expr/mathexp/reduce.go
+++ b/pkg/expr/mathexp/reduce.go
@@ -113,7 +113,7 @@ func (s Series) Reduce(refID, rFunc string, mapper ReduceMapper) (Number, error)
 	if s.GetLabels() != nil {
 		l = s.GetLabels().Copy()
 	}
-	number := NewNumber(refID, l)
+	number := NewNumber(s.GetName(), l)
 	var f *float64
 	series := s
 	if mapper != nil {
@@ -129,6 +129,7 @@ func (s Series) Reduce(refID, rFunc string, mapper ReduceMapper) (Number, error)
 	if f != nil && mapper != nil {
 		f = mapper.MapOutput(f)
 	}
+	number.Frame.Fields[0].Name = series.GetName()
 	number.SetValue(f)
 	return number, nil
 }
@@ -140,7 +141,7 @@ type ReduceMapper interface {
 
 // mapSeries creates a series where all points are mapped using the provided map function ReduceMapper.MapInput
 func mapSeries(s Series, mapper ReduceMapper) Series {
-	newSeries := NewSeries(s.Frame.RefID, s.GetLabels(), 0)
+	newSeries := NewSeries(s.GetName(), s.GetLabels(), 0)
 	for i := 0; i < s.Len(); i++ {
 		f := s.GetValue(i)
 		f = mapper.MapInput(f)

--- a/pkg/expr/mathexp/resample.go
+++ b/pkg/expr/mathexp/resample.go
@@ -8,12 +8,12 @@ import (
 )
 
 // Resample turns the Series into a Number based on the given reduction function
-func (s Series) Resample(refID string, interval time.Duration, downsampler string, upsampler string, from, to time.Time) (Series, error) {
+func (s Series) Resample(interval time.Duration, downsampler string, upsampler string, from, to time.Time) (Series, error) {
 	newSeriesLength := int(float64(to.Sub(from).Nanoseconds()) / float64(interval.Nanoseconds()))
 	if newSeriesLength <= 0 {
 		return s, fmt.Errorf("the series cannot be sampled further; the time range is shorter than the interval")
 	}
-	resampled := NewSeries(refID, s.GetLabels(), newSeriesLength+1)
+	resampled := NewSeries(s.GetName(), s.GetLabels(), newSeriesLength+1)
 	bookmark := 0
 	var lastSeen *float64
 	idx := 0

--- a/pkg/expr/mathexp/resample_test.go
+++ b/pkg/expr/mathexp/resample_test.go
@@ -280,7 +280,7 @@ func TestResampleSeries(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			series, err := tt.seriesToResample.Resample("", tt.interval, tt.downsampler, tt.upsampler, tt.timeRange.From, tt.timeRange.To)
+			series, err := tt.seriesToResample.Resample(tt.interval, tt.downsampler, tt.upsampler, tt.timeRange.From, tt.timeRange.To)
 			if tt.series.Frame == nil {
 				require.Error(t, err)
 			} else {

--- a/pkg/expr/mathexp/type_series.go
+++ b/pkg/expr/mathexp/type_series.go
@@ -128,10 +128,10 @@ FIELDS:
 }
 
 // NewSeries returns a dataframe of type Series.
-func NewSeries(refID string, labels data.Labels, size int) Series {
+func NewSeries(name string, labels data.Labels, size int) Series {
 	fields := make([]*data.Field, 2)
 	fields[seriesTypeTimeIdx] = data.NewField("Time", nil, make([]time.Time, size))
-	fields[seriesTypeValIdx] = data.NewField(refID, labels, make([]*float64, size))
+	fields[seriesTypeValIdx] = data.NewField(name, labels, make([]*float64, size))
 
 	return Series{
 		Frame: data.NewFrame("", fields...),

--- a/pkg/expr/mathexp/type_series.go
+++ b/pkg/expr/mathexp/type_series.go
@@ -148,7 +148,9 @@ func (s Series) GetLabels() data.Labels { return s.Frame.Fields[seriesTypeValIdx
 
 func (s Series) SetLabels(ls data.Labels) { s.Frame.Fields[seriesTypeValIdx].Labels = ls }
 
-func (s Series) GetName() string { return s.Frame.Fields[seriesTypeValIdx].Name }
+func (s Series) GetName() string {
+	return getFieldDisplayName(s.Frame, s.Frame.Fields[seriesTypeValIdx])
+}
 
 func (s Series) GetMeta() interface{} {
 	return s.Frame.Meta.Custom

--- a/pkg/expr/mathexp/types.go
+++ b/pkg/expr/mathexp/types.go
@@ -106,6 +106,8 @@ func (n Number) Type() parse.ReturnType { return parse.TypeNumberSet }
 // Value returns the actual value allows it to fulfill the Value interface.
 func (n Number) Value() interface{} { return &n }
 
+func (n Number) GetName() string { return n.Frame.Fields[0].Name }
+
 func (n Number) GetLabels() data.Labels { return n.Frame.Fields[0].Labels }
 
 func (n Number) SetLabels(ls data.Labels) { n.Frame.Fields[0].Labels = ls }

--- a/pkg/services/ngalert/eval/eval.go
+++ b/pkg/services/ngalert/eval/eval.go
@@ -330,11 +330,8 @@ func queryDataResponseToExecutionResults(c models.Condition, execResp *backend.Q
 				}
 				continue
 			}
-			var v *float64
-			if frame.Fields[0].Len() == 1 {
-				v = frame.At(0, 0).(*float64) // type checked above
-			}
-			captureVal(frame.RefID, frame.Fields[0].Labels, frame.Fields[0].Name, v)
+			number := mathexp.Number{Frame: frame}
+			captureVal(frame.RefID, number.GetLabels(), number.GetName(), number.GetFloat64Value())
 		}
 
 		if refID == c.Condition {

--- a/pkg/services/ngalert/eval/eval.go
+++ b/pkg/services/ngalert/eval/eval.go
@@ -155,9 +155,7 @@ type Result struct {
 	// Results contains the results of all queries, reduce and math expressions
 	Results map[string]data.Frames
 
-	// Values contains the RefID and value of reduce and math expressions.
-	// It does not contain values for classic conditions as the values
-	// in classic conditions do not have a RefID.
+	// Values contains the metric and value of the condition's reduce or math expression.
 	Values map[string]NumberValueCapture
 
 	EvaluatedAt        time.Time

--- a/pkg/services/ngalert/eval/eval.go
+++ b/pkg/services/ngalert/eval/eval.go
@@ -285,16 +285,18 @@ type NumberValueCapture struct {
 	Var    string // RefID
 	Labels data.Labels
 	Value  *float64
+	Metric string
 }
 
 func queryDataResponseToExecutionResults(c models.Condition, execResp *backend.QueryDataResponse) ExecutionResults {
 	// eval captures for the '__value_string__' annotation and the Value property of the API response.
 	captures := make([]NumberValueCapture, 0, len(execResp.Responses))
-	captureVal := func(refID string, labels data.Labels, value *float64) {
+	captureVal := func(refID string, labels data.Labels, name string, value *float64) {
 		captures = append(captures, NumberValueCapture{
 			Var:    refID,
 			Value:  value,
 			Labels: labels.Copy(),
+			Metric: name,
 		})
 	}
 
@@ -330,7 +332,7 @@ func queryDataResponseToExecutionResults(c models.Condition, execResp *backend.Q
 			if frame.Fields[0].Len() == 1 {
 				v = frame.At(0, 0).(*float64) // type checked above
 			}
-			captureVal(frame.RefID, frame.Fields[0].Labels, v)
+			captureVal(frame.RefID, frame.Fields[0].Labels, frame.Fields[0].Name, v)
 		}
 
 		if refID == c.Condition {

--- a/pkg/services/ngalert/eval/extract_md.go
+++ b/pkg/services/ngalert/eval/extract_md.go
@@ -47,6 +47,7 @@ func extractEvalString(frame *data.Frame) (s string) {
 		for i, c := range caps {
 			sb.WriteString("[ ")
 			sb.WriteString(fmt.Sprintf("var='%s' ", c.Var))
+			sb.WriteString(fmt.Sprintf("metric='%s' ", c.Metric))
 			sb.WriteString(fmt.Sprintf("labels={%s} ", c.Labels))
 
 			valString := "null"

--- a/pkg/services/ngalert/eval/extract_md.go
+++ b/pkg/services/ngalert/eval/extract_md.go
@@ -91,6 +91,7 @@ func extractValues(frame *data.Frame) map[string]NumberValueCapture {
 				Var:    frame.RefID,
 				Labels: match.Labels,
 				Value:  match.Value,
+				Metric: match.Metric,
 			}
 		}
 		return v

--- a/pkg/services/ngalert/notifier/channels/default_template.go
+++ b/pkg/services/ngalert/notifier/channels/default_template.go
@@ -66,6 +66,34 @@ Annotations:
 
 {{ end }}{{ end }}{{ if gt (len .Alerts.Resolved) 0 }}**Resolved**
 {{ template "__teams_text_alert_list" .Alerts.Resolved }}{{ end }}{{ end }}
+
+{{ define "slack.default.title" -}}
+    {{ template "slack.alert_emoji" . }} {{ if eq .CommonLabels.alertname "DatasourceError" -}}
+        {{ .CommonLabels.rulename }} [query {{ .CommonLabels.ref_id}}]
+    {{- else if eq .CommonLabels.alertname "DatasourceNoData" -}}
+		{{ .CommonLabels.rulename }} [No Data]
+    {{- else -}}
+        {{.CommonLabels.alertname}}
+    {{- end -}}
+{{- end -}}
+
+{{ define "slack.alert_emoji" -}}
+    {{ if eq .Status "resolved" }}:white_check_mark:
+    {{- else if eq .CommonLabels.alertname "DatasourceError" }}:question:
+    {{- else if eq .CommonLabels.alertname "DatasourceNoData" }}:grey_question:
+    {{- else }}:rotating_light:
+    {{- end -}}
+{{ end -}}
+
+{{ define "slack.default.text" -}}
+    {{ if eq .Status "firing" -}}
+        {{ if eq .CommonLabels.alertname "DatasourceError" -}}
+            {{ .CommonAnnotations.Error -}}
+        {{ else -}}
+            {{ .CommonAnnotations.summary }}{{ .CommonAnnotations.message -}}
+        {{ end -}}
+    {{ end -}}
+{{ end }}
 `
 
 // TemplateForTestsString is the template used for unit tests and integration tests.

--- a/pkg/services/ngalert/notifier/channels_config/available_channels.go
+++ b/pkg/services/ngalert/notifier/channels_config/available_channels.go
@@ -2,6 +2,7 @@ package channels_config
 
 import (
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier/channels"
+	"github.com/prometheus/alertmanager/config"
 )
 
 // GetAvailableNotifiers returns the metadata of all the notification channels that can be configured.
@@ -534,14 +535,20 @@ func GetAvailableNotifiers() []*NotifierPlugin {
 					InputType:    InputTypeText,
 					Description:  "Templated title of the slack message",
 					PropertyName: "title",
-					Placeholder:  `{{ template "slack.default.title" . }}`,
+					Placeholder:  config.DefaultSlackConfig.Title,
 				},
 				{ // New in 8.0.
 					Label:        "Text Body",
 					Element:      ElementTypeTextArea,
 					Description:  "Body of the slack message",
 					PropertyName: "text",
-					Placeholder:  `{{ template "slack.default.text" . }}`,
+					Placeholder:  config.DefaultSlackConfig.Text,
+				},
+				{ // New in 9.3.
+					Label:        "Include Fields",
+					Element:      ElementTypeCheckbox,
+					Description:  "Include Field elements for firing alert values (up to 10)",
+					PropertyName: "includeFields",
 				},
 			},
 		},

--- a/pkg/services/ngalert/notifier/receivers.go
+++ b/pkg/services/ngalert/notifier/receivers.go
@@ -241,7 +241,8 @@ func newTestAlert(c apimodels.TestReceiversConfigBodyParams, startsAt, updatedAt
 	var (
 		defaultAnnotations = model.LabelSet{
 			"summary":          "Notification test",
-			"__value_string__": "[ metric='foo' labels={instance=bar} value=10 ]",
+			"__value_string__": "'foo'=10",
+			"__values__":       "{\"foo\": 10}",
 		}
 		defaultLabels = model.LabelSet{
 			"alertname": "TestAlert",

--- a/pkg/services/ngalert/state/cache.go
+++ b/pkg/services/ngalert/state/cache.go
@@ -52,11 +52,11 @@ func (rs *ruleStates) getOrCreate(ctx context.Context, log log.Logger, alertRule
 	ruleLabels, annotations := rs.expandRuleLabelsAndAnnotations(ctx, log, alertRule, result, extraLabels, externalURL)
 
 	values := make(map[string]float64)
-	for _, v := range result.Values {
+	for k, v := range result.Values {
 		if v.Value != nil {
-			values[v.Var] = *v.Value
+			values[k] = *v.Value
 		} else {
-			values[v.Var] = math.NaN()
+			values[k] = math.NaN()
 		}
 	}
 

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -190,12 +190,14 @@ func (st *Manager) setNextState(ctx context.Context, alertRule *ngModels.AlertRu
 
 	currentState.LastEvaluationTime = result.EvaluatedAt
 	currentState.EvaluationDuration = result.EvaluationDuration
+
 	currentState.Results = append(currentState.Results, Evaluation{
 		EvaluationTime:  result.EvaluatedAt,
 		EvaluationState: result.State,
 		Values:          NewEvaluationValues(result.Values),
 		Condition:       alertRule.Condition,
 	})
+
 	currentState.LastEvaluationString = result.EvaluationString
 	currentState.TrimResults(alertRule)
 	oldState := currentState.State

--- a/pkg/services/ngalert/state/state.go
+++ b/pkg/services/ngalert/state/state.go
@@ -84,7 +84,7 @@ type Evaluation struct {
 	Condition string
 }
 
-// NewEvaluationValues returns the labels and values for each RefID in the capture.
+// NewEvaluationValues returns the labels and values for each metric in the capture.
 func NewEvaluationValues(m map[string]eval.NumberValueCapture) map[string]*float64 {
 	result := make(map[string]*float64, len(m))
 	for k, v := range m {

--- a/pkg/services/ngalert/state/template.go
+++ b/pkg/services/ngalert/state/template.go
@@ -23,6 +23,7 @@ import (
 type templateCaptureValue struct {
 	Labels map[string]string
 	Value  float64
+	Metric string
 }
 
 // String implements the Stringer interface to print the value of each RefID
@@ -82,6 +83,7 @@ func newTemplateCaptureValues(values map[string]eval.NumberValueCapture) map[str
 		m[k] = templateCaptureValue{
 			Labels: v.Labels,
 			Value:  f,
+			Metric: v.Metric,
 		}
 	}
 	return m


### PR DESCRIPTION
This is a concept ('spike') PR I put together in response to a cluster of various UX pain points introduced by the new Grafana Alerting system. (I couldn't find a specific set of existing issues to reference here, but see [Alerting in Grafana 9 is too confusing](https://www.reddit.com/r/grafana/comments/xv64t1/alerting_in_grafana_9_is_too_confusing/) for someone's high-level take that covers the basics).

The basic idea is to extract more useful, relevant info from evaluated alert rules so we can more easily filter out the less-relevant parts. I'd like to avoid constantly mucking around with Go-template annotations just to format basic alerts from a set of query labels, or pluck the value of a firing alert from a rule's expressions. I'd also like the default templates to give a simple, clean notification that lets me quickly see relevant info about firing alerts without a big data dump. This PR is a sketch that restores the simple, seamless 'metric=value' presentation that existed in legacy alerting, by deriving the metric names from the source query and the value from the final evaluated result used to condition the alert.

Here are some images showing default Slack notifications rendered for a simple Prometheus query (returning two series with two labels each) with the 'legend' set to `{{foo}}`, and reduce ('B') and threshold ('C') expressions configured on the alert rule:
Before:
<img src="https://user-images.githubusercontent.com/56541/197328146-a8e3da8f-2a44-47cb-83a3-e8aeed3f523d.png" width="335" /> <img src="https://user-images.githubusercontent.com/56541/197328184-3c31784e-524a-4e90-9e6d-775b88510cc9.png" width="321" />

After:
<img src="https://user-images.githubusercontent.com/56541/197328221-64eb4810-773f-49e5-a698-c94fd5bfc862.png" width="217" />  <img src="https://user-images.githubusercontent.com/56541/197328013-fe0856a8-aed1-47ee-9c4c-90460eb576c1.png" width="215" />

This PR makes big changes to several subsystems (more details below), updates the Slack notifier in ways that could use further discussion, and doesn't yet update any tests at all. So please think of this work not as a focused piece ready to be merged as-is, but as a broad sketch of where the new alerting system _could_ end up if there's enough positive feedback to continue in this direction. At the very least I hope this PR helps drive some open-source discussions around the Grafana Alerting UX forward (in the spirit of 'rough consensus and working code').

---
Here's a more detailed description of each change:

1. 49c8685 Pass the series name from the alert rule's source query (currently passed as `Metric` field in `classic.EvalMatch` for classic conditions and used only for rendering the `ValueString` object) through to `templateCaptureValue` so the `$values.A.Metric` field can be referenced in annotation templates. Also pass the `Metric` field through to `NumberValueCapture` so it's properly captured for rules without classic conditions as well.

2. f8497c1
    1. Use the source Value's `Name` instead of `RefID` for each derived Value's new name through the various value-transformation operations used by expressions so the original query names are preserved across them. (The RefID still seems to be stored in the data frame so I didn't notice any drawbacks from this change, though anyone more familiar with this code please correct me if I'm mistaken.)
    2. Change the `mathexp` logic to preserve values for 'truthy' conditional expressions, so firing alerts conditioned on Math, Threshold, etc expressions retain their actual values instead of a meaningless `1`. This lets you automatically reference a firing alert's value directly from an evaluated result's condition, instead of needing to manually reference the expression containing the proper value in an annotation template (or dumping all expression values).

3. 497843a Simplify the `Values` map to include the metric name as key and the final result as value. Similarly, simplify ValueString to a much shorter `'metric'=value, 'metric2'=value2` string.

4. ab0bf80 Fit all the pieces together with improved Slack notification formatting, taking advantage of the simplified `Alert.Values` map to append metric name/value pairs as fields to firing-notification messages (enabled by a checkbox config on the contact point). The commit also includes an updated default Slack template which provides simpler notifications closer to those in the legacy alerting system.