### PR TITLE
ServiceAccounts: Do not display warnings about secret scanner when scanner is disabled

### DIFF
--- a/pkg/services/serviceaccounts/manager/service.go
+++ b/pkg/services/serviceaccounts/manager/service.go
@@ -55,10 +55,9 @@ func ProvideServiceAccountsService(
 	serviceaccountsAPI.RegisterAPIEndpoints()
 
 	s.secretScanEnabled = cfg.SectionWithEnvOverrides("secretscan").Key("enabled").MustBool(false)
+	s.secretScanInterval = cfg.SectionWithEnvOverrides("secretscan").
+		Key("interval").MustDuration(defaultSecretScanInterval)
 	if s.secretScanEnabled {
-		s.secretScanInterval = cfg.SectionWithEnvOverrides("secretscan").
-			Key("interval").MustDuration(defaultSecretScanInterval)
-
 		s.secretScanService = secretscan.NewService(s.store, cfg)
 	}
 
@@ -76,7 +75,7 @@ func (sa *ServiceAccountsService) Run(ctx context.Context) error {
 	defer updateStatsTicker.Stop()
 
 	// Enforce a minimum interval of 1 minute.
-	if sa.secretScanInterval < time.Minute {
+	if sa.secretScanEnabled && sa.secretScanInterval < time.Minute {
 		sa.backgroundLog.Warn("secret scan interval is too low, increasing to " +
 			defaultSecretScanInterval.String())
 


### PR DESCRIPTION
**Which issue(s) does this PR fix?**:

A warning on the minimal secret scan interval was displayed even when the service is disabled, since the default value was 0.

Changes:

- Always set a default for the timer (which will be stopped if the service is disabled)
- Only emit warning if the service is enabled

Related report https://github.com/grafana/grafana/issues/53567#issuecomment-1338193288 

**Special notes for your reviewer**:

