### PR TITLE
CloudWatch: Fix deeplinks to still be able to pass log group names

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/utils/datalinks.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/utils/datalinks.test.ts
@@ -35,6 +35,7 @@ describe('addDataLinksToLogsResponse', () => {
           refId: 'A',
           expression: 'stats count(@message) by bin(1h)',
           logGroupNames: ['fake-log-group-one', 'fake-log-group-two'],
+          logGroups: [{}], // empty log groups should be ignored and fall back to logGroupNames
           region: 'us-east-1',
         },
       ],
@@ -115,6 +116,7 @@ describe('addDataLinksToLogsResponse', () => {
         {
           refId: 'A',
           expression: 'stats count(@message) by bin(1h)',
+          logGroupNames: [''],
           logGroups: [
             { value: 'arn:aws:logs:us-east-1:111111111111:log-group:/aws/lambda/test:*' },
             { value: 'arn:aws:logs:us-east-2:222222222222:log-group:/ecs/prometheus:*' },
@@ -174,6 +176,7 @@ describe('addDataLinksToLogsResponse', () => {
         {
           refId: 'A',
           expression: 'stats count(@message) by bin(1h)',
+          logGroupNames: [''],
           logGroups: [{ value: 'arn:aws:logs:us-east-1:111111111111:log-group:/aws/lambda/test' }],
           region: 'us-east-1',
         } as CloudWatchQuery,

--- a/public/app/plugins/datasource/cloudwatch/utils/datalinks.ts
+++ b/public/app/plugins/datasource/cloudwatch/utils/datalinks.ts
@@ -74,7 +74,7 @@ function createAwsConsoleLink(
     .filter((group) => group?.value)
     .map((group) => (group.value ?? '').replace(/:\*$/, '')); // remove `:*` from end of arn
   const logGroupNames = target.logGroupNames;
-  let sources = arns?.length ? arns : logGroupNames;
+  const sources = arns?.length ? arns : logGroupNames;
   const interpolatedExpression = target.expression ? replace(target.expression) : '';
   const interpolatedGroups = sources?.flatMap(getVariableValue) ?? [];
 

--- a/public/app/plugins/datasource/cloudwatch/utils/datalinks.ts
+++ b/public/app/plugins/datasource/cloudwatch/utils/datalinks.ts
@@ -77,12 +77,7 @@ function createAwsConsoleLink(
     return [group.value.replace(/:\*$/, '')]; // remove `:*` from end of arn
   });
   const logGroupNames = target.logGroupNames;
-  let sources: string[] = [];
-  if (arns?.length) {
-    sources = arns;
-  } else if (logGroupNames) {
-    sources = logGroupNames;
-  }
+  let sources = arns?.length ? arns : logGroupNames;
   const interpolatedExpression = target.expression ? replace(target.expression) : '';
   const interpolatedGroups = sources?.flatMap(getVariableValue) ?? [];
 

--- a/public/app/plugins/datasource/cloudwatch/utils/datalinks.ts
+++ b/public/app/plugins/datasource/cloudwatch/utils/datalinks.ts
@@ -76,7 +76,7 @@ function createAwsConsoleLink(
 const logGroupNames = target.logGroupNames ?? [];
   const sources = arns?.length ? arns : logGroupNames;
   const interpolatedExpression = target.expression ? replace(target.expression) : '';
-  const interpolatedGroups = sources?.flatMap(getVariableValue) ?? [];
+const interpolatedGroups = sources?.flatMap(getVariableValue);
 
   const urlProps: AwsUrl = {
     end: range.to.toISOString(),

--- a/public/app/plugins/datasource/cloudwatch/utils/datalinks.ts
+++ b/public/app/plugins/datasource/cloudwatch/utils/datalinks.ts
@@ -78,7 +78,7 @@ function createAwsConsoleLink(
   });
   const logGroupNames = target.logGroupNames;
   let sources = [''];
-  if (arns && arns.length > 0) {
+  if (arns?.length) {
     sources = arns;
   } else if (logGroupNames) {
     sources = logGroupNames;

--- a/public/app/plugins/datasource/cloudwatch/utils/datalinks.ts
+++ b/public/app/plugins/datasource/cloudwatch/utils/datalinks.ts
@@ -77,7 +77,12 @@ function createAwsConsoleLink(
     return [group.value.replace(/:\*$/, '')]; // remove `:*` from end of arn
   });
   const logGroupNames = target.logGroupNames;
-  const sources = arns ?? logGroupNames;
+  let sources = [''];
+  if (arns && arns.length > 0) {
+    sources = arns;
+  } else if (logGroupNames) {
+    sources = logGroupNames;
+  }
   const interpolatedExpression = target.expression ? replace(target.expression) : '';
   const interpolatedGroups = sources?.flatMap(getVariableValue) ?? [];
 

--- a/public/app/plugins/datasource/cloudwatch/utils/datalinks.ts
+++ b/public/app/plugins/datasource/cloudwatch/utils/datalinks.ts
@@ -73,10 +73,10 @@ function createAwsConsoleLink(
   const arns = (target.logGroups ?? [])
     .filter((group) => group?.value)
     .map((group) => (group.value ?? '').replace(/:\*$/, '')); // remove `:*` from end of arn
-const logGroupNames = target.logGroupNames ?? [];
+  const logGroupNames = target.logGroupNames ?? [];
   const sources = arns?.length ? arns : logGroupNames;
   const interpolatedExpression = target.expression ? replace(target.expression) : '';
-const interpolatedGroups = sources?.flatMap(getVariableValue);
+  const interpolatedGroups = sources?.flatMap(getVariableValue);
 
   const urlProps: AwsUrl = {
     end: range.to.toISOString(),

--- a/public/app/plugins/datasource/cloudwatch/utils/datalinks.ts
+++ b/public/app/plugins/datasource/cloudwatch/utils/datalinks.ts
@@ -70,12 +70,9 @@ function createAwsConsoleLink(
   replace: (target: string, fieldName?: string) => string,
   getVariableValue: (value: string) => string[]
 ) {
-  const arns = target.logGroups?.flatMap((group) => {
-    if (group.value === undefined) {
-      return [];
-    }
-    return [group.value.replace(/:\*$/, '')]; // remove `:*` from end of arn
-  });
+  const arns = (target.logGroups ?? [])
+    .filter((group) => group?.value)
+    .map((group) => (group.value ?? '').replace(/:\*$/, '')); // remove `:*` from end of arn
   const logGroupNames = target.logGroupNames;
   let sources = arns?.length ? arns : logGroupNames;
   const interpolatedExpression = target.expression ? replace(target.expression) : '';

--- a/public/app/plugins/datasource/cloudwatch/utils/datalinks.ts
+++ b/public/app/plugins/datasource/cloudwatch/utils/datalinks.ts
@@ -73,7 +73,7 @@ function createAwsConsoleLink(
   const arns = (target.logGroups ?? [])
     .filter((group) => group?.value)
     .map((group) => (group.value ?? '').replace(/:\*$/, '')); // remove `:*` from end of arn
-  const logGroupNames = target.logGroupNames;
+const logGroupNames = target.logGroupNames ?? [];
   const sources = arns?.length ? arns : logGroupNames;
   const interpolatedExpression = target.expression ? replace(target.expression) : '';
   const interpolatedGroups = sources?.flatMap(getVariableValue) ?? [];

--- a/public/app/plugins/datasource/cloudwatch/utils/datalinks.ts
+++ b/public/app/plugins/datasource/cloudwatch/utils/datalinks.ts
@@ -77,7 +77,7 @@ function createAwsConsoleLink(
     return [group.value.replace(/:\*$/, '')]; // remove `:*` from end of arn
   });
   const logGroupNames = target.logGroupNames;
-  let sources = [''];
+  let sources: string[] = [];
   if (arns?.length) {
     sources = arns;
   } else if (logGroupNames) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

While adding ARNs to deeplinks in https://github.com/grafana/grafana/pull/59646, this broke the deeplinks when using `logGroupNames`.
The logic expressed in `sources = arns ?? logGroupNames` for the deeplink was faulty. The `flatMap` on `arns` creates an empty array and so the deeplink was using the empty array as the list of log groups.

This proposes one way to fix by checking the length of the ARNs array.


