### PR TITLE
Chore: Update prometheus, loki, graphite and influx plugins to support contextual logs.

### DIFF
--- a/pkg/tsdb/graphite/graphite_test.go
+++ b/pkg/tsdb/graphite/graphite_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
-	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -50,7 +49,7 @@ func TestFixIntervalFormat(t *testing.T) {
 		})
 	}
 
-	service := &Service{logger: log.New("tsdb.graphite")}
+	service := &Service{}
 
 	t.Run("Converts response without tags to data frames", func(*testing.T) {
 		body := `
@@ -69,7 +68,7 @@ func TestFixIntervalFormat(t *testing.T) {
 		expectedFrames := data.Frames{expectedFrame}
 
 		httpResponse := &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(body))}
-		dataFrames, err := service.toDataFrames(httpResponse)
+		dataFrames, err := service.toDataFrames(logger, httpResponse)
 
 		require.NoError(t, err)
 		if !reflect.DeepEqual(expectedFrames, dataFrames) {
@@ -102,7 +101,7 @@ func TestFixIntervalFormat(t *testing.T) {
 		expectedFrames := data.Frames{expectedFrame}
 
 		httpResponse := &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(body))}
-		dataFrames, err := service.toDataFrames(httpResponse)
+		dataFrames, err := service.toDataFrames(logger, httpResponse)
 
 		require.NoError(t, err)
 		if !reflect.DeepEqual(expectedFrames, dataFrames) {

--- a/pkg/tsdb/influxdb/flux/executor_test.go
+++ b/pkg/tsdb/influxdb/flux/executor_test.go
@@ -14,11 +14,12 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana-plugin-sdk-go/experimental"
-	"github.com/grafana/grafana/pkg/components/simplejson"
-	"github.com/grafana/grafana/pkg/tsdb/influxdb/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/xorcare/pointer"
+
+	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/tsdb/influxdb/models"
 
 	influxdb2 "github.com/influxdata/influxdb-client-go/v2"
 	"github.com/influxdata/influxdb-client-go/v2/api"
@@ -62,7 +63,7 @@ func executeMockedQuery(t *testing.T, name string, query queryModel) *backend.Da
 		testDataPath: name + ".csv",
 	}
 
-	dr := executeQuery(context.Background(), query, runner, 50)
+	dr := executeQuery(context.Background(), glog, query, runner, 50)
 	return &dr
 }
 
@@ -226,7 +227,7 @@ func TestRealQuery(t *testing.T) {
 		runner, err := runnerFromDataSource(dsInfo)
 		require.NoError(t, err)
 
-		dr := executeQuery(context.Background(), queryModel{
+		dr := executeQuery(context.Background(), glog, queryModel{
 			MaxDataPoints: 100,
 			RawQuery:      "buckets()",
 		}, runner, 50)

--- a/pkg/tsdb/influxdb/flux/flux.go
+++ b/pkg/tsdb/influxdb/flux/flux.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
-	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/tsdb/influxdb/models"
 	influxdb2 "github.com/influxdata/influxdb-client-go/v2"
 	"github.com/influxdata/influxdb-client-go/v2/api"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/tsdb/influxdb/models"
 )
 
 var (
@@ -18,8 +19,9 @@ var (
 // Query builds flux queries, executes them, and returns the results.
 func Query(ctx context.Context, dsInfo *models.DatasourceInfo, tsdbQuery backend.QueryDataRequest) (
 	*backend.QueryDataResponse, error) {
+	logger := glog.FromContext(ctx)
 	tRes := backend.NewQueryDataResponse()
-	glog.Debug("Received a query", "query", tsdbQuery)
+	logger.Debug("Received a query", "query", tsdbQuery)
 	r, err := runnerFromDataSource(dsInfo)
 	if err != nil {
 		return &backend.QueryDataResponse{}, err
@@ -36,7 +38,7 @@ func Query(ctx context.Context, dsInfo *models.DatasourceInfo, tsdbQuery backend
 
 		// If the default changes also update labels/placeholder in config page.
 		maxSeries := dsInfo.MaxSeries
-		res := executeQuery(ctx, *qm, r, maxSeries)
+		res := executeQuery(ctx, logger, *qm, r, maxSeries)
 
 		tRes.Responses[query.RefID] = res
 	}

--- a/pkg/tsdb/influxdb/healthcheck.go
+++ b/pkg/tsdb/influxdb/healthcheck.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/tsdb/influxdb/flux"
 	"github.com/grafana/grafana/pkg/tsdb/influxdb/models"
 )
@@ -17,28 +19,30 @@ const (
 
 func (s *Service) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult,
 	error) {
+	logger := logger.FromContext(ctx)
 	dsInfo, err := s.getDSInfo(req.PluginContext)
 	if err != nil {
-		return getHealthCheckMessage(s, "error getting datasource info", err)
+		return getHealthCheckMessage(logger, "error getting datasource info", err)
 	}
 
 	if dsInfo == nil {
-		return getHealthCheckMessage(s, "", errors.New("invalid datasource info received"))
+		return getHealthCheckMessage(logger, "", errors.New("invalid datasource info received"))
 	}
 
 	switch dsInfo.Version {
 	case influxVersionFlux:
-		return CheckFluxHealth(ctx, dsInfo, s, req)
+		return CheckFluxHealth(ctx, dsInfo, req)
 	case influxVersionInfluxQL:
 		return CheckInfluxQLHealth(ctx, dsInfo, s)
 	default:
-		return getHealthCheckMessage(s, "", errors.New("unknown influx version"))
+		return getHealthCheckMessage(logger, "", errors.New("unknown influx version"))
 	}
 }
 
-func CheckFluxHealth(ctx context.Context, dsInfo *models.DatasourceInfo, s *Service,
+func CheckFluxHealth(ctx context.Context, dsInfo *models.DatasourceInfo,
 	req *backend.CheckHealthRequest) (*backend.CheckHealthResult,
 	error) {
+	logger := logger.FromContext(ctx)
 	ds, err := flux.Query(ctx, dsInfo, backend.QueryDataRequest{
 		PluginContext: req.PluginContext,
 		Queries: []backend.DataQuery{
@@ -56,40 +60,41 @@ func CheckFluxHealth(ctx context.Context, dsInfo *models.DatasourceInfo, s *Serv
 	})
 
 	if err != nil {
-		return getHealthCheckMessage(s, "error performing flux query", err)
+		return getHealthCheckMessage(logger, "error performing flux query", err)
 	}
 	if res, ok := ds.Responses[refID]; ok {
 		if res.Error != nil {
-			return getHealthCheckMessage(s, "error reading buckets", res.Error)
+			return getHealthCheckMessage(logger, "error reading buckets", res.Error)
 		}
 		if len(res.Frames) > 0 && len(res.Frames[0].Fields) > 0 {
-			return getHealthCheckMessage(s, fmt.Sprintf("%d buckets found", res.Frames[0].Fields[0].Len()), nil)
+			return getHealthCheckMessage(logger, fmt.Sprintf("%d buckets found", res.Frames[0].Fields[0].Len()), nil)
 		}
 	}
 
-	return getHealthCheckMessage(s, "", errors.New("error getting flux query buckets"))
+	return getHealthCheckMessage(logger, "", errors.New("error getting flux query buckets"))
 }
 
 func CheckInfluxQLHealth(ctx context.Context, dsInfo *models.DatasourceInfo, s *Service) (*backend.CheckHealthResult, error) {
+	logger := logger.FromContext(ctx)
 	queryString := "SHOW measurements"
-	hcRequest, err := s.createRequest(ctx, dsInfo, queryString)
+	hcRequest, err := s.createRequest(ctx, logger, dsInfo, queryString)
 	if err != nil {
-		return getHealthCheckMessage(s, "error creating influxDB healthcheck request", err)
+		return getHealthCheckMessage(logger, "error creating influxDB healthcheck request", err)
 	}
 
 	res, err := dsInfo.HTTPClient.Do(hcRequest)
 	if err != nil {
-		return getHealthCheckMessage(s, "error performing influxQL query", err)
+		return getHealthCheckMessage(logger, "error performing influxQL query", err)
 	}
 
 	defer func() {
 		if err := res.Body.Close(); err != nil {
-			s.glog.Warn("failed to close response body", "err", err)
+			logger.Warn("failed to close response body", "err", err)
 		}
 	}()
 
 	if res.StatusCode/100 != 2 {
-		return getHealthCheckMessage(s, "", fmt.Errorf("error reading InfluxDB. Status Code: %d", res.StatusCode))
+		return getHealthCheckMessage(logger, "", fmt.Errorf("error reading InfluxDB. Status Code: %d", res.StatusCode))
 	}
 	resp := s.responseParser.Parse(res.Body, []Query{{
 		RefID:       refID,
@@ -98,22 +103,22 @@ func CheckInfluxQLHealth(ctx context.Context, dsInfo *models.DatasourceInfo, s *
 	}})
 	if res, ok := resp.Responses[refID]; ok {
 		if res.Error != nil {
-			return getHealthCheckMessage(s, "error reading influxDB", res.Error)
+			return getHealthCheckMessage(logger, "error reading influxDB", res.Error)
 		}
 
 		if len(res.Frames) == 0 {
-			return getHealthCheckMessage(s, "0 measurements found", nil)
+			return getHealthCheckMessage(logger, "0 measurements found", nil)
 		}
 
 		if len(res.Frames) > 0 && len(res.Frames[0].Fields) > 0 {
-			return getHealthCheckMessage(s, fmt.Sprintf("%d measurements found", res.Frames[0].Fields[0].Len()), nil)
+			return getHealthCheckMessage(logger, fmt.Sprintf("%d measurements found", res.Frames[0].Fields[0].Len()), nil)
 		}
 	}
 
-	return getHealthCheckMessage(s, "", errors.New("error connecting influxDB influxQL"))
+	return getHealthCheckMessage(logger, "", errors.New("error connecting influxDB influxQL"))
 }
 
-func getHealthCheckMessage(s *Service, message string, err error) (*backend.CheckHealthResult, error) {
+func getHealthCheckMessage(logger log.Logger, message string, err error) (*backend.CheckHealthResult, error) {
 	if err == nil {
 		return &backend.CheckHealthResult{
 			Status:  backend.HealthStatusOk,
@@ -121,7 +126,7 @@ func getHealthCheckMessage(s *Service, message string, err error) (*backend.Chec
 		}, nil
 	}
 
-	s.glog.Warn("error performing influxdb healthcheck", "err", err.Error())
+	logger.Warn("error performing influxdb healthcheck", "err", err.Error())
 	errorMessage := fmt.Sprintf("%s %s", err.Error(), message)
 
 	return &backend.CheckHealthResult{

--- a/pkg/tsdb/influxdb/influxdb_test.go
+++ b/pkg/tsdb/influxdb/influxdb_test.go
@@ -6,10 +6,10 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/tsdb/influxdb/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/tsdb/influxdb/models"
 )
 
 func TestExecutor_createRequest(t *testing.T) {
@@ -22,11 +22,10 @@ func TestExecutor_createRequest(t *testing.T) {
 	s := &Service{
 		queryParser:    &InfluxdbQueryParser{},
 		responseParser: &ResponseParser{},
-		glog:           log.New("test"),
 	}
 
 	t.Run("createRequest with GET httpMode", func(t *testing.T) {
-		req, err := s.createRequest(context.Background(), datasource, query)
+		req, err := s.createRequest(context.Background(), logger, datasource, query)
 
 		require.NoError(t, err)
 
@@ -40,7 +39,7 @@ func TestExecutor_createRequest(t *testing.T) {
 
 	t.Run("createRequest with POST httpMode", func(t *testing.T) {
 		datasource.HTTPMode = "POST"
-		req, err := s.createRequest(context.Background(), datasource, query)
+		req, err := s.createRequest(context.Background(), logger, datasource, query)
 		require.NoError(t, err)
 
 		assert.Equal(t, "POST", req.Method)
@@ -59,7 +58,7 @@ func TestExecutor_createRequest(t *testing.T) {
 
 	t.Run("createRequest with PUT httpMode", func(t *testing.T) {
 		datasource.HTTPMode = "PUT"
-		_, err := s.createRequest(context.Background(), datasource, query)
+		_, err := s.createRequest(context.Background(), logger, datasource, query)
 		require.EqualError(t, err, ErrInvalidHttpMode.Error())
 	})
 }

--- a/pkg/tsdb/influxdb/mocks_test.go
+++ b/pkg/tsdb/influxdb/mocks_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
+
 	"github.com/grafana/grafana/pkg/infra/httpclient"
-	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/tsdb/influxdb/models"
 )
 
@@ -114,7 +114,6 @@ func GetMockService(version string, rt RoundTripper) *Service {
 	return &Service{
 		queryParser:    &InfluxdbQueryParser{},
 		responseParser: &ResponseParser{},
-		glog:           log.New("tsdb.influxdb"),
 		im: &fakeInstance{
 			version:          version,
 			fakeRoundTripper: rt,

--- a/pkg/tsdb/loki/auth_test.go
+++ b/pkg/tsdb/loki/auth_test.go
@@ -8,9 +8,10 @@ import (
 	"testing"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
-	"github.com/stretchr/testify/require"
 )
 
 type mockedRoundTripperForOauth struct {
@@ -122,7 +123,7 @@ func TestOauthForwardIdentity(t *testing.T) {
 
 			tracer := tracing.InitializeTracerForTest()
 
-			data, err := queryData(context.Background(), &req, &dsInfo, log.New("testlog"), tracer)
+			data, err := queryData(context.Background(), &req, &dsInfo, tracer)
 			// we do a basic check that the result is OK
 			require.NoError(t, err)
 			require.Len(t, data.Responses, 1)

--- a/pkg/tsdb/loki/loki.go
+++ b/pkg/tsdb/loki/loki.go
@@ -13,17 +13,19 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend/datasource"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"go.opentelemetry.io/otel/attribute"
+
 	"github.com/grafana/grafana/pkg/infra/httpclient"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
-	"go.opentelemetry.io/otel/attribute"
 )
+
+var logger = log.New("tsdb.loki")
 
 type Service struct {
 	im       instancemgmt.InstanceManager
 	features featuremgmt.FeatureToggles
-	plog     log.Logger
 	tracer   tracing.Tracer
 }
 
@@ -37,7 +39,6 @@ func ProvideService(httpClientProvider httpclient.Provider, features featuremgmt
 	return &Service{
 		im:       datasource.NewInstanceManager(newInstanceSettings(httpClientProvider)),
 		features: features,
-		plog:     log.New("tsdb.loki"),
 		tracer:   tracer,
 	}
 }
@@ -115,8 +116,7 @@ func (s *Service) CallResource(ctx context.Context, req *backend.CallResourceReq
 	if err != nil {
 		return err
 	}
-
-	return callResource(ctx, req, sender, dsInfo, s.plog)
+	return callResource(ctx, req, sender, dsInfo, logger.FromContext(ctx))
 }
 
 func getAuthHeadersForCallResource(headers map[string][]string) map[string]string {
@@ -170,13 +170,13 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 		return result, err
 	}
 
-	return queryData(ctx, req, dsInfo, s.plog, s.tracer)
+	return queryData(ctx, req, dsInfo, s.tracer)
 }
 
-func queryData(ctx context.Context, req *backend.QueryDataRequest, dsInfo *datasourceInfo, plog log.Logger, tracer tracing.Tracer) (*backend.QueryDataResponse, error) {
+func queryData(ctx context.Context, req *backend.QueryDataRequest, dsInfo *datasourceInfo, tracer tracing.Tracer) (*backend.QueryDataResponse, error) {
 	result := backend.NewQueryDataResponse()
 
-	api := newLokiAPI(dsInfo.HTTPClient, dsInfo.URL, plog, req.Headers)
+	api := newLokiAPI(dsInfo.HTTPClient, dsInfo.URL, logger.FromContext(ctx), req.Headers)
 
 	queries, err := parseQuery(req)
 	if err != nil {
@@ -184,12 +184,14 @@ func queryData(ctx context.Context, req *backend.QueryDataRequest, dsInfo *datas
 	}
 
 	for _, query := range queries {
-		plog.Debug("Sending query", "start", query.Start, "end", query.End, "step", query.Step, "query", query.Expr)
 		_, span := tracer.Start(ctx, "alerting.loki")
 		span.SetAttributes("expr", query.Expr, attribute.Key("expr").String(query.Expr))
 		span.SetAttributes("start_unixnano", query.Start, attribute.Key("start_unixnano").Int64(query.Start.UnixNano()))
 		span.SetAttributes("stop_unixnano", query.End, attribute.Key("stop_unixnano").Int64(query.End.UnixNano()))
 		defer span.End()
+
+		logger := logger.FromContext(ctx) // get logger with trace-id and other contextual info
+		logger.Debug("Sending query", "start", query.Start, "end", query.End, "step", query.Step, "query", query.Expr)
 
 		frames, err := runQuery(ctx, api, query)
 

--- a/pkg/tsdb/prometheus/buffered/framing_test.go
+++ b/pkg/tsdb/prometheus/buffered/framing_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/prometheus/client_golang/api"
 	apiv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 
-	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/infra/log/logtest"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/tsdb/intervalv2"
 )
@@ -140,7 +140,7 @@ func runQuery(response []byte, sq storedPrometheusQuery) (*backend.QueryDataResp
 		intervalCalculator: intervalv2.NewCalculator(),
 		tracer:             tracer,
 		TimeInterval:       "15s",
-		log:                &fakeLogger{},
+		log:                &logtest.Fake{},
 		client:             api,
 	}
 
@@ -178,12 +178,3 @@ func runQuery(response []byte, sq storedPrometheusQuery) (*backend.QueryDataResp
 
 	return b.runQueries(context.Background(), queries)
 }
-
-type fakeLogger struct {
-	log.Logger
-}
-
-func (fl *fakeLogger) Debug(testMessage string, ctx ...interface{}) {}
-func (fl *fakeLogger) Info(testMessage string, ctx ...interface{})  {}
-func (fl *fakeLogger) Warn(testMessage string, ctx ...interface{})  {}
-func (fl *fakeLogger) Error(testMessage string, ctx ...interface{}) {}

--- a/pkg/tsdb/prometheus/buffered/prometeus_bench_test.go
+++ b/pkg/tsdb/prometheus/buffered/prometeus_bench_test.go
@@ -11,8 +11,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/infra/log/logtest"
+	"github.com/grafana/grafana/pkg/infra/tracing"
 )
 
 // when memory-profiling this benchmark, these commands are recommended:
@@ -34,7 +36,7 @@ func BenchmarkExemplarJson(b *testing.B) {
 
 	tracer := tracing.InitializeTracerForTest()
 
-	s := Buffered{tracer: tracer, log: &fakeLogger{}, client: api}
+	s := Buffered{tracer: tracer, log: &logtest.Fake{}, client: api}
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
@@ -52,7 +54,7 @@ func BenchmarkRangeJson(b *testing.B) {
 	api, err := makeMockedApi(resp)
 	require.NoError(b, err)
 
-	s := Buffered{tracer: tracing.InitializeTracerForTest(), log: &fakeLogger{}, client: api}
+	s := Buffered{tracer: tracing.InitializeTracerForTest(), log: &logtest.Fake{}, client: api}
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {

--- a/pkg/tsdb/prometheus/buffered/time_series_query.go
+++ b/pkg/tsdb/prometheus/buffered/time_series_query.go
@@ -15,15 +15,16 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	sdkHTTPClient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
+	apiv1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+	"go.opentelemetry.io/otel/attribute"
+
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/tsdb/intervalv2"
 	"github.com/grafana/grafana/pkg/tsdb/prometheus/middleware"
 	"github.com/grafana/grafana/pkg/tsdb/prometheus/utils"
 	"github.com/grafana/grafana/pkg/util/maputil"
-	apiv1 "github.com/prometheus/client_golang/api/prometheus/v1"
-	"github.com/prometheus/common/model"
-	"go.opentelemetry.io/otel/attribute"
 )
 
 // Internal interval and range variables
@@ -120,16 +121,16 @@ func (b *Buffered) runQueries(ctx context.Context, queries []*PrometheusQuery) (
 	result := backend.QueryDataResponse{
 		Responses: backend.Responses{},
 	}
-
 	for _, query := range queries {
-		b.log.Debug("Sending query", "start", query.Start, "end", query.End, "step", query.Step, "query", query.Expr)
-
 		ctx, endSpan := utils.StartTrace(ctx, b.tracer, "datasource.prometheus", []utils.Attribute{
 			{Key: "expr", Value: query.Expr, Kv: attribute.Key("expr").String(query.Expr)},
 			{Key: "start_unixnano", Value: query.Start, Kv: attribute.Key("start_unixnano").Int64(query.Start.UnixNano())},
 			{Key: "stop_unixnano", Value: query.End, Kv: attribute.Key("stop_unixnano").Int64(query.End.UnixNano())},
 		})
 		defer endSpan()
+
+		logger := b.log.FromContext(ctx) // read trace-id and other info from the context
+		logger.Debug("Sending query", "start", query.Start, "end", query.End, "step", query.Step, "query", query.Expr)
 
 		response := make(map[TimeSeriesQueryType]interface{})
 
@@ -143,7 +144,7 @@ func (b *Buffered) runQueries(ctx context.Context, queries []*PrometheusQuery) (
 		if query.RangeQuery {
 			rangeResponse, _, err := b.client.QueryRange(ctx, query.Expr, timeRange)
 			if err != nil {
-				b.log.Error("Range query failed", "query", query.Expr, "err", err)
+				logger.Error("Range query failed", "query", query.Expr, "err", err)
 				result.Responses[query.RefId] = backend.DataResponse{Error: err}
 				continue
 			}
@@ -153,7 +154,7 @@ func (b *Buffered) runQueries(ctx context.Context, queries []*PrometheusQuery) (
 		if query.InstantQuery {
 			instantResponse, _, err := b.client.Query(ctx, query.Expr, query.End)
 			if err != nil {
-				b.log.Error("Instant query failed", "query", query.Expr, "err", err)
+				logger.Error("Instant query failed", "query", query.Expr, "err", err)
 				result.Responses[query.RefId] = backend.DataResponse{Error: err}
 				continue
 			}
@@ -165,7 +166,7 @@ func (b *Buffered) runQueries(ctx context.Context, queries []*PrometheusQuery) (
 		if query.ExemplarQuery {
 			exemplarResponse, err := b.client.QueryExemplars(ctx, query.Expr, timeRange.Start, timeRange.End)
 			if err != nil {
-				b.log.Error("Exemplar query failed", "query", query.Expr, "err", err)
+				logger.Error("Exemplar query failed", "query", query.Expr, "err", err)
 			} else {
 				response[ExemplarQueryType] = exemplarResponse
 			}

--- a/pkg/tsdb/prometheus/prometheus.go
+++ b/pkg/tsdb/prometheus/prometheus.go
@@ -13,6 +13,11 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/datasource"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
+	"github.com/patrickmn/go-cache"
+	apiv1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/yudai/gojsondiff"
+	"github.com/yudai/gojsondiff/formatter"
+
 	"github.com/grafana/grafana/pkg/infra/httpclient"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
@@ -21,10 +26,6 @@ import (
 	"github.com/grafana/grafana/pkg/tsdb/prometheus/buffered"
 	"github.com/grafana/grafana/pkg/tsdb/prometheus/querydata"
 	"github.com/grafana/grafana/pkg/tsdb/prometheus/resource"
-	"github.com/patrickmn/go-cache"
-	apiv1 "github.com/prometheus/client_golang/api/prometheus/v1"
-	"github.com/yudai/gojsondiff"
-	"github.com/yudai/gojsondiff/formatter"
 )
 
 var plog = log.New("tsdb.prometheus")
@@ -110,7 +111,7 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 		var data *backend.QueryDataResponse
 		var err error
 
-		plog.Debug("PrometheusStreamingJSONParserTest", "req", req)
+		plog.FromContext(ctx).Debug("PrometheusStreamingJSONParserTest", "req", req)
 
 		wg.Add(1)
 		go func() {

--- a/pkg/tsdb/prometheus/querydata/framing_test.go
+++ b/pkg/tsdb/prometheus/querydata/framing_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/experimental"
 
-	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/tsdb/prometheus/models"
 )
 
@@ -157,12 +156,3 @@ func runQuery(response []byte, q *backend.QueryDataRequest, wide bool) (*backend
 	tCtx.httpProvider.setResponse(res)
 	return tCtx.queryData.Execute(context.Background(), q)
 }
-
-type fakeLogger struct {
-	log.Logger
-}
-
-func (fl *fakeLogger) Debug(testMessage string, ctx ...interface{}) {}
-func (fl *fakeLogger) Info(testMessage string, ctx ...interface{})  {}
-func (fl *fakeLogger) Warn(testMessage string, ctx ...interface{})  {}
-func (fl *fakeLogger) Error(testMessage string, ctx ...interface{}) {}

--- a/pkg/tsdb/prometheus/querydata/request.go
+++ b/pkg/tsdb/prometheus/querydata/request.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"go.opentelemetry.io/otel/attribute"
+
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -16,7 +18,6 @@ import (
 	"github.com/grafana/grafana/pkg/tsdb/prometheus/models"
 	"github.com/grafana/grafana/pkg/tsdb/prometheus/utils"
 	"github.com/grafana/grafana/pkg/util/maputil"
-	"go.opentelemetry.io/otel/attribute"
 )
 
 const legendFormatAuto = "__auto"
@@ -90,7 +91,7 @@ func (s *QueryData) Execute(ctx context.Context, req *backend.QueryDataRequest) 
 			return &result, err
 		}
 		if r == nil {
-			s.log.Debug("Received nilresponse from runQuery", "query", query.Expr)
+			s.log.FromContext(ctx).Debug("Received nilresponse from runQuery", "query", query.Expr)
 			continue
 		}
 		result.Responses[q.RefID] = *r
@@ -100,10 +101,11 @@ func (s *QueryData) Execute(ctx context.Context, req *backend.QueryDataRequest) 
 }
 
 func (s *QueryData) fetch(ctx context.Context, client *client.Client, q *models.Query, headers map[string]string) (*backend.DataResponse, error) {
-	s.log.Debug("Sending query", "start", q.Start, "end", q.End, "step", q.Step, "query", q.Expr)
-
 	traceCtx, end := s.trace(ctx, q)
 	defer end()
+
+	logger := s.log.FromContext(traceCtx)
+	logger.Debug("Sending query", "start", q.Start, "end", q.End, "step", q.Step, "query", q.Expr)
 
 	response := &backend.DataResponse{
 		Frames: data.Frames{},
@@ -131,7 +133,7 @@ func (s *QueryData) fetch(ctx context.Context, client *client.Client, q *models.
 		if err != nil {
 			// If exemplar query returns error, we want to only log it and
 			// continue with other results processing
-			s.log.Error("Exemplar query failed", "query", q.Expr, "err", err)
+			logger.Error("Exemplar query failed", "query", q.Expr, "err", err)
 		}
 		if res != nil {
 			response.Frames = append(response.Frames, res.Frames...)

--- a/pkg/tsdb/prometheus/querydata/request_test.go
+++ b/pkg/tsdb/prometheus/querydata/request_test.go
@@ -13,15 +13,17 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
+	apiv1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	p "github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/grafana/pkg/infra/httpclient"
+	"github.com/grafana/grafana/pkg/infra/log/logtest"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tsdb/prometheus/buffered"
 	"github.com/grafana/grafana/pkg/tsdb/prometheus/models"
 	"github.com/grafana/grafana/pkg/tsdb/prometheus/querydata"
-	apiv1 "github.com/prometheus/client_golang/api/prometheus/v1"
-	p "github.com/prometheus/common/model"
-	"github.com/stretchr/testify/require"
 )
 
 func TestPrometheus_parseTimeSeriesResponse(t *testing.T) {
@@ -415,7 +417,7 @@ func setup(wideFrames bool) (*testContext, error) {
 
 	features := &fakeFeatureToggles{flags: map[string]bool{"prometheusStreamingJSONParser": true, "prometheusWideSeries": wideFrames}}
 
-	opts, err := buffered.CreateTransportOptions(settings, &setting.Cfg{}, &fakeLogger{})
+	opts, err := buffered.CreateTransportOptions(settings, &setting.Cfg{}, &logtest.Fake{})
 	if err != nil {
 		return nil, err
 	}
@@ -425,7 +427,7 @@ func setup(wideFrames bool) (*testContext, error) {
 		return nil, err
 	}
 
-	queryData, _ := querydata.New(httpClient, features, tracer, settings, &fakeLogger{})
+	queryData, _ := querydata.New(httpClient, features, tracer, settings, &logtest.Fake{})
 
 	return &testContext{
 		httpProvider: httpProvider,

--- a/pkg/tsdb/prometheus/querydata/response.go
+++ b/pkg/tsdb/prometheus/querydata/response.go
@@ -10,15 +10,16 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
+	jsoniter "github.com/json-iterator/go"
+
 	"github.com/grafana/grafana/pkg/tsdb/prometheus/models"
 	"github.com/grafana/grafana/pkg/util/converter"
-	jsoniter "github.com/json-iterator/go"
 )
 
 func (s *QueryData) parseResponse(ctx context.Context, q *models.Query, res *http.Response) (*backend.DataResponse, error) {
 	defer func() {
 		if err := res.Body.Close(); err != nil {
-			s.log.Error("Failed to close response body", "err", err)
+			s.log.FromContext(ctx).Error("Failed to close response body", "err", err)
 		}
 	}()
 

--- a/pkg/tsdb/prometheus/resource/resource.go
+++ b/pkg/tsdb/prometheus/resource/resource.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/tsdb/prometheus/client"
 	"github.com/grafana/grafana/pkg/tsdb/prometheus/utils"
@@ -70,7 +71,7 @@ func (r *Resource) Execute(ctx context.Context, req *backend.CallResourceRequest
 	delHopHeaders(req.Headers)
 	delStopHeaders(req.Headers)
 
-	r.log.Debug("Sending resource query", "URL", req.URL)
+	r.log.FromContext(ctx).Debug("Sending resource query", "URL", req.URL)
 	resp, err := r.promClient.QueryResource(ctx, req)
 	if err != nil {
 		return nil, fmt.Errorf("error querying resource: %v", err)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
PR https://github.com/grafana/grafana/pull/57476 added a new log context provider for alerting, which provides rule UID and orgID  (rule key) to log context. This PR adds support for loading logger context from the execution context to 4 data source plugins: Prometheus, Loki, Graphite and Influx. 

<details><summary> Influx logs </summary>

```
DEBUG[10-27|10:45:25] Received a query request                 logger=tsdb.influxdb rule_uid=9tiEPoH4z org_id=1 numQueries=1
DEBUG[10-27|10:45:25] Received a query                         logger=tsdb.influx_flux rule_uid=9tiEPoH4z org_id=1 query="{PluginContext:{OrgID:1 PluginID:influxdb User:<nil> AppInstanceSettings:<nil> DataSourceInstanceSetti
ngs:0xc0001ce900} Headers:map[FromAlert:true X-Cache-Skip:true X-Rule-Uid:9tiEPoH4z] Queries:[{RefID:A QueryType: MaxDataPoints:43200 Interval:1s TimeRange:{From:2022-10-27 10:35:20 -0400 EDT To:2022-10-27 10:45:20 -0400 EDT
} JSON:[123 34 104 105 100 101 34 58 102 97 108 115 101 44 34 105 110 116 101 114 118 97 108 77 115 34 58 49 48 48 48 44 34 109 97 120 68 97 116 97 80 111 105 110 116 115 34 58 52 51 50 48 48 44 34 113 117 101 114 121 34 58 34 98 117 99 107 101 116 115 40 41 34 44 34 114 101 102 73 100 34 58 34 65 34 125]}]}"
DEBUG[10-27|10:45:25] Executing Flux query                     logger=tsdb.influx_flux rule_uid=9tiEPoH4z org_id=1 flux=buckets()
DEBUG[10-27|10:45:25] Reading data frames from query result    logger=tsdb.influx_flux rule_uid=9tiEPoH4z org_id=1 maxPoints=432000 maxSeries=1000
DEBUG[10-27|10:45:25] expression datasource query (numberSet)  logger=expr rule_uid=9tiEPoH4z org_id=1 datasourceType=influxdb query=A
```
</details>

<details><summary> Prometheus logs </summary>

```
DEBUG[10-27|10:47:50] Sending query                            logger=tsdb.prometheus rule_uid=Gv8cETNVz org_id=1 start=2022-10-27T10:37:50-04:00 end=2022-10-27T10:47:50-04:00 step=1s query=up{}
```
</details>

<details><summary> Graphite logs </summary>

```
DEBUG[10-27|10:51:03] graphite                                 logger=tsdb.graphite rule_uid=OmLgsTH4z org_id=1 query="&{data:map[hide:false intervalMs:1000 maxDataPoints:43200 refId:A target:*.*]}"
DEBUG[10-27|10:51:03] Graphite request                         logger=tsdb.graphite rule_uid=OmLgsTH4z org_id=1 params="map[format:[json] from:[1666881660] maxDataPoints:[500] target:[*.*] until:[1666882260]]"
DEBUG[10-27|10:51:03] Graphite response                        logger=tsdb.graphite rule_uid=OmLgsTH4z org_id=1 target=statsd.numStats datapoints=60
DEBUG[10-27|10:51:03] expression datasource query (seriesSet)  logger=expr rule_uid=OmLgsTH4z org_id=1 datasourceType=graphite query=A
```
</details>

**Why do we need this feature?**
This feature will help trace the requests made by alerting engine. 

**Who is this feature for?**
Grafana developers and administrators. 

**Which issue(s) does this PR fix?**:

Related to https://github.com/grafana/grafana/pull/57476
<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
The remaining data sources will be updated in the following PRs
