### PR TITLE
Navigation: Fix crash when Help is disabled

### DIFF
--- a/pkg/services/navtree/models.go
+++ b/pkg/services/navtree/models.go
@@ -151,6 +151,10 @@ func (root *NavTreeRoot) RemoveEmptySectionsAndApplyNewInformationArchitecture(t
 			node.Url = node.Children[0].Url
 		}
 	}
+
+	if len(root.Children) < 1 {
+		root.Children = make([]*NavLink, 0)
+	}
 }
 
 func (root *NavTreeRoot) Sort() {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

App is crashing during unauthenticated state and help feature toggle is set to false. This is because NavTree is set to null during this scenario.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #58809 

**Special notes for your reviewer**:
- As discussed internally, we should set NavTree to an empty array instead of null.

