### PR TITLE
Alerting: Add For error feature in UI and Backend

### DIFF
--- a/pkg/services/ngalert/api/api_ruler.go
+++ b/pkg/services/ngalert/api/api_ruler.go
@@ -486,8 +486,10 @@ func toGettableExtendedRuleNode(r ngmodels.AlertRule, namespaceID int64, provena
 		},
 	}
 	forDuration := model.Duration(r.For)
+	forErrorDuration := model.Duration(r.ForError)
 	gettableExtendedRuleNode.ApiRuleNode = &apimodels.ApiRuleNode{
 		For:         &forDuration,
+		ForError:    &forErrorDuration,
 		Annotations: r.Annotations,
 		Labels:      r.Labels,
 	}

--- a/pkg/services/ngalert/api/api_ruler.go
+++ b/pkg/services/ngalert/api/api_ruler.go
@@ -465,6 +465,7 @@ func toGettableExtendedRuleNode(r ngmodels.AlertRule, namespaceID int64, provena
 	if prov, exists := provenanceRecords[r.ResourceID()]; exists {
 		provenance = prov
 	}
+	forErrorDuration := model.Duration(r.ForError)
 	gettableExtendedRuleNode := apimodels.GettableExtendedRuleNode{
 		GrafanaManagedAlert: &apimodels.GettableGrafanaRule{
 			ID:              r.ID,
@@ -481,15 +482,14 @@ func toGettableExtendedRuleNode(r ngmodels.AlertRule, namespaceID int64, provena
 			RuleGroup:       r.RuleGroup,
 			NoDataState:     apimodels.NoDataState(r.NoDataState),
 			ExecErrState:    apimodels.ExecutionErrorState(r.ExecErrState),
+			ForError:        &forErrorDuration,
 			Provenance:      provenance,
 			IsPaused:        r.IsPaused,
 		},
 	}
 	forDuration := model.Duration(r.For)
-	forErrorDuration := model.Duration(r.ForError)
 	gettableExtendedRuleNode.ApiRuleNode = &apimodels.ApiRuleNode{
 		For:         &forDuration,
-		ForError:    &forErrorDuration,
 		Annotations: r.Annotations,
 		Labels:      r.Labels,
 	}

--- a/pkg/services/ngalert/api/api_ruler_validation_test.go
+++ b/pkg/services/ngalert/api/api_ruler_validation_test.go
@@ -46,8 +46,7 @@ func validRule() apimodels.PostableExtendedRuleNode {
 	forErrorDuration := model.Duration(rand.Int63n(2000))
 	return apimodels.PostableExtendedRuleNode{
 		ApiRuleNode: &apimodels.ApiRuleNode{
-			For:      &forDuration,
-			ForError: &forErrorDuration,
+			For: &forDuration,
 			Labels: map[string]string{
 				"test-label": "data",
 			},
@@ -73,6 +72,7 @@ func validRule() apimodels.PostableExtendedRuleNode {
 			UID:          util.GenerateShortUID(),
 			NoDataState:  allNoData[rand.Intn(len(allNoData))],
 			ExecErrState: allExecError[rand.Intn(len(allExecError))],
+			ForError:     &forErrorDuration,
 		},
 	}
 }
@@ -262,7 +262,7 @@ func TestValidateRuleNode_NoUID(t *testing.T) {
 				require.Equal(t, models.NoDataState(api.GrafanaManagedAlert.NoDataState), alert.NoDataState)
 				require.Equal(t, models.ExecutionErrorState(api.GrafanaManagedAlert.ExecErrState), alert.ExecErrState)
 				require.Equal(t, time.Duration(*api.ApiRuleNode.For), alert.For)
-				require.Equal(t, time.Duration(*api.ApiRuleNode.ForError), alert.ForError)
+				require.Equal(t, time.Duration(*api.GrafanaManagedAlert.ForError), alert.ForError)
 				require.Equal(t, api.ApiRuleNode.Annotations, alert.Annotations)
 				require.Equal(t, api.ApiRuleNode.Labels, alert.Labels)
 			},
@@ -276,7 +276,6 @@ func TestValidateRuleNode_NoUID(t *testing.T) {
 			},
 			assert: func(t *testing.T, api *apimodels.PostableExtendedRuleNode, alert *models.AlertRule) {
 				require.Equal(t, time.Duration(0), alert.For)
-				require.Equal(t, time.Duration(0), alert.ForError)
 				require.Nil(t, alert.Annotations)
 				require.Nil(t, alert.Labels)
 			},

--- a/pkg/services/ngalert/api/api_ruler_validation_test.go
+++ b/pkg/services/ngalert/api/api_ruler_validation_test.go
@@ -43,9 +43,11 @@ func config(t *testing.T) *setting.UnifiedAlertingSettings {
 
 func validRule() apimodels.PostableExtendedRuleNode {
 	forDuration := model.Duration(rand.Int63n(1000))
+	forErrorDuration := model.Duration(rand.Int63n(2000))
 	return apimodels.PostableExtendedRuleNode{
 		ApiRuleNode: &apimodels.ApiRuleNode{
-			For: &forDuration,
+			For:      &forDuration,
+			ForError: &forErrorDuration,
 			Labels: map[string]string{
 				"test-label": "data",
 			},
@@ -260,6 +262,7 @@ func TestValidateRuleNode_NoUID(t *testing.T) {
 				require.Equal(t, models.NoDataState(api.GrafanaManagedAlert.NoDataState), alert.NoDataState)
 				require.Equal(t, models.ExecutionErrorState(api.GrafanaManagedAlert.ExecErrState), alert.ExecErrState)
 				require.Equal(t, time.Duration(*api.ApiRuleNode.For), alert.For)
+				require.Equal(t, time.Duration(*api.ApiRuleNode.ForError), alert.ForError)
 				require.Equal(t, api.ApiRuleNode.Annotations, alert.Annotations)
 				require.Equal(t, api.ApiRuleNode.Labels, alert.Labels)
 			},
@@ -273,6 +276,7 @@ func TestValidateRuleNode_NoUID(t *testing.T) {
 			},
 			assert: func(t *testing.T, api *apimodels.PostableExtendedRuleNode, alert *models.AlertRule) {
 				require.Equal(t, time.Duration(0), alert.For)
+				require.Equal(t, time.Duration(0), alert.ForError)
 				require.Nil(t, alert.Annotations)
 				require.Nil(t, alert.Labels)
 			},

--- a/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
+++ b/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
@@ -264,6 +264,7 @@ type ApiRuleNode struct {
 	Alert       string            `yaml:"alert,omitempty" json:"alert,omitempty"`
 	Expr        string            `yaml:"expr" json:"expr"`
 	For         *model.Duration   `yaml:"for,omitempty" json:"for,omitempty"`
+	ForError    *model.Duration   `yaml:"for_error,omitempty" json:"for_error,omitempty"`
 	Labels      map[string]string `yaml:"labels,omitempty" json:"labels,omitempty"`
 	Annotations map[string]string `yaml:"annotations,omitempty" json:"annotations,omitempty"`
 }

--- a/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
+++ b/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
@@ -264,7 +264,6 @@ type ApiRuleNode struct {
 	Alert       string            `yaml:"alert,omitempty" json:"alert,omitempty"`
 	Expr        string            `yaml:"expr" json:"expr"`
 	For         *model.Duration   `yaml:"for,omitempty" json:"for,omitempty"`
-	ForError    *model.Duration   `yaml:"for_error,omitempty" json:"for_error,omitempty"`
 	Labels      map[string]string `yaml:"labels,omitempty" json:"labels,omitempty"`
 	Annotations map[string]string `yaml:"annotations,omitempty" json:"annotations,omitempty"`
 }
@@ -375,6 +374,7 @@ type PostableGrafanaRule struct {
 	UID          string              `json:"uid" yaml:"uid"`
 	NoDataState  NoDataState         `json:"no_data_state" yaml:"no_data_state"`
 	ExecErrState ExecutionErrorState `json:"exec_err_state" yaml:"exec_err_state"`
+	ForError     *model.Duration     `json:"for_error" yaml:"for_error"`
 	IsPaused     *bool               `json:"is_paused" yaml:"is_paused"`
 }
 
@@ -393,6 +393,7 @@ type GettableGrafanaRule struct {
 	NamespaceID     int64               `json:"namespace_id" yaml:"namespace_id"`
 	RuleGroup       string              `json:"rule_group" yaml:"rule_group"`
 	NoDataState     NoDataState         `json:"no_data_state" yaml:"no_data_state"`
+	ForError        *model.Duration     `json:"for_error" yaml:"for_error"`
 	ExecErrState    ExecutionErrorState `json:"exec_err_state" yaml:"exec_err_state"`
 	Provenance      models.Provenance   `json:"provenance,omitempty" yaml:"provenance,omitempty"`
 	IsPaused        bool                `json:"is_paused" yaml:"is_paused"`

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -157,6 +157,7 @@ type AlertRule struct {
 	// ideally this field should have been apimodels.ApiDuration
 	// but this is currently not possible because of circular dependencies
 	For         time.Duration
+	ForError    time.Duration
 	Annotations map[string]string
 	Labels      map[string]string
 	IsPaused    bool
@@ -482,6 +483,9 @@ func PatchPartialAlertRule(existingRule *AlertRule, ruleToPatch *AlertRuleWithOp
 	}
 	if !ruleToPatch.HasPause {
 		ruleToPatch.IsPaused = existingRule.IsPaused
+	}
+	if ruleToPatch.ForError == -1 {
+		ruleToPatch.ForError = existingRule.ForError
 	}
 }
 

--- a/pkg/services/ngalert/models/alert_rule_test.go
+++ b/pkg/services/ngalert/models/alert_rule_test.go
@@ -205,6 +205,12 @@ func TestPatchPartialAlertRule(t *testing.T) {
 					r.IsPaused = true
 				},
 			},
+			{
+				name: "ForError is -1",
+				mutator: func(r *AlertRuleWithOptionals) {
+					r.ForError = -1
+				},
+			},
 		}
 
 		for _, testCase := range testCases {
@@ -441,6 +447,13 @@ func TestDiff(t *testing.T) {
 			assert.Len(t, diff, 1)
 			assert.Equal(t, rule1.For, diff[0].Left.Interface())
 			assert.Equal(t, rule2.For, diff[0].Right.Interface())
+			difCnt++
+		}
+		if rule1.ForError != rule2.ForError {
+			diff := diffs.GetDiffsForField("ForError")
+			assert.Len(t, diff, 1)
+			assert.Equal(t, rule1.ForError, diff[0].Left.Interface())
+			assert.Equal(t, rule2.ForError, diff[0].Right.Interface())
 			difCnt++
 		}
 		if rule1.RuleGroupIndex != rule2.RuleGroupIndex {

--- a/pkg/services/ngalert/models/testing.go
+++ b/pkg/services/ngalert/models/testing.go
@@ -39,6 +39,7 @@ func AlertRuleGen(mutators ...AlertRuleMutator) func() *AlertRule {
 
 		interval := (rand.Int63n(6) + 1) * 10
 		forInterval := time.Duration(interval*rand.Int63n(6)) * time.Second
+		forErrorInterval := time.Duration(interval*rand.Int63n(6)) * time.Second
 
 		var annotations map[string]string = nil
 		if rand.Int63()%2 == 0 {
@@ -76,6 +77,7 @@ func AlertRuleGen(mutators ...AlertRuleMutator) func() *AlertRule {
 			NoDataState:     randNoDataState(),
 			ExecErrState:    randErrState(),
 			For:             forInterval,
+			ForError:        forErrorInterval,
 			Annotations:     annotations,
 			Labels:          labels,
 		}
@@ -256,6 +258,7 @@ func CopyRule(r *AlertRule) *AlertRule {
 		NoDataState:     r.NoDataState,
 		ExecErrState:    r.ExecErrState,
 		For:             r.For,
+		ForError:        r.ForError,
 	}
 
 	if r.DashboardUID != nil {

--- a/pkg/services/ngalert/provisioning/alert_rules_test.go
+++ b/pkg/services/ngalert/provisioning/alert_rules_test.go
@@ -382,6 +382,7 @@ func createTestRule(title string, groupTitle string, orgID int64) models.AlertRu
 		NamespaceUID: "my-namespace",
 		RuleGroup:    groupTitle,
 		For:          time.Second * 60,
+		ForError:     time.Second * 60,
 		NoDataState:  models.OK,
 		ExecErrState: models.OkErrState,
 	}

--- a/pkg/services/ngalert/state/manager_test.go
+++ b/pkg/services/ngalert/state/manager_test.go
@@ -1652,7 +1652,7 @@ func TestProcessEvalResults(t *testing.T) {
 			},
 		},
 		{
-			desc: "normal -> error when result is Error and ExecErrState is Error",
+			desc: "normal -> error when result is Error and ExecErrState is Error and ForError is not set",
 			alertRule: &models.AlertRule{
 				OrgID:        1,
 				Title:        "test_title",
@@ -1707,6 +1707,88 @@ func TestProcessEvalResults(t *testing.T) {
 					},
 					Values: make(map[string]float64),
 					State:  eval.Error,
+					Error: expr.QueryError{
+						RefID: "A",
+						Err:   errors.New("this is an error"),
+					},
+					Results: []state.Evaluation{
+						{
+							EvaluationTime:  evaluationTime,
+							EvaluationState: eval.Normal,
+							Values:          make(map[string]*float64),
+						},
+						{
+							EvaluationTime:  evaluationTime.Add(10 * time.Second),
+							EvaluationState: eval.Error,
+							Values:          make(map[string]*float64),
+						},
+					},
+					StartsAt:           evaluationTime.Add(10 * time.Second),
+					EndsAt:             evaluationTime.Add(10 * time.Second).Add(state.ResendDelay * 3),
+					LastEvaluationTime: evaluationTime.Add(10 * time.Second),
+					EvaluationDuration: evaluationDuration,
+					Annotations:        map[string]string{"annotation": "test", "Error": "failed to execute query A: this is an error"},
+				},
+			},
+		},
+		{
+			desc: "normal -> pending error when result is Error and ExecErrState is Error and ForError is set",
+			alertRule: &models.AlertRule{
+				OrgID:        1,
+				Title:        "test_title",
+				UID:          "test_alert_rule_uid_2",
+				NamespaceUID: "test_namespace_uid",
+				Data: []models.AlertQuery{{
+					RefID:         "A",
+					DatasourceUID: "datasource_uid_1",
+				}},
+				Annotations:     map[string]string{"annotation": "test"},
+				Labels:          map[string]string{"label": "test"},
+				IntervalSeconds: 10,
+				For:             1 * time.Minute,
+				ForError:        1 * time.Minute,
+				ExecErrState:    models.ErrorErrState,
+			},
+			evalResults: []eval.Results{
+				{
+					eval.Result{
+						Instance:           data.Labels{"instance_label": "test"},
+						State:              eval.Normal,
+						EvaluatedAt:        evaluationTime,
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+				{
+					eval.Result{
+						Instance: data.Labels{"instance_label": "test"},
+						Error: expr.QueryError{
+							RefID: "A",
+							Err:   errors.New("this is an error"),
+						},
+						State:              eval.Error,
+						EvaluatedAt:        evaluationTime.Add(10 * time.Second),
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+			},
+			expectedAnnotations: 1,
+			expectedStates: map[string]*state.State{
+				`[["__alert_rule_namespace_uid__","test_namespace_uid"],["__alert_rule_uid__","test_alert_rule_uid_2"],["alertname","test_title"],["instance_label","test"],["label","test"]]`: {
+					AlertRuleUID: "test_alert_rule_uid_2",
+					OrgID:        1,
+					CacheID:      `[["__alert_rule_namespace_uid__","test_namespace_uid"],["__alert_rule_uid__","test_alert_rule_uid_2"],["alertname","test_title"],["instance_label","test"],["label","test"]]`,
+					Labels: data.Labels{
+						"__alert_rule_namespace_uid__": "test_namespace_uid",
+						"__alert_rule_uid__":           "test_alert_rule_uid_2",
+						"alertname":                    "test_title",
+						"label":                        "test",
+						"instance_label":               "test",
+						"datasource_uid":               "datasource_uid_1",
+						"ref_id":                       "A",
+					},
+					Values:      make(map[string]float64),
+					State:       eval.Pending,
+					StateReason: "Error",
 					Error: expr.QueryError{
 						RefID: "A",
 						Err:   errors.New("this is an error"),
@@ -1974,6 +2056,336 @@ func TestProcessEvalResults(t *testing.T) {
 					StartsAt:           evaluationTime.Add(30 * time.Second),
 					EndsAt:             evaluationTime.Add(50 * time.Second).Add(state.ResendDelay * 3),
 					LastEvaluationTime: evaluationTime.Add(50 * time.Second),
+					EvaluationDuration: evaluationDuration,
+					Annotations:        map[string]string{"annotation": "test"},
+				},
+			},
+		},
+		{
+			desc: "pending -> pending error when result is Error and ExecErrorState is Error with For and ForError set",
+			alertRule: &models.AlertRule{
+				OrgID:           1,
+				Title:           "test_title",
+				UID:             "test_alert_rule_uid_2",
+				NamespaceUID:    "test_namespace_uid",
+				Annotations:     map[string]string{"annotation": "test"},
+				Labels:          map[string]string{"label": "test"},
+				IntervalSeconds: 10,
+				For:             20 * time.Second,
+				ForError:        20 * time.Second,
+				ExecErrState:    models.ErrorErrState,
+			},
+			evalResults: []eval.Results{
+				{
+					eval.Result{
+						Instance:           data.Labels{"instance_label": "test"},
+						State:              eval.Alerting,
+						EvaluatedAt:        evaluationTime,
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+				{
+					eval.Result{
+						Instance:           data.Labels{"instance_label": "test"},
+						State:              eval.Alerting,
+						EvaluatedAt:        evaluationTime.Add(10 * time.Second),
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+				{
+					eval.Result{
+						Instance: data.Labels{"instance_label": "test"},
+						State:    eval.Error,
+						Error: expr.QueryError{
+							RefID: "A",
+							Err:   errors.New("this is an error"),
+						},
+						EvaluatedAt:        evaluationTime.Add(20 * time.Second),
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+				{
+					eval.Result{
+						Instance: data.Labels{"instance_label": "test"},
+						State:    eval.Error,
+						Error: expr.QueryError{
+							RefID: "A",
+							Err:   errors.New("this is an error"),
+						},
+						EvaluatedAt:        evaluationTime.Add(30 * time.Second),
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+			},
+			expectedAnnotations: 2,
+			expectedStates: map[string]*state.State{
+				`[["__alert_rule_namespace_uid__","test_namespace_uid"],["__alert_rule_uid__","test_alert_rule_uid_2"],["alertname","test_title"],["instance_label","test"],["label","test"]]`: {
+					AlertRuleUID: "test_alert_rule_uid_2",
+					OrgID:        1,
+					CacheID:      `[["__alert_rule_namespace_uid__","test_namespace_uid"],["__alert_rule_uid__","test_alert_rule_uid_2"],["alertname","test_title"],["instance_label","test"],["label","test"]]`,
+					Labels: data.Labels{
+						"__alert_rule_namespace_uid__": "test_namespace_uid",
+						"__alert_rule_uid__":           "test_alert_rule_uid_2",
+						"alertname":                    "test_title",
+						"label":                        "test",
+						"instance_label":               "test",
+					},
+					Values:      make(map[string]float64),
+					State:       eval.Pending,
+					StateReason: models.StateReasonError,
+					Error: expr.QueryError{
+						RefID: "A",
+						Err:   errors.New("this is an error"),
+					},
+					Results: []state.Evaluation{
+						{
+							EvaluationTime:  evaluationTime.Add(20 * time.Second),
+							EvaluationState: eval.Error,
+							Values:          make(map[string]*float64),
+						},
+						{
+							EvaluationTime:  evaluationTime.Add(30 * time.Second),
+							EvaluationState: eval.Error,
+							Values:          make(map[string]*float64),
+						},
+					},
+					StartsAt:           evaluationTime.Add(20 * time.Second),
+					EndsAt:             evaluationTime.Add(20 * time.Second).Add(state.ResendDelay * 3),
+					LastEvaluationTime: evaluationTime.Add(30 * time.Second),
+					EvaluationDuration: evaluationDuration,
+					Annotations:        map[string]string{"annotation": "test"},
+				},
+			},
+		},
+		{
+			desc: "pending error -> pending when result is Error and ExecErrorState is Error with For and ForError set",
+			alertRule: &models.AlertRule{
+				OrgID:           1,
+				Title:           "test_title",
+				UID:             "test_alert_rule_uid_2",
+				NamespaceUID:    "test_namespace_uid",
+				Annotations:     map[string]string{"annotation": "test"},
+				Labels:          map[string]string{"label": "test"},
+				IntervalSeconds: 10,
+				For:             20 * time.Second,
+				ForError:        20 * time.Second,
+				ExecErrState:    models.ErrorErrState,
+			},
+			evalResults: []eval.Results{
+				{
+					eval.Result{
+						Instance: data.Labels{"instance_label": "test"},
+						State:    eval.Error,
+						Error: expr.QueryError{
+							RefID: "A",
+							Err:   errors.New("this is an error"),
+						},
+						EvaluatedAt:        evaluationTime,
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+				{
+					eval.Result{
+						Instance: data.Labels{"instance_label": "test"},
+						State:    eval.Error,
+						Error: expr.QueryError{
+							RefID: "A",
+							Err:   errors.New("this is an error"),
+						},
+						EvaluatedAt:        evaluationTime.Add(10 * time.Second),
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+				{
+					eval.Result{
+						Instance:           data.Labels{"instance_label": "test"},
+						State:              eval.Alerting,
+						EvaluatedAt:        evaluationTime.Add(20 * time.Second),
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+				{
+					eval.Result{
+						Instance:           data.Labels{"instance_label": "test"},
+						State:              eval.Alerting,
+						EvaluatedAt:        evaluationTime.Add(30 * time.Second),
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+			},
+			expectedAnnotations: 2,
+			expectedStates: map[string]*state.State{
+				`[["__alert_rule_namespace_uid__","test_namespace_uid"],["__alert_rule_uid__","test_alert_rule_uid_2"],["alertname","test_title"],["instance_label","test"],["label","test"]]`: {
+					AlertRuleUID: "test_alert_rule_uid_2",
+					OrgID:        1,
+					CacheID:      `[["__alert_rule_namespace_uid__","test_namespace_uid"],["__alert_rule_uid__","test_alert_rule_uid_2"],["alertname","test_title"],["instance_label","test"],["label","test"]]`,
+					Labels: data.Labels{
+						"__alert_rule_namespace_uid__": "test_namespace_uid",
+						"__alert_rule_uid__":           "test_alert_rule_uid_2",
+						"alertname":                    "test_title",
+						"label":                        "test",
+						"instance_label":               "test",
+					},
+					Values: make(map[string]float64),
+					State:  eval.Pending,
+					Results: []state.Evaluation{
+						{
+							EvaluationTime:  evaluationTime.Add(20 * time.Second),
+							EvaluationState: eval.Alerting,
+							Values:          make(map[string]*float64),
+						},
+						{
+							EvaluationTime:  evaluationTime.Add(30 * time.Second),
+							EvaluationState: eval.Alerting,
+							Values:          make(map[string]*float64),
+						},
+					},
+					StartsAt:           evaluationTime.Add(20 * time.Second),
+					EndsAt:             evaluationTime.Add(20 * time.Second).Add(state.ResendDelay * 3),
+					LastEvaluationTime: evaluationTime.Add(30 * time.Second),
+					EvaluationDuration: evaluationDuration,
+					Annotations:        map[string]string{"annotation": "test"},
+				},
+			},
+		},
+		{
+			desc: "normal -> pending -> alerting -> pending error -> error -> pending -> alerting when result is Error and ExecErrorState is Error with For and ForError set",
+			alertRule: &models.AlertRule{
+				OrgID:           1,
+				Title:           "test_title",
+				UID:             "test_alert_rule_uid_2",
+				NamespaceUID:    "test_namespace_uid",
+				Annotations:     map[string]string{"annotation": "test"},
+				Labels:          map[string]string{"label": "test"},
+				IntervalSeconds: 10,
+				For:             20 * time.Second,
+				ForError:        20 * time.Second,
+				ExecErrState:    models.ErrorErrState,
+			},
+			evalResults: []eval.Results{
+				{
+					eval.Result{
+						Instance:           data.Labels{"instance_label": "test"},
+						State:              eval.Normal,
+						EvaluatedAt:        evaluationTime,
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+				{
+					eval.Result{
+						Instance:           data.Labels{"instance_label": "test"},
+						State:              eval.Alerting,
+						EvaluatedAt:        evaluationTime.Add(10 * time.Second),
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+				{
+					eval.Result{
+						Instance:           data.Labels{"instance_label": "test"},
+						State:              eval.Alerting,
+						EvaluatedAt:        evaluationTime.Add(20 * time.Second),
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+				{
+					eval.Result{
+						Instance:           data.Labels{"instance_label": "test"},
+						State:              eval.Alerting,
+						EvaluatedAt:        evaluationTime.Add(30 * time.Second),
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+				{
+					eval.Result{
+						Instance: data.Labels{"instance_label": "test"},
+						State:    eval.Error,
+						Error: expr.QueryError{
+							RefID: "A",
+							Err:   errors.New("this is an error"),
+						},
+						EvaluatedAt:        evaluationTime.Add(40 * time.Second),
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+				{
+					eval.Result{
+						Instance: data.Labels{"instance_label": "test"},
+						State:    eval.Error,
+						Error: expr.QueryError{
+							RefID: "A",
+							Err:   errors.New("this is an error"),
+						},
+						EvaluatedAt:        evaluationTime.Add(50 * time.Second),
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+				{
+					eval.Result{
+						Instance: data.Labels{"instance_label": "test"},
+						State:    eval.Error,
+						Error: expr.QueryError{
+							RefID: "A",
+							Err:   errors.New("this is an error"),
+						},
+						EvaluatedAt:        evaluationTime.Add(60 * time.Second),
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+				{
+					eval.Result{
+						Instance:           data.Labels{"instance_label": "test"},
+						State:              eval.Alerting,
+						EvaluatedAt:        evaluationTime.Add(70 * time.Second),
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+				{
+					eval.Result{
+						Instance:           data.Labels{"instance_label": "test"},
+						State:              eval.Alerting,
+						EvaluatedAt:        evaluationTime.Add(80 * time.Second),
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+				{
+					eval.Result{
+						Instance:           data.Labels{"instance_label": "test"},
+						State:              eval.Alerting,
+						EvaluatedAt:        evaluationTime.Add(90 * time.Second),
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+			},
+			expectedAnnotations: 6,
+			expectedStates: map[string]*state.State{
+				`[["__alert_rule_namespace_uid__","test_namespace_uid"],["__alert_rule_uid__","test_alert_rule_uid_2"],["alertname","test_title"],["instance_label","test"],["label","test"]]`: {
+					AlertRuleUID: "test_alert_rule_uid_2",
+					OrgID:        1,
+					CacheID:      `[["__alert_rule_namespace_uid__","test_namespace_uid"],["__alert_rule_uid__","test_alert_rule_uid_2"],["alertname","test_title"],["instance_label","test"],["label","test"]]`,
+					Labels: data.Labels{
+						"__alert_rule_namespace_uid__": "test_namespace_uid",
+						"__alert_rule_uid__":           "test_alert_rule_uid_2",
+						"alertname":                    "test_title",
+						"label":                        "test",
+						"instance_label":               "test",
+					},
+					Values: make(map[string]float64),
+					State:  eval.Alerting,
+					Results: []state.Evaluation{
+						{
+							EvaluationTime:  evaluationTime.Add(80 * time.Second),
+							EvaluationState: eval.Alerting,
+							Values:          make(map[string]*float64),
+						},
+						{
+							EvaluationTime:  evaluationTime.Add(90 * time.Second),
+							EvaluationState: eval.Alerting,
+							Values:          make(map[string]*float64),
+						},
+					},
+					StartsAt:           evaluationTime.Add(90 * time.Second),
+					EndsAt:             evaluationTime.Add(90 * time.Second).Add(state.ResendDelay * 3),
+					LastEvaluationTime: evaluationTime.Add(90 * time.Second),
 					EvaluationDuration: evaluationDuration,
 					Annotations:        map[string]string{"annotation": "test"},
 				},

--- a/pkg/services/ngalert/state/state_test.go
+++ b/pkg/services/ngalert/state/state_test.go
@@ -109,6 +109,54 @@ func TestSetPending(t *testing.T) {
 	}
 }
 
+func TestSetPendingError(t *testing.T) {
+	mock := clock.NewMock()
+	tests := []struct {
+		name     string
+		state    State
+		startsAt time.Time
+		endsAt   time.Time
+		error    error
+		expected State
+	}{{
+		name:     "state is set to Pending with error",
+		error:    errors.New("this is an error"),
+		startsAt: mock.Now(),
+		endsAt:   mock.Now().Add(time.Minute),
+		expected: State{
+			State:       eval.Pending,
+			StateReason: ngmodels.StateReasonError,
+			StartsAt:    mock.Now(),
+			EndsAt:      mock.Now().Add(time.Minute),
+			Error:       errors.New("this is an error"),
+		},
+	}, {
+		name:  "previous state is removed",
+		error: errors.New("this is an error"),
+		state: State{
+			State:       eval.Pending,
+			StateReason: "this is a reason",
+		},
+		startsAt: mock.Now(),
+		endsAt:   mock.Now().Add(time.Minute),
+		expected: State{
+			State:       eval.Pending,
+			StateReason: ngmodels.StateReasonError,
+			StartsAt:    mock.Now(),
+			EndsAt:      mock.Now().Add(time.Minute),
+			Error:       errors.New("this is an error"),
+		},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := test.state
+			actual.SetPendingError(test.error, test.startsAt, test.endsAt)
+			assert.Equal(t, test.expected, actual)
+		})
+	}
+}
+
 func TestNormal(t *testing.T) {
 	mock := clock.NewMock()
 	tests := []struct {

--- a/pkg/services/provisioning/alerting/file/rules_types.go
+++ b/pkg/services/provisioning/alerting/file/rules_types.go
@@ -76,6 +76,7 @@ type AlertRuleV1 struct {
 	NoDataState  values.StringValue    `json:"noDataState" yaml:"noDataState"`
 	ExecErrState values.StringValue    `json:"execErrState" yaml:"execErrState"`
 	For          values.StringValue    `json:"for" yaml:"for"`
+	ForError     values.StringValue    `json:"forError" yaml:"forError"`
 	Annotations  values.StringMapValue `json:"annotations" yaml:"annotations"`
 	Labels       values.StringMapValue `json:"labels" yaml:"labels"`
 	IsPaused     values.BoolValue      `json:"isPaused" yaml:"isPaused"`
@@ -97,6 +98,13 @@ func (rule *AlertRuleV1) mapToModel(orgID int64) (models.AlertRule, error) {
 		return models.AlertRule{}, fmt.Errorf("rule '%s' failed to parse: %w", alertRule.Title, err)
 	}
 	alertRule.For = time.Duration(duration)
+	if rule.ForError.Value() != "" {
+		errorDuration, err := model.ParseDuration(rule.ForError.Value())
+		if err != nil {
+			return models.AlertRule{}, fmt.Errorf("rule '%s' failed to parse: %w", alertRule.Title, err)
+		}
+		alertRule.ForError = time.Duration(errorDuration)
+	}
 	dashboardUID := rule.DashboardUID.Value()
 	alertRule.DashboardUID = &dashboardUID
 	panelID := rule.PanelID.Value()

--- a/pkg/services/provisioning/alerting/file/rules_types_test.go
+++ b/pkg/services/provisioning/alerting/file/rules_types_test.go
@@ -125,6 +125,24 @@ func TestRules(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 48*time.Hour, ruleMapped.For)
 	})
+	t.Run("a rule with a forError duration containing 'd' should work", func(t *testing.T) {
+		rule := validRuleV1(t)
+		forErrorDuration := values.StringValue{}
+		err := yaml.Unmarshal([]byte("2d"), &forErrorDuration)
+		rule.ForError = forErrorDuration
+		require.NoError(t, err)
+		ruleMapped, err := rule.mapToModel(1)
+		require.NoError(t, err)
+		require.Equal(t, 48*time.Hour, ruleMapped.ForError)
+	})
+	t.Run("a rule with an empty forError duration should work", func(t *testing.T) {
+		rule := validRuleV1(t)
+		forErrorDuration := values.StringValue{}
+		rule.ForError = forErrorDuration
+		ruleMapped, err := rule.mapToModel(1)
+		require.NoError(t, err)
+		require.Equal(t, 0*time.Second, ruleMapped.ForError)
+	})
 	t.Run("a rule with out a condition should error", func(t *testing.T) {
 		rule := validRuleV1(t)
 		rule.Condition = values.StringValue{}

--- a/pkg/services/sqlstore/migrations/migrations.go
+++ b/pkg/services/sqlstore/migrations/migrations.go
@@ -105,7 +105,6 @@ func (*OSSMigrations) AddMigration(mg *Migrator) {
 	AddExternalAlertmanagerToDatasourceMigration(mg)
 
 	addFolderMigrations(mg)
-	ualert.AddForErrorColumnMigration(mg)
 }
 
 func addMigrationLogMigrations(mg *Migrator) {

--- a/pkg/services/sqlstore/migrations/migrations.go
+++ b/pkg/services/sqlstore/migrations/migrations.go
@@ -105,6 +105,7 @@ func (*OSSMigrations) AddMigration(mg *Migrator) {
 	AddExternalAlertmanagerToDatasourceMigration(mg)
 
 	addFolderMigrations(mg)
+	ualert.AddForErrorColumnMigration(mg)
 }
 
 func addMigrationLogMigrations(mg *Migrator) {

--- a/pkg/services/sqlstore/migrations/ualert/tables.go
+++ b/pkg/services/sqlstore/migrations/ualert/tables.go
@@ -290,6 +290,16 @@ func addAlertRuleMigrations(mg *migrator.Migrator, defaultIntervalSeconds int64)
 			Default:  "false",
 		},
 	))
+
+	mg.AddMigration("add for_error column to alert_rule table", migrator.NewAddColumnMigration(
+		alertRule,
+		&migrator.Column{
+			Name:     "for_error",
+			Type:     migrator.DB_BigInt,
+			Nullable: false,
+			Default:  "0",
+		},
+	))
 }
 
 func addAlertRuleVersionMigrations(mg *migrator.Migrator) {
@@ -352,6 +362,16 @@ func addAlertRuleVersionMigrations(mg *migrator.Migrator) {
 			Type:     migrator.DB_Bool,
 			Nullable: false,
 			Default:  "false",
+		},
+	))
+
+	mg.AddMigration("add for_error column to alert_rule_version table", migrator.NewAddColumnMigration(
+		alertRuleVersion,
+		&migrator.Column{
+			Name:     "for_error",
+			Type:     migrator.DB_BigInt,
+			Nullable: false,
+			Default:  "0",
 		},
 	))
 }

--- a/pkg/services/sqlstore/migrations/ualert/ualert.go
+++ b/pkg/services/sqlstore/migrations/ualert/ualert.go
@@ -927,13 +927,3 @@ func (s *uidSet) generateUid() (string, error) {
 
 	return "", errors.New("failed to generate UID")
 }
-
-func AddForErrorColumnMigration(mg *migrator.Migrator) {
-	if !mg.Cfg.UnifiedAlerting.IsEnabled() {
-		return
-	}
-	mg.AddMigration(
-		"add for error column to alert_rule table",
-		migrator.NewRawSQLMigration("ALTER TABLE alert_rule ADD COLUMN for_error INTEGER DEFAULT 0;"),
-	)
-}

--- a/pkg/services/sqlstore/migrations/ualert/ualert.go
+++ b/pkg/services/sqlstore/migrations/ualert/ualert.go
@@ -927,3 +927,13 @@ func (s *uidSet) generateUid() (string, error) {
 
 	return "", errors.New("failed to generate UID")
 }
+
+func AddForErrorColumnMigration(mg *migrator.Migrator) {
+	if !mg.Cfg.UnifiedAlerting.IsEnabled() {
+		return
+	}
+	mg.AddMigration(
+		"add for error column to alert_rule table",
+		migrator.NewRawSQLMigration("ALTER TABLE alert_rule ADD COLUMN for_error INTEGER DEFAULT 0;"),
+	)
+}

--- a/public/app/features/alerting/unified/RuleEditorExisting.test.tsx
+++ b/public/app/features/alerting/unified/RuleEditorExisting.test.tsx
@@ -137,6 +137,7 @@ describe('RuleEditor grafana managed rules', () => {
                 data: getDefaultQueries(),
                 exec_err_state: GrafanaAlertStateDecision.Error,
                 no_data_state: GrafanaAlertStateDecision.NoData,
+                for_error: '0m',
                 title: 'my great new rule',
               },
             },

--- a/public/app/features/alerting/unified/RuleViewer.test.tsx
+++ b/public/app/features/alerting/unified/RuleViewer.test.tsx
@@ -10,12 +10,37 @@ import { contextSrv } from 'app/core/services/context_srv';
 import { AccessControlAction } from 'app/types';
 import { CombinedRule } from 'app/types/unified-alerting';
 
+import { GrafanaAlertStateDecision } from "../../../types/unified-alerting-dto";
+
 import { RuleViewer } from './RuleViewer';
 import { useCombinedRule } from './hooks/useCombinedRule';
 import { useIsRuleEditable } from './hooks/useIsRuleEditable';
 import { getCloudRule, getGrafanaRule, grantUserPermissions } from './mocks';
 
-const mockGrafanaRule = getGrafanaRule({ name: 'Test alert' });
+const mockGrafanaRule = getGrafanaRule({
+  name: 'Test alert',
+  query: 'up',
+  group: {
+    name: 'Prom up alert',
+    rules: [],
+  },
+  rulerRule: {
+    for: '',
+    for_error: '',
+    annotations: {},
+    labels: {},
+    grafana_alert: {
+      condition: 'B',
+      exec_err_state: GrafanaAlertStateDecision.Alerting,
+      namespace_id: 11,
+      namespace_uid: 'namespaceuid123',
+      no_data_state: GrafanaAlertStateDecision.NoData,
+      title: 'Test alert',
+      uid: 'asdf23',
+      data: [],
+    },
+  },
+});
 const mockCloudRule = getCloudRule({ name: 'cloud test alert' });
 const mockRoute: GrafanaRouteComponentProps<{ id?: string; sourceName?: string }> = {
   route: {

--- a/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
@@ -219,22 +219,26 @@ function FolderGroupAndEvaluationInterval({
   );
 }
 
-function ForInput({ evaluateEvery }: { evaluateEvery: string }) {
+function ForInput({
+  evaluateId,
+  evaluateName,
+  evaluateEvery,
+  tooltip,
+}: {
+  evaluateId: string;
+  evaluateName: 'evaluateFor' | 'evaluateForError';
+  evaluateEvery: string;
+  tooltip: string;
+}) {
   const styles = useStyles2(getStyles);
   const {
     register,
     formState: { errors },
   } = useFormContext<RuleFormValues>();
 
-  const evaluateForId = 'eval-for-input';
-
   return (
     <Stack direction="row" justify-content="flex-start" align-items="flex-start">
-      <InlineLabel
-        htmlFor={evaluateForId}
-        width={7}
-        tooltip='Once the condition is breached, the alert goes into pending state. If the alert is pending longer than the "for" value, it becomes a firing alert.'
-      >
+      <InlineLabel htmlFor={evaluateId} width={7} tooltip={tooltip}>
         for
       </InlineLabel>
       <Field
@@ -243,7 +247,7 @@ function ForInput({ evaluateEvery }: { evaluateEvery: string }) {
         invalid={!!errors.evaluateFor?.message}
         validationMessageHorizontalOverflow={true}
       >
-        <Input id={evaluateForId} width={8} {...register('evaluateFor', forValidationOptions(evaluateEvery))} />
+        <Input id={evaluateId} width={8} {...register(evaluateName, forValidationOptions(evaluateEvery))} />
       </Field>
     </Stack>
   );
@@ -262,6 +266,8 @@ export function GrafanaEvaluationBehavior({
 }) {
   const styles = useStyles2(getStyles);
   const [showErrorHandling, setShowErrorHandling] = useState(false);
+  const evaluateForId = 'eval-for-input';
+  const evaluateForErrorId = 'eval-for-error-input';
 
   const { watch, setValue } = useFormContext<RuleFormValues>();
 
@@ -276,7 +282,12 @@ export function GrafanaEvaluationBehavior({
           setEvaluateEvery={setEvaluateEvery}
           evaluateEvery={evaluateEvery}
         />
-        <ForInput evaluateEvery={evaluateEvery} />
+        <ForInput
+          evaluateId={evaluateForId}
+          evaluateName="evaluateFor"
+          evaluateEvery={evaluateEvery}
+          tooltip='Once the condition is breached, the alert goes into pending state. If the alert is pending longer than the "for" value, it becomes a firing alert.'
+        />
 
         {existing && (
           <Field htmlFor="pause-alert-switch">
@@ -326,21 +337,31 @@ export function GrafanaEvaluationBehavior({
               name="noDataState"
             />
           </Field>
-          <Field htmlFor="exec-err-state-input" label="Alert state if execution error or timeout">
-            <InputControl
-              render={({ field: { onChange, ref, ...field } }) => (
-                <GrafanaAlertStatePicker
-                  {...field}
-                  inputId="exec-err-state-input"
-                  width={42}
-                  includeNoData={false}
-                  includeError={true}
-                  onChange={(value) => onChange(value?.value)}
-                />
-              )}
-              name="execErrState"
-            />
-          </Field>
+          <Stack direction="row" justify-content="flex-start" align-items="flex-start">
+            <Field htmlFor="exec-err-state-input" label="Alert state if execution error or timeout">
+              <InputControl
+                render={({ field: { onChange, ref, ...field } }) => (
+                  <GrafanaAlertStatePicker
+                    {...field}
+                    inputId="exec-err-state-input"
+                    width={42}
+                    includeNoData={false}
+                    includeError={true}
+                    onChange={(value) => onChange(value?.value)}
+                  />
+                )}
+                name="execErrState"
+              />
+            </Field>
+            <Field htmlFor="exec-for-err-input" label="">
+              <ForInput
+                evaluateId={evaluateForErrorId}
+                evaluateName="evaluateForError"
+                evaluateEvery={evaluateEvery}
+                tooltip='Once an error is thrown, the alert state freezes. If the error continues to be thrown longer than the "for" value, it becomes an error alert. If not, the alert state unfreezes and continues.'
+              />
+            </Field>
+          </Stack>
         </>
       )}
     </RuleEditorSection>

--- a/public/app/features/alerting/unified/components/rules/RuleDetails.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleDetails.tsx
@@ -61,11 +61,13 @@ interface EvaluationBehaviorSummaryProps {
 
 const EvaluationBehaviorSummary = ({ rule }: EvaluationBehaviorSummaryProps) => {
   let forDuration: string | undefined;
+  let forErrorDuration: string | undefined;
   let every = rule.group.interval;
 
   // recording rules don't have a for duration
   if (!isRecordingRulerRule(rule.rulerRule)) {
     forDuration = rule.rulerRule?.for;
+    forErrorDuration = rule.rulerRule?.for_error;
   }
 
   return (
@@ -78,6 +80,11 @@ const EvaluationBehaviorSummary = ({ rule }: EvaluationBehaviorSummaryProps) => 
       {forDuration && (
         <DetailsField label="For" horizontal={true}>
           {forDuration}
+        </DetailsField>
+      )}
+      {forErrorDuration && (
+        <DetailsField label="Error For" horizontal={true}>
+          {forErrorDuration}
         </DetailsField>
       )}
     </>

--- a/public/app/features/alerting/unified/components/rules/RuleDetails.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleDetails.tsx
@@ -67,7 +67,9 @@ const EvaluationBehaviorSummary = ({ rule }: EvaluationBehaviorSummaryProps) => 
   // recording rules don't have a for duration
   if (!isRecordingRulerRule(rule.rulerRule)) {
     forDuration = rule.rulerRule?.for;
-    forErrorDuration = rule.rulerRule?.for_error;
+    if (rule.rulerRule && 'grafana_alert' in rule.rulerRule) {
+      forErrorDuration = rule.rulerRule.grafana_alert.for_error;
+    }
   }
 
   return (

--- a/public/app/features/alerting/unified/mocks.ts
+++ b/public/app/features/alerting/unified/mocks.ts
@@ -95,6 +95,7 @@ export const mockRulerGrafanaRule = (
 ): RulerGrafanaRuleDTO => {
   return {
     for: '1m',
+    for_error: '3m',
     grafana_alert: {
       uid: '123',
       title: 'myalert',

--- a/public/app/features/alerting/unified/mocks.ts
+++ b/public/app/features/alerting/unified/mocks.ts
@@ -95,7 +95,6 @@ export const mockRulerGrafanaRule = (
 ): RulerGrafanaRuleDTO => {
   return {
     for: '1m',
-    for_error: '3m',
     grafana_alert: {
       uid: '123',
       title: 'myalert',
@@ -104,6 +103,7 @@ export const mockRulerGrafanaRule = (
       condition: 'A',
       no_data_state: GrafanaAlertStateDecision.Alerting,
       exec_err_state: GrafanaAlertStateDecision.Alerting,
+      for_error: '3m',
       data: [
         {
           datasourceUid: '123',

--- a/public/app/features/alerting/unified/types/rule-form.ts
+++ b/public/app/features/alerting/unified/types/rule-form.ts
@@ -29,6 +29,7 @@ export interface RuleFormValues {
   folder: RuleForm | null;
   evaluateEvery: string;
   evaluateFor: string;
+  evaluateForError: string;
   isPaused?: boolean;
 
   // cortex / loki rules

--- a/public/app/features/alerting/unified/utils/query.test.ts
+++ b/public/app/features/alerting/unified/utils/query.test.ts
@@ -24,7 +24,6 @@ describe('alertRuleToQueries', () => {
       },
       rulerRule: {
         for: '',
-        for_error: '',
         annotations: {},
         labels: {},
         grafana_alert: grafanaAlert,
@@ -86,6 +85,7 @@ const grafanaAlert = {
   namespace_id: 11,
   namespace_uid: 'namespaceuid123',
   no_data_state: GrafanaAlertStateDecision.NoData,
+  for_error: '',
   title: 'Test alert',
   uid: 'asdf23',
   data: [

--- a/public/app/features/alerting/unified/utils/query.test.ts
+++ b/public/app/features/alerting/unified/utils/query.test.ts
@@ -24,6 +24,7 @@ describe('alertRuleToQueries', () => {
       },
       rulerRule: {
         for: '',
+        for_error: '',
         annotations: {},
         labels: {},
         grafana_alert: grafanaAlert,

--- a/public/app/features/alerting/unified/utils/rule-form.ts
+++ b/public/app/features/alerting/unified/utils/rule-form.ts
@@ -62,6 +62,7 @@ export const getDefaultFormValues = (): RuleFormValues => {
     execErrState: GrafanaAlertStateDecision.Error,
     evaluateFor: '5m',
     evaluateEvery: MINUTE,
+    evaluateForError: '0m', // Set default as old behaviour
 
     // cortex / loki
     namespace: '',
@@ -96,7 +97,7 @@ function listifyLabelsOrAnnotations(item: Labels | Annotations | undefined): Arr
 }
 
 export function formValuesToRulerGrafanaRuleDTO(values: RuleFormValues): PostableRuleGrafanaRuleDTO {
-  const { name, condition, noDataState, execErrState, evaluateFor, queries, isPaused } = values;
+  const { name, condition, noDataState, execErrState, evaluateFor, evaluateForError, queries, isPaused } = values;
   if (condition) {
     return {
       grafana_alert: {
@@ -108,6 +109,7 @@ export function formValuesToRulerGrafanaRuleDTO(values: RuleFormValues): Postabl
         is_paused: Boolean(isPaused),
       },
       for: evaluateFor,
+      for_error: evaluateForError,
       annotations: arrayToRecord(values.annotations || []),
       labels: arrayToRecord(values.labels || []),
     };

--- a/public/app/features/alerting/unified/utils/rule-form.ts
+++ b/public/app/features/alerting/unified/utils/rule-form.ts
@@ -105,11 +105,11 @@ export function formValuesToRulerGrafanaRuleDTO(values: RuleFormValues): Postabl
         condition,
         no_data_state: noDataState,
         exec_err_state: execErrState,
+        for_error: evaluateForError,
         data: queries.map(fixBothInstantAndRangeQuery),
         is_paused: Boolean(isPaused),
       },
       for: evaluateFor,
-      for_error: evaluateForError,
       annotations: arrayToRecord(values.annotations || []),
       labels: arrayToRecord(values.labels || []),
     };

--- a/public/app/features/alerting/unified/utils/rule-id.test.ts
+++ b/public/app/features/alerting/unified/utils/rule-id.test.ts
@@ -53,6 +53,7 @@ describe('hashRulerRule', () => {
     const grafanaRule: RulerGrafanaRuleDTO = {
       grafana_alert: grafanaAlertDefinition,
       for: '30s',
+      for_error: '3m',
       labels: { type: 'cpu' },
       annotations: { description: 'CPU usage too high' },
     };

--- a/public/app/features/alerting/unified/utils/rule-id.test.ts
+++ b/public/app/features/alerting/unified/utils/rule-id.test.ts
@@ -49,11 +49,11 @@ describe('hashRulerRule', () => {
       data: [],
       no_data_state: GrafanaAlertStateDecision.NoData,
       exec_err_state: GrafanaAlertStateDecision.Alerting,
+      for_error: '3m',
     };
     const grafanaRule: RulerGrafanaRuleDTO = {
       grafana_alert: grafanaAlertDefinition,
       for: '30s',
-      for_error: '3m',
       labels: { type: 'cpu' },
       annotations: { description: 'CPU usage too high' },
     };

--- a/public/app/types/unified-alerting-dto.ts
+++ b/public/app/types/unified-alerting-dto.ts
@@ -168,7 +168,6 @@ export interface RulerRecordingRuleDTO extends RulerRuleBaseDTO {
 export interface RulerAlertingRuleDTO extends RulerRuleBaseDTO {
   alert: string;
   for?: string;
-  for_error?: string;
   annotations?: Annotations;
 }
 
@@ -200,6 +199,7 @@ export interface PostableGrafanaRuleDefinition {
   condition: string;
   no_data_state: GrafanaAlertStateDecision;
   exec_err_state: GrafanaAlertStateDecision;
+  for_error: string;
   data: AlertQuery[];
   is_paused?: boolean;
 }
@@ -214,7 +214,6 @@ export interface GrafanaRuleDefinition extends PostableGrafanaRuleDefinition {
 export interface RulerGrafanaRuleDTO {
   grafana_alert: GrafanaRuleDefinition;
   for: string;
-  for_error: string;
   annotations: Annotations;
   labels: Labels;
 }
@@ -222,7 +221,6 @@ export interface RulerGrafanaRuleDTO {
 export interface PostableRuleGrafanaRuleDTO {
   grafana_alert: PostableGrafanaRuleDefinition;
   for: string;
-  for_error: string;
   annotations: Annotations;
   labels: Labels;
 }

--- a/public/app/types/unified-alerting-dto.ts
+++ b/public/app/types/unified-alerting-dto.ts
@@ -168,6 +168,7 @@ export interface RulerRecordingRuleDTO extends RulerRuleBaseDTO {
 export interface RulerAlertingRuleDTO extends RulerRuleBaseDTO {
   alert: string;
   for?: string;
+  for_error?: string;
   annotations?: Annotations;
 }
 
@@ -213,6 +214,7 @@ export interface GrafanaRuleDefinition extends PostableGrafanaRuleDefinition {
 export interface RulerGrafanaRuleDTO {
   grafana_alert: GrafanaRuleDefinition;
   for: string;
+  for_error: string;
   annotations: Annotations;
   labels: Labels;
 }
@@ -220,6 +222,7 @@ export interface RulerGrafanaRuleDTO {
 export interface PostableRuleGrafanaRuleDTO {
   grafana_alert: PostableGrafanaRuleDefinition;
   for: string;
+  for_error: string;
   annotations: Annotations;
   labels: Labels;
 }


### PR DESCRIPTION
**What is this feature?**

This feature adds a For-like field for the `error` state when it is handled as an `error`.
It adds a time window where DataSource errors can occur without entering the `error` state but a pending one.

**Why do we need this feature?**

Currently, if a data source stops responding it will immediately trigger an alert to the user. We didn't have a way to have a wait window on errors.

**Who is this feature for?**

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer**:

The default value is set to 0.
The default behavior is to jump to the `error` state right away as if we didn't have this feature.

Rule edition view:
![Captura de pantalla 2022-12-20 a las 11 08 32](https://user-images.githubusercontent.com/2112640/208641236-b2fee1dc-6b26-4c12-a9a0-75d78b218475.png)

![Captura de pantalla 2022-12-20 a las 11 12 46](https://user-images.githubusercontent.com/2112640/208641989-d153996f-e46e-4824-b825-97adb13d89cd.png)
