### PR TITLE
[v9.3.x] CI: Remove `npm` steps from enterprise pipelines (#59108)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2839,17 +2839,6 @@ steps:
   image: grafana/grafana-ci-deploy:1.3.3
   name: upload-cdn-assets-enterprise2
 - commands:
-  - ./bin/grabpl artifacts npm store --tag ${DRONE_TAG}
-  depends_on:
-  - build-frontend-packages
-  environment:
-    GCP_KEY:
-      from_secret: gcp_key
-    PRERELEASE_BUCKET:
-      from_secret: prerelease_bucket
-  image: grafana/build-container:1.6.6
-  name: store-npm-packages
-- commands:
   - ./bin/grabpl upload-packages --edition enterprise2
   depends_on:
   - package-enterprise2
@@ -5636,6 +5625,6 @@ kind: secret
 name: packages_secret_access_key
 ---
 kind: signature
-hmac: 7b6f6906fff47ab3bfcc9fde3c30428766c935d1a8b0d80fde012bec248b7951
+hmac: 484a60c2bddc31ee390456bae87bf13d2cd1c3eef0b4b07460d84c0978b14340
 
 ...

--- a/scripts/drone/events/release.star
+++ b/scripts/drone/events/release.star
@@ -290,11 +290,8 @@ def get_enterprise_pipelines(trigger, ver_mode):
         ])
     if should_publish:
         publish_step = store_storybook_step(edition=edition, ver_mode=ver_mode)
-        store_npm_step = store_npm_packages_step()
         if publish_step:
             publish_steps.append(publish_step)
-        if store_npm_step:
-            publish_steps.append(store_npm_step)
     windows_package_steps = get_windows_steps(edition=edition, ver_mode=ver_mode)
 
     if should_upload:


### PR DESCRIPTION
Remove npm steps from enterprise pipelines

(cherry picked from commit 2d7fcea8fa553a2811316d117e8a40c4a08c0dc2)

Backports #59108 