### PR TITLE
TimeSeries: Support vertical zoom

### DIFF
--- a/packages/grafana-ui/src/components/TimeSeries/utils.ts
+++ b/packages/grafana-ui/src/components/TimeSeries/utils.ts
@@ -533,6 +533,8 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn<{
   const hoverProximityPx = 15;
 
   let cursor: Partial<uPlot.Cursor> = {
+    // allow X / Y zoom
+    drag: { setScale: true, x: true, y: true, uni: Infinity },
     // this scans left and right from cursor position to find nearest data index with value != null
     // TODO: do we want to only scan past undefined values, but halt at explicit null values?
     dataIdx: (self, seriesIdx, hoveredIdx, cursorXVal) => {


### PR DESCRIPTION
**What is this feature?**

When visualizing a time series, click and drag the mouse vertically to zoom on the Y-axis.
(Dragging the mouse horizontally still zooms on the X-axis.)

![a](https://user-images.githubusercontent.com/11032610/199342676-ea8e144f-132f-4ab9-818f-6bbefd3e3c77.png)
![b](https://user-images.githubusercontent.com/11032610/199342691-8c3cc63d-e934-4d6b-b756-fa370730f622.png)

**Why do we need this feature?**

Vertical zoom has been asked by many users in my company who do not want to resort to the "soft min / max trick" when quickly exploring some data. This is a real frustration for them.

**Who is this feature for?**

Everyone who uses time series.

**Which issue(s) does this PR fix?**:

Fixes #9457

**Special notes for your reviewer**:

This feature simply uses uPlot "adaptive" zoom: <https://leeoniya.github.io/uPlot/demos/zoom-variations.html>
I am new to Grafana, so I hope there is no regression I haven't noticed.

Unfortunately, when zooming on the X-axis, the Y-axis zoom is reset. After testing, this seems to be the default behavior of uPlot, and I can see no obvious way to change it. I believe this is part of the reason why the "omni" zoom does not work.