### PR TITLE
Prometheus: Add traceID field on top of the exemplar popover

### DIFF
--- a/public/app/plugins/panel/timeseries/plugins/ExemplarMarker.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/ExemplarMarker.tsx
@@ -70,6 +70,10 @@ export const ExemplarMarker: React.FC<ExemplarMarkerProps> = ({
   }, [setIsOpen]);
 
   const renderMarker = useCallback(() => {
+    // Put the traceID field in front.
+    const traceIDField = dataFrame.fields.find((field) => field.name === 'traceID') || dataFrame.fields[0];
+    const orderedDataFrameFields = [traceIDField, ...dataFrame.fields.filter((field) => traceIDField !== field)];
+
     const timeFormatter = (value: number) => {
       return dateTimeFormat(value, {
         format: systemDateFormats.fullDate,
@@ -94,7 +98,7 @@ export const ExemplarMarker: React.FC<ExemplarMarkerProps> = ({
             <div>
               <table className={styles.exemplarsTable}>
                 <tbody>
-                  {dataFrame.fields.map((field, i) => {
+                  {orderedDataFrameFields.map((field, i) => {
                     const value = field.values.get(dataFrameFieldIndex.fieldIndex);
                     const links = field.config.links?.length
                       ? getFieldLinks(field, dataFrameFieldIndex.fieldIndex)


### PR DESCRIPTION
**What is this feature?**

On the Exemplar popover, place the traceID field first

**Why do we need this feature?**

To prioritize the link that let user go from Exemplar to Tempo

**Who is this feature for?**

Any Prometheus user that use Exemplar

**Which issue(s) does this PR fix?**:

Closes #59837 


