### PR TITLE
Package: @grafana/e2e updates

### DIFF
--- a/packages/grafana-e2e/cypress.json
+++ b/packages/grafana-e2e/cypress.json
@@ -1,5 +1,7 @@
 {
   "projectId": "zb7k1c",
   "supportFile": "cypress/support/index.ts",
-  "videoCompression": 20
+  "videoCompression": 20,
+  "viewportWidth": 1920,
+  "viewportHeight": 1080
 }

--- a/packages/grafana-e2e/src/flows/addDashboard.ts
+++ b/packages/grafana-e2e/src/flows/addDashboard.ts
@@ -236,9 +236,9 @@ const addVariable = (config: PartialAddVariableConfig, isFirst: boolean): AddVar
     e2e.pages.Dashboard.Settings.Variables.Edit.General.generalTypeSelectV2()
       .should('be.visible')
       .within(() => {
-        e2e.components.Select.singleValue().should('have.text', 'Query').click();
+        e2e.components.Select.singleValue().should('have.text', 'Query').parent().click();
       });
-    e2e.components.Select.option().should('be.visible').contains(type).click();
+    e2e.pages.Dashboard.Settings.Variables.Edit.General.generalTypeSelectV2().find('input').type(`${type}{enter}`);
   }
 
   if (label) {


### PR DESCRIPTION
Some issues in the `addDashboard` flow preventing Timestream E2E tests from functioning as expected on the latest grafana version.

- Update addDashboard flow to work with latest grafana
- Update viewport configuration to ensure components aren't hidden

Should unblock grafana/timestream-datasource#206.