### PR TITLE
Alerting: Add tests that check current No Data behaviour with two conditions

### DIFF
--- a/pkg/expr/classic/classic_test.go
+++ b/pkg/expr/classic/classic_test.go
@@ -473,6 +473,131 @@ func TestConditionsCmd(t *testing.T) {
 			})
 			return newResults(v)
 		},
+	}, {
+		name: "two queries with two conditions using and operator and first is No Data",
+		vars: mathexp.Vars{
+			"A": mathexp.Results{
+				Values: []mathexp.Value{mathexp.NoData{}.New()},
+			},
+			"B": mathexp.Results{
+				Values: []mathexp.Value{newSeries(ptr.Float64(5))},
+			},
+		},
+		cmd: &ConditionsCmd{
+			Conditions: []condition{
+				{
+					InputRefID: "A",
+					Reducer:    reducer("min"),
+					Operator:   "and",
+					Evaluator:  &thresholdEvaluator{"gt", 1},
+				},
+				{
+					InputRefID: "B",
+					Reducer:    reducer("min"),
+					Operator:   "and",
+					Evaluator:  &thresholdEvaluator{"gt", 1},
+				},
+			},
+		},
+		expected: func() mathexp.Results {
+			v := newNumber(ptr.Float64(0))
+			v.SetMeta([]EvalMatch{{Metric: "NoData"}, {Value: ptr.Float64(5)}})
+			return newResults(v)
+		},
+	}, {
+		// TODO: NoData behavior is different if the last condition is no data
+		name: "two queries with two conditions using and operator and last is No Data",
+		vars: mathexp.Vars{
+			"A": mathexp.Results{
+				Values: []mathexp.Value{newSeries(ptr.Float64(5))},
+			},
+			"B": mathexp.Results{
+				Values: []mathexp.Value{mathexp.NoData{}.New()},
+			},
+		},
+		cmd: &ConditionsCmd{
+			Conditions: []condition{
+				{
+					InputRefID: "A",
+					Reducer:    reducer("min"),
+					Operator:   "and",
+					Evaluator:  &thresholdEvaluator{"gt", 1},
+				},
+				{
+					InputRefID: "B",
+					Reducer:    reducer("min"),
+					Operator:   "and",
+					Evaluator:  &thresholdEvaluator{"gt", 1},
+				},
+			},
+		},
+		expected: func() mathexp.Results {
+			v := newNumber(nil)
+			v.SetMeta([]EvalMatch{{Value: ptr.Float64(5)}, {Metric: "NoData"}})
+			return newResults(v)
+		},
+	}, {
+		name: "two queries with two conditions using or operator and first is No Data",
+		vars: mathexp.Vars{
+			"A": mathexp.Results{
+				Values: []mathexp.Value{mathexp.NoData{}.New()},
+			},
+			"B": mathexp.Results{
+				Values: []mathexp.Value{newSeries(ptr.Float64(5))},
+			},
+		},
+		cmd: &ConditionsCmd{
+			Conditions: []condition{
+				{
+					InputRefID: "A",
+					Reducer:    reducer("min"),
+					Operator:   "or",
+					Evaluator:  &thresholdEvaluator{"gt", 1},
+				},
+				{
+					InputRefID: "B",
+					Reducer:    reducer("min"),
+					Operator:   "or",
+					Evaluator:  &thresholdEvaluator{"gt", 1},
+				},
+			},
+		},
+		expected: func() mathexp.Results {
+			v := newNumber(nil)
+			v.SetMeta([]EvalMatch{{Metric: "NoData"}, {Value: ptr.Float64(5)}})
+			return newResults(v)
+		},
+	}, {
+		name: "two queries with two conditions using or operator and last is No Data",
+		vars: mathexp.Vars{
+			"A": mathexp.Results{
+				Values: []mathexp.Value{newSeries(ptr.Float64(5))},
+			},
+			"B": mathexp.Results{
+				Values: []mathexp.Value{mathexp.NoData{}.New()},
+			},
+		},
+		cmd: &ConditionsCmd{
+			Conditions: []condition{
+				{
+					InputRefID: "A",
+					Reducer:    reducer("min"),
+					Operator:   "or",
+					Evaluator:  &thresholdEvaluator{"gt", 1},
+				},
+				{
+					InputRefID: "B",
+					Reducer:    reducer("min"),
+					Operator:   "or",
+					Evaluator:  &thresholdEvaluator{"gt", 1},
+				},
+			},
+		},
+		expected: func() mathexp.Results {
+			v := newNumber(nil)
+			v.SetMeta([]EvalMatch{{Value: ptr.Float64(5)}, {Metric: "NoData"}})
+			return newResults(v)
+		},
 	}}
 
 	for _, tt := range tests {


### PR DESCRIPTION
**Which issue(s) does this PR fix?**:

This test asserts some incorrect behaviour of `ConditionsCmd` where it returns a different result if the last condition is No Data.

Fixes #

**Special notes for your reviewer**:

