### PR TITLE
elastic: backend: handle naming bucket_scripts

### DIFF
--- a/pkg/tsdb/elasticsearch/response_parser.go
+++ b/pkg/tsdb/elasticsearch/response_parser.go
@@ -587,8 +587,8 @@ func getFieldName(dataField data.Field, target *Query, metricTypeCount int) stri
 		return frameName
 	}
 	// todo, if field and pipelineAgg
-	if field != "" && isPipelineAgg(metricType) {
-		if isPipelineAggWithMultipleBucketPaths(metricType) {
+	if isPipelineAgg(metricType) {
+		if metricType != "" && isPipelineAggWithMultipleBucketPaths(metricType) {
 			metricID := ""
 			if v, ok := dataField.Labels["metricId"]; ok {
 				metricID = v
@@ -607,15 +607,17 @@ func getFieldName(dataField data.Field, target *Query, metricTypeCount int) stri
 				}
 			}
 		} else {
-			found := false
-			for _, metric := range target.Metrics {
-				if metric.ID == field {
-					metricName += " " + describeMetric(metric.Type, field)
-					found = true
+			if field != "" {
+				found := false
+				for _, metric := range target.Metrics {
+					if metric.ID == field {
+						metricName += " " + describeMetric(metric.Type, field)
+						found = true
+					}
 				}
-			}
-			if !found {
-				metricName = "Unset"
+				if !found {
+					metricName = "Unset"
+				}
 			}
 		}
 	} else if field != "" {

--- a/pkg/tsdb/elasticsearch/response_parser_frontend_test.go
+++ b/pkg/tsdb/elasticsearch/response_parser_frontend_test.go
@@ -1281,7 +1281,7 @@ func TestBucketScript(t *testing.T) {
 	requireFrameLength(t, frames[0], 2)
 	requireTimeSeriesName(t, "Sum @value", frames[0])
 	requireTimeSeriesName(t, "Max @value", frames[1])
-	// requireTimeSeriesName(t, "Sum @value * Max @value", frames[2]) // FIXME
+	requireTimeSeriesName(t, "Sum @value * Max @value", frames[2])
 
 	requireNumberValue(t, 2, frames[0], 0)
 	requireNumberValue(t, 3, frames[1], 0)

--- a/pkg/tsdb/elasticsearch/response_parser_test.go
+++ b/pkg/tsdb/elasticsearch/response_parser_test.go
@@ -912,7 +912,6 @@ func TestResponseParser(t *testing.T) {
             { "id": "3", "type": "max", "field": "@value" },
             {
               "id": "4",
-              "field": "select field",
               "pipelineVariables": [{ "name": "var1", "pipelineAgg": "1" }, { "name": "var2", "pipelineAgg": "3" }],
               "settings": { "script": "params.var1 * params.var2" },
               "type": "bucket_script"
@@ -991,14 +990,12 @@ func TestResponseParser(t *testing.T) {
             			{ "id": "3", "type": "max", "field": "@value" },
             			{
               				"id": "4",
-              				"field": "select field",
               				"pipelineVariables": [{ "name": "var1", "pipelineAgg": "1" }, { "name": "var2", "pipelineAgg": "3" }],
               				"settings": { "script": "params.var1 * params.var2" },
               				"type": "bucket_script"
 						},
             			{
 							"id": "5",
-							"field": "select field",
 							"pipelineVariables": [{ "name": "var1", "pipelineAgg": "1" }, { "name": "var2", "pipelineAgg": "3" }],
 							"settings": { "script": "params.var1 * params.var2 * 2" },
 							"type": "bucket_script"


### PR DESCRIPTION
part of https://github.com/grafana/grafana/issues/54011

the name of bucket script fields was not correct.

for an example bucket-script usage, see this screenshot:
<img width="733" alt="bucket" src="https://user-images.githubusercontent.com/51989/208108633-67871505-6cfb-416f-afd4-d6a12e70ac5f.png">

there were already tests for the backend code (`response_parser_test.go`), and we added a copy-of-the-frontend-tests in `response_parser_frontend_test.go`.

there is some duplication between those two files, we will eliminate that at the end.

i wanted to fix a commented out failing test in `response_parser_frontend_test.go`, but the interesting thing was, the same test also existed in `response_parser_test.go`:
- https://github.com/grafana/grafana/blob/1da7bf7f600e6a978afdfb07b210be1969a5155e/pkg/tsdb/elasticsearch/response_parser_frontend_test.go#L1220
- https://github.com/grafana/grafana/blob/1da7bf7f600e6a978afdfb07b210be1969a5155e/pkg/tsdb/elasticsearch/response_parser_test.go#L906


and the copy in `response_parser_test.go` was succeeding, while my copy in `response_parser_frontend_test.go` was failing 😄 

after some investigation, i spotted that the input-data for the test is different. in `response_parser_test.go`, the bucket-script item has a `field` attribute at https://github.com/grafana/grafana/blob/1da7bf7f600e6a978afdfb07b210be1969a5155e/pkg/tsdb/elasticsearch/response_parser_test.go#L915

but, as you can see from the screenshot above, in reality there is no `field` attribute in a bucket-script. (the `field` is used to choose an elastic-field, for example see the `min` and `max` in the screenshot, those choose the `counter` elastic-field. but a bucket-script does not choose an elastic-field)

if i remove the `field` attribute from the tst in `response_parser_test.go`, then it fails too.

the fix is in `response_parser.go`, i recommend looking at the diff in hide-whitespace mode. there are two changes:
1. the `field != ""` test was removed from the "top IF", and moved to the "inner IF". basically, the `if isPipelineAggWithMultipleBucketPaths` branch needs to be reachable even if `field == ""`. it's body does not use `field` at all. but i had to re-add the `field != ""` check lower, where the field-value is used.
2. (this is minor, and does not change anything). i added a `metricType != "" &&` part to an `IF`. this does not really change anything, but it is more correct. you see, we will call `isPipelineAggWithMultipleBucketPaths(metricType)`, which will do a check in a go `map` based on `metricType`, and that map does not have an emptystring-key, so it will return empty anyway, but i thought it's better to explicitly check the value first.