### PR TITLE
PanelRenderer: Interpolate variables in applyFieldOverrides

### DIFF
--- a/packages/grafana-data/src/utils/dataLinks.ts
+++ b/packages/grafana-data/src/utils/dataLinks.ts
@@ -62,7 +62,7 @@ export function mapInternalLinkToExplore(options: LinkToExploreOptions): LinkMod
           });
         }
       : undefined,
-    target: '_self',
+    target: link?.targetBlank ? '_blank' : '_self',
     origin: field,
   };
 }

--- a/public/app/features/panel/components/PanelRenderer.tsx
+++ b/public/app/features/panel/components/PanelRenderer.tsx
@@ -10,8 +10,9 @@ import {
   compareArrayValues,
   compareDataFrameStructures,
   PluginContextProvider,
+  ScopedVars,
 } from '@grafana/data';
-import { PanelRendererProps } from '@grafana/runtime';
+import { getTemplateSrv, PanelRendererProps } from '@grafana/runtime';
 import { ErrorBoundaryAlert, useTheme2 } from '@grafana/ui';
 import { appEvents } from 'app/core/core';
 
@@ -151,7 +152,9 @@ export function useFieldOverrides(
         data: series,
         fieldConfig,
         fieldConfigRegistry,
-        replaceVariables: (str: string) => str,
+        replaceVariables: (str: string, scopedVars?: ScopedVars) => {
+          return getTemplateSrv().replace(str, scopedVars);
+        },
         theme,
         timeZone,
       }),


### PR DESCRIPTION
**What is this feature?**

Updates the panel renderer to interpolate template variables. The replaceVariables function gets used by applyFieldOverrides when building links for a dataframe, so this allows more dynamic links in features/plugins using the panel renderer.

**Why do we need this feature?**

This will let features/plugins using the PanelRender include template variables in links. We want to use this for the application observability plugin so that we can include a dynamic query to logs for a given error. Without this change, the query won't build correctly (need to use the variable `${__value.raw}` in the frame link config).

![Screenshot 2022-12-05 at 9 52 01 AM](https://user-images.githubusercontent.com/12838032/205695149-4d77913c-2505-433d-b40d-69bb01059889.png)

**Who is this feature for?**

Devs using the PanelRenderer needing template variable interpolation

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

