### PR TITLE
Use relref resolved from nearest section

### DIFF
--- a/docs/sources/setup-grafana/image-rendering/troubleshooting/index.md
+++ b/docs/sources/setup-grafana/image-rendering/troubleshooting/index.md
@@ -30,9 +30,9 @@ filters = rendering:debug
 
 You can also enable more logs in image renderer service itself by:
 
-- Increasing the [log level]({{< relref "../../image-rendering#log-level" >}}).
-- Enabling [verbose logging]({{< relref "../../image-rendering#verbose-logging" >}}).
-- [Capturing headless browser output]({{< relref "../../image-rendering#capture-browser-output" >}}).
+- Increasing the [log level]({{< relref ".#log-level" >}}).
+- Enabling [verbose logging]({{< relref "./#verbose-logging" >}}).
+- [Capturing headless browser output]({{< relref "./#capture-browser-output" >}}).
 
 ## Missing libraries
 


### PR DESCRIPTION
As image-rendering is a branch bundle, it is considered a section by Hugo and relrefs should be resolved from there even for child pages.

The behavior that worked in `next` but not `latest` could be explained by the lenient but potentially ambiguous relref resolution algorithm Hugo uses. However, I have not determined the exact difference between the two sets of content that causes `next` to work but `latest` not to.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>