### PR TITLE
Alerting: Add un-documented toggle for changing state history backend, add shells for remote loki and sql

### DIFF
--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -200,11 +200,9 @@ func (ng *AlertNG) init() error {
 		AlertSender:          alertsRouter,
 	}
 
-	var history state.Historian
-	if ng.Cfg.UnifiedAlerting.StateHistory.Enabled {
-		history = historian.NewAnnotationHistorian(ng.annotationsRepo, ng.dashboardService)
-	} else {
-		history = historian.NewNopHistorian()
+	history, err := configureHistorianBackend(ng.Cfg.UnifiedAlerting.StateHistory, ng.annotationsRepo, ng.dashboardService)
+	if err != nil {
+		return err
 	}
 	stateManager := state.NewManager(ng.Metrics.GetStateMetrics(), appUrl, store, ng.imageService, clk, history)
 	scheduler := schedule.NewScheduler(schedCfg, stateManager)
@@ -364,4 +362,22 @@ func readQuotaConfig(cfg *setting.Cfg) (*quota.Map, error) {
 	limits.Set(globalQuotaTag, alertGlobalQuota)
 	limits.Set(orgQuotaTag, alertOrgQuota)
 	return limits, nil
+}
+
+func configureHistorianBackend(cfg setting.UnifiedAlertingStateHistorySettings, ar annotations.Repository, ds dashboards.DashboardService) (state.Historian, error) {
+	if !cfg.Enabled {
+		return historian.NewNopHistorian(), nil
+	}
+
+	if cfg.Backend == "annotations" {
+		return historian.NewAnnotationBackend(ar, ds), nil
+	}
+	if cfg.Backend == "loki" {
+		return historian.NewRemoteLokiBackend(), nil
+	}
+	if cfg.Backend == "sql" {
+		return historian.NewSqlBackend(), nil
+	}
+
+	return nil, fmt.Errorf("unrecognized state history backend: %s", cfg.Backend)
 }

--- a/pkg/services/ngalert/state/historian/core.go
+++ b/pkg/services/ngalert/state/historian/core.go
@@ -1,0 +1,56 @@
+package historian
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/ngalert/eval"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/services/ngalert/state"
+)
+
+func shouldRecord(transition state.StateTransition) bool {
+	// Do not log not transitioned states normal states if it was marked as stale
+	if !transition.Changed() || transition.StateReason == models.StateReasonMissingSeries && transition.PreviousState == eval.Normal && transition.State.State == eval.Normal {
+		return false
+	}
+	return true
+}
+
+func removePrivateLabels(labels data.Labels) data.Labels {
+	result := make(data.Labels)
+	for k, v := range labels {
+		if !strings.HasPrefix(k, "__") && !strings.HasSuffix(k, "__") {
+			result[k] = v
+		}
+	}
+	return result
+}
+
+// panelKey uniquely identifies a panel.
+type panelKey struct {
+	orgID   int64
+	dashUID string
+	panelID int64
+}
+
+// panelKey attempts to get the key of the panel attached to the given rule. Returns nil if the rule is not attached to a panel.
+func parsePanelKey(rule *models.AlertRule, logger log.Logger) *panelKey {
+	dashUID, ok := rule.Annotations[models.DashboardUIDAnnotation]
+	if ok {
+		panelAnno := rule.Annotations[models.PanelIDAnnotation]
+		panelID, err := strconv.ParseInt(panelAnno, 10, 64)
+		if err != nil {
+			logger.Error("Error parsing panelUID for alert annotation", "actual", panelAnno, "error", err)
+			return nil
+		}
+		return &panelKey{
+			orgID:   rule.OrgID,
+			dashUID: dashUID,
+			panelID: panelID,
+		}
+	}
+	return nil
+}

--- a/pkg/services/ngalert/state/historian/loki.go
+++ b/pkg/services/ngalert/state/historian/loki.go
@@ -1,0 +1,22 @@
+package historian
+
+import (
+	"context"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/services/ngalert/state"
+)
+
+type RemoteLokiBackend struct {
+	log log.Logger
+}
+
+func NewRemoteLokiBackend() *RemoteLokiBackend {
+	return &RemoteLokiBackend{
+		log: log.New("ngalert.state.historian"),
+	}
+}
+
+func (h *RemoteLokiBackend) RecordStatesAsync(ctx context.Context, _ *models.AlertRule, _ []state.StateTransition) {
+}

--- a/pkg/services/ngalert/state/historian/sql.go
+++ b/pkg/services/ngalert/state/historian/sql.go
@@ -1,0 +1,22 @@
+package historian
+
+import (
+	"context"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/services/ngalert/state"
+)
+
+type SqlBackend struct {
+	log log.Logger
+}
+
+func NewSqlBackend() *SqlBackend {
+	return &SqlBackend{
+		log: log.New("ngalert.state.historian"),
+	}
+}
+
+func (h *SqlBackend) RecordStatesAsync(ctx context.Context, _ *models.AlertRule, _ []state.StateTransition) {
+}

--- a/pkg/services/ngalert/state/manager_test.go
+++ b/pkg/services/ngalert/state/manager_test.go
@@ -210,7 +210,7 @@ func TestDashboardAnnotations(t *testing.T) {
 	_, dbstore := tests.SetupTestEnv(t, 1)
 
 	fakeAnnoRepo := annotationstest.NewFakeAnnotationsRepo()
-	hist := historian.NewAnnotationHistorian(fakeAnnoRepo, &dashboards.FakeDashboardService{})
+	hist := historian.NewAnnotationBackend(fakeAnnoRepo, &dashboards.FakeDashboardService{})
 	st := state.NewManager(testMetrics.GetStateMetrics(), nil, dbstore, &state.NoopImageService{}, clock.New(), hist)
 
 	const mainOrgID int64 = 1
@@ -2191,7 +2191,7 @@ func TestProcessEvalResults(t *testing.T) {
 
 	for _, tc := range testCases {
 		fakeAnnoRepo := annotationstest.NewFakeAnnotationsRepo()
-		hist := historian.NewAnnotationHistorian(fakeAnnoRepo, &dashboards.FakeDashboardService{})
+		hist := historian.NewAnnotationBackend(fakeAnnoRepo, &dashboards.FakeDashboardService{})
 		st := state.NewManager(testMetrics.GetStateMetrics(), nil, &state.FakeInstanceStore{}, &state.NotAvailableImageService{}, clock.New(), hist)
 		t.Run(tc.desc, func(t *testing.T) {
 			for _, res := range tc.evalResults {

--- a/pkg/setting/setting_unified_alerting.go
+++ b/pkg/setting/setting_unified_alerting.go
@@ -102,6 +102,7 @@ type UnifiedAlertingReservedLabelSettings struct {
 
 type UnifiedAlertingStateHistorySettings struct {
 	Enabled bool
+	Backend string
 }
 
 // IsEnabled returns true if UnifiedAlertingSettings.Enabled is either nil or true.
@@ -313,6 +314,7 @@ func (cfg *Cfg) ReadUnifiedAlertingSettings(iniFile *ini.File) error {
 	stateHistory := iniFile.Section("unified_alerting.state_history")
 	uaCfgStateHistory := UnifiedAlertingStateHistorySettings{
 		Enabled: stateHistory.Key("enabled").MustBool(stateHistoryDefaultEnabled),
+		Backend: stateHistory.Key("backend").MustString("annotations"),
 	}
 	uaCfg.StateHistory = uaCfgStateHistory
 


### PR DESCRIPTION
**What is this feature?**

Adds a toggle for changing the state history backend to a different one.
Specifically avoid adding this to the documentation. This toggle will serve as our "feature flag."
The default is the current annotation-based backend.

Secondly, we add shells for the other backend types, which we can use in future PRs without having to repeatedly touch the configuration logic.

We also extract out some shared code among all the different backends, and write tests for it.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/52501

**Special notes for your reviewer**:

