### PR TITLE
Oauth: Only fetch user data from api if api_url is configured

### DIFF
--- a/pkg/login/social/generic_oauth.go
+++ b/pkg/login/social/generic_oauth.go
@@ -98,15 +98,17 @@ func (info *UserInfoJson) String() string {
 
 func (s *SocialGenericOAuth) UserInfo(client *http.Client, token *oauth2.Token) (*BasicUserInfo, error) {
 	s.log.Debug("Getting user info")
-	tokenData := s.extractFromToken(token)
-	apiData := s.extractFromAPI(client)
+	toCheck := make([]*UserInfoJson, 0, 2)
+
+	if tokenData := s.extractFromToken(token); tokenData != nil {
+		toCheck = append(toCheck, tokenData)
+	}
+	if apiData := s.extractFromAPI(client); apiData != nil {
+		toCheck = append(toCheck, apiData)
+	}
 
 	userInfo := &BasicUserInfo{}
-	for _, data := range []*UserInfoJson{tokenData, apiData} {
-		if data == nil {
-			continue
-		}
-
+	for _, data := range toCheck {
 		s.log.Debug("Processing external user info", "source", data.source, "data", data)
 
 		if userInfo.Name == "" {
@@ -279,6 +281,11 @@ func (s *SocialGenericOAuth) extractFromToken(token *oauth2.Token) *UserInfoJson
 
 func (s *SocialGenericOAuth) extractFromAPI(client *http.Client) *UserInfoJson {
 	s.log.Debug("Getting user info from API")
+	if s.apiUrl == "" {
+		s.log.Debug("No api url configured")
+		return nil
+	}
+
 	rawUserInfoResponse, err := s.httpGet(client, s.apiUrl)
 	if err != nil {
 		s.log.Debug("Error getting user info from API", "url", s.apiUrl, "error", err)


### PR DESCRIPTION
**What is this feature?**
When using generic oauth we always try to fetch user data from api even if the api_url is not configured.

With this pr we are skipping the request if api_url is empty and only try to parse info from id token

**Which issue(s) does this PR fix?**:

Fixes #57678

**Special notes for your reviewer**:

