### PR TITLE
AppRootPage: Render app plugins without pages

### DIFF
--- a/public/app/features/plugins/routes.tsx
+++ b/public/app/features/plugins/routes.tsx
@@ -12,8 +12,7 @@ export function getAppPluginRoutes(): RouteDescriptor[] {
   const isStandalonePluginPage = (id: string) => id.startsWith('standalone-plugin-page-/');
   const isPluginNavModelItem = (model: NavModelItem): model is PluginNavModelItem =>
     'pluginId' in model && 'id' in model;
-
-  return Object.values(navIndex)
+  const explicitAppPluginRoutes = Object.values(navIndex)
     .filter<PluginNavModelItem>(isPluginNavModelItem)
     .map((navItem) => {
       const pluginNavSection = getRootSectionForNode(navItem);
@@ -26,6 +25,17 @@ export function getAppPluginRoutes(): RouteDescriptor[] {
         component: () => <AppRootPage pluginId={navItem.pluginId} pluginNavSection={pluginNavSection} />,
       };
     });
+
+  return [
+    ...explicitAppPluginRoutes,
+
+    // Fallback route for plugins that don't have any pages under includes
+    {
+      path: '/a/:pluginId',
+      exact: false, // route everything under this path to the plugin, so it can define more routes under this path
+      component: ({ match }) => <AppRootPage pluginId={match.params.pluginId} pluginNavSection={navIndex.home} />,
+    },
+  ];
 }
 
 interface PluginNavModelItem extends Omit<NavModelItem, 'pluginId' | 'id'> {


### PR DESCRIPTION
### What is the problem?

There are plugins which have no pages under `includes: []` in their plugin.json, e.g. the `"cloud-home-app"` which serves the home page using an app plugin for Cloud users. With the [current explicit app-plugin routing solution](https://github.com/grafana/grafana/pull/57771/files#diff-28aa515cce6c275d3776b64550d509ac87c0c8952bef1b224d37fff4c10d6751L40) these kind of plugins wouldn't get routed and `/a/cloud-home-app` is not working for Cloud.

### What changed?

This PR fixes that by adding a fallback route at the end of the app plugin routes. This is only a temporary solution though, we are planning to make an explicit configuration option for plugins to handle situations like this.




 