### PR TITLE
Prometheus: Fix exemplar popover overflow

### DIFF
--- a/public/app/plugins/panel/timeseries/plugins/ExemplarMarker.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/ExemplarMarker.tsx
@@ -37,7 +37,22 @@ export const ExemplarMarker: React.FC<ExemplarMarkerProps> = ({
   const [isOpen, setIsOpen] = useState(false);
   const [markerElement, setMarkerElement] = React.useState<HTMLDivElement | null>(null);
   const [popperElement, setPopperElement] = React.useState<HTMLDivElement | null>(null);
-  const { styles: popperStyles, attributes } = usePopper(markerElement, popperElement);
+  const { styles: popperStyles, attributes } = usePopper(markerElement, popperElement, {
+    modifiers: [
+      {
+        name: 'preventOverflow',
+        options: {
+          altAxis: true,
+        },
+      },
+      {
+        name: 'flip',
+        options: {
+          fallbackPlacements: ['top', 'left-start'],
+        },
+      },
+    ],
+  });
   const popoverRenderTimeout = useRef<NodeJS.Timer>();
 
   const getSymbol = () => {


### PR DESCRIPTION
**What is this feature?**

The issue

[The issue](https://user-images.githubusercontent.com/820946/207116295-a8ea928b-6173-4b5e-8a9e-8dbf0f3cbde2.mov)

After the fix

[After the fix](https://user-images.githubusercontent.com/820946/207116368-d992539d-e9e6-4b90-bf93-079246719cfd.mov)

See the documentation about modifiers:
- Prevent Overflow: https://popper.js.org/docs/v2/modifiers/prevent-overflow/#altaxis
- Flip: https://popper.js.org/docs/v2/modifiers/flip/#fallbackplacements

This is a fix only for this issue. modifiers will kick in when they are needed. 

Fixes https://github.com/grafana/grafana/issues/59846

**Special notes for your reviewer**:
Create a dashboard using Prometheus as a datasource with exemplars enabled. Have a panel that renders a time-series chart. Place it at the bottom of the page. Don't allow scroll bars to appear. (Check the video as a reference). Try to hover over exemplar markers that are most close to the top. 
