### PR TITLE
Hackathon 2022 12 hgmt configmap

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -311,6 +311,7 @@ require (
 	github.com/segmentio/asm v1.1.4 // indirect
 	github.com/shopspring/decimal v1.2.0 // indirect
 	github.com/spf13/cast v1.3.1 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/unknwon/bra v0.0.0-20200517080246-1e3013ecaff8 // indirect
 	github.com/unknwon/com v1.0.1 // indirect
 	github.com/unknwon/log v0.0.0-20150304194804-e617c87089d3 // indirect

--- a/pkg/services/mtctx/middleware.go
+++ b/pkg/services/mtctx/middleware.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"github.com/grafana/grafana/pkg/services/sqlstore/session"
+	v1 "k8s.io/api/core/v1"
 )
 
 type tenantInfoKey struct{}
@@ -16,6 +17,8 @@ var (
 type TenantInfo struct {
 	StackID   int64
 	SessionDB *session.SessionDB
+	Err       error
+	Config    *v1.ConfigMap
 }
 
 func ContextWithTenantInfo(ctx context.Context, data *TenantInfo) context.Context {

--- a/pkg/services/mtctx/service.go
+++ b/pkg/services/mtctx/service.go
@@ -9,6 +9,7 @@ import (
 
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 type Service interface {
@@ -19,11 +20,19 @@ var _ Service = (*serviceImpl)(nil)
 
 func ProvideService(router routing.RouteRegister) Service {
 	svc := &serviceImpl{
-		cache: make(map[int64]*TenantInfo, 0),
+		cache:     make(map[int64]*TenantInfo, 0),
+		namespace: "default", // "hosted-grafana"
 	}
 
-	// attach kubernetes client to service
-	config, err := rest.InClusterConfig()
+	kubeconfig := "/Users/ryan/.kube/config"
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+
+	if err != nil {
+		// attach kubernetes client to service
+		svc.namespace = "hosted-grafana"
+		config, err = rest.InClusterConfig()
+	}
+
 	if err != nil {
 		log.Println("could not get kubernetes config", err)
 	} else if config != nil {

--- a/pkg/services/mtctx/service_impl.go
+++ b/pkg/services/mtctx/service_impl.go
@@ -6,9 +6,11 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/grafana/grafana/pkg/api/response"
+	"github.com/grafana/grafana/pkg/cmd/grafana-cli/logger"
 	"github.com/grafana/grafana/pkg/infra/appcontext"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
@@ -21,6 +23,7 @@ import (
 )
 
 type serviceImpl struct {
+	namespace string
 	clientset *kubernetes.Clientset
 	cache     map[int64]*TenantInfo
 	//watchers  map[int64]watch.Interface
@@ -39,9 +42,11 @@ func (s *serviceImpl) showTenantInfo(c *models.ReqContext) response.Response {
 	}
 
 	return response.JSON(200, map[string]interface{}{
-		"stackID": t.StackID,
-		"user":    c.SignedInUser,
-		"env":     os.Getenv("HG_STACK_ID"),
+		"stackID":     t.StackID,
+		"user":        c.SignedInUser,
+		"hasdb":       t.SessionDB != nil,
+		"HG_STACK_ID": os.Getenv("HG_STACK_ID"),
+		"info":        t,
 	})
 }
 
@@ -73,6 +78,18 @@ func (s *serviceImpl) Middleware(next http.Handler) http.Handler {
 			return
 		}
 
+		// Try to set it from environment (only relevant for single tenant setup)
+		if user.StackID == 0 {
+			v := os.Getenv("HG_STACK_ID")
+			if v == "" {
+				v = "6" // VSCODE DEBUGGER ENVIRONMENT
+			}
+			stackID, err := strconv.ParseInt(v, 10, 64)
+			if err == nil {
+				user.StackID = stackID
+			}
+		}
+
 		// Check cache for config by stackID
 		info, ok := s.cache[user.StackID]
 
@@ -82,16 +99,18 @@ func (s *serviceImpl) Middleware(next http.Handler) http.Handler {
 
 			// get the initial config map
 			if s.clientset != nil {
-				config, err = s.clientset.CoreV1().ConfigMaps("hosted-grafana").Get(context.TODO(), stackName(user.StackID), metav1.GetOptions{})
+				config, err = s.clientset.CoreV1().ConfigMaps(s.namespace).Get(context.TODO(), stackName(user.StackID), metav1.GetOptions{})
 				if err != nil {
 					fmt.Println("Error getting config map:", err)
+					info.Err = err
 				}
 			}
 
 			// build tenant info and add to context
 			info = buildTenantInfoFromConfig(user.StackID, config)
-			fmt.Println("POTATO: context set")
-			s.cache[user.StackID] = info
+			logger.Info("POTATO: context set: %v", config)
+
+			//	s.cache[user.StackID] = info
 
 			// Get config watcher
 			//w, err := s.GetStackConfigWatcher(context.TODO(), stackID)
@@ -152,45 +171,42 @@ func stackName(stackID int64) string {
 }
 
 // takes INI, initializes db connection and returns it
-func initializeDBConnection(config *v1.ConfigMap) *session.SessionDB {
+func initializeDBConnection(config *v1.ConfigMap) (*session.SessionDB, error) {
 	if config == nil {
-		fmt.Printf("missing config!")
-		return nil
+		return nil, fmt.Errorf("missing config")
 	}
-	jsontxt, ok := config.Data["ini"]
+	jsontxt, ok := config.Data["ini.json"]
 	if !ok {
-		fmt.Printf("could not find key ini")
-		return nil
+		return nil, fmt.Errorf("could not find key ini")
 	}
 
 	jsonmap := make(map[string]map[string]string, 0)
 	err := json.Unmarshal([]byte(jsontxt), &jsonmap)
 	if err != nil {
-		fmt.Printf("missing config!")
-		return nil
+		return nil, err
 	}
 	cfg, err := setting.FromJSON(jsonmap)
 	if err != nil {
-		fmt.Printf("error reading json config: " + err.Error())
-		return nil
+		return nil, err
 	}
 
-	// a whold new instance?   ┗|・o・|┛
+	// a whole new instance?   ┗|・o・|┛
 	ss, err := sqlstore.NewSQLStore(cfg, nil, nil, nil, nil, nil)
 	if err != nil {
-		fmt.Printf("error reading json config: " + err.Error())
-		return nil
+		return nil, err
 	}
 
-	return ss.GetSqlxSession()
+	return ss.GetSqlxSession(), nil
 }
 
 // Builds tenant info and returns it to enter into cache
 func buildTenantInfoFromConfig(stackID int64, config *v1.ConfigMap) *TenantInfo {
-	dbCon := initializeDBConnection(config)
+	dbCon, err := initializeDBConnection(config)
 
 	return &TenantInfo{
 		StackID:   stackID,
 		SessionDB: dbCon,
+		Err:       err,
+		Config:    config,
 	}
 }

--- a/pkg/services/mtctx/service_impl_test.go
+++ b/pkg/services/mtctx/service_impl_test.go
@@ -1,0 +1,30 @@
+package mtctx
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+func TestKubeAccess(t *testing.T) {
+	t.Skip()
+
+	kubeconfig := "/Users/ryan/.kube/config"
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	require.NoError(t, err)
+
+	client, err := kubernetes.NewForConfig(config)
+	require.NoError(t, err)
+
+	out, err := client.CoreV1().ConfigMaps("default").Get(context.TODO(), "123-mt-config", metav1.GetOptions{})
+	require.NoError(t, err)
+
+	fmt.Printf("%v", out)
+
+	t.FailNow() // shows logs
+}

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -969,6 +969,8 @@ func (cfg *Cfg) Load(args CommandLineArgs) error {
 // Load Cfg from a string map rather than a real ini file
 func FromJSON(config map[string]map[string]string) (*Cfg, error) {
 	inifile := ini.Empty()
+	// TODO... gettting all defaults will be essential :grimmice:
+
 	for section, vals := range config {
 		s, err := inifile.NewSection(section)
 		if err != nil {


### PR DESCRIPTION
use real config maps

NOTE:
* this avoids caching config changes for now

```
apiVersion: v1
kind: ConfigMap
metadata:
  name: 5-mt-config
data:
  hello: mysql
  ini.json: |
    {"database":  { 
      "type": "mysql",
      "host": "localhost:3306",
      "database": "grafana",
      "name": "grafana",
      "user": "grafana",
      "password": "password"
    }}
    
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: 6-mt-config
data:
  hello: postgresql
  ini.json: |
    {"database":  { 
      "type": "postgres",
      "host": "localhost:5432",
      "database": "grafana",
      "name": "grafana",
      "user": "grafana",
      "password": "password"
    }}

```