### PR TITLE
grafana.com: Make `beta` and `test` releases not stable

### DIFF
--- a/pkg/build/cmd/grafanacom.go
+++ b/pkg/build/cmd/grafanacom.go
@@ -177,7 +177,7 @@ func publishPackages(cfg packaging.PublishConfig) error {
 		Version:     cfg.Version,
 		ReleaseDate: time.Now().UTC(),
 		Builds:      builds,
-		Stable:      cfg.ReleaseMode.Mode == config.TagMode,
+		Stable:      cfg.ReleaseMode.Mode == config.TagMode && !cfg.ReleaseMode.IsBeta && !cfg.ReleaseMode.IsTest,
 		Beta:        cfg.ReleaseMode.IsBeta,
 		Nightly:     cfg.ReleaseMode.Mode == config.CronjobMode,
 	}


### PR DESCRIPTION
**What is this feature?**

During `v9.3.0-beta1` we realised that we accidentally marked it as stable and it was the Grafana version shown as the default version to be downloaded in grafana.com.
This was clearly wrong since it shouldn't be regarded as stable. This PR fixes this issue, by adding a couple of conditions.
It's all amounted to:
_If a build is a tag, but it's not **test** or **beta**, then mark it as stable._