### PR TITLE
Fix release_branch_regexp

### DIFF
--- a/.github/workflows/publish-technical-documentation-release.yml
+++ b/.github/workflows/publish-technical-documentation-release.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           ref_name: "${{ github.ref_name }}"
           release_tag_regexp: "^v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$"
-          release_branch_regexp: "^v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)$"
+          release_branch_regexp: "^v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.x$"
 
       - name: "Determine technical documentation version"
         if: "steps.has-matching-release-tag.outputs.bool == 'true'"


### PR DESCRIPTION
Apparently the non-capturing group was incorrect.

I verified the logic in a branch in grafana-github-actions: https://github.com/grafana/grafana-github-actions/compare/jdb/2022-11-prove-grafana-regexp-behaves-correctly?expand=1

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>

