### PR TITLE
Chore: make Logger interface be closed to itself

### DIFF
--- a/pkg/infra/log/interface.go
+++ b/pkg/infra/log/interface.go
@@ -14,7 +14,7 @@ const (
 
 type Logger interface {
 	// New returns a new contextual Logger that has this logger's context plus the given context.
-	New(ctx ...interface{}) *ConcreteLogger
+	New(ctx ...interface{}) Logger
 
 	Log(keyvals ...interface{}) error
 

--- a/pkg/infra/log/log.go
+++ b/pkg/infra/log/log.go
@@ -208,7 +208,7 @@ func (cl *ConcreteLogger) FromContext(ctx context.Context) Logger {
 	return cl
 }
 
-func (cl *ConcreteLogger) New(ctx ...interface{}) *ConcreteLogger {
+func (cl *ConcreteLogger) New(ctx ...interface{}) Logger {
 	if len(ctx) == 0 {
 		root.New()
 	}

--- a/pkg/infra/log/logtest/fake.go
+++ b/pkg/infra/log/logtest/fake.go
@@ -19,8 +19,8 @@ type Logs struct {
 	Ctx     []interface{}
 }
 
-func (f *Fake) New(ctx ...interface{}) *log.ConcreteLogger {
-	return log.NewNopLogger()
+func (f *Fake) New(ctx ...interface{}) log.Logger {
+	return f
 }
 
 func (f *Fake) Log(keyvals ...interface{}) error {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Currently, the Logger interface exposes ConcreteLogger via the method New. This PR changes the result of the method New to return Logger itself. 

**Why do we need this feature?**
This makes abstract interface to not expose details of implementations which makes it simpler to reuse 


