### PR TITLE
Feat: Adding an optional browser config option to e2e test runner

### DIFF
--- a/packages/grafana-e2e/cli.js
+++ b/packages/grafana-e2e/cli.js
@@ -3,7 +3,7 @@ const execa = require('execa');
 const { resolve, sep } = require('path');
 const resolveBin = require('resolve-as-bin');
 
-const cypress = (commandName, { updateScreenshots }) => {
+const cypress = (commandName, { updateScreenshots, browser }) => {
   // Support running an unpublished dev build
   const dirname = __dirname.split(sep).pop();
   const projectPath = resolve(`${__dirname}${dirname === 'dist' ? '/..' : ''}`);
@@ -15,6 +15,10 @@ const cypress = (commandName, { updateScreenshots }) => {
   const UPDATE_SCREENSHOTS = `UPDATE_SCREENSHOTS=${updateScreenshots ? 1 : 0}`;
 
   const cypressOptions = [commandName, '--env', `${CWD},${UPDATE_SCREENSHOTS}`, `--project=${projectPath}`];
+
+  if (browser) {
+    cypressOptions.push('--browser', browser);
+  }
 
   const execaOptions = {
     cwd: __dirname,
@@ -32,17 +36,21 @@ const cypress = (commandName, { updateScreenshots }) => {
 module.exports = () => {
   const updateOption = '-u, --update-screenshots';
   const updateDescription = 'update expected screenshots';
+  const browserOption = '-b, --browser <browser>';
+  const browserDescription = 'specify which browser to use';
 
   program
     .command('open')
     .description('runs tests within the interactive GUI')
     .option(updateOption, updateDescription)
+    .option(browserOption, browserDescription)
     .action((options) => cypress('open', options));
 
   program
     .command('run')
     .description('runs tests from the CLI without the GUI')
     .option(updateOption, updateDescription)
+    .option(browserOption, browserDescription)
     .action((options) => cypress('run', options));
 
   program.parse(process.argv);


### PR DESCRIPTION
(cherry picked from commit 9e2d37462baf3422034c6601e745cd7fbee535e4)

Backporting: https://github.com/grafana/grafana/pull/59076

