### PR TITLE
Alerting: Move modal buttons before the rules table

### DIFF
--- a/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
+++ b/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
@@ -394,6 +394,26 @@ export function EditCloudGroupModal(props: ModalProps): React.ReactElement {
             {checkEvaluationIntervalGlobalLimit(watch('groupInterval')).exceedsLimit && (
               <EvaluationIntervalLimitExceeded />
             )}
+            <div className={styles.modalButtons}>
+              <Modal.ButtonRow>
+                <Button
+                  variant="secondary"
+                  type="button"
+                  disabled={loading}
+                  onClick={() => onClose(false)}
+                  fill="outline"
+                >
+                  Close
+                </Button>
+                <Button
+                  type="button"
+                  disabled={!isDirty || loading}
+                  onClick={handleSubmit((values) => onSubmit(values), onInvalid)}
+                >
+                  {loading ? 'Saving...' : 'Save changes'}
+                </Button>
+              </Modal.ButtonRow>
+            </div>
             {rulerRuleRequests && (
               <>
                 <div>List of rules that belong to this group</div>
@@ -407,25 +427,6 @@ export function EditCloudGroupModal(props: ModalProps): React.ReactElement {
                 />
               </>
             )}
-
-            <Modal.ButtonRow>
-              <Button
-                variant="secondary"
-                type="button"
-                disabled={loading}
-                onClick={() => onClose(false)}
-                fill="outline"
-              >
-                Close
-              </Button>
-              <Button
-                type="button"
-                disabled={!isDirty || loading}
-                onClick={handleSubmit((values) => onSubmit(values), onInvalid)}
-              >
-                {loading ? 'Saving...' : 'Save changes'}
-              </Button>
-            </Modal.ButtonRow>
           </>
         </form>
       </FormProvider>
@@ -436,6 +437,10 @@ export function EditCloudGroupModal(props: ModalProps): React.ReactElement {
 const getStyles = (theme: GrafanaTheme2) => ({
   modal: css`
     max-width: 560px;
+  `,
+  modalButtons: css`
+    top: -24px;
+    position: relative;
   `,
   formInput: css`
     width: 275px;


### PR DESCRIPTION

**What is this feature?**

This PR moves the group modal buttons before the list of rules, as this list doesn't belong to the form.

**Why do we need this feature?**

With this change, user can easily see the buttons to save the changes and there is no need to scroll down.

**Who is this feature for?**

User that maintain evaluation groups.

**Special notes for your reviewer**:

<img width="712" alt="Screenshot 2022-12-02 at 12 20 30" src="https://user-images.githubusercontent.com/33540275/205282955-5e67f770-ba30-4ad7-9f0f-6bb065e8fd8d.png">


