### PR TITLE
Alerting: Enable editing evaluation interval in alert form when creating a new group

### DIFF
--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -11297,6 +11297,60 @@
         }
       }
     },
+    "BacktestConfig": {
+      "type": "object",
+      "properties": {
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "condition": {
+          "type": "string"
+        },
+        "data": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AlertQuery"
+          }
+        },
+        "for": {
+          "$ref": "#/definitions/Duration"
+        },
+        "from": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "interval": {
+          "$ref": "#/definitions/Duration"
+        },
+        "labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "no_data_state": {
+          "type": "string",
+          "enum": [
+            "Alerting",
+            "NoData",
+            "OK"
+          ]
+        },
+        "title": {
+          "type": "string"
+        },
+        "to": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "BacktestResult": {
+      "$ref": "#/definitions/Frame"
+    },
     "BasicAuth": {
       "type": "object",
       "title": "BasicAuth contains basic HTTP authentication credentials.",

--- a/public/app/features/alerting/unified/RuleEditorGrafanaRules.test.tsx
+++ b/public/app/features/alerting/unified/RuleEditorGrafanaRules.test.tsx
@@ -128,7 +128,7 @@ describe('RuleEditor grafana managed rules', () => {
     await clickSelectOption(folderInput, 'Folder A');
     const groupInput = await ui.inputs.group.find();
     await userEvent.click(byRole('combobox').get(groupInput));
-    await clickSelectOption(groupInput, 'group1 (1m)');
+    await clickSelectOption(groupInput, 'group1');
     await userEvent.type(ui.inputs.annotationValue(1).get(), 'some description');
 
     // TODO remove skipPointerEventsCheck once https://github.com/jsdom/jsdom/issues/3232 is fixed

--- a/public/app/features/alerting/unified/components/rule-editor/AlertRuleForm.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AlertRuleForm.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import React, { FC, useMemo, useState } from 'react';
+import React, { FC, useEffect, useMemo, useState } from 'react';
 import { DeepMap, FieldError, FormProvider, useForm, useFormContext, UseFormWatch } from 'react-hook-form';
 import { Link } from 'react-router-dom';
 
@@ -180,6 +180,8 @@ export const AlertRuleForm: FC<Props> = ({ existing, prefill }) => {
       });
     }
   };
+  const evaluateEveryInForm = watch('evaluateEvery');
+  useEffect(() => setEvaluateEvery(evaluateEveryInForm), [evaluateEveryInForm]);
 
   return (
     <FormProvider {...formAPI}>

--- a/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
@@ -194,6 +194,7 @@ export function FolderAndGroup({ initialFolder }: FolderAndGroupProps) {
               <LoadingPlaceholder text="Loading..." />
             ) : (
               <SelectWithAdd
+                disabled={!folder}
                 key={`my_unique_select_key__${folder?.title ?? ''}`}
                 {...field}
                 options={groupOptions}
@@ -203,7 +204,7 @@ export function FolderAndGroup({ initialFolder }: FolderAndGroupProps) {
                 value={selectedGroup}
                 custom={isAddingGroup}
                 onCustomChange={(custom: boolean) => setIsAddingGroup(custom)}
-                placeholder="Evaluation group name"
+                placeholder={isAddingGroup ? 'New evaluation group name' : 'Evaluation group name'}
                 onChange={(value: string) => {
                   field.onChange(value);
                   setSelectedGroup(value);

--- a/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
@@ -40,8 +40,16 @@ const useGetGroups = (groupfoldersForGrafana: RulerRulesConfigDTO | null | undef
   return groupOptions;
 };
 
-function mapGroupsToOptions(groups: string[]): Array<SelectableValue<string>> {
-  return groups.map((group) => ({ label: group, value: group }));
+function mapGroupsToOptions(
+  groupsForFolder: RulerRulesConfigDTO | null | undefined,
+  groups: string[],
+  folderTitle: string
+): Array<SelectableValue<string>> {
+  return groups.map((group) => ({
+    label: group,
+    value: group,
+    description: `${getIntervalForGroup(groupsForFolder, group, folderTitle)}`,
+  }));
 }
 interface FolderAndGroupProps {
   initialFolder: RuleForm | null;
@@ -52,11 +60,14 @@ export const useGetGroupOptionsFromFolder = (folderTitle: string) => {
 
   const groupfoldersForGrafana = rulerRuleRequests[GRAFANA_RULES_SOURCE_NAME];
 
-  const groupOptions: Array<SelectableValue<string>> = mapGroupsToOptions(
-    useGetGroups(groupfoldersForGrafana?.result, folderTitle)
-  );
   const groupsForFolder = groupfoldersForGrafana?.result;
-  return { groupOptions, groupsForFolder, loading: groupfoldersForGrafana?.loading };
+
+  const groupOptions: Array<SelectableValue<string>> = mapGroupsToOptions(
+    groupsForFolder,
+    useGetGroups(groupfoldersForGrafana?.result, folderTitle),
+    folderTitle
+  );
+  return { groupOptions, loading: groupfoldersForGrafana?.loading };
 };
 
 const useRuleFolderFilter = (existingRuleForm: RuleForm | null) => {
@@ -106,7 +117,7 @@ export function FolderAndGroup({ initialFolder }: FolderAndGroupProps) {
   const [selectedGroup, setSelectedGroup] = useState(group);
   const initialRender = useRef(true);
 
-  const { groupOptions, groupsForFolder, loading } = useGetGroupOptionsFromFolder(folder?.title ?? '');
+  const { groupOptions, loading } = useGetGroupOptionsFromFolder(folder?.title ?? '');
 
   useEffect(() => setSelectedGroup(group), [group, setSelectedGroup]);
 
@@ -198,9 +209,7 @@ export function FolderAndGroup({ initialFolder }: FolderAndGroupProps) {
                 key={`my_unique_select_key__${folder?.title ?? ''}`}
                 {...field}
                 options={groupOptions}
-                getOptionLabel={(option: SelectableValue<string>) =>
-                  `${option.label}  (${getIntervalForGroup(groupsForFolder, option.label ?? '', folder?.title ?? '')})`
-                }
+                getOptionLabel={(option: SelectableValue<string>) => `${option.label}`}
                 value={selectedGroup}
                 custom={isAddingGroup}
                 onCustomChange={(custom: boolean) => setIsAddingGroup(custom)}

--- a/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
@@ -93,6 +93,7 @@ export function FolderAndGroup({ initialFolder }: FolderAndGroupProps) {
     formState: { errors },
     watch,
     control,
+    setValue,
   } = useFormContext<RuleFormValues>();
 
   const styles = useStyles2(getStyles);
@@ -119,6 +120,10 @@ export function FolderAndGroup({ initialFolder }: FolderAndGroupProps) {
     }
     initialRender.current = false;
   }, [group, folder?.title]);
+
+  useEffect(() => {
+    setValue('group', selectedGroup);
+  }, [selectedGroup, setValue]);
 
   const groupIsInGroupOptions = useCallback(
     (group_: string) => {

--- a/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
@@ -92,15 +92,15 @@ export const EvaluateEveryNewGroup = ({ rules }: { rules: RulerRulesConfigDTO | 
       label="Evaluation interval"
       description="Evaluation interval applies to every rule within a group. It can overwrite the interval of an existing alert rule."
     >
-      <Stack direction="row" justify-content="left" align-items="center">
-        <InlineLabel
-          htmlFor={evaluateEveryId}
-          width={16}
-          tooltip="How often the alert will be evaluated to see if it fires"
-        >
-          Evaluate every
-        </InlineLabel>
-        <div className={styles.marginTop}>
+      <div className={styles.alignInterval}>
+        <Stack direction="row" justify-content="left" align-items="baseline">
+          <InlineLabel
+            htmlFor={evaluateEveryId}
+            width={16}
+            tooltip="How often the alert will be evaluated to see if it fires"
+          >
+            Evaluate every
+          </InlineLabel>
           <Field
             className={styles.inlineField}
             error={errors.evaluateEvery?.message}
@@ -116,8 +116,8 @@ export const EvaluateEveryNewGroup = ({ rules }: { rules: RulerRulesConfigDTO | 
               )}
             />
           </Field>
-        </div>
-      </Stack>
+        </Stack>
+      </div>
     </Field>
   );
 };
@@ -346,6 +346,10 @@ const getStyles = (theme: GrafanaTheme2) => ({
   `,
   bold: css`
     font-weight: bold;
+  `,
+  alignInterval: css`
+    margin-top: ${theme.spacing(1)};
+    margin-left: -${theme.spacing(1)};
   `,
   marginTop: css`
     margin-top: ${theme.spacing(1)};

--- a/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
@@ -4,7 +4,7 @@ import { RegisterOptions, useFormContext } from 'react-hook-form';
 
 import { GrafanaTheme2, SelectableValue } from '@grafana/data';
 import { Stack } from '@grafana/experimental';
-import { Button, Card, Field, InlineLabel, Input, InputControl, useStyles2 } from '@grafana/ui';
+import { Button, Field, InlineLabel, Input, InputControl, useStyles2 } from '@grafana/ui';
 import { RulerRuleDTO, RulerRuleGroupDTO, RulerRulesConfigDTO } from 'app/types/unified-alerting-dto';
 
 import { logInfo, LogMessages } from '../../Analytics';
@@ -90,10 +90,10 @@ export const EvaluateEveryNewGroup = ({ rules }: { rules: RulerRulesConfigDTO | 
   return (
     <Field
       label="Evaluation interval"
-      description="Evaluation interval applies to every rule within a group. It can overwrite the interval of an existing alert rule."
+      description="Applies to every rule within a group. It can overwrite the interval of an existing alert rule."
     >
       <div className={styles.alignInterval}>
-        <Stack direction="row" justify-content="left" align-items="baseline">
+        <Stack direction="row" justify-content="left" align-items="baseline" gap={0}>
           <InlineLabel
             htmlFor={evaluateEveryId}
             width={16}
@@ -178,45 +178,42 @@ function FolderGroupAndEvaluationInterval({
         />
       )}
       {folder && group && (
-        <Card className={styles.cardContainer}>
-          <Card.Heading>Evaluation behavior</Card.Heading>
-          <Card.Meta>
+        <div className={styles.evaluationContainer}>
+          <Stack direction="column" gap={0}>
             <div className={styles.marginTop}>
               {isNewGroup && group ? (
                 <EvaluateEveryNewGroup rules={groupfoldersForGrafana?.result} />
               ) : (
-                <Stack direction="column">
+                <Stack direction="column" gap={1}>
                   <div className={styles.evaluateLabel}>
                     {`Alert rules in the `} <span className={styles.bold}>{group}</span> group are evaluated every{' '}
                     <span className={styles.bold}>{evaluateEvery}</span>.
                   </div>
-                  <br />
                   {!isNewGroup && (
                     <div>
                       {`Evaluation group interval applies to every rule within a group. It overwrites intervals defined for existing alert rules.`}
                     </div>
                   )}
-                  <br />
                 </Stack>
               )}
             </div>
-          </Card.Meta>
-          <Card.Actions>
             <Stack direction="row" justify-content="right" align-items="center">
               {!isNewGroup && (
-                <Button
-                  icon={'edit'}
-                  type="button"
-                  variant="secondary"
-                  disabled={editGroupDisabled}
-                  onClick={onOpenEditGroupModal}
-                >
-                  <span>{'Edit evaluation group'}</span>
-                </Button>
+                <div className={styles.marginTop}>
+                  <Button
+                    icon={'edit'}
+                    type="button"
+                    variant="secondary"
+                    disabled={editGroupDisabled}
+                    onClick={onOpenEditGroupModal}
+                  >
+                    <span>{'Edit evaluation group'}</span>
+                  </Button>
+                </div>
               )}
             </Stack>
-          </Card.Actions>
-        </Card>
+          </Stack>
+        </div>
       )}
     </div>
   );
@@ -330,8 +327,11 @@ const getStyles = (theme: GrafanaTheme2) => ({
     align-self: left;
     margin-right: ${theme.spacing(1)};
   `,
-  cardContainer: css`
+  evaluationContainer: css`
+    background-color: ${theme.colors.background.secondary};
+    padding: ${theme.spacing(2)};
     max-width: ${theme.breakpoints.values.sm}px;
+    font-size: ${theme.typography.size.sm};
   `,
   intervalChangedLabel: css`
     margin-bottom: ${theme.spacing(1)};

--- a/public/app/features/alerting/unified/components/rule-editor/SelectWIthAdd.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/SelectWIthAdd.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useMemo, useState } from 'react';
+import React, { FC, useEffect, useMemo, useRef, useState } from 'react';
 
 import { SelectableValue } from '@grafana/data';
 import { Input, Select } from '@grafana/ui';
@@ -43,6 +43,14 @@ export const SelectWithAdd: FC<Props> = ({
     [options, addLabel]
   );
 
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (inputRef.current && isCustom) {
+      inputRef.current.focus();
+    }
+  }, [isCustom]);
+
   if (isCustom) {
     return (
       <Input
@@ -53,6 +61,7 @@ export const SelectWithAdd: FC<Props> = ({
         placeholder={placeholder}
         className={className}
         disabled={disabled}
+        ref={inputRef}
         onChange={(e) => onChange(e.currentTarget.value)}
       />
     );

--- a/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
+++ b/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
@@ -151,7 +151,7 @@ export const RulesForGroupTable = ({
         renderCell: ({ data: { alertName } }) => {
           return <>{alertName}</>;
         },
-        size: 0.6,
+        size: '330px',
       },
       {
         id: 'for',
@@ -174,7 +174,7 @@ export const RulesForGroupTable = ({
             return <>{numberEvaluations}</>;
           }
         },
-        size: 0.2,
+        size: 0.6,
       },
     ];
   }, [currentInterval]);

--- a/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
+++ b/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
@@ -208,6 +208,37 @@ interface FormValues {
   groupInterval: string;
 }
 
+export const evaluateEveryValidationOptions = (
+  rules: RulerRulesConfigDTO | null | undefined,
+  groupName: string,
+  nameSpaceName: string
+): RegisterOptions => ({
+  required: {
+    value: true,
+    message: 'Required.',
+  },
+  validate: (value: string) => {
+    try {
+      const duration = parsePrometheusDuration(value);
+
+      if (duration < MIN_TIME_RANGE_STEP_S * 1000) {
+        return `Cannot be less than ${MIN_TIME_RANGE_STEP_S} seconds.`;
+      }
+
+      if (duration % (MIN_TIME_RANGE_STEP_S * 1000) !== 0) {
+        return `Must be a multiple of ${MIN_TIME_RANGE_STEP_S} seconds.`;
+      }
+      if (rulesInSameGroupHaveInvalidFor(rules, groupName, nameSpaceName, value).length === 0) {
+        return true;
+      } else {
+        return `Invalid evaluation interval. Evaluation interval should be smaller or equal to 'For' values for existing rules in this group.`;
+      }
+    } catch (error) {
+      return error instanceof Error ? error.message : 'Failed to parse duration';
+    }
+  },
+});
+
 export function EditCloudGroupModal(props: ModalProps): React.ReactElement {
   const {
     nameSpaceAndGroup: { namespace, group },
@@ -285,35 +316,6 @@ export function EditCloudGroupModal(props: ModalProps): React.ReactElement {
   const rulerRuleRequests = useUnifiedAlertingSelector((state) => state.rulerRules);
   const groupfoldersForSource = rulerRuleRequests[sourceName];
 
-  const evaluateEveryValidationOptions: RegisterOptions = {
-    required: {
-      value: true,
-      message: 'Required.',
-    },
-    validate: (value: string) => {
-      try {
-        const duration = parsePrometheusDuration(value);
-
-        if (duration < MIN_TIME_RANGE_STEP_S * 1000) {
-          return `Cannot be less than ${MIN_TIME_RANGE_STEP_S} seconds.`;
-        }
-
-        if (duration % (MIN_TIME_RANGE_STEP_S * 1000) !== 0) {
-          return `Must be a multiple of ${MIN_TIME_RANGE_STEP_S} seconds.`;
-        }
-        if (
-          rulesInSameGroupHaveInvalidFor(groupfoldersForSource.result, groupName, nameSpaceName, value).length === 0
-        ) {
-          return true;
-        } else {
-          return `Invalid evaluation interval. Evaluation interval should be smaller or equal to 'For' values for existing rules in this group.`;
-        }
-      } catch (error) {
-        return error instanceof Error ? error.message : 'Failed to parse duration';
-      }
-    },
-  };
-
   return (
     <Modal
       className={styles.modal}
@@ -387,7 +389,10 @@ export function EditCloudGroupModal(props: ModalProps): React.ReactElement {
               <Input
                 id="groupInterval"
                 placeholder="1m"
-                {...register('groupInterval', evaluateEveryValidationOptions)}
+                {...register(
+                  'groupInterval',
+                  evaluateEveryValidationOptions(groupfoldersForSource?.result, groupName, nameSpaceName)
+                )}
               />
             </Field>
 

--- a/public/app/features/alerting/unified/types/rule-form.ts
+++ b/public/app/features/alerting/unified/types/rule-form.ts
@@ -27,6 +27,7 @@ export interface RuleFormValues {
   noDataState: GrafanaAlertStateDecision;
   execErrState: GrafanaAlertStateDecision;
   folder: RuleForm | null;
+  evaluateEvery: string;
   evaluateFor: string;
 
   // cortex / loki rules

--- a/public/app/features/alerting/unified/utils/rule-form.ts
+++ b/public/app/features/alerting/unified/utils/rule-form.ts
@@ -29,6 +29,7 @@ import {
 } from 'app/types/unified-alerting-dto';
 
 import { EvalFunction } from '../../state/alertDef';
+import { MINUTE } from '../components/rule-editor/AlertRuleForm';
 import { RuleFormType, RuleFormValues } from '../types/rule-form';
 
 import { getRulesAccess } from './access-control';
@@ -60,6 +61,7 @@ export const getDefaultFormValues = (): RuleFormValues => {
     noDataState: GrafanaAlertStateDecision.NoData,
     execErrState: GrafanaAlertStateDecision.Error,
     evaluateFor: '5m',
+    evaluateEvery: MINUTE,
 
     // cortex / loki
     namespace: '',
@@ -124,6 +126,7 @@ export function rulerRuleToFormValues(ruleWithLocation: RuleWithLocation): RuleF
         name: ga.title,
         type: RuleFormType.grafana,
         group: group.name,
+        evaluateEvery: group.interval || defaultFormValues.evaluateEvery,
         evaluateFor: rule.for || '0',
         noDataState: ga.no_data_state,
         execErrState: ga.exec_err_state,


### PR DESCRIPTION
**What is this feature?**

This feature allows user to edit evaluation interval when editing an alert rule with a new group.

**Why do we need this feature?**

Users need to edit the interval when creating a new group for the alert. So far, users need to save the alert and group before editing this new value. We want to reduce the number of required steps for being for editing this interval value.

**Who is this feature for?**

Users that create and edit alert rules.

Fixes [#381](https://github.com/grafana/alerting-squad/issues/381)

**Special notes for your reviewer**:

https://user-images.githubusercontent.com/33540275/207647777-cb6230f6-5405-4b3f-bfff-04e85d226525.mp4

**Second commit adds the following:**

- disables group when no folder selected yet
- focus on group when clicking add new option
- change placeholder when adding new group


https://user-images.githubusercontent.com/33540275/206756692-5d2307f4-9dc7-4caf-ba5b-162287970c61.mp4

**Third commit changes the group drop-down:** 

<img width="436" alt="Screenshot 2022-12-14 at 11 40 30" src="https://user-images.githubusercontent.com/33540275/207576064-9240aefd-7561-4a29-9cc5-f4029a9003fb.png">

**And last commit fix alignment in interval input:** 
<img width="642" alt="Screenshot 2022-12-14 at 13 12 46" src="https://user-images.githubusercontent.com/33540275/207594169-cb97b60c-15ad-4ca1-987d-c72104da7acb.png">





