### PR TITLE
Alerting: Scheduler to call DeleteAlertRule once when it stops deleted rules

### DIFF
--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -305,10 +305,11 @@ func (sch *schedule) processTick(ctx context.Context, dispatcherGroup *errgroup.
 	}
 
 	// unregister and stop routines of the deleted alert rules
+	toDelete := make([]ngmodels.AlertRuleKey, 0, len(registeredDefinitions))
 	for key := range registeredDefinitions {
-		sch.DeleteAlertRule(key)
+		toDelete = append(toDelete, key)
 	}
-
+	sch.DeleteAlertRule(toDelete...)
 	return readyToRun, registeredDefinitions
 }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Currently, when a user deletes alert rules, the scheduler will notice it in up to 10 seconds (if Grafana is in HA mode, or when rules are deleted via provisioning API), at the end of the `processTick` it will call DeleteAlertRule for each of rules that were detected as deleted. At the end of that method we update metrics. This PR just makes scheduler call that method once and provide all rules to stop. 

Note: this does not change how Grafana works in standalone mode when rules are deleted via regular API (e.g. UI)

