### PR TITLE
Levitate: Fix typo in CI workflow scripts

### DIFF
--- a/.github/workflows/scripts/pr-get-job-link.js
+++ b/.github/workflows/scripts/pr-get-job-link.js
@@ -3,7 +3,7 @@ module.exports = async ({ name, github, context, core }) => {
     const { owner, repo } = context.repo;
     const url = `https://api.github.com/repos/${owner}/${repo}/actions/runs/${context.runId}/jobs`
     const result = await github.request(url);
-    const job = result.jobs.find(j => j.name === name);
+    const job = result.data.jobs.find(j => j.name === name);
     
     core.setOutput('link', `${job.html_url}?check_suite_focus=true`);
 }


### PR DESCRIPTION
[Slack discussion](https://raintank-corp.slack.com/archives/C024NL6AEJH/p1671184639480479)

### What changed?
@jackw spotted a lot of failing Levitate workflows due to a typo in how we access job results in one of our scripts.