### PR TITLE
Remove packages path from branch filter

### DIFF
--- a/.github/workflows/publish-technical-documentation-next.yml
+++ b/.github/workflows/publish-technical-documentation-next.yml
@@ -6,7 +6,6 @@ on:
       - "main"
     paths:
       - "docs/sources/**"
-      - "packages/grafana-*/**"
   workflow_dispatch:
 jobs:
   sync:

--- a/.github/workflows/publish-technical-documentation-release.yml
+++ b/.github/workflows/publish-technical-documentation-release.yml
@@ -8,7 +8,6 @@ on:
       - v[0-9]+.[0-9]+.[0-9]+
     paths:
       - "docs/sources/**"
-      - "packages/grafana-*/**"
   workflow_dispatch:
 jobs:
   sync:


### PR DESCRIPTION
That directory is no longer used in published docs and causes this workflow to fail when changes only affect the packages directory.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>

