### PR TITLE
kindsys: Make kind generators run in Windows

### DIFF
--- a/kinds/gen.go
+++ b/kinds/gen.go
@@ -12,10 +12,10 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"strings"
 
 	"cuelang.org/go/cue/errors"
 	"github.com/grafana/codejen"
+
 	"github.com/grafana/grafana/pkg/codegen"
 	"github.com/grafana/grafana/pkg/cuectx"
 	"github.com/grafana/grafana/pkg/kindsys"
@@ -57,8 +57,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "could not get working directory: %s", err)
 		os.Exit(1)
 	}
-	grootp := strings.Split(cwd, sep)
-	groot := filepath.Join(sep, filepath.Join(grootp[:len(grootp)-1]...))
+	groot := filepath.Dir(cwd)
 
 	rt := cuectx.GrafanaThemaRuntime()
 	var all []*codegen.DeclForGen

--- a/pkg/kindsys/load.go
+++ b/pkg/kindsys/load.go
@@ -8,10 +8,11 @@ import (
 
 	"cuelang.org/go/cue"
 	"cuelang.org/go/cue/errors"
-	"github.com/grafana/grafana"
-	"github.com/grafana/grafana/pkg/cuectx"
 	"github.com/grafana/thema"
 	tload "github.com/grafana/thema/load"
+
+	"github.com/grafana/grafana"
+	"github.com/grafana/grafana/pkg/cuectx"
 )
 
 // CoreStructuredDeclParentPath is the path, relative to the repository root, where
@@ -54,15 +55,7 @@ func doLoadFrameworkCUE(ctx *cue.Context) (cue.Value, error) {
 	var v cue.Value
 	var err error
 
-	absolutePath := prefix
-	if !filepath.IsAbs(absolutePath) {
-		absolutePath, err = filepath.Abs(absolutePath)
-		if err != nil {
-			return v, err
-		}
-	}
-
-	bi, err := tload.InstancesWithThema(grafana.CueSchemaFS, absolutePath)
+	bi, err := tload.InstancesWithThema(grafana.CueSchemaFS, prefix)
 	if err != nil {
 		return v, err
 	}


### PR DESCRIPTION

**What is this feature?**
This PR fixes a bug in core models generator to work in Windows OS.

The change was introduced in https://github.com/grafana/grafana/pull/56492