### PR TITLE
Chore: Remove createorgwithmember

### DIFF
--- a/pkg/api/annotations_test.go
+++ b/pkg/api/annotations_test.go
@@ -385,7 +385,7 @@ func deleteAnnotationsScenario(t *testing.T, desc string, url string, routePatte
 func TestAPI_Annotations_AccessControl(t *testing.T) {
 	sc := setupHTTPServer(t, true)
 	setInitCtxSignedInEditor(sc.initCtx)
-	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
+	err := sc.db.CreateOrg(context.Background(), &models.CreateOrgCommand{Name: "TestOrg", UserId: testUserID})
 	require.NoError(t, err)
 
 	dashboardAnnotation := &annotations.Item{Id: 1, DashboardId: 1}
@@ -787,7 +787,7 @@ func TestService_AnnotationTypeScopeResolver(t *testing.T) {
 func TestAPI_MassDeleteAnnotations_AccessControl(t *testing.T) {
 	sc := setupHTTPServer(t, true)
 	setInitCtxSignedInEditor(sc.initCtx)
-	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
+	err := sc.db.CreateOrg(context.Background(), &models.CreateOrgCommand{Name: "TestOrg", UserId: testUserID})
 	require.NoError(t, err)
 
 	type args struct {

--- a/pkg/api/org_test.go
+++ b/pkg/api/org_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -9,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/org/orgimpl"
 	"github.com/grafana/grafana/pkg/services/quota/quotatest"
@@ -49,7 +51,7 @@ func TestAPIEndpoint_GetCurrentOrg_LegacyAccessControl(t *testing.T) {
 	sc := setupHTTPServerWithCfg(t, true, cfg)
 	setInitCtxSignedInViewer(sc.initCtx)
 
-	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
+	err := sc.db.CreateOrg(context.Background(), &models.CreateOrgCommand{Name: "TestOrg", UserId: testUserID})
 	require.NoError(t, err)
 
 	t.Run("Viewer can view CurrentOrg", func(t *testing.T) {
@@ -68,7 +70,7 @@ func TestAPIEndpoint_GetCurrentOrg_AccessControl(t *testing.T) {
 	sc := setupHTTPServer(t, true)
 	setInitCtxSignedInViewer(sc.initCtx)
 
-	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
+	err := sc.db.CreateOrg(context.Background(), &models.CreateOrgCommand{Name: "TestOrg", UserId: testUserID})
 	require.NoError(t, err)
 
 	t.Run("AccessControl allows viewing CurrentOrg with correct permissions", func(t *testing.T) {
@@ -93,7 +95,7 @@ func TestAPIEndpoint_PutCurrentOrg_LegacyAccessControl(t *testing.T) {
 	cfg.RBACEnabled = false
 	sc := setupHTTPServerWithCfg(t, true, cfg)
 
-	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
+	err := sc.db.CreateOrg(context.Background(), &models.CreateOrgCommand{Name: "TestOrg", UserId: testUserID})
 	require.NoError(t, err)
 
 	input := strings.NewReader(testUpdateOrgNameForm)
@@ -117,7 +119,7 @@ func TestAPIEndpoint_PutCurrentOrg_AccessControl(t *testing.T) {
 	sc := setupHTTPServer(t, true)
 	setInitCtxSignedInViewer(sc.initCtx)
 
-	_, err := sc.db.CreateOrgWithMember("TestOrg", sc.initCtx.UserID)
+	err := sc.db.CreateOrg(context.Background(), &models.CreateOrgCommand{Name: "TestOrg", UserId: sc.initCtx.UserID})
 	require.NoError(t, err)
 
 	sc.hs.orgService, err = orgimpl.ProvideService(sc.db, sc.cfg, quotatest.New(false, nil))
@@ -148,7 +150,7 @@ func TestAPIEndpoint_PutCurrentOrgAddress_LegacyAccessControl(t *testing.T) {
 	cfg.RBACEnabled = false
 	sc := setupHTTPServerWithCfg(t, true, cfg)
 
-	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
+	err := sc.db.CreateOrg(context.Background(), &models.CreateOrgCommand{Name: "TestOrg", UserId: testUserID})
 	require.NoError(t, err)
 
 	input := strings.NewReader(testUpdateOrgAddressForm)
@@ -170,7 +172,7 @@ func TestAPIEndpoint_PutCurrentOrgAddress_AccessControl(t *testing.T) {
 	sc := setupHTTPServer(t, true)
 	setInitCtxSignedInViewer(sc.initCtx)
 
-	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
+	err := sc.db.CreateOrg(context.Background(), &models.CreateOrgCommand{Name: "TestOrg", UserId: testUserID})
 	require.NoError(t, err)
 
 	input := strings.NewReader(testUpdateOrgAddressForm)
@@ -206,7 +208,7 @@ func setupOrgsDBForAccessControlTests(t *testing.T, db *sqlstore.SQLStore, c acc
 
 	// Create `orgsCount` orgs
 	for i := 1; i <= int(orgID); i++ {
-		_, err := db.CreateOrgWithMember(fmt.Sprintf("TestOrg%v", i), 0)
+		err := db.CreateOrg(context.Background(), &models.CreateOrgCommand{Name: fmt.Sprintf("TestOrg%v", i), UserId: 0})
 		require.NoError(t, err)
 	}
 }

--- a/pkg/api/org_users_test.go
+++ b/pkg/api/org_users_test.go
@@ -341,9 +341,9 @@ func setupOrgUsersDBForAccessControlTests(t *testing.T, db *sqlstore.SQLStore, o
 	require.NoError(t, err)
 
 	// Create both orgs with server admin
-	_, err = db.CreateOrgWithMember(testServerAdminViewer.OrgName, testServerAdminViewer.UserID)
+	err = db.CreateOrg(context.Background(), &models.CreateOrgCommand{Name: testServerAdminViewer.OrgName, UserId: testServerAdminViewer.UserID})
 	require.NoError(t, err)
-	_, err = db.CreateOrgWithMember(testAdminOrg2.OrgName, testServerAdminViewer.UserID)
+	err = db.CreateOrg(context.Background(), &models.CreateOrgCommand{Name: testAdminOrg2.OrgName, UserId: testServerAdminViewer.UserID})
 	require.NoError(t, err)
 
 	err = orgService.AddOrgUser(context.Background(), &org.AddOrgUserCommand{LoginOrEmail: testAdminOrg2.Login, Role: testAdminOrg2.OrgRole, OrgID: testAdminOrg2.OrgID, UserID: testAdminOrg2.UserID})

--- a/pkg/api/preferences_test.go
+++ b/pkg/api/preferences_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -50,7 +51,7 @@ func TestAPIEndpoint_GetCurrentOrgPreferences_LegacyAccessControl(t *testing.T) 
 	prefService.ExpectedPreference = &pref.Preference{HomeDashboardID: 1, Theme: "dark"}
 	sc.hs.preferenceService = prefService
 
-	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
+	err := sc.db.CreateOrg(context.Background(), &models.CreateOrgCommand{Name: "TestOrg", UserId: testUserID})
 	require.NoError(t, err)
 
 	setInitCtxSignedInViewer(sc.initCtx)
@@ -79,7 +80,7 @@ func TestAPIEndpoint_GetCurrentOrgPreferences_AccessControl(t *testing.T) {
 	prefService.ExpectedPreference = &pref.Preference{HomeDashboardID: 1, Theme: "dark"}
 	sc.hs.preferenceService = prefService
 
-	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
+	err := sc.db.CreateOrg(context.Background(), &models.CreateOrgCommand{Name: "TestOrg", UserId: testUserID})
 	require.NoError(t, err)
 
 	t.Run("AccessControl allows getting org preferences with correct permissions", func(t *testing.T) {
@@ -104,7 +105,7 @@ func TestAPIEndpoint_PutCurrentOrgPreferences_LegacyAccessControl(t *testing.T) 
 	cfg.RBACEnabled = false
 	sc := setupHTTPServerWithCfg(t, true, cfg)
 
-	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
+	err := sc.db.CreateOrg(context.Background(), &models.CreateOrgCommand{Name: "TestOrg", UserId: testUserID})
 	require.NoError(t, err)
 
 	setInitCtxSignedInViewer(sc.initCtx)
@@ -126,7 +127,7 @@ func TestAPIEndpoint_PutCurrentOrgPreferences_AccessControl(t *testing.T) {
 	sc := setupHTTPServer(t, true)
 	setInitCtxSignedInViewer(sc.initCtx)
 
-	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
+	err := sc.db.CreateOrg(context.Background(), &models.CreateOrgCommand{Name: "TestOrg", UserId: testUserID})
 	require.NoError(t, err)
 
 	input := strings.NewReader(testUpdateOrgPreferencesCmd)
@@ -156,7 +157,7 @@ func TestAPIEndpoint_PatchUserPreferences(t *testing.T) {
 	cfg.RBACEnabled = false
 	sc := setupHTTPServerWithCfg(t, true, cfg)
 
-	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
+	err := sc.db.CreateOrg(context.Background(), &models.CreateOrgCommand{Name: "TestOrg", UserId: testUserID})
 	require.NoError(t, err)
 
 	setInitCtxSignedInOrgAdmin(sc.initCtx)
@@ -189,7 +190,7 @@ func TestAPIEndpoint_PatchOrgPreferences(t *testing.T) {
 	cfg.RBACEnabled = false
 	sc := setupHTTPServerWithCfg(t, true, cfg)
 
-	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
+	err := sc.db.CreateOrg(context.Background(), &models.CreateOrgCommand{Name: "TestOrg", UserId: testUserID})
 	require.NoError(t, err)
 
 	setInitCtxSignedInOrgAdmin(sc.initCtx)

--- a/pkg/api/team_members_test.go
+++ b/pkg/api/team_members_test.go
@@ -127,8 +127,10 @@ func setupTeamTestScenario(userCount int, db *sqlstore.SQLStore, t *testing.T) i
 	teamService := teamimpl.ProvideService(db, setting.NewCfg()) // FIXME
 	user, err := db.CreateUser(context.Background(), user.CreateUserCommand{SkipOrgSetup: true, Login: testUserLogin})
 	require.NoError(t, err)
-	testOrg, err := db.CreateOrgWithMember("TestOrg", user.ID)
+	cmd := &models.CreateOrgCommand{Name: "TestOrg", UserId: user.ID}
+	err = db.CreateOrg(context.Background(), cmd)
 	require.NoError(t, err)
+	testOrg := cmd.Result
 
 	team, err := teamService.CreateTeam("test", "test@test.com", testOrg.Id)
 	require.NoError(t, err)

--- a/pkg/services/accesscontrol/resourcepermissions/store_test.go
+++ b/pkg/services/accesscontrol/resourcepermissions/store_test.go
@@ -486,8 +486,10 @@ func seedResourcePermissions(t *testing.T, store *store, sql *sqlstore.SQLStore,
 	var org *models.Org
 	for i := 0; i < numUsers; i++ {
 		if org == nil {
-			addedOrg, err := sql.CreateOrgWithMember("test", int64(i))
+			cmd := &models.CreateOrgCommand{Name: "test", UserId: int64(i)}
+			err := sql.CreateOrg(context.Background(), cmd)
 			require.NoError(t, err)
+			addedOrg := cmd.Result
 			org = &addedOrg
 		}
 

--- a/pkg/services/sqlstore/org.go
+++ b/pkg/services/sqlstore/org.go
@@ -71,11 +71,6 @@ func (ss *SQLStore) createOrg(ctx context.Context, name string, userID int64, en
 	return orga, nil
 }
 
-// CreateOrgWithMember creates an organization with a certain name and a certain user as member.
-func (ss *SQLStore) CreateOrgWithMember(name string, userID int64) (models.Org, error) {
-	return ss.createOrg(context.Background(), name, userID, ss.engine)
-}
-
 func (ss *SQLStore) CreateOrg(ctx context.Context, cmd *models.CreateOrgCommand) error {
 	org, err := ss.createOrg(ctx, cmd.Name, cmd.UserId, ss.engine)
 	if err != nil {

--- a/pkg/tests/api/alerting/api_alertmanager_test.go
+++ b/pkg/tests/api/alerting/api_alertmanager_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/grafana/pkg/models"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	ngstore "github.com/grafana/grafana/pkg/services/ngalert/store"
@@ -2540,8 +2541,10 @@ func createUser(t *testing.T, store *sqlstore.SQLStore, cmd user.CreateUserComma
 }
 
 func createOrg(t *testing.T, store *sqlstore.SQLStore, name string, userID int64) int64 {
-	org, err := store.CreateOrgWithMember(name, userID)
+	cmd := &models.CreateOrgCommand{Name: name, UserId: userID}
+	err := store.CreateOrg(context.Background(), cmd)
 	require.NoError(t, err)
+	org := cmd.Result
 	return org.Id
 }
 


### PR DESCRIPTION
Related to sqlstore split this removes sqlstore.CreateOrgWithMember and use sqlstore.CreateOrg instead. Yeah, not much of an improvement but still one method fewer.