### PR TITLE
TimeSeries: Fix log y scale when min/max settings don't land on divisors

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/config/UPlotScaleBuilder.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotScaleBuilder.ts
@@ -116,7 +116,7 @@ export class UPlotScaleBuilder extends PlotConfigBuilder<ScaleProps, Scale> {
           minMax = uPlot.rangeNum(hardMinOnly ? hardMin : dataMin, hardMaxOnly ? hardMax : dataMax, rangeConfig);
         }
       } else if (scale.distr === 3) {
-        minMax = uPlot.rangeLog(dataMin!, dataMax!, logBase, true);
+        minMax = uPlot.rangeLog(hardMin ?? dataMin!, hardMax ?? dataMax!, logBase, true);
       }
 
       if (decimals === 0) {
@@ -154,13 +154,15 @@ export class UPlotScaleBuilder extends PlotConfigBuilder<ScaleProps, Scale> {
         }
       }
 
-      // if all we got were hard limits, treat them as static min/max
-      if (hardMinOnly) {
-        minMax[0] = hardMin!;
-      }
+      if (scale.distr === 1) {
+        // if all we got were hard limits, treat them as static min/max
+        if (hardMinOnly) {
+          minMax[0] = hardMin!;
+        }
 
-      if (hardMaxOnly) {
-        minMax[1] = hardMax!;
+        if (hardMaxOnly) {
+          minMax[1] = hardMax!;
+        }
       }
 
       // guard against invalid y ranges


### PR DESCRIPTION
Fixes https://github.com/grafana/support-escalations/issues/4707

keeping as draft until uPlot 1.6.24 is released.

<details><summary>log2-ticks.json</summary>

```json
{
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": {
          "type": "grafana",
          "uid": "-- Grafana --"
        },
        "enable": true,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "target": {
          "limit": 100,
          "matchAny": false,
          "tags": [],
          "type": "dashboard"
        },
        "type": "dashboard"
      }
    ]
  },
  "editable": true,
  "fiscalYearStartMonth": 0,
  "graphTooltip": 0,
  "id": 566,
  "links": [],
  "liveNow": false,
  "panels": [
    {
      "datasource": {
        "type": "testdata",
        "uid": "PD8C576611E62080A"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "palette-classic"
          },
          "custom": {
            "axisCenteredZero": false,
            "axisColorMode": "text",
            "axisLabel": "",
            "axisPlacement": "auto",
            "barAlignment": 0,
            "drawStyle": "line",
            "fillOpacity": 0,
            "gradientMode": "none",
            "hideFrom": {
              "legend": false,
              "tooltip": false,
              "viz": false
            },
            "lineInterpolation": "linear",
            "lineWidth": 1,
            "pointSize": 5,
            "scaleDistribution": {
              "log": 2,
              "type": "log"
            },
            "showPoints": "auto",
            "spanNulls": false,
            "stacking": {
              "group": "A",
              "mode": "none"
            },
            "thresholdsStyle": {
              "mode": "off"
            }
          },
          "decimals": 7,
          "mappings": [],
          "max": 0.5,
          "min": 0.01,
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": null
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": []
      },
      "gridPos": {
        "h": 18,
        "w": 18,
        "x": 0,
        "y": 0
      },
      "id": 2,
      "options": {
        "legend": {
          "calcs": [],
          "displayMode": "list",
          "placement": "bottom",
          "showLegend": true
        },
        "tooltip": {
          "mode": "single",
          "sort": "none"
        }
      },
      "targets": [
        {
          "datasource": {
            "type": "testdata",
            "uid": "PD8C576611E62080A"
          },
          "refId": "A",
          "scenarioId": "csv_metric_values",
          "stringInput": "0.01,1"
        }
      ],
      "title": "Panel Title",
      "type": "timeseries"
    }
  ],
  "revision": 1,
  "schemaVersion": 37,
  "style": "dark",
  "tags": [],
  "templating": {
    "list": []
  },
  "time": {
    "from": "now-6h",
    "to": "now"
  },
  "timepicker": {},
  "timezone": "",
  "title": "log2-ticks",
  "uid": "0KKWQKp4z",
  "version": 3,
  "weekStart": ""
}
```
</details>

![image](https://user-images.githubusercontent.com/43234/209620442-996a55bb-4c44-42f8-96c2-d080bdece26d.png)
