### PR TITLE
EntityAPI: disable integration tests

### DIFF
--- a/pkg/services/store/entity/tests/server_integration_test.go
+++ b/pkg/services/store/entity/tests/server_integration_test.go
@@ -119,6 +119,11 @@ func requireVersionMatch(t *testing.T, obj *entity.EntityVersionInfo, m objectVe
 }
 
 func TestIntegrationEntityServer(t *testing.T) {
+	if true {
+		// FIXME
+		t.Skip()
+	}
+
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}


### PR DESCRIPTION
The setup for integration tests is flakey - probably related to https://github.com/grafana/grafana/issues/55223