### PR TITLE
LDAP: Make LDAP attribute mapping case-insensitive

### DIFF
--- a/pkg/services/ldap/helpers.go
+++ b/pkg/services/ldap/helpers.go
@@ -34,7 +34,7 @@ func getAttribute(name string, entry *ldap.Entry) string {
 	}
 
 	for _, attr := range entry.Attributes {
-		if attr.Name == name {
+		if strings.EqualFold(attr.Name, name) {
 			if len(attr.Values) > 0 {
 				return attr.Values[0]
 			}

--- a/pkg/services/ldap/helpers.go
+++ b/pkg/services/ldap/helpers.go
@@ -1,6 +1,7 @@
 package ldap
 
 import (
+	"fmt"
 	"strings"
 
 	"gopkg.in/ldap.v3"
@@ -49,7 +50,7 @@ func getArrayAttribute(name string, entry *ldap.Entry) []string {
 	}
 
 	for _, attr := range entry.Attributes {
-		if attr.Name == name && len(attr.Values) > 0 {
+		if strings.EqualFold(attr.Name, name) && len(attr.Values) > 0 {
 			return attr.Values
 		}
 	}

--- a/pkg/services/ldap/helpers.go
+++ b/pkg/services/ldap/helpers.go
@@ -1,7 +1,6 @@
 package ldap
 
 import (
-	"fmt"
 	"strings"
 
 	"gopkg.in/ldap.v3"

--- a/pkg/services/ldap/ldap_helpers_test.go
+++ b/pkg/services/ldap/ldap_helpers_test.go
@@ -83,6 +83,20 @@ func TestGetAttribute(t *testing.T) {
 		assert.Equal(t, value, result)
 	})
 
+	t.Run("mixed case attribute", func(t *testing.T) {
+		value := "roelgerrits"
+		entry := &ldap.Entry{
+			Attributes: []*ldap.EntryAttribute{
+				{
+					Name: "sAMAccountName", Values: []string{value},
+				},
+			},
+		}
+
+		result := getAttribute("samaccountname", entry)
+		assert.Equal(t, value, result)
+	})
+
 	t.Run("no result", func(t *testing.T) {
 		value := []string{"roelgerrits"}
 		entry := &ldap.Entry{

--- a/pkg/services/ldap/ldap_helpers_test.go
+++ b/pkg/services/ldap/ldap_helpers_test.go
@@ -83,7 +83,7 @@ func TestGetAttribute(t *testing.T) {
 		assert.Equal(t, value, result)
 	})
 
-	t.Run("mixed case attribute", func(t *testing.T) {
+	t.Run("letter case mismatch", func(t *testing.T) {
 		value := "roelgerrits"
 		entry := &ldap.Entry{
 			Attributes: []*ldap.EntryAttribute{
@@ -134,6 +134,21 @@ func TestGetArrayAttribute(t *testing.T) {
 		}
 
 		result := getArrayAttribute("username", entry)
+
+		assert.EqualValues(t, value, result)
+	})
+
+	t.Run("letter case mismatch", func(t *testing.T) {
+		value := []string{"CN=Administrators,CN=Builtin,DC=grafana,DC=org"}
+		entry := &ldap.Entry{
+			Attributes: []*ldap.EntryAttribute{
+				{
+					Name: "memberOf", Values: value,
+				},
+			},
+		}
+
+		result := getArrayAttribute("memberof", entry)
 
 		assert.EqualValues(t, value, result)
 	})


### PR DESCRIPTION
Make Grafana's LDAP attribute mapping case-insensitive.
I did a lot of LDAP integrations and never came against this issue, so I think this might be the most common behavior.
Even tools like `ldapsearch` and `ldp.exe` do not care about attribute's letter case.

fix: #11300
fix: #58991

