### PR TITLE
I18N: Fail i18n:extract on warnings + update strings

### DIFF
--- a/packages/grafana-ui/src/utils/i18n.tsx
+++ b/packages/grafana-ui/src/utils/i18n.tsx
@@ -30,5 +30,8 @@ export const Trans: typeof I18NextTrans = (props) => {
 
 export const t = (id: string, defaultMessage: string, values?: Record<string, unknown>) => {
   initI18n();
-  return i18next.t(id, defaultMessage, values);
+
+  // Reassign t() so i18next-parser doesn't warn on dynamic key, and we can have 'failOnWarnings' enabled
+  const tFunc = i18next.t;
+  return tFunc(id, defaultMessage, values);
 };

--- a/packages/grafana-ui/src/utils/i18n.tsx
+++ b/packages/grafana-ui/src/utils/i18n.tsx
@@ -28,10 +28,11 @@ export const Trans: typeof I18NextTrans = (props) => {
   return <I18NextTrans {...props} />;
 };
 
+// Reassign t() so i18next-parser doesn't warn on dynamic key, and we can have 'failOnWarnings' enabled
+const tFunc = i18next.t;
+
 export const t = (id: string, defaultMessage: string, values?: Record<string, unknown>) => {
   initI18n();
 
-  // Reassign t() so i18next-parser doesn't warn on dynamic key, and we can have 'failOnWarnings' enabled
-  const tFunc = i18next.t;
   return tFunc(id, defaultMessage, values);
 };

--- a/public/app/core/internationalization/index.tsx
+++ b/public/app/core/internationalization/index.tsx
@@ -56,7 +56,9 @@ export const Trans: typeof I18NextTrans = (props) => {
 };
 
 export const t = (id: string, defaultMessage: string, values?: Record<string, unknown>) => {
-  return i18n.t(id, defaultMessage, values);
+  // Reassign t() so i18next-parser doesn't warn on dynamic key, and we can have 'failOnWarnings' enabled
+  const tFunc = i18n.t;
+  return tFunc(id, defaultMessage, values);
 };
 
 export const i18nDate = (value: number | Date | string, format: Intl.DateTimeFormatOptions = {}): string => {

--- a/public/app/core/internationalization/index.tsx
+++ b/public/app/core/internationalization/index.tsx
@@ -55,9 +55,10 @@ export const Trans: typeof I18NextTrans = (props) => {
   return <I18NextTrans {...props} />;
 };
 
+// Reassign t() so i18next-parser doesn't warn on dynamic key, and we can have 'failOnWarnings' enabled
+const tFunc = i18n.t;
+
 export const t = (id: string, defaultMessage: string, values?: Record<string, unknown>) => {
-  // Reassign t() so i18next-parser doesn't warn on dynamic key, and we can have 'failOnWarnings' enabled
-  const tFunc = i18n.t;
   return tFunc(id, defaultMessage, values);
 };
 

--- a/public/app/features/dashboard/containers/NewDashboardPage.tsx
+++ b/public/app/features/dashboard/containers/NewDashboardPage.tsx
@@ -32,7 +32,7 @@ export default function NewDashboardPage(props: GrafanaRouteComponentProps) {
       title={t('datasource-onboarding.welcome', 'Welcome to Grafana dashboards!')}
       CTAText={t('datasource-onboarding.sampleData', 'Or set up a new dashboard with sample data')}
       navId="dashboards/browse"
-      pageNav={{ text: t('dashboard', 'New dashboard'), url: '/dashboard/new' }}
+      pageNav={{ text: t('datasource-onboarding.new-dashboard', 'New dashboard'), url: '/dashboard/new' }}
     />
   );
 }

--- a/public/locales/de-DE/grafana.json
+++ b/public/locales/de-DE/grafana.json
@@ -80,6 +80,16 @@
       "unmark-favorite": "Markierung als Favorit entfernen"
     }
   },
+  "datasource-onboarding": {
+    "contact-admin": "",
+    "explanation": "",
+    "logo": "",
+    "new-dashboard": "",
+    "preferred": "",
+    "sampleData": "",
+    "viewAll": "",
+    "welcome": ""
+  },
   "folder-picker": {
     "loading": "Ordner werden geladen …"
   },
@@ -130,6 +140,9 @@
     "alerting-groups": {
       "subtitle": "Zeige gruppierte Warnungen vom Alertmanager an",
       "title": "Gruppen"
+    },
+    "alerting-home": {
+      "title": ""
     },
     "alerting-legacy": {
       "title": "Warnungen (Legacy)"
@@ -208,6 +221,7 @@
     "help/documentation": "Dokumentation",
     "help/keyboard-shortcuts": "Tastaturbefehle",
     "help/support": "Support",
+    "help/support-bundle": "",
     "home": {
       "title": "Home"
     },
@@ -297,6 +311,10 @@
     "storage": {
       "subtitle": "Dateispeicher verwalten",
       "title": "Speicher"
+    },
+    "support-bundles": {
+      "subtitle": "",
+      "title": ""
     },
     "teams": {
       "subtitle": "Gruppen von Benutzern mit gemeinsamen Dashboards und Benachrichtigungen",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -80,6 +80,16 @@
       "unmark-favorite": "Unmark as favorite"
     }
   },
+  "datasource-onboarding": {
+    "contact-admin": "Please contact your administrator to configure data sources.",
+    "explanation": "To visualize your data, you'll need to connect it first.",
+    "logo": "Logo for {{datasourceName}} data source",
+    "new-dashboard": "New dashboard",
+    "preferred": "Connect your preferred data source:",
+    "sampleData": "Or set up a new dashboard with sample data",
+    "viewAll": "View all",
+    "welcome": "Welcome to Grafana dashboards!"
+  },
   "folder-picker": {
     "loading": "Loading folders..."
   },
@@ -130,6 +140,9 @@
     "alerting-groups": {
       "subtitle": "See grouped alerts from an Alertmanager instance",
       "title": "Groups"
+    },
+    "alerting-home": {
+      "title": "Home"
     },
     "alerting-legacy": {
       "title": "Alerting (legacy)"
@@ -208,6 +221,7 @@
     "help/documentation": "Documentation",
     "help/keyboard-shortcuts": "Keyboard shortcuts",
     "help/support": "Support",
+    "help/support-bundle": "Support Bundles",
     "home": {
       "title": "Home"
     },
@@ -297,6 +311,10 @@
     "storage": {
       "subtitle": "Manage file storage",
       "title": "Storage"
+    },
+    "support-bundles": {
+      "subtitle": "Download support bundles",
+      "title": "Support Bundles"
     },
     "teams": {
       "subtitle": "Groups of users that have common dashboard and permission needs",

--- a/public/locales/es-ES/grafana.json
+++ b/public/locales/es-ES/grafana.json
@@ -80,6 +80,16 @@
       "unmark-favorite": "Deshacer marca como favorito"
     }
   },
+  "datasource-onboarding": {
+    "contact-admin": "",
+    "explanation": "",
+    "logo": "",
+    "new-dashboard": "",
+    "preferred": "",
+    "sampleData": "",
+    "viewAll": "",
+    "welcome": ""
+  },
   "folder-picker": {
     "loading": "Cargando carpetas..."
   },
@@ -130,6 +140,9 @@
     "alerting-groups": {
       "subtitle": "Ver alertas agrupadas de una instancia de Alertmanager",
       "title": "Grupos"
+    },
+    "alerting-home": {
+      "title": ""
     },
     "alerting-legacy": {
       "title": "Alertas (heredado)"
@@ -208,6 +221,7 @@
     "help/documentation": "Documentación",
     "help/keyboard-shortcuts": "Atajos de teclado",
     "help/support": "Asistencia",
+    "help/support-bundle": "",
     "home": {
       "title": "Inicio"
     },
@@ -297,6 +311,10 @@
     "storage": {
       "subtitle": "Gestionar el almacenamiento de archivos",
       "title": "Almacenamiento"
+    },
+    "support-bundles": {
+      "subtitle": "",
+      "title": ""
     },
     "teams": {
       "subtitle": "Grupos de usuarios que tienen necesidades comunes de permisos y de panel de control",

--- a/public/locales/fr-FR/grafana.json
+++ b/public/locales/fr-FR/grafana.json
@@ -80,6 +80,16 @@
       "unmark-favorite": "Supprimer des favoris"
     }
   },
+  "datasource-onboarding": {
+    "contact-admin": "",
+    "explanation": "",
+    "logo": "",
+    "new-dashboard": "",
+    "preferred": "",
+    "sampleData": "",
+    "viewAll": "",
+    "welcome": ""
+  },
   "folder-picker": {
     "loading": "Chargement des dossiers..."
   },
@@ -130,6 +140,9 @@
     "alerting-groups": {
       "subtitle": "Consulter les alertes groupées d'une instance Alertmanager",
       "title": "Groupes"
+    },
+    "alerting-home": {
+      "title": ""
     },
     "alerting-legacy": {
       "title": "Alerte (existante)"
@@ -208,6 +221,7 @@
     "help/documentation": "Documentation",
     "help/keyboard-shortcuts": "Raccourcis clavier",
     "help/support": "Assistance",
+    "help/support-bundle": "",
     "home": {
       "title": "Accueil"
     },
@@ -297,6 +311,10 @@
     "storage": {
       "subtitle": "Gérer le stockage de fichiers",
       "title": "Stockage"
+    },
+    "support-bundles": {
+      "subtitle": "",
+      "title": ""
     },
     "teams": {
       "subtitle": "Groupes d'utilisateurs ayant des besoins communs en matière de tableau de bord et d'autorisations",

--- a/public/locales/i18next-parser.config.js
+++ b/public/locales/i18next-parser.config.js
@@ -12,6 +12,10 @@ module.exports = {
 
   createOldCatalogs: false,
 
+  failOnWarnings: true,
+
+  verbose: false,
+
   // Don't include default values for English, they'll remain in the source code
   skipDefaultValues: (locale) => locale !== 'en-US',
 };

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -80,6 +80,16 @@
       "unmark-favorite": "Ůŉmäřĸ äş ƒävőřįŧę"
     }
   },
+  "datasource-onboarding": {
+    "contact-admin": "Pľęäşę čőŉŧäčŧ yőūř äđmįŉįşŧřäŧőř ŧő čőŉƒįģūřę đäŧä şőūřčęş.",
+    "explanation": "Ŧő vįşūäľįžę yőūř đäŧä, yőū'ľľ ŉęęđ ŧő čőŉŉęčŧ įŧ ƒįřşŧ.",
+    "logo": "Ŀőģő ƒőř {{datasourceName}} đäŧä şőūřčę",
+    "new-dashboard": "Ńęŵ đäşĥþőäřđ",
+    "preferred": "Cőŉŉęčŧ yőūř přęƒęřřęđ đäŧä şőūřčę:",
+    "sampleData": "Øř şęŧ ūp ä ŉęŵ đäşĥþőäřđ ŵįŧĥ şämpľę đäŧä",
+    "viewAll": "Vįęŵ äľľ",
+    "welcome": "Ŵęľčőmę ŧő Ğřäƒäŉä đäşĥþőäřđş!"
+  },
   "folder-picker": {
     "loading": "Ŀőäđįŉģ ƒőľđęřş..."
   },
@@ -130,6 +140,9 @@
     "alerting-groups": {
       "subtitle": "Ŝęę ģřőūpęđ äľęřŧş ƒřőm äŉ Åľęřŧmäŉäģęř įŉşŧäŉčę",
       "title": "Ğřőūpş"
+    },
+    "alerting-home": {
+      "title": "Ħőmę"
     },
     "alerting-legacy": {
       "title": "Åľęřŧįŉģ (ľęģäčy)"
@@ -208,6 +221,7 @@
     "help/documentation": "Đőčūmęŉŧäŧįőŉ",
     "help/keyboard-shortcuts": "Ķęyþőäřđ şĥőřŧčūŧş",
     "help/support": "Ŝūppőřŧ",
+    "help/support-bundle": "Ŝūppőřŧ ßūŉđľęş",
     "home": {
       "title": "Ħőmę"
     },
@@ -297,6 +311,10 @@
     "storage": {
       "subtitle": "Mäŉäģę ƒįľę şŧőřäģę",
       "title": "Ŝŧőřäģę"
+    },
+    "support-bundles": {
+      "subtitle": "Đőŵŉľőäđ şūppőřŧ þūŉđľęş",
+      "title": "Ŝūppőřŧ ßūŉđľęş"
     },
     "teams": {
       "subtitle": "Ğřőūpş őƒ ūşęřş ŧĥäŧ ĥävę čőmmőŉ đäşĥþőäřđ äŉđ pęřmįşşįőŉ ŉęęđş",

--- a/public/locales/zh-Hans/grafana.json
+++ b/public/locales/zh-Hans/grafana.json
@@ -80,6 +80,16 @@
       "unmark-favorite": "取消标记为收藏"
     }
   },
+  "datasource-onboarding": {
+    "contact-admin": "",
+    "explanation": "",
+    "logo": "",
+    "new-dashboard": "",
+    "preferred": "",
+    "sampleData": "",
+    "viewAll": "",
+    "welcome": ""
+  },
   "folder-picker": {
     "loading": "正在加载文件夹..."
   },
@@ -130,6 +140,9 @@
     "alerting-groups": {
       "subtitle": "查看来自 Alertmanager（警报管理器）实例的分组警报",
       "title": "组"
+    },
+    "alerting-home": {
+      "title": ""
     },
     "alerting-legacy": {
       "title": "警报（遗留）"
@@ -208,6 +221,7 @@
     "help/documentation": "文档",
     "help/keyboard-shortcuts": "快捷键",
     "help/support": "支持",
+    "help/support-bundle": "",
     "home": {
       "title": "首页"
     },
@@ -297,6 +311,10 @@
     "storage": {
       "subtitle": "管理文件存储",
       "title": "存储"
+    },
+    "support-bundles": {
+      "subtitle": "",
+      "title": ""
     },
     "teams": {
       "subtitle": "具有共同仪表板和权限需求的用户组",


### PR DESCRIPTION
**What is this feature?**

A string was added with the key `dashboard` which conflicts with all the other `dashboard.foo.bar` strings. At the moment this causes an easily ignorable error, which _removes_ other strings from the extracted JSON.

This PR makes i18next-parser fail on warnings so this will no longer be silently ignored.

Also fixes the string key to not conflict, and ensure everything is extracted.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

