### PR TITLE
Alerting: Allow Rules to Schedule to be filtered by Rule Group

### DIFF
--- a/pkg/services/ngalert/eval/eval.go
+++ b/pkg/services/ngalert/eval/eval.go
@@ -29,7 +29,7 @@ var logger = log.New("ngalert.eval")
 type EvaluatorFactory interface {
 	// Validate validates that the condition is correct. Returns nil if the condition is correct. Otherwise, error that describes the failure
 	Validate(ctx EvaluationContext, condition models.Condition) error
-	// BuildRuleEvaluator build an evaluator pipeline ready to evaluate a rule's query
+	// Create builds an evaluator pipeline ready to evaluate a rule's query
 	Create(ctx EvaluationContext, condition models.Condition) (ConditionEvaluator, error)
 }
 

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -398,6 +398,7 @@ type CountAlertRulesQuery struct {
 
 type GetAlertRulesForSchedulingQuery struct {
 	PopulateFolders bool
+	RuleGroups      []string
 
 	ResultRules         []*AlertRule
 	ResultFoldersTitles map[string]string

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -454,7 +454,7 @@ func (st DBstore) GetAlertRulesForScheduling(ctx context.Context, query *ngmodel
 			disabledOrgs = append(disabledOrgs, orgID)
 		}
 
-		alertRulesSql := sess.Table("alert_rule").Select("*")
+		alertRulesSql := sess.Table("alert_rule")
 		if len(disabledOrgs) > 0 {
 			alertRulesSql.NotIn("org_id", disabledOrgs)
 		}

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -456,7 +456,6 @@ func (st DBstore) GetAlertRulesForScheduling(ctx context.Context, query *ngmodel
 			}
 		}
 
-		//<<<<<<< HEAD
 		alertRulesSql := sess.Table("alert_rule").Select("*")
 		if len(ids) > 0 {
 			alertRulesSql.NotIn("org_id", ids)

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -427,7 +427,7 @@ func (st DBstore) GetAlertRulesKeysForScheduling(ctx context.Context) ([]ngmodel
 		alertRulesSql := sess.Table("alert_rule").Select("org_id, uid, version")
 		if len(st.Cfg.DisabledOrgs) > 0 {
 			var ids []int64
-			for orgID, _ := range st.Cfg.DisabledOrgs {
+			for orgID := range st.Cfg.DisabledOrgs {
 				ids = append(ids, orgID)
 			}
 
@@ -451,7 +451,7 @@ func (st DBstore) GetAlertRulesForScheduling(ctx context.Context, query *ngmodel
 	return st.SQLStore.WithDbSession(ctx, func(sess *db.Session) error {
 		var ids []int64
 		if len(st.Cfg.DisabledOrgs) > 0 {
-			for orgID, _ := range st.Cfg.DisabledOrgs {
+			for orgID := range st.Cfg.DisabledOrgs {
 				ids = append(ids, orgID)
 			}
 		}
@@ -486,7 +486,9 @@ func (st DBstore) GetAlertRulesForScheduling(ctx context.Context, query *ngmodel
 		query.ResultRules = rules
 
 		if query.PopulateFolders {
-			foldersSql := sess.Table("dashboard").Alias("D").Select("D.uid, D.title").Where("is_folder = ?", true).And("EXISTS (SELECT 1 FROM alert_rule AS A WHERE D.uid = A.namespace_uid)")
+			foldersSql := sess.Table("dashboard").Alias("D").Select("D.uid, D.title").
+				Where("is_folder = ?", true).
+				And("EXISTS (SELECT 1 FROM alert_rule A WHERE D.uid = A.namespace_uid)")
 			if len(ids) > 0 {
 				foldersSql = foldersSql.NotIn("org_id", ids)
 			}

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -468,7 +468,11 @@ func (st DBstore) GetAlertRulesForScheduling(ctx context.Context, query *ngmodel
 		if err != nil {
 			return fmt.Errorf("failed to fetch alert rules: %w", err)
 		}
-		defer rows.Close()
+		defer func() {
+			if err := rows.Close(); err != nil {
+				st.Logger.Error("unable to close rows session", "error", err)
+			}
+		}()
 
 		// Deserialize each rule separately in case any of them contain invalid JSON.
 		for rows.Next() {

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -486,9 +486,9 @@ func (st DBstore) GetAlertRulesForScheduling(ctx context.Context, query *ngmodel
 		query.ResultRules = rules
 
 		if query.PopulateFolders {
-			foldersSql := sess.Table("dashboard").Alias("D").Select("D.uid, D.title").
+			foldersSql := sess.Table("dashboard").Alias("d").Select("d.uid, d.title").
 				Where("is_folder = ?", true).
-				And(`EXISTS (SELECT 1 FROM alert_rule A WHERE "D".uid = A.namespace_uid)`)
+				And(`EXISTS (SELECT 1 FROM alert_rule a WHERE d.uid = a.namespace_uid)`)
 			if len(ids) > 0 {
 				foldersSql = foldersSql.NotIn("org_id", ids)
 			}

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -488,7 +488,7 @@ func (st DBstore) GetAlertRulesForScheduling(ctx context.Context, query *ngmodel
 		if query.PopulateFolders {
 			foldersSql := sess.Table("dashboard").Alias("D").Select("D.uid, D.title").
 				Where("is_folder = ?", true).
-				And("EXISTS (SELECT 1 FROM alert_rule A WHERE D.uid = A.namespace_uid)")
+				And(`EXISTS (SELECT 1 FROM alert_rule A WHERE "D".uid = A.namespace_uid)`)
 			if len(ids) > 0 {
 				foldersSql = foldersSql.NotIn("org_id", ids)
 			}

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -489,7 +489,7 @@ func (st DBstore) GetAlertRulesForScheduling(ctx context.Context, query *ngmodel
 
 		if query.PopulateFolders {
 			foldersSql := sess.Table("dashboard").Alias("d").Select("d.uid, d.title").
-				Where("is_folder = ?", true).
+				Where("is_folder = ?", st.SQLStore.GetDialect().BooleanStr(true)).
 				And(`EXISTS (SELECT 1 FROM alert_rule a WHERE d.uid = a.namespace_uid)`)
 			if len(disabledOrgs) > 0 {
 				foldersSql.NotIn("org_id", disabledOrgs)

--- a/pkg/services/ngalert/store/alert_rule_test.go
+++ b/pkg/services/ngalert/store/alert_rule_test.go
@@ -154,7 +154,6 @@ func TestIntegration_GetAlertRulesForScheduling(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func withIntervalMatching(baseInterval time.Duration) func(*models.AlertRule) {

--- a/pkg/services/ngalert/store/alert_rule_test.go
+++ b/pkg/services/ngalert/store/alert_rule_test.go
@@ -7,24 +7,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/mock"
-
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/infra/tracing"
-	"github.com/grafana/grafana/pkg/services/accesscontrol"
-	acmock "github.com/grafana/grafana/pkg/services/accesscontrol/mock"
-	"github.com/grafana/grafana/pkg/services/dashboards"
-	databasestore "github.com/grafana/grafana/pkg/services/dashboards/database"
-	dashboardservice "github.com/grafana/grafana/pkg/services/dashboards/service"
-	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/folder/folderimpl"
-	"github.com/grafana/grafana/pkg/services/folder/foldertest"
-	"github.com/grafana/grafana/pkg/services/guardian"
 	"github.com/grafana/grafana/pkg/services/org"
-	"github.com/grafana/grafana/pkg/services/quota/quotatest"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
-	"github.com/grafana/grafana/pkg/services/tag/tagimpl"
 	"github.com/grafana/grafana/pkg/services/user"
 
 	"github.com/stretchr/testify/require"
@@ -288,46 +276,4 @@ func setupFolderService(t *testing.T, sqlStore *sqlstore.SQLStore, cfg *setting.
 	_, dashboardStore := SetupDashboardService(t, sqlStore, folderStore, cfg)
 
 	return SetupFolderService(t, cfg, dashboardStore, folderStore, inProcBus)
-}
-
-func SetupFolderService(tb testing.TB, cfg *setting.Cfg, dashboardStore dashboards.Store, folderStore *folderimpl.DashboardFolderStoreImpl, bus *bus.InProcBus) folder.Service {
-	tb.Helper()
-
-	ac := acmock.New()
-	features := featuremgmt.WithFeatures()
-
-	return folderimpl.ProvideService(ac, bus, cfg, dashboardStore, folderStore, nil, features)
-}
-
-func SetupDashboardService(tb testing.TB, sqlStore *sqlstore.SQLStore, fs *folderimpl.DashboardFolderStoreImpl, cfg *setting.Cfg) (*dashboardservice.DashboardServiceImpl, dashboards.Store) {
-	tb.Helper()
-
-	origNewGuardian := guardian.New
-	guardian.MockDashboardGuardian(&guardian.FakeDashboardGuardian{
-		CanSaveValue:  true,
-		CanViewValue:  true,
-		CanAdminValue: true,
-	})
-	tb.Cleanup(func() {
-		guardian.New = origNewGuardian
-	})
-
-	ac := acmock.New()
-	dashboardPermissions := acmock.NewMockedPermissionsService()
-	folderPermissions := acmock.NewMockedPermissionsService()
-	folderPermissions.On("SetPermissions", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]accesscontrol.ResourcePermission{}, nil)
-
-	features := featuremgmt.WithFeatures()
-	quotaService := quotatest.New(false, nil)
-
-	dashboardStore, err := databasestore.ProvideDashboardStore(sqlStore, sqlStore.Cfg, features, tagimpl.ProvideService(sqlStore, sqlStore.Cfg), quotaService)
-	dashboardService := dashboardservice.ProvideDashboardServiceImpl(
-		cfg, dashboardStore, fs, nil,
-		features, folderPermissions, dashboardPermissions, ac,
-		foldertest.NewFakeService(),
-	)
-
-	require.NoError(tb, err)
-
-	return dashboardService, dashboardStore
 }

--- a/pkg/services/ngalert/store/alert_rule_test.go
+++ b/pkg/services/ngalert/store/alert_rule_test.go
@@ -266,7 +266,6 @@ func createFolder(t *testing.T, store *DBstore, namespace, title string, orgID i
 	})
 
 	require.NoError(t, err)
-
 }
 
 func setupFolderService(t *testing.T, sqlStore *sqlstore.SQLStore, cfg *setting.Cfg) folder.Service {

--- a/pkg/services/ngalert/store/alert_rule_test.go
+++ b/pkg/services/ngalert/store/alert_rule_test.go
@@ -7,7 +7,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/infra/slugify"
+
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/rand"
 
@@ -68,65 +70,97 @@ func TestIntegrationUpdateAlertRules(t *testing.T) {
 	})
 }
 
+func TestIntegration_GetAlertRulesForScheduling(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	sqlStore := db.InitTestDB(t)
+
+	store := &DBstore{
+		SQLStore: sqlStore,
+		Cfg: setting.UnifiedAlertingSettings{
+			BaseInterval: time.Duration(rand.Int63n(100)) * time.Second,
+		},
+	}
+
+	rule1 := createRule(t, store)
+	rule2 := createRule(t, store)
+
+	tc := []struct {
+		name         string
+		rules        []string
+		ruleGroups   []string
+		disabledOrgs []int64
+		folders      map[string]string
+	}{
+		{
+			name:  "without a rule group filter, it returns all created rules",
+			rules: []string{rule1.Title, rule2.Title},
+		},
+		{
+			name:       "with a rule group filter, it only returns the rules that match on rule group",
+			ruleGroups: []string{rule1.RuleGroup},
+			rules:      []string{rule1.Title},
+		},
+		{
+			name:         "with a filter on orgs, it returns rules that do not belong to that org",
+			rules:        []string{rule1.Title},
+			disabledOrgs: []int64{rule2.OrgID},
+		},
+		{
+			name:    "with populate folders enabled, it returns them",
+			rules:   []string{rule1.Title, rule2.Title},
+			folders: map[string]string{rule1.NamespaceUID: rule1.Title, rule2.NamespaceUID: rule2.Title},
+		},
+		{
+			name:         "with populate folders enabled and a filter on orgs, it only returns selected information",
+			rules:        []string{rule1.Title},
+			disabledOrgs: []int64{rule2.OrgID},
+			folders:      map[string]string{rule1.NamespaceUID: rule1.Title},
+		},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			if len(tt.disabledOrgs) > 0 {
+				store.Cfg.DisabledOrgs = map[int64]struct{}{}
+
+				for _, orgID := range tt.disabledOrgs {
+					store.Cfg.DisabledOrgs[orgID] = struct{}{}
+					t.Cleanup(func() {
+						delete(store.Cfg.DisabledOrgs, orgID)
+					})
+				}
+			}
+
+			populateFolders := len(tt.folders) > 0
+			query := &models.GetAlertRulesForSchedulingQuery{
+				RuleGroups:      tt.ruleGroups,
+				PopulateFolders: populateFolders,
+			}
+			require.NoError(t, store.GetAlertRulesForScheduling(context.Background(), query))
+			require.Len(t, query.ResultRules, len(tt.rules))
+
+			r := make([]string, 0, len(query.ResultRules))
+			for _, rule := range query.ResultRules {
+				r = append(r, rule.Title)
+			}
+
+			require.ElementsMatch(t, r, tt.rules)
+
+			if populateFolders {
+				require.Equal(t, tt.folders, query.ResultFoldersTitles)
+			}
+		})
+	}
+
+}
+
 func withIntervalMatching(baseInterval time.Duration) func(*models.AlertRule) {
 	return func(rule *models.AlertRule) {
 		rule.IntervalSeconds = int64(baseInterval.Seconds()) * rand.Int63n(10)
 		rule.For = time.Duration(rule.IntervalSeconds*rand.Int63n(9)+1) * time.Second
-	}
-}
-
-func TestIntegration_getFilterByOrgsString(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping integration test")
-	}
-	testCases := []struct {
-		testName       string
-		orgs           map[int64]struct{}
-		expectedFilter string
-		expectedArgs   []interface{}
-	}{
-		{
-			testName:       "should return empty string if map is empty",
-			orgs:           map[int64]struct{}{},
-			expectedFilter: "",
-			expectedArgs:   nil,
-		},
-		{
-			testName:       "should return empty string if map is nil",
-			orgs:           nil,
-			expectedFilter: "",
-			expectedArgs:   nil,
-		},
-		{
-			testName: "should return correct filter if single element",
-			orgs: map[int64]struct{}{
-				1: {},
-			},
-			expectedFilter: "org_id NOT IN(?)",
-			expectedArgs:   []interface{}{int64(1)},
-		},
-		{
-			testName: "should return correct filter if many elements",
-			orgs: map[int64]struct{}{
-				1: {},
-				2: {},
-				3: {},
-			},
-			expectedFilter: "org_id NOT IN(?,?,?)",
-			expectedArgs:   []interface{}{int64(1), int64(2), int64(3)},
-		},
-	}
-	for _, testCase := range testCases {
-		t.Run(testCase.testName, func(t *testing.T) {
-			store := &DBstore{
-				Cfg: setting.UnifiedAlertingSettings{
-					DisabledOrgs: testCase.orgs,
-				},
-			}
-			filter, args := store.getFilterByOrgsString()
-			assert.Equal(t, testCase.expectedFilter, filter)
-			assert.ElementsMatch(t, testCase.expectedArgs, args)
-		})
 	}
 }
 
@@ -176,7 +210,9 @@ func TestIntegration_CountAlertRules(t *testing.T) {
 }
 
 func createRule(t *testing.T, store *DBstore) *models.AlertRule {
+	t.Helper()
 	rule := models.AlertRuleGen(withIntervalMatching(store.Cfg.BaseInterval), models.WithUniqueID())()
+	createFolder(t, store, rule.NamespaceUID, rule.Title, rule.OrgID)
 	err := store.SQLStore.WithDbSession(context.Background(), func(sess *db.Session) error {
 		_, err := sess.Table(models.AlertRule{}).InsertOne(rule)
 		if err != nil {
@@ -191,8 +227,151 @@ func createRule(t *testing.T, store *DBstore) *models.AlertRule {
 			return errors.New("cannot read inserted record")
 		}
 		rule = dbRule
+
+		require.NoError(t, err)
+
 		return nil
 	})
 	require.NoError(t, err)
+
 	return rule
+}
+
+func createFolder(t *testing.T, store *DBstore, namespace string, title string, orgID int64) *dashboard {
+	t.Helper()
+
+	var resultDashboard *dashboard
+	err := store.SQLStore.WithDbSession(context.Background(), func(sess *db.Session) error {
+		cmd := saveFolderCommand{
+			OrgId:    orgID,
+			FolderId: 0,
+			IsFolder: true,
+			Dashboard: simplejson.NewFromAny(map[string]interface{}{
+				"title": title,
+			}),
+		}
+		dash := cmd.getDashboardModel()
+
+		dash.setUid(namespace)
+
+		dash.setVersion(1)
+		dash.Created = time.Now()
+		dash.CreatedBy = 1
+		dash.Updated = time.Now()
+		dash.UpdatedBy = 1
+
+		if _, err := sess.Insert(dash); err != nil {
+			return err
+		}
+
+		resultDashboard = dash
+
+		return nil
+	})
+
+	require.NoError(t, err)
+
+	return resultDashboard
+}
+
+type dashboard struct {
+	Id       int64
+	Uid      string
+	Slug     string
+	OrgId    int64
+	GnetId   int64
+	Version  int
+	PluginId string
+
+	Created time.Time
+	Updated time.Time
+
+	UpdatedBy int64
+	CreatedBy int64
+	FolderId  int64
+	IsFolder  bool
+	HasACL    bool `xorm:"has_acl"`
+
+	Title string
+	Data  *simplejson.Json
+}
+
+func (d *dashboard) setUid(uid string) {
+	d.Uid = uid
+	d.Data.Set("uid", uid)
+}
+
+func (d *dashboard) setVersion(version int) {
+	d.Version = version
+	d.Data.Set("version", version)
+}
+
+// UpdateSlug updates the slug
+func (d *dashboard) updateSlug() {
+	title := d.Data.Get("title").MustString()
+	d.Slug = slugify.Slugify(title)
+}
+
+func newDashboardFromJson(data *simplejson.Json) *dashboard {
+	dash := &dashboard{}
+	dash.Data = data
+	dash.Title = dash.Data.Get("title").MustString()
+	dash.updateSlug()
+	update := false
+
+	if id, err := dash.Data.Get("id").Float64(); err == nil {
+		dash.Id = int64(id)
+		update = true
+	}
+
+	if uid, err := dash.Data.Get("uid").String(); err == nil {
+		dash.Uid = uid
+		update = true
+	}
+
+	if version, err := dash.Data.Get("version").Float64(); err == nil && update {
+		dash.Version = int(version)
+		dash.Updated = time.Now()
+	} else {
+		dash.Data.Set("version", 0)
+		dash.Created = time.Now()
+		dash.Updated = time.Now()
+	}
+
+	if gnetId, err := dash.Data.Get("gnetId").Float64(); err == nil {
+		dash.GnetId = int64(gnetId)
+	}
+
+	return dash
+}
+
+type saveFolderCommand struct {
+	Dashboard    *simplejson.Json `json:"dashboard" binding:"Required"`
+	UserId       int64            `json:"userId"`
+	Message      string           `json:"message"`
+	OrgId        int64            `json:"-"`
+	RestoredFrom int              `json:"-"`
+	PluginId     string           `json:"-"`
+	FolderId     int64            `json:"folderId"`
+	IsFolder     bool             `json:"isFolder"`
+
+	Result *dashboard
+}
+
+// GetDashboardModel turns the command into the saveable model
+func (cmd *saveFolderCommand) getDashboardModel() *dashboard {
+	dash := newDashboardFromJson(cmd.Dashboard)
+	userId := cmd.UserId
+
+	if userId == 0 {
+		userId = -1
+	}
+
+	dash.UpdatedBy = userId
+	dash.OrgId = cmd.OrgId
+	dash.PluginId = cmd.PluginId
+	dash.IsFolder = cmd.IsFolder
+	dash.FolderId = cmd.FolderId
+	dash.updateSlug()
+	return dash
 }

--- a/pkg/services/ngalert/store/testing.go
+++ b/pkg/services/ngalert/store/testing.go
@@ -6,7 +6,25 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/bus"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	acmock "github.com/grafana/grafana/pkg/services/accesscontrol/mock"
+	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/services/dashboards/database"
+	dashboardservice "github.com/grafana/grafana/pkg/services/dashboards/service"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/folder"
+	"github.com/grafana/grafana/pkg/services/folder/folderimpl"
+	"github.com/grafana/grafana/pkg/services/folder/foldertest"
+	"github.com/grafana/grafana/pkg/services/guardian"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/services/quota/quotatest"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
+	"github.com/grafana/grafana/pkg/services/tag/tagimpl"
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 func NewFakeImageStore(t *testing.T) *FakeImageStore {
@@ -99,4 +117,46 @@ func (f *FakeAdminConfigStore) UpdateAdminConfiguration(cmd UpdateAdminConfigura
 	f.Configs[cmd.AdminConfiguration.OrgID] = cmd.AdminConfiguration
 
 	return nil
+}
+
+func SetupFolderService(tb testing.TB, cfg *setting.Cfg, dashboardStore dashboards.Store, folderStore *folderimpl.DashboardFolderStoreImpl, bus *bus.InProcBus) folder.Service {
+	tb.Helper()
+
+	ac := acmock.New()
+	features := featuremgmt.WithFeatures()
+
+	return folderimpl.ProvideService(ac, bus, cfg, dashboardStore, folderStore, nil, features)
+}
+
+func SetupDashboardService(tb testing.TB, sqlStore *sqlstore.SQLStore, fs *folderimpl.DashboardFolderStoreImpl, cfg *setting.Cfg) (*dashboardservice.DashboardServiceImpl, dashboards.Store) {
+	tb.Helper()
+
+	origNewGuardian := guardian.New
+	guardian.MockDashboardGuardian(&guardian.FakeDashboardGuardian{
+		CanSaveValue:  true,
+		CanViewValue:  true,
+		CanAdminValue: true,
+	})
+	tb.Cleanup(func() {
+		guardian.New = origNewGuardian
+	})
+
+	ac := acmock.New()
+	dashboardPermissions := acmock.NewMockedPermissionsService()
+	folderPermissions := acmock.NewMockedPermissionsService()
+	folderPermissions.On("SetPermissions", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]accesscontrol.ResourcePermission{}, nil)
+
+	features := featuremgmt.WithFeatures()
+	quotaService := quotatest.New(false, nil)
+
+	dashboardStore, err := database.ProvideDashboardStore(sqlStore, sqlStore.Cfg, features, tagimpl.ProvideService(sqlStore, sqlStore.Cfg), quotaService)
+	dashboardService := dashboardservice.ProvideDashboardServiceImpl(
+		cfg, dashboardStore, fs, nil,
+		features, folderPermissions, dashboardPermissions, ac,
+		foldertest.NewFakeService(),
+	)
+
+	require.NoError(tb, err)
+
+	return dashboardService, dashboardStore
 }

--- a/pkg/services/ngalert/tests/util.go
+++ b/pkg/services/ngalert/tests/util.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/api/routing"
@@ -19,17 +18,12 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/plugins"
-	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	acmock "github.com/grafana/grafana/pkg/services/accesscontrol/mock"
 	"github.com/grafana/grafana/pkg/services/annotations/annotationstest"
 	"github.com/grafana/grafana/pkg/services/dashboards"
-	databasestore "github.com/grafana/grafana/pkg/services/dashboards/database"
-	dashboardservice "github.com/grafana/grafana/pkg/services/dashboards/service"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/folder/folderimpl"
-	"github.com/grafana/grafana/pkg/services/folder/foldertest"
-	"github.com/grafana/grafana/pkg/services/guardian"
 	"github.com/grafana/grafana/pkg/services/ngalert"
 	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
@@ -38,7 +32,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/quota/quotatest"
 	"github.com/grafana/grafana/pkg/services/secrets/database"
 	secretsManager "github.com/grafana/grafana/pkg/services/secrets/manager"
-	"github.com/grafana/grafana/pkg/services/tag/tagimpl"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
@@ -47,15 +40,6 @@ import (
 // SetupTestEnv initializes a store to used by the tests.
 func SetupTestEnv(tb testing.TB, baseInterval time.Duration) (*ngalert.AlertNG, *store.DBstore) {
 	tb.Helper()
-	origNewGuardian := guardian.New
-	guardian.MockDashboardGuardian(&guardian.FakeDashboardGuardian{
-		CanSaveValue:  true,
-		CanViewValue:  true,
-		CanAdminValue: true,
-	})
-	tb.Cleanup(func() {
-		guardian.New = origNewGuardian
-	})
 
 	cfg := setting.NewCfg()
 	cfg.IsFeatureToggleEnabled = featuremgmt.WithFeatures().IsEnabled
@@ -69,27 +53,14 @@ func SetupTestEnv(tb testing.TB, baseInterval time.Duration) (*ngalert.AlertNG, 
 	m := metrics.NewNGAlert(prometheus.NewRegistry())
 	sqlStore := db.InitTestDB(tb)
 	secretsService := secretsManager.SetupTestService(tb, database.ProvideSecretsStore(sqlStore))
-	quotaService := quotatest.New(false, nil)
-	dashboardStore, err := databasestore.ProvideDashboardStore(sqlStore, sqlStore.Cfg, featuremgmt.WithFeatures(), tagimpl.ProvideService(sqlStore, sqlStore.Cfg), quotaService)
-	require.NoError(tb, err)
 
 	ac := acmock.New()
-	features := featuremgmt.WithFeatures()
-	folderPermissions := acmock.NewMockedPermissionsService()
-	folderPermissions.On("SetPermissions", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]accesscontrol.ResourcePermission{}, nil)
-	dashboardPermissions := acmock.NewMockedPermissionsService()
-
-	folderStore := folderimpl.ProvideDashboardFolderStore(sqlStore)
-
-	dashboardService := dashboardservice.ProvideDashboardServiceImpl(
-		cfg, dashboardStore, folderStore, nil,
-		features, folderPermissions, dashboardPermissions, ac,
-		foldertest.NewFakeService(),
-	)
 
 	tracer := tracing.InitializeTracerForTest()
 	bus := bus.ProvideBus(tracer)
-	folderService := folderimpl.ProvideService(ac, bus, cfg, dashboardStore, folderStore, nil, features)
+	folderStore := folderimpl.ProvideDashboardFolderStore(sqlStore)
+	dashboardService, dashboardStore := store.SetupDashboardService(tb, sqlStore, folderStore, cfg)
+	folderService := store.SetupFolderService(tb, cfg, dashboardStore, folderStore, bus)
 
 	ng, err := ngalert.ProvideService(
 		cfg, featuremgmt.WithFeatures(), nil, nil, routing.NewRouteRegister(), sqlStore, nil, nil, nil, quotatest.New(false, nil),


### PR DESCRIPTION
This PR enables us to filter down by rule groups when fetching alert rules. You have the ability to specify multiple groups at the same time.