### PR TITLE
fix(dashboard versions service): include DashboardUID in DashboardVersionDTO

### DIFF
--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -133,7 +133,7 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 		fakeDash.FolderId = 1
 		fakeDash.HasACL = false
 		fakeDashboardVersionService := dashvertest.NewDashboardVersionServiceFake()
-		fakeDashboardVersionService.ExpectedDashboardVersion = &dashver.DashboardVersion{}
+		fakeDashboardVersionService.ExpectedDashboardVersion = &dashver.DashboardVersionDTO{}
 		teamService := &teamtest.FakeService{}
 		dashboardService := dashboards.NewFakeDashboardService(t)
 		dashboardService.On("GetDashboard", mock.Anything, mock.AnythingOfType("*models.GetDashboardQuery")).Run(func(args mock.Arguments) {
@@ -241,7 +241,7 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 		fakeDash.FolderId = 1
 		fakeDash.HasACL = true
 		fakeDashboardVersionService := dashvertest.NewDashboardVersionServiceFake()
-		fakeDashboardVersionService.ExpectedDashboardVersion = &dashver.DashboardVersion{}
+		fakeDashboardVersionService.ExpectedDashboardVersion = &dashver.DashboardVersionDTO{}
 		teamService := &teamtest.FakeService{}
 		dashboardService := dashboards.NewFakeDashboardService(t)
 		dashboardService.On("GetDashboard", mock.Anything, mock.AnythingOfType("*models.GetDashboardQuery")).Run(func(args mock.Arguments) {
@@ -787,7 +787,7 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 
 	t.Run("Given two dashboards being compared", func(t *testing.T) {
 		fakeDashboardVersionService := dashvertest.NewDashboardVersionServiceFake()
-		fakeDashboardVersionService.ExpectedDashboardVersions = []*dashver.DashboardVersion{
+		fakeDashboardVersionService.ExpectedDashboardVersions = []*dashver.DashboardVersionDTO{
 			{
 				DashboardID: 1,
 				Version:     1,
@@ -874,7 +874,7 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 			Version: 1,
 		}
 		fakeDashboardVersionService := dashvertest.NewDashboardVersionServiceFake()
-		fakeDashboardVersionService.ExpectedDashboardVersions = []*dashver.DashboardVersion{
+		fakeDashboardVersionService.ExpectedDashboardVersions = []*dashver.DashboardVersionDTO{
 			{
 				DashboardID: 2,
 				Version:     1,
@@ -908,7 +908,7 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 		}).Return(nil, nil)
 
 		fakeDashboardVersionService := dashvertest.NewDashboardVersionServiceFake()
-		fakeDashboardVersionService.ExpectedDashboardVersions = []*dashver.DashboardVersion{
+		fakeDashboardVersionService.ExpectedDashboardVersions = []*dashver.DashboardVersionDTO{
 			{
 				DashboardID: 2,
 				Version:     1,

--- a/pkg/services/dashboardversion/dashver.go
+++ b/pkg/services/dashboardversion/dashver.go
@@ -5,7 +5,7 @@ import (
 )
 
 type Service interface {
-	Get(context.Context, *GetDashboardVersionQuery) (*DashboardVersion, error)
+	Get(context.Context, *GetDashboardVersionQuery) (*DashboardVersionDTO, error)
 	DeleteExpired(context.Context, *DeleteExpiredVersionsCommand) error
 	List(context.Context, *ListDashboardVersionsQuery) ([]*DashboardVersionDTO, error)
 }

--- a/pkg/services/dashboardversion/dashverimpl/dashver.go
+++ b/pkg/services/dashboardversion/dashverimpl/dashver.go
@@ -84,7 +84,7 @@ func (s *Service) List(ctx context.Context, query *dashver.ListDashboardVersions
 		query.Limit = 1000
 	}
 
-	var dashUID string = query.DashboardUID
+	var dashUID = query.DashboardUID
 	if dashUID == "" { // get the dashUID for the return DashboardVersionDTO
 		q := models.GetDashboardRefByIdQuery{Id: query.DashboardID}
 		err := s.dashSvc.GetDashboardUIDById(ctx, &q)
@@ -98,7 +98,7 @@ func (s *Service) List(ctx context.Context, query *dashver.ListDashboardVersions
 		if err != nil {
 			return nil, err
 		}
-		query.DashboardID = q.Id
+		query.DashboardID = q.Result.Id
 	}
 
 	versions, err := s.store.List(ctx, query)

--- a/pkg/services/dashboardversion/dashverimpl/sqlx_store.go
+++ b/pkg/services/dashboardversion/dashverimpl/sqlx_store.go
@@ -59,16 +59,15 @@ func (ss *sqlxStore) DeleteBatch(ctx context.Context, cmd *dashver.DeleteExpired
 	return deleted, err
 }
 
-func (ss *sqlxStore) List(ctx context.Context, query *dashver.ListDashboardVersionsQuery) ([]*dashver.DashboardVersionDTO, error) {
-	var dashboardVersion []*dashver.DashboardVersionDTO
+func (ss *sqlxStore) List(ctx context.Context, query *dashver.ListDashboardVersionsQuery) ([]*dashver.DashboardVersion, error) {
+	var dashboardVersion []*dashver.DashboardVersion
 	qr := `SELECT dashboard_version.id,
 				dashboard_version.dashboard_id,
 				dashboard_version.parent_version,
 				dashboard_version.restored_from,
 				dashboard_version.version,
 				dashboard_version.created,
-				dashboard_version.message,
-				"user".login as created_by_login
+				dashboard_version.message
 			FROM dashboard_version
 			LEFT JOIN "user" ON "user".id = dashboard_version.created_by
 			LEFT JOIN dashboard ON dashboard.id = dashboard_version.dashboard_id
@@ -83,5 +82,6 @@ func (ss *sqlxStore) List(ctx context.Context, query *dashver.ListDashboardVersi
 	if len(dashboardVersion) < 1 {
 		return nil, dashver.ErrNoVersionsForDashboardID
 	}
+
 	return dashboardVersion, nil
 }

--- a/pkg/services/dashboardversion/dashverimpl/store.go
+++ b/pkg/services/dashboardversion/dashverimpl/store.go
@@ -10,5 +10,5 @@ type store interface {
 	Get(context.Context, *dashver.GetDashboardVersionQuery) (*dashver.DashboardVersion, error)
 	GetBatch(context.Context, *dashver.DeleteExpiredVersionsCommand, int, int) ([]interface{}, error)
 	DeleteBatch(context.Context, *dashver.DeleteExpiredVersionsCommand, []interface{}) (int64, error)
-	List(context.Context, *dashver.ListDashboardVersionsQuery) ([]*dashver.DashboardVersionDTO, error)
+	List(context.Context, *dashver.ListDashboardVersionsQuery) ([]*dashver.DashboardVersion, error)
 }

--- a/pkg/services/dashboardversion/dashverimpl/xorm_store.go
+++ b/pkg/services/dashboardversion/dashverimpl/xorm_store.go
@@ -71,8 +71,8 @@ func (ss *sqlStore) DeleteBatch(ctx context.Context, cmd *dashver.DeleteExpiredV
 	return deleted, err
 }
 
-func (ss *sqlStore) List(ctx context.Context, query *dashver.ListDashboardVersionsQuery) ([]*dashver.DashboardVersionDTO, error) {
-	var dashboardVersion []*dashver.DashboardVersionDTO
+func (ss *sqlStore) List(ctx context.Context, query *dashver.ListDashboardVersionsQuery) ([]*dashver.DashboardVersion, error) {
+	var dashboardVersion []*dashver.DashboardVersion
 	err := ss.db.WithDbSession(ctx, func(sess *db.Session) error {
 		err := sess.Table("dashboard_version").
 			Select(`dashboard_version.id,

--- a/pkg/services/dashboardversion/dashvertest/fake.go
+++ b/pkg/services/dashboardversion/dashvertest/fake.go
@@ -7,18 +7,17 @@ import (
 )
 
 type FakeDashboardVersionService struct {
-	ExpectedDashboardVersion     *dashver.DashboardVersion
-	ExpectedDashboardVersions    []*dashver.DashboardVersion
-	ExpectedListDashboarVersions []*dashver.DashboardVersionDTO
-	counter                      int
-	ExpectedError                error
+	ExpectedDashboardVersion  *dashver.DashboardVersionDTO
+	ExpectedDashboardVersions []*dashver.DashboardVersionDTO
+	counter                   int
+	ExpectedError             error
 }
 
 func NewDashboardVersionServiceFake() *FakeDashboardVersionService {
 	return &FakeDashboardVersionService{}
 }
 
-func (f *FakeDashboardVersionService) Get(ctx context.Context, query *dashver.GetDashboardVersionQuery) (*dashver.DashboardVersion, error) {
+func (f *FakeDashboardVersionService) Get(ctx context.Context, query *dashver.GetDashboardVersionQuery) (*dashver.DashboardVersionDTO, error) {
 	if len(f.ExpectedDashboardVersions) == 0 {
 		return f.ExpectedDashboardVersion, f.ExpectedError
 	}
@@ -31,5 +30,5 @@ func (f *FakeDashboardVersionService) DeleteExpired(ctx context.Context, cmd *da
 }
 
 func (f *FakeDashboardVersionService) List(ctx context.Context, query *dashver.ListDashboardVersionsQuery) ([]*dashver.DashboardVersionDTO, error) {
-	return f.ExpectedListDashboarVersions, f.ExpectedError
+	return f.ExpectedDashboardVersions, f.ExpectedError
 }

--- a/pkg/services/dashboardversion/model.go
+++ b/pkg/services/dashboardversion/model.go
@@ -45,17 +45,33 @@ type ListDashboardVersionsQuery struct {
 }
 
 type DashboardVersionDTO struct {
-	ID            int64     `json:"id" xorm:"id" db:"id"`
-	DashboardID   int64     `json:"dashboardId" xorm:"dashboard_id" db:"dashboard_id"`
-	DashboardUID  string    `json:"dashboardUid" xorm:"dashboard_uid" db:"dashboard_uid"`
-	ParentVersion int       `json:"parentVersion" db:"parent_version"`
-	RestoredFrom  int       `json:"restoredFrom" db:"restored_from"`
-	Version       int       `json:"version" db:"version"`
-	Created       time.Time `json:"created" db:"created"`
-	// Since we get created by with left join user table, this can be null technically,
-	// but in reality it will always be set, when database is not corrupted.
-	CreatedBy *string `json:"createdBy" db:"created_by_login"`
-	Message   string  `json:"message" db:"message"`
+	ID            int64            `json:"id"`
+	DashboardID   int64            `json:"dashboardId"`
+	DashboardUID  string           `json:"dashboardUid"`
+	ParentVersion int              `json:"parentVersion"`
+	RestoredFrom  int              `json:"restoredFrom"`
+	Version       int              `json:"version"`
+	Created       time.Time        `json:"created"`
+	CreatedBy     int64            `json:"createdBy"`
+	Message       string           `json:"message"`
+	Data          *simplejson.Json `json:"data"`
+}
+
+func (d *DashboardVersion) ToDTO(uid string) *DashboardVersionDTO {
+	if d == nil {
+		return nil
+	}
+	return &DashboardVersionDTO{
+		ID:            d.ID,
+		DashboardUID:  uid,
+		ParentVersion: d.ParentVersion,
+		RestoredFrom:  d.RestoredFrom,
+		Version:       d.Version,
+		Created:       d.Created,
+		CreatedBy:     d.CreatedBy,
+		Message:       d.Message,
+		Data:          d.Data,
+	}
 }
 
 // DashboardVersionMeta extends the dashboard version model with the names


### PR DESCRIPTION
This adds the dashboard UID to the DashboardVersionDTO returned by Get and List, by adding the DashboardService as a dependency and using the ID (stored in the dashboard version table) to get the dashboard UID.

The return object was not consistent, so I also refactored things so that the Service always returns the DTO - with the dashboard UID - while the store return just the DashboardVersion object. I removed the database-related tags from the DTO to (hopefully) make its use case more obvious.

Finally, I added a DashboardVersion.ToDTO method which takes the UID as an argument and returns a DashboardVersionDTO.

Addresses #59643 (but might not close it)