### PR TITLE
CLI: Fix wire graph for reset-admin-password

### DIFF
--- a/pkg/cmd/grafana-cli/runner/wire.go
+++ b/pkg/cmd/grafana-cli/runner/wire.go
@@ -336,7 +336,7 @@ var wireSet = wire.NewSet(
 	wire.Bind(new(notifications.EmailSender), new(*notifications.NotificationServiceMock)),
 	dbtest.NewFakeDB,
 	wire.Bind(new(sqlstore.Store), new(*sqlstore.SQLStore)),
-	wire.Bind(new(db.DB), new(*dbtest.FakeDB)),
+	wire.Bind(new(db.DB), new(*sqlstore.SQLStore)),
 	prefimpl.ProvideService,
 	opentsdb.ProvideService,
 	acimpl.ProvideAccessControl,


### PR DESCRIPTION
The cli methods were updated to use the db.DB interface, but that interface was still wired in as the fake DB - it had only been used for tests previously. 

This isn't an issue in the main branch now that it's been collapsed into a single binary all using the same wire graph.

Fixes #59915
