### PR TITLE
Explore: Fix a11y issue with show all series button in Graph

### DIFF
--- a/public/app/features/explore/Graph/ExploreGraph.tsx
+++ b/public/app/features/explore/Graph/ExploreGraph.tsx
@@ -167,7 +167,7 @@ export function ExploreGraph({
       {dataWithConfig.length > MAX_NUMBER_OF_TIME_SERIES && !showAllTimeSeries && (
         <div className={cx([style.timeSeriesDisclaimer])}>
           <Icon className={style.disclaimerIcon} name="exclamation-triangle" />
-          {`Showing only ${MAX_NUMBER_OF_TIME_SERIES} time series. `}
+          Showing only {MAX_NUMBER_OF_TIME_SERIES} time series.
           <Button variant="primary" fill="text" onClick={() => setShowAllTimeSeries(true)}>
             Show all {dataWithConfig.length}
           </Button>

--- a/public/app/features/explore/Graph/ExploreGraph.tsx
+++ b/public/app/features/explore/Graph/ExploreGraph.tsx
@@ -22,6 +22,7 @@ import {
 import { PanelRenderer } from '@grafana/runtime';
 import { GraphDrawStyle, LegendDisplayMode, TooltipDisplayMode, SortOrder } from '@grafana/schema';
 import {
+  Button,
   Icon,
   PanelContext,
   PanelContextProvider,
@@ -167,12 +168,9 @@ export function ExploreGraph({
         <div className={cx([style.timeSeriesDisclaimer])}>
           <Icon className={style.disclaimerIcon} name="exclamation-triangle" />
           {`Showing only ${MAX_NUMBER_OF_TIME_SERIES} time series. `}
-          <span
-            className={cx([style.showAllTimeSeries])}
-            onClick={() => {
-              setShowAllTimeSeries(true);
-            }}
-          >{`Show all ${dataWithConfig.length}`}</span>
+          <Button variant="primary" fill="text" onClick={() => setShowAllTimeSeries(true)}>
+            Show all {dataWithConfig.length}
+          </Button>
         </div>
       )}
       <PanelRenderer
@@ -192,7 +190,6 @@ export function ExploreGraph({
 const getStyles = (theme: GrafanaTheme2) => ({
   timeSeriesDisclaimer: css`
     label: time-series-disclaimer;
-    width: 300px;
     margin: ${theme.spacing(1)} auto;
     padding: 10px 0;
     border-radius: ${theme.spacing(2)};
@@ -203,10 +200,5 @@ const getStyles = (theme: GrafanaTheme2) => ({
     label: disclaimer-icon;
     color: ${theme.colors.warning.main};
     margin-right: ${theme.spacing(0.5)};
-  `,
-  showAllTimeSeries: css`
-    label: show-all-time-series;
-    cursor: pointer;
-    color: ${theme.colors.text.link};
   `,
 });

--- a/public/app/features/explore/Graph/ExploreGraph.tsx
+++ b/public/app/features/explore/Graph/ExploreGraph.tsx
@@ -168,7 +168,12 @@ export function ExploreGraph({
         <div className={cx([style.timeSeriesDisclaimer])}>
           <Icon className={style.disclaimerIcon} name="exclamation-triangle" />
           Showing only {MAX_NUMBER_OF_TIME_SERIES} time series.
-          <Button variant="primary" fill="text" onClick={() => setShowAllTimeSeries(true)}>
+          <Button
+            variant="primary"
+            fill="text"
+            onClick={() => setShowAllTimeSeries(true)}
+            className={style.showAllButton}
+          >
             Show all {dataWithConfig.length}
           </Button>
         </div>
@@ -200,5 +205,8 @@ const getStyles = (theme: GrafanaTheme2) => ({
     label: disclaimer-icon;
     color: ${theme.colors.warning.main};
     margin-right: ${theme.spacing(0.5)};
+  `,
+  showAllButton: css`
+    margin-left: ${theme.spacing(0.5)};
   `,
 });


### PR DESCRIPTION
**What is this feature?**

Replaces a span behaving like a button with an actual text button. this ensures the element is properly accessible.


**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #58928

**Special notes for your reviewer**:
Not backporting this as ExploreGraph went trhough quite a big refactoring after 9.3. given this PR is fairly simple i can create a separate PR if needed.

BEFORE:
<img width="1039" alt="Screenshot 2022-11-18 at 10 52 50" src="https://user-images.githubusercontent.com/1170767/202673572-6bdaa921-3220-4da3-b073-de09226ccdb9.png">


AFTER: 
<img width="1034" alt="Screenshot 2022-11-18 at 10 54 27" src="https://user-images.githubusercontent.com/1170767/202673881-fa369921-2c59-42b9-b51a-4e686ab222c7.png">

