### PR TITLE
Alerting: Prevent uid collision in migration when db is case-insensitive

### DIFF
--- a/pkg/services/sqlstore/migrations/ualert/testing.go
+++ b/pkg/services/sqlstore/migrations/ualert/testing.go
@@ -16,6 +16,8 @@ func newTestMigration(t *testing.T) *migration {
 
 			Logger: log.New("test"),
 		},
-		seenChannelUIDs: make(map[string]struct{}),
+		seenUIDs: uidSet{
+			set: make(map[string]struct{}),
+		},
 	}
 }

--- a/pkg/services/sqlstore/migrations/ualert/ualert.go
+++ b/pkg/services/sqlstore/migrations/ualert/ualert.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -74,8 +75,9 @@ func AddDashAlertMigration(mg *migrator.Migrator) {
 			mg.Logger.Error("alert migration error: could not clear alert migration for removing data", "error", err)
 		}
 		mg.AddMigration(migTitle, &migration{
-			seenChannelUIDs: make(map[string]struct{}),
-			silences:        make(map[int64][]*pb.MeshSilence),
+			// We deduplicate for case-insensitive matching in MySQL-compatible backend flavours because they use case-insensitive collation.
+			seenUIDs: uidSet{set: make(map[string]struct{}), caseInsensitive: mg.Dialect.SupportEngine()},
+			silences: make(map[int64][]*pb.MeshSilence),
 		})
 	// If unified alerting is disabled and upgrade migration has been run
 	case !mg.Cfg.UnifiedAlerting.IsEnabled() && migrationRun:
@@ -226,8 +228,8 @@ type migration struct {
 	sess *xorm.Session
 	mg   *migrator.Migrator
 
-	seenChannelUIDs map[string]struct{}
-	silences        map[int64][]*pb.MeshSilence
+	seenUIDs uidSet
+	silences map[int64][]*pb.MeshSilence
 }
 
 func (m *migration) SQL(dialect migrator.Dialect) string {
@@ -882,4 +884,46 @@ func (c updateRulesOrderInGroup) Exec(sess *xorm.Session, migrator *migrator.Mig
 		return fmt.Errorf("unable to update alert rules with group index: %w", err)
 	}
 	return nil
+}
+
+// uidSet is a wrapper around map[string]struct{} and util.GenerateShortUID() which aims help generate uids in quick
+// succession while taking into consideration case sensitivity requirements. if caseInsensitive is true, all generated
+// uids must also be unique when compared in a case-insensitive manner.
+type uidSet struct {
+	set             map[string]struct{}
+	caseInsensitive bool
+}
+
+// contains checks whether the given uid has already been generated in this uidSet.
+func (s *uidSet) contains(uid string) bool {
+	dedup := uid
+	if s.caseInsensitive {
+		dedup = strings.ToLower(dedup)
+	}
+	_, seen := s.set[dedup]
+	return seen
+}
+
+// add adds the given uid to the uidSet.
+func (s *uidSet) add(uid string) {
+	dedup := uid
+	if s.caseInsensitive {
+		dedup = strings.ToLower(dedup)
+	}
+	s.set[dedup] = struct{}{}
+}
+
+// generateUid will generate a new unique uid that is not already contained in the uidSet.
+// If it fails to create one that has not already been generated it will make multiple, but not unlimited, attempts.
+// If all attempts are exhausted an error will be returned.
+func (s *uidSet) generateUid() (string, error) {
+	for i := 0; i < 5; i++ {
+		gen := util.GenerateShortUID()
+		if !s.contains(gen) {
+			s.add(gen)
+			return gen, nil
+		}
+	}
+
+	return "", errors.New("failed to generate UID")
 }

--- a/pkg/services/sqlstore/migrations/ualert/ualert_test.go
+++ b/pkg/services/sqlstore/migrations/ualert/ualert_test.go
@@ -175,7 +175,6 @@ func Test_getAlertFolderNameFromDashboard(t *testing.T) {
 }
 
 func Test_shortUIDCaseInsensitiveConflicts(t *testing.T) {
-	// Note: Because of the nature of this test, if it's flaky it could be because of an issue in uid generation not necessarily a faulty test.
 	s := uidSet{
 		set:             make(map[string]struct{}),
 		caseInsensitive: true,


### PR DESCRIPTION
**What is this feature?**

This improves our duplicate uid detection during legacy migration to include checking for case-insensitive duplicates.

**Why do we need this feature?**

Two factors come into play that cause sporadic uid conflicts during legacy alert migration:
- MySQL and MySQL-compatible backends use case-insensitive collation.
- Our short uid generator is not a uniform RNG and generates uids in such a way that generations in quick succession have a higher probability of creating similar uids.

Normally we would be guaranteed unique short uid generation, however if the source alphabet contains duplicate characters (for example, if we use case-insensitive comparison) this guarantee is void.

Generating even ~1000 uids in quick succession is nearly guaranteed to create a case-insensitive duplicate.

**Which issue(s) does this PR fix?**:

Fixes #54680
