### PR TITLE
Auth: Display id Provider label in orgs/users view

### DIFF
--- a/pkg/api/common_test.go
+++ b/pkg/api/common_test.go
@@ -352,6 +352,7 @@ func setupSimpleHTTPServer(features *featuremgmt.FeatureManager) *HTTPServer {
 		License:         &licensing.OSSLicensingService{},
 		AccessControl:   acimpl.ProvideAccessControl(cfg),
 		annotationsRepo: annotationstest.NewFakeAnnotationsRepo(),
+		authInfoService: &logintest.AuthInfoServiceFake{},
 	}
 }
 
@@ -429,6 +430,7 @@ func setupHTTPServerWithCfgDb(
 		orgService:        orgMock,
 		teamService:       teamService,
 		annotationsRepo:   annotationstest.NewFakeAnnotationsRepo(),
+		authInfoService:   &logintest.AuthInfoServiceFake{},
 	}
 
 	for _, o := range options {

--- a/pkg/api/common_test.go
+++ b/pkg/api/common_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/guardian"
 	"github.com/grafana/grafana/pkg/services/ldap"
 	"github.com/grafana/grafana/pkg/services/licensing"
+	"github.com/grafana/grafana/pkg/services/login"
 	"github.com/grafana/grafana/pkg/services/login/loginservice"
 	"github.com/grafana/grafana/pkg/services/login/logintest"
 	"github.com/grafana/grafana/pkg/services/org"
@@ -352,7 +353,9 @@ func setupSimpleHTTPServer(features *featuremgmt.FeatureManager) *HTTPServer {
 		License:         &licensing.OSSLicensingService{},
 		AccessControl:   acimpl.ProvideAccessControl(cfg),
 		annotationsRepo: annotationstest.NewFakeAnnotationsRepo(),
-		authInfoService: &logintest.AuthInfoServiceFake{},
+		authInfoService: &logintest.AuthInfoServiceFake{
+			ExpectedLabels: map[int64]string{int64(1): login.GetAuthProviderLabel(login.LDAPAuthModule)},
+		},
 	}
 }
 
@@ -430,7 +433,9 @@ func setupHTTPServerWithCfgDb(
 		orgService:        orgMock,
 		teamService:       teamService,
 		annotationsRepo:   annotationstest.NewFakeAnnotationsRepo(),
-		authInfoService:   &logintest.AuthInfoServiceFake{},
+		authInfoService: &logintest.AuthInfoServiceFake{
+			ExpectedLabels: map[int64]string{int64(1): login.GetAuthProviderLabel(login.LDAPAuthModule)},
+		},
 	}
 
 	for _, o := range options {

--- a/pkg/api/org_users.go
+++ b/pkg/api/org_users.go
@@ -234,12 +234,10 @@ func (hs *HTTPServer) getOrgUsersHelper(c *models.ReqContext, query *org.GetOrgU
 
 	// Get accesscontrol metadata and IPD labels for users in the target org
 	accessControlMetadata := hs.getMultiAccessControlMetadata(c, query.OrgID, "users:id:", userIDs)
-	if len(accessControlMetadata) > 0 {
-		for i := range filteredUsers {
-			filteredUsers[i].AccessControl = accessControlMetadata[fmt.Sprint(filteredUsers[i].UserID)]
-			if module, ok := modules[filteredUsers[i].UserID]; ok {
-				filteredUsers[i].AuthLabels = []string{login.GetAuthProviderLabel(module)}
-			}
+	for i := range filteredUsers {
+		filteredUsers[i].AccessControl = accessControlMetadata[fmt.Sprint(filteredUsers[i].UserID)]
+		if module, ok := modules[filteredUsers[i].UserID]; ok {
+			filteredUsers[i].AuthLabels = []string{login.GetAuthProviderLabel(module)}
 		}
 	}
 

--- a/pkg/models/user_auth.go
+++ b/pkg/models/user_auth.go
@@ -125,6 +125,10 @@ type GetAuthInfoQuery struct {
 	Result *UserAuth
 }
 
+type GetUserLabelsQuery struct {
+	UserIDs []int64
+}
+
 type TeamOrgGroupDTO struct {
 	TeamName string `json:"teamName"`
 	OrgName  string `json:"orgName"`

--- a/pkg/services/login/authinfo.go
+++ b/pkg/services/login/authinfo.go
@@ -10,6 +10,7 @@ import (
 type AuthInfoService interface {
 	LookupAndUpdate(ctx context.Context, query *models.GetUserByAuthInfoQuery) (*user.User, error)
 	GetAuthInfo(ctx context.Context, query *models.GetAuthInfoQuery) error
+	GetUserLabels(ctx context.Context, query models.GetUserLabelsQuery) (map[int64]string, error)
 	GetExternalUserInfoByLogin(ctx context.Context, query *models.GetExternalUserInfoByLoginQuery) error
 	SetAuthInfo(ctx context.Context, cmd *models.SetAuthInfoCommand) error
 	UpdateAuthInfo(ctx context.Context, cmd *models.UpdateAuthInfoCommand) error

--- a/pkg/services/login/authinfoservice/service.go
+++ b/pkg/services/login/authinfoservice/service.go
@@ -185,6 +185,13 @@ func (s *Implementation) GetAuthInfo(ctx context.Context, query *models.GetAuthI
 	return s.authInfoStore.GetAuthInfo(ctx, query)
 }
 
+func (s *Implementation) GetUserLabels(ctx context.Context, query models.GetUserLabelsQuery) (map[int64]string, error) {
+	if len(query.UserIDs) == 0 {
+		return map[int64]string{}, nil
+	}
+	return s.authInfoStore.GetUserLabels(ctx, query)
+}
+
 func (s *Implementation) UpdateAuthInfo(ctx context.Context, cmd *models.UpdateAuthInfoCommand) error {
 	return s.authInfoStore.UpdateAuthInfo(ctx, cmd)
 }

--- a/pkg/services/login/authinfoservice/user_auth_test.go
+++ b/pkg/services/login/authinfoservice/user_auth_test.go
@@ -478,6 +478,7 @@ func TestUserAuth(t *testing.T) {
 }
 
 type FakeAuthInfoStore struct {
+	login.AuthInfoService
 	ExpectedError                   error
 	ExpectedUser                    *user.User
 	ExpectedOAuth                   *models.UserAuth

--- a/pkg/services/login/logintest/logintest.go
+++ b/pkg/services/login/logintest/logintest.go
@@ -28,6 +28,7 @@ type AuthInfoServiceFake struct {
 	ExpectedUser         *user.User
 	ExpectedExternalUser *models.ExternalUserInfo
 	ExpectedError        error
+	ExpectedLabels       map[int64]string
 }
 
 func (a *AuthInfoServiceFake) LookupAndUpdate(ctx context.Context, query *models.GetUserByAuthInfoQuery) (*user.User, error) {
@@ -46,7 +47,7 @@ func (a *AuthInfoServiceFake) GetAuthInfo(ctx context.Context, query *models.Get
 }
 
 func (a *AuthInfoServiceFake) GetUserLabels(ctx context.Context, query models.GetUserLabelsQuery) (map[int64]string, error) {
-	return map[int64]string{int64(1): login.GetAuthProviderLabel(login.LDAPAuthModule)}, nil
+	return a.ExpectedLabels, a.ExpectedError
 }
 
 func (a *AuthInfoServiceFake) SetAuthInfo(ctx context.Context, cmd *models.SetAuthInfoCommand) error {

--- a/pkg/services/login/logintest/logintest.go
+++ b/pkg/services/login/logintest/logintest.go
@@ -22,6 +22,7 @@ func (l *LoginServiceFake) DisableExternalUser(ctx context.Context, username str
 func (l *LoginServiceFake) SetTeamSyncFunc(login.TeamSyncFunc) {}
 
 type AuthInfoServiceFake struct {
+	login.AuthInfoService
 	LatestUserID         int64
 	ExpectedUserAuth     *models.UserAuth
 	ExpectedUser         *user.User
@@ -42,6 +43,10 @@ func (a *AuthInfoServiceFake) GetAuthInfo(ctx context.Context, query *models.Get
 	a.LatestUserID = query.UserId
 	query.Result = a.ExpectedUserAuth
 	return a.ExpectedError
+}
+
+func (a *AuthInfoServiceFake) GetUserLabels(ctx context.Context, query models.GetUserLabelsQuery) (map[int64]string, error) {
+	return map[int64]string{int64(1): login.GetAuthProviderLabel(login.LDAPAuthModule)}, nil
 }
 
 func (a *AuthInfoServiceFake) SetAuthInfo(ctx context.Context, cmd *models.SetAuthInfoCommand) error {

--- a/pkg/services/login/userprotection.go
+++ b/pkg/services/login/userprotection.go
@@ -14,6 +14,7 @@ type UserProtectionService interface {
 type Store interface {
 	GetExternalUserInfoByLogin(ctx context.Context, query *models.GetExternalUserInfoByLoginQuery) error
 	GetAuthInfo(ctx context.Context, query *models.GetAuthInfoQuery) error
+	GetUserLabels(ctx context.Context, query models.GetUserLabelsQuery) (map[int64]string, error)
 	SetAuthInfo(ctx context.Context, cmd *models.SetAuthInfoCommand) error
 	UpdateAuthInfo(ctx context.Context, cmd *models.UpdateAuthInfoCommand) error
 	UpdateAuthInfoDate(ctx context.Context, authInfo *models.UserAuth) error

--- a/pkg/services/oauthtoken/oauth_token_test.go
+++ b/pkg/services/oauthtoken/oauth_token_test.go
@@ -304,6 +304,7 @@ func (m *MockSocialConnector) TokenSource(ctx context.Context, t *oauth2.Token) 
 }
 
 type FakeAuthInfoStore struct {
+	login.Store
 	ExpectedError                   error
 	ExpectedUser                    *user.User
 	ExpectedOAuth                   *models.UserAuth

--- a/pkg/services/org/model.go
+++ b/pkg/services/org/model.go
@@ -148,6 +148,7 @@ type OrgUserDTO struct {
 	LastSeenAtAge string          `json:"lastSeenAtAge"`
 	AccessControl map[string]bool `json:"accessControl,omitempty"`
 	IsDisabled    bool            `json:"isDisabled"`
+	AuthLabels    []string        `json:"authLabels" xorm:"-"`
 }
 
 type RemoveOrgUserCommand struct {

--- a/pkg/services/quota/quotaimpl/storage/storage.json
+++ b/pkg/services/quota/quotaimpl/storage/storage.json
@@ -1,5 +1,0 @@
-{
-  "allowUnsanitizedSvgUpload": false,
-  "addDevEnv": true,
-  "roots": null
-}

--- a/pkg/services/quota/quotaimpl/storage/storage.json
+++ b/pkg/services/quota/quotaimpl/storage/storage.json
@@ -1,0 +1,5 @@
+{
+  "allowUnsanitizedSvgUpload": false,
+  "addDevEnv": true,
+  "roots": null
+}

--- a/public/app/features/users/UsersTable.test.tsx
+++ b/public/app/features/users/UsersTable.test.tsx
@@ -48,6 +48,12 @@ describe('Render', () => {
 
     expect(screen.getByText('Disabled')).toBeInTheDocument();
   });
+  it('should render LDAP label', () => {
+    const usersData = getMockUsers(5);
+    usersData[0].authLabels = ['LDAP'];
+    setup({ users: usersData });
+    expect(screen.getByText(usersData[0].authLabels[0])).toBeInTheDocument();
+  });
 });
 
 describe('Remove modal', () => {

--- a/public/app/features/users/UsersTable.tsx
+++ b/public/app/features/users/UsersTable.tsx
@@ -4,6 +4,7 @@ import { OrgRole } from '@grafana/data';
 import { Button, ConfirmModal } from '@grafana/ui';
 import { UserRolePicker } from 'app/core/components/RolePicker/UserRolePicker';
 import { fetchRoleOptions } from 'app/core/components/RolePicker/api';
+import { TagBadge } from 'app/core/components/TagFilter/TagBadge';
 import { contextSrv } from 'app/core/core';
 import { AccessControlAction, OrgUser, Role } from 'app/types';
 
@@ -49,6 +50,7 @@ const UsersTable: FC<Props> = (props) => {
             <th>Seen</th>
             <th>Role</th>
             <th style={{ width: '34px' }} />
+            <th></th>
             <th></th>
           </tr>
         </thead>
@@ -99,6 +101,12 @@ const UsersTable: FC<Props> = (props) => {
 
                 <td className="width-1 text-center">
                   {user.isDisabled && <span className="label label-tag label-tag--gray">Disabled</span>}
+                </td>
+
+                <td className="width-1">
+                  {Array.isArray(user.authLabels) && user.authLabels.length > 0 && (
+                    <TagBadge label={user.authLabels[0]} removeIcon={false} count={0} />
+                  )}
                 </td>
 
                 {contextSrv.hasPermissionInMetadata(AccessControlAction.OrgUsersRemove, user) && (

--- a/public/app/features/users/__mocks__/userMocks.ts
+++ b/public/app/features/users/__mocks__/userMocks.ts
@@ -15,6 +15,7 @@ export const getMockUsers = (amount: number) => {
       role: 'Admin',
       userId: i,
       isDisabled: false,
+      authLabels: [],
     });
   }
 

--- a/public/app/types/user.ts
+++ b/public/app/types/user.ts
@@ -12,6 +12,7 @@ export interface OrgUser extends WithAccessControlMetadata {
   role: OrgRole;
   userId: number;
   isDisabled: boolean;
+  authLabels?: string[];
 }
 
 export interface User {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This includes the needed changes for displaying the external id provider label at the organization user screen.

**Which issue(s) does this PR fix?**:



<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #57539

**Special notes for your reviewer**:

Please provide feedback on this implementation. I'm aware we want to move away from cross-referencing data stores, but nothing is set in stone yet.

Also, in an ideal scenario, I'd love to aggregate all available idP's with something like `STRING_AGG` for psql, but could find something similar with xorm.

For now, we only care about the first result/idP since it gets ignored by frontend anyway.
