### PR TITLE
Access Control: move data source permission model to enterprise repo

### DIFF
--- a/pkg/services/datasources/models.go
+++ b/pkg/services/datasources/models.go
@@ -188,31 +188,6 @@ type GetDataSourceQuery struct {
 	Result *DataSource
 }
 
-// ---------------------
-//  Permissions
-// ---------------------
-
-// Datasource permission
-// Description:
-// * `0` - No Access
-// * `1` - Query
-// Enum: 0,1
-// swagger:model
-type DsPermissionType int
-
-const (
-	DsPermissionNoAccess DsPermissionType = iota
-	DsPermissionQuery
-)
-
-func (p DsPermissionType) String() string {
-	names := map[int]string{
-		int(DsPermissionQuery):    "Query",
-		int(DsPermissionNoAccess): "No Access",
-	}
-	return names[int(p)]
-}
-
 type DatasourcesPermissionFilterQuery struct {
 	User        *user.SignedInUser
 	Datasources []*DataSource


### PR DESCRIPTION
**What is this feature?**
A small refactor that moves data source permission model to Enterprise repo - DS permissions is an enterprise feature, so all the code related to them lives in the Enterprise repo.

Related enterprise PR: https://github.com/grafana/grafana-enterprise/pull/4049
