### PR TITLE
Alerting: Add refactoring todo for getting rid of '+ Add new' option in drop-downs

### DIFF
--- a/public/app/features/alerting/unified/TODO.md
+++ b/public/app/features/alerting/unified/TODO.md
@@ -16,6 +16,8 @@ If the item needs more rationale and you feel like a single sentence is inedequa
 
 ## Refactoring
 
+- Get rid of "+ Add new" in drop-downs : Let's see if is there a way we can make it work with `<Select allowCustomValue />`
+
 ## Bug fixes
 
 _Preferably these should go to GitHub for discoverability, but not all bugs are equal, use your best judgment._


### PR DESCRIPTION
This PR adds a refactoring entry in alerting todo file, to get rid of the '+ Add new' option in drop-downs.

The idea came from this [comment](https://github.com/grafana/grafana/pull/60083#issuecomment-1351718205) in another PR.