### PR TITLE
Loki: Add `gzip` compression to resource calls

### DIFF
--- a/pkg/tsdb/loki/api_mock.go
+++ b/pkg/tsdb/loki/api_mock.go
@@ -32,6 +32,29 @@ func (mockedRT *mockedRoundTripper) RoundTrip(req *http.Request) (*http.Response
 	}, nil
 }
 
+type mockedCompressedRoundTripper struct {
+	statusCode      int
+	responseBytes   []byte
+	contentType     string
+	requestCallback mockRequestCallback
+}
+
+func (mockedRT *mockedCompressedRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	requestCallback := mockedRT.requestCallback
+	if requestCallback != nil {
+		requestCallback(req)
+	}
+
+	header := http.Header{}
+	header.Add("Content-Type", mockedRT.contentType)
+	header.Add("Content-Encoding", "gzip")
+	return &http.Response{
+		StatusCode: mockedRT.statusCode,
+		Header:     header,
+		Body:       io.NopCloser(bytes.NewReader(mockedRT.responseBytes)),
+	}, nil
+}
+
 func makeMockedAPI(statusCode int, contentType string, responseBytes []byte, requestCallback mockRequestCallback) *LokiAPI {
 	return makeMockedAPIWithUrl("http://localhost:9999", statusCode, contentType, responseBytes, requestCallback)
 }
@@ -39,6 +62,14 @@ func makeMockedAPI(statusCode int, contentType string, responseBytes []byte, req
 func makeMockedAPIWithUrl(url string, statusCode int, contentType string, responseBytes []byte, requestCallback mockRequestCallback) *LokiAPI {
 	client := http.Client{
 		Transport: &mockedRoundTripper{statusCode: statusCode, contentType: contentType, responseBytes: responseBytes, requestCallback: requestCallback},
+	}
+
+	return newLokiAPI(&client, url, log.New("test"), nil)
+}
+
+func makeCompressedMockedAPIWithUrl(url string, statusCode int, contentType string, responseBytes []byte, requestCallback mockRequestCallback) *LokiAPI {
+	client := http.Client{
+		Transport: &mockedCompressedRoundTripper{statusCode: statusCode, contentType: contentType, responseBytes: responseBytes, requestCallback: requestCallback},
 	}
 
 	return newLokiAPI(&client, url, log.New("test"), nil)

--- a/pkg/tsdb/loki/api_test.go
+++ b/pkg/tsdb/loki/api_test.go
@@ -135,6 +135,20 @@ func TestApiUrlHandling(t *testing.T) {
 			require.True(t, called)
 		})
 	}
+	
+	for _, test := range queryTestData {
+		t.Run("Loki should build the metadata query URL correctly when "+test.name, func(t *testing.T) {
+			called := false
+			api := makeMockedAPIWithUrl(test.dsUrl, 200, "application/json", response, func(req *http.Request) {
+				called = true
+				require.Equal(t, test.metaUrl, req.URL.String())
+			})
+
+			_, err := api.RawQuery(context.Background(), "/loki/api/v1/labels?start=1&end=2")
+			require.NoError(t, err)
+			require.True(t, called)
+		})
+	}
 }
 
 func TestApiReturnValues(t *testing.T) {

--- a/pkg/tsdb/loki/api_test.go
+++ b/pkg/tsdb/loki/api_test.go
@@ -135,18 +135,19 @@ func TestApiUrlHandling(t *testing.T) {
 			require.True(t, called)
 		})
 	}
+}
 
-	for _, test := range queryTestData {
-		t.Run("Loki should build the metadata query URL correctly when "+test.name, func(t *testing.T) {
-			called := false
-			api := makeMockedAPIWithUrl(test.dsUrl, 200, "application/json", response, func(req *http.Request) {
-				called = true
-				require.Equal(t, test.metaUrl, req.URL.String())
-			})
-
-			_, err := api.RawQuery(context.Background(), "/loki/api/v1/labels?start=1&end=2")
-			require.NoError(t, err)
-			require.True(t, called)
+func TestApiReturnValues(t *testing.T) {
+	t.Run("Loki should return the right encoding", func(t *testing.T) {
+		called := false
+		api := makeCompressedMockedAPIWithUrl("http://localhost:3100", 200, "application/json", []byte("foo"), func(req *http.Request) {
+			called = true
 		})
-	}
+
+		encodedBytes, err := api.RawQuery(context.Background(), "/loki/api/v1/labels?start=1&end=2")
+		require.NoError(t, err)
+		require.True(t, called)
+		require.Equal(t, "gzip", encodedBytes.Encoding)
+		require.Equal(t, []byte("foo"), encodedBytes.Body)
+	})
 }

--- a/pkg/tsdb/loki/api_test.go
+++ b/pkg/tsdb/loki/api_test.go
@@ -135,7 +135,7 @@ func TestApiUrlHandling(t *testing.T) {
 			require.True(t, called)
 		})
 	}
-	
+
 	for _, test := range queryTestData {
 		t.Run("Loki should build the metadata query URL correctly when "+test.name, func(t *testing.T) {
 			called := false


### PR DESCRIPTION
**What is this feature?**

Loki returns gzip compressed responses in certain situations. This PR enables this compression in the Loki datasource.

**Why do we need this feature?**

Improved performance if e.g. label values get large.

**Special notes for your reviewer**:

To get Loki into a setup where compression is enabled:
1. Add the following lines to https://github.com/grafana/grafana/blob/main/devenv/docker/blocks/loki/loki-config.yaml:
```
frontend:
  compress_responses: true
```
This enables compression on responses which are larger than 1400 bytes.
2. Create a bunch of labels to get more than 1400 bytes by changing the https://github.com/grafana/grafana/blob/main/devenv/docker/blocks/loki/data/data.js file. E.g. change the `main` method to:
```
async function main() {
  for (let step = 0; step < 300000; step++) {

    const timestampMs = new Date().getTime();
    const item = getRandomLogItem(step + 1)
    await lokiSendLogLine(timestampMs, JSON.stringify(item), {[`test${step}`]: step, place:'moon', source: 'data', instance: 'server\\1', job: '"grafana/data"'});
    // lokiSendLogLine(timestampMs, logFmtLine(item), {place:'luna', source: 'data', instance: 'server\\2', job: '"grafana/data"'});
  }
}
```
3. Run `make devenv sources=loki`
4. Go to explore, select Loki, select Query Builder, open the labels select-component while your browser's dev-tools are opened. Observe that the response to this request is now gzip-compressed:
![image](https://user-images.githubusercontent.com/8092184/203102570-6aadaf8f-9eb6-481d-a8ca-54147bd6d04e.png)
