### PR TITLE
Docs: adds workaround for editing provisioned rules using the HTTP API

### DIFF
--- a/docs/sources/alerting/set-up/provision-alerting-resources/_index.md
+++ b/docs/sources/alerting/set-up/provision-alerting-resources/_index.md
@@ -27,7 +27,9 @@ There are three options to choose from:
 
    **Note:**
 
-   If you want to be able to edit provisioned alert rules directly in the Grafana UI, create or edit your alert rules in the Alerting Provisioning HTTP API and add the x-disable-provenance header to the following requests:
+   Typically, you cannot edit API-provisioned alert rules from the Grafana UI.
+
+   In order to enable editing, add the x-disable-provenance header to the following requests when creating or editing your alert rules in the API:
 
    POST /api/v1/provisioning/alert-rules
 

--- a/docs/sources/alerting/set-up/provision-alerting-resources/_index.md
+++ b/docs/sources/alerting/set-up/provision-alerting-resources/_index.md
@@ -21,15 +21,23 @@ There are three options to choose from:
 
 1. Use file provisioning to provision your Grafana Alerting resources, such as alert rules and contact points, through files on disk.
 
-1. Provision your alerting resources using the Grafana HTTP API.
+1. Provision your alerting resources using the Alerting Provisioning HTTP API.
 
-   For more information on the Grafana Alerting provisioning API, refer to [Alerting provisioning API](https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/).
+   For more information on the Alerting Provisioning HTTP API, refer to [Alerting provisioning API](https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/).
+
+   **Note:**
+
+   If you migrate your alert rules to Grafana Alerting using the Alerting Provisioning HTTP API, you can edit alert rules in Grafana by adding the x-disable-provenance header to the following requests:
+
+   POST /api/v1/provisioning/alert-rules
+
+   PUT /api/v1/provisioning/alert-rules/{UID}
 
 1. Provision your alerting resources using Terraform.
 
 **Note:**
 
-Currently, provisioning for Grafana Alerting supports alert rules, contact points, mute timings, and templates. Provisioned alerting resources can only be edited in the source that created them and not from within Grafana or any other source. For example, if you provision your alerting resources using files from disk, you cannot edit the data in Terraform or from within Grafana.
+Currently, provisioning for Grafana Alerting supports alert rules, contact points, mute timings, and templates. Provisioned alerting resources using file provisioning or Terraform can only be edited in the source that created them and not from within Grafana or any other source. For example, if you provision your alerting resources using files from disk, you cannot edit the data in Terraform or from within Grafana.
 
 **Useful Links:**
 

--- a/docs/sources/alerting/set-up/provision-alerting-resources/_index.md
+++ b/docs/sources/alerting/set-up/provision-alerting-resources/_index.md
@@ -27,7 +27,7 @@ There are three options to choose from:
 
    **Note:**
 
-   If you migrate your alert rules to Grafana Alerting using the Alerting Provisioning HTTP API, you can edit alert rules in Grafana by adding the x-disable-provenance header to the following requests:
+   If you want to be able to edit provisioned alert rules directly in the Grafana UI, create or edit your alert rules in the Alerting Provisioning HTTP API and add the x-disable-provenance header to the following requests:
 
    POST /api/v1/provisioning/alert-rules
 


### PR DESCRIPTION
Adds a note to the docs on the workaround for editing rules provisionined by the alerting HTTP API. 