### PR TITLE
StateTimelinePanel: Fix duration on merged values

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/config/addTooltipSupport.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/addTooltipSupport.ts
@@ -126,7 +126,7 @@ export const addTooltipSupport = ({
   }
 
   config.addHook('setLegend', (u) => {
-    if (!isToolTipOpen.current) {
+    if (!isToolTipOpen.current && !tooltipInterpolator) {
       setFocusedPointIdx(u.legend.idx!);
     }
     if (u.cursor.idxs != null) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Fixes the statetimeline duration when values are merged.

**Why do we need this feature?**
When values are merged the duration should show a sum of all merged values, not each duration independently as it does now

**Who is this feature for?**
StateTimeline panel users

**Special notes for your reviewer**:
This was fixed in https://github.com/grafana/grafana/pull/54697 - v9.1.3, but somehow I broke it in https://github.com/grafana/grafana/pull/55809 - v9.1.8
Will try looking into adding some tests
