### PR TITLE
Alerting: Update Email receiver to parse settings using encoding/json

### DIFF
--- a/pkg/services/ngalert/notifier/channels/email.go
+++ b/pkg/services/ngalert/notifier/channels/email.go
@@ -46,7 +46,7 @@ func EmailFactory(fc channels.FactoryConfig) (channels.NotificationChannel, erro
 	return notifier, nil
 }
 
-func buildWebexSettings(fc channels.FactoryConfig) (*emailSettings, error) {
+func buildEmailSettings(fc channels.FactoryConfig) (*emailSettings, error) {
 	type emailSettingsRaw struct {
 		SingleEmail bool   `json:"singleEmail,omitempty"`
 		Addresses   string `json:"addresses,omitempty"`
@@ -80,7 +80,7 @@ func buildWebexSettings(fc channels.FactoryConfig) (*emailSettings, error) {
 // NewEmailNotifier is the constructor function
 // for the EmailNotifier.
 func buildEmailNotifier(fc channels.FactoryConfig) (*EmailNotifier, error) {
-	settings, err := buildWebexSettings(fc)
+	settings, err := buildEmailSettings(fc)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/ngalert/notifier/channels/testing.go
+++ b/pkg/services/ngalert/notifier/channels/testing.go
@@ -86,6 +86,10 @@ type emailSender struct {
 	ns *notifications.NotificationService
 }
 
+func (e emailSender) SendWebhook(ctx context.Context, cmd *channels.SendWebhookSettings) error {
+	panic("not implemented")
+}
+
 func (e emailSender) SendEmail(ctx context.Context, cmd *channels.SendEmailSettings) error {
 	attached := make([]*models.SendEmailAttachFile, 0, len(cmd.AttachedFiles))
 	for _, file := range cmd.AttachedFiles {


### PR DESCRIPTION
**What this PR does / why we need it**:

Instead of using `simplejson` to loosely parse notifier settings which is [bug-prone](https://github.com/grafana/grafana/issues/55139), this PR instead makes notifiers declare a well-defined struct for their settings.

This has some benefits:
- Improves validation for all settings fields and eliminates bugs (see attached issue)
- The total set of fields for each notifier is now clear and obvious. Settings are easier to reason about.
- Simplifies notifier construction logic by removing a layer of indirection
- Eliminates repetition/mapping of settings fields, which was a vector for bugs
- Makes our notifiers more in-line with [Prometheus's notifiers](https://github.com/prometheus/alertmanager/blob/3d624c0552e173aa57bbdad52a55788e38744252/notify/slack/slack.go). They also use settings structs.

**Which issue(s) this PR fixes**:

Fixes: https://github.com/grafana/grafana/issues/55139
