### PR TITLE
[v9.2.x] CI: Add `GCP_KEY` to `publish-grafanacom` step (#57910)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3816,6 +3816,8 @@ steps:
   depends_on:
   - publish-packages-oss
   environment:
+    GCP_KEY:
+      from_secret: gcp_key
     GRAFANA_COM_API_KEY:
       from_secret: grafana_api_key
   image: grafana/grafana-ci-deploy:1.3.3
@@ -3927,6 +3929,8 @@ steps:
   depends_on:
   - publish-packages-enterprise
   environment:
+    GCP_KEY:
+      from_secret: gcp_key
     GRAFANA_COM_API_KEY:
       from_secret: grafana_api_key
   image: grafana/grafana-ci-deploy:1.3.3
@@ -5622,6 +5626,6 @@ kind: secret
 name: packages_secret_access_key
 ---
 kind: signature
-hmac: 170743e634118a20238e3c360d87177b98bb391bb3eb9ff409b3adb78e4686df
+hmac: 1c0aab8b158701fdee8f92fa746a6dedaef1bbbe03f636dda626b14d71387d21
 
 ...

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -1040,6 +1040,7 @@ def publish_grafanacom_step(edition, ver_mode):
         ],
         'environment': {
             'GRAFANA_COM_API_KEY': from_secret('grafana_api_key'),
+            'GCP_KEY': from_secret('gcp_key'),
         },
         'commands': [
             cmd,


### PR DESCRIPTION
(cherry picked from commit 1eaf7cbfc0f4aaed8b84c3e50d9c0c352668b363)

Backport of #57910

