### PR TITLE
Prometheus Datasource: Improve Prom query variable editor

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -6261,8 +6261,8 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "3"],
-      [0, 0, 0, "Do not use any type assertions.", "4"],
+      [0, 0, 0, "Do not use any type assertions.", "3"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "4"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "5"]
     ],
     "public/app/plugins/datasource/prometheus/query_hints.ts:5381": [

--- a/.betterer.results
+++ b/.betterer.results
@@ -6262,8 +6262,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
       [0, 0, 0, "Do not use any type assertions.", "3"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "4"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "5"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "4"]
     ],
     "public/app/plugins/datasource/prometheus/query_hints.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],

--- a/docs/sources/datasources/prometheus/template-variables/index.md
+++ b/docs/sources/datasources/prometheus/template-variables/index.md
@@ -23,17 +23,17 @@ For an introduction to templating and template variables, refer to the [Templati
 
 ## Use query variables
 
-You can use variables of the type _Query_ to query Prometheus for a list of metrics, labels, or label values.
+Use variables of the type _Query_ to query Prometheus for a list of metrics, labels, or label values.
 
-You can use these Prometheus data source functions in the **Query** input field:
+Select a Prometheus data source query type and enter the required inputs:
 
-| Name                          | Description                                                             | Used API endpoints                |
-| ----------------------------- | ----------------------------------------------------------------------- | --------------------------------- |
-| `label_names()`               | Returns a list of label names.                                          | /api/v1/labels                    |
-| `label_values(label)`         | Returns a list of label values for the `label` in every metric.         | /api/v1/label/`label`/values      |
-| `label_values(metric, label)` | Returns a list of label values for the `label` in the specified metric. | /api/v1/series                    |
-| `metrics(metric)`             | Returns a list of metrics matching the specified `metric` regex.        | /api/v1/label/\_\_name\_\_/values |
-| `query_result(query)`         | Returns a list of Prometheus query result for the `query`.              | /api/v1/query                     |
+| Query Type     | Input(\* required)        | Description                                                                           | Used API endpoints                             |
+| -------------- | ------------------------- | ------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| `Label names`  | none                      | Returns a list of all label names.                                                    | /api/v1/labels                                 |
+| `Label values` | `label`\*, `metric`       | Returns a list of label values for the `label` in all metrics or the optional metric. | /api/v1/label/`label`/values or /api/v1/series |
+| `Metrics`      | `metric`                  | Returns a list of metrics matching the specified `metric` regex.                      | /api/v1/label/\_\_name\_\_/values              |
+| `Query result` | `query`                   | Returns a list of Prometheus query result for the `query`.                            | /api/v1/query                                  |
+| `Series query` | `metric`, `label` or both | Returns a list of time series associated with the entered data.                       | /api/v1/series                                 |
 
 For details on _metric names_, _label names_, and _label values_, refer to the [Prometheus documentation](http://prometheus.io/docs/concepts/data_model/#metric-names-and-labels).
 

--- a/public/app/plugins/datasource/prometheus/components/VariableQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/prometheus/components/VariableQueryEditor.test.tsx
@@ -1,0 +1,142 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { selectOptionInTest } from 'test/helpers/selectOptionInTest';
+
+import { PrometheusDatasource } from '../datasource';
+
+import { PromVariableQueryEditor, Props } from './VariableQueryEditor';
+
+const refId = 'PrometheusVariableQueryEditor-VariableQuery';
+
+describe('PromVariableQueryEditor', () => {
+  let props: Props;
+
+  beforeEach(() => {
+    props = {
+      datasource: {
+        hasLabelsMatchAPISupport: () => 1,
+        languageProvider: {
+          start: () => Promise.resolve([]),
+          syntax: () => {},
+          getLabelKeys: () => [],
+          metrics: [],
+        },
+        getInitHints: () => [],
+      } as unknown as PrometheusDatasource,
+      query: {
+        refId: 'test',
+        expr: 'label_names()',
+      },
+      onRunQuery: () => {},
+      onChange: () => {},
+      history: [],
+    };
+  });
+
+  test('Displays a group of function options', async () => {
+    render(<PromVariableQueryEditor {...props} />);
+
+    const select = screen.getByLabelText('Function type').parentElement!;
+    await userEvent.click(select);
+
+    await waitFor(() => expect(screen.getAllByText('Label names')).toHaveLength(2));
+    await waitFor(() => expect(screen.getByText('Label values')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText('Metrics')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText('Query result')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText('Match[] series')).toBeInTheDocument());
+  });
+
+  test('Calls onChange for label_names() query', async () => {
+    const onChange = jest.fn();
+
+    props.query = {
+      refId: 'test',
+      expr: '',
+    };
+
+    render(<PromVariableQueryEditor {...props} onChange={onChange} />);
+
+    await selectOptionInTest(screen.getByLabelText('Function type'), 'Label names');
+
+    expect(onChange).toHaveBeenCalledWith({
+      expr: 'label_names()',
+      refId,
+    });
+  });
+
+  test('Does not call onChange for other queries', async () => {
+    const onChange = jest.fn();
+
+    render(<PromVariableQueryEditor {...props} onChange={onChange} />);
+
+    await selectOptionInTest(screen.getByLabelText('Function type'), 'Metrics');
+    await selectOptionInTest(screen.getByLabelText('Function type'), 'Query result');
+    await selectOptionInTest(screen.getByLabelText('Function type'), 'Match[] series');
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  test('Calls onChange for metrics() with argument onBlur', async () => {
+    const onChange = jest.fn();
+
+    props.query = {
+      refId: 'test',
+      expr: 'metrics(a)',
+    };
+
+    render(<PromVariableQueryEditor {...props} onChange={onChange} />);
+
+    const labelSelect = screen.getByLabelText('Metric selector');
+    await userEvent.click(labelSelect);
+    const functionSelect = screen.getByLabelText('Function type').parentElement!;
+    await userEvent.click(functionSelect);
+
+    expect(onChange).toHaveBeenCalledWith({
+      expr: 'metrics(a)',
+      refId,
+    });
+  });
+
+  test('Calls onChange for query_result() with argument onBlur', async () => {
+    const onChange = jest.fn();
+
+    props.query = {
+      refId: 'test',
+      expr: 'query_result(a)',
+    };
+
+    render(<PromVariableQueryEditor {...props} onChange={onChange} />);
+
+    const labelSelect = screen.getByLabelText('Prometheus Query');
+    await userEvent.click(labelSelect);
+    const functionSelect = screen.getByLabelText('Function type').parentElement!;
+    await userEvent.click(functionSelect);
+
+    expect(onChange).toHaveBeenCalledWith({
+      expr: 'query_result(a)',
+      refId,
+    });
+  });
+
+  test('Calls onChange for Match[] series with argument onBlur', async () => {
+    const onChange = jest.fn();
+
+    props.query = {
+      refId: 'test',
+      expr: '{a: "example"}',
+    };
+
+    render(<PromVariableQueryEditor {...props} onChange={onChange} />);
+
+    const labelSelect = screen.getByLabelText('Series Query');
+    await userEvent.click(labelSelect);
+    const functionSelect = screen.getByLabelText('Function type').parentElement!;
+    await userEvent.click(functionSelect);
+
+    expect(onChange).toHaveBeenCalledWith({
+      expr: '{a: "example"}',
+      refId,
+    });
+  });
+});

--- a/public/app/plugins/datasource/prometheus/components/VariableQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/prometheus/components/VariableQueryEditor.test.tsx
@@ -26,7 +26,7 @@ describe('PromVariableQueryEditor', () => {
       } as unknown as PrometheusDatasource,
       query: {
         refId: 'test',
-        expr: 'label_names()',
+        query: 'label_names()',
       },
       onRunQuery: () => {},
       onChange: () => {},
@@ -44,7 +44,7 @@ describe('PromVariableQueryEditor', () => {
     await waitFor(() => expect(screen.getByText('Label values')).toBeInTheDocument());
     await waitFor(() => expect(screen.getByText('Metrics')).toBeInTheDocument());
     await waitFor(() => expect(screen.getByText('Query result')).toBeInTheDocument());
-    await waitFor(() => expect(screen.getByText('Match[] series')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText('Series query')).toBeInTheDocument());
   });
 
   test('Calls onChange for label_names() query', async () => {
@@ -52,7 +52,7 @@ describe('PromVariableQueryEditor', () => {
 
     props.query = {
       refId: 'test',
-      expr: '',
+      query: '',
     };
 
     render(<PromVariableQueryEditor {...props} onChange={onChange} />);
@@ -60,7 +60,7 @@ describe('PromVariableQueryEditor', () => {
     await selectOptionInTest(screen.getByLabelText('Function type'), 'Label names');
 
     expect(onChange).toHaveBeenCalledWith({
-      expr: 'label_names()',
+      query: 'label_names()',
       refId,
     });
   });
@@ -72,7 +72,7 @@ describe('PromVariableQueryEditor', () => {
 
     await selectOptionInTest(screen.getByLabelText('Function type'), 'Metrics');
     await selectOptionInTest(screen.getByLabelText('Function type'), 'Query result');
-    await selectOptionInTest(screen.getByLabelText('Function type'), 'Match[] series');
+    await selectOptionInTest(screen.getByLabelText('Function type'), 'Series query');
 
     expect(onChange).not.toHaveBeenCalled();
   });
@@ -82,7 +82,7 @@ describe('PromVariableQueryEditor', () => {
 
     props.query = {
       refId: 'test',
-      expr: 'metrics(a)',
+      query: 'metrics(a)',
     };
 
     render(<PromVariableQueryEditor {...props} onChange={onChange} />);
@@ -93,7 +93,7 @@ describe('PromVariableQueryEditor', () => {
     await userEvent.click(functionSelect);
 
     expect(onChange).toHaveBeenCalledWith({
-      expr: 'metrics(a)',
+      query: 'metrics(a)',
       refId,
     });
   });
@@ -103,7 +103,7 @@ describe('PromVariableQueryEditor', () => {
 
     props.query = {
       refId: 'test',
-      expr: 'query_result(a)',
+      query: 'query_result(a)',
     };
 
     render(<PromVariableQueryEditor {...props} onChange={onChange} />);
@@ -114,7 +114,7 @@ describe('PromVariableQueryEditor', () => {
     await userEvent.click(functionSelect);
 
     expect(onChange).toHaveBeenCalledWith({
-      expr: 'query_result(a)',
+      query: 'query_result(a)',
       refId,
     });
   });
@@ -124,7 +124,7 @@ describe('PromVariableQueryEditor', () => {
 
     props.query = {
       refId: 'test',
-      expr: '{a: "example"}',
+      query: '{a: "example"}',
     };
 
     render(<PromVariableQueryEditor {...props} onChange={onChange} />);
@@ -135,7 +135,7 @@ describe('PromVariableQueryEditor', () => {
     await userEvent.click(functionSelect);
 
     expect(onChange).toHaveBeenCalledWith({
-      expr: '{a: "example"}',
+      query: '{a: "example"}',
       refId,
     });
   });

--- a/public/app/plugins/datasource/prometheus/components/VariableQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/prometheus/components/VariableQueryEditor.test.tsx
@@ -37,7 +37,7 @@ describe('PromVariableQueryEditor', () => {
   test('Displays a group of function options', async () => {
     render(<PromVariableQueryEditor {...props} />);
 
-    const select = screen.getByLabelText('Function type').parentElement!;
+    const select = screen.getByLabelText('Query type').parentElement!;
     await userEvent.click(select);
 
     await waitFor(() => expect(screen.getAllByText('Label names')).toHaveLength(2));
@@ -57,7 +57,7 @@ describe('PromVariableQueryEditor', () => {
 
     render(<PromVariableQueryEditor {...props} onChange={onChange} />);
 
-    await selectOptionInTest(screen.getByLabelText('Function type'), 'Label names');
+    await selectOptionInTest(screen.getByLabelText('Query type'), 'Label names');
 
     expect(onChange).toHaveBeenCalledWith({
       query: 'label_names()',
@@ -70,9 +70,9 @@ describe('PromVariableQueryEditor', () => {
 
     render(<PromVariableQueryEditor {...props} onChange={onChange} />);
 
-    await selectOptionInTest(screen.getByLabelText('Function type'), 'Metrics');
-    await selectOptionInTest(screen.getByLabelText('Function type'), 'Query result');
-    await selectOptionInTest(screen.getByLabelText('Function type'), 'Series query');
+    await selectOptionInTest(screen.getByLabelText('Query type'), 'Metrics');
+    await selectOptionInTest(screen.getByLabelText('Query type'), 'Query result');
+    await selectOptionInTest(screen.getByLabelText('Query type'), 'Series query');
 
     expect(onChange).not.toHaveBeenCalled();
   });
@@ -89,7 +89,7 @@ describe('PromVariableQueryEditor', () => {
 
     const labelSelect = screen.getByLabelText('Metric selector');
     await userEvent.click(labelSelect);
-    const functionSelect = screen.getByLabelText('Function type').parentElement!;
+    const functionSelect = screen.getByLabelText('Query type').parentElement!;
     await userEvent.click(functionSelect);
 
     expect(onChange).toHaveBeenCalledWith({
@@ -110,7 +110,7 @@ describe('PromVariableQueryEditor', () => {
 
     const labelSelect = screen.getByLabelText('Prometheus Query');
     await userEvent.click(labelSelect);
-    const functionSelect = screen.getByLabelText('Function type').parentElement!;
+    const functionSelect = screen.getByLabelText('Query type').parentElement!;
     await userEvent.click(functionSelect);
 
     expect(onChange).toHaveBeenCalledWith({
@@ -131,7 +131,7 @@ describe('PromVariableQueryEditor', () => {
 
     const labelSelect = screen.getByLabelText('Series Query');
     await userEvent.click(labelSelect);
-    const functionSelect = screen.getByLabelText('Function type').parentElement!;
+    const functionSelect = screen.getByLabelText('Query type').parentElement!;
     await userEvent.click(functionSelect);
 
     expect(onChange).toHaveBeenCalledWith({

--- a/public/app/plugins/datasource/prometheus/components/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/components/VariableQueryEditor.tsx
@@ -48,7 +48,7 @@ export const PromVariableQueryEditor: FC<Props> = ({ onChange, query, datasource
     if (!query) {
       return;
     }
-    // Migrate the previous variable expr string
+    // Changing from standard to custom variable editor changes the string attr from expr to query
     const variableQuery = query.query ? migrateVariableQueryToEditor(query.query) : query;
 
     setExprType(variableQuery.exprType);

--- a/public/app/plugins/datasource/prometheus/components/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/components/VariableQueryEditor.tsx
@@ -16,7 +16,7 @@ export const variableOptions = [
   { label: 'Label values', value: QueryType.LabelValues },
   { label: 'Metrics', value: QueryType.MetricNames },
   { label: 'Query result', value: QueryType.VarQueryResult },
-  { label: 'Match[] series', value: QueryType.SeriesQuery },
+  { label: 'Series Query', value: QueryType.SeriesQuery },
 ];
 
 export type Props = QueryEditorProps<PrometheusDatasource, PromQuery, PromOptions, PromVariableQuery>;
@@ -143,7 +143,7 @@ export const PromVariableQueryEditor: FC<Props> = ({ onChange, query, datasource
           onBlur={handleBlur}
           value={exprType}
           options={variableOptions}
-          width={16}
+          width={25}
         />
       </InlineField>
       {exprType === QueryType.LabelValues && (
@@ -155,7 +155,7 @@ export const PromVariableQueryEditor: FC<Props> = ({ onChange, query, datasource
               onBlur={handleBlur}
               value={label}
               options={labelOptions}
-              width={16}
+              width={25}
               allowCustomValue
             />
           </InlineField>
@@ -177,7 +177,7 @@ export const PromVariableQueryEditor: FC<Props> = ({ onChange, query, datasource
                 value={metric}
                 onChange={onMetricChange}
                 onBlur={handleBlur}
-                width={22}
+                width={25}
               />
             </InlineField>
           )}
@@ -197,7 +197,7 @@ export const PromVariableQueryEditor: FC<Props> = ({ onChange, query, datasource
               value={metric}
               onChange={onMetricChange}
               onBlur={handleBlur}
-              width={22}
+              width={25}
             />
           </InlineField>
         </>
@@ -207,7 +207,11 @@ export const PromVariableQueryEditor: FC<Props> = ({ onChange, query, datasource
           <InlineField
             label="Query Result"
             labelWidth={20}
-            tooltip={<div>Returns a list of Prometheus query result for the query.</div>}
+            tooltip={
+              <div>
+                Returns a list of Prometheus query results for the query. This can include Prometheus functions.
+              </div>
+            }
           >
             <Input
               type="text"
@@ -216,7 +220,7 @@ export const PromVariableQueryEditor: FC<Props> = ({ onChange, query, datasource
               value={varQuery}
               onChange={onVarQueryChange}
               onBlur={handleBlur}
-              width={22}
+              width={25}
             />
           </InlineField>
         </>
@@ -240,7 +244,7 @@ export const PromVariableQueryEditor: FC<Props> = ({ onChange, query, datasource
               value={seriesQuery}
               onChange={onSeriesQueryChange}
               onBlur={handleBlur}
-              width={22}
+              width={25}
             />
           </InlineField>
         </>

--- a/public/app/plugins/datasource/prometheus/components/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/components/VariableQueryEditor.tsx
@@ -41,9 +41,6 @@ export const PromVariableQueryEditor: FC<Props> = ({ onChange, query, datasource
   // list of label names for label_values(), /api/v1/labels, contains the same results as label_names() function
   const [labelOptions, setLabelOptions] = useState<Array<SelectableValue<string>>>([]);
 
-  // if true, allows user to input metric variable in label_values() thus calling the match[] labels endpoint
-  const supportLabelMatch = datasource.hasLabelsMatchAPISupport();
-
   useEffect(() => {
     if (!query) {
       return;
@@ -159,28 +156,26 @@ export const PromVariableQueryEditor: FC<Props> = ({ onChange, query, datasource
               allowCustomValue
             />
           </InlineField>
-          {supportLabelMatch && (
-            <InlineField
-              label="Metric"
-              labelWidth={20}
-              tooltip={
-                <div>
-                  If a metric is added, this calls /api/v1/label/label/values. This endpoint is available depending on
-                  prometheus type and version in datasource configuration.
-                </div>
-              }
-            >
-              <Input
-                type="text"
-                aria-label="Metric selector"
-                placeholder="Optional metric selector"
-                value={metric}
-                onChange={onMetricChange}
-                onBlur={handleBlur}
-                width={25}
-              />
-            </InlineField>
-          )}
+          <InlineField
+            label="Metric"
+            labelWidth={20}
+            tooltip={
+              <div>
+                If a metric is added, this calls /api/v1/series. This endpoint is available depending on prometheus type
+                and version in datasource configuration.
+              </div>
+            }
+          >
+            <Input
+              type="text"
+              aria-label="Metric selector"
+              placeholder="Optional metric selector"
+              value={metric}
+              onChange={onMetricChange}
+              onBlur={handleBlur}
+              width={25}
+            />
+          </InlineField>
         </>
       )}
       {exprType === QueryType.MetricNames && (

--- a/public/app/plugins/datasource/prometheus/components/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/components/VariableQueryEditor.tsx
@@ -49,12 +49,7 @@ export const PromVariableQueryEditor: FC<Props> = ({ onChange, query, datasource
       return;
     }
     // Migrate the previous variable expr string
-    const variableQuery =
-      typeof query === 'string'
-        ? migrateVariableQueryToEditor(query)
-        : typeof query.expr === 'string'
-        ? migrateVariableQueryToEditor(query.expr)
-        : query;
+    const variableQuery = query.query ? migrateVariableQueryToEditor(query.query) : query;
 
     setExprType(variableQuery.exprType);
     setLabel(variableQuery.label || '');
@@ -89,10 +84,10 @@ export const PromVariableQueryEditor: FC<Props> = ({ onChange, query, datasource
       refId: 'PrometheusVariableQueryEditor-VariableQuery',
     };
 
-    const expr = migrateVariableEditorBackToVariableSupport(queryVar);
+    const queryString = migrateVariableEditorBackToVariableSupport(queryVar);
 
     onChange({
-      expr: expr,
+      query: queryString,
       refId,
     });
   };

--- a/public/app/plugins/datasource/prometheus/components/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/components/VariableQueryEditor.tsx
@@ -92,16 +92,8 @@ export const PromVariableQueryEditor: FC<Props> = ({ onChange, query, datasource
     });
   };
 
-  const resetTextFields = () => {
-    setLabel('');
-    setMetric('');
-    setVarQuery('');
-    setSeriesQuery('');
-  };
-
   const onQueryTypeChange = (newType: SelectableValue<QueryType>) => {
     setExprType(newType.value);
-    resetTextFields();
     if (newType.value === QueryType.LabelNames) {
       onChangeWithVariableString(newType.value);
     }

--- a/public/app/plugins/datasource/prometheus/components/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/components/VariableQueryEditor.tsx
@@ -52,10 +52,10 @@ export const PromVariableQueryEditor: FC<Props> = ({ onChange, query, datasource
     const variableQuery = query.query ? migrateVariableQueryToEditor(query.query) : query;
 
     setExprType(variableQuery.exprType);
-    setLabel(variableQuery.label || '');
-    setMetric(variableQuery.metric || '');
-    setVarQuery(variableQuery.varQuery || '');
-    setSeriesQuery(variableQuery.seriesQuery || '');
+    setLabel(variableQuery.label ?? '');
+    setMetric(variableQuery.metric ?? '');
+    setVarQuery(variableQuery.varQuery ?? '');
+    setSeriesQuery(variableQuery.seriesQuery ?? '');
 
     // set the migrated label in the label options
     if (variableQuery.label) {
@@ -100,7 +100,7 @@ export const PromVariableQueryEditor: FC<Props> = ({ onChange, query, datasource
   };
 
   const onLabelChange = (newLabel: SelectableValue<string>) => {
-    setLabel(newLabel.value || '');
+    setLabel(newLabel.value ?? '');
   };
 
   const onMetricChange = (e: FormEvent<HTMLInputElement>) => {

--- a/public/app/plugins/datasource/prometheus/components/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/components/VariableQueryEditor.tsx
@@ -16,7 +16,7 @@ export const variableOptions = [
   { label: 'Label values', value: QueryType.LabelValues },
   { label: 'Metrics', value: QueryType.MetricNames },
   { label: 'Query result', value: QueryType.VarQueryResult },
-  { label: 'Series Query', value: QueryType.SeriesQuery },
+  { label: 'Series query', value: QueryType.SeriesQuery },
 ];
 
 export type Props = QueryEditorProps<PrometheusDatasource, PromQuery, PromOptions, PromVariableQuery>;

--- a/public/app/plugins/datasource/prometheus/components/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/components/VariableQueryEditor.tsx
@@ -1,0 +1,263 @@
+import React, { FC, FormEvent, useEffect, useState } from 'react';
+
+import { QueryEditorProps, SelectableValue } from '@grafana/data';
+import { InlineField, InlineFieldRow, Input, Select } from '@grafana/ui';
+
+import { PrometheusDatasource } from '../datasource';
+import { labelNamesVarQuery } from '../metric_find_query';
+import {
+  migrateVariableEditorBackToVariableSupport,
+  migrateVariableQueryToEditor,
+} from '../migrations/variableMigration';
+import { PromOptions, PromQuery, PromVariableQuery, PromVariableQueryType as QueryType } from '../types';
+
+export const variableOptions = [
+  { label: 'Label names', value: QueryType.LabelNames },
+  { label: 'Label values', value: QueryType.LabelValues },
+  { label: 'Metrics', value: QueryType.MetricNames },
+  { label: 'Query result', value: QueryType.VarQueryResult },
+  { label: 'Match[] series', value: QueryType.SeriesQuery },
+];
+
+export type Props = QueryEditorProps<PrometheusDatasource, PromQuery, PromOptions, PromVariableQuery>;
+
+const refId = 'PrometheusVariableQueryEditor-VariableQuery';
+
+export const PromVariableQueryEditor: FC<Props> = ({ onChange, query, datasource }) => {
+  // to select the type of function, i.e. label_names, label_values, etc.
+  const [exprType, setExprType] = useState<number | undefined>(undefined);
+
+  // list of variables for each function
+  const [label, setLabel] = useState('');
+  // metric is used for both label_values() and metric()
+  // label_values() metric requires a whole/complete metric
+  // metric() is expected to be a part of a metric string
+  const [metric, setMetric] = useState('');
+  // varQuery is a whole query, can include math/rates/etc
+  const [varQuery, setVarQuery] = useState('');
+  // seriesQuery is only a whole
+  const [seriesQuery, setSeriesQuery] = useState('');
+
+  // list of label names for label_values(), /api/v1/labels, contains the same results as label_names() function
+  const [labelOptions, setLabelOptions] = useState<Array<SelectableValue<string>>>([]);
+
+  // if true, allows user to input metric variable in label_values() thus calling the match[] labels endpoint
+  const supportLabelMatch = datasource.hasLabelsMatchAPISupport();
+
+  useEffect(() => {
+    if (!query) {
+      return;
+    }
+    // Migrate the previous variable expr string
+    const variableQuery =
+      typeof query === 'string'
+        ? migrateVariableQueryToEditor(query)
+        : typeof query.expr === 'string'
+        ? migrateVariableQueryToEditor(query.expr)
+        : query;
+
+    setExprType(variableQuery.exprType);
+    setLabel(variableQuery.label || '');
+    setMetric(variableQuery.metric || '');
+    setVarQuery(variableQuery.varQuery || '');
+    setSeriesQuery(variableQuery.seriesQuery || '');
+
+    // set the migrated label in the label options
+    if (variableQuery.label) {
+      setLabelOptions([{ label: variableQuery.label, value: variableQuery.label }]);
+    }
+  }, [query]);
+
+  // set the label names options for the label values var query
+  useEffect(() => {
+    if (exprType !== QueryType.LabelValues) {
+      return;
+    }
+
+    labelNamesVarQuery(datasource).then((labelNames: Array<{ text: string }>) => {
+      setLabelOptions(labelNames.map(({ text }) => ({ label: text, value: text })));
+    });
+  }, [datasource, exprType]);
+
+  const onChangeWithVariableString = (exprType: number) => {
+    const queryVar = {
+      exprType: exprType,
+      label,
+      metric,
+      varQuery,
+      seriesQuery,
+      refId: 'PrometheusVariableQueryEditor-VariableQuery',
+    };
+
+    const expr = migrateVariableEditorBackToVariableSupport(queryVar);
+
+    onChange({
+      expr: expr,
+      refId,
+    });
+  };
+
+  const resetTextFields = () => {
+    setLabel('');
+    setMetric('');
+    setVarQuery('');
+    setSeriesQuery('');
+  };
+
+  const onQueryTypeChange = (newType: SelectableValue<QueryType>) => {
+    setExprType(newType.value);
+    resetTextFields();
+    if (newType.value === QueryType.LabelNames) {
+      onChangeWithVariableString(newType.value);
+    }
+  };
+
+  const onLabelChange = (newLabel: SelectableValue<string>) => {
+    setLabel(newLabel.value || '');
+  };
+
+  const onMetricChange = (e: FormEvent<HTMLInputElement>) => {
+    setMetric(e.currentTarget.value);
+  };
+
+  const onVarQueryChange = (e: FormEvent<HTMLInputElement>) => {
+    setVarQuery(e.currentTarget.value);
+  };
+
+  const onSeriesQueryChange = (e: FormEvent<HTMLInputElement>) => {
+    setSeriesQuery(e.currentTarget.value);
+  };
+
+  const handleBlur = () => {
+    if (exprType === QueryType.LabelNames) {
+      onChangeWithVariableString(exprType);
+    } else if (exprType === QueryType.LabelValues && label) {
+      onChangeWithVariableString(exprType);
+    } else if (exprType === QueryType.MetricNames && metric) {
+      onChangeWithVariableString(exprType);
+    } else if (exprType === QueryType.VarQueryResult && varQuery) {
+      onChangeWithVariableString(exprType);
+    } else if (exprType === QueryType.SeriesQuery && seriesQuery) {
+      onChangeWithVariableString(exprType);
+    }
+  };
+
+  return (
+    <InlineFieldRow>
+      <InlineField
+        label="Function type"
+        labelWidth={20}
+        tooltip={<div>The Prometheus data source plugin provides the following functions for querying variables.</div>}
+      >
+        <Select
+          placeholder="Select function"
+          aria-label="Function type"
+          onChange={onQueryTypeChange}
+          onBlur={handleBlur}
+          value={exprType}
+          options={variableOptions}
+          width={16}
+        />
+      </InlineField>
+      {exprType === QueryType.LabelValues && (
+        <>
+          <InlineField label="Label" labelWidth={20}>
+            <Select
+              aria-label="label-select"
+              onChange={onLabelChange}
+              onBlur={handleBlur}
+              value={label}
+              options={labelOptions}
+              width={16}
+              allowCustomValue
+            />
+          </InlineField>
+          {supportLabelMatch && (
+            <InlineField
+              label="Metric"
+              labelWidth={20}
+              tooltip={
+                <div>
+                  If a metric is added, this calls /api/v1/label/label/values. This endpoint is available depending on
+                  prometheus type and version in datasource configuration.
+                </div>
+              }
+            >
+              <Input
+                type="text"
+                aria-label="Metric selector"
+                placeholder="Optional metric selector"
+                value={metric}
+                onChange={onMetricChange}
+                onBlur={handleBlur}
+                width={22}
+              />
+            </InlineField>
+          )}
+        </>
+      )}
+      {exprType === QueryType.MetricNames && (
+        <>
+          <InlineField
+            label="Metric Regex"
+            labelWidth={20}
+            tooltip={<div>Returns a list of metrics matching the specified metric regex.</div>}
+          >
+            <Input
+              type="text"
+              aria-label="Metric selector"
+              placeholder="Metric Regex"
+              value={metric}
+              onChange={onMetricChange}
+              onBlur={handleBlur}
+              width={22}
+            />
+          </InlineField>
+        </>
+      )}
+      {exprType === QueryType.VarQueryResult && (
+        <>
+          <InlineField
+            label="Query Result"
+            labelWidth={20}
+            tooltip={<div>Returns a list of Prometheus query result for the query.</div>}
+          >
+            <Input
+              type="text"
+              aria-label="Prometheus Query"
+              placeholder="Prometheus Query"
+              value={varQuery}
+              onChange={onVarQueryChange}
+              onBlur={handleBlur}
+              width={22}
+            />
+          </InlineField>
+        </>
+      )}
+      {exprType === QueryType.SeriesQuery && (
+        <>
+          <InlineField
+            label="Series Query"
+            labelWidth={20}
+            tooltip={
+              <div>
+                Enter a query that contains full metric name, i.e. &#123;instance=&quot;localhost:9090&quot;&#125;.
+                Returns a metric name and label list.
+              </div>
+            }
+          >
+            <Input
+              type="text"
+              aria-label="Series Query"
+              placeholder="Series Query"
+              value={seriesQuery}
+              onChange={onSeriesQueryChange}
+              onBlur={handleBlur}
+              width={22}
+            />
+          </InlineField>
+        </>
+      )}
+    </InlineFieldRow>
+  );
+};

--- a/public/app/plugins/datasource/prometheus/components/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/components/VariableQueryEditor.tsx
@@ -160,8 +160,8 @@ export const PromVariableQueryEditor: FC<Props> = ({ onChange, query, datasource
             labelWidth={20}
             tooltip={
               <div>
-                If a metric is added, this calls /api/v1/series. This endpoint is available depending on prometheus type
-                and version in datasource configuration.
+                Returns a list of label values for the label in every metric unless a metric is specified, which then
+                returns a list of label values for the label in the specified metric.
               </div>
             }
           >

--- a/public/app/plugins/datasource/prometheus/components/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/components/VariableQueryEditor.tsx
@@ -1,7 +1,7 @@
 import React, { FC, FormEvent, useEffect, useState } from 'react';
 
 import { QueryEditorProps, SelectableValue } from '@grafana/data';
-import { InlineField, InlineFieldRow, Input, Select } from '@grafana/ui';
+import { InlineField, InlineFieldRow, Input, Select, TextArea } from '@grafana/ui';
 
 import { PrometheusDatasource } from '../datasource';
 import {
@@ -103,7 +103,7 @@ export const PromVariableQueryEditor: FC<Props> = ({ onChange, query, datasource
     setMetric(e.currentTarget.value);
   };
 
-  const onVarQueryChange = (e: FormEvent<HTMLInputElement>) => {
+  const onVarQueryChange = (e: FormEvent<HTMLTextAreaElement>) => {
     setVarQuery(e.currentTarget.value);
   };
 
@@ -144,7 +144,16 @@ export const PromVariableQueryEditor: FC<Props> = ({ onChange, query, datasource
       </InlineField>
       {exprType === QueryType.LabelValues && (
         <>
-          <InlineField label="Label" labelWidth={20}>
+          <InlineField
+            label="Label"
+            labelWidth={20}
+            required
+            tooltip={
+              <div>
+                Returns a list of label values for the label name in all metrics unless the metric is specified.
+              </div>
+            }
+          >
             <Select
               aria-label="label-select"
               onChange={onLabelChange}
@@ -158,12 +167,7 @@ export const PromVariableQueryEditor: FC<Props> = ({ onChange, query, datasource
           <InlineField
             label="Metric"
             labelWidth={20}
-            tooltip={
-              <div>
-                Returns a list of label values for the label in every metric unless a metric is specified, which then
-                returns a list of label values for the label in the specified metric.
-              </div>
-            }
+            tooltip={<div>*Optional: returns a list of label values for the label name in the specified metric.</div>}
           >
             <Input
               type="text"
@@ -207,14 +211,14 @@ export const PromVariableQueryEditor: FC<Props> = ({ onChange, query, datasource
               </div>
             }
           >
-            <Input
+            <TextArea
               type="text"
               aria-label="Prometheus Query"
               placeholder="Prometheus Query"
               value={varQuery}
               onChange={onVarQueryChange}
               onBlur={handleBlur}
-              width={25}
+              cols={100}
             />
           </InlineField>
         </>
@@ -226,8 +230,10 @@ export const PromVariableQueryEditor: FC<Props> = ({ onChange, query, datasource
             labelWidth={20}
             tooltip={
               <div>
-                Enter a query that contains full metric name, i.e. &#123;instance=&quot;localhost:9090&quot;&#125;.
-                Returns a metric name and label list.
+                Enter enter a metric with labels, only a metric or only labels, i.e.
+                go_goroutines&#123;instance=&quot;localhost:9090&quot;&#125;, go_goroutines, or
+                &#123;instance=&quot;localhost:9090&quot;&#125;. Returns a list of time series associated with the
+                entered data.
               </div>
             }
           >
@@ -238,7 +244,7 @@ export const PromVariableQueryEditor: FC<Props> = ({ onChange, query, datasource
               value={seriesQuery}
               onChange={onSeriesQueryChange}
               onBlur={handleBlur}
-              width={25}
+              width={100}
             />
           </InlineField>
         </>

--- a/public/app/plugins/datasource/prometheus/components/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/components/VariableQueryEditor.tsx
@@ -169,7 +169,7 @@ export const PromVariableQueryEditor: FC<Props> = ({ onChange, query, datasource
           <InlineField
             label="Metric"
             labelWidth={20}
-            tooltip={<div>*Optional: returns a list of label values for the label name in the specified metric.</div>}
+            tooltip={<div>Optional: returns a list of label values for the label name in the specified metric.</div>}
           >
             <Input
               type="text"

--- a/public/app/plugins/datasource/prometheus/components/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/components/VariableQueryEditor.tsx
@@ -4,7 +4,6 @@ import { QueryEditorProps, SelectableValue } from '@grafana/data';
 import { InlineField, InlineFieldRow, Input, Select } from '@grafana/ui';
 
 import { PrometheusDatasource } from '../datasource';
-import { labelNamesVarQuery } from '../metric_find_query';
 import {
   migrateVariableEditorBackToVariableSupport,
   migrateVariableQueryToEditor,
@@ -66,7 +65,7 @@ export const PromVariableQueryEditor: FC<Props> = ({ onChange, query, datasource
       return;
     }
 
-    labelNamesVarQuery(datasource).then((labelNames: Array<{ text: string }>) => {
+    datasource.getLabelNames().then((labelNames: Array<{ text: string }>) => {
       setLabelOptions(labelNames.map(({ text }) => ({ label: text, value: text })));
     });
   }, [datasource, exprType]);

--- a/public/app/plugins/datasource/prometheus/components/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/components/VariableQueryEditor.tsx
@@ -71,7 +71,7 @@ export const PromVariableQueryEditor: FC<Props> = ({ onChange, query, datasource
     });
   }, [datasource, exprType]);
 
-  const onChangeWithVariableString = (exprType: number) => {
+  const onChangeWithVariableString = (exprType: QueryType) => {
     const queryVar = {
       exprType: exprType,
       label,

--- a/public/app/plugins/datasource/prometheus/components/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/components/VariableQueryEditor.tsx
@@ -23,8 +23,8 @@ export type Props = QueryEditorProps<PrometheusDatasource, PromQuery, PromOption
 const refId = 'PrometheusVariableQueryEditor-VariableQuery';
 
 export const PromVariableQueryEditor: FC<Props> = ({ onChange, query, datasource }) => {
-  // to select the type of function, i.e. label_names, label_values, etc.
-  const [exprType, setExprType] = useState<number | undefined>(undefined);
+  // to select the query type, i.e. label_names, label_values, etc.
+  const [qryType, setQryType] = useState<number | undefined>(undefined);
 
   // list of variables for each function
   const [label, setLabel] = useState('');
@@ -47,7 +47,7 @@ export const PromVariableQueryEditor: FC<Props> = ({ onChange, query, datasource
     // Changing from standard to custom variable editor changes the string attr from expr to query
     const variableQuery = query.query ? migrateVariableQueryToEditor(query.query) : query;
 
-    setExprType(variableQuery.exprType);
+    setQryType(variableQuery.qryType);
     setLabel(variableQuery.label ?? '');
     setMetric(variableQuery.metric ?? '');
     setVarQuery(variableQuery.varQuery ?? '');
@@ -61,18 +61,18 @@ export const PromVariableQueryEditor: FC<Props> = ({ onChange, query, datasource
 
   // set the label names options for the label values var query
   useEffect(() => {
-    if (exprType !== QueryType.LabelValues) {
+    if (qryType !== QueryType.LabelValues) {
       return;
     }
 
     datasource.getLabelNames().then((labelNames: Array<{ text: string }>) => {
       setLabelOptions(labelNames.map(({ text }) => ({ label: text, value: text })));
     });
-  }, [datasource, exprType]);
+  }, [datasource, qryType]);
 
-  const onChangeWithVariableString = (exprType: QueryType) => {
+  const onChangeWithVariableString = (qryType: QueryType) => {
     const queryVar = {
-      exprType: exprType,
+      qryType: qryType,
       label,
       metric,
       varQuery,
@@ -89,7 +89,7 @@ export const PromVariableQueryEditor: FC<Props> = ({ onChange, query, datasource
   };
 
   const onQueryTypeChange = (newType: SelectableValue<QueryType>) => {
-    setExprType(newType.value);
+    setQryType(newType.value);
     if (newType.value === QueryType.LabelNames) {
       onChangeWithVariableString(newType.value);
     }
@@ -112,37 +112,39 @@ export const PromVariableQueryEditor: FC<Props> = ({ onChange, query, datasource
   };
 
   const handleBlur = () => {
-    if (exprType === QueryType.LabelNames) {
-      onChangeWithVariableString(exprType);
-    } else if (exprType === QueryType.LabelValues && label) {
-      onChangeWithVariableString(exprType);
-    } else if (exprType === QueryType.MetricNames && metric) {
-      onChangeWithVariableString(exprType);
-    } else if (exprType === QueryType.VarQueryResult && varQuery) {
-      onChangeWithVariableString(exprType);
-    } else if (exprType === QueryType.SeriesQuery && seriesQuery) {
-      onChangeWithVariableString(exprType);
+    if (qryType === QueryType.LabelNames) {
+      onChangeWithVariableString(qryType);
+    } else if (qryType === QueryType.LabelValues && label) {
+      onChangeWithVariableString(qryType);
+    } else if (qryType === QueryType.MetricNames && metric) {
+      onChangeWithVariableString(qryType);
+    } else if (qryType === QueryType.VarQueryResult && varQuery) {
+      onChangeWithVariableString(qryType);
+    } else if (qryType === QueryType.SeriesQuery && seriesQuery) {
+      onChangeWithVariableString(qryType);
     }
   };
 
   return (
     <InlineFieldRow>
       <InlineField
-        label="Function type"
+        label="Query Type"
         labelWidth={20}
-        tooltip={<div>The Prometheus data source plugin provides the following functions for querying variables.</div>}
+        tooltip={
+          <div>The Prometheus data source plugin provides the following query types for template variables.</div>
+        }
       >
         <Select
-          placeholder="Select function"
-          aria-label="Function type"
+          placeholder="Select query type"
+          aria-label="Query type"
           onChange={onQueryTypeChange}
           onBlur={handleBlur}
-          value={exprType}
+          value={qryType}
           options={variableOptions}
           width={25}
         />
       </InlineField>
-      {exprType === QueryType.LabelValues && (
+      {qryType === QueryType.LabelValues && (
         <>
           <InlineField
             label="Label"
@@ -181,7 +183,7 @@ export const PromVariableQueryEditor: FC<Props> = ({ onChange, query, datasource
           </InlineField>
         </>
       )}
-      {exprType === QueryType.MetricNames && (
+      {qryType === QueryType.MetricNames && (
         <>
           <InlineField
             label="Metric Regex"
@@ -200,14 +202,15 @@ export const PromVariableQueryEditor: FC<Props> = ({ onChange, query, datasource
           </InlineField>
         </>
       )}
-      {exprType === QueryType.VarQueryResult && (
+      {qryType === QueryType.VarQueryResult && (
         <>
           <InlineField
-            label="Query Result"
+            label="Query"
             labelWidth={20}
             tooltip={
               <div>
-                Returns a list of Prometheus query results for the query. This can include Prometheus functions.
+                Returns a list of Prometheus query results for the query. This can include Prometheus functions, i.e.
+                sum(go_goroutines).
               </div>
             }
           >
@@ -223,7 +226,7 @@ export const PromVariableQueryEditor: FC<Props> = ({ onChange, query, datasource
           </InlineField>
         </>
       )}
-      {exprType === QueryType.SeriesQuery && (
+      {qryType === QueryType.SeriesQuery && (
         <>
           <InlineField
             label="Series Query"

--- a/public/app/plugins/datasource/prometheus/datasource.test.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.test.ts
@@ -153,7 +153,7 @@ describe('PrometheusDatasource', () => {
       ).rejects.toMatchObject({
         message: expect.stringMatching('Browser access'),
       });
-      await expect(directDs.getTagKeys()).rejects.toMatchObject({
+      await expect(directDs.getLabelNames()).rejects.toMatchObject({
         message: expect.stringMatching('Browser access'),
       });
       await expect(directDs.getTagValues()).rejects.toMatchObject({

--- a/public/app/plugins/datasource/prometheus/datasource.tsx
+++ b/public/app/plugins/datasource/prometheus/datasource.tsx
@@ -286,7 +286,7 @@ export class PrometheusDatasource
         hideFromInspector: true,
         ...options,
       })
-    ); // toPromise until we change getTagValues, getTagKeys to Observable
+    ); // toPromise until we change getTagValues, getLabelNames to Observable
   }
 
   interpolateQueryExpr(value: string | string[] = [], variable: any) {
@@ -908,7 +908,10 @@ export class PrometheusDatasource
     );
   }
 
-  async getTagKeys(options?: any) {
+  // this is used to get label keys, a.k.a label names
+  // it is used in metric_find_query.ts
+  // and in Tempo here grafana/public/app/plugins/datasource/tempo/QueryEditor/ServiceGraphSection.tsx
+  async getLabelNames(options?: any) {
     if (options?.series) {
       // Get tags for the provided series only
       const seriesLabels: Array<Record<string, string[]>> = await Promise.all(

--- a/public/app/plugins/datasource/prometheus/metric_find_query.ts
+++ b/public/app/plugins/datasource/prometheus/metric_find_query.ts
@@ -55,23 +55,6 @@ export default class PrometheusMetricFindQuery {
     return Promise.resolve([]);
   }
 
-  // labelNamesQuery() {
-  //   const start = this.datasource.getPrometheusTime(this.range.from, false);
-  //   const end = this.datasource.getPrometheusTime(this.range.to, true);
-  //   const params = {
-  //     start: start.toString(),
-  //     end: end.toString(),
-  //   };
-
-  //   const url = `/api/v1/labels`;
-
-  //   return this.datasource.metadataRequest(url, params).then((result: any) => {
-  //     return _map(result.data.data, (value) => {
-  //       return { text: value };
-  //     });
-  //   });
-  // }
-
   labelValuesQuery(label: string, metric?: string) {
     const start = this.datasource.getPrometheusTime(this.range.from, false);
     const end = this.datasource.getPrometheusTime(this.range.to, true);

--- a/public/app/plugins/datasource/prometheus/metric_find_query.ts
+++ b/public/app/plugins/datasource/prometheus/metric_find_query.ts
@@ -24,7 +24,7 @@ export default class PrometheusMetricFindQuery {
     const queryResultRegex = /^query_result\((.+)\)\s*$/;
     const labelNamesQuery = this.query.match(labelNamesRegex);
     if (labelNamesQuery) {
-      return labelNamesVarQuery(this.datasource);
+      return this.datasource.getLabelNames();
     }
 
     const labelValuesQuery = this.query.match(labelValuesRegex);
@@ -172,22 +172,4 @@ export default class PrometheusMetricFindQuery {
       });
     });
   }
-}
-
-export function labelNamesVarQuery(datasource: PrometheusDatasource) {
-  const range = getTimeSrv().timeRange();
-  const start = datasource.getPrometheusTime(range.from, false);
-  const end = datasource.getPrometheusTime(range.to, true);
-  const params = {
-    start: start.toString(),
-    end: end.toString(),
-  };
-
-  const url = `/api/v1/labels`;
-
-  return datasource.metadataRequest(url, params).then((result: any) => {
-    return _map(result.data.data, (value) => {
-      return { text: value };
-    });
-  });
 }

--- a/public/app/plugins/datasource/prometheus/migrations/variableMigration.ts
+++ b/public/app/plugins/datasource/prometheus/migrations/variableMigration.ts
@@ -30,14 +30,14 @@ export function migrateVariableQueryToEditor(rawQuery: string | PromVariableQuer
       return {
         ...queryBase,
         exprType: QueryType.LabelValues,
-        label: labelValues[1],
-        metric: labelValues[2],
+        label: labelValues[2],
+        metric: labelValues[1],
       };
     } else {
       return {
         ...queryBase,
         exprType: QueryType.LabelValues,
-        label: labelValues[1],
+        label: labelValues[2],
       };
     }
   }
@@ -79,10 +79,8 @@ export function migrateVariableEditorBackToVariableSupport(QueryVariable: PromVa
       return 'label_names()';
     case QueryType.LabelValues:
       if (QueryVariable.metric) {
-        // labels endpoint match
-        return `label_values(${QueryVariable.label},${QueryVariable.metric})`;
+        return `label_values(${QueryVariable.metric},${QueryVariable.label})`;
       } else {
-        // old series match
         return `label_values(${QueryVariable.label})`;
       }
     case QueryType.MetricNames:

--- a/public/app/plugins/datasource/prometheus/migrations/variableMigration.ts
+++ b/public/app/plugins/datasource/prometheus/migrations/variableMigration.ts
@@ -79,9 +79,10 @@ export function migrateVariableEditorBackToVariableSupport(QueryVariable: PromVa
       return 'label_names()';
     case 1: // LabelValues
       if (QueryVariable.metric) {
-        // series match
-        return `label_values(${QueryVariable.metric},${QueryVariable.label})`;
+        // labels endpoint match
+        return `label_values(${QueryVariable.label},${QueryVariable.metric})`;
       } else {
+        // old series match
         return `label_values(${QueryVariable.label})`;
       }
     case 2: // MetricNames

--- a/public/app/plugins/datasource/prometheus/migrations/variableMigration.ts
+++ b/public/app/plugins/datasource/prometheus/migrations/variableMigration.ts
@@ -1,0 +1,96 @@
+import { PromVariableQuery, PromVariableQueryType as QueryType } from '../types';
+
+const labelNamesRegex = /^label_names\(\)\s*$/;
+const labelValuesRegex = /^label_values\((?:(.+),\s*)?([a-zA-Z_][a-zA-Z0-9_]*)\)\s*$/;
+const metricNamesRegex = /^metrics\((.+)\)\s*$/;
+const queryResultRegex = /^query_result\((.+)\)\s*$/;
+
+export function migrateVariableQueryToEditor(rawQuery: string | PromVariableQuery): PromVariableQuery {
+  // If not string, we assume PromVariableQuery
+  if (typeof rawQuery !== 'string') {
+    return rawQuery;
+  }
+
+  const queryBase = {
+    refId: 'PrometheusDatasource-VariableQuery',
+    exprType: QueryType.LabelNames,
+  };
+
+  const labelNames = rawQuery.match(labelNamesRegex);
+  if (labelNames) {
+    return {
+      ...queryBase,
+      exprType: QueryType.LabelNames,
+    };
+  }
+
+  const labelValues = rawQuery.match(labelValuesRegex);
+  if (labelValues) {
+    if (labelValues[1]) {
+      return {
+        ...queryBase,
+        exprType: QueryType.LabelValues,
+        label: labelValues[2],
+        metric: labelValues[1],
+      };
+    } else {
+      return {
+        ...queryBase,
+        exprType: QueryType.LabelValues,
+        label: labelValues[2],
+      };
+    }
+  }
+
+  const metricNames = rawQuery.match(metricNamesRegex);
+  if (metricNames) {
+    return {
+      ...queryBase,
+      exprType: QueryType.MetricNames,
+      metric: metricNames[1],
+    };
+  }
+
+  const queryResult = rawQuery.match(queryResultRegex);
+  if (queryResult) {
+    return {
+      ...queryBase,
+      exprType: QueryType.VarQueryResult,
+      varQuery: queryResult[1],
+    };
+  }
+
+  // seriesQuery does not have a function and no regex above
+  if (!labelNames && !labelValues && !metricNames && !queryResult) {
+    return {
+      ...queryBase,
+      exprType: QueryType.SeriesQuery,
+      seriesQuery: rawQuery,
+    };
+  }
+
+  return queryBase;
+}
+
+// migrate it back to a string with the correct varialbes in place
+export function migrateVariableEditorBackToVariableSupport(QueryVariable: PromVariableQuery): string {
+  switch (QueryVariable.exprType) {
+    case 0: // LabelNames
+      return 'label_names()';
+    case 1: // LabelValues
+      if (QueryVariable.metric) {
+        // series match
+        return `label_values(${QueryVariable.metric},${QueryVariable.label})`;
+      } else {
+        return `label_values(${QueryVariable.label})`;
+      }
+    case 2: // MetricNames
+      return `metrics(${QueryVariable.metric})`;
+    case 3: // VarQueryResult
+      return `query_result(${QueryVariable.varQuery})`;
+    case 4: // SeriesQuery
+      return '' + QueryVariable.seriesQuery;
+  }
+
+  return '';
+}

--- a/public/app/plugins/datasource/prometheus/migrations/variableMigration.ts
+++ b/public/app/plugins/datasource/prometheus/migrations/variableMigration.ts
@@ -26,18 +26,18 @@ export function migrateVariableQueryToEditor(rawQuery: string | PromVariableQuer
 
   const labelValues = rawQuery.match(labelValuesRegex);
   if (labelValues) {
-    if (labelValues[1]) {
+    if (labelValues[2]) {
       return {
         ...queryBase,
         exprType: QueryType.LabelValues,
-        label: labelValues[2],
-        metric: labelValues[1],
+        label: labelValues[1],
+        metric: labelValues[2],
       };
     } else {
       return {
         ...queryBase,
         exprType: QueryType.LabelValues,
-        label: labelValues[2],
+        label: labelValues[1],
       };
     }
   }

--- a/public/app/plugins/datasource/prometheus/migrations/variableMigration.ts
+++ b/public/app/plugins/datasource/prometheus/migrations/variableMigration.ts
@@ -75,9 +75,9 @@ export function migrateVariableQueryToEditor(rawQuery: string | PromVariableQuer
 // migrate it back to a string with the correct varialbes in place
 export function migrateVariableEditorBackToVariableSupport(QueryVariable: PromVariableQuery): string {
   switch (QueryVariable.exprType) {
-    case 0: // LabelNames
+    case QueryType.LabelNames:
       return 'label_names()';
-    case 1: // LabelValues
+    case QueryType.LabelValues:
       if (QueryVariable.metric) {
         // labels endpoint match
         return `label_values(${QueryVariable.label},${QueryVariable.metric})`;
@@ -85,11 +85,11 @@ export function migrateVariableEditorBackToVariableSupport(QueryVariable: PromVa
         // old series match
         return `label_values(${QueryVariable.label})`;
       }
-    case 2: // MetricNames
+    case QueryType.MetricNames:
       return `metrics(${QueryVariable.metric})`;
-    case 3: // VarQueryResult
+    case QueryType.VarQueryResult:
       return `query_result(${QueryVariable.varQuery})`;
-    case 4: // SeriesQuery
+    case QueryType.SeriesQuery:
       return '' + QueryVariable.seriesQuery;
   }
 

--- a/public/app/plugins/datasource/prometheus/migrations/variableMigration.ts
+++ b/public/app/plugins/datasource/prometheus/migrations/variableMigration.ts
@@ -89,10 +89,16 @@ export function migrateVariableEditorBackToVariableSupport(QueryVariable: PromVa
     case QueryType.MetricNames:
       return `metrics(${QueryVariable.metric})`;
     case QueryType.VarQueryResult:
-      return `query_result(${QueryVariable.varQuery})`;
+      const varQuery = removeLineBreaks(QueryVariable.varQuery);
+      return `query_result(${varQuery})`;
     case QueryType.SeriesQuery:
       return '' + QueryVariable.seriesQuery;
   }
 
   return '';
+}
+
+// allow line breaks in query result textarea
+function removeLineBreaks(input?: string) {
+  return input ? input.replace(/[\r\n]+/gm, '') : '';
 }

--- a/public/app/plugins/datasource/prometheus/migrations/variableMigration.ts
+++ b/public/app/plugins/datasource/prometheus/migrations/variableMigration.ts
@@ -25,19 +25,22 @@ export function migrateVariableQueryToEditor(rawQuery: string | PromVariableQuer
   }
 
   const labelValues = rawQuery.match(labelValuesRegex);
+
   if (labelValues) {
-    if (labelValues[2]) {
+    const label = labelValues[2];
+    const metric = labelValues[1];
+    if (metric) {
       return {
         ...queryBase,
         exprType: QueryType.LabelValues,
-        label: labelValues[2],
-        metric: labelValues[1],
+        label,
+        metric,
       };
     } else {
       return {
         ...queryBase,
         exprType: QueryType.LabelValues,
-        label: labelValues[2],
+        label,
       };
     }
   }

--- a/public/app/plugins/datasource/prometheus/migrations/variableMigration.ts
+++ b/public/app/plugins/datasource/prometheus/migrations/variableMigration.ts
@@ -13,14 +13,14 @@ export function migrateVariableQueryToEditor(rawQuery: string | PromVariableQuer
 
   const queryBase = {
     refId: 'PrometheusDatasource-VariableQuery',
-    exprType: QueryType.LabelNames,
+    qryType: QueryType.LabelNames,
   };
 
   const labelNames = rawQuery.match(labelNamesRegex);
   if (labelNames) {
     return {
       ...queryBase,
-      exprType: QueryType.LabelNames,
+      qryType: QueryType.LabelNames,
     };
   }
 
@@ -32,14 +32,14 @@ export function migrateVariableQueryToEditor(rawQuery: string | PromVariableQuer
     if (metric) {
       return {
         ...queryBase,
-        exprType: QueryType.LabelValues,
+        qryType: QueryType.LabelValues,
         label,
         metric,
       };
     } else {
       return {
         ...queryBase,
-        exprType: QueryType.LabelValues,
+        qryType: QueryType.LabelValues,
         label,
       };
     }
@@ -49,7 +49,7 @@ export function migrateVariableQueryToEditor(rawQuery: string | PromVariableQuer
   if (metricNames) {
     return {
       ...queryBase,
-      exprType: QueryType.MetricNames,
+      qryType: QueryType.MetricNames,
       metric: metricNames[1],
     };
   }
@@ -58,7 +58,7 @@ export function migrateVariableQueryToEditor(rawQuery: string | PromVariableQuer
   if (queryResult) {
     return {
       ...queryBase,
-      exprType: QueryType.VarQueryResult,
+      qryType: QueryType.VarQueryResult,
       varQuery: queryResult[1],
     };
   }
@@ -67,7 +67,7 @@ export function migrateVariableQueryToEditor(rawQuery: string | PromVariableQuer
   if (!labelNames && !labelValues && !metricNames && !queryResult) {
     return {
       ...queryBase,
-      exprType: QueryType.SeriesQuery,
+      qryType: QueryType.SeriesQuery,
       seriesQuery: rawQuery,
     };
   }
@@ -77,7 +77,7 @@ export function migrateVariableQueryToEditor(rawQuery: string | PromVariableQuer
 
 // migrate it back to a string with the correct varialbes in place
 export function migrateVariableEditorBackToVariableSupport(QueryVariable: PromVariableQuery): string {
-  switch (QueryVariable.exprType) {
+  switch (QueryVariable.qryType) {
     case QueryType.LabelNames:
       return 'label_names()';
     case QueryType.LabelValues:

--- a/public/app/plugins/datasource/prometheus/types.ts
+++ b/public/app/plugins/datasource/prometheus/types.ts
@@ -22,6 +22,7 @@ export interface PromQuery extends DataQuery {
   showingTable?: boolean;
   /** Code, Builder or Explain */
   editorMode?: QueryEditorMode;
+  query?: string;
 }
 
 export interface PromOptions extends DataSourceJsonData {
@@ -175,6 +176,7 @@ export enum PromVariableQueryType {
 }
 
 export interface PromVariableQuery extends DataQuery {
+  query?: string;
   expr?: string;
   exprType?: PromVariableQueryType;
   label?: string;

--- a/public/app/plugins/datasource/prometheus/types.ts
+++ b/public/app/plugins/datasource/prometheus/types.ts
@@ -178,7 +178,7 @@ export enum PromVariableQueryType {
 export interface PromVariableQuery extends DataQuery {
   query?: string;
   expr?: string;
-  exprType?: PromVariableQueryType;
+  qryType?: PromVariableQueryType;
   label?: string;
   metric?: string;
   varQuery?: string;

--- a/public/app/plugins/datasource/prometheus/types.ts
+++ b/public/app/plugins/datasource/prometheus/types.ts
@@ -165,3 +165,20 @@ export enum LegendFormatMode {
   Verbose = '__verbose',
   Custom = '__custom',
 }
+
+export enum PromVariableQueryType {
+  LabelNames,
+  LabelValues,
+  MetricNames,
+  VarQueryResult,
+  SeriesQuery,
+}
+
+export interface PromVariableQuery extends DataQuery {
+  expr?: string;
+  exprType?: PromVariableQueryType;
+  label?: string;
+  metric?: string;
+  varQuery?: string;
+  seriesQuery?: string;
+}

--- a/public/app/plugins/datasource/prometheus/variables.ts
+++ b/public/app/plugins/datasource/prometheus/variables.ts
@@ -1,22 +1,17 @@
 import { from, Observable, of } from 'rxjs';
 import { map } from 'rxjs/operators';
 
-import {
-  DataQueryRequest,
-  DataQueryResponse,
-  rangeUtil,
-  StandardVariableQuery,
-  StandardVariableSupport,
-} from '@grafana/data';
+import { CustomVariableSupport, DataQueryRequest, DataQueryResponse, rangeUtil } from '@grafana/data';
 import { getTemplateSrv, TemplateSrv } from '@grafana/runtime';
 
 import { getTimeSrv, TimeSrv } from '../../../features/dashboard/services/TimeSrv';
 
+import { PromVariableQueryEditor } from './components/VariableQueryEditor';
 import { PrometheusDatasource } from './datasource';
 import PrometheusMetricFindQuery from './metric_find_query';
 import { PromQuery } from './types';
 
-export class PrometheusVariableSupport extends StandardVariableSupport<PrometheusDatasource> {
+export class PrometheusVariableSupport extends CustomVariableSupport<PrometheusDatasource> {
   constructor(
     private readonly datasource: PrometheusDatasource,
     private readonly templateSrv: TemplateSrv = getTemplateSrv(),
@@ -25,6 +20,8 @@ export class PrometheusVariableSupport extends StandardVariableSupport<Prometheu
     super();
     this.query = this.query.bind(this);
   }
+
+  editor = PromVariableQueryEditor;
 
   query(request: DataQueryRequest<PromQuery>): Observable<DataQueryResponse> {
     const query = request.targets[0].expr;
@@ -47,12 +44,5 @@ export class PrometheusVariableSupport extends StandardVariableSupport<Prometheu
     const metricFindStream = from(metricFindQuery.process());
 
     return metricFindStream.pipe(map((results) => ({ data: results })));
-  }
-
-  toDataQuery(query: StandardVariableQuery): PromQuery {
-    return {
-      refId: 'PrometheusDatasource-VariableQuery',
-      expr: query.query,
-    };
   }
 }

--- a/public/app/plugins/datasource/prometheus/variables.ts
+++ b/public/app/plugins/datasource/prometheus/variables.ts
@@ -24,7 +24,7 @@ export class PrometheusVariableSupport extends CustomVariableSupport<PrometheusD
   editor = PromVariableQueryEditor;
 
   query(request: DataQueryRequest<PromQuery>): Observable<DataQueryResponse> {
-    const query = request.targets[0].expr;
+    const query = request.targets[0].query;
     if (!query) {
       return of({ data: [] });
     }

--- a/public/app/plugins/datasource/tempo/QueryEditor/ServiceGraphSection.tsx
+++ b/public/app/plugins/datasource/tempo/QueryEditor/ServiceGraphSection.tsx
@@ -29,7 +29,7 @@ export function ServiceGraphSection({
   const [hasKeys, setHasKeys] = useState<boolean | undefined>(undefined);
   useEffect(() => {
     async function fn(ds: PrometheusDatasource) {
-      const keys = await ds.getTagKeys({
+      const keys = await ds.getLabelNames({
         series: [
           'traces_service_graph_request_server_seconds_sum',
           'traces_service_graph_request_total',


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/59559 (allow newlines in Prom query result variable query editor)
Fixes https://github.com/grafana/observability-metrics-squad/issues/48

**What is this feature?**
This changes the prometheus query variable editor to a group of selects and inputs to better explain the functions, arguments, and endpoint calls used in the prometheus variable queries.

Previous single input:
<img width="376" alt="Screen Shot 2022-11-05 at 12 16 57 PM" src="https://user-images.githubusercontent.com/25674746/200129624-966cdd04-59ba-4c73-b9a8-37ba06d2867f.png">

New function select and variable inputs:
<img width="529" alt="Screen Shot 2022-11-05 at 12 17 30 PM" src="https://user-images.githubusercontent.com/25674746/200129632-174ab92f-d811-4a92-849a-a928e1867234.png">

Full proposal [here](https://docs.google.com/document/d/1VsMFjiuug-sbSm5XaQffISsUcyxQ5CeHFAjT-POcIqo/edit).

**Why do we need this feature?**
This is in line with the Grafana 10 goal of "Getting Started." More clarity around creating variables in Prometheus will help onboard new customers.

**Who is this feature for?**
This feature is for anyone using the Prometheus datasource plugin who wants to create template variables.
This is for all users of prometheus datasource plugin, from expert to beginner.


<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

**Special notes for your reviewer**:
1. Please create a prometheus variable in the main branch, for example, `label_names()`
2. Switch to the new branch and open the variable editor to see that the function has been correctly passed to the inputs.
3. Check that the variables are returned.
4. Look for confusing language and readability. Are the tooltips helpful?

