### PR TITLE
Alerting: skip flaky test `RuleEditor recording rules.can create a new cloud recording rule`

### DIFF
--- a/public/app/features/alerting/unified/RuleEditorRecordingRule.test.tsx
+++ b/public/app/features/alerting/unified/RuleEditorRecordingRule.test.tsx
@@ -61,7 +61,7 @@ describe('RuleEditor recording rules', () => {
   });
 
   disableRBAC();
-  it('can create a new cloud recording rule', async () => {
+  it.skip('can create a new cloud recording rule', async () => {
     const dataSources = {
       default: mockDataSource(
         {


### PR DESCRIPTION
The test is failing in the master branch https://drone.grafana.net/grafana/grafana/92300/1/6