### PR TITLE
Azure Monitor: Fix empty/errored responses for Logs variables

### DIFF
--- a/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
@@ -190,7 +190,7 @@ func (e *AzureLogAnalyticsDatasource) executeQuery(ctx context.Context, logger l
 	if err != nil {
 		return dataResponseErrorWithExecuted(err)
 	}
-	appendErrorNotice(frame, logResponse.Error)
+	frame = appendErrorNotice(frame, logResponse.Error)
 	if frame == nil {
 		return dataResponse
 	}

--- a/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
@@ -191,6 +191,9 @@ func (e *AzureLogAnalyticsDatasource) executeQuery(ctx context.Context, logger l
 		return dataResponseErrorWithExecuted(err)
 	}
 	appendErrorNotice(frame, logResponse.Error)
+	if frame == nil {
+		return dataResponse
+	}
 
 	model, err := simplejson.NewJson(query.JSON)
 	if err != nil {
@@ -222,10 +225,15 @@ func (e *AzureLogAnalyticsDatasource) executeQuery(ctx context.Context, logger l
 	return dataResponse
 }
 
-func appendErrorNotice(frame *data.Frame, err *AzureLogAnalyticsAPIError) {
-	if err != nil {
-		frame.AppendNotices(apiErrorToNotice(err))
+func appendErrorNotice(frame *data.Frame, err *AzureLogAnalyticsAPIError) *data.Frame {
+	if err == nil {
+		return frame
 	}
+	if frame == nil {
+		frame = &data.Frame{}
+	}
+	frame.AppendNotices(apiErrorToNotice(err))
+	return frame
 }
 
 func (e *AzureLogAnalyticsDatasource) createRequest(ctx context.Context, logger log.Logger, url string) (*http.Request, error) {

--- a/pkg/tsdb/azuremonitor/loganalytics/azure-response-table-frame.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/azure-response-table-frame.go
@@ -45,12 +45,7 @@ func apiErrorToNotice(err *AzureLogAnalyticsAPIError) data.Notice {
 // ResponseTableToFrame converts an AzureResponseTable to a data.Frame.
 func ResponseTableToFrame(table *types.AzureResponseTable, refID string, executedQuery string) (*data.Frame, error) {
 	if len(table.Rows) == 0 {
-		return &data.Frame{
-			RefID: refID,
-			Meta: &data.FrameMeta{
-				ExecutedQueryString: executedQuery,
-			},
-		}, nil
+		return nil, nil
 	}
 
 	converterFrame, err := converterFrameForTable(table)

--- a/pkg/tsdb/azuremonitor/loganalytics/azure-response-table-frame_test.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/azure-response-table-frame_test.go
@@ -173,12 +173,7 @@ func TestLogTableToFrame(t *testing.T) {
 			name:     "empty data response",
 			testFile: "loganalytics/11-log-analytics-response-empty.json",
 			expectedFrame: func() *data.Frame {
-				return &data.Frame{
-					RefID: "A",
-					Meta: &data.FrameMeta{
-						ExecutedQueryString: "query",
-					},
-				}
+				return nil
 			},
 		},
 	}

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/variables.test.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/variables.test.ts
@@ -489,6 +489,38 @@ describe('VariableSupport', () => {
     });
   });
 
+  it('passes on the query error for a log query', (done) => {
+    const variableSupport = new VariableSupport(
+      createMockDatasource({
+        query: () =>
+          from(
+            Promise.resolve({
+              data: [],
+              error: {
+                message: 'boom',
+              },
+            })
+          ),
+      })
+    );
+    const mockRequest = {
+      targets: [
+        {
+          queryType: AzureQueryType.LogAnalytics,
+          azureLogAnalytics: {
+            query: 'some log thing',
+          },
+        } as AzureMonitorQuery,
+      ],
+    } as DataQueryRequest<AzureMonitorQuery>;
+    const observables = variableSupport.query(mockRequest);
+    observables.subscribe((result: DataQueryResponseData) => {
+      expect(result.data).toEqual([]);
+      expect(result.error.message).toEqual('boom');
+      done();
+    });
+  });
+
   it('should handle http error', (done) => {
     const error = invalidSubscriptionError();
     const variableSupport = new VariableSupport(

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/variables.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/variables.ts
@@ -94,6 +94,7 @@ export class VariableSupport extends CustomVariableSupport<DataSource, AzureMoni
             const queryResp = await lastValueFrom(this.datasource.query(request));
             return {
               data: queryResp.data,
+              error: queryResp.error ? new Error(messageFromError(queryResp.error)) : undefined,
             };
         }
       } catch (err) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR is fixing two separated things, related to template variables when using Azure Monitor Logs:

 - If the response from Azure is empty (no rows), we were still returning a frame. This caused an error since the fronted tried to find a string parameter within the frame: `Error: Couldn't find any field of type string in the results.` This is now fixed in the backend.
 - If the request failed, the error was ignored and the frontend was still looking for a string field (resulting in the same error). This is fixed in the frontend code.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/support-escalations/issues/4499

**Special notes for your reviewer**:

I double checked that empty responses are not causing an error for alerting.
