### PR TITLE
SupportBundles: Do not allow multiple collectors with the same UID

### DIFF
--- a/pkg/infra/supportbundles/supportbundlesimpl/api.go
+++ b/pkg/infra/supportbundles/supportbundlesimpl/api.go
@@ -36,7 +36,7 @@ func (s *Service) registerAPIEndpoints(routeRegister routing.RouteRegister) {
 }
 
 func (s *Service) handleList(ctx *models.ReqContext) response.Response {
-	bundles, err := s.List(ctx.Req.Context())
+	bundles, err := s.list(ctx.Req.Context())
 	if err != nil {
 		return response.Error(http.StatusInternalServerError, "failed to list bundles", err)
 	}
@@ -59,7 +59,7 @@ func (s *Service) handleCreate(ctx *models.ReqContext) response.Response {
 		return response.Error(http.StatusBadRequest, "failed to parse request", err)
 	}
 
-	bundle, err := s.Create(context.Background(), c.Collectors, ctx.SignedInUser)
+	bundle, err := s.create(context.Background(), c.Collectors, ctx.SignedInUser)
 	if err != nil {
 		return response.Error(http.StatusInternalServerError, "failed to create support bundle", err)
 	}
@@ -74,7 +74,7 @@ func (s *Service) handleCreate(ctx *models.ReqContext) response.Response {
 
 func (s *Service) handleDownload(ctx *models.ReqContext) {
 	uid := web.Params(ctx.Req)[":uid"]
-	bundle, err := s.Get(ctx.Req.Context(), uid)
+	bundle, err := s.get(ctx.Req.Context(), uid)
 	if err != nil {
 		ctx.Redirect("/admin/support-bundles")
 		return
@@ -102,7 +102,7 @@ func (s *Service) handleDownload(ctx *models.ReqContext) {
 
 func (s *Service) handleRemove(ctx *models.ReqContext) response.Response {
 	uid := web.Params(ctx.Req)[":uid"]
-	err := s.Remove(ctx.Req.Context(), uid)
+	err := s.remove(ctx.Req.Context(), uid)
 	if err != nil {
 		return response.Error(http.StatusInternalServerError, "failed to remove bundle", err)
 	}

--- a/pkg/infra/supportbundles/supportbundlesimpl/api.go
+++ b/pkg/infra/supportbundles/supportbundlesimpl/api.go
@@ -111,5 +111,11 @@ func (s *Service) handleRemove(ctx *models.ReqContext) response.Response {
 }
 
 func (s *Service) handleGetCollectors(ctx *models.ReqContext) response.Response {
-	return response.JSON(http.StatusOK, s.collectors)
+	collectors := make([]supportbundles.Collector, 0, len(s.collectors))
+
+	for _, c := range s.collectors {
+		collectors = append(collectors, c)
+	}
+
+	return response.JSON(http.StatusOK, collectors)
 }

--- a/pkg/infra/supportbundles/supportbundlesimpl/models.go
+++ b/pkg/infra/supportbundles/supportbundlesimpl/models.go
@@ -35,7 +35,7 @@ var (
 	}
 )
 
-func DeclareFixedRoles(ac accesscontrol.Service) error {
+func declareFixedRoles(ac accesscontrol.Service) error {
 	bundleReader := accesscontrol.RoleRegistration{
 		Role:   bundleReaderRole,
 		Grants: []string{string(org.RoleAdmin)},

--- a/pkg/infra/supportbundles/supportbundlesimpl/service.go
+++ b/pkg/infra/supportbundles/supportbundlesimpl/service.go
@@ -36,7 +36,7 @@ type Service struct {
 
 	log log.Logger
 
-	collectors []supportbundles.Collector
+	collectors map[string]supportbundles.Collector
 }
 
 func ProvideService(cfg *setting.Cfg,
@@ -59,6 +59,7 @@ func ProvideService(cfg *setting.Cfg,
 		accessControl:  accessControl,
 		features:       features,
 		log:            log.New("supportbundle.service"),
+		collectors:     make(map[string]supportbundles.Collector),
 	}
 
 	if !features.IsEnabled(featuremgmt.FlagSupportBundles) {
@@ -85,8 +86,11 @@ func ProvideService(cfg *setting.Cfg,
 }
 
 func (s *Service) RegisterSupportItemCollector(collector supportbundles.Collector) {
-	// FIXME: add check for duplicate UIDs
-	s.collectors = append(s.collectors, collector)
+	if _, ok := s.collectors[collector.UID]; ok {
+		s.log.Warn("Support bundle collector with the same UID already registered", "uid", collector.UID)
+	}
+
+	s.collectors[collector.UID] = collector
 }
 
 func (s *Service) Run(ctx context.Context) error {

--- a/pkg/infra/supportbundles/supportbundlesimpl/service.go
+++ b/pkg/infra/supportbundles/supportbundlesimpl/service.go
@@ -21,6 +21,11 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 )
 
+const (
+	cleanUpInterval       = 24 * time.Hour
+	bundleCreationTimeout = 20 * time.Minute
+)
+
 type Service struct {
 	cfg            *setting.Cfg
 	store          bundleStore
@@ -89,7 +94,7 @@ func (s *Service) Run(ctx context.Context) error {
 		return nil
 	}
 
-	ticker := time.NewTicker(24 * time.Hour)
+	ticker := time.NewTicker(cleanUpInterval)
 	defer ticker.Stop()
 	s.cleanup(ctx)
 	select {
@@ -108,7 +113,7 @@ func (s *Service) create(ctx context.Context, collectors []string, usr *user.Sig
 	}
 
 	go func(uid string, collectors []string) {
-		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
+		ctx, cancel := context.WithTimeout(context.Background(), bundleCreationTimeout)
 		defer cancel()
 		s.startBundleWork(ctx, collectors, uid)
 	}(bundle.UID, collectors)

--- a/pkg/infra/supportbundles/supportbundlesimpl/service.go
+++ b/pkg/infra/supportbundles/supportbundlesimpl/service.go
@@ -128,12 +128,12 @@ func (s *Service) remove(ctx context.Context, uid string) error {
 	// Remove the data
 	bundle, err := s.store.Get(ctx, uid)
 	if err != nil {
-		return fmt.Errorf("could not retrieve support bundle with uid %s: %w", uid, err)
+		return fmt.Errorf("could not retrieve support bundle with UID %s: %w", uid, err)
 	}
 
 	// TODO handle cases when bundles aren't complete yet
 	if bundle.State == supportbundles.StatePending {
-		return fmt.Errorf("could not remove a support bundle with uid %s as it is still beign cteated", uid)
+		return fmt.Errorf("could not remove a support bundle with uid %s as it is still being created", uid)
 	}
 
 	if bundle.FilePath != "" {

--- a/pkg/infra/supportbundles/supportbundlesimpl/service_test.go
+++ b/pkg/infra/supportbundles/supportbundlesimpl/service_test.go
@@ -1,0 +1,44 @@
+package supportbundlesimpl
+
+import (
+	"context"
+	"testing"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/infra/supportbundles"
+	"github.com/grafana/grafana/pkg/setting"
+	"github.com/stretchr/testify/require"
+)
+
+func TestService_RegisterSupportItemCollector(t *testing.T) {
+	s := &Service{
+		cfg:            &setting.Cfg{},
+		store:          nil,
+		pluginStore:    nil,
+		pluginSettings: nil,
+		accessControl:  nil,
+		features:       nil,
+		log:            log.NewNopLogger(),
+		collectors:     map[string]supportbundles.Collector{},
+	}
+	collector := supportbundles.Collector{
+		UID:               "test",
+		DisplayName:       "test",
+		Description:       "test",
+		IncludedByDefault: true,
+		Default:           true,
+		Fn: func(context.Context) (*supportbundles.SupportItem, error) {
+			return nil, nil
+		},
+	}
+
+	t.Run("should register collector", func(t *testing.T) {
+		s.RegisterSupportItemCollector(collector)
+		require.Len(t, s.collectors, 1)
+	})
+
+	t.Run("should not register collector with same UID", func(t *testing.T) {
+		s.RegisterSupportItemCollector(collector)
+		require.Len(t, s.collectors, 1)
+	})
+}

--- a/pkg/infra/supportbundles/supportbundlesimpl/store.go
+++ b/pkg/infra/supportbundles/supportbundlesimpl/store.go
@@ -22,6 +22,14 @@ type store struct {
 	kv *kvstore.NamespacedKVStore
 }
 
+type bundleStore interface {
+	Create(ctx context.Context, usr *user.SignedInUser) (*supportbundles.Bundle, error)
+	Get(ctx context.Context, uid string) (*supportbundles.Bundle, error)
+	List() ([]supportbundles.Bundle, error)
+	Remove(ctx context.Context, uid string) error
+	Update(ctx context.Context, uid string, state supportbundles.State, filePath string) error
+}
+
 func (s *store) Create(ctx context.Context, usr *user.SignedInUser) (*supportbundles.Bundle, error) {
 	uid, err := uuid.NewRandom()
 	if err != nil {

--- a/pkg/infra/supportbundles/supportbundlesimpl/store.go
+++ b/pkg/infra/supportbundles/supportbundlesimpl/store.go
@@ -14,6 +14,10 @@ import (
 	"github.com/grafana/grafana/pkg/services/user"
 )
 
+const (
+	defaultBundleExpiration = 72 * time.Hour // 72h
+)
+
 func newStore(kv kvstore.KVStore) *store {
 	return &store{kv: kvstore.WithNamespace(kv, 0, "supportbundle")}
 }
@@ -41,7 +45,7 @@ func (s *store) Create(ctx context.Context, usr *user.SignedInUser) (*supportbun
 		State:     supportbundles.StatePending,
 		Creator:   usr.Login,
 		CreatedAt: time.Now().Unix(),
-		ExpiresAt: time.Now().Add(24 * time.Hour).Unix(),
+		ExpiresAt: time.Now().Add(defaultBundleExpiration).Unix(),
 	}
 
 	if err := s.set(ctx, &bundle); err != nil {


### PR DESCRIPTION
- Unexport service methods
- Fix Typos
- Make constants out of durations
- Prevent bundles from having the same UID (breaks the frontend and creation) 