### PR TITLE
Connections: Render a landing page for pages without actual content

### DIFF
--- a/public/app/features/connections/Connections.test.tsx
+++ b/public/app/features/connections/Connections.test.tsx
@@ -41,14 +41,21 @@ describe('Connections', () => {
     (contextSrv.hasPermission as jest.Mock) = jest.fn().mockReturnValue(true);
   });
 
-  test('shows the "Data sources" page by default', async () => {
+  test('shows a landing page by default', async () => {
     renderPage();
 
-    expect(await screen.findByText('Datasources')).toBeVisible();
+    expect(await screen.findByRole('link', { name: 'Your connections' })).toBeVisible();
+    expect(await screen.findByText('Manage your existing connections')).toBeVisible();
+
+    expect(await screen.findByRole('link', { name: 'Connect data' })).toBeVisible();
+    expect(await screen.findByText('Browse and create new connections')).toBeVisible();
+  });
+
+  test('shows a landing page for Your connections', async () => {
+    renderPage(ROUTES.YourConnections);
+
+    expect(await screen.findByRole('link', { name: 'Datasources' })).toBeVisible();
     expect(await screen.findByText('Manage your existing datasource connections')).toBeVisible();
-    expect(await screen.findByText('Sort by A–Z')).toBeVisible();
-    expect(await screen.findByRole('link', { name: /add new data source/i })).toBeVisible();
-    expect(await screen.findByText(mockDatasources[0].name)).toBeVisible();
   });
 
   test('renders the correct tab even if accessing it with a "sub-url"', async () => {

--- a/public/app/features/connections/Connections.tsx
+++ b/public/app/features/connections/Connections.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Route, Switch } from 'react-router-dom';
 
+import { NavLandingPage } from 'app/core/components/AppChrome/NavLandingPage';
 import { DataSourcesRoutesContext } from 'app/features/datasources/state';
 import { StoreState, useSelector } from 'app/types';
 
@@ -27,8 +28,12 @@ export default function Connections() {
       }}
     >
       <Switch>
-        <Route exact path={ROUTES.Base} component={DataSourcesListPage} />
-        <Route exact path={ROUTES.YourConnections} component={DataSourcesListPage} />
+        <Route exact path={ROUTES.Base} component={() => <NavLandingPage navId="connections" />} />
+        <Route
+          exact
+          path={ROUTES.YourConnections}
+          component={() => <NavLandingPage navId="connections-your-connections" />}
+        />
         <Route exact path={ROUTES.DataSources} component={DataSourcesListPage} />
         <Route exact path={ROUTES.DataSourcesDetails} component={DataSourceDetailsPage} />
         <Route exact path={ROUTES.DataSourcesNew} component={NewDataSourcePage} />


### PR DESCRIPTION


<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Currently, the "Connections" and the "Your connections" pages both render the "Data sources" page, which can be misleading and it is inconsistent with the rest of Grafana.
Grafana renders cards for each child for this kind of pages (e.g. Alerts & incidents), so let's do the same for our pages.

![Screenshot from 2022-12-15 09-40-48](https://user-images.githubusercontent.com/13637610/207813160-ad0192b3-e1a0-4ba7-802a-8da9ac8810be.png)
![Screenshot from 2022-12-15 09-40-42](https://user-images.githubusercontent.com/13637610/207813166-e7a50ad4-9b71-4a54-88ec-33c69b10b18d.png)


**Which issue(s) does this PR fix?**:

Fixes #60367 

