### PR TITLE
Logs: Add callback option onScroll

### DIFF
--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -37,6 +37,7 @@ export const LogsPanel: React.FunctionComponent<LogsPanelProps> = ({
     sortOrder,
     dedupStrategy,
     enableLogDetails,
+    onScroll,
   },
   title,
   id,
@@ -102,7 +103,7 @@ export const LogsPanel: React.FunctionComponent<LogsPanelProps> = ({
   );
 
   return (
-    <CustomScrollbar autoHide scrollTop={scrollTop}>
+    <CustomScrollbar autoHide onScroll={onScroll} scrollTop={scrollTop}>
       <div className={style.container} ref={logsContainerRef}>
         {showCommonLabels && !isAscending && renderCommonLabels()}
         <LogRows

--- a/public/app/plugins/panel/logs/types.ts
+++ b/public/app/plugins/panel/logs/types.ts
@@ -1,3 +1,5 @@
+import { UIEventHandler } from 'react';
+
 import { LogsSortOrder, LogsDedupStrategy } from '@grafana/data';
 
 export interface Options {
@@ -9,4 +11,5 @@ export interface Options {
   enableLogDetails: boolean;
   sortOrder: LogsSortOrder;
   dedupStrategy: LogsDedupStrategy;
+  onScroll?: UIEventHandler;
 }


### PR DESCRIPTION
**What is this feature?**
Scroll events emitted by the LogsPanel.

**Why do we need this feature?**
The k6 team would like to load logs as the user scrolls rather than using buttons

**Who is this feature for?**
Initially, it would be for k6 load-test users


https://user-images.githubusercontent.com/4395376/203081584-8fbcba31-718a-4de6-a3db-6c4c6e4826c1.mov


