### PR TITLE
Middleware: Add Custom Headers to HTTP responses

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -85,7 +85,7 @@ cdn_url =
 # `0` means there is no timeout for reading the request.
 read_timeout = 0
 
-# Defines custom headers to add in the HTTP responses
+# This setting enables you to specify additional headers that the server adds to HTTP(S) responses.
 [server.custom_response_headers]
 #exampleHeader1 = exampleValue1
 #exampleHeader2 = exampleValue2

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -85,6 +85,11 @@ cdn_url =
 # `0` means there is no timeout for reading the request.
 read_timeout = 0
 
+# Defines custom headers to add in the HTTP responses
+[server.custom_response_headers]
+#exampleHeader1 = exampleValue1
+#exampleHeader2 = exampleValue2
+
 #################################### Database ############################
 [database]
 # You can configure the database connection by specifying type, host, name, user and password

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -86,7 +86,7 @@
 # `0` means there is no timeout for reading the request.
 ;read_timeout = 0
 
-# Defines custom headers to add in the HTTP responses
+# This setting enables you to specify additional headers that the server adds to HTTP(S) responses.
 [server.custom_response_headers]
 #exampleHeader1 = exampleValue1
 #exampleHeader2 = exampleValue2

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -86,6 +86,11 @@
 # `0` means there is no timeout for reading the request.
 ;read_timeout = 0
 
+# Defines custom headers to add in the HTTP responses
+[server.custom_response_headers]
+#exampleHeader1 = exampleValue1
+#exampleHeader2 = exampleValue2
+
 #################################### Database ####################################
 [database]
 # You can configure the database connection by specifying type, host, name, user and password

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -294,7 +294,7 @@ Sets the maximum time using a duration format (5s/5m/5ms) before timing out read
 
 ## [server.custom_response_headers]
 
-Lets you specify additional headers that the server can add to HTTP(S) responses.
+This setting enables you to specify additional headers that the server adds to HTTP(S) responses.
 
 ```
 ; exampleHeader1 = exampleValue1

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -297,8 +297,8 @@ Sets the maximum time using a duration format (5s/5m/5ms) before timing out read
 This setting enables you to specify additional headers that the server adds to HTTP(S) responses.
 
 ```
-; exampleHeader1 = exampleValue1
-; exampleHeader2 = exampleValue2
+exampleHeader1 = exampleValue1
+exampleHeader2 = exampleValue2
 ```
 
 <hr />

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -292,6 +292,17 @@ Sets the maximum time using a duration format (5s/5m/5ms) before timing out read
 
 <hr />
 
+## [server.custom_response_headers]
+
+Lets you specify additional headers that the server can add to HTTP(S) responses.
+
+```
+; exampleHeader1 = exampleValue1
+; exampleHeader2 = exampleValue2
+```
+
+<hr />
+
 ## [database]
 
 Grafana needs a database to store users and dashboards (and other

--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -594,6 +594,10 @@ func (hs *HTTPServer) addMiddlewaresAndStaticRoutes() {
 		hs.mapStatic(m, hs.Cfg.ImagesDir, "", "/public/img/attachments")
 	}
 
+	if len(hs.Cfg.CustomResponseHeaders) > 0 {
+		m.Use(middleware.AddCustomResponseHeaders(hs.Cfg))
+	}
+
 	m.Use(middleware.AddDefaultResponseHeaders(hs.Cfg))
 
 	if hs.Cfg.ServeFromSubPath && hs.Cfg.AppSubURL != "" {

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -77,3 +77,21 @@ func addNoCacheHeaders(w web.ResponseWriter) {
 func addXFrameOptionsDenyHeader(w web.ResponseWriter) {
 	w.Header().Set("X-Frame-Options", "deny")
 }
+
+func AddCustomResponseHeaders(cfg *setting.Cfg) web.Handler {
+	return func(c *web.Context) {
+		c.Resp.Before(func(w web.ResponseWriter) {
+			if w.Written() {
+				return
+			}
+
+			for header, value := range cfg.CustomResponseHeaders {
+				// do not override existing headers
+				if w.Header().Get(header) != "" {
+					continue
+				}
+				w.Header().Set(header, value)
+			}
+		})
+	}
+}

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -481,6 +481,8 @@ type Cfg struct {
 	GRPCServerNetwork   string
 	GRPCServerAddress   string
 	GRPCServerTLSConfig *tls.Config
+
+	CustomResponseHeaders map[string]string
 }
 
 type CommandLineArgs struct {
@@ -1670,6 +1672,14 @@ func (cfg *Cfg) readServerSettings(iniFile *ini.File) error {
 	}
 
 	cfg.ReadTimeout = server.Key("read_timeout").MustDuration(0)
+
+	headersSection := cfg.Raw.Section("server.custom_response_headers")
+	keys := headersSection.Keys()
+	cfg.CustomResponseHeaders = make(map[string]string, len(keys))
+
+	for _, key := range keys {
+		cfg.CustomResponseHeaders[key.Name()] = key.Value()
+	}
 
 	return nil
 }


### PR DESCRIPTION
**What is this feature?**

Allows setting a `custom_response_headers` config that defines a map of headers and values to add in the HTTP responses. 

**Why do we need this feature?**

In the scope of https://github.com/grafana/hosted-grafana/issues/2681, we will start testing a Content-Security-Policy in Report Only mode. This mode requires setting a `report-to` directive which refers to an extra [Reporting-Endpoints](https://www.w3.org/TR/reporting/#reporting-endpoints) header ([see csp report-to docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-to)).

Instead of explicitly supporting this additional Reporting-Endpoints header, we thought it would be useful to support setting any custom headers instead.


**Which issue(s) does this PR fix?**:

https://github.com/grafana/hosted-grafana/issues/2681


**Special notes for your reviewer**:
I'm wondering if there should be any validation or restriction for this custom headers (e.g., not allowing specific headers, limiting header/value size, etc.). Let me know if there are any concerns about this. 
