### PR TITLE
Alerting: Simplify scheduler configuration and remove dependency on Grafana-wide settings

### DIFF
--- a/pkg/services/ngalert/metrics/ngalert.go
+++ b/pkg/services/ngalert/metrics/ngalert.go
@@ -100,7 +100,7 @@ func (ng *NGAlert) GetMultiOrgAlertmanagerMetrics() *MultiOrgAlertmanager {
 func NewNGAlert(r prometheus.Registerer) *NGAlert {
 	return &NGAlert{
 		Registerer:                  r,
-		schedulerMetrics:            newSchedulerMetrics(r),
+		schedulerMetrics:            NewSchedulerMetrics(r),
 		stateMetrics:                newStateMetrics(r),
 		multiOrgAlertmanagerMetrics: newMultiOrgAlertmanagerMetrics(r),
 		apiMetrics:                  newAPIMetrics(r),
@@ -125,7 +125,7 @@ func (moa *MultiOrgAlertmanager) GetOrCreateOrgRegistry(id int64) prometheus.Reg
 	return moa.registries.GetOrCreateOrgRegistry(id)
 }
 
-func newSchedulerMetrics(r prometheus.Registerer) *Scheduler {
+func NewSchedulerMetrics(r prometheus.Registerer) *Scheduler {
 	return &Scheduler{
 		Registerer: r,
 		BehindSeconds: promauto.With(r).NewGauge(prometheus.GaugeOpts{

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -186,7 +186,8 @@ func (ng *AlertNG) init() error {
 	schedCfg := schedule.SchedulerCfg{
 		MaxAttempts:          ng.Cfg.UnifiedAlerting.MaxAttempts,
 		C:                    clk,
-		MinRuleInterval:      ng.Cfg.UnifiedAlerting.BaseInterval,
+		BaseInterval:         ng.Cfg.UnifiedAlerting.BaseInterval,
+		MinRuleInterval:      ng.Cfg.UnifiedAlerting.MinInterval,
 		DisableGrafanaFolder: ng.Cfg.UnifiedAlerting.ReservedLabels.IsReservedLabelDisabled(models.FolderTitleLabel),
 		AppURL:               appUrl,
 		EvaluatorFactory:     evalFactory,

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -184,17 +184,20 @@ func (ng *AlertNG) init() error {
 
 	evalFactory := eval.NewEvaluatorFactory(ng.Cfg.UnifiedAlerting, ng.DataSourceCache, ng.ExpressionService)
 	schedCfg := schedule.SchedulerCfg{
-		Cfg:              ng.Cfg.UnifiedAlerting,
-		C:                clk,
-		EvaluatorFactory: evalFactory,
-		RuleStore:        store,
-		Metrics:          ng.Metrics.GetSchedulerMetrics(),
-		AlertSender:      alertsRouter,
+		MaxAttempts:          ng.Cfg.UnifiedAlerting.MaxAttempts,
+		C:                    clk,
+		MinRuleInterval:      ng.Cfg.UnifiedAlerting.BaseInterval,
+		DisableGrafanaFolder: ng.Cfg.UnifiedAlerting.ReservedLabels.IsReservedLabelDisabled(models.FolderTitleLabel),
+		AppURL:               appUrl,
+		EvaluatorFactory:     evalFactory,
+		RuleStore:            store,
+		Metrics:              ng.Metrics.GetSchedulerMetrics(),
+		AlertSender:          alertsRouter,
 	}
 
 	historian := historian.NewAnnotationHistorian(ng.annotationsRepo, ng.dashboardService)
 	stateManager := state.NewManager(ng.Metrics.GetStateMetrics(), appUrl, store, ng.imageService, clk, historian)
-	scheduler := schedule.NewScheduler(schedCfg, appUrl, stateManager)
+	scheduler := schedule.NewScheduler(schedCfg, stateManager)
 
 	// if it is required to include folder title to the alerts, we need to subscribe to changes of alert title
 	if !ng.Cfg.UnifiedAlerting.ReservedLabels.IsReservedLabelDisabled(models.FolderTitleLabel) {


### PR DESCRIPTION
**What is this feature?**

Simplifies the scheduler config and makes it independent of the Grafana-wide settings structure.

Rather than asking for all Unified Alerting settings, the scheduler's cfg struct now only asks for the fields that the scheduler cares about.

**Why do we need this feature?**

Reduces coupling between the scheduler and core Grafana objects.

**Which issue(s) does this PR fix?**:

n/a

**Special notes for your reviewer**:

