### PR TITLE
Transformations: Make Card Descriptions Clickable

### DIFF
--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationsEditor.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationsEditor.tsx
@@ -380,7 +380,7 @@ function TransformationCard({ transform, onClick }: TransformationCardProps) {
       onClick={onClick}
     >
       <Card.Heading>{transform.name}</Card.Heading>
-      <Card.Meta>{transform.description}</Card.Meta>
+      <Card.Description>{transform.description}</Card.Description>
       {transform.state && (
         <Card.Tags>
           <PluginStateInfo state={transform.state} />


### PR DESCRIPTION
Fixes #58616

**Special notes for your reviewer**:

Currently you cannot add a transformation when you try clicking on the transformation's description. The larger card and the title work just fine (see screencast below). 

This change makes the description 'clickable'. But the text is now larger. I don't know if we want to adjust that so it is smaller like it was when using the `Card.Meta`

![CleanShot 2022-11-14 at 10 22 46](https://user-images.githubusercontent.com/37156449/201761172-2694cde3-4801-4a53-972e-d8b9a2baa803.gif)
