### PR TITLE
Doc: Fix wrong default callback URL

### DIFF
--- a/docs/sources/setup-grafana/configure-security/configure-authentication/github/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/github/index.md
@@ -23,8 +23,10 @@ settings page). When you create the application you will need to specify
 a callback URL. Specify this as callback:
 
 ```bash
-http://<my_grafana_server_name_or_ip>:<grafana_server_port>/grafana/login/github
+http://<my_grafana_server_name_or_ip>:<grafana_server_port>/login/github
 ```
+
+> Note: <my_grafana_server_name_or_ip>'s value should match your grafana server's `root_url`, the URL used to access grafana.
 
 This callback URL must match the full HTTP address that you use in your
 browser to access Grafana, but with the suffix path of `/login/github`.

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/gitlab/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/gitlab/index.md
@@ -33,10 +33,10 @@ instance, if you access Grafana at `http://203.0.113.31:3000`, you should use
 http://203.0.113.31:3000/login/gitlab
 ```
 
-Finally, select _read_api_as the_Scope_and submit the form. Note that if you're
+Finally, select `read_api` as the scope and submit the form. Note that if you're
 not going to use GitLab groups for authorization (i.e. not setting
-`allowed_groups`, see below), you can select_read_user_ instead of _read_api_as
-the_Scope_, thus giving a more restricted access to your GitLab API.
+`allowed_groups`, see below), you can select `read_user` instead of `read_api` as
+the scope, thus giving a more restricted access to your GitLab API.
 
 You'll get an _Application Id_ and a _Secret_ in return; we'll call them
 `GITLAB_APPLICATION_ID` and `GITLAB_SECRET` respectively for the rest of this


### PR DESCRIPTION
**What is this feature?**

GitHub OAuth docs pointed to wrong callback url by default

Fix https://github.com/grafana/grafana/issues/57736


