### PR TITLE
Alerting: Adds evaluation interval to group view

### DIFF
--- a/public/app/features/alerting/unified/RuleList.test.tsx
+++ b/public/app/features/alerting/unified/RuleList.test.tsx
@@ -322,8 +322,11 @@ describe('RuleList', () => {
 
     const groups = await ui.ruleGroup.findAll();
     expect(groups).toHaveLength(2);
-    expect(groups[0]).toHaveTextContent('1 rule');
-    expect(groups[1]).toHaveTextContent('4 rules: 1 firing, 1 pending');
+    expect(groups[0]).toHaveTextContent('1 firing');
+    expect(groups[1]).toHaveTextContent('1 firing');
+    expect(groups[1]).toHaveTextContent('1 pending');
+    expect(groups[1]).toHaveTextContent('1 recording');
+    expect(groups[1]).toHaveTextContent('1 normal');
 
     // expand second group to see rules table
     expect(ui.rulesTable.query()).not.toBeInTheDocument();

--- a/public/app/features/alerting/unified/RuleList.tsx
+++ b/public/app/features/alerting/unified/RuleList.tsx
@@ -105,7 +105,7 @@ const RuleList = withErrorBoundary(
                     {expandAll ? 'Collapse all' : 'Expand all'}
                   </Button>
                 )}
-                <RuleStats namespaces={filteredNamespaces} />
+                <RuleStats namespaces={filteredNamespaces} includeTotal />
               </div>
               {(canCreateGrafanaRules || canCreateCloudRules) && (
                 <LinkButton

--- a/public/app/features/alerting/unified/RuleList.tsx
+++ b/public/app/features/alerting/unified/RuleList.tsx
@@ -105,7 +105,7 @@ const RuleList = withErrorBoundary(
                     {expandAll ? 'Collapse all' : 'Expand all'}
                   </Button>
                 )}
-                <RuleStats showInactive={true} showRecording={true} namespaces={filteredNamespaces} />
+                <RuleStats namespaces={filteredNamespaces} />
               </div>
               {(canCreateGrafanaRules || canCreateCloudRules) && (
                 <LinkButton

--- a/public/app/features/alerting/unified/components/rules/RuleStats.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleStats.tsx
@@ -1,4 +1,5 @@
-import React, { FC, useMemo } from 'react';
+import pluralize from 'pluralize';
+import React, { FC, Fragment, useMemo } from 'react';
 
 import { Stack } from '@grafana/experimental';
 import { Badge } from '@grafana/ui';
@@ -8,6 +9,7 @@ import { PromAlertingRuleState } from 'app/types/unified-alerting-dto';
 import { isAlertingRule, isRecordingRule, isRecordingRulerRule } from '../../utils/rules';
 
 interface Props {
+  includeTotal?: boolean;
   group?: CombinedRuleGroup;
   namespaces?: CombinedRuleNamespace[];
 }
@@ -21,7 +23,7 @@ const emptyStats = {
   error: 0,
 } as const;
 
-export const RuleStats: FC<Props> = ({ group, namespaces }) => {
+export const RuleStats: FC<Props> = ({ group, namespaces, includeTotal }) => {
   const evaluationInterval = group?.interval;
 
   const calculated = useMemo(() => {
@@ -55,6 +57,14 @@ export const RuleStats: FC<Props> = ({ group, namespaces }) => {
   }, [group, namespaces]);
 
   const statsComponents: React.ReactNode[] = [];
+
+  if (includeTotal) {
+    statsComponents.push(
+      <Fragment key="total">
+        {calculated.total} {pluralize('rule', calculated.total)}
+      </Fragment>
+    );
+  }
 
   if (calculated[PromAlertingRuleState.Firing]) {
     statsComponents.push(

--- a/public/app/features/alerting/unified/components/rules/RulesGroup.tsx
+++ b/public/app/features/alerting/unified/components/rules/RulesGroup.tsx
@@ -3,6 +3,7 @@ import pluralize from 'pluralize';
 import React, { FC, useEffect, useState } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
+import { Stack } from '@grafana/experimental';
 import { logInfo } from '@grafana/runtime';
 import { Badge, ConfirmModal, HorizontalGroup, Icon, Spinner, Tooltip, useStyles2 } from '@grafana/ui';
 import { useDispatch } from 'app/types';
@@ -213,12 +214,22 @@ export const RulesGroup: FC<Props> = React.memo(({ group, namespace, expandAll, 
         </h6>
         <div className={styles.spacer} />
         <div className={styles.headerStats}>
-          <RuleStats showInactive={false} group={group} />
+          <RuleStats group={group} />
         </div>
+        {isProvisioned && (
+          <>
+            <div className={styles.actionsSeparator}>|</div>
+            <div className={styles.actionIcons}>
+              <Badge color="purple" text="Provisioned" />
+            </div>
+          </>
+        )}
         {!!actionIcons.length && (
           <>
             <div className={styles.actionsSeparator}>|</div>
-            <div className={styles.actionIcons}>{actionIcons}</div>
+            <div className={styles.actionIcons}>
+              <Stack gap={0.5}>{actionIcons}</Stack>
+            </div>
           </>
         )}
       </div>
@@ -313,9 +324,8 @@ export const getStyles = (theme: GrafanaTheme2) => ({
     margin: 0 ${theme.spacing(2)};
   `,
   actionIcons: css`
-    & > * + * {
-      margin-left: ${theme.spacing(0.5)};
-    }
+    width: 80px;
+    align-items: center;
   `,
   rulesTable: css`
     margin-top: ${theme.spacing(3)};


### PR DESCRIPTION
This change adds the evaluation interval to the summary view for evaluation groups.

Also adds some more colors to the rule summary and always shows recording and normal alert rules in the stats.

<img width="1159" alt="Screenshot 2022-12-07 at 17 58 49" src="https://user-images.githubusercontent.com/868844/206242648-0bac5b37-d94e-4313-b86c-1f1d1a5d3688.png">
