### PR TITLE
Loki Monaco Editor: enable by default

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -34,7 +34,7 @@ export interface FeatureToggles {
   publicDashboards?: boolean;
   lokiLive?: boolean;
   lokiDataframeApi?: boolean;
-  lokiMonacoEditor?: boolean;
+  disableLokiMonacoEditor?: boolean;
   swaggerUi?: boolean;
   featureHighlights?: boolean;
   dashboardComments?: boolean;

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -106,7 +106,7 @@ var (
 			State:       FeatureStateAlpha,
 		},
 		{
-			Name:        "lokiMonacoEditor",
+			Name:        "disableLokiMonacoEditor",
 			Description: "Access to Monaco query editor for Loki",
 			State:       FeatureStateAlpha,
 		},

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -79,9 +79,9 @@ const (
 	// use experimental loki api for websocket streaming (early prototype)
 	FlagLokiDataframeApi = "lokiDataframeApi"
 
-	// FlagLokiMonacoEditor
+	// FlagDisableLokiMonacoEditor
 	// Access to Monaco query editor for Loki
-	FlagLokiMonacoEditor = "lokiMonacoEditor"
+	FlagDisableLokiMonacoEditor = "disableLokiMonacoEditor"
 
 	// FlagSwaggerUi
 	// Serves swagger UI

--- a/public/app/plugins/datasource/loki/components/LokiQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryEditor.test.tsx
@@ -3,10 +3,9 @@ import userEvent from '@testing-library/user-event';
 import { cloneDeep, defaultsDeep } from 'lodash';
 import React from 'react';
 
-import { DataSourcePluginMeta } from '@grafana/data';
 import { QueryEditorMode } from 'app/plugins/datasource/prometheus/querybuilder/shared/types';
 
-import { LokiDatasource } from '../datasource';
+import { createLokiDatasource } from '../mocks';
 import { EXPLAIN_LABEL_FILTER_CONTENT } from '../querybuilder/components/LokiQueryBuilderExplained';
 import { LokiQuery, LokiQueryType } from '../types';
 
@@ -36,24 +35,10 @@ const defaultQuery = {
   expr: '{label1="foo", label2="bar"}',
 };
 
-const datasource = new LokiDatasource(
-  {
-    id: 1,
-    uid: '',
-    type: 'loki',
-    name: 'loki-test',
-    access: 'proxy',
-    url: '',
-    jsonData: {},
-    meta: {} as DataSourcePluginMeta,
-    readOnly: false,
-  },
-  undefined,
-  undefined
-);
+const datasource = createLokiDatasource();
 
-datasource.languageProvider.fetchLabels = jest.fn().mockResolvedValue([]);
-datasource.getDataSamples = jest.fn().mockResolvedValue([]);
+jest.spyOn(datasource.languageProvider, 'fetchLabels').mockResolvedValue([]);
+jest.spyOn(datasource, 'getDataSamples').mockResolvedValue([]);
 
 const defaultProps = {
   datasource,

--- a/public/app/plugins/datasource/loki/components/LokiQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryEditor.test.tsx
@@ -66,7 +66,7 @@ describe('LokiQueryEditorSelector', () => {
   it('shows code editor if expr and nothing else', async () => {
     // We opt for showing code editor for queries created before this feature was added
     render(<LokiQueryEditor {...defaultProps} />);
-    expectCodeEditor();
+    await expectCodeEditor();
   });
 
   it('shows builder if new query', async () => {
@@ -84,7 +84,7 @@ describe('LokiQueryEditorSelector', () => {
 
   it('shows code editor when code mode is set', async () => {
     renderWithMode(QueryEditorMode.Code);
-    expectCodeEditor();
+    await expectCodeEditor();
   });
 
   it('shows builder when builder mode is set', async () => {
@@ -94,6 +94,7 @@ describe('LokiQueryEditorSelector', () => {
 
   it('changes to builder mode', async () => {
     const { onChange } = renderWithMode(QueryEditorMode.Code);
+    await expectCodeEditor();
     await switchToMode(QueryEditorMode.Builder);
     expect(onChange).toBeCalledWith({
       refId: 'A',
@@ -129,7 +130,11 @@ describe('LokiQueryEditorSelector', () => {
 
   it('changes to code mode', async () => {
     const { onChange } = renderWithMode(QueryEditorMode.Builder);
+
+    await expectBuilder();
+
     await switchToMode(QueryEditorMode.Code);
+
     expect(onChange).toBeCalledWith({
       refId: 'A',
       expr: defaultQuery.expr,
@@ -144,6 +149,7 @@ describe('LokiQueryEditorSelector', () => {
       expr: 'rate({instance="host.docker.internal:3000"}[$__interval])',
       editorMode: QueryEditorMode.Code,
     });
+    await expectCodeEditor();
     await switchToMode(QueryEditorMode.Builder);
     rerender(
       <LokiQueryEditor
@@ -174,9 +180,9 @@ function renderWithProps(overrides?: Partial<LokiQuery>) {
   return { onChange, ...stuff };
 }
 
-function expectCodeEditor() {
+async function expectCodeEditor() {
   // Log browser shows this until log labels are loaded.
-  expect(screen.getByText('Loading labels...')).toBeInTheDocument();
+  expect(await screen.findByText('Loading...')).toBeInTheDocument();
 }
 
 async function expectBuilder() {

--- a/public/app/plugins/datasource/loki/components/LokiQueryField.test.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryField.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import React, { ComponentProps } from 'react';
 
 import { dateTime } from '@grafana/data';
@@ -43,6 +43,8 @@ describe('LokiQueryField', () => {
 
     const { rerender } = render(<LokiQueryField {...props} />);
 
+    expect(await screen.findByText('Loading...')).toBeInTheDocument();
+
     expect(fetchLabelsMock).not.toHaveBeenCalled();
 
     // 2 minutes difference over the initial time
@@ -65,6 +67,8 @@ describe('LokiQueryField', () => {
     props.datasource.languageProvider.fetchLabels = fetchLabelsMock;
 
     const { rerender } = render(<LokiQueryField {...props} />);
+
+    expect(await screen.findByText('Loading...')).toBeInTheDocument();
 
     expect(fetchLabelsMock).not.toHaveBeenCalled();
 

--- a/public/app/plugins/datasource/loki/components/LokiQueryField.test.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryField.test.tsx
@@ -3,49 +3,40 @@ import React, { ComponentProps } from 'react';
 
 import { dateTime } from '@grafana/data';
 
-import LokiLanguageProvider from '../LanguageProvider';
-import { LokiDatasource } from '../datasource';
-import syntax from '../syntax';
+import { createLokiDatasource } from '../mocks';
 
 import { LokiQueryField } from './LokiQueryField';
 
 type Props = ComponentProps<typeof LokiQueryField>;
 
-const defaultProps: Props = {
-  datasource: {
-    languageProvider: {
-      start: () => Promise.resolve(['label1']),
-      fetchLabels: Promise.resolve(['label1']),
-      getSyntax: () => syntax,
-      getLabelKeys: () => ['label1'],
-      getLabelValues: () => Promise.resolve(['value1']),
-    } as unknown as LokiLanguageProvider,
-  } as LokiDatasource,
-  range: {
-    from: dateTime([2021, 1, 11, 12, 0, 0]),
-    to: dateTime([2021, 1, 11, 18, 0, 0]),
-    raw: {
-      from: 'now-1h',
-      to: 'now',
-    },
-  },
-  query: { expr: '', refId: '' },
-  onRunQuery: () => {},
-  onChange: () => {},
-  history: [],
-};
-
 describe('LokiQueryField', () => {
-  it('refreshes metrics when time range changes over 1 minute', async () => {
-    const fetchLabelsMock = jest.fn();
-    const props = defaultProps;
-    props.datasource.languageProvider.fetchLabels = fetchLabelsMock;
+  let props: Props;
+  beforeEach(() => {
+    props = {
+      datasource: createLokiDatasource(),
+      range: {
+        from: dateTime([2021, 1, 11, 12, 0, 0]),
+        to: dateTime([2021, 1, 11, 18, 0, 0]),
+        raw: {
+          from: 'now-1h',
+          to: 'now',
+        },
+      },
+      query: { expr: '', refId: '' },
+      onRunQuery: () => {},
+      onChange: () => {},
+      history: [],
+    };
+    jest.spyOn(props.datasource.languageProvider, 'start').mockResolvedValue([]);
+    jest.spyOn(props.datasource.languageProvider, 'fetchLabels').mockResolvedValue(['label1']);
+  });
 
+  it('refreshes metrics when time range changes over 1 minute', async () => {
     const { rerender } = render(<LokiQueryField {...props} />);
 
     expect(await screen.findByText('Loading...')).toBeInTheDocument();
 
-    expect(fetchLabelsMock).not.toHaveBeenCalled();
+    expect(props.datasource.languageProvider.fetchLabels).not.toHaveBeenCalled();
 
     // 2 minutes difference over the initial time
     const newRange = {
@@ -58,19 +49,15 @@ describe('LokiQueryField', () => {
     };
 
     rerender(<LokiQueryField {...props} range={newRange} />);
-    expect(fetchLabelsMock).toHaveBeenCalledTimes(1);
+    expect(props.datasource.languageProvider.fetchLabels).toHaveBeenCalledTimes(1);
   });
 
   it('does not refreshes metrics when time range change by less than 1 minute', async () => {
-    const fetchLabelsMock = jest.fn();
-    const props = defaultProps;
-    props.datasource.languageProvider.fetchLabels = fetchLabelsMock;
-
     const { rerender } = render(<LokiQueryField {...props} />);
 
     expect(await screen.findByText('Loading...')).toBeInTheDocument();
 
-    expect(fetchLabelsMock).not.toHaveBeenCalled();
+    expect(props.datasource.languageProvider.fetchLabels).not.toHaveBeenCalled();
 
     // 20 seconds difference over the initial time
     const newRange = {
@@ -83,6 +70,6 @@ describe('LokiQueryField', () => {
     };
 
     rerender(<LokiQueryField {...props} range={newRange} />);
-    expect(fetchLabelsMock).not.toHaveBeenCalled();
+    expect(props.datasource.languageProvider.fetchLabels).not.toHaveBeenCalled();
   });
 });

--- a/public/app/plugins/datasource/loki/components/LokiQueryField.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryField.tsx
@@ -214,16 +214,7 @@ export class LokiQueryField extends React.PureComponent<LokiQueryFieldProps, Lok
                   <Icon name={labelBrowserVisible ? 'angle-down' : 'angle-right'} />
                 </button>
                 <div className="gf-form gf-form--grow flex-shrink-1 min-width-15">
-                  {config.featureToggles.lokiMonacoEditor ? (
-                    <MonacoQueryFieldWrapper
-                      runQueryOnBlur={app !== CoreApp.Explore}
-                      languageProvider={datasource.languageProvider}
-                      history={history ?? []}
-                      onChange={this.onChangeQuery}
-                      onRunQuery={onRunQuery}
-                      initialValue={query.expr ?? ''}
-                    />
-                  ) : (
+                  {config.featureToggles.disableLokiMonacoEditor ? (
                     <QueryField
                       additionalPlugins={this.plugins}
                       cleanText={datasource.languageProvider.cleanText}
@@ -235,6 +226,15 @@ export class LokiQueryField extends React.PureComponent<LokiQueryFieldProps, Lok
                       onRunQuery={onRunQuery}
                       placeholder={placeholder}
                       portalOrigin="loki"
+                    />
+                  ) : (
+                    <MonacoQueryFieldWrapper
+                      runQueryOnBlur={app !== CoreApp.Explore}
+                      languageProvider={datasource.languageProvider}
+                      history={history ?? []}
+                      onChange={this.onChangeQuery}
+                      onRunQuery={onRunQuery}
+                      initialValue={query.expr ?? ''}
                     />
                   )}
                 </div>

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryCodeEditor.test.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryCodeEditor.test.tsx
@@ -36,18 +36,20 @@ const createDefaultProps = () => {
 };
 
 describe('LokiQueryCodeEditor', () => {
-  it('shows explain section when showExplain is true', () => {
+  it('shows explain section when showExplain is true', async () => {
     const props = createDefaultProps();
     props.showExplain = true;
     props.datasource.metadataRequest = jest.fn().mockResolvedValue([]);
     render(<LokiQueryCodeEditor {...props} query={defaultQuery} />);
+    expect(await screen.findByText('Loading...')).toBeInTheDocument();
     expect(screen.getByText(EXPLAIN_LABEL_FILTER_CONTENT)).toBeInTheDocument();
   });
 
-  it('does not show explain section when showExplain is false', () => {
+  it('does not show explain section when showExplain is false', async () => {
     const props = createDefaultProps();
     props.datasource.metadataRequest = jest.fn().mockResolvedValue([]);
     render(<LokiQueryCodeEditor {...props} query={defaultQuery} />);
+    expect(await screen.findByText('Loading...')).toBeInTheDocument();
     expect(screen.queryByText(EXPLAIN_LABEL_FILTER_CONTENT)).not.toBeInTheDocument();
   });
 });

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryCodeEditor.test.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryCodeEditor.test.tsx
@@ -1,9 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 
-import { DataSourceInstanceSettings, DataSourcePluginMeta } from '@grafana/data';
-
-import { LokiDatasource } from '../../datasource';
+import { createLokiDatasource } from '../../mocks';
 import { LokiQuery } from '../../types';
 
 import { EXPLAIN_LABEL_FILTER_CONTENT } from './LokiQueryBuilderExplained';
@@ -15,15 +13,7 @@ const defaultQuery: LokiQuery = {
 };
 
 const createDefaultProps = () => {
-  const datasource = new LokiDatasource(
-    {
-      url: '',
-      jsonData: {},
-      meta: {} as DataSourcePluginMeta,
-    } as DataSourceInstanceSettings,
-    undefined,
-    undefined
-  );
+  const datasource = createLokiDatasource();
 
   const props = {
     datasource,


### PR DESCRIPTION
**What is this feature?**

In this PR we enable the Monaco editor for Loki by default, keeping feature flag support to disable it if necessary.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana/issues/44985

**Special notes for your reviewer**:

Will merge after https://github.com/grafana/grafana/pull/57368