### PR TITLE
Alerting: fix "no permissions" alert flashing

### DIFF
--- a/public/app/features/alerting/unified/ExistingRuleEditor.tsx
+++ b/public/app/features/alerting/unified/ExistingRuleEditor.tsx
@@ -19,9 +19,21 @@ interface ExistingRuleEditorProps {
 
 export function ExistingRuleEditor({ identifier }: ExistingRuleEditorProps) {
   useCleanup((state) => (state.unifiedAlerting.ruleForm.existingRule = initialAsyncRequestState));
-  const { loading, result, error, dispatched } = useUnifiedAlertingSelector((state) => state.ruleForm.existingRule);
+
+  const {
+    loading: loadingAlertRule,
+    result,
+    error,
+    dispatched,
+  } = useUnifiedAlertingSelector((state) => state.ruleForm.existingRule);
+
   const dispatch = useDispatch();
-  const { isEditable } = useIsRuleEditable(ruleId.ruleIdentifierToRuleSourceName(identifier), result?.rule);
+  const { isEditable, loading: loadingEditable } = useIsRuleEditable(
+    ruleId.ruleIdentifierToRuleSourceName(identifier),
+    result?.rule
+  );
+
+  const loading = loadingAlertRule || loadingEditable;
 
   useEffect(() => {
     if (!dispatched) {

--- a/public/app/features/alerting/unified/hooks/useIsRuleEditable.ts
+++ b/public/app/features/alerting/unified/hooks/useIsRuleEditable.ts
@@ -18,7 +18,6 @@ export function useIsRuleEditable(rulesSourceName: string, rule?: RulerRuleDTO):
   const folderUID = rule && isGrafanaRulerRule(rule) ? rule.grafana_alert.namespace_uid : undefined;
 
   const rulePermission = getRulesPermissions(rulesSourceName);
-
   const { folder, loading } = useFolder(folderUID);
 
   if (!rule) {


### PR DESCRIPTION
**What is this feature?**

This fixes the "no permission to edit this alert rule" alert briefly showing while we are fetching information about the alert rule and RBAC.

