### PR TITLE
Runtime: Expose panel plugin import utils

### DIFF
--- a/packages/grafana-runtime/src/index.ts
+++ b/packages/grafana-runtime/src/index.ts
@@ -6,7 +6,13 @@
 export * from './services';
 export * from './config';
 export * from './analytics/types';
-export { loadPluginCss, SystemJS, type PluginCssOptions } from './utils/plugin';
+export {
+  loadPluginCss,
+  SystemJS,
+  type PluginCssOptions,
+  setPluginImportUtils,
+  getPluginImportUtils,
+} from './utils/plugin';
 export { reportMetaAnalytics, reportInteraction, reportPageview, reportExperimentView } from './analytics/utils';
 export { featureEnabled } from './utils/licensing';
 export { logInfo, logDebug, logWarning, logError } from './utils/logging';

--- a/packages/grafana-runtime/src/utils/plugin.ts
+++ b/packages/grafana-runtime/src/utils/plugin.ts
@@ -1,7 +1,7 @@
 // @ts-ignore
 import System from 'systemjs/dist/system.js';
 
-import { PanelPlugin, PanelPluginMeta } from '@grafana/data';
+import { PanelPlugin } from '@grafana/data';
 
 import { config } from '../config';
 

--- a/packages/grafana-runtime/src/utils/plugin.ts
+++ b/packages/grafana-runtime/src/utils/plugin.ts
@@ -1,6 +1,8 @@
 // @ts-ignore
 import System from 'systemjs/dist/system.js';
 
+import { PanelPlugin, PanelPluginMeta } from '@grafana/data';
+
 import { config } from '../config';
 
 // @ts-ignore
@@ -31,4 +33,28 @@ export const SystemJS = System;
 export function loadPluginCss(options: PluginCssOptions): Promise<any> {
   const theme = config.bootData.user.lightTheme ? options.light : options.dark;
   return SystemJS.import(`${theme}!css`);
+}
+
+interface PluginImportUtils {
+  importPanelPlugin: (id: string) => Promise<PanelPlugin>;
+  importPanelPluginFromMeta: (meta: PanelPluginMeta) => Promise<PanelPlugin>;
+  syncGetPanelPlugin: (id: string) => PanelPlugin | undefined;
+}
+
+let pluginImportUtils: PluginImportUtils | undefined;
+
+export function setPluginImportUtils(utils: PluginImportUtils) {
+  if (pluginImportUtils) {
+    throw new Error('pluginImportUtils should only be set once, when Grafana is starting.');
+  }
+
+  pluginImportUtils = utils;
+}
+
+export function getPluginImportUtils(): PluginImportUtils {
+  if (!pluginImportUtils) {
+    throw new Error('pluginImportUtils can only be used after Grafana instance has started.');
+  }
+
+  return pluginImportUtils;
 }

--- a/packages/grafana-runtime/src/utils/plugin.ts
+++ b/packages/grafana-runtime/src/utils/plugin.ts
@@ -37,8 +37,7 @@ export function loadPluginCss(options: PluginCssOptions): Promise<any> {
 
 interface PluginImportUtils {
   importPanelPlugin: (id: string) => Promise<PanelPlugin>;
-  importPanelPluginFromMeta: (meta: PanelPluginMeta) => Promise<PanelPlugin>;
-  syncGetPanelPlugin: (id: string) => PanelPlugin | undefined;
+  getPanelPluginFromCache: (id: string) => PanelPlugin | undefined;
 }
 
 let pluginImportUtils: PluginImportUtils | undefined;

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -32,6 +32,7 @@ import {
   setLocationSrv,
   setQueryRunnerFactory,
   setRunRequest,
+  setPluginImportUtils,
 } from '@grafana/runtime';
 import { setPanelDataErrorView } from '@grafana/runtime/src/components/PanelDataErrorView';
 import { setPanelRenderer } from '@grafana/runtime/src/components/PanelRenderer';
@@ -68,6 +69,7 @@ import { getTimeSrv } from './features/dashboard/services/TimeSrv';
 import { PanelDataErrorView } from './features/panel/components/PanelDataErrorView';
 import { PanelRenderer } from './features/panel/components/PanelRenderer';
 import { DatasourceSrv } from './features/plugins/datasource_srv';
+import { importPanelPlugin, importPanelPluginFromMeta, syncGetPanelPlugin } from './features/plugins/importPanelPlugin';
 import { preloadPlugins } from './features/plugins/pluginPreloader';
 import { QueryRunner } from './features/query/state/QueryRunner';
 import { runRequest } from './features/query/state/runRequest';
@@ -144,6 +146,13 @@ export class GrafanaApp {
 
       // Provide runRequest implementation to packages, @grafana/scenes in particular
       setRunRequest(runRequest);
+
+      // Privide plugin import utils to packages, @grafana/scenes in particular
+      setPluginImportUtils({
+        importPanelPlugin,
+        importPanelPluginFromMeta,
+        syncGetPanelPlugin,
+      });
 
       locationUtil.initialize({
         config,

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -69,7 +69,7 @@ import { getTimeSrv } from './features/dashboard/services/TimeSrv';
 import { PanelDataErrorView } from './features/panel/components/PanelDataErrorView';
 import { PanelRenderer } from './features/panel/components/PanelRenderer';
 import { DatasourceSrv } from './features/plugins/datasource_srv';
-import { importPanelPlugin, importPanelPluginFromMeta, syncGetPanelPlugin } from './features/plugins/importPanelPlugin';
+import { importPanelPlugin, syncGetPanelPlugin } from './features/plugins/importPanelPlugin';
 import { preloadPlugins } from './features/plugins/pluginPreloader';
 import { QueryRunner } from './features/query/state/QueryRunner';
 import { runRequest } from './features/query/state/runRequest';
@@ -150,8 +150,7 @@ export class GrafanaApp {
       // Privide plugin import utils to packages, @grafana/scenes in particular
       setPluginImportUtils({
         importPanelPlugin,
-        importPanelPluginFromMeta,
-        syncGetPanelPlugin,
+        getPanelPluginFromCache: syncGetPanelPlugin,
       });
 
       locationUtil.initialize({


### PR DESCRIPTION
This PR exposes [plugin import utils](https://github.com/grafana/grafana/blob/runtime-expose-plugin-import-utils/public/app/features/plugins/importPanelPlugin.ts#L10-L11) function via runtime getter.

This change is necessary for @grafana/scenes library to be able to perform panel plugin loading via VizPanel scene object.
