### PR TITLE
[v9.2.x] Alerting: Fix logging pointer address of DashboardUID and PanelID variables

### DIFF
--- a/pkg/services/ngalert/image/service.go
+++ b/pkg/services/ngalert/image/service.go
@@ -126,19 +126,23 @@ func NewScreenshotImageServiceFromCfg(cfg *setting.Cfg, db *store.DBstore, ds da
 func (s *ScreenshotImageService) NewImage(ctx context.Context, r *models.AlertRule) (*models.Image, error) {
 	logger := s.logger.FromContext(ctx)
 
-	if r.DashboardUID == nil || *r.DashboardUID == "" {
+	dashboardUID := r.GetDashboardUID()
+	if dashboardUID == "" {
 		logger.Debug("Cannot take screenshot for alert rule as it is not associated with a dashboard")
 		return nil, ErrNoDashboard
 	}
 
-	if r.PanelID == nil || *r.PanelID == 0 {
+	panelID := r.GetPanelID()
+	if panelID <= 0 {
 		logger.Debug("Cannot take screenshot for alert rule as it is not associated with a panel")
 		return nil, ErrNoPanel
 	}
 
+	logger = logger.New("dashboard", dashboardUID, "panel", panelID)
+
 	opts := screenshot.ScreenshotOptions{
-		DashboardUID: *r.DashboardUID,
-		PanelID:      *r.PanelID,
+		DashboardUID: dashboardUID,
+		PanelID:      panelID,
 		Timeout:      screenshotTimeout,
 	}
 

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -155,6 +155,22 @@ type AlertRule struct {
 	Labels      map[string]string
 }
 
+// GetDashboardUID returns the DashboardUID or "".
+func (alertRule *AlertRule) GetDashboardUID() string {
+	if alertRule.DashboardUID != nil {
+		return *alertRule.DashboardUID
+	}
+	return ""
+}
+
+// GetPanelID returns the Panel ID or -1.
+func (alertRule *AlertRule) GetPanelID() int64 {
+	if alertRule.PanelID != nil {
+		return *alertRule.PanelID
+	}
+	return -1
+}
+
 type LabelOption func(map[string]string)
 
 func WithoutInternalLabels() LabelOption {

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -239,8 +239,8 @@ func (st *Manager) setNextState(ctx context.Context, alertRule *ngModels.AlertRu
 		image, err := takeImage(ctx, st.imageService, alertRule)
 		if err != nil {
 			st.log.Warn("Failed to take an image",
-				"dashboard", alertRule.DashboardUID,
-				"panel", alertRule.PanelID,
+				"dashboard", alertRule.GetDashboardUID(),
+				"panel", alertRule.GetPanelID(),
 				"error", err)
 		} else if image != nil {
 			currentState.Image = image
@@ -417,8 +417,8 @@ func (st *Manager) staleResultsHandler(ctx context.Context, r *ngModels.AlertRul
 					image, err := takeImage(ctx, st.imageService, r)
 					if err != nil {
 						st.log.Warn("Failed to take an image",
-							"dashboard", r.DashboardUID,
-							"panel", r.PanelID,
+							"dashboard", r.GetDashboardUID(),
+							"panel", r.GetPanelID(),
 							"error", err)
 					} else if image != nil {
 						resolvedImage = image


### PR DESCRIPTION
Backports `c5ae1bc` from https://github.com/grafana/grafana/pull/58539 to `v9.2.x`.
