### PR TITLE
Fix: Unlock new button based on user permissions

### DIFF
--- a/public/app/features/search/components/ManageDashboardsNew.tsx
+++ b/public/app/features/search/components/ManageDashboardsNew.tsx
@@ -32,10 +32,12 @@ export const ManageDashboardsNew = React.memo(({ folder }: Props) => {
   const { isEditor } = contextSrv;
   const hasEditPermissionInFolders = folder ? canSave : contextSrv.hasEditPermissionInFolders;
   const canCreateFolders = contextSrv.hasAccess(AccessControlAction.FoldersCreate, isEditor);
-  const canCreateDashboards = contextSrv.hasAccess(
-    AccessControlAction.DashboardsCreate,
-    hasEditPermissionInFolders || !!canSave
-  );
+  const canCreateDashboardsFallback = hasEditPermissionInFolders || !!canSave;
+  const canCreateDashboards = folder?.id
+    ? contextSrv.hasAccessInMetadata(AccessControlAction.DashboardsCreate, folder, canCreateDashboardsFallback)
+    : contextSrv.hasAccess(AccessControlAction.DashboardsCreate, canCreateDashboardsFallback);
+  const viewActions = (folder === undefined && canCreateFolders) || canCreateDashboards;
+
   let [includePanels, setIncludePanels] = useLocalStorage<boolean>(SEARCH_PANELS_LOCAL_STORAGE_KEY, true);
   if (!config.featureToggles.panelTitleSearch) {
     includePanels = false;
@@ -60,7 +62,7 @@ export const ManageDashboardsNew = React.memo(({ folder }: Props) => {
             suffix={false ? <Spinner /> : null}
           />
         </div>
-        {canCreateFolders && canCreateDashboards && (
+        {viewActions && (
           <DashboardActions
             folderId={folderId}
             canCreateFolders={canCreateFolders}

--- a/public/app/features/search/loaders.ts
+++ b/public/app/features/search/loaders.ts
@@ -3,7 +3,7 @@ import { backendSrv } from 'app/core/services/backend_srv';
 import { buildNavModel } from '../folders/state/navModel';
 
 export const loadFolderPage = (uid: string) => {
-  return backendSrv.getFolderByUid(uid).then((folder) => {
+  return backendSrv.getFolderByUid(uid, { withAccessControl: true }).then((folder) => {
     const navModel = buildNavModel(folder);
     navModel.children![0].active = true;
 


### PR DESCRIPTION
**What is this feature?**

Fix some edge cases with permissions regarding the New button in the dashboards view:
![image](https://user-images.githubusercontent.com/5232696/198262722-5f00d933-6a79-4cef-b155-ae08038fc1ee.png)

Example:
* User A is a viewer in the main Org
* User A has Edit permission in a folder
* User A cannot see the `New` button, because User A has `{ "action": "dashboards:create", "scope": "folders:uid:zehf" }` but does not have `{ "action": "folders:create" }`

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

