### PR TITLE
Chore: Upgrade Go to 1.19.3

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -23,17 +23,17 @@ steps:
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: gen-version
 - commands:
   - make gen-go
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: yarn-install
 - commands:
   - ./bin/grabpl verify-drone
@@ -51,13 +51,13 @@ steps:
     wan" > words_to_ignore.txt
   - codespell -I words_to_ignore.txt docs/
   - rm words_to_ignore.txt
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: codespell
 - commands:
   - ./bin/grabpl shellcheck
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: shellcheck
 - commands:
   - ./bin/grabpl lint-backend --edition oss
@@ -65,7 +65,7 @@ steps:
   - wire-install
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: lint-backend
 - commands:
   - yarn run prettier:check
@@ -76,19 +76,19 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: lint-frontend
 - commands:
   - ./bin/grabpl test-backend --edition oss
   depends_on:
   - wire-install
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: test-backend
 - commands:
   - ./bin/grabpl integration-tests --edition oss
   depends_on:
   - wire-install
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: test-backend-integration
 - commands:
   - yarn run ci:test-frontend
@@ -96,7 +96,7 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: test-frontend
 trigger:
   event:
@@ -134,17 +134,17 @@ steps:
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: gen-version
 - commands:
   - make gen-go
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: yarn-install
 - commands:
   - ./bin/grabpl build-backend --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
@@ -152,7 +152,7 @@ steps:
   depends_on:
   - gen-version
   - wire-install
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: build-backend
 - commands:
   - ./bin/grabpl build-frontend --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
@@ -161,7 +161,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: build-frontend
 - commands:
   - ./bin/grabpl build-frontend-packages --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
@@ -170,7 +170,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: build-frontend-packages
 - commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition oss
@@ -178,13 +178,13 @@ steps:
   - gen-version
   - yarn-install
   environment: null
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: build-plugins
 - commands:
   - ./bin/linux-amd64/grafana-cli cue validate-schema --grafana-root .
   depends_on:
   - build-backend
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: validate-scuemata
 - commands:
   - '# It is required that the generated Typescript be in sync with the input CUE
@@ -197,7 +197,7 @@ steps:
   - ./bin/linux-amd64/grafana-cli cue gen-ts --grafana-root . --diff
   depends_on:
   - validate-scuemata
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: ensure-cuetsified
 - commands:
   - . scripts/build/gpg-test-vars.sh && ./bin/grabpl package --jobs 8 --edition oss
@@ -208,7 +208,7 @@ steps:
   - build-frontend
   - build-frontend-packages
   environment: null
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: package
 - commands:
   - ./scripts/grafana-server/start-server
@@ -221,7 +221,7 @@ steps:
   environment:
     ARCH: linux-amd64
     PORT: 3001
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: grafana-server
 - commands:
   - apt-get install -y netcat
@@ -299,7 +299,7 @@ steps:
   - build-frontend-packages
   environment:
     NODE_OPTIONS: --max_old_space_size=4096
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: build-storybook
 - commands:
   - yarn wait-on http://$HOST:$PORT
@@ -319,7 +319,7 @@ steps:
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: copy-packages-for-docker
 - commands:
   - ./bin/grabpl build-docker --edition oss -archs amd64
@@ -398,7 +398,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -413,7 +413,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: mysql-integration-tests
 trigger:
   event:
@@ -457,13 +457,13 @@ steps:
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: gen-version
 - commands:
   - yarn install --immutable
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: yarn-install
 - commands:
   - |-
@@ -475,7 +475,7 @@ steps:
     wan" > words_to_ignore.txt
   - codespell -I words_to_ignore.txt docs/
   - rm words_to_ignore.txt
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: codespell
 - commands:
   - yarn run prettier:checkDocs
@@ -483,7 +483,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: lint-docs
 - commands:
   - ./bin/grabpl build-frontend-packages --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
@@ -492,13 +492,13 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: build-frontend-packages
 - commands:
   - ./scripts/ci-reference-docs-lint.sh ci
   depends_on:
   - build-frontend-packages
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: build-frontend-docs
 - commands:
   - mkdir -p /hugo/content/docs/grafana
@@ -545,13 +545,13 @@ steps:
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: gen-version
 - commands:
   - yarn install --immutable
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: yarn-install
 - commands:
   - |-
@@ -563,7 +563,7 @@ steps:
     wan" > words_to_ignore.txt
   - codespell -I words_to_ignore.txt docs/
   - rm words_to_ignore.txt
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: codespell
 - commands:
   - yarn run prettier:checkDocs
@@ -571,7 +571,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: lint-docs
 - commands:
   - ./bin/grabpl build-frontend-packages --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
@@ -580,13 +580,13 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: build-frontend-packages
 - commands:
   - ./scripts/ci-reference-docs-lint.sh ci
   depends_on:
   - build-frontend-packages
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: build-frontend-docs
 - commands:
   - mkdir -p /hugo/content/docs/grafana
@@ -630,17 +630,17 @@ steps:
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: gen-version
 - commands:
   - make gen-go
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: yarn-install
 - commands:
   - ./bin/grabpl verify-drone
@@ -658,13 +658,13 @@ steps:
     wan" > words_to_ignore.txt
   - codespell -I words_to_ignore.txt docs/
   - rm words_to_ignore.txt
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: codespell
 - commands:
   - ./bin/grabpl shellcheck
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: shellcheck
 - commands:
   - ./bin/grabpl lint-backend --edition oss
@@ -672,7 +672,7 @@ steps:
   - wire-install
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: lint-backend
 - commands:
   - yarn run prettier:check
@@ -683,19 +683,19 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: lint-frontend
 - commands:
   - ./bin/grabpl test-backend --edition oss
   depends_on:
   - wire-install
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: test-backend
 - commands:
   - ./bin/grabpl integration-tests --edition oss
   depends_on:
   - wire-install
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: test-backend-integration
 - commands:
   - yarn run ci:test-frontend
@@ -703,7 +703,7 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: test-frontend
 trigger:
   branch: main
@@ -739,17 +739,17 @@ steps:
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: gen-version
 - commands:
   - make gen-go
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: yarn-install
 - commands:
   - git clone "https://$${GITHUB_TOKEN}@github.com/grafana/grafana-enterprise.git"
@@ -770,7 +770,7 @@ steps:
       from_secret: github_token
     TEST_TAG: v0.0.0-test
   failure: ignore
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: trigger-test-release
   when:
     paths:
@@ -794,7 +794,7 @@ steps:
   depends_on:
   - gen-version
   - wire-install
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: build-backend
 - commands:
   - ./bin/grabpl build-frontend --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
@@ -803,7 +803,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: build-frontend
 - commands:
   - ./bin/grabpl build-frontend-packages --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
@@ -812,7 +812,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: build-frontend-packages
 - commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition oss --sign --signing-admin
@@ -822,13 +822,13 @@ steps:
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: build-plugins
 - commands:
   - ./bin/linux-amd64/grafana-cli cue validate-schema --grafana-root .
   depends_on:
   - build-backend
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: validate-scuemata
 - commands:
   - '# It is required that the generated Typescript be in sync with the input CUE
@@ -841,7 +841,7 @@ steps:
   - ./bin/linux-amd64/grafana-cli cue gen-ts --grafana-root . --diff
   depends_on:
   - validate-scuemata
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: ensure-cuetsified
 - commands:
   - ./bin/grabpl package --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER} --sign
@@ -859,7 +859,7 @@ steps:
       from_secret: gpg_pub_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: package
 - commands:
   - ./scripts/grafana-server/start-server
@@ -872,7 +872,7 @@ steps:
   environment:
     ARCH: linux-amd64
     PORT: 3001
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: grafana-server
 - commands:
   - apt-get install -y netcat
@@ -950,7 +950,7 @@ steps:
   - build-frontend-packages
   environment:
     NODE_OPTIONS: --max_old_space_size=4096
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: build-storybook
 - commands:
   - ./bin/grabpl store-storybook --deployment canary --src-bucket grafana-storybook
@@ -991,7 +991,7 @@ steps:
     GRAFANA_MISC_STATS_API_KEY:
       from_secret: grafana_misc_stats_api_key
   failure: ignore
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: publish-frontend-metrics
   when:
     repo:
@@ -1001,7 +1001,7 @@ steps:
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: copy-packages-for-docker
 - commands:
   - ./bin/grabpl build-docker --edition oss
@@ -1079,7 +1079,7 @@ steps:
   environment:
     NPM_TOKEN:
       from_secret: npm_token
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: release-canary-npm-packages
   when:
     repo:
@@ -1184,7 +1184,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -1199,7 +1199,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: mysql-integration-tests
 trigger:
   branch: main
@@ -1414,24 +1414,24 @@ steps:
   - ./bin/grabpl gen-version ${DRONE_TAG}
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: gen-version
 - commands:
   - make gen-go
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: yarn-install
 - commands:
   - ./bin/grabpl build-backend --jobs 8 --edition oss ${DRONE_TAG}
   depends_on:
   - gen-version
   - wire-install
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: build-backend
 - commands:
   - ./bin/grabpl build-frontend --jobs 8 --edition oss ${DRONE_TAG}
@@ -1440,7 +1440,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: build-frontend
 - commands:
   - ./bin/grabpl build-frontend-packages --jobs 8 --edition oss ${DRONE_TAG}
@@ -1449,7 +1449,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: build-frontend-packages
 - commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition oss --sign --signing-admin
@@ -1459,13 +1459,13 @@ steps:
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: build-plugins
 - commands:
   - ./bin/linux-amd64/grafana-cli cue validate-schema --grafana-root .
   depends_on:
   - build-backend
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: validate-scuemata
 - commands:
   - '# It is required that the generated Typescript be in sync with the input CUE
@@ -1478,7 +1478,7 @@ steps:
   - ./bin/linux-amd64/grafana-cli cue gen-ts --grafana-root . --diff
   depends_on:
   - validate-scuemata
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: ensure-cuetsified
 - commands:
   - ./bin/grabpl package --jobs 8 --edition oss  --sign ${DRONE_TAG}
@@ -1496,14 +1496,14 @@ steps:
       from_secret: gpg_pub_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: package
 - commands:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: copy-packages-for-docker
 - commands:
   - ./bin/grabpl build-docker --edition oss --shouldSave
@@ -1540,7 +1540,7 @@ steps:
   environment:
     ARCH: linux-amd64
     PORT: 3001
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: grafana-server
 - commands:
   - apt-get install -y netcat
@@ -1618,7 +1618,7 @@ steps:
   - build-frontend-packages
   environment:
     NODE_OPTIONS: --max_old_space_size=4096
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: build-storybook
 - commands:
   - ./bin/grabpl upload-cdn --edition oss --src-bucket "$${PRERELEASE_BUCKET}" --src-dir
@@ -1720,23 +1720,23 @@ steps:
   - ./bin/grabpl gen-version ${DRONE_TAG}
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: gen-version
 - commands:
   - make gen-go
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: yarn-install
 - commands:
   - ./bin/grabpl shellcheck
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: shellcheck
 - commands:
   - |-
@@ -1748,7 +1748,7 @@ steps:
     wan" > words_to_ignore.txt
   - codespell -I words_to_ignore.txt docs/
   - rm words_to_ignore.txt
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: codespell
 - commands:
   - ./bin/grabpl lint-backend --edition oss
@@ -1756,7 +1756,7 @@ steps:
   - wire-install
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: lint-backend
 - commands:
   - yarn run prettier:check
@@ -1767,19 +1767,19 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: lint-frontend
 - commands:
   - ./bin/grabpl test-backend --edition oss
   depends_on:
   - wire-install
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: test-backend
 - commands:
   - ./bin/grabpl integration-tests --edition oss
   depends_on:
   - wire-install
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: test-backend-integration
 - commands:
   - yarn run ci:test-frontend
@@ -1787,7 +1787,7 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: test-frontend
 trigger:
   event:
@@ -1857,7 +1857,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -1872,7 +1872,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: mysql-integration-tests
 trigger:
   event:
@@ -1987,7 +1987,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: clone-enterprise
 - commands:
   - mv bin/grabpl /tmp/
@@ -2003,32 +2003,32 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: init-enterprise
 - commands:
   - make gen-go
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: yarn-install
 - commands:
   - ./bin/grabpl gen-version ${DRONE_TAG}
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: gen-version
 - commands:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise ${DRONE_TAG}
   depends_on:
   - gen-version
   - wire-install
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: build-backend
 - commands:
   - ./bin/grabpl build-frontend --jobs 8 --edition enterprise ${DRONE_TAG}
@@ -2037,7 +2037,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: build-frontend
 - commands:
   - ./bin/grabpl build-frontend-packages --jobs 8 --edition enterprise ${DRONE_TAG}
@@ -2046,7 +2046,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: build-frontend-packages
 - commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition enterprise --sign --signing-admin
@@ -2056,13 +2056,13 @@ steps:
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: build-plugins
 - commands:
   - ./bin/linux-amd64/grafana-cli cue validate-schema --grafana-root .
   depends_on:
   - build-backend
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: validate-scuemata
 - commands:
   - '# It is required that the generated Typescript be in sync with the input CUE
@@ -2075,14 +2075,14 @@ steps:
   - ./bin/linux-amd64/grafana-cli cue gen-ts --grafana-root . --diff
   depends_on:
   - validate-scuemata
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: ensure-cuetsified
 - commands:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise2 ${DRONE_TAG}
   depends_on:
   - gen-version
   - wire-install
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: build-backend-enterprise2
 - commands:
   - ./bin/grabpl package --jobs 8 --edition enterprise  --sign ${DRONE_TAG}
@@ -2101,14 +2101,14 @@ steps:
       from_secret: gpg_pub_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: package
 - commands:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: copy-packages-for-docker
 - commands:
   - ./bin/grabpl build-docker --edition enterprise --shouldSave
@@ -2146,7 +2146,7 @@ steps:
     ARCH: linux-amd64
     PORT: 3001
     RUNDIR: scripts/grafana-server/tmp-grafana-enterprise
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: grafana-server
 - commands:
   - apt-get install -y netcat
@@ -2267,7 +2267,7 @@ steps:
       from_secret: gpg_pub_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: package-enterprise2
 - commands:
   - ./bin/grabpl upload-cdn --edition enterprise2 --src-bucket "$${PRERELEASE_BUCKET}"
@@ -2344,7 +2344,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: clone-enterprise
 - commands:
   - mv bin/grabpl /tmp/
@@ -2360,25 +2360,25 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: init-enterprise
 - commands:
   - make gen-go
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: yarn-install
 - commands:
   - ./bin/grabpl gen-version ${DRONE_TAG}
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: gen-version
 - commands:
   - |-
@@ -2390,7 +2390,7 @@ steps:
     wan" > words_to_ignore.txt
   - codespell -I words_to_ignore.txt docs/
   - rm words_to_ignore.txt
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: codespell
 - commands:
   - ./bin/grabpl lint-backend --edition enterprise
@@ -2398,7 +2398,7 @@ steps:
   - wire-install
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: lint-backend
 - commands:
   - yarn run prettier:check
@@ -2409,19 +2409,19 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: lint-frontend
 - commands:
   - ./bin/grabpl test-backend --edition enterprise
   depends_on:
   - wire-install
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: test-backend
 - commands:
   - ./bin/grabpl integration-tests --edition enterprise
   depends_on:
   - wire-install
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: test-backend-integration
 - commands:
   - yarn run ci:test-frontend
@@ -2429,7 +2429,7 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: test-frontend
 - commands:
   - ./bin/grabpl lint-backend --edition enterprise2
@@ -2437,19 +2437,19 @@ steps:
   - wire-install
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: lint-backend-enterprise2
 - commands:
   - ./bin/grabpl test-backend --edition enterprise2
   depends_on:
   - wire-install
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: test-backend-enterprise2
 - commands:
   - ./bin/grabpl integration-tests --edition enterprise2
   depends_on:
   - wire-install
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: test-backend-integration-enterprise2
 trigger:
   event:
@@ -2523,7 +2523,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: clone-enterprise
 - commands:
   - mv bin/grabpl /tmp/
@@ -2539,7 +2539,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: init-enterprise
 - commands:
   - apt-get update
@@ -2554,7 +2554,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -2569,7 +2569,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: mysql-integration-tests
 - commands:
   - dockerize -wait tcp://redis:6379/0 -timeout 120s
@@ -2578,7 +2578,7 @@ steps:
   - init-enterprise
   environment:
     REDIS_URL: redis://redis:6379/0
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: redis-integration-tests
 - commands:
   - dockerize -wait tcp://memcached:11211 -timeout 120s
@@ -2587,7 +2587,7 @@ steps:
   - init-enterprise
   environment:
     MEMCACHED_HOSTS: memcached:11211
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: memcached-integration-tests
 trigger:
   event:
@@ -3071,7 +3071,7 @@ steps:
   - yarn install --immutable
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: yarn-install
 - commands:
   - ./bin/grabpl artifacts npm retrieve --tag v${TAG}
@@ -3091,7 +3091,7 @@ steps:
   environment:
     NPM_TOKEN:
       from_secret: npm_token
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: release-npm-packages
 trigger:
   event:
@@ -3224,24 +3224,24 @@ steps:
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: gen-version
 - commands:
   - make gen-go
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: yarn-install
 - commands:
   - ./bin/grabpl build-backend --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - gen-version
   - wire-install
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: build-backend
 - commands:
   - ./bin/grabpl build-frontend --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
@@ -3250,7 +3250,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: build-frontend
 - commands:
   - ./bin/grabpl build-frontend-packages --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
@@ -3259,7 +3259,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: build-frontend-packages
 - commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition oss --sign --signing-admin
@@ -3269,13 +3269,13 @@ steps:
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: build-plugins
 - commands:
   - ./bin/linux-amd64/grafana-cli cue validate-schema --grafana-root .
   depends_on:
   - build-backend
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: validate-scuemata
 - commands:
   - '# It is required that the generated Typescript be in sync with the input CUE
@@ -3288,7 +3288,7 @@ steps:
   - ./bin/linux-amd64/grafana-cli cue gen-ts --grafana-root . --diff
   depends_on:
   - validate-scuemata
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: ensure-cuetsified
 - commands:
   - ./bin/grabpl package --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER} --sign
@@ -3306,14 +3306,14 @@ steps:
       from_secret: gpg_pub_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: package
 - commands:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: copy-packages-for-docker
 - commands:
   - ./bin/grabpl build-docker --edition oss --shouldSave
@@ -3350,7 +3350,7 @@ steps:
   environment:
     ARCH: linux-amd64
     PORT: 3001
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: grafana-server
 - commands:
   - apt-get install -y netcat
@@ -3428,7 +3428,7 @@ steps:
   - build-frontend-packages
   environment:
     NODE_OPTIONS: --max_old_space_size=4096
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: build-storybook
 - commands:
   - ./bin/grabpl upload-cdn --edition oss --src-bucket "grafana-static-assets"
@@ -3500,23 +3500,23 @@ steps:
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: gen-version
 - commands:
   - make gen-go
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: yarn-install
 - commands:
   - ./bin/grabpl shellcheck
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: shellcheck
 - commands:
   - |-
@@ -3528,7 +3528,7 @@ steps:
     wan" > words_to_ignore.txt
   - codespell -I words_to_ignore.txt docs/
   - rm words_to_ignore.txt
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: codespell
 - commands:
   - ./bin/grabpl lint-backend --edition oss
@@ -3536,7 +3536,7 @@ steps:
   - wire-install
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: lint-backend
 - commands:
   - yarn run prettier:check
@@ -3547,19 +3547,19 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: lint-frontend
 - commands:
   - ./bin/grabpl test-backend --edition oss
   depends_on:
   - wire-install
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: test-backend
 - commands:
   - ./bin/grabpl integration-tests --edition oss
   depends_on:
   - wire-install
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: test-backend-integration
 - commands:
   - yarn run ci:test-frontend
@@ -3567,7 +3567,7 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: test-frontend
 trigger:
   ref:
@@ -3631,7 +3631,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -3646,7 +3646,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: mysql-integration-tests
 trigger:
   ref:
@@ -3744,7 +3744,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: clone-enterprise
 - commands:
   - mv bin/grabpl /tmp/
@@ -3757,32 +3757,32 @@ steps:
   depends_on:
   - clone-enterprise
   environment: {}
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: init-enterprise
 - commands:
   - make gen-go
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: yarn-install
 - commands:
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: gen-version
 - commands:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - gen-version
   - wire-install
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: build-backend
 - commands:
   - ./bin/grabpl build-frontend --jobs 8 --edition enterprise --build-id ${DRONE_BUILD_NUMBER}
@@ -3791,7 +3791,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: build-frontend
 - commands:
   - ./bin/grabpl build-frontend-packages --jobs 8 --edition enterprise --build-id
@@ -3801,7 +3801,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: build-frontend-packages
 - commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition enterprise --sign --signing-admin
@@ -3811,13 +3811,13 @@ steps:
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: build-plugins
 - commands:
   - ./bin/linux-amd64/grafana-cli cue validate-schema --grafana-root .
   depends_on:
   - build-backend
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: validate-scuemata
 - commands:
   - '# It is required that the generated Typescript be in sync with the input CUE
@@ -3830,7 +3830,7 @@ steps:
   - ./bin/linux-amd64/grafana-cli cue gen-ts --grafana-root . --diff
   depends_on:
   - validate-scuemata
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: ensure-cuetsified
 - commands:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise2 --build-id ${DRONE_BUILD_NUMBER}
@@ -3838,7 +3838,7 @@ steps:
   depends_on:
   - gen-version
   - wire-install
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: build-backend-enterprise2
 - commands:
   - ./bin/grabpl package --jobs 8 --edition enterprise --build-id ${DRONE_BUILD_NUMBER}
@@ -3858,14 +3858,14 @@ steps:
       from_secret: gpg_pub_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: package
 - commands:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: copy-packages-for-docker
 - commands:
   - ./bin/grabpl build-docker --edition enterprise --shouldSave
@@ -3903,7 +3903,7 @@ steps:
     ARCH: linux-amd64
     PORT: 3001
     RUNDIR: scripts/grafana-server/tmp-grafana-enterprise
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: grafana-server
 - commands:
   - apt-get install -y netcat
@@ -3981,7 +3981,7 @@ steps:
   - build-frontend-packages
   environment:
     NODE_OPTIONS: --max_old_space_size=4096
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: build-storybook
 - commands:
   - ./bin/grabpl upload-cdn --edition enterprise --src-bucket "grafana-static-assets"
@@ -4029,7 +4029,7 @@ steps:
       from_secret: gpg_pub_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: package-enterprise2
 - commands:
   - ./bin/grabpl upload-cdn --edition enterprise2 --src-bucket "grafana-static-assets"
@@ -4099,7 +4099,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: clone-enterprise
 - commands:
   - mv bin/grabpl /tmp/
@@ -4112,25 +4112,25 @@ steps:
   depends_on:
   - clone-enterprise
   environment: {}
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: init-enterprise
 - commands:
   - make gen-go
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: yarn-install
 - commands:
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: gen-version
 - commands:
   - |-
@@ -4142,7 +4142,7 @@ steps:
     wan" > words_to_ignore.txt
   - codespell -I words_to_ignore.txt docs/
   - rm words_to_ignore.txt
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: codespell
 - commands:
   - ./bin/grabpl lint-backend --edition enterprise
@@ -4150,7 +4150,7 @@ steps:
   - wire-install
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: lint-backend
 - commands:
   - yarn run prettier:check
@@ -4161,19 +4161,19 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: lint-frontend
 - commands:
   - ./bin/grabpl test-backend --edition enterprise
   depends_on:
   - wire-install
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: test-backend
 - commands:
   - ./bin/grabpl integration-tests --edition enterprise
   depends_on:
   - wire-install
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: test-backend-integration
 - commands:
   - yarn run ci:test-frontend
@@ -4181,7 +4181,7 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: test-frontend
 - commands:
   - ./bin/grabpl lint-backend --edition enterprise2
@@ -4189,19 +4189,19 @@ steps:
   - wire-install
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: lint-backend-enterprise2
 - commands:
   - ./bin/grabpl test-backend --edition enterprise2
   depends_on:
   - wire-install
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: test-backend-enterprise2
 - commands:
   - ./bin/grabpl integration-tests --edition enterprise2
   depends_on:
   - wire-install
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: test-backend-integration-enterprise2
 trigger:
   ref:
@@ -4269,7 +4269,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: clone-enterprise
 - commands:
   - mv bin/grabpl /tmp/
@@ -4282,7 +4282,7 @@ steps:
   depends_on:
   - clone-enterprise
   environment: {}
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: init-enterprise
 - commands:
   - apt-get update
@@ -4297,7 +4297,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -4312,7 +4312,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: mysql-integration-tests
 - commands:
   - dockerize -wait tcp://redis:6379/0 -timeout 120s
@@ -4321,7 +4321,7 @@ steps:
   - init-enterprise
   environment:
     REDIS_URL: redis://redis:6379/0
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: redis-integration-tests
 - commands:
   - dockerize -wait tcp://memcached:11211 -timeout 120s
@@ -4330,7 +4330,7 @@ steps:
   - init-enterprise
   environment:
     MEMCACHED_HOSTS: memcached:11211
-  image: grafana/build-container:1.5.5-go1.19.2-2
+  image: grafana/build-container:1.5.5-go1.19.3
   name: memcached-integration-tests
 trigger:
   ref:
@@ -4566,6 +4566,6 @@ kind: secret
 name: gcp_upload_artifacts_key
 ---
 kind: signature
-hmac: 446ce211b77712caad1a1dca5a5f30d4b60adf585c76eddf5aba003da2d7f598
+hmac: 4087e4f48643f33a6a0b9bb426d48b484336c1c79a30d03d66c430d36c68c5ad
 
 ...

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ COPY emails emails
 ENV NODE_ENV production
 RUN yarn build
 
-FROM golang:1.19.2-alpine3.15 as go-builder
+FROM golang:1.19.3-alpine3.15 as go-builder
 
 RUN apk add --no-cache gcc g++ make
 

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -21,7 +21,7 @@ COPY emails emails
 ENV NODE_ENV production
 RUN yarn build
 
-FROM golang:1.19.2 AS go-builder
+FROM golang:1.19.3 AS go-builder
 
 WORKDIR /src/grafana
 

--- a/scripts/build/ci-build/Dockerfile
+++ b/scripts/build/ci-build/Dockerfile
@@ -110,7 +110,7 @@ RUN rm dockerize-linux-amd64-v${DOCKERIZE_VERSION}.tar.gz
 # Use old Debian (this has support into 2022) in order to ensure binary compatibility with older glibc's.
 FROM debian:stretch-20210208
 
-ENV GOVERSION=1.19.2 \
+ENV GOVERSION=1.19.3 \
     PATH=/usr/local/go/bin:$PATH \
     GOPATH=/go \
     NODEVERSION=16.14.0-1nodesource1 \

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -1,7 +1,7 @@
 load('scripts/drone/vault.star', 'from_secret', 'github_token', 'pull_secret', 'drone_token', 'prerelease_bucket')
 
 grabpl_version = 'v2.9.50'
-build_image = 'grafana/build-container:1.5.5-go1.19.2-2'
+build_image = 'grafana/build-container:1.5.5-go1.19.3'
 publish_image = 'grafana/grafana-ci-deploy:1.3.1'
 deploy_docker_image = 'us.gcr.io/kubernetes-dev/drone/plugins/deploy-image'
 alpine_image = 'alpine:3.15'


### PR DESCRIPTION
Upgrades Go for v8.5.x, sort of backport of #58052, but using the 1.5.5 version of the build container that is used for 8.5.x since before.