### PR TITLE
Chore: Reduce the usage of sqlstore.createorg and use orgservice instead

### DIFF
--- a/pkg/api/annotations_test.go
+++ b/pkg/api/annotations_test.go
@@ -385,7 +385,7 @@ func deleteAnnotationsScenario(t *testing.T, desc string, url string, routePatte
 func TestAPI_Annotations_AccessControl(t *testing.T) {
 	sc := setupHTTPServer(t, true)
 	setInitCtxSignedInEditor(sc.initCtx)
-	err := sc.db.CreateOrg(context.Background(), &models.CreateOrgCommand{Name: "TestOrg", UserId: testUserID})
+	_, err := sc.hs.orgService.CreateWithMember(context.Background(), &org.CreateOrgCommand{Name: "TestOrg", UserID: testUserID})
 	require.NoError(t, err)
 
 	dashboardAnnotation := &annotations.Item{Id: 1, DashboardId: 1}
@@ -787,7 +787,7 @@ func TestService_AnnotationTypeScopeResolver(t *testing.T) {
 func TestAPI_MassDeleteAnnotations_AccessControl(t *testing.T) {
 	sc := setupHTTPServer(t, true)
 	setInitCtxSignedInEditor(sc.initCtx)
-	err := sc.db.CreateOrg(context.Background(), &models.CreateOrgCommand{Name: "TestOrg", UserId: testUserID})
+	_, err := sc.hs.orgService.CreateWithMember(context.Background(), &org.CreateOrgCommand{Name: "TestOrg", UserID: testUserID})
 	require.NoError(t, err)
 
 	type args struct {

--- a/pkg/api/org_test.go
+++ b/pkg/api/org_test.go
@@ -123,7 +123,7 @@ func TestAPIEndpoint_PutCurrentOrg_AccessControl(t *testing.T) {
 	sc := setupHTTPServer(t, true)
 	setInitCtxSignedInViewer(sc.initCtx)
 
-	sc.hs.orgService, err = orgimpl.ProvideService(sc.db, sc.cfg, quotatest.New(false, nil))
+	sc.hs.orgService, err = orgimpl.ProvideService(sc.db, sc.cfg, sc.hs.QuotaService)
 	require.NoError(t, err)
 
 	_, err = sc.hs.orgService.CreateWithMember(context.Background(), &org.CreateOrgCommand{Name: "TestOrg", UserID: sc.initCtx.UserID})

--- a/pkg/api/org_test.go
+++ b/pkg/api/org_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/org/orgimpl"
 	"github.com/grafana/grafana/pkg/services/quota/quotatest"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
@@ -51,7 +51,7 @@ func TestAPIEndpoint_GetCurrentOrg_LegacyAccessControl(t *testing.T) {
 	sc := setupHTTPServerWithCfg(t, true, cfg)
 	setInitCtxSignedInViewer(sc.initCtx)
 
-	err := sc.db.CreateOrg(context.Background(), &models.CreateOrgCommand{Name: "TestOrg", UserId: testUserID})
+	_, err := sc.hs.orgService.CreateWithMember(context.Background(), &org.CreateOrgCommand{Name: "TestOrg", UserID: testUserID})
 	require.NoError(t, err)
 
 	t.Run("Viewer can view CurrentOrg", func(t *testing.T) {
@@ -70,7 +70,7 @@ func TestAPIEndpoint_GetCurrentOrg_AccessControl(t *testing.T) {
 	sc := setupHTTPServer(t, true)
 	setInitCtxSignedInViewer(sc.initCtx)
 
-	err := sc.db.CreateOrg(context.Background(), &models.CreateOrgCommand{Name: "TestOrg", UserId: testUserID})
+	_, err := sc.hs.orgService.CreateWithMember(context.Background(), &org.CreateOrgCommand{Name: "TestOrg", UserID: testUserID})
 	require.NoError(t, err)
 
 	t.Run("AccessControl allows viewing CurrentOrg with correct permissions", func(t *testing.T) {
@@ -91,11 +91,14 @@ func TestAPIEndpoint_GetCurrentOrg_AccessControl(t *testing.T) {
 }
 
 func TestAPIEndpoint_PutCurrentOrg_LegacyAccessControl(t *testing.T) {
+	var err error
 	cfg := setting.NewCfg()
 	cfg.RBACEnabled = false
 	sc := setupHTTPServerWithCfg(t, true, cfg)
+	sc.hs.orgService, err = orgimpl.ProvideService(sc.db, sc.cfg, sc.hs.QuotaService)
+	require.NoError(t, err)
 
-	err := sc.db.CreateOrg(context.Background(), &models.CreateOrgCommand{Name: "TestOrg", UserId: testUserID})
+	_, err = sc.hs.orgService.CreateWithMember(context.Background(), &org.CreateOrgCommand{Name: "TestOrg", UserID: testUserID})
 	require.NoError(t, err)
 
 	input := strings.NewReader(testUpdateOrgNameForm)
@@ -116,13 +119,14 @@ func TestAPIEndpoint_PutCurrentOrg_LegacyAccessControl(t *testing.T) {
 }
 
 func TestAPIEndpoint_PutCurrentOrg_AccessControl(t *testing.T) {
+	var err error
 	sc := setupHTTPServer(t, true)
 	setInitCtxSignedInViewer(sc.initCtx)
 
-	err := sc.db.CreateOrg(context.Background(), &models.CreateOrgCommand{Name: "TestOrg", UserId: sc.initCtx.UserID})
+	sc.hs.orgService, err = orgimpl.ProvideService(sc.db, sc.cfg, quotatest.New(false, nil))
 	require.NoError(t, err)
 
-	sc.hs.orgService, err = orgimpl.ProvideService(sc.db, sc.cfg, quotatest.New(false, nil))
+	_, err = sc.hs.orgService.CreateWithMember(context.Background(), &org.CreateOrgCommand{Name: "TestOrg", UserID: sc.initCtx.UserID})
 	require.NoError(t, err)
 
 	input := strings.NewReader(testUpdateOrgNameForm)
@@ -150,7 +154,7 @@ func TestAPIEndpoint_PutCurrentOrgAddress_LegacyAccessControl(t *testing.T) {
 	cfg.RBACEnabled = false
 	sc := setupHTTPServerWithCfg(t, true, cfg)
 
-	err := sc.db.CreateOrg(context.Background(), &models.CreateOrgCommand{Name: "TestOrg", UserId: testUserID})
+	_, err := sc.hs.orgService.CreateWithMember(context.Background(), &org.CreateOrgCommand{Name: "TestOrg", UserID: testUserID})
 	require.NoError(t, err)
 
 	input := strings.NewReader(testUpdateOrgAddressForm)
@@ -172,7 +176,7 @@ func TestAPIEndpoint_PutCurrentOrgAddress_AccessControl(t *testing.T) {
 	sc := setupHTTPServer(t, true)
 	setInitCtxSignedInViewer(sc.initCtx)
 
-	err := sc.db.CreateOrg(context.Background(), &models.CreateOrgCommand{Name: "TestOrg", UserId: testUserID})
+	_, err := sc.hs.orgService.CreateWithMember(context.Background(), &org.CreateOrgCommand{Name: "TestOrg", UserID: testUserID})
 	require.NoError(t, err)
 
 	input := strings.NewReader(testUpdateOrgAddressForm)
@@ -208,7 +212,7 @@ func setupOrgsDBForAccessControlTests(t *testing.T, db *sqlstore.SQLStore, c acc
 
 	// Create `orgsCount` orgs
 	for i := 1; i <= int(orgID); i++ {
-		err := db.CreateOrg(context.Background(), &models.CreateOrgCommand{Name: fmt.Sprintf("TestOrg%v", i), UserId: 0})
+		_, err := c.hs.orgService.CreateWithMember(context.Background(), &org.CreateOrgCommand{Name: fmt.Sprintf("TestOrg%v", i), UserID: 0})
 		require.NoError(t, err)
 	}
 }

--- a/pkg/api/org_users_test.go
+++ b/pkg/api/org_users_test.go
@@ -341,9 +341,9 @@ func setupOrgUsersDBForAccessControlTests(t *testing.T, db *sqlstore.SQLStore, o
 	require.NoError(t, err)
 
 	// Create both orgs with server admin
-	err = db.CreateOrg(context.Background(), &models.CreateOrgCommand{Name: testServerAdminViewer.OrgName, UserId: testServerAdminViewer.UserID})
+	_, err = orgService.CreateWithMember(context.Background(), &org.CreateOrgCommand{Name: testServerAdminViewer.OrgName, UserID: testServerAdminViewer.UserID})
 	require.NoError(t, err)
-	err = db.CreateOrg(context.Background(), &models.CreateOrgCommand{Name: testAdminOrg2.OrgName, UserId: testServerAdminViewer.UserID})
+	_, err = orgService.CreateWithMember(context.Background(), &org.CreateOrgCommand{Name: testAdminOrg2.OrgName, UserID: testServerAdminViewer.UserID})
 	require.NoError(t, err)
 
 	err = orgService.AddOrgUser(context.Background(), &org.AddOrgUserCommand{LoginOrEmail: testAdminOrg2.Login, Role: testAdminOrg2.OrgRole, OrgID: testAdminOrg2.OrgID, UserID: testAdminOrg2.UserID})
@@ -728,6 +728,7 @@ func TestOrgUsersAPIEndpointWithSetPerms_AccessControl(t *testing.T) {
 			var err error
 			sc := setupHTTPServer(t, true, func(hs *HTTPServer) {
 				hs.tempUserService = tempuserimpl.ProvideService(hs.SQLStore)
+				hs.orgService, err = orgimpl.ProvideService(hs.SQLStore, setting.NewCfg(), quotatest.New(false, nil))
 				hs.userService, err = userimpl.ProvideService(
 					hs.SQLStore, nil, setting.NewCfg(), teamimpl.ProvideService(hs.SQLStore.(*sqlstore.SQLStore), setting.NewCfg()), localcache.ProvideService(), quotatest.New(false, nil))
 				require.NoError(t, err)

--- a/pkg/api/preferences_test.go
+++ b/pkg/api/preferences_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/services/org"
 	pref "github.com/grafana/grafana/pkg/services/preference"
 	"github.com/grafana/grafana/pkg/services/preference/preftest"
 )
@@ -51,7 +52,7 @@ func TestAPIEndpoint_GetCurrentOrgPreferences_LegacyAccessControl(t *testing.T) 
 	prefService.ExpectedPreference = &pref.Preference{HomeDashboardID: 1, Theme: "dark"}
 	sc.hs.preferenceService = prefService
 
-	err := sc.db.CreateOrg(context.Background(), &models.CreateOrgCommand{Name: "TestOrg", UserId: testUserID})
+	_, err := sc.hs.orgService.CreateWithMember(context.Background(), &org.CreateOrgCommand{Name: "TestOrg", UserID: testUserID})
 	require.NoError(t, err)
 
 	setInitCtxSignedInViewer(sc.initCtx)
@@ -80,7 +81,7 @@ func TestAPIEndpoint_GetCurrentOrgPreferences_AccessControl(t *testing.T) {
 	prefService.ExpectedPreference = &pref.Preference{HomeDashboardID: 1, Theme: "dark"}
 	sc.hs.preferenceService = prefService
 
-	err := sc.db.CreateOrg(context.Background(), &models.CreateOrgCommand{Name: "TestOrg", UserId: testUserID})
+	_, err := sc.hs.orgService.CreateWithMember(context.Background(), &org.CreateOrgCommand{Name: "TestOrg", UserID: testUserID})
 	require.NoError(t, err)
 
 	t.Run("AccessControl allows getting org preferences with correct permissions", func(t *testing.T) {
@@ -105,7 +106,7 @@ func TestAPIEndpoint_PutCurrentOrgPreferences_LegacyAccessControl(t *testing.T) 
 	cfg.RBACEnabled = false
 	sc := setupHTTPServerWithCfg(t, true, cfg)
 
-	err := sc.db.CreateOrg(context.Background(), &models.CreateOrgCommand{Name: "TestOrg", UserId: testUserID})
+	_, err := sc.hs.orgService.CreateWithMember(context.Background(), &org.CreateOrgCommand{Name: "TestOrg", UserID: testUserID})
 	require.NoError(t, err)
 
 	setInitCtxSignedInViewer(sc.initCtx)
@@ -127,7 +128,7 @@ func TestAPIEndpoint_PutCurrentOrgPreferences_AccessControl(t *testing.T) {
 	sc := setupHTTPServer(t, true)
 	setInitCtxSignedInViewer(sc.initCtx)
 
-	err := sc.db.CreateOrg(context.Background(), &models.CreateOrgCommand{Name: "TestOrg", UserId: testUserID})
+	_, err := sc.hs.orgService.CreateWithMember(context.Background(), &org.CreateOrgCommand{Name: "TestOrg", UserID: testUserID})
 	require.NoError(t, err)
 
 	input := strings.NewReader(testUpdateOrgPreferencesCmd)
@@ -157,7 +158,7 @@ func TestAPIEndpoint_PatchUserPreferences(t *testing.T) {
 	cfg.RBACEnabled = false
 	sc := setupHTTPServerWithCfg(t, true, cfg)
 
-	err := sc.db.CreateOrg(context.Background(), &models.CreateOrgCommand{Name: "TestOrg", UserId: testUserID})
+	_, err := sc.hs.orgService.CreateWithMember(context.Background(), &org.CreateOrgCommand{Name: "TestOrg", UserID: testUserID})
 	require.NoError(t, err)
 
 	setInitCtxSignedInOrgAdmin(sc.initCtx)
@@ -190,7 +191,7 @@ func TestAPIEndpoint_PatchOrgPreferences(t *testing.T) {
 	cfg.RBACEnabled = false
 	sc := setupHTTPServerWithCfg(t, true, cfg)
 
-	err := sc.db.CreateOrg(context.Background(), &models.CreateOrgCommand{Name: "TestOrg", UserId: testUserID})
+	_, err := sc.hs.orgService.CreateWithMember(context.Background(), &org.CreateOrgCommand{Name: "TestOrg", UserID: testUserID})
 	require.NoError(t, err)
 
 	setInitCtxSignedInOrgAdmin(sc.initCtx)

--- a/pkg/services/accesscontrol/resourcepermissions/store_test.go
+++ b/pkg/services/accesscontrol/resourcepermissions/store_test.go
@@ -10,8 +10,10 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/infra/db"
-	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/org"
+	"github.com/grafana/grafana/pkg/services/org/orgimpl"
+	"github.com/grafana/grafana/pkg/services/quota/quotatest"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/services/user"
 )
@@ -435,8 +437,10 @@ func TestIntegrationStore_GetResourcePermissions(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			store, sql := setupTestEnv(t)
+			orgService, err := orgimpl.ProvideService(sql, sql.Cfg, quotatest.New(false, nil))
+			require.NoError(t, err)
 
-			err := sql.WithDbSession(context.Background(), func(sess *db.Session) error {
+			err = sql.WithDbSession(context.Background(), func(sess *db.Session) error {
 				role := &accesscontrol.Role{
 					OrgID:   tt.user.OrgID,
 					UID:     "seeded",
@@ -471,7 +475,7 @@ func TestIntegrationStore_GetResourcePermissions(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			seedResourcePermissions(t, store, sql, tt.query.Actions, tt.query.Resource, tt.query.ResourceID, tt.query.ResourceAttribute, tt.numUsers)
+			seedResourcePermissions(t, store, sql, orgService, tt.query.Actions, tt.query.Resource, tt.query.ResourceID, tt.query.ResourceAttribute, tt.numUsers)
 
 			tt.query.User = tt.user
 			permissions, err := store.GetResourcePermissions(context.Background(), tt.user.OrgID, tt.query)
@@ -481,21 +485,20 @@ func TestIntegrationStore_GetResourcePermissions(t *testing.T) {
 	}
 }
 
-func seedResourcePermissions(t *testing.T, store *store, sql *sqlstore.SQLStore, actions []string, resource, resourceID, resourceAttribute string, numUsers int) {
+func seedResourcePermissions(t *testing.T, store *store, sql *sqlstore.SQLStore, orgService org.Service, actions []string, resource, resourceID, resourceAttribute string, numUsers int) {
 	t.Helper()
-	var org *models.Org
+	var orgModel *org.Org
 	for i := 0; i < numUsers; i++ {
-		if org == nil {
-			cmd := &models.CreateOrgCommand{Name: "test", UserId: int64(i)}
-			err := sql.CreateOrg(context.Background(), cmd)
+		if orgModel == nil {
+			cmd := &org.CreateOrgCommand{Name: "test", UserID: int64(i)}
+			addedOrg, err := orgService.CreateWithMember(context.Background(), cmd)
 			require.NoError(t, err)
-			addedOrg := cmd.Result
-			org = &addedOrg
+			orgModel = addedOrg
 		}
 
 		u, err := sql.CreateUser(context.Background(), user.CreateUserCommand{
 			Login: fmt.Sprintf("user:%s%d", resourceID, i),
-			OrgID: org.Id,
+			OrgID: orgModel.ID,
 		})
 		require.NoError(t, err)
 

--- a/pkg/services/org/orgimpl/store_test.go
+++ b/pkg/services/org/orgimpl/store_test.go
@@ -176,16 +176,14 @@ func TestIntegrationOrgDataAccess(t *testing.T) {
 		sqlStore := db.InitTestDB(t)
 
 		t.Run("Given we have organizations, we can query them by IDs", func(t *testing.T) {
-			var err error
-			var cmd *models.CreateOrgCommand
 			ids := []int64{}
 
 			for i := 1; i < 4; i++ {
-				cmd = &models.CreateOrgCommand{Name: fmt.Sprint("Org #", i)}
-				err = sqlStore.CreateOrg(context.Background(), cmd)
+				cmd := &org.CreateOrgCommand{Name: fmt.Sprint("Org #", i)}
+				org, err := orgStore.CreateWithMember(context.Background(), cmd)
 				require.NoError(t, err)
 
-				ids = append(ids, cmd.Result.Id)
+				ids = append(ids, org.ID)
 			}
 
 			query := &org.SearchOrgsQuery{IDs: ids}

--- a/pkg/services/provisioning/dashboards/config_reader_test.go
+++ b/pkg/services/provisioning/dashboards/config_reader_test.go
@@ -3,14 +3,12 @@ package dashboards
 import (
 	"context"
 	"errors"
-	"fmt"
 	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/org/orgtest"
@@ -26,7 +24,7 @@ var (
 func TestDashboardsAsConfig(t *testing.T) {
 	t.Run("Dashboards as configuration", func(t *testing.T) {
 		logger := log.New("test-logger")
-		store := db.InitTestDB(t)
+		// store := db.InitTestDB(t)
 		orgFake := orgtest.NewOrgServiceFake()
 
 		t.Run("Should fail if orgs don't exist in the database", func(t *testing.T) {
@@ -37,12 +35,6 @@ func TestDashboardsAsConfig(t *testing.T) {
 			assert.True(t, errors.Is(err, models.ErrOrgNotFound))
 			orgFake.ExpectedError = nil
 		})
-
-		for i := 1; i <= 2; i++ {
-			orgCommand := models.CreateOrgCommand{Name: fmt.Sprintf("Main Org. %v", i)}
-			err := store.CreateOrg(context.Background(), &orgCommand)
-			require.NoError(t, err)
-		}
 
 		t.Run("default values should be applied", func(t *testing.T) {
 			cfgProvider := configReader{path: appliedDefaults, log: logger, orgService: orgFake}

--- a/pkg/services/provisioning/notifiers/config_reader_test.go
+++ b/pkg/services/provisioning/notifiers/config_reader_test.go
@@ -14,7 +14,8 @@ import (
 	encryptionservice "github.com/grafana/grafana/pkg/services/encryption/service"
 	"github.com/grafana/grafana/pkg/services/notifications"
 	"github.com/grafana/grafana/pkg/services/org"
-	"github.com/grafana/grafana/pkg/services/org/orgtest"
+	"github.com/grafana/grafana/pkg/services/org/orgimpl"
+	"github.com/grafana/grafana/pkg/services/quota/quotatest"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 
 	"github.com/stretchr/testify/require"
@@ -35,24 +36,22 @@ var (
 
 func TestNotificationAsConfig(t *testing.T) {
 	var sqlStore *sqlstore.SQLStore
-	var orgFake org.Service
+	var orgService org.Service
 	var ns *alerting.AlertNotificationService
 	logger := log.New("fake.log")
-	orgService := orgtest.NewOrgServiceFake()
-	orgService.ExpectedOrg = &org.Org{}
 
 	encryptionService := encryptionservice.SetupTestService(t)
 
 	t.Run("Testing notification as configuration", func(t *testing.T) {
 		setup := func() {
 			sqlStore = db.InitTestDB(t)
-			orgFake = orgtest.NewOrgServiceFake()
+			orgService, _ = orgimpl.ProvideService(sqlStore, sqlStore.Cfg, quotatest.New(false, nil))
 			nm := &notifications.NotificationService{}
 			ns = alerting.ProvideService(sqlStore, encryptionService, nm)
 
 			for i := 1; i < 5; i++ {
-				orgCommand := models.CreateOrgCommand{Name: fmt.Sprintf("Main Org. %v", i)}
-				err := sqlStore.CreateOrg(context.Background(), &orgCommand)
+				orgCommand := org.CreateOrgCommand{Name: fmt.Sprintf("Main Org. %v", i)}
+				_, err := orgService.CreateWithMember(context.Background(), &orgCommand)
 				require.NoError(t, err)
 			}
 
@@ -73,7 +72,7 @@ func TestNotificationAsConfig(t *testing.T) {
 			setup()
 			_ = os.Setenv("TEST_VAR", "default")
 			cfgProvider := &configReader{
-				orgService:        orgFake,
+				orgService:        orgService,
 				encryptionService: encryptionService,
 				log:               log.New("test logger"),
 			}
@@ -282,7 +281,7 @@ func TestNotificationAsConfig(t *testing.T) {
 
 		t.Run("Broken yaml should return error", func(t *testing.T) {
 			reader := &configReader{
-				orgService:        orgFake,
+				orgService:        orgService,
 				encryptionService: encryptionService,
 				log:               log.New("test logger"),
 			}
@@ -293,7 +292,7 @@ func TestNotificationAsConfig(t *testing.T) {
 
 		t.Run("Skip invalid directory", func(t *testing.T) {
 			cfgProvider := &configReader{
-				orgService:        orgFake,
+				orgService:        orgService,
 				encryptionService: encryptionService,
 				log:               log.New("test logger"),
 			}
@@ -307,7 +306,7 @@ func TestNotificationAsConfig(t *testing.T) {
 
 		t.Run("Unknown notifier should return error", func(t *testing.T) {
 			cfgProvider := &configReader{
-				orgService:        orgFake,
+				orgService:        orgService,
 				encryptionService: encryptionService,
 				log:               log.New("test logger"),
 			}
@@ -318,7 +317,7 @@ func TestNotificationAsConfig(t *testing.T) {
 
 		t.Run("Read incorrect properties", func(t *testing.T) {
 			cfgProvider := &configReader{
-				orgService:        orgFake,
+				orgService:        orgService,
 				encryptionService: encryptionService,
 				log:               log.New("test logger"),
 			}

--- a/pkg/services/serviceaccounts/api/api_test.go
+++ b/pkg/services/serviceaccounts/api/api_test.go
@@ -60,8 +60,8 @@ func TestServiceAccountsAPI_CreateServiceAccount(t *testing.T) {
 		store.Cfg.AutoAssignOrg = autoAssignOrg
 	}()
 
-	orgCmd := &models.CreateOrgCommand{Name: "Some Test Org"}
-	err = store.CreateOrg(context.Background(), orgCmd)
+	orgCmd := &org.CreateOrgCommand{Name: "Some Test Org"}
+	_, err = orgService.CreateWithMember(context.Background(), orgCmd)
 	require.Nil(t, err)
 
 	type testCreateSATestCase struct {


### PR DESCRIPTION
This is related to https://github.com/grafana/grafana/issues/46522 and replaces sqlstore.CreateOrg with org.Service. All but one use cases are resolved, the remaining one is in the legacy alerting, and it causes a test to fail if replaced, so probably that change+fix would be in a separate PR.