### PR TITLE
TimeSeriesPanel: Allow threshold indicators without change handler

### DIFF
--- a/packages/grafana-ui/src/components/PanelChrome/PanelContext.ts
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelContext.ts
@@ -46,6 +46,13 @@ export interface PanelContext {
   canEditThresholds?: boolean;
 
   /**
+   * Shows threshold indicators on the right-hand side of the panel
+   *
+   * @alpha -- experimental
+   */
+  showThresholds?: boolean;
+
+  /**
    * Called when a panel wants to change default thresholds configuration
    *
    * @alpha -- experimental

--- a/public/app/features/alerting/unified/components/rule-editor/QueryRows.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryRows.tsx
@@ -59,43 +59,6 @@ export class QueryRows extends PureComponent<Props> {
     );
   };
 
-  onChangeThreshold = (thresholds: ThresholdsConfig, index: number) => {
-    const { queries, onQueriesChange } = this.props;
-
-    const referencedRefId = queries[index].refId;
-
-    onQueriesChange(
-      queries.map((query) => {
-        if (!isExpressionQuery(query.model)) {
-          return query;
-        }
-
-        if (query.model.conditions && query.model.conditions[0].query.params[0] === referencedRefId) {
-          return {
-            ...query,
-            model: {
-              ...query.model,
-              conditions: query.model.conditions.map((condition, conditionIndex) => {
-                // Only update the first condition for a given refId.
-                if (condition.query.params[0] === referencedRefId && conditionIndex === 0) {
-                  return {
-                    ...condition,
-                    evaluator: {
-                      ...condition.evaluator,
-                      params: [parseFloat(thresholds.steps[1].value.toPrecision(3))],
-                    },
-                  };
-                }
-                return condition;
-              }),
-            },
-          };
-        }
-        return query;
-      })
-    );
-  };
-
   onChangeDataSource = (settings: DataSourceInstanceSettings, index: number) => {
     const { queries, onQueriesChange } = this.props;
 
@@ -253,7 +216,6 @@ export class QueryRows extends PureComponent<Props> {
                       onDuplicateQuery={this.props.onDuplicateQuery}
                       onChangeTimeRange={this.onChangeTimeRange}
                       thresholds={thresholdByRefId[query.refId]}
-                      onChangeThreshold={this.onChangeThreshold}
                       onRunQueries={this.props.onRunQueries}
                       condition={this.props.condition}
                       onSetCondition={this.props.onSetCondition}

--- a/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { cloneDeep } from 'lodash';
+import { cloneDeep, noop } from 'lodash';
 import React, { FC, useState } from 'react';
 
 import {
@@ -39,7 +39,7 @@ interface Props {
   onRunQueries: () => void;
   index: number;
   thresholds: ThresholdsConfig;
-  onChangeThreshold: (thresholds: ThresholdsConfig, index: number) => void;
+  onChangeThreshold?: (thresholds: ThresholdsConfig, index: number) => void;
   condition: string | null;
   onSetCondition: (refId: string) => void;
 }
@@ -141,7 +141,7 @@ export const QueryWrapper: FC<Props> = ({
               changePanel={changePluginId}
               currentPanel={pluginId}
               thresholds={thresholds}
-              onThresholdsChange={(thresholds) => onChangeThreshold(thresholds, index)}
+              onThresholdsChange={onChangeThreshold ? (thresholds) => onChangeThreshold(thresholds, index) : noop}
             />
           ) : null
         }

--- a/public/app/features/alerting/unified/components/rule-editor/VizWrapper.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/VizWrapper.tsx
@@ -52,7 +52,8 @@ export const VizWrapper: FC<Props> = ({ data, currentPanel, changePanel, onThres
   const context: PanelContext = useMemo(
     () => ({
       eventBus: appEvents,
-      canEditThresholds: true,
+      canEditThresholds: false,
+      showThresholds: true,
       onThresholdsChange: onThresholdsChange,
     }),
     [onThresholdsChange]

--- a/public/app/plugins/panel/candlestick/CandlestickPanel.tsx
+++ b/public/app/plugins/panel/candlestick/CandlestickPanel.tsx
@@ -38,7 +38,8 @@ export const CandlestickPanel: React.FC<CandlestickPanelProps> = ({
   onChangeTimeRange,
   replaceVariables,
 }) => {
-  const { sync, canAddAnnotations, onThresholdsChange, canEditThresholds, onSplitOpen } = usePanelContext();
+  const { sync, canAddAnnotations, onThresholdsChange, canEditThresholds, showThresholds, onSplitOpen } =
+    usePanelContext();
 
   const getFieldLinks = (field: Field, rowIndex: number) => {
     return getFieldLinksForExplore({ field, rowIndex, splitOpenFn: onSplitOpen, range: timeRange });
@@ -320,11 +321,11 @@ export const CandlestickPanel: React.FC<CandlestickPanelProps> = ({
               />
             )}
 
-            {canEditThresholds && onThresholdsChange && (
+            {((canEditThresholds && onThresholdsChange) || showThresholds) && (
               <ThresholdControlsPlugin
                 config={config}
                 fieldConfig={fieldConfig}
-                onThresholdsChange={onThresholdsChange}
+                onThresholdsChange={canEditThresholds ? onThresholdsChange : undefined}
               />
             )}
 

--- a/public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx
+++ b/public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx
@@ -30,7 +30,8 @@ export const TimeSeriesPanel: React.FC<TimeSeriesPanelProps> = ({
   replaceVariables,
   id,
 }) => {
-  const { sync, canAddAnnotations, onThresholdsChange, canEditThresholds, onSplitOpen } = usePanelContext();
+  const { sync, canAddAnnotations, onThresholdsChange, canEditThresholds, showThresholds, onSplitOpen } =
+    usePanelContext();
 
   const getFieldLinks = (field: Field, rowIndex: number) => {
     return getFieldLinksForExplore({ field, rowIndex, splitOpenFn: onSplitOpen, range: timeRange });
@@ -141,11 +142,11 @@ export const TimeSeriesPanel: React.FC<TimeSeriesPanelProps> = ({
               />
             )}
 
-            {canEditThresholds && onThresholdsChange && (
+            {((canEditThresholds && onThresholdsChange) || showThresholds) && (
               <ThresholdControlsPlugin
                 config={config}
                 fieldConfig={fieldConfig}
-                onThresholdsChange={onThresholdsChange}
+                onThresholdsChange={canEditThresholds ? onThresholdsChange : undefined}
               />
             )}
 

--- a/public/app/plugins/panel/timeseries/plugins/ThresholdControlsPlugin.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/ThresholdControlsPlugin.tsx
@@ -11,7 +11,7 @@ const GUTTER_SIZE = 60;
 interface ThresholdControlsPluginProps {
   config: UPlotConfigBuilder;
   fieldConfig: FieldConfigSource;
-  onThresholdsChange: (thresholds: ThresholdsConfig) => void;
+  onThresholdsChange?: (thresholds: ThresholdsConfig) => void;
 }
 
 export const ThresholdControlsPlugin: React.FC<ThresholdControlsPluginProps> = ({
@@ -59,15 +59,10 @@ export const ThresholdControlsPlugin: React.FC<ThresholdControlsPluginProps> = (
 
       const height = plot.bbox.height / window.devicePixelRatio;
 
-      const handle = (
-        <ThresholdDragHandle
-          key={`${step.value}-${i}`}
-          step={step}
-          y={yPos}
-          dragBounds={{ top: 0, bottom: height }}
-          mapPositionToValue={(y) => plot.posToVal(y, scale)}
-          formatValue={(v) => getValueFormat(scale)(v, decimals).text}
-          onChange={(value) => {
+      const isEditable = typeof onThresholdsChange === 'function';
+
+      const onChange = isEditable
+        ? (value: number) => {
             const nextSteps = [
               ...thresholds.steps.slice(0, i),
               ...thresholds.steps.slice(i + 1),
@@ -78,7 +73,18 @@ export const ThresholdControlsPlugin: React.FC<ThresholdControlsPluginProps> = (
               ...thresholds,
               steps: nextSteps,
             });
-          }}
+          }
+        : undefined;
+
+      const handle = (
+        <ThresholdDragHandle
+          key={`${step.value}-${i}`}
+          step={step}
+          y={yPos}
+          dragBounds={{ top: 0, bottom: height }}
+          mapPositionToValue={(y) => plot.posToVal(y, scale)}
+          formatValue={(v) => getValueFormat(scale)(v, decimals).text}
+          onChange={onChange}
         />
       );
 


### PR DESCRIPTION
**What is this feature?**

Allows showing threshold indicators _without_ having to have a `onChange` handler and disabling the dragging behavior.

<img width="574" alt="image" src="https://user-images.githubusercontent.com/868844/208687999-79753e78-0a50-4b90-9541-18366b3bbdf8.png">

**Why do we need this feature?**

This is split off from https://github.com/grafana/grafana/pull/60046 where we have better support for visualising threshold indicators for multiple expressions but without the ability to drag the thresholds.

This PR makes the `onChange` handler optional and introduces a new property called `showThresholds` to the panel context.

Right now using `canEditThresholds` will still show the threshold handles even if `showThresholds` is set to `false` to remain backwards compatible but I'm also up for changing that since we (alerting) seems to be the only consumers of this property.

