### PR TITLE
Public Dashboards: Dont make annotations request when access token is falsey

### DIFF
--- a/public/app/features/dashboard/services/PublicDashboardDataSource.test.ts
+++ b/public/app/features/dashboard/services/PublicDashboardDataSource.test.ts
@@ -45,6 +45,34 @@ describe('PublicDashboardDatasource', () => {
     expect(annotation?.queryType).toEqual(GrafanaQueryType.Annotations);
   });
 
+  test('will not fetch annotations when access token is falsey', async () => {
+    mockDatasourceRequest.mockReset();
+    mockDatasourceRequest.mockReturnValue(Promise.resolve([]));
+
+    const ds = new PublicDashboardDataSource('public');
+    const panelId = 1;
+    const publicDashboardAccessToken = undefined;
+
+    await ds.query({
+      maxDataPoints: 10,
+      intervalMs: 5000,
+      targets: [
+        {
+          refId: 'A',
+          datasource: { uid: GRAFANA_DATASOURCE_NAME, type: 'sample' },
+          queryType: GrafanaQueryType.Annotations,
+        },
+      ],
+      panelId,
+      publicDashboardAccessToken,
+      range: { from: new Date().toLocaleString(), to: new Date().toLocaleString() } as unknown as TimeRange,
+    } as DataQueryRequest);
+
+    const mock = mockDatasourceRequest.mock;
+
+    expect(mock.calls.length).toBe(0);
+  });
+
   test('fetches results from the pubdash annotations endpoint when it is an annotation query', async () => {
     mockDatasourceRequest.mockReset();
     mockDatasourceRequest.mockReturnValue(Promise.resolve([]));

--- a/public/app/features/dashboard/services/PublicDashboardDataSource.ts
+++ b/public/app/features/dashboard/services/PublicDashboardDataSource.ts
@@ -130,7 +130,10 @@ export class PublicDashboardDataSource extends DataSourceApi<DataQuery, DataSour
       from: from.valueOf(),
       to: to.valueOf(),
     };
-    const annotations = await getBackendSrv().get(`/api/public/dashboards/${accessToken}/annotations`, params);
+
+    const annotations = accessToken
+      ? await getBackendSrv().get(`/api/public/dashboards/${accessToken}/annotations`, params)
+      : [];
 
     return { data: [toDataFrame(annotations)] };
   }


### PR DESCRIPTION
**Changes**
Don't fetch annotations when the access token is falsey.

**How to test**
Follow the steps to reproduce in the issue below

fixes https://github.com/grafana/grafana-enterprise/issues/4589