### PR TITLE
CI: Make build and store storybook trigger in the release process

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2132,9 +2132,8 @@ steps:
   image: grafana/build-container:1.6.5
   name: build-storybook
   when:
-    paths:
-      include:
-      - packages/grafana-ui/**
+    event:
+    - tag
 - commands:
   - ./bin/grabpl upload-cdn --edition oss
   depends_on:
@@ -2177,9 +2176,8 @@ steps:
   image: grafana/grafana-ci-deploy:1.3.3
   name: store-storybook
   when:
-    paths:
-      include:
-      - packages/grafana-ui/**
+    event:
+    - tag
 - commands:
   - ./bin/grabpl artifacts npm store --tag ${DRONE_TAG}
   depends_on:
@@ -5514,6 +5512,6 @@ kind: secret
 name: packages_secret_access_key
 ---
 kind: signature
-hmac: 1d42ccac383b4cacb1a626ffdc71847208cca3b464a5ba80e012703b47d2b347
+hmac: 4f5e09af0ec5a9d59c5e31333bf180dd52cba1ad2780d96a62d20583113ccb16
 
 ...

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -16,13 +16,6 @@ trigger_oss = {
         'grafana/grafana',
     ]
 }
-trigger_storybook = {
-    'paths': {
-        'include': [
-            'packages/grafana-ui/**',
-        ],
-    }
-}
 
 
 def slack_step(channel, template, secret):
@@ -259,7 +252,7 @@ def build_storybook_step(edition, ver_mode):
             'yarn storybook:build',
             './bin/grabpl verify-storybook',
         ],
-        'when': trigger_storybook,
+        'when': get_trigger_storybook(ver_mode),
     }
 
 
@@ -287,7 +280,7 @@ def store_storybook_step(edition, ver_mode, trigger=None):
             'PRERELEASE_BUCKET': from_secret(prerelease_bucket)
         },
         'commands': commands,
-        'when': trigger_storybook,
+        'when': get_trigger_storybook(ver_mode),
     }
     if trigger and ver_mode in ("release-branch", "main"):
         # no dict merge operation available, https://github.com/harness/drone-cli/pull/220
@@ -1282,3 +1275,19 @@ def compile_build_cmd(edition='oss'):
             'CGO_ENABLED': 0,
     },
 }
+
+def get_trigger_storybook(ver_mode):
+    trigger_storybook = ''
+    if ver_mode == 'release':
+        trigger_storybook = {
+            'event': ['tag']
+        }
+    else:
+        trigger_storybook = {
+            'paths': {
+                'include': [
+                    'packages/grafana-ui/**',
+                ],
+            }
+        }
+    return trigger_storybook


### PR DESCRIPTION
**Why do we need this feature?**

During `9.2.4` release, we encountered a failure with the storybook. This was due to storybook missing, since it wasn't built and stored anywhere. The storybook means to be triggered only when there are ui packages changes and doesn't care about the typo of the build happening.
This PR, makes the storybook triggers conditional, to run for ui changes on main and by default on releases.