### PR TITLE
[v9.2.x] Chore: Remote cache key prefix (#59838)

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -139,6 +139,9 @@ type = database
 # memcache: 127.0.0.1:11211
 connstr =
 
+# prefix prepended to all the keys in the remote cache
+prefix =
+
 #################################### Data proxy ###########################
 [dataproxy]
 

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -145,6 +145,9 @@
 # memcache: 127.0.0.1:11211
 ;connstr =
 
+# prefix prepended to all the keys in the remote cache
+; prefix =
+
 #################################### Data proxy ###########################
 [dataproxy]
 

--- a/pkg/infra/remotecache/remotecache_test.go
+++ b/pkg/infra/remotecache/remotecache_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/stretchr/testify/assert"
@@ -86,4 +87,28 @@ func canNotFetchExpiredItems(t *testing.T, client CacheStorage) {
 	// should not be able to read that value since its expired
 	_, err = client.Get(context.Background(), "key1")
 	assert.Equal(t, err, ErrCacheItemNotFound)
+}
+
+func TestCachePrefix(t *testing.T) {
+	db := sqlstore.InitTestDB(t)
+	cache := &databaseCache{
+		SQLStore: db,
+		log:      log.New("remotecache.database"),
+	}
+	prefixCache := &prefixCacheStorage{cache: cache, prefix: "test/"}
+
+	// Set a value (with a prefix)
+	err := prefixCache.Set(context.Background(), "foo", "bar", time.Hour)
+	require.NoError(t, err)
+	// Get a value (with a prefix)
+	v, err := prefixCache.Get(context.Background(), "foo")
+	require.NoError(t, err)
+	require.Equal(t, "bar", v)
+	// Get a value directly from the underlying cache, ensure the prefix is in the key
+	v, err = cache.Get(context.Background(), "test/foo")
+	require.NoError(t, err)
+	require.Equal(t, "bar", v)
+	// Get a value directly from the underlying cache without a prefix, should not be there
+	_, err = cache.Get(context.Background(), "foo")
+	require.Error(t, err)
 }

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -1072,10 +1072,12 @@ func (cfg *Cfg) Load(args CommandLineArgs) error {
 	cacheServer := iniFile.Section("remote_cache")
 	dbName := valueAsString(cacheServer, "type", "database")
 	connStr := valueAsString(cacheServer, "connstr", "")
+	prefix := valueAsString(cacheServer, "prefix", "")
 
 	cfg.RemoteCacheOptions = &RemoteCacheOptions{
 		Name:    dbName,
 		ConnStr: connStr,
+		Prefix:  prefix,
 	}
 
 	geomapSection := iniFile.Section("geomap")
@@ -1111,6 +1113,7 @@ func valueAsString(section *ini.Section, keyName string, defaultValue string) st
 type RemoteCacheOptions struct {
 	Name    string
 	ConnStr string
+	Prefix  string
 }
 
 func (cfg *Cfg) readLDAPConfig() {


### PR DESCRIPTION
(cherry picked from commit 3978502d837986a9ad77f4bf303b433f038637b1)

Backport of https://github.com/grafana/grafana/pull/59838
