### PR TITLE
RBAC: Handle edge case where there is duplicated acl entries for a role on a single dashboard

### DIFF
--- a/pkg/services/sqlstore/migrations/accesscontrol/dashboard_permissions.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/dashboard_permissions.go
@@ -243,6 +243,7 @@ func deduplicateAcl(acl []models.DashboardACL) []models.DashboardACL {
 		current, ok := uniqueACL[string(*item.Role)]
 		if !ok {
 			uniqueACL[string(*item.Role)] = item
+			continue
 		}
 
 		if current.Permission < item.Permission {

--- a/pkg/services/sqlstore/migrations/accesscontrol/dashboard_permissions.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/dashboard_permissions.go
@@ -119,9 +119,10 @@ func (m dashboardPermissionsMigrator) migratePermissions(dashboards []dashboard,
 				m.mapPermission(d.ID, models.PERMISSION_VIEW, d.IsFolder)...,
 			)
 		} else {
-			for _, a := range acls {
-				permissionMap[d.OrgID][getRoleName(a)] = append(
-					permissionMap[d.OrgID][getRoleName(a)],
+			for _, a := range deduplicateAcl(acls) {
+				roleName := getRoleName(a)
+				permissionMap[d.OrgID][roleName] = append(
+					permissionMap[d.OrgID][roleName],
 					m.mapPermission(d.ID, a.Permission, d.IsFolder)...,
 				)
 			}
@@ -222,6 +223,38 @@ func getRoleName(p models.DashboardACL) string {
 		return fmt.Sprintf("managed:teams:%d:permissions", p.TeamID)
 	}
 	return fmt.Sprintf("managed:builtins:%s:permissions", strings.ToLower(string(*p.Role)))
+}
+
+func deduplicateAcl(acl []models.DashboardACL) []models.DashboardACL {
+	output := make([]models.DashboardACL, 0, len(acl))
+	uniqueACL := map[string]models.DashboardACL{}
+	for _, item := range acl {
+		// acl items with userID or teamID is enforced to be unique by sql constraint, so we can skip those
+		if item.UserID > 0 || item.TeamID > 0 {
+			output = append(output, item)
+			continue
+		}
+
+		// better to make sure so we don't panic
+		if item.Role == nil {
+			continue
+		}
+
+		current, ok := uniqueACL[string(*item.Role)]
+		if !ok {
+			uniqueACL[string(*item.Role)] = item
+		}
+
+		if current.Permission < item.Permission {
+			uniqueACL[string(*item.Role)] = item
+		}
+	}
+
+	for _, item := range uniqueACL {
+		output = append(output, item)
+	}
+
+	return output
 }
 
 var _ migrator.CodeMigration = new(dashboardUidPermissionMigrator)


### PR DESCRIPTION
**Why do we need this feature?**
The dashboard acl table has unique constraint for dashboard_id + user_id and dashboard_id + team_id but does not have it if there is a entry for role (Admin, Editor, Viewer).

There is validation in the API for duplication but could still be the reason to why some migrations fail on [duplicate entries error](https://github.com/grafana/grafana/issues/55924).
The fix check for duplication and only keeps the highest one

**Which issue(s) does this PR fix?**:

Fixes #55924

**Special notes for your reviewer**:

