### PR TITLE
Build: properly format new .drone.yml in verify-drone

### DIFF
--- a/pkg/build/cmd/verifydrone.go
+++ b/pkg/build/cmd/verifydrone.go
@@ -39,6 +39,9 @@ func VerifyDrone(c *cli.Context) error {
 	for _, flag := range starlark.Command.Flags {
 		flag.Apply(flags)
 	}
+	if err := flags.Set("format", "true"); err != nil {
+		return err
+	}
 	cStarlark := cliv1.NewContext(cliv1.NewApp(), flags, nil)
 	action := starlark.Command.Action.(func(*cliv1.Context))
 	action(cStarlark)


### PR DESCRIPTION
This PR fixes the error produced by the verify-drone build step when starlark doesn't generate formatted output.