### PR TITLE
Navigation: Add `pluginId` to standalone plugin page NavLinks

### DIFF
--- a/packages/grafana-data/src/types/navModel.ts
+++ b/packages/grafana-data/src/types/navModel.ts
@@ -26,6 +26,8 @@ export interface NavLinkDTO {
   children?: NavLinkDTO[];
   highlightText?: string;
   emptyMessageId?: string;
+  // In case it is a (standalone) plugin page, the ID of the plugin which registered it.
+  pluginId?: string;
 }
 
 export interface NavModelItem extends NavLinkDTO {

--- a/packages/grafana-data/src/types/navModel.ts
+++ b/packages/grafana-data/src/types/navModel.ts
@@ -26,7 +26,7 @@ export interface NavLinkDTO {
   children?: NavLinkDTO[];
   highlightText?: string;
   emptyMessageId?: string;
-  // In case it is a (standalone) plugin page, the ID of the plugin which registered it.
+  // The ID of the plugin that registered the page (in case it was registered by a plugin, otherwise left empty)
   pluginId?: string;
 }
 

--- a/pkg/services/navtree/models.go
+++ b/pkg/services/navtree/models.go
@@ -67,6 +67,7 @@ type NavLink struct {
 	HighlightText    string     `json:"highlightText,omitempty"`
 	HighlightID      string     `json:"highlightId,omitempty"`
 	EmptyMessageId   string     `json:"emptyMessageId,omitempty"`
+	PluginId         string     `json:"pluginId,omitempty"` // (Optional) The ID of the plugin that registered nav link (e.g. as a standalone plugin page)
 }
 
 func (node *NavLink) Sort() {

--- a/pkg/services/navtree/models.go
+++ b/pkg/services/navtree/models.go
@@ -67,7 +67,7 @@ type NavLink struct {
 	HighlightText    string     `json:"highlightText,omitempty"`
 	HighlightID      string     `json:"highlightId,omitempty"`
 	EmptyMessageId   string     `json:"emptyMessageId,omitempty"`
-	PluginId         string     `json:"pluginId,omitempty"` // (Optional) The ID of the plugin that registered nav link (e.g. as a standalone plugin page)
+	PluginID         string     `json:"pluginId,omitempty"` // (Optional) The ID of the plugin that registered nav link (e.g. as a standalone plugin page)
 }
 
 func (node *NavLink) Sort() {

--- a/pkg/services/navtree/navtreeimpl/applinks.go
+++ b/pkg/services/navtree/navtreeimpl/applinks.go
@@ -126,7 +126,6 @@ func (s *ServiceImpl) processAppPlugin(plugin plugins.PluginDTO, c *models.ReqCo
 					if !isOverridingCorePage {
 						sectionForPage.Children = append(sectionForPage.Children, link)
 					}
-
 				}
 			} else {
 				appLink.Children = append(appLink.Children, link)

--- a/pkg/services/navtree/navtreeimpl/applinks.go
+++ b/pkg/services/navtree/navtreeimpl/applinks.go
@@ -72,7 +72,7 @@ func (s *ServiceImpl) processAppPlugin(plugin plugins.PluginDTO, c *models.ReqCo
 		Section:    navtree.NavSectionPlugin,
 		SortWeight: navtree.WeightPlugin,
 		IsSection:  true,
-		PluginId:   plugin.ID,
+		PluginID:   plugin.ID,
 	}
 
 	if topNavEnabled {
@@ -90,7 +90,7 @@ func (s *ServiceImpl) processAppPlugin(plugin plugins.PluginDTO, c *models.ReqCo
 			link := &navtree.NavLink{
 				Text:     include.Name,
 				Icon:     include.Icon,
-				PluginId: plugin.ID,
+				PluginID: plugin.ID,
 			}
 
 			if len(include.Path) > 0 {
@@ -115,7 +115,7 @@ func (s *ServiceImpl) processAppPlugin(plugin plugins.PluginDTO, c *models.ReqCo
 						if child.Url == link.Url {
 							child.Id = link.Id
 							child.SortWeight = link.SortWeight
-							child.PluginId = link.PluginId
+							child.PluginID = link.PluginID
 							child.Children = []*navtree.NavLink{}
 							isOverridingCorePage = true
 							break
@@ -138,7 +138,7 @@ func (s *ServiceImpl) processAppPlugin(plugin plugins.PluginDTO, c *models.ReqCo
 				link := &navtree.NavLink{
 					Url:      path.Join(s.cfg.AppSubURL, dboardURL),
 					Text:     include.Name,
-					PluginId: plugin.ID,
+					PluginID: plugin.ID,
 				}
 				appLink.Children = append(appLink.Children, link)
 			}

--- a/pkg/services/navtree/navtreeimpl/applinks_test.go
+++ b/pkg/services/navtree/navtreeimpl/applinks_test.go
@@ -202,14 +202,14 @@ func TestAddAppLinks(t *testing.T) {
 		require.Equal(t, "Connections", treeRoot.Children[0].Text)
 		require.Equal(t, "Connect Data", treeRoot.Children[0].Children[1].Text)
 		require.Equal(t, "connections-connect-data", treeRoot.Children[0].Children[1].Id)
-		require.Equal(t, "", treeRoot.Children[0].Children[1].PluginId)
+		require.Equal(t, "", treeRoot.Children[0].Children[1].PluginID)
 
 		err := service.addAppLinks(&treeRoot, reqCtx)
 		require.NoError(t, err)
 		require.Equal(t, "Connections", treeRoot.Children[0].Text)
 		require.Equal(t, "Connect Data", treeRoot.Children[0].Children[1].Text)
 		require.Equal(t, "standalone-plugin-page-/connections/connect-data", treeRoot.Children[0].Children[1].Id)
-		require.Equal(t, "test-app3", treeRoot.Children[0].Children[1].PluginId)
+		require.Equal(t, "test-app3", treeRoot.Children[0].Children[1].PluginID)
 	})
 }
 

--- a/pkg/services/navtree/navtreeimpl/applinks_test.go
+++ b/pkg/services/navtree/navtreeimpl/applinks_test.go
@@ -201,15 +201,15 @@ func TestAddAppLinks(t *testing.T) {
 		treeRoot.AddSection(service.buildDataConnectionsNavLink(reqCtx))
 		require.Equal(t, "Connections", treeRoot.Children[0].Text)
 		require.Equal(t, "Connect Data", treeRoot.Children[0].Children[1].Text)
-		require.Equal(t, "connections-connect-data", treeRoot.Children[0].Children[1].Id)	
-		require.Equal(t, "", treeRoot.Children[0].Children[1].PluginId)	
+		require.Equal(t, "connections-connect-data", treeRoot.Children[0].Children[1].Id)
+		require.Equal(t, "", treeRoot.Children[0].Children[1].PluginId)
 
 		err := service.addAppLinks(&treeRoot, reqCtx)
 		require.NoError(t, err)
 		require.Equal(t, "Connections", treeRoot.Children[0].Text)
-		require.Equal(t, "Connect Data", treeRoot.Children[0].Children[1].Text)	
-		require.Equal(t, "standalone-plugin-page-/connections/connect-data", treeRoot.Children[0].Children[1].Id)	
-		require.Equal(t, "test-app3", treeRoot.Children[0].Children[1].PluginId)	
+		require.Equal(t, "Connect Data", treeRoot.Children[0].Children[1].Text)
+		require.Equal(t, "standalone-plugin-page-/connections/connect-data", treeRoot.Children[0].Children[1].Id)
+		require.Equal(t, "test-app3", treeRoot.Children[0].Children[1].PluginId)
 	})
 }
 


### PR DESCRIPTION
**Related PRs**
- [Connections page: support standalone plugin pages](https://github.com/grafana/grafana/pull/57772)
- [Frontend Routing: always render standalone plugin pages using the `<AppRootPage>`](https://github.com/grafana/grafana/pull/57771)

### Why?
Standalone plugin pages can be used to extend a certain part of Grafana by registering a page served by a plugin under an existing section. In order to make it possible for the frontend to route standalone plugin pages using the `AppRootPage` we need to make sure that it also knows which plugin it needs to route them to.

### The usecase
While working on the Connections page we would like certain sub-pages to be served by the Cloud Integrations plugin. The necessary APIs for the functionality of these pages doesn't exist in OSS yet, however they would bring a lot of value in the Cloud.

### What changed?
- extended the `NavLinkDTO` with an optional `pluginId` field
- setting the `pluginId` field on every `NavLink` that is backed by a plugin
- making it possible to override core pages and URLs (e.g. `"/connections/connect-data"`)

