### PR TITLE
Search: Fix report search usage from throwing in console

### DIFF
--- a/public/app/features/search/state/SearchStateManager.ts
+++ b/public/app/features/search/state/SearchStateManager.ts
@@ -239,7 +239,7 @@ export class SearchStateManager extends StateManagerBase<SearchState> {
   /**
    * Caller should handle debounce
    */
-  onReportSearchUsage() {
+  onReportSearchUsage = () => {
     reportDashboardListViewed(this.state.eventTrackingNamespace, {
       layout: this.state.layout,
       starred: this.state.starred,
@@ -248,7 +248,7 @@ export class SearchStateManager extends StateManagerBase<SearchState> {
       tagCount: this.state.tag?.length,
       includePanels: this.state.includePanels,
     });
-  }
+  };
 }
 
 let stateManager: SearchStateManager;


### PR DESCRIPTION
Fixes #60377

Class method being passed into useDebounced is called with wrong/missing `this`, so `this.state` was not availabe inside it.