### PR TITLE
PanelEditor: Fixes issue where panel edit would show the panel plugin options of the previous edit panel 

### DIFF
--- a/packages/grafana-ui/src/components/BarGauge/BarGauge.tsx
+++ b/packages/grafana-ui/src/components/BarGauge/BarGauge.tsx
@@ -471,7 +471,7 @@ export function getBasicAndGradientStyles(props: Props): BasicAndGradientStyles 
   };
 
   const emptyBar: CSSProperties = {
-    background: `rgba(${theme.isDark ? '255,255,255' : '0,0,0'}, 0.07)`,
+    background: theme.colors.background.secondary,
     flexGrow: 1,
     display: 'flex',
     borderRadius: '3px',

--- a/public/app/features/dashboard/components/PanelEditor/state/actions.test.ts
+++ b/public/app/features/dashboard/components/PanelEditor/state/actions.test.ts
@@ -24,12 +24,10 @@ describe('panelEditor actions', () => {
         .givenThunk(initPanelEditor)
         .whenThunkIsDispatched(sourcePanel, dashboard);
 
-      expect(dispatchedActions.length).toBe(2);
-      expect(dispatchedActions[0].type).toBe(panelModelAndPluginReady.type);
-
-      expect(dispatchedActions[1].payload.sourcePanel).toBe(sourcePanel);
-      expect(dispatchedActions[1].payload.panel).not.toBe(sourcePanel);
-      expect(dispatchedActions[1].payload.panel.id).toBe(sourcePanel.id);
+      expect(dispatchedActions.length).toBe(1);
+      expect(dispatchedActions[0].payload.sourcePanel).toBe(sourcePanel);
+      expect(dispatchedActions[0].payload.panel).not.toBe(sourcePanel);
+      expect(dispatchedActions[0].payload.panel.id).toBe(sourcePanel.id);
     });
   });
 

--- a/public/app/features/dashboard/components/PanelEditor/state/actions.ts
+++ b/public/app/features/dashboard/components/PanelEditor/state/actions.ts
@@ -1,7 +1,7 @@
 import { pick } from 'lodash';
 
 import store from 'app/core/store';
-import { cleanUpPanelState, initPanelState } from 'app/features/panel/state/actions';
+import { cleanUpPanelState } from 'app/features/panel/state/actions';
 import { panelModelAndPluginReady } from 'app/features/panel/state/reducers';
 import { ThunkResult } from 'app/types';
 
@@ -19,8 +19,6 @@ import {
 export function initPanelEditor(sourcePanel: PanelModel, dashboard: DashboardModel): ThunkResult<void> {
   return async (dispatch) => {
     const panel = dashboard.initEditPanel(sourcePanel);
-
-    await dispatch(initPanelState(panel));
 
     dispatch(
       updateEditorInitState({

--- a/public/app/features/dashboard/components/PanelEditor/state/reducers.ts
+++ b/public/app/features/dashboard/components/PanelEditor/state/reducers.ts
@@ -109,6 +109,8 @@ const pluginsSlice = createSlice({
       state.tableViewEnabled = !state.tableViewEnabled;
     },
     closeEditor: (state) => {
+      state.getPanel = () => new PanelModel({});
+      state.getSourcePanel = () => new PanelModel({});
       state.isOpen = false;
       state.initDone = false;
       state.isVizPickerOpen = false;

--- a/public/app/features/panel/state/actions.ts
+++ b/public/app/features/panel/state/actions.ts
@@ -34,6 +34,7 @@ export function initPanelState(panel: PanelModel): ThunkResult<void> {
       panel.pluginLoaded(plugin);
     }
 
+    console.log('initPanelState', { key: panel.key, plugin });
     dispatch(panelModelAndPluginReady({ key: panel.key, plugin }));
   };
 }

--- a/public/app/features/panel/state/actions.ts
+++ b/public/app/features/panel/state/actions.ts
@@ -34,7 +34,6 @@ export function initPanelState(panel: PanelModel): ThunkResult<void> {
       panel.pluginLoaded(plugin);
     }
 
-    console.log('initPanelState', { key: panel.key, plugin });
     dispatch(panelModelAndPluginReady({ key: panel.key, plugin }));
   };
 }


### PR DESCRIPTION
This fixes an issue with clean-up in the panel editor (And also dual init actions). 

The getPanel() function was never reset so when you opened panel editor the second time this would return the last panel being edited.  It's a bit hard to replicate, you have to leave panel edit via clicking on grafana logo (in new topnav), then go to another dashboard and open panel edit. 

Normally I would add a unit test for a bug like this but think the whole panel edit state system will likely be rewritten pretty soon (~Q1) to work with scene architecture so not sure it's worth investing more into.   
