### PR TITLE
Snapshots: Allow user with viewer permissions to delete own snapshots

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -679,5 +679,5 @@ func (hs *HTTPServer) registerRoutes() {
 	r.Get("/api/snapshot/shared-options/", reqSignedIn, GetSharingOptions)
 	r.Get("/api/snapshots/:key", routing.Wrap(hs.GetDashboardSnapshot))
 	r.Get("/api/snapshots-delete/:deleteKey", reqSnapshotPublicModeOrSignedIn, routing.Wrap(hs.DeleteDashboardSnapshotByDeleteKey))
-	r.Delete("/api/snapshots/:key", reqEditorRole, routing.Wrap(hs.DeleteDashboardSnapshot))
+	r.Delete("/api/snapshots/:key", reqSignedIn, routing.Wrap(hs.DeleteDashboardSnapshot))
 }


### PR DESCRIPTION
Allows a user with viewer permissions to delete snapshots that they have created, and also allows deletion of snapshots whose original dashboard is in a folder which the viewer has explicit edit permissions for.