### PR TITLE
Navigation: Prevent app crash when importing a dashboard with a uid of `home`

### DIFF
--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -224,7 +224,7 @@ func (s *ServiceImpl) getHomeNode(c *models.ReqContext, prefs *pref.Preference) 
 
 	homeNode := &navtree.NavLink{
 		Text:       "Home",
-		Id:         "__home__",
+		Id:         "home",
 		Url:        homeUrl,
 		Icon:       "home-alt",
 		Section:    navtree.NavSectionCore,
@@ -342,7 +342,7 @@ func (s *ServiceImpl) buildStarredItemsNavLinks(c *models.ReqContext) ([]*navtre
 		})
 		for _, starredItem := range starredDashboards {
 			starredItemsChildNavs = append(starredItemsChildNavs, &navtree.NavLink{
-				Id:   starredItem.Uid,
+				Id:   "starred/" + starredItem.Uid,
 				Text: starredItem.Title,
 				Url:  starredItem.GetUrl(),
 			})

--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -224,7 +224,7 @@ func (s *ServiceImpl) getHomeNode(c *models.ReqContext, prefs *pref.Preference) 
 
 	homeNode := &navtree.NavLink{
 		Text:       "Home",
-		Id:         "home",
+		Id:         "__home__",
 		Url:        homeUrl,
 		Icon:       "home-alt",
 		Section:    navtree.NavSectionCore,

--- a/public/app/core/reducers/navBarTree.ts
+++ b/public/app/core/reducers/navBarTree.ts
@@ -5,6 +5,9 @@ import { config } from '@grafana/runtime';
 
 export const initialState: NavModelItem[] = config.bootData?.navTree ?? [];
 
+// this matches the prefix set in the backend navtree
+export const ID_PREFIX = 'starred/';
+
 const navTreeSlice = createSlice({
   name: 'navBarTree',
   initialState,
@@ -18,14 +21,14 @@ const navTreeSlice = createSlice({
             starredItems.children = [];
           }
           const newStarredItem: NavModelItem = {
-            id,
+            id: ID_PREFIX + id,
             text: title,
             url,
           };
           starredItems.children.push(newStarredItem);
           starredItems.children.sort((a, b) => a.text.localeCompare(b.text));
         } else {
-          const index = starredItems.children?.findIndex((item) => item.id === id) ?? -1;
+          const index = starredItems.children?.findIndex((item) => item.id === ID_PREFIX + id) ?? -1;
           if (index > -1) {
             starredItems?.children?.splice(index, 1);
           }

--- a/public/app/core/reducers/navModel.ts
+++ b/public/app/core/reducers/navModel.ts
@@ -4,20 +4,19 @@ import { cloneDeep } from 'lodash';
 import { NavIndex, NavModel, NavModelItem } from '@grafana/data';
 import config from 'app/core/config';
 
-export const HOME_NAV_ID = 'home';
+export const HOME_NAV_ID = '__home__';
 
 export function buildInitialState(): NavIndex {
   const navIndex: NavIndex = {};
   const rootNodes = cloneDeep(config.bootData.navTree);
   const homeNav = rootNodes.find((node) => node.id === HOME_NAV_ID);
+  const otherRootNodes = rootNodes.filter((node) => node.id !== HOME_NAV_ID);
 
-  // set home as parent for the rootNodes
-  buildNavIndex(navIndex, rootNodes, homeNav);
-
-  // remove circular parent reference on the home node
-  if (navIndex[HOME_NAV_ID]) {
-    delete navIndex[HOME_NAV_ID].parentItem;
+  if (homeNav) {
+    buildNavIndex(navIndex, [homeNav]);
   }
+  // set home as parent for the other rootNodes
+  buildNavIndex(navIndex, otherRootNodes, homeNav);
 
   return navIndex;
 }
@@ -26,7 +25,9 @@ function buildNavIndex(navIndex: NavIndex, children: NavModelItem[], parentItem?
   for (const node of children) {
     node.parentItem = parentItem;
 
-    navIndex[node.id!] = node;
+    if (node.id) {
+      navIndex[node.id] = node;
+    }
 
     if (node.children) {
       buildNavIndex(navIndex, node.children, node);

--- a/public/app/core/reducers/navModel.ts
+++ b/public/app/core/reducers/navModel.ts
@@ -4,7 +4,7 @@ import { cloneDeep } from 'lodash';
 import { NavIndex, NavModel, NavModelItem } from '@grafana/data';
 import config from 'app/core/config';
 
-export const HOME_NAV_ID = '__home__';
+export const HOME_NAV_ID = 'home';
 
 export function buildInitialState(): NavIndex {
   const navIndex: NavIndex = {};


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- when a dashboard is starred and added to the navtree, it uses the dashboard `uid` as the `navModel.id`: https://github.com/grafana/grafana/blob/main/pkg/services/navtree/navtreeimpl/navtree.go#L345
- this dashboard uid can then clash with some of our internal navtree ids (e.g. `home`)
- add a `starred/` prefix for dashboard uids so they can't clash with internal ids
- also refactor `buildInitialState` slightly so it can't create a circular reference on the home node
  - before we created this circular reference then removed it after
  - if something clashed with the home node, whatever was processed last is added to the `navIndex`, so when it comes to remove this circular reference it might find an incorrect node
  - instead, lets remove the home node from the array and handle it separately

**Why do we need this feature?**

- prevent crashes in grafana

**Who is this feature for?**

- everyone! 🙌 

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/59764

**Special notes for your reviewer**:

