### PR TITLE
Auth: Refactor auth package

### DIFF
--- a/pkg/api/admin_users.go
+++ b/pkg/api/admin_users.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/metrics"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/auth"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/util"
 	"github.com/grafana/grafana/pkg/web"
@@ -416,7 +417,7 @@ func (hs *HTTPServer) AdminGetUserAuthTokens(c *models.ReqContext) response.Resp
 // 404: notFoundError
 // 500: internalServerError
 func (hs *HTTPServer) AdminRevokeUserAuthToken(c *models.ReqContext) response.Response {
-	cmd := models.RevokeAuthTokenCmd{}
+	cmd := auth.RevokeAuthTokenCmd{}
 	if err := web.Bind(c.Req, &cmd); err != nil {
 		return response.Error(http.StatusBadRequest, "bad request data", err)
 	}
@@ -476,7 +477,7 @@ type AdminLogoutUserParams struct {
 type AdminRevokeUserAuthTokenParams struct {
 	// in:body
 	// required:true
-	Body models.RevokeAuthTokenCmd `json:"body"`
+	Body auth.RevokeAuthTokenCmd `json:"body"`
 	// in:path
 	// required:true
 	UserID int64 `json:"user_id"`
@@ -508,5 +509,5 @@ type AdminCreateUserResponseResponse struct {
 // swagger:response adminGetUserAuthTokensResponse
 type AdminGetUserAuthTokensResponse struct {
 	// in:body
-	Body []*models.UserToken `json:"body"`
+	Body []*auth.UserToken `json:"body"`
 }

--- a/pkg/api/admin_users_test.go
+++ b/pkg/api/admin_users_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/auth"
 	"github.com/grafana/grafana/pkg/services/auth/authtest"
 	"github.com/grafana/grafana/pkg/services/login/loginservice"
 	"github.com/grafana/grafana/pkg/services/login/logintest"
@@ -65,7 +66,7 @@ func TestAdminAPIEndpoint(t *testing.T) {
 	})
 
 	t.Run("When a server admin attempts to revoke an auth token for a non-existing user", func(t *testing.T) {
-		cmd := models.RevokeAuthTokenCmd{AuthTokenId: 2}
+		cmd := auth.RevokeAuthTokenCmd{AuthTokenId: 2}
 		mockUser := usertest.NewUserServiceFake()
 		mockUser.ExpectedError = user.ErrUserNotFound
 		adminRevokeUserAuthTokenScenario(t, "Should return not found when calling POST on",
@@ -285,7 +286,7 @@ func adminLogoutUserScenario(t *testing.T, desc string, url string, routePattern
 	})
 }
 
-func adminRevokeUserAuthTokenScenario(t *testing.T, desc string, url string, routePattern string, cmd models.RevokeAuthTokenCmd, fn scenarioFunc, userService user.Service) {
+func adminRevokeUserAuthTokenScenario(t *testing.T, desc string, url string, routePattern string, cmd auth.RevokeAuthTokenCmd, fn scenarioFunc, userService user.Service) {
 	t.Run(fmt.Sprintf("%s %s", desc, url), func(t *testing.T) {
 		fakeAuthTokenService := authtest.NewFakeUserAuthTokenService()
 

--- a/pkg/api/admin_users_test.go
+++ b/pkg/api/admin_users_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/models"
-	"github.com/grafana/grafana/pkg/services/auth"
+	"github.com/grafana/grafana/pkg/services/auth/authtest"
 	"github.com/grafana/grafana/pkg/services/login/loginservice"
 	"github.com/grafana/grafana/pkg/services/login/logintest"
 	"github.com/grafana/grafana/pkg/services/org"
@@ -263,7 +263,7 @@ func putAdminScenario(t *testing.T, desc string, url string, routePattern string
 func adminLogoutUserScenario(t *testing.T, desc string, url string, routePattern string, fn scenarioFunc, userService *usertest.FakeUserService) {
 	t.Run(fmt.Sprintf("%s %s", desc, url), func(t *testing.T) {
 		hs := HTTPServer{
-			AuthTokenService: auth.NewFakeUserAuthTokenService(),
+			AuthTokenService: authtest.NewFakeUserAuthTokenService(),
 			userService:      userService,
 		}
 
@@ -287,7 +287,7 @@ func adminLogoutUserScenario(t *testing.T, desc string, url string, routePattern
 
 func adminRevokeUserAuthTokenScenario(t *testing.T, desc string, url string, routePattern string, cmd models.RevokeAuthTokenCmd, fn scenarioFunc, userService user.Service) {
 	t.Run(fmt.Sprintf("%s %s", desc, url), func(t *testing.T) {
-		fakeAuthTokenService := auth.NewFakeUserAuthTokenService()
+		fakeAuthTokenService := authtest.NewFakeUserAuthTokenService()
 
 		hs := HTTPServer{
 			AuthTokenService: fakeAuthTokenService,
@@ -315,7 +315,7 @@ func adminRevokeUserAuthTokenScenario(t *testing.T, desc string, url string, rou
 
 func adminGetUserAuthTokensScenario(t *testing.T, desc string, url string, routePattern string, fn scenarioFunc, userService *usertest.FakeUserService) {
 	t.Run(fmt.Sprintf("%s %s", desc, url), func(t *testing.T) {
-		fakeAuthTokenService := auth.NewFakeUserAuthTokenService()
+		fakeAuthTokenService := authtest.NewFakeUserAuthTokenService()
 
 		hs := HTTPServer{
 			AuthTokenService: fakeAuthTokenService,
@@ -341,7 +341,7 @@ func adminGetUserAuthTokensScenario(t *testing.T, desc string, url string, route
 
 func adminDisableUserScenario(t *testing.T, desc string, action string, url string, routePattern string, fn scenarioFunc) {
 	t.Run(fmt.Sprintf("%s %s", desc, url), func(t *testing.T) {
-		fakeAuthTokenService := auth.NewFakeUserAuthTokenService()
+		fakeAuthTokenService := authtest.NewFakeUserAuthTokenService()
 
 		authInfoService := &logintest.AuthInfoServiceFake{}
 

--- a/pkg/api/common_test.go
+++ b/pkg/api/common_test.go
@@ -28,7 +28,7 @@ import (
 	accesscontrolmock "github.com/grafana/grafana/pkg/services/accesscontrol/mock"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/ossaccesscontrol"
 	"github.com/grafana/grafana/pkg/services/annotations/annotationstest"
-	"github.com/grafana/grafana/pkg/services/auth"
+	"github.com/grafana/grafana/pkg/services/auth/authtest"
 	"github.com/grafana/grafana/pkg/services/contexthandler"
 	"github.com/grafana/grafana/pkg/services/contexthandler/authproxy"
 	"github.com/grafana/grafana/pkg/services/contexthandler/ctxkey"
@@ -181,7 +181,7 @@ type scenarioContext struct {
 	defaultHandler          web.Handler
 	req                     *http.Request
 	url                     string
-	userAuthTokenService    *auth.FakeUserAuthTokenService
+	userAuthTokenService    *authtest.FakeUserAuthTokenService
 	sqlStore                sqlstore.Store
 	authInfoService         *logintest.AuthInfoServiceFake
 	dashboardVersionService dashver.Service
@@ -207,7 +207,7 @@ func getContextHandler(t *testing.T, cfg *setting.Cfg) *contexthandler.ContextHa
 	cfg.RemoteCacheOptions = &setting.RemoteCacheOptions{
 		Name: "database",
 	}
-	userAuthTokenSvc := auth.NewFakeUserAuthTokenService()
+	userAuthTokenSvc := authtest.NewFakeUserAuthTokenService()
 	renderSvc := &fakeRenderService{}
 	authJWTSvc := models.NewFakeJWTService()
 	tracer := tracing.InitializeTracerForTest()

--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/middleware/csrf"
+	"github.com/grafana/grafana/pkg/services/auth"
 	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/oauthtoken"
 	"github.com/grafana/grafana/pkg/services/querylibrary"
@@ -120,7 +121,7 @@ type HTTPServer struct {
 	navTreeService               navtree.Service
 	CacheService                 *localcache.CacheService
 	DataSourceCache              datasources.CacheService
-	AuthTokenService             models.UserTokenService
+	AuthTokenService             auth.UserTokenService
 	QuotaService                 quota.Service
 	RemoteCacheService           *remotecache.RemoteCache
 	ProvisioningService          provisioning.ProvisioningService
@@ -220,7 +221,7 @@ func ProvideHTTPServer(opts ServerOptions, cfg *setting.Cfg, routeRegister routi
 	pluginRequestValidator models.PluginRequestValidator, pluginStaticRouteResolver plugins.StaticRouteResolver,
 	pluginDashboardService plugindashboards.Service, pluginStore plugins.Store, pluginClient plugins.Client,
 	pluginErrorResolver plugins.ErrorResolver, pluginInstaller plugins.Installer, settingsProvider setting.Provider,
-	dataSourceCache datasources.CacheService, userTokenService models.UserTokenService,
+	dataSourceCache datasources.CacheService, userTokenService auth.UserTokenService,
 	cleanUpService *cleanup.CleanUpService, shortURLService shorturls.Service, queryHistoryService queryhistory.Service, correlationsService correlations.Service,
 	thumbService thumbs.Service, remoteCache *remotecache.RemoteCache, provisioningService provisioning.ProvisioningService,
 	loginService login.Service, authenticator loginpkg.Authenticator, accessControl accesscontrol.AccessControl,

--- a/pkg/api/ldap_debug_test.go
+++ b/pkg/api/ldap_debug_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
-	"github.com/grafana/grafana/pkg/services/auth"
+	"github.com/grafana/grafana/pkg/services/auth/authtest"
 	"github.com/grafana/grafana/pkg/services/ldap"
 	"github.com/grafana/grafana/pkg/services/login/loginservice"
 	"github.com/grafana/grafana/pkg/services/login/logintest"
@@ -379,7 +379,7 @@ func postSyncUserWithLDAPContext(t *testing.T, requestURL string, preHook func(*
 
 	hs := &HTTPServer{
 		Cfg:              sc.cfg,
-		AuthTokenService: auth.NewFakeUserAuthTokenService(),
+		AuthTokenService: authtest.NewFakeUserAuthTokenService(),
 		Login:            loginservice.LoginServiceMock{},
 		authInfoService:  sc.authInfoService,
 		userService:      userService,

--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grafana/grafana/pkg/login"
 	"github.com/grafana/grafana/pkg/middleware/cookies"
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/auth"
 	loginService "github.com/grafana/grafana/pkg/services/login"
 	"github.com/grafana/grafana/pkg/services/secrets"
 	"github.com/grafana/grafana/pkg/services/user"
@@ -227,7 +228,7 @@ func (hs *HTTPServer) LoginPost(c *models.ReqContext) response.Response {
 
 	err = hs.loginUserWithUser(usr, c)
 	if err != nil {
-		var createTokenErr *models.CreateTokenErr
+		var createTokenErr *auth.CreateTokenErr
 		if errors.As(err, &createTokenErr) {
 			resp = response.Error(createTokenErr.StatusCode, createTokenErr.ExternalErr, createTokenErr.InternalErr)
 		} else {
@@ -299,7 +300,7 @@ func (hs *HTTPServer) Logout(c *models.ReqContext) {
 	}
 
 	err := hs.AuthTokenService.RevokeToken(c.Req.Context(), c.UserToken, false)
-	if err != nil && !errors.Is(err, models.ErrUserTokenNotFound) {
+	if err != nil && !errors.Is(err, auth.ErrUserTokenNotFound) {
 		hs.log.Error("failed to revoke auth token", "error", err)
 	}
 
@@ -370,7 +371,7 @@ func (hs *HTTPServer) samlSingleLogoutEnabled() bool {
 }
 
 func getLoginExternalError(err error) string {
-	var createTokenErr *models.CreateTokenErr
+	var createTokenErr *auth.CreateTokenErr
 	if errors.As(err, &createTokenErr) {
 		return createTokenErr.ExternalErr
 	}

--- a/pkg/api/login_test.go
+++ b/pkg/api/login_test.go
@@ -12,8 +12,6 @@ import (
 	"strings"
 	"testing"
 
-	loginservice "github.com/grafana/grafana/pkg/services/login"
-	"github.com/grafana/grafana/pkg/services/navtree"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -25,9 +23,11 @@ import (
 	"github.com/grafana/grafana/pkg/login"
 	"github.com/grafana/grafana/pkg/login/social"
 	"github.com/grafana/grafana/pkg/models"
-	"github.com/grafana/grafana/pkg/services/auth"
+	"github.com/grafana/grafana/pkg/services/auth/authtest"
 	"github.com/grafana/grafana/pkg/services/hooks"
 	"github.com/grafana/grafana/pkg/services/licensing"
+	loginservice "github.com/grafana/grafana/pkg/services/login"
+	"github.com/grafana/grafana/pkg/services/navtree"
 	"github.com/grafana/grafana/pkg/services/secrets"
 	"github.com/grafana/grafana/pkg/services/secrets/fakes"
 	secretsManager "github.com/grafana/grafana/pkg/services/secrets/manager"
@@ -323,7 +323,7 @@ func TestLoginPostRedirect(t *testing.T) {
 		Cfg:              setting.NewCfg(),
 		HooksService:     &hooks.HooksService{},
 		License:          &licensing.OSSLicensingService{},
-		AuthTokenService: auth.NewFakeUserAuthTokenService(),
+		AuthTokenService: authtest.NewFakeUserAuthTokenService(),
 	}
 	hs.Cfg.CookieSecure = true
 
@@ -564,7 +564,7 @@ func setupAuthProxyLoginTest(t *testing.T, enableLoginToken bool) *scenarioConte
 		Cfg:              sc.cfg,
 		SettingsProvider: &setting.OSSImpl{Cfg: sc.cfg},
 		License:          &licensing.OSSLicensingService{},
-		AuthTokenService: auth.NewFakeUserAuthTokenService(),
+		AuthTokenService: authtest.NewFakeUserAuthTokenService(),
 		log:              log.New("hello"),
 		SocialService:    &mockSocialService{},
 	}
@@ -602,7 +602,7 @@ func TestLoginPostRunLokingHook(t *testing.T) {
 		log:              log.New("test"),
 		Cfg:              setting.NewCfg(),
 		License:          &licensing.OSSLicensingService{},
-		AuthTokenService: auth.NewFakeUserAuthTokenService(),
+		AuthTokenService: authtest.NewFakeUserAuthTokenService(),
 		HooksService:     hookService,
 	}
 

--- a/pkg/api/user_token_test.go
+++ b/pkg/api/user_token_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/models"
-	"github.com/grafana/grafana/pkg/services/auth"
+	"github.com/grafana/grafana/pkg/services/auth/authtest"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/services/user/usertest"
@@ -148,7 +148,7 @@ func TestUserTokenAPIEndpoint(t *testing.T) {
 func revokeUserAuthTokenScenario(t *testing.T, desc string, url string, routePattern string, cmd models.RevokeAuthTokenCmd,
 	userId int64, fn scenarioFunc, userService user.Service) {
 	t.Run(fmt.Sprintf("%s %s", desc, url), func(t *testing.T) {
-		fakeAuthTokenService := auth.NewFakeUserAuthTokenService()
+		fakeAuthTokenService := authtest.NewFakeUserAuthTokenService()
 
 		hs := HTTPServer{
 			AuthTokenService: fakeAuthTokenService,
@@ -175,7 +175,7 @@ func revokeUserAuthTokenScenario(t *testing.T, desc string, url string, routePat
 
 func getUserAuthTokensScenario(t *testing.T, desc string, url string, routePattern string, userId int64, fn scenarioFunc, userService user.Service) {
 	t.Run(fmt.Sprintf("%s %s", desc, url), func(t *testing.T) {
-		fakeAuthTokenService := auth.NewFakeUserAuthTokenService()
+		fakeAuthTokenService := authtest.NewFakeUserAuthTokenService()
 
 		hs := HTTPServer{
 			AuthTokenService: fakeAuthTokenService,
@@ -202,7 +202,7 @@ func getUserAuthTokensScenario(t *testing.T, desc string, url string, routePatte
 func logoutUserFromAllDevicesInternalScenario(t *testing.T, desc string, userId int64, fn scenarioFunc, userService user.Service) {
 	t.Run(desc, func(t *testing.T) {
 		hs := HTTPServer{
-			AuthTokenService: auth.NewFakeUserAuthTokenService(),
+			AuthTokenService: authtest.NewFakeUserAuthTokenService(),
 			userService:      userService,
 		}
 
@@ -225,7 +225,7 @@ func logoutUserFromAllDevicesInternalScenario(t *testing.T, desc string, userId 
 func revokeUserAuthTokenInternalScenario(t *testing.T, desc string, cmd models.RevokeAuthTokenCmd, userId int64,
 	token *models.UserToken, fn scenarioFunc, userService user.Service) {
 	t.Run(desc, func(t *testing.T) {
-		fakeAuthTokenService := auth.NewFakeUserAuthTokenService()
+		fakeAuthTokenService := authtest.NewFakeUserAuthTokenService()
 
 		hs := HTTPServer{
 			AuthTokenService: fakeAuthTokenService,
@@ -250,7 +250,7 @@ func revokeUserAuthTokenInternalScenario(t *testing.T, desc string, cmd models.R
 
 func getUserAuthTokensInternalScenario(t *testing.T, desc string, token *models.UserToken, fn scenarioFunc, userService user.Service) {
 	t.Run(desc, func(t *testing.T) {
-		fakeAuthTokenService := auth.NewFakeUserAuthTokenService()
+		fakeAuthTokenService := authtest.NewFakeUserAuthTokenService()
 
 		hs := HTTPServer{
 			AuthTokenService: fakeAuthTokenService,

--- a/pkg/cmd/grafana-cli/runner/wire.go
+++ b/pkg/cmd/grafana-cli/runner/wire.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	"github.com/google/wire"
+	"github.com/grafana/grafana/pkg/services/auth/authimpl"
 	"github.com/grafana/grafana/pkg/tsdb/parca"
 	"github.com/grafana/grafana/pkg/tsdb/phlare"
 
@@ -253,8 +254,8 @@ var wireSet = wire.NewSet(
 	influxdb.ProvideService,
 	wire.Bind(new(social.Service), new(*social.SocialService)),
 	oauthtoken.ProvideService,
-	auth.ProvideActiveAuthTokenService,
-	wire.Bind(new(auth.ActiveTokenService), new(*auth.ActiveAuthTokenService)),
+	authimpl.ProvideActiveAuthTokenService,
+	wire.Bind(new(auth.ActiveTokenService), new(*authimpl.ActiveAuthTokenService)),
 	wire.Bind(new(oauthtoken.OAuthTokenService), new(*oauthtoken.Service)),
 	tempo.ProvideService,
 	loki.ProvideService,

--- a/pkg/cmd/grafana-cli/runner/wireexts_oss.go
+++ b/pkg/cmd/grafana-cli/runner/wireexts_oss.go
@@ -16,7 +16,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/ossaccesscontrol"
-	"github.com/grafana/grafana/pkg/services/auth"
+	"github.com/grafana/grafana/pkg/services/auth/authimpl"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/datasources/permissions"
 	datasourceservice "github.com/grafana/grafana/pkg/services/datasources/service"
@@ -48,9 +48,9 @@ var wireExtsSet = wire.NewSet(
 	wire.Bind(new(setting.Provider), new(*setting.OSSImpl)),
 	osskmsproviders.ProvideService,
 	wire.Bind(new(kmsproviders.Service), new(osskmsproviders.Service)),
-	auth.ProvideUserAuthTokenService,
-	wire.Bind(new(models.UserTokenService), new(*auth.UserAuthTokenService)),
-	wire.Bind(new(models.UserTokenBackgroundService), new(*auth.UserAuthTokenService)),
+	authimpl.ProvideUserAuthTokenService,
+	wire.Bind(new(models.UserTokenService), new(*authimpl.UserAuthTokenService)),
+	wire.Bind(new(models.UserTokenBackgroundService), new(*authimpl.UserAuthTokenService)),
 	acimpl.ProvideService,
 	wire.Bind(new(accesscontrol.Service), new(*acimpl.Service)),
 	wire.Bind(new(accesscontrol.RoleRegistry), new(*acimpl.Service)),

--- a/pkg/cmd/grafana-cli/runner/wireexts_oss.go
+++ b/pkg/cmd/grafana-cli/runner/wireexts_oss.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/ossaccesscontrol"
+	"github.com/grafana/grafana/pkg/services/auth"
 	"github.com/grafana/grafana/pkg/services/auth/authimpl"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/datasources/permissions"
@@ -49,8 +50,8 @@ var wireExtsSet = wire.NewSet(
 	osskmsproviders.ProvideService,
 	wire.Bind(new(kmsproviders.Service), new(osskmsproviders.Service)),
 	authimpl.ProvideUserAuthTokenService,
-	wire.Bind(new(models.UserTokenService), new(*authimpl.UserAuthTokenService)),
-	wire.Bind(new(models.UserTokenBackgroundService), new(*authimpl.UserAuthTokenService)),
+	wire.Bind(new(auth.UserTokenService), new(*authimpl.UserAuthTokenService)),
+	wire.Bind(new(auth.UserTokenBackgroundService), new(*authimpl.UserAuthTokenService)),
 	acimpl.ProvideService,
 	wire.Bind(new(accesscontrol.Service), new(*acimpl.Service)),
 	wire.Bind(new(accesscontrol.RoleRegistry), new(*acimpl.Service)),

--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -10,6 +10,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/middleware/cookies"
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/auth"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/team"
@@ -42,7 +43,7 @@ func notAuthorized(c *models.ReqContext) {
 	c.Redirect(setting.AppSubUrl + "/login")
 }
 
-func tokenRevoked(c *models.ReqContext, err *models.TokenRevokedError) {
+func tokenRevoked(c *models.ReqContext, err *auth.TokenRevokedError) {
 	if c.IsApiRequest() {
 		c.JSON(401, map[string]interface{}{
 			"message": "Token revoked",
@@ -117,7 +118,7 @@ func Auth(options *AuthOptions) web.Handler {
 		requireLogin := !c.AllowAnonymous || forceLogin || options.ReqNoAnonynmous
 
 		if !c.IsSignedIn && options.ReqSignedIn && requireLogin {
-			var revokedErr *models.TokenRevokedError
+			var revokedErr *auth.TokenRevokedError
 			if errors.As(c.LookupTokenErr, &revokedErr) {
 				tokenRevoked(c, revokedErr)
 				return

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/apikey"
 	"github.com/grafana/grafana/pkg/services/apikey/apikeytest"
-	"github.com/grafana/grafana/pkg/services/auth"
+	"github.com/grafana/grafana/pkg/services/auth/authtest"
 	"github.com/grafana/grafana/pkg/services/contexthandler"
 	"github.com/grafana/grafana/pkg/services/contexthandler/authproxy"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -819,14 +819,14 @@ func middlewareScenario(t *testing.T, desc string, fn scenarioFunc, cbs ...func(
 		sc.userService = usertest.NewUserServiceFake()
 		sc.orgService = orgtest.NewOrgServiceFake()
 		sc.apiKeyService = &apikeytest.Service{}
-		sc.oauthTokenService = &auth.FakeOAuthTokenService{}
+		sc.oauthTokenService = &authtest.FakeOAuthTokenService{}
 		ctxHdlr := getContextHandler(t, cfg, sc.mockSQLStore, sc.loginService, sc.apiKeyService, sc.userService, sc.orgService, sc.oauthTokenService)
 		sc.sqlStore = ctxHdlr.SQLStore
 		sc.contextHandler = ctxHdlr
 		sc.m.Use(ctxHdlr.Middleware)
 		sc.m.Use(OrgRedirect(sc.cfg, sc.userService))
 
-		sc.userAuthTokenService = ctxHdlr.AuthTokenService.(*auth.FakeUserAuthTokenService)
+		sc.userAuthTokenService = ctxHdlr.AuthTokenService.(*authtest.FakeUserAuthTokenService)
 		sc.jwtAuthService = ctxHdlr.JWTAuthService.(*models.FakeJWTService)
 		sc.remoteCacheService = ctxHdlr.RemoteCache
 
@@ -856,7 +856,7 @@ func middlewareScenario(t *testing.T, desc string, fn scenarioFunc, cbs ...func(
 func getContextHandler(t *testing.T, cfg *setting.Cfg, mockSQLStore *dbtest.FakeDB,
 	loginService *loginservice.LoginServiceMock, apiKeyService *apikeytest.Service,
 	userService *usertest.FakeUserService, orgService *orgtest.FakeOrgService,
-	oauthTokenService *auth.FakeOAuthTokenService,
+	oauthTokenService *authtest.FakeOAuthTokenService,
 ) *contexthandler.ContextHandler {
 	t.Helper()
 
@@ -868,7 +868,7 @@ func getContextHandler(t *testing.T, cfg *setting.Cfg, mockSQLStore *dbtest.Fake
 	}
 
 	remoteCacheSvc := remotecache.NewFakeStore(t)
-	userAuthTokenSvc := auth.NewFakeUserAuthTokenService()
+	userAuthTokenSvc := authtest.NewFakeUserAuthTokenService()
 	renderSvc := &fakeRenderService{}
 	authJWTSvc := models.NewFakeJWTService()
 	tracer := tracing.InitializeTracerForTest()

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/apikey"
 	"github.com/grafana/grafana/pkg/services/apikey/apikeytest"
+	"github.com/grafana/grafana/pkg/services/auth"
 	"github.com/grafana/grafana/pkg/services/auth/authtest"
 	"github.com/grafana/grafana/pkg/services/contexthandler"
 	"github.com/grafana/grafana/pkg/services/contexthandler/authproxy"
@@ -264,8 +265,8 @@ func TestMiddlewareContext(t *testing.T) {
 		sc.withTokenSessionCookie("token")
 		sc.userService.ExpectedSignedInUser = &user.SignedInUser{OrgID: 2, UserID: userID}
 
-		sc.userAuthTokenService.LookupTokenProvider = func(ctx context.Context, unhashedToken string) (*models.UserToken, error) {
-			return &models.UserToken{
+		sc.userAuthTokenService.LookupTokenProvider = func(ctx context.Context, unhashedToken string) (*auth.UserToken, error) {
+			return &auth.UserToken{
 				UserId:        userID,
 				UnhashedToken: unhashedToken,
 			}, nil
@@ -288,14 +289,14 @@ func TestMiddlewareContext(t *testing.T) {
 		sc.withTokenSessionCookie("token")
 		sc.userService.ExpectedSignedInUser = &user.SignedInUser{OrgID: 2, UserID: userID}
 
-		sc.userAuthTokenService.LookupTokenProvider = func(ctx context.Context, unhashedToken string) (*models.UserToken, error) {
-			return &models.UserToken{
+		sc.userAuthTokenService.LookupTokenProvider = func(ctx context.Context, unhashedToken string) (*auth.UserToken, error) {
+			return &auth.UserToken{
 				UserId:        userID,
 				UnhashedToken: "",
 			}, nil
 		}
 
-		sc.userAuthTokenService.TryRotateTokenProvider = func(ctx context.Context, userToken *models.UserToken,
+		sc.userAuthTokenService.TryRotateTokenProvider = func(ctx context.Context, userToken *auth.UserToken,
 			clientIP net.IP, userAgent string) (bool, error) {
 			userToken.UnhashedToken = "rotated"
 			return true, nil
@@ -371,8 +372,8 @@ func TestMiddlewareContext(t *testing.T) {
 	middlewareScenario(t, "Invalid/expired auth token in cookie", func(t *testing.T, sc *scenarioContext) {
 		sc.withTokenSessionCookie("token")
 
-		sc.userAuthTokenService.LookupTokenProvider = func(ctx context.Context, unhashedToken string) (*models.UserToken, error) {
-			return nil, models.ErrUserTokenNotFound
+		sc.userAuthTokenService.LookupTokenProvider = func(ctx context.Context, unhashedToken string) (*auth.UserToken, error) {
+			return nil, auth.ErrUserTokenNotFound
 		}
 
 		sc.fakeReq("GET", "/").exec()
@@ -391,8 +392,8 @@ func TestMiddlewareContext(t *testing.T) {
 		sc.userService.ExpectedSignedInUser = &user.SignedInUser{OrgID: 2, UserID: userID}
 		sc.oauthTokenService.ExpectedAuthUser = &models.UserAuth{UserId: userID, OAuthExpiry: fakeGetTime()().Add(11 * time.Second)}
 
-		sc.userAuthTokenService.LookupTokenProvider = func(ctx context.Context, unhashedToken string) (*models.UserToken, error) {
-			return &models.UserToken{
+		sc.userAuthTokenService.LookupTokenProvider = func(ctx context.Context, unhashedToken string) (*auth.UserToken, error) {
+			return &auth.UserToken{
 				UserId:        userID,
 				UnhashedToken: unhashedToken,
 			}, nil
@@ -424,8 +425,8 @@ func TestMiddlewareContext(t *testing.T) {
 			OAuthRefreshToken: "refresh_token"}
 		sc.oauthTokenService.ExpectedErrors = map[string]error{"TryTokenRefresh": errors.New("error")}
 
-		sc.userAuthTokenService.LookupTokenProvider = func(ctx context.Context, unhashedToken string) (*models.UserToken, error) {
-			return &models.UserToken{
+		sc.userAuthTokenService.LookupTokenProvider = func(ctx context.Context, unhashedToken string) (*auth.UserToken, error) {
+			return &auth.UserToken{
 				UserId:        userID,
 				UnhashedToken: unhashedToken,
 			}, nil
@@ -454,8 +455,8 @@ func TestMiddlewareContext(t *testing.T) {
 		sc.userService.ExpectedSignedInUser = &user.SignedInUser{OrgID: 2, UserID: userID}
 		sc.oauthTokenService.ExpectedAuthUser = &models.UserAuth{UserId: userID, OAuthExpiry: fakeGetTime()().Add(-5 * time.Second), OAuthRefreshToken: "refreshtoken"}
 
-		sc.userAuthTokenService.LookupTokenProvider = func(ctx context.Context, unhashedToken string) (*models.UserToken, error) {
-			return &models.UserToken{
+		sc.userAuthTokenService.LookupTokenProvider = func(ctx context.Context, unhashedToken string) (*auth.UserToken, error) {
+			return &auth.UserToken{
 				UserId:        userID,
 				UnhashedToken: unhashedToken,
 			}, nil
@@ -481,8 +482,8 @@ func TestMiddlewareContext(t *testing.T) {
 		sc.userService.ExpectedSignedInUser = &user.SignedInUser{OrgID: 2, UserID: userID}
 		sc.oauthTokenService.ExpectedAuthUser = &models.UserAuth{UserId: userID}
 
-		sc.userAuthTokenService.LookupTokenProvider = func(ctx context.Context, unhashedToken string) (*models.UserToken, error) {
-			return &models.UserToken{
+		sc.userAuthTokenService.LookupTokenProvider = func(ctx context.Context, unhashedToken string) (*auth.UserToken, error) {
+			return &auth.UserToken{
 				UserId:        userID,
 				UnhashedToken: unhashedToken,
 			}, nil

--- a/pkg/middleware/org_redirect_test.go
+++ b/pkg/middleware/org_redirect_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/auth"
 	"github.com/grafana/grafana/pkg/services/user"
 )
 
@@ -48,8 +48,8 @@ func TestOrgRedirectMiddleware(t *testing.T) {
 		middlewareScenario(t, tc.desc, func(t *testing.T, sc *scenarioContext) {
 			sc.withTokenSessionCookie("token")
 			sc.userService.ExpectedSignedInUser = &user.SignedInUser{OrgID: 1, UserID: 12}
-			sc.userAuthTokenService.LookupTokenProvider = func(ctx context.Context, unhashedToken string) (*models.UserToken, error) {
-				return &models.UserToken{
+			sc.userAuthTokenService.LookupTokenProvider = func(ctx context.Context, unhashedToken string) (*auth.UserToken, error) {
+				return &auth.UserToken{
 					UserId:        0,
 					UnhashedToken: "",
 				}, nil
@@ -68,8 +68,8 @@ func TestOrgRedirectMiddleware(t *testing.T) {
 		sc.userService.ExpectedSetUsingOrgError = fmt.Errorf("")
 		sc.userService.ExpectedSignedInUser = &user.SignedInUser{OrgID: 1, UserID: 12}
 
-		sc.userAuthTokenService.LookupTokenProvider = func(ctx context.Context, unhashedToken string) (*models.UserToken, error) {
-			return &models.UserToken{
+		sc.userAuthTokenService.LookupTokenProvider = func(ctx context.Context, unhashedToken string) (*auth.UserToken, error) {
+			return &auth.UserToken{
 				UserId:        12,
 				UnhashedToken: "",
 			}, nil

--- a/pkg/middleware/quota_test.go
+++ b/pkg/middleware/quota_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/auth"
 	"github.com/grafana/grafana/pkg/services/quota/quotatest"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
@@ -55,8 +55,8 @@ func TestMiddlewareQuota(t *testing.T) {
 		setUp := func(sc *scenarioContext) {
 			sc.withTokenSessionCookie("token")
 			sc.userService.ExpectedSignedInUser = &user.SignedInUser{UserID: 12}
-			sc.userAuthTokenService.LookupTokenProvider = func(ctx context.Context, unhashedToken string) (*models.UserToken, error) {
-				return &models.UserToken{
+			sc.userAuthTokenService.LookupTokenProvider = func(ctx context.Context, unhashedToken string) (*auth.UserToken, error) {
+				return &auth.UserToken{
 					UserId:        12,
 					UnhashedToken: "",
 				}, nil

--- a/pkg/middleware/recovery_test.go
+++ b/pkg/middleware/recovery_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/infra/remotecache"
 	"github.com/grafana/grafana/pkg/models"
-	"github.com/grafana/grafana/pkg/services/auth"
+	"github.com/grafana/grafana/pkg/services/auth/authtest"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/web"
 )
@@ -65,7 +65,7 @@ func recoveryScenario(t *testing.T, desc string, url string, fn scenarioFunc) {
 		sc.m.Use(AddDefaultResponseHeaders(cfg))
 		sc.m.UseMiddleware(web.Renderer(viewsPath, "[[", "]]"))
 
-		sc.userAuthTokenService = auth.NewFakeUserAuthTokenService()
+		sc.userAuthTokenService = authtest.NewFakeUserAuthTokenService()
 		sc.remoteCacheService = remotecache.NewFakeStore(t)
 
 		contextHandler := getContextHandler(t, nil, nil, nil, nil, nil, nil, nil)

--- a/pkg/middleware/testing.go
+++ b/pkg/middleware/testing.go
@@ -13,7 +13,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/remotecache"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/apikey/apikeytest"
-	"github.com/grafana/grafana/pkg/services/auth"
+	"github.com/grafana/grafana/pkg/services/auth/authtest"
 	"github.com/grafana/grafana/pkg/services/contexthandler"
 	"github.com/grafana/grafana/pkg/services/contexthandler/ctxkey"
 	"github.com/grafana/grafana/pkg/services/login/loginservice"
@@ -36,7 +36,7 @@ type scenarioContext struct {
 	handlerFunc          handlerFunc
 	defaultHandler       web.Handler
 	url                  string
-	userAuthTokenService *auth.FakeUserAuthTokenService
+	userAuthTokenService *authtest.FakeUserAuthTokenService
 	jwtAuthService       *models.FakeJWTService
 	remoteCacheService   *remotecache.RemoteCache
 	cfg                  *setting.Cfg
@@ -46,7 +46,7 @@ type scenarioContext struct {
 	loginService         *loginservice.LoginServiceMock
 	apiKeyService        *apikeytest.Service
 	userService          *usertest.FakeUserService
-	oauthTokenService    *auth.FakeOAuthTokenService
+	oauthTokenService    *authtest.FakeOAuthTokenService
 	orgService           *orgtest.FakeOrgService
 
 	req *http.Request

--- a/pkg/models/context.go
+++ b/pkg/models/context.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
+	"github.com/grafana/grafana/pkg/services/auth"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
@@ -15,7 +16,7 @@ import (
 type ReqContext struct {
 	*web.Context
 	*user.SignedInUser
-	UserToken *UserToken
+	UserToken *auth.UserToken
 
 	IsSignedIn     bool
 	IsRenderCall   bool

--- a/pkg/models/context.go
+++ b/pkg/models/context.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
-	"github.com/grafana/grafana/pkg/services/auth"
+	"github.com/grafana/grafana/pkg/models/usertoken"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
@@ -16,7 +16,7 @@ import (
 type ReqContext struct {
 	*web.Context
 	*user.SignedInUser
-	UserToken *auth.UserToken
+	UserToken *usertoken.UserToken
 
 	IsSignedIn     bool
 	IsRenderCall   bool

--- a/pkg/models/user_token.go
+++ b/pkg/models/user_token.go
@@ -1,9 +1,0 @@
-package models
-
-type TokenRevokedError struct {
-	UserID                int64
-	TokenID               int64
-	MaxConcurrentSessions int64
-}
-
-func (e *TokenRevokedError) Error() string { return "user token revoked" }

--- a/pkg/models/user_token.go
+++ b/pkg/models/user_token.go
@@ -1,40 +1,5 @@
 package models
 
-import (
-	"context"
-	"errors"
-	"net"
-
-	"github.com/grafana/grafana/pkg/registry"
-	"github.com/grafana/grafana/pkg/services/user"
-)
-
-// Typed errors
-var (
-	ErrUserTokenNotFound = errors.New("user token not found")
-)
-
-// CreateTokenErr represents a token creation error; used in Enterprise
-type CreateTokenErr struct {
-	StatusCode  int
-	InternalErr error
-	ExternalErr string
-}
-
-func (e *CreateTokenErr) Error() string {
-	if e.InternalErr != nil {
-		return e.InternalErr.Error()
-	}
-	return "failed to create token"
-}
-
-type TokenExpiredError struct {
-	UserID  int64
-	TokenID int64
-}
-
-func (e *TokenExpiredError) Error() string { return "user token expired" }
-
 type TokenRevokedError struct {
 	UserID                int64
 	TokenID               int64
@@ -42,40 +7,3 @@ type TokenRevokedError struct {
 }
 
 func (e *TokenRevokedError) Error() string { return "user token revoked" }
-
-// UserToken represents a user token
-type UserToken struct {
-	Id            int64
-	UserId        int64
-	AuthToken     string
-	PrevAuthToken string
-	UserAgent     string
-	ClientIp      string
-	AuthTokenSeen bool
-	SeenAt        int64
-	RotatedAt     int64
-	CreatedAt     int64
-	UpdatedAt     int64
-	RevokedAt     int64
-	UnhashedToken string
-}
-
-type RevokeAuthTokenCmd struct {
-	AuthTokenId int64 `json:"authTokenId"`
-}
-
-// UserTokenService are used for generating and validating user tokens
-type UserTokenService interface {
-	CreateToken(ctx context.Context, user *user.User, clientIP net.IP, userAgent string) (*UserToken, error)
-	LookupToken(ctx context.Context, unhashedToken string) (*UserToken, error)
-	TryRotateToken(ctx context.Context, token *UserToken, clientIP net.IP, userAgent string) (bool, error)
-	RevokeToken(ctx context.Context, token *UserToken, soft bool) error
-	RevokeAllUserTokens(ctx context.Context, userId int64) error
-	GetUserToken(ctx context.Context, userId, userTokenId int64) (*UserToken, error)
-	GetUserTokens(ctx context.Context, userId int64) ([]*UserToken, error)
-	GetUserRevokedTokens(ctx context.Context, userId int64) ([]*UserToken, error)
-}
-
-type UserTokenBackgroundService interface {
-	registry.BackgroundService
-}

--- a/pkg/models/usertoken/user_token.go
+++ b/pkg/models/usertoken/user_token.go
@@ -1,0 +1,26 @@
+package usertoken
+
+type TokenRevokedError struct {
+	UserID                int64
+	TokenID               int64
+	MaxConcurrentSessions int64
+}
+
+func (e *TokenRevokedError) Error() string { return "user token revoked" }
+
+// UserToken represents a user token
+type UserToken struct {
+	Id            int64
+	UserId        int64
+	AuthToken     string
+	PrevAuthToken string
+	UserAgent     string
+	ClientIp      string
+	AuthTokenSeen bool
+	SeenAt        int64
+	RotatedAt     int64
+	CreatedAt     int64
+	UpdatedAt     int64
+	RevokedAt     int64
+	UnhashedToken string
+}

--- a/pkg/server/backgroundsvcs/background_services.go
+++ b/pkg/server/backgroundsvcs/background_services.go
@@ -7,10 +7,10 @@ import (
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	uss "github.com/grafana/grafana/pkg/infra/usagestats/service"
 	"github.com/grafana/grafana/pkg/infra/usagestats/statscollector"
-	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/plugins/manager/process"
 	"github.com/grafana/grafana/pkg/registry"
 	"github.com/grafana/grafana/pkg/services/alerting"
+	"github.com/grafana/grafana/pkg/services/auth"
 	"github.com/grafana/grafana/pkg/services/cleanup"
 	"github.com/grafana/grafana/pkg/services/dashboardsnapshots"
 	"github.com/grafana/grafana/pkg/services/grpcserver"
@@ -38,7 +38,7 @@ import (
 func ProvideBackgroundServiceRegistry(
 	httpServer *api.HTTPServer, ng *ngalert.AlertNG, cleanup *cleanup.CleanUpService, live *live.GrafanaLive,
 	pushGateway *pushhttp.Gateway, notifications *notifications.NotificationService, processManager *process.Manager,
-	rendering *rendering.RenderingService, tokenService models.UserTokenBackgroundService, tracing tracing.Tracer,
+	rendering *rendering.RenderingService, tokenService auth.UserTokenBackgroundService, tracing tracing.Tracer,
 	provisioning *provisioning.ProvisioningServiceImpl, alerting *alerting.AlertEngine, usageStats *uss.UsageStats,
 	statsCollector *statscollector.Service, grafanaUpdateChecker *updatechecker.GrafanaService,
 	pluginsUpdateChecker *updatechecker.PluginsService, metrics *metrics.InternalMetricsService,

--- a/pkg/server/wire.go
+++ b/pkg/server/wire.go
@@ -49,6 +49,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/annotations/annotationsimpl"
 	"github.com/grafana/grafana/pkg/services/apikey/apikeyimpl"
 	"github.com/grafana/grafana/pkg/services/auth"
+	"github.com/grafana/grafana/pkg/services/auth/authimpl"
 	"github.com/grafana/grafana/pkg/services/auth/jwt"
 	"github.com/grafana/grafana/pkg/services/cleanup"
 	"github.com/grafana/grafana/pkg/services/comments"
@@ -271,8 +272,8 @@ var wireBasicSet = wire.NewSet(
 	influxdb.ProvideService,
 	wire.Bind(new(social.Service), new(*social.SocialService)),
 	oauthtoken.ProvideService,
-	auth.ProvideActiveAuthTokenService,
-	wire.Bind(new(auth.ActiveTokenService), new(*auth.ActiveAuthTokenService)),
+	authimpl.ProvideActiveAuthTokenService,
+	wire.Bind(new(auth.ActiveTokenService), new(*authimpl.ActiveAuthTokenService)),
 	wire.Bind(new(oauthtoken.OAuthTokenService), new(*oauthtoken.Service)),
 	tempo.ProvideService,
 	loki.ProvideService,

--- a/pkg/server/wireexts_oss.go
+++ b/pkg/server/wireexts_oss.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/ossaccesscontrol"
+	"github.com/grafana/grafana/pkg/services/auth"
 	"github.com/grafana/grafana/pkg/services/auth/authimpl"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/datasources/permissions"
@@ -40,8 +41,8 @@ import (
 
 var wireExtsBasicSet = wire.NewSet(
 	authimpl.ProvideUserAuthTokenService,
-	wire.Bind(new(models.UserTokenService), new(*authimpl.UserAuthTokenService)),
-	wire.Bind(new(models.UserTokenBackgroundService), new(*authimpl.UserAuthTokenService)),
+	wire.Bind(new(auth.UserTokenService), new(*authimpl.UserAuthTokenService)),
+	wire.Bind(new(auth.UserTokenBackgroundService), new(*authimpl.UserAuthTokenService)),
 	licensing.ProvideService,
 	wire.Bind(new(models.Licensing), new(*licensing.OSSLicensingService)),
 	setting.ProvideProvider,

--- a/pkg/server/wireexts_oss.go
+++ b/pkg/server/wireexts_oss.go
@@ -16,7 +16,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/ossaccesscontrol"
-	"github.com/grafana/grafana/pkg/services/auth"
+	"github.com/grafana/grafana/pkg/services/auth/authimpl"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/datasources/permissions"
 	datasourceservice "github.com/grafana/grafana/pkg/services/datasources/service"
@@ -39,9 +39,9 @@ import (
 )
 
 var wireExtsBasicSet = wire.NewSet(
-	auth.ProvideUserAuthTokenService,
-	wire.Bind(new(models.UserTokenService), new(*auth.UserAuthTokenService)),
-	wire.Bind(new(models.UserTokenBackgroundService), new(*auth.UserAuthTokenService)),
+	authimpl.ProvideUserAuthTokenService,
+	wire.Bind(new(models.UserTokenService), new(*authimpl.UserAuthTokenService)),
+	wire.Bind(new(models.UserTokenBackgroundService), new(*authimpl.UserAuthTokenService)),
 	licensing.ProvideService,
 	wire.Bind(new(models.Licensing), new(*licensing.OSSLicensingService)),
 	setting.ProvideProvider,

--- a/pkg/services/accesscontrol/middleware.go
+++ b/pkg/services/accesscontrol/middleware.go
@@ -14,8 +14,8 @@ import (
 	"time"
 
 	"github.com/grafana/grafana/pkg/middleware/cookies"
-
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/models/usertoken"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
@@ -41,7 +41,7 @@ func Middleware(ac AccessControl) func(web.Handler, Evaluator) web.Handler {
 				}
 			}
 
-			var revokedErr *models.TokenRevokedError
+			var revokedErr *usertoken.TokenRevokedError
 			if errors.As(c.LookupTokenErr, &revokedErr) {
 				unauthorized(c, revokedErr)
 				return
@@ -111,7 +111,7 @@ func unauthorized(c *models.ReqContext, err error) {
 			"message": "Unauthorized",
 		}
 
-		var revokedErr *models.TokenRevokedError
+		var revokedErr *usertoken.TokenRevokedError
 		if errors.As(err, &revokedErr) {
 			response["message"] = "Token revoked"
 			response["error"] = map[string]interface{}{

--- a/pkg/services/auth/auth.go
+++ b/pkg/services/auth/auth.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net"
 
+	"github.com/grafana/grafana/pkg/models/usertoken"
 	"github.com/grafana/grafana/pkg/registry"
 	"github.com/grafana/grafana/pkg/services/quota"
 	"github.com/grafana/grafana/pkg/services/user"
@@ -23,6 +24,8 @@ type ActiveTokenService interface {
 var (
 	ErrUserTokenNotFound = errors.New("user token not found")
 )
+
+type TokenRevokedError = usertoken.TokenRevokedError
 
 // CreateTokenErr represents a token creation error; used in Enterprise
 type CreateTokenErr struct {
@@ -45,22 +48,7 @@ type TokenExpiredError struct {
 
 func (e *TokenExpiredError) Error() string { return "user token expired" }
 
-// UserToken represents a user token
-type UserToken struct {
-	Id            int64
-	UserId        int64
-	AuthToken     string
-	PrevAuthToken string
-	UserAgent     string
-	ClientIp      string
-	AuthTokenSeen bool
-	SeenAt        int64
-	RotatedAt     int64
-	CreatedAt     int64
-	UpdatedAt     int64
-	RevokedAt     int64
-	UnhashedToken string
-}
+type UserToken = usertoken.UserToken
 
 type RevokeAuthTokenCmd struct {
 	AuthTokenId int64 `json:"authTokenId"`

--- a/pkg/services/auth/auth.go
+++ b/pkg/services/auth/auth.go
@@ -6,6 +6,11 @@ import (
 	"github.com/grafana/grafana/pkg/services/quota"
 )
 
+const (
+	QuotaTargetSrv quota.TargetSrv = "auth"
+	QuotaTarget    quota.Target    = "session"
+)
+
 type ActiveTokenService interface {
 	ActiveTokenCount(ctx context.Context, _ *quota.ScopeParameters) (*quota.Map, error)
 }

--- a/pkg/services/auth/auth.go
+++ b/pkg/services/auth/auth.go
@@ -1,0 +1,11 @@
+package auth
+
+import (
+	"context"
+
+	"github.com/grafana/grafana/pkg/services/quota"
+)
+
+type ActiveTokenService interface {
+	ActiveTokenCount(ctx context.Context, _ *quota.ScopeParameters) (*quota.Map, error)
+}

--- a/pkg/services/auth/auth.go
+++ b/pkg/services/auth/auth.go
@@ -2,8 +2,12 @@ package auth
 
 import (
 	"context"
+	"errors"
+	"net"
 
+	"github.com/grafana/grafana/pkg/registry"
 	"github.com/grafana/grafana/pkg/services/quota"
+	"github.com/grafana/grafana/pkg/services/user"
 )
 
 const (
@@ -13,4 +17,67 @@ const (
 
 type ActiveTokenService interface {
 	ActiveTokenCount(ctx context.Context, _ *quota.ScopeParameters) (*quota.Map, error)
+}
+
+// Typed errors
+var (
+	ErrUserTokenNotFound = errors.New("user token not found")
+)
+
+// CreateTokenErr represents a token creation error; used in Enterprise
+type CreateTokenErr struct {
+	StatusCode  int
+	InternalErr error
+	ExternalErr string
+}
+
+func (e *CreateTokenErr) Error() string {
+	if e.InternalErr != nil {
+		return e.InternalErr.Error()
+	}
+	return "failed to create token"
+}
+
+type TokenExpiredError struct {
+	UserID  int64
+	TokenID int64
+}
+
+func (e *TokenExpiredError) Error() string { return "user token expired" }
+
+// UserToken represents a user token
+type UserToken struct {
+	Id            int64
+	UserId        int64
+	AuthToken     string
+	PrevAuthToken string
+	UserAgent     string
+	ClientIp      string
+	AuthTokenSeen bool
+	SeenAt        int64
+	RotatedAt     int64
+	CreatedAt     int64
+	UpdatedAt     int64
+	RevokedAt     int64
+	UnhashedToken string
+}
+
+type RevokeAuthTokenCmd struct {
+	AuthTokenId int64 `json:"authTokenId"`
+}
+
+// UserTokenService are used for generating and validating user tokens
+type UserTokenService interface {
+	CreateToken(ctx context.Context, user *user.User, clientIP net.IP, userAgent string) (*UserToken, error)
+	LookupToken(ctx context.Context, unhashedToken string) (*UserToken, error)
+	TryRotateToken(ctx context.Context, token *UserToken, clientIP net.IP, userAgent string) (bool, error)
+	RevokeToken(ctx context.Context, token *UserToken, soft bool) error
+	RevokeAllUserTokens(ctx context.Context, userId int64) error
+	GetUserToken(ctx context.Context, userId, userTokenId int64) (*UserToken, error)
+	GetUserTokens(ctx context.Context, userId int64) ([]*UserToken, error)
+	GetUserRevokedTokens(ctx context.Context, userId int64) ([]*UserToken, error)
+}
+
+type UserTokenBackgroundService interface {
+	registry.BackgroundService
 }

--- a/pkg/services/auth/auth_token.go
+++ b/pkg/services/auth/auth_token.go
@@ -42,10 +42,6 @@ type UserAuthTokenService struct {
 	log               log.Logger
 }
 
-type ActiveTokenService interface {
-	ActiveTokenCount(ctx context.Context, _ *quota.ScopeParameters) (*quota.Map, error)
-}
-
 type ActiveAuthTokenService struct {
 	cfg      *setting.Cfg
 	sqlStore db.DB

--- a/pkg/services/auth/authimpl/auth_token.go
+++ b/pkg/services/auth/authimpl/auth_token.go
@@ -1,4 +1,4 @@
-package auth
+package authimpl
 
 import (
 	"context"
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/serverlock"
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/auth"
 	"github.com/grafana/grafana/pkg/services/quota"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
@@ -59,7 +60,7 @@ func ProvideActiveAuthTokenService(cfg *setting.Cfg, sqlStore db.DB, quotaServic
 	}
 
 	if err := quotaService.RegisterQuotaReporter(&quota.NewUsageReporter{
-		TargetSrv:     QuotaTargetSrv,
+		TargetSrv:     auth.QuotaTargetSrv,
 		DefaultLimits: defaultLimits,
 		Reporter:      s.ActiveTokenCount,
 	}); err != nil {
@@ -82,7 +83,7 @@ func (a *ActiveAuthTokenService) ActiveTokenCount(ctx context.Context, _ *quota.
 		return err
 	})
 
-	tag, err := quota.NewTag(QuotaTargetSrv, QuotaTarget, quota.GlobalScope)
+	tag, err := quota.NewTag(auth.QuotaTargetSrv, auth.QuotaTarget, quota.GlobalScope)
 	if err != nil {
 		return nil, err
 	}
@@ -503,7 +504,7 @@ func readQuotaConfig(cfg *setting.Cfg) (*quota.Map, error) {
 		return limits, nil
 	}
 
-	globalQuotaTag, err := quota.NewTag(QuotaTargetSrv, QuotaTarget, quota.GlobalScope)
+	globalQuotaTag, err := quota.NewTag(auth.QuotaTargetSrv, auth.QuotaTarget, quota.GlobalScope)
 	if err != nil {
 		return limits, err
 	}

--- a/pkg/services/auth/authimpl/auth_token.go
+++ b/pkg/services/auth/authimpl/auth_token.go
@@ -11,7 +11,6 @@ import (
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/serverlock"
-	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/auth"
 	"github.com/grafana/grafana/pkg/services/quota"
 	"github.com/grafana/grafana/pkg/services/user"
@@ -166,7 +165,7 @@ func (s *UserAuthTokenService) LookupToken(ctx context.Context, unhashedToken st
 
 	if model.RevokedAt > 0 {
 		ctxLogger.Debug("user token has been revoked", "user ID", model.UserId, "token ID", model.Id)
-		return nil, &models.TokenRevokedError{
+		return nil, &auth.TokenRevokedError{
 			UserID:  model.UserId,
 			TokenID: model.Id,
 		}

--- a/pkg/services/auth/authimpl/auth_token_test.go
+++ b/pkg/services/auth/authimpl/auth_token_test.go
@@ -1,4 +1,4 @@
-package auth
+package authimpl
 
 import (
 	"context"
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/grafana/pkg/services/auth"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
@@ -43,7 +44,7 @@ func TestUserAuthToken(t *testing.T) {
 		t.Run("Can count active tokens", func(t *testing.T) {
 			m, err := ctx.activeTokenService.ActiveTokenCount(context.Background(), &quota.ScopeParameters{})
 			require.Nil(t, err)
-			tag, err := quota.NewTag(QuotaTargetSrv, QuotaTarget, quota.GlobalScope)
+			tag, err := quota.NewTag(auth.QuotaTargetSrv, auth.QuotaTarget, quota.GlobalScope)
 			require.NoError(t, err)
 			count, ok := m.Get(tag)
 			require.True(t, ok)
@@ -215,7 +216,7 @@ func TestUserAuthToken(t *testing.T) {
 			t.Run("should not find active token when expired", func(t *testing.T) {
 				m, err := ctx.activeTokenService.ActiveTokenCount(context.Background(), &quota.ScopeParameters{})
 				require.Nil(t, err)
-				tag, err := quota.NewTag(QuotaTargetSrv, QuotaTarget, quota.GlobalScope)
+				tag, err := quota.NewTag(auth.QuotaTargetSrv, auth.QuotaTarget, quota.GlobalScope)
 				require.NoError(t, err)
 				count, ok := m.Get(tag)
 				require.True(t, ok)

--- a/pkg/services/auth/authimpl/auth_token_test.go
+++ b/pkg/services/auth/authimpl/auth_token_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/quota"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
@@ -30,7 +29,7 @@ func TestUserAuthToken(t *testing.T) {
 	defer func() { getTime = time.Now }()
 
 	t.Run("When creating token", func(t *testing.T) {
-		createToken := func() *models.UserToken {
+		createToken := func() *auth.UserToken {
 			userToken, err := ctx.tokenService.CreateToken(context.Background(), user,
 				net.ParseIP("192.168.10.11"), "some user agent")
 			require.Nil(t, err)
@@ -66,7 +65,7 @@ func TestUserAuthToken(t *testing.T) {
 
 		t.Run("When lookup hashed token should return user auth token not found error", func(t *testing.T) {
 			userToken, err := ctx.tokenService.LookupToken(context.Background(), userToken.AuthToken)
-			require.Equal(t, models.ErrUserTokenNotFound, err)
+			require.Equal(t, auth.ErrUserTokenNotFound, err)
 			require.Nil(t, userToken)
 		})
 
@@ -91,13 +90,13 @@ func TestUserAuthToken(t *testing.T) {
 
 		t.Run("revoking nil token should return error", func(t *testing.T) {
 			err := ctx.tokenService.RevokeToken(context.Background(), nil, false)
-			require.Equal(t, models.ErrUserTokenNotFound, err)
+			require.Equal(t, auth.ErrUserTokenNotFound, err)
 		})
 
 		t.Run("revoking non-existing token should return error", func(t *testing.T) {
 			userToken.Id = 1000
 			err := ctx.tokenService.RevokeToken(context.Background(), userToken, false)
-			require.Equal(t, models.ErrUserTokenNotFound, err)
+			require.Equal(t, auth.ErrUserTokenNotFound, err)
 		})
 
 		ctx = createTestContext(t)
@@ -210,7 +209,7 @@ func TestUserAuthToken(t *testing.T) {
 			}
 
 			notGood, err := ctx.tokenService.LookupToken(context.Background(), userToken.UnhashedToken)
-			require.Equal(t, reflect.TypeOf(err), reflect.TypeOf(&models.TokenExpiredError{}))
+			require.Equal(t, reflect.TypeOf(err), reflect.TypeOf(&auth.TokenExpiredError{}))
 			require.Nil(t, notGood)
 
 			t.Run("should not find active token when expired", func(t *testing.T) {
@@ -248,7 +247,7 @@ func TestUserAuthToken(t *testing.T) {
 			}
 
 			notGood, err := ctx.tokenService.LookupToken(context.Background(), userToken.UnhashedToken)
-			require.Equal(t, reflect.TypeOf(err), reflect.TypeOf(&models.TokenExpiredError{}))
+			require.Equal(t, reflect.TypeOf(err), reflect.TypeOf(&auth.TokenExpiredError{}))
 			require.Nil(t, notGood)
 		})
 	})
@@ -275,7 +274,7 @@ func TestUserAuthToken(t *testing.T) {
 		model, err := ctx.getAuthTokenByID(userToken.Id)
 		require.Nil(t, err)
 
-		var tok models.UserToken
+		var tok auth.UserToken
 		err = model.toUserToken(&tok)
 		require.Nil(t, err)
 
@@ -472,7 +471,7 @@ func TestUserAuthToken(t *testing.T) {
 	})
 
 	t.Run("When populating userAuthToken from UserToken should copy all properties", func(t *testing.T) {
-		ut := models.UserToken{
+		ut := auth.UserToken{
 			Id:            1,
 			UserId:        2,
 			AuthToken:     "a",
@@ -525,7 +524,7 @@ func TestUserAuthToken(t *testing.T) {
 		require.Nil(t, err)
 		uatMap := uatJSON.MustMap()
 
-		var ut models.UserToken
+		var ut auth.UserToken
 		err = uat.toUserToken(&ut)
 		require.Nil(t, err)
 		utBytes, err := json.Marshal(ut)

--- a/pkg/services/auth/authimpl/model.go
+++ b/pkg/services/auth/authimpl/model.go
@@ -3,7 +3,7 @@ package authimpl
 import (
 	"fmt"
 
-	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/auth"
 )
 
 type userAuthToken struct {
@@ -22,13 +22,13 @@ type userAuthToken struct {
 	UnhashedToken string `xorm:"-"`
 }
 
-func userAuthTokenFromUserToken(ut *models.UserToken) (*userAuthToken, error) {
+func userAuthTokenFromUserToken(ut *auth.UserToken) (*userAuthToken, error) {
 	var uat userAuthToken
 	err := uat.fromUserToken(ut)
 	return &uat, err
 }
 
-func (uat *userAuthToken) fromUserToken(ut *models.UserToken) error {
+func (uat *userAuthToken) fromUserToken(ut *auth.UserToken) error {
 	if uat == nil {
 		return fmt.Errorf("needs pointer to userAuthToken struct")
 	}
@@ -50,7 +50,7 @@ func (uat *userAuthToken) fromUserToken(ut *models.UserToken) error {
 	return nil
 }
 
-func (uat *userAuthToken) toUserToken(ut *models.UserToken) error {
+func (uat *userAuthToken) toUserToken(ut *auth.UserToken) error {
 	if uat == nil {
 		return fmt.Errorf("needs pointer to userAuthToken struct")
 	}

--- a/pkg/services/auth/authimpl/model.go
+++ b/pkg/services/auth/authimpl/model.go
@@ -1,4 +1,4 @@
-package auth
+package authimpl
 
 import (
 	"fmt"

--- a/pkg/services/auth/authimpl/token_cleanup.go
+++ b/pkg/services/auth/authimpl/token_cleanup.go
@@ -1,4 +1,4 @@
-package auth
+package authimpl
 
 import (
 	"context"

--- a/pkg/services/auth/authimpl/token_cleanup_test.go
+++ b/pkg/services/auth/authimpl/token_cleanup_test.go
@@ -1,4 +1,4 @@
-package auth
+package authimpl
 
 import (
 	"context"

--- a/pkg/services/auth/authtest/testing.go
+++ b/pkg/services/auth/authtest/testing.go
@@ -6,42 +6,43 @@ import (
 	"time"
 
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/auth"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/user"
 	"golang.org/x/oauth2"
 )
 
 type FakeUserAuthTokenService struct {
-	CreateTokenProvider          func(ctx context.Context, user *user.User, clientIP net.IP, userAgent string) (*models.UserToken, error)
-	TryRotateTokenProvider       func(ctx context.Context, token *models.UserToken, clientIP net.IP, userAgent string) (bool, error)
-	LookupTokenProvider          func(ctx context.Context, unhashedToken string) (*models.UserToken, error)
-	RevokeTokenProvider          func(ctx context.Context, token *models.UserToken, soft bool) error
+	CreateTokenProvider          func(ctx context.Context, user *user.User, clientIP net.IP, userAgent string) (*auth.UserToken, error)
+	TryRotateTokenProvider       func(ctx context.Context, token *auth.UserToken, clientIP net.IP, userAgent string) (bool, error)
+	LookupTokenProvider          func(ctx context.Context, unhashedToken string) (*auth.UserToken, error)
+	RevokeTokenProvider          func(ctx context.Context, token *auth.UserToken, soft bool) error
 	RevokeAllUserTokensProvider  func(ctx context.Context, userId int64) error
 	ActiveAuthTokenCount         func(ctx context.Context) (int64, error)
-	GetUserTokenProvider         func(ctx context.Context, userId, userTokenId int64) (*models.UserToken, error)
-	GetUserTokensProvider        func(ctx context.Context, userId int64) ([]*models.UserToken, error)
-	GetUserRevokedTokensProvider func(ctx context.Context, userId int64) ([]*models.UserToken, error)
+	GetUserTokenProvider         func(ctx context.Context, userId, userTokenId int64) (*auth.UserToken, error)
+	GetUserTokensProvider        func(ctx context.Context, userId int64) ([]*auth.UserToken, error)
+	GetUserRevokedTokensProvider func(ctx context.Context, userId int64) ([]*auth.UserToken, error)
 	BatchRevokedTokenProvider    func(ctx context.Context, userIds []int64) error
 }
 
 func NewFakeUserAuthTokenService() *FakeUserAuthTokenService {
 	return &FakeUserAuthTokenService{
-		CreateTokenProvider: func(ctx context.Context, user *user.User, clientIP net.IP, userAgent string) (*models.UserToken, error) {
-			return &models.UserToken{
+		CreateTokenProvider: func(ctx context.Context, user *user.User, clientIP net.IP, userAgent string) (*auth.UserToken, error) {
+			return &auth.UserToken{
 				UserId:        0,
 				UnhashedToken: "",
 			}, nil
 		},
-		TryRotateTokenProvider: func(ctx context.Context, token *models.UserToken, clientIP net.IP, userAgent string) (bool, error) {
+		TryRotateTokenProvider: func(ctx context.Context, token *auth.UserToken, clientIP net.IP, userAgent string) (bool, error) {
 			return false, nil
 		},
-		LookupTokenProvider: func(ctx context.Context, unhashedToken string) (*models.UserToken, error) {
-			return &models.UserToken{
+		LookupTokenProvider: func(ctx context.Context, unhashedToken string) (*auth.UserToken, error) {
+			return &auth.UserToken{
 				UserId:        0,
 				UnhashedToken: "",
 			}, nil
 		},
-		RevokeTokenProvider: func(ctx context.Context, token *models.UserToken, soft bool) error {
+		RevokeTokenProvider: func(ctx context.Context, token *auth.UserToken, soft bool) error {
 			return nil
 		},
 		RevokeAllUserTokensProvider: func(ctx context.Context, userId int64) error {
@@ -53,10 +54,10 @@ func NewFakeUserAuthTokenService() *FakeUserAuthTokenService {
 		ActiveAuthTokenCount: func(ctx context.Context) (int64, error) {
 			return 10, nil
 		},
-		GetUserTokenProvider: func(ctx context.Context, userId, userTokenId int64) (*models.UserToken, error) {
+		GetUserTokenProvider: func(ctx context.Context, userId, userTokenId int64) (*auth.UserToken, error) {
 			return nil, nil
 		},
-		GetUserTokensProvider: func(ctx context.Context, userId int64) ([]*models.UserToken, error) {
+		GetUserTokensProvider: func(ctx context.Context, userId int64) ([]*auth.UserToken, error) {
 			return nil, nil
 		},
 	}
@@ -68,20 +69,20 @@ func (s *FakeUserAuthTokenService) Init() error {
 	return nil
 }
 
-func (s *FakeUserAuthTokenService) CreateToken(ctx context.Context, user *user.User, clientIP net.IP, userAgent string) (*models.UserToken, error) {
+func (s *FakeUserAuthTokenService) CreateToken(ctx context.Context, user *user.User, clientIP net.IP, userAgent string) (*auth.UserToken, error) {
 	return s.CreateTokenProvider(context.Background(), user, clientIP, userAgent)
 }
 
-func (s *FakeUserAuthTokenService) LookupToken(ctx context.Context, unhashedToken string) (*models.UserToken, error) {
+func (s *FakeUserAuthTokenService) LookupToken(ctx context.Context, unhashedToken string) (*auth.UserToken, error) {
 	return s.LookupTokenProvider(context.Background(), unhashedToken)
 }
 
-func (s *FakeUserAuthTokenService) TryRotateToken(ctx context.Context, token *models.UserToken, clientIP net.IP,
+func (s *FakeUserAuthTokenService) TryRotateToken(ctx context.Context, token *auth.UserToken, clientIP net.IP,
 	userAgent string) (bool, error) {
 	return s.TryRotateTokenProvider(context.Background(), token, clientIP, userAgent)
 }
 
-func (s *FakeUserAuthTokenService) RevokeToken(ctx context.Context, token *models.UserToken, soft bool) error {
+func (s *FakeUserAuthTokenService) RevokeToken(ctx context.Context, token *auth.UserToken, soft bool) error {
 	return s.RevokeTokenProvider(context.Background(), token, soft)
 }
 
@@ -93,15 +94,15 @@ func (s *FakeUserAuthTokenService) ActiveTokenCount(ctx context.Context) (int64,
 	return s.ActiveAuthTokenCount(context.Background())
 }
 
-func (s *FakeUserAuthTokenService) GetUserToken(ctx context.Context, userId, userTokenId int64) (*models.UserToken, error) {
+func (s *FakeUserAuthTokenService) GetUserToken(ctx context.Context, userId, userTokenId int64) (*auth.UserToken, error) {
 	return s.GetUserTokenProvider(context.Background(), userId, userTokenId)
 }
 
-func (s *FakeUserAuthTokenService) GetUserTokens(ctx context.Context, userId int64) ([]*models.UserToken, error) {
+func (s *FakeUserAuthTokenService) GetUserTokens(ctx context.Context, userId int64) ([]*auth.UserToken, error) {
 	return s.GetUserTokensProvider(context.Background(), userId)
 }
 
-func (s *FakeUserAuthTokenService) GetUserRevokedTokens(ctx context.Context, userId int64) ([]*models.UserToken, error) {
+func (s *FakeUserAuthTokenService) GetUserRevokedTokens(ctx context.Context, userId int64) ([]*auth.UserToken, error) {
 	return s.GetUserRevokedTokensProvider(context.Background(), userId)
 }
 

--- a/pkg/services/auth/authtest/testing.go
+++ b/pkg/services/auth/authtest/testing.go
@@ -1,4 +1,4 @@
-package auth
+package authtest
 
 import (
 	"context"

--- a/pkg/services/auth/model.go
+++ b/pkg/services/auth/model.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/grafana/grafana/pkg/models"
-	"github.com/grafana/grafana/pkg/services/quota"
 )
 
 type userAuthToken struct {
@@ -72,8 +71,3 @@ func (uat *userAuthToken) toUserToken(ut *models.UserToken) error {
 
 	return nil
 }
-
-const (
-	QuotaTargetSrv quota.TargetSrv = "auth"
-	QuotaTarget    quota.Target    = "session"
-)

--- a/pkg/services/contexthandler/auth_proxy_test.go
+++ b/pkg/services/contexthandler/auth_proxy_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/remotecache"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/models"
-	"github.com/grafana/grafana/pkg/services/auth"
+	"github.com/grafana/grafana/pkg/services/auth/authtest"
 	"github.com/grafana/grafana/pkg/services/contexthandler/authproxy"
 	"github.com/grafana/grafana/pkg/services/login/loginservice"
 	"github.com/grafana/grafana/pkg/services/org/orgtest"
@@ -80,7 +80,7 @@ func getContextHandler(t *testing.T) *ContextHandler {
 	cfg.AuthProxyHeaderProperty = "username"
 	remoteCacheSvc, err := remotecache.ProvideService(cfg, sqlStore)
 	require.NoError(t, err)
-	userAuthTokenSvc := auth.NewFakeUserAuthTokenService()
+	userAuthTokenSvc := authtest.NewFakeUserAuthTokenService()
 	renderSvc := &fakeRenderService{}
 	authJWTSvc := models.NewFakeJWTService()
 	tracer := tracing.InitializeTracerForTest()

--- a/pkg/services/contexthandler/contexthandler.go
+++ b/pkg/services/contexthandler/contexthandler.go
@@ -44,7 +44,7 @@ const (
 
 const ServiceName = "ContextHandler"
 
-func ProvideService(cfg *setting.Cfg, tokenService models.UserTokenService, jwtService models.JWTService,
+func ProvideService(cfg *setting.Cfg, tokenService auth.UserTokenService, jwtService models.JWTService,
 	remoteCache *remotecache.RemoteCache, renderService rendering.Service, sqlStore db.DB,
 	tracer tracing.Tracer, authProxy *authproxy.AuthProxy, loginService login.Service,
 	apiKeyService apikey.Service, authenticator loginpkg.Authenticator, userService user.Service,
@@ -77,7 +77,7 @@ func ProvideService(cfg *setting.Cfg, tokenService models.UserTokenService, jwtS
 // ContextHandler is a middleware.
 type ContextHandler struct {
 	Cfg               *setting.Cfg
-	AuthTokenService  models.UserTokenService
+	AuthTokenService  auth.UserTokenService
 	JWTAuthService    models.JWTService
 	RemoteCache       *remotecache.RemoteCache
 	RenderService     rendering.Service
@@ -474,7 +474,7 @@ func (h *ContextHandler) initContextWithToken(reqContext *models.ReqContext, org
 					}
 
 					err = h.AuthTokenService.RevokeToken(ctx, token, false)
-					if err != nil && !errors.Is(err, models.ErrUserTokenNotFound) {
+					if err != nil && !errors.Is(err, auth.ErrUserTokenNotFound) {
 						reqContext.Logger.Error("failed to revoke auth token", "error", err)
 					}
 					return false
@@ -506,8 +506,8 @@ func (h *ContextHandler) deleteInvalidCookieEndOfRequestFunc(reqContext *models.
 	}
 }
 
-func (h *ContextHandler) rotateEndOfRequestFunc(reqContext *models.ReqContext, authTokenService models.UserTokenService,
-	token *models.UserToken) web.BeforeFunc {
+func (h *ContextHandler) rotateEndOfRequestFunc(reqContext *models.ReqContext, authTokenService auth.UserTokenService,
+	token *auth.UserToken) web.BeforeFunc {
 	return func(w web.ResponseWriter) {
 		// if response has already been written, skip.
 		if w.Written() {

--- a/pkg/services/contexthandler/contexthandler_test.go
+++ b/pkg/services/contexthandler/contexthandler_test.go
@@ -7,14 +7,15 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/grafana-plugin-sdk-go/backend/gtime"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
-	"github.com/grafana/grafana/pkg/services/auth"
+	"github.com/grafana/grafana/pkg/services/auth/authtest"
 	"github.com/grafana/grafana/pkg/util"
 	"github.com/grafana/grafana/pkg/web"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestDontRotateTokensOnCancelledRequests(t *testing.T) {
@@ -25,7 +26,7 @@ func TestDontRotateTokensOnCancelledRequests(t *testing.T) {
 	require.NoError(t, err)
 
 	tryRotateCallCount := 0
-	uts := &auth.FakeUserAuthTokenService{
+	uts := &authtest.FakeUserAuthTokenService{
 		TryRotateTokenProvider: func(ctx context.Context, token *models.UserToken, clientIP net.IP,
 			userAgent string) (bool, error) {
 			tryRotateCallCount++
@@ -48,7 +49,7 @@ func TestTokenRotationAtEndOfRequest(t *testing.T) {
 	reqContext, rr, err := initTokenRotationScenario(context.Background(), t, ctxHdlr)
 	require.NoError(t, err)
 
-	uts := &auth.FakeUserAuthTokenService{
+	uts := &authtest.FakeUserAuthTokenService{
 		TryRotateTokenProvider: func(ctx context.Context, token *models.UserToken, clientIP net.IP,
 			userAgent string) (bool, error) {
 			newToken, err := util.RandomHex(16)

--- a/pkg/services/contexthandler/contexthandler_test.go
+++ b/pkg/services/contexthandler/contexthandler_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend/gtime"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/auth"
 	"github.com/grafana/grafana/pkg/services/auth/authtest"
 	"github.com/grafana/grafana/pkg/util"
 	"github.com/grafana/grafana/pkg/web"
@@ -27,14 +28,14 @@ func TestDontRotateTokensOnCancelledRequests(t *testing.T) {
 
 	tryRotateCallCount := 0
 	uts := &authtest.FakeUserAuthTokenService{
-		TryRotateTokenProvider: func(ctx context.Context, token *models.UserToken, clientIP net.IP,
+		TryRotateTokenProvider: func(ctx context.Context, token *auth.UserToken, clientIP net.IP,
 			userAgent string) (bool, error) {
 			tryRotateCallCount++
 			return false, nil
 		},
 	}
 
-	token := &models.UserToken{AuthToken: "oldtoken"}
+	token := &auth.UserToken{AuthToken: "oldtoken"}
 
 	fn := ctxHdlr.rotateEndOfRequestFunc(reqContext, uts, token)
 	cancel()
@@ -50,7 +51,7 @@ func TestTokenRotationAtEndOfRequest(t *testing.T) {
 	require.NoError(t, err)
 
 	uts := &authtest.FakeUserAuthTokenService{
-		TryRotateTokenProvider: func(ctx context.Context, token *models.UserToken, clientIP net.IP,
+		TryRotateTokenProvider: func(ctx context.Context, token *auth.UserToken, clientIP net.IP,
 			userAgent string) (bool, error) {
 			newToken, err := util.RandomHex(16)
 			require.NoError(t, err)
@@ -59,7 +60,7 @@ func TestTokenRotationAtEndOfRequest(t *testing.T) {
 		},
 	}
 
-	token := &models.UserToken{AuthToken: "oldtoken"}
+	token := &auth.UserToken{AuthToken: "oldtoken"}
 
 	ctxHdlr.rotateEndOfRequestFunc(reqContext, uts, token)(reqContext.Resp)
 

--- a/pkg/services/ngalert/api/util_test.go
+++ b/pkg/services/ngalert/api/util_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
 	accesscontrolmock "github.com/grafana/grafana/pkg/services/accesscontrol/mock"
+	"github.com/grafana/grafana/pkg/services/auth"
 	models2 "github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/user"
@@ -45,7 +46,7 @@ func TestAlertingProxy_createProxyContext(t *testing.T) {
 			Req: &http.Request{},
 		},
 		SignedInUser:          &user.SignedInUser{},
-		UserToken:             &models.UserToken{},
+		UserToken:             &auth.UserToken{},
 		IsSignedIn:            rand.Int63()%2 == 1,
 		IsRenderCall:          rand.Int63()%2 == 1,
 		AllowAnonymous:        rand.Int63()%2 == 1,

--- a/pkg/services/quota/quotaimpl/quota_test.go
+++ b/pkg/services/quota/quotaimpl/quota_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/apikey"
 	"github.com/grafana/grafana/pkg/services/apikey/apikeyimpl"
 	"github.com/grafana/grafana/pkg/services/auth"
+	"github.com/grafana/grafana/pkg/services/auth/authimpl"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	dashboardStore "github.com/grafana/grafana/pkg/services/dashboards/database"
 	"github.com/grafana/grafana/pkg/services/datasources"
@@ -464,7 +465,7 @@ func getQuotaBySrvTargetScope(t *testing.T, quotaService quota.Service, srv quot
 func setupEnv(t *testing.T, sqlStore *sqlstore.SQLStore, b bus.Bus, quotaService quota.Service) {
 	_, err := apikeyimpl.ProvideService(sqlStore, sqlStore.Cfg, quotaService)
 	require.NoError(t, err)
-	_, err = auth.ProvideActiveAuthTokenService(sqlStore.Cfg, sqlStore, quotaService)
+	_, err = authimpl.ProvideActiveAuthTokenService(sqlStore.Cfg, sqlStore, quotaService)
 	require.NoError(t, err)
 	_, err = dashboardStore.ProvideDashboardStore(sqlStore, sqlStore.Cfg, featuremgmt.WithFeatures(), tagimpl.ProvideService(sqlStore, sqlStore.Cfg), quotaService)
 	require.NoError(t, err)


### PR DESCRIPTION
What is this feature?
Refactor the auth package to use internal impl and test packages and moving relevant models and interfaces from the models package to auth package.

Things left to do in another pr:
Seperate db logic from the service i.e. create a store and move sql queries into the store

Which issue(s) does this PR fix?:

Fixes #

Special notes for your reviewer: