### PR TITLE
Alerting: PagerDuty receiver to let user configure fields Source, Client and Client URL

### DIFF
--- a/pkg/services/ngalert/notifier/channels/pagerduty.go
+++ b/pkg/services/ngalert/notifier/channels/pagerduty.go
@@ -23,14 +23,14 @@ const (
 	pagerDutyEventTrigger = "trigger"
 	pagerDutyEventResolve = "resolve"
 
-	defaultSeverity = "critical"
+	defaultSeverity = "error"
 	defaultClass    = "default"
 	defaultGroup    = "default"
 	defaultClient   = "Grafana"
 )
 
 var (
-	knownSeverity        = map[string]struct{}{defaultSeverity: {}, "error": {}, "warning": {}, "info": {}}
+	knownSeverity        = map[string]struct{}{"critical": {}, defaultSeverity: {}, "warning": {}, "info": {}}
 	PagerdutyEventAPIURL = "https://events.pagerduty.com/v2/enqueue"
 )
 

--- a/pkg/services/ngalert/notifier/channels/pagerduty.go
+++ b/pkg/services/ngalert/notifier/channels/pagerduty.go
@@ -26,6 +26,7 @@ const (
 	defaultSeverity = "critical"
 	defaultClass    = "default"
 	defaultGroup    = "default"
+	defaultClient   = "Grafana"
 )
 
 var (
@@ -52,6 +53,7 @@ type pagerdutySettings struct {
 	Component     string `json:"component,omitempty" yaml:"component,omitempty"`
 	Group         string `json:"group,omitempty" yaml:"group,omitempty"`
 	Summary       string `json:"summary,omitempty" yaml:"summary,omitempty"`
+	Source        string `json:"source,omitempty" yaml:"source,omitempty"`
 }
 
 func buildPagerdutySettings(fc FactoryConfig) (*pagerdutySettings, error) {
@@ -88,7 +90,13 @@ func buildPagerdutySettings(fc FactoryConfig) (*pagerdutySettings, error) {
 	if settings.Summary == "" {
 		settings.Summary = DefaultMessageTitleEmbed
 	}
-
+	if settings.Source == "" {
+		hostname, err := os.Hostname()
+		if err != nil {
+			hostname = defaultClient
+		}
+		settings.Source = hostname
+	}
 	return &settings, nil
 }
 
@@ -190,7 +198,7 @@ func (pn *PagerdutyNotifier) buildPagerdutyMessage(ctx context.Context, alerts m
 	}
 
 	msg := &pagerDutyMessage{
-		Client:      "Grafana",
+		Client:      defaultClient,
 		ClientURL:   pn.tmpl.ExternalURL.String(),
 		RoutingKey:  pn.settings.Key,
 		EventAction: eventType,
@@ -200,6 +208,7 @@ func (pn *PagerdutyNotifier) buildPagerdutyMessage(ctx context.Context, alerts m
 			Text: "External URL",
 		}},
 		Payload: pagerDutyPayload{
+			Source:        tmpl(pn.settings.Source),
 			Component:     tmpl(pn.settings.Component),
 			Summary:       tmpl(pn.settings.Summary),
 			Severity:      severity,
@@ -222,11 +231,6 @@ func (pn *PagerdutyNotifier) buildPagerdutyMessage(ctx context.Context, alerts m
 	if summary, truncated := notify.Truncate(msg.Payload.Summary, 1024); truncated {
 		pn.log.Debug("Truncated summary", "original", msg.Payload.Summary)
 		msg.Payload.Summary = summary
-	}
-
-	if hostname, err := os.Hostname(); err == nil {
-		// TODO: should this be configured like in Prometheus AM?
-		msg.Payload.Source = hostname
 	}
 
 	if tmplErr != nil {

--- a/pkg/services/ngalert/notifier/channels/pagerduty.go
+++ b/pkg/services/ngalert/notifier/channels/pagerduty.go
@@ -54,6 +54,7 @@ type pagerdutySettings struct {
 	Group         string `json:"group,omitempty" yaml:"group,omitempty"`
 	Summary       string `json:"summary,omitempty" yaml:"summary,omitempty"`
 	Source        string `json:"source,omitempty" yaml:"source,omitempty"`
+	Client        string `json:"client,omitempty" yaml:"client,omitempty"`
 }
 
 func buildPagerdutySettings(fc FactoryConfig) (*pagerdutySettings, error) {
@@ -90,12 +91,15 @@ func buildPagerdutySettings(fc FactoryConfig) (*pagerdutySettings, error) {
 	if settings.Summary == "" {
 		settings.Summary = DefaultMessageTitleEmbed
 	}
+	if settings.Client == "" {
+		settings.Client = defaultClient
+	}
 	if settings.Source == "" {
-		hostname, err := os.Hostname()
+		source, err := os.Hostname()
 		if err != nil {
-			hostname = defaultClient
+			source = settings.Client
 		}
-		settings.Source = hostname
+		settings.Source = source
 	}
 	return &settings, nil
 }
@@ -198,7 +202,7 @@ func (pn *PagerdutyNotifier) buildPagerdutyMessage(ctx context.Context, alerts m
 	}
 
 	msg := &pagerDutyMessage{
-		Client:      defaultClient,
+		Client:      tmpl(pn.settings.Client),
 		ClientURL:   pn.tmpl.ExternalURL.String(),
 		RoutingKey:  pn.settings.Key,
 		EventAction: eventType,

--- a/pkg/services/ngalert/notifier/channels/pagerduty.go
+++ b/pkg/services/ngalert/notifier/channels/pagerduty.go
@@ -23,14 +23,14 @@ const (
 	pagerDutyEventTrigger = "trigger"
 	pagerDutyEventResolve = "resolve"
 
-	defaultSeverity = "error"
+	defaultSeverity = "critical"
 	defaultClass    = "default"
 	defaultGroup    = "default"
 	defaultClient   = "Grafana"
 )
 
 var (
-	knownSeverity        = map[string]struct{}{"critical": {}, defaultSeverity: {}, "warning": {}, "info": {}}
+	knownSeverity        = map[string]struct{}{defaultSeverity: {}, "error": {}, "warning": {}, "info": {}}
 	PagerdutyEventAPIURL = "https://events.pagerduty.com/v2/enqueue"
 )
 

--- a/pkg/services/ngalert/notifier/channels/pagerduty.go
+++ b/pkg/services/ngalert/notifier/channels/pagerduty.go
@@ -55,6 +55,7 @@ type pagerdutySettings struct {
 	Summary       string `json:"summary,omitempty" yaml:"summary,omitempty"`
 	Source        string `json:"source,omitempty" yaml:"source,omitempty"`
 	Client        string `json:"client,omitempty" yaml:"client,omitempty"`
+	ClientURL     string `json:"client_url,omitempty" yaml:"client_url,omitempty"`
 }
 
 func buildPagerdutySettings(fc FactoryConfig) (*pagerdutySettings, error) {
@@ -93,6 +94,9 @@ func buildPagerdutySettings(fc FactoryConfig) (*pagerdutySettings, error) {
 	}
 	if settings.Client == "" {
 		settings.Client = defaultClient
+	}
+	if settings.ClientURL == "" {
+		settings.ClientURL = "{{ .ExternalURL }}"
 	}
 	if settings.Source == "" {
 		source, err := os.Hostname()
@@ -203,7 +207,7 @@ func (pn *PagerdutyNotifier) buildPagerdutyMessage(ctx context.Context, alerts m
 
 	msg := &pagerDutyMessage{
 		Client:      tmpl(pn.settings.Client),
-		ClientURL:   pn.tmpl.ExternalURL.String(),
+		ClientURL:   tmpl(pn.settings.ClientURL),
 		RoutingKey:  pn.settings.Key,
 		EventAction: eventType,
 		DedupKey:    key.Hash(),

--- a/pkg/services/ngalert/notifier/channels/pagerduty_test.go
+++ b/pkg/services/ngalert/notifier/channels/pagerduty_test.go
@@ -109,8 +109,17 @@ func TestPagerdutyNotifier(t *testing.T) {
 			expMsgError: nil,
 		},
 		{
-			name:     "Should expand templates in fields",
-			settings: `{"integrationKey": "abcdefgh0123456789", "severity" : "{{ .CommonLabels.severity }}", "class": "{{ .CommonLabels.class }}",  "component": "{{ .CommonLabels.component }}", "group" : "{{ .CommonLabels.group }}", "source": "{{ .CommonLabels.source }}" }`,
+			name: "Should expand templates in fields",
+			settings: `{
+				"integrationKey": "abcdefgh0123456789", 
+				"severity" : "{{ .CommonLabels.severity }}", 
+				"class": "{{ .CommonLabels.class }}",  
+				"component": "{{ .CommonLabels.component }}", 
+				"group" : "{{ .CommonLabels.group }}", 
+				"source": "{{ .CommonLabels.source }}",
+				"client": "client-{{ .CommonLabels.source }}",
+				"client_url": "http://localhost:20200/{{ .CommonLabels.group }}"
+			}`,
 			alerts: []*types.Alert{
 				{
 					Alert: model.Alert{
@@ -137,8 +146,8 @@ func TestPagerdutyNotifier(t *testing.T) {
 						"resolved":     "",
 					},
 				},
-				Client:    "Grafana",
-				ClientURL: "http://localhost",
+				Client:    "client-test-source",
+				ClientURL: "http://localhost:20200/test-group",
 				Links:     []pagerDutyLink{{HRef: "http://localhost", Text: "External URL"}},
 			},
 			expMsgError: nil,

--- a/pkg/services/ngalert/notifier/channels/pagerduty_test.go
+++ b/pkg/services/ngalert/notifier/channels/pagerduty_test.go
@@ -109,6 +109,41 @@ func TestPagerdutyNotifier(t *testing.T) {
 			expMsgError: nil,
 		},
 		{
+			name:     "Should expand templates in fields",
+			settings: `{"integrationKey": "abcdefgh0123456789", "severity" : "{{ .CommonLabels.severity }}", "class": "{{ .CommonLabels.class }}",  "component": "{{ .CommonLabels.component }}", "group" : "{{ .CommonLabels.group }}", "source": "{{ .CommonLabels.source }}" }`,
+			alerts: []*types.Alert{
+				{
+					Alert: model.Alert{
+						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1", "severity": "test-severity", "class": "test-class", "group": "test-group", "component": "test-component", "source": "test-source"},
+						Annotations: model.LabelSet{"ann1": "annv1", "__dashboardUid__": "abcd", "__panelId__": "efgh"},
+					},
+				},
+			},
+			expMsg: &pagerDutyMessage{
+				RoutingKey:  "abcdefgh0123456789",
+				DedupKey:    "6e3538104c14b583da237e9693b76debbc17f0f8058ef20492e5853096cf8733",
+				EventAction: "trigger",
+				Payload: pagerDutyPayload{
+					Summary:   "[FIRING:1]  (test-class test-component test-group val1 test-severity test-source)",
+					Source:    "test-source",
+					Severity:  "test-severity",
+					Class:     "test-class",
+					Component: "test-component",
+					Group:     "test-group",
+					CustomDetails: map[string]string{
+						"firing":       "\nValue: [no value]\nLabels:\n - alertname = alert1\n - class = test-class\n - component = test-component\n - group = test-group\n - lbl1 = val1\n - severity = test-severity\n - source = test-source\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=class%3Dtest-class&matcher=component%3Dtest-component&matcher=group%3Dtest-group&matcher=lbl1%3Dval1&matcher=severity%3Dtest-severity&matcher=source%3Dtest-source\nDashboard: http://localhost/d/abcd\nPanel: http://localhost/d/abcd?viewPanel=efgh\n",
+						"num_firing":   "1",
+						"num_resolved": "0",
+						"resolved":     "",
+					},
+				},
+				Client:    "Grafana",
+				ClientURL: "http://localhost",
+				Links:     []pagerDutyLink{{HRef: "http://localhost", Text: "External URL"}},
+			},
+			expMsgError: nil,
+		},
+		{
 			name:     "Default config with one alert and custom summary",
 			settings: `{"integrationKey": "abcdefgh0123456789", "summary": "Alerts firing: {{ len .Alerts.Firing }}"}`,
 			alerts: []*types.Alert{

--- a/pkg/services/ngalert/notifier/channels/pagerduty_test.go
+++ b/pkg/services/ngalert/notifier/channels/pagerduty_test.go
@@ -56,7 +56,7 @@ func TestPagerdutyNotifier(t *testing.T) {
 				Payload: pagerDutyPayload{
 					Summary:   "[FIRING:1]  (val1)",
 					Source:    hostname,
-					Severity:  "critical",
+					Severity:  defaultSeverity,
 					Class:     "default",
 					Component: "Grafana",
 					Group:     "default",
@@ -114,7 +114,7 @@ func TestPagerdutyNotifier(t *testing.T) {
 			alerts: []*types.Alert{
 				{
 					Alert: model.Alert{
-						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1", "severity": "test-severity", "class": "test-class", "group": "test-group", "component": "test-component", "source": "test-source"},
+						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1", "severity": "critical", "class": "test-class", "group": "test-group", "component": "test-component", "source": "test-source"},
 						Annotations: model.LabelSet{"ann1": "annv1", "__dashboardUid__": "abcd", "__panelId__": "efgh"},
 					},
 				},
@@ -124,14 +124,14 @@ func TestPagerdutyNotifier(t *testing.T) {
 				DedupKey:    "6e3538104c14b583da237e9693b76debbc17f0f8058ef20492e5853096cf8733",
 				EventAction: "trigger",
 				Payload: pagerDutyPayload{
-					Summary:   "[FIRING:1]  (test-class test-component test-group val1 test-severity test-source)",
+					Summary:   "[FIRING:1]  (test-class test-component test-group val1 critical test-source)",
 					Source:    "test-source",
-					Severity:  "test-severity",
+					Severity:  "critical",
 					Class:     "test-class",
 					Component: "test-component",
 					Group:     "test-group",
 					CustomDetails: map[string]string{
-						"firing":       "\nValue: [no value]\nLabels:\n - alertname = alert1\n - class = test-class\n - component = test-component\n - group = test-group\n - lbl1 = val1\n - severity = test-severity\n - source = test-source\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=class%3Dtest-class&matcher=component%3Dtest-component&matcher=group%3Dtest-group&matcher=lbl1%3Dval1&matcher=severity%3Dtest-severity&matcher=source%3Dtest-source\nDashboard: http://localhost/d/abcd\nPanel: http://localhost/d/abcd?viewPanel=efgh\n",
+						"firing":       "\nValue: [no value]\nLabels:\n - alertname = alert1\n - class = test-class\n - component = test-component\n - group = test-group\n - lbl1 = val1\n - severity = critical\n - source = test-source\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=class%3Dtest-class&matcher=component%3Dtest-component&matcher=group%3Dtest-group&matcher=lbl1%3Dval1&matcher=severity%3Dcritical&matcher=source%3Dtest-source\nDashboard: http://localhost/d/abcd\nPanel: http://localhost/d/abcd?viewPanel=efgh\n",
 						"num_firing":   "1",
 						"num_resolved": "0",
 						"resolved":     "",
@@ -161,7 +161,7 @@ func TestPagerdutyNotifier(t *testing.T) {
 				Payload: pagerDutyPayload{
 					Summary:   "Alerts firing: 1",
 					Source:    hostname,
-					Severity:  "critical",
+					Severity:  defaultSeverity,
 					Class:     "default",
 					Component: "Grafana",
 					Group:     "default",
@@ -241,7 +241,7 @@ func TestPagerdutyNotifier(t *testing.T) {
 				Payload: pagerDutyPayload{
 					Summary:   fmt.Sprintf("%s…", strings.Repeat("1", 1023)),
 					Source:    hostname,
-					Severity:  "critical",
+					Severity:  defaultSeverity,
 					Class:     "default",
 					Component: "Grafana",
 					Group:     "default",

--- a/pkg/services/ngalert/notifier/channels_config/available_channels.go
+++ b/pkg/services/ngalert/notifier/channels_config/available_channels.go
@@ -242,8 +242,8 @@ func GetAvailableNotifiers() []*NotifierPlugin {
 					Label:        "Severity",
 					Element:      ElementTypeInput,
 					InputType:    InputTypeText,
-					Placeholder:  "critical",
-					Description:  "Severity of the event. It must be critical, error, warning, info - otherwise, the default is set which is critical. You can use templates",
+					Placeholder:  "error",
+					Description:  "Severity of the event. It must be critical, error, warning, info - otherwise, the default is set which is error. You can use templates",
 					PropertyName: "severity",
 				},
 				{ // New in 8.0.

--- a/pkg/services/ngalert/notifier/channels_config/available_channels.go
+++ b/pkg/services/ngalert/notifier/channels_config/available_channels.go
@@ -1,11 +1,15 @@
 package channels_config
 
 import (
+	"os"
+
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier/channels"
 )
 
 // GetAvailableNotifiers returns the metadata of all the notification channels that can be configured.
 func GetAvailableNotifiers() []*NotifierPlugin {
+	hostname, _ := os.Hostname()
+
 	pushoverSoundOptions := []SelectOption{
 		{
 			Value: "default",
@@ -281,7 +285,7 @@ func GetAvailableNotifiers() []*NotifierPlugin {
 					Description:  "The unique location of the affected system, preferably a hostname or FQDN. You can use templates",
 					Element:      ElementTypeInput,
 					InputType:    InputTypeText,
-					Placeholder:  "<hostname>",
+					Placeholder:  hostname,
 					PropertyName: "source",
 				},
 				{ // New in 9.4.

--- a/pkg/services/ngalert/notifier/channels_config/available_channels.go
+++ b/pkg/services/ngalert/notifier/channels_config/available_channels.go
@@ -284,6 +284,14 @@ func GetAvailableNotifiers() []*NotifierPlugin {
 					Placeholder:  "<hostname>",
 					PropertyName: "source",
 				},
+				{ // New in 9.4.
+					Label:        "Client",
+					Description:  "The name of the monitoring client that is triggering this event. You can use templates",
+					Element:      ElementTypeInput,
+					InputType:    InputTypeText,
+					Placeholder:  "Grafana",
+					PropertyName: "client",
+				},
 			},
 		},
 		{

--- a/pkg/services/ngalert/notifier/channels_config/available_channels.go
+++ b/pkg/services/ngalert/notifier/channels_config/available_channels.go
@@ -292,6 +292,14 @@ func GetAvailableNotifiers() []*NotifierPlugin {
 					Placeholder:  "Grafana",
 					PropertyName: "client",
 				},
+				{ // New in 9.4.
+					Label:        "Client URL",
+					Description:  "The URL of the monitoring client that is triggering this event. You can use templates",
+					Element:      ElementTypeInput,
+					InputType:    InputTypeText,
+					Placeholder:  "{{ .ExternalURL }}",
+					PropertyName: "client_url",
+				},
 			},
 		},
 		{

--- a/pkg/services/ngalert/notifier/channels_config/available_channels.go
+++ b/pkg/services/ngalert/notifier/channels_config/available_channels.go
@@ -276,6 +276,14 @@ func GetAvailableNotifiers() []*NotifierPlugin {
 					Placeholder:  channels.DefaultMessageTitleEmbed,
 					PropertyName: "summary",
 				},
+				{ // New in 9.4.
+					Label:        "Source",
+					Description:  "The unique location of the affected system, preferably a hostname or FQDN. You can use templates",
+					Element:      ElementTypeInput,
+					InputType:    InputTypeText,
+					Placeholder:  "<hostname>",
+					PropertyName: "source",
+				},
 			},
 		},
 		{


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
This pull request introduces support for new fields of PagerDuty configuration: source, client, and client_url. 

![image](https://user-images.githubusercontent.com/25988953/206509803-03044dd8-036b-43b6-ae83-d0de45bc2439.png)

**Why do we need this feature?**
This is needed for the unification of Grafana and Alertmanager receivers.

**Which issue(s) does this PR fix?**:
Related: https://github.com/grafana/alerting/issues/20#issuecomment-1317895945

Fixes https://github.com/grafana/grafana/issues/59502

**Special notes for your reviewer**:

