### PR TITLE
[v9.1.x] Linux Packages: Handle publish to beta (#57528)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3559,7 +3559,7 @@ steps:
   settings:
     access_key_id:
       from_secret: packages_access_key_id
-    deb_distribution: stable
+    deb_distribution: auto
     gpg_passphrase:
       from_secret: packages_gpg_passphrase
     gpg_private_key:
@@ -3581,7 +3581,7 @@ steps:
   settings:
     access_key_id:
       from_secret: packages_access_key_id
-    deb_distribution: stable
+    deb_distribution: auto
     gpg_passphrase:
       from_secret: packages_gpg_passphrase
     gpg_private_key:
@@ -3659,7 +3659,7 @@ steps:
   settings:
     access_key_id:
       from_secret: packages_access_key_id
-    deb_distribution: stable
+    deb_distribution: auto
     gpg_passphrase:
       from_secret: packages_gpg_passphrase
     gpg_private_key:
@@ -3681,7 +3681,7 @@ steps:
   settings:
     access_key_id:
       from_secret: packages_access_key_id
-    deb_distribution: stable
+    deb_distribution: auto
     gpg_passphrase:
       from_secret: packages_gpg_passphrase
     gpg_private_key:
@@ -5208,6 +5208,6 @@ kind: secret
 name: packages_secret_access_key
 ---
 kind: signature
-hmac: bb96677e0e3c1d25e4f91dd7f7752d0f0135002f27363c7e9e4310ec5276eb45
+hmac: 61544f9437501dccedc793eadc13d6d9e0d29d3f658e6d49f14a2125f8cb1c9a
 
 ...

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -1039,7 +1039,7 @@ def publish_linux_packages_step(edition, package_manager='deb'):
             'secret_access_key': from_secret('packages_secret_access_key'),
             'service_account_json': from_secret('packages_service_account'),
             'target_bucket': 'grafana-packages',
-            'deb_distribution': 'stable',
+            'deb_distribution': 'auto',
             'gpg_passphrase': from_secret('packages_gpg_passphrase'),
             'gpg_public_key': from_secret('packages_gpg_public_key'),
             'gpg_private_key': from_secret('packages_gpg_private_key'),


### PR DESCRIPTION
Uses the feature added here: https://github.com/grafana/deployment_tools/pull/46301 When a version is named "beta", it will be distributed in the beta distribution, rather than in stable

Co-authored-by: dsotirakis <dimitrios.sotirakis@grafana.com>
(cherry picked from commit c46a4a0b260d3b008bfa771cdc103065a6fe6880)

Backport of #57528