### PR TITLE
Various Panels: Remove beta label from Bar Chart, Candlestick, Histogram, State Timeline, & Status History Panels

### DIFF
--- a/pkg/tests/api/plugins/data/expectedListResp.json
+++ b/pkg/tests/api/plugins/data/expectedListResp.json
@@ -201,7 +201,7 @@
     "hasUpdate": false,
     "defaultNavUrl": "/plugins/barchart/",
     "category": "",
-    "state": "beta",
+    "state": "",
     "signature": "internal",
     "signatureType": "",
     "signatureOrg": ""
@@ -273,7 +273,7 @@
     "hasUpdate": false,
     "defaultNavUrl": "/plugins/candlestick/",
     "category": "",
-    "state": "beta",
+    "state": "",
     "signature": "internal",
     "signatureType": "",
     "signatureOrg": ""
@@ -800,7 +800,7 @@
     "hasUpdate": false,
     "defaultNavUrl": "/plugins/histogram/",
     "category": "",
-    "state": "beta",
+    "state": "",
     "signature": "internal",
     "signatureType": "",
     "signatureOrg": ""
@@ -1327,7 +1327,7 @@
     "hasUpdate": false,
     "defaultNavUrl": "/plugins/state-timeline/",
     "category": "",
-    "state": "beta",
+    "state": "",
     "signature": "internal",
     "signatureType": "",
     "signatureOrg": ""
@@ -1363,7 +1363,7 @@
     "hasUpdate": false,
     "defaultNavUrl": "/plugins/status-history/",
     "category": "",
-    "state": "beta",
+    "state": "",
     "signature": "internal",
     "signatureType": "",
     "signatureOrg": ""

--- a/public/app/plugins/panel/barchart/plugin.json
+++ b/public/app/plugins/panel/barchart/plugin.json
@@ -2,7 +2,6 @@
   "type": "panel",
   "name": "Bar chart",
   "id": "barchart",
-  "state": "beta",
 
   "info": {
     "description": "Categorical charts with group support",

--- a/public/app/plugins/panel/candlestick/plugin.json
+++ b/public/app/plugins/panel/candlestick/plugin.json
@@ -2,7 +2,6 @@
   "type": "panel",
   "name": "Candlestick",
   "id": "candlestick",
-  "state": "beta",
 
   "info": {
     "author": {

--- a/public/app/plugins/panel/histogram/plugin.json
+++ b/public/app/plugins/panel/histogram/plugin.json
@@ -3,8 +3,6 @@
   "name": "Histogram",
   "id": "histogram",
 
-  "state": "beta",
-
   "info": {
     "author": {
       "name": "Grafana Labs",

--- a/public/app/plugins/panel/state-timeline/plugin.json
+++ b/public/app/plugins/panel/state-timeline/plugin.json
@@ -3,8 +3,6 @@
   "name": "State timeline",
   "id": "state-timeline",
 
-  "state": "beta",
-
   "info": {
     "description": "State changes and durations",
     "author": {

--- a/public/app/plugins/panel/status-history/plugin.json
+++ b/public/app/plugins/panel/status-history/plugin.json
@@ -3,8 +3,6 @@
   "name": "Status history",
   "id": "status-history",
 
-  "state": "beta",
-
   "info": {
     "description": "Periodic status history",
     "author": {


### PR DESCRIPTION
This PR removes the beta label from a number of panels that are now fairly stable and in common usage.



