### PR TITLE
docs: fixes typo in What's New 9.0

### DIFF
--- a/docs/sources/whatsnew/whats-new-in-v9-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v9-0.md
@@ -41,7 +41,7 @@ All functions, aggregations and binary operations are added via the + Operation 
 
 ### Range vector
 
-The query builder will automatically mange and add the range selector. It will be shown as a parameter to the operations that require a range vector (rate, delta, increase, etc).
+The query builder will automatically manage and add the range selector. It will be shown as a parameter to the operations that require a range vector (rate, delta, increase, etc).
 
 ### Binary operations
 


### PR DESCRIPTION
This PR fixes a typo in the What's new in 9.0 doc.