### PR TITLE
Loki: Fix missing parameters on Query Builder operations

### DIFF
--- a/public/app/plugins/datasource/loki/querybuilder/operations.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/operations.ts
@@ -2,7 +2,7 @@ import {
   createAggregationOperation,
   createAggregationOperationWithParam,
 } from '../../prometheus/querybuilder/shared/operationUtils';
-import { QueryBuilderOperationDef } from '../../prometheus/querybuilder/shared/types';
+import { QueryBuilderOperationDef, QueryBuilderOperationParamValue } from '../../prometheus/querybuilder/shared/types';
 
 import { binaryScalarOperations } from './binaryScalarOperations';
 import { UnwrapParamEditor } from './components/UnwrapParamEditor';
@@ -479,4 +479,17 @@ export function explainOperator(id: LokiOperationId | string): string {
 
   // Strip markdown links
   return explain.replace(/\[(.*)\]\(.*\)/g, '$1');
+}
+
+export function getOperationById(id: string): QueryBuilderOperationDef | undefined {
+  return definitions.find((x) => x.id === id);
+}
+
+export function checkParamsAreValid(op: QueryBuilderOperationDef, params: QueryBuilderOperationParamValue[]): boolean {
+  // For now we only check if the operation has all the required params.
+  if (params.length < op.params.filter((param) => !param.optional).length) {
+    return false;
+  }
+
+  return true;
 }

--- a/public/app/plugins/datasource/loki/querybuilder/operations.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/operations.ts
@@ -481,13 +481,13 @@ export function explainOperator(id: LokiOperationId | string): string {
   return explain.replace(/\[(.*)\]\(.*\)/g, '$1');
 }
 
-export function getOperationById(id: string): QueryBuilderOperationDef | undefined {
+export function getDefinitionById(id: string): QueryBuilderOperationDef | undefined {
   return definitions.find((x) => x.id === id);
 }
 
-export function checkParamsAreValid(op: QueryBuilderOperationDef, params: QueryBuilderOperationParamValue[]): boolean {
+export function checkParamsAreValid(def: QueryBuilderOperationDef, params: QueryBuilderOperationParamValue[]): boolean {
   // For now we only check if the operation has all the required params.
-  if (params.length < op.params.filter((param) => !param.optional).length) {
+  if (params.length < def.params.filter((param) => !param.optional).length) {
     return false;
   }
 

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.test.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.test.ts
@@ -586,6 +586,81 @@ describe('buildVisualQueryFromString', () => {
       })
     );
   });
+
+  it('parses a regexp with empty string param', () => {
+    expect(buildVisualQueryFromString('{app="frontend"} | regexp "" ')).toEqual(
+      noErrors({
+        labels: [
+          {
+            op: '=',
+            value: 'frontend',
+            label: 'app',
+          },
+        ],
+        operations: [{ id: LokiOperationId.Regexp, params: [''] }],
+      })
+    );
+  });
+
+  it('parses a regexp with no param', () => {
+    expect(buildVisualQueryFromString('{app="frontend"} | regexp ')).toEqual(
+      noErrors({
+        labels: [
+          {
+            op: '=',
+            value: 'frontend',
+            label: 'app',
+          },
+        ],
+        operations: [{ id: LokiOperationId.Regexp, params: [''] }],
+      })
+    );
+  });
+
+  it('parses a pattern with empty string param', () => {
+    expect(buildVisualQueryFromString('{app="frontend"} | pattern "" ')).toEqual(
+      noErrors({
+        labels: [
+          {
+            op: '=',
+            value: 'frontend',
+            label: 'app',
+          },
+        ],
+        operations: [{ id: LokiOperationId.Pattern, params: [''] }],
+      })
+    );
+  });
+
+  it('parses a pattern with no param', () => {
+    expect(buildVisualQueryFromString('{app="frontend"} | pattern ')).toEqual(
+      noErrors({
+        labels: [
+          {
+            op: '=',
+            value: 'frontend',
+            label: 'app',
+          },
+        ],
+        operations: [{ id: LokiOperationId.Pattern, params: [''] }],
+      })
+    );
+  });
+
+  it('parses a json with no param', () => {
+    expect(buildVisualQueryFromString('{app="frontend"} | json ')).toEqual(
+      noErrors({
+        labels: [
+          {
+            op: '=',
+            value: 'frontend',
+            label: 'app',
+          },
+        ],
+        operations: [{ id: LokiOperationId.Json, params: [] }],
+      })
+    );
+  });
 });
 
 function noErrors(query: LokiVisualQuery) {

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.ts
@@ -58,7 +58,7 @@ import {
 } from '../../prometheus/querybuilder/shared/types';
 
 import { binaryScalarDefs } from './binaryScalarOperations';
-import { checkParamsAreValid, getOperationById } from './operations';
+import { checkParamsAreValid, getDefinitionById } from './operations';
 import { LokiOperationId, LokiVisualQuery, LokiVisualQueryBinary } from './types';
 
 interface Context {
@@ -262,9 +262,9 @@ function getLabelParser(expr: string, node: SyntaxNode): QueryBuilderOperation {
 
   const string = handleQuotes(getString(expr, node.getChild(String)));
   let params: QueryBuilderOperationParamValue[] = !!string ? [string] : [];
-  const defaultOperation = getOperationById(parser);
-  if (defaultOperation && !checkParamsAreValid(defaultOperation, params)) {
-    params = defaultOperation?.defaultParams || [];
+  const opDef = getDefinitionById(parser);
+  if (opDef && !checkParamsAreValid(opDef, params)) {
+    params = opDef?.defaultParams || [];
   }
 
   return {

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.ts
@@ -277,7 +277,7 @@ function getJsonExpressionParser(expr: string, node: SyntaxNode): QueryBuilderOp
   const parserNode = node.getChild(Json);
   const parser = getString(expr, parserNode);
 
-  let params = [...getAllByType(expr, node, JsonExpression)];
+  const params = [...getAllByType(expr, node, JsonExpression)];
   return {
     id: parser,
     params,


### PR DESCRIPTION
**What is this feature?**

Certain operations like `regexp` or `pattern` where not properly parsed when an empty string was given as a parameter.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes  https://github.com/grafana/support-escalations/issues/4700

**Special notes for your reviewer**:

Example see https://play.grafana.org/goto/RU1KJ6c4z?orgId=1

Test it with queries like `{source="data"} | regexp ""` and see that `{source="data"} | json` is not adding the parameter since they are optional. 