### PR TITLE
Toolkit: Deprecate `plugin:bundle-managed` command and move its functionality to a bash script.

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "storybook:build": "yarn workspace @grafana/ui storybook:build",
     "themes:generate": "ts-node --transpile-only --project ./scripts/cli/tsconfig.json ./scripts/cli/generateSassVariableFiles.ts",
     "typecheck": "tsc --noEmit && yarn run packages:typecheck",
-    "plugins:build-bundled": "grafana-toolkit plugin:bundle-managed",
+    "plugins:build-bundled": "find plugins-bundled -name package.json -not -path '*/node_modules/*' -execdir yarn build \\;",
     "watch": "yarn start -d watch,start core:start --watchTheme",
     "ci:test-frontend": "yarn run test:ci",
     "postinstall": "husky install",

--- a/packages/grafana-toolkit/src/cli/index.ts
+++ b/packages/grafana-toolkit/src/cli/index.ts
@@ -223,6 +223,9 @@ export const run = (includeInternalScripts = false) => {
     .command('plugin:bundle-managed')
     .description('Builds managed plugins')
     .action(async (cmd) => {
+      chalk.yellow.bold(
+        `⚠️ This command is deprecated and will be removed in v10. No further support will be provided. ⚠️`
+      );
       await execTask(bundleManagedTask)({});
     });
 


### PR DESCRIPTION
**What is this feature?**

Deprecates the `plugin:bundle-managed` command from grafana-toolkit. This command is currently only used locally as our CI [already migrated this out](https://github.com/grafana/grafana/blob/main/pkg/build/plugins/build.go#L21) and bundled-plugins are not a widespread used feature.

**Why do we need this feature?**

We are reducing the scope of action of toolkit https://github.com/grafana/grafana/issues/55997 to its minimal 

**Which issue(s) does this PR fix?**:
Closes: https://github.com/grafana/grafana/issues/56015

**Special notes for your reviewer**:

