### PR TITLE
Chore: Fix some as HTMLElement type assertions

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -1520,8 +1520,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "7"],
       [0, 0, 0, "Do not use any type assertions.", "8"],
       [0, 0, 0, "Do not use any type assertions.", "9"],
-      [0, 0, 0, "Do not use any type assertions.", "10"],
-      [0, 0, 0, "Do not use any type assertions.", "11"]
+      [0, 0, 0, "Do not use any type assertions.", "10"]
     ],
     "packages/grafana-ui/src/components/Table/TableCell.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
@@ -2940,9 +2939,6 @@ exports[`better eslint`] = {
     "public/app/features/alerting/unified/components/alert-groups/GroupBy.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
-    "public/app/features/alerting/unified/components/alert-groups/MatcherFilter.tsx:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"]
-    ],
     "public/app/features/alerting/unified/components/amroutes/AmRoutesTable.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
@@ -3003,13 +2999,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
     "public/app/features/alerting/unified/components/rules/RulesFilter.tsx:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"],
-      [0, 0, 0, "Do not use any type assertions.", "1"]
-    ],
-    "public/app/features/alerting/unified/components/silences/SilencesEditor.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
-    "public/app/features/alerting/unified/components/silences/SilencesFilter.tsx:5381": [
+    "public/app/features/alerting/unified/components/silences/SilencesEditor.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
     "public/app/features/alerting/unified/hooks/useControlledFieldArray.ts:5381": [
@@ -4589,9 +4581,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
     ],
     "public/app/features/search/components/SearchCard.tsx:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
-      [0, 0, 0, "Do not use any type assertions.", "1"],
-      [0, 0, 0, "Do not use any type assertions.", "2"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
     "public/app/features/search/components/SearchItem.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]

--- a/packages/grafana-ui/src/components/Table/Table.tsx
+++ b/packages/grafana-ui/src/components/Table/Table.tsx
@@ -439,7 +439,7 @@ export const Table = memo((props: Props) => {
   };
 
   const handleScroll: React.UIEventHandler = (event) => {
-    const { scrollTop } = event.target as HTMLDivElement;
+    const { scrollTop } = event.currentTarget;
 
     if (listRef.current !== null) {
       listRef.current.scrollTo(scrollTop);

--- a/public/app/features/alerting/unified/components/alert-groups/MatcherFilter.tsx
+++ b/public/app/features/alerting/unified/components/alert-groups/MatcherFilter.tsx
@@ -23,7 +23,7 @@ export const MatcherFilter = ({ className, onFilterChange, defaultQueryString }:
       debounce((e: FormEvent<HTMLInputElement>) => {
         logInfo(LogMessages.filterByLabel);
 
-        const target = e.target as HTMLInputElement;
+        const target = e.currentTarget;
         onFilterChange(target.value);
       }, 600),
     [onFilterChange]

--- a/public/app/features/alerting/unified/components/rules/RulesFilter.tsx
+++ b/public/app/features/alerting/unified/components/rules/RulesFilter.tsx
@@ -66,7 +66,7 @@ const RulesFilter = () => {
   };
 
   const handleQueryStringChange = debounce((e: FormEvent<HTMLInputElement>) => {
-    const target = e.target as HTMLInputElement;
+    const target = e.currentTarget;
     setQueryParams({ queryString: target.value || null });
   }, 600);
 

--- a/public/app/features/alerting/unified/components/silences/SilencesFilter.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilencesFilter.tsx
@@ -25,7 +25,7 @@ export const SilencesFilter = () => {
   const styles = useStyles2(getStyles);
 
   const handleQueryStringChange = debounce((e: FormEvent<HTMLInputElement>) => {
-    const target = e.target as HTMLInputElement;
+    const target = e.currentTarget;
     setQueryParams({ queryString: target.value || null });
   }, 400);
 

--- a/public/app/features/search/components/SearchCard.tsx
+++ b/public/app/features/search/components/SearchCard.tsx
@@ -47,8 +47,8 @@ export function SearchCard({ editable, item, onTagSelected, onToggleChecked, onC
     },
     []
   );
-  const [markerElement, setMarkerElement] = React.useState<HTMLDivElement | null>(null);
-  const [popperElement, setPopperElement] = React.useState<HTMLDivElement | null>(null);
+  const [markerElement, setMarkerElement] = React.useState<HTMLElement | null>(null);
+  const [popperElement, setPopperElement] = React.useState<HTMLElement | null>(null);
   const { styles: popperStyles, attributes } = usePopper(markerElement, popperElement, {
     modifiers: [
       {
@@ -119,7 +119,7 @@ export function SearchCard({ editable, item, onTagSelected, onToggleChecked, onC
       className={styles.card}
       key={item.uid}
       href={item.url}
-      ref={(ref) => setMarkerElement(ref as unknown as HTMLDivElement)}
+      ref={(ref) => setMarkerElement(ref)}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
       onMouseMove={onMouseMove}


### PR DESCRIPTION
**What is this feature?**

Fixes some low-hanging fruit to use the typed `event.currentTarget` to remove some type assertions

**Why do we need this feature?**

To improve the quality and reliability of our code 😄 

