### PR TITLE
Cloudwatch: Remove unused code

### DIFF
--- a/pkg/tsdb/cloudwatch/cloudwatch.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch.go
@@ -164,7 +164,13 @@ func (e *cloudWatchExecutor) checkHealthMetrics(pluginCtx backend.PluginContext)
 		Namespace:  &namespace,
 		MetricName: &metric,
 	}
-	_, err := e.listMetrics(pluginCtx, defaultRegion, params)
+
+	session, err := e.newSession(pluginCtx, defaultRegion)
+	if err != nil {
+		return err
+	}
+	metricClient := clients.NewMetricsClient(NewMetricsAPI(session), e.cfg)
+	_, err = metricClient.ListMetricsWithPageLimit(params)
 	return err
 }
 

--- a/pkg/tsdb/cloudwatch/cloudwatch_test.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
-	"github.com/aws/aws-sdk-go/service/cloudwatch/cloudwatchiface"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs/cloudwatchlogsiface"
 	"github.com/google/go-cmp/cmp"
@@ -95,15 +94,15 @@ func TestNewInstanceSettings(t *testing.T) {
 }
 
 func Test_CheckHealth(t *testing.T) {
-	origNewCWClient := NewCWClient
+	origNewMetricsAPI := NewMetricsAPI
 	origNewCWLogsClient := NewCWLogsClient
 	t.Cleanup(func() {
-		NewCWClient = origNewCWClient
+		NewMetricsAPI = origNewMetricsAPI
 		NewCWLogsClient = origNewCWLogsClient
 	})
 
 	var client fakeCheckHealthClient
-	NewCWClient = func(sess *session.Session) cloudwatchiface.CloudWatchAPI {
+	NewMetricsAPI = func(sess *session.Session) models.CloudWatchMetricsAPIProvider {
 		return client
 	}
 	NewCWLogsClient = func(sess *session.Session) cloudwatchlogsiface.CloudWatchLogsAPI {

--- a/pkg/tsdb/cloudwatch/metric_find_query.go
+++ b/pkg/tsdb/cloudwatch/metric_find_query.go
@@ -316,8 +316,6 @@ func (e *cloudWatchExecutor) resourceGroupsGetResources(pluginCtx backend.Plugin
 	return &resp, nil
 }
 
-var metricsCacheLock sync.Mutex
-
 func (e *cloudWatchExecutor) handleGetLogGroups(pluginCtx backend.PluginContext, parameters url.Values) ([]suggestData, error) {
 	region := parameters.Get("region")
 	limit := parameters.Get("limit")

--- a/pkg/tsdb/cloudwatch/metric_find_query_test.go
+++ b/pkg/tsdb/cloudwatch/metric_find_query_test.go
@@ -7,9 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/client"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/cloudwatch"
-	"github.com/aws/aws-sdk-go/service/cloudwatch/cloudwatchiface"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
@@ -20,59 +17,10 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/constants"
-	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/mocks"
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func TestQuery_Metrics(t *testing.T) {
-	origNewCWClient := NewCWClient
-	t.Cleanup(func() {
-		NewCWClient = origNewCWClient
-	})
-
-	var cwClient mocks.FakeMetricsAPI
-
-	NewCWClient = func(sess *session.Session) cloudwatchiface.CloudWatchAPI {
-		return &cwClient
-	}
-
-	t.Run("Custom metrics", func(t *testing.T) {
-		cwClient = mocks.FakeMetricsAPI{
-			Metrics: []*cloudwatch.Metric{
-				{
-					MetricName: aws.String("Test_MetricName"),
-					Dimensions: []*cloudwatch.Dimension{
-						{
-							Name: aws.String("Test_DimensionName"),
-						},
-					},
-				},
-			},
-		}
-
-		im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-			return DataSource{Settings: &models.CloudWatchSettings{}}, nil
-		})
-
-		executor := newExecutor(im, newTestConfig(), &fakeSessionCache{}, featuremgmt.WithFeatures())
-		resp, err := executor.handleGetMetrics(
-			backend.PluginContext{
-				DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{},
-			}, url.Values{
-				"region":    []string{"us-east-1"},
-				"namespace": []string{"custom"},
-			},
-		)
-		require.NoError(t, err)
-
-		expResponse := []suggestData{
-			{Text: "Test_MetricName", Value: "Test_MetricName", Label: "Test_MetricName"},
-		}
-		assert.Equal(t, expResponse, resp)
-	})
-}
 
 func TestQuery_Regions(t *testing.T) {
 	origNewEC2Client := newEC2Client
@@ -333,31 +281,5 @@ func TestQuery_ResourceARNs(t *testing.T) {
 			expResponse = append(expResponse, suggestData{Text: value, Value: value, Label: value})
 		}
 		assert.Equal(t, expResponse, resp)
-	})
-}
-
-func TestQuery_GetAllMetrics(t *testing.T) {
-	t.Run("all metrics in all namespaces are being returned", func(t *testing.T) {
-		im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-			return DataSource{Settings: &models.CloudWatchSettings{}}, nil
-		})
-
-		executor := newExecutor(im, newTestConfig(), &fakeSessionCache{}, featuremgmt.WithFeatures())
-		resp, err := executor.handleGetAllMetrics(
-			backend.PluginContext{
-				DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{},
-			},
-			url.Values{
-				"region": []string{"us-east-1"},
-			},
-		)
-		require.NoError(t, err)
-
-		metricCount := 0
-		for _, metrics := range constants.NamespaceMetricsMap {
-			metricCount += len(metrics)
-		}
-
-		assert.Equal(t, metricCount, len(resp))
 	})
 }


### PR DESCRIPTION
**What is this feature?**
This PR is a follow up on https://github.com/grafana/grafana/pull/57424. It removes a few methods and functions in the metric_find_query.go file that are not used anymore. Also, now that the `ListMetrics` method is available in the client, the check health handler uses the client instead of the old method defined in the metric_find_query.go file. 

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->
Part of https://github.com/grafana/grafana/issues/57146


