### PR TITLE
CI: Add `aws-marketplace` pipeline

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -23,6 +23,7 @@ load(
     'publish_image_pipelines_security',
 )
 load('scripts/drone/pipelines/github.star', 'publish_github_pipeline')
+load('scripts/drone/pipelines/aws_marketplace.star', 'publish_aws_marketplace_pipeline')
 load('scripts/drone/version.star', 'version_branch_pipelines')
 load('scripts/drone/events/cron.star', 'cronjobs')
 load('scripts/drone/vault.star', 'secrets')
@@ -43,6 +44,7 @@ def main(ctx):
         + publish_image_pipelines_security()
         + publish_github_pipeline('public')
         + publish_github_pipeline('security')
+        + publish_aws_marketplace_pipeline('public')
         + publish_artifacts_pipelines('security')
         + publish_artifacts_pipelines('public')
         + publish_npm_pipelines()

--- a/.drone.yml
+++ b/.drone.yml
@@ -4179,6 +4179,72 @@ clone:
   retries: 3
 depends_on: []
 environment:
+  EDITION: enterprise2
+image_pull_secrets:
+- dockerconfigjson
+kind: pipeline
+name: publish-aws-marketplace-public
+node:
+  type: no-parallel
+platform:
+  arch: amd64
+  os: linux
+services: []
+steps:
+- commands:
+  - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
+  depends_on: []
+  environment:
+    CGO_ENABLED: 0
+  image: golang:1.19.3
+  name: compile-build-cmd
+- commands:
+  - ./bin/build artifacts docker fetch --edition enterprise2
+  depends_on:
+  - compile-build-cmd
+  environment:
+    DOCKER_ENTERPRISE2_REPO:
+      from_secret: docker_enterprise2_repo
+    DOCKER_PASSWORD:
+      from_secret: docker_password
+    DOCKER_USER:
+      from_secret: docker_username
+    GCP_KEY:
+      from_secret: gcp_key
+  image: google/cloud-sdk
+  name: fetch-images-enterprise2
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+- commands:
+  - ./bin/build publish aws --image grafana/grafana-enterprise-dev --repo grafana-labs/grafana-enterprise
+    --product 1b97f7d0-f274-4cce-b5f4-910dbfa45535
+  depends_on:
+  - fetch-images-enterprise2
+  environment:
+    AWS_ACCESS_KEY_ID:
+      from_secret: aws_access_key_id
+    AWS_REGION:
+      from_secret: aws_region
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: aws_secret_access_key
+  image: grafana/grafana-ci-deploy:1.3.3
+  name: publish-aws-marketplace
+trigger:
+  event:
+  - promote
+  target:
+  - public
+type: docker
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
+---
+clone:
+  retries: 3
+depends_on: []
+environment:
   EDITION: all
 image_pull_secrets:
 - dockerconfigjson
@@ -6348,7 +6414,25 @@ get:
 kind: secret
 name: packages_secret_access_key
 ---
+get:
+  name: aws_region
+  path: secret/aws-marketplace
+kind: secret
+name: aws_region
+---
+get:
+  name: aws_access_key_id
+  path: secret/aws-marketplace
+kind: secret
+name: aws_access_key_id
+---
+get:
+  name: aws_secret_access_key
+  path: secret/aws-marketplace
+kind: secret
+name: aws_secret_access_key
+---
 kind: signature
-hmac: b4096b73caa8b48e68c564820954e1fb5632a49a91021c30fab1880d8afb96ba
+hmac: 820cb5f74979902c1674132a46cbc90a98efb23b771faa74cbfda133bfc21df6
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -4230,6 +4230,9 @@ steps:
       from_secret: aws_secret_access_key
   image: grafana/grafana-ci-deploy:1.3.3
   name: publish-aws-marketplace
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
 trigger:
   event:
   - promote
@@ -6433,6 +6436,6 @@ kind: secret
 name: aws_secret_access_key
 ---
 kind: signature
-hmac: 1469aed3e12075feb3f8719ca24ccbb462f9e94dec5360af009d5ba6030597d7
+hmac: 2b425ae03e938476aa4ce99fce87474d68d13e76cbb1988cef45b42949b439cf
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -4218,7 +4218,7 @@ steps:
   - name: docker
     path: /var/run/docker.sock
 - commands:
-  - ./bin/build publish aws --image grafana/grafana-enterprise --repo grafana-labs/grafana-enterprise
+  - ./bin/build publish aws --image grafana/grafana-enterprise --repo grafana-labs/grafanaenterprise
     --product 422b46fb-bea6-4f27-8bcc-832117bd627e
   depends_on:
   - fetch-images-enterprise
@@ -6437,6 +6437,6 @@ kind: secret
 name: aws_secret_access_key
 ---
 kind: signature
-hmac: c8f9d3463b57b855994905b4ee9645c3562fefb13b150284bc39d70ede21cc33
+hmac: e3d58aacde14e03c46303c4d707f9b4e7d6e33b92b696b19befd06d6a28cf88a
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -4218,8 +4218,8 @@ steps:
   - name: docker
     path: /var/run/docker.sock
 - commands:
-  - ./bin/build publish aws --image grafana/grafana-enterprise-dev --repo grafana-labs/grafana-enterprise
-    --product 1b97f7d0-f274-4cce-b5f4-910dbfa45535
+  - ./bin/build publish aws --image grafana/grafana-enterprise --repo grafana-labs/grafana-enterprise
+    --product 422b46fb-bea6-4f27-8bcc-832117bd627e
   depends_on:
   - fetch-images-enterprise
   environment:
@@ -6437,6 +6437,6 @@ kind: secret
 name: aws_secret_access_key
 ---
 kind: signature
-hmac: d1a975199dd1a46f114f8c6283538fd4b9c3a334a289b16454f362717e06e930
+hmac: c8f9d3463b57b855994905b4ee9645c3562fefb13b150284bc39d70ede21cc33
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -4177,7 +4177,8 @@ volumes:
 ---
 clone:
   retries: 3
-depends_on: []
+depends_on:
+- publish-docker-enterprise-public
 environment:
   EDITION: enterprise2
 image_pull_secrets:
@@ -4199,7 +4200,7 @@ steps:
   image: golang:1.19.3
   name: compile-build-cmd
 - commands:
-  - ./bin/build artifacts docker fetch --edition enterprise2
+  - ./bin/build artifacts docker fetch --edition enterprise
   depends_on:
   - compile-build-cmd
   environment:
@@ -4212,7 +4213,7 @@ steps:
     GCP_KEY:
       from_secret: gcp_key
   image: google/cloud-sdk
-  name: fetch-images-enterprise2
+  name: fetch-images-enterprise
   volumes:
   - name: docker
     path: /var/run/docker.sock
@@ -4220,7 +4221,7 @@ steps:
   - ./bin/build publish aws --image grafana/grafana-enterprise-dev --repo grafana-labs/grafana-enterprise
     --product 1b97f7d0-f274-4cce-b5f4-910dbfa45535
   depends_on:
-  - fetch-images-enterprise2
+  - fetch-images-enterprise
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: aws_access_key_id
@@ -6436,6 +6437,6 @@ kind: secret
 name: aws_secret_access_key
 ---
 kind: signature
-hmac: 2b425ae03e938476aa4ce99fce87474d68d13e76cbb1988cef45b42949b439cf
+hmac: d1a975199dd1a46f114f8c6283538fd4b9c3a334a289b16454f362717e06e930
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -6416,23 +6416,23 @@ name: packages_secret_access_key
 ---
 get:
   name: aws_region
-  path: secret/aws-marketplace
+  path: secret/data/common/aws-marketplace
 kind: secret
 name: aws_region
 ---
 get:
   name: aws_access_key_id
-  path: secret/aws-marketplace
+  path: secret/data/common/aws-marketplace
 kind: secret
 name: aws_access_key_id
 ---
 get:
   name: aws_secret_access_key
-  path: secret/aws-marketplace
+  path: secret/data/common/aws-marketplace
 kind: secret
 name: aws_secret_access_key
 ---
 kind: signature
-hmac: 820cb5f74979902c1674132a46cbc90a98efb23b771faa74cbfda133bfc21df6
+hmac: 1469aed3e12075feb3f8719ca24ccbb462f9e94dec5360af009d5ba6030597d7
 
 ...

--- a/scripts/drone/pipelines/aws_marketplace.star
+++ b/scripts/drone/pipelines/aws_marketplace.star
@@ -1,0 +1,37 @@
+load(
+    'scripts/drone/steps/lib.star',
+    'download_grabpl_step',
+    'publish_images_step',
+    'compile_build_cmd',
+    'fetch_images_step',
+    'publish_image',
+)
+
+load('scripts/drone/vault.star', 'from_secret')
+
+load(
+    'scripts/drone/utils/utils.star',
+    'pipeline',
+)
+
+def publish_aws_marketplace_step():
+    return {
+        'name': 'publish-aws-marketplace',
+        'image': publish_image,
+        'commands': ['./bin/build publish aws --image grafana/grafana-enterprise-dev --repo grafana-labs/grafana-enterprise --product 1b97f7d0-f274-4cce-b5f4-910dbfa45535'],
+        'depends_on': ['fetch-images-enterprise2'],
+        'environment': {
+            'AWS_REGION': from_secret('aws_region'),
+            'AWS_ACCESS_KEY_ID': from_secret('aws_access_key_id'),
+            'AWS_SECRET_ACCESS_KEY': from_secret('aws_secret_access_key'),
+        },
+    }
+
+def publish_aws_marketplace_pipeline(mode):
+    trigger = {
+        'event': ['promote'],
+        'target': [mode],
+    }
+    return [pipeline(
+        name='publish-aws-marketplace-{}'.format(mode), trigger=trigger, steps=[compile_build_cmd(), fetch_images_step('enterprise2'), publish_aws_marketplace_step()], edition="", environment = {'EDITION': 'enterprise2'}
+    ),]

--- a/scripts/drone/pipelines/aws_marketplace.star
+++ b/scripts/drone/pipelines/aws_marketplace.star
@@ -18,7 +18,7 @@ def publish_aws_marketplace_step():
     return {
         'name': 'publish-aws-marketplace',
         'image': publish_image,
-        'commands': ['./bin/build publish aws --image grafana/grafana-enterprise-dev --repo grafana-labs/grafana-enterprise --product 1b97f7d0-f274-4cce-b5f4-910dbfa45535'],
+        'commands': ['./bin/build publish aws --image grafana/grafana-enterprise --repo grafana-labs/grafana-enterprise --product 422b46fb-bea6-4f27-8bcc-832117bd627e'],
         'depends_on': ['fetch-images-enterprise'],
         'environment': {
             'AWS_REGION': from_secret('aws_region'),

--- a/scripts/drone/pipelines/aws_marketplace.star
+++ b/scripts/drone/pipelines/aws_marketplace.star
@@ -18,7 +18,7 @@ def publish_aws_marketplace_step():
     return {
         'name': 'publish-aws-marketplace',
         'image': publish_image,
-        'commands': ['./bin/build publish aws --image grafana/grafana-enterprise --repo grafana-labs/grafana-enterprise --product 422b46fb-bea6-4f27-8bcc-832117bd627e'],
+        'commands': ['./bin/build publish aws --image grafana/grafana-enterprise --repo grafana-labs/grafanaenterprise --product 422b46fb-bea6-4f27-8bcc-832117bd627e'],
         'depends_on': ['fetch-images-enterprise'],
         'environment': {
             'AWS_REGION': from_secret('aws_region'),

--- a/scripts/drone/pipelines/aws_marketplace.star
+++ b/scripts/drone/pipelines/aws_marketplace.star
@@ -34,5 +34,5 @@ def publish_aws_marketplace_pipeline(mode):
         'target': [mode],
     }
     return [pipeline(
-        name='publish-aws-marketplace-{}'.format(mode), trigger=trigger, steps=[compile_build_cmd(), fetch_images_step('enterprise2'), publish_aws_marketplace_step()], edition="", environment = {'EDITION': 'enterprise2'}
+        name='publish-aws-marketplace-{}'.format(mode), trigger=trigger, steps=[compile_build_cmd(), fetch_images_step('enterprise'), publish_aws_marketplace_step()], edition="", environment = {'EDITION': 'enterprise2'}
     ),]

--- a/scripts/drone/pipelines/aws_marketplace.star
+++ b/scripts/drone/pipelines/aws_marketplace.star
@@ -19,7 +19,7 @@ def publish_aws_marketplace_step():
         'name': 'publish-aws-marketplace',
         'image': publish_image,
         'commands': ['./bin/build publish aws --image grafana/grafana-enterprise-dev --repo grafana-labs/grafana-enterprise --product 1b97f7d0-f274-4cce-b5f4-910dbfa45535'],
-        'depends_on': ['fetch-images-enterprise2'],
+        'depends_on': ['fetch-images-enterprise'],
         'environment': {
             'AWS_REGION': from_secret('aws_region'),
             'AWS_ACCESS_KEY_ID': from_secret('aws_access_key_id'),
@@ -34,5 +34,5 @@ def publish_aws_marketplace_pipeline(mode):
         'target': [mode],
     }
     return [pipeline(
-        name='publish-aws-marketplace-{}'.format(mode), trigger=trigger, steps=[compile_build_cmd(), fetch_images_step('enterprise'), publish_aws_marketplace_step()], edition="", environment = {'EDITION': 'enterprise2'}
+        name='publish-aws-marketplace-{}'.format(mode), trigger=trigger, steps=[compile_build_cmd(), fetch_images_step('enterprise'), publish_aws_marketplace_step()], edition="", depends_on = ['publish-docker-enterprise-public'], environment = {'EDITION': 'enterprise2'}
     ),]

--- a/scripts/drone/pipelines/aws_marketplace.star
+++ b/scripts/drone/pipelines/aws_marketplace.star
@@ -25,6 +25,7 @@ def publish_aws_marketplace_step():
             'AWS_ACCESS_KEY_ID': from_secret('aws_access_key_id'),
             'AWS_SECRET_ACCESS_KEY': from_secret('aws_secret_access_key'),
         },
+        'volumes': [{'name': 'docker', 'path': '/var/run/docker.sock'}],
     }
 
 def publish_aws_marketplace_pipeline(mode):

--- a/scripts/drone/vault.star
+++ b/scripts/drone/vault.star
@@ -81,17 +81,17 @@ def secrets():
         ),
         vault_secret(
             'aws_region',
-            'secret/aws-marketplace',
+            'secret/data/common/aws-marketplace',
             'aws_region',
         ),
         vault_secret(
             'aws_access_key_id',
-            'secret/aws-marketplace',
+            'secret/data/common/aws-marketplace',
             'aws_access_key_id',
         ),
         vault_secret(
             'aws_secret_access_key',
-            'secret/aws-marketplace',
+            'secret/data/common/aws-marketplace',
             'aws_secret_access_key',
         ),
     ]

--- a/scripts/drone/vault.star
+++ b/scripts/drone/vault.star
@@ -79,4 +79,19 @@ def secrets():
             'infra/data/ci/packages-publish/bucket-credentials',
             'Secret',
         ),
+        vault_secret(
+            'aws_region',
+            'secret/aws-marketplace',
+            'aws_region',
+        ),
+        vault_secret(
+            'aws_access_key_id',
+            'secret/aws-marketplace',
+            'aws_access_key_id',
+        ),
+        vault_secret(
+            'aws_secret_access_key',
+            'secret/aws-marketplace',
+            'aws_secret_access_key',
+        ),
     ]


### PR DESCRIPTION
**What is this feature?**

Adds automation around AWS marketplace docker image publishing. For every public release, this pipeline should run as a standalone one, depending on the actual enterprise image publishing to DockerHub.

**Special notes for your reviewer**:

Have tested the flow using `grafana/grafana-enterprise-dev` and a testing product number. 

