### PR TITLE
Build: Remove unnecessary alpine package updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,8 +57,6 @@ ENV PATH="/usr/share/grafana/bin:$PATH" \
 WORKDIR $GF_PATHS_HOME
 
 RUN apk add --no-cache ca-certificates bash tzdata musl-utils
-RUN apk add --no-cache openssl ncurses-libs ncurses-terminfo-base --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
-RUN apk upgrade ncurses-libs ncurses-terminfo-base --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
 RUN apk info -vv | sort
 
 COPY conf ./conf

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -26,10 +26,8 @@ ENV PATH=/usr/share/grafana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bi
 
 WORKDIR $GF_PATHS_HOME
 
-RUN apk add --no-cache ca-certificates bash tzdata && \
-    apk add --no-cache musl-utils
-
-RUN apk add --no-cache openssl --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
+RUN apk add --no-cache ca-certificates bash tzdata musl-utils
+RUN apk info -vv | sort
 
 # Oracle Support for x86_64 only
 RUN if [ `arch` = "x86_64" ]; then \


### PR DESCRIPTION
These package updates were originally added to the alpine dockerfiles to pull in necessary updates, but they are no longer needed.