### PR TITLE
Reqcontext: Add methods to write responses bases on errutil.Error

### DIFF
--- a/pkg/models/context.go
+++ b/pkg/models/context.go
@@ -115,7 +115,7 @@ func (ctx *ReqContext) writeErrOrFallback(status int, message string, err error)
 			logger = gfErr.LogLevel.LogFunc(ctx.Logger)
 			publicErr := gfErr.Public()
 
-			// need to manually set these fields for us to be able to set traceID
+			// need to manually set these fields because we want to include the trace id
 			data["extra"] = publicErr.Extra
 			data["message"] = publicErr.Message
 			data["messageId"] = publicErr.MessageID

--- a/pkg/models/context.go
+++ b/pkg/models/context.go
@@ -90,6 +90,8 @@ func (ctx *ReqContext) JsonApiErr(status int, message string, err error) {
 	ctx.JSON(status, resp)
 }
 
+// Err writes an error response based on errutil.Error.
+// If provided error is not a errutil.Error a 500 response is written.
 func (ctx *ReqContext) Err(err error) {
 	grafanaErr := &errutil.Error{}
 	if !errors.As(err, grafanaErr) {
@@ -98,6 +100,8 @@ func (ctx *ReqContext) Err(err error) {
 	ctx.JsonApiErr(grafanaErr.Reason.Status().HTTPStatus(), grafanaErr.Public().Message, err)
 }
 
+// ErrOrFallback uses the information in an errutil.Error if available
+// and otherwise falls back to the status and message provided as arguments.
 func (ctx *ReqContext) ErrOrFallback(status int, message string, err error) {
 	grafanaErr := &errutil.Error{}
 	if errors.As(err, grafanaErr) {

--- a/pkg/models/context.go
+++ b/pkg/models/context.go
@@ -90,9 +90,9 @@ func (ctx *ReqContext) JsonApiErr(status int, message string, err error) {
 	ctx.JSON(status, resp)
 }
 
-// Err writes an error response based on errutil.Error.
+// WriteErr writes an error response based on errutil.Error.
 // If provided error is not a errutil.Error a 500 response is written.
-func (ctx *ReqContext) Err(err error) {
+func (ctx *ReqContext) WriteErr(err error) {
 	grafanaErr := &errutil.Error{}
 	if !errors.As(err, grafanaErr) {
 		ctx.JsonApiErr(http.StatusInternalServerError, "", fmt.Errorf("unexpected error type [%s]: %w", reflect.TypeOf(err), err))
@@ -100,12 +100,12 @@ func (ctx *ReqContext) Err(err error) {
 	ctx.JsonApiErr(grafanaErr.Reason.Status().HTTPStatus(), grafanaErr.Public().Message, err)
 }
 
-// ErrOrFallback uses the information in an errutil.Error if available
+// WriteErrOrFallback uses the information in an errutil.Error if available
 // and otherwise falls back to the status and message provided as arguments.
-func (ctx *ReqContext) ErrOrFallback(status int, message string, err error) {
+func (ctx *ReqContext) WriteErrOrFallback(status int, message string, err error) {
 	grafanaErr := &errutil.Error{}
 	if errors.As(err, grafanaErr) {
-		ctx.Err(err)
+		ctx.WriteErr(err)
 		return
 	}
 	ctx.JsonApiErr(status, message, err)

--- a/pkg/models/context.go
+++ b/pkg/models/context.go
@@ -1,7 +1,10 @@
 package models
 
 import (
+	"errors"
+	"fmt"
 	"net/http"
+	"reflect"
 	"strings"
 
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -10,6 +13,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/util/errutil"
 	"github.com/grafana/grafana/pkg/web"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -84,6 +88,23 @@ func (ctx *ReqContext) JsonApiErr(status int, message string, err error) {
 	}
 
 	ctx.JSON(status, resp)
+}
+
+func (ctx *ReqContext) Err(err error) {
+	grafanaErr := &errutil.Error{}
+	if !errors.As(err, grafanaErr) {
+		ctx.JsonApiErr(http.StatusInternalServerError, "", fmt.Errorf("unexpected error type [%s]: %w", reflect.TypeOf(err), err))
+	}
+	ctx.JsonApiErr(grafanaErr.Reason.Status().HTTPStatus(), grafanaErr.Public().Message, err)
+}
+
+func (ctx *ReqContext) ErrOrFallback(status int, message string, err error) {
+	grafanaErr := &errutil.Error{}
+	if errors.As(err, grafanaErr) {
+		ctx.Err(err)
+		return
+	}
+	ctx.JsonApiErr(status, message, err)
 }
 
 func (ctx *ReqContext) HasUserRole(role org.RoleType) bool {

--- a/pkg/services/contexthandler/auth_jwt.go
+++ b/pkg/services/contexthandler/auth_jwt.go
@@ -36,7 +36,7 @@ func (h *ContextHandler) initContextWithJWT(ctx *models.ReqContext, orgId int64)
 		*ctx.Req = *ctx.Req.WithContext(newCtx)
 
 		if err != nil {
-			writeErr(ctx, err)
+			ctx.WriteErr(err)
 			return true
 		}
 

--- a/pkg/services/contexthandler/contexthandler.go
+++ b/pkg/services/contexthandler/contexthandler.go
@@ -415,7 +415,7 @@ func (h *ContextHandler) initContextWithBasicAuth(reqContext *models.ReqContext,
 		*reqContext.Req = *reqContext.Req.WithContext(ctx)
 
 		if err != nil {
-			writeErr(reqContext, err)
+			reqContext.WriteErr(err)
 			return true
 		}
 

--- a/pkg/services/contexthandler/contexthandler.go
+++ b/pkg/services/contexthandler/contexthandler.go
@@ -287,7 +287,7 @@ func (h *ContextHandler) initContextWithAPIKey(reqContext *models.ReqContext) bo
 		*reqContext.Req = *reqContext.Req.WithContext(ctx)
 
 		if err != nil {
-			writeErr(reqContext, err)
+			reqContext.WriteErr(err)
 			return true
 		}
 

--- a/pkg/services/contexthandler/contexthandler.go
+++ b/pkg/services/contexthandler/contexthandler.go
@@ -34,7 +34,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
-	"github.com/grafana/grafana/pkg/util/errutil"
 	"github.com/grafana/grafana/pkg/web"
 )
 
@@ -827,16 +826,6 @@ func (h *ContextHandler) initContextWithAuthProxy(reqContext *models.ReqContext,
 	}
 
 	return true
-}
-
-// writeErr will write error response based on errutil.Error.
-func writeErr(c *models.ReqContext, err error) {
-	grfErr := &errutil.Error{}
-	if !errors.As(err, grfErr) {
-		c.JsonApiErr(http.StatusInternalServerError, "", err)
-		return
-	}
-	c.JsonApiErr(grfErr.Reason.Status().HTTPStatus(), grfErr.Public().Message, err)
 }
 
 type authHTTPHeaderListContextKey struct{}

--- a/pkg/services/contexthandler/contexthandler.go
+++ b/pkg/services/contexthandler/contexthandler.go
@@ -639,7 +639,7 @@ func (h *ContextHandler) initContextWithRenderAuth(reqContext *models.ReqContext
 		}
 
 		if err != nil {
-			writeErr(reqContext, err)
+			reqContext.WriteErr(err)
 			return true
 		}
 
@@ -723,7 +723,8 @@ func (h *ContextHandler) initContextWithAuthProxy(reqContext *models.ReqContext,
 		}
 
 		if err != nil {
-			writeErr(reqContext, err)
+			reqContext.WriteErr(err)
+			return true
 		}
 
 		ctx := WithAuthHTTPHeader(reqContext.Req.Context(), h.Cfg.AuthProxyHeaderName)


### PR DESCRIPTION
**What is this feature?**
Add methods to reqcontext for writing error responses based on errutil.Error. These functions mimic the behaviour from 
https://github.com/grafana/grafana/blob/main/pkg/api/response/response.go#L229 and https://github.com/grafana/grafana/blob/main/pkg/api/response/response.go#L249

**Special notes for your reviewer**:

