### PR TITLE
Chore: Remove `%w` and `err` from print line

### DIFF
--- a/pkg/build/cmd/genversions.go
+++ b/pkg/build/cmd/genversions.go
@@ -21,7 +21,7 @@ func GenerateMetadata(c *cli.Context) (config.Metadata, error) {
 
 	tag, ok := os.LookupEnv("DRONE_TAG")
 	if !ok {
-		fmt.Println("DRONE_TAG envvar not present, %w", err)
+		fmt.Println("DRONE_TAG envvar not present")
 	}
 
 	var releaseMode config.ReleaseMode


### PR DESCRIPTION
**Why do we need this feature?**

Cleans up the console log when the `DRONE_TAG` is missing.