### PR TITLE
QueryHistory: prevent query history tests from failing if the suite is rerun

### DIFF
--- a/e2e/various-suite/explore.spec.ts
+++ b/e2e/various-suite/explore.spec.ts
@@ -47,5 +47,10 @@ e2e.scenario({
     // Both queries above should have been run and be shown in the query history
     e2e.components.QueryTab.queryHistoryButton().should('be.visible').click();
     e2e.components.QueryHistory.queryText().should('have.length', 2).should('contain', 'csv_metric_values');
+
+    // delete all queries
+    cy.get('button[title="Delete query"]').each((button) => {
+      button.trigger('click');
+    });
   },
 });


### PR DESCRIPTION
Fixes #59315

Explore tests were failing due to a flakiness in the trace view tests. 

when any test in the suite fails we rerun the whole suite. if a test happens to fail after explore, the test will run on a non-blank state as the number of queries in the initial state may be different than zero.

One of the assertions in Explore was counting the number of queries in the history tab, which was expected to be exactly 2, but due to the previous point, any run other then the first will result in a failure.

~to avoid that, instead of asserting that the number of queries in history is exactly 2, we assert that it has increased by 2 instead. this should prevent the test from failing on rerun and at the same time provide the same value.~

to avoid that, at the end of each test we delete each item in history.
