### PR TITLE
AzureMonitor: Wait for credentials to be ready

### DIFF
--- a/e2e/cloud-plugins-suite/azure-monitor.spec.ts
+++ b/e2e/cloud-plugins-suite/azure-monitor.spec.ts
@@ -20,10 +20,11 @@ type AzureMonitorConfig = {
 
 type AzureMonitorProvision = { datasources: AzureMonitorConfig[] };
 
-const dataSourceName = `Azure Monitor E2E Tests - ${uuidv4()}`;
+let dataSourceName = '';
 
 function provisionAzureMonitorDatasources(datasources: AzureMonitorProvision[]) {
   const datasource = datasources[0].datasources[0];
+  dataSourceName = `Azure Monitor E2E Tests - ${uuidv4()}`;
 
   e2e()
     .intercept(/subscriptions/)
@@ -45,6 +46,7 @@ function provisionAzureMonitorDatasources(datasources: AzureMonitorProvision[]) 
       e2eSelectors.configEditor.defaultSubscription.input().find('input').type('datasources{enter}');
     },
     expectedAlertMessage: 'Successfully connected to all Azure Monitor endpoints',
+    timeout: 10000,
   });
 }
 
@@ -127,6 +129,7 @@ e2e.scenario({
     }
     e2e.setScenarioContext({ addedDataSources: [] });
   },
+  config: { retries: 3 },
 });
 
 e2e.scenario({

--- a/e2e/cloud-plugins-suite/azure-monitor.spec.ts
+++ b/e2e/cloud-plugins-suite/azure-monitor.spec.ts
@@ -44,6 +44,8 @@ function provisionAzureMonitorDatasources(datasources: AzureMonitorProvision[]) 
         .type(datasource.secureJsonData.clientSecret, { log: false });
       e2eSelectors.configEditor.loadSubscriptions.button().click().wait('@subscriptions').wait(500);
       e2eSelectors.configEditor.defaultSubscription.input().find('input').type('datasources{enter}');
+      // Wait for 15s so that credentials are ready
+      e2e().wait(15000);
     },
     expectedAlertMessage: 'Successfully connected to all Azure Monitor endpoints',
     timeout: 10000,
@@ -129,7 +131,6 @@ e2e.scenario({
     }
     e2e.setScenarioContext({ addedDataSources: [] });
   },
-  config: { retries: 3 },
 });
 
 e2e.scenario({

--- a/e2e/cloud-plugins-suite/azure-monitor.spec.ts
+++ b/e2e/cloud-plugins-suite/azure-monitor.spec.ts
@@ -44,10 +44,11 @@ function provisionAzureMonitorDatasources(datasources: AzureMonitorProvision[]) 
         .type(datasource.secureJsonData.clientSecret, { log: false });
       e2eSelectors.configEditor.loadSubscriptions.button().click().wait('@subscriptions').wait(500);
       e2eSelectors.configEditor.defaultSubscription.input().find('input').type('datasources{enter}');
-      // Wait for 15s so that credentials are ready
+      // Wait for 15s so that credentials are ready. 5s has been tested locally before and seemed insufficient.
       e2e().wait(15000);
     },
     expectedAlertMessage: 'Successfully connected to all Azure Monitor endpoints',
+    // Reduce the timeout from 30s to error faster when an invalid alert message is presented
     timeout: 10000,
   });
 }

--- a/e2e/cloud-plugins-suite/azure-monitor.spec.ts
+++ b/e2e/cloud-plugins-suite/azure-monitor.spec.ts
@@ -20,11 +20,10 @@ type AzureMonitorConfig = {
 
 type AzureMonitorProvision = { datasources: AzureMonitorConfig[] };
 
-let dataSourceName = '';
+const dataSourceName = `Azure Monitor E2E Tests - ${uuidv4()}`;
 
 function provisionAzureMonitorDatasources(datasources: AzureMonitorProvision[]) {
   const datasource = datasources[0].datasources[0];
-  dataSourceName = `Azure Monitor E2E Tests - ${uuidv4()}`;
 
   e2e()
     .intercept(/subscriptions/)

--- a/packages/grafana-e2e/src/support/scenario.ts
+++ b/packages/grafana-e2e/src/support/scenario.ts
@@ -8,7 +8,6 @@ export interface ScenarioArguments {
   addScenarioDataSource?: boolean;
   addScenarioDashBoard?: boolean;
   loginViaApi?: boolean;
-  config?: Cypress.TestConfigOverrides;
 }
 
 export const e2eScenario = ({
@@ -19,7 +18,6 @@ export const e2eScenario = ({
   addScenarioDataSource = false,
   addScenarioDashBoard = false,
   loginViaApi = true,
-  config = {},
 }: ScenarioArguments) => {
   describe(describeName, () => {
     if (skipScenario) {
@@ -41,7 +39,7 @@ export const e2eScenario = ({
       afterEach(() => e2e.flows.revertAllChanges());
       after(() => e2e().clearCookies());
 
-      it(itName, { ...config }, () => scenario());
+      it(itName, () => scenario());
 
       // @todo remove when possible: https://github.com/cypress-io/cypress/issues/2831
       it('temporary', () => {});

--- a/packages/grafana-e2e/src/support/scenario.ts
+++ b/packages/grafana-e2e/src/support/scenario.ts
@@ -8,6 +8,7 @@ export interface ScenarioArguments {
   addScenarioDataSource?: boolean;
   addScenarioDashBoard?: boolean;
   loginViaApi?: boolean;
+  config?: Cypress.TestConfigOverrides;
 }
 
 export const e2eScenario = ({
@@ -18,6 +19,7 @@ export const e2eScenario = ({
   addScenarioDataSource = false,
   addScenarioDashBoard = false,
   loginViaApi = true,
+  config = {},
 }: ScenarioArguments) => {
   describe(describeName, () => {
     if (skipScenario) {
@@ -39,7 +41,7 @@ export const e2eScenario = ({
       afterEach(() => e2e.flows.revertAllChanges());
       after(() => e2e().clearCookies());
 
-      it(itName, () => scenario());
+      it(itName, { ...config }, () => scenario());
 
       // @todo remove when possible: https://github.com/cypress-io/cypress/issues/2831
       it('temporary', () => {});


### PR DESCRIPTION
This PR exposes the `config` property allowing Cypress configuration to be specified as a part of the scenario.

Also updates the Azure Monitor E2E tests to retry the datasource configuration on failure.

This PR may need to be backported to `v9.3.x` to reduce test flakiness.