### PR TITLE
[Alerting] Avoid invalid characters in copied rule expression

### DIFF
--- a/public/app/features/alerting/unified/components/Expression.test.tsx
+++ b/public/app/features/alerting/unified/components/Expression.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+import { PluginType } from '@grafana/data';
+
+import { Expression } from './Expression';
+
+const expression =
+  '100 - ( avg by ( agent_hostname ) ( rate ( node_cpu_seconds_total { mode = "idle" } [ 2h ] ) ) * 100 ) > 97';
+
+const rulesSource = {
+  id: 5,
+  uid: 'gdev-prometheus',
+  type: 'prometheus',
+  name: 'gdev-prometheus',
+  meta: {
+    id: 'prometheus',
+    type: PluginType.datasource,
+    name: 'Prometheus',
+    info: {
+      author: {
+        name: 'Grafana Labs',
+        url: 'https://grafana.com',
+      },
+      description: 'Open source time series database & alerting',
+      links: [
+        {
+          name: 'Learn more',
+          url: 'https://prometheus.io/',
+        },
+      ],
+      logos: {
+        small: 'public/app/plugins/datasource/prometheus/img/prometheus_logo.svg',
+        large: 'public/app/plugins/datasource/prometheus/img/prometheus_logo.svg',
+      },
+      build: {},
+      screenshots: [],
+      version: '',
+      updated: '',
+    },
+    module: 'app/plugins/datasource/prometheus/module',
+    baseUrl: 'public/app/plugins/datasource/prometheus',
+  },
+  url: '/api/datasources/proxy/5',
+  access: 'proxy' as 'proxy',
+  jsonData: {
+    manageAlerts: true,
+  },
+  readOnly: false,
+};
+
+describe('Expression', () => {
+  it('Should not allow to edit the text in the editor', () => {
+    render(<Expression expression={expression} rulesSource={rulesSource} />);
+
+    const editor = screen.getByTestId('expression-editor');
+    userEvent.type(editor, 'something else');
+
+    expect(editor).toHaveTextContent(expression);
+    expect(editor).not.toHaveTextContent('something else');
+  });
+});

--- a/public/app/features/alerting/unified/components/Expression.tsx
+++ b/public/app/features/alerting/unified/components/Expression.tsx
@@ -34,6 +34,7 @@ export const HighlightedQuery: FC<{ language: 'promql' | 'logql'; expr: string }
 
   const slateValue = useMemo(() => makeValue(expr), [expr]);
 
+  //We don't want to set readOnly={true} to the Editor to prevent unwanted charaters in the copied text. See https://github.com/grafana/grafana/pull/57839
   return <Editor data-testid={'expression-editor'} plugins={plugins} value={slateValue} />;
 };
 

--- a/public/app/features/alerting/unified/components/Expression.tsx
+++ b/public/app/features/alerting/unified/components/Expression.tsx
@@ -34,12 +34,11 @@ export const HighlightedQuery: FC<{ language: 'promql' | 'logql'; expr: string }
 
   const slateValue = useMemo(() => makeValue(expr), [expr]);
 
-  return <Editor plugins={plugins} value={slateValue} readOnly={true} />;
+  return <Editor data-testid={'expression-editor'} plugins={plugins} value={slateValue} />;
 };
 
 export const Expression: FC<Props> = ({ expression: query, rulesSource }) => {
   const styles = useStyles(getStyles);
-
   return (
     <Well className={cx(styles.well, 'slate-query-field')}>
       {isCloudRulesSource(rulesSource) ? (


### PR DESCRIPTION
**What is this feature?**

Allows to copy rule expressions without adding invalid characters in the pasted text.

**Why do we need this feature?**

Copying an expression and pasting it resulted in text that contained unwanted UTF-8 byte order mark characters.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/57610

**Special notes for your reviewer**:

**Before:**

![2022-10-28 13 12 07](https://user-images.githubusercontent.com/6271380/198684975-611b75d3-ff28-41d0-975e-6e98c32bbd50.gif)

**After:**

![2022-10-28 13 12 41](https://user-images.githubusercontent.com/6271380/198684996-7df1fc11-63af-42ce-8aa9-f78b78f7585b.gif)

The issue happened when the `slate-react`'s Editor had the `readOnly=true` prop. Setting it to `false` prevents it from happening, but the editor is still non-editable regardless of that. The issue is reported in the Slate repo: https://github.com/ianstormtaylor/slate/issues/2597