### PR TITLE
Loki: Fix explain handlers for line- and label-format

### DIFF
--- a/public/app/plugins/datasource/loki/querybuilder/operations.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/operations.ts
@@ -189,9 +189,9 @@ export function getOperationDefinitions(): QueryBuilderOperationDef[] {
       explainHandler: () =>
         `This will replace log line using a specified template. The template can refer to stream labels and extracted labels.
 
-        Example: \`{{.status_code}} - {{.message}}\`
+Example: \`{{.status_code}} - {{.message}}\`
 
-        [Read the docs](https://grafana.com/docs/loki/latest/logql/log_queries/#line-format-expression) for more.
+[Read the docs](https://grafana.com/docs/loki/latest/logql/log_queries/#line-format-expression) for more.
         `,
     },
     {
@@ -210,9 +210,9 @@ export function getOperationDefinitions(): QueryBuilderOperationDef[] {
       explainHandler: () =>
         `This will change name of label to desired new label. In the example below, label "error_level" will be renamed to "level".
 
-        Example: error_level=\`level\`
+Example: \`\`error_level=\`level\` \`\`
 
-        [Read the docs](https://grafana.com/docs/loki/latest/logql/log_queries/#labels-format-expression) for more.
+[Read the docs](https://grafana.com/docs/loki/latest/logql/log_queries/#labels-format-expression) for more.
         `,
     },
 


### PR DESCRIPTION
**What is this feature?**

The explain handlers for `LineFormat` and `LabelFormat` are not displayed correctly. This PR fixes that.

**Special notes for your reviewer**:

`LineFormat` before:
<img width="619" alt="image" src="https://user-images.githubusercontent.com/8092184/199719466-d8cee6c8-189c-4a5f-a0d3-c9f58aceb290.png">

`LineFormat` now:
<img width="630" alt="image" src="https://user-images.githubusercontent.com/8092184/199719535-8688876a-f867-452d-8070-467ca7d10c14.png">

