### PR TITLE
Hackathon: Enable plugins to emit AppNotifications

### DIFF
--- a/packages/grafana-data/src/types/index.ts
+++ b/packages/grafana-data/src/types/index.ts
@@ -52,3 +52,4 @@ export * from './alerts';
 export * from './slider';
 export * from './accesscontrol';
 export * from './icon';
+export * from './notification';

--- a/packages/grafana-data/src/types/notification.ts
+++ b/packages/grafana-data/src/types/notification.ts
@@ -1,0 +1,18 @@
+export interface AppNotification {
+  id: string;
+  severity: AppNotificationSeverity;
+  icon: string;
+  title: string;
+  text: string;
+  traceId?: string;
+  component?: React.ReactElement;
+  showing: boolean;
+  timestamp: number;
+}
+
+export enum AppNotificationSeverity {
+  Success = 'success',
+  Warning = 'warning',
+  Error = 'error',
+  Info = 'info',
+}

--- a/packages/grafana-data/src/types/notification.ts
+++ b/packages/grafana-data/src/types/notification.ts
@@ -8,6 +8,7 @@ export interface AppNotification {
   component?: React.ReactElement;
   showing: boolean;
   timestamp: number;
+  type?: AppNotificationType;
 }
 
 export enum AppNotificationSeverity {
@@ -15,4 +16,12 @@ export enum AppNotificationSeverity {
   Warning = 'warning',
   Error = 'error',
   Info = 'info',
+}
+
+export enum AppNotificationType {
+  Update = 'update',
+  ProductAnnouncement = 'productAnnouncement',
+  Permissions = 'permissions',
+  Access = 'access',
+  SystemMessage = 'systemMessage',
 }

--- a/packages/grafana-runtime/src/services/appEvents.ts
+++ b/packages/grafana-runtime/src/services/appEvents.ts
@@ -1,4 +1,12 @@
-import { BusEventBase, BusEventWithPayload, EventBus, GrafanaTheme2, PanelModel, TimeRange } from '@grafana/data';
+import {
+  AppNotification,
+  BusEventBase,
+  BusEventWithPayload,
+  EventBus,
+  GrafanaTheme2,
+  PanelModel,
+  TimeRange,
+} from '@grafana/data';
 
 /**
  * Called when a dashboard is refreshed
@@ -34,6 +42,15 @@ export class TimeRangeUpdatedEvent extends BusEventWithPayload<TimeRange> {
  */
 export class CopyPanelEvent extends BusEventWithPayload<PanelModel> {
   static type = 'copy-panel';
+}
+
+/**
+ * Called to show a toast notification
+ *
+ * @public
+ */
+export class AppNotificationEvent extends BusEventWithPayload<AppNotification> {
+  static type = 'app-notification';
 }
 
 // Internal singleton instance

--- a/public/app/core/components/AppNotifications/AppNotificationItem.tsx
+++ b/public/app/core/components/AppNotifications/AppNotificationItem.tsx
@@ -2,10 +2,10 @@ import { css } from '@emotion/css';
 import React from 'react';
 import { useEffectOnce } from 'react-use';
 
-import { AppNotification, GrafanaTheme2 } from '@grafana/data';
+import { AppNotification, AppNotificationType, GrafanaTheme2 } from '@grafana/data';
 import { config } from '@grafana/runtime';
-import { Alert, useStyles2 } from '@grafana/ui';
-import { timeoutMap } from 'app/types';
+import { Alert, Tag, useStyles2 } from '@grafana/ui';
+import { tagColorMap, timeoutMap } from 'app/types';
 
 interface Props {
   appNotification: AppNotification;
@@ -14,6 +14,8 @@ interface Props {
 
 export default function AppNotificationItem({ appNotification, onClearNotification }: Props) {
   const styles = useStyles2(getStyles);
+
+  const type = appNotification.type ?? AppNotificationType.SystemMessage;
 
   useEffectOnce(() => {
     setTimeout(() => {
@@ -33,6 +35,9 @@ export default function AppNotificationItem({ appNotification, onClearNotificati
       <div className={styles.wrapper}>
         <span>{appNotification.component || appNotification.text}</span>
         {showTraceId && <span className={styles.trace}>Trace ID: {appNotification.traceId}</span>}
+        <div className={styles.tagWrapper}>
+          <Tag name={type} colorIndex={tagColorMap[type]} className={styles.tag} />
+        </div>
       </div>
     </Alert>
   );
@@ -46,6 +51,14 @@ function getStyles(theme: GrafanaTheme2) {
     }),
     trace: css({
       fontSize: theme.typography.pxToRem(10),
+    }),
+    tag: css({
+      width: 'object-fit',
+    }),
+    tagWrapper: css({
+      display: 'flex',
+      justifyContent: 'end',
+      marginTop: theme.spacing(1),
     }),
   };
 }

--- a/public/app/core/components/AppNotifications/AppNotificationItem.tsx
+++ b/public/app/core/components/AppNotifications/AppNotificationItem.tsx
@@ -2,10 +2,10 @@ import { css } from '@emotion/css';
 import React from 'react';
 import { useEffectOnce } from 'react-use';
 
-import { GrafanaTheme2 } from '@grafana/data';
+import { AppNotification, GrafanaTheme2 } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { Alert, useStyles2 } from '@grafana/ui';
-import { AppNotification, timeoutMap } from 'app/types';
+import { timeoutMap } from 'app/types';
 
 interface Props {
   appNotification: AppNotification;

--- a/public/app/core/components/AppNotifications/AppNotificationList.tsx
+++ b/public/app/core/components/AppNotifications/AppNotificationList.tsx
@@ -2,6 +2,7 @@ import React, { PureComponent } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 
 import { AppEvents } from '@grafana/data';
+import { AppNotificationEvent } from '@grafana/runtime';
 import { VerticalGroup } from '@grafana/ui';
 import { notifyApp, hideAppNotification } from 'app/core/actions';
 import appEvents from 'app/core/app_events';
@@ -38,6 +39,8 @@ export class AppNotificationListUnConnected extends PureComponent<Props> {
     appEvents.on(AppEvents.alertWarning, (payload) => notifyApp(createWarningNotification(...payload)));
     appEvents.on(AppEvents.alertSuccess, (payload) => notifyApp(createSuccessNotification(...payload)));
     appEvents.on(AppEvents.alertError, (payload) => notifyApp(createErrorNotification(...payload)));
+
+    appEvents.subscribe(AppNotificationEvent, (event) => notifyApp(event.payload));
   }
 
   onClearAppNotification = (id: string) => {

--- a/public/app/core/components/AppNotifications/StoredNotificationItem.tsx
+++ b/public/app/core/components/AppNotifications/StoredNotificationItem.tsx
@@ -2,9 +2,10 @@ import { css } from '@emotion/css';
 import { formatDistanceToNow } from 'date-fns';
 import React, { ReactNode } from 'react';
 
-import { GrafanaTheme2 } from '@grafana/data';
+import { AppNotificationType, GrafanaTheme2 } from '@grafana/data';
 import { config } from '@grafana/runtime';
-import { Card, Checkbox, useTheme2 } from '@grafana/ui';
+import { Card, Checkbox, Tag, useTheme2 } from '@grafana/ui';
+import { tagColorMap } from 'app/types';
 
 export type AlertVariant = 'success' | 'warning' | 'error' | 'info';
 
@@ -17,6 +18,7 @@ export interface Props {
   title: string;
   timestamp?: number;
   traceId?: string;
+  type?: AppNotificationType;
 }
 
 export const StoredNotificationItem = ({
@@ -28,10 +30,12 @@ export const StoredNotificationItem = ({
   title,
   traceId,
   timestamp,
+  type,
 }: Props) => {
   const theme = useTheme2();
   const styles = getStyles(theme);
   const showTraceId = config.featureToggles.tracing && traceId;
+  const tagType = type ?? AppNotificationType.SystemMessage;
 
   return (
     <Card className={className} onClick={onClick}>
@@ -41,6 +45,7 @@ export const StoredNotificationItem = ({
         <Checkbox onChange={onClick} tabIndex={-1} value={isSelected} />
       </Card.Figure>
       <Card.Tags className={styles.trace}>
+        <Tag name={tagType} colorIndex={tagColorMap[tagType]} />
         {showTraceId && <span>{`Trace ID: ${traceId}`}</span>}
         {timestamp && formatDistanceToNow(timestamp, { addSuffix: true })}
       </Card.Tags>

--- a/public/app/core/components/Page/usePageTitle.ts
+++ b/public/app/core/components/Page/usePageTitle.ts
@@ -8,7 +8,7 @@ import { Branding } from '../Branding/Branding';
 import { buildBreadcrumbs } from '../Breadcrumbs/utils';
 
 export function usePageTitle(navModel?: NavModel, pageNav?: NavModelItem) {
-  const homeNav = useSelector((state) => state.navIndex)[HOME_NAV_ID];
+  const homeNav = useSelector((state) => state.navIndex)?.[HOME_NAV_ID];
   useEffect(() => {
     const sectionNav = (navModel?.node !== navModel?.main ? navModel?.node : navModel?.main) ?? { text: 'Grafana' };
     const parts: string[] = buildBreadcrumbs(sectionNav, pageNav, homeNav)

--- a/public/app/core/copy/appNotification.ts
+++ b/public/app/core/copy/appNotification.ts
@@ -1,8 +1,9 @@
 import { useMemo } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 
+import { AppNotification, AppNotificationSeverity } from '@grafana/data';
 import { getMessageFromError } from 'app/core/utils/errors';
-import { AppNotification, AppNotificationSeverity, useDispatch } from 'app/types';
+import { useDispatch } from 'app/types';
 
 import { notifyApp } from '../actions';
 

--- a/public/app/core/reducers/appNotification.test.ts
+++ b/public/app/core/reducers/appNotification.test.ts
@@ -1,4 +1,5 @@
-import { AppNotificationSeverity, AppNotificationsState } from 'app/types/';
+import { AppNotificationSeverity } from '@grafana/data';
+import { AppNotificationsState } from 'app/types/';
 
 import { appNotificationsReducer, clearNotification, notifyApp } from './appNotification';
 

--- a/public/app/core/reducers/appNotification.ts
+++ b/public/app/core/reducers/appNotification.ts
@@ -1,6 +1,7 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
-import { AppNotification, AppNotificationSeverity, AppNotificationsState } from 'app/types/';
+import { AppNotification, AppNotificationSeverity } from '@grafana/data';
+import { AppNotificationsState } from 'app/types/';
 
 const MAX_STORED_NOTIFICATIONS = 25;
 export const STORAGE_KEY = 'notifications';

--- a/public/app/features/admin/ldap/LdapConnectionStatus.tsx
+++ b/public/app/features/admin/ldap/LdapConnectionStatus.tsx
@@ -1,7 +1,8 @@
 import React, { FC } from 'react';
 
+import { AppNotificationSeverity } from '@grafana/data';
 import { Alert, Icon } from '@grafana/ui';
-import { AppNotificationSeverity, LdapConnectionInfo, LdapServerInfo } from 'app/types';
+import { LdapConnectionInfo, LdapServerInfo } from 'app/types';
 
 interface Props {
   ldapConnectionInfo: LdapConnectionInfo;

--- a/public/app/features/admin/ldap/LdapPage.tsx
+++ b/public/app/features/admin/ldap/LdapPage.tsx
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 
-import { NavModel } from '@grafana/data';
+import { AppNotificationSeverity, NavModel } from '@grafana/data';
 import { featureEnabled } from '@grafana/runtime';
 import { Alert, Button, LegacyForms } from '@grafana/ui';
 const { FormField } = LegacyForms;
@@ -9,15 +9,7 @@ import { Page } from 'app/core/components/Page/Page';
 import { contextSrv } from 'app/core/core';
 import { GrafanaRouteComponentProps } from 'app/core/navigation/types';
 import { getNavModel } from 'app/core/selectors/navModel';
-import {
-  AppNotificationSeverity,
-  LdapError,
-  LdapUser,
-  StoreState,
-  SyncInfo,
-  LdapConnectionInfo,
-  AccessControlAction,
-} from 'app/types';
+import { LdapError, LdapUser, StoreState, SyncInfo, LdapConnectionInfo, AccessControlAction } from 'app/types';
 
 import {
   loadLdapState,

--- a/public/app/features/alerting/AlertTab.tsx
+++ b/public/app/features/alerting/AlertTab.tsx
@@ -1,13 +1,13 @@
 import React, { PureComponent } from 'react';
 import { connect, MapDispatchToProps, MapStateToProps } from 'react-redux';
 
-import { EventBusSrv } from '@grafana/data';
+import { EventBusSrv, AppNotificationSeverity } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { AngularComponent, config, getAngularLoader, getDataSourceSrv } from '@grafana/runtime';
 import { Alert, Button, ConfirmModal, Container, CustomScrollbar, HorizontalGroup, Modal } from '@grafana/ui';
 import EmptyListCTA from 'app/core/components/EmptyListCTA/EmptyListCTA';
 import { getPanelStateForModel } from 'app/features/panel/state/selectors';
-import { AppNotificationSeverity, StoreState } from 'app/types';
+import { StoreState } from 'app/types';
 
 import { AlertState } from '../../plugins/datasource/alertmanager/types';
 import { PanelNotSupported } from '../dashboard/components/PanelEditor/PanelNotSupported';

--- a/public/app/features/connections/pages/DataSourceDetailsPage.tsx
+++ b/public/app/features/connections/pages/DataSourceDetailsPage.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import { useParams } from 'react-router-dom';
 
+import { AppNotificationSeverity } from '@grafana/data';
 import { Alert, Badge } from '@grafana/ui';
 import { PluginDetailsPage } from 'app/features/plugins/admin/components/PluginDetailsPage';
-import { StoreState, useSelector, AppNotificationSeverity } from 'app/types';
+import { StoreState, useSelector } from 'app/types';
 
 import { ROUTES } from '../constants';
 

--- a/public/app/features/dashboard/components/DashboardLoading/DashboardFailed.tsx
+++ b/public/app/features/dashboard/components/DashboardLoading/DashboardFailed.tsx
@@ -1,9 +1,10 @@
 import { css } from '@emotion/css';
 import React from 'react';
 
+import { AppNotificationSeverity } from '@grafana/data';
 import { Alert } from '@grafana/ui';
 import { getMessageFromError } from 'app/core/utils/errors';
-import { DashboardInitError, AppNotificationSeverity } from 'app/types';
+import { DashboardInitError } from 'app/types';
 
 export interface Props {
   initError?: DashboardInitError;

--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationsEditor.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationsEditor.tsx
@@ -12,6 +12,7 @@ import {
   SelectableValue,
   standardTransformersRegistry,
   TransformerRegistryItem,
+  AppNotificationSeverity,
 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import {
@@ -31,7 +32,6 @@ import { LocalStorageValueProvider } from 'app/core/components/LocalStorageValue
 import { getDocsLink } from 'app/core/utils/docsLinks';
 import { PluginStateInfo } from 'app/features/plugins/components/PluginStateInfo';
 
-import { AppNotificationSeverity } from '../../../../types';
 import { PanelModel } from '../../state';
 import { PanelNotSupported } from '../PanelEditor/PanelNotSupported';
 

--- a/public/app/features/library-panels/utils.ts
+++ b/public/app/features/library-panels/utils.ts
@@ -1,5 +1,6 @@
+import { AppNotification } from '@grafana/data';
+
 import { createErrorNotification, createSuccessNotification } from '../../core/copy/appNotification';
-import { AppNotification } from '../../types';
 import { PanelModel } from '../dashboard/state';
 
 import { addLibraryPanel, updateLibraryPanel } from './state/api';

--- a/public/app/features/notifications/StoredNotifications.tsx
+++ b/public/app/features/notifications/StoredNotifications.tsx
@@ -9,14 +9,14 @@ import {
   clearAllNotifications,
   clearNotification,
   readAllNotifications,
-  selectWarningsAndErrors,
+  selectAll,
   selectLastReadTimestamp,
 } from 'app/core/reducers/appNotification';
 import { useDispatch, useSelector } from 'app/types';
 
 export function StoredNotifications() {
   const dispatch = useDispatch();
-  const notifications = useSelector((state) => selectWarningsAndErrors(state.appNotifications));
+  const notifications = useSelector((state) => selectAll(state.appNotifications));
   const [selectedNotificationIds, setSelectedNotificationIds] = useState<string[]>([]);
   const allNotificationsSelected = notifications.every((notification) =>
     selectedNotificationIds.includes(notification.id)

--- a/public/app/features/notifications/StoredNotifications.tsx
+++ b/public/app/features/notifications/StoredNotifications.tsx
@@ -88,6 +88,7 @@ export function StoredNotifications() {
               title={notif.title}
               timestamp={notif.timestamp}
               traceId={notif.traceId}
+              type={notif.type}
             >
               <span>{notif.text}</span>
             </StoredNotificationItem>

--- a/public/app/features/panel/components/PanelPluginError.tsx
+++ b/public/app/features/panel/components/PanelPluginError.tsx
@@ -2,9 +2,8 @@
 import React, { PureComponent, ReactNode } from 'react';
 
 // Types
-import { PanelProps, PanelPlugin, PluginType, PanelPluginMeta } from '@grafana/data';
+import { PanelProps, PanelPlugin, PluginType, PanelPluginMeta, AppNotificationSeverity } from '@grafana/data';
 import { Alert } from '@grafana/ui';
-import { AppNotificationSeverity } from 'app/types';
 
 interface Props {
   title: string;

--- a/public/app/features/plugins/admin/components/PluginDetailsPage.tsx
+++ b/public/app/features/plugins/admin/components/PluginDetailsPage.tsx
@@ -2,11 +2,10 @@ import { css } from '@emotion/css';
 import React from 'react';
 import { useLocation } from 'react-router-dom';
 
-import { GrafanaTheme2, NavModelItem } from '@grafana/data';
+import { GrafanaTheme2, NavModelItem, AppNotificationSeverity } from '@grafana/data';
 import { useStyles2, TabContent, Alert } from '@grafana/ui';
 import { Layout } from '@grafana/ui/src/components/Layout/Layout';
 import { Page } from 'app/core/components/Page/Page';
-import { AppNotificationSeverity } from 'app/types';
 
 import { Loader } from '../components/Loader';
 import { PluginDetailsBody } from '../components/PluginDetailsBody';

--- a/public/app/features/variables/state/actions.ts
+++ b/public/app/features/variables/state/actions.ts
@@ -1,6 +1,7 @@
 import { castArray, isEqual } from 'lodash';
 
 import {
+  AppNotification,
   DataQuery,
   getDataSourceRef,
   isDataSourceRef,
@@ -20,7 +21,7 @@ import { createErrorNotification } from '../../../core/copy/appNotification';
 import { appEvents } from '../../../core/core';
 import { getBackendSrv } from '../../../core/services/backend_srv';
 import { Graph } from '../../../core/utils/dag';
-import { AppNotification, StoreState, ThunkResult } from '../../../types';
+import { StoreState, ThunkResult } from '../../../types';
 import { getDatasourceSrv } from '../../plugins/datasource_srv';
 import { getTemplateSrv, TemplateSrv } from '../../templating/template_srv';
 import { variableAdapters } from '../adapters';

--- a/public/app/types/appNotifications.ts
+++ b/public/app/types/appNotifications.ts
@@ -1,4 +1,4 @@
-import { AppNotification, AppNotificationSeverity } from '@grafana/data';
+import { AppNotification, AppNotificationSeverity, AppNotificationType } from '@grafana/data';
 
 export enum AppNotificationTimeout {
   Success = 3000,
@@ -11,6 +11,14 @@ export const timeoutMap = {
   [AppNotificationSeverity.Warning]: AppNotificationTimeout.Warning,
   [AppNotificationSeverity.Error]: AppNotificationTimeout.Error,
   [AppNotificationSeverity.Info]: AppNotificationTimeout.Success,
+};
+
+export const tagColorMap = {
+  [AppNotificationType.Access]: 0,
+  [AppNotificationType.Permissions]: 1,
+  [AppNotificationType.ProductAnnouncement]: 2,
+  [AppNotificationType.SystemMessage]: 3,
+  [AppNotificationType.Update]: 4,
 };
 
 export interface AppNotificationsState {

--- a/public/app/types/appNotifications.ts
+++ b/public/app/types/appNotifications.ts
@@ -1,21 +1,4 @@
-export interface AppNotification {
-  id: string;
-  severity: AppNotificationSeverity;
-  icon: string;
-  title: string;
-  text: string;
-  traceId?: string;
-  component?: React.ReactElement;
-  showing: boolean;
-  timestamp: number;
-}
-
-export enum AppNotificationSeverity {
-  Success = 'success',
-  Warning = 'warning',
-  Error = 'error',
-  Info = 'info',
-}
+import { AppNotification, AppNotificationSeverity } from '@grafana/data';
 
 export enum AppNotificationTimeout {
   Success = 3000,


### PR DESCRIPTION
***This PR is part of our hackathon project, we don't intend to merge to main as it is***


<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Expose `AppNotification` in `@grafana-data` and `AppNotificationEvent` in `@grafana-runtime`, so that app plugins can emit notifications like this:

```
import { AppNotificationSeverity } from '@grafana/data';
import { AppNotificationEvent, getAppEvents } from '@grafana/runtime';

const EXAMPLE_EVENT = new AppNotificationEvent({
  id: 'plugin_notification',
  severity: AppNotificationSeverity.Success,
  icon: '',
  title: 'Success from plugin',
  text: 'This notification is shown from a plugin',
  showing: true,
  timestamp: Date.now(),
});
const eventBus = getAppEvents();
eventBus.publish(EXAMPLE_EVENT);
```

`AppNotificationList` subscribes to these events and therefore these notifications are shown as a toast message, and are also saved in the notification history.

I also added `AppNotificationType`, because we want to differentiate notifications for a better UX.
