### PR TITLE
Annotations: disable 'Add annotation' popover on touch-only devices

### DIFF
--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -1134,6 +1134,11 @@ export class DashboardModel implements TimeModel {
       return false;
     }
 
+    // Disable 'Add annotation' popover when the device cannot hover, and must "click" to trigger tooltip
+    if (window.matchMedia('(hover: none)').matches) {
+      return false;
+    }
+
     // If RBAC is enabled there are additional conditions to check.
     return !contextSrv.accessControlEnabled() || Boolean(this.meta.annotationsPermissions?.dashboard.canAdd);
   }


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/57565

(follow-up to https://github.com/grafana/grafana/pull/57481)

devices without the ability to "hover" cannot trigger a tooltip on viz panels except by "clicking", which also triggers the 'Add annotation' popover that occludes the tooltip with data values. this PR disables the popover on devices that cannot hover with the assumption that seeing the tooltip on touch devices is much more valuable than adding annotations.

browser support is good: https://caniuse.com/?search=media%20features

you can test using the "mobile" mode in Chrome devtools:

![image](https://user-images.githubusercontent.com/43234/198189541-5e12f22a-47bf-47e2-b88c-0890d73af10f.png)