### PR TITLE
Alerting: Add pagination in group modal alert table

### DIFF
--- a/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
+++ b/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
@@ -24,6 +24,7 @@ import { EvaluationIntervalLimitExceeded } from '../InvalidIntervalWarning';
 import { MIN_TIME_RANGE_STEP_S } from '../rule-editor/GrafanaEvaluationBehavior';
 
 const MINUTE = '1m';
+const ITEMS_PER_PAGE = 10;
 interface AlertInfo {
   alertName: string;
   forDuration: string;
@@ -192,7 +193,7 @@ export const RulesForGroupTable = ({
 
   return (
     <div className={styles.tableWrapper}>
-      <DynamicTable items={rows} cols={columns} />
+      <DynamicTable items={rows} cols={columns} pagination={{ itemsPerPage: ITEMS_PER_PAGE }} />
     </div>
   );
 };


### PR DESCRIPTION
**What is this feature?**

This PR adds pagination in group modal alert list.

**Why do we need this feature?**

We need to handle thousands of alerts in this list, so we need to paginate or use virtualised list to prevent the browser getting stuck. I decided to use pagination for this case as it seems more clear for the user that there are more alerts in the table.

**Who is this feature for?**

All users.

**Special notes for your reviewer**:
<img width="971" alt="Screenshot 2023-01-02 at 10 02 54" src="https://user-images.githubusercontent.com/33540275/210212156-5debf670-04a7-4738-8857-af4fef3a7952.png">


