### PR TITLE
feat(grafana-cli): allow configuring admin ID for reset-admin-password

### DIFF
--- a/pkg/cmd/grafana-cli/commands/commands.go
+++ b/pkg/cmd/grafana-cli/commands/commands.go
@@ -160,6 +160,11 @@ var adminCommands = []*cli.Command{
 				Usage: "Read the password from stdin",
 				Value: false,
 			},
+			&cli.IntFlag{
+				Name:  "user-id",
+				Usage: "The admin user's ID",
+				Value: DefaultAdminUserId,
+			},
 		},
 	},
 	{

--- a/pkg/cmd/grafana-cli/commands/reset_password_command_test.go
+++ b/pkg/cmd/grafana-cli/commands/reset_password_command_test.go
@@ -1,0 +1,54 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/grafana/grafana/pkg/services/user/usertest"
+)
+
+func TestResetPassword(t *testing.T) {
+	tests := map[string]struct {
+		UserID    int64
+		IsAdmin   bool
+		ExpectErr error
+	}{
+		"basic success": {
+			DefaultAdminUserId,
+			true,
+			nil,
+		},
+		"default user is not an admin": {
+			DefaultAdminUserId,
+			false,
+			ErrMustBeAdmin,
+		},
+		"random user is not an admin": {
+			11,
+			false,
+			ErrMustBeAdmin,
+		},
+		"random user is an admin": {
+			11,
+			true,
+			nil,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			svc := &usertest.FakeUserService{}
+			svc.ExpectedUser = &user.User{
+				IsAdmin: test.IsAdmin,
+			}
+			err := resetPassword(test.UserID, "s00pers3cure!", svc)
+			if test.ExpectErr != nil {
+				require.EqualError(t, err, test.ExpectErr.Error())
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Since this is now more permissive than using our hard-coded default admin password, I added a check that will fail if the userID is not associated with an admin user (`IsAdmin` setting is true). It's also slightly refactored so I could write a (very simple) test (only validating this behavior).

This is backwards compatible; the default behavior has not changed. 

The new option in action:
```
./bin/darwin-amd64/grafana-cli admin reset-admin-password --user-id=2 <password>
Error: ✗ reset-admin-password can only be used to reset an admin user account
```

and a random user who is an admin:
```
./bin/darwin-amd64/grafana-cli admin reset-admin-password --user-id=3 himildwonkey
Admin password changed successfully ✔
```


Fixes #55976