### PR TITLE
Loki: Remove redundant feature flag in defaults.ini

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1251,9 +1251,6 @@ enable =
 # The new prometheus visual query builder
 promQueryBuilder = true
 
-# The new loki visual query builder
-lokiQueryBuilder = true
-
 # Experimental Explore to Dashboard workflow
 explore2Dashboard = true
 


### PR DESCRIPTION
This feature flag is not used anymore anywhere in codebase, therefore we can remove it from `defaults.ini`.  In https://github.com/grafana/grafana/pull/57192 we removed redundant reference to feature toggle `lokiQueryBuilder` as it wasn't  used anymore.