### PR TITLE
Logs: Fix line not being selectable in Firefox

### DIFF
--- a/public/app/features/logs/components/LogRowMessage.tsx
+++ b/public/app/features/logs/components/LogRowMessage.tsx
@@ -86,6 +86,7 @@ const getStyles = (theme: GrafanaTheme2, showContextButton: boolean, isInDashboa
       letter-spacing: ${theme.typography.bodySmall.letterSpacing};
       text-align: left;
       padding: 0;
+      user-select: text;
     `,
   };
 };


### PR DESCRIPTION
**What is this feature?**

Since we improved a11y by using a button for the loglines, the text was not selectable in some browsers anymore. This is fixed by using the `user-select` CSS property.

**Special notes for your reviewer**:

- bug was only reproducible in Firefox
