### PR TITLE
Navigation: Add Cancel button to Import dashboard page

### DIFF
--- a/public/app/features/manage-dashboards/DashboardImportPage.tsx
+++ b/public/app/features/manage-dashboards/DashboardImportPage.tsx
@@ -4,7 +4,7 @@ import { connect, ConnectedProps } from 'react-redux';
 
 import { AppEvents, GrafanaTheme2, LoadingState, NavModelItem } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
-import { reportInteraction } from '@grafana/runtime';
+import { config, reportInteraction } from '@grafana/runtime';
 import {
   Button,
   Field,
@@ -20,6 +20,7 @@ import {
   withTheme2,
   DropzoneFile,
   FileDropzoneDefaultChildren,
+  LinkButton,
 } from '@grafana/ui';
 import appEvents from 'app/core/app_events';
 import { Page } from 'app/core/components/Page/Page';
@@ -172,9 +173,14 @@ class UnthemedDashboardImport extends PureComponent<Props> {
                     rows={10}
                   />
                 </Field>
-                <Button type="submit" data-testid={selectors.components.DashboardImportPage.submit}>
-                  Load
-                </Button>
+                <HorizontalGroup>
+                  <Button type="submit" data-testid={selectors.components.DashboardImportPage.submit}>
+                    Load
+                  </Button>
+                  <LinkButton variant="secondary" href={`${config.appSubUrl}/dashboards`}>
+                    Cancel
+                  </LinkButton>
+                </HorizontalGroup>
               </>
             )}
           </Form>


### PR DESCRIPTION
**What is this feature?**

Adds a cancel button to the bottom of the "Import dashboard" page

<img width="677" alt="Screenshot 2023-01-09 at 16 57 35" src="https://user-images.githubusercontent.com/100691367/211364633-05b8af72-c6d9-4c5a-ae69-e9d438167034.png">

**Why do we need this feature?**

So a user can get out of this form easily without having to navigate away

**Who is this feature for?**

Users who import dashboards

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #60960

**Special notes for your reviewer**:

