### PR TITLE
RBAC: Add benchmarks to search all users given a specific permission

### DIFF
--- a/pkg/services/accesscontrol/acimpl/service_bench_test.go
+++ b/pkg/services/accesscontrol/acimpl/service_bench_test.go
@@ -76,9 +76,9 @@ func concurrentBatch(workers, count, size int, eachFn func(start, end int) error
 }
 
 // setupBenchEnv will create userCount users, userCount managed roles with resourceCount managed permission each
-// Example: setupBenchEnv(b, 2, 3) will create:
-//          3 users and assign them 3 managed roles
-//          each managed role will have 3 permissions {"resources:action2", "resources:id:x"} where x belongs to [1, 3]
+// Example: setupBenchEnv(b, 2, 3):
+//  - will create 3 users and assign them 3 managed roles
+//  - each managed role will have 3 permissions {"resources:action2", "resources:id:x"} where x belongs to [1, 3]
 func setupBenchEnv(b *testing.B, usersCount, resourceCount int) (accesscontrol.Service, *user.SignedInUser) {
 	now := time.Now()
 	sqlStore := db.InitTestDB(b)

--- a/pkg/services/accesscontrol/acimpl/service_bench_test.go
+++ b/pkg/services/accesscontrol/acimpl/service_bench_test.go
@@ -77,7 +77,7 @@ func concurrentBatch(workers, count, size int, eachFn func(start, end int) error
 
 // setupBenchEnv will create userCount users, userCount managed roles with resourceCount managed permission each
 // Example: setupBenchEnv(b, 2, 3):
-// - will create 3 users and assign them 3 managed roles
+// - will create 2 users and assign them 2 managed roles
 // - each managed role will have 3 permissions {"resources:action2", "resources:id:x"} where x belongs to [1, 3]
 func setupBenchEnv(b *testing.B, usersCount, resourceCount int) (accesscontrol.Service, *user.SignedInUser) {
 	now := time.Now()

--- a/pkg/services/accesscontrol/acimpl/service_bench_test.go
+++ b/pkg/services/accesscontrol/acimpl/service_bench_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const concurrency = 10
+const concurrency = 20
 const batchSize = 1000
 
 type bounds struct {
@@ -67,7 +67,6 @@ func concurrentBatch(workers, count, size int, eachFn func(start, end int) error
 	// wait for an error or for all workers to be done
 	select {
 	case err := <-ret:
-		fmt.Println("Got an error from a worker", err)
 		return err
 	case <-alldone:
 		break
@@ -250,7 +249,10 @@ func BenchmarkSearchUsersPermissions_10K_1K(b *testing.B) {
 } // ~50s/op
 
 // Benchmarking search when we specify Action and Scope
-func benchSearchUsersSpecificPermissions(b *testing.B, usersCount, resourceCount int) {
+func benchSearchUsersWithPerm(b *testing.B, usersCount, resourceCount int) {
+	if testing.Short() {
+		b.Skip("Skipping benchmark in short mode")
+	}
 	acService, siu := setupBenchEnv(b, usersCount, resourceCount)
 	b.ResetTimer()
 
@@ -265,84 +267,21 @@ func benchSearchUsersSpecificPermissions(b *testing.B, usersCount, resourceCount
 	}
 }
 
-func BenchmarkSearchUsersSpecificPermissions_1K_10(b *testing.B) {
-	if testing.Short() {
-		b.Skip("Skipping benchmark in short mode")
-	}
-	benchSearchUsersSpecificPermissions(b, 1000, 10)
-} // ~0.045s/op
-func BenchmarkSearchUsersSpecificPermissions_1K_100(b *testing.B) {
-	if testing.Short() {
-		b.Skip("Skipping benchmark in short mode")
-	}
-	benchSearchUsersSpecificPermissions(b, 1000, 100)
-} // ~0.038s/op
-func BenchmarkSearchUsersSpecificPermissions_1K_1K(b *testing.B) {
-	if testing.Short() {
-		b.Skip("Skipping benchmark in short mode")
-	}
-	benchSearchUsersSpecificPermissions(b, 1000, 1000)
-} // ~0.033s/op
-func BenchmarkSearchUsersSpecificPermissions_1K_10K(b *testing.B) {
-	if testing.Short() {
-		b.Skip("Skipping benchmark in short mode")
-	}
-	benchSearchUsersSpecificPermissions(b, 1000, 10000)
-} // ~0.033s/op
-func BenchmarkSearchUsersSpecificPermissions_1K_100K(b *testing.B) {
-	if testing.Short() {
-		b.Skip("Skipping benchmark in short mode")
-	}
-	benchSearchUsersSpecificPermissions(b, 1000, 100000)
-} // ~0.056s/op
+func BenchmarkSearchUsersWithPerm_1K_10(b *testing.B)   { benchSearchUsersWithPerm(b, 1000, 10) }     // ~0.045s/op
+func BenchmarkSearchUsersWithPerm_1K_100(b *testing.B)  { benchSearchUsersWithPerm(b, 1000, 100) }    // ~0.038s/op
+func BenchmarkSearchUsersWithPerm_1K_1K(b *testing.B)   { benchSearchUsersWithPerm(b, 1000, 1000) }   // ~0.033s/op
+func BenchmarkSearchUsersWithPerm_1K_10K(b *testing.B)  { benchSearchUsersWithPerm(b, 1000, 10000) }  // ~0.033s/op
+func BenchmarkSearchUsersWithPerm_1K_100K(b *testing.B) { benchSearchUsersWithPerm(b, 1000, 100000) } // ~0.056s/op
 
-func BenchmarkSearchUsersSpecificPermissions_10K_10(b *testing.B) {
-	if testing.Short() {
-		b.Skip("Skipping benchmark in short mode")
-	}
-	benchSearchUsersSpecificPermissions(b, 10000, 10)
-} // ~0.11s/op
-func BenchmarkSearchUsersSpecificPermissions_10K_100(b *testing.B) {
-	if testing.Short() {
-		b.Skip("Skipping benchmark in short mode")
-	}
-	benchSearchUsersSpecificPermissions(b, 10000, 100)
-} // ~0.12s/op
-func BenchmarkSearchUsersSpecificPermissions_10K_1K(b *testing.B) {
-	if testing.Short() {
-		b.Skip("Skipping benchmark in short mode")
-	}
-	benchSearchUsersSpecificPermissions(b, 10000, 1000)
-} // ~0.12s/op
+func BenchmarkSearchUsersWithPerm_10K_10(b *testing.B)  { benchSearchUsersWithPerm(b, 10000, 10) }    // ~0.11s/op
+func BenchmarkSearchUsersWithPerm_10K_100(b *testing.B) { benchSearchUsersWithPerm(b, 10000, 100) }   // ~0.12s/op
+func BenchmarkSearchUsersWithPerm_10K_1K(b *testing.B)  { benchSearchUsersWithPerm(b, 10000, 1000) }  // ~0.12s/op
+func BenchmarkSearchUsersWithPerm_10K_10K(b *testing.B) { benchSearchUsersWithPerm(b, 10000, 10000) } // ~1.77s/op
 
-func BenchmarkSearchUsersSpecificPermissions_20K_10(b *testing.B) {
-	if testing.Short() {
-		b.Skip("Skipping benchmark in short mode")
-	}
-	benchSearchUsersSpecificPermissions(b, 20000, 10)
-} // ~0.22s/op
-func BenchmarkSearchUsersSpecificPermissions_20K_100(b *testing.B) {
-	if testing.Short() {
-		b.Skip("Skipping benchmark in short mode")
-	}
-	benchSearchUsersSpecificPermissions(b, 20000, 100)
-} // ~0.22s/op
-func BenchmarkSearchUsersSpecificPermissions_20K_1K(b *testing.B) {
-	if testing.Short() {
-		b.Skip("Skipping benchmark in short mode")
-	}
-	benchSearchUsersSpecificPermissions(b, 20000, 1000)
-} // ~0.25s/op
+func BenchmarkSearchUsersWithPerm_20K_10(b *testing.B)  { benchSearchUsersWithPerm(b, 20000, 10) }    // ~0.22s/op
+func BenchmarkSearchUsersWithPerm_20K_100(b *testing.B) { benchSearchUsersWithPerm(b, 20000, 100) }   // ~0.22s/op
+func BenchmarkSearchUsersWithPerm_20K_1K(b *testing.B)  { benchSearchUsersWithPerm(b, 20000, 1000) }  // ~0.25s/op
+func BenchmarkSearchUsersWithPerm_20K_10K(b *testing.B) { benchSearchUsersWithPerm(b, 20000, 10000) } // ~s/op
 
-func BenchmarkSearchUsersSpecificPermissions_100K_10(b *testing.B) {
-	if testing.Short() {
-		b.Skip("Skipping benchmark in short mode")
-	}
-	benchSearchUsersSpecificPermissions(b, 100000, 10)
-} // ~0.88s/op
-func BenchmarkSearchUsersSpecificPermissions_100K_100(b *testing.B) {
-	if testing.Short() {
-		b.Skip("Skipping benchmark in short mode")
-	}
-	benchSearchUsersSpecificPermissions(b, 100000, 100)
-} // ~0.72s/op
+func BenchmarkSearchUsersWithPerm_100K_10(b *testing.B)  { benchSearchUsersWithPerm(b, 100000, 10) }  // ~0.88s/op
+func BenchmarkSearchUsersWithPerm_100K_100(b *testing.B) { benchSearchUsersWithPerm(b, 100000, 100) } // ~0.72s/op

--- a/pkg/services/accesscontrol/acimpl/service_bench_test.go
+++ b/pkg/services/accesscontrol/acimpl/service_bench_test.go
@@ -282,7 +282,7 @@ func BenchmarkSearchUsersWithPerm_1K_100K(b *testing.B) { benchSearchUsersWithPe
 func BenchmarkSearchUsersWithPerm_10K_10(b *testing.B)  { benchSearchUsersWithPerm(b, 10000, 10) }    // ~0.11s/op
 func BenchmarkSearchUsersWithPerm_10K_100(b *testing.B) { benchSearchUsersWithPerm(b, 10000, 100) }   // ~0.12s/op
 func BenchmarkSearchUsersWithPerm_10K_1K(b *testing.B)  { benchSearchUsersWithPerm(b, 10000, 1000) }  // ~0.12s/op
-func BenchmarkSearchUsersWithPerm_10K_10K(b *testing.B) { benchSearchUsersWithPerm(b, 10000, 10000) } // ~1.77s/op
+func BenchmarkSearchUsersWithPerm_10K_10K(b *testing.B) { benchSearchUsersWithPerm(b, 10000, 10000) } // ~0.17s/op
 
 func BenchmarkSearchUsersWithPerm_20K_10(b *testing.B)  { benchSearchUsersWithPerm(b, 20000, 10) }    // ~0.22s/op
 func BenchmarkSearchUsersWithPerm_20K_100(b *testing.B) { benchSearchUsersWithPerm(b, 20000, 100) }   // ~0.22s/op

--- a/pkg/services/accesscontrol/acimpl/service_bench_test.go
+++ b/pkg/services/accesscontrol/acimpl/service_bench_test.go
@@ -77,8 +77,8 @@ func concurrentBatch(workers, count, size int, eachFn func(start, end int) error
 
 // setupBenchEnv will create userCount users, userCount managed roles with resourceCount managed permission each
 // Example: setupBenchEnv(b, 2, 3):
-//  - will create 3 users and assign them 3 managed roles
-//  - each managed role will have 3 permissions {"resources:action2", "resources:id:x"} where x belongs to [1, 3]
+// - will create 3 users and assign them 3 managed roles
+// - each managed role will have 3 permissions {"resources:action2", "resources:id:x"} where x belongs to [1, 3]
 func setupBenchEnv(b *testing.B, usersCount, resourceCount int) (accesscontrol.Service, *user.SignedInUser) {
 	now := time.Now()
 	sqlStore := db.InitTestDB(b)

--- a/pkg/services/accesscontrol/acimpl/service_bench_test.go
+++ b/pkg/services/accesscontrol/acimpl/service_bench_test.go
@@ -107,7 +107,7 @@ func setupBenchEnv(b *testing.B, usersCount, resourceCount int) (accesscontrol.S
 		orgUsers := make([]org.OrgUser, 0, n)
 		roles := make([]accesscontrol.Role, 0, n)
 		userRoles := make([]accesscontrol.UserRole, 0, n)
-		for u := start; u < end; u++ {
+		for u := start + 1; u < end+1; u++ {
 			users = append(users, user.User{
 				ID:      int64(u),
 				Name:    fmt.Sprintf("user%v", u),

--- a/pkg/services/accesscontrol/acimpl/service_bench_test.go
+++ b/pkg/services/accesscontrol/acimpl/service_bench_test.go
@@ -24,6 +24,7 @@ type bounds struct {
 	start, end int
 }
 
+// concurrentBatch spawns the requested amount of workers then ask them to run eachFn on chunks of the requested size
 func concurrentBatch(workers, count, size int, eachFn func(start, end int) error) error {
 	var wg sync.WaitGroup
 	alldone := make(chan bool) // Indicates that all workers have finished working

--- a/pkg/services/accesscontrol/acimpl/service_bench_test.go
+++ b/pkg/services/accesscontrol/acimpl/service_bench_test.go
@@ -301,7 +301,7 @@ func BenchmarkSearchUsersSpecificPermissions_10K_10(b *testing.B) {
 		b.Skip("Skipping benchmark in short mode")
 	}
 	benchSearchUsersSpecificPermissions(b, 10000, 10)
-} // ~s/op
+} // ~0.11s/op
 func BenchmarkSearchUsersSpecificPermissions_10K_100(b *testing.B) {
 	if testing.Short() {
 		b.Skip("Skipping benchmark in short mode")


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

OnCall has a use case we might need to cover:
* Searching users that have the required access to be notified.
This translates to searching users with a given permission.

This PR intends to benchmark whether our search function can do that nicely at scale.
Specifically when dealing with a large number of users (10k) and a large number of managed permissions (10K per user => 100M).

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

