### PR TITLE
Perfomance: add preallocation for some slices

### DIFF
--- a/pkg/api/dashboard_permission.go
+++ b/pkg/api/dashboard_permission.go
@@ -156,7 +156,7 @@ func (hs *HTTPServer) UpdateDashboardPermissions(c *models.ReqContext) response.
 		return dashboardGuardianResponse(err)
 	}
 
-	var items []*models.DashboardACL
+	items := make([]*models.DashboardACL, 0, len(apiCmd.Items))
 	for _, item := range apiCmd.Items {
 		items = append(items, &models.DashboardACL{
 			OrgID:       c.OrgID,

--- a/pkg/api/folder_permission.go
+++ b/pkg/api/folder_permission.go
@@ -105,7 +105,7 @@ func (hs *HTTPServer) UpdateFolderPermissions(c *models.ReqContext) response.Res
 		return apierrors.ToFolderErrorResponse(dashboards.ErrFolderAccessDenied)
 	}
 
-	var items []*models.DashboardACL
+	items := make([]*models.DashboardACL, 0, len(apiCmd.Items))
 	for _, item := range apiCmd.Items {
 		items = append(items, &models.DashboardACL{
 			OrgID:       c.OrgID,

--- a/pkg/codegen/jenny_tsveneerindex.go
+++ b/pkg/codegen/jenny_tsveneerindex.go
@@ -306,7 +306,7 @@ var allowedTSVeneers = map[string]bool{
 }
 
 func allowedTSVeneersString() string {
-	var list []string
+	list := make([]string, 0, len(allowedTSVeneers))
 	for tgt := range allowedTSVeneers {
 		list = append(list, tgt)
 	}

--- a/pkg/plugins/pfs/pfs.go
+++ b/pkg/plugins/pfs/pfs.go
@@ -49,7 +49,7 @@ type slotandname struct {
 var allslots []slotandname
 
 func init() {
-	var all []string
+	all := make([]string, 0, len(PermittedCUEImports()))
 	for _, im := range PermittedCUEImports() {
 		all = append(all, fmt.Sprintf("\t%s", im))
 	}

--- a/pkg/plugins/storage/fs.go
+++ b/pkg/plugins/storage/fs.go
@@ -55,7 +55,7 @@ func (fs *FS) Add(ctx context.Context, pluginID string, pluginArchive *zip.ReadC
 
 	fs.log.Successf("Downloaded and extracted %s v%s zip successfully to %s", res.ID, res.Info.Version, pluginDir)
 
-	var deps []*Dependency
+	deps := make([]*Dependency, 0, len(res.Dependencies.Plugins))
 	for _, plugin := range res.Dependencies.Plugins {
 		deps = append(deps, &Dependency{
 			ID:      plugin.ID,

--- a/pkg/services/accesscontrol/evaluator.go
+++ b/pkg/services/accesscontrol/evaluator.go
@@ -124,7 +124,7 @@ func (a allEvaluator) Evaluate(permissions map[string][]string) bool {
 }
 
 func (a allEvaluator) MutateScopes(ctx context.Context, mutate ScopeAttributeMutator) (Evaluator, error) {
-	var modified []Evaluator
+	modified := make([]Evaluator, 0, len(a.allOf))
 	for _, e := range a.allOf {
 		i, err := e.MutateScopes(ctx, mutate)
 		if err != nil {
@@ -174,7 +174,7 @@ func (a anyEvaluator) Evaluate(permissions map[string][]string) bool {
 }
 
 func (a anyEvaluator) MutateScopes(ctx context.Context, mutate ScopeAttributeMutator) (Evaluator, error) {
-	var modified []Evaluator
+	modified := make([]Evaluator, 0, len(a.anyOf))
 	for _, e := range a.anyOf {
 		i, err := e.MutateScopes(ctx, mutate)
 		if err != nil {

--- a/pkg/services/accesscontrol/resourcepermissions/service.go
+++ b/pkg/services/accesscontrol/resourcepermissions/service.go
@@ -53,7 +53,7 @@ func New(
 	ac accesscontrol.AccessControl, service accesscontrol.Service, sqlStore db.DB,
 	teamService team.Service, userService user.Service,
 ) (*Service, error) {
-	var permissions []string
+	permissions := make([]string, 0, len(options.PermissionsToActions))
 	actionSet := make(map[string]struct{})
 	for permission, actions := range options.PermissionsToActions {
 		permissions = append(permissions, permission)

--- a/pkg/services/accesscontrol/resourcepermissions/store.go
+++ b/pkg/services/accesscontrol/resourcepermissions/store.go
@@ -608,7 +608,7 @@ func (s *store) createPermissions(sess *db.Session, roleID int64, resource, reso
 	if len(actions) == 0 {
 		return nil
 	}
-	var permissions []accesscontrol.Permission
+	permissions := make([]accesscontrol.Permission, 0, len(actions))
 	for action := range actions {
 		p := managedPermission(action, resource, resourceID, resourceAttribute)
 		p.RoleID = roleID


### PR DESCRIPTION
**What is this feature?**

Add preallocations for slices to decrease number of calls to the go allocator / OS api and thereby reduce the program execution time. It's little part of https://github.com/grafana/grafana/pull/59118 PR.

**Why do we need this feature?**

It's perfomance improvement.

**Who is this feature for?**

\-

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer**:

