### PR TITLE
Cloudwatch: Improve user feedback for invalid fields (POC)

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/components/Dimensions/FilterItem.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/Dimensions/FilterItem.tsx
@@ -7,6 +7,7 @@ import { AccessoryButton, InputGroup } from '@grafana/experimental';
 import { Select, stylesFactory, useTheme2 } from '@grafana/ui';
 
 import { CloudWatchDatasource } from '../../datasource';
+import { useDimensionKeys2 } from '../../hooks';
 import { Dimensions, MetricStat } from '../../types';
 import { appendTemplateVariables } from '../../utils/utils';
 
@@ -36,7 +37,7 @@ export const FilterItem: FunctionComponent<Props> = ({
   filter,
   metricStat: { region, namespace, metricName, dimensions, accountId },
   datasource,
-  dimensionKeys,
+  // dimensionKeys,
   disableExpressions,
   onChange,
   onDelete,
@@ -44,6 +45,18 @@ export const FilterItem: FunctionComponent<Props> = ({
   const dimensionsExcludingCurrentKey = useMemo(
     () => excludeCurrentKey(dimensions ?? {}, filter.key),
     [dimensions, filter]
+  );
+
+  const dimensionKeys = useDimensionKeys2(
+    datasource,
+    {
+      region,
+      namespace,
+      metricName,
+      accountId,
+      dimensionFilters: dimensionsExcludingCurrentKey,
+    },
+    filter.key
   );
 
   const loadDimensionValues = async () => {
@@ -88,7 +101,8 @@ export const FilterItem: FunctionComponent<Props> = ({
           width="auto"
           value={filter.key ? toOption(filter.key) : null}
           allowCustomValue
-          options={dimensionKeys}
+          // options={dimensionKeys}
+          {...dimensionKeys}
           onChange={(change) => {
             if (change.label) {
               onChange({ key: change.label, value: undefined });

--- a/public/app/plugins/datasource/cloudwatch/components/Dimensions/FilterItem.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/Dimensions/FilterItem.tsx
@@ -81,8 +81,6 @@ export const FilterItem: FunctionComponent<Props> = ({
       });
   };
 
-  console.log('isValid', dimensionKeyFieldState.invalid);
-
   const [state, loadOptions] = useAsyncFn(loadDimensionValues, [
     filter.key,
     dimensions,

--- a/public/app/plugins/datasource/cloudwatch/components/Dimensions/FilterItem.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/Dimensions/FilterItem.tsx
@@ -47,7 +47,7 @@ export const FilterItem: FunctionComponent<Props> = ({
     [dimensions, filter]
   );
 
-  const dimensionKeys = useDimensionKeys2(
+  const dimensionKeyFieldState = useDimensionKeys2(
     datasource,
     {
       region,
@@ -81,6 +81,8 @@ export const FilterItem: FunctionComponent<Props> = ({
       });
   };
 
+  console.log('isValid', dimensionKeyFieldState.invalid);
+
   const [state, loadOptions] = useAsyncFn(loadDimensionValues, [
     filter.key,
     dimensions,
@@ -96,17 +98,14 @@ export const FilterItem: FunctionComponent<Props> = ({
     <div data-testid="cloudwatch-dimensions-filter-item">
       <InputGroup>
         <Select
+          {...dimensionKeyFieldState}
           aria-label="Dimensions filter key"
           inputId="cloudwatch-dimensions-filter-item-key"
           width="auto"
           value={filter.key ? toOption(filter.key) : null}
           allowCustomValue
-          // options={dimensionKeys}
-          {...dimensionKeys}
           onChange={(change) => {
-            if (change.label) {
-              onChange({ key: change.label, value: undefined });
-            }
+            onChange({ key: change?.label, value: undefined });
           }}
         />
 

--- a/public/app/plugins/datasource/cloudwatch/components/MetricStatEditor/MetricStatEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/MetricStatEditor/MetricStatEditor.tsx
@@ -63,18 +63,16 @@ export function MetricStatEditor({
               aria-label="Namespace"
               value={metricStat?.namespace && toOption(metricStat.namespace)}
               allowCustomValue
-              onChange={(option) => {
-                onChange({ ...metricStat, namespace: option?.value ?? '' });
-              }}
+              onChange={(option) => onChange({ ...metricStat, namespace: option?.value ?? '' })}
             />
           </EditorField>
-          <EditorField label="Metric name" width={16}>
+          <EditorField label="Metric name" width={16} error="test">
             <Select
               {...metricFieldState}
               aria-label="Metric name"
               value={metricStat?.metricName && toOption(metricStat.metricName)}
               allowCustomValue
-              onChange={({ value: metricName }) => metricName && onChange({ ...metricStat, metricName })}
+              onChange={(option) => onChange({ ...metricStat, metricName: option?.value })}
             />
           </EditorField>
 

--- a/public/app/plugins/datasource/cloudwatch/components/MetricStatEditor/MetricStatEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/MetricStatEditor/MetricStatEditor.tsx
@@ -30,7 +30,6 @@ export function MetricStatEditor({
   const namespaceFieldState = useNamespaces(datasource, metricStat.namespace);
   const metricFieldState = useMetrics(datasource, metricStat, metricStat.metricName);
   const dimensionKeys = useDimensionKeys(datasource, { ...metricStat, dimensionFilters: metricStat.dimensions });
-  console.log({ dimensionKeys });
   const accountState = useAccountOptions(datasource.api, metricStat.region);
 
   useEffect(() => {
@@ -64,8 +63,8 @@ export function MetricStatEditor({
               aria-label="Namespace"
               value={metricStat?.namespace && toOption(metricStat.namespace)}
               allowCustomValue
-              onChange={({ value: namespace }) => {
-                namespace && onChange({ ...metricStat, namespace });
+              onChange={(option) => {
+                onChange({ ...metricStat, namespace: option?.value ?? '' });
               }}
             />
           </EditorField>
@@ -75,11 +74,7 @@ export function MetricStatEditor({
               aria-label="Metric name"
               value={metricStat?.metricName && toOption(metricStat.metricName)}
               allowCustomValue
-              onChange={({ value: metricName }) => {
-                if (metricName) {
-                  onChange({ ...metricStat, metricName });
-                }
-              }}
+              onChange={({ value: metricName }) => metricName && onChange({ ...metricStat, metricName })}
             />
           </EditorField>
 

--- a/public/app/plugins/datasource/cloudwatch/components/SQLBuilderEditor/SQLBuilderSelectRow.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/SQLBuilderEditor/SQLBuilderSelectRow.tsx
@@ -47,8 +47,8 @@ const SQLBuilderSelectRow: React.FC<SQLBuilderSelectRowProps> = ({ datasource, q
   const schemaLabels = getSchemaLabels(sql.from);
   const withSchemaEnabled = isUsingWithSchema(sql.from);
 
-  const namespaceOptions = useNamespaces(datasource);
-  const metricOptions = useMetrics(datasource, { region: query.region, namespace });
+  const namespaceFieldState = useNamespaces(datasource, namespace);
+  const metricFieldState = useMetrics(datasource, { region: query.region, namespace }, metricName);
   const existingFilters = useMemo(() => stringArrayToDimensions(schemaLabels ?? []), [schemaLabels]);
   const unusedDimensionKeys = useDimensionKeys(datasource, {
     region: query.region,
@@ -84,7 +84,7 @@ const SQLBuilderSelectRow: React.FC<SQLBuilderSelectRowProps> = ({ datasource, q
             aria-label="Namespace"
             value={namespace ? toOption(namespace) : null}
             inputId={`${query.refId}-cloudwatch-sql-namespace`}
-            options={namespaceOptions}
+            {...namespaceFieldState}
             allowCustomValue
             onChange={({ value }) => value && onNamespaceChange(setNamespace(query, value))}
           />
@@ -118,9 +118,9 @@ const SQLBuilderSelectRow: React.FC<SQLBuilderSelectRowProps> = ({ datasource, q
       <EditorFieldGroup>
         <EditorField label="Metric name" width={16}>
           <Select
+            {...metricFieldState}
             aria-label="Metric name"
             value={metricName ? toOption(metricName) : null}
-            options={metricOptions}
             allowCustomValue
             onChange={({ value }) => value && onQueryChange(setMetricName(query, value))}
           />

--- a/public/app/plugins/datasource/cloudwatch/components/VariableQueryEditor/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/VariableQueryEditor/VariableQueryEditor.tsx
@@ -37,8 +37,8 @@ export const VariableQueryEditor = ({ query, datasource, onChange }: Props) => {
 
   const { region, namespace, metricName, dimensionKey, dimensionFilters } = parsedQuery;
   const [regions, regionIsLoading] = useRegions(datasource);
-  const namespaces = useNamespaces(datasource);
-  const metrics = useMetrics(datasource, { region, namespace });
+  const namespaceFieldState = useNamespaces(datasource, namespace);
+  const metricFieldState = useMetrics(datasource, { region, namespace }, metricName);
   const dimensionKeys = useDimensionKeys(datasource, { region, namespace, metricName });
   const keysForDimensionFilter = useDimensionKeys(datasource, { region, namespace, metricName, dimensionFilters });
 
@@ -122,8 +122,8 @@ export const VariableQueryEditor = ({ query, datasource, onChange }: Props) => {
       )}
       {hasNamespaceField && (
         <VariableQueryField
+          {...namespaceFieldState}
           value={namespace}
-          options={namespaces}
           onChange={(value: string) => onNamespaceChange(value)}
           label="Namespace"
           inputId={`variable-query-namespace-${query.refId}`}
@@ -134,7 +134,7 @@ export const VariableQueryEditor = ({ query, datasource, onChange }: Props) => {
         <>
           <VariableQueryField
             value={metricName || null}
-            options={metrics}
+            {...metricFieldState}
             onChange={(value: string) => onQueryChange({ ...parsedQuery, metricName: value })}
             label="Metric"
             inputId={`variable-query-metric-${query.refId}`}

--- a/public/app/plugins/datasource/cloudwatch/components/VariableQueryEditor/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/VariableQueryEditor/VariableQueryEditor.tsx
@@ -16,7 +16,7 @@ import { VariableTextField } from './VariableTextField';
 
 export type Props = QueryEditorProps<CloudWatchDatasource, CloudWatchQuery, CloudWatchJsonData, VariableQuery>;
 
-const queryTypes: Array<{ value: string; label: string }> = [
+const queryTypes: Array<SelectableValue<VariableQueryType>> = [
   { value: VariableQueryType.Regions, label: 'Regions' },
   { value: VariableQueryType.Namespaces, label: 'Namespaces' },
   { value: VariableQueryType.Metrics, label: 'Metrics' },

--- a/public/app/plugins/datasource/cloudwatch/components/VariableQueryEditor/VariableQueryField.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/VariableQueryEditor/VariableQueryField.tsx
@@ -15,6 +15,7 @@ interface VariableQueryFieldProps<T> {
   inputId?: string;
   allowCustomValue?: boolean;
   isLoading?: boolean;
+  invalid?: boolean;
 }
 
 export const VariableQueryField = <T extends string | VariableQueryType>({
@@ -25,10 +26,12 @@ export const VariableQueryField = <T extends string | VariableQueryType>({
   allowCustomValue = false,
   isLoading = false,
   inputId = label,
+  invalid = false,
 }: VariableQueryFieldProps<T>) => {
   return (
     <InlineField label={label} labelWidth={LABEL_WIDTH} htmlFor={inputId}>
       <Select
+        invalid={invalid}
         aria-label={label}
         width={25}
         allowCustomValue={allowCustomValue}

--- a/public/app/plugins/datasource/cloudwatch/components/VariableQueryEditor/VariableQueryField.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/VariableQueryEditor/VariableQueryField.tsx
@@ -9,7 +9,7 @@ const LABEL_WIDTH = 20;
 
 interface VariableQueryFieldProps<T> {
   onChange: (value: T) => void;
-  options: SelectableValue[];
+  options: Array<SelectableValue<T>>;
   value: T | null;
   label: string;
   inputId?: string;

--- a/public/app/plugins/datasource/cloudwatch/hooks.ts
+++ b/public/app/plugins/datasource/cloudwatch/hooks.ts
@@ -10,10 +10,10 @@ import { CloudWatchDatasource } from './datasource';
 import { GetDimensionKeysRequest, GetMetricsRequest } from './types';
 import { appendTemplateVariables } from './utils/utils';
 
-type FieldDataState = Pick<
-  SelectCommonProps<string>,
-  'options' | 'isLoading' | 'invalid' | 'isLoading' | 'isClearable'
->;
+interface FieldDataState
+  extends Pick<SelectCommonProps<string>, 'isLoading' | 'invalid' | 'isLoading' | 'isClearable'> {
+  options: Array<SelectableValue<string>>;
+}
 
 export const useRegions = (datasource: CloudWatchDatasource): [Array<SelectableValue<string>>, boolean] => {
   const [regionsIsLoading, setRegionsIsLoading] = useState<boolean>(false);
@@ -50,7 +50,10 @@ export const useNamespaces = (datasource: CloudWatchDatasource, currentNamespace
       .finally(() => setIsLoading(false));
   }, [datasource]);
 
-  const invalid = !isLoading && !namespaces.some((n) => n.value === currentNamespace);
+  const invalid =
+    !!currentNamespace &&
+    !isLoading &&
+    !namespaces.some((n) => n.value === datasource.templateSrv.replace(currentNamespace));
   return {
     isLoading,
     options: namespaces,
@@ -88,7 +91,10 @@ export const useMetrics = (
       .finally(() => setIsLoading(false));
   }, [datasource, region, namespace, accountId]);
 
-  const invalid = !isLoading && !metrics.some((metric) => metric.value === currentMetricName);
+  const invalid =
+    !!currentMetricName &&
+    !isLoading &&
+    !metrics.some((metric) => metric.value === datasource.templateSrv.replace(currentMetricName));
   return {
     isLoading,
     options: metrics,
@@ -175,7 +181,10 @@ export const useDimensionKeys2 = (
       .finally(() => setIsLoading(false));
   }, [datasource, namespace, region, metricName, accountId, dimensionFilters]);
 
-  const invalid = !isLoading && !dimensionKeys.some((dk) => dk.value === currentDimensionKey);
+  const invalid =
+    !!currentDimensionKey &&
+    !isLoading &&
+    !dimensionKeys.some((dk) => dk.value === datasource.templateSrv.replace(currentDimensionKey));
   return {
     isLoading,
     options: dimensionKeys,

--- a/public/app/plugins/datasource/cloudwatch/hooks.ts
+++ b/public/app/plugins/datasource/cloudwatch/hooks.ts
@@ -11,8 +11,9 @@ import { appendTemplateVariables } from './utils/utils';
 
 export interface FieldDataState<T> {
   options: Array<SelectableValue<T>>;
-  isValid: boolean;
+  invalid: boolean;
   isLoading: boolean;
+  isClearable: boolean;
 }
 
 // type FieldDataState = Pick<SelectCommonProps<string>, 'isLoading'>;
@@ -52,10 +53,12 @@ export const useNamespaces = (datasource: CloudWatchDatasource, currentNamespace
       .finally(() => setIsLoading(false));
   }, [datasource]);
 
+  const invalid = !isLoading && !namespaces.some((n) => n.value === currentNamespace);
   return {
     isLoading,
     options: namespaces,
-    isValid: isLoading || namespaces.some((n) => n.value === currentNamespace),
+    invalid,
+    isClearable: invalid,
   };
 };
 
@@ -88,10 +91,12 @@ export const useMetrics = (
       .finally(() => setIsLoading(false));
   }, [datasource, region, namespace, accountId]);
 
+  const invalid = !isLoading && !metrics.some((metric) => metric.value === currentMetricName);
   return {
     isLoading,
     options: metrics,
-    isValid: isLoading || metrics.some((metric) => metric.value === currentMetricName),
+    invalid,
+    isClearable: invalid,
   };
 };
 
@@ -173,10 +178,12 @@ export const useDimensionKeys2 = (
       .finally(() => setIsLoading(false));
   }, [datasource, namespace, region, metricName, accountId, dimensionFilters]);
 
+  const invalid = !isLoading && !dimensionKeys.some((dk) => dk.value === currentDimensionKey);
   return {
     isLoading,
     options: dimensionKeys,
-    isValid: isLoading || dimensionKeys.some((dk) => dk.value === currentDimensionKey),
+    invalid,
+    isClearable: invalid,
   };
 };
 

--- a/public/app/plugins/datasource/cloudwatch/hooks.ts
+++ b/public/app/plugins/datasource/cloudwatch/hooks.ts
@@ -3,20 +3,17 @@ import { useAsyncFn, useDeepCompareEffect } from 'react-use';
 
 import { SelectableValue, toOption } from '@grafana/data';
 import { config } from '@grafana/runtime';
+import { SelectCommonProps } from '@grafana/ui';
 
 import { CloudWatchAPI } from './api';
 import { CloudWatchDatasource } from './datasource';
 import { GetDimensionKeysRequest, GetMetricsRequest } from './types';
 import { appendTemplateVariables } from './utils/utils';
 
-export interface FieldDataState<T> {
-  options: Array<SelectableValue<T>>;
-  invalid: boolean;
-  isLoading: boolean;
-  isClearable: boolean;
-}
-
-// type FieldDataState = Pick<SelectCommonProps<string>, 'isLoading'>;
+type FieldDataState = Pick<
+  SelectCommonProps<string>,
+  'options' | 'isLoading' | 'invalid' | 'isLoading' | 'isClearable'
+>;
 
 export const useRegions = (datasource: CloudWatchDatasource): [Array<SelectableValue<string>>, boolean] => {
   const [regionsIsLoading, setRegionsIsLoading] = useState<boolean>(false);
@@ -39,7 +36,7 @@ export const useRegions = (datasource: CloudWatchDatasource): [Array<SelectableV
   return [regions, regionsIsLoading];
 };
 
-export const useNamespaces = (datasource: CloudWatchDatasource, currentNamespace?: string): FieldDataState<string> => {
+export const useNamespaces = (datasource: CloudWatchDatasource, currentNamespace?: string): FieldDataState => {
   const [namespaces, setNamespaces] = useState<Array<SelectableValue<string>>>([]);
   const [isLoading, setIsLoading] = useState<boolean>(false);
 
@@ -66,7 +63,7 @@ export const useMetrics = (
   datasource: CloudWatchDatasource,
   { region, namespace, accountId }: GetMetricsRequest,
   currentMetricName?: string
-): FieldDataState<string> => {
+): FieldDataState => {
   const [metrics, setMetrics] = useState<Array<SelectableValue<string>>>([]);
   const [isLoading, setIsLoading] = useState<boolean>(false);
 
@@ -142,7 +139,7 @@ export const useDimensionKeys2 = (
   datasource: CloudWatchDatasource,
   { region, namespace, metricName, dimensionFilters, accountId }: GetDimensionKeysRequest,
   currentDimensionKey?: string
-): FieldDataState<string> => {
+): FieldDataState => {
   const [dimensionKeys, setDimensionKeys] = useState<Array<SelectableValue<string>>>([]);
   const [isLoading, setIsLoading] = useState<boolean>(false);
 


### PR DESCRIPTION
**What is this feature?**

The query editors in some plugins requires the user to fill in multiple fields for the query to be valid. In some occasions, what options are valid for a field depends on the selection in a previous field, causing a cascading dependency chain in the editor. 
_Currently in the Azure Monitor editor_
![example](https://user-images.githubusercontent.com/2388950/208102126-6b57dd03-b048-482b-9fc5-1b80a94d1c75.gif)


If a field higher up in the chain is changed, there are a few different actions that can be taken. 
1. clear all following fields that directly or indirectly depend on the field that was changed (this it partly how it's handled in the CloudWatch editor and in the Azure Monitor editor)
2. auto select the first out of all options that are valid for the child of the changed field (partly done in the CloudMonitoring editor)
3. do nothing - simple let the query through and let the upstream error be propagated to the panel even though it may be hard to make any sense out of it (partly done in the CloudWatch editor)

Handling scenario 1 and 2 is trickier than you'd expect, and even more so when a change high up in the chain should trigger multiple subsequent asynchronous changes to fields further down the chain. Over the years, we've had numerous bugs reported for this in CloudWatch, CloudMonitoring and in Azure Monitor. That is problematic of course, but second to that I'm not sure scenario 1 and 2 from above would provide the desired behavior. If you for example want to explore another _Metric namespace_ in the Azure Monitor plugin just to find out that it did not return any data, you're gonna have to fill in _Metric_, _Aggregation_ and _Time grain_ once again which is really tedious. 

To me, it would be better if field selections further down the chain would remain the same even after top level fields are changed. Then the editor could provide some kind of feedback that indicates whether subsequent selection are valid or not. This PR provides an early stage draft of that behavior. Since all fields in the CloudWatch editor use hooks for providing select options, setting field's `valid` state can be done easily without rewriting the entire editor and hopefully without causing too many bugs. Currently no error message is being displayed next to the invalid field, but that could be added too. 

![validate-fields](https://user-images.githubusercontent.com/2388950/208099131-3356d375-76e0-4810-96c9-fda922b1d8eb.gif)

This is an early draft, so don't pay too much attention to the code. At this point I'm mostly interested on getting feedback on this from a usability standpoint. 

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

