### PR TITLE
Auth: Always include oauth and saml settings for frontend

### DIFF
--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -198,6 +198,9 @@ func (hs *HTTPServer) getFrontendSettingsMap(c *models.ReqContext) (map[string]i
 		"unifiedAlerting": map[string]interface{}{
 			"minInterval": hs.Cfg.UnifiedAlerting.MinInterval.String(),
 		},
+		"oauth":       hs.getEnabledOAuthProviders(),
+		"samlEnabled": hs.samlEnabled(),
+		"samlName":    hs.samlName(),
 	}
 
 	if hs.ThumbService != nil {
@@ -500,4 +503,15 @@ func (hs *HTTPServer) pluginSettings(ctx context.Context, orgID int64) (map[stri
 	}
 
 	return pluginSettings, nil
+}
+
+func (hs *HTTPServer) getEnabledOAuthProviders() map[string]interface{} {
+	providers := make(map[string]interface{})
+	for key, oauth := range hs.SocialService.GetOAuthInfoProviders() {
+		providers[key] = map[string]string{
+			"name": oauth.Name,
+			"icon": oauth.Icon,
+		}
+	}
+	return providers
 }

--- a/pkg/api/frontendsettings_test.go
+++ b/pkg/api/frontendsettings_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/grafana/grafana/pkg/login/social"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -57,6 +58,7 @@ func setupTestEnvironment(t *testing.T, cfg *setting.Cfg, features *featuremgmt.
 		grafanaUpdateChecker: &updatechecker.GrafanaService{},
 		AccessControl:        accesscontrolmock.New().WithDisabled(),
 		PluginSettings:       pluginSettings.ProvideService(sqlStore, secretsService),
+		SocialService:        social.ProvideService(cfg),
 	}
 
 	m := web.New()

--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -91,19 +91,6 @@ func (hs *HTTPServer) LoginView(c *models.ReqContext) {
 		return
 	}
 
-	enabledOAuths := make(map[string]interface{})
-	providers := hs.SocialService.GetOAuthInfoProviders()
-	for key, oauth := range providers {
-		enabledOAuths[key] = map[string]string{
-			"name": oauth.Name,
-			"icon": oauth.Icon,
-		}
-	}
-
-	viewData.Settings["oauth"] = enabledOAuths
-	viewData.Settings["samlEnabled"] = hs.samlEnabled()
-	viewData.Settings["samlName"] = hs.samlName()
-
 	if loginError, ok := hs.tryGetEncryptedCookie(c, loginErrorCookieName); ok {
 		// this cookie is only set whenever an OAuth login fails
 		// therefore the loginError should be passed to the view data


### PR DESCRIPTION
**What is this feature?**
OAuth and Saml settings was only provided to frontend if a user visited GET /login. When we do frontend redirect to /login  any configured oauth or saml will not be displayed

This is not a problem for ldap because that is always part of frontend settings map.

**Why do we need this feature?**
If we start grafana with GF_USERS_ALLOW_SIGN_UP=false and go directly to <url>/signup we perform a frontend redirect to /login. Then any configured oauth or saml instances would be missing.

This is also true for /verify that does a redirect to /signup that then redirects to /login

Fixes #57651

