### PR TITLE
Feat: Adding an optional browser config option to e2e test runner

### DIFF
--- a/packages/grafana-e2e/cli.js
+++ b/packages/grafana-e2e/cli.js
@@ -3,7 +3,7 @@ const execa = require('execa');
 const { resolve, sep } = require('path');
 const resolveBin = require('resolve-as-bin');
 
-const cypress = (commandName, { updateScreenshots }) => {
+const cypress = (commandName, { updateScreenshots, browser }) => {
   // Support running an unpublished dev build
   const dirname = __dirname.split(sep).pop();
   const projectPath = resolve(`${__dirname}${dirname === 'dist' ? '/..' : ''}`);
@@ -15,6 +15,10 @@ const cypress = (commandName, { updateScreenshots }) => {
   const UPDATE_SCREENSHOTS = `UPDATE_SCREENSHOTS=${updateScreenshots ? 1 : 0}`;
 
   const cypressOptions = [commandName, '--env', `${CWD},${UPDATE_SCREENSHOTS}`, `--project=${projectPath}`];
+
+  if (browser) {
+    cypressOptions.push('--browser', browser);
+  }
 
   const execaOptions = {
     cwd: __dirname,
@@ -32,17 +36,21 @@ const cypress = (commandName, { updateScreenshots }) => {
 module.exports = () => {
   const updateOption = '-u, --update-screenshots';
   const updateDescription = 'update expected screenshots';
+  const browserOption = '-b, --browser <browser>';
+  const browserDescription = 'specify which browser to use';
 
   program
     .command('open')
     .description('runs tests within the interactive GUI')
     .option(updateOption, updateDescription)
+    .option(browserOption, browserDescription)
     .action((options) => cypress('open', options));
 
   program
     .command('run')
     .description('runs tests from the CLI without the GUI')
     .option(updateOption, updateDescription)
+    .option(browserOption, browserDescription)
     .action((options) => cypress('run', options));
 
   program.parse(process.argv);


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Adding an optional `--browser` parameter to e2e runner

**Why do we need this feature?**

Being able to specify browser

**Who is this feature for?**

- e2e tests in plugins, local and ci