### PR TITLE
Plugins: Fix parsing of Azure settings for plugins

### DIFF
--- a/pkg/plugins/config/config.go
+++ b/pkg/plugins/config/config.go
@@ -41,7 +41,6 @@ func ProvideConfig(settingProvider setting.Provider, grafanaCfg *setting.Cfg) *C
 func NewCfg(settingProvider setting.Provider, grafanaCfg *setting.Cfg) *Cfg {
 	logger := log.New("plugin.cfg")
 
-	azure := settingProvider.Section("azure")
 	aws := settingProvider.Section("aws")
 	plugins := settingProvider.Section("plugins")
 
@@ -65,12 +64,8 @@ func NewCfg(settingProvider setting.Provider, grafanaCfg *setting.Cfg) *Cfg {
 		PluginsAllowUnsigned:    allowedUnsigned,
 		AWSAllowedAuthProviders: allowedAuth,
 		AWSAssumeRoleEnabled:    aws.KeyValue("assume_role_enabled").MustBool(grafanaCfg.AWSAssumeRoleEnabled),
-		Azure: &azsettings.AzureSettings{
-			Cloud:                   azure.KeyValue("cloud").MustString(grafanaCfg.Azure.Cloud),
-			ManagedIdentityEnabled:  azure.KeyValue("managed_identity_enabled").MustBool(grafanaCfg.Azure.ManagedIdentityEnabled),
-			ManagedIdentityClientId: azure.KeyValue("managed_identity_client_id").MustString(grafanaCfg.Azure.ManagedIdentityClientId),
-		},
-		LogDatasourceRequests: grafanaCfg.IsFeatureToggleEnabled(featuremgmt.FlagDatasourceLogger),
+		Azure:                   grafanaCfg.Azure,
+		LogDatasourceRequests:   grafanaCfg.IsFeatureToggleEnabled(featuremgmt.FlagDatasourceLogger),
 	}
 }
 


### PR DESCRIPTION
Fixes inconsistently in parsing of Azure settings introduced by `config.NewCfg()`:
https://github.com/grafana/grafana/blob/06705a49e236dc3ab3b35db51b7bad8625e4866f/pkg/plugins/config/config.go#L69

See #60610 for details.

**Which issue(s) does this PR fix?**:

Fixes #60610

**Special notes for your reviewer**:

The `grafanaCfg.Azure` struct is already sanitized and can be passed as is to external plugins. There should be no difference between internal and external plugins.