### PR TITLE
Codegen: Fix mudball gen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ gen-cue: ## Do all CUE/Thema code generation
 	@echo "generate code from .cue files"
 	go generate ./pkg/plugins/plugindef
 	go generate ./kinds/gen.go
-	go generate ./pkg/framework/coremodel
+	go generate ./pkg/framework/coremodel/gen.go
 	go generate ./public/app/plugins/gen.go
 	go generate ./pkg/kindsys/report.go
 

--- a/pkg/framework/coremodel/gen.go
+++ b/pkg/framework/coremodel/gen.go
@@ -2,6 +2,8 @@
 //go:build ignore
 // +build ignore
 
+//go:generate go run gen.go
+
 package main
 
 import (
@@ -40,6 +42,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "coremodel code generator does not currently accept any arguments\n, got %q", os.Args)
 		os.Exit(1)
 	}
+
 	wd := gcgen.NewWriteDiffer()
 
 	// TODO generating these is here temporarily until we make a more permanent home

--- a/pkg/framework/coremodel/gen.go
+++ b/pkg/framework/coremodel/gen.go
@@ -1,4 +1,3 @@
-// go:build ignore
 //go:build ignore
 // +build ignore
 


### PR DESCRIPTION
**What is this feature?**

Tweak _mudball_ code generation to:

- Specify the specific go generate entrypoint in the `gen-cue` Makefile job
- Add the `//go:generate` directive to the generation entrypoint mentioned above

These seems to be the unique diffs between _mudball_ code generation and the rest of the code generations, which seems to be working properly.

**Why do we need this feature?**

@torkelo noticed that _mudball_ code generation wasn't working as expected, so these changes try to fix it. 

**Who is this feature for?**

Grafana contributors interacting with _mudball_ schemas.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer**:

If I'm not wrong, seems the involved files there haven't been changed since [this very large pull request](https://github.com/grafana/grafana/pull/56492), so maybe something stopped working since then (or never have worked, cause there are no updates since then).