### PR TITLE
AzureMonitor: Set Logs portal URL from resource URI

### DIFF
--- a/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
@@ -202,8 +202,7 @@ func (e *AzureLogAnalyticsDatasource) executeQuery(ctx context.Context, logger l
 
 	err = setAdditionalFrameMeta(frame,
 		query.Params.Get("query"),
-		model.Get("subscriptionId").MustString(),
-		model.Get("azureLogAnalytics").Get("workspace").MustString())
+		model.Get("azureLogAnalytics").Get("resource").MustString())
 	if err != nil {
 		frame.AppendNotices(data.Notice{Severity: data.NoticeSeverityWarning, Text: "could not add custom metadata: " + err.Error()})
 		logger.Warn("failed to add custom metadata to azure log analytics response", err)
@@ -317,12 +316,11 @@ func (e *AzureLogAnalyticsDatasource) unmarshalResponse(logger log.Logger, res *
 // LogAnalyticsMeta is a type for the a Frame's Meta's Custom property.
 type LogAnalyticsMeta struct {
 	ColumnTypes  []string `json:"azureColumnTypes"`
-	Subscription string   `json:"subscription"`
-	Workspace    string   `json:"workspace"`
 	EncodedQuery []byte   `json:"encodedQuery"` // EncodedQuery is used for deep links.
+	Resource     string   `json:"resource"`
 }
 
-func setAdditionalFrameMeta(frame *data.Frame, query, subscriptionID, workspace string) error {
+func setAdditionalFrameMeta(frame *data.Frame, query, resource string) error {
 	if frame.Meta == nil || frame.Meta.Custom == nil {
 		// empty response
 		return nil
@@ -332,8 +330,7 @@ func setAdditionalFrameMeta(frame *data.Frame, query, subscriptionID, workspace 
 	if !ok {
 		return fmt.Errorf("unexpected type found for frame's custom metadata")
 	}
-	la.Subscription = subscriptionID
-	la.Workspace = workspace
+	la.Resource = resource
 	encodedQuery, err := encodeQuery(query)
 	if err == nil {
 		la.EncodedQuery = encodedQuery

--- a/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource_test.go
@@ -247,7 +247,7 @@ func Test_executeQueryErrorWithDifferentLogAnalyticsCreds(t *testing.T) {
 func Test_setAdditionalFrameMeta(t *testing.T) {
 	t.Run("it should not error with an empty response", func(t *testing.T) {
 		frame := data.NewFrame("test")
-		err := setAdditionalFrameMeta(frame, "", "", "")
+		err := setAdditionalFrameMeta(frame, "", "")
 		require.NoError(t, err)
 	})
 }

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_log_analytics/azure_log_analytics_datasource.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_log_analytics/azure_log_analytics_datasource.ts
@@ -184,19 +184,12 @@ export default class AzureLogAnalyticsDatasource extends DataSourceWithBackend<
 
   private async buildDeepLink(customMeta: Record<string, any>) {
     const base64Enc = encodeURIComponent(customMeta.encodedQuery);
-    const workspaceId = customMeta.workspace;
-    const subscription = customMeta.subscription;
-
-    const details = await this.getWorkspaceDetails(workspaceId);
-    if (!details.workspace || !details.resourceGroup) {
-      return '';
-    }
+    const resource = encodeURIComponent(customMeta.resource);
 
     const url =
       `${this.azurePortalUrl}/#blade/Microsoft_OperationsManagementSuite_Workspace/` +
       `AnalyticsBlade/initiator/AnalyticsShareLinkToQuery/isQueryEditorVisible/true/scope/` +
-      `%7B%22resources%22%3A%5B%7B%22resourceId%22%3A%22%2Fsubscriptions%2F${subscription}` +
-      `%2Fresourcegroups%2F${details.resourceGroup}%2Fproviders%2Fmicrosoft.operationalinsights%2Fworkspaces%2F${details.workspace}` +
+      `%7B%22resources%22%3A%5B%7B%22resourceId%22%3A%22${resource}` +
       `%22%7D%5D%7D/query/${base64Enc}/isQueryBase64Compressed/true/timespanInIsoFormat/P1D`;
     return url;
   }


### PR DESCRIPTION
Correctly uses the resource URI to set the portal deep link.

Fixes #52294 