### PR TITLE
CI: Remove `enterprise2` bits from `enterprise` pipelines

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2680,13 +2680,6 @@ steps:
   image: grafana/build-container:1.6.4
   name: build-plugins
 - commands:
-  - ./bin/build build-backend --jobs 8 --edition enterprise2 ${DRONE_TAG}
-  depends_on:
-  - wire-install
-  - compile-build-cmd
-  image: grafana/build-container:1.6.4
-  name: build-backend-enterprise2
-- commands:
   - ./bin/build package --jobs 8 --edition enterprise  --sign ${DRONE_TAG}
   depends_on:
   - build-plugins
@@ -2840,46 +2833,6 @@ steps:
       from_secret: prerelease_bucket
   image: grafana/grafana-ci-deploy:1.3.3
   name: upload-packages
-- commands:
-  - ./bin/build package --jobs 8 --edition enterprise2  --sign ${DRONE_TAG}
-  depends_on:
-  - build-plugins
-  - build-backend-enterprise2
-  - build-frontend
-  - build-frontend-packages
-  environment:
-    GPG_KEY_PASSWORD:
-      from_secret: gpg_key_password
-    GPG_PRIV_KEY:
-      from_secret: gpg_priv_key
-    GPG_PUB_KEY:
-      from_secret: gpg_pub_key
-    GRAFANA_API_KEY:
-      from_secret: grafana_api_key
-  image: grafana/build-container:1.6.4
-  name: package-enterprise2
-- commands:
-  - ./bin/build upload-cdn --edition enterprise2
-  depends_on:
-  - package-enterprise2
-  environment:
-    GCP_KEY:
-      from_secret: gcp_key
-    PRERELEASE_BUCKET:
-      from_secret: prerelease_bucket
-  image: grafana/grafana-ci-deploy:1.3.3
-  name: upload-cdn-assets-enterprise2
-- commands:
-  - ./bin/build upload-packages --edition enterprise2
-  depends_on:
-  - package-enterprise2
-  environment:
-    GCP_KEY:
-      from_secret: gcp_key
-    PRERELEASE_BUCKET:
-      from_secret: prerelease_bucket
-  image: grafana/grafana-ci-deploy:1.3.3
-  name: upload-packages-enterprise2
 trigger:
   event:
     exclude:
@@ -5307,14 +5260,6 @@ steps:
   image: grafana/build-container:1.6.4
   name: build-plugins
 - commands:
-  - ./bin/build build-backend --jobs 8 --edition enterprise2 --build-id ${DRONE_BUILD_NUMBER}
-    --variants linux-amd64
-  depends_on:
-  - wire-install
-  - compile-build-cmd
-  image: grafana/build-container:1.6.4
-  name: build-backend-enterprise2
-- commands:
   - ./bin/build package --jobs 8 --edition enterprise --build-id ${DRONE_BUILD_NUMBER}
     --sign
   depends_on:
@@ -5475,47 +5420,6 @@ steps:
   when:
     repo:
     - grafana/grafana
-- commands:
-  - ./bin/build package --jobs 8 --edition enterprise2 --build-id ${DRONE_BUILD_NUMBER}
-    --variants linux-amd64 --sign
-  depends_on:
-  - build-plugins
-  - build-backend-enterprise2
-  - build-frontend
-  - build-frontend-packages
-  environment:
-    GPG_KEY_PASSWORD:
-      from_secret: gpg_key_password
-    GPG_PRIV_KEY:
-      from_secret: gpg_priv_key
-    GPG_PUB_KEY:
-      from_secret: gpg_pub_key
-    GRAFANA_API_KEY:
-      from_secret: grafana_api_key
-  image: grafana/build-container:1.6.4
-  name: package-enterprise2
-- commands:
-  - ./bin/build upload-cdn --edition enterprise2
-  depends_on:
-  - package-enterprise2
-  environment:
-    GCP_KEY:
-      from_secret: gcp_key
-    PRERELEASE_BUCKET:
-      from_secret: prerelease_bucket
-  image: grafana/grafana-ci-deploy:1.3.3
-  name: upload-cdn-assets-enterprise2
-- commands:
-  - ./bin/build upload-packages --edition enterprise2
-  depends_on:
-  - package-enterprise2
-  environment:
-    GCP_KEY:
-      from_secret: gcp_key
-    PRERELEASE_BUCKET:
-      from_secret: prerelease_bucket
-  image: grafana/grafana-ci-deploy:1.3.3
-  name: upload-packages-enterprise2
 trigger:
   ref:
   - refs/heads/v[0-9]*
@@ -6445,6 +6349,6 @@ kind: secret
 name: packages_secret_access_key
 ---
 kind: signature
-hmac: 232bd9c4601917826ebb8fcd50a19fa728a4d65264c20ee9d5d482fb86d6205e
+hmac: b4096b73caa8b48e68c564820954e1fb5632a49a91021c30fab1880d8afb96ba
 
 ...

--- a/scripts/drone/events/release.star
+++ b/scripts/drone/events/release.star
@@ -292,13 +292,9 @@ def enterprise_pipelines(ver_mode=ver_mode, trigger=release_trigger):
         build_frontend_step(edition='enterprise', ver_mode=ver_mode),
         build_frontend_package_step(edition='enterprise', ver_mode=ver_mode),
         build_plugins_step(edition='enterprise', ver_mode=ver_mode),
-        build_backend_step(
-            edition='enterprise2', ver_mode=ver_mode, variants=['linux-amd64']
-        ),
         package_step(
             edition='enterprise',
             ver_mode=ver_mode,
-            include_enterprise2=True,
         ),
         copy_packages_for_docker_step(),
         build_docker_images_step(edition='enterprise', ver_mode=ver_mode, publish=True),
@@ -324,25 +320,12 @@ def enterprise_pipelines(ver_mode=ver_mode, trigger=release_trigger):
         )
         upload_packages_enterprise['depends_on'] = ['package']
 
-        upload_packages_enterprise2 = upload_packages_step(
-            edition='enterprise2', ver_mode=ver_mode
-        )
-        upload_packages_enterprise2['depends_on'] = ['package-enterprise2']
-
         publish_steps.extend(
             [
                 upload_cdn_step(
                     edition='enterprise', ver_mode=ver_mode, trigger=trigger_oss
                 ),
                 upload_packages_enterprise,
-                package_step(
-                    edition='enterprise2',
-                    ver_mode=ver_mode,
-                    include_enterprise2=True,
-                    variants=['linux-amd64'],
-                ),
-                upload_cdn_step(edition='enterprise2', ver_mode=ver_mode),
-                upload_packages_enterprise2,
             ]
         )
 
@@ -472,7 +455,6 @@ def enterprise2_pipelines(prefix='', ver_mode=ver_mode, trigger=release_trigger)
             package_step(
                 edition='enterprise2',
                 ver_mode=ver_mode,
-                include_enterprise2=True,
                 variants=['linux-amd64'],
             ),
             upload_cdn,

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -628,7 +628,7 @@ def codespell_step():
     }
 
 
-def package_step(edition, ver_mode, include_enterprise2=False, variants=None):
+def package_step(edition, ver_mode, variants=None):
     deps = [
         'build-plugins',
         'build-backend' + enterprise2_suffix(edition),


### PR DESCRIPTION
**What is this feature?**

After the split of `Enterprise` and `Enterprise2` pipelines, there are some `Enterprise2` leftover steps in `Enterprise` pipelines. This PR addresses this issue by removing them. The only place where `Enterprise2` related steps should run is in it's own pipeline.