### PR TITLE
UsageInsights: Record events for Explore queries

### DIFF
--- a/docs/sources/setup-grafana/configure-security/export-logs.md
+++ b/docs/sources/setup-grafana/configure-security/export-logs.md
@@ -44,6 +44,7 @@ Logs of usage insights contain the following fields, where the fields followed b
 | `panelName` | string | Name of the panel of the query. |
 | `error` | string | Error returned by the query. |
 | `duration` | number | Duration of the query. |
+| `source` | string | Source of the query. For example, `dashboard` or `explore`. |
 | `orgId`\* | number | ID of the user’s organization. |
 | `orgName`\* | string | Name of the user’s organization. |
 | `timestamp`\* | string | The date and time that the request was made, in Coordinated Universal Time (UTC) in [RFC3339](https://tools.ietf.org/html/rfc3339#section-5.6) format. |

--- a/packages/grafana-runtime/src/analytics/types.ts
+++ b/packages/grafana-runtime/src/analytics/types.ts
@@ -1,3 +1,5 @@
+import { CoreApp } from '@grafana/data';
+
 import { EchoEvent, EchoEventType } from '../services/EchoSrv';
 
 /**
@@ -20,6 +22,7 @@ export interface DashboardInfo {
  * @public
  */
 export interface DataRequestInfo extends Partial<DashboardInfo> {
+  source: CoreApp | string;
   datasourceName: string;
   datasourceId: number;
   datasourceUid: string;

--- a/packages/grafana-runtime/src/analytics/types.ts
+++ b/packages/grafana-runtime/src/analytics/types.ts
@@ -22,7 +22,7 @@ export interface DashboardInfo {
  * @public
  */
 export interface DataRequestInfo extends Partial<DashboardInfo> {
-  source: CoreApp | string;
+  source?: CoreApp | string;
   datasourceName: string;
   datasourceId: number;
   datasourceUid: string;

--- a/public/app/features/query/state/queryAnalytics.test.ts
+++ b/public/app/features/query/state/queryAnalytics.test.ts
@@ -217,6 +217,8 @@ describe('emitDataRequestEvent - from a dashboard panel', () => {
   });
 });
 
+// Previously we filtered out Explore events due to too many errors being generated while a user is building a query
+// This tests that we send an event for Explore queries but do not record errors
 describe('emitDataRequestEvent - from Explore', () => {
   it('Should report meta analytics', () => {
     const data = getTestDataForExplore(CoreApp.Explore);

--- a/public/app/features/query/state/queryAnalytics.ts
+++ b/public/app/features/query/state/queryAnalytics.ts
@@ -8,7 +8,7 @@ export function emitDataRequestEvent(datasource: DataSourceApi) {
   let done = false;
 
   return (data: PanelData) => {
-    if (!data.request || done || data.request.app === CoreApp.Explore) {
+    if (!data.request || done) {
       return;
     }
 
@@ -21,6 +21,41 @@ export function emitDataRequestEvent(datasource: DataSourceApi) {
       return;
     }
 
+    const eventData: DataRequestEventPayload = {
+      eventName: MetaAnalyticsEventName.DataRequest,
+      source: data.request.app,
+      datasourceName: datasource.name,
+      datasourceId: datasource.id,
+      datasourceUid: datasource.uid,
+      datasourceType: datasource.type,
+      dataSize: 0,
+      duration: data.request.endTime! - data.request.startTime,
+    };
+
+    if (data.request.app === CoreApp.Explore) {
+      enrichWithExploreInfo(eventData, data);
+    } else {
+      enrichWithDashboardInfo(eventData, data);
+    }
+
+    if (data.series && data.series.length > 0) {
+      // estimate size
+      eventData.dataSize = data.series.length;
+    }
+
+    reportMetaAnalytics(eventData);
+
+    // this done check is to make sure we do not double emit events in case
+    // there are multiple responses with done state
+    done = true;
+  };
+
+  function enrichWithExploreInfo(eventData: DataRequestEventPayload, data: PanelData) {
+    const totalQueries = Object.keys(data.series).length;
+    eventData.totalQueries = totalQueries;
+  }
+
+  function enrichWithDashboardInfo(eventData: DataRequestEventPayload, data: PanelData) {
     const queryCacheStatus: { [key: string]: boolean } = {};
     for (let i = 0; i < data.series.length; i++) {
       const refId = data.series[i].refId;
@@ -31,21 +66,11 @@ export function emitDataRequestEvent(datasource: DataSourceApi) {
     const totalQueries = Object.keys(queryCacheStatus).length;
     const cachedQueries = Object.values(queryCacheStatus).filter((val) => val === true).length;
 
-    const eventData: DataRequestEventPayload = {
-      eventName: MetaAnalyticsEventName.DataRequest,
-      datasourceName: datasource.name,
-      datasourceId: datasource.id,
-      datasourceUid: datasource.uid,
-      datasourceType: datasource.type,
-      panelId: data.request.panelId,
-      dashboardId: data.request.dashboardId,
-      dataSize: 0,
-      duration: data.request.endTime! - data.request.startTime,
-      totalQueries,
-      cachedQueries,
-    };
+    eventData.panelId = data.request!.panelId;
+    eventData.dashboardId = data.request!.dashboardId;
+    eventData.totalQueries = totalQueries;
+    eventData.cachedQueries = cachedQueries;
 
-    // enrich with dashboard info
     const dashboard = getDashboardSrv().getCurrent();
     if (dashboard) {
       eventData.dashboardId = dashboard.id;
@@ -58,19 +83,8 @@ export function emitDataRequestEvent(datasource: DataSourceApi) {
       }
     }
 
-    if (data.series && data.series.length > 0) {
-      // estimate size
-      eventData.dataSize = data.series.length;
-    }
-
     if (data.error) {
       eventData.error = data.error.message;
     }
-
-    reportMetaAnalytics(eventData);
-
-    // this done check is to make sure we do not double emit events in case
-    // there are multiple responses with done state
-    done = true;
-  };
+  }
 }


### PR DESCRIPTION
**What is this feature?**

Records an event in Usage Insights for Explore queries.

**Why do we need this feature?**

We have admins who would like more insights on all queries that are executed for a data source. Sometimes their users write ad hoc queries from Explore that can have performance issues.

**Who is this feature for?**

Users of the Usage Insights feature in Grafana Enterprise.

**Which issue(s) does this PR fix?**:

Contributes to https://github.com/grafana/grafana-enterprise/issues/4206

**Special notes for your reviewer**:

Complement to [Enterprise-#4209](https://github.com/grafana/grafana-enterprise/pull/4209)

- If an Explore query has an error, then that error is ignored but an event is still recorded. Should Grafana instead not send an event at all to Usage Insights if the Explore query returned an error?
- Adds a new `source` field that contains either `explore` or `dashboard` as a value. This could be used in the Usage Insights dashboards - [dashboard that is linked to in the docs](https://grafana.com/grafana/dashboards/13786-grafana-usage-insights-datasource-details/) and [dashboard that is used on Grafana Cloud](https://grafana.com/grafana/dashboards/15088-usage-insights-2-data-sources/).