### PR TITLE
Chore: Remote cache key prefix

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -162,6 +162,9 @@ type = database
 # memcache: 127.0.0.1:11211
 connstr =
 
+# prefix prepended to all the keys in the remote cache
+prefix =
+
 #################################### Data proxy ###########################
 [dataproxy]
 

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -169,6 +169,9 @@
 # memcache: 127.0.0.1:11211
 ;connstr =
 
+# prefix prepended to all the keys in the remote cache
+; prefix =
+
 #################################### Data proxy ###########################
 [dataproxy]
 

--- a/pkg/infra/remotecache/remotecache.go
+++ b/pkg/infra/remotecache/remotecache.go
@@ -97,20 +97,24 @@ func (ds *RemoteCache) Run(ctx context.Context) error {
 	return ctx.Err()
 }
 
-func createClient(opts *setting.RemoteCacheOptions, sqlstore db.DB) (CacheStorage, error) {
-	if opts.Name == redisCacheType {
-		return newRedisStorage(opts)
+func createClient(opts *setting.RemoteCacheOptions, sqlstore db.DB) (cache CacheStorage, err error) {
+	switch opts.Name {
+	case redisCacheType:
+		cache, err = newRedisStorage(opts)
+	case memcachedCacheType:
+		cache = newMemcachedStorage(opts)
+	case databaseCacheType:
+		cache = newDatabaseCache(sqlstore)
+	default:
+		return nil, ErrInvalidCacheType
 	}
-
-	if opts.Name == memcachedCacheType {
-		return newMemcachedStorage(opts), nil
+	if err != nil {
+		return cache, err
 	}
-
-	if opts.Name == databaseCacheType {
-		return newDatabaseCache(sqlstore), nil
+	if opts.Prefix != "" {
+		cache = &prefixCacheStorage{cache: cache, prefix: opts.Prefix}
 	}
-
-	return nil, ErrInvalidCacheType
+	return cache, nil
 }
 
 // Register records a type, identified by a value for that type, under its
@@ -136,4 +140,19 @@ func encodeGob(item *cachedItem) ([]byte, error) {
 func decodeGob(data []byte, out *cachedItem) error {
 	buf := bytes.NewBuffer(data)
 	return gob.NewDecoder(buf).Decode(&out)
+}
+
+type prefixCacheStorage struct {
+	cache  CacheStorage
+	prefix string
+}
+
+func (pcs *prefixCacheStorage) Get(ctx context.Context, key string) (interface{}, error) {
+	return pcs.cache.Get(ctx, pcs.prefix+key)
+}
+func (pcs *prefixCacheStorage) Set(ctx context.Context, key string, value interface{}, expire time.Duration) error {
+	return pcs.cache.Set(ctx, pcs.prefix+key, value, expire)
+}
+func (pcs *prefixCacheStorage) Delete(ctx context.Context, key string) error {
+	return pcs.cache.Delete(ctx, pcs.prefix+key)
 }

--- a/pkg/infra/remotecache/remotecache_test.go
+++ b/pkg/infra/remotecache/remotecache_test.go
@@ -99,7 +99,8 @@ func TestCachePrefix(t *testing.T) {
 	prefixCache := &prefixCacheStorage{cache: cache, prefix: "test/"}
 
 	// Set a value (with a prefix)
-	prefixCache.Set(context.Background(), "foo", "bar", time.Hour)
+	err := prefixCache.Set(context.Background(), "foo", "bar", time.Hour)
+	require.NoError(t, err)
 	// Get a value (with a prefix)
 	v, err := prefixCache.Get(context.Background(), "foo")
 	require.NoError(t, err)

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -1120,10 +1120,12 @@ func (cfg *Cfg) Load(args CommandLineArgs) error {
 	cacheServer := iniFile.Section("remote_cache")
 	dbName := valueAsString(cacheServer, "type", "database")
 	connStr := valueAsString(cacheServer, "connstr", "")
+	prefix := valueAsString(cacheServer, "prefix", "")
 
 	cfg.RemoteCacheOptions = &RemoteCacheOptions{
 		Name:    dbName,
 		ConnStr: connStr,
+		Prefix:  prefix,
 	}
 
 	geomapSection := iniFile.Section("geomap")
@@ -1159,6 +1161,7 @@ func valueAsString(section *ini.Section, keyName string, defaultValue string) st
 type RemoteCacheOptions struct {
 	Name    string
 	ConnStr string
+	Prefix  string
 }
 
 func (cfg *Cfg) readLDAPConfig() {


### PR DESCRIPTION
This PR introduces a `[remote_cache]` new `prefix` string parameter, that is always prepended to all the keys stored in any of the remote caches (db, memcached, redis).