### PR TITLE
renovate: group @types/slate* with slate*

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -68,6 +68,8 @@
     {
       "groupName": "Slate",
       "matchPackageNames": [
+        "@types/slate",
+        "@types/slate-react",
         "slate",
         "slate-react"
       ]


### PR DESCRIPTION
i think it makes sense to group the `@types` changes together with the slate-changes. (or i may be very wrong, comments welcome :) 