### PR TITLE
Graphite: Allow metric name to use true/false as name

### DIFF
--- a/public/app/plugins/datasource/graphite/parser.ts
+++ b/public/app/plugins/datasource/graphite/parser.ts
@@ -68,7 +68,7 @@ export class Parser {
       return curly;
     }
 
-    if (this.match('identifier') || this.match('number')) {
+    if (this.match('identifier') || this.match('number') || this.match('bool')) {
       // hack to handle float numbers in metric segments
       const parts = this.consumeToken().value.split('.');
       if (parts.length === 2) {

--- a/public/app/plugins/datasource/graphite/specs/parser.test.ts
+++ b/public/app/plugins/datasource/graphite/specs/parser.test.ts
@@ -21,6 +21,28 @@ describe('when parsing', () => {
     expect(rootNode.segments[3].value).toBe('5');
   });
 
+  it('simple metric expression with "true" boolean in segments', () => {
+    const parser = new Parser('metric.15_20.5.true');
+    const rootNode = parser.getAst();
+
+    expect(rootNode.type).toBe('metric');
+    expect(rootNode.segments.length).toBe(4);
+    expect(rootNode.segments[1].value).toBe('15_20');
+    expect(rootNode.segments[2].value).toBe('5');
+    expect(rootNode.segments[3].value).toBe('true');
+  });
+
+  it('simple metric expression with "false" boolean in segments', () => {
+    const parser = new Parser('metric.false.15_20.5');
+    const rootNode = parser.getAst();
+
+    expect(rootNode.type).toBe('metric');
+    expect(rootNode.segments.length).toBe(4);
+    expect(rootNode.segments[1].value).toBe('false');
+    expect(rootNode.segments[2].value).toBe('15_20');
+    expect(rootNode.segments[3].value).toBe('5');
+  });
+
   it('simple metric expression with curly braces', () => {
     const parser = new Parser('metric.se1-{count, max}');
     const rootNode = parser.getAst();

--- a/public/app/plugins/datasource/graphite/specs/store.test.ts
+++ b/public/app/plugins/datasource/graphite/specs/store.test.ts
@@ -94,12 +94,6 @@ describe('Graphite actions', () => {
       expect(ctx.datasource.metricFindQuery.mock.calls[lastCallIndex][0]).toBe('test.prod.*');
     });
 
-    it('should delete last segment if no metrics are found', () => {
-      expect(ctx.state.segments[0].value).toBe('test');
-      expect(ctx.state.segments[1].value).toBe('prod');
-      expect(ctx.state.segments[2].value).toBe('select metric');
-    });
-
     it('should parse expression and build function model', () => {
       expect(ctx.state.queryModel.functions.length).toBe(2);
     });
@@ -114,12 +108,6 @@ describe('Graphite actions', () => {
     it('should validate metric key exists', () => {
       const lastCallIndex = ctx.datasource.metricFindQuery.mock.calls.length - 1;
       expect(ctx.datasource.metricFindQuery.mock.calls[lastCallIndex][0]).toBe('test.test.*');
-    });
-
-    it('should delete last segment if no metrics are found', () => {
-      expect(ctx.state.segments[0].value).toBe('test');
-      expect(ctx.state.segments[1].value).toBe('test');
-      expect(ctx.state.segments[2].value).toBe('select metric');
     });
 
     it('should parse expression and build function model', () => {
@@ -166,7 +154,7 @@ describe('Graphite actions', () => {
     });
 
     it('should add 2 segments', () => {
-      expect(ctx.state.segments.length).toBe(2);
+      expect(ctx.state.segments.length).toBe(3);
     });
 
     it('should add function param', () => {
@@ -197,7 +185,7 @@ describe('Graphite actions', () => {
     });
 
     it('should add segments', () => {
-      expect(ctx.state.segments.length).toBe(3);
+      expect(ctx.state.segments.length).toBe(4);
     });
 
     it('should have correct func params', () => {


### PR DESCRIPTION
**What is this feature?**

This PR fixes the query builder toggler flow to work when a metric name uses boolean values (e.g. true or false) as the name.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/20349

**Special notes for your reviewer**:

Before this change, some segments were being arbitrarily removed in the Visual Mode when no queries were being returned or "unexpected" values like the matric names using boolean values as the name. It creates confusion for the users, since in the Code Mode segments present all values, even the ones unnecessarily removed in Visual Mode.

https://user-images.githubusercontent.com/1680157/199263857-b8cea215-413f-4500-a1a3-5db1e4e3f72e.mov


