### PR TITLE
Add flame graph, Phlare and Parca to code owners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -69,6 +69,8 @@ go.sum @grafana/backend-platform
 /pkg/tsdb/loki @grafana/observability-logs
 /pkg/tsdb/zipkin @grafana/observability-traces-and-profiling
 /pkg/tsdb/tempo @grafana/observability-traces-and-profiling
+/pkg/tsdb/phlare @grafana/observability-traces-and-profiling
+/pkg/tsdb/parca @grafana/observability-traces-and-profiling
 
 # BI backend code
 /pkg/tsdb/mysql @grafana/grafana-bi-squad
@@ -152,6 +154,7 @@ go.sum @grafana/backend-platform
 /public/app/plugins/panel/logs @grafana/observability-logs
 /public/app/plugins/panel/nodeGraph @grafana/observability-traces-and-profiling
 /public/app/plugins/panel/traces @grafana/observability-traces-and-profiling
+/public/app/plugins/panel/flamegraph @grafana/observability-traces-and-profiling
 /public/app/plugins/panel/piechart @grafana/grafana-bi-squad
 /public/app/plugins/panel/state-timeline @grafana/grafana-bi-squad
 /public/app/plugins/panel/status-history @grafana/grafana-bi-squad
@@ -196,6 +199,8 @@ lerna.json @grafana/frontend-ops
 /public/app/plugins/datasource/cloud-monitoring @grafana/cloud-provider-plugins
 /public/app/plugins/datasource/zipkin @grafana/observability-traces-and-profiling
 /public/app/plugins/datasource/tempo @grafana/observability-traces-and-profiling
+/public/app/plugins/datasource/phlare @grafana/observability-traces-and-profiling
+/public/app/plugins/datasource/parca @grafana/observability-traces-and-profiling
 /public/app/plugins/datasource/alertmanager @grafana/alerting-squad
 
 # Cloud middleware


### PR DESCRIPTION
**What is this feature?**

Adds the flame graph, Phlare and Parca to the .CODEOWNERS file.

**Why do we need this feature?**

So the observability-traces-and-profiling will get auto assigned as a reviewer when flame graph, Phlare or Parca files are modified.

**Who is this feature for?**

Anyone modifying flame graph, Phlare or Parca files