### PR TITLE
Alerting: Adds TODO list

### DIFF
--- a/public/app/features/alerting/unified/TODO.md
+++ b/public/app/features/alerting/unified/TODO.md
@@ -1,0 +1,21 @@
+# Alerting TODO List
+
+## Rationale
+
+_This is an experiment, if it doesn't work or is disruptive to our workflow we'll revise and adapt._
+
+We often identify smaller items to work on while we refactor code or build a new feature. These items may be small enough not to deserve their own GitHub issue and might make a PR either confusing or too large.
+
+This document aims to make the threshold of adding such items very small to prevent ideas or small improvements from being forgotten or not recorded because we don't feel like creating a formal GitHub issue.
+
+If the item needs more rationale and you feel like a single sentence is inedequate to describe the issue, create a regular GitHub issue.
+
+## Improvements
+
+- Add a `edit` button to the alert detail page
+
+## Refactoring
+
+## Bug fixes
+
+_Preferably these should go to GitHub for discoverability, but not all bugs are equal, use your best judgment._


### PR DESCRIPTION
**What is this feature?**

Adds a `TODO.md` file for the alerting FE team.

**Why do we need this feature?**

An idea that was spawned from a conversation I struck up with @konrad147 where we often come up with smaller TODO items during our work on a PR that we never get around to formalize in a GitHub issue because it can be described in a single sentence and creating an issue with the correct set of labels (and writing a rationale) can be a barrier that prevents that from happening and they simply get lost.

**DO** use this file to add smaller items to work on, and it's encouraged to add things to it in a PR when you notice something that should be improved.

**Don't** use this file for adding anything that _should_ require its own GitHub issue. If the item requires additional rationale or if it's a painful bug _do_ create a proper GitHub issue. Use your best judgment.

**Who is this feature for?**

SWEs working on the Alerting Front-end.

**Special notes for your reviewer**:

Understandably there will be some confusion about whether this file is really necessary at all since it's rather unconventional.

This is an experiment, we're keen to see if we use it (or not) and if it's disruptive to our workflow. If it is, we'll reassess and adapt and if need be we can just remove this file and record those items in a single GitHub issue and admit it was a silly idea in the first place.

