### PR TITLE
Add check for ds.name with adhoc filter

### DIFF
--- a/public/app/features/templating/template_srv.ts
+++ b/public/app/features/templating/template_srv.ts
@@ -106,7 +106,7 @@ export class TemplateSrv implements BaseTemplateSrv {
     for (const variable of this.getAdHocVariables()) {
       const variableUid = variable.datasource?.uid;
 
-      if (variableUid === ds.uid) {
+      if (variableUid === ds.uid || variableUid === ds.name) {
         filters = filters.concat(variable.filters);
       } else if (variableUid?.indexOf('$') === 0) {
         if (this.replace(variableUid) === datasourceName) {


### PR DESCRIPTION
**What is this feature?**
Allows provisioned dashboards to use the datasource name as a reference rather than requiring the UID.

**Why do we need this feature?**
Allows provisioned dashboards to use the datasource name as a reference rather than requiring the UID.

**Who is this feature for?**
This is for anyone wanting to provision the same dashboard (with adhoc filters) to multiple organisation where the datasource UID would be different between each organisation.

