### PR TITLE
Connections: Align permissions for Connections page

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -132,6 +132,14 @@ func (hs *HTTPServer) registerRoutes() {
 	r.Get("/plugins/:id/", middleware.CanAdminPlugins(hs.Cfg), hs.Index)
 	r.Get("/plugins/:id/edit", middleware.CanAdminPlugins(hs.Cfg), hs.Index) // deprecated
 	r.Get("/plugins/:id/page/:page", middleware.CanAdminPlugins(hs.Cfg), hs.Index)
+
+	r.Get("/connections/your-connections/datasources", authorize(reqOrgAdmin, datasources.ConfigurationPageAccess), hs.Index)
+	r.Get("/connections/your-connections/datasources/new", authorize(reqOrgAdmin, datasources.NewPageAccess), hs.Index)
+	r.Get("/connections/your-connections/datasources/edit/*", authorize(reqOrgAdmin, datasources.EditPageAccess), hs.Index)
+	r.Get("/connections/connect-data", middleware.CanAdminPlugins(hs.Cfg), hs.Index)
+	r.Get("/connections/connect-data/datasources/:id", middleware.CanAdminPlugins(hs.Cfg), hs.Index)
+	r.Get("/connections/connect-data/datasources/:id/page/:page", middleware.CanAdminPlugins(hs.Cfg), hs.Index)
+
 	// App Root Page
 	appPluginIDScope := plugins.ScopeProvider.GetResourceScope(ac.Parameter(":id"))
 	r.Get("/a/:id/*", authorize(reqSignedIn, ac.EvalPermission(plugins.ActionAppAccess, appPluginIDScope)), hs.Index)

--- a/pkg/services/datasources/accesscontrol.go
+++ b/pkg/services/datasources/accesscontrol.go
@@ -24,12 +24,15 @@ var (
 
 var (
 	// ConfigurationPageAccess is used to protect the "Configure > Data sources" tab access
-	ConfigurationPageAccess = accesscontrol.EvalAll(
-		accesscontrol.EvalPermission(ActionRead),
-		accesscontrol.EvalAny(
-			accesscontrol.EvalPermission(ActionCreate),
-			accesscontrol.EvalPermission(ActionDelete),
-			accesscontrol.EvalPermission(ActionWrite),
+	ConfigurationPageAccess = accesscontrol.EvalAny(
+		accesscontrol.EvalPermission(accesscontrol.ActionDatasourcesExplore),
+		accesscontrol.EvalAll(
+			accesscontrol.EvalPermission(ActionRead),
+			accesscontrol.EvalAny(
+				accesscontrol.EvalPermission(ActionCreate),
+				accesscontrol.EvalPermission(ActionDelete),
+				accesscontrol.EvalPermission(ActionWrite),
+			),
 		),
 	)
 

--- a/pkg/services/navtree/navtreeimpl/applinks_test.go
+++ b/pkg/services/navtree/navtreeimpl/applinks_test.go
@@ -25,6 +25,7 @@ func TestAddAppLinks(t *testing.T) {
 	reqCtx := &models.ReqContext{SignedInUser: &user.SignedInUser{}, Context: &web.Context{Req: httpReq}}
 	permissions := []ac.Permission{
 		{Action: plugins.ActionAppAccess, Scope: "*"},
+		{Action: plugins.ActionInstall, Scope: "*"},
 	}
 
 	testApp1 := plugins.PluginDTO{
@@ -290,18 +291,20 @@ func TestAddAppLinks(t *testing.T) {
 		treeRoot.AddSection(service.buildDataConnectionsNavLink(reqCtx))
 		connectionsNode := treeRoot.FindById("connections")
 		require.Equal(t, "Connections", connectionsNode.Text)
-		require.Equal(t, "Connect data", connectionsNode.Children[1].Text)
-		require.Equal(t, "connections-connect-data", connectionsNode.Children[1].Id) // Original "Connect data" page
-		require.Equal(t, "", connectionsNode.Children[1].PluginID)
+
+		connectDataNode := connectionsNode.Children[0]
+		require.Equal(t, "Connect data", connectDataNode.Text)
+		require.Equal(t, "connections-connect-data", connectDataNode.Id) // Original "Connect data" page
+		require.Equal(t, "", connectDataNode.PluginID)
 
 		err := service.addAppLinks(&treeRoot, reqCtx)
 
 		// Check if the standalone plugin page appears under the section where we registered it
 		require.NoError(t, err)
 		require.Equal(t, "Connections", connectionsNode.Text)
-		require.Equal(t, "Connect data", connectionsNode.Children[1].Text)
-		require.Equal(t, "standalone-plugin-page-/connections/connect-data", connectionsNode.Children[1].Id) // Overridden "Connect data" page
-		require.Equal(t, "test-app3", connectionsNode.Children[1].PluginID)
+		require.Equal(t, "Connect data", connectDataNode.Text)
+		require.Equal(t, "standalone-plugin-page-/connections/connect-data", connectDataNode.Id) // Overridden "Connect data" page
+		require.Equal(t, "test-app3", connectDataNode.PluginID)
 
 		// Check if the standalone plugin page does not appear under the app section anymore
 		// (Also checking if the Default Page got removed)

--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -586,7 +586,8 @@ func (s *ServiceImpl) buildDataConnectionsNavLink(c *models.ReqContext) *navtree
 	}
 
 	// Connect data
-	if hasAccess(plugins.ReqCanAdminPlugins(s.cfg), plugins.AdminAccessEvaluator) {
+	// FIXME: while we don't have a permissions for listing plugins the legacy check has to stay as a default
+	if plugins.ReqCanAdminPlugins(s.cfg)(c) || hasAccess(plugins.ReqCanAdminPlugins(s.cfg), plugins.AdminAccessEvaluator) {
 		children = append(children, &navtree.NavLink{
 			Id:       "connections-connect-data",
 			Text:     "Connect data",

--- a/public/app/features/datasources/components/DataSourcesList.test.tsx
+++ b/public/app/features/datasources/components/DataSourcesList.test.tsx
@@ -2,14 +2,11 @@ import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { Provider } from 'react-redux';
 
-import { contextSrv } from 'app/core/services/context_srv';
 import { configureStore } from 'app/store/configureStore';
 
 import { getMockDataSources } from '../__mocks__';
 
 import { DataSourcesListView } from './DataSourcesList';
-
-jest.mock('app/core/services/context_srv');
 
 const setup = () => {
   const store = configureStore();
@@ -21,16 +18,14 @@ const setup = () => {
         dataSourcesCount={3}
         isLoading={false}
         hasCreateRights={true}
+        hasWriteRights={true}
+        hasExploreRights={true}
       />
     </Provider>
   );
 };
 
 describe('<DataSourcesList>', () => {
-  beforeEach(() => {
-    (contextSrv.hasPermission as jest.Mock) = jest.fn().mockReturnValue(true);
-  });
-
   it('should render action bar', async () => {
     setup();
 
@@ -52,13 +47,5 @@ describe('<DataSourcesList>', () => {
 
     expect(await screen.findByRole('heading', { name: 'dataSource-0' })).toBeInTheDocument();
     expect(await screen.findByRole('link', { name: 'dataSource-0' })).toBeInTheDocument();
-  });
-
-  it('should not render Explore button if user has no permissions', async () => {
-    (contextSrv.hasPermission as jest.Mock) = jest.fn().mockReturnValue(false);
-    setup();
-
-    expect(await screen.findAllByRole('link', { name: 'Build a Dashboard' })).toHaveLength(3);
-    expect(screen.queryAllByRole('link', { name: 'Explore' })).toHaveLength(0);
   });
 });

--- a/public/app/features/datasources/components/DataSourcesList.tsx
+++ b/public/app/features/datasources/components/DataSourcesList.tsx
@@ -21,6 +21,8 @@ export function DataSourcesList() {
   const dataSourcesCount = useSelector(({ dataSources }: StoreState) => getDataSourcesCount(dataSources));
   const hasFetched = useSelector(({ dataSources }: StoreState) => dataSources.hasFetched);
   const hasCreateRights = contextSrv.hasPermission(AccessControlAction.DataSourcesCreate);
+  const hasWriteRights = contextSrv.hasPermission(AccessControlAction.DataSourcesWrite);
+  const hasExploreRights = contextSrv.hasPermission(AccessControlAction.DataSourcesExplore);
 
   return (
     <DataSourcesListView
@@ -28,6 +30,8 @@ export function DataSourcesList() {
       dataSourcesCount={dataSourcesCount}
       isLoading={!hasFetched}
       hasCreateRights={hasCreateRights}
+      hasWriteRights={hasWriteRights}
+      hasExploreRights={hasExploreRights}
     />
   );
 }
@@ -37,12 +41,20 @@ export type ViewProps = {
   dataSourcesCount: number;
   isLoading: boolean;
   hasCreateRights: boolean;
+  hasWriteRights: boolean;
+  hasExploreRights: boolean;
 };
 
-export function DataSourcesListView({ dataSources, dataSourcesCount, isLoading, hasCreateRights }: ViewProps) {
+export function DataSourcesListView({
+  dataSources,
+  dataSourcesCount,
+  isLoading,
+  hasCreateRights,
+  hasWriteRights,
+  hasExploreRights,
+}: ViewProps) {
   const styles = useStyles2(getStyles);
   const dataSourcesRoutes = useDataSourcesRoutes();
-  const canExploreDataSources = contextSrv.hasPermission(AccessControlAction.DataSourcesExplore);
 
   if (isLoading) {
     return <PageLoader />;
@@ -75,7 +87,7 @@ export function DataSourcesListView({ dataSources, dataSourcesCount, isLoading, 
           const dsLink = config.appSubUrl + dataSourcesRoutes.Edit.replace(/:uid/gi, dataSource.uid);
           return (
             <li key={dataSource.uid}>
-              <Card href={dsLink}>
+              <Card href={hasWriteRights ? dsLink : undefined}>
                 <Card.Heading>{dataSource.name}</Card.Heading>
                 <Card.Figure>
                   <img src={dataSource.typeLogoUrl} alt="" height="40px" width="40px" className={styles.logo} />
@@ -91,7 +103,7 @@ export function DataSourcesListView({ dataSources, dataSourcesCount, isLoading, 
                   <LinkButton icon="apps" fill="outline" variant="secondary" href={config.appSubUrl + '/dashboard/new'}>
                     Build a Dashboard
                   </LinkButton>
-                  {canExploreDataSources && (
+                  {hasExploreRights && (
                     <LinkButton
                       icon="compass"
                       fill="outline"

--- a/public/app/features/datasources/pages/DataSourcesListPage.test.tsx
+++ b/public/app/features/datasources/pages/DataSourcesListPage.test.tsx
@@ -52,15 +52,52 @@ describe('Render', () => {
     expect(await screen.findByRole('link', { name: 'Add data source' })).toBeInTheDocument();
   });
 
-  it('should disable the "Add data source" button if user has no permissions', async () => {
-    (contextSrv.hasPermission as jest.Mock) = jest.fn().mockReturnValue(false);
+  describe('when user has no permissions', () => {
+    beforeEach(() => {
+      (contextSrv.hasPermission as jest.Mock) = jest.fn().mockReturnValue(false);
+    });
+
+    it('should disable the "Add data source" button if user has no permissions', async () => {
+      setup({ isSortAscending: true });
+
+      expect(await screen.findByRole('heading', { name: 'Configuration' })).toBeInTheDocument();
+      expect(await screen.findByRole('link', { name: 'Documentation' })).toBeInTheDocument();
+      expect(await screen.findByRole('link', { name: 'Support' })).toBeInTheDocument();
+      expect(await screen.findByRole('link', { name: 'Community' })).toBeInTheDocument();
+      expect(await screen.findByRole('link', { name: 'Add data source' })).toHaveStyle('pointer-events: none');
+    });
+
+    it('should not show the Explore button', async () => {
+      getDataSourcesMock.mockResolvedValue(getMockDataSources(3));
+      setup({ isSortAscending: true });
+
+      expect(await screen.findAllByRole('link', { name: 'Build a Dashboard' })).toHaveLength(3);
+      expect(screen.queryAllByRole('link', { name: 'Explore' })).toHaveLength(0);
+    });
+
+    it('should not link cards to edit pages', async () => {
+      getDataSourcesMock.mockResolvedValue(getMockDataSources(1));
+      setup({ isSortAscending: true });
+
+      expect(await screen.findByRole('heading', { name: 'dataSource-0' })).toBeInTheDocument();
+      expect(await screen.queryByRole('link', { name: 'dataSource-0' })).toBeNull();
+    });
+  });
+
+  it('should show the Explore button', async () => {
+    getDataSourcesMock.mockResolvedValue(getMockDataSources(3));
     setup({ isSortAscending: true });
 
-    expect(await screen.findByRole('heading', { name: 'Configuration' })).toBeInTheDocument();
-    expect(await screen.findByRole('link', { name: 'Documentation' })).toBeInTheDocument();
-    expect(await screen.findByRole('link', { name: 'Support' })).toBeInTheDocument();
-    expect(await screen.findByRole('link', { name: 'Community' })).toBeInTheDocument();
-    expect(await screen.findByRole('link', { name: 'Add data source' })).toHaveStyle('pointer-events: none');
+    expect(await screen.findAllByRole('link', { name: 'Build a Dashboard' })).toHaveLength(3);
+    expect(screen.queryAllByRole('link', { name: 'Explore' })).toHaveLength(3);
+  });
+
+  it('should link cards to edit pages', async () => {
+    getDataSourcesMock.mockResolvedValue(getMockDataSources(1));
+    setup({ isSortAscending: true });
+
+    expect(await screen.findByRole('heading', { name: 'dataSource-0' })).toBeInTheDocument();
+    expect(await screen.findByRole('link', { name: 'dataSource-0' })).toBeInTheDocument();
   });
 
   it('should render action bar and datasources', async () => {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Throughout this PR I am referring to the Connections section which can be accessed when the `dataConnectionsConsole` feature toggle is turned on.

In this PR I defined required permissions for pages under the Connections section based on existing permissions for the original version of these pages (under `/datasources` and `/plugins`).

However, I changed one page's permissions: I softened the required permissions for the datasources page, because recently we show an "Explore" button on datasource cards in this page, so it makes sense to show this page for users who don't have permissions to create/delete/edit these datasources but have permission to explore them.

I also took care of not including the Connections section in the navtree if the user doesn't have permissions to view any child page.

_Note:_
This works just fine also when the cloud-onboarding plugin is present, since the plugin registers pages for Editors, and the Connections section is now included in the navtree for Editors.

[Screencast from 2022-12-23 12:21:46.webm](https://user-images.githubusercontent.com/13637610/209336404-6e01f750-8743-4e76-b334-dd812f6e9e6b.webm)

_Update after the recording:_ 
I updated the branch so that Editors cannot click on data sources cards on the data sources page. This way they won't be able to see the configuration of data sources (which they couldn't edit anyway). But they can still click on "Build a Dashboard" or "Explore".

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Closes #52592

**Special notes for your reviewer**:

