### PR TITLE
Elasticsearch: backend: do not set name for time-fields

### DIFF
--- a/pkg/tsdb/elasticsearch/response_parser_test.go
+++ b/pkg/tsdb/elasticsearch/response_parser_test.go
@@ -853,7 +853,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[1].Len(), 2)
 			require.Equal(t, frame.Fields[2].Name, "Count")
 			require.Equal(t, frame.Fields[2].Len(), 2)
-			assert.Equal(t, frame.Fields[1].Config.DisplayNameFromDS, "")
+			require.Nil(t, frame.Fields[1].Config)
 		})
 
 		t.Run("Multiple metrics of same type", func(t *testing.T) {
@@ -900,7 +900,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[1].Len(), 1)
 			require.Equal(t, frame.Fields[2].Name, "Average test2")
 			require.Equal(t, frame.Fields[2].Len(), 1)
-			assert.Equal(t, frame.Fields[1].Config.DisplayNameFromDS, "")
+			require.Nil(t, frame.Fields[1].Config)
 		})
 
 		t.Run("With bucket_script", func(t *testing.T) {
@@ -1057,7 +1057,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[3].Len(), 2)
 			require.Equal(t, frame.Fields[4].Name, "params.var1 * params.var2 * 2")
 			require.Equal(t, frame.Fields[4].Len(), 2)
-			assert.Equal(t, frame.Fields[1].Config.DisplayNameFromDS, "")
+			require.Nil(t, frame.Fields[1].Config)
 		})
 	})
 

--- a/pkg/tsdb/elasticsearch/testdata/trimedges_string.golden.jsonc
+++ b/pkg/tsdb/elasticsearch/testdata/trimedges_string.golden.jsonc
@@ -1,6 +1,8 @@
 //  🌟 This was machine generated.  Do not edit. 🌟
 //  
-//  Frame[0] 
+//  Frame[0] {
+//      "type": "timeseries-multi"
+//  }
 //  Name: 
 //  Dimensions: 2 Fields by 3 Rows
 //  +-------------------------------+------------------+
@@ -20,15 +22,15 @@
   "frames": [
     {
       "schema": {
+        "meta": {
+          "type": "timeseries-multi"
+        },
         "fields": [
           {
             "name": "time",
             "type": "time",
             "typeInfo": {
               "frame": "time.Time"
-            },
-            "config": {
-              "displayNameFromDS": "Count"
             }
           },
           {

--- a/pkg/tsdb/elasticsearch/testdata_response/metric_complex.a.golden.jsonc
+++ b/pkg/tsdb/elasticsearch/testdata_response/metric_complex.a.golden.jsonc
@@ -1,6 +1,8 @@
 //  🌟 This was machine generated.  Do not edit. 🌟
 //  
-//  Frame[0] 
+//  Frame[0] {
+//      "type": "timeseries-multi"
+//  }
 //  Name: 
 //  Dimensions: 2 Fields by 3 Rows
 //  +-------------------------------+--------------------+
@@ -15,7 +17,9 @@
 //  
 //  
 //  
-//  Frame[1] 
+//  Frame[1] {
+//      "type": "timeseries-multi"
+//  }
 //  Name: 
 //  Dimensions: 2 Fields by 3 Rows
 //  +-------------------------------+--------------------+
@@ -30,7 +34,9 @@
 //  
 //  
 //  
-//  Frame[2] 
+//  Frame[2] {
+//      "type": "timeseries-multi"
+//  }
 //  Name: 
 //  Dimensions: 2 Fields by 3 Rows
 //  +-------------------------------+--------------------+
@@ -45,7 +51,9 @@
 //  
 //  
 //  
-//  Frame[3] 
+//  Frame[3] {
+//      "type": "timeseries-multi"
+//  }
 //  Name: 
 //  Dimensions: 2 Fields by 3 Rows
 //  +-------------------------------+--------------------+
@@ -60,7 +68,9 @@
 //  
 //  
 //  
-//  Frame[4] 
+//  Frame[4] {
+//      "type": "timeseries-multi"
+//  }
 //  Name: 
 //  Dimensions: 2 Fields by 3 Rows
 //  +-------------------------------+--------------------+
@@ -75,7 +85,9 @@
 //  
 //  
 //  
-//  Frame[5] 
+//  Frame[5] {
+//      "type": "timeseries-multi"
+//  }
 //  Name: 
 //  Dimensions: 2 Fields by 3 Rows
 //  +-------------------------------+--------------------+
@@ -95,15 +107,15 @@
   "frames": [
     {
       "schema": {
+        "meta": {
+          "type": "timeseries-multi"
+        },
         "fields": [
           {
             "name": "time",
             "type": "time",
             "typeInfo": {
               "frame": "time.Time"
-            },
-            "config": {
-              "displayNameFromDS": "val3 Max float"
             }
           },
           {
@@ -139,15 +151,15 @@
     },
     {
       "schema": {
+        "meta": {
+          "type": "timeseries-multi"
+        },
         "fields": [
           {
             "name": "time",
             "type": "time",
             "typeInfo": {
               "frame": "time.Time"
-            },
-            "config": {
-              "displayNameFromDS": "val3 Min float"
             }
           },
           {
@@ -183,15 +195,15 @@
     },
     {
       "schema": {
+        "meta": {
+          "type": "timeseries-multi"
+        },
         "fields": [
           {
             "name": "time",
             "type": "time",
             "typeInfo": {
               "frame": "time.Time"
-            },
-            "config": {
-              "displayNameFromDS": "val2 Max float"
             }
           },
           {
@@ -227,15 +239,15 @@
     },
     {
       "schema": {
+        "meta": {
+          "type": "timeseries-multi"
+        },
         "fields": [
           {
             "name": "time",
             "type": "time",
             "typeInfo": {
               "frame": "time.Time"
-            },
-            "config": {
-              "displayNameFromDS": "val2 Min float"
             }
           },
           {
@@ -271,15 +283,15 @@
     },
     {
       "schema": {
+        "meta": {
+          "type": "timeseries-multi"
+        },
         "fields": [
           {
             "name": "time",
             "type": "time",
             "typeInfo": {
               "frame": "time.Time"
-            },
-            "config": {
-              "displayNameFromDS": "val1 Max float"
             }
           },
           {
@@ -315,15 +327,15 @@
     },
     {
       "schema": {
+        "meta": {
+          "type": "timeseries-multi"
+        },
         "fields": [
           {
             "name": "time",
             "type": "time",
             "typeInfo": {
               "frame": "time.Time"
-            },
-            "config": {
-              "displayNameFromDS": "val1 Min float"
             }
           },
           {

--- a/pkg/tsdb/elasticsearch/testdata_response/metric_multi.a.golden.jsonc
+++ b/pkg/tsdb/elasticsearch/testdata_response/metric_multi.a.golden.jsonc
@@ -1,6 +1,8 @@
 //  🌟 This was machine generated.  Do not edit. 🌟
 //  
-//  Frame[0] 
+//  Frame[0] {
+//      "type": "timeseries-multi"
+//  }
 //  Name: 
 //  Dimensions: 2 Fields by 3 Rows
 //  +-------------------------------+-------------------+
@@ -20,15 +22,15 @@
   "frames": [
     {
       "schema": {
+        "meta": {
+          "type": "timeseries-multi"
+        },
         "fields": [
           {
             "name": "time",
             "type": "time",
             "typeInfo": {
               "frame": "time.Time"
-            },
-            "config": {
-              "displayNameFromDS": "Max float"
             }
           },
           {

--- a/pkg/tsdb/elasticsearch/testdata_response/metric_multi.b.golden.jsonc
+++ b/pkg/tsdb/elasticsearch/testdata_response/metric_multi.b.golden.jsonc
@@ -1,6 +1,8 @@
 //  🌟 This was machine generated.  Do not edit. 🌟
 //  
-//  Frame[0] 
+//  Frame[0] {
+//      "type": "timeseries-multi"
+//  }
 //  Name: 
 //  Dimensions: 2 Fields by 3 Rows
 //  +-------------------------------+---------------------+
@@ -20,15 +22,15 @@
   "frames": [
     {
       "schema": {
+        "meta": {
+          "type": "timeseries-multi"
+        },
         "fields": [
           {
             "name": "time",
             "type": "time",
             "typeInfo": {
               "frame": "time.Time"
-            },
-            "config": {
-              "displayNameFromDS": "Min float"
             }
           },
           {

--- a/pkg/tsdb/elasticsearch/testdata_response/metric_simple.a.golden.jsonc
+++ b/pkg/tsdb/elasticsearch/testdata_response/metric_simple.a.golden.jsonc
@@ -1,6 +1,8 @@
 //  🌟 This was machine generated.  Do not edit. 🌟
 //  
-//  Frame[0] 
+//  Frame[0] {
+//      "type": "timeseries-multi"
+//  }
 //  Name: 
 //  Dimensions: 2 Fields by 4 Rows
 //  +-------------------------------+--------------------+
@@ -16,7 +18,9 @@
 //  
 //  
 //  
-//  Frame[1] 
+//  Frame[1] {
+//      "type": "timeseries-multi"
+//  }
 //  Name: 
 //  Dimensions: 2 Fields by 4 Rows
 //  +-------------------------------+--------------------+
@@ -32,7 +36,9 @@
 //  
 //  
 //  
-//  Frame[2] 
+//  Frame[2] {
+//      "type": "timeseries-multi"
+//  }
 //  Name: 
 //  Dimensions: 2 Fields by 4 Rows
 //  +-------------------------------+--------------------+
@@ -53,15 +59,15 @@
   "frames": [
     {
       "schema": {
+        "meta": {
+          "type": "timeseries-multi"
+        },
         "fields": [
           {
             "name": "time",
             "type": "time",
             "typeInfo": {
               "frame": "time.Time"
-            },
-            "config": {
-              "displayNameFromDS": "val3"
             }
           },
           {
@@ -99,15 +105,15 @@
     },
     {
       "schema": {
+        "meta": {
+          "type": "timeseries-multi"
+        },
         "fields": [
           {
             "name": "time",
             "type": "time",
             "typeInfo": {
               "frame": "time.Time"
-            },
-            "config": {
-              "displayNameFromDS": "val2"
             }
           },
           {
@@ -145,15 +151,15 @@
     },
     {
       "schema": {
+        "meta": {
+          "type": "timeseries-multi"
+        },
         "fields": [
           {
             "name": "time",
             "type": "time",
             "typeInfo": {
               "frame": "time.Time"
-            },
-            "config": {
-              "displayNameFromDS": "val1"
             }
           },
           {


### PR DESCRIPTION
short version:
this PR changes the backend-mode so that for timeseries-data, witth a time-field and a number-field, the time-field does not get an "improved name", only the value-field. this is how it should work, and how the frontend-mode work.

long version:
the way we assign names to dataframe-fields in elasticsearch-backend works like this:

- frames are generated
- after every frame has been generated, we go through those frames, and enhance the names of the fields

frames are generated at two places:
- A. when the last aggregation is `date_histogram`, frames are generated in  [processMetrics](https://github.com/grafana/grafana/blob/main/pkg/tsdb/elasticsearch/response_parser.go#L144) , which generates timeseries-frames, with two fields, a timestamp field and a number field. these dataframes are suitable for displaying in a timeseries-graph
- B. when the last aggregation is not a `date_histogram`, frames are generated in [processAggregationDocs](https://github.com/grafana/grafana/blob/main/pkg/tsdb/elasticsearch/response_parser.go#L336), which generates table-like dataframes, (string and number fields, any number of them). this data is usually displayed in a table

the names are enhanced in [nameFields](https://github.com/grafana/grafana/blob/main/pkg/tsdb/elasticsearch/response_parser.go#L524) , which processes every frame. but, if we analyze the code-flow, we find out that only `processMetrics` frames get enhanced names, for `processAggregationDocs` frames no new name is found. there are two "proofs" for this:
- the name-generation relies on artificial field-labels that are added by `processMetrics`, like `"metric"` or `"field"`. these are not set by `processAggregationDocs`
- if a query-alias is used, technically that gets applied to `processAggregationDocs` too, but that's something that should not happen. the alias-field-tooltip says "alias only work for timeseries queries", and, indeed, in frontend-mode, `processAggregationDocs` frames do not get aliased.

so, in theory, we only need to apply the name-enhancing to `processMetrics` frames, which have a fixed structure anyway (time&number). the problem is, how do we know if the frame was generated by `processMetrics`?

i changed `processMetrics` so that when it creates a dataframe, it sets the `frame.config.type` to `timeSeriesMulti`. it is the correct value for this frame-type, and also, this allows us to later find out that this is a frame from `processMetrics`.


(NOTE: there may be a second PR afterwards, where we switch from `field.config.displayNameFromDS` to something else)