### PR TITLE
Traces: Fix for multiple $__tags in trace to metrics

### DIFF
--- a/public/app/features/explore/TraceView/createSpanLink.test.ts
+++ b/public/app/features/explore/TraceView/createSpanLink.test.ts
@@ -512,7 +512,7 @@ describe('createSpanLinkFactory', () => {
       splitOpenFn,
       traceToMetricsOptions: {
         datasourceUid: 'prom1Uid',
-        queries: [{ name: 'Named Query', query: 'metric{$__tags}[5m]' }],
+        queries: [{ name: 'Named Query', query: 'metric{$__tags, $__tags}[5m]' }],
         tags: [
           { key: 'job', value: '' },
           { key: 'k8s.pod', value: 'pod' },
@@ -535,7 +535,7 @@ describe('createSpanLinkFactory', () => {
     expect(links).toBeDefined();
     expect(links!.metricLinks![0]!.href).toBe(
       `/explore?left=${encodeURIComponent(
-        '{"range":{"from":"2020-10-14T01:00:00.000Z","to":"2020-10-14T01:00:01.000Z"},"datasource":"prom1Uid","queries":[{"expr":"metric{job=\\"tns/app\\", pod=\\"sample-pod\\"}[5m]","refId":"A"}],"panelsState":{}}'
+        '{"range":{"from":"2020-10-14T01:00:00.000Z","to":"2020-10-14T01:00:01.000Z"},"datasource":"prom1Uid","queries":[{"expr":"metric{job=\\"tns/app\\", pod=\\"sample-pod\\", job=\\"tns/app\\", pod=\\"sample-pod\\"}[5m]","refId":"A"}],"panelsState":{}}'
       )}`
     );
   });

--- a/public/app/features/explore/TraceView/createSpanLink.tsx
+++ b/public/app/features/explore/TraceView/createSpanLink.tsx
@@ -455,7 +455,7 @@ function buildMetricsQuery(query: TraceToMetricQuery, tags: Array<KeyValue<strin
     }, [] as string[]);
 
     const labelsQuery = labels?.join(', ');
-    expr = expr.replace('$__tags', labelsQuery);
+    expr = expr.replace(/\$__tags/g, labelsQuery);
   }
 
   return expr;


### PR DESCRIPTION
**What is this feature?**

Adds a fix to allow the use of multiple $__tags in trace to metrics queries.

**Why do we need this feature?**

We need to support adding $__tags in multiple places in the query.

**Who is this feature for?**

Users of our tracing datasources.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/59618

**Special notes for your reviewer**:

<img width="1322" alt="Screenshot 2022-12-01 at 10 55 30" src="https://user-images.githubusercontent.com/90795735/205035259-839cacf2-b648-4b83-ae45-c003038a308a.png">
<img width="701" alt="Screenshot 2022-12-01 at 10 55 38" src="https://user-images.githubusercontent.com/90795735/205035265-21b0fabd-4050-4eeb-a53a-ad617c4c2b80.png">
