### PR TITLE
Internationalization: Translate menu items

### DIFF
--- a/public/app/core/components/NavBar/NavBarMenu.tsx
+++ b/public/app/core/components/NavBar/NavBarMenu.tsx
@@ -256,7 +256,7 @@ export function NavItem({
                   }}
                   styleOverrides={styles.item}
                   target={childLink.target}
-                  text={childLink.text}
+                  text={getNavTitle(childLink.id) ?? childLink.text}
                   url={childLink.url}
                   isMobile={true}
                 />
@@ -297,7 +297,7 @@ export function NavItem({
                 <NavBarItemIcon link={link} />
               </FeatureHighlightWrapper>
             </div>
-            <span className={styles.linkText}>{link.text}</span>
+            <span className={styles.linkText}>{getNavTitle(link.id) ?? link.text}</span>
           </div>
         </NavBarItemWithoutMenu>
       </li>
@@ -398,7 +398,7 @@ function CollapsibleNavItem({
           contentClassName={styles.collapseContent}
           label={
             <div className={cx(styles.labelWrapper, { [styles.primary]: isActive })}>
-              <span className={styles.linkText}>{link.text}</span>
+              <span className={styles.linkText}>{getNavTitle(link.id) ?? link.text}</span>
             </div>
           }
         >


### PR DESCRIPTION
**What is this feature?**

Translate these menu items:
<img width="740" alt="MenuItems" src="https://user-images.githubusercontent.com/65417731/203271178-43bf7f91-b52b-45e6-80d7-15a9bbc62370.png">

**Why do we need this feature?**

To see the menu items translated.

**Who is this feature for?**

Everyone

**Which issue(s) does this PR fix?**:

Fixes #59060

**Special notes for your reviewer**:

