### PR TITLE
Alerting: Add custom title to pushover contact point

### DIFF
--- a/pkg/services/ngalert/notifier/channels/pushover.go
+++ b/pkg/services/ngalert/notifier/channels/pushover.go
@@ -68,25 +68,25 @@ func PushoverFactory(fc FactoryConfig) (NotificationChannel, error) {
 // newPushoverNotifier is the constructor for the Pushover notifier
 func newPushoverNotifier(fc FactoryConfig) (*PushoverNotifier, error) {
 	decryptFunc := fc.DecryptFunc
-	uk := decryptFunc(context.Background(), fc.Config.SecureSettings, "userKey", fc.Config.Settings.Get("userKey").MustString())
-	if uk == "" {
+	userKey := decryptFunc(context.Background(), fc.Config.SecureSettings, "userKey", fc.Config.Settings.Get("userKey").MustString())
+	if userKey == "" {
 		return nil, errors.New("user key not found")
 	}
-	at := decryptFunc(context.Background(), fc.Config.SecureSettings, "apiToken", fc.Config.Settings.Get("apiToken").MustString())
-	if at == "" {
+	apiToken := decryptFunc(context.Background(), fc.Config.SecureSettings, "apiToken", fc.Config.Settings.Get("apiToken").MustString())
+	if apiToken == "" {
 		return nil, errors.New("API token not found")
 	}
 
-	ap, err := strconv.Atoi(fc.Config.Settings.Get("priority").MustString("0")) // default Normal
+	alertingPriority, err := strconv.Atoi(fc.Config.Settings.Get("priority").MustString("0")) // default Normal
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert alerting priority to integer: %w", err)
 	}
-	okp, err := strconv.Atoi(fc.Config.Settings.Get("okPriority").MustString("0")) // default Normal
+	okPriority, err := strconv.Atoi(fc.Config.Settings.Get("okPriority").MustString("0")) // default Normal
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert OK priority to integer: %w", err)
 	}
-	r, _ := strconv.Atoi(fc.Config.Settings.Get("retry").MustString())
-	e, _ := strconv.Atoi(fc.Config.Settings.Get("expire").MustString())
+	retry, _ := strconv.Atoi(fc.Config.Settings.Get("retry").MustString())
+	expire, _ := strconv.Atoi(fc.Config.Settings.Get("expire").MustString())
 
 	return &PushoverNotifier{
 		Base: NewBase(&models.AlertNotification{
@@ -102,12 +102,12 @@ func newPushoverNotifier(fc FactoryConfig) (*PushoverNotifier, error) {
 		images: fc.ImageStore,
 		ns:     fc.NotificationService,
 		settings: pushoverSettings{
-			userKey:          uk,
-			apiToken:         at,
-			alertingPriority: ap,
-			okPriority:       okp,
-			retry:            r,
-			expire:           e,
+			userKey:          userKey,
+			apiToken:         apiToken,
+			alertingPriority: alertingPriority,
+			okPriority:       okPriority,
+			retry:            retry,
+			expire:           expire,
 			device:           fc.Config.Settings.Get("device").MustString(),
 			alertingSound:    fc.Config.Settings.Get("sound").MustString(),
 			okSound:          fc.Config.Settings.Get("okSound").MustString(),

--- a/pkg/services/ngalert/notifier/channels/pushover.go
+++ b/pkg/services/ngalert/notifier/channels/pushover.go
@@ -66,7 +66,7 @@ func PushoverFactory(fc FactoryConfig) (NotificationChannel, error) {
 	return pn, nil
 }
 
-// newSlackNotifier is the constructor for the Slack notifier
+// newPushoverNotifier is the constructor for the Pushover notifier
 func newPushoverNotifier(fc FactoryConfig) (*PushoverNotifier, error) {
 	decryptFunc := fc.DecryptFunc
 	var settings pushoverSettings

--- a/pkg/services/ngalert/notifier/channels/pushover_test.go
+++ b/pkg/services/ngalert/notifier/channels/pushover_test.go
@@ -68,6 +68,35 @@ func TestPushoverNotifier(t *testing.T) {
 			expMsgError: nil,
 		},
 		{
+			name: "Custom title",
+			settings: `{
+				"userKey": "<userKey>",
+				"apiToken": "<apiToken>",
+				"title": "Alerts firing: {{ len .Alerts.Firing }}"
+			}`,
+			alerts: []*types.Alert{
+				{
+					Alert: model.Alert{
+						Labels:      model.LabelSet{"__alert_rule_uid__": "rule uid", "alertname": "alert1", "lbl1": "val1"},
+						Annotations: model.LabelSet{"ann1": "annv1", "__dashboardUid__": "abcd", "__panelId__": "efgh", "__alertImageToken__": "test-image-1"},
+					},
+				},
+			},
+			expMsg: map[string]string{
+				"user":       "<userKey>",
+				"token":      "<apiToken>",
+				"priority":   "0",
+				"sound":      "",
+				"title":      "Alerts firing: 1",
+				"url":        "http://localhost/alerting/list",
+				"url_title":  "Show alert rule",
+				"message":    "**Firing**\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1\nDashboard: http://localhost/d/abcd\nPanel: http://localhost/d/abcd?viewPanel=efgh\n",
+				"attachment": "\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\b\x04\x00\x00\x00\xb5\x1c\f\x02\x00\x00\x00\vIDATx\xdacd`\x00\x00\x00\x06\x00\x020\x81\xd0/\x00\x00\x00\x00IEND\xaeB`\x82",
+				"html":       "1",
+			},
+			expMsgError: nil,
+		},
+		{
 			name: "Custom config with multiple alerts",
 			settings: `{
 					"userKey": "<userKey>",
@@ -141,17 +170,24 @@ func TestPushoverNotifier(t *testing.T) {
 			require.NoError(t, err)
 			secureSettings := make(map[string][]byte)
 
-			m := &NotificationChannelConfig{
-				Name:           "pushover_testing",
-				Type:           "pushover",
-				Settings:       settingsJSON,
-				SecureSettings: secureSettings,
-			}
-
 			webhookSender := mockNotificationService()
 			secretsService := secretsManager.SetupTestService(t, fakes.NewFakeSecretsStore())
 			decryptFn := secretsService.GetDecryptedValue
-			cfg, err := NewPushoverConfig(m, decryptFn)
+
+			fc := FactoryConfig{
+				Config: &NotificationChannelConfig{
+					Name:           "pushover_testing",
+					Type:           "pushover",
+					Settings:       settingsJSON,
+					SecureSettings: secureSettings,
+				},
+				ImageStore: images,
+				// TODO: allow changing the associated values for different tests.
+				NotificationService: webhookSender,
+				DecryptFunc:         decryptFn,
+				Template:            tmpl,
+			}
+			pn, err := newPushoverNotifier(fc)
 			if c.expInitError != "" {
 				require.Error(t, err)
 				require.Equal(t, c.expInitError, err.Error())
@@ -161,7 +197,6 @@ func TestPushoverNotifier(t *testing.T) {
 
 			ctx := notify.WithGroupKey(context.Background(), "alertname")
 			ctx = notify.WithGroupLabels(ctx, model.LabelSet{"alertname": ""})
-			pn := NewPushoverNotifier(cfg, images, webhookSender, tmpl)
 			ok, err := pn.Notify(ctx, c.alerts...)
 			if c.expMsgError != nil {
 				require.Error(t, err)

--- a/pkg/services/ngalert/notifier/channels/pushover_test.go
+++ b/pkg/services/ngalert/notifier/channels/pushover_test.go
@@ -181,8 +181,7 @@ func TestPushoverNotifier(t *testing.T) {
 					Settings:       settingsJSON,
 					SecureSettings: secureSettings,
 				},
-				ImageStore: images,
-				// TODO: allow changing the associated values for different tests.
+				ImageStore:          images,
 				NotificationService: webhookSender,
 				DecryptFunc:         decryptFn,
 				Template:            tmpl,

--- a/pkg/services/ngalert/notifier/channels_config/available_channels.go
+++ b/pkg/services/ngalert/notifier/channels_config/available_channels.go
@@ -410,6 +410,13 @@ func GetAvailableNotifiers() []*NotifierPlugin {
 					SelectOptions: pushoverSoundOptions,
 					PropertyName:  "okSound",
 				},
+				{ // New in 9.3.
+					Label:        "Title",
+					Element:      ElementTypeInput,
+					InputType:    InputTypeText,
+					Placeholder:  channels.DefaultMessageTitleEmbed,
+					PropertyName: "title",
+				},
 				{ // New in 8.0.
 					Label:        "Message",
 					Element:      ElementTypeTextArea,


### PR DESCRIPTION
**What this PR does / why we need it**:

It allows users to add a custom title for Pushover contact points.
It defaults to title default messages.