### PR TITLE
Linux repositories: Document `apt|rpm.grafana.com`

### DIFF
--- a/docs/sources/setup-grafana/installation/debian/index.md
+++ b/docs/sources/setup-grafana/installation/debian/index.md
@@ -12,6 +12,12 @@ weight: 100
 
 This page explains how to install Grafana dependencies, download and install Grafana, get the service up and running on your Debian or Ubuntu system, and also describes the installation package details.
 
+## Repository migration (November 8th 2022)
+
+From that date, Grafana packages will be served from a new repository (<packages.grafana.com/deb/{product}> -> <apt.grafana.com>). The new repository serves, from a single YUM/DNF configuration, all Grafana OSS products, as well as Grafana Enterprise.
+
+The old URLs will still work, serving the content from the new repository, but you may encounter warnings about some repository attributes changing (e.g. `Origin` and `Label`).
+
 ## Note on upgrading
 
 While the process for upgrading Grafana is very similar to installing Grafana, there are some key backup steps you should perform. Read [Upgrading Grafana]({{< relref "../../upgrade-grafana/" >}}) for tips and guidance on updating an existing installation.

--- a/docs/sources/setup-grafana/installation/debian/index.md
+++ b/docs/sources/setup-grafana/installation/debian/index.md
@@ -14,7 +14,7 @@ This page explains how to install Grafana dependencies, download and install Gra
 
 ## Repository migration (November 8th 2022)
 
-From that date, Grafana packages will be served from a new repository (<packages.grafana.com/deb/{product}> -> <apt.grafana.com>). The new repository serves, from a single YUM/DNF configuration, all Grafana OSS products, as well as Grafana Enterprise.
+From that date, Grafana packages will be served from a new repository (<packages.grafana.com/deb/{product}> -> <apt.grafana.com>). The new repository serves, from a single APT configuration, all Grafana OSS products, as well as Grafana Enterprise.
 
 The old URLs will still work, serving the content from the new repository, but you may encounter warnings about some repository attributes changing (e.g. `Origin` and `Label`).
 

--- a/docs/sources/setup-grafana/installation/debian/index.md
+++ b/docs/sources/setup-grafana/installation/debian/index.md
@@ -24,67 +24,45 @@ You can install Grafana using our official APT repository, by downloading a `.de
 
 If you install from the APT repository, then Grafana is automatically updated every time you run `apt-get update`.
 
-| Grafana Version           | Package            | Repository                                                |
-| ------------------------- | ------------------ | --------------------------------------------------------- |
-| Grafana Enterprise        | grafana-enterprise | `https://packages.grafana.com/enterprise/deb stable main` |
-| Grafana Enterprise (Beta) | grafana-enterprise | `https://packages.grafana.com/enterprise/deb beta main`   |
-| Grafana OSS               | grafana            | `https://packages.grafana.com/oss/deb stable main`        |
-| Grafana OSS (Beta)        | grafana            | `https://packages.grafana.com/oss/deb beta main`          |
+| Grafana Version           | Package            | Repository                            |
+| ------------------------- | ------------------ | ------------------------------------- |
+| Grafana Enterprise        | grafana-enterprise | `https://apt.grafana.com stable main` |
+| Grafana Enterprise (Beta) | grafana-enterprise | `https://apt.grafana.com beta main`   |
+| Grafana OSS               | grafana            | `https://apt.grafana.com stable main` |
+| Grafana OSS (Beta)        | grafana            | `https://apt.grafana.com beta main`   |
 
 > **Note:** Grafana Enterprise is the recommended and default edition. It is available for free and includes all the features of the OSS edition. You can also upgrade to the [full Enterprise feature set](https://grafana.com/products/enterprise/?utm_source=grafana-install-page), which has support for [Enterprise plugins](https://grafana.com/grafana/plugins/?enterprise=1&utcm_source=grafana-install-page).
 
-#### To install the latest Enterprise edition:
+#### To install the latest release:
 
 ```bash
 sudo apt-get install -y apt-transport-https
 sudo apt-get install -y software-properties-common wget
-sudo wget -q -O /usr/share/keyrings/grafana.key https://packages.grafana.com/gpg.key
+sudo wget -q -O /usr/share/keyrings/grafana.key https://apt.grafana.com/gpg.key
 ```
 
 Add this repository for stable releases:
 
 ```bash
-echo "deb [signed-by=/usr/share/keyrings/grafana.key] https://packages.grafana.com/enterprise/deb stable main" | sudo tee -a /etc/apt/sources.list.d/grafana.list
+echo "deb [signed-by=/usr/share/keyrings/grafana.key] https://apt.grafana.com stable main" | sudo tee -a /etc/apt/sources.list.d/grafana.list
 ```
 
 Add this repository if you want beta releases:
 
 ```bash
-echo "deb [signed-by=/usr/share/keyrings/grafana.key] https://packages.grafana.com/enterprise/deb beta main" | sudo tee -a /etc/apt/sources.list.d/grafana.list
+echo "deb [signed-by=/usr/share/keyrings/grafana.key] https://apt.grafana.com beta main" | sudo tee -a /etc/apt/sources.list.d/grafana.list
 ```
 
 After you add the repository:
 
 ```bash
 sudo apt-get update
-sudo apt-get install grafana-enterprise
-```
 
-#### To install the latest OSS release:
-
-```bash
-sudo apt-get install -y apt-transport-https
-sudo apt-get install -y software-properties-common wget
-sudo wget -q -O /usr/share/keyrings/grafana.key https://packages.grafana.com/gpg.key
-```
-
-Add this repository for stable releases:
-
-```bash
-echo "deb [signed-by=/usr/share/keyrings/grafana.key] https://packages.grafana.com/oss/deb stable main" | sudo tee -a /etc/apt/sources.list.d/grafana.list
-```
-
-Add this repository if you want beta releases:
-
-```bash
-echo "deb [signed-by=/usr/share/keyrings/grafana.key] https://packages.grafana.com/oss/deb beta main" | sudo tee -a /etc/apt/sources.list.d/grafana.list
-```
-
-After you add the repository:
-
-```bash
-sudo apt-get update
+# Install the latest OSS release:
 sudo apt-get install grafana
+
+# Install the latest Enterprise release:
+sudo apt-get install grafana-enterprise
 ```
 
 ### Install .deb package

--- a/docs/sources/setup-grafana/installation/rpm/index.md
+++ b/docs/sources/setup-grafana/installation/rpm/index.md
@@ -25,12 +25,10 @@ You can install Grafana from a YUM repository, manually using YUM, manually usin
 
 If you install from the YUM repository, then Grafana is automatically updated every time you run `sudo yum update`.
 
-| Grafana Version           | Package            | Repository                                         |
-| ------------------------- | ------------------ | -------------------------------------------------- |
-| Grafana Enterprise        | grafana-enterprise | `https://packages.grafana.com/enterprise/rpm`      |
-| Grafana Enterprise (Beta) | grafana-enterprise | `https://packages.grafana.com/enterprise/rpm-beta` |
-| Grafana OSS               | grafana            | `https://packages.grafana.com/oss/rpm`             |
-| Grafana OSS (Beta)        | grafana            | `https://packages.grafana.com/oss/rpm-beta`        |
+| Grafana Version    | Package            | Repository                |
+| ------------------ | ------------------ | ------------------------- |
+| Grafana Enterprise | grafana-enterprise | `https://rpm.grafana.com` |
+| Grafana OSS        | grafana            | `https://rpm.grafana.com` |
 
 > **Note:** Grafana Enterprise is the recommended and default edition. It is available for free and includes all the features of the OSS Edition. You can also upgrade to the [full Enterprise feature set](https://grafana.com/products/enterprise/?utm_source=grafana-install-page) and has support for [Enterprise plugins](https://grafana.com/grafana/plugins/?enterprise=1&utcm_source=grafana-install-page).
 
@@ -49,11 +47,11 @@ For Enterprise releases:
 ```bash
 [grafana]
 name=grafana
-baseurl=https://packages.grafana.com/enterprise/rpm
+baseurl=https://rpm.grafana.com
 repo_gpgcheck=1
 enabled=1
 gpgcheck=1
-gpgkey=https://packages.grafana.com/gpg.key
+gpgkey=https://rpm.grafana.com/gpg.key
 sslverify=1
 sslcacert=/etc/pki/tls/certs/ca-bundle.crt
 ```
@@ -63,13 +61,19 @@ For OSS releases:
 ```bash
 [grafana]
 name=grafana
-baseurl=https://packages.grafana.com/oss/rpm
+baseurl=https://rpm.grafana.com
 repo_gpgcheck=1
 enabled=1
 gpgcheck=1
-gpgkey=https://packages.grafana.com/gpg.key
+gpgkey=https://rpm.grafana.com/gpg.key
 sslverify=1
 sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+```
+
+Optionally, add an exclude line to your `.repo` file to prevent beta versions from being installed.
+
+```bash
+exclude=*beta*
 ```
 
 Install Grafana with one of the following commands:
@@ -110,7 +114,7 @@ sudo yum install <rpm package url>
 
 If you install with RPM, then you will need to manually update Grafana for each new version. This method varies according to which Linux OS you are running. Read the instructions fully before you begin.
 
-**Note:** The .rpm files are signed, you can verify the signature with this [public GPG key](https://packages.grafana.com/gpg.key).
+**Note:** The .rpm files are signed, you can verify the signature with this [public GPG key](https://rpm.grafana.com/gpg.key).
 
 1. On the [Grafana download page](https://grafana.com/grafana/download), select the Grafana version you want to install.
    - The most recent Grafana version is selected by default.

--- a/docs/sources/setup-grafana/installation/rpm/index.md
+++ b/docs/sources/setup-grafana/installation/rpm/index.md
@@ -38,26 +38,6 @@ Add a new file to your YUM repo using the method of your choice. The command bel
 sudo nano /etc/yum.repos.d/grafana.repo
 ```
 
-Choose if you want to install the Open Source or Enterprise edition of Grafana and enter the information from the edition you've chosen into `grafana.repo`. If you want to install the beta version of Grafana you need to replace the URL with a beta URL from the table above.
-
-> We recommend all users to install the Enterprise Edition of Grafana, which can be seamlessly upgraded with a Grafana Enterprise [subscription](https://grafana.com/products/enterprise/?utm_source=grafana-install-page).
-
-For Enterprise releases:
-
-```bash
-[grafana]
-name=grafana
-baseurl=https://rpm.grafana.com
-repo_gpgcheck=1
-enabled=1
-gpgcheck=1
-gpgkey=https://rpm.grafana.com/gpg.key
-sslverify=1
-sslcacert=/etc/pki/tls/certs/ca-bundle.crt
-```
-
-For OSS releases:
-
 ```bash
 [grafana]
 name=grafana
@@ -76,7 +56,9 @@ Optionally, add an exclude line to your `.repo` file to prevent beta versions fr
 exclude=*beta*
 ```
 
-Install Grafana with one of the following commands:
+Install Grafana with one of the following commands
+
+> We recommend all users to install the Enterprise Edition of Grafana, which can be seamlessly upgraded with a Grafana Enterprise [subscription](https://grafana.com/products/enterprise/?utm_source=grafana-install-page).
 
 ```bash
 sudo yum install grafana

--- a/docs/sources/setup-grafana/installation/rpm/index.md
+++ b/docs/sources/setup-grafana/installation/rpm/index.md
@@ -13,6 +13,12 @@ weight: 400
 
 This topic explains how to install Grafana dependencies, download and install Grafana, get the service up and running on your RPM-based Linux system, and the installation package details.
 
+## Repository migration (November 8th 2022)
+
+From that date, Grafana packages will be served from a new repository (<packages.grafana.com/rpm/{product}> -> <rpm.grafana.com>). The new repository serves, from a single YUM/DNF configuration, all Grafana OSS products, as well as Grafana Enterprise.
+
+The old URLs will still work, serving the content from the new repository, but you may encounter warnings about some repository attributes changing.
+
 ## Note on upgrading
 
 While the process for upgrading Grafana is very similar to installing Grafana, there are some key backup steps you should perform. Read [Upgrading Grafana]({{< relref "../../upgrade-grafana/" >}}) for tips and guidance on updating an existing installation.


### PR DESCRIPTION
We'll be moving off packages.grafana.com (it will be linked to the new repositories).
The new package repositories are easier to use, so let's document them instead. Users may also encounter some warnings when we migrate to the new repos (Nov 8th), so it'll be something to point to