### PR TITLE
Alerting: fix filtering in notification policies

### DIFF
--- a/public/app/features/alerting/unified/components/alert-groups/MatcherFilter.test.tsx
+++ b/public/app/features/alerting/unified/components/alert-groups/MatcherFilter.test.tsx
@@ -12,9 +12,14 @@ import { MatcherFilter } from './MatcherFilter';
 jest.mock('@grafana/runtime');
 
 describe('Analytics', () => {
-  it('Sends log info when filtering alert instances by label', async () => {
-    lodash.debounce = jest.fn().mockImplementation((fn) => fn);
+  beforeEach(() => {
+    lodash.debounce = jest.fn().mockImplementation((fn) => {
+      fn.cancel = () => {};
+      return fn;
+    });
+  });
 
+  it('Sends log info when filtering alert instances by label', async () => {
     render(<MatcherFilter onFilterChange={jest.fn()} />);
 
     const searchInput = screen.getByTestId('search-query-input');
@@ -24,7 +29,6 @@ describe('Analytics', () => {
   });
 
   it('should call onChange handler', async () => {
-    lodash.debounce = jest.fn().mockImplementation((fn) => fn);
     const onFilterMock = jest.fn();
 
     render(<MatcherFilter defaultQueryString="foo" onFilterChange={onFilterMock} />);

--- a/public/app/features/alerting/unified/components/alert-groups/MatcherFilter.test.tsx
+++ b/public/app/features/alerting/unified/components/alert-groups/MatcherFilter.test.tsx
@@ -22,4 +22,16 @@ describe('Analytics', () => {
 
     expect(logInfo).toHaveBeenCalledWith(LogMessages.filterByLabel);
   });
+
+  it('should call onChange handler', async () => {
+    lodash.debounce = jest.fn().mockImplementation((fn) => fn);
+    const onFilterMock = jest.fn();
+
+    render(<MatcherFilter defaultQueryString="foo" onFilterChange={onFilterMock} />);
+
+    const searchInput = screen.getByTestId('search-query-input');
+    await userEvent.type(searchInput, '=bar');
+
+    expect(onFilterMock).toHaveBeenLastCalledWith('foo=bar');
+  });
 });

--- a/public/app/features/alerting/unified/components/alert-groups/MatcherFilter.tsx
+++ b/public/app/features/alerting/unified/components/alert-groups/MatcherFilter.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import { debounce } from 'lodash';
-import React, { FormEvent } from 'react';
+import React, { FormEvent, useEffect, useMemo } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { Stack } from '@grafana/experimental';
@@ -18,12 +18,18 @@ interface Props {
 export const MatcherFilter = ({ className, onFilterChange, defaultQueryString }: Props) => {
   const styles = useStyles2(getStyles);
 
-  const handleSearchChange = debounce((e: FormEvent<HTMLInputElement>) => {
-    logInfo(LogMessages.filterByLabel);
+  const onSearchInputChanged = useMemo(
+    () =>
+      debounce((e: FormEvent<HTMLInputElement>) => {
+        logInfo(LogMessages.filterByLabel);
 
-    const target = e.target as HTMLInputElement;
-    onFilterChange(target.value);
-  }, 600);
+        const target = e.target as HTMLInputElement;
+        onFilterChange(target.value);
+      }, 600),
+    [onFilterChange]
+  );
+
+  useEffect(() => onSearchInputChanged.cancel(), [onSearchInputChanged]);
 
   const searchIcon = <Icon name={'search'} />;
 
@@ -47,7 +53,7 @@ export const MatcherFilter = ({ className, onFilterChange, defaultQueryString }:
       <Input
         placeholder="Search"
         defaultValue={defaultQueryString}
-        onChange={handleSearchChange}
+        onChange={onSearchInputChanged}
         data-testid="search-query-input"
         prefix={searchIcon}
         className={styles.inputWidth}

--- a/public/app/features/alerting/unified/components/alert-groups/MatcherFilter.tsx
+++ b/public/app/features/alerting/unified/components/alert-groups/MatcherFilter.tsx
@@ -11,20 +11,22 @@ import { LogMessages } from '../../Analytics';
 
 interface Props {
   className?: string;
-  queryString?: string;
   defaultQueryString?: string;
   onFilterChange: (filterString: string) => void;
 }
 
-export const MatcherFilter = ({ className, onFilterChange, defaultQueryString, queryString }: Props) => {
+export const MatcherFilter = ({ className, onFilterChange, defaultQueryString }: Props) => {
   const styles = useStyles2(getStyles);
+
   const handleSearchChange = debounce((e: FormEvent<HTMLInputElement>) => {
     logInfo(LogMessages.filterByLabel);
 
     const target = e.target as HTMLInputElement;
     onFilterChange(target.value);
   }, 600);
+
   const searchIcon = <Icon name={'search'} />;
+
   return (
     <div className={className}>
       <Label>
@@ -45,7 +47,6 @@ export const MatcherFilter = ({ className, onFilterChange, defaultQueryString, q
       <Input
         placeholder="Search"
         defaultValue={defaultQueryString}
-        value={queryString}
         onChange={handleSearchChange}
         data-testid="search-query-input"
         prefix={searchIcon}

--- a/public/app/features/alerting/unified/components/amroutes/AmSpecificRouting.tsx
+++ b/public/app/features/alerting/unified/components/amroutes/AmSpecificRouting.tsx
@@ -119,7 +119,7 @@ export const AmSpecificRouting: FC<AmSpecificRoutingProps> = ({
                   onFilterChange={(filter) =>
                     setFilters((currentFilters) => ({ ...currentFilters, queryString: filter }))
                   }
-                  queryString={filters.queryString ?? ''}
+                  defaultQueryString={filters.queryString ?? ''}
                   className={styles.filterInput}
                 />
                 <div className={styles.filterInput}>


### PR DESCRIPTION
Fixes filtering for notification policies. Previously we were passing `value` instead of `defaultValue` in to the `MatcherFilter` which would make the component render an empty value at all times – effectively disabling user input.

I've removed the `queryString` prop from the component to prevent this from happening in the future.

