### PR TITLE
RBAC: move RBAC + OnCall feature toggle to beta state

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -94,6 +94,7 @@ Alpha features might be changed or removed without prior notice.
 | `authnService`                     | Use new auth service to perform authentication                                                                                                                               |
 | `sessionRemoteCache`               | Enable using remote cache for user sessions                                                                                                                                  |
 | `alertingBacktesting`              | Rule backtesting API for alerting                                                                                                                                            |
+| `accessControlOnCall`              | Access control primitives for OnCall                                                                                                                                         |
 
 ## Development feature toggles
 
@@ -111,5 +112,4 @@ The following toggles require explicitly setting Grafana's [app mode]({{< relref
 | `grpcServer`                           | Run GRPC server                                                         |
 | `entityStore`                          | SQL-based entity store (requires storage flag also)                     |
 | `queryLibrary`                         | Reusable query library                                                  |
-| `accessControlOnCall`                  | Access control primitives for OnCall                                    |
 | `nestedFolders`                        | Enable folder nesting                                                   |

--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -44,6 +44,7 @@ Some stable features are enabled by default. You can disable a stable feature by
 | `validateDashboardsOnSave`        | Validate dashboard JSON POSTed to api/dashboards/db                             |
 | `autoMigrateGraphPanels`          | Replace the angular graph panel with timeseries                                 |
 | `datasourceLogger`                | Logs all datasource requests                                                    |
+| `accessControlOnCall`             | Access control primitives for OnCall                                            |
 
 ## Alpha feature toggles
 
@@ -94,7 +95,6 @@ Alpha features might be changed or removed without prior notice.
 | `authnService`                     | Use new auth service to perform authentication                                                                                                                               |
 | `sessionRemoteCache`               | Enable using remote cache for user sessions                                                                                                                                  |
 | `alertingBacktesting`              | Rule backtesting API for alerting                                                                                                                                            |
-| `accessControlOnCall`              | Access control primitives for OnCall                                                                                                                                         |
 
 ## Development feature toggles
 

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -353,10 +353,9 @@ var (
 			State:       FeatureStateBeta,
 		},
 		{
-			Name:            "accessControlOnCall",
-			Description:     "Access control primitives for OnCall",
-			State:           FeatureStateAlpha,
-			RequiresDevMode: true,
+			Name:        "accessControlOnCall",
+			Description: "Access control primitives for OnCall",
+			State:       FeatureStateBeta,
 		},
 		{
 			Name:            "nestedFolders",


### PR DESCRIPTION
**What is this feature?**

Moves `accessControlOnCall` to beta state, so that it no longer requires the instance to be a dev instance.

**Why do we need this feature?**

To test OnCall + RBAC PoC

