### PR TITLE
Connections: Add redirect notice for datasources and plugins pages

### DIFF
--- a/public/app/features/connections/components/ConnectionsRedirectNotice/ConnectionsRedirectNotice.tsx
+++ b/public/app/features/connections/components/ConnectionsRedirectNotice/ConnectionsRedirectNotice.tsx
@@ -1,0 +1,54 @@
+import { css } from '@emotion/css';
+import React from 'react';
+
+import { GrafanaTheme2 } from '@grafana/data';
+import { Alert, LinkButton, useStyles2 } from '@grafana/ui';
+
+import { ROUTES } from '../../constants';
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  alert: css`
+  > div:nth-child(2) {
+    > div:last-child {
+      padding-top: 0;
+  `,
+  alertContent: css`
+    display: flex;
+    flex-direction: row;
+    padding: 0;
+    justify-content: space-between;
+  `,
+  alertParagraph: css`
+    margin: 0 ${theme.spacing(1)} 0 0;
+    line-height: ${theme.spacing(theme.components.height.md)};
+    color: ${theme.colors.text.primary};
+  `,
+});
+
+export enum DestinationPage {
+  dataSources = 'dataSources',
+  connectData = 'connectData',
+}
+
+const destinationLinks = {
+  [DestinationPage.dataSources]: ROUTES.DataSources,
+  [DestinationPage.connectData]: ROUTES.ConnectData,
+};
+
+export function ConnectionsRedirectNotice({ destinationPage }: { destinationPage: DestinationPage }) {
+  const styles = useStyles2(getStyles);
+
+  return (
+    <Alert severity="warning" title="" className={styles.alert}>
+      <div className={styles.alertContent}>
+        <p className={styles.alertParagraph}>
+          Data sources have a new home! You can discover new data sources or manage existing ones in the new Connections
+          section, accessible from the left-hand navigation, or click the button here.
+        </p>
+        <LinkButton icon="link" href={destinationLinks[destinationPage]}>
+          Connections
+        </LinkButton>
+      </div>
+    </Alert>
+  );
+}

--- a/public/app/features/connections/components/ConnectionsRedirectNotice/ConnectionsRedirectNotice.tsx
+++ b/public/app/features/connections/components/ConnectionsRedirectNotice/ConnectionsRedirectNotice.tsx
@@ -7,11 +7,6 @@ import { Alert, LinkButton, useStyles2 } from '@grafana/ui';
 import { ROUTES } from '../../constants';
 
 const getStyles = (theme: GrafanaTheme2) => ({
-  alert: css`
-  > div:nth-child(2) {
-    > div:last-child {
-      padding-top: 0;
-  `,
   alertContent: css`
     display: flex;
     flex-direction: row;
@@ -39,13 +34,13 @@ export function ConnectionsRedirectNotice({ destinationPage }: { destinationPage
   const styles = useStyles2(getStyles);
 
   return (
-    <Alert severity="warning" title="" className={styles.alert}>
+    <Alert severity="warning" title="Data sources have a new home!">
       <div className={styles.alertContent}>
         <p className={styles.alertParagraph}>
-          Data sources have a new home! You can discover new data sources or manage existing ones in the new Connections
-          section, accessible from the left-hand navigation, or click the button here.
+          You can discover new data sources or manage existing ones in the new Connections section, accessible from the
+          left-hand navigation, or click the button here.
         </p>
-        <LinkButton icon="link" href={destinationLinks[destinationPage]}>
+        <LinkButton aria-label="Link to Connections" icon="link" href={destinationLinks[destinationPage]}>
           Connections
         </LinkButton>
       </div>

--- a/public/app/features/connections/components/ConnectionsRedirectNotice/index.ts
+++ b/public/app/features/connections/components/ConnectionsRedirectNotice/index.ts
@@ -1,0 +1,1 @@
+export * from './ConnectionsRedirectNotice';

--- a/public/app/features/datasources/pages/DataSourcesListPage.tsx
+++ b/public/app/features/datasources/pages/DataSourcesListPage.tsx
@@ -2,6 +2,10 @@ import React from 'react';
 
 import { config } from '@grafana/runtime';
 import { Page } from 'app/core/components/Page/Page';
+import {
+  ConnectionsRedirectNotice,
+  DestinationPage,
+} from 'app/features/connections/components/ConnectionsRedirectNotice';
 
 import { DataSourceAddButton } from '../components/DataSourceAddButton';
 import { DataSourcesList } from '../components/DataSourcesList';
@@ -11,6 +15,9 @@ export function DataSourcesListPage() {
   return (
     <Page navId="datasources" actions={actions}>
       <Page.Contents>
+        {config.featureToggles.dataConnectionsConsole && (
+          <ConnectionsRedirectNotice destinationPage={DestinationPage.dataSources} />
+        )}
         <DataSourcesList />
       </Page.Contents>
     </Page>

--- a/public/app/features/plugins/admin/pages/Browse.tsx
+++ b/public/app/features/plugins/admin/pages/Browse.tsx
@@ -3,11 +3,15 @@ import React, { ReactElement } from 'react';
 import { useLocation } from 'react-router-dom';
 
 import { SelectableValue, GrafanaTheme2 } from '@grafana/data';
-import { locationSearchToObject } from '@grafana/runtime';
+import { config, locationSearchToObject } from '@grafana/runtime';
 import { LoadingPlaceholder, Select, RadioButtonGroup, useStyles2, Tooltip } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 import { GrafanaRouteComponentProps } from 'app/core/navigation/types';
 import { getNavModel } from 'app/core/selectors/navModel';
+import {
+  ConnectionsRedirectNotice,
+  DestinationPage,
+} from 'app/features/connections/components/ConnectionsRedirectNotice';
 import { useSelector } from 'app/types';
 
 import { HorizontalGroup } from '../components/HorizontalGroup';
@@ -66,6 +70,10 @@ export default function Browse({ route }: GrafanaRouteComponentProps): ReactElem
   return (
     <Page navModel={navModel}>
       <Page.Contents>
+        {config.featureToggles.dataConnectionsConsole && (filterByType === 'all' || filterByType === 'datasource') && (
+          <ConnectionsRedirectNotice destinationPage={DestinationPage.connectData} />
+        )}
+
         <HorizontalGroup wrap>
           <SearchField value={query} onSearch={onSearch} />
           <HorizontalGroup wrap className={styles.actionBar}>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Add a redirect banner to the Plugins page when "All" or "Data sources" filter is set and to the Data sources page. The "Connections" button redirects to the corresponding page depending on the origin page.

[Screencast from 2023-01-05 13-18-45.webm](https://user-images.githubusercontent.com/13637610/210778919-898aca5b-833e-4ee6-9be5-8e55a1df23ec.webm)

**UPDATE:** after [this commit](https://github.com/grafana/grafana/pull/61037/commits/244399730ee5c6d0f61522c92b7b5acb4d50de71) the banner looks like this:
![Screenshot from 2023-01-05 15-06-34](https://user-images.githubusercontent.com/13637610/210799018-b9d19c47-163d-4eab-979a-a5d81062c867.png)


**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes https://github.com/grafana/cloud-onboarding/issues/2886"

-->

Fixes https://github.com/grafana/cloud-onboarding/issues/2886

