### PR TITLE
Explore: Re-initialize graph when number of series to show changes

### DIFF
--- a/public/app/features/explore/Graph/ExploreGraph.tsx
+++ b/public/app/features/explore/Graph/ExploreGraph.tsx
@@ -120,10 +120,12 @@ export function ExploreGraph({
     });
   }, [fieldConfigRegistry, data, timeZone, theme, styledFieldConfig]);
 
+  const seriesToShow = showAllTimeSeries ? dataWithConfig : dataWithConfig.slice(0, MAX_NUMBER_OF_TIME_SERIES);
+
   // We need to increment structureRev when the number of series changes.
   // the function passed to useMemo runs during rendering, so when we get a different
   // amount of data, structureRev is incremented before we render it
-  useMemo(inc, [dataWithConfig.length, styledFieldConfig, inc]);
+  useMemo(inc, [dataWithConfig.length, styledFieldConfig, seriesToShow.length, inc]);
 
   useEffect(() => {
     if (onHiddenSeriesChanged) {
@@ -137,8 +139,6 @@ export function ExploreGraph({
       onHiddenSeriesChanged(hiddenFrames);
     }
   }, [dataWithConfig, onHiddenSeriesChanged]);
-
-  const seriesToShow = showAllTimeSeries ? dataWithConfig : dataWithConfig.slice(0, MAX_NUMBER_OF_TIME_SERIES);
 
   const panelContext: PanelContext = {
     eventBus,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

https://github.com/grafana/grafana/pull/57906 optimized explore graph by avoiding re-initialization when not needed, however it introduced a bug which resulted in the graph not displaying all the series after clicking on the "Show all" button when more than 20 series were returned by queries as reported in https://github.com/grafana/grafana/issues/59994.

This PR fixes that by taking into account also the number of series to show when incrementing the structure rev.


Fixes #59994


