### PR TITLE
Fix: correctly close trace span in Prometheus and Loki data sources

### DIFF
--- a/pkg/tsdb/loki/loki.go
+++ b/pkg/tsdb/loki/loki.go
@@ -184,7 +184,7 @@ func queryData(ctx context.Context, req *backend.QueryDataRequest, dsInfo *datas
 	}
 
 	for _, query := range queries {
-		_, span := tracer.Start(ctx, "alerting.loki")
+		_, span := tracer.Start(ctx, "datasource.loki")
 		span.SetAttributes("expr", query.Expr, attribute.Key("expr").String(query.Expr))
 		span.SetAttributes("start_unixnano", query.Start, attribute.Key("start_unixnano").Int64(query.Start.UnixNano()))
 		span.SetAttributes("stop_unixnano", query.End, attribute.Key("stop_unixnano").Int64(query.End.UnixNano()))

--- a/pkg/tsdb/loki/loki.go
+++ b/pkg/tsdb/loki/loki.go
@@ -188,13 +188,13 @@ func queryData(ctx context.Context, req *backend.QueryDataRequest, dsInfo *datas
 		span.SetAttributes("expr", query.Expr, attribute.Key("expr").String(query.Expr))
 		span.SetAttributes("start_unixnano", query.Start, attribute.Key("start_unixnano").Int64(query.Start.UnixNano()))
 		span.SetAttributes("stop_unixnano", query.End, attribute.Key("stop_unixnano").Int64(query.End.UnixNano()))
-		defer span.End()
 
 		logger := logger.FromContext(ctx) // get logger with trace-id and other contextual info
 		logger.Debug("Sending query", "start", query.Start, "end", query.End, "step", query.Step, "query", query.Expr)
 
 		frames, err := runQuery(ctx, api, query)
 
+		span.End()
 		queryRes := backend.DataResponse{}
 
 		if err != nil {

--- a/pkg/tsdb/prometheus/buffered/time_series_query.go
+++ b/pkg/tsdb/prometheus/buffered/time_series_query.go
@@ -122,72 +122,77 @@ func (b *Buffered) runQueries(ctx context.Context, queries []*PrometheusQuery) (
 		Responses: backend.Responses{},
 	}
 	for _, query := range queries {
-		ctx, endSpan := utils.StartTrace(ctx, b.tracer, "datasource.prometheus", []utils.Attribute{
-			{Key: "expr", Value: query.Expr, Kv: attribute.Key("expr").String(query.Expr)},
-			{Key: "start_unixnano", Value: query.Start, Kv: attribute.Key("start_unixnano").Int64(query.Start.UnixNano())},
-			{Key: "stop_unixnano", Value: query.End, Kv: attribute.Key("stop_unixnano").Int64(query.End.UnixNano())},
-		})
-		defer endSpan()
-
-		logger := b.log.FromContext(ctx) // read trace-id and other info from the context
-		logger.Debug("Sending query", "start", query.Start, "end", query.End, "step", query.Step, "query", query.Expr)
-
-		response := make(map[TimeSeriesQueryType]interface{})
-
-		timeRange := apiv1.Range{
-			Step: query.Step,
-			// Align query range to step. It rounds start and end down to a multiple of step.
-			Start: alignTimeRange(query.Start, query.Step, query.UtcOffsetSec),
-			End:   alignTimeRange(query.End, query.Step, query.UtcOffsetSec),
-		}
-
-		if query.RangeQuery {
-			rangeResponse, _, err := b.client.QueryRange(ctx, query.Expr, timeRange)
-			if err != nil {
-				logger.Error("Range query failed", "query", query.Expr, "err", err)
-				result.Responses[query.RefId] = backend.DataResponse{Error: err}
-				continue
-			}
-			response[RangeQueryType] = rangeResponse
-		}
-
-		if query.InstantQuery {
-			instantResponse, _, err := b.client.Query(ctx, query.Expr, query.End)
-			if err != nil {
-				logger.Error("Instant query failed", "query", query.Expr, "err", err)
-				result.Responses[query.RefId] = backend.DataResponse{Error: err}
-				continue
-			}
-			response[InstantQueryType] = instantResponse
-		}
-
-		// This is a special case
-		// If exemplar query returns error, we want to only log it and continue with other results processing
-		if query.ExemplarQuery {
-			exemplarResponse, err := b.client.QueryExemplars(ctx, query.Expr, timeRange.Start, timeRange.End)
-			if err != nil {
-				logger.Error("Exemplar query failed", "query", query.Expr, "err", err)
-			} else {
-				response[ExemplarQueryType] = exemplarResponse
-			}
-		}
-
-		frames, err := parseTimeSeriesResponse(response, query)
+		response, err := b.runQuery(ctx, query)
 		if err != nil {
 			return &result, err
 		}
+		result.Responses[query.RefId] = response
+	}
+	return &result, nil
+}
 
-		// The ExecutedQueryString can be viewed in QueryInspector in UI
-		for _, frame := range frames {
-			frame.Meta.ExecutedQueryString = "Expr: " + query.Expr + "\n" + "Step: " + query.Step.String()
+func (b *Buffered) runQuery(ctx context.Context, query *PrometheusQuery) (backend.DataResponse, error) {
+	ctx, endSpan := utils.StartTrace(ctx, b.tracer, "datasource.prometheus", []utils.Attribute{
+		{Key: "expr", Value: query.Expr, Kv: attribute.Key("expr").String(query.Expr)},
+		{Key: "start_unixnano", Value: query.Start, Kv: attribute.Key("start_unixnano").Int64(query.Start.UnixNano())},
+		{Key: "stop_unixnano", Value: query.End, Kv: attribute.Key("stop_unixnano").Int64(query.End.UnixNano())},
+	})
+	defer endSpan()
+
+	logger := b.log.FromContext(ctx) // read trace-id and other info from the context
+	logger.Debug("Sending query", "start", query.Start, "end", query.End, "step", query.Step, "query", query.Expr)
+
+	response := make(map[TimeSeriesQueryType]interface{})
+
+	timeRange := apiv1.Range{
+		Step: query.Step,
+		// Align query range to step. It rounds start and end down to a multiple of step.
+		Start: alignTimeRange(query.Start, query.Step, query.UtcOffsetSec),
+		End:   alignTimeRange(query.End, query.Step, query.UtcOffsetSec),
+	}
+
+	if query.RangeQuery {
+		rangeResponse, _, err := b.client.QueryRange(ctx, query.Expr, timeRange)
+		if err != nil {
+			logger.Error("Range query failed", "query", query.Expr, "err", err)
+			return backend.DataResponse{Error: err}, nil
 		}
+		response[RangeQueryType] = rangeResponse
+	}
 
-		result.Responses[query.RefId] = backend.DataResponse{
-			Frames: frames,
+	if query.InstantQuery {
+		instantResponse, _, err := b.client.Query(ctx, query.Expr, query.End)
+		if err != nil {
+			logger.Error("Instant query failed", "query", query.Expr, "err", err)
+			return backend.DataResponse{Error: err}, nil
+		}
+		response[InstantQueryType] = instantResponse
+	}
+
+	// This is a special case
+	// If exemplar query returns error, we want to only log it and continue with other results processing
+	if query.ExemplarQuery {
+		exemplarResponse, err := b.client.QueryExemplars(ctx, query.Expr, timeRange.Start, timeRange.End)
+		if err != nil {
+			logger.Error("Exemplar query failed", "query", query.Expr, "err", err)
+		} else {
+			response[ExemplarQueryType] = exemplarResponse
 		}
 	}
 
-	return &result, nil
+	frames, err := parseTimeSeriesResponse(response, query)
+	if err != nil {
+		return backend.DataResponse{}, err
+	}
+
+	// The ExecutedQueryString can be viewed in QueryInspector in UI
+	for _, frame := range frames {
+		frame.Meta.ExecutedQueryString = "Expr: " + query.Expr + "\n" + "Step: " + query.Step.String()
+	}
+
+	return backend.DataResponse{
+		Frames: frames,
+	}, nil
 }
 
 func formatLegend(metric model.Metric, query *PrometheusQuery) string {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Currently, when there are many queries in a single request to a data source the trancing does not work correctly. The duration of the span of a query execution includes the duration of all subsequent executions. This happens because the method `span.End` is called in `defer` within the loop.

https://github.com/grafana/grafana/blob/9f77bd4728ba86a897ff837f1ae94bf19517004e/pkg/tsdb/loki/loki.go#L186-L191

and 

https://github.com/grafana/grafana/blob/9f77bd4728ba86a897ff837f1ae94bf19517004e/pkg/tsdb/prometheus/buffered/time_series_query.go#L124-L130

This PR 
1. fixes these sections to properly close the tracing span.
2. Renames a span that is created by Loki data source from "alerting.loki" to "datasource.loki"