### PR TITLE
Prometheus: Fix Instant query time calculation

### DIFF
--- a/pkg/tsdb/prometheus/client/client.go
+++ b/pkg/tsdb/prometheus/client/client.go
@@ -52,10 +52,10 @@ func (c *Client) QueryRange(ctx context.Context, q *models.Query) (*http.Respons
 func (c *Client) QueryInstant(ctx context.Context, q *models.Query) (*http.Response, error) {
 	// We do not need a time range here.
 	// Instant query evaluates at a single point in time.
-	// https://prometheus.io/docs/prometheus/latest/querying/api/#instant-queries
 	// Using q.TimeRange is aligning the query range to step.
 	// Which causes a misleading time point.
 	// Instead of aligning we use time point directly.
+	// https://prometheus.io/docs/prometheus/latest/querying/api/#instant-queries
 	qv := map[string]string{"query": q.Expr, "time": formatTime(q.End)}
 	req, err := c.createQueryRequest(ctx, "api/v1/query", qv)
 	if err != nil {

--- a/pkg/tsdb/prometheus/client/client.go
+++ b/pkg/tsdb/prometheus/client/client.go
@@ -50,12 +50,13 @@ func (c *Client) QueryRange(ctx context.Context, q *models.Query) (*http.Respons
 }
 
 func (c *Client) QueryInstant(ctx context.Context, q *models.Query) (*http.Response, error) {
-	qv := map[string]string{"query": q.Expr}
-	tr := q.TimeRange()
-	if !tr.End.IsZero() {
-		qv["time"] = formatTime(tr.End)
-	}
-
+	// We do not need a time range here.
+	// Instant query evaluates at a single point in time.
+	// https://prometheus.io/docs/prometheus/latest/querying/api/#instant-queries
+	// Using q.TimeRange is aligning the query range to step.
+	// Which causes a misleading time point.
+	// Instead of aligning we use time point directly.
+	qv := map[string]string{"query": q.Expr, "time": formatTime(q.End)}
 	req, err := c.createQueryRequest(ctx, "api/v1/query", qv)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**What is this feature?**
Instant query time calculation was misleading a wrong time. It was using timerange calculation which is doing an alignment with the time ranges. In instant query call we only need one time point. So instead of doing the calculation we send the time value directly.
See: https://prometheus.io/docs/prometheus/latest/querying/api/#instant-queries

**Why do we need this feature?**
Instant query time calculation was misleading a wrong time. This PR is addressing this issue.

**Who is this feature for?**

People who use Prometheus datasource with the new client.
In `v9.2.x` it is behind the feature flag `prometheusBufferedClient`
In `v9.3.x` it is the default client unless it is decided to use the old client with the `prometheusBufferedClient` feature flag
In `v9.4.x` it is the only client.

**Which issue(s) does this PR fix?**:

Fixes:
- https://github.com/grafana/support-escalations/issues/4699
- https://github.com/grafana/grafana/issues/60467

Special thanks to @toddtreece 