### PR TITLE
[DRAFT] chore(folder service): add folder_uid to dashboard table and model

### DIFF
--- a/pkg/models/dashboards.go
+++ b/pkg/models/dashboards.go
@@ -35,6 +35,7 @@ type Dashboard struct {
 	UpdatedBy int64
 	CreatedBy int64
 	FolderId  int64
+	FolderUID string `xorm:"folder_uid"`
 	IsFolder  bool
 	HasACL    bool `xorm:"has_acl"`
 
@@ -81,7 +82,6 @@ func NewDashboard(title string) *Dashboard {
 // NewDashboardFolder creates a new dashboard folder
 func NewDashboardFolder(title string) *Dashboard {
 	folder := NewDashboard(title)
-	folder.IsFolder = true
 	folder.Data.Set("schemaVersion", 17)
 	folder.Data.Set("version", 0)
 	folder.IsFolder = true
@@ -140,6 +140,7 @@ func (cmd *SaveDashboardCommand) GetDashboardModel() *Dashboard {
 	dash.PluginId = cmd.PluginId
 	dash.IsFolder = cmd.IsFolder
 	dash.FolderId = cmd.FolderId
+	dash.FolderUID = cmd.FolderUid
 	dash.UpdateSlug()
 	return dash
 }

--- a/pkg/services/sqlstore/migrations/dashboard_mig.go
+++ b/pkg/services/sqlstore/migrations/dashboard_mig.go
@@ -234,4 +234,9 @@ func addDashboardMigration(mg *Migrator) {
 	mg.AddMigration("Add isPublic for dashboard", NewAddColumnMigration(dashboardV2, &Column{
 		Name: "is_public", Type: DB_Bool, Nullable: false, Default: "0",
 	}))
+
+	// add column to store the containing (parent) folder_uid
+	mg.AddMigration("Add column folder_uid in dashboard", NewAddColumnMigration(dashboardV2, &Column{
+		Name: "folder_uid", Type: DB_NVarchar, Length: 40, Nullable: true, Default: "",
+	}))
 }


### PR DESCRIPTION
***DRAFT PR***
This DOES NOT handle updating all the existing dashboard records to include their actual parent folder UID, if that is not the general folder UID. I want to decide what to do about that before merging. (This PR should not block anyone else, but if it does we can merge it and iterate on the migration later).
--------

Added a folder_uid column to the dashboard table (default set to "", the root folder) and folderUID to the dashboard model.  Local tests found no issues switching between this branch and main, even with the migration.

This should be reasonably safe and backwards compatible in that folderID is still the main field used. I made no attempt to otherwise deprecate folderID; that work will come later, though I did poke through the callers using the folder_id.