### PR TITLE
Folder: Folder name update redirects to desired location, for grafana served with subpath

### DIFF
--- a/public/app/features/folders/state/actions.ts
+++ b/public/app/features/folders/state/actions.ts
@@ -1,7 +1,7 @@
 import { lastValueFrom } from 'rxjs';
 
 import { locationUtil } from '@grafana/data';
-import { getBackendSrv, isFetchError, locationService, config } from '@grafana/runtime';
+import { getBackendSrv, isFetchError, locationService } from '@grafana/runtime';
 import { notifyApp, updateNavIndex } from 'app/core/actions';
 import { createSuccessNotification, createWarningNotification } from 'app/core/copy/appNotification';
 import { contextSrv } from 'app/core/core';
@@ -29,8 +29,7 @@ export function saveFolder(folder: FolderState): ThunkResult<void> {
 
     dispatch(notifyApp(createSuccessNotification('Folder saved')));
     dispatch(loadFolder(res));
-    const resUrl = config.appSubUrl ? `${res.url}`.replace(new RegExp(`^${config.appSubUrl}`), '') : res.url;
-    locationService.push(`${resUrl}/settings`);
+    locationService.push(locationUtil.stripBaseFromUrl(`${res.url}/settings`))
   };
 }
 

--- a/public/app/features/folders/state/actions.ts
+++ b/public/app/features/folders/state/actions.ts
@@ -1,7 +1,7 @@
 import { lastValueFrom } from 'rxjs';
 
 import { locationUtil } from '@grafana/data';
-import { getBackendSrv, isFetchError, locationService } from '@grafana/runtime';
+import { getBackendSrv, isFetchError, locationService, config } from '@grafana/runtime';
 import { notifyApp, updateNavIndex } from 'app/core/actions';
 import { createSuccessNotification, createWarningNotification } from 'app/core/copy/appNotification';
 import { contextSrv } from 'app/core/core';
@@ -28,7 +28,9 @@ export function saveFolder(folder: FolderState): ThunkResult<void> {
     });
 
     dispatch(notifyApp(createSuccessNotification('Folder saved')));
-    locationService.push(`${res.url}/settings`);
+    dispatch(loadFolder(res));
+    const resUrl = config.appSubUrl ? `${res.url}`.replace(new RegExp(`^${config.appSubUrl}`), '') : res.url;
+    locationService.push(`${resUrl}/settings`);
   };
 }
 

--- a/public/app/features/folders/state/actions.ts
+++ b/public/app/features/folders/state/actions.ts
@@ -29,7 +29,7 @@ export function saveFolder(folder: FolderState): ThunkResult<void> {
 
     dispatch(notifyApp(createSuccessNotification('Folder saved')));
     dispatch(loadFolder(res));
-    locationService.push(locationUtil.stripBaseFromUrl(`${res.url}/settings`))
+    locationService.push(locationUtil.stripBaseFromUrl(`${res.url}/settings`));
   };
 }
 


### PR DESCRIPTION
Fix for #52378

Issue: Folder name update redirects to 404 when grafana is served with subpath.

Changes:
- After folder name update, check for config appSubUrl and set the redirect url accordingly.
- Also after folder update, new state is not getting updated in the store. Which doesn't allow user to change the folder name again from same screen. So, set new state to store.

Implemented changes:
![FolderUpdateIssue](https://user-images.githubusercontent.com/9843492/209299810-56988e67-7029-473c-9de1-2a78dd13a27a.gif)

