### PR TITLE
Elasticsearch: Fix adding of adhoc filters when jumping to explore

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/LanguageProvider.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/LanguageProvider.test.ts
@@ -37,7 +37,7 @@ describe('transform abstract query to elasticsearch query', () => {
 
     expect(result).toEqual({
       ...baseLogsQuery,
-      query: 'label1:"value1" AND NOT label2:"value2" AND label3:/value3/ AND NOT label4:/value4/',
+      query: 'label1:"value1" AND -label2:"value2" AND label3:/value3/ AND -label4:/value4/',
       refId: abstractQuery.refId,
     });
   });

--- a/public/app/plugins/datasource/elasticsearch/LanguageProvider.ts
+++ b/public/app/plugins/datasource/elasticsearch/LanguageProvider.ts
@@ -39,13 +39,13 @@ export default class ElasticsearchLanguageProvider extends LanguageProvider {
             return label.name + ':"' + label.value + '"';
           }
           case AbstractLabelOperator.NotEqual: {
-            return 'NOT ' + label.name + ':"' + label.value + '"';
+            return '-' + label.name + ':"' + label.value + '"';
           }
           case AbstractLabelOperator.EqualRegEx: {
             return label.name + ':/' + label.value + '/';
           }
           case AbstractLabelOperator.NotEqualRegEx: {
-            return 'NOT ' + label.name + ':/' + label.value + '/';
+            return '-' + label.name + ':/' + label.value + '/';
           }
         }
       })

--- a/public/app/plugins/datasource/elasticsearch/datasource.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.test.ts
@@ -1051,7 +1051,7 @@ describe('modifyQuery', () => {
 
     it('should add the negative filter', () => {
       expect(ds.modifyQuery(query, { type: 'ADD_FILTER_OUT', options: { key: 'foo', value: 'bar' } }).query).toBe(
-        'NOT foo:"bar"'
+        '-foo:"bar"'
       );
     });
 
@@ -1074,7 +1074,7 @@ describe('modifyQuery', () => {
 
     it('should add the negative filter', () => {
       expect(ds.modifyQuery(query, { type: 'ADD_FILTER_OUT', options: { key: 'foo', value: 'bar' } }).query).toBe(
-        'test:"value" AND NOT foo:"bar"'
+        'test:"value" AND -foo:"bar"'
       );
     });
 
@@ -1148,13 +1148,13 @@ describe('addAdhocFilters', () => {
     it('should correctly add ad hoc filters when query is not empty', () => {
       const query = ds.addAdHocFilters('foo:"bar" AND test:"test1"');
       expect(query).toBe(
-        'foo:"bar" AND test:"test1" AND bar:"baz" AND NOT job:"grafana" AND service:/service/ AND count:>1'
+        'foo:"bar" AND test:"test1" AND bar:"baz" AND -job:"grafana" AND service:/service/ AND count:>1'
       );
     });
 
     it('should correctly add ad hoc filters when query is  empty', () => {
       const query = ds.addAdHocFilters('');
-      expect(query).toBe('bar:"baz" AND NOT job:"grafana" AND service:/service/ AND count:>1');
+      expect(query).toBe('bar:"baz" AND -job:"grafana" AND service:/service/ AND count:>1');
     });
   });
 });

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -964,7 +964,7 @@ export class ElasticDatasource
         if (expression.length > 0) {
           expression += ' AND ';
         }
-        expression += `NOT ${action.options.key}:"${action.options.value}"`;
+        expression += `-${action.options.key}:"${action.options.value}"`;
         break;
       }
     }
@@ -985,11 +985,11 @@ export class ElasticDatasource
         case '=':
           return `${key}:"${value}"`;
         case '!=':
-          return `NOT ${key}:"${value}"`;
+          return `-${key}:"${value}"`;
         case '=~':
           return `${key}:/${value}/`;
         case '!~':
-          return `NOT ${key}:/${value}/`;
+          return `-${key}:/${value}/`;
         case '>':
           return `${key}:>${value}`;
         case '<':


### PR DESCRIPTION
The same as was fixed for Loki & Prometheus in https://github.com/grafana/grafana/pull/55915

This PR fixes a bug around adhoc filters and the Explore experience for elasticsearch. When you have adhoc filters (type of dashboards variable) and you jump to Explore, all variables are interpolated, but adhoc filters were ignored. For consistency, it would make sense to interpolate and include all variables. Not just some of them. 

In this PR, we are creating a new data source method `addAdHocVariables` and then using it in `interpolateVariablesInQuery`, which is a function used to interpolate variables when jumping from dashboard to explore.

I have also added test coverage for all the new functionality.

Lastly, I have replaced usage of `NOT` operator to `-`, as that is recommended as preferred operator: https://www.elastic.co/guide/en/elasticsearch/reference/8.5/query-dsl-query-string-query.html#_boolean_operators 

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/55916

**Special notes for your reviewer**:
1. Run elastic data source by `make devenv sources=elastic`
2. Create simple dashboard with 1 ES panel (any query, default query works)
3. Add ad hoc template variables
4. Apply variables and then jump to explore
5. Check if variables were correctly added

This is how it CORRECTLY WORKS on **this branch**:

https://user-images.githubusercontent.com/30407135/209147111-9d8a0445-6c98-4134-b0fb-ef64e986c368.mov

For comparison, this is how it DOES NOT WORK on **main branch**:

https://user-images.githubusercontent.com/30407135/209147406-62d68879-284d-4027-be94-c62448bb6fc5.mov
