### PR TITLE
Chore: Remove unused config fields

### DIFF
--- a/pkg/build/config/config.go
+++ b/pkg/build/config/config.go
@@ -1,20 +1,18 @@
 package config
 
 type Config struct {
-	Version            string
-	Bucket             string
-	DebRepoBucket      string
-	DebDBBucket        string
-	RPMRepoBucket      string
-	GPGPassPath        string
-	GPGPrivateKey      string
-	GPGPublicKey       string
-	GCPKeyFile         string
-	NumWorkers         int
-	GitHubUser         string
-	GitHubToken        string
-	PullEnterprise     bool
-	NetworkConcurrency bool
-	PackageVersion     string
-	SignPackages       bool
+	Version        string
+	Bucket         string
+	DebRepoBucket  string
+	DebDBBucket    string
+	RPMRepoBucket  string
+	GPGPassPath    string
+	GPGPrivateKey  string
+	GPGPublicKey   string
+	NumWorkers     int
+	GitHubUser     string
+	GitHubToken    string
+	PullEnterprise bool
+	PackageVersion string
+	SignPackages   bool
 }


### PR DESCRIPTION
**What is this feature?**

Removes two unused fields from `pkg/build/config/config.go`