### PR TITLE
Email: Update email template to use correct logo location

### DIFF
--- a/emails/templates/layouts/default.html
+++ b/emails/templates/layouts/default.html
@@ -107,7 +107,7 @@ td[class="stack-column-center"] {
 						            <table class="twelve columns">
 						              <tr>
 						                <td class="twelve sub-columns center">
-                              <img class="logo" src="https://grafana.com/assets/img/logo_new_transparent_200x48.png" style="width: 200px; float: none; display: inline">
+                              <img class="logo" src="https://grafana.com/static/assets/img/logo_new_transparent_200x48.png" style="width: 200px; float: none; display: inline">
                             </td>
                             <td class="expander"></td>
                           </tr>


### PR DESCRIPTION
This PR updates the email template to use the new corrected url. 

A redirect is being setup to handle any of the rest that may exist 

