### PR TITLE
CloudMonitor: Add adoption metrics

### DIFF
--- a/public/app/plugins/datasource/cloud-monitoring/module.ts
+++ b/public/app/plugins/datasource/cloud-monitoring/module.ts
@@ -1,3 +1,5 @@
+import { get } from 'lodash';
+
 import { DataSourcePlugin, DashboardLoadedEvent } from '@grafana/data';
 import { getAppEvents } from '@grafana/runtime';
 
@@ -23,19 +25,15 @@ getAppEvents().subscribe<DashboardLoadedEvent<CloudMonitoringQuery>>(
     const cloudmonitorQueries = queries[pluginJson.id];
     let stats = {
       [QueryType.TIME_SERIES_QUERY]: {
-        hidden: 0,
         visible: 0,
       },
       [QueryType.TIME_SERIES_LIST]: {
-        hidden: 0,
         visible: 0,
       },
       [QueryType.SLO]: {
-        hidden: 0,
         visible: 0,
       },
       [QueryType.ANNOTATION]: {
-        hidden: 0,
         visible: 0,
       },
     };
@@ -46,7 +44,16 @@ getAppEvents().subscribe<DashboardLoadedEvent<CloudMonitoringQuery>>(
         query.queryType === QueryType.SLO ||
         query.queryType === QueryType.ANNOTATION
       ) {
-        stats[query.queryType][query.hide ? 'hidden' : 'visible']++;
+        stats[query.queryType].visible++;
+      } else if (query.queryType === 'metrics') {
+        if (query.hasOwnProperty('type') && get(query, 'type') === 'annotationQuery') {
+          stats.annotation.visible++;
+        }
+        if (get(query, 'metricQuery.editorMode') === 'mql') {
+          stats.timeSeriesQuery.visible++;
+        } else {
+          stats.timeSeriesList.visible++;
+        }
       }
     });
 

--- a/public/app/plugins/datasource/cloud-monitoring/module.ts
+++ b/public/app/plugins/datasource/cloud-monitoring/module.ts
@@ -1,14 +1,65 @@
-import { DataSourcePlugin } from '@grafana/data';
+import { DataSourcePlugin, DashboardLoadedEvent } from '@grafana/data';
+import { getAppEvents } from '@grafana/runtime';
 
 import CloudMonitoringCheatSheet from './components/CloudMonitoringCheatSheet';
 import { ConfigEditor } from './components/ConfigEditor/ConfigEditor';
 import { QueryEditor } from './components/QueryEditor';
 import { CloudMonitoringVariableQueryEditor } from './components/VariableQueryEditor';
 import CloudMonitoringDatasource from './datasource';
-import { CloudMonitoringQuery } from './types';
+import pluginJson from './plugin.json';
+import { trackCloudMonitoringDashboardLoaded } from './tracking';
+import { CloudMonitoringQuery, QueryType } from './types';
 
 export const plugin = new DataSourcePlugin<CloudMonitoringDatasource, CloudMonitoringQuery>(CloudMonitoringDatasource)
   .setQueryEditorHelp(CloudMonitoringCheatSheet)
   .setQueryEditor(QueryEditor)
   .setConfigEditor(ConfigEditor)
   .setVariableQueryEditor(CloudMonitoringVariableQueryEditor);
+
+// Track dashboard loads to RudderStack
+getAppEvents().subscribe<DashboardLoadedEvent<CloudMonitoringQuery>>(
+  DashboardLoadedEvent,
+  ({ payload: { dashboardId, orgId, grafanaVersion, queries } }) => {
+    const cloudmonitorQueries = queries[pluginJson.id];
+    let stats = {
+      [QueryType.TIME_SERIES_QUERY]: {
+        hidden: 0,
+        visible: 0,
+      },
+      [QueryType.TIME_SERIES_LIST]: {
+        hidden: 0,
+        visible: 0,
+      },
+      [QueryType.SLO]: {
+        hidden: 0,
+        visible: 0,
+      },
+      [QueryType.ANNOTATION]: {
+        hidden: 0,
+        visible: 0,
+      },
+    };
+    cloudmonitorQueries.forEach((query) => {
+      if (
+        query.queryType === QueryType.TIME_SERIES_QUERY ||
+        query.queryType === QueryType.TIME_SERIES_LIST ||
+        query.queryType === QueryType.SLO ||
+        query.queryType === QueryType.ANNOTATION
+      ) {
+        stats[query.queryType][query.hide ? 'hidden' : 'visible']++;
+      }
+    });
+
+    if (cloudmonitorQueries && cloudmonitorQueries.length > 0) {
+      trackCloudMonitoringDashboardLoaded({
+        grafana_version: grafanaVersion,
+        dashboard_id: dashboardId,
+        org_id: orgId,
+        mql_queries: stats[QueryType.TIME_SERIES_QUERY].visible,
+        time_series_filter_queries: stats[QueryType.TIME_SERIES_LIST].visible,
+        slo_queries: stats[QueryType.SLO].visible,
+        annotation_queries: stats[QueryType.ANNOTATION].visible,
+      });
+    }
+  }
+);

--- a/public/app/plugins/datasource/cloud-monitoring/module.ts
+++ b/public/app/plugins/datasource/cloud-monitoring/module.ts
@@ -24,18 +24,10 @@ getAppEvents().subscribe<DashboardLoadedEvent<CloudMonitoringQuery>>(
   ({ payload: { dashboardId, orgId, grafanaVersion, queries } }) => {
     const cloudmonitorQueries = queries[pluginJson.id];
     let stats = {
-      [QueryType.TIME_SERIES_QUERY]: {
-        visible: 0,
-      },
-      [QueryType.TIME_SERIES_LIST]: {
-        visible: 0,
-      },
-      [QueryType.SLO]: {
-        visible: 0,
-      },
-      [QueryType.ANNOTATION]: {
-        visible: 0,
-      },
+      [QueryType.TIME_SERIES_QUERY]: 0,
+      [QueryType.TIME_SERIES_LIST]: 0,
+      [QueryType.SLO]: 0,
+      [QueryType.ANNOTATION]: 0,
     };
     cloudmonitorQueries.forEach((query) => {
       if (
@@ -44,15 +36,15 @@ getAppEvents().subscribe<DashboardLoadedEvent<CloudMonitoringQuery>>(
         query.queryType === QueryType.SLO ||
         query.queryType === QueryType.ANNOTATION
       ) {
-        stats[query.queryType].visible++;
+        stats[query.queryType]++;
       } else if (query.queryType === 'metrics') {
         if (query.hasOwnProperty('type') && get(query, 'type') === 'annotationQuery') {
-          stats.annotation.visible++;
+          stats.annotation++;
         }
         if (get(query, 'metricQuery.editorMode') === 'mql') {
-          stats.timeSeriesQuery.visible++;
+          stats.timeSeriesQuery++;
         } else {
-          stats.timeSeriesList.visible++;
+          stats.timeSeriesList++;
         }
       }
     });
@@ -62,10 +54,10 @@ getAppEvents().subscribe<DashboardLoadedEvent<CloudMonitoringQuery>>(
         grafana_version: grafanaVersion,
         dashboard_id: dashboardId,
         org_id: orgId,
-        mql_queries: stats[QueryType.TIME_SERIES_QUERY].visible,
-        time_series_filter_queries: stats[QueryType.TIME_SERIES_LIST].visible,
-        slo_queries: stats[QueryType.SLO].visible,
-        annotation_queries: stats[QueryType.ANNOTATION].visible,
+        mql_queries: stats[QueryType.TIME_SERIES_QUERY],
+        time_series_filter_queries: stats[QueryType.TIME_SERIES_LIST],
+        slo_queries: stats[QueryType.SLO],
+        annotation_queries: stats[QueryType.ANNOTATION],
       });
     }
   }

--- a/public/app/plugins/datasource/cloud-monitoring/tracking.ts
+++ b/public/app/plugins/datasource/cloud-monitoring/tracking.ts
@@ -1,0 +1,23 @@
+import { reportInteraction } from '@grafana/runtime';
+
+/**
+ * Loaded the first time a dashboard containing Cloudmonitoring queries is loaded (not on every render)
+ * Note: The queries used here are the ones pre-migration and pre-filterQuery
+ */
+export const trackCloudMonitoringDashboardLoaded = (props: CloudMonitoringDashboardLoadedProps) => {
+  reportInteraction('grafana_ds_cloudmonitoring_dashboard_loaded', props);
+};
+
+export type CloudMonitoringDashboardLoadedProps = {
+  grafana_version?: string;
+  dashboard_id: string;
+  org_id?: number;
+  /** number of non hidden queries of type TimeSeriesQuery (MQL) if any  */
+  mql_queries: number;
+  /** number of non hidden queries of type TimeSeriesFilter (Builder) if any  */
+  time_series_filter_queries: number;
+  /** number of non hidden queries of type SLO if any  */
+  slo_queries: number;
+  /** number of non hidden queries of type annotation if any  */
+  annotation_queries: number;
+};


### PR DESCRIPTION
Add basic metrics to track each query type in use on dashboard load.

Fixes #58353 