### PR TITLE
Alerting: Change handling of settings to pagerduty contact point

### DIFF
--- a/pkg/services/ngalert/notifier/channels/pagerduty.go
+++ b/pkg/services/ngalert/notifier/channels/pagerduty.go
@@ -39,7 +39,6 @@ type PagerdutyNotifier struct {
 }
 
 type pagerdutySettings struct {
-	*NotificationChannelConfig
 	Key           string `json:"integrationKey,omitempty" yaml:"integrationKey,omitempty"`
 	Severity      string `json:"severity,omitempty" yaml:"severity,omitempty"`
 	customDetails map[string]string
@@ -68,8 +67,8 @@ func newPagerdutyNotifier(fc FactoryConfig) (*PagerdutyNotifier, error) {
 		return nil, fmt.Errorf("failed to unmarshal settings: %w", err)
 	}
 
-	key := fc.DecryptFunc(context.Background(), fc.Config.SecureSettings, "integrationKey", settings.Key)
-	if key == "" {
+	settings.Key = fc.DecryptFunc(context.Background(), fc.Config.SecureSettings, "integrationKey", settings.Key)
+	if settings.Key == "" {
 		return nil, errors.New("could not find integration key property in settings")
 	}
 

--- a/pkg/services/ngalert/notifier/channels/pagerduty.go
+++ b/pkg/services/ngalert/notifier/channels/pagerduty.go
@@ -61,42 +61,9 @@ func PagerdutyFactory(fc FactoryConfig) (NotificationChannel, error) {
 
 // NewPagerdutyNotifier is the constructor for the PagerDuty notifier
 func newPagerdutyNotifier(fc FactoryConfig) (*PagerdutyNotifier, error) {
-	settings := pagerdutySettings{}
-	err := fc.Config.unmarshalSettings(&settings)
-	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal settings: %w", err)
-	}
-
-	settings.Key = fc.DecryptFunc(context.Background(), fc.Config.SecureSettings, "integrationKey", settings.Key)
-	if settings.Key == "" {
+	key := fc.DecryptFunc(context.Background(), fc.Config.SecureSettings, "integrationKey", fc.Config.Settings.Get("integrationKey").MustString())
+	if key == "" {
 		return nil, errors.New("could not find integration key property in settings")
-	}
-
-	if settings.Severity == "" {
-		settings.Severity = "critical"
-	}
-
-	settings.customDetails = map[string]string{
-		"firing":       `{{ template "__text_alert_list" .Alerts.Firing }}`,
-		"resolved":     `{{ template "__text_alert_list" .Alerts.Resolved }}`,
-		"num_firing":   `{{ .Alerts.Firing | len }}`,
-		"num_resolved": `{{ .Alerts.Resolved | len }}`,
-	}
-
-	if settings.Class == "" {
-		settings.Class = "default"
-	}
-
-	if settings.Component == "" {
-		settings.Component = "Grafana"
-	}
-
-	if settings.Group == "" {
-		settings.Group = "default"
-	}
-
-	if settings.Summary == "" {
-		settings.Summary = DefaultMessageTitleEmbed
 	}
 
 	return &PagerdutyNotifier{
@@ -107,11 +74,24 @@ func newPagerdutyNotifier(fc FactoryConfig) (*PagerdutyNotifier, error) {
 			DisableResolveMessage: fc.Config.DisableResolveMessage,
 			Settings:              fc.Config.Settings,
 		}),
-		tmpl:     fc.Template,
-		log:      log.New("alerting.notifier." + fc.Config.Name),
-		ns:       fc.NotificationService,
-		images:   fc.ImageStore,
-		settings: settings,
+		tmpl:   fc.Template,
+		log:    log.New("alerting.notifier." + fc.Config.Name),
+		ns:     fc.NotificationService,
+		images: fc.ImageStore,
+		settings: pagerdutySettings{
+			Key:      key,
+			Severity: fc.Config.Settings.Get("severity").MustString("critical"),
+			customDetails: map[string]string{
+				"firing":       `{{ template "__text_alert_list" .Alerts.Firing }}`,
+				"resolved":     `{{ template "__text_alert_list" .Alerts.Resolved }}`,
+				"num_firing":   `{{ .Alerts.Firing | len }}`,
+				"num_resolved": `{{ .Alerts.Resolved | len }}`,
+			},
+			Class:     fc.Config.Settings.Get("class").MustString("default"),
+			Component: fc.Config.Settings.Get("component").MustString("Grafana"),
+			Group:     fc.Config.Settings.Get("group").MustString("default"),
+			Summary:   fc.Config.Settings.Get("summary").MustString(DefaultMessageTitleEmbed),
+		},
 	}, nil
 }
 

--- a/pkg/services/ngalert/notifier/channels_config/available_channels.go
+++ b/pkg/services/ngalert/notifier/channels_config/available_channels.go
@@ -262,8 +262,9 @@ func GetAvailableNotifiers() []*NotifierPlugin {
 				{ // New in 8.0.
 					Label:        "Summary",
 					Description:  "You can use templates for summary",
-					Element:      ElementTypeTextArea,
-					Placeholder:  channels.DefaultMessageEmbed,
+					Element:      ElementTypeInput,
+					InputType:    InputTypeText,
+					Placeholder:  channels.DefaultMessageTitleEmbed,
 					PropertyName: "summary",
 				},
 			},

--- a/pkg/tests/api/alerting/api_notification_channel_test.go
+++ b/pkg/tests/api/alerting/api_notification_channel_test.go
@@ -1612,7 +1612,7 @@ const alertmanagerConfig = `
             }
           }
         ]
-      },   
+      },
 	  {
         "name": "slack_recv2",
         "grafana_managed_receiver_configs": [
@@ -2356,7 +2356,6 @@ var expNonEmailNotifications = map[string][]string{
 		`{
 		  "routing_key": "pagerduty_recv/pagerduty_test",
 		  "dedup_key": "234edb34441f942f713f3c2ccf58b1d719d921b4cbe34e57a1630f1dee847e3b",
-		  "description": "[FIRING:1] PagerdutyAlert (default)",
 		  "event_action": "trigger",
 		  "payload": {
 			"summary": "Integration Test [FIRING:1] PagerdutyAlert (default)",


### PR DESCRIPTION
**What this PR does / why we need it**:

Changes in how the summary and settings are handled.
The summary defaults to the title default messages.

Removed description attribute in payload to pagerduty. There is no such attribute in their docs.
https://developer.pagerduty.com/docs/ZG9jOjExMDI5NTgx-send-an-alert-event