### PR TITLE
PublicDashboards: do not return errors when resource not found from store layer

### DIFF
--- a/pkg/services/publicdashboards/api/api.go
+++ b/pkg/services/publicdashboards/api/api.go
@@ -111,7 +111,7 @@ func (api *Api) SavePublicDashboard(c *models.ReqContext) response.Response {
 	// exit if we don't have a valid dashboardUid
 	dashboardUid := web.Params(c.Req)[":dashboardUid"]
 	if dashboardUid == "" || !util.IsValidShortUID(dashboardUid) {
-		api.handleError(c.Req.Context(), http.StatusBadRequest, "SavePublicDashboard: no valid dashboardUid", dashboards.ErrDashboardIdentifierNotSet)
+		api.handleError(c.Req.Context(), http.StatusBadRequest, "SavePublicDashboard: invalid dashboardUid", dashboards.ErrDashboardIdentifierNotSet)
 	}
 
 	pubdash := &PublicDashboard{}

--- a/pkg/services/publicdashboards/api/api.go
+++ b/pkg/services/publicdashboards/api/api.go
@@ -92,6 +92,12 @@ func (api *Api) ListPublicDashboards(c *models.ReqContext) response.Response {
 // GetPublicDashboard Gets public dashboard configuration for dashboard
 // GET /api/dashboards/uid/:uid/public-config
 func (api *Api) GetPublicDashboard(c *models.ReqContext) response.Response {
+	// exit if we don't have a valid dashboardUid
+	dashboardUid := web.Params(c.Req)[":dashboardUid"]
+	if dashboardUid == "" || !util.IsValidShortUID(dashboardUid) {
+		api.handleError(c.Req.Context(), http.StatusBadRequest, "GetPublicDashboard: no valid dashboardUid", dashboards.ErrDashboardIdentifierNotSet)
+	}
+
 	pdc, err := api.PublicDashboardService.FindByDashboardUid(c.Req.Context(), c.OrgID, web.Params(c.Req)[":dashboardUid"])
 	if err != nil {
 		return api.handleError(c.Req.Context(), http.StatusInternalServerError, "GetPublicDashboardConfig: failed to get public dashboard config", err)
@@ -105,12 +111,12 @@ func (api *Api) SavePublicDashboard(c *models.ReqContext) response.Response {
 	// exit if we don't have a valid dashboardUid
 	dashboardUid := web.Params(c.Req)[":dashboardUid"]
 	if dashboardUid == "" || !util.IsValidShortUID(dashboardUid) {
-		api.handleError(c.Req.Context(), http.StatusBadRequest, "SavePublicDashboardConfig: no dashboardUid", dashboards.ErrDashboardIdentifierNotSet)
+		api.handleError(c.Req.Context(), http.StatusBadRequest, "SavePublicDashboard: no valid dashboardUid", dashboards.ErrDashboardIdentifierNotSet)
 	}
 
 	pubdash := &PublicDashboard{}
 	if err := web.Bind(c.Req, pubdash); err != nil {
-		return response.Error(http.StatusBadRequest, "SavePublicDashboardConfig: bad request data", err)
+		return response.Error(http.StatusBadRequest, "SavePublicDashboard: bad request data", err)
 	}
 
 	// Always set the orgID and userID from the session

--- a/pkg/services/publicdashboards/database/database_test.go
+++ b/pkg/services/publicdashboards/database/database_test.go
@@ -228,7 +228,7 @@ func TestIntegrationFindByDashboardUid(t *testing.T) {
 		savedDashboard = insertTestDashboard(t, dashboardStore, "testDashie", 1, 0, true)
 	}
 
-	t.Run("returns isPublic and set dashboardUid and orgId", func(t *testing.T) {
+	t.Run("returns public dashboard by dashboardUid", func(t *testing.T) {
 		setup()
 		savedPubdash := insertPublicDashboard(t, publicdashboardStore, savedDashboard.Uid, savedDashboard.OrgId, false)
 		pubdash, err := publicdashboardStore.FindByDashboardUid(context.Background(), savedDashboard.OrgId, savedDashboard.Uid)
@@ -236,10 +236,11 @@ func TestIntegrationFindByDashboardUid(t *testing.T) {
 		assert.Equal(t, savedPubdash, pubdash)
 	})
 
-	t.Run("returns dashboard errDashboardIdentifierNotSet", func(t *testing.T) {
+	t.Run("returns nil when identifier is not set", func(t *testing.T) {
 		setup()
-		_, err := publicdashboardStore.FindByDashboardUid(context.Background(), savedDashboard.OrgId, "")
-		require.Error(t, dashboards.ErrDashboardIdentifierNotSet, err)
+		pubdash, err := publicdashboardStore.FindByDashboardUid(context.Background(), savedDashboard.OrgId, "")
+		assert.Nil(t, err)
+		assert.Nil(t, pubdash)
 	})
 
 	t.Run("returns along with public dashboard when exists", func(t *testing.T) {
@@ -267,7 +268,7 @@ func TestIntegrationFindByDashboardUid(t *testing.T) {
 		assert.True(t, assert.ObjectsAreEqualValues(&cmd.PublicDashboard, pubdash))
 	})
 
-	t.Run("returns error when public dashboard doesn't exist", func(t *testing.T) {
+	t.Run("returns nil when public dashboard doesn't exist", func(t *testing.T) {
 		setup()
 		pubdash, err := publicdashboardStore.FindByDashboardUid(context.Background(), 9, "fake-dashboard-uid")
 		require.NoError(t, err)
@@ -289,7 +290,7 @@ func TestIntegrationFindByAccessToken(t *testing.T) {
 		savedDashboard = insertTestDashboard(t, dashboardStore, "testDashie", 1, 0, true)
 	}
 
-	t.Run("returns isPublic and set dashboardUid and orgId", func(t *testing.T) {
+	t.Run("returns public dashboard by accessToken", func(t *testing.T) {
 		setup()
 		savedPubdash := insertPublicDashboard(t, publicdashboardStore, savedDashboard.Uid, savedDashboard.OrgId, false)
 		pubdash, err := publicdashboardStore.FindByAccessToken(context.Background(), savedPubdash.AccessToken)
@@ -297,10 +298,11 @@ func TestIntegrationFindByAccessToken(t *testing.T) {
 		assert.Equal(t, savedPubdash, pubdash)
 	})
 
-	t.Run("returns dashboard errDashboardIdentifierNotSet", func(t *testing.T) {
+	t.Run("returns nil when identifier is not set", func(t *testing.T) {
 		setup()
-		_, err := publicdashboardStore.FindByAccessToken(context.Background(), "")
-		require.Error(t, dashboards.ErrDashboardIdentifierNotSet, err)
+		pubdash, err := publicdashboardStore.FindByAccessToken(context.Background(), "")
+		assert.Nil(t, err)
+		assert.Nil(t, pubdash)
 	})
 
 	t.Run("returns along with public dashboard when exists", func(t *testing.T) {
@@ -397,7 +399,8 @@ func TestIntegrationSavePublicDashboard(t *testing.T) {
 				AccessToken:  "NOTAREALUUID",
 			},
 		})
-		assert.Error(t, err, dashboards.ErrDashboardIdentifierNotSet)
+		require.Error(t, err)
+		assert.Equal(t, err, dashboards.ErrDashboardIdentifierNotSet)
 	})
 }
 

--- a/pkg/services/publicdashboards/database/database_test.go
+++ b/pkg/services/publicdashboards/database/database_test.go
@@ -81,7 +81,7 @@ func TestIntegrationFindDashboard(t *testing.T) {
 	t.Run("FindDashboard can get original dashboard by uid", func(t *testing.T) {
 		setup()
 
-		dashboard, err := publicdashboardStore.FindDashboard(context.Background(), savedDashboard.Uid, savedDashboard.OrgId)
+		dashboard, err := publicdashboardStore.FindDashboard(context.Background(), savedDashboard.OrgId, savedDashboard.Uid)
 
 		require.NoError(t, err)
 		require.Equal(t, savedDashboard.Uid, dashboard.Uid)
@@ -270,9 +270,70 @@ func TestIntegrationFindByDashboardUid(t *testing.T) {
 	t.Run("returns error when public dashboard doesn't exist", func(t *testing.T) {
 		setup()
 		pubdash, err := publicdashboardStore.FindByDashboardUid(context.Background(), 9, "fake-dashboard-uid")
-		require.Error(t, err)
-		require.Nil(t, pubdash)
-		assert.Equal(t, ErrPublicDashboardNotFound, err)
+		require.NoError(t, err)
+		assert.Nil(t, pubdash)
+	})
+}
+
+func TestIntegrationFindByAccessToken(t *testing.T) {
+	var sqlStore db.DB
+	var cfg *setting.Cfg
+	var dashboardStore *dashboardsDB.DashboardStore
+	var publicdashboardStore *PublicDashboardStoreImpl
+	var savedDashboard *models.Dashboard
+
+	setup := func() {
+		sqlStore, cfg = db.InitTestDBwithCfg(t)
+		dashboardStore = dashboardsDB.ProvideDashboardStore(sqlStore, cfg, featuremgmt.WithFeatures(), tagimpl.ProvideService(sqlStore, cfg))
+		publicdashboardStore = ProvideStore(sqlStore)
+		savedDashboard = insertTestDashboard(t, dashboardStore, "testDashie", 1, 0, true)
+	}
+
+	t.Run("returns isPublic and set dashboardUid and orgId", func(t *testing.T) {
+		setup()
+		savedPubdash := insertPublicDashboard(t, publicdashboardStore, savedDashboard.Uid, savedDashboard.OrgId, false)
+		pubdash, err := publicdashboardStore.FindByAccessToken(context.Background(), savedPubdash.AccessToken)
+		require.NoError(t, err)
+		assert.Equal(t, savedPubdash, pubdash)
+	})
+
+	t.Run("returns dashboard errDashboardIdentifierNotSet", func(t *testing.T) {
+		setup()
+		_, err := publicdashboardStore.FindByAccessToken(context.Background(), "")
+		require.Error(t, dashboards.ErrDashboardIdentifierNotSet, err)
+	})
+
+	t.Run("returns along with public dashboard when exists", func(t *testing.T) {
+		setup()
+		cmd := SavePublicDashboardCommand{
+			PublicDashboard: PublicDashboard{
+				IsEnabled:    true,
+				Uid:          "pubdash-uid",
+				DashboardUid: savedDashboard.Uid,
+				OrgId:        savedDashboard.OrgId,
+				TimeSettings: DefaultTimeSettings,
+				CreatedAt:    DefaultTime,
+				CreatedBy:    7,
+				AccessToken:  "thisisavalidaccesstoken",
+			},
+		}
+
+		// insert test public dashboard
+		err := publicdashboardStore.Save(context.Background(), cmd)
+		require.NoError(t, err)
+
+		// retrieve from db
+		pubdash, err := publicdashboardStore.FindByAccessToken(context.Background(), cmd.PublicDashboard.AccessToken)
+		require.NoError(t, err)
+
+		assert.True(t, assert.ObjectsAreEqualValues(&cmd.PublicDashboard, pubdash))
+	})
+
+	t.Run("returns error when public dashboard doesn't exist", func(t *testing.T) {
+		setup()
+		pubdash, err := publicdashboardStore.FindByAccessToken(context.Background(), "fake-accessToken-uid")
+		require.NoError(t, err)
+		assert.Nil(t, pubdash)
 	})
 }
 

--- a/pkg/services/publicdashboards/public_dashboard_service_mock.go
+++ b/pkg/services/publicdashboards/public_dashboard_service_mock.go
@@ -136,13 +136,13 @@ func (_m *FakePublicDashboardService) FindByDashboardUid(ctx context.Context, or
 	return r0, r1
 }
 
-// FindDashboard provides a mock function with given fields: ctx, dashboardUid, orgId
-func (_m *FakePublicDashboardService) FindDashboard(ctx context.Context, dashboardUid string, orgId int64) (*pkgmodels.Dashboard, error) {
-	ret := _m.Called(ctx, dashboardUid, orgId)
+// FindDashboard provides a mock function with given fields: ctx, orgId, dashboardUid
+func (_m *FakePublicDashboardService) FindDashboard(ctx context.Context, orgId int64, dashboardUid string) (*pkgmodels.Dashboard, error) {
+	ret := _m.Called(ctx, orgId, dashboardUid)
 
 	var r0 *pkgmodels.Dashboard
-	if rf, ok := ret.Get(0).(func(context.Context, string, int64) *pkgmodels.Dashboard); ok {
-		r0 = rf(ctx, dashboardUid, orgId)
+	if rf, ok := ret.Get(0).(func(context.Context, int64, string) *pkgmodels.Dashboard); ok {
+		r0 = rf(ctx, orgId, dashboardUid)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*pkgmodels.Dashboard)
@@ -150,8 +150,8 @@ func (_m *FakePublicDashboardService) FindDashboard(ctx context.Context, dashboa
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, string, int64) error); ok {
-		r1 = rf(ctx, dashboardUid, orgId)
+	if rf, ok := ret.Get(1).(func(context.Context, int64, string) error); ok {
+		r1 = rf(ctx, orgId, dashboardUid)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/services/publicdashboards/public_dashboard_store_mock.go
+++ b/pkg/services/publicdashboards/public_dashboard_store_mock.go
@@ -152,13 +152,13 @@ func (_m *FakePublicDashboardStore) FindByDashboardUid(ctx context.Context, orgI
 	return r0, r1
 }
 
-// FindDashboard provides a mock function with given fields: ctx, dashboardUid, orgId
-func (_m *FakePublicDashboardStore) FindDashboard(ctx context.Context, dashboardUid string, orgId int64) (*pkgmodels.Dashboard, error) {
-	ret := _m.Called(ctx, dashboardUid, orgId)
+// FindDashboard provides a mock function with given fields: ctx, orgId, dashboardUid
+func (_m *FakePublicDashboardStore) FindDashboard(ctx context.Context, orgId int64, dashboardUid string) (*pkgmodels.Dashboard, error) {
+	ret := _m.Called(ctx, orgId, dashboardUid)
 
 	var r0 *pkgmodels.Dashboard
-	if rf, ok := ret.Get(0).(func(context.Context, string, int64) *pkgmodels.Dashboard); ok {
-		r0 = rf(ctx, dashboardUid, orgId)
+	if rf, ok := ret.Get(0).(func(context.Context, int64, string) *pkgmodels.Dashboard); ok {
+		r0 = rf(ctx, orgId, dashboardUid)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*pkgmodels.Dashboard)
@@ -166,8 +166,8 @@ func (_m *FakePublicDashboardStore) FindDashboard(ctx context.Context, dashboard
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, string, int64) error); ok {
-		r1 = rf(ctx, dashboardUid, orgId)
+	if rf, ok := ret.Get(1).(func(context.Context, int64, string) error); ok {
+		r1 = rf(ctx, orgId, dashboardUid)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/services/publicdashboards/publicdashboard.go
+++ b/pkg/services/publicdashboards/publicdashboard.go
@@ -17,7 +17,7 @@ type Service interface {
 	FindPublicDashboardAndDashboardByAccessToken(ctx context.Context, accessToken string) (*PublicDashboard, *models.Dashboard, error)
 	FindByDashboardUid(ctx context.Context, orgId int64, dashboardUid string) (*PublicDashboard, error)
 	FindAnnotations(ctx context.Context, reqDTO AnnotationsQueryDTO, accessToken string) ([]AnnotationEvent, error)
-	FindDashboard(ctx context.Context, dashboardUid string, orgId int64) (*models.Dashboard, error)
+	FindDashboard(ctx context.Context, orgId int64, dashboardUid string) (*models.Dashboard, error)
 	FindAll(ctx context.Context, u *user.SignedInUser, orgId int64) ([]PublicDashboardListResponse, error)
 	Save(ctx context.Context, u *user.SignedInUser, dto *SavePublicDashboardDTO) (*PublicDashboard, error)
 
@@ -36,7 +36,7 @@ type Store interface {
 	Find(ctx context.Context, uid string) (*PublicDashboard, error)
 	FindByAccessToken(ctx context.Context, accessToken string) (*PublicDashboard, error)
 	FindByDashboardUid(ctx context.Context, orgId int64, dashboardUid string) (*PublicDashboard, error)
-	FindDashboard(ctx context.Context, dashboardUid string, orgId int64) (*models.Dashboard, error)
+	FindDashboard(ctx context.Context, orgId int64, dashboardUid string) (*models.Dashboard, error)
 	FindAll(ctx context.Context, orgId int64) ([]PublicDashboardListResponse, error)
 	Save(ctx context.Context, cmd SavePublicDashboardCommand) error
 	Update(ctx context.Context, cmd SavePublicDashboardCommand) error

--- a/pkg/services/publicdashboards/service/query_test.go
+++ b/pkg/services/publicdashboards/service/query_test.go
@@ -423,7 +423,7 @@ func TestGetAnnotations(t *testing.T) {
 		}
 		fakeStore.On("FindByAccessToken", mock.Anything, mock.AnythingOfType("string")).
 			Return(&PublicDashboard{Uid: "uid1", IsEnabled: true}, nil)
-		fakeStore.On("FindDashboard", mock.Anything, mock.AnythingOfType("string"), mock.Anything).
+		fakeStore.On("FindDashboard", mock.Anything, mock.Anything, mock.AnythingOfType("string")).
 			Return(grafanamodels.NewDashboard("dash1"), nil)
 
 		reqDTO := AnnotationsQueryDTO{
@@ -479,7 +479,7 @@ func TestGetAnnotations(t *testing.T) {
 		pubdash := &PublicDashboard{Uid: "uid1", IsEnabled: true, OrgId: 1, DashboardUid: dashboard.Uid, AnnotationsEnabled: true}
 
 		fakeStore.On("FindByAccessToken", mock.Anything, mock.AnythingOfType("string")).Return(pubdash, nil)
-		fakeStore.On("FindDashboard", mock.Anything, mock.AnythingOfType("string"), mock.Anything).Return(dashboard, nil)
+		fakeStore.On("FindDashboard", mock.Anything, mock.Anything, mock.AnythingOfType("string")).Return(dashboard, nil)
 
 		annotationsRepo.On("Find", mock.Anything, mock.Anything).Return([]*annotations.ItemDTO{
 			{
@@ -539,7 +539,7 @@ func TestGetAnnotations(t *testing.T) {
 		pubdash := &PublicDashboard{Uid: "uid1", IsEnabled: true, OrgId: 1, DashboardUid: dashboard.Uid, AnnotationsEnabled: true}
 
 		fakeStore.On("FindByAccessToken", mock.Anything, mock.AnythingOfType("string")).Return(pubdash, nil)
-		fakeStore.On("FindDashboard", mock.Anything, mock.AnythingOfType("string"), mock.Anything).Return(dashboard, nil)
+		fakeStore.On("FindDashboard", mock.Anything, mock.Anything, mock.AnythingOfType("string")).Return(dashboard, nil)
 
 		annotationsRepo.On("Find", mock.Anything, mock.Anything).Return([]*annotations.ItemDTO{
 			{
@@ -611,7 +611,7 @@ func TestGetAnnotations(t *testing.T) {
 		pubdash := &PublicDashboard{Uid: "uid1", IsEnabled: true, OrgId: 1, DashboardUid: dashboard.Uid, AnnotationsEnabled: true}
 
 		fakeStore.On("FindByAccessToken", mock.Anything, mock.AnythingOfType("string")).Return(pubdash, nil)
-		fakeStore.On("FindDashboard", mock.Anything, mock.AnythingOfType("string"), mock.Anything).Return(dashboard, nil)
+		fakeStore.On("FindDashboard", mock.Anything, mock.Anything, mock.AnythingOfType("string")).Return(dashboard, nil)
 
 		annotationsRepo.On("Find", mock.Anything, mock.Anything).Return([]*annotations.ItemDTO{
 			{
@@ -656,7 +656,7 @@ func TestGetAnnotations(t *testing.T) {
 		pubdash := &PublicDashboard{Uid: "uid1", IsEnabled: true, OrgId: 1, DashboardUid: dashboard.Uid, AnnotationsEnabled: true}
 
 		fakeStore.On("FindByAccessToken", mock.Anything, mock.AnythingOfType("string")).Return(pubdash, nil)
-		fakeStore.On("FindDashboard", mock.Anything, mock.AnythingOfType("string"), mock.Anything).Return(dashboard, nil)
+		fakeStore.On("FindDashboard", mock.Anything, mock.Anything, mock.AnythingOfType("string")).Return(dashboard, nil)
 
 		items, err := service.FindAnnotations(context.Background(), AnnotationsQueryDTO{}, "abc123")
 
@@ -691,7 +691,7 @@ func TestGetAnnotations(t *testing.T) {
 		pubdash := &PublicDashboard{Uid: "uid1", IsEnabled: true, OrgId: 1, DashboardUid: dashboard.Uid, AnnotationsEnabled: false}
 
 		fakeStore.On("FindByAccessToken", mock.Anything, mock.AnythingOfType("string")).Return(pubdash, nil)
-		fakeStore.On("FindDashboard", mock.Anything, mock.AnythingOfType("string"), mock.Anything).Return(dashboard, nil)
+		fakeStore.On("FindDashboard", mock.Anything, mock.Anything, mock.AnythingOfType("string")).Return(dashboard, nil)
 
 		items, err := service.FindAnnotations(context.Background(), AnnotationsQueryDTO{}, "abc123")
 
@@ -725,7 +725,7 @@ func TestGetAnnotations(t *testing.T) {
 		pubdash := &PublicDashboard{Uid: "uid1", IsEnabled: true, OrgId: 1, DashboardUid: dash.Uid, AnnotationsEnabled: true}
 
 		fakeStore.On("FindByAccessToken", mock.Anything, mock.AnythingOfType("string")).Return(pubdash, nil)
-		fakeStore.On("FindDashboard", mock.Anything, mock.AnythingOfType("string"), mock.Anything).Return(dash, nil)
+		fakeStore.On("FindDashboard", mock.Anything, mock.Anything, mock.AnythingOfType("string")).Return(dash, nil)
 
 		annotationsRepo.On("Find", mock.Anything, mock.Anything).Return(nil, errors.New("failed")).Maybe()
 

--- a/pkg/services/publicdashboards/service/service.go
+++ b/pkg/services/publicdashboards/service/service.go
@@ -62,13 +62,17 @@ func ProvideService(
 }
 
 // FindDashboard Gets a dashboard by Uid
-func (pd *PublicDashboardServiceImpl) FindDashboard(ctx context.Context, dashboardUid string, orgId int64) (*models.Dashboard, error) {
-	dashboard, err := pd.store.FindDashboard(ctx, dashboardUid, orgId)
+func (pd *PublicDashboardServiceImpl) FindDashboard(ctx context.Context, orgId int64, dashboardUid string) (*models.Dashboard, error) {
+	dash, err := pd.store.FindDashboard(ctx, orgId, dashboardUid)
 	if err != nil {
 		return nil, err
 	}
 
-	return dashboard, nil
+	if dash == nil {
+		return nil, dashboards.ErrDashboardNotFound
+	}
+
+	return dash, nil
 }
 
 // FindPublicDashboardAndDashboardByAccessToken Gets public dashboard via access token
@@ -90,7 +94,7 @@ func (pd *PublicDashboardServiceImpl) FindPublicDashboardAndDashboardByAccessTok
 		return nil, nil, ErrPublicDashboardNotFound
 	}
 
-	dash, err := pd.store.FindDashboard(ctx, pubdash.DashboardUid, pubdash.OrgId)
+	dash, err := pd.store.FindDashboard(ctx, pubdash.OrgId, pubdash.DashboardUid)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -105,21 +109,29 @@ func (pd *PublicDashboardServiceImpl) FindPublicDashboardAndDashboardByAccessTok
 
 // FindByDashboardUid is a helper method to retrieve the public dashboard configuration for a given dashboard from the database
 func (pd *PublicDashboardServiceImpl) FindByDashboardUid(ctx context.Context, orgId int64, dashboardUid string) (*PublicDashboard, error) {
-	pdc, err := pd.store.FindByDashboardUid(ctx, orgId, dashboardUid)
+	pubdash, err := pd.store.FindByDashboardUid(ctx, orgId, dashboardUid)
 	if err != nil {
 		return nil, err
 	}
 
-	return pdc, nil
+	if pubdash == nil {
+		return nil, ErrPublicDashboardNotFound
+	}
+
+	return pubdash, nil
 }
 
 // Save is a helper method to persist the sharing config
 // to the database. It handles validations for sharing config and persistence
 func (pd *PublicDashboardServiceImpl) Save(ctx context.Context, u *user.SignedInUser, dto *SavePublicDashboardDTO) (*PublicDashboard, error) {
 	// validate if the dashboard exists
-	dashboard, err := pd.FindDashboard(ctx, dto.DashboardUid, u.OrgID)
+	dashboard, err := pd.FindDashboard(ctx, u.OrgID, dto.DashboardUid)
 	if err != nil {
 		return nil, err
+	}
+
+	if dashboard == nil {
+		return nil, dashboards.ErrDashboardNotFound
 	}
 
 	// set default value for time settings


### PR DESCRIPTION
**What is this feature?**
* Add consistency to the store layer returning methods when resources are not found
* Not returning an error when parameters are not set, return nil instead.
* Add input validation for API method
* Create a new unit test for method without coverage
* Invert parameter order on `FindDashboard` method


**Which issue(s) does this PR fix?**:
Fixes https://github.com/grafana/grafana-enterprise/issues/4598

