### PR TITLE
[v9.2.x] Alerting: Small improvements to staleResultsHandler (#58007)

### DIFF
--- a/pkg/services/ngalert/state/state.go
+++ b/pkg/services/ngalert/state/state.go
@@ -73,6 +73,13 @@ func (a *State) GetRuleKey() models.AlertRuleKey {
 	}
 }
 
+func (a *State) Resolve(reason string, endsAt time.Time) {
+	a.State = eval.Normal
+	a.StateReason = reason
+	a.EndsAt = endsAt
+	a.Resolved = true
+}
+
 type Evaluation struct {
 	EvaluationTime  time.Time
 	EvaluationState eval.State

--- a/pkg/services/ngalert/state/state_test.go
+++ b/pkg/services/ngalert/state/state_test.go
@@ -298,6 +298,13 @@ func TestGetLastEvaluationValuesForCondition(t *testing.T) {
 	})
 }
 
+func TestResolve(t *testing.T) {
+	s := State{State: eval.Alerting, EndsAt: time.Now().Add(time.Minute)}
+	expected := State{State: eval.Normal, StateReason: "This is a reason", EndsAt: time.Now(), Resolved: true}
+	s.Resolve("This is a reason", expected.EndsAt)
+	assert.Equal(t, expected, s)
+}
+
 func TestShouldTakeImage(t *testing.T) {
 	tests := []struct {
 		name          string


### PR DESCRIPTION
Backports `290951` from https://github.com/grafana/grafana/pull/58007 to `v9.2.x`.
