### PR TITLE
Alerting: More idiomatic context for SignedInUser

### DIFF
--- a/pkg/services/ngalert/api/api_ruler.go
+++ b/pkg/services/ngalert/api/api_ruler.go
@@ -30,7 +30,7 @@ import (
 
 type ConditionValidator interface {
 	// Validate validates that the condition is correct. Returns nil if the condition is correct. Otherwise, error that describes the failure
-	Validate(ctx eval.EvaluationContext, condition ngmodels.Condition) error
+	Validate(ctx context.Context, condition ngmodels.Condition) error
 }
 
 type RulerSrv struct {
@@ -308,7 +308,7 @@ func (srv RulerSrv) RoutePostNameRulesConfig(c *models.ReqContext, ruleGroupConf
 	}
 
 	rules, err := validateRuleGroup(&ruleGroupConfig, c.SignedInUser.OrgID, namespace, func(condition ngmodels.Condition) error {
-		return srv.conditionValidator.Validate(eval.Context(c.Req.Context(), c.SignedInUser), condition)
+		return srv.conditionValidator.Validate(eval.NewSignedInUserContext(c.Req.Context(), c.SignedInUser), condition)
 	}, srv.cfg)
 	if err != nil {
 		return ErrResp(http.StatusBadRequest, err, "")

--- a/pkg/services/ngalert/api/api_testing.go
+++ b/pkg/services/ngalert/api/api_testing.go
@@ -50,7 +50,7 @@ func (srv TestingApiSrv) RouteTestGrafanaRuleConfig(c *models.ReqContext, body a
 		Condition: body.GrafanaManagedCondition.Condition,
 		Data:      body.GrafanaManagedCondition.Data,
 	}
-	ctx := eval.Context(c.Req.Context(), c.SignedInUser)
+	ctx := eval.NewSignedInUserContext(c.Req.Context(), c.SignedInUser)
 
 	conditionEval, err := srv.evaluator.Create(ctx, evalCond)
 	if err != nil {
@@ -125,7 +125,7 @@ func (srv TestingApiSrv) RouteEvalQueries(c *models.ReqContext, cmd apimodels.Ev
 	if len(cmd.Data) > 0 {
 		cond.Condition = cmd.Data[0].RefID
 	}
-	evaluator, err := srv.evaluator.Create(eval.Context(c.Req.Context(), c.SignedInUser), cond)
+	evaluator, err := srv.evaluator.Create(eval.NewSignedInUserContext(c.Req.Context(), c.SignedInUser), cond)
 
 	if err != nil {
 		return ErrResp(http.StatusBadRequest, err, "Failed to build evaluator for queries and expressions")

--- a/pkg/services/ngalert/backtesting/engine.go
+++ b/pkg/services/ngalert/backtesting/engine.go
@@ -137,9 +137,7 @@ func newBacktestingEvaluator(ctx context.Context, evalFactory eval.EvaluatorFact
 		}
 	}
 
-	evaluator, err := evalFactory.Create(eval.EvaluationContext{Ctx: ctx,
-		User: user,
-	}, condition)
+	evaluator, err := evalFactory.Create(eval.NewSignedInUserContext(ctx, user), condition)
 
 	if err != nil {
 		return nil, err

--- a/pkg/services/ngalert/eval/context.go
+++ b/pkg/services/ngalert/eval/context.go
@@ -6,15 +6,20 @@ import (
 	"github.com/grafana/grafana/pkg/services/user"
 )
 
-// EvaluationContext represents the context in which a condition is evaluated.
-type EvaluationContext struct {
-	Ctx  context.Context
-	User *user.SignedInUser
+var (
+	// signedInUserKey uniquely identifies the signed-in user in a context.Context
+	signedInUserKey = struct{}{}
+)
+
+// NewSignedInUserContext returns a new context.Context with the signed-in user
+func NewSignedInUserContext(ctx context.Context, user *user.SignedInUser) context.Context {
+	return context.WithValue(ctx, signedInUserKey, user)
 }
 
-func Context(ctx context.Context, user *user.SignedInUser) EvaluationContext {
-	return EvaluationContext{
-		Ctx:  ctx,
-		User: user,
+// GetSignedInUser returns the signed-in user or nil
+func GetSignedInUser(ctx context.Context) *user.SignedInUser {
+	if v := ctx.Value(signedInUserKey); v != nil {
+		return v.(*user.SignedInUser)
 	}
+	return nil
 }

--- a/pkg/services/ngalert/eval/eval_mocks/FakeFactory.go
+++ b/pkg/services/ngalert/eval/eval_mocks/FakeFactory.go
@@ -1,6 +1,7 @@
 package eval_mocks
 
 import (
+	"context"
 	"errors"
 
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
@@ -23,10 +24,10 @@ func NewFailingEvaluatorFactory(err error) eval.EvaluatorFactory {
 	return &fakeEvaluatorFactory{err: err}
 }
 
-func (f fakeEvaluatorFactory) Validate(ctx eval.EvaluationContext, condition models.Condition) error {
+func (f fakeEvaluatorFactory) Validate(ctx context.Context, condition models.Condition) error {
 	return f.err
 }
 
-func (f fakeEvaluatorFactory) Create(ctx eval.EvaluationContext, condition models.Condition) (eval.ConditionEvaluator, error) {
+func (f fakeEvaluatorFactory) Create(ctx context.Context, condition models.Condition) (eval.ConditionEvaluator, error) {
 	return f.evaluator, f.err
 }

--- a/pkg/services/ngalert/eval/eval_test.go
+++ b/pkg/services/ngalert/eval/eval_test.go
@@ -533,7 +533,7 @@ func TestValidate(t *testing.T) {
 			})
 
 			evaluator := NewEvaluatorFactory(setting.UnifiedAlertingSettings{}, cacheService, expr.ProvideService(&setting.Cfg{ExpressionsEnabled: true}, nil, nil), store)
-			evalCtx := Context(context.Background(), u)
+			evalCtx := NewSignedInUserContext(context.Background(), u)
 
 			err := evaluator.Validate(evalCtx, condition)
 			if testCase.error {

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -341,7 +341,7 @@ func (sch *schedule) ruleRoutine(grafanaCtx context.Context, key ngmodels.AlertR
 				},
 			},
 		}
-		evalCtx := eval.Context(ctx, schedulerUser)
+		evalCtx := eval.NewSignedInUserContext(ctx, schedulerUser)
 		ruleEval, err := sch.evaluatorFactory.Create(evalCtx, e.rule.GetEvalCondition())
 		var results eval.Results
 		var dur time.Duration


### PR DESCRIPTION
**What is this feature?**

This commit replaces `EvaluationContext` with a more Go idiomatic structure that uses `context.WithValue`. I think you could argue that this is more error-prone than what we had before, but I believe if we want `SignedInUser` to be in the context instead of being passed as its own argument then we should use `WithValue`.

[Add a brief description of what the feature or update does.]

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

