### PR TITLE
Azure Monitor: Fix health check for empty default subscription

### DIFF
--- a/pkg/tsdb/azuremonitor/azuremonitor.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor.go
@@ -235,8 +235,8 @@ func checkAzureMonitorMetricsHealth(dsInfo types.DatasourceInfo) (*http.Response
 	return res, nil
 }
 
-func checkAzureLogAnalyticsHealth(dsInfo types.DatasourceInfo) (*http.Response, error) {
-	workspacesUrl := fmt.Sprintf("%v/subscriptions/%v/providers/Microsoft.OperationalInsights/workspaces?api-version=2017-04-26-preview", dsInfo.Routes["Azure Monitor"].URL, dsInfo.Settings.SubscriptionId)
+func checkAzureLogAnalyticsHealth(dsInfo types.DatasourceInfo, subscription string) (*http.Response, error) {
+	workspacesUrl := fmt.Sprintf("%v/subscriptions/%v/providers/Microsoft.OperationalInsights/workspaces?api-version=2017-04-26-preview", dsInfo.Routes["Azure Monitor"].URL, subscription)
 	workspacesReq, err := http.NewRequest(http.MethodGet, workspacesUrl, nil)
 	if err != nil {
 		return nil, err
@@ -280,10 +280,10 @@ func checkAzureLogAnalyticsHealth(dsInfo types.DatasourceInfo) (*http.Response, 
 	return res, nil
 }
 
-func checkAzureMonitorResourceGraphHealth(dsInfo types.DatasourceInfo) (*http.Response, error) {
+func checkAzureMonitorResourceGraphHealth(dsInfo types.DatasourceInfo, subscription string) (*http.Response, error) {
 	body, err := json.Marshal(map[string]interface{}{
 		"query":         "Resources | project id | limit 1",
-		"subscriptions": []string{dsInfo.Settings.SubscriptionId},
+		"subscriptions": []string{subscription},
 	})
 	if err != nil {
 		return nil, err
@@ -303,6 +303,26 @@ func checkAzureMonitorResourceGraphHealth(dsInfo types.DatasourceInfo) (*http.Re
 	return res, nil
 }
 
+func parseSubscriptions(res *http.Response) ([]string, error) {
+	var target struct {
+		Value []struct {
+			SubscriptionId string `json:"subscriptionId"`
+		}
+	}
+	err := json.NewDecoder(res.Body).Decode(&target)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	result := make([]string, len(target.Value))
+	for i, v := range target.Value {
+		result[i] = v.SubscriptionId
+	}
+
+	return result, nil
+}
+
 func (s *Service) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
 	dsInfo, err := s.getDSInfo(req.PluginContext)
 	if err != nil {
@@ -316,6 +336,7 @@ func (s *Service) CheckHealth(ctx context.Context, req *backend.CheckHealthReque
 	metricsLog := "Successfully connected to Azure Monitor endpoint."
 	logAnalyticsLog := "Successfully connected to Azure Log Analytics endpoint."
 	graphLog := "Successfully connected to Azure Resource Graph endpoint."
+	defaultSubscription := dsInfo.Settings.SubscriptionId
 
 	metricsRes, err := checkAzureMonitorMetricsHealth(dsInfo)
 	if err != nil || metricsRes.StatusCode != 200 {
@@ -333,9 +354,17 @@ func (s *Service) CheckHealth(ctx context.Context, req *backend.CheckHealthReque
 			}
 			metricsLog = fmt.Sprintf("Error connecting to Azure Monitor endpoint: %s", string(body))
 		}
+	} else {
+		subscriptions, err := parseSubscriptions(metricsRes)
+		if err != nil {
+			return nil, err
+		}
+		if defaultSubscription == "" && len(subscriptions) > 0 {
+			defaultSubscription = subscriptions[0]
+		}
 	}
 
-	logsRes, err := checkAzureLogAnalyticsHealth(dsInfo)
+	logsRes, err := checkAzureLogAnalyticsHealth(dsInfo, defaultSubscription)
 	if err != nil || logsRes.StatusCode != 200 {
 		status = backend.HealthStatusError
 		if err != nil {
@@ -356,7 +385,7 @@ func (s *Service) CheckHealth(ctx context.Context, req *backend.CheckHealthReque
 		}
 	}
 
-	resourceGraphRes, err := checkAzureMonitorResourceGraphHealth(dsInfo)
+	resourceGraphRes, err := checkAzureMonitorResourceGraphHealth(dsInfo, defaultSubscription)
 	if err != nil || resourceGraphRes.StatusCode != 200 {
 		status = backend.HealthStatusError
 		if err != nil {

--- a/pkg/tsdb/azuremonitor/azuremonitor.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor.go
@@ -313,7 +313,10 @@ func parseSubscriptions(res *http.Response) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer res.Body.Close()
+	defer func() {
+		err := res.Body.Close()
+		backend.Logger.Error("Failed to close response body", "err", err)
+	}()
 
 	result := make([]string, len(target.Value))
 	for i, v := range target.Value {

--- a/pkg/tsdb/azuremonitor/azuremonitor_test.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor_test.go
@@ -265,7 +265,7 @@ func TestCheckHealth(t *testing.T) {
 				if !fail {
 					return &http.Response{
 						StatusCode: 200,
-						Body:       io.NopCloser(bytes.NewBufferString("OK")),
+						Body:       io.NopCloser(bytes.NewBufferString("{\"value\": [{\"subscriptionId\": \"abcd-1234\"}]}")),
 						Header:     make(http.Header),
 					}, nil
 				} else {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

For the Azure Monitor health check, re-use the result of the first health check, that retrieves subscriptions, to select a default subscription in case the setting is not set in the configuration (since this parameter is optional).

![Screenshot from 2022-12-20 13-31-10](https://user-images.githubusercontent.com/4025665/208668751-06a5a83b-3af7-41db-a9ce-e14697af213f.png)

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/59102

**Special notes for your reviewer**:

