### PR TITLE
PanelEdit: Fixes bug with not remembering panel options pane collapse/expand state

### DIFF
--- a/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
@@ -193,11 +193,6 @@ export class PanelEditorUnconnected extends PureComponent<Props> {
     this.props.toggleTableView();
   };
 
-  onTogglePanelOptions = () => {
-    const { uiState, updatePanelEditorUIState } = this.props;
-    updatePanelEditorUIState({ isPanelOptionsVisible: !uiState.isPanelOptionsVisible });
-  };
-
   renderPanel(styles: EditorStyles, isOnlyPanel: boolean) {
     const { dashboard, panel, uiState, tableViewEnabled, theme } = this.props;
 

--- a/public/app/features/dashboard/components/PanelEditor/VisualizationButton.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/VisualizationButton.tsx
@@ -8,7 +8,8 @@ import { useDispatch, useSelector } from 'app/types';
 import { PanelModel } from '../../state';
 import { getPanelPluginWithFallback } from '../../state/selectors';
 
-import { setPanelEditorUIState, toggleVizPicker } from './state/reducers';
+import { updatePanelEditorUIState } from './state/actions';
+import { toggleVizPicker } from './state/reducers';
 
 type Props = {
   panel: PanelModel;
@@ -25,7 +26,7 @@ export const VisualizationButton = ({ panel }: Props) => {
   };
 
   const onToggleOptionsPane = () => {
-    dispatch(setPanelEditorUIState({ isPanelOptionsVisible: !isPanelOptionsVisible }));
+    dispatch(updatePanelEditorUIState({ isPanelOptionsVisible: !isPanelOptionsVisible }));
   };
 
   if (!plugin) {


### PR DESCRIPTION
Fixes a bug with Panel edit where the panel options pane expand / collapse state was not being stored in
local storage so not being restored on full page reload.

I have tried to identify when this bug was introduced without success. Looks like a very long time a go
but why have we not noticed it if that is the case? Confusing :)

