### PR TITLE
Docs: removes email templating

### DIFF
--- a/docs/sources/whatsnew/whats-new-in-v9-3.md
+++ b/docs/sources/whatsnew/whats-new-in-v9-3.md
@@ -221,12 +221,6 @@ Finally, we have fixed several access control related bugs to ensure a smoother 
 
 All of these new alerting features are generally available in all editions of Grafana.
 
-### Email templating
-
-We've improved the design and functionality of email templates to make template creation much easier and more customizable. The email template framework utilizes MJML to define and compile the final email HTML output. Sprig functions in the email templates provide more customizable template functions.
-
-{{< figure src="/static/img/docs/alerting/alert-templates-whats-new-v9.3.png" max-width="750px" caption="Email template redesign" >}}
-
 ### Support for Webex Teams
 
 You can now use Cisco Webex Teams as a contact point, to send alerts to a Webex Teams space.


### PR DESCRIPTION
This PR removes the email templating section from 9.3 what's new because that change did not make it into the 9.3 release. I have moved that content to the what's new doc for v9.4.