### PR TITLE
Chore: Extract server lock error so it can be used with errors.As

### DIFF
--- a/pkg/infra/serverlock/errors.go
+++ b/pkg/infra/serverlock/errors.go
@@ -1,0 +1,9 @@
+package serverlock
+
+type ServerLockExistsError struct {
+	actionName string
+}
+
+func (e *ServerLockExistsError) Error() string {
+	return "there is already a lock for this actionName: " + e.actionName
+}

--- a/pkg/infra/serverlock/serverlock.go
+++ b/pkg/infra/serverlock/serverlock.go
@@ -2,7 +2,6 @@ package serverlock
 
 import (
 	"context"
-	"errors"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -185,7 +184,7 @@ func (sl *ServerLockService) acquireForRelease(ctx context.Context, actionName s
 		if len(lockRows) > 0 {
 			result := lockRows[0]
 			if sl.isLockWithinInterval(result, maxInterval) {
-				return errors.New("there is already a lock for this actionName: " + actionName)
+				return &ServerLockExistsError{actionName: actionName}
 			} else {
 				// lock has timeouted, so we update the timestamp
 				result.LastExecution = time.Now().Unix()


### PR DESCRIPTION
Extract server lock error so it can be used with errors.As

Used in https://github.com/grafana/grafana-enterprise/pull/4129