### PR TITLE
Tempo: Send the correct start time when making a TraceQL query

### DIFF
--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -184,7 +184,7 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
           this._request('/api/search', {
             q: targets.traceql[0].query,
             limit: options.targets[0].limit,
-            start: 0, // Currently the API doesn't return traces when using the 'From' time selected in Explore
+            start: options.range.from.unix(),
             end: options.range.to.unix(),
           }).pipe(
             map((response) => {


### PR DESCRIPTION
Currently, the start time sent to the Tempo API is 0 as the API would not return any traces if the start time selected in Explore was sent. This issue has finally been fixed (https://github.com/grafana/tempo/pull/1902), so the PR updates the query to send the correct start time.