### PR TITLE
Dashboards: Fix 'Make Editable' button not working in Dashboard Settings

### DIFF
--- a/public/app/features/dashboard/components/DashboardSettings/DashboardSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/DashboardSettings.tsx
@@ -39,6 +39,8 @@ export function DashboardSettings({ dashboard, editview, pageNav, sectionNav }: 
   useEffect(() => {
     dashboard.events.subscribe(DashboardMetaChangedEvent, () => setUpdateId((v) => v + 1));
   }, [dashboard]);
+
+  // updateId in deps so we can revaluate when dashboard is mutated
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const pages = useMemo(() => getSettingsPages(dashboard), [dashboard, updateId]);
 

--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -499,6 +499,15 @@ export class DashboardModel implements TimeModel {
     this.events.publish(new DashboardMetaChangedEvent());
   }
 
+  makeEditable() {
+    this.editable = true;
+    this.updateMeta({
+      canMakeEditable: false,
+      canEdit: true,
+      canSave: true,
+    });
+  }
+
   sortPanelsByGridPos() {
     this.panels.sort((panelA, panelB) => {
       if (panelA.gridPos.y === panelB.gridPos.y) {


### PR DESCRIPTION
**What is this feature?**

PR https://github.com/grafana/grafana/pull/52682 [introduced a regression](https://github.com/grafana/grafana/pull/52682/files#diff-d77b6c1b027bdc1db035aadf8b5ab885f55d0fd1315170dc9c992a9c193d93b0R200-R207) where the "Make Editable" button in Dashboard Settings for uneditable dashboards doesn't do anything.

This fixes that.

**Why do we need this feature?**

So people can edit their dashboards.

**Who is this feature for?**

Admins and editors of Grafana

**Which issue(s) does this PR fix?**:

Fixes #60305


