### PR TITLE
Futures: Introduce common util for scheduler and futures

### DIFF
--- a/pkg/util/x/parallel/future.go
+++ b/pkg/util/x/parallel/future.go
@@ -114,6 +114,7 @@ func (f *Future[T]) Start() {
 
 		f.startTime = f.opts.Now()
 
+		defer finishFn()
 		if !f.opts.CrashOnPanic {
 			defer recoverFn()
 		}
@@ -123,8 +124,6 @@ func (f *Future[T]) Start() {
 			Value: val,
 			Error: err,
 		}
-
-		finishFn()
 
 		if span != nil {
 			if err != nil {

--- a/pkg/util/x/parallel/future.go
+++ b/pkg/util/x/parallel/future.go
@@ -1,0 +1,157 @@
+package parallel
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/grafana/grafana/pkg/util/errutil"
+)
+
+// ErrPanicked denotes recovering from a panic in a Future.
+var ErrPanicked = errutil.NewBase(errutil.StatusInternal, "parallel.panic")
+
+// RunFuture creates a new [Future] using [NewFuture] and starts it in
+// the background before returning.
+func RunFuture[T any](ctx context.Context, fn func(context.Context) (T, error), opts FutureOpts) *Future[T] {
+	f := NewFuture(ctx, fn, opts)
+	f.Start()
+	return f
+}
+
+// NewFuture creates a new [Future] that will run a function returning
+// a value of any type and an [error].
+//
+// The Future is not started automatically and must be started manually
+// using either [Future.Start] or a [Scheduler]
+// (possibly via a [Group], to simplify the collection of the result).
+func NewFuture[T any](ctx context.Context, fn func(context.Context) (T, error), opts FutureOpts) *Future[T] {
+	done := make(chan struct{})
+	future := &Future[T]{
+		fn:   fn,
+		ctx:  ctx,
+		done: done,
+		opts: opts,
+	}
+
+	return future
+}
+
+// FutureOpts contain runtime options for running a [Future].
+type FutureOpts struct {
+	// CrashOnPanic overrides the default panic recovery and allows a
+	// [Future] to retain the default Go-routine behavior of crashing
+	// the application in case a failure occurs.
+	CrashOnPanic bool
+	// NowFunc allows overriding the function used to determine the
+	// start and end time of a [Future]. Primarily for testing.
+	NowFunc func() time.Time
+}
+
+// A Future is a concurrency primitive running a given task in the
+// background yielding either a value or an error in a [Result] when
+// completed.
+type Future[T any] struct {
+	fn       func(context.Context) (T, error)
+	ctx      context.Context
+	once     sync.Once
+	done     chan struct{}
+	opts     FutureOpts
+	finishFn func()
+
+	result    Result[T]
+	startTime time.Time
+	endTime   time.Time
+}
+
+// Result combines an arbitrary value and an [error].
+type Result[T any] struct {
+	Value T
+	Error error
+}
+
+// Start runs the [Future] in the background if it has not already run.
+// Start will only start a Future once, and will immediately return on
+// subsequent calls (it is idempotent).
+func (f *Future[T]) Start() {
+	finishFn := func() {
+		f.endTime = f.opts.Now()
+		close(f.done)
+		if f.finishFn != nil {
+			f.finishFn()
+		}
+	}
+	recoverFn := func() {
+		p := recover()
+		if p != nil {
+			f.result = Result[T]{Error: ErrPanicked.Errorf("caught panic crashing out of Future[%T]: %v", f.result.Value, p)}
+		}
+	}
+
+	go f.once.Do(func() {
+		f.startTime = f.opts.Now()
+
+		defer finishFn()
+		if !f.opts.CrashOnPanic {
+			defer recoverFn()
+		}
+
+		val, err := f.fn(f.ctx)
+		f.result = Result[T]{
+			Value: val,
+			Error: err,
+		}
+	})
+}
+
+// Get returns ([Result], true) of the [Future] if it has completed
+// and otherwise (empty [Result], false).
+func (f *Future[T]) Get() (Result[T], bool) {
+	if f.endTime.IsZero() {
+		return Result[T]{}, false
+	}
+
+	return f.result, true
+}
+
+// Wait waits until the [Future] has completed and then returns its
+// [Result].
+func (f *Future[T]) Wait(ctx context.Context) Result[T] {
+	select {
+	case <-f.done:
+	case <-ctx.Done():
+		return Result[T]{Error: ctx.Err()}
+	}
+
+	return f.result
+}
+
+// Duration returns either of the following:
+// The total runtime of the future if it has completed;
+// the time since the future started if it is currently running;
+// or 0 if it has not yet been started.
+//
+// It is possible that the returned value decreases on subsequent calls
+// if Duration is called near the completion of the Future to avoid the
+// need for complex synchronization.
+func (f *Future[T]) Duration() time.Duration {
+	if f.startTime.IsZero() {
+		return 0
+	}
+
+	if f.endTime.IsZero() {
+		return f.opts.Now().Sub(f.startTime)
+	}
+
+	return f.endTime.Sub(f.startTime)
+}
+
+// Now returns the value of [FutureOpts.NowFunc] if set, otherwise
+// returns the value of [time.Now].
+func (o FutureOpts) Now() time.Time {
+	if o.NowFunc == nil {
+		return time.Now()
+	}
+
+	return o.NowFunc()
+}

--- a/pkg/util/x/parallel/future_test.go
+++ b/pkg/util/x/parallel/future_test.go
@@ -14,7 +14,7 @@ import (
 func TestFutureCatchPanic(t *testing.T) {
 	const msg = "Panicking in the Future"
 	ctx := context.Background()
-	f := RunFuture(ctx, func(ctx context.Context) (int, error) {
+	f := RunFuture(ctx, "", func(ctx context.Context) (int, error) {
 		panic(msg)
 	}, FutureOpts{})
 
@@ -25,7 +25,7 @@ func TestFutureCatchPanic(t *testing.T) {
 
 func TestFuture_Wait_RunTwice(t *testing.T) {
 	ctx := context.Background()
-	f := RunFuture(ctx, func(ctx context.Context) (int, error) {
+	f := RunFuture(ctx, "", func(ctx context.Context) (int, error) {
 		return 42, nil
 	}, FutureOpts{})
 
@@ -42,7 +42,7 @@ func TestFuture_Get(t *testing.T) {
 	ctx := context.Background()
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
-	f := RunFuture(ctx, func(ctx context.Context) (int, error) {
+	f := RunFuture(ctx, "", func(ctx context.Context) (int, error) {
 		wg.Wait()
 		return 42, nil
 	}, FutureOpts{})

--- a/pkg/util/x/parallel/future_test.go
+++ b/pkg/util/x/parallel/future_test.go
@@ -1,0 +1,89 @@
+package parallel
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFutureCatchPanic(t *testing.T) {
+	const msg = "Panicking in the Future"
+	ctx := context.Background()
+	f := RunFuture(ctx, func(ctx context.Context) (int, error) {
+		panic(msg)
+	}, FutureOpts{})
+
+	result := f.Wait(ctx)
+	assert.ErrorContains(t, result.Error, msg)
+	assert.Empty(t, result.Value)
+}
+
+func TestFuture_Wait_RunTwice(t *testing.T) {
+	ctx := context.Background()
+	f := RunFuture(ctx, func(ctx context.Context) (int, error) {
+		return 42, nil
+	}, FutureOpts{})
+
+	result := f.Wait(ctx)
+	require.NoError(t, result.Error)
+	assert.Equal(t, 42, result.Value)
+
+	result = f.Wait(ctx)
+	require.NoError(t, result.Error)
+	assert.Equal(t, 42, result.Value)
+}
+
+func TestFuture_Get(t *testing.T) {
+	ctx := context.Background()
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	f := RunFuture(ctx, func(ctx context.Context) (int, error) {
+		wg.Wait()
+		return 42, nil
+	}, FutureOpts{})
+
+	result, ok := f.Get()
+	assert.False(t, ok)
+	assert.Empty(t, result)
+
+	wg.Done()
+	<-f.done
+
+	result, ok = f.Get()
+	assert.True(t, ok)
+	require.NoError(t, result.Error)
+	assert.Equal(t, 42, result.Value)
+}
+
+func TestFutureOpts_Now(t *testing.T) {
+	// veryLargeDelta will let us assume that time.Now() is roughly
+	// equal to all other time.Now() in the test.
+	const veryLargeDelta = float64(3 * time.Second)
+
+	fakeTimestamp := time.Date(2002, 1, 1, 0, 0, 1, 0, time.UTC)
+	tests := []struct {
+		name              string
+		nowFunc           func() time.Time
+		expectedTimestamp time.Time
+	}{
+		{name: "not set (using time.Now())", nowFunc: nil, expectedTimestamp: time.Now()},
+		{name: "set to time.Now()", nowFunc: time.Now, expectedTimestamp: time.Now()},
+		{name: "set to specific time", nowFunc: func() time.Time {
+			return fakeTimestamp
+		}, expectedTimestamp: fakeTimestamp},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			o := FutureOpts{
+				NowFunc: tc.nowFunc,
+			}
+			assert.InDelta(t, tc.expectedTimestamp.UnixNano(), o.Now().UnixNano(), veryLargeDelta)
+		})
+	}
+}

--- a/pkg/util/x/parallel/group.go
+++ b/pkg/util/x/parallel/group.go
@@ -1,0 +1,91 @@
+package parallel
+
+import (
+	"context"
+	"sync"
+
+	"github.com/grafana/grafana/pkg/util/errutil"
+)
+
+// FIXME: Test and document Group.
+
+var ErrGroupCollected = errutil.NewBase(errutil.StatusInternal, "parallel.groupCollected")
+var ErrNotResolved = errutil.NewBase(errutil.StatusInternal, "parallel.notResolved")
+
+type Group[T any] struct {
+	futures    []*Future[T]
+	ctx        context.Context
+	cancelFunc context.CancelFunc
+	opts       GroupOpts[T]
+	lock       sync.Mutex
+	collected  bool
+	wg         *sync.WaitGroup
+}
+
+type GroupOpts[T any] struct {
+	FutureOptions FutureOpts
+	Scheduler     Scheduler[T]
+}
+
+func NewGroup[T any](ctx context.Context, opts GroupOpts[T]) *Group[T] {
+	ctx, cancel := context.WithCancel(ctx)
+
+	if opts.Scheduler == nil {
+		opts.Scheduler = NewBlockingScheduler[T](0)
+	}
+
+	return &Group[T]{
+		ctx:        ctx,
+		cancelFunc: cancel,
+		opts:       opts,
+	}
+}
+
+func (g *Group[T]) Go(fn func(context.Context) (T, error)) error {
+	g.lock.Lock()
+	defer g.lock.Unlock()
+	if g.collected {
+		return ErrGroupCollected.Errorf("The future group has already been collected, cannot add more futures to it")
+	}
+
+	future := NewFuture(g.ctx, fn, g.opts.FutureOptions)
+	g.wg.Add(1)
+	future.finishFn = func() {
+		g.wg.Done()
+	}
+
+	g.futures = append(g.futures, future)
+	return g.opts.Scheduler.Schedule(future)
+}
+
+func (g *Group[T]) Cancel() {
+	g.cancelFunc()
+}
+
+func (g *Group[T]) Get() []*Future[T] {
+	g.lock.Lock()
+	defer g.lock.Unlock()
+	g.collected = true
+
+	return g.futures
+}
+
+func (g *Group[T]) Wait() ([]Result[T], error) {
+	g.lock.Lock()
+	g.collected = true
+	g.lock.Unlock()
+
+	g.wg.Wait()
+	g.lock.Lock()
+	defer g.lock.Unlock()
+
+	results := make([]Result[T], 0, len(g.futures))
+	for _, future := range g.futures {
+		result, ok := future.Get()
+		if !ok {
+			return nil, ErrNotResolved.Errorf("")
+		}
+		results = append(results, result)
+	}
+	return results, nil
+}

--- a/pkg/util/x/parallel/group.go
+++ b/pkg/util/x/parallel/group.go
@@ -62,14 +62,14 @@ func NewGroup[T any](ctx context.Context, opts GroupOpts[T]) *Group[T] {
 //
 // Go will return an error if [Group.Get] or [Group.Wait] has already
 // been called.
-func (g *Group[T]) Go(fn func(context.Context) (T, error)) error {
+func (g *Group[T]) Go(name string, fn func(context.Context) (T, error)) error {
 	g.lock.Lock()
 	defer g.lock.Unlock()
 	if g.collected {
 		return ErrGroupCollected.Errorf("The future group has already been collected, cannot add more futures to it")
 	}
 
-	future := NewFuture(g.ctx, fn, g.opts.FutureOptions)
+	future := NewFuture(g.ctx, name, fn, g.opts.FutureOptions)
 	g.wg.Add(1)
 	future.finishFn = func() {
 		g.wg.Done()

--- a/pkg/util/x/parallel/group_test.go
+++ b/pkg/util/x/parallel/group_test.go
@@ -16,7 +16,7 @@ func TestGroup(t *testing.T) {
 
 	for _, c := range characters {
 		c := c
-		err := g.Go(func(ctx context.Context) (rune, error) {
+		err := g.Go("", func(ctx context.Context) (rune, error) {
 			return c, nil
 		})
 		require.NoError(t, err)
@@ -39,7 +39,7 @@ func TestGroup_Cancel(t *testing.T) {
 
 	for i := 0; i < 32; i++ {
 		i := i
-		err := g.Go(func(ctx context.Context) (int, error) {
+		err := g.Go("", func(ctx context.Context) (int, error) {
 			select {
 			case <-ch:
 				return i, nil

--- a/pkg/util/x/parallel/group_test.go
+++ b/pkg/util/x/parallel/group_test.go
@@ -1,0 +1,62 @@
+package parallel
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGroup(t *testing.T) {
+	g := NewGroup[rune](context.Background(), GroupOpts[rune]{})
+	const characters = "abcdef"
+
+	for _, c := range characters {
+		c := c
+		err := g.Go(func(ctx context.Context) (rune, error) {
+			return c, nil
+		})
+		require.NoError(t, err)
+	}
+
+	results, err := g.Wait()
+	require.NoError(t, err)
+
+	sb := strings.Builder{}
+	for _, res := range results {
+		require.NoError(t, res.Error)
+		sb.WriteRune(res.Value)
+	}
+	assert.Equal(t, characters, sb.String())
+}
+
+func TestGroup_Cancel(t *testing.T) {
+	g := NewGroup[int](context.Background(), GroupOpts[int]{})
+	ch := make(chan struct{})
+
+	for i := 0; i < 32; i++ {
+		i := i
+		err := g.Go(func(ctx context.Context) (int, error) {
+			select {
+			case <-ch:
+				return i, nil
+			case <-ctx.Done():
+				return 0, ctx.Err()
+			}
+		})
+		require.NoError(t, err)
+	}
+
+	g.Cancel()
+
+	results, err := g.Wait()
+	require.NoError(t, err)
+
+	for _, res := range results {
+		require.ErrorIs(t, res.Error, context.Canceled)
+		assert.Empty(t, res.Value)
+	}
+}

--- a/pkg/util/x/parallel/scheduler.go
+++ b/pkg/util/x/parallel/scheduler.go
@@ -1,0 +1,123 @@
+package parallel
+
+import (
+	"context"
+
+	"github.com/grafana/grafana/pkg/util/errutil"
+)
+
+// Scheduler provides an advanced runtime for [Future].
+//
+// A Scheduler will one call to [Scheduler.Schedule] per Future and will
+// eventually run the provided future.
+type Scheduler[T any] interface {
+	// Schedule accepts a [Future] and return nil if it has been
+	// scheduled to run or an error if it is unable to schedule the
+	// Future.
+	Schedule(*Future[T]) error
+}
+
+// BlockingScheduler implements [Scheduler].
+type BlockingScheduler[T any] struct {
+	sem chan struct{}
+}
+
+// NewBlockingScheduler creates a [BlockingScheduler] with a provided
+// concurrencyLimit. If the concurrency limit is 0, any number of
+// [Future]:s can be run simultaneously, otherwise the scheduler will
+// allow up to concurrencyLimit simultaneous Futures.
+func NewBlockingScheduler[T any](concurrencyLimit int64) *BlockingScheduler[T] {
+	var sem chan struct{}
+	if concurrencyLimit != 0 {
+		sem = make(chan struct{}, concurrencyLimit)
+	}
+
+	return &BlockingScheduler[T]{
+		sem: sem,
+	}
+}
+
+// Schedule starts the provided [Future]. If the [BlockingScheduler] has
+// a concurrency limit, this will block when that number of
+// Futures are simultaneously running until one or more Future has
+// completed.
+//
+// [*BlockingScheduler.Schedule] always return nil.
+func (r *BlockingScheduler[T]) Schedule(f *Future[T]) error {
+	if r.sem != nil {
+		r.sem <- struct{}{}
+		oldFinishFn := f.finishFn
+		f.finishFn = func() {
+			if oldFinishFn != nil {
+				oldFinishFn()
+			}
+
+			<-r.sem
+		}
+	}
+
+	f.Start()
+	return nil
+}
+
+var ErrSchedulerStopped = errutil.NewBase(errutil.StatusInternal, "parallel.schedulerStopped")
+
+// QueueScheduler provides a queued [Scheduler].
+//
+// This allows a number of [Future] jobs to be scheduled to run "in the
+// future" without blocking on [*QueueScheduler.Schedule].
+type QueueScheduler[T any] struct {
+	queue             chan *Future[T]
+	stopped           bool
+	blockingScheduler *BlockingScheduler[T]
+}
+
+// NewQueueScheduler creates and starts a [QueueScheduler].
+//
+// The QueueScheduler will run in the background moving [Future] jobs
+// from a queue with at most queueSize jobs onto a [BlockingScheduler]
+// with its concurrencyLimit set to the provided concurrencyLimit.
+//
+// The QueueScheduler will terminate when the [context.Context.Done]
+// channel is closed and will not accept the scheduling of any new
+// [Future] jobs.
+// Jobs already scheduled will be finished before the scheduler
+// terminates.
+func NewQueueScheduler[T any](ctx context.Context, concurrencyLimit int64, queueSize int64) *QueueScheduler[T] {
+	qs := &QueueScheduler[T]{
+		queue:             make(chan *Future[T], queueSize),
+		blockingScheduler: NewBlockingScheduler[T](concurrencyLimit),
+	}
+
+	qs.run(ctx)
+
+	return qs
+}
+
+// Schedule adds a [Future] to the queue. Returns an error based on
+// [ErrSchedulerStopped] if the [QueueScheduler] has been stopped.
+func (q *QueueScheduler[T]) Schedule(f *Future[T]) error {
+	if q.stopped {
+		return ErrSchedulerStopped.Errorf("%T has been stopped", q)
+	}
+
+	q.queue <- f
+	return nil
+}
+
+func (q *QueueScheduler[T]) run(ctx context.Context) {
+	go func() {
+		for {
+			select {
+			case f := <-q.queue:
+				// the blocking scheduler cannot fail.
+				_ = q.blockingScheduler.Schedule(f)
+			case <-ctx.Done():
+				q.stopped = true
+				if len(q.queue) == 0 {
+					return
+				}
+			}
+		}
+	}()
+}

--- a/pkg/util/x/parallel/scheduler_test.go
+++ b/pkg/util/x/parallel/scheduler_test.go
@@ -1,0 +1,95 @@
+package parallel
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestBlockingScheduler_concurrencyOne creates a very race-condition
+// prone test that is _almost_ guaranteed to fail if more than one
+// future runs simultaneously.
+func TestBlockingScheduler_concurrencyOne(t *testing.T) {
+	bs := NewBlockingScheduler[int](1)
+	var n int
+	var futures []*Future[int]
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	t.Cleanup(cancel)
+
+	const target = 32
+	for i := 0; i < target; i++ {
+		future := NewFuture(ctx, func(ctx context.Context) (int, error) {
+			old := n
+			time.Sleep(time.Millisecond)
+			n = old + 1
+			return n, nil
+		}, FutureOpts{})
+		futures = append(futures, future)
+		err := bs.Schedule(future)
+		require.NoError(t, err)
+	}
+
+	for _, future := range futures {
+		res := future.Wait(ctx)
+		require.NoError(t, res.Error)
+	}
+	assert.Equal(t, target, n)
+}
+
+// TestBlockingScheduler_waiting asserts that the blocking scheduler can
+// run several futures in parallel. This is done by a rendezvous
+// WaitGroup where every [Future] both reduces the semaphore by one and
+// waits until it reaches zero. This can only happen if there are enough
+// concurrent futures.
+func TestBlockingScheduler_waiting(t *testing.T) {
+	const target = 16
+
+	bs := NewBlockingScheduler[int](target)
+	wg := &sync.WaitGroup{}
+	wg.Add(target)
+	for i := 0; i < target; i++ {
+		future := NewFuture(context.Background(), func(ctx context.Context) (int, error) {
+			wg.Done()
+			return 0, nil
+		}, FutureOpts{})
+		err := bs.Schedule(future)
+		require.NoError(t, err)
+	}
+
+	wg.Wait()
+}
+
+// TestQueueScheduler fills up the queue and then finishes.
+func TestQueueScheduler(t *testing.T) {
+	const target = 16
+	var futures []*Future[int]
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	t.Cleanup(cancel)
+
+	var eoq bool
+	sched := NewQueueScheduler[int](ctx, 4, target)
+	for !eoq {
+		future := NewFuture(context.Background(), func(ctx context.Context) (int, error) {
+			for !eoq {
+				if len(sched.queue) == cap(sched.queue) {
+					eoq = true
+				}
+				time.Sleep(time.Microsecond)
+			}
+			return 0, nil
+		}, FutureOpts{})
+		futures = append(futures, future)
+		err := sched.Schedule(future)
+		require.NoError(t, err)
+	}
+
+	for _, future := range futures {
+		res := future.Wait(ctx)
+		require.NoError(t, res.Error)
+	}
+}

--- a/pkg/util/x/parallel/scheduler_test.go
+++ b/pkg/util/x/parallel/scheduler_test.go
@@ -23,7 +23,7 @@ func TestBlockingScheduler_concurrencyOne(t *testing.T) {
 
 	const target = 32
 	for i := 0; i < target; i++ {
-		future := NewFuture(ctx, func(ctx context.Context) (int, error) {
+		future := NewFuture(ctx, "", func(ctx context.Context) (int, error) {
 			old := n
 			time.Sleep(time.Millisecond)
 			n = old + 1
@@ -53,7 +53,7 @@ func TestBlockingScheduler_waiting(t *testing.T) {
 	wg := &sync.WaitGroup{}
 	wg.Add(target)
 	for i := 0; i < target; i++ {
-		future := NewFuture(context.Background(), func(ctx context.Context) (int, error) {
+		future := NewFuture(context.Background(), "", func(ctx context.Context) (int, error) {
 			wg.Done()
 			return 0, nil
 		}, FutureOpts{})
@@ -74,7 +74,7 @@ func TestQueueScheduler(t *testing.T) {
 	var eoq bool
 	sched := NewQueueScheduler[int](ctx, 4, target)
 	for !eoq {
-		future := NewFuture(context.Background(), func(ctx context.Context) (int, error) {
+		future := NewFuture(context.Background(), "", func(ctx context.Context) (int, error) {
 			for !eoq {
 				if len(sched.queue) == cap(sched.queue) {
 					eoq = true


### PR DESCRIPTION
**What is this feature?**

First of all, this is very much a playground and a draft with no immediate plan of merging and even less using any of this anytime soon.

There are several different similar implementations of schedulers in Grafana, and I would like to explore if we can wrap Go concurrency with good utilities for logs, traces, metrics to allow us to improve insight into (and by extension reliability and performance of) background tasks.

**Why do we need this feature?**

Right now? We don't, it's too far away from being a completed argument for me to claim we do.

**Who is this feature for?**

Grafana core backend devs.

**Which issue(s) does this PR fix?**:

> **Note**
> Create and add issues based on the exploration I'm doing around this.