### PR TITLE
Elasticsearch: Use constants for default values and types

### DIFF
--- a/pkg/tsdb/elasticsearch/client/search_request.go
+++ b/pkg/tsdb/elasticsearch/client/search_request.go
@@ -6,6 +6,12 @@ import (
 	"github.com/grafana/grafana/pkg/tsdb/intervalv2"
 )
 
+const (
+	highlightPreTagsString  = "@HIGHLIGHT@"
+	highlightPostTagsString = "@/HIGHLIGHT@"
+	highlightFragmentSize   = 2147483647
+)
+
 // SearchRequestBuilder represents a builder which can build a search request
 type SearchRequestBuilder struct {
 	interval intervalv2.Interval
@@ -98,9 +104,9 @@ func (b *SearchRequestBuilder) AddHighlight() *SearchRequestBuilder {
 		"fields": map[string]interface{}{
 			"*": map[string]interface{}{},
 		},
-		"pre_tags":      []string{"@HIGHLIGHT@"},
-		"post_tags":     []string{"@/HIGHLIGHT@"},
-		"fragment_size": 2147483647,
+		"pre_tags":      []string{highlightPreTagsString},
+		"post_tags":     []string{highlightPostTagsString},
+		"fragment_size": highlightFragmentSize,
 	}
 	return b
 }

--- a/pkg/tsdb/elasticsearch/response_parser.go
+++ b/pkg/tsdb/elasticsearch/response_parser.go
@@ -26,6 +26,11 @@ const (
 	filtersType     = "filters"
 	termsType       = "terms"
 	geohashGridType = "geohash_grid"
+	//  Document types
+	rawDocumentType = "raw_document"
+	rawDataType     = "raw_data"
+	// Logs type
+	logsType = "logs"
 )
 
 func parseResponse(responses []*es.SearchResponse, targets []*Query) (*backend.QueryDataResponse, error) {

--- a/pkg/tsdb/elasticsearch/time_series_query_test.go
+++ b/pkg/tsdb/elasticsearch/time_series_query_test.go
@@ -70,7 +70,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 			require.Equal(t, firstLevel.Key, "2")
 			termsAgg := firstLevel.Aggregation.Aggregation.(*es.TermsAggregation)
 			require.Equal(t, termsAgg.Field, "@host")
-			require.Equal(t, termsAgg.Size, 500)
+			require.Equal(t, termsAgg.Size, defaultSize)
 			secondLevel := firstLevel.Aggregation.Aggs[0]
 			require.Equal(t, secondLevel.Key, "3")
 			require.Equal(t, secondLevel.Aggregation.Aggregation.(*es.DateHistogramAgg).Field, "@timestamp")
@@ -421,7 +421,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 			require.NoError(t, err)
 			sr := c.multisearchRequests[0].Requests[0]
 
-			require.Equal(t, sr.Size, 500)
+			require.Equal(t, sr.Size, defaultSize)
 		})
 
 		t.Run("With raw document metric query (from frontend tests)", func(t *testing.T) {
@@ -440,7 +440,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 			require.Equal(t, rangeFilter.Gte, fromMs)
 			require.Equal(t, rangeFilter.Format, es.DateFormatEpochMS)
 
-			require.Equal(t, sr.Size, 500)
+			require.Equal(t, sr.Size, defaultSize)
 			require.Equal(t, sr.Sort["@timestamp"], map[string]string{"order": "desc", "unmapped_type": "boolean"})
 			require.Equal(t, sr.Sort["_doc"], map[string]string{"order": "desc"})
 			require.Equal(t, sr.CustomProps["script_fields"], map[string]interface{}{})
@@ -462,7 +462,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 			require.Equal(t, rangeFilter.Gte, fromMs)
 			require.Equal(t, rangeFilter.Format, es.DateFormatEpochMS)
 
-			require.Equal(t, sr.Size, 500)
+			require.Equal(t, sr.Size, defaultSize)
 			require.Equal(t, sr.Sort["@timestamp"], map[string]string{"order": "desc", "unmapped_type": "boolean"})
 			require.Equal(t, sr.Sort["_doc"], map[string]string{"order": "desc"})
 			require.Equal(t, sr.CustomProps["script_fields"], map[string]interface{}{})
@@ -1347,7 +1347,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 			}`, from, to, 15*time.Second)
 			require.NoError(t, err)
 			sr := c.multisearchRequests[0].Requests[0]
-			require.Equal(t, sr.Size, 500)
+			require.Equal(t, sr.Size, defaultSize)
 
 			rangeFilter := sr.Query.Bool.Filters[0].(*es.RangeFilter)
 			require.Equal(t, rangeFilter.Key, c.timeField)


### PR DESCRIPTION
In this PR, we are:

- moving default 500 size to constant and use it instead of hardcoded string
- moving specific highlight strings into constants
- raw data, raw doc and logs type were missing, so we are introducing them and using them