### PR TITLE
Docs: Reference Alertmanagers in Notifications docs and move Alertmanager docs

### DIFF
--- a/docs/sources/alerting/fundamentals/notifications.md
+++ b/docs/sources/alerting/fundamentals/notifications.md
@@ -1,24 +1,21 @@
 ---
 aliases:
   - /docs/grafana/latest/alerting/notifications/
-  - /docs/grafana/latest/alerting/contact-points/
-  - /docs/grafana/latest/alerting/unified-alerting/contact-points/
-  - /docs/grafana/latest/alerting/fundamentals/contact-points/contact-point-types/
-description: Create or edit contact point
+description: Notifications
 keywords:
   - grafana
   - alerting
-  - guide
-  - contact point
-  - notification channel
-  - create
+  - alertmanager
+  - notification policies
+  - contact points
+  - silences
 title: Notifications
 weight: 410
 ---
 
 # Notifications
 
-Notifications are sent when an alert is firing or has been resolved. You use notification policies to configure how and where a notification is sent; how often a notification should be sent; and whether alerts should all be sent in the same notification, sent in grouped notifications based on a set of labels, or as separate notifications.
+Grafana uses Alertmanagers to send notifications for firing and resolved alerts. Grafana has its own Alertmanager, referred to as "Grafana" in the user interface, but also supports sending notifications from other Alertmanagers too, such as the [Prometheus Alertmanager](https://prometheus.io/docs/alerting/latest/alertmanager/). The Grafana Alertmanager uses notification policies and contact points to configure how and where a notification is sent; how often a notification should be sent; and whether alerts should all be sent in the same notification, sent in grouped notifications based on a set of labels, or as separate notifications.
 
 ## Notification policies
 

--- a/docs/sources/alerting/manage-notifications/alertmanager.md
+++ b/docs/sources/alerting/manage-notifications/alertmanager.md
@@ -4,7 +4,7 @@ aliases:
   - /docs/grafana/latest/alerting/metrics/
   - /docs/grafana/latest/alerting/unified-alerting/fundamentals/alertmanager/
 title: Alertmanager
-weight: 116
+weight: 460
 ---
 
 # Alertmanager

--- a/docs/sources/alerting/manage-notifications/images-in-notifications.md
+++ b/docs/sources/alerting/manage-notifications/images-in-notifications.md
@@ -7,7 +7,7 @@ keywords:
   - images
   - notifications
 title: Use images in notifications
-weight: 460
+weight: 480
 ---
 
 # Use images in notifications


### PR DESCRIPTION
**What is this feature?**

This pull request mentions Alertmanagers in the "Notifications" docs and moves the "Alertmanager" docs under "Manage your alert notifications".

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

