### PR TITLE
Explore: Remove explore2Dashboard feature toggle

### DIFF
--- a/docs/sources/explore/_index.md
+++ b/docs/sources/explore/_index.md
@@ -68,12 +68,6 @@ The Share shortened link capability allows you to create smaller and simpler URL
 
 ## Available feature toggles
 
-### explore2Dashboard
-
-> **Note:** Available in Grafana 8.5.0 and later versions.
-
-Enabled by default, allows users to create panels in dashboards from within Explore.
-
 ### exploreMixedDatasource
 
 Disabled by default, allows users in Explore to have different datasources for different queries. If compatible, results will be combined.

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -45,7 +45,6 @@ export interface FeatureToggles {
   dashboardsFromStorage?: boolean;
   export?: boolean;
   azureMonitorResourcePickerForMetrics?: boolean;
-  explore2Dashboard?: boolean;
   exploreMixedDatasource?: boolean;
   tracing?: boolean;
   commandPalette?: boolean;

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -167,13 +167,6 @@ var (
 			FrontendOnly:    true,
 		},
 		{
-			Name:         "explore2Dashboard",
-			Description:  "Experimental Explore to Dashboard workflow",
-			State:        FeatureStateStable,
-			Expression:   "true", // enabled by default
-			FrontendOnly: true,
-		},
-		{
 			Name:         "exploreMixedDatasource",
 			Description:  "Enable mixed datasource in Explore",
 			State:        FeatureStateAlpha,

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -123,10 +123,6 @@ const (
 	// New UI for Azure Monitor Metrics Query
 	FlagAzureMonitorResourcePickerForMetrics = "azureMonitorResourcePickerForMetrics"
 
-	// FlagExplore2Dashboard
-	// Experimental Explore to Dashboard workflow
-	FlagExplore2Dashboard = "explore2Dashboard"
-
 	// FlagExploreMixedDatasource
 	// Enable mixed datasource in Explore
 	FlagExploreMixedDatasource = "exploreMixedDatasource"

--- a/public/app/features/explore/ExploreToolbar.tsx
+++ b/public/app/features/explore/ExploreToolbar.tsx
@@ -157,7 +157,7 @@ class UnConnectedExploreToolbar extends PureComponent<Props> {
         </ToolbarButton>
       ),
 
-      config.featureToggles.explore2Dashboard && showExploreToDashboard && (
+      showExploreToDashboard && (
         <Suspense key="addToDashboard" fallback={null}>
           <AddToDashboard exploreId={exploreId} />
         </Suspense>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Removes the `explore2Dashboard` feature toggle 

**Why do we need this feature?**

the explore2Dashboard feature toggle was introduced in 8.5.0 (enabled by default), allowing users to disable the e2d flow. Given there were no major issues found with it and the feature is being used and perceived in a positive way, we want to remove the feature toggle.



**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #52402


