### PR TITLE
Chore: Update vscode "Run Server" config for single-binary

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,10 +6,10 @@
       "type": "go",
       "request": "launch",
       "mode": "auto",
-      "program": "${workspaceFolder}/pkg/cmd/grafana-server/",
+      "program": "${workspaceFolder}/pkg/cmd/grafana/",
       "env": {},
       "cwd": "${workspaceFolder}",
-      "args": ["--homepath", "${workspaceFolder}", "--packaging", "dev"]
+      "args": ["server", "--homepath", "${workspaceFolder}", "--packaging", "dev"]
     },
     {
       "name": "Attach to Chrome",


### PR DESCRIPTION
This PR changes the vscode "Run Server" config to launch the new `grafana` binary directly, fixing the issue reported by @andresmgot in #58286 