### PR TITLE
Docs: Replace toolkit command to scaffold plugins with create-plugin

### DIFF
--- a/docs/sources/developers/plugins/_index.md
+++ b/docs/sources/developers/plugins/_index.md
@@ -13,15 +13,15 @@ For more information on the types of plugins you can build, refer to the [Plugin
 
 ## Get started
 
-The easiest way to start developing Grafana plugins is to use the [Grafana Toolkit](https://www.npmjs.com/package/@grafana/toolkit).
+The easiest way to start developing Grafana plugins is to use the [Grafana create-plugin](https://www.npmjs.com/package/@grafana/create-plugin).
 
 Open the terminal, and run the following command in your [plugin directory]({{< relref "../../setup-grafana/configure-grafana/#plugins" >}}):
 
 ```bash
-npx @grafana/toolkit plugin:create my-grafana-plugin
+npx @grafana/create-plugin
 ```
 
-> **Note:** If running NPM 7+ the `npx` commands mentioned in this article may hang. The workaround is to use `npx --legacy-peer-deps <command to run>`.
+Follow the questions and you will have a starter plugin ready to develop.
 
 If you want a more guided introduction to plugin development, check out our tutorials:
 

--- a/docs/sources/developers/plugins/_index.md
+++ b/docs/sources/developers/plugins/_index.md
@@ -13,7 +13,7 @@ For more information on the types of plugins you can build, refer to the [Plugin
 
 ## Get started
 
-The easiest way to start developing Grafana plugins is to use the [Grafana create-plugin](https://www.npmjs.com/package/@grafana/create-plugin).
+The easiest way to start developing Grafana plugins is to use the Grafana [create-plugin tool](https://www.npmjs.com/package/@grafana/create-plugin).
 
 Open the terminal, and run the following command in your [plugin directory]({{< relref "../../setup-grafana/configure-grafana/#plugins" >}}):
 


### PR DESCRIPTION
**What is this feature?**

With https://github.com/grafana/grafana/issues/55997 we are moving away the plugin's functionality inside toolkit to https://github.com/grafana/plugin-tools/tree/main/packages/create-plugin

This PR changes the used command to scaffold a plugin to create-plugin and avoid [confusion](https://community.grafana.com/t/what-is-the-recommended-way-to-create-grafana-plugin/75315/3) in the community between toolkit, our [plugin-examples](https://github.com/grafana/grafana-plugin-examples/) and the create-plugin tool


**Who is this feature for?**

All people visiting our documentation portals

**Which issue(s) does this PR fix?**:

Partially addresses https://github.com/grafana/grafana/issues/56001 and https://github.com/grafana/plugin-tools/issues/42

Fixes #

**Special notes for your reviewer**:

