### PR TITLE
Fix: Use an existing Dockerfile for the Go image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 ARG BASE_IMAGE=alpine:3.15
 ARG JS_IMAGE=node:16-alpine3.15
-ARG GO_IMAGE=golang:1.19.4-alpine3.15
+ARG GO_IMAGE=golang:1.19.4-alpine3.17
 
 ARG GO_SRC=go-builder
 ARG JS_SRC=js-builder


### PR DESCRIPTION
**What is this misfeature?**

1.19.4 isn't defined for alpine 3.15, upgrading to 3.17 instead. That seem to work quite well.

**Who is this misfeature realignment for?**

Grafana developers using the Dockerfile in the root of the repository (n.b. this isn't what's used in prod, which is why this slipped through)

**Which issue(s) does this PR fix?**:

Fixes #61134 

**Special notes for your reviewer**:

