### PR TITLE
Revert "Chore: Update typescript to 4.9.3 (#60538)"

### DIFF
--- a/.yarn/sdks/integrations.yml
+++ b/.yarn/sdks/integrations.yml
@@ -2,5 +2,5 @@
 # Manual changes might be lost!
 
 integrations:
-  - vscode
   - vim
+  - vscode

--- a/.yarn/sdks/typescript/package.json
+++ b/.yarn/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript",
-  "version": "4.9.3-sdk",
+  "version": "4.8.4-sdk",
   "main": "./lib/typescript.js",
   "type": "commonjs"
 }

--- a/devenv/docker/loadtest-ts/package.json
+++ b/devenv/docker/loadtest-ts/package.json
@@ -15,7 +15,7 @@
     "babel-loader": "9.1.0",
     "shortid": "2.2.16",
     "ts-node": "10.9.1",
-    "typescript": "4.9.3",
+    "typescript": "4.8.4",
     "webpack": "5.74.0",
     "webpack-cli": "4.10.0",
     "webpack-glob-entries": "1.0.1"

--- a/package.json
+++ b/package.json
@@ -230,7 +230,7 @@
     "ts-jest": "29.0.3",
     "ts-loader": "9.3.1",
     "ts-node": "10.9.1",
-    "typescript": "4.9.3",
+    "typescript": "4.8.4",
     "wait-on": "6.0.1",
     "webpack": "5.74.0",
     "webpack-bundle-analyzer": "4.7.0",

--- a/packages/grafana-data/package.json
+++ b/packages/grafana-data/package.json
@@ -89,7 +89,7 @@
     "rollup-plugin-esbuild": "5.0.0",
     "rollup-plugin-node-externals": "^5.0.0",
     "sinon": "14.0.1",
-    "typescript": "4.9.3"
+    "typescript": "4.8.4"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0",

--- a/packages/grafana-data/src/themes/colorManipulator.ts
+++ b/packages/grafana-data/src/themes/colorManipulator.ts
@@ -32,23 +32,19 @@ export function hexToRgb(color: string) {
   color = color.slice(1);
 
   const re = new RegExp(`.{1,${color.length >= 6 ? 2 : 1}}`, 'g');
-  const result = color.match(re);
-  if (!result) {
-    return '';
-  }
-  let colors = Array.from(result);
+  let colors = color.match(re);
 
-  if (colors[0].length === 1) {
+  if (colors && colors[0].length === 1) {
     colors = colors.map((n) => n + n);
   }
 
-  const segments = colors
-    .map((n, index) => {
-      return index < 3 ? parseInt(n, 16) : Math.round((parseInt(n, 16) / 255) * 1000) / 1000;
-    })
-    .join(', ');
-
-  return `rgb${colors.length === 4 ? 'a' : ''}(${segments})`;
+  return colors
+    ? `rgb${colors.length === 4 ? 'a' : ''}(${colors
+        .map((n, index) => {
+          return index < 3 ? parseInt(n, 16) : Math.round((parseInt(n, 16) / 255) * 1000) / 1000;
+        })
+        .join(', ')})`
+    : '';
 }
 
 function intToHex(int: number) {

--- a/packages/grafana-e2e-selectors/package.json
+++ b/packages/grafana-e2e-selectors/package.json
@@ -52,6 +52,6 @@
   "dependencies": {
     "@grafana/tsconfig": "^1.2.0-rc1",
     "tslib": "2.4.1",
-    "typescript": "4.9.3"
+    "typescript": "4.8.4"
   }
 }

--- a/packages/grafana-e2e/package.json
+++ b/packages/grafana-e2e/package.json
@@ -81,7 +81,7 @@
     "tracelib": "1.0.1",
     "ts-loader": "8.4.0",
     "tslib": "2.4.1",
-    "typescript": "4.9.3",
+    "typescript": "4.8.4",
     "uuid": "9.0.0",
     "yaml": "^2.0.0"
   }

--- a/packages/grafana-runtime/package.json
+++ b/packages/grafana-runtime/package.json
@@ -74,7 +74,7 @@
     "rollup-plugin-node-externals": "^5.0.0",
     "rollup-plugin-sourcemaps": "0.6.3",
     "rollup-plugin-terser": "7.0.2",
-    "typescript": "4.9.3"
+    "typescript": "4.8.4"
   },
   "peerDependencies": {
     "react": "17.0.2",

--- a/packages/grafana-schema/package.json
+++ b/packages/grafana-schema/package.json
@@ -47,7 +47,7 @@
     "rollup-plugin-dts": "^5.0.0",
     "rollup-plugin-esbuild": "5.0.0",
     "rollup-plugin-node-externals": "^5.0.0",
-    "typescript": "4.9.3"
+    "typescript": "4.8.4"
   },
   "dependencies": {
     "tslib": "2.4.1"

--- a/packages/grafana-toolkit/package.json
+++ b/packages/grafana-toolkit/package.json
@@ -121,7 +121,7 @@
     "ts-loader": "^9.3.1",
     "ts-node": "^9.1.0",
     "tslib": "2.4.0",
-    "typescript": "4.9.3",
+    "typescript": "4.8.2",
     "webpack": "^5.72.0"
   }
 }

--- a/packages/grafana-toolkit/src/cli/tasks/plugin.utils.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/plugin.utils.ts
@@ -40,7 +40,7 @@ const checkoutBranch = async (branchName: string): Promise<Command> => {
 };
 
 const gitUrlParse = (url: string): { owner: string; name: string } => {
-  let matchResult: string[] | null = [];
+  let matchResult: RegExpMatchArray | null = [];
 
   if (url.match(/^git@github.com/)) {
     // We have an ssh style url.

--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -190,7 +190,7 @@
     "storybook-addon-turbo-build": "1.1.0",
     "storybook-dark-mode": "2.0.4",
     "style-loader": "3.3.1",
-    "typescript": "4.9.3",
+    "typescript": "4.8.4",
     "webpack": "5.74.0"
   },
   "peerDependencies": {

--- a/packages/jaeger-ui-components/package.json
+++ b/packages/jaeger-ui-components/package.json
@@ -27,7 +27,7 @@
     "@types/tinycolor2": "1.4.3",
     "enzyme": "3.11.0",
     "sinon": "14.0.1",
-    "typescript": "4.9.3"
+    "typescript": "4.8.4"
   },
   "dependencies": {
     "@emotion/css": "11.10.5",

--- a/public/app/features/variables/adhoc/AdHocVariableEditor.test.tsx
+++ b/public/app/features/variables/adhoc/AdHocVariableEditor.test.tsx
@@ -38,7 +38,12 @@ jest.mock('@grafana/runtime/src/services/dataSourceSrv', () => {
 });
 
 const props = {
-  extended: {},
+  extended: {
+    dataSources: [
+      { text: 'Prometheus', value: null }, // default datasource
+      { text: 'Loki', value: { type: 'loki-ds', uid: 'abc' } },
+    ],
+  },
   variable: adHocBuilder().withId('adhoc').withRootStateKey('key').withName('adhoc').build(),
   onPropChange: jest.fn(),
 

--- a/public/app/plugins/datasource/testdata/runStreams.ts
+++ b/public/app/plugins/datasource/testdata/runStreams.ts
@@ -188,7 +188,7 @@ export function runFetchStream(
     data.refId = target.refId;
     data.name = target.alias || 'Fetch ' + target.refId;
 
-    let reader: ReadableStreamDefaultReader<Uint8Array>;
+    let reader: ReadableStreamReader<Uint8Array>;
     const csv = new CSVReader({
       callback: {
         onHeader: (fields: Field[]) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4860,7 +4860,7 @@ __metadata:
     sinon: 14.0.1
     tinycolor2: 1.4.2
     tslib: 2.4.1
-    typescript: 4.9.3
+    typescript: 4.8.4
     uplot: 1.6.23
     xss: 1.0.14
   peerDependencies:
@@ -4884,7 +4884,7 @@ __metadata:
     rollup-plugin-esbuild: 5.0.0
     rollup-plugin-node-externals: ^5.0.0
     tslib: 2.4.1
-    typescript: 4.9.3
+    typescript: 4.8.4
   languageName: unknown
   linkType: soft
 
@@ -4923,7 +4923,7 @@ __metadata:
     tracelib: 1.0.1
     ts-loader: 8.4.0
     tslib: 2.4.1
-    typescript: 4.9.3
+    typescript: 4.8.4
     uuid: 9.0.0
     webpack: 5.74.0
     yaml: ^2.0.0
@@ -5068,7 +5068,7 @@ __metadata:
     rxjs: 7.5.7
     systemjs: 0.20.19
     tslib: 2.4.1
-    typescript: 4.9.3
+    typescript: 4.8.4
   peerDependencies:
     react: 17.0.2
     react-dom: 17.0.2
@@ -5091,7 +5091,7 @@ __metadata:
     rollup-plugin-esbuild: 5.0.0
     rollup-plugin-node-externals: ^5.0.0
     tslib: 2.4.1
-    typescript: 4.9.3
+    typescript: 4.8.4
   languageName: unknown
   linkType: soft
 
@@ -5181,7 +5181,7 @@ __metadata:
     ts-loader: ^9.3.1
     ts-node: ^9.1.0
     tslib: 2.4.0
-    typescript: 4.9.3
+    typescript: 4.8.2
     webpack: ^5.72.0
   bin:
     grafana-toolkit: ./bin/grafana-toolkit.js
@@ -5338,7 +5338,7 @@ __metadata:
     style-loader: 3.3.1
     tinycolor2: 1.4.2
     tslib: 2.4.1
-    typescript: 4.9.3
+    typescript: 4.8.4
     uplot: 1.6.23
     uuid: 9.0.0
     webpack: 5.74.0
@@ -5530,7 +5530,7 @@ __metadata:
     tinycolor2: 1.4.2
     tslib: 2.4.1
     tween-functions: ^1.2.0
-    typescript: 4.9.3
+    typescript: 4.8.4
   languageName: unknown
   linkType: soft
 
@@ -22224,7 +22224,7 @@ __metadata:
     ts-loader: 9.3.1
     ts-node: 10.9.1
     tslib: 2.4.1
-    typescript: 4.9.3
+    typescript: 4.8.4
     uplot: 1.6.23
     uuid: 9.0.0
     vendor: "link:./public/vendor"
@@ -37670,6 +37670,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typescript@npm:4.8.2":
+  version: 4.8.2
+  resolution: "typescript@npm:4.8.2"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 7f5b81d0d558c9067f952c7af52ab7f19c2e70a916817929e4a5b256c93990bf3178eccb1ac8a850bc75df35f6781b6f4cb3370ce20d8b1ded92ed462348f628
+  languageName: node
+  linkType: hard
+
 "typescript@npm:4.8.4, typescript@npm:^3 || ^4":
   version: 4.8.4
   resolution: "typescript@npm:4.8.4"
@@ -37677,16 +37687,6 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 3e4f061658e0c8f36c820802fa809e0fd812b85687a9a2f5430bc3d0368e37d1c9605c3ce9b39df9a05af2ece67b1d844f9f6ea8ff42819f13bcb80f85629af0
-  languageName: node
-  linkType: hard
-
-"typescript@npm:4.9.3":
-  version: 4.9.3
-  resolution: "typescript@npm:4.9.3"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 17b8f816050b412403e38d48eef0e893deb6be522d6dc7caf105e54a72e34daf6835c447735fd2b28b66784e72bfbf87f627abb4818a8e43d1fa8106396128dc
   languageName: node
   linkType: hard
 
@@ -37720,6 +37720,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typescript@patch:typescript@4.8.2#~builtin<compat/typescript>":
+  version: 4.8.2
+  resolution: "typescript@patch:typescript@npm%3A4.8.2#~builtin<compat/typescript>::version=4.8.2&hash=aae4e6"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 5cb0f02f414f5405f4b0e7ee1fd7fa9177b6a8783c9017b6cad85f56ce4c4f93e0e6f2ce37e863cb597d44227cd009474c9fbd85bf7a50004e5557426cb58079
+  languageName: node
+  linkType: hard
+
 "typescript@patch:typescript@4.8.4#~builtin<compat/typescript>, typescript@patch:typescript@^3 || ^4#~builtin<compat/typescript>":
   version: 4.8.4
   resolution: "typescript@patch:typescript@npm%3A4.8.4#~builtin<compat/typescript>::version=4.8.4&hash=0102e9"
@@ -37727,16 +37737,6 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 301459fc3eb3b1a38fe91bf96d98eb55da88a9cb17b4ef80b4d105d620f4d547ba776cc27b44cc2ef58b66eda23fe0a74142feb5e79a6fb99f54fc018a696afa
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@4.9.3#~builtin<compat/typescript>":
-  version: 4.9.3
-  resolution: "typescript@patch:typescript@npm%3A4.9.3#~builtin<compat/typescript>::version=4.9.3&hash=d73830"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 67ca21a387c0572f1c04936e638dde7782c5aa520c3754aadc7cc9b7c915da9ebc3e27c601bfff4ccb7d7264e82dce6d277ada82ec09dc75024349e0ef64926d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR reverts commit 51f5334748d8347707a63414e5d14a3aeeff04ee due to the issue people are facing with VSC.

Ref https://github.com/grafana/grafana/pull/60538
