### PR TITLE
Chore: Add appcontext.WithUser and appcontext.User

### DIFF
--- a/pkg/infra/appcontext/user.go
+++ b/pkg/infra/appcontext/user.go
@@ -1,0 +1,41 @@
+package appcontext
+
+import (
+	"context"
+
+	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/contexthandler/ctxkey"
+	grpccontext "github.com/grafana/grafana/pkg/services/grpcserver/context"
+	"github.com/grafana/grafana/pkg/services/user"
+)
+
+type ctxUserKey struct{}
+
+// WithUser adds the supplied SignedInUser to the context.
+func WithUser(ctx context.Context, usr *user.SignedInUser) context.Context {
+	return context.WithValue(ctx, ctxUserKey{}, usr)
+}
+
+// User extracts the SignedInUser from the supplied context.
+// Supports context set by appcontext.WithUser, gRPC server context, and HTTP ReqContext.
+func User(ctx context.Context) *user.SignedInUser {
+	// Set by appcontext.WithUser
+	u, ok := ctx.Value(ctxUserKey{}).(*user.SignedInUser)
+	if ok && u != nil {
+		return u
+	}
+
+	// Set by incoming gRPC server request
+	grpcCtx := grpccontext.FromContext(ctx)
+	if grpcCtx != nil && grpcCtx.SignedInUser != nil {
+		return grpcCtx.SignedInUser
+	}
+
+	// Set by incoming HTTP request
+	c, ok := ctxkey.Get(ctx).(*models.ReqContext)
+	if !ok || c == nil || c.SignedInUser == nil {
+		return nil
+	}
+
+	return c.SignedInUser
+}

--- a/pkg/infra/appcontext/user_test.go
+++ b/pkg/infra/appcontext/user_test.go
@@ -16,15 +16,23 @@ import (
 )
 
 func TestUserFromContext(t *testing.T) {
-	t.Run("should not return user", func(t *testing.T) {
-		usr := appcontext.User(context.Background())
+	t.Run("User should error when context is missing user", func(t *testing.T) {
+		usr, err := appcontext.User(context.Background())
 		require.Nil(t, usr)
+		require.Error(t, err)
+	})
+
+	t.Run("MustUser should panic when context is missing user", func(t *testing.T) {
+		require.Panics(t, func() {
+			_ = appcontext.MustUser(context.Background())
+		})
 	})
 
 	t.Run("should return user set by ContextWithUser", func(t *testing.T) {
 		expected := testUser()
 		ctx := appcontext.WithUser(context.Background(), expected)
-		actual := appcontext.User(ctx)
+		actual, err := appcontext.User(ctx)
+		require.NoError(t, err)
 		require.Equal(t, expected.UserID, actual.UserID)
 	})
 
@@ -32,7 +40,8 @@ func TestUserFromContext(t *testing.T) {
 		expected := testUser()
 		handler := grpccontext.ProvideContextHandler(tracing.InitializeTracerForTest())
 		ctx := handler.SetUser(context.Background(), expected)
-		actual := appcontext.User(ctx)
+		actual, err := appcontext.User(ctx)
+		require.NoError(t, err)
 		require.Equal(t, expected.UserID, actual.UserID)
 	})
 
@@ -41,7 +50,8 @@ func TestUserFromContext(t *testing.T) {
 		ctx := ctxkey.Set(context.Background(), &models.ReqContext{
 			SignedInUser: expected,
 		})
-		actual := appcontext.User(ctx)
+		actual, err := appcontext.User(ctx)
+		require.NoError(t, err)
 		require.Equal(t, expected.UserID, actual.UserID)
 	})
 }

--- a/pkg/infra/appcontext/user_test.go
+++ b/pkg/infra/appcontext/user_test.go
@@ -1,0 +1,58 @@
+package appcontext_test
+
+import (
+	"context"
+	"crypto/rand"
+	"math/big"
+	"testing"
+
+	"github.com/grafana/grafana/pkg/infra/appcontext"
+	"github.com/grafana/grafana/pkg/infra/tracing"
+	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/contexthandler/ctxkey"
+	grpccontext "github.com/grafana/grafana/pkg/services/grpcserver/context"
+	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUserFromContext(t *testing.T) {
+	t.Run("should not return user", func(t *testing.T) {
+		usr := appcontext.User(context.Background())
+		require.Nil(t, usr)
+	})
+
+	t.Run("should return user set by ContextWithUser", func(t *testing.T) {
+		expected := testUser()
+		ctx := appcontext.WithUser(context.Background(), expected)
+		actual := appcontext.User(ctx)
+		require.Equal(t, expected.UserID, actual.UserID)
+	})
+
+	t.Run("should return user set by gRPC context", func(t *testing.T) {
+		expected := testUser()
+		handler := grpccontext.ProvideContextHandler(tracing.InitializeTracerForTest())
+		ctx := handler.SetUser(context.Background(), expected)
+		actual := appcontext.User(ctx)
+		require.Equal(t, expected.UserID, actual.UserID)
+	})
+
+	t.Run("should return user set by HTTP ReqContext", func(t *testing.T) {
+		expected := testUser()
+		ctx := ctxkey.Set(context.Background(), &models.ReqContext{
+			SignedInUser: expected,
+		})
+		actual := appcontext.User(ctx)
+		require.Equal(t, expected.UserID, actual.UserID)
+	})
+}
+
+func testUser() *user.SignedInUser {
+	i, err := rand.Int(rand.Reader, big.NewInt(100000))
+	if err != nil {
+		panic(err)
+	}
+	return &user.SignedInUser{
+		UserID: i.Int64(),
+		OrgID:  1,
+	}
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

@ArturWierzbicki suggested that this should be split out of #57420. Adds `appcontext.WithUser` and `appcontext.User` based on a suggested interface from @marefr in https://github.com/grafana/grafana/issues/50983#issuecomment-1160600222.

> My idea back then was to introduce a new package, appcontext (in lack of better name)? Having a function With<something> to populate the context and a function <something> to read the value from the context in a typesafe way, e.g.
> 
> ```
> package appcontext
> 
> func WithUser(ctx context.Context, user *models.SignedInUser) context.Context {
>   ...
>   return ctx
> }
> 
> func User(ctx context.Context) *models.SignedInUser {
>   ...
> }
> ```

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/50983

**Special notes for your reviewer**:

