### PR TITLE
Alerting: Fix response is not returned for invalid Duration in Provisioning API

### DIFF
--- a/pkg/services/ngalert/api/api_provisioning.go
+++ b/pkg/services/ngalert/api/api_provisioning.go
@@ -257,7 +257,7 @@ func (srv *ProvisioningSrv) RoutePostAlertRule(c *models.ReqContext, ar definiti
 	upstreamModel, err := ar.UpstreamModel()
 	upstreamModel.OrgID = c.OrgID
 	if err != nil {
-		ErrResp(http.StatusBadRequest, err, "")
+		return ErrResp(http.StatusBadRequest, err, "")
 	}
 	createdAlertRule, err := srv.alertRules.CreateAlertRule(c.Req.Context(), upstreamModel, alerting_models.ProvenanceAPI, c.UserID)
 	if errors.Is(err, alerting_models.ErrAlertRuleFailedValidation) {


### PR DESCRIPTION
**Which issue(s) does this PR fix?**:

Fixes a bug where an invalid For duration would attempt to create an alert rule with all default values.

**Special notes for your reviewer**:

