### PR TITLE
Alerting: Warn about missing contact-point in notification policy

### DIFF
--- a/public/app/features/alerting/unified/components/amroutes/AmRoutesTable.test.tsx
+++ b/public/app/features/alerting/unified/components/amroutes/AmRoutesTable.test.tsx
@@ -1,9 +1,13 @@
+import { render, screen } from '@testing-library/react';
+import { noop } from 'lodash';
+import React from 'react';
+
 import { MatcherOperator } from 'app/plugins/datasource/alertmanager/types';
 
 import { FormAmRoute } from '../../types/amroutes';
 import { MatcherFieldValue } from '../../types/silence-form';
 
-import { deleteRoute, getFilteredRoutes, updatedRoute } from './AmRoutesTable';
+import { AmRoutesTable, deleteRoute, getFilteredRoutes, updatedRoute } from './AmRoutesTable';
 
 const defaultAmRoute: FormAmRoute = {
   id: '',
@@ -188,5 +192,25 @@ describe('deleteRoute', () => {
     expect(updatedRoutes[0].id).toBe('1');
     expect(updatedRoutes[1].id).toBe('2');
     expect(updatedRoutes[2].id).toBe('3');
+  });
+
+  it('Should warn about policies with no contact point', () => {
+    const routes: FormAmRoute[] = [
+      buildAmRoute({ id: 'no-contact-point' }),
+      buildAmRoute({ id: 'with-contact-point', receiver: 'TestContactPoint' }),
+    ];
+
+    render(
+      <AmRoutesTable
+        onChange={noop}
+        onCancelAdd={noop}
+        routes={routes}
+        isAddMode={false}
+        alertManagerSourceName={'grafana'}
+        receivers={[]}
+      />
+    );
+    expect(screen.getByText('None')).toBeInTheDocument();
+    expect(screen.getByText('TestContactPoint')).toBeInTheDocument();
   });
 });

--- a/public/app/features/alerting/unified/components/amroutes/AmRoutesTable.tsx
+++ b/public/app/features/alerting/unified/components/amroutes/AmRoutesTable.tsx
@@ -1,7 +1,7 @@
 import { intersectionWith, isEqual } from 'lodash';
 import React, { FC, useCallback, useEffect, useMemo, useState } from 'react';
 
-import { Button, ConfirmModal, HorizontalGroup, IconButton } from '@grafana/ui';
+import { Badge, Button, ConfirmModal, HorizontalGroup, IconButton, Tooltip } from '@grafana/ui';
 import { contextSrv } from 'app/core/services/context_srv';
 
 import { FormAmRoute } from '../../types/amroutes';
@@ -95,6 +95,10 @@ export const AmRoutesTable: FC<AmRoutesTableProps> = ({
   const expandItem = useCallback((item: RouteTableItemProps) => setExpandedId(item.id), []);
   const collapseItem = useCallback(() => setExpandedId(undefined), []);
 
+  const missingReceiver = (route: FormAmRoute) => {
+    return Boolean(route.receiver) === false;
+  };
+
   const cols: RouteTableColumnProps[] = [
     {
       id: 'matchingCriteria',
@@ -120,12 +124,21 @@ export const AmRoutesTable: FC<AmRoutesTableProps> = ({
       label: 'Contact point',
       renderCell: (item) => {
         const type = getGrafanaAppReceiverType(receivers, item.data.receiver);
-        return item.data.receiver ? (
-          <>
-            {item.data.receiver} {type && <GrafanaAppBadge grafanaAppType={type} />}
-          </>
-        ) : (
-          '-'
+
+        if (!missingReceiver(item.data)) {
+          return (
+            <>
+              {item.data.receiver} {type && <GrafanaAppBadge grafanaAppType={type} />}
+            </>
+          );
+        }
+
+        return (
+          <Tooltip content={'No notifications will be delivered until a contact point is configured.'} placement="top">
+            <span>
+              <Badge color="orange" icon="exclamation-triangle" text="None" />
+            </span>
+          </Tooltip>
         );
       },
       size: 5,

--- a/public/app/features/alerting/unified/components/amroutes/AmRoutesTable.tsx
+++ b/public/app/features/alerting/unified/components/amroutes/AmRoutesTable.tsx
@@ -134,7 +134,10 @@ export const AmRoutesTable: FC<AmRoutesTableProps> = ({
         }
 
         return (
-          <Tooltip content={'No notifications will be delivered until a contact point is configured.'} placement="top">
+          <Tooltip
+            content={'No notifications will be delivered for this policy until a contact point is configured.'}
+            placement="top"
+          >
             <span>
               <Badge color="orange" icon="exclamation-triangle" text="None" />
             </span>


### PR DESCRIPTION
When a notification policy does not have a contact point assigned it will swallow all alert instances that match it and will never deliver any notifications for them.

This might be intentional but it might also _not_ be. In which case we've decided to show a warning indicating that no particular contact point has been assigned and might have been a mistake.

This also applies to "parent" policies that might have child policies as the parent might still be matched.

<img width="1222" alt="image" src="https://user-images.githubusercontent.com/868844/209342456-1add07cf-a00f-4fe3-981f-05b06dfec5cc.png">
