### PR TITLE
Alerting: Create alertmanager config history table

### DIFF
--- a/pkg/services/sqlstore/migrations/ualert/tables.go
+++ b/pkg/services/sqlstore/migrations/ualert/tables.go
@@ -33,6 +33,8 @@ func AddTablesMigrations(mg *migrator.Migrator) {
 	AddProvisioningMigrations(mg)
 
 	AddAlertImageMigrations(mg)
+
+	AddAlertmanagerConfigHistoryMigrations(mg)
 }
 
 // AddAlertDefinitionMigrations should not be modified.
@@ -343,6 +345,26 @@ func AddAlertmanagerConfigMigrations(mg *migrator.Migrator) {
 	mg.AddMigration("add configuration_hash column to alert_configuration", migrator.NewAddColumnMigration(alertConfiguration, &migrator.Column{
 		Name: "configuration_hash", Type: migrator.DB_Varchar, Nullable: false, Default: "'not-yet-calculated'", Length: 32,
 	}))
+}
+
+func AddAlertmanagerConfigHistoryMigrations(mg *migrator.Migrator) {
+	alertConfigHistory := migrator.Table{
+		Name: "alert_configuration_history",
+		Columns: []*migrator.Column{
+			{Name: "id", Type: migrator.DB_BigInt, IsPrimaryKey: true, IsAutoIncrement: true},
+			{Name: "org_id", Type: migrator.DB_BigInt, Nullable: false, Default: "0"},
+			{Name: "alertmanager_configuration", Type: migrator.DB_MediumText, Nullable: false},
+			{Name: "configuration_hash", Type: migrator.DB_Varchar, Nullable: false, Default: "'not-yet-calculated'", Length: 32},
+			{Name: "configuration_version", Type: migrator.DB_NVarchar, Length: 3}, // In a format of vXX e.g. v1, v2, v10, etc
+			{Name: "created_at", Type: migrator.DB_Int, Nullable: false},
+			{Name: "default", Type: migrator.DB_Bool, Nullable: false, Default: "0"},
+		},
+		Indices: []*migrator.Index{
+			{Cols: []string{"org_id"}},
+		},
+	}
+
+	mg.AddMigration("create_alert_configuration_history_table", migrator.NewAddTableMigration(alertConfigHistory))
 }
 
 func AddAlertAdminConfigMigrations(mg *migrator.Migrator) {


### PR DESCRIPTION
**What is this feature?**

This PR adds a new table for alertmanager config history. The table will be empty going forward, we just add it.

**Why do we need this feature?**

This is the first step in https://github.com/grafana/grafana/issues/60053

**Which issue(s) does this PR fix?**:

Contributes to https://github.com/grafana/grafana/issues/60053

**Special notes for your reviewer**:

