### PR TITLE
Elasticsearch: Return error if invalid query

### DIFF
--- a/pkg/tests/api/elasticsearch/elasticsearch_test.go
+++ b/pkg/tests/api/elasticsearch/elasticsearch_test.go
@@ -77,6 +77,11 @@ func TestIntegrationElasticsearch(t *testing.T) {
 			"rawQuery":  "*",
 			"type":      "",
 			"timeField": "@timestamp",
+			"metrics": []interface{}{
+				map[string]interface{}{
+					"type": "logs",
+				},
+			},
 		})
 		buf1 := &bytes.Buffer{}
 		err = json.NewEncoder(buf1).Encode(dtos.MetricRequest{

--- a/pkg/tsdb/elasticsearch/time_series_query.go
+++ b/pkg/tsdb/elasticsearch/time_series_query.go
@@ -37,11 +37,8 @@ func (e *timeSeriesQuery) execute() (*backend.QueryDataResponse, error) {
 
 	from := e.dataQueries[0].TimeRange.From.UnixNano() / int64(time.Millisecond)
 	to := e.dataQueries[0].TimeRange.To.UnixNano() / int64(time.Millisecond)
-	result := backend.QueryDataResponse{
-		Responses: backend.Responses{},
-	}
 	for _, q := range queries {
-		if err := e.processQuery(q, ms, from, to, result); err != nil {
+		if err := e.processQuery(q, ms, from, to); err != nil {
 			return &backend.QueryDataResponse{}, err
 		}
 	}
@@ -59,8 +56,7 @@ func (e *timeSeriesQuery) execute() (*backend.QueryDataResponse, error) {
 	return parseResponse(res.Responses, queries)
 }
 
-func (e *timeSeriesQuery) processQuery(q *Query, ms *es.MultiSearchRequestBuilder, from, to int64,
-	result backend.QueryDataResponse) error {
+func (e *timeSeriesQuery) processQuery(q *Query, ms *es.MultiSearchRequestBuilder, from, to int64) error {
 	defaultTimeField := e.client.GetTimeField()
 
 	b := ms.Search(q.Interval)
@@ -72,10 +68,7 @@ func (e *timeSeriesQuery) processQuery(q *Query, ms *es.MultiSearchRequestBuilde
 	if len(q.BucketAggs) == 0 {
 		// If no aggregations, only document and logs queries are valid
 		if len(q.Metrics) == 0 || !(q.Metrics[0].Type == rawDataType || q.Metrics[0].Type == rawDocumentType || q.Metrics[0].Type == logsType) {
-			result.Responses[q.RefID] = backend.DataResponse{
-				Error: fmt.Errorf("invalid query, missing metrics and aggregations"),
-			}
-			return nil
+			return fmt.Errorf("invalid query, missing metrics and aggregations")
 		}
 
 		// Defaults for log and document queries

--- a/pkg/tsdb/elasticsearch/time_series_query_test.go
+++ b/pkg/tsdb/elasticsearch/time_series_query_test.go
@@ -1403,6 +1403,15 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 				"pre_tags":      []string{"@HIGHLIGHT@"},
 			})
 		})
+
+		t.Run("With invalid query should return error", (func(t *testing.T) {
+			c := newFakeClient()
+			_, err := executeTsdbQuery(c, `{
+				"timeField": "@timestamp",
+				"query": "foo",
+			}`, from, to)
+			require.Error(t, err)
+		}))
 	})
 }
 

--- a/pkg/tsdb/elasticsearch/time_series_query_test.go
+++ b/pkg/tsdb/elasticsearch/time_series_query_test.go
@@ -1316,7 +1316,9 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 			c := newFakeClient()
 			_, err := executeTsdbQuery(c, `{
 				"timeField": "@timestamp",
-				"query": "foo"
+				"query": "foo",
+				"bucketAggs": [],
+				"metrics": [{ "id": "1", "type": "raw_data", "settings": {}	}]
 			}`, from, to)
 			require.NoError(t, err)
 			sr := c.multisearchRequests[0].Requests[0]
@@ -1329,7 +1331,9 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 			c := newFakeClient()
 			_, err := executeTsdbQuery(c, `{
 				"timeField": "@timestamp",
-				"query": "foo"
+				"query": "foo",
+				"bucketAggs": [],
+				"metrics": [{ "id": "1", "type": "raw_data", "settings": {}	}]
 			}`, from, to)
 			require.NoError(t, err)
 			sr := c.multisearchRequests[0].Requests[0]


### PR DESCRIPTION
**What is this?**

Currently, if user writes invalid query , we don't return error. We just modify created `result`, but then this `result` is not used anywhere. This PR cleans this up and removes `result` as it was redundant and not used. Instead of that, we return this error. 

I would also like to highlight, that this should never happen as ES query builder does not let you create query without metrics or aggregations, if it is not log/raw data query. 