### PR TITLE
[DOC] Add link to access policies

### DIFF
--- a/docs/sources/administration/_index.md
+++ b/docs/sources/administration/_index.md
@@ -9,3 +9,5 @@ weight: 40
 This section includes information for Grafana administrators, team administrators, and users performing administrative tasks:
 
 {{< section >}}
+
+For information about authorization and authentication for your Grafana Cloud Stack and Grafana Cloud Portal, see the [Grafana Cloud Access Policies documentation](https://grafana.com/docs/grafana-cloud/authentication-and-permissions/access-policies/).

--- a/docs/sources/administration/_index.md
+++ b/docs/sources/administration/_index.md
@@ -10,4 +10,4 @@ This section includes information for Grafana administrators, team administrator
 
 {{< section >}}
 
-For information about authorization and authentication for your Grafana Cloud Stack and Grafana Cloud Portal, see the [Grafana Cloud Access Policies documentation](https://grafana.com/docs/grafana-cloud/authentication-and-permissions/access-policies/).
+For information about authorization and authentication for your Grafana Cloud Stack and Grafana Cloud Portal, refer to [Grafana Cloud Access Policies](https://grafana.com/docs/grafana-cloud/authentication-and-permissions/access-policies/).


### PR DESCRIPTION
Added a link to Grafana Cloud Access Policies at the bottom of the Administration page. 