### PR TITLE
Traces: Create span when a new session is opened

### DIFF
--- a/pkg/services/sqlstore/session.go
+++ b/pkg/services/sqlstore/session.go
@@ -7,11 +7,13 @@ import (
 	"reflect"
 	"time"
 
+	"go.opentelemetry.io/otel/attribute"
 	"xorm.io/xorm"
 
 	"github.com/mattn/go-sqlite3"
 
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
 	"github.com/grafana/grafana/pkg/util/errutil"
 	"github.com/grafana/grafana/pkg/util/retryer"
@@ -36,7 +38,7 @@ func (sess *DBSession) PublishAfterCommit(msg interface{}) {
 	sess.events = append(sess.events, msg)
 }
 
-func startSessionOrUseExisting(ctx context.Context, engine *xorm.Engine, beginTran bool) (*DBSession, bool, error) {
+func startSessionOrUseExisting(ctx context.Context, engine *xorm.Engine, beginTran bool, tracer tracing.Tracer) (*DBSession, bool, tracing.Span, error) {
 	value := ctx.Value(ContextSessionKey{})
 	var sess *DBSession
 	sess, ok := value.(*DBSession)
@@ -45,20 +47,23 @@ func startSessionOrUseExisting(ctx context.Context, engine *xorm.Engine, beginTr
 		ctxLogger := sessionLogger.FromContext(ctx)
 		ctxLogger.Debug("reusing existing session", "transaction", sess.transactionOpen)
 		sess.Session = sess.Session.Context(ctx)
-		return sess, false, nil
+		return sess, false, nil, nil
 	}
 
+	tctx, span := tracer.Start(ctx, "open session")
+	span.SetAttributes("transaction", beginTran, attribute.Key("transaction").Bool(beginTran))
+
 	newSess := &DBSession{Session: engine.NewSession(), transactionOpen: beginTran}
+
 	if beginTran {
 		err := newSess.Begin()
 		if err != nil {
-			return nil, false, err
+			return nil, false, span, err
 		}
 	}
+	newSess.Session = newSess.Session.Context(tctx)
 
-	newSess.Session = newSess.Session.Context(ctx)
-
-	return newSess, true, nil
+	return newSess, true, span, nil
 }
 
 // WithDbSession calls the callback with the session in the context (if exists).
@@ -106,12 +111,17 @@ func (ss *SQLStore) retryOnLocks(ctx context.Context, callback DBTransactionFunc
 }
 
 func (ss *SQLStore) withDbSession(ctx context.Context, engine *xorm.Engine, callback DBTransactionFunc) error {
-	sess, isNew, err := startSessionOrUseExisting(ctx, engine, false)
+	sess, isNew, span, err := startSessionOrUseExisting(ctx, engine, false, ss.tracer)
 	if err != nil {
 		return err
 	}
 	if isNew {
-		defer sess.Close()
+		defer func() {
+			if span != nil {
+				span.End()
+			}
+			sess.Close()
+		}()
 	}
 	retry := 0
 	return retryer.Retry(ss.retryOnLocks(ctx, callback, sess, retry), ss.dbCfg.QueryRetries, time.Millisecond*time.Duration(10), time.Second)

--- a/pkg/services/sqlstore/transactions.go
+++ b/pkg/services/sqlstore/transactions.go
@@ -34,7 +34,7 @@ func (ss *SQLStore) inTransactionWithRetry(ctx context.Context, fn func(ctx cont
 }
 
 func (ss *SQLStore) inTransactionWithRetryCtx(ctx context.Context, engine *xorm.Engine, bus bus.Bus, callback DBTransactionFunc, retry int) error {
-	sess, isNew, err := startSessionOrUseExisting(ctx, engine, true)
+	sess, isNew, span, err := startSessionOrUseExisting(ctx, engine, true, ss.tracer)
 	if err != nil {
 		return err
 	}
@@ -45,7 +45,12 @@ func (ss *SQLStore) inTransactionWithRetryCtx(ctx context.Context, engine *xorm.
 	}
 
 	if isNew { // if this call initiated the session, it should be responsible for closing it.
-		defer sess.Close()
+		defer func() {
+			if span != nil {
+				span.End()
+			}
+			sess.Close()
+		}()
 	}
 
 	err = callback(sess)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
When I tested changes in https://github.com/grafana/grafana/pull/61109 I found serious difference between top-level spans and 
query execution spans (sometimes seconds). It turned out that in my tests the code was blocked on starting a new session. 

This PR adds a tracing span that records when the session is open and closed. This will make db operations more visible because real duration of the query does not indicate the time it took to get data from database. 


![image](https://user-images.githubusercontent.com/25988953/211127208-e9ae8b84-dd74-46b6-82dc-4c0a8e36c6c6.png)

for example, this trace is much useful because it shows that although query took 3.78ms, the real db access took more than 4.8s ! 
Also, it revealed some unnecessary session opening, which is fixed in https://github.com/grafana/grafana/pull/61117
