### PR TITLE
SQL Datasources: Fix annotation migration

### DIFF
--- a/public/app/features/plugins/sql/utils/migration.test.ts
+++ b/public/app/features/plugins/sql/utils/migration.test.ts
@@ -1,0 +1,28 @@
+import { QueryFormat } from '../types';
+
+import migrateAnnotation from './migration';
+
+describe('Annotation migration', () => {
+  const annotation = {
+    datasource: {
+      uid: 'P4FDCC188E688367F',
+      type: 'mysql',
+    },
+    enable: false,
+    hide: false,
+    iconColor: 'rgba(0, 211, 255, 1)',
+    limit: 100,
+    name: 'Single',
+    rawQuery:
+      "SELECT\n  createdAt as time,\n  'single' as text,\n hostname as tags\nFROM\n   grafana_metric\nWHERE\n  $__timeFilter(createdAt)\nORDER BY time\nLIMIT 1\n",
+    showIn: 0,
+    tags: [],
+    type: 'tags',
+  };
+
+  it('should migrate from old format to new', () => {
+    const newAnnotationFormat = migrateAnnotation(annotation);
+    expect(newAnnotationFormat.target?.format).toBe(QueryFormat.Table);
+    expect(newAnnotationFormat.target?.rawSql).toBe(annotation.rawQuery);
+  });
+});

--- a/public/app/features/plugins/sql/utils/migration.ts
+++ b/public/app/features/plugins/sql/utils/migration.ts
@@ -1,6 +1,6 @@
 import { AnnotationQuery } from '@grafana/data';
-import { EditorMode } from '@grafana/experimental';
 
+import { applyQueryDefaults } from '../defaults';
 import { SQLQuery } from '../types';
 
 export default function migrateAnnotation(annotation: AnnotationQuery<SQLQuery>) {
@@ -10,12 +10,7 @@ export default function migrateAnnotation(annotation: AnnotationQuery<SQLQuery>)
     return annotation;
   }
 
-  const newQuery: SQLQuery = {
-    ...(annotation.target ?? {}),
-    refId: annotation.target?.refId ?? 'Anno',
-    editorMode: EditorMode.Code,
-    rawSql: oldQuery,
-  };
+  const newQuery = applyQueryDefaults({ refId: 'Annotation', ...(annotation.target ?? {}), rawSql: oldQuery });
 
   return {
     ...annotation,


### PR DESCRIPTION
I've missed to pass default values to the query in https://github.com/grafana/grafana/pull/58847. Format is required in order to make a sql query.

**Which issue(s) does this PR fix?**:

Fixes #58497

