### PR TITLE
grafana/data: Move data frames processing functions from core

### DIFF
--- a/packages/grafana-data/src/dataframe/processDataFrame.ts
+++ b/packages/grafana-data/src/dataframe/processDataFrame.ts
@@ -19,6 +19,7 @@ import {
   DataFrameDTO,
   TIME_SERIES_VALUE_FIELD_NAME,
   TIME_SERIES_TIME_FIELD_NAME,
+  DataQueryResponseData,
 } from '../types/index';
 import { ArrayVector } from '../vector/ArrayVector';
 import { SortedVector } from '../vector/SortedVector';
@@ -510,3 +511,29 @@ export const getTimeField = (series: DataFrame): { timeField?: Field; timeIndex?
   }
   return {};
 };
+
+function getProcessedDataFrame(data: DataQueryResponseData): DataFrame {
+  const dataFrame = guessFieldTypes(toDataFrame(data));
+
+  if (dataFrame.fields && dataFrame.fields.length) {
+    // clear out the cached info
+    for (const field of dataFrame.fields) {
+      field.state = null;
+    }
+  }
+
+  return dataFrame;
+}
+
+/**
+ * Given data request results, will return data frames with field types set
+ *
+ * This is also used by PanelChrome for snapshot support
+ */
+export function getProcessedDataFrames(results?: DataQueryResponseData[]): DataFrame[] {
+  if (!results || !isArray(results)) {
+    return [];
+  }
+
+  return results.map((data) => getProcessedDataFrame(data));
+}

--- a/public/app/features/dashboard/utils/loadSnapshotData.ts
+++ b/public/app/features/dashboard/utils/loadSnapshotData.ts
@@ -1,8 +1,14 @@
-import { applyFieldOverrides, ArrayDataFrame, getDefaultTimeRange, LoadingState, PanelData } from '@grafana/data';
+import {
+  applyFieldOverrides,
+  ArrayDataFrame,
+  getDefaultTimeRange,
+  getProcessedDataFrames,
+  LoadingState,
+  PanelData,
+} from '@grafana/data';
 import { config } from 'app/core/config';
 
 import { SnapshotWorker } from '../../query/state/DashboardQueryRunner/SnapshotWorker';
-import { getProcessedDataFrames } from '../../query/state/runRequest';
 import { getTimeSrv } from '../services/TimeSrv';
 import { DashboardModel, PanelModel } from '../state';
 

--- a/public/app/features/variables/query/operators.ts
+++ b/public/app/features/variables/query/operators.ts
@@ -1,8 +1,14 @@
 import { from, of, OperatorFunction } from 'rxjs';
 import { map, mergeMap } from 'rxjs/operators';
 
-import { FieldType, getFieldDisplayName, isDataFrame, MetricFindValue, PanelData } from '@grafana/data';
-import { getProcessedDataFrames } from 'app/features/query/state/runRequest';
+import {
+  FieldType,
+  getFieldDisplayName,
+  getProcessedDataFrames,
+  isDataFrame,
+  MetricFindValue,
+  PanelData,
+} from '@grafana/data';
 
 import { ThunkDispatch } from '../../../types';
 import { validateVariableSelectionState } from '../state/actions';

--- a/public/app/plugins/panel/graph/specs/data_processor.test.ts
+++ b/public/app/plugins/panel/graph/specs/data_processor.test.ts
@@ -1,4 +1,4 @@
-import { getProcessedDataFrames } from 'app/features/query/state/runRequest';
+import { getProcessedDataFrames } from '@grafana/data';
 
 import { DataProcessor } from '../data_processor';
 


### PR DESCRIPTION
Moves [`getProcessedDataFrames`](https://github.com/grafana/grafana/blob/main/public/app/features/query/state/runRequest.ts#L218)  from core to @grafana/data 

This change is necessary for @grafana/scenes library.