### PR TITLE
devenv:elastic: update version

### DIFF
--- a/devenv/docker/blocks/elastic/.env
+++ b/devenv/docker/blocks/elastic/.env
@@ -1,1 +1,1 @@
-elastic_version=8.4.1
+elastic_version=8.5.0

--- a/devenv/docker/blocks/elasticstack/.env
+++ b/devenv/docker/blocks/elasticstack/.env
@@ -1,1 +1,1 @@
-elastic_version=8.4.1
+elastic_version=8.5.0


### PR DESCRIPTION
updates the elasticsearch-database-version in `devenv` from `8.4.1` to `8.5.0`.

unfortunately the elasticsaearch docker images do not have the `:latest` label, so we cannot just link permanently to the latest one, we have to keep updating this.
