### PR TITLE
Prometheus: Fix X-Id-Token and X-ID-Token sent to Prometheus in query requests

### DIFF
--- a/pkg/tsdb/prometheus/querydata/request.go
+++ b/pkg/tsdb/prometheus/querydata/request.go
@@ -187,7 +187,7 @@ func (s *QueryData) trace(ctx context.Context, q *models.Query) (context.Context
 func sdkHeaderToHttpHeader(headers map[string]string) http.Header {
 	httpHeader := make(http.Header, len(headers))
 	for key, val := range headers {
-		httpHeader[key] = []string{val}
+		httpHeader.Set(key, val)
 	}
 	return httpHeader
 }

--- a/pkg/tsdb/prometheus/querydata/request_test.go
+++ b/pkg/tsdb/prometheus/querydata/request_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grafana/grafana/pkg/tsdb/prometheus/client"
 	apiv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	p "github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/infra/httpclient"
@@ -342,15 +343,36 @@ func TestPrometheus_parseTimeSeriesResponse(t *testing.T) {
 	})
 }
 
+func TestPrometheusCanonicalHeaders(t *testing.T) {
+	// Ensure headers are always canonicalized for all outgoing requests
+	b, err := json.Marshal(models.QueryModel{})
+	require.NoError(t, err)
+	query := backend.DataQuery{JSON: b}
+	tctx, err := setup(true)
+	require.NoError(t, err)
+	const idToken = "abc"
+	_, err = executeWithHeaders(tctx, query, queryResult{}, map[string]string{
+		"X-Id-Token": idToken,
+		"X-ID-Token": idToken,
+		"X-Other":    "thing",
+	})
+	require.NoError(t, err)
+	assert.NotEmpty(t, tctx.httpProvider.req.Header)
+	// Check the request that hit the fake prometheus server to ensure headers are valid
+	assert.Equal(t, []string{idToken}, tctx.httpProvider.req.Header["X-Id-Token"])
+	assert.Empty(t, tctx.httpProvider.req.Header["X-ID-Token"]) //nolint:staticcheck
+	assert.Equal(t, []string{"thing"}, tctx.httpProvider.req.Header["X-Other"])
+}
+
 type queryResult struct {
 	Type   p.ValueType `json:"resultType"`
 	Result interface{} `json:"result"`
 }
 
-func execute(tctx *testContext, query backend.DataQuery, qr interface{}) (data.Frames, error) {
+func executeWithHeaders(tctx *testContext, query backend.DataQuery, qr interface{}, headers map[string]string) (data.Frames, error) {
 	req := backend.QueryDataRequest{
 		Queries: []backend.DataQuery{query},
-		Headers: map[string]string{},
+		Headers: headers,
 	}
 
 	promRes, err := toAPIResponse(qr)
@@ -365,6 +387,10 @@ func execute(tctx *testContext, query backend.DataQuery, qr interface{}) (data.F
 	}
 
 	return res.Responses[req.Queries[0].RefID].Frames, nil
+}
+
+func execute(tctx *testContext, query backend.DataQuery, qr interface{}) (data.Frames, error) {
+	return executeWithHeaders(tctx, query, qr, map[string]string{})
 }
 
 type apiResponse struct {
@@ -447,6 +473,7 @@ func (f *fakeFeatureToggles) IsEnabled(feature string) bool {
 type fakeHttpClientProvider struct {
 	httpclient.Provider
 	opts sdkhttpclient.Options
+	req  *http.Request
 	res  *http.Response
 }
 
@@ -470,5 +497,6 @@ func (p *fakeHttpClientProvider) setResponse(res *http.Response) {
 }
 
 func (p *fakeHttpClientProvider) RoundTrip(req *http.Request) (*http.Response, error) {
+	p.req = req
 	return p.res, nil
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Ensures X-Id-Token header is sent as canonical form only to the Prometheus server.

The plugins SDK uses X-ID-Token, which is not canonical and cannot be changed for now to ensure backwards compatibility.

**Why do we need this feature?**

Currently, all outgoing Prometheus query requests have `X-ID-Token` and `X-Id-Token` set. Proxies should concatenate those values according to the RFC, so the value will be wrong. This PR fixes the issue and ensures that only `X-Id-Token` (MIME canonical format) is present. See the linked issue at the bottom for more details.

**Who is this feature for?**

Prometheus users using OAuth forwarding behind a proxy.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #59940

**Special notes for your reviewer**:

