### PR TITLE
AuthN: set org id for authentication request in service

### DIFF
--- a/pkg/services/authn/authn.go
+++ b/pkg/services/authn/authn.go
@@ -42,6 +42,8 @@ type Client interface {
 }
 
 type Request struct {
+	// OrgID will be populated by authn.Service
+	OrgID       int64
 	HTTPRequest *http.Request
 }
 

--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -73,8 +73,7 @@ func (s *Service) Authenticate(ctx context.Context, client string, r *authn.Requ
 		return nil, false, nil
 	}
 
-	orgID := orgIDFromRequest(r)
-
+	r.OrgID = orgIDFromRequest(r)
 	identity, err := c.Authenticate(ctx, r)
 	if err != nil {
 		logger.Warn("auth client could not authenticate request", "client", client, "error", err)

--- a/pkg/services/authn/authnimpl/service_test.go
+++ b/pkg/services/authn/authnimpl/service_test.go
@@ -3,6 +3,8 @@ package authnimpl
 import (
 	"context"
 	"errors"
+	"net/http"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -57,6 +59,77 @@ func TestService_Authenticate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestService_AuthenticateOrgID(t *testing.T) {
+	type TestCase struct {
+		desc          string
+		req           *authn.Request
+		expectedOrgID int64
+	}
+
+	tests := []TestCase{
+		{
+			desc: "should set org id when present in header",
+			req: &authn.Request{HTTPRequest: &http.Request{
+				Header: map[string][]string{orgIDHeaderName: {"1"}},
+				URL:    &url.URL{},
+			}},
+			expectedOrgID: 1,
+		},
+		{
+			desc: "should set org id when present in url",
+			req: &authn.Request{HTTPRequest: &http.Request{
+				Header: map[string][]string{},
+				URL:    mustParseURL("http://localhost/?targetOrgId=2"),
+			}},
+			expectedOrgID: 2,
+		},
+		{
+			desc: "should prioritise org id from url when present in both header and url",
+			req: &authn.Request{HTTPRequest: &http.Request{
+				Header: map[string][]string{orgIDHeaderName: {"1"}},
+				URL:    mustParseURL("http://localhost/?targetOrgId=2"),
+			}},
+			expectedOrgID: 2,
+		},
+		{
+			desc: "should set org id to 0 when missing in both header and url",
+			req: &authn.Request{HTTPRequest: &http.Request{
+				Header: map[string][]string{},
+				URL:    &url.URL{},
+			}},
+			expectedOrgID: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var calledWith int64
+			s := setupTests(t, func(svc *Service) {
+				svc.clients["fake"] = authntest.MockClient{
+					AuthenticateFunc: func(ctx context.Context, r *authn.Request) (*authn.Identity, error) {
+						calledWith = r.OrgID
+						return nil, nil
+					},
+					TestFunc: func(ctx context.Context, r *authn.Request) bool {
+						return true
+					},
+				}
+			})
+
+			_, _, _ = s.Authenticate(context.Background(), "fake", tt.req)
+			assert.Equal(t, tt.expectedOrgID, calledWith)
+		})
+	}
+}
+
+func mustParseURL(s string) *url.URL {
+	u, err := url.Parse(s)
+	if err != nil {
+		panic(err)
+	}
+	return u
 }
 
 func setupTests(t *testing.T, opts ...func(svc *Service)) *Service {

--- a/pkg/services/authn/authntest/mock.go
+++ b/pkg/services/authn/authntest/mock.go
@@ -1,0 +1,31 @@
+package authntest
+
+import (
+	"context"
+
+	"github.com/grafana/grafana/pkg/services/authn"
+)
+
+var _ authn.Client = new(MockClient)
+
+type MockClient struct {
+	AuthenticateFunc func(ctx context.Context, r *authn.Request) (*authn.Identity, error)
+	TestFunc         func(ctx context.Context, r *authn.Request) bool
+}
+
+type ClientFunctions struct {
+}
+
+func (m MockClient) Authenticate(ctx context.Context, r *authn.Request) (*authn.Identity, error) {
+	if m.AuthenticateFunc != nil {
+		return m.AuthenticateFunc(ctx, r)
+	}
+	return nil, nil
+}
+
+func (m MockClient) Test(ctx context.Context, r *authn.Request) bool {
+	if m.TestFunc != nil {
+		return m.TestFunc(ctx, r)
+	}
+	return false
+}

--- a/pkg/services/authn/authntest/mock.go
+++ b/pkg/services/authn/authntest/mock.go
@@ -10,10 +10,8 @@ var _ authn.Client = new(MockClient)
 
 type MockClient struct {
 	AuthenticateFunc func(ctx context.Context, r *authn.Request) (*authn.Identity, error)
+	ClientParamsFunc func() *authn.ClientParams
 	TestFunc         func(ctx context.Context, r *authn.Request) bool
-}
-
-type ClientFunctions struct {
 }
 
 func (m MockClient) Authenticate(ctx context.Context, r *authn.Request) (*authn.Identity, error) {
@@ -21,6 +19,13 @@ func (m MockClient) Authenticate(ctx context.Context, r *authn.Request) (*authn.
 		return m.AuthenticateFunc(ctx, r)
 	}
 	return nil, nil
+}
+
+func (m MockClient) ClientParams() *authn.ClientParams {
+	if m.ClientParamsFunc != nil {
+		return m.ClientParamsFunc()
+	}
+	return nil
 }
 
 func (m MockClient) Test(ctx context.Context, r *authn.Request) bool {


### PR DESCRIPTION
**What is this feature?**
For some authentication request we need to know the org id the authentication is targeting.

This replicates the behaviour we have in [context handler](https://github.com/grafana/grafana/blob/main/pkg/services/contexthandler/contexthandler.go#L134-L157).


Fixes #

**Special notes for your reviewer**:

