### PR TITLE
Chore: Fix flaky test in `SpanGraph/index.test.tsx`

### DIFF
--- a/packages/jaeger-ui-components/src/TracePageHeader/SpanGraph/index.test.tsx
+++ b/packages/jaeger-ui-components/src/TracePageHeader/SpanGraph/index.test.tsx
@@ -63,9 +63,11 @@ describe('<SpanGraph>', () => {
 
   it('renders <TickLabels /> with the correct value next to each tick', () => {
     render(<TickLabels numTicks={5} duration={1} />);
-    expect(screen.getByText(/0.2/)).toBeTruthy();
-    expect(screen.getByText(/0.4/)).toBeTruthy();
-    expect(screen.getByText(/0.6/)).toBeTruthy();
-    expect(screen.getByText(/0.8/)).toBeTruthy();
+    expect(screen.getAllByText(/0/)).toBeTruthy();
+    expect(screen.getAllByText(/0.2/)).toBeTruthy();
+    expect(screen.getAllByText(/0.4/)).toBeTruthy();
+    expect(screen.getAllByText(/0.6/)).toBeTruthy();
+    expect(screen.getAllByText(/0.8/)).toBeTruthy();
+    expect(screen.getAllByText(/1/)).toBeTruthy();
   });
 });


### PR DESCRIPTION
This PR fixes a flaky test in `packages/jaeger-ui-components/src/TracePageHeader/SpanGraph/index.test.tsx` due to the occasional multiple matching elements. 

Here's an example of a failing build: https://drone.grafana.net/grafana/grafana/95654/1/6