### PR TITLE
Alerting: Fix swallowing of errors when attaching images to notifications

### DIFF
--- a/pkg/services/ngalert/notifier/channels/pushover.go
+++ b/pkg/services/ngalert/notifier/channels/pushover.go
@@ -284,7 +284,7 @@ func (pn *PushoverNotifier) genPushoverBody(ctx context.Context, as ...*types.Al
 func (pn *PushoverNotifier) writeImageParts(ctx context.Context, w *multipart.Writer, as ...*types.Alert) {
 	// Pushover supports at most one image attachment with a maximum size of pushoverMaxFileSize.
 	// If the image is larger than pushoverMaxFileSize then return an error.
-	err := withStoredImages(ctx, pn.log, pn.images, func(index int, image ngmodels.Image) error {
+	_ = withStoredImages(ctx, pn.log, pn.images, func(index int, image ngmodels.Image) error {
 		f, err := os.Open(image.Path)
 		if err != nil {
 			return fmt.Errorf("Failed to open the image: %w", err)
@@ -315,7 +315,4 @@ func (pn *PushoverNotifier) writeImageParts(ctx context.Context, w *multipart.Wr
 
 		return ErrImagesDone
 	}, as...)
-	if err != nil {
-		pn.log.Warn("Failed to attach image, skipping", "error", err)
-	}
 }

--- a/pkg/services/ngalert/notifier/channels/pushover.go
+++ b/pkg/services/ngalert/notifier/channels/pushover.go
@@ -287,30 +287,30 @@ func (pn *PushoverNotifier) writeImageParts(ctx context.Context, w *multipart.Wr
 	_ = withStoredImages(ctx, pn.log, pn.images, func(index int, image ngmodels.Image) error {
 		f, err := os.Open(image.Path)
 		if err != nil {
-			return fmt.Errorf("Failed to open the image: %w", err)
+			return fmt.Errorf("failed to open the image: %w", err)
 		}
 		defer func() {
 			if err := f.Close(); err != nil {
-				pn.log.Error("Failed to close the image", "file", image.Path)
+				pn.log.Error("failed to close the image", "file", image.Path)
 			}
 		}()
 
 		fileInfo, err := f.Stat()
 		if err != nil {
-			return fmt.Errorf("Failed to stat the image: %w", err)
+			return fmt.Errorf("failed to stat the image: %w", err)
 		}
 
 		if fileInfo.Size() > pushoverMaxFileSize {
-			return fmt.Errorf("Image would exceeded maximum file size: %d", fileInfo.Size())
+			return fmt.Errorf("image would exceeded maximum file size: %d", fileInfo.Size())
 		}
 
 		fw, err := w.CreateFormFile("attachment", image.Path)
 		if err != nil {
-			return fmt.Errorf("Failed to create form file for the image: %w", err)
+			return fmt.Errorf("failed to create form file for the image: %w", err)
 		}
 
 		if _, err = io.Copy(fw, f); err != nil {
-			return fmt.Errorf("Failed to copy the image to the form file: %w", err)
+			return fmt.Errorf("failed to copy the image to the form file: %w", err)
 		}
 
 		return ErrImagesDone

--- a/pkg/services/ngalert/notifier/channels/util.go
+++ b/pkg/services/ngalert/notifier/channels/util.go
@@ -82,7 +82,8 @@ func getImage(ctx context.Context, l log.Logger, imageStore ImageStore, alert ty
 // images have been found.
 func withStoredImages(ctx context.Context, l log.Logger, imageStore ImageStore, forEachFunc forEachImageFunc, alerts ...*types.Alert) error {
 	for index, alert := range alerts {
-		img, err := getImage(ctx, l, imageStore, *alert)
+		logger := l.New("alert", alert.String())
+		img, err := getImage(ctx, logger, imageStore, *alert)
 		if err != nil {
 			return err
 		} else if img != nil {
@@ -90,6 +91,7 @@ func withStoredImages(ctx context.Context, l log.Logger, imageStore ImageStore, 
 				if errors.Is(err, ErrImagesDone) {
 					return nil
 				}
+				logger.Error("Failed to attach image to notification", "error", err)
 				return err
 			}
 		}


### PR DESCRIPTION
**What is this feature?**

When making an unrelated change in the Pushover notifier, I noticed it silently drops any errors that happen when trying to attach the image to the multipart request.

**Why do we need this feature?**

This PR fixes this for all notifiers. We now log the reason why we failed to attach an image.
Also attaches the appropriate log context when trying to get images from the cache.

**Which issue(s) does this PR fix?**:

Contributes to https://github.com/grafana/alerting-squad/issues/240

**Special notes for your reviewer**:
n/a
