### PR TITLE
SQLStore: Add test for nested transactions events

### DIFF
--- a/pkg/services/sqlstore/session.go
+++ b/pkg/services/sqlstore/session.go
@@ -63,7 +63,7 @@ func startSessionOrUseExisting(ctx context.Context, engine *xorm.Engine, beginTr
 
 // WithDbSession calls the callback with the session in the context (if exists).
 // Otherwise it creates a new one that is closed upon completion.
-// A session is stored in the context if sqlstore.InTransaction() has been been previously called with the same context (and it's not committed/rolledback yet).
+// A session is stored in the context if sqlstore.InTransaction() has been previously called with the same context (and it's not committed/rolledback yet).
 // In case of sqlite3.ErrLocked or sqlite3.ErrBusy failure it will be retried at most five times before giving up.
 func (ss *SQLStore) WithDbSession(ctx context.Context, callback DBTransactionFunc) error {
 	return ss.withDbSession(ctx, ss.engine, callback)

--- a/pkg/services/sqlstore/transactions.go
+++ b/pkg/services/sqlstore/transactions.go
@@ -80,11 +80,9 @@ func (ss *SQLStore) inTransactionWithRetryCtx(ctx context.Context, engine *xorm.
 		return err
 	}
 
-	if len(sess.events) > 0 {
-		for _, e := range sess.events {
-			if err = bus.Publish(ctx, e); err != nil {
-				ctxLogger.Error("Failed to publish event after commit.", "error", err)
-			}
+	for _, e := range sess.events {
+		if err = bus.Publish(ctx, e); err != nil {
+			ctxLogger.Error("Failed to publish event after commit.", "error", err)
 		}
 	}
 

--- a/pkg/services/sqlstore/transactions_test.go
+++ b/pkg/services/sqlstore/transactions_test.go
@@ -3,7 +3,6 @@ package sqlstore
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -81,7 +80,7 @@ func TestIntegrationPublishAfterCommitWithNestedTransactions(t *testing.T) {
 	var xHasSucceeded bool
 	ss.Bus().AddEventListener(func(ctx context.Context, e *X) error {
 		xHasSucceeded = true
-		fmt.Printf("Succeeded and committed: %T\n", e)
+		t.Logf("Succeeded and committed: %T\n", e)
 		return nil
 	})
 
@@ -89,21 +88,21 @@ func TestIntegrationPublishAfterCommitWithNestedTransactions(t *testing.T) {
 	var yHasSucceeded bool
 	ss.Bus().AddEventListener(func(ctx context.Context, e *Y) error {
 		yHasSucceeded = true
-		fmt.Printf("Succeeded and committed: %T\n", e)
+		t.Log("Succeeded and committed: %T\n", e)
 		return nil
 	})
 
 	err := ss.WithTransactionalDbSession(ctx, func(sess *DBSession) error {
-		fmt.Println("Outer transaction: doing X... success!")
+		t.Logf("Outer transaction: doing X... success!")
 		sess.PublishAfterCommit(&X{})
 
 		ss.InTransaction(ctx, func(ctx context.Context) error {
-			fmt.Println("Inner transaction: doing Y... success!")
+			t.Log("Inner transaction: doing Y... success!")
 			sess.PublishAfterCommit(&Y{})
 			return nil
 		})
 
-		fmt.Println("Outer transaction: doing Z... failure, rolling back...")
+		t.Log("Outer transaction: doing Z... failure, rolling back...")
 		return errors.New("z failed")
 	})
 


### PR DESCRIPTION
**What is this feature?**

Go integration (DB) test to proof that registered events to be published after commit (within transactions) behave as expected (no event is published until the outer-most transaction is committed).

**Why do we need this feature?**

To add more test coverage? 🤔  It basically tests [these few lines](https://github.com/grafana/grafana/blob/main/pkg/services/sqlstore/transactions.go#L55-L59). 

**Who is this feature for?**

Honestly, I'm even not sure if we want to maintain the `PublishAfterCommit` feature in the long term, AND I know this isn't the most beautiful code in the world, but I was looking at this code while debugging/reasoning about [this](https://github.com/grafana/support-escalations/issues/4467#issuecomment-1353258901) and I thought it could worth adding it into our test suite instead of just discarding these few lines of code I wrote.  

However, I'm completely fine with closing this pull request as well, just wanted to share in case it makes sense for you.

**Which issue(s) does this PR fix?**:

_No issue related_

**Special notes for your reviewer**:

It also contains a small typo fix in a comment and removes a not needed conditional statement (note the `for... range` loop would only iterate when `len(sess.events) > 0` anyway.