### PR TITLE
Auth: Session cache [v9.2.x]

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -68,4 +68,5 @@ export interface FeatureToggles {
   athenaAsyncQueryDataSupport?: boolean;
   increaseInMemDatabaseQueryCache?: boolean;
   datasourceLogger?: boolean;
+  sessionRemoteCache?: boolean;
 }

--- a/pkg/services/auth/auth_token.go
+++ b/pkg/services/auth/auth_token.go
@@ -160,7 +160,7 @@ func (s *UserAuthTokenService) lookupTokenWithCache(ctx context.Context, unhashe
 	// only cache tokens until their rotation time
 	nextRotation := time.Unix(token.RotatedAt, 0).Add(time.Duration(s.Cfg.TokenRotationIntervalMinutes) * time.Minute)
 	if now := getTime(); now.Before(nextRotation) {
-		if ttlSet := min(ttl, nextRotation.Sub(now)); ttlSet >= 1 {
+		if ttlSet := min(ttl, nextRotation.Sub(now)); ttlSet >= time.Second {
 			if err := s.remoteCache.Set(ctx, cacheKey, *token, ttlSet); err != nil {
 				s.log.Warn("could not cache token", "error", err, "cacheKey", cacheKey, "userId", token.UserId)
 			}

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -287,5 +287,10 @@ var (
 			Name:        "datasourceLogger",
 			Description: "Logs all datasource requests",
 		},
+		{
+			Name:        "sessionRemoteCache",
+			Description: "Enable using remote cache for user sessions",
+			State:       FeatureStateAlpha,
+		},
 	}
 )

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -214,4 +214,8 @@ const (
 	// FlagDatasourceLogger
 	// Logs all datasource requests
 	FlagDatasourceLogger = "datasourceLogger"
+
+	// FlagSessionRemoteCache
+	// Enable using remote cache for users and sessions
+	FlagSessionRemoteCache = "sessionRemoteCache"
 )

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -216,6 +216,6 @@ const (
 	FlagDatasourceLogger = "datasourceLogger"
 
 	// FlagSessionRemoteCache
-	// Enable using remote cache for users and sessions
+	// Enable using remote cache for user sessions
 	FlagSessionRemoteCache = "sessionRemoteCache"
 )


### PR DESCRIPTION
**What is this feature?**

- Session cache for v9.2.x
- Some edge cases could generate multiple token rotations but this issue already exists in the current system.


Feature flag: `sessionRemoteCache`
