### PR TITLE
CloudWatch: Add RDS dimension

### DIFF
--- a/pkg/tsdb/cloudwatch/constants/metrics.go
+++ b/pkg/tsdb/cloudwatch/constants/metrics.go
@@ -486,7 +486,7 @@ var NamespaceDimensionKeysMap = map[string][]string{
 	"AWS/PrivateLinkEndpoints":    {"Endpoint Type", "Service Name", "Subnet Id", "VPC Endpoint Id", "VPC Id"},
 	"AWS/PrivateLinkServices":     {"Az", "Load Balancer Arn", "Service Id", "VPC Endpoint Id"},
 	"AWS/Prometheus":              {"Reason", "RuleGroup", "Workspace"},
-	"AWS/RDS":                     {"DBClusterIdentifier", "DBInstanceIdentifier", "DatabaseClass", "DbClusterIdentifier", "EngineName", "ProxyName", "Role", "SourceRegion", "Target", "TargetGroup", "TargetRole"},
+	"AWS/RDS":                     {"DBClusterIdentifier", "DBInstanceIdentifier", "DatabaseClass", "DbClusterIdentifier", "EndpointName", "EngineName", "ProxyName", "Role", "SourceRegion", "Target", "TargetGroup", "TargetRole"},
 	"AWS/Redshift":                {"ClusterIdentifier", "NodeID", "service class", "stage", "latency", "wlmid"},
 	"AWS/Robomaker":               {"SimulationJobId"},
 	"AWS/Route53":                 {"HealthCheckId", "Region", "HostedZoneId"},


### PR DESCRIPTION
`EndpointName` RDS dimension is missing. Doc: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy.monitoring.html