### PR TITLE
Alerting: Fix images cached on rule instead of dashboard panel signature

### DIFF
--- a/pkg/services/ngalert/image/service_test.go
+++ b/pkg/services/ngalert/image/service_test.go
@@ -36,7 +36,7 @@ func TestScreenshotImageService(t *testing.T) {
 	ctx := context.Background()
 
 	// assert that the cache is checked for an existing image
-	cache.EXPECT().Get(gomock.Any(), "{orgID: 1, UID: foo}").Return(models.Image{}, false)
+	cache.EXPECT().Get(gomock.Any(), "M2DGZaRLXtg=").Return(models.Image{}, false)
 
 	// assert that a screenshot is taken
 	screenshots.EXPECT().Take(gomock.Any(), screenshot.ScreenshotOptions{
@@ -60,7 +60,7 @@ func TestScreenshotImageService(t *testing.T) {
 	}
 
 	// assert that the image is saved into the cache
-	cache.EXPECT().Set(gomock.Any(), "{orgID: 1, UID: foo}", expected).Return(nil)
+	cache.EXPECT().Set(gomock.Any(), "M2DGZaRLXtg=", expected).Return(nil)
 
 	image, err := s.NewImage(ctx, &models.AlertRule{
 		OrgID:        1,
@@ -71,7 +71,7 @@ func TestScreenshotImageService(t *testing.T) {
 	assert.Equal(t, expected, *image)
 
 	// assert that the cache is checked for an existing image
-	cache.EXPECT().Get(gomock.Any(), "{orgID: 1, UID: bar}").Return(models.Image{}, false)
+	cache.EXPECT().Get(gomock.Any(), "rTOWVcbRidk=").Return(models.Image{}, false)
 
 	// assert that a screenshot is taken
 	screenshots.EXPECT().Take(gomock.Any(), screenshot.ScreenshotOptions{
@@ -94,7 +94,7 @@ func TestScreenshotImageService(t *testing.T) {
 	}
 
 	// assert that the image is saved into the cache, but without a URL
-	cache.EXPECT().Set(gomock.Any(), "{orgID: 1, UID: bar}", expected).Return(nil)
+	cache.EXPECT().Set(gomock.Any(), "rTOWVcbRidk=", expected).Return(nil)
 
 	image, err = s.NewImage(ctx, &models.AlertRule{
 		OrgID:        1,
@@ -107,7 +107,7 @@ func TestScreenshotImageService(t *testing.T) {
 	expected = models.Image{Path: "baz.png", URL: "https://example.com/baz.png"}
 
 	// assert that the cache is checked for an existing image and it is returned
-	cache.EXPECT().Get(gomock.Any(), "{orgID: 1, UID: baz}").Return(expected, true)
+	cache.EXPECT().Get(gomock.Any(), "8hJuVe20rVE=").Return(expected, true)
 
 	image, err = s.NewImage(ctx, &models.AlertRule{
 		OrgID:        1,


### PR DESCRIPTION
**Which issue(s) does this PR fix?**:

This pull request fixes an issue where we would cache images on the rule signature instead of the dashboard panel. This meant that two alert rules that were associated with the same dashboard panel could not share the same screenshot.

**Special notes for your reviewer**:

