### PR TITLE
Scene: SceneObject and SceneObjectBase refinements and stricter typing 

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -220,9 +220,10 @@ exports[`better eslint`] = {
     "packages/grafana-data/src/events/EventBus.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
-      [0, 0, 0, "Do not use any type assertions.", "2"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "3"],
-      [0, 0, 0, "Do not use any type assertions.", "4"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
+      [0, 0, 0, "Do not use any type assertions.", "3"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "4"],
+      [0, 0, 0, "Do not use any type assertions.", "5"]
     ],
     "packages/grafana-data/src/events/common.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
@@ -4660,6 +4661,9 @@ exports[`better eslint`] = {
     "public/app/features/scenes/core/SceneComponentWrapper.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
+    ],
+    "public/app/features/scenes/core/SceneObjectBase.test.ts:5381": [
+      [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
     "public/app/features/scenes/core/SceneObjectBase.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],

--- a/.betterer.results
+++ b/.betterer.results
@@ -4669,10 +4669,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
-      [0, 0, 0, "Do not use any type assertions.", "3"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "4"],
-      [0, 0, 0, "Do not use any type assertions.", "5"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "6"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "3"],
+      [0, 0, 0, "Do not use any type assertions.", "4"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "5"]
     ],
     "public/app/features/scenes/core/SceneTimeRange.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],

--- a/.betterer.results
+++ b/.betterer.results
@@ -220,10 +220,9 @@ exports[`better eslint`] = {
     "packages/grafana-data/src/events/EventBus.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
-      [0, 0, 0, "Do not use any type assertions.", "3"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "4"],
-      [0, 0, 0, "Do not use any type assertions.", "5"]
+      [0, 0, 0, "Do not use any type assertions.", "2"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "3"],
+      [0, 0, 0, "Do not use any type assertions.", "4"]
     ],
     "packages/grafana-data/src/events/common.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],

--- a/packages/grafana-data/src/events/EventBus.test.ts
+++ b/packages/grafana-data/src/events/EventBus.test.ts
@@ -181,15 +181,18 @@ describe('EventBus', () => {
     it('removeAllListeners should unsubscribe to all', () => {
       const bus = new EventBusSrv();
       const events: LoginEvent[] = [];
+      let completed = false;
 
-      bus.subscribe(LoginEvent, (event) => {
-        events.push(event);
+      bus.getStream(LoginEvent).subscribe({
+        next: (evt) => events.push(evt),
+        complete: () => (completed = true),
       });
 
       bus.removeAllListeners();
       bus.publish(new LoginEvent({ logins: 10 }));
 
       expect(events.length).toBe(0);
+      expect(completed).toBe(true);
     });
   });
 });

--- a/packages/grafana-data/src/events/EventBus.ts
+++ b/packages/grafana-data/src/events/EventBus.ts
@@ -18,7 +18,7 @@ import {
  */
 export class EventBusSrv implements EventBus, LegacyEmitter {
   private emitter: EventEmitter;
-  private subscribers = new Map<BusEventHandler<any>, Subscriber<BusEvent>>();
+  private subscribers = new Map<Function, Subscriber<BusEvent>>();
 
   constructor() {
     this.emitter = new EventEmitter();
@@ -32,7 +32,7 @@ export class EventBusSrv implements EventBus, LegacyEmitter {
     return this.getStream(typeFilter).subscribe({ next: handler });
   }
 
-  getStream<T extends BusEvent>(eventType: BusEventType<T>): Observable<T> {
+  getStream<T extends BusEvent = BusEvent>(eventType: BusEventType<T>): Observable<T> {
     return new Observable<T>((observer) => {
       const handler = (event: T) => {
         observer.next(event);

--- a/packages/grafana-data/src/events/types.ts
+++ b/packages/grafana-data/src/events/types.ts
@@ -68,7 +68,7 @@ export interface EventFilterOptions {
  */
 export interface EventBus {
   /**
-   * Publish single vent
+   * Publish single event
    */
   publish<T extends BusEvent>(event: T): void;
 

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -12606,6 +12606,9 @@
         "auth_password": {
           "$ref": "#/definitions/Secret"
         },
+        "auth_password_file": {
+          "type": "string"
+        },
         "auth_secret": {
           "$ref": "#/definitions/Secret"
         },
@@ -13518,6 +13521,9 @@
         },
         "smtp_auth_password": {
           "$ref": "#/definitions/Secret"
+        },
+        "smtp_auth_password_file": {
+          "type": "string"
         },
         "smtp_auth_secret": {
           "$ref": "#/definitions/Secret"
@@ -17273,6 +17279,9 @@
             "type": "string"
           }
         },
+        "location": {
+          "type": "string"
+        },
         "months": {
           "type": "array",
           "items": {
@@ -18323,7 +18332,6 @@
       }
     },
     "alertGroup": {
-      "description": "AlertGroup alert group",
       "type": "object",
       "required": [
         "alerts",
@@ -18515,7 +18523,6 @@
       }
     },
     "gettableSilence": {
-      "description": "GettableSilence gettable silence",
       "type": "object",
       "required": [
         "comment",
@@ -18564,13 +18571,13 @@
       }
     },
     "gettableSilences": {
-      "description": "GettableSilences gettable silences",
       "type": "array",
       "items": {
         "$ref": "#/definitions/gettableSilence"
       }
     },
     "integration": {
+      "description": "Integration integration",
       "type": "object",
       "required": [
         "name",
@@ -18667,6 +18674,15 @@
         }
       }
     },
+    "postSilencesOKBody": {
+      "type": "object",
+      "properties": {
+        "silenceID": {
+          "description": "silence ID",
+          "type": "string"
+        }
+      }
+    },
     "postableAlert": {
       "description": "PostableAlert postable alert",
       "type": "object",
@@ -18705,7 +18721,6 @@
       }
     },
     "postableSilence": {
-      "description": "PostableSilence postable silence",
       "type": "object",
       "required": [
         "comment",
@@ -18743,6 +18758,7 @@
       }
     },
     "receiver": {
+      "description": "Receiver receiver",
       "type": "object",
       "required": [
         "active",
@@ -19933,6 +19949,15 @@
       "description": "(empty)",
       "schema": {
         "$ref": "#/definitions/QueryDataResponse"
+      }
+    },
+    "receiversResponse": {
+      "description": "(empty)",
+      "schema": {
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/receiver"
+        }
       }
     },
     "recordingRuleResponse": {

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -12606,9 +12606,6 @@
         "auth_password": {
           "$ref": "#/definitions/Secret"
         },
-        "auth_password_file": {
-          "type": "string"
-        },
         "auth_secret": {
           "$ref": "#/definitions/Secret"
         },
@@ -13521,9 +13518,6 @@
         },
         "smtp_auth_password": {
           "$ref": "#/definitions/Secret"
-        },
-        "smtp_auth_password_file": {
-          "type": "string"
         },
         "smtp_auth_secret": {
           "$ref": "#/definitions/Secret"
@@ -17279,9 +17273,6 @@
             "type": "string"
           }
         },
-        "location": {
-          "type": "string"
-        },
         "months": {
           "type": "array",
           "items": {
@@ -18332,6 +18323,7 @@
       }
     },
     "alertGroup": {
+      "description": "AlertGroup alert group",
       "type": "object",
       "required": [
         "alerts",
@@ -18523,6 +18515,7 @@
       }
     },
     "gettableSilence": {
+      "description": "GettableSilence gettable silence",
       "type": "object",
       "required": [
         "comment",
@@ -18571,13 +18564,13 @@
       }
     },
     "gettableSilences": {
+      "description": "GettableSilences gettable silences",
       "type": "array",
       "items": {
         "$ref": "#/definitions/gettableSilence"
       }
     },
     "integration": {
-      "description": "Integration integration",
       "type": "object",
       "required": [
         "name",
@@ -18674,15 +18667,6 @@
         }
       }
     },
-    "postSilencesOKBody": {
-      "type": "object",
-      "properties": {
-        "silenceID": {
-          "description": "silence ID",
-          "type": "string"
-        }
-      }
-    },
     "postableAlert": {
       "description": "PostableAlert postable alert",
       "type": "object",
@@ -18721,6 +18705,7 @@
       }
     },
     "postableSilence": {
+      "description": "PostableSilence postable silence",
       "type": "object",
       "required": [
         "comment",
@@ -18758,7 +18743,6 @@
       }
     },
     "receiver": {
-      "description": "Receiver receiver",
       "type": "object",
       "required": [
         "active",
@@ -19949,15 +19933,6 @@
       "description": "(empty)",
       "schema": {
         "$ref": "#/definitions/QueryDataResponse"
-      }
-    },
-    "receiversResponse": {
-      "description": "(empty)",
-      "schema": {
-        "type": "array",
-        "items": {
-          "$ref": "#/definitions/receiver"
-        }
       }
     },
     "recordingRuleResponse": {

--- a/public/app/features/scenes/components/ScenePanelRepeater.tsx
+++ b/public/app/features/scenes/components/ScenePanelRepeater.tsx
@@ -21,7 +21,7 @@ export class ScenePanelRepeater extends SceneObjectBase<RepeatOptions> {
     super.activate();
 
     this.subs.add(
-      this.getData().subscribe({
+      this.getData().subscribeToState({
         next: (data) => {
           if (data.data?.state === LoadingState.Done) {
             this.performRepeat(data.data);

--- a/public/app/features/scenes/core/SceneObjectBase.test.ts
+++ b/public/app/features/scenes/core/SceneObjectBase.test.ts
@@ -120,11 +120,11 @@ describe('SceneObject', () => {
       expect(scene.isActive).toBe(false);
     });
 
-    it('Should activate $data', () => {
+    it('Should deactivate $data', () => {
       expect(scene.state.$data!.isActive).toBe(false);
     });
 
-    it('Should activate $variables', () => {
+    it('Should deactivate $variables', () => {
       expect(scene.state.$variables!.isActive).toBe(false);
     });
   });

--- a/public/app/features/scenes/core/SceneObjectBase.test.ts
+++ b/public/app/features/scenes/core/SceneObjectBase.test.ts
@@ -1,4 +1,8 @@
+import { SceneVariableSet } from '../variables/sets/SceneVariableSet';
+
+import { SceneDataNode } from './SceneDataNode';
 import { SceneObjectBase } from './SceneObjectBase';
+import { SceneObjectStateChangedEvent } from './events';
 import { SceneLayoutChild, SceneObject, SceneObjectStatePlain } from './types';
 
 interface TestSceneState extends SceneObjectStatePlain {
@@ -64,5 +68,58 @@ describe('SceneObject', () => {
 
     const clone = scene.clone({ name: 'new name' });
     expect(clone.state.name).toBe('new name');
+  });
+
+  describe('When activated', () => {
+    const scene = new TestScene({
+      $data: new SceneDataNode({}),
+      $variables: new SceneVariableSet({ variables: [] }),
+    });
+
+    scene.activate();
+
+    it('Should set isActive true', () => {
+      expect(scene.isActive).toBe(true);
+    });
+
+    it('Should activate $data', () => {
+      expect(scene.state.$data!.isActive).toBe(true);
+    });
+
+    it('Should activate $variables', () => {
+      expect(scene.state.$variables!.isActive).toBe(true);
+    });
+  });
+
+  describe('When deactivated', () => {
+    const scene = new TestScene({
+      $data: new SceneDataNode({}),
+      $variables: new SceneVariableSet({ variables: [] }),
+    });
+
+    scene.activate();
+
+    // Subscribe to state change and to event
+    const stateSub = scene.subscribe({ next: () => {} });
+    const eventSub = scene.events.subscribe(SceneObjectStateChangedEvent, () => {});
+
+    scene.deactivate();
+
+    it('Should close subscriptions', () => {
+      expect(stateSub.closed).toBe(true);
+      expect((eventSub as any).closed).toBe(true);
+    });
+
+    it('Should set isActive false', () => {
+      expect(scene.isActive).toBe(false);
+    });
+
+    it('Should activate $data', () => {
+      expect(scene.state.$data!.isActive).toBe(false);
+    });
+
+    it('Should activate $variables', () => {
+      expect(scene.state.$variables!.isActive).toBe(false);
+    });
   });
 });

--- a/public/app/features/scenes/core/SceneObjectBase.test.ts
+++ b/public/app/features/scenes/core/SceneObjectBase.test.ts
@@ -32,7 +32,7 @@ describe('SceneObject', () => {
     const clone = scene.clone();
     expect(clone).not.toBe(scene);
     expect(clone.state.nested).not.toBe(scene.state.nested);
-    expect(clone.state.nested?.isActive).toBe(undefined);
+    expect(clone.state.nested?.isActive).toBe(false);
     expect(clone.state.children![0]).not.toBe(scene.state.children![0]);
   });
 

--- a/public/app/features/scenes/core/SceneObjectBase.test.ts
+++ b/public/app/features/scenes/core/SceneObjectBase.test.ts
@@ -20,6 +20,11 @@ describe('SceneObject', () => {
       nested: new TestScene({
         name: 'nested',
       }),
+      actions: [
+        new TestScene({
+          name: 'action child',
+        }),
+      ],
       children: [
         new TestScene({
           name: 'layout child',
@@ -34,6 +39,7 @@ describe('SceneObject', () => {
     expect(clone.state.nested).not.toBe(scene.state.nested);
     expect(clone.state.nested?.isActive).toBe(false);
     expect(clone.state.children![0]).not.toBe(scene.state.children![0]);
+    expect(clone.state.actions![0]).not.toBe(scene.state.actions![0]);
   });
 
   it('SceneObject should have parent when added to container', () => {

--- a/public/app/features/scenes/core/SceneObjectBase.test.ts
+++ b/public/app/features/scenes/core/SceneObjectBase.test.ts
@@ -1,4 +1,4 @@
-import { SceneVariableSet } from '../variables/sets/SceneVariableSet';
+import { SceneVariableSet } from '../variables/SceneVariableSet';
 
 import { SceneDataNode } from './SceneDataNode';
 import { SceneObjectBase } from './SceneObjectBase';
@@ -100,8 +100,8 @@ describe('SceneObject', () => {
     scene.activate();
 
     // Subscribe to state change and to event
-    const stateSub = scene.subscribe({ next: () => {} });
-    const eventSub = scene.events.subscribe(SceneObjectStateChangedEvent, () => {});
+    const stateSub = scene.subscribeToState({ next: () => {} });
+    const eventSub = scene.subscribeToEvent(SceneObjectStateChangedEvent, () => {});
 
     scene.deactivate();
 

--- a/public/app/features/scenes/core/SceneObjectBase.tsx
+++ b/public/app/features/scenes/core/SceneObjectBase.tsx
@@ -74,8 +74,8 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = {}> impl
 
       if (Array.isArray(propValue)) {
         for (const child of propValue) {
-          if (propValue instanceof SceneObjectBase) {
-            child.parent = this;
+          if (child instanceof SceneObjectBase) {
+            child._parent = this;
           }
         }
       }

--- a/public/app/features/scenes/core/SceneObjectBase.tsx
+++ b/public/app/features/scenes/core/SceneObjectBase.tsx
@@ -10,11 +10,11 @@ import { SceneObjectStateChangedEvent } from './events';
 import { SceneDataState, SceneObject, SceneComponent, SceneEditor, SceneTimeRange, SceneObjectState } from './types';
 
 export abstract class SceneObjectBase<TState extends SceneObjectState = {}> implements SceneObject<TState> {
-  events = new EventBusSrv();
-
   private _isActive = false;
   private _subject = new Subject<TState>();
   private _state: TState;
+  private _events = new EventBusSrv();
+
   protected _parent?: SceneObject;
   protected subs = new Subscription();
 
@@ -85,7 +85,7 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = {}> impl
    * Subscribe to the scene event
    **/
   subscribeToEvent<T extends BusEvent>(eventType: BusEventType<T>, handler: BusEventHandler<T>): Unsubscribable {
-    return this.events.subscribe(eventType, handler);
+    return this._events.subscribe(eventType, handler);
   }
 
   setState(update: Partial<TState>) {
@@ -113,10 +113,10 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = {}> impl
    * Publish an event and optionally bubble it up the scene
    **/
   publishEvent(event: BusEvent, bubble?: boolean) {
-    this.events.publish(event);
+    this._events.publish(event);
 
     if (bubble && this.parent) {
-      this.parent.publishEvent(event);
+      this.parent.publishEvent(event, bubble);
     }
   }
 
@@ -152,7 +152,7 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = {}> impl
     }
 
     // Clear subscriptions and listeners
-    this.events.removeAllListeners();
+    this._events.removeAllListeners();
     this.subs.unsubscribe();
     this.subs = new Subscription();
 

--- a/public/app/features/scenes/core/SceneObjectBase.tsx
+++ b/public/app/features/scenes/core/SceneObjectBase.tsx
@@ -7,15 +7,7 @@ import { useForceUpdate } from '@grafana/ui';
 
 import { SceneComponentWrapper } from './SceneComponentWrapper';
 import { SceneObjectStateChangedEvent } from './events';
-import {
-  SceneDataState,
-  SceneObject,
-  SceneComponent,
-  SceneEditor,
-  SceneTimeRange,
-  SceneObjectState,
-  SceneLayoutChild,
-} from './types';
+import { SceneDataState, SceneObject, SceneComponent, SceneEditor, SceneTimeRange, SceneObjectState } from './types';
 
 export abstract class SceneObjectBase<TState extends SceneObjectState = {}> implements SceneObject<TState> {
   events = new EventBusSrv();
@@ -233,15 +225,19 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = {}> impl
       if (propValue instanceof SceneObjectBase) {
         clonedState[key] = propValue.clone();
       }
-    }
 
-    // Clone layout children
-    if ('children' in this.state) {
-      const newChildren: SceneLayoutChild[] = [];
-      for (const child of this.state.children) {
-        newChildren.push(child.clone());
+      // Clone scene objects in arrays
+      if (Array.isArray(propValue)) {
+        const newArray: any = [];
+        for (const child of propValue) {
+          if (child instanceof SceneObjectBase) {
+            newArray.push(child.clone());
+          } else {
+            newArray.push(child);
+          }
+        }
+        clonedState[key] = newArray;
       }
-      (clonedState as any).children = newChildren;
     }
 
     Object.assign(clonedState, withState);

--- a/public/app/features/scenes/core/SceneObjectBase.tsx
+++ b/public/app/features/scenes/core/SceneObjectBase.tsx
@@ -121,7 +121,7 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = {}> impl
   }
 
   getRoot(): SceneObject {
-    return !this.parent ? this : this.parent.getRoot();
+    return !this._parent ? this : this._parent.getRoot();
   }
 
   activate() {

--- a/public/app/features/scenes/core/events.ts
+++ b/public/app/features/scenes/core/events.ts
@@ -12,3 +12,10 @@ export interface SceneObjectStateChangedPayload {
 export class SceneObjectStateChangedEvent extends BusEventWithPayload<SceneObjectStateChangedPayload> {
   static type = 'scene-object-state-change';
 }
+
+export class SceneObjectActivedEvent extends BusEventWithPayload<SceneObject> {
+  static type = 'scene-object-activated';
+}
+export class SceneObjectDeactivatedEvent extends BusEventWithPayload<SceneObject> {
+  static type = 'scene-object-deactivated';
+}

--- a/public/app/features/scenes/core/types.ts
+++ b/public/app/features/scenes/core/types.ts
@@ -46,7 +46,7 @@ export interface SceneObject<TState extends SceneObjectState = SceneObjectState>
   readonly state: TState;
 
   /** True when there is a React component mounted for this Object */
-  readonly isActive?: boolean;
+  readonly isActive: boolean;
 
   /** SceneObject parent */
   readonly parent?: SceneObject;
@@ -69,7 +69,7 @@ export interface SceneObject<TState extends SceneObjectState = SceneObjectState>
   /** Called when the Component is mounted. A place to register event listeners add subscribe to state changes */
   activate(): void;
 
-  /** Called when component unmounts. Unsubscribe to events */
+  /** Called when component unmounts. Unsubscribe and closes all subscriptions  */
   deactivate(): void;
 
   /** Get the scene editor */

--- a/public/app/features/scenes/core/types.ts
+++ b/public/app/features/scenes/core/types.ts
@@ -1,16 +1,16 @@
 import React from 'react';
-import { Subscribable } from 'rxjs';
+import { Observer, Subscription, Unsubscribable } from 'rxjs';
 
-import { EventBus, PanelData, TimeRange, UrlQueryMap } from '@grafana/data';
+import { BusEvent, BusEventHandler, BusEventType, PanelData, TimeRange, UrlQueryMap } from '@grafana/data';
 
-import { SceneVariableSet } from '../variables/types';
+import { SceneVariables } from '../variables/types';
 
 export interface SceneObjectStatePlain {
   key?: string;
   $timeRange?: SceneTimeRange;
   $data?: SceneObject<SceneDataState>;
   $editor?: SceneEditor;
-  $variables?: SceneVariableSet;
+  $variables?: SceneVariables;
 }
 
 export interface SceneLayoutChildState extends SceneObjectStatePlain {
@@ -41,7 +41,7 @@ export interface SceneDataState extends SceneObjectStatePlain {
   data?: PanelData;
 }
 
-export interface SceneObject<TState extends SceneObjectState = SceneObjectState> extends Subscribable<TState> {
+export interface SceneObject<TState extends SceneObjectState = SceneObjectState> {
   /** The current state */
   state: TState;
 
@@ -51,8 +51,11 @@ export interface SceneObject<TState extends SceneObjectState = SceneObjectState>
   /** SceneObject parent */
   parent?: SceneObject;
 
-  /** Currently only used from root to broadcast events */
-  events: EventBus;
+  /** Subscribe to state changes */
+  subscribeToState(observer?: Partial<Observer<TState>>): Subscription;
+
+  /** Subscribe to a scene event */
+  subscribeToEvent<T extends BusEvent>(typeFilter: BusEventType<T>, handler: BusEventHandler<T>): Unsubscribable;
 
   /** Utility hook that wraps useObservable. Used by React components to subscribes to state changes */
   useState(): TState;

--- a/public/app/features/scenes/core/types.ts
+++ b/public/app/features/scenes/core/types.ts
@@ -43,19 +43,22 @@ export interface SceneDataState extends SceneObjectStatePlain {
 
 export interface SceneObject<TState extends SceneObjectState = SceneObjectState> {
   /** The current state */
-  state: TState;
+  readonly state: TState;
 
   /** True when there is a React component mounted for this Object */
-  isActive?: boolean;
+  readonly isActive?: boolean;
 
   /** SceneObject parent */
-  parent?: SceneObject;
+  readonly parent?: SceneObject;
 
   /** Subscribe to state changes */
   subscribeToState(observer?: Partial<Observer<TState>>): Subscription;
 
   /** Subscribe to a scene event */
   subscribeToEvent<T extends BusEvent>(typeFilter: BusEventType<T>, handler: BusEventHandler<T>): Unsubscribable;
+
+  /** Publish an event and optionally bubble it up the scene */
+  publishEvent(event: BusEvent, bubble?: boolean): void;
 
   /** Utility hook that wraps useObservable. Used by React components to subscribes to state changes */
   useState(): TState;
@@ -71,6 +74,15 @@ export interface SceneObject<TState extends SceneObjectState = SceneObjectState>
 
   /** Get the scene editor */
   getSceneEditor(): SceneEditor;
+
+  /** Get the scene root */
+  getRoot(): SceneObject;
+
+  /** Get the closest node with data */
+  getData(): SceneObject<SceneDataState>;
+
+  /** Get the closest node with time range */
+  getTimeRange(): SceneTimeRange;
 
   /** Returns a deep clone this object and all its children */
   clone(state?: Partial<TState>): this;

--- a/public/app/features/scenes/querying/SceneQueryRunner.ts
+++ b/public/app/features/scenes/querying/SceneQueryRunner.ts
@@ -37,7 +37,7 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> {
     const timeRange = this.getTimeRange();
 
     this.subs.add(
-      timeRange.subscribe({
+      timeRange.subscribeToState({
         next: (timeRange) => {
           this.runWithTimeRange(timeRange);
         },

--- a/public/app/features/scenes/services/UrlSyncManager.ts
+++ b/public/app/features/scenes/services/UrlSyncManager.ts
@@ -11,7 +11,7 @@ export class UrlSyncManager {
   private stateChangeSub: Unsubscribable;
 
   constructor(sceneRoot: SceneObject) {
-    this.stateChangeSub = sceneRoot.events.subscribe(SceneObjectStateChangedEvent, this.onStateChanged);
+    this.stateChangeSub = sceneRoot.subscribeToEvent(SceneObjectStateChangedEvent, this.onStateChanged);
     this.locationListenerUnsub = locationService.getHistory().listen(this.onLocationUpdate);
   }
 

--- a/public/app/features/scenes/variables/SceneVariableSet.test.ts
+++ b/public/app/features/scenes/variables/SceneVariableSet.test.ts
@@ -1,7 +1,7 @@
 import { SceneObjectBase } from '../core/SceneObjectBase';
 import { SceneObjectStatePlain } from '../core/types';
 
-import { sceneTemplateInterpolator, SceneVariableManager, TextBoxSceneVariable } from './SceneVariableSet';
+import { sceneTemplateInterpolator, SceneVariableSet, TextBoxSceneVariable } from './SceneVariableSet';
 
 interface TestSceneState extends SceneObjectStatePlain {
   nested?: TestScene;
@@ -12,7 +12,7 @@ class TestScene extends SceneObjectBase<TestSceneState> {}
 describe('SceneObject with variables', () => {
   it('Should be interpolate and use closest variable', () => {
     const scene = new TestScene({
-      $variables: new SceneVariableManager({
+      $variables: new SceneVariableSet({
         variables: [
           new TextBoxSceneVariable({
             name: 'test',
@@ -25,7 +25,7 @@ describe('SceneObject with variables', () => {
         ],
       }),
       nested: new TestScene({
-        $variables: new SceneVariableManager({
+        $variables: new SceneVariableSet({
           variables: [
             new TextBoxSceneVariable({
               name: 'test',

--- a/public/app/features/scenes/variables/SceneVariableSet.ts
+++ b/public/app/features/scenes/variables/SceneVariableSet.ts
@@ -3,11 +3,11 @@ import { variableRegex } from 'app/features/variables/utils';
 import { SceneObjectBase } from '../core/SceneObjectBase';
 import { SceneObject } from '../core/types';
 
-import { SceneVariable, SceneVariableSet, SceneVariableSetState, SceneVariableState } from './types';
+import { SceneVariable, SceneVariables, SceneVariableSetState, SceneVariableState } from './types';
 
 export class TextBoxSceneVariable extends SceneObjectBase<SceneVariableState> implements SceneVariable {}
 
-export class SceneVariableManager extends SceneObjectBase<SceneVariableSetState> implements SceneVariableSet {
+export class SceneVariableSet extends SceneObjectBase<SceneVariableSetState> implements SceneVariables {
   getVariableByName(name: string): SceneVariable | undefined {
     // TODO: Replace with index
     return this.state.variables.find((x) => x.state.name === name);

--- a/public/app/features/scenes/variables/types.ts
+++ b/public/app/features/scenes/variables/types.ts
@@ -19,6 +19,6 @@ export interface SceneVariableSetState extends SceneObjectStatePlain {
   variables: SceneVariable[];
 }
 
-export interface SceneVariableSet extends SceneObject<SceneVariableSetState> {
+export interface SceneVariables extends SceneObject<SceneVariableSetState> {
   getVariableByName(name: string): SceneVariable | undefined;
 }


### PR DESCRIPTION
Extracted some model changes from https://github.com/grafana/grafana/pull/57784  to this separate PR and built on it a bit more

* Try to lock down props more (readonly, protected etc) to prevent changes of props that should not be allowed 
* Makes some things private in SceneObjectBase 
* Fixes so that active activates $variables 
* Fixes to that deactivate remove all subs and event subscriptions (adds some tests for this) 
* Fixes an issue in EventBus where removeAllListeners did not complete all currently open subscribers   
* Fixes so that clone clones all child scene objects (in arrays no matter their name, not just children) 

**SceneObject events and subscribe**
Changes so that SceneObject no longer implements `Subscribable<TState>` (rxjs) as this interface has a subscribe method. And felt that having sceneObject.events.subscribe and sceneObject.subscribe was a bit confusing. So instead this PR changes so we have two methods named 
`subscribeToState` and `subscribeToEvent`. So this means I removed the events prop from SceneObject, feels better to not expose the EventBus interface directly. 
 
An alternative would be getStateStream, and getEventStream (that return Observable<T>). It's a bit more verbose to use then, I like the simplicity and readability of subscribeToState vs getStateStream().subscribe(). But can be more easily composed by rxjs operators. But if we needed that it would be easy to create an Observable wrapper. 

**Events**
* adds `publishEvent(evt, bubble?: boolean)` makes state change events bubble by default, useful for VariableSet to subscribe to changes to child variables).  Used by https://github.com/grafana/grafana/pull/57784 

