### PR TITLE
Prometheus: Create feature flag to disable exemplar sampling

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -19,16 +19,17 @@ This page contains a list of available feature toggles. To learn how to turn on 
 
 Some stable features are enabled by default. You can disable a stable feature by setting the feature flag to "false" in the configuration.
 
-| Feature toggle name          | Description                                                                          | Enabled by default |
-| ---------------------------- | ------------------------------------------------------------------------------------ | ------------------ |
-| `disableEnvelopeEncryption`  | Disable envelope encryption (emergency only)                                         |                    |
-| `database_metrics`           | Add Prometheus metrics for database tables                                           |                    |
-| `lokiMonacoEditor`           | Access to Monaco query editor for Loki                                               | Yes                |
-| `featureHighlights`          | Highlight Grafana Enterprise features                                                |                    |
-| `commandPalette`             | Enable command palette                                                               | Yes                |
-| `cloudWatchDynamicLabels`    | Use dynamic labels instead of alias patterns in CloudWatch datasource                | Yes                |
-| `internationalization`       | Enables internationalization                                                         | Yes                |
-| `accessTokenExpirationCheck` | Enable OAuth access_token expiration check and token refresh using the refresh_token |                    |
+| Feature toggle name                 | Description                                                                          | Enabled by default |
+| ----------------------------------- | ------------------------------------------------------------------------------------ | ------------------ |
+| `disableEnvelopeEncryption`         | Disable envelope encryption (emergency only)                                         |                    |
+| `database_metrics`                  | Add Prometheus metrics for database tables                                           |                    |
+| `lokiMonacoEditor`                  | Access to Monaco query editor for Loki                                               | Yes                |
+| `featureHighlights`                 | Highlight Grafana Enterprise features                                                |                    |
+| `commandPalette`                    | Enable command palette                                                               | Yes                |
+| `cloudWatchDynamicLabels`           | Use dynamic labels instead of alias patterns in CloudWatch datasource                | Yes                |
+| `internationalization`              | Enables internationalization                                                         | Yes                |
+| `accessTokenExpirationCheck`        | Enable OAuth access_token expiration check and token refresh using the refresh_token |                    |
+| `disablePrometheusExemplarSampling` | Disable Prometheus examplar sampling                                                 |                    |
 
 ## Beta feature toggles
 

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -84,5 +84,6 @@ export interface FeatureToggles {
   secureSocksDatasourceProxy?: boolean;
   authnService?: boolean;
   sessionRemoteCache?: boolean;
+  disablePrometheusExemplarSampling?: boolean;
   alertingBacktesting?: boolean;
 }

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -383,6 +383,11 @@ var (
 			State:       FeatureStateAlpha,
 		},
 		{
+			Name:        "disablePrometheusExemplarSampling",
+			Description: "Disable Prometheus examplar sampling",
+			State:       FeatureStateStable,
+		},
+		{
 			Name:        "alertingBacktesting",
 			Description: "Rule backtesting API for alerting",
 			State:       FeatureStateAlpha,

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -279,6 +279,10 @@ const (
 	// Enable using remote cache for user sessions
 	FlagSessionRemoteCache = "sessionRemoteCache"
 
+	// FlagDisablePrometheusExemplarSampling
+	// Disable Prometheus examplar sampling
+	FlagDisablePrometheusExemplarSampling = "disablePrometheusExemplarSampling"
+
 	// FlagAlertingBacktesting
 	// Rule backtesting API for alerting
 	FlagAlertingBacktesting = "alertingBacktesting"

--- a/pkg/tsdb/prometheus/querydata/request.go
+++ b/pkg/tsdb/prometheus/querydata/request.go
@@ -34,14 +34,15 @@ type ExemplarEvent struct {
 // QueryData handles querying but different from buffered package uses a custom client instead of default Go Prom
 // client.
 type QueryData struct {
-	intervalCalculator intervalv2.Calculator
-	tracer             tracing.Tracer
-	client             *client.Client
-	log                log.Logger
-	ID                 int64
-	URL                string
-	TimeInterval       string
-	enableWideSeries   bool
+	intervalCalculator                intervalv2.Calculator
+	tracer                            tracing.Tracer
+	client                            *client.Client
+	log                               log.Logger
+	ID                                int64
+	URL                               string
+	TimeInterval                      string
+	enableWideSeries                  bool
+	disablePrometheusExemplarSampling bool
 }
 
 func New(
@@ -65,14 +66,15 @@ func New(
 	promClient := client.NewClient(httpClient, httpMethod, settings.URL)
 
 	return &QueryData{
-		intervalCalculator: intervalv2.NewCalculator(),
-		tracer:             tracer,
-		log:                plog,
-		client:             promClient,
-		TimeInterval:       timeInterval,
-		ID:                 settings.ID,
-		URL:                settings.URL,
-		enableWideSeries:   features.IsEnabled(featuremgmt.FlagPrometheusWideSeries),
+		intervalCalculator:                intervalv2.NewCalculator(),
+		tracer:                            tracer,
+		log:                               plog,
+		client:                            promClient,
+		TimeInterval:                      timeInterval,
+		ID:                                settings.ID,
+		URL:                               settings.URL,
+		enableWideSeries:                  features.IsEnabled(featuremgmt.FlagPrometheusWideSeries),
+		disablePrometheusExemplarSampling: features.IsEnabled(featuremgmt.FlagDisablePrometheusExemplarSampling),
 	}, nil
 }
 

--- a/pkg/tsdb/prometheus/querydata/response.go
+++ b/pkg/tsdb/prometheus/querydata/response.go
@@ -41,7 +41,7 @@ func (s *QueryData) parseResponse(ctx context.Context, q *models.Query, res *htt
 		}
 	}
 
-	r = processExemplars(q, r)
+	r = processExemplars(q, r, s.disablePrometheusExemplarSampling)
 	return r, nil
 }
 
@@ -136,8 +136,8 @@ func getName(q *models.Query, field *data.Field) string {
 	return legend
 }
 
-func processExemplars(q *models.Query, dr *backend.DataResponse) *backend.DataResponse {
-	sampler := newExemplarSampler()
+func processExemplars(q *models.Query, dr *backend.DataResponse, disableSampling bool) *backend.DataResponse {
+	sampler := newExemplarSampler(disableSampling)
 
 	// we are moving from a multi-frame response returned
 	// by the converter to a single exemplar frame,


### PR DESCRIPTION
**What is this feature?**

It creates a feature flag to disable sampling of Prometheus's exemplars

**Why do we need this feature?**

It can be useful for debugging purpose to be able to see the full set of exemplars

**Who is this feature for?**

Developers

**Which issue(s) does this PR fix?**:

Fixes #59831

**Special notes for your reviewer**:

Should we only allow this feature flag on dev ?


Default (sampling on)
![Screenshot from 2022-12-09 16-50-44](https://user-images.githubusercontent.com/9373203/206740836-54c9a2de-7e67-4f64-930c-14460d20c48d.png)


With feature flag enable (no sampling)
![Screenshot from 2022-12-09 16-50-05](https://user-images.githubusercontent.com/9373203/206740735-0182cfd3-b5aa-48db-ba4a-549d7dfa1ae4.png)

