### PR TITLE
Storage: fix failing test (set IsServiceAccount=true)

### DIFF
--- a/pkg/services/store/object/tests/common.go
+++ b/pkg/services/store/object/tests/common.go
@@ -42,11 +42,12 @@ func createServiceAccountAdminToken(t *testing.T, env *server.TestEnv) (string, 
 	})
 
 	return keyGen.ClientSecret, &user.SignedInUser{
-		UserID: account.ID,
-		Email:  account.Email,
-		Name:   account.Name,
-		Login:  account.Login,
-		OrgID:  account.OrgID,
+		UserID:           account.ID,
+		Email:            account.Email,
+		Name:             account.Name,
+		Login:            account.Login,
+		OrgID:            account.OrgID,
+		IsServiceAccount: account.IsServiceAccount,
 	}
 }
 

--- a/pkg/services/store/object/tests/server_integration_test.go
+++ b/pkg/services/store/object/tests/server_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/store"
 	"github.com/grafana/grafana/pkg/services/store/object"
 	"github.com/grafana/grafana/pkg/util"
 	"github.com/stretchr/testify/require"
@@ -120,7 +121,7 @@ func TestIntegrationObjectServer(t *testing.T) {
 	testCtx := createTestContext(t)
 	ctx := metadata.AppendToOutgoingContext(testCtx.ctx, "authorization", fmt.Sprintf("Bearer %s", testCtx.authToken))
 
-	fakeUser := fmt.Sprintf("user:%d:%s", testCtx.user.UserID, testCtx.user.Login)
+	fakeUser := store.GetUserIDString(testCtx.user)
 	firstVersion := "1"
 	kind := models.StandardKindJSONObj
 	grn := &object.GRN{


### PR DESCRIPTION
It looks like a change to `IsRealUser()` is causing the storage tests to fail.  

This PR makes sure to properly set the `IsServiceAccount` flag on the local copy of the test token.

<img width="904" alt="image" src="https://user-images.githubusercontent.com/705951/200026466-20fa4b65-60e8-4b81-83f8-09cc7afb932a.png">
