### PR TITLE
CloudWatch: Create deeplinks from log group ARNs

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/utils/datalinks.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/utils/datalinks.test.ts
@@ -6,6 +6,10 @@ import { CloudWatchQuery } from '../types';
 import { addDataLinksToLogsResponse } from './datalinks';
 
 describe('addDataLinksToLogsResponse', () => {
+  const time = {
+    from: dateMath.parse('2016-12-31 15:00:00Z', false)!,
+    to: dateMath.parse('2016-12-31 16:00:00Z', false)!,
+  };
   it('should add data links to response from log group names', async () => {
     const mockResponse: DataQueryResponse = {
       data: [
@@ -34,11 +38,6 @@ describe('addDataLinksToLogsResponse', () => {
           region: 'us-east-1',
         },
       ],
-    };
-
-    const time = {
-      from: dateMath.parse('2016-12-31 15:00:00Z', false)!,
-      to: dateMath.parse('2016-12-31 16:00:00Z', false)!,
     };
 
     setDataSourceSrv({
@@ -125,11 +124,6 @@ describe('addDataLinksToLogsResponse', () => {
       ],
     } as DataQueryRequest<CloudWatchQuery>;
 
-    const time = {
-      from: dateMath.parse('2016-12-31 15:00:00Z', false)!,
-      to: dateMath.parse('2016-12-31 16:00:00Z', false)!,
-    };
-
     await addDataLinksToLogsResponse(
       mockResponse,
       mockOptions,
@@ -148,6 +142,62 @@ describe('addDataLinksToLogsResponse', () => {
                 links: [
                   {
                     url: "https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logs-insights:queryDetail=~(end~'2016-12-31T16*3a00*3a00.000Z~start~'2016-12-31T15*3a00*3a00.000Z~timeType~'ABSOLUTE~tz~'UTC~editorString~'stats*20count*28*40message*29*20by*20bin*281h*29~isLiveTail~false~source~(~'arn*3aaws*3alogs*3aus-east-1*3a111111111111*3alog-group*3a*2faws*2flambda*2ftest~'arn*3aaws*3alogs*3aus-east-2*3a222222222222*3alog-group*3a*2fecs*2fprometheus))",
+                    title: 'View in CloudWatch console',
+                  },
+                ],
+              },
+            },
+          ],
+          refId: 'A',
+        },
+      ],
+    });
+  });
+
+  it('should add data links to response from log groups, even without trimming :*', async () => {
+    const mockResponse: DataQueryResponse = {
+      data: [
+        {
+          fields: [
+            {
+              name: '@message',
+              config: {},
+            },
+          ],
+          refId: 'A',
+        },
+      ],
+    };
+
+    const mockOptions = {
+      targets: [
+        {
+          refId: 'A',
+          expression: 'stats count(@message) by bin(1h)',
+          logGroups: [{ value: 'arn:aws:logs:us-east-1:111111111111:log-group:/aws/lambda/test' }],
+          region: 'us-east-1',
+        } as CloudWatchQuery,
+      ],
+    } as DataQueryRequest<CloudWatchQuery>;
+
+    await addDataLinksToLogsResponse(
+      mockResponse,
+      mockOptions,
+      { ...time, raw: time },
+      (s) => s ?? '',
+      (v) => [v] ?? [],
+      (r) => r
+    );
+    expect(mockResponse).toMatchObject({
+      data: [
+        {
+          fields: [
+            {
+              name: '@message',
+              config: {
+                links: [
+                  {
+                    url: "https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logs-insights:queryDetail=~(end~'2016-12-31T16*3a00*3a00.000Z~start~'2016-12-31T15*3a00*3a00.000Z~timeType~'ABSOLUTE~tz~'UTC~editorString~'stats*20count*28*40message*29*20by*20bin*281h*29~isLiveTail~false~source~(~'arn*3aaws*3alogs*3aus-east-1*3a111111111111*3alog-group*3a*2faws*2flambda*2ftest))",
                     title: 'View in CloudWatch console',
                   },
                 ],

--- a/public/app/plugins/datasource/cloudwatch/utils/datalinks.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/utils/datalinks.test.ts
@@ -1,10 +1,12 @@
-import { DataQueryResponse, dateMath } from '@grafana/data';
+import { DataQueryRequest, DataQueryResponse, dateMath } from '@grafana/data';
 import { setDataSourceSrv } from '@grafana/runtime';
+
+import { CloudWatchQuery } from '../types';
 
 import { addDataLinksToLogsResponse } from './datalinks';
 
 describe('addDataLinksToLogsResponse', () => {
-  it('should add data links to response', async () => {
+  it('should add data links to response from log group names', async () => {
     const mockResponse: DataQueryResponse = {
       data: [
         {
@@ -83,6 +85,70 @@ describe('addDataLinksToLogsResponse', () => {
                       datasourceUid: 'xrayUid',
                       datasourceName: 'Xray',
                     },
+                  },
+                ],
+              },
+            },
+          ],
+          refId: 'A',
+        },
+      ],
+    });
+  });
+
+  it('should add data links to response from log groups, trimming :*', async () => {
+    const mockResponse: DataQueryResponse = {
+      data: [
+        {
+          fields: [
+            {
+              name: '@message',
+              config: {},
+            },
+          ],
+          refId: 'A',
+        },
+      ],
+    };
+
+    const mockOptions = {
+      targets: [
+        {
+          refId: 'A',
+          expression: 'stats count(@message) by bin(1h)',
+          logGroups: [
+            { value: 'arn:aws:logs:us-east-1:111111111111:log-group:/aws/lambda/test:*' },
+            { value: 'arn:aws:logs:us-east-2:222222222222:log-group:/ecs/prometheus:*' },
+          ],
+          region: 'us-east-1',
+        } as CloudWatchQuery,
+      ],
+    } as DataQueryRequest<CloudWatchQuery>;
+
+    const time = {
+      from: dateMath.parse('2016-12-31 15:00:00Z', false)!,
+      to: dateMath.parse('2016-12-31 16:00:00Z', false)!,
+    };
+
+    await addDataLinksToLogsResponse(
+      mockResponse,
+      mockOptions,
+      { ...time, raw: time },
+      (s) => s ?? '',
+      (v) => [v] ?? [],
+      (r) => r
+    );
+    expect(mockResponse).toMatchObject({
+      data: [
+        {
+          fields: [
+            {
+              name: '@message',
+              config: {
+                links: [
+                  {
+                    url: "https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logs-insights:queryDetail=~(end~'2016-12-31T16*3a00*3a00.000Z~start~'2016-12-31T15*3a00*3a00.000Z~timeType~'ABSOLUTE~tz~'UTC~editorString~'stats*20count*28*40message*29*20by*20bin*281h*29~isLiveTail~false~source~(~'arn*3aaws*3alogs*3aus-east-1*3a111111111111*3alog-group*3a*2faws*2flambda*2ftest~'arn*3aaws*3alogs*3aus-east-2*3a222222222222*3alog-group*3a*2fecs*2fprometheus))",
+                    title: 'View in CloudWatch console',
                   },
                 ],
               },

--- a/public/app/plugins/datasource/cloudwatch/utils/datalinks.ts
+++ b/public/app/plugins/datasource/cloudwatch/utils/datalinks.ts
@@ -70,14 +70,12 @@ function createAwsConsoleLink(
   replace: (target: string, fieldName?: string) => string,
   getVariableValue: (value: string) => string[]
 ) {
-  const arns =
-    target.logGroups &&
-    target.logGroups.flatMap((group) => {
-      if (group.value === undefined) {
-        return [];
-      }
-      return [group.value.replace(/:\*$/, '')]; // remove `:*` from end of arn
-    });
+  const arns = target.logGroups?.flatMap((group) => {
+    if (group.value === undefined) {
+      return [];
+    }
+    return [group.value.replace(/:\*$/, '')]; // remove `:*` from end of arn
+  });
   const logGroupNames = target.logGroupNames;
   const sources = arns ?? logGroupNames;
   const interpolatedExpression = target.expression ? replace(target.expression) : '';

--- a/public/app/plugins/datasource/cloudwatch/utils/datalinks.ts
+++ b/public/app/plugins/datasource/cloudwatch/utils/datalinks.ts
@@ -70,8 +70,18 @@ function createAwsConsoleLink(
   replace: (target: string, fieldName?: string) => string,
   getVariableValue: (value: string) => string[]
 ) {
+  const arns =
+    target.logGroups &&
+    target.logGroups.flatMap((group) => {
+      if (group.value === undefined) {
+        return [];
+      }
+      return [group.value.replace(/:\*$/, '')]; // remove `:*` from end of arn
+    });
+  const logGroupNames = target.logGroupNames;
+  const sources = arns ?? logGroupNames;
   const interpolatedExpression = target.expression ? replace(target.expression) : '';
-  const interpolatedGroups = target.logGroupNames?.flatMap(getVariableValue) ?? [];
+  const interpolatedGroups = sources?.flatMap(getVariableValue) ?? [];
 
   const urlProps: AwsUrl = {
     end: range.to.toISOString(),


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This takes logGroups, takes their ARN value, strips `:*`, and uses them in the deeplink to correctly link to them in the AWS console.

**Why do we need this feature?**

While adding support for cross-account querying, logGroups were introduced in favor of logGroupNames, but this had not yet been updated in the deeplink.


**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes # https://github.com/grafana/cloud-data-sources/issues/88

