### PR TITLE
Phlare: Transition from LogQL/PromQL to Phlare should keep the query

### DIFF
--- a/public/app/plugins/datasource/phlare/datasource.test.ts
+++ b/public/app/plugins/datasource/phlare/datasource.test.ts
@@ -1,0 +1,66 @@
+import { AbstractLabelOperator, DataSourceInstanceSettings, PluginMetaInfo, PluginType } from '@grafana/data';
+
+import { PhlareDataSource } from './datasource';
+
+describe('Phlare data source', () => {
+  let ds: PhlareDataSource;
+  beforeEach(() => {
+    ds = new PhlareDataSource(defaultSettings);
+  });
+
+  describe('importing queries', () => {
+    it('keeps all labels and values', async () => {
+      const queries = await ds.importFromAbstractQueries([
+        {
+          refId: 'A',
+          labelMatchers: [
+            { name: 'foo', operator: AbstractLabelOperator.Equal, value: 'bar' },
+            { name: 'foo2', operator: AbstractLabelOperator.Equal, value: 'bar2' },
+          ],
+        },
+      ]);
+      expect(queries[0].labelSelector).toBe('{foo="bar", foo2="bar2"}');
+    });
+  });
+
+  describe('exporting queries', () => {
+    it('keeps all labels and values', async () => {
+      const queries = await ds.exportToAbstractQueries([
+        {
+          refId: 'A',
+          labelSelector: '{foo="bar", foo2="bar2"}',
+          queryType: 'both',
+          profileTypeId: '',
+          groupBy: [''],
+        },
+      ]);
+      expect(queries).toMatchObject([
+        {
+          refId: 'A',
+          labelMatchers: [
+            { name: 'foo', operator: AbstractLabelOperator.Equal, value: 'bar' },
+            { name: 'foo2', operator: AbstractLabelOperator.Equal, value: 'bar2' },
+          ],
+        },
+      ]);
+    });
+  });
+});
+
+const defaultSettings: DataSourceInstanceSettings = {
+  id: 0,
+  uid: 'phlare',
+  type: 'profiling',
+  name: 'phlare',
+  access: 'proxy',
+  meta: {
+    id: 'phlare',
+    name: 'phlare',
+    type: PluginType.datasource,
+    info: {} as PluginMetaInfo,
+    module: '',
+    baseUrl: '',
+  },
+  jsonData: {},
+  readOnly: false,
+};

--- a/public/app/plugins/datasource/phlare/datasource.ts
+++ b/public/app/plugins/datasource/phlare/datasource.ts
@@ -1,7 +1,10 @@
+import Prism, { Grammar } from 'prismjs';
 import { Observable, of } from 'rxjs';
 
-import { DataQueryRequest, DataQueryResponse, DataSourceInstanceSettings } from '@grafana/data';
+import { AbstractQuery, DataQueryRequest, DataQueryResponse, DataSourceInstanceSettings } from '@grafana/data';
 import { DataSourceWithBackend } from '@grafana/runtime';
+
+import { extractLabelMatchers, toPromLikeExpr } from '../prometheus/language_utils';
 
 import { normalizeQuery } from './QueryEditor/QueryEditor';
 import { PhlareDataSourceOptions, Query, ProfileTypeMessage, SeriesMessage } from './types';
@@ -45,4 +48,58 @@ export class PhlareDataSource extends DataSourceWithBackend<Query, PhlareDataSou
   async getLabelNames(): Promise<string[]> {
     return await super.getResource('labelNames');
   }
+
+  async importFromAbstractQueries(abstractQueries: AbstractQuery[]): Promise<Query[]> {
+    return abstractQueries.map((abstractQuery) => this.importFromAbstractQuery(abstractQuery));
+  }
+
+  importFromAbstractQuery(labelBasedQuery: AbstractQuery): Query {
+    return {
+      refId: labelBasedQuery.refId,
+      labelSelector: toPromLikeExpr(labelBasedQuery),
+      queryType: 'both',
+      profileTypeId: '',
+      groupBy: [''],
+    };
+  }
+
+  async exportToAbstractQueries(queries: Query[]): Promise<AbstractQuery[]> {
+    return queries.map((query) => this.exportToAbstractQuery(query));
+  }
+
+  exportToAbstractQuery(query: Query): AbstractQuery {
+    const phlareQuery = query.labelSelector;
+    if (!phlareQuery || phlareQuery.length === 0) {
+      return { refId: query.refId, labelMatchers: [] };
+    }
+    const tokens = Prism.tokenize(phlareQuery, grammar);
+    return {
+      refId: query.refId,
+      labelMatchers: extractLabelMatchers(tokens),
+    };
+  }
 }
+
+const grammar: Grammar = {
+  'context-labels': {
+    pattern: /\{[^}]*(?=}?)/,
+    greedy: true,
+    inside: {
+      comment: {
+        pattern: /#.*/,
+      },
+      'label-key': {
+        pattern: /[a-zA-Z_]\w*(?=\s*(=|!=|=~|!~))/,
+        alias: 'attr-name',
+        greedy: true,
+      },
+      'label-value': {
+        pattern: /"(?:\\.|[^\\"])*"/,
+        greedy: true,
+        alias: 'attr-value',
+      },
+      punctuation: /[{]/,
+    },
+  },
+  punctuation: /[{}(),.]/,
+};


### PR DESCRIPTION
**What is this feature?**

Keeps the Phlare query when transitioning from LogQL/PromQL.

**Why do we need this feature?**

Makes it easier for users to keep labels rather than typing them out again.

**Who is this feature for?**

Users.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/58368

