### PR TITLE
Loki/Prometheus: Fix wrong queries executed in split view

### DIFF
--- a/public/app/plugins/datasource/loki/components/monaco-query-field/MonacoQueryField.tsx
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/MonacoQueryField.tsx
@@ -116,6 +116,7 @@ const MonacoQueryField = ({ languageProvider, history, onBlur, onRunQuery, initi
           ensureLogQL(monaco);
         }}
         onMount={(editor, monaco) => {
+          // Monaco has a bug where it runs actions on all instances (https://github.com/microsoft/monaco-editor/issues/2947), so we ensure actions are executed on instance-level with this ContextKey.
           const isEditorFocused = editor.createContextKey<boolean>('isEditorFocused' + id, false);
           // we setup on-blur
           editor.onDidBlurEditorWidget(() => {
@@ -174,7 +175,7 @@ const MonacoQueryField = ({ languageProvider, history, onBlur, onRunQuery, initi
             },
             'isEditorFocused' + id
           );
-          
+
           editor.onDidFocusEditorText(() => {
             isEditorFocused.set(true);
             if (editor.getValue().trim() === '') {

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/MonacoQueryField.tsx
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/MonacoQueryField.tsx
@@ -172,7 +172,7 @@ const MonacoQueryField = ({ languageProvider, history, onBlur, onRunQuery, initi
             () => {
               onRunQueryRef.current(editor.getValue());
             },
-            'runQueryCondition' + id
+            'isEditorFocused' + id
           );
           
           editor.onDidFocusEditorText(() => {

--- a/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryField.tsx
+++ b/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryField.tsx
@@ -88,12 +88,12 @@ const getStyles = (theme: GrafanaTheme2, placeholder: string) => {
 };
 
 const MonacoQueryField = (props: Props) => {
-  // we need only one instance of `overrideSerices` during the lifetime of the react component
+  const id = uuidv4();
+
+  // we need only one instance of `overrideServices` during the lifetime of the react component
   const overrideServicesRef = useRef(getOverrideServices());
   const containerRef = useRef<HTMLDivElement>(null);
   const { languageProvider, history, onBlur, onRunQuery, initialValue, placeholder, onChange } = props;
-
-  const id = uuidv4();
 
   const lpRef = useLatest(languageProvider);
   const historyRef = useLatest(history);


### PR DESCRIPTION
**What is this feature?**

Currently the wrong query is executed when multiple Monaco editors are present. This PR adds a `context` value, which has to be true, to the relevant `editor.addCommand` call.

**Which issue(s) does this PR fix?**:

Fixes #60059

