### PR TITLE
Loki: Usage for queries not from dashboards

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/tracking.ts
+++ b/public/app/plugins/datasource/elasticsearch/tracking.ts
@@ -1,4 +1,4 @@
-import { DashboardLoadedEvent, DataQueryResponse } from '@grafana/data';
+import { CoreApp, DashboardLoadedEvent, DataQueryResponse } from '@grafana/data';
 import { reportInteraction } from '@grafana/runtime';
 import { variableRegex } from 'app/features/variables/utils';
 
@@ -111,6 +111,10 @@ const shouldNotReportBasedOnRefId = (refId: string): boolean => {
 };
 
 export function trackQuery(response: DataQueryResponse, queries: ElasticsearchQuery[], app: string): void {
+  if (app === CoreApp.Dashboard || app === CoreApp.PanelViewer) {
+    return;
+  }
+
   for (const query of queries) {
     if (shouldNotReportBasedOnRefId(query.refId)) {
       return;

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -6,6 +6,7 @@ import {
   AbstractLabelOperator,
   AnnotationQueryRequest,
   ArrayVector,
+  CoreApp,
   DataFrame,
   dataFrameToJSON,
   DataQueryResponse,
@@ -134,7 +135,8 @@ describe('LokiDatasource', () => {
     const runTest = async (
       queryMaxLines: number | undefined,
       dsMaxLines: string | undefined,
-      expectedMaxLines: number
+      expectedMaxLines: number,
+      app: CoreApp | undefined
     ) => {
       const settings = {
         jsonData: {
@@ -150,6 +152,7 @@ describe('LokiDatasource', () => {
 
       const options = getQueryOptions<LokiQuery>({
         targets: [{ expr: '{a="b"}', refId: 'B', maxLines: queryMaxLines }],
+        app: app ?? CoreApp.Dashboard,
       });
 
       const fetchMock = jest.fn().mockReturnValue(of({ data: testLogsResponse }));
@@ -162,19 +165,36 @@ describe('LokiDatasource', () => {
     };
 
     it('should use datasource max lines when no query max lines', async () => {
-      await runTest(undefined, '40', 40);
+      await runTest(undefined, '40', 40, undefined);
     });
 
     it('should use query max lines, if exists', async () => {
-      await runTest(80, undefined, 80);
+      await runTest(80, undefined, 80, undefined);
     });
 
     it('should use query max lines, if both exist, even if it is higher than ds max lines', async () => {
-      await runTest(80, '40', 80);
+      await runTest(80, '40', 80, undefined);
     });
 
     it('should report query interaction', async () => {
-      await runTest(80, '40', 80);
+      await runTest(80, '40', 80, CoreApp.Explore);
+      expect(reportInteraction).toHaveBeenCalledWith(
+        'grafana_loki_query_executed',
+        expect.objectContaining({
+          query_type: 'logs',
+          line_limit: 80,
+          parsed_query: parseToNodeNamesArray('{a="b"}').join(','),
+        })
+      );
+    });
+
+    it('should not report query interaction for dashboard query', async () => {
+      await runTest(80, '40', 80, CoreApp.Dashboard);
+      expect(reportInteraction).not.toBeCalled();
+    });
+
+    it('should not report query interaction for panel edit query', async () => {
+      await runTest(80, '40', 80, CoreApp.PanelEditor);
       expect(reportInteraction).toHaveBeenCalledWith(
         'grafana_loki_query_executed',
         expect.objectContaining({

--- a/public/app/plugins/datasource/loki/tracking.ts
+++ b/public/app/plugins/datasource/loki/tracking.ts
@@ -1,4 +1,4 @@
-import { DashboardLoadedEvent, DataQueryResponse } from '@grafana/data';
+import { CoreApp, DashboardLoadedEvent, DataQueryResponse } from '@grafana/data';
 import { reportInteraction } from '@grafana/runtime';
 import { variableRegex } from 'app/features/variables/utils';
 
@@ -133,6 +133,11 @@ const shouldNotReportBasedOnRefId = (refId: string): boolean => {
 };
 
 export function trackQuery(response: DataQueryResponse, queries: LokiQuery[], app: string): void {
+  // We only want to track usage for these specific apps
+  if (app === CoreApp.Dashboard || app === CoreApp.PanelViewer) {
+    return;
+  }
+
   for (const query of queries) {
     if (shouldNotReportBasedOnRefId(query.refId)) {
       return;


### PR DESCRIPTION
Remove usage tracking for panel viewever and dashboard queries, as they are oftenly not executed by users. 
