### PR TITLE
Glue: Show data links only for fully interpolated correlations [CLOSED]

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -783,10 +783,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "10"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "11"]
     ],
-    "packages/grafana-data/src/utils/dataLinks.test.ts:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
-    ],
     "packages/grafana-data/src/utils/dataLinks.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"]

--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -380,8 +380,8 @@ export const getLinksSupplier =
 
         valueVars = {
           raw: field.values.get(config.valueRowIndex),
-          numeric: fieldsProxy[field.name]?.numeric ?? NaN,
-          text: fieldsProxy[field.name]?.text ?? '',
+          numeric: fieldsProxy[field.name].numeric,
+          text: fieldsProxy[field.name].text,
           time: timeField ? timeField.values.get(config.valueRowIndex) : undefined,
         };
 

--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -380,8 +380,8 @@ export const getLinksSupplier =
 
         valueVars = {
           raw: field.values.get(config.valueRowIndex),
-          numeric: fieldsProxy[field.name].numeric,
-          text: fieldsProxy[field.name].text,
+          numeric: fieldsProxy[field.name]?.numeric ?? NaN,
+          text: fieldsProxy[field.name]?.text ?? '',
           time: timeField ? timeField.values.get(config.valueRowIndex) : undefined,
         };
 

--- a/packages/grafana-data/src/field/getFieldDisplayValuesProxy.test.tsx
+++ b/packages/grafana-data/src/field/getFieldDisplayValuesProxy.test.tsx
@@ -87,9 +87,9 @@ describe('getFieldDisplayValuesProxy', () => {
 
   it('should return undefined when value of a field is missing', () => {
     const proxyByRow = [
-      getFieldDisplayValuesProxy({ frame: dataShortTimeRange, rowIndex: 0 }),
-      getFieldDisplayValuesProxy({ frame: dataShortTimeRange, rowIndex: 1 }),
-      getFieldDisplayValuesProxy({ frame: dataShortTimeRange, rowIndex: 2 }),
+      getFieldDisplayValuesProxy({ frame: dataShortTimeRange, rowIndex: 0, skipEmptyValuesFormatting: true }),
+      getFieldDisplayValuesProxy({ frame: dataShortTimeRange, rowIndex: 1, skipEmptyValuesFormatting: true }),
+      getFieldDisplayValuesProxy({ frame: dataShortTimeRange, rowIndex: 2, skipEmptyValuesFormatting: true }),
     ];
     expect(proxyByRow[0].Missing).toBeUndefined();
     expect(proxyByRow[1].Missing).toBeUndefined();

--- a/packages/grafana-data/src/field/getFieldDisplayValuesProxy.test.tsx
+++ b/packages/grafana-data/src/field/getFieldDisplayValuesProxy.test.tsx
@@ -21,6 +21,8 @@ describe('getFieldDisplayValuesProxy', () => {
       },
     },
     { name: 'Last', values: ['a', 'b', 'c'] },
+    { name: 'Missing', values: [null, null, undefined] },
+    { name: 'NotMissing', values: [0, false, ''] },
   ];
 
   const overrides = {
@@ -77,10 +79,24 @@ describe('getFieldDisplayValuesProxy', () => {
     expect(p[1].numeric).toEqual(300);
   });
 
-  it('should return undefined when missing', () => {
+  it('should return undefined when field is missing', () => {
     const p = getFieldDisplayValuesProxy({ frame: dataShortTimeRange, rowIndex: 0 });
     expect(p.xyz).toBeUndefined();
     expect(p[100]).toBeUndefined();
+  });
+
+  it('should return undefined when value of a field is missing', () => {
+    const proxyByRow = [
+      getFieldDisplayValuesProxy({ frame: dataShortTimeRange, rowIndex: 0 }),
+      getFieldDisplayValuesProxy({ frame: dataShortTimeRange, rowIndex: 1 }),
+      getFieldDisplayValuesProxy({ frame: dataShortTimeRange, rowIndex: 2 }),
+    ];
+    expect(proxyByRow[0].Missing).toBeUndefined();
+    expect(proxyByRow[1].Missing).toBeUndefined();
+    expect(proxyByRow[2].Missing).toBeUndefined();
+    expect(proxyByRow[0].NotMissing).toBeDefined();
+    expect(proxyByRow[1].NotMissing).toBeDefined();
+    expect(proxyByRow[2].NotMissing).toBeDefined();
   });
 
   it('should use default display processor if display is not defined', () => {

--- a/packages/grafana-data/src/field/getFieldDisplayValuesProxy.ts
+++ b/packages/grafana-data/src/field/getFieldDisplayValuesProxy.ts
@@ -18,6 +18,7 @@ export function getFieldDisplayValuesProxy(options: {
   frame: DataFrame;
   rowIndex: number;
   timeZone?: TimeZone;
+  skipEmptyValuesFormatting?: boolean;
 }): Record<string, DisplayValue> {
   return new Proxy({} as Record<string, DisplayValue>, {
     get: (obj: any, key: string): DisplayValue | undefined => {
@@ -46,7 +47,7 @@ export function getFieldDisplayValuesProxy(options: {
       }
 
       const raw = field.values.get(options.rowIndex);
-      if (raw === null || raw === undefined) {
+      if (options.skipEmptyValuesFormatting && (raw === null || raw === undefined)) {
         return undefined;
       }
 

--- a/packages/grafana-data/src/field/getFieldDisplayValuesProxy.ts
+++ b/packages/grafana-data/src/field/getFieldDisplayValuesProxy.ts
@@ -44,10 +44,15 @@ export function getFieldDisplayValuesProxy(options: {
       if (!field) {
         return undefined;
       }
+
+      const raw = field.values.get(options.rowIndex);
+      if (raw === null || raw === undefined) {
+        return undefined;
+      }
+
       // TODO: we could supply the field here for the getDisplayProcessor fallback but we would also need theme which
       //  we do not have access to here
       const displayProcessor = field.display ?? getDisplayProcessor();
-      const raw = field.values.get(options.rowIndex);
       const disp = displayProcessor(raw);
       disp.toString = () => formattedValueToString(disp);
       return disp;

--- a/packages/grafana-data/src/types/dataLink.ts
+++ b/packages/grafana-data/src/types/dataLink.ts
@@ -61,6 +61,9 @@ export interface LinkModel<T = any> {
 
   // When a click callback exists, this is passed the raw mouse|react event
   onClick?: (e: any, origin?: any) => void;
+
+  // Additional information that the link when executed will contain template variables
+  containsTemplate?: boolean;
 }
 
 /**

--- a/packages/grafana-data/src/utils/dataLinks.test.ts
+++ b/packages/grafana-data/src/utils/dataLinks.test.ts
@@ -1,7 +1,18 @@
+import { dateTime } from '../datetime';
 import { DataLink, FieldType } from '../types';
 import { ArrayVector } from '../vector';
 
 import { mapInternalLinkToExplore } from './dataLinks';
+
+const mockTimeRange = {
+  from: dateTime(0),
+  to: dateTime(1000),
+  raw: {
+    from: dateTime(0),
+    to: dateTime(1000),
+  },
+};
+const serializedRange = '{"from":"1970-01-01T00:00:00.000Z","to":"1970-01-01T00:00:01.000Z"}';
 
 describe('mapInternalLinkToExplore', () => {
   it('creates internal link', () => {
@@ -19,7 +30,7 @@ describe('mapInternalLinkToExplore', () => {
       link: dataLink,
       internalLink: dataLink.internal,
       scopedVars: {},
-      range: {} as any,
+      range: mockTimeRange,
       field: {
         name: 'test',
         type: FieldType.number,
@@ -33,9 +44,10 @@ describe('mapInternalLinkToExplore', () => {
       expect.objectContaining({
         title: 'dsName',
         href: `/explore?left=${encodeURIComponent(
-          '{"datasource":"uid","queries":[{"query":"12344"}],"panelsState":{}}'
+          `{"range":${serializedRange},"datasource":"uid","queries":[{"query":"12344"}],"panelsState":{}}`
         )}`,
         onClick: undefined,
+        containsTemplate: undefined,
       })
     );
   });
@@ -62,7 +74,7 @@ describe('mapInternalLinkToExplore', () => {
       link: dataLink,
       internalLink: dataLink.internal!,
       scopedVars: {},
-      range: {} as any,
+      range: mockTimeRange,
       field: {
         name: 'test',
         type: FieldType.number,
@@ -76,9 +88,47 @@ describe('mapInternalLinkToExplore', () => {
       expect.objectContaining({
         title: 'dsName',
         href: `/explore?left=${encodeURIComponent(
-          '{"datasource":"uid","queries":[{"query":"12344"}],"panelsState":{"trace":{"spanId":"abcdef"}}}'
+          `{"range":${serializedRange},"datasource":"uid","queries":[{"query":"12344"}],"panelsState":{"trace":{"spanId":"abcdef"}}}`
         )}`,
         onClick: undefined,
+      })
+    );
+  });
+
+  it('passed containsTemplate to link model', () => {
+    const dataLink = {
+      url: '',
+      title: '',
+      internal: {
+        datasourceUid: 'uid',
+        datasourceName: 'dsName',
+        query: { query: '12344' },
+      },
+    };
+
+    const link = mapInternalLinkToExplore({
+      link: dataLink,
+      internalLink: dataLink.internal,
+      scopedVars: {},
+      range: mockTimeRange,
+      field: {
+        name: 'test',
+        type: FieldType.number,
+        config: {},
+        values: new ArrayVector([2]),
+      },
+      replaceVariables: (val) => val,
+      containsTemplate: () => true,
+    });
+
+    expect(link).toEqual(
+      expect.objectContaining({
+        title: 'dsName',
+        href: `/explore?left=${encodeURIComponent(
+          `{"range":${serializedRange},"datasource":"uid","queries":[{"query":"12344"}],"panelsState":{}}`
+        )}`,
+        onClick: undefined,
+        containsTemplate: true,
       })
     );
   });

--- a/packages/grafana-runtime/src/services/templateSrv.ts
+++ b/packages/grafana-runtime/src/services/templateSrv.ts
@@ -20,8 +20,9 @@ export interface TemplateSrv {
 
   /**
    * Checks if a target contains template variables.
+   * If scopedVars are not provided the function will verify if target contains a variables defined in global state
    */
-  containsTemplate(target?: string): boolean;
+  containsTemplate(target?: string, scopedVars?: ScopedVars): boolean;
 
   /**
    * Update the current time range to be used when interpolating __from / __to variables.

--- a/packages/jaeger-ui-components/src/TraceTimelineViewer/SpanDetail/index.tsx
+++ b/packages/jaeger-ui-components/src/TraceTimelineViewer/SpanDetail/index.tsx
@@ -291,7 +291,9 @@ export default function SpanDetail(props: SpanDetailProps) {
         {topOfViewRefType === TopOfViewRefType.Explore && (
           <small className={styles.debugInfo}>
             <a
-              {...focusSpanLink}
+              title={focusSpanLink.title}
+              href={focusSpanLink.href}
+              target={focusSpanLink.target}
               onClick={(e) => {
                 // click handling logic copied from react router:
                 // https://github.com/remix-run/react-router/blob/997b4d67e506d39ac6571cb369d6d2d6b3dda557/packages/react-router-dom/index.tsx#L392-L394s

--- a/public/app/features/explore/utils/links.test.ts
+++ b/public/app/features/explore/utils/links.test.ts
@@ -16,6 +16,8 @@ import { setLinkSrv } from '../../panel/panellinks/link_srv';
 import { getFieldLinksForExplore } from './links';
 
 describe('getFieldLinksForExplore', () => {
+  const containsTemplateMock = jest.fn();
+
   beforeEach(() => {
     setTemplateSrv({
       replace(target, scopedVars, format) {
@@ -25,10 +27,11 @@ describe('getFieldLinksForExplore', () => {
         return [];
       },
       containsTemplate() {
-        return false;
+        return containsTemplateMock();
       },
       updateTimeRange(timeRange: TimeRange) {},
     });
+    containsTemplateMock.mockReturnValue(false);
   });
 
   it('returns correct link model for external link', () => {
@@ -121,6 +124,21 @@ describe('getFieldLinksForExplore', () => {
       },
       false
     );
+    const links = getFieldLinksForExplore({ field, rowIndex: 0, range });
+    expect(links).toHaveLength(0);
+  });
+
+  it('returns no internal links when target contains template variables after interpolation', () => {
+    containsTemplateMock.mockReturnValue(true);
+    const { field, range } = setup({
+      title: '',
+      url: '',
+      internal: {
+        query: { query: 'query_1' },
+        datasourceUid: 'uid_1',
+        datasourceName: 'test_ds',
+      },
+    });
     const links = getFieldLinksForExplore({ field, rowIndex: 0, range });
     expect(links).toHaveLength(0);
   });

--- a/public/app/features/explore/utils/links.ts
+++ b/public/app/features/explore/utils/links.ts
@@ -64,28 +64,33 @@ export const getFieldLinksForExplore = (options: {
       links.push(...field.config.links);
     }
 
-    return links.map((link) => {
-      if (!link.internal) {
-        const replace: InterpolateFunction = (value, vars) =>
-          getTemplateSrv().replace(value, { ...vars, ...scopedVars });
+    return links
+      .map((link) => {
+        if (!link.internal) {
+          const replace: InterpolateFunction = (value, vars) =>
+            getTemplateSrv().replace(value, { ...vars, ...scopedVars });
 
-        const linkModel = getLinkSrv().getDataLinkUIModel(link, replace, field);
-        if (!linkModel.title) {
-          linkModel.title = getTitleFromHref(linkModel.href);
+          const linkModel = getLinkSrv().getDataLinkUIModel(link, replace, field);
+          if (!linkModel.title) {
+            linkModel.title = getTitleFromHref(linkModel.href);
+          }
+          return linkModel;
+        } else {
+          return mapInternalLinkToExplore({
+            link,
+            internalLink: link.internal,
+            scopedVars: scopedVars,
+            range,
+            field,
+            onClickFn: splitOpenFn,
+            replaceVariables: getTemplateSrv().replace.bind(getTemplateSrv()),
+            containsTemplate: (target) => {
+              return getTemplateSrv().containsTemplate(target, scopedVars);
+            },
+          });
         }
-        return linkModel;
-      } else {
-        return mapInternalLinkToExplore({
-          link,
-          internalLink: link.internal,
-          scopedVars: scopedVars,
-          range,
-          field,
-          onClickFn: splitOpenFn,
-          replaceVariables: getTemplateSrv().replace.bind(getTemplateSrv()),
-        });
-      }
-    });
+      })
+      .filter((link) => link.containsTemplate !== true);
   }
 
   return [];

--- a/public/app/features/explore/utils/links.ts
+++ b/public/app/features/explore/utils/links.ts
@@ -49,6 +49,7 @@ export const getFieldLinksForExplore = (options: {
         fields: getFieldDisplayValuesProxy({
           frame: dataFrame,
           rowIndex,
+          skipEmptyValuesFormatting: true,
         }),
       },
       text: 'Data',

--- a/public/app/features/templating/template_srv.test.ts
+++ b/public/app/features/templating/template_srv.test.ts
@@ -427,44 +427,53 @@ describe('templateSrv', () => {
     });
   });
 
-  describe('can check if variable exists', () => {
-    beforeEach(() => {
-      _templateSrv = initTemplateSrv(key, [{ type: 'query', name: 'test', current: { value: 'oogle' } }]);
-    });
+  [
+    {
+      type: 'global',
+      globalVars: [{ type: 'query', name: 'test', current: { value: 'oogle' } }],
+      scopedVars: undefined,
+    },
+    { type: 'scoped', globalVars: [], scopedVars: { test: 'oogle' } },
+  ].forEach((testCase) => {
+    describe(`can check if ${testCase.type} variable exists`, () => {
+      beforeEach(() => {
+        _templateSrv = initTemplateSrv(key, testCase.globalVars);
+      });
 
-    it('should return true if $test exists', () => {
-      const result = _templateSrv.containsTemplate('$test');
-      expect(result).toBe(true);
-    });
+      it('should return true if $test exists', () => {
+        const result = _templateSrv.containsTemplate('$test', testCase.scopedVars);
+        expect(result).toBe(true);
+      });
 
-    it('should return true if $test exists in string', () => {
-      const result = _templateSrv.containsTemplate('something $test something');
-      expect(result).toBe(true);
-    });
+      it('should return true if $test exists in string', () => {
+        const result = _templateSrv.containsTemplate('something $test something', testCase.scopedVars);
+        expect(result).toBe(true);
+      });
 
-    it('should return true if [[test]] exists in string', () => {
-      const result = _templateSrv.containsTemplate('something [[test]] something');
-      expect(result).toBe(true);
-    });
+      it('should return true if [[test]] exists in string', () => {
+        const result = _templateSrv.containsTemplate('something [[test]] something', testCase.scopedVars);
+        expect(result).toBe(true);
+      });
 
-    it('should return true if [[test:csv]] exists in string', () => {
-      const result = _templateSrv.containsTemplate('something [[test:csv]] something');
-      expect(result).toBe(true);
-    });
+      it('should return true if [[test:csv]] exists in string', () => {
+        const result = _templateSrv.containsTemplate('something [[test:csv]] something', testCase.scopedVars);
+        expect(result).toBe(true);
+      });
 
-    it('should return true if ${test} exists in string', () => {
-      const result = _templateSrv.containsTemplate('something ${test} something');
-      expect(result).toBe(true);
-    });
+      it('should return true if ${test} exists in string', () => {
+        const result = _templateSrv.containsTemplate('something ${test} something', testCase.scopedVars);
+        expect(result).toBe(true);
+      });
 
-    it('should return true if ${test:raw} exists in string', () => {
-      const result = _templateSrv.containsTemplate('something ${test:raw} something');
-      expect(result).toBe(true);
-    });
+      it('should return true if ${test:raw} exists in string', () => {
+        const result = _templateSrv.containsTemplate('something ${test:raw} something', testCase.scopedVars);
+        expect(result).toBe(true);
+      });
 
-    it('should return null if there are no variables in string', () => {
-      const result = _templateSrv.containsTemplate('string without variables');
-      expect(result).toBe(false);
+      it('should return null if there are no variables in string', () => {
+        const result = _templateSrv.containsTemplate('string without variables', testCase.scopedVars);
+        expect(result).toBe(false);
+      });
     });
   });
 

--- a/public/app/features/templating/template_srv.ts
+++ b/public/app/features/templating/template_srv.ts
@@ -199,12 +199,12 @@ export class TemplateSrv implements BaseTemplateSrv {
     return variableName;
   }
 
-  containsTemplate(target: string | undefined): boolean {
+  containsTemplate(target: string | undefined, scopedVars?: ScopedVars): boolean {
     if (!target) {
       return false;
     }
     const name = this.getVariableName(target);
-    const variable = name && this.getVariableAtIndex(name);
+    const variable = name && (scopedVars ? scopedVars[name] : this.getVariableAtIndex(name));
     return variable !== null && variable !== undefined;
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The problem is described in https://github.com/grafana/grafana/issues/58574.

**Which issue(s) this PR fixes**:

Fixes #58574

**Special notes for your reviewer**:

* field proxy was adjusted to return `undefined` if the value is not provided (previously worked only if the field was missing)
* `skipUndefined` added to field proxy, because it looks like API was designed to return undefined only for non-existing fields (e.g. fieldOverrides uses the proxy to create valueVars assuming it always exists.
* `containsTemplate` allows to pass scopedVariables (for cases outside of the main variable system)[^1]
* `getFieldLinksForExplore` will now return only fully interpolated internal links

<details><summary>How to test it</summary>

Ensure the feature toggle for correlations is on in custom.ini:

```ini
[feature_toggles]
correlations = true
```

1. Install and run mock data source

2. Create a new correlation from Mock to any data source using variables for `app` and `endpoint` fields, and attach it to `app` field e.g.:  Prometheus `{app="${__data.fields.app}", endpoint="${__data.fields.endpoint}"}`:
<img width="1215" alt="Screenshot 2022-11-17 at 13 47 31" src="https://user-images.githubusercontent.com/745532/202450898-95046a2f-d9b3-4e1e-bae2-c8747c5ba2e7.png">

3. Run mock data source using raw data frame and paste [the following data frame](https://gist.githubusercontent.com/ifrost/8c1d5df13681aa8bce1216bd7cfa0fb8/raw/796183ef58e5517e2e7147cab64c5766d4f4a97c/logs.json)

4. Run the query

5. Expected result: the link to the correlations should show up only in the log line with both fields provided:
<img width="1529" alt="Screenshot 2022-11-17 at 13 34 48" src="https://user-images.githubusercontent.com/745532/202451464-34a4fcdf-0613-40a7-afb3-8703d2486b75.png">

6. Expected result: clicking on the link should open target data source with interpolated values

</details>

[^1]: alternatively, to support our use case, we could create a separate instance of TemplateService inside `getFieldLinksForExplore` and initialize it with scoped variables. 