### PR TITLE
Prometheus: Hide query section when empty

### DIFF
--- a/public/app/plugins/datasource/prometheus/querybuilder/components/QueryPreview.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/QueryPreview.tsx
@@ -10,6 +10,10 @@ export interface Props {
 }
 
 export function QueryPreview({ query }: Props) {
+  if (!query) {
+    return null;
+  }
+
   return (
     <EditorRow>
       <EditorFieldGroup>


### PR DESCRIPTION
**What is this feature?**

Hide query section when empty on the Prometheus's query builder (frontend)

**Why do we need this feature?**

It looks like there is a visual glitch when the row is displayed empty

**Who is this feature for?**

Users of Prometheus query builder

**Which issue(s) does this PR fix?**:

Fixes #59975
