### PR TITLE
Make command parameter names consistent

### DIFF
--- a/pkg/services/accesscontrol/models.go
+++ b/pkg/services/accesscontrol/models.go
@@ -262,9 +262,9 @@ func (p *ResourcePermission) Contains(targetActions []string) bool {
 }
 
 type SetResourcePermissionCommand struct {
-	UserID      int64  `json:"userID"`
-	TeamID      int64  `json:"teamID"`
-	BuiltinRole string `json:"builtinRole"`
+	UserID      int64  `json:"userId,omitempty"`
+	TeamID      int64  `json:"teamId,omitempty"`
+	BuiltinRole string `json:"builtInRole,omitempty"`
 	Permission  string `json:"permission"`
 }
 


### PR DESCRIPTION
**What is this feature?**

Change json command parameter names for `SetResourcePermissionCommand` from `userID` to `userId`, `teamID` to `teamId` and `builtinRole` to `builtInRole`.

**Why do we need this feature?**

In https://github.com/grafana/grafana/pull/57893 I introduced a new endpoint that takes in team ID, user ID and builtin role name in the request body. I realised that json parameter names that I used for `SetResourcePermissionCommand` are inconsistent with those used by `resourcePermissionDTO` (this is what is returned when resource permissions are listed). This is inconvenient and confusing, so I'm making them consistent while it's still easy to do so.