### PR TITLE
[9.2.x] Fix #58598 X-ID-Token header missing on Loki Datasource (#58784)

### DIFF
--- a/pkg/tsdb/loki/loki.go
+++ b/pkg/tsdb/loki/loki.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/textproto"
 	"regexp"
 	"strings"
 	"sync"
@@ -122,18 +123,22 @@ func (s *Service) CallResource(ctx context.Context, req *backend.CallResourceReq
 func getAuthHeadersForCallResource(headers map[string][]string) map[string]string {
 	data := make(map[string]string)
 
-	if auth := arrayHeaderFirstValue(headers["Authorization"]); auth != "" {
-		data["Authorization"] = auth
-	}
+	for k, values := range headers {
+		k = textproto.CanonicalMIMEHeaderKey(k)
+		firstValue := arrayHeaderFirstValue(values)
 
-	if cookie := arrayHeaderFirstValue(headers["Cookie"]); cookie != "" {
-		data["Cookie"] = cookie
+		if firstValue == "" {
+			continue
+		}
+		switch k {
+		case "Authorization":
+			data["Authorization"] = firstValue
+		case "X-Id-Token":
+			data["X-ID-Token"] = firstValue
+		case "Cookie":
+			data["Cookie"] = firstValue
+		}
 	}
-
-	if idToken := arrayHeaderFirstValue(headers["X-ID-Token"]); idToken != "" {
-		data["X-ID-Token"] = idToken
-	}
-
 	return data
 }
 

--- a/pkg/tsdb/loki/loki_test.go
+++ b/pkg/tsdb/loki/loki_test.go
@@ -37,7 +37,6 @@ func TestGetHeadersForCallResource(t *testing.T) {
 			expectedHeaders: map[string]string{
 				"Authorization":   authTokn1,
 				"Cookie":          "a=1",
-				"Accept-Encoding": "gzip",
 				"X-ID-Token":      idTokn1,
 			},
 		},
@@ -52,7 +51,6 @@ func TestGetHeadersForCallResource(t *testing.T) {
 			expectedHeaders: map[string]string{
 				"Authorization":   authTokn1,
 				"Cookie":          "a=1",
-				"Accept-Encoding": "gzip",
 				"X-ID-Token":      idTokn1,
 			},
 		},
@@ -67,7 +65,7 @@ func TestGetHeadersForCallResource(t *testing.T) {
 	}
 	for name, test := range testCases {
 		t.Run(name, func(t *testing.T) {
-			headers := getHeadersForCallResource(test.headers)
+			headers := getAuthHeadersForCallResource(test.headers)
 			assert.Equal(t, test.expectedHeaders, headers)
 		})
 	}

--- a/pkg/tsdb/loki/loki_test.go
+++ b/pkg/tsdb/loki/loki_test.go
@@ -35,9 +35,9 @@ func TestGetHeadersForCallResource(t *testing.T) {
 				"X-Id-Token":       {idTokn1, idTokn2},
 			},
 			expectedHeaders: map[string]string{
-				"Authorization":   authTokn1,
-				"Cookie":          "a=1",
-				"X-ID-Token":      idTokn1,
+				"Authorization": authTokn1,
+				"Cookie":        "a=1",
+				"X-ID-Token":    idTokn1,
 			},
 		},
 		"Headers with single value": {
@@ -49,9 +49,9 @@ func TestGetHeadersForCallResource(t *testing.T) {
 				"X-Id-Token":       {idTokn1},
 			},
 			expectedHeaders: map[string]string{
-				"Authorization":   authTokn1,
-				"Cookie":          "a=1",
-				"X-ID-Token":      idTokn1,
+				"Authorization": authTokn1,
+				"Cookie":        "a=1",
+				"X-ID-Token":    idTokn1,
 			},
 		},
 		"Non Canonical 'X-Id-Token' header key": {

--- a/pkg/tsdb/loki/loki_test.go
+++ b/pkg/tsdb/loki/loki_test.go
@@ -1,0 +1,74 @@
+package loki
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetHeadersForCallResource(t *testing.T) {
+	const idTokn1 = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+	const idTokn2 = "eyJhbGciOiJIUzI1NiJ9.eyJuYW1lIjoiSm9obiBEb2UiLCJleHAiOjE2Njg2MjExODQsImlhdCI6MTY2ODYyMTE4NH0.bg0Y0S245DeANhNnnLBCfGYBseTld29O0xynhQwZZlU"
+	const authTokn1 = "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+	const authTokn2 = "Bearer eyJhbGciOiJIUzI1NiJ9.eyJuYW1lIjoiSm9obiBEb2UiLCJleHAiOjE2Njg2MjExODQsImlhdCI6MTY2ODYyMTE4NH0.bg0Y0S245DeANhNnnLBCfGYBseTld29O0xynhQwZZlU"
+
+	testCases := map[string]struct {
+		headers         map[string][]string
+		expectedHeaders map[string]string
+	}{
+		"Headers with empty value": {
+			headers: map[string][]string{
+				"X-Grafana-Org-Id": {"1"},
+				"Cookie":           {""},
+				"X-Id-Token":       {""},
+				"Accept-Encoding":  {""},
+				"Authorization":    {""},
+			},
+			expectedHeaders: map[string]string{},
+		},
+		"Headers with multiple values": {
+			headers: map[string][]string{
+				"Authorization":    {authTokn1, authTokn2},
+				"Cookie":           {"a=1"},
+				"X-Grafana-Org-Id": {"1"},
+				"Accept-Encoding":  {"gzip", "compress"},
+				"X-Id-Token":       {idTokn1, idTokn2},
+			},
+			expectedHeaders: map[string]string{
+				"Authorization":   authTokn1,
+				"Cookie":          "a=1",
+				"Accept-Encoding": "gzip",
+				"X-ID-Token":      idTokn1,
+			},
+		},
+		"Headers with single value": {
+			headers: map[string][]string{
+				"Authorization":    {authTokn1},
+				"X-Grafana-Org-Id": {"1"},
+				"Cookie":           {"a=1"},
+				"Accept-Encoding":  {"gzip"},
+				"X-Id-Token":       {idTokn1},
+			},
+			expectedHeaders: map[string]string{
+				"Authorization":   authTokn1,
+				"Cookie":          "a=1",
+				"Accept-Encoding": "gzip",
+				"X-ID-Token":      idTokn1,
+			},
+		},
+		"Non Canonical 'X-Id-Token' header key": {
+			headers: map[string][]string{
+				"X-ID-TOKEN": {idTokn1},
+			},
+			expectedHeaders: map[string]string{
+				"X-ID-Token": idTokn1,
+			},
+		},
+	}
+	for name, test := range testCases {
+		t.Run(name, func(t *testing.T) {
+			headers := getHeadersForCallResource(test.headers)
+			assert.Equal(t, test.expectedHeaders, headers)
+		})
+	}
+}


### PR DESCRIPTION
Backport https://github.com/grafana/grafana/commit/f1ef63791ad17d4c3b16cd296148c403515ad37d from https://github.com/grafana/grafana/pull/58784