### PR TITLE
Alerting: Change TestConditionsCmd to assert on mathexp.Results

### DIFF
--- a/pkg/expr/classic/classic_test.go
+++ b/pkg/expr/classic/classic_test.go
@@ -15,10 +15,10 @@ import (
 
 func TestConditionsCmd(t *testing.T) {
 	tests := []struct {
-		name          string
-		vars          mathexp.Vars
-		conditionsCmd *ConditionsCmd
-		resultNumber  func() mathexp.Number
+		name     string
+		cmd      *ConditionsCmd
+		vars     mathexp.Vars
+		expected func() mathexp.Results
 	}{
 		{
 			name: "single query and single condition",
@@ -29,7 +29,7 @@ func TestConditionsCmd(t *testing.T) {
 					},
 				},
 			},
-			conditionsCmd: &ConditionsCmd{
+			cmd: &ConditionsCmd{
 				Conditions: []condition{
 					{
 						InputRefID: "A",
@@ -38,10 +38,10 @@ func TestConditionsCmd(t *testing.T) {
 						Evaluator:  &thresholdEvaluator{Type: "gt", Threshold: 34},
 					},
 				}},
-			resultNumber: func() mathexp.Number {
+			expected: func() mathexp.Results {
 				v := valBasedNumber(ptr.Float64(1))
 				v.SetMeta([]EvalMatch{{Value: ptr.Float64(35)}})
-				return v
+				return mathexp.NewResults(v)
 			},
 		},
 		{
@@ -53,7 +53,7 @@ func TestConditionsCmd(t *testing.T) {
 					},
 				},
 			},
-			conditionsCmd: &ConditionsCmd{
+			cmd: &ConditionsCmd{
 				Conditions: []condition{
 					{
 						InputRefID: "A",
@@ -62,10 +62,10 @@ func TestConditionsCmd(t *testing.T) {
 						Evaluator:  &thresholdEvaluator{Type: "gt", Threshold: 34},
 					},
 				}},
-			resultNumber: func() mathexp.Number {
+			expected: func() mathexp.Results {
 				v := valBasedNumber(nil)
 				v.SetMeta([]EvalMatch{{Metric: "NoData"}})
-				return v
+				return mathexp.NewResults(v)
 			},
 		},
 		{
@@ -78,7 +78,7 @@ func TestConditionsCmd(t *testing.T) {
 					},
 				},
 			},
-			conditionsCmd: &ConditionsCmd{
+			cmd: &ConditionsCmd{
 				Conditions: []condition{
 					{
 						InputRefID: "A",
@@ -87,10 +87,10 @@ func TestConditionsCmd(t *testing.T) {
 						Evaluator:  &thresholdEvaluator{Type: "gt", Threshold: .5},
 					},
 				}},
-			resultNumber: func() mathexp.Number {
+			expected: func() mathexp.Results {
 				v := valBasedNumber(ptr.Float64(1))
 				v.SetMeta([]EvalMatch{{Value: ptr.Float64(3)}})
-				return v
+				return mathexp.NewResults(v)
 			},
 		},
 		{
@@ -102,7 +102,7 @@ func TestConditionsCmd(t *testing.T) {
 					},
 				},
 			},
-			conditionsCmd: &ConditionsCmd{
+			cmd: &ConditionsCmd{
 				Conditions: []condition{
 					{
 						InputRefID: "A",
@@ -116,10 +116,10 @@ func TestConditionsCmd(t *testing.T) {
 						Evaluator:  &thresholdEvaluator{Type: "gt", Threshold: 12},
 					},
 				}},
-			resultNumber: func() mathexp.Number {
+			expected: func() mathexp.Results {
 				v := valBasedNumber(ptr.Float64(1))
 				v.SetMeta([]EvalMatch{{Value: ptr.Float64(40)}, {Value: ptr.Float64(30)}})
-				return v
+				return mathexp.NewResults(v)
 			},
 		},
 		{
@@ -132,7 +132,7 @@ func TestConditionsCmd(t *testing.T) {
 					},
 				},
 			},
-			conditionsCmd: &ConditionsCmd{
+			cmd: &ConditionsCmd{
 				Conditions: []condition{
 					{
 						InputRefID: "A",
@@ -141,10 +141,10 @@ func TestConditionsCmd(t *testing.T) {
 						Evaluator:  &thresholdEvaluator{Type: "gt", Threshold: 34},
 					},
 				}},
-			resultNumber: func() mathexp.Number {
+			expected: func() mathexp.Results {
 				v := valBasedNumber(ptr.Float64(1))
 				v.SetMeta([]EvalMatch{{Value: ptr.Float64(35), Labels: data.Labels{"h": "1"}}})
-				return v
+				return mathexp.NewResults(v)
 			},
 		},
 		{
@@ -157,7 +157,7 @@ func TestConditionsCmd(t *testing.T) {
 					},
 				},
 			},
-			conditionsCmd: &ConditionsCmd{
+			cmd: &ConditionsCmd{
 				Conditions: []condition{
 					{
 						InputRefID: "A",
@@ -166,10 +166,10 @@ func TestConditionsCmd(t *testing.T) {
 						Evaluator:  &thresholdEvaluator{Type: "gt", Threshold: 34},
 					},
 				}},
-			resultNumber: func() mathexp.Number {
+			expected: func() mathexp.Results {
 				v := valBasedNumber(ptr.Float64(1))
 				v.SetMeta([]EvalMatch{{Value: ptr.Float64(35)}})
-				return v
+				return mathexp.NewResults(v)
 			},
 		},
 		{
@@ -182,7 +182,7 @@ func TestConditionsCmd(t *testing.T) {
 					},
 				},
 			},
-			conditionsCmd: &ConditionsCmd{
+			cmd: &ConditionsCmd{
 				Conditions: []condition{
 					{
 						InputRefID: "A",
@@ -191,10 +191,10 @@ func TestConditionsCmd(t *testing.T) {
 						Evaluator:  &thresholdEvaluator{Type: "gt", Threshold: 34},
 					},
 				}},
-			resultNumber: func() mathexp.Number {
+			expected: func() mathexp.Results {
 				v := valBasedNumber(ptr.Float64(0))
 				v.SetMeta([]EvalMatch{})
-				return v
+				return mathexp.Results{Values: mathexp.Values{v}}
 			},
 		},
 		{
@@ -206,7 +206,7 @@ func TestConditionsCmd(t *testing.T) {
 					},
 				},
 			},
-			conditionsCmd: &ConditionsCmd{
+			cmd: &ConditionsCmd{
 				Conditions: []condition{
 					{
 						InputRefID: "A",
@@ -216,10 +216,10 @@ func TestConditionsCmd(t *testing.T) {
 					},
 				},
 			},
-			resultNumber: func() mathexp.Number {
+			expected: func() mathexp.Results {
 				v := valBasedNumber(ptr.Float64(0))
 				v.SetMeta([]EvalMatch{})
-				return v
+				return mathexp.NewResults(v)
 			},
 		},
 		{
@@ -229,7 +229,7 @@ func TestConditionsCmd(t *testing.T) {
 					Values: []mathexp.Value{mathexp.NoData{}.New()},
 				},
 			},
-			conditionsCmd: &ConditionsCmd{
+			cmd: &ConditionsCmd{
 				Conditions: []condition{
 					{
 						InputRefID: "A",
@@ -239,10 +239,10 @@ func TestConditionsCmd(t *testing.T) {
 					},
 				},
 			},
-			resultNumber: func() mathexp.Number {
+			expected: func() mathexp.Results {
 				v := valBasedNumber(nil)
 				v.SetMeta([]EvalMatch{{Metric: "NoData"}})
-				return v
+				return mathexp.NewResults(v)
 			},
 		},
 		{
@@ -252,7 +252,7 @@ func TestConditionsCmd(t *testing.T) {
 					Values: []mathexp.Value{},
 				},
 			},
-			conditionsCmd: &ConditionsCmd{
+			cmd: &ConditionsCmd{
 				Conditions: []condition{
 					{
 						InputRefID: "A",
@@ -262,10 +262,10 @@ func TestConditionsCmd(t *testing.T) {
 					},
 				},
 			},
-			resultNumber: func() mathexp.Number {
+			expected: func() mathexp.Results {
 				v := valBasedNumber(nil)
 				v.SetMeta([]EvalMatch{{Metric: "NoData"}})
-				return v
+				return mathexp.NewResults(v)
 			},
 		},
 		{
@@ -279,7 +279,7 @@ func TestConditionsCmd(t *testing.T) {
 					},
 				},
 			},
-			conditionsCmd: &ConditionsCmd{
+			cmd: &ConditionsCmd{
 				Conditions: []condition{
 					{
 						InputRefID: "A",
@@ -289,26 +289,26 @@ func TestConditionsCmd(t *testing.T) {
 					},
 				},
 			},
-			resultNumber: func() mathexp.Number {
+			expected: func() mathexp.Results {
 				v := valBasedNumber(ptr.Float64(1))
 				v.SetMeta([]EvalMatch{
 					{Value: ptr.Float64(5)},
 					{Value: ptr.Float64(10)},
 					{Value: ptr.Float64(15)},
 				})
-				return v
+				return mathexp.NewResults(v)
 			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			res, err := tt.conditionsCmd.Execute(context.Background(), time.Now(), tt.vars)
+			res, err := tt.cmd.Execute(context.Background(), time.Now(), tt.vars)
 			require.NoError(t, err)
 
 			require.Equal(t, 1, len(res.Values))
 
-			require.Equal(t, tt.resultNumber(), res.Values[0])
+			require.Equal(t, tt.expected(), res)
 		})
 	}
 }

--- a/pkg/expr/classic/classic_test.go
+++ b/pkg/expr/classic/classic_test.go
@@ -19,287 +19,275 @@ func TestConditionsCmd(t *testing.T) {
 		cmd      *ConditionsCmd
 		vars     mathexp.Vars
 		expected func() mathexp.Results
-	}{
-		{
-			name: "single query and single condition",
-			vars: mathexp.Vars{
-				"A": mathexp.Results{
-					Values: []mathexp.Value{
-						valBasedSeries(ptr.Float64(30), ptr.Float64(40)),
-					},
+	}{{
+		name: "single query and single condition",
+		vars: mathexp.Vars{
+			"A": mathexp.Results{
+				Values: []mathexp.Value{
+					valBasedSeries(ptr.Float64(30), ptr.Float64(40)),
 				},
-			},
-			cmd: &ConditionsCmd{
-				Conditions: []condition{
-					{
-						InputRefID: "A",
-						Reducer:    reducer("avg"),
-						Operator:   "and",
-						Evaluator:  &thresholdEvaluator{Type: "gt", Threshold: 34},
-					},
-				}},
-			expected: func() mathexp.Results {
-				v := valBasedNumber(ptr.Float64(1))
-				v.SetMeta([]EvalMatch{{Value: ptr.Float64(35)}})
-				return mathexp.NewResults(v)
 			},
 		},
-		{
-			name: "single query and single condition - empty series",
-			vars: mathexp.Vars{
-				"A": mathexp.Results{
-					Values: []mathexp.Value{
-						valBasedSeries(),
-					},
+		cmd: &ConditionsCmd{
+			Conditions: []condition{
+				{
+					InputRefID: "A",
+					Reducer:    reducer("avg"),
+					Operator:   "and",
+					Evaluator:  &thresholdEvaluator{Type: "gt", Threshold: 34},
 				},
-			},
-			cmd: &ConditionsCmd{
-				Conditions: []condition{
-					{
-						InputRefID: "A",
-						Reducer:    reducer("avg"),
-						Operator:   "and",
-						Evaluator:  &thresholdEvaluator{Type: "gt", Threshold: 34},
-					},
-				}},
-			expected: func() mathexp.Results {
-				v := valBasedNumber(nil)
-				v.SetMeta([]EvalMatch{{Metric: "NoData"}})
-				return mathexp.NewResults(v)
+			}},
+		expected: func() mathexp.Results {
+			v := valBasedNumber(ptr.Float64(1))
+			v.SetMeta([]EvalMatch{{Value: ptr.Float64(35)}})
+			return mathexp.NewResults(v)
+		},
+	}, {
+		name: "single query and single condition - empty series",
+		vars: mathexp.Vars{
+			"A": mathexp.Results{
+				Values: []mathexp.Value{
+					valBasedSeries(),
+				},
 			},
 		},
-		{
-			name: "single query and single condition - empty series and not empty series",
-			vars: mathexp.Vars{
-				"A": mathexp.Results{
-					Values: []mathexp.Value{
-						valBasedSeries(),
-						valBasedSeries(ptr.Float64(3)),
-					},
+		cmd: &ConditionsCmd{
+			Conditions: []condition{
+				{
+					InputRefID: "A",
+					Reducer:    reducer("avg"),
+					Operator:   "and",
+					Evaluator:  &thresholdEvaluator{Type: "gt", Threshold: 34},
 				},
-			},
-			cmd: &ConditionsCmd{
-				Conditions: []condition{
-					{
-						InputRefID: "A",
-						Reducer:    reducer("avg"),
-						Operator:   "and",
-						Evaluator:  &thresholdEvaluator{Type: "gt", Threshold: .5},
-					},
-				}},
-			expected: func() mathexp.Results {
-				v := valBasedNumber(ptr.Float64(1))
-				v.SetMeta([]EvalMatch{{Value: ptr.Float64(3)}})
-				return mathexp.NewResults(v)
+			}},
+		expected: func() mathexp.Results {
+			v := valBasedNumber(nil)
+			v.SetMeta([]EvalMatch{{Metric: "NoData"}})
+			return mathexp.NewResults(v)
+		},
+	}, {
+		name: "single query and single condition - empty series and not empty series",
+		vars: mathexp.Vars{
+			"A": mathexp.Results{
+				Values: []mathexp.Value{
+					valBasedSeries(),
+					valBasedSeries(ptr.Float64(3)),
+				},
 			},
 		},
-		{
-			name: "single query and two conditions",
-			vars: mathexp.Vars{
-				"A": mathexp.Results{
-					Values: []mathexp.Value{
-						valBasedSeries(ptr.Float64(30), ptr.Float64(40)),
-					},
+		cmd: &ConditionsCmd{
+			Conditions: []condition{
+				{
+					InputRefID: "A",
+					Reducer:    reducer("avg"),
+					Operator:   "and",
+					Evaluator:  &thresholdEvaluator{Type: "gt", Threshold: .5},
 				},
-			},
-			cmd: &ConditionsCmd{
-				Conditions: []condition{
-					{
-						InputRefID: "A",
-						Reducer:    reducer("max"),
-						Evaluator:  &thresholdEvaluator{Type: "gt", Threshold: 34},
-					},
-					{
-						InputRefID: "A",
-						Reducer:    reducer("min"),
-						Operator:   "or",
-						Evaluator:  &thresholdEvaluator{Type: "gt", Threshold: 12},
-					},
-				}},
-			expected: func() mathexp.Results {
-				v := valBasedNumber(ptr.Float64(1))
-				v.SetMeta([]EvalMatch{{Value: ptr.Float64(40)}, {Value: ptr.Float64(30)}})
-				return mathexp.NewResults(v)
+			}},
+		expected: func() mathexp.Results {
+			v := valBasedNumber(ptr.Float64(1))
+			v.SetMeta([]EvalMatch{{Value: ptr.Float64(3)}})
+			return mathexp.NewResults(v)
+		},
+	}, {
+		name: "single query and two conditions",
+		vars: mathexp.Vars{
+			"A": mathexp.Results{
+				Values: []mathexp.Value{
+					valBasedSeries(ptr.Float64(30), ptr.Float64(40)),
+				},
 			},
 		},
-		{
-			name: "single query and single condition - multiple series (one true, one not == true)",
-			vars: mathexp.Vars{
-				"A": mathexp.Results{
-					Values: []mathexp.Value{
-						valBasedSeriesWithLabels(data.Labels{"h": "1"}, ptr.Float64(30), ptr.Float64(40)),
-						valBasedSeries(ptr.Float64(0), ptr.Float64(10)),
-					},
+		cmd: &ConditionsCmd{
+			Conditions: []condition{
+				{
+					InputRefID: "A",
+					Reducer:    reducer("max"),
+					Evaluator:  &thresholdEvaluator{Type: "gt", Threshold: 34},
 				},
-			},
-			cmd: &ConditionsCmd{
-				Conditions: []condition{
-					{
-						InputRefID: "A",
-						Reducer:    reducer("avg"),
-						Operator:   "and",
-						Evaluator:  &thresholdEvaluator{Type: "gt", Threshold: 34},
-					},
-				}},
-			expected: func() mathexp.Results {
-				v := valBasedNumber(ptr.Float64(1))
-				v.SetMeta([]EvalMatch{{Value: ptr.Float64(35), Labels: data.Labels{"h": "1"}}})
-				return mathexp.NewResults(v)
+				{
+					InputRefID: "A",
+					Reducer:    reducer("min"),
+					Operator:   "or",
+					Evaluator:  &thresholdEvaluator{Type: "gt", Threshold: 12},
+				},
+			}},
+		expected: func() mathexp.Results {
+			v := valBasedNumber(ptr.Float64(1))
+			v.SetMeta([]EvalMatch{{Value: ptr.Float64(40)}, {Value: ptr.Float64(30)}})
+			return mathexp.NewResults(v)
+		},
+	}, {
+		name: "single query and single condition - multiple series (one true, one not == true)",
+		vars: mathexp.Vars{
+			"A": mathexp.Results{
+				Values: []mathexp.Value{
+					valBasedSeriesWithLabels(data.Labels{"h": "1"}, ptr.Float64(30), ptr.Float64(40)),
+					valBasedSeries(ptr.Float64(0), ptr.Float64(10)),
+				},
 			},
 		},
-		{
-			name: "single query and single condition - multiple series (one not true, one true == true)",
-			vars: mathexp.Vars{
-				"A": mathexp.Results{
-					Values: []mathexp.Value{
-						valBasedSeries(ptr.Float64(0), ptr.Float64(10)),
-						valBasedSeries(ptr.Float64(30), ptr.Float64(40)),
-					},
+		cmd: &ConditionsCmd{
+			Conditions: []condition{
+				{
+					InputRefID: "A",
+					Reducer:    reducer("avg"),
+					Operator:   "and",
+					Evaluator:  &thresholdEvaluator{Type: "gt", Threshold: 34},
 				},
-			},
-			cmd: &ConditionsCmd{
-				Conditions: []condition{
-					{
-						InputRefID: "A",
-						Reducer:    reducer("avg"),
-						Operator:   "and",
-						Evaluator:  &thresholdEvaluator{Type: "gt", Threshold: 34},
-					},
-				}},
-			expected: func() mathexp.Results {
-				v := valBasedNumber(ptr.Float64(1))
-				v.SetMeta([]EvalMatch{{Value: ptr.Float64(35)}})
-				return mathexp.NewResults(v)
+			}},
+		expected: func() mathexp.Results {
+			v := valBasedNumber(ptr.Float64(1))
+			v.SetMeta([]EvalMatch{{Value: ptr.Float64(35), Labels: data.Labels{"h": "1"}}})
+			return mathexp.NewResults(v)
+		},
+	}, {
+		name: "single query and single condition - multiple series (one not true, one true == true)",
+		vars: mathexp.Vars{
+			"A": mathexp.Results{
+				Values: []mathexp.Value{
+					valBasedSeries(ptr.Float64(0), ptr.Float64(10)),
+					valBasedSeries(ptr.Float64(30), ptr.Float64(40)),
+				},
 			},
 		},
-		{
-			name: "single query and single condition - multiple series (2 not true == false)",
-			vars: mathexp.Vars{
-				"A": mathexp.Results{
-					Values: []mathexp.Value{
-						valBasedSeries(ptr.Float64(0), ptr.Float64(10)),
-						valBasedSeries(ptr.Float64(20), ptr.Float64(30)),
-					},
+		cmd: &ConditionsCmd{
+			Conditions: []condition{
+				{
+					InputRefID: "A",
+					Reducer:    reducer("avg"),
+					Operator:   "and",
+					Evaluator:  &thresholdEvaluator{Type: "gt", Threshold: 34},
 				},
-			},
-			cmd: &ConditionsCmd{
-				Conditions: []condition{
-					{
-						InputRefID: "A",
-						Reducer:    reducer("avg"),
-						Operator:   "and",
-						Evaluator:  &thresholdEvaluator{Type: "gt", Threshold: 34},
-					},
-				}},
-			expected: func() mathexp.Results {
-				v := valBasedNumber(ptr.Float64(0))
-				v.SetMeta([]EvalMatch{})
-				return mathexp.Results{Values: mathexp.Values{v}}
+			}},
+		expected: func() mathexp.Results {
+			v := valBasedNumber(ptr.Float64(1))
+			v.SetMeta([]EvalMatch{{Value: ptr.Float64(35)}})
+			return mathexp.NewResults(v)
+		},
+	}, {
+		name: "single query and single condition - multiple series (2 not true == false)",
+		vars: mathexp.Vars{
+			"A": mathexp.Results{
+				Values: []mathexp.Value{
+					valBasedSeries(ptr.Float64(0), ptr.Float64(10)),
+					valBasedSeries(ptr.Float64(20), ptr.Float64(30)),
+				},
 			},
 		},
-		{
-			name: "single query and single ranged condition",
-			vars: mathexp.Vars{
-				"A": mathexp.Results{
-					Values: []mathexp.Value{
-						valBasedSeries(ptr.Float64(30), ptr.Float64(40)),
-					},
+		cmd: &ConditionsCmd{
+			Conditions: []condition{
+				{
+					InputRefID: "A",
+					Reducer:    reducer("avg"),
+					Operator:   "and",
+					Evaluator:  &thresholdEvaluator{Type: "gt", Threshold: 34},
 				},
-			},
-			cmd: &ConditionsCmd{
-				Conditions: []condition{
-					{
-						InputRefID: "A",
-						Reducer:    reducer("diff"),
-						Operator:   "and",
-						Evaluator:  &rangedEvaluator{Type: "within_range", Lower: 2, Upper: 3},
-					},
+			}},
+		expected: func() mathexp.Results {
+			v := valBasedNumber(ptr.Float64(0))
+			v.SetMeta([]EvalMatch{})
+			return mathexp.Results{Values: mathexp.Values{v}}
+		},
+	}, {
+		name: "single query and single ranged condition",
+		vars: mathexp.Vars{
+			"A": mathexp.Results{
+				Values: []mathexp.Value{
+					valBasedSeries(ptr.Float64(30), ptr.Float64(40)),
 				},
-			},
-			expected: func() mathexp.Results {
-				v := valBasedNumber(ptr.Float64(0))
-				v.SetMeta([]EvalMatch{})
-				return mathexp.NewResults(v)
 			},
 		},
-		{
-			name: "single query with no data",
-			vars: mathexp.Vars{
-				"A": mathexp.Results{
-					Values: []mathexp.Value{mathexp.NoData{}.New()},
+		cmd: &ConditionsCmd{
+			Conditions: []condition{
+				{
+					InputRefID: "A",
+					Reducer:    reducer("diff"),
+					Operator:   "and",
+					Evaluator:  &rangedEvaluator{Type: "within_range", Lower: 2, Upper: 3},
 				},
-			},
-			cmd: &ConditionsCmd{
-				Conditions: []condition{
-					{
-						InputRefID: "A",
-						Reducer:    reducer("avg"),
-						Operator:   "and",
-						Evaluator:  &thresholdEvaluator{"gt", 1},
-					},
-				},
-			},
-			expected: func() mathexp.Results {
-				v := valBasedNumber(nil)
-				v.SetMeta([]EvalMatch{{Metric: "NoData"}})
-				return mathexp.NewResults(v)
 			},
 		},
-		{
-			name: "single query with no values",
-			vars: mathexp.Vars{
-				"A": mathexp.Results{
-					Values: []mathexp.Value{},
-				},
-			},
-			cmd: &ConditionsCmd{
-				Conditions: []condition{
-					{
-						InputRefID: "A",
-						Reducer:    reducer("avg"),
-						Operator:   "and",
-						Evaluator:  &thresholdEvaluator{"gt", 1},
-					},
-				},
-			},
-			expected: func() mathexp.Results {
-				v := valBasedNumber(nil)
-				v.SetMeta([]EvalMatch{{Metric: "NoData"}})
-				return mathexp.NewResults(v)
+		expected: func() mathexp.Results {
+			v := valBasedNumber(ptr.Float64(0))
+			v.SetMeta([]EvalMatch{})
+			return mathexp.NewResults(v)
+		},
+	}, {
+		name: "single query with no data",
+		vars: mathexp.Vars{
+			"A": mathexp.Results{
+				Values: []mathexp.Value{mathexp.NoData{}.New()},
 			},
 		},
-		{
-			name: "should accept numbers",
-			vars: mathexp.Vars{
-				"A": mathexp.Results{
-					Values: []mathexp.Value{
-						valBasedNumber(ptr.Float64(5)),
-						valBasedNumber(ptr.Float64(10)),
-						valBasedNumber(ptr.Float64(15)),
-					},
+		cmd: &ConditionsCmd{
+			Conditions: []condition{
+				{
+					InputRefID: "A",
+					Reducer:    reducer("avg"),
+					Operator:   "and",
+					Evaluator:  &thresholdEvaluator{"gt", 1},
 				},
-			},
-			cmd: &ConditionsCmd{
-				Conditions: []condition{
-					{
-						InputRefID: "A",
-						Reducer:    reducer("avg"),
-						Operator:   "and",
-						Evaluator:  &thresholdEvaluator{"gt", 1},
-					},
-				},
-			},
-			expected: func() mathexp.Results {
-				v := valBasedNumber(ptr.Float64(1))
-				v.SetMeta([]EvalMatch{
-					{Value: ptr.Float64(5)},
-					{Value: ptr.Float64(10)},
-					{Value: ptr.Float64(15)},
-				})
-				return mathexp.NewResults(v)
 			},
 		},
-	}
+		expected: func() mathexp.Results {
+			v := valBasedNumber(nil)
+			v.SetMeta([]EvalMatch{{Metric: "NoData"}})
+			return mathexp.NewResults(v)
+		},
+	}, {
+		name: "single query with no values",
+		vars: mathexp.Vars{
+			"A": mathexp.Results{
+				Values: []mathexp.Value{},
+			},
+		},
+		cmd: &ConditionsCmd{
+			Conditions: []condition{
+				{
+					InputRefID: "A",
+					Reducer:    reducer("avg"),
+					Operator:   "and",
+					Evaluator:  &thresholdEvaluator{"gt", 1},
+				},
+			},
+		},
+		expected: func() mathexp.Results {
+			v := valBasedNumber(nil)
+			v.SetMeta([]EvalMatch{{Metric: "NoData"}})
+			return mathexp.NewResults(v)
+		},
+	}, {
+		name: "should accept numbers",
+		vars: mathexp.Vars{
+			"A": mathexp.Results{
+				Values: []mathexp.Value{
+					valBasedNumber(ptr.Float64(5)),
+					valBasedNumber(ptr.Float64(10)),
+					valBasedNumber(ptr.Float64(15)),
+				},
+			},
+		},
+		cmd: &ConditionsCmd{
+			Conditions: []condition{
+				{
+					InputRefID: "A",
+					Reducer:    reducer("avg"),
+					Operator:   "and",
+					Evaluator:  &thresholdEvaluator{"gt", 1},
+				},
+			},
+		},
+		expected: func() mathexp.Results {
+			v := valBasedNumber(ptr.Float64(1))
+			v.SetMeta([]EvalMatch{
+				{Value: ptr.Float64(5)},
+				{Value: ptr.Float64(10)},
+				{Value: ptr.Float64(15)},
+			})
+			return mathexp.NewResults(v)
+		},
+	}}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/expr/mathexp/types.go
+++ b/pkg/expr/mathexp/types.go
@@ -11,6 +11,10 @@ type Results struct {
 	Values Values
 }
 
+func NewResults(values ...Value) Results {
+	return Results{Values: values}
+}
+
 // Values is a slice of Value interfaces
 type Values []Value
 


### PR DESCRIPTION
**Which issue(s) does this PR fix?**:

This pull request changes `TestConditionsCmd` to assert on `mathexp.Results`. This will allow asserting the complete result returned from `ConditionsCmd` instead of just the first `mathexp.Number`.

Fixes #

**Special notes for your reviewer**:

