### PR TITLE
Chore: Replace yaml.v2 with yaml.v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -121,7 +121,7 @@ require (
 	gopkg.in/ldap.v3 v3.1.0
 	gopkg.in/mail.v2 v2.3.1
 	gopkg.in/square/go-jose.v2 v2.5.1
-	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1
 	xorm.io/builder v0.3.6
 	xorm.io/core v0.7.3

--- a/pkg/services/featuremgmt/settings.go
+++ b/pkg/services/featuremgmt/settings.go
@@ -3,7 +3,7 @@ package featuremgmt
 import (
 	"os"
 
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 type configBody struct {

--- a/pkg/services/ngalert/notifier/channels/util.go
+++ b/pkg/services/ngalert/notifier/channels/util.go
@@ -20,7 +20,7 @@ import (
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/common/model"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"

--- a/pkg/services/provisioning/alerting/config_reader.go
+++ b/pkg/services/provisioning/alerting/config_reader.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/grafana/grafana/pkg/infra/log"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 type rulesConfigReader struct {

--- a/pkg/services/provisioning/alerting/contact_point_types_test.go
+++ b/pkg/services/provisioning/alerting/contact_point_types_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/services/provisioning/values"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 func TestReceivers(t *testing.T) {

--- a/pkg/services/provisioning/alerting/notification_policy_types_test.go
+++ b/pkg/services/provisioning/alerting/notification_policy_types_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/services/provisioning/dashboards/config_reader.go
+++ b/pkg/services/provisioning/dashboards/config_reader.go
@@ -11,7 +11,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/provisioning/utils"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 type configReader struct {

--- a/pkg/services/provisioning/datasources/config_reader.go
+++ b/pkg/services/provisioning/datasources/config_reader.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/datasources"

--- a/pkg/services/provisioning/notifiers/config_reader.go
+++ b/pkg/services/provisioning/notifiers/config_reader.go
@@ -16,7 +16,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/provisioning/utils"
 	"github.com/grafana/grafana/pkg/setting"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 type configReader struct {

--- a/pkg/services/provisioning/plugins/config_reader.go
+++ b/pkg/services/provisioning/plugins/config_reader.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/plugins"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 type configReader interface {

--- a/pkg/services/provisioning/values/values.go
+++ b/pkg/services/provisioning/values/values.go
@@ -210,8 +210,8 @@ func (val *JSONSliceValue) UnmarshalYAML(unmarshal func(interface{}) error) erro
 	for _, v := range unmarshaled {
 		i := make(map[string]interface{})
 		r := make(map[string]interface{})
-		for key, val := range v.(map[interface{}]interface{}) {
-			i[key.(string)], r[key.(string)], err = transformInterface(val)
+		for key, val := range v.(map[string]interface{}) {
+			i[key], r[key], err = transformInterface(val)
 			if err != nil {
 				return err
 			}
@@ -245,7 +245,7 @@ func transformInterface(i interface{}) (interface{}, interface{}, error) {
 	case reflect.Slice:
 		return transformSlice(i.([]interface{}))
 	case reflect.Map:
-		return transformMap(i.(map[interface{}]interface{}))
+		return transformMap(i.(map[string]interface{}))
 	case reflect.String:
 		return interpolateValue(i.(string))
 	default:
@@ -268,17 +268,14 @@ func transformSlice(i []interface{}) (interface{}, interface{}, error) {
 	return transformedSlice, rawSlice, nil
 }
 
-func transformMap(i map[interface{}]interface{}) (interface{}, interface{}, error) {
+func transformMap(i map[string]interface{}) (interface{}, interface{}, error) {
 	transformed := make(map[string]interface{})
 	raw := make(map[string]interface{})
 	for key, val := range i {
-		stringKey, ok := key.(string)
-		if ok {
-			var err error
-			transformed[stringKey], raw[stringKey], err = transformInterface(val)
-			if err != nil {
-				return nil, nil, err
-			}
+		var err error
+		transformed[key], raw[key], err = transformInterface(val)
+		if err != nil {
+			return nil, nil, err
 		}
 	}
 	return transformed, raw, nil

--- a/pkg/services/provisioning/values/values_test.go
+++ b/pkg/services/provisioning/values/values_test.go
@@ -39,21 +39,23 @@ func TestValues(t *testing.T) {
 			type Data struct {
 				Val IntValue `yaml:"val"`
 			}
-			d := &Data{}
-
 			t.Run("Should unmarshal simple number", func(t *testing.T) {
+				d := &Data{}
+
 				unmarshalingTest(t, `val: 1`, d)
 				require.Equal(t, d.Val.Value(), 1)
 				require.Equal(t, d.Val.Raw, "1")
 			})
 
 			t.Run("Should unmarshal env var", func(t *testing.T) {
+				d := &Data{}
 				unmarshalingTest(t, `val: $INT`, d)
 				require.Equal(t, d.Val.Value(), 1)
 				require.Equal(t, d.Val.Raw, "$INT")
 			})
 
 			t.Run("Should ignore empty value", func(t *testing.T) {
+				d := &Data{}
 				unmarshalingTest(t, `val: `, d)
 				require.Equal(t, d.Val.Value(), 0)
 				require.Equal(t, d.Val.Raw, "")
@@ -64,39 +66,43 @@ func TestValues(t *testing.T) {
 			type Data struct {
 				Val StringValue `yaml:"val"`
 			}
-			d := &Data{}
-
 			t.Run("Should unmarshal simple string", func(t *testing.T) {
+				d := &Data{}
 				unmarshalingTest(t, `val: test`, d)
 				require.Equal(t, d.Val.Value(), "test")
 				require.Equal(t, d.Val.Raw, "test")
 			})
 
 			t.Run("Should unmarshal env var", func(t *testing.T) {
+				d := &Data{}
 				unmarshalingTest(t, `val: $STRING`, d)
 				require.Equal(t, d.Val.Value(), "test")
 				require.Equal(t, d.Val.Raw, "$STRING")
 			})
 
 			t.Run("Should ignore empty value", func(t *testing.T) {
+				d := &Data{}
 				unmarshalingTest(t, `val: `, d)
 				require.Equal(t, d.Val.Value(), "")
 				require.Equal(t, d.Val.Raw, "")
 			})
 
 			t.Run("empty var should have empty value", func(t *testing.T) {
+				d := &Data{}
 				unmarshalingTest(t, `val: $EMPTYSTRING`, d)
 				require.Equal(t, d.Val.Value(), "")
 				require.Equal(t, d.Val.Raw, "$EMPTYSTRING")
 			})
 
 			t.Run("$$ should be a literal $", func(t *testing.T) {
+				d := &Data{}
 				unmarshalingTest(t, `val: $$`, d)
 				require.Equal(t, d.Val.Value(), "$")
 				require.Equal(t, d.Val.Raw, "$$")
 			})
 
 			t.Run("$$ should be a literal $ and not expanded within a string", func(t *testing.T) {
+				d := &Data{}
 				unmarshalingTest(t, `val: mY,Passwo$$rd`, d)
 				require.Equal(t, d.Val.Value(), "mY,Passwo$rd")
 				require.Equal(t, d.Val.Raw, "mY,Passwo$$rd")
@@ -107,27 +113,29 @@ func TestValues(t *testing.T) {
 			type Data struct {
 				Val BoolValue `yaml:"val"`
 			}
-			d := &Data{}
-
 			t.Run("Should unmarshal bool value", func(t *testing.T) {
+				d := &Data{}
 				unmarshalingTest(t, `val: true`, d)
 				require.True(t, d.Val.Value())
 				require.Equal(t, d.Val.Raw, "true")
 			})
 
 			t.Run("Should unmarshal explicit string", func(t *testing.T) {
+				d := &Data{}
 				unmarshalingTest(t, `val: "true"`, d)
 				require.True(t, d.Val.Value())
 				require.Equal(t, d.Val.Raw, "true")
 			})
 
 			t.Run("Should unmarshal env var", func(t *testing.T) {
+				d := &Data{}
 				unmarshalingTest(t, `val: $BOOL`, d)
 				require.True(t, d.Val.Value())
 				require.Equal(t, d.Val.Raw, "$BOOL")
 			})
 
 			t.Run("Should ignore empty value", func(t *testing.T) {
+				d := &Data{}
 				unmarshalingTest(t, `val: `, d)
 				require.False(t, d.Val.Value())
 				require.Equal(t, d.Val.Raw, "")

--- a/pkg/services/provisioning/values/values_test.go
+++ b/pkg/services/provisioning/values/values_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/ini.v1"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 func TestValues(t *testing.T) {


### PR DESCRIPTION
Some files import yaml.v2, some yaml.v3. Let's be modern and just use v3 everywhere.