### PR TITLE
ServiceAccounts: Wrap ServiceAccountPage route in dynamic import

### DIFF
--- a/public/app/features/serviceaccounts/ServiceAccountPage.tsx
+++ b/public/app/features/serviceaccounts/ServiceAccountPage.tsx
@@ -223,4 +223,4 @@ export const ServiceAccountPageUnconnected = ({
   );
 };
 
-export const ServiceAccountPage = connector(ServiceAccountPageUnconnected);
+export default connector(ServiceAccountPageUnconnected);

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -14,7 +14,6 @@ import { DATASOURCES_ROUTES } from 'app/features/datasources/constants';
 import { getLiveRoutes } from 'app/features/live/pages/routes';
 import { getRoutes as getPluginCatalogRoutes } from 'app/features/plugins/admin/routes';
 import { getProfileRoutes } from 'app/features/profile/routes';
-import { ServiceAccountPage } from 'app/features/serviceaccounts/ServiceAccountPage';
 import { AccessControlAction, DashboardRoutes } from 'app/types';
 
 import { SafeDynamicImport } from '../core/components/DynamicImports/SafeDynamicImport';
@@ -269,7 +268,9 @@ export function getAppRoutes(): RouteDescriptor[] {
     },
     {
       path: '/org/serviceaccounts/:id',
-      component: ServiceAccountPage,
+      component: SafeDynamicImport(
+        () => import(/* webpackChunkName: "ServiceAccountPage" */ 'app/features/serviceaccounts/ServiceAccountPage')
+      ),
     },
     {
       path: '/org/teams',


### PR DESCRIPTION
Small change to dynamically import the `ServiceAccountPage` route so it's not included in the main bundle.