### PR TITLE
Prometheus: Fix exception being thrown when toggling visibility in explore

### DIFF
--- a/public/app/plugins/panel/timeseries/plugins/ExemplarsPlugin.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/ExemplarsPlugin.tsx
@@ -119,8 +119,8 @@ export const getVisibleLabels = (config: UPlotConfigBuilder, frames: DataFrame[]
       const fieldIndex = plotInstance.props?.dataFrameFieldIndex?.fieldIndex;
 
       if (frameIndex !== undefined && fieldIndex !== undefined) {
-        const field = frames[frameIndex].fields[fieldIndex];
-        if (field.labels) {
+        const field = frames[frameIndex]?.fields[fieldIndex];
+        if (field?.labels) {
           // Note that this may be an empty object in the case of a metric being rendered with no labels
           visibleLabels.push({
             labels: field.labels,


### PR DESCRIPTION

**What is this feature?**
Fix bug introduced in https://github.com/grafana/grafana/pull/59743

**Why do we need this feature?**
To keep visibility toggling from breaking explore view

**Who is this feature for?**
Users of prometheus/explore

**Which issue(s) does this PR fix?**:
Fixes https://github.com/grafana/grafana/issues/60138

**Special notes for your reviewer**:

