### PR TITLE
Alerting: Support Prometheus durations in Provisioning API

### DIFF
--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_alert_rules.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_alert_rules.go
@@ -98,10 +98,6 @@ type ProvisionedAlertRule struct {
 }
 
 func (a *ProvisionedAlertRule) UpstreamModel() (models.AlertRule, error) {
-	forDur, err := time.ParseDuration(a.For.String())
-	if err != nil {
-		return models.AlertRule{}, err
-	}
 	return models.AlertRule{
 		ID:           a.ID,
 		UID:          a.UID,
@@ -114,7 +110,7 @@ func (a *ProvisionedAlertRule) UpstreamModel() (models.AlertRule, error) {
 		Updated:      a.Updated,
 		NoDataState:  a.NoDataState,
 		ExecErrState: a.ExecErrState,
-		For:          forDur,
+		For:          time.Duration(a.For),
 		Annotations:  a.Annotations,
 		Labels:       a.Labels,
 	}, nil

--- a/pkg/services/provisioning/alerting/rules_types.go
+++ b/pkg/services/provisioning/alerting/rules_types.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/provisioning/values"
+
+	"github.com/prometheus/common/model"
 )
 
 type RuleDelete struct {
@@ -39,11 +41,11 @@ func (ruleGroupV1 *AlertRuleGroupV1) MapToModel() (AlertRuleGroup, error) {
 	if ruleGroup.OrgID < 1 {
 		ruleGroup.OrgID = 1
 	}
-	interval, err := time.ParseDuration(ruleGroupV1.Interval.Value())
+	interval, err := model.ParseDuration(ruleGroupV1.Interval.Value())
 	if err != nil {
 		return AlertRuleGroup{}, err
 	}
-	ruleGroup.Interval = interval
+	ruleGroup.Interval = time.Duration(interval)
 	ruleGroup.Folder = ruleGroupV1.Folder.Value()
 	if strings.TrimSpace(ruleGroup.Folder) == "" {
 		return AlertRuleGroup{}, errors.New("rule group has no folder set")
@@ -91,11 +93,11 @@ func (rule *AlertRuleV1) mapToModel(orgID int64) (models.AlertRule, error) {
 		return models.AlertRule{}, fmt.Errorf("rule '%s' failed to parse: no UID set", alertRule.Title)
 	}
 	alertRule.OrgID = orgID
-	duration, err := time.ParseDuration(rule.For.Value())
+	duration, err := model.ParseDuration(rule.For.Value())
 	if err != nil {
 		return models.AlertRule{}, fmt.Errorf("rule '%s' failed to parse: %w", alertRule.Title, err)
 	}
-	alertRule.For = duration
+	alertRule.For = time.Duration(duration)
 	dashboardUID := rule.DashboardUID.Value()
 	alertRule.DashboardUID = &dashboardUID
 	panelID := rule.PanelID.Value()

--- a/pkg/services/provisioning/alerting/rules_types_test.go
+++ b/pkg/services/provisioning/alerting/rules_types_test.go
@@ -2,6 +2,7 @@ package alerting
 
 import (
 	"testing"
+	"time"
 
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/provisioning/values"
@@ -50,6 +51,16 @@ func TestRuleGroup(t *testing.T) {
 		rg.Interval = interval
 		_, err = rg.MapToModel()
 		require.Error(t, err)
+	})
+	t.Run("a rule group with an interval containing 'd' should work", func(t *testing.T) {
+		rg := validRuleGroupV1(t)
+		var interval values.StringValue
+		err := yaml.Unmarshal([]byte("2d"), &interval)
+		require.NoError(t, err)
+		rg.Interval = interval
+		rgMapped, err := rg.MapToModel()
+		require.NoError(t, err)
+		require.Equal(t, 48*time.Hour, rgMapped.Interval)
 	})
 	t.Run("a rule group with an empty org id should default to 1", func(t *testing.T) {
 		rg := validRuleGroupV1(t)
@@ -102,6 +113,16 @@ func TestRules(t *testing.T) {
 		require.NoError(t, err)
 		_, err = rule.mapToModel(1)
 		require.Error(t, err)
+	})
+	t.Run("a rule with a for duration containing 'd' should work", func(t *testing.T) {
+		rule := validRuleV1(t)
+		forDuration := values.StringValue{}
+		err := yaml.Unmarshal([]byte("2d"), &forDuration)
+		rule.For = forDuration
+		require.NoError(t, err)
+		ruleMapped, err := rule.mapToModel(1)
+		require.NoError(t, err)
+		require.Equal(t, 48*time.Hour, ruleMapped.For)
 	})
 	t.Run("a rule with out a condition should error", func(t *testing.T) {
 		rule := validRuleV1(t)


### PR DESCRIPTION
Make provisioning API support durations containing 'd' by using prometheus Duration instead of time Duration.

Fixes #58117

Not sure if we need a test to check it works with 'd' in duration and if so where I should write this test.