### PR TITLE
Loki Query Editor: Autocompletion and suggestions improvements (unwrap, parser, extracted labels)

### DIFF
--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/CompletionDataProvider.test.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/CompletionDataProvider.test.ts
@@ -81,7 +81,7 @@ describe('CompletionDataProvider', () => {
   });
 
   test('Returns the expected parser and label keys', async () => {
-    expect(await completionProvider.getParserAndLabelKeys([])).toEqual(parserAndLabelKeys);
+    expect(await completionProvider.getParserAndLabelKeys('')).toEqual(parserAndLabelKeys);
   });
 
   test('Returns the expected series labels', async () => {

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/CompletionDataProvider.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/CompletionDataProvider.ts
@@ -42,8 +42,8 @@ export class CompletionDataProvider {
     return data[labelName] ?? [];
   }
 
-  async getParserAndLabelKeys(labels: Label[]) {
-    return await this.languageProvider.getParserAndLabelKeys(this.buildSelector(labels));
+  async getParserAndLabelKeys(logQuery: string) {
+    return await this.languageProvider.getParserAndLabelKeys(logQuery);
   }
 
   async getSeriesLabels(labels: Label[]) {

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.test.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.test.ts
@@ -318,7 +318,7 @@ describe('getCompletions', () => {
         hasJSON: true,
         hasLogfmt: false,
       });
-      const situation: Situation = { type: 'AFTER_SELECTOR', labels: [], afterPipe };
+      const situation: Situation = { type: 'AFTER_SELECTOR', labels: [], afterPipe, lineFilter: false };
       const completions = await getCompletions(situation, completionProvider);
 
       const expected = buildAfterSelectorCompletions('json', 'PARSER', 'logfmt', afterPipe);
@@ -334,7 +334,7 @@ describe('getCompletions', () => {
         hasJSON: false,
         hasLogfmt: true,
       });
-      const situation: Situation = { type: 'AFTER_SELECTOR', labels: [], afterPipe };
+      const situation: Situation = { type: 'AFTER_SELECTOR', labels: [], afterPipe, lineFilter: false };
       const completions = await getCompletions(situation, completionProvider);
 
       const expected = buildAfterSelectorCompletions('logfmt', 'DURATION', 'json', afterPipe);

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.test.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.test.ts
@@ -212,7 +212,7 @@ describe('getCompletions', () => {
   });
 
   test('Returns completion options when the situation is IN_GROUPING', async () => {
-    const situation: Situation = { type: 'IN_GROUPING', otherLabels };
+    const situation: Situation = { type: 'IN_GROUPING', logQuery: '' };
     const completions = await getCompletions(situation, completionProvider);
 
     expect(completions).toEqual([
@@ -313,7 +313,7 @@ describe('getCompletions', () => {
         hasJSON: true,
         hasLogfmt: false,
       });
-      const situation: Situation = { type: 'AFTER_SELECTOR', labels: [], afterPipe };
+      const situation: Situation = { type: 'AFTER_SELECTOR', logQuery: '', afterPipe };
       const completions = await getCompletions(situation, completionProvider);
 
       const expected = buildAfterSelectorCompletions('json', 'logfmt', afterPipe);
@@ -329,7 +329,7 @@ describe('getCompletions', () => {
         hasJSON: false,
         hasLogfmt: true,
       });
-      const situation: Situation = { type: 'AFTER_SELECTOR', labels: [], afterPipe };
+      const situation: Situation = { type: 'AFTER_SELECTOR', logQuery: '', afterPipe };
       const completions = await getCompletions(situation, completionProvider);
 
       const expected = buildAfterSelectorCompletions('logfmt', 'json', afterPipe);
@@ -343,7 +343,7 @@ describe('getCompletions', () => {
       hasJSON: false,
       hasLogfmt: true,
     });
-    const situation: Situation = { type: 'AFTER_SELECTOR', labels: [], afterPipe: false };
+    const situation: Situation = { type: 'AFTER_SELECTOR', logQuery: '', afterPipe: false };
     const completions = await getCompletions(situation, completionProvider);
 
     const expected = buildAfterSelectorCompletions('logfmt', 'json', false);
@@ -358,7 +358,7 @@ describe('getCompletions', () => {
     });
     const situation: Situation = {
       type: 'AFTER_SELECTOR',
-      labels: [],
+      logQuery: '',
       afterPipe: false,
       parser: 'logfmt',
     };
@@ -379,7 +379,7 @@ describe('getCompletions', () => {
   });
 
   test('Returns completion options when the situation is AFTER_UNWRAP', async () => {
-    const situation: Situation = { type: 'AFTER_UNWRAP', otherLabels: [] };
+    const situation: Situation = { type: 'AFTER_UNWRAP', logQuery: '' };
     const completions = await getCompletions(situation, completionProvider);
 
     const extractedCompletions = completions.filter((completion) => completion.type === 'LABEL_NAME');

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.test.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.test.ts
@@ -313,7 +313,7 @@ describe('getCompletions', () => {
         hasJSON: true,
         hasLogfmt: false,
       });
-      const situation: Situation = { type: 'AFTER_SELECTOR', labels: [], afterPipe, lineFilter: false };
+      const situation: Situation = { type: 'AFTER_SELECTOR', labels: [], afterPipe };
       const completions = await getCompletions(situation, completionProvider);
 
       const expected = buildAfterSelectorCompletions('json', 'logfmt', afterPipe);
@@ -329,7 +329,7 @@ describe('getCompletions', () => {
         hasJSON: false,
         hasLogfmt: true,
       });
-      const situation: Situation = { type: 'AFTER_SELECTOR', labels: [], afterPipe, lineFilter: false };
+      const situation: Situation = { type: 'AFTER_SELECTOR', labels: [], afterPipe };
       const completions = await getCompletions(situation, completionProvider);
 
       const expected = buildAfterSelectorCompletions('logfmt', 'json', afterPipe);
@@ -343,7 +343,7 @@ describe('getCompletions', () => {
       hasJSON: false,
       hasLogfmt: true,
     });
-    const situation: Situation = { type: 'AFTER_SELECTOR', labels: [], afterPipe: false, lineFilter: false };
+    const situation: Situation = { type: 'AFTER_SELECTOR', labels: [], afterPipe: false };
     const completions = await getCompletions(situation, completionProvider);
 
     const expected = buildAfterSelectorCompletions('logfmt', 'json', false);
@@ -361,7 +361,6 @@ describe('getCompletions', () => {
       labels: [],
       afterPipe: false,
       parser: 'logfmt',
-      lineFilter: false,
     };
     const completions = await getCompletions(situation, completionProvider);
 
@@ -369,28 +368,6 @@ describe('getCompletions', () => {
     const expected = buildAfterSelectorCompletions('logfmt', 'json', false).filter(
       (completion) => completion.type !== 'PARSER'
     );
-    expect(completions).toEqual(expected);
-  });
-
-  test('Returns completion options when the situation is AFTER_SELECTOR with parser and line filter', async () => {
-    jest.spyOn(completionProvider, 'getParserAndLabelKeys').mockResolvedValue({
-      extractedLabelKeys,
-      hasJSON: false,
-      hasLogfmt: true,
-    });
-    const situation: Situation = {
-      type: 'AFTER_SELECTOR',
-      labels: [],
-      afterPipe: false,
-      parser: 'logfmt',
-      lineFilter: true,
-    };
-    const completions = await getCompletions(situation, completionProvider);
-
-    // Exclude parsers and line filters because we already have them
-    const expected = buildAfterSelectorCompletions('logfmt', 'json', false)
-      .filter((completion) => completion.type !== 'PARSER')
-      .filter((completion) => completion.type !== 'LINE_FILTER');
     expect(completions).toEqual(expected);
   });
 

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.test.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.test.ts
@@ -200,8 +200,8 @@ describe('getCompletions', () => {
     expect(completions).toHaveLength(25);
   });
 
-  test('Returns completion options when the situation is IN_DURATION', async () => {
-    const situation: Situation = { type: 'IN_DURATION' };
+  test('Returns completion options when the situation is IN_RANGE', async () => {
+    const situation: Situation = { type: 'IN_RANGE' };
     const completions = await getCompletions(situation, completionProvider);
 
     expect(completions).toEqual([

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.test.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.test.ts
@@ -337,40 +337,6 @@ describe('getCompletions', () => {
     }
   );
 
-  test('Returns completion options when the situation is AFTER_SELECTOR with no parser and no line filter', async () => {
-    jest.spyOn(completionProvider, 'getParserAndLabelKeys').mockResolvedValue({
-      extractedLabelKeys,
-      hasJSON: false,
-      hasLogfmt: true,
-    });
-    const situation: Situation = { type: 'AFTER_SELECTOR', logQuery: '', afterPipe: false };
-    const completions = await getCompletions(situation, completionProvider);
-
-    const expected = buildAfterSelectorCompletions('logfmt', 'json', false);
-    expect(completions).toEqual(expected);
-  });
-
-  test('Returns completion options when the situation is AFTER_SELECTOR with parser and no line filter', async () => {
-    jest.spyOn(completionProvider, 'getParserAndLabelKeys').mockResolvedValue({
-      extractedLabelKeys,
-      hasJSON: false,
-      hasLogfmt: true,
-    });
-    const situation: Situation = {
-      type: 'AFTER_SELECTOR',
-      logQuery: '',
-      afterPipe: false,
-      parser: 'logfmt',
-    };
-    const completions = await getCompletions(situation, completionProvider);
-
-    // Exclude parsers because we already have one
-    const expected = buildAfterSelectorCompletions('logfmt', 'json', false).filter(
-      (completion) => completion.type !== 'PARSER'
-    );
-    expect(completions).toEqual(expected);
-  });
-
   test('Returns completion options when the situation is IN_AGGREGATION', async () => {
     const situation: Situation = { type: 'IN_AGGREGATION' };
     const completions = await getCompletions(situation, completionProvider);

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.test.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.test.ts
@@ -377,4 +377,15 @@ describe('getCompletions', () => {
 
     expect(completions).toHaveLength(22);
   });
+
+  test('Returns completion options when the situation is AFTER_UNWRAP', async () => {
+    const situation: Situation = { type: 'AFTER_UNWRAP', otherLabels: [] };
+    const completions = await getCompletions(situation, completionProvider);
+
+    const extractedCompletions = completions.filter((completion) => completion.type === 'LABEL_NAME');
+    const functionCompletions = completions.filter((completion) => completion.type === 'FUNCTION');
+
+    expect(extractedCompletions).toHaveLength(3);
+    expect(functionCompletions).toHaveLength(3);
+  });
 });

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
@@ -210,14 +210,11 @@ async function getParserCompletions(
 async function getAfterSelectorCompletions(
   logQuery: string,
   afterPipe: boolean,
-  parser: string | undefined,
   dataProvider: CompletionDataProvider
 ): Promise<Completion[]> {
   const { extractedLabelKeys, hasJSON, hasLogfmt } = await dataProvider.getParserAndLabelKeys(logQuery);
 
-  const completions: Completion[] = parser
-    ? []
-    : await getParserCompletions(afterPipe, hasJSON, hasLogfmt, extractedLabelKeys);
+  const completions: Completion[] = await getParserCompletions(afterPipe, hasJSON, hasLogfmt, extractedLabelKeys);
 
   const prefix = afterPipe ? ' ' : '| ';
 
@@ -310,7 +307,7 @@ export async function getCompletions(
         dataProvider
       );
     case 'AFTER_SELECTOR':
-      return getAfterSelectorCompletions(situation.logQuery, situation.afterPipe, situation.parser, dataProvider);
+      return getAfterSelectorCompletions(situation.logQuery, situation.afterPipe, dataProvider);
     case 'AFTER_UNWRAP':
       return getAfterUnwrapCompletions(situation.logQuery, dataProvider);
     case 'IN_AGGREGATION':

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
@@ -144,11 +144,8 @@ async function getLabelNamesForSelectorCompletions(
   }));
 }
 
-async function getInGroupingCompletions(
-  otherLabels: Label[],
-  dataProvider: CompletionDataProvider
-): Promise<Completion[]> {
-  const { extractedLabelKeys } = await dataProvider.getParserAndLabelKeys(otherLabels);
+async function getInGroupingCompletions(logQuery: string, dataProvider: CompletionDataProvider): Promise<Completion[]> {
+  const { extractedLabelKeys } = await dataProvider.getParserAndLabelKeys(logQuery);
 
   return extractedLabelKeys.map((label) => ({
     type: 'LABEL_NAME',
@@ -211,12 +208,12 @@ async function getParserCompletions(
 }
 
 async function getAfterSelectorCompletions(
-  labels: Label[],
+  logQuery: string,
   afterPipe: boolean,
   parser: string | undefined,
   dataProvider: CompletionDataProvider
 ): Promise<Completion[]> {
-  const { extractedLabelKeys, hasJSON, hasLogfmt } = await dataProvider.getParserAndLabelKeys(labels);
+  const { extractedLabelKeys, hasJSON, hasLogfmt } = await dataProvider.getParserAndLabelKeys(logQuery);
 
   const completions: Completion[] = parser
     ? []
@@ -274,8 +271,11 @@ async function getLabelValuesForMetricCompletions(
   }));
 }
 
-async function getAfterUnwrapCompletions(labels: Label[], dataProvider: CompletionDataProvider): Promise<Completion[]> {
-  const { extractedLabelKeys } = await dataProvider.getParserAndLabelKeys(labels);
+async function getAfterUnwrapCompletions(
+  logQuery: string,
+  dataProvider: CompletionDataProvider
+): Promise<Completion[]> {
+  const { extractedLabelKeys } = await dataProvider.getParserAndLabelKeys(logQuery);
 
   const labelCompletions: Completion[] = extractedLabelKeys.map((label) => ({
     type: 'LABEL_NAME',
@@ -299,7 +299,7 @@ export async function getCompletions(
     case 'IN_RANGE':
       return DURATION_COMPLETIONS;
     case 'IN_GROUPING':
-      return getInGroupingCompletions(situation.otherLabels, dataProvider);
+      return getInGroupingCompletions(situation.logQuery, dataProvider);
     case 'IN_LABEL_SELECTOR_NO_LABEL_NAME':
       return getLabelNamesForSelectorCompletions(situation.otherLabels, dataProvider);
     case 'IN_LABEL_SELECTOR_WITH_LABEL_NAME':
@@ -310,9 +310,9 @@ export async function getCompletions(
         dataProvider
       );
     case 'AFTER_SELECTOR':
-      return getAfterSelectorCompletions(situation.labels, situation.afterPipe, situation.parser, dataProvider);
+      return getAfterSelectorCompletions(situation.logQuery, situation.afterPipe, situation.parser, dataProvider);
     case 'AFTER_UNWRAP':
-      return getAfterUnwrapCompletions(situation.otherLabels, dataProvider);
+      return getAfterUnwrapCompletions(situation.logQuery, dataProvider);
     case 'IN_AGGREGATION':
       return [...FUNCTION_COMPLETIONS, ...AGGREGATION_COMPLETIONS];
     default:

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
@@ -188,7 +188,7 @@ async function getParserCompletions(
     allParsers.delete('logfmt');
     const extra = hasLevelInExtractedLabels ? '' : ' (detected)';
     completions.push({
-      type: 'DURATION',
+      type: 'PARSER',
       label: `logfmt${extra}`,
       insertText: `${prefix}logfmt`,
       documentation: hasLevelInExtractedLabels
@@ -227,7 +227,7 @@ async function getAfterSelectorCompletions(
 
   extractedLabelKeys.forEach((key) => {
     completions.push({
-      type: 'LINE_FILTER',
+      type: 'PIPE_OPERATION',
       label: `unwrap ${key}`,
       insertText: `${prefix}unwrap ${key}`,
     });

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
@@ -81,7 +81,7 @@ const UNWRAP_FUNCTION_COMPLETIONS: Completion[] = [
   },
   {
     type: 'FUNCTION',
-    label: 'duration',
+    label: 'bytes',
     documentation: 'Will convert the label value to raw bytes applying the bytes unit (e.g. 5 MiB, 3k, 1G).',
     insertText: 'bytes()',
   },
@@ -291,7 +291,6 @@ export async function getCompletions(
   situation: Situation,
   dataProvider: CompletionDataProvider
 ): Promise<Completion[]> {
-  console.log(situation);
   switch (situation.type) {
     case 'EMPTY':
     case 'AT_ROOT':

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
@@ -214,7 +214,6 @@ async function getAfterSelectorCompletions(
   labels: Label[],
   afterPipe: boolean,
   parser: string | undefined,
-  lineFilter: boolean,
   dataProvider: CompletionDataProvider
 ): Promise<Completion[]> {
   const { extractedLabelKeys, hasJSON, hasLogfmt } = await dataProvider.getParserAndLabelKeys(labels);
@@ -256,7 +255,7 @@ async function getAfterSelectorCompletions(
     documentation: explainOperator(LokiOperationId.LabelFormat),
   });
 
-  const lineFilters = lineFilter ? [] : getLineFilterCompletions(afterPipe);
+  const lineFilters = getLineFilterCompletions(afterPipe);
 
   return [...lineFilters, ...completions];
 }
@@ -292,6 +291,7 @@ export async function getCompletions(
   situation: Situation,
   dataProvider: CompletionDataProvider
 ): Promise<Completion[]> {
+  console.log(situation);
   switch (situation.type) {
     case 'EMPTY':
     case 'AT_ROOT':
@@ -311,13 +311,7 @@ export async function getCompletions(
         dataProvider
       );
     case 'AFTER_SELECTOR':
-      return getAfterSelectorCompletions(
-        situation.labels,
-        situation.afterPipe,
-        situation.parser,
-        situation.lineFilter,
-        dataProvider
-      );
+      return getAfterSelectorCompletions(situation.labels, situation.afterPipe, situation.parser, dataProvider);
     case 'AFTER_UNWRAP':
       return getAfterUnwrapCompletions(situation.otherLabels, dataProvider);
     case 'IN_AGGREGATION':

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
@@ -254,10 +254,10 @@ async function getLabelValuesForMetricCompletions(
   }));
 }
 
-async function getAfterUnwrapCompletions(labels: Label[], dataProvider: CompletionDataProvider) {
+async function getAfterUnwrapCompletions(labels: Label[], dataProvider: CompletionDataProvider): Promise<Completion[]> {
   const { extractedLabelKeys } = await dataProvider.getParserAndLabelKeys(labels);
 
-  const labelCompletions = extractedLabelKeys.map((label) => ({
+  const labelCompletions: Completion[] = extractedLabelKeys.map((label) => ({
     type: 'LABEL_NAME',
     label,
     insertText: label,
@@ -276,7 +276,7 @@ export async function getCompletions(
     case 'AT_ROOT':
       const historyCompletions = await getAllHistoryCompletions(dataProvider);
       return [...historyCompletions, ...LOG_COMPLETIONS, ...AGGREGATION_COMPLETIONS, ...FUNCTION_COMPLETIONS];
-    case 'IN_DURATION':
+    case 'IN_RANGE':
       return DURATION_COMPLETIONS;
     case 'IN_GROUPING':
       return getInGroupingCompletions(situation.otherLabels, dataProvider);

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
@@ -66,6 +66,27 @@ const DURATION_COMPLETIONS: Completion[] = ['$__interval', '$__range', '1m', '5m
   })
 );
 
+const UNWRAP_FUNCTION_COMPLETIONS: Completion[] = [
+  {
+    type: 'FUNCTION',
+    label: 'duration_seconds',
+    documentation: 'Will convert the label value in seconds from the go duration format (e.g 5m, 24s30ms).',
+    insertText: 'duration_seconds()',
+  },
+  {
+    type: 'FUNCTION',
+    label: 'duration',
+    documentation: 'Short version of duration_seconds().',
+    insertText: 'duration()',
+  },
+  {
+    type: 'FUNCTION',
+    label: 'duration',
+    documentation: 'Will convert the label value to raw bytes applying the bytes unit (e.g. 5 MiB, 3k, 1G).',
+    insertText: 'bytes()',
+  },
+];
+
 const LINE_FILTER_COMPLETIONS = [
   {
     operator: '|=',
@@ -233,6 +254,19 @@ async function getLabelValuesForMetricCompletions(
   }));
 }
 
+async function getAfterUnwrapCompletions(labels: Label[], dataProvider: CompletionDataProvider) {
+  const { extractedLabelKeys } = await dataProvider.getParserAndLabelKeys(labels);
+
+  const labelCompletions = extractedLabelKeys.map((label) => ({
+    type: 'LABEL_NAME',
+    label,
+    insertText: label,
+    triggerOnInsert: false,
+  }));
+
+  return [...labelCompletions, ...UNWRAP_FUNCTION_COMPLETIONS];
+}
+
 export async function getCompletions(
   situation: Situation,
   dataProvider: CompletionDataProvider
@@ -257,6 +291,8 @@ export async function getCompletions(
       );
     case 'AFTER_SELECTOR':
       return getAfterSelectorCompletions(situation.labels, situation.afterPipe, dataProvider);
+    case 'AFTER_UNWRAP':
+      return getAfterUnwrapCompletions(situation.otherLabels, dataProvider);
     case 'IN_AGGREGATION':
       return [...FUNCTION_COMPLETIONS, ...AGGREGATION_COMPLETIONS];
     default:

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.test.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.test.ts
@@ -43,6 +43,8 @@ describe('situation', () => {
       type: 'AFTER_SELECTOR',
       afterPipe: false,
       labels: [{ name: 'level', value: 'info', op: '=' }],
+      lineFilter: false,
+      parser: undefined,
     });
 
     // should not trigger AFTER_SELECTOR before the selector
@@ -55,18 +57,24 @@ describe('situation', () => {
       type: 'AFTER_SELECTOR',
       afterPipe: false,
       labels: [{ name: 'level', value: 'info', op: '=' }],
+      lineFilter: false,
+      parser: 'json',
     });
 
     assertSituation('{level="info"} | json | ^', {
       type: 'AFTER_SELECTOR',
       afterPipe: true,
       labels: [{ name: 'level', value: 'info', op: '=' }],
+      lineFilter: false,
+      parser: 'json',
     });
 
     assertSituation('count_over_time({level="info"}^[10s])', {
       type: 'AFTER_SELECTOR',
       afterPipe: false,
       labels: [{ name: 'level', value: 'info', op: '=' }],
+      lineFilter: false,
+      parser: undefined,
     });
 
     // should not trigger AFTER_SELECTOR before the selector
@@ -77,6 +85,16 @@ describe('situation', () => {
       type: 'AFTER_SELECTOR',
       afterPipe: false,
       labels: [{ name: 'level', value: 'info', op: '=' }],
+      lineFilter: false,
+      parser: undefined,
+    });
+
+    assertSituation('{level="info"} |= "a" | logfmt ^', {
+      type: 'AFTER_SELECTOR',
+      afterPipe: false,
+      labels: [{ name: 'level', value: 'info', op: '=' }],
+      lineFilter: true,
+      parser: 'logfmt',
     });
   });
 

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.test.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.test.ts
@@ -169,6 +169,11 @@ describe('situation', () => {
         logQuery: '{cluster="ops-tools1",container="ingress-nginx"}| json | __error__ = ""',
       }
     );
+
+    assertSituation('sum(sum_over_time({place="luna"} | unwrap ^ [5m])) by (level)', {
+      type: 'AFTER_UNWRAP',
+      logQuery: '{place="luna"}',
+    });
   });
 
   it.each(['count_over_time({job="mysql"}[^])', 'rate({instance="server\\1"}[^])', 'rate({}[^'])(

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.test.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.test.ts
@@ -43,7 +43,6 @@ describe('situation', () => {
       type: 'AFTER_SELECTOR',
       afterPipe: false,
       labels: [{ name: 'level', value: 'info', op: '=' }],
-      lineFilter: false,
       parser: undefined,
     });
 
@@ -57,7 +56,7 @@ describe('situation', () => {
       type: 'AFTER_SELECTOR',
       afterPipe: false,
       labels: [{ name: 'level', value: 'info', op: '=' }],
-      lineFilter: false,
+
       parser: 'json',
     });
 
@@ -65,7 +64,6 @@ describe('situation', () => {
       type: 'AFTER_SELECTOR',
       afterPipe: true,
       labels: [{ name: 'level', value: 'info', op: '=' }],
-      lineFilter: false,
       parser: 'json',
     });
 
@@ -73,7 +71,6 @@ describe('situation', () => {
       type: 'AFTER_SELECTOR',
       afterPipe: false,
       labels: [{ name: 'level', value: 'info', op: '=' }],
-      lineFilter: false,
       parser: undefined,
     });
 
@@ -85,7 +82,6 @@ describe('situation', () => {
       type: 'AFTER_SELECTOR',
       afterPipe: false,
       labels: [{ name: 'level', value: 'info', op: '=' }],
-      lineFilter: false,
       parser: undefined,
     });
 
@@ -93,7 +89,6 @@ describe('situation', () => {
       type: 'AFTER_SELECTOR',
       afterPipe: false,
       labels: [{ name: 'level', value: 'info', op: '=' }],
-      lineFilter: true,
       parser: 'logfmt',
     });
   });

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.test.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.test.ts
@@ -137,6 +137,24 @@ describe('situation', () => {
     });
   });
 
+  it('identifies AFTER_UNWRAP autocomplete situations', () => {
+    assertSituation('sum(count_over_time({one="val1"} | unwrap^', {
+      type: 'AFTER_UNWRAP',
+      otherLabels: [{ name: 'one', value: 'val1', op: '=' }],
+    });
+
+    assertSituation(
+      'quantile_over_time(0.99, {cluster="ops-tools1",container="ingress-nginx"} | json | __error__ = "" | unwrap ^',
+      {
+        type: 'AFTER_UNWRAP',
+        otherLabels: [
+          { name: 'cluster', value: 'ops-tools1', op: '=' },
+          { name: 'container', value: 'ingress-nginx', op: '=' },
+        ],
+      }
+    );
+  });
+
   it('handles label values', () => {
     assertSituation('{job=^}', {
       type: 'IN_LABEL_SELECTOR_WITH_LABEL_NAME',

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.test.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.test.ts
@@ -157,7 +157,7 @@ describe('situation', () => {
   });
 
   it('identifies AFTER_UNWRAP autocomplete situations', () => {
-    assertSituation('sum(count_over_time({one="val1"} | unwrap^', {
+    assertSituation('sum(sum_over_time({one="val1"} | unwrap^', {
       type: 'AFTER_UNWRAP',
       logQuery: '{one="val1"}',
     });

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.test.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.test.ts
@@ -155,6 +155,15 @@ describe('situation', () => {
     );
   });
 
+  it.each(['count_over_time({job="mysql"}[^])', 'rate({instance="server\\1"}[^])', 'rate({}[^'])(
+    'identifies IN_RANGE autocomplete situations in metric query %s',
+    (query: string) => {
+      assertSituation(query, {
+        type: 'IN_RANGE',
+      });
+    }
+  );
+
   it('handles label values', () => {
     assertSituation('{job=^}', {
       type: 'IN_LABEL_SELECTOR_WITH_LABEL_NAME',

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.test.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.test.ts
@@ -26,15 +26,19 @@ function assertSituation(situation: string, expectedSituation: Situation | null)
 }
 
 describe('situation', () => {
-  it('handles things', () => {
+  it('identifies EMPTY autocomplete situations', () => {
     assertSituation('^', {
       type: 'EMPTY',
     });
+  });
 
+  it('identifies EMPTY autocomplete situations', () => {
     assertSituation('s^', {
       type: 'AT_ROOT',
     });
+  });
 
+  it('identifies AFTER_SELECTOR autocomplete situations', () => {
     assertSituation('{level="info"} ^', {
       type: 'AFTER_SELECTOR',
       afterPipe: false,
@@ -74,18 +78,27 @@ describe('situation', () => {
       afterPipe: false,
       labels: [{ name: 'level', value: 'info', op: '=' }],
     });
+  });
 
+  it('identifies IN_AGGREGATION autocomplete situations', () => {
     assertSituation('sum(^)', {
       type: 'IN_AGGREGATION',
     });
   });
 
-  it('handles label names', () => {
+  it('identifies IN_LABEL_SELECTOR_NO_LABEL_NAME autocomplete situations', () => {
     assertSituation('{^}', {
       type: 'IN_LABEL_SELECTOR_NO_LABEL_NAME',
       otherLabels: [],
     });
 
+    assertSituation('sum({^})', {
+      type: 'IN_LABEL_SELECTOR_NO_LABEL_NAME',
+      otherLabels: [],
+    });
+  });
+
+  it('identifies labels from queries', () => {
     assertSituation('sum(count_over_time({level="info"})) by (^)', {
       type: 'IN_GROUPING',
       otherLabels: [{ name: 'level', value: 'info', op: '=' }],

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.test.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.test.ts
@@ -43,7 +43,6 @@ describe('situation', () => {
       type: 'AFTER_SELECTOR',
       afterPipe: false,
       logQuery: '{level="info"}',
-      parser: undefined,
     });
 
     // should not trigger AFTER_SELECTOR before the selector
@@ -56,21 +55,18 @@ describe('situation', () => {
       type: 'AFTER_SELECTOR',
       afterPipe: false,
       logQuery: '{level="info"} | json',
-      parser: 'json',
     });
 
     assertSituation('{level="info"} | json | ^', {
       type: 'AFTER_SELECTOR',
       afterPipe: true,
       logQuery: '{level="info"} | json |',
-      parser: 'json',
     });
 
     assertSituation('count_over_time({level="info"}^[10s])', {
       type: 'AFTER_SELECTOR',
       afterPipe: false,
       logQuery: '{level="info"}',
-      parser: undefined,
     });
 
     // should not trigger AFTER_SELECTOR before the selector
@@ -81,21 +77,18 @@ describe('situation', () => {
       type: 'AFTER_SELECTOR',
       afterPipe: false,
       logQuery: '{level="info"}',
-      parser: undefined,
     });
 
     assertSituation('{level="info"} |= "a" | logfmt ^', {
       type: 'AFTER_SELECTOR',
       afterPipe: false,
       logQuery: '{level="info"} |= "a" | logfmt',
-      parser: 'logfmt',
     });
 
     assertSituation('sum(count_over_time({place="luna"} | logfmt |^)) by (place)', {
       type: 'AFTER_SELECTOR',
       afterPipe: true,
       logQuery: '{place="luna"}| logfmt |',
-      parser: 'logfmt',
     });
   });
 

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.test.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.test.ts
@@ -42,7 +42,7 @@ describe('situation', () => {
     assertSituation('{level="info"} ^', {
       type: 'AFTER_SELECTOR',
       afterPipe: false,
-      labels: [{ name: 'level', value: 'info', op: '=' }],
+      logQuery: '{level="info"}',
       parser: undefined,
     });
 
@@ -55,22 +55,21 @@ describe('situation', () => {
     assertSituation('{level="info"} | json ^', {
       type: 'AFTER_SELECTOR',
       afterPipe: false,
-      labels: [{ name: 'level', value: 'info', op: '=' }],
-
+      logQuery: '{level="info"} | json',
       parser: 'json',
     });
 
     assertSituation('{level="info"} | json | ^', {
       type: 'AFTER_SELECTOR',
       afterPipe: true,
-      labels: [{ name: 'level', value: 'info', op: '=' }],
+      logQuery: '{level="info"} | json |',
       parser: 'json',
     });
 
     assertSituation('count_over_time({level="info"}^[10s])', {
       type: 'AFTER_SELECTOR',
       afterPipe: false,
-      labels: [{ name: 'level', value: 'info', op: '=' }],
+      logQuery: '{level="info"}',
       parser: undefined,
     });
 
@@ -81,14 +80,21 @@ describe('situation', () => {
     assertSituation('count_over_time({level="info"}^)', {
       type: 'AFTER_SELECTOR',
       afterPipe: false,
-      labels: [{ name: 'level', value: 'info', op: '=' }],
+      logQuery: '{level="info"}',
       parser: undefined,
     });
 
     assertSituation('{level="info"} |= "a" | logfmt ^', {
       type: 'AFTER_SELECTOR',
       afterPipe: false,
-      labels: [{ name: 'level', value: 'info', op: '=' }],
+      logQuery: '{level="info"} |= "a" | logfmt',
+      parser: 'logfmt',
+    });
+
+    assertSituation('sum(count_over_time({place="luna"} | logfmt |^)) by (place)', {
+      type: 'AFTER_SELECTOR',
+      afterPipe: true,
+      logQuery: '{place="luna"}| logfmt |',
       parser: 'logfmt',
     });
   });
@@ -114,12 +120,12 @@ describe('situation', () => {
   it('identifies labels from queries', () => {
     assertSituation('sum(count_over_time({level="info"})) by (^)', {
       type: 'IN_GROUPING',
-      otherLabels: [{ name: 'level', value: 'info', op: '=' }],
+      logQuery: '{level="info"}',
     });
 
     assertSituation('sum by (^) (count_over_time({level="info"}))', {
       type: 'IN_GROUPING',
-      otherLabels: [{ name: 'level', value: 'info', op: '=' }],
+      logQuery: '{level="info"}',
     });
 
     assertSituation('{one="val1",two!="val2",three=~"val3",four!~"val4",^}', {
@@ -153,17 +159,14 @@ describe('situation', () => {
   it('identifies AFTER_UNWRAP autocomplete situations', () => {
     assertSituation('sum(count_over_time({one="val1"} | unwrap^', {
       type: 'AFTER_UNWRAP',
-      otherLabels: [{ name: 'one', value: 'val1', op: '=' }],
+      logQuery: '{one="val1"}',
     });
 
     assertSituation(
       'quantile_over_time(0.99, {cluster="ops-tools1",container="ingress-nginx"} | json | __error__ = "" | unwrap ^',
       {
         type: 'AFTER_UNWRAP',
-        otherLabels: [
-          { name: 'cluster', value: 'ops-tools1', op: '=' },
-          { name: 'container', value: 'ingress-nginx', op: '=' },
-        ],
+        logQuery: '{cluster="ops-tools1",container="ingress-nginx"}| json | __error__ = ""',
       }
     );
   });

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.ts
@@ -20,9 +20,7 @@ import {
   LiteralExpr,
   MetricExpr,
   UnwrapExpr,
-  LineFilter,
   LabelParser,
-  LineFilters,
 } from '@grafana/lezer-logql';
 
 type Direction = 'parent' | 'firstChild' | 'lastChild' | 'nextSibling';
@@ -121,7 +119,6 @@ export type Situation =
       type: 'AFTER_SELECTOR';
       afterPipe: boolean;
       labels: Label[];
-      lineFilter: boolean;
       parser?: string;
     }
   | {
@@ -260,29 +257,6 @@ function getLabels(selectorNode: SyntaxNode, text: string): Label[] {
   labels.reverse();
 
   return labels;
-}
-
-function hasLineFilter(node: SyntaxNode, afterPipe: boolean) {
-  const path: Path = afterPipe
-    ? [
-        ['lastChild', PipelineExpr],
-        ['firstChild', PipelineExpr],
-        ['firstChild', PipelineExpr],
-        ['firstChild', PipelineStage],
-        ['firstChild', LineFilters],
-        ['firstChild', LineFilter],
-      ]
-    : [
-        ['lastChild', PipelineExpr],
-        ['firstChild', PipelineExpr],
-        ['firstChild', PipelineStage],
-        ['firstChild', LineFilters],
-        ['firstChild', LineFilter],
-      ];
-
-  const lineFilterNode = walk(node, path);
-
-  return lineFilterNode ? true : false;
 }
 
 function getParser(node: SyntaxNode, text: string, afterPipe: boolean) {
@@ -507,14 +481,12 @@ function resolveLogOrLogRange(node: SyntaxNode, text: string, pos: number, after
   }
 
   const labels = getLabels(selectorNode, text);
-  const lineFilter = hasLineFilter(node, afterPipe);
   const parser = getParser(node, text, afterPipe);
 
   return {
     type: 'AFTER_SELECTOR',
     afterPipe,
     labels,
-    lineFilter,
     parser,
   };
 }

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.ts
@@ -169,7 +169,7 @@ const RESOLVERS: Resolver[] = [
     fun: resolveLogRangeFromError,
   },
   {
-    path: [ERROR_NODE_ID, LiteralExpr, MetricExpr, VectorAggregationExpr, MetricExpr, Expr, LogQL],
+    path: [ERROR_NODE_ID, LiteralExpr, MetricExpr, VectorAggregationExpr],
     fun: () => ({ type: 'IN_AGGREGATION' }),
   },
   {

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.ts
@@ -20,11 +20,9 @@ import {
   LiteralExpr,
   MetricExpr,
   UnwrapExpr,
-  LabelParser,
-  JsonExpressionParser,
 } from '@grafana/lezer-logql';
 
-import { getLogQueryFromMetricsQuery, getParser } from '../../../queryUtils';
+import { getLogQueryFromMetricsQuery, getParserFromQuery } from '../../../queryUtils';
 
 type Direction = 'parent' | 'firstChild' | 'lastChild' | 'nextSibling';
 type NodeType = number;
@@ -456,7 +454,7 @@ function resolveLogOrLogRange(node: SyntaxNode, text: string, pos: number, after
     return null;
   }
 
-  const parser = getParser(text);
+  const parser = getParserFromQuery(text);
 
   return {
     type: 'AFTER_SELECTOR',

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.ts
@@ -183,6 +183,10 @@ const RESOLVERS: Resolver[] = [
     path: [ERROR_NODE_ID, UnwrapExpr],
     fun: resolveAfterUnwrap,
   },
+  {
+    path: [UnwrapExpr],
+    fun: resolveAfterUnwrap,
+  },
 ];
 
 const LABEL_OP_MAP = new Map<string, LabelOperator>([
@@ -261,16 +265,6 @@ function getLabels(selectorNode: SyntaxNode, text: string): Label[] {
 }
 
 function resolveAfterUnwrap(node: SyntaxNode, text: string, pos: number): Situation | null {
-  const selectorNode = walk(node, [
-    ['parent', UnwrapExpr],
-    ['parent', LogRangeExpr],
-    ['firstChild', Selector],
-  ]);
-
-  if (selectorNode === null) {
-    return null;
-  }
-
   return {
     type: 'AFTER_UNWRAP',
     logQuery: getLogQueryFromMetricsQuery(text).trim(),

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.ts
@@ -95,7 +95,7 @@ export type Situation =
       type: 'AT_ROOT';
     }
   | {
-      type: 'IN_DURATION';
+      type: 'IN_RANGE';
     }
   | {
       type: 'IN_AGGREGATION';
@@ -428,7 +428,7 @@ function resolveTopLevel(node: SyntaxNode, text: string, pos: number): Situation
 
 function resolveDurations(node: SyntaxNode, text: string, pos: number): Situation {
   return {
-    type: 'IN_DURATION',
+    type: 'IN_RANGE',
   };
 }
 

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.ts
@@ -22,7 +22,7 @@ import {
   UnwrapExpr,
 } from '@grafana/lezer-logql';
 
-import { getLogQueryFromMetricsQuery, getParserFromQuery } from '../../../queryUtils';
+import { getLogQueryFromMetricsQuery } from '../../../queryUtils';
 
 type Direction = 'parent' | 'firstChild' | 'lastChild' | 'nextSibling';
 type NodeType = number;
@@ -119,7 +119,6 @@ export type Situation =
   | {
       type: 'AFTER_SELECTOR';
       afterPipe: boolean;
-      parser?: string;
       logQuery: string;
     }
   | {
@@ -448,12 +447,9 @@ function resolveLogOrLogRange(node: SyntaxNode, text: string, pos: number, after
     return null;
   }
 
-  const parser = getParserFromQuery(text);
-
   return {
     type: 'AFTER_SELECTOR',
     afterPipe,
-    parser,
     logQuery: getLogQueryFromMetricsQuery(text).trim(),
   };
 }

--- a/public/app/plugins/datasource/loki/queryUtils.test.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.test.ts
@@ -6,6 +6,7 @@ import {
   isQueryWithParser,
   isValidQuery,
   parseToNodeNamesArray,
+  getParserFromQuery,
 } from './queryUtils';
 import { LokiQuery, LokiQueryType } from './types';
 
@@ -247,5 +248,18 @@ describe('isQueryWithLabelFormat', () => {
 
   it('returns false if metrics query without label format', () => {
     expect(isQueryWithLabelFormat('rate({job="grafana"} [5m])')).toBe(false);
+  });
+});
+
+describe('getParserFromQuery', () => {
+  it('returns no parser', () => {
+    expect(getParserFromQuery('{job="grafana"}')).toBeUndefined();
+  });
+
+  it.each(['json', 'logfmt', 'pattern', 'regexp', 'unpack'])('detects %s parser', (parser: string) => {
+    expect(getParserFromQuery(`{job="grafana"} | ${parser}`)).toBe(parser);
+    expect(getParserFromQuery(`sum(count_over_time({place="luna"} | ${parser} | unwrap counter )) by (place)`)).toBe(
+      parser
+    );
   });
 });

--- a/public/app/plugins/datasource/loki/queryUtils.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.ts
@@ -158,13 +158,14 @@ export function isQueryWithParser(query: string): { queryWithParser: boolean; pa
   return { queryWithParser: parserCount > 0, parserCount };
 }
 
-export function getParser(query: string) {
+export function getParserFromQuery(query: string) {
   const tree = parser.parse(query);
   let logParser;
   tree.iterate({
-    enter: (node: SyntaxNode) => {
+    enter: (node: SyntaxNode): false | void => {
       if (node.type.id === LabelParser || node.type.id === JsonExpressionParser) {
-        logParser = query.substring(node.from, node.to);
+        logParser = query.substring(node.from, node.to).trim();
+        return false;
       }
     },
   });

--- a/public/app/plugins/datasource/loki/queryUtils.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.ts
@@ -158,6 +158,20 @@ export function isQueryWithParser(query: string): { queryWithParser: boolean; pa
   return { queryWithParser: parserCount > 0, parserCount };
 }
 
+export function getParser(query: string) {
+  const tree = parser.parse(query);
+  let logParser;
+  tree.iterate({
+    enter: (node: SyntaxNode) => {
+      if (node.type.id === LabelParser || node.type.id === JsonExpressionParser) {
+        logParser = query.substring(node.from, node.to);
+      }
+    },
+  });
+
+  return logParser;
+}
+
 export function isQueryPipelineErrorFiltering(query: string): boolean {
   let isQueryPipelineErrorFiltering = false;
   const tree = parser.parse(query);


### PR DESCRIPTION
**What is this feature?**

This PR adds several improvements to our autocompletion support for the Monaco query editor.

- Improved `unwrap` identification and suggestion.
- Improved suggestions for `unwrap`: labels or functions.
- Testing and coverage improvements.
- We now send the full log query to get a data sample and extract labels, instead of just the query labels.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/57683

**Special notes for your reviewer**:

Compare previous with current suggestion behavior.

https://user-images.githubusercontent.com/1069378/203310123-d227255e-f1ef-4b82-a871-60bae3248e8f.mov

Demo of sending full logs query for extracted labels:

https://user-images.githubusercontent.com/1069378/203346970-d7106c93-070e-436f-95b9-b1f1bc291dc8.mov
