### PR TITLE
Docs: Rename Message templates to Notification templates

### DIFF
--- a/docs/sources/alerting/fundamentals/alert-rules/message-templating.md
+++ b/docs/sources/alerting/fundamentals/alert-rules/message-templating.md
@@ -3,20 +3,20 @@ aliases:
   - ../../contact-points/message-templating/
   - ../../message-templating/
   - ../../unified-alerting/message-templating/
-description: Message templating
+description: Notification templating
 keywords:
   - grafana
   - alerting
   - guide
   - contact point
   - templating
-title: Message templating
+title: Notification templating
 weight: 415
 ---
 
-# Message templating
+# Notification templating
 
-Notifications sent via contact points are built using messaging templates. Grafana's default templates are based on the [Go templating system](https://golang.org/pkg/text/template) where some fields are evaluated as text, while others are evaluated as HTML (which can affect escaping). The default template, defined in [default_template.go](https://github.com/grafana/alerting/blob/main/alerting/notifier/channels/default_template.go), is a useful reference for custom templates.
+Notifications sent via contact points are built using notification templates. Grafana's default templates are based on the [Go templating system](https://golang.org/pkg/text/template) where some fields are evaluated as text, while others are evaluated as HTML (which can affect escaping). The default template, defined in [default_template.go](https://github.com/grafana/alerting/blob/main/alerting/notifier/channels/default_template.go), is a useful reference for custom templates.
 
 Since most of the contact point fields can be templated, you can create reusable custom templates and use them in multiple contact points. The default template is defined in [default_template.go](https://github.com/grafana/alerting/blob/main/alerting/notifier/channels/default_template.go) which can serve as a useful reference or starting point for custom templates.
 
@@ -57,8 +57,8 @@ You can use any of the following built-in template options to embed custom templ
 | `default.message`       | Provides a formatted summary of firing and resolved alerts.   |
 | `teams.default.message` | Similar to `default.messsage`, formatted for Microsoft Teams. |
 
-### HTML in message templates
+### HTML in notification templates
 
-HTML in alerting message templates is escaped. We do not support rendering of HTML in the resulting notification.
+HTML in alerting notification templates is escaped. We do not support rendering of HTML in the resulting notification.
 
 Some notifiers support alternative methods of changing the look and feel of the resulting notification. For example, Grafana installs the base template for alerting emails to `<grafana-install-dir>/public/emails/ng_alert_notification.html`. You can edit this file to change the appearance of all alerting emails.

--- a/docs/sources/alerting/fundamentals/contact-points/index.md
+++ b/docs/sources/alerting/fundamentals/contact-points/index.md
@@ -1,0 +1,55 @@
+---
+aliases:
+  - /docs/grafana/latest/alerting/contact-points/
+  - /docs/grafana/latest/alerting/unified-alerting/contact-points/
+  - /docs/grafana/latest/alerting/fundamentals/contact-points/contact-point-types/
+description: Create or edit contact point
+keywords:
+  - grafana
+  - alerting
+  - guide
+  - contact point
+  - notification channel
+  - create
+title: Contact points
+weight: 410
+---
+
+# Contact points
+
+Use contact points to define how your contacts are notified when an alert rule fires. A contact point can have one or more contact point types, for example, email, slack, webhook, and so on. When an alert rule fires, a notification is sent to all contact point types listed for a contact point. Contact points can be configured for the Grafana Alertmanager as well as external alertmanagers.
+
+You can also use notification templating to customize notification messages for contact point types.
+
+## Supported contact point types
+
+The following table lists the contact point types supported by Grafana.
+
+| Name                                             | Type                      | Grafana Alertmanager | Other Alertmanagers                                                                                      |
+| ------------------------------------------------ | ------------------------- | -------------------- | -------------------------------------------------------------------------------------------------------- |
+| [DingDing](https://www.dingtalk.com/en)          | `dingding`                | Supported            | N/A                                                                                                      |
+| [Discord](https://discord.com/)                  | `discord`                 | Supported            | N/A                                                                                                      |
+| [Email](#email)                                  | `email`                   | Supported            | Supported                                                                                                |
+| [Google Hangouts](https://hangouts.google.com/)  | `googlechat`              | Supported            | N/A                                                                                                      |
+| [Kafka](https://kafka.apache.org/)               | `kafka`                   | Supported            | N/A                                                                                                      |
+| [Line](https://line.me/en/)                      | `line`                    | Supported            | N/A                                                                                                      |
+| [Microsoft Teams](https://teams.microsoft.com/)  | `teams`                   | Supported            | N/A                                                                                                      |
+| [Opsgenie](https://atlassian.com/opsgenie/)      | `opsgenie`                | Supported            | Supported                                                                                                |
+| [Pagerduty](https://www.pagerduty.com/)          | `pagerduty`               | Supported            | Supported                                                                                                |
+| [Prometheus Alertmanager](https://prometheus.io) | `prometheus-alertmanager` | Supported            | N/A                                                                                                      |
+| [Pushover](https://pushover.net/)                | `pushover`                | Supported            | Supported                                                                                                |
+| [Sensu Go](https://docs.sensu.io/sensu-go/)      | `sensugo`                 | Supported            | N/A                                                                                                      |
+| [Slack](https://slack.com/)                      | `slack`                   | Supported            | Supported                                                                                                |
+| [Telegram](https://telegram.org/)                | `telegram`                | Supported            | N/A                                                                                                      |
+| [Threema](https://threema.ch/)                   | `threema`                 | Supported            | N/A                                                                                                      |
+| [VictorOps](https://help.victorops.com/)         | `victorops`               | Supported            | Supported                                                                                                |
+| [Webhook](#webhook)                              | `webhook`                 | Supported            | Supported ([different format](https://prometheus.io/docs/alerting/latest/configuration/#webhook_config)) |
+| [Cisco Webex Teams](#webex)                      | `webex`                   | Supported            | Supported                                                                                                |
+| [WeCom](#wecom)                                  | `wecom`                   | Supported            | N/A                                                                                                      |
+| [Zenduty](https://www.zenduty.com/)              | `webhook`                 | Supported            | N/A                                                                                                      |
+
+## Useful links
+
+[Manage contact points](https://grafana.com/docs/grafana/next/alerting/manage-notifications/create-contact-point/)
+
+[Create and edit notification templates](https://grafana.com/docs/grafana/next/alerting/manage-notifications/create-message-template/)

--- a/docs/sources/alerting/manage-notifications/_index.md
+++ b/docs/sources/alerting/manage-notifications/_index.md
@@ -12,7 +12,7 @@ weight: 160
 
 Choosing how, when, and where to send your alert notifications is an important part of setting up your alerting system. These decisions will have a direct impact on your ability to resolve issues quickly and not miss anything important.
 
-As a first step, define your contact points; where to send your alert notifications to. A contact point can be a set of destinations for matching notifications. Add message templates to contact points for reuse and consistent messaging in your notifications.
+As a first step, define your contact points; where to send your alert notifications to. A contact point can be a set of destinations for matching notifications. Add notification templates to contact points for reuse and consistent messaging in your notifications.
 
 Next, create a notification policy which is a set of rules for where, when and how your alerts are routed to contact points. In a notification policy, you define where to send your alert notifications by choosing one of the contact points you created.Add mute timings to your notification policy. A mute timing is a recurring interval of time during which you don’t want any notifications to be sent out.
 

--- a/docs/sources/alerting/manage-notifications/create-message-template.md
+++ b/docs/sources/alerting/manage-notifications/create-message-template.md
@@ -1,0 +1,175 @@
+---
+aliases:
+  - /docs/grafana/latest/alerting/contact-points/message-templating/
+  - /docs/grafana/latest/alerting/contact-points/message-templating/create-message-template/
+  - /docs/grafana/latest/alerting/message-templating/
+  - /docs/grafana/latest/alerting/unified-alerting/message-templating/
+  - /docs/grafana/latest/alerting/contact-points/message-templating/delete-message-template/
+  - /docs/grafana/latest/alerting/contact-points/message-templating/edit-message-template/
+  - /docs/grafana/latest/alerting/manage-notifications/create-message-template/
+  - /docs/grafana/latest/alerting/contact-points/message-templating/
+  - /docs/grafana/latest/alerting/contact-points/message-templating/example-template/
+  - /docs/grafana/latest/alerting/message-templating/
+  - /docs/grafana/latest/alerting/unified-alerting/message-templating/
+  - /docs/grafana/latest/alerting/fundamentals/contact-points/example-template/
+  - /docs/grafana/latest/alerting/contact-points/message-templating/template-data/
+  - /docs/grafana/latest/alerting/message-templating/template-data/
+  - /docs/grafana/latest/alerting/unified-alerting/message-templating/template-data/
+  - /docs/grafana/latest/alerting/fundamentals/contact-points/template-data/
+keywords:
+  - grafana
+  - alerting
+  - guide
+  - contact point
+  - templating
+title: Create and edit notification templates
+weight: 200
+---
+
+# Create and edit notification templates
+
+You can use notification templates to customize notification messages for the contact point types.
+
+## Create a notification template:
+
+To create a notification template, complete the following steps.
+
+1. In the Grafana menu, click the **Alerting** (bell) icon to open the Alerting page listing existing alerts.
+2. In the Alerting page, click **Contact points** to open the page listing existing contact points.
+3. From Alertmanager drop-down, select an external Alertmanager to create and manage templates for the external data source. Otherwise, keep the default option of Grafana.
+   {{< figure max-width="250px" src="/static/img/docs/alerting/unified/contact-points-select-am-8-0.gif" caption="Select Alertmanager" >}}
+4. Click **Add template**.
+5. In **Name**, add a descriptive name.
+6. In **Content**, add the content of the template.
+7. Click **Save template** button at the bottom of the page.
+   <img  src="/static/img/docs/alerting/unified/templates-create-8-0.png" width="600px">
+
+The `define` tag in the Content section assigns the template name. This tag is optional, and when omitted, the template name is derived from the **Name** field. When both are specified, it is a best practice to ensure that they are the same.
+
+## Edit a notification template:
+
+To edit a notification template, complete the following steps.
+
+1. In the Alerting page, click **Contact points** to open the page listing existing contact points.
+1. In the Template table, find the template you want to edit, then click the **Edit** (pen icon).
+1. Make your changes, then click **Save template**.
+
+## Delete a notification template:
+
+To delete a notification template, complete the following steps.
+
+1. In the Alerting page, click **Contact points** to open the page listing existing contact points.
+1. In the Template table, find the template you want to delete, then click the **Delete** (trash icon).
+1. In the confirmation dialog, click **Yes, delete** to delete the template.
+
+Use caution when deleting a template since Grafana does not prevent you from deleting templates that are in use.
+
+## Create a custom template
+
+Here's an example of how to use a custom template. You can also use the default template included in the setup.
+
+Step 1: Configure a template to render a single alert.
+
+```
+{{ define "myalert" }}
+  [{{.Status}}] {{ .Labels.alertname }}
+
+  Labels:
+  {{ range .Labels.SortedPairs }}
+    {{ .Name }}: {{ .Value }}
+  {{ end }}
+
+  {{ if gt (len .Annotations) 0 }}
+  Annotations:
+  {{ range .Annotations.SortedPairs }}
+    {{ .Name }}: {{ .Value }}
+  {{ end }}
+  {{ end }}
+
+  {{ if gt (len .SilenceURL ) 0 }}
+    Silence alert: {{ .SilenceURL }}
+  {{ end }}
+  {{ if gt (len .DashboardURL ) 0 }}
+    Go to dashboard: {{ .DashboardURL }}
+  {{ end }}
+{{ end }}
+```
+
+Step 2: Configure a template to render entire notification message.
+
+```
+{{ define "mymessage" }}
+  {{ if gt (len .Alerts.Firing) 0 }}
+    {{ len .Alerts.Firing }} firing:
+    {{ range .Alerts.Firing }} {{ template "myalert" .}} {{ end }}
+  {{ end }}
+  {{ if gt (len .Alerts.Resolved) 0 }}
+    {{ len .Alerts.Resolved }} resolved:
+    {{ range .Alerts.Resolved }} {{ template "myalert" .}} {{ end }}
+  {{ end }}
+{{ end }}
+```
+
+Step 3: Add `mymessage` in the notification message field.
+
+```
+Alert summary:
+{{ template "mymessage" . }}
+```
+
+## Template data
+
+Template data is passed on to notification templates as well as sent as payload to webhook pushes.
+
+| Name              | Type     | Notes                                                                                                                |
+| ----------------- | -------- | -------------------------------------------------------------------------------------------------------------------- |
+| Receiver          | string   | Name of the contact point that the notification is being sent to.                                                    |
+| Status            | string   | `firing` if at least one alert is firing, otherwise `resolved`.                                                      |
+| Alerts            | Alert    | List of alert objects that are included in this notification (see below).                                            |
+| GroupLabels       | KeyValue | Labels these alerts were grouped by.                                                                                 |
+| CommonLabels      | KeyValue | Labels common to all the alerts included in this notification.                                                       |
+| CommonAnnotations | KeyValue | Annotations common to all the alerts included in this notification.                                                  |
+| ExternalURL       | string   | Back link to the Grafana that sent the notification. If using external Alertmanager, back link to this Alertmanager. |
+
+The `Alerts` type exposes functions for filtering alerts:
+
+- `Alerts.Firing` returns a list of firing alerts.
+- `Alerts.Resolved` returns a list of resolved alerts.
+
+## Alert
+
+| Name         | Type      | Notes                                                                                                                                          |
+| ------------ | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| Status       | string    | `firing` or `resolved`.                                                                                                                        |
+| Labels       | KeyValue  | A set of labels attached to the alert.                                                                                                         |
+| Annotations  | KeyValue  | A set of annotations attached to the alert.                                                                                                    |
+| StartsAt     | time.Time | Time the alert started firing.                                                                                                                 |
+| EndsAt       | time.Time | Only set if the end time of an alert is known. Otherwise set to a configurable timeout period from the time since the last alert was received. |
+| GeneratorURL | string    | A back link to Grafana or external Alertmanager.                                                                                               |
+| SilenceURL   | string    | Link to grafana silence for with labels for this alert pre-filled. Only for Grafana managed alerts.                                            |
+| DashboardURL | string    | Link to grafana dashboard, if alert rule belongs to one. Only for Grafana managed alerts.                                                      |
+| PanelURL     | string    | Link to grafana dashboard panel, if alert rule belongs to one. Only for Grafana managed alerts.                                                |
+| Fingerprint  | string    | Fingerprint that can be used to identify the alert.                                                                                            |
+| ValueString  | string    | A string that contains the labels and value of each reduced expression in the alert.                                                           |
+
+## KeyValue
+
+`KeyValue` is a set of key/value string pairs that represent labels and annotations.
+
+Here is an example containing two annotations:
+
+```json
+{
+  "summary": "alert summary",
+  "description": "alert description"
+}
+```
+
+In addition to direct access of data (labels and annotations) stored as KeyValue, there are also methods for sorting, removing and transforming.
+
+| Name        | Arguments | Returns                                 | Notes                                                       |
+| ----------- | --------- | --------------------------------------- | ----------------------------------------------------------- |
+| SortedPairs |           | Sorted list of key & value string pairs |
+| Remove      | []string  | KeyValue                                | Returns a copy of the Key/Value map without the given keys. |
+| Names       |           | []string                                | List of label names                                         |
+| Values      |           | []string                                | List of label values                                        |

--- a/docs/sources/alerting/manage-notifications/template-notifications/_index.md
+++ b/docs/sources/alerting/manage-notifications/template-notifications/_index.md
@@ -11,18 +11,18 @@ weight: 400
 
 # Customize notifications
 
-Customize your notifications with creating message templates.
+Customize your notifications with notifications templates.
 
-You can use message templates to change the title, message, and format of the message in your notifications.
+You can use notification templates to change the title, message, and format of the message in your notifications.
 
-Message templates are not tied to specific contact point integrations, such as email or Slack. However, you can choose to create separate message templates for different contact point integrations.
+Notification templates are not tied to specific contact point integrations, such as email or Slack. However, you can choose to create separate notification templates for different contact point integrations.
 
-You can use message templates to:
+You can use notification templates to:
 
 - Add, remove, or re-order information in the notification including the summary, description, labels and annotations, values, and links
 - Format text in bold and italic, and add or remove line breaks
 
-You cannot use message templates to:
+You cannot use notification templates to:
 
 - Change how images are included in notifications, such as the number of images in each notification or where in the notification inline images are shown
 - Change the design of notifications in instant messaging services such as Slack and Microsoft Teams
@@ -31,15 +31,15 @@ You cannot use message templates to:
 
 [Using Go's templating language]({{< relref "./using-go-templating-language" >}})
 
-Learn how to write the content of your message templates in Go’s templating language.
+Learn how to write the content of your notification templates in Go’s templating language.
 
-[Create message templates]({{< relref "./create-message-templates" >}})
+[Create notification templates]({{< relref "./create-notification-templates" >}})
 
-Create reusable message templates for your contact points.
+Create reusable notification templates for your contact points.
 
-[Use message templates]({{< relref "./use-message-templates" >}})
+[Use notification templates]({{< relref "./use-notification-templates" >}})
 
-Use message templates to send notifications to your contact points.
+Use notification templates to send notifications to your contact points.
 
 [Reference]({{< relref "./reference" >}})
 

--- a/docs/sources/alerting/manage-notifications/template-notifications/create-notification-templates.md
+++ b/docs/sources/alerting/manage-notifications/template-notifications/create-notification-templates.md
@@ -8,45 +8,45 @@ keywords:
   - create templates
   - edit templates
   - delete templates
-title: Create message templates
+title: Create notification templates
 weight: 200
 ---
 
-# Create message templates
+# Create notification templates
 
-Create reusable message templates to send to your contact points.
+Create reusable notification templates to send to your contact points.
 
-You can add one or more templates to your message template.
+You can add one or more templates to your notification template.
 
-Your message template name must be unique. You cannot have two templates with the same name in the same message template or in different message templates. Avoid defining templates with the same name as default templates, such as: `__subject`, `__text_values_list`, `__text_alert_list`, `default.title` and `default.message`.
+Your notification template name must be unique. You cannot have two templates with the same name in the same notification template or in different notification templates. Avoid defining templates with the same name as default templates, such as: `__subject`, `__text_values_list`, `__text_alert_list`, `default.title` and `default.message`.
 
-In the Contact points tab, you can see a list of your message templates.
+In the Contact points tab, you can see a list of your notification templates.
 
 To create a template, complete the following steps.
 
 1. Click New template.
 
-2. Choose a name for the message template.
+2. Choose a name for the notification template.
 
 3. Write the content of the template in the content field.
 
-{{< figure max-width="940px" src="/static/img/docs/alerting/unified/new-message-template-email-subject-9-3.png" caption="New message template email.subject" >}}
+{{< figure max-width="940px" src="/static/img/docs/alerting/unified/new-message-template-email-subject-9-3.png" caption="New notification template email.subject" >}}
 
 5. Click Save.
 
 `{{ define "email.subject" }}` and `{{ end }}` is automatically added to the start and end of the content:
 
-{{< figure max-width="940px" src="/static/img/docs/alerting/unified/edit-message-template-email-subject-9-3.png" caption="Edit message template email.subject" >}}
+{{< figure max-width="940px" src="/static/img/docs/alerting/unified/edit-message-template-email-subject-9-3.png" caption="Edit notification template email.subject" >}}
 
-To create a message template that contains more than one template:
+To create a notification template that contains more than one template:
 
 1. Click New Template.
 
-2. Enter a name for the message template.
+2. Enter a name for the notification template.
 
 3. Write each template in the Content field, including `{{ define "name-of-template" }}` and `{{ end }}` at the start and end of each template.
 
-{{< figure max-width="940px" src="/static/img/docs/alerting/unified/new-message-template-email-9-3.png" caption="New message template" >}}
+{{< figure max-width="940px" src="/static/img/docs/alerting/unified/new-message-template-email-9-3.png" caption="New notification template" >}}
 
 5. Click Save.
 
@@ -89,7 +89,7 @@ Resolved alerts:
 - alertname=Test 3 grafana_folder=GrafanaCloud has value(s) B=0
 ```
 
-1. Create a message template called `email` with two templates in the content: `email.message_alert` and `email.message`.
+1. Create a notification template called `email` with two templates in the content: `email.message_alert` and `email.message`.
 
    The `email.message_alert` template is used to print the labels and values for each firing and resolved alert while the `email.message` template contains the structure of the email.
 
@@ -224,7 +224,7 @@ Annotations:
 
 ## Template both email and Slack with shared templates
 
-Instead of creating separate message templates for email and Slack, you can share the same template.
+Instead of creating separate notification templates for email and Slack, you can share the same template.
 
 For example, if you want to send an email with this subject and Slack message with this title:
 

--- a/docs/sources/alerting/manage-notifications/template-notifications/create-notification-templates.md
+++ b/docs/sources/alerting/manage-notifications/template-notifications/create-notification-templates.md
@@ -30,13 +30,13 @@ To create a template, complete the following steps.
 
 3. Write the content of the template in the content field.
 
-{{< figure max-width="940px" src="/static/img/docs/alerting/unified/new-message-template-email-subject-9-3.png" caption="New notification template email.subject" >}}
+{{< figure max-width="940px" src="/static/img/docs/alerting/unified/new-notification-template-email-subject-9-4.png" caption="New notification template email.subject" >}}
 
 5. Click Save.
 
 `{{ define "email.subject" }}` and `{{ end }}` is automatically added to the start and end of the content:
 
-{{< figure max-width="940px" src="/static/img/docs/alerting/unified/edit-message-template-email-subject-9-3.png" caption="Edit notification template email.subject" >}}
+{{< figure max-width="940px" src="/static/img/docs/alerting/unified/edit-notification-template-email-subject-9-4.png" caption="Edit notification template email.subject" >}}
 
 To create a notification template that contains more than one template:
 
@@ -46,7 +46,7 @@ To create a notification template that contains more than one template:
 
 3. Write each template in the Content field, including `{{ define "name-of-template" }}` and `{{ end }}` at the start and end of each template.
 
-{{< figure max-width="940px" src="/static/img/docs/alerting/unified/new-message-template-email-9-3.png" caption="New notification template" >}}
+{{< figure max-width="940px" src="/static/img/docs/alerting/unified/new-notification-template-email-9-4.png" caption="New notification template" >}}
 
 5. Click Save.
 

--- a/docs/sources/alerting/manage-notifications/template-notifications/use-notification-templates.md
+++ b/docs/sources/alerting/manage-notifications/template-notifications/use-notification-templates.md
@@ -6,11 +6,11 @@ keywords:
   - notifications
   - templates
   - use templates
-title: Use message templates
+title: Use notification templates
 weight: 300
 ---
 
-# Use message templates
+# Use notification templates
 
 Use templates in contact points to customize your notifications.
 
@@ -22,8 +22,8 @@ In the Contact points tab, you can see a list of your contact points.
 
 2. Execute a template from one or more fields such as Message and Subject:
 
-{{< figure max-width="940px" src="/static/img/docs/alerting/unified/use-message-template-9-3.png" caption="Use message template" >}}
+{{< figure max-width="940px" src="/static/img/docs/alerting/unified/use-message-template-9-3.png" caption="Use notification template" >}}
 
-For more information on how to write and execute templates, refer to [Using Go's templating language]({{< relref "./using-go-templating-language" >}}) and [Create message templates]({{< relref "./create-message-templates" >}}).
+For more information on how to write and execute templates, refer to [Using Go's templating language]({{< relref "./using-go-templating-language" >}}) and [Create notification templates]({{< relref "./create-notification-templates" >}}).
 
 4. Click Save template.

--- a/docs/sources/alerting/manage-notifications/template-notifications/use-notification-templates.md
+++ b/docs/sources/alerting/manage-notifications/template-notifications/use-notification-templates.md
@@ -22,7 +22,7 @@ In the Contact points tab, you can see a list of your contact points.
 
 2. Execute a template from one or more fields such as Message and Subject:
 
-{{< figure max-width="940px" src="/static/img/docs/alerting/unified/use-message-template-9-3.png" caption="Use notification template" >}}
+{{< figure max-width="940px" src="/static/img/docs/alerting/unified/use-notification-template-9-4.png" caption="Use notification template" >}}
 
 For more information on how to write and execute templates, refer to [Using Go's templating language]({{< relref "./using-go-templating-language" >}}) and [Create notification templates]({{< relref "./create-notification-templates" >}}).
 

--- a/docs/sources/alerting/manage-notifications/template-notifications/using-go-templating-language.md
+++ b/docs/sources/alerting/manage-notifications/template-notifications/using-go-templating-language.md
@@ -12,13 +12,13 @@ weight: 100
 
 # Using Go's templating language
 
-You write message templates in Go's templating language, [text/template](https://pkg.go.dev/text/template).
+You write notification templates in Go's templating language, [text/template](https://pkg.go.dev/text/template).
 
-Before you start creating your own message templates, we recommend that you read through this topic, which provides you with an overview of Go's templating language and writing templates in text/template.
+Before you start creating your own notification templates, we recommend that you read through this topic, which provides you with an overview of Go's templating language and writing templates in text/template.
 
 ## Dot
 
-In text/template there is a special cursor called dot, and is written as `.`. You can think of this cursor as a variable whose value changes depending where in the template it is used. For example, at the start of a message template `.` refers to something called [`ExtendedData`]({{< relref "./reference#extendeddata" >}}) which contains a number of fields including `Alerts`, `Status`, `GroupLabels`, `CommonLabels`, `CommonAnnotations` and `ExternalURL`. However, dot might refer to something else when used in a range over a list, when used inside a `with`, or when writing feature templates to be used in other templates. You can see examples of this in [Create message templates]({{< relref "./create-message-templates" >}}), and all data and functions in the [Reference]({{< relref "./reference" >}}).
+In text/template there is a special cursor called dot, and is written as `.`. You can think of this cursor as a variable whose value changes depending where in the template it is used. For example, at the start of a notification template `.` refers to something called [`ExtendedData`]({{< relref "./reference#extendeddata" >}}) which contains a number of fields including `Alerts`, `Status`, `GroupLabels`, `CommonLabels`, `CommonAnnotations` and `ExternalURL`. However, dot might refer to something else when used in a range over a list, when used inside a `with`, or when writing feature templates to be used in other templates. You can see examples of this in [Create notification templates]({{< relref "./create-notification-templates" >}}), and all data and functions in the [Reference]({{< relref "./reference" >}}).
 
 ## Opening and closing tags
 
@@ -143,7 +143,7 @@ This is alert {{ $index }} out of {{ $num_alerts }}
 
 ## Define templates
 
-You can define templates using `define` and the name of the template in double quotes. You should not define templates with the same name as other templates, including default templates such as `__subject`, `__text_values_list`, `__text_alert_list`, `default.title` and `default.message`. Where a template has been created with the same name as a default template, or a template in another message template, Grafana might use either template. Grafana does not prevent, or show an error message, when there are two or more templates with the same name.
+You can define templates using `define` and the name of the template in double quotes. You should not define templates with the same name as other templates, including default templates such as `__subject`, `__text_values_list`, `__text_alert_list`, `default.title` and `default.message`. Where a template has been created with the same name as a default template, or a template in another notification template, Grafana might use either template. Grafana does not prevent, or show an error message, when there are two or more templates with the same name.
 
 ```
 {{ define "print_labels" }}

--- a/docs/sources/alerting/set-up/provision-alerting-resources/terraform-provisioning/index.md
+++ b/docs/sources/alerting/set-up/provision-alerting-resources/terraform-provisioning/index.md
@@ -98,7 +98,7 @@ EOT
 
 2. Enter text for your notification in the text field.
 
-The `text` field supports [Go-style templating](https://pkg.go.dev/text/template). This enables you to manage your Grafana Alerting message templates directly in Terraform.
+The `text` field supports [Go-style templating](https://pkg.go.dev/text/template). This enables you to manage your Grafana Alerting notification templates directly in Terraform.
 
 3. Run the command ‘terraform apply’.
 

--- a/docs/sources/developers/http_api/alerting_provisioning.md
+++ b/docs/sources/developers/http_api/alerting_provisioning.md
@@ -70,12 +70,12 @@ title: 'Alerting Provisioning HTTP API '
 
 ### Templates
 
-| Method | URI                                   | Name                                            | Summary                        |
-| ------ | ------------------------------------- | ----------------------------------------------- | ------------------------------ |
-| GET    | /api/v1/provisioning/templates        | [route get templates](#route-get-templates)     | Get all message templates.     |
-| GET    | /api/v1/provisioning/templates/{name} | [route get template](#route-get-template)       | Get a message template.        |
-| PUT    | /api/v1/provisioning/templates/{name} | [route put template](#route-put-template)       | Creates or updates a template. |
-| DELETE | /api/v1/provisioning/templates/{name} | [route delete template](#route-delete-template) | Delete a template.             |
+| Method | URI                                   | Name                                            | Summary                         |
+| ------ | ------------------------------------- | ----------------------------------------------- | ------------------------------- |
+| GET    | /api/v1/provisioning/templates        | [route get templates](#route-get-templates)     | Get all notification templates. |
+| GET    | /api/v1/provisioning/templates/{name} | [route get template](#route-get-template)       | Get a notification template.    |
+| PUT    | /api/v1/provisioning/templates/{name} | [route put template](#route-put-template)       | Creates or updates a template.  |
+| DELETE | /api/v1/provisioning/templates/{name} | [route delete template](#route-delete-template) | Delete a template.              |
 
 ## Paths
 
@@ -378,7 +378,7 @@ Status: Bad Request
 
 [ValidationError](#validation-error)
 
-### <span id="route-get-template"></span> Get a message template. (_RouteGetTemplate_)
+### <span id="route-get-template"></span> Get a notification template. (_RouteGetTemplate_)
 
 ```
 GET /api/v1/provisioning/templates/{name}
@@ -392,20 +392,20 @@ GET /api/v1/provisioning/templates/{name}
 
 #### All responses
 
-| Code                           | Status    | Description     | Has headers | Schema                                   |
-| ------------------------------ | --------- | --------------- | :---------: | ---------------------------------------- |
-| [200](#route-get-template-200) | OK        | MessageTemplate |             | [schema](#route-get-template-200-schema) |
-| [404](#route-get-template-404) | Not Found | NotFound        |             | [schema](#route-get-template-404-schema) |
+| Code                           | Status    | Description          | Has headers | Schema                                   |
+| ------------------------------ | --------- | -------------------- | :---------: | ---------------------------------------- |
+| [200](#route-get-template-200) | OK        | NotificationTemplate |             | [schema](#route-get-template-200-schema) |
+| [404](#route-get-template-404) | Not Found | NotFound             |             | [schema](#route-get-template-404-schema) |
 
 #### Responses
 
-##### <span id="route-get-template-200"></span> 200 - MessageTemplate
+##### <span id="route-get-template-200"></span> 200 - NotificationTemplate
 
 Status: OK
 
 ###### <span id="route-get-template-200-schema"></span> Schema
 
-[MessageTemplate](#message-template)
+[NotificationTemplate](#message-template)
 
 ##### <span id="route-get-template-404"></span> 404 - NotFound
 
@@ -415,7 +415,7 @@ Status: Not Found
 
 [NotFound](#not-found)
 
-### <span id="route-get-templates"></span> Get all message templates. (_RouteGetTemplates_)
+### <span id="route-get-templates"></span> Get all notification templates. (_RouteGetTemplates_)
 
 ```
 GET /api/v1/provisioning/templates
@@ -423,20 +423,20 @@ GET /api/v1/provisioning/templates
 
 #### All responses
 
-| Code                            | Status      | Description     | Has headers | Schema                                    |
-| ------------------------------- | ----------- | --------------- | :---------: | ----------------------------------------- |
-| [200](#route-get-templates-200) | OK          | MessageTemplate |             | [schema](#route-get-templates-200-schema) |
-| [400](#route-get-templates-400) | Bad Request | ValidationError |             | [schema](#route-get-templates-400-schema) |
+| Code                            | Status      | Description          | Has headers | Schema                                    |
+| ------------------------------- | ----------- | -------------------- | :---------: | ----------------------------------------- |
+| [200](#route-get-templates-200) | OK          | NotificationTemplate |             | [schema](#route-get-templates-200-schema) |
+| [400](#route-get-templates-400) | Bad Request | ValidationError      |             | [schema](#route-get-templates-400-schema) |
 
 #### Responses
 
-##### <span id="route-get-templates-200"></span> 200 - MessageTemplate
+##### <span id="route-get-templates-200"></span> 200 - NotificationTemplate
 
 Status: OK
 
 ###### <span id="route-get-templates-200-schema"></span> Schema
 
-[MessageTemplate](#message-template)
+[NotificationTemplate](#message-template)
 
 ##### <span id="route-get-templates-400"></span> 400 - ValidationError
 
@@ -787,10 +787,10 @@ PUT /api/v1/provisioning/templates/{name}
 
 #### Parameters
 
-| Name | Source | Type                                                | Go type                         | Separator | Required | Default | Description   |
-| ---- | ------ | --------------------------------------------------- | ------------------------------- | --------- | :------: | ------- | ------------- |
-| name | `path` | string                                              | `string`                        |           |    ✓     |         | Template Name |
-| Body | `body` | [MessageTemplateContent](#message-template-content) | `models.MessageTemplateContent` |           |          |         |               |
+| Name | Source | Type                                                     | Go type                              | Separator | Required | Default | Description   |
+| ---- | ------ | -------------------------------------------------------- | ------------------------------------ | --------- | :------: | ------- | ------------- |
+| name | `path` | string                                                   | `string`                             |           |    ✓     |         | Template Name |
+| Body | `body` | [NotificationTemplateContent](#message-template-content) | `models.NotificationTemplateContent` |           |          |         |               |
 
 #### All responses
 
@@ -915,7 +915,7 @@ Status: Bad Request
 
 [][matcher](#matcher)
 
-### <span id="message-template"></span> MessageTemplate
+### <span id="message-template"></span> NotificationTemplate
 
 **Properties**
 
@@ -925,7 +925,7 @@ Status: Bad Request
 | Template   | string | `string`     |          |         |             |         |
 | provenance | string | `Provenance` |          |         |             |         |
 
-### <span id="message-template-content"></span> MessageTemplateContent
+### <span id="message-template-content"></span> NotificationTemplateContent
 
 **Properties**
 

--- a/pkg/services/ngalert/api/api_alertmanager_test.go
+++ b/pkg/services/ngalert/api/api_alertmanager_test.go
@@ -650,7 +650,7 @@ func setContactPointProvenance(t *testing.T, orgID int64, UID string, ps provisi
 // setTemplateProvenance marks a template as provisioned.
 func setTemplateProvenance(t *testing.T, orgID int64, name string, ps provisioning.ProvisioningStore) {
 	t.Helper()
-	err := ps.SetProvenance(context.Background(), &apimodels.MessageTemplate{Name: name}, orgID, ngmodels.ProvenanceAPI)
+	err := ps.SetProvenance(context.Background(), &apimodels.NotificationTemplate{Name: name}, orgID, ngmodels.ProvenanceAPI)
 	require.NoError(t, err)
 }
 

--- a/pkg/services/ngalert/api/api_provisioning.go
+++ b/pkg/services/ngalert/api/api_provisioning.go
@@ -35,7 +35,7 @@ type ContactPointService interface {
 
 type TemplateService interface {
 	GetTemplates(ctx context.Context, orgID int64) (map[string]string, error)
-	SetTemplate(ctx context.Context, orgID int64, tmpl definitions.MessageTemplate) (definitions.MessageTemplate, error)
+	SetTemplate(ctx context.Context, orgID int64, tmpl definitions.NotificationTemplate) (definitions.NotificationTemplate, error)
 	DeleteTemplate(ctx context.Context, orgID int64, name string) error
 }
 
@@ -149,9 +149,9 @@ func (srv *ProvisioningSrv) RouteGetTemplates(c *models.ReqContext) response.Res
 	if err != nil {
 		return ErrResp(http.StatusInternalServerError, err, "")
 	}
-	result := make([]definitions.MessageTemplate, 0, len(templates))
+	result := make([]definitions.NotificationTemplate, 0, len(templates))
 	for k, v := range templates {
-		result = append(result, definitions.MessageTemplate{Name: k, Template: v})
+		result = append(result, definitions.NotificationTemplate{Name: k, Template: v})
 	}
 	return response.JSON(http.StatusOK, result)
 }
@@ -162,13 +162,13 @@ func (srv *ProvisioningSrv) RouteGetTemplate(c *models.ReqContext, name string) 
 		return ErrResp(http.StatusInternalServerError, err, "")
 	}
 	if tmpl, ok := templates[name]; ok {
-		return response.JSON(http.StatusOK, definitions.MessageTemplate{Name: name, Template: tmpl})
+		return response.JSON(http.StatusOK, definitions.NotificationTemplate{Name: name, Template: tmpl})
 	}
 	return response.Empty(http.StatusNotFound)
 }
 
-func (srv *ProvisioningSrv) RoutePutTemplate(c *models.ReqContext, body definitions.MessageTemplateContent, name string) response.Response {
-	tmpl := definitions.MessageTemplate{
+func (srv *ProvisioningSrv) RoutePutTemplate(c *models.ReqContext, body definitions.NotificationTemplateContent, name string) response.Response {
+	tmpl := definitions.NotificationTemplate{
 		Name:       name,
 		Template:   body.Template,
 		Provenance: alerting_models.ProvenanceAPI,

--- a/pkg/services/ngalert/api/api_provisioning_test.go
+++ b/pkg/services/ngalert/api/api_provisioning_test.go
@@ -178,7 +178,7 @@ func TestProvisioningApi(t *testing.T) {
 			t.Run("PUT returns 400", func(t *testing.T) {
 				sut := createProvisioningSrvSut(t)
 				rc := createTestRequestCtx()
-				tmpl := definitions.MessageTemplateContent{Template: ""}
+				tmpl := definitions.NotificationTemplateContent{Template: ""}
 
 				response := sut.RoutePutTemplate(&rc, tmpl, "test")
 

--- a/pkg/services/ngalert/api/generated_base_api_provisioning.go
+++ b/pkg/services/ngalert/api/generated_base_api_provisioning.go
@@ -177,7 +177,7 @@ func (f *ProvisioningApiHandler) RoutePutTemplate(ctx *models.ReqContext) respon
 	// Parse Path Parameters
 	nameParam := web.Params(ctx.Req)[":name"]
 	// Parse Request Body
-	conf := apimodels.MessageTemplateContent{}
+	conf := apimodels.NotificationTemplateContent{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
 		return response.Error(http.StatusBadRequest, "bad request data", err)
 	}

--- a/pkg/services/ngalert/api/provisioning.go
+++ b/pkg/services/ngalert/api/provisioning.go
@@ -48,7 +48,7 @@ func (f *ProvisioningApiHandler) handleRouteGetTemplate(ctx *models.ReqContext, 
 	return f.svc.RouteGetTemplate(ctx, name)
 }
 
-func (f *ProvisioningApiHandler) handleRoutePutTemplate(ctx *models.ReqContext, body apimodels.MessageTemplateContent, name string) response.Response {
+func (f *ProvisioningApiHandler) handleRoutePutTemplate(ctx *models.ReqContext, body apimodels.NotificationTemplateContent, name string) response.Response {
 	return f.svc.RoutePutTemplate(ctx, body, name)
 }
 

--- a/pkg/services/ngalert/api/tooling/api.json
+++ b/pkg/services/ngalert/api/tooling/api.json
@@ -7,6 +7,26 @@
   "Ack": {
    "type": "object"
   },
+  "AddCommand": {
+   "properties": {
+    "name": {
+     "type": "string"
+    },
+    "role": {
+     "enum": [
+      "Viewer",
+      "Editor",
+      "Admin"
+     ],
+     "type": "string"
+    },
+    "secondsToLive": {
+     "format": "int64",
+     "type": "integer"
+    }
+   },
+   "type": "object"
+  },
   "Alert": {
    "properties": {
     "activeAt": {
@@ -1491,34 +1511,6 @@
    },
    "type": "array"
   },
-  "MessageTemplate": {
-   "properties": {
-    "name": {
-     "type": "string"
-    },
-    "provenance": {
-     "$ref": "#/definitions/Provenance"
-    },
-    "template": {
-     "type": "string"
-    }
-   },
-   "type": "object"
-  },
-  "MessageTemplateContent": {
-   "properties": {
-    "template": {
-     "type": "string"
-    }
-   },
-   "type": "object"
-  },
-  "MessageTemplates": {
-   "items": {
-    "$ref": "#/definitions/MessageTemplate"
-   },
-   "type": "array"
-  },
   "MultiStatus": {
    "type": "object"
   },
@@ -1579,6 +1571,34 @@
    "format": "int64",
    "title": "NoticeSeverity is a type for the Severity property of a Notice.",
    "type": "integer"
+  },
+  "NotificationTemplate": {
+   "properties": {
+    "name": {
+     "type": "string"
+    },
+    "provenance": {
+     "$ref": "#/definitions/Provenance"
+    },
+    "template": {
+     "type": "string"
+    }
+   },
+   "type": "object"
+  },
+  "NotificationTemplateContent": {
+   "properties": {
+    "template": {
+     "type": "string"
+    }
+   },
+   "type": "object"
+  },
+  "NotificationTemplates": {
+   "items": {
+    "$ref": "#/definitions/NotificationTemplate"
+   },
+   "type": "array"
   },
   "NotifierConfig": {
    "properties": {
@@ -3352,7 +3372,6 @@
    "type": "object"
   },
   "alertGroups": {
-   "description": "AlertGroups alert groups",
    "items": {
     "$ref": "#/definitions/alertGroup"
    },
@@ -3513,14 +3532,12 @@
    "type": "object"
   },
   "gettableAlerts": {
-   "description": "GettableAlerts gettable alerts",
    "items": {
     "$ref": "#/definitions/gettableAlert"
    },
    "type": "array"
   },
   "gettableSilence": {
-   "description": "GettableSilence gettable silence",
    "properties": {
     "comment": {
      "description": "comment",
@@ -3569,7 +3586,6 @@
    "type": "object"
   },
   "gettableSilences": {
-   "description": "GettableSilences gettable silences",
    "items": {
     "$ref": "#/definitions/gettableSilence"
    },
@@ -3756,6 +3772,7 @@
    "type": "object"
   },
   "receiver": {
+   "description": "Receiver receiver",
    "properties": {
     "active": {
      "description": "active",
@@ -4442,16 +4459,16 @@
     "operationId": "RouteGetTemplates",
     "responses": {
      "200": {
-      "description": "MessageTemplates",
+      "description": "NotificationTemplates",
       "schema": {
-       "$ref": "#/definitions/MessageTemplates"
+       "$ref": "#/definitions/NotificationTemplates"
       }
      },
      "404": {
       "description": " Not found."
      }
     },
-    "summary": "Get all message templates.",
+    "summary": "Get all notification templates.",
     "tags": [
      "provisioning"
     ]
@@ -4492,16 +4509,16 @@
     ],
     "responses": {
      "200": {
-      "description": "MessageTemplate",
+      "description": "NotificationTemplate",
       "schema": {
-       "$ref": "#/definitions/MessageTemplate"
+       "$ref": "#/definitions/NotificationTemplate"
       }
      },
      "404": {
       "description": " Not found."
      }
     },
-    "summary": "Get a message template.",
+    "summary": "Get a notification template.",
     "tags": [
      "provisioning"
     ]
@@ -4523,15 +4540,15 @@
       "in": "body",
       "name": "Body",
       "schema": {
-       "$ref": "#/definitions/MessageTemplateContent"
+       "$ref": "#/definitions/NotificationTemplateContent"
       }
      }
     ],
     "responses": {
      "202": {
-      "description": "MessageTemplate",
+      "description": "NotificationTemplate",
       "schema": {
-       "$ref": "#/definitions/MessageTemplate"
+       "$ref": "#/definitions/NotificationTemplate"
       }
      },
      "400": {
@@ -4541,7 +4558,7 @@
       }
      }
     },
-    "summary": "Updates an existing template.",
+    "summary": "Updates an existing notification template.",
     "tags": [
      "provisioning"
     ]

--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager_validation.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager_validation.go
@@ -57,7 +57,7 @@ func (r *Route) validateChild() error {
 	return nil
 }
 
-func (t *MessageTemplate) Validate() error {
+func (t *NotificationTemplate) Validate() error {
 	if t.Name == "" {
 		return fmt.Errorf("template must have a name")
 	}

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_templates.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_templates.go
@@ -6,29 +6,29 @@ import (
 
 // swagger:route GET /api/v1/provisioning/templates provisioning stable RouteGetTemplates
 //
-// Get all message templates.
+// Get all notification templates.
 //
 //     Responses:
-//       200: MessageTemplates
+//       200: NotificationTemplates
 //       404: description: Not found.
 
 // swagger:route GET /api/v1/provisioning/templates/{name} provisioning stable RouteGetTemplate
 //
-// Get a message template.
+// Get a notification template.
 //
 //     Responses:
-//       200: MessageTemplate
+//       200: NotificationTemplate
 //       404: description: Not found.
 
 // swagger:route PUT /api/v1/provisioning/templates/{name} provisioning stable RoutePutTemplate
 //
-// Updates an existing template.
+// Updates an existing notification template.
 //
 //     Consumes:
 //     - application/json
 //
 //     Responses:
-//       202: MessageTemplate
+//       202: NotificationTemplate
 //       400: ValidationError
 
 // swagger:route DELETE /api/v1/provisioning/templates/{name} provisioning stable RouteDeleteTemplate
@@ -46,29 +46,29 @@ type RouteGetTemplateParam struct {
 }
 
 // swagger:model
-type MessageTemplate struct {
+type NotificationTemplate struct {
 	Name       string            `json:"name"`
 	Template   string            `json:"template"`
 	Provenance models.Provenance `json:"provenance,omitempty"`
 }
 
 // swagger:model
-type MessageTemplates []MessageTemplate
+type NotificationTemplates []NotificationTemplate
 
-type MessageTemplateContent struct {
+type NotificationTemplateContent struct {
 	Template string `json:"template"`
 }
 
 // swagger:parameters RoutePutTemplate
-type MessageTemplatePayload struct {
+type NotificationTemplatePayload struct {
 	// in:body
-	Body MessageTemplateContent
+	Body NotificationTemplateContent
 }
 
-func (t *MessageTemplate) ResourceType() string {
+func (t *NotificationTemplate) ResourceType() string {
 	return "template"
 }
 
-func (t *MessageTemplate) ResourceID() string {
+func (t *NotificationTemplate) ResourceID() string {
 	return t.Name
 }

--- a/pkg/services/ngalert/api/tooling/post.json
+++ b/pkg/services/ngalert/api/tooling/post.json
@@ -1491,34 +1491,6 @@
    },
    "type": "array"
   },
-  "MessageTemplate": {
-   "properties": {
-    "name": {
-     "type": "string"
-    },
-    "provenance": {
-     "$ref": "#/definitions/Provenance"
-    },
-    "template": {
-     "type": "string"
-    }
-   },
-   "type": "object"
-  },
-  "MessageTemplateContent": {
-   "properties": {
-    "template": {
-     "type": "string"
-    }
-   },
-   "type": "object"
-  },
-  "MessageTemplates": {
-   "items": {
-    "$ref": "#/definitions/MessageTemplate"
-   },
-   "type": "array"
-  },
   "MultiStatus": {
    "type": "object"
   },
@@ -1579,6 +1551,34 @@
    "format": "int64",
    "title": "NoticeSeverity is a type for the Severity property of a Notice.",
    "type": "integer"
+  },
+  "NotificationTemplate": {
+   "properties": {
+    "name": {
+     "type": "string"
+    },
+    "provenance": {
+     "$ref": "#/definitions/Provenance"
+    },
+    "template": {
+     "type": "string"
+    }
+   },
+   "type": "object"
+  },
+  "NotificationTemplateContent": {
+   "properties": {
+    "template": {
+     "type": "string"
+    }
+   },
+   "type": "object"
+  },
+  "NotificationTemplates": {
+   "items": {
+    "$ref": "#/definitions/NotificationTemplate"
+   },
+   "type": "array"
   },
   "NotifierConfig": {
    "properties": {
@@ -3455,6 +3455,7 @@
    "type": "object"
   },
   "gettableAlert": {
+   "description": "GettableAlert gettable alert",
    "properties": {
     "annotations": {
      "$ref": "#/definitions/labelSet"
@@ -3510,7 +3511,6 @@
    "type": "object"
   },
   "gettableAlerts": {
-   "description": "GettableAlerts gettable alerts",
    "items": {
     "$ref": "#/definitions/gettableAlert"
    },
@@ -3752,7 +3752,6 @@
    "type": "object"
   },
   "receiver": {
-   "description": "Receiver receiver",
    "properties": {
     "active": {
      "description": "active",
@@ -6111,16 +6110,16 @@
     "operationId": "RouteGetTemplates",
     "responses": {
      "200": {
-      "description": "MessageTemplates",
+      "description": "NotificationTemplates",
       "schema": {
-       "$ref": "#/definitions/MessageTemplates"
+       "$ref": "#/definitions/NotificationTemplates"
       }
      },
      "404": {
       "description": " Not found."
      }
     },
-    "summary": "Get all message templates.",
+    "summary": "Get all notification templates.",
     "tags": [
      "provisioning"
     ]
@@ -6161,16 +6160,16 @@
     ],
     "responses": {
      "200": {
-      "description": "MessageTemplate",
+      "description": "NotificationTemplate",
       "schema": {
-       "$ref": "#/definitions/MessageTemplate"
+       "$ref": "#/definitions/NotificationTemplate"
       }
      },
      "404": {
       "description": " Not found."
      }
     },
-    "summary": "Get a message template.",
+    "summary": "Get a notification template.",
     "tags": [
      "provisioning"
     ]
@@ -6192,15 +6191,15 @@
       "in": "body",
       "name": "Body",
       "schema": {
-       "$ref": "#/definitions/MessageTemplateContent"
+       "$ref": "#/definitions/NotificationTemplateContent"
       }
      }
     ],
     "responses": {
      "202": {
-      "description": "MessageTemplate",
+      "description": "NotificationTemplate",
       "schema": {
-       "$ref": "#/definitions/MessageTemplate"
+       "$ref": "#/definitions/NotificationTemplate"
       }
      },
      "400": {
@@ -6210,7 +6209,7 @@
       }
      }
     },
-    "summary": "Updates an existing template.",
+    "summary": "Updates an existing notification template.",
     "tags": [
      "provisioning"
     ]

--- a/pkg/services/ngalert/api/tooling/spec.json
+++ b/pkg/services/ngalert/api/tooling/spec.json
@@ -2276,13 +2276,13 @@
           "provisioning",
           "stable"
         ],
-        "summary": "Get all message templates.",
+        "summary": "Get all notification templates.",
         "operationId": "RouteGetTemplates",
         "responses": {
           "200": {
-            "description": "MessageTemplates",
+            "description": "NotificationTemplates",
             "schema": {
-              "$ref": "#/definitions/MessageTemplates"
+              "$ref": "#/definitions/NotificationTemplates"
             }
           },
           "404": {
@@ -2297,7 +2297,7 @@
           "provisioning",
           "stable"
         ],
-        "summary": "Get a message template.",
+        "summary": "Get a notification template.",
         "operationId": "RouteGetTemplate",
         "parameters": [
           {
@@ -2310,9 +2310,9 @@
         ],
         "responses": {
           "200": {
-            "description": "MessageTemplate",
+            "description": "NotificationTemplate",
             "schema": {
-              "$ref": "#/definitions/MessageTemplate"
+              "$ref": "#/definitions/NotificationTemplate"
             }
           },
           "404": {
@@ -2328,7 +2328,7 @@
           "provisioning",
           "stable"
         ],
-        "summary": "Updates an existing template.",
+        "summary": "Updates an existing notification template.",
         "operationId": "RoutePutTemplate",
         "parameters": [
           {
@@ -2342,15 +2342,15 @@
             "name": "Body",
             "in": "body",
             "schema": {
-              "$ref": "#/definitions/MessageTemplateContent"
+              "$ref": "#/definitions/NotificationTemplateContent"
             }
           }
         ],
         "responses": {
           "202": {
-            "description": "MessageTemplate",
+            "description": "NotificationTemplate",
             "schema": {
-              "$ref": "#/definitions/MessageTemplate"
+              "$ref": "#/definitions/NotificationTemplate"
             }
           },
           "400": {
@@ -3977,34 +3977,6 @@
       },
       "$ref": "#/definitions/Matchers"
     },
-    "MessageTemplate": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "provenance": {
-          "$ref": "#/definitions/Provenance"
-        },
-        "template": {
-          "type": "string"
-        }
-      }
-    },
-    "MessageTemplateContent": {
-      "type": "object",
-      "properties": {
-        "template": {
-          "type": "string"
-        }
-      }
-    },
-    "MessageTemplates": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/MessageTemplate"
-      }
-    },
     "MultiStatus": {
       "type": "object"
     },
@@ -4065,6 +4037,34 @@
       "type": "integer",
       "format": "int64",
       "title": "NoticeSeverity is a type for the Severity property of a Notice."
+    },
+    "NotificationTemplate": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "provenance": {
+          "$ref": "#/definitions/Provenance"
+        },
+        "template": {
+          "type": "string"
+        }
+      }
+    },
+    "NotificationTemplateContent": {
+      "type": "object",
+      "properties": {
+        "template": {
+          "type": "string"
+        }
+      }
+    },
+    "NotificationTemplates": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/NotificationTemplate"
+      }
     },
     "NotifierConfig": {
       "type": "object",
@@ -5943,6 +5943,7 @@
       }
     },
     "gettableAlert": {
+      "description": "GettableAlert gettable alert",
       "type": "object",
       "required": [
         "labels",
@@ -5999,7 +6000,6 @@
       "$ref": "#/definitions/gettableAlert"
     },
     "gettableAlerts": {
-      "description": "GettableAlerts gettable alerts",
       "type": "array",
       "items": {
         "$ref": "#/definitions/gettableAlert"
@@ -6246,7 +6246,6 @@
       "$ref": "#/definitions/postableSilence"
     },
     "receiver": {
-      "description": "Receiver receiver",
       "type": "object",
       "required": [
         "active",

--- a/pkg/services/ngalert/notifier/alertmanager_config.go
+++ b/pkg/services/ngalert/notifier/alertmanager_config.go
@@ -145,7 +145,7 @@ func (moa *MultiOrgAlertmanager) mergeProvenance(ctx context.Context, config def
 		}
 	}
 
-	tmpl := definitions.MessageTemplate{}
+	tmpl := definitions.NotificationTemplate{}
 	tmplProvs, err := moa.ProvStore.GetProvenances(ctx, org, tmpl.ResourceType())
 	if err != nil {
 		return definitions.GettableUserConfig{}, nil

--- a/pkg/services/ngalert/notifier/channels_config/available_channels.go
+++ b/pkg/services/ngalert/notifier/channels_config/available_channels.go
@@ -1227,8 +1227,8 @@ func GetAvailableNotifiers() []*NotifierPlugin {
 					Required:     true,
 				},
 				{
-					Label:        "Message Template",
-					Description:  "Message template to use. Markdown is supported.",
+					Label:        "Notification Template",
+					Description:  "Notification template to use. Markdown is supported.",
 					Element:      ElementTypeInput,
 					InputType:    InputTypeText,
 					Placeholder:  `{{ template "default.message" . }}`,

--- a/pkg/services/ngalert/provisioning/templates.go
+++ b/pkg/services/ngalert/provisioning/templates.go
@@ -38,15 +38,15 @@ func (t *TemplateService) GetTemplates(ctx context.Context, orgID int64) (map[st
 	return revision.cfg.TemplateFiles, nil
 }
 
-func (t *TemplateService) SetTemplate(ctx context.Context, orgID int64, tmpl definitions.MessageTemplate) (definitions.MessageTemplate, error) {
+func (t *TemplateService) SetTemplate(ctx context.Context, orgID int64, tmpl definitions.NotificationTemplate) (definitions.NotificationTemplate, error) {
 	err := tmpl.Validate()
 	if err != nil {
-		return definitions.MessageTemplate{}, fmt.Errorf("%w: %s", ErrValidation, err.Error())
+		return definitions.NotificationTemplate{}, fmt.Errorf("%w: %s", ErrValidation, err.Error())
 	}
 
 	revision, err := getLastConfiguration(ctx, orgID, t.config)
 	if err != nil {
-		return definitions.MessageTemplate{}, err
+		return definitions.NotificationTemplate{}, err
 	}
 
 	if revision.cfg.TemplateFiles == nil {
@@ -56,7 +56,7 @@ func (t *TemplateService) SetTemplate(ctx context.Context, orgID int64, tmpl def
 
 	serialized, err := serializeAlertmanagerConfig(*revision.cfg)
 	if err != nil {
-		return definitions.MessageTemplate{}, err
+		return definitions.NotificationTemplate{}, err
 	}
 	cmd := models.SaveAlertmanagerConfigurationCmd{
 		AlertmanagerConfiguration: string(serialized),
@@ -77,7 +77,7 @@ func (t *TemplateService) SetTemplate(ctx context.Context, orgID int64, tmpl def
 		return nil
 	})
 	if err != nil {
-		return definitions.MessageTemplate{}, err
+		return definitions.NotificationTemplate{}, err
 	}
 
 	return tmpl, nil
@@ -108,7 +108,7 @@ func (t *TemplateService) DeleteTemplate(ctx context.Context, orgID int64, name 
 		if err != nil {
 			return err
 		}
-		tgt := definitions.MessageTemplate{
+		tgt := definitions.NotificationTemplate{
 			Name: name,
 		}
 		err = t.prov.DeleteProvenance(ctx, &tgt, orgID)

--- a/pkg/services/ngalert/provisioning/templates_test.go
+++ b/pkg/services/ngalert/provisioning/templates_test.go
@@ -79,7 +79,7 @@ func TestTemplateService(t *testing.T) {
 	t.Run("setting templates", func(t *testing.T) {
 		t.Run("rejects templates that fail validation", func(t *testing.T) {
 			sut := createTemplateServiceSut()
-			tmpl := definitions.MessageTemplate{
+			tmpl := definitions.NotificationTemplate{
 				Name:     "",
 				Template: "",
 			}
@@ -92,7 +92,7 @@ func TestTemplateService(t *testing.T) {
 		t.Run("propagates errors", func(t *testing.T) {
 			t.Run("when unable to read config", func(t *testing.T) {
 				sut := createTemplateServiceSut()
-				tmpl := createMessageTemplate()
+				tmpl := createNotificationTemplate()
 				sut.config.(*MockAMConfigStore).EXPECT().
 					GetLatestAlertmanagerConfiguration(mock.Anything, mock.Anything).
 					Return(fmt.Errorf("failed"))
@@ -104,7 +104,7 @@ func TestTemplateService(t *testing.T) {
 
 			t.Run("when config is invalid", func(t *testing.T) {
 				sut := createTemplateServiceSut()
-				tmpl := createMessageTemplate()
+				tmpl := createNotificationTemplate()
 				sut.config.(*MockAMConfigStore).EXPECT().
 					GetsConfig(models.AlertConfiguration{
 						AlertmanagerConfiguration: brokenConfig,
@@ -117,7 +117,7 @@ func TestTemplateService(t *testing.T) {
 
 			t.Run("when no AM config in current org", func(t *testing.T) {
 				sut := createTemplateServiceSut()
-				tmpl := createMessageTemplate()
+				tmpl := createNotificationTemplate()
 				sut.config.(*MockAMConfigStore).EXPECT().
 					GetLatestAlertmanagerConfiguration(mock.Anything, mock.Anything).
 					Return(nil)
@@ -129,7 +129,7 @@ func TestTemplateService(t *testing.T) {
 
 			t.Run("when provenance fails to save", func(t *testing.T) {
 				sut := createTemplateServiceSut()
-				tmpl := createMessageTemplate()
+				tmpl := createNotificationTemplate()
 				sut.config.(*MockAMConfigStore).EXPECT().
 					GetsConfig(models.AlertConfiguration{
 						AlertmanagerConfiguration: configWithTemplates,
@@ -146,7 +146,7 @@ func TestTemplateService(t *testing.T) {
 
 			t.Run("when AM config fails to save", func(t *testing.T) {
 				sut := createTemplateServiceSut()
-				tmpl := createMessageTemplate()
+				tmpl := createNotificationTemplate()
 				sut.config.(*MockAMConfigStore).EXPECT().
 					GetsConfig(models.AlertConfiguration{
 						AlertmanagerConfiguration: configWithTemplates,
@@ -164,7 +164,7 @@ func TestTemplateService(t *testing.T) {
 
 		t.Run("adds new template to config file on success", func(t *testing.T) {
 			sut := createTemplateServiceSut()
-			tmpl := createMessageTemplate()
+			tmpl := createNotificationTemplate()
 			sut.config.(*MockAMConfigStore).EXPECT().
 				GetsConfig(models.AlertConfiguration{
 					AlertmanagerConfiguration: configWithTemplates,
@@ -179,7 +179,7 @@ func TestTemplateService(t *testing.T) {
 
 		t.Run("succeeds when stitching config file with no templates", func(t *testing.T) {
 			sut := createTemplateServiceSut()
-			tmpl := createMessageTemplate()
+			tmpl := createNotificationTemplate()
 			sut.config.(*MockAMConfigStore).EXPECT().
 				GetsConfig(models.AlertConfiguration{
 					AlertmanagerConfiguration: defaultConfig,
@@ -194,7 +194,7 @@ func TestTemplateService(t *testing.T) {
 
 		t.Run("normalizes template content with no define", func(t *testing.T) {
 			sut := createTemplateServiceSut()
-			tmpl := definitions.MessageTemplate{
+			tmpl := definitions.NotificationTemplate{
 				Name:     "name",
 				Template: "content",
 			}
@@ -213,7 +213,7 @@ func TestTemplateService(t *testing.T) {
 
 		t.Run("avoids normalizing template content with define", func(t *testing.T) {
 			sut := createTemplateServiceSut()
-			tmpl := definitions.MessageTemplate{
+			tmpl := definitions.NotificationTemplate{
 				Name:     "name",
 				Template: "{{define \"name\"}}content{{end}}",
 			}
@@ -231,7 +231,7 @@ func TestTemplateService(t *testing.T) {
 
 		t.Run("rejects syntactically invalid template", func(t *testing.T) {
 			sut := createTemplateServiceSut()
-			tmpl := definitions.MessageTemplate{
+			tmpl := definitions.NotificationTemplate{
 				Name:     "name",
 				Template: "{{ .MyField }",
 			}
@@ -249,7 +249,7 @@ func TestTemplateService(t *testing.T) {
 
 		t.Run("does not reject template with unknown field", func(t *testing.T) {
 			sut := createTemplateServiceSut()
-			tmpl := definitions.MessageTemplate{
+			tmpl := definitions.NotificationTemplate{
 				Name:     "name",
 				Template: "{{ .NotAField }}",
 			}
@@ -388,8 +388,8 @@ func createTemplateServiceSut() *TemplateService {
 	}
 }
 
-func createMessageTemplate() definitions.MessageTemplate {
-	return definitions.MessageTemplate{
+func createNotificationTemplate() definitions.NotificationTemplate {
+	return definitions.NotificationTemplate{
 		Name:     "test",
 		Template: "asdf",
 	}

--- a/pkg/services/provisioning/alerting/text_templates_types.go
+++ b/pkg/services/provisioning/alerting/text_templates_types.go
@@ -9,8 +9,8 @@ import (
 )
 
 type TemplateV1 struct {
-	OrgID    values.Int64Value           `json:"orgId" yaml:"orgId"`
-	Template definitions.MessageTemplate `json:",inline" yaml:",inline"`
+	OrgID    values.Int64Value                `json:"orgId" yaml:"orgId"`
+	Template definitions.NotificationTemplate `json:",inline" yaml:",inline"`
 }
 
 func (v1 *TemplateV1) mapToModel() Template {
@@ -26,7 +26,7 @@ func (v1 *TemplateV1) mapToModel() Template {
 
 type Template struct {
 	OrgID int64
-	Data  definitions.MessageTemplate
+	Data  definitions.NotificationTemplate
 }
 
 type DeleteTemplateV1 struct {

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -3008,13 +3008,13 @@
         "tags": [
           "provisioning"
         ],
-        "summary": "Get all message templates.",
+        "summary": "Get all notification templates.",
         "operationId": "RouteGetTemplates",
         "responses": {
           "200": {
-            "description": "MessageTemplates",
+            "description": "NotificationTemplates",
             "schema": {
-              "$ref": "#/definitions/MessageTemplates"
+              "$ref": "#/definitions/NotificationTemplates"
             }
           },
           "404": {
@@ -3028,7 +3028,7 @@
         "tags": [
           "provisioning"
         ],
-        "summary": "Get a message template.",
+        "summary": "Get a notification template.",
         "operationId": "RouteGetTemplate",
         "parameters": [
           {
@@ -3041,9 +3041,9 @@
         ],
         "responses": {
           "200": {
-            "description": "MessageTemplate",
+            "description": "NotificationTemplate",
             "schema": {
-              "$ref": "#/definitions/MessageTemplate"
+              "$ref": "#/definitions/NotificationTemplate"
             }
           },
           "404": {
@@ -3072,15 +3072,15 @@
             "name": "Body",
             "in": "body",
             "schema": {
-              "$ref": "#/definitions/MessageTemplateContent"
+              "$ref": "#/definitions/NotificationTemplateContent"
             }
           }
         ],
         "responses": {
           "202": {
-            "description": "MessageTemplate",
+            "description": "NotificationTemplate",
             "schema": {
-              "$ref": "#/definitions/MessageTemplate"
+              "$ref": "#/definitions/NotificationTemplate"
             }
           },
           "400": {
@@ -14447,7 +14447,7 @@
         "$ref": "#/definitions/Matcher"
       }
     },
-    "MessageTemplate": {
+    "NotificationTemplate": {
       "type": "object",
       "properties": {
         "name": {
@@ -14461,7 +14461,7 @@
         }
       }
     },
-    "MessageTemplateContent": {
+    "NotificationTemplateContent": {
       "type": "object",
       "properties": {
         "template": {
@@ -14469,10 +14469,10 @@
         }
       }
     },
-    "MessageTemplates": {
+    "NotificationTemplates": {
       "type": "array",
       "items": {
-        "$ref": "#/definitions/MessageTemplate"
+        "$ref": "#/definitions/NotificationTemplate"
       }
     },
     "Metadata": {

--- a/public/app/features/alerting/unified/Receivers.tsx
+++ b/public/app/features/alerting/unified/Receivers.tsx
@@ -180,7 +180,7 @@ const Receivers = () => {
 function getPageNavigationModel(type: PageType | undefined, id: string | undefined) {
   let pageNav: NavModelItem | undefined;
   if (type === 'receivers' || type === 'templates') {
-    const objectText = type === 'receivers' ? 'contact point' : 'message template';
+    const objectText = type === 'receivers' ? 'contact point' : 'notification template';
     if (id) {
       pageNav = {
         text: id,

--- a/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
@@ -105,7 +105,7 @@ export const TemplateForm: FC<Props> = ({ existing, alertManagerSourceName, conf
 
   return (
     <form onSubmit={handleSubmit(submit)}>
-      <h4>{existing ? 'Edit message template' : 'Create message template'}</h4>
+      <h4>{existing ? 'Edit notification template' : 'Create notification template'}</h4>
       {error && (
         <Alert severity="error" title="Error saving template">
           {error.message || (error as any)?.data?.message || String(error)}

--- a/public/app/features/alerting/unified/components/receivers/TemplatesTable.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplatesTable.tsx
@@ -49,8 +49,8 @@ export const TemplatesTable: FC<Props> = ({ config, alertManagerName }) => {
 
   return (
     <ReceiversSection
-      title="Message templates"
-      description="Templates construct the messages that get sent to the contact points."
+      title="Notification templates"
+      description="Notification templates customize notifications sent from contact points."
       addButtonLabel="New template"
       addButtonTo={makeAMLink('/alerting/notifications/templates/new', alertManagerName)}
       showButton={contextSrv.hasPermission(permissions.create)}

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -5764,7 +5764,7 @@
         },
         "type": "array"
       },
-      "MessageTemplate": {
+      "NotificationTemplate": {
         "properties": {
           "name": {
             "type": "string"
@@ -5778,7 +5778,7 @@
         },
         "type": "object"
       },
-      "MessageTemplateContent": {
+      "NotificationTemplateContent": {
         "properties": {
           "template": {
             "type": "string"
@@ -5786,9 +5786,9 @@
         },
         "type": "object"
       },
-      "MessageTemplates": {
+      "NotificationTemplates": {
         "items": {
-          "$ref": "#/components/schemas/MessageTemplate"
+          "$ref": "#/components/schemas/NotificationTemplate"
         },
         "type": "array"
       },
@@ -13717,17 +13717,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/MessageTemplates"
+                  "$ref": "#/components/schemas/NotificationTemplates"
                 }
               }
             },
-            "description": "MessageTemplates"
+            "description": "NotificationTemplates"
           },
           "404": {
             "description": " Not found."
           }
         },
-        "summary": "Get all message templates.",
+        "summary": "Get all notification templates.",
         "tags": [
           "provisioning"
         ]
@@ -13775,17 +13775,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/MessageTemplate"
+                  "$ref": "#/components/schemas/NotificationTemplate"
                 }
               }
             },
-            "description": "MessageTemplate"
+            "description": "NotificationTemplate"
           },
           "404": {
             "description": " Not found."
           }
         },
-        "summary": "Get a message template.",
+        "summary": "Get a notification template.",
         "tags": [
           "provisioning"
         ]
@@ -13807,7 +13807,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/MessageTemplateContent"
+                "$ref": "#/components/schemas/NotificationTemplateContent"
               }
             }
           },
@@ -13818,11 +13818,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/MessageTemplate"
+                  "$ref": "#/components/schemas/NotificationTemplate"
                 }
               }
             },
-            "description": "MessageTemplate"
+            "description": "NotificationTemplate"
           },
           "400": {
             "content": {


### PR DESCRIPTION
**What is this feature?**

This commit renames "Message templates" to "Notification templates" in the user interface as it suggests that these templates cannot be used to template anything other than the message. However, message templates are much more general and can be used to template other fields too such as the subject of an email, or the title of a Slack message.

![image](https://user-images.githubusercontent.com/85952834/204517252-a890a8bf-0bfd-4628-8ebe-1a4874ac905e.png)

**Why do we need this feature?**

I think that changing "Message templates" to "Notification templates" is much better at describing what the templates do, and will help avoid confusion in the documentation when using "Message templates" to template fields other than the message.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

