### PR TITLE
Loki Autocomplete: Improve handling of trailing spaces in queries

### DIFF
--- a/public/app/plugins/datasource/loki/components/monaco-query-field/MonacoQueryField.tsx
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/MonacoQueryField.tsx
@@ -75,6 +75,7 @@ const getStyles = (theme: GrafanaTheme2) => {
     container: css`
       border-radius: ${theme.shape.borderRadius()};
       border: 1px solid ${theme.components.input.borderColor};
+      width: 100%;
     `,
   };
 };
@@ -177,19 +178,18 @@ const MonacoQueryField = ({ history, onBlur, onRunQuery, initialValue, datasourc
           // (it will grow taller when necessary)
           // FIXME: maybe move this functionality into CodeEditor, like:
           // <CodeEditor resizingMode="single-line"/>
-          const updateElementHeight = () => {
+          const handleResize = () => {
             const containerDiv = containerRef.current;
             if (containerDiv !== null) {
               const pixelHeight = editor.getContentHeight();
               containerDiv.style.height = `${pixelHeight + EDITOR_HEIGHT_OFFSET}px`;
-              containerDiv.style.width = '100%';
               const pixelWidth = containerDiv.clientWidth;
               editor.layout({ width: pixelWidth, height: pixelHeight });
             }
           };
 
-          editor.onDidContentSizeChange(updateElementHeight);
-          updateElementHeight();
+          editor.onDidContentSizeChange(handleResize);
+          handleResize();
           // handle: shift + enter
           // FIXME: maybe move this functionality into CodeEditor?
           editor.addCommand(

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
@@ -248,7 +248,7 @@ async function getAfterSelectorCompletions(
     documentation: explainOperator(LokiOperationId.LabelFormat),
   });
 
-  // With an space between the pipe and the cursor, we omit line filters
+  // With a space between the pipe and the cursor, we omit line filters
   // E.g. `{label="value"} | `
   const lineFilters = afterPipe && hasSpace ? [] : getLineFilterCompletions(afterPipe);
 

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.test.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.test.ts
@@ -42,6 +42,7 @@ describe('situation', () => {
     assertSituation('{level="info"} ^', {
       type: 'AFTER_SELECTOR',
       afterPipe: false,
+      hasSpace: true,
       logQuery: '{level="info"}',
     });
 
@@ -54,18 +55,21 @@ describe('situation', () => {
     assertSituation('{level="info"} | json ^', {
       type: 'AFTER_SELECTOR',
       afterPipe: false,
+      hasSpace: true,
       logQuery: '{level="info"} | json',
     });
 
-    assertSituation('{level="info"} | json | ^', {
+    assertSituation('{level="info"} | json |^', {
       type: 'AFTER_SELECTOR',
       afterPipe: true,
+      hasSpace: false,
       logQuery: '{level="info"} | json |',
     });
 
     assertSituation('count_over_time({level="info"}^[10s])', {
       type: 'AFTER_SELECTOR',
       afterPipe: false,
+      hasSpace: false,
       logQuery: '{level="info"}',
     });
 
@@ -76,18 +80,21 @@ describe('situation', () => {
     assertSituation('count_over_time({level="info"}^)', {
       type: 'AFTER_SELECTOR',
       afterPipe: false,
+      hasSpace: false,
       logQuery: '{level="info"}',
     });
 
     assertSituation('{level="info"} |= "a" | logfmt ^', {
       type: 'AFTER_SELECTOR',
       afterPipe: false,
+      hasSpace: true,
       logQuery: '{level="info"} |= "a" | logfmt',
     });
 
     assertSituation('sum(count_over_time({place="luna"} | logfmt |^)) by (place)', {
       type: 'AFTER_SELECTOR',
       afterPipe: true,
+      hasSpace: false,
       logQuery: '{place="luna"}| logfmt |',
     });
   });

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.ts
@@ -119,6 +119,7 @@ export type Situation =
   | {
       type: 'AFTER_SELECTOR';
       afterPipe: boolean;
+      hasSpace: boolean;
       logQuery: string;
     }
   | {
@@ -450,6 +451,7 @@ function resolveLogOrLogRange(node: SyntaxNode, text: string, pos: number, after
   return {
     type: 'AFTER_SELECTOR',
     afterPipe,
+    hasSpace: text.endsWith(' '),
     logQuery: getLogQueryFromMetricsQuery(text).trim(),
   };
 }


### PR DESCRIPTION
These changes improve how we handle trailing spaces in queries. 

For example, there were situations where the user would trigger `AFTER_SELECTOR` suggestions `{label="value"} |` and added a space `{label="value"} | `, which produced extra spaces after selecting a suggestion `{label="value"} |  json`.

Additionally, when the user inputs a space after a pipe, we stop displaying line filter suggestions.

A minor change is included, to improve a callback function name, related with the recent https://github.com/grafana/grafana/pull/61061#issuecomment-1372555510

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana/issues/60233

**Special notes for your reviewer**:

Try different query combinations with and without trailing spaces. The inserted text after selecting a suggestion should produce a well formatted query.