### PR TITLE
Jest: Add logger to print test results in Loki friendly format

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -29,4 +29,6 @@ module.exports = {
     '\\.css': '<rootDir>/public/test/mocks/style.ts',
     'monaco-editor/esm/vs/editor/editor.api': '<rootDir>/public/test/mocks/monaco.ts',
   },
+  // Log the test results with dynamic Loki tags. Drone CI only
+  reporters: ['default', ['<rootDir>/public/test/log-reporter.js', { enable: process.env.DRONE === 'true' }]],
 };

--- a/public/test/log-reporter.js
+++ b/public/test/log-reporter.js
@@ -9,7 +9,7 @@ class CustomReporter {
     if (!this._options.enable) {
       return;
     }
-    console.log(results);
+
     this.logStats(results);
     this.logTestFailures(results);
   }

--- a/public/test/log-reporter.js
+++ b/public/test/log-reporter.js
@@ -1,0 +1,83 @@
+class CustomReporter {
+  constructor(globalConfig, reporterOptions, reporterContext) {
+    this._globalConfig = globalConfig;
+    this._options = reporterOptions;
+    this._context = reporterContext;
+  }
+
+  onRunComplete(testContexts, results) {
+    if (!this._options.enable) {
+      return;
+    }
+    console.log(results);
+    this.logStats(results);
+    this.logTestFailures(results);
+  }
+
+  logTestFailures(results) {
+    results.testResults.forEach(printTestFailures);
+  }
+
+  logStats(results) {
+    const stats = {
+      suites: results.numTotalTestSuites,
+      tests: results.numTotalTests,
+      passes: results.numPassedTests,
+      pending: results.numPendingTests,
+      failures: results.numFailedTests,
+      duration: Date.now() - results.startTime,
+    };
+    // JestStats suites=1 tests=94 passes=93 pending=0 failures=1 duration=-3973
+    console.log(`JestStats ${objToLogAttributes(stats)}`);
+  }
+}
+
+function printTestFailures(result) {
+  if (result.status === 'pending') {
+    return;
+  }
+  if (result.numFailingTests > 0) {
+    const testInfo = {
+      file: result.testFilePath,
+      failures: result.numFailingTests,
+      duration: result.perfStats.end - result.perfStats.start,
+      errorMessage: result.failureMessage,
+    };
+    // JestFailure file=<...>/public/app/features/dashboard/state/DashboardMigrator.test.ts
+    // failures=1 duration=3251 errorMessage="formatted error message"
+    console.log(`JestFailure ${objToLogAttributes(testInfo)}`);
+  }
+}
+
+/**
+ * Stringify object to be log friendly
+ * @param {Object} obj
+ * @returns {String}
+ */
+function objToLogAttributes(obj) {
+  return Object.entries(obj)
+    .map(([key, value]) => `${key}=${formatValue(value)}`)
+    .join(' ');
+}
+
+/**
+ * Escape double quotes
+ * @param {String} str
+ * @returns
+ */
+function escapeQuotes(str) {
+  return String(str).replaceAll('"', '\\"');
+}
+
+/**
+ * Wrap the value within double quote if needed
+ * @param {*} value
+ * @returns
+ */
+function formatValue(value) {
+  const hasWhiteSpaces = /\s/g.test(value);
+
+  return hasWhiteSpaces ? `"${escapeQuotes(value)}"` : value;
+}
+
+module.exports = CustomReporter;

--- a/public/test/log-reporter.js
+++ b/public/test/log-reporter.js
@@ -27,7 +27,7 @@ class CustomReporter {
       failures: results.numFailedTests,
       duration: Date.now() - results.startTime,
     };
-    // JestStats suites=1 tests=94 passes=93 pending=0 failures=1 duration=-3973
+    // JestStats suites=1 tests=94 passes=93 pending=0 failures=1 duration=3973
     console.log(`JestStats ${objToLogAttributes(stats)}`);
   }
 }

--- a/public/test/log-reporter.js
+++ b/public/test/log-reporter.js
@@ -1,4 +1,4 @@
-class CustomReporter {
+class LogReporter {
   constructor(globalConfig, reporterOptions, reporterContext) {
     this._globalConfig = globalConfig;
     this._options = reporterOptions;


### PR DESCRIPTION
Improve Jest reporter to add logs in a Loki-friendly way the Jest results when running in Drone only. The results are file-based. If we do it test-based it would add an excessive amount of logs.

Stats logs to be able to track runs based on time and results:
```
JestStats suites=1 tests=94 passes=93 pending=0 failures=1 duration=-3973
```
Failure logs to track errors based on the file:
```
JestFailure file=<...>/public/app/features/dashboard/state/DashboardMigrator.test.ts failures=1 duration=3251 errorMessage="formatted error message"
```