### PR TITLE
Alerting: change context parameter type

### DIFF
--- a/public/app/features/alerting/unified/Analytics.ts
+++ b/public/app/features/alerting/unified/Analytics.ts
@@ -17,7 +17,7 @@ export const LogMessages = {
 };
 
 // logInfo from '@grafana/runtime' should be used, but it doesn't handle Grafana JS Agent and Sentry correctly
-export function logInfo(message: string, context: Record<string, string | number | boolean> = {}) {
+export function logInfo(message: string, context: Record<string, string | number> = {}) {
   if (config.grafanaJavascriptAgent.enabled) {
     faro.api.pushLog([message], {
       level: GrafanaLogLevel.INFO,

--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -484,7 +484,7 @@ export const saveRuleFormAction = createAsyncThunk(
             throw new Error('Unexpected rule form type');
           }
 
-          logInfo(LogMessages.successSavingAlertRule, { type, isNew: !existing });
+          logInfo(LogMessages.successSavingAlertRule, { type, isNew: (!existing).toString() });
 
           if (!existing) {
             trackNewAlerRuleFormSaved({


### PR DESCRIPTION
**What is this feature?**

Small fix after https://github.com/grafana/grafana/pull/61105. Changes the `isNew` value type from boolean to string as the Faro API doesn't accept boolean types for the entries of the context object when pushing logs. 

**Why do we need this feature?**

Without this, the tracking of successfully created alert rules will fail.

![image](https://user-images.githubusercontent.com/6271380/211410696-a8b14b5c-a47d-4343-bd73-c30eef1ec048.png)

