### PR TITLE
Alerting: Speed up unit and integration tests.

### DIFF
--- a/pkg/services/ngalert/notifier/alertmanager_test.go
+++ b/pkg/services/ngalert/notifier/alertmanager_test.go
@@ -391,9 +391,9 @@ func TestSilenceCleanup(t *testing.T) {
 		// Active now
 		makeSilence("", "tests", dt(now.Add(-5*time.Hour)), dt(now.Add(6*time.Hour)), matchers),
 		// Expiring soon.
-		makeSilence("", "tests", dt(now.Add(-5*time.Hour)), dt(now.Add(5*time.Second)), matchers),
-		// Expiring *very* soon
 		makeSilence("", "tests", dt(now.Add(-5*time.Hour)), dt(now.Add(2*time.Second)), matchers),
+		// Expiring *very* soon
+		makeSilence("", "tests", dt(now.Add(-5*time.Hour)), dt(now.Add(1*time.Second)), matchers),
 	}
 
 	for _, s := range silences {
@@ -407,12 +407,12 @@ func TestSilenceCleanup(t *testing.T) {
 		found, err := am.ListSilences(nil)
 		require.NoError(err)
 		return len(found) == 3
-	}, 3*time.Second, 150*time.Millisecond)
+	}, 3*time.Second, 100*time.Millisecond)
 
 	// Wait again for another silence to expire.
 	require.Eventually(func() bool {
 		found, err := am.ListSilences(nil)
 		require.NoError(err)
 		return len(found) == 2
-	}, 6*time.Second, 150*time.Millisecond)
+	}, 6*time.Second, 100*time.Millisecond)
 }

--- a/pkg/services/ngalert/sender/router_test.go
+++ b/pkg/services/ngalert/sender/router_test.go
@@ -31,7 +31,10 @@ import (
 	"github.com/grafana/grafana/pkg/util"
 )
 
-func TestSendingToExternalAlertmanager(t *testing.T) {
+func TestIntegrationSendingToExternalAlertmanager(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
 	ruleKey := models.GenerateRuleKey(1)
 
 	fakeAM := NewFakeExternalAlertmanager(t)
@@ -97,7 +100,10 @@ func TestSendingToExternalAlertmanager(t *testing.T) {
 	assertAlertmanagersStatusForOrg(t, alertsRouter, ruleKey.OrgID, 0, 0)
 }
 
-func TestSendingToExternalAlertmanager_WithMultipleOrgs(t *testing.T) {
+func TestIntegrationSendingToExternalAlertmanager_WithMultipleOrgs(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
 	ruleKey1 := models.GenerateRuleKey(1)
 	ruleKey2 := models.GenerateRuleKey(2)
 

--- a/pkg/services/ngalert/store/instance_database_test.go
+++ b/pkg/services/ngalert/store/instance_database_test.go
@@ -59,9 +59,9 @@ func TestIntegrationAlertInstanceBulkWrite(t *testing.T) {
 	_, dbstore := tests.SetupTestEnv(t, baseIntervalSeconds)
 
 	orgIDs := []int64{1, 2, 3, 4, 5}
-	counts := []int{20_000, 200, 503, 0, 1256}
-	instances := []models.AlertInstance{}
-	keys := []models.AlertInstanceKey{}
+	counts := []int{10_000, 200, 503, 0, 1256}
+	instances := make([]models.AlertInstance, 0, 10_000+200+503+0+1256)
+	keys := make([]models.AlertInstanceKey, 0, 10_000+200+503+0+1256)
 
 	for i, id := range orgIDs {
 		alertRule := tests.CreateTestAlertRule(t, ctx, dbstore, 60, id)


### PR DESCRIPTION
This change marks tests in the `sender` package that use an external process as integration tests instead of unit tests. This speeds up the package's unit tests by about 20 seconds.

This change also reduces the number of alert instances in the `store` package's bulk write integration test from 20_000 to 10_000. This is still enough to exercise the bulk-write code but speeds up the package tests from about 250s to 130s.

Put together, integration tests are about 90s faster and unit tests are about 20s faster.