### PR TITLE
Dashboards: Show error when data source is missing

### DIFF
--- a/packages/grafana-runtime/src/utils/toDataQueryError.ts
+++ b/packages/grafana-runtime/src/utils/toDataQueryError.ts
@@ -6,7 +6,7 @@ import { DataQueryError } from '@grafana/data';
  *
  * @public
  */
-export function toDataQueryError(err: DataQueryError | string | Object): DataQueryError {
+export function toDataQueryError(err: DataQueryError | string | unknown): DataQueryError {
   const error = (err || {}) as DataQueryError;
 
   if (!error.message) {

--- a/public/app/features/query/state/PanelQueryRunner.ts
+++ b/public/app/features/query/state/PanelQueryRunner.ts
@@ -25,7 +25,7 @@ import {
   toDataFrame,
   transformDataFrame,
 } from '@grafana/data';
-import { getTemplateSrv } from '@grafana/runtime';
+import { getTemplateSrv, toDataQueryError } from '@grafana/runtime';
 import { ExpressionDatasourceRef } from '@grafana/runtime/src/utils/DataSourceWithBackend';
 import { StreamingDataFrame } from 'app/features/live/data/StreamingDataFrame';
 import { isStreamingDataFrame } from 'app/features/live/data/utils';
@@ -276,7 +276,15 @@ export class PanelQueryRunner {
 
       this.pipeToSubject(runRequest(ds, request), panelId);
     } catch (err) {
-      console.error('PanelQueryRunner Error', err);
+      this.pipeToSubject(
+        of({
+          state: LoadingState.Error,
+          error: toDataQueryError(err),
+          series: [],
+          timeRange: request.range,
+        }),
+        panelId
+      );
     }
   }
 


### PR DESCRIPTION
**What is this feature?**

Shows an error on panels when the data source is missing.

The error was already being caught, but it was just ignored. This just pipes it through to the observable so it can be shown to the user.

![image](https://user-images.githubusercontent.com/46142/206735195-49ff9bfc-1e0a-4c5f-a19e-521e6e49de13.png)


Fixes #60088

You can test this by importing the dashboard from https://github.com/grafana/grafana/issues/60088