### PR TITLE
Refactor: Adjust DeleteFolder to use new signatures & models

### DIFF
--- a/pkg/api/folder.go
+++ b/pkg/api/folder.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/guardian"
 	"github.com/grafana/grafana/pkg/services/libraryelements"
 	"github.com/grafana/grafana/pkg/util"
@@ -175,7 +176,7 @@ func (hs *HTTPServer) DeleteFolder(c *models.ReqContext) response.Response { // 
 	}
 
 	uid := web.Params(c.Req)[":uid"]
-	f, err := hs.folderService.DeleteFolder(c.Req.Context(), c.SignedInUser, c.OrgID, uid, c.QueryBool("forceDeleteRules"))
+	f, err := hs.folderService.DeleteFolder(c.Req.Context(), &folder.DeleteFolderCommand{UID: uid, OrgID: c.OrgID, ForceDeleteRules: c.QueryBool("forceDeleteRules")})
 	if err != nil {
 		return apierrors.ToFolderErrorResponse(err)
 	}
@@ -183,7 +184,7 @@ func (hs *HTTPServer) DeleteFolder(c *models.ReqContext) response.Response { // 
 	return response.JSON(http.StatusOK, util.DynMap{
 		"title":   f.Title,
 		"message": fmt.Sprintf("Folder %s deleted", f.Title),
-		"id":      f.Id,
+		"id":      f.ID,
 	})
 }
 

--- a/pkg/api/folder_test.go
+++ b/pkg/api/folder_test.go
@@ -308,7 +308,7 @@ type fakeFolderService struct {
 	CreateFolderError    error
 	UpdateFolderResult   *models.Folder
 	UpdateFolderError    error
-	DeleteFolderResult   *models.Folder
+	DeleteFolderResult   *folder.Folder
 	DeleteFolderError    error
 	DeletedFolderUids    []string
 }
@@ -334,7 +334,7 @@ func (s *fakeFolderService) UpdateFolder(ctx context.Context, user *user.SignedI
 	return s.UpdateFolderError
 }
 
-func (s *fakeFolderService) DeleteFolder(ctx context.Context, user *user.SignedInUser, orgID int64, uid string, forceDeleteRules bool) (*models.Folder, error) {
-	s.DeletedFolderUids = append(s.DeletedFolderUids, uid)
+func (s *fakeFolderService) DeleteFolder(ctx context.Context, cmd *folder.DeleteFolderCommand) (*folder.Folder, error) {
+	s.DeletedFolderUids = append(s.DeletedFolderUids, cmd.UID)
 	return s.DeleteFolderResult, s.DeleteFolderError
 }

--- a/pkg/services/folder/foldertest/foldertest.go
+++ b/pkg/services/folder/foldertest/foldertest.go
@@ -35,8 +35,8 @@ func (s *FakeService) UpdateFolder(ctx context.Context, user *user.SignedInUser,
 	cmd.Result = s.ExpectedFolder
 	return s.ExpectedError
 }
-func (s *FakeService) DeleteFolder(ctx context.Context, user *user.SignedInUser, orgID int64, uid string, forceDeleteRules bool) (*models.Folder, error) {
-	return s.ExpectedFolder, s.ExpectedError
+func (s *FakeService) DeleteFolder(ctx context.Context, cmd *folder.DeleteFolderCommand) (*folder.Folder, error) {
+	return folder.ConvertModelFolderToFolder(s.ExpectedFolder), s.ExpectedError
 }
 func (s *FakeService) MakeUserAdmin(ctx context.Context, orgID int64, userID, folderID int64, setViewAndEditPermissions bool) error {
 	return s.ExpectedError

--- a/pkg/services/folder/model.go
+++ b/pkg/services/folder/model.go
@@ -24,6 +24,7 @@ type Folder struct {
 	UID         string `xorm:"uid"`
 	ParentUID   string `xorm:"parent_uid"`
 	Title       string
+	URL         string
 	Description string
 
 	Created time.Time
@@ -74,7 +75,9 @@ type MoveFolderCommand struct {
 // DeleteFolderCommand captures the information required by the folder service
 // to delete a folder.
 type DeleteFolderCommand struct {
-	UID string `json:"uid" xorm:"uid"`
+	UID              string `json:"uid" xorm:"uid"`
+	OrgID            int64  `json:"-"`
+	ForceDeleteRules bool   `json:"forceDeleteRules"`
 }
 
 // GetFolderQuery is used for all folder Get requests. Only one of UID, ID, or

--- a/pkg/services/folder/service.go
+++ b/pkg/services/folder/service.go
@@ -14,8 +14,22 @@ type Service interface {
 	GetFolderByTitle(ctx context.Context, user *user.SignedInUser, orgID int64, title string) (*models.Folder, error)
 	CreateFolder(ctx context.Context, user *user.SignedInUser, orgID int64, title, uid string) (*models.Folder, error)
 	UpdateFolder(ctx context.Context, user *user.SignedInUser, orgID int64, existingUid string, cmd *models.UpdateFolderCommand) error
-	DeleteFolder(ctx context.Context, user *user.SignedInUser, orgID int64, uid string, forceDeleteRules bool) (*models.Folder, error)
+	DeleteFolder(ctx context.Context, cmd *DeleteFolderCommand) (*Folder, error)
 	MakeUserAdmin(ctx context.Context, orgID int64, userID, folderID int64, setViewAndEditPermissions bool) error
+}
+
+// TODO: remove when nested folder refactor is done.
+func ConvertModelFolderToFolder(folder *models.Folder) *Folder {
+	if folder == nil {
+		return nil
+	}
+	return &Folder{
+		ID:    folder.Id,
+		UID:   folder.Uid,
+		URL:   folder.Url,
+		Title: folder.Title,
+		// how do we get orgId from models.Folder?
+	}
 }
 
 // NestedFolderService is the temporary interface definition for the folder


### PR DESCRIPTION
Adjust `DeleteFolder` signature to be `DeleteFolder(ctx context.Context, cmd *DeleteFolderCommand) (*Folder, error)` in preparation for nested folders project.