### PR TITLE
Chore: create parent folder UID list in the dashboard table

### DIFF
--- a/pkg/services/dashboards/database/database.go
+++ b/pkg/services/dashboards/database/database.go
@@ -125,7 +125,11 @@ func (d *DashboardStore) GetFolderByUID(ctx context.Context, orgID int64, uid st
 
 	dashboard := models.Dashboard{OrgId: orgID, FolderId: 0, Uid: uid}
 	err := d.store.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
-		has, err := sess.Table(&models.Dashboard{}).Where("is_folder = " + d.store.GetDialect().BooleanStr(true)).Where("folder_id=0").Get(&dashboard)
+		query := sess.Table(&models.Dashboard{}).Where("is_folder = " + d.store.GetDialect().BooleanStr(true))
+		if !d.features.IsEnabled(featuremgmt.FlagNestedFolders) {
+			query = query.Where("folder_id=0")
+		}
+		has, err := query.Get(&dashboard)
 		if err != nil {
 			return err
 		}

--- a/pkg/services/dashboards/database/database.go
+++ b/pkg/services/dashboards/database/database.go
@@ -84,7 +84,11 @@ func (d *DashboardStore) GetFolderByTitle(ctx context.Context, orgID int64, titl
 	// there are no nested folders so the parent folder id is always 0
 	dashboard := models.Dashboard{OrgId: orgID, FolderId: 0, Title: title}
 	err := d.store.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
-		has, err := sess.Table(&models.Dashboard{}).Where("is_folder = " + d.store.GetDialect().BooleanStr(true)).Where("folder_id=0").Get(&dashboard)
+		query := sess.Table(&models.Dashboard{}).Where("is_folder = " + d.store.GetDialect().BooleanStr(true))
+		if !d.features.IsEnabled(featuremgmt.FlagNestedFolders) {
+			query = query.Where("folder_id=0")
+		}
+		has, err := query.Get(&dashboard)
 		if err != nil {
 			return err
 		}
@@ -101,7 +105,11 @@ func (d *DashboardStore) GetFolderByTitle(ctx context.Context, orgID int64, titl
 func (d *DashboardStore) GetFolderByID(ctx context.Context, orgID int64, id int64) (*folder.Folder, error) {
 	dashboard := models.Dashboard{OrgId: orgID, FolderId: 0, Id: id}
 	err := d.store.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
-		has, err := sess.Table(&models.Dashboard{}).Where("is_folder = " + d.store.GetDialect().BooleanStr(true)).Where("folder_id=0").Get(&dashboard)
+		query := sess.Table(&models.Dashboard{}).Where("is_folder = " + d.store.GetDialect().BooleanStr(true))
+		if !d.features.IsEnabled(featuremgmt.FlagNestedFolders) {
+			query = query.Where("folder_id=0")
+		}
+		has, err := query.Get(&dashboard)
 		if err != nil {
 			return err
 		}

--- a/pkg/services/folder/folderimpl/folder.go
+++ b/pkg/services/folder/folderimpl/folder.go
@@ -244,7 +244,7 @@ func (s *Service) Create(ctx context.Context, cmd *folder.CreateFolderCommand) (
 		if err != nil {
 			return nil, err
 		}
-		saveDashboardCmd.FolderId = parentFolder.Id
+		saveDashboardCmd.FolderId = parentFolder.ID
 		saveDashboardCmd.FolderUid = cmd.ParentUID
 	}
 

--- a/pkg/services/folder/model.go
+++ b/pkg/services/folder/model.go
@@ -65,7 +65,7 @@ type CreateFolderCommand struct {
 	OrgID       int64  `json:"-"`
 	Title       string `json:"title"`
 	Description string `json:"description"`
-	ParentUID   string `json:"parent_uid"`
+	ParentUID   string `json:"parentUid"`
 }
 
 // UpdateFolderCommand captures the information required by the folder service
@@ -73,6 +73,7 @@ type CreateFolderCommand struct {
 type UpdateFolderCommand struct {
 	Folder         *Folder `json:"folder"` // The extant folder
 	NewUID         *string `json:"uid" xorm:"uid"`
+	NewParentUID   *string `json:"parentUid" xorm:"parent_uid"`
 	NewTitle       *string `json:"title"`
 	NewDescription *string `json:"description"`
 }
@@ -81,7 +82,7 @@ type UpdateFolderCommand struct {
 // to move a folder.
 type MoveFolderCommand struct {
 	UID          string `json:"uid"`
-	NewParentUID string `json:"new_parent_uid"`
+	NewParentUID string `json:"NewParentUid"`
 	OrgID        int64  `json:"-"`
 }
 


### PR DESCRIPTION
This PR is related to https://github.com/grafana/grafana/issues/56880 and attempts to create a linked structure of folders in the `dashboard` table as well. This implies that https://github.com/grafana/grafana/pull/58590 would have to be adjusted to respect `parent_uid` column during the migrations.