### PR TITLE
Fix incorrect start time for DatasourceError alerts

### DIFF
--- a/pkg/services/ngalert/state/manager_test.go
+++ b/pkg/services/ngalert/state/manager_test.go
@@ -1868,7 +1868,7 @@ func TestProcessEvalResults(t *testing.T) {
 							Values:          make(map[string]*float64),
 						},
 					},
-					StartsAt:           evaluationTime.Add(20 * time.Second),
+					StartsAt:           evaluationTime.Add(30 * time.Second),
 					EndsAt:             evaluationTime.Add(50 * time.Second).Add(state.ResendDelay * 3),
 					LastEvaluationTime: evaluationTime.Add(50 * time.Second),
 					EvaluationDuration: evaluationDuration,

--- a/pkg/services/ngalert/state/state.go
+++ b/pkg/services/ngalert/state/state.go
@@ -198,6 +198,11 @@ func (a *State) resultError(alertRule *models.AlertRule, result eval.Result) {
 		// is unavailable or queries against the datasource returns errors, and is
 		// then resolved as soon as the datasource is available and queries return
 		// without error
+		if a.State != execErrState {
+			// Set the start time if the state changes from Alerting to Error or from
+			// Error to Alerting
+			a.StartsAt = result.EvaluatedAt
+		}
 		a.State = execErrState
 		a.setEndsAt(alertRule, result)
 	case eval.Pending:


### PR DESCRIPTION
**What is this feature?**

This pull request fixes an incorrect start time for DatasourceError alerts if the state changes between Alerting and Error.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

