### PR TITLE
Alerting: Allow state history to be disabled through configuration

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -958,6 +958,10 @@ upload_external_image_storage = false
 # For example: `disabled_labels=grafana_folder`
 disabled_labels =
 
+[unified_alerting.state_history]
+# Enable the state history functionality in Unified Alerting. The previous states of alert rules will be visible in panels and in the UI.
+enabled = true
+
 #################################### Alerting ############################
 [alerting]
 # Enable the legacy alerting sub-system and interface. If Unified Alerting is already enabled and you try to go back to legacy alerting, all data that is part of Unified Alerting will be deleted. When this configuration section and flag are not defined, the state is defined at runtime. See the documentation for more details.

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -200,8 +200,13 @@ func (ng *AlertNG) init() error {
 		AlertSender:          alertsRouter,
 	}
 
-	historian := historian.NewAnnotationHistorian(ng.annotationsRepo, ng.dashboardService)
-	stateManager := state.NewManager(ng.Metrics.GetStateMetrics(), appUrl, store, ng.imageService, clk, historian)
+	var history state.Historian
+	if ng.Cfg.UnifiedAlerting.StateHistory.Enabled {
+		history = historian.NewAnnotationHistorian(ng.annotationsRepo, ng.dashboardService)
+	} else {
+		history = historian.NewNopHistorian()
+	}
+	stateManager := state.NewManager(ng.Metrics.GetStateMetrics(), appUrl, store, ng.imageService, clk, history)
 	scheduler := schedule.NewScheduler(schedCfg, stateManager)
 
 	// if it is required to include folder title to the alerts, we need to subscribe to changes of alert title

--- a/pkg/services/ngalert/state/historian/noop.go
+++ b/pkg/services/ngalert/state/historian/noop.go
@@ -1,0 +1,18 @@
+package historian
+
+import (
+	"context"
+
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/services/ngalert/state"
+)
+
+// NoOpHistorian is a state.Historian that does nothing with the resulting data, to be used in contexts where history is not needed.
+type NoOpHistorian struct{}
+
+func NewNopHistorian() *NoOpHistorian {
+	return &NoOpHistorian{}
+}
+
+func (f *NoOpHistorian) RecordStatesAsync(ctx context.Context, _ *models.AlertRule, _ []state.StateTransition) {
+}

--- a/pkg/setting/setting_unified_alerting.go
+++ b/pkg/setting/setting_unified_alerting.go
@@ -58,6 +58,7 @@ const (
 	SchedulerBaseInterval = 10 * time.Second
 	// DefaultRuleEvaluationInterval indicates a default interval of for how long a rule should be evaluated to change state from Pending to Alerting
 	DefaultRuleEvaluationInterval = SchedulerBaseInterval * 6 // == 60 seconds
+	stateHistoryDefaultEnabled    = true
 )
 
 type UnifiedAlertingSettings struct {
@@ -83,6 +84,7 @@ type UnifiedAlertingSettings struct {
 	DefaultRuleEvaluationInterval time.Duration
 	Screenshots                   UnifiedAlertingScreenshotSettings
 	ReservedLabels                UnifiedAlertingReservedLabelSettings
+	StateHistory                  UnifiedAlertingStateHistorySettings
 }
 
 type UnifiedAlertingScreenshotSettings struct {
@@ -93,6 +95,10 @@ type UnifiedAlertingScreenshotSettings struct {
 
 type UnifiedAlertingReservedLabelSettings struct {
 	DisabledLabels map[string]struct{}
+}
+
+type UnifiedAlertingStateHistorySettings struct {
+	Enabled bool
 }
 
 // IsEnabled returns true if UnifiedAlertingSettings.Enabled is either nil or true.
@@ -293,6 +299,12 @@ func (cfg *Cfg) ReadUnifiedAlertingSettings(iniFile *ini.File) error {
 		uaCfgReservedLabels.DisabledLabels[label] = struct{}{}
 	}
 	uaCfg.ReservedLabels = uaCfgReservedLabels
+
+	stateHistory := iniFile.Section("unified_alerting.state_history")
+	uaCfgStateHistory := UnifiedAlertingStateHistorySettings{
+		Enabled: stateHistory.Key("enabled").MustBool(stateHistoryDefaultEnabled),
+	}
+	uaCfg.StateHistory = uaCfgStateHistory
 
 	cfg.UnifiedAlerting = uaCfg
 	return nil


### PR DESCRIPTION
**What is this feature?**

This PR adds a configuration flag section for future state history work.

It also adds an `enabled` flag. When this is false, state history will not be recorded.

**Why do we need this feature?**

Users who are experiencing database bottlenecks can now choose to disable state history, which will completely cut out a major source of database traffic. State history is not required for alerting to function.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/60930

**Special notes for your reviewer**:

We might also want to hide the button to view the state history in the UI, if state history is disabled. Will look into this in a future PR.
