### PR TITLE
Logs: Fix Logs Pagination Button styling

### DIFF
--- a/public/app/features/explore/LogsNavigationPages.tsx
+++ b/public/app/features/explore/LogsNavigationPages.tsx
@@ -51,7 +51,7 @@ export function LogsNavigationPages({
             <button
               type="button"
               data-testid={`page${index + 1}`}
-              className={styles.page}
+              className={cx(clearButtonStyles(theme), styles.page)}
               key={page.queryRange.to}
               onClick={() => {
                 reportInteraction('grafana_explore_logs_pagination_clicked', {
@@ -102,7 +102,6 @@ const getStyles = (theme: GrafanaTheme2, loading: boolean) => {
       flex-direction: column;
     `,
     page: css`
-      ${clearButtonStyles(theme)}
       display: flex;
       margin: ${theme.spacing(2)} 0;
       cursor: ${loading ? 'auto' : 'pointer'};


### PR DESCRIPTION
**Why do we need this feature?**

Current styling is weirdly broken:
![image](https://user-images.githubusercontent.com/8092184/207297830-ac121a40-d9ad-4e49-9258-07a48026a207.png)

`clearButtonStyles(theme)` already resolves to a css class and not css strings.


