### PR TITLE
RBAC: Fix DeleteUserPermissions not being called on Upsert org sync

### DIFF
--- a/pkg/services/login/loginservice/loginservice.go
+++ b/pkg/services/login/loginservice/loginservice.go
@@ -315,8 +315,7 @@ func (ls *Implementation) syncOrgRoles(ctx context.Context, usr *user.User, extU
 		}
 
 		if err := ls.accessControl.DeleteUserPermissions(ctx, orgId, cmd.UserID); err != nil {
-			logger.Error("failed to delete permissions for user", "error", err, "userID", cmd.UserID, "orgID", orgId)
-			return err
+			logger.Warn("failed to delete permissions for user", "error", err, "userID", cmd.UserID, "orgID", orgId)
 		}
 	}
 

--- a/pkg/services/login/loginservice/loginservice.go
+++ b/pkg/services/login/loginservice/loginservice.go
@@ -310,10 +310,12 @@ func (ls *Implementation) syncOrgRoles(ctx context.Context, usr *user.User, extU
 				logger.Error(err.Error(), "userId", cmd.UserID, "orgId", cmd.OrgID)
 				continue
 			}
-			if err := ls.accessControl.DeleteUserPermissions(ctx, orgId, cmd.UserID); err != nil {
-				logger.Warn("failed to delete permissions for user", "userID", cmd.UserID, "orgID", orgId)
-			}
 
+			return err
+		}
+
+		if err := ls.accessControl.DeleteUserPermissions(ctx, orgId, cmd.UserID); err != nil {
+			logger.Error("failed to delete permissions for user", "error", err, "userID", cmd.UserID, "orgID", orgId)
 			return err
 		}
 	}

--- a/pkg/services/login/loginservice/loginservice_test.go
+++ b/pkg/services/login/loginservice/loginservice_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/accesscontrol/actest"
 	"github.com/grafana/grafana/pkg/services/login"
 	"github.com/grafana/grafana/pkg/services/login/logintest"
 	"github.com/grafana/grafana/pkg/services/org"
@@ -54,6 +55,7 @@ func Test_syncOrgRoles_whenTryingToRemoveLastOrgLogsError(t *testing.T) {
 		AuthInfoService: authInfoMock,
 		userService:     usertest.NewUserServiceFake(),
 		orgService:      orgService,
+		accessControl:   &actest.FakeService{},
 	}
 
 	err := login.syncOrgRoles(context.Background(), &user, &externalUser)


### PR DESCRIPTION
When users are removed by UpsertUser from an org their custom org role assignments are not removed.

This PR makes `DeleteUserPermissions` when the user is removed from an org
