### PR TITLE
OpenSearch: Use `aoss` servicename if OpenSearch is configured as `serverless`

### DIFF
--- a/pkg/services/datasources/service/datasource.go
+++ b/pkg/services/datasources/service/datasource.go
@@ -577,10 +577,8 @@ func awsServiceNamespace(dsType string, jsonData *simplejson.Json) string {
 	case datasources.DS_ES, datasources.DS_ES_OPEN_DISTRO:
 		return "es"
 	case datasources.DS_ES_OPENSEARCH:
-		serverless, err := jsonData.Get("serverless").Bool()
-		if err != nil {
-			serverless = false
-		}
+		serverless := jsonData.Get("serverless").MustBool()
+
 		if serverless {
 			return "aoss"
 		} else {


### PR DESCRIPTION
**What is this feature?**

We are currently implementing to also query OpenSearch Serverless in the OpenSearch datasource. That service uses a different `serviceName` when requested via SigV4. This PR adds a logic to determine the right servicename for OpenSearch.

**Special notes for your reviewer**:

PR in OpenSearch as a followup: https://github.com/grafana/opensearch-datasource/pull/92/

