### PR TITLE
DataLinks: Fix double dollar-sign bug in data-links editor

### DIFF
--- a/packages/grafana-ui/src/components/DataLinks/DataLinkInput.tsx
+++ b/packages/grafana-ui/src/components/DataLinks/DataLinkInput.tsx
@@ -141,7 +141,7 @@ export const DataLinkInput: React.FC<DataLinkInputProps> = memo(
       if (item.origin !== VariableOrigin.Template || item.value === DataLinkBuiltInVars.includeVars) {
         editor.insertText(`${includeDollarSign ? '$' : ''}\{${item.value}}`);
       } else {
-        editor.insertText(`\${${item.value}:queryparam}`);
+        editor.insertText(`${includeDollarSign ? '$' : ''}\{${item.value}:queryparam}`);
       }
 
       setLinkUrl(editor.value);

--- a/packages/grafana-ui/src/components/DataLinks/DataLinkInput.tsx
+++ b/packages/grafana-ui/src/components/DataLinks/DataLinkInput.tsx
@@ -137,12 +137,10 @@ export const DataLinkInput: React.FC<DataLinkInputProps> = memo(
     }, []);
 
     const onVariableSelect = (item: VariableSuggestion, editor = editorRef.current!) => {
-      const includeDollarSign =
-        Plain.serialize(editor.value).slice(-1) !== '$' && Plain.serialize(editor.value).slice(-1) !== '}';
       if (item.origin !== VariableOrigin.Template || item.value === DataLinkBuiltInVars.includeVars) {
-        editor.insertText(`${includeDollarSign ? '$' : ''}\{${item.value}}`);
+        editor.insertText(`\{${item.value}}`);
       } else {
-        editor.insertText(`${includeDollarSign ? '$' : ''}\{${item.value}:queryparam}`);
+        editor.insertText(`\{${item.value}:queryparam}`);
       }
 
       setLinkUrl(editor.value);

--- a/packages/grafana-ui/src/components/DataLinks/DataLinkInput.tsx
+++ b/packages/grafana-ui/src/components/DataLinks/DataLinkInput.tsx
@@ -137,10 +137,11 @@ export const DataLinkInput: React.FC<DataLinkInputProps> = memo(
     }, []);
 
     const onVariableSelect = (item: VariableSuggestion, editor = editorRef.current!) => {
+      const includeDollarSign = Plain.serialize(editor.value).slice(-1) !== '$';
       if (item.origin !== VariableOrigin.Template || item.value === DataLinkBuiltInVars.includeVars) {
-        editor.insertText(`\{${item.value}}`);
+        editor.insertText(`${includeDollarSign ? '$' : ''}\{${item.value}}`);
       } else {
-        editor.insertText(`\{${item.value}:queryparam}`);
+        editor.insertText(`${includeDollarSign ? '$' : ''}\{${item.value}:queryparam}`);
       }
 
       setLinkUrl(editor.value);

--- a/packages/grafana-ui/src/components/DataLinks/DataLinkInput.tsx
+++ b/packages/grafana-ui/src/components/DataLinks/DataLinkInput.tsx
@@ -137,7 +137,8 @@ export const DataLinkInput: React.FC<DataLinkInputProps> = memo(
     }, []);
 
     const onVariableSelect = (item: VariableSuggestion, editor = editorRef.current!) => {
-      const includeDollarSign = Plain.serialize(editor.value).slice(-1) !== '$';
+      const includeDollarSign =
+        Plain.serialize(editor.value).slice(-1) !== '$' && Plain.serialize(editor.value).slice(-1) !== '}';
       if (item.origin !== VariableOrigin.Template || item.value === DataLinkBuiltInVars.includeVars) {
         editor.insertText(`${includeDollarSign ? '$' : ''}\{${item.value}}`);
       } else {


### PR DESCRIPTION
**Which issue(s) does this PR fix?**:

Fixes #47184 and another related bug

**Special notes for your reviewer**:

the pr addresses ~~two similar bugs with~~ duplicate `$` characters. ~~each is described below. Not sure how to resolve the second scenario (which is described in #47184) while preserving the `includeDollarSign` logic.~~ 
- ~~**But I'm curious**: is that logic still needed here?~~ 
- ~~Looks like that line hasn't changed since v7. And now, if you have to type a `$` character to make the variable suggestions appear, then won't a `$` always be present?~~ 
- ~~Is there a scenario where you can trigger the variables suggestions inside the data-link editor without adding the `$` character?~~ 

~~simplifying the function resolves the two bugs mentioned above. But I can't see what it would break...is there some gotcha I can't see? any help?~~

scenario 1: if you add a template variable using the data-link editor, it produces a double `$$`

![CleanShot 2022-11-02 at 11 16 28](https://user-images.githubusercontent.com/37156449/199604128-f81547b5-b093-4527-b8de-821cb285687c.gif)


~~scenario 2: this is the bug described by OP in #47184. to reproduce: Try to insert a new data-link var **into the middle of a URL**. This also produces a double `$$`~~

![CleanShot 2022-11-02 at 11 17 58](https://user-images.githubusercontent.com/37156449/199604449-cde17f39-bd24-4de2-b8eb-41e6ae75d3a5.gif)

