### PR TITLE
CI: Add automation for github assets publishing

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -22,6 +22,7 @@ load(
     'publish_image_pipelines_public',
     'publish_image_pipelines_security',
 )
+load('scripts/drone/pipelines/github.star', 'publish_github_pipeline')
 load('scripts/drone/version.star', 'version_branch_pipelines')
 load('scripts/drone/events/cron.star', 'cronjobs')
 load('scripts/drone/vault.star', 'secrets')
@@ -40,6 +41,8 @@ def main(ctx):
         )
         + publish_image_pipelines_public()
         + publish_image_pipelines_security()
+        + publish_github_pipeline('public')
+        + publish_github_pipeline('security')
         + publish_artifacts_pipelines('security')
         + publish_artifacts_pipelines('public')
         + publish_npm_pipelines()

--- a/.drone.yml
+++ b/.drone.yml
@@ -4139,6 +4139,8 @@ steps:
 - commands:
   - ./bin/build publish github --repo grafana/grafana-ci-sandbox --artifact grafana-enterprise2-0.0.0-testpre-amd64.img
     --create
+  depends_on:
+  - fetch-images-enterprise2
   image: grafana/grafana-ci-deploy:1.3.3
   name: publish-github
 trigger:
@@ -4196,6 +4198,8 @@ steps:
 - commands:
   - ./bin/build publish github --repo grafana/grafana-ci-sandbox --artifact grafana-enterprise2-0.0.0-testpre-amd64.img
     --create
+  depends_on:
+  - fetch-images-enterprise2
   image: grafana/grafana-ci-deploy:1.3.3
   name: publish-github
 trigger:
@@ -6432,6 +6436,6 @@ kind: secret
 name: packages_secret_access_key
 ---
 kind: signature
-hmac: 56a20724d65c6d1ef17ca521d0f1a5826748c289e31ff70aa5a858066fef7d52
+hmac: b74c88121ceaad31691b5175ee9c32aa80225dac9e286b0a6e77445a7a5cc0d4
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -4137,7 +4137,7 @@ steps:
   - name: docker
     path: /var/run/docker.sock
 - commands:
-  - ./bin/build publish github --repo grafana/grafana-ci-sandbox --artifact grafana-enterprise2-0.0.0-testpre-amd64.img
+  - ./bin/build publish github --repo grafana/grafana-ci-sandbox --path grafana-enterprise2-0.0.0-testpre-amd64.img
     --create
   depends_on:
   - fetch-images-enterprise2
@@ -4196,7 +4196,7 @@ steps:
   - name: docker
     path: /var/run/docker.sock
 - commands:
-  - ./bin/build publish github --repo grafana/grafana-ci-sandbox --artifact grafana-enterprise2-0.0.0-testpre-amd64.img
+  - ./bin/build publish github --repo grafana/grafana-ci-sandbox --path grafana-enterprise2-0.0.0-testpre-amd64.img
     --create
   depends_on:
   - fetch-images-enterprise2
@@ -6436,6 +6436,6 @@ kind: secret
 name: packages_secret_access_key
 ---
 kind: signature
-hmac: b74c88121ceaad31691b5175ee9c32aa80225dac9e286b0a6e77445a7a5cc0d4
+hmac: a6df105617ba9bb9554244be7450e76576f0309486bba00df7b403cb0ffb8e85
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -4137,8 +4137,7 @@ steps:
   - name: docker
     path: /var/run/docker.sock
 - commands:
-  - ./bin/build publish github --repo grafana/grafana-ci-sandbox --path grafana-enterprise2-0.0.0-test-amd64.img
-    --create
+  - ./bin/build publish github --repo grafana/grafana-ci-sandbox --create
   depends_on:
   - fetch-images-enterprise2
   environment:
@@ -4199,8 +4198,7 @@ steps:
   - name: docker
     path: /var/run/docker.sock
 - commands:
-  - ./bin/build publish github --repo grafana/grafana-ci-sandbox --path grafana-enterprise2-0.0.0-test-amd64.img
-    --create
+  - ./bin/build publish github --repo grafana/grafana-ci-sandbox --create
   depends_on:
   - fetch-images-enterprise2
   environment:
@@ -6442,6 +6440,6 @@ kind: secret
 name: packages_secret_access_key
 ---
 kind: signature
-hmac: 9b732fc4da5e282bb57140c6c2d1b6bdbfc157aeeafaedcfc419c1cb8c0bae05
+hmac: a4f67364c29316b0aa1cf0cada0789f863b1808571a8d24e3be94862b9fb48de
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -4137,10 +4137,12 @@ steps:
   - name: docker
     path: /var/run/docker.sock
 - commands:
-  - ./bin/build publish github --repo grafana/grafana-ci-sandbox --create
+  - ./bin/build publish github --repo $${GH_REGISTRY} --create
   depends_on:
   - fetch-images-enterprise2
   environment:
+    GH_REGISTRY:
+      from_secret: gh_registry
     GH_TOKEN:
       from_secret: github_token
   image: grafana/grafana-ci-deploy:1.3.3
@@ -4198,10 +4200,12 @@ steps:
   - name: docker
     path: /var/run/docker.sock
 - commands:
-  - ./bin/build publish github --repo grafana/grafana-ci-sandbox --create
+  - ./bin/build publish github --repo $${GH_REGISTRY} --create
   depends_on:
   - fetch-images-enterprise2
   environment:
+    GH_REGISTRY:
+      from_secret: gh_registry
     GH_TOKEN:
       from_secret: github_token
   image: grafana/grafana-ci-deploy:1.3.3
@@ -6440,6 +6444,6 @@ kind: secret
 name: packages_secret_access_key
 ---
 kind: signature
-hmac: a4f67364c29316b0aa1cf0cada0789f863b1808571a8d24e3be94862b9fb48de
+hmac: 7045c606549d05fbe66b2e683b318c7063a4e875e1a94168d5f5b03bb7e319c6
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -4099,6 +4099,120 @@ clone:
   retries: 3
 depends_on: []
 environment:
+  EDITION: enterprise2
+image_pull_secrets:
+- dockerconfigjson
+kind: pipeline
+name: publish-github-public
+node:
+  type: no-parallel
+platform:
+  arch: amd64
+  os: linux
+services: []
+steps:
+- commands:
+  - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
+  depends_on: []
+  environment:
+    CGO_ENABLED: 0
+  image: golang:1.19.3
+  name: compile-build-cmd
+- commands:
+  - ./bin/build artifacts docker fetch --edition enterprise2
+  depends_on:
+  - compile-build-cmd
+  environment:
+    DOCKER_ENTERPRISE2_REPO:
+      from_secret: docker_enterprise2_repo
+    DOCKER_PASSWORD:
+      from_secret: docker_password
+    DOCKER_USER:
+      from_secret: docker_username
+    GCP_KEY:
+      from_secret: gcp_key
+  image: google/cloud-sdk
+  name: fetch-images-enterprise2
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+- commands:
+  - ./bin/build publish github --repo grafana/grafana-ci-sandbox --artifact grafana-enterprise2-0.0.0-testpre-amd64.img
+    --create
+  image: grafana/grafana-ci-deploy:1.3.3
+  name: publish-github
+trigger:
+  event:
+  - promote
+  target:
+  - public
+type: docker
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
+---
+clone:
+  retries: 3
+depends_on: []
+environment:
+  EDITION: enterprise2
+image_pull_secrets:
+- dockerconfigjson
+kind: pipeline
+name: publish-github-security
+node:
+  type: no-parallel
+platform:
+  arch: amd64
+  os: linux
+services: []
+steps:
+- commands:
+  - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
+  depends_on: []
+  environment:
+    CGO_ENABLED: 0
+  image: golang:1.19.3
+  name: compile-build-cmd
+- commands:
+  - ./bin/build artifacts docker fetch --edition enterprise2
+  depends_on:
+  - compile-build-cmd
+  environment:
+    DOCKER_ENTERPRISE2_REPO:
+      from_secret: docker_enterprise2_repo
+    DOCKER_PASSWORD:
+      from_secret: docker_password
+    DOCKER_USER:
+      from_secret: docker_username
+    GCP_KEY:
+      from_secret: gcp_key
+  image: google/cloud-sdk
+  name: fetch-images-enterprise2
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+- commands:
+  - ./bin/build publish github --repo grafana/grafana-ci-sandbox --artifact grafana-enterprise2-0.0.0-testpre-amd64.img
+    --create
+  image: grafana/grafana-ci-deploy:1.3.3
+  name: publish-github
+trigger:
+  event:
+  - promote
+  target:
+  - security
+type: docker
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
+---
+clone:
+  retries: 3
+depends_on: []
+environment:
   EDITION: all
 image_pull_secrets:
 - dockerconfigjson
@@ -6318,6 +6432,6 @@ kind: secret
 name: packages_secret_access_key
 ---
 kind: signature
-hmac: dcf24226fae30872050cdc031430374d811e6bbe13158ce0fbf234c90c1d83f9
+hmac: 56a20724d65c6d1ef17ca521d0f1a5826748c289e31ff70aa5a858066fef7d52
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -4137,7 +4137,7 @@ steps:
   - name: docker
     path: /var/run/docker.sock
 - commands:
-  - ./bin/build publish github --repo grafana/grafana-ci-sandbox --path grafana-enterprise2-0.0.0-testpre-amd64.img
+  - ./bin/build publish github --repo grafana/grafana-ci-sandbox --path grafana-enterprise2-0.0.0-test-amd64.img
     --create
   depends_on:
   - fetch-images-enterprise2
@@ -4199,7 +4199,7 @@ steps:
   - name: docker
     path: /var/run/docker.sock
 - commands:
-  - ./bin/build publish github --repo grafana/grafana-ci-sandbox --path grafana-enterprise2-0.0.0-testpre-amd64.img
+  - ./bin/build publish github --repo grafana/grafana-ci-sandbox --path grafana-enterprise2-0.0.0-test-amd64.img
     --create
   depends_on:
   - fetch-images-enterprise2
@@ -6442,6 +6442,6 @@ kind: secret
 name: packages_secret_access_key
 ---
 kind: signature
-hmac: 002f2ddd7b13c10987a9a5b628a48b2b609254c71acb6a71e78987a165bb5bac
+hmac: 9b732fc4da5e282bb57140c6c2d1b6bdbfc157aeeafaedcfc419c1cb8c0bae05
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -4141,6 +4141,9 @@ steps:
     --create
   depends_on:
   - fetch-images-enterprise2
+  environment:
+    GH_TOKEN:
+      from_secret: github_token
   image: grafana/grafana-ci-deploy:1.3.3
   name: publish-github
 trigger:
@@ -4200,6 +4203,9 @@ steps:
     --create
   depends_on:
   - fetch-images-enterprise2
+  environment:
+    GH_TOKEN:
+      from_secret: github_token
   image: grafana/grafana-ci-deploy:1.3.3
   name: publish-github
 trigger:
@@ -6436,6 +6442,6 @@ kind: secret
 name: packages_secret_access_key
 ---
 kind: signature
-hmac: a6df105617ba9bb9554244be7450e76576f0309486bba00df7b403cb0ffb8e85
+hmac: 002f2ddd7b13c10987a9a5b628a48b2b609254c71acb6a71e78987a165bb5bac
 
 ...

--- a/pkg/build/cmd/main.go
+++ b/pkg/build/cmd/main.go
@@ -238,9 +238,8 @@ func main() {
 					Flags: []cli.Flag{
 						&dryRunFlag,
 						&cli.StringFlag{
-							Name:     "path",
-							Required: true,
-							Usage:    "Path to the asset to be published",
+							Name:  "path",
+							Usage: "Path to the asset to be published",
 						},
 						&cli.StringFlag{
 							Name:     "repo",

--- a/pkg/build/cmd/publishgithub.go
+++ b/pkg/build/cmd/publishgithub.go
@@ -114,6 +114,10 @@ func getPublishGithubFlags(ctx *cli.Context) (*publishGithubFlags, error) {
 	name := strings.Split(fullRepo, "/")[1]
 	create := ctx.Value("create").(bool)
 	artifactPath := ctx.Value("path").(string)
+	if artifactPath == "" {
+		artifactPath = fmt.Sprintf("grafana-enterprise2-%s-amd64.img", metadata.GrafanaVersion)
+		fmt.Printf("path argument is not provided, resolving to default %s...\n", artifactPath)
+	}
 	return &publishGithubFlags{
 		artifactPath: artifactPath,
 		create:       create,

--- a/scripts/drone/pipelines/github.star
+++ b/scripts/drone/pipelines/github.star
@@ -1,0 +1,29 @@
+load(
+    'scripts/drone/steps/lib.star',
+    'download_grabpl_step',
+    'publish_images_step',
+    'compile_build_cmd',
+    'fetch_images_step',
+    'publish_image',
+)
+
+load(
+    'scripts/drone/utils/utils.star',
+    'pipeline',
+)
+
+def publish_github_step():
+    return {
+        'name': 'publish-github',
+        'image': publish_image,
+        'commands': ['./bin/build publish github --repo grafana/grafana-ci-sandbox --artifact grafana-enterprise2-{}pre-amd64.img --create'.format('0.0.0-test')]
+    }
+
+def publish_github_pipeline(mode):
+    trigger = {
+        'event': ['promote'],
+        'target': [mode],
+    }
+    return [pipeline(
+        name='publish-github-{}'.format(mode), trigger=trigger, steps=[compile_build_cmd(), fetch_images_step('enterprise2'), publish_github_step()], edition="", environment = {'EDITION': 'enterprise2'}
+    ),]

--- a/scripts/drone/pipelines/github.star
+++ b/scripts/drone/pipelines/github.star
@@ -16,7 +16,7 @@ def publish_github_step():
     return {
         'name': 'publish-github',
         'image': publish_image,
-        'commands': ['./bin/build publish github --repo grafana/grafana-ci-sandbox --artifact grafana-enterprise2-{}pre-amd64.img --create'.format('0.0.0-test')],
+        'commands': ['./bin/build publish github --repo grafana/grafana-ci-sandbox --path grafana-enterprise2-{}pre-amd64.img --create'.format('0.0.0-test')],
         'depends_on': ['fetch-images-enterprise2'],
     }
 

--- a/scripts/drone/pipelines/github.star
+++ b/scripts/drone/pipelines/github.star
@@ -18,7 +18,7 @@ def publish_github_step():
     return {
         'name': 'publish-github',
         'image': publish_image,
-        'commands': ['./bin/build publish github --repo grafana/grafana-ci-sandbox --path grafana-enterprise2-{}-amd64.img --create'.format('0.0.0-test')],
+        'commands': ['./bin/build publish github --repo grafana/grafana-ci-sandbox --create'],
         'depends_on': ['fetch-images-enterprise2'],
         'environment': {
             'GH_TOKEN': from_secret('github_token'),

--- a/scripts/drone/pipelines/github.star
+++ b/scripts/drone/pipelines/github.star
@@ -18,10 +18,11 @@ def publish_github_step():
     return {
         'name': 'publish-github',
         'image': publish_image,
-        'commands': ['./bin/build publish github --repo grafana/grafana-ci-sandbox --create'],
+        'commands': ['./bin/build publish github --repo $${GH_REGISTRY} --create'],
         'depends_on': ['fetch-images-enterprise2'],
         'environment': {
             'GH_TOKEN': from_secret('github_token'),
+            'GH_REGISTRY': from_secret('gh_registry'),
         },
     }
 

--- a/scripts/drone/pipelines/github.star
+++ b/scripts/drone/pipelines/github.star
@@ -16,7 +16,8 @@ def publish_github_step():
     return {
         'name': 'publish-github',
         'image': publish_image,
-        'commands': ['./bin/build publish github --repo grafana/grafana-ci-sandbox --artifact grafana-enterprise2-{}pre-amd64.img --create'.format('0.0.0-test')]
+        'commands': ['./bin/build publish github --repo grafana/grafana-ci-sandbox --artifact grafana-enterprise2-{}pre-amd64.img --create'.format('0.0.0-test')],
+        'depends_on': ['fetch-images-enterprise2'],
     }
 
 def publish_github_pipeline(mode):

--- a/scripts/drone/pipelines/github.star
+++ b/scripts/drone/pipelines/github.star
@@ -7,6 +7,8 @@ load(
     'publish_image',
 )
 
+load('scripts/drone/vault.star', 'from_secret')
+
 load(
     'scripts/drone/utils/utils.star',
     'pipeline',
@@ -18,6 +20,9 @@ def publish_github_step():
         'image': publish_image,
         'commands': ['./bin/build publish github --repo grafana/grafana-ci-sandbox --path grafana-enterprise2-{}pre-amd64.img --create'.format('0.0.0-test')],
         'depends_on': ['fetch-images-enterprise2'],
+        'environment': {
+            'GH_TOKEN': from_secret('github_token'),
+        },
     }
 
 def publish_github_pipeline(mode):

--- a/scripts/drone/pipelines/github.star
+++ b/scripts/drone/pipelines/github.star
@@ -18,7 +18,7 @@ def publish_github_step():
     return {
         'name': 'publish-github',
         'image': publish_image,
-        'commands': ['./bin/build publish github --repo grafana/grafana-ci-sandbox --path grafana-enterprise2-{}pre-amd64.img --create'.format('0.0.0-test')],
+        'commands': ['./bin/build publish github --repo grafana/grafana-ci-sandbox --path grafana-enterprise2-{}-amd64.img --create'.format('0.0.0-test')],
         'depends_on': ['fetch-images-enterprise2'],
         'environment': {
             'GH_TOKEN': from_secret('github_token'),


### PR DESCRIPTION
**What is this feature?**

This PR adds a `./bin/build publish github` command in the CI, which will get triggered on promotions.

**Why do we need this feature?**

We need an automation for the github assets to be in place. 

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana-release-engineering/issues/30
