### PR TITLE
Apply linting advice from doc-validator tool

### DIFF
--- a/docs/sources/administration/api-keys/index.md
+++ b/docs/sources/administration/api-keys/index.md
@@ -48,7 +48,7 @@ This topic shows you how to create an API key using the Grafana UI. You can also
 ## Migrate API Keys to Grafana service accounts
 
 You can migrate one or all API keys to [Grafana service accounts]({{< relref "../service-accounts/" >}}). When you migrate an API key to a service account, a service account will be created with a service account token.
-The API key will continue to work, and you can find it in the [Grafana service account tokens]({{< relref "../service-accounts/#service-account-benefits/#service-account-tokens" >}}) details.
+The API key will continue to work, and you can find it in the [Grafana service account tokens]({{< relref "../service-accounts/#service-account-tokens" >}}) details.
 For more information about benefits of service accounts, refer to [Grafana service account benefits]({{< relref "../service-accounts/#service-account-benefits" >}}).
 
 You can choose to migrate a single API key or all API keys. Note that when you migrate all API keys, you can't create new API keys anymore and will have to use service accounts instead.

--- a/docs/sources/administration/data-source-management/index.md
+++ b/docs/sources/administration/data-source-management/index.md
@@ -127,7 +127,7 @@ You can make a panel retrieve fresh data more frequently by increasing the **Max
 
 ### Data sources that work with query caching
 
-Query caching works for all [Enterprise data sources](https://grafana.com/grafana/plugins/?type=datasource&enterprise=1) as well as the following [built-in data sources]({{< relref "../../datasources/" >}}):
+Query caching works for all [Enterprise data sources](/grafana/plugins/?type=datasource&enterprise=1) as well as the following [built-in data sources]({{< relref "../../datasources/" >}}):
 
 - CloudWatch Metrics
 - Google Cloud Monitoring

--- a/docs/sources/administration/enterprise-licensing/_index.md
+++ b/docs/sources/administration/enterprise-licensing/_index.md
@@ -14,7 +14,7 @@ keywords:
   - grafana
   - licensing
   - enterprise
-title: Enterprise licensing
+title: Grafana Enterprise license
 weight: 500
 ---
 
@@ -22,7 +22,7 @@ weight: 500
 
 When you become a Grafana Enterprise customer, you gain access to Grafana's premium observability features, including enterprise data source plugins, reporting, and role-based access control. In order to use these [enhanced features of Grafana Enterprise]({{< relref "../../introduction/grafana-enterprise" >}}), you must purchase and activate a Grafana Enterprise license.
 
-To purchase a license directly from Grafana Labs, [Contact a Grafana Labs representative](https://grafana.com/contact?about=grafana-enterprise). To activate an Enterprise license purchased from Grafana Labs, refer to [Activate an Enterprise license]({{< ref "#activate-an-enterprise-license" >}}).
+To purchase a license directly from Grafana Labs, [Contact a Grafana Labs representative](/contact?about=grafana-enterprise). To activate an Enterprise license purchased from Grafana Labs, refer to [Activate an Enterprise license]({{< relref "#activate-an-enterprise-license" >}}).
 
 You can also purchase a Grafana Enterprise license through the AWS Marketplace. To learn more about activating a license purchased through AWS, refer to [Activate a Grafana Enterprise license purchased through AWS Marketplace]({{< relref "./activate-aws-marketplace-license/" >}}).
 
@@ -36,7 +36,7 @@ Follow these steps to activate your Grafana Enterprise license:
 
 To download your Grafana Enterprise license:
 
-1. Sign in to your [Grafana Cloud](https://grafana.com) account.
+1. Sign in to your [Grafana Cloud](/) account.
 1. Go to **My Account** and select an organization from the drop-down menu at the top left of the page. On the Overview page for each organization, you can see a section for Grafana Enterprise licenses. Click **Details** next to a license.
 1. At the bottom of the license details page, select **Download token** to download the `license.jwt` file that contains your license.
 
@@ -81,9 +81,9 @@ environment variable.
 
 ### Step 3. Ensure that the license file's root URL matches the root_url configuration option
 
-Update the [`root_url`]({{< relref "../../setup-grafana/configure-grafana/#root-url" >}}) in your configuration. It should be the URL that users type in their browsers to access the frontend, not the node hostname(s).
+Update the [`root_url`]({{< relref "../../setup-grafana/configure-grafana/#root_url" >}}) in your configuration. It should be the URL that users type in their browsers to access the frontend, not the node hostname(s).
 
-This is important, because as part of the validation checks at startup, Grafana compares the license URL to the [`root_url`]({{< relref "../../setup-grafana/configure-grafana/#root-url" >}}) in your configuration.
+This is important, because as part of the validation checks at startup, Grafana compares the license URL to the [`root_url`]({{< relref "../../setup-grafana/configure-grafana/#root_url" >}}) in your configuration.
 
 In your configuration file:
 
@@ -119,7 +119,7 @@ If your license has expired, most of Grafana keeps working as normal. Some enter
 
    The configuration file's location may also be overridden by the `GF_ENTERPRISE_LICENSE_PATH` environment variable.
 
-2. Log in to your [Grafana Cloud Account](https://grafana.com/login) and make sure you're in the correct organization in the dropdown at the top of the page.
+2. Log in to your [Grafana Cloud Account](/login) and make sure you're in the correct organization in the dropdown at the top of the page.
 3. Under the **Grafana Enterprise** section in the menu bar to the left, choose licenses and download the currently valid license with which you want to run Grafana. If you cannot see a valid license on Grafana.com, please contact your account manager at Grafana Labs to renew your subscription.
 4. Replace the current `license.jwt`-file with the one you've just downloaded.
 5. [Restart Grafana]({{< relref "../../setup-grafana/restart-grafana/" >}}).
@@ -222,7 +222,7 @@ Your license is controlled by the following rules:
 
 **License expiration date:** The license includes an expiration date, which is the date when a license becomes inactive.
 
-As the license expiration date approaches, you will see a banner in Grafana that encourages you to renew. To learn about how to renew your license and what happens in Grafana when a license expires, refer to [License expiration]({{< ref "#license-expiration" >}}).
+As the license expiration date approaches, you will see a banner in Grafana that encourages you to renew. To learn about how to renew your license and what happens in Grafana when a license expires, refer to [License expiration]({{< relref "#license-expiration" >}}).
 
 **Grafana License URL:** Your license does not work with an instance of Grafana with a different root URL.
 
@@ -242,6 +242,6 @@ Usage billing involves a contractual agreement between you and Grafana Labs, and
 
 ### Request a change to your license
 
-To increase the number of licensed users within Grafana, extend a license, or change your licensed URL, contact [Grafana support](https://grafana.com/profile/org#support) or your Grafana Labs account team. They will update your license, which you can activate from within Grafana.
+To increase the number of licensed users within Grafana, extend a license, or change your licensed URL, contact [Grafana support](/profile/org#support) or your Grafana Labs account team. They will update your license, which you can activate from within Grafana.
 
-For instructions about how to activate your license after it is updated, refer to [Activate an Enterprise license]({{< ref "#activate-an-enterprise-license" >}}).
+For instructions about how to activate your license after it is updated, refer to [Activate an Enterprise license]({{< relref "#activate-an-enterprise-license" >}}).

--- a/docs/sources/administration/enterprise-licensing/activate-aws-marketplace-license/_index.md
+++ b/docs/sources/administration/enterprise-licensing/activate-aws-marketplace-license/_index.md
@@ -11,7 +11,7 @@ keywords:
   - marketplace
   - enterprise
   - license
-title: Enterprise licenses through AWS Marketplace
+title: Activate a Grafana Enterprise license purchased through AWS Marketplace
 weight: 400
 ---
 
@@ -28,7 +28,7 @@ You can deploy Grafana Enterprise in the following ways:
 
 In each case, you must activate the Grafana Enterprise license purchased in AWS Marketplace to take advantage of Grafana Enterprise observability features. Grafana Enterprise licenses purchased through AWS Marketplace are subject to the same [restrictions]({{< relref "../#license-restrictions" >}}) as Grafana Enterprise licensed purchased directly from Grafana Labs.
 
-> To purchase a license directly from Grafana Labs or learn more about other Grafana offerings, [Contact a Grafana Labs representative](https://grafana.com/contact?about=grafana-enterprise).
+> To purchase a license directly from Grafana Labs or learn more about other Grafana offerings, [Contact a Grafana Labs representative](/contact?about=grafana-enterprise).
 
 ## Before you begin
 

--- a/docs/sources/administration/enterprise-licensing/activate-aws-marketplace-license/manage-license-in-aws-marketplace/index.md
+++ b/docs/sources/administration/enterprise-licensing/activate-aws-marketplace-license/manage-license-in-aws-marketplace/index.md
@@ -39,4 +39,4 @@ You can use AWS Marketplace to make the following modifications to your Grafana 
 
    This action retrieves updated license information from AWS.
 
-> To learn more about licensing and active users, refer to [Understanding Grafana Enterprise licensing]({{< relref "../#license-restrictions" >}}).
+> To learn more about licensing and active users, refer to [Activate a Grafana Enterprise license purchased through AWS Marketplace]({{< relref "../" >}}).

--- a/docs/sources/administration/organization-preferences/index.md
+++ b/docs/sources/administration/organization-preferences/index.md
@@ -101,7 +101,7 @@ Here is an example of the light theme.
 
 ### Change server UI theme
 
-As a Grafana server administrator, you can change the default Grafana UI theme for all users who are on the server by setting the [default_theme]({{< relref "../../setup-grafana/configure-grafana/#default-theme" >}}) option in the Grafana configuration file.
+As a Grafana server administrator, you can change the default Grafana UI theme for all users who are on the server by setting the [default_theme]({{< relref "../../setup-grafana/configure-grafana/#default_theme" >}}) option in the Grafana configuration file.
 
 To see what the current settings are, refer to [View server settings]({{< relref "../stats-and-license#view-server-settings" >}}).
 
@@ -141,7 +141,7 @@ Some tasks require certain permissions. For more information about roles, refer 
 
 ### Set server timezone
 
-Grafana server administrators can choose a default timezone for all users on the server by setting the [default_timezone]({{< relref "../../setup-grafana/configure-grafana/#default-timezone" >}}) option in the Grafana configuration file.
+Grafana server administrators can choose a default timezone for all users on the server by setting the [default_timezone]({{< relref "../../setup-grafana/configure-grafana/#default_timezone" >}}) option in the Grafana configuration file.
 
 ### Set organization timezone
 
@@ -149,7 +149,7 @@ Organization administrators can choose a default timezone for their organization
 
 1. Hover your cursor over the **Configuration** (gear) icon.
 1. Click **Preferences**.
-1. Click to select an option in the **Timezone** list. **Default** is either the browser local timezone or the timezone selected at a higher level. Refer to [Time range controls]({{< relref "../../dashboards/manage-dashboards/#configure-dashboard-time-range-controls" >}}) for more information about Grafana time settings.
+1. Click to select an option in the **Timezone** list. **Default** is either the browser local timezone or the timezone selected at a higher level.
 1. Click **Save**.
 
 ### Set team timezone
@@ -160,7 +160,7 @@ Organization administrators and team administrators can choose a default timezon
 1. Click **Teams**. Grafana displays the team list.
 1. Click the team for which you want to change the timezone.
 1. Click **Settings**
-1. Click to select an option in the **Timezone** list. **Default** is either the browser local timezone or the timezone selected at a higher level. Refer to [[Time range controls]({{< relref "../../dashboards/manage-dashboards/#configure-dashboard-time-range-controls" >}}) for more information about Grafana time settings.
+1. Click to select an option in the **Timezone** list. **Default** is either the browser local timezone or the timezone selected at a higher level.
 1. Click **Save**.
 
 ### Set your personal timezone
@@ -168,7 +168,7 @@ Organization administrators and team administrators can choose a default timezon
 You can change the timezone for your user account. This setting overrides timezone settings at higher levels.
 
 1. On the left menu, hover your cursor over your avatar and then click **Preferences**.
-1. Click to select an option in the **Timezone** list. **Default** is either the browser local timezone or the timezone selected at a higher level. Refer to [Time range controls]({{< relref "../../dashboards/manage-dashboards/#configure-dashboard-time-range-controls" >}}) for more information about Grafana time settings.
+1. Click to select an option in the **Timezone** list. **Default** is either the browser local timezone or the timezone selected at a higher level.
 1. Click **Save**.
 
 ## Change the default home dashboard
@@ -245,7 +245,7 @@ You can choose your own personal home dashboard. This setting overrides all home
 
 ### Change server language
 
-Grafana server administrators can change the default Grafana UI language for all users on the server by setting the [default_language]({{< relref "../../setup-grafana/configure-grafana/#default-language" >}}) option in the Grafana configuration file.
+Grafana server administrators can change the default Grafana UI language for all users on the server by setting the [default_language]({{< relref "../../setup-grafana/configure-grafana/#default_language" >}}) option in the Grafana configuration file.
 
 ### Change organization language
 

--- a/docs/sources/administration/plugin-management/index.md
+++ b/docs/sources/administration/plugin-management/index.md
@@ -14,13 +14,13 @@ weight: 600
 
 Besides the wide range of visualizations and data sources that are available immediately after you install Grafana, you can extend your Grafana experience with _plugins_.
 
-You can [install]({{< ref "#install-a-plugin" >}}) one of the plugins built by the Grafana community, or [build one yourself]({{< relref "../../developers/plugins/" >}}).
+You can [install]({{< relref "#install-a-plugin" >}}) one of the plugins built by the Grafana community, or [build one yourself]({{< relref "../../developers/plugins/" >}}).
 
-Grafana supports three types of plugins: [panels](https://grafana.com/grafana/plugins?type=panel), [data sources](https://grafana.com/grafana/plugins?type=datasource), and [apps](https://grafana.com/grafana/plugins?type=app).
+Grafana supports three types of plugins: [panels](/grafana/plugins?type=panel), [data sources](/plugins?type=datasource), and [apps](/grafana/plugins?type=app).
 
 ## Panel plugins
 
-Add new visualizations to your dashboard with panel plugins, such as the [Worldmap Panel](https://grafana.com/grafana/plugins/grafana-worldmap-panel), [Clock](https://grafana.com/grafana/plugins/grafana-clock-panel), and [Pie Chart](https://grafana.com/grafana/plugins/grafana-piechart-panel).
+Add new visualizations to your dashboard with panel plugins, such as the [Worldmap Panel](/grafana/plugins/grafana-worldmap-panel), [Clock](/grafana/plugins/grafana-clock-panel), and [Pie Chart](/grafana/plugins/grafana-piechart-panel).
 
 Use panel plugins when you want to:
 
@@ -30,7 +30,7 @@ Use panel plugins when you want to:
 
 ## Data source plugins
 
-Data source plugins add support for new databases, such as [Google BigQuery](https://grafana.com/grafana/plugins/doitintl-bigquery-datasource).
+Data source plugins add support for new databases, such as [Google BigQuery](/grafana/plugins/doitintl-bigquery-datasource).
 
 Data source plugins communicate with external sources of data and return the data in a format that Grafana understands. By adding a data source plugin, you can immediately use the data in any of your existing dashboards.
 
@@ -38,7 +38,7 @@ Use data source plugins when you want to import data from external systems.
 
 ## App plugins
 
-Applications, or _app plugins_, bundle data sources and panels to provide a cohesive experience, such as the [Zabbix](https://grafana.com/grafana/plugins/alexanderzobnin-zabbix-app) app.
+Applications, or _app plugins_, bundle data sources and panels to provide a cohesive experience, such as the [Zabbix](/grafana/plugins/alexanderzobnin-zabbix-app) app.
 
 Apps can also add custom pages for things like control panels.
 
@@ -123,7 +123,7 @@ When the update is complete, you see a confirmation message that the uninstall w
 
 Grafana supports data source, panel, and app plugins. Having panels as plugins makes it easy to create and add any kind of panel, to show your data, or improve your favorite dashboards. Apps enable the bundling of data sources, panels, dashboards, and Grafana pages into a cohesive experience.
 
-1. In a web browser, navigate to the official [Grafana Plugins page](https://grafana.com/plugins) and find a plugin that you want to install.
+1. In a web browser, navigate to the official [Grafana Plugins page](/plugins) and find a plugin that you want to install.
 1. Click the plugin, and then click the **Installation** tab.
 
 ### Install plugin on Grafana Cloud
@@ -140,7 +140,7 @@ Follow the instructions on the Install tab. You can either install the plugin wi
 
 For more information about Grafana CLI plugin commands, refer to [Plugin commands]({{< relref "../../cli/#plugins-commands" >}}).
 
-As of Grafana v8.0, a plugin catalog app was introduced in order to make managing plugins easier. For more information, refer to [Plugin catalog]({{< ref "#plugin-catalog" >}}).
+As of Grafana v8.0, a plugin catalog app was introduced in order to make managing plugins easier. For more information, refer to [Plugin catalog]({{< relref "#plugin-catalog" >}}).
 
 #### Install a packaged plugin
 
@@ -200,4 +200,4 @@ WARN[06-01|16:45:59] Running an unsigned plugin   pluginID=<plugin id>
 
 ## Learn more
 
-- Browse the available [Plugins](https://grafana.com/grafana/plugins)
+- Browse the available [Plugins](/grafana/plugins)

--- a/docs/sources/administration/provisioning/index.md
+++ b/docs/sources/administration/provisioning/index.md
@@ -131,7 +131,7 @@ datasources:
     # <map> Fields to convert to JSON and store in jsonData.
     jsonData:
       # <string> Defines the Graphite service's version.
-      graphiteVersion: "1.1"
+      graphiteVersion: '1.1'
       # <bool> Enables TLS authentication using a client
       # certificate configured in secureJsonData.
       tlsAuth: true
@@ -142,9 +142,9 @@ datasources:
     secureJsonData:
       # <string> Defines the CA cert, client cert, and
       # client key for encrypted authentication.
-      tlsCACert: "..."
-      tlsClientCert: "..."
-      tlsClientKey: "..."
+      tlsCACert: '...'
+      tlsClientCert: '...'
+      tlsClientKey: '...'
       # <string> Sets the database password, if necessary.
       password:
       # <string> Sets the basic authorization password.
@@ -248,11 +248,11 @@ apiVersion: 1
 datasources:
   - name: Graphite
     jsonData:
-      httpHeaderName1: "HeaderName"
-      httpHeaderName2: "Authorization"
+      httpHeaderName1: 'HeaderName'
+      httpHeaderName2: 'Authorization'
     secureJsonData:
-      httpHeaderValue1: "HeaderValue"
-      httpHeaderValue2: "Bearer XXXXXXXXX"
+      httpHeaderValue1: 'HeaderValue'
+      httpHeaderValue2: 'Bearer XXXXXXXXX'
 ```
 
 ## Plugins
@@ -299,13 +299,13 @@ apiVersion: 1
 
 providers:
   # <string> an unique provider name. Required
-  - name: "a unique provider name"
+  - name: 'a unique provider name'
     # <int> Org id. Default to 1
     orgId: 1
     # <string> name of the dashboard folder.
-    folder: ""
+    folder: ''
     # <string> folder UID. will be automatically generated if not specified
-    folderUid: ""
+    folderUid: ''
     # <string> provider type. Default to 'file'
     type: file
     # <bool> disable dashboard deletion
@@ -444,13 +444,13 @@ notifiers:
     # See `Supported Settings` section for settings supported for each
     # alert notification type.
     settings:
-      recipient: "XXX"
+      recipient: 'XXX'
       uploadImage: true
-      token: "xoxb" # legacy setting since Grafana v7.2 (stored non-encrypted)
+      token: 'xoxb' # legacy setting since Grafana v7.2 (stored non-encrypted)
       url: https://slack.com # legacy setting since Grafana v7.2 (stored non-encrypted)
     # Secure settings that will be encrypted in the database (supported since Grafana v7.2). See `Supported Settings` section for secure settings supported for each notifier.
     secure_settings:
-      token: "xoxb"
+      token: 'xoxb'
       url: https://slack.com
 
 delete_notifiers:

--- a/docs/sources/administration/provisioning/index.md
+++ b/docs/sources/administration/provisioning/index.md
@@ -131,7 +131,7 @@ datasources:
     # <map> Fields to convert to JSON and store in jsonData.
     jsonData:
       # <string> Defines the Graphite service's version.
-      graphiteVersion: '1.1'
+      graphiteVersion: "1.1"
       # <bool> Enables TLS authentication using a client
       # certificate configured in secureJsonData.
       tlsAuth: true
@@ -142,9 +142,9 @@ datasources:
     secureJsonData:
       # <string> Defines the CA cert, client cert, and
       # client key for encrypted authentication.
-      tlsCACert: '...'
-      tlsClientCert: '...'
-      tlsClientKey: '...'
+      tlsCACert: "..."
+      tlsClientCert: "..."
+      tlsClientKey: "..."
       # <string> Sets the database password, if necessary.
       password:
       # <string> Sets the basic authorization password.
@@ -248,11 +248,11 @@ apiVersion: 1
 datasources:
   - name: Graphite
     jsonData:
-      httpHeaderName1: 'HeaderName'
-      httpHeaderName2: 'Authorization'
+      httpHeaderName1: "HeaderName"
+      httpHeaderName2: "Authorization"
     secureJsonData:
-      httpHeaderValue1: 'HeaderValue'
-      httpHeaderValue2: 'Bearer XXXXXXXXX'
+      httpHeaderValue1: "HeaderValue"
+      httpHeaderValue2: "Bearer XXXXXXXXX"
 ```
 
 ## Plugins
@@ -299,13 +299,13 @@ apiVersion: 1
 
 providers:
   # <string> an unique provider name. Required
-  - name: 'a unique provider name'
+  - name: "a unique provider name"
     # <int> Org id. Default to 1
     orgId: 1
     # <string> name of the dashboard folder.
-    folder: ''
+    folder: ""
     # <string> folder UID. will be automatically generated if not specified
-    folderUid: ''
+    folderUid: ""
     # <string> provider type. Default to 'file'
     type: file
     # <bool> disable dashboard deletion
@@ -392,11 +392,11 @@ providers:
 
 ## Alerting
 
-For information on provisioning Grafana Alerting, refer to [Provision Grafana Alerting resources](https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/).
+For information on provisioning Grafana Alerting, refer to [Provision Grafana Alerting resources]({{< relref "../../alerting/set-up/provision-alerting-resources/"  >}}).
 
 ## Alert Notification Channels
 
-> **Note:** Alert Notification Channels are part of legacy alerting, which is deprecated and will be removed in Grafana 10. Use the Provision contact points section in [Create and manage alerting resources using file provisioning](https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/file-provisioning/).
+> **Note:** Alert Notification Channels are part of legacy alerting, which is deprecated and will be removed in Grafana 10. Use the Provision contact points section in [Create and manage alerting resources using file provisioning]({{< relref "../../alerting/set-up/provision-alerting-resources/file-provisioning" >}}).
 
 Alert Notification Channels can be provisioned by adding one or more YAML config files in the [`provisioning/notifiers`](/administration/configuration/#provisioning) directory.
 
@@ -444,13 +444,13 @@ notifiers:
     # See `Supported Settings` section for settings supported for each
     # alert notification type.
     settings:
-      recipient: 'XXX'
+      recipient: "XXX"
       uploadImage: true
-      token: 'xoxb' # legacy setting since Grafana v7.2 (stored non-encrypted)
+      token: "xoxb" # legacy setting since Grafana v7.2 (stored non-encrypted)
       url: https://slack.com # legacy setting since Grafana v7.2 (stored non-encrypted)
     # Secure settings that will be encrypted in the database (supported since Grafana v7.2). See `Supported Settings` section for secure settings supported for each notifier.
     secure_settings:
-      token: 'xoxb'
+      token: "xoxb"
       url: https://slack.com
 
 delete_notifiers:

--- a/docs/sources/administration/recorded-queries/index.md
+++ b/docs/sources/administration/recorded-queries/index.md
@@ -24,11 +24,11 @@ For our plugins that do not return time series, it might be useful to plot histo
 
 > **Note:** An administrator must configure a Prometheus data source and associate it with a [Remote write target](#remote-write-target) before recorded queries can be used.
 
-Recorded queries only work with backend data source plugins. Refer to [Backend data source plugin](https://grafana.com/tutorials/build-a-data-source-backend-plugin/) for more information about backend data source plugins. You can recorded three types of queries:
+Recorded queries only work with backend data source plugins. Refer to [Backend data source plugin](/tutorials/build-a-data-source-backend-plugin/) for more information about backend data source plugins. You can recorded three types of queries:
 
 - single row and column - A query that returns a single row and column.
 - row count - A query that returns meaningful rows to be counted.
-- expression - Any expression. To learn more about creating and using expressions, see [Expressions](https://grafana.com/docs/grafana/latest/panels/expressions/).
+- expression - Any expression. To learn more about creating and using expressions, see [Write expression queries]({{< relref "../../panels-visualizations/query-transform-data/expression-queries" >}}).
 
 After a recorded query is created or enabled, it immediately creates a snapshot and continues to create snapshots at the set interval. The recorded query stops taking snapshots when it is disabled, deleted, or when Grafana is not running. Data points are gathered in the backend by running the recorded query and forwarding each result to a remote-write enabled Prometheus instance.
 
@@ -40,7 +40,7 @@ To use a recorded query, create one and add it to a dashboard. After that, it ca
 
 1.  Find/create a query you want to record on a dashboard in an edit panel. The query must only return one row and column. If it returns more, you can still record the number of results returned using the “count” option.
     - The query's data source must be a backend data source.
-    - Expressions can be used to aggregate data from a time series query. Refer to [Expressions](https://grafana.com/docs/grafana/latest/panels/expressions/) to learn more about creating and using expressions.
+    - Expressions can be used to aggregate data from a time series query. Refer to [Write expression queries]({{< relref "../../panels-visualizations/query-transform-data/expression-queries" >}}) to learn more about creating and using expressions.
 1.  Click the record query button located in the top right of the query editor.
 1.  Enter recorded query information. All fields are required unless otherwise indicated.
     - Name - Name of the recorded query.
@@ -60,7 +60,7 @@ You can add existing recorded queries to panels in a dashboard. For each recorde
 1. If you want to filter recorded queries by data source, select a data source from the filter by data source drop down menu.
 1. Click the `Add` button on your recorded query to add it to the panel.
 
-After adding your recorded query to the panel, the panel data source will become `-- Mixed --`. Your recorded query is represented by a `Prometheus` query with a name label matching your recorded query name. Refer to [Prometheus](https://grafana.com/docs/grafana/latest/datasources/prometheus/) to learn more about the `Prometheus` data source.
+After adding your recorded query to the panel, the panel data source will become `-- Mixed --`. Your recorded query is represented by a `Prometheus` query with a name label matching your recorded query name. Refer to [Prometheus]({{< relref "../../datasources/prometheus/" >}}) to learn more about the `Prometheus` data source.
 
 If after adding a recorded query, a query with a `-- Mixed --` data source instead of `Prometheus` data source appears, this could mean that a Prometheus remote write target was not set up for recorded queries. Refer to [Remote write target](#remote-write-target) to set up a remote write point.
 

--- a/docs/sources/administration/roles-and-permissions/_index.md
+++ b/docs/sources/administration/roles-and-permissions/_index.md
@@ -27,7 +27,7 @@ You can assign a user one of three types of permissions:
 
 A Grafana server administrator manages server-wide settings and access to resources such as organizations, users, and licenses. Grafana includes a default server administrator that you can use to manage all of Grafana, or you can divide that responsibility among other server administrators that you create.
 
-> **Note:** The server administrator role does not mean that the user is also a Grafana [organization administrator]({{< ref "#organization-roles" >}}).
+> **Note:** The server administrator role does not mean that the user is also a Grafana [organization administrator]({{< relref "#organization-roles" >}}).
 
 A server administrator can perform the following tasks:
 
@@ -124,7 +124,7 @@ For more information about assigning administrator permissions to editors, refer
 If you have access to the Grafana server, you can modify the default viewer role so that viewers can:
 
 - Edit and preview dashboards, but cannot save their changes or create new dashboards.
-- Access and use [Explore]({{< ref "/explore" >}}).
+- Access and use [Explore]({{< relref "../../explore" >}}).
 
 Extending the viewer role is useful for public Grafana installations where you want anonymous users to be able to edit panels and queries, but not be able to save or create new dashboards.
 

--- a/docs/sources/dashboards/_index.md
+++ b/docs/sources/dashboards/_index.md
@@ -22,7 +22,6 @@ Before you begin, ensure that you have configured a data source. See also:
 - [Annotations]({{< relref "./build-dashboards/annotate-visualizations" >}})
 - [Playlist]({{< relref "./create-manage-playlists/" >}})
 - [Reporting]({{< relref "./create-reports" >}})
-- [Time range controls]({{< relref "./manage-dashboards/#common-time-range-controls" >}})
 - [Version history]({{< relref "./build-dashboards/manage-version-history" >}})
 - [Export and import]({{< relref "./manage-dashboards/#export-and-import-dashboards" >}})
 - [JSON model]({{< relref "./build-dashboards/view-dashboard-json-model/" >}})

--- a/docs/sources/dashboards/manage-dashboards/index.md
+++ b/docs/sources/dashboards/manage-dashboards/index.md
@@ -37,7 +37,6 @@ This topic includes techniques you can use to manage your Grafana dashboards, in
 
 - [Creating and managing dashboard folders](#create-and-manage-dashboard-folders)
 - [Exporting and importing dashboards](#export-and-import-dashboards)
-- [Configuring dashboard time range controls](#configure-dashboard-time-range-controls)
 - [Organizing dashboards](#organize-a-dashboard)
 - [Troubleshooting dashboards](#troubleshoot-dashboards)
 

--- a/docs/sources/panels-visualizations/panel-editor-overview/index.md
+++ b/docs/sources/panels-visualizations/panel-editor-overview/index.md
@@ -40,7 +40,7 @@ This section describes the areas of the Grafana panel editor.
    - **Table view:** Convert any visualization to a table so that you can see the data. Table views are useful for troubleshooting.
    - **Fill:** The visualization preview fills the available space. If you change the width of the side pane or height of the bottom pane the visualization changes to fill the available space.
    - **Actual:** The visualization preview will have the exact size as the size on the dashboard. If not enough space is available, the visualization will scale down preserving the aspect ratio.
-   - **Time range controls:** For more information, refer to [Time range controls]({{< relref "../../dashboards/manage-dashboards/#configure-dashboard-time-range-controls" >}}).
+   - **Time range controls:** **Default** is either the browser local timezone or the timezone selected at a higher level.
 
 1. Data section: The data section contains tabs where you enter queries, transform your data, and create alert rules (if applicable).
 

--- a/docs/sources/panels-visualizations/query-transform-data/_index.md
+++ b/docs/sources/panels-visualizations/query-transform-data/_index.md
@@ -179,8 +179,6 @@ Panel data source query options include:
 - **Time shift:** Overrides the time range for individual panels by shifting its start and end relative to the time picker.
   For example, you can shift the time range for the panel to be two hours earlier than the dashboard time picker.
 
-  For more information, refer to [Time range controls]({{< relref "../../dashboards/manage-dashboards/#configure-dashboard-time-range-controls" >}}).
-
   > **Note:** Panel time overrides have no effect when the dashboard's time range is absolute.
 
   | Example              | Time shift field |

--- a/docs/sources/shared/preferences/select-timezone-list.md
+++ b/docs/sources/shared/preferences/select-timezone-list.md
@@ -4,5 +4,5 @@ aliases:
 title: Select home dashboard list
 ---
 
-1. Click to select an option in the **Timezone** list. **Default** is either the browser local timezone or the timezone selected at a higher level. Refer to [Time range controls]({{< relref "../../dashboards/time-range-controls/" >}}) for more information about Grafana time settings.
+1. Click to select an option in the **Timezone** list. **Default** is either the browser local timezone or the timezone selected at a higher level.
 1. Click **Save**.


### PR DESCRIPTION
This fixes a subset of linting errors found by the `doc-validator` tool.

The command that was run was:

```
docker run -w / -v "$(pwd)/docs/sources:/docs/sources" grafana/doc-validator:v1.5.0 -skip-image-validation ./docs/sources
```

The errors are defined in the errata of the tool at https://github.com/grafana/technical-documentation/blob/main/tools/doc-validator/errata.hcl.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>

