### PR TITLE
OAuth: Support pagination for GitHub orgs

### DIFF
--- a/pkg/login/social/github_oauth.go
+++ b/pkg/login/social/github_oauth.go
@@ -230,7 +230,7 @@ func (s *SocialGithub) UserInfo(client *http.Client, token *oauth2.Token) (*Basi
 		userInfo.Name = data.Name
 	}
 
-	organizationsUrl := fmt.Sprintf(s.apiUrl + "/orgs")
+	organizationsUrl := fmt.Sprintf(s.apiUrl + "/orgs?per_page=100")
 
 	if !s.IsTeamMember(client) {
 		return nil, ErrMissingTeamMembership

--- a/pkg/login/social/github_oauth.go
+++ b/pkg/login/social/github_oauth.go
@@ -174,7 +174,7 @@ func (s *SocialGithub) FetchOrganizations(client *http.Client, organizationsUrl 
 			return nil, fmt.Errorf("error getting organizations: %s", err)
 		}
 
-		for i, record := range records {
+		for _, record := range records {
 			logins = append(logins, record.Login)
 		}
 


### PR DESCRIPTION
This implements the same pagination strategy for github orgs as exists in the github teams.

Fixes #58645

