### PR TITLE
Alerting: Fix ConditionsCmd behavior when last is No Data

### DIFF
--- a/pkg/expr/classic/classic.go
+++ b/pkg/expr/classic/classic.go
@@ -146,7 +146,6 @@ func (cmd *ConditionsCmd) Execute(_ context.Context, _ time.Time, vars mathexp.V
 			matches = append(matches, EvalMatch{
 				Metric: "NoData",
 			})
-			noDataFound = true
 		}
 
 		firingCount = 0

--- a/pkg/expr/classic/classic_test.go
+++ b/pkg/expr/classic/classic_test.go
@@ -504,7 +504,6 @@ func TestConditionsCmd(t *testing.T) {
 			return newResults(v)
 		},
 	}, {
-		// TODO: NoData behavior is different if the last condition is no data
 		name: "two queries with two conditions using and operator and last is No Data",
 		vars: mathexp.Vars{
 			"A": mathexp.Results{
@@ -531,7 +530,7 @@ func TestConditionsCmd(t *testing.T) {
 			},
 		},
 		expected: func() mathexp.Results {
-			v := newNumber(nil)
+			v := newNumber(ptr.Float64(0))
 			v.SetMeta([]EvalMatch{{Value: ptr.Float64(5)}, {Metric: "NoData"}})
 			return newResults(v)
 		},


### PR DESCRIPTION
**Which issue(s) does this PR fix?**:

This pull request fixes a bug where `ConditionsCmd` returns inconsistent results depending on whether the first or last value is No Data.

**Special notes for your reviewer**:

