### PR TITLE
Auth: Add caseinsensitive check for ingestion command

### DIFF
--- a/pkg/cmd/grafana-cli/commands/conflict_user_command.go
+++ b/pkg/cmd/grafana-cli/commands/conflict_user_command.go
@@ -36,6 +36,10 @@ func initConflictCfg(cmd *utils.ContextCommandLine) (*setting.Cfg, error) {
 		HomePath: cmd.HomePath(),
 		Args:     append(configOptions, "cfg:log.level=error"), // tailing arguments have precedence over the options string
 	})
+	if !cfg.CaseInsensitiveLogin {
+		logger.Info("Case Insensitive Login is not enabled, setting to true to not introduce any more conflicts")
+		cfg.CaseInsensitiveLogin = true
+	}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
This feature adds a check if the caseinsensitiveLogin check is not set.
Also, should point out to set this to true after running the resolver.

- Sets caseinsensitiveLogin configuration to true during ingestion

**Why do we need this feature?**
This makes sure that during ingestion we do not add any more conflicts as the users can still have set this setting to false and we would be able to create more conflicts.

**Which issue(s) does this PR fix?**:
https://github.com/grafana/grafana/issues/57508

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

