### PR TITLE
Fix: Report E2E result stack trace

### DIFF
--- a/e2e/log-reporter.js
+++ b/e2e/log-reporter.js
@@ -3,24 +3,24 @@
 const Mocha = require('mocha');
 const { EVENT_TEST_END, EVENT_RUN_END, EVENT_TEST_FAIL, EVENT_TEST_PASS } = Mocha.Runner.constants;
 
-class LogReporter extends Mocha.reporters.Base {
+class LogReporter extends Mocha.reporters.Spec {
   constructor(runner, options = {}) {
     super(runner, options);
 
-    this.tests = [];
-    this.failures = [];
-    this.passes = [];
+    this._testsResults = [];
+    this._testFailures = [];
+    this._testPasses = [];
 
     runner.on(EVENT_TEST_END, (test) => {
-      this.tests.push(cleanTest(test));
+      this._testsResults.push(test);
     });
 
     runner.on(EVENT_TEST_PASS, (test) => {
-      this.passes.push(cleanTest(test));
+      this._testPasses.push(test);
     });
 
     runner.on(EVENT_TEST_FAIL, (test) => {
-      this.failures.push(cleanTest(test));
+      this._testFailures.push(test);
     });
 
     runner.once(EVENT_RUN_END, () => {
@@ -39,13 +39,13 @@ class LogReporter extends Mocha.reporters.Base {
     };
 
     // Example
-    // CypressStats suites=1 tests=2 passes=1 pending=0 failures=1
+    // CypressStats suites=1 tests=2 testPasses=1 pending=0 failures=1
     // start=1668783563731 end=1668783645198 duration=81467
     console.log(`CypressStats ${objToLogAttributes(stats)}`);
   }
 
   reportResults() {
-    this.tests.map((test) => {
+    this._testsResults.map(cleanTest).map((test) => {
       // Example
       // CypressTestResult title="Login scenario, create test data source, dashboard, panel, and export scenario"
       // suite="Smoke tests" file=../../e2e/smoke-tests-suite/1-smoketests.spec.ts duration=68694
@@ -55,7 +55,7 @@ class LogReporter extends Mocha.reporters.Base {
   }
 
   reportErrors() {
-    this.failures.forEach((failure) => {
+    this._testFailures.map(cleanTest).forEach((failure) => {
       const suite = failure.suite;
       const test = failure.title;
       const error = failure.err;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Mocha uses logs and spec reporter to not lose stack trace from the e2e result.

**Why do we need this feature?**

When adding the new log reporter to have easier Loki exploration, we stop using the default Mocha reporter. Now, the logs reporter extends the `Spec` reporter which is the default Mocha one.

| Before ([Drone CI missing info](https://drone.grafana.net/grafana/grafana/93921/3/20))| After (Including both reporters)
|-|-|
<img width="1501" alt="Captura de pantalla 2022-12-20 a las 18 32 01" src="https://user-images.githubusercontent.com/5699976/208729915-49f656d5-1969-4fce-877a-b35cb7c22817.png">|![Captura de pantalla 2022-12-20 a las 18 29 58](https://user-images.githubusercontent.com/5699976/208729532-0eda8e07-10b4-4fca-bfa6-ea9cb7d00d3d.png)


