### PR TITLE
Alerting: Fix ConditionsCmd No Data for "has no value"

### DIFF
--- a/pkg/expr/classic/classic.go
+++ b/pkg/expr/classic/classic.go
@@ -79,6 +79,12 @@ func (cmd *ConditionsCmd) Execute(_ context.Context, _ time.Time, vars mathexp.V
 		querySeriesSet := vars[c.InputRefID]
 		nilReducedCount := 0
 		firingCount := 0
+
+		if len(querySeriesSet.Values) == 0 {
+			// Append a NoData data frame so "has no value" still works
+			querySeriesSet.Values = append(querySeriesSet.Values, mathexp.NoData{}.New())
+		}
+
 		for _, val := range querySeriesSet.Values {
 			var reducedNum mathexp.Number
 			var name string
@@ -103,10 +109,6 @@ func (cmd *ConditionsCmd) Execute(_ context.Context, _ time.Time, vars mathexp.V
 			// TODO handle error / no data signals
 			thisCondNoDataFound := reducedNum.GetFloat64Value() == nil
 
-			if thisCondNoDataFound {
-				nilReducedCount++
-			}
-
 			evalRes := c.Evaluator.Eval(reducedNum)
 
 			if evalRes {
@@ -119,6 +121,8 @@ func (cmd *ConditionsCmd) Execute(_ context.Context, _ time.Time, vars mathexp.V
 				}
 				matches = append(matches, match)
 				firingCount++
+			} else if thisCondNoDataFound {
+				nilReducedCount++
 			}
 		}
 

--- a/pkg/expr/classic/classic_test.go
+++ b/pkg/expr/classic/classic_test.go
@@ -203,9 +203,8 @@ func TestConditionsCmd(t *testing.T) {
 			},
 		},
 		expected: func() mathexp.Results {
-			v := newNumber(nil)
-			// This seems incorrect
-			v.SetMeta([]EvalMatch{{}, {Metric: "NoData"}})
+			v := newNumber(ptr.Float64(1))
+			v.SetMeta([]EvalMatch{{Value: nil}})
 			return newResults(v)
 		},
 	}, {
@@ -226,9 +225,9 @@ func TestConditionsCmd(t *testing.T) {
 			},
 		},
 		expected: func() mathexp.Results {
-			v := newNumber(nil)
+			v := newNumber(ptr.Float64(1))
 			// This too seems incorrect, looks like we don't call the evaluator
-			v.SetMeta([]EvalMatch{{Metric: "NoData"}})
+			v.SetMeta([]EvalMatch{{Value: nil}})
 			return newResults(v)
 		},
 	}, {
@@ -251,9 +250,9 @@ func TestConditionsCmd(t *testing.T) {
 			},
 		},
 		expected: func() mathexp.Results {
-			v := newNumber(nil)
+			v := newNumber(ptr.Float64(1))
 			// This seems incorrect
-			v.SetMeta([]EvalMatch{{}, {Metric: "NoData"}})
+			v.SetMeta([]EvalMatch{{Value: nil}})
 			return newResults(v)
 		},
 	}, {


### PR DESCRIPTION
**Which issue(s) does this PR fix?**:

This commit fixes a bug where `ConditionsCmd` returns No Data even when the condition checks for `"has no value"`. It should return 1 with a nil match.

Fixes #

**Special notes for your reviewer**:

