### PR TITLE
Usage Insights: Make it toggleable

### DIFF
--- a/packages/grafana-data/src/types/config.ts
+++ b/packages/grafana-data/src/types/config.ts
@@ -217,6 +217,7 @@ export interface GrafanaConfig {
   rudderstackDataPlaneUrl: string | undefined;
   rudderstackSdkUrl: string | undefined;
   rudderstackConfigUrl: string | undefined;
+  usageInsightsEnabled: boolean;
 }
 
 export interface AuthSettings {

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -86,7 +86,7 @@ export class GrafanaBootConfig implements GrafanaConfig {
       requiredImageRendererPluginVersion: string;
     };
     thumbnailsExist: boolean;
-  } = {systemRequirements: {met: false, requiredImageRendererPluginVersion: ''}, thumbnailsExist: false};
+  } = { systemRequirements: { met: false, requiredImageRendererPluginVersion: '' }, thumbnailsExist: false };
   rendererVersion = '';
   secretsManagerPluginEnabled = false;
   http2Enabled = false;

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -189,11 +189,11 @@ export class GrafanaBootConfig implements GrafanaConfig {
 function getThemeCustomizations(config: GrafanaBootConfig) {
   const mode = config.bootData.user.lightTheme ? 'light' : 'dark';
   const themeOptions: NewThemeOptions = {
-    colors: {mode},
+    colors: { mode },
   };
 
   if (config.featureToggles.interFont) {
-    themeOptions.typography = {fontFamily: '"Inter", "Helvetica", "Arial", sans-serif'};
+    themeOptions.typography = { fontFamily: '"Inter", "Helvetica", "Arial", sans-serif' };
   }
 
   return themeOptions;

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -86,7 +86,7 @@ export class GrafanaBootConfig implements GrafanaConfig {
       requiredImageRendererPluginVersion: string;
     };
     thumbnailsExist: boolean;
-  } = { systemRequirements: { met: false, requiredImageRendererPluginVersion: '' }, thumbnailsExist: false };
+  } = {systemRequirements: {met: false, requiredImageRendererPluginVersion: ''}, thumbnailsExist: false};
   rendererVersion = '';
   secretsManagerPluginEnabled = false;
   http2Enabled = false;
@@ -122,7 +122,7 @@ export class GrafanaBootConfig implements GrafanaConfig {
   geomapDefaultBaseLayerConfig?: MapLayerOptions;
   geomapDisableCustomBaseLayer?: boolean;
   unifiedAlertingEnabled = false;
-  unifiedAlerting = { minInterval: '' };
+  unifiedAlerting = {minInterval: ''};
   applicationInsightsConnectionString?: string;
   applicationInsightsEndpointUrl?: string;
   recordedQueries = {
@@ -141,7 +141,7 @@ export class GrafanaBootConfig implements GrafanaConfig {
   rudderstackDataPlaneUrl: undefined;
   rudderstackSdkUrl: undefined;
   rudderstackConfigUrl: undefined;
-
+  usageInsightsEnabled =  true;
   tokenExpirationDayLimit: undefined;
 
   constructor(options: GrafanaBootConfig) {
@@ -189,11 +189,11 @@ export class GrafanaBootConfig implements GrafanaConfig {
 function getThemeCustomizations(config: GrafanaBootConfig) {
   const mode = config.bootData.user.lightTheme ? 'light' : 'dark';
   const themeOptions: NewThemeOptions = {
-    colors: { mode },
+    colors: {mode},
   };
 
   if (config.featureToggles.interFont) {
-    themeOptions.typography = { fontFamily: '"Inter", "Helvetica", "Arial", sans-serif' };
+    themeOptions.typography = {fontFamily: '"Inter", "Helvetica", "Arial", sans-serif'};
   }
 
   return themeOptions;

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -122,7 +122,7 @@ export class GrafanaBootConfig implements GrafanaConfig {
   geomapDefaultBaseLayerConfig?: MapLayerOptions;
   geomapDisableCustomBaseLayer?: boolean;
   unifiedAlertingEnabled = false;
-  unifiedAlerting = {minInterval: ''};
+  unifiedAlerting = { minInterval: '' };
   applicationInsightsConnectionString?: string;
   applicationInsightsEndpointUrl?: string;
   recordedQueries = {

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -202,6 +202,7 @@ func (hs *HTTPServer) getFrontendSettingsMap(c *models.ReqContext) (map[string]i
 		"samlEnabled":             hs.samlEnabled(),
 		"samlName":                hs.samlName(),
 		"tokenExpirationDayLimit": hs.Cfg.SATokenExpirationDayLimit,
+		"usageInsightsEnabled":    setting.UsageInsightsEnabled,
 	}
 
 	if hs.ThumbService != nil {

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -179,6 +179,9 @@ var (
 	GrafanaComUrl string
 
 	ImageUploadProvider string
+
+	// Usage Insights
+	UsageInsightsEnabled bool
 )
 
 // AddChangePasswordLink returns if login form is disabled or not since


### PR DESCRIPTION
**What is this feature?**

These changes contribute to make Usage Insights service toggleable (make it possible to enable/disable it).

**Why do we need this feature?**

In short: in certain cases, it makes no sense to keep Usage Insights enabled, but you can find further details [here](https://github.com/grafana/grafana-enterprise/issues/4164).

**Who is this feature for?**

Grafana administrators / operators

**Which issue(s) does this PR fix?**:

Contributes to https://github.com/grafana/grafana-enterprise/issues/4164

**Special notes for your reviewer**:

Tested and seems to be worked as expected, but any extra test will be more than welcome.

Complement to https://github.com/grafana/grafana-enterprise/pull/4165
