### PR TITLE
Loki/ES: Add further items to query tracking

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -6224,6 +6224,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "1"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "2"]
     ],
+    "public/app/plugins/datasource/loki/tracking.ts:5381": [
+      [0, 0, 0, "Do not use any type assertions.", "0"]
+    ],
     "public/app/plugins/datasource/mixed/MixedDataSource.test.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"],

--- a/.betterer.results
+++ b/.betterer.results
@@ -6224,9 +6224,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "1"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "2"]
     ],
-    "public/app/plugins/datasource/loki/tracking.ts:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"]
-    ],
     "public/app/plugins/datasource/mixed/MixedDataSource.test.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"],

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -638,7 +638,8 @@ export class ElasticDatasource
     const shouldRunTroughBackend =
       request.app === CoreApp.Explore && config.featureToggles.elasticsearchBackendMigration;
     if (shouldRunTroughBackend) {
-      return super.query(request).pipe(tap((response) => trackQuery(response, request.targets, request.app)));
+      const start = new Date();
+      return super.query(request).pipe(tap((response) => trackQuery(response, request, start)));
     }
     let payload = '';
     const targets = this.interpolateVariablesInQueries(cloneDeep(request.targets), request.scopedVars);
@@ -705,6 +706,7 @@ export class ElasticDatasource
 
     const url = this.getMultiSearchUrl();
 
+    const start = new Date();
     return this.post(url, payload).pipe(
       map((res) => {
         const er = new ElasticResponse(sentTargets, res);
@@ -721,7 +723,7 @@ export class ElasticDatasource
 
         return er.getTimeSeries();
       }),
-      tap((response) => trackQuery(response, request.targets, request.app))
+      tap((response) => trackQuery(response, request, start))
     );
   }
 

--- a/public/app/plugins/datasource/elasticsearch/tracking.ts
+++ b/public/app/plugins/datasource/elasticsearch/tracking.ts
@@ -1,5 +1,5 @@
 import { CoreApp, DashboardLoadedEvent, DataQueryResponse } from '@grafana/data';
-import { reportInteraction } from '@grafana/runtime';
+import { config, reportInteraction } from '@grafana/runtime';
 import { variableRegex } from 'app/features/variables/utils';
 
 import { REF_ID_STARTER_LOG_VOLUME } from './datasource';
@@ -121,6 +121,7 @@ export function trackQuery(response: DataQueryResponse, queries: ElasticsearchQu
     }
     reportInteraction('grafana_elasticsearch_query_executed', {
       app,
+      grafana_version: config.buildInfo.version,
       with_lucene_query: query.query ? true : false,
       query_type: getQueryType(query),
       line_limit: getLineLimit(query),

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -170,7 +170,7 @@ export class LokiDatasource
       .map(getNormalizedLokiQuery) // "fix" the `.queryType` prop
       .map((q) => ({ ...q, maxLines: q.maxLines || this.maxLines })); // set maxLines if not set
 
-    const fixedRequest = {
+    const fixedRequest: DataQueryRequest<LokiQuery> & { targets: LokiQuery[] } = {
       ...request,
       targets: queries,
     };
@@ -197,12 +197,13 @@ export class LokiDatasource
     if (fixedRequest.liveStreaming) {
       return this.runLiveQueryThroughBackend(fixedRequest);
     } else {
+      const startTime = new Date();
       return super.query(fixedRequest).pipe(
         // in case of an empty query, this is somehow run twice. `share()` is no workaround here as the observable is generated from `of()`.
         map((response) =>
           transformBackendResult(response, fixedRequest.targets, this.instanceSettings.jsonData.derivedFields ?? [])
         ),
-        tap((response) => trackQuery(response, fixedRequest.targets, fixedRequest.app))
+        tap((response) => trackQuery(response, fixedRequest, startTime))
       );
     }
   }

--- a/public/app/plugins/datasource/loki/tracking.ts
+++ b/public/app/plugins/datasource/loki/tracking.ts
@@ -145,10 +145,11 @@ export function trackQuery(
   }
 
   let totalBytes = 0;
-  for (const frame of response.data as DataFrame[]) {
+  for (const frame of response.data) {
     const byteKey = frame.meta?.custom?.lokiQueryStatKey;
     if (byteKey) {
-      totalBytes += frame.meta?.stats?.find((stat) => stat.displayName === byteKey)?.value ?? 0;
+      totalBytes +=
+        frame.meta?.stats?.find((stat: { displayName: string }) => stat.displayName === byteKey)?.value ?? 0;
     }
   }
 

--- a/public/app/plugins/datasource/loki/tracking.ts
+++ b/public/app/plugins/datasource/loki/tracking.ts
@@ -1,4 +1,4 @@
-import { CoreApp, DashboardLoadedEvent, DataFrame, DataQueryRequest, DataQueryResponse } from '@grafana/data';
+import { CoreApp, DashboardLoadedEvent, DataQueryRequest, DataQueryResponse } from '@grafana/data';
 import { reportInteraction, config } from '@grafana/runtime';
 import { variableRegex } from 'app/features/variables/utils';
 

--- a/public/app/plugins/datasource/loki/tracking.ts
+++ b/public/app/plugins/datasource/loki/tracking.ts
@@ -1,5 +1,5 @@
-import { CoreApp, DashboardLoadedEvent, DataQueryResponse } from '@grafana/data';
-import { reportInteraction } from '@grafana/runtime';
+import { CoreApp, DashboardLoadedEvent, DataFrame, DataQueryRequest, DataQueryResponse } from '@grafana/data';
+import { reportInteraction, config } from '@grafana/runtime';
 import { variableRegex } from 'app/features/variables/utils';
 
 import { QueryEditorMode } from '../prometheus/querybuilder/shared/types';
@@ -132,18 +132,34 @@ const shouldNotReportBasedOnRefId = (refId: string): boolean => {
   return false;
 };
 
-export function trackQuery(response: DataQueryResponse, queries: LokiQuery[], app: string): void {
+export function trackQuery(
+  response: DataQueryResponse,
+  request: DataQueryRequest<LokiQuery> & { targets: LokiQuery[] },
+  startTime: Date
+): void {
   // We only want to track usage for these specific apps
+  const { app, targets: queries } = request;
+
   if (app === CoreApp.Dashboard || app === CoreApp.PanelViewer) {
     return;
+  }
+
+  let totalBytes = 0;
+  for (const frame of response.data as DataFrame[]) {
+    const byteKey = frame.meta?.custom?.lokiQueryStatKey;
+    if (byteKey) {
+      totalBytes += frame.meta?.stats?.find((stat) => stat.displayName === byteKey)?.value ?? 0;
+    }
   }
 
   for (const query of queries) {
     if (shouldNotReportBasedOnRefId(query.refId)) {
       return;
     }
+
     reportInteraction('grafana_loki_query_executed', {
       app,
+      grafana_version: config.buildInfo.version,
       editor_mode: query.editorMode,
       has_data: response.data.some((frame) => frame.length > 0),
       has_error: response.error !== undefined,
@@ -154,6 +170,10 @@ export function trackQuery(response: DataQueryResponse, queries: LokiQuery[], ap
       query_vector_type: query.queryType,
       resolution: query.resolution,
       simultaneously_sent_query_count: queries.length,
+      time_range_from: request?.range?.from?.toISOString(),
+      time_range_to: request?.range?.to?.toISOString(),
+      time_taken: Date.now() - startTime.getTime(),
+      bytes_processed: totalBytes,
     });
   }
 }


### PR DESCRIPTION
**What is this feature?**

This PR adds more items to track in queries executed.

ElasticSearch:
- grafana_version

Loki:
- grafana_version
- time_range_from
- time_range_to
- time_taken
- bytes_processed
