### PR TITLE
Alerting: Use the QuotaTargetSrv instead of the QuotaTarget in quota check

### DIFF
--- a/pkg/services/ngalert/provisioning/alert_rules.go
+++ b/pkg/services/ngalert/provisioning/alert_rules.go
@@ -318,7 +318,7 @@ func (service *AlertRuleService) DeleteAlertRule(ctx context.Context, orgID int6
 
 // checkLimitsTransactionCtx checks whether the current transaction (as identified by the ctx) breaches configured alert rule limits.
 func (service *AlertRuleService) checkLimitsTransactionCtx(ctx context.Context, orgID, userID int64) error {
-	limitReached, err := service.quotas.CheckQuotaReached(ctx, "alert_rule", &quota.ScopeParameters{
+	limitReached, err := service.quotas.CheckQuotaReached(ctx, models.QuotaTargetSrv, &quota.ScopeParameters{
 		OrgID:  orgID,
 		UserID: userID,
 	})


### PR DESCRIPTION
Before this change, the alerting provisioning system incorrectly used the QuotaTarget to check if alerting's request quota had been reached. The quota service requires the QuotaTargetSrv, which is what's registered with the service at startup time. This is leading to errors in the provisioning system.
