### PR TITLE
Tempo: Fix search removing service name from query

### DIFF
--- a/public/app/plugins/datasource/tempo/QueryEditor/NativeSearch.tsx
+++ b/public/app/plugins/datasource/tempo/QueryEditor/NativeSearch.tsx
@@ -168,7 +168,7 @@ const NativeSearch = ({ datasource, query, onChange, onBlur, onRunQuery }: Props
       });
     },
     [onChange, query]
-  ); // eslint-disable-line
+  );
 
   const templateSrv: TemplateSrv = getTemplateSrv();
 

--- a/public/app/plugins/datasource/tempo/QueryEditor/NativeSearch.tsx
+++ b/public/app/plugins/datasource/tempo/QueryEditor/NativeSearch.tsx
@@ -160,12 +160,15 @@ const NativeSearch = ({ datasource, query, onChange, onBlur, onRunQuery }: Props
     }
   };
 
-  const handleOnChange = useCallback((value) => {
-    onChange({
-      ...query,
-      search: value,
-    });
-  }, []); // eslint-disable-line
+  const handleOnChange = useCallback(
+    (value) => {
+      onChange({
+        ...query,
+        search: value,
+      });
+    },
+    [onChange, query]
+  ); // eslint-disable-line
 
   const templateSrv: TemplateSrv = getTemplateSrv();
 


### PR DESCRIPTION
**What is this feature?**

It's a bug fix!

**Why do we need this feature?**

Fixes issue in Tempo search where adding tags after selecting service name will run the query with the service name omitted.

**Who is this feature for?**

Users of the Tempo datasource.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/58628

