### PR TITLE
Alerting: Update receivers to use app version from factory config

### DIFF
--- a/pkg/services/ngalert/notifier/channels/discord.go
+++ b/pkg/services/ngalert/notifier/channels/discord.go
@@ -18,16 +18,16 @@ import (
 	"github.com/prometheus/common/model"
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
-	"github.com/grafana/grafana/pkg/setting"
 )
 
 type DiscordNotifier struct {
 	*channels.Base
-	log      channels.Logger
-	ns       channels.WebhookSender
-	images   channels.ImageStore
-	tmpl     *template.Template
-	settings *discordSettings
+	log        channels.Logger
+	ns         channels.WebhookSender
+	images     channels.ImageStore
+	tmpl       *template.Template
+	settings   *discordSettings
+	appVersion string
 }
 
 type discordSettings struct {
@@ -83,12 +83,13 @@ func newDiscordNotifier(fc channels.FactoryConfig) (*DiscordNotifier, error) {
 		return nil, err
 	}
 	return &DiscordNotifier{
-		Base:     channels.NewBase(fc.Config),
-		log:      fc.Logger,
-		ns:       fc.NotificationService,
-		images:   fc.ImageStore,
-		tmpl:     fc.Template,
-		settings: settings,
+		Base:       channels.NewBase(fc.Config),
+		log:        fc.Logger,
+		ns:         fc.NotificationService,
+		images:     fc.ImageStore,
+		tmpl:       fc.Template,
+		settings:   settings,
+		appVersion: fc.GrafanaBuildVersion,
 	}, nil
 }
 
@@ -121,7 +122,7 @@ func (d DiscordNotifier) Notify(ctx context.Context, as ...*types.Alert) (bool, 
 	}
 
 	footer := map[string]interface{}{
-		"text":     "Grafana v" + setting.BuildVersion,
+		"text":     "Grafana v" + d.appVersion,
 		"icon_url": "https://grafana.com/static/assets/img/fav32.png",
 	}
 

--- a/pkg/services/ngalert/notifier/channels/discord_test.go
+++ b/pkg/services/ngalert/notifier/channels/discord_test.go
@@ -3,6 +3,8 @@ package channels
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"math/rand"
 	"net/url"
 	"testing"
 
@@ -11,8 +13,6 @@ import (
 	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
-
-	"github.com/grafana/grafana/pkg/setting"
 )
 
 func TestDiscordNotifier(t *testing.T) {
@@ -21,7 +21,7 @@ func TestDiscordNotifier(t *testing.T) {
 	externalURL, err := url.Parse("http://localhost")
 	require.NoError(t, err)
 	tmpl.ExternalURL = externalURL
-
+	appVersion := fmt.Sprintf("%d.0.0", rand.Uint32())
 	cases := []struct {
 		name         string
 		settings     string
@@ -47,7 +47,7 @@ func TestDiscordNotifier(t *testing.T) {
 					"color": 1.4037554e+07,
 					"footer": map[string]interface{}{
 						"icon_url": "https://grafana.com/static/assets/img/fav32.png",
-						"text":     "Grafana v" + setting.BuildVersion,
+						"text":     "Grafana v" + appVersion,
 					},
 					"title": "[FIRING:1]  (val1)",
 					"url":   "http://localhost/alerting/list",
@@ -74,7 +74,7 @@ func TestDiscordNotifier(t *testing.T) {
 					"color": 1.4037554e+07,
 					"footer": map[string]interface{}{
 						"icon_url": "https://grafana.com/static/assets/img/fav32.png",
-						"text":     "Grafana v" + setting.BuildVersion,
+						"text":     "Grafana v" + appVersion,
 					},
 					"title": "Alerts firing: 1",
 					"url":   "http://localhost/alerting/list",
@@ -106,7 +106,7 @@ func TestDiscordNotifier(t *testing.T) {
 					"color": 1.4037554e+07,
 					"footer": map[string]interface{}{
 						"icon_url": "https://grafana.com/static/assets/img/fav32.png",
-						"text":     "Grafana v" + setting.BuildVersion,
+						"text":     "Grafana v" + appVersion,
 					},
 					"title": "[FIRING:1]  (val1)",
 					"url":   "http://localhost/alerting/list",
@@ -138,7 +138,7 @@ func TestDiscordNotifier(t *testing.T) {
 					"color": 1.4037554e+07,
 					"footer": map[string]interface{}{
 						"icon_url": "https://grafana.com/static/assets/img/fav32.png",
-						"text":     "Grafana v" + setting.BuildVersion,
+						"text":     "Grafana v" + appVersion,
 					},
 					"title": "[FIRING:1]  (val1)",
 					"url":   "http://localhost/alerting/list",
@@ -170,7 +170,7 @@ func TestDiscordNotifier(t *testing.T) {
 					"color": 1.4037554e+07,
 					"footer": map[string]interface{}{
 						"icon_url": "https://grafana.com/static/assets/img/fav32.png",
-						"text":     "Grafana v" + setting.BuildVersion,
+						"text":     "Grafana v" + appVersion,
 					},
 					"title": "[FIRING:1]  (val1)",
 					"url":   "http://localhost/alerting/list",
@@ -202,7 +202,7 @@ func TestDiscordNotifier(t *testing.T) {
 					"color": 1.4037554e+07,
 					"footer": map[string]interface{}{
 						"icon_url": "https://grafana.com/static/assets/img/fav32.png",
-						"text":     "Grafana v" + setting.BuildVersion,
+						"text":     "Grafana v" + appVersion,
 					},
 					"title": "[FIRING:1]  (val1)",
 					"url":   "http://localhost/alerting/list",
@@ -239,7 +239,7 @@ func TestDiscordNotifier(t *testing.T) {
 					"color": 1.4037554e+07,
 					"footer": map[string]interface{}{
 						"icon_url": "https://grafana.com/static/assets/img/fav32.png",
-						"text":     "Grafana v" + setting.BuildVersion,
+						"text":     "Grafana v" + appVersion,
 					},
 					"title": "[FIRING:2]  ",
 					"url":   "http://localhost/alerting/list",
@@ -274,7 +274,7 @@ func TestDiscordNotifier(t *testing.T) {
 					"color": 1.4037554e+07,
 					"footer": map[string]interface{}{
 						"icon_url": "https://grafana.com/static/assets/img/fav32.png",
-						"text":     "Grafana v" + setting.BuildVersion,
+						"text":     "Grafana v" + appVersion,
 					},
 					"title": "[FIRING:1]  (val1)",
 					"url":   "http://localhost/alerting/list",
@@ -301,6 +301,7 @@ func TestDiscordNotifier(t *testing.T) {
 				NotificationService: webhookSender,
 				Template:            tmpl,
 				Logger:              &channels.FakeLogger{},
+				GrafanaBuildVersion: appVersion,
 			}
 
 			dn, err := newDiscordNotifier(fc)

--- a/pkg/services/ngalert/notifier/channels/googlechat.go
+++ b/pkg/services/ngalert/notifier/channels/googlechat.go
@@ -11,19 +11,18 @@ import (
 	"github.com/grafana/alerting/alerting/notifier/channels"
 	"github.com/prometheus/alertmanager/template"
 	"github.com/prometheus/alertmanager/types"
-
-	"github.com/grafana/grafana/pkg/setting"
 )
 
 // GoogleChatNotifier is responsible for sending
 // alert notifications to Google chat.
 type GoogleChatNotifier struct {
 	*channels.Base
-	log      channels.Logger
-	ns       channels.WebhookSender
-	images   channels.ImageStore
-	tmpl     *template.Template
-	settings *googleChatSettings
+	log        channels.Logger
+	ns         channels.WebhookSender
+	images     channels.ImageStore
+	tmpl       *template.Template
+	settings   *googleChatSettings
+	appVersion string
 }
 
 type googleChatSettings struct {
@@ -68,12 +67,13 @@ func newGoogleChatNotifier(fc channels.FactoryConfig) (*GoogleChatNotifier, erro
 		return nil, err
 	}
 	return &GoogleChatNotifier{
-		Base:     channels.NewBase(fc.Config),
-		log:      fc.Logger,
-		ns:       fc.NotificationService,
-		images:   fc.ImageStore,
-		tmpl:     fc.Template,
-		settings: settings,
+		Base:       channels.NewBase(fc.Config),
+		log:        fc.Logger,
+		ns:         fc.NotificationService,
+		images:     fc.ImageStore,
+		tmpl:       fc.Template,
+		settings:   settings,
+		appVersion: fc.GrafanaBuildVersion,
 	}, nil
 }
 
@@ -121,7 +121,7 @@ func (gcn *GoogleChatNotifier) Notify(ctx context.Context, as ...*types.Alert) (
 	// Add text paragraph widget for the build version and timestamp.
 	widgets = append(widgets, textParagraphWidget{
 		Text: text{
-			Text: "Grafana v" + setting.BuildVersion + " | " + (timeNow()).Format(time.RFC822),
+			Text: "Grafana v" + gcn.appVersion + " | " + (timeNow()).Format(time.RFC822),
 		},
 	})
 

--- a/pkg/services/ngalert/notifier/channels/googlechat_test.go
+++ b/pkg/services/ngalert/notifier/channels/googlechat_test.go
@@ -3,6 +3,8 @@ package channels
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"math/rand"
 	"net/url"
 	"testing"
 	"time"
@@ -13,13 +15,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/alerting/alerting/notifier/channels"
-
-	"github.com/grafana/grafana/pkg/setting"
 )
 
 func TestGoogleChatNotifier(t *testing.T) {
 	constNow := time.Now()
 	defer mockTimeNow(constNow)()
+	appVersion := fmt.Sprintf("%d.0.0", rand.Uint32())
 
 	cases := []struct {
 		name         string
@@ -75,7 +76,7 @@ func TestGoogleChatNotifier(t *testing.T) {
 									textParagraphWidget{
 										Text: text{
 											// RFC822 only has the minute, hence it works in most cases.
-											Text: "Grafana v" + setting.BuildVersion + " | " + constNow.Format(time.RFC822),
+											Text: "Grafana v" + appVersion + " | " + constNow.Format(time.RFC822),
 										},
 									},
 								},
@@ -134,7 +135,7 @@ func TestGoogleChatNotifier(t *testing.T) {
 									},
 									textParagraphWidget{
 										Text: text{
-											Text: "Grafana v" + setting.BuildVersion + " | " + constNow.Format(time.RFC822),
+											Text: "Grafana v" + appVersion + " | " + constNow.Format(time.RFC822),
 										},
 									},
 								},
@@ -194,7 +195,7 @@ func TestGoogleChatNotifier(t *testing.T) {
 									textParagraphWidget{
 										Text: text{
 											// RFC822 only has the minute, hence it works in most cases.
-											Text: "Grafana v" + setting.BuildVersion + " | " + constNow.Format(time.RFC822),
+											Text: "Grafana v" + appVersion + " | " + constNow.Format(time.RFC822),
 										},
 									},
 								},
@@ -249,7 +250,7 @@ func TestGoogleChatNotifier(t *testing.T) {
 									textParagraphWidget{
 										Text: text{
 											// RFC822 only has the minute, hence it works in most cases.
-											Text: "Grafana v" + setting.BuildVersion + " | " + constNow.Format(time.RFC822),
+											Text: "Grafana v" + appVersion + " | " + constNow.Format(time.RFC822),
 										},
 									},
 								},
@@ -304,7 +305,7 @@ func TestGoogleChatNotifier(t *testing.T) {
 									textParagraphWidget{
 										Text: text{
 											// RFC822 only has the minute, hence it works in most cases.
-											Text: "Grafana v" + setting.BuildVersion + " | " + constNow.Format(time.RFC822),
+											Text: "Grafana v" + appVersion + " | " + constNow.Format(time.RFC822),
 										},
 									},
 								},
@@ -354,7 +355,7 @@ func TestGoogleChatNotifier(t *testing.T) {
 									textParagraphWidget{
 										Text: text{
 											// RFC822 only has the minute, hence it works in most cases.
-											Text: "Grafana v" + setting.BuildVersion + " | " + constNow.Format(time.RFC822),
+											Text: "Grafana v" + appVersion + " | " + constNow.Format(time.RFC822),
 										},
 									},
 								},
@@ -399,7 +400,7 @@ func TestGoogleChatNotifier(t *testing.T) {
 									textParagraphWidget{
 										Text: text{
 											// RFC822 only has the minute, hence it works in most cases.
-											Text: "Grafana v" + setting.BuildVersion + " | " + constNow.Format(time.RFC822),
+											Text: "Grafana v" + appVersion + " | " + constNow.Format(time.RFC822),
 										},
 									},
 								},
@@ -443,7 +444,7 @@ func TestGoogleChatNotifier(t *testing.T) {
 									textParagraphWidget{
 										Text: text{
 											// RFC822 only has the minute, hence it works in most cases.
-											Text: "Grafana v" + setting.BuildVersion + " | " + constNow.Format(time.RFC822),
+											Text: "Grafana v" + appVersion + " | " + constNow.Format(time.RFC822),
 										},
 									},
 								},
@@ -476,6 +477,7 @@ func TestGoogleChatNotifier(t *testing.T) {
 				NotificationService: webhookSender,
 				Template:            tmpl,
 				Logger:              &channels.FakeLogger{},
+				GrafanaBuildVersion: appVersion,
 			}
 
 			pn, err := newGoogleChatNotifier(fc)

--- a/pkg/services/ngalert/notifier/channels/slack.go
+++ b/pkg/services/ngalert/notifier/channels/slack.go
@@ -23,8 +23,6 @@ import (
 	"github.com/prometheus/alertmanager/types"
 
 	"github.com/grafana/alerting/alerting/notifier/channels"
-
-	"github.com/grafana/grafana/pkg/setting"
 )
 
 const (
@@ -68,6 +66,7 @@ type SlackNotifier struct {
 	webhookSender channels.WebhookSender
 	sendFn        sendFunc
 	settings      slackSettings
+	appVersion    string
 }
 
 type slackSettings struct {
@@ -164,6 +163,7 @@ func buildSlackNotifier(factoryConfig channels.FactoryConfig) (*SlackNotifier, e
 		sendFn:        sendSlackRequest,
 		log:           factoryConfig.Logger,
 		tmpl:          factoryConfig.Template,
+		appVersion:    factoryConfig.GrafanaBuildVersion,
 	}, nil
 }
 
@@ -374,7 +374,7 @@ func (sn *SlackNotifier) createSlackMessage(ctx context.Context, alerts []*types
 				Color:      getAlertStatusColor(types.Alerts(alerts...).Status()),
 				Title:      title,
 				Fallback:   title,
-				Footer:     "Grafana v" + setting.BuildVersion,
+				Footer:     "Grafana v" + sn.appVersion,
 				FooterIcon: channels.FooterIconURL,
 				Ts:         time.Now().Unix(),
 				TitleLink:  ruleURL,

--- a/pkg/services/ngalert/notifier/channels/slack_test.go
+++ b/pkg/services/ngalert/notifier/channels/slack_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
+	"math/rand"
 	"mime"
 	"mime/multipart"
 	"net/http"
@@ -20,9 +22,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/alerting/alerting/notifier/channels"
-
-	"github.com/grafana/grafana/pkg/setting"
 )
+
+var appVersion = fmt.Sprintf("%d.0.0", rand.Uint32())
 
 func TestSlackIncomingWebhook(t *testing.T) {
 	tests := []struct {
@@ -55,7 +57,7 @@ func TestSlackIncomingWebhook(t *testing.T) {
 					Text:       "**Firing**\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1\n",
 					Fallback:   "[FIRING:1]  (val1)",
 					Fields:     nil,
-					Footer:     "Grafana v" + setting.BuildVersion,
+					Footer:     "Grafana v" + appVersion,
 					FooterIcon: "https://grafana.com/static/assets/img/fav32.png",
 					Color:      "#D63232",
 				},
@@ -85,7 +87,7 @@ func TestSlackIncomingWebhook(t *testing.T) {
 					Text:       "**Firing**\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1\nDashboard: http://localhost/d/abcd\nPanel: http://localhost/d/abcd?viewPanel=efgh\n",
 					Fallback:   "[FIRING:1]  (val1)",
 					Fields:     nil,
-					Footer:     "Grafana v" + setting.BuildVersion,
+					Footer:     "Grafana v" + appVersion,
 					FooterIcon: "https://grafana.com/static/assets/img/fav32.png",
 					Color:      "#D63232",
 					ImageURL:   "https://www.example.com/test.png",
@@ -116,7 +118,7 @@ func TestSlackIncomingWebhook(t *testing.T) {
 					Text:       "**Firing**\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1\nDashboard: http://localhost/d/abcd\nPanel: http://localhost/d/abcd?viewPanel=efgh\n",
 					Fallback:   "[FIRING:1]  (val1)",
 					Fields:     nil,
-					Footer:     "Grafana v" + setting.BuildVersion,
+					Footer:     "Grafana v" + appVersion,
 					FooterIcon: "https://grafana.com/static/assets/img/fav32.png",
 					Color:      "#D63232",
 				},
@@ -198,7 +200,7 @@ func TestSlackPostMessage(t *testing.T) {
 					Text:       "**Firing**\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1\nDashboard: http://localhost/d/abcd\nPanel: http://localhost/d/abcd?viewPanel=efgh\n",
 					Fallback:   "[FIRING:1]  (val1)",
 					Fields:     nil,
-					Footer:     "Grafana v" + setting.BuildVersion,
+					Footer:     "Grafana v" + appVersion,
 					FooterIcon: "https://grafana.com/static/assets/img/fav32.png",
 					Color:      "#D63232",
 				},
@@ -234,7 +236,7 @@ func TestSlackPostMessage(t *testing.T) {
 					Text:       "**Firing**\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val2\nAnnotations:\n - ann1 = annv2\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval2\n",
 					Fallback:   "2 firing, 0 resolved",
 					Fields:     nil,
-					Footer:     "Grafana v" + setting.BuildVersion,
+					Footer:     "Grafana v" + appVersion,
 					FooterIcon: "https://grafana.com/static/assets/img/fav32.png",
 					Color:      "#D63232",
 				},
@@ -264,7 +266,7 @@ func TestSlackPostMessage(t *testing.T) {
 					Text:       "**Firing**\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1\nDashboard: http://localhost/d/abcd\nPanel: http://localhost/d/abcd?viewPanel=efgh\n",
 					Fallback:   "[FIRING:1]  (val1)",
 					Fields:     nil,
-					Footer:     "Grafana v" + setting.BuildVersion,
+					Footer:     "Grafana v" + appVersion,
 					FooterIcon: "https://grafana.com/static/assets/img/fav32.png",
 					Color:      "#D63232",
 				},
@@ -304,7 +306,7 @@ func TestSlackPostMessage(t *testing.T) {
 					Text:       "**Firing**\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1\n",
 					Fallback:   "[FIRING:1]  (val1)",
 					Fields:     nil,
-					Footer:     "Grafana v" + setting.BuildVersion,
+					Footer:     "Grafana v" + appVersion,
 					FooterIcon: "https://grafana.com/static/assets/img/fav32.png",
 					Color:      "#D63232",
 				},
@@ -435,8 +437,9 @@ func setupSlackForTests(t *testing.T, settings string) (*SlackNotifier, *slackRe
 		DecryptFunc: func(ctx context.Context, sjd map[string][]byte, key string, fallback string) string {
 			return fallback
 		},
-		Template: tmpl,
-		Logger:   &channels.FakeLogger{},
+		Template:            tmpl,
+		Logger:              &channels.FakeLogger{},
+		GrafanaBuildVersion: appVersion,
 	}
 
 	sn, err := buildSlackNotifier(c)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Since https://github.com/grafana/alerting/pull/25 FactoryConfig started providing a field GrafanaBuildVersion, which is wired to setting.BuildVersion in https://github.com/grafana/grafana/pull/60543. This PR refactors all remaining receivers to use that field instead of the static BuildVersion

