### PR TITLE
Storage: Fix initialization on windows

### DIFF
--- a/pkg/services/store/storage_disk.go
+++ b/pkg/services/store/storage_disk.go
@@ -2,7 +2,6 @@ package store
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
@@ -46,7 +45,8 @@ func newDiskStorage(meta RootStorageMeta, scfg RootStorageConfig) *rootStorageDi
 	}
 
 	if meta.Notice == nil {
-		path := fmt.Sprintf("file://%s", cfg.Path)
+		protocol := "file:///"
+		path := protocol + cfg.Path
 		bucket, err := blob.OpenBucket(context.Background(), path)
 		if err != nil {
 			grafanaStorageLogger.Warn("error loading storage", "prefix", scfg.Prefix, "err", err)


### PR DESCRIPTION
(should🤞) fix https://github.com/grafana/grafana/discussions/56835#discussioncomment-3917279


Running a fresh 9.2.1 install on windows yields this log:

```
logger=grafanaStorageLogger t=2022-10-24T14:55:15.1439663+08:00 level=warn msg="error loading storage" prefix=public-static err="open blob.Bucket: parse \"file://C:\\\\Program Files\\\\GrafanaLabs\\\\grafana\\\\public\": invalid port \":\\\\Program Files\\\\GrafanaLabs\\\\grafana\\\\public\" after host"
```

based on https://en.wikipedia.org/wiki/File_URI_scheme, the file protocol is missing a slash when ran on windows machines. Note that this change will prefix the path with an additional slash on unix machines which does not change the end result: `file:////etc/conf/abc.json` vs `file:///etc/conf/abc.json`
