### PR TITLE
Chore: remove various type assertions in Explore

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -3739,17 +3739,6 @@ exports[`better eslint`] = {
     "public/app/features/explore/ElapsedTime.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
-    "public/app/features/explore/Explore.test.tsx:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
-    ],
-    "public/app/features/explore/ExplorePaneContainer.tsx:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"]
-    ],
-    "public/app/features/explore/ExploreQueryInspector.test.tsx:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "2"]
-    ],
     "public/app/features/explore/ExploreQueryInspector.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
@@ -3765,16 +3754,11 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
     "public/app/features/explore/NodeGraphContainer.test.tsx:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "2"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
     "public/app/features/explore/QueryRows.test.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
-    ],
-    "public/app/features/explore/ResponseErrorContainer.test.tsx:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
     "public/app/features/explore/RichHistory/RichHistory.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
@@ -3783,26 +3767,18 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
     "public/app/features/explore/TableContainer.test.tsx:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
     "public/app/features/explore/TraceView/TraceView.test.tsx:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "3"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "4"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "5"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
     "public/app/features/explore/TraceView/TraceView.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"],
       [0, 0, 0, "Do not use any type assertions.", "2"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "3"],
-      [0, 0, 0, "Do not use any type assertions.", "4"],
-      [0, 0, 0, "Do not use any type assertions.", "5"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "6"],
-      [0, 0, 0, "Do not use any type assertions.", "7"]
+      [0, 0, 0, "Do not use any type assertions.", "3"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "4"],
+      [0, 0, 0, "Do not use any type assertions.", "5"]
     ],
     "public/app/features/explore/TraceView/createSpanLink.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
@@ -3813,15 +3789,10 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "5"],
       [0, 0, 0, "Do not use any type assertions.", "6"],
       [0, 0, 0, "Do not use any type assertions.", "7"],
-      [0, 0, 0, "Do not use any type assertions.", "8"],
-      [0, 0, 0, "Do not use any type assertions.", "9"]
+      [0, 0, 0, "Do not use any type assertions.", "8"]
     ],
     "public/app/features/explore/Wrapper.test.tsx:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "3"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "4"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
     "public/app/features/explore/spec/helper/setup.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
@@ -3830,8 +3801,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "3"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "4"],
       [0, 0, 0, "Do not use any type assertions.", "5"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "6"],
-      [0, 0, 0, "Do not use any type assertions.", "7"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "6"]
     ],
     "public/app/features/explore/spec/interpolation.test.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
@@ -3846,19 +3816,8 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "3"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "4"]
     ],
-    "public/app/features/explore/state/helpers.ts:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
-      [0, 0, 0, "Do not use any type assertions.", "2"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "3"]
-    ],
     "public/app/features/explore/state/main.test.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
-    ],
-    "public/app/features/explore/state/main.ts:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"],
-      [0, 0, 0, "Do not use any type assertions.", "1"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "2"]
     ],
     "public/app/features/explore/state/query.test.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
@@ -3871,9 +3830,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "7"]
     ],
     "public/app/features/explore/state/time.test.ts:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "2"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
     "public/app/features/explore/state/utils.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],

--- a/public/app/features/explore/Explore.test.tsx
+++ b/public/app/features/explore/Explore.test.tsx
@@ -82,7 +82,7 @@ const dummyProps: Props = {
   showTrace: true,
   showNodeGraph: true,
   showFlameGraph: true,
-  splitOpen: (() => {}) as any,
+  splitOpen: () => {},
   splitted: false,
   isFromCompactUrl: false,
   eventBus: new EventBusSrv(),

--- a/public/app/features/explore/ExplorePaneContainer.tsx
+++ b/public/app/features/explore/ExplorePaneContainer.tsx
@@ -3,7 +3,7 @@ import memoizeOne from 'memoize-one';
 import React from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 
-import { ExploreUrlState, EventBusExtended, EventBusSrv, GrafanaTheme2, EventBus } from '@grafana/data';
+import { EventBusExtended, EventBusSrv, GrafanaTheme2, EventBus } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { reportInteraction } from '@grafana/runtime';
 import { Themeable2, withTheme2 } from '@grafana/ui';
@@ -174,7 +174,7 @@ function mapStateToProps(state: StoreState, props: OwnProps) {
   const timeZone = getTimeZone(state.user);
   const fiscalYearStartMonth = getFiscalYearStartMonth(state.user);
 
-  const { datasource, queries, range: urlRange, panelsState } = (urlState || {}) as ExploreUrlState;
+  const { datasource, queries, range: urlRange, panelsState } = urlState || {};
   const initialDatasource = datasource || store.get(lastUsedDatasourceKeyForOrgId(state.user.orgId));
   const initialRange = urlRange
     ? getTimeRangeFromUrlMemoized(urlRange, timeZone, fiscalYearStartMonth)

--- a/public/app/features/explore/ExploreQueryInspector.test.tsx
+++ b/public/app/features/explore/ExploreQueryInspector.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import React, { ComponentProps } from 'react';
 import { Observable } from 'rxjs';
 
-import { TimeRange, LoadingState, InternalTimeZones } from '@grafana/data';
+import { LoadingState, InternalTimeZones, getDefaultTimeRange } from '@grafana/data';
 import { ExploreId } from 'app/types';
 
 import { ExploreQueryInspector } from './ExploreQueryInspector';
@@ -19,7 +19,7 @@ jest.mock('app/core/services/backend_srv', () => ({
       new Observable((subscriber) => {
         subscriber.next(response());
         subscriber.next(response(true));
-      }) as any,
+      }),
   },
 }));
 
@@ -44,7 +44,7 @@ const setup = (propOverrides = {}) => {
     queryResponse: {
       state: LoadingState.Done,
       series: [],
-      timeRange: {} as TimeRange,
+      timeRange: getDefaultTimeRange(),
       graphFrames: [],
       logsFrames: [],
       tableFrames: [],
@@ -87,11 +87,11 @@ const response = (hideFromInspector = false) => ({
   status: 1,
   statusText: '',
   ok: true,
-  headers: {} as any,
+  headers: {},
   redirected: false,
   type: 'basic',
   url: '',
-  request: {} as any,
+  request: {},
   data: {
     test: {
       testKey: 'Very unique test value',

--- a/public/app/features/explore/NodeGraphContainer.test.tsx
+++ b/public/app/features/explore/NodeGraphContainer.test.tsx
@@ -14,7 +14,7 @@ describe('NodeGraphContainer', () => {
         dataFrames={[emptyFrame]}
         exploreId={ExploreId.left}
         range={getDefaultTimeRange()}
-        splitOpenFn={(() => {}) as any}
+        splitOpenFn={() => {}}
         withTraceView={true}
         datasourceType={''}
       />
@@ -30,7 +30,7 @@ describe('NodeGraphContainer', () => {
         dataFrames={[nodes]}
         exploreId={ExploreId.left}
         range={getDefaultTimeRange()}
-        splitOpenFn={(() => {}) as any}
+        splitOpenFn={() => {}}
         datasourceType={''}
       />
     );

--- a/public/app/features/explore/ResponseErrorContainer.test.tsx
+++ b/public/app/features/explore/ResponseErrorContainer.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { Provider } from 'react-redux';
 
-import { DataQueryError, LoadingState } from '@grafana/data';
+import { DataQueryError, LoadingState, getDefaultTimeRange } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 
 import { configureStore } from '../../store/configureStore';
@@ -47,7 +47,7 @@ describe('ResponseErrorContainer', () => {
 function setup(error: DataQueryError) {
   const store = configureStore();
   store.getState().explore[ExploreId.left].queryResponse = {
-    timeRange: {} as any,
+    timeRange: getDefaultTimeRange(),
     series: [],
     state: LoadingState.Error,
     error,

--- a/public/app/features/explore/TableContainer.test.tsx
+++ b/public/app/features/explore/TableContainer.test.tsx
@@ -48,12 +48,12 @@ const dataFrame = toDataFrame({
 });
 
 const defaultProps = {
-  exploreId: ExploreId.left as ExploreId,
+  exploreId: ExploreId.left,
   loading: false,
   width: 800,
   onCellFilterAdded: jest.fn(),
   tableResult: [dataFrame],
-  splitOpenFn: (() => {}) as any,
+  splitOpenFn: () => {},
   range: {} as any,
   timeZone: InternalTimeZones.utc,
 };
@@ -73,13 +73,13 @@ describe('TableContainer', () => {
   });
 
   it('should render 0 series returned on no items', () => {
-    const emptyFrames = [
+    const emptyFrames: DataFrame[] = [
       {
         name: 'TableResultName',
         fields: [],
         length: 0,
       },
-    ] as DataFrame[];
+    ];
     render(<TableContainer {...defaultProps} tableResult={emptyFrames} />);
     expect(screen.getByText('0 series returned')).toBeInTheDocument();
   });

--- a/public/app/features/explore/TraceView/TraceView.test.tsx
+++ b/public/app/features/explore/TraceView/TraceView.test.tsx
@@ -157,7 +157,7 @@ const response: TraceData & { spans: TraceSpanData[] } = {
       spanID: '1ed38015486087ca',
       flags: 1,
       operationName: 'HTTP POST - api_prom_push',
-      references: [] as any,
+      references: [],
       startTime: 1585244579835187,
       duration: 1098,
       tags: [
@@ -191,7 +191,7 @@ const response: TraceData & { spans: TraceSpanData[] } = {
         },
       ],
       processID: '1ed38015486087ca',
-      warnings: null as any,
+      warnings: null,
     },
     {
       traceID: '1ed38015486087ca',
@@ -223,9 +223,9 @@ const response: TraceData & { spans: TraceSpanData[] } = {
         { key: 'component', type: 'string', value: 'gRPC' },
         { key: 'internal.span.format', type: 'string', value: 'proto' },
       ],
-      logs: [] as any,
+      logs: [],
       processID: '35118c298fc91f68',
-      warnings: null as any,
+      warnings: null,
     },
   ],
   processes: {
@@ -257,7 +257,7 @@ const response: TraceData & { spans: TraceSpanData[] } = {
       ],
     },
   },
-  warnings: null as any,
+  warnings: null,
 };
 
 export const frameOld = new MutableDataFrame({

--- a/public/app/features/explore/TraceView/TraceView.tsx
+++ b/public/app/features/explore/TraceView/TraceView.tsx
@@ -188,7 +188,7 @@ export function TraceView(props: Props) {
             setTrace={noop}
             addHoverIndentGuideId={addHoverIndentGuideId}
             removeHoverIndentGuideId={removeHoverIndentGuideId}
-            linksGetter={noop as any}
+            linksGetter={() => []}
             uiFind={props.search}
             createSpanLink={createSpanLink}
             scrollElement={props.scrollElement}

--- a/public/app/features/explore/TraceView/TraceViewContainer.test.tsx
+++ b/public/app/features/explore/TraceView/TraceViewContainer.test.tsx
@@ -79,7 +79,7 @@ describe('TraceViewContainer', () => {
     renderTraceViewContainer();
     await userEvent.type(screen.getByPlaceholderText('Find...'), '1ed38015486087ca');
     expect(
-      (screen.queryAllByText('', { selector: 'div[data-testid="span-view"]' })[0].parentNode! as HTMLElement).className
+      screen.queryAllByText('', { selector: 'div[data-testid="span-view"]' })[0].parentElement!.className
     ).toContain('rowMatchingFilter');
   });
 
@@ -93,32 +93,32 @@ describe('TraceViewContainer', () => {
     await userEvent.click(nextResultButton);
     expect(suffix.textContent).toBe('1 of 2');
     expect(
-      (screen.queryAllByText('', { selector: 'div[data-testid="span-view"]' })[1].parentNode! as HTMLElement).className
+      screen.queryAllByText('', { selector: 'div[data-testid="span-view"]' })[1].parentElement!.className
     ).toContain('rowFocused');
     await userEvent.click(nextResultButton);
     expect(suffix.textContent).toBe('2 of 2');
     expect(
-      (screen.queryAllByText('', { selector: 'div[data-testid="span-view"]' })[2].parentNode! as HTMLElement).className
+      screen.queryAllByText('', { selector: 'div[data-testid="span-view"]' })[2].parentElement!.className
     ).toContain('rowFocused');
     await userEvent.click(nextResultButton);
     expect(suffix.textContent).toBe('1 of 2');
     expect(
-      (screen.queryAllByText('', { selector: 'div[data-testid="span-view"]' })[1].parentNode! as HTMLElement).className
+      screen.queryAllByText('', { selector: 'div[data-testid="span-view"]' })[1].parentElement!.className
     ).toContain('rowFocused');
     await userEvent.click(prevResultButton);
     expect(suffix.textContent).toBe('2 of 2');
     expect(
-      (screen.queryAllByText('', { selector: 'div[data-testid="span-view"]' })[2].parentNode! as HTMLElement).className
+      screen.queryAllByText('', { selector: 'div[data-testid="span-view"]' })[2].parentElement!.className
     ).toContain('rowFocused');
     await userEvent.click(prevResultButton);
     expect(suffix.textContent).toBe('1 of 2');
     expect(
-      (screen.queryAllByText('', { selector: 'div[data-testid="span-view"]' })[1].parentNode! as HTMLElement).className
+      screen.queryAllByText('', { selector: 'div[data-testid="span-view"]' })[1].parentElement!.className
     ).toContain('rowFocused');
     await userEvent.click(prevResultButton);
     expect(suffix.textContent).toBe('2 of 2');
     expect(
-      (screen.queryAllByText('', { selector: 'div[data-testid="span-view"]' })[2].parentNode! as HTMLElement).className
+      screen.queryAllByText('', { selector: 'div[data-testid="span-view"]' })[2].parentElement!.className
     ).toContain('rowFocused');
   });
 });

--- a/public/app/features/explore/TraceView/createSpanLink.test.ts
+++ b/public/app/features/explore/TraceView/createSpanLink.test.ts
@@ -445,7 +445,7 @@ describe('createSpanLinkFactory', () => {
             { name: 'defaultQuery', query: '' },
             { query: 'no_name_here' },
           ],
-        } as TraceToMetricsOptions,
+        },
       });
       expect(createLink).toBeDefined();
 
@@ -517,7 +517,7 @@ describe('createSpanLinkFactory', () => {
           { key: 'job', value: '' },
           { key: 'k8s.pod', value: 'pod' },
         ],
-      } as TraceToMetricsOptions,
+      },
     });
     expect(createLink).toBeDefined();
 

--- a/public/app/features/explore/TraceView/createSpanLink.tsx
+++ b/public/app/features/explore/TraceView/createSpanLink.tsx
@@ -446,13 +446,13 @@ function buildMetricsQuery(query: TraceToMetricQuery, tags: Array<KeyValue<strin
   let expr = query.query;
   if (tags.length && expr.indexOf('$__tags') !== -1) {
     const spanTags = [...span.process.tags, ...span.tags];
-    const labels = tags.reduce((acc, tag) => {
+    const labels = tags.reduce<string[]>((acc, tag) => {
       const tagValue = spanTags.find((t) => t.key === tag.key)?.value;
       if (tagValue) {
         acc.push(`${tag.value ? tag.value : tag.key}="${tagValue}"`);
       }
       return acc;
-    }, [] as string[]);
+    }, []);
 
     const labelsQuery = labels?.join(', ');
     expr = expr.replace(/\$__tags/g, labelsQuery);

--- a/public/app/features/explore/TraceView/useDetailState.test.ts
+++ b/public/app/features/explore/TraceView/useDetailState.test.ts
@@ -30,7 +30,7 @@ describe('useDetailState', () => {
     act(() => result.current.detailLogsToggle('span1'));
     expect(result.current.detailStates.get('span1')?.logs.isOpen).toBe(true);
 
-    const log = { timestamp: 1 } as TraceLog;
+    const log: TraceLog = { timestamp: 1, fields: [] };
     act(() => result.current.detailLogItemToggle('span1', log));
     expect(result.current.detailStates.get('span1')?.logs.openedItems.has(log)).toBe(true);
   });

--- a/public/app/features/explore/Wrapper.test.tsx
+++ b/public/app/features/explore/Wrapper.test.tsx
@@ -261,7 +261,7 @@ describe('Wrapper', () => {
       // to work
       await screen.findByText(`loki Editor input: { label="value"}`);
 
-      store.dispatch(mainState.splitOpen<any>({ datasourceUid: 'elastic', query: { expr: 'error' } }) as any);
+      store.dispatch(mainState.splitOpen({ datasourceUid: 'elastic', query: { expr: 'error', refId: 'A' } }));
 
       // Editor renders the new query
       await screen.findByText(`elastic Editor input: error`);
@@ -318,7 +318,7 @@ describe('Wrapper', () => {
       // to work
       await screen.findByText(`loki Editor input: { label="value"}`);
 
-      store.dispatch(mainState.splitOpen<any>({ datasourceUid: 'elastic', query: { expr: 'error' } }) as any);
+      store.dispatch(mainState.splitOpen({ datasourceUid: 'elastic', query: { expr: 'error', refId: 'A' } }));
       await waitFor(() => expect(document.title).toEqual('Explore - loki | elastic - Grafana'));
     });
   });

--- a/public/app/features/explore/spec/helper/setup.tsx
+++ b/public/app/features/explore/spec/helper/setup.tsx
@@ -203,16 +203,12 @@ export const localStorageHasAlreadyBeenMigrated = () => {
 };
 
 export const setupLocalStorageRichHistory = (dsName: string) => {
-  window.localStorage.setItem(
-    RICH_HISTORY_KEY,
-    JSON.stringify([
-      {
-        ts: Date.now(),
-        datasourceName: dsName,
-        starred: true,
-        comment: '',
-        queries: [{ refId: 'A' }],
-      } as RichHistoryLocalStorageDTO,
-    ])
-  );
+  const richHistoryDTO: RichHistoryLocalStorageDTO = {
+    ts: Date.now(),
+    datasourceName: dsName,
+    starred: true,
+    comment: '',
+    queries: [{ refId: 'A' }],
+  };
+  window.localStorage.setItem(RICH_HISTORY_KEY, JSON.stringify([richHistoryDTO]));
 };

--- a/public/app/features/explore/state/helpers.ts
+++ b/public/app/features/explore/state/helpers.ts
@@ -30,8 +30,8 @@ export const createDefaultInitialState = () => {
         },
         initialized: true,
         containerWidth: 1920,
-        eventBridge: { emit: () => {} } as any,
-        queries: [{ expr: 'test' }] as any[],
+        eventBridge: { emit: () => {} },
+        queries: [{ expr: 'test' }],
         range: testRange,
         history: [],
         refreshInterval: {

--- a/public/app/features/explore/state/main.test.ts
+++ b/public/app/features/explore/state/main.test.ts
@@ -41,28 +41,25 @@ const getNavigateToExploreContext = async (openInNewWindow?: (url: string) => vo
 describe('navigateToExplore', () => {
   describe('when navigateToExplore thunk is dispatched', () => {
     describe('and openInNewWindow is undefined', () => {
-      const openInNewWindow: (url: string) => void = undefined as unknown as (url: string) => void;
       it('then it should dispatch correct actions', async () => {
-        const { url } = await getNavigateToExploreContext(openInNewWindow);
+        const { url } = await getNavigateToExploreContext();
         expect(locationService.getLocation().pathname).toEqual(url);
       });
 
       it('then getDataSourceSrv should have been once', async () => {
-        const { getDataSourceSrv } = await getNavigateToExploreContext(openInNewWindow);
+        const { getDataSourceSrv } = await getNavigateToExploreContext();
 
         expect(getDataSourceSrv).toHaveBeenCalledTimes(1);
       });
 
       it('then getTimeSrv should have been called once', async () => {
-        const { getTimeSrv } = await getNavigateToExploreContext(openInNewWindow);
+        const { getTimeSrv } = await getNavigateToExploreContext();
 
         expect(getTimeSrv).toHaveBeenCalledTimes(1);
       });
 
       it('then getExploreUrl should have been called with correct arguments', async () => {
-        const { getExploreUrl, panel, getDataSourceSrv, getTimeSrv } = await getNavigateToExploreContext(
-          openInNewWindow
-        );
+        const { getExploreUrl, panel, getDataSourceSrv, getTimeSrv } = await getNavigateToExploreContext();
 
         expect(getExploreUrl).toHaveBeenCalledTimes(1);
         expect(getExploreUrl).toHaveBeenCalledWith({

--- a/public/app/features/explore/state/main.ts
+++ b/public/app/features/explore/state/main.ts
@@ -184,7 +184,7 @@ export const initialExploreState: ExploreState = {
  */
 export const exploreReducer = (state = initialExploreState, action: AnyAction): ExploreState => {
   if (splitCloseAction.match(action)) {
-    const { itemId } = action.payload as SplitCloseActionPayload;
+    const { itemId } = action.payload;
     const targetSplit = {
       left: itemId === ExploreId.left ? state.right! : state.left,
       right: undefined,
@@ -289,7 +289,7 @@ export const exploreReducer = (state = initialExploreState, action: AnyAction): 
     if (exploreId !== undefined) {
       // @ts-ignore
       const explorePaneState = state[exploreId];
-      return { ...state, [exploreId]: paneReducer(explorePaneState, action as any) };
+      return { ...state, [exploreId]: paneReducer(explorePaneState, action) };
     }
   }
 

--- a/public/app/features/explore/state/query.test.ts
+++ b/public/app/features/explore/state/query.test.ts
@@ -4,7 +4,6 @@ import { assertIsDefined } from 'test/helpers/asserts';
 
 import {
   ArrayVector,
-  DataFrame,
   DataQuery,
   DataQueryResponse,
   DataSourceApi,
@@ -12,7 +11,6 @@ import {
   DataSourceWithLogsVolumeSupport,
   LoadingState,
   MutableDataFrame,
-  PanelData,
   RawTimeRange,
 } from '@grafana/data';
 import { ExploreId, ExploreItemState, StoreState, ThunkDispatch } from 'app/types';
@@ -70,7 +68,7 @@ jest.mock('app/features/dashboard/services/TimeSrv', () => ({
 }));
 
 jest.mock('@grafana/runtime', () => ({
-  ...(jest.requireActual('@grafana/runtime') as unknown as object),
+  ...jest.requireActual('@grafana/runtime'),
   getTemplateSrv: () => ({
     updateTimeRange: jest.fn(),
   }),
@@ -282,9 +280,9 @@ describe('reducer', () => {
           [ExploreId.left]: {
             ...defaultInitialState.explore[ExploreId.left],
             queryResponse: {
-              series: [{ name: 'test name' }] as DataFrame[],
+              series: [{ name: 'test name' }],
               state: LoadingState.Done,
-            } as PanelData,
+            },
             absoluteRange: { from: 1621348027000, to: 1621348050000 },
           },
         },
@@ -303,7 +301,7 @@ describe('reducer', () => {
         explore: {
           [ExploreId.left]: {
             ...defaultInitialState.explore[ExploreId.left],
-            queryResponse: { series: [{ name: 'test name' }] as DataFrame[], state: LoadingState.Loading } as PanelData,
+            queryResponse: { series: [{ name: 'test name' }], state: LoadingState.Loading },
             absoluteRange: { from: 1621348027000, to: 1621348050000 },
           },
         },
@@ -321,9 +319,9 @@ describe('reducer', () => {
           [ExploreId.left]: {
             ...defaultInitialState.explore[ExploreId.left],
             queryResponse: {
-              series: [{ name: 'test name' }] as DataFrame[],
+              series: [{ name: 'test name' }],
               state: LoadingState.Done,
-            } as PanelData,
+            },
             absoluteRange: { from: 1621348027000, to: 1621348050000 },
             cache: [
               {

--- a/public/app/features/explore/state/time.test.ts
+++ b/public/app/features/explore/state/time.test.ts
@@ -25,7 +25,7 @@ const mockTemplateSrv = {
   updateTimeRange: jest.fn(),
 };
 jest.mock('@grafana/runtime', () => ({
-  ...(jest.requireActual('@grafana/runtime') as unknown as object),
+  ...jest.requireActual('@grafana/runtime'),
   getTemplateSrv: () => mockTemplateSrv,
 }));
 
@@ -53,7 +53,7 @@ describe('Explore item reducer', () => {
         loading: true,
         logsResult: {
           hasUniqueLabels: false,
-          rows: [] as any[],
+          rows: [],
         },
         queryResponse: {
           ...initialState.queryResponse,
@@ -73,7 +73,7 @@ describe('Explore item reducer', () => {
         refreshInterval: '',
         logsResult: {
           hasUniqueLabels: false,
-          rows: [] as any[],
+          rows: [],
         },
         queryResponse: {
           ...initialState.queryResponse,

--- a/public/app/features/explore/utils/decorators.test.ts
+++ b/public/app/features/explore/utils/decorators.test.ts
@@ -8,7 +8,7 @@ import {
   FieldType,
   LoadingState,
   PanelData,
-  TimeRange,
+  getDefaultTimeRange,
   toDataFrame,
 } from '@grafana/data';
 import { config } from '@grafana/runtime/src/config';
@@ -86,14 +86,14 @@ const getTestContext = () => {
 const createExplorePanelData = (args: Partial<ExplorePanelData>): ExplorePanelData => {
   const defaults: ExplorePanelData = {
     series: [],
-    timeRange: {} as unknown as TimeRange,
+    timeRange: getDefaultTimeRange(),
     state: LoadingState.Done,
     graphFrames: [],
-    graphResult: undefined as unknown as null,
+    graphResult: null,
     logsFrames: [],
-    logsResult: undefined as unknown as null,
+    logsResult: null,
     tableFrames: [],
-    tableResult: undefined as unknown as null,
+    tableResult: null,
     traceFrames: [],
     nodeGraphFrames: [],
     flameGraphFrames: [],
@@ -106,10 +106,11 @@ describe('decorateWithGraphLogsTraceTableAndFlameGraph', () => {
   it('should correctly classify the dataFrames', () => {
     const { table, logs, timeSeries, emptyTable, flameGraph } = getTestContext();
     const series = [table, logs, timeSeries, emptyTable, flameGraph];
+    const timeRange = getDefaultTimeRange();
     const panelData: PanelData = {
       series,
       state: LoadingState.Done,
-      timeRange: {} as unknown as TimeRange,
+      timeRange,
     };
     // Needed so flamegraph does not fallback to table, will be removed when feature flag no longer necessary
     config.featureToggles.flameGraph = true;
@@ -117,7 +118,7 @@ describe('decorateWithGraphLogsTraceTableAndFlameGraph', () => {
     expect(decorateWithFrameTypeMetadata(panelData)).toEqual({
       series,
       state: LoadingState.Done,
-      timeRange: {},
+      timeRange,
       graphFrames: [timeSeries],
       tableFrames: [table, emptyTable],
       logsFrames: [logs],
@@ -132,16 +133,17 @@ describe('decorateWithGraphLogsTraceTableAndFlameGraph', () => {
 
   it('should handle empty array', () => {
     const series: DataFrame[] = [];
+    const timeRange = getDefaultTimeRange();
     const panelData: PanelData = {
       series,
       state: LoadingState.Done,
-      timeRange: {} as unknown as TimeRange,
+      timeRange,
     };
 
     expect(decorateWithFrameTypeMetadata(panelData)).toEqual({
       series: [],
       state: LoadingState.Done,
-      timeRange: {},
+      timeRange: timeRange,
       graphFrames: [],
       tableFrames: [],
       logsFrames: [],
@@ -157,18 +159,19 @@ describe('decorateWithGraphLogsTraceTableAndFlameGraph', () => {
   it('should return frames even if there is an error', () => {
     const { timeSeries, logs, table } = getTestContext();
     const series: DataFrame[] = [timeSeries, logs, table];
+    const timeRange = getDefaultTimeRange();
     const panelData: PanelData = {
       series,
       error: {},
       state: LoadingState.Error,
-      timeRange: {} as unknown as TimeRange,
+      timeRange,
     };
 
     expect(decorateWithFrameTypeMetadata(panelData)).toEqual({
       series: [timeSeries, logs, table],
       error: {},
       state: LoadingState.Error,
-      timeRange: {},
+      timeRange,
       graphFrames: [timeSeries],
       tableFrames: [table],
       logsFrames: [logs],
@@ -324,7 +327,7 @@ describe('decorateWithLogsResult', () => {
           labels: {},
           logLevel: 'unknown',
           raw: 'this is a message',
-          searchWords: [] as string[],
+          searchWords: [],
           timeEpochMs: 100,
           timeEpochNs: '100000002',
           timeFromNow: 'fromNow() jest mocked',
@@ -343,7 +346,7 @@ describe('decorateWithLogsResult', () => {
           labels: {},
           logLevel: 'unknown',
           raw: 'third',
-          searchWords: [] as string[],
+          searchWords: [],
           timeEpochMs: 100,
           timeEpochNs: '100000001',
           timeFromNow: 'fromNow() jest mocked',
@@ -362,7 +365,7 @@ describe('decorateWithLogsResult', () => {
           labels: {},
           logLevel: 'unknown',
           raw: 'second message',
-          searchWords: [] as string[],
+          searchWords: [],
           timeEpochMs: 100,
           timeEpochNs: '100000000',
           timeFromNow: 'fromNow() jest mocked',


### PR DESCRIPTION
Removes ~40 unneeded type assertions from the Explore code base (just the easiest ones).
tested behaviour is unchanged