### PR TITLE
chore(dashboard version service): remove user table join from store implementations

### DIFF
--- a/pkg/services/dashboardversion/dashverimpl/sqlx_store.go
+++ b/pkg/services/dashboardversion/dashverimpl/sqlx_store.go
@@ -67,9 +67,9 @@ func (ss *sqlxStore) List(ctx context.Context, query *dashver.ListDashboardVersi
 				dashboard_version.restored_from,
 				dashboard_version.version,
 				dashboard_version.created,
+				dashboard_version.created_by,
 				dashboard_version.message
 			FROM dashboard_version
-			LEFT JOIN "user" ON "user".id = dashboard_version.created_by
 			LEFT JOIN dashboard ON dashboard.id = dashboard_version.dashboard_id
 			WHERE dashboard_version.dashboard_id=? AND dashboard.org_id=?
 			ORDER BY dashboard_version.version DESC

--- a/pkg/services/dashboardversion/dashverimpl/xorm_store.go
+++ b/pkg/services/dashboardversion/dashverimpl/xorm_store.go
@@ -81,11 +81,9 @@ func (ss *sqlStore) List(ctx context.Context, query *dashver.ListDashboardVersio
 				dashboard_version.restored_from,
 				dashboard_version.version,
 				dashboard_version.created,
-				dashboard_version.created_by as created_by_id,
+				dashboard_version.created_by,
 				dashboard_version.message,
-				dashboard_version.data,`+
-				ss.dialect.Quote("user")+`.login as created_by`).
-			Join("LEFT", ss.dialect.Quote("user"), `dashboard_version.created_by = `+ss.dialect.Quote("user")+`.id`).
+				dashboard_version.data`).
 			Join("LEFT", "dashboard", `dashboard.id = dashboard_version.dashboard_id`).
 			Where("dashboard_version.dashboard_id=? AND dashboard.org_id=?", query.DashboardID, query.OrgID).
 			OrderBy("dashboard_version.version DESC").


### PR DESCRIPTION
As discussed in https://github.com/grafana/grafana/pull/60736

The dashboard table join, on the other hand, is very much load bearing and cannot be removed. We could store the orgID in the dashboard versions panel alongside the dashboardID, so we can confidently return the correct dashboardversions (dashboard ID is unique per-org, so we can't just search by that), without pulling in the dashboard table. I don't know of any downsides to that (other than the data migration it requires). Any thoughts on that? 