### PR TITLE
CloudWatch: Fix flaky test assertions

### DIFF
--- a/pkg/tsdb/cloudwatch/routes/dimension_keys_test.go
+++ b/pkg/tsdb/cloudwatch/routes/dimension_keys_test.go
@@ -29,8 +29,8 @@ func Test_DimensionKeys_Route(t *testing.T) {
 				r.Namespace == "AWS/EC2" &&
 				r.MetricName == "CPUUtilization" &&
 				len(r.DimensionFilter) == 2 &&
-				assert.Contains(t, r.DimensionFilter, &resources.Dimension{"NodeID", "Shared"}) &&
-				assert.Contains(t, r.DimensionFilter, &resources.Dimension{"stage", "QueryCommit"})
+				assert.Contains(t, r.DimensionFilter, &resources.Dimension{Name: "NodeID", Value: "Shared"}) &&
+				assert.Contains(t, r.DimensionFilter, &resources.Dimension{Name: "stage", Value: "QueryCommit"})
 		})).Return([]string{}, nil).Once()
 		newListMetricsService = func(pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.ListMetricsProvider, error) {
 			return &mockListMetricsService, nil

--- a/pkg/tsdb/cloudwatch/routes/dimension_keys_test.go
+++ b/pkg/tsdb/cloudwatch/routes/dimension_keys_test.go
@@ -24,7 +24,14 @@ var logger = &logtest.Fake{}
 func Test_DimensionKeys_Route(t *testing.T) {
 	t.Run("calls FilterDimensionKeysRequest when a StandardDimensionKeysRequest is passed", func(t *testing.T) {
 		mockListMetricsService := mocks.ListMetricsServiceMock{}
-		mockListMetricsService.On("GetDimensionKeysByDimensionFilter", mock.Anything).Return([]string{}, nil).Once()
+		mockListMetricsService.On("GetDimensionKeysByDimensionFilter", mock.MatchedBy(func(r resources.DimensionKeysRequest) bool {
+			return r.ResourceRequest != nil && *r.ResourceRequest == resources.ResourceRequest{Region: "us-east-2"} &&
+				r.Namespace == "AWS/EC2" &&
+				r.MetricName == "CPUUtilization" &&
+				len(r.DimensionFilter) == 2 &&
+				assert.Contains(t, r.DimensionFilter, &resources.Dimension{"NodeID", "Shared"}) &&
+				assert.Contains(t, r.DimensionFilter, &resources.Dimension{"stage", "QueryCommit"})
+		})).Return([]string{}, nil).Once()
 		newListMetricsService = func(pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.ListMetricsProvider, error) {
 			return &mockListMetricsService, nil
 		}
@@ -32,12 +39,6 @@ func Test_DimensionKeys_Route(t *testing.T) {
 		req := httptest.NewRequest("GET", `/dimension-keys?region=us-east-2&namespace=AWS/EC2&metricName=CPUUtilization&dimensionFilters={"NodeID":["Shared"],"stage":["QueryCommit"]}`, nil)
 		handler := http.HandlerFunc(ResourceRequestMiddleware(DimensionKeysHandler, logger, nil))
 		handler.ServeHTTP(rr, req)
-		mockListMetricsService.AssertCalled(t, "GetDimensionKeysByDimensionFilter", resources.DimensionKeysRequest{
-			ResourceRequest: &resources.ResourceRequest{Region: "us-east-2"},
-			Namespace:       "AWS/EC2",
-			MetricName:      "CPUUtilization",
-			DimensionFilter: []*resources.Dimension{{Name: "NodeID", Value: "Shared"}, {Name: "stage", Value: "QueryCommit"}},
-		})
 	})
 
 	t.Run("calls GetHardCodedDimensionKeysByNamespace when a StandardDimensionKeysRequest is passed", func(t *testing.T) {

--- a/pkg/tsdb/cloudwatch/routes/dimension_values_test.go
+++ b/pkg/tsdb/cloudwatch/routes/dimension_values_test.go
@@ -24,8 +24,8 @@ func Test_DimensionValues_Route(t *testing.T) {
 				r.MetricName == "CPUUtilization" &&
 				r.DimensionKey == "instanceId" &&
 				len(r.DimensionFilter) == 2 &&
-				assert.Contains(t, r.DimensionFilter, &resources.Dimension{"NodeID", "Shared"}) &&
-				assert.Contains(t, r.DimensionFilter, &resources.Dimension{"stage", "QueryCommit"})
+				assert.Contains(t, r.DimensionFilter, &resources.Dimension{Name: "NodeID", Value: "Shared"}) &&
+				assert.Contains(t, r.DimensionFilter, &resources.Dimension{Name: "stage", Value: "QueryCommit"})
 		})).Return([]string{}, nil).Once()
 		newListMetricsService = func(pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.ListMetricsProvider, error) {
 			return &mockListMetricsService, nil

--- a/pkg/tsdb/cloudwatch/routes/dimension_values_test.go
+++ b/pkg/tsdb/cloudwatch/routes/dimension_values_test.go
@@ -18,7 +18,15 @@ import (
 func Test_DimensionValues_Route(t *testing.T) {
 	t.Run("Calls GetDimensionValuesByDimensionFilter when a valid request is passed", func(t *testing.T) {
 		mockListMetricsService := mocks.ListMetricsServiceMock{}
-		mockListMetricsService.On("GetDimensionValuesByDimensionFilter", mock.Anything).Return([]string{}, nil).Once()
+		mockListMetricsService.On("GetDimensionValuesByDimensionFilter", mock.MatchedBy(func(r resources.DimensionValuesRequest) bool {
+			return r.ResourceRequest != nil && *r.ResourceRequest == resources.ResourceRequest{Region: "us-east-2"} &&
+				r.Namespace == "AWS/EC2" &&
+				r.MetricName == "CPUUtilization" &&
+				r.DimensionKey == "instanceId" &&
+				len(r.DimensionFilter) == 2 &&
+				assert.Contains(t, r.DimensionFilter, &resources.Dimension{"NodeID", "Shared"}) &&
+				assert.Contains(t, r.DimensionFilter, &resources.Dimension{"stage", "QueryCommit"})
+		})).Return([]string{}, nil).Once()
 		newListMetricsService = func(pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.ListMetricsProvider, error) {
 			return &mockListMetricsService, nil
 		}
@@ -26,13 +34,6 @@ func Test_DimensionValues_Route(t *testing.T) {
 		req := httptest.NewRequest("GET", `/dimension-values?region=us-east-2&dimensionKey=instanceId&namespace=AWS/EC2&metricName=CPUUtilization&dimensionFilters={"NodeID":["Shared"],"stage":["QueryCommit"]}`, nil)
 		handler := http.HandlerFunc(ResourceRequestMiddleware(DimensionValuesHandler, logger, nil))
 		handler.ServeHTTP(rr, req)
-		mockListMetricsService.AssertCalled(t, "GetDimensionValuesByDimensionFilter", resources.DimensionValuesRequest{
-			ResourceRequest: &resources.ResourceRequest{Region: "us-east-2"},
-			Namespace:       "AWS/EC2",
-			MetricName:      "CPUUtilization",
-			DimensionKey:    "instanceId",
-			DimensionFilter: []*resources.Dimension{{Name: "NodeID", Value: "Shared"}, {Name: "stage", Value: "QueryCommit"}},
-		})
 	})
 
 	t.Run("returns 500 if GetDimensionValuesByDimensionFilter returns an error", func(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

The previous assertions were flaky --seems to have been because of one of the asserted arrays could be in a different order. I didn't look into how that list was populated. 

I just rewrote the assertion so that the assertions are now in the mock's call definition and used `assert.Contains` + length of the array to effectively assert the same thing.
It's not maybe the best practice to chuck the `assert.Contains` in that matching function, but I think it's acceptable for now to prevent the flaky test.


