### PR TITLE
RelativeTimeRangePicker: Don't respond to submit event when nested in a form element

### DIFF
--- a/packages/grafana-ui/src/components/DateTimePickers/RelativeTimeRangePicker/RelativeTimeRangePicker.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/RelativeTimeRangePicker/RelativeTimeRangePicker.tsx
@@ -103,7 +103,7 @@ export function RelativeTimeRangePicker(props: RelativeTimeRangePickerProps) {
 
   return (
     <div className={styles.container} ref={setMarkerElement}>
-      <button className={styles.pickerInput} onClick={onOpen}>
+      <button className={styles.pickerInput} type="button" onClick={onOpen}>
         <span className={styles.clockIcon}>
           <Icon name="clock-nine" />
         </span>


### PR DESCRIPTION
**What is this feature?**

Fixes a small bug / regression in https://github.com/grafana/grafana/pull/60016

Prevents a submit action (enter button press) from opening the relative time range picker when nested in a form.

**Video demonstrating the problem**
https://user-images.githubusercontent.com/868844/208256415-a937387b-4c69-4826-a60c-0a3541a4cf66.mp4


