### PR TITLE
Logs: Fix height of logs component when used with topnav

### DIFF
--- a/public/app/features/explore/LogsNavigation.tsx
+++ b/public/app/features/explore/LogsNavigation.tsx
@@ -1,10 +1,11 @@
 import { css } from '@emotion/css';
 import { isEqual } from 'lodash';
-import React, { memo, useState, useEffect, useRef } from 'react';
+import React, { memo, useEffect, useRef, useState } from 'react';
 
-import { LogsSortOrder, AbsoluteTimeRange, TimeZone, DataQuery, GrafanaTheme2 } from '@grafana/data';
+import { AbsoluteTimeRange, DataQuery, GrafanaTheme2, LogsSortOrder, TimeZone } from '@grafana/data';
 import { reportInteraction } from '@grafana/runtime';
 import { Button, Icon, Spinner, useTheme2 } from '@grafana/ui';
+import { TOP_BAR_LEVEL_HEIGHT } from 'app/core/components/AppChrome/types';
 
 import { LogsNavigationPages } from './LogsNavigationPages';
 
@@ -188,9 +189,12 @@ function LogsNavigation({
 export default memo(LogsNavigation);
 
 const getStyles = (theme: GrafanaTheme2, oldestLogsFirst: boolean, loading: boolean) => {
+  const navContainerHeight = theme.flags.topnav
+    ? `calc(100vh - 2*${theme.spacing(2)} - 2*${TOP_BAR_LEVEL_HEIGHT}px)`
+    : '95vh';
   return {
     navContainer: css`
-      max-height: 95vh;
+      max-height: ${navContainerHeight};
       display: flex;
       flex-direction: column;
       justify-content: ${oldestLogsFirst ? 'flex-start' : 'space-between'};


### PR DESCRIPTION
**What is this feature?**

When using `topnav` the height of the LogsNavigation is wrong:
<img width="95" alt="image" src="https://user-images.githubusercontent.com/8092184/209087179-a42ec50b-e6b4-4afc-b9c7-70cf4f460298.png">

**Who is this feature for?**

topnav users.

**Special notes for your reviewer**:

Reason for the calculation: 
100 total height minus two times a topnav menu row minus two times 16px "padding".

<img width="82" alt="image" src="https://user-images.githubusercontent.com/8092184/209087276-3f8846c1-b014-4ebb-85c7-561f82ecca07.png">


