### PR TITLE
Connections: Make "Connect data" a section title

### DIFF
--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -568,6 +568,19 @@ func (s *ServiceImpl) buildDataConnectionsNavLink(c *models.ReqContext) *navtree
 
 	baseUrl := s.cfg.AppSubURL + "/connections"
 
+	// Connect data
+	// FIXME: while we don't have a permissions for listing plugins the legacy check has to stay as a default
+	if plugins.ReqCanAdminPlugins(s.cfg)(c) || hasAccess(plugins.ReqCanAdminPlugins(s.cfg), plugins.AdminAccessEvaluator) {
+		children = append(children, &navtree.NavLink{
+			Id:        "connections-connect-data",
+			Text:      "Connect data",
+			SubTitle:  "Browse and create new connections",
+			IsSection: true,
+			Url:       s.cfg.AppSubURL + "/connections/connect-data",
+			Children:  []*navtree.NavLink{},
+		})
+	}
+
 	if hasAccess(ac.ReqOrgAdmin, datasources.ConfigurationPageAccess) {
 		// Your connections
 		children = append(children, &navtree.NavLink{
@@ -582,18 +595,6 @@ func (s *ServiceImpl) buildDataConnectionsNavLink(c *models.ReqContext) *navtree
 				SubTitle: "View and manage your connected data source connections",
 				Url:      baseUrl + "/your-connections/datasources",
 			}},
-		})
-	}
-
-	// Connect data
-	// FIXME: while we don't have a permissions for listing plugins the legacy check has to stay as a default
-	if plugins.ReqCanAdminPlugins(s.cfg)(c) || hasAccess(plugins.ReqCanAdminPlugins(s.cfg), plugins.AdminAccessEvaluator) {
-		children = append(children, &navtree.NavLink{
-			Id:       "connections-connect-data",
-			Text:     "Connect data",
-			SubTitle: "Browse and create new connections",
-			Url:      s.cfg.AppSubURL + "/connections/connect-data",
-			Children: []*navtree.NavLink{},
 		})
 	}
 

--- a/public/app/features/connections/Connections.test.tsx
+++ b/public/app/features/connections/Connections.test.tsx
@@ -41,13 +41,14 @@ describe('Connections', () => {
     (contextSrv.hasPermission as jest.Mock) = jest.fn().mockReturnValue(true);
   });
 
-  test('shows a landing page by default', async () => {
+  test('shows the "Connect data" page by default', async () => {
     renderPage();
 
-    expect(await screen.findByRole('link', { name: 'Your connections' })).toBeVisible();
-    expect(await screen.findByText('Manage your existing connections')).toBeVisible();
+    // Data sources group
+    expect(await screen.findByText('Data sources')).toBeVisible();
 
-    expect(await screen.findByRole('link', { name: 'Connect data' })).toBeVisible();
+    // Heading
+    expect(await screen.findByText('Connect data')).toBeVisible();
     expect(await screen.findByText('Browse and create new connections')).toBeVisible();
   });
 

--- a/public/app/features/connections/Connections.tsx
+++ b/public/app/features/connections/Connections.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Route, Switch } from 'react-router-dom';
+import { Redirect, Route, Switch } from 'react-router-dom';
 
 import { NavLandingPage } from 'app/core/components/AppChrome/NavLandingPage';
 import { DataSourcesRoutesContext } from 'app/features/datasources/state';
@@ -28,7 +28,7 @@ export default function Connections() {
       }}
     >
       <Switch>
-        <Route exact path={ROUTES.Base} component={() => <NavLandingPage navId="connections" />} />
+        <Route exact path={ROUTES.Base} component={() => <Redirect to={ROUTES.ConnectData} />} />
         <Route
           exact
           path={ROUTES.YourConnections}

--- a/public/app/features/connections/Connections.tsx
+++ b/public/app/features/connections/Connections.tsx
@@ -2,8 +2,9 @@ import * as React from 'react';
 import { Redirect, Route, Switch } from 'react-router-dom';
 
 import { NavLandingPage } from 'app/core/components/AppChrome/NavLandingPage';
+import { contextSrv } from 'app/core/core';
 import { DataSourcesRoutesContext } from 'app/features/datasources/state';
-import { StoreState, useSelector } from 'app/types';
+import { AccessControlAction, StoreState, useSelector } from 'app/types';
 
 import { ROUTES } from './constants';
 import {
@@ -17,6 +18,7 @@ import {
 export default function Connections() {
   const navIndex = useSelector((state: StoreState) => state.navIndex);
   const isConnectDataPageOverriden = Boolean(navIndex['standalone-plugin-page-/connections/connect-data']);
+  const canAdminPlugins = contextSrv.hasPermission(AccessControlAction.PluginsInstall);
 
   return (
     <DataSourcesRoutesContext.Provider
@@ -28,7 +30,17 @@ export default function Connections() {
       }}
     >
       <Switch>
-        <Route exact path={ROUTES.Base} component={() => <Redirect to={ROUTES.ConnectData} />} />
+        <Route
+          exact
+          path={ROUTES.Base}
+          component={() => {
+            if (canAdminPlugins) {
+              return <Redirect to={ROUTES.ConnectData} />;
+            }
+
+            return <Redirect to={ROUTES.DataSources} />;
+          }}
+        />
         <Route
           exact
           path={ROUTES.YourConnections}


### PR DESCRIPTION
**Related Slack discussions**
- https://raintank-corp.slack.com/archives/C034LMXLXQU/p1673252400307109
- https://raintank-corp.slack.com/archives/C034LMXLXQU/p1673252276920419

### What changed?
- [x] Make the "Connect data" menu item a section as well (it is on the same hierarchical level as "Your connections")
- [x] Move "Connect data" to the first place in the Connections section
- [x] Automatically redirect the user Connections -> Connect data (if they can manage plugins)
- [x] Automatically redirect Editors (or anyone who cannot manage plugins) to "Your connections"

<img width="1378" alt="Screenshot 2023-01-09 at 12 45 49" src="https://user-images.githubusercontent.com/9974811/211300962-d793303e-7a01-46c3-8784-793dbce09566.png">
