### PR TITLE
Navigation: conditionally use actions in `DataSourceListPage`

### DIFF
--- a/public/app/features/connections/pages/DataSourcesListPage.tsx
+++ b/public/app/features/connections/pages/DataSourcesListPage.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
 
+import { config } from '@grafana/runtime';
 import { Page } from 'app/core/components/Page/Page';
 import { DataSourceAddButton } from 'app/features/datasources/components/DataSourceAddButton';
 import { DataSourcesList } from 'app/features/datasources/components/DataSourcesList';
 
 export function DataSourcesListPage() {
+  const actions = config.featureToggles.topnav ? DataSourceAddButton() : undefined;
   return (
-    <Page navId={'connections-your-connections-datasources'} actions={DataSourceAddButton()}>
+    <Page navId={'connections-your-connections-datasources'} actions={actions}>
       <Page.Contents>
         <DataSourcesList />
       </Page.Contents>

--- a/public/app/features/datasources/components/DataSourcesListHeader.tsx
+++ b/public/app/features/datasources/components/DataSourcesListHeader.tsx
@@ -1,10 +1,18 @@
 import React, { useCallback } from 'react';
 
 import { SelectableValue } from '@grafana/data';
+import { config } from '@grafana/runtime';
 import PageActionBar from 'app/core/components/PageActionBar/PageActionBar';
-import { StoreState, useSelector, useDispatch } from 'app/types';
+import { contextSrv } from 'app/core/core';
+import { StoreState, useSelector, useDispatch, AccessControlAction } from 'app/types';
 
-import { getDataSourcesSearchQuery, getDataSourcesSort, setDataSourcesSearchQuery, setIsSortAscending } from '../state';
+import {
+  getDataSourcesSearchQuery,
+  getDataSourcesSort,
+  setDataSourcesSearchQuery,
+  setIsSortAscending,
+  useDataSourcesRoutes,
+} from '../state';
 
 const ascendingSortValue = 'alpha-asc';
 const descendingSortValue = 'alpha-desc';
@@ -22,6 +30,19 @@ export function DataSourcesListHeader() {
   const setSearchQuery = useCallback((q: string) => dispatch(setDataSourcesSearchQuery(q)), [dispatch]);
   const searchQuery = useSelector(({ dataSources }: StoreState) => getDataSourcesSearchQuery(dataSources));
 
+  // TODO remove this logic adding the link button once topnav is live
+  // instead use the actions in DataSourcesListPage
+  const canCreateDataSource = contextSrv.hasPermission(AccessControlAction.DataSourcesCreate);
+  const dataSourcesRoutes = useDataSourcesRoutes();
+  const isTopnav = config.featureToggles.topnav;
+  const linkButton =
+    !isTopnav && canCreateDataSource
+      ? {
+          href: dataSourcesRoutes.New,
+          title: 'Add new data source',
+        }
+      : undefined;
+
   const setSort = useCallback(
     (sort: SelectableValue) => dispatch(setIsSortAscending(sort.value === ascendingSortValue)),
     [dispatch]
@@ -35,6 +56,12 @@ export function DataSourcesListHeader() {
   };
 
   return (
-    <PageActionBar searchQuery={searchQuery} setSearchQuery={setSearchQuery} key="action-bar" sortPicker={sortPicker} />
+    <PageActionBar
+      searchQuery={searchQuery}
+      setSearchQuery={setSearchQuery}
+      key="action-bar"
+      sortPicker={sortPicker}
+      linkButton={linkButton}
+    />
   );
 }

--- a/public/app/features/datasources/pages/DataSourcesListPage.test.tsx
+++ b/public/app/features/datasources/pages/DataSourcesListPage.test.tsx
@@ -49,10 +49,10 @@ describe('Render', () => {
     expect(await screen.findByRole('link', { name: 'Documentation' })).toBeInTheDocument();
     expect(await screen.findByRole('link', { name: 'Support' })).toBeInTheDocument();
     expect(await screen.findByRole('link', { name: 'Community' })).toBeInTheDocument();
-    expect(await screen.findByRole('link', { name: 'Add new data source' })).toBeInTheDocument();
+    expect(await screen.findByRole('link', { name: 'Add data source' })).toBeInTheDocument();
   });
 
-  it('should not render "Add new data source" button if user has no permissions', async () => {
+  it('should disable the "Add data source" button if user has no permissions', async () => {
     (contextSrv.hasPermission as jest.Mock) = jest.fn().mockReturnValue(false);
     setup({ isSortAscending: true });
 
@@ -60,7 +60,7 @@ describe('Render', () => {
     expect(await screen.findByRole('link', { name: 'Documentation' })).toBeInTheDocument();
     expect(await screen.findByRole('link', { name: 'Support' })).toBeInTheDocument();
     expect(await screen.findByRole('link', { name: 'Community' })).toBeInTheDocument();
-    expect(screen.queryByRole('link', { name: 'Add new data source' })).toBeNull();
+    expect(await screen.findByRole('link', { name: 'Add data source' })).toHaveStyle('pointer-events: none');
   });
 
   it('should render action bar and datasources', async () => {

--- a/public/app/features/datasources/pages/DataSourcesListPage.tsx
+++ b/public/app/features/datasources/pages/DataSourcesListPage.tsx
@@ -1,13 +1,15 @@
 import React from 'react';
 
+import { config } from '@grafana/runtime';
 import { Page } from 'app/core/components/Page/Page';
 
 import { DataSourceAddButton } from '../components/DataSourceAddButton';
 import { DataSourcesList } from '../components/DataSourcesList';
 
 export function DataSourcesListPage() {
+  const actions = config.featureToggles.topnav ? DataSourceAddButton() : undefined;
   return (
-    <Page navId="datasources" actions={DataSourceAddButton()}>
+    <Page navId="datasources" actions={actions}>
       <Page.Contents>
         <DataSourcesList />
       </Page.Contents>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

context here: https://raintank-corp.slack.com/archives/C01LENC4MD5/p1670919778711599

| | topnav off | topnav on |
| --- | --- | --- |
| before | ![image](https://user-images.githubusercontent.com/20999846/207577487-fdd19104-28a1-4788-90ed-26ccfcc7ad4f.png) | ![image](https://user-images.githubusercontent.com/20999846/207577735-32691f16-972c-42b9-a33b-4affbc7b7593.png) |
| after | ![image](https://user-images.githubusercontent.com/20999846/207577397-d9351e62-06b2-4c66-89ea-f67489ce311e.png) | ![image](https://user-images.githubusercontent.com/20999846/207577162-c92705d0-2e50-4603-b553-c3a43d98794a.png) |


**Why do we need this feature?**

- stop showing `add new data source` button outside of it's intended tab

**Who is this feature for?**

- everyone!

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

this is pretty temporary. once topnav goes live in 9.4.0, we can rip out this conditional logic.