### PR TITLE
feat(loki-monaco-editor): update e2e test with autocomplete steps

### DIFF
--- a/e2e/various-suite/loki-editor.spec.ts
+++ b/e2e/various-suite/loki-editor.spec.ts
@@ -39,53 +39,10 @@ e2e.scenario({
 
     // Wait for lazy loading
     const monacoLoadingText = 'Loading...';
-
     e2e.components.QueryField.container().should('be.visible').should('have.text', monacoLoadingText);
     e2e.components.QueryField.container().should('be.visible').should('not.have.text', monacoLoadingText);
+    e2e.components.QueryField.container().type('time(', { parseSpecialCharSequences: false });
 
-    const queryFieldValue = e2e().get('.monaco-editor textarea:first');
-
-    // adds closing braces around empty value
-    e2e.components.QueryField.container().type('time(');
-    queryFieldValue.should(($el) => {
-      expect($el.val()).to.eq('time()');
-    });
-
-    // removes closing brace when opening brace is removed
-    e2e.components.QueryField.container().type('{backspace}');
-    queryFieldValue.should(($el) => {
-      expect($el.val()).to.eq('time');
-    });
-
-    // keeps closing brace when opening brace is removed and inner values exist
-    e2e.components.QueryField.container().type(
-      `{selectall}{backspace}time(test{leftArrow}{leftArrow}{leftArrow}{leftArrow}{backspace}`
-    );
-    queryFieldValue.should(($el) => {
-      expect($el.val()).to.eq('timetest)');
-    });
-
-    // overrides an automatically inserted brace
-    e2e.components.QueryField.container().type(`{selectall}{backspace}time()`);
-    queryFieldValue.should(($el) => {
-      expect($el.val()).to.eq('time()');
-    });
-
-    // does not override manually inserted braces
-    e2e.components.QueryField.container().type(`{selectall}{backspace}))`);
-    queryFieldValue.should(($el) => {
-      expect($el.val()).to.eq('))');
-    });
-
-    /** Runner plugin */
-
-    // Should execute the query when enter with shift is pressed
-    e2e.components.QueryField.container().type(`{selectall}{backspace}{shift+enter}`);
-    e2e().get('[data-testid="explore-no-data"]').should('be.visible');
-
-    /** Suggestions plugin */
-    e2e().get('[role="code"]').type(`{selectall}av`);
-    e2e().contains('avg').should('be.visible');
-    e2e().contains('avg_over_time').should('be.visible');
+    cy.contains('time(').should('be.visible');
   },
 });

--- a/e2e/various-suite/loki-editor.spec.ts
+++ b/e2e/various-suite/loki-editor.spec.ts
@@ -39,10 +39,41 @@ e2e.scenario({
 
     // Wait for lazy loading
     const monacoLoadingText = 'Loading...';
+
     e2e.components.QueryField.container().should('be.visible').should('have.text', monacoLoadingText);
     e2e.components.QueryField.container().should('be.visible').should('not.have.text', monacoLoadingText);
-    e2e.components.QueryField.container().type('time(', { parseSpecialCharSequences: false });
 
-    cy.contains('time(').should('be.visible');
+    // adds closing braces around empty value
+    e2e.components.QueryField.container().type('time(');
+    cy.contains('time()').should('be.visible');
+
+    // removes closing brace when opening brace is removed
+    e2e.components.QueryField.container().type('avg_over_time({backspace}');
+    cy.contains('avg_over_time').should('be.visible');
+
+    // keeps closing brace when opening brace is removed and inner values exist
+    e2e.components.QueryField.container().type(
+      '{selectall}{backspace}time(test{leftArrow}{leftArrow}{leftArrow}{leftArrow}{backspace}'
+    );
+    cy.contains('timetest)').should('be.visible');
+
+    // overrides an automatically inserted brace
+    e2e.components.QueryField.container().type('{selectall}{backspace}time()');
+    cy.contains('time()').should('be.visible');
+
+    // does not override manually inserted braces
+    e2e.components.QueryField.container().type('{selectall}{backspace}))');
+    cy.contains('))').should('be.visible');
+
+    /** Runner plugin */
+
+    // Should execute the query when enter with shift is pressed
+    e2e.components.QueryField.container().type('{selectall}{backspace}{shift+enter}');
+    e2e().get('[data-testid="explore-no-data"]').should('be.visible');
+
+    /** Suggestions plugin */
+    e2e.components.QueryField.container().type('{selectall}av');
+    e2e().contains('avg').should('be.visible');
+    e2e().contains('avg_over_time').should('be.visible');
   },
 });

--- a/e2e/various-suite/loki-editor.spec.ts
+++ b/e2e/various-suite/loki-editor.spec.ts
@@ -45,25 +45,45 @@ e2e.scenario({
 
     // adds closing braces around empty value
     e2e.components.QueryField.container().type('time(');
-    cy.contains('time()').should('be.visible');
+    e2e()
+      .get('.monaco-editor textarea:first')
+      .should(($el) => {
+        expect($el.val()).to.eq('time()');
+      });
 
     // removes closing brace when opening brace is removed
-    e2e.components.QueryField.container().type('avg_over_time({backspace}');
-    cy.contains('avg_over_time').should('be.visible');
+    e2e.components.QueryField.container().type('{selectall}{backspace}avg_over_time({backspace}');
+    e2e()
+      .get('.monaco-editor textarea:first')
+      .should(($el) => {
+        expect($el.val()).to.eq('avg_over_time');
+      });
 
     // keeps closing brace when opening brace is removed and inner values exist
     e2e.components.QueryField.container().type(
       '{selectall}{backspace}time(test{leftArrow}{leftArrow}{leftArrow}{leftArrow}{backspace}'
     );
-    cy.contains('timetest)').should('be.visible');
+    e2e()
+      .get('.monaco-editor textarea:first')
+      .should(($el) => {
+        expect($el.val()).to.eq('timetest)');
+      });
 
     // overrides an automatically inserted brace
     e2e.components.QueryField.container().type('{selectall}{backspace}time()');
-    cy.contains('time()').should('be.visible');
+    e2e()
+      .get('.monaco-editor textarea:first')
+      .should(($el) => {
+        expect($el.val()).to.eq('time()');
+      });
 
     // does not override manually inserted braces
     e2e.components.QueryField.container().type('{selectall}{backspace}))');
-    cy.contains('))').should('be.visible');
+    e2e()
+      .get('.monaco-editor textarea:first')
+      .should(($el) => {
+        expect($el.val()).to.eq('))');
+      });
 
     /** Runner plugin */
 

--- a/e2e/various-suite/loki-editor.spec.ts
+++ b/e2e/various-suite/loki-editor.spec.ts
@@ -43,35 +43,36 @@ e2e.scenario({
     e2e.components.QueryField.container().should('be.visible').should('have.text', monacoLoadingText);
     e2e.components.QueryField.container().should('be.visible').should('not.have.text', monacoLoadingText);
 
-    const queryField = e2e.components.QueryField.container();
     const queryFieldValue = e2e().get('.monaco-editor textarea:first');
 
     // adds closing braces around empty value
-    queryField.type('time(', { parseSpecialCharSequences: false });
+    e2e.components.QueryField.container().type('time(');
     queryFieldValue.should(($el) => {
       expect($el.val()).to.eq('time()');
     });
 
     // removes closing brace when opening brace is removed
-    queryField.type('{backspace}');
+    e2e.components.QueryField.container().type('{backspace}');
     queryFieldValue.should(($el) => {
       expect($el.val()).to.eq('time');
     });
 
     // keeps closing brace when opening brace is removed and inner values exist
-    queryField.type(`{selectall}{backspace}time(test{leftArrow}{leftArrow}{leftArrow}{leftArrow}{backspace}`);
+    e2e.components.QueryField.container().type(
+      `{selectall}{backspace}time(test{leftArrow}{leftArrow}{leftArrow}{leftArrow}{backspace}`
+    );
     queryFieldValue.should(($el) => {
       expect($el.val()).to.eq('timetest)');
     });
 
     // overrides an automatically inserted brace
-    queryField.type(`{selectall}{backspace}time()`);
+    e2e.components.QueryField.container().type(`{selectall}{backspace}time()`);
     queryFieldValue.should(($el) => {
       expect($el.val()).to.eq('time()');
     });
 
     // does not override manually inserted braces
-    queryField.type(`{selectall}{backspace}))`);
+    e2e.components.QueryField.container().type(`{selectall}{backspace}))`);
     queryFieldValue.should(($el) => {
       expect($el.val()).to.eq('))');
     });
@@ -79,7 +80,7 @@ e2e.scenario({
     /** Runner plugin */
 
     // Should execute the query when enter with shift is pressed
-    queryField.type(`{selectall}{backspace}{shift+enter}`);
+    e2e.components.QueryField.container().type(`{selectall}{backspace}{shift+enter}`);
     e2e().get('[data-testid="explore-no-data"]').should('be.visible');
 
     /** Suggestions plugin */


### PR DESCRIPTION
**What is this feature?**

This PR properly adds back the testing steps that were missing by a test commit made to https://github.com/grafana/grafana/pull/58080.

In short, the editor has been updated to Monaco, so we want to have E2E coverage of the autocomplete feature.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana/issues/44985

**Special notes for your reviewer**:

