### PR TITLE
build: fix corss build

### DIFF
--- a/pkg/build/cmd.go
+++ b/pkg/build/cmd.go
@@ -146,6 +146,11 @@ func setup(goos string) {
 
 func doBuild(binaryName, pkg string, opts BuildOpts) error {
 	log.Println("building", binaryName, pkg)
+
+	if err := setBuildEnv(opts); err != nil {
+		return err
+	}
+	
 	libcPart := ""
 	if opts.libc != "" {
 		libcPart = fmt.Sprintf("-%s", opts.libc)
@@ -194,9 +199,6 @@ func doBuild(binaryName, pkg string, opts BuildOpts) error {
 		return nil
 	}
 
-	if err := setBuildEnv(opts); err != nil {
-		return err
-	}
 	runPrint("go", "version")
 	libcPart = ""
 	if opts.libc != "" {

--- a/pkg/build/cmd.go
+++ b/pkg/build/cmd.go
@@ -150,7 +150,7 @@ func doBuild(binaryName, pkg string, opts BuildOpts) error {
 	if err := setBuildEnv(opts); err != nil {
 		return err
 	}
-	
+
 	libcPart := ""
 	if opts.libc != "" {
 		libcPart = fmt.Sprintf("-%s", opts.libc)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**


**Why do we need this feature?**



**Who is this feature for?**



**Which issue(s) does this PR fix?**:

Fix corss build issue, `setBuildEnv` should be invoked before `runPrint`.

Before fix:

```
$ go run build.go --goos=darwin --goarch=amd64 build-server
Version: 9.4.0, Linux Version: 9.4.0, Package Iteration: 1673140414pre
rm -r dist
rm -r tmp
rm -r /Users/jimmiehan/go/pkg/darwin_amd64/github.com/grafana
building grafana-server ./pkg/cmd/grafana-server
rm -r ./bin/darwin-amd64/grafana-server
rm -r ./bin/darwin-amd64/grafana-server.md5
go build -ldflags -w -X main.version=9.4.0-pre -X main.commit=d44de7f20a -X main.buildstamp=1673058226 -X main.buildBranch=main -o ./bin/darwin-amd64/grafana-server ./pkg/cmd/grafana-server
go version
go version go1.19.1 darwin/arm64
Targeting darwin/amd64
```

```
$ file ./bin/darwin-amd64/grafana-server                                
./bin/darwin-amd64/grafana-server: Mach-O 64-bit executable arm64
```

After fix:

```
$ go run build.go --goos=darwin --goarch=amd64 build-server
Version: 9.4.0, Linux Version: 9.4.0, Package Iteration: 1673140473pre
rm -r dist
rm -r tmp
rm -r /Users/jimmiehan/go/pkg/darwin_amd64/github.com/grafana
building grafana-server ./pkg/cmd/grafana-server
rm -r ./bin/darwin-amd64/grafana-server
rm -r ./bin/darwin-amd64/grafana-server.md5
go build -ldflags -w -X main.version=9.4.0-pre -X main.commit=d1f213dcf2 -X main.buildstamp=1673097489 -X main.buildBranch=fix/jimmiehan-fix-cross-build -o ./bin/darwin-amd64/grafana-server ./pkg/cmd/grafana-server
go version
go version go1.19.1 darwin/arm64
Targeting darwin/amd64
```

```
$ file ./bin/darwin-amd64/grafana-server                   
./bin/darwin-amd64/grafana-server: Mach-O 64-bit executable x86_64
```
**Special notes for your reviewer**:

