### PR TITLE
Move preprocessor handling to the backend

### DIFF
--- a/pkg/tsdb/cloudmonitoring/time_series_filter_test.go
+++ b/pkg/tsdb/cloudmonitoring/time_series_filter_test.go
@@ -18,6 +18,42 @@ import (
 )
 
 func TestTimeSeriesFilter(t *testing.T) {
+	t.Run("parses params", func(t *testing.T) {
+		query := &cloudMonitoringTimeSeriesList{parameters: &timeSeriesList{}}
+		query.setParams(time.Time{}, time.Time{}, 0, 0)
+
+		assert.Equal(t, "0001-01-01T00:00:00Z", query.params.Get("interval.startTime"))
+		assert.Equal(t, "0001-01-01T00:00:00Z", query.params.Get("interval.endTime"))
+		assert.Equal(t, "", query.params.Get("filter"))
+		assert.Equal(t, "", query.params.Get("view"))
+		assert.Equal(t, "+60s", query.params.Get("aggregation.alignmentPeriod"))
+		assert.Equal(t, "REDUCE_NONE", query.params.Get("aggregation.crossSeriesReducer"))
+		assert.Equal(t, "ALIGN_MEAN", query.params.Get("aggregation.perSeriesAligner"))
+		assert.Equal(t, "", query.params.Get("aggregation.groupByFields"))
+		assert.Equal(t, "", query.params.Get("secondaryAggregation.alignmentPeriod"))
+		assert.Equal(t, "", query.params.Get("secondaryAggregation.crossSeriesReducer"))
+		assert.Equal(t, "", query.params.Get("secondaryAggregation.perSeriesAligner"))
+		assert.Equal(t, "", query.params.Get("secondaryAggregation.groupByFields"))
+	})
+
+	t.Run("parses params with preprocessor", func(t *testing.T) {
+		query := &cloudMonitoringTimeSeriesList{parameters: &timeSeriesList{Preprocessor: "rate"}}
+		query.setParams(time.Time{}, time.Time{}, 0, 0)
+
+		assert.Equal(t, "0001-01-01T00:00:00Z", query.params.Get("interval.startTime"))
+		assert.Equal(t, "0001-01-01T00:00:00Z", query.params.Get("interval.endTime"))
+		assert.Equal(t, "", query.params.Get("filter"))
+		assert.Equal(t, "", query.params.Get("view"))
+		assert.Equal(t, "+60s", query.params.Get("aggregation.alignmentPeriod"))
+		assert.Equal(t, "REDUCE_NONE", query.params.Get("aggregation.crossSeriesReducer"))
+		assert.Equal(t, "ALIGN_RATE", query.params.Get("aggregation.perSeriesAligner"))
+		assert.Equal(t, "", query.params.Get("aggregation.groupByFields"))
+		assert.Equal(t, "", query.params.Get("secondaryAggregation.alignmentPeriod"))
+		assert.Equal(t, "REDUCE_NONE", query.params.Get("secondaryAggregation.crossSeriesReducer"))
+		assert.Equal(t, "ALIGN_MEAN", query.params.Get("secondaryAggregation.perSeriesAligner"))
+		assert.Equal(t, "", query.params.Get("secondaryAggregation.groupByFields"))
+	})
+
 	t.Run("when data from query aggregated to one time series", func(t *testing.T) {
 		data, err := loadTestFile("./test-data/1-series-response-agg-one-metric.json")
 		require.NoError(t, err)

--- a/pkg/tsdb/cloudmonitoring/types.go
+++ b/pkg/tsdb/cloudmonitoring/types.go
@@ -50,6 +50,10 @@ type (
 		SecondaryCrossSeriesReducer string   `json:"secondaryCrossSeriesReducer"`
 		SecondaryPerSeriesAligner   string   `json:"secondaryPerSeriesAligner"`
 		SecondaryGroupBys           []string `json:"secondaryGroupBys"`
+		// Preprocessor is not part of the GCM API but added for simplicity
+		// It will overwrite AligmentPeriod, CrossSeriesReducer, PerSeriesAligner, GroupBys
+		// and its secondary counterparts
+		Preprocessor string `json:"preprocessor"`
 	}
 
 	// sloQuery is an internal convention but the API is the same as timeSeriesList


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

I am going back in my decission of not having `preprocessor` in the plugin API. This change made the frontend code too complicated:

 - Required the same "migration" code than the one already existing in the backend (the code that generates a crossSeriesReducer, perSeriesAligner, etc from a preprocessor).
 - It required some complicated handling in the UI, for example, the selector for "Alignment function" would require to show either the primary or the secondary aligner depending on the value of the preprocessor.

This way the plugin API does not exactly represent the GCM API but makes the frontend code significantly easier.