### PR TITLE
GrafanaUI: Fix vercal slider handle positioning

### DIFF
--- a/packages/grafana-ui/src/components/Slider/styles.ts
+++ b/packages/grafana-ui/src/components/Slider/styles.ts
@@ -36,9 +36,6 @@ export const getStyles = stylesFactory((theme: GrafanaTheme2, isHorizontal: bool
       .rc-slider-mark-text-active {
         color: ${theme.colors.text.primary};
       }
-      .rc-slider-vertical .rc-slider-handle {
-        margin-top: -10px;
-      }
       .rc-slider-handle {
         border: none;
         background-color: ${handleColor};


### PR DESCRIPTION
Fixes vertical slider handle positioning having a negative top margin which resulted in the handles being offsetted from the track.

**Before**:
![Screenshot 2023-01-06 at 12 41 08](https://user-images.githubusercontent.com/1170767/211014473-d22d11dc-2138-441c-b2c8-3e046700208a.png)

**After**:
![Screenshot 2023-01-06 at 12 35 08](https://user-images.githubusercontent.com/1170767/211014521-477d34e0-3549-412f-9105-213b04448e79.png)


**Notes**:
I couldn't find any usage in Grafana of a vertical slider aside from Query History in Explore. Also it seems like the issue wasn't visible in storybook, i'm not sure why as i didn't investigate further.