### PR TITLE
VizPanel: Fixes sizing issues

### DIFF
--- a/public/app/features/scenes/components/VizPanel/VizPanelRenderer.tsx
+++ b/public/app/features/scenes/components/VizPanel/VizPanelRenderer.tsx
@@ -50,7 +50,7 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
   }
 
   return (
-    <div ref={ref as RefCallback<HTMLDivElement>} style={{ width: '100%', height: '100%' }}>
+    <div ref={ref as RefCallback<HTMLDivElement>} style={{ position: 'absolute', width: '100%', height: '100%' }}>
       <PanelChrome
         title={titleInterpolated}
         width={width}

--- a/public/app/features/scenes/components/layout/SceneFlexLayout.tsx
+++ b/public/app/features/scenes/components/layout/SceneFlexLayout.tsx
@@ -60,6 +60,7 @@ function getItemStyles(direction: FlexLayoutDirection, sizing: SceneObjectSize =
     flexDirection: direction,
     minWidth: sizing.minWidth,
     minHeight: sizing.minHeight,
+    position: 'relative',
   };
 
   if (direction === 'column') {


### PR DESCRIPTION
In the recent big VizPanel PR update I switched from AutoSize to useMeasure, but with useMeasure
the panel does not handle getting smaller (when resizing window, or collapsing things) (as the inner panel has set width/height).

And discovered another issue, when I collapse a row (in flex layout), the row below takes up all the remaining
space and will not give it back when the row above is expanded again.

The solution is to switch to absolute positioned div wrapper around PanelChrome (or make PanelChrome's outer div absolute positioned).
This way it does not impact the outer layout div size.


