### PR TITLE
Build: add explicit build step for go codeql

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -49,5 +49,11 @@ jobs:
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
+    - if: matrix.language == 'go'
+      name: Build Go
+      run: |
+        go mod verify
+        make build-go
+
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -8,7 +8,7 @@ name: "CodeQL"
 on:
   workflow_dispatch:
   push:
-    branches: [main, v1.8.x, v2.0.x, v2.1.x, v2.6.x, v3.0.x, v3.1.x, v4.0.x, v4.1.x, v4.2.x, v4.3.x, v4.4.x, v4.5.x, v4.6.x, v4.7.x, v5.0.x, v5.1.x, v5.2.x, v5.3.x, v5.4.x, v6.0.x, v6.1.x, v6.2.x, v6.3.x, v6.4.x, v6.5.x, v6.6.x, v6.7.x, v7.0.x, v7.1.x, v7.2.x, codeql-go]
+    branches: [main, v1.8.x, v2.0.x, v2.1.x, v2.6.x, v3.0.x, v3.1.x, v4.0.x, v4.1.x, v4.2.x, v4.3.x, v4.4.x, v4.5.x, v4.6.x, v4.7.x, v5.0.x, v5.1.x, v5.2.x, v5.3.x, v5.4.x, v6.0.x, v6.1.x, v6.2.x, v6.3.x, v6.4.x, v6.5.x, v6.6.x, v6.7.x, v7.0.x, v7.1.x, v7.2.x]
     paths-ignore:
       - '**/*.cue'
       - '**/*.json'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,6 +6,7 @@
 name: "CodeQL"
 
 on:
+  workflow_dispatch:
   push:
     branches: [main, v1.8.x, v2.0.x, v2.1.x, v2.6.x, v3.0.x, v3.1.x, v4.0.x, v4.1.x, v4.2.x, v4.3.x, v4.4.x, v4.5.x, v4.6.x, v4.7.x, v5.0.x, v5.1.x, v5.2.x, v5.3.x, v5.4.x, v6.0.x, v6.1.x, v6.2.x, v6.3.x, v6.4.x, v6.5.x, v6.6.x, v6.7.x, v7.0.x, v7.1.x, v7.2.x, codeql-go]
     paths-ignore:
@@ -16,7 +17,6 @@ on:
       - '**/*.yml'
   schedule:
     - cron: '0 4 * * 6'
-  workflow_dispatch:
 
 jobs:
   analyze:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -41,9 +41,10 @@ jobs:
         fetch-depth: 2
 
     - if: matrix.language == 'go'
+      name: Set go version
       uses: actions/setup-go@v3
       with:
-        go-version-file: 'go.mod'
+        go-version: '1.19.2'
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
@@ -56,6 +57,7 @@ jobs:
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
     - if: matrix.language == 'go'
+      name: Build go files
       run: |
         go mod verify
         make build-go

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,6 +16,7 @@ on:
       - '**/*.yml'
   schedule:
     - cron: '0 4 * * 6'
+  workflow_dispatch
 
 jobs:
   analyze:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -40,6 +40,11 @@ jobs:
         # a pull request then we can checkout the head.
         fetch-depth: 2
 
+    - if: matrix.language == 'go'
+      uses: actions/setup-go@v3
+      with:
+        go-version-file: 'go.mod'
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
@@ -51,7 +56,6 @@ jobs:
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
     - if: matrix.language == 'go'
-      name: Build Go
       run: |
         go mod verify
         make build-go

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,7 +7,7 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [main, v1.8.x, v2.0.x, v2.1.x, v2.6.x, v3.0.x, v3.1.x, v4.0.x, v4.1.x, v4.2.x, v4.3.x, v4.4.x, v4.5.x, v4.6.x, v4.7.x, v5.0.x, v5.1.x, v5.2.x, v5.3.x, v5.4.x, v6.0.x, v6.1.x, v6.2.x, v6.3.x, v6.4.x, v6.5.x, v6.6.x, v6.7.x, v7.0.x, v7.1.x, v7.2.x]
+    branches: [main, v1.8.x, v2.0.x, v2.1.x, v2.6.x, v3.0.x, v3.1.x, v4.0.x, v4.1.x, v4.2.x, v4.3.x, v4.4.x, v4.5.x, v4.6.x, v4.7.x, v5.0.x, v5.1.x, v5.2.x, v5.3.x, v5.4.x, v6.0.x, v6.1.x, v6.2.x, v6.3.x, v6.4.x, v6.5.x, v6.6.x, v6.7.x, v7.0.x, v7.1.x, v7.2.x, codeql-go]
     paths-ignore:
       - '**/*.cue'
       - '**/*.json'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,7 +16,7 @@ on:
       - '**/*.yml'
   schedule:
     - cron: '0 4 * * 6'
-  workflow_dispatch
+  workflow_dispatch:
 
 jobs:
   analyze:

--- a/.github/workflows/pr-codeql-analysis-go.yml
+++ b/.github/workflows/pr-codeql-analysis-go.yml
@@ -20,9 +20,10 @@ jobs:
         # a pull request then we can checkout the head.
         fetch-depth: 2
 
-    - uses: actions/setup-go@v3
+    - name: Set go version
+      uses: actions/setup-go@v3
       with:
-        go-version-file: 'go.mod'
+        go-version: '1.19.2'
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
@@ -30,7 +31,7 @@ jobs:
       with:
         languages: "go"
 
-    - name: Build Go
+    - name: Build go files
       run: |
         go mod verify
         make build-go

--- a/.github/workflows/pr-codeql-analysis-go.yml
+++ b/.github/workflows/pr-codeql-analysis-go.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
     paths:
       - '**/*.go'
-  workflow_dispatch
+  workflow_dispatch:
 
 jobs:
   analyze:

--- a/.github/workflows/pr-codeql-analysis-go.yml
+++ b/.github/workflows/pr-codeql-analysis-go.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - '**/*.go'
+  workflow_dispatch
 
 jobs:
   analyze:

--- a/.github/workflows/pr-codeql-analysis-go.yml
+++ b/.github/workflows/pr-codeql-analysis-go.yml
@@ -20,6 +20,10 @@ jobs:
         # a pull request then we can checkout the head.
         fetch-depth: 2
 
+    - uses: actions/setup-go@v3
+      with:
+        go-version-file: 'go.mod'
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2

--- a/.github/workflows/pr-codeql-analysis-go.yml
+++ b/.github/workflows/pr-codeql-analysis-go.yml
@@ -1,11 +1,11 @@
 name: "CodeQL for PR / go"
 
 on:
+  workflow_dispatch:
   pull_request:
     branches: [main]
     paths:
       - '**/*.go'
-  workflow_dispatch:
 
 jobs:
   analyze:

--- a/.github/workflows/pr-codeql-analysis-go.yml
+++ b/.github/workflows/pr-codeql-analysis-go.yml
@@ -25,5 +25,10 @@ jobs:
       with:
         languages: "go"
 
+    - name: Build Go
+      run: |
+        go mod verify
+        make build-go
+
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/.github/workflows/pr-codeql-analysis-javascript.yml
+++ b/.github/workflows/pr-codeql-analysis-javascript.yml
@@ -1,6 +1,7 @@
 name: "CodeQL for PR / javascript"
 
 on:
+  workflow_dispatch:
   pull_request:
     branches: [main]
     paths:

--- a/.github/workflows/pr-codeql-analysis-python.yml
+++ b/.github/workflows/pr-codeql-analysis-python.yml
@@ -1,6 +1,7 @@
 name: "CodeQL for PR / python"
 
 on:
+  workflow_dispatch:
   pull_request:
     branches: [main]
     paths:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana
 
-go 1.18
+go 1.19
 
 // Override xorm's outdated go-mssqldb dependency, since we can't upgrade to current xorm (due to breaking changes).
 // We need a more current go-mssqldb so we get rid of a version of apache/thrift with vulnerabilities.


### PR DESCRIPTION
We're currently relying on codeql's autobuild capabilities for go which aren't working properly.  This PR adds an explicit step to run the same build commands we use in our dockerfiles to install dependencies and build the go code so it can be scanned.

