### PR TITLE
Navigation: add explore button to new topnav

### DIFF
--- a/public/app/core/components/AppChrome/TopSearchBar.tsx
+++ b/public/app/core/components/AppChrome/TopSearchBar.tsx
@@ -2,10 +2,12 @@ import { css } from '@emotion/css';
 import React from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
+import { locationService } from '@grafana/runtime';
 import { Dropdown, Icon, ToolbarButton, useStyles2 } from '@grafana/ui';
 import { contextSrv } from 'app/core/core';
 import { useSelector } from 'app/types';
 
+import { NavToolbarSeparator } from './NavToolbarSeparator';
 import { NewsContainer } from './News/NewsContainer';
 import { OrganizationSwitcher } from './Organization/OrganizationSwitcher';
 import { QuickAdd } from './QuickAdd/QuickAdd';
@@ -34,6 +36,14 @@ export function TopSearchBar() {
         <TopSearchBarInput />
       </TopSearchBarSection>
       <TopSearchBarSection align="right">
+        <ToolbarButton
+          iconOnly
+          onClick={() => locationService.push(`/explore`)}
+          icon="compass"
+          title="Explore your Data"
+          aria-label="Explore"
+        />
+        <NavToolbarSeparator className={styles.separator} />
         <QuickAdd />
         {helpNode && (
           <Dropdown overlay={() => <TopNavBarMenu node={helpNode} />} placement="bottom-end">
@@ -86,6 +96,11 @@ const getStyles = (theme: GrafanaTheme2) => ({
     },
   }),
   newsButton: css({
+    [theme.breakpoints.down('sm')]: {
+      display: 'none',
+    },
+  }),
+  separator: css({
     [theme.breakpoints.down('sm')]: {
       display: 'none',
     },


### PR DESCRIPTION
**What is this feature?**

Add a button to link to Explore
<img width="1506" alt="Screenshot 2022-12-09 at 02 08 06" src="https://user-images.githubusercontent.com/5741401/206599820-42e35d1e-182a-4243-8552-717b2e28c56e.png">


**Why do we need this feature?**

In the new Nav it requires multiple clicks to start exploring data. With this its a single click to that area.

**Who is this feature for?**

-

**Which issue(s) does this PR fix?**:

-

**Special notes for your reviewer**:

