### PR TITLE
MSSQL/Postgres: Fix visual query editor filter disappearing

### DIFF
--- a/public/app/plugins/datasource/mssql/datasource.ts
+++ b/public/app/plugins/datasource/mssql/datasource.ts
@@ -61,6 +61,9 @@ export class MssqlDatasource extends SqlDatasource {
   }
 
   getDB(): DB {
+    if (this.db !== undefined) {
+      return this.db;
+    }
     return {
       init: () => Promise.resolve(true),
       datasets: () => this.fetchDatasets(),

--- a/public/app/plugins/datasource/postgres/datasource.ts
+++ b/public/app/plugins/datasource/postgres/datasource.ts
@@ -67,6 +67,9 @@ export class PostgresDatasource extends SqlDatasource {
   }
 
   getDB(): DB {
+    if (this.db !== undefined) {
+      return this.db;
+    }
     return {
       init: () => Promise.resolve(true),
       datasets: () => Promise.resolve([]),


### PR DESCRIPTION
The issue was that the props always changed because we gave back a new object every time getDB was called.

**Which issue(s) does this PR fix?**:

Fixes #58031 

