### PR TITLE
Alerting: Remove checkForPathSeparator validation in alert rule name

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/AlertRuleForm.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AlertRuleForm.tsx
@@ -27,7 +27,6 @@ import { NotificationsStep } from './NotificationsStep';
 import { RuleEditorSection } from './RuleEditorSection';
 import { RuleInspector } from './RuleInspector';
 import { QueryAndExpressionsStep } from './query-and-alert-condition/QueryAndExpressionsStep';
-import { checkForPathSeparator } from './util';
 
 const recordingRuleNameValidationPattern = {
   message:
@@ -58,16 +57,6 @@ const AlertRuleNameInput = () => {
           {...register('name', {
             required: { value: true, message: 'Must enter an alert name' },
             pattern: ruleFormType === RuleFormType.cloudRecording ? recordingRuleNameValidationPattern : undefined,
-            validate: {
-              pathSeparator: (value: string) => {
-                // we use the alert rule name as the "groupname" for Grafana managed alerts, so we can't allow path separators
-                if (ruleFormType === RuleFormType.grafana) {
-                  return checkForPathSeparator(value);
-                }
-
-                return true;
-              },
-            },
           })}
           placeholder="Give your alert rule a name."
         />


### PR DESCRIPTION
**What is this feature?**

This PR removes validation (`checkForPathSeparator`) in the alert rule name, as rule names are not used as a path any more.

**Why do we need this feature?**

Alert rule names can contain slashes  as is not going to be a part of a path any more.

**Who is this feature for?**

Users creating/editing alert rules.


