### PR TITLE
Explore: Enable cheat sheet queries to work with mixed datasources

### DIFF
--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -318,6 +318,10 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
   };
 
   onClickExample = (query: TQuery) => {
+    if (query.datasource === undefined) {
+      query.datasource = { type: this.props.dataSource.type, uid: this.props.dataSource.uid };
+    }
+
     this.props.onChange({
       ...query,
       refId: this.props.query.refId,


### PR DESCRIPTION
**What is this feature?**

There was a bug involving the datasources' cheat sheet where a clicked query was populating without a query level datasource, which broke some expectations that are needed with mixed datasources. This constructs the datasource ref if it is not passed in from the datasource cheat sheet.

**Why do we need this feature?**
To fix a regression regarding mixed datasources and how it works with existing features.

**Which issue(s) does this PR fix?**:

Fixes #57650 

