### PR TITLE
Oauth: Display friendly error message when role_attribute_strict=true and no valid role found

### DIFF
--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -353,7 +353,7 @@ func (hs *HTTPServer) trySetEncryptedCookie(ctx *models.ReqContext, cookieName s
 }
 
 func (hs *HTTPServer) redirectWithError(ctx *models.ReqContext, err error, v ...interface{}) {
-	ctx.Logger.Error(err.Error(), v...)
+	ctx.Logger.Warn(err.Error(), v...)
 	if err := hs.trySetEncryptedCookie(ctx, loginErrorCookieName, getLoginExternalError(err), 60); err != nil {
 		hs.log.Error("Failed to set encrypted cookie", "err", err)
 	}

--- a/pkg/login/social/azuread_oauth.go
+++ b/pkg/login/social/azuread_oauth.go
@@ -72,7 +72,7 @@ func (s *SocialAzureAD) UserInfo(client *http.Client, token *oauth2.Token) (*Bas
 
 	role, grafanaAdmin := s.extractRoleAndAdmin(&claims)
 	if s.roleAttributeStrict && !role.IsValid() {
-		return nil, ErrInvalidBasicRole
+		return nil, &InvalidBasicRoleError{idP: "Azure", assignedRole: string(role)}
 	}
 
 	logger.Debug("AzureAD OAuth: extracted role", "email", email, "role", role)

--- a/pkg/login/social/errors.go
+++ b/pkg/login/social/errors.go
@@ -1,9 +1,26 @@
 package social
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
 
 var (
 	ErrIDTokenNotFound  = errors.New("id_token not found")
-	ErrInvalidBasicRole = errors.New("user does not have a valid basic role")
 	ErrEmailNotFound    = errors.New("error getting user info: no email found in access token")
 )
+
+type InvalidBasicRoleError struct {
+	assignedRole string
+}
+
+func (e *InvalidBasicRoleError) Error() string {
+	return fmt.Sprintf("integration requires a valid org role assigned in idP. Assigned role: %s", e.assignedRole)
+}
+
+func (e *InvalidBasicRoleError) Unwrap() error {
+	return Error{cases.Title(language.Und).String(e.Error())}
+}

--- a/pkg/login/social/errors.go
+++ b/pkg/login/social/errors.go
@@ -14,15 +14,18 @@ var (
 )
 
 type InvalidBasicRoleError struct {
+	idP          string
 	assignedRole string
 }
 
 func (e *InvalidBasicRoleError) Error() string {
-	role := e.assignedRole
-	if role == "" {
-		role = "<Empty>"
+	withFallback := func(v, fallback string) string {
+		if v == "" {
+			return fallback
+		}
+		return v
 	}
-	return fmt.Sprintf("integration requires a valid org role assigned in idP. Assigned role: %s", role)
+	return fmt.Sprintf("integration requires a valid org role assigned in %s. Assigned role: %s", withFallback(e.idP, "idP"), withFallback(e.assignedRole, "<empty>"))
 }
 
 func (e *InvalidBasicRoleError) Unwrap() error {

--- a/pkg/login/social/errors.go
+++ b/pkg/login/social/errors.go
@@ -9,8 +9,8 @@ import (
 )
 
 var (
-	ErrIDTokenNotFound  = errors.New("id_token not found")
-	ErrEmailNotFound    = errors.New("error getting user info: no email found in access token")
+	ErrIDTokenNotFound = errors.New("id_token not found")
+	ErrEmailNotFound   = errors.New("error getting user info: no email found in access token")
 )
 
 type InvalidBasicRoleError struct {
@@ -18,9 +18,13 @@ type InvalidBasicRoleError struct {
 }
 
 func (e *InvalidBasicRoleError) Error() string {
-	return fmt.Sprintf("integration requires a valid org role assigned in idP. Assigned role: %s", e.assignedRole)
+	role := e.assignedRole
+	if role == "" {
+		role = "<Empty>"
+	}
+	return fmt.Sprintf("integration requires a valid org role assigned in idP. Assigned role: %s", role)
 }
 
 func (e *InvalidBasicRoleError) Unwrap() error {
-	return Error{cases.Title(language.Und).String(e.Error())}
+	return &Error{cases.Title(language.Und).String(e.Error())}
 }

--- a/pkg/login/social/errors.go
+++ b/pkg/login/social/errors.go
@@ -3,9 +3,6 @@ package social
 import (
 	"errors"
 	"fmt"
-
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
 )
 
 var (
@@ -25,9 +22,9 @@ func (e *InvalidBasicRoleError) Error() string {
 		}
 		return v
 	}
-	return fmt.Sprintf("integration requires a valid org role assigned in %s. Assigned role: %s", withFallback(e.idP, "idP"), withFallback(e.assignedRole, "<empty>"))
+	return fmt.Sprintf("Integration requires a valid org role assigned in %s. Assigned role: %s", withFallback(e.idP, "idP"), withFallback(e.assignedRole, "\" \""))
 }
 
 func (e *InvalidBasicRoleError) Unwrap() error {
-	return &Error{cases.Title(language.Und).String(e.Error())}
+	return &Error{e.Error()}
 }

--- a/pkg/login/social/generic_oauth.go
+++ b/pkg/login/social/generic_oauth.go
@@ -167,7 +167,7 @@ func (s *SocialGenericOAuth) UserInfo(client *http.Client, token *oauth2.Token) 
 	}
 
 	if s.roleAttributeStrict && !userInfo.Role.IsValid() {
-		return nil, ErrInvalidBasicRole
+		return nil, &InvalidBasicRoleError{assignedRole: string(userInfo.Role)}
 	}
 
 	if userInfo.Email == "" {

--- a/pkg/login/social/github_oauth.go
+++ b/pkg/login/social/github_oauth.go
@@ -203,7 +203,7 @@ func (s *SocialGithub) UserInfo(client *http.Client, token *oauth2.Token) (*Basi
 
 	role, grafanaAdmin := s.extractRoleAndAdmin(response.Body, teams, true)
 	if s.roleAttributeStrict && !role.IsValid() {
-		return nil, ErrInvalidBasicRole
+		return nil, &InvalidBasicRoleError{idP: "Github", assignedRole: string(role)}
 	}
 
 	var isGrafanaAdmin *bool = nil

--- a/pkg/login/social/gitlab_oauth.go
+++ b/pkg/login/social/gitlab_oauth.go
@@ -115,7 +115,7 @@ func (s *SocialGitlab) UserInfo(client *http.Client, _ *oauth2.Token) (*BasicUse
 
 	role, grafanaAdmin := s.extractRoleAndAdmin(response.Body, groups, true)
 	if s.roleAttributeStrict && !role.IsValid() {
-		return nil, ErrInvalidBasicRole
+		return nil, &InvalidBasicRoleError{idP: "Gitlab", assignedRole: string(role)}
 	}
 
 	var isGrafanaAdmin *bool = nil

--- a/pkg/login/social/gitlab_oauth_test.go
+++ b/pkg/login/social/gitlab_oauth_test.go
@@ -99,7 +99,7 @@ func TestSocialGitlab_UserInfo(t *testing.T) {
 			UserRespBody:      editorUserRespBody,
 			GroupsRespBody:    "[" + strings.Join([]string{}, ",") + "]",
 			RoleAttributePath: gitlabAttrPath,
-			ExpectedError:     ErrInvalidBasicRole,
+			ExpectedError:     &InvalidBasicRoleError{},
 		},
 		{ // Edge case, no match, no strict mode and no fallback => User has an empty role
 			Name:              "Fallback with no default will create a user with an empty role",
@@ -117,7 +117,7 @@ func TestSocialGitlab_UserInfo(t *testing.T) {
 			UserRespBody:      editorUserRespBody,
 			GroupsRespBody:    "[" + strings.Join([]string{editorGroup}, ",") + "]",
 			RoleAttributePath: "",
-			ExpectedError:     ErrInvalidBasicRole,
+			ExpectedError:     &InvalidBasicRoleError{},
 		},
 	}
 

--- a/pkg/login/social/gitlab_oauth_test.go
+++ b/pkg/login/social/gitlab_oauth_test.go
@@ -99,7 +99,7 @@ func TestSocialGitlab_UserInfo(t *testing.T) {
 			UserRespBody:      editorUserRespBody,
 			GroupsRespBody:    "[" + strings.Join([]string{}, ",") + "]",
 			RoleAttributePath: gitlabAttrPath,
-			ExpectedError:     &InvalidBasicRoleError{},
+			ExpectedError:     &InvalidBasicRoleError{idP: "Gitlab"},
 		},
 		{ // Edge case, no match, no strict mode and no fallback => User has an empty role
 			Name:              "Fallback with no default will create a user with an empty role",
@@ -117,7 +117,7 @@ func TestSocialGitlab_UserInfo(t *testing.T) {
 			UserRespBody:      editorUserRespBody,
 			GroupsRespBody:    "[" + strings.Join([]string{editorGroup}, ",") + "]",
 			RoleAttributePath: "",
-			ExpectedError:     &InvalidBasicRoleError{},
+			ExpectedError:     &InvalidBasicRoleError{idP: "Gitlab"},
 		},
 	}
 

--- a/pkg/login/social/okta_oauth.go
+++ b/pkg/login/social/okta_oauth.go
@@ -82,7 +82,7 @@ func (s *SocialOkta) UserInfo(client *http.Client, token *oauth2.Token) (*BasicU
 
 	role, grafanaAdmin := s.extractRoleAndAdmin(data.rawJSON, groups, true)
 	if s.roleAttributeStrict && !role.IsValid() {
-		return nil, ErrInvalidBasicRole
+		return nil, &InvalidBasicRoleError{idP: "Okta", assignedRole: string(role)}
 	}
 
 	var isGrafanaAdmin *bool = nil


### PR DESCRIPTION
**What is this feature?**
For oauth integrations we are currently returning a generic error response with a 500 http status if role_attribute_strict is set to true and no valid role was provided for the user:
![2022-10-28-12:32:20](https://user-images.githubusercontent.com/23356117/198567179-8f4cecc1-5cd8-496e-8b87-2ed65d28d543.png)


In this pr this behavior change to return a 401 http status code and a redirect to login page with a more descriptive message of why the login failed:
![2022-10-28-12:34:09](https://user-images.githubusercontent.com/23356117/198567493-b33ee0f0-3d43-45a7-a016-2ebe30f6f2a5.png)



**Which issue(s) does this PR fix?**:

Fixes #49367
Fixes #36339
