### PR TITLE
Docs: Clarify that audit logs are generated only for API requests

### DIFF
--- a/docs/sources/setup-grafana/configure-security/audit-grafana.md
+++ b/docs/sources/setup-grafana/configure-security/audit-grafana.md
@@ -16,6 +16,8 @@ weight: 800
 
 Auditing allows you to track important changes to your Grafana instance. By default, audit logs are logged to file but the auditing feature also supports sending logs directly to Loki.
 
+Only API requests or UI actions that trigger an API request generate an audit log.
+
 > **Note:** Available in [Grafana Enterprise]({{< relref "../../enterprise/" >}}) version 7.3 and later, and [Grafana Cloud Advanced]({{< ref "/docs/grafana-cloud" >}}).
 
 ## Audit logs


### PR DESCRIPTION
It adds a clarification of when an audit log is generated.

Related issue: https://github.com/grafana/grafana-enterprise/issues/4028