### PR TITLE
CloudWatch: Fix broken test

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchMetricsQueryRunner.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchMetricsQueryRunner.test.ts
@@ -572,6 +572,10 @@ describe('CloudWatchMetricsQueryRunner', () => {
   });
 
   describe('timezoneUTCOffset', () => {
+    afterEach(() => {
+      jest.resetAllMocks();
+    });
+
     const testQuery = {
       id: '',
       refId: 'a',
@@ -595,6 +599,7 @@ describe('CloudWatchMetricsQueryRunner', () => {
       ['UTC', '+0000'],
     ];
     describe.each(testTable)('should use the right time zone offset', (ianaTimezone, expectedOffset) => {
+      jest.useFakeTimers().setSystemTime(new Date('2022-09-01'));
       const { runner, fetchMock, request } = setupMockedMetricsQueryRunner();
       runner.handleMetricQueries([testQuery], {
         ...request,

--- a/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchMetricsQueryRunner.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchMetricsQueryRunner.test.ts
@@ -572,8 +572,11 @@ describe('CloudWatchMetricsQueryRunner', () => {
   });
 
   describe('timezoneUTCOffset', () => {
+    beforeEach(() => {
+      jest.useFakeTimers().setSystemTime(new Date('2022-09-01'));
+    });
     afterEach(() => {
-      jest.resetAllMocks();
+      jest.useFakeTimers().clearAllTimers();
     });
 
     const testQuery = {
@@ -598,8 +601,7 @@ describe('CloudWatchMetricsQueryRunner', () => {
       ['Asia/Tokyo', '+0900'],
       ['UTC', '+0000'],
     ];
-    describe.each(testTable)('should use the right time zone offset', (ianaTimezone, expectedOffset) => {
-      jest.useFakeTimers().setSystemTime(new Date('2022-09-01'));
+    test.each(testTable)('should use the right time zone offset', (ianaTimezone, expectedOffset) => {
       const { runner, fetchMock, request } = setupMockedMetricsQueryRunner();
       runner.handleMetricQueries([testQuery], {
         ...request,


### PR DESCRIPTION
**What is this feature?**

This PR mocks the response of `Date.now` in a test that asserted on timezone offsets. 
