### PR TITLE
Graphite: Fix bug in wildcard queries to Graphite plugin

### DIFF
--- a/pkg/tsdb/graphite/graphite.go
+++ b/pkg/tsdb/graphite/graphite.go
@@ -168,13 +168,23 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 		return &result, err
 	}
 
+	framesPerQuery := make(map[string][]*data.Frame)
+
+	for _, f := range frames {
+		if frames, ok := framesPerQuery[f.Name]; ok {
+			framesPerQuery[f.Name] = append(frames, f)
+		} else {
+			framesPerQuery[f.Name] = []*data.Frame{f}
+		}
+	}
+
 	result = backend.QueryDataResponse{
 		Responses: make(backend.Responses),
 	}
 
-	for _, f := range frames {
-		result.Responses[f.Name] = backend.DataResponse{
-			Frames: data.Frames{f},
+	for k, v := range framesPerQuery {
+		result.Responses[k] = backend.DataResponse{
+			Frames: v,
 		}
 	}
 

--- a/pkg/tsdb/graphite/graphite.go
+++ b/pkg/tsdb/graphite/graphite.go
@@ -168,23 +168,18 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 		return &result, err
 	}
 
-	framesPerQuery := make(map[string][]*data.Frame)
-
-	for _, f := range frames {
-		if frames, ok := framesPerQuery[f.Name]; ok {
-			framesPerQuery[f.Name] = append(frames, f)
-		} else {
-			framesPerQuery[f.Name] = []*data.Frame{f}
-		}
-	}
-
 	result = backend.QueryDataResponse{
 		Responses: make(backend.Responses),
 	}
 
-	for k, v := range framesPerQuery {
-		result.Responses[k] = backend.DataResponse{
-			Frames: v,
+	for _, f := range frames {
+		if resp, ok := result.Responses[f.Name]; ok {
+			resp.Frames = append(resp.Frames, f)
+			result.Responses[f.Name] = resp
+		} else {
+			result.Responses[f.Name] = backend.DataResponse{
+				Frames: data.Frames{f},
+			}
 		}
 	}
 


### PR DESCRIPTION
**What is this feature?**

In [this recent PR](https://github.com/grafana/grafana/pull/59608), the Graphite datasource was refactored to support multiple queries. However, this introduced a bug in wildcard queries due to the fact that it was overwriting results belonging to the same frame instead of appending them. This PR fixes that.

*Public dashboard panel with wildcard queries*

<img width="707" alt="image" src="https://user-images.githubusercontent.com/41969079/208571061-268a590c-ba5d-4bb2-8817-31d9ca538991.png">

**Why do we need this feature?**

In order to make public dashboards accurately reflect what is shown on regular dashboards. Note that this has no bearing on regular dashboards, which query graphite through the datasource proxy endpoint.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/60141

