### PR TITLE
Accessibility: Enable `jsx-a11y/mouse-events-have-key-events`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -73,7 +73,6 @@
         // we should remove the corresponding line and fix them one by one
         // any marked "error" contain specific overrides we'll need to keep
         "jsx-a11y/click-events-have-key-events": "off",
-        "jsx-a11y/mouse-events-have-key-events": "off",
         "jsx-a11y/no-autofocus": [
           "error",
           {

--- a/packages/grafana-ui/src/components/VizLegend/VizLegend.tsx
+++ b/packages/grafana-ui/src/components/VizLegend/VizLegend.tsx
@@ -28,8 +28,11 @@ export function VizLegend<T>({
 }: LegendProps<T>) {
   const { eventBus, onToggleSeriesVisibility, onToggleLegendSort } = usePanelContext();
 
-  const onMouseEnter = useCallback(
-    (item: VizLegendItem, event: React.MouseEvent<HTMLElement, MouseEvent>) => {
+  const onMouseOver = useCallback(
+    (
+      item: VizLegendItem,
+      event: React.MouseEvent<HTMLButtonElement, MouseEvent> | React.FocusEvent<HTMLButtonElement>
+    ) => {
       eventBus?.publish({
         type: DataHoverEvent.type,
         payload: {
@@ -44,7 +47,10 @@ export function VizLegend<T>({
   );
 
   const onMouseOut = useCallback(
-    (item: VizLegendItem, event: React.MouseEvent<HTMLElement, MouseEvent>) => {
+    (
+      item: VizLegendItem,
+      event: React.MouseEvent<HTMLButtonElement, MouseEvent> | React.FocusEvent<HTMLButtonElement>
+    ) => {
       eventBus?.publish({
         type: DataHoverClearEvent.type,
         payload: {
@@ -59,7 +65,7 @@ export function VizLegend<T>({
   );
 
   const onLegendLabelClick = useCallback(
-    (item: VizLegendItem, event: React.MouseEvent<HTMLElement, MouseEvent>) => {
+    (item: VizLegendItem, event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
       if (onLabelClick) {
         onLabelClick(item, event);
       }
@@ -86,7 +92,7 @@ export function VizLegend<T>({
           sortDesc={sortDesc}
           onLabelClick={onLegendLabelClick}
           onToggleSort={onToggleSort || onToggleLegendSort}
-          onLabelMouseEnter={onMouseEnter}
+          onLabelMouseOver={onMouseOver}
           onLabelMouseOut={onMouseOut}
           itemRenderer={itemRenderer}
           readonly={readonly}
@@ -98,7 +104,7 @@ export function VizLegend<T>({
           className={className}
           items={items}
           placement={placement}
-          onLabelMouseEnter={onMouseEnter}
+          onLabelMouseOver={onMouseOver}
           onLabelMouseOut={onMouseOut}
           onLabelClick={onLegendLabelClick}
           itemRenderer={itemRenderer}

--- a/packages/grafana-ui/src/components/VizLegend/VizLegendList.tsx
+++ b/packages/grafana-ui/src/components/VizLegend/VizLegendList.tsx
@@ -18,7 +18,7 @@ export interface Props<T> extends VizLegendBaseProps<T> {}
 export const VizLegendList = <T extends unknown>({
   items,
   itemRenderer,
-  onLabelMouseEnter,
+  onLabelMouseOver,
   onLabelMouseOut,
   onLabelClick,
   placement,
@@ -33,7 +33,7 @@ export const VizLegendList = <T extends unknown>({
       <VizLegendListItem
         item={item}
         onLabelClick={onLabelClick}
-        onLabelMouseEnter={onLabelMouseEnter}
+        onLabelMouseOver={onLabelMouseOver}
         onLabelMouseOut={onLabelMouseOut}
         readonly={readonly}
       />

--- a/packages/grafana-ui/src/components/VizLegend/VizLegendListItem.tsx
+++ b/packages/grafana-ui/src/components/VizLegend/VizLegendListItem.tsx
@@ -13,9 +13,15 @@ import { VizLegendItem } from './types';
 export interface Props<T> {
   item: VizLegendItem<T>;
   className?: string;
-  onLabelClick?: (item: VizLegendItem<T>, event: React.MouseEvent<HTMLDivElement>) => void;
-  onLabelMouseEnter?: (item: VizLegendItem, event: React.MouseEvent<HTMLDivElement>) => void;
-  onLabelMouseOut?: (item: VizLegendItem, event: React.MouseEvent<HTMLDivElement>) => void;
+  onLabelClick?: (item: VizLegendItem<T>, event: React.MouseEvent<HTMLButtonElement>) => void;
+  onLabelMouseOver?: (
+    item: VizLegendItem,
+    event: React.MouseEvent<HTMLButtonElement> | React.FocusEvent<HTMLButtonElement>
+  ) => void;
+  onLabelMouseOut?: (
+    item: VizLegendItem,
+    event: React.MouseEvent<HTMLButtonElement> | React.FocusEvent<HTMLButtonElement>
+  ) => void;
   readonly?: boolean;
 }
 
@@ -25,24 +31,24 @@ export interface Props<T> {
 export const VizLegendListItem = <T = unknown,>({
   item,
   onLabelClick,
-  onLabelMouseEnter,
+  onLabelMouseOver,
   onLabelMouseOut,
   className,
   readonly,
 }: Props<T>) => {
   const styles = useStyles2(getStyles);
 
-  const onMouseEnter = useCallback(
-    (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
-      if (onLabelMouseEnter) {
-        onLabelMouseEnter(item, event);
+  const onMouseOver = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement, MouseEvent> | React.FocusEvent<HTMLButtonElement>) => {
+      if (onLabelMouseOver) {
+        onLabelMouseOver(item, event);
       }
     },
-    [item, onLabelMouseEnter]
+    [item, onLabelMouseOver]
   );
 
   const onMouseOut = useCallback(
-    (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+    (event: React.MouseEvent<HTMLButtonElement, MouseEvent> | React.FocusEvent<HTMLButtonElement>) => {
       if (onLabelMouseOut) {
         onLabelMouseOut(item, event);
       }
@@ -51,7 +57,7 @@ export const VizLegendListItem = <T = unknown,>({
   );
 
   const onClick = useCallback(
-    (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+    (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
       if (onLabelClick) {
         onLabelClick(item, event);
       }
@@ -65,14 +71,18 @@ export const VizLegendListItem = <T = unknown,>({
       aria-label={selectors.components.VizLegend.seriesName(item.label)}
     >
       <VizLegendSeriesIcon seriesName={item.label} color={item.color} gradient={item.gradient} readonly={readonly} />
-      <div
-        onMouseEnter={onMouseEnter}
+      <button
+        disabled={readonly}
+        type="button"
+        onBlur={onMouseOut}
+        onFocus={onMouseOver}
+        onMouseOver={onMouseOver}
         onMouseOut={onMouseOut}
-        onClick={!readonly ? onClick : undefined}
-        className={cx(styles.label, !readonly && styles.clickable)}
+        onClick={onClick}
+        className={styles.label}
       >
         {item.label}
-      </div>
+      </button>
 
       {item.getDisplayValues && <VizLegendStatsList stats={item.getDisplayValues()} />}
     </div>
@@ -85,10 +95,10 @@ const getStyles = (theme: GrafanaTheme2) => ({
   label: css`
     label: LegendLabel;
     white-space: nowrap;
-  `,
-  clickable: css`
-    label: LegendClickabel;
-    cursor: pointer;
+    background: none;
+    border: none;
+    font-size: inherit;
+    padding: 0;
   `,
   itemDisabled: css`
     label: LegendLabelDisabled;

--- a/packages/grafana-ui/src/components/VizLegend/VizLegendTable.tsx
+++ b/packages/grafana-ui/src/components/VizLegend/VizLegendTable.tsx
@@ -21,7 +21,7 @@ export const VizLegendTable = <T extends unknown>({
   className,
   onToggleSort,
   onLabelClick,
-  onLabelMouseEnter,
+  onLabelMouseOver,
   onLabelMouseOut,
   readonly,
 }: VizLegendTableProps<T>): JSX.Element => {
@@ -57,7 +57,7 @@ export const VizLegendTable = <T extends unknown>({
         key={`${item.label}-${index}`}
         item={item}
         onLabelClick={onLabelClick}
-        onLabelMouseEnter={onLabelMouseEnter}
+        onLabelMouseOver={onLabelMouseOver}
         onLabelMouseOut={onLabelMouseOut}
         readonly={readonly}
       />

--- a/packages/grafana-ui/src/components/VizLegend/VizLegendTableItem.tsx
+++ b/packages/grafana-ui/src/components/VizLegend/VizLegendTableItem.tsx
@@ -13,9 +13,15 @@ export interface Props {
   key?: React.Key;
   item: VizLegendItem;
   className?: string;
-  onLabelClick?: (item: VizLegendItem, event: React.MouseEvent<HTMLDivElement>) => void;
-  onLabelMouseEnter?: (item: VizLegendItem, event: React.MouseEvent<HTMLDivElement>) => void;
-  onLabelMouseOut?: (item: VizLegendItem, event: React.MouseEvent<HTMLDivElement>) => void;
+  onLabelClick?: (item: VizLegendItem, event: React.MouseEvent<HTMLButtonElement>) => void;
+  onLabelMouseOver?: (
+    item: VizLegendItem,
+    event: React.MouseEvent<HTMLButtonElement> | React.FocusEvent<HTMLButtonElement>
+  ) => void;
+  onLabelMouseOut?: (
+    item: VizLegendItem,
+    event: React.MouseEvent<HTMLButtonElement> | React.FocusEvent<HTMLButtonElement>
+  ) => void;
   readonly?: boolean;
 }
 
@@ -25,24 +31,24 @@ export interface Props {
 export const LegendTableItem: React.FunctionComponent<Props> = ({
   item,
   onLabelClick,
-  onLabelMouseEnter,
+  onLabelMouseOver,
   onLabelMouseOut,
   className,
   readonly,
 }) => {
   const styles = useStyles2(getStyles);
 
-  const onMouseEnter = useCallback(
-    (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
-      if (onLabelMouseEnter) {
-        onLabelMouseEnter(item, event);
+  const onMouseOver = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement, MouseEvent> | React.FocusEvent<HTMLButtonElement>) => {
+      if (onLabelMouseOver) {
+        onLabelMouseOver(item, event);
       }
     },
-    [item, onLabelMouseEnter]
+    [item, onLabelMouseOver]
   );
 
   const onMouseOut = useCallback(
-    (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+    (event: React.MouseEvent<HTMLButtonElement, MouseEvent> | React.FocusEvent<HTMLButtonElement>) => {
       if (onLabelMouseOut) {
         onLabelMouseOut(item, event);
       }
@@ -51,7 +57,7 @@ export const LegendTableItem: React.FunctionComponent<Props> = ({
   );
 
   const onClick = useCallback(
-    (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+    (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
       if (onLabelClick) {
         onLabelClick(item, event);
       }
@@ -64,14 +70,18 @@ export const LegendTableItem: React.FunctionComponent<Props> = ({
       <td>
         <span className={styles.itemWrapper}>
           <VizLegendSeriesIcon color={item.color} seriesName={item.label} readonly={readonly} />
-          <div
-            onMouseEnter={onMouseEnter}
+          <button
+            disabled={readonly}
+            type="button"
+            onBlur={onMouseOut}
+            onFocus={onMouseOver}
+            onMouseOver={onMouseOver}
             onMouseOut={onMouseOut}
             onClick={!readonly ? onClick : undefined}
-            className={cx(styles.label, item.disabled && styles.labelDisabled, !readonly && styles.clickable)}
+            className={cx(styles.label, item.disabled && styles.labelDisabled)}
           >
             {item.label} {item.yAxis === 2 && <span className={styles.yAxisLabel}>(right y-axis)</span>}
-          </div>
+          </button>
         </span>
       </td>
       {item.getDisplayValues &&
@@ -108,14 +118,14 @@ const getStyles = (theme: GrafanaTheme2) => {
     label: css`
       label: LegendLabel;
       white-space: nowrap;
+      background: none;
+      border: none;
+      font-size: inherit;
+      padding: 0;
     `,
     labelDisabled: css`
       label: LegendLabelDisabled;
       color: ${theme.colors.text.disabled};
-    `,
-    clickable: css`
-      label: LegendClickable;
-      cursor: pointer;
     `,
     itemWrapper: css`
       display: flex;

--- a/packages/grafana-ui/src/components/VizLegend/types.ts
+++ b/packages/grafana-ui/src/components/VizLegend/types.ts
@@ -13,10 +13,16 @@ export interface VizLegendBaseProps<T> {
   className?: string;
   items: Array<VizLegendItem<T>>;
   seriesVisibilityChangeBehavior?: SeriesVisibilityChangeBehavior;
-  onLabelClick?: (item: VizLegendItem<T>, event: React.MouseEvent<HTMLElement>) => void;
+  onLabelClick?: (item: VizLegendItem<T>, event: React.MouseEvent<HTMLButtonElement>) => void;
   itemRenderer?: (item: VizLegendItem<T>, index: number) => JSX.Element;
-  onLabelMouseEnter?: (item: VizLegendItem, event: React.MouseEvent<HTMLElement>) => void;
-  onLabelMouseOut?: (item: VizLegendItem, event: React.MouseEvent<HTMLElement>) => void;
+  onLabelMouseOver?: (
+    item: VizLegendItem,
+    event: React.MouseEvent<HTMLButtonElement> | React.FocusEvent<HTMLButtonElement>
+  ) => void;
+  onLabelMouseOut?: (
+    item: VizLegendItem,
+    event: React.MouseEvent<HTMLButtonElement> | React.FocusEvent<HTMLButtonElement>
+  ) => void;
   readonly?: boolean;
 }
 

--- a/packages/jaeger-ui-components/src/TraceTimelineViewer/SpanBar.tsx
+++ b/packages/jaeger-ui-components/src/TraceTimelineViewer/SpanBar.tsx
@@ -147,8 +147,10 @@ function SpanBar({
   return (
     <div
       className={cx(styles.wrapper, className)}
+      onBlur={setShortLabel}
       onClick={onClick}
-      onMouseLeave={setShortLabel}
+      onFocus={setLongLabel}
+      onMouseOut={setShortLabel}
       onMouseOver={setLongLabel}
       aria-hidden
       data-testid={selectors.components.TraceViewer.spanBar}

--- a/public/app/plugins/datasource/graphite/components/GraphiteFunctionEditor.tsx
+++ b/public/app/plugins/datasource/graphite/components/GraphiteFunctionEditor.tsx
@@ -37,8 +37,10 @@ export function GraphiteFunctionEditor({ func }: FunctionEditorProps) {
   return (
     <div
       className={cx(styles.container, { [styles.error]: func.def.unknown })}
+      onBlur={() => setIsMouseOver(false)}
+      onFocus={() => setIsMouseOver(true)}
       onMouseOver={() => setIsMouseOver(true)}
-      onMouseLeave={() => setIsMouseOver(false)}
+      onMouseOut={() => setIsMouseOver(false)}
     >
       <HorizontalGroup spacing="none">
         <FunctionEditor


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- enables rule `jsx-a11y/mouse-events-have-key-events`
- changes to consistently use either `onMouseOver`+`onMouseOut` or `onMouseEnter`+`onMouseLeave` (we were using these interchangeably when they have subtly different behaviours and kind of go in pairs)
- improves `VizLegend` accessibility
  - the legend labels are now buttons. this means you can navigate to them via a keyboard
  - changed to use `onMouseOver` instead of `onMouseEnter`
  - changed the event types to either be a `MouseEvent` or a `FocusEvent`

**Why do we need this feature?**

- improve accessibility + prevent future problems

**Who is this feature for?**

- everyone!

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/58041

**Special notes for your reviewer**:

i've checked the dashboard at https://ops.grafana.net/d/bML5aAb7k/plugins-imports?orgId=1&var-packageName=@grafana%2Fui for imports of `VizLegendListItem` and there isn't any, so expect this to be a fairly low impact change. 

# Release notice breaking change

We've made some accessibility improvements to `VizLegend`. As a result, the `onMouseEnter` prop for both `VizLegendList` and `VizLegendTable` has now been changed to `onMouseOver`. The event types that these props receive has been updated to come from a `HTMLButtonElement` and we've extended the types to account for `FocusEvent`s as well as `MouseEvent`s. 