### PR TITLE
Search: Revert "load dashboard performance improvements"

### DIFF
--- a/pkg/services/searchV2/index.go
+++ b/pkg/services/searchV2/index.go
@@ -846,101 +846,30 @@ func (l sqlDashboardLoader) loadAllDashboards(ctx context.Context, limit int, or
 			dashboardQuerySpan.SetAttributes("dashboardUID", dashboardUID, attribute.Key("dashboardUID").String(dashboardUID))
 			dashboardQuerySpan.SetAttributes("lastID", lastID, attribute.Key("lastID").Int64(lastID))
 
-			var slices [][]string
+			rows := make([]*dashboardQueryResult, 0)
 			err := l.sql.WithDbSession(dashboardQueryCtx, func(sess *db.Session) error {
-				sql := "select id, uid, is_folder, folder_id, slug, data, created, updated from dashboard where org_id = ?"
-				sqlAndArgs := []interface{}{"", orgID}
+				sess.Table("dashboard").
+					Where("org_id = ?", orgID)
 
 				if lastID > 0 {
-					sql += " AND id > ?"
-					sqlAndArgs = append(sqlAndArgs, lastID)
+					sess.Where("id > ?", lastID)
 				}
 
 				if dashboardUID != "" {
-					sql += " AND uid = ?"
-					sqlAndArgs = append(sqlAndArgs, dashboardUID)
+					sess.Where("uid = ?", dashboardUID)
 				}
 
-				sql += " order by id asc"
-				sql += " limit ?"
-				sqlAndArgs = append(sqlAndArgs, limit)
+				sess.Cols("id", "uid", "is_folder", "folder_id", "data", "slug", "created", "updated")
 
-				sqlAndArgs[0] = sql
-				output, err := sess.QuerySliceString(sqlAndArgs...)
-				slices = output
-				return err
+				sess.OrderBy("id ASC")
+				sess.Limit(limit)
+
+				return sess.Find(&rows)
 			})
 
-			dashboardQuerySpan.SetAttributes("dashboardCount", len(slices), attribute.Key("dashboardCount").Int(len(slices)))
-
-			if err != nil || slices == nil {
-				dashboardQuerySpan.End()
-				ch <- &dashboardsRes{
-					dashboards: nil,
-					err:        err,
-				}
-				break
-			}
-
-			rows := make([]*dashboardQueryResult, len(slices))
-			var parsingErr error
-			for i := range slices {
-				if len(slices[i]) < 8 {
-					parsingErr = fmt.Errorf("expected the dashboard row at index %d to contain 8 elements, has %d. lastID: %d", i, len(slices[i]), lastID)
-					break
-				}
-
-				id, err := strconv.ParseInt(slices[i][0], 10, 64)
-				if err != nil {
-					parsingErr = err
-					break
-				}
-				uid := slices[i][1]
-				isFolder := false
-				if slices[i][2] == "1" {
-					isFolder = true
-				}
-
-				folderID, err := strconv.ParseInt(slices[i][3], 10, 64)
-				if err != nil {
-					parsingErr = err
-					break
-				}
-
-				// xorm/session_query.go::value2String() uses `time.RFC3339Nano` to format the time type
-				created, err := time.Parse(time.RFC3339Nano, slices[i][6])
-				if err != nil {
-					parsingErr = err
-					break
-				}
-				updated, err := time.Parse(time.RFC3339Nano, slices[i][7])
-				if err != nil {
-					parsingErr = err
-					break
-				}
-
-				rows[i] = &dashboardQueryResult{
-					Id:       id,
-					Uid:      uid,
-					IsFolder: isFolder,
-					FolderID: folderID,
-					Slug:     slices[i][4],
-					Data:     []byte(slices[i][5]),
-					Created:  created,
-					Updated:  updated,
-				}
-			}
-
 			dashboardQuerySpan.End()
-			if parsingErr != nil {
-				ch <- &dashboardsRes{
-					dashboards: nil,
-					err:        parsingErr,
-				}
-				break
-			}
 
-			if len(rows) < limit || dashboardUID != "" {
+			if err != nil || len(rows) < limit || dashboardUID != "" {
 				ch <- &dashboardsRes{
 					dashboards: rows,
 					err:        err,
@@ -1010,7 +939,7 @@ func (l sqlDashboardLoader) LoadDashboards(ctx context.Context, orgID int64, das
 	for {
 		res, ok := <-dashboardsChannel
 		if res != nil && res.err != nil {
-			l.logger.Error("Error when loading dashboards", "error", res.err, "orgID", orgID, "dashboardUID", dashboardUID)
+			l.logger.Error("Error when loading dashboards", "error", err, "orgID", orgID, "dashboardUID", dashboardUID)
 			break
 		}
 
@@ -1020,14 +949,14 @@ func (l sqlDashboardLoader) LoadDashboards(ctx context.Context, orgID int64, das
 
 		rows := res.dashboards
 
-		readDashboardCtx, readDashboardSpan := l.tracer.Start(ctx, "sqlDashboardLoader readDashboard")
+		_, readDashboardSpan := l.tracer.Start(ctx, "sqlDashboardLoader readDashboard")
 		readDashboardSpan.SetAttributes("orgID", orgID, attribute.Key("orgID").Int64(orgID))
 		readDashboardSpan.SetAttributes("dashboardCount", len(rows), attribute.Key("dashboardCount").Int(len(rows)))
 
 		reader := kdash.NewStaticDashboardSummaryBuilder(lookup, false)
 
 		for _, row := range rows {
-			summary, _, err := reader(readDashboardCtx, row.Uid, row.Data)
+			summary, _, err := reader(ctx, row.Uid, row.Data)
 			if err != nil {
 				l.logger.Warn("Error indexing dashboard data", "error", err, "dashboardId", row.Id, "dashboardSlug", row.Slug)
 				// But append info anyway for now, since we possibly extracted useful information.


### PR DESCRIPTION
Reverts [grafana/grafana#57509](https://github.com/grafana/grafana/pull/57509)


The original PR has issues with formatting the time:

```
logger=sqlDashboardLoader t=2022-11-15T07:16:44.877810534Z level=error msg="Error when loading dashboards" error="parsing time \"0001-01-01 00:00:00\" as \"2006-01-02T15:04:05.999999999Z07:00\": cannot parse \" 00:00:00\" as \"T\"" orgID=1 dashboardUID=
```