### PR TITLE
Dashboards: Wrap MakeEditable in the new Page layout

### DIFF
--- a/public/app/features/dashboard/components/DashboardSettings/DashboardSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/DashboardSettings.tsx
@@ -6,6 +6,7 @@ import { locationUtil, NavModel, NavModelItem } from '@grafana/data';
 import { locationService } from '@grafana/runtime';
 import { Button, PageToolbar } from '@grafana/ui';
 import { AppChromeUpdate } from 'app/core/components/AppChrome/AppChromeUpdate';
+import { Page } from 'app/core/components/PageNew/Page';
 import config from 'app/core/config';
 import { contextSrv } from 'app/core/services/context_srv';
 import { AccessControlAction } from 'app/types';
@@ -204,7 +205,7 @@ function getSectionNav(
   };
 }
 
-function MakeEditable({ dashboard }: SettingsPageProps) {
+function MakeEditable({ dashboard, sectionNav }: SettingsPageProps) {
   const onMakeEditable = () => {
     dashboard.editable = true;
     dashboard.meta.canMakeEditable = false;
@@ -214,12 +215,12 @@ function MakeEditable({ dashboard }: SettingsPageProps) {
   };
 
   return (
-    <div>
+    <Page navModel={sectionNav}>
       <div className="dashboard-settings__header">Dashboard not editable</div>
       <Button type="submit" onClick={onMakeEditable}>
         Make editable
       </Button>
-    </div>
+    </Page>
   );
 }
 


### PR DESCRIPTION
**What is this feature?**

Wrap the MakeEditable Dashboard Settings view in the Page layout, and give it the nav.

Because I'm passing the section nav into the page layout, there is a slight functionality change as now the Permissions and JSON Model views are rendered. But as these pages were always in the section nav, these pages were able to be navigated to by URL previously.

If these pages should not be able to be navigated to when the dashboard isn't editable, then the logic in `getSectionPages` should be tweaked instead.

With topnav:

| Before   | After   |
|---|---|
| ![image](https://user-images.githubusercontent.com/46142/207595848-ded29dc3-06bc-46eb-83a9-60cc545a316f.png) | ![image](https://user-images.githubusercontent.com/46142/207595513-6685d9b7-57a0-4efb-b800-23bb7221c763.png) |


Without topnav:

| Before   | After   |
|---|---|
| ![image](https://user-images.githubusercontent.com/46142/207595770-bf164745-c71c-426e-8f2b-77e3c047092f.png) | ![image](https://user-images.githubusercontent.com/46142/207595606-400e753b-8ef8-4975-9c23-462c4d51b96a.png) |

**Why do we need this feature?**

So it looks less ugly

**Who is this feature for?**

Admins and Editors of Grafana

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #57691

**Special notes for your reviewer**:

