### PR TITLE
AuthN: Set LookupTokenErr and fall through in case of error

### DIFF
--- a/pkg/services/contexthandler/contexthandler.go
+++ b/pkg/services/contexthandler/contexthandler.go
@@ -489,8 +489,8 @@ func (h *ContextHandler) initContextWithToken(reqContext *models.ReqContext, org
 				reqContext.Resp.Before(h.deleteInvalidCookieEndOfRequestFunc(reqContext))
 			}
 
-			writeErr(reqContext, err)
-			return true
+			reqContext.LookupTokenErr = err
+			return false
 		}
 
 		reqContext.IsSignedIn = true


### PR DESCRIPTION
**What is this feature?**
During token authentication we need to fall through and set the LookupTokenErr on req context in case of any error. This is how it is done without the authnService flag
