### PR TITLE
Chore: Fix some as HTMLElement type assertions

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -4651,8 +4651,7 @@ exports[`better eslint`] = {
     "public/app/features/search/state/SearchStateManager.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"],
-      [0, 0, 0, "Do not use any type assertions.", "2"],
-      [0, 0, 0, "Do not use any type assertions.", "3"]
+      [0, 0, 0, "Do not use any type assertions.", "2"]
     ],
     "public/app/features/search/types.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
@@ -6349,8 +6348,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
     "public/app/plugins/datasource/prometheus/components/PromQueryEditor.tsx:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
-      [0, 0, 0, "Do not use any type assertions.", "1"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
     "public/app/plugins/datasource/prometheus/components/PromQueryEditorByApp.test.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
@@ -6850,13 +6848,10 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
       [0, 0, 0, "Do not use any type assertions.", "3"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "4"],
-      [0, 0, 0, "Do not use any type assertions.", "5"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "5"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "6"],
       [0, 0, 0, "Do not use any type assertions.", "7"],
-      [0, 0, 0, "Do not use any type assertions.", "8"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "9"],
-      [0, 0, 0, "Do not use any type assertions.", "10"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "11"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "8"]
     ],
     "public/app/plugins/datasource/testdata/components/PredictablePulseEditor.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
@@ -6876,13 +6871,11 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "1"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
       [0, 0, 0, "Do not use any type assertions.", "3"],
-      [0, 0, 0, "Do not use any type assertions.", "4"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "5"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "4"]
     ],
     "public/app/plugins/datasource/testdata/components/SimulationSchemaForm.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
-      [0, 0, 0, "Do not use any type assertions.", "2"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
     ],
     "public/app/plugins/datasource/testdata/components/StreamingClientEditor.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
@@ -7005,11 +6998,10 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
       [0, 0, 0, "Do not use any type assertions.", "2"],
-      [0, 0, 0, "Do not use any type assertions.", "3"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "4"],
-      [0, 0, 0, "Do not use any type assertions.", "5"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "6"],
-      [0, 0, 0, "Do not use any type assertions.", "7"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "3"],
+      [0, 0, 0, "Do not use any type assertions.", "4"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "5"],
+      [0, 0, 0, "Do not use any type assertions.", "6"]
     ],
     "public/app/plugins/panel/barchart/module.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
@@ -7066,9 +7058,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "9"],
       [0, 0, 0, "Do not use any type assertions.", "10"],
       [0, 0, 0, "Do not use any type assertions.", "11"]
-    ],
-    "public/app/plugins/panel/canvas/CanvasContextMenu.tsx:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
     "public/app/plugins/panel/canvas/CanvasPanel.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
@@ -8184,9 +8173,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "14"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "15"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "16"]
-    ],
-    "public/app/plugins/panel/timeseries/plugins/ContextMenuPlugin.tsx:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
     "public/app/plugins/panel/timeseries/plugins/annotations/AnnotationEditor.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]

--- a/public/app/features/search/state/SearchStateManager.ts
+++ b/public/app/features/search/state/SearchStateManager.ts
@@ -105,7 +105,7 @@ export class SearchStateManager extends StateManagerBase<SearchState> {
   };
 
   onStarredFilterChange = (e: FormEvent<HTMLInputElement>) => {
-    const starred = (e.target as HTMLInputElement).checked;
+    const starred = e.currentTarget.checked;
     this.setStateAndDoSearch({ starred });
   };
 

--- a/public/app/plugins/datasource/prometheus/components/PromQueryEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromQueryEditor.tsx
@@ -75,7 +75,7 @@ export class PromQueryEditor extends PureComponent<PromQueryEditorProps, State> 
   };
 
   onInstantChange = (e: React.SyntheticEvent<HTMLInputElement>) => {
-    const instant = (e.target as HTMLInputElement).checked;
+    const instant = e.currentTarget.checked;
     this.query.instant = instant;
     this.setState({ instant }, this.onRunQuery);
   };

--- a/public/app/plugins/datasource/testdata/QueryEditor.tsx
+++ b/public/app/plugins/datasource/testdata/QueryEditor.tsx
@@ -124,22 +124,22 @@ export const QueryEditor = ({ query, datasource, onChange, onRunQuery }: Props) 
   };
 
   const onInputChange = (e: FormEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-    const { name, value, type } = e.target as HTMLInputElement | HTMLTextAreaElement;
+    const { name, value, type } = e.currentTarget;
     let newValue: any = value;
 
     if (type === 'number') {
       newValue = Number(value);
     }
 
-    if (name === 'levelColumn') {
-      newValue = (e.target as HTMLInputElement).checked;
+    if (name === 'levelColumn' && e.currentTarget instanceof HTMLInputElement) {
+      newValue = e.currentTarget.checked;
     }
 
     onUpdate({ ...query, [name]: newValue });
   };
 
   const onFieldChange = (field: string) => (e: ChangeEvent<HTMLInputElement>) => {
-    const { name, value, type } = e.target as HTMLInputElement;
+    const { name, value, type } = e.currentTarget;
     let newValue: any = value;
 
     if (type === 'number') {

--- a/public/app/plugins/datasource/testdata/components/SimulationQueryEditor.tsx
+++ b/public/app/plugins/datasource/testdata/components/SimulationQueryEditor.tsx
@@ -64,7 +64,7 @@ export const SimulationQueryEditor = ({ onChange, query, ds }: EditorProps) => {
   };
 
   const onUIDChanged = (e: FormEvent<HTMLInputElement>) => {
-    const { value } = e.target as HTMLInputElement;
+    const { value } = e.currentTarget;
     onUpdateKey({ ...simKey, uid: value ?? undefined });
   };
 

--- a/public/app/plugins/datasource/testdata/components/SimulationSchemaForm.tsx
+++ b/public/app/plugins/datasource/testdata/components/SimulationSchemaForm.tsx
@@ -60,7 +60,7 @@ export const SimulationSchemaForm = ({ config, schema, onChange }: SchemaFormPro
   const styles = useStyles2(getStyles);
 
   const onUpdateTextArea = (event: FormEvent<HTMLTextAreaElement>) => {
-    const element = event.target as HTMLInputElement;
+    const element = event.currentTarget;
     onChange(JSON.parse(element.value));
   };
 

--- a/public/app/plugins/panel/barchart/bars.ts
+++ b/public/app/plugins/panel/barchart/bars.ts
@@ -417,7 +417,9 @@ export function getConfig(opts: BarsOptions, theme: GrafanaTheme2) {
     let over = u.over;
     over.style.overflow = 'hidden';
     u.root.querySelectorAll('.u-cursor-pt').forEach((el) => {
-      (el as HTMLElement).style.borderRadius = '0';
+      if (el instanceof HTMLElement) {
+        el.style.borderRadius = '0';
+      }
     });
   };
 

--- a/public/app/plugins/panel/canvas/CanvasContextMenu.tsx
+++ b/public/app/plugins/panel/canvas/CanvasContextMenu.tsx
@@ -36,8 +36,11 @@ export const CanvasContextMenu = ({ scene, panel }: Props) => {
       panel.setActivePanel();
 
       const shouldSelectElement = event.currentTarget !== scene.div;
-      if (shouldSelectElement) {
-        scene.select({ targets: [event.currentTarget as HTMLElement | SVGElement] });
+      if (
+        shouldSelectElement &&
+        (event.currentTarget instanceof HTMLElement || event.currentTarget instanceof SVGElement)
+      ) {
+        scene.select({ targets: [event.currentTarget] });
       }
       setAnchorPoint({ x: event.pageX, y: event.pageY });
       setIsMenuVisible(true);

--- a/public/app/plugins/panel/timeseries/plugins/ContextMenuPlugin.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/ContextMenuPlugin.tsx
@@ -119,9 +119,8 @@ export const ContextMenuPlugin: React.FC<ContextMenuPluginProps> = ({
         }
         isClick = true;
 
-        if (e.target) {
-          const target = e.target as HTMLElement;
-          if (!target.classList.contains('u-cursor-pt')) {
+        if (e.target instanceof HTMLElement) {
+          if (!e.target.classList.contains('u-cursor-pt')) {
             pluginLog('ContextMenuPlugin', false, 'canvas click');
             setPoint({ seriesIdx: null, dataIdx: null });
           }


### PR DESCRIPTION
**What is this feature?**

Removes from `as HTMLElement` (etc) type assertions from a bunch of event handlers, in favor of narrowing the type with `instanceof`.

**Why do we need this feature?**

 - so number go down

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

