### PR TITLE
Alerting: Make the Grouped view the default one for Rules

### DIFF
--- a/public/app/features/alerting/unified/components/rules/GrafanaRules.tsx
+++ b/public/app/features/alerting/unified/components/rules/GrafanaRules.tsx
@@ -34,8 +34,8 @@ export const GrafanaRules: FC<Props> = ({ namespaces, expandAll }) => {
   const loading = prom.loading || ruler.loading;
   const hasResult = !!prom.result || !!ruler.result;
 
-  const wantsGroupedView = queryParams['view'] === 'grouped';
-  const namespacesFormat = wantsGroupedView ? namespaces : flattenGrafanaManagedRules(namespaces);
+  const wantsListView = queryParams['view'] === 'list';
+  const namespacesFormat = wantsListView ? flattenGrafanaManagedRules(namespaces) : namespaces;
 
   const groupsWithNamespaces = useCombinedGroupNamespace(namespacesFormat);
 
@@ -58,7 +58,7 @@ export const GrafanaRules: FC<Props> = ({ namespaces, expandAll }) => {
           key={`${namespace.name}-${group.name}`}
           namespace={namespace}
           expandAll={expandAll}
-          viewMode={wantsGroupedView ? 'grouped' : 'list'}
+          viewMode={wantsListView ? 'list' : 'grouped'}
         />
       ))}
       {hasResult && namespacesFormat?.length === 0 && <p>No rules found.</p>}

--- a/public/app/features/alerting/unified/components/rules/RulesFilter.tsx
+++ b/public/app/features/alerting/unified/components/rules/RulesFilter.tsx
@@ -15,14 +15,14 @@ import { alertStateToReadable } from '../../utils/rules';
 
 const ViewOptions: SelectableValue[] = [
   {
-    icon: 'list-ul',
-    label: 'List',
-    value: 'list',
-  },
-  {
     icon: 'folder',
     label: 'Grouped',
     value: 'grouped',
+  },
+  {
+    icon: 'list-ul',
+    label: 'List',
+    value: 'list',
   },
   {
     icon: 'heart-rate',


### PR DESCRIPTION
**What is this feature?**

Makes the Groups view the default one in the Alert Rules list.

![2022-11-04 16 22 53](https://user-images.githubusercontent.com/6271380/200058588-4b31fc7a-781d-4b14-ac61-a80d9a960729.gif)

**Why do we need this feature?**

This way of displaying rules is more clear than the List view.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/58172
