### PR TITLE
Alerting: Remove duplicate Slack notification title

### DIFF
--- a/pkg/services/ngalert/notifier/channels/slack.go
+++ b/pkg/services/ngalert/notifier/channels/slack.go
@@ -132,7 +132,7 @@ type slackMessage struct {
 	IconEmoji   string                   `json:"icon_emoji,omitempty"`
 	IconURL     string                   `json:"icon_url,omitempty"`
 	Attachments []attachment             `json:"attachments"`
-	Blocks      []map[string]interface{} `json:"blocks"`
+	Blocks      []map[string]interface{} `json:"blocks,omitempty"`
 }
 
 // attachment is used to display a richly-formatted message block.
@@ -147,6 +147,8 @@ type attachment struct {
 	FooterIcon string              `json:"footer_icon"`
 	Color      string              `json:"color,omitempty"`
 	Ts         int64               `json:"ts,omitempty"`
+	Pretext    string              `json:"pretext,omitempty"`
+	MrkdwnIn   []string            `json:"mrkdwn_in,omitempty"`
 }
 
 // Notify sends an alert notification to Slack.
@@ -261,7 +263,6 @@ func (sn *SlackNotifier) buildSlackMessage(ctx context.Context, alrts []*types.A
 
 	req := &slackMessage{
 		Channel:   tmpl(sn.settings.Recipient),
-		Text:      tmpl(sn.settings.Title),
 		Username:  tmpl(sn.settings.Username),
 		IconEmoji: tmpl(sn.settings.IconEmoji),
 		IconURL:   tmpl(sn.settings.IconURL),
@@ -315,15 +316,9 @@ func (sn *SlackNotifier) buildSlackMessage(ctx context.Context, alrts []*types.A
 	}
 
 	if mentionsBuilder.Len() > 0 {
-		req.Blocks = []map[string]interface{}{
-			{
-				"type": "section",
-				"text": map[string]interface{}{
-					"type": "mrkdwn",
-					"text": mentionsBuilder.String(),
-				},
-			},
-		}
+		// Use markdown-formatted pretext for any mentions.
+		req.Attachments[0].MrkdwnIn = []string{"pretext"}
+		req.Attachments[0].Pretext = mentionsBuilder.String()
 	}
 
 	return req, nil

--- a/pkg/services/ngalert/notifier/channels/slack_test.go
+++ b/pkg/services/ngalert/notifier/channels/slack_test.go
@@ -64,7 +64,6 @@ func TestSlackNotifier(t *testing.T) {
 			},
 			expMsg: &slackMessage{
 				Channel:   "#testchannel",
-				Text:      "[FIRING:1]  (val1)",
 				Username:  "Grafana",
 				IconEmoji: ":emoji:",
 				Attachments: []attachment{
@@ -100,7 +99,6 @@ func TestSlackNotifier(t *testing.T) {
 			},
 			expMsg: &slackMessage{
 				Channel:   "#testchannel",
-				Text:      "[FIRING:1]  (val1)",
 				Username:  "Grafana",
 				IconEmoji: ":emoji:",
 				Attachments: []attachment{
@@ -136,7 +134,6 @@ func TestSlackNotifier(t *testing.T) {
 			},
 			expMsg: &slackMessage{
 				Channel:   "#testchannel",
-				Text:      "[FIRING:1]  (val1)",
 				Username:  "Grafana",
 				IconEmoji: ":emoji:",
 				Attachments: []attachment{
@@ -180,7 +177,6 @@ func TestSlackNotifier(t *testing.T) {
 			},
 			expMsg: &slackMessage{
 				Channel:   "#testchannel",
-				Text:      "2 firing, 0 resolved",
 				Username:  "Grafana",
 				IconEmoji: ":emoji:",
 				Attachments: []attachment{
@@ -229,7 +225,6 @@ func TestSlackNotifier(t *testing.T) {
 			},
 			expMsg: &slackMessage{
 				Channel:   "#testchannel",
-				Text:      "[FIRING:1]  (val1)",
 				Username:  "Grafana",
 				IconEmoji: ":emoji:",
 				Attachments: []attachment{

--- a/pkg/tests/api/alerting/api_notification_channel_test.go
+++ b/pkg/tests/api/alerting/api_notification_channel_test.go
@@ -2312,7 +2312,6 @@ var expNonEmailNotifications = map[string][]string{
 	"slack_recv1/slack_test_without_token": {
 		`{
 		  "channel": "#test-channel",
-          "text": "Integration Test [FIRING:1] SlackAlert1 (default)",
 		  "username": "Integration Test",
 		  "icon_emoji": "🚀",
 		  "icon_url": "https://awesomeemoji.com/rocket",
@@ -2325,16 +2324,9 @@ var expNonEmailNotifications = map[string][]string{
 			  "footer": "Grafana v",
 			  "footer_icon": "https://grafana.com/assets/img/fav32.png",
 			  "color": "#D63232",
-			  "ts": %s
-			}
-		  ],
-		  "blocks": [
-			{
-			  "text": {
-				"text": "<!here|here> <!subteam^group1><!subteam^group2> <@user1><@user2>",
-				"type": "mrkdwn"
-			  },
-			  "type": "section"
+			  "ts": %s,
+              "mrkdwn_in": ["pretext"],
+              "pretext": "<!here|here> <!subteam^group1><!subteam^group2> <@user1><@user2>"
 			}
 		  ]
 		}`,
@@ -2342,7 +2334,6 @@ var expNonEmailNotifications = map[string][]string{
 	"slack_recvX/slack_testX": {
 		`{
 		  "channel": "#test-channel",
-          "text": "[FIRING:1] SlackAlert2 (default)",
 		  "username": "Integration Test",
 		  "attachments": [
 			{
@@ -2353,16 +2344,9 @@ var expNonEmailNotifications = map[string][]string{
 			  "footer": "Grafana v",
 			  "footer_icon": "https://grafana.com/assets/img/fav32.png",
 			  "color": "#D63232",
-			  "ts": %s
-			}
-		  ],
-		  "blocks": [
-			{
-			  "text": {
-				"text": "<@user1><@user2>",
-				"type": "mrkdwn"
-			  },
-			  "type": "section"
+			  "ts": %s,
+              "mrkdwn_in": ["pretext"],
+              "pretext": "<@user1><@user2>"
 			}
 		  ]
 		}`,


### PR DESCRIPTION
Fixes #52881 while preventing #42768 from recurring.

This issue has also appeared and been fixed before in legacy-alerting Slack notifications: see #19938, #21734 (specifically, see  https://github.com/grafana/grafana/pull/21734#discussion_r375144907 for the reason behind adding the `text` field), #23252, #37834.

The direct fix for the duplicate Slack notification title is to remove the redundant `text` field from the Slack-message payload. However, this on its own may cause #42768 to resurface, preventing the notification title from being displayed in the preview whenever mentions are included in a contact point config. (Note: In my tests the notification preview displayed the mention alone, which is better than `This content can't be displayed` but still probably an issue.)

The fix for #42768 that doesn't involve duplicating the subject/title is to stop mixing `blocks` with legacy `attachments` in the same Slack message. (The current 'mentions' logic appends a `section` block, which is what triggers the issue.) Migrating the whole notification to Block Kit is one solution, but the narrower fix in this PR moves the mention text into a markdown-formatted `pretext` field within the legacy attachment, instead of appended as a separate block, allowing it to be displayed properly.