### PR TITLE
Removing workflow_call from update-changelog and bump-version action

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -5,17 +5,6 @@ on:
       version:
         description: 'Needs to match, exactly, the name of a milestone. The version to be released please respect: major.minor.patch or major.minor.patch-beta<number> format. example: 7.4.3 or 7.4.3-beta1'
         required: true
-  workflow_call:
-    inputs:
-      version_call:
-        description: 'Needs to match, exactly, the name of a milestone. The version to be released please respect: major.minor.patch or major.minor.patch-beta<number> format. example: 7.4.3 or 7.4.3-beta1'
-        required: true
-        type: string
-    secrets:
-        token:
-          required: true
-        metricsWriteAPIKey:
-          required: true
 env:
     YARN_ENABLE_IMMUTABLE_INSTALLS: false
 jobs:
@@ -79,16 +68,8 @@ jobs:
           node-version: '16'
       - name: Install Actions
         run: npm install --production --prefix ./actions
-      - name: Run bump version (manually invoked)
-        if: ${{ github.event.inputs.version != '' }}
+      - name: Run bump version (manually invoked)        
         uses: ./actions/bump-version
         with:
           token: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
           metricsWriteAPIKey: ${{ secrets.GRAFANA_MISC_STATS_API_KEY }}
-      - name: Run bump version (workflow invoked)
-        if: ${{ inputs.version_call != '' }}
-        uses: ./actions/bump-version
-        with:
-          version_call: ${{ inputs.version_call }}
-          token: ${{ secrets.token }}
-          metricsWriteAPIKey: ${{ secrets.metricsWriteAPIKey }}

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -5,17 +5,6 @@ on:
       version:
         required: true
         description: 'Needs to match, exactly, the name of a milestone. The version to be released please respect: major.minor.patch or major.minor.patch-beta<number> format. example: 7.4.3 or 7.4.3-beta1'
-  workflow_call:
-    inputs:
-      version_call:
-        description: 'Needs to match, exactly, the name of a milestone. The version to be released please respect: major.minor.patch or major.minor.patch-beta<number> format. example: 7.4.3 or 7.4.3-beta1'
-        required: true
-        type: string
-    secrets:
-        token:
-          required: true
-        metricsWriteAPIKey:
-          required: true
 jobs:
   main:
     runs-on: ubuntu-latest
@@ -28,16 +17,8 @@ jobs:
           ref: main
       - name: Install Actions
         run: npm install --production --prefix ./actions
-      - name: Run update changelog (manually invoked)
-        if: ${{ github.event.inputs.version != '' }}
+      - name: Run update changelog (manually invoked)        
         uses: ./actions/update-changelog
         with:
           token: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
           metricsWriteAPIKey: ${{ secrets.GRAFANA_MISC_STATS_API_KEY }}
-      - name: Run update changelog (workflow invoked)
-        if: ${{ inputs.version != '' }}
-        uses: ./actions/update-changelog
-        with:
-          version_call: ${{ inputs.version }}
-          token: ${{ secrets.token }}
-          metricsWriteAPIKey: ${{ secrets.metricsWriteAPIKey }}


### PR DESCRIPTION
**Why do we need this feature?**
Following up on https://github.com/grafana/grafana/pull/55893.

Since the prepare-release GH action was removed, there is no more need for `workflow_call` workflows in `bump-version` and `update-changelog` actions. This PR removes the unnecessary code to clean it up and reduce confusion.

**Who is this feature for?**

Internal release process