### PR TITLE
DataProxy: Populate X-Grafana-Referer header

### DIFF
--- a/pkg/util/proxyutil/proxyutil.go
+++ b/pkg/util/proxyutil/proxyutil.go
@@ -7,9 +7,17 @@ import (
 )
 
 // PrepareProxyRequest prepares a request for being proxied.
-// Removes X-Forwarded-Host, X-Forwarded-Port, X-Forwarded-Proto headers.
+// Removes X-Forwarded-Host, X-Forwarded-Port, X-Forwarded-Proto, Origin, Referer headers.
+// Set X-Grafana-Referer based on contents of Referer.
 // Set X-Forwarded-For headers.
 func PrepareProxyRequest(req *http.Request) {
+	// Set X-Grafana-Referer to correlate access logs to dashboards
+	req.Header.Set("X-Grafana-Referer", req.Header.Get("Referer"))
+
+	// Clear Origin and Referer to avoid CORS issues
+	req.Header.Del("Origin")
+	req.Header.Del("Referer")
+
 	req.Header.Del("X-Forwarded-Host")
 	req.Header.Del("X-Forwarded-Port")
 	req.Header.Del("X-Forwarded-Proto")

--- a/pkg/util/proxyutil/proxyutil_test.go
+++ b/pkg/util/proxyutil/proxyutil_test.go
@@ -8,6 +8,27 @@ import (
 )
 
 func TestPrepareProxyRequest(t *testing.T) {
+	t.Run("Prepare proxy request should clear Origin and Referer headers", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, "/", nil)
+		require.NoError(t, err)
+		req.Header.Set("Origin", "https://host.com")
+		req.Header.Set("Referer", "https://host.com/dashboard")
+
+		PrepareProxyRequest(req)
+		require.NotContains(t, req.Header, "Origin")
+		require.NotContains(t, req.Header, "Referer")
+	})
+
+	t.Run("Prepare proxy request should set X-Grafana-Referer header", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, "/", nil)
+		require.NoError(t, err)
+		req.Header.Set("Referer", "https://host.com/dashboard")
+
+		PrepareProxyRequest(req)
+		require.Contains(t, req.Header, "X-Grafana-Referer")
+		require.Equal(t, "https://host.com/dashboard", req.Header.Get("X-Grafana-Referer"))
+	})
+
 	t.Run("Prepare proxy request should clear X-Forwarded headers", func(t *testing.T) {
 		req, err := http.NewRequest(http.MethodGet, "/", nil)
 		require.NoError(t, err)

--- a/pkg/util/proxyutil/proxyutil_test.go
+++ b/pkg/util/proxyutil/proxyutil_test.go
@@ -36,6 +36,7 @@ func TestPrepareProxyRequest(t *testing.T) {
 
 		PrepareProxyRequest(req)
 		require.Contains(t, req.Header, "X-Grafana-Referer")
+		require.NotContains(t, req.Header, "OtherHeader")
 		require.Equal(t, "https://www.google.ch\r\nOtherHeader:https://www.somethingelse.com", req.Header.Get("X-Grafana-Referer"))
 	})
 

--- a/pkg/util/proxyutil/proxyutil_test.go
+++ b/pkg/util/proxyutil/proxyutil_test.go
@@ -29,6 +29,16 @@ func TestPrepareProxyRequest(t *testing.T) {
 		require.Equal(t, "https://host.com/dashboard", req.Header.Get("X-Grafana-Referer"))
 	})
 
+	t.Run("Prepare proxy request X-Grafana-Referer handles multiline", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, "/", nil)
+		require.NoError(t, err)
+		req.Header.Set("Referer", "https://www.google.ch\r\nOtherHeader:https://www.somethingelse.com")
+
+		PrepareProxyRequest(req)
+		require.Contains(t, req.Header, "X-Grafana-Referer")
+		require.Equal(t, "https://www.google.ch\r\nOtherHeader:https://www.somethingelse.com", req.Header.Get("X-Grafana-Referer"))
+	})
+
 	t.Run("Prepare proxy request should clear X-Forwarded headers", func(t *testing.T) {
 		req, err := http.NewRequest(http.MethodGet, "/", nil)
 		require.NoError(t, err)

--- a/pkg/util/proxyutil/reverse_proxy.go
+++ b/pkg/util/proxyutil/reverse_proxy.go
@@ -77,6 +77,9 @@ func wrapDirector(d func(*http.Request)) func(req *http.Request) {
 		d(req)
 		PrepareProxyRequest(req)
 
+		// Set X-Grafana-Referer to correlate access logs to dashboards
+		req.Header.Set("X-Grafana-Referer", req.Header.Get("Referer"))
+
 		// Clear Origin and Referer to avoid CORS issues
 		req.Header.Del("Origin")
 		req.Header.Del("Referer")

--- a/pkg/util/proxyutil/reverse_proxy.go
+++ b/pkg/util/proxyutil/reverse_proxy.go
@@ -76,13 +76,6 @@ func wrapDirector(d func(*http.Request)) func(req *http.Request) {
 
 		d(req)
 		PrepareProxyRequest(req)
-
-		// Set X-Grafana-Referer to correlate access logs to dashboards
-		req.Header.Set("X-Grafana-Referer", req.Header.Get("Referer"))
-
-		// Clear Origin and Referer to avoid CORS issues
-		req.Header.Del("Origin")
-		req.Header.Del("Referer")
 	}
 }
 

--- a/pkg/util/proxyutil/reverse_proxy_test.go
+++ b/pkg/util/proxyutil/reverse_proxy_test.go
@@ -50,6 +50,7 @@ func TestReverseProxy(t *testing.T) {
 		require.Equal(t, "10.0.0.1", actualReq.Header.Get("X-Forwarded-For"))
 		require.Empty(t, actualReq.Header.Get("Origin"))
 		require.Empty(t, actualReq.Header.Get("Referer"))
+		require.Equal(t, "https://test.com/api", actualReq.Header.Get("X-Grafana-Referer"))
 		require.Equal(t, "value", actualReq.Header.Get("X-KEY"))
 		resp := rec.Result()
 		require.Empty(t, resp.Cookies())


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Adds a new header X-Grafana-Referer to requests via the datasource proxy, which captures the contents of the the original Referer header, prior to its deletion.  Under normal circumstances (when called from a dashboard), this header will contain a dashboard name.

**Why do we need this feature?**
There are other suggested use cases in https://github.com/grafana/grafana/discussions/38367

Knowing what dashboard kicked off a query is useful for troubleshooting issues with slow running queries.  Some systems which use the proxy data source (like OpenTSDB) don't provide tracing.  This provides a convenient way to correlate expensive requests with the source dashboard via slow query logs.

E.g. OpenTSDB logs the request headers along with query stats https://github.com/OpenTSDB/opentsdb/blob/ab656051b4bb18d2935b8a4f7c77141503bfb597/src/stats/QueryStats.java#L318

In addition, I have another internal service which relies on the referer header being set to provide a way of automatically throttling dashboards which create a large number of slow requests over a short time frame.  I could perhaps use X-Grafana-User for that, but going by dashboard name alone works for anonymous users too.  It's helpful in situations where a dashboard with a number of expensive queries is shared widely and lots of engineers open the same dashboard with different time ranges.

**Who is this feature for?**
System admins who need to understand performance issues with a database called by the proxy.

**Which issue(s) does this PR fix?**:
Fixes https://github.com/grafana/grafana/discussions/38367

**Special notes for your reviewer**:
Extra context: The Referer header was removed to address https://github.com/grafana/grafana/issues/13949.  That fixed issues for some data sources, but inadvertently caused some issues for services which relied on it.  


