### PR TITLE
Add VSCode Chrome Debugging Support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,6 +12,13 @@
       "args": ["--homepath", "${workspaceFolder}", "--packaging", "dev"]
     },
     {
+      "name": "Attach to Chrome",
+      "port": 9222,
+      "request": "attach",
+      "type": "chrome",
+      "webRoot": "${workspaceFolder}"
+    },
+    {
       "name": "Debug Jest test",
       "type": "node",
       "request": "launch",


### PR DESCRIPTION
**What is this feature?**

This PR adds a launch configuration to `launch.json` for VSCode which will attach to a running debug enabled instance of Chrome.

**Why do we need this feature?**

This will help those using VSCode for development to more easily develop and debug code on the Grafana codebase.

