### PR TITLE
Fix dashboard legend switch for new panels, break for old ones

### DIFF
--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -1090,13 +1090,15 @@ export class DashboardModel implements TimeModel {
     const panelsWithLegends = this.panels.filter(isPanelWithLegend);
 
     // determine if more panels are displaying legends or not
-    const onCount = panelsWithLegends.filter((panel) => panel.legend.show).length;
+    const onCount = panelsWithLegends.filter((panel) => panel.options.legend.showLegend).length;
     const offCount = panelsWithLegends.length - onCount;
     const panelLegendsOn = onCount >= offCount;
 
     for (const panel of panelsWithLegends) {
-      panel.legend.show = !panelLegendsOn;
-      panel.render();
+      const newOptions = { ...panel.options };
+      newOptions.legend.showLegend = !panelLegendsOn;
+
+      panel.updateOptions(newOptions);
     }
   }
 
@@ -1226,5 +1228,5 @@ export class DashboardModel implements TimeModel {
 }
 
 function isPanelWithLegend(panel: PanelModel): panel is PanelModel & Pick<Required<PanelModel>, 'legend'> {
-  return Boolean(panel.legend);
+  return Boolean(panel.options.legend);
 }


### PR DESCRIPTION
**What is this feature?**

This feature fixes whole dashboard legend toggle via `d` `l`. It existed for a long time, but it seems to only work for old panels (think Graph). This PR makes it work for new ones (think Timeseries).

In #52241 @alyssabull broke `p` `l` (panel level toggle) for old panels, but fixed it for new ones. I'm bringing the same change to the dashboard level toggle. I'm not sure if old panels were meant to be broken.

**Why do we need this feature?**

It exists in keyboard shortcuts, so it needs to be working.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

See also: #49005.