### PR TITLE
PanelEdit: Fixes broken panel edit splitter logic

### DIFF
--- a/public/app/core/components/SplitPaneWrapper/SplitPaneWrapper.tsx
+++ b/public/app/core/components/SplitPaneWrapper/SplitPaneWrapper.tsx
@@ -73,17 +73,15 @@ export class SplitPaneWrapper extends PureComponent<Props> {
     // Limit options pane width to 90% of screen.
     const styles = getStyles(config.theme2, splitVisible);
 
+    if (childrenArr.length === 1) {
+      return <div className={styles.singleLeftPane}>{childrenArr[0]}</div>;
+    }
+
     // Need to handle when width is relative. ie a percentage of the viewport
     const paneSizePx =
       paneSize <= 1
         ? paneSize * (splitOrientation === 'horizontal' ? window.innerHeight : window.innerWidth)
         : paneSize;
-
-    // the react split pane library always wants 2 children. This logic ensures that happens, even if one child is passed in
-    const childrenFragments = [
-      <React.Fragment key="leftPane">{childrenArr[0]}</React.Fragment>,
-      <React.Fragment key="rightPane">{childrenArr[1] || undefined}</React.Fragment>,
-    ];
 
     return (
       <SplitPane
@@ -98,7 +96,7 @@ export class SplitPaneWrapper extends PureComponent<Props> {
         paneStyle={paneStyle}
         pane2Style={secondaryPaneStyle}
       >
-        {childrenFragments}
+        {children}
       </SplitPane>
     );
   }

--- a/public/app/core/components/SplitPaneWrapper/SplitPaneWrapper.tsx
+++ b/public/app/core/components/SplitPaneWrapper/SplitPaneWrapper.tsx
@@ -65,7 +65,7 @@ export class SplitPaneWrapper extends PureComponent<Props> {
 
     let childrenArr = [];
     if (Array.isArray(children)) {
-      childrenArr = children;
+      childrenArr = children.filter((child) => child !== undefined);
     } else {
       childrenArr.push(children);
     }

--- a/public/app/features/explore/Wrapper.tsx
+++ b/public/app/features/explore/Wrapper.tsx
@@ -153,7 +153,7 @@ function Wrapper(props: GrafanaRouteComponentProps<{}, ExploreQueryParams>) {
           <ErrorBoundaryAlert style="page">
             <ExplorePaneContainer exploreId={ExploreId.left} urlQuery={queryParams.left} eventBus={eventBus.current} />
           </ErrorBoundaryAlert>
-          {hasSplit && (
+          {hasSplit ? (
             <ErrorBoundaryAlert style="page">
               <ExplorePaneContainer
                 exploreId={ExploreId.right}
@@ -161,7 +161,7 @@ function Wrapper(props: GrafanaRouteComponentProps<{}, ExploreQueryParams>) {
                 eventBus={eventBus.current}
               />
             </ErrorBoundaryAlert>
-          )}
+          ) : undefined}
         </SplitPaneWrapper>
       </div>
     </div>


### PR DESCRIPTION
The SplitWrapper changes (https://github.com/grafana/grafana/pull/58380) broke Panel edit UX in a pretty big way leaving a big empty splitter area for all non data panels. The change missed the old logic of not rendering the splitter when the split elements only contains a single item. 

This restores the old logic 

![Screenshot from 2022-12-06 08-15-32](https://user-images.githubusercontent.com/10999/205845882-193fa416-1b5a-4d29-bf27-27ec473be405.png)
