### PR TITLE
CI: Add `enterprise2` flag to unblock enterprise2 image deployments

### DIFF
--- a/pkg/build/cmd/main.go
+++ b/pkg/build/cmd/main.go
@@ -168,6 +168,10 @@ func main() {
 			Flags: []cli.Flag{
 				&jobsFlag,
 				&editionFlag,
+				&cli.BoolFlag{
+					Name:  "enterprise2",
+					Usage: "Declare if the edition is enterprise2",
+				},
 			},
 		},
 		{

--- a/pkg/build/cmd/uploadpackages.go
+++ b/pkg/build/cmd/uploadpackages.go
@@ -86,7 +86,7 @@ func UploadPackages(c *cli.Context) error {
 		distDir:     distDir,
 	}
 
-	if cfg.edition == config.EditionEnterprise2 {
+	if cfg.edition == config.EditionEnterprise2 || c.Bool("enterprise2") {
 		if releaseModeConfig.Buckets.ArtifactsEnterprise2 != "" {
 			cfg.Config.Bucket = releaseModeConfig.Buckets.ArtifactsEnterprise2
 		} else {


### PR DESCRIPTION
**What is this feature?**

This is a hacky way to deal with the wrong enterprise2 paths. Will revisit shortly. For now we'd like to have this flag in place so we can unblock enterprise2 deployments.

Related: https://github.com/grafana/grafana-enterprise/pull/4205