### PR TITLE
PageHeader: Move page header logo to after heading

### DIFF
--- a/public/app/core/components/PageNew/PageHeader.tsx
+++ b/public/app/core/components/PageNew/PageHeader.tsx
@@ -28,8 +28,8 @@ export function PageHeader({ navItem, renderTitle, actions, info, subTitle }: Pr
       <div className={styles.topRow}>
         <div className={styles.titleInfoContainer}>
           <div className={styles.title}>
-            {navItem.img && <img className={styles.img} src={navItem.img} alt={`logo for ${navItem.text}`} />}
             {titleElement}
+            {navItem.img && <img className={styles.img} src={navItem.img} alt={`logo for ${navItem.text}`} />}
           </div>
           {info && <PageInfo info={info} />}
         </div>
@@ -52,6 +52,7 @@ const getStyles = (theme: GrafanaTheme2) => {
     title: css({
       display: 'flex',
       flexDirection: 'row',
+      alignItems: 'center',
     }),
     actions: css({
       display: 'flex',
@@ -85,7 +86,7 @@ const getStyles = (theme: GrafanaTheme2) => {
     img: css({
       width: '32px',
       height: '32px',
-      marginRight: theme.spacing(2),
+      marginLeft: theme.spacing(2),
     }),
   };
 };

--- a/public/app/features/plugins/admin/components/GetStartedWithPlugin/GetStartedWithDataSource.tsx
+++ b/public/app/features/plugins/admin/components/GetStartedWithPlugin/GetStartedWithDataSource.tsx
@@ -28,8 +28,8 @@ export function GetStartedWithDataSource({ plugin }: Props): React.ReactElement 
   }
 
   return (
-    <Button variant="primary" onClick={onAddDataSource}>
-      Create a {plugin.name} data source
+    <Button variant="primary" onClick={onAddDataSource} icon="plus">
+      Add new data source
     </Button>
   );
 }


### PR DESCRIPTION
Moving the logo to after heading text aligns the heading with the sub title and the rest of the body text making it overall easier to scan and read the page. 

Before
![Screenshot from 2022-12-28 16-14-24](https://user-images.githubusercontent.com/10999/209837533-3492b7b0-ea68-4f88-9ff7-ccedbf50517a.png)

After:
![Screenshot from 2022-12-28 16-14-16](https://user-images.githubusercontent.com/10999/209837542-de0dec3c-c03b-4eae-95a5-78c9135fec9c.png)

![Screenshot from 2022-12-28 16-48-46](https://user-images.githubusercontent.com/10999/209837655-285d2d3b-f4ec-48d6-a210-998fcbf29632.png)

