### PR TITLE
Chore: Switching to new output format for detect breaking changes action

### DIFF
--- a/.github/workflows/detect-breaking-changes-build.yml
+++ b/.github/workflows/detect-breaking-changes-build.yml
@@ -26,7 +26,7 @@ jobs:
 
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path
-      run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+      run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
 
     - name: Restore yarn cache
       uses: actions/cache@v3.0.11
@@ -74,7 +74,7 @@ jobs:
 
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path
-      run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+      run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
 
     - name: Restore yarn cache
       uses: actions/cache@v3.0.11

--- a/.github/workflows/detect-breaking-changes-build.yml
+++ b/.github/workflows/detect-breaking-changes-build.yml
@@ -26,7 +26,7 @@ jobs:
 
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path
-      run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
+      run: echo "dir=$(yarn config get cacheFolder)" >> "$GITHUB_OUTPUT"
 
     - name: Restore yarn cache
       uses: actions/cache@v3.0.11
@@ -74,7 +74,7 @@ jobs:
 
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path
-      run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
+      run: echo "dir=$(yarn config get cacheFolder)" >> "$GITHUB_OUTPUT"
 
     - name: Restore yarn cache
       uses: actions/cache@v3.0.11

--- a/.github/workflows/detect-breaking-changes-build.yml
+++ b/.github/workflows/detect-breaking-changes-build.yml
@@ -26,7 +26,7 @@ jobs:
 
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path
-      run: echo "dir=$(yarn config get cacheFolder)" >> "$GITHUB_OUTPUT"
+      run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
 
     - name: Restore yarn cache
       uses: actions/cache@v3.0.11
@@ -74,7 +74,7 @@ jobs:
 
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path
-      run: echo "dir=$(yarn config get cacheFolder)" >> "$GITHUB_OUTPUT"
+      run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
 
     - name: Restore yarn cache
       uses: actions/cache@v3.0.11

--- a/scripts/check-breaking-changes.sh
+++ b/scripts/check-breaking-changes.sh
@@ -48,8 +48,8 @@ while IFS=" " read -r -a package; do
 done <<< "$PACKAGES"
 
 # "Export" the message to an environment variable that can be used across Github Actions steps
-echo "is_breaking=$EXIT_CODE" >> $GITHUB_OUTPUT
-echo "message=$GITHUB_MESSAGE" >> $GITHUB_OUTPUT
+echo "is_breaking=$EXIT_CODE" >> "$GITHUB_OUTPUT"
+echo "message=$GITHUB_MESSAGE" >> "$GITHUB_OUTPUT"
 
 # We will exit the workflow accordingly at another step
 exit 0

--- a/scripts/check-breaking-changes.sh
+++ b/scripts/check-breaking-changes.sh
@@ -48,8 +48,8 @@ while IFS=" " read -r -a package; do
 done <<< "$PACKAGES"
 
 # "Export" the message to an environment variable that can be used across Github Actions steps
-echo "::set-output name=is_breaking::$EXIT_CODE"
-echo "::set-output name=message::$GITHUB_MESSAGE"
+echo "is_breaking=$EXIT_CODE" >> $GITHUB_OUTPUT
+echo "message=$GITHUB_MESSAGE" >> $GITHUB_OUTPUT
 
 # We will exit the workflow accordingly at another step
 exit 0


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

The `set-output` command is deprecated and will be disabled soon. This PR switches to the new, supported, format for a github action called `Detect breaking changes`

For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Here is an example run where you can see these warnings: https://github.com/grafana/grafana/actions/runs/3427688153

**Why do we need this feature?**
To make sure GH actions keep working as expected
