### PR TITLE
Devenv: Add back `loki-promtail`

### DIFF
--- a/devenv/docker/blocks/loki-promtail/README.md
+++ b/devenv/docker/blocks/loki-promtail/README.md
@@ -1,3 +1,5 @@
+NB: This will not work properly on MacOS. The loglines of grafana.log are ingested at the start of this devenv and you won't get any more logs are the Docker service is started.
+
 By default this block is setup to scrape logs from Grafana. If you need to log some service from the docker-compse you can add:
 ```
     # For this to work you need to install the logging driver see https://github.com/grafana/loki/tree/master/cmd/docker-driver#plugin-installation

--- a/devenv/docker/blocks/loki-promtail/README.md
+++ b/devenv/docker/blocks/loki-promtail/README.md
@@ -1,0 +1,8 @@
+By default this block is setup to scrape logs from /var/logs. If you need to log some service from the docker-compse you can add:
+```
+    # For this to work you need to install the logging driver see https://github.com/grafana/loki/tree/master/cmd/docker-driver#plugin-installation
+    logging:
+      driver: loki
+      options:
+        loki-url: "http://loki:3100/loki/api/v1/push"
+```

--- a/devenv/docker/blocks/loki-promtail/README.md
+++ b/devenv/docker/blocks/loki-promtail/README.md
@@ -1,4 +1,4 @@
-By default this block is setup to scrape logs from /var/logs. If you need to log some service from the docker-compse you can add:
+By default this block is setup to scrape logs from Grafana. If you need to log some service from the docker-compse you can add:
 ```
     # For this to work you need to install the logging driver see https://github.com/grafana/loki/tree/master/cmd/docker-driver#plugin-installation
     logging:

--- a/devenv/docker/blocks/loki-promtail/docker-compose.yaml
+++ b/devenv/docker/blocks/loki-promtail/docker-compose.yaml
@@ -1,0 +1,12 @@
+  loki:
+    image: grafana/loki:latest
+    ports:
+      - "3100:3100"
+    command: -config.file=/etc/loki/local-config.yaml
+  promtail:
+    image: grafana/promtail:latest
+    volumes:
+      - ./docker/blocks/loki-promtail/promtail-config.yaml:/etc/promtail/docker-config.yaml
+      - ../data/log:/var/log/grafana
+    command:
+      -config.file=/etc/promtail/docker-config.yaml

--- a/devenv/docker/blocks/loki-promtail/promtail-config.yaml
+++ b/devenv/docker/blocks/loki-promtail/promtail-config.yaml
@@ -1,0 +1,25 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+client:
+  url: http://loki:3100/api/prom/push
+
+scrape_configs:
+- job_name: system
+  static_configs:
+  - targets:
+      - localhost
+    labels:
+      job: varlogs
+      __path__: /var/log/*log
+- job_name: grafana
+  static_configs:
+  - targets:
+      - localhost
+    labels:
+      job: grafana
+      __path__: /var/log/grafana/*log


### PR DESCRIPTION
**What is this feature?**

A Loki devenv containing promtail which scrapes the local Grafana log file.

**Special notes for your reviewer**:

The config was removed in #55752 but it can be useful, so we are adding it back.