### PR TITLE
return a copy of the map to avoid concurrency issues in tests

### DIFF
--- a/pkg/services/annotations/annotationstest/fake.go
+++ b/pkg/services/annotations/annotationstest/fake.go
@@ -93,6 +93,9 @@ func (repo *fakeAnnotationsRepo) Len() int {
 func (repo *fakeAnnotationsRepo) Items() map[int64]annotations.Item {
 	repo.mtx.Lock()
 	defer repo.mtx.Unlock()
-
-	return repo.annotations
+	ret := make(map[int64]annotations.Item)
+	for k, v := range repo.annotations {
+		ret[k] = v
+	}
+	return ret
 }


### PR DESCRIPTION
This is an attempt to fix the following (flapping) panic by returning a deep copy of the map from the `fakeAnnotationsRepo`:

```
fatal error: concurrent map iteration and map write

goroutine 1231 [running]:
github.com/grafana/grafana/pkg/services/ngalert/state_test.printAllAnnotations(...)
        /Users/kristin/go/src/github.com/grafana/grafana/pkg/services/ngalert/state/manager_test.go:2076
github.com/grafana/grafana/pkg/services/ngalert/state_test.TestProcessEvalResults.func1(0x14000b0a680?)
        /Users/kristin/go/src/github.com/grafana/grafana/pkg/services/ngalert/state/manager_test.go:2043 +0x264
testing.tRunner(0x14000b0a680, 0x140010f8580)
        /usr/local/go/src/testing/testing.go:1446 +0x10c
created by testing.(*T).Run
        /usr/local/go/src/testing/testing.go:1493 +0x300
```
