### PR TITLE
fix the resp of  "invalid API Key"   when set anonymous access

### DIFF
--- a/pkg/services/contexthandler/contexthandler.go
+++ b/pkg/services/contexthandler/contexthandler.go
@@ -157,13 +157,13 @@ func (h *ContextHandler) Middleware(next http.Handler) http.Handler {
 		// then look for api key in session (special case for render calls via api)
 		// then test if anonymous access is enabled
 		switch {
+		case h.initContextWithAnonymousUser(reqContext):
 		case h.initContextWithRenderAuth(reqContext):
 		case h.initContextWithJWT(reqContext, orgID):
 		case h.initContextWithAPIKey(reqContext):
 		case h.initContextWithBasicAuth(reqContext, orgID):
 		case h.initContextWithAuthProxy(reqContext, orgID):
 		case h.initContextWithToken(reqContext, orgID):
-		case h.initContextWithAnonymousUser(reqContext):
 		}
 
 		reqContext.Logger = reqContext.Logger.New("userId", reqContext.UserID, "orgId", reqContext.OrgID, "uname", reqContext.Login)


### PR DESCRIPTION
fix the resp of  "invalid API Key"   when set anonymous access,if we use proxy to visit grafana,always with some info like jwt and grafana should not handle it 