### PR TITLE
Alerting: Add client configuration for remote Loki historian backend and test connection

### DIFF
--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -387,7 +387,15 @@ func configureHistorianBackend(cfg setting.UnifiedAlertingStateHistorySettings, 
 		return historian.NewAnnotationBackend(ar, ds), nil
 	}
 	if cfg.Backend == "loki" {
-		return historian.NewRemoteLokiBackend(), nil
+		baseURL, err := url.Parse(cfg.LokiRemoteURL)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse remote loki URL: %w", err)
+		}
+		backend := historian.NewRemoteLokiBackend(baseURL)
+		if err := backend.TestConnection(); err != nil {
+			return nil, fmt.Errorf("failed to ping the remote loki historian: %w", err)
+		}
+		return backend, nil
 	}
 	if cfg.Backend == "sql" {
 		return historian.NewSqlBackend(), nil

--- a/pkg/services/ngalert/state/historian/loki.go
+++ b/pkg/services/ngalert/state/historian/loki.go
@@ -8,15 +8,28 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/state"
 )
 
+type remoteLokiClient interface {
+	ping() error
+}
+
 type RemoteLokiBackend struct {
-	log log.Logger
+	client remoteLokiClient
+	log    log.Logger
 }
 
 func NewRemoteLokiBackend() *RemoteLokiBackend {
+	logger := log.New("ngalert.state.historian", "backend", "loki")
 	return &RemoteLokiBackend{
-		log: log.New("ngalert.state.historian"),
+		client: newLokiClient(nil, logger),
+		log:    logger,
 	}
 }
 
+func (h *RemoteLokiBackend) TestConnection() error {
+	return h.client.ping()
+}
+
 func (h *RemoteLokiBackend) RecordStatesAsync(ctx context.Context, _ *models.AlertRule, _ []state.StateTransition) {
+	logger := h.log.FromContext(ctx)
+	logger.Debug("Remote Loki state history backend was called with states")
 }

--- a/pkg/services/ngalert/state/historian/loki.go
+++ b/pkg/services/ngalert/state/historian/loki.go
@@ -2,6 +2,7 @@ package historian
 
 import (
 	"context"
+	"net/url"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
@@ -17,10 +18,10 @@ type RemoteLokiBackend struct {
 	log    log.Logger
 }
 
-func NewRemoteLokiBackend() *RemoteLokiBackend {
+func NewRemoteLokiBackend(url *url.URL) *RemoteLokiBackend {
 	logger := log.New("ngalert.state.historian", "backend", "loki")
 	return &RemoteLokiBackend{
-		client: newLokiClient(nil, logger),
+		client: newLokiClient(url, logger),
 		log:    logger,
 	}
 }

--- a/pkg/services/ngalert/state/historian/loki_http.go
+++ b/pkg/services/ngalert/state/historian/loki_http.go
@@ -18,7 +18,7 @@ func newLokiClient(u *url.URL, logger log.Logger) *httpLokiClient {
 	return &httpLokiClient{
 		client: http.Client{},
 		url:    u,
-		log:    logger.New("backend", "loki"),
+		log:    logger.New("protocol", "http"),
 	}
 }
 

--- a/pkg/services/ngalert/state/historian/loki_http.go
+++ b/pkg/services/ngalert/state/historian/loki_http.go
@@ -1,0 +1,41 @@
+package historian
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+)
+
+type httpLokiClient struct {
+	client http.Client
+	url    *url.URL
+	log    log.Logger
+}
+
+func newLokiClient(u *url.URL, logger log.Logger) *httpLokiClient {
+	return &httpLokiClient{
+		client: http.Client{},
+		url:    u,
+		log:    logger.New("backend", "loki"),
+	}
+}
+
+func (c *httpLokiClient) ping() error {
+	uri := c.url.JoinPath("/loki/api/v1/status/buildinfo")
+	req, err := http.NewRequest(http.MethodGet, uri.String(), nil)
+	if err != nil {
+		return fmt.Errorf("error creating request: %w", err)
+	}
+
+	res, err := c.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("error sending request: %w", err)
+	}
+
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		return fmt.Errorf("request to the loki buildinfo endpoint returned a non-200 status code: %d", res.StatusCode)
+	}
+	return nil
+}

--- a/pkg/services/ngalert/state/historian/loki_http.go
+++ b/pkg/services/ngalert/state/historian/loki_http.go
@@ -30,9 +30,17 @@ func (c *httpLokiClient) ping() error {
 	}
 
 	res, err := c.client.Do(req)
+	if res != nil {
+		defer func() {
+			if err := res.Body.Close(); err != nil {
+				c.log.Warn("Failed to close response body", "err", err)
+			}
+		}()
+	}
 	if err != nil {
 		return fmt.Errorf("error sending request: %w", err)
 	}
+	defer res.Body.Close()
 
 	if res.StatusCode < 200 || res.StatusCode >= 300 {
 		return fmt.Errorf("request to the loki buildinfo endpoint returned a non-200 status code: %d", res.StatusCode)

--- a/pkg/services/ngalert/state/historian/loki_http.go
+++ b/pkg/services/ngalert/state/historian/loki_http.go
@@ -37,5 +37,6 @@ func (c *httpLokiClient) ping() error {
 	if res.StatusCode < 200 || res.StatusCode >= 300 {
 		return fmt.Errorf("request to the loki buildinfo endpoint returned a non-200 status code: %d", res.StatusCode)
 	}
+	c.log.Debug("Request to Loki buildinfo endpoint succeeded", "status", res.StatusCode)
 	return nil
 }

--- a/pkg/services/ngalert/state/historian/loki_http.go
+++ b/pkg/services/ngalert/state/historian/loki_http.go
@@ -4,9 +4,12 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 )
+
+const defaultClientTimeout = 30 * time.Second
 
 type httpLokiClient struct {
 	client http.Client
@@ -16,9 +19,11 @@ type httpLokiClient struct {
 
 func newLokiClient(u *url.URL, logger log.Logger) *httpLokiClient {
 	return &httpLokiClient{
-		client: http.Client{},
-		url:    u,
-		log:    logger.New("protocol", "http"),
+		client: http.Client{
+			Timeout: defaultClientTimeout,
+		},
+		url: u,
+		log: logger.New("protocol", "http"),
 	}
 }
 

--- a/pkg/services/ngalert/state/historian/loki_http.go
+++ b/pkg/services/ngalert/state/historian/loki_http.go
@@ -45,7 +45,6 @@ func (c *httpLokiClient) ping() error {
 	if err != nil {
 		return fmt.Errorf("error sending request: %w", err)
 	}
-	defer res.Body.Close()
 
 	if res.StatusCode < 200 || res.StatusCode >= 300 {
 		return fmt.Errorf("request to the loki buildinfo endpoint returned a non-200 status code: %d", res.StatusCode)

--- a/pkg/setting/setting_unified_alerting.go
+++ b/pkg/setting/setting_unified_alerting.go
@@ -101,8 +101,9 @@ type UnifiedAlertingReservedLabelSettings struct {
 }
 
 type UnifiedAlertingStateHistorySettings struct {
-	Enabled bool
-	Backend string
+	Enabled       bool
+	Backend       string
+	LokiRemoteURL string
 }
 
 // IsEnabled returns true if UnifiedAlertingSettings.Enabled is either nil or true.
@@ -313,8 +314,9 @@ func (cfg *Cfg) ReadUnifiedAlertingSettings(iniFile *ini.File) error {
 
 	stateHistory := iniFile.Section("unified_alerting.state_history")
 	uaCfgStateHistory := UnifiedAlertingStateHistorySettings{
-		Enabled: stateHistory.Key("enabled").MustBool(stateHistoryDefaultEnabled),
-		Backend: stateHistory.Key("backend").MustString("annotations"),
+		Enabled:       stateHistory.Key("enabled").MustBool(stateHistoryDefaultEnabled),
+		Backend:       stateHistory.Key("backend").MustString("annotations"),
+		LokiRemoteURL: stateHistory.Key("loki_remote_url").MustString(""),
 	}
 	uaCfg.StateHistory = uaCfgStateHistory
 


### PR DESCRIPTION
**What is this feature?**

This PR creates and allows configuration of a Loki client, to be used in the remote loki state historian backend.
We configure the client with a URL only (for now), and verify that we are able to communicate with Loki on startup.

As in the previous PR, the configuration options are intentionally not documented. We might break them in the future.

**Which issue(s) does this PR fix?**:

contrib https://github.com/grafana/grafana/issues/48359

**Special notes for your reviewer**:

