### PR TITLE
AppRootPage: Fix passing the queryParams

### DIFF
--- a/public/app/features/plugins/components/AppRootPage.tsx
+++ b/public/app/features/plugins/components/AppRootPage.tsx
@@ -5,7 +5,7 @@ import { createHtmlPortalNode, InPortal, OutPortal } from 'react-reverse-portal'
 import { useLocation, useRouteMatch } from 'react-router-dom';
 
 import { AppEvents, AppPlugin, AppPluginMeta, NavModel, NavModelItem, PluginType } from '@grafana/data';
-import { config } from '@grafana/runtime';
+import { config, locationSearchToObject } from '@grafana/runtime';
 import { getNotFoundNav, getWarningNav, getExceptionNav } from 'app/angular/services/nav_model_srv';
 import { Page } from 'app/core/components/Page/Page';
 import PageLoader from 'app/core/components/PageLoader/PageLoader';
@@ -41,7 +41,7 @@ export function AppRootPage({ pluginId, pluginNavSection }: Props) {
   const currentUrl = config.appSubUrl + location.pathname + location.search;
   const { plugin, loading, pluginNav } = state;
   const navModel = buildPluginSectionNav(pluginNavSection, pluginNav, currentUrl);
-  const queryParams = useMemo(() => convertLocationSearchToObject(location.search), [location.search]);
+  const queryParams = useMemo(() => locationSearchToObject(location.search), [location.search]);
   const context = useMemo(() => buildPluginPageContext(navModel), [navModel]);
 
   useEffect(() => {
@@ -155,16 +155,6 @@ export function getAppPluginPageError(meta: AppPluginMeta) {
     return 'Application Not Enabled';
   }
   return null;
-}
-
-function convertLocationSearchToObject(locationSearch: string) {
-  const result: Record<string, string> = {};
-
-  for (const [key, value] of new URLSearchParams(locationSearch).entries()) {
-    result[key] = value;
-  }
-
-  return result;
 }
 
 export default AppRootPage;

--- a/public/app/features/plugins/components/AppRootPage.tsx
+++ b/public/app/features/plugins/components/AppRootPage.tsx
@@ -48,9 +48,10 @@ export function AppRootPage({ pluginId, pluginNavSection }: Props) {
     loadAppPlugin(pluginId, dispatch);
   }, [pluginId]);
 
-  const onNavChanged = useCallback((newPluginNav: NavModel) => {
-    dispatch(stateSlice.actions.changeNav(newPluginNav));
-  }, []);
+  const onNavChanged = useCallback(
+    (newPluginNav: NavModel) => dispatch(stateSlice.actions.changeNav(newPluginNav)),
+    []
+  );
 
   if (!plugin || pluginId !== plugin.meta.id) {
     return <Page navModel={navModel}>{loading && <PageLoader />}</Page>;


### PR DESCRIPTION
### What is the problem?

While [updating the routing for app plugins](https://github.com/grafana/grafana/pull/57771/files#diff-1cf7e00838f17a49eba2776a92eab85653b4894158fad3e4ba4f3245bc14af8eR38) I have introduced a bug: accidentally passing down the route params instead of the key-value pairs of query parameters. This caused plugins relying on the `queryParams` prop not work. ([Example issue](https://github.com/grafana/gex-plugins/issues/844))

### What changed?

- Pushing the correct query parameters down
- Only re-create the query params object if the `location.search` changes