### PR TITLE
Elastic: always return DataFrames from the datasource's query method

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/ElasticResponse.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/ElasticResponse.test.ts
@@ -787,9 +787,14 @@ describe('ElasticResponse', () => {
       result = new ElasticResponse(targets, response).getTimeSeries();
     });
 
-    it('should return table with byte and count', () => {
-      expect(result.data[0].rows.length).toBe(3);
-      expect(result.data[0].columns).toEqual([{ text: 'bytes', filterable: true }, { text: 'Count' }]);
+    it('should return dataframe with byte and count', () => {
+      expect(result.data[0].length).toBe(3);
+      const { fields } = result.data[0];
+      expect(fields.length).toBe(2);
+      expect(fields[0].name).toBe('bytes');
+      expect(fields[0].config).toStrictEqual({ filterable: true });
+      expect(fields[1].name).toBe('Count');
+      expect(fields[1].config).toStrictEqual({});
     });
   });
 
@@ -954,16 +959,17 @@ describe('ElasticResponse', () => {
       result = new ElasticResponse(targets, response).getTimeSeries();
     });
 
-    it('should return table', () => {
+    it('should return dataframe', () => {
       expect(result.data.length).toBe(1);
-      expect(result.data[0].type).toBe('table');
-      expect(result.data[0].rows.length).toBe(2);
-      expect(result.data[0].rows[0][0]).toBe('server-1');
-      expect(result.data[0].rows[0][1]).toBe(1000);
-      expect(result.data[0].rows[0][2]).toBe(369);
+      expect(result.data[0].length).toBe(2);
+      expect(result.data[0].fields.length).toBe(3);
+      const field1 = result.data[0].fields[0];
+      const field2 = result.data[0].fields[1];
+      const field3 = result.data[0].fields[2];
 
-      expect(result.data[0].rows[1][0]).toBe('server-2');
-      expect(result.data[0].rows[1][1]).toBe(2000);
+      expect(field1.values.toArray()).toStrictEqual(['server-1', 'server-2']);
+      expect(field2.values.toArray()).toStrictEqual([1000, 2000]);
+      expect(field3.values.toArray()).toStrictEqual([369, 200]);
     });
   });
 
@@ -1006,19 +1012,19 @@ describe('ElasticResponse', () => {
       result = new ElasticResponse(targets, response).getTimeSeries();
     });
 
-    it('should return table', () => {
+    it('should return dataframe', () => {
       expect(result.data.length).toBe(1);
-      expect(result.data[0].type).toBe('table');
-      expect(result.data[0].columns[0].text).toBe('id');
-      expect(result.data[0].columns[1].text).toBe('p75 value');
-      expect(result.data[0].columns[2].text).toBe('p90 value');
-      expect(result.data[0].rows.length).toBe(2);
-      expect(result.data[0].rows[0][0]).toBe('id1');
-      expect(result.data[0].rows[0][1]).toBe(3.3);
-      expect(result.data[0].rows[0][2]).toBe(5.5);
-      expect(result.data[0].rows[1][0]).toBe('id2');
-      expect(result.data[0].rows[1][1]).toBe(2.3);
-      expect(result.data[0].rows[1][2]).toBe(4.5);
+      expect(result.data[0].length).toBe(2);
+      const field1 = result.data[0].fields[0];
+      const field2 = result.data[0].fields[1];
+      const field3 = result.data[0].fields[2];
+      expect(field1.name).toBe('id');
+      expect(field2.name).toBe('p75 value');
+      expect(field3.name).toBe('p90 value');
+
+      expect(field1.values.toArray()).toStrictEqual(['id1', 'id2']);
+      expect(field2.values.toArray()).toStrictEqual([3.3, 2.3]);
+      expect(field3.values.toArray()).toStrictEqual([5.5, 4.5]);
     });
   });
 
@@ -1058,9 +1064,11 @@ describe('ElasticResponse', () => {
     });
 
     it('should include field in metric name', () => {
-      expect(result.data[0].type).toBe('table');
-      expect(result.data[0].rows[0][1]).toBe(1000);
-      expect(result.data[0].rows[0][2]).toBe(3000);
+      expect(result.data[0].length).toBe(1);
+      expect(result.data[0].fields.length).toBe(3);
+      expect(result.data[0].fields[0].values.toArray()).toStrictEqual(['server-1']);
+      expect(result.data[0].fields[1].values.toArray()).toStrictEqual([1000]);
+      expect(result.data[0].fields[2].values.toArray()).toStrictEqual([3000]);
     });
   });
 
@@ -1248,16 +1256,15 @@ describe('ElasticResponse', () => {
     });
 
     it('should return 2 rows with 5 columns', () => {
-      expect(result.data[0].columns.length).toBe(5);
-      expect(result.data[0].rows.length).toBe(2);
-      expect(result.data[0].rows[0][1]).toBe(2);
-      expect(result.data[0].rows[0][2]).toBe(3);
-      expect(result.data[0].rows[0][3]).toBe(6);
-      expect(result.data[0].rows[0][4]).toBe(24);
-      expect(result.data[0].rows[1][1]).toBe(3);
-      expect(result.data[0].rows[1][2]).toBe(4);
-      expect(result.data[0].rows[1][3]).toBe(12);
-      expect(result.data[0].rows[1][4]).toBe(48);
+      const frame = result.data[0];
+      expect(frame.length).toBe(2);
+      const { fields } = frame;
+      expect(fields.length).toBe(5);
+      expect(fields[0].values.toArray()).toStrictEqual([1000, 2000]);
+      expect(fields[1].values.toArray()).toStrictEqual([2, 3]);
+      expect(fields[2].values.toArray()).toStrictEqual([3, 4]);
+      expect(fields[3].values.toArray()).toStrictEqual([6, 12]);
+      expect(fields[4].values.toArray()).toStrictEqual([24, 48]);
     });
   });
 

--- a/public/app/plugins/datasource/elasticsearch/ElasticResponse.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/ElasticResponse.test.ts
@@ -1,4 +1,4 @@
-import { Column, DataFrameView, Field, FieldCache, KeyValue, MutableDataFrame } from '@grafana/data';
+import { Column, DataFrameView, Field, FieldCache, FieldType, KeyValue, MutableDataFrame } from '@grafana/data';
 import flatten from 'app/core/utils/flatten';
 
 import { ElasticResponse } from './ElasticResponse';
@@ -1110,13 +1110,17 @@ describe('ElasticResponse', () => {
       result = new ElasticResponse(targets, response).getTimeSeries();
     });
 
-    it('should return docs', () => {
+    it('should return raw_document formatted data', () => {
       expect(result.data.length).toBe(1);
-      expect(result.data[0].type).toBe('docs');
-      expect(result.data[0].total).toBe(100);
-      expect(result.data[0].datapoints.length).toBe(2);
-      expect(result.data[0].datapoints[0].sourceProp).toBe('asd');
-      expect(result.data[0].datapoints[0].fieldProp).toBe('field');
+      const frame = result.data[0];
+      const { fields } = frame;
+      expect(fields.length).toBe(1);
+      const field = fields[0];
+      expect(field.type === FieldType.other);
+      const values = field.values.toArray();
+      expect(values.length).toBe(2);
+      expect(values[0].sourceProp).toBe('asd');
+      expect(values[0].fieldProp).toBe('field');
     });
   });
 

--- a/public/app/plugins/datasource/elasticsearch/ElasticResponse.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/ElasticResponse.test.ts
@@ -1,13 +1,4 @@
-import {
-  Column,
-  DataFrame,
-  DataFrameView,
-  Field,
-  FieldCache,
-  FieldType,
-  KeyValue,
-  MutableDataFrame,
-} from '@grafana/data';
+import { DataFrame, DataFrameView, Field, FieldCache, FieldType, KeyValue, MutableDataFrame } from '@grafana/data';
 import flatten from 'app/core/utils/flatten';
 
 import { ElasticResponse } from './ElasticResponse';
@@ -36,7 +27,7 @@ describe('ElasticResponse', () => {
     responses: unknown[];
   };
   let result: {
-    data: MockedResultData[];
+    data: DataFrame[];
   };
 
   describe('refId matching', () => {
@@ -331,7 +322,7 @@ describe('ElasticResponse', () => {
 
   describe('simple query count & avg aggregation', () => {
     let result: {
-      data: MockedResultData[];
+      data: DataFrame[];
     };
 
     beforeEach(() => {
@@ -386,7 +377,7 @@ describe('ElasticResponse', () => {
 
   describe('single group by query one metric', () => {
     let result: {
-      data: MockedResultData[];
+      data: DataFrame[];
     };
 
     beforeEach(() => {
@@ -448,7 +439,7 @@ describe('ElasticResponse', () => {
 
   describe('single group by query two metrics', () => {
     let result: {
-      data: MockedResultData[];
+      data: DataFrame[];
     };
 
     beforeEach(() => {
@@ -513,7 +504,7 @@ describe('ElasticResponse', () => {
 
   describe('with percentiles ', () => {
     let result: {
-      data: MockedResultData[];
+      data: DataFrame[];
     };
 
     beforeEach(() => {
@@ -563,7 +554,7 @@ describe('ElasticResponse', () => {
 
   describe('with extended_stats', () => {
     let result: {
-      data: MockedResultData[];
+      data: DataFrame[];
     };
 
     beforeEach(() => {
@@ -716,7 +707,7 @@ describe('ElasticResponse', () => {
 
   describe('single group by with alias pattern', () => {
     let result: {
-      data: MockedResultData[];
+      data: DataFrame[];
     };
 
     beforeEach(() => {
@@ -788,7 +779,7 @@ describe('ElasticResponse', () => {
 
   describe('histogram response', () => {
     let result: {
-      data: MockedResultData[];
+      data: DataFrame[];
     };
 
     beforeEach(() => {
@@ -831,7 +822,7 @@ describe('ElasticResponse', () => {
 
   describe('with two filters agg', () => {
     let result: {
-      data: MockedResultData[];
+      data: DataFrame[];
     };
 
     beforeEach(() => {
@@ -1006,7 +997,7 @@ describe('ElasticResponse', () => {
 
   describe('No group by time with percentiles ', () => {
     let result: {
-      data: MockedResultData[];
+      data: DataFrame[];
     };
 
     beforeEach(() => {
@@ -1105,7 +1096,7 @@ describe('ElasticResponse', () => {
 
   describe('Raw documents query', () => {
     let result: {
-      data: Array<MockedResultData<{ [key: string]: string | undefined }>>;
+      data: DataFrame[];
     };
     beforeEach(() => {
       targets = [
@@ -1157,7 +1148,7 @@ describe('ElasticResponse', () => {
 
   describe('with bucket_script ', () => {
     let result: {
-      data: MockedResultData[];
+      data: DataFrame[];
     };
 
     beforeEach(() => {
@@ -1226,7 +1217,7 @@ describe('ElasticResponse', () => {
 
   describe('terms with bucket_script and two scripts', () => {
     let result: {
-      data: MockedResultData[];
+      data: DataFrame[];
     };
 
     beforeEach(() => {
@@ -1557,15 +1548,4 @@ interface MockedElasticResponse {
 interface MockedQueryData {
   target: ElasticsearchQuery;
   response: MockedElasticResponse;
-}
-
-interface MockedResultData<T = number[]> {
-  refId: string;
-  target: string;
-  datapoints: T[];
-  type: string;
-  rows: number[][];
-  total: number;
-  fields: Field[];
-  columns: Column[];
 }

--- a/public/app/plugins/datasource/elasticsearch/ElasticResponse.ts
+++ b/public/app/plugins/datasource/elasticsearch/ElasticResponse.ts
@@ -487,17 +487,8 @@ export class ElasticResponse {
     const result = this.processResponseToSeries();
     return {
       ...result,
-      data: result.data.map((item) => {
-        if (item.type === 'table') {
-          return toDataFrame(item);
-        }
-        if (item.type === 'docs') {
-          return toDataFrame(item);
-        }
-        return item;
-      }),
+      data: result.data.map((item) => toDataFrame(item)),
     };
-    return result;
   }
 
   getLogs(logMessageField?: string, logLevelField?: string): DataQueryResponse {

--- a/public/app/plugins/datasource/elasticsearch/ElasticResponse.ts
+++ b/public/app/plugins/datasource/elasticsearch/ElasticResponse.ts
@@ -484,7 +484,17 @@ export class ElasticResponse {
     if (this.targets.some((target) => queryDef.hasMetricOfType(target, 'raw_data'))) {
       return this.processResponseToDataFrames(false);
     }
-    return this.processResponseToSeries();
+    const result = this.processResponseToSeries();
+    return {
+      ...result,
+      data: result.data.map((item) => {
+        if (item.type === 'table') {
+          return toDataFrame(item);
+        }
+        return item;
+      }),
+    };
+    return result;
   }
 
   getLogs(logMessageField?: string, logLevelField?: string): DataQueryResponse {

--- a/public/app/plugins/datasource/elasticsearch/ElasticResponse.ts
+++ b/public/app/plugins/datasource/elasticsearch/ElasticResponse.ts
@@ -491,6 +491,9 @@ export class ElasticResponse {
         if (item.type === 'table') {
           return toDataFrame(item);
         }
+        if (item.type === 'docs') {
+          return toDataFrame(item);
+        }
         return item;
       }),
     };

--- a/public/app/plugins/datasource/elasticsearch/datasource.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.test.ts
@@ -12,6 +12,7 @@ import {
   DateTime,
   dateTime,
   Field,
+  FieldType,
   MutableDataFrame,
   RawTimeRange,
   TimeRange,
@@ -223,11 +224,23 @@ describe('ElasticDatasource', () => {
         expect(received[0]).toEqual({
           data: [
             {
-              datapoints: [[10, 1000]],
-              metric: 'count',
-              props: {},
+              name: 'resolvedVariable',
               refId: 'test',
-              target: 'resolvedVariable',
+              fields: [
+                {
+                  name: 'Time',
+                  type: FieldType.time,
+                  config: {},
+                  values: new ArrayVector([1000]),
+                },
+                {
+                  name: 'Value',
+                  type: FieldType.number,
+                  config: {},
+                  values: new ArrayVector([10]),
+                },
+              ],
+              length: 1,
             },
           ],
         });
@@ -255,7 +268,7 @@ describe('ElasticDatasource', () => {
 
     it('should resolve the alias variable for the alias/target in the result', async () => {
       const { result } = await runScenario();
-      expect(result.data[0].target).toEqual('resolvedVariable');
+      expect(result.data[0].name).toEqual('resolvedVariable');
     });
 
     it('should json escape lucene query', async () => {


### PR DESCRIPTION
datasources usually return `DataFrame` objects from their `query()` method, but older datasources, might return other things too, like `TimeSeries`, `TableModel` etc.

for this reason, when grafana is processing the datasource-response, the code evantually calls `toDataFrame` ( https://github.com/grafana/grafana/blob/main/packages/grafana-data/src/dataframe/processDataFrame.ts#L309 ) .
this makes sure that Grafana can work with dataframes.

this pull request modifies the elastic datasource so that it's `query()` method always returns dataframes. there was only one point where non-dataframes were returned, and we simply wrap that point in an explicit call to `toDataFrame`.

the tests had to be adjusted.

the motivation here is a longer plan to "migrate" the frontend-unit-tests to the backend-mode, and for that we need the unit-tests to deal with DataFrames.

how to test:
- open the elastic datasource in explore-mode, try all kinds of settings in the elastic-query-builder, and make sure the response is always the same as it was with the previous version.
    - one easy way is to run `make devenv sources=elastic.grafana grafan_version=9.2.4` next to the locally-running Grafana, and then you can just compare `http://127.0.0.1:3001` (the `before`) with `http://localhost:3000` (the `after`).