### PR TITLE
Alerting: Set isNoData if isCondNoData

### DIFF
--- a/pkg/expr/classic/classic.go
+++ b/pkg/expr/classic/classic.go
@@ -137,11 +137,6 @@ func (cmd *ConditionsCmd) Execute(_ context.Context, _ time.Time, vars mathexp.V
 		// The condition is no data iff all the input data is a combination of all mathexp.NoData,
 		// mathexp.Number with a nil loat64, or mathexp.Series that reduce to a nil float64
 		isCondNoData = numSeriesNoData == len(series.Values)
-		if isCondNoData {
-			matches = append(matches, EvalMatch{
-				Metric: "NoData",
-			})
-		}
 
 		if ix == 0 {
 			isFiring = isCondFiring
@@ -152,6 +147,13 @@ func (cmd *ConditionsCmd) Execute(_ context.Context, _ time.Time, vars mathexp.V
 		} else {
 			isFiring = isFiring && isCondFiring
 			isNoData = isNoData && isCondNoData
+		}
+
+		if isCondNoData {
+			matches = append(matches, EvalMatch{
+				Metric: "NoData",
+			})
+			isNoData = true
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it:**

In the original `ConditionsCmd` code No Data was set to `true` if `thisCondNoData`, even if the outcome of the `||` or `&&` comparison was `false`.

```
if c.Operator == "or" {
	firing = firing || thisCondFiring
	noDataFound = noDataFound || thisCondNoData
} else {
	firing = firing && thisCondFiring
	noDataFound = noDataFound && thisCondNoData
}

if thisCondNoData {
	matches = append(matches, EvalMatch{
		Metric: "NoData",
	})
        // noDataFound is set to true here
	noDataFound = true
}
```

This line appears to be significant in maintaining the current behaviour of `ConditionsCmd` and was omitted from https://github.com/grafana/grafana/pull/56812.

**Which issue(s) does this PR fix?**:

Fixes #55085

**Special notes for your reviewer**:

