### PR TITLE
Explore: Support fields interpolation in logs panel

### DIFF
--- a/public/app/features/explore/Logs.tsx
+++ b/public/app/features/explore/Logs.tsx
@@ -79,7 +79,7 @@ interface Props extends Themeable2 {
   onStartScanning?: () => void;
   onStopScanning?: () => void;
   getRowContext?: (row: LogRowModel, options?: RowContextOptions) => Promise<any>;
-  getFieldLinks: (field: Field, rowIndex: number) => Array<LinkModel<Field>>;
+  getFieldLinks: (field: Field, rowIndex: number, dataFrame: DataFrame) => Array<LinkModel<Field>>;
   addResultsToCache: () => void;
   clearCache: () => void;
   eventBus: EventBus;

--- a/public/app/features/explore/LogsContainer.tsx
+++ b/public/app/features/explore/LogsContainer.tsx
@@ -10,6 +10,7 @@ import {
   RawTimeRange,
   EventBus,
   SplitOpen,
+  DataFrame,
 } from '@grafana/data';
 import { Collapse } from '@grafana/ui';
 import { StoreState } from 'app/types';
@@ -71,9 +72,9 @@ class LogsContainer extends PureComponent<LogsContainerProps> {
     return false;
   };
 
-  getFieldLinks = (field: Field, rowIndex: number) => {
+  getFieldLinks = (field: Field, rowIndex: number, dataFrame: DataFrame) => {
     const { splitOpenFn, range } = this.props;
-    return getFieldLinksForExplore({ field, rowIndex, splitOpenFn, range });
+    return getFieldLinksForExplore({ field, rowIndex, splitOpenFn, range, dataFrame });
   };
 
   render() {

--- a/public/app/features/logs/components/LogDetails.tsx
+++ b/public/app/features/logs/components/LogDetails.tsx
@@ -2,7 +2,7 @@ import { css, cx } from '@emotion/css';
 import memoizeOne from 'memoize-one';
 import React, { PureComponent } from 'react';
 
-import { Field, LinkModel, LogRowModel, GrafanaTheme2, CoreApp } from '@grafana/data';
+import { Field, LinkModel, LogRowModel, GrafanaTheme2, CoreApp, DataFrame } from '@grafana/data';
 import { withTheme2, Themeable2, Icon, Tooltip } from '@grafana/ui';
 
 import { calculateFieldStats, calculateLogsLabelStats, calculateStats, getParser } from '../utils';
@@ -24,7 +24,7 @@ export interface Props extends Themeable2 {
 
   onClickFilterLabel?: (key: string, value: string) => void;
   onClickFilterOutLabel?: (key: string, value: string) => void;
-  getFieldLinks?: (field: Field, rowIndex: number) => Array<LinkModel<Field>>;
+  getFieldLinks?: (field: Field, rowIndex: number, dataFrame: DataFrame) => Array<LinkModel<Field>>;
   showDetectedFields?: string[];
   onClickShowDetectedField?: (key: string) => void;
   onClickHideDetectedField?: (key: string) => void;

--- a/public/app/features/logs/components/LogRow.tsx
+++ b/public/app/features/logs/components/LogRow.tsx
@@ -11,6 +11,7 @@ import {
   dateTimeFormat,
   GrafanaTheme2,
   CoreApp,
+  DataFrame,
 } from '@grafana/data';
 import { reportInteraction } from '@grafana/runtime';
 import { styleMixins, withTheme2, Themeable2, Icon, Tooltip } from '@grafana/ui';
@@ -52,7 +53,7 @@ interface Props extends Themeable2 {
   onClickFilterOutLabel?: (key: string, value: string) => void;
   onContextClick?: () => void;
   getRowContext: (row: LogRowModel, options?: RowContextOptions) => Promise<DataQueryResponse>;
-  getFieldLinks?: (field: Field, rowIndex: number) => Array<LinkModel<Field>>;
+  getFieldLinks?: (field: Field, rowIndex: number, dataFrame: DataFrame) => Array<LinkModel<Field>>;
   showContextToggle?: (row?: LogRowModel) => boolean;
   onClickShowDetectedField?: (key: string) => void;
   onClickHideDetectedField?: (key: string) => void;

--- a/public/app/features/logs/components/LogRowMessageDetectedFields.tsx
+++ b/public/app/features/logs/components/LogRowMessageDetectedFields.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 import React, { PureComponent } from 'react';
 
-import { LogRowModel, Field, LinkModel } from '@grafana/data';
+import { LogRowModel, Field, LinkModel, DataFrame } from '@grafana/data';
 import { withTheme2, Themeable2 } from '@grafana/ui';
 
 import { getAllFields } from './logParser';
@@ -10,7 +10,7 @@ export interface Props extends Themeable2 {
   row: LogRowModel;
   showDetectedFields: string[];
   wrapLogMessage: boolean;
-  getFieldLinks?: (field: Field, rowIndex: number) => Array<LinkModel<Field>>;
+  getFieldLinks?: (field: Field, rowIndex: number, dataFrame: DataFrame) => Array<LinkModel<Field>>;
 }
 
 class UnThemedLogRowMessageDetectedFields extends PureComponent<Props> {

--- a/public/app/features/logs/components/LogRows.tsx
+++ b/public/app/features/logs/components/LogRows.tsx
@@ -1,7 +1,16 @@
 import memoizeOne from 'memoize-one';
 import React, { PureComponent } from 'react';
 
-import { TimeZone, LogsDedupStrategy, LogRowModel, Field, LinkModel, LogsSortOrder, CoreApp } from '@grafana/data';
+import {
+  TimeZone,
+  LogsDedupStrategy,
+  LogRowModel,
+  Field,
+  LinkModel,
+  LogsSortOrder,
+  CoreApp,
+  DataFrame,
+} from '@grafana/data';
 import { withTheme2, Themeable2 } from '@grafana/ui';
 
 import { sortLogRows } from '../utils';
@@ -33,7 +42,7 @@ export interface Props extends Themeable2 {
   onClickFilterLabel?: (key: string, value: string) => void;
   onClickFilterOutLabel?: (key: string, value: string) => void;
   getRowContext?: (row: LogRowModel, options?: RowContextOptions) => Promise<any>;
-  getFieldLinks?: (field: Field, rowIndex: number) => Array<LinkModel<Field>>;
+  getFieldLinks?: (field: Field, rowIndex: number, dataFrame: DataFrame) => Array<LinkModel<Field>>;
   onClickShowDetectedField?: (key: string) => void;
   onClickHideDetectedField?: (key: string) => void;
   onLogRowHover?: (row?: LogRowModel) => void;


### PR DESCRIPTION
**What this PR does / why we need it**:

The logic to interpolate the query of a data link supports using field values from the same row but to make it work the component needs to pass `DataFrame` object so the interpolation logic can extract it. LogPanel doesn't pass `DataFrame` (I guess because it never intended to support anything else but traceId).

With this change, other field values can be used in the interpolated query in generic data links but it also can be useful in old-fashioned plugin data links inside external URLs.

This will enable more complex flows with generic links (see videos in _How to test it_ section), examples:
* Running metrics query based on multiple fields from the log line
* Running log queries based on metric labels (only in a table view for now [^table])
* It's also now possible to run a trace query using generic data links

**Which issue(s) this PR fixes**:

Relates to #58235

**Special notes for your reviewer**:

<details><summary>How to test it</summary>

* Grab https://github.com/grafana/tns
* Go to `/production/docker`
* Change Grafana port so it doesn't clash with you local Grafana instance
* Spin the docker image

Use the following provisioning file for tns:  https://gist.github.com/ifrost/1bb1340d20c460c85db24406eabd2531

Run sample queries (check comments in provisioning file or videos below):

https://user-images.githubusercontent.com/745532/200581824-9eea6f31-c1f3-4418-8ce4-a39fd16bd46f.mov

https://user-images.githubusercontent.com/745532/200581891-8409b807-1a22-40b9-9af2-91994e1fb883.mov

</details>

[^table]: In the provisioned file there's a link that opens metrics for given log level in a table view (_Show metrics with this level_). This is because adding generic data links with field values to a graph view doesn't make much sense yet. The only fields that can be used in a graph view are `Time` and `Value`. Once we introduce transformations it will be possible to create flows like with the table and opening logs for metrics using not only field values, but also labels.