### PR TITLE
Fix Silence table grid layout

### DIFF
--- a/public/app/features/alerting/unified/components/silences/SilencesTable.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilencesTable.tsx
@@ -186,7 +186,7 @@ function useColumns(alertManagerSourceName: string) {
         renderCell: function renderStateTag({ data: { status } }) {
           return <SilenceStateTag state={status.state} />;
         },
-        size: '88px',
+        size: 4,
       },
       {
         id: 'matchers',
@@ -194,7 +194,7 @@ function useColumns(alertManagerSourceName: string) {
         renderCell: function renderMatchers({ data: { matchers } }) {
           return <Matchers matchers={matchers || []} />;
         },
-        size: 9,
+        size: 10,
       },
       {
         id: 'alerts',
@@ -202,7 +202,7 @@ function useColumns(alertManagerSourceName: string) {
         renderCell: function renderSilencedAlerts({ data: { silencedAlerts } }) {
           return <span data-testid="alerts">{silencedAlerts.length}</span>;
         },
-        size: 1,
+        size: 4,
       },
       {
         id: 'schedule',
@@ -215,12 +215,11 @@ function useColumns(alertManagerSourceName: string) {
             <>
               {' '}
               {startsAtDate?.format(dateDisplayFormat)} {'-'}
-              <br />
               {endsAtDate?.format(dateDisplayFormat)}
             </>
           );
         },
-        size: '150px',
+        size: 7,
       },
     ];
     if (showActions) {
@@ -250,7 +249,7 @@ function useColumns(alertManagerSourceName: string) {
             </Stack>
           );
         },
-        size: '147px',
+        size: 5,
       });
     }
     return columns;


### PR DESCRIPTION
This PR fixes Silence table grid layout: 

**Special notes for your reviewer**:

Before:
<img width="1382" alt="Screenshot 2022-11-28 at 16 51 09" src="https://user-images.githubusercontent.com/33540275/204322448-30378cb0-fe78-4100-988f-5ffad469f55c.png">

After:
<img width="1381" alt="Screenshot 2022-11-28 at 16 49 25" src="https://user-images.githubusercontent.com/33540275/204322483-b9eeeacb-36f1-4940-be18-551ad76fa876.png">


