### PR TITLE
PublicDashboards: Rename PubdashFooter frontend component

### DIFF
--- a/public/app/features/dashboard/components/PublicDashboardFooter/PublicDashboardsFooter.tsx
+++ b/public/app/features/dashboard/components/PublicDashboardFooter/PublicDashboardsFooter.tsx
@@ -4,16 +4,16 @@ import React from 'react';
 import { GrafanaTheme2, colorManipulator } from '@grafana/data';
 import { useStyles2 } from '@grafana/ui';
 
-export interface PublicDashboardFooter {
+export interface PublicDashboardFooterCfg {
   hide: boolean;
   text: string;
   logo: string;
   link: string;
 }
 
-export const PubdashFooter = function () {
+export const PublicDashboardFooter = function () {
   const styles = useStyles2(getStyles);
-  const conf = getPubdashFooterConfig();
+  const conf = getPublicDashboardFooterConfig();
 
   return conf.hide ? null : (
     <div className={styles.footer}>
@@ -26,10 +26,10 @@ export const PubdashFooter = function () {
   );
 };
 
-export function setPubdashFooterConfigFn(fn: typeof getPubdashFooterConfig) {
-  getPubdashFooterConfig = fn;
+export function setPublicDashboardFooterConfigFn(fn: typeof getPublicDashboardFooterConfig) {
+  getPublicDashboardFooterConfig = fn;
 }
-export let getPubdashFooterConfig = (): PublicDashboardFooter => ({
+export let getPublicDashboardFooterConfig = (): PublicDashboardFooterCfg => ({
   hide: false,
   text: 'powered by Grafana',
   logo: 'public/img/grafana_icon.svg',

--- a/public/app/features/dashboard/containers/DashboardPage.tsx
+++ b/public/app/features/dashboard/containers/DashboardPage.tsx
@@ -28,7 +28,7 @@ import { DashboardPrompt } from '../components/DashboardPrompt/DashboardPrompt';
 import { DashboardSettings } from '../components/DashboardSettings';
 import { PanelInspector } from '../components/Inspector/PanelInspector';
 import { PanelEditor } from '../components/PanelEditor/PanelEditor';
-import { PubdashFooter } from '../components/PubdashFooter/PubdashFooter';
+import { PublicDashboardFooter } from '../components/PublicDashboardFooter/PublicDashboardsFooter';
 import { SubMenu } from '../components/SubMenu/SubMenu';
 import { DashboardGrid } from '../dashgrid/DashboardGrid';
 import { liveTimer } from '../dashgrid/liveTimer';
@@ -415,7 +415,7 @@ export class UnthemedDashboardPage extends PureComponent<Props, State> {
         )}
         {
           // TODO: assess if there are other places where we may want a footer, which may reveal a better place to add this
-          isPublic && <PubdashFooter />
+          isPublic && <PublicDashboardFooter />
         }
       </>
     );


### PR DESCRIPTION
**What is this feature?**
Renames the PubdashFooter component to PublicDashboardFooter to follow the naming convention 

Fixes https://github.com/grafana/grafana-enterprise/issues/4590

