### PR TITLE
Chore: Reordering codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -114,6 +114,8 @@ go.sum @grafana/backend-platform
 /contribute/architecture/backend @grafana/backend-platform
 /contribute/engineering/backend @grafana/backend-platform
 
+package.json @grafana/frontend-ops
+tsconfig.json @grafana/frontend-ops
 /crowdin.yml @grafana/user-essentials
 /public/locales @grafana/user-essentials
 /public/app/core/internationalization @grafana/user-essentials
@@ -167,8 +169,6 @@ go.sum @grafana/backend-platform
 /scripts/grunt @grafana/frontend-ops
 /scripts/webpack @grafana/frontend-ops
 /scripts/generate-a11y-report.sh @grafana/user-essentials
-package.json @grafana/frontend-ops
-tsconfig.json @grafana/frontend-ops
 lerna.json @grafana/frontend-ops
 .babelrc @grafana/frontend-ops
 .prettierrc.js @grafana/frontend-ops


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Reordering `CODEOWNERS` file line order to make changes to packages being assigned to the correct teams. Reason for that codeowners last match wins. This leads to currently anything that is changed in `package.json` and `tsconfig.json` will go to frontend-ops, instead it should go to the ones owning a package.