### PR TITLE
Docs: Update `merge-pull-request.md` regarding backport policies

### DIFF
--- a/contribute/merge-pull-request.md
+++ b/contribute/merge-pull-request.md
@@ -135,6 +135,14 @@ Some examples when backport is not required:
 
 - The change is supposed to be released in the next major/minor release, e.g. v8.0.0, but the release branch, e.g. v8.0.x, has not yet been created.
 
+#### Required labels
+
+To ensure that we don't backport pull requests that don't need to be backported, i.e. implement new features, and only backport pull requests that address bugs, have a product approval, or refer to docs changes, backport labels need to be followed by either:
+
+* `type/bug` label: Pull requests which address bugs,
+* `product-approved` label: Urgent fixes which need product approval, in order to get merged,
+* `type/docs` label: Docs changes`.
+
 > **Note:** You can still backport a pull request after it's been merged.
 
 ## Doing the actual merge

--- a/contribute/merge-pull-request.md
+++ b/contribute/merge-pull-request.md
@@ -139,9 +139,9 @@ Some examples when backport is not required:
 
 To ensure that we don't backport pull requests that don't need to be backported, i.e. implement new features, and only backport pull requests that address bugs, have a product approval, or refer to docs changes, backport labels need to be followed by either:
 
-* `type/bug` label: Pull requests which address bugs,
-* `product-approved` label: Urgent fixes which need product approval, in order to get merged,
-* `type/docs` label: Docs changes`.
+- `type/bug` label: Pull requests which address bugs,
+- `product-approved` label: Urgent fixes which need product approval, in order to get merged,
+- `type/docs` label: Docs changes`.
 
 > **Note:** You can still backport a pull request after it's been merged.
 


### PR DESCRIPTION
**What is this feature?**

This is a new policy that will help us ensure a good Grafana version quality. Backports should be done cautiously, and only address bugs or fixes which need to go in the next patch release, after product approval.
 
**Who is this feature for?**

Every Grafana contributor!

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana-release/issues/248

