### PR TITLE
[v9.2.x] Chore: Add encryption codec to the remote cache (#59871)

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -142,6 +142,9 @@ connstr =
 # prefix prepended to all the keys in the remote cache
 prefix =
 
+# This enables encryption of values stored in the remote cache
+encryption =
+
 #################################### Data proxy ###########################
 [dataproxy]
 

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -148,6 +148,9 @@
 # prefix prepended to all the keys in the remote cache
 ; prefix =
 
+# This enables encryption of values stored in the remote cache
+;encryption =
+
 #################################### Data proxy ###########################
 [dataproxy]
 

--- a/pkg/infra/remotecache/database_storage.go
+++ b/pkg/infra/remotecache/database_storage.go
@@ -14,12 +14,14 @@ const databaseCacheType = "database"
 
 type databaseCache struct {
 	SQLStore *sqlstore.SQLStore
+	codec    codec
 	log      log.Logger
 }
 
-func newDatabaseCache(sqlstore *sqlstore.SQLStore) *databaseCache {
+func newDatabaseCache(sqlstore *sqlstore.SQLStore, codec codec) *databaseCache {
 	dc := &databaseCache{
 		SQLStore: sqlstore,
+		codec:    codec,
 		log:      log.New("remotecache.database"),
 	}
 
@@ -79,7 +81,7 @@ func (dc *databaseCache) Get(ctx context.Context, key string) (interface{}, erro
 	}
 
 	item := &cachedItem{}
-	if err = decodeGob(cacheHit.Data, item); err != nil {
+	if err = dc.codec.Decode(ctx, cacheHit.Data, item); err != nil {
 		return nil, err
 	}
 
@@ -88,7 +90,7 @@ func (dc *databaseCache) Get(ctx context.Context, key string) (interface{}, erro
 
 func (dc *databaseCache) Set(ctx context.Context, key string, value interface{}, expire time.Duration) error {
 	item := &cachedItem{Val: value}
-	data, err := encodeGob(item)
+	data, err := dc.codec.Encode(ctx, item)
 	if err != nil {
 		return err
 	}

--- a/pkg/infra/remotecache/database_storage_test.go
+++ b/pkg/infra/remotecache/database_storage_test.go
@@ -15,6 +15,7 @@ func TestDatabaseStorageGarbageCollection(t *testing.T) {
 
 	db := &databaseCache{
 		SQLStore: sqlstore,
+		codec:    &gobCodec{},
 		log:      log.New("remotecache.database"),
 	}
 
@@ -63,6 +64,7 @@ func TestSecondSet(t *testing.T) {
 
 	db := &databaseCache{
 		SQLStore: sqlstore,
+		codec:    &gobCodec{},
 		log:      log.New("remotecache.database"),
 	}
 

--- a/pkg/infra/remotecache/redis_storage.go
+++ b/pkg/infra/remotecache/redis_storage.go
@@ -15,7 +15,8 @@ import (
 const redisCacheType = "redis"
 
 type redisStorage struct {
-	c *redis.Client
+	c     *redis.Client
+	codec codec
 }
 
 // parseRedisConnStr parses k=v pairs in csv and builds a redis Options object
@@ -76,18 +77,18 @@ func parseRedisConnStr(connStr string) (*redis.Options, error) {
 	return options, nil
 }
 
-func newRedisStorage(opts *setting.RemoteCacheOptions) (*redisStorage, error) {
+func newRedisStorage(opts *setting.RemoteCacheOptions, codec codec) (*redisStorage, error) {
 	opt, err := parseRedisConnStr(opts.ConnStr)
 	if err != nil {
 		return nil, err
 	}
-	return &redisStorage{c: redis.NewClient(opt)}, nil
+	return &redisStorage{c: redis.NewClient(opt), codec: codec}, nil
 }
 
 // Set sets value to given key in session.
 func (s *redisStorage) Set(ctx context.Context, key string, val interface{}, expires time.Duration) error {
 	item := &cachedItem{Val: val}
-	value, err := encodeGob(item)
+	value, err := s.codec.Encode(ctx, item)
 	if err != nil {
 		return err
 	}
@@ -100,7 +101,7 @@ func (s *redisStorage) Get(ctx context.Context, key string) (interface{}, error)
 	v := s.c.Get(ctx, key)
 
 	item := &cachedItem{}
-	err := decodeGob([]byte(v.Val()), item)
+	err := s.codec.Decode(ctx, []byte(v.Val()), item)
 
 	if err == nil {
 		return item.Val, nil

--- a/pkg/infra/remotecache/remotecache.go
+++ b/pkg/infra/remotecache/remotecache.go
@@ -11,6 +11,7 @@ import (
 
 	glog "github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/registry"
+	"github.com/grafana/grafana/pkg/services/secrets"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/setting"
 )
@@ -29,8 +30,14 @@ const (
 	ServiceName = "RemoteCache"
 )
 
-func ProvideService(cfg *setting.Cfg, sqlStore *sqlstore.SQLStore) (*RemoteCache, error) {
-	client, err := createClient(cfg.RemoteCacheOptions, sqlStore)
+func ProvideService(cfg *setting.Cfg, sqlStore *sqlstore.SQLStore, secretsService secrets.Service) (*RemoteCache, error) {
+	var codec codec
+	if cfg.RemoteCacheOptions.Encryption {
+		codec = &encryptionCodec{secretsService}
+	} else {
+		codec = &gobCodec{}
+	}
+	client, err := createClient(cfg.RemoteCacheOptions, sqlStore, codec)
 	if err != nil {
 		return nil, err
 	}
@@ -97,14 +104,14 @@ func (ds *RemoteCache) Run(ctx context.Context) error {
 	return ctx.Err()
 }
 
-func createClient(opts *setting.RemoteCacheOptions, sqlstore *sqlstore.SQLStore) (cache CacheStorage, err error) {
+func createClient(opts *setting.RemoteCacheOptions, sqlstore *sqlstore.SQLStore, codec codec) (cache CacheStorage, err error) {
 	switch opts.Name {
 	case redisCacheType:
-		cache, err = newRedisStorage(opts)
+		cache, err = newRedisStorage(opts, codec)
 	case memcachedCacheType:
-		cache = newMemcachedStorage(opts)
+		cache = newMemcachedStorage(opts, codec)
 	case databaseCacheType:
-		cache = newDatabaseCache(sqlstore)
+		cache = newDatabaseCache(sqlstore, codec)
 	default:
 		return nil, ErrInvalidCacheType
 	}
@@ -131,14 +138,43 @@ type cachedItem struct {
 	Val interface{}
 }
 
-func encodeGob(item *cachedItem) ([]byte, error) {
+type codec interface {
+	Encode(context.Context, *cachedItem) ([]byte, error)
+	Decode(context.Context, []byte, *cachedItem) error
+}
+
+type gobCodec struct{}
+
+func (c *gobCodec) Encode(_ context.Context, item *cachedItem) ([]byte, error) {
 	buf := bytes.NewBuffer(nil)
 	err := gob.NewEncoder(buf).Encode(item)
 	return buf.Bytes(), err
 }
 
-func decodeGob(data []byte, out *cachedItem) error {
+func (c *gobCodec) Decode(_ context.Context, data []byte, out *cachedItem) error {
 	buf := bytes.NewBuffer(data)
+	return gob.NewDecoder(buf).Decode(&out)
+}
+
+type encryptionCodec struct {
+	secretsService secrets.Service
+}
+
+func (c *encryptionCodec) Encode(ctx context.Context, item *cachedItem) ([]byte, error) {
+	buf := bytes.NewBuffer(nil)
+	err := gob.NewEncoder(buf).Encode(item)
+	if err != nil {
+		return nil, err
+	}
+	return c.secretsService.Encrypt(ctx, buf.Bytes(), secrets.WithoutScope())
+}
+
+func (c *encryptionCodec) Decode(ctx context.Context, data []byte, out *cachedItem) error {
+	decrypted, err := c.secretsService.Decrypt(ctx, data)
+	if err != nil {
+		return err
+	}
+	buf := bytes.NewBuffer(decrypted)
 	return gob.NewDecoder(buf).Decode(&out)
 }
 

--- a/pkg/infra/remotecache/remotecache_test.go
+++ b/pkg/infra/remotecache/remotecache_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/secrets/fakes"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/stretchr/testify/assert"
@@ -27,7 +28,7 @@ func createTestClient(t *testing.T, opts *setting.RemoteCacheOptions, sqlstore *
 	cfg := &setting.Cfg{
 		RemoteCacheOptions: opts,
 	}
-	dc, err := ProvideService(cfg, sqlstore)
+	dc, err := ProvideService(cfg, sqlstore, fakes.NewFakeSecretsService())
 	require.Nil(t, err, "Failed to init client for test")
 
 	return dc
@@ -45,7 +46,7 @@ func TestCachedBasedOnConfig(t *testing.T) {
 }
 
 func TestInvalidCacheTypeReturnsError(t *testing.T) {
-	_, err := createClient(&setting.RemoteCacheOptions{Name: "invalid"}, nil)
+	_, err := createClient(&setting.RemoteCacheOptions{Name: "invalid"}, nil, &gobCodec{})
 	assert.Equal(t, err, ErrInvalidCacheType)
 }
 
@@ -94,6 +95,7 @@ func TestCachePrefix(t *testing.T) {
 	cache := &databaseCache{
 		SQLStore: db,
 		log:      log.New("remotecache.database"),
+		codec:    &gobCodec{},
 	}
 	prefixCache := &prefixCacheStorage{cache: cache, prefix: "test/"}
 

--- a/pkg/infra/remotecache/testing.go
+++ b/pkg/infra/remotecache/testing.go
@@ -3,6 +3,7 @@ package remotecache
 import (
 	"testing"
 
+	"github.com/grafana/grafana/pkg/services/secrets/fakes"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/stretchr/testify/require"
@@ -21,7 +22,7 @@ func NewFakeStore(t *testing.T) *RemoteCache {
 
 	dc, err := ProvideService(&setting.Cfg{
 		RemoteCacheOptions: opts,
-	}, sqlStore)
+	}, sqlStore, fakes.NewFakeSecretsService())
 	require.NoError(t, err, "Failed to init remote cache for test")
 
 	return dc

--- a/pkg/services/contexthandler/auth_proxy_test.go
+++ b/pkg/services/contexthandler/auth_proxy_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/contexthandler/authproxy"
 	"github.com/grafana/grafana/pkg/services/login/loginservice"
 	"github.com/grafana/grafana/pkg/services/rendering"
+	"github.com/grafana/grafana/pkg/services/secrets/fakes"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/services/user/usertest"
@@ -76,7 +77,7 @@ func getContextHandler(t *testing.T) *ContextHandler {
 	cfg.AuthProxyHeaderName = "X-Killa"
 	cfg.AuthProxyEnabled = true
 	cfg.AuthProxyHeaderProperty = "username"
-	remoteCacheSvc, err := remotecache.ProvideService(cfg, sqlStore)
+	remoteCacheSvc, err := remotecache.ProvideService(cfg, sqlStore, fakes.NewFakeSecretsService())
 	require.NoError(t, err)
 	userAuthTokenSvc := auth.NewFakeUserAuthTokenService()
 	renderSvc := &fakeRenderService{}

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -1073,11 +1073,13 @@ func (cfg *Cfg) Load(args CommandLineArgs) error {
 	dbName := valueAsString(cacheServer, "type", "database")
 	connStr := valueAsString(cacheServer, "connstr", "")
 	prefix := valueAsString(cacheServer, "prefix", "")
+	encryption := cacheServer.Key("encryption").MustBool(false)
 
 	cfg.RemoteCacheOptions = &RemoteCacheOptions{
-		Name:    dbName,
-		ConnStr: connStr,
-		Prefix:  prefix,
+		Name:       dbName,
+		ConnStr:    connStr,
+		Prefix:     prefix,
+		Encryption: encryption,
 	}
 
 	geomapSection := iniFile.Section("geomap")
@@ -1111,9 +1113,10 @@ func valueAsString(section *ini.Section, keyName string, defaultValue string) st
 }
 
 type RemoteCacheOptions struct {
-	Name    string
-	ConnStr string
-	Prefix  string
+	Name       string
+	ConnStr    string
+	Prefix     string
+	Encryption bool
 }
 
 func (cfg *Cfg) readLDAPConfig() {


### PR DESCRIPTION
* add encryption codec to the remote cache

* change config files too

* fix test constructor

* pass codec into the test cache

(cherry picked from commit f1fb202284a961bd8e3229742e57cc834a201078)

Backport of https://github.com/grafana/grafana/pull/59871