### PR TITLE
PanelEdit: Fixes alignment issue with collapse button

### DIFF
--- a/public/app/features/alerting/unified/components/CollapseToggle.tsx
+++ b/public/app/features/alerting/unified/components/CollapseToggle.tsx
@@ -29,6 +29,7 @@ export const CollapseToggle: FC<Props> = ({
     <Button
       type="button"
       fill="text"
+      variant="secondary"
       aria-expanded={!isCollapsed}
       aria-controls={idControlled}
       className={cx(styles.expandButton, className)}
@@ -43,7 +44,6 @@ export const CollapseToggle: FC<Props> = ({
 
 export const getStyles = (theme: GrafanaTheme2) => ({
   expandButton: css`
-    color: ${theme.colors.text.secondary};
     margin-right: ${theme.spacing(1)};
   `,
 });

--- a/public/app/features/alerting/unified/components/alert-groups/AlertGroup.tsx
+++ b/public/app/features/alerting/unified/components/alert-groups/AlertGroup.tsx
@@ -25,6 +25,7 @@ export const AlertGroup = ({ alertManagerSourceName, group }: Props) => {
       <div className={styles.header}>
         <div className={styles.group} data-testid="alert-group">
           <CollapseToggle
+            size="sm"
             isCollapsed={isCollapsed}
             onToggle={() => setIsCollapsed(!isCollapsed)}
             data-testid="alert-group-collapse-toggle"

--- a/public/app/features/alerting/unified/components/rules/RulesGroup.tsx
+++ b/public/app/features/alerting/unified/components/rules/RulesGroup.tsx
@@ -192,6 +192,7 @@ export const RulesGroup: FC<Props> = React.memo(({ group, namespace, expandAll, 
     <div className={styles.wrapper} data-testid="rule-group">
       <div className={styles.header} data-testid="rule-group-header">
         <CollapseToggle
+          size="sm"
           className={styles.collapseToggle}
           isCollapsed={isCollapsed}
           onToggle={setIsCollapsed}

--- a/public/app/features/dashboard/components/PanelEditor/OptionsPaneCategory.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/OptionsPaneCategory.tsx
@@ -4,9 +4,8 @@ import { useLocalStorage } from 'react-use';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
-import { Counter, useStyles2 } from '@grafana/ui';
+import { Button, Counter, useStyles2 } from '@grafana/ui';
 import { useQueryParams } from 'app/core/hooks/useQueryParams';
-import { CollapseToggle } from 'app/features/alerting/unified/components/CollapseToggle';
 
 import { PANEL_EDITOR_UI_STATE_STORAGE_KEY } from './state/reducers';
 
@@ -107,7 +106,16 @@ export const OptionsPaneCategory: FC<OptionsPaneCategoryProps> = React.memo(
         ref={ref}
       >
         <div className={headerStyles} onClick={onToggle} aria-label={selectors.components.OptionsGroup.toggle(id)}>
-          <CollapseToggle isCollapsed={!isExpanded} idControlled={id} onToggle={onToggle} />
+          <Button
+            type="button"
+            fill="text"
+            size="sm"
+            variant="secondary"
+            aria-expanded={isExpanded}
+            className={styles.toggleButton}
+            icon={isExpanded ? 'angle-down' : 'angle-right'}
+            onClick={onToggle}
+          />
           <h6 id={`button-${id}`} className={styles.title}>
             {renderTitle(isExpanded)}
           </h6>
@@ -137,13 +145,14 @@ const getStyles = (theme: GrafanaTheme2) => {
       overflow: hidden;
       line-height: 1.5;
       font-size: 1rem;
+      padding-left: ${theme.spacing(0.7)};
       font-weight: ${theme.typography.fontWeightMedium};
       margin: 0;
     `,
     header: css`
       display: flex;
       cursor: pointer;
-      align-items: baseline;
+      align-items: center;
       padding: ${theme.spacing(0.5)};
       color: ${theme.colors.text.primary};
       font-weight: ${theme.typography.fontWeightMedium};
@@ -151,6 +160,9 @@ const getStyles = (theme: GrafanaTheme2) => {
       &:hover {
         background: ${theme.colors.emphasize(theme.colors.background.primary, 0.03)};
       }
+    `,
+    toggleButton: css`
+      align-self: baseline;
     `,
     headerExpanded: css`
       color: ${theme.colors.text.primary};

--- a/public/app/features/dashboard/components/PanelEditor/OptionsPaneCategory.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/OptionsPaneCategory.tsx
@@ -145,7 +145,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       overflow: hidden;
       line-height: 1.5;
       font-size: 1rem;
-      padding-left: ${theme.spacing(0.7)};
+      padding-left: 6px;
       font-weight: ${theme.typography.fontWeightMedium};
       margin: 0;
     `,

--- a/public/app/plugins/panel/alertGroups/AlertGroup.tsx
+++ b/public/app/plugins/panel/alertGroups/AlertGroup.tsx
@@ -103,6 +103,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     display: flex;
     flex-direction: row;
     align-items: center;
+    gap: ${theme.spacing(1)};
   `,
   alerts: css`
     margin: ${theme.spacing(0, 2, 0, 4)};


### PR DESCRIPTION
Fixes issue with Panel Edit options pane where the exanded content is not aligned with the category title!

Was introduced by this PR https://github.com/grafana/grafana/pull/4640

I tried to change the CollapseButton but it was used in a lot of places in Alerting (which has two different toggle buttons), CollapseButton is strange and should be removed (or moved to Grafana ui and made more generic), it has a built-in margin which makes it very hard to use in different settings (component should never have margin!), and overrides the size property to not be the normal button size (ComponentSize) but icon size instead. It needs a redesign re-think :) 

I tried to update it but requires updating a bunch of places in alerting. So instead just fixing panel edit by using a plain Button 

Before: 
<img width="293" alt="Screenshot 2022-11-28 at 09 52 17" src="https://user-images.githubusercontent.com/10999/204319377-1bd96920-5c2b-4c8f-bf93-1cdefee766ee.png">

After: 
![image](https://user-images.githubusercontent.com/10999/204319245-5a84437e-6136-4452-9268-adcdb4e1c5da.png)
