### PR TITLE
Themes: Re-init graph on theme change

### DIFF
--- a/packages/grafana-ui/src/components/TimeSeries/TimeSeries.tsx
+++ b/packages/grafana-ui/src/components/TimeSeries/TimeSeries.tsx
@@ -10,7 +10,7 @@ import { UPlotConfigBuilder } from '../uPlot/config/UPlotConfigBuilder';
 
 import { preparePlotConfigBuilder } from './utils';
 
-const propsToDiff: Array<string | PropDiffFn> = ['legend', 'options'];
+const propsToDiff: Array<string | PropDiffFn> = ['legend', 'options', 'theme'];
 
 type TimeSeriesProps = Omit<GraphNGProps, 'prepConfig' | 'propsToDiff' | 'renderLegend'>;
 


### PR DESCRIPTION
Fixes issue with time series not picking up theme change right away without a full page reload
