### PR TITLE
Loki Variable Query Editor: Improve stream selector tooltip text

### DIFF
--- a/public/app/plugins/datasource/loki/components/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/VariableQueryEditor.tsx
@@ -104,7 +104,7 @@ export const LokiVariableQueryEditor: FC<Props> = ({ onChange, query, datasource
             tooltip={
               <div>
                 {
-                  'Optional. If defined, a list of values for the label in the specified log stream selector is returned. E.g. {stream="name"}'
+                  'Optional. If defined, a list of values for the label in the specified log stream selector is returned. E.g. {name="value"}'
                 }
               </div>
             }

--- a/public/app/plugins/datasource/loki/components/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/VariableQueryEditor.tsx
@@ -104,7 +104,7 @@ export const LokiVariableQueryEditor: FC<Props> = ({ onChange, query, datasource
             tooltip={
               <div>
                 {
-                  'Optional. If defined, a list of values for the label in the specified log stream selector is returned. E.g. {label="value"}'
+                  'Optional. If defined, a list of values for the specified log stream selector is returned. For example: {label="value"} or {label="$variable"}'
                 }
               </div>
             }

--- a/public/app/plugins/datasource/loki/components/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/VariableQueryEditor.tsx
@@ -104,7 +104,7 @@ export const LokiVariableQueryEditor: FC<Props> = ({ onChange, query, datasource
             tooltip={
               <div>
                 {
-                  'Optional. If defined, a list of values for the label in the specified log stream selector is returned. E.g. {name="value"}'
+                  'Optional. If defined, a list of values for the label in the specified log stream selector is returned. E.g. {label="value"}'
                 }
               </div>
             }

--- a/public/app/plugins/datasource/loki/components/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/VariableQueryEditor.tsx
@@ -103,7 +103,9 @@ export const LokiVariableQueryEditor: FC<Props> = ({ onChange, query, datasource
             labelWidth={20}
             tooltip={
               <div>
-                Optional. If defined, a list of values for the label in the specified log stream selector is returned.
+                {
+                  'Optional. If defined, a list of values for the label in the specified log stream selector is returned. E.g. {stream="name"}'
+                }
               </div>
             }
           >


### PR DESCRIPTION
**Why do we need this feature?**

When creating variables that query for label values the users can input a stream selector. A user had troubles trying to use a stream selector with interpolation, thinking it was because it was not supported. The actual problem was caused for the actual stream selector, which needs to be in the correct format. For example: `{name="value"}` or `{name="$interpolated"}`.

This PR improves the tooltip to remind users of the expected format of a stream selector.

**Which issue(s) does this PR fix?**:

Related with https://github.com/grafana/grafana/issues/52380

**Special notes for your reviewer**:

See the tooltip, understand it.

![imagen](https://user-images.githubusercontent.com/1069378/203831046-326d9427-39a0-4fc1-bf4c-6e14995fe917.png)
