### PR TITLE
Docs: adds view notification errors topic

### DIFF
--- a/docs/sources/alerting/manage-notifications/view-notification-errors
+++ b/docs/sources/alerting/manage-notifications/view-notification-errors
@@ -1,6 +1,6 @@
 ---
 aliases:
-  - /docs/grafana/latest/alerting/manage-notifications/view-notification-errors/
+  - /docs/grafana/next/alerting/manage-notifications/view-notification-errors/
 keywords:
   - grafana
   - alerting


### PR DESCRIPTION
Re-adding the view notification errors topic as it had /latest and not /next so wasn't appearing :)