### PR TITLE
Variables: Url sync for MultiValueVariable 

### DIFF
--- a/public/app/features/scenes/core/types.ts
+++ b/public/app/features/scenes/core/types.ts
@@ -151,14 +151,13 @@ export function isSceneObject(obj: any): obj is SceneObject {
   return obj.useState !== undefined;
 }
 
-/** These functions are still just temporary until this get's refined */
 export interface SceneObjectWithUrlSync<TState> extends SceneObject {
   getUrlState(state: TState): SceneObjectUrlValues;
   updateFromUrl(values: SceneObjectUrlValues): void;
 }
 
 export interface SceneObjectUrlSyncHandler<TState> {
-  getKeys(): Set<string>;
+  getKeys(): string[];
   getUrlState(state: TState): SceneObjectUrlValues;
   updateFromUrl(values: SceneObjectUrlValues): void;
 }

--- a/public/app/features/scenes/services/SceneObjectUrlSyncConfig.ts
+++ b/public/app/features/scenes/services/SceneObjectUrlSyncConfig.ts
@@ -6,17 +6,17 @@ import {
 } from '../core/types';
 
 interface SceneObjectUrlSyncConfigOptions {
-  keys?: string[];
+  keys: string[];
 }
 
 export class SceneObjectUrlSyncConfig<TState extends SceneObjectState> implements SceneObjectUrlSyncHandler<TState> {
-  private _keys: Set<string>;
+  private _keys: string[];
 
   public constructor(private _sceneObject: SceneObjectWithUrlSync<TState>, _options: SceneObjectUrlSyncConfigOptions) {
-    this._keys = new Set(_options.keys);
+    this._keys = _options.keys;
   }
 
-  public getKeys(): Set<string> {
+  public getKeys(): string[] {
     return this._keys;
   }
 

--- a/public/app/features/scenes/services/UrlSyncManager.test.ts
+++ b/public/app/features/scenes/services/UrlSyncManager.test.ts
@@ -72,12 +72,6 @@ describe('UrlSyncManager', () => {
 
       // Should not update url
       expect(locationUpdates.length).toBe(1);
-
-      // When clearing url (via go back)
-      locationService.getHistory().goBack();
-
-      // Should restore to initial state
-      expect(obj.state.name).toBe('test');
     });
   });
 
@@ -102,7 +96,8 @@ describe('UrlSyncManager', () => {
       expect(obj.state.name).toBe('test2');
 
       // When relevant key is cleared (say go back)
-      locationService.partial({ name: null });
+      locationService.getHistory().goBack();
+
       // Should revert to initial state
       expect(obj.state.name).toBe('test');
 

--- a/public/app/features/scenes/services/UrlSyncManager.test.ts
+++ b/public/app/features/scenes/services/UrlSyncManager.test.ts
@@ -17,9 +17,7 @@ interface TestObjectState extends SceneLayoutChildState {
 }
 
 class TestObj extends SceneObjectBase<TestObjectState> {
-  protected _urlSync = new SceneObjectUrlSyncConfig(this, {
-    keys: ['name', 'array'],
-  });
+  protected _urlSync = new SceneObjectUrlSyncConfig(this, { keys: ['name', 'array'] });
 
   public getUrlState(state: TestObjectState) {
     return { name: state.name, array: state.array };

--- a/public/app/features/scenes/services/UrlSyncManager.ts
+++ b/public/app/features/scenes/services/UrlSyncManager.ts
@@ -63,7 +63,7 @@ export class UrlSyncManager {
       }
 
       if (Object.keys(mappedUpdated).length > 0) {
-        locationService.partial(mappedUpdated, false);
+        locationService.partial(mappedUpdated, true);
       }
     }
   };

--- a/public/app/features/scenes/variables/variants/MultiValueVariable.test.ts
+++ b/public/app/features/scenes/variables/variants/MultiValueVariable.test.ts
@@ -153,4 +153,64 @@ describe('MultiValueVariable', () => {
       expect(variable.getValue()).toEqual(['1', '2']);
     });
   });
+
+  describe('Url syncing', () => {
+    it('getUrlState should return single value state if value is single value', async () => {
+      const variable = new ExampleVariable({
+        name: 'test',
+        options: [],
+        optionsToReturn: [],
+        value: '1',
+        text: 'A',
+      });
+
+      expect(variable.urlSync?.getUrlState(variable.state)).toEqual({ ['var-test']: '1' });
+    });
+
+    it('getUrlState should return string array if value is string array', async () => {
+      const variable = new ExampleVariable({
+        name: 'test',
+        options: [],
+        optionsToReturn: [],
+        value: ['1', '2'],
+        text: ['A', 'B'],
+      });
+
+      expect(variable.urlSync?.getUrlState(variable.state)).toEqual({ ['var-test']: ['1', '2'] });
+    });
+
+    it('fromUrlState should update value for single value', async () => {
+      const variable = new ExampleVariable({
+        name: 'test',
+        options: [
+          { label: 'A', value: '1' },
+          { label: 'B', value: '2' },
+        ],
+        optionsToReturn: [],
+        value: '1',
+        text: 'A',
+      });
+
+      variable.urlSync?.updateFromUrl({ ['var-test']: '2' });
+      expect(variable.state.value).toEqual('2');
+      expect(variable.state.text).toEqual('B');
+    });
+
+    it('fromUrlState should update value for array value', async () => {
+      const variable = new ExampleVariable({
+        name: 'test',
+        options: [
+          { label: 'A', value: '1' },
+          { label: 'B', value: '2' },
+        ],
+        optionsToReturn: [],
+        value: '1',
+        text: 'A',
+      });
+
+      variable.urlSync?.updateFromUrl({ ['var-test']: ['2', '1'] });
+      expect(variable.state.value).toEqual(['2', '1']);
+      expect(variable.state.text).toEqual(['B', 'A']);
+    });
+  });
 });


### PR DESCRIPTION
Based on https://github.com/grafana/grafana/pull/59154 

* [x] Implements url sync for multi value variable
* [x] Switches to location replace by default so url sync via state change does not create browser history item (to change state and get a new browser history will need explicit state change via URL instead of via scene state change)

Issues to fix in follow-up PR
* Highlights some limitations in the Select / MultiSelect (Selector component) that currently does show the value until the options are loading. Think we should fix this. At some point we need to switch to AsyncSelect or implement Async behavior ontop of the non async select 