### PR TITLE
CloudWatch: fix non-deterministic test

### DIFF
--- a/pkg/tsdb/cloudwatch/models/cloudwatch_query_test.go
+++ b/pkg/tsdb/cloudwatch/models/cloudwatch_query_test.go
@@ -883,7 +883,6 @@ func Test_migrateAliasToDynamicLabel_single_query_preserves_old_alias_and_create
 	}
 }
 func Test_ParseMetricDataQueries_migrate_alias_to_label(t *testing.T) {
-	t.Skip()
 	t.Run("migrates alias to label when label does not already exist and feature toggle enabled", func(t *testing.T) {
 		query := []backend.DataQuery{
 			{
@@ -953,7 +952,7 @@ func Test_ParseMetricDataQueries_migrate_alias_to_label(t *testing.T) {
 		require.Len(t, res, 2)
 
 		sort.Slice(res, func(i, j int) bool {
-			return res[i].RefId > res[j].RefId
+			return res[i].RefId < res[j].RefId
 		})
 
 		require.NotNil(t, res[0])

--- a/pkg/tsdb/cloudwatch/models/cloudwatch_query_test.go
+++ b/pkg/tsdb/cloudwatch/models/cloudwatch_query_test.go
@@ -3,6 +3,7 @@ package models
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 	"testing"
 	"time"
 
@@ -882,6 +883,7 @@ func Test_migrateAliasToDynamicLabel_single_query_preserves_old_alias_and_create
 	}
 }
 func Test_ParseMetricDataQueries_migrate_alias_to_label(t *testing.T) {
+	t.Skip()
 	t.Run("migrates alias to label when label does not already exist and feature toggle enabled", func(t *testing.T) {
 		query := []backend.DataQuery{
 			{
@@ -948,8 +950,11 @@ func Test_ParseMetricDataQueries_migrate_alias_to_label(t *testing.T) {
 
 		res, err := ParseMetricDataQueries(query, time.Now(), time.Now(), true)
 		assert.NoError(t, err)
-
 		require.Len(t, res, 2)
+
+		sort.Slice(res, func(i, j int) bool {
+			return res[i].RefId > res[j].RefId
+		})
 
 		require.NotNil(t, res[0])
 		assert.Equal(t, "{{period}} {{any_other_word}}", res[0].Alias)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
This sorts the result of the function in a test file in order to make assertions on it consistently.

Fixes issue raised in comment of the PR that introduced the behavior https://github.com/grafana/grafana/pull/57624#issuecomment-1295004120

(What happened was that I introduced a map in the mix that was never there before and that introduces some randomness before it is re-transformed into a slice for the result.)
