### PR TITLE
Alerting: update Telegram notifier to fallback to default template if expanded message is empty

### DIFF
--- a/pkg/services/ngalert/notifier/channels/telegram_test.go
+++ b/pkg/services/ngalert/notifier/channels/telegram_test.go
@@ -111,6 +111,25 @@ func TestTelegramNotifier(t *testing.T) {
 				"parse_mode": "test"
 			}`,
 			expInitError: "unknown parse_mode, must be Markdown, MarkdownV2, HTML or None",
+		}, {
+			name: "Fallback to default template if custom results in empty string",
+			settings: `{
+				"bottoken": "abcdefgh0123456789",
+				"chatid": "someid",
+				"message": "{{ .CommonLabels.myLabel }}"
+			}`,
+			alerts: []*types.Alert{
+				{
+					Alert: model.Alert{
+						Labels: model.LabelSet{"alertname": "test"},
+					},
+				},
+			},
+			expMsg: map[string]string{
+				"parse_mode": "HTML",
+				"text":       "**Firing**\n\nValue: [no value]\nLabels:\n - alertname = test\nAnnotations:\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dtest\n",
+			},
+			expMsgError: nil,
 		},
 	}
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
This PR updates the Telegram notifier to fall back to the default message template if the user-provided one results in an empty string.

**Why do we need this feature?**
According to the [documentation](https://core.telegram.org/bots/api#sendmessage), Telegram sendMessage API does not accept empty string for field `text`. Therefore, if the message template for the Telegram notifier results in an empty string, which is possible, the API will reject such a request. That error will be visible in UI. However, the error can be intermittent because some alerts could be sent successfully while other - fail. 

Related to: https://github.com/grafana/grafana/issues/50249