### PR TITLE
Explore: Margins / scroll / padding issues

### DIFF
--- a/public/app/core/components/SplitPaneWrapper/SplitPaneWrapper.tsx
+++ b/public/app/core/components/SplitPaneWrapper/SplitPaneWrapper.tsx
@@ -95,6 +95,7 @@ export class SplitPaneWrapper extends PureComponent<Props> {
         resizerClassName={splitOrientation === 'horizontal' ? styles.resizerH : styles.resizerV}
         onDragStarted={() => this.onDragStarted()}
         onDragFinished={(size) => this.onDragFinished(size)}
+        style={{ height: 'auto' }}
         paneStyle={paneStyle}
         pane2Style={secondaryPaneStyle}
       >

--- a/public/app/core/components/SplitPaneWrapper/SplitPaneWrapper.tsx
+++ b/public/app/core/components/SplitPaneWrapper/SplitPaneWrapper.tsx
@@ -15,6 +15,7 @@ interface Props {
   onDragFinished?: (size?: number) => void;
   paneStyle?: React.CSSProperties;
   secondaryPaneStyle?: React.CSSProperties;
+  style?: React.CSSProperties;
 }
 
 export class SplitPaneWrapper extends PureComponent<Props> {
@@ -59,6 +60,7 @@ export class SplitPaneWrapper extends PureComponent<Props> {
       minSize,
       primary,
       paneStyle,
+      style,
       secondaryPaneStyle,
       splitVisible = true,
     } = this.props;
@@ -95,7 +97,7 @@ export class SplitPaneWrapper extends PureComponent<Props> {
         resizerClassName={splitOrientation === 'horizontal' ? styles.resizerH : styles.resizerV}
         onDragStarted={() => this.onDragStarted()}
         onDragFinished={(size) => this.onDragFinished(size)}
-        style={{ height: 'auto' }}
+        style={style}
         paneStyle={paneStyle}
         pane2Style={secondaryPaneStyle}
       >

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -75,11 +75,6 @@ const getStyles = (theme: GrafanaTheme2) => {
       display: flex;
       flex: 1 1 auto;
       flex-direction: column;
-      padding: ${theme.spacing(2)};
-      padding-top: 0;
-    `,
-    exploreContainerTopnav: css`
-      padding-top: ${theme.spacing(2)};
     `,
   };
 };
@@ -423,11 +418,7 @@ export class Explore extends React.PureComponent<Props, ExploreState> {
         {isFromCompactUrl ? this.renderCompactUrlWarning() : null}
         {datasourceMissing ? this.renderEmptyState(styles.exploreContainer) : null}
         {datasourceInstance && (
-          <div
-            className={cx(styles.exploreContainer, {
-              [styles.exploreContainerTopnav]: Boolean(config.featureToggles.topnav && !splitted),
-            })}
-          >
+          <div className={styles.exploreContainer}>
             <PanelContainer className={styles.queryContainer}>
               <QueryRows exploreId={exploreId} />
               <SecondaryActions

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -387,7 +387,6 @@ export class Explore extends React.PureComponent<Props, ExploreState> {
       showTrace,
       showNodeGraph,
       showFlameGraph,
-      splitted,
       timeZone,
       isFromCompactUrl,
     } = this.props;

--- a/public/app/features/explore/ExplorePaneContainer.tsx
+++ b/public/app/features/explore/ExplorePaneContainer.tsx
@@ -37,7 +37,6 @@ const getStyles = (theme: GrafanaTheme2) => {
       display: flex;
       flex: 1 1 auto;
       flex-direction: column;
-      overflow: scroll;
       min-width: 600px;
       & + & {
         border-left: 1px dotted ${theme.colors.border.medium};

--- a/public/app/features/explore/Wrapper.tsx
+++ b/public/app/features/explore/Wrapper.tsx
@@ -132,6 +132,7 @@ function Wrapper(props: GrafanaRouteComponentProps<{}, ExploreQueryParams>) {
         primary="second"
         splitVisible={hasSplit}
         paneStyle={{ display: 'flex', flexDirection: 'column' }}
+        style={{ left: '16px', right: '16px' }}
         onDragFinished={(size) => {
           if (size) {
             updateSplitSize(size);


### PR DESCRIPTION
Trying to fix Explore infinte nested scroll containers and margins issues but this is pretty tricky :) 

Tried to use the Page component which was an easy edition but breaks because for the Old nav to work you need to pass the toolbar to the Page component but this is build 3 more component levels down :( 

To give you some context on the number of scroll containers
* Split vertical (this is always added no matter if we are in split mode or not)  (overflow: scroll)
   * Split pane child (overflow : Y) 
     * child of split pane overflow: scroll
        * CustomScrollbar 

Each of the overflow: scroll / Y adds a 8px right margin :) 

