### PR TITLE
kindsys: Return Decl from Kinds

### DIFF
--- a/pkg/codegen/generators.go
+++ b/pkg/codegen/generators.go
@@ -29,6 +29,29 @@ func ForGen(rt *thema.Runtime, decl *kindsys.SomeDecl) (*DeclForGen, error) {
 	}, nil
 }
 
+// RawForGen produces a [DeclForGen] from a [kindsys.Raw] kind.
+//
+// Useful for grafana-external code generators, which depend on the Kind
+// representation in registries produced by grafana core (such as
+// ["github.com/grafana/grafana/pkg/registry/corekind".NewBase]).
+func RawForGen(k kindsys.Raw) *DeclForGen {
+	return &DeclForGen{
+		SomeDecl: k.Decl().Some(),
+	}
+}
+
+// StructuredForGen produces a [DeclForGen] from a [kindsys.Structured] kind.
+//
+// Useful for grafana-external code generators, which depend on the Kind
+// representation in registries produced by grafana core (such as
+// ["github.com/grafana/grafana/pkg/registry/corekind".NewBase]).
+func StructuredForGen(k kindsys.Structured) *DeclForGen {
+	return &DeclForGen{
+		SomeDecl: k.Decl().Some(),
+		lin:      k.Lineage(),
+	}
+}
+
 // DeclForGen wraps [kindsys.SomeDecl] to provide trivial caching of
 // the lineage declared by the kind (nil for raw kinds).
 type DeclForGen struct {

--- a/pkg/codegen/tmpl/kind_corestructured.tmpl
+++ b/pkg/codegen/tmpl/kind_corestructured.tmpl
@@ -90,6 +90,7 @@ func (k *Kind) Maturity() kindsys.Maturity {
 }
 
 // TODO standard generated docs
-func (k *Kind) Meta() kindsys.CoreStructuredMeta {
-	return k.decl.Meta
+func (k *Kind) Decl() *kindsys.Decl[kindsys.CoreStructuredMeta] {
+	d := k.decl
+	return &d
 }

--- a/pkg/codegen/tmpl/kind_raw.tmpl
+++ b/pkg/codegen/tmpl/kind_raw.tmpl
@@ -42,6 +42,7 @@ func (k *Kind) Maturity() kindsys.Maturity {
 }
 
 // TODO standard generated docs
-func (k *Kind) Meta() kindsys.RawMeta {
-	return k.decl.Meta
+func (k *Kind) Decl() *kindsys.Decl[kindsys.RawMeta] {
+	d := k.decl
+	return &d
 }

--- a/pkg/kinds/dashboard/dashboard_kind_gen.go
+++ b/pkg/kinds/dashboard/dashboard_kind_gen.go
@@ -99,6 +99,7 @@ func (k *Kind) Maturity() kindsys.Maturity {
 }
 
 // TODO standard generated docs
-func (k *Kind) Meta() kindsys.CoreStructuredMeta {
-	return k.decl.Meta
+func (k *Kind) Decl() *kindsys.Decl[kindsys.CoreStructuredMeta] {
+	d := k.decl
+	return &d
 }

--- a/pkg/kinds/playlist/playlist_kind_gen.go
+++ b/pkg/kinds/playlist/playlist_kind_gen.go
@@ -99,6 +99,7 @@ func (k *Kind) Maturity() kindsys.Maturity {
 }
 
 // TODO standard generated docs
-func (k *Kind) Meta() kindsys.CoreStructuredMeta {
-	return k.decl.Meta
+func (k *Kind) Decl() *kindsys.Decl[kindsys.CoreStructuredMeta] {
+	d := k.decl
+	return &d
 }

--- a/pkg/kinds/svg/svg_kind_gen.go
+++ b/pkg/kinds/svg/svg_kind_gen.go
@@ -49,6 +49,7 @@ func (k *Kind) Maturity() kindsys.Maturity {
 }
 
 // TODO standard generated docs
-func (k *Kind) Meta() kindsys.RawMeta {
-	return k.decl.Meta
+func (k *Kind) Decl() *kindsys.Decl[kindsys.RawMeta] {
+	d := k.decl
+	return &d
 }

--- a/pkg/kindsys/kind.go
+++ b/pkg/kindsys/kind.go
@@ -58,7 +58,7 @@ type Raw interface {
 	Interface
 
 	// TODO docs
-	Meta() RawMeta
+	Decl() *Decl[RawMeta]
 }
 
 type Structured interface {
@@ -68,7 +68,7 @@ type Structured interface {
 	Lineage() thema.Lineage
 
 	// TODO docs
-	Meta() CoreStructuredMeta // TODO figure out how to reconcile this interface with CustomStructuredMeta
+	Decl() *Decl[CoreStructuredMeta] // TODO figure out how to reconcile this interface with CustomStructuredMeta
 }
 
 // type Composable interface {

--- a/pkg/kindsys/kindmetas.go
+++ b/pkg/kindsys/kindmetas.go
@@ -2,7 +2,7 @@ package kindsys
 
 import "github.com/grafana/thema"
 
-// CommonMeta contains the kind metadata common to all categories of kinds.
+// CommonMeta contains the metadata common to all categories of kinds.
 type CommonMeta struct {
 	Name              string   `json:"name"`
 	PluralName        string   `json:"pluralName"`


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This modifies kindsys interfaces and code jennies so it's possible to get the original `Kindsys.Decl` out from a `Kind`. Also adds some helper funcs to do just that.

**Why do we need this feature?**

Most core code jennies are written with [`codegen.DeclForGen` as their input type](https://github.com/grafana/grafana/blob/57d6adbc7c4008143ac18fc7076607be227e12d3/pkg/codegen/generators.go#L32-L38). To reuse those jennies in grok, it needs to be easy to get at `DeclForGen` from the generated `Kind` types, which are what's available to grok via [the generated registry](https://github.com/grafana/grafana/blob/57d6adbc7c4008143ac18fc7076607be227e12d3/pkg/registry/corekind/base.go#L28).

**Who is this feature for?**

External as-code platform generators.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

