### PR TITLE
Alerting: Add discord as a possible receiver in cloud rules

### DIFF
--- a/public/app/features/alerting/unified/utils/cloud-alertmanager-notifier-types.ts
+++ b/public/app/features/alerting/unified/utils/cloud-alertmanager-notifier-types.ts
@@ -330,6 +330,26 @@ export const cloudNotifierTypes: NotifierDTO[] = [
       httpConfigOption,
     ],
   },
+  {
+    name: 'Discord',
+    description: 'Sends notifications to Discord',
+    type: 'discord',
+    info: '',
+    heading: 'Discord settings',
+    options: [
+      option('title', 'Title', 'Templated title of the message', {
+        placeholder: '{{ template "discord.default.title" . }}',
+      }),
+      option(
+        'message',
+        'Message Content',
+        'Mention a group using @ or a user using <@ID> when notifying in a channel',
+        { placeholder: '{{ template "discord.default.message" . }}' }
+      ),
+      option('webhook_url', 'Webhook URL', '', { placeholder: 'Discord webhook URL', required: true }),
+      httpConfigOption,
+    ],
+  },
 ];
 
 export const globalConfigOptions: NotificationChannelOption[] = [


### PR DESCRIPTION
**What is this feature?**

This PR adds Discord receivers for cloud rules in the grafana UI.

**Why do we need this feature?**

Since we merged https://github.com/grafana/mimir/pull/3309 we should be able to add support for Discord receivers.

**Who is this feature for?**

All users.

**Which issue(s) does this PR fix?**:


Fixes [#57666](https://github.com/grafana/grafana/issues/57666)

**Special notes for your reviewer**:


[discordm.webm](https://user-images.githubusercontent.com/33540275/204236367-98fed944-9b41-46b8-823e-610de3d8dba0.webm)
