### PR TITLE
RBAC: dashboard permission filter

### DIFF
--- a/pkg/services/searchV2/auth.go
+++ b/pkg/services/searchV2/auth.go
@@ -41,7 +41,7 @@ func (a *simpleSQLAuthService) getDashboardTableAuthFilter(user *user.SignedInUs
 		}
 	}
 
-	return permissions.NewAccessControlDashboardPermissionFilter(user, models.PERMISSION_VIEW, searchstore.TypeDashboard)
+	return permissions.NewAccessControlDashboardPermissionFilter(user, models.PERMISSION_VIEW, "")
 }
 
 func (a *simpleSQLAuthService) GetDashboardReadFilter(user *user.SignedInUser) (ResourceFilter, error) {

--- a/pkg/services/sqlstore/permissions/dashboard.go
+++ b/pkg/services/sqlstore/permissions/dashboard.go
@@ -133,7 +133,7 @@ func (f AccessControlDashboardPermissionFilter) Where() (string, []interface{}) 
 	folderWildcards := accesscontrol.WildcardsFromPrefix(dashboards.ScopeFoldersPrefix)
 
 	filter, params := accesscontrol.UserRolesFilter(f.user.OrgID, f.user.UserID, f.user.Teams, accesscontrol.GetOrgRoles(f.user))
-	rolesFilter := " AND role_id IN(SELECT distinct id FROM role " + filter + ") "
+	rolesFilter := " AND role_id IN(SELECT id FROM role " + filter + ") "
 	var args []interface{}
 	builder := strings.Builder{}
 	builder.WriteRune('(')


### PR DESCRIPTION
**What is this feature?**
Seems like the group by used in dashboard permission filter is causing some [performance issues](https://github.com/grafana/grafana/issues/55332#issuecomment-1359018233)

We need it when filtering on certain permissions e.g. searching for folders that a user can read and create dashboards in.

But there are room for improvements there:

1. Check all available query types and only add actions related to that type, "dash-folder", "dash-db" and "dash-folder-alerting". This would reduce the amount of permissions we have to filter on when only searching for e.g. folders. If no type is specified then default should is dashboard and folder actions

2. If we only need to check one scope we could skip the in + group by in the query and replace that with action = ?. This seems to be the most common case when using old search (used for main search view) and only need more actions for listing folders to add / save dashboard in and when listing folders for alerting

@IevaVasiljeva Is working on new search. There we can skip doing a db lookup for permissions and construct the lookup map from the permissions provided in "SignedInUser"

Fixes #

**Special notes for your reviewer**:

