### PR TITLE
Service Account docs: Remove View role

### DIFF
--- a/docs/sources/administration/service-accounts/index.md
+++ b/docs/sources/administration/service-accounts/index.md
@@ -143,7 +143,7 @@ You can assign on of the following permissions to a specific user or a team:
 1. Click the service account for which you want to update team permissions a role.
 1. In the **Permissions** section at the bottom, click **Add permission**.
 1. Choose **Team** in the dropdown and select your desired team.
-1. Choose **View**, **Edit** or **Admin** role in the dropdown and click **Save**.
+1. Choose **Edit** or **Admin** role in the dropdown and click **Save**.
 
 ### To update user permissions for a service account
 
@@ -152,4 +152,4 @@ You can assign on of the following permissions to a specific user or a team:
 1. Click the service account for which you want to update team permissions a role.
 1. In the **Permissions** section at the bottom, click **Add permission**.
 1. Choose **User** in the dropdown and select your desired user.
-1. Choose **View**, **Edit** or **Admin** role in the dropdown and click **Save**.
+1. Choose **Edit** or **Admin** role in the dropdown and click **Save**.


### PR DESCRIPTION
**User and team permissions for a service account** describes available roles as being Admin and Edit only, but the step-by-step instructions for updating user and team permissions show View as an option. It's currently not possible to assign View as a role here.

Updating steps to remove View as a role option.

Screenshots showing only Admin/Edit options available in Grafana UI:
<img width="733" alt="Screen Shot 2022-10-27 at 10 42 35 AM" src="https://user-images.githubusercontent.com/86264026/198349677-ef68fcb3-cfb1-45e7-84de-ba988f43aaab.png">


<img width="763" alt="Screen Shot 2022-10-27 at 10 43 21 AM" src="https://user-images.githubusercontent.com/86264026/198349823-28a6a65b-5e93-416d-80a0-7e0bfcc69cd6.png">

