### PR TITLE
fix: #54959, remove useless quote and backslash in logs panel

### DIFF
--- a/public/app/features/logs/utils.test.ts
+++ b/public/app/features/logs/utils.test.ts
@@ -170,11 +170,17 @@ describe('LogsParsers', () => {
     });
 
     test('should return detected fields', () => {
-      expect(parser.getFields('{ "foo" : "bar", "baz" : 42 }')).toEqual(['"foo":"bar"', '"baz":42']);
+      expect(parser.getFields('{ "foo" : "bar", "baz" : 42 }')).toEqual(['"foo":bar', '"baz":42']);
     });
 
     test('should return detected fields for nested quotes', () => {
-      expect(parser.getFields(`{"foo":"bar: '[value=\\"42\\"]'"}`)).toEqual([`"foo":"bar: '[value=\\"42\\"]'"`]);
+      expect(parser.getFields(`{"foo":"bar: '[value=\\"42\\"]'"}`)).toEqual([`"foo":bar: '[value=\"42\"]'`]);
+    });
+
+    test('should avoid useless quote and backslash', () => {
+      expect(
+        parser.getFields(JSON.stringify({ method: 'POST', body: '{"Key": 123}', result: '\\/!@#$%^&*()' }))
+      ).toEqual([`"method":POST`, `"body":{"Key": 123}`, `"result":\\/!@#$%^&*()`]);
     });
 
     test('should return label for field', () => {

--- a/public/app/features/logs/utils.ts
+++ b/public/app/features/logs/utils.ts
@@ -1,4 +1,4 @@
-import { countBy, chain, escapeRegExp } from 'lodash';
+import { countBy, chain, escapeRegExp, isObject } from 'lodash';
 
 import {
   ArrayVector,
@@ -110,7 +110,7 @@ export const LogsParsers: { [name: string]: LogsParser } = {
       try {
         const parsed = JSON.parse(line);
         return Object.keys(parsed).map((key) => {
-          return `"${key}":${JSON.stringify(parsed[key])}`;
+          return `"${key}":${isObject(parsed[key]) ? JSON.stringify(parsed[key]) : parsed[key]}`;
         });
       } catch {}
       return [];


### PR DESCRIPTION
**What is this feature?**

Remove useless quote and backslash in logs panel.

**Why do we need this feature?**

See #54959.

**Who is this feature for?**

Use Explorer page to look up http logs, etc.

**Which issue(s) does this PR fix?**:

Fixes #54959
