### PR TITLE
bump @grafana/toolkit's babel-loader version to 9.1.0

### DIFF
--- a/packages/grafana-toolkit/package.json
+++ b/packages/grafana-toolkit/package.json
@@ -72,7 +72,7 @@
     "@typescript-eslint/parser": "5.36.2",
     "axios": "^0.26.1",
     "babel-jest": "27.5.1",
-    "babel-loader": "^8.2.5",
+    "babel-loader": "^9.1.0",
     "babel-plugin-angularjs-annotate": "0.10.0",
     "chalk": "^4.1.2",
     "command-exists": "^1.2.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4609,7 +4609,7 @@ __metadata:
     "@typescript-eslint/parser": 5.36.2
     axios: ^0.26.1
     babel-jest: 27.5.1
-    babel-loader: ^8.2.5
+    babel-loader: ^9.1.0
     babel-plugin-angularjs-annotate: 0.10.0
     chalk: ^4.1.2
     command-exists: ^1.2.9
@@ -13968,7 +13968,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-loader@npm:9.1.0":
+"babel-loader@npm:9.1.0, babel-loader@npm:^9.1.0":
   version: 9.1.0
   resolution: "babel-loader@npm:9.1.0"
   dependencies:
@@ -13981,7 +13981,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-loader@npm:^8.0.0, babel-loader@npm:^8.2.5":
+"babel-loader@npm:^8.0.0":
   version: 8.2.5
   resolution: "babel-loader@npm:8.2.5"
   dependencies:


### PR DESCRIPTION
**What is this feature?**

Updates `babel-loader` dependency in `@grafana/toolkit` package

**Why do we need this feature?**

Patches a transitive CVE

**Who is this feature for?**

**Which issue(s) does this PR fix?**:

Currently `babel-loader` is affected by a transitive CVE in one of its dependencies, this was patched in `v9.0.0`. Noticed this on a `grafana/oncall` dependabot alert:
<img width="1252" alt="Screenshot 2022-11-23 at 11 04 11" src="https://user-images.githubusercontent.com/9406895/203519653-a6efc76c-842f-4c98-8ad8-318712a8c91b.png">

**Special notes for your reviewer**:

