### PR TITLE
Explore: A11y of range slider in query history

### DIFF
--- a/packages/grafana-ui/src/components/Slider/RangeSlider.tsx
+++ b/packages/grafana-ui/src/components/Slider/RangeSlider.tsx
@@ -73,8 +73,6 @@ export const RangeSlider: FunctionComponent<RangeSliderProps> = ({
         onAfterChange={handleAfterChange}
         vertical={!isHorizontal}
         reverse={reverse}
-        // TODO: The following is a temporary work around for making content after the slider accessible and it will be removed when fixing the slider in public/app/features/explore/RichHistory/RichHistoryQueriesTab.tsx.
-        tabIndex={[0, 1]}
         handleRender={tipHandleRender}
       />
     </div>


### PR DESCRIPTION
Fixes [#46480](https://github.com/grafana/grafana/issues/46480)

In the meantime the issue got solved probably by updating the slider version and I only had to remove the tabIndex.