### PR TITLE
I18n: Translate Dashboard Starred notification

### DIFF
--- a/public/app/features/dashboard/services/DashboardSrv.ts
+++ b/public/app/features/dashboard/services/DashboardSrv.ts
@@ -1,7 +1,9 @@
 import { lastValueFrom } from 'rxjs';
 
+import { AppEvents } from '@grafana/data';
 import { BackendSrvRequest } from '@grafana/runtime';
 import { appEvents } from 'app/core/app_events';
+import { t } from 'app/core/internationalization';
 import { getBackendSrv } from 'app/core/services/backend_srv';
 import { saveDashboard } from 'app/features/manage-dashboards/state/actions';
 import { DashboardMeta } from 'app/types';
@@ -92,23 +94,27 @@ export class DashboardSrv {
 
   starDashboard(dashboardId: string, isStarred: boolean) {
     const backendSrv = getBackendSrv();
-    let promise;
 
-    if (isStarred) {
-      promise = backendSrv.delete('/api/user/stars/dashboard/' + dashboardId).then(() => {
-        return false;
-      });
-    } else {
-      promise = backendSrv.post('/api/user/stars/dashboard/' + dashboardId).then(() => {
-        return true;
-      });
-    }
+    const request = {
+      showSuccessAlert: false,
+      url: '/api/user/stars/dashboard/' + dashboardId,
+      method: isStarred ? 'DELETE' : 'POST',
+    };
 
-    return promise.then((res: boolean) => {
-      if (this.dashboard && this.dashboard.id === dashboardId) {
-        this.dashboard.meta.isStarred = res;
+    return backendSrv.request(request).then(() => {
+      const newIsStarred = !isStarred;
+
+      if (this.dashboard?.id === dashboardId) {
+        this.dashboard.meta.isStarred = newIsStarred;
       }
-      return res;
+
+      const message = newIsStarred
+        ? t('notifications.starred-dashboard', 'Dashboard starred')
+        : t('notifications.unstarred-dashboard', 'Dashboard unstarred');
+
+      appEvents.emit(AppEvents.alertSuccess, [message]);
+
+      return newIsStarred;
     });
   }
 }

--- a/public/locales/de-DE/grafana.json
+++ b/public/locales/de-DE/grafana.json
@@ -318,6 +318,10 @@
   "news": {
     "title": "Das Neueste aus dem Blog"
   },
+  "notifications": {
+    "starred-dashboard": "",
+    "unstarred-dashboard": ""
+  },
   "panel": {
     "header-menu": {
       "hide-legend": "",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -318,6 +318,10 @@
   "news": {
     "title": "Latest from the blog"
   },
+  "notifications": {
+    "starred-dashboard": "Dashboard starred",
+    "unstarred-dashboard": "Dashboard unstarred"
+  },
   "panel": {
     "header-menu": {
       "hide-legend": "Hide legend",

--- a/public/locales/es-ES/grafana.json
+++ b/public/locales/es-ES/grafana.json
@@ -318,6 +318,10 @@
   "news": {
     "title": "Últimas entradas del blog"
   },
+  "notifications": {
+    "starred-dashboard": "",
+    "unstarred-dashboard": ""
+  },
   "panel": {
     "header-menu": {
       "hide-legend": "",

--- a/public/locales/fr-FR/grafana.json
+++ b/public/locales/fr-FR/grafana.json
@@ -318,6 +318,10 @@
   "news": {
     "title": "Dernières nouvelles sur le blog"
   },
+  "notifications": {
+    "starred-dashboard": "",
+    "unstarred-dashboard": ""
+  },
   "panel": {
     "header-menu": {
       "hide-legend": "",

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -318,6 +318,10 @@
   "news": {
     "title": "Ŀäŧęşŧ ƒřőm ŧĥę þľőģ"
   },
+  "notifications": {
+    "starred-dashboard": "Đäşĥþőäřđ şŧäřřęđ",
+    "unstarred-dashboard": "Đäşĥþőäřđ ūŉşŧäřřęđ"
+  },
   "panel": {
     "header-menu": {
       "hide-legend": "Ħįđę ľęģęŉđ",

--- a/public/locales/zh-Hans/grafana.json
+++ b/public/locales/zh-Hans/grafana.json
@@ -318,6 +318,10 @@
   "news": {
     "title": "最新博客"
   },
+  "notifications": {
+    "starred-dashboard": "",
+    "unstarred-dashboard": ""
+  },
   "panel": {
     "header-menu": {
       "hide-legend": "",


### PR DESCRIPTION
**What is this feature?**

Translates the "Starred dashboard" toast that's shown when starring (or unstarring) a dashboard.

It removes the behaviour of relying on automatic toasts from the `message` key in the response to the frontend showing the message.

**Which issue(s) does this PR fix?**:

Part of #51578

**Special notes for your reviewer**:

