### PR TITLE
Hackathon: background services registration 

### DIFF
--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -3,12 +3,14 @@ package registry
 import (
 	"context"
 
+	"github.com/grafana/dskit/services"
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
 )
 
 // BackgroundServiceRegistry provides background services.
 type BackgroundServiceRegistry interface {
 	GetServices() []BackgroundService
+	services.Service
 }
 
 // CanBeDisabled allows the services to decide if it should

--- a/pkg/server/backgroundsvcs/background_services.go
+++ b/pkg/server/backgroundsvcs/background_services.go
@@ -158,7 +158,7 @@ func NewBackgroundServiceRegistry(
 		cfg:                         cfg,
 	}
 
-	r.BasicService = services.NewBasicService(nil, r.run, r.stop)
+	r.BasicService = services.NewBasicService(r.start, r.run, r.stop)
 	return r
 }
 
@@ -173,10 +173,6 @@ func (r *BackgroundServiceRegistry) start(ctx context.Context) error {
 }
 
 func (r *BackgroundServiceRegistry) run(ctx context.Context) error {
-	if err := r.start(ctx); err != nil {
-		return err
-	}
-
 	// Start background services.
 	for _, svc := range r.Services {
 		if registry.IsDisabled(svc) {

--- a/pkg/server/modules/modules.go
+++ b/pkg/server/modules/modules.go
@@ -7,7 +7,7 @@ import (
 	"github.com/grafana/dskit/services"
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/server/backgroundsvcs"
+	"github.com/grafana/grafana/pkg/registry"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/grpcserver"
 	"github.com/grafana/grafana/pkg/services/store/entity/sqlstash"
@@ -31,7 +31,7 @@ type Modules struct {
 
 	grpcServer                grpcserver.Provider
 	kindRegistry              kind.KindRegistry
-	backgroundServiceRegistry *backgroundsvcs.BackgroundServiceRegistry
+	backgroundServiceRegistry registry.BackgroundServiceRegistry
 	db                        db.DB
 	entityReferenceResolver   resolver.EntityReferenceResolver
 
@@ -45,7 +45,7 @@ func ProvideService(
 	cfg *setting.Cfg,
 	server grpcserver.Provider,
 	kindRegistry kind.KindRegistry,
-	backgroundServiceRegistry *backgroundsvcs.BackgroundServiceRegistry,
+	backgroundServiceRegistry registry.BackgroundServiceRegistry,
 	roleRegistry accesscontrol.RoleRegistry,
 	db db.DB,
 	entityReferenceResolver resolver.EntityReferenceResolver,


### PR DESCRIPTION
This PR
- Makes the module package depend on the `registry.BackgroundServiceRegistry` interface rather than the concrete oss version (`*backgroundsvcs.BackgroundServiceRegistry`). Overrides from ent will reuse the oss implementation.
- Fixes the `start` method - its now called in the `run()`

