### PR TITLE
Dashboard: .txt file extension is not supported in /dashboard/import file upload

### DIFF
--- a/public/app/features/manage-dashboards/DashboardImportPage.tsx
+++ b/public/app/features/manage-dashboards/DashboardImportPage.tsx
@@ -131,7 +131,7 @@ class UnthemedDashboardImport extends PureComponent<Props> {
     return (
       <>
         <div className={styles.option}>
-          <FileUpload accept="application/json" onFileUpload={this.onFileUpload}>
+          <FileUpload accept="application/json, text/plain" onFileUpload={this.onFileUpload}>
             Upload JSON file
           </FileUpload>
         </div>
@@ -189,7 +189,7 @@ class UnthemedDashboardImport extends PureComponent<Props> {
 
   pageNav: NavModelItem = {
     text: 'Import dashboard',
-    subTitle: 'Import dashboard from file or Grafana.com"',
+    subTitle: 'Import dashboard from file or Grafana.com',
     breadcrumbs: [{ title: 'Dashboards', url: 'dashboards' }],
   };
 


### PR DESCRIPTION
**What is this feature?**
We provide .txt dashboard exports now in the Panel > More > Get help > export view, but we don't allow imports of them.

**Why do we need this feature?**
General usability, users might not know how to workaround the suggested file types, and be unable to import dashboards provided from the debug export.

**Who is this feature for?**
Users importing dashboards

**Which issue(s) does this PR fix?**:
Fixes https://github.com/grafana/grafana/issues/59759

**Special notes for your reviewer**:
Should be quick and easy
