### PR TITLE
Alerting: Rename contact point type to receiver in the user interface

### DIFF
--- a/docs/sources/alerting/manage-notifications/create-contact-point.md
+++ b/docs/sources/alerting/manage-notifications/create-contact-point.md
@@ -30,10 +30,10 @@ Complete the following steps to add a contact point.
 1. Click **New contact point**.
 1. From the **Alertmanager** dropdown, select an Alertmanager. By default, Grafana Alertmanager is selected.
 1. In **Name**, enter a descriptive name for the contact point.
-1. From **Contact point type**, select a type and fill out mandatory fields. For example, if you choose email, enter the email addresses. Or if you choose Slack, enter the Slack channel(s) and users who should be contacted.
-1. Some contact point types, like email or webhook, have optional settings. In **Optional settings**, specify additional settings for the selected contact point type.
+1. From **Contact point integration**, select a type and fill out mandatory fields. For example, if you choose email, enter the email addresses. Or if you choose Slack, enter the Slack channel(s) and users who should be contacted.
+1. Some contact point integrations, like email or webhook, have optional settings. In **Optional settings**, specify additional settings for the selected contact point integration.
 1. In Notification settings, optionally select **Disable resolved message** if you do not want to be notified when an alert resolves.
-1. To add another contact point type, click **New contact point type** and repeat steps 6 through 8.
+1. To add another contact point integration, click **New contact point integration** and repeat steps 6 through 8.
 1. Click **Save contact point** to save your changes.
 
 ## Edit a contact point

--- a/docs/sources/alerting/manage-notifications/create-message-template.md
+++ b/docs/sources/alerting/manage-notifications/create-message-template.md
@@ -24,7 +24,7 @@ weight: 200
 
 # Create and edit message templates
 
-You can use message templates to customize notification messages for the contact point types.
+You can use message templates to customize notification messages for the contact point integrations.
 
 ## Create a message template:
 

--- a/docs/sources/alerting/manage-notifications/create-notification-policy.md
+++ b/docs/sources/alerting/manage-notifications/create-notification-policy.md
@@ -83,7 +83,7 @@ An example of an alert configuration.
 - Create a "default" contact point for slack notifications, and set it on root policy.
 - Edit the root policy grouping to group alerts by `cluster`, `namespace` and `severity` so that you get a notification per alert rule and specific kubernetes cluster and namespace.
 - Create specific route for alerts coming from the development cluster with an appropriate contact point.
-- Create a specific route for alerts with "critical" severity with a more invasive contact point type, like pager duty notification.
+- Create a specific route for alerts with "critical" severity with a more invasive contact point integration, like pager duty notification.
 - Create specific routes for particular teams that handle their own onduty rotations.
 
 {{< figure max-width="40%" src="/static/img/docs/alerting/unified/notification-policies-8-0.png" max-width="650px" caption="Notification policies" >}}

--- a/docs/sources/alerting/set-up/provision-alerting-resources/file-provisioning/index.md
+++ b/docs/sources/alerting/set-up/provision-alerting-resources/file-provisioning/index.md
@@ -176,7 +176,7 @@ deleteContactPoints:
 #### Settings
 
 Here are some examples of settings you can use for the different
-contact point types.
+contact point integrations.
 
 ##### Alertmanager
 

--- a/docs/sources/developers/http_api/alerting_provisioning.md
+++ b/docs/sources/developers/http_api/alerting_provisioning.md
@@ -877,7 +877,7 @@ Status: Bad Request
 
 ### <span id="embedded-contact-point"></span> EmbeddedContactPoint
 
-> EmbeddedContactPoint is the contact point type that is used
+> EmbeddedContactPoint is the contact point integration that is used
 > by grafanas embedded alertmanager implementation.
 
 **Properties**

--- a/public/app/features/alerting/unified/Receivers.test.tsx
+++ b/public/app/features/alerting/unified/Receivers.test.tsx
@@ -96,7 +96,7 @@ const dataSources = {
 const ui = {
   newContactPointButton: byRole('link', { name: /new contact point/i }),
   saveContactButton: byRole('button', { name: /save contact point/i }),
-  newContactPointTypeButton: byRole('button', { name: /new contact point type/i }),
+  newContactPointIntegrationButton: byRole('button', { name: /new contact point integration/i }),
   testContactPointButton: byRole('button', { name: /Test/ }),
   testContactPointModal: byRole('heading', { name: /test contact point/i }),
   customContactPointOption: byRole('radio', { name: /custom/i }),
@@ -403,7 +403,7 @@ describe('Receivers', () => {
     await byText(/Fields \(1\)/i).get(slackContainer);
 
     // add another channel
-    await userEvent.click(ui.newContactPointTypeButton.get());
+    await userEvent.click(ui.newContactPointIntegrationButton.get());
     await clickSelectOption(await byTestId('items.2.type').find(), 'Webhook');
     await userEvent.type(await ui.inputs.webhook.URL.find(), 'http://webhookurl');
 

--- a/public/app/features/alerting/unified/components/receivers/form/ChannelSubForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/ChannelSubForm.tsx
@@ -96,7 +96,7 @@ export function ChannelSubForm<R extends ChannelValues>({
     <div className={styles.wrapper} data-testid="item-container">
       <div className={styles.topRow}>
         <div>
-          <Field label="Contact point type" htmlFor={contactPointTypeInputId} data-testid={`${pathPrefix}type`}>
+          <Field label="Type" htmlFor={contactPointTypeInputId} data-testid={`${pathPrefix}type`}>
             <InputControl
               name={name('type')}
               defaultValue={defaultValues.type}

--- a/public/app/features/alerting/unified/components/receivers/form/ChannelSubForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/ChannelSubForm.tsx
@@ -96,7 +96,7 @@ export function ChannelSubForm<R extends ChannelValues>({
     <div className={styles.wrapper} data-testid="item-container">
       <div className={styles.topRow}>
         <div>
-          <Field label="Type" htmlFor={contactPointTypeInputId} data-testid={`${pathPrefix}type`}>
+          <Field label="Integration" htmlFor={contactPointTypeInputId} data-testid={`${pathPrefix}type`}>
             <InputControl
               name={name('type')}
               defaultValue={defaultValues.type}

--- a/public/app/features/alerting/unified/components/receivers/form/ReceiverForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/ReceiverForm.tsx
@@ -159,7 +159,7 @@ export function ReceiverForm<R extends ChannelValues>({
               variant="secondary"
               onClick={() => append({ ...defaultItem, __id: String(Math.random()) } as R)}
             >
-              New contact point receiver
+              New contact point integration
             </Button>
           )}
           <div className={styles.buttons}>

--- a/public/app/features/alerting/unified/components/receivers/form/ReceiverForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/ReceiverForm.tsx
@@ -159,7 +159,7 @@ export function ReceiverForm<R extends ChannelValues>({
               variant="secondary"
               onClick={() => append({ ...defaultItem, __id: String(Math.random()) } as R)}
             >
-              New contact point type
+              New contact point receiver
             </Button>
           )}
           <div className={styles.buttons}>


### PR DESCRIPTION
**What is this feature?**

This commit renames contact point type to receiver in the user interface as "New contact point type" suggests that you are creating a new type, when instead you are just creating a new receiver of a pre-determined type, such as email or Slack. You can also have two or more receivers of the same type, something which is not apparent from the current text.

This change will also make it easier to explain the difference between a contact point "type", and how to configure a receiver of a certain type, such as email.

<img width="1240" alt="Screenshot 2022-11-30 at 15 46 54" src="https://user-images.githubusercontent.com/85952834/204843779-384928e5-db50-4317-b360-309f336e39b7.png">

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

