### PR TITLE
Elasticsearch: Fix removing of empty settings from query in backend implementation

### DIFF
--- a/pkg/tsdb/elasticsearch/time_series_query.go
+++ b/pkg/tsdb/elasticsearch/time_series_query.go
@@ -454,7 +454,7 @@ func (p *timeSeriesQueryParser) parseMetrics(model *simplejson.Json) ([]*MetricA
 		metric.Hide = metricJSON.Get("hide").MustBool(false)
 		metric.ID = metricJSON.Get("id").MustString()
 		metric.PipelineAggregate = metricJSON.Get("pipelineAgg").MustString()
-		// In legacy editors, we were storing empty settings values as null
+		// In legacy editors, we were storing empty settings values as "null"
 		// The new editor doesn't store empty strings at all
 		// We need to ensures backward compatibility with old queries and remove empty fields
 		settings := metricJSON.Get("settings").MustMap()

--- a/pkg/tsdb/elasticsearch/time_series_query.go
+++ b/pkg/tsdb/elasticsearch/time_series_query.go
@@ -181,7 +181,6 @@ func (e *timeSeriesQuery) processQuery(q *Query, ms *es.MultiSearchRequestBuilde
 	return nil
 }
 
-// Changes string values to float64 values in json
 func setFloatPath(settings *simplejson.Json, path ...string) {
 	if stringValue, err := settings.GetPath(path...).String(); err == nil {
 		if value, err := strconv.ParseFloat(stringValue, 64); err == nil {
@@ -190,7 +189,6 @@ func setFloatPath(settings *simplejson.Json, path ...string) {
 	}
 }
 
-// Changes string values to int64 values in json
 func setIntPath(settings *simplejson.Json, path ...string) {
 	if stringValue, err := settings.GetPath(path...).String(); err == nil {
 		if value, err := strconv.ParseInt(stringValue, 10, 64); err == nil {

--- a/pkg/tsdb/elasticsearch/time_series_query.go
+++ b/pkg/tsdb/elasticsearch/time_series_query.go
@@ -222,6 +222,7 @@ func (metricAggregation MetricAgg) generateSettingsForDSL() map[string]interface
 			metricAggregation.Settings.SetPath([]string{"script"}, scriptValue)
 		}
 	}
+
 	return metricAggregation.Settings.MustMap()
 }
 
@@ -454,7 +455,8 @@ func (p *timeSeriesQueryParser) parseMetrics(model *simplejson.Json) ([]*MetricA
 		metric.ID = metricJSON.Get("id").MustString()
 		metric.PipelineAggregate = metricJSON.Get("pipelineAgg").MustString()
 		// In legacy editors, we were storing empty settings values as null
-		// The new editor doesn't store empty strings at all, but we need to ensures backward compatibility with old queries
+		// The new editor doesn't store empty strings at all
+		// We need to ensures backward compatibility with old queries and remove empty fields
 		settings := metricJSON.Get("settings").MustMap()
 		for k, v := range settings {
 			if v == "null" {

--- a/pkg/tsdb/elasticsearch/time_series_query_test.go
+++ b/pkg/tsdb/elasticsearch/time_series_query_test.go
@@ -39,7 +39,6 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 			require.Equal(t, dateHistogramAgg.ExtendedBounds.Min, fromMs)
 			require.Equal(t, dateHistogramAgg.ExtendedBounds.Max, toMs)
 		})
-
 		t.Run("Should clean settings from null values (from frontend tests)", func(t *testing.T) {
 			c := newFakeClient()
 			_, err := executeTsdbQuery(c, `{
@@ -52,8 +51,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 			firstLevel := sr.Aggs[0]
 			secondLevel := firstLevel.Aggregation.Aggs[0]
 			require.Equal(t, secondLevel.Aggregation.Aggregation.(*es.MetricAggregation).Settings["script"], "1")
-			// FIXME: This is a bug in implementation, missing is set to "null" instead of being removed
-			// require.Equal(t, secondLevel.Aggregation.Aggregation.(*es.MetricAggregation).Settings["missing"], nil)
+			require.NotContains(t, secondLevel.Aggregation.Aggregation.(*es.MetricAggregation).Settings, "missing")
 		})
 
 		t.Run("With multiple bucket aggs", func(t *testing.T) {

--- a/public/app/plugins/datasource/elasticsearch/QueryBuilder.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/QueryBuilder.test.ts
@@ -22,7 +22,7 @@ describe('ElasticQueryBuilder', () => {
       // The following `missing: null as any` is because previous versions of the DS where
       // storing null in the query model when inputting an empty string,
       // which were then removed in the query builder.
-      // The new version doesn't store empty strings at all. This tests ensures backward compatinility.
+      // The new version doesn't store empty strings at all. This tests ensures backward compatibility.
       metrics: [{ type: 'avg', id: '0', settings: { missing: null as any, script: '1' } }],
       timeField: '@timestamp',
       bucketAggs: [{ type: 'date_histogram', field: '@timestamp', id: '1' }],


### PR DESCRIPTION
Part of https://github.com/grafana/grafana/issues/54011

Fixes 1 failing tests that was commented out during https://github.com/grafana/grafana/pull/59578. 

This PR is basically same as https://github.com/grafana/grafana/pull/30234 that was done on frontend. 