### PR TITLE
Cloudwatch: Increase label width in Config Editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -243,7 +243,7 @@
     "@daybrush/utils": "1.10.0",
     "@emotion/css": "11.10.5",
     "@emotion/react": "11.10.5",
-    "@grafana/aws-sdk": "0.0.37",
+    "@grafana/aws-sdk": "0.0.40",
     "@grafana/data": "workspace:*",
     "@grafana/e2e-selectors": "workspace:*",
     "@grafana/experimental": "1.0.1",

--- a/public/app/plugins/datasource/cloudwatch/components/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/ConfigEditor.tsx
@@ -75,8 +75,9 @@ export const ConfigEditor: FC<Props> = (props: Props) => {
               );
           })
         }
+        labelWidth={29}
       >
-        <InlineField label="Namespaces of Custom Metrics" labelWidth={28} tooltip="Namespaces of Custom Metrics.">
+        <InlineField label="Namespaces of Custom Metrics" labelWidth={29} tooltip="Namespaces of Custom Metrics.">
           <Input
             width={60}
             placeholder="Namespace1,Namespace2"

--- a/public/app/plugins/datasource/cloudwatch/components/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/ConfigEditor.tsx
@@ -62,6 +62,7 @@ export const ConfigEditor: FC<Props> = (props: Props) => {
     <>
       <ConnectionConfig
         {...props}
+        labelWidth={29}
         loadRegions={
           datasource &&
           (async () => {
@@ -75,7 +76,6 @@ export const ConfigEditor: FC<Props> = (props: Props) => {
               );
           })
         }
-        labelWidth={29}
       >
         <InlineField label="Namespaces of Custom Metrics" labelWidth={29} tooltip="Namespaces of Custom Metrics.">
           <Input

--- a/yarn.lock
+++ b/yarn.lock
@@ -4643,10 +4643,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@grafana/aws-sdk@npm:0.0.37":
-  version: 0.0.37
-  resolution: "@grafana/aws-sdk@npm:0.0.37"
-  checksum: 3994e78182dc181c9ba1b0595551480eb699c34531f582c52badec8da1d930a3198530145ef58a9543f77e424026c6a70a213097e0b56534f44894165db9c4d2
+"@grafana/aws-sdk@npm:0.0.40":
+  version: 0.0.40
+  resolution: "@grafana/aws-sdk@npm:0.0.40"
+  checksum: 23d20f8da262b7a80a13d0c60bbefa49760c5b1459c00646cbb4762d861003f8c3a32d8c6660902762c27ba136831b15d420291b105f4d72b971a04854d9027f
   languageName: node
   linkType: hard
 
@@ -21861,7 +21861,7 @@ __metadata:
     "@emotion/css": 11.10.5
     "@emotion/eslint-plugin": 11.10.0
     "@emotion/react": 11.10.5
-    "@grafana/aws-sdk": 0.0.37
+    "@grafana/aws-sdk": 0.0.40
     "@grafana/data": "workspace:*"
     "@grafana/e2e": "workspace:*"
     "@grafana/e2e-selectors": "workspace:*"


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Fixes overflowing label width in Cloudwatch  Config editor: 

<img width="597" alt="Screen Shot 2022-12-12 at 5 34 13 PM" src="https://user-images.githubusercontent.com/16140639/207626174-c008853d-767c-4df2-8cd9-e66ff2b6bce0.png">

Added an optional labelWidth prop to aws-sdk-react 0.0.40 [release](https://github.com/grafana/grafana-aws-sdk-react/pull/34)  and updated this repo to pass the new width that will make all the labels the same width to accommodate the overflowing label

After: 

<img width="767" alt="Screen Shot 2022-12-14 at 3 32 48 PM" src="https://user-images.githubusercontent.com/16140639/207627097-ebdf20b6-1485-48f7-a3d4-5c1f1cedfc75.png">