### PR TITLE
Transformations: Fix bug in convert fields boolean to number

### DIFF
--- a/packages/grafana-data/src/transformations/transformers/convertFieldType.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/convertFieldType.test.ts
@@ -121,6 +121,26 @@ it('can convert strings with commas to numbers', () => {
   });
 });
 
+it('converts booleans to numbers', () => {
+  const options = { targetField: 'booleans', destinationType: FieldType.number };
+
+  const stringyNumbers = {
+    name: 'booleans',
+    type: FieldType.boolean,
+    values: new ArrayVector([true, false]),
+    config: {},
+  };
+
+  const numbers = convertFieldType(stringyNumbers, options);
+
+  expect(numbers).toEqual({
+    name: 'booleans',
+    type: FieldType.number,
+    values: new ArrayVector([1, 0]),
+    config: {},
+  });
+});
+
 describe('field convert types transformer', () => {
   beforeAll(() => {
     mockTransformationsRegistry([convertFieldTypeTransformer]);

--- a/packages/grafana-data/src/transformations/transformers/convertFieldType.ts
+++ b/packages/grafana-data/src/transformations/transformers/convertFieldType.ts
@@ -141,10 +141,12 @@ export function fieldToTimeField(field: Field, dateFormat?: string): Field {
 function fieldToNumberField(field: Field): Field {
   const numValues = field.values.toArray().slice();
 
+  const valuesAsStrings = numValues.some((v) => typeof v === 'string');
+
   for (let n = 0; n < numValues.length; n++) {
     let toBeConverted = numValues[n];
 
-    if (typeof toBeConverted === 'string') {
+    if (valuesAsStrings) {
       // some numbers returned from datasources have commas
       // strip the commas, coerce the string to a number
       toBeConverted = toBeConverted.replace(/,/g, '');

--- a/packages/grafana-data/src/transformations/transformers/convertFieldType.ts
+++ b/packages/grafana-data/src/transformations/transformers/convertFieldType.ts
@@ -142,9 +142,16 @@ function fieldToNumberField(field: Field): Field {
   const numValues = field.values.toArray().slice();
 
   for (let n = 0; n < numValues.length; n++) {
-    // some numbers returned from datasources have commas
-    // strip the commas, coerce the string to a number
-    const number = +numValues[n].replace(/,/g, '');
+    let toBeConverted = numValues[n];
+
+    if (typeof toBeConverted === 'string') {
+      // some numbers returned from datasources have commas
+      // strip the commas, coerce the string to a number
+      toBeConverted = toBeConverted.replace(/,/g, '');
+    }
+
+    const number = +toBeConverted;
+
     numValues[n] = Number.isFinite(number) ? number : null;
   }
 


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/60072

A bug was introduced into the Convert Fields transformation recently. Booleans were not being converted to numbers. A request had been made to convert strings with commas to numbers, which used a replace regex function, removing commas before coercing the string, and that broke the conversion of booleans to numbers. To fix this, we now only remove commas from strings, everything else we coerce.
