### PR TITLE
Prometheus: Add query tracking

### DIFF
--- a/public/app/plugins/datasource/prometheus/datasource.tsx
+++ b/public/app/plugins/datasource/prometheus/datasource.tsx
@@ -779,7 +779,6 @@ export class PrometheusDatasource
     }
 
     const step = options.annotation.step || ANNOTATION_QUERY_STEP_DEFAULT;
-    // const maxDataPoints = window.innerWidth || document.documentElement.clientWidth || document.body.clientWidth;
     const queryModel = {
       expr,
       range: true,
@@ -788,7 +787,6 @@ export class PrometheusDatasource
       interval: step,
       refId: 'X',
       datasource: this.getRef(),
-      // maxDataPoints: maxDataPoints
     };
 
     return await lastValueFrom(

--- a/public/app/plugins/datasource/prometheus/datasource.tsx
+++ b/public/app/plugins/datasource/prometheus/datasource.tsx
@@ -51,6 +51,7 @@ import { renderLegendFormat } from './legend';
 import PrometheusMetricFindQuery from './metric_find_query';
 import { getInitHints, getQueryHints } from './query_hints';
 import { getOriginalMetricName, transform, transformV2 } from './result_transformer';
+import { trackQuery } from './tracking';
 import {
   ExemplarTraceIdDestination,
   PromDataErrorResponse,
@@ -440,14 +441,15 @@ export class PrometheusDatasource
   query(request: DataQueryRequest<PromQuery>): Observable<DataQueryResponse> {
     if (this.access === 'proxy') {
       const targets = request.targets.map((target) => this.processTargetV2(target, request));
-
-      return super
-        .query({ ...request, targets: targets.flat() })
-        .pipe(
-          map((response) =>
-            transformV2(response, request, { exemplarTraceIdDestinations: this.exemplarTraceIdDestinations })
-          )
-        );
+      const startTime = new Date();
+      return super.query({ ...request, targets: targets.flat() }).pipe(
+        map((response) =>
+          transformV2(response, request, { exemplarTraceIdDestinations: this.exemplarTraceIdDestinations })
+        ),
+        tap((response: DataQueryResponse) => {
+          trackQuery(response, request, startTime);
+        })
+      );
       // Run queries trough browser/proxy
     } else {
       const start = this.getPrometheusTime(request.range.from, false);
@@ -607,6 +609,7 @@ export class PrometheusDatasource
         ...this.getRangeScopedVars(options.range),
       });
     }
+
     query.step = interval;
 
     let expr = target.expr;
@@ -776,6 +779,7 @@ export class PrometheusDatasource
     }
 
     const step = options.annotation.step || ANNOTATION_QUERY_STEP_DEFAULT;
+    // const maxDataPoints = window.innerWidth || document.documentElement.clientWidth || document.body.clientWidth;
     const queryModel = {
       expr,
       range: true,
@@ -784,6 +788,7 @@ export class PrometheusDatasource
       interval: step,
       refId: 'X',
       datasource: this.getRef(),
+      // maxDataPoints: maxDataPoints
     };
 
     return await lastValueFrom(

--- a/public/app/plugins/datasource/prometheus/tracking.ts
+++ b/public/app/plugins/datasource/prometheus/tracking.ts
@@ -1,0 +1,46 @@
+import { CoreApp, DataQueryRequest, DataQueryResponse } from '@grafana/data';
+import { reportInteraction, config } from '@grafana/runtime';
+
+import { PromQuery } from './types';
+
+export function trackQuery(
+  response: DataQueryResponse,
+  request: DataQueryRequest<PromQuery> & { targets: PromQuery[] },
+  startTime: Date
+): void {
+  const { app, targets: queries } = request;
+  // We do want to track panel-editor and explore
+  // We do not want to track queries from the dashboard or viewing a panel
+  // also included in the tracking is cloud-alerting, unified-alerting, and unknown
+  if (app === CoreApp.Dashboard || app === CoreApp.PanelViewer) {
+    return;
+  }
+
+  for (const query of queries) {
+    reportInteraction('grafana_prometheus_query_executed', {
+      app,
+      grafana_version: config.buildInfo.version,
+      has_data: response.data.some((frame) => frame.length > 0),
+      has_error: response.error !== undefined,
+      expr: query.expr,
+      format: query.format,
+      instant: query.instant,
+      range: query.range,
+      exemplar: query.exemplar,
+      hinting: query.hinting,
+      interval: query.interval,
+      intervalFactor: query.intervalFactor,
+      utcOffsetSec: query.utcOffsetSec,
+      legend: query.legendFormat,
+      valueWithRefId: query.valueWithRefId,
+      requestId: query.requestId,
+      showingGraph: query.showingGraph,
+      showingTable: query.showingTable,
+      editor_mode: query.editorMode,
+      simultaneously_sent_query_count: queries.length,
+      time_range_from: request?.range?.from?.toISOString(),
+      time_range_to: request?.range?.to?.toISOString(),
+      time_taken: Date.now() - startTime.getTime(),
+    });
+  }
+}


### PR DESCRIPTION
**What is this feature?**
This feature uses feature tracking to gather data on prometheus queries.

**Why do we need this feature?**
This is part of G10 goals "Having a measurable impact" and "Getting started." By tracking queries we can use this to measure onboarding for prometheus by analyzing the length of time between creating a prometheus plugin instance, ["grafana_ds_add_datasource_clicked,"](https://github.com/grafana/grafana/blob/93345820229624889f4bcbc7c4ed34a543dd05a5/public/app/features/datasources/tracking.ts#L15-L17) and successfully running a prometheus query, "grafana_prometheus_query_executed."

**Who is this feature for?**
This feature is for the Observability Metrics Squad and Grafana as a whole for the G10 goals listed above.
