### PR TITLE
Prometheus: Send time range params when requesting labels

### DIFF
--- a/public/app/plugins/datasource/prometheus/datasource.tsx
+++ b/public/app/plugins/datasource/prometheus/datasource.tsx
@@ -896,12 +896,7 @@ export class PrometheusDatasource
     } else {
       // Get all tags
       const range = this.timeSrv.timeRange();
-      const start = this.getPrometheusTime(range.from, false);
-      const end = this.getPrometheusTime(range.to, true);
-      const params = {
-        start: start.toString(),
-        end: end.toString(),
-      };
+      const params = this.getTimeRangeParams();
       const result = await this.metadataRequest('/api/v1/labels', params);
       return result?.data?.data?.map((value: any) => ({ text: value })) ?? [];
     }

--- a/public/app/plugins/datasource/prometheus/datasource.tsx
+++ b/public/app/plugins/datasource/prometheus/datasource.tsx
@@ -895,7 +895,6 @@ export class PrometheusDatasource
       return uniqueLabels.map((value: any) => ({ text: value }));
     } else {
       // Get all tags
-      const range = this.timeSrv.timeRange();
       const params = this.getTimeRangeParams();
       const result = await this.metadataRequest('/api/v1/labels', params);
       return result?.data?.data?.map((value: any) => ({ text: value })) ?? [];
@@ -903,7 +902,8 @@ export class PrometheusDatasource
   }
 
   async getTagValues(options: { key?: string } = {}) {
-    const result = await this.metadataRequest(`/api/v1/label/${options.key}/values`);
+    const params = this.getTimeRangeParams();
+    const result = await this.metadataRequest(`/api/v1/label/${options.key}/values`, params);
     return result?.data?.data?.map((value: any) => ({ text: value })) ?? [];
   }
 

--- a/public/app/plugins/datasource/prometheus/datasource.tsx
+++ b/public/app/plugins/datasource/prometheus/datasource.tsx
@@ -6,8 +6,11 @@ import { catchError, filter, map, tap } from 'rxjs/operators';
 import semver from 'semver/preload';
 
 import {
+  AbstractQuery,
   AnnotationEvent,
+  AnnotationQueryRequest,
   CoreApp,
+  DataFrame,
   DataQueryError,
   DataQueryRequest,
   DataQueryResponse,
@@ -16,32 +19,29 @@ import {
   DataSourceWithQueryImportSupport,
   dateMath,
   DateTime,
-  AbstractQuery,
+  dateTime,
   LoadingState,
+  QueryFixAction,
   rangeUtil,
   ScopedVars,
   TimeRange,
-  DataFrame,
-  dateTime,
-  AnnotationQueryRequest,
-  QueryFixAction,
 } from '@grafana/data';
 import {
+  BackendDataSourceResponse,
   BackendSrvRequest,
+  DataSourceWithBackend,
   FetchError,
   FetchResponse,
   getBackendSrv,
-  DataSourceWithBackend,
-  BackendDataSourceResponse,
-  toDataQueryResponse,
   isFetchError,
+  toDataQueryResponse,
 } from '@grafana/runtime';
 import { Badge, BadgeColor, Tooltip } from '@grafana/ui';
 import { safeStringifyValue } from 'app/core/utils/explore';
 import { discoverDataSourceFeatures } from 'app/features/alerting/unified/api/buildInfo';
 import { getTimeSrv, TimeSrv } from 'app/features/dashboard/services/TimeSrv';
 import { getTemplateSrv, TemplateSrv } from 'app/features/templating/template_srv';
-import { PromApplication, PromApiFeatures } from 'app/types/unified-alerting-dto';
+import { PromApiFeatures, PromApplication } from 'app/types/unified-alerting-dto';
 
 import { addLabelToQuery } from './add_label_to_query';
 import { AnnotationQueryEditor } from './components/AnnotationQueryEditor';
@@ -895,7 +895,14 @@ export class PrometheusDatasource
       return uniqueLabels.map((value: any) => ({ text: value }));
     } else {
       // Get all tags
-      const result = await this.metadataRequest('/api/v1/labels');
+      const range = this.timeSrv.timeRange();
+      const start = this.getPrometheusTime(range.from, false);
+      const end = this.getPrometheusTime(range.to, true);
+      const params = {
+        start: start.toString(),
+        end: end.toString(),
+      };
+      const result = await this.metadataRequest('/api/v1/labels', params);
       return result?.data?.data?.map((value: any) => ({ text: value })) ?? [];
     }
   }


### PR DESCRIPTION
**What is this feature?**

We were not sending the time range param when we are requesting `labels` from Prometheus when we are querying ad-hoc filters. It was not the case for other `labels` calls. So I added time range params into ad-hoc filter calls. 


**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/56479

**Special notes for your reviewer**:

Set up a Prometheus datasource and dashboard with minimal requirements. Create an ad-hoc filter variable and normal variable with the query `label_names()`. 
Observe the second variable calls the` labels` endpoint with time range params. 
Observe ad-hoc filter will also call `labels` with time range and get the response back successfully.