### PR TITLE
[9.2.x]: LibrayPanels: Fix unlinking libray panel #57825

### DIFF
--- a/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
@@ -370,8 +370,7 @@ export class PanelEditorUnconnected extends PureComponent<Props> {
                 onClick={() => {
                   showModal(UnlinkModal, {
                     onConfirm: () => {
-                      delete this.props.panel.libraryPanel;
-                      this.props.panel.render();
+                      this.props.panel.unlinkLibraryPanel();
                       this.forceUpdate();
                     },
                     onDismiss: hideModal,

--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -659,6 +659,12 @@ export class PanelModel implements DataConfigSource, IPanelModel {
   getDisplayTitle(): string {
     return this.replaceVariables(this.title, undefined, 'text');
   }
+
+  unlinkLibraryPanel() {
+    delete this.libraryPanel;
+    this.configRev++;
+    this.render();
+  }
 }
 
 function getPluginVersion(plugin: PanelPlugin): string {

--- a/public/app/features/dashboard/utils/panel.ts
+++ b/public/app/features/dashboard/utils/panel.ts
@@ -87,10 +87,7 @@ export const unlinkLibraryPanel = (panel: PanelModel) => {
     new ShowModalReactEvent({
       component: UnlinkModal,
       props: {
-        onConfirm: () => {
-          delete panel.libraryPanel;
-          panel.render();
-        },
+        onConfirm: () => panel.unlinkLibraryPanel(),
         isOpen: true,
       },
     })


### PR DESCRIPTION
Discovered that when unlinking from panel edit, then hitting apply the change is not actually committed.

This is not a bug caused by recent big change to library panels (https://github.com/grafana/grafana/pull/50560) but a bug that is actually part of 9.1 and 9.2


manual backport of
https://github.com/grafana/grafana/pull/57825