### PR TITLE
Alerting: Add info to alert rule creation metric

### DIFF
--- a/public/app/features/alerting/unified/Analytics.ts
+++ b/public/app/features/alerting/unified/Analytics.ts
@@ -13,7 +13,7 @@ export const LogMessages = {
 };
 
 // logInfo from '@grafana/runtime' should be used, but it doesn't handle Grafana JS Agent and Sentry correctly
-export function logInfo(message: string, context: Record<string, string | number> = {}) {
+export function logInfo(message: string, context: Record<string, string | number | boolean> = {}) {
   if (config.grafanaJavascriptAgent.enabled) {
     faro.api.pushLog([message], {
       level: GrafanaLogLevel.INFO,

--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -484,7 +484,7 @@ export const saveRuleFormAction = createAsyncThunk(
             throw new Error('Unexpected rule form type');
           }
 
-          logInfo(LogMessages.successSavingAlertRule);
+          logInfo(LogMessages.successSavingAlertRule, { type, isNew: !existing });
 
           if (!existing) {
             trackNewAlerRuleFormSaved({


### PR DESCRIPTION
**What is this feature?**

When creating an alert rule, we log this information via Faro and it can be consumed from Loki. This PR adds extra info to the action of saving it: whether the rule is new and what type it is (either `grafana`, `cloud-alerting` or `cloud-recording`)

**Why do we need this feature?**

Having these metrics and information are useful in order to understand the success rate of alert creation.

**Who is this feature for?**

Grafana users.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/alerting-squad/issues/357


![image](https://user-images.githubusercontent.com/6271380/211074189-6bb5d1cd-04a2-49cc-92a3-335c090c94ec.png)
![image](https://user-images.githubusercontent.com/6271380/211074850-60e0ec24-d54f-426f-a0a1-5d56caede68b.png)


