### PR TITLE
DataSourceWithBackend - Set postResource method to POST

### DIFF
--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -299,7 +299,7 @@ class DataSourceWithBackend<
     const result = await lastValueFrom(
       getBackendSrv().fetch<T>({
         ...options,
-        method: 'GET',
+        method: 'POST',
         headers: options?.headers ? { ...options.headers, ...headers } : headers,
         data: data ?? { ...data },
         url: `/api/datasources/${this.id}/resources/${path}`,


### PR DESCRIPTION
#58082 set the HTTP method of `postResource` to `GET` rather than `POST`. Just a quick fix for this as its broken some Azure Monitor requests (and potentially other requests elsewhere).