### PR TITLE
EntityStore: support filtering by labels

### DIFF
--- a/pkg/services/store/entity/sqlstash/querybuilder.go
+++ b/pkg/services/store/entity/sqlstash/querybuilder.go
@@ -17,6 +17,11 @@ func (q *selectQuery) addWhere(f string, val interface{}) {
 	q.where = append(q.where, f+"=?")
 }
 
+func (q *selectQuery) addWhereInSubquery(f string, subquery string, subqueryArgs []interface{}) {
+	q.args = append(q.args, subqueryArgs...)
+	q.where = append(q.where, f+" IN ("+subquery+")")
+}
+
 func (q *selectQuery) addWhereIn(f string, vals []string) {
 	count := len(vals)
 	if count > 1 {

--- a/pkg/services/store/entity/sqlstash/sql_storage_server.go
+++ b/pkg/services/store/entity/sqlstash/sql_storage_server.go
@@ -669,13 +669,13 @@ func (s *sqlEntityServer) Search(ctx context.Context, r *entity.EntitySearchRequ
 		for labelKey, labelValue := range r.Labels {
 			args = append(args, labelKey)
 			args = append(args, labelValue)
-			conditions = append(conditions, "(label = ? AND value = ?)")
+			conditions = append(conditions, "(LABEL = ? AND VALUE = ?)")
 		}
 		joinedConditions := strings.Join(conditions, " OR ")
-		query := "select grn from entity_labels where " + joinedConditions + " group by grn having count(label) = ?"
+		query := "SELECT GRN FROM ENTITY_LABELS WHERE " + joinedConditions + " GROUP BY GRN HAVING COUNT(LABEL) = ?"
 		args = append(args, len(r.Labels))
 
-		entityQuery.addWhereInSubquery("grn", query, args)
+		entityQuery.addWhereInSubquery("GRN", query, args)
 	}
 
 	query, args := entityQuery.toQuery()

--- a/pkg/services/store/entity/sqlstash/sql_storage_server.go
+++ b/pkg/services/store/entity/sqlstash/sql_storage_server.go
@@ -669,13 +669,13 @@ func (s *sqlEntityServer) Search(ctx context.Context, r *entity.EntitySearchRequ
 		for labelKey, labelValue := range r.Labels {
 			args = append(args, labelKey)
 			args = append(args, labelValue)
-			conditions = append(conditions, "(LABEL = ? AND VALUE = ?)")
+			conditions = append(conditions, "(label = ? AND value = ?)")
 		}
 		joinedConditions := strings.Join(conditions, " OR ")
-		query := "SELECT GRN FROM ENTITY_LABELS WHERE " + joinedConditions + " GROUP BY GRN HAVING COUNT(LABEL) = ?"
+		query := "SELECT grn FROM entity_labels WHERE " + joinedConditions + " GROUP BY grn HAVING COUNT(label) = ?"
 		args = append(args, len(r.Labels))
 
-		entityQuery.addWhereInSubquery("GRN", query, args)
+		entityQuery.addWhereInSubquery("grn", query, args)
 	}
 
 	query, args := entityQuery.toQuery()

--- a/pkg/services/store/entity/sqlstash/sql_storage_server.go
+++ b/pkg/services/store/entity/sqlstash/sql_storage_server.go
@@ -672,7 +672,7 @@ func (s *sqlEntityServer) Search(ctx context.Context, r *entity.EntitySearchRequ
 			conditions = append(conditions, "(label = ? AND value = ?)")
 		}
 		joinedConditions := strings.Join(conditions, " OR ")
-		query := "select grn from entity_labels where " + joinedConditions + " group by grn having count(distinct label) = ?"
+		query := "select grn from entity_labels where " + joinedConditions + " group by grn having count(label) = ?"
 		args = append(args, len(r.Labels))
 
 		entityQuery.addWhereInSubquery("grn", query, args)

--- a/pkg/services/store/entity/tests/server_integration_test.go
+++ b/pkg/services/store/entity/tests/server_integration_test.go
@@ -426,6 +426,32 @@ func TestIntegrationEntityServer(t *testing.T) {
 			WithBody:   false,
 			WithLabels: true,
 			Labels: map[string]string{
+				"red":   "",
+				"green": "",
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, search)
+		require.Len(t, search.Results, 1)
+		require.Equal(t, search.Results[0].GRN.UID, "red-green")
+
+		search, err = testCtx.client.Search(ctx, &entity.EntitySearchRequest{
+			Kind:       []string{kind},
+			WithBody:   false,
+			WithLabels: true,
+			Labels: map[string]string{
+				"red": "invalid",
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, search)
+		require.Len(t, search.Results, 0)
+
+		search, err = testCtx.client.Search(ctx, &entity.EntitySearchRequest{
+			Kind:       []string{kind},
+			WithBody:   false,
+			WithLabels: true,
+			Labels: map[string]string{
 				"green": "",
 			},
 		})

--- a/pkg/services/store/entity/tests/testdata/dashboard-with-tags-b-g.json
+++ b/pkg/services/store/entity/tests/testdata/dashboard-with-tags-b-g.json
@@ -1,0 +1,40 @@
+{
+  "tags": [
+    "blue",
+    "green"
+  ],
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 221,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "id": 8,
+      "title": "Row title",
+      "type": "row"
+    }
+  ],
+  "schemaVersion": 36,
+  "style": "dark",
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "special ds",
+  "uid": "mocpwtR4k",
+  "version": 1,
+  "weekStart": ""
+}

--- a/pkg/services/store/entity/tests/testdata/dashboard-with-tags-r-g.json
+++ b/pkg/services/store/entity/tests/testdata/dashboard-with-tags-r-g.json
@@ -1,0 +1,40 @@
+{
+  "tags": [
+    "red",
+    "green"
+  ],
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 221,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "id": 8,
+      "title": "Row title",
+      "type": "row"
+    }
+  ],
+  "schemaVersion": 36,
+  "style": "dark",
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "special ds",
+  "uid": "mocpwtR4k",
+  "version": 1,
+  "weekStart": ""
+}


### PR DESCRIPTION
This PR adds support for label filtering to the SQL version of EntityStore

The resulting query looks something like this:

```sql
SELECT grn,tenant_id,kind,uid,version,folder,slug,errors,size,updated_at,updated_by,name,description,labels
FROM entity
WHERE
    tenant_id=? AND
    kind=? AND
    grn IN (
        SELECT GRN
        FROM ENTITY_LABELS
        WHERE
            (LABEL = ? AND VALUE = ?) OR
            (LABEL = ? AND VALUE = ?) OR
            (LABEL = ? AND VALUE = ?)
        GROUP BY GRN HAVING COUNT(LABEL) = 3)   # <--- dynamic number equal to the number of labels in the request
LIMIT ?
```