### PR TITLE
AuthN: Add client to perform basic authentication

### DIFF
--- a/pkg/services/authn/authn.go
+++ b/pkg/services/authn/authn.go
@@ -108,6 +108,11 @@ func (i *Identity) NamespacedID() (string, int64) {
 }
 
 func (i *Identity) SignedInUser() *user.SignedInUser {
+	var isGrafanaAdmin bool
+	if i.IsGrafanaAdmin != nil {
+		isGrafanaAdmin = *i.IsGrafanaAdmin
+	}
+
 	u := &user.SignedInUser{
 		UserID:             0,
 		OrgID:              i.OrgID,
@@ -119,7 +124,7 @@ func (i *Identity) SignedInUser() *user.SignedInUser {
 		Name:               i.Name,
 		Email:              i.Email,
 		OrgCount:           i.OrgCount,
-		IsGrafanaAdmin:     *i.IsGrafanaAdmin,
+		IsGrafanaAdmin:     isGrafanaAdmin,
 		IsAnonymous:        i.IsAnonymous(),
 		IsDisabled:         i.IsDisabled,
 		HelpFlags1:         i.HelpFlags1,

--- a/pkg/services/authn/authn.go
+++ b/pkg/services/authn/authn.go
@@ -16,6 +16,7 @@ import (
 const (
 	ClientAPIKey    = "auth.client.api-key" // #nosec G101
 	ClientAnonymous = "auth.client.anonymous"
+	ClientBasic     = "auth.client.basic"
 )
 
 type ClientParams struct {

--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -40,7 +40,7 @@ func ProvideService(
 	}
 
 	// FIXME (kalleep): handle cfg.DisableLogin as well?
-	if !s.cfg.BasicAuthEnabled || s.cfg.DisableLogin {
+	if s.cfg.BasicAuthEnabled && !s.cfg.DisableLogin {
 		s.clients[authn.ClientBasic] = clients.ProvideBasic(userService, loginAttempts)
 	}
 

--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -35,6 +35,11 @@ func ProvideService(cfg *setting.Cfg, tracer tracing.Tracer, orgService org.Serv
 		s.clients[authn.ClientAnonymous] = clients.ProvideAnonymous(cfg, orgService)
 	}
 
+	// FIXME (kalleep): handle cfg.DisableLogin as well?
+	if !s.cfg.BasicAuthEnabled {
+		s.clients[authn.ClientBasic] = clients.ProvideBasic()
+	}
+
 	// FIXME (jguer): move to User package
 	userSyncService := &sync.UserSync{}
 	orgUserSyncService := &sync.OrgSync{}

--- a/pkg/services/authn/authnimpl/usersync/orgsync.go
+++ b/pkg/services/authn/authnimpl/usersync/orgsync.go
@@ -15,6 +15,10 @@ import (
 	"github.com/grafana/grafana/pkg/services/user"
 )
 
+func ProvideOrgSync(userService user.Service, orgService org.Service, accessControl accesscontrol.Service) *OrgSync {
+	return &OrgSync{userService, orgService, accessControl, log.New("org.sync")}
+}
+
 type OrgSync struct {
 	userService   user.Service
 	orgService    org.Service

--- a/pkg/services/authn/authnimpl/usersync/usersync.go
+++ b/pkg/services/authn/authnimpl/usersync/usersync.go
@@ -13,6 +13,10 @@ import (
 	"github.com/grafana/grafana/pkg/services/user"
 )
 
+func ProvideUserSync(userService user.Service, authInfoService login.AuthInfoService, quotaService quota.Service) *UserSync {
+	return &UserSync{userService, authInfoService, quotaService, log.New("user.sync")}
+}
+
 type UserSync struct {
 	userService     user.Service
 	authInfoService login.AuthInfoService

--- a/pkg/services/authn/clients/api_key.go
+++ b/pkg/services/authn/clients/api_key.go
@@ -46,14 +46,6 @@ type APIKey struct {
 	apiKeyService apikey.Service
 }
 
-func (s *APIKey) ClientParams() *authn.ClientParams {
-	return &authn.ClientParams{
-		SyncUser:            false,
-		AllowSignUp:         false,
-		EnableDisabledUsers: false,
-	}
-}
-
 func (s *APIKey) Authenticate(ctx context.Context, r *authn.Request) (*authn.Identity, error) {
 	apiKey, err := s.getAPIKey(ctx, getTokenFromRequest(r))
 	if err != nil {
@@ -157,6 +149,10 @@ func (s *APIKey) getFromTokenLegacy(ctx context.Context, token string) (*apikey.
 	}
 
 	return keyQuery.Result, nil
+}
+
+func (s *APIKey) ClientParams() *authn.ClientParams {
+	return &authn.ClientParams{}
 }
 
 func (s *APIKey) Test(ctx context.Context, r *authn.Request) bool {

--- a/pkg/services/authn/clients/api_key.go
+++ b/pkg/services/authn/clients/api_key.go
@@ -18,11 +18,6 @@ import (
 	"github.com/grafana/grafana/pkg/util/errutil"
 )
 
-const (
-	basicPrefix  = "Basic "
-	bearerPrefix = "Bearer "
-)
-
 var (
 	ErrAPIKeyInvalid          = errutil.NewBase(errutil.StatusUnauthorized, "api-key.invalid", errutil.WithPublicMessage("Invalid API key"))
 	ErrAPIKeyExpired          = errutil.NewBase(errutil.StatusUnauthorized, "api-key.expired", errutil.WithPublicMessage("Expired API key"))

--- a/pkg/services/authn/clients/api_key.go
+++ b/pkg/services/authn/clients/api_key.go
@@ -3,7 +3,6 @@ package clients
 import (
 	"context"
 	"errors"
-	"fmt"
 	"strings"
 	"time"
 
@@ -72,7 +71,7 @@ func (s *APIKey) Authenticate(ctx context.Context, r *authn.Request) (*authn.Ide
 	// if the api key don't belong to a service account construct the identity and return it
 	if apiKey.ServiceAccountId == nil || *apiKey.ServiceAccountId < 1 {
 		return &authn.Identity{
-			ID:       fmt.Sprintf("%s%d", authn.APIKeyIDPrefix, apiKey.Id),
+			ID:       authn.NamespacedID(authn.NamespaceAPIKey, apiKey.Id),
 			OrgID:    apiKey.OrgId,
 			OrgRoles: map[int64]org.RoleType{apiKey.OrgId: apiKey.Role},
 		}, nil
@@ -91,7 +90,7 @@ func (s *APIKey) Authenticate(ctx context.Context, r *authn.Request) (*authn.Ide
 		return nil, ErrServiceAccountDisabled.Errorf("Disabled service account")
 	}
 
-	return authn.IdentityFromSignedInUser(fmt.Sprintf("%s%d", authn.ServiceAccountIDPrefix, *apiKey.ServiceAccountId), usr), nil
+	return authn.IdentityFromSignedInUser(authn.NamespacedID(authn.NamespaceServiceAccount, usr.UserID), usr), nil
 }
 
 func (s *APIKey) getAPIKey(ctx context.Context, token string) (*apikey.APIKey, error) {

--- a/pkg/services/authn/clients/basic.go
+++ b/pkg/services/authn/clients/basic.go
@@ -1,0 +1,30 @@
+package clients
+
+import (
+	"context"
+
+	"github.com/grafana/grafana/pkg/services/authn"
+)
+
+var _ authn.Client = new(Basic)
+
+func ProvideBasic() *Basic {
+	return &Basic{}
+}
+
+type Basic struct {
+}
+
+func (b *Basic) Authenticate(ctx context.Context, r *authn.Request) (*authn.Identity, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (b *Basic) ClientParams() *authn.ClientParams {
+	return &authn.ClientParams{}
+}
+
+func (b *Basic) Test(ctx context.Context, r *authn.Request) bool {
+	//TODO implement me
+	panic("implement me")
+}

--- a/pkg/services/authn/clients/basic.go
+++ b/pkg/services/authn/clients/basic.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	ErrBasicAuthCredentials    = errutil.NewBase(errutil.StatusBadRequest, "basic.invalid-credentials", errutil.WithPublicMessage("Invalid username or password"))
+	ErrBasicAuthCredentials    = errutil.NewBase(errutil.StatusUnauthorized, "basic.invalid-credentials", errutil.WithPublicMessage("Invalid username or password"))
 	ErrDecodingBasicAuthHeader = errutil.NewBase(errutil.StatusBadRequest, "basic.invalid-header", errutil.WithPublicMessage("Invalid Basic Auth Header"))
 )
 

--- a/pkg/services/authn/clients/basic.go
+++ b/pkg/services/authn/clients/basic.go
@@ -101,5 +101,5 @@ func getBasicAuthHeaderFromRequest(r *authn.Request) string {
 func comparePassword(password, salt, hash string) bool {
 	// It is ok to ignore the error here because util.EncodePassword can never return a error
 	hashedPassword, _ := util.EncodePassword(password, salt)
-	return subtle.ConstantTimeCompare([]byte(hashedPassword), []byte(hash)) != 1
+	return subtle.ConstantTimeCompare([]byte(hashedPassword), []byte(hash)) == 1
 }

--- a/pkg/services/authn/clients/basic.go
+++ b/pkg/services/authn/clients/basic.go
@@ -2,6 +2,7 @@ package clients
 
 import (
 	"context"
+	"strings"
 
 	"github.com/grafana/grafana/pkg/services/authn"
 )
@@ -25,6 +26,14 @@ func (b *Basic) ClientParams() *authn.ClientParams {
 }
 
 func (b *Basic) Test(ctx context.Context, r *authn.Request) bool {
-	//TODO implement me
-	panic("implement me")
+	if r.HTTPRequest == nil {
+		return false
+	}
+
+	header := r.HTTPRequest.Header.Get(authorizationHeaderName)
+	if header == "" {
+		return false
+	}
+
+	return strings.HasPrefix(header, basicPrefix)
 }

--- a/pkg/services/authn/clients/basic.go
+++ b/pkg/services/authn/clients/basic.go
@@ -13,8 +13,8 @@ import (
 )
 
 var (
-	ErrBasicAuthCredentials    = errutil.NewBase(errutil.StatusUnauthorized, "basic.invalid-credentials", errutil.WithPublicMessage("Invalid username or password"))
-	ErrDecodingBasicAuthHeader = errutil.NewBase(errutil.StatusBadRequest, "basic.invalid-header", errutil.WithPublicMessage("Invalid Basic Auth Header"))
+	ErrBasicAuthCredentials    = errutil.NewBase(errutil.StatusUnauthorized, "basic-auth.invalid-credentials", errutil.WithPublicMessage("Invalid username or password"))
+	ErrDecodingBasicAuthHeader = errutil.NewBase(errutil.StatusBadRequest, "basic-auth.invalid-header", errutil.WithPublicMessage("Invalid Basic Auth Header"))
 )
 
 var _ authn.Client = new(Basic)
@@ -101,8 +101,5 @@ func getBasicAuthHeaderFromRequest(r *authn.Request) string {
 func comparePassword(password, salt, hash string) bool {
 	// It is ok to ignore the error here because util.EncodePassword can never return a error
 	hashedPassword, _ := util.EncodePassword(password, salt)
-	if subtle.ConstantTimeCompare([]byte(hashedPassword), []byte(hash)) != 1 {
-		return false
-	}
-	return true
+	return subtle.ConstantTimeCompare([]byte(hashedPassword), []byte(hash)) != 1
 }

--- a/pkg/services/authn/clients/basic.go
+++ b/pkg/services/authn/clients/basic.go
@@ -2,38 +2,107 @@ package clients
 
 import (
 	"context"
+	"crypto/subtle"
 	"strings"
 
 	"github.com/grafana/grafana/pkg/services/authn"
+	"github.com/grafana/grafana/pkg/services/loginattempt"
+	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/grafana/grafana/pkg/util"
+	"github.com/grafana/grafana/pkg/util/errutil"
+)
+
+var (
+	ErrBasicAuthCredentials    = errutil.NewBase(errutil.StatusBadRequest, "basic.invalid-credentials", errutil.WithPublicMessage("Invalid username or password"))
+	ErrDecodingBasicAuthHeader = errutil.NewBase(errutil.StatusBadRequest, "basic.invalid-header", errutil.WithPublicMessage("Invalid Basic Auth Header"))
 )
 
 var _ authn.Client = new(Basic)
 
-func ProvideBasic() *Basic {
-	return &Basic{}
+func ProvideBasic(userService user.Service, loginAttempts loginattempt.Service) *Basic {
+	return &Basic{userService, loginAttempts}
 }
 
 type Basic struct {
+	userService   user.Service
+	loginAttempts loginattempt.Service
 }
 
-func (b *Basic) Authenticate(ctx context.Context, r *authn.Request) (*authn.Identity, error) {
-	//TODO implement me
-	panic("implement me")
+func (c *Basic) Authenticate(ctx context.Context, r *authn.Request) (*authn.Identity, error) {
+	username, password, err := util.DecodeBasicAuthHeader(getBasicAuthHeaderFromRequest(r))
+	if err != nil {
+		return nil, ErrDecodingBasicAuthHeader.Errorf("failed to decode basic auth header: %w", err)
+	}
+
+	ok, err := c.loginAttempts.Validate(ctx, username)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, ErrBasicAuthCredentials.Errorf("too many consecutive incorrect login attempts for user - login for user temporarily blocked")
+	}
+
+	if len(password) == 0 {
+		return nil, ErrBasicAuthCredentials.Errorf("no password provided")
+	}
+
+	// FIXME (kalleep): decide if we should handle ldap here
+	usr, err := c.userService.GetByLogin(ctx, &user.GetUserByLoginQuery{LoginOrEmail: username})
+	if err != nil {
+		return nil, ErrBasicAuthCredentials.Errorf("failed to fetch user: %w", err)
+	}
+
+	if ok := comparePassword(password, usr.Salt, usr.Password); !ok {
+		_ = c.loginAttempts.Add(ctx, username, r.HTTPRequest.RemoteAddr)
+		return nil, ErrBasicAuthCredentials.Errorf("incorrect password provided")
+	}
+
+	signedInUser, err := c.userService.GetSignedInUserWithCacheCtx(ctx, &user.GetSignedInUserQuery{
+		UserID: usr.ID,
+		OrgID:  r.OrgID,
+	})
+
+	if err != nil {
+		return nil, ErrBasicAuthCredentials.Errorf("failed to fetch user: %w", err)
+	}
+
+	return authn.IdentityFromSignedInUser(authn.NamespacedID(authn.NamespaceUser, signedInUser.UserID), signedInUser), nil
 }
 
-func (b *Basic) ClientParams() *authn.ClientParams {
+func (c *Basic) ClientParams() *authn.ClientParams {
 	return &authn.ClientParams{}
 }
 
-func (b *Basic) Test(ctx context.Context, r *authn.Request) bool {
+func (c *Basic) Test(ctx context.Context, r *authn.Request) bool {
+	return looksLikeBasicAuthRequest(r)
+}
+
+func looksLikeBasicAuthRequest(r *authn.Request) bool {
+	return getBasicAuthHeaderFromRequest(r) != ""
+}
+
+func getBasicAuthHeaderFromRequest(r *authn.Request) string {
 	if r.HTTPRequest == nil {
-		return false
+		return ""
 	}
 
 	header := r.HTTPRequest.Header.Get(authorizationHeaderName)
 	if header == "" {
-		return false
+		return ""
 	}
 
-	return strings.HasPrefix(header, basicPrefix)
+	if !strings.HasPrefix(header, basicPrefix) {
+		return ""
+	}
+
+	return header
+}
+
+func comparePassword(password, salt, hash string) bool {
+	// It is ok to ignore the error here because util.EncodePassword can never return a error
+	hashedPassword, _ := util.EncodePassword(password, salt)
+	if subtle.ConstantTimeCompare([]byte(hashedPassword), []byte(hash)) != 1 {
+		return false
+	}
+	return true
 }

--- a/pkg/services/authn/clients/basic_test.go
+++ b/pkg/services/authn/clients/basic_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/grafana/grafana/pkg/services/authn"
+	"github.com/grafana/grafana/pkg/services/loginattempt/loginattempttest"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -48,7 +49,7 @@ func TestBasic_Test(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			c := ProvideBasic()
+			c := ProvideBasic(loginattempttest.FakeLoginAttemptService{})
 			assert.Equal(t, tt.expected, c.Test(context.Background(), tt.req))
 		})
 	}

--- a/pkg/services/authn/clients/basic_test.go
+++ b/pkg/services/authn/clients/basic_test.go
@@ -7,8 +7,74 @@ import (
 
 	"github.com/grafana/grafana/pkg/services/authn"
 	"github.com/grafana/grafana/pkg/services/loginattempt/loginattempttest"
+	"github.com/grafana/grafana/pkg/services/org"
+	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/grafana/grafana/pkg/services/user/usertest"
+	"github.com/grafana/grafana/pkg/util"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestBasic_Authenticate(t *testing.T) {
+	type TestCase struct {
+		desc                 string
+		req                  *authn.Request
+		blockLogin           bool
+		expectedErr          error
+		expectedSignedInUser *user.SignedInUser
+		expectedIdentity     *authn.Identity
+	}
+
+	tests := []TestCase{
+		{
+			desc:                 "should successfully authenticate user with correct password",
+			req:                  &authn.Request{HTTPRequest: &http.Request{Header: map[string][]string{authorizationHeaderName: {encodeBasicAuth("user", "password")}}}},
+			expectedErr:          nil,
+			expectedSignedInUser: &user.SignedInUser{UserID: 1, OrgID: 1, OrgRole: "Viewer"},
+			expectedIdentity:     &authn.Identity{ID: "user:1", OrgID: 1, OrgRoles: map[int64]org.RoleType{1: "Viewer"}, IsGrafanaAdmin: boolPtr(false)},
+		},
+		{
+			desc:        "should fail for incorrect password",
+			req:         &authn.Request{HTTPRequest: &http.Request{Header: map[string][]string{authorizationHeaderName: {encodeBasicAuth("user", "wrong")}}}},
+			expectedErr: ErrBasicAuthCredentials,
+		},
+		{
+			desc:        "should fail for empty password",
+			req:         &authn.Request{HTTPRequest: &http.Request{Header: map[string][]string{authorizationHeaderName: {encodeBasicAuth("user", "")}}}},
+			expectedErr: ErrBasicAuthCredentials,
+		},
+		{
+			desc:        "should if login is blocked by to many attempts",
+			req:         &authn.Request{HTTPRequest: &http.Request{Header: map[string][]string{authorizationHeaderName: {encodeBasicAuth("user", "")}}}},
+			blockLogin:  true,
+			expectedErr: ErrBasicAuthCredentials,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			hashed, _ := util.EncodePassword("password", "salt")
+			c := ProvideBasic(&usertest.FakeUserService{
+				ExpectedUser: &user.User{
+					Password: hashed,
+					Salt:     "salt",
+				},
+				ExpectedSignedInUser: tt.expectedSignedInUser,
+			}, loginattempttest.FakeLoginAttemptService{
+				ExpectedValid: !tt.blockLogin,
+			})
+
+			identity, err := c.Authenticate(context.Background(), tt.req)
+			if tt.expectedErr != nil {
+				assert.ErrorIs(t, err, tt.expectedErr)
+				assert.Nil(t, identity)
+			} else {
+				assert.NoError(t, err)
+				assert.EqualValues(t, *tt.expectedIdentity, *identity)
+			}
+
+		})
+	}
+}
 
 func TestBasic_Test(t *testing.T) {
 	type TestCase struct {
@@ -49,7 +115,7 @@ func TestBasic_Test(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			c := ProvideBasic(loginattempttest.FakeLoginAttemptService{})
+			c := ProvideBasic(usertest.NewUserServiceFake(), loginattempttest.FakeLoginAttemptService{})
 			assert.Equal(t, tt.expected, c.Test(context.Background(), tt.req))
 		})
 	}

--- a/pkg/services/authn/clients/basic_test.go
+++ b/pkg/services/authn/clients/basic_test.go
@@ -1,0 +1,55 @@
+package clients
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/grafana/grafana/pkg/services/authn"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBasic_Test(t *testing.T) {
+	type TestCase struct {
+		desc     string
+		req      *authn.Request
+		expected bool
+	}
+
+	tests := []TestCase{
+		{
+			desc: "should succeed when authorization header is set with basic prefix",
+			req: &authn.Request{
+				HTTPRequest: &http.Request{
+					Header: map[string][]string{
+						authorizationHeaderName: {encodeBasicAuth("user", "password")},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			desc: "should fail when no http request is passed",
+			req:  &authn.Request{},
+		},
+		{
+			desc: "should fail when no http authorization header is set in http request",
+			req: &authn.Request{
+				HTTPRequest: &http.Request{Header: map[string][]string{}},
+			},
+		},
+		{
+			desc: "should fail when authorization header is set but without basic prefix",
+			req: &authn.Request{
+				HTTPRequest: &http.Request{Header: map[string][]string{authorizationHeaderName: {"something"}}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			c := ProvideBasic()
+			assert.Equal(t, tt.expected, c.Test(context.Background(), tt.req))
+		})
+	}
+}

--- a/pkg/services/authn/clients/basic_test.go
+++ b/pkg/services/authn/clients/basic_test.go
@@ -71,7 +71,6 @@ func TestBasic_Authenticate(t *testing.T) {
 				assert.NoError(t, err)
 				assert.EqualValues(t, *tt.expectedIdentity, *identity)
 			}
-
 		})
 	}
 }

--- a/pkg/services/authn/clients/constants.go
+++ b/pkg/services/authn/clients/constants.go
@@ -1,0 +1,7 @@
+package clients
+
+const (
+	basicPrefix             = "Basic "
+	bearerPrefix            = "Bearer "
+	authorizationHeaderName = "Authorization"
+)


### PR DESCRIPTION
**What is this feature?**
Porting over the logic to perform basic authentication with a auth client.

Intentionally left out checking against ldap until we decide how that one should be performed / ldap has its own client

Fixes #

**Special notes for your reviewer**:
* Added providers for sync services to be able to set dependencies

