### PR TITLE
Accessibility: Render gauge as a button when onClick is provided

### DIFF
--- a/packages/grafana-ui/src/components/Gauge/Gauge.test.tsx
+++ b/packages/grafana-ui/src/components/Gauge/Gauge.test.tsx
@@ -1,4 +1,5 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import { ThresholdsMode, FieldConfig, FieldColorModeId, createTheme } from '@grafana/data';
@@ -40,5 +41,14 @@ const props: Props = {
 describe('Gauge', () => {
   it('should render without blowing up', () => {
     expect(() => render(<Gauge {...props} />)).not.toThrow();
+  });
+
+  it('should render as a button when an onClick is provided', async () => {
+    const mockOnClick = jest.fn();
+    render(<Gauge {...props} onClick={mockOnClick} />);
+    const gaugeButton = screen.getByRole('button');
+    expect(gaugeButton).toBeInTheDocument();
+    await userEvent.click(gaugeButton);
+    expect(mockOnClick).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/grafana-ui/src/components/Gauge/Gauge.tsx
+++ b/packages/grafana-ui/src/components/Gauge/Gauge.tsx
@@ -8,12 +8,12 @@ import {
   ThresholdsMode,
   GAUGE_DEFAULT_MAXIMUM,
   GAUGE_DEFAULT_MINIMUM,
-  GrafanaTheme,
   GrafanaTheme2,
 } from '@grafana/data';
 import { VizTextDisplayOptions } from '@grafana/schema';
 
 import { calculateFontSize } from '../../utils/measureText';
+import { clearButtonStyles } from '../Button';
 
 import { calculateGaugeAutoProps, DEFAULT_THRESHOLDS, getFormattedThresholds } from './utils';
 
@@ -27,7 +27,7 @@ export interface Props {
   text?: VizTextDisplayOptions;
   onClick?: React.MouseEventHandler<HTMLElement>;
   className?: string;
-  theme: GrafanaTheme | GrafanaTheme2;
+  theme: GrafanaTheme2;
 }
 
 export class Gauge extends PureComponent<Props> {
@@ -56,7 +56,7 @@ export class Gauge extends PureComponent<Props> {
 
     const autoProps = calculateGaugeAutoProps(width, height, value.title);
     const dimension = Math.min(width, autoProps.gaugeHeight);
-    const backgroundColor = 'v1' in theme ? theme.colors.background.secondary : theme.colors.bg2;
+    const backgroundColor = theme.colors.background.secondary;
     const gaugeWidthReduceRatio = showThresholdLabels ? 1.5 : 1;
     const gaugeWidth = Math.min(dimension / 5.5, 40) / gaugeWidthReduceRatio;
     const thresholdMarkersWidth = gaugeWidth / 5;
@@ -145,16 +145,24 @@ export class Gauge extends PureComponent<Props> {
   }
 
   renderVisualization = () => {
-    const { width, value, height, onClick, text } = this.props;
+    const { width, value, height, onClick, text, theme } = this.props;
     const autoProps = calculateGaugeAutoProps(width, height, value.title);
+    const gaugeElement = (
+      <div
+        style={{ height: `${autoProps.gaugeHeight}px`, width: '100%' }}
+        ref={(element) => (this.canvasElement = element)}
+      />
+    );
 
     return (
       <>
-        <div
-          style={{ height: `${autoProps.gaugeHeight}px`, width: '100%' }}
-          ref={(element) => (this.canvasElement = element)}
-          onClick={onClick}
-        />
+        {onClick ? (
+          <button className={clearButtonStyles(theme)} type="button" onClick={onClick}>
+            {gaugeElement}
+          </button>
+        ) : (
+          gaugeElement
+        )}
         {autoProps.showLabel && (
           <div
             style={{


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- wraps the gauge element in a button when an `onClick` is provided

**Why do we need this feature?**

- to ensure the data links menu is accessible to those not using a mouse

**Who is this feature for?**

- everyone!

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/59860

**Special notes for your reviewer**:

