### PR TITLE
Bugfix: Attach correct link to "levitate detect breaking changes"-message included in PR

### DIFF
--- a/.github/workflows/detect-breaking-changes-build.yml
+++ b/.github/workflows/detect-breaking-changes-build.yml
@@ -108,7 +108,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: ['buildPR', 'buildBase']
     env:
-      GITHUB_STEP_NUMBER: 7
+      GITHUB_STEP_NUMBER: 8
 
     steps:
       - uses: actions/checkout@v3
@@ -134,8 +134,9 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
+              const name = 'Detect breaking changes';
               const script = require('./.github/workflows/scripts/pr-get-job-link.js')
-              await script({github, context, core})
+              await script({name, github, context, core})
 
       - name: Detect breaking changes
         id: breaking-changes

--- a/.github/workflows/scripts/pr-get-job-link.js
+++ b/.github/workflows/scripts/pr-get-job-link.js
@@ -1,13 +1,9 @@
 
-module.exports = async ({ github, context, core }) => {
-    const name = "Detect breaking changes";
+module.exports = async ({ name, github, context, core }) => {
     const { owner, repo } = context.repo;
     const url = `https://api.github.com/repos/${owner}/${repo}/actions/runs/${context.runId}/jobs`
-    
     const result = await github.request(url);
     const job = result.jobs.find(j => j.name === name);
-    const stepIndex = job.steps.findIndex(s => s.name === name);
-    const link = `${job.html_url}#step:${stepIndex + 1}:1`;
     
-    core.setOutput('link', link);
+    core.setOutput('link', job.html_url);
 }

--- a/.github/workflows/scripts/pr-get-job-link.js
+++ b/.github/workflows/scripts/pr-get-job-link.js
@@ -1,9 +1,13 @@
 
 module.exports = async ({ github, context, core }) => {
+    const name = "Detect breaking changes";
     const { owner, repo } = context.repo;
     const url = `https://api.github.com/repos/${owner}/${repo}/actions/runs/${context.runId}/jobs`
-    const result = await github.request(url)
-    const link = `https://github.com/grafana/grafana/runs/${result.data.jobs[0].id}?check_suite_focus=true`;
-
+    
+    const result = await github.request(url);
+    const job = result.jobs.find(j => j.name === name);
+    const stepIndex = job.steps.findIndex(s => s.name === name);
+    const link = `${job.html_url}#step:${stepIndex + 1}:1`;
+    
     core.setOutput('link', link);
 }

--- a/.github/workflows/scripts/pr-get-job-link.js
+++ b/.github/workflows/scripts/pr-get-job-link.js
@@ -5,5 +5,5 @@ module.exports = async ({ name, github, context, core }) => {
     const result = await github.request(url);
     const job = result.jobs.find(j => j.name === name);
     
-    core.setOutput('link', job.html_url);
+    core.setOutput('link', `${job.html_url}?check_suite_focus=true`);
 }


### PR DESCRIPTION
**What is this feature?**
The link that gets added to the "Detect breaking changes" message posted by Levitate pointed towards the wrong build step. This PR will change so it should point to the correct job and step.


**Why do we need this feature?**
To make it easier for developers of Grafana to view the detect breaking changed output.

**Who is this feature for?**
Developers of grafana/grafana

**Which issue(s) does this PR fix?**:
No issue reported

**Special notes for your reviewer**:

