### PR TITLE
Plugins: Remove connection/hop-by-hop request/response headers for call resource

### DIFF
--- a/pkg/plugins/manager/client/client.go
+++ b/pkg/plugins/manager/client/client.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/textproto"
+	"strings"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 
@@ -82,7 +84,19 @@ func (s *Service) CallResource(ctx context.Context, req *backend.CallResourceReq
 		return backendplugin.ErrPluginNotRegistered
 	}
 	err := instrumentation.InstrumentCallResourceRequest(ctx, &req.PluginContext, s.cfg, func() error {
-		if err := p.CallResource(ctx, req, sender); err != nil {
+		removeConnectionHeaders(req.Headers)
+		removeHopByHopHeaders(req.Headers)
+
+		wrappedSender := callResourceResponseSenderFunc(func(res *backend.CallResourceResponse) error {
+			if res != nil && len(res.Headers) > 0 {
+				removeConnectionHeaders(res.Headers)
+				removeHopByHopHeaders(res.Headers)
+			}
+
+			return sender.Send(res)
+		})
+
+		if err := p.CallResource(ctx, req, wrappedSender); err != nil {
 			return err
 		}
 		return nil
@@ -203,4 +217,74 @@ func (s *Service) plugin(ctx context.Context, pluginID string) (*plugins.Plugin,
 	}
 
 	return p, true
+}
+
+// removeConnectionHeaders removes hop-by-hop headers listed in the "Connection" header of h.
+// See RFC 7230, section 6.1
+//
+// Based on https://cs.opensource.google/go/go/+/refs/tags/go1.19.4:src/net/http/httputil/reverseproxy.go;l=411-421
+func removeConnectionHeaders(h map[string][]string) {
+	for _, f := range h["Connection"] {
+		for _, sf := range strings.Split(f, ",") {
+			if sf = textproto.TrimString(sf); sf != "" {
+				delHeader := ""
+				for k := range h {
+					if textproto.CanonicalMIMEHeaderKey(sf) == textproto.CanonicalMIMEHeaderKey(k) {
+						delHeader = k
+						break
+					}
+				}
+
+				if delHeader != "" {
+					delete(h, delHeader)
+				}
+			}
+		}
+	}
+}
+
+// Hop-by-hop headers. These are removed when sent to the backend.
+// As of RFC 7230, hop-by-hop headers are required to appear in the
+// Connection header field. These are the headers defined by the
+// obsoleted RFC 2616 (section 13.5.1) and are used for backward
+// compatibility.
+//
+// Copied from https://cs.opensource.google/go/go/+/refs/tags/go1.19.4:src/net/http/httputil/reverseproxy.go;l=171-186
+var hopHeaders = []string{
+	"Connection",
+	"Proxy-Connection", // non-standard but still sent by libcurl and rejected by e.g. google
+	"Keep-Alive",
+	"Proxy-Authenticate",
+	"Proxy-Authorization",
+	"Te",      // canonicalized version of "TE"
+	"Trailer", // not Trailers per URL above; https://www.rfc-editor.org/errata_search.php?eid=4522
+	"Transfer-Encoding",
+	"Upgrade",
+}
+
+// removeHopByHopHeaders removes hop-by-hop headers. Especially
+// important is "Connection" because we want a persistent
+// connection, regardless of what the client sent to us.
+//
+// Based on https://cs.opensource.google/go/go/+/refs/tags/go1.19.4:src/net/http/httputil/reverseproxy.go;l=276-281
+func removeHopByHopHeaders(h map[string][]string) {
+	for _, hh := range hopHeaders {
+		delHeader := ""
+		for k := range h {
+			if hh == textproto.CanonicalMIMEHeaderKey(k) {
+				delHeader = k
+				break
+			}
+		}
+
+		if delHeader != "" {
+			delete(h, delHeader)
+		}
+	}
+}
+
+type callResourceResponseSenderFunc func(res *backend.CallResourceResponse) error
+
+func (fn callResourceResponseSenderFunc) Send(res *backend.CallResourceResponse) error {
+	return fn(res)
 }

--- a/pkg/plugins/manager/client/client.go
+++ b/pkg/plugins/manager/client/client.go
@@ -222,21 +222,16 @@ func (s *Service) plugin(ctx context.Context, pluginID string) (*plugins.Plugin,
 // removeConnectionHeaders removes hop-by-hop headers listed in the "Connection" header of h.
 // See RFC 7230, section 6.1
 //
-// Based on https://cs.opensource.google/go/go/+/refs/tags/go1.19.4:src/net/http/httputil/reverseproxy.go;l=411-421
+// Based on https://github.com/golang/go/blob/dc04f3ba1f25313bc9c97e728620206c235db9ee/src/net/http/httputil/reverseproxy.go#L411-L421
 func removeConnectionHeaders(h map[string][]string) {
 	for _, f := range h["Connection"] {
 		for _, sf := range strings.Split(f, ",") {
 			if sf = textproto.TrimString(sf); sf != "" {
-				delHeader := ""
 				for k := range h {
 					if textproto.CanonicalMIMEHeaderKey(sf) == textproto.CanonicalMIMEHeaderKey(k) {
-						delHeader = k
+						delete(h, k)
 						break
 					}
-				}
-
-				if delHeader != "" {
-					delete(h, delHeader)
 				}
 			}
 		}
@@ -249,7 +244,7 @@ func removeConnectionHeaders(h map[string][]string) {
 // obsoleted RFC 2616 (section 13.5.1) and are used for backward
 // compatibility.
 //
-// Copied from https://cs.opensource.google/go/go/+/refs/tags/go1.19.4:src/net/http/httputil/reverseproxy.go;l=171-186
+// Copied from https://github.com/golang/go/blob/dc04f3ba1f25313bc9c97e728620206c235db9ee/src/net/http/httputil/reverseproxy.go#L171-L186
 var hopHeaders = []string{
 	"Connection",
 	"Proxy-Connection", // non-standard but still sent by libcurl and rejected by e.g. google
@@ -266,7 +261,7 @@ var hopHeaders = []string{
 // important is "Connection" because we want a persistent
 // connection, regardless of what the client sent to us.
 //
-// Based on https://cs.opensource.google/go/go/+/refs/tags/go1.19.4:src/net/http/httputil/reverseproxy.go;l=276-281
+// Based on https://github.com/golang/go/blob/dc04f3ba1f25313bc9c97e728620206c235db9ee/src/net/http/httputil/reverseproxy.go#L276-L281
 func removeHopByHopHeaders(h map[string][]string) {
 	for _, hh := range hopHeaders {
 		for k := range h {

--- a/pkg/plugins/manager/client/client.go
+++ b/pkg/plugins/manager/client/client.go
@@ -269,16 +269,11 @@ var hopHeaders = []string{
 // Based on https://cs.opensource.google/go/go/+/refs/tags/go1.19.4:src/net/http/httputil/reverseproxy.go;l=276-281
 func removeHopByHopHeaders(h map[string][]string) {
 	for _, hh := range hopHeaders {
-		delHeader := ""
 		for k := range h {
 			if hh == textproto.CanonicalMIMEHeaderKey(k) {
-				delHeader = k
+				delete(h, k)
 				break
 			}
-		}
-
-		if delHeader != "" {
-			delete(h, delHeader)
 		}
 	}
 }

--- a/pkg/plugins/manager/client/decorator_test.go
+++ b/pkg/plugins/manager/client/decorator_test.go
@@ -220,10 +220,4 @@ func (m *TestMiddleware) RunStream(ctx context.Context, req *backend.RunStreamRe
 	return err
 }
 
-type callResourceResponseSenderFunc func(res *backend.CallResourceResponse) error
-
-func (fn callResourceResponseSenderFunc) Send(res *backend.CallResourceResponse) error {
-	return fn(res)
-}
-
 var _ plugins.Client = &TestClient{}

--- a/pkg/tsdb/prometheus/resource/resource.go
+++ b/pkg/tsdb/prometheus/resource/resource.go
@@ -19,37 +19,6 @@ type Resource struct {
 	log        log.Logger
 }
 
-// Hop-by-hop headers. These are removed when sent to the backend.
-// http://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html
-var hopHeaders = []string{
-	"Connection",
-	"Keep-Alive",
-	"Proxy-Authenticate",
-	"Proxy-Authorization",
-	"Te", // canonicalized version of "TE"
-	"Trailers",
-	"Transfer-Encoding",
-	"Upgrade",
-}
-
-// The following headers will be removed from the request
-var stopHeaders = []string{
-	"cookie",
-	"Cookie",
-}
-
-func delHopHeaders(header http.Header) {
-	for _, h := range hopHeaders {
-		header.Del(h)
-	}
-}
-
-func delStopHeaders(header http.Header) {
-	for _, h := range stopHeaders {
-		header.Del(h)
-	}
-}
-
 func New(
 	httpClient *http.Client,
 	settings backend.DataSourceInstanceSettings,
@@ -68,9 +37,6 @@ func New(
 }
 
 func (r *Resource) Execute(ctx context.Context, req *backend.CallResourceRequest) (*backend.CallResourceResponse, error) {
-	delHopHeaders(req.Headers)
-	delStopHeaders(req.Headers)
-
 	r.log.FromContext(ctx).Debug("Sending resource query", "URL", req.URL)
 	resp, err := r.promClient.QueryResource(ctx, req)
 	if err != nil {


### PR DESCRIPTION
**What is this feature?**
Removes request/response connection/hop headers for call resource in similar manner as Go's reverse proxy functions. Also removes Prometheus datasource custom call resource header manipulation in regards to hop-by-hop headers.

**Why do we need this feature?**
Call resource should remove request/response connection/hop headers in similar manner as Go's reverse proxy functions:
- https://github.com/golang/go/blob/dc04f3ba1f25313bc9c97e728620206c235db9ee/src/net/http/httputil/reverseproxy.go#L274-L281
- https://github.com/golang/go/blob/dc04f3ba1f25313bc9c97e728620206c235db9ee/src/net/http/httputil/reverseproxy.go#L328-L332 

In addition, prometheus deletes "stop" and hop headers for call resource and shouldn't be needed any longer after these changes:
https://github.com/grafana/grafana/blob/3c9ccd45121aeef5cac4ed0e5f1718bb33c436f1/pkg/tsdb/prometheus/resource/resource.go#L71-L72 

**Who is this feature for?**
Plugin platform/developers.

**Which issue(s) does this PR fix?**:
Fixes #60076 
Ref #58646 

**Special notes for your reviewer**:
Prometheus call resource header manipulation removed forwarding of Cookie headers. This is now removed and should be automatically handled by https://github.com/grafana/grafana/blob/main/pkg/services/pluginsintegration/clientmiddleware/cookies_middleware.go
