### PR TITLE
Toolkit: Fix compilation loop when watching plugins for changes

### DIFF
--- a/packages/grafana-toolkit/src/cli/tasks/plugin/bundle.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/plugin/bundle.ts
@@ -22,9 +22,8 @@ export const bundlePlugin = async ({ watch, production, preserveConsole }: Plugi
   const webpackPromise = new Promise<void>((resolve, reject) => {
     if (watch) {
       console.log('Started watching plugin for changes...');
-      compiler.watch({}, (err, stats) => {});
+      compiler.watch({ ignored: ['**/node_modules', '**/dist'] }, (err, stats) => {});
 
-      // @ts-ignore
       compiler.hooks.invalid.tap('invalid', () => {
         clearConsole();
         console.log('Compiling...');

--- a/packages/grafana-toolkit/src/config/webpack.plugin.config.ts
+++ b/packages/grafana-toolkit/src/config/webpack.plugin.config.ts
@@ -162,11 +162,6 @@ const getBaseWebpackConfig: WebpackConfigurationGetter = async (options) => {
       libraryTarget: 'amd',
       publicPath: '/',
     },
-
-    watchOptions: {
-      ignored: ['**/node_modules', '**/dist'],
-    },
-
     performance: { hints: false },
     externals: [
       'lodash',

--- a/packages/grafana-toolkit/src/config/webpack.plugin.config.ts
+++ b/packages/grafana-toolkit/src/config/webpack.plugin.config.ts
@@ -163,6 +163,10 @@ const getBaseWebpackConfig: WebpackConfigurationGetter = async (options) => {
       publicPath: '/',
     },
 
+    watchOptions: {
+      ignored: ['**/node_modules', '**/dist'],
+    },
+
     performance: { hints: false },
     externals: [
       'lodash',


### PR DESCRIPTION


<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR fixes a bug that causes plugins to go into an endless compilation loop when running `yarn grafana-toolkit plugin:dev --watch`.

**Why do we need this feature?**

Bug fix for grafana/toolkit

**Who is this feature for?**

Plugin developers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #57862

**Special notes for your reviewer**:
Tested by publishing the changes to local verdaccio, scaffolding a plugin with the locally published version of toolkit and running `yarn dev --watch`.