### PR TITLE
Command Palette: Links now work when grafana is served under a subpath

### DIFF
--- a/public/app/features/commandPalette/actions/global.static.actions.tsx
+++ b/public/app/features/commandPalette/actions/global.static.actions.tsx
@@ -1,7 +1,7 @@
 import { Action, Priority } from 'kbar';
 import React from 'react';
 
-import { isIconName, NavModelItem } from '@grafana/data';
+import { isIconName, locationUtil, NavModelItem } from '@grafana/data';
 import { locationService } from '@grafana/runtime';
 import { Icon } from '@grafana/ui';
 import { changeTheme } from 'app/core/services/theme';
@@ -35,7 +35,7 @@ function navTreeToActions(navTree: NavModelItem[], parent?: NavModelItem): Actio
       id: idForNavItem(navItem),
       name: text, // TODO: translate
       section: isCreateAction ? SECTION_ACTIONS : SECTION_PAGES,
-      perform: url ? () => locationService.push(url) : undefined,
+      perform: url ? () => locationService.push(locationUtil.stripBaseFromUrl(url)) : undefined,
       parent: parent && idForNavItem(parent),
 
       // Only show icons for top level items


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- strips the base path when pushing urls to the `locationService`
- this is the same as we do in the `Navbar`: https://github.com/grafana/grafana/blob/main/public/app/core/components/NavBar/NavBarItem.tsx#L49

**Why do we need this feature?**

- so links work correctly in the Command Palette when grafana is served under a subpath

**Who is this feature for?**

- anyone serving grafana under a subpath!

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #60032 

**Special notes for your reviewer**:

