### PR TITLE
CloudWatch: Add CloudWatchSynthetics dimension

### DIFF
--- a/pkg/tsdb/cloudwatch/constants/metrics.go
+++ b/pkg/tsdb/cloudwatch/constants/metrics.go
@@ -518,7 +518,7 @@ var NamespaceDimensionKeysMap = map[string][]string{
 	"AWS/Rekognition":             {},
 	"AWS/Cassandra":               {"Keyspace", "Operation", "TableName"},
 	"AWS/AmplifyHosting":          {"App"},
-	"CloudWatchSynthetics":        {"CanaryName"},
+	"CloudWatchSynthetics":        {"CanaryName", "StepName"},
 }
 
 var Regions = []string{


### PR DESCRIPTION
StepName can be a dimension. Doc: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Synthetics_Canaries_metrics.html
