### PR TITLE
ServiceAccount: Rewrite the api test to use fakes

### DIFF
--- a/pkg/services/accesscontrol/actest/fake.go
+++ b/pkg/services/accesscontrol/actest/fake.go
@@ -94,3 +94,36 @@ func (f FakeStore) GetUsersBasicRoles(ctx context.Context, userFilter []int64, o
 func (f FakeStore) DeleteUserPermissions(ctx context.Context, orgID, userID int64) error {
 	return f.ExpectedErr
 }
+
+var _ accesscontrol.PermissionsService = new(FakePermissionsService)
+
+type FakePermissionsService struct {
+	ExpectedErr          error
+	ExpectedPermission   *accesscontrol.ResourcePermission
+	ExpectedPermissions  []accesscontrol.ResourcePermission
+	ExpectedMappedAction string
+}
+
+func (f *FakePermissionsService) GetPermissions(ctx context.Context, user *user.SignedInUser, resourceID string) ([]accesscontrol.ResourcePermission, error) {
+	return f.ExpectedPermissions, f.ExpectedErr
+}
+
+func (f *FakePermissionsService) SetUserPermission(ctx context.Context, orgID int64, user accesscontrol.User, resourceID, permission string) (*accesscontrol.ResourcePermission, error) {
+	return f.ExpectedPermission, f.ExpectedErr
+}
+
+func (f *FakePermissionsService) SetTeamPermission(ctx context.Context, orgID, teamID int64, resourceID, permission string) (*accesscontrol.ResourcePermission, error) {
+	return f.ExpectedPermission, f.ExpectedErr
+}
+
+func (f *FakePermissionsService) SetBuiltInRolePermission(ctx context.Context, orgID int64, builtInRole string, resourceID string, permission string) (*accesscontrol.ResourcePermission, error) {
+	return f.ExpectedPermission, f.ExpectedErr
+}
+
+func (f *FakePermissionsService) SetPermissions(ctx context.Context, orgID int64, resourceID string, commands ...accesscontrol.SetResourcePermissionCommand) ([]accesscontrol.ResourcePermission, error) {
+	return f.ExpectedPermissions, f.ExpectedErr
+}
+
+func (f *FakePermissionsService) MapActions(permission accesscontrol.ResourcePermission) string {
+	return f.ExpectedMappedAction
+}

--- a/pkg/services/serviceaccounts/api/api_test.go
+++ b/pkg/services/serviceaccounts/api/api_test.go
@@ -376,6 +376,7 @@ var _ service = new(fakeService)
 type fakeService struct {
 	service
 	ExpectedErr                   error
+	ExpectedApiKey                *apikey.APIKey
 	ExpectedServiceAccountTokens  []apikey.APIKey
 	ExpectedServiceAccount        *serviceaccounts.ServiceAccountDTO
 	ExpectedServiceAccountProfile *serviceaccounts.ServiceAccountProfileDTO
@@ -399,4 +400,9 @@ func (f *fakeService) ListTokens(ctx context.Context, query *serviceaccounts.Get
 
 func (f *fakeService) UpdateServiceAccount(ctx context.Context, orgID, id int64, cmd *serviceaccounts.UpdateServiceAccountForm) (*serviceaccounts.ServiceAccountProfileDTO, error) {
 	return f.ExpectedServiceAccountProfile, f.ExpectedErr
+}
+
+func (f *fakeService) AddServiceAccountToken(ctx context.Context, id int64, cmd *serviceaccounts.AddServiceAccountTokenCommand) error {
+	cmd.Result = f.ExpectedApiKey
+	return f.ExpectedErr
 }

--- a/pkg/services/serviceaccounts/api/api_test.go
+++ b/pkg/services/serviceaccounts/api/api_test.go
@@ -87,9 +87,9 @@ func TestServiceAccountsAPI_CreateServiceAccount(t *testing.T) {
 			webtest.RequestWithSignedInUser(req, &user.SignedInUser{OrgRole: tt.basicRole, OrgID: 1, Permissions: map[int64]map[string][]string{1: accesscontrol.GroupScopesByAction(tt.permissions)}})
 			res, err := server.SendJSON(req)
 			require.NoError(t, err)
-			defer res.Body.Close()
 
 			assert.Equal(t, tt.expectedCode, res.StatusCode)
+			require.NoError(t, res.Body.Close())
 		})
 	}
 }
@@ -124,9 +124,9 @@ func TestServiceAccountsAPI_DeleteServiceAccount(t *testing.T) {
 			webtest.RequestWithSignedInUser(req, &user.SignedInUser{OrgID: 1, Permissions: map[int64]map[string][]string{1: accesscontrol.GroupScopesByAction(tt.permissions)}})
 			res, err := server.Send(req)
 			require.NoError(t, err)
-			defer res.Body.Close()
 
 			assert.Equal(t, tt.expectedCode, res.StatusCode)
+			require.NoError(t, res.Body.Close())
 		})
 	}
 }
@@ -137,7 +137,6 @@ func TestServiceAccountsAPI_RetrieveServiceAccount(t *testing.T) {
 		id           int64
 		permissions  []accesscontrol.Permission
 		expectedCode int
-		expectedErr  error
 		expectedSA   *serviceaccounts.ServiceAccountProfileDTO
 	}
 
@@ -166,9 +165,8 @@ func TestServiceAccountsAPI_RetrieveServiceAccount(t *testing.T) {
 			webtest.RequestWithSignedInUser(req, &user.SignedInUser{OrgID: 1, Permissions: map[int64]map[string][]string{1: accesscontrol.GroupScopesByAction(tt.permissions)}})
 			res, err := server.Send(req)
 			require.NoError(t, err)
-			defer res.Body.Close()
-
 			assert.Equal(t, tt.expectedCode, res.StatusCode)
+			require.NoError(t, res.Body.Close())
 		})
 	}
 }
@@ -230,9 +228,9 @@ func TestServiceAccountsAPI_UpdateServiceAccount(t *testing.T) {
 			webtest.RequestWithSignedInUser(req, &user.SignedInUser{OrgRole: tt.basicRole, OrgID: 1, Permissions: map[int64]map[string][]string{1: accesscontrol.GroupScopesByAction(tt.permissions)}})
 			res, err := server.SendJSON(req)
 			require.NoError(t, err)
-			defer res.Body.Close()
 
 			assert.Equal(t, tt.expectedCode, res.StatusCode)
+			require.NoError(t, res.Body.Close())
 		})
 	}
 }

--- a/pkg/services/serviceaccounts/api/api_test.go
+++ b/pkg/services/serviceaccounts/api/api_test.go
@@ -406,3 +406,7 @@ func (f *fakeService) AddServiceAccountToken(ctx context.Context, id int64, cmd 
 	cmd.Result = f.ExpectedApiKey
 	return f.ExpectedErr
 }
+
+func (f *fakeService) DeleteServiceAccountToken(ctx context.Context, orgID, id, tokenID int64) error {
+	return f.ExpectedErr
+}

--- a/pkg/services/serviceaccounts/api/token_test.go
+++ b/pkg/services/serviceaccounts/api/token_test.go
@@ -49,9 +49,9 @@ func TestServiceAccountsAPI_ListTokens(t *testing.T) {
 			webtest.RequestWithSignedInUser(req, &user.SignedInUser{OrgID: 1, Permissions: map[int64]map[string][]string{1: accesscontrol.GroupScopesByAction(tt.permissions)}})
 			res, err := server.Send(req)
 			require.NoError(t, err)
-			defer res.Body.Close()
 
 			assert.Equal(t, tt.expectedCode, res.StatusCode)
+			require.NoError(t, res.Body.Close())
 		})
 	}
 }
@@ -118,9 +118,9 @@ func TestServiceAccountsAPI_CreateToken(t *testing.T) {
 			webtest.RequestWithSignedInUser(req, &user.SignedInUser{OrgID: 1, Permissions: map[int64]map[string][]string{1: accesscontrol.GroupScopesByAction(tt.permissions)}})
 			res, err := server.SendJSON(req)
 			require.NoError(t, err)
-			defer res.Body.Close()
 
 			assert.Equal(t, tt.expectedCode, res.StatusCode)
+			require.NoError(t, res.Body.Close())
 		})
 	}
 }
@@ -170,9 +170,9 @@ func TestServiceAccountsAPI_DeleteToken(t *testing.T) {
 			webtest.RequestWithSignedInUser(req, &user.SignedInUser{OrgID: 1, Permissions: map[int64]map[string][]string{1: accesscontrol.GroupScopesByAction(tt.permissions)}})
 			res, err := server.SendJSON(req)
 			require.NoError(t, err)
-			defer res.Body.Close()
 
 			assert.Equal(t, tt.expectedCode, res.StatusCode)
+			require.NoError(t, res.Body.Close())
 		})
 	}
 }

--- a/pkg/services/serviceaccounts/api/token_test.go
+++ b/pkg/services/serviceaccounts/api/token_test.go
@@ -1,22 +1,20 @@
 package api
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/grafana/grafana/pkg/web/webtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/grafana/pkg/components/apikeygen"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/apikey"
 	"github.com/grafana/grafana/pkg/services/serviceaccounts"
 	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/grafana/grafana/pkg/web/webtest"
 )
 
 func TestServiceAccountsAPI_ListTokens(t *testing.T) {
@@ -178,26 +176,4 @@ func TestServiceAccountsAPI_DeleteToken(t *testing.T) {
 			assert.Equal(t, tt.expectedCode, res.StatusCode)
 		})
 	}
-}
-
-const (
-	serviceaccountIDTokensPath       = "/api/serviceaccounts/%v/tokens"    // #nosec G101
-	serviceaccountIDTokensDetailPath = "/api/serviceaccounts/%v/tokens/%v" // #nosec G101
-)
-
-func createTokenforSA(t *testing.T, service serviceaccounts.Service, keyName string, orgID int64, saID int64, secondsToLive int64) *apikey.APIKey {
-	key, err := apikeygen.New(orgID, keyName)
-	require.NoError(t, err)
-
-	cmd := serviceaccounts.AddServiceAccountTokenCommand{
-		Name:          keyName,
-		OrgId:         orgID,
-		Key:           key.HashedKey,
-		SecondsToLive: secondsToLive,
-		Result:        &apikey.APIKey{},
-	}
-
-	err = service.AddServiceAccountToken(context.Background(), saID, &cmd)
-	require.NoError(t, err)
-	return cmd.Result
 }

--- a/pkg/services/serviceaccounts/api/token_test.go
+++ b/pkg/services/serviceaccounts/api/token_test.go
@@ -2,11 +2,8 @@ package api
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -15,17 +12,51 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/components/apikeygen"
-	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
-	accesscontrolmock "github.com/grafana/grafana/pkg/services/accesscontrol/mock"
 	"github.com/grafana/grafana/pkg/services/apikey"
 	"github.com/grafana/grafana/pkg/services/serviceaccounts"
-	"github.com/grafana/grafana/pkg/services/serviceaccounts/tests"
 	"github.com/grafana/grafana/pkg/services/user"
-	"github.com/grafana/grafana/pkg/web"
 )
+
+func TestServiceAccountsAPI_ListTokens(t *testing.T) {
+	type TestCase struct {
+		desc         string
+		id           int64
+		permissions  []accesscontrol.Permission
+		expectedCode int
+	}
+
+	tests := []TestCase{
+		{
+			desc:         "should be able to list tokens with correct permission",
+			id:           1,
+			permissions:  []accesscontrol.Permission{{Action: serviceaccounts.ActionRead, Scope: "serviceaccounts:id:1"}},
+			expectedCode: http.StatusOK,
+		},
+		{
+			desc:         "should not be able to list tokens with wrong permission",
+			id:           2,
+			permissions:  []accesscontrol.Permission{{Action: serviceaccounts.ActionRead, Scope: "serviceaccounts:id:1"}},
+			expectedCode: http.StatusForbidden,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			server := setupTests(t, func(a *ServiceAccountsAPI) {
+				a.service = &fakeService{}
+			})
+			req := server.NewGetRequest(fmt.Sprintf("/api/serviceaccounts/%d/tokens", tt.id))
+			webtest.RequestWithSignedInUser(req, &user.SignedInUser{OrgID: 1, Permissions: map[int64]map[string][]string{1: accesscontrol.GroupScopesByAction(tt.permissions)}})
+			res, err := server.Send(req)
+			require.NoError(t, err)
+			defer res.Body.Close()
+
+			assert.Equal(t, tt.expectedCode, res.StatusCode)
+		})
+	}
+}
 
 func TestServiceAccountsAPI_CreateToken(t *testing.T) {
 	type TestCase struct {
@@ -169,115 +200,4 @@ func createTokenforSA(t *testing.T, service serviceaccounts.Service, keyName str
 	err = service.AddServiceAccountToken(context.Background(), saID, &cmd)
 	require.NoError(t, err)
 	return cmd.Result
-}
-
-func TestServiceAccountsAPI_ListTokens(t *testing.T) {
-	store := db.InitTestDB(t)
-	services := setupTestServices(t, store)
-
-	sa := tests.SetupUserServiceAccount(t, store, tests.TestUser{Login: "sa", IsServiceAccount: true})
-	type testCreateSAToken struct {
-		desc                      string
-		tokens                    []apikey.APIKey
-		expectedHasExpired        bool
-		expectedResponseBodyField string
-		expectedCode              int
-		acmock                    *accesscontrolmock.Mock
-	}
-
-	var saId int64 = 1
-	var timeInFuture = time.Now().Add(time.Second * 100).Unix()
-	var timeInPast = time.Now().Add(-time.Second * 100).Unix()
-
-	testCases := []testCreateSAToken{
-		{
-			desc: "should be able to list serviceaccount with no expiration date",
-			tokens: []apikey.APIKey{{
-				Id:               1,
-				OrgId:            1,
-				ServiceAccountId: &saId,
-				Expires:          nil,
-				Name:             "Test1",
-			}},
-			acmock: tests.SetupMockAccesscontrol(
-				t,
-				func(c context.Context, siu *user.SignedInUser, _ accesscontrol.Options) ([]accesscontrol.Permission, error) {
-					return []accesscontrol.Permission{{Action: serviceaccounts.ActionRead, Scope: "serviceaccounts:id:1"}}, nil
-				},
-				false,
-			),
-			expectedHasExpired:        false,
-			expectedResponseBodyField: "hasExpired",
-			expectedCode:              http.StatusOK,
-		},
-		{
-			desc: "should be able to list serviceaccount with secondsUntilExpiration",
-			tokens: []apikey.APIKey{{
-				Id:               1,
-				OrgId:            1,
-				ServiceAccountId: &saId,
-				Expires:          &timeInFuture,
-				Name:             "Test2",
-			}},
-			acmock: tests.SetupMockAccesscontrol(
-				t,
-				func(c context.Context, siu *user.SignedInUser, _ accesscontrol.Options) ([]accesscontrol.Permission, error) {
-					return []accesscontrol.Permission{{Action: serviceaccounts.ActionRead, Scope: "serviceaccounts:id:1"}}, nil
-				},
-				false,
-			),
-			expectedHasExpired:        false,
-			expectedResponseBodyField: "secondsUntilExpiration",
-			expectedCode:              http.StatusOK,
-		},
-		{
-			desc: "should be able to list serviceaccount with expired token",
-			tokens: []apikey.APIKey{{
-				Id:               1,
-				OrgId:            1,
-				ServiceAccountId: &saId,
-				Expires:          &timeInPast,
-				Name:             "Test3",
-			}},
-			acmock: tests.SetupMockAccesscontrol(
-				t,
-				func(c context.Context, siu *user.SignedInUser, _ accesscontrol.Options) ([]accesscontrol.Permission, error) {
-					return []accesscontrol.Permission{{Action: serviceaccounts.ActionRead, Scope: "serviceaccounts:id:1"}}, nil
-				},
-				false,
-			),
-			expectedHasExpired:        true,
-			expectedResponseBodyField: "secondsUntilExpiration",
-			expectedCode:              http.StatusOK,
-		},
-	}
-
-	var requestResponse = func(server *web.Mux, httpMethod, requestpath string, requestBody io.Reader) *httptest.ResponseRecorder {
-		req, err := http.NewRequest(httpMethod, requestpath, requestBody)
-		require.NoError(t, err)
-		req.Header.Add("Content-Type", "application/json")
-		recorder := httptest.NewRecorder()
-		server.ServeHTTP(recorder, req)
-		return recorder
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.desc, func(t *testing.T) {
-			endpoint := fmt.Sprintf(serviceAccountIDPath+"/tokens", sa.ID)
-			services.SAService.ExpectedTokens = tc.tokens
-			server, _ := setupTestServer(t, &services.SAService, routing.NewRouteRegister(), tc.acmock, store)
-			actual := requestResponse(server, http.MethodGet, endpoint, http.NoBody)
-
-			actualCode := actual.Code
-			actualBody := []map[string]interface{}{}
-
-			_ = json.Unmarshal(actual.Body.Bytes(), &actualBody)
-			require.Equal(t, tc.expectedCode, actualCode, endpoint, actualBody)
-
-			require.Equal(t, tc.expectedCode, actualCode)
-			require.Equal(t, tc.expectedHasExpired, actualBody[0]["hasExpired"])
-			_, exists := actualBody[0][tc.expectedResponseBodyField]
-			require.Equal(t, exists, true)
-		})
-	}
 }

--- a/pkg/services/serviceaccounts/api/token_test.go
+++ b/pkg/services/serviceaccounts/api/token_test.go
@@ -123,7 +123,6 @@ func TestServiceAccountsAPI_CreateToken(t *testing.T) {
 			assert.Equal(t, tt.expectedCode, res.StatusCode)
 		})
 	}
-
 }
 
 func TestServiceAccountsAPI_DeleteToken(t *testing.T) {

--- a/pkg/services/serviceaccounts/tests/common.go
+++ b/pkg/services/serviceaccounts/tests/common.go
@@ -15,7 +15,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/org/orgimpl"
 	"github.com/grafana/grafana/pkg/services/quota/quotaimpl"
 	"github.com/grafana/grafana/pkg/services/quota/quotatest"
-	"github.com/grafana/grafana/pkg/services/serviceaccounts"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/services/user/userimpl"
@@ -101,63 +100,6 @@ func SetupApiKey(t *testing.T, sqlStore *sqlstore.SQLStore, testKey TestApiKey) 
 	return addKeyCmd.Result
 }
 
-// Service implements the API exposed methods for service accounts.
-type serviceAccountStore interface {
-	CreateServiceAccount(ctx context.Context, orgID int64, saForm *serviceaccounts.CreateServiceAccountForm) (*serviceaccounts.ServiceAccountDTO, error)
-	RetrieveServiceAccount(ctx context.Context, orgID, serviceAccountID int64) (*serviceaccounts.ServiceAccountProfileDTO, error)
-	UpdateServiceAccount(ctx context.Context, orgID, serviceAccountID int64,
-		saForm *serviceaccounts.UpdateServiceAccountForm) (*serviceaccounts.ServiceAccountProfileDTO, error)
-	SearchOrgServiceAccounts(ctx context.Context, query *serviceaccounts.SearchOrgServiceAccountsQuery) (*serviceaccounts.SearchOrgServiceAccountsResult, error)
-	ListTokens(ctx context.Context, query *serviceaccounts.GetSATokensQuery) ([]apikey.APIKey, error)
-	DeleteServiceAccount(ctx context.Context, orgID, serviceAccountID int64) error
-	GetAPIKeysMigrationStatus(ctx context.Context, orgID int64) (*serviceaccounts.APIKeysMigrationStatus, error)
-	HideApiKeysTab(ctx context.Context, orgID int64) error
-	MigrateApiKeysToServiceAccounts(ctx context.Context, orgID int64) error
-	MigrateApiKey(ctx context.Context, orgID int64, keyId int64) error
-	RevertApiKey(ctx context.Context, saId int64, keyId int64) error
-	// Service account tokens
-	AddServiceAccountToken(ctx context.Context, serviceAccountID int64, cmd *serviceaccounts.AddServiceAccountTokenCommand) error
-	DeleteServiceAccountToken(ctx context.Context, orgID, serviceAccountID, tokenID int64) error
-}
-
-// create mock for serviceaccountservice
-type ServiceAccountMock struct {
-	Store             serviceAccountStore
-	Calls             Calls
-	Stats             *serviceaccounts.Stats
-	SecretScanEnabled bool
-	ExpectedTokens    []apikey.APIKey
-	ExpectedError     error
-}
-
-func (s *ServiceAccountMock) CreateServiceAccount(ctx context.Context, orgID int64, saForm *serviceaccounts.CreateServiceAccountForm) (*serviceaccounts.ServiceAccountDTO, error) {
-	s.Calls.CreateServiceAccount = append(s.Calls.CreateServiceAccount, []interface{}{ctx, orgID, saForm})
-	return s.Store.CreateServiceAccount(ctx, orgID, saForm)
-}
-func (s *ServiceAccountMock) DeleteServiceAccount(ctx context.Context, orgID, serviceAccountID int64) error {
-	s.Calls.DeleteServiceAccount = append(s.Calls.DeleteServiceAccount, []interface{}{ctx, orgID, serviceAccountID})
-	return s.Store.DeleteServiceAccount(ctx, orgID, serviceAccountID)
-}
-
-func (s *ServiceAccountMock) RetrieveServiceAccount(ctx context.Context, orgID, serviceAccountID int64) (*serviceaccounts.ServiceAccountProfileDTO, error) {
-	s.Calls.RetrieveServiceAccount = append(s.Calls.RetrieveServiceAccount, []interface{}{ctx, orgID, serviceAccountID})
-	return s.Store.RetrieveServiceAccount(ctx, orgID, serviceAccountID)
-}
-
-func (s *ServiceAccountMock) UpdateServiceAccount(ctx context.Context,
-	orgID, serviceAccountID int64,
-	saForm *serviceaccounts.UpdateServiceAccountForm) (*serviceaccounts.ServiceAccountProfileDTO, error) {
-	s.Calls.UpdateServiceAccount = append(s.Calls.UpdateServiceAccount, []interface{}{ctx, orgID, serviceAccountID, saForm})
-	return s.Store.UpdateServiceAccount(ctx, orgID, serviceAccountID, saForm)
-}
-
-func (s *ServiceAccountMock) RetrieveServiceAccountIdByName(ctx context.Context, orgID int64, name string) (int64, error) {
-	return 0, nil
-}
-func (s *ServiceAccountMock) Migrated(ctx context.Context, orgID int64) bool {
-	return false
-}
-
 func SetupMockAccesscontrol(t *testing.T,
 	userpermissionsfunc func(c context.Context, siu *user.SignedInUser, opt accesscontrol.Options) ([]accesscontrol.Permission, error),
 	disableAccessControl bool) *accesscontrolmock.Mock {
@@ -168,76 +110,4 @@ func SetupMockAccesscontrol(t *testing.T,
 	}
 	acmock.GetUserPermissionsFunc = userpermissionsfunc
 	return acmock
-}
-
-var _ serviceaccounts.Service = new(ServiceAccountMock)
-
-type Calls struct {
-	CreateServiceAccount            []interface{}
-	RetrieveServiceAccount          []interface{}
-	DeleteServiceAccount            []interface{}
-	GetAPIKeysMigrationStatus       []interface{}
-	HideApiKeysTab                  []interface{}
-	MigrateApiKeysToServiceAccounts []interface{}
-	MigrateApiKey                   []interface{}
-	RevertApiKey                    []interface{}
-	ListTokens                      []interface{}
-	DeleteServiceAccountToken       []interface{}
-	UpdateServiceAccount            []interface{}
-	AddServiceAccountToken          []interface{}
-	SearchOrgServiceAccounts        []interface{}
-	RetrieveServiceAccountIdByName  []interface{}
-}
-
-func (s *ServiceAccountMock) HideApiKeysTab(ctx context.Context, orgID int64) error {
-	s.Calls.HideApiKeysTab = append(s.Calls.HideApiKeysTab, []interface{}{ctx})
-	return nil
-}
-
-func (s *ServiceAccountMock) GetAPIKeysMigrationStatus(ctx context.Context, orgID int64) (*serviceaccounts.APIKeysMigrationStatus, error) {
-	s.Calls.GetAPIKeysMigrationStatus = append(s.Calls.GetAPIKeysMigrationStatus, []interface{}{ctx})
-	return nil, nil
-}
-
-func (s *ServiceAccountMock) MigrateApiKeysToServiceAccounts(ctx context.Context, orgID int64) error {
-	s.Calls.MigrateApiKeysToServiceAccounts = append(s.Calls.MigrateApiKeysToServiceAccounts, []interface{}{ctx})
-	return nil
-}
-
-func (s *ServiceAccountMock) MigrateApiKey(ctx context.Context, orgID int64, keyId int64) error {
-	s.Calls.MigrateApiKey = append(s.Calls.MigrateApiKey, []interface{}{ctx})
-	return nil
-}
-
-func (s *ServiceAccountMock) RevertApiKey(ctx context.Context, saId int64, keyId int64) error {
-	s.Calls.RevertApiKey = append(s.Calls.RevertApiKey, []interface{}{ctx})
-	return nil
-}
-
-func (s *ServiceAccountMock) ListTokens(ctx context.Context, query *serviceaccounts.GetSATokensQuery) ([]apikey.APIKey, error) {
-	s.Calls.ListTokens = append(s.Calls.ListTokens, []interface{}{ctx, query.OrgID, query.ServiceAccountID})
-	return s.ExpectedTokens, s.ExpectedError
-}
-
-func (s *ServiceAccountMock) SearchOrgServiceAccounts(ctx context.Context, query *serviceaccounts.SearchOrgServiceAccountsQuery) (*serviceaccounts.SearchOrgServiceAccountsResult, error) {
-	s.Calls.SearchOrgServiceAccounts = append(s.Calls.SearchOrgServiceAccounts, []interface{}{ctx, query})
-	return nil, nil
-}
-
-func (s *ServiceAccountMock) AddServiceAccountToken(ctx context.Context, serviceAccountID int64, cmd *serviceaccounts.AddServiceAccountTokenCommand) error {
-	s.Calls.AddServiceAccountToken = append(s.Calls.AddServiceAccountToken, []interface{}{ctx, cmd})
-	return s.Store.AddServiceAccountToken(ctx, serviceAccountID, cmd)
-}
-
-func (s *ServiceAccountMock) DeleteServiceAccountToken(ctx context.Context, orgID, serviceAccountID, tokenID int64) error {
-	s.Calls.DeleteServiceAccountToken = append(s.Calls.DeleteServiceAccountToken, []interface{}{ctx, orgID, serviceAccountID, tokenID})
-	return s.Store.DeleteServiceAccountToken(ctx, orgID, serviceAccountID, tokenID)
-}
-
-func (s *ServiceAccountMock) GetUsageMetrics(ctx context.Context) (*serviceaccounts.Stats, error) {
-	if s.Stats == nil {
-		return &serviceaccounts.Stats{}, nil
-	}
-
-	return s.Stats, nil
 }


### PR DESCRIPTION

**What is this feature?**
Rewrite service account api tests to use fakes and not having to initiate sqlite database and perform a lot of db setupt

Fixes #

**Special notes for your reviewer**:

