### PR TITLE
Graphite: bug fix, strip white space from queries before comparing them

### DIFF
--- a/public/app/plugins/datasource/graphite/state/helpers.ts
+++ b/public/app/plugins/datasource/graphite/state/helpers.ts
@@ -158,7 +158,7 @@ export function handleTargetChanged(state: GraphiteQueryEditorState): void {
     return;
   }
 
-  const oldTarget = state.queryModel.target.target;
+  let oldTarget = state.queryModel.target.target;
   // Interpolate from other queries:
   // Because of mixed data sources the list may contain queries for non-Graphite data sources. To ensure a valid query
   // is used for interpolation we should check required properties are passed though in theory it allows to interpolate
@@ -167,7 +167,11 @@ export function handleTargetChanged(state: GraphiteQueryEditorState): void {
     (state.queries || []).filter((query) => 'target' in query && typeof (query as GraphiteQuery).target === 'string')
   );
 
-  if (state.queryModel.target.target !== oldTarget && !state.paused) {
+  // remove spaces from old and new targets
+  const newTarget = state.queryModel.target.target.replace(/\s+/g, '');
+  oldTarget = oldTarget.replace(/\s+/g, '');
+
+  if (newTarget !== oldTarget && !state.paused) {
     state.refresh();
   }
 }


### PR DESCRIPTION
Fixes https://github.com/grafana/support-escalations/issues/4478

When comparing an old query to a new query after the "queries-changed" action has occured, Graphite compares queries with whitespaces.

`keepLastvalue(series,3) !== keepLastValue(series, 3)`

This became a problem when creating an alert with graphite, starting with the graphite query text editor using a function that takes two arguments, creating an expression with a classic condition for the alert, toggling graphite to the builder mode, and then changing the expression. [See this discussion for more details](https://github.com/grafana/support-escalations/issues/4478#issuecomment-1344894676). A function written without a space in the text editor is rendered with a space in the builder. 

When queries are changed the functions are rendered again for the query builder
https://github.com/grafana/grafana/blob/1149ddd506b65f2ee7e212642e608565c009ae25/public/app/plugins/datasource/graphite/graphite_query.ts#L186-L189

and the render is just above here
https://github.com/grafana/grafana/blob/1149ddd506b65f2ee7e212642e608565c009ae25/public/app/plugins/datasource/graphite/graphite_query.ts#L181

in the function renderer the space is added
https://github.com/grafana/grafana/blob/ca3c4bb50f96a5b1fc8e88109fd0bab9c6930cb6/public/app/plugins/datasource/graphite/gfunc.ts#L1061

Then, since `keepLastvalue(series,3) !== keepLastValue(series, 3)` evaluates to false, the graphite query editor refreshes until it breaks. https://github.com/grafana/grafana/blob/ca3c4bb50f96a5b1fc8e88109fd0bab9c6930cb6/public/app/plugins/datasource/graphite/state/helpers.ts#L170-L172

Therefore, this fix compares the old and new queries without the space.