### PR TITLE
Docs: Add source code url field description in publish a plugin documentation (#61080)

### DIFF
--- a/docs/sources/developers/plugins/package-a-plugin.md
+++ b/docs/sources/developers/plugins/package-a-plugin.md
@@ -66,7 +66,7 @@ To speed up the time it takes to review your plugin:
 
 ## Publishing your plugin for the first time
 
-{{< figure src="/static/img/docs/plugins/plugins-submission-create.png" class="docs-image--no-shadow" max-width="850px" >}}
+{{< figure src="/static/img/docs/plugins/plugins-submission-create2.png" class="docs-image--no-shadow" max-width="650px" >}}
 
 1. [Sign in](https://grafana.com/auth/sign-in) to your Grafana Cloud account.
 1. In the left menu, under **Org settings**, click **My Plugins**.
@@ -76,6 +76,7 @@ To speed up the time it takes to review your plugin:
      - Select **Single** if your plugin archive contains binaries for multiple architectures.
      - Select **Multiple** if you'd like to submit separate plugin archives for each architecture. This can lead to faster downloads since users can select the specific architecture on which they want to install the plugin.
    - **URL:** A URL that points to a ZIP archive of your packaged plugin.
+   - **Source Code URL:** A URL that points to a public git repository or ZIP archive of your complete plugin source code.
    - **MD5:** The MD5 hash of the plugin specified by the **URL**.
    - The remaining questions help us determine the [signature level](https://grafana.com/docs/grafana/latest/plugins/plugin-signatures/#plugin-signature-levels) for your plugin.
 1. Click **Submit**.
@@ -98,5 +99,6 @@ To submit an **update** for an already published plugin:
      - Select **Single** if your plugin archive contains binaries for multiple architectures.
      - Select **Multiple** if you'd like to submit separate plugin archives for each architecture. This can lead to faster downloads since users can select the specific architecture they want to install the plugin on.
    - **URL:** A URL that points to a ZIP archive of your packaged plugin.
+   - **Source Code URL:** A URL that points to a public git repository or ZIP archive of your complete plugin source code.
    - **MD5:** The MD5 hash of the plugin specified by the **URL**.
 1. Click **Submit**.


### PR DESCRIPTION
Backport for https://github.com/grafana/grafana/pull/61080
