### PR TITLE
Authn: Add client for api keys

### DIFF
--- a/pkg/services/authn/authn.go
+++ b/pkg/services/authn/authn.go
@@ -3,13 +3,15 @@ package authn
 import (
 	"context"
 	"net/http"
+	"strconv"
+	"strings"
 
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/user"
 )
 
 const (
-	ClientAPIKey    = "auth.client.apikey"
+	ClientAPIKey    = "auth.client.api-key"
 	ClientAnonymous = "auth.client.anonymous"
 )
 

--- a/pkg/services/authn/authn.go
+++ b/pkg/services/authn/authn.go
@@ -9,8 +9,8 @@ import (
 )
 
 const (
-	ClientApiKey    = "auth.api_key"
-	ClientAnonymous = "auth.anonymous"
+	ClientApiKey    = "auth.client.apikey"
+	ClientAnonymous = "auth.client.anonymous"
 )
 
 type Service interface {

--- a/pkg/services/authn/authn.go
+++ b/pkg/services/authn/authn.go
@@ -13,11 +13,15 @@ const (
 )
 
 type Service interface {
+	// Authenticate is used to authenticate using a specific client
 	Authenticate(ctx context.Context, client string, r *Request) (*Identity, error)
+	// Test will return true if client can be used for the auth request and false if not
+	Test(ctx context.Context, client string, r *Request) bool
 }
 
 type Client interface {
 	Authenticate(ctx context.Context, r *Request) (*Identity, error)
+	Test(ctx context.Context, r *Request) bool
 }
 
 type Request struct {

--- a/pkg/services/authn/authn.go
+++ b/pkg/services/authn/authn.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	ClientAPIKey    = "auth.client.api-key"
+	ClientAPIKey    = "auth.client.api-key" // #nosec G101
 	ClientAnonymous = "auth.client.anonymous"
 )
 
@@ -80,7 +80,7 @@ func (i *Identity) SignedInUser() *user.SignedInUser {
 		IsGrafanaAdmin:     i.IsGrafanaAdmin,
 		IsAnonymous:        i.IsAnonymous(),
 		IsDisabled:         i.IsDisabled,
-		HelpFlags1:         user.HelpFlags1(i.HelpFlags1),
+		HelpFlags1:         i.HelpFlags1,
 		LastSeenAt:         i.LastSeenAt,
 		Teams:              i.Teams,
 	}

--- a/pkg/services/authn/authn.go
+++ b/pkg/services/authn/authn.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	ClientApiKey    = "auth.client.apikey"
+	ClientAPIKey    = "auth.client.apikey"
 	ClientAnonymous = "auth.client.anonymous"
 )
 
@@ -28,6 +28,11 @@ type Client interface {
 type Request struct {
 	HTTPRequest *http.Request
 }
+
+const (
+	APIKeyIDPrefix         = "apikey:"
+	ServiceAccountIDPrefix = "service-account:"
+)
 
 type Identity struct {
 	OrgID       int64

--- a/pkg/services/authn/authn.go
+++ b/pkg/services/authn/authn.go
@@ -15,13 +15,13 @@ const (
 
 type Service interface {
 	// Authenticate is used to authenticate using a specific client
-	Authenticate(ctx context.Context, client string, r *Request) (*Identity, error)
-	// Test will return true if client can be used for the auth request and false if not
-	Test(ctx context.Context, client string, r *Request) bool
+	Authenticate(ctx context.Context, client string, r *Request) (*Identity, bool, error)
 }
 
 type Client interface {
+	// Authenticate performs the authentication for the request
 	Authenticate(ctx context.Context, r *Request) (*Identity, error)
+	// Test should return true if client can be used to authenticate request
 	Test(ctx context.Context, r *Request) bool
 }
 

--- a/pkg/services/authn/authn.go
+++ b/pkg/services/authn/authn.go
@@ -9,6 +9,7 @@ import (
 )
 
 const (
+	ClientApiKey    = "auth.api_key"
 	ClientAnonymous = "auth.anonymous"
 )
 

--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -60,3 +60,16 @@ func (s *Service) Authenticate(ctx context.Context, clientName string, r *authn.
 
 	return client.Authenticate(ctx, r)
 }
+
+func (s *Service) Test(ctx context.Context, client string, r *authn.Request) bool {
+	ctx, span := s.tracer.Start(ctx, "authn.Test")
+	defer span.End()
+
+	span.SetAttributes("authn.client", client, attribute.Key("authn.client").String(client))
+	c, ok := s.clients[client]
+	if !ok {
+		return false
+	}
+
+	return c.Test(ctx, r)
+}

--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -65,7 +65,7 @@ func (s *Service) Authenticate(ctx context.Context, client string, r *authn.Requ
 
 	identity, err := c.Authenticate(ctx, r)
 	if err != nil {
-		logger.Warn("auth client could not authenticate request", "client", client)
+		logger.Warn("auth client could not authenticate request", "client", client, "err", err)
 		span.AddEvents([]string{"message"}, []tracing.EventValue{{Str: "auth client could not authenticate request"}})
 		return nil, true, err
 	}

--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -65,7 +65,7 @@ func (s *Service) Authenticate(ctx context.Context, client string, r *authn.Requ
 
 	identity, err := c.Authenticate(ctx, r)
 	if err != nil {
-		logger.Warn("auth client could not authenticate request", "client", client, "err", err)
+		logger.Warn("auth client could not authenticate request", "client", client, "error", err)
 		span.AddEvents([]string{"message"}, []tracing.EventValue{{Str: "auth client could not authenticate request"}})
 		return nil, true, err
 	}

--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -22,6 +22,8 @@ func ProvideService(cfg *setting.Cfg, tracer tracing.Tracer, orgService org.Serv
 		tracer:  tracer,
 	}
 
+	s.clients[authn.ClientApiKey] = clients.ProvideApiKey()
+
 	if s.cfg.AnonymousEnabled {
 		s.clients[authn.ClientAnonymous] = clients.ProvideAnonymous(cfg, orgService)
 	}

--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
+	"github.com/grafana/grafana/pkg/services/apikey"
 	"github.com/grafana/grafana/pkg/services/authn"
 	"github.com/grafana/grafana/pkg/services/authn/clients"
 	"github.com/grafana/grafana/pkg/services/org"
@@ -14,7 +15,7 @@ import (
 
 var _ authn.Service = new(Service)
 
-func ProvideService(cfg *setting.Cfg, tracer tracing.Tracer, orgService org.Service) *Service {
+func ProvideService(cfg *setting.Cfg, tracer tracing.Tracer, orgService org.Service, apikeyService apikey.Service) *Service {
 	s := &Service{
 		log:     log.New("authn.service"),
 		cfg:     cfg,
@@ -22,7 +23,7 @@ func ProvideService(cfg *setting.Cfg, tracer tracing.Tracer, orgService org.Serv
 		tracer:  tracer,
 	}
 
-	s.clients[authn.ClientApiKey] = clients.ProvideApiKey()
+	s.clients[authn.ClientApiKey] = clients.ProvideAPIKey(apikeyService)
 
 	if s.cfg.AnonymousEnabled {
 		s.clients[authn.ClientAnonymous] = clients.ProvideAnonymous(cfg, orgService)

--- a/pkg/services/authn/authnimpl/service_test.go
+++ b/pkg/services/authn/authnimpl/service_test.go
@@ -44,6 +44,44 @@ func TestService_Authenticate(t *testing.T) {
 	}
 }
 
+func TestService_Test(t *testing.T) {
+	type TestCase struct {
+		desc     string
+		client   string
+		expected bool
+	}
+
+	tests := []TestCase{
+		{
+			desc:     "should return true for registered client",
+			client:   "fake",
+			expected: true,
+		},
+		{
+			desc:     "should return false for registered client that cannot process request",
+			client:   "fake",
+			expected: false,
+		},
+		{
+			desc:     "should return false for non existing client",
+			client:   "gitlab",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			svc := setupTests(t, func(svc *Service) {
+				svc.clients["fake"] = &authntest.FakeClient{ExpectedTest: tt.expected}
+			})
+
+			ok := svc.Test(context.Background(), tt.client, &authn.Request{})
+			assert.Equal(t, tt.expected, ok)
+		})
+	}
+
+}
+
 func setupTests(t *testing.T, opts ...func(svc *Service)) *Service {
 	t.Helper()
 

--- a/pkg/services/authn/authntest/fake.go
+++ b/pkg/services/authn/authntest/fake.go
@@ -14,9 +14,14 @@ var _ authn.Client = new(FakeClient)
 
 type FakeClient struct {
 	ExpectedErr      error
+	ExpectedTest     bool
 	ExpectedIdentity *authn.Identity
 }
 
 func (f *FakeClient) Authenticate(ctx context.Context, r *authn.Request) (*authn.Identity, error) {
 	return f.ExpectedIdentity, f.ExpectedErr
+}
+
+func (f *FakeClient) Test(ctx context.Context, r *authn.Request) bool {
+	return f.ExpectedTest
 }

--- a/pkg/services/authn/clients/anonymous.go
+++ b/pkg/services/authn/clients/anonymous.go
@@ -33,10 +33,9 @@ func (a *Anonymous) Authenticate(ctx context.Context, r *authn.Request) (*authn.
 	}
 
 	return &authn.Identity{
-		OrgID:       o.ID,
-		OrgName:     o.Name,
-		OrgRoles:    map[int64]org.RoleType{o.ID: org.RoleType(a.cfg.AnonymousOrgRole)},
-		IsAnonymous: true,
+		OrgID:    o.ID,
+		OrgName:  o.Name,
+		OrgRoles: map[int64]org.RoleType{o.ID: org.RoleType(a.cfg.AnonymousOrgRole)},
 	}, nil
 }
 

--- a/pkg/services/authn/clients/anonymous.go
+++ b/pkg/services/authn/clients/anonymous.go
@@ -39,3 +39,8 @@ func (a *Anonymous) Authenticate(ctx context.Context, r *authn.Request) (*authn.
 		IsAnonymous: true,
 	}, nil
 }
+
+func (a *Anonymous) Test(ctx context.Context, r *authn.Request) bool {
+	// If anonymous client is register it can always be used for authentication
+	return true
+}

--- a/pkg/services/authn/clients/anonymous_test.go
+++ b/pkg/services/authn/clients/anonymous_test.go
@@ -56,7 +56,7 @@ func TestAnonymous_Authenticate(t *testing.T) {
 			} else {
 				require.Nil(t, err)
 
-				assert.Equal(t, true, identity.IsAnonymous)
+				assert.Equal(t, true, identity.ID == "")
 				assert.Equal(t, tt.org.ID, identity.OrgID)
 				assert.Equal(t, tt.org.Name, identity.OrgName)
 				assert.Equal(t, tt.cfg.AnonymousOrgRole, string(identity.Role()))

--- a/pkg/services/authn/clients/api_key.go
+++ b/pkg/services/authn/clients/api_key.go
@@ -1,0 +1,53 @@
+package clients
+
+import (
+	"context"
+	"strings"
+
+	"github.com/grafana/grafana/pkg/services/authn"
+	"github.com/grafana/grafana/pkg/util"
+)
+
+const (
+	apiKeyPrefix = ""
+)
+
+var _ authn.Client = new(ApiKey)
+
+func ProvideApiKey() *ApiKey {
+	return &ApiKey{}
+}
+
+type ApiKey struct {
+}
+
+func (a *ApiKey) Authenticate(ctx context.Context, r *authn.Request) (*authn.Identity, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (a *ApiKey) Test(ctx context.Context, r *authn.Request) bool {
+	// api keys are only supported through http requests
+	if r.HTTPRequest == nil {
+		return false
+	}
+
+	return looksLikeApiKey(r.HTTPRequest.Header.Get("Authorization"))
+}
+
+func looksLikeApiKey(header string) bool {
+	parts := strings.Split(header, "")
+
+	var keyString string
+
+	if len(parts) == 2 && parts[0] == "Bearer" {
+		keyString = parts[1]
+	} else {
+		username, password, err := util.DecodeBasicAuthHeader(header)
+		if err == nil && username == "api_key" {
+			keyString = password
+		}
+	}
+
+	return keyString != ""
+}

--- a/pkg/services/authn/clients/api_key.go
+++ b/pkg/services/authn/clients/api_key.go
@@ -23,8 +23,9 @@ const (
 )
 
 var (
-	ErrAPIKeyExpired = errutil.NewBase(errutil.StatusUnauthorized, "apikey.expired", errutil.WithPublicMessage("Expired API key"))
-	ErrAPIKeyRevoked = errutil.NewBase(errutil.StatusUnauthorized, "apikey.revoked", errutil.WithPublicMessage("Revoked API key"))
+	ErrAPIKeyExpired          = errutil.NewBase(errutil.StatusUnauthorized, "api-key.expired", errutil.WithPublicMessage("Expired API key"))
+	ErrAPIKeyRevoked          = errutil.NewBase(errutil.StatusUnauthorized, "api-key.revoked", errutil.WithPublicMessage("Revoked API key"))
+	ErrServiceAccountDisabled = errutil.NewBase(errutil.StatusUnauthorized, "service-account.disabled", errutil.WithPublicMessage("Disabled service account"))
 )
 
 var _ authn.Client = new(APIKey)
@@ -87,7 +88,7 @@ func (s *APIKey) Authenticate(ctx context.Context, r *authn.Request) (*authn.Ide
 	}
 
 	if usr.IsDisabled {
-		// TODO: return error
+		return nil, ErrServiceAccountDisabled
 	}
 
 	return authn.IdentityFromSignedInUser(fmt.Sprintf("%s:%d", authn.ServiceAccountIDPrefix, *apiKey.ServiceAccountId), usr), nil

--- a/pkg/services/authn/clients/api_key.go
+++ b/pkg/services/authn/clients/api_key.go
@@ -90,13 +90,7 @@ func (s *APIKey) Authenticate(ctx context.Context, r *authn.Request) (*authn.Ide
 		// TODO: return error
 	}
 
-	// TODO: set all fields required from usr
-	return &authn.Identity{
-		ID:       fmt.Sprintf("%s:%d", authn.ServiceAccountIDPrefix, *apiKey.ServiceAccountId),
-		OrgID:    usr.OrgID,
-		OrgName:  usr.OrgName,
-		OrgRoles: map[int64]org.RoleType{usr.OrgID: usr.OrgRole},
-	}, nil
+	return authn.IdentityFromSignedInUser(fmt.Sprintf("%s:%d", authn.ServiceAccountIDPrefix, *apiKey.ServiceAccountId), usr), nil
 }
 
 func (s *APIKey) getAPIKey(ctx context.Context, token string) (*apikey.APIKey, error) {

--- a/pkg/services/authn/clients/api_key.go
+++ b/pkg/services/authn/clients/api_key.go
@@ -77,7 +77,7 @@ func (s *APIKey) Authenticate(ctx context.Context, r *authn.Request) (*authn.Ide
 	// if the api key don't belong to a service account construct the identity and return it
 	if apiKey.ServiceAccountId == nil || *apiKey.ServiceAccountId < 1 {
 		return &authn.Identity{
-			ID:       fmt.Sprintf("%s:%d", authn.APIKeyIDPrefix, apiKey.Id),
+			ID:       fmt.Sprintf("%s%d", authn.APIKeyIDPrefix, apiKey.Id),
 			OrgID:    apiKey.OrgId,
 			OrgRoles: map[int64]org.RoleType{apiKey.OrgId: apiKey.Role},
 		}, nil
@@ -96,7 +96,7 @@ func (s *APIKey) Authenticate(ctx context.Context, r *authn.Request) (*authn.Ide
 		return nil, ErrServiceAccountDisabled.Errorf("Disabled service account")
 	}
 
-	return authn.IdentityFromSignedInUser(fmt.Sprintf("%s:%d", authn.ServiceAccountIDPrefix, *apiKey.ServiceAccountId), usr), nil
+	return authn.IdentityFromSignedInUser(fmt.Sprintf("%s%d", authn.ServiceAccountIDPrefix, *apiKey.ServiceAccountId), usr), nil
 }
 
 func (s *APIKey) getAPIKey(ctx context.Context, token string) (*apikey.APIKey, error) {

--- a/pkg/services/authn/clients/api_key.go
+++ b/pkg/services/authn/clients/api_key.go
@@ -2,12 +2,17 @@ package clients
 
 import (
 	"context"
-	"errors"
 	"strings"
+	"time"
 
+	"github.com/grafana/grafana/pkg/components/apikeygen"
+	apikeygenprefix "github.com/grafana/grafana/pkg/components/apikeygenprefixed"
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/apikey"
 	"github.com/grafana/grafana/pkg/services/authn"
+	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/util"
+	"github.com/grafana/grafana/pkg/util/errutil"
 )
 
 const (
@@ -15,36 +20,114 @@ const (
 	bearerPrefix = "Bearer "
 )
 
+var (
+	ErrAPIKeyExpired = errutil.NewBase(errutil.StatusUnauthorized, "apikey.expired", errutil.WithPublicMessage("Expired API key"))
+	ErrAPIKeyRevoked = errutil.NewBase(errutil.StatusUnauthorized, "apikey.revoked", errutil.WithPublicMessage("Revoked API key"))
+)
+
 var _ authn.Client = new(APIKey)
 
 func ProvideAPIKey(service apikey.Service) *APIKey {
-	return &APIKey{}
+	return &APIKey{
+		service: service,
+		log:     log.New(authn.ClientAPIKey),
+	}
 }
 
 type APIKey struct {
 	service apikey.Service
+	log     log.Logger
 }
 
-func (a *APIKey) Authenticate(ctx context.Context, r *authn.Request) (*authn.Identity, error) {
-	key := getApiKey(r)
-	if key == "" {
-		// TODO: return error
-		return nil, errors.New("temp")
+func (s *APIKey) Authenticate(ctx context.Context, r *authn.Request) (*authn.Identity, error) {
+	apiKey, err := s.getAPIKey(ctx, getTokenFromRequest(r))
+	if err != nil {
+		return nil, err
 	}
 
-	//TODO implement me
-	panic("implement me")
+	if apiKey.Expires != nil && *apiKey.Expires <= time.Now().Unix() {
+		return nil, ErrAPIKeyExpired
+	}
+
+	if apiKey.IsRevoked != nil && *apiKey.IsRevoked {
+		return nil, ErrAPIKeyRevoked
+	}
+
+	go func(id int64) {
+		if err := s.service.UpdateAPIKeyLastUsedDate(context.Background(), id); err != nil {
+			s.log.Warn("failed to update last use date for api key", "id", id)
+		}
+	}(apiKey.Id)
+
+	identity := &authn.Identity{}
+	identity.OrgID = apiKey.OrgId
+	// Not correct for a service account
+	identity.OrgRoles = map[int64]org.RoleType{apiKey.OrgId: apiKey.Role}
+
+	return identity, nil
 }
 
-func (a *APIKey) Test(ctx context.Context, r *authn.Request) bool {
-	return looksLikeApiKey(getApiKey(r))
+func (s *APIKey) getAPIKey(ctx context.Context, token string) (*apikey.APIKey, error) {
+	fn := s.getFromToken
+	if !strings.HasPrefix(token, apikeygenprefix.GrafanaPrefix) {
+		fn = s.getFromTokenLegacy
+	}
+
+	apiKey, err := fn(ctx, token)
+	if err != nil {
+		return nil, err
+	}
+
+	return apiKey, nil
+}
+
+func (s *APIKey) getFromToken(ctx context.Context, token string) (*apikey.APIKey, error) {
+	decoded, err := apikeygenprefix.Decode(token)
+	if err != nil {
+		return nil, err
+	}
+
+	hash, err := decoded.Hash()
+	if err != nil {
+		return nil, err
+	}
+
+	return s.service.GetAPIKeyByHash(ctx, hash)
+}
+
+func (s *APIKey) getFromTokenLegacy(ctx context.Context, token string) (*apikey.APIKey, error) {
+	decoded, err := apikeygen.Decode(token)
+	if err != nil {
+		return nil, err
+	}
+
+	// fetch key
+	keyQuery := apikey.GetByNameQuery{KeyName: decoded.Name, OrgId: decoded.OrgId}
+	if err := s.service.GetApiKeyByName(ctx, &keyQuery); err != nil {
+		return nil, err
+	}
+
+	// validate api key
+	isValid, err := apikeygen.IsValid(decoded, keyQuery.Result.Key)
+	if err != nil {
+		return nil, err
+	}
+	if !isValid {
+		return nil, apikeygen.ErrInvalidApiKey
+	}
+
+	return keyQuery.Result, nil
+}
+
+func (s *APIKey) Test(ctx context.Context, r *authn.Request) bool {
+	return looksLikeApiKey(getTokenFromRequest(r))
 }
 
 func looksLikeApiKey(token string) bool {
 	return token != ""
 }
 
-func getApiKey(r *authn.Request) string {
+func getTokenFromRequest(r *authn.Request) string {
 	// api keys are only supported through http requests
 	if r.HTTPRequest == nil {
 		return ""

--- a/pkg/services/authn/clients/api_key.go
+++ b/pkg/services/authn/clients/api_key.go
@@ -2,8 +2,10 @@ package clients
 
 import (
 	"context"
+	"errors"
 	"strings"
 
+	"github.com/grafana/grafana/pkg/services/apikey"
 	"github.com/grafana/grafana/pkg/services/authn"
 	"github.com/grafana/grafana/pkg/util"
 )
@@ -13,21 +15,28 @@ const (
 	bearerPrefix = "Bearer "
 )
 
-var _ authn.Client = new(ApiKey)
+var _ authn.Client = new(APIKey)
 
-func ProvideApiKey() *ApiKey {
-	return &ApiKey{}
+func ProvideAPIKey(service apikey.Service) *APIKey {
+	return &APIKey{}
 }
 
-type ApiKey struct {
+type APIKey struct {
+	service apikey.Service
 }
 
-func (a *ApiKey) Authenticate(ctx context.Context, r *authn.Request) (*authn.Identity, error) {
+func (a *APIKey) Authenticate(ctx context.Context, r *authn.Request) (*authn.Identity, error) {
+	key := getApiKey(r)
+	if key == "" {
+		// TODO: return error
+		return nil, errors.New("temp")
+	}
+
 	//TODO implement me
 	panic("implement me")
 }
 
-func (a *ApiKey) Test(ctx context.Context, r *authn.Request) bool {
+func (a *APIKey) Test(ctx context.Context, r *authn.Request) bool {
 	return looksLikeApiKey(getApiKey(r))
 }
 

--- a/pkg/services/authn/clients/api_key_test.go
+++ b/pkg/services/authn/clients/api_key_test.go
@@ -7,11 +7,130 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/grafana/grafana/pkg/components/apikeygen"
+	apikeygenprefix "github.com/grafana/grafana/pkg/components/apikeygenprefixed"
+	"github.com/grafana/grafana/pkg/services/apikey"
 	"github.com/grafana/grafana/pkg/services/apikey/apikeytest"
 	"github.com/grafana/grafana/pkg/services/authn"
+	"github.com/grafana/grafana/pkg/services/org"
+	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/services/user/usertest"
 	"github.com/stretchr/testify/assert"
 )
+
+var (
+	revoked      = true
+	secret, hash = genApiKey(false)
+)
+
+func TestAPIKey_Authenticate(t *testing.T) {
+	type TestCase struct {
+		desc             string
+		req              *authn.Request
+		expectedKey      *apikey.APIKey
+		expectedUser     *user.SignedInUser
+		expectedErr      error
+		expectedIdentity *authn.Identity
+	}
+
+	tests := []TestCase{
+		{
+			desc: "should success for valid token that is not connected to a service account",
+			req: &authn.Request{HTTPRequest: &http.Request{
+				Header: map[string][]string{
+					"Authorization": {"Bearer " + secret},
+				},
+			}},
+			expectedKey: &apikey.APIKey{
+				Id:    1,
+				OrgId: 1,
+				Key:   hash,
+				Role:  org.RoleAdmin,
+			},
+			expectedIdentity: &authn.Identity{
+				ID:       "api-key:1",
+				OrgID:    1,
+				OrgRoles: map[int64]org.RoleType{1: org.RoleAdmin},
+			},
+		},
+		{
+			desc: "should success for valid token that is connected to service account",
+			req: &authn.Request{HTTPRequest: &http.Request{
+				Header: map[string][]string{
+					"Authorization": {"Bearer " + secret},
+				},
+			}},
+			expectedKey: &apikey.APIKey{
+				Id:               1,
+				OrgId:            1,
+				Key:              hash,
+				ServiceAccountId: intPtr(1),
+			},
+			expectedUser: &user.SignedInUser{
+				UserID:           1,
+				OrgID:            1,
+				IsServiceAccount: true,
+				OrgCount:         1,
+				OrgRole:          org.RoleViewer,
+				Name:             "test",
+			},
+			expectedIdentity: &authn.Identity{
+				ID:       "service-account:1",
+				OrgID:    1,
+				OrgCount: 1,
+				Name:     "test",
+				OrgRoles: map[int64]org.RoleType{1: org.RoleViewer},
+			},
+		},
+		{
+			desc: "should fail for expired api key",
+			req:  &authn.Request{HTTPRequest: &http.Request{Header: map[string][]string{"Authorization": {"Bearer " + secret}}}},
+			expectedKey: &apikey.APIKey{
+				Key:     hash,
+				Expires: intPtr(0),
+			},
+			expectedErr: ErrAPIKeyExpired,
+		},
+		{
+			desc: "should fail for revoked api key",
+			req:  &authn.Request{HTTPRequest: &http.Request{Header: map[string][]string{"Authorization": {"Bearer " + secret}}}},
+			expectedKey: &apikey.APIKey{
+				Key:       hash,
+				IsRevoked: &revoked,
+			},
+			expectedErr: ErrAPIKeyRevoked,
+		},
+		{
+			desc: "should fail if service account is disabled",
+			req:  &authn.Request{HTTPRequest: &http.Request{Header: map[string][]string{"Authorization": {"Bearer " + secret}}}},
+			expectedKey: &apikey.APIKey{
+				Key:              hash,
+				ServiceAccountId: intPtr(1),
+			},
+			expectedUser: &user.SignedInUser{IsDisabled: true},
+			expectedErr:  ErrServiceAccountDisabled,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			c := ProvideAPIKey(&apikeytest.Service{
+				ExpectedAPIKey: tt.expectedKey,
+			}, &usertest.FakeUserService{
+				ExpectedSignedInUser: tt.expectedUser,
+			})
+
+			identity, err := c.Authenticate(context.Background(), tt.req)
+			if tt.expectedErr != nil {
+				assert.Nil(t, identity)
+				assert.ErrorIs(t, err, tt.expectedErr)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, *tt.expectedIdentity, *identity)
+			}
+		})
+	}
+}
 
 func TestAPIKey_Test(t *testing.T) {
 	type TestCase struct {
@@ -68,6 +187,19 @@ func TestAPIKey_Test(t *testing.T) {
 			assert.Equal(t, tt.expected, c.Test(context.Background(), tt.req))
 		})
 	}
+}
+
+func intPtr(n int64) *int64 {
+	return &n
+}
+
+func genApiKey(legacy bool) (string, string) {
+	if legacy {
+		res, _ := apikeygen.New(1, "test")
+		return res.ClientSecret, res.HashedKey
+	}
+	res, _ := apikeygenprefix.New("test")
+	return res.ClientSecret, res.HashedKey
 }
 
 func encodeBasicAuth(username, password string) string {

--- a/pkg/services/authn/clients/api_key_test.go
+++ b/pkg/services/authn/clients/api_key_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/services/apikey/apikeytest"
 	"github.com/grafana/grafana/pkg/services/authn"
+	"github.com/grafana/grafana/pkg/services/user/usertest"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -63,7 +64,7 @@ func TestAPIKey_Test(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			c := ProvideAPIKey(&apikeytest.Service{})
+			c := ProvideAPIKey(&apikeytest.Service{}, usertest.NewUserServiceFake())
 			assert.Equal(t, tt.expected, c.Test(context.Background(), tt.req))
 		})
 	}

--- a/pkg/services/authn/clients/api_key_test.go
+++ b/pkg/services/authn/clients/api_key_test.go
@@ -1,0 +1,73 @@
+package clients
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/grafana/grafana/pkg/services/authn"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestApiKey_Test(t *testing.T) {
+	type TestCase struct {
+		desc     string
+		req      *authn.Request
+		expected bool
+	}
+
+	tests := []TestCase{
+		{
+			desc: "should succeed when api key is provided in Authorization header as bearer token",
+			req: &authn.Request{HTTPRequest: &http.Request{
+				Header: map[string][]string{
+					"Authorization": {"Bearer 123123"},
+				},
+			}},
+			expected: true,
+		},
+		{
+			desc: "should succeed when api key is provided in Authorization header as basic auth and api_key as username",
+			req: &authn.Request{HTTPRequest: &http.Request{
+				Header: map[string][]string{
+					"Authorization": {encodeBasicAuth("api_key", "test")},
+				},
+			}},
+			expected: true,
+		},
+		{
+			desc:     "should fail when no http request is passed",
+			req:      &authn.Request{},
+			expected: false,
+		},
+		{
+			desc: "should fail when no there is no Authorization header",
+			req: &authn.Request{HTTPRequest: &http.Request{
+				Header: map[string][]string{},
+			}},
+			expected: false,
+		},
+		{
+			desc: "should fail when Authorization header is not prefixed with Basic or Bearer",
+			req: &authn.Request{HTTPRequest: &http.Request{
+				Header: map[string][]string{
+					"Authorization": {"test"},
+				},
+			}},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			c := ProvideApiKey()
+			assert.Equal(t, tt.expected, c.Test(context.Background(), tt.req))
+		})
+	}
+}
+
+func encodeBasicAuth(username, password string) string {
+	return "Basic " + base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", username, password)))
+}

--- a/pkg/services/authn/clients/api_key_test.go
+++ b/pkg/services/authn/clients/api_key_test.go
@@ -7,11 +7,12 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/grafana/grafana/pkg/services/apikey/apikeytest"
 	"github.com/grafana/grafana/pkg/services/authn"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestApiKey_Test(t *testing.T) {
+func TestAPIKey_Test(t *testing.T) {
 	type TestCase struct {
 		desc     string
 		req      *authn.Request
@@ -62,7 +63,7 @@ func TestApiKey_Test(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			c := ProvideApiKey()
+			c := ProvideAPIKey(&apikeytest.Service{})
 			assert.Equal(t, tt.expected, c.Test(context.Background(), tt.req))
 		})
 	}

--- a/pkg/services/contexthandler/contexthandler.go
+++ b/pkg/services/contexthandler/contexthandler.go
@@ -68,6 +68,7 @@ func ProvideService(cfg *setting.Cfg, tokenService auth.UserTokenService, jwtSer
 		orgService:        orgService,
 		oauthTokenService: oauthTokenService,
 		features:          features,
+		authnService:      authnService,
 	}
 }
 

--- a/pkg/services/contexthandler/contexthandler.go
+++ b/pkg/services/contexthandler/contexthandler.go
@@ -287,8 +287,8 @@ func (h *ContextHandler) initContextWithAPIKey(reqContext *models.ReqContext) bo
 			return true
 		}
 
-		reqContext.SignedInUser = identity.SignedInUser()
 		reqContext.IsSignedIn = true
+		reqContext.SignedInUser = identity.SignedInUser()
 		return true
 	}
 

--- a/pkg/services/contexthandler/contexthandler.go
+++ b/pkg/services/contexthandler/contexthandler.go
@@ -738,7 +738,7 @@ func writeErr(c *models.ReqContext, err error) {
 		c.JsonApiErr(http.StatusInternalServerError, "", err)
 		return
 	}
-	c.JsonApiErr(grfErr.Reason.Status().HTTPStatus(), grfErr.Public().Message, nil)
+	c.JsonApiErr(grfErr.Reason.Status().HTTPStatus(), grfErr.Public().Message, err)
 }
 
 type authHTTPHeaderListContextKey struct{}


### PR DESCRIPTION
**What is this feature?**
Adding a authn client to perform authentication for api keys, both legacy and api keys connected to service accounts.

An auth client now need to implement the Test method, this method is used to determine if a specific client can be used to authenticate request. For api key client this will be true if we have a bearer token in the authorization header or if passed as basic auth with username "api_key". The test method is required to keep existing flow where we need to check several auth clients in context handler before we have a better system in place (priority system).


Most of the work done is porting the logic done in the initContextWithAPIKey to the auth client and adding more fields to the identity struct

Part of https://github.com/grafana/grafana-authnz-team/issues/159

