### PR TITLE
SupportBundles: Improve UX

### DIFF
--- a/pkg/infra/supportbundles/supportbundlesimpl/store.go
+++ b/pkg/infra/supportbundles/supportbundlesimpl/store.go
@@ -113,7 +113,7 @@ func (s *store) List() ([]supportbundles.Bundle, error) {
 	}
 
 	sort.Slice(res, func(i, j int) bool {
-		return res[i].CreatedAt < res[j].CreatedAt
+		return res[i].CreatedAt > res[j].CreatedAt
 	})
 
 	return res, nil

--- a/public/app/features/support-bundles/SupportBundles.tsx
+++ b/public/app/features/support-bundles/SupportBundles.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import { useAsyncFn } from 'react-use';
 
 import { dateTimeFormat } from '@grafana/data';
-import { getBackendSrv } from '@grafana/runtime';
+import { config, getBackendSrv } from '@grafana/runtime';
 import { LinkButton } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 
@@ -11,6 +11,12 @@ const subTitle = (
     Support bundles allow you to easily collect and share Grafana logs, configuration, and data with the Grafana Labs
     team.
   </span>
+);
+
+const newButton = (
+  <LinkButton icon="plus" href="admin/support-bundles/create" variant="primary">
+    New Support Bundle
+  </LinkButton>
 );
 
 type SupportBundleState = 'complete' | 'error' | 'timeout' | 'pending';
@@ -34,17 +40,17 @@ function SupportBundles() {
     fetchBundles();
   }, [fetchBundles]);
 
+  const actions = config.featureToggles.topnav ? newButton : undefined;
+
   return (
-    <Page navId="support-bundles" subTitle={subTitle}>
+    <Page navId="support-bundles" subTitle={subTitle} actions={actions}>
       <Page.Contents isLoading={bundlesState.loading}>
-        <LinkButton href="admin/support-bundles/create" variant="primary">
-          Create New Support Bundle
-        </LinkButton>
+        {!config.featureToggles.topnav && newButton}
 
         <table className="filter-table form-inline">
           <thead>
             <tr>
-              <th>Date</th>
+              <th>Created on</th>
               <th>Requested by</th>
               <th>Expires</th>
               <th style={{ width: '1%' }} />
@@ -57,7 +63,12 @@ function SupportBundles() {
                 <th>{b.creator}</th>
                 <th>{dateTimeFormat(b.expiresAt * 1000)}</th>
                 <th>
-                  <LinkButton disabled={b.state !== 'complete'} target={'_self'} href={'/api/support-bundles/' + b.uid}>
+                  <LinkButton
+                    fill="outline"
+                    disabled={b.state !== 'complete'}
+                    target={'_self'}
+                    href={'/api/support-bundles/' + b.uid}
+                  >
                     Download
                   </LinkButton>
                 </th>

--- a/public/app/features/support-bundles/SupportBundlesCreate.tsx
+++ b/public/app/features/support-bundles/SupportBundlesCreate.tsx
@@ -25,6 +25,12 @@ const createSupportBundle = async (data: SupportBundleCreateRequest) => {
   return result;
 };
 
+const subTitle = (
+  <span>
+    Choose the components for the support bundle. The support bundle will be available for 3 days after creation.
+  </span>
+);
+
 export const SupportBundlesCreate = ({}: Props): JSX.Element => {
   const onSubmit = useCallback(async (data) => {
     try {
@@ -57,7 +63,7 @@ export const SupportBundlesCreate = ({}: Props): JSX.Element => {
   }, {});
 
   return (
-    <Page navId="support-bundles" pageNav={{ text: 'Create support bundle' }}>
+    <Page navId="support-bundles" pageNav={{ text: 'Create support bundle' }} subTitle={subTitle}>
       <Page.Contents>
         <Page.OldNavOnly>
           <h3 className="page-sub-heading">Create support bundle</h3>


### PR DESCRIPTION
Implement the easiest of @VesnaDean's feedback

>I would suggest to replace the primary “Download” buttons with an outlined version so that there aren’t many primary buttons on one page. (see screenshot)
When a new bundle is created, I would expect it to be at the top of the list instead of the bottom.
The “Date” column could be named “Created on”. The Expires column also has dates so it’s important to make that distinction.
 I would suggest removing the double header in the bundle creation view (see screenshot)
The “Create new support bundle” button could benefit from an icon and shorter text. We’re trying to standardise all the create buttons across Grafana and this idiom is what we’re leaning towards. (see screenshot)


![image](https://user-images.githubusercontent.com/8071073/210568956-f4ee4e6e-e844-4edc-bc5a-96a4a56f8199.png)

![image](https://user-images.githubusercontent.com/8071073/210568999-6b175ba8-29c9-4350-97e3-72aa7170d944.png)


