### PR TITLE
Docs: Add prerequisites to enable auth.jwt for url login

### DIFF
--- a/docs/sources/setup-grafana/configure-security/configure-authentication/jwt/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/jwt/index.md
@@ -82,6 +82,10 @@ can use URL login instead.
 > **Warning**: this can lead to JWTs being exposed in logs and possible session hijacking if the server is not
 > using HTTP over TLS.
 
+#### Prerequisites
+
+- [Enable JWT]({{< relref "#enable-jwt" >}}).
+
 ```ini
 # [auth.jwt]
 # ...

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/jwt/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/jwt/index.md
@@ -82,7 +82,9 @@ can use URL login instead.
 > **Warning**: this can lead to JWTs being exposed in logs and possible session hijacking if the server is not
 > using HTTP over TLS.
 
-#### Prerequisites
+> *Note*
+
+You need to enable JWT with this setting as well
 
 - [Enable JWT]({{< relref "#enable-jwt" >}}).
 

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/jwt/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/jwt/index.md
@@ -79,14 +79,10 @@ can use URL login instead.
 `url_login` allows grafana to search for a JWT in the URL query parameter
 `auth_token` and use it as the authentication token.
 
+**Note**: You need to have enabled JWT before setting this setting see section Enabled JWT
+
 > **Warning**: this can lead to JWTs being exposed in logs and possible session hijacking if the server is not
 > using HTTP over TLS.
-
-> *Note*
-
-You need to enable JWT with this setting as well
-
-- [Enable JWT]({{< relref "#enable-jwt" >}}).
 
 ```ini
 # [auth.jwt]


### PR DESCRIPTION
**why/what**
We need to add doc for prerequirestes for enabling the auth.jwt before adding the url_login parameter for jwt authentication

notes
original issue - https://github.com/grafana/grafana/issues/57072