### PR TITLE
AzureMonitor: Fix bad request when setting dimensions

### DIFF
--- a/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource.go
+++ b/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource.go
@@ -185,10 +185,12 @@ func (e *AzureMonitorDatasource) buildQueries(logger log.Logger, queries []backe
 			Alias:     alias,
 			TimeRange: query.TimeRange,
 		}
-		if filterInBody {
-			query.BodyFilter = filterString
-		} else {
-			query.Params.Add("$filter", filterString)
+		if filterString != "" {
+			if filterInBody {
+				query.BodyFilter = filterString
+			} else {
+				query.Params.Add("$filter", filterString)
+			}
 		}
 		azureMonitorQueries = append(azureMonitorQueries, query)
 	}

--- a/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource.go
+++ b/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource.go
@@ -107,6 +107,7 @@ func (e *AzureMonitorDatasource) buildQueries(logger log.Logger, queries []backe
 		}
 
 		azureURL := BuildSubscriptionMetricsURL(queryJSONModel.Subscription)
+		filterInBody := true
 		if azJSONModel.Region != "" {
 			params.Add("region", azJSONModel.Region)
 		} else {
@@ -121,6 +122,8 @@ func (e *AzureMonitorDatasource) buildQueries(logger log.Logger, queries []backe
 				ResourceName:        azJSONModel.ResourceName,
 			}
 			azureURL = ub.BuildMetricsURL()
+			// POST requests are only supported at the subscription level
+			filterInBody = false
 		}
 
 		// old model
@@ -174,15 +177,20 @@ func (e *AzureMonitorDatasource) buildQueries(logger log.Logger, queries []backe
 			logger.Debug("Azuremonitor request", "params", params)
 		}
 
-		azureMonitorQueries = append(azureMonitorQueries, &types.AzureMonitorQuery{
+		query := &types.AzureMonitorQuery{
 			URL:       azureURL,
 			Target:    target,
 			Params:    params,
 			RefID:     query.RefID,
 			Alias:     alias,
 			TimeRange: query.TimeRange,
-			Filter:    filterString,
-		})
+		}
+		if filterInBody {
+			query.BodyFilter = filterString
+		} else {
+			query.Params.Add("$filter", filterString)
+		}
+		azureMonitorQueries = append(azureMonitorQueries, query)
 	}
 
 	return azureMonitorQueries, nil
@@ -200,9 +208,9 @@ func (e *AzureMonitorDatasource) executeQuery(ctx context.Context, logger log.Lo
 
 	req.URL.Path = path.Join(req.URL.Path, query.URL)
 	req.URL.RawQuery = query.Params.Encode()
-	if query.Filter != "" {
+	if query.BodyFilter != "" {
 		req.Method = http.MethodPost
-		req.Body = io.NopCloser(strings.NewReader(fmt.Sprintf(`{"filter": "%s"}`, query.Filter)))
+		req.Body = io.NopCloser(strings.NewReader(fmt.Sprintf(`{"filter": "%s"}`, query.BodyFilter)))
 	}
 
 	ctx, span := tracer.Start(ctx, "azuremonitor query")

--- a/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource_test.go
@@ -298,7 +298,11 @@ func TestAzureMonitorBuildQueries(t *testing.T) {
 				azureMonitorQuery.BodyFilter = tt.expectedFilter
 			} else {
 				// In other case, the filter will be added in the URL
-				assert.Equal(t, tt.expectedFilter, queries[0].Params.Get("$filter"))
+				if tt.expectedFilter != "" {
+					assert.Equal(t, tt.expectedFilter, queries[0].Params.Get("$filter"))
+				} else {
+					assert.Equal(t, false, queries[0].Params.Has("$filter"))
+				}
 			}
 			if azureMonitorQuery.URL == "" {
 				azureMonitorQuery.URL = "/subscriptions/12345678-aaaa-bbbb-cccc-123456789abc/resourceGroups/grafanastaging/providers/Microsoft.Compute/virtualMachines/grafana/providers/microsoft.insights/metrics"

--- a/pkg/tsdb/azuremonitor/types/types.go
+++ b/pkg/tsdb/azuremonitor/types/types.go
@@ -59,13 +59,13 @@ type DatasourceInfo struct {
 // AzureMonitorQuery is the query for all the services as they have similar queries
 // with a url, a querystring and an alias field
 type AzureMonitorQuery struct {
-	URL       string
-	Target    string
-	Params    url.Values
-	RefID     string
-	Alias     string
-	TimeRange backend.TimeRange
-	Filter    string
+	URL        string
+	Target     string
+	Params     url.Values
+	RefID      string
+	Alias      string
+	TimeRange  backend.TimeRange
+	BodyFilter string
 }
 
 // AzureMonitorResponse is the json response from the Azure Monitor API


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

The [metric list](https://learn.microsoft.com/en-us/rest/api/monitor/metrics/list) API endpoint only supports to set the `filter` in the body of a POST request if the resourceID is a subscription, not a resource, causing the response to return a `400 Bad Request`.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #59629

**Special notes for your reviewer**:

