### PR TITLE
Build: Adds a fallback script to fix package.json main and types fields before packaging

### DIFF
--- a/packages/grafana-data/package.json
+++ b/packages/grafana-data/package.json
@@ -32,7 +32,7 @@
     "clean": "rimraf ./dist ./compiled ./package.tgz",
     "typecheck": "tsc --emitDeclarationOnly false --noEmit",
     "prepack": "cp package.json package.json.bak && node ../../scripts/prepare-packagejson.js",
-    "postpack": "cp package.json.bak package.json"
+    "postpack": "mv package.json.bak package.json"
   },
   "dependencies": {
     "@braintree/sanitize-url": "6.0.1",

--- a/packages/grafana-data/package.json
+++ b/packages/grafana-data/package.json
@@ -30,7 +30,9 @@
   "scripts": {
     "build": "tsc -p ./tsconfig.build.json && rollup -c rollup.config.ts",
     "clean": "rimraf ./dist ./compiled ./package.tgz",
-    "typecheck": "tsc --emitDeclarationOnly false --noEmit"
+    "typecheck": "tsc --emitDeclarationOnly false --noEmit",
+    "prepack": "cp package.json package.json.bak && node ../../scripts/prepare-packagejson.js",
+    "postpack": "cp package.json.bak package.json"
   },
   "dependencies": {
     "@braintree/sanitize-url": "6.0.1",

--- a/packages/grafana-e2e-selectors/package.json
+++ b/packages/grafana-e2e-selectors/package.json
@@ -36,7 +36,7 @@
     "clean": "rimraf ./dist ./compiled ./package.tgz",
     "typecheck": "tsc --emitDeclarationOnly false --noEmit",
     "prepack": "cp package.json package.json.bak && node ../../scripts/prepare-packagejson.js",
-    "postpack": "cp package.json.bak package.json"
+    "postpack": "mv package.json.bak package.json"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "23.0.2",

--- a/packages/grafana-e2e-selectors/package.json
+++ b/packages/grafana-e2e-selectors/package.json
@@ -34,7 +34,9 @@
     "build": "tsc -p ./tsconfig.build.json && rollup -c rollup.config.ts",
     "bundle": "rollup -c rollup.config.ts",
     "clean": "rimraf ./dist ./compiled ./package.tgz",
-    "typecheck": "tsc --emitDeclarationOnly false --noEmit"
+    "typecheck": "tsc --emitDeclarationOnly false --noEmit",
+    "prepack": "cp package.json package.json.bak && node ../../scripts/prepare-packagejson.js",
+    "postpack": "cp package.json.bak package.json"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "23.0.2",

--- a/packages/grafana-e2e/package.json
+++ b/packages/grafana-e2e/package.json
@@ -44,7 +44,7 @@
     "test": "pushd test && node ../dist/bin/grafana-e2e.js run",
     "typecheck": "tsc --emitDeclarationOnly false --noEmit",
     "prepack": "cp package.json package.json.bak && node ../../scripts/prepare-packagejson.js",
-    "postpack": "cp package.json.bak package.json"
+    "postpack": "mv package.json.bak package.json"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "15.0.1",

--- a/packages/grafana-e2e/package.json
+++ b/packages/grafana-e2e/package.json
@@ -42,7 +42,9 @@
     "start": "cypress run --browser=chrome",
     "start-benchmark": "CYPRESS_NO_COMMAND_LOG=1 yarn start",
     "test": "pushd test && node ../dist/bin/grafana-e2e.js run",
-    "typecheck": "tsc --emitDeclarationOnly false --noEmit"
+    "typecheck": "tsc --emitDeclarationOnly false --noEmit",
+    "prepack": "cp package.json package.json.bak && node ../../scripts/prepare-packagejson.js",
+    "postpack": "cp package.json.bak package.json"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "15.0.1",

--- a/packages/grafana-runtime/package.json
+++ b/packages/grafana-runtime/package.json
@@ -32,7 +32,9 @@
     "build": "tsc -p ./tsconfig.build.json && rollup -c rollup.config.ts",
     "bundle": "rollup -c rollup.config.ts",
     "clean": "rimraf ./dist ./compiled ./package.tgz",
-    "typecheck": "tsc --emitDeclarationOnly false --noEmit"
+    "typecheck": "tsc --emitDeclarationOnly false --noEmit",
+    "prepack": "cp package.json package.json.bak && node ../../scripts/prepare-packagejson.js",
+    "postpack": "cp package.json.bak package.json"
   },
   "dependencies": {
     "@grafana/data": "9.4.0-pre",

--- a/packages/grafana-runtime/package.json
+++ b/packages/grafana-runtime/package.json
@@ -34,7 +34,7 @@
     "clean": "rimraf ./dist ./compiled ./package.tgz",
     "typecheck": "tsc --emitDeclarationOnly false --noEmit",
     "prepack": "cp package.json package.json.bak && node ../../scripts/prepare-packagejson.js",
-    "postpack": "cp package.json.bak package.json"
+    "postpack": "mv package.json.bak package.json"
   },
   "dependencies": {
     "@grafana/data": "9.4.0-pre",

--- a/packages/grafana-schema/package.json
+++ b/packages/grafana-schema/package.json
@@ -33,7 +33,7 @@
     "clean": "rimraf ./dist ./compiled ./package.tgz",
     "typecheck": "tsc --emitDeclarationOnly false --noEmit",
     "prepack": "cp package.json package.json.bak && node ../../scripts/prepare-packagejson.js",
-    "postpack": "cp package.json.bak package.json"
+    "postpack": "mv package.json.bak package.json"
   },
   "devDependencies": {
     "@grafana/tsconfig": "^1.2.0-rc1",

--- a/packages/grafana-schema/package.json
+++ b/packages/grafana-schema/package.json
@@ -31,7 +31,9 @@
     "build": "tsc -p ./tsconfig.build.json && rollup -c rollup.config.ts",
     "bundle": "rollup -c rollup.config.ts",
     "clean": "rimraf ./dist ./compiled ./package.tgz",
-    "typecheck": "tsc --emitDeclarationOnly false --noEmit"
+    "typecheck": "tsc --emitDeclarationOnly false --noEmit",
+    "prepack": "cp package.json package.json.bak && node ../../scripts/prepare-packagejson.js",
+    "postpack": "cp package.json.bak package.json"
   },
   "devDependencies": {
     "@grafana/tsconfig": "^1.2.0-rc1",

--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -16,8 +16,8 @@
     "url": "http://github.com/grafana/grafana.git",
     "directory": "packages/grafana-ui"
   },
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
   "publishConfig": {
     "main": "dist/index.js",
     "module": "dist/esm/index.js",
@@ -40,7 +40,7 @@
     "typecheck": "tsc --emitDeclarationOnly false --noEmit",
     "generate-icons-bundle-cache-file": "node ./scripts/generate-icon-bundle.js",
     "prepack": "cp package.json package.json.bak && node ../../scripts/prepare-packagejson.js",
-    "postpack": "cp package.json.bak package.json"
+    "postpack": "mv package.json.bak package.json"
   },
   "browserslist": [
     "defaults",

--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -16,8 +16,8 @@
     "url": "http://github.com/grafana/grafana.git",
     "directory": "packages/grafana-ui"
   },
-  "main": "src/index.ts",
-  "types": "src/index.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "publishConfig": {
     "main": "dist/index.js",
     "module": "dist/esm/index.js",
@@ -38,7 +38,9 @@
     "storybook": "start-storybook -p 9001 -c .storybook",
     "storybook:build": "build-storybook -o ./dist/storybook -c .storybook",
     "typecheck": "tsc --emitDeclarationOnly false --noEmit",
-    "generate-icons-bundle-cache-file": "node ./scripts/generate-icon-bundle.js"
+    "generate-icons-bundle-cache-file": "node ./scripts/generate-icon-bundle.js",
+    "prepack": "cp package.json package.json.bak && node ../../scripts/prepare-packagejson.js",
+    "postpack": "cp package.json.bak package.json"
   },
   "browserslist": [
     "defaults",

--- a/scripts/prepare-packagejson.js
+++ b/scripts/prepare-packagejson.js
@@ -1,0 +1,14 @@
+const fs = require('fs');
+
+const cwd = process.cwd();
+const packageJson = require(`${cwd}/package.json`);
+
+const newPackageJson = {
+  ...packageJson,
+  main: packageJson.publishConfig?.main ?? packageJson.main,
+  types: packageJson.publishConfig?.types ?? packageJson.types,
+};
+
+try {
+  fs.writeFileSync(`${cwd}/package.json`, JSON.stringify(newPackageJson, null, 2));
+} catch (e) {}

--- a/scripts/prepare-packagejson.js
+++ b/scripts/prepare-packagejson.js
@@ -9,6 +9,10 @@ const newPackageJson = {
   types: packageJson.publishConfig?.types ?? packageJson.types,
 };
 
+if (packageJson.publishConfig?.module) {
+  newPackageJson.module = packageJson.publishConfig.module;
+}
+
 try {
   fs.writeFileSync(`${cwd}/package.json`, JSON.stringify(newPackageJson, null, 2));
 } catch (e) {}

--- a/scripts/prepare-packagejson.js
+++ b/scripts/prepare-packagejson.js
@@ -6,8 +6,11 @@ const packageJson = require(`${cwd}/package.json`);
 const newPackageJson = {
   ...packageJson,
   main: packageJson.publishConfig?.main ?? packageJson.main,
-  types: packageJson.publishConfig?.types ?? packageJson.types,
 };
+
+if (packageJson.publishConfig?.types) {
+  newPackageJson.types = packageJson.publishConfig.types;
+}
 
 if (packageJson.publishConfig?.module) {
   newPackageJson.module = packageJson.publishConfig.module;


### PR DESCRIPTION
**What is this feature?**

Introduces a prepack and postpack lifecycle scripts to most grafana packages to remediate an [under investigation bug](https://github.com/grafana/grafana/issues/59636) where the `main` and `types` field are populated with the wrong values.

The script will make sure the package.json file contains the correct values from the `package.json` `publishConfig` before `yarn pack` (where the bug is suspected) runs.

**Why do we need this feature?**

Without this fix we risk publishing packages that are broken and can't be used inside plugins.

**Who is this feature for?**

Every plugin developer

**Which issue(s) does this PR fix?**:

Partially addresses https://github.com/grafana/grafana/issues/59636

**Special notes for your reviewer**:

