### PR TITLE
elastic: remove unused debug-code

### DIFF
--- a/pkg/tsdb/elasticsearch/client/models.go
+++ b/pkg/tsdb/elasticsearch/client/models.go
@@ -2,16 +2,10 @@ package es
 
 import (
 	"encoding/json"
-	"net/http"
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/tsdb/intervalv2"
 )
-
-type response struct {
-	httpResponse *http.Response
-	reqInfo      *SearchRequestInfo
-}
 
 type SearchRequestInfo struct {
 	Method string `json:"method"`
@@ -22,11 +16,6 @@ type SearchRequestInfo struct {
 type SearchResponseInfo struct {
 	Status int              `json:"status"`
 	Data   *simplejson.Json `json:"data"`
-}
-
-type SearchDebugInfo struct {
-	Request  *SearchRequestInfo  `json:"request"`
-	Response *SearchResponseInfo `json:"response"`
 }
 
 // SearchRequest represents a search request
@@ -83,7 +72,6 @@ type MultiSearchRequest struct {
 type MultiSearchResponse struct {
 	Status    int               `json:"status,omitempty"`
 	Responses []*SearchResponse `json:"responses"`
-	DebugInfo *SearchDebugInfo  `json:"-"`
 }
 
 // Query represents a query

--- a/pkg/tsdb/elasticsearch/client/models.go
+++ b/pkg/tsdb/elasticsearch/client/models.go
@@ -3,20 +3,8 @@ package es
 import (
 	"encoding/json"
 
-	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/tsdb/intervalv2"
 )
-
-type SearchRequestInfo struct {
-	Method string `json:"method"`
-	Url    string `json:"url"`
-	Data   string `json:"data"`
-}
-
-type SearchResponseInfo struct {
-	Status int              `json:"status"`
-	Data   *simplejson.Json `json:"data"`
-}
 
 // SearchRequest represents a search request
 type SearchRequest struct {

--- a/pkg/tsdb/elasticsearch/response_parser_test.go
+++ b/pkg/tsdb/elasticsearch/response_parser_test.go
@@ -1216,5 +1216,5 @@ func newResponseParserForTest(tsdbQueries map[string]string, responseBody string
 		return nil, err
 	}
 
-	return newResponseParser(response.Responses, queries, nil), nil
+	return newResponseParser(response.Responses, queries), nil
 }

--- a/pkg/tsdb/elasticsearch/testdata/trimedges_string.golden.jsonc
+++ b/pkg/tsdb/elasticsearch/testdata/trimedges_string.golden.jsonc
@@ -1,8 +1,6 @@
 //  🌟 This was machine generated.  Do not edit. 🌟
 //  
-//  Frame[0] {
-//      "custom": null
-//  }
+//  Frame[0] 
 //  Name: 
 //  Dimensions: 2 Fields by 3 Rows
 //  +-------------------------------+------------------+
@@ -22,9 +20,6 @@
   "frames": [
     {
       "schema": {
-        "meta": {
-          "custom": null
-        },
         "fields": [
           {
             "name": "time",

--- a/pkg/tsdb/elasticsearch/testdata_response/metric_complex.a.golden.jsonc
+++ b/pkg/tsdb/elasticsearch/testdata_response/metric_complex.a.golden.jsonc
@@ -1,8 +1,6 @@
 //  🌟 This was machine generated.  Do not edit. 🌟
 //  
-//  Frame[0] {
-//      "custom": null
-//  }
+//  Frame[0] 
 //  Name: 
 //  Dimensions: 2 Fields by 3 Rows
 //  +-------------------------------+--------------------+
@@ -17,9 +15,7 @@
 //  
 //  
 //  
-//  Frame[1] {
-//      "custom": null
-//  }
+//  Frame[1] 
 //  Name: 
 //  Dimensions: 2 Fields by 3 Rows
 //  +-------------------------------+--------------------+
@@ -34,9 +30,7 @@
 //  
 //  
 //  
-//  Frame[2] {
-//      "custom": null
-//  }
+//  Frame[2] 
 //  Name: 
 //  Dimensions: 2 Fields by 3 Rows
 //  +-------------------------------+--------------------+
@@ -51,9 +45,7 @@
 //  
 //  
 //  
-//  Frame[3] {
-//      "custom": null
-//  }
+//  Frame[3] 
 //  Name: 
 //  Dimensions: 2 Fields by 3 Rows
 //  +-------------------------------+--------------------+
@@ -68,9 +60,7 @@
 //  
 //  
 //  
-//  Frame[4] {
-//      "custom": null
-//  }
+//  Frame[4] 
 //  Name: 
 //  Dimensions: 2 Fields by 3 Rows
 //  +-------------------------------+--------------------+
@@ -85,9 +75,7 @@
 //  
 //  
 //  
-//  Frame[5] {
-//      "custom": null
-//  }
+//  Frame[5] 
 //  Name: 
 //  Dimensions: 2 Fields by 3 Rows
 //  +-------------------------------+--------------------+
@@ -107,9 +95,6 @@
   "frames": [
     {
       "schema": {
-        "meta": {
-          "custom": null
-        },
         "fields": [
           {
             "name": "time",
@@ -154,9 +139,6 @@
     },
     {
       "schema": {
-        "meta": {
-          "custom": null
-        },
         "fields": [
           {
             "name": "time",
@@ -201,9 +183,6 @@
     },
     {
       "schema": {
-        "meta": {
-          "custom": null
-        },
         "fields": [
           {
             "name": "time",
@@ -248,9 +227,6 @@
     },
     {
       "schema": {
-        "meta": {
-          "custom": null
-        },
         "fields": [
           {
             "name": "time",
@@ -295,9 +271,6 @@
     },
     {
       "schema": {
-        "meta": {
-          "custom": null
-        },
         "fields": [
           {
             "name": "time",
@@ -342,9 +315,6 @@
     },
     {
       "schema": {
-        "meta": {
-          "custom": null
-        },
         "fields": [
           {
             "name": "time",

--- a/pkg/tsdb/elasticsearch/testdata_response/metric_multi.a.golden.jsonc
+++ b/pkg/tsdb/elasticsearch/testdata_response/metric_multi.a.golden.jsonc
@@ -1,8 +1,6 @@
 //  🌟 This was machine generated.  Do not edit. 🌟
 //  
-//  Frame[0] {
-//      "custom": null
-//  }
+//  Frame[0] 
 //  Name: 
 //  Dimensions: 2 Fields by 3 Rows
 //  +-------------------------------+-------------------+
@@ -22,9 +20,6 @@
   "frames": [
     {
       "schema": {
-        "meta": {
-          "custom": null
-        },
         "fields": [
           {
             "name": "time",

--- a/pkg/tsdb/elasticsearch/testdata_response/metric_multi.b.golden.jsonc
+++ b/pkg/tsdb/elasticsearch/testdata_response/metric_multi.b.golden.jsonc
@@ -1,8 +1,6 @@
 //  🌟 This was machine generated.  Do not edit. 🌟
 //  
-//  Frame[0] {
-//      "custom": null
-//  }
+//  Frame[0] 
 //  Name: 
 //  Dimensions: 2 Fields by 3 Rows
 //  +-------------------------------+---------------------+
@@ -22,9 +20,6 @@
   "frames": [
     {
       "schema": {
-        "meta": {
-          "custom": null
-        },
         "fields": [
           {
             "name": "time",

--- a/pkg/tsdb/elasticsearch/testdata_response/metric_simple.a.golden.jsonc
+++ b/pkg/tsdb/elasticsearch/testdata_response/metric_simple.a.golden.jsonc
@@ -1,8 +1,6 @@
 //  🌟 This was machine generated.  Do not edit. 🌟
 //  
-//  Frame[0] {
-//      "custom": null
-//  }
+//  Frame[0] 
 //  Name: 
 //  Dimensions: 2 Fields by 4 Rows
 //  +-------------------------------+--------------------+
@@ -18,9 +16,7 @@
 //  
 //  
 //  
-//  Frame[1] {
-//      "custom": null
-//  }
+//  Frame[1] 
 //  Name: 
 //  Dimensions: 2 Fields by 4 Rows
 //  +-------------------------------+--------------------+
@@ -36,9 +32,7 @@
 //  
 //  
 //  
-//  Frame[2] {
-//      "custom": null
-//  }
+//  Frame[2] 
 //  Name: 
 //  Dimensions: 2 Fields by 4 Rows
 //  +-------------------------------+--------------------+
@@ -59,9 +53,6 @@
   "frames": [
     {
       "schema": {
-        "meta": {
-          "custom": null
-        },
         "fields": [
           {
             "name": "time",
@@ -108,9 +99,6 @@
     },
     {
       "schema": {
-        "meta": {
-          "custom": null
-        },
         "fields": [
           {
             "name": "time",
@@ -157,9 +145,6 @@
     },
     {
       "schema": {
-        "meta": {
-          "custom": null
-        },
         "fields": [
           {
             "name": "time",

--- a/pkg/tsdb/elasticsearch/time_series_query.go
+++ b/pkg/tsdb/elasticsearch/time_series_query.go
@@ -57,7 +57,7 @@ func (e *timeSeriesQuery) execute() (*backend.QueryDataResponse, error) {
 		return &backend.QueryDataResponse{}, err
 	}
 
-	rp := newResponseParser(res.Responses, queries, res.DebugInfo)
+	rp := newResponseParser(res.Responses, queries)
 	return rp.getTimeSeries()
 }
 

--- a/pkg/tsdb/elasticsearch/time_series_query_test.go
+++ b/pkg/tsdb/elasticsearch/time_series_query_test.go
@@ -1713,8 +1713,6 @@ func newFakeClient() *fakeClient {
 	}
 }
 
-func (c *fakeClient) EnableDebug() {}
-
 func (c *fakeClient) GetTimeField() string {
 	return c.timeField
 }


### PR DESCRIPTION
fixes https://github.com/grafana/grafana/issues/58428

the way this diff happened is:
1. because now no code calls `client.EnableDebug()`, `client.debugEnabled` is always `false`
2. because `client.debugEnabled` is always `false`, all the code that is in `if c.debugEnabled` sections, can be removed, so i removed them
3. because the code removed in [2], even more fields, in other structures became never-used. so i found them, and removed those too
4. some snapshot-tests had to be updated for this change, but you can see that the difference is that empty-frame-meta-sections getting removed