### PR TITLE
Alerting: Increase test timeout

### DIFF
--- a/public/app/features/alerting/unified/RuleEditorCloudRules.test.tsx
+++ b/public/app/features/alerting/unified/RuleEditorCloudRules.test.tsx
@@ -38,6 +38,12 @@ jest.mock('app/features/query/components/QueryEditorRow', () => ({
 
 jest.spyOn(config, 'getAllDataSources');
 
+// these tests are rather slow because we have to wait for various API calls and mocks to be called
+// and wait for the UI to be in particular states, drone seems to time out quite often so
+// we're increasing the timeout here to remove the flakey-ness of this test
+// ideally we'd move this to an e2e test but it's quite involved to set up the test environment
+jest.setTimeout(60 * 1000);
+
 const mocks = {
   getAllDataSources: jest.mocked(config.getAllDataSources),
   searchFolders: jest.mocked(searchFolders),

--- a/public/app/features/alerting/unified/RuleEditorExisting.test.tsx
+++ b/public/app/features/alerting/unified/RuleEditorExisting.test.tsx
@@ -48,6 +48,8 @@ jest.mock('app/features/query/components/QueryEditorRow', () => ({
 
 jest.spyOn(config, 'getAllDataSources');
 
+jest.setTimeout(60 * 1000);
+
 const mocks = {
   getAllDataSources: jest.mocked(config.getAllDataSources),
   searchFolders: jest.mocked(searchFolders),

--- a/public/app/features/alerting/unified/RuleEditorGrafanaRules.test.tsx
+++ b/public/app/features/alerting/unified/RuleEditorGrafanaRules.test.tsx
@@ -41,6 +41,8 @@ jest.mock('app/features/query/components/QueryEditorRow', () => ({
 
 jest.spyOn(config, 'getAllDataSources');
 
+jest.setTimeout(60 * 1000);
+
 const mocks = {
   getAllDataSources: jest.mocked(config.getAllDataSources),
   searchFolders: jest.mocked(searchFolders),


### PR DESCRIPTION
**What is this feature?**

`RuleEditorCloudRules.test.tsx` seems to be flakey on CI – increasing the timeout of this particular test suite should help it pass the Drone CI.

**Why do we need this feature?**

Ideally we wouldn't and we'd move these to e2e tests but setting up the correct testing environment is quite involved (judging by the amount of mocks that are involved in this test).

**Special notes for your reviewer**:

I'm increasing the timeout of this particular test instead of skipping it entirely, I hope this is an acceptable trade-off between confidence and patience.

