### PR TITLE
Dashboard: Place timerangepicker inside viewport for smaller screen

### DIFF
--- a/packages/grafana-ui/src/components/DateTimePickers/useInteractionObserver.ts
+++ b/packages/grafana-ui/src/components/DateTimePickers/useInteractionObserver.ts
@@ -1,0 +1,69 @@
+import { useEffect, useMemo, useState } from 'react';
+
+export default (ref: React.RefObject<HTMLDivElement>) => {
+  const [entry, setEntry] = useState<IntersectionObserverEntry | undefined>();
+
+  const observer = useMemo(
+    () =>
+      new IntersectionObserver((entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setEntry(entry);
+          }
+        });
+      }),
+    []
+  );
+
+  useEffect(() => {
+    if (ref.current) {
+      observer.observe(ref.current);
+    }
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [ref, observer]);
+
+  return entry;
+};
+
+const isIntersectingLeft = (entry: IntersectionObserverEntry) => {
+  const offset = getLeftOffset(entry);
+
+  return offset < 0;
+};
+
+const isIntersectingRight = (entry: IntersectionObserverEntry) => {
+  const offset = getRightOffset(entry);
+
+  return offset < 0;
+};
+
+export const getRightOffset = ({ rootBounds, boundingClientRect }: IntersectionObserverEntry) =>
+  (rootBounds?.right ?? 0) - boundingClientRect.right;
+
+export const getLeftOffset = ({ rootBounds, boundingClientRect, intersectionRatio }: IntersectionObserverEntry) =>
+  (rootBounds?.left ?? 0) + boundingClientRect.left;
+
+export const getHorizontalOffset = (entry?: IntersectionObserverEntry) => {
+  if (!entry) {
+    return 0;
+  }
+  const intersectingLeft = isIntersectingLeft(entry);
+  const intersectingRight = isIntersectingRight(entry);
+
+  if (!intersectingLeft && !intersectingRight) {
+    return 0;
+  }
+
+  if (intersectingLeft && intersectingRight) {
+    return 0;
+  }
+
+  if (intersectingLeft) {
+    return getLeftOffset(entry);
+  }
+
+  return getRightOffset(entry);
+};


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

Display Time range picker within the viewport for smaller screen. This is needed so user can still select time range for smaller screen



**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #32369 

**Special notes for your reviewer**:
- I've use InteractionObserver to get the offset needed to place the TimePickerContent inside the viewport. At the moment, it will only check if it is intersecting horizontally which I think is enough to address the issue. Let me know what you think.
