### PR TITLE
Accessibility: Increase badge constrast to be WCAG AA compliant

### DIFF
--- a/packages/grafana-ui/src/components/Badge/Badge.tsx
+++ b/packages/grafana-ui/src/components/Badge/Badge.tsx
@@ -54,7 +54,7 @@ const getStyles = (theme: GrafanaTheme2, color: BadgeColor) => {
   } else {
     bgColor = tinycolor(sourceColor).setAlpha(0.15).toString();
     borderColor = tinycolor(sourceColor).lighten(20).toString();
-    textColor = tinycolor(sourceColor).darken(15).toString();
+    textColor = tinycolor(sourceColor).darken(20).toString();
   }
 
   return {


### PR DESCRIPTION
**What is this feature?**

Darken the 'alpha' badge colour to meet AA criteria as set out in our [accessibility statement](https://grafana.com/accessibility/).

**Why do we need this feature?**

Meet AA criteria as set out in our [accessibility statement](https://grafana.com/accessibility/).

**Who is this feature for?**

Everyone.

**Which issue(s) does this PR fix?**:

Fixes #58948 

**Special notes for your reviewer**:
After the changes, the colour of the badge is approved by the `WGAC Color contrast checker`.

<img width="845" alt="a11y-58948" src="https://user-images.githubusercontent.com/65417731/204755665-f6eb139f-8039-41bf-b222-4cf77f4441f2.png">
