### PR TITLE
Alerting: Use fnv hash of opts in singleflight

### DIFF
--- a/pkg/services/ngalert/image/service.go
+++ b/pkg/services/ngalert/image/service.go
@@ -2,6 +2,7 @@ package image
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"time"
@@ -135,8 +136,8 @@ func (s *ScreenshotImageService) NewImage(ctx context.Context, r *models.AlertRu
 		Timeout:      screenshotTimeout,
 	}
 
-	k := fmt.Sprintf("%s-%d-%s", opts.DashboardUID, opts.PanelID, opts.Theme)
-	result, err, _ := s.singleflight.Do(k, func() (interface{}, error) {
+	optsHash := base64.StdEncoding.EncodeToString(opts.Hash())
+	result, err, _ := s.singleflight.Do(optsHash, func() (interface{}, error) {
 		screenshot, err := s.limiter.Do(ctx, opts, s.screenshots.Take)
 		if err != nil {
 			if errors.Is(err, dashboards.ErrDashboardNotFound) {


### PR DESCRIPTION
**Which issue(s) does this PR fix?**:

Use `opts.Sum()` instead of creating our own string. This will also let us re-use the hash for singleflight screenshots in ngalert.

Fixes #

**Special notes for your reviewer**:

