### PR TITLE
Plugins: Ensure CallResource responses contain valid Content-Type header

### DIFF
--- a/pkg/api/plugins_test.go
+++ b/pkg/api/plugins_test.go
@@ -336,6 +336,66 @@ func TestMakePluginResourceRequest(t *testing.T) {
 	require.Empty(t, req.Header.Get(customHeader))
 }
 
+func TestMakePluginResourceRequestSetCookieNotPresent(t *testing.T) {
+	hs := HTTPServer{
+		Cfg: setting.NewCfg(),
+		log: log.New(),
+		pluginClient: &fakePluginClient{
+			headers: map[string][]string{"Set-Cookie": {"monster"}},
+		},
+	}
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	resp := httptest.NewRecorder()
+	pCtx := backend.PluginContext{}
+	err := hs.makePluginResourceRequest(resp, req, pCtx)
+	require.NoError(t, err)
+
+	for {
+		if resp.Flushed {
+			break
+		}
+	}
+	assert.Empty(t, resp.Header().Values("Set-Cookie"), "Set-Cookie header should not be present")
+}
+
+func TestMakePluginResourceRequestContentTypeUnique(t *testing.T) {
+	// Ensures Content-Type is present only once, even if it's present with
+	// a non-canonical key in the plugin response.
+
+	// Test various upper/lower case combinations for content-type that may be returned by the plugin.
+	for _, ctHeader := range []string{"content-type", "Content-Type", "CoNtEnT-TyPe"} {
+		t.Run(ctHeader, func(t *testing.T) {
+
+			hs := HTTPServer{
+				Cfg: setting.NewCfg(),
+				log: log.New(),
+				pluginClient: &fakePluginClient{
+					headers: map[string][]string{
+						// This should be "overwritten" by the HTTP server
+						ctHeader: {"application/json"},
+
+						// Another header that should still be present
+						"x-another": {"hello"},
+					},
+				},
+			}
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			resp := httptest.NewRecorder()
+			pCtx := backend.PluginContext{}
+			err := hs.makePluginResourceRequest(resp, req, pCtx)
+			require.NoError(t, err)
+
+			for {
+				if resp.Flushed {
+					break
+				}
+			}
+			assert.Len(t, resp.Header().Values("Content-Type"), 1, "should have 1 Content-Type header")
+			assert.Len(t, resp.Header().Values("x-another"), 1, "should have 1 X-Another header")
+		})
+	}
+}
+
 func TestMakePluginResourceRequestContentTypeEmpty(t *testing.T) {
 	pluginClient := &fakePluginClient{
 		statusCode: http.StatusNoContent,
@@ -393,6 +453,7 @@ type fakePluginClient struct {
 	backend.QueryDataHandlerFunc
 
 	statusCode int
+	headers    map[string][]string
 }
 
 func (c *fakePluginClient) CallResource(_ context.Context, req *backend.CallResourceRequest, sender backend.CallResourceResponseSender) error {
@@ -411,7 +472,7 @@ func (c *fakePluginClient) CallResource(_ context.Context, req *backend.CallReso
 
 	return sender.Send(&backend.CallResourceResponse{
 		Status:  statusCode,
-		Headers: make(map[string][]string),
+		Headers: c.headers,
 		Body:    bytes,
 	})
 }

--- a/pkg/api/plugins_test.go
+++ b/pkg/api/plugins_test.go
@@ -365,7 +365,6 @@ func TestMakePluginResourceRequestContentTypeUnique(t *testing.T) {
 	// Test various upper/lower case combinations for content-type that may be returned by the plugin.
 	for _, ctHeader := range []string{"content-type", "Content-Type", "CoNtEnT-TyPe"} {
 		t.Run(ctHeader, func(t *testing.T) {
-
 			hs := HTTPServer{
 				Cfg: setting.NewCfg(),
 				log: log.New(),


### PR DESCRIPTION
Use canonical MIME header keys for comparisons in CallResource response.

This ensures that the headers forced by the HTTP server are overwritten properly, if already provided by the plugin response.

**Which issue(s) does this PR fix?**:

Fixes #57239

**Special notes for your reviewer**:

