### PR TITLE
Loki Editor Autocomplete: Suggest unique history items

### DIFF
--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/CompletionDataProvider.test.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/CompletionDataProvider.test.ts
@@ -24,6 +24,13 @@ const history = [
     },
   },
   {
+    ts: 87654321,
+    query: {
+      refId: 'test-1',
+      expr: '{unit: test}',
+    },
+  },
+  {
     ts: 0,
     query: {
       refId: 'test-0',

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/CompletionDataProvider.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/CompletionDataProvider.ts
@@ -1,3 +1,5 @@
+import { chain } from 'lodash';
+
 import { HistoryItem } from '@grafana/data';
 import { escapeLabelValueInExactSelector } from 'app/plugins/datasource/prometheus/language_utils';
 
@@ -7,7 +9,10 @@ import { LokiQuery } from '../../../types';
 import { Label } from './situation';
 
 export class CompletionDataProvider {
-  constructor(private languageProvider: LanguageProvider, private history: Array<HistoryItem<LokiQuery>> = []) {}
+  private history: string[] = [];
+  constructor(private languageProvider: LanguageProvider, history: Array<HistoryItem<LokiQuery>> = []) {
+    this.setHistory(history);
+  }
 
   private buildSelector(labels: Label[]): string {
     const allLabelTexts = labels.map(
@@ -17,8 +22,16 @@ export class CompletionDataProvider {
     return `{${allLabelTexts.join(',')}}`;
   }
 
+  setHistory(history: Array<HistoryItem<LokiQuery>> = []) {
+    this.history = chain(history)
+      .map((history: HistoryItem<LokiQuery>) => history.query.expr)
+      .filter()
+      .uniq()
+      .value();
+  }
+
   getHistory() {
-    return this.history.map((entry) => entry.query.expr).filter((expr) => expr !== undefined);
+    return this.history;
   }
 
   async getLabelNames(otherLabels: Label[] = []) {

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.test.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.test.ts
@@ -197,7 +197,7 @@ describe('getCompletions', () => {
     const situation = { type } as Situation;
     const completions = await getCompletions(situation, completionProvider);
 
-    expect(completions).toHaveLength(25);
+    expect(completions).toHaveLength(24);
   });
 
   test('Returns completion options when the situation is IN_DURATION', async () => {


### PR DESCRIPTION
We were suggesting a lot of duplicated history entries with the autocomplete. We now suggest unique entries.

Before:
![Before](https://user-images.githubusercontent.com/1069378/207396253-c500696a-e90b-428d-a038-cab77e12bf24.png)

After:
![After](https://user-images.githubusercontent.com/1069378/207396258-66953f9e-7690-4a21-b0ac-8797fcfe6603.png)

Part of https://github.com/grafana/grafana/issues/44985