### PR TITLE
Teams: Support paginating and filtering more then 1000 teams

### DIFF
--- a/public/app/core/reducers/root.test.ts
+++ b/public/app/core/reducers/root.test.ts
@@ -28,12 +28,15 @@ describe('rootReducer', () => {
 
       reducerTester<StoreState>()
         .givenReducer(rootReducer, state)
-        .whenActionIsDispatched(teamsLoaded(teams))
+        .whenActionIsDispatched(teamsLoaded({ teams: teams, page: 1, noTeams: false, perPage: 30, totalCount: 1 }))
         .thenStatePredicateShouldEqual((resultingState) => {
           expect(resultingState.teams).toEqual({
             hasFetched: true,
-            searchQuery: '',
-            searchPage: 1,
+            noTeams: false,
+            perPage: 30,
+            totalPages: 1,
+            query: '',
+            page: 1,
             teams,
           });
           return true;
@@ -47,8 +50,11 @@ describe('rootReducer', () => {
       const state: StoreState = {
         teams: {
           hasFetched: true,
-          searchQuery: '',
-          searchPage: 1,
+          query: '',
+          page: 1,
+          noTeams: false,
+          totalPages: 1,
+          perPage: 30,
           teams,
         },
       } as StoreState;

--- a/public/app/features/teams/TeamList.test.tsx
+++ b/public/app/features/teams/TeamList.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
-import { mockToolkitActionCreator } from 'test/core/redux/mocks';
 
 import { contextSrv, User } from 'app/core/services/context_srv';
 
@@ -9,7 +8,6 @@ import { OrgRole, Team } from '../../types';
 
 import { Props, TeamList } from './TeamList';
 import { getMockTeam, getMultipleMockTeams } from './__mocks__/teamMocks';
-import { setSearchQuery, setCurrentPage } from './state/reducers';
 
 jest.mock('app/core/config', () => ({
   ...jest.requireActual('app/core/config'),
@@ -21,11 +19,11 @@ const setup = (propOverrides?: object) => {
     teams: [] as Team[],
     loadTeams: jest.fn(),
     deleteTeam: jest.fn(),
-    setSearchQuery: mockToolkitActionCreator(setSearchQuery),
-    setCurrentPage: mockToolkitActionCreator(setCurrentPage),
-    searchQuery: '',
-    currentPage: 1,
-    totalCount: 0,
+    changePage: jest.fn(),
+    changeQuery: jest.fn(),
+    query: '',
+    page: 1,
+    totalPages: 0,
     hasFetched: false,
     editorsCanAdmin: false,
     signedInUser: {
@@ -52,7 +50,7 @@ describe('TeamList', () => {
       it('should enable the new team button', () => {
         setup({
           teams: getMultipleMockTeams(1),
-          teamsCount: 1,
+          totalCount: 1,
           hasFetched: true,
           editorsCanAdmin: true,
           signedInUser: {
@@ -69,7 +67,7 @@ describe('TeamList', () => {
       it('should disable the new team button', () => {
         setup({
           teams: getMultipleMockTeams(1),
-          teamsCount: 1,
+          totalCount: 1,
           hasFetched: true,
           editorsCanAdmin: true,
           signedInUser: {
@@ -87,7 +85,7 @@ describe('TeamList', () => {
 it('should call delete team', async () => {
   const mockDelete = jest.fn();
   const mockTeam = getMockTeam();
-  setup({ deleteTeam: mockDelete, teams: [mockTeam], teamsCount: 1, hasFetched: true });
+  setup({ deleteTeam: mockDelete, teams: [mockTeam], totalCount: 1, hasFetched: true });
   await userEvent.click(screen.getByRole('button', { name: `Delete team ${mockTeam.name}` }));
   await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
   await waitFor(() => {

--- a/public/app/features/teams/TeamList.test.tsx
+++ b/public/app/features/teams/TeamList.test.tsx
@@ -17,6 +17,7 @@ jest.mock('app/core/config', () => ({
 const setup = (propOverrides?: object) => {
   const props: Props = {
     teams: [] as Team[],
+    noTeams: false,
     loadTeams: jest.fn(),
     deleteTeam: jest.fn(),
     changePage: jest.fn(),

--- a/public/app/features/teams/TeamList.test.tsx
+++ b/public/app/features/teams/TeamList.test.tsx
@@ -25,7 +25,7 @@ const setup = (propOverrides?: object) => {
     setTeamsSearchPage: mockToolkitActionCreator(setTeamsSearchPage),
     searchQuery: '',
     searchPage: 1,
-    teamsCount: 0,
+    totalCount: 0,
     hasFetched: false,
     editorsCanAdmin: false,
     signedInUser: {

--- a/public/app/features/teams/TeamList.test.tsx
+++ b/public/app/features/teams/TeamList.test.tsx
@@ -9,7 +9,7 @@ import { OrgRole, Team } from '../../types';
 
 import { Props, TeamList } from './TeamList';
 import { getMockTeam, getMultipleMockTeams } from './__mocks__/teamMocks';
-import { setSearchQuery, setTeamsSearchPage } from './state/reducers';
+import { setSearchQuery, setCurrentPage } from './state/reducers';
 
 jest.mock('app/core/config', () => ({
   ...jest.requireActual('app/core/config'),
@@ -22,9 +22,9 @@ const setup = (propOverrides?: object) => {
     loadTeams: jest.fn(),
     deleteTeam: jest.fn(),
     setSearchQuery: mockToolkitActionCreator(setSearchQuery),
-    setTeamsSearchPage: mockToolkitActionCreator(setTeamsSearchPage),
+    setCurrentPage: mockToolkitActionCreator(setCurrentPage),
     searchQuery: '',
-    searchPage: 1,
+    currentPage: 1,
     totalCount: 0,
     hasFetched: false,
     editorsCanAdmin: false,

--- a/public/app/features/teams/TeamList.tsx
+++ b/public/app/features/teams/TeamList.tsx
@@ -95,9 +95,7 @@ export class TeamList extends PureComponent<Props, State> {
     const { searchQuery, editorsCanAdmin, searchPage, setTeamsSearchPage, signedInUser } = this.props;
     const canCreate = canCreateTeam(editorsCanAdmin);
     const displayRolePicker = shouldDisaplyRolePicker();
-    const newTeamHref = canCreate ? 'org/teams/new' : '#';
     const paginatedTeams = this.getPaginatedTeams(teams);
-    const totalPages = Math.ceil(teams.length / pageLimit);
 
     return (
       <>
@@ -106,7 +104,7 @@ export class TeamList extends PureComponent<Props, State> {
             <FilterInput placeholder="Search teams" value={searchQuery} onChange={this.onSearchQueryChange} />
           </div>
 
-          <LinkButton href={newTeamHref} disabled={!canCreate}>
+          <LinkButton href={canCreate ? 'org/teams/new' : '#'} disabled={!canCreate}>
             New Team
           </LinkButton>
         </div>
@@ -141,7 +139,7 @@ export class TeamList extends PureComponent<Props, State> {
               <Pagination
                 onNavigate={setTeamsSearchPage}
                 currentPage={searchPage}
-                numberOfPages={totalPages}
+                numberOfPages={Math.ceil(totalCount / pageLimit)}
                 hideWhenSinglePage={true}
               />
             </HorizontalGroup>

--- a/public/app/features/teams/TeamList.tsx
+++ b/public/app/features/teams/TeamList.tsx
@@ -12,7 +12,7 @@ import { connectWithCleanUp } from '../../core/components/connectWithCleanUp';
 
 import { TeamListRow } from './TeamListRow';
 import { deleteTeam, loadTeams } from './state/actions';
-import { initialTeamsState, setSearchQuery, setTeamsSearchPage } from './state/reducers';
+import { initialTeamsState, setSearchQuery, setCurrentPage } from './state/reducers';
 import { getTeams, isPermissionTeamAdmin } from './state/selectors';
 
 const pageLimit = 30;
@@ -20,13 +20,13 @@ const pageLimit = 30;
 export interface Props {
   teams: Team[];
   totalCount: number;
+  currentPage: number;
   searchQuery: string;
-  searchPage: number;
   hasFetched: boolean;
   loadTeams: typeof loadTeams;
   deleteTeam: typeof deleteTeam;
+  setCurrentPage: typeof setCurrentPage;
   setSearchQuery: typeof setSearchQuery;
-  setTeamsSearchPage: typeof setTeamsSearchPage;
   editorsCanAdmin: boolean;
   signedInUser: User;
 }
@@ -66,11 +66,11 @@ export class TeamList extends PureComponent<Props, State> {
   };
 
   getPaginatedTeams = (teams: Team[]) => {
-    const offset = (this.props.searchPage - 1) * pageLimit;
+    const offset = (this.props.currentPage - 1) * pageLimit;
     return teams.slice(offset, offset + pageLimit);
   };
   renderList() {
-    const { teams, totalCount, hasFetched } = this.props;
+    const { teams, totalCount, currentPage, hasFetched } = this.props;
 
     if (!hasFetched) {
       return null;
@@ -92,7 +92,7 @@ export class TeamList extends PureComponent<Props, State> {
       );
     }
 
-    const { searchQuery, editorsCanAdmin, searchPage, setTeamsSearchPage, signedInUser } = this.props;
+    const { searchQuery, editorsCanAdmin, setCurrentPage, signedInUser } = this.props;
     const canCreate = canCreateTeam(editorsCanAdmin);
     const displayRolePicker = shouldDisaplyRolePicker();
     const paginatedTeams = this.getPaginatedTeams(teams);
@@ -137,8 +137,8 @@ export class TeamList extends PureComponent<Props, State> {
             </table>
             <HorizontalGroup justify="flex-end">
               <Pagination
-                onNavigate={setTeamsSearchPage}
-                currentPage={searchPage}
+                onNavigate={setCurrentPage}
+                currentPage={currentPage}
                 numberOfPages={Math.ceil(totalCount / pageLimit)}
                 hideWhenSinglePage={true}
               />
@@ -177,8 +177,8 @@ function mapStateToProps(state: StoreState) {
   return {
     teams: getTeams(state.teams),
     totalCount: state.teams.totalCount,
+    currentPage: state.teams.currentPage,
     searchQuery: state.teams.searchQuery,
-    searchPage: state.teams.searchPage,
     hasFetched: state.teams.hasFetched,
     editorsCanAdmin: config.editorsCanAdmin, // this makes the feature toggle mockable/controllable from tests,
     signedInUser: contextSrv.user, // this makes the feature toggle mockable/controllable from tests,
@@ -188,8 +188,8 @@ function mapStateToProps(state: StoreState) {
 const mapDispatchToProps = {
   loadTeams,
   deleteTeam,
+  setCurrentPage,
   setSearchQuery,
-  setTeamsSearchPage,
 };
 
 export default connectWithCleanUp(

--- a/public/app/features/teams/TeamList.tsx
+++ b/public/app/features/teams/TeamList.tsx
@@ -61,7 +61,7 @@ export const TeamList = ({
   }, []);
 
   const canCreate = canCreateTeam(editorsCanAdmin);
-  const displayRolePicker = shouldDisaplyRolePicker();
+  const displayRolePicker = shouldDisplayRolePicker();
 
   return (
     <Page navId="teams">
@@ -142,8 +142,7 @@ function canCreateTeam(editorsCanAdmin: boolean): boolean {
   return contextSrv.hasAccess(AccessControlAction.ActionTeamsCreate, teamAdmin);
 }
 
-function shouldDisaplyRolePicker(): boolean {
-  return false;
+function shouldDisplayRolePicker(): boolean {
   return (
     contextSrv.licensedAccessControlEnabled() &&
     contextSrv.hasPermission(AccessControlAction.ActionTeamsRolesList) &&

--- a/public/app/features/teams/TeamList.tsx
+++ b/public/app/features/teams/TeamList.tsx
@@ -13,7 +13,7 @@ import { connectWithCleanUp } from '../../core/components/connectWithCleanUp';
 import { TeamListRow } from './TeamListRow';
 import { deleteTeam, loadTeams } from './state/actions';
 import { initialTeamsState, setSearchQuery, setCurrentPage } from './state/reducers';
-import { getTeams, isPermissionTeamAdmin } from './state/selectors';
+import { isPermissionTeamAdmin } from './state/selectors';
 
 const pageLimit = 30;
 
@@ -35,12 +35,12 @@ export interface State {
   roleOptions: Role[];
 }
 
-export const TeamList = ({ hasFetched, loadTeams, deleteTeam, ...rest }: Props) => {
+export const TeamList = ({ hasFetched, loadTeams, deleteTeam, searchQuery, currentPage, ...rest }: Props) => {
   const [roleOptions, setRoleOptions] = useState<Role[]>([]);
 
   useEffect(() => {
-    loadTeams();
-  }, [loadTeams]);
+    loadTeams(searchQuery, pageLimit, currentPage);
+  }, [loadTeams, searchQuery, currentPage]);
 
   useEffect(() => {
     if (contextSrv.licensedAccessControlEnabled() && contextSrv.hasPermission(AccessControlAction.ActionRolesList)) {
@@ -52,6 +52,7 @@ export const TeamList = ({ hasFetched, loadTeams, deleteTeam, ...rest }: Props) 
     const { teams, totalCount } = rest;
 
     if (totalCount === 0) {
+      /*
       return (
         <EmptyListCTA
           title="You haven't created any teams yet."
@@ -65,9 +66,10 @@ export const TeamList = ({ hasFetched, loadTeams, deleteTeam, ...rest }: Props) 
           proTipTarget="_blank"
         />
       );
+        */
     }
 
-    const { searchQuery, editorsCanAdmin, setCurrentPage, signedInUser, currentPage } = rest;
+    const { editorsCanAdmin, setCurrentPage, signedInUser } = rest;
     const canCreate = canCreateTeam(editorsCanAdmin);
     const displayRolePicker = shouldDisaplyRolePicker();
 
@@ -136,6 +138,7 @@ function canCreateTeam(editorsCanAdmin: boolean): boolean {
 }
 
 function shouldDisaplyRolePicker(): boolean {
+  return false;
   return (
     contextSrv.licensedAccessControlEnabled() &&
     contextSrv.hasPermission(AccessControlAction.ActionTeamsRolesList) &&
@@ -145,7 +148,7 @@ function shouldDisaplyRolePicker(): boolean {
 
 function mapStateToProps(state: StoreState) {
   return {
-    teams: getTeams(state.teams),
+    teams: state.teams.teams,
     totalCount: state.teams.totalCount,
     currentPage: state.teams.currentPage,
     searchQuery: state.teams.searchQuery,

--- a/public/app/features/teams/TeamList.tsx
+++ b/public/app/features/teams/TeamList.tsx
@@ -35,22 +35,21 @@ export interface State {
   roleOptions: Role[];
 }
 
-const TeamList = ({ hasFetched, loadTeams, ...rest }: Props) => {
+export const TeamList = ({ hasFetched, loadTeams, deleteTeam, ...rest }: Props) => {
   const [roleOptions, setRoleOptions] = useState<Role[]>([]);
 
   useEffect(() => {
     loadTeams();
+  }, [loadTeams]);
+
+  useEffect(() => {
     if (contextSrv.licensedAccessControlEnabled() && contextSrv.hasPermission(AccessControlAction.ActionRolesList)) {
       fetchRoleOptions().then((roles) => setRoleOptions(roles));
     }
-  }, [loadTeams]);
+  }, []);
 
   const render = () => {
-    const { teams, totalCount, currentPage } = rest;
-
-    if (!hasFetched) {
-      return null;
-    }
+    const { teams, totalCount } = rest;
 
     if (totalCount === 0) {
       return (
@@ -68,7 +67,7 @@ const TeamList = ({ hasFetched, loadTeams, ...rest }: Props) => {
       );
     }
 
-    const { searchQuery, editorsCanAdmin, setCurrentPage, signedInUser } = rest;
+    const { searchQuery, editorsCanAdmin, setCurrentPage, signedInUser, currentPage } = rest;
     const canCreate = canCreateTeam(editorsCanAdmin);
     const displayRolePicker = shouldDisaplyRolePicker();
 
@@ -105,17 +104,17 @@ const TeamList = ({ hasFetched, loadTeams, ...rest }: Props) => {
                     roleOptions={roleOptions}
                     displayRolePicker={displayRolePicker}
                     isTeamAdmin={isPermissionTeamAdmin({ permission: team.permission, editorsCanAdmin, signedInUser })}
-                    onDelete={rest.deleteTeam}
+                    onDelete={deleteTeam}
                   />
                 ))}
               </tbody>
             </table>
             <HorizontalGroup justify="flex-end">
               <Pagination
+                hideWhenSinglePage
                 onNavigate={setCurrentPage}
                 currentPage={currentPage}
                 numberOfPages={Math.ceil(totalCount / pageLimit)}
-                hideWhenSinglePage={true}
               />
             </HorizontalGroup>
           </VerticalGroup>

--- a/public/app/features/teams/TeamList.tsx
+++ b/public/app/features/teams/TeamList.tsx
@@ -19,6 +19,7 @@ export interface Props {
   teams: Team[];
   page: number;
   query: string;
+  noTeams: boolean;
   totalPages: number;
   hasFetched: boolean;
   loadTeams: typeof loadTeams;
@@ -37,6 +38,7 @@ export const TeamList = ({
   teams,
   page,
   query,
+  noTeams,
   totalPages,
   hasFetched,
   loadTeams,
@@ -49,7 +51,7 @@ export const TeamList = ({
   const [roleOptions, setRoleOptions] = useState<Role[]>([]);
 
   useEffect(() => {
-    loadTeams();
+    loadTeams(true);
   }, [loadTeams]);
 
   useEffect(() => {
@@ -58,7 +60,6 @@ export const TeamList = ({
     }
   }, []);
 
-  const noTeams = false;
   const canCreate = canCreateTeam(editorsCanAdmin);
   const displayRolePicker = shouldDisaplyRolePicker();
 
@@ -142,6 +143,7 @@ function canCreateTeam(editorsCanAdmin: boolean): boolean {
 }
 
 function shouldDisaplyRolePicker(): boolean {
+  return false;
   return (
     contextSrv.licensedAccessControlEnabled() &&
     contextSrv.hasPermission(AccessControlAction.ActionTeamsRolesList) &&
@@ -155,6 +157,7 @@ function mapStateToProps(state: StoreState) {
     page: state.teams.page,
     query: state.teams.query,
     perPage: state.teams.perPage,
+    noTeams: state.teams.noTeams,
     totalPages: state.teams.totalPages,
     hasFetched: state.teams.hasFetched,
     editorsCanAdmin: config.editorsCanAdmin, // this makes the feature toggle mockable/controllable from tests,

--- a/public/app/features/teams/TeamList.tsx
+++ b/public/app/features/teams/TeamList.tsx
@@ -57,18 +57,6 @@ export class TeamList extends PureComponent<Props, State> {
     this.setState({ roleOptions });
   }
 
-  deleteTeam = (team: Team) => {
-    this.props.deleteTeam(team.id);
-  };
-
-  onSearchQueryChange = (value: string) => {
-    this.props.setSearchQuery(value);
-  };
-
-  getPaginatedTeams = (teams: Team[]) => {
-    const offset = (this.props.currentPage - 1) * pageLimit;
-    return teams.slice(offset, offset + pageLimit);
-  };
   renderList() {
     const { teams, totalCount, currentPage, hasFetched } = this.props;
 
@@ -95,13 +83,12 @@ export class TeamList extends PureComponent<Props, State> {
     const { searchQuery, editorsCanAdmin, setCurrentPage, signedInUser } = this.props;
     const canCreate = canCreateTeam(editorsCanAdmin);
     const displayRolePicker = shouldDisaplyRolePicker();
-    const paginatedTeams = this.getPaginatedTeams(teams);
 
     return (
       <>
         <div className="page-action-bar">
           <div className="gf-form gf-form--grow">
-            <FilterInput placeholder="Search teams" value={searchQuery} onChange={this.onSearchQueryChange} />
+            <FilterInput placeholder="Search teams" value={searchQuery} onChange={this.props.setSearchQuery} />
           </div>
 
           <LinkButton href={canCreate ? 'org/teams/new' : '#'} disabled={!canCreate}>
@@ -123,14 +110,14 @@ export class TeamList extends PureComponent<Props, State> {
                 </tr>
               </thead>
               <tbody>
-                {paginatedTeams.map((team) => (
+                {teams.map((team) => (
                   <TeamListRow
                     key={team.id}
                     team={team}
                     roleOptions={this.state.roleOptions}
                     displayRolePicker={displayRolePicker}
                     isTeamAdmin={isPermissionTeamAdmin({ permission: team.permission, editorsCanAdmin, signedInUser })}
-                    onDelete={(t: Team) => this.deleteTeam(t)}
+                    onDelete={this.props.deleteTeam}
                   />
                 ))}
               </tbody>
@@ -166,6 +153,7 @@ function canCreateTeam(editorsCanAdmin: boolean): boolean {
 }
 
 function shouldDisaplyRolePicker(): boolean {
+  return false;
   return (
     contextSrv.licensedAccessControlEnabled() &&
     contextSrv.hasPermission(AccessControlAction.ActionTeamsRolesList) &&

--- a/public/app/features/teams/TeamList.tsx
+++ b/public/app/features/teams/TeamList.tsx
@@ -33,7 +33,19 @@ export interface State {
   roleOptions: Role[];
 }
 
-export const TeamList = ({ teams, hasFetched, loadTeams, deleteTeam, query, page, totalPages, ...rest }: Props) => {
+export const TeamList = ({
+  teams,
+  page,
+  query,
+  totalPages,
+  hasFetched,
+  loadTeams,
+  deleteTeam,
+  changeQuery,
+  changePage,
+  signedInUser,
+  editorsCanAdmin,
+}: Props) => {
   const [roleOptions, setRoleOptions] = useState<Role[]>([]);
 
   useEffect(() => {
@@ -46,84 +58,80 @@ export const TeamList = ({ teams, hasFetched, loadTeams, deleteTeam, query, page
     }
   }, []);
 
-  const render = () => {
-    if (totalPages === 0) {
-      /*
-      return (
-        <EmptyListCTA
-          title="You haven't created any teams yet."
-          buttonIcon="users-alt"
-          buttonLink="org/teams/new"
-          buttonTitle=" New team"
-          buttonDisabled={!contextSrv.hasPermission(AccessControlAction.ActionTeamsCreate)}
-          proTip="Assign folder and dashboard permissions to teams instead of users to ease administration."
-          proTipLink=""
-          proTipLinkTitle=""
-          proTipTarget="_blank"
-        />
-      );
-        */
-    }
-
-    const { editorsCanAdmin, signedInUser } = rest;
-    const canCreate = canCreateTeam(editorsCanAdmin);
-    const displayRolePicker = shouldDisaplyRolePicker();
-
-    return (
-      <>
-        <div className="page-action-bar">
-          <div className="gf-form gf-form--grow">
-            <FilterInput placeholder="Search teams" value={query} onChange={rest.changeQuery} />
-          </div>
-
-          <LinkButton href={canCreate ? 'org/teams/new' : '#'} disabled={!canCreate}>
-            New Team
-          </LinkButton>
-        </div>
-
-        <div className="admin-list-table">
-          <VerticalGroup spacing="md">
-            <table className="filter-table filter-table--hover form-inline">
-              <thead>
-                <tr>
-                  <th />
-                  <th>Name</th>
-                  <th>Email</th>
-                  <th>Members</th>
-                  {displayRolePicker && <th>Roles</th>}
-                  <th style={{ width: '1%' }} />
-                </tr>
-              </thead>
-              <tbody>
-                {teams.map((team) => (
-                  <TeamListRow
-                    key={team.id}
-                    team={team}
-                    roleOptions={roleOptions}
-                    displayRolePicker={displayRolePicker}
-                    isTeamAdmin={isPermissionTeamAdmin({ permission: team.permission, editorsCanAdmin, signedInUser })}
-                    onDelete={deleteTeam}
-                  />
-                ))}
-              </tbody>
-            </table>
-            <HorizontalGroup justify="flex-end">
-              <Pagination
-                hideWhenSinglePage
-                currentPage={page}
-                numberOfPages={totalPages}
-                onNavigate={rest.changePage}
-              />
-            </HorizontalGroup>
-          </VerticalGroup>
-        </div>
-      </>
-    );
-  };
+  const noTeams = false;
+  const canCreate = canCreateTeam(editorsCanAdmin);
+  const displayRolePicker = shouldDisaplyRolePicker();
 
   return (
     <Page navId="teams">
-      <Page.Contents isLoading={!hasFetched}>{render()}</Page.Contents>
+      <Page.Contents isLoading={!hasFetched}>
+        {noTeams ? (
+          <EmptyListCTA
+            title="You haven't created any teams yet."
+            buttonIcon="users-alt"
+            buttonLink="org/teams/new"
+            buttonTitle=" New team"
+            buttonDisabled={!contextSrv.hasPermission(AccessControlAction.ActionTeamsCreate)}
+            proTip="Assign folder and dashboard permissions to teams instead of users to ease administration."
+            proTipLink=""
+            proTipLinkTitle=""
+            proTipTarget="_blank"
+          />
+        ) : (
+          <>
+            <div className="page-action-bar">
+              <div className="gf-form gf-form--grow">
+                <FilterInput placeholder="Search teams" value={query} onChange={changeQuery} />
+              </div>
+
+              <LinkButton href={canCreate ? 'org/teams/new' : '#'} disabled={!canCreate}>
+                New Team
+              </LinkButton>
+            </div>
+
+            <div className="admin-list-table">
+              <VerticalGroup spacing="md">
+                <table className="filter-table filter-table--hover form-inline">
+                  <thead>
+                    <tr>
+                      <th />
+                      <th>Name</th>
+                      <th>Email</th>
+                      <th>Members</th>
+                      {displayRolePicker && <th>Roles</th>}
+                      <th style={{ width: '1%' }} />
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {teams.map((team) => (
+                      <TeamListRow
+                        key={team.id}
+                        team={team}
+                        roleOptions={roleOptions}
+                        displayRolePicker={displayRolePicker}
+                        isTeamAdmin={isPermissionTeamAdmin({
+                          permission: team.permission,
+                          editorsCanAdmin,
+                          signedInUser,
+                        })}
+                        onDelete={deleteTeam}
+                      />
+                    ))}
+                  </tbody>
+                </table>
+                <HorizontalGroup justify="flex-end">
+                  <Pagination
+                    hideWhenSinglePage
+                    currentPage={page}
+                    numberOfPages={totalPages}
+                    onNavigate={changePage}
+                  />
+                </HorizontalGroup>
+              </VerticalGroup>
+            </div>
+          </>
+        )}
+      </Page.Contents>
     </Page>
   );
 };

--- a/public/app/features/teams/TeamList.tsx
+++ b/public/app/features/teams/TeamList.tsx
@@ -13,7 +13,7 @@ import { connectWithCleanUp } from '../../core/components/connectWithCleanUp';
 import { TeamListRow } from './TeamListRow';
 import { deleteTeam, loadTeams } from './state/actions';
 import { initialTeamsState, setSearchQuery, setTeamsSearchPage } from './state/reducers';
-import { getSearchQuery, getTeams, getTeamsCount, getTeamsSearchPage, isPermissionTeamAdmin } from './state/selectors';
+import { getSearchQuery, getTeams, getTeamsSearchPage, isPermissionTeamAdmin } from './state/selectors';
 
 const pageLimit = 30;
 
@@ -21,7 +21,6 @@ export interface Props {
   teams: Team[];
   searchQuery: string;
   searchPage: number;
-  teamsCount: number;
   hasFetched: boolean;
   loadTeams: typeof loadTeams;
   deleteTeam: typeof deleteTeam;
@@ -150,17 +149,17 @@ export class TeamList extends PureComponent<Props, State> {
   }
 
   renderList() {
-    const { teamsCount, hasFetched } = this.props;
+    const { teams, hasFetched } = this.props;
 
     if (!hasFetched) {
       return null;
     }
 
-    if (teamsCount > 0) {
-      return this.renderTeamList();
-    } else {
+    if (teams.length === 0) {
       return this.renderEmptyList();
     }
+
+    return this.renderTeamList();
   }
 
   render() {
@@ -179,7 +178,6 @@ function mapStateToProps(state: StoreState) {
     teams: getTeams(state.teams),
     searchQuery: getSearchQuery(state.teams),
     searchPage: getTeamsSearchPage(state.teams),
-    teamsCount: getTeamsCount(state.teams),
     hasFetched: state.teams.hasFetched,
     editorsCanAdmin: config.editorsCanAdmin, // this makes the feature toggle mockable/controllable from tests,
     signedInUser: contextSrv.user, // this makes the feature toggle mockable/controllable from tests,

--- a/public/app/features/teams/TeamListRow.tsx
+++ b/public/app/features/teams/TeamListRow.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+
+import { DeleteButton } from '@grafana/ui';
+import { TeamRolePicker } from 'app/core/components/RolePicker/TeamRolePicker';
+import { contextSrv } from 'app/core/services/context_srv';
+import { AccessControlAction, Role, Team } from 'app/types';
+
+type Props = {
+  team: Team;
+  roleOptions: Role[];
+  isTeamAdmin: boolean;
+  onDelete: (team: Team) => void;
+};
+
+export const TeamListRow = ({ team, roleOptions, isTeamAdmin, onDelete }: Props) => {
+  const teamUrl = `org/teams/edit/${team.id}`;
+  const canDelete = contextSrv.hasAccessInMetadata(AccessControlAction.ActionTeamsDelete, team, isTeamAdmin);
+  const canReadTeam = contextSrv.hasAccessInMetadata(AccessControlAction.ActionTeamsRead, team, isTeamAdmin);
+  const canSeeTeamRoles = contextSrv.hasAccessInMetadata(AccessControlAction.ActionTeamsRolesList, team, false);
+  const displayRolePicker =
+    contextSrv.licensedAccessControlEnabled() && contextSrv.hasPermission(AccessControlAction.ActionRolesList);
+
+  return (
+    <tr key={team.id}>
+      <td className="width-4 text-center link-td">
+        {canReadTeam ? (
+          <a href={teamUrl}>
+            <img className="filter-table__avatar" src={team.avatarUrl} alt="Team avatar" />
+          </a>
+        ) : (
+          <img className="filter-table__avatar" src={team.avatarUrl} alt="Team avatar" />
+        )}
+      </td>
+      <td className="link-td">
+        {canReadTeam ? <a href={teamUrl}>{team.name}</a> : <div style={{ padding: '0px 8px' }}>{team.name}</div>}
+      </td>
+      <td className="link-td">
+        {canReadTeam ? (
+          <a href={teamUrl} aria-label={team.email?.length > 0 ? undefined : 'Empty email cell'}>
+            {team.email}
+          </a>
+        ) : (
+          <div style={{ padding: '0px 8px' }} aria-label={team.email?.length > 0 ? undefined : 'Empty email cell'}>
+            {team.email}
+          </div>
+        )}
+      </td>
+      <td className="link-td">
+        {canReadTeam ? (
+          <a href={teamUrl}>{team.memberCount}</a>
+        ) : (
+          <div style={{ padding: '0px 8px' }}>{team.memberCount}</div>
+        )}
+      </td>
+      {displayRolePicker && <td>{canSeeTeamRoles && <TeamRolePicker teamId={team.id} roleOptions={roleOptions} />}</td>}
+      <td className="text-right">
+        <DeleteButton
+          aria-label={`Delete team ${team.name}`}
+          size="sm"
+          disabled={!canDelete}
+          onConfirm={() => onDelete(team)}
+        />
+      </td>
+    </tr>
+  );
+};

--- a/public/app/features/teams/TeamListRow.tsx
+++ b/public/app/features/teams/TeamListRow.tsx
@@ -9,16 +9,15 @@ type Props = {
   team: Team;
   roleOptions: Role[];
   isTeamAdmin: boolean;
+  displayRolePicker: boolean;
   onDelete: (team: Team) => void;
 };
 
-export const TeamListRow = ({ team, roleOptions, isTeamAdmin, onDelete }: Props) => {
+export const TeamListRow = ({ team, roleOptions, isTeamAdmin, displayRolePicker, onDelete }: Props) => {
   const teamUrl = `org/teams/edit/${team.id}`;
   const canDelete = contextSrv.hasAccessInMetadata(AccessControlAction.ActionTeamsDelete, team, isTeamAdmin);
   const canReadTeam = contextSrv.hasAccessInMetadata(AccessControlAction.ActionTeamsRead, team, isTeamAdmin);
   const canSeeTeamRoles = contextSrv.hasAccessInMetadata(AccessControlAction.ActionTeamsRolesList, team, false);
-  const displayRolePicker =
-    contextSrv.licensedAccessControlEnabled() && contextSrv.hasPermission(AccessControlAction.ActionRolesList);
 
   return (
     <tr key={team.id}>

--- a/public/app/features/teams/TeamListRow.tsx
+++ b/public/app/features/teams/TeamListRow.tsx
@@ -10,7 +10,7 @@ type Props = {
   roleOptions: Role[];
   isTeamAdmin: boolean;
   displayRolePicker: boolean;
-  onDelete: (team: Team) => void;
+  onDelete: (id: number) => void;
 };
 
 export const TeamListRow = ({ team, roleOptions, isTeamAdmin, displayRolePicker, onDelete }: Props) => {
@@ -57,7 +57,7 @@ export const TeamListRow = ({ team, roleOptions, isTeamAdmin, displayRolePicker,
           aria-label={`Delete team ${team.name}`}
           size="sm"
           disabled={!canDelete}
-          onConfirm={() => onDelete(team)}
+          onConfirm={() => onDelete(team.id)}
         />
       </td>
     </tr>

--- a/public/app/features/teams/state/actions.ts
+++ b/public/app/features/teams/state/actions.ts
@@ -8,16 +8,17 @@ import { buildNavModel } from './navModel';
 import { teamGroupsLoaded, teamLoaded, teamMembersLoaded, teamsLoaded } from './reducers';
 
 export function loadTeams(): ThunkResult<void> {
-  return async (dispatch) => {
+  return async (dispatch, getState) => {
     // Early return if the user cannot list teams
     if (!contextSrv.hasPermission(AccessControlAction.ActionTeamsRead)) {
-      dispatch(teamsLoaded([]));
+      dispatch(teamsLoaded({ teams: [], totalCount: 0 }));
       return;
     }
 
+    const currentPage = getState().teams.currentPage;
     const response = await getBackendSrv().get(
       '/api/teams/search',
-      accessControlQueryParam({ perpage: 1000, page: 1 })
+      accessControlQueryParam({ perpage: 30, page: currentPage })
     );
     dispatch(teamsLoaded({ teams: response.teams, totalCount: response.totalCount }));
   };

--- a/public/app/features/teams/state/actions.ts
+++ b/public/app/features/teams/state/actions.ts
@@ -7,7 +7,7 @@ import { AccessControlAction, TeamMember, ThunkResult } from 'app/types';
 import { buildNavModel } from './navModel';
 import { teamGroupsLoaded, teamLoaded, teamMembersLoaded, teamsLoaded } from './reducers';
 
-export function loadTeams(): ThunkResult<void> {
+export function loadTeams(query: string, perpage: number, page: number): ThunkResult<void> {
   return async (dispatch, getState) => {
     // Early return if the user cannot list teams
     if (!contextSrv.hasPermission(AccessControlAction.ActionTeamsRead)) {
@@ -15,11 +15,7 @@ export function loadTeams(): ThunkResult<void> {
       return;
     }
 
-    const currentPage = getState().teams.currentPage;
-    const response = await getBackendSrv().get(
-      '/api/teams/search',
-      accessControlQueryParam({ perpage: 30, page: currentPage })
-    );
+    const response = await getBackendSrv().get('/api/teams/search', accessControlQueryParam({ query, perpage, page }));
     dispatch(teamsLoaded({ teams: response.teams, totalCount: response.totalCount }));
   };
 }

--- a/public/app/features/teams/state/actions.ts
+++ b/public/app/features/teams/state/actions.ts
@@ -19,7 +19,7 @@ export function loadTeams(): ThunkResult<void> {
       '/api/teams/search',
       accessControlQueryParam({ perpage: 1000, page: 1 })
     );
-    dispatch(teamsLoaded(response.teams));
+    dispatch(teamsLoaded({ teams: response.teams, totalCount: response.totalCount }));
   };
 }
 

--- a/public/app/features/teams/state/reducers.test.ts
+++ b/public/app/features/teams/state/reducers.test.ts
@@ -6,9 +6,9 @@ import {
   initialTeamsState,
   initialTeamState,
   setSearchMemberQuery,
-  setSearchQuery,
   teamGroupsLoaded,
   teamLoaded,
+  queryChanged,
   teamMembersLoaded,
   teamReducer,
   teamsLoaded,
@@ -20,11 +20,17 @@ describe('teams reducer', () => {
     it('then state should be correct', () => {
       reducerTester<TeamsState>()
         .givenReducer(teamsReducer, { ...initialTeamsState })
-        .whenActionIsDispatched(teamsLoaded([getMockTeam()]))
+        .whenActionIsDispatched(
+          teamsLoaded({ teams: [getMockTeam()], page: 1, perPage: 30, noTeams: false, totalCount: 100 })
+        )
         .thenStateShouldEqual({
           ...initialTeamsState,
           hasFetched: true,
           teams: [getMockTeam()],
+          noTeams: false,
+          totalPages: 4,
+          perPage: 30,
+          page: 1,
         });
     });
   });
@@ -33,10 +39,10 @@ describe('teams reducer', () => {
     it('then state should be correct', () => {
       reducerTester<TeamsState>()
         .givenReducer(teamsReducer, { ...initialTeamsState })
-        .whenActionIsDispatched(setSearchQuery('test'))
+        .whenActionIsDispatched(queryChanged('test'))
         .thenStateShouldEqual({
           ...initialTeamsState,
-          searchQuery: 'test',
+          query: 'test',
         });
     });
   });

--- a/public/app/features/teams/state/reducers.ts
+++ b/public/app/features/teams/state/reducers.ts
@@ -8,6 +8,7 @@ export const initialTeamsState: TeamsState = {
   query: '',
   perPage: 30,
   totalPages: 0,
+  noTeams: false,
   hasFetched: false,
 };
 
@@ -15,6 +16,7 @@ type TeamsFetched = {
   teams: Team[];
   page: number;
   perPage: number;
+  noTeams: boolean;
   totalCount: number;
 };
 

--- a/public/app/features/teams/state/reducers.ts
+++ b/public/app/features/teams/state/reducers.ts
@@ -4,29 +4,39 @@ import { Team, TeamGroup, TeamMember, TeamsState, TeamState } from 'app/types';
 
 export const initialTeamsState: TeamsState = {
   teams: [],
-  currentPage: 1,
-  searchQuery: '',
-  totalCount: 0,
+  page: 1,
+  query: '',
+  perPage: 30,
+  totalPages: 0,
   hasFetched: false,
+};
+
+type TeamsFetched = {
+  teams: Team[];
+  page: number;
+  perPage: number;
+  totalCount: number;
 };
 
 const teamsSlice = createSlice({
   name: 'teams',
   initialState: initialTeamsState,
   reducers: {
-    teamsLoaded: (state, action: PayloadAction<{ teams: Team[]; totalCount: number }>): TeamsState => {
-      return { ...state, hasFetched: true, teams: action.payload.teams, totalCount: action.payload.totalCount };
+    teamsLoaded: (state, action: PayloadAction<TeamsFetched>): TeamsState => {
+      const { totalCount, perPage, ...rest } = action.payload;
+      const totalPages = Math.ceil(totalCount / perPage);
+      return { ...state, ...rest, totalPages, perPage, hasFetched: true };
     },
-    setSearchQuery: (state, action: PayloadAction<string>): TeamsState => {
-      return { ...state, searchQuery: action.payload, currentPage: initialTeamsState.currentPage };
+    queryChanged: (state, action: PayloadAction<string>): TeamsState => {
+      return { ...state, page: 1, query: action.payload };
     },
-    setCurrentPage: (state, action: PayloadAction<number>): TeamsState => {
-      return { ...state, currentPage: action.payload };
+    pageChanged: (state, action: PayloadAction<number>): TeamsState => {
+      return { ...state, page: action.payload };
     },
   },
 });
 
-export const { teamsLoaded, setSearchQuery, setCurrentPage } = teamsSlice.actions;
+export const { teamsLoaded, queryChanged, pageChanged } = teamsSlice.actions;
 
 export const teamsReducer = teamsSlice.reducer;
 

--- a/public/app/features/teams/state/reducers.ts
+++ b/public/app/features/teams/state/reducers.ts
@@ -2,7 +2,13 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 import { Team, TeamGroup, TeamMember, TeamsState, TeamState } from 'app/types';
 
-export const initialTeamsState: TeamsState = { teams: [], searchQuery: '', searchPage: 1, hasFetched: false };
+export const initialTeamsState: TeamsState = {
+  teams: [],
+  searchQuery: '',
+  searchPage: 1,
+  totalCount: 0,
+  hasFetched: false,
+};
 
 const teamsSlice = createSlice({
   name: 'teams',

--- a/public/app/features/teams/state/reducers.ts
+++ b/public/app/features/teams/state/reducers.ts
@@ -14,8 +14,8 @@ const teamsSlice = createSlice({
   name: 'teams',
   initialState: initialTeamsState,
   reducers: {
-    teamsLoaded: (state, action: PayloadAction<Team[]>): TeamsState => {
-      return { ...state, hasFetched: true, teams: action.payload };
+    teamsLoaded: (state, action: PayloadAction<{ teams: Team[]; totalCount: number }>): TeamsState => {
+      return { ...state, hasFetched: true, teams: action.payload.teams, totalCount: action.payload.totalCount };
     },
     setSearchQuery: (state, action: PayloadAction<string>): TeamsState => {
       return { ...state, searchQuery: action.payload, searchPage: initialTeamsState.searchPage };

--- a/public/app/features/teams/state/reducers.ts
+++ b/public/app/features/teams/state/reducers.ts
@@ -4,8 +4,8 @@ import { Team, TeamGroup, TeamMember, TeamsState, TeamState } from 'app/types';
 
 export const initialTeamsState: TeamsState = {
   teams: [],
+  currentPage: 1,
   searchQuery: '',
-  searchPage: 1,
   totalCount: 0,
   hasFetched: false,
 };
@@ -18,15 +18,15 @@ const teamsSlice = createSlice({
       return { ...state, hasFetched: true, teams: action.payload.teams, totalCount: action.payload.totalCount };
     },
     setSearchQuery: (state, action: PayloadAction<string>): TeamsState => {
-      return { ...state, searchQuery: action.payload, searchPage: initialTeamsState.searchPage };
+      return { ...state, searchQuery: action.payload, currentPage: initialTeamsState.currentPage };
     },
-    setTeamsSearchPage: (state, action: PayloadAction<number>): TeamsState => {
-      return { ...state, searchPage: action.payload };
+    setCurrentPage: (state, action: PayloadAction<number>): TeamsState => {
+      return { ...state, currentPage: action.payload };
     },
   },
 });
 
-export const { teamsLoaded, setSearchQuery, setTeamsSearchPage } = teamsSlice.actions;
+export const { teamsLoaded, setSearchQuery, setCurrentPage } = teamsSlice.actions;
 
 export const teamsReducer = teamsSlice.reducer;
 

--- a/public/app/features/teams/state/selectors.test.ts
+++ b/public/app/features/teams/state/selectors.test.ts
@@ -1,7 +1,7 @@
 import { User } from 'app/core/services/context_srv';
 
 import { Team, TeamGroup, TeamState, OrgRole } from '../../../types';
-import { getMockTeam, getMockTeamMembers, getMultipleMockTeams } from '../__mocks__/teamMocks';
+import { getMockTeam, getMockTeamMembers } from '../__mocks__/teamMocks';
 
 import { getTeam, getTeamMembers, isSignedInUserTeamAdmin, Config } from './selectors';
 

--- a/public/app/features/teams/state/selectors.test.ts
+++ b/public/app/features/teams/state/selectors.test.ts
@@ -1,29 +1,9 @@
 import { User } from 'app/core/services/context_srv';
 
-import { Team, TeamGroup, TeamsState, TeamState, OrgRole } from '../../../types';
+import { Team, TeamGroup, TeamState, OrgRole } from '../../../types';
 import { getMockTeam, getMockTeamMembers, getMultipleMockTeams } from '../__mocks__/teamMocks';
 
-import { getTeam, getTeamMembers, getTeams, isSignedInUserTeamAdmin, Config } from './selectors';
-
-describe('Teams selectors', () => {
-  describe('Get teams', () => {
-    const mockTeams = getMultipleMockTeams(5);
-
-    it('should return teams if no search query', () => {
-      const mockState: TeamsState = { teams: mockTeams, searchQuery: '', searchPage: 1, hasFetched: false };
-
-      const teams = getTeams(mockState);
-      expect(teams).toEqual(mockTeams);
-    });
-
-    it('Should filter teams if search query', () => {
-      const mockState: TeamsState = { teams: mockTeams, searchQuery: '5', searchPage: 1, hasFetched: false };
-
-      const teams = getTeams(mockState);
-      expect(teams.length).toEqual(1);
-    });
-  });
-});
+import { getTeam, getTeamMembers, isSignedInUserTeamAdmin, Config } from './selectors';
 
 describe('Team selectors', () => {
   describe('Get team', () => {

--- a/public/app/features/teams/state/selectors.ts
+++ b/public/app/features/teams/state/selectors.ts
@@ -1,5 +1,5 @@
 import { User } from 'app/core/services/context_srv';
-import { Team, TeamsState, TeamState, TeamMember, OrgRole, TeamPermissionLevel } from 'app/types';
+import { Team, TeamState, TeamMember, OrgRole, TeamPermissionLevel } from 'app/types';
 
 export const getSearchMemberQuery = (state: TeamState) => state.searchMemberQuery;
 export const getTeamGroups = (state: TeamState) => state.groups;
@@ -10,14 +10,6 @@ export const getTeam = (state: TeamState, currentTeamId: any): Team | null => {
   }
 
   return null;
-};
-
-export const getTeams = (state: TeamsState) => {
-  const regex = RegExp(state.searchQuery, 'i');
-
-  return state.teams.filter((team) => {
-    return regex.test(team.name);
-  });
 };
 
 export const getTeamMembers = (state: TeamState) => {

--- a/public/app/features/teams/state/selectors.ts
+++ b/public/app/features/teams/state/selectors.ts
@@ -4,7 +4,6 @@ import { Team, TeamsState, TeamState, TeamMember, OrgRole, TeamPermissionLevel }
 export const getSearchQuery = (state: TeamsState) => state.searchQuery;
 export const getSearchMemberQuery = (state: TeamState) => state.searchMemberQuery;
 export const getTeamGroups = (state: TeamState) => state.groups;
-export const getTeamsCount = (state: TeamsState) => state.teams.length;
 export const getTeamsSearchPage = (state: TeamsState) => state.searchPage;
 
 export const getTeam = (state: TeamState, currentTeamId: any): Team | null => {

--- a/public/app/features/teams/state/selectors.ts
+++ b/public/app/features/teams/state/selectors.ts
@@ -1,10 +1,8 @@
 import { User } from 'app/core/services/context_srv';
 import { Team, TeamsState, TeamState, TeamMember, OrgRole, TeamPermissionLevel } from 'app/types';
 
-export const getSearchQuery = (state: TeamsState) => state.searchQuery;
 export const getSearchMemberQuery = (state: TeamState) => state.searchMemberQuery;
 export const getTeamGroups = (state: TeamState) => state.groups;
-export const getTeamsSearchPage = (state: TeamsState) => state.searchPage;
 
 export const getTeam = (state: TeamState, currentTeamId: any): Team | null => {
   if (state.team.id === parseInt(currentTeamId, 10)) {

--- a/public/app/types/teams.ts
+++ b/public/app/types/teams.ts
@@ -30,8 +30,8 @@ export interface TeamGroup {
 export interface TeamsState {
   teams: Team[];
   totalCount: number;
+  currentPage: number;
   searchQuery: string;
-  searchPage: number;
   hasFetched: boolean;
 }
 

--- a/public/app/types/teams.ts
+++ b/public/app/types/teams.ts
@@ -29,6 +29,7 @@ export interface TeamGroup {
 
 export interface TeamsState {
   teams: Team[];
+  totalCount: number;
   searchQuery: string;
   searchPage: number;
   hasFetched: boolean;

--- a/public/app/types/teams.ts
+++ b/public/app/types/teams.ts
@@ -29,9 +29,10 @@ export interface TeamGroup {
 
 export interface TeamsState {
   teams: Team[];
-  totalCount: number;
-  currentPage: number;
-  searchQuery: string;
+  page: number;
+  query: string;
+  perPage: number;
+  totalPages: number;
   hasFetched: boolean;
 }
 

--- a/public/app/types/teams.ts
+++ b/public/app/types/teams.ts
@@ -32,6 +32,7 @@ export interface TeamsState {
   page: number;
   query: string;
   perPage: number;
+  noTeams: boolean;
   totalPages: number;
   hasFetched: boolean;
 }


### PR DESCRIPTION
**What is this feature?**
The team list page always fetch the first 1000 teams and do all pagination and filtering in front-end, making it impossible to view a team that that is not part of that first 1000 in the list.

The API already has support for paginating and filtering (by query) so I just had to update the front-end code to support back-end pagination and filtering.

**Why do we need this feature?**
To be able to view more teams than the first 1000.

**Which issue(s) does this PR fix?**:
Fixes #58736

**Special notes for your reviewer**:
* Extract the code for team row as its own component
* Rework TeamList to be a functional component
