### PR TITLE
PanelEdit: Fixes broken panel edit splitter logic 

### DIFF
--- a/public/app/core/components/SplitPaneWrapper/SplitPaneWrapper.tsx
+++ b/public/app/core/components/SplitPaneWrapper/SplitPaneWrapper.tsx
@@ -141,12 +141,6 @@ const getStyles = (theme: GrafanaTheme2, hasSplit: boolean) => {
   `;
 
   return {
-    singleLeftPane: css`
-      height: 100%;
-      position: absolute;
-      overflow: hidden;
-      width: 100%;
-    `,
     resizerV: cx(
       resizer,
       css`

--- a/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
@@ -241,32 +241,45 @@ export class PanelEditorUnconnected extends PureComponent<Props> {
     );
   }
 
-  renderPanelAndEditor(styles: EditorStyles) {
+  renderPanelAndEditor(uiState: PanelEditorUIState, styles: EditorStyles) {
     const { panel, dashboard, plugin, tab } = this.props;
     const tabs = getPanelEditorTabs(tab, plugin);
     const isOnlyPanel = tabs.length === 0;
     const panelPane = this.renderPanel(styles, isOnlyPanel);
 
     if (tabs.length === 0) {
-      return panelPane;
+      return <div className={styles.onlyPanel}>{panelPane}</div>;
     }
 
-    return [
-      panelPane,
-      <div
-        className={styles.tabsWrapper}
-        aria-label={selectors.components.PanelEditor.DataPane.content}
-        key="panel-editor-tabs"
+    return (
+      <SplitPaneWrapper
+        splitOrientation="horizontal"
+        maxSize={-200}
+        paneSize={uiState.topPaneSize}
+        primary="first"
+        secondaryPaneStyle={{ minHeight: 0 }}
+        onDragFinished={(size) => {
+          if (size) {
+            updatePanelEditorUIState({ topPaneSize: size / window.innerHeight });
+          }
+        }}
       >
-        <PanelEditorTabs
-          key={panel.key}
-          panel={panel}
-          dashboard={dashboard}
-          tabs={tabs}
-          onChangeTab={this.onChangeTab}
-        />
-      </div>,
-    ];
+        <div
+          className={styles.tabsWrapper}
+          aria-label={selectors.components.PanelEditor.DataPane.content}
+          key="panel-editor-tabs"
+        >
+          {panelPane}
+          <PanelEditorTabs
+            key={panel.key}
+            panel={panel}
+            dashboard={dashboard}
+            tabs={tabs}
+            onChangeTab={this.onChangeTab}
+          />
+        </div>
+      </SplitPaneWrapper>
+    );
   }
 
   renderTemplateVariables(styles: EditorStyles) {
@@ -433,25 +446,6 @@ export class PanelEditorUnconnected extends PureComponent<Props> {
     );
   }
 
-  renderHorizontalSplit(uiState: PanelEditorUIState, styles: EditorStyles) {
-    return (
-      <SplitPaneWrapper
-        splitOrientation="horizontal"
-        maxSize={-200}
-        paneSize={uiState.topPaneSize}
-        primary="first"
-        secondaryPaneStyle={{ minHeight: 0 }}
-        onDragFinished={(size) => {
-          if (size) {
-            updatePanelEditorUIState({ topPaneSize: size / window.innerHeight });
-          }
-        }}
-      >
-        {this.renderPanelAndEditor(styles)}
-      </SplitPaneWrapper>
-    );
-  }
-
   render() {
     const { initDone, uiState, theme, sectionNav, pageNav, className, updatePanelEditorUIState } = this.props;
     const styles = getStyles(theme, this.props);
@@ -472,7 +466,7 @@ export class PanelEditorUnconnected extends PureComponent<Props> {
         <div className={styles.wrapper}>
           <div className={styles.verticalSplitPanesWrapper}>
             {!uiState.isPanelOptionsVisible ? (
-              this.renderHorizontalSplit(uiState, styles)
+              this.renderPanelAndEditor(uiState, styles)
             ) : (
               <SplitPaneWrapper
                 splitOrientation="vertical"
@@ -485,7 +479,7 @@ export class PanelEditorUnconnected extends PureComponent<Props> {
                   }
                 }}
               >
-                {this.renderHorizontalSplit(uiState, styles)}
+                {this.renderPanelAndEditor(uiState, styles)}
                 {this.renderOptionsPane()}
               </SplitPaneWrapper>
             )}
@@ -568,6 +562,12 @@ export const getStyles = stylesFactory((theme: GrafanaTheme2, props: Props) => {
       align-items: center;
       position: relative;
       flex-direction: column;
+    `,
+    onlyPanel: css`
+      height: 100%;
+      position: absolute;
+      overflow: hidden;
+      width: 100%;
     `,
   };
 });

--- a/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
@@ -264,12 +264,12 @@ export class PanelEditorUnconnected extends PureComponent<Props> {
           }
         }}
       >
+        {panelPane}
         <div
           className={styles.tabsWrapper}
           aria-label={selectors.components.PanelEditor.DataPane.content}
           key="panel-editor-tabs"
         >
-          {panelPane}
           <PanelEditorTabs
             key={panel.key}
             panel={panel}


### PR DESCRIPTION
Alt fix to https://github.com/grafana/grafana/pull/59858 

The SplitWrapper changes (https://github.com/grafana/grafana/pull/58380) broke Panel edit UX in a pretty big way leaving a big empty splitter area for all non data panels. The change missed the old logic of not rendering the splitter when the split elements only contains a single item. 

This restores the old logic 

![Screenshot from 2022-12-06 08-15-32](https://user-images.githubusercontent.com/10999/205845882-193fa416-1b5a-4d29-bf27-27ec473be405.png)
