### PR TITLE
Chore: Fix not connecting to CloudSQL Postgres

### DIFF
--- a/pkg/services/sqlstore/sqlstore_test.go
+++ b/pkg/services/sqlstore/sqlstore_test.go
@@ -5,8 +5,9 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/grafana/grafana/pkg/setting"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 type sqlStoreTest struct {
@@ -66,6 +67,20 @@ var sqlStoreTestCases = []sqlStoreTest{
 		dbType:        "postgres",
 		dbHost:        "[::1]",
 		connStrValues: []string{"host=::1", "port=5432"},
+	},
+	{
+		name:          "Postgres Unix socket for CloudSQL",
+		dbType:        "postgres",
+		dbHost:        "/cloudsql/development-mycompany:northamerica-northeast2:company-db",
+		connStrValues: []string{"host=/cloudsql/development-mycompany:northamerica-northeast2:company-db", "port=5432"},
+	},
+	{
+		name:   "Postgres Unix socket for CloudSQL (URL)",
+		dbType: "postgres",
+		dbURL: "postgres:///grafana?host=/cloudsql/development-mycompany:northamerica-northeast2:company-db&" +
+			"user=grafana@development-mycompany.iam&password=apassword&port=5432",
+		connStrValues: []string{"host=/cloudsql/development-mycompany:northamerica-northeast2:company-db", "port=5432",
+			"user=grafana@development-mycompany.iam", "password=apassword"},
 	},
 	{
 		name:  "Invalid database URL",

--- a/pkg/util/ip_address.go
+++ b/pkg/util/ip_address.go
@@ -21,6 +21,12 @@ func SplitHostPortDefault(input, defaultHost, defaultPort string) (NetworkAddres
 		return addr, nil
 	}
 
+	// Determine if it's a file path for unix sockets
+	if strings.HasPrefix(input, "/") {
+		addr.Host = input
+		return addr, nil
+	}
+
 	start := 0
 	// Determine if IPv6 address, in which case IP address will be enclosed in square brackets
 	if strings.Index(input, "[") == 0 {

--- a/pkg/util/ip_address_test.go
+++ b/pkg/util/ip_address_test.go
@@ -23,6 +23,7 @@ func TestSplitHostPortDefault_Valid(t *testing.T) {
 		{input: "xyz.rds.amazonaws.com", defaultHost: "", defaultPort: "123", host: "xyz.rds.amazonaws.com", port: "123"},
 		{input: "xyz.rds.amazonaws.com:123", defaultHost: "", defaultPort: "", host: "xyz.rds.amazonaws.com", port: "123"},
 		{input: "", defaultHost: "localhost", defaultPort: "1433", host: "localhost", port: "1433"},
+		{input: "/cloudsql/development-flahmingo:northamerica-northeast1:flahmingo-dev-14", defaultHost: "127.0.0.1", defaultPort: "5432", host: "/cloudsql/development-flahmingo:northamerica-northeast1:flahmingo-dev-14", port: "5432"},
 	}
 
 	for _, testcase := range tests {


### PR DESCRIPTION
**What is this feature?**

Checks if the host string starts with a `/`. This way it knows it's a file path and does nothing to it.

**Why do we need this feature?**

GCP CloudRun  and cloud_sql_proxy use unix sockets, and with the following path `/cloudsql/development-mycompany:northamerica-northeast2:company-db`.

The current implementation returns `127.0.0.1:5432` (the default value).

**Who is this feature for?**

Those that use Google CloudSQL.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/58690

**Special notes for your reviewer**:

