### PR TITLE
Chore: Automatically add crowdin PRs to User Essentials board

### DIFF
--- a/.github/commands.json
+++ b/.github/commands.json
@@ -314,5 +314,13 @@
     "addToProject": {
       "url": "https://github.com/orgs/grafana/projects/86"
     }
+  },
+  {
+    "type": "label",
+    "name": "area/internationalization",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/78"
+    }
   }
 ]


### PR DESCRIPTION
**What is this feature?**

Adds PRs with the `area/internationalization` label (typically from crowdin bot) to the [User Essentials project board](https://github.com/orgs/grafana/projects/78).

