### PR TITLE
CI: Move `verify-storybook` command from grabpl

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -575,7 +575,7 @@ steps:
     - failure
 - commands:
   - yarn storybook:build
-  - ./bin/grabpl verify-storybook
+  - ./bin/build verify-storybook
   depends_on:
   - build-frontend
   - build-frontend-packages
@@ -1430,7 +1430,7 @@ steps:
     - failure
 - commands:
   - yarn storybook:build
-  - ./bin/grabpl verify-storybook
+  - ./bin/build verify-storybook
   depends_on:
   - build-frontend
   - build-frontend-packages
@@ -2155,7 +2155,7 @@ steps:
     - failure
 - commands:
   - yarn storybook:build
-  - ./bin/grabpl verify-storybook
+  - ./bin/build verify-storybook
   depends_on:
   - build-frontend
   - build-frontend-packages
@@ -4699,7 +4699,7 @@ steps:
     - failure
 - commands:
   - yarn storybook:build
-  - ./bin/grabpl verify-storybook
+  - ./bin/build verify-storybook
   depends_on:
   - build-frontend
   - build-frontend-packages
@@ -6318,6 +6318,6 @@ kind: secret
 name: packages_secret_access_key
 ---
 kind: signature
-hmac: efffc2eb55bbfa1cebe950585df1f3f81d2f2a38311e2854f3ce08d1eec16fe3
+hmac: dcf24226fae30872050cdc031430374d811e6bbe13158ce0fbf234c90c1d83f9
 
 ...

--- a/pkg/build/cmd/main.go
+++ b/pkg/build/cmd/main.go
@@ -152,7 +152,7 @@ func main() {
 		},
 		{
 			Name:   "store-storybook",
-			Usage:  "Integrity check for storybook build",
+			Usage:  "Stores storybook to GCS buckets",
 			Action: StoreStorybook,
 			Flags: []cli.Flag{
 				&cli.StringFlag{
@@ -160,6 +160,11 @@ func main() {
 					Usage: "Kind of deployment (e.g. canary/latest)",
 				},
 			},
+		},
+		{
+			Name:   "verify-storybook",
+			Usage:  "Integrity check for storybook build",
+			Action: VerifyStorybook,
 		},
 		{
 			Name:   "upload-packages",

--- a/pkg/build/cmd/verifystorybook.go
+++ b/pkg/build/cmd/verifystorybook.go
@@ -1,0 +1,32 @@
+// Package verifystorybook contains the sub-command "verify-storybook".
+package main
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/grafana/grafana/pkg/infra/fs"
+	"github.com/rs/zerolog/log"
+	"github.com/urfave/cli/v2"
+)
+
+// VerifyStorybook Action implements the sub-command "verify-storybook".
+func VerifyStorybook(c *cli.Context) error {
+	const grafanaDir = "."
+
+	paths := []string{
+		"packages/grafana-ui/dist/storybook/index.html",
+		"packages/grafana-ui/dist/storybook/iframe.html"}
+	for _, p := range paths {
+		exists, err := fs.Exists(filepath.Join(grafanaDir, p))
+		if err != nil {
+			return cli.NewExitError(fmt.Sprintf("failed to verify Storybook build: %s", err), 1)
+		}
+		if !exists {
+			return fmt.Errorf("failed to verify Storybook build, missing %q", p)
+		}
+	}
+
+	log.Printf("Successfully verified Storybook integrity")
+	return nil
+}

--- a/pkg/build/cmd/verifystorybook.go
+++ b/pkg/build/cmd/verifystorybook.go
@@ -3,10 +3,10 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"path/filepath"
 
 	"github.com/grafana/grafana/pkg/infra/fs"
-	"github.com/rs/zerolog/log"
 	"github.com/urfave/cli/v2"
 )
 

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -246,7 +246,7 @@ def build_storybook_step(ver_mode):
         },
         'commands': [
             'yarn storybook:build',
-            './bin/grabpl verify-storybook',
+            './bin/build verify-storybook',
         ],
         'when': get_trigger_storybook(ver_mode),
     }


### PR DESCRIPTION
**What is this feature?**

Moves `verify-storybook` command from grabpl.

Part of: https://github.com/grafana/grafana-release-engineering/issues/3