### PR TITLE
Time Series Panel: Fix legend text selection in Firefox

### DIFF
--- a/packages/grafana-ui/src/components/VizLegend/VizLegendListItem.tsx
+++ b/packages/grafana-ui/src/components/VizLegend/VizLegendListItem.tsx
@@ -99,6 +99,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     border: none;
     font-size: inherit;
     padding: 0;
+    user-select: text;
   `,
   itemDisabled: css`
     label: LegendLabelDisabled;


### PR DESCRIPTION
**What is this feature?**

Adds `user-select` CSS property to buttons in the legend to allow text to be selectable. This is an undefined behavior in the spec so there's different default behavior across browsers.

**Which issue(s) does this PR fix?**:

Fixes #60715

