### PR TITLE
Chore: normalize monaco colors to hex string

### DIFF
--- a/packages/grafana-ui/src/components/Monaco/theme.ts
+++ b/packages/grafana-ui/src/components/Monaco/theme.ts
@@ -1,3 +1,5 @@
+import tinycolor from 'tinycolor2';
+
 import { GrafanaTheme2 } from '@grafana/data';
 
 import { Monaco, monacoTypes } from './types';
@@ -6,11 +8,22 @@ function getColors(theme?: GrafanaTheme2): monacoTypes.editor.IColors {
   if (theme === undefined) {
     return {};
   } else {
-    return {
+    const colors: Record<string, string> = {
       'editor.background': theme.components.input.background,
       'minimap.background': theme.colors.background.secondary,
     };
+
+    Object.keys(colors).forEach((resultKey) => {
+      colors[resultKey] = normalizeColorForMonaco(colors[resultKey]);
+    });
+    return colors;
   }
+}
+
+function normalizeColorForMonaco(color?: string): string {
+  // monaco needs 6char hex colors
+  // see https://github.com/grafana/grafana/issues/43158
+  return tinycolor(color).toHexString();
 }
 
 // we support calling this without a theme, it will make sure the themes
@@ -24,9 +37,9 @@ export default function defineThemes(monaco: Monaco, theme?: GrafanaTheme2) {
     colors: colors,
     // fallback syntax highlighting for languages that microsoft doesn't handle (ex cloudwatch's metric math)
     rules: [
-      { token: 'predefined', foreground: theme?.visualization.getColorByName('purple') },
-      { token: 'operator', foreground: theme?.visualization.getColorByName('orange') },
-      { token: 'tag', foreground: theme?.visualization.getColorByName('green') },
+      { token: 'predefined', foreground: normalizeColorForMonaco(theme?.visualization.getColorByName('purple')) },
+      { token: 'operator', foreground: normalizeColorForMonaco(theme?.visualization.getColorByName('orange')) },
+      { token: 'tag', foreground: normalizeColorForMonaco(theme?.visualization.getColorByName('green')) },
     ],
   });
 
@@ -36,9 +49,9 @@ export default function defineThemes(monaco: Monaco, theme?: GrafanaTheme2) {
     colors: colors,
     // fallback syntax highlighting for languages that microsoft doesn't handle (ex cloudwatch's metric math)
     rules: [
-      { token: 'predefined', foreground: theme?.visualization.getColorByName('purple') },
-      { token: 'operator', foreground: theme?.visualization.getColorByName('orange') },
-      { token: 'tag', foreground: theme?.visualization.getColorByName('green') },
+      { token: 'predefined', foreground: normalizeColorForMonaco(theme?.visualization.getColorByName('purple')) },
+      { token: 'operator', foreground: normalizeColorForMonaco(theme?.visualization.getColorByName('orange')) },
+      { token: 'tag', foreground: normalizeColorForMonaco(theme?.visualization.getColorByName('green')) },
     ],
   });
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- adds a new function, `normalizeColorForMonaco`
- this uses the `tinycolor` package to ensure that the color is a hex string
- applies it wherever we're passing colors to monaco

**Why do we need this feature?**

- prevent monaco crashing in the future if we decide to use short hex codes for our colors

**Who is this feature for?**

- grafana devs

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #43158 

**Special notes for your reviewer**:

