### PR TITLE
Alerting: Show unknown badge instead of Error in group rule modal in case of  Mimir unknown interval

### DIFF
--- a/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
+++ b/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
@@ -136,7 +136,7 @@ export const RulesForGroupTable = ({
 
   const { watch } = useFormContext<FormValues>();
   const currentInterval = watch('groupInterval');
-  const unknownCurrentInteval = !Boolean(currentInterval);
+  const unknownCurrentInterval = !Boolean(currentInterval);
 
   const rows: AlertsWithForTableProps[] = rules
     .slice()
@@ -170,7 +170,7 @@ export const RulesForGroupTable = ({
         id: 'numberEvaluations',
         label: '#Evaluations',
         renderCell: ({ data: { evaluationsToFire: numberEvaluations } }) => {
-          if (unknownCurrentInteval) {
+          if (unknownCurrentInterval) {
             return <ForBadge message="#Evaluations not available." />;
           } else {
             if (!isValidEvaluation(currentInterval)) {
@@ -188,7 +188,7 @@ export const RulesForGroupTable = ({
         size: 0.6,
       },
     ];
-  }, [currentInterval, unknownCurrentInteval]);
+  }, [currentInterval, unknownCurrentInterval]);
 
   return (
     <div className={styles.tableWrapper}>

--- a/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
+++ b/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
@@ -29,8 +29,12 @@ interface AlertInfo {
   forDuration: string;
   evaluationsToFire: number;
 }
-function ForError({ message }: { message: string }) {
-  return <Badge color="orange" icon="exclamation-triangle" text={'Error'} tooltip={message} />;
+function ForBadge({ message, error }: { message: string; error?: boolean }) {
+  if (error) {
+    return <Badge color="orange" icon="exclamation-triangle" text={'Error'} tooltip={message} />;
+  } else {
+    return <Badge color="orange" icon="exclamation-triangle" text={'Unknown'} tooltip={message} />;
+  }
 }
 
 export const getNumberEvaluationsToStartAlerting = (forDuration: string, currentEvaluation: string) => {
@@ -132,6 +136,7 @@ export const RulesForGroupTable = ({
 
   const { watch } = useFormContext<FormValues>();
   const currentInterval = watch('groupInterval');
+  const unknownCurrentInteval = !Boolean(currentInterval);
 
   const rows: AlertsWithForTableProps[] = rules
     .slice()
@@ -165,19 +170,25 @@ export const RulesForGroupTable = ({
         id: 'numberEvaluations',
         label: '#Evaluations',
         renderCell: ({ data: { evaluationsToFire: numberEvaluations } }) => {
-          if (!isValidEvaluation(currentInterval)) {
-            return <ForError message={'Invalid evaluation interval format'} />;
-          }
-          if (numberEvaluations === 0) {
-            return <ForError message="Invalid 'For' value: it should be greater or equal to evaluation interval." />;
+          if (unknownCurrentInteval) {
+            return <ForBadge message="#Evaluations not available." />;
           } else {
-            return <>{numberEvaluations}</>;
+            if (!isValidEvaluation(currentInterval)) {
+              return <ForBadge message={'Invalid evaluation interval format'} error />;
+            }
+            if (numberEvaluations === 0) {
+              return (
+                <ForBadge message="Invalid 'For' value: it should be greater or equal to evaluation interval." error />
+              );
+            } else {
+              return <>{numberEvaluations}</>;
+            }
           }
         },
         size: 0.6,
       },
     ];
-  }, [currentInterval]);
+  }, [currentInterval, unknownCurrentInteval]);
 
   return (
     <div className={styles.tableWrapper}>

--- a/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
+++ b/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
@@ -31,7 +31,7 @@ interface AlertInfo {
 }
 function ForBadge({ message, error }: { message: string; error?: boolean }) {
   if (error) {
-    return <Badge color="orange" icon="exclamation-triangle" text={'Error'} tooltip={message} />;
+    return <Badge color="red" icon="exclamation-circle" text={'Error'} tooltip={message} />;
   } else {
     return <Badge color="orange" icon="exclamation-triangle" text={'Unknown'} tooltip={message} />;
   }


### PR DESCRIPTION
**What is this feature?**

This PR shows `Unknown` badge instead of `Error` badge in case of Mimir alert group with a fallback evaluation interval.

In this case, the UI has no way of knowing the eval interval, because the default interval is a flag passed to the Mimir instance that's not exposed through the API.

**Why do we need this feature?**

We want to avoid and Error warning in this case, as it's not an error. We will show an `Unknow` badge instead, so the user understand why the UI it's not showing the #evaluations in the alert rules table.


**Who is this feature for?**

All users.

**Which issue(s) does this PR fix?**:
This PR fixes a problem commented on this escalation https://github.com/grafana/support-escalations/issues/4645

**Special notes for your reviewer**:

<img width="670" alt="Screenshot 2022-12-19 at 11 33 45" src="https://user-images.githubusercontent.com/33540275/208408798-4156fa4b-cbe1-42d8-b693-7c4011d131ca.png">

and when hovering: 

<img width="568" alt="Screenshot 2022-12-19 at 11 34 10" src="https://user-images.githubusercontent.com/33540275/208408845-f40d3456-72d6-4e00-bd89-5ee38b8c8c02.png">

It also changes the way we render this Badge in case of error:
<img width="584" alt="Screenshot 2022-12-19 at 14 38 19" src="https://user-images.githubusercontent.com/33540275/208447181-c1c4eecd-8688-4d08-abb0-71b431f96621.png">


