### PR TITLE
#60736, but make it anonymous

### DIFF
--- a/pkg/infra/db/sqlbuilder_test.go
+++ b/pkg/infra/db/sqlbuilder_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/dashboards"
-	dashver "github.com/grafana/grafana/pkg/services/dashboardversion"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/services/user"
@@ -362,7 +361,17 @@ func insertTestDashboard(t *testing.T, sqlStore *sqlstore.SQLStore, title string
 	dash.Data.Set("uid", dash.Uid)
 
 	err = sqlStore.WithDbSession(context.Background(), func(sess *Session) error {
-		dashVersion := &dashver.DashboardVersion{
+		dashVersion := struct {
+			ID            int64            `xorm:"pk autoincr 'id'" db:"id"`
+			DashboardID   int64            `xorm:"dashboard_id" db:"dashboard_id"`
+			ParentVersion int              `db:"parent_version"`
+			RestoredFrom  int              `db:"restored_from"`
+			Version       int              `db:"version"`
+			Created       time.Time        `db:"created"`
+			CreatedBy     int64            `db:"created_by"`
+			Message       string           `db:"message"`
+			Data          *simplejson.Json `db:"data"`
+		}{
 			DashboardID:   dash.Id,
 			ParentVersion: dash.Version,
 			RestoredFrom:  cmd.RestoredFrom,

--- a/pkg/services/alerting/store_test.go
+++ b/pkg/services/alerting/store_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/dashboards"
-	dashver "github.com/grafana/grafana/pkg/services/dashboardversion"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/tag/tagimpl"
 	"github.com/grafana/grafana/pkg/services/user"
@@ -410,7 +409,17 @@ func insertTestDashboard(t *testing.T, store db.DB, title string, orgId int64,
 	dash.Data.Set("uid", dash.Uid)
 
 	err = store.WithDbSession(context.Background(), func(sess *db.Session) error {
-		dashVersion := &dashver.DashboardVersion{
+		dashVersion := struct {
+			ID            int64            `xorm:"pk autoincr 'id'" db:"id"`
+			DashboardID   int64            `xorm:"dashboard_id" db:"dashboard_id"`
+			ParentVersion int              `db:"parent_version"`
+			RestoredFrom  int              `db:"restored_from"`
+			Version       int              `db:"version"`
+			Created       time.Time        `db:"created"`
+			CreatedBy     int64            `db:"created_by"`
+			Message       string           `db:"message"`
+			Data          *simplejson.Json `db:"data"`
+		}{
 			DashboardID:   dash.Id,
 			ParentVersion: dash.Version,
 			RestoredFrom:  cmd.RestoredFrom,

--- a/pkg/services/dashboards/database/database.go
+++ b/pkg/services/dashboards/database/database.go
@@ -8,13 +8,13 @@ import (
 
 	"xorm.io/xorm"
 
+	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/metrics"
 	"github.com/grafana/grafana/pkg/models"
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/dashboards"
-	dashver "github.com/grafana/grafana/pkg/services/dashboardversion"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/quota"
@@ -550,7 +550,17 @@ func saveDashboard(sess *db.Session, cmd *models.SaveDashboardCommand, emitEntit
 		return dashboards.ErrDashboardNotFound
 	}
 
-	dashVersion := &dashver.DashboardVersion{
+	dashVersion := struct {
+		ID            int64            `xorm:"pk autoincr 'id'" db:"id"`
+		DashboardID   int64            `xorm:"dashboard_id" db:"dashboard_id"`
+		ParentVersion int              `db:"parent_version"`
+		RestoredFrom  int              `db:"restored_from"`
+		Version       int              `db:"version"`
+		Created       time.Time        `db:"created"`
+		CreatedBy     int64            `db:"created_by"`
+		Message       string           `db:"message"`
+		Data          *simplejson.Json `db:"data"`
+	}{
 		DashboardID:   dash.Id,
 		ParentVersion: parentVersion,
 		RestoredFrom:  cmd.RestoredFrom,

--- a/pkg/services/dashboardversion/dashverimpl/dashver_test.go
+++ b/pkg/services/dashboardversion/dashverimpl/dashver_test.go
@@ -17,7 +17,7 @@ func TestDashboardVersionService(t *testing.T) {
 	dashboardVersionService := Service{store: dashboardVersionStore}
 
 	t.Run("Get dashboard version", func(t *testing.T) {
-		dashboard := &dashver.DashboardVersion{
+		dashboard := &dashboardVersion{
 			ID:   11,
 			Data: &simplejson.Json{},
 		}
@@ -60,7 +60,7 @@ func TestListDashboardVersions(t *testing.T) {
 
 	t.Run("Get all versions for a given Dashboard ID", func(t *testing.T) {
 		query := dashver.ListDashboardVersionsQuery{}
-		dashboardVersionStore.ExpectedListVersions = []*dashver.DashboardVersion{{}}
+		dashboardVersionStore.ExpectedListVersions = []*dashboardVersion{{}}
 		res, err := dashboardVersionService.List(context.Background(), &query)
 		require.Nil(t, err)
 		require.Equal(t, 1, len(res))
@@ -68,10 +68,10 @@ func TestListDashboardVersions(t *testing.T) {
 }
 
 type FakeDashboardVersionStore struct {
-	ExpectedDashboardVersion *dashver.DashboardVersion
+	ExpectedDashboardVersion *dashboardVersion
 	ExptectedDeletedVersions int64
 	ExpectedVersions         []interface{}
-	ExpectedListVersions     []*dashver.DashboardVersion
+	ExpectedListVersions     []*dashboardVersion
 	ExpectedError            error
 }
 
@@ -79,7 +79,7 @@ func newDashboardVersionStoreFake() *FakeDashboardVersionStore {
 	return &FakeDashboardVersionStore{}
 }
 
-func (f *FakeDashboardVersionStore) Get(ctx context.Context, query *dashver.GetDashboardVersionQuery) (*dashver.DashboardVersion, error) {
+func (f *FakeDashboardVersionStore) Get(ctx context.Context, query *dashver.GetDashboardVersionQuery) (*dashboardVersion, error) {
 	return f.ExpectedDashboardVersion, f.ExpectedError
 }
 
@@ -91,6 +91,6 @@ func (f *FakeDashboardVersionStore) DeleteBatch(ctx context.Context, cmd *dashve
 	return f.ExptectedDeletedVersions, f.ExpectedError
 }
 
-func (f *FakeDashboardVersionStore) List(ctx context.Context, query *dashver.ListDashboardVersionsQuery) ([]*dashver.DashboardVersion, error) {
+func (f *FakeDashboardVersionStore) List(ctx context.Context, query *dashver.ListDashboardVersionsQuery) ([]*dashboardVersion, error) {
 	return f.ExpectedListVersions, f.ExpectedError
 }

--- a/pkg/services/dashboardversion/dashverimpl/sqlx_store.go
+++ b/pkg/services/dashboardversion/dashverimpl/sqlx_store.go
@@ -14,8 +14,8 @@ type sqlxStore struct {
 	sess *session.SessionDB
 }
 
-func (ss *sqlxStore) Get(ctx context.Context, query *dashver.GetDashboardVersionQuery) (*dashver.DashboardVersion, error) {
-	var version dashver.DashboardVersion
+func (ss *sqlxStore) Get(ctx context.Context, query *dashver.GetDashboardVersionQuery) (*dashboardVersion, error) {
+	var version dashboardVersion
 	qr := `SELECT dashboard_version.* 
 	FROM dashboard_version
 	LEFT JOIN dashboard ON dashboard.id=dashboard_version.dashboard_id
@@ -59,8 +59,8 @@ func (ss *sqlxStore) DeleteBatch(ctx context.Context, cmd *dashver.DeleteExpired
 	return deleted, err
 }
 
-func (ss *sqlxStore) List(ctx context.Context, query *dashver.ListDashboardVersionsQuery) ([]*dashver.DashboardVersion, error) {
-	var dashboardVersion []*dashver.DashboardVersion
+func (ss *sqlxStore) List(ctx context.Context, query *dashver.ListDashboardVersionsQuery) ([]*dashboardVersion, error) {
+	var dashboardVersion []*dashboardVersion
 	qr := `SELECT dashboard_version.id,
 				dashboard_version.dashboard_id,
 				dashboard_version.parent_version,

--- a/pkg/services/dashboardversion/dashverimpl/store.go
+++ b/pkg/services/dashboardversion/dashverimpl/store.go
@@ -2,13 +2,46 @@ package dashverimpl
 
 import (
 	"context"
+	"time"
 
+	"github.com/grafana/grafana/pkg/components/simplejson"
 	dashver "github.com/grafana/grafana/pkg/services/dashboardversion"
 )
 
 type store interface {
-	Get(context.Context, *dashver.GetDashboardVersionQuery) (*dashver.DashboardVersion, error)
+	Get(context.Context, *dashver.GetDashboardVersionQuery) (*dashboardVersion, error)
 	GetBatch(context.Context, *dashver.DeleteExpiredVersionsCommand, int, int) ([]interface{}, error)
 	DeleteBatch(context.Context, *dashver.DeleteExpiredVersionsCommand, []interface{}) (int64, error)
-	List(context.Context, *dashver.ListDashboardVersionsQuery) ([]*dashver.DashboardVersion, error)
+	List(context.Context, *dashver.ListDashboardVersionsQuery) ([]*dashboardVersion, error)
+}
+
+// dashboardVersion represents a dashboard version in the database.
+type dashboardVersion struct {
+	ID            int64 `json:"id" xorm:"pk autoincr 'id'" db:"id"`
+	DashboardID   int64 `json:"dashboardId"  xorm:"dashboard_id" db:"dashboard_id"`
+	ParentVersion int   `json:"parentVersion" db:"parent_version"`
+	RestoredFrom  int   `json:"restoredFrom" db:"restored_from"`
+	Version       int   `json:"version" db:"version"`
+
+	Created   time.Time `json:"created" db:"created"`
+	CreatedBy int64     `json:"createdBy" db:"created_by"`
+
+	Message string           `json:"message" db:"message"`
+	Data    *simplejson.Json `json:"data" db:"data"`
+}
+
+// ToDTO converts a DashboardVersion to a DashboardVersionDTO.
+func (v *dashboardVersion) ToDTO(dashUid string) *dashver.DashboardVersionDTO {
+	return &dashver.DashboardVersionDTO{
+		ID:            v.ID,
+		DashboardID:   v.DashboardID,
+		DashboardUID:  dashUid,
+		ParentVersion: v.ParentVersion,
+		RestoredFrom:  v.RestoredFrom,
+		Version:       v.Version,
+		Created:       v.Created,
+		CreatedBy:     v.CreatedBy,
+		Message:       v.Message,
+		Data:          v.Data,
+	}
 }

--- a/pkg/services/dashboardversion/dashverimpl/store_test.go
+++ b/pkg/services/dashboardversion/dashverimpl/store_test.go
@@ -159,7 +159,7 @@ func insertTestDashboard(t *testing.T, sqlStore db.DB, title string, orgId int64
 	dash.Data.Set("uid", dash.Uid)
 
 	err = sqlStore.WithDbSession(context.Background(), func(sess *db.Session) error {
-		dashVersion := &dashver.DashboardVersion{
+		dashVersion := &dashboardVersion{
 			DashboardID:   dash.Id,
 			ParentVersion: dash.Version,
 			RestoredFrom:  cmd.RestoredFrom,
@@ -221,7 +221,7 @@ func updateTestDashboard(t *testing.T, sqlStore db.DB, dashboard *models.Dashboa
 	require.Nil(t, err)
 
 	err = sqlStore.WithDbSession(context.Background(), func(sess *db.Session) error {
-		dashVersion := &dashver.DashboardVersion{
+		dashVersion := &dashboardVersion{
 			DashboardID:   dash.Id,
 			ParentVersion: parentVersion,
 			RestoredFrom:  cmd.RestoredFrom,

--- a/pkg/services/dashboardversion/dashverimpl/xorm_store.go
+++ b/pkg/services/dashboardversion/dashverimpl/xorm_store.go
@@ -14,8 +14,8 @@ type sqlStore struct {
 	dialect migrator.Dialect
 }
 
-func (ss *sqlStore) Get(ctx context.Context, query *dashver.GetDashboardVersionQuery) (*dashver.DashboardVersion, error) {
-	var version dashver.DashboardVersion
+func (ss *sqlStore) Get(ctx context.Context, query *dashver.GetDashboardVersionQuery) (*dashboardVersion, error) {
+	var version dashboardVersion
 	err := ss.db.WithDbSession(ctx, func(sess *db.Session) error {
 		has, err := sess.Where("dashboard_version.dashboard_id=? AND dashboard_version.version=? AND dashboard.org_id=?", query.DashboardID, query.Version, query.OrgID).
 			Join("LEFT", "dashboard", `dashboard.id = dashboard_version.dashboard_id`).
@@ -71,8 +71,8 @@ func (ss *sqlStore) DeleteBatch(ctx context.Context, cmd *dashver.DeleteExpiredV
 	return deleted, err
 }
 
-func (ss *sqlStore) List(ctx context.Context, query *dashver.ListDashboardVersionsQuery) ([]*dashver.DashboardVersion, error) {
-	var dashboardVersion []*dashver.DashboardVersion
+func (ss *sqlStore) List(ctx context.Context, query *dashver.ListDashboardVersionsQuery) ([]*dashboardVersion, error) {
+	var dashboardVersion []*dashboardVersion
 	err := ss.db.WithDbSession(ctx, func(sess *db.Session) error {
 		err := sess.Table("dashboard_version").
 			Select(`dashboard_version.id,

--- a/pkg/services/dashboardversion/model.go
+++ b/pkg/services/dashboardversion/model.go
@@ -12,40 +12,6 @@ var (
 	ErrNoVersionsForDashboardID = errors.New("no dashboard versions found for the given DashboardId")
 )
 
-// DashboardVersion represents a dashboard version in the database. Ideally this
-// will be moved into dashverimpl and unexported, but there are a few test
-// fixtures that insert DashboardVersions directly into a database which must be
-// refactored first.
-type DashboardVersion struct {
-	ID            int64 `json:"id" xorm:"pk autoincr 'id'" db:"id"`
-	DashboardID   int64 `json:"dashboardId"  xorm:"dashboard_id" db:"dashboard_id"`
-	ParentVersion int   `json:"parentVersion" db:"parent_version"`
-	RestoredFrom  int   `json:"restoredFrom" db:"restored_from"`
-	Version       int   `json:"version" db:"version"`
-
-	Created   time.Time `json:"created" db:"created"`
-	CreatedBy int64     `json:"createdBy" db:"created_by"`
-
-	Message string           `json:"message" db:"message"`
-	Data    *simplejson.Json `json:"data" db:"data"`
-}
-
-// ToDTO converts a DashboardVersion to a DashboardVersionDTO.
-func (v *DashboardVersion) ToDTO(dashUid string) *DashboardVersionDTO {
-	return &DashboardVersionDTO{
-		ID:            v.ID,
-		DashboardID:   v.DashboardID,
-		DashboardUID:  dashUid,
-		ParentVersion: v.ParentVersion,
-		RestoredFrom:  v.RestoredFrom,
-		Version:       v.Version,
-		Created:       v.Created,
-		CreatedBy:     v.CreatedBy,
-		Message:       v.Message,
-		Data:          v.Data,
-	}
-}
-
 type GetDashboardVersionQuery struct {
 	DashboardID int64
 	OrgID       int64

--- a/pkg/services/sqlstore/migrations/ualert/permissions.go
+++ b/pkg/services/sqlstore/migrations/ualert/permissions.go
@@ -7,13 +7,11 @@ import (
 	"xorm.io/xorm"
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
-	"github.com/grafana/grafana/pkg/services/dashboards"
-	dashver "github.com/grafana/grafana/pkg/services/dashboardversion"
-	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
-	"github.com/grafana/grafana/pkg/util"
-
 	"github.com/grafana/grafana/pkg/infra/metrics"
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
+	"github.com/grafana/grafana/pkg/util"
 )
 
 type roleType string
@@ -122,7 +120,17 @@ func (m *folderHelper) createFolder(orgID int64, title string) (*dashboard, erro
 		return nil, err
 	}
 
-	dashVersion := &dashver.DashboardVersion{
+	dashVersion := struct {
+		ID            int64            `xorm:"pk autoincr 'id'" db:"id"`
+		DashboardID   int64            `xorm:"dashboard_id" db:"dashboard_id"`
+		ParentVersion int              `db:"parent_version"`
+		RestoredFrom  int              `db:"restored_from"`
+		Version       int              `db:"version"`
+		Created       time.Time        `db:"created"`
+		CreatedBy     int64            `db:"created_by"`
+		Message       string           `db:"message"`
+		Data          *simplejson.Json `db:"data"`
+	}{
 		DashboardID:   dash.Id,
 		ParentVersion: parentVersion,
 		RestoredFrom:  cmd.RestoredFrom,

--- a/pkg/services/thumbs/dashboardthumbsimpl/store_test.go
+++ b/pkg/services/thumbs/dashboardthumbsimpl/store_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/dashboards"
-	dashver "github.com/grafana/grafana/pkg/services/dashboardversion"
 	"github.com/grafana/grafana/pkg/services/thumbs"
 	"github.com/grafana/grafana/pkg/util"
 )
@@ -322,7 +321,17 @@ func updateTestDashboard(t *testing.T, sqlStore db.DB, dashModel *models.Dashboa
 	require.Nil(t, err)
 
 	err = sqlStore.WithDbSession(context.Background(), func(sess *db.Session) error {
-		dashVersion := &dashver.DashboardVersion{
+		dashVersion := struct {
+			ID            int64            `xorm:"pk autoincr 'id'" db:"id"`
+			DashboardID   int64            `xorm:"dashboard_id" db:"dashboard_id"`
+			ParentVersion int              `db:"parent_version"`
+			RestoredFrom  int              `db:"restored_from"`
+			Version       int              `db:"version"`
+			Created       time.Time        `db:"created"`
+			CreatedBy     int64            `db:"created_by"`
+			Message       string           `db:"message"`
+			Data          *simplejson.Json `db:"data"`
+		}{
 			DashboardID:   dash.Id,
 			ParentVersion: parentVersion,
 			RestoredFrom:  cmd.RestoredFrom,
@@ -376,7 +385,17 @@ func insertTestDashboard(t *testing.T, sqlStore db.DB, title string, orgId int64
 	dash.Data.Set("uid", dash.Uid)
 
 	err = sqlStore.WithDbSession(context.Background(), func(sess *db.Session) error {
-		dashVersion := &dashver.DashboardVersion{
+		dashVersion := struct {
+			ID            int64            `xorm:"pk autoincr 'id'" db:"id"`
+			DashboardID   int64            `xorm:"dashboard_id" db:"dashboard_id"`
+			ParentVersion int              `db:"parent_version"`
+			RestoredFrom  int              `db:"restored_from"`
+			Version       int              `db:"version"`
+			Created       time.Time        `db:"created"`
+			CreatedBy     int64            `db:"created_by"`
+			Message       string           `db:"message"`
+			Data          *simplejson.Json `db:"data"`
+		}{
 			DashboardID:   dash.Id,
 			ParentVersion: dash.Version,
 			RestoredFrom:  cmd.RestoredFrom,


### PR DESCRIPTION
We'd like to unexport the DashboardVersion, since it's the database model, but this exposed a few unexpected places where Grafana is `Insert`ing those directly into the database: the `Dashboard` service and a migration. The Dashboard service should eventually get refactored; I think the migration is Just Fine™️ but I may be too optimistic about that.   