### PR TITLE
Login: Remove CreateUser from LoginService

### DIFF
--- a/pkg/api/admin_users.go
+++ b/pkg/api/admin_users.go
@@ -65,7 +65,7 @@ func (hs *HTTPServer) AdminCreateUser(c *models.ReqContext) response.Response {
 		return response.Error(400, "Password is missing or too short", nil)
 	}
 
-	usr, err := hs.Login.CreateUser(cmd)
+	usr, err := hs.userService.Create(c.Req.Context(), &cmd)
 	if err != nil {
 		if errors.Is(err, models.ErrOrgNotFound) {
 			return response.Error(400, err.Error(), nil)

--- a/pkg/api/admin_users_test.go
+++ b/pkg/api/admin_users_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/auth"
 	"github.com/grafana/grafana/pkg/services/auth/authtest"
-	"github.com/grafana/grafana/pkg/services/login/loginservice"
 	"github.com/grafana/grafana/pkg/services/login/logintest"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
@@ -400,11 +399,15 @@ func adminDeleteUserScenario(t *testing.T, desc string, url string, routePattern
 func adminCreateUserScenario(t *testing.T, desc string, url string, routePattern string, cmd dtos.AdminCreateUserForm, fn scenarioFunc) {
 	t.Run(fmt.Sprintf("%s %s", desc, url), func(t *testing.T) {
 		hs := HTTPServer{
-			Login: loginservice.LoginServiceMock{
-				ExpectedUserForm:    cmd,
-				NoExistingOrgId:     nonExistingOrgID,
-				AlreadyExitingLogin: existingTestLogin,
-				GeneratedUserId:     testUserID,
+			userService: &usertest.FakeUserService{
+				ExpectedUser:             nil,
+				ExpectedSignedInUser:     nil,
+				ExpectedError:            nil,
+				ExpectedSetUsingOrgError: nil,
+				ExpectedSearchUsers:      user.SearchUserQueryResult{},
+				ExpectedUserProfileDTO:   nil,
+				ExpectedUserProfileDTOs:  nil,
+				GetSignedInUserFn:        nil,
 			},
 		}
 

--- a/pkg/api/org_invite.go
+++ b/pkg/api/org_invite.go
@@ -259,7 +259,7 @@ func (hs *HTTPServer) CompleteInvite(c *models.ReqContext) response.Response {
 		SkipOrgSetup: true,
 	}
 
-	usr, err := hs.Login.CreateUser(cmd)
+	usr, err := hs.userService.Create(c.Req.Context(), &cmd)
 	if err != nil {
 		if errors.Is(err, user.ErrUserAlreadyExists) {
 			return response.Error(412, fmt.Sprintf("User with email '%s' or username '%s' already exists", completeInvite.Email, completeInvite.Username), err)

--- a/pkg/api/signup.go
+++ b/pkg/api/signup.go
@@ -102,7 +102,7 @@ func (hs *HTTPServer) SignUpStep2(c *models.ReqContext) response.Response {
 		createUserCmd.EmailVerified = true
 	}
 
-	usr, err := hs.Login.CreateUser(createUserCmd)
+	usr, err := hs.userService.Create(c.Req.Context(), &createUserCmd)
 	if err != nil {
 		if errors.Is(err, user.ErrUserAlreadyExists) {
 			return response.Error(401, "User with same email address already exists", nil)

--- a/pkg/services/login/login.go
+++ b/pkg/services/login/login.go
@@ -18,7 +18,6 @@ var (
 type TeamSyncFunc func(user *user.User, externalUser *models.ExternalUserInfo) error
 
 type Service interface {
-	CreateUser(cmd user.CreateUserCommand) (*user.User, error)
 	UpsertUser(ctx context.Context, cmd *models.UpsertUserCommand) error
 	DisableExternalUser(ctx context.Context, username string) error
 	SetTeamSyncFunc(TeamSyncFunc)

--- a/pkg/services/login/loginservice/loginservice_mock.go
+++ b/pkg/services/login/loginservice/loginservice_mock.go
@@ -2,9 +2,7 @@ package loginservice
 
 import (
 	"context"
-	"errors"
 
-	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/login"
 	"github.com/grafana/grafana/pkg/services/user"
@@ -12,30 +10,9 @@ import (
 
 type LoginServiceMock struct {
 	login.Service
-	ExpectedUserForm    dtos.AdminCreateUserForm
-	NoExistingOrgId     int64
-	AlreadyExitingLogin string
-	GeneratedUserId     int64
-	ExpectedUser        *user.User
-	ExpectedUserFunc    func(cmd *models.UpsertUserCommand) *user.User
-	ExpectedError       error
-}
-
-func (s LoginServiceMock) CreateUser(cmd user.CreateUserCommand) (*user.User, error) {
-	if cmd.OrgID == s.NoExistingOrgId {
-		return nil, models.ErrOrgNotFound
-	}
-
-	if cmd.Login == s.AlreadyExitingLogin {
-		return nil, user.ErrUserAlreadyExists
-	}
-
-	if s.ExpectedUserForm.Login == cmd.Login && s.ExpectedUserForm.Email == cmd.Email &&
-		s.ExpectedUserForm.Password == cmd.Password && s.ExpectedUserForm.Name == cmd.Name && s.ExpectedUserForm.OrgId == cmd.OrgID {
-		return &user.User{ID: s.GeneratedUserId}, nil
-	}
-
-	return nil, errors.New("unexpected cmd")
+	ExpectedUser     *user.User
+	ExpectedUserFunc func(cmd *models.UpsertUserCommand) *user.User
+	ExpectedError    error
 }
 
 func (s LoginServiceMock) UpsertUser(ctx context.Context, cmd *models.UpsertUserCommand) error {

--- a/pkg/services/login/logintest/logintest.go
+++ b/pkg/services/login/logintest/logintest.go
@@ -10,9 +10,6 @@ import (
 
 type LoginServiceFake struct{}
 
-func (l *LoginServiceFake) CreateUser(cmd user.CreateUserCommand) (*user.User, error) {
-	return nil, nil
-}
 func (l *LoginServiceFake) UpsertUser(ctx context.Context, cmd *models.UpsertUserCommand) error {
 	return nil
 }


### PR DESCRIPTION
**What is this feature?**
LoginService.CreateUser just called UserService.Create so there is no point of wrapping it and expose the function.

Remove CreateUser from LoginService and call UserService.Create in api handlers instead

**Which issue(s) does this PR fix?**:


Fixes #

**Special notes for your reviewer**:

