### PR TITLE
SQL: Return no data response when no rows returned

### DIFF
--- a/pkg/tsdb/sqleng/sql_engine.go
+++ b/pkg/tsdb/sqleng/sql_engine.go
@@ -297,7 +297,7 @@ func (e *DataSourceHandler) executeQuery(query backend.DataQuery, wg *sync.WaitG
 
 	// If no rows were returned, no point checking anything else.
 	if frame.Rows() == 0 {
-		queryResult.dataResponse.Frames = data.Frames{frame}
+		queryResult.dataResponse.Frames = data.Frames{}
 		ch <- queryResult
 		return
 	}


### PR DESCRIPTION
This PR modifies the response returned for SQL datasources when no rows returned.

**Special notes for your reviewer**:

I've tried this out with the MSSql datasource and the devenv docker image. With the following query
```sql
SELECT
  TOP(50) createdAt,
  value
FROM
  grafana.dbo.grafana_metric
WHERE
  value = 23
 ```
 This query used to return an empty response but we should return no data instead.
 
 This also fixes #44405