### PR TITLE
Fix branch filter for release workflows

### DIFF
--- a/.github/workflows/publish-technical-documentation-release.yml
+++ b/.github/workflows/publish-technical-documentation-release.yml
@@ -3,7 +3,7 @@ name: "publish-technical-documentation-release"
 on:
   push:
     branches:
-      - v[0-9]+.[0-9]+.[0-9]+
+      - v[0-9]+.[0-9]+.x
     tags:
       - v[0-9]+.[0-9]+.[0-9]+
     paths:


### PR DESCRIPTION
Ensures the workflow is run on every push to all version branches.

This was thought to be working because it was tested with a manual dispatch, however, that trigger does not consider filters and was not an accurate test.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
