### PR TITLE
Azure Monitor: Add support to customized Azure portal URL

### DIFF
--- a/pkg/tsdb/azuremonitor/azuremonitor.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor.go
@@ -108,7 +108,7 @@ func NewInstanceSettings(cfg *setting.Cfg, clientProvider *httpclient.Provider, 
 			return nil, fmt.Errorf("error getting credentials: %w", err)
 		}
 
-		routesForModel, err := getAzureRoutes(cloud, settings.JSONData)
+		routesForModel, err := getAzureRoutes(cloud, azMonitorSettings)
 		if err != nil {
 			return nil, err
 		}
@@ -141,25 +141,12 @@ func NewInstanceSettings(cfg *setting.Cfg, clientProvider *httpclient.Provider, 
 	}
 }
 
-func getCustomizedCloudSettings(cloud string, jsonData json.RawMessage) (types.AzureMonitorCustomizedCloudSettings, error) {
-	customizedCloudSettings := types.AzureMonitorCustomizedCloudSettings{}
-	err := json.Unmarshal(jsonData, &customizedCloudSettings)
-	if err != nil {
-		return types.AzureMonitorCustomizedCloudSettings{}, fmt.Errorf("error getting customized cloud settings: %w", err)
-	}
-	return customizedCloudSettings, nil
-}
-
-func getAzureRoutes(cloud string, jsonData json.RawMessage) (map[string]types.AzRoute, error) {
+func getAzureRoutes(cloud string, settings types.AzureMonitorSettings) (map[string]types.AzRoute, error) {
 	if cloud == azsettings.AzureCustomized {
-		customizedCloudSettings, err := getCustomizedCloudSettings(cloud, jsonData)
-		if err != nil {
-			return nil, err
-		}
-		if customizedCloudSettings.CustomizedRoutes == nil {
+		if settings.CustomizedCloudSettings.CustomizedRoutes == nil {
 			return nil, fmt.Errorf("unable to instantiate routes, customizedRoutes must be set")
 		}
-		azureRoutes := customizedCloudSettings.CustomizedRoutes
+		azureRoutes := settings.CustomizedCloudSettings.CustomizedRoutes
 		return azureRoutes, nil
 	} else {
 		return routes[cloud], nil

--- a/pkg/tsdb/azuremonitor/azuremonitor_test.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor_test.go
@@ -55,7 +55,7 @@ func TestNewInstanceSettings(t *testing.T) {
 		{
 			name: "creates an instance for customized cloud",
 			settings: backend.DataSourceInstanceSettings{
-				JSONData:                []byte(`{"cloudName":"customizedazuremonitor","customizedRoutes":{"Route":{"URL":"url"}},"azureAuthType":"clientsecret"}`),
+				JSONData:                []byte(`{"cloudName":"customizedazuremonitor","customizedCloudSettings":{"customizedRoutes":{"Route":{"URL":"url"}},"customizedAzurePortalUrl":"Portal"},"azureAuthType":"clientsecret"}`),
 				DecryptedSecureJSONData: map[string]string{"clientSecret": "secret"},
 				ID:                      50,
 			},
@@ -65,7 +65,16 @@ func TestNewInstanceSettings(t *testing.T) {
 					AzureCloud:   "AzureCustomizedCloud",
 					ClientSecret: "secret",
 				},
-				Settings: types.AzureMonitorSettings{},
+				Settings: types.AzureMonitorSettings{
+					CustomizedCloudSettings: types.AzureMonitorCustomizedCloudSettings{
+						CustomizedRoutes: map[string]types.AzRoute{
+							"Route": {
+								URL: "url",
+							},
+						},
+						CustomizedAzurePortalUrl: "Portal",
+					},
+				},
 				Routes: map[string]types.AzRoute{
 					"Route": {
 						URL: "url",
@@ -74,10 +83,13 @@ func TestNewInstanceSettings(t *testing.T) {
 				JSONData: map[string]interface{}{
 					"azureAuthType": "clientsecret",
 					"cloudName":     "customizedazuremonitor",
-					"customizedRoutes": map[string]interface{}{
-						"Route": map[string]interface{}{
-							"URL": "url",
+					"customizedCloudSettings": map[string]interface{}{
+						"customizedRoutes": map[string]interface{}{
+							"Route": map[string]interface{}{
+								"URL": "url",
+							},
 						},
+						"customizedAzurePortalUrl": "Portal",
 					},
 				},
 				DatasourceID:            50,

--- a/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource.go
+++ b/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource.go
@@ -244,7 +244,7 @@ func (e *AzureMonitorDatasource) executeQuery(ctx context.Context, logger log.Lo
 		return dataResponse
 	}
 
-	azurePortalUrl, err := resourcegraph.GetAzurePortalUrl(dsInfo.Cloud)
+	azurePortalUrl, err := resourcegraph.GetAzurePortalUrl(dsInfo)
 	if err != nil {
 		dataResponse.Error = err
 		return dataResponse

--- a/pkg/tsdb/azuremonitor/resourcegraph/azure-resource-graph-datasource.go
+++ b/pkg/tsdb/azuremonitor/resourcegraph/azure-resource-graph-datasource.go
@@ -197,7 +197,7 @@ func (e *AzureResourceGraphDatasource) executeQuery(ctx context.Context, logger 
 		return dataResponse
 	}
 
-	azurePortalUrl, err := GetAzurePortalUrl(dsInfo.Cloud)
+	azurePortalUrl, err := GetAzurePortalUrl(dsInfo)
 	if err != nil {
 		return dataResponseErrorWithExecuted(err)
 	}
@@ -269,8 +269,8 @@ func (e *AzureResourceGraphDatasource) unmarshalResponse(logger log.Logger, res 
 	return data, nil
 }
 
-func GetAzurePortalUrl(azureCloud string) (string, error) {
-	switch azureCloud {
+func GetAzurePortalUrl(dsInfo types.DatasourceInfo) (string, error) {
+	switch dsInfo.Cloud {
 	case azsettings.AzurePublic:
 		return "https://portal.azure.com", nil
 	case azsettings.AzureChina:
@@ -279,6 +279,11 @@ func GetAzurePortalUrl(azureCloud string) (string, error) {
 		return "https://portal.azure.us", nil
 	case azsettings.AzureGermany:
 		return "https://portal.microsoftazure.de", nil
+	case azsettings.AzureCustomized:
+		if dsInfo.Settings.CustomizedCloudSettings.CustomizedAzurePortalUrl == "" {
+			return "", fmt.Errorf("the customized Azure portal URL is not provided")
+		}
+		return dsInfo.Settings.CustomizedCloudSettings.CustomizedAzurePortalUrl, nil
 	default:
 		return "", fmt.Errorf("the cloud is not supported")
 	}

--- a/pkg/tsdb/azuremonitor/resourcegraph/azure-resource-graph-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/resourcegraph/azure-resource-graph-datasource_test.go
@@ -141,20 +141,41 @@ func TestAddConfigData(t *testing.T) {
 }
 
 func TestGetAzurePortalUrl(t *testing.T) {
-	clouds := []string{azsettings.AzurePublic, azsettings.AzureChina, azsettings.AzureUSGovernment, azsettings.AzureGermany}
+	dsInfos := []types.DatasourceInfo{
+		{
+			Cloud: azsettings.AzurePublic,
+		},
+		{
+			Cloud: azsettings.AzureChina},
+		{
+			Cloud: azsettings.AzureUSGovernment,
+		},
+		{
+			Cloud: azsettings.AzureGermany,
+		},
+		{
+			Cloud: azsettings.AzureCustomized,
+			Settings: types.AzureMonitorSettings{
+				CustomizedCloudSettings: types.AzureMonitorCustomizedCloudSettings{
+					CustomizedAzurePortalUrl: "Portal",
+				},
+			},
+		},
+	}
 	expectedAzurePortalUrl := map[string]interface{}{
 		azsettings.AzurePublic:       "https://portal.azure.com",
 		azsettings.AzureChina:        "https://portal.azure.cn",
 		azsettings.AzureUSGovernment: "https://portal.azure.us",
 		azsettings.AzureGermany:      "https://portal.microsoftazure.de",
+		azsettings.AzureCustomized:   "Portal",
 	}
 
-	for _, cloud := range clouds {
-		azurePortalUrl, err := GetAzurePortalUrl(cloud)
+	for _, dsInfo := range dsInfos {
+		azurePortalUrl, err := GetAzurePortalUrl(dsInfo)
 		if err != nil {
 			t.Errorf("The cloud not supported")
 		}
-		assert.Equal(t, expectedAzurePortalUrl[cloud], azurePortalUrl)
+		assert.Equal(t, expectedAzurePortalUrl[dsInfo.Cloud], azurePortalUrl)
 	}
 }
 

--- a/pkg/tsdb/azuremonitor/types/types.go
+++ b/pkg/tsdb/azuremonitor/types/types.go
@@ -28,14 +28,16 @@ type AzRoute struct {
 }
 
 type AzureMonitorSettings struct {
-	SubscriptionId               string `json:"subscriptionId"`
-	LogAnalyticsDefaultWorkspace string `json:"logAnalyticsDefaultWorkspace"`
-	AppInsightsAppId             string `json:"appInsightsAppId"`
+	SubscriptionId               string                              `json:"subscriptionId"`
+	LogAnalyticsDefaultWorkspace string                              `json:"logAnalyticsDefaultWorkspace"`
+	AppInsightsAppId             string                              `json:"appInsightsAppId"`
+	CustomizedCloudSettings      AzureMonitorCustomizedCloudSettings `json:"customizedCloudSettings"`
 }
 
 // AzureMonitorCustomizedCloudSettings is the extended Azure Monitor settings for customized cloud
 type AzureMonitorCustomizedCloudSettings struct {
-	CustomizedRoutes map[string]AzRoute `json:"customizedRoutes"`
+	CustomizedRoutes         map[string]AzRoute `json:"customizedRoutes"`
+	CustomizedAzurePortalUrl string             `json:"customizedAzurePortalUrl"`
 }
 
 type DatasourceService struct {

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_log_analytics/azure_log_analytics_datasource.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_log_analytics/azure_log_analytics_datasource.ts
@@ -52,7 +52,7 @@ export default class AzureLogAnalyticsDatasource extends DataSourceWithBackend<
     this.resourcePath = `${routeNames.logAnalytics}`;
     this.azureMonitorPath = `${routeNames.azureMonitor}/subscriptions`;
     const cloud = getAzureCloud(instanceSettings);
-    this.azurePortalUrl = getAzurePortalUrl(cloud);
+    this.azurePortalUrl = getAzurePortalUrl(cloud, instanceSettings);
 
     this.defaultSubscriptionId = this.instanceSettings.jsonData.subscriptionId || '';
   }

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_monitor/azure_monitor_datasource.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_monitor/azure_monitor_datasource.ts
@@ -58,7 +58,7 @@ export default class AzureMonitorDatasource extends DataSourceWithBackend<AzureM
 
     const cloud = getAzureCloud(instanceSettings);
     this.resourcePath = routeNames.azureMonitor;
-    this.azurePortalUrl = getAzurePortalUrl(cloud);
+    this.azurePortalUrl = getAzurePortalUrl(cloud, instanceSettings);
   }
 
   isConfigured(): boolean {

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/credentials.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/credentials.ts
@@ -44,7 +44,10 @@ function getDefaultAzureCloud(): string {
   }
 }
 
-export function getAzurePortalUrl(azureCloud: string): string {
+export function getAzurePortalUrl(
+  azureCloud: string,
+  options: AzureDataSourceSettings | AzureDataSourceInstanceSettings
+): string {
   switch (azureCloud) {
     case 'azuremonitor':
       return 'https://portal.azure.com';
@@ -54,6 +57,11 @@ export function getAzurePortalUrl(azureCloud: string): string {
       return 'https://portal.azure.us';
     case 'germanyazuremonitor':
       return 'https://portal.microsoftazure.de';
+    case 'customizedazuremonitor':
+      if (!options.jsonData.customizedCloudSettings?.customizedAzurePortalUrl) {
+        throw new Error('The customized Azure portal URL not provided.');
+      }
+      return options.jsonData.customizedCloudSettings.customizedAzurePortalUrl;
     default:
       throw new Error('The cloud not supported.');
   }

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/types/types.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/types/types.ts
@@ -53,6 +53,10 @@ export interface AzureClientSecretCredentials extends AzureCredentialsBase {
 
 export type AzureCredentials = AzureManagedIdentityCredentials | AzureClientSecretCredentials;
 
+export interface AzureMonitorCustomizedCloudSettings {
+  customizedAzurePortalUrl: string;
+}
+
 export interface AzureDataSourceJsonData extends DataSourceJsonData {
   cloudName: string;
   azureAuthType?: AzureAuthType;
@@ -76,6 +80,9 @@ export interface AzureDataSourceJsonData extends DataSourceJsonData {
 
   // App Insights
   appInsightsAppId?: string;
+
+  // Customized cloud settings
+  customizedCloudSettings?: AzureMonitorCustomizedCloudSettings;
 }
 
 export interface AzureDataSourceSecureJsonData {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Add support to customize Azure portal URL for customized cloud.

**Why do we need this feature?**

To unblock the requirement from #59857, @mrinbh hopes to test the customized cloud feature #54829 by provisioning an Azure Monitor datasource by yaml file.

**Who is this feature for?**

Users who want to provision a datasource for customized Azure cloud.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #59857 

**Special notes for your reviewer**:
All the JSON data members for customized cloud are moved to `AzureMonitorSettings` so that extra JSON deserialization is avoided when accessing.
