### PR TITLE
Chore: gitignore storage.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,7 @@ debug.test
 /packaging/**/*.tar.gz
 /packaging/**/*.tar.gz.sha256
 pkg/cmd/grafana-server/__debug_bin
+pkg/services/quota/quotaimpl/storage/storage.json
 
 # Ignore OSX indexing
 .DS_Store


### PR DESCRIPTION


**What is this feature?**

ignores a file generated by the quota service integration tests