### PR TITLE
Transformations: Fix Organize Fields sorting

### DIFF
--- a/packages/grafana-data/src/transformations/transformers/order.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/order.test.ts
@@ -73,6 +73,60 @@ describe('Order Transformer', () => {
         ]);
       });
     });
+
+    it('should disable order according to config', async () => {
+      const cfg: DataTransformerConfig<OrderFieldsTransformerOptions> = {
+        id: DataTransformerID.order,
+        disabled: true,
+        options: {
+          indexByName: {
+            time: 2,
+            temperature: 0,
+            humidity: 1,
+          },
+        },
+      };
+
+      await expect(transformDataFrame([cfg], [data])).toEmitValuesWith((received) => {
+        const data = received[0];
+        const ordered = data[0];
+        expect(ordered.fields).toEqual([
+          {
+            config: {},
+            name: 'time',
+            type: FieldType.time,
+            values: new ArrayVector([3000, 4000, 5000, 6000]),
+            labels: undefined,
+            state: {
+              displayName: 'time',
+              multipleFrames: false,
+            },
+          },
+          {
+            config: {},
+            name: 'temperature',
+            type: FieldType.number,
+            values: new ArrayVector([10.3, 10.4, 10.5, 10.6]),
+            labels: undefined,
+            state: {
+              displayName: 'temperature',
+              multipleFrames: false,
+            },
+          },
+          {
+            config: {},
+            name: 'humidity',
+            type: FieldType.number,
+            values: new ArrayVector([10000.3, 10000.4, 10000.5, 10000.6]),
+            labels: undefined,
+            state: {
+              displayName: 'humidity',
+              multipleFrames: false,
+            },
+          },
+        ]);
+      });
+    });
   });
 
   describe('when inconsistent data is received', () => {

--- a/packages/grafana-data/src/transformations/transformers/order.ts
+++ b/packages/grafana-data/src/transformations/transformers/order.ts
@@ -1,3 +1,4 @@
+import { clone } from 'lodash';
 import { map } from 'rxjs/operators';
 
 import { getFieldDisplayName } from '../../field/fieldState';
@@ -52,7 +53,9 @@ const createFieldsOrderer =
       return fields;
     }
     const comparer = createOrderFieldsComparer(indexByName);
-    return fields.sort((a, b) => comparer(getFieldDisplayName(a, frame, data), getFieldDisplayName(b, frame, data)));
+    return clone(fields).sort((a, b) =>
+      comparer(getFieldDisplayName(a, frame, data), getFieldDisplayName(b, frame, data))
+    );
   };
 
 const indexOfField = (fieldName: string, indexByName: Record<string, number>) => {


### PR DESCRIPTION
**What is this feature?**

This PR ensures that the state being sorted by transformation is fresh.

**Why do we need this feature?**

To make sure that the `Organize Fields` transformation works properly. 

**Which issue(s) does this PR fix?**: 

Fixes https://github.com/grafana/grafana/issues/49897

**Special notes for your reviewer**:

https://user-images.githubusercontent.com/1680157/197869160-9257bd19-d26b-45fb-9dad-0f7455d56d37.mov