### PR TITLE
Toolkit: Fix Webpack less-loader config

### DIFF
--- a/packages/grafana-toolkit/src/config/webpack/loaders.ts
+++ b/packages/grafana-toolkit/src/config/webpack/loaders.ts
@@ -94,7 +94,9 @@ export const getStyleLoaders = () => {
         {
           loader: require.resolve('less-loader'),
           options: {
-            javascriptEnabled: true,
+            lessOptions: {
+              javascriptEnabled: true,
+            },
           },
         },
       ],


### PR DESCRIPTION

**What is this feature?**

Update less-loader config for @grafana/toolkit

**Why do we need this feature?**

Build with @grafana/toolkit would fail because the less-loader config

**Who is this feature for?**

plugin developer

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/57946

**Special notes for your reviewer**:

