### PR TITLE
Table: Improve data link text style

### DIFF
--- a/packages/grafana-ui/src/components/Table/DefaultCell.tsx
+++ b/packages/grafana-ui/src/components/Table/DefaultCell.tsx
@@ -27,7 +27,6 @@ export const DefaultCell: FC<TableCellProps> = (props) => {
   const showFilters = field.config.filterable;
   const showActions = (showFilters && cell.value !== undefined) || inspectEnabled;
   const cellStyle = getCellStyle(tableStyles, field, displayValue, inspectEnabled);
-
   const hasLinks = Boolean(getCellLinks(field, row)?.length);
 
   return (
@@ -38,7 +37,7 @@ export const DefaultCell: FC<TableCellProps> = (props) => {
         <DataLinksContextMenu links={() => getCellLinks(field, row) || []}>
           {(api) => {
             return (
-              <div onClick={api.openMenu} className={cx(tableStyles.cellLink, api.targetClassName)}>
+              <div onClick={api.openMenu} className={getLinkStyle(tableStyles, field, api.targetClassName)}>
                 {value}
               </div>
             );
@@ -84,4 +83,12 @@ function getCellStyle(
   }
 
   return disableOverflowOnHover ? tableStyles.cellContainerNoOverflow : tableStyles.cellContainer;
+}
+
+function getLinkStyle(tableStyles: TableStyles, field: Field, targetClassName: string | undefined) {
+  if (field.config.custom?.displayMode === TableCellDisplayMode.Auto) {
+    return cx(tableStyles.cellLink, targetClassName);
+  }
+
+  return cx(tableStyles.cellLinkForColoredCell, targetClassName);
 }

--- a/packages/grafana-ui/src/components/Table/styles.ts
+++ b/packages/grafana-ui/src/components/Table/styles.ts
@@ -16,6 +16,7 @@ export const getTableStyles = (theme: GrafanaTheme2) => {
     const cellActionsOverflow: CSSObject = {
       margin: theme.spacing(0, -0.5, 0, 0.5),
     };
+
     const cellActionsNoOverflow: CSSObject = {
       position: 'absolute',
       top: 0,
@@ -168,6 +169,19 @@ export const getTableStyles = (theme: GrafanaTheme2) => {
       text-overflow: ellipsis;
       user-select: text;
       white-space: nowrap;
+      color: ${theme.colors.text.link};
+      font-weight: ${theme.typography.fontWeightMedium};
+      &:hover {
+        text-decoration: underline;
+      }
+    `,
+    cellLinkForColoredCell: css`
+      cursor: pointer;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      user-select: text;
+      white-space: nowrap;
+      font-weight: ${theme.typography.fontWeightMedium};
       text-decoration: underline;
     `,
     imageCellLink: css`


### PR DESCRIPTION
While working on the the scene app demo I was not happy with the table with links look

Before: 
![Screenshot from 2022-12-29 10-16-40](https://user-images.githubusercontent.com/10999/209930273-248cc549-dfc4-466d-ab9c-7bac61b8bd0c.png)

I think data links would be nicer if they where shown with medium bold link color: (with hover underline effect) 
![Screenshot from 2022-12-29 10-20-32](https://user-images.githubusercontent.com/10999/209930780-d3adeb3f-a308-4f6c-b871-7f2b09800803.png)


Links in colored cells remain the same (text-decoration underline)

The larger background for this change is to make drilldown (data links) more prominent, easy to read and identify on a large dashboard. 