### PR TITLE
Chore: Add api test utility and library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -244,6 +244,7 @@ require (
 	github.com/Azure/azure-storage-blob-go v0.15.0
 	github.com/Azure/go-autorest/autorest/adal v0.9.20
 	github.com/armon/go-radix v1.0.0
+	github.com/bhmj/jsonslice v1.1.2
 	github.com/blugelabs/bluge v0.1.9
 	github.com/blugelabs/bluge_segment_api v0.2.0
 	github.com/bufbuild/connect-go v1.0.0
@@ -273,6 +274,7 @@ require (
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.1.1 // indirect
 	github.com/armon/go-metrics v0.3.10 // indirect
+	github.com/bhmj/xpression v0.9.1 // indirect
 	github.com/bmatcuk/doublestar v1.1.1 // indirect
 	github.com/buildkite/yaml v2.1.0+incompatible // indirect
 	github.com/containerd/containerd v1.6.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -439,6 +439,10 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
+github.com/bhmj/jsonslice v1.1.2 h1:Lzen2S9iG3HsESpiIAnTM7Obs1QiTz83ZXa5YrpTTWI=
+github.com/bhmj/jsonslice v1.1.2/go.mod h1:O3ZoA0zdEefdbk1dkU5aWPOA36zQhhS/HV6RQFLTlnU=
+github.com/bhmj/xpression v0.9.1 h1:N7bX/nWx9oFi/zsiMTx2ehoRApTDAWdQadq/5o2wMGk=
+github.com/bhmj/xpression v0.9.1/go.mod h1:j9oYmEXJjeL9mrgW1+ZDBKJXnbupsCPGhlO9J5YhS1Q=
 github.com/bitly/go-hostpool v0.0.0-20171023180738-a3a6125de932/go.mod h1:NOuUCSz6Q9T7+igc/hlvDOUdtWKryOrtFyIVABv/p7k=
 github.com/bitly/go-simplejson v0.5.0/go.mod h1:cXHtHw4XUPsvGaxgjIAn8PhEWG9NfngEKAMDJEczWVA=
 github.com/bits-and-blooms/bitset v1.2.0 h1:Kn4yilvwNtMACtf1eYDlG8H77R07mZSPbMjLyS07ChA=

--- a/pkg/tests/api/apitest/apitest.go
+++ b/pkg/tests/api/apitest/apitest.go
@@ -1,0 +1,254 @@
+package apitest
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"reflect"
+	"regexp"
+	"testing"
+	"text/template"
+
+	"github.com/bhmj/jsonslice"
+	"gopkg.in/yaml.v3"
+)
+
+// Workflow is an API test scenario that contains a sequence of test steps and
+// a shared environment and, optionally, auth information.
+type Workflow struct {
+	Env      map[string]string `json:"env",yaml:"env"`
+	Auth     Auth              `json:"auth",yaml:"auth"`
+	RawSteps []json.RawMessage `json:"steps",yaml:"steps"`
+
+	steps []Step
+}
+
+// Auth defines credentials for API tests, such as HTTP Basic Auth or Bearer.
+type Auth struct {
+	Username string `json:"username",yaml:"username"`
+	Password string `json:"password",yaml:"password"`
+	Bearer   string `json:"bearer",yaml:"bearer"`
+}
+
+func New(body string) (w *Workflow, err error) {
+	var x any
+	b := []byte(body)
+	err = yaml.Unmarshal(b, &x)
+	if err == nil {
+		b, _ = json.Marshal(x)
+	}
+	err = json.Unmarshal(b, &w)
+	w.steps = make([]Step, len(w.RawSteps))
+	for i, b := range w.RawSteps {
+		if err := json.Unmarshal(b, &w.steps[i]); err != nil {
+			return nil, err
+		}
+		w.steps[i].raw = b
+	}
+	return w, err
+}
+
+func NewWorkflow(filename string) (w *Workflow, err error) {
+	b, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	return New(string(b))
+}
+
+func TestAPI(t *testing.T, body string) {
+	t.Helper()
+	w, err := New(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Run(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func (w *Workflow) Run() error {
+	caps := map[string]any{}
+	for _, step := range w.steps {
+		step.Compile(w.Env, caps)
+		req, err := step.Request(w.Auth)
+		if err != nil {
+			log.Fatal(err)
+		}
+		res, err := http.DefaultClient.Do(req)
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Println("\n### " + step.Name)
+		c, err := step.Checks.Check(res)
+		if err != nil {
+			log.Fatal(err)
+		}
+		for k, v := range c {
+			caps[k] = v
+		}
+	}
+	return nil
+}
+
+type Step struct {
+	Name    string            `json:"name"`
+	URL     string            `json:"url"`
+	Method  string            `json:"method"`
+	Auth    Auth              `json:"auth"`
+	Body    any               `json:"body"`
+	Headers map[string]string `json:"headers"`
+	Checks  Checks            `json:"checks"`
+
+	raw []byte
+}
+
+func (s *Step) Compile(env map[string]string, captures map[string]any) error {
+	b := &bytes.Buffer{}
+	t, err := template.New(s.Name).Parse(string(s.raw))
+	if err != nil {
+		return err
+	}
+	vars := map[string]any{}
+	for k, v := range env {
+		vars[k] = v
+	}
+	for k, v := range captures {
+		vars[k] = v
+	}
+	if err := t.Execute(b, vars); err != nil {
+		return err
+	}
+	return json.Unmarshal(b.Bytes(), s)
+}
+
+type Checks struct {
+	Schema  string             `json:"schema"`
+	Status  int                `json:"status"`
+	Body    map[string]Matcher `json:"body"`
+	Capture map[string]string  `json:"captures"`
+}
+
+type Matcher struct {
+	Equals    any
+	NotEquals any
+	RegExp    *regexp.Regexp
+}
+
+func (m *Matcher) UnmarshalJSON(b []byte) error {
+	var v any
+	err := json.Unmarshal(b, &v)
+	if err != nil {
+		return err
+	}
+	if obj, ok := v.(map[string]any); ok {
+		m.Equals = obj["eq"]
+		m.NotEquals = obj["neq"]
+		if re, ok := obj["regexp"]; ok {
+			if s, ok := re.(string); !ok {
+				return errors.New("regexp must be a string")
+				m.RegExp = nil // TODO
+			} else if m.RegExp, err = regexp.Compile(s); err != nil {
+				return err
+			}
+		}
+	} else {
+		m.Equals = v
+	}
+	return nil
+}
+
+func (m *Matcher) Match(v any) error {
+	if m.Equals != nil && !reflect.DeepEqual(v, m.Equals) {
+		return fmt.Errorf("expected %#v, but got %#v", m.Equals, v)
+	}
+	if m.NotEquals != nil && reflect.DeepEqual(v, m.NotEquals) {
+		return fmt.Errorf("expected not to be %#v", m.NotEquals)
+	}
+	if s, ok := v.(string); ok && m.RegExp != nil && !m.RegExp.MatchString(s) {
+		return fmt.Errorf("expected not match %#v but got %s", m.RegExp, s)
+	}
+	return nil
+}
+
+func (c *Checks) Check(res *http.Response) (map[string]any, error) {
+	caps := map[string]any{}
+	if c.Status != 0 && res.StatusCode != c.Status {
+		return nil, fmt.Errorf("expected status %d, got %d", c.Status, res.StatusCode)
+	}
+	if res.Body == nil {
+		if c.Body != nil {
+			return nil, fmt.Errorf("expected body")
+		}
+		return nil, nil
+	}
+	defer res.Body.Close()
+	b, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+	fmt.Println(">", string(b))
+	for path, expect := range c.Body {
+		b, err := jsonslice.Get(b, path)
+		if err != nil {
+			return nil, err
+		}
+		var v any
+		if err := json.Unmarshal(b, &v); err != nil {
+			return nil, err
+		}
+		if err := expect.Match(v); err != nil {
+			return nil, err
+		}
+	}
+
+	for name, path := range c.Capture {
+		b, err := jsonslice.Get(b, path)
+		if err != nil {
+			return nil, err
+		}
+		var v any
+		if err := json.Unmarshal(b, &v); err != nil {
+			return nil, err
+		}
+		caps[name] = v
+	}
+
+	return caps, nil
+}
+
+func (step *Step) Request(globalAuth Auth) (*http.Request, error) {
+	body := &bytes.Buffer{}
+	if step.Body != nil {
+		if err := json.NewEncoder(body).Encode(step.Body); err != nil {
+			return nil, err
+		}
+	}
+	req, err := http.NewRequest(step.Method, step.URL, body)
+	if err != nil {
+		return nil, err
+	}
+
+	if step.Body != nil {
+		req.Header.Set("Content-type", "application/json")
+	}
+	for k, v := range step.Headers {
+		req.Header.Set(k, v)
+	}
+
+	auth := step.Auth
+	if auth.Username == "" && auth.Password == "" && auth.Bearer == "" {
+		auth = globalAuth
+	}
+	if auth.Username != "" || auth.Password != "" {
+		req.SetBasicAuth(auth.Username, auth.Password)
+	} else if auth.Bearer != "" {
+		req.Header.Add("Bearer", auth.Bearer)
+	}
+	return req, nil
+}

--- a/pkg/tests/api/apitest/cmd/apitest/cmd.go
+++ b/pkg/tests/api/apitest/cmd/apitest/cmd.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/grafana/grafana/pkg/tests/api/apitest"
+)
+
+func main() {
+	for _, arg := range os.Args[1:] {
+		w, err := apitest.NewWorkflow(arg)
+		if err != nil {
+			log.Fatal(err)
+		}
+		if err := w.Run(); err != nil {
+			log.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
DO NOT MERGE! ☠️ ☢️ 🛑 ⛔ ☣️ 🧨 

This is an experimental approach on how to test Grafana APIs using a simple declarative syntax without too much boilerplate.

Can be used with Go's testing framework or as a standalone CLI. 

Input can be provided as YAML or JSON.

Input may use Go template syntax to substitute variables (steps are parsed lazily right before they are executed, so captured variables from earlier steps can be used in the following steps).

Variables can be provided globally using "env" block or captured from the step response.

JSONPath syntax is used to define which response value to capture and which response value to verify in tests.

"Checks" by default means "equals", i.e. `status: 200` means status is expected to be equal to 200. Other matchers are available, i.e. `$.message: {regexp: "/sometext/"}` or `status: {ne: 200}` to text for regexp match or to make sure status is not equal to 200. More matchers can be added on-demand.

An example of an API test workflow may look like this:

```yaml
env:
  baseURL: http://admin:admin@localhost:3000 # this will be common for all steps
steps:
  - name: when quota limit doesn't exceed, importing a dashboard should succeed
    method: POST
    url: "{{.baseURL}}/api/dashboards/import" # this is how variable interpolation works
    body: # this is JSON body we send in request, variable interpolation may be used here as well
      dashboard:
        title: just testing
    checks:
      status: 200 # make sure status == 200
      body:
        '$.dashboardId': 1 # make sure dashboardId == 1
      captures:
        'uid': '$.dashboardUid' # capture dashboard UID, can be used as {{.uid}} later
  - name: some other test
    ....
```