### PR TITLE
CloudWatch: Decrease log group picker viewport size

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/components/styles.ts
+++ b/public/app/plugins/datasource/cloudwatch/components/styles.ts
@@ -34,7 +34,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
   }),
 
   tableScroller: css({
-    maxHeight: '50vh',
+    maxHeight: '40vh',
     overflow: 'auto',
   }),
 


### PR DESCRIPTION

**What is this feature?**

In [PR](https://github.com/grafana/grafana/pull/60619) that was just merged to main, log group picker CTA buttons were not always visible for small screen. This PR decreases viewport height to address that. 