### PR TITLE
Alerting: Fix incorrect links/aliases to template docs

### DIFF
--- a/docs/sources/alerting/manage-notifications/create-contact-point.md
+++ b/docs/sources/alerting/manage-notifications/create-contact-point.md
@@ -3,10 +3,7 @@ aliases:
   - ../contact-points/create-contact-point/
   - ../contact-points/delete-contact-point/
   - ../contact-points/edit-contact-point/
-  - ../contact-points/message-templating/
   - ../contact-points/test-contact-point/
-  - ../message-templating/
-  - ../unified-alerting/message-templating/
 keywords:
   - grafana
   - alerting

--- a/docs/sources/alerting/manage-notifications/webhook-notifier.md
+++ b/docs/sources/alerting/manage-notifications/webhook-notifier.md
@@ -1,10 +1,7 @@
 ---
 aliases:
-  - ../contact-points/message-templating/
   - ../contact-points/notifiers/webhook-notifier/
   - ../fundamentals/contact-points/webhook-notifier/
-  - ../message-templating/
-  - ../unified-alerting/message-templating/
 keywords:
   - grafana
   - alerting

--- a/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
@@ -183,7 +183,7 @@ function TemplatingGuideline() {
         </div>
         <div>
           <LinkButton
-            href="https://grafana.com/docs/grafana/latest/alerting/contact-points/message-templating"
+            href="https://grafana.com/docs/grafana/latest/alerting/manage-notifications/create-message-template"
             target="_blank"
             icon="external-link-alt"
           >


### PR DESCRIPTION
The button in the "New message template" page leads to the webhook contact point docs instead of the message template docs.

![image](https://user-images.githubusercontent.com/41638679/208735476-a9994ea7-a615-47ba-ab40-c4bfb3f94402.png)

This PR fixes the outdated link and the aliases which cause redirections to other pages in our docs.