### PR TITLE
Traces: Add query tags setting for trace to logs

### DIFF
--- a/docs/sources/datasources/jaeger/_index.md
+++ b/docs/sources/datasources/jaeger/_index.md
@@ -62,6 +62,7 @@ Select a target data source, limited to Loki and Splunk \[logs\] data sources, a
 | **Span end time shift**   | Shifts the end time for the logs query based on the span end time. Use time interval units. Default is `0`.                                                                        |
 | **Filter by Trace ID**    | Toggles whether to append the trace ID to the logs query.                                                                                                                          |
 | **Filter by Span ID**     | Toggles whether to append the span ID to the logs query.                                                                                                                           |
+| **Query tags**            | Adds the tags to your query e.g. index='prod' for Splunk datasources.                                                                                                              |
 
 ### Configure trace to metrics
 
@@ -135,6 +136,7 @@ datasources:
         spanEndTimeShift: '1h'
         filterByTraceID: false
         filterBySpanID: false
+        queryTags: []
       tracesToMetrics:
         datasourceUid: 'prom'
         tags: [{ key: 'service.name', value: 'service' }, { key: 'job' }]

--- a/docs/sources/datasources/tempo/_index.md
+++ b/docs/sources/datasources/tempo/_index.md
@@ -70,6 +70,7 @@ The **Trace to logs** setting configures the [trace to logs feature]({{< relref 
 | **Span end time shift**   | Shifts the end time for the logs query, based on the span's end time. You can use time units. Default is 0.                                                                                     |
 | **Filter by Trace ID**    | Toggles whether to append the trace ID to the logs query.                                                                                                                                       |
 | **Filter by Span ID**     | Toggles whether to append the span ID to the logs query.                                                                                                                                        |
+| **Query tags**            | Adds the tags to your query e.g. index='prod' for Splunk datasources.                                                                                                                           |
 
 ### Configure trace to metrics
 
@@ -161,6 +162,7 @@ datasources:
         spanEndTimeShift: '1h'
         filterByTraceID: false
         filterBySpanID: false
+        queryTags: []
       tracesToMetrics:
         datasourceUid: 'prom'
         tags: [{ key: 'service.name', value: 'service' }, { key: 'job' }]

--- a/docs/sources/datasources/zipkin/_index.md
+++ b/docs/sources/datasources/zipkin/_index.md
@@ -59,6 +59,7 @@ Select a target data source, limited to Loki and Splunk \[logs\] data sources, a
 | **Span end time shift**   | Shifts the end time for the logs query based on the span end time. Use time interval units. Default is `0`.                                                                        |
 | **Filter by Trace ID**    | Toggles whether to append the trace ID to the logs query.                                                                                                                          |
 | **Filter by Span ID**     | Toggles whether to append the span ID to the logs query.                                                                                                                           |
+| **Query tags**            | Adds the tags to your query e.g. index='prod' for Splunk datasources.                                                                                                              |
 
 ### Configure trace to metrics
 

--- a/public/app/core/components/TraceToLogs/TraceToLogsSettings.tsx
+++ b/public/app/core/components/TraceToLogs/TraceToLogsSettings.tsx
@@ -23,6 +23,7 @@ export interface TraceToLogsOptions {
   spanEndTimeShift?: string;
   filterByTraceID?: boolean;
   filterBySpanID?: boolean;
+  queryTags?: string[];
   lokiSearch?: boolean; // legacy
 }
 
@@ -210,6 +211,26 @@ export function TraceToLogsSettings({ options, onOptionsChange }: Props) {
               updateDatasourcePluginJsonDataOption({ onOptionsChange, options }, 'tracesToLogs', {
                 ...options.jsonData.tracesToLogs,
                 filterBySpanID: event.currentTarget.checked,
+              })
+            }
+          />
+        </InlineField>
+      </InlineFieldRow>
+
+      <InlineFieldRow>
+        <InlineField
+          label="Query tags"
+          labelWidth={26}
+          grow
+          tooltip="Adds the tags to your query e.g. index='prod' for Splunk datasources."
+        >
+          <TagsInput
+            tags={options.jsonData.tracesToLogs?.queryTags}
+            width={40}
+            onChange={(tags) =>
+              updateDatasourcePluginJsonDataOption({ onOptionsChange, options }, 'tracesToLogs', {
+                ...options.jsonData.tracesToLogs,
+                queryTags: tags,
               })
             }
           />

--- a/public/app/features/explore/TraceView/createSpanLink.test.ts
+++ b/public/app/features/explore/TraceView/createSpanLink.test.ts
@@ -138,6 +138,22 @@ describe('createSpanLinkFactory', () => {
       );
     });
 
+    it('adds queryTags to the query', () => {
+      const createLink = setupSpanLinkFactory({
+        queryTags: ['index="prod"', 'dest="the moon"'],
+      });
+      expect(createLink).toBeDefined();
+      const links = createLink!(createTraceSpan());
+
+      const linkDef = links?.logLinks?.[0];
+      expect(linkDef).toBeDefined();
+      expect(linkDef!.href).toBe(
+        `/explore?left=${encodeURIComponent(
+          '{"range":{"from":"2020-10-14T01:00:00.000Z","to":"2020-10-14T01:00:01.000Z"},"datasource":"loki1_uid","queries":[{"expr":"{cluster=\\"cluster1\\", hostname=\\"hostname1\\", index=\\"prod\\", dest=\\"the moon\\"}","refId":""}],"panelsState":{}}'
+        )}`
+      );
+    });
+
     it('creates link from dataFrame', () => {
       const splitOpenFn = jest.fn();
       const createLink = createSpanLinkFactory({
@@ -302,6 +318,24 @@ describe('createSpanLinkFactory', () => {
       expect(linkDef!.href).toBe(
         `/explore?left=${encodeURIComponent(
           '{"range":{"from":"2020-10-14T01:00:00.000Z","to":"2020-10-14T01:00:01.000Z"},"datasource":"splunkUID","queries":[{"query":"cluster=\\"cluster1\\" hostname=\\"hostname1\\" \\"7946b05c2e2e4e5a\\" \\"6605c7b08e715d6c\\"","refId":""}],"panelsState":{}}'
+        )}`
+      );
+    });
+
+    it('formats query correctly if queryTags added to query', () => {
+      const createLink = setupSpanLinkFactory({
+        datasourceUid: splunkUID,
+        queryTags: ['index="prod"', 'dest="the moon"'],
+      });
+
+      expect(createLink).toBeDefined();
+      const links = createLink!(createTraceSpan());
+
+      const linkDef = links?.logLinks?.[0];
+      expect(linkDef).toBeDefined();
+      expect(linkDef!.href).toBe(
+        `/explore?left=${encodeURIComponent(
+          '{"range":{"from":"2020-10-14T01:00:00.000Z","to":"2020-10-14T01:00:01.000Z"},"datasource":"splunkUID","queries":[{"query":"cluster=\\"cluster1\\" hostname=\\"hostname1\\" index=\\"prod\\" dest=\\"the moon\\"","refId":""}],"panelsState":{}}'
         )}`
       );
     });
@@ -661,6 +695,27 @@ describe('createSpanLinkFactory', () => {
       expect(linkDef!.href).toBe(
         `/explore?left=${encodeURIComponent(
           `{"range":{"from":"2020-10-14T01:00:00.000Z","to":"2020-10-14T01:00:01.000Z"},"datasource":"${searchUID}","queries":[{"query":"\\"6605c7b08e715d6c\\" AND \\"7946b05c2e2e4e5a\\" AND cluster:\\"cluster1\\" AND hostname:\\"hostname1\\"","refId":"","metrics":[{"id":"1","type":"logs"}]}],"panelsState":{}}`
+        )}`
+      );
+    });
+
+    it('formats query correctly if queryTags added to query', () => {
+      const createLink = setupSpanLinkFactory(
+        {
+          datasourceUid: searchUID,
+          queryTags: ['index="prod"', 'dest="the moon"'],
+        },
+        searchUID
+      );
+
+      expect(createLink).toBeDefined();
+      const links = createLink!(createTraceSpan());
+
+      const linkDef = links?.logLinks?.[0];
+      expect(linkDef).toBeDefined();
+      expect(linkDef!.href).toBe(
+        `/explore?left=${encodeURIComponent(
+          `{"range":{"from":"2020-10-14T01:00:00.000Z","to":"2020-10-14T01:00:01.000Z"},"datasource":"${searchUID}","queries":[{"query":"cluster:\\"cluster1\\" AND hostname:\\"hostname1\\" AND index=\\"prod\\" AND dest=\\"the moon\\"","refId":"","metrics":[{"id":"1","type":"logs"}]}],"panelsState":{}}`
         )}`
       );
     });

--- a/public/app/features/explore/TraceView/createSpanLink.tsx
+++ b/public/app/features/explore/TraceView/createSpanLink.tsx
@@ -262,17 +262,19 @@ function getLinkForLoki(span: TraceSpan, options: TraceToLogsOptions, dataSource
   if (!tags.length) {
     return undefined;
   }
-  let expr = `{${tags.join(', ')}}`;
+  let expr = '{';
+  expr += `${tags.join(', ')}`;
+  if (queryTags && queryTags.length > 0) {
+    for (const tag of queryTags) {
+      expr += `, ${tag}`;
+    }
+  }
+  expr += '}';
   if (filterByTraceID && span.traceID) {
     expr += ` |="${span.traceID}"`;
   }
   if (filterBySpanID && span.spanID) {
     expr += ` |="${span.spanID}"`;
-  }
-  if (queryTags && queryTags.length > 0) {
-    for (const tag of queryTags) {
-      expr += ` ${tag}`;
-    }
   }
 
   const dataLink: DataLink<LokiQuery> = {
@@ -327,16 +329,16 @@ function getLinkForElasticsearchOrOpensearch(
   if (tags.length > 0) {
     query += `${tags.join(' AND ')}`;
   }
+  if (queryTags && queryTags.length > 0) {
+    for (const tag of queryTags) {
+      query += ` AND ${tag}`;
+    }
+  }
   if (filterByTraceID && span.traceID) {
     query = `"${span.traceID}" AND ` + query;
   }
   if (filterBySpanID && span.spanID) {
     query = `"${span.spanID}" AND ` + query;
-  }
-  if (queryTags && queryTags.length > 0) {
-    for (const tag of queryTags) {
-      query += ` AND ${tag}`;
-    }
   }
 
   const dataLink: DataLink<ElasticsearchOrOpensearchQuery> = {
@@ -389,16 +391,16 @@ function getLinkForSplunk(
   if (tags.length > 0) {
     query += `${tags.join(' ')}`;
   }
+  if (queryTags && queryTags.length > 0) {
+    for (const tag of queryTags) {
+      query += ` ${tag}`;
+    }
+  }
   if (filterByTraceID && span.traceID) {
     query += ` "${span.traceID}"`;
   }
   if (filterBySpanID && span.spanID) {
     query += ` "${span.spanID}"`;
-  }
-  if (queryTags && queryTags.length > 0) {
-    for (const tag of queryTags) {
-      query += ` ${tag}`;
-    }
   }
 
   const dataLink: DataLink<DataQuery> = {

--- a/public/app/features/explore/TraceView/createSpanLink.tsx
+++ b/public/app/features/explore/TraceView/createSpanLink.tsx
@@ -239,7 +239,7 @@ function legacyCreateSpanLinkFactory(
  */
 const defaultKeys = ['cluster', 'hostname', 'namespace', 'pod'];
 function getLinkForLoki(span: TraceSpan, options: TraceToLogsOptions, dataSourceSettings: DataSourceInstanceSettings) {
-  const { tags: keys, filterByTraceID, filterBySpanID, mapTagNamesEnabled, mappedTags } = options;
+  const { tags: keys, filterByTraceID, filterBySpanID, mapTagNamesEnabled, mappedTags, queryTags } = options;
 
   // In order, try to use mapped tags -> tags -> default tags
   const keysToCheck = mapTagNamesEnabled && mappedTags?.length ? mappedTags : keys?.length ? keys : defaultKeys;
@@ -268,6 +268,11 @@ function getLinkForLoki(span: TraceSpan, options: TraceToLogsOptions, dataSource
   }
   if (filterBySpanID && span.spanID) {
     expr += ` |="${span.spanID}"`;
+  }
+  if (queryTags && queryTags.length > 0) {
+    for (const tag of queryTags) {
+      expr += ` ${tag}`;
+    }
   }
 
   const dataLink: DataLink<LokiQuery> = {
@@ -301,7 +306,7 @@ function getLinkForElasticsearchOrOpensearch(
   options: TraceToLogsOptions,
   dataSourceSettings: DataSourceInstanceSettings
 ) {
-  const { tags: keys, filterByTraceID, filterBySpanID, mapTagNamesEnabled, mappedTags } = options;
+  const { tags: keys, filterByTraceID, filterBySpanID, mapTagNamesEnabled, mappedTags, queryTags } = options;
   const tags = [...span.process.tags, ...span.tags].reduce((acc: string[], tag) => {
     if (mapTagNamesEnabled && mappedTags?.length) {
       const keysToCheck = mappedTags;
@@ -327,6 +332,11 @@ function getLinkForElasticsearchOrOpensearch(
   }
   if (filterBySpanID && span.spanID) {
     query = `"${span.spanID}" AND ` + query;
+  }
+  if (queryTags && queryTags.length > 0) {
+    for (const tag of queryTags) {
+      query += ` AND ${tag}`;
+    }
   }
 
   const dataLink: DataLink<ElasticsearchOrOpensearchQuery> = {
@@ -356,7 +366,7 @@ function getLinkForSplunk(
   options: TraceToLogsOptions,
   dataSourceSettings: DataSourceInstanceSettings
 ) {
-  const { tags: keys, filterByTraceID, filterBySpanID, mapTagNamesEnabled, mappedTags } = options;
+  const { tags: keys, filterByTraceID, filterBySpanID, mapTagNamesEnabled, mappedTags, queryTags } = options;
 
   // In order, try to use mapped tags -> tags -> default tags
   const keysToCheck = mapTagNamesEnabled && mappedTags?.length ? mappedTags : keys?.length ? keys : defaultKeys;
@@ -384,6 +394,11 @@ function getLinkForSplunk(
   }
   if (filterBySpanID && span.spanID) {
     query += ` "${span.spanID}"`;
+  }
+  if (queryTags && queryTags.length > 0) {
+    for (const tag of queryTags) {
+      query += ` ${tag}`;
+    }
   }
 
   const dataLink: DataLink<DataQuery> = {


### PR DESCRIPTION
**What is this feature?**

This adds query tags to the trace to logs settings for Tempo, Jaeger and Zipkin. Any tags specified here will add those tags to the query that is added (and executed) in the logs datasource after clicking the trace to logs button e.g. logs for this span.

**Why do we need this feature?**

This is more of a requirement for Splunk as e.g. `index="prod"` should be added to the Splunk query. It's also a nice to have for Loki, Elasticsearch where the user may want to add more default tags to the query.

**Who is this feature for?**

Users of Tempo, Jaeger or Zipkin using the trace to logs feature (via Splunk, Loki or Elasticsearch).

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/support-escalations/issues/4504

**Notes for your reviewer**

This is basically an addition to fix an escalation where the user would like to add the index (e.g. index="prod") to every Splunk query initiated from the trace to logs button.

<img width="585" alt="Screenshot 2022-12-03 at 20 40 08" src="https://user-images.githubusercontent.com/90795735/205461247-88103f13-0ee8-4e5f-8e9e-26115a4a710a.png">

<img width="702" alt="Screenshot 2022-12-03 at 20 41 12" src="https://user-images.githubusercontent.com/90795735/205461286-560fde49-42b2-4a2a-bd26-0cb550e85186.png">
