### PR TITLE
Loki: Remove raw query toggle

### DIFF
--- a/e2e/various-suite/loki-query-builder.spec.ts
+++ b/e2e/various-suite/loki-query-builder.spec.ts
@@ -72,10 +72,6 @@ describe('Loki query builder', () => {
     e2e().contains(MISSING_LABEL_FILTER_ERROR_MESSAGE).should('not.exist');
     e2e().contains(finalQuery).should('be.visible');
 
-    // Toggle raw query
-    e2e().contains('label', 'Raw query').click();
-    e2e().contains('Raw query').should('have.length', 1);
-
     // Change to code editor
     e2e().contains('label', 'Code').click();
     // We need to test this manually because the final query is split into separate DOM elements using e2e().contains(finalQuery).should('be.visible'); does not detect the query.

--- a/public/app/plugins/datasource/loki/components/LokiQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryEditor.test.tsx
@@ -94,7 +94,7 @@ describe('LokiQueryEditorSelector', () => {
     });
   });
 
-  it('Should show raw query by default', async () => {
+  it('Should show the query by default', async () => {
     renderWithProps({
       editorMode: QueryEditorMode.Builder,
       expr: '{job="grafana"}',

--- a/public/app/plugins/datasource/loki/components/LokiQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryEditor.test.tsx
@@ -94,13 +94,6 @@ describe('LokiQueryEditorSelector', () => {
     });
   });
 
-  it('Can enable raw query', async () => {
-    renderWithMode(QueryEditorMode.Builder);
-    expect(await screen.findByLabelText('selector')).toBeInTheDocument();
-    screen.getByLabelText('Raw query').click();
-    expect(screen.queryByLabelText('selector')).not.toBeInTheDocument();
-  });
-
   it('Should show raw query by default', async () => {
     renderWithProps({
       editorMode: QueryEditorMode.Builder,

--- a/public/app/plugins/datasource/loki/components/LokiQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryEditor.tsx
@@ -9,11 +9,7 @@ import { QueryEditorModeToggle } from 'app/plugins/datasource/prometheus/querybu
 import { QueryHeaderSwitch } from 'app/plugins/datasource/prometheus/querybuilder/shared/QueryHeaderSwitch';
 import { QueryEditorMode } from 'app/plugins/datasource/prometheus/querybuilder/shared/types';
 
-import {
-  lokiQueryEditorExplainKey,
-  lokiQueryEditorRawQueryKey,
-  useFlag,
-} from '../../prometheus/querybuilder/shared/hooks/useFlag';
+import { lokiQueryEditorExplainKey, useFlag } from '../../prometheus/querybuilder/shared/hooks/useFlag';
 import { LokiQueryBuilderContainer } from '../querybuilder/components/LokiQueryBuilderContainer';
 import { LokiQueryBuilderOptions } from '../querybuilder/components/LokiQueryBuilderOptions';
 import { LokiQueryCodeEditor } from '../querybuilder/components/LokiQueryCodeEditor';
@@ -34,7 +30,6 @@ export const LokiQueryEditor = React.memo<LokiQueryEditorProps>((props) => {
   const [queryPatternsModalOpen, setQueryPatternsModalOpen] = useState(false);
   const [dataIsStale, setDataIsStale] = useState(false);
   const { flag: explain, setFlag: setExplain } = useFlag(lokiQueryEditorExplainKey);
-  const { flag: rawQuery, setFlag: setRawQuery } = useFlag(lokiQueryEditorRawQueryKey, true);
 
   const query = getQueryWithDefaults(props.query);
   // This should be filled in from the defaults by now.
@@ -73,11 +68,6 @@ export const LokiQueryEditor = React.memo<LokiQueryEditorProps>((props) => {
   const onChangeInternal = (query: LokiQuery) => {
     setDataIsStale(true);
     onChange(query);
-  };
-
-  const onQueryPreviewChange = (event: SyntheticEvent<HTMLInputElement>) => {
-    const isEnabled = event.currentTarget.checked;
-    setRawQuery(isEnabled);
   };
 
   return (
@@ -123,11 +113,6 @@ export const LokiQueryEditor = React.memo<LokiQueryEditorProps>((props) => {
           Kick start your query
         </Button>
         <QueryHeaderSwitch label="Explain" value={explain} onChange={onExplainChange} />
-        {editorMode === QueryEditorMode.Builder && (
-          <>
-            <QueryHeaderSwitch label="Raw query" value={rawQuery} onChange={onQueryPreviewChange} />
-          </>
-        )}
         <FlexItem grow={1} />
         {app !== CoreApp.Explore && (
           <Button

--- a/public/app/plugins/datasource/loki/components/LokiQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryEditor.tsx
@@ -153,7 +153,6 @@ export const LokiQueryEditor = React.memo<LokiQueryEditorProps>((props) => {
             query={query}
             onChange={onChangeInternal}
             onRunQuery={props.onRunQuery}
-            showRawQuery={rawQuery}
             showExplain={explain}
           />
         )}

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderContainer.test.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderContainer.test.tsx
@@ -32,7 +32,6 @@ describe('LokiQueryBuilderContainer', () => {
       ),
       onChange: jest.fn(),
       onRunQuery: () => {},
-      showRawQuery: true,
       showExplain: false,
     };
     props.datasource.getDataSamples = jest.fn().mockResolvedValue([]);

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderContainer.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderContainer.tsx
@@ -66,7 +66,7 @@ export function LokiQueryBuilderContainer(props: Props) {
         showExplain={showExplain}
         data-testid={testIds.editor}
       />
-      <QueryPreview query={query.expr} />
+      {query.expr !== '' && <QueryPreview query={query.expr} />}
     </>
   );
 }

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderContainer.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderContainer.tsx
@@ -16,7 +16,6 @@ export interface Props {
   datasource: LokiDatasource;
   onChange: (update: LokiQuery) => void;
   onRunQuery: () => void;
-  showRawQuery: boolean;
   showExplain: boolean;
 }
 
@@ -29,7 +28,7 @@ export interface State {
  * This component is here just to contain the translation logic between string query and the visual query builder model.
  */
 export function LokiQueryBuilderContainer(props: Props) {
-  const { query, onChange, onRunQuery, datasource, showRawQuery, showExplain } = props;
+  const { query, onChange, onRunQuery, datasource, showExplain } = props;
   const [state, dispatch] = useReducer(stateSlice.reducer, {
     expr: query.expr,
     // Use initial visual query only if query.expr is empty string
@@ -67,7 +66,7 @@ export function LokiQueryBuilderContainer(props: Props) {
         showExplain={showExplain}
         data-testid={testIds.editor}
       />
-      {showRawQuery && <QueryPreview query={query.expr} />}
+      <QueryPreview query={query.expr} />
     </>
   );
 }

--- a/public/app/plugins/datasource/loki/querybuilder/components/QueryPreview.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/QueryPreview.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { EditorRow, EditorFieldGroup, EditorField } from '@grafana/experimental';
+import { EditorRow, EditorFieldGroup } from '@grafana/experimental';
 
 import { RawQuery } from '../../../prometheus/querybuilder/shared/RawQuery';
 import { lokiGrammar } from '../../syntax';
@@ -13,9 +13,7 @@ export function QueryPreview({ query }: Props) {
   return (
     <EditorRow>
       <EditorFieldGroup>
-        <EditorField label="Raw query">
-          <RawQuery query={query} lang={{ grammar: lokiGrammar, name: 'lokiql' }} />
-        </EditorField>
+        <RawQuery query={query} lang={{ grammar: lokiGrammar, name: 'lokiql' }} />
       </EditorFieldGroup>
     </EditorRow>
   );

--- a/public/app/plugins/datasource/loki/querybuilder/state.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/state.ts
@@ -42,7 +42,7 @@ export function getQueryWithDefaults(query: LokiQuery): LokiQuery {
   }
 
   if (query.expr == null) {
-    result = { ...result, expr: '{} |= ``' };
+    result = { ...result, expr: '' };
   }
 
   if (query.queryType == null) {

--- a/public/app/plugins/datasource/loki/querybuilder/state.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/state.ts
@@ -42,7 +42,7 @@ export function getQueryWithDefaults(query: LokiQuery): LokiQuery {
   }
 
   if (query.expr == null) {
-    result = { ...result, expr: '' };
+    result = { ...result, expr: '{} |= ``' };
   }
 
   if (query.queryType == null) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
This PR removes the `Raw query` toggle in the builder mode and permanently shows the query.

**Why do we need this feature?**
During user interviews we've noticed that query editor has (too) many buttons/toggles. Moreover, no users we talked to uses this to toggle their query preview off.

**Who is this feature for?**
...

**Which issue(s) does this PR fix?**:
Fixes #58511

**Special notes for your reviewer**:
...
