### PR TITLE
Prometheus: fix Heatmap y buckets when legendFormat: auto

### DIFF
--- a/public/app/plugins/datasource/prometheus/result_transformer.test.ts
+++ b/public/app/plugins/datasource/prometheus/result_transformer.test.ts
@@ -264,8 +264,8 @@ describe('Prometheus Result Transformer', () => {
               {
                 name: 'Value',
                 type: FieldType.number,
-                values: [20, 10, 30],
-                labels: { le: '2' },
+                values: [30, 10, 40],
+                labels: { le: '+Inf' },
               },
             ],
           }),
@@ -276,8 +276,8 @@ describe('Prometheus Result Transformer', () => {
               {
                 name: 'Value',
                 type: FieldType.number,
-                values: [30, 10, 40],
-                labels: { le: '3' },
+                values: [20, 10, 30],
+                labels: { le: '2' },
               },
             ],
           }),
@@ -289,6 +289,9 @@ describe('Prometheus Result Transformer', () => {
       expect(series.data[0].fields[1].values.toArray()).toEqual([10, 10, 0]);
       expect(series.data[0].fields[2].values.toArray()).toEqual([10, 0, 30]);
       expect(series.data[0].fields[3].values.toArray()).toEqual([10, 0, 10]);
+      expect(series.data[0].fields[1].name).toEqual('1');
+      expect(series.data[0].fields[2].name).toEqual('2');
+      expect(series.data[0].fields[3].name).toEqual('+Inf');
     });
 
     it('results with heatmap format from multiple queries should be correctly transformed', () => {

--- a/public/app/plugins/datasource/prometheus/result_transformer.ts
+++ b/public/app/plugins/datasource/prometheus/result_transformer.ts
@@ -105,10 +105,17 @@ export function transformV2(
   // this works around the fact that we only get back frame.name with le buckets when legendFormat == {{le}}...which is not the default
   heatmapResults.forEach((df) => {
     if (df.name == null) {
-      let le = df.fields.find((f) => f.name === 'Value')?.labels?.le;
+      let f = df.fields.find((f) => f.name === 'Value');
 
-      if (le != null) {
-        df.name = le;
+      if (f) {
+        let le = f.labels?.le;
+
+        if (le) {
+          // this is used for sorting the frames by numeric ascending le labels for de-accum
+          df.name = le;
+          // this is used for renaming the Value fields to le label
+          f.config.displayNameFromDS = le;
+        }
       }
     }
   });

--- a/public/app/plugins/datasource/prometheus/result_transformer.ts
+++ b/public/app/plugins/datasource/prometheus/result_transformer.ts
@@ -102,6 +102,17 @@ export function transformV2(
     (df) => isHeatmapResult(df, request)
   );
 
+  // this works around the fact that we only get back frame.name with le buckets when legendFormat == {{le}}...which is not the default
+  heatmapResults.forEach((df) => {
+    if (df.name == null) {
+      let le = df.fields.find((f) => f.name === 'Value')?.labels?.le;
+
+      if (le != null) {
+        df.name = le;
+      }
+    }
+  });
+
   // Group heatmaps by query
   const heatmapResultsGroupedByQuery = groupBy<DataFrame>(heatmapResults, (h) => h.refId);
 


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/55535

this works around the fact that we only get back frame.name with le buckets when legendFormat == {{le}}...which is not the default.

more thorough explanation here: https://github.com/grafana/grafana/issues/55535#issuecomment-1321330816