### PR TITLE
Loki: Remove annotation, context and volume tracking

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -76,6 +76,9 @@ import { LokiVariableSupport } from './variables';
 export type RangeQueryOptions = DataQueryRequest<LokiQuery> | AnnotationQueryRequest<LokiQuery>;
 export const DEFAULT_MAX_LINES = 1000;
 export const LOKI_ENDPOINT = '/loki/api/v1';
+export const REF_ID_DATA_SAMPLES = 'loki-data-samples';
+export const REF_ID_STARTER_ANNOTATION = 'annotation-';
+export const REF_ID_STARTER_LOG_ROW_CONTEXT = 'log-row-context-query-';
 const NS_IN_MS = 1000000;
 
 function makeRequest(
@@ -556,7 +559,7 @@ export class LokiDatasource
     const app = CoreApp.Explore;
 
     return lastValueFrom(
-      this.query(makeRequest(query, range, app, `log-row-context-query-${direction}`)).pipe(
+      this.query(makeRequest(query, range, app, `${REF_ID_STARTER_LOG_ROW_CONTEXT}${direction}`)).pipe(
         catchError((err) => {
           const error: DataQueryError = {
             message: 'Error during context query. Please check JS console logs.',
@@ -597,7 +600,7 @@ export class LokiDatasource
     const query: LokiQuery = {
       expr: `{${expr}}`,
       queryType: LokiQueryType.Range,
-      refId: row.dataFrame.refId ?? '',
+      refId: `${REF_ID_STARTER_LOG_ROW_CONTEXT}${row.dataFrame.refId || ''}`,
       maxLines: limit,
       direction: queryDirection,
     };
@@ -675,7 +678,7 @@ export class LokiDatasource
       return [];
     }
 
-    const id = `annotation-${options.annotation.name}`;
+    const id = `${REF_ID_STARTER_ANNOTATION}${options.annotation.name}`;
 
     const query: LokiQuery = {
       refId: id,

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -79,6 +79,7 @@ export const LOKI_ENDPOINT = '/loki/api/v1';
 export const REF_ID_DATA_SAMPLES = 'loki-data-samples';
 export const REF_ID_STARTER_ANNOTATION = 'annotation-';
 export const REF_ID_STARTER_LOG_ROW_CONTEXT = 'log-row-context-query-';
+export const REF_ID_STARTER_LOG_VOLUME = 'log-volume-';
 const NS_IN_MS = 1000000;
 
 function makeRequest(
@@ -150,6 +151,7 @@ export class LokiDatasource
       const query = removeCommentsFromQuery(target.expr);
       return {
         ...target,
+        refId: `${REF_ID_STARTER_LOG_VOLUME}${target.refId}`,
         instant: false,
         volumeQuery: true,
         expr: `sum by (level) (count_over_time(${query}[$__interval]))`,

--- a/public/app/plugins/datasource/loki/tracking.ts
+++ b/public/app/plugins/datasource/loki/tracking.ts
@@ -4,6 +4,7 @@ import { variableRegex } from 'app/features/variables/utils';
 
 import { QueryEditorMode } from '../prometheus/querybuilder/shared/types';
 
+import { REF_ID_STARTER_ANNOTATION, REF_ID_DATA_SAMPLES, REF_ID_STARTER_LOG_ROW_CONTEXT } from './datasource';
 import pluginJson from './plugin.json';
 import { getNormalizedLokiQuery, isLogsQuery, parseToNodeNamesArray } from './queryUtils';
 import { LokiQuery, LokiQueryType } from './types';
@@ -117,8 +118,22 @@ const isQueryWithChangedLegend = (query: LokiQuery): boolean => {
   return query.legendFormat !== '';
 };
 
+const shouldNotReportBasedOnRefId = (refId: string): boolean => {
+  if (
+    refId === REF_ID_DATA_SAMPLES ||
+    refId.startsWith(REF_ID_STARTER_ANNOTATION) ||
+    refId.startsWith(REF_ID_STARTER_LOG_ROW_CONTEXT)
+  ) {
+    return true;
+  }
+  return false;
+};
+
 export function trackQuery(response: DataQueryResponse, queries: LokiQuery[], app: string): void {
   for (const query of queries) {
+    if (shouldNotReportBasedOnRefId(query.refId)) {
+      return;
+    }
     reportInteraction('grafana_loki_query_executed', {
       app,
       editor_mode: query.editorMode,

--- a/public/app/plugins/datasource/loki/tracking.ts
+++ b/public/app/plugins/datasource/loki/tracking.ts
@@ -4,7 +4,12 @@ import { variableRegex } from 'app/features/variables/utils';
 
 import { QueryEditorMode } from '../prometheus/querybuilder/shared/types';
 
-import { REF_ID_STARTER_ANNOTATION, REF_ID_DATA_SAMPLES, REF_ID_STARTER_LOG_ROW_CONTEXT } from './datasource';
+import {
+  REF_ID_STARTER_ANNOTATION,
+  REF_ID_DATA_SAMPLES,
+  REF_ID_STARTER_LOG_ROW_CONTEXT,
+  REF_ID_STARTER_LOG_VOLUME,
+} from './datasource';
 import pluginJson from './plugin.json';
 import { getNormalizedLokiQuery, isLogsQuery, parseToNodeNamesArray } from './queryUtils';
 import { LokiQuery, LokiQueryType } from './types';
@@ -119,11 +124,9 @@ const isQueryWithChangedLegend = (query: LokiQuery): boolean => {
 };
 
 const shouldNotReportBasedOnRefId = (refId: string): boolean => {
-  if (
-    refId === REF_ID_DATA_SAMPLES ||
-    refId.startsWith(REF_ID_STARTER_ANNOTATION) ||
-    refId.startsWith(REF_ID_STARTER_LOG_ROW_CONTEXT)
-  ) {
+  const starters = [REF_ID_STARTER_ANNOTATION, REF_ID_STARTER_LOG_ROW_CONTEXT, REF_ID_STARTER_LOG_VOLUME];
+
+  if (refId === REF_ID_DATA_SAMPLES || starters.some((starter) => refId.startsWith(starter))) {
     return true;
   }
   return false;


### PR DESCRIPTION
Same as https://github.com/grafana/grafana/pull/59960 but for annotation and context. I checked and these are last "non-query" queries. 