### PR TITLE
Chore: Remove CreateOrg from alerting and use orgStore instead

### DIFF
--- a/pkg/services/sqlstore/org.go
+++ b/pkg/services/sqlstore/org.go
@@ -1,85 +1,15 @@
 package sqlstore
 
 import (
-	"context"
 	"fmt"
 	"time"
 
 	"github.com/grafana/grafana/pkg/events"
 	"github.com/grafana/grafana/pkg/models"
-	"github.com/grafana/grafana/pkg/services/org"
-	"xorm.io/xorm"
 )
 
 // MainOrgName is the name of the main organization.
 const MainOrgName = "Main Org."
-
-func isOrgNameTaken(name string, existingId int64, sess *DBSession) (bool, error) {
-	// check if org name is taken
-	var org models.Org
-	exists, err := sess.Where("name=?", name).Get(&org)
-
-	if err != nil {
-		return false, nil
-	}
-
-	if exists && existingId != org.Id {
-		return true, nil
-	}
-
-	return false, nil
-}
-
-func (ss *SQLStore) createOrg(ctx context.Context, name string, userID int64, engine *xorm.Engine) (models.Org, error) {
-	orga := models.Org{
-		Name:    name,
-		Created: time.Now(),
-		Updated: time.Now(),
-	}
-	if err := ss.inTransactionWithRetryCtx(ctx, engine, ss.bus, func(sess *DBSession) error {
-		if isNameTaken, err := isOrgNameTaken(name, 0, sess); err != nil {
-			return err
-		} else if isNameTaken {
-			return models.ErrOrgNameTaken
-		}
-
-		if _, err := sess.Insert(&orga); err != nil {
-			return err
-		}
-
-		user := models.OrgUser{
-			OrgId:   orga.Id,
-			UserId:  userID,
-			Role:    org.RoleAdmin,
-			Created: time.Now(),
-			Updated: time.Now(),
-		}
-
-		_, err := sess.Insert(&user)
-
-		sess.publishAfterCommit(&events.OrgCreated{
-			Timestamp: orga.Created,
-			Id:        orga.Id,
-			Name:      orga.Name,
-		})
-
-		return err
-	}, 0); err != nil {
-		return orga, err
-	}
-
-	return orga, nil
-}
-
-func (ss *SQLStore) CreateOrg(ctx context.Context, cmd *models.CreateOrgCommand) error {
-	org, err := ss.createOrg(ctx, cmd.Name, cmd.UserId, ss.engine)
-	if err != nil {
-		return err
-	}
-
-	cmd.Result = org
-	return nil
-}
 
 func verifyExistingOrg(sess *DBSession, orgId int64) error {
 	var org models.Org

--- a/pkg/tests/api/alerting/api_admin_configuration_test.go
+++ b/pkg/tests/api/alerting/api_admin_configuration_test.go
@@ -2,6 +2,7 @@ package alerting
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -13,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
@@ -42,8 +44,13 @@ func TestAdminConfiguration_SendingToExternalAlertmanagers(t *testing.T) {
 		Password:       "password",
 	})
 	apiClient := newAlertingApiClient(grafanaListedAddr, "grafana", "password")
+
 	// create another organisation
-	orgID := createOrg(t, s, "another org", userID)
+	cmd := &models.CreateOrgCommand{Name: "another org", UserId: userID}
+	err := s.CreateOrg(context.Background(), cmd)
+	require.NoError(t, err)
+	orgID := cmd.Result.Id
+
 	// ensure that the orgID is 3 (the disabled org)
 	require.Equal(t, disableOrgID, orgID)
 

--- a/pkg/tests/api/alerting/api_admin_configuration_test.go
+++ b/pkg/tests/api/alerting/api_admin_configuration_test.go
@@ -14,12 +14,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
-	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/sender"
 	"github.com/grafana/grafana/pkg/services/org"
+	"github.com/grafana/grafana/pkg/services/org/orgimpl"
+	"github.com/grafana/grafana/pkg/services/quota/quotatest"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/tests/testinfra"
 )
@@ -37,6 +38,9 @@ func TestAdminConfiguration_SendingToExternalAlertmanagers(t *testing.T) {
 
 	grafanaListedAddr, s := testinfra.StartGrafana(t, dir, path)
 
+	orgService, err := orgimpl.ProvideService(s, s.Cfg, quotatest.New(false, nil))
+	require.NoError(t, err)
+
 	// Create a user to make authenticated requests
 	userID := createUser(t, s, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
@@ -46,10 +50,9 @@ func TestAdminConfiguration_SendingToExternalAlertmanagers(t *testing.T) {
 	apiClient := newAlertingApiClient(grafanaListedAddr, "grafana", "password")
 
 	// create another organisation
-	cmd := &models.CreateOrgCommand{Name: "another org", UserId: userID}
-	err := s.CreateOrg(context.Background(), cmd)
+	newOrg, err := orgService.CreateWithMember(context.Background(), &org.CreateOrgCommand{Name: "another org", UserID: userID})
 	require.NoError(t, err)
-	orgID := cmd.Result.Id
+	orgID := newOrg.ID
 
 	// ensure that the orgID is 3 (the disabled org)
 	require.Equal(t, disableOrgID, orgID)

--- a/pkg/tests/api/alerting/api_alertmanager_configuration_test.go
+++ b/pkg/tests/api/alerting/api_alertmanager_configuration_test.go
@@ -1,6 +1,7 @@
 package alerting
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -9,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/user"
@@ -39,7 +41,10 @@ func TestAlertmanagerConfigurationIsTransactional(t *testing.T) {
 	})
 
 	// create another organisation
-	orgID := createOrg(t, store, "another org", userID)
+	cmd := &models.CreateOrgCommand{Name: "another org", UserId: userID}
+	err := store.CreateOrg(context.Background(), cmd)
+	require.NoError(t, err)
+	orgID := cmd.Result.Id
 
 	// create user under different organisation
 	createUser(t, store, user.CreateUserCommand{

--- a/pkg/tests/api/alerting/api_alertmanager_test.go
+++ b/pkg/tests/api/alerting/api_alertmanager_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/grafana/pkg/models"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	ngstore "github.com/grafana/grafana/pkg/services/ngalert/store"
@@ -2538,14 +2537,6 @@ func createUser(t *testing.T, store *sqlstore.SQLStore, cmd user.CreateUserComma
 	u, err := store.CreateUser(context.Background(), cmd)
 	require.NoError(t, err)
 	return u.ID
-}
-
-func createOrg(t *testing.T, store *sqlstore.SQLStore, name string, userID int64) int64 {
-	cmd := &models.CreateOrgCommand{Name: name, UserId: userID}
-	err := store.CreateOrg(context.Background(), cmd)
-	require.NoError(t, err)
-	org := cmd.Result
-	return org.Id
 }
 
 func getLongString(t *testing.T, n int) string {


### PR DESCRIPTION
This is a continuation of https://github.com/grafana/grafana/pull/59356 and is related to the #46522 epic.

It removes the last usage of sqlstore.CreateOrg from the alerting tests.