### PR TITLE
Explore: Fix a11y issue with logs navigation buttons

### DIFF
--- a/public/app/features/explore/LogsNavigationPages.tsx
+++ b/public/app/features/explore/LogsNavigationPages.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import { dateTimeFormat, systemDateFormats, TimeZone, AbsoluteTimeRange, GrafanaTheme2 } from '@grafana/data';
 import { reportInteraction } from '@grafana/runtime';
-import { CustomScrollbar, Spinner, useTheme2 } from '@grafana/ui';
+import { CustomScrollbar, Spinner, useTheme2, clearButtonStyles } from '@grafana/ui';
 
 import { LogsPage } from './LogsNavigation';
 
@@ -48,7 +48,8 @@ export function LogsNavigationPages({
       <div className={styles.pagesWrapper} data-testid="logsNavigationPages">
         <div className={styles.pagesContainer}>
           {pages.map((page: LogsPage, index: number) => (
-            <div
+            <button
+              type="button"
               data-testid={`page${index + 1}`}
               className={styles.page}
               key={page.queryRange.to}
@@ -64,7 +65,7 @@ export function LogsNavigationPages({
               <div className={cx(styles.time, { selectedText: currentPageIndex === index })}>
                 {createPageContent(page, index)}
               </div>
-            </div>
+            </button>
           ))}
         </div>
       </div>
@@ -101,6 +102,7 @@ const getStyles = (theme: GrafanaTheme2, loading: boolean) => {
       flex-direction: column;
     `,
     page: css`
+      ${clearButtonStyles(theme)}
       display: flex;
       margin: ${theme.spacing(2)} 0;
       cursor: ${loading ? 'auto' : 'pointer'};


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Replaces divs with buttons in logs navigation to improve a11y.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #58929

**Special notes for your reviewer**:
BEFORE:
<img width="174" alt="Screenshot 2022-11-18 at 11 05 20" src="https://user-images.githubusercontent.com/1170767/202678184-d4fcc66d-d4fc-4b05-93b8-2e72f8f86960.png">

AFTER:

<img width="125" alt="Screenshot 2022-11-18 at 11 13 21" src="https://user-images.githubusercontent.com/1170767/202678236-bbe61891-4c17-444f-8715-e3db53fab253.png">
