### PR TITLE
Breadcrumbs: Make breadcrumbs font weight medium (proposal)

### DIFF
--- a/public/app/core/components/Breadcrumbs/BreadcrumbItem.tsx
+++ b/public/app/core/components/Breadcrumbs/BreadcrumbItem.tsx
@@ -43,6 +43,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       textOverflow: 'ellipsis',
       overflow: 'hidden',
       padding: theme.spacing(0, 0.5),
+      fontWeight: theme.typography.fontWeightMedium,
       whiteSpace: 'nowrap',
       color: theme.colors.text.secondary,
     }),


### PR DESCRIPTION
Just a proposal to align the breadcrumbs with text in ToolbarButtons and the MegaMenu who all use medium bold 

On linux and windows fonts are rendered with a lot finer weight by default than on osx making inter very thin, which might mean I see this as a bit more noticeable than osx users. Inter default font weight is also very thin 

Current: 
![Screenshot from 2022-12-15 08-52-45](https://user-images.githubusercontent.com/10999/207803746-2a60ac97-0a08-4eb9-a8e3-7e0ccb8ff908.png)
![Screenshot from 2022-12-15 08-52-32](https://user-images.githubusercontent.com/10999/207804788-3d34bcb4-ae97-4d22-a654-309ccc16e097.png)

Next to mega menu links:
![Screenshot from 2022-12-15 08-52-45](https://user-images.githubusercontent.com/10999/207803814-2fd9955c-a159-48ef-ad59-2b7d4ae61315.png)

With medium bold:
![Screenshot from 2022-12-15 08-56-48](https://user-images.githubusercontent.com/10999/207804130-604083fb-ce6b-4209-83dc-77a8c710a4b7.png)
![Screenshot from 2022-12-15 08-56-56](https://user-images.githubusercontent.com/10999/207804142-7ee0b647-f8da-4f99-8e38-710bf79d16b8.png)

Not part of PR but another style tweak we could try is adding blue link color on hover (together with underline) 
![Screenshot from 2022-12-15 08-50-31](https://user-images.githubusercontent.com/10999/207804237-2ad447ae-80fa-4f36-ac2b-84eaa771f5f9.png)
![Screenshot from 2022-12-15 08-50-27](https://user-images.githubusercontent.com/10999/207804243-930bbc9d-cc80-486d-bbe4-d182652bfdbf.png)

