### PR TITLE
PostgreSQL: Fix missing CA field from configuration

### DIFF
--- a/public/app/plugins/datasource/postgres/configuration/ConfigurationEditor.tsx
+++ b/public/app/plugins/datasource/postgres/configuration/ConfigurationEditor.tsx
@@ -153,10 +153,16 @@ export const PostgresConfigEditor = (props: DataSourcePluginOptionsEditorProps<P
         ) : null}
       </FieldSet>
 
-      {options.jsonData.sslmode !== 'disable' ? (
+      {jsonData.sslmode !== 'disable' ? (
         <FieldSet label="TLS/SSL Auth Details">
-          {options.jsonData.tlsConfigurationMethod === PostgresTLSMethods.fileContent ? (
-            <TLSSecretsConfig editorProps={props} labelWidth={labelWidthSSLDetails}></TLSSecretsConfig>
+          {jsonData.tlsConfigurationMethod === PostgresTLSMethods.fileContent ? (
+            <TLSSecretsConfig
+              showCACert={
+                jsonData.sslmode === PostgresTLSModes.verifyCA || jsonData.sslmode === PostgresTLSModes.verifyFull
+              }
+              editorProps={props}
+              labelWidth={labelWidthSSLDetails}
+            ></TLSSecretsConfig>
           ) : (
             <>
               <InlineField

--- a/public/app/plugins/datasource/postgres/configuration/ConfigurationEditor.tsx
+++ b/public/app/plugins/datasource/postgres/configuration/ConfigurationEditor.tsx
@@ -153,7 +153,7 @@ export const PostgresConfigEditor = (props: DataSourcePluginOptionsEditorProps<P
         ) : null}
       </FieldSet>
 
-      {jsonData.sslmode !== 'disable' ? (
+      {jsonData.sslmode !== PostgresTLSModes.disable ? (
         <FieldSet label="TLS/SSL Auth Details">
           {jsonData.tlsConfigurationMethod === PostgresTLSMethods.fileContent ? (
             <TLSSecretsConfig


### PR DESCRIPTION
**What is this feature?**

Fixes the issue where it was not possible to add CA cert as content (not as a file) to postgres datasource config
