### PR TITLE
Chore: New workflow to add and update epic issue into parent project

### DIFF
--- a/.github/workflows/epic-add-to-platform-ux-parent-project.yml
+++ b/.github/workflows/epic-add-to-platform-ux-parent-project.yml
@@ -1,4 +1,4 @@
-name: When epic issues changed, check if part of specified child projects and update on specified parent project
+name: When epic issues changed in Platform UX squad porjects, check if epic is part of specified child projects and update on Platform UX parent project
 
 on:
   issues:

--- a/.github/workflows/epic-add-to-platform-ux-parent-project.yml
+++ b/.github/workflows/epic-add-to-platform-ux-parent-project.yml
@@ -1,8 +1,8 @@
-name: When epic issues changed in Platform UX squad porjects, check if epic is part of specified child projects and update on Platform UX parent project
+name: When epic issues changed in Platform UX squad projects, check if epic is part of specified child projects and update on Platform UX parent project
 
 on:
   issues:
-    types: [opened, edited, reopened, assigned, unassigned, labeled, unlabeled]
+    types: [opened, closed, edited, reopened, assigned, unassigned, labeled, unlabeled]
     labels:
       - 'type/epic'
       

--- a/.github/workflows/issue-add-to-parent-project.yml
+++ b/.github/workflows/issue-add-to-parent-project.yml
@@ -1,0 +1,134 @@
+name: When epic issues changed, check if part of specified child projects and update on specified parent project
+
+on:
+  issues:
+    types: [opened, edited, reopened, assigned, unassigned, labeled, unlabeled]
+    labels:
+      - 'type/epic'
+      
+env:
+  GITHUB_TOKEN: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
+  ORGANIZATION: ${{ github.repository_owner }}
+  REPO: ${{ github.event.repository.name }}
+  PARENT_PROJECT: 304
+  CHILD_PROJECT_1: 78
+  CHILD_PROJECT_2: 111
+  CHILD_PROJECT_3: 202
+    
+concurrency:
+  group: issue-add-to-parent-project-${{ github.event.number }}
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if issue is in child or parent projects
+        run: |
+          gh api graphql -f query='
+            query($org: String!, $repo: String!) {
+              repository(name: $repo, owner: $org) {
+                issue (number: ${{ github.event.issue.number }}) {
+                  projectItems(first:20) {
+                    nodes {
+                      id,
+                      project {
+                        number,
+                        title
+                      },
+                      fieldValueByName(name:"Status") {
+                        ... on ProjectV2ItemFieldSingleSelectValue {
+                          optionId
+                          name
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }' -f org=$ORGANIZATION -f repo=$REPO > projects_data.json
+            
+            echo 'IN_PARENT_PROJ='$(jq '.data.repository.issue.projectItems.nodes[] | select(.project.number==${{ env.PARENT_PROJECT }}) | .project != null' projects_data.json) >> $GITHUB_ENV
+            echo 'PARENT_PROJ_STATUS_ID='$(jq '.data.repository.issue.projectItems.nodes[] | select(.project.number==${{ env.PARENT_PROJECT }}) | select(.fieldValueByName != null) | .fieldValueByName.optionId' projects_data.json) >> $GITHUB_ENV
+            echo 'ITEM_ID='$(jq '.data.repository.issue.projectItems.nodes[] | select(.project.number==${{ env.PARENT_PROJECT }}) | .id' projects_data.json) >> $GITHUB_ENV
+            echo 'IN_CHILD_PROJ='$(jq 'first(.data.repository.issue.projectItems.nodes[] | select(.project.number==${{ env.CHILD_PROJECT_1 }} or .project.number==${{ env.CHILD_PROJECT_2 }} or .project.number==${{ env.CHILD_PROJECT_3 }}) | .project != null)' projects_data.json) >> $GITHUB_ENV
+            echo 'CHILD_PROJ_STATUS='$(jq -r '.data.repository.issue.projectItems.nodes[] | select(.project.number==${{ env.CHILD_PROJECT_1 }} or .project.number==${{ env.CHILD_PROJECT_2 }} or .project.number==${{ env.CHILD_PROJECT_3 }}) | select(.fieldValueByName != null) | .fieldValueByName.name' projects_data.json) >> $GITHUB_ENV
+      - name: Get parent project project data
+        if: env.IN_CHILD_PROJ
+        run: |
+          gh api graphql -f query='
+            query($org: String!, $number: Int!) {
+              organization(login: $org){
+                projectV2(number: $number) {
+                  id
+                  fields(first:20) {
+                    nodes {
+                      ... on ProjectV2Field {
+                        id
+                        name
+                      }
+                      ... on ProjectV2SingleSelectField {
+                        id
+                        name
+                        options {
+                          id
+                          name
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }' -f org=$ORGANIZATION -F number=$PARENT_PROJECT > project_data.json
+
+          echo 'PROJECT_ID='$(jq '.data.organization.projectV2.id' project_data.json) >> $GITHUB_ENV
+          echo 'STATUS_FIELD_ID='$(jq '.data.organization.projectV2.fields.nodes[] | select(.name== "Status") | .id' project_data.json) >> $GITHUB_ENV
+          echo 'TODO_OPTION_ID='$(jq '.data.organization.projectV2.fields.nodes[] | select(.name== "Status") | .options[] | select(.name=="Todo") |.id' project_data.json) >> $GITHUB_ENV
+          echo 'PROGRESS_OPTION_ID='$(jq '.data.organization.projectV2.fields.nodes[] | select(.name== "Status") | .options[] | select(.name=="In Progress") |.id' project_data.json) >> $GITHUB_ENV
+          echo 'DONE_OPTION_ID='$(jq '.data.organization.projectV2.fields.nodes[] | select(.name== "Status") | .options[] | select(.name=="Done") |.id' project_data.json) >> $GITHUB_ENV
+      - name: Add issue to parent project
+        if: env.IN_CHILD_PROJ && !env.IN_PARENT_PROJ
+        run: |
+          item_id="$( gh api graphql -f query='
+            mutation($project:ID!, $issue:ID!) {
+              addProjectV2ItemById(input: {projectId: $project, contentId: $issue}) {
+                item {
+                  id
+                }
+              }
+            }' -f project=$PROJECT_ID -f issue=${{ github.event.issue.node_id }} --jq '.data.addProjectV2ItemById.item.id')"
+ 
+            echo 'ITEM_ID='$item_id >> $GITHUB_ENV
+      - name: Set parent project status Done
+        if: contains(env.CHILD_PROJ_STATUS, 'Done')
+        run: |
+          echo 'OPTION_ID='$DONE_OPTION_ID >> $GITHUB_ENV
+      - name: Set parent project status In Progress
+        if: contains(env.CHILD_PROJ_STATUS, 'In ') || contains(env.CHILD_PROJ_STATUS, 'Blocked')
+        run: |
+          echo 'OPTION_ID='$PROGRESS_OPTION_ID >> $GITHUB_ENV
+      - name: Set parent project status To do
+        if: env.CHILD_PROJ_STATUS && !contains(env.CHILD_PROJ_STATUS, 'In ') && !contains(env.CHILD_PROJ_STATUS, 'Blocked') && ! contains(env.CHILD_PROJ_STATUS, 'Done')
+        run: |
+          echo 'OPTION_ID='$TODO_OPTION_ID >> $GITHUB_ENV
+      - name: Set issue status in parent project
+        if: env.OPTION_ID && (env.OPTION_ID != env.PARENT_PROJ_STATUS_ID)
+        run: |
+          gh api graphql -f query='
+            mutation (
+              $project: ID!
+              $item: ID!
+              $status_field: ID!
+              $status_value: String!
+            ) {
+              set_status: updateProjectV2ItemFieldValue(input: {
+                projectId: $project
+                itemId: $item
+                fieldId: $status_field
+                value: { 
+                  singleSelectOptionId: $status_value
+                  }
+              }) {
+                projectV2Item {
+                  id
+                  }
+              }
+            }' -f project=$PROJECT_ID -f item=$ITEM_ID -f status_field=$STATUS_FIELD_ID -f status_value=${{ env.OPTION_ID }} --silent


### PR DESCRIPTION
Tested in https://github.com/grafana/github-actions-testrepo/blob/main/.github/workflows/issue-add-to-parent-project.yml

**What is this feature?**

Creating a new Github workflow to add & update issue items between child project onto parent project.

**Why do we need this feature?**

This allows us to keep epic status up to date on parent project Platform UX based on each individual squad project. This is currently an experiment and can be later extended to cover multiple parent projects if successful.

**Who is this feature for?**

Platform UX team members

**Special notes for your reviewer**:
If you want to see it in action, have a look at https://github.com/grafana/github-actions-testrepo/actions/workflows/issue-add-to-parent-project.yml

