### PR TITLE
Add a separate grafana.com API URL setting

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1060,6 +1060,7 @@ url = https://grafana.com
 
 [grafana_com]
 url = https://grafana.com
+api_url = https://grafana.com/api
 
 #################################### Distributed tracing ############
 # Opentracing is deprecated use opentelemetry instead

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -1029,6 +1029,7 @@
 # Url used to import dashboards directly from Grafana.com
 [grafana_com]
 ;url = https://grafana.com
+;api_url = https://grafana.com/api
 
 #################################### Distributed tracing ############
 # Opentracing is deprecated use opentelemetry instead

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -456,8 +456,12 @@ type Cfg struct {
 	// then Live uses AppURL as the only allowed origin.
 	LiveAllowedOrigins []string
 
-	// Grafana.com URL
+	// Grafana.com URL, used for OAuth redirect.
 	GrafanaComURL string
+	// Grafana.com API URL. Can be set separately to GrafanaComURL
+	// in case API is not publicly accessible.
+	// Defaults to GrafanaComURL setting + "/api" if unset.
+	GrafanaComAPIURL string
 
 	// Geomap base layer config
 	GeomapDefaultBaseLayerConfig map[string]interface{}
@@ -1090,6 +1094,8 @@ func (cfg *Cfg) Load(args CommandLineArgs) error {
 		GrafanaComUrl = valueAsString(iniFile.Section("grafana_com"), "url", "https://grafana.com")
 	}
 	cfg.GrafanaComURL = GrafanaComUrl
+
+	cfg.GrafanaComAPIURL = valueAsString(iniFile.Section("grafana_com"), "api_url", GrafanaComUrl+"/api")
 
 	imageUploadingSection := iniFile.Section("external_image_storage")
 	cfg.ImageUploadProvider = valueAsString(imageUploadingSection, "provider", "")

--- a/pkg/setting/setting_test.go
+++ b/pkg/setting/setting_test.go
@@ -266,6 +266,30 @@ func TestLoadingSettings(t *testing.T) {
 			require.Equal(t, "default_url_val", value)
 		})
 	})
+
+	t.Run("grafana.com API URL can be set separately from grafana.com URL", func(t *testing.T) {
+		err := os.Setenv("GF_GRAFANA_NET_URL", "https://grafana-dev.com")
+		require.NoError(t, err)
+		err = os.Setenv("GF_GRAFANA_COM_API_URL", "http://grafana-dev.internal/api")
+		require.NoError(t, err)
+		cfg := NewCfg()
+		err = cfg.Load(CommandLineArgs{HomePath: "../../", Config: "../../conf/defaults.ini"})
+		require.Nil(t, err)
+		require.Equal(t, "https://grafana-dev.com", cfg.GrafanaComURL)
+		require.Equal(t, "http://grafana-dev.internal/api", cfg.GrafanaComAPIURL)
+	})
+
+	t.Run("grafana.com API URL falls back to grafana.com URL + /api", func(t *testing.T) {
+		err := os.Unsetenv("GF_GRAFANA_NET_URL")
+		require.NoError(t, err)
+		err = os.Unsetenv("GF_GRAFANA_COM_API_URL")
+		require.NoError(t, err)
+		cfg := NewCfg()
+		err = cfg.Load(CommandLineArgs{HomePath: "../../"})
+		require.Nil(t, err)
+		require.Equal(t, "https://grafana.com", cfg.GrafanaComURL)
+		require.Equal(t, "https://grafana.com/api", cfg.GrafanaComAPIURL)
+	})
 }
 
 func TestParseAppURLAndSubURL(t *testing.T) {


### PR DESCRIPTION
The `GrafanaComURL` setting is currently used in two places:

- the `/api/gnet` endpoint, which proxies all requests to the URL
  configured in `GrafanaComURL`
- OAuth logins using grafana.com, where the auth URL, token URL and
  redirect URL are all configured to use the `GrafanaComURL`.

This has worked fine until now because almost all Grafana instances have
just used the default value, https://grafana.com. However, we now have a
few different grafana.com's, some of which are behind IAP. The IAP
causes the `/api/gnet` proxy to fail because the required cookies are not
present in the request (how could they be?). Setting the
`[grafana_net.url]` setting to an internal-only URL improves the situation
slightly - the proxy works again just fine - but breaks any OAuth logins
using grafana.com, because the user must be redirected to a publicly
accessible URL.

This commit adds an additional setting, `[grafana_net.api_url]`
(and equivalently `[grafana_com.api_url]`), which can be used to tell
Grafana to use the new API URL when proxying requests to the grafana.com
API, while still using the existing `GrafanaComURL` setting for other
things.

The setting will fall back to the `GrafanaComURL` setting + "/api" if unset.
