### PR TITLE
Plugins: update defaultNavUrl when Connections is on

### DIFF
--- a/pkg/api/plugins.go
+++ b/pkg/api/plugins.go
@@ -147,7 +147,11 @@ func (hs *HTTPServer) GetPluginList(c *models.ReqContext) response.Response {
 		}
 
 		if listItem.DefaultNavUrl == "" || !listItem.Enabled {
-			listItem.DefaultNavUrl = hs.Cfg.AppSubURL + "/plugins/" + listItem.Id + "/"
+			if listItem.Type == "datasource" && hs.Features.IsEnabled(featuremgmt.FlagDataConnectionsConsole) {
+				listItem.DefaultNavUrl = hs.Cfg.AppSubURL + "/connections/connect-data/datasources/" + listItem.Id + "/"
+			} else {
+				listItem.DefaultNavUrl = hs.Cfg.AppSubURL + "/plugins/" + listItem.Id + "/"
+			}
 		}
 
 		result = append(result, listItem)

--- a/pkg/api/plugins.go
+++ b/pkg/api/plugins.go
@@ -147,11 +147,7 @@ func (hs *HTTPServer) GetPluginList(c *models.ReqContext) response.Response {
 		}
 
 		if listItem.DefaultNavUrl == "" || !listItem.Enabled {
-			if listItem.Type == "datasource" && hs.Features.IsEnabled(featuremgmt.FlagDataConnectionsConsole) {
-				listItem.DefaultNavUrl = hs.Cfg.AppSubURL + "/connections/connect-data/datasources/" + listItem.Id + "/"
-			} else {
-				listItem.DefaultNavUrl = hs.Cfg.AppSubURL + "/plugins/" + listItem.Id + "/"
-			}
+			listItem.DefaultNavUrl = GetDefaultNavUrl(listItem, hs.Features.IsEnabled(featuremgmt.FlagDataConnectionsConsole), hs.Cfg.AppSubURL)
 		}
 
 		result = append(result, listItem)

--- a/pkg/api/utils.go
+++ b/pkg/api/utils.go
@@ -3,6 +3,8 @@ package api
 import (
 	"encoding/json"
 	"net/mail"
+
+	"github.com/grafana/grafana/pkg/api/dtos"
 )
 
 func jsonMap(data []byte) (map[string]string, error) {
@@ -22,4 +24,12 @@ func ValidateAndNormalizeEmail(email string) (string, error) {
 	}
 
 	return e.Address, nil
+}
+
+func GetDefaultNavUrl(listItem dtos.PluginListItem, isDataConnectionsConsoleEnabled bool, appSubURL string) string {
+	if listItem.Type == "datasource" && isDataConnectionsConsoleEnabled {
+		return appSubURL + "/connections/connect-data/datasources/" + listItem.Id + "/"
+	} else {
+		return appSubURL + "/plugins/" + listItem.Id + "/"
+	}
 }


### PR DESCRIPTION
When the `dataConnectionsConsole` feature is turned on, then the primary url for data source plugins is under `/connections`. Since the cloud-onboarding plugin uses this `defaultNavUrl` field to link to the data source details page, we should update this field to make everything work correctly.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #57411

