### PR TITLE
CI: Remove `wire-install` dependency from `lint-backend` pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -276,15 +276,8 @@ steps:
   image: golang:1.19.3
   name: compile-build-cmd
 - commands:
-  - make gen-go
-  depends_on: []
-  image: grafana/build-container:1.6.4
-  name: wire-install
-- commands:
   - apt-get update && apt-get install make
   - make lint-go
-  depends_on:
-  - wire-install
   environment:
     CGO_ENABLED: "1"
   image: golang:1.19.3
@@ -1151,15 +1144,8 @@ steps:
   image: golang:1.19.3
   name: compile-build-cmd
 - commands:
-  - make gen-go
-  depends_on: []
-  image: grafana/build-container:1.6.4
-  name: wire-install
-- commands:
   - apt-get update && apt-get install make
   - make lint-go
-  depends_on:
-  - wire-install
   environment:
     CGO_ENABLED: "1"
   image: golang:1.19.3
@@ -5512,6 +5498,6 @@ kind: secret
 name: packages_secret_access_key
 ---
 kind: signature
-hmac: 2b1b5ade4e8007a9d5b76ec2dbc9e647ca0938e00713b3ad8e8163bce2db40a6
+hmac: e5f4a2f2bdd46ea136b38ee6c03035aa9d95b2ce4989f0e0faa79a23fab36e71
 
 ...

--- a/pkg/README.md
+++ b/pkg/README.md
@@ -1,5 +1,5 @@
 # Backend
-
+test trigger
 This directory contains the code for the Grafana backend. This document gives an overview of the directory structure, and ongoing refactorings.
 
 For more information on developing for the backend:

--- a/scripts/drone/events/release.star
+++ b/scripts/drone/events/release.star
@@ -10,7 +10,6 @@ load(
     'build_image',
     'identify_runner_step',
     'publish_image',
-    'lint_backend_step',
     'lint_frontend_step',
     'test_backend_step',
     'test_backend_integration_step',

--- a/scripts/drone/pipelines/lint_backend.star
+++ b/scripts/drone/pipelines/lint_backend.star
@@ -13,12 +13,9 @@ load(
 )
 
 def lint_backend_pipeline(trigger, ver_mode):
-    wire_step = wire_install_step()
-    wire_step.update({ 'depends_on': [] })
     init_steps = [
         identify_runner_step(),
         compile_build_cmd(),
-        wire_step,
     ]
     test_steps = [
         lint_backend_step(edition="oss"),

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -208,9 +208,6 @@ def lint_backend_step(edition):
             # We need CGO because of go-sqlite3
             'CGO_ENABLED': '1',
         },
-        'depends_on': [
-            'wire-install',
-        ],
         'commands': [
             'apt-get update && apt-get install make',
             # Don't use Make since it will re-download the linters


### PR DESCRIPTION
**Why do we need this feature?**

Removes an unnecessary dependency between CI steps.