### PR TITLE
Chore: Add deprecation warnings for Sentry

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -21,6 +21,12 @@
     "ts-loader", // we should remove ts-loader and use babel-loader instead
     "ora", // we should bump this once we move to esm modules
 
+    // Sentry deprecated in favor of Grafana Faro for frontend logging.
+    // Major effort required to upgrade to latest Sentry, not worthwhile
+    "@sentry/browser",
+    "@sentry/types",
+    "@sentry/utils",
+
     // dep updates blocked by React 18
     "@testing-library/react",
     "@types/react",

--- a/pkg/api/frontend_logging.go
+++ b/pkg/api/frontend_logging.go
@@ -19,6 +19,7 @@ type frontendLogMessageHandler func(hs *HTTPServer, c *web.Context)
 const sentryLogEndpointPath = "/log"
 const grafanaJavascriptAgentEndpointPath = "/log-grafana-javascript-agent"
 
+/** @deprecated will be removed in the next major version */
 func NewFrontendLogMessageHandler(store *frontendlogging.SourceMapStore) frontendLogMessageHandler {
 	return func(hs *HTTPServer, c *web.Context) {
 		event := frontendlogging.FrontendSentryEvent{}

--- a/pkg/setting/setting_sentry.go
+++ b/pkg/setting/setting_sentry.go
@@ -1,5 +1,7 @@
 package setting
 
+import "github.com/go-kit/kit/log/level"
+
 type Sentry struct {
 	Enabled        bool    `json:"enabled"`
 	DSN            string  `json:"dsn"`
@@ -13,6 +15,7 @@ func (cfg *Cfg) readSentryConfig() {
 	raw := cfg.Raw.Section("log.frontend")
 	provider := raw.Key("provider").MustString("sentry")
 	if provider == "sentry" || provider != "grafana" {
+		level.Warn(cfg.Logger).Log("msg", "\"sentry\" frontend logging provider is deprecated and will be removed in the next major version. Use \"grafana\" provider instead.")
 		cfg.Sentry = Sentry{
 			Enabled:        raw.Key("enabled").MustBool(true),
 			DSN:            raw.Key("sentry_dsn").String(),

--- a/pkg/setting/setting_sentry.go
+++ b/pkg/setting/setting_sentry.go
@@ -15,7 +15,7 @@ func (cfg *Cfg) readSentryConfig() {
 	raw := cfg.Raw.Section("log.frontend")
 	provider := raw.Key("provider").MustString("sentry")
 	if provider == "sentry" || provider != "grafana" {
-		level.Warn(cfg.Logger).Log("msg", "\"sentry\" frontend logging provider is deprecated and will be removed in the next major version. Use \"grafana\" provider instead.")
+		_ = level.Warn(cfg.Logger).Log("msg", "\"sentry\" frontend logging provider is deprecated and will be removed in the next major version. Use \"grafana\" provider instead.")
 		cfg.Sentry = Sentry{
 			Enabled:        raw.Key("enabled").MustBool(true),
 			DSN:            raw.Key("sentry_dsn").String(),


### PR DESCRIPTION
**Why do we need this feature?**

Before there was Grafana Faro, we used Sentry js client to collect logs & errors from Grafana frontend. Currently Grafana frontend supports both Grafana Faro & Sentry, with Faro enabled on hosted grafana instances. I believe we should mark Sentry support as deprecated and eventually remove it altogether in favor of Faro. It doesn't make a lot of sense to spend effort to support Sentry, especially as it's introducing significant breaking changes with latest version.

This PR adds Sentry js libs to ignore list for renovate, and adds deprecation warning if Sentry logging is enabled.

Related:  https://github.com/grafana/grafana/pull/52880

# Deprecation notice

Sentry frontend logging provider will be removed with next major version.