### PR TITLE
kindsys: Move code ownership of CustomStructured to apps platform team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -237,6 +237,7 @@ lerna.json @grafana/frontend-ops
 embed.go @grafana/grafana-as-code
 /kinds/ @grafana/grafana-as-code
 /pkg/codegen @grafana/grafana-as-code
+/pkg/kindsys/kindcat_custom.cue @grafana/apps-platform-core
 /pkg/kindsys @grafana/grafana-as-code
 /pkg/kinds/*/*_gen.go @grafana/grafana-as-code
 /pkg/registry/corekind @grafana/grafana-as-code

--- a/pkg/kindsys/kindcat_custom.cue
+++ b/pkg/kindsys/kindcat_custom.cue
@@ -1,0 +1,15 @@
+package kindsys
+
+// CustomStructured specifies the Kind category for plugin-defined arbitrary types.
+// Custom kinds have the same purpose as CoreStructured kinds, differing only in
+// that they are declared by external plugins rather than in Grafana core. As such,
+// this specification is kept closely aligned with the CoreStructured kind.
+//
+// Grafana provides Kubernetes apiserver-shaped APIs for interacting with custom kinds -
+// The same API patterns (and clients) used to interact with CustomResources.
+#CustomStructured: {
+	#Structured
+
+	lineageIsGroup: false
+	...
+}

--- a/pkg/kindsys/kindcats.cue
+++ b/pkg/kindsys/kindcats.cue
@@ -121,14 +121,6 @@ _sharedKind: {
 }
 
 // TODO
-#CustomStructured: {
-	#Structured
-
-	lineageIsGroup: false
-	...
-}
-
-// TODO
 #CoreStructured: {
 	#Structured
 


### PR DESCRIPTION
**What is this feature?**

This PR separates the declaration of `#CustomStructured` into a separate file, and grants ownership of it to @grafana/apps-platform-core . 

**Why do we need this feature?**

As with all the kind categories, this specification is a contract. And all such contracts have at least two sides - producers and consumers.

Because `#CustomStructured` is specifically for defining kinds in plugins, not in Grafana core, it means that Grafana itself solely sits on the consumer side of the contract. And custom kinds will be kept similar enough to core kinds that little additional machinery beyond what we already have for `#CoreStructured` will be needed within Grafana's backend to support them.

The grafana-app-sdk (not yet public) is the primary toolkit we expect to use for allowing plugin authors to create custom kinds - the producer side. It is responsible for doing the equivalent of, for example, [the code generation pipeline in `kinds/gen.go`](https://github.com/grafana/grafana/blob/92d12fdefaf990358f8c7a23f185e6d95ba1dfd0/kinds/gen.go). (And lots more)

It still makes sense to keep the declaration of `#CustomStructured` within kindsys. The Grafana backend does need it, and it would be considerably more challenging to keep the core and custom kind specs tightly aligned if they didn't live in the same repo. So, as @grafana/apps-platform-core are the owners of the app SDK, that makes them the right choice for ownership over this part of the spec.