### PR TITLE
PublicDashboards: Fix unsafe code snippets

### DIFF
--- a/pkg/services/publicdashboards/models/models.go
+++ b/pkg/services/publicdashboards/models/models.go
@@ -61,6 +61,10 @@ var (
 		Reason:     "bad Request",
 		StatusCode: 400,
 	}
+	ErrNoPanelQueriesFound = PublicDashboardErr{
+		Reason:     "failed to extract queries from panel",
+		StatusCode: 400,
+	}
 )
 
 type PublicDashboard struct {

--- a/pkg/services/publicdashboards/service/query.go
+++ b/pkg/services/publicdashboards/service/query.go
@@ -131,7 +131,7 @@ func (pd *PublicDashboardServiceImpl) GetQueryDataResponse(ctx context.Context, 
 	}
 
 	if len(metricReq.Queries) == 0 {
-		return nil, nil
+		return nil, models.ErrNoPanelQueriesFound
 	}
 
 	anonymousUser := buildAnonymousUser(ctx, dashboard)

--- a/public/app/features/dashboard/services/PublicDashboardDataSource.ts
+++ b/public/app/features/dashboard/services/PublicDashboardDataSource.ts
@@ -59,7 +59,7 @@ export class PublicDashboardDataSource extends DataSourceApi<DataQuery, DataSour
   }
 
   private static isMixedDatasource(datasource: DataSourceRef | string | DataSourceApi | null): boolean {
-    if (typeof datasource === 'string' || datasource === null) {
+    if (typeof datasource === 'string' || datasource == null) {
       return false;
     }
 
@@ -67,7 +67,7 @@ export class PublicDashboardDataSource extends DataSourceApi<DataQuery, DataSour
   }
 
   private static resolveInterval(datasource: DataSourceRef | string | DataSourceApi | null): string {
-    if (typeof datasource === 'string' || datasource === null) {
+    if (typeof datasource === 'string' || datasource == null) {
       return DEFAULT_INTERVAL;
     }
 


### PR DESCRIPTION
**What is this feature?**

This fixes some unsafe code I ran into while fighting other fires:

1. Attempting to serialize a nil response 
2. Checking for null instead of null and undefined (== and != are evidently the proper way to do this, lets see if the linter is okay with it)
