### PR TITLE
Chore: Fix status codes for nested folders

### DIFF
--- a/pkg/api/apierrors/folder.go
+++ b/pkg/api/apierrors/folder.go
@@ -6,10 +6,16 @@ import (
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/util"
+	"github.com/grafana/grafana/pkg/util/errutil"
 )
 
 // ToFolderErrorResponse returns a different response status according to the folder error type
 func ToFolderErrorResponse(err error) response.Response {
+	grafanaErr := &errutil.Error{}
+	if errors.As(err, grafanaErr) {
+		return response.Error(grafanaErr.Reason.Status().HTTPStatus(), string(grafanaErr.Reason.Status()), grafanaErr)
+	}
+
 	var dashboardErr dashboards.DashboardErr
 	if ok := errors.As(err, &dashboardErr); ok {
 		return response.Error(dashboardErr.StatusCode, err.Error(), err)

--- a/pkg/api/apierrors/folder.go
+++ b/pkg/api/apierrors/folder.go
@@ -6,16 +6,10 @@ import (
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/util"
-	"github.com/grafana/grafana/pkg/util/errutil"
 )
 
 // ToFolderErrorResponse returns a different response status according to the folder error type
 func ToFolderErrorResponse(err error) response.Response {
-	grafanaErr := &errutil.Error{}
-	if errors.As(err, grafanaErr) {
-		return response.Error(grafanaErr.Reason.Status().HTTPStatus(), string(grafanaErr.Reason.Status()), grafanaErr)
-	}
-
 	var dashboardErr dashboards.DashboardErr
 	if ok := errors.As(err, &dashboardErr); ok {
 		return response.Error(dashboardErr.StatusCode, err.Error(), err)
@@ -46,5 +40,5 @@ func ToFolderErrorResponse(err error) response.Response {
 		return response.JSON(412, util.DynMap{"status": "version-mismatch", "message": dashboards.ErrFolderVersionMismatch.Error()})
 	}
 
-	return response.Error(500, "Folder API error", err)
+	return response.ErrOrFallback(500, "Folder API error", err)
 }


### PR DESCRIPTION
Related to https://github.com/grafana/grafana/issues/56880 this PR fixes HTTP API status codes for 404 and 400 "errutil" errors.