### PR TITLE
Build: don't remove grafana-server and grafana-cli binaries from deb and rpm packages

### DIFF
--- a/packaging/wrappers/grafana-server
+++ b/packaging/wrappers/grafana-server
@@ -5,17 +5,7 @@
 # the system-wide Grafana configuration that was bundled with the package as we
 # use the binary.
 
-DEFAULT=/etc/default/grafana
-
 GRAFANA_HOME="${GRAFANA_HOME:-/usr/share/grafana}"
-
-CONF_DIR=/etc/grafana
-DATA_DIR=/var/lib/grafana
-PLUGINS_DIR=/var/lib/grafana/plugins
-LOG_DIR=/var/log/grafana
-
-CONF_FILE=$CONF_DIR/grafana.ini
-PROVISIONING_CFG_DIR=$CONF_DIR/provisioning
 
 EXECUTABLE="$GRAFANA_HOME/bin/grafana"
 
@@ -24,18 +14,6 @@ if [ ! -x $EXECUTABLE ]; then
  exit 5
 fi
 
-# overwrite settings from default file
-if [ -f "$DEFAULT" ]; then
-  . "$DEFAULT"
-fi
-
-OPTS="--homepath=${GRAFANA_HOME} \
-      --config=${CONF_FILE} \
-      --configOverrides='cfg:default.paths.provisioning=$PROVISIONING_CFG_DIR \
-                        cfg:default.paths.data=${DATA_DIR} \
-                        cfg:default.paths.logs=${LOG_DIR} \
-                        cfg:default.paths.plugins=${PLUGINS_DIR}'"
-
 CMD=server
 
-eval $EXECUTABLE "$CMD" "$OPTS" "$@"
+eval $EXECUTABLE "$CMD" "$@"

--- a/pkg/build/packaging/grafana.go
+++ b/pkg/build/packaging/grafana.go
@@ -340,18 +340,6 @@ func createPackage(srcDir string, options linuxPackageOptions) error {
 		return err
 	}
 
-	// remove unneeded binaries, these are exposed via wrappers that provide the needed configuration
-	for _, fileName := range []string{
-		cliBinary,
-		cliBinary + ".md5",
-		serverBinary,
-		serverBinary + ".md5",
-	} {
-		if err := os.Remove(filepath.Join(packageRoot, options.homeBinDir, fileName)); err != nil {
-			return fmt.Errorf("failed to remove %q: %w", filepath.Join(options.homeBinDir, fileName), err)
-		}
-	}
-
 	if err := executeFPM(options, packageRoot, srcDir); err != nil {
 		return err
 	}


### PR DESCRIPTION
These files are useful for backward compatibility if scripts call these paths directly instead of using the wrappers.