### PR TITLE
grafana/data: Deprecate kbn.regexEscape and move to grafana/data

### DIFF
--- a/packages/grafana-data/src/text/string.ts
+++ b/packages/grafana-data/src/text/string.ts
@@ -5,21 +5,21 @@ const specialMatcher = '([\\' + specialChars.join('\\') + '])';
 const specialCharEscape = new RegExp(specialMatcher, 'g');
 const specialCharUnescape = new RegExp('(\\\\)' + specialMatcher, 'g');
 
-export const escapeStringForRegex = (value: string) => {
+export function escapeStringForRegex(value: string) {
   if (!value) {
     return value;
   }
 
   return value.replace(specialCharEscape, '\\$1');
-};
+}
 
-export const unEscapeStringFromRegex = (value: string) => {
+export function unEscapeStringFromRegex(value: string) {
   if (!value) {
     return value;
   }
 
   return value.replace(specialCharUnescape, '$2');
-};
+}
 
 export function stringStartsAsRegEx(str: string): boolean {
   if (!str) {
@@ -95,7 +95,11 @@ export function toFloatOrUndefined(value: string): number | undefined {
   return isNaN(v) ? undefined : v;
 }
 
-export const toPascalCase = (string: string) => {
+export function toPascalCase(string: string) {
   const str = camelCase(string);
   return str.charAt(0).toUpperCase() + str.substring(1);
-};
+}
+
+export function escapeRegex(value: string): string {
+  return value.replace(/[\\^$*+?.()|[\]{}\/]/g, '\\$&');
+}

--- a/public/app/core/utils/kbn.ts
+++ b/public/app/core/utils/kbn.ts
@@ -9,6 +9,7 @@ import {
   TimeRange,
   ValueFormatterIndex,
   rangeUtil,
+  escapeRegex,
 } from '@grafana/data';
 
 const kbn = {
@@ -24,7 +25,11 @@ const kbn = {
     s: 1,
     ms: 0.001,
   } as { [index: string]: number },
-  regexEscape: (value: string): string => value.replace(/[\\^$*+?.()|[\]{}\/]/g, '\\$&'),
+  /** @deprecated since 9.4, use grafana/data */
+  regexEscape: (value: string): string => {
+    deprecationWarning('kbn.ts', 'kbn.regexEscape()', 'escapeRegex from @grafana/data');
+    return escapeRegex(value);
+  },
 
   /** @deprecated since 7.2, use grafana/data */
   roundInterval: (interval: number) => {

--- a/public/app/features/scenes/variables/interpolation/formatRegistry.ts
+++ b/public/app/features/scenes/variables/interpolation/formatRegistry.ts
@@ -1,8 +1,7 @@
 import { isArray, map, replace } from 'lodash';
 
-import { dateTime, Registry, RegistryItem, textUtil } from '@grafana/data';
+import { dateTime, Registry, RegistryItem, textUtil, escapeRegex } from '@grafana/data';
 import { VariableType } from '@grafana/schema';
-import kbn from 'app/core/utils/kbn';
 import { ALL_VARIABLE_VALUE } from 'app/features/variables/constants';
 
 import { VariableValue, VariableValueSingle } from '../types';
@@ -81,15 +80,15 @@ export const formatRegistry = new Registry<FormatRegistryItem>(() => {
       description: 'Values are regex escaped and multi-valued variables generate a (<value>|<value>) expression',
       formatter: (value) => {
         if (typeof value === 'string') {
-          return kbn.regexEscape(value);
+          return escapeRegex(value);
         }
 
         if (Array.isArray(value)) {
           const escapedValues = value.map((item) => {
             if (typeof item === 'string') {
-              return kbn.regexEscape(item);
+              return escapeRegex(item);
             } else {
-              return kbn.regexEscape(String(item));
+              return escapeRegex(String(item));
             }
           });
 
@@ -100,7 +99,7 @@ export const formatRegistry = new Registry<FormatRegistryItem>(() => {
           return '(' + escapedValues.join('|') + ')';
         }
 
-        return kbn.regexEscape(`${value}`);
+        return escapeRegex(`${value}`);
       },
     },
     {

--- a/public/app/plugins/datasource/influxdb/influx_query_model.ts
+++ b/public/app/plugins/datasource/influxdb/influx_query_model.ts
@@ -1,8 +1,7 @@
 import { map, find, filter, indexOf } from 'lodash';
 
-import { ScopedVars } from '@grafana/data';
+import { escapeRegex, ScopedVars } from '@grafana/data';
 import { TemplateSrv } from '@grafana/runtime';
-import kbn from 'app/core/utils/kbn';
 
 import queryPart from './query_part';
 import { InfluxQuery, InfluxQueryTag } from './types';
@@ -201,10 +200,10 @@ export default class InfluxQueryModel {
     }
 
     if (typeof value === 'string') {
-      return kbn.regexEscape(value);
+      return escapeRegex(value);
     }
 
-    const escapedValues = map(value, kbn.regexEscape);
+    const escapedValues = map(value, escapeRegex);
     return '(' + escapedValues.join('|') + ')';
   }
 

--- a/public/app/plugins/datasource/influxdb/query_builder.ts
+++ b/public/app/plugins/datasource/influxdb/query_builder.ts
@@ -1,6 +1,6 @@
 import { reduce } from 'lodash';
 
-import kbn from 'app/core/utils/kbn';
+import { escapeRegex } from '@grafana/data';
 
 function renderTagCondition(tag: { operator: any; value: string; condition: any; key: string }, index: number) {
   // FIXME: merge this function with influx_query_model/renderTagCondition
@@ -48,7 +48,7 @@ export class InfluxQueryBuilder {
       query = 'SHOW MEASUREMENTS';
       if (withMeasurementFilter) {
         // we do a case-insensitive regex-based lookup
-        query += ' WITH MEASUREMENT =~ /(?i)' + kbn.regexEscape(withMeasurementFilter) + '/';
+        query += ' WITH MEASUREMENT =~ /(?i)' + escapeRegex(withMeasurementFilter) + '/';
       }
     } else if (type === 'FIELDS') {
       measurement = this.target.measurement;


### PR DESCRIPTION
Moves [kbn.regexEscape](https://github.com/grafana/grafana/blob/main/public/app/core/utils/kbn.ts#L27) from core to @grafana/data, adds deprecation notice and renames to `escapeRegex`.

This change is necessary for @grafana/scenes library.

