### PR TITLE
Elasticsearch: Add feature toggle for backend migration

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -80,4 +80,5 @@ export interface FeatureToggles {
   datasourceLogger?: boolean;
   accessControlOnCall?: boolean;
   nestedFolders?: boolean;
+  elasticsearchBackendMigration?: boolean;
 }

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -357,5 +357,10 @@ var (
 			State:           FeatureStateAlpha,
 			RequiresDevMode: true,
 		},
+		{
+			Name:        "elasticsearchBackendMigration",
+			Description: "Use Elasticsearch as backend data source",
+			State:       FeatureStateAlpha,
+		},
 	}
 )

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -263,7 +263,7 @@ const (
 	// Enable folder nesting
 	FlagNestedFolders = "nestedFolders"
 
-	// FlagElasticsearchBackendMode
+	// FlagElasticsearchBackendMigration
 	// Use Elasticsearch as backend data source
 	FlagElasticsearchBackendMigration = "elasticsearchBackendMigration"
 )

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -262,4 +262,8 @@ const (
 	// FlagNestedFolders
 	// Enable folder nesting
 	FlagNestedFolders = "nestedFolders"
+
+	// FlagElasticsearchBackendMode
+	// Use Elasticsearch as backend data source
+	FlagElasticsearchBackendMigration = "elasticsearchBackendMigration"
 )


### PR DESCRIPTION
This PR adds feature toggle that we will use for Elasticsearch backend migration. To enable feature toggle add `elasticsearchBackendMigration = true` to your `custom.ini` configuration. 

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana/issues/54011

