### PR TITLE
Cloudwatch: Improve log group selector styling 

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/components/CrossAccountLogsQueryField.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/CrossAccountLogsQueryField.tsx
@@ -102,7 +102,7 @@ export const CrossAccountLogsQueryField = (props: CrossAccountLogsQueryProps) =>
             accountId={searchAccountId}
           />
         </div>
-        <Space layout="block" v={1.5} />
+        <Space layout="block" v={2} />
         <div>
           <div className={styles.tableScroller}>
             <table className={styles.table}>
@@ -150,6 +150,7 @@ export const CrossAccountLogsQueryField = (props: CrossAccountLogsQueryProps) =>
             </table>
           </div>
         </div>
+        <Space layout="block" v={2} />
         <div>
           <Button onClick={handleApply} type="button" className={styles.addBtn}>
             Add log groups

--- a/public/app/plugins/datasource/cloudwatch/components/CrossAccountLogsQueryField.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/CrossAccountLogsQueryField.tsx
@@ -155,7 +155,7 @@ export const CrossAccountLogsQueryField = (props: CrossAccountLogsQueryProps) =>
           <Button onClick={handleApply} type="button" className={styles.addBtn}>
             Add log groups
           </Button>
-          <Button onClick={handleCancel} type="button">
+          <Button onClick={handleCancel} variant="secondary" type="button">
             Cancel
           </Button>
         </div>

--- a/public/app/plugins/datasource/cloudwatch/components/CrossAccountLogsQueryField.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/CrossAccountLogsQueryField.tsx
@@ -81,7 +81,7 @@ export const CrossAccountLogsQueryField = (props: CrossAccountLogsQueryProps) =>
 
   return (
     <>
-      <Modal className={styles.modal} title="Select Log Groups" isOpen={isModalOpen} onDismiss={toggleModal}>
+      <Modal className={styles.modal} title="Select Log Groups" isOpen={true} onDismiss={toggleModal}>
         <div className={styles.logGroupSelectionArea}>
           <EditorField label="Log Group Name">
             <Search
@@ -92,6 +92,7 @@ export const CrossAccountLogsQueryField = (props: CrossAccountLogsQueryProps) =>
               searchPhrase={searchPhrase}
             />
           </EditorField>
+
           <Account
             onChange={(accountId?: string) => {
               searchFn(searchPhrase, accountId);
@@ -129,14 +130,17 @@ export const CrossAccountLogsQueryField = (props: CrossAccountLogsQueryProps) =>
                   selectableLogGroups.map((row) => (
                     <tr className={styles.row} key={`${row.value}`}>
                       <td className={styles.cell}>
-                        <Checkbox
-                          id={row.value}
-                          onChange={(ev) => handleSelectCheckbox(row, ev.currentTarget.checked)}
-                          value={!!(row.value && selectedLogGroups.some((lg) => lg.value === row.value))}
-                        />
-                        <label className={styles.logGroupSearchResults} htmlFor={row.value}>
-                          {row.label}
-                        </label>
+                        <div className={styles.nestedEntry}>
+                          <Checkbox
+                            id={row.value}
+                            onChange={(ev) => handleSelectCheckbox(row, ev.currentTarget.checked)}
+                            value={!!(row.value && selectedLogGroups.some((lg) => lg.value === row.value))}
+                          />
+                          <Space layout="inline" h={2} />
+                          <label className={styles.logGroupSearchResults} htmlFor={row.value}>
+                            {row.label}
+                          </label>
+                        </div>
                       </td>
                       <td className={styles.cell}>{accountNameById[row.text]}</td>
                       <td className={styles.cell}>{row.text}</td>

--- a/public/app/plugins/datasource/cloudwatch/components/CrossAccountLogsQueryField.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/CrossAccountLogsQueryField.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useState } from 'react';
 
 import { SelectableValue } from '@grafana/data';
-import { EditorField } from '@grafana/experimental';
+import { EditorField, Space } from '@grafana/experimental';
 import { Button, Checkbox, IconButton, LoadingPlaceholder, Modal, useStyles2 } from '@grafana/ui';
 
 import Search from '../Search';
@@ -101,6 +101,7 @@ export const CrossAccountLogsQueryField = (props: CrossAccountLogsQueryProps) =>
             accountId={searchAccountId}
           />
         </div>
+        <Space layout="block" v={1.5} />
         <div>
           <div className={styles.tableScroller}>
             <table className={styles.table}>

--- a/public/app/plugins/datasource/cloudwatch/components/CrossAccountLogsQueryField.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/CrossAccountLogsQueryField.tsx
@@ -81,7 +81,7 @@ export const CrossAccountLogsQueryField = (props: CrossAccountLogsQueryProps) =>
 
   return (
     <>
-      <Modal className={styles.modal} title="Select Log Groups" isOpen={true} onDismiss={toggleModal}>
+      <Modal className={styles.modal} title="Select Log Groups" isOpen={isModalOpen} onDismiss={toggleModal}>
         <div className={styles.logGroupSelectionArea}>
           <EditorField label="Log Group Name">
             <Search

--- a/public/app/plugins/datasource/cloudwatch/components/CrossAccountLogsQueryField.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/CrossAccountLogsQueryField.tsx
@@ -167,7 +167,7 @@ export const CrossAccountLogsQueryField = (props: CrossAccountLogsQueryProps) =>
         </Button>
       </div>
 
-      <div>
+      <div className={styles.selectedLogGroupsContainer}>
         {props.selectedLogGroups.map((lg) => (
           <div key={lg.value} className={styles.selectedLogGroup}>
             {lg.label}

--- a/public/app/plugins/datasource/cloudwatch/components/styles.ts
+++ b/public/app/plugins/datasource/cloudwatch/components/styles.ts
@@ -8,6 +8,12 @@ const getStyles = (theme: GrafanaTheme2) => ({
     tableLayout: 'fixed',
   }),
 
+  selectedLogGroupsContainer: css({
+    marginLeft: theme.spacing(0.5),
+    display: 'flex',
+    flexFlow: 'wrap',
+  }),
+
   tableScroller: css({
     maxHeight: '50vh',
     overflow: 'auto',
@@ -63,8 +69,8 @@ const getStyles = (theme: GrafanaTheme2) => ({
   selectedLogGroup: css({
     background: theme.colors.background.secondary,
     borderRadius: theme.shape.borderRadius(),
-    margin: theme.spacing(0.25, 1, 0.25, 0),
-    padding: theme.spacing(0.25, 0, 0.25, 1),
+    margin: theme.spacing(0, 1, 1, 0),
+    padding: theme.spacing(0.5, 0, 0.5, 1),
     color: theme.colors.text.primary,
     fontSize: theme.typography.size.sm,
   }),
@@ -75,6 +81,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
 
   removeButton: css({
     verticalAlign: 'middle',
+    marginLeft: theme.spacing(0.5),
   }),
 
   addBtn: css({

--- a/public/app/plugins/datasource/cloudwatch/components/styles.ts
+++ b/public/app/plugins/datasource/cloudwatch/components/styles.ts
@@ -30,6 +30,11 @@ const getStyles = (theme: GrafanaTheme2) => ({
     },
   }),
 
+  nestedEntry: css({
+    display: 'flex',
+    alignItems: 'center',
+  }),
+
   logGroupSearchResults: css({
     overflow: 'hidden',
     textOverflow: 'ellipsis',


### PR DESCRIPTION
**What is this feature?**

This PR fixes a few styling glitches in the log groups selector that is currently used in CloudWatch logs cross-account querying editor. Except for the problems reported in [this](https://github.com/grafana/cloud-data-sources/issues/89) issue, it also switches the `Cancel` button from being primary to secondary.

After changes in this PR:

![Screenshot from 2022-12-15 10-08-39](https://user-images.githubusercontent.com/2388950/207818855-15a231dd-b065-41bb-a2ec-c78ea9b81ca8.png)

![Screenshot from 2022-12-15 10-08-56](https://user-images.githubusercontent.com/2388950/207818851-7cb8c6c0-1a2a-4794-8499-b6b12b658fbf.png)


Fixes #https://github.com/grafana/cloud-data-sources/issues/89

