### PR TITLE
Alerting: Redo refactoring from reverted fix in #56812

### DIFF
--- a/pkg/expr/classic/evaluator.go
+++ b/pkg/expr/classic/evaluator.go
@@ -6,21 +6,42 @@ import (
 	"github.com/grafana/grafana/pkg/expr/mathexp"
 )
 
+type EvaluatorKind int
+
+const (
+	EvaluatorNoValue = iota
+	EvaluatorThreshold
+	EvaluatorRanged
+)
+
 type evaluator interface {
 	Eval(mathexp.Number) bool
+	Kind() EvaluatorKind
 }
 
 type noValueEvaluator struct{}
+
+func (noValueEvaluator) Kind() EvaluatorKind {
+	return EvaluatorNoValue
+}
 
 type thresholdEvaluator struct {
 	Type      string
 	Threshold float64
 }
 
+func (thresholdEvaluator) Kind() EvaluatorKind {
+	return EvaluatorThreshold
+}
+
 type rangedEvaluator struct {
 	Type  string
 	Lower float64
 	Upper float64
+}
+
+func (rangedEvaluator) Kind() EvaluatorKind {
+	return EvaluatorRanged
 }
 
 // newAlertEvaluator is a factory function for returning


### PR DESCRIPTION
**What is this feature?**

This pull request re-applies the refactoring of `ConditionsCmd` from a reverted fix https://github.com/grafana/grafana/pull/56812 for `mathexp.noData`. It does not add the fix, or tests for the fix, because those were added in https://github.com/grafana/grafana/pull/56816. We use the additional test coverage added in https://github.com/grafana/grafana/pull/56816 and https://github.com/grafana/grafana/pull/58650 to avoid the reoccurrence of regressions that caused us to revert https://github.com/grafana/grafana/pull/56812 the first time.

[Add a brief description of what the feature or update does.]

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

