### PR TITLE
SQLStore: Fix tests failures due to SQLite locking (WIP)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -217,13 +217,13 @@ steps:
   image: grafana/build-container:1.6.4
   name: wire-install
 - commands:
-  - go test -short -covermode=atomic -timeout=5m ./pkg/...
+  - go test -short -covermode=atomic -timeout=10m ./pkg/...
   depends_on:
   - wire-install
   image: grafana/build-container:1.6.4
   name: test-backend
 - commands:
-  - go test -run Integration -covermode=atomic -timeout=5m ./pkg/...
+  - go test -run Integration -covermode=atomic -timeout=10m ./pkg/...
   depends_on:
   - wire-install
   image: grafana/build-container:1.6.4

--- a/.drone.yml
+++ b/.drone.yml
@@ -1099,13 +1099,13 @@ steps:
   image: grafana/build-container:1.6.4
   name: wire-install
 - commands:
-  - go test -short -covermode=atomic -timeout=5m ./pkg/...
+  - go test -short -covermode=atomic -timeout=10m ./pkg/...
   depends_on:
   - wire-install
   image: grafana/build-container:1.6.4
   name: test-backend
 - commands:
-  - go test -run Integration -covermode=atomic -timeout=5m ./pkg/...
+  - go test -run Integration -covermode=atomic -timeout=10m ./pkg/...
   depends_on:
   - wire-install
   image: grafana/build-container:1.6.4
@@ -2313,13 +2313,13 @@ steps:
   image: grafana/build-container:1.6.4
   name: wire-install
 - commands:
-  - go test -short -covermode=atomic -timeout=5m ./pkg/...
+  - go test -short -covermode=atomic -timeout=10m ./pkg/...
   depends_on:
   - wire-install
   image: grafana/build-container:1.6.4
   name: test-backend
 - commands:
-  - go test -run Integration -covermode=atomic -timeout=5m ./pkg/...
+  - go test -run Integration -covermode=atomic -timeout=10m ./pkg/...
   depends_on:
   - wire-install
   image: grafana/build-container:1.6.4
@@ -3044,13 +3044,13 @@ steps:
   image: grafana/build-container:1.6.4
   name: wire-install
 - commands:
-  - go test -short -covermode=atomic -timeout=5m ./pkg/...
+  - go test -short -covermode=atomic -timeout=10m ./pkg/...
   depends_on:
   - wire-install
   image: grafana/build-container:1.6.4
   name: test-backend
 - commands:
-  - go test -run Integration -covermode=atomic -timeout=5m ./pkg/...
+  - go test -run Integration -covermode=atomic -timeout=10m ./pkg/...
   depends_on:
   - wire-install
   image: grafana/build-container:1.6.4
@@ -4304,13 +4304,13 @@ steps:
   image: grafana/build-container:1.6.4
   name: wire-install
 - commands:
-  - go test -short -covermode=atomic -timeout=5m ./pkg/...
+  - go test -short -covermode=atomic -timeout=10m ./pkg/...
   depends_on:
   - wire-install
   image: grafana/build-container:1.6.4
   name: test-backend
 - commands:
-  - go test -run Integration -covermode=atomic -timeout=5m ./pkg/...
+  - go test -run Integration -covermode=atomic -timeout=10m ./pkg/...
   depends_on:
   - wire-install
   image: grafana/build-container:1.6.4
@@ -5011,13 +5011,13 @@ steps:
   image: grafana/build-container:1.6.4
   name: wire-install
 - commands:
-  - go test -short -covermode=atomic -timeout=5m ./pkg/...
+  - go test -short -covermode=atomic -timeout=10m ./pkg/...
   depends_on:
   - wire-install
   image: grafana/build-container:1.6.4
   name: test-backend
 - commands:
-  - go test -run Integration -covermode=atomic -timeout=5m ./pkg/...
+  - go test -run Integration -covermode=atomic -timeout=10m ./pkg/...
   depends_on:
   - wire-install
   image: grafana/build-container:1.6.4
@@ -5512,6 +5512,6 @@ kind: secret
 name: packages_secret_access_key
 ---
 kind: signature
-hmac: 2b1b5ade4e8007a9d5b76ec2dbc9e647ca0938e00713b3ad8e8163bce2db40a6
+hmac: 2452bf071f3a67213042cd125ad4ede3e92921f3c3d1ed697310d9904ad15939
 
 ...

--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -571,6 +571,11 @@ func initTestDB(migration registry.DatabaseMigrator, opts ...InitTestDBOpt) (*SQ
 			if _, err := sec.NewKey("connection_string", sqlutil.SQLite3TestDB().ConnStr); err != nil {
 				return nil, err
 			}
+			// set maxmum open connections to 1
+			// to prevent failure due to database locking
+			if _, err := sec.NewKey("max_open_conn", "1"); err != nil {
+				return nil, err
+			}
 		}
 
 		// useful if you already have a database that you want to use for tests.

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -481,7 +481,7 @@ def test_backend_step(edition):
             'wire-install',
         ],
         'commands': [
-            'go test -short -covermode=atomic -timeout=5m ./pkg/...',
+            'go test -short -covermode=atomic -timeout=10m ./pkg/...',
         ],
     }
 
@@ -495,7 +495,7 @@ def test_backend_integration_step(edition):
             'wire-install',
         ],
         'commands': [
-            'go test -run Integration -covermode=atomic -timeout=5m ./pkg/...',
+            'go test -run Integration -covermode=atomic -timeout=10m ./pkg/...',
         ],
     }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Regarding #55223 #57117

For the tests we use [in-memory database with shared cache mode](https://github.com/grafana/grafana/blob/b398e8640dffecadc9ee9744b44d45c6e7c98da8/pkg/services/sqlstore/sqlutil/sqlutil.go#L18). According to [this ticket](https://github.com/mattn/go-sqlite3/issues/632):
> SQLITE_LOCKED will happen much more often. Now, normal, seemingly separate connections will get SQLITE_LOCKED if they happen to run conflicting statements at the same time. Worse, you can't set a busy timeout to fix it. If a lock error happens, it's failed. The only way around this now is to support the unlock_notify API, which this driver currently does not support. So we dig our heels in even further and limit the connection pool to only a single connection.

This POC tries to limit the open connections for the tests to 1. If that does not help then they we can consider the [sqlite3_unlock_notify()](https://github.com/mattn/go-sqlite3/issues/438) API (it seems [to be supported](https://github.com/mattn/go-sqlite3/issues/438) now) or not use in-memory database and enable [recommended](https://www.sqlite.org/sharedcache.html#use_of_shared_cache_is_discouraged) WAL mode.

Further reading:
https://activesphere.com/blog/2018/12/24/understanding-sqlite-busy

It additionally includes additional information for the SQLite error in the error message and in the logs.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
Side effect: this may have slow down tests and CI cycles.


[Fist attempt](https://drone.grafana.net/grafana/grafana/89178/1/7) failed due to 5m timeout (`pkg/tests/web` package)
[Second attempt](https://drone.grafana.net/grafana/grafana/89182/4/7) failed due to 10m timeout (`pkg/tests/web` package)

It seems that the most common failure is the [TestUpdatingProvisionionedDashboards](https://github.com/grafana/grafana/blob/b398e8640dffecadc9ee9744b44d45c6e7c98da8/pkg/tests/api/dashboards/api_dashboards_test.go#L108) and more specifically the `/api/search` route.