### PR TITLE
Alerting: Fix slack receiver to close file descriptors when they're not needed anymore

### DIFF
--- a/pkg/services/ngalert/notifier/channels/slack.go
+++ b/pkg/services/ngalert/notifier/channels/slack.go
@@ -477,6 +477,11 @@ func (sn *SlackNotifier) createImageMultipart(image ngmodels.Image, channel, com
 	if err != nil {
 		return nil, nil, err
 	}
+	defer func() {
+		if err := f.Close(); err != nil {
+			sn.log.Error("Failed to close image file reader", "error", err)
+		}
+	}()
 
 	fw, err := w.CreateFormFile("file", image.Path)
 	if err != nil {

--- a/pkg/services/ngalert/notifier/channels/slack_test.go
+++ b/pkg/services/ngalert/notifier/channels/slack_test.go
@@ -409,6 +409,7 @@ func setupSlackForTests(t *testing.T, settings string) (*SlackNotifier, *slackRe
 	f, err := os.Create(t.TempDir() + "test.png")
 	require.NoError(t, err)
 	t.Cleanup(func() {
+		_ = f.Close()
 		if err := os.Remove(f.Name()); err != nil {
 			t.Logf("failed to delete test file: %s", err)
 		}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
The problem was introduced recently in #59163. This PR fixes Slack receivers to close file descriptors when they are not needed anymore.