### PR TITLE
Alerting: Create index on rule group

### DIFF
--- a/pkg/services/sqlstore/migrations/ualert/tables.go
+++ b/pkg/services/sqlstore/migrations/ualert/tables.go
@@ -257,6 +257,10 @@ func AddAlertRuleMigrations(mg *migrator.Migrator, defaultIntervalSeconds int64)
 			Default:  "1",
 		},
 	))
+
+	mg.AddMigration("add index on group", migrator.NewAddIndexMigration(alertRule, &migrator.Index{
+		Cols: []string{"rule_group"},
+	}))
 }
 
 func AddAlertRuleVersionMigrations(mg *migrator.Migrator) {


### PR DESCRIPTION
**Why do we need this feature?**

Querying by group is a common operation.
Supports all queries with a group clause.
Rules are a low-write, high-read table so it makes sense to index.
This also allows queries like "What are all the group names?" to be answered without a table scan.

**Which issue(s) does this PR fix?**:

n/a

**Special notes for your reviewer**:

