### PR TITLE
Loki: Fix tracking of `queries_with_changed_line_limit_count`

### DIFF
--- a/public/app/plugins/datasource/loki/module.test.ts
+++ b/public/app/plugins/datasource/loki/module.test.ts
@@ -81,7 +81,7 @@ describe('queriesOnInitDashboard', () => {
       metric_queries_count: 3,
       queries_count: 5,
       queries_with_changed_legend_count: 3,
-      queries_with_changed_line_limit_count: 5,
+      queries_with_changed_line_limit_count: 2,
       queries_with_changed_resolution_count: 0,
       queries_with_template_variables_count: 2,
       range_queries_count: 4,

--- a/public/app/plugins/datasource/loki/tracking.ts
+++ b/public/app/plugins/datasource/loki/tracking.ts
@@ -107,7 +107,7 @@ const isQueryWithChangedResolution = (query: LokiQuery): boolean => {
 };
 
 const isQueryWithChangedLineLimit = (query: LokiQuery): boolean => {
-  return query.maxLines !== null || query.maxLines !== undefined;
+  return query.maxLines !== null && query.maxLines !== undefined;
 };
 
 const isQueryWithChangedLegend = (query: LokiQuery): boolean => {


### PR DESCRIPTION
**What is this feature?**

Fixed the statement which determines if a `lineLimit` was changed. Previously it was falsely resolving to `true` everytime.

