### PR TITLE
Alerting: Store alertmanager configuration history in a separate table in the database

### DIFF
--- a/pkg/services/ngalert/store/alertmanager.go
+++ b/pkg/services/ngalert/store/alertmanager.go
@@ -6,9 +6,6 @@ import (
 	"fmt"
 	"time"
 
-	"xorm.io/builder"
-	"xorm.io/core"
-
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 )
@@ -31,7 +28,7 @@ func (st *DBstore) GetLatestAlertmanagerConfiguration(ctx context.Context, query
 	return st.SQLStore.WithDbSession(ctx, func(sess *db.Session) error {
 		c := &models.AlertConfiguration{}
 		// The ID is already an auto incremental column, using the ID as an order should guarantee the latest.
-		ok, err := sess.Desc("id").Where("org_id = ?", query.OrgID).Limit(1).Get(c)
+		ok, err := sess.Table("alert_configuration").Where("org_id = ?", query.OrgID).Get(c)
 		if err != nil {
 			return err
 		}
@@ -49,8 +46,7 @@ func (st *DBstore) GetLatestAlertmanagerConfiguration(ctx context.Context, query
 func (st *DBstore) GetAllLatestAlertmanagerConfiguration(ctx context.Context) ([]*models.AlertConfiguration, error) {
 	var result []*models.AlertConfiguration
 	err := st.SQLStore.WithDbSession(ctx, func(sess *db.Session) error {
-		condition := builder.In("id", builder.Select("MAX(id)").From("alert_configuration").GroupBy("org_id"))
-		if err := sess.Table("alert_configuration").Where(condition).Find(&result); err != nil {
+		if err := sess.Table("alert_configuration").Find(&result); err != nil {
 			return err
 		}
 		return nil
@@ -78,10 +74,23 @@ func (st DBstore) SaveAlertmanagerConfigurationWithCallback(ctx context.Context,
 			ConfigurationVersion:      cmd.ConfigurationVersion,
 			Default:                   cmd.Default,
 			OrgID:                     cmd.OrgID,
+			CreatedAt:                 time.Now().Unix(),
 		}
-		if _, err := sess.Insert(config); err != nil {
+		// TODO: If we are more structured around how we seed configurations in the future, this can be a pure update instead of upsert. This should improve perf and code clarity.
+		upsertSQL := st.SQLStore.GetDialect().UpsertSQL(
+			"alert_configuration",
+			[]string{"org_id"},
+			[]string{"alertmanager_configuration", "configuration_version", "created_at", "default", "org_id", "configuration_hash"},
+		)
+		params := append(make([]interface{}, 0), cmd.AlertmanagerConfiguration, cmd.ConfigurationVersion, config.CreatedAt, config.Default, config.OrgID, config.ConfigurationHash)
+		if _, err := sess.SQL(upsertSQL, params...).Query(); err != nil {
 			return err
 		}
+
+		if _, err := sess.Table("alert_configuration_history").Insert(config); err != nil {
+			return err
+		}
+
 		if _, err := st.deleteOldConfigurations(ctx, cmd.OrgID, ConfigRecordsLimit); err != nil {
 			st.Logger.Warn("failed to delete old am configs", "org", cmd.OrgID, "error", err)
 		}
@@ -93,6 +102,7 @@ func (st DBstore) SaveAlertmanagerConfigurationWithCallback(ctx context.Context,
 	})
 }
 
+// UpdateAlertmanagerConfiguration replaces an alertmanager configuration with optimistic locking. It assumes that an existing revision of the configuration exists in the store, and will return an error otherwise.
 func (st *DBstore) UpdateAlertmanagerConfiguration(ctx context.Context, cmd *models.SaveAlertmanagerConfigurationCmd) error {
 	return st.SQLStore.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
 		config := models.AlertConfiguration{
@@ -103,107 +113,23 @@ func (st *DBstore) UpdateAlertmanagerConfiguration(ctx context.Context, cmd *mod
 			OrgID:                     cmd.OrgID,
 			CreatedAt:                 time.Now().Unix(),
 		}
-		res, err := sess.Exec(fmt.Sprintf(getInsertQuery(st.SQLStore.GetDialect().DriverName()), st.SQLStore.GetDialect().Quote("default")),
-			config.AlertmanagerConfiguration,
-			config.ConfigurationHash,
-			config.ConfigurationVersion,
-			config.OrgID,
-			config.CreatedAt,
-			st.SQLStore.GetDialect().BooleanStr(config.Default),
-			cmd.OrgID,
-			cmd.OrgID,
-			cmd.FetchedConfigurationHash,
-		)
-		if err != nil {
-			return err
-		}
-		rows, err := res.RowsAffected()
+		rows, err := sess.Table("alert_configuration").
+			Where("org_id = ? AND configuration_hash = ?", config.OrgID, cmd.FetchedConfigurationHash).
+			Update(config)
 		if err != nil {
 			return err
 		}
 		if rows == 0 {
 			return ErrVersionLockedObjectNotFound
 		}
+		if _, err := sess.Table("alert_configuration_history").Insert(config); err != nil {
+			return err
+		}
 		if _, err := st.deleteOldConfigurations(ctx, cmd.OrgID, ConfigRecordsLimit); err != nil {
 			st.Logger.Warn("failed to delete old am configs", "org", cmd.OrgID, "error", err)
 		}
-		return err
+		return nil
 	})
-}
-
-// getInsertQuery is used to determinate the insert query for the alertmanager config
-// based on the provided sql driver. This is necesarry as such an advanced query
-// is not supported by our ORM and we need to generate it manually for each SQL dialect.
-// We introduced this as part of a bug fix as the old approach wasn't working.
-// Rel: https://github.com/grafana/grafana/issues/51356
-func getInsertQuery(driver string) string {
-	switch driver {
-	case core.MYSQL:
-		return `
-		INSERT INTO alert_configuration
-		(alertmanager_configuration, configuration_hash, configuration_version, org_id, created_at, %s) 
-		SELECT T.* FROM (SELECT ? AS alertmanager_configuration,? AS configuration_hash,? AS configuration_version,? AS org_id,? AS created_at,? AS 'default') AS T
-		WHERE
-		EXISTS (
-			SELECT 1 
-			FROM alert_configuration 
-			WHERE 
-				org_id = ? 
-			AND 
-				id = (SELECT MAX(id) FROM alert_configuration WHERE org_id = ?) 
-			AND 
-				configuration_hash = ?
-		)`
-	case core.POSTGRES:
-		return `
-		INSERT INTO alert_configuration
-		(alertmanager_configuration, configuration_hash, configuration_version, org_id, created_at, %s) 
-		SELECT T.* FROM (VALUES($1,$2,$3,$4::bigint,$5::integer,$6::boolean)) AS T
-		WHERE
-		EXISTS (
-			SELECT 1 
-			FROM alert_configuration 
-			WHERE 
-				org_id = $7 
-			AND 
-				id = (SELECT MAX(id) FROM alert_configuration WHERE org_id = $8::bigint) 
-			AND 
-				configuration_hash = $9
-		)`
-	case core.SQLITE:
-		return `
-		INSERT INTO alert_configuration
-		(alertmanager_configuration, configuration_hash, configuration_version, org_id, created_at, %s) 
-		SELECT T.* FROM (VALUES(?,?,?,?,?,?)) AS T
-		WHERE
-		EXISTS (
-			SELECT 1 
-			FROM alert_configuration 
-			WHERE 
-				org_id = ? 
-			AND 
-				id = (SELECT MAX(id) FROM alert_configuration WHERE org_id = ?) 
-			AND 
-				configuration_hash = ?
-		)`
-	default:
-		// SQLite version
-		return `
-		INSERT INTO alert_configuration
-		(alertmanager_configuration, configuration_hash, configuration_version, org_id, created_at, %s) 
-		SELECT T.* FROM (VALUES(?,?,?,?,?,?)) AS T
-		WHERE
-		EXISTS (
-			SELECT 1 
-			FROM alert_configuration 
-			WHERE 
-				org_id = ? 
-			AND 
-				id = (SELECT MAX(id) FROM alert_configuration WHERE org_id = ?) 
-			AND 
-				configuration_hash = ?
-		)`
-	}
 }
 
 func (st *DBstore) deleteOldConfigurations(ctx context.Context, orgID int64, limit int) (int64, error) {
@@ -218,7 +144,7 @@ func (st *DBstore) deleteOldConfigurations(ctx context.Context, orgID int64, lim
 	var affectedRows int64
 	err := st.SQLStore.WithDbSession(ctx, func(sess *db.Session) error {
 		highest := &models.AlertConfiguration{}
-		ok, err := sess.Desc("id").Where("org_id = ?", orgID).OrderBy("id").Limit(1, limit-1).Get(highest)
+		ok, err := sess.Table("alert_configuration_history").Desc("id").Where("org_id = ?", orgID).OrderBy("id").Limit(1, limit-1).Get(highest)
 		if err != nil {
 			return err
 		}
@@ -237,7 +163,7 @@ func (st *DBstore) deleteOldConfigurations(ctx context.Context, orgID int64, lim
 
 		res, err := sess.Exec(`
 			DELETE FROM 
-				alert_configuration 
+				alert_configuration_history
 			WHERE
 				org_id = ?
 			AND 

--- a/pkg/services/sqlstore/migrations/ualert/tables.go
+++ b/pkg/services/sqlstore/migrations/ualert/tables.go
@@ -346,8 +346,8 @@ func AddAlertmanagerConfigMigrations(mg *migrator.Migrator) {
 		Name: "configuration_hash", Type: migrator.DB_Varchar, Nullable: false, Default: "'not-yet-calculated'", Length: 32,
 	}))
 
-	// TODO: This must be run AFTER we move records to the history table.
-	// TODO: Does this conflict with the add index above? Do we need to drop that one and add this one?
+	ExtractAlertmanagerConfigurationHistoryMigration(mg)
+
 	mg.AddMigration("drop non-unique orgID index", migrator.NewDropIndexMigration(alertConfiguration, &migrator.Index{
 		Cols: []string{"org_id"},
 	}))

--- a/pkg/services/sqlstore/migrations/ualert/tables.go
+++ b/pkg/services/sqlstore/migrations/ualert/tables.go
@@ -345,6 +345,16 @@ func AddAlertmanagerConfigMigrations(mg *migrator.Migrator) {
 	mg.AddMigration("add configuration_hash column to alert_configuration", migrator.NewAddColumnMigration(alertConfiguration, &migrator.Column{
 		Name: "configuration_hash", Type: migrator.DB_Varchar, Nullable: false, Default: "'not-yet-calculated'", Length: 32,
 	}))
+
+	// TODO: This must be run AFTER we move records to the history table.
+	// TODO: Does this conflict with the add index above? Do we need to drop that one and add this one?
+	mg.AddMigration("drop non-unique orgID index", migrator.NewDropIndexMigration(alertConfiguration, &migrator.Index{
+		Cols: []string{"org_id"},
+	}))
+	mg.AddMigration("add unique index on orgID", migrator.NewAddIndexMigration(alertConfiguration, &migrator.Index{
+		Type: migrator.UniqueIndex,
+		Cols: []string{"org_id"},
+	}))
 }
 
 func AddAlertmanagerConfigHistoryMigrations(mg *migrator.Migrator) {

--- a/pkg/services/sqlstore/migrations/ualert/tables.go
+++ b/pkg/services/sqlstore/migrations/ualert/tables.go
@@ -23,8 +23,6 @@ func AddTablesMigrations(mg *migrator.Migrator) {
 	AddAlertRuleMigrations(mg, 60)
 	AddAlertRuleVersionMigrations(mg)
 
-	AddAlertmanagerConfigHistoryMigrations(mg)
-
 	// Create Alertmanager configurations
 	AddAlertmanagerConfigMigrations(mg)
 
@@ -35,6 +33,11 @@ func AddTablesMigrations(mg *migrator.Migrator) {
 	AddProvisioningMigrations(mg)
 
 	AddAlertImageMigrations(mg)
+
+	AddAlertmanagerConfigHistoryMigrations(mg)
+	ExtractAlertmanagerConfigurationHistoryMigration(mg)
+	mg.AddMigration("drop non-unique orgID index", migrator.NewDropIndexMigration(migrator.Table{Name: "alert_configuration"}, &migrator.Index{Cols: []string{"org_id"}}))
+	mg.AddMigration("add unique index on orgID", migrator.NewAddIndexMigration(migrator.Table{Name: "alert_configuration"}, &migrator.Index{Type: migrator.UniqueIndex, Cols: []string{"org_id"}}))
 }
 
 // AddAlertDefinitionMigrations should not be modified.
@@ -344,16 +347,6 @@ func AddAlertmanagerConfigMigrations(mg *migrator.Migrator) {
 
 	mg.AddMigration("add configuration_hash column to alert_configuration", migrator.NewAddColumnMigration(alertConfiguration, &migrator.Column{
 		Name: "configuration_hash", Type: migrator.DB_Varchar, Nullable: false, Default: "'not-yet-calculated'", Length: 32,
-	}))
-
-	ExtractAlertmanagerConfigurationHistoryMigration(mg)
-
-	mg.AddMigration("drop non-unique orgID index", migrator.NewDropIndexMigration(alertConfiguration, &migrator.Index{
-		Cols: []string{"org_id"},
-	}))
-	mg.AddMigration("add unique index on orgID", migrator.NewAddIndexMigration(alertConfiguration, &migrator.Index{
-		Type: migrator.UniqueIndex,
-		Cols: []string{"org_id"},
 	}))
 }
 

--- a/pkg/services/sqlstore/migrations/ualert/tables.go
+++ b/pkg/services/sqlstore/migrations/ualert/tables.go
@@ -23,6 +23,8 @@ func AddTablesMigrations(mg *migrator.Migrator) {
 	AddAlertRuleMigrations(mg, 60)
 	AddAlertRuleVersionMigrations(mg)
 
+	AddAlertmanagerConfigHistoryMigrations(mg)
+
 	// Create Alertmanager configurations
 	AddAlertmanagerConfigMigrations(mg)
 
@@ -33,8 +35,6 @@ func AddTablesMigrations(mg *migrator.Migrator) {
 	AddProvisioningMigrations(mg)
 
 	AddAlertImageMigrations(mg)
-
-	AddAlertmanagerConfigHistoryMigrations(mg)
 }
 
 // AddAlertDefinitionMigrations should not be modified.

--- a/pkg/services/sqlstore/migrations/ualert/tables.go
+++ b/pkg/services/sqlstore/migrations/ualert/tables.go
@@ -36,8 +36,6 @@ func AddTablesMigrations(mg *migrator.Migrator) {
 
 	AddAlertmanagerConfigHistoryMigrations(mg)
 	ExtractAlertmanagerConfigurationHistoryMigration(mg)
-	mg.AddMigration("drop non-unique orgID index", migrator.NewDropIndexMigration(migrator.Table{Name: "alert_configuration"}, &migrator.Index{Cols: []string{"org_id"}}))
-	mg.AddMigration("add unique index on orgID", migrator.NewAddIndexMigration(migrator.Table{Name: "alert_configuration"}, &migrator.Index{Type: migrator.UniqueIndex, Cols: []string{"org_id"}}))
 }
 
 // AddAlertDefinitionMigrations should not be modified.

--- a/pkg/services/sqlstore/migrations/ualert/ualert.go
+++ b/pkg/services/sqlstore/migrations/ualert/ualert.go
@@ -988,8 +988,8 @@ func (c extractAlertmanagerConfigurationHistory) Exec(sess *xorm.Session, migrat
 		}
 
 		// Set the IDs back to the default, so XORM will ignore the field and auto-assign them.
-		for _, h := range history {
-			h.ID = 0
+		for i := range history {
+			history[i].ID = 0
 		}
 
 		_, err = sess.Table("alert_configuration_history").InsertMulti(history)

--- a/pkg/services/sqlstore/migrations/ualert/ualert.go
+++ b/pkg/services/sqlstore/migrations/ualert/ualert.go
@@ -948,10 +948,13 @@ func (c extractAlertmanagerConfigurationHistory) Exec(sess *xorm.Session, migrat
 	if err := sess.Table("alert_configuration").Distinct("org_id").Find(&orgs); err != nil {
 		return fmt.Errorf("failed to retrieve the organizations with alerting configurations: %w", err)
 	}
+
+	// Quote the column called "default" because it's a reserved keyword in SQL.
+	fields := fmt.Sprintf("org_id, alertmanager_configuration, configuration_hash, configuration_version, created_at, %s", migrator.Dialect.Quote("default"))
 	for _, orgID := range orgs {
 		_, err := sess.Exec(`
-			INSERT INTO alert_configuration_history (org_id, alertmanager_configuration, configuration_hash, configuration_version, created_at, default)
-			SELECT org_id, alertmanager_configuration, configuration_hash, configuration_version, created_at, default
+			INSERT INTO alert_configuration_history (`+fields+`)
+			SELECT `+fields+`
 			FROM alert_configuration
 			WHERE org_id = ? AND id != (SELECT MAX(id) FROM alert_configuration WHERE org_id = ?)`,
 			orgID, orgID)

--- a/pkg/services/sqlstore/migrations/ualert/ualert.go
+++ b/pkg/services/sqlstore/migrations/ualert/ualert.go
@@ -932,7 +932,6 @@ func ExtractAlertmanagerConfigurationHistoryMigration(mg *migrator.Migrator) {
 	if !mg.Cfg.UnifiedAlerting.IsEnabled() {
 		return
 	}
-	// TODO: Re-fix-up indexes.
 	// Since it's not always consistent as to what state the org ID indexes are in, just drop them all and rebuild from scratch.
 	// This is not expensive since this table is guaranteed to have a small number of rows.
 	mg.AddMigration("drop non-unique orgID index on alert_configuration", migrator.NewDropIndexMigration(migrator.Table{Name: "alert_configuration"}, &migrator.Index{Cols: []string{"org_id"}}))

--- a/pkg/services/sqlstore/migrations/ualert/ualert.go
+++ b/pkg/services/sqlstore/migrations/ualert/ualert.go
@@ -953,6 +953,10 @@ func (c extractAlertmanagerConfigurationHistory) Exec(sess *xorm.Session, migrat
 		if err != nil {
 			return fmt.Errorf("failed to move old configurations to history table: %w", err)
 		}
+		_, err = sess.Exec("DELETE FROM alert_configuration WHERE org_id = ? AND id != (SELECT MAX(id) FROM alert_configuration WHERE org_id = ?)", orgID, orgID)
+		if err != nil {
+			return fmt.Errorf("failed to evict old configurations after moving to history table: %w", err)
+		}
 	}
 	return nil
 }

--- a/pkg/services/sqlstore/migrations/ualert/ualert.go
+++ b/pkg/services/sqlstore/migrations/ualert/ualert.go
@@ -927,3 +927,32 @@ func (s *uidSet) generateUid() (string, error) {
 
 	return "", errors.New("failed to generate UID")
 }
+
+func ExtractAlertmanagerConfigurationHistoryMigration(mg *migrator.Migrator) {
+	if !mg.Cfg.UnifiedAlerting.IsEnabled() {
+		return
+	}
+	mg.AddMigration("extract alertmanager configuration history to separate table", &extractAlertmanagerConfigurationHistory{})
+}
+
+type extractAlertmanagerConfigurationHistory struct {
+	migrator.MigrationBase
+}
+
+func (c extractAlertmanagerConfigurationHistory) SQL(migrator.Dialect) string {
+	return codeMigration
+}
+
+func (c extractAlertmanagerConfigurationHistory) Exec(sess *xorm.Session, migrator *migrator.Migrator) error {
+	var orgs []int64
+	if err := sess.Table("alert_configuration").Distinct("org_id").Find(&orgs); err != nil {
+		return fmt.Errorf("failed to retrieve the organizations with alerting configurations: %w", err)
+	}
+	for _, orgID := range orgs {
+		_, err := sess.Exec("INSERT INTO alert_configuration_history SELECT * FROM alert_configuration WHERE org_id = ? AND id != (SELECT MAX(id) FROM alert_configuration WHERE org_id = ?)", orgID, orgID)
+		if err != nil {
+			return fmt.Errorf("failed to move old configurations to history table: %w", err)
+		}
+	}
+	return nil
+}

--- a/pkg/services/sqlstore/migrations/ualert/ualert.go
+++ b/pkg/services/sqlstore/migrations/ualert/ualert.go
@@ -949,7 +949,12 @@ func (c extractAlertmanagerConfigurationHistory) Exec(sess *xorm.Session, migrat
 		return fmt.Errorf("failed to retrieve the organizations with alerting configurations: %w", err)
 	}
 	for _, orgID := range orgs {
-		_, err := sess.Exec("INSERT INTO alert_configuration_history SELECT * FROM alert_configuration WHERE org_id = ? AND id != (SELECT MAX(id) FROM alert_configuration WHERE org_id = ?)", orgID, orgID)
+		_, err := sess.Exec(`
+			INSERT INTO alert_configuration_history (org_id, alertmanager_configuration, configuration_hash, configuration_version, created_at, default)
+			SELECT org_id, alertmanager_configuration, configuration_hash, configuration_version, created_at, default
+			FROM alert_configuration
+			WHERE org_id = ? AND id != (SELECT MAX(id) FROM alert_configuration WHERE org_id = ?)`,
+			orgID, orgID)
 		if err != nil {
 			return fmt.Errorf("failed to move old configurations to history table: %w", err)
 		}


### PR DESCRIPTION
**What is this feature?**

Instead of storing all (both active and historical) configurations in the same table, we now store the active configurations in a separate table from the historical ones.

**Why do we need this feature?**

This drastically simplifies the SQL required to manage configurations. This fixes a couple existing bugs, and would have prevented others from happening.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/59845
Contributes https://github.com/grafana/grafana/issues/60053

**Special notes for your reviewer**:

I decided to revert the original attempt at this. The migration ran into a known issue in MySQL where if a certain query optimization was applied, the query would fail, so it failed on a subset of mysql environments.

https://github.com/grafana/grafana/pull/60197

This PR is exactly the same, except for the migration. The migration logic has been re-implemented in Golang instead of SQL, and now uses only extremely trivial SQL commands, issued through the ORM where possible.

I'm performing the same test suite as before, on it. So far, everything is working well. Posting now