### PR TITLE
Scene: PanelTimeRange 

### DIFF
--- a/public/app/features/scenes/components/VizPanel/VizPanelRenderer.tsx
+++ b/public/app/features/scenes/components/VizPanel/VizPanelRenderer.tsx
@@ -8,6 +8,7 @@ import { useFieldOverrides } from 'app/features/panel/components/PanelRenderer';
 
 import { sceneGraph } from '../../core/sceneGraph';
 import { SceneComponentProps } from '../../core/types';
+import { PanelTimeRange } from '../../dashboard/PanelTimeRange';
 import { SceneQueryRunner } from '../../querying/SceneQueryRunner';
 import { CustomFormatterFn } from '../../variables/interpolation/sceneInterpolator';
 import { SceneDragHandle } from '../SceneDragHandle';
@@ -30,7 +31,8 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
   const titleInterpolated = sceneGraph.interpolate(model, title);
 
   // Not sure we need to subscribe to this state
-  const timeZone = sceneGraph.getTimeRange(model).state.timeZone;
+  const timeRange = sceneGraph.getTimeRange(model);
+  const timeZone = timeRange.state.timeZone;
 
   const dataWithOverrides = useFieldOverrides(plugin, fieldConfig, data, timeZone);
 
@@ -53,10 +55,10 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
     $data.setContainerWidth(width);
   }
 
-  if (data?.request?.timeInfo) {
+  if (timeRange instanceof PanelTimeRange) {
     titleItems.push({
       icon: toIconName('clock-nine')!,
-      tooltip: data?.request?.timeInfo,
+      tooltip: timeRange.getTimeOverrideInfo(),
     });
   }
 

--- a/public/app/features/scenes/dashboard/DashboardsLoader.ts
+++ b/public/app/features/scenes/dashboard/DashboardsLoader.ts
@@ -11,6 +11,7 @@ import { DashboardModel, PanelModel } from 'app/features/dashboard/state';
 import { DashboardDTO } from 'app/types';
 
 import { VizPanel, SceneTimePicker, SceneGridLayout, SceneGridRow, SceneSubMenu } from '../components';
+import { VizPanelState } from '../components/VizPanel/VizPanel';
 import { SceneTimeRange } from '../core/SceneTimeRange';
 import { SceneObject } from '../core/types';
 import { SceneQueryRunner } from '../querying/SceneQueryRunner';
@@ -23,6 +24,7 @@ import { DataSourceVariable } from '../variables/variants/DataSourceVariable';
 import { QueryVariable } from '../variables/variants/query/QueryVariable';
 
 import { DashboardScene } from './DashboardScene';
+import { PanelTimeRange } from './PanelTimeRange';
 
 export interface DashboardLoaderState {
   dashboard?: DashboardScene;
@@ -250,7 +252,7 @@ export function createVariableFromLegacyModel(variable: VariableModel): SceneVar
 }
 
 function createVizPanelFromPanelModel(panel: PanelModel) {
-  return new VizPanel({
+  const state: VizPanelState = {
     title: panel.title,
     pluginId: panel.type,
     placement: {
@@ -262,14 +264,18 @@ function createVizPanelFromPanelModel(panel: PanelModel) {
     options: panel.options,
     fieldConfig: panel.fieldConfig,
     pluginVersion: panel.pluginVersion,
+    hideTimeOverride: panel.hideTimeOverride,
     $data: new SceneQueryRunner({
       queries: panel.targets,
-      timeFrom: panel.timeFrom,
-      timeShift: panel.timeShift,
-      hideTimeOverride: panel.hideTimeOverride,
       maxDataPoints: panel.maxDataPoints,
     }),
-  });
+  };
+
+  if (panel.timeFrom || panel.timeShift) {
+    state.$timeRange = new PanelTimeRange({ from: panel.timeFrom, timeShift: panel.timeShift });
+  }
+
+  return new VizPanel(state);
 }
 
 let loader: DashboardLoader | null = null;

--- a/public/app/features/scenes/dashboard/PanelTimeRange.ts
+++ b/public/app/features/scenes/dashboard/PanelTimeRange.ts
@@ -20,7 +20,7 @@ export class PanelTimeRange extends SceneObjectBase<PanelTimeRangeState> impleme
     super.activate();
 
     if (this.state.timeShift) {
-      // subscribe to parent time etc
+      // subscribe to parent time etc and perform time shift
     }
   }
 

--- a/public/app/features/scenes/dashboard/PanelTimeRange.ts
+++ b/public/app/features/scenes/dashboard/PanelTimeRange.ts
@@ -48,6 +48,10 @@ export class PanelTimeRange extends SceneObjectBase<PanelTimeRangeState> impleme
   };
 
   public onIntervalChanged = (_: string) => {};
+
+  public getTimeOverrideInfo() {
+    return 'now-1h';
+  }
 }
 
 function evaluateTimeRange(from: string, to: string, timeZone: TimeZone, fiscalYearStartMonth?: number): TimeRange {

--- a/public/app/features/scenes/dashboard/PanelTimeRange.ts
+++ b/public/app/features/scenes/dashboard/PanelTimeRange.ts
@@ -1,0 +1,62 @@
+import { dateMath, getTimeZone, TimeRange, TimeZone } from '@grafana/data';
+
+import { SceneObjectBase } from '../core/SceneObjectBase';
+import { SceneTimeRangeLike, SceneTimeRangeState } from '../core/types';
+
+export interface PanelTimeRangeState extends SceneTimeRangeState {
+  timeShift?: string;
+}
+
+export class PanelTimeRange extends SceneObjectBase<PanelTimeRangeState> implements SceneTimeRangeLike {
+  public constructor(state: Partial<SceneTimeRangeState> = {}) {
+    const from = state.from ?? 'now-6h';
+    const to = state.to ?? 'now';
+    const timeZone = state.timeZone ?? getTimeZone();
+    const value = evaluateTimeRange(from, to, timeZone);
+    super({ from, to, timeZone, value, ...state });
+  }
+
+  public activate(): void {
+    super.activate();
+
+    if (this.state.timeShift) {
+      // subscribe to parent time etc
+    }
+  }
+
+  public onTimeRangeChange = (timeRange: TimeRange) => {
+    const update: Partial<SceneTimeRangeState> = {};
+
+    if (typeof timeRange.raw.from === 'string') {
+      update.from = timeRange.raw.from;
+    } else {
+      update.from = timeRange.raw.from.toISOString();
+    }
+
+    if (typeof timeRange.raw.to === 'string') {
+      update.to = timeRange.raw.to;
+    } else {
+      update.to = timeRange.raw.to.toISOString();
+    }
+
+    update.value = evaluateTimeRange(update.from, update.to, this.state.timeZone);
+    this.setState(update);
+  };
+
+  public onRefresh = () => {
+    this.setState({ value: evaluateTimeRange(this.state.from, this.state.to, this.state.timeZone) });
+  };
+
+  public onIntervalChanged = (_: string) => {};
+}
+
+function evaluateTimeRange(from: string, to: string, timeZone: TimeZone, fiscalYearStartMonth?: number): TimeRange {
+  return {
+    from: dateMath.parse(from, false, timeZone, fiscalYearStartMonth)!,
+    to: dateMath.parse(to, true, timeZone, fiscalYearStartMonth)!,
+    raw: {
+      from: from,
+      to: to,
+    },
+  };
+}


### PR DESCRIPTION
I am pretty foggy so this is just sketch of the direction that could be worth persuing. 

Instead of adding custom time override and time shift features to SceneQueryRunner we could use our existing $timeRange abstraction and handle it through that instead. 

That is create a new type of PanelOverrideTimeRange that can handle the local time range, and any time shift relative to parent time range. 

The benefits here that I can see is that SceneQueryRunner and VizPanel can just ask sceneGraph.getTimeRange and it will get the same time range (the local or time shifted one), if you zoom in on panel with local time range we can treat that as a local zoom in that only affects that panel. (A problem with the current panel time range is that it only works for relative time ranges. when you zoom in all panels are affected). 

Using a custom PanelTimeRange could also potentially make easy to add URL sync support (when you zoomed in on a panel with local time range). 

I think this might require some slight changes to SceneTimeRangeState and SceneTimeRangeLike, slim it down a bit. onIntervalChanged should probably not be part of it. And the other thing is how to propagate refresh triggers when there are panels with local time ranges, and you hit the refresh button on the whole scene top level time range. How do we propagate this? Should PanelTimeRange subscribe to parent time range and update it's own when parent changes (this would be one way). 