### PR TITLE
Backend: Consistently use context RemoteAddr function to determine remote address.

### DIFF
--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -195,7 +195,7 @@ func (hs *HTTPServer) LoginPost(c *models.ReqContext) response.Response {
 		ReqContext: c,
 		Username:   cmd.User,
 		Password:   cmd.Password,
-		IpAddress:  c.Req.RemoteAddr,
+		IpAddress:  c.RemoteAddr(),
 		Cfg:        hs.Cfg,
 	}
 

--- a/pkg/api/org_invite.go
+++ b/pkg/api/org_invite.go
@@ -102,7 +102,7 @@ func (hs *HTTPServer) AddOrgInvite(c *models.ReqContext) response.Response {
 		return response.Error(500, "Could not generate random string", err)
 	}
 	cmd.Role = inviteDto.Role
-	cmd.RemoteAddr = c.Req.RemoteAddr
+	cmd.RemoteAddr = c.RemoteAddr()
 
 	if err := hs.tempUserService.CreateTempUser(c.Req.Context(), &cmd); err != nil {
 		return response.Error(500, "Failed to save invite to database", err)

--- a/pkg/api/signup.go
+++ b/pkg/api/signup.go
@@ -56,7 +56,7 @@ func (hs *HTTPServer) SignUp(c *models.ReqContext) response.Response {
 	if err != nil {
 		return response.Error(500, "Failed to generate random string", err)
 	}
-	cmd.RemoteAddr = c.Req.RemoteAddr
+	cmd.RemoteAddr = c.RemoteAddr()
 
 	if err := hs.tempUserService.CreateTempUser(c.Req.Context(), &cmd); err != nil {
 		return response.Error(500, "Failed to create signup", err)


### PR DESCRIPTION
Our `ReqContext` model provides a `RemoteAddr()` helper that we use to determine the user's IP address for logging purposes.  This is designed to account for things like reverse proxies so that we log the correct IP rather than the IP of the proxy itself.

This PR corrects a few places where the code uses the incoming request RemoteAddr property instead of the context helper.

It's worth noting that this PR does not update `initContextWithAuthProxy`, which does need to use the IP of the proxy to determine whether the proxy is on the allowed list.