### PR TITLE
Remove dependency on test job

### DIFF
--- a/.github/workflows/publish-technical-documentation-next.yml
+++ b/.github/workflows/publish-technical-documentation-next.yml
@@ -11,7 +11,6 @@ on:
 jobs:
   sync:
     runs-on: "ubuntu-latest"
-    needs: "test"
     steps:
       - name: "Checkout Grafana repo"
         uses: "actions/checkout@v3"

--- a/.github/workflows/publish-technical-documentation-release.yml
+++ b/.github/workflows/publish-technical-documentation-release.yml
@@ -13,7 +13,6 @@ on:
 jobs:
   sync:
     runs-on: "ubuntu-latest"
-    needs: "test"
     steps:
       - name: "Checkout Grafana repo"
         uses: "actions/checkout@v3"


### PR DESCRIPTION
Prevents the workflow from running.

Will manually cherry-pick this into the existing backport branches for #59550. 

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
