### PR TITLE
Fix https://github.com/grafana/grafana/issues/60772 -- typo in alerting-rules-edit-mimir-loki-namespace-group

### DIFF
--- a/docs/sources/alerting/alerting-rules/edit-mimir-loki-namespace-group.md
+++ b/docs/sources/alerting/alerting-rules/edit-mimir-loki-namespace-group.md
@@ -38,7 +38,7 @@ A new namespace is created and all groups are copied into this namespace from th
 
 The rules within a group are run sequentially at a regular interval, the default interval is one (1) minute. You can modify this interval using the following instructions.
 
-1. n the Grafana menu, click the **Alerting** (bell) icon to open the Alerting page listing existing alerts.
+1. In the Grafana menu, click the **Alerting** (bell) icon to open the Alerting page listing existing alerts.
 1. Find a Grafana Mimir or Loki managed rule with the group you want to edit.
 1. Click **Edit** (pen) icon.
 1. Modify the **Rule group** and **Rule group evaluation interval** information as necessary.


### PR DESCRIPTION
Fixing typo reported in https://github.com/grafana/grafana/issues/60772