### PR TITLE
QueryVariable: Add support for expandable variables

### DIFF
--- a/packages/grafana-data/src/types/templateVars.ts
+++ b/packages/grafana-data/src/types/templateVars.ts
@@ -42,6 +42,7 @@ export enum VariableHide {
   dontHide,
   hideLabel,
   hideVariable,
+  hideExpandable,
 }
 
 export interface AdHocVariableFilter {

--- a/public/app/features/dashboard/components/SubMenu/ExpandableItem.tsx
+++ b/public/app/features/dashboard/components/SubMenu/ExpandableItem.tsx
@@ -1,0 +1,31 @@
+import React, { FC, ReactElement } from 'react';
+
+import { SelectableValue } from '@grafana/data/src';
+import { Icon, SegmentAsync } from '@grafana/ui/src';
+
+interface Props {
+  onChange: (item: SelectableValue<string | null>) => void;
+  loadOptions: () => Promise<Array<SelectableValue<string>>>;
+  disabled?: boolean;
+}
+
+const expandSegment: ReactElement = (
+  <span className="gf-form-label query-part" aria-label="Add Filter">
+    <Icon name="gf-show-context" />
+  </span>
+);
+
+export const ExpandableItem: FC<Props> = ({ onChange, loadOptions, disabled }) => {
+  const MIN_WIDTH = 90;
+
+  return (
+    <SegmentAsync
+      disabled={disabled}
+      className="query-segment-key"
+      Component={expandSegment}
+      onChange={onChange}
+      loadOptions={loadOptions}
+      inputMinWidth={MIN_WIDTH}
+    />
+  );
+};

--- a/public/app/features/dashboard/components/SubMenu/SubMenuItems.tsx
+++ b/public/app/features/dashboard/components/SubMenu/SubMenuItems.tsx
@@ -1,9 +1,14 @@
+import { Set } from 'immutable';
 import React, { FunctionComponent, useEffect, useState } from 'react';
 
+import { VariableWithOptions } from '@grafana/data';
+import { SelectableValue } from '@grafana/data/src';
 import { selectors } from '@grafana/e2e-selectors';
 
 import { PickerRenderer } from '../../../variables/pickers/PickerRenderer';
 import { VariableHide, VariableModel } from '../../../variables/types';
+
+import { ExpandableItem } from './ExpandableItem';
 
 interface Props {
   variables: VariableModel[];
@@ -12,14 +17,34 @@ interface Props {
 
 export const SubMenuItems: FunctionComponent<Props> = ({ variables, readOnly }) => {
   const [visibleVariables, setVisibleVariables] = useState<VariableModel[]>([]);
+  const [expandedVariables, setExpandedVariables] = useState<Set<string>>(
+    Set.of(
+      ...variables
+        .filter((v) => !!(v as VariableWithOptions).current?.value) // eslint-disable-line
+        .map((v) => v.name)
+    )
+  );
 
   useEffect(() => {
-    setVisibleVariables(variables.filter((state) => state.hide !== VariableHide.hideVariable));
-  }, [variables]);
+    setVisibleVariables(
+      variables.filter(
+        (state) =>
+          (state.hide === VariableHide.hideExpandable && expandedVariables.has(state.name)) ||
+          (state.hide !== VariableHide.hideVariable && state.hide !== VariableHide.hideExpandable)
+      )
+    );
+  }, [expandedVariables, variables]);
 
-  if (visibleVariables.length === 0) {
+  const expandableVariables = variables.filter((state) => state.hide === VariableHide.hideExpandable);
+
+  if (visibleVariables.length + expandableVariables.length === 0) {
     return null;
   }
+
+  const loadExpandable = (): Promise<Array<SelectableValue<string>>> =>
+    Promise.resolve(
+      expandableVariables.filter((v) => !expandedVariables.has(v.name)).map((v) => ({ label: v.label, value: v.name }))
+    );
 
   return (
     <>
@@ -34,6 +59,12 @@ export const SubMenuItems: FunctionComponent<Props> = ({ variables, readOnly }) 
           </div>
         );
       })}
+      {expandableVariables.length !== 0 && (
+        <ExpandableItem
+          onChange={(item) => setExpandedVariables((s) => s.add(item.value!))}
+          loadOptions={loadExpandable}
+        />
+      )}
     </>
   );
 };

--- a/public/app/features/variables/editor/VariableHideSelect.tsx
+++ b/public/app/features/variables/editor/VariableHideSelect.tsx
@@ -13,6 +13,7 @@ const HIDE_OPTIONS = [
   { label: 'Label and value', value: VariableHide.dontHide },
   { label: 'Value', value: VariableHide.hideLabel },
   { label: 'Nothing', value: VariableHide.hideVariable },
+  { label: 'Expandable', value: VariableHide.hideExpandable },
 ];
 
 export function VariableHideSelect({ onChange, hide, type }: PropsWithChildren<Props>) {

--- a/public/app/features/variables/pickers/PickerRenderer.tsx
+++ b/public/app/features/variables/pickers/PickerRenderer.tsx
@@ -31,7 +31,7 @@ export const PickerRenderer: FunctionComponent<Props> = (props) => {
 function PickerLabel({ variable }: PropsWithChildren<Props>): ReactElement | null {
   const labelOrName = useMemo(() => variable.label || variable.name, [variable]);
 
-  if (variable.hide !== VariableHide.dontHide) {
+  if (variable.hide === VariableHide.hideLabel || variable.hide === VariableHide.hideVariable) {
     return null;
   }
 


### PR DESCRIPTION
**What is this feature?**
It allows to hide a variable until it gets manually expanded. This is a proof of concept and I am very open to improvements, since I am very new to React/TS and don't know how to properly do this 😄 

<img width="1449" alt="Screenshot 2022-12-07 at 03 17 24" src="https://user-images.githubusercontent.com/5741401/206316339-f64be256-6e71-4820-a470-2cb0a3c19bdf.png">
<img width="1450" alt="Screenshot 2022-12-07 at 03 17 29" src="https://user-images.githubusercontent.com/5741401/206316350-fb2da735-f5a0-4999-9801-a53059e329d2.png">

**Why do we need this feature?**
I currently 15 variables and soon probably more, I wanted to reduce the clutter in the Dashboard.

**Who is this feature for?**
Everyone who uses way too many Variables

**Which issue(s) does this PR fix?**:
-

**Special notes for your reviewer**:

