### PR TITLE
Dashboard: Run requests with correct app type

### DIFF
--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -16,6 +16,7 @@ import {
   urlUtil,
   PanelModel as IPanelModel,
   DataSourceRef,
+  CoreApp,
 } from '@grafana/data';
 import { getTemplateSrv, RefreshEvent } from '@grafana/runtime';
 import config from 'app/core/config';
@@ -366,6 +367,7 @@ export class PanelModel implements DataConfigSource, IPanelModel {
       scopedVars: this.scopedVars,
       cacheTimeout: this.cacheTimeout,
       transformations: this.transformations,
+      app: this.isEditing ? CoreApp.PanelEditor : this.isViewing ? CoreApp.PanelViewer : CoreApp.Dashboard,
     });
   }
 

--- a/public/app/features/query/state/PanelQueryRunner.ts
+++ b/public/app/features/query/state/PanelQueryRunner.ts
@@ -58,6 +58,7 @@ export interface QueryRunnerOptions<
   scopedVars?: ScopedVars;
   cacheTimeout?: string | null;
   transformations?: DataTransformerConfig[];
+  app?: CoreApp;
 }
 
 let counter = 100;
@@ -213,6 +214,7 @@ export class PanelQueryRunner {
       maxDataPoints,
       scopedVars,
       minInterval,
+      app,
     } = options;
 
     if (isSharedDashboardQuery(datasource)) {
@@ -221,7 +223,7 @@ export class PanelQueryRunner {
     }
 
     const request: DataQueryRequest = {
-      app: CoreApp.Dashboard,
+      app: app ?? CoreApp.Dashboard,
       requestId: getNextRequestId(),
       timezone,
       panelId,


### PR DESCRIPTION
**What is this feature?**

Currently, all requests from dashboard are run with `app=CoreApp.Dashboard`. However, we have `CoreApp.PanelEditor` and `CoreApp.PanelViewer`, that we don't use to determine if the request was run from edit view or view view. This PR fixes it. In case app is not set, we default to `CoreApp.Dashboard` as before. 

This is going to be helpful for logging squad for usage tracking, as we'd like to learn about queries in dashboard written and run by users (so from `CoreApp.PanelEditor`) and therefore we'd like to have it distinguished from other - `CoreApp.Dashboard` and `CoreApp.PanelViewer` queries. 