### PR TITLE
Runtime: Expose runRequest function

### DIFF
--- a/packages/grafana-runtime/src/index.ts
+++ b/packages/grafana-runtime/src/index.ts
@@ -28,7 +28,13 @@ export {
 export { PanelRenderer, type PanelRendererProps } from './components/PanelRenderer';
 export { PanelDataErrorView, type PanelDataErrorViewProps } from './components/PanelDataErrorView';
 export { toDataQueryError } from './utils/toDataQueryError';
-export { setQueryRunnerFactory, createQueryRunner, type QueryRunnerFactory } from './services/QueryRunner';
+export {
+  setQueryRunnerFactory,
+  createQueryRunner,
+  type QueryRunnerFactory,
+  setRunRequest,
+  getRunRequest,
+} from './services/QueryRunner';
 export { PluginPage } from './components/PluginPage';
 export type { PluginPageType, PluginPageProps } from './components/PluginPage';
 export {

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -31,6 +31,7 @@ import {
   setEchoSrv,
   setLocationSrv,
   setQueryRunnerFactory,
+  setRunRequest,
 } from '@grafana/runtime';
 import { setPanelDataErrorView } from '@grafana/runtime/src/components/PanelDataErrorView';
 import { setPanelRenderer } from '@grafana/runtime/src/components/PanelRenderer';
@@ -69,6 +70,7 @@ import { PanelRenderer } from './features/panel/components/PanelRenderer';
 import { DatasourceSrv } from './features/plugins/datasource_srv';
 import { preloadPlugins } from './features/plugins/pluginPreloader';
 import { QueryRunner } from './features/query/state/QueryRunner';
+import { runRequest } from './features/query/state/runRequest';
 import { initWindowRuntime } from './features/runtime/init';
 import { variableAdapters } from './features/variables/adapters';
 import { createAdHocVariableAdapter } from './features/variables/adhoc/adapter';
@@ -139,6 +141,9 @@ export class GrafanaApp {
 
       setQueryRunnerFactory(() => new QueryRunner());
       setVariableQueryRunner(new VariableQueryRunner());
+
+      // Provide runRequest implementation to packages, @grafana/scenes in particular
+      setRunRequest(runRequest);
 
       locationUtil.initialize({
         config,


### PR DESCRIPTION
This PR exposes [`runRequest`](https://github.com/grafana/grafana/blob/runtime-expose-request-runner/public/app/features/query/state/runRequest.ts#L0-L1) function via runtime getter. 

This change is necessary for @grafana/scenes library to be able to perform data source requests via its query runners.

