### PR TITLE
Grafana Enterprise Packaging: Set to conflict with `grafana`, not replace

### DIFF
--- a/pkg/build/packaging/grafana.go
+++ b/pkg/build/packaging/grafana.go
@@ -384,7 +384,10 @@ func executeFPM(options linuxPackageOptions, packageRoot, srcDir string) error {
 		"-a", string(options.packageArch),
 	}
 	if options.edition == config.EditionEnterprise || options.edition == config.EditionEnterprise2 || options.goArch == config.ArchARMv6 {
-		args = append(args, "--replaces", "grafana")
+		args = append(args, "--conflicts", "grafana")
+	}
+	if options.edition == config.EditionOSS {
+		args = append(args, "--conflicts", "grafana-enterprise")
 	}
 	if options.edition == config.EditionOSS {
 		args = append(args, "--license", "\"AGPLv3\"")

--- a/pkg/build/packaging/grafana.go
+++ b/pkg/build/packaging/grafana.go
@@ -387,9 +387,6 @@ func executeFPM(options linuxPackageOptions, packageRoot, srcDir string) error {
 		args = append(args, "--conflicts", "grafana")
 	}
 	if options.edition == config.EditionOSS {
-		args = append(args, "--conflicts", "grafana-enterprise")
-	}
-	if options.edition == config.EditionOSS {
 		args = append(args, "--license", "\"AGPLv3\"")
 	}
 	switch options.packageType {


### PR DESCRIPTION
When `grafana` and `grafana-enterprise` are in the same RPM repository, grafana-enterprise takes precedence over Grafana This is not what we want. Users should be able to install either OSS or Enterprise
