### PR TITLE
Docs: Re-order nav for Manage your alert notifications

### DIFF
--- a/docs/sources/alerting/manage-notifications/alertmanager.md
+++ b/docs/sources/alerting/manage-notifications/alertmanager.md
@@ -4,7 +4,7 @@ aliases:
   - ../metrics/
   - ../unified-alerting/fundamentals/alertmanager/
 title: Alertmanager
-weight: 460
+weight: 100
 ---
 
 # Alertmanager

--- a/docs/sources/alerting/manage-notifications/create-contact-point.md
+++ b/docs/sources/alerting/manage-notifications/create-contact-point.md
@@ -11,7 +11,7 @@ keywords:
   - contact point
   - templating
 title: Manage contact points
-weight: 100
+weight: 200
 ---
 
 # Manage contact points

--- a/docs/sources/alerting/manage-notifications/create-silence.md
+++ b/docs/sources/alerting/manage-notifications/create-silence.md
@@ -12,7 +12,7 @@ keywords:
   - silence
   - mute
 title: Manage silences
-weight: 450
+weight: 600
 ---
 
 # Manage silences

--- a/docs/sources/alerting/manage-notifications/images-in-notifications.md
+++ b/docs/sources/alerting/manage-notifications/images-in-notifications.md
@@ -6,7 +6,7 @@ keywords:
   - images
   - notifications
 title: Use images in notifications
-weight: 480
+weight: 500
 ---
 
 # Use images in notifications

--- a/docs/sources/alerting/manage-notifications/mute-timings.md
+++ b/docs/sources/alerting/manage-notifications/mute-timings.md
@@ -11,7 +11,7 @@ keywords:
   - mute timings
   - mute time interval
 title: Create mute timings
-weight: 400
+weight: 700
 ---
 
 # Create mute timings

--- a/docs/sources/alerting/manage-notifications/template-notifications/_index.md
+++ b/docs/sources/alerting/manage-notifications/template-notifications/_index.md
@@ -6,7 +6,7 @@ keywords:
   - notifications
   - templates
 title: Customize notifications
-weight: 100
+weight: 400
 ---
 
 # Customize notifications

--- a/docs/sources/alerting/manage-notifications/view-alert-groups.md
+++ b/docs/sources/alerting/manage-notifications/view-alert-groups.md
@@ -12,7 +12,7 @@ keywords:
   - alerts
   - groups
 title: View and filter by alert groups
-weight: 455
+weight: 800
 ---
 
 # View and filter by alert groups

--- a/docs/sources/alerting/manage-notifications/view-notification-errors.md
+++ b/docs/sources/alerting/manage-notifications/view-notification-errors.md
@@ -6,7 +6,7 @@ keywords:
   - errors
   - contact points
 title: View notification errors
-weight: 150
+weight: 900
 ---
 
 # View notification errors

--- a/docs/sources/alerting/manage-notifications/webhook-notifier.md
+++ b/docs/sources/alerting/manage-notifications/webhook-notifier.md
@@ -9,7 +9,7 @@ keywords:
   - contact point
   - templating
 title: Configure the webhook notifier
-weight: 115
+weight: 1000
 ---
 
 ### Configure the webhook notifier


### PR DESCRIPTION
This pull request changes the navigation for **Manage your alert notifications** to match the order most users will need to follow:

- Alertmanager
- Manage your contact points
- Manage your notification policies
- Customize notifications
- Use images in notifications
- Manage silences
- Create mute timings
- View and filter by alert groups
- View notification errors
- Configure the webhook notifier (this needs to be made a sub-page of somewhere else)