### PR TITLE
A11y: Fix accessibility in menu icon on small screens

### DIFF
--- a/public/app/core/components/NavBar/NavBar.tsx
+++ b/public/app/core/components/NavBar/NavBar.tsx
@@ -7,7 +7,7 @@ import { useLocation } from 'react-router-dom';
 
 import { GrafanaTheme2, NavModelItem, NavSection } from '@grafana/data';
 import { config, locationSearchToObject, locationService, reportInteraction } from '@grafana/runtime';
-import { Icon, useTheme2, CustomScrollbar } from '@grafana/ui';
+import { Icon, useTheme2, CustomScrollbar, IconButton } from '@grafana/ui';
 import { getKioskMode } from 'app/core/navigation/kiosk';
 import { useSelector } from 'app/types';
 
@@ -90,8 +90,14 @@ export const NavBar = React.memo(() => {
           }}
         >
           <FocusScope>
-            <div className={styles.mobileSidemenuLogo} onClick={() => setMenuOpen(!menuOpen)} key="hamburger">
-              <Icon name="bars" size="xl" />
+            <div className={styles.mobileSidemenuLogo} key="hamburger">
+              <IconButton
+                name="bars"
+                tooltip="Toggle menu"
+                tooltipPlacement="bottom"
+                size="xl"
+                onClick={() => setMenuOpen(!menuOpen)}
+              />
             </div>
 
             <NavBarToggle
@@ -212,7 +218,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
   }),
   mobileSidemenuLogo: css({
     alignItems: 'center',
-    cursor: 'pointer',
     display: 'flex',
     flexDirection: 'row',
     justifyContent: 'space-between',

--- a/public/app/core/components/NavBar/NavBar.tsx
+++ b/public/app/core/components/NavBar/NavBar.tsx
@@ -7,7 +7,7 @@ import { useLocation } from 'react-router-dom';
 
 import { GrafanaTheme2, NavModelItem, NavSection } from '@grafana/data';
 import { config, locationSearchToObject, locationService, reportInteraction } from '@grafana/runtime';
-import { Icon, useTheme2, CustomScrollbar, IconButton } from '@grafana/ui';
+import { useTheme2, CustomScrollbar, IconButton } from '@grafana/ui';
 import { getKioskMode } from 'app/core/navigation/kiosk';
 import { useSelector } from 'app/types';
 


### PR DESCRIPTION
**What is this feature?**

Replaces `Icon` with `IconButton` in the `NavBar` that is visible for small screens to make it accessible.

**Why do we need this feature?**

It was not possible to access the hamburger button with the keyboard (and hence open the navigation) on a small screen. 
<img width="579" alt="Screenshot 2022-12-30 at 14 50 43" src="https://user-images.githubusercontent.com/100691367/210083076-db38332f-fbe4-4614-8010-ed571b920c1b.png">

**Who is this feature for?**

Everyone

**Which issue(s) does this PR fix?**:

Fixes #60843

**Special notes for your reviewer**:

