### PR TITLE
Remove Sensu from docs

### DIFF
--- a/docs/sources/alerting/fundamentals/contact-points/index.md
+++ b/docs/sources/alerting/fundamentals/contact-points/index.md
@@ -38,7 +38,6 @@ The following table lists the contact point types supported by Grafana.
 | [Pagerduty](https://www.pagerduty.com/)          | `pagerduty`               | Supported            | Supported                                                                                                |
 | [Prometheus Alertmanager](https://prometheus.io) | `prometheus-alertmanager` | Supported            | N/A                                                                                                      |
 | [Pushover](https://pushover.net/)                | `pushover`                | Supported            | Supported                                                                                                |
-| [Sensu](https://sensu.io/)                       | `sensu`                   | Supported            | N/A                                                                                                      |
 | [Sensu Go](https://docs.sensu.io/sensu-go/)      | `sensugo`                 | Supported            | N/A                                                                                                      |
 | [Slack](https://slack.com/)                      | `slack`                   | Supported            | Supported                                                                                                |
 | [Telegram](https://telegram.org/)                | `telegram`                | Supported            | N/A                                                                                                      |


### PR DESCRIPTION
We do not support Sensu in Grafana Alerting, only Sensu Go, this clarifies the docs.

Resolves https://github.com/grafana/grafana/issues/57720