### PR TITLE
CloudWatch: fix custom namespace for listing dimension keys, refactor to non-pointer types, add test assertions, rename packages

### DIFF
--- a/pkg/tsdb/cloudwatch/annotation_query_test.go
+++ b/pkg/tsdb/cloudwatch/annotation_query_test.go
@@ -32,7 +32,7 @@ func TestQuery_AnnotationQuery(t *testing.T) {
 	t.Run("DescribeAlarmsForMetric is called with minimum parameters", func(t *testing.T) {
 		client = fakeCWAnnotationsClient{describeAlarmsForMetricOutput: &cloudwatch.DescribeAlarmsForMetricOutput{}}
 		im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-			return DataSource{Settings: &models.CloudWatchSettings{}}, nil
+			return DataSource{Settings: models.CloudWatchSettings{}}, nil
 		})
 
 		executor := newExecutor(im, newTestConfig(), &fakeSessionCache{}, featuremgmt.WithFeatures())
@@ -66,7 +66,7 @@ func TestQuery_AnnotationQuery(t *testing.T) {
 	t.Run("DescribeAlarms is called when prefixMatching is true", func(t *testing.T) {
 		client = fakeCWAnnotationsClient{describeAlarmsOutput: &cloudwatch.DescribeAlarmsOutput{}}
 		im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-			return DataSource{Settings: &models.CloudWatchSettings{}}, nil
+			return DataSource{Settings: models.CloudWatchSettings{}}, nil
 		})
 
 		executor := newExecutor(im, newTestConfig(), &fakeSessionCache{}, featuremgmt.WithFeatures())

--- a/pkg/tsdb/cloudwatch/cloudwatch.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch.go
@@ -50,7 +50,7 @@ type DataQueryJson struct {
 }
 
 type DataSource struct {
-	Settings   *models.CloudWatchSettings
+	Settings   models.CloudWatchSettings
 	HTTPClient *http.Client
 }
 

--- a/pkg/tsdb/cloudwatch/cloudwatch_test.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch_test.go
@@ -52,7 +52,7 @@ func TestNewInstanceSettings(t *testing.T) {
 				},
 			},
 			expectedDS: DataSource{
-				Settings: &models.CloudWatchSettings{
+				Settings: models.CloudWatchSettings{
 					AWSDatasourceSettings: awsds.AWSDatasourceSettings{
 						Profile:       "foo",
 						Region:        "us-east2",
@@ -112,7 +112,7 @@ func Test_CheckHealth(t *testing.T) {
 	t.Run("successfully query metrics and logs", func(t *testing.T) {
 		client = fakeCheckHealthClient{}
 		im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-			return DataSource{Settings: &models.CloudWatchSettings{}}, nil
+			return DataSource{Settings: models.CloudWatchSettings{}}, nil
 		})
 		executor := newExecutor(im, newTestConfig(), &fakeSessionCache{}, featuremgmt.WithFeatures())
 
@@ -133,7 +133,7 @@ func Test_CheckHealth(t *testing.T) {
 				return nil, fmt.Errorf("some logs query error")
 			}}
 		im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-			return DataSource{Settings: &models.CloudWatchSettings{}}, nil
+			return DataSource{Settings: models.CloudWatchSettings{}}, nil
 		})
 		executor := newExecutor(im, newTestConfig(), &fakeSessionCache{}, featuremgmt.WithFeatures())
 
@@ -154,7 +154,7 @@ func Test_CheckHealth(t *testing.T) {
 				return fmt.Errorf("some list metrics error")
 			}}
 		im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-			return DataSource{Settings: &models.CloudWatchSettings{}}, nil
+			return DataSource{Settings: models.CloudWatchSettings{}}, nil
 		})
 		executor := newExecutor(im, newTestConfig(), &fakeSessionCache{}, featuremgmt.WithFeatures())
 
@@ -172,7 +172,7 @@ func Test_CheckHealth(t *testing.T) {
 	t.Run("fail to get clients", func(t *testing.T) {
 		client = fakeCheckHealthClient{}
 		im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-			return DataSource{Settings: &models.CloudWatchSettings{}}, nil
+			return DataSource{Settings: models.CloudWatchSettings{}}, nil
 		})
 		executor := newExecutor(im, newTestConfig(), &fakeSessionCache{getSession: func(c awsds.SessionConfig) (*session.Session, error) {
 			return nil, fmt.Errorf("some sessions error")
@@ -203,7 +203,7 @@ func Test_executeLogAlertQuery(t *testing.T) {
 	t.Run("getCWLogsClient is called with region from input JSON", func(t *testing.T) {
 		cli = fakeCWLogsClient{queryResults: cloudwatchlogs.GetQueryResultsOutput{Status: aws.String("Complete")}}
 		im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-			return DataSource{Settings: &models.CloudWatchSettings{}}, nil
+			return DataSource{Settings: models.CloudWatchSettings{}}, nil
 		})
 		sess := fakeSessionCache{}
 		executor := newExecutor(im, newTestConfig(), &sess, featuremgmt.WithFeatures())
@@ -229,7 +229,7 @@ func Test_executeLogAlertQuery(t *testing.T) {
 	t.Run("getCWLogsClient is called with region from instance manager when region is default", func(t *testing.T) {
 		cli = fakeCWLogsClient{queryResults: cloudwatchlogs.GetQueryResultsOutput{Status: aws.String("Complete")}}
 		im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-			return DataSource{Settings: &models.CloudWatchSettings{AWSDatasourceSettings: awsds.AWSDatasourceSettings{Region: "instance manager's region"}}}, nil
+			return DataSource{Settings: models.CloudWatchSettings{AWSDatasourceSettings: awsds.AWSDatasourceSettings{Region: "instance manager's region"}}}, nil
 		})
 		sess := fakeSessionCache{}
 
@@ -266,7 +266,7 @@ func TestQuery_ResourceRequest_DescribeAllLogGroups(t *testing.T) {
 	}
 
 	im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-		return DataSource{Settings: &models.CloudWatchSettings{}}, nil
+		return DataSource{Settings: models.CloudWatchSettings{}}, nil
 	})
 
 	executor := newExecutor(im, newTestConfig(), &fakeSessionCache{}, featuremgmt.WithFeatures())
@@ -412,7 +412,7 @@ func TestQuery_ResourceRequest_DescribeLogGroups(t *testing.T) {
 	}
 
 	im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-		return DataSource{Settings: &models.CloudWatchSettings{}}, nil
+		return DataSource{Settings: models.CloudWatchSettings{}}, nil
 	})
 
 	executor := newExecutor(im, newTestConfig(), &fakeSessionCache{}, featuremgmt.WithFeatures())
@@ -467,7 +467,7 @@ func TestQuery_ResourceRequest_DescribeLogGroups(t *testing.T) {
 		}
 
 		im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-			return DataSource{Settings: &models.CloudWatchSettings{}}, nil
+			return DataSource{Settings: models.CloudWatchSettings{}}, nil
 		})
 
 		executor := newExecutor(im, newTestConfig(), &fakeSessionCache{}, featuremgmt.WithFeatures())
@@ -505,7 +505,7 @@ func TestQuery_ResourceRequest_DescribeLogGroups(t *testing.T) {
 		}
 
 		im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-			return DataSource{Settings: &models.CloudWatchSettings{}}, nil
+			return DataSource{Settings: models.CloudWatchSettings{}}, nil
 		})
 
 		executor := newExecutor(im, newTestConfig(), &fakeSessionCache{}, featuremgmt.WithFeatures())
@@ -546,7 +546,7 @@ func Test_CloudWatch_CallResource_Integration_Test(t *testing.T) {
 		return &api
 	}
 	im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-		return DataSource{Settings: &models.CloudWatchSettings{}}, nil
+		return DataSource{Settings: models.CloudWatchSettings{}}, nil
 	})
 
 	t.Run("Should handle dimension value request and return values from the api", func(t *testing.T) {

--- a/pkg/tsdb/cloudwatch/cloudwatch_test.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/mocks"
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/models"
+	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/models/resources"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -699,10 +700,10 @@ func Test_CloudWatch_CallResource_Integration_Test(t *testing.T) {
 		sent := sender.Response
 		require.NotNil(t, sent)
 		require.Equal(t, http.StatusOK, sent.Status)
-		res := []models.Metric{}
+		res := []resources.Metric{}
 		err = json.Unmarshal(sent.Body, &res)
 		require.Nil(t, err)
-		assert.Equal(t, []models.Metric{{Name: "Test_MetricName1", Namespace: "AWS/EC2"}, {Name: "Test_MetricName2", Namespace: "AWS/EC2"}, {Name: "Test_MetricName3", Namespace: "AWS/ECS"}, {Name: "Test_MetricName10", Namespace: "AWS/ECS"}, {Name: "Test_MetricName4", Namespace: "AWS/ECS"}, {Name: "Test_MetricName5", Namespace: "AWS/Redshift"}}, res)
+		assert.Equal(t, []resources.Metric{{Name: "Test_MetricName1", Namespace: "AWS/EC2"}, {Name: "Test_MetricName2", Namespace: "AWS/EC2"}, {Name: "Test_MetricName3", Namespace: "AWS/ECS"}, {Name: "Test_MetricName10", Namespace: "AWS/ECS"}, {Name: "Test_MetricName4", Namespace: "AWS/ECS"}, {Name: "Test_MetricName5", Namespace: "AWS/Redshift"}}, res)
 	})
 }
 

--- a/pkg/tsdb/cloudwatch/log_actions_test.go
+++ b/pkg/tsdb/cloudwatch/log_actions_test.go
@@ -83,7 +83,7 @@ func TestQuery_GetLogEvents(t *testing.T) {
 			cli = fakeCWLogsClient{}
 
 			im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-				return DataSource{Settings: &models.CloudWatchSettings{}}, nil
+				return DataSource{Settings: models.CloudWatchSettings{}}, nil
 			})
 
 			executor := newExecutor(im, newTestConfig(), &fakeSessionCache{}, featuremgmt.WithFeatures())
@@ -141,7 +141,7 @@ func TestQuery_GetLogGroupFields(t *testing.T) {
 	const refID = "A"
 
 	im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-		return DataSource{Settings: &models.CloudWatchSettings{}}, nil
+		return DataSource{Settings: models.CloudWatchSettings{}}, nil
 	})
 
 	executor := newExecutor(im, newTestConfig(), &fakeSessionCache{}, featuremgmt.WithFeatures())
@@ -222,7 +222,7 @@ func TestQuery_StartQuery(t *testing.T) {
 		}
 
 		im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-			return DataSource{Settings: &models.CloudWatchSettings{}}, nil
+			return DataSource{Settings: models.CloudWatchSettings{}}, nil
 		})
 
 		executor := newExecutor(im, newTestConfig(), &fakeSessionCache{}, featuremgmt.WithFeatures())
@@ -275,7 +275,7 @@ func TestQuery_StartQuery(t *testing.T) {
 		}
 
 		im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-			return DataSource{Settings: &models.CloudWatchSettings{}}, nil
+			return DataSource{Settings: models.CloudWatchSettings{}}, nil
 		})
 
 		executor := newExecutor(im, newTestConfig(), &fakeSessionCache{}, featuremgmt.WithFeatures())
@@ -333,7 +333,7 @@ func Test_executeStartQuery(t *testing.T) {
 	t.Run("successfully parses information from JSON to StartQueryWithContext", func(t *testing.T) {
 		cli = fakeCWLogsClient{}
 		im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-			return DataSource{Settings: &models.CloudWatchSettings{}}, nil
+			return DataSource{Settings: models.CloudWatchSettings{}}, nil
 		})
 		executor := newExecutor(im, newTestConfig(), &fakeSessionCache{}, featuremgmt.WithFeatures())
 
@@ -369,7 +369,7 @@ func Test_executeStartQuery(t *testing.T) {
 	t.Run("does not populate StartQueryInput.limit when no limit provided", func(t *testing.T) {
 		cli = fakeCWLogsClient{}
 		im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-			return DataSource{Settings: &models.CloudWatchSettings{}}, nil
+			return DataSource{Settings: models.CloudWatchSettings{}}, nil
 		})
 		executor := newExecutor(im, newTestConfig(), &fakeSessionCache{}, featuremgmt.WithFeatures())
 
@@ -425,7 +425,7 @@ func TestQuery_StopQuery(t *testing.T) {
 	}
 
 	im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-		return DataSource{Settings: &models.CloudWatchSettings{}}, nil
+		return DataSource{Settings: models.CloudWatchSettings{}}, nil
 	})
 
 	timeRange := backend.TimeRange{
@@ -520,7 +520,7 @@ func TestQuery_GetQueryResults(t *testing.T) {
 	}
 
 	im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-		return DataSource{Settings: &models.CloudWatchSettings{}}, nil
+		return DataSource{Settings: models.CloudWatchSettings{}}, nil
 	})
 
 	executor := newExecutor(im, newTestConfig(), &fakeSessionCache{}, featuremgmt.WithFeatures())

--- a/pkg/tsdb/cloudwatch/metric_find_query_test.go
+++ b/pkg/tsdb/cloudwatch/metric_find_query_test.go
@@ -41,7 +41,7 @@ func TestQuery_Regions(t *testing.T) {
 		}
 
 		im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-			return DataSource{Settings: &models.CloudWatchSettings{}}, nil
+			return DataSource{Settings: models.CloudWatchSettings{}}, nil
 		})
 
 		executor := newExecutor(im, newTestConfig(), &fakeSessionCache{}, featuremgmt.WithFeatures())
@@ -108,7 +108,7 @@ func TestQuery_InstanceAttributes(t *testing.T) {
 		}
 
 		im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-			return DataSource{Settings: &models.CloudWatchSettings{}}, nil
+			return DataSource{Settings: models.CloudWatchSettings{}}, nil
 		})
 
 		filterMap := map[string][]string{
@@ -191,7 +191,7 @@ func TestQuery_EBSVolumeIDs(t *testing.T) {
 		}
 
 		im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-			return DataSource{Settings: &models.CloudWatchSettings{}}, nil
+			return DataSource{Settings: models.CloudWatchSettings{}}, nil
 		})
 
 		executor := newExecutor(im, newTestConfig(), &fakeSessionCache{}, featuremgmt.WithFeatures())
@@ -251,7 +251,7 @@ func TestQuery_ResourceARNs(t *testing.T) {
 		}
 
 		im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-			return DataSource{Settings: &models.CloudWatchSettings{}}, nil
+			return DataSource{Settings: models.CloudWatchSettings{}}, nil
 		})
 
 		tagMap := map[string][]string{

--- a/pkg/tsdb/cloudwatch/mocks/list_metrics_service.go
+++ b/pkg/tsdb/cloudwatch/mocks/list_metrics_service.go
@@ -1,8 +1,7 @@
 package mocks
 
 import (
-	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/models"
-	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/models/request"
+	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/models/resources"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -10,26 +9,26 @@ type ListMetricsServiceMock struct {
 	mock.Mock
 }
 
-func (a *ListMetricsServiceMock) GetDimensionKeysByDimensionFilter(*request.DimensionKeysRequest) ([]string, error) {
-	args := a.Called()
+func (a *ListMetricsServiceMock) GetDimensionKeysByDimensionFilter(r resources.DimensionKeysRequest) ([]string, error) {
+	args := a.Called(r)
 
 	return args.Get(0).([]string), args.Error(1)
 }
 
-func (a *ListMetricsServiceMock) GetDimensionValuesByDimensionFilter(r *request.DimensionValuesRequest) ([]string, error) {
-	args := a.Called()
+func (a *ListMetricsServiceMock) GetDimensionValuesByDimensionFilter(r resources.DimensionValuesRequest) ([]string, error) {
+	args := a.Called(r)
 
 	return args.Get(0).([]string), args.Error(1)
 }
 
-func (a *ListMetricsServiceMock) GetDimensionKeysByNamespace(string) ([]string, error) {
-	args := a.Called()
+func (a *ListMetricsServiceMock) GetDimensionKeysByNamespace(namespace string) ([]string, error) {
+	args := a.Called(namespace)
 
 	return args.Get(0).([]string), args.Error(1)
 }
 
-func (a *ListMetricsServiceMock) GetMetricsByNamespace(namespace string) ([]models.Metric, error) {
-	args := a.Called()
+func (a *ListMetricsServiceMock) GetMetricsByNamespace(namespace string) ([]resources.Metric, error) {
+	args := a.Called(namespace)
 
-	return args.Get(0).([]models.Metric), args.Error(1)
+	return args.Get(0).([]resources.Metric), args.Error(1)
 }

--- a/pkg/tsdb/cloudwatch/models/api.go
+++ b/pkg/tsdb/cloudwatch/models/api.go
@@ -2,14 +2,14 @@ package models
 
 import (
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
-	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/models/request"
+	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/models/resources"
 )
 
 type ListMetricsProvider interface {
-	GetDimensionKeysByDimensionFilter(*request.DimensionKeysRequest) ([]string, error)
+	GetDimensionKeysByDimensionFilter(resources.DimensionKeysRequest) ([]string, error)
 	GetDimensionKeysByNamespace(string) ([]string, error)
-	GetDimensionValuesByDimensionFilter(*request.DimensionValuesRequest) ([]string, error)
-	GetMetricsByNamespace(namespace string) ([]Metric, error)
+	GetDimensionValuesByDimensionFilter(resources.DimensionValuesRequest) ([]string, error)
+	GetMetricsByNamespace(namespace string) ([]resources.Metric, error)
 }
 
 type MetricsClientProvider interface {

--- a/pkg/tsdb/cloudwatch/models/request/types.go
+++ b/pkg/tsdb/cloudwatch/models/request/types.go
@@ -1,6 +1,0 @@
-package request
-
-type Dimension struct {
-	Name  string
-	Value string
-}

--- a/pkg/tsdb/cloudwatch/models/resources/dimension_keys_request.go
+++ b/pkg/tsdb/cloudwatch/models/resources/dimension_keys_request.go
@@ -1,4 +1,4 @@
-package request
+package resources
 
 import (
 	"net/url"
@@ -9,7 +9,6 @@ type DimensionKeysRequestType uint32
 const (
 	StandardDimensionKeysRequest DimensionKeysRequestType = iota
 	FilterDimensionKeysRequest
-	CustomMetricDimensionKeysRequest
 )
 
 type DimensionKeysRequest struct {
@@ -20,24 +19,20 @@ type DimensionKeysRequest struct {
 }
 
 func (q *DimensionKeysRequest) Type() DimensionKeysRequestType {
-	if isCustomNamespace(q.Namespace) {
-		return CustomMetricDimensionKeysRequest
-	}
-
-	if len(q.DimensionFilter) > 0 {
+	if isCustomNamespace(q.Namespace) || len(q.DimensionFilter) > 0 {
 		return FilterDimensionKeysRequest
 	}
 
 	return StandardDimensionKeysRequest
 }
 
-func GetDimensionKeysRequest(parameters url.Values) (*DimensionKeysRequest, error) {
+func GetDimensionKeysRequest(parameters url.Values) (DimensionKeysRequest, error) {
 	resourceRequest, err := getResourceRequest(parameters)
 	if err != nil {
-		return nil, err
+		return DimensionKeysRequest{}, err
 	}
 
-	request := &DimensionKeysRequest{
+	request := DimensionKeysRequest{
 		ResourceRequest: resourceRequest,
 		Namespace:       parameters.Get("namespace"),
 		MetricName:      parameters.Get("metricName"),
@@ -46,7 +41,7 @@ func GetDimensionKeysRequest(parameters url.Values) (*DimensionKeysRequest, erro
 
 	dimensions, err := parseDimensionFilter(parameters.Get("dimensionFilters"))
 	if err != nil {
-		return nil, err
+		return DimensionKeysRequest{}, err
 	}
 
 	request.DimensionFilter = dimensions

--- a/pkg/tsdb/cloudwatch/models/resources/dimension_values_request.go
+++ b/pkg/tsdb/cloudwatch/models/resources/dimension_values_request.go
@@ -1,4 +1,4 @@
-package request
+package resources
 
 import (
 	"net/url"
@@ -12,13 +12,13 @@ type DimensionValuesRequest struct {
 	DimensionFilter []*Dimension
 }
 
-func GetDimensionValuesRequest(parameters url.Values) (*DimensionValuesRequest, error) {
+func GetDimensionValuesRequest(parameters url.Values) (DimensionValuesRequest, error) {
 	resourceRequest, err := getResourceRequest(parameters)
 	if err != nil {
-		return nil, err
+		return DimensionValuesRequest{}, err
 	}
 
-	request := &DimensionValuesRequest{
+	request := DimensionValuesRequest{
 		ResourceRequest: resourceRequest,
 		Namespace:       parameters.Get("namespace"),
 		MetricName:      parameters.Get("metricName"),
@@ -28,7 +28,7 @@ func GetDimensionValuesRequest(parameters url.Values) (*DimensionValuesRequest, 
 
 	dimensions, err := parseDimensionFilter(parameters.Get("dimensionFilters"))
 	if err != nil {
-		return nil, err
+		return DimensionValuesRequest{}, err
 	}
 
 	request.DimensionFilter = dimensions

--- a/pkg/tsdb/cloudwatch/models/resources/dimension_values_rquest_test.go
+++ b/pkg/tsdb/cloudwatch/models/resources/dimension_values_rquest_test.go
@@ -1,4 +1,4 @@
-package request
+package resources
 
 import (
 	"testing"
@@ -7,24 +7,27 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDimensionKeyRequest(t *testing.T) {
+func TestDimensionValuesRequest(t *testing.T) {
 	t.Run("Should parse parameters without dimension filter", func(t *testing.T) {
-		request, err := GetDimensionKeysRequest(map[string][]string{
-			"region":     {"us-east-1"},
-			"namespace":  {"AWS/EC2"},
-			"metricName": {"CPUUtilization"}},
+		request, err := GetDimensionValuesRequest(map[string][]string{
+			"region":       {"us-east-1"},
+			"namespace":    {"AWS/EC2"},
+			"metricName":   {"CPUUtilization"},
+			"dimensionKey": {"InstanceId"}},
 		)
 		require.NoError(t, err)
 		assert.Equal(t, "us-east-1", request.Region)
 		assert.Equal(t, "AWS/EC2", request.Namespace)
 		assert.Equal(t, "CPUUtilization", request.MetricName)
+		assert.Equal(t, "InstanceId", request.DimensionKey)
 	})
 
 	t.Run("Should parse parameters with single valued dimension filter", func(t *testing.T) {
-		request, err := GetDimensionKeysRequest(map[string][]string{
+		request, err := GetDimensionValuesRequest(map[string][]string{
 			"region":           {"us-east-1"},
 			"namespace":        {"AWS/EC2"},
 			"metricName":       {"CPUUtilization"},
+			"dimensionKey":     {"InstanceId"},
 			"dimensionFilters": {"{\"InstanceId\": \"i-1234567890abcdef0\"}"},
 		})
 		require.NoError(t, err)
@@ -32,15 +35,17 @@ func TestDimensionKeyRequest(t *testing.T) {
 		assert.Equal(t, "AWS/EC2", request.Namespace)
 		assert.Equal(t, "CPUUtilization", request.MetricName)
 		assert.Equal(t, 1, len(request.DimensionFilter))
+		assert.Equal(t, "InstanceId", request.DimensionKey)
 		assert.Equal(t, "InstanceId", request.DimensionFilter[0].Name)
 		assert.Equal(t, "i-1234567890abcdef0", request.DimensionFilter[0].Value)
 	})
 
 	t.Run("Should parse parameters with multi-valued dimension filter", func(t *testing.T) {
-		request, err := GetDimensionKeysRequest(map[string][]string{
+		request, err := GetDimensionValuesRequest(map[string][]string{
 			"region":           {"us-east-1"},
 			"namespace":        {"AWS/EC2"},
 			"metricName":       {"CPUUtilization"},
+			"dimensionKey":     {"InstanceId"},
 			"dimensionFilters": {"{\"InstanceId\": [\"i-1234567890abcdef0\", \"i-1234567890abcdef1\"]}"},
 		})
 		require.NoError(t, err)
@@ -48,6 +53,7 @@ func TestDimensionKeyRequest(t *testing.T) {
 		assert.Equal(t, "AWS/EC2", request.Namespace)
 		assert.Equal(t, "CPUUtilization", request.MetricName)
 		assert.Equal(t, 2, len(request.DimensionFilter))
+		assert.Equal(t, "InstanceId", request.DimensionKey)
 		assert.Equal(t, "InstanceId", request.DimensionFilter[0].Name)
 		assert.Equal(t, "i-1234567890abcdef0", request.DimensionFilter[0].Value)
 		assert.Equal(t, "InstanceId", request.DimensionFilter[1].Name)
@@ -55,7 +61,7 @@ func TestDimensionKeyRequest(t *testing.T) {
 	})
 
 	t.Run("Should parse parameters with wildcard dimension filter", func(t *testing.T) {
-		request, err := GetDimensionKeysRequest(map[string][]string{
+		request, err := GetDimensionValuesRequest(map[string][]string{
 			"region":           {"us-east-1"},
 			"namespace":        {"AWS/EC2"},
 			"metricName":       {"CPUUtilization"},

--- a/pkg/tsdb/cloudwatch/models/resources/metrics_resource_request.go
+++ b/pkg/tsdb/cloudwatch/models/resources/metrics_resource_request.go
@@ -1,4 +1,4 @@
-package request
+package resources
 
 import (
 	"net/url"

--- a/pkg/tsdb/cloudwatch/models/resources/metrics_resource_request_test.go
+++ b/pkg/tsdb/cloudwatch/models/resources/metrics_resource_request_test.go
@@ -1,4 +1,4 @@
-package request
+package resources
 
 import (
 	"net/url"

--- a/pkg/tsdb/cloudwatch/models/resources/resource_request.go
+++ b/pkg/tsdb/cloudwatch/models/resources/resource_request.go
@@ -1,4 +1,4 @@
-package request
+package resources
 
 import (
 	"fmt"

--- a/pkg/tsdb/cloudwatch/models/resources/resource_request_test.go
+++ b/pkg/tsdb/cloudwatch/models/resources/resource_request_test.go
@@ -1,4 +1,4 @@
-package request
+package resources
 
 import (
 	"testing"
@@ -10,7 +10,7 @@ import (
 func TestResourceRequest(t *testing.T) {
 	t.Run("Should return an error if region is not provided", func(t *testing.T) {
 		request, err := GetDimensionValuesRequest(map[string][]string{})
-		require.Nil(t, request)
+		require.Empty(t, request)
 		assert.Equal(t, "region is required", err.Error())
 	})
 }

--- a/pkg/tsdb/cloudwatch/models/resources/types.go
+++ b/pkg/tsdb/cloudwatch/models/resources/types.go
@@ -1,0 +1,11 @@
+package resources
+
+type Dimension struct {
+	Name  string
+	Value string
+}
+
+type Metric struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+}

--- a/pkg/tsdb/cloudwatch/models/resources/utils.go
+++ b/pkg/tsdb/cloudwatch/models/resources/utils.go
@@ -1,4 +1,4 @@
-package request
+package resources
 
 import (
 	"encoding/json"

--- a/pkg/tsdb/cloudwatch/models/settings.go
+++ b/pkg/tsdb/cloudwatch/models/settings.go
@@ -13,11 +13,11 @@ type CloudWatchSettings struct {
 	Namespace string `json:"customMetricsNamespaces"`
 }
 
-func LoadCloudWatchSettings(config backend.DataSourceInstanceSettings) (*CloudWatchSettings, error) {
-	instance := &CloudWatchSettings{}
+func LoadCloudWatchSettings(config backend.DataSourceInstanceSettings) (CloudWatchSettings, error) {
+	instance := CloudWatchSettings{}
 	if config.JSONData != nil && len(config.JSONData) > 1 {
-		if err := json.Unmarshal(config.JSONData, instance); err != nil {
-			return nil, fmt.Errorf("could not unmarshal DatasourceSettings json: %w", err)
+		if err := json.Unmarshal(config.JSONData, &instance); err != nil {
+			return CloudWatchSettings{}, fmt.Errorf("could not unmarshal DatasourceSettings json: %w", err)
 		}
 	}
 

--- a/pkg/tsdb/cloudwatch/models/types.go
+++ b/pkg/tsdb/cloudwatch/models/types.go
@@ -8,7 +8,7 @@ import (
 
 type RequestContext struct {
 	MetricsClientProvider MetricsClientProvider
-	Settings              *CloudWatchSettings
+	Settings              CloudWatchSettings
 }
 
 type RequestContextFactoryFunc func(pluginCtx backend.PluginContext, region string) (reqCtx RequestContext, err error)

--- a/pkg/tsdb/cloudwatch/models/types.go
+++ b/pkg/tsdb/cloudwatch/models/types.go
@@ -35,8 +35,3 @@ type metricStatMeta struct {
 	Period int    `json:"period"`
 	Label  string `json:"label,omitempty"`
 }
-
-type Metric struct {
-	Name      string `json:"name"`
-	Namespace string `json:"namespace"`
-}

--- a/pkg/tsdb/cloudwatch/routes/dimension_keys.go
+++ b/pkg/tsdb/cloudwatch/routes/dimension_keys.go
@@ -7,12 +7,12 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/models"
-	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/models/request"
+	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/models/resources"
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/services"
 )
 
 func DimensionKeysHandler(pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, parameters url.Values) ([]byte, *models.HttpError) {
-	dimensionKeysRequest, err := request.GetDimensionKeysRequest(parameters)
+	dimensionKeysRequest, err := resources.GetDimensionKeysRequest(parameters)
 	if err != nil {
 		return nil, models.NewHttpError("error in DimensionKeyHandler", http.StatusBadRequest, err)
 	}
@@ -22,25 +22,23 @@ func DimensionKeysHandler(pluginCtx backend.PluginContext, reqCtxFactory models.
 		return nil, models.NewHttpError("error in DimensionKeyHandler", http.StatusInternalServerError, err)
 	}
 
-	dimensionKeys := []string{}
+	var response []string
 	switch dimensionKeysRequest.Type() {
-	case request.StandardDimensionKeysRequest:
-		dimensionKeys, err = services.GetHardCodedDimensionKeysByNamespace(dimensionKeysRequest.Namespace)
-	case request.FilterDimensionKeysRequest:
-		dimensionKeys, err = service.GetDimensionKeysByDimensionFilter(dimensionKeysRequest)
-	case request.CustomMetricDimensionKeysRequest:
-		dimensionKeys, err = service.GetDimensionKeysByNamespace(dimensionKeysRequest.Namespace)
+	case resources.FilterDimensionKeysRequest:
+		response, err = service.GetDimensionKeysByDimensionFilter(dimensionKeysRequest)
+	default:
+		response, err = services.GetHardCodedDimensionKeysByNamespace(dimensionKeysRequest.Namespace)
 	}
 	if err != nil {
 		return nil, models.NewHttpError("error in DimensionKeyHandler", http.StatusInternalServerError, err)
 	}
 
-	dimensionKeysResponse, err := json.Marshal(dimensionKeys)
+	jsonResponse, err := json.Marshal(response)
 	if err != nil {
 		return nil, models.NewHttpError("error in DimensionKeyHandler", http.StatusInternalServerError, err)
 	}
 
-	return dimensionKeysResponse, nil
+	return jsonResponse, nil
 }
 
 // newListMetricsService is an list metrics service factory.

--- a/pkg/tsdb/cloudwatch/routes/dimension_keys_test.go
+++ b/pkg/tsdb/cloudwatch/routes/dimension_keys_test.go
@@ -8,7 +8,9 @@ import (
 	"testing"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/models/resources"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/infra/log/logtest"
@@ -22,7 +24,7 @@ var logger = &logtest.Fake{}
 func Test_DimensionKeys_Route(t *testing.T) {
 	t.Run("calls FilterDimensionKeysRequest when a StandardDimensionKeysRequest is passed", func(t *testing.T) {
 		mockListMetricsService := mocks.ListMetricsServiceMock{}
-		mockListMetricsService.On("GetDimensionKeysByDimensionFilter").Return([]string{}, nil)
+		mockListMetricsService.On("GetDimensionKeysByDimensionFilter", mock.Anything).Return([]string{}, nil).Once()
 		newListMetricsService = func(pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.ListMetricsProvider, error) {
 			return &mockListMetricsService, nil
 		}
@@ -30,20 +32,12 @@ func Test_DimensionKeys_Route(t *testing.T) {
 		req := httptest.NewRequest("GET", `/dimension-keys?region=us-east-2&namespace=AWS/EC2&metricName=CPUUtilization&dimensionFilters={"NodeID":["Shared"],"stage":["QueryCommit"]}`, nil)
 		handler := http.HandlerFunc(ResourceRequestMiddleware(DimensionKeysHandler, logger, nil))
 		handler.ServeHTTP(rr, req)
-		mockListMetricsService.AssertNumberOfCalls(t, "GetDimensionKeysByDimensionFilter", 1)
-	})
-
-	t.Run("calls GetDimensionKeysByNamespace when a CustomMetricDimensionKeysRequest is passed", func(t *testing.T) {
-		mockListMetricsService := mocks.ListMetricsServiceMock{}
-		mockListMetricsService.On("GetDimensionKeysByNamespace").Return([]string{}, nil)
-		newListMetricsService = func(pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.ListMetricsProvider, error) {
-			return &mockListMetricsService, nil
-		}
-		rr := httptest.NewRecorder()
-		req := httptest.NewRequest("GET", `/dimension-keys?region=us-east-2&namespace=custom&metricName=CPUUtilization`, nil)
-		handler := http.HandlerFunc(ResourceRequestMiddleware(DimensionKeysHandler, logger, nil))
-		handler.ServeHTTP(rr, req)
-		mockListMetricsService.AssertNumberOfCalls(t, "GetDimensionKeysByNamespace", 1)
+		mockListMetricsService.AssertCalled(t, "GetDimensionKeysByDimensionFilter", resources.DimensionKeysRequest{
+			ResourceRequest: &resources.ResourceRequest{Region: "us-east-2"},
+			Namespace:       "AWS/EC2",
+			MetricName:      "CPUUtilization",
+			DimensionFilter: []*resources.Dimension{{Name: "NodeID", Value: "Shared"}, {Name: "stage", Value: "QueryCommit"}},
+		})
 	})
 
 	t.Run("calls GetHardCodedDimensionKeysByNamespace when a StandardDimensionKeysRequest is passed", func(t *testing.T) {
@@ -62,7 +56,7 @@ func Test_DimensionKeys_Route(t *testing.T) {
 		req := httptest.NewRequest("GET", "/dimension-keys?region=us-east-2&namespace=AWS/EC2&metricName=CPUUtilization", nil)
 		handler := http.HandlerFunc(ResourceRequestMiddleware(DimensionKeysHandler, logger, nil))
 		handler.ServeHTTP(rr, req)
-		res := []models.Metric{}
+		res := []resources.Metric{}
 		err := json.Unmarshal(rr.Body.Bytes(), &res)
 		require.Nil(t, err)
 		assert.True(t, haveBeenCalled)
@@ -71,7 +65,7 @@ func Test_DimensionKeys_Route(t *testing.T) {
 
 	t.Run("return 500 if GetDimensionKeysByDimensionFilter returns an error", func(t *testing.T) {
 		mockListMetricsService := mocks.ListMetricsServiceMock{}
-		mockListMetricsService.On("GetDimensionKeysByDimensionFilter").Return([]string{}, fmt.Errorf("some error"))
+		mockListMetricsService.On("GetDimensionKeysByDimensionFilter", mock.Anything).Return([]string{}, fmt.Errorf("some error"))
 		newListMetricsService = func(pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.ListMetricsProvider, error) {
 			return &mockListMetricsService, nil
 		}

--- a/pkg/tsdb/cloudwatch/routes/dimension_values.go
+++ b/pkg/tsdb/cloudwatch/routes/dimension_values.go
@@ -7,11 +7,11 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/models"
-	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/models/request"
+	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/models/resources"
 )
 
 func DimensionValuesHandler(pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, parameters url.Values) ([]byte, *models.HttpError) {
-	dimensionValuesRequest, err := request.GetDimensionValuesRequest(parameters)
+	dimensionValuesRequest, err := resources.GetDimensionValuesRequest(parameters)
 	if err != nil {
 		return nil, models.NewHttpError("error in DimensionValuesHandler", http.StatusBadRequest, err)
 	}
@@ -21,12 +21,12 @@ func DimensionValuesHandler(pluginCtx backend.PluginContext, reqCtxFactory model
 		return nil, models.NewHttpError("error in DimensionValuesHandler", http.StatusInternalServerError, err)
 	}
 
-	dimensionValues, err := service.GetDimensionValuesByDimensionFilter(dimensionValuesRequest)
+	response, err := service.GetDimensionValuesByDimensionFilter(dimensionValuesRequest)
 	if err != nil {
 		return nil, models.NewHttpError("error in DimensionValuesHandler", http.StatusInternalServerError, err)
 	}
 
-	dimensionValuesResponse, err := json.Marshal(dimensionValues)
+	dimensionValuesResponse, err := json.Marshal(response)
 	if err != nil {
 		return nil, models.NewHttpError("error in DimensionValuesHandler", http.StatusInternalServerError, err)
 	}

--- a/pkg/tsdb/cloudwatch/routes/metrics.go
+++ b/pkg/tsdb/cloudwatch/routes/metrics.go
@@ -7,12 +7,12 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/models"
-	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/models/request"
+	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/models/resources"
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/services"
 )
 
 func MetricsHandler(pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, parameters url.Values) ([]byte, *models.HttpError) {
-	metricsRequest, err := request.GetMetricsRequest(parameters)
+	metricsRequest, err := resources.GetMetricsRequest(parameters)
 	if err != nil {
 		return nil, models.NewHttpError("error in MetricsHandler", http.StatusBadRequest, err)
 	}
@@ -22,13 +22,13 @@ func MetricsHandler(pluginCtx backend.PluginContext, reqCtxFactory models.Reques
 		return nil, models.NewHttpError("error in MetricsHandler", http.StatusInternalServerError, err)
 	}
 
-	var metrics []models.Metric
+	var metrics []resources.Metric
 	switch metricsRequest.Type() {
-	case request.AllMetricsRequestType:
+	case resources.AllMetricsRequestType:
 		metrics = services.GetAllHardCodedMetrics()
-	case request.MetricsByNamespaceRequestType:
+	case resources.MetricsByNamespaceRequestType:
 		metrics, err = services.GetHardCodedMetricsByNamespace(metricsRequest.Namespace)
-	case request.CustomNamespaceRequestType:
+	case resources.CustomNamespaceRequestType:
 		metrics, err = service.GetMetricsByNamespace(metricsRequest.Namespace)
 	}
 	if err != nil {

--- a/pkg/tsdb/cloudwatch/routes/namespaces_test.go
+++ b/pkg/tsdb/cloudwatch/routes/namespaces_test.go
@@ -16,7 +16,7 @@ func Test_Namespaces_Route(t *testing.T) {
 	customNamespaces := ""
 	factoryFunc := func(pluginCtx backend.PluginContext, region string) (reqCtx models.RequestContext, err error) {
 		return models.RequestContext{
-			Settings: &models.CloudWatchSettings{
+			Settings: models.CloudWatchSettings{
 				Namespace: customNamespaces,
 			},
 		}, nil

--- a/pkg/tsdb/cloudwatch/services/hardcoded_metrics.go
+++ b/pkg/tsdb/cloudwatch/services/hardcoded_metrics.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/constants"
-	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/models"
+	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/models/resources"
 )
 
 var GetHardCodedDimensionKeysByNamespace = func(namespace string) ([]string, error) {
@@ -16,8 +16,8 @@ var GetHardCodedDimensionKeysByNamespace = func(namespace string) ([]string, err
 	return dimensionKeys, nil
 }
 
-var GetHardCodedMetricsByNamespace = func(namespace string) ([]models.Metric, error) {
-	response := []models.Metric{}
+var GetHardCodedMetricsByNamespace = func(namespace string) ([]resources.Metric, error) {
+	response := []resources.Metric{}
 	exists := false
 	var metrics []string
 	if metrics, exists = constants.NamespaceMetricsMap[namespace]; !exists {
@@ -25,17 +25,17 @@ var GetHardCodedMetricsByNamespace = func(namespace string) ([]models.Metric, er
 	}
 
 	for _, metric := range metrics {
-		response = append(response, models.Metric{Namespace: namespace, Name: metric})
+		response = append(response, resources.Metric{Namespace: namespace, Name: metric})
 	}
 
 	return response, nil
 }
 
-var GetAllHardCodedMetrics = func() []models.Metric {
-	response := []models.Metric{}
+var GetAllHardCodedMetrics = func() []resources.Metric {
+	response := []resources.Metric{}
 	for namespace, metrics := range constants.NamespaceMetricsMap {
 		for _, metric := range metrics {
-			response = append(response, models.Metric{Namespace: namespace, Name: metric})
+			response = append(response, resources.Metric{Namespace: namespace, Name: metric})
 		}
 	}
 

--- a/pkg/tsdb/cloudwatch/services/hardcoded_metrics_test.go
+++ b/pkg/tsdb/cloudwatch/services/hardcoded_metrics_test.go
@@ -3,7 +3,7 @@ package services
 import (
 	"testing"
 
-	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/models"
+	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/models/resources"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -34,6 +34,6 @@ func TestHardcodedMetrics_GetHardCodedMetricsByNamespace(t *testing.T) {
 	t.Run("Should return metrics if namespace exist", func(t *testing.T) {
 		resp, err := GetHardCodedMetricsByNamespace("AWS/IoTAnalytics")
 		require.NoError(t, err)
-		assert.Equal(t, []models.Metric{{Name: "ActionExecution", Namespace: "AWS/IoTAnalytics"}, {Name: "ActivityExecutionError", Namespace: "AWS/IoTAnalytics"}, {Name: "IncomingMessages", Namespace: "AWS/IoTAnalytics"}}, resp)
+		assert.Equal(t, []resources.Metric{{Name: "ActionExecution", Namespace: "AWS/IoTAnalytics"}, {Name: "ActivityExecutionError", Namespace: "AWS/IoTAnalytics"}, {Name: "IncomingMessages", Namespace: "AWS/IoTAnalytics"}}, resp)
 	})
 }

--- a/pkg/tsdb/cloudwatch/services/list_metrics.go
+++ b/pkg/tsdb/cloudwatch/services/list_metrics.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/models"
-	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/models/request"
+	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/models/resources"
 )
 
 type ListMetricsService struct {
@@ -18,7 +18,7 @@ func NewListMetricsService(metricsClient models.MetricsClientProvider) models.Li
 	return &ListMetricsService{metricsClient}
 }
 
-func (l *ListMetricsService) GetDimensionKeysByDimensionFilter(r *request.DimensionKeysRequest) ([]string, error) {
+func (l *ListMetricsService) GetDimensionKeysByDimensionFilter(r resources.DimensionKeysRequest) ([]string, error) {
 	input := &cloudwatch.ListMetricsInput{}
 	if r.Namespace != "" {
 		input.Namespace = aws.String(r.Namespace)
@@ -63,7 +63,7 @@ func (l *ListMetricsService) GetDimensionKeysByDimensionFilter(r *request.Dimens
 	return dimensionKeys, nil
 }
 
-func (l *ListMetricsService) GetDimensionValuesByDimensionFilter(r *request.DimensionValuesRequest) ([]string, error) {
+func (l *ListMetricsService) GetDimensionValuesByDimensionFilter(r resources.DimensionValuesRequest) ([]string, error) {
 	input := &cloudwatch.ListMetricsInput{
 		Namespace:  aws.String(r.Namespace),
 		MetricName: aws.String(r.MetricName),
@@ -116,26 +116,26 @@ func (l *ListMetricsService) GetDimensionKeysByNamespace(namespace string) ([]st
 	return dimensionKeys, nil
 }
 
-func (l *ListMetricsService) GetMetricsByNamespace(namespace string) ([]models.Metric, error) {
+func (l *ListMetricsService) GetMetricsByNamespace(namespace string) ([]resources.Metric, error) {
 	metrics, err := l.ListMetricsWithPageLimit(&cloudwatch.ListMetricsInput{Namespace: aws.String(namespace)})
 	if err != nil {
 		return nil, err
 	}
 
-	response := []models.Metric{}
+	response := []resources.Metric{}
 	dupCheck := make(map[string]struct{})
 	for _, metric := range metrics {
 		if _, exists := dupCheck[*metric.MetricName]; exists {
 			continue
 		}
 		dupCheck[*metric.MetricName] = struct{}{}
-		response = append(response, models.Metric{Name: *metric.MetricName, Namespace: *metric.Namespace})
+		response = append(response, resources.Metric{Name: *metric.MetricName, Namespace: *metric.Namespace})
 	}
 
 	return response, nil
 }
 
-func setDimensionFilter(input *cloudwatch.ListMetricsInput, dimensionFilter []*request.Dimension) {
+func setDimensionFilter(input *cloudwatch.ListMetricsInput, dimensionFilter []*resources.Dimension) {
 	for _, dimension := range dimensionFilter {
 		df := &cloudwatch.DimensionFilter{
 			Name: aws.String(dimension.Name),

--- a/pkg/tsdb/cloudwatch/services/list_metrics_test.go
+++ b/pkg/tsdb/cloudwatch/services/list_metrics_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/mocks"
-	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/models/request"
+	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/models/resources"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -47,11 +47,11 @@ func TestListMetricsService_GetDimensionKeysByDimensionFilter(t *testing.T) {
 		fakeMetricsClient.On("ListMetricsWithPageLimit", mock.Anything).Return(metricResponse, nil)
 		listMetricsService := NewListMetricsService(fakeMetricsClient)
 
-		resp, err := listMetricsService.GetDimensionKeysByDimensionFilter(&request.DimensionKeysRequest{
-			ResourceRequest: &request.ResourceRequest{Region: "us-east-1"},
+		resp, err := listMetricsService.GetDimensionKeysByDimensionFilter(resources.DimensionKeysRequest{
+			ResourceRequest: &resources.ResourceRequest{Region: "us-east-1"},
 			Namespace:       "AWS/EC2",
 			MetricName:      "CPUUtilization",
-			DimensionFilter: []*request.Dimension{
+			DimensionFilter: []*resources.Dimension{
 				{Name: "InstanceId", Value: ""},
 			},
 		})
@@ -80,12 +80,12 @@ func TestListMetricsService_GetDimensionValuesByDimensionFilter(t *testing.T) {
 		fakeMetricsClient.On("ListMetricsWithPageLimit", mock.Anything).Return(metricResponse, nil)
 		listMetricsService := NewListMetricsService(fakeMetricsClient)
 
-		resp, err := listMetricsService.GetDimensionValuesByDimensionFilter(&request.DimensionValuesRequest{
-			ResourceRequest: &request.ResourceRequest{Region: "us-east-1"},
+		resp, err := listMetricsService.GetDimensionValuesByDimensionFilter(resources.DimensionValuesRequest{
+			ResourceRequest: &resources.ResourceRequest{Region: "us-east-1"},
 			Namespace:       "AWS/EC2",
 			MetricName:      "CPUUtilization",
 			DimensionKey:    "InstanceId",
-			DimensionFilter: []*request.Dimension{
+			DimensionFilter: []*resources.Dimension{
 				{Name: "InstanceId", Value: ""},
 			},
 		})

--- a/pkg/tsdb/cloudwatch/time_series_query_test.go
+++ b/pkg/tsdb/cloudwatch/time_series_query_test.go
@@ -50,7 +50,7 @@ func TestTimeSeriesQuery(t *testing.T) {
 				}}}, nil)
 
 		im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-			return DataSource{Settings: &models.CloudWatchSettings{}}, nil
+			return DataSource{Settings: models.CloudWatchSettings{}}, nil
 		})
 
 		executor := newExecutor(im, newTestConfig(), &fakeSessionCache{}, featuremgmt.WithFeatures())
@@ -150,7 +150,7 @@ func Test_executeTimeSeriesQuery_getCWClient_is_called_once_per_region_and_GetMe
 	}
 
 	im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-		return DataSource{Settings: &models.CloudWatchSettings{}}, nil
+		return DataSource{Settings: models.CloudWatchSettings{}}, nil
 	})
 
 	t.Run("Queries with the same region should call GetSession with that region 1 time and call GetMetricDataWithContext 1 time", func(t *testing.T) {
@@ -342,7 +342,7 @@ func Test_QueryData_timeSeriesQuery_GetMetricDataWithContext(t *testing.T) {
 	}
 
 	im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-		return DataSource{Settings: &models.CloudWatchSettings{}}, nil
+		return DataSource{Settings: models.CloudWatchSettings{}}, nil
 	})
 
 	t.Run("passes query label as GetMetricData label when dynamic labels feature toggle is enabled", func(t *testing.T) {
@@ -444,7 +444,7 @@ func Test_QueryData_response_data_frame_names(t *testing.T) {
 			}}, nil)
 
 	im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-		return DataSource{Settings: &models.CloudWatchSettings{}}, nil
+		return DataSource{Settings: models.CloudWatchSettings{}}, nil
 	})
 	executor := newExecutor(im, newTestConfig(), &fakeSessionCache{}, featuremgmt.WithFeatures())
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

* Reorganizes models > requests to models > resources
* Adds tests assertions to routes > dimension_keys_test.go and routes > dimension_values_test.go
* In case a custom namespace is used, metric name wasn't taken into account when querying the list metrics api. Turns out we can just remove the FilterDimensionKeysRequest type, and in case it's a custom metric just use the already existing service handler for listing dimension keys by dimension filter.
* Change settings to be non-pointer. The original value did not need pointers either I believe (see #57452) and we can reserve pointer use only when absolutely necessary to be safer.
* Changes ListMetricsProvider interface methods to take non-pointer request types



Co-authored-by: Erik Sundell <erik.sundell87@gmail.com>