### PR TITLE
Dashboard: Making a dashboard editable does not allow resizing of panels

### DIFF
--- a/public/app/features/dashboard/containers/DashboardPage.tsx
+++ b/public/app/features/dashboard/containers/DashboardPage.tsx
@@ -392,7 +392,12 @@ export class UnthemedDashboardPage extends PureComponent<Props, State> {
             </section>
           )}
 
-          <DashboardGrid dashboard={dashboard} viewPanel={viewPanel} editPanel={editPanel} />
+          <DashboardGrid
+            dashboard={dashboard}
+            isEditable={!!dashboard.meta.canEdit}
+            viewPanel={viewPanel}
+            editPanel={editPanel}
+          />
 
           {inspectPanel && <PanelInspector dashboard={dashboard} panel={inspectPanel} />}
         </Page>

--- a/public/app/features/dashboard/dashgrid/DashboardGrid.test.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardGrid.test.tsx
@@ -57,6 +57,7 @@ describe('DashboardGrid', () => {
     const props: Props = {
       editPanel: null,
       viewPanel: null,
+      isEditable: true,
       dashboard: getTestDashboard(),
     };
     expect(() => render(<DashboardGrid {...props} />)).not.toThrow();

--- a/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
@@ -17,6 +17,7 @@ import { DashboardPanel } from './DashboardPanel';
 
 export interface Props {
   dashboard: DashboardModel;
+  isEditable: boolean;
   editPanel: PanelModel | null;
   viewPanel: PanelModel | null;
 }
@@ -200,7 +201,7 @@ export class DashboardGrid extends PureComponent<Props, State> {
   }
 
   render() {
-    const { dashboard } = this.props;
+    const { isEditable } = this.props;
 
     /**
      * We have a parent with "flex: 1 1 0" we need to reset it to "flex: 1 1 auto" to have the AutoSizer
@@ -215,14 +216,13 @@ export class DashboardGrid extends PureComponent<Props, State> {
               return null;
             }
 
-            const draggable = width <= 769 ? false : dashboard.meta.canEdit;
+            const draggable = width <= 769 ? false : isEditable;
 
             /*
             Disable draggable if mobile device, solving an issue with unintentionally
             moving panels. https://github.com/grafana/grafana/issues/18497
             theme.breakpoints.md = 769
           */
-
             return (
               /**
                * The children is using a width of 100% so we need to guarantee that it is wrapped
@@ -233,7 +233,7 @@ export class DashboardGrid extends PureComponent<Props, State> {
                 <ReactGridLayout
                   width={width}
                   isDraggable={draggable}
-                  isResizable={dashboard.meta.canEdit}
+                  isResizable={isEditable}
                   containerPadding={[0, 0]}
                   useCSSTransforms={false}
                   margin={[GRID_CELL_VMARGIN, GRID_CELL_VMARGIN]}


### PR DESCRIPTION
**What is this feature?**

When `dashboard.meta.canEdit`/`canSave` is updated ([here](https://github.com/grafana/grafana/blob/polibb/rerender-dashboard-grid-when-editable-set/public/app/features/dashboard/components/DashboardSettings/DashboardSettings.tsx#L207)) the `DashboardGrid` should be rerendered in order to rerender `ReactGridLayout` with correct `isDraggable={true}` and `isResizable={true}` props.
It does not rerender because the dashboard prop defies the immutability principle and the object is the same. So, as the quickest/cleanest current solution, we can pass the `dashboard.meta.canEdit` value directly as it is not an object. 

**Why do we need this feature?**

When a read-only dashboard is set to "Make Editable" from its settings, the user can go back to the dashboard. The dashboard should now be editable and for the most part it is, except the Grid layout does not re-render, so it does not allow the resizing of panels as it should. 

**Which issue(s) does this PR fix?**:

Escalation https://github.com/grafana/support-escalations/issues/4493. 

Fixes #

**Special notes for your reviewer**:

