### PR TITLE
TablePanel: Improve and align table styles with the rest of Grafana

### DIFF
--- a/packages/grafana-ui/src/components/Table/FooterRow.tsx
+++ b/packages/grafana-ui/src/components/Table/FooterRow.tsx
@@ -14,11 +14,10 @@ export interface FooterRowProps {
   footerGroups: HeaderGroup[];
   footerValues: FooterItem[];
   isPaginationVisible: boolean;
-  height: number;
 }
 
 export const FooterRow = (props: FooterRowProps) => {
-  const { totalColumnsWidth, footerGroups, height, isPaginationVisible } = props;
+  const { totalColumnsWidth, footerGroups, isPaginationVisible } = props;
   const e2eSelectorsTable = selectors.components.Panels.Visualization.Table;
   const tableStyles = useStyles2(getTableStyles);
 
@@ -33,14 +32,8 @@ export const FooterRow = (props: FooterRowProps) => {
       {footerGroups.map((footerGroup: HeaderGroup) => {
         const { key, ...footerGroupProps } = footerGroup.getFooterGroupProps();
         return (
-          <div
-            className={tableStyles.tfoot}
-            {...footerGroupProps}
-            key={key}
-            data-testid={e2eSelectorsTable.footer}
-            style={height ? { height: `${height}px` } : undefined}
-          >
-            {footerGroup.headers.map((column: ColumnInstance) => renderFooterCell(column, tableStyles, height))}
+          <div className={tableStyles.tfoot} {...footerGroupProps} key={key} data-testid={e2eSelectorsTable.footer}>
+            {footerGroup.headers.map((column: ColumnInstance) => renderFooterCell(column, tableStyles))}
           </div>
         );
       })}
@@ -48,7 +41,7 @@ export const FooterRow = (props: FooterRowProps) => {
   );
 };
 
-function renderFooterCell(column: ColumnInstance, tableStyles: TableStyles, height?: number) {
+function renderFooterCell(column: ColumnInstance, tableStyles: TableStyles) {
   const footerProps = column.getHeaderProps();
 
   if (!footerProps) {
@@ -58,9 +51,6 @@ function renderFooterCell(column: ColumnInstance, tableStyles: TableStyles, heig
   footerProps.style = footerProps.style ?? {};
   footerProps.style.position = 'absolute';
   footerProps.style.justifyContent = (column as any).justifyContent;
-  if (height) {
-    footerProps.style.height = height;
-  }
 
   return (
     <div className={tableStyles.headerCell} {...footerProps}>

--- a/packages/grafana-ui/src/components/Table/HeaderRow.tsx
+++ b/packages/grafana-ui/src/components/Table/HeaderRow.tsx
@@ -21,7 +21,7 @@ export const HeaderRow = (props: HeaderRowProps) => {
   const tableStyles = useStyles2(getTableStyles);
 
   return (
-    <div role="rowgroup">
+    <div role="rowgroup" className={tableStyles.headerRow}>
       {headerGroups.map((headerGroup: HeaderGroup) => {
         const { key, ...headerGroupProps } = headerGroup.getHeaderGroupProps();
         return (
@@ -62,9 +62,12 @@ function renderHeaderCell(column: any, tableStyles: TableStyles, showTypeIcons?:
               <Icon name={getFieldTypeIcon(field)} title={field?.type} size="sm" className={tableStyles.typeIcon} />
             )}
             <div>{column.render('Header')}</div>
-            <div>
-              {column.isSorted && (column.isSortedDesc ? <Icon name="arrow-down" /> : <Icon name="arrow-up" />)}
-            </div>
+            {column.isSorted &&
+              (column.isSortedDesc ? (
+                <Icon size="lg" name="arrow-down" className={tableStyles.sortIcon} />
+              ) : (
+                <Icon name="arrow-up" size="lg" className={tableStyles.sortIcon} />
+              ))}
           </button>
           {column.canFilter && <Filter column={column} tableStyles={tableStyles} field={field} />}
         </>

--- a/packages/grafana-ui/src/components/Table/Table.tsx
+++ b/packages/grafana-ui/src/components/Table/Table.tsx
@@ -156,7 +156,7 @@ export const Table = memo((props: Props) => {
   const prevExpandedIndexes = usePrevious(expandedIndexes);
 
   const footerHeight = useMemo(() => {
-    const EXTENDED_ROW_HEIGHT = 33;
+    const EXTENDED_ROW_HEIGHT = headerHeight;
     let length = 0;
 
     if (!footerItems) {
@@ -174,7 +174,7 @@ export const Table = memo((props: Props) => {
     }
 
     return EXTENDED_ROW_HEIGHT;
-  }, [footerItems]);
+  }, [footerItems, headerHeight]);
 
   // React table data array. This data acts just like a dummy array to let react-table know how many rows exist
   // The cells use the field to look up values
@@ -475,7 +475,6 @@ export const Table = memo((props: Props) => {
           )}
           {footerItems && (
             <FooterRow
-              height={footerHeight}
               isPaginationVisible={Boolean(enablePagination)}
               footerValues={footerItems}
               footerGroups={footerGroups}

--- a/packages/grafana-ui/src/components/Table/Table.tsx
+++ b/packages/grafana-ui/src/components/Table/Table.tsx
@@ -150,7 +150,7 @@ export const Table = memo((props: Props) => {
   const variableSizeListScrollbarRef = useRef<HTMLDivElement>(null);
   const tableStyles = useStyles2(getTableStyles);
   const theme = useTheme2();
-  const headerHeight = noHeader ? 0 : tableStyles.cellHeight;
+  const headerHeight = noHeader ? 0 : tableStyles.rowHeight;
   const [footerItems, setFooterItems] = useState<FooterItem[] | undefined>(footerValues);
   const [expandedIndexes, setExpandedIndexes] = useState<Set<number>>(new Set());
   const prevExpandedIndexes = usePrevious(expandedIndexes);
@@ -288,7 +288,9 @@ export const Table = memo((props: Props) => {
   if (enablePagination) {
     listHeight -= tableStyles.cellHeight;
   }
-  const pageSize = Math.round(listHeight / tableStyles.cellHeight) - 1;
+
+  const pageSize = Math.round(listHeight / tableStyles.rowHeight) - 1;
+
   useEffect(() => {
     // Don't update the page size if it is less than 1
     if (pageSize <= 0) {

--- a/packages/grafana-ui/src/components/Table/styles.ts
+++ b/packages/grafana-ui/src/components/Table/styles.ts
@@ -3,8 +3,7 @@ import { css, CSSObject } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
 
 export const getTableStyles = (theme: GrafanaTheme2) => {
-  const { colors } = theme;
-  const headerBg = theme.colors.background.secondary;
+  const footerBg = theme.colors.background.secondary;
   const borderColor = theme.colors.border.weak;
   const resizerColor = theme.colors.primary.border;
   const cellPadding = 6;
@@ -107,10 +106,9 @@ export const getTableStyles = (theme: GrafanaTheme2) => {
     `,
     thead: css`
       label: thead;
-      height: ${cellHeight}px;
+      height: ${rowHeight}px;
       overflow-y: auto;
       overflow-x: hidden;
-      background: ${headerBg};
       position: relative;
     `,
     tfoot: css`
@@ -118,15 +116,17 @@ export const getTableStyles = (theme: GrafanaTheme2) => {
       height: ${cellHeight}px;
       overflow-y: auto;
       overflow-x: hidden;
-      background: ${headerBg};
+      background: ${footerBg};
       position: relative;
+    `,
+    headerRow: css`
+      label: row;
+      border-bottom: 1px solid ${borderColor};
     `,
     headerCell: css`
       padding: ${cellPadding}px;
       overflow: hidden;
       white-space: nowrap;
-      color: ${colors.primary.text};
-      border-right: 1px solid ${theme.colors.border.weak};
       display: flex;
 
       &:last-child {
@@ -141,8 +141,15 @@ export const getTableStyles = (theme: GrafanaTheme2) => {
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
+      font-weight: ${theme.typography.fontWeightMedium};
       display: flex;
+      align-items: center;
       margin-right: ${theme.spacing(0.5)};
+
+      &:hover {
+        text-decoration: underline;
+        color: ${theme.colors.text.link};
+      }
     `,
     cellContainer: buildCellContainerStyle(undefined, undefined, true),
     cellContainerNoOverflow: buildCellContainerStyle(undefined, undefined, false),
@@ -151,6 +158,9 @@ export const getTableStyles = (theme: GrafanaTheme2) => {
       text-overflow: ellipsis;
       user-select: text;
       white-space: nowrap;
+    `,
+    sortIcon: css`
+      margin-left: ${theme.spacing(0.5)};
     `,
     cellLink: css`
       cursor: pointer;
@@ -173,12 +183,10 @@ export const getTableStyles = (theme: GrafanaTheme2) => {
     `,
     paginationWrapper: css`
       display: flex;
-      background: ${headerBg};
       height: ${cellHeight}px;
       justify-content: center;
       align-items: center;
       width: 100%;
-      border-top: 1px solid ${theme.colors.border.weak};
       li {
         margin-bottom: 0;
       }

--- a/packages/grafana-ui/src/components/Table/styles.ts
+++ b/packages/grafana-ui/src/components/Table/styles.ts
@@ -3,7 +3,6 @@ import { css, CSSObject } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
 
 export const getTableStyles = (theme: GrafanaTheme2) => {
-  const footerBg = theme.colors.background.secondary;
   const borderColor = theme.colors.border.weak;
   const resizerColor = theme.colors.primary.border;
   const cellPadding = 6;
@@ -113,10 +112,10 @@ export const getTableStyles = (theme: GrafanaTheme2) => {
     `,
     tfoot: css`
       label: tfoot;
-      height: ${cellHeight}px;
+      height: ${rowHeight}px;
+      border-top: 1px solid ${borderColor};
       overflow-y: auto;
       overflow-x: hidden;
-      background: ${footerBg};
       position: relative;
     `,
     headerRow: css`
@@ -128,6 +127,7 @@ export const getTableStyles = (theme: GrafanaTheme2) => {
       overflow: hidden;
       white-space: nowrap;
       display: flex;
+      font-weight: ${theme.typography.fontWeightMedium};
 
       &:last-child {
         border-right: none;

--- a/public/app/plugins/panel/table/module.tsx
+++ b/public/app/plugins/panel/table/module.tsx
@@ -20,7 +20,6 @@ const footerCategory = 'Table footer';
 export const plugin = new PanelPlugin<PanelOptions, TableFieldOptions>(TablePanel)
   .setPanelChangeHandler(tablePanelChangedHandler)
   .setMigrationHandler(tableMigrationHandler)
-  .setNoPadding()
   .useFieldConfig({
     useCustomConfig: (builder) => {
       builder


### PR DESCRIPTION
The current table header styles have many issues

* Inconsistent with the other tables we have in admin and setting sections 
* On the light theme the header and footer are the same as the canvas color which makes them blend in and not be as clear. (footer as similar issues, and missing font-weight) 
* The use of blue text in the header is better reserved for page links that go to other views

PR

* New styles that align the header with other parts of Grafana
* New hover styles for header "buttons" (text underline + blue) 
* New pagination styles (removed background)
* Remove the no padding to make the panel more like other panels that have content padding (this is needed for the change to new left-aligned panel titles as well, to make things align better).  
* Make the sort icon a tiny bit bigger and centered 
* Fixes scrollbar showing when pagination is enabled (bug in 9.2), due to wrong row height used to calculate available list space 
* Also fixes footer styles (See commend below for details), the footer styles were a bit broken, and missing font-weight. Incorrect row height and cell heights (and manual passing of height which was not needed)

Before:
![Screenshot from 2022-12-14 21-16-24](https://user-images.githubusercontent.com/10999/207787513-165b219e-7b15-44ea-a585-1e1814e3b7ae.png)
![Screenshot from 2022-12-14 21-16-37](https://user-images.githubusercontent.com/10999/207787533-78a45d30-c45a-4b63-87fb-64ca071f12d1.png)

After:
![Screenshot from 2022-12-14 21-14-30](https://user-images.githubusercontent.com/10999/207787598-18362881-66bd-4e8d-b54c-7420e859b846.png)

![Screenshot from 2022-12-14 21-14-06](https://user-images.githubusercontent.com/10999/207787626-01197774-2e5f-4d3e-85dc-8290e560e38b.png)



