### PR TITLE
flapflapflapflap - "organization not found" is really annoying

### DIFF
--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -380,6 +380,7 @@ func CreateUser(t *testing.T, store *sqlstore.SQLStore, cmd user.CreateUserComma
 
 	store.Cfg.AutoAssignOrg = true
 	store.Cfg.AutoAssignOrgId = 1
+	cmd.OrgID = 1
 
 	quotaService := quotaimpl.ProvideService(store, store.Cfg)
 	orgService, err := orgimpl.ProvideService(store, store.Cfg, quotaService)


### PR DESCRIPTION
i dunno let's see what this does 🤷 
Lately all the flapping test failures I've noticed share the testinfra setup (likely coincidence), and I really don't expect this to fix things, but let's see what happens if we're a tiny bit more explicit? absolutely should not make the difference?  