### PR TITLE
Plugins: Add username to datasource plugin logging

### DIFF
--- a/pkg/infra/log/requestTiming.go
+++ b/pkg/infra/log/requestTiming.go
@@ -18,9 +18,9 @@ func InitstartTime(ctx context.Context, now time.Time) context.Context {
 func TimeSinceStart(ctx context.Context, now time.Time) time.Duration {
 	val := ctx.Value(requestStartTime)
 	if val != nil {
-		starTime, ok := val.(time.Time)
+		startTime, ok := val.(time.Time)
 		if ok {
-			return now.Sub(starTime)
+			return now.Sub(startTime)
 		}
 	}
 

--- a/pkg/infra/log/requestTiming.go
+++ b/pkg/infra/log/requestTiming.go
@@ -1,0 +1,28 @@
+package log
+
+import (
+	"context"
+	"time"
+)
+
+type requestStartTimeContextKey struct{}
+
+var requestStartTime = requestStartTimeContextKey{}
+
+// InitCounter creates a pointer on the context that can be incremented later
+func InitstartTime(ctx context.Context, now time.Time) context.Context {
+	return context.WithValue(ctx, requestStartTime, now)
+}
+
+// TimeSinceStart returns time spend since the request started in grafana
+func TimeSinceStart(ctx context.Context, now time.Time) time.Duration {
+	val := ctx.Value(requestStartTime)
+	if val != nil {
+		starTime, ok := val.(time.Time)
+		if ok {
+			return now.Sub(starTime)
+		}
+	}
+
+	return 0
+}

--- a/pkg/middleware/logger.go
+++ b/pkg/middleware/logger.go
@@ -35,6 +35,8 @@ func Logger(cfg *setting.Cfg) web.Middleware {
 
 			// we have to init the context with the counter here to update the request
 			r = r.WithContext(log.InitCounter(r.Context()))
+			// put the start time on context so we can measure it later.
+			r = r.WithContext(log.InitstartTime(r.Context(), time.Now()))
 
 			rw := web.Rw(w, r)
 			next.ServeHTTP(rw, r)

--- a/pkg/plugins/backendplugin/instrumentation/instrumentation.go
+++ b/pkg/plugins/backendplugin/instrumentation/instrumentation.go
@@ -55,7 +55,6 @@ func instrumentPluginRequest(ctx context.Context, cfg *config.Cfg, pluginCtx *ba
 
 		if pluginCtx.User != nil {
 			logParams = append(logParams, "uname", pluginCtx.User.Login)
-			logParams = append(logParams, "user.name", pluginCtx.User.Name)
 		}
 
 		traceID := tracing.TraceIDFromContext(ctx, false)

--- a/pkg/plugins/backendplugin/instrumentation/instrumentation.go
+++ b/pkg/plugins/backendplugin/instrumentation/instrumentation.go
@@ -54,7 +54,7 @@ func instrumentPluginRequest(ctx context.Context, cfg *config.Cfg, pluginCtx *ba
 		}
 
 		if pluginCtx.User != nil {
-			logParams = append(logParams, "user.login", pluginCtx.User.Login)
+			logParams = append(logParams, "uname", pluginCtx.User.Login)
 			logParams = append(logParams, "user.name", pluginCtx.User.Name)
 		}
 

--- a/pkg/plugins/backendplugin/instrumentation/instrumentation.go
+++ b/pkg/plugins/backendplugin/instrumentation/instrumentation.go
@@ -51,6 +51,8 @@ func instrumentPluginRequest(ctx context.Context, cfg *config.Cfg, pluginCtx *ba
 			"duration", elapsed,
 			"pluginId", pluginCtx.PluginID,
 			"endpoint", endpoint,
+			"eventName", "grafana-data-egress",
+			"insight_logs", true,
 		}
 
 		if pluginCtx.User != nil {

--- a/pkg/plugins/backendplugin/instrumentation/instrumentation.go
+++ b/pkg/plugins/backendplugin/instrumentation/instrumentation.go
@@ -53,6 +53,11 @@ func instrumentPluginRequest(ctx context.Context, cfg *config.Cfg, pluginCtx *ba
 			"endpoint", endpoint,
 		}
 
+		if pluginCtx.User != nil {
+			logParams = append(logParams, "user.login", pluginCtx.User.Login)
+			logParams = append(logParams, "user.name", pluginCtx.User.Name)
+		}
+
 		traceID := tracing.TraceIDFromContext(ctx, false)
 		if traceID != "" {
 			logParams = append(logParams, "traceID", traceID)

--- a/pkg/plugins/backendplugin/instrumentation/instrumentation.go
+++ b/pkg/plugins/backendplugin/instrumentation/instrumentation.go
@@ -53,6 +53,7 @@ func instrumentPluginRequest(ctx context.Context, cfg *config.Cfg, pluginCtx *ba
 			"endpoint", endpoint,
 			"eventName", "grafana-data-egress",
 			"insight_logs", true,
+			"since_grafana_request_started", log.TimeSinceStart(ctx, time.Now()),
 		}
 
 		if pluginCtx.User != nil {


### PR DESCRIPTION
By logging these fields we can easier to find traces for certain users in large instances who claims queries are slow.

Signed-off-by: bergquist <carl.bergquist@gmail.com>
