### PR TITLE
Logs: Fix misalignment of LogRows

### DIFF
--- a/public/app/features/logs/components/LogRowMessage.tsx
+++ b/public/app/features/logs/components/LogRowMessage.tsx
@@ -47,7 +47,8 @@ const getStyles = (theme: GrafanaTheme2, showContextButton: boolean, isInDashboa
       display: inherit;
     `,
     horizontalScroll: css`
-      label: verticalScroll;
+      label: horizontalScroll;
+      display: flex;
       white-space: pre;
     `,
     contextNewline: css`

--- a/public/app/features/logs/components/LogRowMessage.tsx
+++ b/public/app/features/logs/components/LogRowMessage.tsx
@@ -48,7 +48,6 @@ const getStyles = (theme: GrafanaTheme2, showContextButton: boolean, isInDashboa
     `,
     horizontalScroll: css`
       label: horizontalScroll;
-      display: flex;
       white-space: pre;
     `,
     contextNewline: css`

--- a/public/app/features/logs/components/getLogRowStyles.ts
+++ b/public/app/features/logs/components/getLogRowStyles.ts
@@ -124,6 +124,7 @@ export const getLogRowStyles = (theme: GrafanaTheme2, logLevel?: LogLevel) => {
       white-space: pre-wrap;
       word-break: break-all;
       width: 100%;
+      text-align: left;
     `,
     //Log details specific CSS
     logDetailsContainer: css`


### PR DESCRIPTION
**What is this fix?**

LogRows in visualisation suggestions seem to be misaligned. This PR fixes that by just adding a default `text-align` of `left` to the `td` containing the LogRowMessages.

**Root cause**:
The LogsPanel is inside a `button`, which sets (dependent on the browser) the `text-align` to `center`:
<img width="761" alt="image" src="https://user-images.githubusercontent.com/8092184/203779932-e4cd7dc4-3c0f-4bd1-ba6f-97b50b1a7073.png">

**Special notes for your reviewer**:

1. Go to a dashboard
2. Create a new logs panel
3. Open visualisation suggestions
Without the fix:
<img width="1441" alt="image" src="https://user-images.githubusercontent.com/8092184/203762635-4b7297da-eed4-4efc-85e4-3460355afa56.png">

With the fix:
<img width="1445" alt="image" src="https://user-images.githubusercontent.com/8092184/203762723-044bfb06-e6b7-4dff-9fc1-b0ec6643467f.png">

