### PR TITLE
Datasources Fix formatting for SQL data sources permissions disclaimer

### DIFF
--- a/public/app/plugins/datasource/mssql/configuration/ConfigurationEditor.tsx
+++ b/public/app/plugins/datasource/mssql/configuration/ConfigurationEditor.tsx
@@ -17,6 +17,7 @@ import {
   InlineFieldRow,
   InlineSwitch,
   Input,
+  Link,
   SecretInput,
   Select,
   useStyles2,
@@ -270,7 +271,12 @@ export const ConfigurationEditor = (props: DataSourcePluginOptionsEditorProps<Ms
         The database user should only be granted SELECT permissions on the specified database and tables you want to
         query. Grafana does not validate that queries are safe so queries can contain any SQL statement. For example,
         statements like <code>USE otherdb;</code> and <code>DROP TABLE user;</code> would be executed. To protect
-        against this we <em>highly</em> recommend you create a specific MS SQL user with restricted permissions.
+        against this we <em>highly</em> recommend you create a specific MS SQL user with restricted permissions. Check
+        out the{' '}
+        <Link rel="noreferrer" target="_blank" href="http://docs.grafana.org/features/datasources/mssql/">
+          Microsoft SQL Server Data Source Docs
+        </Link>{' '}
+        for more information.
       </Alert>
     </>
   );

--- a/public/app/plugins/datasource/mysql/configuration/ConfigurationEditor.tsx
+++ b/public/app/plugins/datasource/mysql/configuration/ConfigurationEditor.tsx
@@ -171,10 +171,10 @@ export const ConfigurationEditor = (props: DataSourcePluginOptionsEditorProps<My
         query. Grafana does not validate that queries are safe so queries can contain any SQL statement. For example,
         statements like <code>USE otherdb;</code> and <code>DROP TABLE user;</code> would be executed. To protect
         against this we <strong>Highly</strong> recommend you create a specific MySQL user with restricted permissions.
-        Checkout the{' '}
+        Check out the{' '}
         <Link rel="noreferrer" target="_blank" href="http://docs.grafana.org/features/datasources/mysql/">
           MySQL Data Source Docs
-        </Link>
+        </Link>{' '}
         for more information.
       </Alert>
     </>

--- a/public/app/plugins/datasource/postgres/configuration/ConfigurationEditor.tsx
+++ b/public/app/plugins/datasource/postgres/configuration/ConfigurationEditor.tsx
@@ -8,7 +8,17 @@ import {
   updateDatasourcePluginJsonDataOption,
   updateDatasourcePluginResetOption,
 } from '@grafana/data';
-import { Alert, InlineSwitch, FieldSet, InlineField, InlineFieldRow, Input, Select, SecretInput } from '@grafana/ui';
+import {
+  Alert,
+  InlineSwitch,
+  FieldSet,
+  InlineField,
+  InlineFieldRow,
+  Input,
+  Select,
+  SecretInput,
+  Link,
+} from '@grafana/ui';
 import { ConnectionLimits } from 'app/features/plugins/sql/components/configuration/ConnectionLimits';
 import { TLSSecretsConfig } from 'app/features/plugins/sql/components/configuration/TLSSecretsConfig';
 
@@ -280,7 +290,11 @@ export const PostgresConfigEditor = (props: DataSourcePluginOptionsEditorProps<P
         query. Grafana does not validate that queries are safe so queries can contain any SQL statement. For example,
         statements like <code>DELETE FROM user;</code> and <code>DROP TABLE user;</code> would be executed. To protect
         against this we <strong>Highly</strong> recommend you create a specific PostgreSQL user with restricted
-        permissions.
+        permissions. Check out the{' '}
+        <Link rel="noreferrer" target="_blank" href="http://docs.grafana.org/features/datasources/postgres/">
+          PostgreSQL Data Source Docs
+        </Link>{' '}
+        for more information.
       </Alert>
     </>
   );


### PR DESCRIPTION
**What is this feature?**

Fixes a formatting issue in the MySQL data source config page, and adds the same docs link to Postgres and MSSQL data source config pages

Before:

![image](https://user-images.githubusercontent.com/46142/207048275-7ba009f0-25f0-4dcb-b054-3afae689601a.png)


After:

![image](https://user-images.githubusercontent.com/46142/207048664-c764e74e-517e-47af-8383-4a2ab047f0ea.png)


