### PR TITLE
Alerting: add group name validation in alert rule form

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
@@ -203,6 +203,9 @@ export function FolderAndGroup({ initialFolder }: FolderAndGroupProps) {
           control={control}
           rules={{
             required: { value: true, message: 'Must enter a group name' },
+            validate: {
+              pathSeparator: (group_: string) => checkForPathSeparator(group_),
+            },
           }}
         />
       </Field>


### PR DESCRIPTION
This PR adds a validation (`checkForPathSeparator`) on evaluation group in the alert rule form.

We've previously validated the "alert rule name" for Grafana Managed alert rules – back when we were using the alert name to automatically create an evaluation group with the same name. (https://github.com/grafana/grafana/pull/44872)

Since refactoring the alert creation and allowing arbitrary evaluation group names we've never added this validation to that component. (https://github.com/grafana/grafana/pull/47785)

This PR adds the path separator validation back in for evaluation groups.


