### PR TITLE
public dashboards: rename route paths

### DIFF
--- a/e2e/dashboards-suite/dashboard-public-create.spec.ts
+++ b/e2e/dashboards-suite/dashboard-public-create.spec.ts
@@ -16,7 +16,7 @@ e2e.scenario({
     e2e.pages.ShareDashboardModal.shareButton().click();
 
     // Select public dashboards tab
-    e2e().intercept('GET', '/api/dashboards/uid/ZqZnVvFZz/public-config').as('query-public-config');
+    e2e().intercept('GET', '/api/dashboards/uid/ZqZnVvFZz/public-dashboard').as('query-public-config');
     e2e.pages.ShareDashboardModal.PublicDashboard.Tab().click();
     e2e().wait('@query-public-config');
 
@@ -68,7 +68,7 @@ e2e.scenario({
     e2e.pages.ShareDashboardModal.shareButton().click();
 
     // Select public dashboards tab
-    e2e().intercept('GET', '/api/dashboards/uid/ZqZnVvFZz/public-config').as('query-public-config');
+    e2e().intercept('GET', '/api/dashboards/uid/ZqZnVvFZz/public-dashboard').as('query-public-config');
     e2e.pages.ShareDashboardModal.PublicDashboard.Tab().click();
     e2e().wait('@query-public-config');
 
@@ -104,7 +104,7 @@ e2e.scenario({
     e2e.pages.ShareDashboardModal.shareButton().click();
 
     // Select public dashboards tab
-    e2e().intercept('GET', '/api/dashboards/uid/ZqZnVvFZz/public-config').as('query-public-config');
+    e2e().intercept('GET', '/api/dashboards/uid/ZqZnVvFZz/public-dashboard').as('query-public-config');
     e2e.pages.ShareDashboardModal.PublicDashboard.Tab().click();
     e2e().wait('@query-public-config');
 
@@ -125,7 +125,7 @@ e2e.scenario({
     e2e.pages.ShareDashboardModal.PublicDashboard.EnableSwitch().should('be.enabled').click({ force: true });
 
     // Save configuration
-    e2e().intercept('POST', '/api/dashboards/uid/ZqZnVvFZz/public-config').as('save');
+    e2e().intercept('POST', '/api/dashboards/uid/ZqZnVvFZz/public-dashboard').as('save');
     e2e.pages.ShareDashboardModal.PublicDashboard.SaveConfigButton().click();
     e2e().wait('@save');
 

--- a/e2e/dashboards-suite/dashboard-public-create.spec.ts
+++ b/e2e/dashboards-suite/dashboard-public-create.spec.ts
@@ -16,9 +16,9 @@ e2e.scenario({
     e2e.pages.ShareDashboardModal.shareButton().click();
 
     // Select public dashboards tab
-    e2e().intercept('GET', '/api/dashboards/uid/ZqZnVvFZz/public-dashboard').as('query-public-config');
+    e2e().intercept('GET', '/api/dashboards/uid/ZqZnVvFZz/public-dashboards').as('query-public-dashboard');
     e2e.pages.ShareDashboardModal.PublicDashboard.Tab().click();
-    e2e().wait('@query-public-config');
+    e2e().wait('@query-public-dashboard');
 
     // Saving button should be disabled
     e2e.pages.ShareDashboardModal.PublicDashboard.SaveConfigButton().should('be.disabled');
@@ -34,17 +34,17 @@ e2e.scenario({
     e2e.pages.ShareDashboardModal.PublicDashboard.EnableSwitch().should('be.enabled').click({ force: true });
     e2e.pages.ShareDashboardModal.PublicDashboard.SaveConfigButton().should('be.enabled');
 
-    // Save configuration
-    e2e().intercept('POST', '/api/dashboards/uid/ZqZnVvFZz/public-config').as('save');
+    // Save public dashboard
+    e2e().intercept('POST', '/api/dashboards/uid/ZqZnVvFZz/public-dashboards').as('save');
     e2e.pages.ShareDashboardModal.PublicDashboard.SaveConfigButton().click();
     e2e().wait('@save');
 
-    // Checkboxes should be disabled after saving configuration
+    // Checkboxes should be disabled after saving public dashboard
     e2e.pages.ShareDashboardModal.PublicDashboard.WillBePublicCheckbox().should('be.disabled');
     e2e.pages.ShareDashboardModal.PublicDashboard.LimitedDSCheckbox().should('be.disabled');
     e2e.pages.ShareDashboardModal.PublicDashboard.CostIncreaseCheckbox().should('be.disabled');
 
-    // Save config button should still be enabled
+    // Save public dashboard button should still be enabled
     e2e.pages.ShareDashboardModal.PublicDashboard.SaveConfigButton().should('be.enabled');
   },
 });
@@ -68,9 +68,9 @@ e2e.scenario({
     e2e.pages.ShareDashboardModal.shareButton().click();
 
     // Select public dashboards tab
-    e2e().intercept('GET', '/api/dashboards/uid/ZqZnVvFZz/public-dashboard').as('query-public-config');
+    e2e().intercept('GET', '/api/dashboards/uid/ZqZnVvFZz/public-dashboards').as('query-public-dashboard');
     e2e.pages.ShareDashboardModal.PublicDashboard.Tab().click();
-    e2e().wait('@query-public-config');
+    e2e().wait('@query-public-dashboard');
 
     e2e.pages.ShareDashboardModal.PublicDashboard.SaveConfigButton().should('be.enabled');
 
@@ -104,9 +104,9 @@ e2e.scenario({
     e2e.pages.ShareDashboardModal.shareButton().click();
 
     // Select public dashboards tab
-    e2e().intercept('GET', '/api/dashboards/uid/ZqZnVvFZz/public-dashboard').as('query-public-config');
+    e2e().intercept('GET', '/api/dashboards/uid/ZqZnVvFZz/public-dashboards').as('query-public-dashboard');
     e2e.pages.ShareDashboardModal.PublicDashboard.Tab().click();
-    e2e().wait('@query-public-config');
+    e2e().wait('@query-public-dashboard');
 
     // All checkboxes should be disabled
     e2e.pages.ShareDashboardModal.PublicDashboard.WillBePublicCheckbox().should('be.disabled');
@@ -124,8 +124,8 @@ e2e.scenario({
     // Switch off enabling toggle
     e2e.pages.ShareDashboardModal.PublicDashboard.EnableSwitch().should('be.enabled').click({ force: true });
 
-    // Save configuration
-    e2e().intercept('POST', '/api/dashboards/uid/ZqZnVvFZz/public-dashboard').as('save');
+    // Save public dashboard
+    e2e().intercept('POST', '/api/dashboards/uid/ZqZnVvFZz/public-dashboards').as('save');
     e2e.pages.ShareDashboardModal.PublicDashboard.SaveConfigButton().click();
     e2e().wait('@save');
 

--- a/e2e/dashboards-suite/dashboard-public-templating.spec.ts
+++ b/e2e/dashboards-suite/dashboard-public-templating.spec.ts
@@ -14,7 +14,7 @@ e2e.scenario({
     e2e.pages.ShareDashboardModal.shareButton().click();
 
     // Select public dashboards tab
-    e2e().intercept('GET', '/api/dashboards/uid/HYaGDGIMk/public-dashboard').as('query-public-config');
+    e2e().intercept('GET', '/api/dashboards/uid/HYaGDGIMk/public-dashboards').as('query-public-config');
     e2e.pages.ShareDashboardModal.PublicDashboard.Tab().click();
     e2e().wait('@query-public-config');
 

--- a/e2e/dashboards-suite/dashboard-public-templating.spec.ts
+++ b/e2e/dashboards-suite/dashboard-public-templating.spec.ts
@@ -14,7 +14,7 @@ e2e.scenario({
     e2e.pages.ShareDashboardModal.shareButton().click();
 
     // Select public dashboards tab
-    e2e().intercept('GET', '/api/dashboards/uid/HYaGDGIMk/public-config').as('query-public-config');
+    e2e().intercept('GET', '/api/dashboards/uid/HYaGDGIMk/public-dashboard').as('query-public-config');
     e2e.pages.ShareDashboardModal.PublicDashboard.Tab().click();
     e2e().wait('@query-public-config');
 

--- a/pkg/services/publicdashboards/api/api.go
+++ b/pkg/services/publicdashboards/api/api.go
@@ -67,7 +67,7 @@ func (api *Api) RegisterAPIEndpoints() {
 
 	// Auth endpoints
 	auth := accesscontrol.Middleware(api.AccessControl)
-	uidScope := dashboards.ScopeDashboardsProvider.GetResourceScopeUID(accesscontrol.Parameter(":uid"))
+	uidScope := dashboards.ScopeDashboardsProvider.GetResourceScopeUID(accesscontrol.Parameter(":dashboardUid"))
 
 	// List public dashboards for org
 	api.RouteRegister.Get("/api/dashboards/public-dashboards", middleware.ReqSignedIn, routing.Wrap(api.ListPublicDashboards))

--- a/pkg/services/publicdashboards/api/api.go
+++ b/pkg/services/publicdashboards/api/api.go
@@ -55,7 +55,6 @@ func ProvideApi(
 
 // RegisterAPIEndpoints Registers Endpoints on Grafana Router
 func (api *Api) RegisterAPIEndpoints() {
-
 	// Public endpoints
 	// Anonymous access to public dashboard route is configured in pkg/api/api.go
 	// because it is deeply dependent on the HTTPServer.Index() method and would result in a

--- a/pkg/services/publicdashboards/api/api.go
+++ b/pkg/services/publicdashboards/api/api.go
@@ -73,12 +73,12 @@ func (api *Api) RegisterAPIEndpoints() {
 	api.RouteRegister.Get("/api/dashboards/public-dashboards", middleware.ReqSignedIn, routing.Wrap(api.ListPublicDashboards))
 
 	// Get public dashboard
-	api.RouteRegister.Get("/api/dashboards/uid/:dashboardUid/public-dashboard",
+	api.RouteRegister.Get("/api/dashboards/uid/:dashboardUid/public-dashboards",
 		auth(middleware.ReqSignedIn, accesscontrol.EvalPermission(dashboards.ActionDashboardsRead, uidScope)),
 		routing.Wrap(api.GetPublicDashboardConfig))
 
 	// Create/Update Public Dashboard
-	api.RouteRegister.Post("/api/dashboards/uid/:dashboardUid/public-dashboard",
+	api.RouteRegister.Post("/api/dashboards/uid/:dashboardUid/public-dashboards",
 		auth(middleware.ReqOrgAdmin, accesscontrol.EvalPermission(dashboards.ActionDashboardsPublicWrite, uidScope)),
 		routing.Wrap(api.SavePublicDashboardConfig))
 }

--- a/pkg/services/publicdashboards/api/api.go
+++ b/pkg/services/publicdashboards/api/api.go
@@ -55,27 +55,30 @@ func ProvideApi(
 
 // RegisterAPIEndpoints Registers Endpoints on Grafana Router
 func (api *Api) RegisterAPIEndpoints() {
-	auth := accesscontrol.Middleware(api.AccessControl)
 
+	// Public endpoints
 	// Anonymous access to public dashboard route is configured in pkg/api/api.go
 	// because it is deeply dependent on the HTTPServer.Index() method and would result in a
 	// circular dependency
 
-	// public endpoints
 	api.RouteRegister.Get("/api/public/dashboards/:accessToken", routing.Wrap(api.GetPublicDashboard))
 	api.RouteRegister.Post("/api/public/dashboards/:accessToken/panels/:panelId/query", routing.Wrap(api.QueryPublicDashboard))
 	api.RouteRegister.Get("/api/public/dashboards/:accessToken/annotations", routing.Wrap(api.GetAnnotations))
 
-	// List Public Dashboards
-	api.RouteRegister.Get("/api/dashboards/public", middleware.ReqSignedIn, routing.Wrap(api.ListPublicDashboards))
-
-	// Create/Update Public Dashboard
+	// Auth endpoints
+	auth := accesscontrol.Middleware(api.AccessControl)
 	uidScope := dashboards.ScopeDashboardsProvider.GetResourceScopeUID(accesscontrol.Parameter(":uid"))
-	api.RouteRegister.Get("/api/dashboards/uid/:uid/public-config",
+
+	// List public dashboards for org
+	api.RouteRegister.Get("/api/dashboards/public-dashboards", middleware.ReqSignedIn, routing.Wrap(api.ListPublicDashboards))
+
+	// Get public dashboard
+	api.RouteRegister.Get("/api/dashboards/uid/:dashboardUid/public-dashboard",
 		auth(middleware.ReqSignedIn, accesscontrol.EvalPermission(dashboards.ActionDashboardsRead, uidScope)),
 		routing.Wrap(api.GetPublicDashboardConfig))
 
-	api.RouteRegister.Post("/api/dashboards/uid/:uid/public-config",
+	// Create/Update Public Dashboard
+	api.RouteRegister.Post("/api/dashboards/uid/:dashboardUid/public-dashboard",
 		auth(middleware.ReqOrgAdmin, accesscontrol.EvalPermission(dashboards.ActionDashboardsPublicWrite, uidScope)),
 		routing.Wrap(api.SavePublicDashboardConfig))
 }
@@ -132,7 +135,7 @@ func (api *Api) ListPublicDashboards(c *models.ReqContext) response.Response {
 // GetPublicDashboardConfig Gets public dashboard configuration for dashboard
 // GET /api/dashboards/uid/:uid/public-config
 func (api *Api) GetPublicDashboardConfig(c *models.ReqContext) response.Response {
-	pdc, err := api.PublicDashboardService.FindByDashboardUid(c.Req.Context(), c.OrgID, web.Params(c.Req)[":uid"])
+	pdc, err := api.PublicDashboardService.FindByDashboardUid(c.Req.Context(), c.OrgID, web.Params(c.Req)[":dashboardUid"])
 	if err != nil {
 		return api.handleError(c.Req.Context(), http.StatusInternalServerError, "GetPublicDashboardConfig: failed to get public dashboard config", err)
 	}
@@ -143,7 +146,7 @@ func (api *Api) GetPublicDashboardConfig(c *models.ReqContext) response.Response
 // POST /api/dashboards/uid/:uid/public-config
 func (api *Api) SavePublicDashboardConfig(c *models.ReqContext) response.Response {
 	// exit if we don't have a valid dashboardUid
-	dashboardUid := web.Params(c.Req)[":uid"]
+	dashboardUid := web.Params(c.Req)[":dashboardUid"]
 	if dashboardUid == "" || !util.IsValidShortUID(dashboardUid) {
 		api.handleError(c.Req.Context(), http.StatusBadRequest, "SavePublicDashboardConfig: no dashboardUid", dashboards.ErrDashboardIdentifierNotSet)
 	}

--- a/pkg/services/publicdashboards/api/api_test.go
+++ b/pkg/services/publicdashboards/api/api_test.go
@@ -139,17 +139,17 @@ func TestAPIFeatureFlag(t *testing.T) {
 		{
 			Name:   "API: List Dashboards",
 			Method: http.MethodGet,
-			Path:   "/api/dashboards/public",
+			Path:   "/api/dashboards/public-dashboards",
 		},
 		{
 			Name:   "API: Get Public Dashboard Config",
 			Method: http.MethodPost,
-			Path:   "/api/dashboards/uid/abc123/public-config",
+			Path:   "/api/dashboards/uid/abc123/public-dashboards",
 		},
 		{
-			Name:   "API: Upate Public Dashboard",
+			Name:   "API: Save Public Dashboard",
 			Method: http.MethodPost,
-			Path:   "/api/dashboards/uid/abc123/public-config",
+			Path:   "/api/dashboards/uid/abc123/public-dashboards",
 		},
 	}
 
@@ -217,7 +217,7 @@ func TestAPIListPublicDashboard(t *testing.T) {
 			features := featuremgmt.WithFeatures(featuremgmt.FlagPublicDashboards)
 			testServer := setupTestServer(t, cfg, features, service, nil, test.User)
 
-			response := callAPI(testServer, http.MethodGet, "/api/dashboards/public", nil, t)
+			response := callAPI(testServer, http.MethodGet, "/api/dashboards/public-dashboards", nil, t)
 			assert.Equal(t, test.ExpectedHttpResponse, response.Code)
 
 			if test.ExpectedHttpResponse == http.StatusOK {
@@ -415,7 +415,7 @@ func TestAPIGetPublicDashboardConfig(t *testing.T) {
 			response := callAPI(
 				testServer,
 				http.MethodGet,
-				"/api/dashboards/uid/1/public-config",
+				"/api/dashboards/uid/1/public-dashboard",
 				nil,
 				t,
 			)
@@ -526,7 +526,7 @@ func TestApiSavePublicDashboardConfig(t *testing.T) {
 			response := callAPI(
 				testServer,
 				http.MethodPost,
-				"/api/dashboards/uid/1/public-config",
+				"/api/dashboards/uid/1/public-dashboard",
 				strings.NewReader(`{ "isPublic": true }`),
 				t,
 			)

--- a/pkg/services/publicdashboards/api/api_test.go
+++ b/pkg/services/publicdashboards/api/api_test.go
@@ -415,7 +415,7 @@ func TestAPIGetPublicDashboardConfig(t *testing.T) {
 			response := callAPI(
 				testServer,
 				http.MethodGet,
-				"/api/dashboards/uid/1/public-dashboard",
+				"/api/dashboards/uid/1/public-dashboards",
 				nil,
 				t,
 			)
@@ -526,7 +526,7 @@ func TestApiSavePublicDashboardConfig(t *testing.T) {
 			response := callAPI(
 				testServer,
 				http.MethodPost,
-				"/api/dashboards/uid/1/public-dashboard",
+				"/api/dashboards/uid/1/public-dashboards",
 				strings.NewReader(`{ "isPublic": true }`),
 				t,
 			)

--- a/public/app/features/dashboard/api/publicDashboardApi.ts
+++ b/public/app/features/dashboard/api/publicDashboardApi.ts
@@ -39,7 +39,7 @@ export const publicDashboardApi = createApi({
   endpoints: (builder) => ({
     getConfig: builder.query<PublicDashboard, string>({
       query: (dashboardUid) => ({
-        url: `/uid/${dashboardUid}/public-dashboard`,
+        url: `/uid/${dashboardUid}/public-dashboards`,
         manageError: getConfigError,
         showErrorAlert: false,
       }),
@@ -56,7 +56,7 @@ export const publicDashboardApi = createApi({
     }),
     saveConfig: builder.mutation<PublicDashboard, { dashboard: DashboardModel; payload: PublicDashboard }>({
       query: (params) => ({
-        url: `/uid/${params.dashboard.uid}/public-dashboard`,
+        url: `/uid/${params.dashboard.uid}/public-dashboards`,
         method: 'POST',
         data: params.payload,
       }),

--- a/public/app/features/dashboard/api/publicDashboardApi.ts
+++ b/public/app/features/dashboard/api/publicDashboardApi.ts
@@ -39,7 +39,7 @@ export const publicDashboardApi = createApi({
   endpoints: (builder) => ({
     getConfig: builder.query<PublicDashboard, string>({
       query: (dashboardUid) => ({
-        url: `/uid/${dashboardUid}/public-config`,
+        url: `/uid/${dashboardUid}/public-dashboard`,
         manageError: getConfigError,
         showErrorAlert: false,
       }),
@@ -56,7 +56,7 @@ export const publicDashboardApi = createApi({
     }),
     saveConfig: builder.mutation<PublicDashboard, { dashboard: DashboardModel; payload: PublicDashboard }>({
       query: (params) => ({
-        url: `/uid/${params.dashboard.uid}/public-config`,
+        url: `/uid/${params.dashboard.uid}/public-dashboard`,
         method: 'POST',
         data: params.payload,
       }),

--- a/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/SharePublicDashboard.test.tsx
+++ b/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/SharePublicDashboard.test.tsx
@@ -18,7 +18,7 @@ import { configureStore } from 'app/store/configureStore';
 import { ShareModal } from '../ShareModal';
 
 const server = setupServer(
-  rest.get('/api/dashboards/uid/:uId/public-config', (_, res, ctx) => {
+  rest.get('/api/dashboards/uid/:dashboardUid/public-dashboards', (_, res, ctx) => {
     return res(
       ctx.status(200),
       ctx.json({
@@ -159,7 +159,7 @@ describe('SharePublic', () => {
   });
   it('when fetch errors happen, then all inputs remain disabled', async () => {
     server.use(
-      rest.get('/api/dashboards/uid/:uId/public-config', (req, res, ctx) => {
+      rest.get('/api/dashboards/uid/:dashboardUid/public-dashboards', (req, res, ctx) => {
         return res(ctx.status(500));
       })
     );
@@ -220,14 +220,14 @@ describe('SharePublic - New config setup', () => {
 describe('SharePublic - Already persisted', () => {
   beforeEach(() => {
     server.use(
-      rest.get('/api/dashboards/uid/:uId/public-config', (req, res, ctx) => {
+      rest.get('/api/dashboards/uid/:dashboardUid/public-dashboards', (req, res, ctx) => {
         return res(
           ctx.status(200),
           ctx.json({
             isEnabled: true,
             annotationsEnabled: true,
             uid: 'a-uid',
-            dashboardUid: req.params.uId,
+            dashboardUid: req.params.dashboardUid,
             accessToken: 'an-access-token',
           })
         );
@@ -266,14 +266,14 @@ describe('SharePublic - Already persisted', () => {
   });
   it('when pubdash is disabled in the db, then link url is not available and annotations toggle is disabled', async () => {
     server.use(
-      rest.get('/api/dashboards/uid/:uId/public-config', (req, res, ctx) => {
+      rest.get('/api/dashboards/uid/:dashboardUid/public-dashboards', (req, res, ctx) => {
         return res(
           ctx.status(200),
           ctx.json({
             isEnabled: false,
             annotationsEnabled: false,
             uid: 'a-uid',
-            dashboardUid: req.params.uId,
+            dashboardUid: req.params.dashboardUid,
             accessToken: 'an-access-token',
           })
         );

--- a/public/app/features/manage-dashboards/components/PublicDashboardListTable.test.tsx
+++ b/public/app/features/manage-dashboards/components/PublicDashboardListTable.test.tsx
@@ -9,7 +9,7 @@ import {
 
 describe('listPublicDashboardsUrl', () => {
   it('has the correct url', () => {
-    expect(LIST_PUBLIC_DASHBOARD_URL).toEqual('/api/dashboards/public');
+    expect(LIST_PUBLIC_DASHBOARD_URL).toEqual('/api/dashboards/public-dashboards');
   });
 });
 

--- a/public/app/features/manage-dashboards/components/PublicDashboardListTable.tsx
+++ b/public/app/features/manage-dashboards/components/PublicDashboardListTable.tsx
@@ -15,7 +15,7 @@ export interface ListPublicDashboardResponse {
   isEnabled: boolean;
 }
 
-export const LIST_PUBLIC_DASHBOARD_URL = `/api/dashboards/public`;
+export const LIST_PUBLIC_DASHBOARD_URL = `/api/dashboards/public-dashboards`;
 export const getPublicDashboards = async (): Promise<ListPublicDashboardResponse[]> => {
   return getBackendSrv().get(LIST_PUBLIC_DASHBOARD_URL);
 };


### PR DESCRIPTION
This PR fixes the naming of routes for public dashboards to be more accurate and descriptive.


Fixes # https://github.com/grafana/grafana-partnerships-team/issues/466

