### PR TITLE
Scenes: Use DataSourceRef only in the query variable type

### DIFF
--- a/public/app/features/scenes/scenes/queryVariableDemo.tsx
+++ b/public/app/features/scenes/scenes/queryVariableDemo.tsx
@@ -29,7 +29,7 @@ export function getQueryVariableDemo(standalone: boolean): Scene {
           name: 'instance (using datasource variable)',
           refresh: VariableRefresh.onTimeRangeChanged,
           query: { query: 'label_values(go_gc_duration_seconds, ${metric})' },
-          datasource: '${datasource}',
+          datasource: { uid: '${datasource}' },
         }),
         new QueryVariable({
           name: 'label values (on time range refresh)',

--- a/public/app/features/scenes/variables/variants/query/QueryVariable.tsx
+++ b/public/app/features/scenes/variables/variants/query/QueryVariable.tsx
@@ -30,7 +30,7 @@ import { metricNamesToVariableValues } from './utils';
 
 export interface QueryVariableState extends MultiValueVariableState {
   type: 'query';
-  datasource: DataSourceRef | string | null;
+  datasource: DataSourceRef | null;
   query: any;
   regex: string;
   refresh: VariableRefresh;
@@ -126,7 +126,7 @@ export class QueryVariable extends MultiValueVariable<QueryVariableState> {
   }
 
   private async getDataSource(): Promise<DataSourceApi> {
-    return getDataSourceSrv().get(this.state.datasource ?? '', {
+    return getDataSourceSrv().get(this.state.datasource, {
       __sceneObject: { text: '__sceneObject', value: this },
     });
   }


### PR DESCRIPTION
Removes the `string` type as an allowed type for data source definition in QueryVariable.