### PR TITLE
Graphite: Process multiple queries to Graphite plugin

### DIFF
--- a/pkg/services/publicdashboards/service/service.go
+++ b/pkg/services/publicdashboards/service/service.go
@@ -168,13 +168,9 @@ func (pd *PublicDashboardServiceImpl) Create(ctx context.Context, u *user.Signed
 		},
 	}
 
-	affectedRows, err := pd.store.Create(ctx, cmd)
+	_, err = pd.store.Create(ctx, cmd)
 	if err != nil {
 		return nil, ErrInternalServerError.Errorf("Create: failed to create the public dashboard: %w", err)
-	}
-
-	if affectedRows == 0 {
-		return nil, ErrPublicDashboardNotFound.Errorf("Create: failed to create a public dashboard with Uid: %s", uid)
 	}
 
 	//Get latest public dashboard to return

--- a/pkg/services/publicdashboards/service/service.go
+++ b/pkg/services/publicdashboards/service/service.go
@@ -168,9 +168,13 @@ func (pd *PublicDashboardServiceImpl) Create(ctx context.Context, u *user.Signed
 		},
 	}
 
-	_, err = pd.store.Create(ctx, cmd)
+	affectedRows, err := pd.store.Create(ctx, cmd)
 	if err != nil {
 		return nil, ErrInternalServerError.Errorf("Create: failed to create the public dashboard: %w", err)
+	}
+
+	if affectedRows == 0 {
+		return nil, ErrPublicDashboardNotFound.Errorf("Create: failed to create a public dashboard with Uid: %s", uid)
 	}
 
 	//Get latest public dashboard to return

--- a/pkg/tsdb/graphite/graphite.go
+++ b/pkg/tsdb/graphite/graphite.go
@@ -122,7 +122,7 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 
 	var result = backend.QueryDataResponse{}
 	if len(emptyQueries) != 0 {
-		logger.Error("Found query models without targets", "models without targets", strings.Join(emptyQueries, "\n"))
+		logger.Warn("Found query models without targets", "models without targets", strings.Join(emptyQueries, "\n"))
 		// If no queries had a valid target, return an error; otherwise, attempt with the targets we have
 		if len(emptyQueries) == len(req.Queries) {
 			return &result, errors.New("no query target found for the alert rule")

--- a/pkg/tsdb/graphite/graphite.go
+++ b/pkg/tsdb/graphite/graphite.go
@@ -261,12 +261,15 @@ func (s *Service) toDataFrames(logger log.Logger, response *http.Response, origR
 		values := make([]*float64, 0, len(series.DataPoints))
 		// series.Target will be in the format <resolvedSeriesName> <formattedRefId>
 		ls := strings.LastIndex(series.Target, " ")
+		if ls == -1 {
+			return nil, fmt.Errorf("received graphite response with invalid target format: %s", series.Target)
+		}
 		target := series.Target[:ls]
 		formattedRefId := series.Target[ls+1:]
 		refId, ok := origRefIds[formattedRefId]
 		if !ok {
-			// fallback - shouldn't happen except for in tests
-			refId = formattedRefId
+			logger.Warn("Unable to find refId associated with provided formattedRefId", "formattedRefId", formattedRefId)
+			refId = formattedRefId // fallback - shouldn't happen except for in tests
 		}
 
 		for _, dataPoint := range series.DataPoints {

--- a/pkg/tsdb/graphite/graphite_test.go
+++ b/pkg/tsdb/graphite/graphite_test.go
@@ -1,7 +1,9 @@
 package graphite
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"reflect"
@@ -9,7 +11,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -48,7 +53,103 @@ func TestFixIntervalFormat(t *testing.T) {
 			assert.Equal(t, tc.expected, tr)
 		})
 	}
+}
 
+func TestProcessQueries(t *testing.T) {
+	service := &Service{}
+	log := logger.FromContext(context.Background())
+	t.Run("Parses single valid query", func(t *testing.T) {
+		queries := []backend.DataQuery{
+			{
+				RefID: "A",
+				JSON: []byte(`{
+					"target": "app.grafana.*.dashboards.views.1M.count"
+				}`),
+			},
+		}
+		targets, invalids, mapping, err := service.processQueries(log, queries)
+		assert.NoError(t, err)
+		assert.Empty(t, invalids)
+		assert.Len(t, mapping, 1)
+		assert.Len(t, targets, 1)
+		assert.Equal(t, "aliasSub(app.grafana.*.dashboards.views.1M.count,\"(^.*$)\",\"\\1 A\")", targets[0])
+	})
+
+	t.Run("Parses multiple valid queries with refId mappings", func(t *testing.T) {
+		queries := []backend.DataQuery{
+			{
+				RefID: "A",
+				JSON: []byte(`{
+					"target": "app.grafana.*.dashboards.views.1M.count"
+				}`),
+			},
+			{
+				RefID: "query B",
+				JSON: []byte(`{
+					"target": "aliasByNode(hitcount(averageSeries(app.grafana.*.dashboards.views.count), '1mon'), 4)"
+				}`),
+			},
+		}
+		targets, invalids, mapping, err := service.processQueries(log, queries)
+		assert.NoError(t, err)
+		assert.Empty(t, invalids)
+		assert.Len(t, mapping, 2)
+		assert.Len(t, targets, 2)
+		assert.Equal(t, "aliasSub(app.grafana.*.dashboards.views.1M.count,\"(^.*$)\",\"\\1 A\")", targets[0])
+		assert.Equal(t, "aliasSub(aliasByNode(hitcount(averageSeries(app.grafana.*.dashboards.views.count), '1mon'), 4),\"(^.*$)\",\"\\1 query_B\")", targets[1])
+	})
+
+	t.Run("Parses multiple queries with one invalid", func(t *testing.T) {
+		queries := []backend.DataQuery{
+			{
+				RefID: "A",
+				JSON: []byte(`{
+					"target": "app.grafana.*.dashboards.views.1M.count"
+				}`),
+			},
+			{
+				RefID: "B",
+				JSON: []byte(`{
+					"query": "app.grafana.*.dashboards.views.1M.count"
+				}`),
+			},
+		}
+		targets, invalids, mapping, err := service.processQueries(log, queries)
+		assert.NoError(t, err)
+		assert.Len(t, invalids, 1)
+		assert.Len(t, mapping, 1)
+		assert.Len(t, targets, 1)
+		json, _ := simplejson.NewJson(queries[1].JSON)
+		expectedInvalid := fmt.Sprintf("Query: %v has no target", json)
+		assert.Equal(t, expectedInvalid, invalids[0])
+	})
+
+	t.Run("QueryData with no valid queries returns an error", func(t *testing.T) {
+		queries := []backend.DataQuery{
+			{
+				RefID: "A",
+				JSON: []byte(`{
+					"query": "app.grafana.*.dashboards.views.1M.count"
+				}`),
+			},
+			{
+				RefID: "B",
+				JSON: []byte(`{
+					"query": "app.grafana.*.dashboards.views.1M.count"
+				}`),
+			},
+		}
+
+		service.im = fakeInstanceManager{}
+		_, err := service.QueryData(context.Background(), &backend.QueryDataRequest{
+			Queries: queries,
+		})
+		assert.Error(t, err)
+		assert.Equal(t, err.Error(), "no query target found for the alert rule")
+	})
+}
+
+func TestConvertResponses(t *testing.T) {
 	service := &Service{}
 
 	t.Run("Converts response without tags to data frames", func(*testing.T) {
@@ -110,4 +211,89 @@ func TestFixIntervalFormat(t *testing.T) {
 			t.Errorf("Data frames should have been equal but was, expected:\n%s\nactual:\n%s", expectedFramesJSON, dataFramesJSON)
 		}
 	})
+
+	t.Run("Converts response with multiple targets", func(*testing.T) {
+		body := `
+		[
+			{
+				"target": "target 1 A",
+				"datapoints": [[50, 1], [null, 2], [100, 3]]
+			},
+			{
+				"target": "target 2 B",
+				"datapoints": [[50, 1], [null, 2], [100, 3]]
+			}
+		]`
+		a := 50.0
+		b := 100.0
+		expectedFrameA := data.NewFrame("A",
+			data.NewField("time", nil, []time.Time{time.Unix(1, 0).UTC(), time.Unix(2, 0).UTC(), time.Unix(3, 0).UTC()}),
+			data.NewField("value", data.Labels{}, []*float64{&a, nil, &b}).SetConfig(&data.FieldConfig{DisplayNameFromDS: "target 1"}),
+		)
+		expectedFrameB := data.NewFrame("B",
+			data.NewField("time", nil, []time.Time{time.Unix(1, 0).UTC(), time.Unix(2, 0).UTC(), time.Unix(3, 0).UTC()}),
+			data.NewField("value", data.Labels{}, []*float64{&a, nil, &b}).SetConfig(&data.FieldConfig{DisplayNameFromDS: "target 2"}),
+		)
+		expectedFrames := data.Frames{expectedFrameA, expectedFrameB}
+
+		httpResponse := &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(body))}
+		dataFrames, err := service.toDataFrames(logger, httpResponse, map[string]string{})
+
+		require.NoError(t, err)
+		if !reflect.DeepEqual(expectedFrames, dataFrames) {
+			expectedFramesJSON, _ := json.Marshal(expectedFrames)
+			dataFramesJSON, _ := json.Marshal(dataFrames)
+			t.Errorf("Data frames should have been equal but was, expected:\n%s\nactual:\n%s", expectedFramesJSON, dataFramesJSON)
+		}
+	})
+
+	t.Run("Converts response with refId mapping", func(*testing.T) {
+		body := `
+		[
+			{
+				"target": "target A_A",
+				"datapoints": [[50, 1], [null, 2], [100, 3]]
+			}
+		]`
+		a := 50.0
+		b := 100.0
+		expectedFrame := data.NewFrame("A A",
+			data.NewField("time", nil, []time.Time{time.Unix(1, 0).UTC(), time.Unix(2, 0).UTC(), time.Unix(3, 0).UTC()}),
+			data.NewField("value", data.Labels{}, []*float64{&a, nil, &b}).SetConfig(&data.FieldConfig{DisplayNameFromDS: "target"}),
+		)
+		expectedFrames := data.Frames{expectedFrame}
+
+		httpResponse := &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(body))}
+		dataFrames, err := service.toDataFrames(logger, httpResponse, map[string]string{"A_A": "A A"})
+
+		require.NoError(t, err)
+		if !reflect.DeepEqual(expectedFrames, dataFrames) {
+			expectedFramesJSON, _ := json.Marshal(expectedFrames)
+			dataFramesJSON, _ := json.Marshal(dataFrames)
+			t.Errorf("Data frames should have been equal but was, expected:\n%s\nactual:\n%s", expectedFramesJSON, dataFramesJSON)
+		}
+	})
+
+	t.Run("Chokes on response with invalid target name", func(*testing.T) {
+		body := `
+		[
+			{
+				"target": "target",
+				"datapoints": [[50, 1], [null, 2], [100, 3]]
+			}
+		]`
+		httpResponse := &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(body))}
+		_, err := service.toDataFrames(logger, httpResponse, map[string]string{})
+		require.Error(t, err)
+	})
+}
+
+type fakeInstanceManager struct{}
+
+func (f fakeInstanceManager) Get(pluginContext backend.PluginContext) (instancemgmt.Instance, error) {
+	return datasourceInfo{}, nil
+}
+
+func (f fakeInstanceManager) Do(pluginContext backend.PluginContext, fn instancemgmt.InstanceCallbackFunc) error {
+	return nil
 }

--- a/pkg/tsdb/graphite/graphite_test.go
+++ b/pkg/tsdb/graphite/graphite_test.go
@@ -55,20 +55,20 @@ func TestFixIntervalFormat(t *testing.T) {
 		body := `
 		[
 			{
-				"target": "target",
+				"target": "target A",
 				"datapoints": [[50, 1], [null, 2], [100, 3]]
 			}
 		]`
 		a := 50.0
 		b := 100.0
-		expectedFrame := data.NewFrame("target",
+		expectedFrame := data.NewFrame("A",
 			data.NewField("time", nil, []time.Time{time.Unix(1, 0).UTC(), time.Unix(2, 0).UTC(), time.Unix(3, 0).UTC()}),
 			data.NewField("value", data.Labels{}, []*float64{&a, nil, &b}).SetConfig(&data.FieldConfig{DisplayNameFromDS: "target"}),
 		)
 		expectedFrames := data.Frames{expectedFrame}
 
 		httpResponse := &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(body))}
-		dataFrames, err := service.toDataFrames(logger, httpResponse)
+		dataFrames, err := service.toDataFrames(logger, httpResponse, map[string]string{})
 
 		require.NoError(t, err)
 		if !reflect.DeepEqual(expectedFrames, dataFrames) {
@@ -82,14 +82,14 @@ func TestFixIntervalFormat(t *testing.T) {
 		body := `
 		[
 			{
-				"target": "target",
+				"target": "target A",
 				"tags": { "fooTag": "fooValue", "barTag": "barValue", "int": 100, "float": 3.14 },
 				"datapoints": [[50, 1], [null, 2], [100, 3]]
 			}
 		]`
 		a := 50.0
 		b := 100.0
-		expectedFrame := data.NewFrame("target",
+		expectedFrame := data.NewFrame("A",
 			data.NewField("time", nil, []time.Time{time.Unix(1, 0).UTC(), time.Unix(2, 0).UTC(), time.Unix(3, 0).UTC()}),
 			data.NewField("value", data.Labels{
 				"fooTag": "fooValue",
@@ -101,7 +101,7 @@ func TestFixIntervalFormat(t *testing.T) {
 		expectedFrames := data.Frames{expectedFrame}
 
 		httpResponse := &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(body))}
-		dataFrames, err := service.toDataFrames(logger, httpResponse)
+		dataFrames, err := service.toDataFrames(logger, httpResponse, map[string]string{})
 
 		require.NoError(t, err)
 		if !reflect.DeepEqual(expectedFrames, dataFrames) {


### PR DESCRIPTION
**What is this feature?**

Updates the Graphite datasource plugin to handle multiple queries, instead of just the last one in the list. It aliases each query in order to correlate queries with results.

**Why do we need this feature?**

The current behavior is causing issues in public dashboards, which we had previously not seen because the front end sends graphite queries to Graphite through the proxy instead of through /ds/query.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/59601

**Special notes for your reviewer**:

There is some less-than-ideal code in here to handle associating graphite query results with requests, but based on my research, it would not be safe to rely on result order aligning with query order. Using aliases seemed to be the safest approach.

An alternative would have been to send off multiple different queries to Graphite, but this seemed preferred to minimize the impact of errors.
