### PR TITLE
Linting: Speed up betterer by sharing eslint instances by groups

### DIFF
--- a/.betterer.ts
+++ b/.betterer.ts
@@ -41,24 +41,8 @@ function countEslintErrors() {
     const { baseDirectory } = resolver;
     const cli = new ESLint({ cwd: baseDirectory });
 
-    const testFiles: string[] = [];
-    const codeFiles: string[] = [];
-
     const eslintConfigFiles = await findEslintConfigFiles();
     const eslintConfigMainPaths = eslintConfigFiles.map((file) => path.resolve(path.dirname(file)));
-
-    filePaths.forEach((filePath) => {
-      const isTestFile =
-        filePath.endsWith('.test.tsx') ||
-        filePath.endsWith('.test.ts') ||
-        filePath.includes('__mocks__') ||
-        filePath.includes('public/test/');
-      if (isTestFile) {
-        testFiles.push(filePath);
-      } else {
-        codeFiles.push(filePath);
-      }
-    });
 
     const baseRules: Partial<Linter.RulesRecord> = {
       '@typescript-eslint/no-explicit-any': 'error',

--- a/.betterer.ts
+++ b/.betterer.ts
@@ -2,7 +2,8 @@ import { regexp } from '@betterer/regexp';
 import { BettererFileTest } from '@betterer/betterer';
 import { ESLint, Linter } from 'eslint';
 import { existsSync } from 'fs';
-
+import { exec } from 'child_process';
+import path from 'path';
 export default {
   'no enzyme tests': () => regexp(/from 'enzyme'/g).include('**/*.test.*'),
   'better eslint': () => countEslintErrors().include('**/*.{ts,tsx}'),
@@ -22,54 +23,91 @@ function countUndocumentedStories() {
   });
 }
 
+async function findEslintConfigFiles(): Promise<string[]> {
+  return new Promise((resolve, reject) => {
+    const findEslintFiles = exec("find . -iname '.eslintrc*' -not -path '*/node_modules/*'", (err, stdout) => {
+      if (err) {
+        reject(err);
+      }
+      const files = stdout.split('\n').filter((file) => !!file.trim());
+      resolve(files);
+    });
+  });
+}
+
 function countEslintErrors() {
   return new BettererFileTest(async (filePaths, fileTestResult, resolver) => {
     const { baseDirectory } = resolver;
     const cli = new ESLint({ cwd: baseDirectory });
 
-    await Promise.all(
-      filePaths.map(async (filePath) => {
-        const linterOptions = (await cli.calculateConfigForFile(filePath)) as Linter.Config;
+    const testFiles: string[] = [];
+    const codeFiles: string[] = [];
 
-        const rules: Partial<Linter.RulesRecord> = {
-          '@typescript-eslint/no-explicit-any': 'error',
-        };
+    const eslintConfigFiles = await findEslintConfigFiles();
+    const eslintConfigMainPaths = eslintConfigFiles.map((file) => path.resolve(path.dirname(file)));
 
-        const isTestFile =
-          filePath.endsWith('.test.tsx') ||
-          filePath.endsWith('.test.ts') ||
-          filePath.includes('__mocks__') ||
-          filePath.includes('public/test/');
+    filePaths.forEach((filePath) => {
+      const isTestFile =
+        filePath.endsWith('.test.tsx') ||
+        filePath.endsWith('.test.ts') ||
+        filePath.includes('__mocks__') ||
+        filePath.includes('public/test/');
+      if (isTestFile) {
+        testFiles.push(filePath);
+      } else {
+        codeFiles.push(filePath);
+      }
+    });
 
-        if (!isTestFile) {
-          rules['@typescript-eslint/consistent-type-assertions'] = [
-            'error',
-            {
-              assertionStyle: 'never',
-            },
-          ];
-        }
+    const baseRules: Partial<Linter.RulesRecord> = {
+      '@typescript-eslint/no-explicit-any': 'error',
+    };
 
-        const runner = new ESLint({
-          baseConfig: {
-            ...linterOptions,
-            rules,
-          },
-          useEslintrc: false,
-          cwd: baseDirectory,
-        });
+    const nonTestFilesRules: Partial<Linter.RulesRecord> = {
+      ...baseRules,
+      '@typescript-eslint/consistent-type-assertions': ['error', { assertionStyle: 'never' }],
+    };
 
-        const lintResults = await runner.lintFiles([filePath]);
-        lintResults
-          .filter((lintResult) => lintResult.source)
-          .forEach((lintResult) => {
-            const { messages } = lintResult;
-            const file = fileTestResult.addFile(filePath, '');
-            messages.forEach((message, index) => {
-              file.addIssue(0, 0, message.message, `${index}`);
-            });
+    const fileGroups: Record<string, string[]> = {};
+
+    for (const filePath of filePaths) {
+      let configPath = eslintConfigMainPaths.find((configPath) => filePath.startsWith(configPath)) ?? '';
+      const isTestFile =
+        filePath.endsWith('.test.tsx') ||
+        filePath.endsWith('.test.ts') ||
+        filePath.includes('__mocks__') ||
+        filePath.includes('public/test/');
+      if (isTestFile) {
+        configPath += '-test';
+      }
+      if (!fileGroups[configPath]) {
+        fileGroups[configPath] = [];
+      }
+      fileGroups[configPath].push(filePath);
+    }
+
+    for (const configPath of Object.keys(fileGroups)) {
+      const rules = configPath.endsWith('-test') ? baseRules : nonTestFilesRules;
+      const linterOptions = (await cli.calculateConfigForFile(fileGroups[configPath][0])) as Linter.Config;
+      const runner = new ESLint({
+        baseConfig: {
+          ...linterOptions,
+          rules: rules,
+        },
+        useEslintrc: false,
+        cwd: baseDirectory,
+      });
+      const lintResults = await runner.lintFiles(fileGroups[configPath]);
+      lintResults
+        .filter((lintResult) => lintResult.source)
+        .forEach((lintResult) => {
+          const { messages } = lintResult;
+          const filePath = lintResult.filePath;
+          const file = fileTestResult.addFile(filePath, '');
+          messages.forEach((message, index) => {
+            file.addIssue(0, 0, message.message, `${index}`);
           });
-      })
-    );
+        });
+    }
   });
 }

--- a/.betterer.ts
+++ b/.betterer.ts
@@ -53,6 +53,9 @@ function countEslintErrors() {
       '@typescript-eslint/consistent-type-assertions': ['error', { assertionStyle: 'never' }],
     };
 
+    // group files by eslint config file
+    // this will create two file groups for each eslint config file
+    // one for test files and one for non-test files
     const fileGroups: Record<string, string[]> = {};
 
     for (const filePath of filePaths) {
@@ -62,6 +65,7 @@ function countEslintErrors() {
         filePath.endsWith('.test.ts') ||
         filePath.includes('__mocks__') ||
         filePath.includes('public/test/');
+
       if (isTestFile) {
         configPath += '-test';
       }
@@ -73,6 +77,7 @@ function countEslintErrors() {
 
     for (const configPath of Object.keys(fileGroups)) {
       const rules = configPath.endsWith('-test') ? baseRules : nonTestFilesRules;
+      // this is by far the slowest part of this code. It takes eslint about 2 seconds just to find the config
       const linterOptions = (await cli.calculateConfigForFile(fileGroups[configPath][0])) as Linter.Config;
       const runner = new ESLint({
         baseConfig: {

--- a/.betterer.ts
+++ b/.betterer.ts
@@ -4,6 +4,8 @@ import { ESLint, Linter } from 'eslint';
 import { existsSync } from 'fs';
 import { exec } from 'child_process';
 import path from 'path';
+import glob from 'glob';
+
 export default {
   'no enzyme tests': () => regexp(/from 'enzyme'/g).include('**/*.test.*'),
   'better eslint': () => countEslintErrors().include('**/*.{ts,tsx}'),
@@ -25,11 +27,10 @@ function countUndocumentedStories() {
 
 async function findEslintConfigFiles(): Promise<string[]> {
   return new Promise((resolve, reject) => {
-    const findEslintFiles = exec("find . -iname '.eslintrc*' -not -path '*/node_modules/*'", (err, stdout) => {
+    glob('**/.eslintrc', (err, files) => {
       if (err) {
         reject(err);
       }
-      const files = stdout.split('\n').filter((file) => !!file.trim());
       resolve(files);
     });
   });

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "@types/enzyme-adapter-react-16": "1.0.6",
     "@types/eslint": "8.4.9",
     "@types/file-saver": "2.0.5",
+    "@types/glob": "^8.0.0",
     "@types/google.analytics": "^0.0.42",
     "@types/gtag.js": "^0.0.12",
     "@types/history": "4.7.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10781,6 +10781,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/glob@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "@types/glob@npm:8.0.0"
+  dependencies:
+    "@types/minimatch": "*"
+    "@types/node": "*"
+  checksum: 1817b05f5a8aed851d102a65b5e926d5c777bef927ea62b36d635860eef5364f2046bb5a692d135b6f2b28f34e4a9d44ade9396122c0845bcc7636d35f624747
+  languageName: node
+  linkType: hard
+
 "@types/google.analytics@npm:^0.0.42":
   version: 0.0.42
   resolution: "@types/google.analytics@npm:0.0.42"
@@ -21518,6 +21528,7 @@ __metadata:
     "@types/enzyme-adapter-react-16": 1.0.6
     "@types/eslint": 8.4.9
     "@types/file-saver": 2.0.5
+    "@types/glob": ^8.0.0
     "@types/google.analytics": ^0.0.42
     "@types/gtag.js": ^0.0.12
     "@types/history": 4.7.11


### PR DESCRIPTION
**What is this feature?**

Modifies the betterer test rules to re-use eslint instances per file group instead of creating one per file

**Why do we need this feature?**

Betterer currently takes a long time to run in the pipeline. This attempts to speed it up for faster pipelines.

**Who is this feature for?**

All developers and build pipeline

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

