### PR TITLE
Auth: Add plugin roles to RolePicker

### DIFF
--- a/public/app/core/components/RolePicker/RolePickerMenu.tsx
+++ b/public/app/core/components/RolePicker/RolePickerMenu.tsx
@@ -223,96 +223,33 @@ export const RolePickerMenu = ({
               />
             </div>
           )}
-          {!!fixedRoles.length && (
-            <div className={customStyles.menuSection}>
-              <div className={customStyles.groupHeader}>Fixed roles</div>
-              <div className={styles.optionBody}>
-                {showGroups && !!optionGroups.fixed.length
-                  ? optionGroups.fixed.map((option, i) => (
-                      <RoleMenuGroupOption
-                        data={option}
-                        key={i}
-                        isSelected={
-                          groupSelected(GroupType.fixed, option.value) ||
-                          groupPartiallySelected(GroupType.fixed, option.value)
-                        }
-                        partiallySelected={groupPartiallySelected(GroupType.fixed, option.value)}
-                        disabled={option.options?.every(isNotDelegatable)}
-                        onChange={(group: string) => onGroupChange(GroupType.fixed, group)}
-                        onOpenSubMenu={(group: string) => onOpenSubMenu(GroupType.fixed, group)}
-                        onCloseSubMenu={onCloseSubMenu}
-                        root={subMenuNode?.current!}
-                        isFocused={showSubMenu && openedMenuGroup === option.value}
-                      >
-                        {showSubMenu && openedMenuGroup === option.value && (
-                          <RolePickerSubMenu
-                            options={subMenuOptions}
-                            selectedOptions={selectedOptions}
-                            onSelect={onChange}
-                            onClear={onClearSubMenu}
-                            showOnLeft={offset.horizontal > 0}
-                          />
-                        )}
-                      </RoleMenuGroupOption>
-                    ))
-                  : fixedRoles.map((option, i) => (
-                      <RoleMenuOption
-                        data={option}
-                        key={i}
-                        isSelected={!!(option.uid && !!selectedOptions.find((opt) => opt.uid === option.uid))}
-                        disabled={isNotDelegatable(option)}
-                        onChange={onChange}
-                        hideDescription
-                      />
-                    ))}
-              </div>
-            </div>
-          )}
-          {!!customRoles.length && (
-            <div className={customStyles.menuSection}>
-              <div className={customStyles.groupHeader}>Custom roles</div>
-              <div className={styles.optionBody}>
-                {showGroups && !!optionGroups.custom.length
-                  ? optionGroups.custom.map((option, i) => (
-                      <RoleMenuGroupOption
-                        data={option}
-                        key={i}
-                        isSelected={
-                          groupSelected(GroupType.custom, option.value) ||
-                          groupPartiallySelected(GroupType.custom, option.value)
-                        }
-                        partiallySelected={groupPartiallySelected(GroupType.custom, option.value)}
-                        disabled={option.options?.every(isNotDelegatable)}
-                        onChange={(group: string) => onGroupChange(GroupType.custom, group)}
-                        onOpenSubMenu={(group: string) => onOpenSubMenu(GroupType.custom, group)}
-                        onCloseSubMenu={onCloseSubMenu}
-                        root={subMenuNode?.current!}
-                        isFocused={showSubMenu && openedMenuGroup === option.value}
-                      >
-                        {showSubMenu && openedMenuGroup === option.value && (
-                          <RolePickerSubMenu
-                            options={subMenuOptions}
-                            selectedOptions={selectedOptions}
-                            onSelect={onChange}
-                            onClear={onClearSubMenu}
-                            showOnLeft={offset.horizontal > 0}
-                          />
-                        )}
-                      </RoleMenuGroupOption>
-                    ))
-                  : customRoles.map((option, i) => (
-                      <RoleMenuOption
-                        data={option}
-                        key={i}
-                        isSelected={!!(option.uid && !!selectedOptions.find((opt) => opt.uid === option.uid))}
-                        disabled={isNotDelegatable(option)}
-                        onChange={onChange}
-                        hideDescription
-                      />
-                    ))}
-              </div>
-            </div>
-          )}
+          {Object.entries(rolesCollection).map(([groupId, collection]) => {
+            return (
+              <RoleMenuGroupsSection
+                key={groupId}
+                roles={collection.roles}
+                renderedName={collection.renderedName}
+                menuSectionStyle={customStyles.menuSection}
+                groupHeaderStyle={customStyles.groupHeader}
+                optionBodyStyle={styles.optionBody}
+                showGroups={showGroups}
+                optionGroups={collection.optionGroup}
+                groupSelected={(group: string) => groupSelected(collection.groupType, group)}
+                groupPartiallySelected={(group: string) => groupPartiallySelected(collection.groupType, group)}
+                onChange={(group: string) => onGroupChange(collection.groupType, group)}
+                onOpenSubMenuRMGS={(group: string) => onOpenSubMenu(collection.groupType, group)}
+                onCloseSubMenu={onCloseSubMenu}
+                subMenuNode={subMenuNode?.current!}
+                showSubMenu={showSubMenu}
+                openedMenuGroup={openedMenuGroup}
+                subMenuOptions={subMenuOptions}
+                selectedOptions={selectedOptions}
+                onChangeSubMenu={onChange}
+                onClearSubMenu={onClearSubMenu}
+                showOnLeftSubMenu={offset.horizontal > 0}
+              ></RoleMenuGroupsSection>
+            );
+          })}
         </CustomScrollbar>
         <div className={customStyles.menuButtonRow}>
           <HorizontalGroup justify="flex-end">

--- a/public/app/core/components/RolePicker/RolePickerMenu.tsx
+++ b/public/app/core/components/RolePicker/RolePickerMenu.tsx
@@ -1,5 +1,6 @@
 import { css, cx } from '@emotion/css';
 import React, { FormEvent, useEffect, useRef, useState } from 'react';
+import { v4 as uuidv4 } from 'uuid';
 
 import { GrafanaTheme2, SelectableValue } from '@grafana/data';
 import {
@@ -290,6 +291,7 @@ const convertRolesToGroupOptions = (roles: Role[]) => {
       name: fixedRoleGroupNames[groupName] || capitalize(groupName),
       value: groupName,
       options: roles.sort(sortRolesByName),
+      uid: uuidv4(),
     };
   });
   return groups;
@@ -425,6 +427,7 @@ interface RoleMenuGroupsSectionProps {
     name: string;
     options: Role[];
     value: string;
+    uid: string;
   }>;
   onChange: (value: string) => void;
   onOpenSubMenuRMGS: (value: string) => void;
@@ -478,15 +481,15 @@ export const RoleMenuGroupsSection = React.forwardRef<HTMLDivElement, RoleMenuGr
               ? optionGroups.map((option, i) => (
                   <RoleMenuGroupOption
                     data={option}
-                    key={i}
+                    key={option.uid}
                     isSelected={groupSelected(option.value) || groupPartiallySelected(option.value)}
                     partiallySelected={groupPartiallySelected(option.value)}
                     disabled={option.options?.every(isNotDelegatable)}
                     onChange={onChange}
-                    onOpenSubMenu={(group: string) => onOpenSubMenuRMGS(group)}
+                    onOpenSubMenu={onOpenSubMenuRMGS}
                     onCloseSubMenu={onCloseSubMenu}
                     root={subMenuNode}
-                    isFocused={showSubMenu && openedMenuGroup === option.value}
+                    isFocused={showSubMenu && openedMenuGroup === option.uid}
                   >
                     {showSubMenu && openedMenuGroup === option.value && (
                       <RolePickerSubMenu
@@ -502,7 +505,7 @@ export const RoleMenuGroupsSection = React.forwardRef<HTMLDivElement, RoleMenuGr
               : roles.map((option, i) => (
                   <RoleMenuOption
                     data={option}
-                    key={i}
+                    key={option.uid}
                     isSelected={!!(option.uid && !!selectedOptions.find((opt) => opt.uid === option.uid))}
                     disabled={isNotDelegatable(option)}
                     onChange={onChangeSubMenu}

--- a/public/app/core/components/RolePicker/RolePickerMenu.tsx
+++ b/public/app/core/components/RolePicker/RolePickerMenu.tsx
@@ -22,6 +22,7 @@ import { MENU_MAX_HEIGHT, ROLE_PICKER_SUBMENU_MIN_WIDTH } from './constants';
 enum GroupType {
   fixed = 'fixed',
   custom = 'custom',
+  plugin = 'plugin',
 }
 
 const BasicRoles = Object.values(OrgRole);
@@ -87,7 +88,29 @@ export const RolePickerMenu = ({
 
   const customRoles = options.filter(filterCustomRoles).sort(sortRolesByName);
   const fixedRoles = options.filter(filterFixedRoles).sort(sortRolesByName);
+  const pluginRoles = options.filter(filterPluginsRoles).sort(sortRolesByName);
   const optionGroups = getOptionGroups(options);
+
+  const rolesCollection = {
+    fixed: {
+      groupType: GroupType.fixed,
+      optionGroup: optionGroups.fixed,
+      renderedName: `Fixed roles`,
+      roles: fixedRoles,
+    },
+    custom: {
+      groupType: GroupType.custom,
+      optionGroup: optionGroups.custom,
+      renderedName: `Custom roles`,
+      roles: customRoles,
+    },
+    pluginRoles: {
+      groupType: GroupType.plugin,
+      optionGroup: optionGroups.plugin,
+      renderedName: `Plugin roles`,
+      roles: pluginRoles,
+    },
+  };
 
   const getSelectedGroupOptions = (group: string) => {
     const selectedGroupOptions = [];
@@ -307,8 +330,9 @@ export const RolePickerMenu = ({
   );
 };
 
-const filterCustomRoles = (option: Role) => !option.name?.startsWith('fixed:');
+const filterCustomRoles = (option: Role) => !option.name?.startsWith('fixed:') && !option.name.startsWith('plugins:');
 const filterFixedRoles = (option: Role) => option.name?.startsWith('fixed:');
+const filterPluginsRoles = (option: Role) => option.name?.startsWith('plugins:');
 
 const getOptionGroups = (options: Role[]) => {
   const groupsMap: { [key: string]: Role[] } = {};
@@ -342,9 +366,16 @@ const getOptionGroups = (options: Role[]) => {
     });
   }
 
+  const pluginGroups: Array<{
+    name: string;
+    value: string;
+    options: Role[];
+  }> = [];
+
   return {
     fixed: groups.sort((a, b) => a.name.localeCompare(b.name)),
     custom: customGroups.sort((a, b) => a.name.localeCompare(b.name)),
+    plugin: pluginGroups.sort((a, b) => a.name.localeCompare(b.name)),
   };
 };
 

--- a/public/app/core/components/RolePicker/RolePickerMenu.tsx
+++ b/public/app/core/components/RolePicker/RolePickerMenu.tsx
@@ -467,6 +467,110 @@ export const RoleMenuOption = React.forwardRef<HTMLDivElement, React.PropsWithCh
 
 RoleMenuOption.displayName = 'RoleMenuOption';
 
+interface RoleMenuGroupsSectionProps {
+  roles: Role[];
+  renderedName: string;
+  menuSectionStyle: string;
+  groupHeaderStyle: string;
+  optionBodyStyle: string;
+  showGroups?: boolean;
+  optionGroups: Array<{
+    name: string;
+    options: Role[];
+    value: string;
+  }>;
+  onChange: (value: string) => void;
+  onOpenSubMenuRMGS: (value: string) => void;
+  onCloseSubMenu?: (value: string) => void;
+  groupSelected: (group: string) => boolean;
+  groupPartiallySelected: (group: string) => boolean;
+  disabled?: boolean;
+  subMenuNode?: HTMLDivElement;
+  showSubMenu: boolean;
+  openedMenuGroup: string;
+  subMenuOptions: Role[];
+  selectedOptions: Role[];
+  onChangeSubMenu: (option: Role) => void;
+  onClearSubMenu: () => void;
+  showOnLeftSubMenu: boolean;
+}
+
+export const RoleMenuGroupsSection = React.forwardRef<HTMLDivElement, RoleMenuGroupsSectionProps>(
+  (
+    {
+      roles,
+      renderedName,
+      menuSectionStyle,
+      groupHeaderStyle,
+      optionBodyStyle,
+      showGroups,
+      optionGroups,
+      onChange,
+      groupSelected,
+      groupPartiallySelected,
+      onOpenSubMenuRMGS,
+      onCloseSubMenu,
+      subMenuNode,
+      showSubMenu,
+      openedMenuGroup,
+      subMenuOptions,
+      selectedOptions,
+      onChangeSubMenu,
+      onClearSubMenu,
+      showOnLeftSubMenu,
+    },
+    _ref
+  ) => {
+    return (
+      <div>
+        {roles.length > 0 && (
+          <div className={menuSectionStyle}>
+            <div className={groupHeaderStyle}>{renderedName}</div>
+            <div className={optionBodyStyle}></div>
+            {showGroups && !!optionGroups?.length
+              ? optionGroups.map((option, i) => (
+                  <RoleMenuGroupOption
+                    data={option}
+                    key={i}
+                    isSelected={groupSelected(option.value) || groupPartiallySelected(option.value)}
+                    partiallySelected={groupPartiallySelected(option.value)}
+                    disabled={option.options?.every(isNotDelegatable)}
+                    onChange={onChange}
+                    onOpenSubMenu={(group: string) => onOpenSubMenuRMGS(group)}
+                    onCloseSubMenu={onCloseSubMenu}
+                    root={subMenuNode}
+                    isFocused={showSubMenu && openedMenuGroup === option.value}
+                  >
+                    {showSubMenu && openedMenuGroup === option.value && (
+                      <RolePickerSubMenu
+                        options={subMenuOptions}
+                        selectedOptions={selectedOptions}
+                        onSelect={onChangeSubMenu}
+                        onClear={onClearSubMenu}
+                        showOnLeft={showOnLeftSubMenu}
+                      />
+                    )}
+                  </RoleMenuGroupOption>
+                ))
+              : roles.map((option, i) => (
+                  <RoleMenuOption
+                    data={option}
+                    key={i}
+                    isSelected={!!(option.uid && !!selectedOptions.find((opt) => opt.uid === option.uid))}
+                    disabled={isNotDelegatable(option)}
+                    onChange={onChangeSubMenu}
+                    hideDescription
+                  />
+                ))}
+          </div>
+        )}
+      </div>
+    );
+  }
+);
+
+RoleMenuGroupsSection.displayName = 'RoleMenuGroupsSection';
+
 interface RoleMenuGroupsOptionProps {
   data: SelectableValue<string>;
   onChange: (value: string) => void;

--- a/public/app/core/components/RolePicker/RolePickerMenu.tsx
+++ b/public/app/core/components/RolePicker/RolePickerMenu.tsx
@@ -146,16 +146,17 @@ export const RolePickerMenu = ({
     const group = optionGroups[groupType].find((g) => {
       return g.value === value;
     });
+
+    if (!group) {
+      return;
+    }
+
     if (groupSelected(groupType, value) || groupPartiallySelected(groupType, value)) {
-      if (group) {
-        setSelectedOptions(selectedOptions.filter((role) => !group.options.find((option) => role.uid === option.uid)));
-      }
+      setSelectedOptions(selectedOptions.filter((role) => !group.options.find((option) => role.uid === option.uid)));
     } else {
-      if (group) {
-        const groupOptions = group.options.filter((role) => role.delegatable);
-        const restOptions = selectedOptions.filter((role) => !group.options.find((option) => role.uid === option.uid));
-        setSelectedOptions([...restOptions, ...groupOptions]);
-      }
+      const groupOptions = group.options.filter((role) => role.delegatable);
+      const restOptions = selectedOptions.filter((role) => !group.options.find((option) => role.uid === option.uid));
+      setSelectedOptions([...restOptions, ...groupOptions]);
     }
   };
 

--- a/public/app/core/components/RolePicker/RolePickerMenu.tsx
+++ b/public/app/core/components/RolePicker/RolePickerMenu.tsx
@@ -478,10 +478,10 @@ export const RoleMenuGroupsSection = React.forwardRef<HTMLDivElement, RoleMenuGr
             <div className={groupHeaderStyle}>{renderedName}</div>
             <div className={optionBodyStyle}></div>
             {showGroups && !!optionGroups?.length
-              ? optionGroups.map((option, i) => (
+              ? optionGroups.map((option) => (
                   <RoleMenuGroupOption
                     data={option}
-                    key={option.uid}
+                    key={option.value}
                     isSelected={groupSelected(option.value) || groupPartiallySelected(option.value)}
                     partiallySelected={groupPartiallySelected(option.value)}
                     disabled={option.options?.every(isNotDelegatable)}
@@ -489,7 +489,7 @@ export const RoleMenuGroupsSection = React.forwardRef<HTMLDivElement, RoleMenuGr
                     onOpenSubMenu={onOpenSubMenuRMGS}
                     onCloseSubMenu={onCloseSubMenu}
                     root={subMenuNode}
-                    isFocused={showSubMenu && openedMenuGroup === option.uid}
+                    isFocused={showSubMenu && openedMenuGroup === option.value}
                   >
                     {showSubMenu && openedMenuGroup === option.value && (
                       <RolePickerSubMenu
@@ -502,7 +502,7 @@ export const RoleMenuGroupsSection = React.forwardRef<HTMLDivElement, RoleMenuGr
                     )}
                   </RoleMenuGroupOption>
                 ))
-              : roles.map((option, i) => (
+              : roles.map((option) => (
                   <RoleMenuOption
                     data={option}
                     key={option.uid}

--- a/public/app/core/components/RolePicker/RolePickerMenu.tsx
+++ b/public/app/core/components/RolePicker/RolePickerMenu.tsx
@@ -89,7 +89,11 @@ export const RolePickerMenu = ({
   const customRoles = options.filter(filterCustomRoles).sort(sortRolesByName);
   const fixedRoles = options.filter(filterFixedRoles).sort(sortRolesByName);
   const pluginRoles = options.filter(filterPluginsRoles).sort(sortRolesByName);
-  const optionGroups = getOptionGroups(options);
+  const optionGroups = {
+    fixed: convertRolesToGroupOptions(fixedRoles).sort((a, b) => a.name.localeCompare(b.name)),
+    custom: convertRolesToGroupOptions(customRoles).sort((a, b) => a.name.localeCompare(b.name)),
+    plugin: convertRolesToGroupOptions(pluginRoles).sort((a, b) => a.name.localeCompare(b.name)),
+  };
 
   const rolesCollection = {
     fixed: {
@@ -272,49 +276,23 @@ const filterCustomRoles = (option: Role) => !option.name?.startsWith('fixed:') &
 const filterFixedRoles = (option: Role) => option.name?.startsWith('fixed:');
 const filterPluginsRoles = (option: Role) => option.name?.startsWith('plugins:');
 
-const getOptionGroups = (options: Role[]) => {
+const convertRolesToGroupOptions = (roles: Role[]) => {
   const groupsMap: { [key: string]: Role[] } = {};
-  const customGroupsMap: { [key: string]: Role[] } = {};
-  options.forEach((role) => {
-    const m = role.name.startsWith('fixed:') ? groupsMap : customGroupsMap;
+  roles.forEach((role) => {
     const groupName = getRoleGroup(role);
-    if (!m[groupName]) {
-      m[groupName] = [];
+    if (!groupsMap[groupName]) {
+      groupsMap[groupName] = [];
     }
-    m[groupName].push(role);
+    groupsMap[groupName].push(role);
   });
-
-  const groups = [];
-  for (const groupName of Object.keys(groupsMap)) {
-    const groupOptions = groupsMap[groupName].sort(sortRolesByName);
-    groups.push({
+  const groups = Object.entries(groupsMap).map(([groupName, roles]) => {
+    return {
       name: fixedRoleGroupNames[groupName] || capitalize(groupName),
       value: groupName,
-      options: groupOptions,
-    });
-  }
-
-  const customGroups = [];
-  for (const groupName of Object.keys(customGroupsMap)) {
-    const groupOptions = customGroupsMap[groupName].sort(sortRolesByName);
-    customGroups.push({
-      name: capitalize(groupName),
-      value: groupName,
-      options: groupOptions,
-    });
-  }
-
-  const pluginGroups: Array<{
-    name: string;
-    value: string;
-    options: Role[];
-  }> = [];
-
-  return {
-    fixed: groups.sort((a, b) => a.name.localeCompare(b.name)),
-    custom: customGroups.sort((a, b) => a.name.localeCompare(b.name)),
-    plugin: pluginGroups.sort((a, b) => a.name.localeCompare(b.name)),
-  };
+      options: roles.sort(sortRolesByName),
+    };
+  });
+  return groups;
 };
 
 interface RolePickerSubMenuProps {


### PR DESCRIPTION
**What is this feature?**

Rework the role picker for a more generic reusable role section component.

**Why do we need this feature?**

We need to add the plug-ins role to the existing list of roles as a new section. Instead of copy/pasting the existing code, a reusable component was added.

**Which issue(s) does this PR fix?**:


Fixes #[4006](https://github.com/grafana/grafana-enterprise/issues/4006)
