### PR TITLE
LoginAttempts: Reset attempts on successfull password reset

### DIFF
--- a/pkg/api/password.go
+++ b/pkg/api/password.go
@@ -60,7 +60,11 @@ func (hs *HTTPServer) ResetPassword(c *models.ReqContext) response.Response {
 	}
 	query := models.ValidateResetPasswordCodeQuery{Code: form.Code}
 
+	// For now the only way to know the username to clear login attempts for is
+	// to set it in the function provided to NotificationService
+	var username string
 	getUserByLogin := func(ctx context.Context, login string) (*user.User, error) {
+		username = login
 		userQuery := user.GetUserByLoginQuery{LoginOrEmail: login}
 		usr, err := hs.userService.GetByLogin(ctx, &userQuery)
 		return usr, err
@@ -92,6 +96,10 @@ func (hs *HTTPServer) ResetPassword(c *models.ReqContext) response.Response {
 
 	if err := hs.userService.ChangePassword(c.Req.Context(), &cmd); err != nil {
 		return response.Error(500, "Failed to change user password", err)
+	}
+
+	if err := hs.loginAttemptService.Reset(c.Req.Context(), username); err != nil {
+		c.Logger.Warn("could not reset login attempts", "err", err, "username", username)
 	}
 
 	return response.Success("User password changed")

--- a/pkg/services/loginattempt/login_attempt.go
+++ b/pkg/services/loginattempt/login_attempt.go
@@ -10,6 +10,8 @@ type Service interface {
 	// Validate checks if username has to many login attempts inside a window.
 	// Will return true if provided username do not have too many attempts.
 	Validate(ctx context.Context, username string) (bool, error)
+	// Reset resets all login attempts attached to username
+	Reset(ctx context.Context, username string) error
 }
 
 type LoginAttempt struct {

--- a/pkg/services/loginattempt/loginattemptimpl/login_attempt.go
+++ b/pkg/services/loginattempt/loginattemptimpl/login_attempt.go
@@ -59,6 +59,10 @@ func (s *Service) Add(ctx context.Context, username, IPAddress string) error {
 	})
 }
 
+func (s *Service) Reset(ctx context.Context, username string) error {
+	return s.store.DeleteLoginAttempts(ctx, DeleteLoginAttemptsCommand{username})
+}
+
 func (s *Service) Validate(ctx context.Context, username string) (bool, error) {
 	if s.cfg.DisableBruteForceLoginProtection {
 		return true, nil

--- a/pkg/services/loginattempt/loginattemptimpl/login_attempt_test.go
+++ b/pkg/services/loginattempt/loginattemptimpl/login_attempt_test.go
@@ -96,3 +96,7 @@ func (f fakeStore) CreateLoginAttempt(ctx context.Context, command CreateLoginAt
 func (f fakeStore) DeleteOldLoginAttempts(ctx context.Context, command DeleteOldLoginAttemptsCommand) (int64, error) {
 	return f.ExpectedDeletedRows, f.ExpectedErr
 }
+
+func (f fakeStore) DeleteLoginAttempts(ctx context.Context, cmd DeleteLoginAttemptsCommand) error {
+	return f.ExpectedErr
+}

--- a/pkg/services/loginattempt/loginattemptimpl/models.go
+++ b/pkg/services/loginattempt/loginattemptimpl/models.go
@@ -21,3 +21,7 @@ type GetUserLoginAttemptCountQuery struct {
 type DeleteOldLoginAttemptsCommand struct {
 	OlderThan time.Time
 }
+
+type DeleteLoginAttemptsCommand struct {
+	Username string
+}

--- a/pkg/services/loginattempt/loginattemptimpl/store.go
+++ b/pkg/services/loginattempt/loginattemptimpl/store.go
@@ -2,7 +2,6 @@ package loginattemptimpl
 
 import (
 	"context"
-	"strconv"
 	"time"
 
 	"github.com/grafana/grafana/pkg/infra/db"
@@ -42,26 +41,7 @@ func (xs *xormStore) CreateLoginAttempt(ctx context.Context, cmd CreateLoginAtte
 func (xs *xormStore) DeleteOldLoginAttempts(ctx context.Context, cmd DeleteOldLoginAttemptsCommand) (int64, error) {
 	var deletedRows int64
 	err := xs.db.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
-		var maxId int64
-		sql := "SELECT max(id) as id FROM login_attempt WHERE created < ?"
-		result, err := sess.Query(sql, cmd.OlderThan.Unix())
-		if err != nil {
-			return err
-		}
-		if len(result) == 0 || result[0] == nil {
-			return nil
-		}
-
-		// TODO: why don't we know the type of ID?
-		maxId = toInt64(result[0]["id"])
-
-		if maxId == 0 {
-			return nil
-		}
-
-		sql = "DELETE FROM login_attempt WHERE id <= ?"
-
-		deleteResult, err := sess.Exec(sql, maxId)
+		deleteResult, err := sess.Exec("DELETE FROM login_attempt WHERE created < ?", cmd.OlderThan.Unix())
 		if err != nil {
 			return err
 		}
@@ -100,17 +80,4 @@ func (xs *xormStore) GetUserLoginAttemptCount(ctx context.Context, query GetUser
 	})
 
 	return total, err
-}
-
-func toInt64(i interface{}) int64 {
-	switch i := i.(type) {
-	case []byte:
-		n, _ := strconv.ParseInt(string(i), 10, 64)
-		return n
-	case int:
-		return int64(i)
-	case int64:
-		return i
-	}
-	return 0
 }

--- a/pkg/services/loginattempt/loginattemptimpl/store.go
+++ b/pkg/services/loginattempt/loginattemptimpl/store.go
@@ -17,6 +17,7 @@ type xormStore struct {
 type store interface {
 	CreateLoginAttempt(ctx context.Context, cmd CreateLoginAttemptCommand) error
 	DeleteOldLoginAttempts(ctx context.Context, cmd DeleteOldLoginAttemptsCommand) (int64, error)
+	DeleteLoginAttempts(ctx context.Context, cmd DeleteLoginAttemptsCommand) error
 	GetUserLoginAttemptCount(ctx context.Context, query GetUserLoginAttemptCountQuery) (int64, error)
 }
 
@@ -72,6 +73,13 @@ func (xs *xormStore) DeleteOldLoginAttempts(ctx context.Context, cmd DeleteOldLo
 		return nil
 	})
 	return deletedRows, err
+}
+
+func (xs *xormStore) DeleteLoginAttempts(ctx context.Context, cmd DeleteLoginAttemptsCommand) error {
+	return xs.db.WithDbSession(ctx, func(sess *db.Session) error {
+		_, err := sess.Exec("DELETE FROM login_attempt WHERE username = ?", cmd.Username)
+		return err
+	})
 }
 
 func (xs *xormStore) GetUserLoginAttemptCount(ctx context.Context, query GetUserLoginAttemptCountQuery) (int64, error) {

--- a/pkg/services/loginattempt/loginattempttest/fake.go
+++ b/pkg/services/loginattempt/loginattempttest/fake.go
@@ -17,6 +17,10 @@ func (f FakeLoginAttemptService) Add(ctx context.Context, username, IPAddress st
 	return f.ExpectedErr
 }
 
+func (f FakeLoginAttemptService) Reset(ctx context.Context, username string) error {
+	return f.ExpectedErr
+}
+
 func (f FakeLoginAttemptService) Validate(ctx context.Context, username string) (bool, error) {
 	return f.ExpectedValid, f.ExpectedErr
 }

--- a/pkg/services/loginattempt/loginattempttest/mock.go
+++ b/pkg/services/loginattempt/loginattempttest/mock.go
@@ -10,6 +10,7 @@ var _ loginattempt.Service = new(MockLoginAttemptService)
 
 type MockLoginAttemptService struct {
 	AddCalled      bool
+	ResetCalled    bool
 	ValidateCalled bool
 
 	ExpectedValid bool
@@ -18,6 +19,11 @@ type MockLoginAttemptService struct {
 
 func (f *MockLoginAttemptService) Add(ctx context.Context, username, IPAddress string) error {
 	f.AddCalled = true
+	return f.ExpectedErr
+}
+
+func (f *MockLoginAttemptService) Reset(ctx context.Context, username string) error {
+	f.ResetCalled = true
 	return f.ExpectedErr
 }
 


### PR DESCRIPTION
**What is this feature?**
When trying to sign in into grafana there is not a clear message on what went wrong, we always display "Invalid username or password".  Login attempts are recorded for every unsuccessful login and have a 5 minute window.

If the user gets blocked by to many login attempts it is not clear what is going wrong and could trigger users to reset their password

When resetting the password we should also reset the login attempts for that user so they can authenticate after a successful reset

**Which issue(s) does this PR fix?**:

Fixes #30161

**Special notes for your reviewer**:
* Simplify the DeleteOldLoginAttempts query
