### PR TITLE
Chore: Make getUserOrgList private to sqlstore

### DIFF
--- a/pkg/services/dashboards/database/acl_test.go
+++ b/pkg/services/dashboards/database/acl_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/org"
+	"github.com/grafana/grafana/pkg/services/org/orgimpl"
+	"github.com/grafana/grafana/pkg/services/quota/quotaimpl"
 	"github.com/grafana/grafana/pkg/services/quota/quotatest"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/services/tag/tagimpl"
@@ -271,12 +273,15 @@ func createUser(t *testing.T, sqlStore *sqlstore.SQLStore, name string, role str
 	sqlStore.Cfg.AutoAssignOrg = true
 	sqlStore.Cfg.AutoAssignOrgId = 1
 	sqlStore.Cfg.AutoAssignOrgRole = role
+
+	orgService, err := orgimpl.ProvideService(sqlStore, sqlStore.Cfg, quotaimpl.ProvideService(sqlStore, sqlStore.Cfg))
+	require.NoError(t, err)
+
 	currentUserCmd := user.CreateUserCommand{Login: name, Email: name + "@test.com", Name: "a " + name, IsAdmin: isAdmin}
 	currentUser, err := sqlStore.CreateUser(context.Background(), currentUserCmd)
 	require.NoError(t, err)
-	q1 := models.GetUserOrgListQuery{UserId: currentUser.ID}
-	err = sqlStore.GetUserOrgList(context.Background(), &q1)
+	orgs, err := orgService.GetUserOrgList(context.Background(), &org.GetUserOrgListQuery{UserID: currentUser.ID})
 	require.NoError(t, err)
-	require.Equal(t, org.RoleType(role), q1.Result[0].Role)
+	require.Equal(t, org.RoleType(role), orgs[0].Role)
 	return *currentUser
 }

--- a/pkg/services/dashboards/database/database_folder_test.go
+++ b/pkg/services/dashboards/database/database_folder_test.go
@@ -42,7 +42,7 @@ func TestIntegrationDashboardFolderDataAccess(t *testing.T) {
 			dashInRoot = insertTestDashboard(t, dashboardStore, "test dash 67", 1, 0, false, "prod", "webapp")
 			childDash = insertTestDashboard(t, dashboardStore, "test dash 23", 1, folder.Id, false, "prod", "webapp")
 			insertTestDashboard(t, dashboardStore, "test dash 45", 1, folder.Id, false, "prod")
-			currentUser = CreateUser(t, sqlStore, "viewer", "Viewer", false)
+			currentUser = createUser(t, sqlStore, "viewer", "Viewer", false)
 		}
 
 		t.Run("Given one dashboard folder with two dashboards and one dashboard in the root folder", func(t *testing.T) {
@@ -199,7 +199,7 @@ func TestIntegrationDashboardFolderDataAccess(t *testing.T) {
 				childDash1 = insertTestDashboard(t, dashboardStore, "child dash 1", 1, folder1.Id, false, "prod")
 				childDash2 = insertTestDashboard(t, dashboardStore, "child dash 2", 1, folder2.Id, false, "prod")
 
-				currentUser = CreateUser(t, sqlStore, "viewer", "Viewer", false)
+				currentUser = createUser(t, sqlStore, "viewer", "Viewer", false)
 			}
 
 			setup2()
@@ -304,9 +304,9 @@ func TestIntegrationDashboardFolderDataAccess(t *testing.T) {
 				folder2 = insertTestDashboard(t, dashboardStore, "2 test dash folder", 1, 0, true, "prod")
 				insertTestDashboard(t, dashboardStore, "folder in another org", 2, 0, true, "prod")
 
-				adminUser = CreateUser(t, sqlStore, "admin", "Admin", true)
-				editorUser = CreateUser(t, sqlStore, "editor", "Editor", false)
-				viewerUser = CreateUser(t, sqlStore, "viewer", "Viewer", false)
+				adminUser = createUser(t, sqlStore, "admin", "Admin", true)
+				editorUser = createUser(t, sqlStore, "editor", "Editor", false)
+				viewerUser = createUser(t, sqlStore, "viewer", "Viewer", false)
 			}
 
 			setup3()

--- a/pkg/services/dashboards/database/database_test.go
+++ b/pkg/services/dashboards/database/database_test.go
@@ -782,22 +782,6 @@ func insertTestRule(t *testing.T, sqlStore sqlstore.Store, foderOrgID int64, fol
 	require.NoError(t, err)
 }
 
-func CreateUser(t *testing.T, sqlStore *sqlstore.SQLStore, name string, role string, isAdmin bool) user.User {
-	t.Helper()
-	sqlStore.Cfg.AutoAssignOrg = true
-	sqlStore.Cfg.AutoAssignOrgId = 1
-	sqlStore.Cfg.AutoAssignOrgRole = role
-	currentUserCmd := user.CreateUserCommand{Login: name, Email: name + "@test.com", Name: "a " + name, IsAdmin: isAdmin}
-	currentUser, err := sqlStore.CreateUser(context.Background(), currentUserCmd)
-
-	require.NoError(t, err)
-	q1 := models.GetUserOrgListQuery{UserId: currentUser.ID}
-	err = sqlStore.GetUserOrgList(context.Background(), &q1)
-	require.NoError(t, err)
-	require.Equal(t, org.RoleType(role), q1.Result[0].Role)
-	return *currentUser
-}
-
 func insertTestDashboard(t *testing.T, dashboardStore *DashboardStore, title string, orgId int64,
 	folderId int64, isFolder bool, tags ...interface{}) *models.Dashboard {
 	t.Helper()

--- a/pkg/services/serviceaccounts/database/database_test.go
+++ b/pkg/services/serviceaccounts/database/database_test.go
@@ -42,7 +42,7 @@ func TestStore_CreateServiceAccountOrgNonExistant(t *testing.T) {
 
 func TestStore_CreateServiceAccount(t *testing.T) {
 	_, store := setupTestDatabase(t)
-	orgQuery := &org.CreateOrgCommand{Name: sqlstore.MainOrgName}
+	orgQuery := &org.CreateOrgCommand{Name: orgimpl.MainOrgName}
 	orgResult, err := store.orgService.CreateWithMember(context.Background(), orgQuery)
 	require.NoError(t, err)
 

--- a/pkg/services/sqlstore/org.go
+++ b/pkg/services/sqlstore/org.go
@@ -9,8 +9,7 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 )
 
-// MainOrgName is the name of the main organization.
-const MainOrgName = "Main Org."
+const mainOrgName = "Main Org."
 
 func verifyExistingOrg(sess *DBSession, orgId int64) error {
 	var org models.Org
@@ -42,7 +41,7 @@ func (ss *SQLStore) getOrCreateOrg(sess *DBSession, orgName string) (int64, erro
 				ss.Cfg.AutoAssignOrgId)
 		}
 
-		org.Name = MainOrgName
+		org.Name = mainOrgName
 		org.Id = int64(ss.Cfg.AutoAssignOrgId)
 	} else {
 		org.Name = orgName

--- a/pkg/services/sqlstore/org_test.go
+++ b/pkg/services/sqlstore/org_test.go
@@ -40,9 +40,9 @@ func TestIntegrationAccountDataAccess(t *testing.T) {
 
 				q1 := models.GetUserOrgListQuery{UserId: ac1.ID}
 				q2 := models.GetUserOrgListQuery{UserId: ac2.ID}
-				err = sqlStore.GetUserOrgList(context.Background(), &q1)
+				err = sqlStore.getUserOrgList(context.Background(), &q1)
 				require.NoError(t, err)
-				err = sqlStore.GetUserOrgList(context.Background(), &q2)
+				err = sqlStore.getUserOrgList(context.Background(), &q2)
 				require.NoError(t, err)
 
 				require.Equal(t, q1.Result[0].OrgId, q2.Result[0].OrgId)
@@ -80,7 +80,7 @@ func TestIntegrationAccountDataAccess(t *testing.T) {
 
 				t.Run("Can get user organizations", func(t *testing.T) {
 					query := models.GetUserOrgListQuery{UserId: ac2.ID}
-					err := sqlStore.GetUserOrgList(context.Background(), &query)
+					err := sqlStore.getUserOrgList(context.Background(), &query)
 
 					require.NoError(t, err)
 					require.Equal(t, len(query.Result), 2)

--- a/pkg/services/sqlstore/org_users.go
+++ b/pkg/services/sqlstore/org_users.go
@@ -14,7 +14,7 @@ func (ss *SQLStore) addOrgUser(ctx context.Context, cmd *models.AddOrgUserComman
 		var usr user.User
 		session := sess.ID(cmd.UserId)
 		if !cmd.AllowAddingServiceAccount {
-			session = session.Where(NotServiceAccountFilter(ss))
+			session = session.Where(notServiceAccountFilter(ss))
 		}
 
 		if exists, err := session.Get(&usr); err != nil {

--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -221,8 +221,8 @@ func (ss *SQLStore) ensureMainOrgAndAdminUser() error {
 			// return nil
 		}
 
-		ss.log.Debug("Creating default org", "name", MainOrgName)
-		if _, err := ss.getOrCreateOrg(sess, MainOrgName); err != nil {
+		ss.log.Debug("Creating default org", "name", mainOrgName)
+		if _, err := ss.getOrCreateOrg(sess, mainOrgName); err != nil {
 			return fmt.Errorf("failed to create default organization: %w", err)
 		}
 

--- a/pkg/services/sqlstore/user.go
+++ b/pkg/services/sqlstore/user.go
@@ -151,7 +151,7 @@ func (ss *SQLStore) CreateUser(ctx context.Context, cmd user.CreateUserCommand) 
 	return &user, createErr
 }
 
-func NotServiceAccountFilter(ss *SQLStore) string {
+func notServiceAccountFilter(ss *SQLStore) string {
 	return fmt.Sprintf("%s.is_service_account = %s",
 		ss.Dialect.Quote("user"),
 		ss.Dialect.BooleanStr(false))
@@ -195,7 +195,7 @@ func (ss *SQLStore) getUserOrgList(ctx context.Context, query *models.GetUserOrg
 		sess.Join("INNER", "org", "org_user.org_id=org.id")
 		sess.Join("INNER", ss.Dialect.Quote("user"), fmt.Sprintf("org_user.user_id=%s.id", ss.Dialect.Quote("user")))
 		sess.Where("org_user.user_id=?", query.UserId)
-		sess.Where(NotServiceAccountFilter(ss))
+		sess.Where(notServiceAccountFilter(ss))
 		sess.Cols("org.name", "org_user.role", "org_user.org_id")
 		sess.OrderBy("org.name")
 		err := sess.Find(&query.Result)

--- a/pkg/services/sqlstore/user.go
+++ b/pkg/services/sqlstore/user.go
@@ -188,7 +188,7 @@ func (o byOrgName) Less(i, j int) bool {
 	return o[i].Name < o[j].Name
 }
 
-func (ss *SQLStore) GetUserOrgList(ctx context.Context, query *models.GetUserOrgListQuery) error {
+func (ss *SQLStore) getUserOrgList(ctx context.Context, query *models.GetUserOrgListQuery) error {
 	return ss.WithDbSession(ctx, func(dbSess *DBSession) error {
 		query.Result = make([]*models.UserOrgDTO, 0)
 		sess := dbSess.Table("org_user")


### PR DESCRIPTION
One more step to finishing sqlstore split, this turns a public GetUserOrgList method into a private one. All external usages are fixed to use org.Service instead. Also, some duplicate code is removed in the dashboard tests.