### PR TITLE
Logs: Add usage tracking to new download-logs button

### DIFF
--- a/public/app/features/explore/LogsMetaRow.tsx
+++ b/public/app/features/explore/LogsMetaRow.tsx
@@ -49,7 +49,7 @@ export const LogsMetaRow = React.memo(
       reportInteraction('grafana_logs_download_logs_clicked', {
         app: CoreApp.Explore,
         format: 'logs',
-        dimension: 'logs-meta-row',
+        area: 'logs-meta-row',
       });
       downloadLogsModelAsTxt({ meta, rows: logRows }, 'Explore');
     };

--- a/public/app/features/explore/LogsMetaRow.tsx
+++ b/public/app/features/explore/LogsMetaRow.tsx
@@ -1,7 +1,8 @@
 import { css } from '@emotion/css';
 import React from 'react';
 
-import { LogsDedupStrategy, LogsMetaItem, LogsMetaKind, LogRowModel } from '@grafana/data';
+import { LogsDedupStrategy, LogsMetaItem, LogsMetaKind, LogRowModel, CoreApp } from '@grafana/data';
+import { reportInteraction } from '@grafana/runtime';
 import { Button, ToolbarButton, Tooltip, useStyles2 } from '@grafana/ui';
 
 import { downloadLogsModelAsTxt } from '../inspector/utils/download';
@@ -45,6 +46,11 @@ export const LogsMetaRow = React.memo(
     const style = useStyles2(getStyles);
 
     const downloadLogs = () => {
+      reportInteraction('grafana_logs_download_logs_clicked', {
+        app: CoreApp.Explore,
+        format: 'logs',
+        dimension: 'logs-meta-row',
+      });
       downloadLogsModelAsTxt({ meta, rows: logRows }, 'Explore');
     };
 

--- a/public/app/features/inspector/InspectDataTab.tsx
+++ b/public/app/features/inspector/InspectDataTab.tsx
@@ -105,6 +105,7 @@ export class InspectDataTab extends PureComponent<Props, State> {
     reportInteraction('grafana_logs_download_logs_clicked', {
       app,
       format: 'logs',
+      area: 'inspector',
     });
 
     const logsModel = dataFrameToLogsModel(data || [], undefined);


### PR DESCRIPTION
**What is this feature?**

Adds tracking to new `Download logs" button

**Why do we need this feature?**

Compare to tracking of old download button.


