### PR TITLE
Chore: Disable dashboard-time-zone e2e tests

### DIFF
--- a/e2e/dashboards-suite/dashboard-time-zone.spec.ts
+++ b/e2e/dashboards-suite/dashboard-time-zone.spec.ts
@@ -16,7 +16,7 @@ e2e.scenario({
   itName: 'Tests dashboard time zone scenarios',
   addScenarioDataSource: false,
   addScenarioDashBoard: false,
-  skipScenario: false,
+  skipScenario: true,
   scenario: () => {
     e2e.flows.openDashboard({ uid: '5SdHCasdf' });
 


### PR DESCRIPTION
**What is this feature?**

Disables flaky tests so releases and PRs aren't blocked

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

Created https://github.com/grafana/grafana/issues/58319 to track fix

**Special notes for your reviewer**:

