### PR TITLE
Access Control: Clear user's permission cache after resource creation

### DIFF
--- a/pkg/api/common_test.go
+++ b/pkg/api/common_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
+	"github.com/grafana/grafana/pkg/services/accesscontrol/actest"
 	accesscontrolmock "github.com/grafana/grafana/pkg/services/accesscontrol/mock"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/ossaccesscontrol"
 	"github.com/grafana/grafana/pkg/services/annotations/annotationstest"
@@ -250,15 +251,16 @@ func (s *fakeRenderService) Init() error {
 func setupAccessControlScenarioContext(t *testing.T, cfg *setting.Cfg, url string, permissions []accesscontrol.Permission) (*scenarioContext, *HTTPServer) {
 	store := sqlstore.InitTestDB(t)
 	hs := &HTTPServer{
-		Cfg:                cfg,
-		Live:               newTestLive(t, store),
-		License:            &licensing.OSSLicensingService{},
-		Features:           featuremgmt.WithFeatures(),
-		QuotaService:       quotatest.New(false, nil),
-		RouteRegister:      routing.NewRouteRegister(),
-		AccessControl:      accesscontrolmock.New().WithPermissions(permissions),
-		searchUsersService: searchusers.ProvideUsersService(filters.ProvideOSSSearchUserFilter(), usertest.NewUserServiceFake()),
-		ldapGroups:         ldap.ProvideGroupsService(),
+		Cfg:                  cfg,
+		Live:                 newTestLive(t, store),
+		License:              &licensing.OSSLicensingService{},
+		Features:             featuremgmt.WithFeatures(),
+		QuotaService:         quotatest.New(false, nil),
+		RouteRegister:        routing.NewRouteRegister(),
+		AccessControl:        accesscontrolmock.New().WithPermissions(permissions),
+		searchUsersService:   searchusers.ProvideUsersService(filters.ProvideOSSSearchUserFilter(), usertest.NewUserServiceFake()),
+		ldapGroups:           ldap.ProvideGroupsService(),
+		accesscontrolService: actest.FakeService{},
 	}
 
 	sc := setupScenarioContext(t, url)

--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -478,13 +478,10 @@ func (hs *HTTPServer) postDashboard(c *models.ReqContext, cmd models.SaveDashboa
 		return apierrors.ToDashboardErrorResponse(ctx, hs.pluginStore, err)
 	}
 
-	// Reload permission cache for the user who's created the dashboard, so that they can access it immediately
+	// Clear permission cache for the user who's created the dashboard, so that new permissions are fetched for their next call
+	// Required for cases when caller wants to immediately interact with the newly created object
 	if newDashboard && !hs.accesscontrolService.IsDisabled() {
-		// Clear permission cache for the user who's created the dashboard, so that new permissions are fetched for their next call
-		// Required for cases when caller wants to immediately interact with the newly created object
-		if err := hs.accesscontrolService.ClearUserPermissionCache(c.SignedInUser); err != nil {
-			return response.Error(500, "Failed to clear permission cache after dashboard creation", err)
-		}
+		hs.accesscontrolService.ClearUserPermissionCache(c.SignedInUser)
 	}
 
 	// connect library panels for this dashboard after the dashboard is stored and has an ID

--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -18,12 +18,11 @@ import (
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/db"
-	"github.com/grafana/grafana/pkg/infra/localcache"
 	"github.com/grafana/grafana/pkg/infra/usagestats"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/registry/corekind"
-	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
+	"github.com/grafana/grafana/pkg/services/accesscontrol/actest"
 	accesscontrolmock "github.com/grafana/grafana/pkg/services/accesscontrol/mock"
 	"github.com/grafana/grafana/pkg/services/alerting"
 	"github.com/grafana/grafana/pkg/services/annotations/annotationstest"
@@ -1083,9 +1082,6 @@ func callPostDashboardShouldReturnSuccess(sc *scenarioContext) {
 func postDashboardScenario(t *testing.T, desc string, url string, routePattern string, cmd models.SaveDashboardCommand, dashboardService dashboards.DashboardService, folderService folder.Service, fn scenarioFunc) {
 	t.Run(fmt.Sprintf("%s %s", desc, url), func(t *testing.T) {
 		cfg := setting.NewCfg()
-		features := featuremgmt.WithFeatures()
-		acService, err := acimpl.ProvideService(cfg, mockstore.NewSQLStoreMock(), routing.NewRouteRegister(), localcache.ProvideService(), features)
-		require.NoError(t, err)
 		hs := HTTPServer{
 			Cfg:                   cfg,
 			ProvisioningService:   provisioning.NewProvisioningServiceMock(context.Background()),
@@ -1096,9 +1092,9 @@ func postDashboardScenario(t *testing.T, desc string, url string, routePattern s
 			LibraryElementService: &mockLibraryElementService{},
 			DashboardService:      dashboardService,
 			folderService:         folderService,
-			Features:              features,
+			Features:              featuremgmt.WithFeatures(),
 			Kinds:                 corekind.NewBase(nil),
-			accesscontrolService:  acService,
+			accesscontrolService:  actest.FakeService{},
 		}
 
 		sc := setupScenarioContext(t, url)
@@ -1195,9 +1191,6 @@ func restoreDashboardVersionScenario(t *testing.T, desc string, url string, rout
 	cmd dtos.RestoreDashboardVersionCommand, fn scenarioFunc, sqlStore sqlstore.Store) {
 	t.Run(fmt.Sprintf("%s %s", desc, url), func(t *testing.T) {
 		cfg := setting.NewCfg()
-		features := featuremgmt.WithFeatures()
-		acService, err := acimpl.ProvideService(cfg, mockstore.NewSQLStoreMock(), routing.NewRouteRegister(), localcache.ProvideService(), features)
-		require.NoError(t, err)
 		hs := HTTPServer{
 			Cfg:                     cfg,
 			ProvisioningService:     provisioning.NewProvisioningServiceMock(context.Background()),
@@ -1207,10 +1200,10 @@ func restoreDashboardVersionScenario(t *testing.T, desc string, url string, rout
 			LibraryElementService:   &mockLibraryElementService{},
 			DashboardService:        mock,
 			SQLStore:                sqlStore,
-			Features:                features,
+			Features:                featuremgmt.WithFeatures(),
 			dashboardVersionService: fakeDashboardVersionService,
 			Kinds:                   corekind.NewBase(nil),
-			accesscontrolService:    acService,
+			accesscontrolService:    actest.FakeService{},
 		}
 
 		sc := setupScenarioContext(t, url)

--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -18,10 +18,12 @@ import (
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/infra/localcache"
 	"github.com/grafana/grafana/pkg/infra/usagestats"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/registry/corekind"
+	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
 	accesscontrolmock "github.com/grafana/grafana/pkg/services/accesscontrol/mock"
 	"github.com/grafana/grafana/pkg/services/alerting"
 	"github.com/grafana/grafana/pkg/services/annotations/annotationstest"
@@ -1081,6 +1083,9 @@ func callPostDashboardShouldReturnSuccess(sc *scenarioContext) {
 func postDashboardScenario(t *testing.T, desc string, url string, routePattern string, cmd models.SaveDashboardCommand, dashboardService dashboards.DashboardService, folderService folder.Service, fn scenarioFunc) {
 	t.Run(fmt.Sprintf("%s %s", desc, url), func(t *testing.T) {
 		cfg := setting.NewCfg()
+		features := featuremgmt.WithFeatures()
+		acService, err := acimpl.ProvideService(cfg, mockstore.NewSQLStoreMock(), routing.NewRouteRegister(), localcache.ProvideService(), features)
+		require.NoError(t, err)
 		hs := HTTPServer{
 			Cfg:                   cfg,
 			ProvisioningService:   provisioning.NewProvisioningServiceMock(context.Background()),
@@ -1091,8 +1096,9 @@ func postDashboardScenario(t *testing.T, desc string, url string, routePattern s
 			LibraryElementService: &mockLibraryElementService{},
 			DashboardService:      dashboardService,
 			folderService:         folderService,
-			Features:              featuremgmt.WithFeatures(),
+			Features:              features,
 			Kinds:                 corekind.NewBase(nil),
+			accesscontrolService:  acService,
 		}
 
 		sc := setupScenarioContext(t, url)
@@ -1189,6 +1195,9 @@ func restoreDashboardVersionScenario(t *testing.T, desc string, url string, rout
 	cmd dtos.RestoreDashboardVersionCommand, fn scenarioFunc, sqlStore sqlstore.Store) {
 	t.Run(fmt.Sprintf("%s %s", desc, url), func(t *testing.T) {
 		cfg := setting.NewCfg()
+		features := featuremgmt.WithFeatures()
+		acService, err := acimpl.ProvideService(cfg, mockstore.NewSQLStoreMock(), routing.NewRouteRegister(), localcache.ProvideService(), features)
+		require.NoError(t, err)
 		hs := HTTPServer{
 			Cfg:                     cfg,
 			ProvisioningService:     provisioning.NewProvisioningServiceMock(context.Background()),
@@ -1198,9 +1207,10 @@ func restoreDashboardVersionScenario(t *testing.T, desc string, url string, rout
 			LibraryElementService:   &mockLibraryElementService{},
 			DashboardService:        mock,
 			SQLStore:                sqlStore,
-			Features:                featuremgmt.WithFeatures(),
+			Features:                features,
 			dashboardVersionService: fakeDashboardVersionService,
 			Kinds:                   corekind.NewBase(nil),
+			accesscontrolService:    acService,
 		}
 
 		sc := setupScenarioContext(t, url)

--- a/pkg/api/datasources.go
+++ b/pkg/api/datasources.go
@@ -396,13 +396,10 @@ func (hs *HTTPServer) AddDataSource(c *models.ReqContext) response.Response {
 		return response.Error(500, "Failed to add datasource", err)
 	}
 
-	// Reload permission cache for the user who's created the data source, so that they can access this data source immediately
+	// Clear permission cache for the user who's created the data source, so that new permissions are fetched for their next call
+	// Required for cases when caller wants to immediately interact with the newly created object
 	if !hs.AccessControl.IsDisabled() {
-		// Clear permission cache for the user who's created the data source, so that new permissions are fetched for their next call
-		// Required for cases when caller wants to immediately interact with the newly created object
-		if err := hs.accesscontrolService.ClearUserPermissionCache(c.SignedInUser); err != nil {
-			return response.Error(500, "Failed to clear permission cache after data source creation", err)
-		}
+		hs.accesscontrolService.ClearUserPermissionCache(c.SignedInUser)
 	}
 
 	ds := hs.convertModelToDtos(c.Req.Context(), cmd.Result)

--- a/pkg/api/datasources_test.go
+++ b/pkg/api/datasources_test.go
@@ -19,6 +19,8 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/plugins"
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
+	"github.com/grafana/grafana/pkg/services/accesscontrol/actest"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/datasources/permissions"
 	"github.com/grafana/grafana/pkg/services/org"
@@ -112,7 +114,9 @@ func TestAddDataSource_URLWithoutProtocol(t *testing.T) {
 		DataSourcesService: &dataSourcesServiceMock{
 			expectedDatasource: &datasources.DataSource{},
 		},
-		Cfg: setting.NewCfg(),
+		Cfg:                  setting.NewCfg(),
+		AccessControl:        acimpl.ProvideAccessControl(setting.NewCfg()),
+		accesscontrolService: actest.FakeService{},
 	}
 
 	sc := setupScenarioContext(t, "/api/datasources")
@@ -224,7 +228,9 @@ func TestUpdateDataSource_URLWithoutProtocol(t *testing.T) {
 		DataSourcesService: &dataSourcesServiceMock{
 			expectedDatasource: &datasources.DataSource{},
 		},
-		Cfg: setting.NewCfg(),
+		Cfg:                  setting.NewCfg(),
+		AccessControl:        acimpl.ProvideAccessControl(setting.NewCfg()),
+		accesscontrolService: actest.FakeService{},
 	}
 
 	sc := setupScenarioContext(t, "/api/datasources/1234")

--- a/pkg/api/folder.go
+++ b/pkg/api/folder.go
@@ -128,13 +128,10 @@ func (hs *HTTPServer) CreateFolder(c *models.ReqContext) response.Response {
 		return apierrors.ToFolderErrorResponse(err)
 	}
 
-	// Reload permission cache for the user who's created the folder, so that they can access it immediately
+	// Clear permission cache for the user who's created the folder, so that new permissions are fetched for their next call
+	// Required for cases when caller wants to immediately interact with the newly created object
 	if !hs.AccessControl.IsDisabled() {
-		// Clear permission cache for the user who's created the folder, so that new permissions are fetched for their next call
-		// Required for cases when caller wants to immediately interact with the newly created object
-		if err := hs.accesscontrolService.ClearUserPermissionCache(c.SignedInUser); err != nil {
-			return response.Error(500, "Failed to clear permission cache after folder creation", err)
-		}
+		hs.accesscontrolService.ClearUserPermissionCache(c.SignedInUser)
 	}
 
 	g := guardian.New(c.Req.Context(), folder.ID, c.OrgID, c.SignedInUser)

--- a/pkg/api/folder_test.go
+++ b/pkg/api/folder_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/accesscontrol/actest"
 	acmock "github.com/grafana/grafana/pkg/services/accesscontrol/mock"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -242,10 +243,11 @@ func createFolderScenario(t *testing.T, desc string, url string, routePattern st
 		store := mockstore.NewSQLStoreMock()
 		guardian.InitLegacyGuardian(store, dashSvc, teamSvc)
 		hs := HTTPServer{
-			AccessControl: acmock.New(),
-			folderService: folderService,
-			Cfg:           setting.NewCfg(),
-			Features:      featuremgmt.WithFeatures(),
+			AccessControl:        acmock.New(),
+			folderService:        folderService,
+			Cfg:                  setting.NewCfg(),
+			Features:             featuremgmt.WithFeatures(),
+			accesscontrolService: actest.FakeService{},
 		}
 
 		sc := setupScenarioContext(t, url)

--- a/pkg/api/team.go
+++ b/pkg/api/team.go
@@ -41,13 +41,10 @@ func (hs *HTTPServer) CreateTeam(c *models.ReqContext) response.Response {
 		return response.Error(500, "Failed to create Team", err)
 	}
 
-	// Reload permission cache for the user who's created the team, so that they can access this data source immediately
+	// Clear permission cache for the user who's created the team, so that new permissions are fetched for their next call
+	// Required for cases when caller wants to immediately interact with the newly created object
 	if !hs.AccessControl.IsDisabled() {
-		// Clear permission cache for the user who's created the team, so that new permissions are fetched for their next call
-		// Required for cases when caller wants to immediately interact with the newly created object
-		if err := hs.accesscontrolService.ClearUserPermissionCache(c.SignedInUser); err != nil {
-			return response.Error(500, "Failed to clear permission cache after team creation", err)
-		}
+		hs.accesscontrolService.ClearUserPermissionCache(c.SignedInUser)
 	}
 
 	if accessControlEnabled || (c.OrgRole == org.RoleEditor && hs.Cfg.EditorsCanAdmin) {

--- a/pkg/api/team_test.go
+++ b/pkg/api/team_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log/logtest"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
+	"github.com/grafana/grafana/pkg/services/accesscontrol/actest"
 	"github.com/grafana/grafana/pkg/services/org"
 	pref "github.com/grafana/grafana/pkg/services/preference"
 	"github.com/grafana/grafana/pkg/services/preference/preftest"
@@ -213,6 +215,8 @@ func TestTeamAPIEndpoint_CreateTeam_RBAC(t *testing.T) {
 	server := SetupAPITestServer(t, func(hs *HTTPServer) {
 		hs.Cfg = setting.NewCfg()
 		hs.teamService = teamtest.NewFakeService()
+		hs.AccessControl = acimpl.ProvideAccessControl(setting.NewCfg())
+		hs.accesscontrolService = actest.FakeService{}
 	})
 
 	input := strings.NewReader(fmt.Sprintf(teamCmd, 1))

--- a/pkg/services/accesscontrol/accesscontrol.go
+++ b/pkg/services/accesscontrol/accesscontrol.go
@@ -26,6 +26,8 @@ type Service interface {
 	registry.ProvidesUsageStats
 	// GetUserPermissions returns user permissions with only action and scope fields set.
 	GetUserPermissions(ctx context.Context, user *user.SignedInUser, options Options) ([]Permission, error)
+	// ClearUserPermissionCache removes the permission cache entry for the given user
+	ClearUserPermissionCache(user *user.SignedInUser) error
 	// DeleteUserPermissions removes all permissions user has in org and all permission to that user
 	// If orgID is set to 0 remove permissions from all orgs
 	DeleteUserPermissions(ctx context.Context, orgID, userID int64) error

--- a/pkg/services/accesscontrol/accesscontrol.go
+++ b/pkg/services/accesscontrol/accesscontrol.go
@@ -27,7 +27,7 @@ type Service interface {
 	// GetUserPermissions returns user permissions with only action and scope fields set.
 	GetUserPermissions(ctx context.Context, user *user.SignedInUser, options Options) ([]Permission, error)
 	// ClearUserPermissionCache removes the permission cache entry for the given user
-	ClearUserPermissionCache(user *user.SignedInUser) error
+	ClearUserPermissionCache(user *user.SignedInUser)
 	// DeleteUserPermissions removes all permissions user has in org and all permission to that user
 	// If orgID is set to 0 remove permissions from all orgs
 	DeleteUserPermissions(ctx context.Context, orgID, userID int64) error

--- a/pkg/services/accesscontrol/acimpl/service.go
+++ b/pkg/services/accesscontrol/acimpl/service.go
@@ -147,13 +147,12 @@ func (s *Service) getCachedUserPermissions(ctx context.Context, user *user.Signe
 	return permissions, nil
 }
 
-func (s *Service) ClearUserPermissionCache(user *user.SignedInUser) error {
+func (s *Service) ClearUserPermissionCache(user *user.SignedInUser) {
 	key, err := permissionCacheKey(user)
 	if err != nil {
-		return err
+		return
 	}
 	s.cache.Delete(key)
-	return nil
 }
 
 func (s *Service) DeleteUserPermissions(ctx context.Context, orgID int64, userID int64) error {

--- a/pkg/services/accesscontrol/acimpl/service.go
+++ b/pkg/services/accesscontrol/acimpl/service.go
@@ -147,6 +147,15 @@ func (s *Service) getCachedUserPermissions(ctx context.Context, user *user.Signe
 	return permissions, nil
 }
 
+func (s *Service) ClearUserPermissionCache(user *user.SignedInUser) error {
+	key, err := permissionCacheKey(user)
+	if err != nil {
+		return err
+	}
+	s.cache.Delete(key)
+	return nil
+}
+
 func (s *Service) DeleteUserPermissions(ctx context.Context, orgID int64, userID int64) error {
 	return s.store.DeleteUserPermissions(ctx, orgID, userID)
 }

--- a/pkg/services/accesscontrol/actest/fake.go
+++ b/pkg/services/accesscontrol/actest/fake.go
@@ -24,9 +24,7 @@ func (f FakeService) GetUserPermissions(ctx context.Context, user *user.SignedIn
 	return f.ExpectedPermissions, f.ExpectedErr
 }
 
-func (f FakeService) ClearUserPermissionCache(user *user.SignedInUser) {
-	return
-}
+func (f FakeService) ClearUserPermissionCache(user *user.SignedInUser) {}
 
 func (f FakeService) DeleteUserPermissions(ctx context.Context, orgID, userID int64) error {
 	return f.ExpectedErr

--- a/pkg/services/accesscontrol/actest/fake.go
+++ b/pkg/services/accesscontrol/actest/fake.go
@@ -24,8 +24,8 @@ func (f FakeService) GetUserPermissions(ctx context.Context, user *user.SignedIn
 	return f.ExpectedPermissions, f.ExpectedErr
 }
 
-func (f FakeService) ClearUserPermissionCache(user *user.SignedInUser) error {
-	return f.ExpectedErr
+func (f FakeService) ClearUserPermissionCache(user *user.SignedInUser) {
+	return
 }
 
 func (f FakeService) DeleteUserPermissions(ctx context.Context, orgID, userID int64) error {

--- a/pkg/services/accesscontrol/actest/fake.go
+++ b/pkg/services/accesscontrol/actest/fake.go
@@ -24,6 +24,10 @@ func (f FakeService) GetUserPermissions(ctx context.Context, user *user.SignedIn
 	return f.ExpectedPermissions, f.ExpectedErr
 }
 
+func (f FakeService) ClearUserPermissionCache(user *user.SignedInUser) error {
+	return f.ExpectedErr
+}
+
 func (f FakeService) DeleteUserPermissions(ctx context.Context, orgID, userID int64) error {
 	return f.ExpectedErr
 }

--- a/pkg/services/accesscontrol/mock/mock.go
+++ b/pkg/services/accesscontrol/mock/mock.go
@@ -146,7 +146,6 @@ func (m *Mock) ClearUserPermissionCache(user *user.SignedInUser) {
 	if m.ClearUserPermissionCacheFunc != nil {
 		m.ClearUserPermissionCacheFunc(user)
 	}
-	return
 }
 
 // Middleware checks if service disabled or not to switch to fallback authorization.

--- a/pkg/services/accesscontrol/mock/mock.go
+++ b/pkg/services/accesscontrol/mock/mock.go
@@ -44,7 +44,7 @@ type Mock struct {
 	// Override functions
 	EvaluateFunc                       func(context.Context, *user.SignedInUser, accesscontrol.Evaluator) (bool, error)
 	GetUserPermissionsFunc             func(context.Context, *user.SignedInUser, accesscontrol.Options) ([]accesscontrol.Permission, error)
-	ClearUserPermissionCacheFunc       func(*user.SignedInUser) error
+	ClearUserPermissionCacheFunc       func(*user.SignedInUser)
 	IsDisabledFunc                     func() bool
 	DeclareFixedRolesFunc              func(...accesscontrol.RoleRegistration) error
 	DeclarePluginRolesFunc             func(context.Context, string, string, []plugins.RoleRegistration) error
@@ -140,13 +140,13 @@ func (m *Mock) GetUserPermissions(ctx context.Context, user *user.SignedInUser, 
 	return m.permissions, nil
 }
 
-func (m *Mock) ClearUserPermissionCache(user *user.SignedInUser) error {
+func (m *Mock) ClearUserPermissionCache(user *user.SignedInUser) {
 	m.Calls.ClearUserPermissionCache = append(m.Calls.ClearUserPermissionCache, []interface{}{user})
 	// Use override if provided
 	if m.ClearUserPermissionCacheFunc != nil {
-		return m.ClearUserPermissionCacheFunc(user)
+		m.ClearUserPermissionCacheFunc(user)
 	}
-	return nil
+	return
 }
 
 // Middleware checks if service disabled or not to switch to fallback authorization.

--- a/pkg/services/accesscontrol/mock/mock.go
+++ b/pkg/services/accesscontrol/mock/mock.go
@@ -20,6 +20,7 @@ type fullAccessControl interface {
 type Calls struct {
 	Evaluate                       []interface{}
 	GetUserPermissions             []interface{}
+	ClearUserPermissionCache       []interface{}
 	IsDisabled                     []interface{}
 	DeclareFixedRoles              []interface{}
 	DeclarePluginRoles             []interface{}
@@ -43,6 +44,7 @@ type Mock struct {
 	// Override functions
 	EvaluateFunc                       func(context.Context, *user.SignedInUser, accesscontrol.Evaluator) (bool, error)
 	GetUserPermissionsFunc             func(context.Context, *user.SignedInUser, accesscontrol.Options) ([]accesscontrol.Permission, error)
+	ClearUserPermissionCacheFunc       func(*user.SignedInUser) error
 	IsDisabledFunc                     func() bool
 	DeclareFixedRolesFunc              func(...accesscontrol.RoleRegistration) error
 	DeclarePluginRolesFunc             func(context.Context, string, string, []plugins.RoleRegistration) error
@@ -136,6 +138,15 @@ func (m *Mock) GetUserPermissions(ctx context.Context, user *user.SignedInUser, 
 	}
 	// Otherwise return the Permissions list
 	return m.permissions, nil
+}
+
+func (m *Mock) ClearUserPermissionCache(user *user.SignedInUser) error {
+	m.Calls.ClearUserPermissionCache = append(m.Calls.ClearUserPermissionCache, []interface{}{user})
+	// Use override if provided
+	if m.ClearUserPermissionCacheFunc != nil {
+		return m.ClearUserPermissionCacheFunc(user)
+	}
+	return nil
 }
 
 // Middleware checks if service disabled or not to switch to fallback authorization.

--- a/pkg/services/serviceaccounts/api/api.go
+++ b/pkg/services/serviceaccounts/api/api.go
@@ -133,9 +133,7 @@ func (api *ServiceAccountsAPI) CreateServiceAccount(c *models.ReqContext) respon
 
 		// Clear permission cache for the user who's created the service account, so that new permissions are fetched for their next call
 		// Required for cases when caller wants to immediately interact with the newly created object
-		if err := api.accesscontrolService.ClearUserPermissionCache(c.SignedInUser); err != nil {
-			return response.Error(500, "Failed to clear permission cache after service account creation", err)
-		}
+		api.accesscontrolService.ClearUserPermissionCache(c.SignedInUser)
 	}
 
 	return response.JSON(http.StatusCreated, serviceAccount)

--- a/pkg/services/serviceaccounts/api/api_test.go
+++ b/pkg/services/serviceaccounts/api/api_test.go
@@ -17,16 +17,14 @@ import (
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/kvstore"
-	"github.com/grafana/grafana/pkg/infra/localcache"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
-	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
+	"github.com/grafana/grafana/pkg/services/accesscontrol/actest"
 	accesscontrolmock "github.com/grafana/grafana/pkg/services/accesscontrol/mock"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/ossaccesscontrol"
 	"github.com/grafana/grafana/pkg/services/apikey/apikeyimpl"
 	"github.com/grafana/grafana/pkg/services/contexthandler/ctxkey"
-	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/licensing"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/org/orgimpl"
@@ -299,8 +297,7 @@ func setupTestServer(t *testing.T, svc *tests.ServiceAccountMock,
 	saPermissionService, err := ossaccesscontrol.ProvideServiceAccountPermissions(
 		cfg, routing.NewRouteRegister(), sqlStore, acmock, &licensing.OSSLicensingService{}, saStore, acmock, teamSvc, userSvc)
 	require.NoError(t, err)
-	acService, err := acimpl.ProvideService(cfg, sqlStore, routerRegister, localcache.ProvideService(), featuremgmt.WithFeatures())
-	require.NoError(t, err)
+	acService := actest.FakeService{}
 
 	a := NewServiceAccountsAPI(cfg, svc, acmock, acService, routerRegister, saStore, saPermissionService)
 	a.RegisterAPIEndpoints()

--- a/pkg/services/serviceaccounts/manager/service.go
+++ b/pkg/services/serviceaccounts/manager/service.go
@@ -51,7 +51,7 @@ func ProvideServiceAccountsService(
 
 	usageStats.RegisterMetricsFunc(s.getUsageMetrics)
 
-	serviceaccountsAPI := api.NewServiceAccountsAPI(cfg, s, ac, routeRegister, s.store, permissionService)
+	serviceaccountsAPI := api.NewServiceAccountsAPI(cfg, s, ac, accesscontrolService, routeRegister, s.store, permissionService)
 	serviceaccountsAPI.RegisterAPIEndpoints()
 
 	s.secretScanEnabled = cfg.SectionWithEnvOverrides("secretscan").Key("enabled").MustBool(false)


### PR DESCRIPTION
**What is this feature?**

Automatically reload user's permission cache after they create a folder, dashboard, team or a data source.

**Why do we need this feature?**

This would allow the creator to immediately access the created resource, which is needed by provisioning (Terraform etc), frontend etc.

**Who is this feature for?**

All users.

**Which issue(s) does this PR fix?**:

Related to https://github.com/grafana/terraform-provider-grafana/issues/521 and https://github.com/grafana/terraform-provider-grafana/issues/665

**Special notes for your reviewer**:

Another approach would be to call a separate endpoint to reload the permission cache (this is what we currently do from the frontend by calling `/api/access-control/user/actions?reloadcache=true`). However, I feel like automatically reloading the cache from the API handlers is a simpler solution and covers all the use cases (ie, other potential provisioning tools, custom scripts etc).
