### PR TITLE
Plugins: add UI for secure socks proxy feature toggle

### DIFF
--- a/public/app/plugins/datasource/loki/configuration/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/loki/configuration/ConfigEditor.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
 
-import { DataSourcePluginOptionsEditorProps, DataSourceSettings } from '@grafana/data';
-import { AlertingSettings, DataSourceHttpSettings } from '@grafana/ui';
+import {
+  DataSourcePluginOptionsEditorProps,
+  DataSourceSettings,
+  onUpdateDatasourceJsonDataOptionChecked,
+} from '@grafana/data';
+import { config } from '@grafana/runtime';
+import { AlertingSettings, DataSourceHttpSettings, InlineField, InlineSwitch } from '@grafana/ui';
 
 import { LokiOptions } from '../types';
 
@@ -27,6 +32,7 @@ const setDerivedFields = makeJsonUpdater('derivedFields');
 
 export const ConfigEditor = (props: Props) => {
   const { options, onOptionsChange } = props;
+  const socksProxy = config.featureToggles.secureSocksDatasourceProxy;
 
   return (
     <>
@@ -36,6 +42,25 @@ export const ConfigEditor = (props: Props) => {
         showAccessOptions={false}
         onChange={onOptionsChange}
       />
+
+      {socksProxy && (
+        <>
+          <h3 className="page-heading">Secure Socks Proxy</h3>
+          <div className="gf-form-group">
+            <div className="gf-form-inline"></div>
+            <InlineField
+              labelWidth={28}
+              label="Enabled"
+              tooltip="Connect to this datasource via the secure socks proxy."
+            >
+              <InlineSwitch
+                value={options.jsonData.enableSecureSocksProxy ?? false}
+                onChange={onUpdateDatasourceJsonDataOptionChecked(props, 'enableSecureSocksProxy')}
+              />
+            </InlineField>
+          </div>
+        </>
+      )}
 
       <AlertingSettings<LokiOptions> options={options} onOptionsChange={onOptionsChange} />
 

--- a/public/app/plugins/datasource/loki/types.ts
+++ b/public/app/plugins/datasource/loki/types.ts
@@ -56,6 +56,7 @@ export interface LokiOptions extends DataSourceJsonData {
   derivedFields?: DerivedFieldConfig[];
   alertmanager?: string;
   keepCookies?: string[];
+  enableSecureSocksProxy?: boolean;
 }
 
 export interface LokiStats {

--- a/public/app/plugins/datasource/prometheus/configuration/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/configuration/ConfigEditor.tsx
@@ -1,8 +1,12 @@
 import React, { useRef } from 'react';
 
 import { SIGV4ConnectionConfig } from '@grafana/aws-sdk';
-import { DataSourcePluginOptionsEditorProps, DataSourceSettings } from '@grafana/data';
-import { AlertingSettings, DataSourceHttpSettings, Alert } from '@grafana/ui';
+import {
+  DataSourcePluginOptionsEditorProps,
+  DataSourceSettings,
+  onUpdateDatasourceJsonDataOptionChecked,
+} from '@grafana/data';
+import { AlertingSettings, DataSourceHttpSettings, Alert, InlineField, InlineSwitch } from '@grafana/ui';
 import { config } from 'app/core/config';
 
 import { PromOptions } from '../types';
@@ -25,6 +29,8 @@ export const ConfigEditor = (props: Props) => {
     azureSettingsUI: AzureAuthSettings,
   };
 
+  const socksProxy = config.featureToggles.secureSocksDatasourceProxy;
+
   return (
     <>
       {options.access === 'direct' && (
@@ -42,6 +48,25 @@ export const ConfigEditor = (props: Props) => {
         azureAuthSettings={azureAuthSettings}
         renderSigV4Editor={<SIGV4ConnectionConfig {...props}></SIGV4ConnectionConfig>}
       />
+
+      {socksProxy && (
+        <>
+          <h3 className="page-heading">Secure Socks Proxy</h3>
+          <div className="gf-form-group">
+            <div className="gf-form-inline"></div>
+            <InlineField
+              labelWidth={28}
+              label="Enabled"
+              tooltip="Connect to this datasource via the secure socks proxy."
+            >
+              <InlineSwitch
+                value={options.jsonData.enableSecureSocksProxy ?? false}
+                onChange={onUpdateDatasourceJsonDataOptionChecked(props, 'enableSecureSocksProxy')}
+              />
+            </InlineField>
+          </div>
+        </>
+      )}
 
       <AlertingSettings<PromOptions> options={options} onOptionsChange={onOptionsChange} />
 

--- a/public/app/plugins/datasource/prometheus/types.ts
+++ b/public/app/plugins/datasource/prometheus/types.ts
@@ -34,6 +34,7 @@ export interface PromOptions extends DataSourceJsonData {
   exemplarTraceIdDestinations?: ExemplarTraceIdDestination[];
   prometheusType?: PromApplication;
   prometheusVersion?: string;
+  enableSecureSocksProxy?: boolean;
 }
 
 export type ExemplarTraceIdDestination = {


### PR DESCRIPTION
Follow up to https://github.com/grafana/grafana/pull/59254. 

This PR adds a toggle on the datasource page to enable the use of the secure socks proxy on Loki and Prometheus datasources (the first two we are looking into) if the feature `secureSocksDatasourceProxy` is enabled. The way this information is displayed will be improved upon in the future, but for now, this will allow an easier way of using the feature toggle.

Screenshot of how it looks:
![Screenshot 2022-12-23 at 1 29 35 PM](https://user-images.githubusercontent.com/14365078/209398462-78eabfc0-36ff-494a-a44b-1c3919af2b46.png)