### PR TITLE
Add reference to Google OAuth docs

### DIFF
--- a/docs/sources/setup-grafana/configure-security/configure-authentication/google.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/google.md
@@ -52,3 +52,6 @@ You may allow users to sign-up via Google authentication by setting the
 `allow_sign_up` option to `true`. When this option is set to `true`, any
 user successfully authenticating via Google authentication will be
 automatically signed up.
+
+You may specify a domain to be passed as `hd` query parameter accepted by Google's
+OAuth 2.0 authentication API. Refer to Google's OAuth [documentation](https://developers.google.com/identity/openid-connect/openid-connect#hd-param).


### PR DESCRIPTION
**What is this feature?**

Adds missing reference to Google Oauth2.0 for hosted domains.

**Why do we need this feature?**

There was no reference for [auth.google] hosted_domain was used for.

**Backport PR**
https://github.com/grafana/grafana/pull/61048