### PR TITLE
Toolkit: Deprecate `plugin:update-circleci` command

### DIFF
--- a/packages/grafana-toolkit/src/cli/index.ts
+++ b/packages/grafana-toolkit/src/cli/index.ts
@@ -247,6 +247,9 @@ export const run = (includeInternalScripts = false) => {
     .command('plugin:update-circleci')
     .description('Update plugin')
     .action(async (cmd) => {
+      chalk.yellow.bold(
+        `⚠️ This command is deprecated and will be removed in v10. No further support will be provided. ⚠️`
+      );
       await execTask(pluginUpdateTask)({});
     });
 


### PR DESCRIPTION
**What is this feature?**

Deprecate the toolkit `plugin:update-circleci` command.

This legacy command was useful when grafana-toolkit scaffolded and updated plugins configurations to have a circleci configuration file. Grafana-toolkit currently doesn't generate circleci configurations, the existing one is not longer maintained and the existing plugins still using circleci should migrate to use github actions or create-plugin.

**Why do we need this feature?**

We are removing all grafana-toolkit plugin-related functionality. See https://github.com/grafana/grafana/issues/55997


**Which issue(s) does this PR fix?**:

Closes: https://github.com/grafana/grafana/issues/57677

**Special notes for your reviewer**:

