### PR TITLE
JavaScript Unit Tests: Enable shouldFailOnLog only for CI environments

### DIFF
--- a/public/test/setupTests.ts
+++ b/public/test/setupTests.ts
@@ -6,7 +6,7 @@ import { initReactI18next } from 'react-i18next';
 import { matchers } from './matchers';
 
 failOnConsole({
-  //shouldFailOnLog: true,
+  shouldFailOnLog: process.env.CI ? true : false,
 });
 
 expect.extend(matchers);


### PR DESCRIPTION
It appears to be common among developers to locally disable this rule, to the extent that it's currently a commented line in the `main` branch. 

In this PR I propose to enable it only for CI environments, and allow developers to locally use console output for debugging.