### PR TITLE
Breadcrumbs: Remove semi-bold and change current/last breadcrumb text color

### DIFF
--- a/public/app/core/components/Breadcrumbs/BreadcrumbItem.tsx
+++ b/public/app/core/components/Breadcrumbs/BreadcrumbItem.tsx
@@ -44,8 +44,10 @@ const getStyles = (theme: GrafanaTheme2) => {
       overflow: 'hidden',
       padding: theme.spacing(0, 0.5),
       whiteSpace: 'nowrap',
+      color: theme.colors.text.secondary,
     }),
     breadcrumbLink: css({
+      color: theme.colors.text.primary,
       '&:hover': {
         textDecoration: 'underline',
       },
@@ -55,7 +57,6 @@ const getStyles = (theme: GrafanaTheme2) => {
       color: theme.colors.text.primary,
       display: 'flex',
       flex: 1,
-      fontWeight: theme.typography.fontWeightMedium,
       minWidth: 0,
       maxWidth: 'max-content',
 


### PR DESCRIPTION
* Make breadcrumbs normal font weight
* Make current/last secondary color

Personally I feel normal font weight looks a bit off on linux/windows that have a much thinner
font rendering than osx. And the other things in toolbar uses semi-bold, like buttons and tags. But it does make it less bright / distracting :) 

Inter 400
![Screenshot from 2022-11-17 08-20-55](https://user-images.githubusercontent.com/10999/202385121-2a3dd66d-11fd-49f5-b299-6556265743eb.png)

Roboto 400
![Screenshot from 2022-11-17 08-19-04](https://user-images.githubusercontent.com/10999/202385125-49745554-90fc-4dc0-8786-cb9ad2f5ed50.png)

Roboto 500
![Screenshot from 2022-11-17 08-25-01](https://user-images.githubusercontent.com/10999/202385192-a6290f18-ae55-4348-88ee-68dbf1175aad.png)

Roboto 500 & 12px font size
![Screenshot from 2022-11-17 08-23-20](https://user-images.githubusercontent.com/10999/202385199-f79de425-faa5-410d-a12b-f35cd080abff.png)

Changing so last is secondary color make
![Screenshot from 2022-11-17 08-40-55](https://user-images.githubusercontent.com/10999/202385590-d5d0f36a-f1ab-4176-9d77-2202785936a0.png)
