### PR TITLE
DataLinks: Improve Data-Links AutoComplete Logic

### DIFF
--- a/packages/grafana-ui/src/components/DataLinks/DataLinkInput.tsx
+++ b/packages/grafana-ui/src/components/DataLinks/DataLinkInput.tsx
@@ -162,6 +162,7 @@ export const DataLinkInput: React.FC<DataLinkInputProps> = memo(
         sel = window.getSelection();
         if (sel && sel.rangeCount > 0) {
           range = sel.getRangeAt(0).cloneRange();
+          // Collapse to the start of the range
           range.collapse(true);
           range.setStart(input, 0);
           precedingChar = range.toString().slice(-1);

--- a/packages/grafana-ui/src/components/DataLinks/DataLinkInput.tsx
+++ b/packages/grafana-ui/src/components/DataLinks/DataLinkInput.tsx
@@ -138,15 +138,12 @@ export const DataLinkInput: React.FC<DataLinkInputProps> = memo(
     }, []);
 
     const onVariableSelect = (item: VariableSuggestion, editor = editorRef.current!) => {
-      const [precedingChar, followingChar]: string[] = getCharactersAroundCaret();
-      const precedingDollar: boolean = precedingChar === '$';
-      const middleOfString: boolean = followingChar !== ' ';
-      const dollarInMiddle: boolean = middleOfString && precedingDollar;
-
+      const precedingChar: string = getCharactersAroundCaret();
+      const precedingDollar = precedingChar === '$';
       if (item.origin !== VariableOrigin.Template || item.value === DataLinkBuiltInVars.includeVars) {
-        editor.insertText(`${dollarInMiddle ? '' : '$'}\{${item.value}}`);
+        editor.insertText(`${precedingDollar ? '' : '$'}\{${item.value}}`);
       } else {
-        editor.insertText(`${dollarInMiddle ? '' : '$'}\{${item.value}:queryparam}`);
+        editor.insertText(`${precedingDollar ? '' : '$'}\{${item.value}:queryparam}`);
       }
 
       setLinkUrl(editor.value);
@@ -159,28 +156,18 @@ export const DataLinkInput: React.FC<DataLinkInputProps> = memo(
     const getCharactersAroundCaret = () => {
       const input: HTMLSpanElement | null = document.getElementById('data-link-input')!;
       let precedingChar = '',
-        preSel: Selection | null,
-        preRange: Range;
-      let followingChar = '',
-        postSel: Selection | null,
-        postRange: Range;
+        sel: Selection | null,
+        range: Range;
       if (window.getSelection) {
-        preSel = window.getSelection();
-        postSel = window.getSelection();
-        if (preSel && preSel.rangeCount > 0) {
-          preRange = preSel.getRangeAt(0).cloneRange();
-          preRange.collapse(true);
-          preRange.setStart(input, 0);
-          precedingChar = preRange.toString().slice(-1);
-        }
-        if (postSel && postSel.rangeCount > 0) {
-          postRange = postSel.getRangeAt(0).cloneRange();
-          postRange.collapse(false);
-          postRange.setEnd(input, input.childNodes.length);
-          followingChar = postRange.toString().charAt(0);
+        sel = window.getSelection();
+        if (sel && sel.rangeCount > 0) {
+          range = sel.getRangeAt(0).cloneRange();
+          range.collapse(true);
+          range.setStart(input, 0);
+          precedingChar = range.toString().slice(-1);
         }
       }
-      return [precedingChar, followingChar];
+      return precedingChar;
     };
 
     return (


### PR DESCRIPTION
Fixes #47184

**Special notes for your reviewer**:

This resolves a pretty narrow edge case so a quick explanation feels useful:

The data-links editor includes a "variable suggestions" dropdown. Users can trigger this dropdown three different ways: by pressing the `$` key, the `=` key, or the `CTRL + SPACE` keys. 

Currently, there are no problems when inserting a variable from the dropdown list IF you triggered the dropdown using `=` or `CTRL + SPACE`. 

But if you use `$` to trigger the dropdown, it only works properly when you are inserting  a var at the very end of the URL string. If you try the `$`-based workflow in the middle of a string, it results in a double `$$`. This is what the OP is describing in the linked issue:  

![CleanShot 2022-11-17 at 19 07 07](https://user-images.githubusercontent.com/37156449/202624092-b4f0fcdd-9ac7-45b0-af46-8fdab4b6a3cc.gif)

This is because the existing logic, `includeDollarSign`, only checked the end of the URL string for an existing `$` (the _most likely_ cursor location). It did not consider the cursor's _actual_ location because it was assumed that users would only insert variables at the very end.

This new logic ([thanks, StackOverflow](https://stackoverflow.com/questions/15157435/get-last-character-before-caret-position-in-javascript) 😄 ❤️  ) grabs the cursor's location and then traps the character directly before it. This new method can both replace the old `includeDollarSign` and has the added benefit of working anywhere in the link's string:

![CleanShot 2022-11-17 at 19 16 24](https://user-images.githubusercontent.com/37156449/202625080-c4f91912-6ee5-482c-be5f-3412cc6b2bc2.gif)
