### PR TITLE
flamegraph: Support x-selection zoom

### DIFF
--- a/public/app/plugins/panel/flamegraph/components/FlameGraph/FlameGraph.tsx
+++ b/public/app/plugins/panel/flamegraph/components/FlameGraph/FlameGraph.tsx
@@ -179,9 +179,8 @@ const FlameGraph = ({
           newMin = levels[levelIndex][barIndex].start / totalTicks;
           newMax = (levels[levelIndex][barIndex].start + levels[levelIndex][barIndex].value) / totalTicks;
         } else {
-          // Drag
-          // We're not clicking on a specific node, so make sure that the levelIndex is the top level
-          levelIndex = 0;
+          // We're not clicking on a specific node, so retain the existing topLevelIndex
+          levelIndex = topLevelIndex;
           // A non-click selection highlights an area from where the mouse was clicked down, to where it was released.
           newMin = Math.min(selectionRef.current.startX, e.offsetX) / graphRef.current!.clientWidth;
           newMax = Math.max(selectionRef.current.startX, e.offsetX) / graphRef.current!.clientWidth;

--- a/public/app/plugins/panel/flamegraph/components/FlameGraph/rendering.ts
+++ b/public/app/plugins/panel/flamegraph/components/FlameGraph/rendering.ts
@@ -9,6 +9,7 @@ import {
   LABEL_THRESHOLD,
   PIXELS_PER_LEVEL,
 } from '../../constants';
+import { Selection } from '../types';
 
 import { ItemWithStart } from './dataTransform';
 
@@ -124,6 +125,22 @@ export function renderRect(
       Math.max(rect.x, 0) + BAR_TEXT_PADDING_LEFT,
       rect.y + PIXELS_PER_LEVEL / 2
     );
+    ctx.restore();
+  }
+}
+
+export function renderSelection(ctx: CanvasRenderingContext2D, selection: Selection) {
+  if (selection.startX && selection.endX) {
+    const height = ctx.canvas.height;
+    const x = selection.startX;
+    const y = 0;
+    const width = selection.endX - x;
+
+    ctx.beginPath();
+    ctx.save();
+    ctx.globalAlpha = 0.2;
+    ctx.fillStyle = '#000';
+    ctx.fillRect(x, y, width, height);
     ctx.restore();
   }
 }

--- a/public/app/plugins/panel/flamegraph/components/types.ts
+++ b/public/app/plugins/panel/flamegraph/components/types.ts
@@ -42,3 +42,9 @@ export type TopTableValue = {
   value: number;
   unitValue: string;
 };
+
+export type Selection = {
+  startX: number;
+  startY: number;
+  endX?: number;
+};


### PR DESCRIPTION
**What is this feature?**

Enables visually hightlighting an area on the flamegraph and zooming into it. The existing behavior of clicking on an individual node is still available.

**Why do we need this feature?**

This differs from the current zoom because it allows zooming across multiple nodes, rather than into a single node and it's children.

This is useful because some smaller nodes in a flamegraph do not have a parent which can be zoomed (the root node) or, zooming to the parent doesn't provide enough of a zoom, due to other siblings taking a larger portion of the level.

**Who is this feature for?**

When viewing a flamegraph, if one node is too big, or certain nodes are simply too small, relative to their siblings, they aren't visible, and it's difficult to view what their contents are. Being able to visually select an area on the graph to zoom allows you to zoom into these areas incrementally.

**Which issue(s) does this PR fix?**:

Fixes #58373

**Special notes for your reviewer**: 

My usage of `useRef` on the selection and `setSelection` is probably suspect. I'm new to react and I found the selection values were not being updated immediately when calling `setSelection`. It is my understanding that stateful values are lazily updated after useEffect runs. Since I need to track the value of startX and endX in the event handlers to compare them, I need the values to be immediately available. To fix this  I used `setSelection` with a reference to work around it. This solution basically came straight from stackoverflow, so I'm not sure if there is a better way.