### PR TITLE
Docs: Updated InfluxDB query editor doc title and added time zone info

### DIFF
--- a/docs/sources/datasources/influxdb/query-editor/index.md
+++ b/docs/sources/datasources/influxdb/query-editor/index.md
@@ -3,8 +3,8 @@ aliases:
   - /docs/grafana/latest/datasources/influxdb/influxdb-flux/
   - /docs/grafana/latest/datasources/influxdb/query-editor/
   - /docs/grafana/latest/data-sources/influxdb/query-editor/
-description: Guide for Flux in Grafana
-title: Flux support in Grafana
+description: Guide for InfluxQL and Flux in Grafana
+title: Query editor
 weight: 200
 ---
 
@@ -73,7 +73,12 @@ SELECT derivative(mean("value"), 10s) /10 AS "REQ/s" FROM ....
 
 ### Group query results
 
-To group results by a tag, define it in a "Group By".
+By default group by `time($__interval)` is selected as part of the query utilizing the **Min time interval** to group results by time. This can be manually changed to a desired interval. Additionally, to group results by a tag, define it in a "Group By".
+
+**To group by a specific time interval:**
+
+1. Click `$__interval` within `time($__interval)`.
+1. Select a time interval from the dropdown that appears or input a valid time interval.
 
 **To group by a tag:**
 
@@ -84,6 +89,13 @@ To group results by a tag, define it in a "Group By".
 
 1. Click the tag.
 1. Click the "x" icon.
+
+### Timezone
+Timezone is an optional field that returns results with the UTC offset for the specified timezone.
+
+If left blank, results will be returned with timestamps in UTC. When utilizing a group by time clause, UTC will be utilized time grouping unless an alternative timezone is specified.
+
+To specify a timezone parameter, input the desired timezone following the defined TZ database name in the [Internet Assigned Numbers Authority time zone database](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List).
 
 ### Text editor mode (RAW)
 

--- a/docs/sources/datasources/influxdb/query-editor/index.md
+++ b/docs/sources/datasources/influxdb/query-editor/index.md
@@ -91,6 +91,7 @@ By default group by `time($__interval)` is selected as part of the query utilizi
 1. Click the "x" icon.
 
 ### Timezone
+
 Timezone is an optional field that returns results with the UTC offset for the specified timezone.
 
 If left blank, results will be returned with timestamps in UTC. When utilizing a group by time clause, UTC will be utilized time grouping unless an alternative timezone is specified.


### PR DESCRIPTION
Updated the document title to better fit the doc content (general query editor support for InfluxDB query languages InfluxQL and Flux) and added additional time zone information.

Reason for adding time zone information is that the Grafana time picker time zone has no impact on the group by clause when used with groups of days, weeks, months, or years.

**What is this feature?**

Updated the document title to better fit the doc content (general query editor support for InfluxDB query languages InfluxQL and Flux) and added information on usage of the time zone clause.

**Why do we need this feature?**

Why title change? Current title of "Flux support in Grafana" does not convey the overall content of the doc.

Why additional info on timezone clause? Grafana has a time range picker which allows specifying time zones, currently this time zone selection does not get linked to InfluxQL's query editor and as such with no timezone clause provided results will default to UTC. The additions for info on group by time and time zone aim to provide more clarity to how results can be properly returned in a desired time zone as this is something I had run into some confusion with.

**Who is this feature for?**

Users of the InfluxQL data source needing to align results to a given timezone other than UTC.

**Which issue(s) does this PR fix?**:

N/A