### PR TITLE
Nested folder: Fix for PostgreSQL

### DIFF
--- a/pkg/services/folder/folderimpl/sqlstore.go
+++ b/pkg/services/folder/folderimpl/sqlstore.go
@@ -261,5 +261,5 @@ func (ss *sqlStore) getParentsMySQL(ctx context.Context, cmd folder.GetParentsQu
 		}
 		return nil
 	})
-	return folders, err
+	return util.Reverse(folders), err
 }

--- a/pkg/services/folder/folderimpl/sqlstore.go
+++ b/pkg/services/folder/folderimpl/sqlstore.go
@@ -216,7 +216,7 @@ func (ss *sqlStore) GetChildren(ctx context.Context, q folder.GetTreeQuery) ([]*
 
 	err := ss.db.WithDbSession(ctx, func(sess *db.Session) error {
 		sql := strings.Builder{}
-		sql.Write([]byte("SELECT * FROM folder WHERE parent_uid=? AND org_id=?"))
+		sql.Write([]byte("SELECT * FROM folder WHERE parent_uid=? AND org_id=? ORDER BY id"))
 
 		if q.Limit != 0 {
 			var offset int64 = 1


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

It fixes failure due to PostgreSQL lack of support of `LastInsertId`:
`[folder.database-error] failed to get last inserted id: LastInsertId is not supported by this driver`

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
I have run store tests against MySQL 5.7 (need to uncomment [the migration](https://github.com/grafana/grafana/blob/0af3515e95cf185b60242022ede43562127757be/pkg/services/sqlstore/migrations/migrations.go#L115) and enable [skipped tests](https://github.com/grafana/grafana/blob/0af3515e95cf185b60242022ede43562127757be/pkg/services/folder/folderimpl/sqlstore_test.go#L26)):
```
make devenv sources=mysql_tests
GRAFANA_TEST_DB=mysql go test -v -count=1 -run Integration -covermode=atomic -timeout=2m ./pkg/services/folder/folderimpl/...
```

MySQL 8.0:
```
make devenv sources=mysql_tests mysql_version=8.0
GRAFANA_TEST_DB=mysql go test -v -count=1 -run Integration -covermode=atomic -timeout=2m ./pkg/services/folder/folderimpl/...
```

and PostgreSQL:
```
make devenv sources=postgres_tests
GRAFANA_TEST_DB=postgres go test -v -count=1 -run Integration -covermode=atomic -timeout=2m ./pkg/services/folder/folderimpl/... 
```



