### PR TITLE
Alerting: revert #60728

### DIFF
--- a/public/app/features/alerting/unified/components/amroutes/AmRoutesTable.test.ts
+++ b/public/app/features/alerting/unified/components/amroutes/AmRoutesTable.test.ts
@@ -1,13 +1,9 @@
-import { render, screen } from '@testing-library/react';
-import { noop } from 'lodash';
-import React from 'react';
-
 import { MatcherOperator } from 'app/plugins/datasource/alertmanager/types';
 
 import { FormAmRoute } from '../../types/amroutes';
 import { MatcherFieldValue } from '../../types/silence-form';
 
-import { AmRoutesTable, deleteRoute, getFilteredRoutes, updatedRoute } from './AmRoutesTable';
+import { deleteRoute, getFilteredRoutes, updatedRoute } from './AmRoutesTable';
 
 const defaultAmRoute: FormAmRoute = {
   id: '',
@@ -192,25 +188,5 @@ describe('deleteRoute', () => {
     expect(updatedRoutes[0].id).toBe('1');
     expect(updatedRoutes[1].id).toBe('2');
     expect(updatedRoutes[2].id).toBe('3');
-  });
-
-  it('Should warn about policies with no contact point', () => {
-    const routes: FormAmRoute[] = [
-      buildAmRoute({ id: 'no-contact-point' }),
-      buildAmRoute({ id: 'with-contact-point', receiver: 'TestContactPoint' }),
-    ];
-
-    render(
-      <AmRoutesTable
-        onChange={noop}
-        onCancelAdd={noop}
-        routes={routes}
-        isAddMode={false}
-        alertManagerSourceName={'grafana'}
-        receivers={[]}
-      />
-    );
-    expect(screen.getByText('None')).toBeInTheDocument();
-    expect(screen.getByText('TestContactPoint')).toBeInTheDocument();
   });
 });

--- a/public/app/features/alerting/unified/components/amroutes/AmRoutesTable.tsx
+++ b/public/app/features/alerting/unified/components/amroutes/AmRoutesTable.tsx
@@ -1,7 +1,7 @@
 import { intersectionWith, isEqual } from 'lodash';
 import React, { FC, useCallback, useEffect, useMemo, useState } from 'react';
 
-import { Badge, Button, ConfirmModal, HorizontalGroup, IconButton, Tooltip } from '@grafana/ui';
+import { Button, ConfirmModal, HorizontalGroup, IconButton } from '@grafana/ui';
 import { contextSrv } from 'app/core/services/context_srv';
 
 import { FormAmRoute } from '../../types/amroutes';
@@ -95,10 +95,6 @@ export const AmRoutesTable: FC<AmRoutesTableProps> = ({
   const expandItem = useCallback((item: RouteTableItemProps) => setExpandedId(item.id), []);
   const collapseItem = useCallback(() => setExpandedId(undefined), []);
 
-  const missingReceiver = (route: FormAmRoute) => {
-    return Boolean(route.receiver) === false;
-  };
-
   const cols: RouteTableColumnProps[] = [
     {
       id: 'matchingCriteria',
@@ -124,24 +120,12 @@ export const AmRoutesTable: FC<AmRoutesTableProps> = ({
       label: 'Contact point',
       renderCell: (item) => {
         const type = getGrafanaAppReceiverType(receivers, item.data.receiver);
-
-        if (!missingReceiver(item.data)) {
-          return (
-            <>
-              {item.data.receiver} {type && <GrafanaAppBadge grafanaAppType={type} />}
-            </>
-          );
-        }
-
-        return (
-          <Tooltip
-            content={'No notifications will be delivered for this policy until a contact point is configured.'}
-            placement="top"
-          >
-            <span>
-              <Badge color="orange" icon="exclamation-triangle" text="None" />
-            </span>
-          </Tooltip>
+        return item.data.receiver ? (
+          <>
+            {item.data.receiver} {type && <GrafanaAppBadge grafanaAppType={type} />}
+          </>
+        ) : (
+          '-'
         );
       },
       size: 5,


### PR DESCRIPTION
This PR reverts #60728 which made the wrong assumption about missing contact points in a notification policy – when a notification policy has no contact point it will inherit it from the parent's configuration.