### PR TITLE
I18n: Fix variables not interpolating with pseudo localisation

### DIFF
--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -20,8 +20,8 @@
       "meta-tab": "Męŧä Đäŧä",
       "query-tab": "Qūęřy",
       "stats-tab": "Ŝŧäŧş",
-      "subtitle": "{{qūęřyCőūŉŧ}} qūęřįęş ŵįŧĥ ŧőŧäľ qūęřy ŧįmę őƒ {{ƒőřmäŧŧęđ}}",
-      "title": "Ĩŉşpęčŧ: {{päŉęľŦįŧľę}}"
+      "subtitle": "{{queryCount}} qūęřįęş ŵįŧĥ ŧőŧäľ qūęřy ŧįmę őƒ {{formatted}}",
+      "title": "Ĩŉşpęčŧ: {{panelTitle}}"
     },
     "inspect-data": {
       "data-options": "Đäŧä őpŧįőŉş",
@@ -51,7 +51,7 @@
       "panel-json-description": "Ŧĥę mőđęľ şävęđ įŉ ŧĥę đäşĥþőäřđ ĴŜØŃ ŧĥäŧ čőŉƒįģūřęş ĥőŵ ęvęřyŧĥįŉģ ŵőřĸş.",
       "panel-json-label": "Päŉęľ ĴŜØŃ",
       "select-source": "Ŝęľęčŧ şőūřčę",
-      "unknown": "Ůŉĸŉőŵŉ Øþĵęčŧ: {{şĥőŵ}}"
+      "unknown": "Ůŉĸŉőŵŉ Øþĵęčŧ: {{show}}"
     },
     "inspect-meta": {
       "no-inspector": "Ńő Męŧäđäŧä Ĩŉşpęčŧőř"
@@ -95,7 +95,7 @@
   },
   "library-panels": {
     "save": {
-      "error": "Ēřřőř şävįŉģ ľįþřäřy päŉęľ: \"{{ęřřőřMşģ}}\"",
+      "error": "Ēřřőř şävįŉģ ľįþřäřy päŉęľ: \"{{errorMsg}}\"",
       "success": "Ŀįþřäřy päŉęľ şävęđ"
     }
   },
@@ -333,7 +333,7 @@
   "refresh-picker": {
     "aria-label": {
       "choose-interval": "Åūŧő řęƒřęşĥ ŧūřŉęđ őƒƒ. Cĥőőşę řęƒřęşĥ ŧįmę įŉŧęřväľ",
-      "duration-selected": "Cĥőőşę řęƒřęşĥ ŧįmę įŉŧęřväľ ŵįŧĥ čūřřęŉŧ įŉŧęřväľ {{đūřäŧįőŉÅřįäĿäþęľ}} şęľęčŧęđ"
+      "duration-selected": "Cĥőőşę řęƒřęşĥ ŧįmę įŉŧęřväľ ŵįŧĥ čūřřęŉŧ įŉŧęřväľ {{durationAriaLabel}} şęľęčŧęđ"
     },
     "live-option": {
       "aria-label": "Ŧūřŉ őŉ ľįvę şŧřęämįŉģ",
@@ -474,7 +474,7 @@
     },
     "range-picker": {
       "backwards-time-aria-label": "Mővę ŧįmę řäŉģę þäčĸŵäřđş",
-      "current-time-selected": "Ŧįmę řäŉģę şęľęčŧęđ: {{čūřřęŉŧŦįmęŖäŉģę}}",
+      "current-time-selected": "Ŧįmę řäŉģę şęľęčŧęđ: {{currentTimeRange}}",
       "forwards-time-aria-label": "Mővę ŧįmę řäŉģę ƒőřŵäřđş",
       "to": "ŧő",
       "zoom-out-button": "Żőőm őūŧ ŧįmę řäŉģę",

--- a/public/locales/psuedo.js
+++ b/public/locales/psuedo.js
@@ -3,9 +3,9 @@ const pseudoizer = require('pseudoizer');
 
 function pseudoizeJsonReplacer(key, value) {
   if (typeof value === 'string') {
-    // Split string on braces. Odd indicies will be {{variables}}
+    // Split string on brace-enclosed segments. Odd indices will be {{variables}}
     const phraseParts = value.split(/(\{\{[^}]+}\})/g);
-    const translatedParts = phraseParts.map((str, index) => index % 2 === 0 ? pseudoizer.pseudoize(str) : str)
+    const translatedParts = phraseParts.map((str, index) => index % 2 ? str : pseudoizer.pseudoize(str))
     return translatedParts.join("")
   }
 

--- a/public/locales/psuedo.js
+++ b/public/locales/psuedo.js
@@ -3,7 +3,10 @@ const pseudoizer = require('pseudoizer');
 
 function pseudoizeJsonReplacer(key, value) {
   if (typeof value === 'string') {
-    return pseudoizer.pseudoize(value);
+    // Split string on braces. Odd indicies will be {{variables}}
+    const phraseParts = value.split(/(\{\{[^}]+}\})/g);
+    const translatedParts = phraseParts.map((str, index) => index % 2 === 0 ? pseudoizer.pseudoize(str) : str)
+    return translatedParts.join("")
   }
 
   return value;


### PR DESCRIPTION
**What is this feature?**

Fixes variables not interpolating properly with the pseudo locale. 

The variable names in the "translations" were being pseudo-localised, which caused them to not be interpolated from the variables object

