### PR TITLE
Scenes: Enforce explicit accessibility modifiers (ESLint) 

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -21,6 +21,7 @@
         "alphabetize": { "order": "asc" }
       }
     ],
+    "@typescript-eslint/explicit-member-accessibility": "off",
     "no-restricted-imports": [
       "error",
       {

--- a/.eslintrc
+++ b/.eslintrc
@@ -21,7 +21,6 @@
         "alphabetize": { "order": "asc" }
       }
     ],
-    "@typescript-eslint/explicit-member-accessibility": "off",
     "no-restricted-imports": [
       "error",
       {
@@ -45,6 +44,12 @@
     "@typescript-eslint/no-redeclare": ["error"]
   },
   "overrides": [
+    {
+      "files": ["public/app/features/scenes/**/*.{ts,tsx}"],
+      "rules": {
+        "@typescript-eslint/explicit-member-accessibility": ["error", { "accessibility": "explicit" }]
+      }
+    },
     {
       "files": ["packages/grafana-ui/src/components/uPlot/**/*.{ts,tsx}"],
       "rules": {

--- a/packages/grafana-toolkit/src/config/eslint.plugin.js
+++ b/packages/grafana-toolkit/src/config/eslint.plugin.js
@@ -2,5 +2,6 @@ module.exports = {
   extends: ['@grafana/eslint-config'],
   rules: {
     'react/prop-types': 'off',
+    '@typescript-eslint/explicit-member-accessibility': ['error', { accessibility: 'no-public' }],
   },
 };

--- a/packages/grafana-toolkit/src/config/eslint.plugin.js
+++ b/packages/grafana-toolkit/src/config/eslint.plugin.js
@@ -2,6 +2,5 @@ module.exports = {
   extends: ['@grafana/eslint-config'],
   rules: {
     'react/prop-types': 'off',
-    '@typescript-eslint/explicit-member-accessibility': ['error', { accessibility: 'no-public' }],
   },
 };

--- a/packages/grafana-toolkit/src/config/eslint.plugin.js
+++ b/packages/grafana-toolkit/src/config/eslint.plugin.js
@@ -2,5 +2,6 @@ module.exports = {
   extends: ['@grafana/eslint-config'],
   rules: {
     'react/prop-types': 'off',
+    '@typescript-eslint/explicit-member-accessibility': ['error'],
   },
 };

--- a/packages/grafana-toolkit/src/config/eslint.plugin.js
+++ b/packages/grafana-toolkit/src/config/eslint.plugin.js
@@ -2,6 +2,5 @@ module.exports = {
   extends: ['@grafana/eslint-config'],
   rules: {
     'react/prop-types': 'off',
-    '@typescript-eslint/explicit-member-accessibility': ['error'],
   },
 };

--- a/public/app/features/scenes/components/NestedScene.tsx
+++ b/public/app/features/scenes/components/NestedScene.tsx
@@ -18,9 +18,9 @@ interface NestedSceneState extends SceneLayoutChildState {
 }
 
 export class NestedScene extends SceneObjectBase<NestedSceneState> {
-  static Component = NestedSceneRenderer;
+  public static Component = NestedSceneRenderer;
 
-  onToggle = () => {
+  public onToggle = () => {
     this.setState({
       isCollapsed: !this.state.isCollapsed,
       size: {
@@ -31,7 +31,7 @@ export class NestedScene extends SceneObjectBase<NestedSceneState> {
   };
 
   /** Removes itself from its parent's children array */
-  onRemove = () => {
+  public onRemove = () => {
     const parent = this.parent!;
     if ('children' in parent.state) {
       parent.setState({

--- a/public/app/features/scenes/components/Scene.tsx
+++ b/public/app/features/scenes/components/Scene.tsx
@@ -18,15 +18,15 @@ interface SceneState extends SceneObjectStatePlain {
 }
 
 export class Scene extends SceneObjectBase<SceneState> {
-  static Component = SceneRenderer;
-  urlSyncManager?: UrlSyncManager;
+  public static Component = SceneRenderer;
+  private urlSyncManager?: UrlSyncManager;
 
-  activate() {
+  public activate() {
     super.activate();
     this.urlSyncManager = new UrlSyncManager(this);
   }
 
-  deactivate() {
+  public deactivate() {
     super.deactivate();
     this.urlSyncManager!.cleanUp();
   }

--- a/public/app/features/scenes/components/SceneCanvasText.tsx
+++ b/public/app/features/scenes/components/SceneCanvasText.tsx
@@ -12,8 +12,8 @@ export interface SceneCanvasTextState extends SceneLayoutChildState {
 }
 
 export class SceneCanvasText extends SceneObjectBase<SceneCanvasTextState> {
-  static Editor = Editor;
-  static Component = ({ model }: SceneComponentProps<SceneCanvasText>) => {
+  public static Editor = Editor;
+  public static Component = ({ model }: SceneComponentProps<SceneCanvasText>) => {
     const { text, fontSize = 20, align = 'left' } = model.useState();
 
     const style: CSSProperties = {

--- a/public/app/features/scenes/components/SceneFlexLayout.tsx
+++ b/public/app/features/scenes/components/SceneFlexLayout.tsx
@@ -12,10 +12,10 @@ interface SceneFlexLayoutState extends SceneLayoutState {
 }
 
 export class SceneFlexLayout extends SceneObjectBase<SceneFlexLayoutState> {
-  static Component = FlexLayoutRenderer;
-  static Editor = FlexLayoutEditor;
+  public static Component = FlexLayoutRenderer;
+  public static Editor = FlexLayoutEditor;
 
-  toggleDirection() {
+  public toggleDirection() {
     this.setState({
       direction: this.state.direction === 'row' ? 'column' : 'row',
     });

--- a/public/app/features/scenes/components/ScenePanelRepeater.tsx
+++ b/public/app/features/scenes/components/ScenePanelRepeater.tsx
@@ -17,7 +17,7 @@ interface RepeatOptions extends SceneObjectStatePlain {
 }
 
 export class ScenePanelRepeater extends SceneObjectBase<RepeatOptions> {
-  activate(): void {
+  public activate(): void {
     super.activate();
 
     this.subs.add(
@@ -31,7 +31,7 @@ export class ScenePanelRepeater extends SceneObjectBase<RepeatOptions> {
     );
   }
 
-  performRepeat(data: PanelData) {
+  private performRepeat(data: PanelData) {
     // assume parent is a layout
     const firstChild = this.state.layout.state.children[0]!;
     const newChildren: SceneLayoutChild[] = [];
@@ -53,7 +53,7 @@ export class ScenePanelRepeater extends SceneObjectBase<RepeatOptions> {
     this.state.layout.setState({ children: newChildren });
   }
 
-  static Component = ({ model, isEditing }: SceneComponentProps<ScenePanelRepeater>) => {
+  public static Component = ({ model, isEditing }: SceneComponentProps<ScenePanelRepeater>) => {
     const { layout } = model.useState();
     return <layout.Component model={layout} isEditing={isEditing} />;
   };

--- a/public/app/features/scenes/components/ScenePanelRepeater.tsx
+++ b/public/app/features/scenes/components/ScenePanelRepeater.tsx
@@ -20,7 +20,7 @@ export class ScenePanelRepeater extends SceneObjectBase<RepeatOptions> {
   public activate(): void {
     super.activate();
 
-    this.subs.add(
+    this._subs.add(
       this.getData().subscribeToState({
         next: (data) => {
           if (data.data?.state === LoadingState.Done) {

--- a/public/app/features/scenes/components/SceneTimePicker.tsx
+++ b/public/app/features/scenes/components/SceneTimePicker.tsx
@@ -11,7 +11,7 @@ export interface SceneTimePickerState extends SceneObjectStatePlain {
 }
 
 export class SceneTimePicker extends SceneObjectBase<SceneTimePickerState> {
-  static Component = SceneTimePickerRenderer;
+  public static Component = SceneTimePickerRenderer;
 }
 
 function SceneTimePickerRenderer({ model }: SceneComponentProps<SceneTimePicker>) {

--- a/public/app/features/scenes/components/SceneToolbarButton.tsx
+++ b/public/app/features/scenes/components/SceneToolbarButton.tsx
@@ -11,7 +11,7 @@ export interface ToolbarButtonState extends SceneObjectStatePlain {
 }
 
 export class SceneToolbarButton extends SceneObjectBase<ToolbarButtonState> {
-  static Component = ({ model }: SceneComponentProps<SceneToolbarButton>) => {
+  public static Component = ({ model }: SceneComponentProps<SceneToolbarButton>) => {
     const state = model.useState();
 
     return <ToolbarButton onClick={state.onClick} icon={state.icon} />;
@@ -24,7 +24,7 @@ export interface SceneToolbarInputState extends SceneObjectStatePlain {
 }
 
 export class SceneToolbarInput extends SceneObjectBase<SceneToolbarInputState> {
-  static Component = ({ model }: SceneComponentProps<SceneToolbarInput>) => {
+  public static Component = ({ model }: SceneComponentProps<SceneToolbarInput>) => {
     const state = model.useState();
 
     return (

--- a/public/app/features/scenes/components/VizPanel.tsx
+++ b/public/app/features/scenes/components/VizPanel.tsx
@@ -16,10 +16,10 @@ export interface VizPanelState extends SceneLayoutChildState {
 }
 
 export class VizPanel extends SceneObjectBase<VizPanelState> {
-  static Component = ScenePanelRenderer;
-  static Editor = VizPanelEditor;
+  public static Component = ScenePanelRenderer;
+  public static Editor = VizPanelEditor;
 
-  onSetTimeRange = (timeRange: AbsoluteTimeRange) => {
+  public onSetTimeRange = (timeRange: AbsoluteTimeRange) => {
     const sceneTimeRange = this.getTimeRange();
     sceneTimeRange.setState({
       raw: {

--- a/public/app/features/scenes/core/SceneObjectBase.tsx
+++ b/public/app/features/scenes/core/SceneObjectBase.tsx
@@ -18,7 +18,7 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = {}> impl
   protected _parent?: SceneObject;
   protected subs = new Subscription();
 
-  constructor(state: TState) {
+  public constructor(state: TState) {
     if (!state.key) {
       state.key = uuidv4();
     }
@@ -29,17 +29,17 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = {}> impl
   }
 
   /** Current state */
-  get state(): TState {
+  public get state(): TState {
     return this._state;
   }
 
   /** True if currently being active (ie displayed for visual objects) */
-  get isActive(): boolean {
+  public get isActive(): boolean {
     return this._isActive;
   }
 
   /** Returns the parent, undefined for root object */
-  get parent(): SceneObject | undefined {
+  public get parent(): SceneObject | undefined {
     return this._parent;
   }
 
@@ -47,14 +47,14 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = {}> impl
    * Used in render functions when rendering a SceneObject.
    * Wraps the component in an EditWrapper that handles edit mode
    */
-  get Component(): SceneComponent<this> {
+  public get Component(): SceneComponent<this> {
     return SceneComponentWrapper;
   }
 
   /**
    * Temporary solution, should be replaced by declarative options
    */
-  get Editor(): SceneComponent<this> {
+  public get Editor(): SceneComponent<this> {
     return ((this as any).constructor['Editor'] ?? (() => null)) as SceneComponent<this>;
   }
 
@@ -84,11 +84,11 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = {}> impl
   /**
    * Subscribe to the scene event
    **/
-  subscribeToEvent<T extends BusEvent>(eventType: BusEventType<T>, handler: BusEventHandler<T>): Unsubscribable {
+  public subscribeToEvent<T extends BusEvent>(eventType: BusEventType<T>, handler: BusEventHandler<T>): Unsubscribable {
     return this._events.subscribe(eventType, handler);
   }
 
-  setState(update: Partial<TState>) {
+  public setState(update: Partial<TState>) {
     const prevState = this._state;
     this._state = {
       ...this._state,
@@ -112,7 +112,7 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = {}> impl
   /*
    * Publish an event and optionally bubble it up the scene
    **/
-  publishEvent(event: BusEvent, bubble?: boolean) {
+  public publishEvent(event: BusEvent, bubble?: boolean) {
     this._events.publish(event);
 
     if (bubble && this.parent) {
@@ -120,11 +120,14 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = {}> impl
     }
   }
 
-  getRoot(): SceneObject {
+  public getRoot(): SceneObject {
     return !this._parent ? this : this._parent.getRoot();
   }
 
-  activate() {
+  /**
+   * Called by the SceneComponentWrapper when the react component is mounted
+   */
+  public activate() {
     this._isActive = true;
 
     const { $data, $variables } = this.state;
@@ -138,7 +141,10 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = {}> impl
     }
   }
 
-  deactivate(): void {
+  /**
+   * Called by the SceneComponentWrapper when the react component is unmounted
+   */
+  public deactivate(): void {
     this._isActive = false;
 
     const { $data, $variables } = this.state;
@@ -160,7 +166,10 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = {}> impl
     this._subject = new Subject<TState>();
   }
 
-  useState() {
+  /**
+   * Utility hook to get and subscribe to state
+   */
+  public useState() {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     return useSceneObjectState(this);
   }
@@ -168,7 +177,7 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = {}> impl
   /**
    * Will walk up the scene object graph to the closest $timeRange scene object
    */
-  getTimeRange(): SceneTimeRange {
+  public getTimeRange(): SceneTimeRange {
     const { $timeRange } = this.state;
     if ($timeRange) {
       return $timeRange;
@@ -184,7 +193,7 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = {}> impl
   /**
    * Will walk up the scene object graph to the closest $data scene object
    */
-  getData(): SceneObject<SceneDataState> {
+  public getData(): SceneObject<SceneDataState> {
     const { $data } = this.state;
     if ($data) {
       return $data;
@@ -200,7 +209,7 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = {}> impl
   /**
    * Will walk up the scene object graph to the closest $editor scene object
    */
-  getSceneEditor(): SceneEditor {
+  public getSceneEditor(): SceneEditor {
     const { $editor } = this.state;
     if ($editor) {
       return $editor;
@@ -216,7 +225,7 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = {}> impl
   /**
    * Will create new SceneItem with shalled cloned state, but all states items of type SceneObject are deep cloned
    */
-  clone(withState?: Partial<TState>): this {
+  public clone(withState?: Partial<TState>): this {
     const clonedState = { ...this.state };
 
     // Clone any SceneItems in state

--- a/public/app/features/scenes/core/SceneObjectBase.tsx
+++ b/public/app/features/scenes/core/SceneObjectBase.tsx
@@ -16,7 +16,7 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = {}> impl
   private _events = new EventBusSrv();
 
   protected _parent?: SceneObject;
-  protected subs = new Subscription();
+  protected _subs = new Subscription();
 
   public constructor(state: TState) {
     if (!state.key) {
@@ -159,8 +159,8 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = {}> impl
 
     // Clear subscriptions and listeners
     this._events.removeAllListeners();
-    this.subs.unsubscribe();
-    this.subs = new Subscription();
+    this._subs.unsubscribe();
+    this._subs = new Subscription();
 
     this._subject.complete();
     this._subject = new Subject<TState>();

--- a/public/app/features/scenes/core/SceneObjectBase.tsx
+++ b/public/app/features/scenes/core/SceneObjectBase.tsx
@@ -77,7 +77,7 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = {}> impl
   /**
    * Subscribe to the scene state subject
    **/
-  subscribeToState(observerOrNext?: Partial<Observer<TState>>): Subscription {
+  public subscribeToState(observerOrNext?: Partial<Observer<TState>>): Subscription {
     return this._subject.subscribe(observerOrNext);
   }
 

--- a/public/app/features/scenes/core/SceneTimeRange.tsx
+++ b/public/app/features/scenes/core/SceneTimeRange.tsx
@@ -4,26 +4,26 @@ import { SceneObjectBase } from './SceneObjectBase';
 import { SceneObjectWithUrlSync, SceneTimeRangeState } from './types';
 
 export class SceneTimeRange extends SceneObjectBase<SceneTimeRangeState> implements SceneObjectWithUrlSync {
-  onTimeRangeChange = (timeRange: TimeRange) => {
+  public onTimeRangeChange = (timeRange: TimeRange) => {
     this.setState(timeRange);
   };
 
-  onRefresh = () => {
+  public onRefresh = () => {
     // TODO re-eval time range
     this.setState({ ...this.state });
   };
 
-  onIntervalChanged = (_: string) => {};
+  public onIntervalChanged = (_: string) => {};
 
   /** These url sync functions are only placeholders for something more sophisticated  */
-  getUrlState() {
+  public getUrlState() {
     return {
       from: this.state.raw.from,
       to: this.state.raw.to,
     } as any;
   }
 
-  updateFromUrl(values: UrlQueryMap) {
+  public updateFromUrl(values: UrlQueryMap) {
     // TODO
   }
 }

--- a/public/app/features/scenes/core/events.ts
+++ b/public/app/features/scenes/core/events.ts
@@ -10,12 +10,5 @@ export interface SceneObjectStateChangedPayload {
 }
 
 export class SceneObjectStateChangedEvent extends BusEventWithPayload<SceneObjectStateChangedPayload> {
-  static type = 'scene-object-state-change';
-}
-
-export class SceneObjectActivedEvent extends BusEventWithPayload<SceneObject> {
-  static type = 'scene-object-activated';
-}
-export class SceneObjectDeactivatedEvent extends BusEventWithPayload<SceneObject> {
-  static type = 'scene-object-deactivated';
+  public static readonly type = 'scene-object-state-change';
 }

--- a/public/app/features/scenes/editor/SceneEditManager.tsx
+++ b/public/app/features/scenes/editor/SceneEditManager.tsx
@@ -11,17 +11,17 @@ import { SceneObjectEditor } from './SceneObjectEditor';
 import { SceneObjectTree } from './SceneObjectTree';
 
 export class SceneEditManager extends SceneObjectBase<SceneEditorState> implements SceneEditor {
-  static Component = SceneEditorRenderer;
+  public static Component = SceneEditorRenderer;
 
-  get Component(): SceneComponent<this> {
+  public get Component(): SceneComponent<this> {
     return SceneEditorRenderer;
   }
 
-  onMouseEnterObject(model: SceneObject) {
+  public onMouseEnterObject(model: SceneObject) {
     this.setState({ hoverObject: { ref: model } });
   }
 
-  onMouseLeaveObject(model: SceneObject) {
+  public onMouseLeaveObject(model: SceneObject) {
     if (model.parent) {
       this.setState({ hoverObject: { ref: model.parent } });
     } else {
@@ -29,7 +29,7 @@ export class SceneEditManager extends SceneObjectBase<SceneEditorState> implemen
     }
   }
 
-  onSelectObject(model: SceneObject) {
+  public onSelectObject(model: SceneObject) {
     this.setState({ selectedObject: { ref: model } });
   }
 }

--- a/public/app/features/scenes/querying/SceneQueryRunner.ts
+++ b/public/app/features/scenes/querying/SceneQueryRunner.ts
@@ -31,7 +31,7 @@ export interface DataQueryExtended extends DataQuery {
 export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> {
   private querySub?: Unsubscribable;
 
-  activate() {
+  public activate() {
     super.activate();
 
     const timeRange = this.getTimeRange();
@@ -49,7 +49,7 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> {
     }
   }
 
-  deactivate(): void {
+  public deactivate(): void {
     super.deactivate();
 
     if (this.querySub) {
@@ -58,7 +58,7 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> {
     }
   }
 
-  runQueries() {
+  public runQueries() {
     const timeRange = this.getTimeRange();
     this.runWithTimeRange(timeRange.state);
   }

--- a/public/app/features/scenes/querying/SceneQueryRunner.ts
+++ b/public/app/features/scenes/querying/SceneQueryRunner.ts
@@ -36,7 +36,7 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> {
 
     const timeRange = this.getTimeRange();
 
-    this.subs.add(
+    this._subs.add(
       timeRange.subscribeToState({
         next: (timeRange) => {
           this.runWithTimeRange(timeRange);

--- a/public/app/features/scenes/services/UrlSyncManager.ts
+++ b/public/app/features/scenes/services/UrlSyncManager.ts
@@ -10,16 +10,16 @@ export class UrlSyncManager {
   private locationListenerUnsub: () => void;
   private stateChangeSub: Unsubscribable;
 
-  constructor(sceneRoot: SceneObject) {
+  public constructor(sceneRoot: SceneObject) {
     this.stateChangeSub = sceneRoot.subscribeToEvent(SceneObjectStateChangedEvent, this.onStateChanged);
     this.locationListenerUnsub = locationService.getHistory().listen(this.onLocationUpdate);
   }
 
-  onLocationUpdate = (location: Location) => {
+  private onLocationUpdate = (location: Location) => {
     // TODO: find any scene object whose state we need to update
   };
 
-  onStateChanged = ({ payload }: SceneObjectStateChangedEvent) => {
+  private onStateChanged = ({ payload }: SceneObjectStateChangedEvent) => {
     const changedObject = payload.changedObject;
 
     if ('getUrlState' in changedObject) {
@@ -28,7 +28,7 @@ export class UrlSyncManager {
     }
   };
 
-  cleanUp() {
+  public cleanUp() {
     this.stateChangeSub.unsubscribe();
     this.locationListenerUnsub();
   }

--- a/public/app/features/scenes/variables/SceneVariableSet.ts
+++ b/public/app/features/scenes/variables/SceneVariableSet.ts
@@ -8,7 +8,7 @@ import { SceneVariable, SceneVariables, SceneVariableSetState, SceneVariableStat
 export class TextBoxSceneVariable extends SceneObjectBase<SceneVariableState> implements SceneVariable {}
 
 export class SceneVariableSet extends SceneObjectBase<SceneVariableSetState> implements SceneVariables {
-  getVariableByName(name: string): SceneVariable | undefined {
+  public getVariableByName(name: string): SceneVariable | undefined {
     // TODO: Replace with index
     return this.state.variables.find((x) => x.state.name === name);
   }


### PR DESCRIPTION
n the new dashboard architecture, we have these state object classes that will be used directly by core features and plugins. And base classes that will be extended by plugins to extend and build new things (when we expose this to plugins, exactly how and where these will be exposed is not explored yet).

Anyway it's super important that the public interface of these classes are as locked down as possible (to prevent breaking changes), so only things that need to be accessible from sub-classes should protected and everything else that is not to be accessed from the outside should be private. To make this more explicit it would be nice to be able to mark functions and properties as public, even though this is the default.

