### PR TITLE
Search: Fixes issue with Recent/Starred section always displaying "General" folder

### DIFF
--- a/public/app/features/search/page/components/FolderSection.test.tsx
+++ b/public/app/features/search/page/components/FolderSection.test.tsx
@@ -26,7 +26,7 @@ describe('FolderSection', () => {
     window.localStorage.clear();
   });
 
-  describe('when where are no results', () => {
+  describe('when there are no results', () => {
     const emptySearchData: DataFrame = {
       fields: [
         { name: 'kind', type: FieldType.string, config: {}, values: new ArrayVector([]) },
@@ -100,8 +100,19 @@ describe('FolderSection', () => {
         { name: 'uid', type: FieldType.string, config: {}, values: new ArrayVector(['my-dashboard-1']) },
         { name: 'url', type: FieldType.string, config: {}, values: new ArrayVector(['/my-dashboard-1']) },
         { name: 'tags', type: FieldType.other, config: {}, values: new ArrayVector([['foo', 'bar']]) },
-        { name: 'location', type: FieldType.string, config: {}, values: new ArrayVector(['/my-dashboard-1']) },
+        { name: 'location', type: FieldType.string, config: {}, values: new ArrayVector(['my-folder-1']) },
       ],
+      meta: {
+        custom: {
+          locationInfo: {
+            'my-folder-1': {
+              name: 'My folder 1',
+              kind: 'folder',
+              url: '/my-folder-1',
+            },
+          },
+        },
+      },
       length: 1,
     };
 
@@ -203,6 +214,24 @@ describe('FolderSection', () => {
         await userEvent.click(await screen.findByRole('checkbox', { name: 'Select folder' }));
         expect(mockSelectionToggle).toHaveBeenCalledWith('folder', 'my-folder');
         expect(mockSelectionToggle).toHaveBeenCalledWith('dashboard', 'my-dashboard-1');
+      });
+    });
+
+    describe('when in a pseudo-folder (i.e. Starred/Recent)', () => {
+      const mockRecentSection = {
+        kind: 'folder',
+        uid: '__recent',
+        title: 'Recent',
+        itemsUIDs: ['my-dashboard-1'],
+      };
+
+      it('shows the correct folder name next to the dashboard', async () => {
+        render(<FolderSection section={mockRecentSection} onTagSelected={mockOnTagSelected} />);
+
+        await userEvent.click(await screen.findByRole('button', { name: mockRecentSection.title }));
+        expect(getGrafanaSearcher().search).toHaveBeenCalled();
+        expect(await screen.findByText('My dashboard 1')).toBeInTheDocument();
+        expect(await screen.findByText('My folder 1')).toBeInTheDocument();
       });
     });
   });

--- a/public/app/features/search/page/components/FolderSection.tsx
+++ b/public/app/features/search/page/components/FolderSection.tsx
@@ -82,8 +82,8 @@ export const FolderSection = ({
       id: 666, // do not use me!
       isStarred: false,
       tags: item.tags ?? [],
-      folderUid,
-      folderTitle,
+      folderUid: folderUid || item.location,
+      folderTitle: folderTitle || raw.view.dataFrame.meta?.custom?.locationInfo[item.location].name,
     }));
     return v;
   }, [sectionExpanded, tags]);


### PR DESCRIPTION
**What is this feature?**

There was an issue with the folder view in Search where in the Recent/Starred sections, all dashboards would be displayed as being a part of the "General" folder:
![Screenshot 2022-11-15 at 10 57 30](https://user-images.githubusercontent.com/100691367/201904463-0815e25b-3329-4bf7-8729-9c4dbb2ebd66.png)

This PR fixes that to show the correct folder name:
![Screenshot 2022-11-15 at 10 57 06](https://user-images.githubusercontent.com/100691367/201904544-a2ab0e12-114b-4858-bcf9-c49dd004d297.png)

**Why do we need this feature?**

Bug fix 🐛 

**Who is this feature for?**

Anyone who uses search

**Which issue(s) does this PR fix?**:

Fixes #58481

