### PR TITLE
CodeOwners: (Chore) Add Server Side Expressions (SSE)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -198,6 +198,9 @@ lerna.json @grafana/frontend-ops
 /public/app/plugins/datasource/tempo @grafana/observability-traces-and-profiling
 /public/app/plugins/datasource/alertmanager @grafana/alerting-squad
 
+# SSE - Server Side Expressions
+/pkg/expr @grafana/observability-metrics
+
 # Cloud middleware
 /grafana-mixin/ @grafana/hosted-grafana-team
 


### PR DESCRIPTION
CODEOWNERS github updated to have SSE owned by observability-metrics

