### PR TITLE
Alerting: Track events for rule creation/abortion

### DIFF
--- a/public/app/features/alerting/unified/Analytics.ts
+++ b/public/app/features/alerting/unified/Analytics.ts
@@ -48,6 +48,10 @@ export const trackNewAlerRuleFormCancelled = (props: AlertRuleTrackingProps) => 
   reportInteraction('grafana_alerting_rule_aborted', props);
 };
 
+export const trackNewAlerRuleFormError = (props: AlertRuleTrackingProps & { error: string }) => {
+  reportInteraction('grafana_alerting_rule_form_error', props);
+};
+
 export type AlertRuleTrackingProps = {
   grafana_version?: string;
   org_id?: number;

--- a/public/app/features/alerting/unified/Analytics.ts
+++ b/public/app/features/alerting/unified/Analytics.ts
@@ -40,15 +40,16 @@ export function withPerformanceLogging<TFunc extends (...args: any[]) => Promise
   };
 }
 
-export const trackAlertRuleCreation = (props: AlertRuleTrackingProps) => {
+export const trackNewAlerRuleFormSaved = (props: AlertRuleTrackingProps) => {
   reportInteraction('grafana_alerting_rule_creation', props);
 };
 
-export const trackAlertRuleAborted = (props: AlertRuleTrackingProps) => {
+export const trackNewAlerRuleFormCancelled = (props: AlertRuleTrackingProps) => {
   reportInteraction('grafana_alerting_rule_aborted', props);
 };
 
 export type AlertRuleTrackingProps = {
   grafana_version?: string;
   org_id?: number;
+  user_id?: number;
 };

--- a/public/app/features/alerting/unified/Analytics.ts
+++ b/public/app/features/alerting/unified/Analytics.ts
@@ -1,5 +1,5 @@
 import { faro, LogLevel as GrafanaLogLevel } from '@grafana/faro-web-sdk';
-import { config } from '@grafana/runtime/src';
+import { config, reportInteraction } from '@grafana/runtime/src';
 
 export const LogMessages = {
   filterByLabel: 'filtering alert instances by label',
@@ -39,3 +39,16 @@ export function withPerformanceLogging<TFunc extends (...args: any[]) => Promise
     return response;
   };
 }
+
+export const trackAlertRuleCreation = (props: AlertRuleTrackingProps) => {
+  reportInteraction('grafana_alerting_rule_creation', props);
+};
+
+export const trackAlertRuleAborted = (props: AlertRuleTrackingProps) => {
+  reportInteraction('grafana_alerting_rule_aborted', props);
+};
+
+export type AlertRuleTrackingProps = {
+  grafana_version?: string;
+  org_id?: number;
+};

--- a/public/app/features/alerting/unified/components/rule-editor/AlertRuleForm.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AlertRuleForm.tsx
@@ -13,7 +13,7 @@ import { useQueryParams } from 'app/core/hooks/useQueryParams';
 import { useDispatch } from 'app/types';
 import { RuleWithLocation } from 'app/types/unified-alerting';
 
-import { LogMessages, trackAlertRuleAborted } from '../../Analytics';
+import { LogMessages, trackNewAlerRuleFormCancelled } from '../../Analytics';
 import { useUnifiedAlertingSelector } from '../../hooks/useUnifiedAlertingSelector';
 import { deleteRuleAction, saveRuleFormAction } from '../../state/actions';
 import { RuleFormType, RuleFormValues } from '../../types/rule-form';
@@ -164,7 +164,13 @@ export const AlertRuleForm: FC<Props> = ({ existing, prefill }) => {
 
   const cancelRuleCreation = () => {
     logInfo(LogMessages.cancelSavingAlertRule);
-    trackAlertRuleAborted({ grafana_version: config.buildInfo.version, org_id: contextSrv.user.orgId });
+    if (!existing) {
+      trackNewAlerRuleFormCancelled({
+        grafana_version: config.buildInfo.version,
+        org_id: contextSrv.user.orgId,
+        user_id: contextSrv.user.id,
+      });
+    }
   };
 
   return (

--- a/public/app/features/alerting/unified/components/rule-editor/AlertRuleForm.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AlertRuleForm.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import React, { FC, useMemo, useState } from 'react';
-import { FormProvider, useForm, useFormContext, UseFormWatch } from 'react-hook-form';
+import { DeepMap, FieldError, FormProvider, useForm, useFormContext, UseFormWatch } from 'react-hook-form';
 import { Link } from 'react-router-dom';
 
 import { GrafanaTheme2 } from '@grafana/data';
@@ -13,7 +13,7 @@ import { useQueryParams } from 'app/core/hooks/useQueryParams';
 import { useDispatch } from 'app/types';
 import { RuleWithLocation } from 'app/types/unified-alerting';
 
-import { LogMessages, trackNewAlerRuleFormCancelled } from '../../Analytics';
+import { LogMessages, trackNewAlerRuleFormCancelled, trackNewAlerRuleFormError } from '../../Analytics';
 import { useUnifiedAlertingSelector } from '../../hooks/useUnifiedAlertingSelector';
 import { deleteRuleAction, saveRuleFormAction } from '../../state/actions';
 import { RuleFormType, RuleFormValues } from '../../types/rule-form';
@@ -158,7 +158,13 @@ export const AlertRuleForm: FC<Props> = ({ existing, prefill }) => {
     }
   };
 
-  const onInvalid = () => {
+  const onInvalid = (errors: DeepMap<RuleFormValues, FieldError>): void => {
+    trackNewAlerRuleFormError({
+      grafana_version: config.buildInfo.version,
+      org_id: contextSrv.user.orgId,
+      user_id: contextSrv.user.id,
+      error: Object.keys(errors).toString(),
+    });
     notifyApp.error('There are errors in the form. Please correct them and try again!');
   };
 

--- a/public/app/features/alerting/unified/components/rule-editor/AlertRuleForm.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AlertRuleForm.tsx
@@ -4,15 +4,16 @@ import { FormProvider, useForm, useFormContext, UseFormWatch } from 'react-hook-
 import { Link } from 'react-router-dom';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { logInfo } from '@grafana/runtime';
+import { logInfo, config } from '@grafana/runtime';
 import { Button, ConfirmModal, CustomScrollbar, Spinner, useStyles2, HorizontalGroup, Field, Input } from '@grafana/ui';
 import { useAppNotification } from 'app/core/copy/appNotification';
+import { contextSrv } from 'app/core/core';
 import { useCleanup } from 'app/core/hooks/useCleanup';
 import { useQueryParams } from 'app/core/hooks/useQueryParams';
 import { useDispatch } from 'app/types';
 import { RuleWithLocation } from 'app/types/unified-alerting';
 
-import { LogMessages } from '../../Analytics';
+import { LogMessages, trackAlertRuleAborted } from '../../Analytics';
 import { useUnifiedAlertingSelector } from '../../hooks/useUnifiedAlertingSelector';
 import { deleteRuleAction, saveRuleFormAction } from '../../state/actions';
 import { RuleFormType, RuleFormValues } from '../../types/rule-form';
@@ -161,6 +162,11 @@ export const AlertRuleForm: FC<Props> = ({ existing, prefill }) => {
     notifyApp.error('There are errors in the form. Please correct them and try again!');
   };
 
+  const cancelRuleCreation = () => {
+    logInfo(LogMessages.cancelSavingAlertRule);
+    trackAlertRuleAborted({ grafana_version: config.buildInfo.version, org_id: contextSrv.user.orgId });
+  };
+
   return (
     <FormProvider {...formAPI}>
       <form onSubmit={(e) => e.preventDefault()} className={styles.form}>
@@ -171,7 +177,7 @@ export const AlertRuleForm: FC<Props> = ({ existing, prefill }) => {
               disabled={submitState.loading}
               type="button"
               fill="outline"
-              onClick={() => logInfo(LogMessages.cancelSavingAlertRule)}
+              onClick={cancelRuleCreation}
             >
               Cancel
             </Button>

--- a/public/app/features/alerting/unified/components/rule-editor/AlertRuleForm.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AlertRuleForm.tsx
@@ -159,12 +159,14 @@ export const AlertRuleForm: FC<Props> = ({ existing, prefill }) => {
   };
 
   const onInvalid = (errors: DeepMap<RuleFormValues, FieldError>): void => {
-    trackNewAlerRuleFormError({
-      grafana_version: config.buildInfo.version,
-      org_id: contextSrv.user.orgId,
-      user_id: contextSrv.user.id,
-      error: Object.keys(errors).toString(),
-    });
+    if (!existing) {
+      trackNewAlerRuleFormError({
+        grafana_version: config.buildInfo.version,
+        org_id: contextSrv.user.orgId,
+        user_id: contextSrv.user.id,
+        error: Object.keys(errors).toString(),
+      });
+    }
     notifyApp.error('There are errors in the form. Please correct them and try again!');
   };
 

--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -33,7 +33,7 @@ import {
 
 import { contextSrv } from '../../../../core/core';
 import { backendSrv } from '../../../../core/services/backend_srv';
-import { logInfo, LogMessages, withPerformanceLogging, trackAlertRuleCreation } from '../Analytics';
+import { logInfo, LogMessages, withPerformanceLogging, trackNewAlerRuleFormSaved } from '../Analytics';
 import {
   addAlertManagers,
   createOrUpdateSilence,
@@ -485,7 +485,14 @@ export const saveRuleFormAction = createAsyncThunk(
           }
 
           logInfo(LogMessages.successSavingAlertRule);
-          trackAlertRuleCreation({ grafana_version: config.buildInfo.version, org_id: contextSrv.user.orgId });
+
+          if (!existing) {
+            trackNewAlerRuleFormSaved({
+              grafana_version: config.buildInfo.version,
+              org_id: contextSrv.user.orgId,
+              user_id: contextSrv.user.id,
+            });
+          }
 
           if (redirectOnSave) {
             locationService.push(redirectOnSave);

--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -1,7 +1,7 @@
 import { createAsyncThunk, AsyncThunk } from '@reduxjs/toolkit';
 import { isEmpty } from 'lodash';
 
-import { locationService } from '@grafana/runtime';
+import { locationService, config } from '@grafana/runtime';
 import {
   AlertmanagerAlert,
   AlertManagerCortexConfig,
@@ -31,8 +31,9 @@ import {
   RulerRulesConfigDTO,
 } from 'app/types/unified-alerting-dto';
 
+import { contextSrv } from '../../../../core/core';
 import { backendSrv } from '../../../../core/services/backend_srv';
-import { logInfo, LogMessages, withPerformanceLogging } from '../Analytics';
+import { logInfo, LogMessages, withPerformanceLogging, trackAlertRuleCreation } from '../Analytics';
 import {
   addAlertManagers,
   createOrUpdateSilence,
@@ -484,6 +485,7 @@ export const saveRuleFormAction = createAsyncThunk(
           }
 
           logInfo(LogMessages.successSavingAlertRule);
+          trackAlertRuleCreation({ grafana_version: config.buildInfo.version, org_id: contextSrv.user.orgId });
 
           if (redirectOnSave) {
             locationService.push(redirectOnSave);


### PR DESCRIPTION
Adds instrumentation for the events of **creating an alert rule**, **aborting its creation** and also when the **form validation fails** due to errors. These events are sent to Rudderstack using the `EchoSrv` service in cloud installations in order to be consumed from Intercom as triggers to display a user survey. 

Part of  https://github.com/grafana/alerting-squad/issues/358

