### PR TITLE
Connections: Update redirect alert message

### DIFF
--- a/packages/grafana-ui/src/components/Alert/Alert.tsx
+++ b/packages/grafana-ui/src/components/Alert/Alert.tsx
@@ -54,7 +54,7 @@ export const Alert = React.forwardRef<HTMLDivElement, Props>(
     ref
   ) => {
     const theme = useTheme2();
-    const hasTitle = title.length > 0;
+    const hasTitle = Boolean(title);
     const styles = getStyles(theme, severity, hasTitle, elevated, bottomSpacing, topSpacing);
     const titleId = useId();
 

--- a/packages/grafana-ui/src/components/Alert/Alert.tsx
+++ b/packages/grafana-ui/src/components/Alert/Alert.tsx
@@ -54,7 +54,8 @@ export const Alert = React.forwardRef<HTMLDivElement, Props>(
     ref
   ) => {
     const theme = useTheme2();
-    const styles = getStyles(theme, severity, elevated, bottomSpacing, topSpacing);
+    const hasTitle = title.length > 0;
+    const styles = getStyles(theme, severity, hasTitle, elevated, bottomSpacing, topSpacing);
     const titleId = useId();
 
     return (
@@ -101,6 +102,7 @@ Alert.displayName = 'Alert';
 const getStyles = (
   theme: GrafanaTheme2,
   severity: AlertVariant,
+  hasTitle: boolean,
   elevated?: boolean,
   bottomSpacing?: number,
   topSpacing?: number
@@ -157,7 +159,7 @@ const getStyles = (
     `,
     content: css`
       color: ${theme.colors.text.secondary};
-      padding-top: ${theme.spacing(1)};
+      padding-top: ${hasTitle ? theme.spacing(1) : 0};
       max-height: 50vh;
       overflow-y: auto;
     `,

--- a/public/app/features/connections/components/ConnectionsRedirectNotice/ConnectionsRedirectNotice.tsx
+++ b/public/app/features/connections/components/ConnectionsRedirectNotice/ConnectionsRedirectNotice.tsx
@@ -12,10 +12,11 @@ const getStyles = (theme: GrafanaTheme2) => ({
     flex-direction: row;
     padding: 0;
     justify-content: space-between;
+    align-items: center;
   `,
   alertParagraph: css`
     margin: 0 ${theme.spacing(1)} 0 0;
-    line-height: ${theme.spacing(theme.components.height.md)};
+    line-height: ${theme.spacing(theme.components.height.sm)};
     color: ${theme.colors.text.primary};
   `,
 });
@@ -34,14 +35,14 @@ export function ConnectionsRedirectNotice({ destinationPage }: { destinationPage
   const styles = useStyles2(getStyles);
 
   return (
-    <Alert severity="warning" title="Data sources have a new home!">
+    <Alert severity="warning" title="">
       <div className={styles.alertContent}>
         <p className={styles.alertParagraph}>
-          You can discover new data sources or manage existing ones in the new Connections section, accessible from the
-          left-hand navigation, or click the button here.
+          Data sources have a new home! You can discover new data sources or manage existing ones in the new Connections
+          page, accessible from the lefthand nav.
         </p>
-        <LinkButton aria-label="Link to Connections" icon="link" href={destinationLinks[destinationPage]}>
-          Connections
+        <LinkButton aria-label="Link to Connections" icon="adjust-circle" href={destinationLinks[destinationPage]}>
+          See data sources in Connections
         </LinkButton>
       </div>
     </Alert>


### PR DESCRIPTION
**Related issue:** https://github.com/grafana/cloud-onboarding/issues/2960
**Related conversation:** https://github.com/grafana/cloud-onboarding/issues/2886#issuecomment-1373749720

### What changed?
- [x] Update the message of the alert based on the [related conversation ](https://github.com/grafana/cloud-onboarding/issues/2886#issuecomment-1373749720)
- [x] UI/Alert - don't add top-padding to the content when there is no title set
- [x] Use the new icon for Connections

**Before - Large screen**
![Screenshot 2023-01-09 at 14 15 40](https://user-images.githubusercontent.com/9974811/211316648-d9101582-f2a3-402a-88e6-6a3468498ec5.png)

**After - Large screen**
![Screenshot 2023-01-09 at 13 54 08](https://user-images.githubusercontent.com/9974811/211314342-2e5f4309-329a-464b-a82f-8f49ff34f8d3.png)

**After - Smaller screen**
![Screenshot 2023-01-09 at 13 53 50](https://user-images.githubusercontent.com/9974811/211314345-537675a3-e8d8-4cb2-8ac1-46660e3f1c86.png)
