### PR TITLE
Internationalization: Translate NavBar - 'Search dashboard' menu item

### DIFF
--- a/public/app/core/components/NavBar/navBarItem-translations.ts
+++ b/public/app/core/components/NavBar/navBarItem-translations.ts
@@ -121,6 +121,8 @@ export function getNavTitle(navId: string | undefined) {
       return t('nav.profile/password.title', 'Change password');
     case 'sign-out':
       return t('nav.sign-out.title', 'Sign out');
+    case 'search':
+      return t('nav.search-dashboards.title', 'Search dashboards');
     default:
       return undefined;
   }

--- a/public/locales/de-DE/grafana.json
+++ b/public/locales/de-DE/grafana.json
@@ -253,6 +253,9 @@
     "search": {
       "placeholder": "Grafana durchsuchen"
     },
+    "search-dashboards": {
+      "title": ""
+    },
     "server-settings": {
       "subtitle": "Zeige die in deiner Grafana-Konfiguration festgelegten Einstellungen an",
       "title": "Einstellungen"

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -253,6 +253,9 @@
     "search": {
       "placeholder": "Search Grafana"
     },
+    "search-dashboards": {
+      "title": "Search dashboards"
+    },
     "server-settings": {
       "subtitle": "View the settings defined in your Grafana config",
       "title": "Settings"

--- a/public/locales/es-ES/grafana.json
+++ b/public/locales/es-ES/grafana.json
@@ -253,6 +253,9 @@
     "search": {
       "placeholder": "Buscar Grafana"
     },
+    "search-dashboards": {
+      "title": ""
+    },
     "server-settings": {
       "subtitle": "Vea la configuración definida en los ajustes de Grafana",
       "title": "Configuración"

--- a/public/locales/fr-FR/grafana.json
+++ b/public/locales/fr-FR/grafana.json
@@ -253,6 +253,9 @@
     "search": {
       "placeholder": "Rechercher dans Grafana"
     },
+    "search-dashboards": {
+      "title": ""
+    },
     "server-settings": {
       "subtitle": "Afficher les paramètres définis dans votre configuration Grafana",
       "title": "Paramètres"

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -253,6 +253,9 @@
     "search": {
       "placeholder": "Ŝęäřčĥ Ğřäƒäŉä"
     },
+    "search-dashboards": {
+      "title": "Ŝęäřčĥ đäşĥþőäřđş"
+    },
     "server-settings": {
       "subtitle": "Vįęŵ ŧĥę şęŧŧįŉģş đęƒįŉęđ įŉ yőūř Ğřäƒäŉä čőŉƒįģ",
       "title": "Ŝęŧŧįŉģş"

--- a/public/locales/zh-Hans/grafana.json
+++ b/public/locales/zh-Hans/grafana.json
@@ -253,6 +253,9 @@
     "search": {
       "placeholder": "搜索 Grafana"
     },
+    "search-dashboards": {
+      "title": ""
+    },
     "server-settings": {
       "subtitle": "查看 Grafana 配置中定义的设置",
       "title": "设置"


### PR DESCRIPTION
**What this PR does / why we need it:**
In the process of getting ready for the translation of the portal, we need to extract strings into translation tags. One of our first steps is to translate the Dashboard in view-only mode. This ticket does part of that by translating the 'Search dasboards' menu item of `NavBar`.

**Which issue(s) this PR fixes:**
Fixes #58811 

![SearchDashboards](https://user-images.githubusercontent.com/65417731/202161144-3949da37-faa9-436b-8561-85709dbbf1c2.png)

