### PR TITLE
Alerting: Add values to annotations

### DIFF
--- a/pkg/services/ngalert/state/historian/annotation.go
+++ b/pkg/services/ngalert/state/historian/annotation.go
@@ -96,14 +96,12 @@ func buildAnnotationTextAndData(rule *ngmodels.AlertRule, currentState *state.St
 		}
 		sort.Strings(keys)
 
-		values := map[string]float64{}
-		var strValues []string
+		var values []string
 		for _, k := range keys {
-			values[k] = currentState.Values[k]
-			strValues = append(strValues, fmt.Sprintf("%s=%f", k, currentState.Values[k]))
+			values = append(values, fmt.Sprintf("%s=%f", k, currentState.Values[k]))
 		}
-		jsonData.Set("values", simplejson.NewFromAny(values))
-		value = strings.Join(strValues, ", ")
+		jsonData.Set("values", simplejson.NewFromAny(currentState.Values))
+		value = strings.Join(values, ", ")
 	}
 
 	labels := removePrivateLabels(currentState.Labels)

--- a/pkg/services/ngalert/state/historian/annotation.go
+++ b/pkg/services/ngalert/state/historian/annotation.go
@@ -3,17 +3,17 @@ package historian
 import (
 	"context"
 	"fmt"
-	"github.com/grafana/grafana/pkg/components/simplejson"
-	"github.com/grafana/grafana/pkg/services/ngalert/eval"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/annotations"
 	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/services/ngalert/eval"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/state"
 )

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -243,7 +243,7 @@ func (st *Manager) setNextState(ctx context.Context, alertRule *ngModels.AlertRu
 
 	shouldUpdateAnnotation := oldState != currentState.State || oldReason != currentState.StateReason
 	if shouldUpdateAnnotation && st.historian != nil {
-		go st.historian.RecordState(ctx, alertRule, currentState.Labels, &result, result.EvaluatedAt,
+		go st.historian.RecordState(ctx, alertRule, currentState, result.EvaluatedAt,
 			InstanceStateAndReason{State: currentState.State, Reason: currentState.StateReason},
 			InstanceStateAndReason{State: oldState, Reason: oldReason})
 	}
@@ -389,7 +389,7 @@ func (st *Manager) staleResultsHandler(ctx context.Context, evaluatedAt time.Tim
 				s.EndsAt = evaluatedAt
 				s.Resolved = true
 				if st.historian != nil {
-					st.historian.RecordState(ctx, alertRule, s.Labels, &eval.Result{}, evaluatedAt,
+					st.historian.RecordState(ctx, alertRule, s, evaluatedAt,
 						InstanceStateAndReason{State: eval.Normal, Reason: s.StateReason},
 						previousState,
 					)

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -243,7 +243,9 @@ func (st *Manager) setNextState(ctx context.Context, alertRule *ngModels.AlertRu
 
 	shouldUpdateAnnotation := oldState != currentState.State || oldReason != currentState.StateReason
 	if shouldUpdateAnnotation && st.historian != nil {
-		go st.historian.RecordState(ctx, alertRule, currentState.Labels, result.EvaluatedAt, InstanceStateAndReason{State: currentState.State, Reason: currentState.StateReason}, InstanceStateAndReason{State: oldState, Reason: oldReason})
+		go st.historian.RecordState(ctx, alertRule, currentState.Labels, &result, result.EvaluatedAt,
+			InstanceStateAndReason{State: currentState.State, Reason: currentState.StateReason},
+			InstanceStateAndReason{State: oldState, Reason: oldReason})
 	}
 	return currentState
 }
@@ -387,7 +389,7 @@ func (st *Manager) staleResultsHandler(ctx context.Context, evaluatedAt time.Tim
 				s.EndsAt = evaluatedAt
 				s.Resolved = true
 				if st.historian != nil {
-					st.historian.RecordState(ctx, alertRule, s.Labels, evaluatedAt,
+					st.historian.RecordState(ctx, alertRule, s.Labels, &eval.Result{}, evaluatedAt,
 						InstanceStateAndReason{State: eval.Normal, Reason: s.StateReason},
 						previousState,
 					)

--- a/pkg/services/ngalert/state/manager_test.go
+++ b/pkg/services/ngalert/state/manager_test.go
@@ -49,15 +49,21 @@ func TestDashboardAnnotations(t *testing.T) {
 	})
 
 	st.Warm(ctx)
+	bValue := float64(42)
+	cValue := float64(1)
 	_ = st.ProcessEvalResults(ctx, evaluationTime, rule, eval.Results{{
 		Instance:    data.Labels{"instance_label": "testValue2"},
 		State:       eval.Alerting,
 		EvaluatedAt: evaluationTime,
+		Values: map[string]eval.NumberValueCapture{
+			"B": {Var: "B", Value: &bValue, Labels: data.Labels{"job": "prometheus"}},
+			"C": {Var: "C", Value: &cValue, Labels: data.Labels{"job": "prometheus"}},
+		},
 	}}, data.Labels{
 		"alertname": rule.Title,
 	})
 
-	expected := []string{rule.Title + " {alertname=" + rule.Title + ", instance_label=testValue2, test1=testValue1, test2=testValue2} - Alerting"}
+	expected := []string{rule.Title + " {alertname=" + rule.Title + ", instance_label=testValue2, test1=testValue1, test2=testValue2} - B=42.000000, C=1.000000"}
 	sort.Strings(expected)
 	require.Eventuallyf(t, func() bool {
 		var actual []string
@@ -1316,6 +1322,7 @@ func TestProcessEvalResults(t *testing.T) {
 					eval.Result{
 						Instance:           data.Labels{"instance_label": "test"},
 						State:              eval.Error,
+						Error:              errors.New("test error"),
 						EvaluatedAt:        evaluationTime.Add(10 * time.Second),
 						EvaluationDuration: evaluationDuration,
 					},
@@ -1337,6 +1344,7 @@ func TestProcessEvalResults(t *testing.T) {
 					Values:      make(map[string]float64),
 					State:       eval.Pending,
 					StateReason: eval.Error.String(),
+					Error:       errors.New("test error"),
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime,

--- a/pkg/services/ngalert/state/persist.go
+++ b/pkg/services/ngalert/state/persist.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"context"
+	"github.com/grafana/grafana/pkg/services/ngalert/eval"
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
@@ -24,5 +25,5 @@ type RuleReader interface {
 
 // Historian maintains an audit log of alert state history.
 type Historian interface {
-	RecordState(ctx context.Context, rule *models.AlertRule, labels data.Labels, evaluatedAt time.Time, currentData, previousData InstanceStateAndReason)
+	RecordState(ctx context.Context, rule *models.AlertRule, labels data.Labels, result *eval.Result, evaluatedAt time.Time, currentData, previousData InstanceStateAndReason)
 }

--- a/pkg/services/ngalert/state/persist.go
+++ b/pkg/services/ngalert/state/persist.go
@@ -2,10 +2,10 @@ package state
 
 import (
 	"context"
-	"github.com/grafana/grafana/pkg/services/ngalert/eval"
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/grafana/grafana/pkg/services/ngalert/eval"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 )
 

--- a/pkg/services/ngalert/state/persist.go
+++ b/pkg/services/ngalert/state/persist.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/grafana/grafana-plugin-sdk-go/data"
-	"github.com/grafana/grafana/pkg/services/ngalert/eval"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 )
 
@@ -25,5 +23,5 @@ type RuleReader interface {
 
 // Historian maintains an audit log of alert state history.
 type Historian interface {
-	RecordState(ctx context.Context, rule *models.AlertRule, labels data.Labels, result *eval.Result, evaluatedAt time.Time, currentData, previousData InstanceStateAndReason)
+	RecordState(ctx context.Context, rule *models.AlertRule, currentState *State, evaluatedAt time.Time, currentData, previousData InstanceStateAndReason)
 }

--- a/pkg/services/ngalert/state/testing.go
+++ b/pkg/services/ngalert/state/testing.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"context"
+	"github.com/grafana/grafana/pkg/services/ngalert/eval"
 	"sync"
 	"time"
 
@@ -50,5 +51,5 @@ func (f *FakeRuleReader) ListAlertRules(_ context.Context, q *models.ListAlertRu
 
 type FakeHistorian struct{}
 
-func (f *FakeHistorian) RecordState(ctx context.Context, rule *models.AlertRule, labels data.Labels, evaluatedAt time.Time, currentData, previousData InstanceStateAndReason) {
+func (f *FakeHistorian) RecordState(ctx context.Context, rule *models.AlertRule, labels data.Labels, result *eval.Result, evaluatedAt time.Time, currentData, previousData InstanceStateAndReason) {
 }

--- a/pkg/services/ngalert/state/testing.go
+++ b/pkg/services/ngalert/state/testing.go
@@ -2,11 +2,11 @@ package state
 
 import (
 	"context"
-	"github.com/grafana/grafana/pkg/services/ngalert/eval"
 	"sync"
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/grafana/grafana/pkg/services/ngalert/eval"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 )
 

--- a/pkg/services/ngalert/state/testing.go
+++ b/pkg/services/ngalert/state/testing.go
@@ -5,8 +5,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/grafana/grafana-plugin-sdk-go/data"
-	"github.com/grafana/grafana/pkg/services/ngalert/eval"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 )
 
@@ -51,5 +49,5 @@ func (f *FakeRuleReader) ListAlertRules(_ context.Context, q *models.ListAlertRu
 
 type FakeHistorian struct{}
 
-func (f *FakeHistorian) RecordState(ctx context.Context, rule *models.AlertRule, labels data.Labels, result *eval.Result, evaluatedAt time.Time, currentData, previousData InstanceStateAndReason) {
+func (f *FakeHistorian) RecordState(ctx context.Context, rule *models.AlertRule, currentState *State, evaluatedAt time.Time, currentData, previousData InstanceStateAndReason) {
 }


### PR DESCRIPTION
**What is this feature?**

Add the value of the metric when the annotation was created on alert status change.

![Captura de Pantalla 2022-10-27 a las 12 43 12](https://user-images.githubusercontent.com/2112640/198264494-855c38fc-f942-40dc-9524-466a4f204bfe.png)

**Why do we need this feature?**

It is important to know what the value of the metric was when the alert status changed.

**Who is this feature for?**

Anyone that has alerts associated with their dashboards.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/57024