### PR TITLE
Alerting: Update Discord receiver to use encoding/json to build a webhook message + truncate long message

### DIFF
--- a/pkg/services/ngalert/notifier/channels/discord.go
+++ b/pkg/services/ngalert/notifier/channels/discord.go
@@ -134,7 +134,7 @@ func newDiscordNotifier(fc channels.FactoryConfig) (*DiscordNotifier, error) {
 func (d DiscordNotifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error) {
 	alerts := types.Alerts(as...)
 
-	msg := discordMessage{}
+	var msg discordMessage
 
 	if !d.settings.UseDiscordUsername {
 		msg.Username = "Grafana"
@@ -173,7 +173,7 @@ func (d DiscordNotifier) Notify(ctx context.Context, as ...*types.Alert) (bool, 
 		IconURL: "https://grafana.com/static/assets/img/fav32.png",
 	}
 
-	linkEmbed := discordLinkEmbed{}
+	var linkEmbed discordLinkEmbed
 
 	linkEmbed.Title = tmpl(d.settings.Title)
 	if tmplErr != nil {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
This PR refactors Discord receiver to use structures for creating webhook messages instead of simplejson framework. This is a requirement for moving it to alerting repository.

Also, while working on the models I found a requirement for the field message https://discord.com/developers/docs/resources/webhook#execute-webhook-jsonform-params which mentions that the content must not be greater than 2000 symbols. This PR introduces truncation of the expanded message. 
