### PR TITLE
Alerting: Encode path separators to side-step proxies

### DIFF
--- a/public/app/features/alerting/unified/utils/rule-id.test.ts
+++ b/public/app/features/alerting/unified/utils/rule-id.test.ts
@@ -71,6 +71,7 @@ describe('hashRulerRule', () => {
     const encodedIdentifier = encodeURIComponent(stringifyIdentifier(identifier));
 
     expect(encodedIdentifier).toBe('pri%24my-datasource%24folder1%1Ffolder2%24group1%1Fgroup2%24abc123');
+    expect(encodedIdentifier).not.toContain('%2F');
     expect(parse(encodedIdentifier, true)).toStrictEqual(identifier);
   });
 
@@ -97,5 +98,13 @@ describe('hashRulerRule', () => {
 
     expect(encodedIdentifier).toBe('pri%24my-datasource%24folder1%1Efolder2%24group1%1Egroup2%24abc123');
     expect(parse(encodedIdentifier, true)).toStrictEqual(identifier);
+  });
+
+  it('should correctly decode a Grafana managed rule id', () => {
+    expect(parse('abc123', false)).toStrictEqual({ uid: 'abc123', ruleSourceName: 'grafana' });
+  });
+
+  it('should throw for malformed identifier', () => {
+    expect(() => parse('foo$bar$baz', false)).toThrow(/failed to parse/i);
   });
 });


### PR DESCRIPTION
This patch fixes (or rather side-steps) the following issue;

Some proxies / environments will automatically decode encoded path separators (`%2F` and `%5C`) and this confuses the router for some URLs we use in the alerting UI. (see https://github.com/envoyproxy/envoy/security/advisories/GHSA-4987-27fx-x6cf)

This patch introduces a backwards-compatible way to side-step this issue by encoding them as non-printable characters and decoding them accordingly.

⚠️ This patch fixes the _UI only_ to make our URLs compatible with external Prometheus data sources. This does _not_ solve https://github.com/grafana/alerting-squad/issues/210 as that is a separate issue when communicating via a REST API that sits behind such a proxy.

Thanks to @konrad147 who figured out how to test this locally with envoy, use the following config file and run with `envoy -c config.yml`, visit `http://localhost:10000`.

<details>
	<summary>config.yml</summary>
	
	static_resources:
	  listeners:
	  - name: listener_0
	    address:
	      socket_address:
	        address: 0.0.0.0
	        port_value: 10000
	    filter_chains:
	    - filters:
	      - name: envoy.filters.network.http_connection_manager
	        typed_config:
	          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
	          stat_prefix: ingress_http
	          path_with_escaped_slashes_action: UNESCAPE_AND_REDIRECT
	          access_log:
	          - name: envoy.access_loggers.stdout
	            typed_config:
	              "@type": type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
	          http_filters:
	          - name: envoy.filters.http.router
	            typed_config:
	              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
	          route_config:
	            name: local_route
	            virtual_hosts:
	            - name: local_service
	              domains: ["*"]
	              routes:
	              - match:
	                  prefix: "/"
	                route:
	                  cluster: service_envoyproxy_io
	
	  clusters:
	  - name: service_envoyproxy_io
	    type: LOGICAL_DNS
	    # Comment out the following line to test on v6 networks
	    dns_lookup_family: V4_ONLY
	    load_assignment:
	      cluster_name: service_envoyproxy_io
	      endpoints:
	      - lb_endpoints:
	        - endpoint:
	            address:
	              socket_address:
	                address: 0.0.0.0
	                port_value: 3000
</details>