### PR TITLE
Scene: Experiment with moving some function away from SceneObjectBase

### DIFF
--- a/public/app/features/scenes/components/SceneCanvasText.tsx
+++ b/public/app/features/scenes/components/SceneCanvasText.tsx
@@ -3,6 +3,7 @@ import React, { CSSProperties } from 'react';
 import { Field, Input } from '@grafana/ui';
 
 import { SceneObjectBase } from '../core/SceneObjectBase';
+import { sceneGraph } from '../core/sceneGraph';
 import { SceneComponentProps, SceneLayoutChildState } from '../core/types';
 import { VariableDependencyConfig } from '../variables/VariableDependencyConfig';
 
@@ -31,7 +32,7 @@ export class SceneCanvasText extends SceneObjectBase<SceneCanvasTextState> {
 
     return (
       <div style={style} data-testid={key}>
-        {model.interpolate(text)}
+        {sceneGraph.interpolateFor(model, text)}
       </div>
     );
   };

--- a/public/app/features/scenes/components/ScenePanelRepeater.tsx
+++ b/public/app/features/scenes/components/ScenePanelRepeater.tsx
@@ -4,6 +4,7 @@ import { LoadingState, PanelData } from '@grafana/data';
 
 import { SceneDataNode } from '../core/SceneDataNode';
 import { SceneObjectBase } from '../core/SceneObjectBase';
+import { sceneGraph } from '../core/sceneGraph';
 import {
   SceneComponentProps,
   SceneObject,
@@ -21,7 +22,7 @@ export class ScenePanelRepeater extends SceneObjectBase<RepeatOptions> {
     super.activate();
 
     this._subs.add(
-      this.getData().subscribeToState({
+      sceneGraph.getDataFor(this).subscribeToState({
         next: (data) => {
           if (data.data?.state === LoadingState.Done) {
             this.performRepeat(data.data);

--- a/public/app/features/scenes/components/SceneTimePicker.tsx
+++ b/public/app/features/scenes/components/SceneTimePicker.tsx
@@ -4,6 +4,7 @@ import { RefreshPicker, ToolbarButtonRow } from '@grafana/ui';
 import { TimePickerWithHistory } from 'app/core/components/TimePicker/TimePickerWithHistory';
 
 import { SceneObjectBase } from '../core/SceneObjectBase';
+import { sceneGraph } from '../core/sceneGraph';
 import { SceneComponentProps, SceneObjectStatePlain } from '../core/types';
 
 export interface SceneTimePickerState extends SceneObjectStatePlain {
@@ -16,7 +17,7 @@ export class SceneTimePicker extends SceneObjectBase<SceneTimePickerState> {
 
 function SceneTimePickerRenderer({ model }: SceneComponentProps<SceneTimePicker>) {
   const { hidePicker } = model.useState();
-  const timeRange = model.getTimeRange();
+  const timeRange = sceneGraph.getTimeRangeFor(model);
   const timeRangeState = timeRange.useState();
 
   if (hidePicker) {

--- a/public/app/features/scenes/components/VizPanel.tsx
+++ b/public/app/features/scenes/components/VizPanel.tsx
@@ -42,7 +42,7 @@ function ScenePanelRenderer({ model }: SceneComponentProps<VizPanel>) {
   const { title, pluginId, options, fieldConfig } = model.useState();
   const { data } = sceneGraph.getDataFor(model).useState();
 
-  const titleInterpolated = model.interpolate(title);
+  const titleInterpolated = sceneGraph.interpolateFor(model, title);
 
   return (
     <AutoSizer>

--- a/public/app/features/scenes/components/VizPanel.tsx
+++ b/public/app/features/scenes/components/VizPanel.tsx
@@ -6,6 +6,7 @@ import { PanelRenderer } from '@grafana/runtime';
 import { Field, PanelChrome, Input } from '@grafana/ui';
 
 import { SceneObjectBase } from '../core/SceneObjectBase';
+import { sceneGraph } from '../core/sceneGraph';
 import { SceneComponentProps, SceneLayoutChildState } from '../core/types';
 import { VariableDependencyConfig } from '../variables/VariableDependencyConfig';
 
@@ -25,7 +26,7 @@ export class VizPanel extends SceneObjectBase<VizPanelState> {
   });
 
   public onSetTimeRange = (timeRange: AbsoluteTimeRange) => {
-    const sceneTimeRange = this.getTimeRange();
+    const sceneTimeRange = sceneGraph.getTimeRangeFor(this);
     sceneTimeRange.setState({
       raw: {
         from: toUtc(timeRange.from),
@@ -39,7 +40,7 @@ export class VizPanel extends SceneObjectBase<VizPanelState> {
 
 function ScenePanelRenderer({ model }: SceneComponentProps<VizPanel>) {
   const { title, pluginId, options, fieldConfig } = model.useState();
-  const { data } = model.getData().useState();
+  const { data } = sceneGraph.getDataFor(model).useState();
 
   const titleInterpolated = model.interpolate(title);
 

--- a/public/app/features/scenes/core/SceneComponentWrapper.tsx
+++ b/public/app/features/scenes/core/SceneComponentWrapper.tsx
@@ -1,8 +1,6 @@
 import React, { useEffect } from 'react';
 
-import { SceneComponentEditingWrapper } from '../editor/SceneComponentEditWrapper';
-
-import { SceneComponentProps, SceneObject } from './types';
+import { SceneComponentProps, SceneEditor, SceneObject } from './types';
 
 export function SceneComponentWrapper<T extends SceneObject>({ model, isEditing }: SceneComponentProps<T>) {
   const Component = (model as any).constructor['Component'] ?? EmptyRenderer;
@@ -28,9 +26,29 @@ export function SceneComponentWrapper<T extends SceneObject>({ model, isEditing 
     return inner;
   }
 
-  return <SceneComponentEditingWrapper model={model}>{inner}</SceneComponentEditingWrapper>;
+  const editor = getSceneEditor(model);
+  const EditWrapper = getSceneEditor(model).getEditComponentWrapper();
+
+  return (
+    <EditWrapper model={model} editor={editor}>
+      {inner}
+    </EditWrapper>
+  );
 }
 
 function EmptyRenderer<T>(_: SceneComponentProps<T>): React.ReactElement | null {
   return null;
+}
+
+function getSceneEditor(sceneObject: SceneObject): SceneEditor {
+  const { $editor } = sceneObject.state;
+  if ($editor) {
+    return $editor;
+  }
+
+  if (sceneObject.parent) {
+    return getSceneEditor(sceneObject.parent);
+  }
+
+  throw new Error('No editor found in scene tree');
 }

--- a/public/app/features/scenes/core/SceneObjectBase.tsx
+++ b/public/app/features/scenes/core/SceneObjectBase.tsx
@@ -5,7 +5,6 @@ import { v4 as uuidv4 } from 'uuid';
 import { BusEvent, BusEventHandler, BusEventType, EventBusSrv } from '@grafana/data';
 import { useForceUpdate } from '@grafana/ui';
 
-import { sceneInterpolator } from '../variables/interpolation/sceneInterpolator';
 import { SceneVariableDependencyConfigLike } from '../variables/types';
 
 import { SceneComponentWrapper } from './SceneComponentWrapper';
@@ -187,19 +186,6 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = SceneObj
    */
   public clone(withState?: Partial<TState>): this {
     return cloneSceneObject(this, withState);
-  }
-
-  /**
-   * Interpolates the given string using the current scene object as context.
-   * TODO: Cache interpolatinos?
-   */
-  public interpolate(value: string | undefined) {
-    // Skip interpolation if there are no variable dependencies
-    if (!value || !this._variableDependency || this._variableDependency.getNames().size === 0) {
-      return value ?? '';
-    }
-
-    return sceneInterpolator(this, value);
   }
 }
 

--- a/public/app/features/scenes/core/SceneObjectBase.tsx
+++ b/public/app/features/scenes/core/SceneObjectBase.tsx
@@ -6,11 +6,11 @@ import { BusEvent, BusEventHandler, BusEventType, EventBusSrv } from '@grafana/d
 import { useForceUpdate } from '@grafana/ui';
 
 import { sceneInterpolator } from '../variables/interpolation/sceneInterpolator';
-import { SceneVariables, SceneVariableDependencyConfigLike } from '../variables/types';
+import { SceneVariableDependencyConfigLike } from '../variables/types';
 
 import { SceneComponentWrapper } from './SceneComponentWrapper';
 import { SceneObjectStateChangedEvent } from './events';
-import { SceneDataState, SceneObject, SceneComponent, SceneEditor, SceneTimeRange, SceneObjectState } from './types';
+import { SceneObject, SceneComponent, SceneObjectState } from './types';
 import { cloneSceneObject, forEachSceneObjectInState } from './utils';
 
 export abstract class SceneObjectBase<TState extends SceneObjectState = SceneObjectState>
@@ -175,66 +175,6 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = SceneObj
   public useState() {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     return useSceneObjectState(this);
-  }
-
-  /**
-   * Will walk up the scene object graph to the closest $timeRange scene object
-   */
-  public getTimeRange(): SceneTimeRange {
-    const { $timeRange } = this.state;
-    if ($timeRange) {
-      return $timeRange;
-    }
-
-    if (this.parent) {
-      return this.parent.getTimeRange();
-    }
-
-    throw new Error('No time range found in scene tree');
-  }
-
-  /**
-   * Will walk up the scene object graph to the closest $data scene object
-   */
-  public getData(): SceneObject<SceneDataState> {
-    const { $data } = this.state;
-    if ($data) {
-      return $data;
-    }
-
-    if (this.parent) {
-      return this.parent.getData();
-    }
-
-    throw new Error('No data found in scene tree');
-  }
-
-  public getVariables(): SceneVariables | undefined {
-    if (this.state.$variables) {
-      return this.state.$variables;
-    }
-
-    if (this.parent) {
-      return this.parent.getVariables();
-    }
-
-    return undefined;
-  }
-
-  /**
-   * Will walk up the scene object graph to the closest $editor scene object
-   */
-  public getSceneEditor(): SceneEditor {
-    const { $editor } = this.state;
-    if ($editor) {
-      return $editor;
-    }
-
-    if (this.parent) {
-      return this.parent.getSceneEditor();
-    }
-
-    throw new Error('No editor found in scene tree');
   }
 
   /** Force a re-render, should only be needed when variable values change */

--- a/public/app/features/scenes/core/sceneGraph.ts
+++ b/public/app/features/scenes/core/sceneGraph.ts
@@ -1,0 +1,90 @@
+import { getDefaultTimeRange, LoadingState } from '@grafana/data';
+
+import { SceneVariableSet } from '../variables/sets/SceneVariableSet';
+import { SceneVariables } from '../variables/types';
+
+import { SceneDataNode } from './SceneDataNode';
+import { SceneTimeRange as SceneTimeRangeImpl } from './SceneTimeRange';
+import { SceneDataState, SceneEditor, SceneObject, SceneTimeRange } from './types';
+
+/**
+ * Get the closest node with variables
+ */
+export function getVariablesFor(sceneObject: SceneObject): SceneVariables {
+  if (sceneObject.state.$variables) {
+    return sceneObject.state.$variables;
+  }
+
+  if (sceneObject.parent) {
+    return getVariablesFor(sceneObject.parent);
+  }
+
+  return EmptyVariableSet;
+}
+
+/**
+ * Will walk up the scene object graph to the closest $data scene object
+ */
+export function getDataFor(sceneObject: SceneObject): SceneObject<SceneDataState> {
+  const { $data } = sceneObject.state;
+  if ($data) {
+    return $data;
+  }
+
+  if (sceneObject.parent) {
+    return getDataFor(sceneObject.parent);
+  }
+
+  return EmptyDataNode;
+}
+
+/**
+ * Will walk up the scene object graph to the closest $timeRange scene object
+ */
+export function getTimeRangeFor(sceneObject: SceneObject): SceneTimeRange {
+  const { $timeRange } = sceneObject.state;
+  if ($timeRange) {
+    return $timeRange;
+  }
+
+  if (sceneObject.parent) {
+    return getTimeRangeFor(sceneObject.parent);
+  }
+
+  return DefaultTimeRange;
+}
+
+/**
+ * Will walk up the scene object graph to the closest $editor scene object
+ */
+export function getSceneEditorFor(sceneObject: SceneObject): SceneEditor {
+  const { $editor } = sceneObject.state;
+  if ($editor) {
+    return $editor;
+  }
+
+  if (sceneObject.parent) {
+    return getSceneEditorFor(sceneObject.parent);
+  }
+
+  throw new Error('No editor found in scene tree');
+}
+
+export const EmptyVariableSet = new SceneVariableSet({ variables: [] });
+
+export const EmptyDataNode = new SceneDataNode({
+  data: {
+    state: LoadingState.Done,
+    series: [],
+    timeRange: getDefaultTimeRange(),
+  },
+});
+
+export const DefaultTimeRange = new SceneTimeRangeImpl(getDefaultTimeRange());
+
+export const sceneGraph = {
+  getVariablesFor,
+  getDataFor,
+  getTimeRangeFor,
+  getSceneEditorFor,
+};

--- a/public/app/features/scenes/core/sceneGraph.ts
+++ b/public/app/features/scenes/core/sceneGraph.ts
@@ -1,5 +1,6 @@
 import { getDefaultTimeRange, LoadingState } from '@grafana/data';
 
+import { sceneInterpolator } from '../variables/interpolation/sceneInterpolator';
 import { SceneVariableSet } from '../variables/sets/SceneVariableSet';
 import { SceneVariables } from '../variables/types';
 
@@ -70,6 +71,18 @@ export function getSceneEditorFor(sceneObject: SceneObject): SceneEditor {
   throw new Error('No editor found in scene tree');
 }
 
+/**
+ * Interpolates the given string using the current scene object as context.   *
+ */
+export function interpolateFor(sceneObject: SceneObject, value: string | undefined | null): string {
+  // Skip interpolation if there are no variable dependencies
+  if (!value || !sceneObject.variableDependency || sceneObject.variableDependency.getNames().size === 0) {
+    return value ?? '';
+  }
+
+  return sceneInterpolator(sceneObject, value);
+}
+
 export const EmptyVariableSet = new SceneVariableSet({ variables: [] });
 
 export const EmptyDataNode = new SceneDataNode({
@@ -87,4 +100,5 @@ export const sceneGraph = {
   getDataFor,
   getTimeRangeFor,
   getSceneEditorFor,
+  interpolateFor,
 };

--- a/public/app/features/scenes/core/types.ts
+++ b/public/app/features/scenes/core/types.ts
@@ -75,20 +75,8 @@ export interface SceneObject<TState extends SceneObjectState = SceneObjectState>
   /** Called when component unmounts. Unsubscribe and closes all subscriptions  */
   deactivate(): void;
 
-  /** Get the scene editor */
-  getSceneEditor(): SceneEditor;
-
   /** Get the scene root */
   getRoot(): SceneObject;
-
-  /** Get the closest node with data */
-  getData(): SceneObject<SceneDataState>;
-
-  /** Get the closest node with variables */
-  getVariables(): SceneVariables | undefined;
-
-  /** Get the closest node with time range */
-  getTimeRange(): SceneTimeRange;
 
   /** Returns a deep clone this object and all its children */
   clone(state?: Partial<TState>): this;

--- a/public/app/features/scenes/core/types.ts
+++ b/public/app/features/scenes/core/types.ts
@@ -108,6 +108,13 @@ export interface SceneEditor extends SceneObject<SceneEditorState> {
   onMouseEnterObject(model: SceneObject): void;
   onMouseLeaveObject(model: SceneObject): void;
   onSelectObject(model: SceneObject): void;
+  getEditComponentWrapper(): React.ComponentType<SceneComponentEditWrapperProps>;
+}
+
+interface SceneComponentEditWrapperProps {
+  editor: SceneEditor;
+  model: SceneObject;
+  children: React.ReactNode;
 }
 
 export interface SceneTimeRangeState extends SceneObjectStatePlain, TimeRange {}

--- a/public/app/features/scenes/editor/SceneComponentEditWrapper.tsx
+++ b/public/app/features/scenes/editor/SceneComponentEditWrapper.tsx
@@ -4,18 +4,18 @@ import React, { CSSProperties } from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
 import { useStyles2 } from '@grafana/ui';
 
-import { sceneGraph } from '../core/sceneGraph';
-import { SceneObject } from '../core/types';
+import { SceneEditor, SceneObject } from '../core/types';
 
-export function SceneComponentEditingWrapper<T extends SceneObject>({
+export function SceneComponentEditWrapper({
   model,
+  editor,
   children,
 }: {
-  model: T;
+  model: SceneObject;
+  editor: SceneEditor;
   children: React.ReactNode;
 }) {
   const styles = useStyles2(getStyles);
-  const editor = sceneGraph.getSceneEditorFor(model);
   const { hoverObject, selectedObject } = editor.useState();
 
   const onMouseEnter = () => editor.onMouseEnterObject(model);

--- a/public/app/features/scenes/editor/SceneComponentEditWrapper.tsx
+++ b/public/app/features/scenes/editor/SceneComponentEditWrapper.tsx
@@ -4,6 +4,7 @@ import React, { CSSProperties } from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
 import { useStyles2 } from '@grafana/ui';
 
+import { sceneGraph } from '../core/sceneGraph';
 import { SceneObject } from '../core/types';
 
 export function SceneComponentEditingWrapper<T extends SceneObject>({
@@ -14,7 +15,7 @@ export function SceneComponentEditingWrapper<T extends SceneObject>({
   children: React.ReactNode;
 }) {
   const styles = useStyles2(getStyles);
-  const editor = model.getSceneEditor();
+  const editor = sceneGraph.getSceneEditorFor(model);
   const { hoverObject, selectedObject } = editor.useState();
 
   const onMouseEnter = () => editor.onMouseEnterObject(model);

--- a/public/app/features/scenes/editor/SceneEditManager.tsx
+++ b/public/app/features/scenes/editor/SceneEditManager.tsx
@@ -7,6 +7,7 @@ import { useStyles2 } from '@grafana/ui';
 import { SceneObjectBase } from '../core/SceneObjectBase';
 import { SceneEditorState, SceneEditor, SceneObject, SceneComponentProps, SceneComponent } from '../core/types';
 
+import { SceneComponentEditWrapper } from './SceneComponentEditWrapper';
 import { SceneObjectEditor } from './SceneObjectEditor';
 import { SceneObjectTree } from './SceneObjectTree';
 
@@ -31,6 +32,10 @@ export class SceneEditManager extends SceneObjectBase<SceneEditorState> implemen
 
   public onSelectObject(model: SceneObject) {
     this.setState({ selectedObject: { ref: model } });
+  }
+
+  public getEditComponentWrapper() {
+    return SceneComponentEditWrapper;
   }
 }
 

--- a/public/app/features/scenes/editor/SceneObjectTree.tsx
+++ b/public/app/features/scenes/editor/SceneObjectTree.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
 import { Icon, useStyles2 } from '@grafana/ui';
 
+import { sceneGraph } from '../core/sceneGraph';
 import { SceneObject, isSceneObject, SceneLayoutChild } from '../core/types';
 
 export interface Props {
@@ -31,7 +32,7 @@ export function SceneObjectTree({ node, selectedObject }: Props) {
 
   const name = node.constructor.name;
   const isSelected = selectedObject === node;
-  const onSelectNode = () => node.getSceneEditor().onSelectObject(node);
+  const onSelectNode = () => sceneGraph.getSceneEditorFor(node).onSelectObject(node);
 
   return (
     <div className={styles.node}>

--- a/public/app/features/scenes/querying/SceneQueryRunner.ts
+++ b/public/app/features/scenes/querying/SceneQueryRunner.ts
@@ -17,6 +17,7 @@ import { getNextRequestId } from 'app/features/query/state/PanelQueryRunner';
 import { runRequest } from 'app/features/query/state/runRequest';
 
 import { SceneObjectBase } from '../core/SceneObjectBase';
+import { sceneGraph } from '../core/sceneGraph';
 import { SceneObjectStatePlain } from '../core/types';
 import { VariableDependencyConfig } from '../variables/VariableDependencyConfig';
 
@@ -40,7 +41,7 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> {
   public activate() {
     super.activate();
 
-    const timeRange = this.getTimeRange();
+    const timeRange = sceneGraph.getTimeRangeFor(this);
 
     this._subs.add(
       timeRange.subscribeToState({
@@ -65,7 +66,7 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> {
   }
 
   public runQueries() {
-    const timeRange = this.getTimeRange();
+    const timeRange = sceneGraph.getTimeRangeFor(this);
     this.runWithTimeRange(timeRange.state);
   }
 

--- a/public/app/features/scenes/variables/components/VariableValueSelectors.tsx
+++ b/public/app/features/scenes/variables/components/VariableValueSelectors.tsx
@@ -5,6 +5,7 @@ import { selectors } from '@grafana/e2e-selectors';
 import { Tooltip } from '@grafana/ui';
 
 import { SceneObjectBase } from '../../core/SceneObjectBase';
+import { sceneGraph } from '../../core/sceneGraph';
 import { SceneComponentProps, SceneObject, SceneObjectStatePlain } from '../../core/types';
 import { SceneVariableState } from '../types';
 
@@ -13,7 +14,7 @@ export class VariableValueSelectors extends SceneObjectBase<SceneObjectStatePlai
 }
 
 function VariableValueSelectorsRenderer({ model }: SceneComponentProps<VariableValueSelectors>) {
-  const variables = model.getVariables()!.useState();
+  const variables = sceneGraph.getVariablesFor(model)!.useState();
 
   return (
     <>

--- a/public/app/features/scenes/variables/interpolation/ScopedVarsVariable.ts
+++ b/public/app/features/scenes/variables/interpolation/ScopedVarsVariable.ts
@@ -1,41 +1,19 @@
 import { property } from 'lodash';
-import { ReactElement } from 'react';
-import { Observable, Observer, Subscription, Unsubscribable } from 'rxjs';
 
-import { BusEvent, BusEventHandler, BusEventType, ScopedVar } from '@grafana/data';
+import { ScopedVar } from '@grafana/data';
 
-import {
-  SceneObject,
-  SceneObjectState,
-  SceneEditor,
-  SceneDataState,
-  SceneTimeRange,
-  SceneComponentProps,
-} from '../../core/types';
-import {
-  SceneVariable,
-  SceneVariableDependencyConfigLike,
-  SceneVariables,
-  SceneVariableState,
-  ValidateAndUpdateResult,
-  VariableValue,
-} from '../types';
+import { SceneObjectBase } from '../../core/SceneObjectBase';
+import { SceneVariable, SceneVariableState, VariableValue } from '../types';
 
 export interface ScopedVarsProxyVariableState extends SceneVariableState {
   value: ScopedVar;
 }
 
-export class ScopedVarsVariable implements SceneVariable<ScopedVarsProxyVariableState> {
-  public state: ScopedVarsProxyVariableState;
+export class ScopedVarsVariable
+  extends SceneObjectBase<ScopedVarsProxyVariableState>
+  implements SceneVariable<ScopedVarsProxyVariableState>
+{
   private static fieldAccessorCache: FieldAccessorCache = {};
-
-  public constructor(state: ScopedVarsProxyVariableState) {
-    this.state = state;
-  }
-
-  public setState(state: Partial<ScopedVarsProxyVariableState>) {
-    this.state = { ...this.state, ...state };
-  }
 
   public getValue(fieldPath: string): VariableValue {
     let { value } = this.state;
@@ -72,83 +50,6 @@ export class ScopedVarsVariable implements SceneVariable<ScopedVarsProxyVariable
 
     return (ScopedVarsVariable.fieldAccessorCache[fieldPath] = property(fieldPath));
   }
-
-  /**
-   * The SceneVariable interface. This class is a bit of fake Variable. Only used in the formatting of the value.
-   * Playing the role of a variable so the formatting logic does not need special handling for scopedVars
-   *
-   * The reason we are implementing the SceneVariable interface here instead of extending SceneObjectBase is because of circular dependencies.
-   * SceneObjectBase depends on sceneInterpolate which depends on this class.
-   **/
-
-  public validateAndUpdate?(): Observable<ValidateAndUpdateResult> {
-    throw new Error('Method not implemented.');
-  }
-
-  public isActive = false;
-  public parent?: SceneObject<SceneObjectState> | undefined;
-  public variableDependency?: SceneVariableDependencyConfigLike | undefined;
-
-  public subscribeToState(observer?: Partial<Observer<ScopedVarsProxyVariableState>> | undefined): Subscription {
-    throw new Error('Method not implemented.');
-  }
-
-  public subscribeToEvent<T extends BusEvent>(
-    typeFilter: BusEventType<T>,
-    handler: BusEventHandler<T>
-  ): Unsubscribable {
-    throw new Error('Method not implemented.');
-  }
-
-  public publishEvent(event: BusEvent, bubble?: boolean | undefined): void {
-    throw new Error('Method not implemented.');
-  }
-
-  public useState(): ScopedVarsProxyVariableState {
-    throw new Error('Method not implemented.');
-  }
-
-  public activate(): void {
-    throw new Error('Method not implemented.');
-  }
-
-  public deactivate(): void {
-    throw new Error('Method not implemented.');
-  }
-
-  public getSceneEditor(): SceneEditor {
-    throw new Error('Method not implemented.');
-  }
-
-  public getRoot(): SceneObject<SceneObjectState> {
-    throw new Error('Method not implemented.');
-  }
-
-  public getData(): SceneObject<SceneDataState> {
-    throw new Error('Method not implemented.');
-  }
-
-  public getVariables(): SceneVariables | undefined {
-    throw new Error('Method not implemented.');
-  }
-
-  public getTimeRange(): SceneTimeRange {
-    throw new Error('Method not implemented.');
-  }
-
-  public clone(state?: Partial<ScopedVarsProxyVariableState>): this {
-    throw new Error('Method not implemented.');
-  }
-
-  public Component(props: SceneComponentProps<SceneObject<ScopedVarsProxyVariableState>>): ReactElement {
-    throw new Error('Method not implemented.');
-  }
-
-  public Editor(props: SceneComponentProps<SceneObject<ScopedVarsProxyVariableState>>): ReactElement {
-    throw new Error('Method not implemented.');
-  }
-
-  public forceRender(): void {}
 }
 
 interface FieldAccessorCache {

--- a/public/app/features/scenes/variables/interpolation/ScopedVarsVariable.ts
+++ b/public/app/features/scenes/variables/interpolation/ScopedVarsVariable.ts
@@ -147,6 +147,8 @@ export class ScopedVarsVariable implements SceneVariable<ScopedVarsProxyVariable
   public Editor(props: SceneComponentProps<SceneObject<ScopedVarsProxyVariableState>>): ReactElement {
     throw new Error('Method not implemented.');
   }
+
+  public forceRender(): void {}
 }
 
 interface FieldAccessorCache {

--- a/public/app/features/scenes/variables/interpolation/sceneInterpolator.ts
+++ b/public/app/features/scenes/variables/interpolation/sceneInterpolator.ts
@@ -2,6 +2,7 @@ import { ScopedVars } from '@grafana/data';
 import { VariableModel } from '@grafana/schema';
 import { variableRegex } from 'app/features/variables/utils';
 
+import { EmptyVariableSet, sceneGraph } from '../../core/sceneGraph';
 import { SceneObject } from '../../core/types';
 import { SceneVariable, VariableValue } from '../types';
 
@@ -31,8 +32,8 @@ export function sceneInterpolator(
     return target ?? '';
   }
 
-  // Skip any interpolation if there are no variables in the scene object graph?
-  if (!sceneObject.getVariables()) {
+  // Skip any interpolation if there are no variables in the scene object graph
+  if (sceneGraph.getVariablesFor(sceneObject) === EmptyVariableSet) {
     return target;
   }
 

--- a/public/app/features/scenes/variables/types.ts
+++ b/public/app/features/scenes/variables/types.ts
@@ -64,8 +64,7 @@ export interface SceneVariableDependencyConfigLike {
   hasDependencyOn(name: string): boolean;
 
   /**
-   * Will be called when any variable value has changed, not just variable names returned by getNames().
-   * It is up the implementation of this interface to filter it by actual dependencies.
+   * Will be called when any variable value has changed.
    **/
   variableValuesChanged(variables: Set<SceneVariable>): void;
 }

--- a/public/app/features/scenes/variables/variants/TestVariable.tsx
+++ b/public/app/features/scenes/variables/variants/TestVariable.tsx
@@ -3,6 +3,7 @@ import { Observable, Subject } from 'rxjs';
 
 import { queryMetricTree } from 'app/plugins/datasource/testdata/metricTree';
 
+import { sceneGraph } from '../../core/sceneGraph';
 import { SceneComponentProps } from '../../core/types';
 import { VariableDependencyConfig } from '../VariableDependencyConfig';
 import { VariableValueSelect } from '../components/VariableValueSelect';
@@ -66,7 +67,7 @@ export class TestVariable extends MultiValueVariable<TestVariableState> {
   }
 
   private issueQuery() {
-    const interpolatedQuery = this.interpolate(this.state.query);
+    const interpolatedQuery = sceneGraph.interpolateFor(this.state.query);
     const options = queryMetricTree(interpolatedQuery).map((x) => ({ label: x.name, value: x.name }));
 
     this.setState({

--- a/public/app/features/scenes/variables/variants/TestVariable.tsx
+++ b/public/app/features/scenes/variables/variants/TestVariable.tsx
@@ -67,7 +67,7 @@ export class TestVariable extends MultiValueVariable<TestVariableState> {
   }
 
   private issueQuery() {
-    const interpolatedQuery = sceneGraph.interpolateFor(this.state.query);
+    const interpolatedQuery = sceneGraph.interpolateFor(this, this.state.query);
     const options = queryMetricTree(interpolatedQuery).map((x) => ({ label: x.name, value: x.name }));
 
     this.setState({


### PR DESCRIPTION
In https://github.com/grafana/grafana/pull/58591 I struggled a bit with circular dependency. I have encountered the same problem with SceneObjectBase getData function, I wanted it to return a default object instead of throw an error but this default object implementation (say SceneTimeRange, or SceneDataNode etc) will depend on SceneObjectBase.

Have a similar problem with interpolate function added to SceneObject interface (and hence SceneObjectBase). That causes circular dependency if sceneInterpolator function wants to use an internal SceneVariable to represent scopedVars (This internal variable will want to extend SceneObjectBase)

An alternative to have getData, getTimeRange, interpolate etc on the SceneObject interface and base class it to move them to external util functions. That way they can return some default values that extend SceneObjectBase and we get rid of this problem of circular dependencies. But it's a lot less discoverable.

Thoughts?