### PR TITLE
Cloudwatch: Add feedback labels to log groups selector

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/Search.tsx
+++ b/public/app/plugins/datasource/cloudwatch/Search.tsx
@@ -1,14 +1,11 @@
 import { debounce } from 'lodash';
 import React, { useEffect, useMemo, useState } from 'react';
 
-import { Icon, Input, useStyles2 } from '@grafana/ui';
-
-import getStyles from './components/styles';
+import { Icon, Input } from '@grafana/ui';
 
 // TODO: consider moving search into grafana/ui, this is mostly the same as that in azure monitor
 const Search = ({ searchFn, searchPhrase }: { searchPhrase: string; searchFn: (searchPhrase: string) => void }) => {
   const [searchFilter, setSearchFilter] = useState(searchPhrase);
-  const styles = useStyles2(getStyles);
 
   const debouncedSearch = useMemo(() => debounce(searchFn, 600), [searchFn]);
 

--- a/public/app/plugins/datasource/cloudwatch/Search.tsx
+++ b/public/app/plugins/datasource/cloudwatch/Search.tsx
@@ -21,8 +21,6 @@ const Search = ({ searchFn, searchPhrase }: { searchPhrase: string; searchFn: (s
 
   return (
     <Input
-      className={styles.search}
-      width={64}
       aria-label="log group search"
       prefix={<Icon name="search" />}
       value={searchFilter}

--- a/public/app/plugins/datasource/cloudwatch/components/CrossAccountLogsQueryField.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/CrossAccountLogsQueryField.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 // eslint-disable-next-line lodash/import-scope
 import lodash from 'lodash';
@@ -180,7 +180,7 @@ describe('CrossAccountLogsQueryField', () => {
 
   const labelText =
     'Only the first 50 results can be shown. If you do not see an expected log group, try narrowing down your search.';
-  it('should not display max result info label in case less than 50 logs groups is being displayed', async () => {
+  it('should not display max result info label in case less than 50 logs groups are being displayed', async () => {
     const defer = new Deferred();
     const fetchLogGroups = jest.fn(async () => {
       await Promise.all([defer.promise]);

--- a/public/app/plugins/datasource/cloudwatch/components/CrossAccountLogsQueryField.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/CrossAccountLogsQueryField.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 // eslint-disable-next-line lodash/import-scope
 import lodash from 'lodash';
@@ -198,7 +198,7 @@ describe('CrossAccountLogsQueryField', () => {
     const fetchLogGroups = jest.fn(async () => {
       await Promise.all([defer.promise]);
       return Array(50).map((i) => ({
-        logGroupName: `logGroup${i}`,
+        value: `logGroup${i}`,
         text: `logGroup${i}`,
         label: `logGroup${i}`,
       }));
@@ -208,5 +208,13 @@ describe('CrossAccountLogsQueryField', () => {
     expect(screen.queryByText(labelText)).not.toBeInTheDocument();
     defer.resolve();
     await waitFor(() => expect(screen.getByText(labelText)).toBeInTheDocument());
+  });
+
+  it('should display log groups counter label', async () => {
+    render(<CrossAccountLogsQueryField {...defaultProps} selectedLogGroups={[]} />);
+    await userEvent.click(screen.getByText('Select Log Groups'));
+    await waitFor(() => expect(screen.getByText('0 log groups selected')).toBeInTheDocument());
+    await userEvent.click(screen.getByLabelText('logGroup2'));
+    await waitFor(() => expect(screen.getByText('1 log group selected')).toBeInTheDocument());
   });
 });

--- a/public/app/plugins/datasource/cloudwatch/components/CrossAccountLogsQueryField.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/CrossAccountLogsQueryField.test.tsx
@@ -177,4 +177,36 @@ describe('CrossAccountLogsQueryField', () => {
       },
     ]);
   });
+
+  const labelText =
+    'Only the first 50 results can be shown. If you do not see an expected log group, try narrowing down your search.';
+  it('should not display max result info label in case less than 50 logs groups is being displayed', async () => {
+    const defer = new Deferred();
+    const fetchLogGroups = jest.fn(async () => {
+      await Promise.all([defer.promise]);
+      return [];
+    });
+    render(<CrossAccountLogsQueryField {...defaultProps} fetchLogGroups={fetchLogGroups} />);
+    await userEvent.click(screen.getByText('Select Log Groups'));
+    expect(screen.queryByText(labelText)).not.toBeInTheDocument();
+    defer.resolve();
+    await waitFor(() => expect(screen.queryByText(labelText)).not.toBeInTheDocument());
+  });
+
+  it('should display max result info label in case 50 or more logs groups are being displayed', async () => {
+    const defer = new Deferred();
+    const fetchLogGroups = jest.fn(async () => {
+      await Promise.all([defer.promise]);
+      return Array(50).map((i) => ({
+        logGroupName: `logGroup${i}`,
+        text: `logGroup${i}`,
+        label: `logGroup${i}`,
+      }));
+    });
+    render(<CrossAccountLogsQueryField {...defaultProps} fetchLogGroups={fetchLogGroups} />);
+    await userEvent.click(screen.getByText('Select Log Groups'));
+    expect(screen.queryByText(labelText)).not.toBeInTheDocument();
+    defer.resolve();
+    await waitFor(() => expect(screen.getByText(labelText)).toBeInTheDocument());
+  });
 });

--- a/public/app/plugins/datasource/cloudwatch/components/CrossAccountLogsQueryField.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/CrossAccountLogsQueryField.tsx
@@ -81,15 +81,17 @@ export const CrossAccountLogsQueryField = (props: CrossAccountLogsQueryProps) =>
     <>
       <Modal className={styles.modal} title="Select Log Groups" isOpen={isModalOpen} onDismiss={toggleModal}>
         <div className={styles.logGroupSelectionArea}>
-          <EditorField label="Log Group Name">
-            <Search
-              searchFn={(phrase) => {
-                searchFn(phrase, searchAccountId);
-                setSearchPhrase(phrase);
-              }}
-              searchPhrase={searchPhrase}
-            />
-          </EditorField>
+          <div className={styles.searchField}>
+            <EditorField label="Log Group Name">
+              <Search
+                searchFn={(phrase) => {
+                  searchFn(phrase, searchAccountId);
+                  setSearchPhrase(phrase);
+                }}
+                searchPhrase={searchPhrase}
+              />
+            </EditorField>
+          </div>
 
           <Account
             onChange={(accountId?: string) => {

--- a/public/app/plugins/datasource/cloudwatch/components/CrossAccountLogsQueryField.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/CrossAccountLogsQueryField.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, useState } from 'react';
 
 import { SelectableValue } from '@grafana/data';
 import { EditorField, Space } from '@grafana/experimental';
-import { Button, Checkbox, IconButton, LoadingPlaceholder, Modal, useStyles2 } from '@grafana/ui';
+import { Button, Checkbox, Icon, IconButton, Label, LoadingPlaceholder, Modal, useStyles2 } from '@grafana/ui';
 
 import Search from '../Search';
 import { SelectableResourceValue } from '../api';
@@ -102,6 +102,16 @@ export const CrossAccountLogsQueryField = (props: CrossAccountLogsQueryProps) =>
         </div>
         <Space layout="block" v={2} />
         <div>
+          {!isLoading && selectableLogGroups.length >= 25 && (
+            <>
+              <Label className={styles.limitLabel}>
+                <Icon name="info-circle"></Icon>
+                Only the first 50 results can be shown. If you do not see an expected log group, try narrowing down your
+                search.
+              </Label>
+              <Space layout="block" v={1} />
+            </>
+          )}
           <div className={styles.tableScroller}>
             <table className={styles.table}>
               <thead>

--- a/public/app/plugins/datasource/cloudwatch/components/CrossAccountLogsQueryField.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/CrossAccountLogsQueryField.tsx
@@ -1,14 +1,16 @@
+import { stubTrue } from 'lodash';
 import React, { useMemo, useState } from 'react';
 
 import { SelectableValue } from '@grafana/data';
 import { EditorField, Space } from '@grafana/experimental';
-import { Button, Checkbox, Icon, IconButton, Label, LoadingPlaceholder, Modal, useStyles2 } from '@grafana/ui';
+import { Button, Checkbox, Icon, Label, LoadingPlaceholder, Modal, useStyles2 } from '@grafana/ui';
 
 import Search from '../Search';
 import { SelectableResourceValue } from '../api';
 import { DescribeLogGroupsRequest } from '../types';
 
 import { Account, ALL_ACCOUNTS_OPTION } from './Account';
+import { SelectedLogsGroups } from './SelectedLogsGroups';
 import getStyles from './styles';
 
 type CrossAccountLogsQueryProps = {
@@ -181,19 +183,7 @@ export const CrossAccountLogsQueryField = (props: CrossAccountLogsQueryProps) =>
         </Button>
       </div>
 
-      <div className={styles.selectedLogGroupsContainer}>
-        {props.selectedLogGroups.map((lg) => (
-          <div key={lg.value} className={styles.selectedLogGroup}>
-            {lg.label}
-            <IconButton
-              size="sm"
-              name="times"
-              className={styles.removeButton}
-              onClick={() => props.onChange(props.selectedLogGroups.filter((slg) => slg.value !== lg.value))}
-            />
-          </div>
-        ))}
-      </div>
+      <SelectedLogsGroups selectedLogGroups={props.selectedLogGroups} onChange={props.onChange}></SelectedLogsGroups>
     </>
   );
 };

--- a/public/app/plugins/datasource/cloudwatch/components/CrossAccountLogsQueryField.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/CrossAccountLogsQueryField.tsx
@@ -159,6 +159,10 @@ export const CrossAccountLogsQueryField = (props: CrossAccountLogsQueryProps) =>
           </div>
         </div>
         <Space layout="block" v={2} />
+        <Label className={styles.logGroupCountLabel}>
+          {selectedLogGroups.length} log group{selectedLogGroups.length !== 1 && 's'} selected
+        </Label>
+        <Space layout="block" v={1.5} />
         <div>
           <Button onClick={handleApply} type="button" className={styles.addBtn}>
             Add log groups

--- a/public/app/plugins/datasource/cloudwatch/components/CrossAccountLogsQueryField.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/CrossAccountLogsQueryField.tsx
@@ -1,4 +1,3 @@
-import { stubTrue } from 'lodash';
 import React, { useMemo, useState } from 'react';
 
 import { SelectableValue } from '@grafana/data';

--- a/public/app/plugins/datasource/cloudwatch/components/SelectedLogsGroups.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/SelectedLogsGroups.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+
+import { SelectedLogsGroups } from './SelectedLogsGroups';
+
+const defaultProps = {
+  selectedLogGroups: [
+    {
+      value: 'aws/lambda/lambda-name1',
+      label: 'aws/lambda/lambda-name1',
+      text: 'aws/lambda/lambda-name1',
+    },
+    {
+      value: 'aws/lambda/lambda-name2',
+      label: 'aws/lambda/lambda-name2',
+      text: 'aws/lambda/lambda-name2',
+    },
+  ],
+  onChange: jest.fn(),
+};
+
+describe('SelectedLogsGroups', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+  describe("'Show more' button", () => {
+    it('should not be displayed in case 0 logs have been selected', async () => {
+      render(<SelectedLogsGroups {...defaultProps} selectedLogGroups={[]} />);
+      await waitFor(() => expect(screen.queryByText('Show all')).not.toBeInTheDocument());
+    });
+    it('should not be displayed in case logs group have been selected but theyre less than 10', async () => {
+      render(<SelectedLogsGroups {...defaultProps} />);
+      await waitFor(() => expect(screen.queryByText('Show all')).not.toBeInTheDocument());
+    });
+    it('should be displayed in case more than 10 log groups have been selected', async () => {
+      const selectedLogGroups = Array(12).map((i) => ({
+        value: `logGroup${i}`,
+        text: `logGroup${i}`,
+        label: `logGroup${i}`,
+      }));
+      render(<SelectedLogsGroups {...defaultProps} selectedLogGroups={selectedLogGroups} />);
+      await waitFor(() => expect(screen.getByText('Show all')).toBeInTheDocument());
+    });
+  });
+
+  describe("'Clear selection' button", () => {
+    it('should not be displayed in case 0 logs have been selected', async () => {
+      render(<SelectedLogsGroups {...defaultProps} selectedLogGroups={[]} />);
+      await waitFor(() => expect(screen.queryByText('Clear selection')).not.toBeInTheDocument());
+    });
+    it('should be displayed in case at least one log group have been selected', async () => {
+      const selectedLogGroups = Array(11).map((i) => ({
+        value: `logGroup${i}`,
+        text: `logGroup${i}`,
+        label: `logGroup${i}`,
+      }));
+      render(<SelectedLogsGroups {...defaultProps} selectedLogGroups={selectedLogGroups} />);
+      await waitFor(() => expect(screen.getByText('Clear selection')).toBeInTheDocument());
+    });
+  });
+
+  describe("'Clear selection' button", () => {
+    it('should not be displayed in case 0 logs have been selected', async () => {
+      render(<SelectedLogsGroups {...defaultProps} selectedLogGroups={[]} />);
+      await waitFor(() => expect(screen.queryByText('Clear selection')).not.toBeInTheDocument());
+    });
+    it('should be displayed in case at least one log group have been selected', async () => {
+      const selectedLogGroups = Array(11).map((i) => ({
+        value: `logGroup${i}`,
+        text: `logGroup${i}`,
+        label: `logGroup${i}`,
+      }));
+      render(<SelectedLogsGroups {...defaultProps} selectedLogGroups={selectedLogGroups} />);
+      await waitFor(() => expect(screen.getByText('Clear selection')).toBeInTheDocument());
+    });
+  });
+});

--- a/public/app/plugins/datasource/cloudwatch/components/SelectedLogsGroups.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/SelectedLogsGroups.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import { SelectedLogsGroups } from './SelectedLogsGroups';
@@ -56,6 +57,21 @@ describe('SelectedLogsGroups', () => {
       }));
       render(<SelectedLogsGroups {...defaultProps} selectedLogGroups={selectedLogGroups} />);
       await waitFor(() => expect(screen.getByText('Clear selection')).toBeInTheDocument());
+    });
+
+    it('should display confirm dialog before clearing all selections', async () => {
+      const selectedLogGroups = Array(11).map((i) => ({
+        value: `logGroup${i}`,
+        text: `logGroup${i}`,
+        label: `logGroup${i}`,
+      }));
+      render(<SelectedLogsGroups {...defaultProps} selectedLogGroups={selectedLogGroups} />);
+      await waitFor(() => userEvent.click(screen.getByText('Clear selection')));
+      await waitFor(() =>
+        expect(screen.getByText('Are you sure you want to clear all log groups?')).toBeInTheDocument()
+      );
+      await waitFor(() => userEvent.click(screen.getByLabelText('Confirm Modal Danger Button')));
+      expect(defaultProps.onChange).toHaveBeenCalledWith([]);
     });
   });
 

--- a/public/app/plugins/datasource/cloudwatch/components/SelectedLogsGroups.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/SelectedLogsGroups.tsx
@@ -1,0 +1,68 @@
+import React, { useEffect, useState } from 'react';
+
+import { Button, useStyles2 } from '@grafana/ui';
+
+import { SelectableResourceValue } from '../api';
+
+import getStyles from './styles';
+
+type CrossAccountLogsQueryProps = {
+  selectedLogGroups: SelectableResourceValue[];
+  onChange: (selectedLogGroups: SelectableResourceValue[]) => void;
+};
+
+const MAX_VISIBLE_LOG_GROUPS = 10;
+
+export const SelectedLogsGroups = ({ selectedLogGroups, onChange }: CrossAccountLogsQueryProps) => {
+  const styles = useStyles2(getStyles);
+  const [visibleSelectecLogGroups, setVisibleSelectecLogGroups] = useState(
+    selectedLogGroups.slice(0, MAX_VISIBLE_LOG_GROUPS)
+  );
+
+  useEffect(() => {
+    setVisibleSelectecLogGroups(selectedLogGroups.slice(0, MAX_VISIBLE_LOG_GROUPS));
+  }, [selectedLogGroups]);
+
+  return (
+    <div className={styles.selectedLogGroupsContainer}>
+      {visibleSelectecLogGroups.map((lg) => (
+        <Button
+          key={lg.value}
+          size="sm"
+          variant="secondary"
+          icon="times"
+          className={styles.removeButton}
+          onClick={() => {
+            onChange(selectedLogGroups.filter((slg) => slg.value !== lg.value));
+          }}
+        >
+          {lg.label}
+        </Button>
+      ))}
+      {visibleSelectecLogGroups.length !== selectedLogGroups.length && (
+        <Button
+          size="sm"
+          variant="secondary"
+          icon="plus"
+          fill="outline"
+          className={styles.removeButton}
+          onClick={() => setVisibleSelectecLogGroups(selectedLogGroups)}
+        >
+          Show all
+        </Button>
+      )}
+      {selectedLogGroups.length > 0 && (
+        <Button
+          size="sm"
+          variant="secondary"
+          icon="times"
+          fill="outline"
+          className={styles.removeButton}
+          onClick={() => onChange([])}
+        >
+          Clear selection
+        </Button>
+      )}
+    </div>
+  );
+};

--- a/public/app/plugins/datasource/cloudwatch/components/SelectedLogsGroups.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/SelectedLogsGroups.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 
-import { Button, useStyles2 } from '@grafana/ui';
+import { Button, ConfirmModal, useStyles2 } from '@grafana/ui';
 
 import { SelectableResourceValue } from '../api';
 
@@ -15,6 +15,7 @@ const MAX_VISIBLE_LOG_GROUPS = 10;
 
 export const SelectedLogsGroups = ({ selectedLogGroups, onChange }: CrossAccountLogsQueryProps) => {
   const styles = useStyles2(getStyles);
+  const [showConfirm, setShowConfirm] = useState(false);
   const [visibleSelectecLogGroups, setVisibleSelectecLogGroups] = useState(
     selectedLogGroups.slice(0, MAX_VISIBLE_LOG_GROUPS)
   );
@@ -24,45 +25,60 @@ export const SelectedLogsGroups = ({ selectedLogGroups, onChange }: CrossAccount
   }, [selectedLogGroups]);
 
   return (
-    <div className={styles.selectedLogGroupsContainer}>
-      {visibleSelectecLogGroups.map((lg) => (
-        <Button
-          key={lg.value}
-          size="sm"
-          variant="secondary"
-          icon="times"
-          className={styles.removeButton}
-          onClick={() => {
-            onChange(selectedLogGroups.filter((slg) => slg.value !== lg.value));
-          }}
-        >
-          {lg.label}
-        </Button>
-      ))}
-      {visibleSelectecLogGroups.length !== selectedLogGroups.length && (
-        <Button
-          size="sm"
-          variant="secondary"
-          icon="plus"
-          fill="outline"
-          className={styles.removeButton}
-          onClick={() => setVisibleSelectecLogGroups(selectedLogGroups)}
-        >
-          Show all
-        </Button>
-      )}
-      {selectedLogGroups.length > 0 && (
-        <Button
-          size="sm"
-          variant="secondary"
-          icon="times"
-          fill="outline"
-          className={styles.removeButton}
-          onClick={() => onChange([])}
-        >
-          Clear selection
-        </Button>
-      )}
-    </div>
+    <>
+      <div className={styles.selectedLogGroupsContainer}>
+        {visibleSelectecLogGroups.map((lg) => (
+          <Button
+            key={lg.value}
+            size="sm"
+            variant="secondary"
+            icon="times"
+            className={styles.removeButton}
+            onClick={() => {
+              onChange(selectedLogGroups.filter((slg) => slg.value !== lg.value));
+            }}
+          >
+            {lg.label}
+          </Button>
+        ))}
+        {visibleSelectecLogGroups.length !== selectedLogGroups.length && (
+          <Button
+            size="sm"
+            variant="secondary"
+            icon="plus"
+            fill="outline"
+            className={styles.removeButton}
+            onClick={() => setVisibleSelectecLogGroups(selectedLogGroups)}
+          >
+            Show all
+          </Button>
+        )}
+        {selectedLogGroups.length > 0 && (
+          <Button
+            size="sm"
+            variant="secondary"
+            icon="times"
+            fill="outline"
+            className={styles.removeButton}
+            onClick={() => setShowConfirm(true)}
+          >
+            Clear selection
+          </Button>
+        )}
+      </div>
+      <ConfirmModal
+        isOpen={showConfirm}
+        title="Clear Log Group Selection"
+        body="Are you sure you want to clear all log groups?"
+        confirmText="Yes"
+        dismissText="No"
+        icon="exclamation-triangle"
+        onConfirm={() => {
+          setShowConfirm(false);
+          onChange([]);
+        }}
+        onDismiss={() => setShowConfirm(false)}
+      />
+    </>
   );
 };

--- a/public/app/plugins/datasource/cloudwatch/components/SelectedLogsGroups.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/SelectedLogsGroups.tsx
@@ -11,7 +11,7 @@ type CrossAccountLogsQueryProps = {
   onChange: (selectedLogGroups: SelectableResourceValue[]) => void;
 };
 
-const MAX_VISIBLE_LOG_GROUPS = 10;
+const MAX_VISIBLE_LOG_GROUPS = 6;
 
 export const SelectedLogsGroups = ({ selectedLogGroups, onChange }: CrossAccountLogsQueryProps) => {
   const styles = useStyles2(getStyles);

--- a/public/app/plugins/datasource/cloudwatch/components/styles.ts
+++ b/public/app/plugins/datasource/cloudwatch/components/styles.ts
@@ -12,6 +12,10 @@ const getStyles = (theme: GrafanaTheme2) => ({
     marginLeft: theme.spacing(0.5),
     display: 'flex',
     flexFlow: 'wrap',
+    gap: theme.spacing(1),
+    button: {
+      margin: 'unset',
+    },
   }),
 
   limitLabel: css({
@@ -83,15 +87,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
   resultLimit: css({
     margin: '4px 0',
     fontStyle: 'italic',
-  }),
-
-  selectedLogGroup: css({
-    background: theme.colors.background.secondary,
-    borderRadius: theme.shape.borderRadius(),
-    margin: theme.spacing(0, 1, 1, 0),
-    padding: theme.spacing(0.5, 0, 0.5, 1),
-    color: theme.colors.text.primary,
-    fontSize: theme.typography.size.sm,
   }),
 
   removeButton: css({

--- a/public/app/plugins/datasource/cloudwatch/components/styles.ts
+++ b/public/app/plugins/datasource/cloudwatch/components/styles.ts
@@ -75,6 +75,11 @@ const getStyles = (theme: GrafanaTheme2) => ({
     display: 'flex',
   }),
 
+  searchField: css({
+    width: '100%',
+    marginRight: theme.spacing(1),
+  }),
+
   resultLimit: css({
     margin: '4px 0',
     fontStyle: 'italic',
@@ -87,10 +92,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
     padding: theme.spacing(0.5, 0, 0.5, 1),
     color: theme.colors.text.primary,
     fontSize: theme.typography.size.sm,
-  }),
-
-  search: css({
-    marginRight: '10px',
   }),
 
   removeButton: css({

--- a/public/app/plugins/datasource/cloudwatch/components/styles.ts
+++ b/public/app/plugins/datasource/cloudwatch/components/styles.ts
@@ -23,6 +23,11 @@ const getStyles = (theme: GrafanaTheme2) => ({
     },
   }),
 
+  logGroupCountLabel: css({
+    color: theme.colors.text.secondary,
+    maxWidth: 'none',
+  }),
+
   tableScroller: css({
     maxHeight: '50vh',
     overflow: 'auto',

--- a/public/app/plugins/datasource/cloudwatch/components/styles.ts
+++ b/public/app/plugins/datasource/cloudwatch/components/styles.ts
@@ -14,6 +14,15 @@ const getStyles = (theme: GrafanaTheme2) => ({
     flexFlow: 'wrap',
   }),
 
+  limitLabel: css({
+    color: theme.colors.text.secondary,
+    textAlign: 'center',
+    maxWidth: 'none',
+    svg: {
+      marginRight: theme.spacing(0.5),
+    },
+  }),
+
   tableScroller: css({
     maxHeight: '50vh',
     overflow: 'auto',

--- a/public/app/plugins/datasource/cloudwatch/components/styles.ts
+++ b/public/app/plugins/datasource/cloudwatch/components/styles.ts
@@ -10,6 +10,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
 
   selectedLogGroupsContainer: css({
     marginLeft: theme.spacing(0.5),
+    marginBottom: theme.spacing(0.5),
     display: 'flex',
     flexFlow: 'wrap',
     gap: theme.spacing(1),


### PR DESCRIPTION
**What is this feature?**

This PR is making some usability improvements to the Log group picker that is used for cross-account querying in the CloudWatch logs editor. Design mockups can be found [here](https://www.figma.com/file/1PyUB9gNP07X05YmSJzRkE/AWS-CloudWatch---Lattice?node-id=255%3A10286&t=16MIQbR7srHu5q2m-1). 

* adds a label at the top of the search result indicating that only the first 50 results was shown, and that the user can try to narrow down the search
* adds a label at the bottom of the log groups picker indicating how many log groups have been selected
* fix styling for top column, giving the Accounts drop down a fixed width and the Search dropdown should use all available space
* adds a _Clear selection_ button 
* adds a _Show more_ button that is being shown in case more than 6 logs groups have been selected

![Screenshot from 2022-12-21 09-59-32](https://user-images.githubusercontent.com/2388950/208863469-5261d5ca-5d0c-4bed-bf3b-5b5259e5a07c.png)
![Screenshot from 2023-01-02 09-22-15](https://user-images.githubusercontent.com/2388950/210207813-57e6942f-74c2-45d6-b59f-e992cee4262e.png)


**Who is this feature for?**

Plugin users

**Which issue(s) does this PR fix?**:

Fixes #60952
Fixes https://github.com/grafana/cloud-data-sources/issues/98
Fixes https://github.com/grafana/cloud-data-sources/issues/99

**Special notes for your reviewer**:

