### PR TITLE
Traces: Fix timestamp for database query traces

### DIFF
--- a/pkg/services/sqlstore/database_wrapper.go
+++ b/pkg/services/sqlstore/database_wrapper.go
@@ -10,13 +10,15 @@ import (
 
 	"github.com/gchaincl/sqlhooks"
 	"github.com/go-sql-driver/mysql"
-	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/infra/tracing"
-	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
 	"github.com/lib/pq"
 	"github.com/mattn/go-sqlite3"
 	"github.com/prometheus/client_golang/prometheus"
+	"go.opentelemetry.io/otel/trace"
 	"xorm.io/core"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/infra/tracing"
+	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
 )
 
 var (
@@ -95,7 +97,7 @@ func (h *databaseQueryWrapper) instrument(ctx context.Context, status string, qu
 
 	ctx = log.IncDBCallCounter(ctx)
 
-	_, span := h.tracer.Start(ctx, "database query")
+	_, span := h.tracer.Start(ctx, "database query", trace.WithTimestamp(begin))
 	defer span.End()
 
 	span.AddEvents([]string{"query", "status"}, []tracing.EventValue{{Str: query}, {Str: status}})


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Grafana support tracing of database queries. However, the trace span starts when the query is already executed and closed almost immediately. 

https://github.com/grafana/grafana/blob/862a6a2fa625100b690c5a48a9b12e7a7dd42041/pkg/services/sqlstore/database_wrapper.go#L98-L108

This makes span duration to be wrong:

<details><summary>Screenshot</summary>

![image](https://user-images.githubusercontent.com/25988953/211105065-e0afb9f1-ab75-452d-892f-a54428f612f9.png)

</details>

This PR updates the creation of the span and provides the actual query start timestamp


Related: https://github.com/grafana/grafana/pull/42674

Note: this fixes only OpenTelemetry mode. OpenTracing implementation does ignores the options