### PR TITLE
Alerting: Fix threshold expression rewire

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/util.test.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/util.test.ts
@@ -94,6 +94,28 @@ describe('rule-editor', () => {
     queryType: '',
   };
 
+  const thresholdExpression = {
+    refId: 'C',
+    datasourceUid: '-100',
+    model: {
+      refId: 'C',
+      type: 'threshold',
+      expression: 'B',
+      datasource: {
+        type: '__expr__',
+        uid: '-100',
+      },
+      conditions: [
+        {
+          evaluator: {
+            params: [0, 'gt'],
+          },
+        },
+      ],
+    },
+    queryType: '',
+  };
+
   describe('rewires query names', () => {
     it('should rewire classic expressions', () => {
       const queries: AlertQuery[] = [dataSource, classicCondition];
@@ -131,6 +153,14 @@ describe('rule-editor', () => {
 
       const queryModel = rewiredQueries[1].model as ExpressionQuery;
       expect(queryModel.expression).toBe('C');
+    });
+
+    it('should rewire threshold expressions', () => {
+      const queries: AlertQuery[] = [dataSource, reduceExpression, thresholdExpression];
+      const rewiredQueries = queriesWithUpdatedReferences(queries, 'B', 'REDUCER');
+
+      const queryModel = rewiredQueries[2].model as ExpressionQuery;
+      expect(queryModel.expression).toBe('REDUCER');
     });
 
     it('should rewire multiple expressions', () => {

--- a/public/app/features/alerting/unified/components/rule-editor/util.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/util.ts
@@ -23,6 +23,7 @@ export function queriesWithUpdatedReferences(
     const isReduceExpression = query.model.type === 'reduce';
     const isResampleExpression = query.model.type === 'resample';
     const isClassicExpression = query.model.type === 'classic_conditions';
+    const isThresholdExpression = query.model.type === 'threshold';
 
     if (isMathExpression) {
       return {
@@ -34,7 +35,7 @@ export function queriesWithUpdatedReferences(
       };
     }
 
-    if (isResampleExpression || isReduceExpression) {
+    if (isResampleExpression || isReduceExpression || isThresholdExpression) {
       const isReferencing = query.model.expression === previousRefId;
 
       return {


### PR DESCRIPTION
When renaming references it now also takes threshold expressions in to account.