### PR TITLE
Query Editor: Hide overflow for long query names

### DIFF
--- a/public/app/features/query/components/QueryEditorRowHeader.tsx
+++ b/public/app/features/query/components/QueryEditorRowHeader.tsx
@@ -153,6 +153,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       display: flex;
       align-items: center;
       margin-left: ${theme.spacing(0.5)};
+      overflow: hidden;
     `,
     queryNameWrapper: css`
       display: flex;
@@ -163,6 +164,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       padding: 0 0 0 ${theme.spacing(0.5)};
       margin: 0;
       background: transparent;
+      overflow: hidden;
 
       &:hover {
         background: ${theme.colors.action.hover};
@@ -214,6 +216,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       font-style: italic;
       color: ${theme.colors.text.secondary};
       padding-left: 10px;
+      padding-right: 10px;
     `,
     itemWrapper: css`
       display: flex;


### PR DESCRIPTION
Fixes #53900

**Special notes for your reviewer**:

Explore before:

![CleanShot 2022-11-16 at 04 41 35](https://user-images.githubusercontent.com/37156449/202210672-787e6124-5eb6-4652-b26d-850353febaf3.gif)

Explore after

![CleanShot 2022-11-16 at 04 44 29@2x](https://user-images.githubusercontent.com/37156449/202211510-ae01b106-96e1-4d38-a6fc-ae81acc531f9.png)

Panel editor before:

![CleanShot 2022-11-16 at 04 43 16](https://user-images.githubusercontent.com/37156449/202211108-ee3fc015-cd2b-4dcc-80c0-31a74167148a.gif)

Panel editor after:

![CleanShot 2022-11-16 at 04 44 14@2x](https://user-images.githubusercontent.com/37156449/202211679-36f1fd0a-1f12-4310-8771-34fed0831b2f.png)



