### PR TITLE
CloudWatch: Fix - make sure dimensions are propagated to alert query editor

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/components/Dimensions/Dimensions.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/Dimensions/Dimensions.test.tsx
@@ -55,6 +55,24 @@ describe('Dimensions', () => {
     });
   });
 
+  describe('when rendered with two existing dimensions and values are represented as arrays', () => {
+    it('should render two filter items', async () => {
+      props.query.dimensions = {
+        InstanceId: ['*'],
+        InstanceGroup: ['Group1'],
+      };
+      render(<Dimensions {...props} metricStat={props.query} dimensionKeys={[]} />);
+      const filterItems = screen.getAllByTestId('cloudwatch-dimensions-filter-item');
+      expect(filterItems.length).toBe(2);
+
+      expect(within(filterItems[0]).getByText('InstanceId')).toBeInTheDocument();
+      expect(within(filterItems[0]).getByText('*')).toBeInTheDocument();
+
+      expect(within(filterItems[1]).getByText('InstanceGroup')).toBeInTheDocument();
+      expect(within(filterItems[1]).getByText('Group1')).toBeInTheDocument();
+    });
+  });
+
   describe('when adding a new filter item', () => {
     it('it should add the new item but not call onChange', async () => {
       props.query.dimensions = {};

--- a/public/app/plugins/datasource/cloudwatch/components/Dimensions/Dimensions.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/Dimensions/Dimensions.tsx
@@ -25,15 +25,32 @@ export interface DimensionFilterCondition {
 
 const dimensionsToFilterConditions = (dimensions: DimensionsType | undefined) =>
   Object.entries(dimensions ?? {}).reduce<DimensionFilterCondition[]>((acc, [key, value]) => {
-    if (value && typeof value === 'string') {
-      const filter = {
-        key,
-        value,
-        operator: '=',
-      };
-      return [...acc, filter];
+    if (!value) {
+      return acc;
     }
-    return acc;
+
+    // Previously, we only appended to the `acc`umulated dimensions if the value was a string.
+    // However, Cloudwatch can present dimensions with single-value arrays, e.g.
+    //   k: FunctionName
+    //   v: ['MyLambdaFunction']
+    // in which case we grab the single-value from the Array and use that as the value.
+    let v = '';
+    if (typeof value === 'string') {
+      v = value;
+    } else if (Array.isArray(value) && typeof value[0] === 'string') {
+      v = value[0];
+    }
+
+    if (!v) {
+      return acc;
+    }
+
+    const filter = {
+      key: key,
+      value: v,
+      operator: '=',
+    };
+    return [...acc, filter];
   }, []);
 
 const filterConditionsToDimensions = (filters: DimensionFilterCondition[]) => {


### PR DESCRIPTION
Signed-off-by: Conor Evans <coevans@tcd.ie>


**Which issue(s) does this PR fix?**: 

Fixes #58280 

**Special notes for your reviewer**:

I'm not sure if Cloudwatch can return `string`s as the value for Dimensions. From what I can see, they're always arrays with a single string. However, I've kept the existing code in place and just modified it to account for that latter case.

Before: 

https://user-images.githubusercontent.com/43791257/200082057-1c3fea53-6aae-4167-80b4-76e40b24bd48.mov

After:

https://user-images.githubusercontent.com/43791257/200082074-3fb3bf89-76e3-40f2-b6b3-702ddce16433.mov
