### PR TITLE
Alerting: Reduce number of scroll bars in rule group modal

### DIFF
--- a/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
+++ b/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
@@ -451,8 +451,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
   tableWrapper: css`
     margin-top: ${theme.spacing(2)};
     margin-bottom: ${theme.spacing(2)};
-    height: 225px;
-    overflow: auto;
+    height: 100%;
   `,
   evalRequiredLabel: css`
     font-size: ${theme.typography.bodySmall.fontSize};


### PR DESCRIPTION
**What is this feature?**

This PR reduces the number of scroll bars in rule group modal.

**Why do we need this feature?**

We had two scroll bars (on for rules table and the other that appears if the modal has no enough vertical space). Having only one (the modal vertical scrollbar) will be enough.

**Who is this feature for?**

All alerting users.

**Special notes for your reviewer**:

https://user-images.githubusercontent.com/33540275/205313791-f300b06f-43f2-40e0-b02e-36982c748188.mp4


