### PR TITLE
Alerting: Always allow configuring AM configuration

### DIFF
--- a/public/app/features/alerting/unified/components/admin/ExternalAlertmanagers.tsx
+++ b/public/app/features/alerting/unified/components/admin/ExternalAlertmanagers.tsx
@@ -130,8 +130,6 @@ export const ExternalAlertmanagers = () => {
   };
 
   const noAlertmanagers = externalAlertManagers?.length === 0;
-  const noDsAlertmanagers = externalDsAlertManagers?.length === 0;
-  const hasExternalAlertmanagers = !(noAlertmanagers && noDsAlertmanagers);
 
   return (
     <div>
@@ -149,20 +147,18 @@ export const ExternalAlertmanagers = () => {
         inactive={alertmanagersChoice === AlertmanagerChoice.Internal}
       />
 
-      {hasExternalAlertmanagers && (
-        <div className={styles.amChoice}>
-          <Field
-            label="Send alerts to"
-            description="Configures how the Grafana alert rule evaluation engine Alertmanager handles your alerts. Internal (Grafana built-in Alertmanager), External (All Alertmanagers configured above), or both."
-          >
-            <RadioButtonGroup
-              options={alertmanagerChoices}
-              value={alertmanagersChoice}
-              onChange={(value) => onChangeAlertmanagerChoice(value!)}
-            />
-          </Field>
-        </div>
-      )}
+      <div className={styles.amChoice}>
+        <Field
+          label="Send alerts to"
+          description="Configures how the Grafana alert rule evaluation engine Alertmanager handles your alerts. Internal (Grafana built-in Alertmanager), External (All Alertmanagers configured above), or both."
+        >
+          <RadioButtonGroup
+            options={alertmanagerChoices}
+            value={alertmanagersChoice}
+            onChange={(value) => onChangeAlertmanagerChoice(value!)}
+          />
+        </Field>
+      </div>
 
       <h5>Alertmanagers by URL</h5>
       <Alert severity="warning" title="Deprecation Notice">


### PR DESCRIPTION
**What this PR does / why we need it**:

It's possible to get in to a situation where you have the AM configuration set to "external" but with no AMs configured (for example, you removed the external AM data source).

You'd be stuck in a situation where you can no longer switch back to the internal AM. This patch always shows the AM configuration to make it possible to switch back.

**Special notes for your reviewer**:

Choosing "external" when you have no AMs configured shows a warning.

