### PR TITLE
Alerting: update dingding, discord, googlechat, kafka, line notifiers to use encoding/json to parse settings

### DIFF
--- a/pkg/services/ngalert/notifier/channels/dingding_test.go
+++ b/pkg/services/ngalert/notifier/channels/dingding_test.go
@@ -80,7 +80,7 @@ func TestDingdingNotifier(t *testing.T) {
 			expMsgError: nil,
 		}, {
 			name:     "Default config with one alert and custom title and description",
-			settings: `{"url": "http://localhost", "title": "Alerts firing: {{ len .Alerts.Firing }}", "message": "customMessage"}}`,
+			settings: `{"url": "http://localhost", "title": "Alerts firing: {{ len .Alerts.Firing }}", "message": "customMessage"}`,
 			alerts: []*types.Alert{
 				{
 					Alert: model.Alert{

--- a/pkg/services/ngalert/notifier/channels/discord.go
+++ b/pkg/services/ngalert/notifier/channels/discord.go
@@ -32,7 +32,7 @@ type DiscordNotifier struct {
 
 type discordSettings struct {
 	Title              string `json:"title,omitempty" yaml:"title,omitempty"`
-	Content            string `json:"message,omitempty" yaml:"message,omitempty"`
+	Message            string `json:"message,omitempty" yaml:"message,omitempty"`
 	AvatarURL          string `json:"avatar_url,omitempty" yaml:"avatar_url,omitempty"`
 	WebhookURL         string `json:"url,omitempty" yaml:"url,omitempty"`
 	UseDiscordUsername bool   `json:"use_discord_username,omitempty" yaml:"use_discord_username,omitempty"`
@@ -50,8 +50,8 @@ func buildDiscordSettings(fc channels.FactoryConfig) (*discordSettings, error) {
 	if settings.Title == "" {
 		settings.Title = channels.DefaultMessageTitleEmbed
 	}
-	if settings.Content == "" {
-		settings.Content = channels.DefaultMessageEmbed
+	if settings.Message == "" {
+		settings.Message = channels.DefaultMessageEmbed
 	}
 	return &settings, nil
 }
@@ -104,7 +104,7 @@ func (d DiscordNotifier) Notify(ctx context.Context, as ...*types.Alert) (bool, 
 	var tmplErr error
 	tmpl, _ := channels.TmplText(ctx, d.tmpl, as, d.log, &tmplErr)
 
-	bodyJSON.Set("content", tmpl(d.settings.Content))
+	bodyJSON.Set("content", tmpl(d.settings.Message))
 	if tmplErr != nil {
 		d.log.Warn("failed to template Discord notification content", "error", tmplErr.Error())
 		// Reset tmplErr for templating other fields.

--- a/pkg/services/ngalert/notifier/channels/googlechat.go
+++ b/pkg/services/ngalert/notifier/channels/googlechat.go
@@ -29,7 +29,7 @@ type GoogleChatNotifier struct {
 type googleChatSettings struct {
 	URL     string `json:"url,omitempty" yaml:"url,omitempty"`
 	Title   string `json:"title,omitempty" yaml:"title,omitempty"`
-	Content string `json:"message,omitempty" yaml:"message,omitempty"`
+	Message string `json:"message,omitempty" yaml:"message,omitempty"`
 }
 
 func buildGoogleChatSettings(fc channels.FactoryConfig) (*googleChatSettings, error) {
@@ -45,8 +45,8 @@ func buildGoogleChatSettings(fc channels.FactoryConfig) (*googleChatSettings, er
 	if settings.Title == "" {
 		settings.Title = channels.DefaultMessageTitleEmbed
 	}
-	if settings.Content == "" {
-		settings.Content = channels.DefaultMessageEmbed
+	if settings.Message == "" {
+		settings.Message = channels.DefaultMessageEmbed
 	}
 	return &settings, nil
 }
@@ -86,7 +86,7 @@ func (gcn *GoogleChatNotifier) Notify(ctx context.Context, as ...*types.Alert) (
 
 	var widgets []widget
 
-	if msg := tmpl(gcn.settings.Content); msg != "" {
+	if msg := tmpl(gcn.settings.Message); msg != "" {
 		// Add a text paragraph widget for the message if there is a message.
 		// Google Chat API doesn't accept an empty text property.
 		widgets = append(widgets, textParagraphWidget{Text: text{Text: msg}})

--- a/pkg/services/ngalert/notifier/channels/googlechat.go
+++ b/pkg/services/ngalert/notifier/channels/googlechat.go
@@ -12,7 +12,6 @@ import (
 	"github.com/prometheus/alertmanager/template"
 	"github.com/prometheus/alertmanager/types"
 
-	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
@@ -24,13 +23,32 @@ type GoogleChatNotifier struct {
 	ns       channels.WebhookSender
 	images   channels.ImageStore
 	tmpl     *template.Template
-	settings googleChatSettings
+	settings *googleChatSettings
 }
 
 type googleChatSettings struct {
-	URL     string
-	Title   string
-	Content string
+	URL     string `json:"url,omitempty" yaml:"url,omitempty"`
+	Title   string `json:"title,omitempty" yaml:"title,omitempty"`
+	Content string `json:"message,omitempty" yaml:"message,omitempty"`
+}
+
+func buildGoogleChatSettings(fc channels.FactoryConfig) (*googleChatSettings, error) {
+	var settings googleChatSettings
+	err := json.Unmarshal(fc.Config.Settings, &settings)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal settings: %w", err)
+	}
+
+	if settings.URL == "" {
+		return nil, errors.New("could not find url property in settings")
+	}
+	if settings.Title == "" {
+		settings.Title = channels.DefaultMessageTitleEmbed
+	}
+	if settings.Content == "" {
+		settings.Content = channels.DefaultMessageEmbed
+	}
+	return &settings, nil
 }
 
 func GoogleChatFactory(fc channels.FactoryConfig) (channels.NotificationChannel, error) {
@@ -45,32 +63,17 @@ func GoogleChatFactory(fc channels.FactoryConfig) (channels.NotificationChannel,
 }
 
 func newGoogleChatNotifier(fc channels.FactoryConfig) (*GoogleChatNotifier, error) {
-	var settings googleChatSettings
-	err := json.Unmarshal(fc.Config.Settings, &settings)
-	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal settings: %w", err)
-	}
-
-	rawsettings, err := simplejson.NewJson(fc.Config.Settings)
+	settings, err := buildGoogleChatSettings(fc)
 	if err != nil {
 		return nil, err
 	}
-	URL := rawsettings.Get("url").MustString()
-	if URL == "" {
-		return nil, errors.New("could not find url property in settings")
-	}
-
 	return &GoogleChatNotifier{
-		Base:   channels.NewBase(fc.Config),
-		log:    fc.Logger,
-		ns:     fc.NotificationService,
-		images: fc.ImageStore,
-		tmpl:   fc.Template,
-		settings: googleChatSettings{
-			URL:     URL,
-			Title:   rawsettings.Get("title").MustString(channels.DefaultMessageTitleEmbed),
-			Content: rawsettings.Get("message").MustString(channels.DefaultMessageEmbed),
-		},
+		Base:     channels.NewBase(fc.Config),
+		log:      fc.Logger,
+		ns:       fc.NotificationService,
+		images:   fc.ImageStore,
+		tmpl:     fc.Template,
+		settings: settings,
 	}, nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Instead of using `simplejson` to loosely parse notifier settings which is [bug-prone](https://github.com/grafana/grafana/issues/55139), this PR instead makes notifiers declare a well-defined struct for their settings.

This has some benefits:
- Improves validation for all settings fields and eliminates bugs (see attached issue)
- The total set of fields for each notifier is now clear and obvious. Settings are easier to reason about.
- Simplifies notifier construction logic by removing a layer of indirection
- Eliminates repetition/mapping of settings fields, which was a vector for bugs
- Makes our notifiers more in-line with [Prometheus's notifiers](https://github.com/prometheus/alertmanager/blob/3d624c0552e173aa57bbdad52a55788e38744252/notify/slack/slack.go). They also use settings structs.

**Which issue(s) this PR fixes**:

Contributes to https://github.com/grafana/grafana/issues/55139