### PR TITLE
[v9.3.x] CloudWatch: Fix deeplinks to still be able to pass log group names

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/utils/datalinks.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/utils/datalinks.test.ts
@@ -35,6 +35,7 @@ describe('addDataLinksToLogsResponse', () => {
           refId: 'A',
           expression: 'stats count(@message) by bin(1h)',
           logGroupNames: ['fake-log-group-one', 'fake-log-group-two'],
+          logGroups: [{}], // empty log groups should be ignored and fall back to logGroupNames
           region: 'us-east-1',
         },
       ],
@@ -115,6 +116,7 @@ describe('addDataLinksToLogsResponse', () => {
         {
           refId: 'A',
           expression: 'stats count(@message) by bin(1h)',
+          logGroupNames: [''],
           logGroups: [
             { value: 'arn:aws:logs:us-east-1:111111111111:log-group:/aws/lambda/test:*' },
             { value: 'arn:aws:logs:us-east-2:222222222222:log-group:/ecs/prometheus:*' },
@@ -174,6 +176,7 @@ describe('addDataLinksToLogsResponse', () => {
         {
           refId: 'A',
           expression: 'stats count(@message) by bin(1h)',
+          logGroupNames: [''],
           logGroups: [{ value: 'arn:aws:logs:us-east-1:111111111111:log-group:/aws/lambda/test' }],
           region: 'us-east-1',
         } as CloudWatchQuery,

--- a/public/app/plugins/datasource/cloudwatch/utils/datalinks.ts
+++ b/public/app/plugins/datasource/cloudwatch/utils/datalinks.ts
@@ -70,16 +70,13 @@ function createAwsConsoleLink(
   replace: (target: string, fieldName?: string) => string,
   getVariableValue: (value: string) => string[]
 ) {
-  const arns = target.logGroups?.flatMap((group) => {
-    if (group.value === undefined) {
-      return [];
-    }
-    return [group.value.replace(/:\*$/, '')]; // remove `:*` from end of arn
-  });
-  const logGroupNames = target.logGroupNames;
-  const sources = arns ?? logGroupNames;
+  const arns = (target.logGroups ?? [])
+    .filter((group) => group?.value)
+    .map((group) => (group.value ?? '').replace(/:\*$/, '')); // remove `:*` from end of arn
+  const logGroupNames = target.logGroupNames ?? [];
+  const sources = arns?.length ? arns : logGroupNames;
   const interpolatedExpression = target.expression ? replace(target.expression) : '';
-  const interpolatedGroups = sources?.flatMap(getVariableValue) ?? [];
+  const interpolatedGroups = sources?.flatMap(getVariableValue);
 
   const urlProps: AwsUrl = {
     end: range.to.toISOString(),


### PR DESCRIPTION
Manual backport of https://github.com/grafana/grafana/pull/59809