### PR TITLE
PanelRenderer: fix error when variable replacement is used

### DIFF
--- a/public/app/features/panel/components/PanelRenderer.tsx
+++ b/public/app/features/panel/components/PanelRenderer.tsx
@@ -33,7 +33,8 @@ export function PanelRenderer<P extends object = any, F extends object = any>(pr
   } = props;
 
   const theme = useTheme2();
-  const replace = useMemo(() => getTemplateSrv().replace, []);
+  const templateSrv = getTemplateSrv();
+  const replace = useMemo(() => templateSrv.replace.bind(templateSrv), [templateSrv]);
   const [plugin, setPlugin] = useState(syncGetPanelPlugin(pluginId));
   const [error, setError] = useState<string | undefined>();
   const optionsWithDefaults = useOptionDefaults(plugin, options, fieldConfig);


### PR DESCRIPTION
Fix PanelRenderer carsh if panel uses variable replacement. 

It was using unbound `templateSrv.replace` method which depends on `this`, causing "undefined does not have property regex" error on [this line](https://github.com/grafana/grafana/blob/main/public/app/features/templating/template_srv.ts#L295).

Fixed by binding `replace` to `templateSrv` before passing it along