### PR TITLE
Documentation: Update prometheus getting started doc

### DIFF
--- a/docs/sources/getting-started/get-started-grafana-prometheus.md
+++ b/docs/sources/getting-started/get-started-grafana-prometheus.md
@@ -29,7 +29,7 @@ Install node_exporter on all hosts you want to monitor. This guide shows you how
 
 Prometheus node_exporter is a widely used tool that exposes system metrics. For instructions on installing node_exporter, refer to the [Installing and running the node_exporter](https://prometheus.io/docs/guides/node-exporter/#installing-and-running-the-node-exporter) section in the Prometheus documentation.
 
-When running node_exporter locally, you can check that it is exporting metrics by navigating to `http://localhost:9100/metrics`.
+When you run node_exporter locally, navigate to `http://localhost:9100/metrics` to check that it is exporting metrics.
 
 > **Note**: The instructions in the referenced topic are intended for Linux users. You may have to alter the instructions slightly depending on your operating system. For example, if you are on Windows, use the [windows_exporter](https://github.com/prometheus-community/windows_exporter) instead.
 

--- a/docs/sources/getting-started/get-started-grafana-prometheus.md
+++ b/docs/sources/getting-started/get-started-grafana-prometheus.md
@@ -35,10 +35,10 @@ When running node_exporter locally, you can check that it is exporting metrics b
 
 1. After downloading Prometheus [here](https://prometheus.io/download/#prometheus), extract it and navigate to the directory.
 
-```
-tar xvfz prometheus-*.tar.gz
-cd prometheus-*
-```
+   ```
+   tar xvfz prometheus-*.tar.gz
+   cd prometheus-*
+   ```
 
 1. Locate the `prometheus.yml` file in the directory.
 

--- a/docs/sources/getting-started/get-started-grafana-prometheus.md
+++ b/docs/sources/getting-started/get-started-grafana-prometheus.md
@@ -25,7 +25,9 @@ Like Grafana, you can install Prometheus on many different operating systems. Re
 
 #### 2. Install Prometheus node_exporter
 
-Install node_exporter on all hosts you want to monitor. In this guide we will assume you are installing it locally. Prometheus node_exporter is a widely used tool that exposes system metrics. For instructions on how to install node_exporter, refer to the [Installing and running the node_exporter](https://prometheus.io/docs/guides/node-exporter/#installing-and-running-the-node-exporter) section in Prometheus documentation.
+Install node_exporter on all hosts you want to monitor. This guide shows you how to install it locally. 
+
+Prometheus node_exporter is a widely used tool that exposes system metrics. For instructions on installing node_exporter, refer to the [Installing and running the node_exporter](https://prometheus.io/docs/guides/node-exporter/#installing-and-running-the-node-exporter) section in the Prometheus documentation.
 
 When running node_exporter locally, you can check that it is exporting metrics by navigating to `http://localhost:9100/metrics`.
 

--- a/docs/sources/getting-started/get-started-grafana-prometheus.md
+++ b/docs/sources/getting-started/get-started-grafana-prometheus.md
@@ -14,7 +14,16 @@ Prometheus is an open source monitoring system for which Grafana provides out-of
 
 {{< docs/shared "getting-started/first-step.md" >}}
 
-#### 1. Download Prometheus and node_exporter
+_Grafana and Prometheus_:
+
+1. Download Prometheus and node_exporter
+1. Install Prometheus node_exporter
+1. Install and configure Prometheus
+1. Configure Prometheus for Grafana
+1. Check Prometheus metrics in Grafana Explore view
+1. Start building dashboards
+
+#### Download Prometheus and node_exporter
 
 Download the following components:
 
@@ -23,7 +32,7 @@ Download the following components:
 
 Like Grafana, you can install Prometheus on many different operating systems. Refer to the [Prometheus download page](https://prometheus.io/download/) to see a list of stable versions of Prometheus components.
 
-#### 2. Install Prometheus node_exporter
+#### Install Prometheus node_exporter
 
 Install node_exporter on all hosts you want to monitor. This guide shows you how to install it locally.
 
@@ -33,7 +42,7 @@ When you run node_exporter locally, navigate to `http://localhost:9100/metrics` 
 
 > **Note**: The instructions in the referenced topic are intended for Linux users. You may have to alter the instructions slightly depending on your operating system. For example, if you are on Windows, use the [windows_exporter](https://github.com/prometheus-community/windows_exporter) instead.
 
-#### 3. Install and configure Prometheus
+#### Install and configure Prometheus
 
 1. After [downloading Prometheus](https://prometheus.io/download/#prometheus), extract it and navigate to the directory.
 
@@ -73,7 +82,7 @@ The following example shows you the code you should add. Notice that static conf
 
 You can see that the node_exporter metrics have been delivered to Prometheus. Next, the metrics will be sent to Grafana.
 
-#### 4. Configure Prometheus for Grafana
+#### Configure Prometheus for Grafana
 
 When running Prometheus locally, there are two ways to configure Prometheus for Grafana. You can use a hosted Grafana instance at [Grafana Cloud](https://grafana.com/) or run Grafana locally.
 
@@ -97,7 +106,7 @@ remote_write:
 
 > **Note**: To configure your Prometheus instance to work with Grafana locally instead of Grafana Cloud, install Grafana [here](https://grafana.com/grafana/download) and follow the configuration steps listed [here](https://grafana.com/docs/grafana/latest/datasources/prometheus/#configure-the-data-source).
 
-#### 5. Check Prometheus metrics in Grafana Explore view
+#### Check Prometheus metrics in Grafana Explore view
 
 In your Grafana instance, go to the [Explore]({{< relref "../explore/" >}}) view and build queries to experiment with the metrics you want to monitor. Here you can also debug issues related to collecting metrics from Prometheus. Pay special attention to the [Prometheus-specific features]({{< relref "../explore/#prometheus-specific-features" >}}) to avail custom querying experience for Prometheus.
 

--- a/docs/sources/getting-started/get-started-grafana-prometheus.md
+++ b/docs/sources/getting-started/get-started-grafana-prometheus.md
@@ -14,24 +14,35 @@ Prometheus is an open source monitoring system for which Grafana provides out-of
 
 {{< docs/shared "getting-started/first-step.md" >}}
 
-#### Download Prometheus and node_exporter
+#### 1. Download Prometheus and node_exporter
 
-Prometheus, like Grafana, can be installed on many different operating systems. Refer to the [Prometheus download page](https://prometheus.io/download/), which lists all stable versions of Prometheus components. Download the following components:
+Download the following components:
 
 - [Prometheus](https://prometheus.io/download/#prometheus)
 - [node_exporter](https://prometheus.io/download/#node_exporter)
 
-#### Install Prometheus node_exporter
+Prometheus, like Grafana, can be installed on many different operating systems. Refer to the [Prometheus download page](https://prometheus.io/download/), which lists all stable versions of Prometheus components.
 
-Prometheus node_exporter is a widely used tool that exposes system metrics. Install node_exporter on all hosts you want to monitor. For instructions on how to install node_exporter, refer to the [Installing and running the node_exporter](https://prometheus.io/docs/guides/node-exporter/#installing-and-running-the-node-exporter) section in Prometheus documentation.
+#### 2. Install Prometheus node_exporter
+
+Install node_exporter on all hosts you want to monitor. In this guide we will assume you are installing it locally. Prometheus node_exporter is a widely used tool that exposes system metrics. For instructions on how to install node_exporter, refer to the [Installing and running the node_exporter](https://prometheus.io/docs/guides/node-exporter/#installing-and-running-the-node-exporter) section in Prometheus documentation.
+
+When running node_exporter locally, you can check that it is exporting metrics by navigating to `http://localhost:9100/metrics`.
 
 > **Note**: The instructions in the referenced topic are intended for Linux users. You may have to alter the instructions slightly depending on your operating system. For example, if you are on Windows, use the [windows_exporter](https://github.com/prometheus-community/windows_exporter) instead.
 
-#### Install and configure Prometheus
+#### 3. Install and configure Prometheus
 
-1. Install Prometheus following instructions in the [Installation](https://prometheus.io/docs/prometheus/latest/installation/) topic in the Prometheus documentation.
+1. After downloading Prometheus [here](https://prometheus.io/download/#prometheus), extract it and navigate to the directory.
 
-1. Configure Prometheus to monitor the hosts where you installed node_exporter. In order to do this, modify Prometheus's configuration file. By default, Prometheus looks for the file `prometheus.yml` in the current working directory. This behavior can be changed via the `--config.file` command line flag. For example, some Prometheus installers use it to set the configuration file to `/etc/prometheus/prometheus.yml`. Here is an example of the code you will need to add.
+```
+tar xvfz prometheus-*.tar.gz
+cd prometheus-*
+```
+
+1. Locate the `prometheus.yml` file in the directory.
+
+1. Configure Prometheus to monitor the hosts where you installed node_exporter. In order to do this, modify Prometheus's configuration file. By default, Prometheus looks for the file `prometheus.yml` in the current working directory. This behavior can be changed via the `--config.file` command line flag. For example, some Prometheus installers use it to set the configuration file to `/etc/prometheus/prometheus.yml`. Here is an example of the code you will need to add. Notice that static configs targets are set to `['localhost:9100']` to target node-explorer when running it locally.
 
    ```
     # A scrape configuration containing exactly one endpoint to scrape from node_exporter running on a host:
@@ -43,17 +54,46 @@ Prometheus node_exporter is a widely used tool that exposes system metrics. Inst
         # scheme defaults to 'http'.
 
           static_configs:
-          - targets: ['<hostname>:9100']
+          - targets: ['localhost:9100']
    ```
 
 1. Start the Prometheus service:
+
    ```
     ./prometheus --config.file=./prometheus.yml
    ```
 
-#### Check Prometheus metrics in Grafana Explore view
+1. Confirm that Prometheus is running by navigating to `http://localhost:9090`. You can see that the node_exporter metrics have been delivered to Prometheus. Next we will send them to Grafana.
+
+#### 4. Configure Prometheus for Grafana
+
+When running Prometheus locally, there are two ways to configure Prometheus for Grafana. You may use a hosted Grafana instance at [Grafana Cloud](https://grafana.com/) or run Grafana locally. This guide will describe configuring Prometheus in a hosted Grafana instance on Grafana Cloud.
+
+1. Sign up for [https://grafana.com/](https://grafana.com/auth/sign-up/create-user). Grafana gives you a Prometheus instance out of the box.
+
+SHOW PICTURE HERE
+
+1. Because you are running your own Prometheus instance locally, you must `remote_write` your metrics to the Grafana.com Prometheus instance. Grafana provides code to add to your `prometheus.yml` config file. This includes a remote write endpoint, your user name and password.
+
+SHOW PICTURE HERE
+
+Add the following code to your prometheus.yml file to begin sending metrics to your hosted Grafana instance.
+
+```
+remote_write:
+- url: <https://your-remote-write-endpoint>
+  basic_auth:
+    username: <your user name>
+    password: <Your Grafana.com API Key>
+```
+
+> **Note**: To configure your Prometheus instance to work with Grafana locally instead of Grafana Cloud, install Grafana [here](https://grafana.com/grafana/download) and follow the configuration steps listed [here](https://grafana.com/docs/grafana/latest/datasources/prometheus/#configure-the-data-source).
+
+#### 5. Check Prometheus metrics in Grafana Explore view
 
 In your Grafana instance, go to the [Explore]({{< relref "../explore/" >}}) view and build queries to experiment with the metrics you want to monitor. Here you can also debug issues related to collecting metrics from Prometheus. Pay special attention to the [Prometheus-specific features]({{< relref "../explore/#prometheus-specific-features" >}}) to avail custom querying experience for Prometheus.
+
+SHOW PICTURE HERE, give example of query
 
 #### Start building dashboards
 

--- a/docs/sources/getting-started/get-started-grafana-prometheus.md
+++ b/docs/sources/getting-started/get-started-grafana-prometheus.md
@@ -69,7 +69,9 @@ The following example shows you the code you should add. Notice that static conf
     ./prometheus --config.file=./prometheus.yml
    ```
 
-1. Confirm that Prometheus is running by navigating to `http://localhost:9090`. You can see that the node_exporter metrics have been delivered to Prometheus. Next we will send them to Grafana.
+1. Confirm that Prometheus is running by navigating to `http://localhost:9090`. 
+
+You can see that the node_exporter metrics have been delivered to Prometheus. Next, the metrics will be sent to Grafana.
 
 #### 4. Configure Prometheus for Grafana
 

--- a/docs/sources/getting-started/get-started-grafana-prometheus.md
+++ b/docs/sources/getting-started/get-started-grafana-prometheus.md
@@ -75,7 +75,9 @@ You can see that the node_exporter metrics have been delivered to Prometheus. Ne
 
 #### 4. Configure Prometheus for Grafana
 
-When running Prometheus locally, there are two ways to configure Prometheus for Grafana. You may use a hosted Grafana instance at [Grafana Cloud](https://grafana.com/) or run Grafana locally. This guide will describe configuring Prometheus in a hosted Grafana instance on Grafana Cloud.
+When running Prometheus locally, there are two ways to configure Prometheus for Grafana. You can use a hosted Grafana instance at [Grafana Cloud](https://grafana.com/) or run Grafana locally. 
+
+This guide describes configuring Prometheus in a hosted Grafana instance on Grafana Cloud.
 
 1. Sign up for [https://grafana.com/](https://grafana.com/auth/sign-up/create-user). Grafana gives you a Prometheus instance out of the box.
 

--- a/docs/sources/getting-started/get-started-grafana-prometheus.md
+++ b/docs/sources/getting-started/get-started-grafana-prometheus.md
@@ -90,7 +90,7 @@ This guide describes configuring Prometheus in a hosted Grafana instance on Graf
 
 1. Sign up for [https://grafana.com/](https://grafana.com/auth/sign-up/create-user). Grafana gives you a Prometheus instance out of the box.
 
-![Prometheus dashboards](/static/img/docs/getting-started/screenshot-grafana-prometheus-details.png)
+![Prometheus details in Grafana.com](/static/img/docs/getting-started/screenshot-grafana-prometheus-details.png)
 
 1. Because you are running your own Prometheus instance locally, you must `remote_write` your metrics to the Grafana.com Prometheus instance. Grafana provides code to add to your `prometheus.yml` config file. This includes a remote write endpoint, your user name and password.
 

--- a/docs/sources/getting-started/get-started-grafana-prometheus.md
+++ b/docs/sources/getting-started/get-started-grafana-prometheus.md
@@ -25,7 +25,7 @@ Like Grafana, you can install Prometheus on many different operating systems. Re
 
 #### 2. Install Prometheus node_exporter
 
-Install node_exporter on all hosts you want to monitor. This guide shows you how to install it locally. 
+Install node_exporter on all hosts you want to monitor. This guide shows you how to install it locally.
 
 Prometheus node_exporter is a widely used tool that exposes system metrics. For instructions on installing node_exporter, refer to the [Installing and running the node_exporter](https://prometheus.io/docs/guides/node-exporter/#installing-and-running-the-node-exporter) section in the Prometheus documentation.
 
@@ -44,24 +44,24 @@ When you run node_exporter locally, navigate to `http://localhost:9100/metrics` 
 
 1. Locate the `prometheus.yml` file in the directory.
 
-1. Modify Prometheus's configuration file to monitor the hosts where you installed node_exporter. 
+1. Modify Prometheus's configuration file to monitor the hosts where you installed node_exporter.
 
-By default, Prometheus looks for the file `prometheus.yml` in the current working directory. This behavior can be changed via the `--config.file` command line flag. For example, some Prometheus installers use it to set the configuration file to `/etc/prometheus/prometheus.yml`. 
+By default, Prometheus looks for the file `prometheus.yml` in the current working directory. This behavior can be changed via the `--config.file` command line flag. For example, some Prometheus installers use it to set the configuration file to `/etc/prometheus/prometheus.yml`.
 
 The following example shows you the code you should add. Notice that static configs targets are set to `['localhost:9100']` to target node-explorer when running it locally.
 
-   ```
-    # A scrape configuration containing exactly one endpoint to scrape from node_exporter running on a host:
-    scrape_configs:
-        # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
-        - job_name: 'node'
+```
+ # A scrape configuration containing exactly one endpoint to scrape from node_exporter running on a host:
+ scrape_configs:
+     # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
+     - job_name: 'node'
 
-        # metrics_path defaults to '/metrics'
-        # scheme defaults to 'http'.
+     # metrics_path defaults to '/metrics'
+     # scheme defaults to 'http'.
 
-          static_configs:
-          - targets: ['localhost:9100']
-   ```
+       static_configs:
+       - targets: ['localhost:9100']
+```
 
 1. Start the Prometheus service:
 
@@ -69,23 +69,21 @@ The following example shows you the code you should add. Notice that static conf
     ./prometheus --config.file=./prometheus.yml
    ```
 
-1. Confirm that Prometheus is running by navigating to `http://localhost:9090`. 
+1. Confirm that Prometheus is running by navigating to `http://localhost:9090`.
 
 You can see that the node_exporter metrics have been delivered to Prometheus. Next, the metrics will be sent to Grafana.
 
 #### 4. Configure Prometheus for Grafana
 
-When running Prometheus locally, there are two ways to configure Prometheus for Grafana. You can use a hosted Grafana instance at [Grafana Cloud](https://grafana.com/) or run Grafana locally. 
+When running Prometheus locally, there are two ways to configure Prometheus for Grafana. You can use a hosted Grafana instance at [Grafana Cloud](https://grafana.com/) or run Grafana locally.
 
 This guide describes configuring Prometheus in a hosted Grafana instance on Grafana Cloud.
 
 1. Sign up for [https://grafana.com/](https://grafana.com/auth/sign-up/create-user). Grafana gives you a Prometheus instance out of the box.
 
-SHOW PICTURE HERE
+![Prometheus dashboards](/static/img/docs/getting-started/screenshot-grafana-prometheus-details.png)
 
 1. Because you are running your own Prometheus instance locally, you must `remote_write` your metrics to the Grafana.com Prometheus instance. Grafana provides code to add to your `prometheus.yml` config file. This includes a remote write endpoint, your user name and password.
-
-SHOW PICTURE HERE
 
 Add the following code to your prometheus.yml file to begin sending metrics to your hosted Grafana instance.
 
@@ -102,8 +100,6 @@ remote_write:
 #### 5. Check Prometheus metrics in Grafana Explore view
 
 In your Grafana instance, go to the [Explore]({{< relref "../explore/" >}}) view and build queries to experiment with the metrics you want to monitor. Here you can also debug issues related to collecting metrics from Prometheus. Pay special attention to the [Prometheus-specific features]({{< relref "../explore/#prometheus-specific-features" >}}) to avail custom querying experience for Prometheus.
-
-SHOW PICTURE HERE, give example of query
 
 #### Start building dashboards
 

--- a/docs/sources/getting-started/get-started-grafana-prometheus.md
+++ b/docs/sources/getting-started/get-started-grafana-prometheus.md
@@ -44,7 +44,11 @@ When you run node_exporter locally, navigate to `http://localhost:9100/metrics` 
 
 1. Locate the `prometheus.yml` file in the directory.
 
-1. Configure Prometheus to monitor the hosts where you installed node_exporter. In order to do this, modify Prometheus's configuration file. By default, Prometheus looks for the file `prometheus.yml` in the current working directory. This behavior can be changed via the `--config.file` command line flag. For example, some Prometheus installers use it to set the configuration file to `/etc/prometheus/prometheus.yml`. Here is an example of the code you will need to add. Notice that static configs targets are set to `['localhost:9100']` to target node-explorer when running it locally.
+1. Modify Prometheus's configuration file to monitor the hosts where you installed node_exporter. 
+
+By default, Prometheus looks for the file `prometheus.yml` in the current working directory. This behavior can be changed via the `--config.file` command line flag. For example, some Prometheus installers use it to set the configuration file to `/etc/prometheus/prometheus.yml`. 
+
+The following example shows you the code you should add. Notice that static configs targets are set to `['localhost:9100']` to target node-explorer when running it locally.
 
    ```
     # A scrape configuration containing exactly one endpoint to scrape from node_exporter running on a host:

--- a/docs/sources/getting-started/get-started-grafana-prometheus.md
+++ b/docs/sources/getting-started/get-started-grafana-prometheus.md
@@ -21,7 +21,7 @@ Download the following components:
 - [Prometheus](https://prometheus.io/download/#prometheus)
 - [node_exporter](https://prometheus.io/download/#node_exporter)
 
-Prometheus, like Grafana, can be installed on many different operating systems. Refer to the [Prometheus download page](https://prometheus.io/download/), which lists all stable versions of Prometheus components.
+Like Grafana, you can install Prometheus on many different operating systems. Refer to the [Prometheus download page](https://prometheus.io/download/) to see a list of stable versions of Prometheus components.
 
 #### 2. Install Prometheus node_exporter
 

--- a/docs/sources/getting-started/get-started-grafana-prometheus.md
+++ b/docs/sources/getting-started/get-started-grafana-prometheus.md
@@ -35,7 +35,7 @@ When you run node_exporter locally, navigate to `http://localhost:9100/metrics` 
 
 #### 3. Install and configure Prometheus
 
-1. After downloading Prometheus [here](https://prometheus.io/download/#prometheus), extract it and navigate to the directory.
+1. After [downloading Prometheus](https://prometheus.io/download/#prometheus), extract it and navigate to the directory.
 
    ```
    tar xvfz prometheus-*.tar.gz


### PR DESCRIPTION
[Part of G10 Getting started with Prometheus](https://github.com/grafana/grafana/issues/57754)

Fixes https://github.com/grafana/grafana/issues/60599

### What is this: 

[This](https://grafana.com/docs/grafana/latest/getting-started/get-started-grafana-prometheus/) docs page assists a user with starting a Prometheus instance but it is missing key data to connect Prometheus with Grafana. This draft updates the tutorial to send metrics to Grafana Cloud.

This draft also needs images, so I need to find where we can store those to reference them in the md file.

### Who is this for? 

New users of Prometheus and Grafana

### Why?

Using the Prometheus installation guide asks the user to create a Prometheus instance that is running locally. The docs do not reflect this in the configuration set up. If a user creates a local Prom instance they must do either of the following:
  - run Grafana locally and and configure Prom themselves
  - Use an Prom instance on Grafana.com and remote_write metrics to that instance
This information is not provided clearly in the tutorial and these two workflows are very different for a new user. 
