### PR TITLE
Annotations: Fix EpochEnd being zero for Alert-generated annotations

### DIFF
--- a/pkg/services/annotations/annotationsimpl/xorm_store.go
+++ b/pkg/services/annotations/annotationsimpl/xorm_store.go
@@ -79,6 +79,8 @@ func (r *xormRepositoryImpl) AddMany(ctx context.Context, items []annotations.It
 	hasNoTags := make([]annotations.Item, 0)
 
 	for i := range items {
+		// The validation logic needs to work in terms of pointers.
+		// So, force everything else to work in terms of pointers too, to avoid any implicit extra copying.
 		item := &items[i]
 		tags := tag.ParseTagPairs(item.Tags)
 		item.Tags = tag.JoinTagPairs(tags)

--- a/pkg/services/annotations/annotationsimpl/xorm_store.go
+++ b/pkg/services/annotations/annotationsimpl/xorm_store.go
@@ -78,7 +78,7 @@ func (r *xormRepositoryImpl) AddMany(ctx context.Context, items []annotations.It
 	hasTags := make([]annotations.Item, 0)
 	hasNoTags := make([]annotations.Item, 0)
 
-	for i, item := range items {
+	for _, item := range items {
 		tags := tag.ParseTagPairs(item.Tags)
 		item.Tags = tag.JoinTagPairs(tags)
 		item.Created = timeNow().UnixNano() / int64(time.Millisecond)
@@ -86,7 +86,7 @@ func (r *xormRepositoryImpl) AddMany(ctx context.Context, items []annotations.It
 		if item.Epoch == 0 {
 			item.Epoch = item.Created
 		}
-		if err := r.validateItem(&items[i]); err != nil {
+		if err := r.validateItem(&item); err != nil {
 			return err
 		}
 

--- a/pkg/services/annotations/annotationsimpl/xorm_store.go
+++ b/pkg/services/annotations/annotationsimpl/xorm_store.go
@@ -78,7 +78,8 @@ func (r *xormRepositoryImpl) AddMany(ctx context.Context, items []annotations.It
 	hasTags := make([]annotations.Item, 0)
 	hasNoTags := make([]annotations.Item, 0)
 
-	for _, item := range items {
+	for i := range items {
+		item := &items[i]
 		tags := tag.ParseTagPairs(item.Tags)
 		item.Tags = tag.JoinTagPairs(tags)
 		item.Created = timeNow().UnixNano() / int64(time.Millisecond)
@@ -86,14 +87,14 @@ func (r *xormRepositoryImpl) AddMany(ctx context.Context, items []annotations.It
 		if item.Epoch == 0 {
 			item.Epoch = item.Created
 		}
-		if err := r.validateItem(&item); err != nil { // nolint:gosec
+		if err := r.validateItem(item); err != nil {
 			return err
 		}
 
 		if len(item.Tags) > 0 {
-			hasTags = append(hasTags, item)
+			hasTags = append(hasTags, *item)
 		} else {
-			hasNoTags = append(hasNoTags, item)
+			hasNoTags = append(hasNoTags, *item)
 		}
 	}
 

--- a/pkg/services/annotations/annotationsimpl/xorm_store.go
+++ b/pkg/services/annotations/annotationsimpl/xorm_store.go
@@ -86,7 +86,7 @@ func (r *xormRepositoryImpl) AddMany(ctx context.Context, items []annotations.It
 		if item.Epoch == 0 {
 			item.Epoch = item.Created
 		}
-		if err := r.validateItem(&item); err != nil {
+		if err := r.validateItem(&item); err != nil { // nolint:gosec
 			return err
 		}
 

--- a/pkg/services/annotations/annotationsimpl/xorm_store_test.go
+++ b/pkg/services/annotations/annotationsimpl/xorm_store_test.go
@@ -185,6 +185,11 @@ func TestIntegrationAnnotations(t *testing.T) {
 			inserted, err := repo.Get(context.Background(), query)
 			require.NoError(t, err)
 			assert.Len(t, inserted, count)
+			for _, ins := range inserted {
+				require.Equal(t, int64(12), ins.Time)
+				require.Equal(t, int64(12), ins.TimeEnd)
+				require.Equal(t, ins.Created, ins.Updated)
+			}
 		})
 
 		t.Run("Can batch-insert annotations with tags", func(t *testing.T) {


### PR DESCRIPTION
**What is this feature?**

Fixes a copy bug where `validateItem` needs to operate on a pointer, but other normalizations were working on an implicitly generated copy.

Note:

Simply doing `r.validateItem(&item)` also fixes this issue. However, the linter complains here, as it blindly errors any time we take the address of a loop variable, even though in reality it's safe to do in this context. The linter's suggested fix when this is done actually causes this bug to be re-introduced!

Working in terms of pointers not only sidesteps this issue by using a different memory address on each iteration, it also reduces a layer of copies, meaning fewer allocations overall.