### PR TITLE
Dashboards: Provide better error messages in SaveDashboardAsForm

### DIFF
--- a/public/app/features/dashboard/components/SaveDashboard/forms/SaveDashboardAsForm.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/forms/SaveDashboardAsForm.tsx
@@ -62,8 +62,8 @@ export const SaveDashboardAsForm: React.FC<SaveDashboardAsFormProps> = ({
     try {
       await validationSrv.validateNewDashboardName(getFormValues().$folder.id, dashboardName);
       return true;
-    } catch (e: any) {
-      return 'message' in e ? e.message : 'Dashboard name is invalid';
+    } catch (e) {
+      return e instanceof Error ? e.message : 'Dashboard name is invalid';
     }
   };
 

--- a/public/app/features/dashboard/components/SaveDashboard/forms/SaveDashboardAsForm.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/forms/SaveDashboardAsForm.tsx
@@ -62,8 +62,8 @@ export const SaveDashboardAsForm: React.FC<SaveDashboardAsFormProps> = ({
     try {
       await validationSrv.validateNewDashboardName(getFormValues().$folder.id, dashboardName);
       return true;
-    } catch (e) {
-      return e instanceof Error ? e.message : 'Dashboard name is invalid';
+    } catch (e: any) {
+      return 'message' in e ? e.message : 'Dashboard name is invalid';
     }
   };
 

--- a/public/app/features/manage-dashboards/services/ValidationSrv.ts
+++ b/public/app/features/manage-dashboards/services/ValidationSrv.ts
@@ -5,6 +5,15 @@ const hitTypes = {
   DASHBOARD: 'dash-db',
 };
 
+class ValidationError extends Error {
+  type: string;
+
+  constructor(type: string, message: string) {
+    super(message);
+    this.type = type;
+  }
+}
+
 export class ValidationSrv {
   rootName = 'general';
 
@@ -21,17 +30,11 @@ export class ValidationSrv {
     const nameLowerCased = name.toLowerCase();
 
     if (name.length === 0) {
-      throw {
-        type: 'REQUIRED',
-        message: 'Name is required',
-      };
+      throw new ValidationError('REQUIRED', 'Name is required');
     }
 
     if (folderId === 0 && nameLowerCased === this.rootName) {
-      throw {
-        type: 'EXISTING',
-        message: 'This is a reserved name and cannot be used for a folder.',
-      };
+      throw new ValidationError('EXISTING', 'This is a reserved name and cannot be used for a folder.');
     }
 
     const promises = [];
@@ -51,10 +54,7 @@ export class ValidationSrv {
 
     for (const hit of hits) {
       if (nameLowerCased === hit.title.toLowerCase()) {
-        throw {
-          type: 'EXISTING',
-          message: existingErrorMessage,
-        };
+        throw new ValidationError('EXISTING', existingErrorMessage);
       }
     }
 


### PR DESCRIPTION
The existing code uses `instanceof Error` to check for a `message` field on the thrown object. The objects that are thrown are never instances of the error interface. This change locally uses `any` so we can check for a `message` field to display instead.