### PR TITLE
CI: Add enterprise2 mode in `versions.go`

### DIFF
--- a/pkg/build/cmd/genversions.go
+++ b/pkg/build/cmd/genversions.go
@@ -36,7 +36,7 @@ func GenerateMetadata(c *cli.Context) (config.Metadata, error) {
 		releaseMode = config.ReleaseMode{Mode: mode}
 	case config.Custom:
 		if edition, _ := os.LookupEnv("EDITION"); edition == string(config.EditionEnterprise2) {
-			releaseMode = config.ReleaseMode{Mode: config.TagMode}
+			releaseMode = config.ReleaseMode{Mode: config.Enterprise2Mode}
 			if tag != "" {
 				version = strings.TrimPrefix(tag, "v")
 			}
@@ -48,7 +48,7 @@ func GenerateMetadata(c *cli.Context) (config.Metadata, error) {
 		}
 		// if there is a custom event targeting the main branch, that's an enterprise downstream build
 		if mode == config.MainBranch {
-			releaseMode = config.ReleaseMode{Mode: config.CustomMode}
+			releaseMode = config.ReleaseMode{Mode: config.DownstreamMode}
 		} else {
 			releaseMode = config.ReleaseMode{Mode: mode}
 		}

--- a/pkg/build/cmd/genversions_test.go
+++ b/pkg/build/cmd/genversions_test.go
@@ -16,6 +16,7 @@ const (
 	DroneTag              = "DRONE_TAG"
 	DroneSemverPrerelease = "DRONE_SEMVER_PRERELEASE"
 	DroneBuildNumber      = "DRONE_BUILD_NUMBER"
+	Edition               = "EDITION"
 )
 
 const (
@@ -33,7 +34,8 @@ func TestGetMetadata(t *testing.T) {
 		{map[string]string{DroneBuildEvent: config.Push, DroneTargetBranch: versionedBranch, DroneTag: "", DroneSemverPrerelease: "", DroneBuildNumber: "12345"}, hashedGrafanaVersion, config.ReleaseMode{Mode: config.ReleaseBranchMode}},
 		{map[string]string{DroneBuildEvent: config.Push, DroneTargetBranch: config.MainBranch, DroneTag: "", DroneSemverPrerelease: "", DroneBuildNumber: "12345"}, hashedGrafanaVersion, config.ReleaseMode{Mode: config.MainMode}},
 		{map[string]string{DroneBuildEvent: config.Custom, DroneTargetBranch: versionedBranch, DroneTag: "", DroneSemverPrerelease: "", DroneBuildNumber: "12345"}, hashedGrafanaVersion, config.ReleaseMode{Mode: config.ReleaseBranchMode}},
-		{map[string]string{DroneBuildEvent: config.Custom, DroneTargetBranch: config.MainBranch, DroneTag: "", DroneSemverPrerelease: "", DroneBuildNumber: "12345"}, hashedGrafanaVersion, config.ReleaseMode{Mode: config.Custom}},
+		{map[string]string{DroneBuildEvent: config.Custom, DroneTargetBranch: config.MainBranch, DroneTag: "", DroneSemverPrerelease: "", DroneBuildNumber: "12345"}, hashedGrafanaVersion, config.ReleaseMode{Mode: config.DownstreamMode}},
+		{map[string]string{DroneBuildEvent: config.Custom, DroneTargetBranch: config.MainBranch, DroneTag: "", DroneSemverPrerelease: "", DroneBuildNumber: "12345", Edition: "enterprise2"}, hashedGrafanaVersion, config.ReleaseMode{Mode: config.Enterprise2Mode}},
 		{map[string]string{DroneBuildEvent: config.Tag, DroneTargetBranch: "", DroneTag: "v9.2.0", DroneSemverPrerelease: "", DroneBuildNumber: "12345"}, "9.2.0", config.ReleaseMode{Mode: config.TagMode, IsBeta: false, IsTest: false}},
 		{map[string]string{DroneBuildEvent: config.Tag, DroneTargetBranch: "", DroneTag: "v9.2.0-beta", DroneSemverPrerelease: "beta", DroneBuildNumber: "12345"}, "9.2.0-beta", config.ReleaseMode{Mode: config.TagMode, IsBeta: true, IsTest: false}},
 		{map[string]string{DroneBuildEvent: config.Tag, DroneTargetBranch: "", DroneTag: "v9.2.0-test", DroneSemverPrerelease: "test", DroneBuildNumber: "12345"}, "9.2.0-test", config.ReleaseMode{Mode: config.TagMode, IsBeta: false, IsTest: true}},

--- a/pkg/build/cmd/grafanacom.go
+++ b/pkg/build/cmd/grafanacom.go
@@ -146,7 +146,7 @@ func publishPackages(cfg packaging.PublishConfig) error {
 	}
 
 	switch cfg.ReleaseMode.Mode {
-	case config.MainMode, config.CustomMode, config.CronjobMode:
+	case config.MainMode, config.DownstreamMode, config.CronjobMode:
 		pth = path.Join(pth, packaging.MainFolder)
 	default:
 		pth = path.Join(pth, packaging.ReleaseFolder)

--- a/pkg/build/cmd/uploadpackages.go
+++ b/pkg/build/cmd/uploadpackages.go
@@ -142,7 +142,7 @@ func uploadPackages(cfg uploadConfig) error {
 	switch cfg.versionMode {
 	case config.TagMode:
 		versionFolder = releaseFolder
-	case config.MainMode, config.CustomMode:
+	case config.MainMode, config.DownstreamMode:
 		versionFolder = mainFolder
 	case config.ReleaseBranchMode:
 		versionFolder = releaseBranchFolder

--- a/pkg/build/config/version_mode.go
+++ b/pkg/build/config/version_mode.go
@@ -8,7 +8,8 @@ const (
 	TagMode           VersionMode = "release"
 	ReleaseBranchMode VersionMode = "branch"
 	PullRequestMode   VersionMode = "pull_request"
-	CustomMode        VersionMode = "custom"
+	DownstreamMode    VersionMode = "downstream"
+	Enterprise2Mode   VersionMode = "enterprise2"
 	CronjobMode       VersionMode = "cron"
 )
 

--- a/pkg/build/config/versions.go
+++ b/pkg/build/config/versions.go
@@ -59,7 +59,7 @@ var Versions = VersionMap{
 			Storybook:            "grafana-storybook",
 		},
 	},
-	CustomMode: {
+	DownstreamMode: {
 		Variants: []Variant{
 			VariantArmV6,
 			VariantArmV7,
@@ -128,6 +128,44 @@ var Versions = VersionMap{
 		},
 	},
 	TagMode: {
+		Variants: []Variant{
+			VariantArmV6,
+			VariantArmV7,
+			VariantArmV7Musl,
+			VariantArm64,
+			VariantArm64Musl,
+			VariantDarwinAmd64,
+			VariantWindowsAmd64,
+			VariantLinuxAmd64,
+			VariantLinuxAmd64Musl,
+		},
+		PluginSignature: PluginSignature{
+			Sign:      true,
+			AdminSign: true,
+		},
+		Docker: Docker{
+			ShouldSave: true,
+			Architectures: []Architecture{
+				ArchAMD64,
+				ArchARM64,
+				ArchARMv7,
+			},
+			Distribution: []Distribution{
+				Alpine,
+				Ubuntu,
+			},
+			PrereleaseBucket: "grafana-prerelease/artifacts/docker",
+		},
+		Buckets: Buckets{
+			Artifacts:            "grafana-prerelease/artifacts/downloads",
+			ArtifactsEnterprise2: "grafana-prerelease/artifacts/downloads-enterprise2",
+			CDNAssets:            "grafana-prerelease",
+			CDNAssetsDir:         "artifacts/static-assets",
+			Storybook:            "grafana-prerelease",
+			StorybookSrcDir:      "artifacts/storybook",
+		},
+	},
+	Enterprise2Mode: {
 		Variants: []Variant{
 			VariantArmV6,
 			VariantArmV7,


### PR DESCRIPTION
**What is this feature?**

`custom` mode in `versions.go`, couldn't handle both enterprise2 pipelines and downstream pipelines, so we had to split it.

**Why do we need this feature?**

Due to misplacing of enterprise2 artifacts, on Friday _12/02/2022_