### PR TITLE
Heatmap: Fix blurry text & rendering

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/Plot.tsx
+++ b/packages/grafana-ui/src/components/uPlot/Plot.tsx
@@ -65,8 +65,8 @@ export class UPlotChart extends Component<PlotProps, UPlotChartState> {
     });
 
     const config: Options = {
-      width: this.props.width,
-      height: this.props.height,
+      width: Math.floor(this.props.width),
+      height: Math.floor(this.props.height),
       ...this.props.config.getConfig(),
     };
 
@@ -93,8 +93,8 @@ export class UPlotChart extends Component<PlotProps, UPlotChartState> {
 
     if (!sameDims(prevProps, this.props)) {
       plot?.setSize({
-        width: this.props.width,
-        height: this.props.height,
+        width: Math.floor(this.props.width),
+        height: Math.floor(this.props.height),
       });
     } else if (!sameConfig(prevProps, this.props)) {
       this.reinitPlot();


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/59205

more details in https://github.com/grafana/grafana/issues/59205#issuecomment-1325907459

that issue is specifically about Heatmap, but this fix actually affects all uPlot-based panels.

basically this ensures we don't set fractional width or height even when the viz container ends up being fractional due to flex auto-sizing and/or fractional vizlegend size.

this is most noticeable on non-hidpi displays (devicePixelRatio=1) with big(ish) pixels.