### PR TITLE
Logs Panel: Add support for keyboard interactions with log lines

### DIFF
--- a/public/app/features/logs/components/LogRowMessage.tsx
+++ b/public/app/features/logs/components/LogRowMessage.tsx
@@ -84,6 +84,7 @@ const getStyles = (theme: GrafanaTheme2, showContextButton: boolean, isInDashboa
       font-family: ${theme.typography.fontFamilyMonospace};
       font-size: ${theme.typography.bodySmall.fontSize};
       letter-spacing: ${theme.typography.bodySmall.letterSpacing};
+      text-align: left;
       padding: 0;
     `,
   };

--- a/public/app/features/logs/components/LogRowMessage.tsx
+++ b/public/app/features/logs/components/LogRowMessage.tsx
@@ -77,6 +77,15 @@ const getStyles = (theme: GrafanaTheme2, showContextButton: boolean, isInDashboa
       right: ${isInDashboard ? '40px' : `calc(75px + ${theme.spacing()} + ${showContextButton ? '80px' : '40px'})`};
       margin-top: -${theme.spacing(0.125)};
     `,
+    logLine: css`
+      background-color: transparent;
+      border: none;
+      diplay: inline;
+      font-family: ${theme.typography.fontFamilyMonospace};
+      font-size: ${theme.typography.bodySmall.fontSize};
+      letter-spacing: ${theme.typography.bodySmall.letterSpacing};
+      padding: 0;
+    `,
   };
 };
 
@@ -193,9 +202,9 @@ class UnThemedLogRowMessage extends PureComponent<Props> {
                 }}
               />
             )}
-            <span className={cx(styles.positionRelative, { [styles.rowWithContext]: contextIsOpen })}>
+            <button className={cx(styles.logLine, styles.positionRelative, { [styles.rowWithContext]: contextIsOpen })}>
               {renderLogMessage(hasAnsi, restructuredEntry, row.searchWords, style.logsRowMatchHighLight)}
-            </span>
+            </button>
           </div>
         </td>
         {showRowMenu && (


### PR DESCRIPTION
This PR adds support to interact with log lines using the keyboard, so a user can toggle them open/closed.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/46485
Fixes https://github.com/grafana/grafana/issues/46478
Fixes https://github.com/grafana/grafana/issues/59047

**Special notes for your reviewer**:

Styles should be unchanged:

https://user-images.githubusercontent.com/1069378/208653757-8cb95a5c-dac4-41e1-8a76-52c75f6e8448.mov

Interaction demo:

https://user-images.githubusercontent.com/1069378/208653781-da18074e-c078-4fea-819d-5e75ebee23d0.mov


