### PR TITLE
[v9.2.x] Linux Packages: Handle publish to beta (#57528)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3831,7 +3831,7 @@ steps:
   settings:
     access_key_id:
       from_secret: packages_access_key_id
-    deb_distribution: stable
+    deb_distribution: auto
     gpg_passphrase:
       from_secret: packages_gpg_passphrase
     gpg_private_key:
@@ -3853,7 +3853,7 @@ steps:
   settings:
     access_key_id:
       from_secret: packages_access_key_id
-    deb_distribution: stable
+    deb_distribution: auto
     gpg_passphrase:
       from_secret: packages_gpg_passphrase
     gpg_private_key:
@@ -3944,7 +3944,7 @@ steps:
   settings:
     access_key_id:
       from_secret: packages_access_key_id
-    deb_distribution: stable
+    deb_distribution: auto
     gpg_passphrase:
       from_secret: packages_gpg_passphrase
     gpg_private_key:
@@ -3966,7 +3966,7 @@ steps:
   settings:
     access_key_id:
       from_secret: packages_access_key_id
-    deb_distribution: stable
+    deb_distribution: auto
     gpg_passphrase:
       from_secret: packages_gpg_passphrase
     gpg_private_key:
@@ -5626,6 +5626,6 @@ kind: secret
 name: packages_secret_access_key
 ---
 kind: signature
-hmac: 1c0aab8b158701fdee8f92fa746a6dedaef1bbbe03f636dda626b14d71387d21
+hmac: 21d121bd16e4cdbbc8ecffb3bd322395f2daa2bf16ba2ce1b5a50938ad77ff92
 
 ...

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -1062,7 +1062,7 @@ def publish_linux_packages_step(edition, package_manager='deb'):
             'secret_access_key': from_secret('packages_secret_access_key'),
             'service_account_json': from_secret('packages_service_account'),
             'target_bucket': 'grafana-packages',
-            'deb_distribution': 'stable',
+            'deb_distribution': 'auto',
             'gpg_passphrase': from_secret('packages_gpg_passphrase'),
             'gpg_public_key': from_secret('packages_gpg_public_key'),
             'gpg_private_key': from_secret('packages_gpg_private_key'),


### PR DESCRIPTION
Uses the feature added here: https://github.com/grafana/deployment_tools/pull/46301 When a version is named "beta", it will be distributed in the beta distribution, rather than in stable

Co-authored-by: dsotirakis <dimitrios.sotirakis@grafana.com>
(cherry picked from commit c46a4a0b260d3b008bfa771cdc103065a6fe6880)

Backport of #57528