### PR TITLE
Candlestick: Maintain candle width at different display resolutions

### DIFF
--- a/public/app/plugins/panel/candlestick/utils.ts
+++ b/public/app/plugins/panel/candlestick/utils.ts
@@ -91,7 +91,7 @@ export function drawMarkers(opts: RendererOpts) {
 
             if (delta < minDelta) {
               minDelta = delta;
-              colWidth = Math.abs(u.valToPos(dataX[i], 'x') - u.valToPos(dataX[prevIdx], 'x'));
+              colWidth = Math.abs(u.valToPos(dataX[i], 'x', true) - u.valToPos(dataX[prevIdx], 'x', true));
             }
           }
 


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/57321

makes sure that _all_ geometry math is done in physical (device) pixels, not logical (css) pixels.