### PR TITLE
Cloudwatch: Fix deeplink with default region (#60260)

### DIFF
--- a/pkg/tsdb/cloudwatch/request_parser_test.go
+++ b/pkg/tsdb/cloudwatch/request_parser_test.go
@@ -73,7 +73,7 @@ func TestRequestParser(t *testing.T) {
 			Hide:      &false,
 		}
 
-		res, err := parseRequestQuery(query, "ref1", time.Now().Add(-2*time.Hour), time.Now().Add(-time.Hour))
+		res, err := parseRequestQuery(query, "ref1", time.Now().Add(-2*time.Hour), time.Now().Add(-time.Hour), "us-east-2")
 		require.NoError(t, err)
 		assert.Equal(t, "us-east-1", res.Region)
 		assert.Equal(t, "ref1", res.RefId)
@@ -107,7 +107,7 @@ func TestRequestParser(t *testing.T) {
 			Hide:      &false,
 		}
 
-		res, err := parseRequestQuery(query, "ref1", time.Now().Add(-2*time.Hour), time.Now().Add(-time.Hour))
+		res, err := parseRequestQuery(query, "ref1", time.Now().Add(-2*time.Hour), time.Now().Add(-time.Hour), "us-east-2")
 		require.NoError(t, err)
 		assert.Equal(t, "us-east-1", res.Region)
 		assert.Equal(t, "ref1", res.RefId)
@@ -141,7 +141,7 @@ func TestRequestParser(t *testing.T) {
 			Hide:      &false,
 		}
 
-		res, err := parseRequestQuery(query, "ref1", time.Now().Add(-2*time.Hour), time.Now().Add(-time.Hour))
+		res, err := parseRequestQuery(query, "ref1", time.Now().Add(-2*time.Hour), time.Now().Add(-time.Hour), "us-east-2")
 		require.NoError(t, err)
 		assert.Equal(t, 900, res.Period)
 	})
@@ -168,7 +168,7 @@ func TestRequestParser(t *testing.T) {
 			to := time.Now()
 			from := to.Local().Add(time.Minute * time.Duration(5))
 
-			res, err := parseRequestQuery(query, "ref1", from, to)
+			res, err := parseRequestQuery(query, "ref1", from, to, "us-east-2")
 			require.NoError(t, err)
 			assert.Equal(t, 60, res.Period)
 		})
@@ -178,7 +178,7 @@ func TestRequestParser(t *testing.T) {
 			to := time.Now()
 			from := to.AddDate(0, 0, -1)
 
-			res, err := parseRequestQuery(query, "ref1", from, to)
+			res, err := parseRequestQuery(query, "ref1", from, to, "us-east-2")
 			require.NoError(t, err)
 			assert.Equal(t, 60, res.Period)
 		})
@@ -187,7 +187,7 @@ func TestRequestParser(t *testing.T) {
 			query.Period = "auto"
 			to := time.Now()
 			from := to.AddDate(0, 0, -2)
-			res, err := parseRequestQuery(query, "ref1", from, to)
+			res, err := parseRequestQuery(query, "ref1", from, to, "us-east-2")
 			require.NoError(t, err)
 			assert.Equal(t, 300, res.Period)
 		})
@@ -197,7 +197,7 @@ func TestRequestParser(t *testing.T) {
 			to := time.Now()
 			from := to.AddDate(0, 0, -7)
 
-			res, err := parseRequestQuery(query, "ref1", from, to)
+			res, err := parseRequestQuery(query, "ref1", from, to, "us-east-2")
 			require.NoError(t, err)
 			assert.Equal(t, 900, res.Period)
 		})
@@ -207,7 +207,7 @@ func TestRequestParser(t *testing.T) {
 			to := time.Now()
 			from := to.AddDate(0, 0, -30)
 
-			res, err := parseRequestQuery(query, "ref1", from, to)
+			res, err := parseRequestQuery(query, "ref1", from, to, "us-east-2")
 			require.NoError(t, err)
 			assert.Equal(t, 3600, res.Period)
 		})
@@ -217,7 +217,7 @@ func TestRequestParser(t *testing.T) {
 			to := time.Now()
 			from := to.AddDate(0, 0, -90)
 
-			res, err := parseRequestQuery(query, "ref1", from, to)
+			res, err := parseRequestQuery(query, "ref1", from, to, "us-east-2")
 			require.NoError(t, err)
 			assert.Equal(t, 21600, res.Period)
 		})
@@ -227,7 +227,7 @@ func TestRequestParser(t *testing.T) {
 			to := time.Now()
 			from := to.AddDate(-1, 0, 0)
 
-			res, err := parseRequestQuery(query, "ref1", from, to)
+			res, err := parseRequestQuery(query, "ref1", from, to, "us-east-2")
 			require.Nil(t, err)
 			assert.Equal(t, 21600, res.Period)
 		})
@@ -237,7 +237,7 @@ func TestRequestParser(t *testing.T) {
 			to := time.Now()
 			from := to.AddDate(-2, 0, 0)
 
-			res, err := parseRequestQuery(query, "ref1", from, to)
+			res, err := parseRequestQuery(query, "ref1", from, to, "us-east-2")
 			require.NoError(t, err)
 			assert.Equal(t, 86400, res.Period)
 		})
@@ -246,7 +246,7 @@ func TestRequestParser(t *testing.T) {
 			query.Period = "auto"
 			to := time.Now().AddDate(0, 0, -14)
 			from := to.AddDate(0, 0, -2)
-			res, err := parseRequestQuery(query, "ref1", from, to)
+			res, err := parseRequestQuery(query, "ref1", from, to, "us-east-2")
 			require.NoError(t, err)
 			assert.Equal(t, 300, res.Period)
 		})
@@ -255,7 +255,7 @@ func TestRequestParser(t *testing.T) {
 			query.Period = "auto"
 			to := time.Now().AddDate(0, 0, -88)
 			from := to.AddDate(0, 0, -2)
-			res, err := parseRequestQuery(query, "ref1", from, to)
+			res, err := parseRequestQuery(query, "ref1", from, to, "us-east-2")
 			require.NoError(t, err)
 			assert.Equal(t, 3600, res.Period)
 		})
@@ -264,7 +264,7 @@ func TestRequestParser(t *testing.T) {
 			query.Period = "auto"
 			to := time.Now().AddDate(0, 0, -454)
 			from := to.AddDate(0, 0, -2)
-			res, err := parseRequestQuery(query, "ref1", from, to)
+			res, err := parseRequestQuery(query, "ref1", from, to, "us-east-2")
 			require.NoError(t, err)
 			assert.Equal(t, 21600, res.Period)
 		})
@@ -274,7 +274,7 @@ func TestRequestParser(t *testing.T) {
 		t.Run("when metric query type and metric editor mode is not specified", func(t *testing.T) {
 			t.Run("it should be metric search builder", func(t *testing.T) {
 				query := getBaseJsonQuery()
-				res, err := parseRequestQuery(query, "ref1", time.Now().Add(-2*time.Hour), time.Now().Add(-time.Hour))
+				res, err := parseRequestQuery(query, "ref1", time.Now().Add(-2*time.Hour), time.Now().Add(-time.Hour), "us-east-2")
 				require.NoError(t, err)
 				assert.Equal(t, MetricQueryTypeSearch, res.MetricQueryType)
 				assert.Equal(t, MetricEditorModeBuilder, res.MetricEditorMode)
@@ -284,7 +284,7 @@ func TestRequestParser(t *testing.T) {
 			t.Run("and an expression is specified it should be metric search builder", func(t *testing.T) {
 				query := getBaseJsonQuery()
 				query.Expression = "SUM(a)"
-				res, err := parseRequestQuery(query, "ref1", time.Now().Add(-2*time.Hour), time.Now().Add(-time.Hour))
+				res, err := parseRequestQuery(query, "ref1", time.Now().Add(-2*time.Hour), time.Now().Add(-time.Hour), "us-east-2")
 				require.NoError(t, err)
 				assert.Equal(t, MetricQueryTypeSearch, res.MetricQueryType)
 				assert.Equal(t, MetricEditorModeRaw, res.MetricEditorMode)
@@ -295,7 +295,7 @@ func TestRequestParser(t *testing.T) {
 		t.Run("and an expression is specified it should be metric search builder", func(t *testing.T) {
 			query := getBaseJsonQuery()
 			query.Expression = "SUM(a)"
-			res, err := parseRequestQuery(query, "ref1", time.Now().Add(-2*time.Hour), time.Now().Add(-time.Hour))
+			res, err := parseRequestQuery(query, "ref1", time.Now().Add(-2*time.Hour), time.Now().Add(-time.Hour), "us-east-2")
 			require.NoError(t, err)
 			assert.Equal(t, MetricQueryTypeSearch, res.MetricQueryType)
 			assert.Equal(t, MetricEditorModeRaw, res.MetricEditorMode)
@@ -307,7 +307,7 @@ func TestRequestParser(t *testing.T) {
 		t.Run("default", func(t *testing.T) {
 			query := getBaseJsonQuery()
 			query.QueryType = "timeSeriesQuery"
-			res, err := parseRequestQuery(query, "ref1", time.Now().Add(-2*time.Hour), time.Now().Add(-time.Hour))
+			res, err := parseRequestQuery(query, "ref1", time.Now().Add(-2*time.Hour), time.Now().Add(-time.Hour), "us-east-2")
 			require.NoError(t, err)
 			require.True(t, res.ReturnData)
 		})
@@ -316,7 +316,7 @@ func TestRequestParser(t *testing.T) {
 			query.QueryType = "timeSeriesQuery"
 			true := true
 			query.Hide = &true
-			res, err := parseRequestQuery(query, "ref1", time.Now().Add(-2*time.Hour), time.Now().Add(-time.Hour))
+			res, err := parseRequestQuery(query, "ref1", time.Now().Add(-2*time.Hour), time.Now().Add(-time.Hour), "us-east-2")
 			require.NoError(t, err)
 			require.False(t, res.ReturnData)
 		})
@@ -325,7 +325,7 @@ func TestRequestParser(t *testing.T) {
 			query.QueryType = "timeSeriesQuery"
 			false := false
 			query.Hide = &false
-			res, err := parseRequestQuery(query, "ref1", time.Now().Add(-2*time.Hour), time.Now().Add(-time.Hour))
+			res, err := parseRequestQuery(query, "ref1", time.Now().Add(-2*time.Hour), time.Now().Add(-time.Hour), "us-east-2")
 			require.NoError(t, err)
 			require.True(t, res.ReturnData)
 		})
@@ -333,7 +333,7 @@ func TestRequestParser(t *testing.T) {
 
 	t.Run("ID is the string `query` appended with refId if refId is a valid MetricData ID", func(t *testing.T) {
 		query := getBaseJsonQuery()
-		res, err := parseRequestQuery(query, "ref1", time.Now().Add(-2*time.Hour), time.Now().Add(-time.Hour))
+		res, err := parseRequestQuery(query, "ref1", time.Now().Add(-2*time.Hour), time.Now().Add(-time.Hour), "us-east-2")
 		require.NoError(t, err)
 		assert.Equal(t, "ref1", res.RefId)
 		assert.Equal(t, "queryref1", res.Id)
@@ -342,7 +342,7 @@ func TestRequestParser(t *testing.T) {
 	t.Run("Valid id is generated if ID is not provided and refId is not a valid MetricData ID", func(t *testing.T) {
 		query := getBaseJsonQuery()
 		query.RefId = "$$"
-		res, err := parseRequestQuery(query, "$$", time.Now().Add(-2*time.Hour), time.Now().Add(-time.Hour))
+		res, err := parseRequestQuery(query, "$$", time.Now().Add(-2*time.Hour), time.Now().Add(-time.Hour), "us-east-2")
 		require.NoError(t, err)
 		assert.Equal(t, "$$", res.RefId)
 		assert.Regexp(t, validMetricDataID, res.Id)
@@ -356,11 +356,20 @@ func TestRequestParser(t *testing.T) {
 		label := "some label"
 		query.Label = &label
 
-		res, err := parseRequestQuery(query, "ref1", time.Now().Add(-2*time.Hour), time.Now().Add(-time.Hour))
+		res, err := parseRequestQuery(query, "ref1", time.Now().Add(-2*time.Hour), time.Now().Add(-time.Hour), "us-east-2")
 
 		assert.NoError(t, err)
 		assert.Equal(t, "some alias", res.Alias) // alias is unmodified
 		assert.Equal(t, "some label", res.Label)
+	})
+
+	t.Run("default region is used when when region not set", func(t *testing.T) {
+		query := getBaseJsonQuery()
+		query.Region = defaultRegion
+		region := "us-east-2"
+		res, err := parseRequestQuery(query, "ref1", time.Now().Add(-2*time.Hour), time.Now().Add(-time.Hour), region)
+		assert.NoError(t, err)
+		assert.Equal(t, region, res.Region)
 	})
 }
 

--- a/pkg/tsdb/cloudwatch/time_series_query.go
+++ b/pkg/tsdb/cloudwatch/time_series_query.go
@@ -28,7 +28,12 @@ func (e *cloudWatchExecutor) executeTimeSeriesQuery(ctx context.Context, req *ba
 		return nil, fmt.Errorf("invalid time range: start time must be before end time")
 	}
 
-	requestQueriesByRegion, err := e.parseQueries(req.Queries, startTime, endTime)
+	dsInfo, err := e.getDSInfo(req.PluginContext)
+	if err != nil {
+		return nil, err
+	}
+
+	requestQueriesByRegion, err := e.parseQueries(req.Queries, startTime, endTime, dsInfo.region)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Cloudwatch: fix deeplink with default region
(cherry picked from commit d6bb2a74931a9c2b393fa22040737fb6480819f3)

Functions moved around, so this is the same content in different files

