### PR TITLE
Influx: Query segment menus now position correctly near the bottom of the screen

### DIFF
--- a/public/app/plugins/datasource/influxdb/components/VisualInfluxQLEditor/Seg.tsx
+++ b/public/app/plugins/datasource/influxdb/components/VisualInfluxQLEditor/Seg.tsx
@@ -111,7 +111,7 @@ const SelSingleLoad = ({ loadOptions, allowCustomValue, onChange, onClose }: Sel
         isLoading={loadState.loading}
         formatCreateLabel={formatCreateLabel}
         autoFocus
-        isOpen
+        isOpen={Boolean(loadState.value)}
         onCloseMenu={onClose}
         allowCustomValue={allowCustomValue}
         options={loadState.value ?? []}

--- a/public/app/plugins/datasource/influxdb/components/VisualInfluxQLEditor/Seg.tsx
+++ b/public/app/plugins/datasource/influxdb/components/VisualInfluxQLEditor/Seg.tsx
@@ -111,7 +111,7 @@ const SelSingleLoad = ({ loadOptions, allowCustomValue, onChange, onClose }: Sel
         isLoading={loadState.loading}
         formatCreateLabel={formatCreateLabel}
         autoFocus
-        isOpen={Boolean(loadState.value)}
+        isOpen={!loadState.loading}
         onCloseMenu={onClose}
         allowCustomValue={allowCustomValue}
         options={loadState.value ?? []}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- only open the `Select` menu once options have loaded
- this allows the `Select` menu to calculate where to position itself correctly

https://user-images.githubusercontent.com/20999846/206698002-1df0aadc-8e5c-4aff-af19-cc97e3492ab9.mp4

**Why do we need this feature?**

- prevent menu overflowing the screen when positioned near the bottom

**Who is this feature for?**

- anyone using influx!

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/59676
Fixes https://github.com/grafana/grafana/issues/44319
Fixes https://github.com/grafana/grafana/issues/43239

**Special notes for your reviewer**:

[For context](https://github.com/grafana/grafana/issues/44319#issuecomment-1026917933):

> it looks like the select menu doesn't correctly calculate the position when you default `isOpen` to true. i'm guessing because the options are populated asynchronously? i think it positions the menu based on the initial content (which is basically nothing). so on first render, the content is empty. then the options get populated and the menu grows. if you change [this line](https://github.com/grafana/grafana/blob/main/public/app/plugins/datasource/influxdb/components/VisualInfluxQLEditor/Seg.tsx#L114) to something like `isOpen={!loadState.loading}`, it positions correctly.
>
> that might be a good enough fix, or you might want the select menu to be open all the time. if that's the case, you'll probably need to trigger a rerender of the select component somehow. 
