### PR TITLE
Tracing: Support multiple OTel propagators

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -1752,7 +1752,7 @@ The host:port destination for reporting spans. (ex: `localhost:14268/api/traces`
 
 ### propagation
 
-The propagation specifies the text map propagation format.(ex: jaeger, w3c)
+The propagation specifies the text map propagation format. The values `jaeger` and `w3c` are supported. Specify multiple values separated by a comma (`,`) to support multiple formats (like `"jaeger,w3c"`). Defaults to `w3c`.
 
 <hr>
 
@@ -1766,7 +1766,7 @@ The host:port destination for reporting spans. (ex: `localhost:4317`)
 
 ### propagation
 
-The propagation specifies the text map propagation format.(ex: jaeger, w3c)
+The propagation specifies the text map propagation format. The values `jaeger` and `w3c` are supported. Specify multiple values separated by a comma (`,`) to support multiple formats (like `"jaeger,w3c"`). Defaults to `w3c`.
 
 <hr>
 

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -1752,7 +1752,7 @@ The host:port destination for reporting spans. (ex: `localhost:14268/api/traces`
 
 ### propagation
 
-The propagation specifies the text map propagation format. The values `jaeger` and `w3c` are supported. Specify multiple values separated by a comma (`,`) to support multiple formats (like `"jaeger,w3c"`). Defaults to `w3c`.
+The propagation specifies the text map propagation format. The values `jaeger` and `w3c` are supported. Add a comma (`,`) between values to specify multiple formats (for example,  `"jaeger,w3c"`). The default value is `w3c`.
 
 <hr>
 
@@ -1766,7 +1766,7 @@ The host:port destination for reporting spans. (ex: `localhost:4317`)
 
 ### propagation
 
-The propagation specifies the text map propagation format. The values `jaeger` and `w3c` are supported. Specify multiple values separated by a comma (`,`) to support multiple formats (like `"jaeger,w3c"`). Defaults to `w3c`.
+The propagation specifies the text map propagation format. The values `jaeger` and `w3c` are supported. Add a comma (`,`) between values to specify multiple formats (for example,  `"jaeger,w3c"`). The default value is `w3c`.
 
 <hr>
 

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -1752,7 +1752,7 @@ The host:port destination for reporting spans. (ex: `localhost:14268/api/traces`
 
 ### propagation
 
-The propagation specifies the text map propagation format. The values `jaeger` and `w3c` are supported. Add a comma (`,`) between values to specify multiple formats (for example,  `"jaeger,w3c"`). The default value is `w3c`.
+The propagation specifies the text map propagation format. The values `jaeger` and `w3c` are supported. Add a comma (`,`) between values to specify multiple formats (for example, `"jaeger,w3c"`). The default value is `w3c`.
 
 <hr>
 
@@ -1766,7 +1766,7 @@ The host:port destination for reporting spans. (ex: `localhost:4317`)
 
 ### propagation
 
-The propagation specifies the text map propagation format. The values `jaeger` and `w3c` are supported. Add a comma (`,`) between values to specify multiple formats (for example,  `"jaeger,w3c"`). The default value is `w3c`.
+The propagation specifies the text map propagation format. The values `jaeger` and `w3c` are supported. Add a comma (`,`) between values to specify multiple formats (for example, `"jaeger,w3c"`). The default value is `w3c`.
 
 <hr>
 

--- a/pkg/infra/tracing/opentelemetry_tracing.go
+++ b/pkg/infra/tracing/opentelemetry_tracing.go
@@ -166,13 +166,17 @@ func (ots *Opentelemetry) initOTLPTracerProvider() (*tracesdk.TracerProvider, er
 		return nil, err
 	}
 
+	return initTracerProvider(exp, ots.customAttribs...)
+}
+
+func initTracerProvider(exp tracesdk.SpanExporter, customAttribs ...attribute.KeyValue) (*tracesdk.TracerProvider, error) {
 	res, err := resource.New(
 		context.Background(),
 		resource.WithAttributes(
 			semconv.ServiceNameKey.String("grafana"),
 			semconv.ServiceVersionKey.String(version.Version),
 		),
-		resource.WithAttributes(ots.customAttribs...),
+		resource.WithAttributes(customAttribs...),
 		resource.WithProcessRuntimeDescription(),
 		resource.WithTelemetrySDK(),
 	)
@@ -222,15 +226,34 @@ func (ots *Opentelemetry) initOpentelemetryTracer() error {
 		otel.SetTracerProvider(tp)
 	}
 
-	switch ots.propagation {
-	case w3cPropagator:
-		otel.SetTextMapPropagator(propagation.TraceContext{})
-	case jaegerPropagator:
-		otel.SetTextMapPropagator(jaegerpropagator.Jaeger{})
-	default:
-		otel.SetTextMapPropagator(propagation.TraceContext{})
+	propagators := []propagation.TextMapPropagator{}
+	for _, p := range strings.Split(ots.propagation, ",") {
+		switch p {
+		case w3cPropagator:
+			propagators = append(propagators, propagation.TraceContext{}, propagation.Baggage{})
+		case jaegerPropagator:
+			propagators = append(propagators, jaegerpropagator.Jaeger{})
+		case "":
+		default:
+			return fmt.Errorf("unsupported OpenTelemetry propagator: %q", p)
+		}
 	}
-	ots.tracerProvider = tp
+
+	switch len(propagators) {
+	case 0:
+		otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+			propagation.TraceContext{}, propagation.Baggage{},
+		))
+	case 1:
+		otel.SetTextMapPropagator(propagators[0])
+	default:
+		otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagators...))
+	}
+
+	if ots.tracerProvider == nil {
+		ots.tracerProvider = tp
+	}
+
 	ots.tracer = otel.GetTracerProvider().Tracer("component-main")
 
 	return nil

--- a/pkg/infra/tracing/opentelemetry_tracing.go
+++ b/pkg/infra/tracing/opentelemetry_tracing.go
@@ -299,6 +299,10 @@ func (ots *Opentelemetry) Inject(ctx context.Context, header http.Header, _ Span
 	otel.GetTextMapPropagator().Inject(ctx, propagation.HeaderCarrier(header))
 }
 
+func (s OpentelemetrySpan) TraceIDString() string {
+	return s.span.SpanContext().TraceID().String()
+}
+
 func (s OpentelemetrySpan) End() {
 	s.span.End()
 }

--- a/pkg/infra/tracing/opentelemetry_tracing.go
+++ b/pkg/infra/tracing/opentelemetry_tracing.go
@@ -299,10 +299,6 @@ func (ots *Opentelemetry) Inject(ctx context.Context, header http.Header, _ Span
 	otel.GetTextMapPropagator().Inject(ctx, propagation.HeaderCarrier(header))
 }
 
-func (s OpentelemetrySpan) TraceIDString() string {
-	return s.span.SpanContext().TraceID().String()
-}
-
 func (s OpentelemetrySpan) End() {
 	s.span.End()
 }

--- a/pkg/infra/tracing/test_helper.go
+++ b/pkg/infra/tracing/test_helper.go
@@ -1,7 +1,16 @@
 package tracing
 
+import (
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
 func InitializeTracerForTest() Tracer {
-	ots := &Opentelemetry{enabled: noopExporter}
+	exp := tracetest.NewInMemoryExporter()
+	tp, _ := initTracerProvider(exp)
+	otel.SetTracerProvider(tp)
+
+	ots := &Opentelemetry{propagation: "jaeger,w3c", tracerProvider: tp}
 	_ = ots.initOpentelemetryTracer()
 	return ots
 }


### PR DESCRIPTION

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Adds support for setting multiple OTel propagators.

**Why do we need this feature?**

When migrating from Jaeger to W3C propagation with OTel, it's helpful to be support both propagation formats simultaneously, so as not to break any traces.

**Who is this feature for?**

Anyone operating and monitoring Grafana

**Which issue(s) does this PR fix?**:

Fixes #61198 

**Special notes for your reviewer**:


Signed-off-by: Dave Henderson <dave.henderson@grafana.com>