### PR TITLE
ServiceAccounts: enable service accounts after IsRealUser change

### DIFF
--- a/pkg/services/accesscontrol/acimpl/service_test.go
+++ b/pkg/services/accesscontrol/acimpl/service_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/database"
+	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
@@ -236,6 +237,71 @@ func TestService_RegisterFixedRoles(t *testing.T) {
 					}
 				}
 			}
+		})
+	}
+}
+
+func TestPermissionCacheKey(t *testing.T) {
+	testcases := []struct {
+		name         string
+		signedInUser *user.SignedInUser
+		expected     string
+		expectedErr  error
+	}{
+		{
+			name: "should return correct key for user",
+			signedInUser: &user.SignedInUser{
+				OrgID:  1,
+				UserID: 1,
+			},
+			expected:    "rbac-permissions-1-user-1",
+			expectedErr: nil,
+		},
+		{
+			name: "should return correct key for api key",
+			signedInUser: &user.SignedInUser{
+				OrgID:            1,
+				ApiKeyID:         1,
+				IsServiceAccount: false,
+			},
+			expected:    "rbac-permissions-1-apikey-1",
+			expectedErr: nil,
+		},
+		{
+			name: "should return correct key for service account",
+			signedInUser: &user.SignedInUser{
+				OrgID:            1,
+				UserID:           1,
+				IsServiceAccount: true,
+			},
+			expected:    "rbac-permissions-1-service-1",
+			expectedErr: nil,
+		},
+		{
+			name: "should return correct key for matching a service account with userId -1",
+			signedInUser: &user.SignedInUser{
+				OrgID:            1,
+				UserID:           -1,
+				IsServiceAccount: true,
+			},
+			expected:    "rbac-permissions-1-service--1",
+			expectedErr: nil,
+		},
+		{
+			name: "should return error if not matching any",
+			signedInUser: &user.SignedInUser{
+				OrgID:  1,
+				UserID: -1,
+			},
+			expected:    "",
+			expectedErr: user.ErrNoUniqueID,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			str, err := permissionCacheKey(tc.signedInUser)
+			require.Equal(t, tc.expectedErr, err)
+			assert.Equal(t, tc.expected, str)
 		})
 	}
 }

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -328,11 +328,11 @@ func (sch *schedule) ruleRoutine(grafanaCtx context.Context, key ngmodels.AlertR
 		start := sch.clock.Now()
 
 		schedulerUser := &user.SignedInUser{
-			// FIXME: add is service account and refactor to a service account instead of a user
-			UserID:  -1,
-			Login:   "grafana_scheduler",
-			OrgID:   e.rule.OrgID,
-			OrgRole: org.RoleAdmin,
+			UserID:           -1,
+			IsServiceAccount: true,
+			Login:            "grafana_scheduler",
+			OrgID:            e.rule.OrgID,
+			OrgRole:          org.RoleAdmin,
 			Permissions: map[int64]map[string][]string{
 				e.rule.OrgID: {
 					datasources.ActionQuery: []string{

--- a/pkg/services/user/model.go
+++ b/pkg/services/user/model.go
@@ -306,6 +306,9 @@ func (u *SignedInUser) GetCacheKey() (string, error) {
 	if u.IsApiKeyUser() {
 		return fmt.Sprintf("%d-apikey-%d", u.OrgID, u.ApiKeyID), nil
 	}
+	if u.IsServiceAccountUser() { // not considered a real user
+		return fmt.Sprintf("%d-service-%d", u.OrgID, u.UserID), nil
+	}
 	return "", ErrNoUniqueID
 }
 


### PR DESCRIPTION
The change in https://github.com/grafana/grafana/pull/58015 makes using service accounts fail.

This is a simple fix, but I suspect there are other places -- I also do not see an obvious place to add a test to check this condition 🤔 