### PR TITLE
Docs: Unified Alerting is now compatible with AWS Aurora

### DIFF
--- a/docs/sources/setup-grafana/installation/_index.md
+++ b/docs/sources/setup-grafana/installation/_index.md
@@ -58,7 +58,6 @@ Grafana will support the versions of these databases that are officially support
 
 > **Note:** PostgreSQL versions 10.9, 11.4, and 12-beta2 are affected by a bug (tracked by the PostgreSQL project as [bug #15865](https://www.postgresql.org/message-id/flat/15865-17940eacc8f8b081%40postgresql.org)) which prevents those versions from being used with Grafana. The bug has been fixed in more recent versions of PostgreSQL.
 > Grafana can report errors when relying on read-only MySQL servers, such as in high-availability failover scenarios or serverless AWS Aurora MySQL. This is a known issue; for more information, see [issue #13399](https://github.com/grafana/grafana/issues/13399).
-> AWS Aurora MySQL is not compatible with Grafana Alerting, see [issue #54556](https://github.com/grafana/grafana/issues/54556).
 
 ## Supported web browsers
 


### PR DESCRIPTION
**What is this feature?**

We recently re-worked the piece that causes the incompatibility.

After testing, it seems this incompatibility no longer exists!
So, we can remove it from docs.
For details, see:
https://github.com/grafana/grafana/issues/54556#issuecomment-1370096897

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/54556

**Special notes for your reviewer**:

