### PR TITLE
TopNav: Make it possible to to have sections without children

### DIFF
--- a/packages/grafana-data/src/types/navModel.ts
+++ b/packages/grafana-data/src/types/navModel.ts
@@ -19,6 +19,10 @@ export interface NavLinkDTO {
   hideFromTabs?: boolean;
   showIconInNavbar?: boolean;
   roundIcon?: boolean;
+  /**
+   * This is true for some sections that have no children (but is still a section)
+   **/
+  isSection?: boolean;
   children?: NavLinkDTO[];
   highlightText?: string;
   emptyMessageId?: string;

--- a/pkg/services/navtree/models.go
+++ b/pkg/services/navtree/models.go
@@ -62,6 +62,7 @@ type NavLink struct {
 	HideFromTabs     bool       `json:"hideFromTabs,omitempty"`
 	ShowIconInNavbar bool       `json:"showIconInNavbar,omitempty"`
 	RoundIcon        bool       `json:"roundIcon,omitempty"`
+	IsSection        bool       `json:"isSection,omitempty"`
 	Children         []*NavLink `json:"children,omitempty"`
 	HighlightText    string     `json:"highlightText,omitempty"`
 	HighlightID      string     `json:"highlightId,omitempty"`

--- a/pkg/services/navtree/navtreeimpl/applinks.go
+++ b/pkg/services/navtree/navtreeimpl/applinks.go
@@ -71,6 +71,7 @@ func (s *ServiceImpl) processAppPlugin(plugin plugins.PluginDTO, c *models.ReqCo
 		Img:        plugin.Info.Logos.Small,
 		Section:    navtree.NavSectionPlugin,
 		SortWeight: navtree.WeightPlugin,
+		IsSection:  true,
 	}
 
 	if topNavEnabled {

--- a/public/app/core/components/PageNew/SectionNavItem.tsx
+++ b/public/app/core/components/PageNew/SectionNavItem.tsx
@@ -24,7 +24,7 @@ export function SectionNavItem({ item, isSectionRoot = false }: Props) {
   const linkClass = cx({
     [styles.link]: true,
     [styles.activeStyle]: item.active,
-    [styles.isSection]: Boolean(children?.length),
+    [styles.isSection]: Boolean(children?.length) || item.isSection,
     [styles.hasActiveChild]: hasActiveChild,
     [styles.isSectionRoot]: isSectionRoot,
     [styles.noRootMargin]: noRootMargin,


### PR DESCRIPTION
Fixes an issue with sections that have no children (For example ML app, Connect data: https://github.com/grafana/grafana/pull/57772).

Only way to solve it was to add yet another property on NavModelItem to specifically mark a page as a section on its own and not just another child page.

