### PR TITLE
Alerting: Update saveAlertStates in state manager to not return results

### DIFF
--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -179,10 +179,8 @@ func (st *Manager) ProcessEvalResults(ctx context.Context, evaluatedAt time.Time
 		processedResults[s.State.CacheID] = s.State
 	}
 	resolvedStates := st.staleResultsHandler(ctx, evaluatedAt, alertRule, processedResults, logger)
-	if len(states) > 0 && st.instanceStore != nil {
-		logger.Debug("Saving new states to the database", "count", len(states))
-		st.saveAlertStates(ctx, states...)
-	}
+
+	st.saveAlertStates(ctx, logger, states...)
 
 	changedStates := make([]StateTransition, 0, len(states))
 	for _, s := range states {
@@ -284,7 +282,7 @@ func (st *Manager) Put(states []*State) {
 }
 
 // TODO: Is the `State` type necessary? Should it embed the instance?
-func (st *Manager) saveAlertStates(ctx context.Context, states ...StateTransition) {
+func (st *Manager) saveAlertStates(ctx context.Context, logger log.Logger, states ...StateTransition) {
 	if st.instanceStore == nil {
 		return
 	}


### PR DESCRIPTION
**What is this feature?**
The results of the method saveAlertStates are not used but the method does extra work to return them. This PR removes that logic and simplifies the way the method is called.

