### PR TITLE
TestDatasource: Add scenario for generating trace data

### DIFF
--- a/pkg/tsdb/testdatasource/scenarios.go
+++ b/pkg/tsdb/testdatasource/scenarios.go
@@ -43,6 +43,7 @@ const (
 	rawFrameQuery                     queryType = "raw_frame"
 	csvFileQueryType                  queryType = "csv_file"
 	csvContentQueryType               queryType = "csv_content"
+	traceType                         queryType = "trace"
 )
 
 type queryType string
@@ -216,6 +217,11 @@ Timestamps will line up evenly on timeStepSeconds (For example, 60 seconds means
 		ID:      string(csvContentQueryType),
 		Name:    "CSV Content",
 		handler: s.handleCsvContentScenario,
+	})
+
+	s.registerScenario(&Scenario{
+		ID:   string(traceType),
+		Name: "Trace",
 	})
 
 	s.queryMux.HandleFunc("", s.handleFallbackScenario)

--- a/public/app/plugins/datasource/testdata/QueryEditor.tsx
+++ b/public/app/plugins/datasource/testdata/QueryEditor.tsx
@@ -302,6 +302,18 @@ export const QueryEditor = ({ query, datasource, onChange, onRunQuery }: Props) 
         <NodeGraphEditor onChange={(val: NodesQuery) => onChange({ ...query, nodes: val })} query={query} />
       )}
       {scenarioId === 'server_error_500' && <ErrorEditor onChange={onUpdate} query={query} ds={datasource} />}
+      {scenarioId === 'trace' && (
+        <InlineField labelWidth={14} label="Span count">
+          <Input
+            type="number"
+            name="spanCount"
+            value={query.spanCount}
+            width={32}
+            onChange={onInputChange}
+            placeholder="10"
+          />
+        </InlineField>
+      )}
 
       {description && <p>{description}</p>}
     </>

--- a/public/app/plugins/datasource/testdata/datasource.ts
+++ b/public/app/plugins/datasource/testdata/datasource.ts
@@ -14,6 +14,7 @@ import {
   TimeRange,
   ScopedVars,
   toDataFrame,
+  MutableDataFrame,
 } from '@grafana/data';
 import { DataSourceWithBackend, getBackendSrv, getGrafanaLiveSrv, getTemplateSrv, TemplateSrv } from '@grafana/runtime';
 import { getSearchFilterScopedVar } from 'app/features/variables/utils';
@@ -69,6 +70,9 @@ export class TestDataDataSource extends DataSourceWithBackend<TestDataQuery> {
           break;
         case 'flame_graph':
           streams.push(this.flameGraphQuery());
+          break;
+        case 'trace':
+          streams.push(this.trace(target, options));
           break;
         case 'raw_frame':
           streams.push(this.rawFrameQuery(target, options));
@@ -219,6 +223,44 @@ export class TestDataDataSource extends DataSourceWithBackend<TestDataQuery> {
 
   flameGraphQuery(): Observable<DataQueryResponse> {
     return of({ data: [flameGraphData] }).pipe(delay(100));
+  }
+
+  trace(target: TestDataQuery, options: DataQueryRequest<TestDataQuery>): Observable<DataQueryResponse> {
+    const frame = new MutableDataFrame({
+      meta: {
+        preferredVisualisationType: 'trace',
+      },
+      fields: [
+        { name: 'traceID' },
+        { name: 'spanID' },
+        { name: 'parentSpanID' },
+        { name: 'operationName' },
+        { name: 'serviceName' },
+        { name: 'serviceTags' },
+        { name: 'startTime' },
+        { name: 'duration' },
+        { name: 'logs' },
+        { name: 'references' },
+        { name: 'tags' },
+      ],
+    });
+    const numberOfSpans = options.targets[0].spanCount || 10;
+    const spanIdPrefix = '75c665dfb68';
+    const start = Date.now() - 1000 * 60 * 30;
+
+    for (let i = 0; i < numberOfSpans; i++) {
+      frame.add({
+        traceID: spanIdPrefix + '10000',
+        spanID: spanIdPrefix + (10000 + i),
+        parentSpanID: i === 0 ? '' : spanIdPrefix + 10000,
+        operationName: `Operation ${i}`,
+        serviceName: `Service ${i}`,
+        startTime: start + i * 100,
+        duration: 300,
+      });
+    }
+
+    return of({ data: [frame] }).pipe(delay(100));
   }
 
   rawFrameQuery(target: TestDataQuery, options: DataQueryRequest<TestDataQuery>): Observable<DataQueryResponse> {

--- a/public/app/plugins/datasource/testdata/types.ts
+++ b/public/app/plugins/datasource/testdata/types.ts
@@ -27,6 +27,7 @@ export interface TestDataQuery extends DataQuery {
   seriesCount?: number;
   usa?: USAQuery;
   errorType?: 'server_panic' | 'frontend_exception' | 'frontend_observable';
+  spanCount?: number;
 }
 
 export interface NodesQuery {


### PR DESCRIPTION
Adds a simple trace generations scenario mainly useful to test trace view panel with long traces:

![Screenshot from 2022-11-24 14-30-49](https://user-images.githubusercontent.com/1014802/203796779-6a336c2d-83de-417a-89e0-daaa3cb789e4.png)
