### PR TITLE
Public Dashboards: Time range for public dashboard in NavToolbar

### DIFF
--- a/public/app/core/components/AppChrome/AppChrome.tsx
+++ b/public/app/core/components/AppChrome/AppChrome.tsx
@@ -20,11 +20,11 @@ export function AppChrome({ children }: Props) {
   const { chrome } = useGrafana();
   const state = chrome.useState();
 
-  if (!config.featureToggles.topnav || config.isPublicDashboardView) {
+  if (!config.featureToggles.topnav) {
     return <main className="main-view">{children}</main>;
   }
 
-  const searchBarHidden = state.searchBarHidden || state.kioskMode === KioskMode.TV;
+  const searchBarHidden = state.searchBarHidden || state.kioskMode === KioskMode.TV || config.isPublicDashboardView;
 
   const contentClass = cx({
     [styles.content]: true,

--- a/public/app/core/components/AppChrome/NavToolbar.tsx
+++ b/public/app/core/components/AppChrome/NavToolbar.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/css';
 import React from 'react';
 
 import { GrafanaTheme2, NavModelItem } from '@grafana/data';
+import { config } from '@grafana/runtime';
 import { Icon, IconButton, ToolbarButton, useStyles2 } from '@grafana/ui';
 import { HOME_NAV_ID } from 'app/core/reducers/navModel';
 import { useSelector } from 'app/types';
@@ -37,19 +38,31 @@ export function NavToolbar({
 
   return (
     <div className={styles.pageToolbar}>
-      <div className={styles.menuButton}>
-        <IconButton name="bars" tooltip="Toggle menu" tooltipPlacement="bottom" size="xl" onClick={onToggleMegaMenu} />
-      </div>
-      <Breadcrumbs breadcrumbs={breadcrumbs} className={styles.breadcrumbs} />
+      {!config.isPublicDashboardView && (
+        <>
+          <div className={styles.menuButton}>
+            <IconButton
+              name="bars"
+              tooltip="Toggle menu"
+              tooltipPlacement="bottom"
+              size="xl"
+              onClick={onToggleMegaMenu}
+            />
+          </div>
+          <Breadcrumbs breadcrumbs={breadcrumbs} className={styles.breadcrumbs} />
+        </>
+      )}
       <div className={styles.actions}>
         {actions}
         {actions && <NavToolbarSeparator />}
-        {searchBarHidden && (
+        {searchBarHidden && !config.isPublicDashboardView && (
           <ToolbarButton onClick={onToggleKioskMode} narrow title="Enable kiosk mode" icon="monitor" />
         )}
-        <ToolbarButton onClick={onToggleSearchBar} narrow title="Toggle top search bar">
-          <Icon name={searchBarHidden ? 'angle-down' : 'angle-up'} size="xl" />
-        </ToolbarButton>
+        {!config.isPublicDashboardView && (
+          <ToolbarButton onClick={onToggleSearchBar} narrow title="Toggle top search bar">
+            <Icon name={searchBarHidden ? 'angle-down' : 'angle-up'} size="xl" />
+          </ToolbarButton>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

It shows the time range picker in the new nav toolbar for public dashboard view.

**Why do we need this feature?**

When the topnav feature is disabled, the old navbar view is shown. In that case, the time range picker is being rendered for public dashboard but not when the topnav feature is enabled.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes (#533)https://github.com/grafana/grafana-enterprise/issues/4579

**Special notes for your reviewer**:
![image](https://user-images.githubusercontent.com/11707172/209140752-74c190bb-094e-46c2-bfa2-b914a8f44f00.png)

