### PR TITLE
TopNav: Fixes the invite user page navId / missing section nav and design of user list page 

### DIFF
--- a/public/app/features/admin/UserListPage.tsx
+++ b/public/app/features/admin/UserListPage.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import React, { useState } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { RadioButtonGroup, Field, useStyles2 } from '@grafana/ui';
+import { useStyles2, TabsBar, Tab } from '@grafana/ui';
 import { contextSrv } from 'app/core/services/context_srv';
 
 import { Page } from '../../core/components/Page/Page';
@@ -10,11 +10,6 @@ import { AccessControlAction } from '../../types';
 import { UsersListPageContent } from '../users/UsersListPage';
 
 import { UserListAdminPageContent } from './UserListAdminPage';
-
-const views = [
-  { value: 'admin', label: 'All organisations' },
-  { value: 'org', label: 'This organisation' },
-];
 
 export default function UserListPage() {
   const hasAccessToAdminUsers = contextSrv.hasAccess(AccessControlAction.UsersRead, contextSrv.isGrafanaAdmin);
@@ -34,19 +29,18 @@ export default function UserListPage() {
   return (
     <Page navId={'global-users'}>
       {showToggle && (
-        <Field label={'Display list of users for'} className={styles.container}>
-          <RadioButtonGroup options={views} onChange={setView} value={view} />
-        </Field>
+        <TabsBar className={styles.tabsMargin}>
+          <Tab label="All users" active={view === 'admin'} onChangeTab={() => setView('admin')} />
+          <Tab label="Organization users" active={view === 'org'} onChangeTab={() => setView('org')} />
+        </TabsBar>
       )}
       {view === 'admin' ? <UserListAdminPageContent /> : <UsersListPageContent />}
     </Page>
   );
 }
 
-const getStyles = (theme: GrafanaTheme2) => {
-  return {
-    container: css`
-      margin: ${theme.spacing(2, 0)};
-    `,
-  };
-};
+const getStyles = (theme: GrafanaTheme2) => ({
+  tabsMargin: css({
+    marginBottom: theme.spacing(3),
+  }),
+});

--- a/public/app/features/org/UserInvitePage.tsx
+++ b/public/app/features/org/UserInvitePage.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { config } from '@grafana/runtime';
 import { Page } from 'app/core/components/Page/Page';
 import { contextSrv } from 'app/core/core';
 
@@ -13,8 +14,10 @@ export function UserInvitePage() {
     </>
   );
 
+  const navId = config.featureToggles.topnav ? 'global-users' : 'users';
+
   return (
-    <Page navId="users" pageNav={{ text: 'Invite user' }} subTitle={subTitle}>
+    <Page navId={navId} pageNav={{ text: 'Invite user' }} subTitle={subTitle}>
       <Page.Contents>
         <Page.OldNavOnly>
           <h3 className="page-sub-heading">Invite user</h3>


### PR DESCRIPTION

The user invite page did not have section nav due to incorrect page navId when topnav is enabled. 

This also fixes the design of the user list for topnav, it used an unconventional radio button to toggle between different views instead of tabs that we normally use to switch between different views. 

Before:
![Screenshot from 2022-12-22 16-36-28](https://user-images.githubusercontent.com/10999/209169551-870d5673-327a-434d-bfc4-71516269b455.png)

After: 
![Screenshot from 2022-12-22 16-36-12](https://user-images.githubusercontent.com/10999/209169584-1e5219fa-47c4-477b-89c6-b3df2ce70dff.png)

