### PR TITLE
Alerting: Improve group modal with validation on evaluation interval

### DIFF
--- a/public/app/features/alerting/unified/RuleList.test.tsx
+++ b/public/app/features/alerting/unified/RuleList.test.tsx
@@ -127,7 +127,7 @@ const ui = {
     namespaceInput: byRole('textbox', { hidden: true, name: /namespace/i }),
     ruleGroupInput: byRole('textbox', { name: 'Evaluation group', exact: true }),
     intervalInput: byRole('textbox', {
-      name: /Rule group evaluation interval Evaluation interval should be smaller or equal than For values for existing rules in this group./i,
+      name: /Rule group evaluation interval Evaluation interval should be smaller or equal than 'For' values for existing rules in this group./i,
     }),
     saveButton: byRole('button', { name: /Save changes/ }),
   },
@@ -616,7 +616,7 @@ describe('RuleList', () => {
       await userEvent.type(screen.getByRole('textbox', { name: 'Evaluation group', exact: true }), 'super group');
       await userEvent.type(
         screen.getByRole('textbox', {
-          name: /rule group evaluation interval evaluation interval should be smaller or equal than for values for existing rules in this group\./i,
+          name: /rule group evaluation interval evaluation interval should be smaller or equal than 'for' values for existing rules in this group\./i,
         }),
         '5m'
       );

--- a/public/app/features/alerting/unified/RuleList.test.tsx
+++ b/public/app/features/alerting/unified/RuleList.test.tsx
@@ -127,7 +127,7 @@ const ui = {
     namespaceInput: byRole('textbox', { hidden: true, name: /namespace/i }),
     ruleGroupInput: byRole('textbox', { name: 'Evaluation group', exact: true }),
     intervalInput: byRole('textbox', {
-      name: /Rule group evaluation interval Evaluation interval should be smaller or equal than 'For' values for existing rules in this group./i,
+      name: /Rule group evaluation interval Evaluation interval should be smaller or equal to 'For' values for existing rules in this group./i,
     }),
     saveButton: byRole('button', { name: /Save changes/ }),
   },
@@ -616,7 +616,7 @@ describe('RuleList', () => {
       await userEvent.type(screen.getByRole('textbox', { name: 'Evaluation group', exact: true }), 'super group');
       await userEvent.type(
         screen.getByRole('textbox', {
-          name: /rule group evaluation interval evaluation interval should be smaller or equal than 'for' values for existing rules in this group\./i,
+          name: /rule group evaluation interval evaluation interval should be smaller or equal to 'for' values for existing rules in this group\./i,
         }),
         '5m'
       );

--- a/public/app/features/alerting/unified/RuleList.test.tsx
+++ b/public/app/features/alerting/unified/RuleList.test.tsx
@@ -125,9 +125,9 @@ const ui = {
 
   editGroupModal: {
     namespaceInput: byRole('textbox', { hidden: true, name: /namespace/i }),
-    ruleGroupInput: byRole('textbox', { name: 'Rule group', exact: true }),
+    ruleGroupInput: byRole('textbox', { name: 'Evaluation group', exact: true }),
     intervalInput: byRole('textbox', {
-      name: /rule group evaluation interval evaluation interval should be smaller or equal than for values for existing rules in this group\./i,
+      name: /Rule group evaluation interval Evaluation interval should be smaller or equal than For values for existing rules in this group./i,
     }),
     saveButton: byRole('button', { name: /Save changes/ }),
   },
@@ -562,7 +562,9 @@ describe('RuleList', () => {
         await expect(screen.getByRole('textbox', { hidden: true, name: /namespace/i })).toHaveDisplayValue(
           'namespace1'
         );
-        await expect(screen.getByRole('textbox', { name: 'Rule group', exact: true })).toHaveDisplayValue('group1');
+        await expect(screen.getByRole('textbox', { name: 'Evaluation group', exact: true })).toHaveDisplayValue(
+          'group1'
+        );
         await fn();
       });
     }
@@ -610,8 +612,8 @@ describe('RuleList', () => {
 
     testCase('rename just the lotex group', async () => {
       // make changes to form
-      await userEvent.clear(screen.getByRole('textbox', { name: 'Rule group', exact: true }));
-      await userEvent.type(screen.getByRole('textbox', { name: 'Rule group', exact: true }), 'super group');
+      await userEvent.clear(screen.getByRole('textbox', { name: 'Evaluation group', exact: true }));
+      await userEvent.type(screen.getByRole('textbox', { name: 'Evaluation group', exact: true }), 'super group');
       await userEvent.type(
         screen.getByRole('textbox', {
           name: /rule group evaluation interval evaluation interval should be smaller or equal than for values for existing rules in this group\./i,

--- a/public/app/features/alerting/unified/RuleList.test.tsx
+++ b/public/app/features/alerting/unified/RuleList.test.tsx
@@ -4,11 +4,12 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { Provider } from 'react-redux';
 import { Router } from 'react-router-dom';
-import { byLabelText, byRole, byTestId, byText } from 'testing-library-selector';
+import { byRole, byTestId, byText } from 'testing-library-selector';
 
 import { locationService, setDataSourceSrv, logInfo } from '@grafana/runtime';
 import { contextSrv } from 'app/core/services/context_srv';
 import * as ruleActionButtons from 'app/features/alerting/unified/components/rules/RuleActionsButtons';
+import * as actions from 'app/features/alerting/unified/state/actions';
 import { configureStore } from 'app/store/configureStore';
 import { AccessControlAction } from 'app/types';
 import { PromAlertingRuleState, PromApplication } from 'app/types/unified-alerting-dto';
@@ -57,9 +58,11 @@ jest.mock('@grafana/runtime', () => {
 });
 
 jest.spyOn(config, 'getAllDataSources');
+jest.spyOn(actions, 'rulesInSameGroupHaveInvalidFor').mockReturnValue([]);
 
 const mocks = {
   getAllDataSourcesMock: jest.mocked(config.getAllDataSources),
+  rulesInSameGroupHaveInvalidForMock: jest.mocked(actions.rulesInSameGroupHaveInvalidFor),
 
   api: {
     discoverFeatures: jest.mocked(discoverFeatures),
@@ -121,9 +124,11 @@ const ui = {
   newRuleButton: byRole('link', { name: 'New alert rule' }),
 
   editGroupModal: {
-    namespaceInput: byLabelText('Namespace'),
-    ruleGroupInput: byLabelText('Rule group'),
-    intervalInput: byLabelText('Rule group evaluation interval'),
+    namespaceInput: byRole('textbox', { hidden: true, name: /namespace/i }),
+    ruleGroupInput: byRole('textbox', { name: 'Rule group', exact: true }),
+    intervalInput: byRole('textbox', {
+      name: /rule group evaluation interval evaluation interval should be smaller or equal than for values for existing rules in this group\./i,
+    }),
     saveButton: byRole('button', { name: /Save changes/ }),
   },
 };
@@ -131,6 +136,7 @@ const ui = {
 describe('RuleList', () => {
   beforeEach(() => {
     contextSrv.isEditor = true;
+    mocks.rulesInSameGroupHaveInvalidForMock.mockReturnValue([]);
   });
 
   afterEach(() => {
@@ -553,9 +559,10 @@ describe('RuleList', () => {
 
         // open edit dialog
         await userEvent.click(ui.editCloudGroupIcon.get(groups[0]));
-
-        expect(ui.editGroupModal.namespaceInput.get()).toHaveValue('namespace1');
-        expect(ui.editGroupModal.ruleGroupInput.get()).toHaveValue('group1');
+        await expect(screen.getByRole('textbox', { hidden: true, name: /namespace/i })).toHaveDisplayValue(
+          'namespace1'
+        );
+        await expect(screen.getByRole('textbox', { name: 'Rule group', exact: true })).toHaveDisplayValue('group1');
         await fn();
       });
     }
@@ -603,9 +610,14 @@ describe('RuleList', () => {
 
     testCase('rename just the lotex group', async () => {
       // make changes to form
-      await userEvent.clear(ui.editGroupModal.ruleGroupInput.get());
-      await userEvent.type(ui.editGroupModal.ruleGroupInput.get(), 'super group');
-      await userEvent.type(ui.editGroupModal.intervalInput.get(), '5m');
+      await userEvent.clear(screen.getByRole('textbox', { name: 'Rule group', exact: true }));
+      await userEvent.type(screen.getByRole('textbox', { name: 'Rule group', exact: true }), 'super group');
+      await userEvent.type(
+        screen.getByRole('textbox', {
+          name: /rule group evaluation interval evaluation interval should be smaller or equal than for values for existing rules in this group\./i,
+        }),
+        '5m'
+      );
 
       // submit, check that appropriate calls were made
       await userEvent.click(ui.editGroupModal.saveButton.get());

--- a/public/app/features/alerting/unified/components/InfoIcon.tsx
+++ b/public/app/features/alerting/unified/components/InfoIcon.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+import { Icon, Tooltip } from '@grafana/ui';
+
+export function InfoIcon({ text }: { text: string }) {
+  return (
+    <Tooltip placement="top" content={<div>{text}</div>}>
+      <Icon name="info-circle" size="xs" />
+    </Tooltip>
+  );
+}

--- a/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
@@ -14,7 +14,7 @@ import { EvaluationIntervalLimitExceeded } from '../InvalidIntervalWarning';
 import { GrafanaAlertStatePicker } from './GrafanaAlertStatePicker';
 import { RuleEditorSection } from './RuleEditorSection';
 
-const MIN_TIME_RANGE_STEP_S = 10; // 10 seconds
+export const MIN_TIME_RANGE_STEP_S = 10; // 10 seconds
 
 export const forValidationOptions = (evaluateEvery: string): RegisterOptions => ({
   required: {

--- a/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
+++ b/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
@@ -41,6 +41,9 @@ function ForError({ message }: { message: string }) {
 export const getNumberEvaluationsToStartAlerting = (forDuration: string, currentEvaluation: string) => {
   const evalNumberMs = safeParseDurationstr(currentEvaluation);
   const forNumber = safeParseDurationstr(forDuration);
+  if (forNumber === 0 && evalNumberMs !== 0) {
+    return 1;
+  }
   if (evalNumberMs === 0) {
     return 0;
   } else {
@@ -94,20 +97,20 @@ export const isValidEvaluation = (evaluation: string) => {
 
 export const getGroupFromRuler = (
   rulerRules: RulerRulesConfigDTO | null | undefined,
-  group: string,
-  folder: string
+  groupName: string,
+  folderName: string
 ) => {
-  const folderObj: Array<RulerRuleGroupDTO<RulerRuleDTO>> = rulerRules ? rulerRules[folder] : [];
-  return folderObj?.find((rulerRuleGroup) => rulerRuleGroup.name === group);
+  const folderObj: Array<RulerRuleGroupDTO<RulerRuleDTO>> = rulerRules ? rulerRules[folderName] : [];
+  return folderObj?.find((rulerRuleGroup) => rulerRuleGroup.name === groupName);
 };
 
 export const getIntervalForGroup = (
   rulerRules: RulerRulesConfigDTO | null | undefined,
-  group: string,
-  folder: string
+  groupName: string,
+  folderName: string
 ) => {
-  const groupObj = getGroupFromRuler(rulerRules, group, folder);
-  const interval = groupObj?.interval ?? MINUTE;
+  const group = getGroupFromRuler(rulerRules, groupName, folderName);
+  const interval = group?.interval ?? MINUTE;
   return interval;
 };
 
@@ -124,16 +127,16 @@ type AlertsWithForTableProps = DynamicTableItemProps<AlertInfo>;
 
 export const RulesForGroupTable = ({
   rulerRules,
-  group,
-  folder,
+  groupName,
+  folderName,
 }: {
   rulerRules: RulerRulesConfigDTO | null | undefined;
-  group: string;
-  folder: string;
+  groupName: string;
+  folderName: string;
 }) => {
   const styles = useStyles2(getStyles);
-  const groupObj = getGroupFromRuler(rulerRules, group, folder);
-  const rules: RulerRuleDTO[] = groupObj?.rules ?? [];
+  const group = getGroupFromRuler(rulerRules, groupName, folderName);
+  const rules: RulerRuleDTO[] = group?.rules ?? [];
 
   const { watch } = useFormContext<FormValues>();
   const currentInterval = watch('groupInterval');
@@ -343,8 +346,8 @@ export function EditCloudGroupModal(props: ModalProps): React.ReactElement {
                 </div>
                 <RulesForGroupTable
                   rulerRules={groupfoldersForSource?.result}
-                  group={group.name}
-                  folder={namespace.name}
+                  groupName={group.name}
+                  folderName={namespace.name}
                 />
               </>
             )}

--- a/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
+++ b/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
@@ -4,7 +4,7 @@ import { FormProvider, useForm, useFormContext } from 'react-hook-form';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { Stack } from '@grafana/experimental';
-import { Modal, Button, Field, Input, useStyles2, Label, Icon, Tooltip, Badge } from '@grafana/ui';
+import { Modal, Button, Field, Input, useStyles2, Label, Badge } from '@grafana/ui';
 import { useAppNotification } from 'app/core/copy/appNotification';
 import { useCleanup } from 'app/core/hooks/useCleanup';
 import { useDispatch } from 'app/types';
@@ -24,6 +24,7 @@ import { getRulesSourceName } from '../../utils/datasource';
 import { initialAsyncRequestState } from '../../utils/redux';
 import { parsePrometheusDuration } from '../../utils/time';
 import { DynamicTable, DynamicTableColumnProps, DynamicTableItemProps } from '../DynamicTable';
+import { InfoIcon } from '../InfoIcon';
 import { EvaluationIntervalLimitExceeded } from '../InvalidIntervalWarning';
 import { evaluateEveryValidationOptions, MIN_TIME_RANGE_STEP_S } from '../rule-editor/GrafanaEvaluationBehavior';
 
@@ -200,14 +201,6 @@ interface FormValues {
   namespaceName: string;
   groupName: string;
   groupInterval: string;
-}
-
-function InfoIcon({ text }: { text: string }) {
-  return (
-    <Tooltip placement="top" content={<div>{text}</div>}>
-      <Icon name="info-circle" size="xs" />
-    </Tooltip>
-  );
 }
 
 export function EditCloudGroupModal(props: ModalProps): React.ReactElement {

--- a/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
+++ b/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import React, { useEffect, useMemo } from 'react';
 import { FormProvider, useForm, useFormContext } from 'react-hook-form';
 
-import { durationToMilliseconds, GrafanaTheme2, parseDuration } from '@grafana/data';
+import { GrafanaTheme2 } from '@grafana/data';
 import { Stack } from '@grafana/experimental';
 import { Modal, Button, Field, Input, useStyles2, Label, Icon, Tooltip, Badge } from '@grafana/ui';
 import { useAppNotification } from 'app/core/copy/appNotification';
@@ -38,8 +38,8 @@ function ForError({ message }: { message: string }) {
 }
 
 const getNumberEvaluationsToStartAlerting = (forDuration: string, currentEvaluation: string) => {
-  const evalNumber = durationToMilliseconds(safeParseDurationstr(currentEvaluation));
-  const forNumber = durationToMilliseconds(safeParseDurationstr(forDuration));
+  const evalNumber = safeParseDurationstr(currentEvaluation);
+  const forNumber = safeParseDurationstr(forDuration);
   if (evalNumber === 0) {
     return 0;
   } else {
@@ -103,10 +103,12 @@ export const getIntervalForGroup = (
   return interval;
 };
 
-// parseDuration method needs units separated by space
-export const safeParseDurationstr = (duration: string) => {
-  const reg = /(?<=[a-z])(?=\d)/i;
-  return parseDuration(duration.replace(reg, ' '));
+export const safeParseDurationstr = (duration: string): number => {
+  try {
+    return parsePrometheusDuration(duration);
+  } catch (e) {
+    return 0;
+  }
 };
 
 type AlertsWithForTableColumnProps = DynamicTableColumnProps<AlertInfo>;
@@ -133,8 +135,8 @@ export const RulesForGroupTable = ({
     .slice()
     .sort(
       (alert1, alert2) =>
-        durationToMilliseconds(safeParseDurationstr(getAlertInfo(alert1, currentInterval).forDuration)) -
-        durationToMilliseconds(safeParseDurationstr(getAlertInfo(alert2, currentInterval).forDuration))
+        safeParseDurationstr(getAlertInfo(alert1, currentInterval).forDuration) -
+        safeParseDurationstr(getAlertInfo(alert2, currentInterval).forDuration)
     )
     .map((rule: RulerRuleDTO, index) => ({
       id: index,

--- a/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
+++ b/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
@@ -39,7 +39,8 @@ const getNumberEvaluationsToStartAlerting = (forDuration: string, currentEvaluat
   if (evalNumber === 0) {
     return 0;
   } else {
-    return Math.ceil(forNumber / evalNumber);
+    const evaluationsBeforeCeil = forNumber / evalNumber;
+    return evaluationsBeforeCeil < 1 ? 0 : Math.ceil(forNumber / evalNumber) + 1;
   }
 };
 
@@ -120,7 +121,7 @@ export const RulesForGroupTable = ({
     }));
 
   //add a hint that would say how many evaluations need to start alerting.
-  function getColumns(currentEvaluation: string): AlertsWithForTableColumnProps[] {
+  function getColumns(): AlertsWithForTableColumnProps[] {
     return [
       {
         id: 'alertName',
@@ -150,7 +151,7 @@ export const RulesForGroupTable = ({
   }
   return (
     <div className={styles.tableWrapper}>
-      <DynamicTable items={rows} cols={getColumns(currentInterval)} />
+      <DynamicTable items={rows} cols={getColumns()} />
     </div>
   );
 };

--- a/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
+++ b/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
@@ -9,19 +9,14 @@ import { useAppNotification } from 'app/core/copy/appNotification';
 import { useCleanup } from 'app/core/hooks/useCleanup';
 import { useDispatch } from 'app/types';
 import { CombinedRuleGroup, CombinedRuleNamespace } from 'app/types/unified-alerting';
-import {
-  RulerRulesConfigDTO,
-  RulerRuleGroupDTO,
-  RulerRuleDTO,
-  RulerGrafanaRuleDTO,
-  RulerAlertingRuleDTO,
-} from 'app/types/unified-alerting-dto';
+import { RulerRulesConfigDTO, RulerRuleGroupDTO, RulerRuleDTO } from 'app/types/unified-alerting-dto';
 
 import { useUnifiedAlertingSelector } from '../../hooks/useUnifiedAlertingSelector';
 import { rulesInSameGroupHaveInvalidFor, updateLotexNamespaceAndGroupAction } from '../../state/actions';
 import { checkEvaluationIntervalGlobalLimit } from '../../utils/config';
 import { getRulesSourceName } from '../../utils/datasource';
 import { initialAsyncRequestState } from '../../utils/redux';
+import { isAlertingRulerRule, isGrafanaRulerRule } from '../../utils/rules';
 import { parsePrometheusDuration } from '../../utils/time';
 import { DynamicTable, DynamicTableColumnProps, DynamicTableItemProps } from '../DynamicTable';
 import { InfoIcon } from '../InfoIcon';
@@ -52,23 +47,20 @@ export const getNumberEvaluationsToStartAlerting = (forDuration: string, current
   }
 };
 
-export const isRulerGrafanaRuleDTO = (rule: RulerRuleDTO): rule is RulerGrafanaRuleDTO => 'grafana_alert' in rule;
-export const isAlertingRuleDTO = (rule: RulerRuleDTO): rule is RulerAlertingRuleDTO => 'alert' in rule;
-
 export const getAlertInfo = (alert: RulerRuleDTO, currentEvaluation: string): AlertInfo => {
   const emptyAlert: AlertInfo = {
     alertName: '',
     forDuration: '0s',
     evaluationsToFire: 0,
   };
-  if (isRulerGrafanaRuleDTO(alert)) {
+  if (isGrafanaRulerRule(alert)) {
     return {
       alertName: alert.grafana_alert.title,
       forDuration: alert.for,
       evaluationsToFire: getNumberEvaluationsToStartAlerting(alert.for, currentEvaluation),
     };
   }
-  if (isAlertingRuleDTO(alert)) {
+  if (isAlertingRulerRule(alert)) {
     return {
       alertName: alert.alert,
       forDuration: alert.for ?? '1m',

--- a/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
+++ b/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
@@ -143,8 +143,7 @@ export const RulesForGroupTable = ({
       data: getAlertInfo(rule, currentInterval),
     }));
 
-  //add a hint that would say how many evaluations need to start alerting.
-  function getColumns(): AlertsWithForTableColumnProps[] {
+  const columns: AlertsWithForTableColumnProps[] = useMemo(() => {
     return [
       {
         id: 'alertName',
@@ -178,10 +177,11 @@ export const RulesForGroupTable = ({
         size: 0.2,
       },
     ];
-  }
+  }, [currentInterval]);
+
   return (
     <div className={styles.tableWrapper}>
-      <DynamicTable items={rows} cols={getColumns()} />
+      <DynamicTable items={rows} cols={columns} />
     </div>
   );
 };

--- a/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
+++ b/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
@@ -91,14 +91,21 @@ export const isValidEvaluation = (evaluation: string) => {
   }
 };
 
-export const getIntervalForGroup = (
+export const getGroupFromRuler = (
   rulerRules: RulerRulesConfigDTO | null | undefined,
   group: string,
   folder: string
 ) => {
   const folderObj: Array<RulerRuleGroupDTO<RulerRuleDTO>> = rulerRules ? rulerRules[folder] : [];
-  const groupObj = folderObj?.find((rulerRuleGroup) => rulerRuleGroup.name === group);
+  return folderObj?.find((rulerRuleGroup) => rulerRuleGroup.name === group);
+};
 
+export const getIntervalForGroup = (
+  rulerRules: RulerRulesConfigDTO | null | undefined,
+  group: string,
+  folder: string
+) => {
+  const groupObj = getGroupFromRuler(rulerRules, group, folder);
   const interval = groupObj?.interval ?? MINUTE;
   return interval;
 };
@@ -124,8 +131,7 @@ export const RulesForGroupTable = ({
   folder: string;
 }) => {
   const styles = useStyles2(getStyles);
-  const folderObj: Array<RulerRuleGroupDTO<RulerRuleDTO>> = rulerRules ? rulerRules[folder] : [];
-  const groupObj = folderObj?.find((rule) => rule.name === group);
+  const groupObj = getGroupFromRuler(rulerRules, group, folder);
   const rules: RulerRuleDTO[] = groupObj?.rules ?? [];
 
   const { watch } = useFormContext<FormValues>();

--- a/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
+++ b/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
@@ -133,15 +133,13 @@ export const RulesForGroupTable = ({
 
   const rows: AlertsWithForTableProps[] = rules
     .slice()
-    .sort(
-      (alert1, alert2) =>
-        safeParseDurationstr(getAlertInfo(alert1, currentInterval).forDuration) -
-        safeParseDurationstr(getAlertInfo(alert2, currentInterval).forDuration)
-    )
     .map((rule: RulerRuleDTO, index) => ({
       id: index,
       data: getAlertInfo(rule, currentInterval),
-    }));
+    }))
+    .sort(
+      (alert1, alert2) => safeParseDurationstr(alert1.data.forDuration) - safeParseDurationstr(alert2.data.forDuration)
+    );
 
   const columns: AlertsWithForTableColumnProps[] = useMemo(() => {
     return [

--- a/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
+++ b/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
@@ -1,18 +1,109 @@
 import { css } from '@emotion/css';
 import React, { useEffect, useMemo } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
 
-import { Modal, Button, Form, Field, Input, useStyles2 } from '@grafana/ui';
+import { GrafanaTheme2 } from '@grafana/data';
+import { Modal, Button, Field, Input, useStyles2 } from '@grafana/ui';
+import { useAppNotification } from 'app/core/copy/appNotification';
 import { useCleanup } from 'app/core/hooks/useCleanup';
 import { useDispatch } from 'app/types';
 import { CombinedRuleGroup, CombinedRuleNamespace } from 'app/types/unified-alerting';
+import { RulerRulesConfigDTO, RulerRuleGroupDTO, RulerRuleDTO } from 'app/types/unified-alerting-dto';
 
 import { useUnifiedAlertingSelector } from '../../hooks/useUnifiedAlertingSelector';
 import { updateLotexNamespaceAndGroupAction } from '../../state/actions';
 import { checkEvaluationIntervalGlobalLimit } from '../../utils/config';
 import { getRulesSourceName } from '../../utils/datasource';
 import { initialAsyncRequestState } from '../../utils/redux';
+import { isGrafanaRulerRule, isAlertingRulerRule } from '../../utils/rules';
+import { DynamicTable, DynamicTableColumnProps, DynamicTableItemProps } from '../DynamicTable';
 import { EvaluationIntervalLimitExceeded } from '../InvalidIntervalWarning';
 import { evaluateEveryValidationOptions } from '../rule-editor/GrafanaEvaluationBehavior';
+
+const MINUTE = '1m';
+interface AlertWithFor {
+  alertName: string;
+  forDuration: string;
+}
+
+export const getAlertInfo = (alert: RulerRuleDTO): AlertWithFor => {
+  const emptyAlert: AlertWithFor = {
+    alertName: '',
+    forDuration: '0s',
+  };
+  if (isGrafanaRulerRule(alert)) {
+    return {
+      alertName: alert.grafana_alert.title,
+      forDuration: alert.for,
+    };
+  }
+  if (isAlertingRulerRule(alert)) {
+    return {
+      alertName: alert.alert,
+      forDuration: alert.for ?? '1m',
+    };
+  }
+  return emptyAlert;
+};
+export const getIntervalForGroup = (
+  rulerRules: RulerRulesConfigDTO | null | undefined,
+  group: string,
+  folder: string
+) => {
+  const folderObj: Array<RulerRuleGroupDTO<RulerRuleDTO>> = rulerRules ? rulerRules[folder] : [];
+  const groupObj = folderObj?.find((rule) => rule.name === group);
+
+  const interval = groupObj?.interval ?? MINUTE;
+  return interval;
+};
+
+type AlertsWithForTableColumnProps = DynamicTableColumnProps<AlertWithFor>;
+type AlertsWithForTableProps = DynamicTableItemProps<AlertWithFor>;
+
+export const RulesForGroupTable = ({
+  rulerRules,
+  group,
+  folder,
+}: {
+  rulerRules: RulerRulesConfigDTO | null | undefined;
+  group: string;
+  folder: string;
+}) => {
+  const styles = useStyles2(getStyles);
+  const folderObj: Array<RulerRuleGroupDTO<RulerRuleDTO>> = rulerRules ? rulerRules[folder] : [];
+  const groupObj = folderObj?.find((rule) => rule.name === group);
+  const rules: RulerRuleDTO[] = groupObj?.rules ?? [];
+  const rows: AlertsWithForTableProps[] = rules.map((rule: RulerRuleDTO, index) => ({
+    id: index,
+    data: getAlertInfo(rule),
+  }));
+
+  function getColumns(): AlertsWithForTableColumnProps[] {
+    return [
+      {
+        id: 'alertName',
+        label: 'Alert',
+        renderCell: ({ data: { alertName } }) => {
+          return <>{alertName}</>;
+        },
+        size: 0.7,
+      },
+      {
+        id: 'for',
+        label: 'For',
+        renderCell: ({ data: { forDuration } }) => {
+          return <>{forDuration}</>;
+        },
+        size: 0.3,
+      },
+    ];
+  }
+  return (
+    <div className={styles.tableWrapper}>
+      <DynamicTable items={rows} cols={getColumns()} />
+    </div>
+  );
+};
 
 interface ModalProps {
   namespace: CombinedRuleNamespace;
@@ -32,6 +123,7 @@ export function EditCloudGroupModal(props: ModalProps): React.ReactElement {
   const dispatch = useDispatch();
   const { loading, error, dispatched } =
     useUnifiedAlertingSelector((state) => state.updateLotexNamespaceAndGroup) ?? initialAsyncRequestState;
+  const notifyApp = useAppNotification();
 
   const defaultValues = useMemo(
     (): FormValues => ({
@@ -64,6 +156,25 @@ export function EditCloudGroupModal(props: ModalProps): React.ReactElement {
     );
   };
 
+  const formAPI = useForm<FormValues>({
+    mode: 'onSubmit',
+    defaultValues,
+    shouldFocusError: true,
+  });
+  const {
+    handleSubmit,
+    register,
+    watch,
+    formState: { isDirty, errors },
+  } = formAPI;
+
+  const onInvalid = () => {
+    notifyApp.error('There are errors in the form. Please correct them and try again!');
+  };
+
+  const rulerRuleRequests = useUnifiedAlertingSelector((state) => state.rulerRules);
+  const groupfoldersForSource = rulerRuleRequests[getRulesSourceName(namespace.rulesSource)];
+
   return (
     <Modal
       className={styles.modal}
@@ -72,8 +183,8 @@ export function EditCloudGroupModal(props: ModalProps): React.ReactElement {
       onDismiss={onClose}
       onClickBackdrop={onClose}
     >
-      <Form defaultValues={defaultValues} onSubmit={onSubmit} key={JSON.stringify(defaultValues)}>
-        {({ register, errors, formState: { isDirty }, watch }) => (
+      <FormProvider {...formAPI}>
+        <form onSubmit={(e) => e.preventDefault()} key={JSON.stringify(defaultValues)}>
           <>
             <Field label="Namespace" invalid={!!errors.namespaceName} error={errors.namespaceName?.message}>
               <Input
@@ -102,8 +213,19 @@ export function EditCloudGroupModal(props: ModalProps): React.ReactElement {
                 {...register('groupInterval', evaluateEveryValidationOptions)}
               />
             </Field>
+
             {checkEvaluationIntervalGlobalLimit(watch('groupInterval')).exceedsLimit && (
               <EvaluationIntervalLimitExceeded />
+            )}
+            {rulerRuleRequests && (
+              <>
+                <div>List of rules that belong to this group</div>
+                <RulesForGroupTable
+                  rulerRules={groupfoldersForSource.result}
+                  group={group.name}
+                  folder={namespace.name}
+                />
+              </>
             )}
 
             <Modal.ButtonRow>
@@ -116,19 +238,33 @@ export function EditCloudGroupModal(props: ModalProps): React.ReactElement {
               >
                 Close
               </Button>
-              <Button type="submit" disabled={!isDirty || loading}>
+              <Button
+                type="button"
+                disabled={!isDirty || loading}
+                onClick={handleSubmit((values) => onSubmit(values), onInvalid)}
+              >
                 {loading ? 'Saving...' : 'Save changes'}
               </Button>
             </Modal.ButtonRow>
           </>
-        )}
-      </Form>
+        </form>
+      </FormProvider>
     </Modal>
   );
 }
 
-const getStyles = () => ({
+const getStyles = (theme: GrafanaTheme2) => ({
   modal: css`
     max-width: 560px;
+  `,
+  formInput: css`
+    width: 275px;
+    & + & {
+      margin-left: ${theme.spacing(3)};
+    }
+  `,
+  tableWrapper: css`
+    margin-top: ${theme.spacing(2)};
+    margin-bottom: ${theme.spacing(2)};
   `,
 });

--- a/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
+++ b/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
@@ -31,20 +31,20 @@ const MINUTE = '1m';
 interface AlertInfo {
   alertName: string;
   forDuration: string;
-  numberEvaluations: number;
+  evaluationsToFire: number;
 }
 function ForError({ message }: { message: string }) {
   return <Badge color="orange" icon="exclamation-triangle" text={'Error'} tooltip={message} />;
 }
 
 const getNumberEvaluationsToStartAlerting = (forDuration: string, currentEvaluation: string) => {
-  const evalNumber = safeParseDurationstr(currentEvaluation);
+  const evalNumberMs = safeParseDurationstr(currentEvaluation);
   const forNumber = safeParseDurationstr(forDuration);
-  if (evalNumber === 0) {
+  if (evalNumberMs === 0) {
     return 0;
   } else {
-    const evaluationsBeforeCeil = forNumber / evalNumber;
-    return evaluationsBeforeCeil < 1 ? 0 : Math.ceil(forNumber / evalNumber) + 1;
+    const evaluationsBeforeCeil = forNumber / evalNumberMs;
+    return evaluationsBeforeCeil < 1 ? 0 : Math.ceil(forNumber / evalNumberMs) + 1;
   }
 };
 
@@ -55,20 +55,20 @@ export const getAlertInfo = (alert: RulerRuleDTO, currentEvaluation: string): Al
   const emptyAlert: AlertInfo = {
     alertName: '',
     forDuration: '0s',
-    numberEvaluations: 0,
+    evaluationsToFire: 0,
   };
   if (isRulerGrafanaRuleDTO(alert)) {
     return {
       alertName: alert.grafana_alert.title,
       forDuration: alert.for,
-      numberEvaluations: getNumberEvaluationsToStartAlerting(alert.for, currentEvaluation),
+      evaluationsToFire: getNumberEvaluationsToStartAlerting(alert.for, currentEvaluation),
     };
   }
   if (isAlertingRuleDTO(alert)) {
     return {
       alertName: alert.alert,
       forDuration: alert.for ?? '1m',
-      numberEvaluations: getNumberEvaluationsToStartAlerting(alert.for ?? '1m', currentEvaluation),
+      evaluationsToFire: getNumberEvaluationsToStartAlerting(alert.for ?? '1m', currentEvaluation),
     };
   }
   return emptyAlert;
@@ -97,7 +97,7 @@ export const getIntervalForGroup = (
   folder: string
 ) => {
   const folderObj: Array<RulerRuleGroupDTO<RulerRuleDTO>> = rulerRules ? rulerRules[folder] : [];
-  const groupObj = folderObj?.find((rule) => rule.name === group);
+  const groupObj = folderObj?.find((rulerRuleGroup) => rulerRuleGroup.name === group);
 
   const interval = groupObj?.interval ?? MINUTE;
   return interval;
@@ -164,7 +164,7 @@ export const RulesForGroupTable = ({
       {
         id: 'numberEvaluations',
         label: '#Evaluations',
-        renderCell: ({ data: { numberEvaluations } }) => {
+        renderCell: ({ data: { evaluationsToFire: numberEvaluations } }) => {
           if (!isValidEvaluation(currentInterval)) {
             return <ForError message={'Invalid evaluation interval format'} />;
           }

--- a/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
+++ b/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
@@ -173,7 +173,7 @@ export const RulesForGroupTable = ({
             return <ForError message={'Invalid evaluation interval format'} />;
           }
           if (numberEvaluations === 0) {
-            return <ForError message="Invalid For value: it should be greater or equal than evaluation interval." />;
+            return <ForError message="Invalid 'For' value: it should be greater or equal than evaluation interval." />;
           } else {
             return <>{numberEvaluations}</>;
           }
@@ -262,7 +262,7 @@ export function EditCloudGroupModal(props: ModalProps): React.ReactElement {
   } = formAPI;
 
   const onInvalid = () => {
-    notifyApp.error('There are errors in the form. Please correct them and try again!');
+    notifyApp.error('There are errors in the form. Correct the errors and retry.');
   };
 
   const rulerRuleRequests = useUnifiedAlertingSelector((state) => state.rulerRules);
@@ -321,7 +321,7 @@ export function EditCloudGroupModal(props: ModalProps): React.ReactElement {
               label={
                 <Label
                   htmlFor="groupInterval"
-                  description="Evaluation interval should be smaller or equal than For values for existing rules in this group."
+                  description="Evaluation interval should be smaller or equal than 'For' values for existing rules in this group."
                 >
                   <Stack gap={0.5}>
                     Rule group evaluation interval

--- a/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
+++ b/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
@@ -3,7 +3,8 @@ import React, { useEffect, useMemo } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 
 import { durationToMilliseconds, GrafanaTheme2, parseDuration } from '@grafana/data';
-import { Modal, Button, Field, Input, useStyles2 } from '@grafana/ui';
+import { Stack } from '@grafana/experimental';
+import { Modal, Button, Field, Input, useStyles2, Label, Icon, Tooltip } from '@grafana/ui';
 import { useAppNotification } from 'app/core/copy/appNotification';
 import { useCleanup } from 'app/core/hooks/useCleanup';
 import { useDispatch } from 'app/types';
@@ -139,6 +140,14 @@ interface FormValues {
   groupInterval: string;
 }
 
+function InfoIcon({ text }: { text: string }) {
+  return (
+    <Tooltip placement="top" content={<div>{text}</div>}>
+      <Icon name="info-circle" size="xs" />
+    </Tooltip>
+  );
+}
+
 export function EditCloudGroupModal(props: ModalProps): React.ReactElement {
   const { namespace, group, onClose } = props;
   const styles = useStyles2(getStyles);
@@ -208,7 +217,18 @@ export function EditCloudGroupModal(props: ModalProps): React.ReactElement {
       <FormProvider {...formAPI}>
         <form onSubmit={(e) => e.preventDefault()} key={JSON.stringify(defaultValues)}>
           <>
-            <Field label="Namespace" invalid={!!errors.namespaceName} error={errors.namespaceName?.message}>
+            <Field
+              label={
+                <Label htmlFor="namespaceName">
+                  <Stack gap={0.5}>
+                    NameSpace
+                    <InfoIcon text={'You can update name space'} />
+                  </Stack>
+                </Label>
+              }
+              invalid={!!errors.namespaceName}
+              error={errors.namespaceName?.message}
+            >
               <Input
                 id="namespaceName"
                 {...register('namespaceName', {
@@ -216,7 +236,18 @@ export function EditCloudGroupModal(props: ModalProps): React.ReactElement {
                 })}
               />
             </Field>
-            <Field label="Rule group" invalid={!!errors.groupName} error={errors.groupName?.message}>
+            <Field
+              label={
+                <Label htmlFor="groupName">
+                  <Stack gap={0.5}>
+                    Rule group
+                    <InfoIcon text={'You can update group name'} />
+                  </Stack>
+                </Label>
+              }
+              invalid={!!errors.groupName}
+              error={errors.groupName?.message}
+            >
               <Input
                 id="groupName"
                 {...register('groupName', {
@@ -225,7 +256,17 @@ export function EditCloudGroupModal(props: ModalProps): React.ReactElement {
               />
             </Field>
             <Field
-              label="Rule group evaluation interval"
+              label={
+                <Label
+                  htmlFor="groupInterval"
+                  description="Evaluation interval should be smaller or equal than For values for existing rules in this group."
+                >
+                  <Stack gap={0.5}>
+                    Rule group evaluation interval
+                    <InfoIcon text={'You can update evaluation interval'} />
+                  </Stack>
+                </Label>
+              }
               invalid={!!errors.groupInterval}
               error={errors.groupInterval?.message}
             >
@@ -288,5 +329,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
   tableWrapper: css`
     margin-top: ${theme.spacing(2)};
     margin-bottom: ${theme.spacing(2)};
+    height: 225px;
+    overflow: auto;
   `,
 });

--- a/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
+++ b/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
@@ -37,7 +37,7 @@ function ForError({ message }: { message: string }) {
   return <Badge color="orange" icon="exclamation-triangle" text={'Error'} tooltip={message} />;
 }
 
-const getNumberEvaluationsToStartAlerting = (forDuration: string, currentEvaluation: string) => {
+export const getNumberEvaluationsToStartAlerting = (forDuration: string, currentEvaluation: string) => {
   const evalNumberMs = safeParseDurationstr(currentEvaluation);
   const forNumber = safeParseDurationstr(forDuration);
   if (evalNumberMs === 0) {

--- a/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
+++ b/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
@@ -174,7 +174,7 @@ export const RulesForGroupTable = ({
             return <ForError message={'Invalid evaluation interval format'} />;
           }
           if (numberEvaluations === 0) {
-            return <ForError message="Invalid 'For' value: it should be greater or equal than evaluation interval." />;
+            return <ForError message="Invalid 'For' value: it should be greater or equal to evaluation interval." />;
           } else {
             return <>{numberEvaluations}</>;
           }
@@ -314,7 +314,7 @@ export function EditCloudGroupModal(props: ModalProps): React.ReactElement {
               label={
                 <Label
                   htmlFor="groupInterval"
-                  description="Evaluation interval should be smaller or equal than 'For' values for existing rules in this group."
+                  description="Evaluation interval should be smaller or equal to 'For' values for existing rules in this group."
                 >
                   <Stack gap={0.5}>
                     Rule group evaluation interval

--- a/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
+++ b/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
@@ -290,7 +290,7 @@ export function EditCloudGroupModal(props: ModalProps): React.ReactElement {
                 >
                   <Stack gap={0.5}>
                     Rule group evaluation interval
-                    <InfoIcon text={'You can update evaluation interval'} />
+                    <InfoIcon text={'How frequently to evaluate rules.'} />
                   </Stack>
                 </Label>
               }

--- a/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
+++ b/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
@@ -342,7 +342,7 @@ export function EditCloudGroupModal(props: ModalProps): React.ReactElement {
               <>
                 <div>List of rules that belong to this group</div>
                 <div className={styles.evalRequiredLabel}>
-                  #Evaluations column represents number of evaluations neededed before alert starts firing.
+                  #Evaluations column represents the number of evaluations needed before alert starts firing.
                 </div>
                 <RulesForGroupTable
                   rulerRules={groupfoldersForSource?.result}

--- a/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
+++ b/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
@@ -237,7 +237,7 @@ export function EditCloudGroupModal(props: ModalProps): React.ReactElement {
     <Modal
       className={styles.modal}
       isOpen={true}
-      title="Edit namespace or rule group"
+      title="Edit namespace or evaluation group"
       onDismiss={onClose}
       onClickBackdrop={onClose}
     >
@@ -267,7 +267,7 @@ export function EditCloudGroupModal(props: ModalProps): React.ReactElement {
               label={
                 <Label htmlFor="groupName">
                   <Stack gap={0.5}>
-                    Rule group
+                    Evaluation group
                     <InfoIcon text={'You can update group name'} />
                   </Stack>
                 </Label>
@@ -278,7 +278,7 @@ export function EditCloudGroupModal(props: ModalProps): React.ReactElement {
               <Input
                 id="groupName"
                 {...register('groupName', {
-                  required: 'Rule group name is required.',
+                  required: 'Evaluation group name is required.',
                 })}
               />
             </Field>

--- a/public/app/features/alerting/unified/components/rules/getNumberEvaluationsToStartAlerting.test.ts
+++ b/public/app/features/alerting/unified/components/rules/getNumberEvaluationsToStartAlerting.test.ts
@@ -2,6 +2,10 @@ import { getNumberEvaluationsToStartAlerting } from './EditRuleGroupModal';
 describe('getNumberEvaluationsToStartAlerting method', () => {
   it('should return 0 in case of invalid data', () => {
     expect(getNumberEvaluationsToStartAlerting('sd', 'ksdh')).toBe(0);
+    expect(getNumberEvaluationsToStartAlerting('0s', '1dfa0m')).toBe(0);
+  });
+  it('should return 1 in case of zero For and valid interval', () => {
+    expect(getNumberEvaluationsToStartAlerting('0s', '10m')).toBe(1);
   });
   it('should return correct number in case of valid data', () => {
     expect(getNumberEvaluationsToStartAlerting('1m', '10m')).toBe(0);

--- a/public/app/features/alerting/unified/components/rules/getNumberEvaluationsToStartAlerting.test.ts
+++ b/public/app/features/alerting/unified/components/rules/getNumberEvaluationsToStartAlerting.test.ts
@@ -1,0 +1,14 @@
+import { getNumberEvaluationsToStartAlerting } from './EditRuleGroupModal';
+describe('getNumberEvaluationsToStartAlerting method', () => {
+  it('should return 0 in case of invalid data', () => {
+    const numberEvals = getNumberEvaluationsToStartAlerting('sd', 'ksdh');
+    expect(numberEvals).toBe(0);
+  });
+  it('should return correct number in case of valid data', () => {
+    expect(getNumberEvaluationsToStartAlerting('1m', '10m')).toBe(0);
+    expect(getNumberEvaluationsToStartAlerting('10m', '10m')).toBe(2);
+    expect(getNumberEvaluationsToStartAlerting('18m', '10m')).toBe(3);
+    expect(getNumberEvaluationsToStartAlerting('1h41m', '10m')).toBe(12);
+    expect(getNumberEvaluationsToStartAlerting('101m', '10m')).toBe(12);
+  });
+});

--- a/public/app/features/alerting/unified/components/rules/getNumberEvaluationsToStartAlerting.test.ts
+++ b/public/app/features/alerting/unified/components/rules/getNumberEvaluationsToStartAlerting.test.ts
@@ -1,8 +1,7 @@
 import { getNumberEvaluationsToStartAlerting } from './EditRuleGroupModal';
 describe('getNumberEvaluationsToStartAlerting method', () => {
   it('should return 0 in case of invalid data', () => {
-    const numberEvals = getNumberEvaluationsToStartAlerting('sd', 'ksdh');
-    expect(numberEvals).toBe(0);
+    expect(getNumberEvaluationsToStartAlerting('sd', 'ksdh')).toBe(0);
   });
   it('should return correct number in case of valid data', () => {
     expect(getNumberEvaluationsToStartAlerting('1m', '10m')).toBe(0);

--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -821,11 +821,11 @@ export const updateLotexNamespaceAndGroupAction = createAsyncThunk(
           // validation for new groupInterval
           if (groupInterval !== existingGroup.interval) {
             const storeState = thunkAPI.getState();
-            const groupfoldersForGrafana = isStoreState(storeState)
-              ? storeState?.unifiedAlerting.rulerRules[GRAFANA_RULES_SOURCE_NAME]
+            const groupfoldersForSource = isStoreState(storeState)
+              ? storeState?.unifiedAlerting.rulerRules[rulesSourceName]
               : null;
             const notValidRules = rulesInSameGroupHaveInvalidFor(
-              groupfoldersForGrafana?.result,
+              groupfoldersForSource?.result,
               groupName,
               namespaceName,
               durationToMilliseconds(safeParseDurationstr(groupInterval ?? ''))

--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -1,7 +1,6 @@
 import { createAsyncThunk, AsyncThunk } from '@reduxjs/toolkit';
 import { isEmpty } from 'lodash';
 
-import { durationToMilliseconds } from '@grafana/data';
 import { locationService } from '@grafana/runtime';
 import {
   AlertmanagerAlert,
@@ -768,10 +767,7 @@ export const rulesInSameGroupHaveInvalidFor = (
 
   return rulesSameGroup.filter((rule: RulerRuleDTO) => {
     const { forDuration } = getAlertInfo(rule, everyDuration);
-    return (
-      durationToMilliseconds(safeParseDurationstr(forDuration)) <
-      durationToMilliseconds(safeParseDurationstr(everyDuration))
-    );
+    return safeParseDurationstr(forDuration) < safeParseDurationstr(everyDuration);
   });
 };
 

--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -28,7 +28,6 @@ import {
   PostableRulerRuleGroupDTO,
   PromApplication,
   RulerRuleDTO,
-  RulerRuleGroupDTO,
   RulerRulesConfigDTO,
 } from 'app/types/unified-alerting-dto';
 
@@ -61,7 +60,7 @@ import {
   FetchRulerRulesFilter,
   setRulerRuleGroup,
 } from '../api/ruler';
-import { getAlertInfo, safeParseDurationstr } from '../components/rules/EditRuleGroupModal';
+import { getAlertInfo, safeParseDurationstr, getGroupFromRuler } from '../components/rules/EditRuleGroupModal';
 import { RuleFormType, RuleFormValues } from '../types/rule-form';
 import { addDefaultsToAlertmanagerConfig, removeMuteTimingFromRoute } from '../utils/alertmanager';
 import {
@@ -760,8 +759,7 @@ export const rulesInSameGroupHaveInvalidFor = (
   folder_: string,
   everyDuration: string
 ) => {
-  const folderObj: RulerRuleGroupDTO[] = (rulerRules && rulerRules[folder_]) ?? [];
-  const groupObj = folderObj?.find((ruleGroup) => ruleGroup.name === group);
+  const groupObj = getGroupFromRuler(rulerRules, group, folder_);
 
   const rulesSameGroup: RulerRuleDTO[] = groupObj?.rules ?? [];
 

--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -767,7 +767,7 @@ const rulesInSameGroupHaveInvalidFor = (
   rulerRules: RulerRulesConfigDTO | null | undefined,
   group: string,
   folder_: string,
-  everyDuration: number
+  everyDuration: string
 ) => {
   const folderObj: RulerRuleGroupDTO[] = (rulerRules && rulerRules[folder_]) ?? [];
   const groupObj = folderObj?.find((ruleGroup) => ruleGroup.name === group);
@@ -775,8 +775,11 @@ const rulesInSameGroupHaveInvalidFor = (
   const rulesSameGroup: RulerRuleDTO[] = groupObj?.rules ?? [];
 
   return rulesSameGroup.filter((rule: RulerRuleDTO) => {
-    const { forDuration } = getAlertInfo(rule);
-    return durationToMilliseconds(safeParseDurationstr(forDuration)) < everyDuration;
+    const { forDuration } = getAlertInfo(rule, everyDuration);
+    return (
+      durationToMilliseconds(safeParseDurationstr(forDuration)) <
+      durationToMilliseconds(safeParseDurationstr(everyDuration))
+    );
   });
 };
 
@@ -828,13 +831,13 @@ export const updateLotexNamespaceAndGroupAction = createAsyncThunk(
               groupfoldersForSource?.result,
               groupName,
               namespaceName,
-              durationToMilliseconds(safeParseDurationstr(groupInterval ?? ''))
+              groupInterval ?? '1m'
             );
             if (notValidRules.length > 0) {
               throw new Error(
                 `These alerts belonging to this group would have an invalid For value: ${notValidRules
                   .map((rule) => {
-                    const { alertName } = getAlertInfo(rule);
+                    const { alertName } = getAlertInfo(rule, groupInterval ?? '');
                     return alertName;
                   })
                   .join(',')}`

--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -1,7 +1,7 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
 import { isEmpty } from 'lodash';
 
-import { durationToMilliseconds, parseDuration } from '@grafana/data';
+import { durationToMilliseconds } from '@grafana/data';
 import { locationService } from '@grafana/runtime';
 import {
   AlertmanagerAlert,
@@ -62,7 +62,7 @@ import {
   FetchRulerRulesFilter,
   setRulerRuleGroup,
 } from '../api/ruler';
-import { getAlertInfo } from '../components/rules/EditRuleGroupModal';
+import { getAlertInfo, safeParseDurationstr } from '../components/rules/EditRuleGroupModal';
 import { RuleFormType, RuleFormValues } from '../types/rule-form';
 import { addDefaultsToAlertmanagerConfig, removeMuteTimingFromRoute } from '../utils/alertmanager';
 import {
@@ -776,7 +776,7 @@ const rulesInSameGroupHaveInvalidFor = (
 
   return rulesSameGroup.filter((rule: RulerRuleDTO) => {
     const { forDuration } = getAlertInfo(rule);
-    return durationToMilliseconds(parseDuration(forDuration)) < everyDuration;
+    return durationToMilliseconds(safeParseDurationstr(forDuration)) < everyDuration;
   });
 };
 
@@ -828,7 +828,7 @@ export const updateLotexNamespaceAndGroupAction = createAsyncThunk(
               groupfoldersForGrafana?.result,
               groupName,
               namespaceName,
-              durationToMilliseconds(parseDuration(groupInterval ?? ''))
+              durationToMilliseconds(safeParseDurationstr(groupInterval ?? ''))
             );
             if (notValidRules.length > 0) {
               throw new Error(

--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -763,7 +763,7 @@ const isStoreState = (something: unknown): something is StoreState => {
   }
 };
 
-const rulesInSameGroupHaveInvalidFor = (
+export const rulesInSameGroupHaveInvalidFor = (
   rulerRules: RulerRulesConfigDTO | null | undefined,
   group: string,
   folder_: string,
@@ -845,6 +845,7 @@ export const updateLotexNamespaceAndGroupAction = createAsyncThunk(
             }
           }
           // if renaming namespace - make new copies of all groups, then delete old namespace
+
           if (newNamespaceName !== namespaceName) {
             for (const group of rulesResult[namespaceName]) {
               await setRulerRuleGroup(

--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -823,7 +823,7 @@ export const updateLotexNamespaceAndGroupAction: AsyncThunk<
             );
             if (notValidRules.length > 0) {
               throw new Error(
-                `These alerts belonging to this group would have an invalid For value: ${notValidRules
+                `These alerts belonging to this group will have an invalid 'For' value: ${notValidRules
                   .map((rule) => {
                     const { alertName } = getAlertInfo(rule, groupInterval ?? '');
                     return alertName;

--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -755,13 +755,13 @@ interface UpdateNamespaceAndGroupOptions {
 
 export const rulesInSameGroupHaveInvalidFor = (
   rulerRules: RulerRulesConfigDTO | null | undefined,
-  group: string,
-  folder_: string,
+  groupName: string,
+  folderName: string,
   everyDuration: string
 ) => {
-  const groupObj = getGroupFromRuler(rulerRules, group, folder_);
+  const group = getGroupFromRuler(rulerRules, groupName, folderName);
 
-  const rulesSameGroup: RulerRuleDTO[] = groupObj?.rules ?? [];
+  const rulesSameGroup: RulerRuleDTO[] = group?.rules ?? [];
 
   return rulesSameGroup.filter((rule: RulerRuleDTO) => {
     const { forDuration } = getAlertInfo(rule, everyDuration);


### PR DESCRIPTION
**What is this feature?**

This PR it's an improvement for the edit group modal:

- It shows alert list belonging to this group, with the `For` value for each alert, so user has more information when updating the evaluation interval. This table also shows a 'hint' about how many evaluations are needed before the alert starts firing. In case some alerts has invalid `For`, this column shows an error Badge.
- it adds a form validation, so user cannot update invalid `evaluation interval` => that means that some rules would have an invalid value after this change.
- It adds an info icon to clarify that in this modal user can only update the names for the namespace/group and the interval value for this group.

**Why do we need this feature?**

With this feature, we avoid invalid alert rules after updating an evaluation interval from this modal.

**Who is this feature for?**

Users that need to update evaluation interval and namespace/group names.

**Special notes for your reviewer**:

https://user-images.githubusercontent.com/33540275/199068909-c0eb07f6-0895-483e-a820-ab88c6b1a572.mp4




