### PR TITLE
Fix Explore URL generator

### DIFF
--- a/public/app/features/alerting/unified/components/rule-viewer/RuleViewerVisualization.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/RuleViewerVisualization.tsx
@@ -146,7 +146,7 @@ function createExploreLink(settings: DataSourceInstanceSettings, model: AlertDat
   return urlUtil.renderUrl(`${config.appSubUrl}/explore`, {
     left: JSON.stringify({
       datasource: name,
-      queries: [{ refId: 'A', datasource: name, expr: queryParams }],
+      queries: [{ refId: 'A', ...queryParams }],
       range: { from: 'now-1h', to: 'now' },
     }),
   });


### PR DESCRIPTION
**What is this feature?**

This fixes a bug in which generating an Explore URL link would always fail.

**Which issue(s) does this PR fix?**:

Fixes #60526

**Special notes for your reviewer**:

This is a regression caused by #59686

Replication Steps
1. Go into Alerting. Click Alert Rules.
2. Expand an alert and click the eye icon - the view action
3. Expand the "Query & Results" dropdown
4. Click "View in Explore"

Previously, it would error. It should not error with this fix.
