### PR TITLE
Alerting: Better define how we set states

### DIFF
--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -116,8 +116,9 @@ const (
 	ValueStringAnnotation = "__value_string__"
 )
 
-var (
+const (
 	StateReasonMissingSeries = "MissingSeries"
+	StateReasonError         = "Error"
 )
 
 var (

--- a/pkg/services/ngalert/state/state.go
+++ b/pkg/services/ngalert/state/state.go
@@ -119,9 +119,9 @@ func (a *State) SetError(err error, startsAt, endsAt time.Time) {
 }
 
 // SetNormal sets the state to Normal. It changes both the start and end time.
-func (a *State) SetNormal(startsAt, endsAt time.Time) {
+func (a *State) SetNormal(reason string, startsAt, endsAt time.Time) {
 	a.State = eval.Normal
-	a.StateReason = ""
+	a.StateReason = reason
 	a.StartsAt = startsAt
 	a.EndsAt = endsAt
 	a.Error = nil
@@ -185,7 +185,7 @@ func resultNormal(state *State, _ *models.AlertRule, result eval.Result, logger 
 	} else {
 		logger.Debug("Changing state", "previous_state", state.State, "next_state", eval.Normal)
 		// Normal states have the same start and end timestamps
-		state.SetNormal(result.EvaluatedAt, result.EvaluatedAt)
+		state.SetNormal("", result.EvaluatedAt, result.EvaluatedAt)
 	}
 }
 

--- a/pkg/services/ngalert/state/state.go
+++ b/pkg/services/ngalert/state/state.go
@@ -112,7 +112,7 @@ func (a *State) SetNoData(startsAt, endsAt time.Time) {
 // SetError sets the state to Error. It changes both the start and end time.
 func (a *State) SetError(err error, startsAt, endsAt time.Time) {
 	a.State = eval.Error
-	a.StateReason = "error"
+	a.StateReason = models.StateReasonError
 	a.StartsAt = startsAt
 	a.EndsAt = endsAt
 	a.Error = err

--- a/pkg/services/ngalert/state/state.go
+++ b/pkg/services/ngalert/state/state.go
@@ -83,27 +83,27 @@ func (a *State) GetAlertInstanceKey() (models.AlertInstanceKey, error) {
 }
 
 // SetAlerting sets the state to Alerting. It changes both the start and end time.
-func (a *State) SetAlerting(startsAt, endsAt time.Time) {
+func (a *State) SetAlerting(reason string, startsAt, endsAt time.Time) {
 	a.State = eval.Alerting
-	a.StateReason = ""
+	a.StateReason = reason
 	a.StartsAt = startsAt
 	a.EndsAt = endsAt
 	a.Error = nil
 }
 
 // SetPending the state to Pending. It changes both the start and end time.
-func (a *State) SetPending(startsAt, endsAt time.Time) {
+func (a *State) SetPending(reason string, startsAt, endsAt time.Time) {
 	a.State = eval.Pending
-	a.StateReason = ""
+	a.StateReason = reason
 	a.StartsAt = startsAt
 	a.EndsAt = endsAt
 	a.Error = nil
 }
 
 // SetNoData sets the state to NoData. It changes both the start and end time.
-func (a *State) SetNoData(startsAt, endsAt time.Time) {
+func (a *State) SetNoData(reason string, startsAt, endsAt time.Time) {
 	a.State = eval.NoData
-	a.StateReason = ""
+	a.StateReason = reason
 	a.StartsAt = startsAt
 	a.EndsAt = endsAt
 	a.Error = nil
@@ -198,16 +198,16 @@ func resultAlerting(state *State, rule *models.AlertRule, result eval.Result, lo
 		// If the previous state is Pending then check if the For duration has been observed
 		if result.EvaluatedAt.Sub(state.StartsAt) >= rule.For {
 			logger.Debug("Changing state", "previous_state", state.State, "next_state", eval.Alerting)
-			state.SetAlerting(result.EvaluatedAt, nextEndsTime(rule.IntervalSeconds, result.EvaluatedAt))
+			state.SetAlerting("", result.EvaluatedAt, nextEndsTime(rule.IntervalSeconds, result.EvaluatedAt))
 		}
 	default:
 		if rule.For > 0 {
 			// If the alert rule has a For duration that should be observed then the state should be set to Pending
 			logger.Debug("Changing state", "previous_state", state.State, "next_state", eval.Pending)
-			state.SetPending(result.EvaluatedAt, nextEndsTime(rule.IntervalSeconds, result.EvaluatedAt))
+			state.SetPending("", result.EvaluatedAt, nextEndsTime(rule.IntervalSeconds, result.EvaluatedAt))
 		} else {
 			logger.Debug("Changing state", "previous_state", state.State, "next_state", eval.Alerting)
-			state.SetAlerting(result.EvaluatedAt, nextEndsTime(rule.IntervalSeconds, result.EvaluatedAt))
+			state.SetAlerting("", result.EvaluatedAt, nextEndsTime(rule.IntervalSeconds, result.EvaluatedAt))
 		}
 	}
 }

--- a/pkg/services/ngalert/state/state_test.go
+++ b/pkg/services/ngalert/state/state_test.go
@@ -24,17 +24,20 @@ func TestSetAlerting(t *testing.T) {
 	tests := []struct {
 		name     string
 		state    State
+		reason   string
 		startsAt time.Time
 		endsAt   time.Time
 		expected State
 	}{{
 		name:     "state is set to Alerting",
+		reason:   "this is a reason",
 		startsAt: mock.Now(),
 		endsAt:   mock.Now().Add(time.Minute),
 		expected: State{
-			State:    eval.Alerting,
-			StartsAt: mock.Now(),
-			EndsAt:   mock.Now().Add(time.Minute),
+			State:       eval.Alerting,
+			StateReason: "this is a reason",
+			StartsAt:    mock.Now(),
+			EndsAt:      mock.Now().Add(time.Minute),
 		},
 	}, {
 		name: "previous state is removed",
@@ -55,7 +58,7 @@ func TestSetAlerting(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			actual := test.state
-			actual.SetAlerting(test.startsAt, test.endsAt)
+			actual.SetAlerting(test.reason, test.startsAt, test.endsAt)
 			assert.Equal(t, test.expected, actual)
 		})
 	}
@@ -66,17 +69,20 @@ func TestSetPending(t *testing.T) {
 	tests := []struct {
 		name     string
 		state    State
+		reason   string
 		startsAt time.Time
 		endsAt   time.Time
 		expected State
 	}{{
 		name:     "state is set to Pending",
+		reason:   "this is a reason",
 		startsAt: mock.Now(),
 		endsAt:   mock.Now().Add(time.Minute),
 		expected: State{
-			State:    eval.Pending,
-			StartsAt: mock.Now(),
-			EndsAt:   mock.Now().Add(time.Minute),
+			State:       eval.Pending,
+			StateReason: "this is a reason",
+			StartsAt:    mock.Now(),
+			EndsAt:      mock.Now().Add(time.Minute),
 		},
 	}, {
 		name: "previous state is removed",
@@ -97,7 +103,7 @@ func TestSetPending(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			actual := test.state
-			actual.SetPending(test.startsAt, test.endsAt)
+			actual.SetPending(test.reason, test.startsAt, test.endsAt)
 			assert.Equal(t, test.expected, actual)
 		})
 	}
@@ -108,17 +114,20 @@ func TestNormal(t *testing.T) {
 	tests := []struct {
 		name     string
 		state    State
+		reason   string
 		startsAt time.Time
 		endsAt   time.Time
 		expected State
 	}{{
 		name:     "state is set to Normal",
+		reason:   "this is a reason",
 		startsAt: mock.Now(),
 		endsAt:   mock.Now().Add(time.Minute),
 		expected: State{
-			State:    eval.Normal,
-			StartsAt: mock.Now(),
-			EndsAt:   mock.Now().Add(time.Minute),
+			State:       eval.Normal,
+			StateReason: "this is a reason",
+			StartsAt:    mock.Now(),
+			EndsAt:      mock.Now().Add(time.Minute),
 		},
 	}, {
 		name: "previous state is removed",
@@ -139,7 +148,7 @@ func TestNormal(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			actual := test.state
-			actual.SetNormal(test.startsAt, test.endsAt)
+			actual.SetNormal(test.reason, test.startsAt, test.endsAt)
 			assert.Equal(t, test.expected, actual)
 		})
 	}
@@ -150,6 +159,7 @@ func TestNoData(t *testing.T) {
 	tests := []struct {
 		name     string
 		state    State
+		reason   string
 		startsAt time.Time
 		endsAt   time.Time
 		expected State
@@ -181,7 +191,7 @@ func TestNoData(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			actual := test.state
-			actual.SetNoData(test.startsAt, test.endsAt)
+			actual.SetNoData(test.reason, test.startsAt, test.endsAt)
 			assert.Equal(t, test.expected, actual)
 		})
 	}

--- a/pkg/services/ngalert/state/state_test.go
+++ b/pkg/services/ngalert/state/state_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/screenshot"
 )
 
-func TestAlerting(t *testing.T) {
+func TestSetAlerting(t *testing.T) {
 	mock := clock.NewMock()
 	tests := []struct {
 		name     string
@@ -55,13 +55,13 @@ func TestAlerting(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			actual := test.state
-			actual.Alerting(test.startsAt, test.endsAt)
+			actual.SetAlerting(test.startsAt, test.endsAt)
 			assert.Equal(t, test.expected, actual)
 		})
 	}
 }
 
-func TestPending(t *testing.T) {
+func TestSetPending(t *testing.T) {
 	mock := clock.NewMock()
 	tests := []struct {
 		name     string
@@ -97,7 +97,7 @@ func TestPending(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			actual := test.state
-			actual.Pending(test.startsAt, test.endsAt)
+			actual.SetPending(test.startsAt, test.endsAt)
 			assert.Equal(t, test.expected, actual)
 		})
 	}
@@ -139,7 +139,7 @@ func TestNormal(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			actual := test.state
-			actual.Normal(test.startsAt, test.endsAt)
+			actual.SetNormal(test.startsAt, test.endsAt)
 			assert.Equal(t, test.expected, actual)
 		})
 	}
@@ -181,7 +181,7 @@ func TestNoData(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			actual := test.state
-			actual.NoData(test.startsAt, test.endsAt)
+			actual.SetNoData(test.startsAt, test.endsAt)
 			assert.Equal(t, test.expected, actual)
 		})
 	}
@@ -202,10 +202,11 @@ func TestSetError(t *testing.T) {
 		endsAt:   mock.Now().Add(time.Minute),
 		error:    errors.New("this is an error"),
 		expected: State{
-			State:    eval.Error,
-			Error:    errors.New("this is an error"),
-			StartsAt: mock.Now(),
-			EndsAt:   mock.Now().Add(time.Minute),
+			State:       eval.Error,
+			StateReason: "error",
+			Error:       errors.New("this is an error"),
+			StartsAt:    mock.Now(),
+			EndsAt:      mock.Now().Add(time.Minute),
 		},
 	}, {
 		name: "previous state is removed",
@@ -218,10 +219,11 @@ func TestSetError(t *testing.T) {
 		endsAt:   mock.Now().Add(time.Minute),
 		error:    errors.New("this is another error"),
 		expected: State{
-			State:    eval.Error,
-			Error:    errors.New("this is another error"),
-			StartsAt: mock.Now(),
-			EndsAt:   mock.Now().Add(time.Minute),
+			State:       eval.Error,
+			StateReason: "error",
+			Error:       errors.New("this is another error"),
+			StartsAt:    mock.Now(),
+			EndsAt:      mock.Now().Add(time.Minute),
 		},
 	}}
 

--- a/pkg/services/ngalert/state/state_test.go
+++ b/pkg/services/ngalert/state/state_test.go
@@ -203,7 +203,7 @@ func TestSetError(t *testing.T) {
 		error:    errors.New("this is an error"),
 		expected: State{
 			State:       eval.Error,
-			StateReason: "error",
+			StateReason: ngmodels.StateReasonError,
 			Error:       errors.New("this is an error"),
 			StartsAt:    mock.Now(),
 			EndsAt:      mock.Now().Add(time.Minute),
@@ -220,7 +220,7 @@ func TestSetError(t *testing.T) {
 		error:    errors.New("this is another error"),
 		expected: State{
 			State:       eval.Error,
-			StateReason: "error",
+			StateReason: ngmodels.StateReasonError,
 			Error:       errors.New("this is another error"),
 			StartsAt:    mock.Now(),
 			EndsAt:      mock.Now().Add(time.Minute),


### PR DESCRIPTION
**What is this feature?**

This pull request better defines how we set states in `resultNormal`, `resultAlerting`, `resultError` and `resultNoData`. It changes the existing code to call methods such as `Alerting`, `Pending`, `Normal`, `SetError` and `NoData` instead of assigning values to each individual field whenever the state is changed. This should make it easier to understand what fields should be set for which states and avoid cases where states are missing, or have additional unexpected fields.

**Why do we need this feature?**

The code written here will be used for the `ForError` feature for `DatasourceError`.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

