### PR TITLE
Packaging: Stop and disable service on DEB package removal

### DIFF
--- a/packaging/deb/control/postinst
+++ b/packaging/deb/control/postinst
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 set -e
 

--- a/packaging/deb/control/prerm
+++ b/packaging/deb/control/prerm
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+if [ "$1" = 'remove' ]
+then
+  echo 'Stopping and disabling grafana-server service...'
+  if command -v systemctl >/dev/null; then
+    systemctl stop grafana-server || true
+    systemctl disable grafana-server || true
+  elif [ -x '/etc/init.d/grafana-server' ]; then
+    if command -v invoke-rc.d >/dev/null; then
+      invoke-rc.d grafana-server stop || true
+      update-rc.d -f grafana-server remove || true
+    else
+      /etc/init.d/grafana-server stop || true
+    fi
+  fi
+fi

--- a/packaging/deb/control/prerm
+++ b/packaging/deb/control/prerm
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 if [ "$1" = 'remove' ]
 then

--- a/pkg/build/packaging/grafana.go
+++ b/pkg/build/packaging/grafana.go
@@ -379,7 +379,7 @@ func executeFPM(options linuxPackageOptions, packageRoot, srcDir string) error {
 		"--vendor", vendor,
 		"-a", string(options.packageArch),
 	}
-	if options.prermSrc != nil && options.prermSrc != "" {
+	if options.prermSrc != "" {
 		args = append(args, "--before-remove", options.prermSrc)
 	}
 	if options.edition == config.EditionEnterprise || options.edition == config.EditionEnterprise2 || options.goArch == config.ArchARMv6 {

--- a/pkg/build/packaging/grafana.go
+++ b/pkg/build/packaging/grafana.go
@@ -379,6 +379,9 @@ func executeFPM(options linuxPackageOptions, packageRoot, srcDir string) error {
 		"--vendor", vendor,
 		"-a", string(options.packageArch),
 	}
+	if options.prermSrc != nil && options.prermSrc != "" {
+		args = append(args, "--before-remove", options.prermSrc)
+	}
 	if options.edition == config.EditionEnterprise || options.edition == config.EditionEnterprise2 || options.goArch == config.ArchARMv6 {
 		args = append(args, "--conflicts", "grafana")
 	}
@@ -727,6 +730,7 @@ func realPackageVariant(ctx context.Context, v config.Variant, edition config.Ed
 			initdScriptFilePath:    "/etc/init.d/grafana-server",
 			systemdServiceFilePath: "/usr/lib/systemd/system/grafana-server.service",
 			postinstSrc:            filepath.Join(grafanaDir, "packaging", "deb", "control", "postinst"),
+			prermSrc:               filepath.Join(grafanaDir, "packaging", "deb", "control", "prerm"),
 			initdScriptSrc:         filepath.Join(grafanaDir, "packaging", "deb", "init.d", "grafana-server"),
 			defaultFileSrc:         filepath.Join(grafanaDir, "packaging", "deb", "default", "grafana-server"),
 			systemdFileSrc:         filepath.Join(grafanaDir, "packaging", "deb", "systemd", "grafana-server.service"),
@@ -843,6 +847,7 @@ type linuxPackageOptions struct {
 	initdScriptFilePath    string
 	systemdServiceFilePath string
 	postinstSrc            string
+	prermSrc               string
 	initdScriptSrc         string
 	defaultFileSrc         string
 	systemdFileSrc         string


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

The Grafana server service is now stopped and disabled on package removal.

**Why do we need this feature?**

Currently the service keeps running after package removal, failing at some point due to missing files. And if enabled, the attempted service start on every boot is doomed to fail.

The condition for this code to run applies on package removal only, not on upgrade or reinstall which generally invoke the `prerm` script as well.

If the `invoke-rc.d` command exists, it can be assumed that `update-rc.d` exists as well, as both are part of the same `init-system-helpers` package in dpkg distro repositories.

If neither systemd, nor the init system helper package is installed, the service is not tried to be disabled, since we cannot know a safe method to do so.

Compared to the `postinst` script, `set -e` is skipped here, since it is implied by dpkg maintainer script invocation, and since we do not run any command which is allowed to fail the whole package removal.

**Who is this feature for?**

Everyone who starts and/or enables the service via systemd or SysV will benefit, since the service doesn't need to be disabled manually anymore after package removal, to avoid service startup failures. Disabling isn't even trivial after the service files have been removed already together with the package, links might need to be removed manually.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

