### PR TITLE
A11y: Remove unnecessary onClick from `LegendSeriesItem`

### DIFF
--- a/public/app/plugins/panel/graph/Legend/LegendSeriesItem.tsx
+++ b/public/app/plugins/panel/graph/Legend/LegendSeriesItem.tsx
@@ -221,14 +221,10 @@ interface LegendValueProps {
 function LegendValue({ value, valueName, asTable, onValueClick }: LegendValueProps) {
   if (asTable) {
     return (
-      <td role="gridcell" className={`graph-legend-value ${valueName}`} onClick={onValueClick}>
+      <td role="gridcell" className={`graph-legend-value ${valueName}`}>
         {value}
       </td>
     );
   }
-  return (
-    <div className={`graph-legend-value ${valueName}`} onClick={onValueClick}>
-      {value}
-    </div>
-  );
+  return <div className={`graph-legend-value ${valueName}`}>{value}</div>;
 }

--- a/public/sass/components/_panel_graph.scss
+++ b/public/sass/components/_panel_graph.scss
@@ -79,7 +79,6 @@
 .graph-legend-alias,
 .graph-legend-value {
   display: inline;
-  cursor: pointer;
   white-space: nowrap;
   font-size: 12px;
   text-align: left;


### PR DESCRIPTION
**What is this feature?**

As part of https://github.com/grafana/grafana/issues/58924 we want to fix a11y issues related to certain rules. In this case, there was an `onClick` on a `div`, however, this `onClick` was unnecessary and it was on the old Graph panel so the best solution is to delete it. You can just click the legend label to show/hide it instead of also the series value.

**Why do we need this feature?**

To increase accessibility!

**Who is this feature for?**

Everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #59668


