### PR TITLE
Alerting: only track events for survey if user is not new

### DIFF
--- a/public/app/features/alerting/unified/Analytics.test.ts
+++ b/public/app/features/alerting/unified/Analytics.test.ts
@@ -1,7 +1,7 @@
 import { dateTime } from '@grafana/data';
 import { getBackendSrv } from '@grafana/runtime';
 
-import { isNewUser } from './Analytics';
+import { isNewUser, USER_CREATION_MIN_DAYS } from './Analytics';
 
 jest.mock('@grafana/runtime', () => ({
   getBackendSrv: jest.fn().mockReturnValue({
@@ -17,26 +17,24 @@ describe('isNewUser', function () {
     };
 
     getBackendSrv().get = jest.fn().mockResolvedValue(newUser);
-    const getRequestSpy = jest.spyOn(getBackendSrv(), 'get');
 
     const isNew = await isNewUser(1);
     expect(isNew).toBe(true);
-    expect(getRequestSpy).toHaveBeenCalledTimes(1);
-    expect(getRequestSpy).toHaveBeenCalledWith('/api/users/1');
+    expect(getBackendSrv().get).toHaveBeenCalledTimes(1);
+    expect(getBackendSrv().get).toHaveBeenCalledWith('/api/users/1');
   });
 
   it('should return false if the user has been created prior to the last two weeks', async () => {
     const oldUser = {
       id: 2,
-      createdAt: dateTime().subtract(15, 'days'),
+      createdAt: dateTime().subtract(USER_CREATION_MIN_DAYS, 'days'),
     };
 
     getBackendSrv().get = jest.fn().mockResolvedValue(oldUser);
-    const getRequestSpy = jest.spyOn(getBackendSrv(), 'get');
 
     const isNew = await isNewUser(2);
     expect(isNew).toBe(false);
-    expect(getRequestSpy).toHaveBeenCalledTimes(1);
-    expect(getRequestSpy).toHaveBeenCalledWith('/api/users/2');
+    expect(getBackendSrv().get).toHaveBeenCalledTimes(1);
+    expect(getBackendSrv().get).toHaveBeenCalledWith('/api/users/2');
   });
 });

--- a/public/app/features/alerting/unified/Analytics.test.ts
+++ b/public/app/features/alerting/unified/Analytics.test.ts
@@ -1,0 +1,42 @@
+import { dateTime } from '@grafana/data';
+import { getBackendSrv } from '@grafana/runtime';
+
+import { isNewUser } from './Analytics';
+
+jest.mock('@grafana/runtime', () => ({
+  getBackendSrv: jest.fn().mockReturnValue({
+    get: jest.fn(),
+  }),
+}));
+
+describe('isNewUser', function () {
+  it('should return true if the user has been created within the last two weeks', async () => {
+    const newUser = {
+      id: 1,
+      createdAt: dateTime().subtract(14, 'days'),
+    };
+
+    getBackendSrv().get = jest.fn().mockResolvedValue(newUser);
+    const getRequestSpy = jest.spyOn(getBackendSrv(), 'get');
+
+    const isNew = await isNewUser(1);
+    expect(isNew).toBe(true);
+    expect(getRequestSpy).toHaveBeenCalledTimes(1);
+    expect(getRequestSpy).toHaveBeenCalledWith('/api/users/1');
+  });
+
+  it('should return false if the user has been created prior to the last two weeks', async () => {
+    const oldUser = {
+      id: 2,
+      createdAt: dateTime().subtract(15, 'days'),
+    };
+
+    getBackendSrv().get = jest.fn().mockResolvedValue(oldUser);
+    const getRequestSpy = jest.spyOn(getBackendSrv(), 'get');
+
+    const isNew = await isNewUser(2);
+    expect(isNew).toBe(false);
+    expect(getRequestSpy).toHaveBeenCalledTimes(1);
+    expect(getRequestSpy).toHaveBeenCalledWith('/api/users/2');
+  });
+});

--- a/public/app/features/alerting/unified/Analytics.ts
+++ b/public/app/features/alerting/unified/Analytics.ts
@@ -3,7 +3,7 @@ import { faro, LogLevel as GrafanaLogLevel } from '@grafana/faro-web-sdk';
 import { getBackendSrv } from '@grafana/runtime';
 import { config, reportInteraction } from '@grafana/runtime/src';
 
-const USER_CREATION_MIN_DAYS = 15;
+export const USER_CREATION_MIN_DAYS = 15;
 
 export const LogMessages = {
   filterByLabel: 'filtering alert instances by label',


### PR DESCRIPTION
**What is this feature?**

In order to show the Alerting Survey, we now make sure that the user has been created for more than 2 weeks.

**Why do we need this feature?**

Showing a survey for users that are new might not be effective and could be bothersome for users that are still trying to understand how things work.

**Who is this feature for?**

All users of Grafana Alerting.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/alerting-squad/issues/358



