### PR TITLE
Fix: don't show an error when receiver status is not available

### DIFF
--- a/public/app/features/alerting/unified/components/receivers/ReceiversTable.tsx
+++ b/public/app/features/alerting/unified/components/receivers/ReceiversTable.tsx
@@ -117,13 +117,13 @@ function ReceiverHealth({ errorsByReceiver, someWithNoAttempt }: ReceiverHealthP
     <Badge color={noErrorsColor} text={noErrorsText} tooltip="" />
   );
 }
+
 const useContactPointsState = (alertManagerName: string) => {
-  const contactPointsState = useGetContactPointsState(alertManagerName ?? '');
+  const contactPointsState = useGetContactPointsState(alertManagerName);
   const receivers: ReceiversState = contactPointsState?.receivers ?? {};
-  const errorStateAvailable = Object.keys(receivers).length > 0; // this logic can change depending on how we implement this in the BE
+  const errorStateAvailable = Object.keys(receivers).length > 0;
   return { contactPointsState, errorStateAvailable };
 };
-
 interface ReceiverItem {
   name: string;
   types: string[];


### PR DESCRIPTION
This PR fixes an error being thrown when alert manager doesn't have receivers status available.

`/api/alertmanager/{datasourceUID}/api/v1/receivers` => we agreed to return 404 in case the status is not available and the FE should handle this as an empty list, instead of throwing an error.

It seems that after refactoring, this error catch was removed,


