### PR TITLE
CI: change regex to accomodate new branching stategy in enterprise

### DIFF
--- a/pkg/build/git/git.go
+++ b/pkg/build/git/git.go
@@ -60,7 +60,7 @@ func NewGitHubClient(ctx context.Context, token string) *github.Client {
 }
 
 func PRCheckRegexp() *regexp.Regexp {
-	reBranch, err := regexp.Compile(`^pr-check-([0-9]+)\/(.+)$`)
+	reBranch, err := regexp.Compile(`^prc-([0-9]+)-([A-Za-z0-9]+)\/(.+)$`)
 	if err != nil {
 		panic(fmt.Sprintf("Failed to compile regexp: %s", err))
 	}

--- a/pkg/build/git/git_test.go
+++ b/pkg/build/git/git_test.go
@@ -8,18 +8,49 @@ import (
 )
 
 func TestPRCheckRegexp(t *testing.T) {
+	type match struct {
+		String string
+		Commit string
+		Branch string
+		PR     string
+	}
+
 	var (
-		shouldMatch    = []string{"pr-check-1/branch-name", "pr-check-111/branch/name", "pr-check-102930122/branch-name"}
-		shouldNotMatch = []string{"pr-check-a/branch", "km/test", "test", "pr-check", "pr-check/test", "price"}
+		shouldMatch = []match{
+			{
+				String: "prc-1-a1b2c3d4/branch-name",
+				Branch: "branch-name",
+				Commit: "a1b2c3d4",
+				PR:     "1",
+			},
+			{
+				String: "prc-111-a1b2c3d4/branch/name",
+				Branch: "branch/name",
+				Commit: "a1b2c3d4",
+				PR:     "111",
+			},
+			{
+				String: "prc-102930122-a1b2c3d4/branch-name",
+				Branch: "branch-name",
+				Commit: "a1b2c3d4",
+				PR:     "102930122",
+			},
+		}
+
+		shouldNotMatch = []string{"prc-a/branch", "km/test", "test", "prc", "prc/test", "price"}
 	)
 
 	regex := git.PRCheckRegexp()
 
 	for _, v := range shouldMatch {
-		assert.Truef(t, regex.MatchString(v), "regex should match %s", v)
+		assert.Truef(t, regex.MatchString(v.String), "regex '%s' should match %s", regex.String(), v)
+		m := regex.FindStringSubmatch(v.String)
+		assert.Equal(t, m[1], v.PR)
+		assert.Equal(t, m[2], v.Commit)
+		assert.Equal(t, m[3], v.Branch)
 	}
 
 	for _, v := range shouldNotMatch {
-		assert.False(t, regex.MatchString(v), "regex should not match %s", v)
+		assert.False(t, regex.MatchString(v), "regex '%s' should not match %s", regex.String(), v)
 	}
 }


### PR DESCRIPTION
This is to make the grafana-enterprise downstream check work.