### PR TITLE
Folder: Provide adhoc ui for nested folder creation

### DIFF
--- a/public/app/features/folders/components/NewDashboardsFolder.tsx
+++ b/public/app/features/folders/components/NewDashboardsFolder.tsx
@@ -1,10 +1,11 @@
-import React, { PureComponent } from 'react';
+import React from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 
 import { NavModelItem } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { Button, Input, Form, Field } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
+import { useQueryParams } from 'app/core/hooks/useQueryParams';
 
 import { validationSrv } from '../../manage-dashboards/services/ValidationSrv';
 import { createNewFolder } from '../state/actions';
@@ -21,16 +22,22 @@ interface FormModel {
   folderName: string;
 }
 
-const initialFormModel: FormModel = { folderName: '' };
-
 type Props = OwnProps & ConnectedProps<typeof connector>;
 
-export class NewDashboardsFolder extends PureComponent<Props> {
-  onSubmit = (formData: FormModel) => {
-    this.props.createNewFolder(formData.folderName);
-  };
+const initialFormModel: FormModel = { folderName: '' };
 
-  validateFolderName = (folderName: string) => {
+const pageNav: NavModelItem = {
+  text: 'Create a new folder',
+  subTitle: 'Folders provide a way to group dashboards and alert rules.',
+  breadcrumbs: [{ title: 'Dashboards', url: 'dashboards' }],
+};
+
+function NewDashboardsFolder({ createNewFolder }: Props) {
+  const [queryParams] = useQueryParams();
+  const onSubmit = (formData: FormModel) => {
+    createNewFolder(formData.folderName, String(queryParams['folderUid']));
+  };
+  const validateFolderName = (folderName: string) => {
     return validationSrv
       .validateNewFolderName(folderName)
       .then(() => {
@@ -41,41 +48,33 @@ export class NewDashboardsFolder extends PureComponent<Props> {
       });
   };
 
-  pageNav: NavModelItem = {
-    text: 'Create a new folder',
-    subTitle: 'Folders provide a way to group dashboards and alert rules.',
-    breadcrumbs: [{ title: 'Dashboards', url: 'dashboards' }],
-  };
-
-  render() {
-    return (
-      <Page navId="dashboards/browse" pageNav={this.pageNav}>
-        <Page.Contents>
-          {!config.featureToggles.topnav && <h3>New dashboard folder</h3>}
-          <Form defaultValues={initialFormModel} onSubmit={this.onSubmit}>
-            {({ register, errors }) => (
-              <>
-                <Field
-                  label="Folder name"
-                  invalid={!!errors.folderName}
-                  error={errors.folderName && errors.folderName.message}
-                >
-                  <Input
-                    id="folder-name-input"
-                    {...register('folderName', {
-                      required: 'Folder name is required.',
-                      validate: async (v) => await this.validateFolderName(v),
-                    })}
-                  />
-                </Field>
-                <Button type="submit">Create</Button>
-              </>
-            )}
-          </Form>
-        </Page.Contents>
-      </Page>
-    );
-  }
+  return (
+    <Page navId="dashboards/browse" pageNav={pageNav}>
+      <Page.Contents>
+        {!config.featureToggles.topnav && <h3>New dashboard folder</h3>}
+        <Form defaultValues={initialFormModel} onSubmit={onSubmit}>
+          {({ register, errors }) => (
+            <>
+              <Field
+                label="Folder name"
+                invalid={!!errors.folderName}
+                error={errors.folderName && errors.folderName.message}
+              >
+                <Input
+                  id="folder-name-input"
+                  {...register('folderName', {
+                    required: 'Folder name is required.',
+                    validate: async (v) => await validateFolderName(v),
+                  })}
+                />
+              </Field>
+              <Button type="submit">Create</Button>
+            </>
+          )}
+        </Form>
+      </Page.Contents>
+    </Page>
+  );
 }
 
 export default connector(NewDashboardsFolder);

--- a/public/app/features/folders/state/actions.ts
+++ b/public/app/features/folders/state/actions.ts
@@ -143,9 +143,9 @@ export function addFolderPermission(newItem: NewDashboardAclItem): ThunkResult<v
   };
 }
 
-export function createNewFolder(folderName: string): ThunkResult<void> {
+export function createNewFolder(folderName: string, uid?: string): ThunkResult<void> {
   return async (dispatch) => {
-    const newFolder = await getBackendSrv().post('/api/folders', { title: folderName });
+    const newFolder = await getBackendSrv().post('/api/folders', { title: folderName, parentUid: uid });
     await contextSrv.fetchUserPermissions();
     dispatch(notifyApp(createSuccessNotification('Folder Created', 'OK')));
     locationService.push(locationUtil.stripBaseFromUrl(newFolder.url));

--- a/public/app/features/search/components/DashboardActions.tsx
+++ b/public/app/features/search/components/DashboardActions.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react';
 
+import { config } from '@grafana/runtime';
 import { Menu, Dropdown, Button, Icon } from '@grafana/ui';
 
 export interface Props {
@@ -11,8 +12,13 @@ export interface Props {
 export const DashboardActions: FC<Props> = ({ folderUid, canCreateFolders = false, canCreateDashboards = false }) => {
   const actionUrl = (type: string) => {
     let url = `dashboard/${type}`;
+    const isTypeNewFolder = type === 'new_folder';
 
-    if (folderUid) {
+    if (isTypeNewFolder) {
+      url = `dashboards/folder/new/`;
+    }
+
+    if ((isTypeNewFolder && config.featureToggles.nestedFolders) || folderUid) {
       url += `?folderUid=${folderUid}`;
     }
 
@@ -23,7 +29,9 @@ export const DashboardActions: FC<Props> = ({ folderUid, canCreateFolders = fals
     return (
       <Menu>
         {canCreateDashboards && <Menu.Item url={actionUrl('new')} label="New Dashboard" />}
-        {!folderUid && canCreateFolders && <Menu.Item url="dashboards/folder/new" label="New Folder" />}
+        {canCreateFolders && (config.featureToggles.nestedFolders || !folderUid) && (
+          <Menu.Item url={actionUrl('new_folder')} label="New Folder" />
+        )}
         {canCreateDashboards && <Menu.Item url={actionUrl('import')} label="Import" />}
       </Menu>
     );


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Adhoc UI to allow nested folder creation. 

**Why do we need this feature?**
This is needed to support backend testing with their nested folder API related changes

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #58762 

**Special notes for your reviewer**:

This feature is only available under nestedFolder feature flag and will only work when [addFolderMigration](https://github.com/grafana/grafana/blob/9c4b78ae4f52ca0e00077241c27e2dcb1008cfde/pkg/services/sqlstore/migrations/migrations.go#L115) is uncommented.
