### PR TITLE
Datasource Loki: preserve header `X-ID-Token` towards Loki backend wh…

### DIFF
--- a/pkg/tsdb/loki/auth_test.go
+++ b/pkg/tsdb/loki/auth_test.go
@@ -53,7 +53,7 @@ func TestOauthForwardIdentity(t *testing.T) {
 		auth   bool
 		cookie bool
 	}{
-		{name: "when auth header exists => add auth header", auth: true, cookie: false},
+		{name: "when auth headers exist => add auth headers", auth: true, cookie: false},
 		{name: "when cookie header exists => add cookie header", auth: false, cookie: true},
 		{name: "when cookie&auth headers exist => add cookie&auth headers", auth: true, cookie: true},
 		{name: "when no header exists => do not add headers", auth: false, cookie: false},
@@ -63,6 +63,8 @@ func TestOauthForwardIdentity(t *testing.T) {
 	authValue := "auth"
 	cookieName := "Cookie"
 	cookieValue := "a=1"
+	idTokenName := "X-ID-Token"
+	idTokenValue := "idtoken"
 
 	for _, test := range tt {
 		t.Run("QueryData: "+test.name, func(t *testing.T) {
@@ -91,10 +93,13 @@ func TestOauthForwardIdentity(t *testing.T) {
 				// as an array
 				authValues := req.Header.Values(authName)
 				cookieValues := req.Header.Values(cookieName)
+				idTokenValues := req.Header.Values(idTokenName)
 				if test.auth {
 					require.Equal(t, []string{authValue}, authValues)
+					require.Equal(t, []string{idTokenValue}, idTokenValues)
 				} else {
 					require.Len(t, authValues, 0)
+					require.Len(t, idTokenValues, 0)
 				}
 				if test.cookie {
 					require.Equal(t, []string{cookieValue}, cookieValues)
@@ -115,6 +120,7 @@ func TestOauthForwardIdentity(t *testing.T) {
 
 			if test.auth {
 				req.Headers[authName] = authValue
+				req.Headers[idTokenName] = idTokenValue
 			}
 
 			if test.cookie {
@@ -146,13 +152,16 @@ func TestOauthForwardIdentity(t *testing.T) {
 				clientUsed = true
 				authValues := req.Header.Values(authName)
 				cookieValues := req.Header.Values(cookieName)
+				idTokenValues := req.Header.Values(idTokenName)
 				// we need to check for "header does not exist",
 				// and the only way i can find is to get the values
 				// as an array
 				if test.auth {
 					require.Equal(t, []string{authValue}, authValues)
+					require.Equal(t, []string{idTokenValue}, idTokenValues)
 				} else {
 					require.Len(t, authValues, 0)
+					require.Len(t, idTokenValues, 0)
 				}
 				if test.cookie {
 					require.Equal(t, []string{cookieValue}, cookieValues)
@@ -169,6 +178,7 @@ func TestOauthForwardIdentity(t *testing.T) {
 
 			if test.auth {
 				req.Headers[authName] = []string{authValue}
+				req.Headers[idTokenName] = []string{idTokenValue}
 			}
 			if test.cookie {
 				req.Headers[cookieName] = []string{cookieValue}

--- a/pkg/tsdb/loki/loki.go
+++ b/pkg/tsdb/loki/loki.go
@@ -130,6 +130,10 @@ func getAuthHeadersForCallResource(headers map[string][]string) map[string]strin
 		data["Cookie"] = cookie
 	}
 
+	if idToken := arrayHeaderFirstValue(headers["X-ID-Token"]); idToken != "" {
+		data["X-ID-Token"] = idToken
+	}
+
 	return data
 }
 


### PR DESCRIPTION
**What is this feature?**
Provides backends of Loki datasource with the user ID token, when `Forward OAuth Identity` is enabled on datasource level.

**Why do we need this feature?**
To improve authentication towards OAuth-oriented Loki backends.

**Who is this feature for?**
Grafana administrators and datasource operators configuring authentication for Grafana datasources and their backends.

**Which issue(s) does this PR fix?**:
Fixes #57870