### PR TITLE
Schema: Add dashboard json fixture for tests

### DIFF
--- a/packages/grafana-schema/src/index.gen.ts
+++ b/packages/grafana-schema/src/index.gen.ts
@@ -11,33 +11,33 @@ export type {
   DashboardLink,
   DashboardLinkType,
   VariableType,
-  FieldColorModeId,
   FieldColorSeriesByMode,
   FieldColor,
   GridPos,
   Threshold,
-  ThresholdsMode,
   ThresholdsConfig,
   ValueMapping,
-  MappingType,
   ValueMap,
   RangeMap,
   RegexMap,
   SpecialValueMap,
-  SpecialValueMatch,
   ValueMappingResult,
   Transformation,
-  DashboardCursorSync,
   MatcherConfig,
   RowPanel
 } from './raw/dashboard/x/dashboard.gen';
 
-// Raw generated default consts from dashboard entity type.
+// Raw generated enums and default consts from dashboard entity type.
 export {
   defaultAnnotationQuery,
   defaultDashboardLink,
+  FieldColorModeId,
   defaultGridPos,
+  ThresholdsMode,
   defaultThresholdsConfig,
+  MappingType,
+  SpecialValueMatch,
+  DashboardCursorSync,
   defaultDashboardCursorSync,
   defaultMatcherConfig,
   defaultRowPanel
@@ -81,5 +81,5 @@ export type {
   PlaylistItem
 } from './raw/playlist/x/playlist.gen';
 
-// Raw generated default consts from playlist entity type.
+// Raw generated enums and default consts from playlist entity type.
 export { defaultPlaylist } from './raw/playlist/x/playlist.gen';

--- a/packages/grafana-schema/src/raw/dashboard/x/dashboard.gen.ts
+++ b/packages/grafana-schema/src/raw/dashboard/x/dashboard.gen.ts
@@ -369,6 +369,7 @@ export interface Panel {
   /**
    * Direction to repeat in if 'repeat' is set.
    * "h" for horizontal, "v" for vertical.
+   * TODO this is probably optional
    */
   repeatDirection: ('h' | 'v');
   /**

--- a/pkg/coremodel/dashboard/coremodel.cue
+++ b/pkg/coremodel/dashboard/coremodel.cue
@@ -318,6 +318,7 @@ seqs: [
 					repeat?: string @grafanamaturity(NeedsExpertReview)
 					// Direction to repeat in if 'repeat' is set.
 					// "h" for horizontal, "v" for vertical.
+          // TODO this is probably optional
 					repeatDirection: *"h" | "v" @grafanamaturity(NeedsExpertReview)
 
 					// TODO docs

--- a/pkg/coremodel/dashboard/dashboard_gen.go
+++ b/pkg/coremodel/dashboard/dashboard_gen.go
@@ -720,6 +720,7 @@ type Panel struct {
 
 	// Direction to repeat in if 'repeat' is set.
 	// "h" for horizontal, "v" for vertical.
+	// TODO this is probably optional
 	RepeatDirection PanelRepeatDirection `json:"repeatDirection"`
 
 	// TODO docs
@@ -758,6 +759,7 @@ type Panel struct {
 
 // Direction to repeat in if 'repeat' is set.
 // "h" for horizontal, "v" for vertical.
+// TODO this is probably optional
 //
 // THIS TYPE IS INTENDED FOR INTERNAL USE BY THE GRAFANA BACKEND, AND IS SUBJECT TO BREAKING CHANGES.
 // Equivalent Go types at stable import paths are provided in https://github.com/grafana/grok.

--- a/public/app/features/alerting/TestRuleResult.test.tsx
+++ b/public/app/features/alerting/TestRuleResult.test.tsx
@@ -1,8 +1,8 @@
 import { render } from '@testing-library/react';
 import React from 'react';
 
-import { DashboardModel, PanelModel } from '../dashboard/state';
-import { createDashboardFixture, createPanelFixture } from '../dashboard/state/__fixtures__/dashboardFixtures';
+import { PanelModel } from '../dashboard/state';
+import { createDashboardModelFixture, createPanelJSONFixture } from '../dashboard/state/__fixtures__/dashboardFixtures';
 
 import { TestRuleResult, Props } from './TestRuleResult';
 
@@ -19,11 +19,9 @@ jest.mock('@grafana/runtime', () => {
 
 const props: Props = {
   panel: new PanelModel({ id: 1 }),
-  dashboard: new DashboardModel(
-    createDashboardFixture({
-      panels: [createPanelFixture({ id: 1 })],
-    })
-  ),
+  dashboard: createDashboardModelFixture({
+    panels: [createPanelJSONFixture({ id: 1 })],
+  }),
 };
 
 describe('TestRuleResult', () => {

--- a/public/app/features/alerting/TestRuleResult.test.tsx
+++ b/public/app/features/alerting/TestRuleResult.test.tsx
@@ -2,7 +2,7 @@ import { render } from '@testing-library/react';
 import React from 'react';
 
 import { DashboardModel, PanelModel } from '../dashboard/state';
-import { createDashboardJSON, createPanelJSON } from '../dashboard/state/__fixtures__/dashboardJson';
+import { createDashboardFixture, createPanelFixture } from '../dashboard/state/__fixtures__/dashboardFixtures';
 
 import { TestRuleResult, Props } from './TestRuleResult';
 
@@ -20,8 +20,8 @@ jest.mock('@grafana/runtime', () => {
 const props: Props = {
   panel: new PanelModel({ id: 1 }),
   dashboard: new DashboardModel(
-    createDashboardJSON({
-      panels: [createPanelJSON({ id: 1 })],
+    createDashboardFixture({
+      panels: [createPanelFixture({ id: 1 })],
     })
   ),
 };

--- a/public/app/features/alerting/TestRuleResult.test.tsx
+++ b/public/app/features/alerting/TestRuleResult.test.tsx
@@ -2,6 +2,7 @@ import { render } from '@testing-library/react';
 import React from 'react';
 
 import { DashboardModel, PanelModel } from '../dashboard/state';
+import { createDashboardJSON, createPanelJSON } from '../dashboard/state/__fixtures__/dashboardJson';
 
 import { TestRuleResult, Props } from './TestRuleResult';
 
@@ -18,7 +19,11 @@ jest.mock('@grafana/runtime', () => {
 
 const props: Props = {
   panel: new PanelModel({ id: 1 }),
-  dashboard: new DashboardModel({ panels: [{ id: 1 }] }),
+  dashboard: new DashboardModel(
+    createDashboardJSON({
+      panels: [createPanelJSON({ id: 1 })],
+    })
+  ),
 };
 
 describe('TestRuleResult', () => {

--- a/public/app/features/alerting/unified/components/panel-alerts-tab/NewRuleFromPanelButton.test.tsx
+++ b/public/app/features/alerting/unified/components/panel-alerts-tab/NewRuleFromPanelButton.test.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 
 import { logInfo } from '@grafana/runtime';
 import { DashboardModel, PanelModel } from 'app/features/dashboard/state';
+import { createDashboardJSON } from 'app/features/dashboard/state/__fixtures__/dashboardJson';
 
 import { LogMessages } from '../../Analytics';
 
@@ -40,9 +41,11 @@ describe('Analytics', () => {
     const panel = new PanelModel({
       id: 123,
     });
-    const dashboard = new DashboardModel({
-      id: 1,
-    });
+    const dashboard = new DashboardModel(
+      createDashboardJSON({
+        id: 1,
+      })
+    );
     render(<NewRuleFromPanelButton panel={panel} dashboard={dashboard} />);
 
     const button = screen.getByText('Create alert rule from this panel');

--- a/public/app/features/alerting/unified/components/panel-alerts-tab/NewRuleFromPanelButton.test.tsx
+++ b/public/app/features/alerting/unified/components/panel-alerts-tab/NewRuleFromPanelButton.test.tsx
@@ -3,8 +3,8 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import { logInfo } from '@grafana/runtime';
-import { DashboardModel, PanelModel } from 'app/features/dashboard/state';
-import { createDashboardFixture } from 'app/features/dashboard/state/__fixtures__/dashboardFixtures';
+import { PanelModel } from 'app/features/dashboard/state';
+import { createDashboardModelFixture } from 'app/features/dashboard/state/__fixtures__/dashboardFixtures';
 
 import { LogMessages } from '../../Analytics';
 
@@ -41,11 +41,9 @@ describe('Analytics', () => {
     const panel = new PanelModel({
       id: 123,
     });
-    const dashboard = new DashboardModel(
-      createDashboardFixture({
-        id: 1,
-      })
-    );
+    const dashboard = createDashboardModelFixture({
+      id: 1,
+    });
     render(<NewRuleFromPanelButton panel={panel} dashboard={dashboard} />);
 
     const button = screen.getByText('Create alert rule from this panel');

--- a/public/app/features/alerting/unified/components/panel-alerts-tab/NewRuleFromPanelButton.test.tsx
+++ b/public/app/features/alerting/unified/components/panel-alerts-tab/NewRuleFromPanelButton.test.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 
 import { logInfo } from '@grafana/runtime';
 import { DashboardModel, PanelModel } from 'app/features/dashboard/state';
-import { createDashboardJSON } from 'app/features/dashboard/state/__fixtures__/dashboardJson';
+import { createDashboardFixture } from 'app/features/dashboard/state/__fixtures__/dashboardFixtures';
 
 import { LogMessages } from '../../Analytics';
 
@@ -42,7 +42,7 @@ describe('Analytics', () => {
       id: 123,
     });
     const dashboard = new DashboardModel(
-      createDashboardJSON({
+      createDashboardFixture({
         id: 1,
       })
     );

--- a/public/app/features/dashboard/components/AddPanelWidget/AddPanelWidget.test.tsx
+++ b/public/app/features/dashboard/components/AddPanelWidget/AddPanelWidget.test.tsx
@@ -2,13 +2,13 @@ import { render, screen } from '@testing-library/react';
 import React from 'react';
 
 import { DashboardModel, PanelModel } from '../../state';
-import { createDashboardJSON } from '../../state/__fixtures__/dashboardJson';
+import { createDashboardFixture } from '../../state/__fixtures__/dashboardFixtures';
 
 import { AddPanelWidgetUnconnected as AddPanelWidget, Props } from './AddPanelWidget';
 
 const getTestContext = (propOverrides?: object) => {
   const props: Props = {
-    dashboard: new DashboardModel(createDashboardJSON()),
+    dashboard: new DashboardModel(createDashboardFixture()),
     panel: new PanelModel({}),
     addPanel: jest.fn() as any,
   };

--- a/public/app/features/dashboard/components/AddPanelWidget/AddPanelWidget.test.tsx
+++ b/public/app/features/dashboard/components/AddPanelWidget/AddPanelWidget.test.tsx
@@ -2,12 +2,13 @@ import { render, screen } from '@testing-library/react';
 import React from 'react';
 
 import { DashboardModel, PanelModel } from '../../state';
+import { createDashboardJSON } from '../../state/__fixtures__/dashboardJson';
 
 import { AddPanelWidgetUnconnected as AddPanelWidget, Props } from './AddPanelWidget';
 
 const getTestContext = (propOverrides?: object) => {
   const props: Props = {
-    dashboard: new DashboardModel({}),
+    dashboard: new DashboardModel(createDashboardJSON()),
     panel: new PanelModel({}),
     addPanel: jest.fn() as any,
   };

--- a/public/app/features/dashboard/components/AddPanelWidget/AddPanelWidget.test.tsx
+++ b/public/app/features/dashboard/components/AddPanelWidget/AddPanelWidget.test.tsx
@@ -1,14 +1,14 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 
-import { DashboardModel, PanelModel } from '../../state';
-import { createDashboardFixture } from '../../state/__fixtures__/dashboardFixtures';
+import { PanelModel } from '../../state';
+import { createDashboardModelFixture } from '../../state/__fixtures__/dashboardFixtures';
 
 import { AddPanelWidgetUnconnected as AddPanelWidget, Props } from './AddPanelWidget';
 
 const getTestContext = (propOverrides?: object) => {
   const props: Props = {
-    dashboard: new DashboardModel(createDashboardFixture()),
+    dashboard: createDashboardModelFixture(),
     panel: new PanelModel({}),
     addPanel: jest.fn() as any,
   };

--- a/public/app/features/dashboard/components/DashNav/DashNav.test.tsx
+++ b/public/app/features/dashboard/components/DashNav/DashNav.test.tsx
@@ -11,13 +11,13 @@ import { setStarred } from '../../../../core/reducers/navBarTree';
 import { configureStore } from '../../../../store/configureStore';
 import { updateTimeZoneForSession } from '../../../profile/state/reducers';
 import { DashboardModel } from '../../state';
-import { createDashboardJSON } from '../../state/__fixtures__/dashboardJson';
+import { createDashboardFixture } from '../../state/__fixtures__/dashboardFixtures';
 
 import { DashNav } from './DashNav';
 
 describe('Public dashboard title tag', () => {
   it('will be rendered when publicDashboardEnabled set to true in dashboard meta', async () => {
-    let dashboard = new DashboardModel(createDashboardJSON(), { publicDashboardEnabled: false });
+    let dashboard = new DashboardModel(createDashboardFixture(), { publicDashboardEnabled: false });
 
     const store = configureStore();
     const context = getGrafanaContextMock();

--- a/public/app/features/dashboard/components/DashNav/DashNav.test.tsx
+++ b/public/app/features/dashboard/components/DashNav/DashNav.test.tsx
@@ -11,12 +11,13 @@ import { setStarred } from '../../../../core/reducers/navBarTree';
 import { configureStore } from '../../../../store/configureStore';
 import { updateTimeZoneForSession } from '../../../profile/state/reducers';
 import { DashboardModel } from '../../state';
+import { createDashboardJSON } from '../../state/__fixtures__/dashboardJson';
 
 import { DashNav } from './DashNav';
 
 describe('Public dashboard title tag', () => {
   it('will be rendered when publicDashboardEnabled set to true in dashboard meta', async () => {
-    let dashboard = new DashboardModel({}, { publicDashboardEnabled: false });
+    let dashboard = new DashboardModel(createDashboardJSON(), { publicDashboardEnabled: false });
 
     const store = configureStore();
     const context = getGrafanaContextMock();

--- a/public/app/features/dashboard/components/DashNav/DashNav.test.tsx
+++ b/public/app/features/dashboard/components/DashNav/DashNav.test.tsx
@@ -10,14 +10,13 @@ import { getGrafanaContextMock } from '../../../../../test/mocks/getGrafanaConte
 import { setStarred } from '../../../../core/reducers/navBarTree';
 import { configureStore } from '../../../../store/configureStore';
 import { updateTimeZoneForSession } from '../../../profile/state/reducers';
-import { DashboardModel } from '../../state';
-import { createDashboardFixture } from '../../state/__fixtures__/dashboardFixtures';
+import { createDashboardModelFixture } from '../../state/__fixtures__/dashboardFixtures';
 
 import { DashNav } from './DashNav';
 
 describe('Public dashboard title tag', () => {
   it('will be rendered when publicDashboardEnabled set to true in dashboard meta', async () => {
-    let dashboard = new DashboardModel(createDashboardFixture(), { publicDashboardEnabled: false });
+    let dashboard = createDashboardModelFixture({}, { publicDashboardEnabled: false });
 
     const store = configureStore();
     const context = getGrafanaContextMock();

--- a/public/app/features/dashboard/components/DashboardPrompt/DashboardPrompt.test.tsx
+++ b/public/app/features/dashboard/components/DashboardPrompt/DashboardPrompt.test.tsx
@@ -11,23 +11,23 @@ function getDefaultDashboardModel(): DashboardModel {
   return createDashboardModelFixture({
     refresh: false,
     panels: [
-      createPanelJSONFixture({
+      {
         id: 1,
         type: 'graph',
         gridPos: { x: 0, y: 0, w: 24, h: 6 },
-        legend: { sortDesc: false }, // legend is not in the cue schema for panel yet
-      }),
-      createPanelJSONFixture({
+        legend: { sortDesc: false }, // TODO legend is marked as a non-persisted field
+      },
+      {
         id: 2,
         type: 'row',
         gridPos: { x: 0, y: 6, w: 24, h: 2 },
-        collapsed: true, // collapsed is not in the cue schema for panel yet
+        collapsed: true,
         panels: [
           { id: 3, type: 'graph', gridPos: { x: 0, y: 6, w: 12, h: 2 } },
           { id: 4, type: 'graph', gridPos: { x: 12, y: 6, w: 12, h: 2 } },
         ],
-      }),
-      createPanelJSONFixture({ id: 5, type: 'row', gridPos: { x: 0, y: 6, w: 1, h: 1 } }),
+      },
+      { id: 5, type: 'row', gridPos: { x: 0, y: 6, w: 1, h: 1 }, collapsed: false, panels: []},
     ],
   });
 }

--- a/public/app/features/dashboard/components/DashboardPrompt/DashboardPrompt.test.tsx
+++ b/public/app/features/dashboard/components/DashboardPrompt/DashboardPrompt.test.tsx
@@ -3,35 +3,33 @@ import { getPanelPlugin } from 'app/features/plugins/__mocks__/pluginMocks';
 import { setContextSrv } from '../../../../core/services/context_srv';
 import { DashboardModel } from '../../state/DashboardModel';
 import { PanelModel } from '../../state/PanelModel';
-import { createDashboardFixture, createPanelFixture } from '../../state/__fixtures__/dashboardFixtures';
+import { createDashboardModelFixture, createPanelJSONFixture } from '../../state/__fixtures__/dashboardFixtures';
 
 import { hasChanges, ignoreChanges } from './DashboardPrompt';
 
 function getDefaultDashboardModel(): DashboardModel {
-  return new DashboardModel(
-    createDashboardFixture({
-      refresh: false,
-      panels: [
-        createPanelFixture({
-          id: 1,
-          type: 'graph',
-          gridPos: { x: 0, y: 0, w: 24, h: 6 },
-          legend: { sortDesc: false }, // legend is not in the cue schema for panel yet
-        }),
-        createPanelFixture({
-          id: 2,
-          type: 'row',
-          gridPos: { x: 0, y: 6, w: 24, h: 2 },
-          collapsed: true, // collapsed is not in the cue schema for panel yet
-          panels: [
-            { id: 3, type: 'graph', gridPos: { x: 0, y: 6, w: 12, h: 2 } },
-            { id: 4, type: 'graph', gridPos: { x: 12, y: 6, w: 12, h: 2 } },
-          ],
-        }),
-        createPanelFixture({ id: 5, type: 'row', gridPos: { x: 0, y: 6, w: 1, h: 1 } }),
-      ],
-    })
-  );
+  return createDashboardModelFixture({
+    refresh: false,
+    panels: [
+      createPanelJSONFixture({
+        id: 1,
+        type: 'graph',
+        gridPos: { x: 0, y: 0, w: 24, h: 6 },
+        legend: { sortDesc: false }, // legend is not in the cue schema for panel yet
+      }),
+      createPanelJSONFixture({
+        id: 2,
+        type: 'row',
+        gridPos: { x: 0, y: 6, w: 24, h: 2 },
+        collapsed: true, // collapsed is not in the cue schema for panel yet
+        panels: [
+          { id: 3, type: 'graph', gridPos: { x: 0, y: 6, w: 12, h: 2 } },
+          { id: 4, type: 'graph', gridPos: { x: 12, y: 6, w: 12, h: 2 } },
+        ],
+      }),
+      createPanelJSONFixture({ id: 5, type: 'row', gridPos: { x: 0, y: 6, w: 1, h: 1 } }),
+    ],
+  });
 }
 
 function getTestContext() {

--- a/public/app/features/dashboard/components/DashboardPrompt/DashboardPrompt.test.tsx
+++ b/public/app/features/dashboard/components/DashboardPrompt/DashboardPrompt.test.tsx
@@ -3,22 +3,22 @@ import { getPanelPlugin } from 'app/features/plugins/__mocks__/pluginMocks';
 import { setContextSrv } from '../../../../core/services/context_srv';
 import { DashboardModel } from '../../state/DashboardModel';
 import { PanelModel } from '../../state/PanelModel';
-import { createDashboardJSON, createPanelJSON } from '../../state/__fixtures__/dashboardJson';
+import { createDashboardFixture, createPanelFixture } from '../../state/__fixtures__/dashboardFixtures';
 
 import { hasChanges, ignoreChanges } from './DashboardPrompt';
 
 function getDefaultDashboardModel(): DashboardModel {
   return new DashboardModel(
-    createDashboardJSON({
+    createDashboardFixture({
       refresh: false,
       panels: [
-        createPanelJSON({
+        createPanelFixture({
           id: 1,
           type: 'graph',
           gridPos: { x: 0, y: 0, w: 24, h: 6 },
           legend: { sortDesc: false }, // legend is not in the cue schema for panel yet
         }),
-        createPanelJSON({
+        createPanelFixture({
           id: 2,
           type: 'row',
           gridPos: { x: 0, y: 6, w: 24, h: 2 },
@@ -28,7 +28,7 @@ function getDefaultDashboardModel(): DashboardModel {
             { id: 4, type: 'graph', gridPos: { x: 12, y: 6, w: 12, h: 2 } },
           ],
         }),
-        createPanelJSON({ id: 5, type: 'row', gridPos: { x: 0, y: 6, w: 1, h: 1 } }),
+        createPanelFixture({ id: 5, type: 'row', gridPos: { x: 0, y: 6, w: 1, h: 1 } }),
       ],
     })
   );

--- a/public/app/features/dashboard/components/DashboardPrompt/DashboardPrompt.test.tsx
+++ b/public/app/features/dashboard/components/DashboardPrompt/DashboardPrompt.test.tsx
@@ -3,32 +3,35 @@ import { getPanelPlugin } from 'app/features/plugins/__mocks__/pluginMocks';
 import { setContextSrv } from '../../../../core/services/context_srv';
 import { DashboardModel } from '../../state/DashboardModel';
 import { PanelModel } from '../../state/PanelModel';
+import { createDashboardJSON, createPanelJSON } from '../../state/__fixtures__/dashboardJson';
 
 import { hasChanges, ignoreChanges } from './DashboardPrompt';
 
 function getDefaultDashboardModel(): DashboardModel {
-  return new DashboardModel({
-    refresh: false,
-    panels: [
-      {
-        id: 1,
-        type: 'graph',
-        gridPos: { x: 0, y: 0, w: 24, h: 6 },
-        legend: { sortDesc: false },
-      },
-      {
-        id: 2,
-        type: 'row',
-        gridPos: { x: 0, y: 6, w: 24, h: 2 },
-        collapsed: true,
-        panels: [
-          { id: 3, type: 'graph', gridPos: { x: 0, y: 6, w: 12, h: 2 } },
-          { id: 4, type: 'graph', gridPos: { x: 12, y: 6, w: 12, h: 2 } },
-        ],
-      },
-      { id: 5, type: 'row', gridPos: { x: 0, y: 6, w: 1, h: 1 } },
-    ],
-  });
+  return new DashboardModel(
+    createDashboardJSON({
+      refresh: false,
+      panels: [
+        createPanelJSON({
+          id: 1,
+          type: 'graph',
+          gridPos: { x: 0, y: 0, w: 24, h: 6 },
+          legend: { sortDesc: false }, // legend is not in the cue schema for panel yet
+        }),
+        createPanelJSON({
+          id: 2,
+          type: 'row',
+          gridPos: { x: 0, y: 6, w: 24, h: 2 },
+          collapsed: true, // collapsed is not in the cue schema for panel yet
+          panels: [
+            { id: 3, type: 'graph', gridPos: { x: 0, y: 6, w: 12, h: 2 } },
+            { id: 4, type: 'graph', gridPos: { x: 12, y: 6, w: 12, h: 2 } },
+          ],
+        }),
+        createPanelJSON({ id: 5, type: 'row', gridPos: { x: 0, y: 6, w: 1, h: 1 } }),
+      ],
+    })
+  );
 }
 
 function getTestContext() {

--- a/public/app/features/dashboard/components/DashboardSettings/AnnotationsSettings.test.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/AnnotationsSettings.test.tsx
@@ -11,7 +11,7 @@ import { GrafanaContext } from 'app/core/context/GrafanaContext';
 import { mockDataSource, MockDataSourceSrv } from 'app/features/alerting/unified/mocks';
 
 import { DashboardModel } from '../../state/DashboardModel';
-import { createDashboardFixture } from '../../state/__fixtures__/dashboardFixtures';
+import { createDashboardModelFixture } from '../../state/__fixtures__/dashboardFixtures';
 
 import { AnnotationsSettings } from './AnnotationsSettings';
 
@@ -79,27 +79,25 @@ describe('AnnotationsSettings', () => {
   });
 
   beforeEach(() => {
-    dashboard = new DashboardModel(
-      createDashboardFixture({
-        id: 74,
-        version: 7,
-        annotations: {
-          list: [
-            {
-              builtIn: 1,
-              datasource: { uid: 'uid1', type: 'grafana' },
-              enable: true,
-              hide: true,
-              iconColor: 'rgba(0, 211, 255, 1)',
-              name: 'Annotations & Alerts',
-              type: 'dashboard',
-              showIn: 1,
-            },
-          ],
-        },
-        links: [],
-      })
-    );
+    dashboard = createDashboardModelFixture({
+      id: 74,
+      version: 7,
+      annotations: {
+        list: [
+          {
+            builtIn: 1,
+            datasource: { uid: 'uid1', type: 'grafana' },
+            enable: true,
+            hide: true,
+            iconColor: 'rgba(0, 211, 255, 1)',
+            name: 'Annotations & Alerts',
+            type: 'dashboard',
+            showIn: 1,
+          },
+        ],
+      },
+      links: [],
+    });
   });
 
   test('it renders empty list cta if only builtIn annotation', async () => {

--- a/public/app/features/dashboard/components/DashboardSettings/AnnotationsSettings.test.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/AnnotationsSettings.test.tsx
@@ -11,7 +11,7 @@ import { GrafanaContext } from 'app/core/context/GrafanaContext';
 import { mockDataSource, MockDataSourceSrv } from 'app/features/alerting/unified/mocks';
 
 import { DashboardModel } from '../../state/DashboardModel';
-import { createDashboardJSON } from '../../state/__fixtures__/dashboardJson';
+import { createDashboardFixture } from '../../state/__fixtures__/dashboardFixtures';
 
 import { AnnotationsSettings } from './AnnotationsSettings';
 
@@ -80,7 +80,7 @@ describe('AnnotationsSettings', () => {
 
   beforeEach(() => {
     dashboard = new DashboardModel(
-      createDashboardJSON({
+      createDashboardFixture({
         id: 74,
         version: 7,
         annotations: {

--- a/public/app/features/dashboard/components/DashboardSettings/AnnotationsSettings.test.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/AnnotationsSettings.test.tsx
@@ -11,6 +11,7 @@ import { GrafanaContext } from 'app/core/context/GrafanaContext';
 import { mockDataSource, MockDataSourceSrv } from 'app/features/alerting/unified/mocks';
 
 import { DashboardModel } from '../../state/DashboardModel';
+import { createDashboardJSON } from '../../state/__fixtures__/dashboardJson';
 
 import { AnnotationsSettings } from './AnnotationsSettings';
 
@@ -78,24 +79,27 @@ describe('AnnotationsSettings', () => {
   });
 
   beforeEach(() => {
-    dashboard = new DashboardModel({
-      id: 74,
-      version: 7,
-      annotations: {
-        list: [
-          {
-            builtIn: 1,
-            datasource: { uid: 'uid1', type: 'grafana' },
-            enable: true,
-            hide: true,
-            iconColor: 'rgba(0, 211, 255, 1)',
-            name: 'Annotations & Alerts',
-            type: 'dashboard',
-          },
-        ],
-      },
-      links: [],
-    });
+    dashboard = new DashboardModel(
+      createDashboardJSON({
+        id: 74,
+        version: 7,
+        annotations: {
+          list: [
+            {
+              builtIn: 1,
+              datasource: { uid: 'uid1', type: 'grafana' },
+              enable: true,
+              hide: true,
+              iconColor: 'rgba(0, 211, 255, 1)',
+              name: 'Annotations & Alerts',
+              type: 'dashboard',
+              showIn: 1,
+            },
+          ],
+        },
+        links: [],
+      })
+    );
   });
 
   test('it renders empty list cta if only builtIn annotation', async () => {

--- a/public/app/features/dashboard/components/DashboardSettings/DashboardSettings.test.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/DashboardSettings.test.tsx
@@ -9,8 +9,7 @@ import { setBackendSrv } from '@grafana/runtime';
 import { GrafanaContext } from 'app/core/context/GrafanaContext';
 import { configureStore } from 'app/store/configureStore';
 
-import { DashboardModel } from '../../state';
-import { createDashboardFixture } from '../../state/__fixtures__/dashboardFixtures';
+import { createDashboardModelFixture } from '../../state/__fixtures__/dashboardFixtures';
 
 import { DashboardSettings } from './DashboardSettings';
 
@@ -28,10 +27,10 @@ setBackendSrv({
 
 describe('DashboardSettings', () => {
   it('pressing escape navigates away correctly', async () => {
-    const dashboard = new DashboardModel(
-      createDashboardFixture({
+    const dashboard = createDashboardModelFixture(
+      {
         title: 'Foo',
-      }),
+      },
       {
         folderId: 1,
       }

--- a/public/app/features/dashboard/components/DashboardSettings/DashboardSettings.test.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/DashboardSettings.test.tsx
@@ -10,7 +10,7 @@ import { GrafanaContext } from 'app/core/context/GrafanaContext';
 import { configureStore } from 'app/store/configureStore';
 
 import { DashboardModel } from '../../state';
-import { createDashboardJSON } from '../../state/__fixtures__/dashboardJson';
+import { createDashboardFixture } from '../../state/__fixtures__/dashboardFixtures';
 
 import { DashboardSettings } from './DashboardSettings';
 
@@ -29,7 +29,7 @@ setBackendSrv({
 describe('DashboardSettings', () => {
   it('pressing escape navigates away correctly', async () => {
     const dashboard = new DashboardModel(
-      createDashboardJSON({
+      createDashboardFixture({
         title: 'Foo',
       }),
       {

--- a/public/app/features/dashboard/components/DashboardSettings/DashboardSettings.test.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/DashboardSettings.test.tsx
@@ -10,6 +10,7 @@ import { GrafanaContext } from 'app/core/context/GrafanaContext';
 import { configureStore } from 'app/store/configureStore';
 
 import { DashboardModel } from '../../state';
+import { createDashboardJSON } from '../../state/__fixtures__/dashboardJson';
 
 import { DashboardSettings } from './DashboardSettings';
 
@@ -28,9 +29,9 @@ setBackendSrv({
 describe('DashboardSettings', () => {
   it('pressing escape navigates away correctly', async () => {
     const dashboard = new DashboardModel(
-      {
+      createDashboardJSON({
         title: 'Foo',
-      },
+      }),
       {
         folderId: 1,
       }

--- a/public/app/features/dashboard/components/DashboardSettings/GeneralSettings.test.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/GeneralSettings.test.tsx
@@ -10,8 +10,7 @@ import { selectors } from '@grafana/e2e-selectors';
 import { setBackendSrv } from '@grafana/runtime';
 import { GrafanaContext } from 'app/core/context/GrafanaContext';
 
-import { DashboardModel } from '../../state';
-import { createDashboardFixture } from '../../state/__fixtures__/dashboardFixtures';
+import { createDashboardModelFixture } from '../../state/__fixtures__/dashboardFixtures';
 
 import { GeneralSettingsUnconnected as GeneralSettings, Props } from './GeneralSettings';
 
@@ -21,8 +20,8 @@ setBackendSrv({
 
 const setupTestContext = (options: Partial<Props>) => {
   const defaults: Props = {
-    dashboard: new DashboardModel(
-      createDashboardFixture({
+    dashboard: createDashboardModelFixture(
+      {
         title: 'test dashboard title',
         description: 'test dashboard description',
         timepicker: {
@@ -33,7 +32,7 @@ const setupTestContext = (options: Partial<Props>) => {
           hidden: false,
         },
         timezone: 'utc',
-      }),
+      },
       {
         folderId: 1,
         folderTitle: 'test',

--- a/public/app/features/dashboard/components/DashboardSettings/GeneralSettings.test.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/GeneralSettings.test.tsx
@@ -11,6 +11,7 @@ import { setBackendSrv } from '@grafana/runtime';
 import { GrafanaContext } from 'app/core/context/GrafanaContext';
 
 import { DashboardModel } from '../../state';
+import { createDashboardJSON } from '../../state/__fixtures__/dashboardJson';
 
 import { GeneralSettingsUnconnected as GeneralSettings, Props } from './GeneralSettings';
 
@@ -21,15 +22,18 @@ setBackendSrv({
 const setupTestContext = (options: Partial<Props>) => {
   const defaults: Props = {
     dashboard: new DashboardModel(
-      {
+      createDashboardJSON({
         title: 'test dashboard title',
         description: 'test dashboard description',
         timepicker: {
           refresh_intervals: ['5s', '10s', '30s', '1m', '5m', '15m', '30m', '1h', '2h', '1d', '2d'],
           time_options: ['5m', '15m', '1h', '6h', '12h', '24h', '2d', '7d', '30d'],
+          collapse: true,
+          enable: true,
+          hidden: false,
         },
         timezone: 'utc',
-      },
+      }),
       {
         folderId: 1,
         folderTitle: 'test',

--- a/public/app/features/dashboard/components/DashboardSettings/GeneralSettings.test.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/GeneralSettings.test.tsx
@@ -11,7 +11,7 @@ import { setBackendSrv } from '@grafana/runtime';
 import { GrafanaContext } from 'app/core/context/GrafanaContext';
 
 import { DashboardModel } from '../../state';
-import { createDashboardJSON } from '../../state/__fixtures__/dashboardJson';
+import { createDashboardFixture } from '../../state/__fixtures__/dashboardFixtures';
 
 import { GeneralSettingsUnconnected as GeneralSettings, Props } from './GeneralSettings';
 
@@ -22,7 +22,7 @@ setBackendSrv({
 const setupTestContext = (options: Partial<Props>) => {
   const defaults: Props = {
     dashboard: new DashboardModel(
-      createDashboardJSON({
+      createDashboardFixture({
         title: 'test dashboard title',
         description: 'test dashboard description',
         timepicker: {

--- a/public/app/features/dashboard/components/DashboardSettings/LinksSettings.test.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/LinksSettings.test.tsx
@@ -10,6 +10,7 @@ import { locationService } from '@grafana/runtime';
 import { GrafanaContext } from 'app/core/context/GrafanaContext';
 
 import { DashboardModel } from '../../state';
+import { createDashboardJSON } from '../../state/__fixtures__/dashboardJson';
 
 import { DashboardSettings } from './DashboardSettings';
 
@@ -32,46 +33,48 @@ function setup(dashboard: DashboardModel) {
 }
 
 function buildTestDashboard() {
-  return new DashboardModel({
-    links: [
-      {
-        asDropdown: false,
-        icon: 'external link',
-        includeVars: false,
-        keepTime: false,
-        tags: [],
-        targetBlank: false,
-        title: 'link 1',
-        tooltip: '',
-        type: 'link',
-        url: 'https://www.google.com',
-      },
-      {
-        asDropdown: false,
-        icon: 'external link',
-        includeVars: false,
-        keepTime: false,
-        tags: ['gdev'],
-        targetBlank: false,
-        title: 'link 2',
-        tooltip: '',
-        type: 'dashboards',
-        url: '',
-      },
-      {
-        asDropdown: false,
-        icon: 'external link',
-        includeVars: false,
-        keepTime: false,
-        tags: [],
-        targetBlank: false,
-        title: '',
-        tooltip: '',
-        type: 'link',
-        url: 'https://www.bing.com',
-      },
-    ],
-  });
+  return new DashboardModel(
+    createDashboardJSON({
+      links: [
+        {
+          asDropdown: false,
+          icon: 'external link',
+          includeVars: false,
+          keepTime: false,
+          tags: [],
+          targetBlank: false,
+          title: 'link 1',
+          tooltip: '',
+          type: 'link',
+          url: 'https://www.google.com',
+        },
+        {
+          asDropdown: false,
+          icon: 'external link',
+          includeVars: false,
+          keepTime: false,
+          tags: ['gdev'],
+          targetBlank: false,
+          title: 'link 2',
+          tooltip: '',
+          type: 'dashboards',
+          url: '',
+        },
+        {
+          asDropdown: false,
+          icon: 'external link',
+          includeVars: false,
+          keepTime: false,
+          tags: [],
+          targetBlank: false,
+          title: '',
+          tooltip: '',
+          type: 'link',
+          url: 'https://www.bing.com',
+        },
+      ],
+    })
+  );
 }
 
 describe('LinksSettings', () => {
@@ -82,7 +85,7 @@ describe('LinksSettings', () => {
   };
 
   test('it renders a header and cta if no links', () => {
-    const linklessDashboard = new DashboardModel({ links: [] });
+    const linklessDashboard = new DashboardModel(createDashboardJSON({ links: [] }));
     setup(linklessDashboard);
 
     expect(screen.getByRole('heading', { name: 'Links' })).toBeInTheDocument();

--- a/public/app/features/dashboard/components/DashboardSettings/LinksSettings.test.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/LinksSettings.test.tsx
@@ -10,7 +10,7 @@ import { locationService } from '@grafana/runtime';
 import { GrafanaContext } from 'app/core/context/GrafanaContext';
 
 import { DashboardModel } from '../../state';
-import { createDashboardJSON } from '../../state/__fixtures__/dashboardJson';
+import { createDashboardFixture } from '../../state/__fixtures__/dashboardFixtures';
 
 import { DashboardSettings } from './DashboardSettings';
 
@@ -34,7 +34,7 @@ function setup(dashboard: DashboardModel) {
 
 function buildTestDashboard() {
   return new DashboardModel(
-    createDashboardJSON({
+    createDashboardFixture({
       links: [
         {
           asDropdown: false,
@@ -85,7 +85,7 @@ describe('LinksSettings', () => {
   };
 
   test('it renders a header and cta if no links', () => {
-    const linklessDashboard = new DashboardModel(createDashboardJSON({ links: [] }));
+    const linklessDashboard = new DashboardModel(createDashboardFixture({ links: [] }));
     setup(linklessDashboard);
 
     expect(screen.getByRole('heading', { name: 'Links' })).toBeInTheDocument();

--- a/public/app/features/dashboard/components/DashboardSettings/LinksSettings.test.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/LinksSettings.test.tsx
@@ -83,7 +83,7 @@ describe('LinksSettings', () => {
   };
 
   test('it renders a header and cta if no links', () => {
-    const linklessDashboard = new DashboardModel(createDashboardModelFixture({ links: [] }));
+    const linklessDashboard = createDashboardModelFixture({ links: [] });
     setup(linklessDashboard);
 
     expect(screen.getByRole('heading', { name: 'Links' })).toBeInTheDocument();

--- a/public/app/features/dashboard/components/DashboardSettings/LinksSettings.test.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/LinksSettings.test.tsx
@@ -10,7 +10,7 @@ import { locationService } from '@grafana/runtime';
 import { GrafanaContext } from 'app/core/context/GrafanaContext';
 
 import { DashboardModel } from '../../state';
-import { createDashboardFixture } from '../../state/__fixtures__/dashboardFixtures';
+import { createDashboardModelFixture } from '../../state/__fixtures__/dashboardFixtures';
 
 import { DashboardSettings } from './DashboardSettings';
 
@@ -33,48 +33,46 @@ function setup(dashboard: DashboardModel) {
 }
 
 function buildTestDashboard() {
-  return new DashboardModel(
-    createDashboardFixture({
-      links: [
-        {
-          asDropdown: false,
-          icon: 'external link',
-          includeVars: false,
-          keepTime: false,
-          tags: [],
-          targetBlank: false,
-          title: 'link 1',
-          tooltip: '',
-          type: 'link',
-          url: 'https://www.google.com',
-        },
-        {
-          asDropdown: false,
-          icon: 'external link',
-          includeVars: false,
-          keepTime: false,
-          tags: ['gdev'],
-          targetBlank: false,
-          title: 'link 2',
-          tooltip: '',
-          type: 'dashboards',
-          url: '',
-        },
-        {
-          asDropdown: false,
-          icon: 'external link',
-          includeVars: false,
-          keepTime: false,
-          tags: [],
-          targetBlank: false,
-          title: '',
-          tooltip: '',
-          type: 'link',
-          url: 'https://www.bing.com',
-        },
-      ],
-    })
-  );
+  return createDashboardModelFixture({
+    links: [
+      {
+        asDropdown: false,
+        icon: 'external link',
+        includeVars: false,
+        keepTime: false,
+        tags: [],
+        targetBlank: false,
+        title: 'link 1',
+        tooltip: '',
+        type: 'link',
+        url: 'https://www.google.com',
+      },
+      {
+        asDropdown: false,
+        icon: 'external link',
+        includeVars: false,
+        keepTime: false,
+        tags: ['gdev'],
+        targetBlank: false,
+        title: 'link 2',
+        tooltip: '',
+        type: 'dashboards',
+        url: '',
+      },
+      {
+        asDropdown: false,
+        icon: 'external link',
+        includeVars: false,
+        keepTime: false,
+        tags: [],
+        targetBlank: false,
+        title: '',
+        tooltip: '',
+        type: 'link',
+        url: 'https://www.bing.com',
+      },
+    ],
+  });
 }
 
 describe('LinksSettings', () => {
@@ -85,7 +83,7 @@ describe('LinksSettings', () => {
   };
 
   test('it renders a header and cta if no links', () => {
-    const linklessDashboard = new DashboardModel(createDashboardFixture({ links: [] }));
+    const linklessDashboard = new DashboardModel(createDashboardModelFixture({ links: [] }));
     setup(linklessDashboard);
 
     expect(screen.getByRole('heading', { name: 'Links' })).toBeInTheDocument();

--- a/public/app/features/dashboard/components/DashboardSettings/VersionsSettings.test.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/VersionsSettings.test.tsx
@@ -7,8 +7,7 @@ import { getGrafanaContextMock } from 'test/mocks/getGrafanaContextMock';
 
 import { GrafanaContext } from 'app/core/context/GrafanaContext';
 
-import { DashboardModel } from '../../state/DashboardModel';
-import { createDashboardFixture } from '../../state/__fixtures__/dashboardFixtures';
+import { createDashboardModelFixture } from '../../state/__fixtures__/dashboardFixtures';
 import { historySrv } from '../VersionHistory/HistorySrv';
 
 import { VersionsSettings, VERSIONS_FETCH_LIMIT } from './VersionsSettings';
@@ -28,14 +27,12 @@ const queryByFullText = (text: string) =>
   });
 
 function setup() {
-  const dashboard = new DashboardModel(
-    createDashboardFixture({
-      id: 74,
-      version: 11,
-      // formatDate: jest.fn(() => 'date'),
-      // getRelativeTime: jest.fn(() => 'time ago'),
-    })
-  );
+  const dashboard = createDashboardModelFixture({
+    id: 74,
+    version: 11,
+    // formatDate: jest.fn(() => 'date'),
+    // getRelativeTime: jest.fn(() => 'time ago'),
+  });
 
   const sectionNav = {
     main: { text: 'Dashboard' },

--- a/public/app/features/dashboard/components/DashboardSettings/VersionsSettings.test.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/VersionsSettings.test.tsx
@@ -8,7 +8,7 @@ import { getGrafanaContextMock } from 'test/mocks/getGrafanaContextMock';
 import { GrafanaContext } from 'app/core/context/GrafanaContext';
 
 import { DashboardModel } from '../../state/DashboardModel';
-import { createDashboardJSON } from '../../state/__fixtures__/dashboardJson';
+import { createDashboardFixture } from '../../state/__fixtures__/dashboardFixtures';
 import { historySrv } from '../VersionHistory/HistorySrv';
 
 import { VersionsSettings, VERSIONS_FETCH_LIMIT } from './VersionsSettings';
@@ -29,7 +29,7 @@ const queryByFullText = (text: string) =>
 
 function setup() {
   const dashboard = new DashboardModel(
-    createDashboardJSON({
+    createDashboardFixture({
       id: 74,
       version: 11,
       // formatDate: jest.fn(() => 'date'),

--- a/public/app/features/dashboard/components/DashboardSettings/VersionsSettings.test.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/VersionsSettings.test.tsx
@@ -8,6 +8,7 @@ import { getGrafanaContextMock } from 'test/mocks/getGrafanaContextMock';
 import { GrafanaContext } from 'app/core/context/GrafanaContext';
 
 import { DashboardModel } from '../../state/DashboardModel';
+import { createDashboardJSON } from '../../state/__fixtures__/dashboardJson';
 import { historySrv } from '../VersionHistory/HistorySrv';
 
 import { VersionsSettings, VERSIONS_FETCH_LIMIT } from './VersionsSettings';
@@ -27,12 +28,14 @@ const queryByFullText = (text: string) =>
   });
 
 function setup() {
-  const dashboard = new DashboardModel({
-    id: 74,
-    version: 11,
-    formatDate: jest.fn(() => 'date'),
-    getRelativeTime: jest.fn(() => 'time ago'),
-  });
+  const dashboard = new DashboardModel(
+    createDashboardJSON({
+      id: 74,
+      version: 11,
+      // formatDate: jest.fn(() => 'date'),
+      // getRelativeTime: jest.fn(() => 'time ago'),
+    })
+  );
 
   const sectionNav = {
     main: { text: 'Dashboard' },

--- a/public/app/features/dashboard/components/PanelEditor/OptionsPaneOptions.test.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/OptionsPaneOptions.test.tsx
@@ -17,7 +17,7 @@ import { getAllOptionEditors, getAllStandardFieldConfigs } from 'app/core/compon
 import { getPanelPlugin } from 'app/features/plugins/__mocks__/pluginMocks';
 
 import { DashboardModel, PanelModel } from '../../state';
-import { createDashboardJSON } from '../../state/__fixtures__/dashboardJson';
+import { createDashboardFixture } from '../../state/__fixtures__/dashboardFixtures';
 
 import { OptionsPaneOptions } from './OptionsPaneOptions';
 import { dataOverrideTooltipDescription, overrideRuleTooltipDescription } from './state/getOptionOverrides';
@@ -89,7 +89,7 @@ class OptionsPaneOptionsTestScenario {
     options: {},
   });
 
-  dashboard = new DashboardModel(createDashboardJSON());
+  dashboard = new DashboardModel(createDashboardFixture());
   store = mockStore({
     dashboard: { panels: [] },
     templating: {

--- a/public/app/features/dashboard/components/PanelEditor/OptionsPaneOptions.test.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/OptionsPaneOptions.test.tsx
@@ -16,8 +16,8 @@ import { selectors } from '@grafana/e2e-selectors';
 import { getAllOptionEditors, getAllStandardFieldConfigs } from 'app/core/components/OptionsUI/registry';
 import { getPanelPlugin } from 'app/features/plugins/__mocks__/pluginMocks';
 
-import { DashboardModel, PanelModel } from '../../state';
-import { createDashboardFixture } from '../../state/__fixtures__/dashboardFixtures';
+import { PanelModel } from '../../state';
+import { createDashboardModelFixture } from '../../state/__fixtures__/dashboardFixtures';
 
 import { OptionsPaneOptions } from './OptionsPaneOptions';
 import { dataOverrideTooltipDescription, overrideRuleTooltipDescription } from './state/getOptionOverrides';
@@ -89,7 +89,7 @@ class OptionsPaneOptionsTestScenario {
     options: {},
   });
 
-  dashboard = new DashboardModel(createDashboardFixture());
+  dashboard = createDashboardModelFixture();
   store = mockStore({
     dashboard: { panels: [] },
     templating: {

--- a/public/app/features/dashboard/components/PanelEditor/OptionsPaneOptions.test.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/OptionsPaneOptions.test.tsx
@@ -17,6 +17,7 @@ import { getAllOptionEditors, getAllStandardFieldConfigs } from 'app/core/compon
 import { getPanelPlugin } from 'app/features/plugins/__mocks__/pluginMocks';
 
 import { DashboardModel, PanelModel } from '../../state';
+import { createDashboardJSON } from '../../state/__fixtures__/dashboardJson';
 
 import { OptionsPaneOptions } from './OptionsPaneOptions';
 import { dataOverrideTooltipDescription, overrideRuleTooltipDescription } from './state/getOptionOverrides';
@@ -88,7 +89,7 @@ class OptionsPaneOptionsTestScenario {
     options: {},
   });
 
-  dashboard = new DashboardModel({});
+  dashboard = new DashboardModel(createDashboardJSON());
   store = mockStore({
     dashboard: { panels: [] },
     templating: {

--- a/public/app/features/dashboard/components/PanelEditor/PanelEditorTableView.test.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelEditorTableView.test.tsx
@@ -18,8 +18,8 @@ import {
 import { getTimeSrv, TimeSrv, setTimeSrv } from 'app/features/dashboard/services/TimeSrv';
 
 import { PanelQueryRunner } from '../../../query/state/PanelQueryRunner';
-import { DashboardModel, PanelModel } from '../../state';
-import { createDashboardFixture } from '../../state/__fixtures__/dashboardFixtures';
+import { PanelModel } from '../../state';
+import { createDashboardModelFixture } from '../../state/__fixtures__/dashboardFixtures';
 
 import { PanelEditorTableView, Props } from './PanelEditorTableView';
 
@@ -54,15 +54,13 @@ function setupTestContext(options: Partial<Props> = {}) {
       getDisplayTitle: jest.fn(),
       runAllPanelQueries: jest.fn(),
     }),
-    dashboard: new DashboardModel(
-      createDashboardFixture({
-        id: 1,
-        uid: 'super-unique-id',
-        // panelInitialized: jest.fn(),
-        // events: new EventBusSrv(),
-        panels: [],
-      })
-    ),
+    dashboard: createDashboardModelFixture({
+      id: 1,
+      uid: 'super-unique-id',
+      // panelInitialized: jest.fn(),
+      // events: new EventBusSrv(),
+      panels: [],
+    }),
     plugin: {
       meta: { skipDataQuery: false },
       panel: TestPanelComponent,
@@ -72,7 +70,6 @@ function setupTestContext(options: Partial<Props> = {}) {
     isInView: false,
     width: 100,
     height: 100,
-    isPublic: false,
     onInstanceStateChange: () => {},
   };
 

--- a/public/app/features/dashboard/components/PanelEditor/PanelEditorTableView.test.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelEditorTableView.test.tsx
@@ -19,6 +19,7 @@ import { getTimeSrv, TimeSrv, setTimeSrv } from 'app/features/dashboard/services
 
 import { PanelQueryRunner } from '../../../query/state/PanelQueryRunner';
 import { DashboardModel, PanelModel } from '../../state';
+import { createDashboardJSON } from '../../state/__fixtures__/dashboardJson';
 
 import { PanelEditorTableView, Props } from './PanelEditorTableView';
 
@@ -53,16 +54,15 @@ function setupTestContext(options: Partial<Props> = {}) {
       getDisplayTitle: jest.fn(),
       runAllPanelQueries: jest.fn(),
     }),
-    dashboard: new DashboardModel({
-      id: 1,
-      uid: 'super-unique-id',
-      panelInitialized: jest.fn(),
-      events: new EventBusSrv(),
-      meta: {
-        isPublic: false,
-      },
-      panels: [],
-    }),
+    dashboard: new DashboardModel(
+      createDashboardJSON({
+        id: 1,
+        uid: 'super-unique-id',
+        // panelInitialized: jest.fn(),
+        // events: new EventBusSrv(),
+        panels: [],
+      })
+    ),
     plugin: {
       meta: { skipDataQuery: false },
       panel: TestPanelComponent,
@@ -72,6 +72,7 @@ function setupTestContext(options: Partial<Props> = {}) {
     isInView: false,
     width: 100,
     height: 100,
+    isPublic: false,
     onInstanceStateChange: () => {},
   };
 

--- a/public/app/features/dashboard/components/PanelEditor/PanelEditorTableView.test.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelEditorTableView.test.tsx
@@ -19,7 +19,7 @@ import { getTimeSrv, TimeSrv, setTimeSrv } from 'app/features/dashboard/services
 
 import { PanelQueryRunner } from '../../../query/state/PanelQueryRunner';
 import { DashboardModel, PanelModel } from '../../state';
-import { createDashboardJSON } from '../../state/__fixtures__/dashboardJson';
+import { createDashboardFixture } from '../../state/__fixtures__/dashboardFixtures';
 
 import { PanelEditorTableView, Props } from './PanelEditorTableView';
 
@@ -55,7 +55,7 @@ function setupTestContext(options: Partial<Props> = {}) {
       runAllPanelQueries: jest.fn(),
     }),
     dashboard: new DashboardModel(
-      createDashboardJSON({
+      createDashboardFixture({
         id: 1,
         uid: 'super-unique-id',
         // panelInitialized: jest.fn(),

--- a/public/app/features/dashboard/components/PanelEditor/state/actions.test.ts
+++ b/public/app/features/dashboard/components/PanelEditor/state/actions.test.ts
@@ -1,4 +1,4 @@
-import { createDashboardJSON } from 'app/features/dashboard/state/__fixtures__/dashboardJson';
+import { createDashboardFixture } from 'app/features/dashboard/state/__fixtures__/dashboardFixtures';
 import { panelModelAndPluginReady, removePanel } from 'app/features/panel/state/reducers';
 import { getPanelPlugin } from 'app/features/plugins/__mocks__/pluginMocks';
 
@@ -12,7 +12,7 @@ describe('panelEditor actions', () => {
   describe('initPanelEditor', () => {
     it('initPanelEditor should create edit panel model as clone', async () => {
       const dashboard = new DashboardModel(
-        createDashboardJSON({
+        createDashboardFixture({
           panels: [{ id: 12, type: 'graph' }],
         })
       );
@@ -40,7 +40,7 @@ describe('panelEditor actions', () => {
     it('should update source panel', async () => {
       const sourcePanel = new PanelModel({ id: 12, type: 'graph' });
       const dashboard = new DashboardModel(
-        createDashboardJSON({
+        createDashboardFixture({
           panels: [{ id: 12, type: 'graph' }],
         })
       );
@@ -74,7 +74,7 @@ describe('panelEditor actions', () => {
     it('should dispatch panelModelAndPluginReady if type changed', async () => {
       const sourcePanel = new PanelModel({ id: 12, type: 'graph' });
       const dashboard = new DashboardModel(
-        createDashboardJSON({
+        createDashboardFixture({
           panels: [{ id: 12, type: 'graph' }],
         })
       );
@@ -115,7 +115,7 @@ describe('panelEditor actions', () => {
       } as any;
 
       const dashboard = new DashboardModel(
-        createDashboardJSON({
+        createDashboardFixture({
           panels: [{ id: 12, type: 'graph' }],
         })
       );
@@ -150,7 +150,7 @@ describe('panelEditor actions', () => {
       sourcePanel.plugin.angularPanelCtrl = undefined;
 
       const dashboard = new DashboardModel(
-        createDashboardJSON({
+        createDashboardFixture({
           panels: [{ id: 12, type: 'graph' }],
         })
       );
@@ -182,7 +182,7 @@ describe('panelEditor actions', () => {
       sourcePanel.plugin.angularPanelCtrl = undefined;
 
       const dashboard = new DashboardModel(
-        createDashboardJSON({
+        createDashboardFixture({
           panels: [{ id: 12, type: 'graph' }],
         })
       );
@@ -223,7 +223,7 @@ describe('panelEditor actions', () => {
       sourcePanel.plugin.angularPanelCtrl = {};
 
       const dashboard = new DashboardModel(
-        createDashboardJSON({
+        createDashboardFixture({
           panels: [{ id: 12, type: 'graph' }],
         })
       );

--- a/public/app/features/dashboard/components/PanelEditor/state/actions.test.ts
+++ b/public/app/features/dashboard/components/PanelEditor/state/actions.test.ts
@@ -1,9 +1,9 @@
-import { createDashboardFixture } from 'app/features/dashboard/state/__fixtures__/dashboardFixtures';
+import { createDashboardModelFixture } from 'app/features/dashboard/state/__fixtures__/dashboardFixtures';
 import { panelModelAndPluginReady, removePanel } from 'app/features/panel/state/reducers';
 import { getPanelPlugin } from 'app/features/plugins/__mocks__/pluginMocks';
 
 import { thunkTester } from '../../../../../../test/core/thunk/thunkTester';
-import { DashboardModel, PanelModel } from '../../../state';
+import { PanelModel } from '../../../state';
 
 import { exitPanelEditor, initPanelEditor, skipPanelUpdate } from './actions';
 import { closeEditor, initialState, PanelEditorState } from './reducers';
@@ -11,11 +11,9 @@ import { closeEditor, initialState, PanelEditorState } from './reducers';
 describe('panelEditor actions', () => {
   describe('initPanelEditor', () => {
     it('initPanelEditor should create edit panel model as clone', async () => {
-      const dashboard = new DashboardModel(
-        createDashboardFixture({
-          panels: [{ id: 12, type: 'graph' }],
-        })
-      );
+      const dashboard = createDashboardModelFixture({
+        panels: [{ id: 12, type: 'graph' }],
+      });
       const sourcePanel = new PanelModel({ id: 12, type: 'graph' });
 
       const dispatchedActions = await thunkTester({
@@ -39,11 +37,9 @@ describe('panelEditor actions', () => {
   describe('panelEditorCleanUp', () => {
     it('should update source panel', async () => {
       const sourcePanel = new PanelModel({ id: 12, type: 'graph' });
-      const dashboard = new DashboardModel(
-        createDashboardFixture({
-          panels: [{ id: 12, type: 'graph' }],
-        })
-      );
+      const dashboard = createDashboardModelFixture({
+        panels: [{ id: 12, type: 'graph' }],
+      });
 
       const panel = dashboard.initEditPanel(sourcePanel);
       panel.updateOptions({ prop: true });
@@ -73,11 +69,9 @@ describe('panelEditor actions', () => {
 
     it('should dispatch panelModelAndPluginReady if type changed', async () => {
       const sourcePanel = new PanelModel({ id: 12, type: 'graph' });
-      const dashboard = new DashboardModel(
-        createDashboardFixture({
-          panels: [{ id: 12, type: 'graph' }],
-        })
-      );
+      const dashboard = createDashboardModelFixture({
+        panels: [{ id: 12, type: 'graph' }],
+      });
 
       const panel = dashboard.initEditPanel(sourcePanel);
       panel.type = 'table';
@@ -114,11 +108,9 @@ describe('panelEditor actions', () => {
         customFieldConfigs: {},
       } as any;
 
-      const dashboard = new DashboardModel(
-        createDashboardFixture({
-          panels: [{ id: 12, type: 'graph' }],
-        })
-      );
+      const dashboard = createDashboardModelFixture({
+        panels: [{ id: 12, type: 'graph' }],
+      });
 
       const panel = dashboard.initEditPanel(sourcePanel);
       panel.updateOptions({ prop: true });
@@ -149,11 +141,9 @@ describe('panelEditor actions', () => {
       sourcePanel.plugin = getPanelPlugin({});
       sourcePanel.plugin.angularPanelCtrl = undefined;
 
-      const dashboard = new DashboardModel(
-        createDashboardFixture({
-          panels: [{ id: 12, type: 'graph' }],
-        })
-      );
+      const dashboard = createDashboardModelFixture({
+        panels: [{ id: 12, type: 'graph' }],
+      });
 
       const panel = dashboard.initEditPanel(sourcePanel);
 
@@ -181,11 +171,9 @@ describe('panelEditor actions', () => {
       sourcePanel.plugin = getPanelPlugin({});
       sourcePanel.plugin.angularPanelCtrl = undefined;
 
-      const dashboard = new DashboardModel(
-        createDashboardFixture({
-          panels: [{ id: 12, type: 'graph' }],
-        })
-      );
+      const dashboard = createDashboardModelFixture({
+        panels: [{ id: 12, type: 'graph' }],
+      });
 
       const panel = dashboard.initEditPanel(sourcePanel);
 
@@ -222,11 +210,9 @@ describe('panelEditor actions', () => {
       sourcePanel.plugin = getPanelPlugin({});
       sourcePanel.plugin.angularPanelCtrl = {};
 
-      const dashboard = new DashboardModel(
-        createDashboardFixture({
-          panels: [{ id: 12, type: 'graph' }],
-        })
-      );
+      const dashboard = createDashboardModelFixture({
+        panels: [{ id: 12, type: 'graph' }],
+      });
 
       const panel = dashboard.initEditPanel(sourcePanel);
 

--- a/public/app/features/dashboard/components/PanelEditor/state/actions.test.ts
+++ b/public/app/features/dashboard/components/PanelEditor/state/actions.test.ts
@@ -1,3 +1,4 @@
+import { createDashboardJSON } from 'app/features/dashboard/state/__fixtures__/dashboardJson';
 import { panelModelAndPluginReady, removePanel } from 'app/features/panel/state/reducers';
 import { getPanelPlugin } from 'app/features/plugins/__mocks__/pluginMocks';
 
@@ -10,9 +11,11 @@ import { closeEditor, initialState, PanelEditorState } from './reducers';
 describe('panelEditor actions', () => {
   describe('initPanelEditor', () => {
     it('initPanelEditor should create edit panel model as clone', async () => {
-      const dashboard = new DashboardModel({
-        panels: [{ id: 12, type: 'graph' }],
-      });
+      const dashboard = new DashboardModel(
+        createDashboardJSON({
+          panels: [{ id: 12, type: 'graph' }],
+        })
+      );
       const sourcePanel = new PanelModel({ id: 12, type: 'graph' });
 
       const dispatchedActions = await thunkTester({
@@ -36,9 +39,11 @@ describe('panelEditor actions', () => {
   describe('panelEditorCleanUp', () => {
     it('should update source panel', async () => {
       const sourcePanel = new PanelModel({ id: 12, type: 'graph' });
-      const dashboard = new DashboardModel({
-        panels: [{ id: 12, type: 'graph' }],
-      });
+      const dashboard = new DashboardModel(
+        createDashboardJSON({
+          panels: [{ id: 12, type: 'graph' }],
+        })
+      );
 
       const panel = dashboard.initEditPanel(sourcePanel);
       panel.updateOptions({ prop: true });
@@ -68,9 +73,11 @@ describe('panelEditor actions', () => {
 
     it('should dispatch panelModelAndPluginReady if type changed', async () => {
       const sourcePanel = new PanelModel({ id: 12, type: 'graph' });
-      const dashboard = new DashboardModel({
-        panels: [{ id: 12, type: 'graph' }],
-      });
+      const dashboard = new DashboardModel(
+        createDashboardJSON({
+          panels: [{ id: 12, type: 'graph' }],
+        })
+      );
 
       const panel = dashboard.initEditPanel(sourcePanel);
       panel.type = 'table';
@@ -107,9 +114,11 @@ describe('panelEditor actions', () => {
         customFieldConfigs: {},
       } as any;
 
-      const dashboard = new DashboardModel({
-        panels: [{ id: 12, type: 'graph' }],
-      });
+      const dashboard = new DashboardModel(
+        createDashboardJSON({
+          panels: [{ id: 12, type: 'graph' }],
+        })
+      );
 
       const panel = dashboard.initEditPanel(sourcePanel);
       panel.updateOptions({ prop: true });
@@ -140,9 +149,11 @@ describe('panelEditor actions', () => {
       sourcePanel.plugin = getPanelPlugin({});
       sourcePanel.plugin.angularPanelCtrl = undefined;
 
-      const dashboard = new DashboardModel({
-        panels: [{ id: 12, type: 'graph' }],
-      });
+      const dashboard = new DashboardModel(
+        createDashboardJSON({
+          panels: [{ id: 12, type: 'graph' }],
+        })
+      );
 
       const panel = dashboard.initEditPanel(sourcePanel);
 
@@ -170,9 +181,11 @@ describe('panelEditor actions', () => {
       sourcePanel.plugin = getPanelPlugin({});
       sourcePanel.plugin.angularPanelCtrl = undefined;
 
-      const dashboard = new DashboardModel({
-        panels: [{ id: 12, type: 'graph' }],
-      });
+      const dashboard = new DashboardModel(
+        createDashboardJSON({
+          panels: [{ id: 12, type: 'graph' }],
+        })
+      );
 
       const panel = dashboard.initEditPanel(sourcePanel);
 
@@ -209,9 +222,11 @@ describe('panelEditor actions', () => {
       sourcePanel.plugin = getPanelPlugin({});
       sourcePanel.plugin.angularPanelCtrl = {};
 
-      const dashboard = new DashboardModel({
-        panels: [{ id: 12, type: 'graph' }],
-      });
+      const dashboard = new DashboardModel(
+        createDashboardJSON({
+          panels: [{ id: 12, type: 'graph' }],
+        })
+      );
 
       const panel = dashboard.initEditPanel(sourcePanel);
 

--- a/public/app/features/dashboard/components/SaveDashboard/SaveDashboardDrawer.test.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/SaveDashboardDrawer.test.tsx
@@ -6,6 +6,7 @@ import { Provider } from 'react-redux';
 import { configureStore } from 'app/store/configureStore';
 
 import { DashboardModel } from '../../state';
+import { createDashboardJSON } from '../../state/__fixtures__/dashboardJson';
 
 import { SaveDashboardDrawer } from './SaveDashboardDrawer';
 
@@ -30,10 +31,12 @@ jest.mock('app/core/services/backend_srv', () => ({
 const store = configureStore();
 const mockPost = jest.fn();
 const buildMocks = () => ({
-  dashboard: new DashboardModel({
-    uid: 'mockDashboardUid',
-    version: 1,
-  }),
+  dashboard: new DashboardModel(
+    createDashboardJSON({
+      uid: 'mockDashboardUid',
+      version: 1,
+    })
+  ),
   error: {
     status: 412,
     data: {

--- a/public/app/features/dashboard/components/SaveDashboard/SaveDashboardDrawer.test.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/SaveDashboardDrawer.test.tsx
@@ -6,7 +6,7 @@ import { Provider } from 'react-redux';
 import { configureStore } from 'app/store/configureStore';
 
 import { DashboardModel } from '../../state';
-import { createDashboardFixture } from '../../state/__fixtures__/dashboardFixtures';
+import { createDashboardModelFixture } from '../../state/__fixtures__/dashboardFixtures';
 
 import { SaveDashboardDrawer } from './SaveDashboardDrawer';
 
@@ -31,12 +31,10 @@ jest.mock('app/core/services/backend_srv', () => ({
 const store = configureStore();
 const mockPost = jest.fn();
 const buildMocks = () => ({
-  dashboard: new DashboardModel(
-    createDashboardFixture({
-      uid: 'mockDashboardUid',
-      version: 1,
-    })
-  ),
+  dashboard: createDashboardModelFixture({
+    uid: 'mockDashboardUid',
+    version: 1,
+  }),
   error: {
     status: 412,
     data: {

--- a/public/app/features/dashboard/components/SaveDashboard/SaveDashboardDrawer.test.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/SaveDashboardDrawer.test.tsx
@@ -6,7 +6,7 @@ import { Provider } from 'react-redux';
 import { configureStore } from 'app/store/configureStore';
 
 import { DashboardModel } from '../../state';
-import { createDashboardJSON } from '../../state/__fixtures__/dashboardJson';
+import { createDashboardFixture } from '../../state/__fixtures__/dashboardFixtures';
 
 import { SaveDashboardDrawer } from './SaveDashboardDrawer';
 
@@ -32,7 +32,7 @@ const store = configureStore();
 const mockPost = jest.fn();
 const buildMocks = () => ({
   dashboard: new DashboardModel(
-    createDashboardJSON({
+    createDashboardFixture({
       uid: 'mockDashboardUid',
       version: 1,
     })

--- a/public/app/features/dashboard/components/SaveDashboard/forms/SaveDashboardForm.test.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/forms/SaveDashboardForm.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import { DashboardModel } from 'app/features/dashboard/state';
-import { createDashboardFixture } from 'app/features/dashboard/state/__fixtures__/dashboardFixtures';
+import { createDashboardModelFixture } from 'app/features/dashboard/state/__fixtures__/dashboardFixtures';
 
 import { SaveDashboardOptions } from '../types';
 
@@ -124,14 +124,14 @@ describe('SaveDashboardAsForm', () => {
     it('renders saved message draft if it was filled before', () => {
       render(
         <SaveDashboardForm
-          dashboard={new DashboardModel(createDashboardFixture())}
+          dashboard={createDashboardModelFixture()}
           onCancel={() => {}}
           onSuccess={() => {}}
           onSubmit={async () => {
             return {};
           }}
           saveModel={{
-            clone: new DashboardModel(createDashboardFixture()),
+            clone: createDashboardModelFixture(),
             diff: {},
             diffCount: 0,
             hasChanges: true,

--- a/public/app/features/dashboard/components/SaveDashboard/forms/SaveDashboardForm.test.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/forms/SaveDashboardForm.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import { DashboardModel } from 'app/features/dashboard/state';
+import { createDashboardJSON } from 'app/features/dashboard/state/__fixtures__/dashboardJson';
 
 import { SaveDashboardOptions } from '../types';
 
@@ -123,14 +124,14 @@ describe('SaveDashboardAsForm', () => {
     it('renders saved message draft if it was filled before', () => {
       render(
         <SaveDashboardForm
-          dashboard={new DashboardModel({})}
+          dashboard={new DashboardModel(createDashboardJSON())}
           onCancel={() => {}}
           onSuccess={() => {}}
           onSubmit={async () => {
             return {};
           }}
           saveModel={{
-            clone: new DashboardModel({}),
+            clone: new DashboardModel(createDashboardJSON()),
             diff: {},
             diffCount: 0,
             hasChanges: true,

--- a/public/app/features/dashboard/components/SaveDashboard/forms/SaveDashboardForm.test.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/forms/SaveDashboardForm.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import { DashboardModel } from 'app/features/dashboard/state';
-import { createDashboardJSON } from 'app/features/dashboard/state/__fixtures__/dashboardJson';
+import { createDashboardFixture } from 'app/features/dashboard/state/__fixtures__/dashboardFixtures';
 
 import { SaveDashboardOptions } from '../types';
 
@@ -124,14 +124,14 @@ describe('SaveDashboardAsForm', () => {
     it('renders saved message draft if it was filled before', () => {
       render(
         <SaveDashboardForm
-          dashboard={new DashboardModel(createDashboardJSON())}
+          dashboard={new DashboardModel(createDashboardFixture())}
           onCancel={() => {}}
           onSuccess={() => {}}
           onSubmit={async () => {
             return {};
           }}
           saveModel={{
-            clone: new DashboardModel(createDashboardJSON()),
+            clone: new DashboardModel(createDashboardFixture()),
             diff: {},
             diffCount: 0,
             hasChanges: true,

--- a/public/app/features/dashboard/components/ShareModal/ShareEmbed.test.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareEmbed.test.tsx
@@ -7,6 +7,7 @@ import config from 'app/core/config';
 
 import { Echo } from '../../../../core/services/echo/Echo';
 import { DashboardModel, PanelModel } from '../../state';
+import { createDashboardJSON } from '../../state/__fixtures__/dashboardJson';
 
 import { ShareEmbed } from './ShareEmbed';
 
@@ -68,9 +69,11 @@ describe('ShareEmbed', () => {
   });
 
   it('generates the correct embed url for a dashboard', () => {
-    const mockDashboard = new DashboardModel({
-      uid: 'mockDashboardUid',
-    });
+    const mockDashboard = new DashboardModel(
+      createDashboardJSON({
+        uid: 'mockDashboardUid',
+      })
+    );
     const mockPanel = new PanelModel({
       id: 'mockPanelId',
     });
@@ -86,9 +89,11 @@ describe('ShareEmbed', () => {
 
   it('generates the correct embed url for a dashboard set to the homepage in the grafana config', () => {
     mockLocationHref('http://dashboards.grafana.com/?orgId=1');
-    const mockDashboard = new DashboardModel({
-      uid: 'mockDashboardUid',
-    });
+    const mockDashboard = new DashboardModel(
+      createDashboardJSON({
+        uid: 'mockDashboardUid',
+      })
+    );
     const mockPanel = new PanelModel({
       id: 'mockPanelId',
     });
@@ -104,9 +109,11 @@ describe('ShareEmbed', () => {
   it('generates the correct embed url for a snapshot', () => {
     const mockSlug = 'mockSlug';
     mockLocationHref(`http://dashboards.grafana.com/dashboard/snapshot/${mockSlug}?orgId=1`);
-    const mockDashboard = new DashboardModel({
-      uid: 'mockDashboardUid',
-    });
+    const mockDashboard = new DashboardModel(
+      createDashboardJSON({
+        uid: 'mockDashboardUid',
+      })
+    );
     const mockPanel = new PanelModel({
       id: 'mockPanelId',
     });
@@ -122,9 +129,11 @@ describe('ShareEmbed', () => {
   it('generates the correct embed url for a scripted dashboard', () => {
     const mockSlug = 'scripted.js';
     mockLocationHref(`http://dashboards.grafana.com/dashboard/script/${mockSlug}?orgId=1`);
-    const mockDashboard = new DashboardModel({
-      uid: 'mockDashboardUid',
-    });
+    const mockDashboard = new DashboardModel(
+      createDashboardJSON({
+        uid: 'mockDashboardUid',
+      })
+    );
     const mockPanel = new PanelModel({
       id: 'mockPanelId',
     });

--- a/public/app/features/dashboard/components/ShareModal/ShareEmbed.test.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareEmbed.test.tsx
@@ -6,8 +6,8 @@ import { setEchoSrv } from '@grafana/runtime/src';
 import config from 'app/core/config';
 
 import { Echo } from '../../../../core/services/echo/Echo';
-import { DashboardModel, PanelModel } from '../../state';
-import { createDashboardFixture } from '../../state/__fixtures__/dashboardFixtures';
+import { PanelModel } from '../../state';
+import { createDashboardModelFixture } from '../../state/__fixtures__/dashboardFixtures';
 
 import { ShareEmbed } from './ShareEmbed';
 
@@ -69,11 +69,9 @@ describe('ShareEmbed', () => {
   });
 
   it('generates the correct embed url for a dashboard', () => {
-    const mockDashboard = new DashboardModel(
-      createDashboardFixture({
-        uid: 'mockDashboardUid',
-      })
-    );
+    const mockDashboard = createDashboardModelFixture({
+      uid: 'mockDashboardUid',
+    });
     const mockPanel = new PanelModel({
       id: 'mockPanelId',
     });
@@ -89,11 +87,9 @@ describe('ShareEmbed', () => {
 
   it('generates the correct embed url for a dashboard set to the homepage in the grafana config', () => {
     mockLocationHref('http://dashboards.grafana.com/?orgId=1');
-    const mockDashboard = new DashboardModel(
-      createDashboardFixture({
-        uid: 'mockDashboardUid',
-      })
-    );
+    const mockDashboard = createDashboardModelFixture({
+      uid: 'mockDashboardUid',
+    });
     const mockPanel = new PanelModel({
       id: 'mockPanelId',
     });
@@ -109,11 +105,9 @@ describe('ShareEmbed', () => {
   it('generates the correct embed url for a snapshot', () => {
     const mockSlug = 'mockSlug';
     mockLocationHref(`http://dashboards.grafana.com/dashboard/snapshot/${mockSlug}?orgId=1`);
-    const mockDashboard = new DashboardModel(
-      createDashboardFixture({
-        uid: 'mockDashboardUid',
-      })
-    );
+    const mockDashboard = createDashboardModelFixture({
+      uid: 'mockDashboardUid',
+    });
     const mockPanel = new PanelModel({
       id: 'mockPanelId',
     });
@@ -129,11 +123,9 @@ describe('ShareEmbed', () => {
   it('generates the correct embed url for a scripted dashboard', () => {
     const mockSlug = 'scripted.js';
     mockLocationHref(`http://dashboards.grafana.com/dashboard/script/${mockSlug}?orgId=1`);
-    const mockDashboard = new DashboardModel(
-      createDashboardFixture({
-        uid: 'mockDashboardUid',
-      })
-    );
+    const mockDashboard = createDashboardModelFixture({
+      uid: 'mockDashboardUid',
+    });
     const mockPanel = new PanelModel({
       id: 'mockPanelId',
     });

--- a/public/app/features/dashboard/components/ShareModal/ShareEmbed.test.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareEmbed.test.tsx
@@ -7,7 +7,7 @@ import config from 'app/core/config';
 
 import { Echo } from '../../../../core/services/echo/Echo';
 import { DashboardModel, PanelModel } from '../../state';
-import { createDashboardJSON } from '../../state/__fixtures__/dashboardJson';
+import { createDashboardFixture } from '../../state/__fixtures__/dashboardFixtures';
 
 import { ShareEmbed } from './ShareEmbed';
 
@@ -70,7 +70,7 @@ describe('ShareEmbed', () => {
 
   it('generates the correct embed url for a dashboard', () => {
     const mockDashboard = new DashboardModel(
-      createDashboardJSON({
+      createDashboardFixture({
         uid: 'mockDashboardUid',
       })
     );
@@ -90,7 +90,7 @@ describe('ShareEmbed', () => {
   it('generates the correct embed url for a dashboard set to the homepage in the grafana config', () => {
     mockLocationHref('http://dashboards.grafana.com/?orgId=1');
     const mockDashboard = new DashboardModel(
-      createDashboardJSON({
+      createDashboardFixture({
         uid: 'mockDashboardUid',
       })
     );
@@ -110,7 +110,7 @@ describe('ShareEmbed', () => {
     const mockSlug = 'mockSlug';
     mockLocationHref(`http://dashboards.grafana.com/dashboard/snapshot/${mockSlug}?orgId=1`);
     const mockDashboard = new DashboardModel(
-      createDashboardJSON({
+      createDashboardFixture({
         uid: 'mockDashboardUid',
       })
     );
@@ -130,7 +130,7 @@ describe('ShareEmbed', () => {
     const mockSlug = 'scripted.js';
     mockLocationHref(`http://dashboards.grafana.com/dashboard/script/${mockSlug}?orgId=1`);
     const mockDashboard = new DashboardModel(
-      createDashboardJSON({
+      createDashboardFixture({
         uid: 'mockDashboardUid',
       })
     );

--- a/public/app/features/dashboard/components/ShareModal/ShareLink.test.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareLink.test.tsx
@@ -12,6 +12,7 @@ import { Echo } from '../../../../core/services/echo/Echo';
 import { variableAdapters } from '../../../variables/adapters';
 import { createQueryVariableAdapter } from '../../../variables/query/adapter';
 import { DashboardModel, PanelModel } from '../../state';
+import { createDashboardJSON } from '../../state/__fixtures__/dashboardJson';
 
 import { Props, ShareLink } from './ShareLink';
 
@@ -78,13 +79,22 @@ describe('ShareModal', () => {
   });
 
   beforeEach(() => {
+    const defaultTimeRange = getDefaultTimeRange();
     setUTCTimeZone();
     mockLocationHref('http://server/#!/test');
     config.rendererAvailable = true;
     config.bootData.user.orgId = 1;
     props = {
       panel: new PanelModel({ id: 22, options: {}, fieldConfig: { defaults: {}, overrides: [] } }),
-      dashboard: new DashboardModel({ time: getDefaultTimeRange(), id: 1 }),
+      dashboard: new DashboardModel(
+        createDashboardJSON({
+          time: {
+            from: defaultTimeRange.from.toISOString(),
+            to: defaultTimeRange.to.toISOString(),
+          },
+          id: 1,
+        })
+      ),
     };
   });
 
@@ -175,10 +185,12 @@ describe('when appUrl is set in the grafana config', () => {
   });
 
   it('should render the correct link', async () => {
-    const mockDashboard = new DashboardModel({
-      uid: 'mockDashboardUid',
-      id: 1,
-    });
+    const mockDashboard = new DashboardModel(
+      createDashboardJSON({
+        uid: 'mockDashboardUid',
+        id: 1,
+      })
+    );
     const mockPanel = new PanelModel({
       id: 'mockPanelId',
     });

--- a/public/app/features/dashboard/components/ShareModal/ShareLink.test.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareLink.test.tsx
@@ -11,8 +11,8 @@ import { initTemplateSrv } from '../../../../../test/helpers/initTemplateSrv';
 import { Echo } from '../../../../core/services/echo/Echo';
 import { variableAdapters } from '../../../variables/adapters';
 import { createQueryVariableAdapter } from '../../../variables/query/adapter';
-import { DashboardModel, PanelModel } from '../../state';
-import { createDashboardFixture } from '../../state/__fixtures__/dashboardFixtures';
+import { PanelModel } from '../../state';
+import { createDashboardModelFixture } from '../../state/__fixtures__/dashboardFixtures';
 
 import { Props, ShareLink } from './ShareLink';
 
@@ -86,15 +86,13 @@ describe('ShareModal', () => {
     config.bootData.user.orgId = 1;
     props = {
       panel: new PanelModel({ id: 22, options: {}, fieldConfig: { defaults: {}, overrides: [] } }),
-      dashboard: new DashboardModel(
-        createDashboardFixture({
-          time: {
-            from: defaultTimeRange.from.toISOString(),
-            to: defaultTimeRange.to.toISOString(),
-          },
-          id: 1,
-        })
-      ),
+      dashboard: createDashboardModelFixture({
+        time: {
+          from: defaultTimeRange.from.toISOString(),
+          to: defaultTimeRange.to.toISOString(),
+        },
+        id: 1,
+      }),
     };
   });
 
@@ -185,12 +183,10 @@ describe('when appUrl is set in the grafana config', () => {
   });
 
   it('should render the correct link', async () => {
-    const mockDashboard = new DashboardModel(
-      createDashboardFixture({
-        uid: 'mockDashboardUid',
-        id: 1,
-      })
-    );
+    const mockDashboard = createDashboardModelFixture({
+      uid: 'mockDashboardUid',
+      id: 1,
+    });
     const mockPanel = new PanelModel({
       id: 'mockPanelId',
     });

--- a/public/app/features/dashboard/components/ShareModal/ShareLink.test.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareLink.test.tsx
@@ -12,7 +12,7 @@ import { Echo } from '../../../../core/services/echo/Echo';
 import { variableAdapters } from '../../../variables/adapters';
 import { createQueryVariableAdapter } from '../../../variables/query/adapter';
 import { DashboardModel, PanelModel } from '../../state';
-import { createDashboardJSON } from '../../state/__fixtures__/dashboardJson';
+import { createDashboardFixture } from '../../state/__fixtures__/dashboardFixtures';
 
 import { Props, ShareLink } from './ShareLink';
 
@@ -87,7 +87,7 @@ describe('ShareModal', () => {
     props = {
       panel: new PanelModel({ id: 22, options: {}, fieldConfig: { defaults: {}, overrides: [] } }),
       dashboard: new DashboardModel(
-        createDashboardJSON({
+        createDashboardFixture({
           time: {
             from: defaultTimeRange.from.toISOString(),
             to: defaultTimeRange.to.toISOString(),
@@ -186,7 +186,7 @@ describe('when appUrl is set in the grafana config', () => {
 
   it('should render the correct link', async () => {
     const mockDashboard = new DashboardModel(
-      createDashboardJSON({
+      createDashboardFixture({
         uid: 'mockDashboardUid',
         id: 1,
       })

--- a/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/SharePublicDashboard.test.tsx
+++ b/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/SharePublicDashboard.test.tsx
@@ -13,6 +13,7 @@ import { backendSrv } from 'app/core/services/backend_srv';
 import { contextSrv } from 'app/core/services/context_srv';
 import { Echo } from 'app/core/services/echo/Echo';
 import { DashboardModel, PanelModel } from 'app/features/dashboard/state';
+import { createDashboardJSON } from 'app/features/dashboard/state/__fixtures__/dashboardJson';
 import { configureStore } from 'app/store/configureStore';
 
 import { ShareModal } from '../ShareModal';
@@ -81,9 +82,11 @@ beforeAll(() => {
 
 beforeEach(() => {
   config.featureToggles.publicDashboards = true;
-  mockDashboard = new DashboardModel({
-    uid: 'mockDashboardUid',
-  });
+  mockDashboard = new DashboardModel(
+    createDashboardJSON({
+      uid: 'mockDashboardUid',
+    })
+  );
 
   mockPanel = new PanelModel({
     id: 'mockPanelId',

--- a/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/SharePublicDashboard.test.tsx
+++ b/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/SharePublicDashboard.test.tsx
@@ -13,7 +13,7 @@ import { backendSrv } from 'app/core/services/backend_srv';
 import { contextSrv } from 'app/core/services/context_srv';
 import { Echo } from 'app/core/services/echo/Echo';
 import { DashboardModel, PanelModel } from 'app/features/dashboard/state';
-import { createDashboardJSON } from 'app/features/dashboard/state/__fixtures__/dashboardJson';
+import { createDashboardFixture } from 'app/features/dashboard/state/__fixtures__/dashboardFixtures';
 import { configureStore } from 'app/store/configureStore';
 
 import { ShareModal } from '../ShareModal';
@@ -83,7 +83,7 @@ beforeAll(() => {
 beforeEach(() => {
   config.featureToggles.publicDashboards = true;
   mockDashboard = new DashboardModel(
-    createDashboardJSON({
+    createDashboardFixture({
       uid: 'mockDashboardUid',
     })
   );

--- a/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/SharePublicDashboard.test.tsx
+++ b/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/SharePublicDashboard.test.tsx
@@ -13,7 +13,7 @@ import { backendSrv } from 'app/core/services/backend_srv';
 import { contextSrv } from 'app/core/services/context_srv';
 import { Echo } from 'app/core/services/echo/Echo';
 import { DashboardModel, PanelModel } from 'app/features/dashboard/state';
-import { createDashboardFixture } from 'app/features/dashboard/state/__fixtures__/dashboardFixtures';
+import { createDashboardModelFixture } from 'app/features/dashboard/state/__fixtures__/dashboardFixtures';
 import { configureStore } from 'app/store/configureStore';
 
 import { ShareModal } from '../ShareModal';
@@ -82,11 +82,9 @@ beforeAll(() => {
 
 beforeEach(() => {
   config.featureToggles.publicDashboards = true;
-  mockDashboard = new DashboardModel(
-    createDashboardFixture({
-      uid: 'mockDashboardUid',
-    })
-  );
+  mockDashboard = createDashboardModelFixture({
+    uid: 'mockDashboardUid',
+  });
 
   mockPanel = new PanelModel({
     id: 'mockPanelId',

--- a/public/app/features/dashboard/components/VersionHistory/HistorySrv.test.ts
+++ b/public/app/features/dashboard/components/VersionHistory/HistorySrv.test.ts
@@ -1,5 +1,5 @@
 import { DashboardModel } from '../../state/DashboardModel';
-import { createDashboardJSON } from '../../state/__fixtures__/dashboardJson';
+import { createDashboardFixture } from '../../state/__fixtures__/dashboardFixtures';
 
 import { HistorySrv } from './HistorySrv';
 import { restore, versions } from './__mocks__/dashboardHistoryMocks';
@@ -26,8 +26,8 @@ describe('historySrv', () => {
 
   let historySrv = new HistorySrv();
 
-  const dash = new DashboardModel(createDashboardJSON({ uid: '_U4zObQMz' }));
-  const emptyDash = new DashboardModel(createDashboardJSON({}));
+  const dash = new DashboardModel(createDashboardFixture({ uid: '_U4zObQMz' }));
+  const emptyDash = new DashboardModel(createDashboardFixture({}));
   const historyListOpts = { limit: 10, start: 0 };
 
   beforeEach(() => {

--- a/public/app/features/dashboard/components/VersionHistory/HistorySrv.test.ts
+++ b/public/app/features/dashboard/components/VersionHistory/HistorySrv.test.ts
@@ -1,4 +1,5 @@
 import { DashboardModel } from '../../state/DashboardModel';
+import { createDashboardJSON } from '../../state/__fixtures__/dashboardJson';
 
 import { HistorySrv } from './HistorySrv';
 import { restore, versions } from './__mocks__/dashboardHistoryMocks';
@@ -25,8 +26,8 @@ describe('historySrv', () => {
 
   let historySrv = new HistorySrv();
 
-  const dash = new DashboardModel({ uid: '_U4zObQMz' });
-  const emptyDash = new DashboardModel({});
+  const dash = new DashboardModel(createDashboardJSON({ uid: '_U4zObQMz' }));
+  const emptyDash = new DashboardModel(createDashboardJSON({}));
   const historyListOpts = { limit: 10, start: 0 };
 
   beforeEach(() => {

--- a/public/app/features/dashboard/components/VersionHistory/HistorySrv.test.ts
+++ b/public/app/features/dashboard/components/VersionHistory/HistorySrv.test.ts
@@ -1,5 +1,5 @@
 import { DashboardModel } from '../../state/DashboardModel';
-import { createDashboardFixture } from '../../state/__fixtures__/dashboardFixtures';
+import { createDashboardModelFixture } from '../../state/__fixtures__/dashboardFixtures';
 
 import { HistorySrv } from './HistorySrv';
 import { restore, versions } from './__mocks__/dashboardHistoryMocks';
@@ -26,8 +26,8 @@ describe('historySrv', () => {
 
   let historySrv = new HistorySrv();
 
-  const dash = new DashboardModel(createDashboardFixture({ uid: '_U4zObQMz' }));
-  const emptyDash = new DashboardModel(createDashboardFixture({}));
+  const dash = createDashboardModelFixture({ uid: '_U4zObQMz' });
+  const emptyDash = createDashboardModelFixture();
   const historyListOpts = { limit: 10, start: 0 };
 
   beforeEach(() => {

--- a/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeader.test.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeader.test.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 
 import { createEmptyQueryResponse } from '../../../explore/state/utils';
 import { DashboardModel, PanelModel } from '../../state';
+import { createDashboardJSON } from '../../state/__fixtures__/dashboardJson';
 
 import { PanelHeader } from './PanelHeader';
 
@@ -16,7 +17,7 @@ let panelModel = new PanelModel({
 let panelData = createEmptyQueryResponse();
 
 describe('Panel Header', () => {
-  const dashboardModel = new DashboardModel({}, { publicDashboardAccessToken: 'abc123' });
+  const dashboardModel = new DashboardModel(createDashboardJSON({}), { publicDashboardAccessToken: 'abc123' });
   it('will render header title but not render dropdown icon when dashboard is being viewed publicly', () => {
     window.history.pushState({}, 'Test Title', '/public-dashboards/abc123');
 
@@ -29,7 +30,7 @@ describe('Panel Header', () => {
   });
 
   it('will render header title and dropdown icon when dashboard is not being viewed publicly', () => {
-    const dashboardModel = new DashboardModel({}, { publicDashboardAccessToken: '' });
+    const dashboardModel = new DashboardModel(createDashboardJSON({}), { publicDashboardAccessToken: '' });
     window.history.pushState({}, 'Test Title', '/d/abc/123');
 
     render(

--- a/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeader.test.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeader.test.tsx
@@ -2,8 +2,8 @@ import { render, screen } from '@testing-library/react';
 import React from 'react';
 
 import { createEmptyQueryResponse } from '../../../explore/state/utils';
-import { DashboardModel, PanelModel } from '../../state';
-import { createDashboardJSON } from '../../state/__fixtures__/dashboardJson';
+import { PanelModel } from '../../state';
+import { createDashboardModelFixture } from '../../state/__fixtures__/dashboardFixtures';
 
 import { PanelHeader } from './PanelHeader';
 
@@ -17,7 +17,7 @@ let panelModel = new PanelModel({
 let panelData = createEmptyQueryResponse();
 
 describe('Panel Header', () => {
-  const dashboardModel = new DashboardModel(createDashboardJSON({}), { publicDashboardAccessToken: 'abc123' });
+  const dashboardModel = createDashboardModelFixture({}, { publicDashboardAccessToken: 'abc123' });
   it('will render header title but not render dropdown icon when dashboard is being viewed publicly', () => {
     window.history.pushState({}, 'Test Title', '/public-dashboards/abc123');
 
@@ -30,7 +30,7 @@ describe('Panel Header', () => {
   });
 
   it('will render header title and dropdown icon when dashboard is not being viewed publicly', () => {
-    const dashboardModel = new DashboardModel(createDashboardJSON({}), { publicDashboardAccessToken: '' });
+    const dashboardModel = createDashboardModelFixture({}, { publicDashboardAccessToken: '' });
     window.history.pushState({}, 'Test Title', '/d/abc/123');
 
     render(

--- a/public/app/features/dashboard/state/DashboardMigrator.test.ts
+++ b/public/app/features/dashboard/state/DashboardMigrator.test.ts
@@ -66,6 +66,7 @@ describe('DashboardModel', () => {
         panels: [
           {
             type: 'graph',
+            // @ts-expect-error
             legend: true,
             aliasYAxis: { test: 2 },
             y_formats: ['kbyte', 'ms'],
@@ -87,6 +88,7 @@ describe('DashboardModel', () => {
           {
             type: 'singlestat',
             legend: true,
+            // @ts-expect-error
             thresholds: '10,20,30',
             colors: ['#FF0000', 'green', 'orange'],
             aliasYAxis: { test: 2 },
@@ -95,6 +97,7 @@ describe('DashboardModel', () => {
           },
           {
             type: 'singlestat',
+            // @ts-expect-error
             thresholds: '10,20,30',
             colors: ['#FF0000', 'green', 'orange'],
             gauge: {
@@ -106,6 +109,7 @@ describe('DashboardModel', () => {
           },
           {
             type: 'table',
+            // @ts-expect-error
             legend: true,
             styles: [{ thresholds: ['10', '20', '30'] }, { thresholds: ['100', '200', '300'] }],
             targets: [{ refId: 'A' }, {}],
@@ -210,6 +214,7 @@ describe('DashboardModel', () => {
         panels: [
           {
             type: 'graph',
+            // @ts-expect-error
             y_formats: ['kbyte', 'ms'],
             grid: {
               threshold1: 200,
@@ -468,6 +473,7 @@ describe('DashboardModel', () => {
       const model = {
         panels: [{ minSpan: 8 }],
       };
+      // @ts-expect-error
       const dashboard = new DashboardModel(model);
       expect(dashboard.panels[0].maxPerRow).toBe(3);
     });
@@ -481,6 +487,7 @@ describe('DashboardModel', () => {
         panels: [
           {
             links: [
+              // @ts-expect-error
               {
                 url: 'http://mylink.com',
                 keepTime: true,
@@ -488,23 +495,28 @@ describe('DashboardModel', () => {
               },
               {
                 url: 'http://mylink.com?existingParam',
+                // @ts-expect-error
                 params: 'customParam',
                 title: 'test',
               },
+              // @ts-expect-error
               {
                 url: 'http://mylink.com?existingParam',
                 includeVars: true,
                 title: 'test',
               },
               {
+                // @ts-expect-error
                 dashboard: 'my other dashboard',
                 title: 'test',
               },
               {
+                // @ts-expect-error
                 dashUri: '',
                 title: 'test',
               },
               {
+                // @ts-expect-error
                 type: 'dashboard',
                 keepTime: true,
               },
@@ -536,6 +548,7 @@ describe('DashboardModel', () => {
     beforeEach(() => {
       model = new DashboardModel({
         panels: [
+          // @ts-expect-error
           {
             //graph panel
             options: {
@@ -549,6 +562,7 @@ describe('DashboardModel', () => {
               ],
             },
           },
+          // @ts-expect-error
           {
             //  panel with field options
             options: {
@@ -601,6 +615,7 @@ describe('DashboardModel', () => {
     beforeEach(() => {
       model = new DashboardModel({
         panels: [
+          // @ts-expect-error
           {
             //graph panel
             options: {
@@ -611,6 +626,7 @@ describe('DashboardModel', () => {
               ],
             },
           },
+          // @ts-expect-error
           {
             //  panel with field options
             options: {
@@ -649,6 +665,7 @@ describe('DashboardModel', () => {
         templating: {
           list: [
             {
+              // @ts-expect-error
               multi: false,
               current: {
                 value: ['value'],
@@ -656,6 +673,7 @@ describe('DashboardModel', () => {
               },
             },
             {
+              // @ts-expect-error
               multi: true,
               current: {
                 value: ['value'],
@@ -697,6 +715,7 @@ describe('DashboardModel', () => {
           list: [
             {
               type: 'query',
+              // @ts-expect-error
               tags: ['Africa', 'America', 'Asia', 'Europe'],
               tagsQuery: 'select datacenter from x',
               tagValuesQuery: 'select value from x where datacenter = xyz',
@@ -704,6 +723,7 @@ describe('DashboardModel', () => {
             },
             {
               type: 'query',
+              // @ts-expect-error
               current: {
                 tags: [
                   {
@@ -729,6 +749,7 @@ describe('DashboardModel', () => {
             },
             {
               type: 'query',
+              // @ts-expect-error
               tags: [
                 { text: 'Africa', selected: false },
                 { text: 'America', selected: true },
@@ -783,10 +804,12 @@ describe('DashboardModel', () => {
             id: 2,
             type: 'text',
             title: 'Angular Text Panel',
+            // @ts-expect-error
             content:
               '# Angular Text Panel\n# $constant\n\nFor markdown syntax help: [commonmark.org/help](https://commonmark.org/help/)\n\n## $text\n\n',
             mode: 'markdown',
           },
+          // @ts-expect-error
           {
             id: 3,
             type: 'text2',
@@ -797,6 +820,7 @@ describe('DashboardModel', () => {
                 '# React Text Panel from scratch\n# $constant\n\nFor markdown syntax help: [commonmark.org/help](https://commonmark.org/help/)\n\n## $text',
             },
           },
+          // @ts-expect-error
           {
             id: 4,
             type: 'text2',
@@ -865,24 +889,28 @@ describe('DashboardModel', () => {
           list: [
             {
               type: 'query',
+              // @ts-expect-error
               hide: VariableHide.dontHide,
               datasource: null,
               allFormat: '',
             },
             {
               type: 'query',
+              // @ts-expect-error
               hide: VariableHide.hideLabel,
               datasource: null,
               allFormat: '',
             },
             {
               type: 'query',
+              // @ts-expect-error
               hide: VariableHide.hideVariable,
               datasource: null,
               allFormat: '',
             },
             {
               type: 'constant',
+              // @ts-expect-error
               hide: VariableHide.dontHide,
               query: 'default value',
               current: { selected: true, text: 'A', value: 'B' },
@@ -892,6 +920,7 @@ describe('DashboardModel', () => {
             },
             {
               type: 'constant',
+              // @ts-expect-error
               hide: VariableHide.hideLabel,
               query: 'default value',
               current: { selected: true, text: 'A', value: 'B' },
@@ -901,6 +930,7 @@ describe('DashboardModel', () => {
             },
             {
               type: 'constant',
+              // @ts-expect-error
               hide: VariableHide.hideVariable,
               query: 'default value',
               current: { selected: true, text: 'A', value: 'B' },
@@ -967,79 +997,93 @@ describe('DashboardModel', () => {
             {
               type: 'query',
               name: 'variable_with_never_refresh_with_options',
+              // @ts-expect-error
               options: [{ text: 'A', value: 'A' }],
               refresh: 0,
             },
             {
               type: 'query',
               name: 'variable_with_never_refresh_without_options',
+              // @ts-expect-error
               options: [],
               refresh: 0,
             },
             {
               type: 'query',
               name: 'variable_with_dashboard_refresh_with_options',
+              // @ts-expect-error
               options: [{ text: 'A', value: 'A' }],
               refresh: 1,
             },
             {
               type: 'query',
               name: 'variable_with_dashboard_refresh_without_options',
+              // @ts-expect-error
               options: [],
               refresh: 1,
             },
             {
               type: 'query',
               name: 'variable_with_timerange_refresh_with_options',
+              // @ts-expect-error
               options: [{ text: 'A', value: 'A' }],
               refresh: 2,
             },
             {
               type: 'query',
               name: 'variable_with_timerange_refresh_without_options',
+              // @ts-expect-error
               options: [],
               refresh: 2,
             },
             {
               type: 'query',
               name: 'variable_with_no_refresh_with_options',
+              // @ts-expect-error
               options: [{ text: 'A', value: 'A' }],
             },
             {
               type: 'query',
               name: 'variable_with_no_refresh_without_options',
+              // @ts-expect-error
               options: [],
             },
             {
               type: 'query',
               name: 'variable_with_unknown_refresh_with_options',
+              // @ts-expect-error
               options: [{ text: 'A', value: 'A' }],
               refresh: 2001,
             },
             {
               type: 'query',
               name: 'variable_with_unknown_refresh_without_options',
+              // @ts-expect-error
               options: [],
               refresh: 2001,
             },
             {
               type: 'custom',
               name: 'custom',
+              // @ts-expect-error
               options: [{ text: 'custom', value: 'custom' }],
             },
             {
               type: 'textbox',
               name: 'textbox',
+              // @ts-expect-error
               options: [{ text: 'Hello', value: 'World' }],
             },
             {
               type: 'datasource',
               name: 'datasource',
+              // @ts-expect-error
               options: [{ text: 'ds', value: 'ds' }], // fake example doesn't exist
             },
             {
               type: 'interval',
               name: 'interval',
+              // @ts-expect-error
               options: [{ text: '1m', value: '1m' }],
             },
           ],
@@ -1112,10 +1156,12 @@ describe('DashboardModel', () => {
             fieldConfig: {
               defaults: {
                 thresholds: {
+                  // @ts-expect-error
                   mode: 'absolute',
                   steps: [
                     {
                       color: 'green',
+                      // @ts-expect-error
                       value: null,
                     },
                     {
@@ -1128,12 +1174,14 @@ describe('DashboardModel', () => {
                   {
                     id: 0,
                     text: '1',
+                    // @ts-expect-error
                     type: 1,
                     value: 'up',
                   },
                   {
                     id: 1,
                     text: 'BAD',
+                    // @ts-expect-error
                     type: 1,
                     value: 'down',
                   },
@@ -1142,6 +1190,7 @@ describe('DashboardModel', () => {
                     id: 2,
                     text: 'below 30',
                     to: '30',
+                    // @ts-expect-error
                     type: 2,
                   },
                   {
@@ -1149,9 +1198,11 @@ describe('DashboardModel', () => {
                     id: 3,
                     text: '100',
                     to: '100',
+                    // @ts-expect-error
                     type: 2,
                   },
                   {
+                    // @ts-expect-error
                     type: 1,
                     value: 'null',
                     text: 'it is null',
@@ -1243,6 +1294,7 @@ describe('DashboardModel', () => {
         panels: [
           {
             type: 'timeseries',
+            // @ts-expect-error
             legend: true,
             options: {
               tooltipOptions: { mode: 'multi' },
@@ -1250,6 +1302,7 @@ describe('DashboardModel', () => {
           },
           {
             type: 'xychart',
+            // @ts-expect-error
             legend: true,
             options: {
               tooltipOptions: { mode: 'single' },
@@ -1281,6 +1334,7 @@ describe('DashboardModel', () => {
           {
             type: 'singlestat',
             legend: true,
+            // @ts-expect-error
             thresholds: '10,20,30',
             colors: ['#FF0000', 'green', 'orange'],
             aliasYAxis: { test: 2 },
@@ -1342,6 +1396,7 @@ describe('DashboardModel', () => {
           {
             type: 'singlestat',
             legend: true,
+            // @ts-expect-error
             thresholds: '10,20,30',
             colors: ['#FF0000', 'green', 'orange'],
             aliasYAxis: { test: 2 },
@@ -1424,6 +1479,7 @@ describe('DashboardModel', () => {
           {
             id: 1,
             type: 'timeseries',
+            // @ts-expect-error
             panels: [
               {
                 id: 2,
@@ -1462,6 +1518,7 @@ describe('DashboardModel', () => {
           {
             id: 1,
             type: 'timeseries',
+            // @ts-expect-error
             transformations: [{ id: 'labelsToFields' }],
           },
         ],
@@ -1493,6 +1550,7 @@ describe('DashboardModel', () => {
         annotations: {
           list: [
             {
+              // @ts-expect-error
               actionPrefix: '',
               alarmNamePrefix: '',
               alias: '',
@@ -1515,6 +1573,7 @@ describe('DashboardModel', () => {
           ],
         },
         panels: [
+          // @ts-expect-error
           {
             gridPos: {
               h: 8,
@@ -1602,6 +1661,7 @@ describe('DashboardModel', () => {
           annotations: {
             list: [
               {
+                // @ts-expect-error
                 actionPrefix: '',
                 alarmNamePrefix: '',
                 alias: '',
@@ -1636,6 +1696,7 @@ describe('DashboardModel', () => {
               title: 'DynamoDB',
               type: 'row',
               panels: [
+                // @ts-expect-error
                 {
                   gridPos: {
                     h: 8,
@@ -1690,6 +1751,7 @@ describe('DashboardModel', () => {
                   title: 'Panel Title',
                   type: 'timeseries',
                 },
+                // @ts-expect-error
                 {
                   gridPos: {
                     h: 8,
@@ -1791,6 +1853,7 @@ describe('DashboardModel', () => {
             {
               type: 'query',
               name: 'var',
+              // @ts-expect-error
               options: [{ text: 'A', value: 'A' }],
               refresh: 0,
               datasource: 'prom',
@@ -1800,14 +1863,17 @@ describe('DashboardModel', () => {
         panels: [
           {
             id: 1,
+            // @ts-expect-error
             datasource: 'prom',
           },
           {
             id: 2,
+            // @ts-expect-error
             datasource: null,
           },
           {
             id: 3,
+            // @ts-expect-error
             datasource: MIXED_DATASOURCE_NAME,
             targets: [
               {
@@ -1827,6 +1893,7 @@ describe('DashboardModel', () => {
             panels: [
               {
                 id: 6,
+                // @ts-expect-error
                 datasource: 'prom',
               },
             ],
@@ -1873,6 +1940,7 @@ describe('DashboardModel', () => {
         panels: [
           {
             id: 2,
+            // @ts-expect-error
             datasource: null,
             targets: [
               {
@@ -1894,6 +1962,7 @@ describe('DashboardModel', () => {
     test('preserves x axis visibility', () => {
       const model = new DashboardModel({
         panels: [
+          // @ts-expect-error
           {
             type: 'timeseries',
             fieldConfig: {
@@ -1937,6 +2006,7 @@ describe('DashboardModel', () => {
             {
               type: 'query',
               name: 'var',
+              // @ts-expect-error
               options: [{ text: 'A', value: 'A' }],
               refresh: 0,
               datasource: null,
@@ -1946,9 +2016,11 @@ describe('DashboardModel', () => {
         annotations: {
           list: [
             {
+              // @ts-expect-error
               datasource: null,
             },
             {
+              // @ts-expect-error
               datasource: 'prom',
             },
           ],
@@ -1956,6 +2028,7 @@ describe('DashboardModel', () => {
         panels: [
           {
             id: 2,
+            // @ts-expect-error
             datasource: null,
             targets: [
               {
@@ -1963,6 +2036,7 @@ describe('DashboardModel', () => {
               },
             ],
           },
+          // @ts-expect-error
           {
             id: 3,
             targets: [
@@ -2007,6 +2081,7 @@ describe('DashboardModel', () => {
     beforeEach(() => {
       model = new DashboardModel({
         panels: [
+          // @ts-expect-error
           {
             id: 2,
             targets: [
@@ -2040,6 +2115,7 @@ describe('when generating the legend for a panel', () => {
   beforeEach(() => {
     model = new DashboardModel({
       panels: [
+        // @ts-expect-error
         {
           id: 0,
           options: {
@@ -2052,6 +2128,7 @@ describe('when generating the legend for a panel', () => {
             },
           },
         },
+        // @ts-expect-error
         {
           id: 1,
           options: {
@@ -2064,6 +2141,7 @@ describe('when generating the legend for a panel', () => {
             },
           },
         },
+        // @ts-expect-error
         {
           id: 2,
           options: {

--- a/public/app/features/dashboard/state/DashboardModel.refresh.test.ts
+++ b/public/app/features/dashboard/state/DashboardModel.refresh.test.ts
@@ -2,8 +2,8 @@ import { appEvents } from '../../../core/core';
 import { VariablesChanged } from '../../variables/types';
 import { getTimeSrv, setTimeSrv } from '../services/TimeSrv';
 
-import { DashboardModel } from './DashboardModel';
 import { PanelModel } from './PanelModel';
+import { createDashboardModelFixture } from './__fixtures__/dashboardFixtures';
 
 function getTestContext({
   usePanelInEdit,
@@ -12,7 +12,7 @@ function getTestContext({
 }: { usePanelInEdit?: boolean; usePanelInView?: boolean; refreshAll?: boolean } = {}) {
   jest.clearAllMocks();
 
-  const dashboard = new DashboardModel({});
+  const dashboard = createDashboardModelFixture();
   const startRefreshMock = jest.fn();
   dashboard.startRefresh = startRefreshMock;
   const panelInView = new PanelModel({ id: 99 });

--- a/public/app/features/dashboard/state/DashboardModel.test.ts
+++ b/public/app/features/dashboard/state/DashboardModel.test.ts
@@ -1,5 +1,6 @@
 import { keys as _keys } from 'lodash';
 
+import { VariableHide } from '@grafana/data';
 import { contextSrv } from 'app/core/services/context_srv';
 
 import { getDashboardModel } from '../../../../test/helpers/getDashboardModel';
@@ -10,6 +11,12 @@ import { createQueryVariableAdapter } from '../../variables/query/adapter';
 import { setTimeSrv, TimeSrv } from '../services/TimeSrv';
 import { DashboardModel } from '../state/DashboardModel';
 import { PanelModel } from '../state/PanelModel';
+
+import {
+  createAnnotationJSONFixture,
+  createDashboardModelFixture,
+  createPanelJSONFixture,
+} from './__fixtures__/dashboardFixtures';
 
 jest.mock('app/core/services/context_srv');
 
@@ -26,7 +33,7 @@ describe('DashboardModel', () => {
     let model: DashboardModel;
 
     beforeEach(() => {
-      model = new DashboardModel({}, {});
+      model = createDashboardModelFixture();
     });
 
     it('should have title', () => {
@@ -47,8 +54,8 @@ describe('DashboardModel', () => {
     let model: DashboardModel;
 
     beforeEach(() => {
-      model = new DashboardModel({
-        panels: [{ id: 5 }],
+      model = createDashboardModelFixture({
+        panels: [createPanelJSONFixture({ id: 5 })],
       });
     });
 
@@ -59,7 +66,7 @@ describe('DashboardModel', () => {
 
   describe('getSaveModelClone', () => {
     it('should sort keys', () => {
-      const model = new DashboardModel({});
+      const model = createDashboardModelFixture();
 
       const saveModel = model.getSaveModelClone();
       const keys = _keys(saveModel);
@@ -69,7 +76,7 @@ describe('DashboardModel', () => {
     });
 
     it('should remove add panel panels', () => {
-      const model = new DashboardModel({});
+      const model = createDashboardModelFixture();
       model.addPanel({
         type: 'add-panel',
       });
@@ -86,7 +93,7 @@ describe('DashboardModel', () => {
     });
 
     it('should save model in edit mode', () => {
-      const model = new DashboardModel({});
+      const model = createDashboardModelFixture();
       model.addPanel({ type: 'graph' });
 
       const panel = model.initEditPanel(model.panels[0]);
@@ -104,7 +111,7 @@ describe('DashboardModel', () => {
     let dashboard: DashboardModel;
 
     beforeEach(() => {
-      dashboard = new DashboardModel({});
+      dashboard = createDashboardModelFixture();
     });
 
     it('adding panel should new up panel model', () => {
@@ -147,7 +154,7 @@ describe('DashboardModel', () => {
     let model: DashboardModel;
 
     beforeEach(() => {
-      model = new DashboardModel({ editable: false });
+      model = createDashboardModelFixture({ editable: false });
     });
 
     it('Should set meta canEdit and canSave to false', () => {
@@ -166,12 +173,10 @@ describe('DashboardModel', () => {
     let target: any;
 
     beforeEach(() => {
-      model = new DashboardModel({
+      model = createDashboardModelFixture({
         panels: [
-          {
+          createPanelJSONFixture({
             type: 'graph',
-            grid: {},
-            yaxes: [{}, {}],
             targets: [
               {
                 alias: '$tag_datacenter $tag_source $col',
@@ -210,7 +215,7 @@ describe('DashboardModel', () => {
                 ],
               },
             ],
-          },
+          }),
         ],
       });
 
@@ -232,7 +237,7 @@ describe('DashboardModel', () => {
     let model: DashboardModel;
 
     beforeEach(() => {
-      model = new DashboardModel({
+      model = createDashboardModelFixture({
         annotations: {
           enable: true,
         },
@@ -257,7 +262,7 @@ describe('DashboardModel', () => {
     let dashboard: DashboardModel;
 
     beforeEach(() => {
-      dashboard = new DashboardModel({ timezone: 'utc' });
+      dashboard = createDashboardModelFixture({ timezone: 'utc' });
     });
 
     it('Should format timestamp with second resolution by default', () => {
@@ -277,7 +282,7 @@ describe('DashboardModel', () => {
     let model: DashboardModel;
 
     beforeEach(() => {
-      model = new DashboardModel({});
+      model = createDashboardModelFixture();
     });
 
     it('should not show submenu', () => {
@@ -289,9 +294,9 @@ describe('DashboardModel', () => {
     let model: DashboardModel;
 
     beforeEach(() => {
-      model = new DashboardModel({
+      model = createDashboardModelFixture({
         annotations: {
-          list: [{}],
+          list: [],
         },
       });
     });
@@ -326,9 +331,9 @@ describe('DashboardModel', () => {
     let model: DashboardModel;
 
     beforeEach(() => {
-      model = new DashboardModel({
+      model = createDashboardModelFixture({
         templating: {
-          list: [{ hide: 2 }],
+          list: [{ hide: VariableHide.hideVariable }],
         },
       });
     });
@@ -342,9 +347,9 @@ describe('DashboardModel', () => {
     let dashboard: DashboardModel;
 
     beforeEach(() => {
-      dashboard = new DashboardModel({
+      dashboard = createDashboardModelFixture({
         annotations: {
-          list: [{ hide: true }],
+          list: [createAnnotationJSONFixture({ hide: true })],
         },
       });
     });
@@ -358,13 +363,13 @@ describe('DashboardModel', () => {
     let dashboard: DashboardModel;
 
     beforeEach(() => {
-      dashboard = new DashboardModel({
+      dashboard = createDashboardModelFixture({
         panels: [
-          { id: 1, type: 'graph', gridPos: { x: 0, y: 0, w: 24, h: 2 } },
-          { id: 2, type: 'row', gridPos: { x: 0, y: 2, w: 24, h: 2 } },
-          { id: 3, type: 'graph', gridPos: { x: 0, y: 4, w: 12, h: 2 } },
-          { id: 4, type: 'graph', gridPos: { x: 12, y: 4, w: 12, h: 2 } },
-          { id: 5, type: 'row', gridPos: { x: 0, y: 6, w: 24, h: 2 } },
+          createPanelJSONFixture({ id: 1, type: 'graph', gridPos: { x: 0, y: 0, w: 24, h: 2 } }),
+          createPanelJSONFixture({ id: 2, type: 'row', gridPos: { x: 0, y: 2, w: 24, h: 2 } }),
+          createPanelJSONFixture({ id: 3, type: 'graph', gridPos: { x: 0, y: 4, w: 12, h: 2 } }),
+          createPanelJSONFixture({ id: 4, type: 'graph', gridPos: { x: 12, y: 4, w: 12, h: 2 } }),
+          createPanelJSONFixture({ id: 5, type: 'row', gridPos: { x: 0, y: 6, w: 24, h: 2 } }),
         ],
       });
       dashboard.toggleRow(dashboard.panels[1]);
@@ -409,7 +414,7 @@ describe('DashboardModel', () => {
     let dashboard: DashboardModel;
 
     beforeEach(() => {
-      dashboard = new DashboardModel({
+      dashboard = createDashboardModelFixture({
         panels: [
           { id: 1, type: 'graph', gridPos: { x: 0, y: 0, w: 24, h: 6 } },
           {
@@ -422,7 +427,7 @@ describe('DashboardModel', () => {
               { id: 4, type: 'graph', gridPos: { x: 12, y: 7, w: 12, h: 2 } },
             ],
           },
-          { id: 5, type: 'row', gridPos: { x: 0, y: 7, w: 1, h: 1 } },
+          { id: 5, type: 'row', collapsed: false, panels: [], gridPos: { x: 0, y: 7, w: 1, h: 1 } },
         ],
       });
       dashboard.toggleRow(dashboard.panels[1]);
@@ -480,7 +485,7 @@ describe('DashboardModel', () => {
     let dashboard: DashboardModel;
 
     beforeEach(() => {
-      dashboard = new DashboardModel({
+      dashboard = createDashboardModelFixture({
         panels: [
           { id: 1, type: 'graph', gridPos: { x: 0, y: 0, w: 24, h: 6 } },
           {
@@ -489,11 +494,12 @@ describe('DashboardModel', () => {
             gridPos: { x: 0, y: 6, w: 24, h: 1 },
             collapsed: true,
             panels: [
+              // this whole test is about dealing with out-of-spec (or at least ambigious) data...
               { id: 3, type: 'graph', gridPos: { w: 12, h: 2 } },
               { id: 4, type: 'graph', gridPos: { w: 12, h: 2 } },
             ],
           },
-          { id: 5, type: 'row', gridPos: { x: 0, y: 7, w: 1, h: 1 } },
+          { id: 5, type: 'row', collapsed: false, panels: [], gridPos: { x: 0, y: 7, w: 1, h: 1 } },
         ],
       });
       dashboard.toggleRow(dashboard.panels[1]);
@@ -522,7 +528,7 @@ describe('DashboardModel', () => {
 
     beforeEach(() => {
       consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-      model = new DashboardModel({
+      model = createDashboardModelFixture({
         time: {
           from: 'now-6h',
           to: 'now',
@@ -837,14 +843,13 @@ describe('DashboardModel', () => {
     let model: DashboardModel;
 
     beforeEach(() => {
-      const data = {
+      model = createDashboardModelFixture({
         panels: [
           { id: 1, type: 'graph', gridPos: { x: 0, y: 0, w: 24, h: 2 }, legend: { show: true } },
           { id: 3, type: 'graph', gridPos: { x: 0, y: 4, w: 12, h: 2 }, legend: { show: false } },
           { id: 4, type: 'graph', gridPos: { x: 12, y: 4, w: 12, h: 2 }, legend: { show: false } },
         ],
-      };
-      model = new DashboardModel(data);
+      });
     });
 
     it('toggleLegendsForAll should toggle all legends on on first execution', () => {
@@ -875,7 +880,7 @@ describe('DashboardModel', () => {
     `(
       'when called with canEdit:{$canEdit}, canMakeEditable:{$canMakeEditable}, canAdd:{$canAdd} and expected:{$expected}',
       ({ canEdit, canMakeEditable, canAdd, expected }) => {
-        const dashboard = new DashboardModel(
+        const dashboard = createDashboardModelFixture(
           {},
           {
             annotationsPermissions: {
@@ -908,7 +913,7 @@ describe('DashboardModel', () => {
     `(
       'when called with canEdit:{$canEdit}, canMakeEditable:{$canMakeEditable}, canEditWithOrgPermission:{$canEditWithOrgPermission} and expected:{$expected}',
       ({ canEdit, canMakeEditable, canEditWithOrgPermission, expected }) => {
-        const dashboard = new DashboardModel(
+        const dashboard = createDashboardModelFixture(
           {},
           {
             annotationsPermissions: {
@@ -939,7 +944,7 @@ describe('DashboardModel', () => {
     `(
       'when called with canEdit:{$canEdit}, canMakeEditable:{$canMakeEditable}, canEditWithDashboardPermission:{$canEditWithDashboardPermission} and expected:{$expected}',
       ({ canEdit, canMakeEditable, canEditWithDashboardPermission, expected }) => {
-        const dashboard = new DashboardModel(
+        const dashboard = createDashboardModelFixture(
           {},
           {
             annotationsPermissions: {
@@ -972,7 +977,7 @@ describe('DashboardModel', () => {
     `(
       'when called with canEdit:{$canEdit}, canMakeEditable:{$canMakeEditable}, canDeleteWithOrgPermission:{$canDeleteWithOrgPermission} and expected:{$expected}',
       ({ canEdit, canMakeEditable, canDeleteWithOrgPermission, expected }) => {
-        const dashboard = new DashboardModel(
+        const dashboard = createDashboardModelFixture(
           {},
           {
             annotationsPermissions: {
@@ -1003,7 +1008,7 @@ describe('DashboardModel', () => {
     `(
       'when called with canEdit:{$canEdit}, canMakeEditable:{$canMakeEditable}, canDeleteWithDashboardPermission:{$canDeleteWithDashboardPermission} and expected:{$expected}',
       ({ canEdit, canMakeEditable, canDeleteWithDashboardPermission, expected }) => {
-        const dashboard = new DashboardModel(
+        const dashboard = createDashboardModelFixture(
           {},
           {
             annotationsPermissions: {
@@ -1024,9 +1029,9 @@ describe('DashboardModel', () => {
 
   describe('canEditPanel', () => {
     it('returns false if the dashboard cannot be edited', () => {
-      const dashboard = new DashboardModel({
+      const dashboard = createDashboardModelFixture({
         panels: [
-          { id: 1, type: 'row', gridPos: { x: 0, y: 0, w: 24, h: 6 } },
+          { id: 1, type: 'row', collapsed: false, panels: [], gridPos: { x: 0, y: 0, w: 24, h: 6 } },
           { id: 2, type: 'graph', gridPos: { x: 0, y: 7, w: 12, h: 2 } },
         ],
       });
@@ -1036,9 +1041,9 @@ describe('DashboardModel', () => {
     });
 
     it('returns false if no panel is passed in', () => {
-      const dashboard = new DashboardModel({
+      const dashboard = createDashboardModelFixture({
         panels: [
-          { id: 1, type: 'row', gridPos: { x: 0, y: 0, w: 24, h: 6 } },
+          { id: 1, type: 'row', collapsed: false, panels: [], gridPos: { x: 0, y: 0, w: 24, h: 6 } },
           { id: 2, type: 'graph', gridPos: { x: 0, y: 7, w: 12, h: 2 } },
         ],
       });
@@ -1046,9 +1051,9 @@ describe('DashboardModel', () => {
     });
 
     it('returns false if the panel is a repeat', () => {
-      const dashboard = new DashboardModel({
+      const dashboard = createDashboardModelFixture({
         panels: [
-          { id: 1, type: 'row', gridPos: { x: 0, y: 0, w: 24, h: 6 } },
+          { id: 1, type: 'row', collapsed: false, panels: [], gridPos: { x: 0, y: 0, w: 24, h: 6 } },
           { id: 2, type: 'graph', gridPos: { x: 0, y: 7, w: 12, h: 2 } },
           { id: 3, type: 'graph', gridPos: { x: 0, y: 7, w: 12, h: 2 }, repeatPanelId: 2 },
         ],
@@ -1058,9 +1063,9 @@ describe('DashboardModel', () => {
     });
 
     it('returns false if the panel is a row', () => {
-      const dashboard = new DashboardModel({
+      const dashboard = createDashboardModelFixture({
         panels: [
-          { id: 1, type: 'row', gridPos: { x: 0, y: 0, w: 24, h: 6 } },
+          { id: 1, type: 'row', collapsed: false, panels: [], gridPos: { x: 0, y: 0, w: 24, h: 6 } },
           { id: 2, type: 'graph', gridPos: { x: 0, y: 7, w: 12, h: 2 } },
         ],
       });
@@ -1069,9 +1074,9 @@ describe('DashboardModel', () => {
     });
 
     it('returns true otherwise', () => {
-      const dashboard = new DashboardModel({
+      const dashboard = createDashboardModelFixture({
         panels: [
-          { id: 1, type: 'row', gridPos: { x: 0, y: 0, w: 24, h: 6 } },
+          { id: 1, type: 'row', collapsed: false, panels: [], gridPos: { x: 0, y: 0, w: 24, h: 6 } },
           { id: 2, type: 'graph', gridPos: { x: 0, y: 7, w: 12, h: 2 } },
         ],
       });
@@ -1084,7 +1089,7 @@ describe('DashboardModel', () => {
 describe('exitViewPanel', () => {
   function getTestContext() {
     const panel: any = { setIsViewing: jest.fn() };
-    const dashboard = new DashboardModel({});
+    const dashboard = createDashboardModelFixture();
     dashboard.startRefresh = jest.fn();
     dashboard.panelInView = panel;
 
@@ -1121,7 +1126,7 @@ describe('exitViewPanel', () => {
 describe('exitPanelEditor', () => {
   function getTestContext(pauseAutoRefresh = false) {
     const panel: any = { destroy: jest.fn() };
-    const dashboard = new DashboardModel({});
+    const dashboard = createDashboardModelFixture();
     const timeSrvMock = {
       pauseAutoRefresh: jest.fn(),
       resumeAutoRefresh: jest.fn(),
@@ -1171,7 +1176,7 @@ describe('exitPanelEditor', () => {
 
 describe('initEditPanel', () => {
   function getTestContext() {
-    const dashboard = new DashboardModel({});
+    const dashboard = createDashboardModelFixture();
     const timeSrvMock = {
       pauseAutoRefresh: jest.fn(),
       resumeAutoRefresh: jest.fn(),

--- a/public/app/features/dashboard/state/__fixtures__/dashboardFixtures.ts
+++ b/public/app/features/dashboard/state/__fixtures__/dashboardFixtures.ts
@@ -5,6 +5,7 @@ export function createDashboardFixture(dashboardInput: Partial<Dashboard> = {}):
     editable: true,
     graphTooltip: defaultDashboardCursorSync,
     schemaVersion: 36,
+    revision: 1,
     style: 'dark',
     ...dashboardInput,
   };

--- a/public/app/features/dashboard/state/__fixtures__/dashboardFixtures.ts
+++ b/public/app/features/dashboard/state/__fixtures__/dashboardFixtures.ts
@@ -1,4 +1,4 @@
-import { Dashboard, defaultDashboardCursorSync, Panel } from '@grafana/schema';
+import { AnnotationQuery, Dashboard, defaultDashboardCursorSync, Panel } from '@grafana/schema';
 import { DashboardMeta } from 'app/types';
 
 import { DashboardModel } from '../DashboardModel';
@@ -31,5 +31,19 @@ export function createPanelJSONFixture(panelInput: Partial<Panel> = {}): Panel {
     transparent: false,
     type: 'timeseries',
     ...panelInput,
+  };
+}
+
+export function createAnnotationJSONFixture(annotationInput: Partial<AnnotationQuery>): AnnotationQuery {
+  return {
+    builtIn: 0, // ??
+    datasource: {
+      type: 'foo',
+      uid: 'bar',
+    },
+    showIn: 2,
+    enable: true,
+    type: 'anno',
+    ...annotationInput,
   };
 }

--- a/public/app/features/dashboard/state/__fixtures__/dashboardFixtures.ts
+++ b/public/app/features/dashboard/state/__fixtures__/dashboardFixtures.ts
@@ -1,7 +1,13 @@
 import { Dashboard, defaultDashboardCursorSync, Panel } from '@grafana/schema';
+import { DashboardMeta } from 'app/types';
 
-export function createDashboardFixture(dashboardInput: Partial<Dashboard> = {}): Dashboard {
-  return {
+import { DashboardModel } from '../DashboardModel';
+
+export function createDashboardModelFixture(
+  dashboardInput: Partial<Dashboard> = {},
+  meta?: DashboardMeta
+): DashboardModel {
+  const dashboardJson: Dashboard = {
     editable: true,
     graphTooltip: defaultDashboardCursorSync,
     schemaVersion: 36,
@@ -9,9 +15,11 @@ export function createDashboardFixture(dashboardInput: Partial<Dashboard> = {}):
     style: 'dark',
     ...dashboardInput,
   };
+
+  return new DashboardModel(dashboardJson, meta);
 }
 
-export function createPanelFixture(panelInput: Partial<Panel> = {}): Panel {
+export function createPanelJSONFixture(panelInput: Partial<Panel> = {}): Panel {
   return {
     fieldConfig: {
       defaults: {},

--- a/public/app/features/dashboard/state/__fixtures__/dashboardFixtures.ts
+++ b/public/app/features/dashboard/state/__fixtures__/dashboardFixtures.ts
@@ -1,6 +1,6 @@
 import { Dashboard, defaultDashboardCursorSync, Panel } from '@grafana/schema';
 
-export function createDashboardJSON(dashboardInput: Partial<Dashboard> = {}): Dashboard {
+export function createDashboardFixture(dashboardInput: Partial<Dashboard> = {}): Dashboard {
   return {
     editable: true,
     graphTooltip: defaultDashboardCursorSync,
@@ -10,7 +10,7 @@ export function createDashboardJSON(dashboardInput: Partial<Dashboard> = {}): Da
   };
 }
 
-export function createPanelJSON(panelInput: Partial<Panel> = {}): Panel {
+export function createPanelFixture(panelInput: Partial<Panel> = {}): Panel {
   return {
     fieldConfig: {
       defaults: {},

--- a/public/app/features/dashboard/state/__fixtures__/dashboardJson.ts
+++ b/public/app/features/dashboard/state/__fixtures__/dashboardJson.ts
@@ -1,0 +1,26 @@
+import { Dashboard, defaultDashboardCursorSync, Panel } from '@grafana/schema';
+
+export function createDashboardJSON(dashboardInput: Partial<Dashboard> = {}): Dashboard {
+  return {
+    editable: true,
+    graphTooltip: defaultDashboardCursorSync,
+    schemaVersion: 36,
+    style: 'dark',
+    ...dashboardInput,
+  };
+}
+
+export function createPanelJSON(panelInput: Partial<Panel> = {}): Panel {
+  return {
+    fieldConfig: {
+      defaults: {},
+      overrides: [],
+    },
+    options: {},
+    repeatDirection: 'h',
+    transformations: [],
+    transparent: false,
+    type: 'timeseries',
+    ...panelInput,
+  };
+}

--- a/public/app/features/dashboard/state/reducers.test.ts
+++ b/public/app/features/dashboard/state/reducers.test.ts
@@ -1,6 +1,5 @@
 import { DashboardInitPhase, DashboardState, OrgRole, PermissionLevel } from 'app/types';
 
-import { DashboardModel } from './DashboardModel';
 import {
   dashboardInitCompleted,
   dashboardInitFailed,
@@ -9,6 +8,7 @@ import {
   dashboardReducer,
   initialState,
 } from './reducers';
+import {createDashboardModelFixture, createPanelJSONFixture} from "./__fixtures__/dashboardFixtures";
 
 describe('dashboard reducer', () => {
   describe('loadDashboardPermissions', () => {
@@ -35,9 +35,9 @@ describe('dashboard reducer', () => {
       state = dashboardReducer(
         state,
         dashboardInitCompleted(
-          new DashboardModel({
+          createDashboardModelFixture({
             title: 'My dashboard',
-            panels: [{ id: 1 }, { id: 2 }],
+            panels: [createPanelJSONFixture({ id: 1 }), createPanelJSONFixture({ id: 2 })],
           })
         )
       );

--- a/public/app/features/dashboard/utils/getPanelMenu.test.ts
+++ b/public/app/features/dashboard/utils/getPanelMenu.test.ts
@@ -3,9 +3,10 @@ import config from 'app/core/config';
 import * as actions from 'app/features/explore/state/main';
 import { setStore } from 'app/store/store';
 
-import { DashboardModel, PanelModel } from '../state';
+import { PanelModel } from '../state';
 
 import { getPanelMenu } from './getPanelMenu';
+import {createDashboardModelFixture} from "../state/__fixtures__/dashboardFixtures";
 
 jest.mock('app/core/services/context_srv', () => ({
   contextSrv: {
@@ -16,7 +17,7 @@ jest.mock('app/core/services/context_srv', () => ({
 describe('getPanelMenu', () => {
   it('should return the correct panel menu items', () => {
     const panel = new PanelModel({});
-    const dashboard = new DashboardModel({});
+    const dashboard = createDashboardModelFixture({});
 
     const menuItems = getPanelMenu(dashboard, panel);
     expect(menuItems).toMatchInlineSnapshot(`
@@ -100,7 +101,7 @@ describe('getPanelMenu', () => {
       const scope: any = { $$childHead: { ctrl } };
       const angularComponent: any = { getScope: () => scope };
       const panel = new PanelModel({ isViewing: true });
-      const dashboard = new DashboardModel({});
+      const dashboard = createDashboardModelFixture({});
 
       const menuItems = getPanelMenu(dashboard, panel, angularComponent);
       expect(menuItems).toMatchInlineSnapshot(`
@@ -171,7 +172,7 @@ describe('getPanelMenu', () => {
 
     beforeAll(() => {
       const panel = new PanelModel({});
-      const dashboard = new DashboardModel({});
+      const dashboard = createDashboardModelFixture({});
       const menuItems = getPanelMenu(dashboard, panel);
       explore = menuItems.find((item) => item.text === 'Explore') as PanelMenuItem;
       navigateSpy = jest.spyOn(actions, 'navigateToExplore');

--- a/public/app/features/dashboard/utils/panelMerge.test.ts
+++ b/public/app/features/dashboard/utils/panelMerge.test.ts
@@ -1,6 +1,8 @@
-import { PanelModel } from '@grafana/data';
+import {PanelModel} from '@grafana/data';
 
-import { DashboardModel } from '../state/DashboardModel';
+import {DashboardModel} from '../state/DashboardModel';
+import {createDashboardModelFixture, createPanelJSONFixture} from "../state/__fixtures__/dashboardFixtures";
+import {FieldColorModeId, ThresholdsMode} from "@grafana/schema/src";
 
 describe('Merge dashbaord panels', () => {
   describe('simple changes', () => {
@@ -8,35 +10,35 @@ describe('Merge dashbaord panels', () => {
     let rawPanels: PanelModel[];
 
     beforeEach(() => {
-      dashboard = new DashboardModel({
+      dashboard = createDashboardModelFixture({
         title: 'simple title',
         panels: [
-          {
+          createPanelJSONFixture({
             id: 1,
             type: 'timeseries',
-          },
-          {
+          }),
+          createPanelJSONFixture({
             id: 2,
             type: 'timeseries',
-          },
-          {
+          }),
+          createPanelJSONFixture({
             id: 3,
             type: 'table',
             fieldConfig: {
               defaults: {
                 thresholds: {
-                  mode: 'absolute',
+                  mode: ThresholdsMode.Absolute,
                   steps: [
                     { color: 'green', value: -Infinity }, // save model has this as null
                     { color: 'red', value: 80 },
                   ],
                 },
                 mappings: [],
-                color: { mode: 'thresholds' },
+                color: { mode: FieldColorModeId.Thresholds },
               },
               overrides: [],
             },
-          },
+          }),
         ],
       });
       rawPanels = dashboard.getSaveModelClone().panels;

--- a/public/app/features/query/state/PanelQueryRunner.test.ts
+++ b/public/app/features/query/state/PanelQueryRunner.test.ts
@@ -1,3 +1,5 @@
+import {createDashboardModelFixture} from "../../dashboard/state/__fixtures__/dashboardFixtures";
+
 const applyFieldOverridesMock = jest.fn(); // needs to be first in this file
 
 import { Subject } from 'rxjs';
@@ -7,7 +9,6 @@ import * as grafanaData from '@grafana/data';
 import { setDataSourceSrv, setEchoSrv } from '@grafana/runtime';
 
 import { Echo } from '../../../core/services/echo/Echo';
-import { DashboardModel } from '../../dashboard/state/index';
 
 import {
   createDashboardQueryRunner,
@@ -30,7 +31,7 @@ jest.mock('app/core/config', () => ({
   }),
 }));
 
-const dashboardModel = new DashboardModel({
+const dashboardModel = createDashboardModelFixture({
   panels: [{ id: 1, type: 'graph' }],
 });
 

--- a/public/app/features/query/state/queryAnalytics.test.ts
+++ b/public/app/features/query/state/queryAnalytics.test.ts
@@ -1,9 +1,8 @@
 import { CoreApp, DataFrame, DataQueryRequest, DataSourceApi, dateTime, LoadingState, PanelData } from '@grafana/data';
 import { MetaAnalyticsEventName, reportMetaAnalytics } from '@grafana/runtime';
 
-import { DashboardModel } from '../../dashboard/state';
-
 import { emitDataRequestEvent } from './queryAnalytics';
+import {createDashboardModelFixture} from "../../dashboard/state/__fixtures__/dashboardFixtures";
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -14,7 +13,7 @@ const datasource = {
   id: 1,
 } as DataSourceApi;
 
-const dashboardModel = new DashboardModel(
+const dashboardModel = createDashboardModelFixture(
   { id: 1, title: 'Test Dashboard', uid: 'test' },
   { folderTitle: 'Test Folder' }
 );

--- a/public/app/features/query/state/runRequest.test.ts
+++ b/public/app/features/query/state/runRequest.test.ts
@@ -14,13 +14,13 @@ import { setEchoSrv } from '@grafana/runtime';
 
 import { deepFreeze } from '../../../../test/core/redux/reducerTester';
 import { Echo } from '../../../core/services/echo/Echo';
-import { DashboardModel } from '../../dashboard/state/DashboardModel';
 
 import { runRequest } from './runRequest';
+import {createDashboardModelFixture} from "../../dashboard/state/__fixtures__/dashboardFixtures";
 
 jest.mock('app/core/services/backend_srv');
 
-const dashboardModel = new DashboardModel({
+const dashboardModel = createDashboardModelFixture({
   panels: [{ id: 1, type: 'graph' }],
 });
 

--- a/public/app/features/variables/state/onTimeRangeUpdated.test.ts
+++ b/public/app/features/variables/state/onTimeRangeUpdated.test.ts
@@ -25,6 +25,7 @@ import {
   variableStateFetching,
 } from './sharedReducer';
 import { variablesInitTransaction } from './transactionReducer';
+import {createDashboardModelFixture} from "../../dashboard/state/__fixtures__/dashboardFixtures";
 
 variableAdapters.setInit(() => [createIntervalVariableAdapter(), createConstantVariableAdapter()]);
 
@@ -226,5 +227,5 @@ describe('when onTimeRangeUpdated is dispatched', () => {
 });
 
 function getDashboardModel(): DashboardModel {
-  return new DashboardModel({ schemaVersion: 9999 }); // ignore any schema migrations
+  return createDashboardModelFixture({ schemaVersion: 9999 }); // ignore any schema migrations
 }

--- a/public/app/features/variables/state/templateVarsChangedInUrl.test.ts
+++ b/public/app/features/variables/state/templateVarsChangedInUrl.test.ts
@@ -1,7 +1,7 @@
 import { TypedVariableModel } from '@grafana/data';
 
 import { DashboardState, StoreState } from '../../../types';
-import { DashboardModel, PanelModel } from '../../dashboard/state';
+import { PanelModel } from '../../dashboard/state';
 import { initialState } from '../../dashboard/state/reducers';
 import { variableAdapters } from '../adapters';
 import { createConstantVariableAdapter } from '../constant/adapter';
@@ -12,8 +12,9 @@ import { ExtendedUrlQueryMap } from '../utils';
 import { templateVarsChangedInUrl } from './actions';
 import { getPreloadedState } from './helpers';
 import { VariablesState } from './types';
+import {createDashboardModelFixture} from "../../dashboard/state/__fixtures__/dashboardFixtures";
 
-const dashboardModel = new DashboardModel({});
+const dashboardModel = createDashboardModelFixture({});
 
 variableAdapters.setInit(() => [createCustomVariableAdapter(), createConstantVariableAdapter()]);
 

--- a/public/app/plugins/datasource/dashboard/DashboardQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/dashboard/DashboardQueryEditor.test.tsx
@@ -10,6 +10,10 @@ import { DashboardModel } from 'app/features/dashboard/state';
 
 import { DashboardQueryEditor } from './DashboardQueryEditor';
 import { SHARED_DASHBOARD_QUERY } from './types';
+import {
+  createDashboardModelFixture,
+  createPanelJSONFixture
+} from "../../../features/dashboard/state/__fixtures__/dashboardFixtures";
 
 jest.mock('app/core/config', () => ({
   ...(jest.requireActual('app/core/config') as unknown as object),
@@ -42,21 +46,21 @@ describe('DashboardQueryEditor', () => {
   let mockDashboard: DashboardModel;
 
   beforeEach(() => {
-    mockDashboard = new DashboardModel({
+    mockDashboard = createDashboardModelFixture({
       panels: [
-        {
+        createPanelJSONFixture({
           targets: [],
           type: 'timeseries',
           id: 1,
           title: 'My first panel',
-        },
-        {
+        }),
+        createPanelJSONFixture({
           targets: [],
           id: 2,
           type: 'timeseries',
           title: 'Another panel',
-        },
-        {
+        }),
+        createPanelJSONFixture({
           datasource: {
             uid: SHARED_DASHBOARD_QUERY,
           },
@@ -64,7 +68,7 @@ describe('DashboardQueryEditor', () => {
           id: 3,
           type: 'timeseries',
           title: 'A dashboard query panel',
-        },
+        }),
       ],
     });
     jest.spyOn(getDashboardSrv(), 'getCurrent').mockImplementation(() => mockDashboard);

--- a/public/app/plugins/panel/graph/specs/graph.test.ts
+++ b/public/app/plugins/panel/graph/specs/graph.test.ts
@@ -6,9 +6,9 @@ import { PanelCtrl } from 'app/angular/panel/panel_ctrl';
 import config from 'app/core/config';
 import TimeSeries from 'app/core/time_series2';
 
-import { DashboardModel } from '../../../../features/dashboard/state';
 import { graphDirective, GraphElement } from '../graph';
 import { GraphCtrl } from '../module';
+import {createDashboardModelFixture} from "../../../../features/dashboard/state/__fixtures__/dashboardFixtures";
 
 jest.mock('../event_manager', () => ({
   EventManager: class EventManagerMock {
@@ -1337,7 +1337,7 @@ describe('grafanaGraph', () => {
 });
 
 function getGraphElement({ canEdit, canMakeEditable }: { canEdit?: boolean; canMakeEditable?: boolean } = {}) {
-  const dashboard = new DashboardModel({});
+  const dashboard = createDashboardModelFixture({});
   dashboard.events.on = jest.fn();
   dashboard.meta.canEdit = canEdit;
   dashboard.meta.canMakeEditable = canMakeEditable;


### PR DESCRIPTION
**What is this feature?**

Adds fixtures functions to create dashboard models in tests. I'm not confident that the default values for this are appropriate to use in runtime, so I've made it 

**Why do we need this feature?**

When using the generated Dashboard type in the constructor for DashboardModel, we get loads of typescript errors from it's usage in tests. This is a quick and easy way to satisfy them all.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

