### PR TITLE
Chore: Deny gopkg.in/yaml.v2

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -19,6 +19,7 @@ include-go-root = true
 packages = ["io/ioutil"]
 [[linters-settings.depguard.packages-with-error-message]]
 "io/ioutil" = "Deprecated: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details."
+"gopkg.in/yaml.v2" = "Grafana packages are not allowed to depend on gopkg.in/yaml.v2 as gopkg.in/yaml.v3 is now available"
 
 [linters-settings.gocritic]
 enabled-checks = ["ruleguard"]


### PR DESCRIPTION
**What is this feature?**

Follow-up to #59897 explicitly forbidding future code from depending on gopkg.in/yaml.v2 to encourage universal v3 adoption.
