### PR TITLE
Navigation: Add Cancel button to New folder page

### DIFF
--- a/public/app/features/folders/components/NewDashboardsFolder.tsx
+++ b/public/app/features/folders/components/NewDashboardsFolder.tsx
@@ -3,7 +3,7 @@ import { connect, ConnectedProps } from 'react-redux';
 
 import { NavModelItem } from '@grafana/data';
 import { config } from '@grafana/runtime';
-import { Button, Input, Form, Field } from '@grafana/ui';
+import { Button, Input, Form, Field, HorizontalGroup, LinkButton } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 import { useQueryParams } from 'app/core/hooks/useQueryParams';
 
@@ -71,7 +71,12 @@ function NewDashboardsFolder({ createNewFolder }: Props) {
                   })}
                 />
               </Field>
-              <Button type="submit">Create</Button>
+              <HorizontalGroup>
+                <Button type="submit">Create</Button>
+                <LinkButton variant="secondary" href={`${config.appSubUrl}/dashboards`}>
+                  Cancel
+                </LinkButton>
+              </HorizontalGroup>
             </>
           )}
         </Form>


### PR DESCRIPTION
**What is this feature?**

Adds a cancel button next to the "Create" button in the "Create a new folder" page.

<img width="651" alt="Screenshot 2023-01-09 at 17 28 07" src="https://user-images.githubusercontent.com/100691367/211369955-6dac9872-e9f4-49c9-959e-0bf373144a87.png">

**Why do we need this feature?**

So a user can get out of this form easily without having to navigate away

**Who is this feature for?**

Everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #60959 

**Special notes for your reviewer**:

