### PR TITLE
Alerting update eval engine to return errors and no data as separate models

### DIFF
--- a/pkg/services/ngalert/api/api_testing.go
+++ b/pkg/services/ngalert/api/api_testing.go
@@ -54,11 +54,7 @@ func (srv TestingApiSrv) RouteTestGrafanaRuleConfig(c *models.ReqContext, body a
 		now = timeNow()
 	}
 
-	evalResults, err := conditionEval.Evaluate(c.Req.Context(), now)
-	if err != nil {
-		return ErrResp(500, err, "Failed to evaluate the rule")
-	}
-
+	evalResults := conditionEval.Evaluate(c.Req.Context(), now)
 	frame := evalResults.AsDataFrame()
 	return response.JSONStreaming(http.StatusOK, util.DynMap{
 		"instances": []*data.Frame{&frame},


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**Background**
Alerting engine uses Grafana expression service to evaluate queries and transform the response. The engine transforms expression service's result to a list of results that contains the original value, labels, and the state (Alerting, Normal etc)

Execution of alert rule query can finish with generally 3 types of results: 
- Normal execution.
- Error. There are two sources of the errors: 
    - expression service, which can be split to two more: query errors (network, data source etc) and transformation (when format of data produced by the previous expression node cannot be accepted by the following node)
    - results transformation. When a normal result (not error or nodata) that is returned by expression service cannot be converted to evaluation results. For example, when the data frame format does not match the expected one (1 number field with 1 row).
- NoData. Two ways of this happening:
   - This can occur when one of the datasources queried by the expression service did not return any data. Generally, that will mean that all downstream transformations will result in no-data (one exception is Classic Condition with mapping of no-data). 
   - The expression service returned a heterogeneous result that contain results with numeric value as well as results with value `null`. The null value is treated as NoData but it is specific to only the dimension (alert instance) that is identified by the set of labels, or in other words, it is complete no data.

All those results are returned to the state manager as a list of `eval.Result`, where every element is treated as a separate state in the state manager and is identified by the set of labels. In the case of error the list will contain only one element with state `Error`. In the case of "global" no-data - a single element with state NoData. *It is important to note that in both cases the set of labels is empty.*

As mentioned above, the state manager processes every result from the list of results individually. In the case of Error or NoData states, it checks alert rule specification and determines what needs to be done with that "abnormal" result. The rule specification provides 3 mapping options:
 - map to OK.
 - map to Alerting.
 - create a special alert `DatasourceNoData` or `DatasourceError`.

Reference to the documentation 
https://github.com/grafana/grafana/blob/0e4108f62f1e9a03a0097f2b8c1236582cac5cfd/docs/sources/alerting/alerting-rules/create-grafana-managed-rule.md?plain=1#L72-L86

According to the documentation, if the abnormal state is mapped to either OK or Alerting it should switch the current state to OK or Alerting (or Pending depending on For setting). However, that is not true in the general case. The problem is that the abnormal result is still treated by the state manager as an individual dimension (aka state, aka instance). As I mentioned before, the abnormal result usually does not have any labels or due to its abnormality, the set of labels can be different than the current states. This causes the state manager to create a new state instead of switching existing instances to the desired state.

Therefore the outcome of mapping abnormal results to Normal and Alerting state is not what user expects and the documentation declares.

**What is this feature?**
This PR does two things:
1. Updates the alerting evaluator package to not return abnormal statuses as a normal result in the list of results. This is done to distinguish between abnormal and normal results so state manager does not need to figure that out by itself.
2. Fixes state manager to properly handle mapping of the abnormal states and pull all existing alert instances for the rule and switch to the desired state.

**Why do we need this feature?**
This fixes the bug of mapping Error|NoData results to OK|Alerting states.