### PR TITLE
Alerting: improve FolderPicker and Evaluation Group Select for Huge lists

### DIFF
--- a/packages/grafana-ui/src/components/Select/Select.tsx
+++ b/packages/grafana-ui/src/components/Select/Select.tsx
@@ -4,7 +4,13 @@ import { SelectableValue } from '@grafana/data';
 
 import { SelectBase } from './SelectBase';
 import { SelectContainer, SelectContainerProps } from './SelectContainer';
-import { SelectCommonProps, MultiSelectCommonProps, SelectAsyncProps, VirtualizedSelectProps } from './types';
+import {
+  SelectCommonProps,
+  MultiSelectCommonProps,
+  SelectAsyncProps,
+  VirtualizedSelectProps,
+  VirtualizedSelectAsyncProps,
+} from './types';
 
 export function Select<T>(props: SelectCommonProps<T>) {
   return <SelectBase {...props} />;
@@ -25,6 +31,10 @@ export function AsyncSelect<T>(props: AsyncSelectProps<T>) {
 }
 
 export function VirtualizedSelect<T>(props: VirtualizedSelectProps<T>) {
+  return <SelectBase virtualized {...props} />;
+}
+
+export function AsyncVirtualizedSelect<T>(props: VirtualizedSelectAsyncProps<T>) {
   return <SelectBase virtualized {...props} />;
 }
 

--- a/packages/grafana-ui/src/components/Select/types.ts
+++ b/packages/grafana-ui/src/components/Select/types.ts
@@ -112,6 +112,11 @@ export interface VirtualizedSelectProps<T> extends Omit<SelectCommonProps<T>, 'v
   options?: Array<Pick<SelectableValue<T>, 'label' | 'value'>>;
 }
 
+/** The AsyncVirtualizedSelect component uses a slightly different SelectableValue, description and other props are not supported */
+export interface VirtualizedSelectAsyncProps<T>
+  extends Omit<SelectCommonProps<T>, 'virtualized'>,
+    SelectAsyncProps<T> {}
+
 export interface MultiSelectCommonProps<T> extends Omit<SelectCommonProps<T>, 'onChange' | 'isMulti' | 'value'> {
   value?: Array<SelectableValue<T>> | T[];
   onChange: (item: Array<SelectableValue<T>>) => {} | void;

--- a/public/app/core/components/Select/FolderPicker.tsx
+++ b/public/app/core/components/Select/FolderPicker.tsx
@@ -16,7 +16,7 @@ import { AccessControlAction, PermissionLevelString } from 'app/types';
 export type FolderPickerFilter = (hits: DashboardSearchHit[]) => DashboardSearchHit[];
 
 export const ADD_NEW_FOLER_OPTION = '+ Add new';
-export const DEFAULT_SLICE_RESULTS = 1000;
+export const SLICE_RESULTS_TO = 1000;
 
 export interface FolderWarning {
   warningCondition: (value: string) => boolean;
@@ -44,7 +44,6 @@ export interface Props {
   accessControlMetadata?: boolean;
   customAdd?: CustomAdd;
   folderWarning?: FolderWarning;
-  sliceResults?: number;
 
   /**
    * Skips loading all folders in order to find the folder matching
@@ -78,7 +77,6 @@ export function FolderPicker(props: Props) {
     accessControlMetadata,
     customAdd,
     folderWarning,
-    sliceResults = DEFAULT_SLICE_RESULTS,
   } = props;
 
   const [folder, setFolder] = useState<SelectedFolder | null>(null);
@@ -94,7 +92,7 @@ export function FolderPicker(props: Props) {
     async (query: string) => {
       const searchHits = await searchFolders(query, permissionLevel, accessControlMetadata);
       const resultsAfterMapAndFilter = mapSearchHitsToOptions(searchHits, filter);
-      const options: Array<SelectableValue<string>> = resultsAfterMapAndFilter.slice(0, sliceResults);
+      const options: Array<SelectableValue<string>> = resultsAfterMapAndFilter.slice(0, SLICE_RESULTS_TO);
 
       const hasAccess =
         contextSrv.hasAccess(AccessControlAction.DashboardsWrite, contextSrv.isEditor) ||
@@ -129,7 +127,6 @@ export function FolderPicker(props: Props) {
       filter,
       enableCreateNew,
       customAdd,
-      sliceResults,
     ]
   );
 
@@ -341,7 +338,6 @@ export function FolderPicker(props: Props) {
           onChange={onFolderChange}
           onCreateOption={createNewFolder}
           isClearable={isClearable}
-          width={42}
         />
       </div>
     );

--- a/public/app/core/components/Select/FolderPicker.tsx
+++ b/public/app/core/components/Select/FolderPicker.tsx
@@ -5,7 +5,7 @@ import { useAsync } from 'react-use';
 
 import { AppEvents, SelectableValue, GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
-import { useStyles2, ActionMeta, Input, InputActionMeta, AsyncSelect, AsyncVirtualizedSelect } from '@grafana/ui';
+import { useStyles2, ActionMeta, Input, InputActionMeta, AsyncVirtualizedSelect } from '@grafana/ui';
 import appEvents from 'app/core/app_events';
 import { t } from 'app/core/internationalization';
 import { contextSrv } from 'app/core/services/context_srv';
@@ -16,6 +16,7 @@ import { AccessControlAction, PermissionLevelString } from 'app/types';
 export type FolderPickerFilter = (hits: DashboardSearchHit[]) => DashboardSearchHit[];
 
 export const ADD_NEW_FOLER_OPTION = '+ Add new';
+export const DEFAULT_SLICE_RESULTS = 1000;
 
 export interface FolderWarning {
   warningCondition: (value: string) => boolean;
@@ -44,7 +45,6 @@ export interface Props {
   customAdd?: CustomAdd;
   folderWarning?: FolderWarning;
   sliceResults?: number;
-  virtualizeResults?: boolean;
 
   /**
    * Skips loading all folders in order to find the folder matching
@@ -78,8 +78,7 @@ export function FolderPicker(props: Props) {
     accessControlMetadata,
     customAdd,
     folderWarning,
-    sliceResults,
-    virtualizeResults,
+    sliceResults = DEFAULT_SLICE_RESULTS,
   } = props;
 
   const [folder, setFolder] = useState<SelectedFolder | null>(null);
@@ -95,8 +94,7 @@ export function FolderPicker(props: Props) {
     async (query: string) => {
       const searchHits = await searchFolders(query, permissionLevel, accessControlMetadata);
       const resultsAfterMapAndFilter = mapSearchHitsToOptions(searchHits, filter);
-      const options: Array<SelectableValue<string>> =
-        (sliceResults ?? 0) > 0 ? resultsAfterMapAndFilter.slice(0, sliceResults) : resultsAfterMapAndFilter;
+      const options: Array<SelectableValue<string>> = resultsAfterMapAndFilter.slice(0, sliceResults);
 
       const hasAccess =
         contextSrv.hasAccess(AccessControlAction.DashboardsWrite, contextSrv.isEditor) ||
@@ -329,40 +327,22 @@ export function FolderPicker(props: Props) {
     return (
       <div data-testid={selectors.components.FolderPicker.containerV2}>
         <FolderWarningWhenSearching />
-        {!virtualizeResults ? (
-          <AsyncSelect
-            inputId={inputId}
-            aria-label={selectors.components.FolderPicker.input}
-            loadingMessage={t('folder-picker.loading', 'Loading folders...')}
-            defaultOptions
-            defaultValue={folder}
-            inputValue={inputValue}
-            onInputChange={onInputChange}
-            value={folder}
-            allowCustomValue={enableCreateNew && !Boolean(customAdd)}
-            loadOptions={debouncedSearch}
-            onChange={onFolderChange}
-            onCreateOption={createNewFolder}
-            isClearable={isClearable}
-          />
-        ) : (
-          <AsyncVirtualizedSelect
-            inputId={inputId}
-            aria-label={selectors.components.FolderPicker.input}
-            loadingMessage={t('folder-picker.loading', 'Loading folders...')}
-            defaultOptions
-            defaultValue={folder}
-            inputValue={inputValue}
-            onInputChange={onInputChange}
-            value={folder}
-            allowCustomValue={enableCreateNew && !Boolean(customAdd)}
-            loadOptions={debouncedSearch}
-            onChange={onFolderChange}
-            onCreateOption={createNewFolder}
-            isClearable={isClearable}
-            width={42}
-          />
-        )}
+        <AsyncVirtualizedSelect
+          inputId={inputId}
+          aria-label={selectors.components.FolderPicker.input}
+          loadingMessage={t('folder-picker.loading', 'Loading folders...')}
+          defaultOptions
+          defaultValue={folder}
+          inputValue={inputValue}
+          onInputChange={onInputChange}
+          value={folder}
+          allowCustomValue={enableCreateNew && !Boolean(customAdd)}
+          loadOptions={debouncedSearch}
+          onChange={onFolderChange}
+          onCreateOption={createNewFolder}
+          isClearable={isClearable}
+          width={42}
+        />
       </div>
     );
   }

--- a/public/app/core/components/Select/FolderPicker.tsx
+++ b/public/app/core/components/Select/FolderPicker.tsx
@@ -16,7 +16,6 @@ import { AccessControlAction, PermissionLevelString } from 'app/types';
 export type FolderPickerFilter = (hits: DashboardSearchHit[]) => DashboardSearchHit[];
 
 export const ADD_NEW_FOLER_OPTION = '+ Add new';
-export const SLICE_RESULTS_TO = 1000;
 
 export interface FolderWarning {
   warningCondition: (value: string) => boolean;
@@ -92,7 +91,7 @@ export function FolderPicker(props: Props) {
     async (query: string) => {
       const searchHits = await searchFolders(query, permissionLevel, accessControlMetadata);
       const resultsAfterMapAndFilter = mapSearchHitsToOptions(searchHits, filter);
-      const options: Array<SelectableValue<string>> = resultsAfterMapAndFilter.slice(0, SLICE_RESULTS_TO);
+      const options: Array<SelectableValue<string>> = resultsAfterMapAndFilter;
 
       const hasAccess =
         contextSrv.hasAccess(AccessControlAction.DashboardsWrite, contextSrv.isEditor) ||

--- a/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
@@ -163,7 +163,7 @@ export function FolderAndGroup({ initialFolder }: FolderAndGroupProps) {
     <div className={styles.container}>
       <Field
         label={
-          <Label htmlFor="folder" description={'Select a folder for your rule. Showing first 1k results.'}>
+          <Label htmlFor="folder" description={'Select a folder for your rule.'}>
             <Stack gap={0.5}>
               Folder
               <InfoIcon

--- a/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
@@ -1,10 +1,12 @@
 import { css } from '@emotion/css';
+import { t } from 'i18next';
+import { debounce } from 'lodash';
 import React, { useState, useRef, useEffect, useCallback, useMemo } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import { GrafanaTheme2, SelectableValue } from '@grafana/data';
 import { Stack } from '@grafana/experimental';
-import { Field, InputControl, Label, LoadingPlaceholder, useStyles2 } from '@grafana/ui';
+import { AsyncSelect, Field, InputControl, Label, LoadingPlaceholder, useStyles2 } from '@grafana/ui';
 import { FolderPickerFilter } from 'app/core/components/Select/FolderPicker';
 import { contextSrv } from 'app/core/core';
 import { DashboardSearchHit } from 'app/features/search/types';
@@ -20,8 +22,9 @@ import { InfoIcon } from '../InfoIcon';
 
 import { getIntervalForGroup } from './GrafanaEvaluationBehavior';
 import { containsSlashes, Folder, RuleFolderPicker } from './RuleFolderPicker';
-import { SelectWithAdd } from './SelectWIthAdd';
 import { checkForPathSeparator } from './util';
+
+export const MAX_GROUP_RESULTS = 1000;
 
 const useGetGroups = (groupfoldersForGrafana: RulerRulesConfigDTO | null | undefined, folderName: string) => {
   const groupOptions = useMemo(() => {
@@ -104,22 +107,20 @@ export function FolderAndGroup({ initialFolder }: FolderAndGroupProps) {
     formState: { errors },
     watch,
     control,
-    setValue,
   } = useFormContext<RuleFormValues>();
 
   const styles = useStyles2(getStyles);
   const dispatch = useDispatch();
   const folderFilter = useRuleFolderFilter(initialFolder);
-  const [isAddingGroup, setIsAddingGroup] = useState(false);
 
   const folder = watch('folder');
   const group = watch('group');
-  const [selectedGroup, setSelectedGroup] = useState(group);
+  const [selectedGroup, setSelectedGroup] = useState<SelectableValue<string>>({ label: group, title: group });
   const initialRender = useRef(true);
 
   const { groupOptions, loading } = useGetGroupOptionsFromFolder(folder?.title ?? '');
 
-  useEffect(() => setSelectedGroup(group), [group, setSelectedGroup]);
+  useEffect(() => setSelectedGroup({ label: group, title: group }), [group, setSelectedGroup]);
 
   useEffect(() => {
     dispatch(fetchRulerRulesIfNotFetchedYet(GRAFANA_RULES_SOURCE_NAME));
@@ -127,14 +128,10 @@ export function FolderAndGroup({ initialFolder }: FolderAndGroupProps) {
 
   const resetGroup = useCallback(() => {
     if (group && !initialRender.current && folder?.title) {
-      setSelectedGroup('');
+      setSelectedGroup({ label: '', title: '' });
     }
     initialRender.current = false;
   }, [group, folder?.title]);
-
-  useEffect(() => {
-    setValue('group', selectedGroup);
-  }, [selectedGroup, setValue]);
 
   const groupIsInGroupOptions = useCallback(
     (group_: string) => {
@@ -142,6 +139,26 @@ export function FolderAndGroup({ initialFolder }: FolderAndGroupProps) {
     },
     [groupOptions]
   );
+  const sliceResults = (list: Array<SelectableValue<string>>) => list.slice(0, MAX_GROUP_RESULTS);
+
+  const getOptions = useCallback(
+    async (query: string) => {
+      const results = query
+        ? sliceResults(
+            groupOptions.filter((el) => {
+              const label = el.label ?? '';
+              return label.toLowerCase().includes(query.toLowerCase());
+            })
+          )
+        : sliceResults(groupOptions);
+      return results;
+    },
+    [groupOptions]
+  );
+
+  const debouncedSearch = useMemo(() => {
+    return debounce(getOptions, 300, { leading: true });
+  }, [getOptions]);
 
   return (
     <div className={styles.container}>
@@ -171,11 +188,9 @@ export function FolderAndGroup({ initialFolder }: FolderAndGroupProps) {
               enableCreateNew={contextSrv.hasPermission(AccessControlAction.FoldersCreate)}
               enableReset={true}
               filter={folderFilter}
-              dissalowSlashes={true}
               onChange={({ title, uid }) => {
                 field.onChange({ title, uid });
-                if (!groupIsInGroupOptions(selectedGroup)) {
-                  setIsAddingGroup(false);
+                if (!groupIsInGroupOptions(selectedGroup.value ?? '')) {
                   resetGroup();
                 }
               }}
@@ -204,20 +219,23 @@ export function FolderAndGroup({ initialFolder }: FolderAndGroupProps) {
             loading ? (
               <LoadingPlaceholder text="Loading..." />
             ) : (
-              <SelectWithAdd
+              <AsyncSelect
                 disabled={!folder}
+                inputId="group"
                 key={`my_unique_select_key__${folder?.title ?? ''}`}
                 {...field}
-                options={groupOptions}
+                loadOptions={debouncedSearch}
+                loadingMessage={t('folder-picker.loading', 'Loading folders...')}
+                defaultOptions
+                defaultValue={selectedGroup}
                 getOptionLabel={(option: SelectableValue<string>) => `${option.label}`}
-                value={selectedGroup}
-                custom={isAddingGroup}
-                onCustomChange={(custom: boolean) => setIsAddingGroup(custom)}
-                placeholder={isAddingGroup ? 'New evaluation group name' : 'Evaluation group name'}
-                onChange={(value: string) => {
-                  field.onChange(value);
-                  setSelectedGroup(value);
+                placeholder={'Evaluation group name'}
+                onChange={(value) => {
+                  field.onChange(value.label ?? '');
                 }}
+                value={selectedGroup}
+                allowCustomValue
+                formatCreateLabel={(newGroup) => '+ Add new '}
               />
             )
           }

--- a/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
@@ -147,7 +147,7 @@ export function FolderAndGroup({ initialFolder }: FolderAndGroupProps) {
     <div className={styles.container}>
       <Field
         label={
-          <Label htmlFor="folder" description={'Select a folder for your rule.'}>
+          <Label htmlFor="folder" description={'Select a folder for your rule. Showing first 1k results.'}>
             <Stack gap={0.5}>
               Folder
               <InfoIcon

--- a/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
@@ -1,12 +1,11 @@
 import { css } from '@emotion/css';
-import { t } from 'i18next';
 import { debounce } from 'lodash';
 import React, { useState, useRef, useEffect, useCallback, useMemo } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import { GrafanaTheme2, SelectableValue } from '@grafana/data';
 import { Stack } from '@grafana/experimental';
-import { AsyncSelect, Field, InputControl, Label, LoadingPlaceholder, useStyles2 } from '@grafana/ui';
+import { AsyncSelect, Field, InputControl, Label, useStyles2, LoadingPlaceholder } from '@grafana/ui';
 import { FolderPickerFilter } from 'app/core/components/Select/FolderPicker';
 import { contextSrv } from 'app/core/core';
 import { DashboardSearchHit } from 'app/features/search/types';
@@ -24,7 +23,7 @@ import { getIntervalForGroup } from './GrafanaEvaluationBehavior';
 import { containsSlashes, Folder, RuleFolderPicker } from './RuleFolderPicker';
 import { checkForPathSeparator } from './util';
 
-export const MAX_GROUP_RESULTS = 1000;
+export const SLICE_GROUP_RESULTS_TO = 1000;
 
 const useGetGroups = (groupfoldersForGrafana: RulerRulesConfigDTO | null | undefined, folderName: string) => {
   const groupOptions = useMemo(() => {
@@ -139,7 +138,7 @@ export function FolderAndGroup({ initialFolder }: FolderAndGroupProps) {
     },
     [groupOptions]
   );
-  const sliceResults = (list: Array<SelectableValue<string>>) => list.slice(0, MAX_GROUP_RESULTS);
+  const sliceResults = (list: Array<SelectableValue<string>>) => list.slice(0, SLICE_GROUP_RESULTS_TO);
 
   const getOptions = useCallback(
     async (query: string) => {
@@ -222,11 +221,11 @@ export function FolderAndGroup({ initialFolder }: FolderAndGroupProps) {
               <AsyncSelect
                 disabled={!folder}
                 inputId="group"
-                key={`my_unique_select_key__${folder?.title ?? ''}`}
+                key={`my_unique_select_key__${selectedGroup?.title ?? ''}`}
                 {...field}
                 loadOptions={debouncedSearch}
-                loadingMessage={t('folder-picker.loading', 'Loading folders...')}
-                defaultOptions
+                loadingMessage={'Loading groups...'}
+                defaultOptions={groupOptions}
                 defaultValue={selectedGroup}
                 getOptionLabel={(option: SelectableValue<string>) => `${option.label}`}
                 placeholder={'Evaluation group name'}
@@ -235,7 +234,7 @@ export function FolderAndGroup({ initialFolder }: FolderAndGroupProps) {
                 }}
                 value={selectedGroup}
                 allowCustomValue
-                formatCreateLabel={(newGroup) => '+ Add new '}
+                formatCreateLabel={(_) => '+ Add new '}
               />
             )
           }

--- a/public/app/features/alerting/unified/components/rule-editor/RuleFolderPicker.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/RuleFolderPicker.tsx
@@ -30,7 +30,6 @@ const SlashesWarning = () => {
     </Stack>
   );
 };
-export const MAX_FOLDERS_IN_LIST = 1000;
 
 export const containsSlashes = (str: string): boolean => str.indexOf('/') !== -1;
 
@@ -60,7 +59,6 @@ export function RuleFolderPicker(props: RuleFolderPickerProps) {
       permissionLevel={PermissionLevelString.View}
       customAdd={customAdd}
       folderWarning={folderWarning}
-      sliceResults={MAX_FOLDERS_IN_LIST}
     />
   );
 }

--- a/public/app/features/alerting/unified/components/rule-editor/RuleFolderPicker.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/RuleFolderPicker.tsx
@@ -61,7 +61,6 @@ export function RuleFolderPicker(props: RuleFolderPickerProps) {
       customAdd={customAdd}
       folderWarning={folderWarning}
       sliceResults={MAX_FOLDERS_IN_LIST}
-      virtualizeResults
     />
   );
 }

--- a/public/app/features/alerting/unified/components/rule-editor/RuleFolderPicker.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/RuleFolderPicker.tsx
@@ -16,7 +16,6 @@ export interface Folder {
 
 export interface RuleFolderPickerProps extends Omit<FolderPickerProps, 'initialTitle' | 'initialFolderId'> {
   value?: Folder;
-  dissalowSlashes: boolean;
 }
 
 const SlashesWarning = () => {

--- a/public/app/features/alerting/unified/components/rule-editor/RuleFolderPicker.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/RuleFolderPicker.tsx
@@ -31,6 +31,7 @@ const SlashesWarning = () => {
     </Stack>
   );
 };
+export const MAX_FOLDERS_IN_LIST = 1000;
 
 export const containsSlashes = (str: string): boolean => str.indexOf('/') !== -1;
 
@@ -60,6 +61,8 @@ export function RuleFolderPicker(props: RuleFolderPickerProps) {
       permissionLevel={PermissionLevelString.View}
       customAdd={customAdd}
       folderWarning={folderWarning}
+      sliceResults={MAX_FOLDERS_IN_LIST}
+      virtualizeResults
     />
   );
 }

--- a/public/app/features/manage-dashboards/state/actions.ts
+++ b/public/app/features/manage-dashboards/state/actions.ts
@@ -286,6 +286,8 @@ export function createFolder(payload: any) {
   return getBackendSrv().post('/api/folders', payload);
 }
 
+export const SLICE_FOLDER_RESULTS_TO = 1000;
+
 export function searchFolders(
   query: any,
   permission?: PermissionLevelString,
@@ -296,6 +298,7 @@ export function searchFolders(
     type: 'dash-folder',
     permission,
     accesscontrol: withAccessControl,
+    limit: SLICE_FOLDER_RESULTS_TO,
   });
 }
 


### PR DESCRIPTION
**What is this feature?**
This PR improves FolderPicker and Evaluation Group select for handling hundred of thousands of options in the list.

- **FolderPicker**
    - Use `AsyncVirtualized` list , we set the limit in the `api/search` request to 1000 rows.
-  **Evaluation Group** 
    - We need to slice the list as we cannot use the Virtualized because of the limitation we have with the description. We use AsyncSelect(using 'allowCustomValue') instead of the SelectWithAdd and limit the rendered results to 1000 (slicing the results in the FE)

It also adds `AsyncVirtualizedSelect` component to the `grafana-ui`.

**Why do we need this feature?**

We need to handle with thousands or more options in these lists without blocking the browser.

**Who is this feature for?**

All Grafana users.

**Which issue(s) does this PR fix?**:

Fixes #57169 

**Special notes for your reviewer**:

Conclusions after some investigation on how to improve rendering huge lists with Select components:

- If we have less than 10k, we can use virtualized to improve list been rendered only for the window of the virtualized. (Take in account virtualized has another limitations like not able to use description in the Select for example)
- If we have more than 10k, we know that virtualized has some issues and doesn't perform well , we have several options:
  - Paginate some way the list of results => some infinite scroll could be implemented to simulate the whole list in the select.
  - If it’s not possible to paginate the results (no api available), we should limit the results in the rendered list: Using AsyncSelect's setting loadOptions to get only a slice of the results (after filtering from the whole list).
  

https://user-images.githubusercontent.com/33540275/211540677-2846bfe2-238a-4c0e-8b19-7435e9bec24a.mp4


