### PR TITLE
CloudWatch: Return error message when getting malformed query exception in Logs

### DIFF
--- a/pkg/tsdb/cloudwatch/log_actions.go
+++ b/pkg/tsdb/cloudwatch/log_actions.go
@@ -270,7 +270,6 @@ func (e *cloudWatchExecutor) handleStartQuery(ctx context.Context, logger log.Lo
 			logger.Debug("malformed query", "err", awsErr)
 			return nil, &AWSError{Code: awsErr.Code(), Message: err.Error()}
 		}
-
 		return nil, err
 	}
 

--- a/pkg/tsdb/cloudwatch/log_actions.go
+++ b/pkg/tsdb/cloudwatch/log_actions.go
@@ -266,6 +266,11 @@ func (e *cloudWatchExecutor) handleStartQuery(ctx context.Context, logger log.Lo
 			logger.Debug("executeStartQuery limit exceeded", "err", awsErr)
 			return nil, &AWSError{Code: limitExceededException, Message: err.Error()}
 		}
+		if errors.As(err, &awsErr) && awsErr.Code() == "MalformedQueryException" {
+			logger.Debug("malformed query", "err", awsErr)
+			return nil, &AWSError{Code: awsErr.Code(), Message: err.Error()}
+		}
+
 		return nil, err
 	}
 

--- a/pkg/tsdb/cloudwatch/test_utils.go
+++ b/pkg/tsdb/cloudwatch/test_utils.go
@@ -20,6 +20,17 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
+type mockCWLogsClient struct {
+	mock.Mock
+	cloudwatchlogsiface.CloudWatchLogsAPI
+}
+
+func (m *mockCWLogsClient) StartQueryWithContext(ctx context.Context, input *cloudwatchlogs.StartQueryInput, option ...request.Option) (*cloudwatchlogs.StartQueryOutput, error) {
+	args := m.Called(ctx, input, option)
+
+	return args.Get(0).(*cloudwatchlogs.StartQueryOutput), args.Get(1).(error)
+}
+
 type fakeCWLogsClient struct {
 	cloudwatchlogsiface.CloudWatchLogsAPI
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This intercepts a `MalformedQueryException` from the CloudWatch Logs API and returns its error message. 
![Screenshot 2022-12-07 at 12 01 47](https://user-images.githubusercontent.com/4163034/206172130-fe8eb299-1006-488a-9a90-e9edc82aab9d.png)
![Screenshot 2022-12-07 at 12 02 42](https://user-images.githubusercontent.com/4163034/206172367-a9bd6897-7dd2-4498-8b7e-1c3bb845b5d5.png)


**Why do we need this feature?**

An invalid query string returned with an error and a message which did not explain what went wrong: "An error has occurred in the plugin" with a 500 code.
This sends a 400 and improves the readability of that error, with supporting information in the Network tab of the browser.

**Which issue(s) does this PR fix?:**

Contributes to https://github.com/grafana/grafana/issues/59972

**Special notes for your reviewer**:
TODO: 
Some investigation to be made to pass the message to the panel instead of making the user open the Network tab.
