### PR TITLE
Loki: Rename "explain" toggle to "explain query"

### DIFF
--- a/docs/sources/datasources/loki/query-editor/index.md
+++ b/docs/sources/datasources/loki/query-editor/index.md
@@ -125,9 +125,9 @@ To re-order operations manually, drag the operation box by its name and drop it 
 
 In same cases the query editor can detect which operations would be most appropriate for a selected log stream. In such cases it will show a hint next to the `+ Operations` button. Click on the hint to add the operations to your query.
 
-### Explain mode
+### Explain Query
 
-Explain mode helps with understanding the query. It shows a step by step explanation of all query parts and the operations.
+This section is only shown if the `Explain Query` switch from the query editor top toolbar is set to `on`. It shows a step by step explanation of all query parts and the operations.
 
 ### Raw query
 

--- a/docs/sources/datasources/loki/query-editor/index.md
+++ b/docs/sources/datasources/loki/query-editor/index.md
@@ -125,9 +125,9 @@ To re-order operations manually, drag the operation box by its name and drop it 
 
 In same cases the query editor can detect which operations would be most appropriate for a selected log stream. In such cases it will show a hint next to the `+ Operations` button. Click on the hint to add the operations to your query.
 
-### Explain Query
+### Explain query
 
-This section is only shown if the `Explain Query` switch from the query editor top toolbar is set to `on`. It shows a step by step explanation of all query parts and the operations.
+This section is only shown if the `Explain query` switch from the query editor top toolbar is set to `on`. It shows a step by step explanation of all query parts and the operations.
 
 ### Raw query
 

--- a/public/app/plugins/datasource/loki/components/LokiQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryEditor.test.tsx
@@ -107,7 +107,7 @@ describe('LokiQueryEditorSelector', () => {
   it('Can enable explain', async () => {
     renderWithMode(QueryEditorMode.Builder);
     expect(screen.queryByText(EXPLAIN_LABEL_FILTER_CONTENT)).not.toBeInTheDocument();
-    screen.getByLabelText('Explain').click();
+    screen.getByLabelText('Explain Query').click();
     expect(await screen.findByText(EXPLAIN_LABEL_FILTER_CONTENT)).toBeInTheDocument();
   });
 

--- a/public/app/plugins/datasource/loki/components/LokiQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryEditor.test.tsx
@@ -107,7 +107,7 @@ describe('LokiQueryEditorSelector', () => {
   it('Can enable explain', async () => {
     renderWithMode(QueryEditorMode.Builder);
     expect(screen.queryByText(EXPLAIN_LABEL_FILTER_CONTENT)).not.toBeInTheDocument();
-    screen.getByLabelText('Explain Query').click();
+    screen.getByLabelText('Explain query').click();
     expect(await screen.findByText(EXPLAIN_LABEL_FILTER_CONTENT)).toBeInTheDocument();
   });
 

--- a/public/app/plugins/datasource/loki/components/LokiQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryEditor.tsx
@@ -136,7 +136,7 @@ export const LokiQueryEditor = React.memo<LokiQueryEditorProps>((props) => {
             Label browser
           </Button>
         </Stack>
-        <QueryHeaderSwitch label="Explain Query" value={explain} onChange={onExplainChange} />
+        <QueryHeaderSwitch label="Explain query" value={explain} onChange={onExplainChange} />
         <FlexItem grow={1} />
         {app !== CoreApp.Explore && (
           <Button

--- a/public/app/plugins/datasource/loki/components/LokiQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryEditor.tsx
@@ -136,7 +136,7 @@ export const LokiQueryEditor = React.memo<LokiQueryEditorProps>((props) => {
             Label browser
           </Button>
         </Stack>
-        <QueryHeaderSwitch label="Explain" value={explain} onChange={onExplainChange} />
+        <QueryHeaderSwitch label="Explain Query" value={explain} onChange={onExplainChange} />
         <FlexItem grow={1} />
         {app !== CoreApp.Explore && (
           <Button


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
we are renaming the toggle to explain the query from `"explain"` to `"explain query"`

**Why do we need this feature?**
currently it can be a little confusing, what exactly will be explained if i toggle this on.
with this change it removes any ambiguity and clearly states what will be explained.

**Who is this feature for?**
...

**Which issue(s) does this PR fix?**:
Fixes #59222

**Special notes for your reviewer**:

