### PR TITLE
ESLint: Allow public accessability modifier or local enforcement

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -21,6 +21,7 @@
         "alphabetize": { "order": "asc" }
       }
     ],
+    "@typescript-eslint/explicit-member-accessibility": "off",
     "no-restricted-imports": [
       "error",
       {

--- a/packages/grafana-toolkit/src/config/eslint.plugin.js
+++ b/packages/grafana-toolkit/src/config/eslint.plugin.js
@@ -2,5 +2,6 @@ module.exports = {
   extends: ['@grafana/eslint-config'],
   rules: {
     'react/prop-types': 'off',
+    '@typescript-eslint/explicit-member-accessibility': ['error', { accessibility: 'no-public' }],
   },
 };

--- a/packages/grafana-toolkit/src/config/eslint.plugin.js
+++ b/packages/grafana-toolkit/src/config/eslint.plugin.js
@@ -2,6 +2,5 @@ module.exports = {
   extends: ['@grafana/eslint-config'],
   rules: {
     'react/prop-types': 'off',
-    '@typescript-eslint/explicit-member-accessibility': ['error', { accessibility: 'no-public' }],
   },
 };

--- a/packages/grafana-toolkit/src/config/eslint.plugin.js
+++ b/packages/grafana-toolkit/src/config/eslint.plugin.js
@@ -2,5 +2,6 @@ module.exports = {
   extends: ['@grafana/eslint-config'],
   rules: {
     'react/prop-types': 'off',
+    '@typescript-eslint/explicit-member-accessibility': ['error'],
   },
 };

--- a/packages/grafana-toolkit/src/config/eslint.plugin.js
+++ b/packages/grafana-toolkit/src/config/eslint.plugin.js
@@ -2,6 +2,5 @@ module.exports = {
   extends: ['@grafana/eslint-config'],
   rules: {
     'react/prop-types': 'off',
-    '@typescript-eslint/explicit-member-accessibility': ['error'],
   },
 };

--- a/public/app/features/scenes/core/SceneObjectBase.tsx
+++ b/public/app/features/scenes/core/SceneObjectBase.tsx
@@ -18,7 +18,7 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = {}> impl
   protected _parent?: SceneObject;
   protected subs = new Subscription();
 
-  constructor(state: TState) {
+  public constructor(state: TState) {
     if (!state.key) {
       state.key = uuidv4();
     }
@@ -29,17 +29,17 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = {}> impl
   }
 
   /** Current state */
-  get state(): TState {
+  public get state(): TState {
     return this._state;
   }
 
   /** True if currently being active (ie displayed for visual objects) */
-  get isActive(): boolean {
+  public get isActive(): boolean {
     return this._isActive;
   }
 
   /** Returns the parent, undefined for root object */
-  get parent(): SceneObject | undefined {
+  public get parent(): SceneObject | undefined {
     return this._parent;
   }
 
@@ -47,14 +47,14 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = {}> impl
    * Used in render functions when rendering a SceneObject.
    * Wraps the component in an EditWrapper that handles edit mode
    */
-  get Component(): SceneComponent<this> {
+  public get Component(): SceneComponent<this> {
     return SceneComponentWrapper;
   }
 
   /**
    * Temporary solution, should be replaced by declarative options
    */
-  get Editor(): SceneComponent<this> {
+  public get Editor(): SceneComponent<this> {
     return ((this as any).constructor['Editor'] ?? (() => null)) as SceneComponent<this>;
   }
 
@@ -84,11 +84,11 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = {}> impl
   /**
    * Subscribe to the scene event
    **/
-  subscribeToEvent<T extends BusEvent>(eventType: BusEventType<T>, handler: BusEventHandler<T>): Unsubscribable {
+  public subscribeToEvent<T extends BusEvent>(eventType: BusEventType<T>, handler: BusEventHandler<T>): Unsubscribable {
     return this._events.subscribe(eventType, handler);
   }
 
-  setState(update: Partial<TState>) {
+  public setState(update: Partial<TState>) {
     const prevState = this._state;
     this._state = {
       ...this._state,
@@ -112,7 +112,7 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = {}> impl
   /*
    * Publish an event and optionally bubble it up the scene
    **/
-  publishEvent(event: BusEvent, bubble?: boolean) {
+  public publishEvent(event: BusEvent, bubble?: boolean) {
     this._events.publish(event);
 
     if (bubble && this.parent) {
@@ -120,11 +120,14 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = {}> impl
     }
   }
 
-  getRoot(): SceneObject {
+  public getRoot(): SceneObject {
     return !this._parent ? this : this._parent.getRoot();
   }
 
-  activate() {
+  /**
+   * Called by the SceneComponentWrapper when the react component is mounted
+   */
+  public activate() {
     this._isActive = true;
 
     const { $data, $variables } = this.state;
@@ -138,7 +141,10 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = {}> impl
     }
   }
 
-  deactivate(): void {
+  /**
+   * Called by the SceneComponentWrapper when the react component is unmounted
+   */
+  public deactivate(): void {
     this._isActive = false;
 
     const { $data, $variables } = this.state;
@@ -160,7 +166,10 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = {}> impl
     this._subject = new Subject<TState>();
   }
 
-  useState() {
+  /**
+   * Utility hook to get and subscribe to state
+   */
+  public useState() {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     return useSceneObjectState(this);
   }
@@ -168,7 +177,7 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = {}> impl
   /**
    * Will walk up the scene object graph to the closest $timeRange scene object
    */
-  getTimeRange(): SceneTimeRange {
+  public getTimeRange(): SceneTimeRange {
     const { $timeRange } = this.state;
     if ($timeRange) {
       return $timeRange;
@@ -184,7 +193,7 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = {}> impl
   /**
    * Will walk up the scene object graph to the closest $data scene object
    */
-  getData(): SceneObject<SceneDataState> {
+  public getData(): SceneObject<SceneDataState> {
     const { $data } = this.state;
     if ($data) {
       return $data;
@@ -200,7 +209,7 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = {}> impl
   /**
    * Will walk up the scene object graph to the closest $editor scene object
    */
-  getSceneEditor(): SceneEditor {
+  public getSceneEditor(): SceneEditor {
     const { $editor } = this.state;
     if ($editor) {
       return $editor;
@@ -216,7 +225,7 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = {}> impl
   /**
    * Will create new SceneItem with shalled cloned state, but all states items of type SceneObject are deep cloned
    */
-  clone(withState?: Partial<TState>): this {
+  public clone(withState?: Partial<TState>): this {
     const clonedState = { ...this.state };
 
     // Clone any SceneItems in state

--- a/public/app/features/scenes/core/SceneObjectBase.tsx
+++ b/public/app/features/scenes/core/SceneObjectBase.tsx
@@ -77,7 +77,7 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = {}> impl
   /**
    * Subscribe to the scene state subject
    **/
-  subscribeToState(observerOrNext?: Partial<Observer<TState>>): Subscription {
+  public subscribeToState(observerOrNext?: Partial<Observer<TState>>): Subscription {
     return this._subject.subscribe(observerOrNext);
   }
 


### PR DESCRIPTION
In the new dashboard architecture, we have these state object classes that will be used directly by core features and plugins. And base classes that will be extended by plugins to extend and build new things (when we expose this to plugins, exactly how and where these will be exposed is not explored yet). 

Anyway it's super important that the public interface of these classes are as locked down as possible (to prevent breaking changes), so only things that need to be accessible from sub-classes should protected and everything else that is not to be accessed from the outside should be private. To make this more explicit it would be nice to be able to mark functions and properties as `public`, even though this is the default. 

We have some options here 
* A) Remove the eslint rule that makes the use of public modifier an error  (current PR change)
* B) Add an override to make public modifier allowed within features/scenes
* C) Add an override to enforce explicit modifiers (ie. error when there is no modifier on all class functions, and properties)  

C sounds the best in terms of making everything in scenes/* be consistent and forcing us to really think about what should be public and what should not be. 
Pushed a branch that tested C: https://github.com/grafana/grafana/compare/force-public-accessability   (Forcing an accessor for everything under scenes/*) 