### PR TITLE
SQLStore: Create utility for bulk inserts

### DIFF
--- a/pkg/services/sqlstore/bulk.go
+++ b/pkg/services/sqlstore/bulk.go
@@ -1,0 +1,36 @@
+package sqlstore
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
+)
+
+type BulkOpSettings struct {
+	BatchSize int
+}
+
+func NativeSettingsForDialect(d migrator.Dialect) BulkOpSettings {
+	return BulkOpSettings{
+		BatchSize: d.BatchSize(),
+	}
+}
+
+func Test() {
+	s := &DBSession{}
+	records := []int{1, 2, 3}
+	s.BulkInsert(1, BulkOpSettings{}, records...)
+}
+
+func (sess *DBSession) BulkInsert(table interface{}, opts BulkOpSettings, records ...any) {
+	sess.Table(table).InsertMulti(records)
+}
+
+func inBatches(items interface{}, size int, fn func(batch []interface{}) error) error {
+	t := reflect.ValueOf(items)
+	if t.Kind() != reflect.Slice {
+		return fmt.Errorf("cannot batch records on a non-slice")
+	}
+	return nil
+}

--- a/pkg/services/sqlstore/bulk.go
+++ b/pkg/services/sqlstore/bulk.go
@@ -21,6 +21,7 @@ func NativeSettingsForDialect(d migrator.Dialect) BulkOpSettings {
 
 func normalizeBulkSettings(s BulkOpSettings) BulkOpSettings {
 	if s.BatchSize < 1 {
+		sessionLogger.Debug("Invalid batch size, falling back to the default", "requested", s.BatchSize, "actual", DefaultBatchSize)
 		s.BatchSize = DefaultBatchSize
 	}
 	return s

--- a/pkg/services/sqlstore/bulk.go
+++ b/pkg/services/sqlstore/bulk.go
@@ -7,6 +7,8 @@ import (
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
 )
 
+const DefaultBatchSize = 1000
+
 type BulkOpSettings struct {
 	BatchSize int
 }
@@ -15,6 +17,13 @@ func NativeSettingsForDialect(d migrator.Dialect) BulkOpSettings {
 	return BulkOpSettings{
 		BatchSize: d.BatchSize(),
 	}
+}
+
+func normalizeBulkSettings(s BulkOpSettings) BulkOpSettings {
+	if s.BatchSize < 1 {
+		s.BatchSize = DefaultBatchSize
+	}
+	return s
 }
 
 func (sess *DBSession) BulkInsert(table interface{}, recordsSlice interface{}, opts BulkOpSettings) (int64, error) {
@@ -28,6 +37,7 @@ func (sess *DBSession) BulkInsert(table interface{}, recordsSlice interface{}, o
 }
 
 func InBatches(items interface{}, opts BulkOpSettings, fn func(batch interface{}) error) error {
+	opts = normalizeBulkSettings(opts)
 	slice := reflect.Indirect(reflect.ValueOf(items))
 	if slice.Kind() != reflect.Slice {
 		return fmt.Errorf("need a slice in order to batch records")

--- a/pkg/services/sqlstore/bulk.go
+++ b/pkg/services/sqlstore/bulk.go
@@ -40,7 +40,7 @@ func InBatches(items interface{}, opts BulkOpSettings, fn func(batch interface{}
 	opts = normalizeBulkSettings(opts)
 	slice := reflect.Indirect(reflect.ValueOf(items))
 	if slice.Kind() != reflect.Slice {
-		return fmt.Errorf("need a slice in order to batch records")
+		return fmt.Errorf("need a slice of objects in order to batch")
 	}
 
 	for i := 0; i < slice.Len(); i += opts.BatchSize {

--- a/pkg/services/sqlstore/bulk_test.go
+++ b/pkg/services/sqlstore/bulk_test.go
@@ -1,0 +1,1 @@
+package sqlstore

--- a/pkg/services/sqlstore/bulk_test.go
+++ b/pkg/services/sqlstore/bulk_test.go
@@ -65,7 +65,8 @@ func TestBulkOps(t *testing.T) {
 		t.Skip("skipping integration test")
 	}
 	db := InitTestDB(t)
-	db.engine.Sync(new(bulkTestItem))
+	err := db.engine.Sync(new(bulkTestItem))
+	require.NoError(t, err)
 
 	t.Run("insert several records", func(t *testing.T) {
 		vals := make([]bulkTestItem, 45)

--- a/pkg/services/sqlstore/bulk_test.go
+++ b/pkg/services/sqlstore/bulk_test.go
@@ -1,1 +1,96 @@
 package sqlstore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type bulkTestItem struct {
+	ID    int64
+	Value string `xorm:"varchar(10)"`
+}
+
+func TestBatching(t *testing.T) {
+	t.Run("InBatches", func(t *testing.T) {
+		t.Run("calls fn 0 times if items is empty", func(t *testing.T) {
+			var calls int
+			fn := func(batch interface{}) error { calls += 1; return nil }
+			opts := BulkOpSettings{BatchSize: DefaultBatchSize}
+
+			err := InBatches([]int{}, opts, fn)
+
+			require.NoError(t, err)
+			require.Zero(t, calls)
+		})
+
+		t.Run("succeeds if batch size is nonpositive", func(t *testing.T) {
+			var calls int
+			fn := func(batch interface{}) error { calls += 1; return nil }
+			opts := BulkOpSettings{BatchSize: DefaultBatchSize}
+
+			err := InBatches([]int{1, 2, 3}, opts, fn)
+
+			require.NoError(t, err)
+			require.Equal(t, 1, calls)
+		})
+
+		t.Run("rejects if items is not a slice", func(t *testing.T) {
+			var calls int
+			fn := func(batch interface{}) error { calls += 1; return nil }
+			opts := BulkOpSettings{BatchSize: DefaultBatchSize}
+
+			err := InBatches("lol", opts, fn)
+
+			require.Error(t, err)
+		})
+
+		t.Run("calls expected number of times when batch size does not evenly divide length", func(t *testing.T) {
+			var calls int
+			fn := func(batch interface{}) error { calls += 1; return nil }
+			opts := BulkOpSettings{BatchSize: 5}
+			vals := make([]int, 93)
+
+			err := InBatches(vals, opts, fn)
+
+			require.NoError(t, err)
+			require.Equal(t, 19, calls)
+		})
+	})
+}
+
+func TestBulkOps(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	db := InitTestDB(t)
+	db.engine.Sync(new(bulkTestItem))
+
+	t.Run("insert several records", func(t *testing.T) {
+		vals := make([]bulkTestItem, 45)
+		opts := NativeSettingsForDialect(db.GetDialect())
+		opts.BatchSize = 10
+
+		var inserted int64
+		err := db.WithDbSession(context.Background(), func(sess *DBSession) error {
+			ins, err := sess.BulkInsert(bulkTestItem{}, vals, opts)
+			inserted = ins
+			return err
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, int64(45), inserted)
+		assertTableCount(t, db, bulkTestItem{}, 45)
+	})
+}
+
+func assertTableCount(t *testing.T, db *SQLStore, table interface{}, expCount int64) {
+	t.Helper()
+	err := db.WithDbSession(context.Background(), func(sess *DBSession) error {
+		total, err := sess.Table(bulkTestItem{}).Count()
+		require.Equal(t, expCount, total)
+		return err
+	})
+	require.NoError(t, err)
+}

--- a/pkg/services/sqlstore/migrator/dialect.go
+++ b/pkg/services/sqlstore/migrator/dialect.go
@@ -26,6 +26,7 @@ type Dialect interface {
 	Default(col *Column) string
 	BooleanStr(bool) string
 	DateTimeFunc(string) string
+	BatchSize() int
 
 	OrderBy(order string) string
 

--- a/pkg/services/sqlstore/migrator/mysql_dialect.go
+++ b/pkg/services/sqlstore/migrator/mysql_dialect.go
@@ -44,6 +44,10 @@ func (db *MySQLDialect) BooleanStr(value bool) string {
 	return "0"
 }
 
+func (db *MySQLDialect) BatchSize() int {
+	return 1000
+}
+
 func (db *MySQLDialect) SQLType(c *Column) string {
 	var res string
 	switch c.Type {

--- a/pkg/services/sqlstore/migrator/postgres_dialect.go
+++ b/pkg/services/sqlstore/migrator/postgres_dialect.go
@@ -45,6 +45,10 @@ func (db *PostgresDialect) BooleanStr(value bool) string {
 	return strconv.FormatBool(value)
 }
 
+func (db *PostgresDialect) BatchSize() int {
+	return 1000
+}
+
 func (db *PostgresDialect) Default(col *Column) string {
 	if col.Type == DB_Bool {
 		if col.Default == "0" {

--- a/pkg/services/sqlstore/migrator/sqlite_dialect.go
+++ b/pkg/services/sqlstore/migrator/sqlite_dialect.go
@@ -40,6 +40,12 @@ func (db *SQLite3) BooleanStr(value bool) string {
 	return "0"
 }
 
+func (db *SQLite3) BatchSize() int {
+	// SQLite has a maximum parameter count per statement of 100.
+	// So, we use a small batch size to support write operations.
+	return 10
+}
+
 func (db *SQLite3) DateTimeFunc(value string) string {
 	return "datetime(" + value + ")"
 }


### PR DESCRIPTION
**What is this feature?**

This PR is to support https://github.com/grafana/grafana/pull/56575, along with some other similar use cases in Alerting.

This PR implements a small utility over the ORM which does bulk inserts, that splits large enough inserts into chunks. The batch size is configurable, and we give a way to pick reasonable defaults based on the dialect being used.

**Why do we need this feature?**

xorm's `InsertMulti()` and other bulk-style family of functions tend to dump all requested operations into a single SQL statement. In practice, we almost always want batching, instead. Batching avoids sending overly large single statements, reduces lock and disk contention, and works around limitations in databases - namely, caps on the number of parameters allowed in a single statement.

**Who is this feature for?**

Initially, this feature will be used in 3 places in the Alerting subsystem where we have potentially large inserts - annotations, state persistence, and the migration from Legacy alerting.

It can also be used as an alternative to `InsertMulti`, by any other subsystem that needs it, for a bit more robustness when dealing with large operations.

**Which issue(s) does this PR fix?**:

Contributes to: https://github.com/grafana/grafana/issues/54096

**Special notes for your reviewer**:

n/a
