### PR TITLE
Internationalization: Enable internationalization by default

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1272,6 +1272,8 @@ license_path =
 # enable = feature1,feature2
 enable =
 
+internationalization = true
+
 # feature1 = true
 # feature2 = false
 

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -270,8 +270,8 @@ var (
 		},
 		{
 			Name:        "internationalization",
-			Description: "Enables work-in-progress internationalization",
-			State:       FeatureStateAlpha,
+			Description: "Enables internationalization",
+			State:       FeatureStateStable,
 		},
 		{
 			Name:        "topnav",

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -196,7 +196,7 @@ const (
 	FlagDataConnectionsConsole = "dataConnectionsConsole"
 
 	// FlagInternationalization
-	// Enables work-in-progress internationalization
+	// Enables internationalization
 	FlagInternationalization = "internationalization"
 
 	// FlagTopnav

--- a/public/app/core/components/SharedPreferences/SharedPreferences.tsx
+++ b/public/app/core/components/SharedPreferences/SharedPreferences.tsx
@@ -187,7 +187,7 @@ export class SharedPreferences extends PureComponent<Props, State> {
                       <span className={styles.labelText}>
                         <Trans i18nKey="shared-preferences.fields.locale-label">Language</Trans>
                       </span>
-                      <FeatureBadge featureState={FeatureState.alpha} />
+                      <FeatureBadge featureState={FeatureState.beta} />
                     </Label>
                   }
                   data-testid="User preferences language drop down"


### PR DESCRIPTION
**What is this feature?**

 - Enables the `internationalization` feature flag by default. This functionality will stay behind a feature flag to allow us to roll back if needed in the short term, but the feature flag will be removed entirely in a future release
 - Changes the feature badge for Language in preferences to Beta instead of alpha.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #51578  
Fixes #49280  
Fixes #448  

**Special notes for your reviewer**:

This PR just enables internationalization by default. See [all previous internationalization PRs](https://github.com/grafana/grafana/pulls?q=is%3Apr+label%3Aarea%2Finternationalization+is%3Amerged) for more details about the changes.