### PR TITLE
Use new link for templating docs

### DIFF
--- a/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
@@ -183,7 +183,7 @@ function TemplatingGuideline() {
         </div>
         <div>
           <LinkButton
-            href="https://grafana.com/docs/grafana/latest/alerting/manage-notifications/create-message-template"
+            href="https://grafana.com/docs/grafana/latest/alerting/manage-notifications/template-notifications/"
             target="_blank"
             icon="external-link-alt"
           >


### PR DESCRIPTION
The templating docs have been heavily refactored in https://github.com/grafana/grafana/pull/60109 leading to link changes. The link used in this PR, https://grafana.com/docs/grafana/latest/alerting/manage-notifications/template-notifications/, does not exist yet as `latest` is the 9.3 docs for now but it will exist once Grafana 9.4 is out as the existence of https://grafana.com/docs/grafana/latest/alerting/manage-notifications/template-notifications/ proves.

Grafana 9.3 now uses a versioned link for this so that both versions have working and up to date links: https://github.com/grafana/grafana/pull/60604