### PR TITLE
AuthN: Login

### DIFF
--- a/pkg/services/authn/authn.go
+++ b/pkg/services/authn/authn.go
@@ -36,6 +36,8 @@ type PostAuthHookFn func(ctx context.Context, identity *Identity, r *Request) er
 type Service interface {
 	// Authenticate authenticates a request using the specified client.
 	Authenticate(ctx context.Context, client string, r *Request) (*Identity, bool, error)
+	// Login authenticates a request and creates a session on successful authentication.
+	Login(ctx context.Context, client string, r *Request) (*Identity, error)
 	// RegisterPostAuthHook registers a hook that is called after a successful authentication.
 	RegisterPostAuthHook(hook PostAuthHookFn)
 }

--- a/pkg/services/authn/authn.go
+++ b/pkg/services/authn/authn.go
@@ -34,10 +34,10 @@ type ClientParams struct {
 type PostAuthHookFn func(ctx context.Context, identity *Identity, r *Request) error
 
 type Service interface {
-	// RegisterPostAuthHook registers a hook that is called after a successful authentication.
-	RegisterPostAuthHook(hook PostAuthHookFn)
 	// Authenticate authenticates a request using the specified client.
 	Authenticate(ctx context.Context, client string, r *Request) (*Identity, bool, error)
+	// RegisterPostAuthHook registers a hook that is called after a successful authentication.
+	RegisterPostAuthHook(hook PostAuthHookFn)
 }
 
 type Client interface {

--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -5,7 +5,10 @@ import (
 	"net/http"
 	"strconv"
 
+	"go.opentelemetry.io/otel/attribute"
+
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/infra/network"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/apikey"
@@ -20,7 +23,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/rendering"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
-	"go.opentelemetry.io/otel/attribute"
+	"github.com/grafana/grafana/pkg/web"
 )
 
 // make sure service implements authn.Service interface
@@ -35,11 +38,12 @@ func ProvideService(
 	authInfoService login.AuthInfoService, renderService rendering.Service,
 ) *Service {
 	s := &Service{
-		log:           log.New("authn.service"),
-		cfg:           cfg,
-		clients:       make(map[string]authn.Client),
-		tracer:        tracer,
-		postAuthHooks: []authn.PostAuthHookFn{},
+		log:            log.New("authn.service"),
+		cfg:            cfg,
+		clients:        make(map[string]authn.Client),
+		tracer:         tracer,
+		sessionService: sessionService,
+		postAuthHooks:  []authn.PostAuthHookFn{},
 	}
 
 	s.clients[authn.ClientRender] = clients.ProvideRender(userService, renderService)
@@ -81,9 +85,12 @@ type Service struct {
 	log     log.Logger
 	cfg     *setting.Cfg
 	clients map[string]authn.Client
+
+	tracer         tracing.Tracer
+	sessionService auth.UserTokenService
+
 	// postAuthHooks are called after a successful authentication. They can modify the identity.
 	postAuthHooks []authn.PostAuthHookFn
-	tracer        tracing.Tracer
 }
 
 func (s *Service) Authenticate(ctx context.Context, client string, r *authn.Request) (*authn.Identity, bool, error) {
@@ -115,6 +122,36 @@ func (s *Service) Authenticate(ctx context.Context, client string, r *authn.Requ
 	}
 
 	return identity, true, nil
+}
+
+func (s *Service) Login(ctx context.Context, client string, r *authn.Request) (*authn.Identity, error) {
+	identity, ok, err := s.Authenticate(ctx, client, r)
+	if !ok {
+		return nil, authn.ErrClientNotConfigured.Errorf("client not configured: %s", client)
+	}
+
+	namespace, id := identity.NamespacedID()
+
+	// Login is only supported for users
+	if namespace != authn.NamespaceUser {
+		return nil, authn.ErrUnsupportedIdentity.Errorf("expected identity of type user but got: %s", namespace)
+	}
+
+	addr := web.RemoteAddr(r.HTTPRequest)
+	ip, err := network.GetIPFromAddress(addr)
+	if err != nil {
+		s.log.Debug("failed to parse ip from address", "addr", addr)
+	}
+
+	sessionToken, err := s.sessionService.CreateToken(ctx, &user.User{ID: id}, ip, r.HTTPRequest.UserAgent())
+	if err != nil {
+		return nil, err
+	}
+
+	// FIXME: add login hooks to replace the one used in HookService
+
+	identity.SessionToken = sessionToken
+	return identity, nil
 }
 
 func (s *Service) RegisterPostAuthHook(hook authn.PostAuthHookFn) {

--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -130,6 +130,10 @@ func (s *Service) Login(ctx context.Context, client string, r *authn.Request) (*
 		return nil, authn.ErrClientNotConfigured.Errorf("client not configured: %s", client)
 	}
 
+	if err != nil {
+		return nil, err
+	}
+
 	namespace, id := identity.NamespacedID()
 
 	// Login is only supported for users

--- a/pkg/services/authn/clients/basic.go
+++ b/pkg/services/authn/clients/basic.go
@@ -9,6 +9,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/loginattempt"
 	"github.com/grafana/grafana/pkg/util"
 	"github.com/grafana/grafana/pkg/util/errutil"
+	"github.com/grafana/grafana/pkg/web"
 )
 
 var (
@@ -54,7 +55,7 @@ func (c *Basic) Authenticate(ctx context.Context, r *authn.Request) (*authn.Iden
 			}
 			if errors.Is(err, errInvalidPassword) {
 				// only add login attempt if identity was found but the provided password was invalid
-				_ = c.loginAttempts.Add(ctx, username, r.HTTPRequest.RemoteAddr)
+				_ = c.loginAttempts.Add(ctx, username, web.RemoteAddr(r.HTTPRequest))
 			}
 			return nil, errBasicAuthCredentials.Errorf("failed to authenticate identity: %w", err)
 		}

--- a/pkg/services/authn/error.go
+++ b/pkg/services/authn/error.go
@@ -2,4 +2,7 @@ package authn
 
 import "github.com/grafana/grafana/pkg/util/errutil"
 
-var ErrClientNotFound = errutil.NewBase(errutil.StatusNotFound, "auth.client.notConfigured")
+var (
+	ErrClientNotConfigured = errutil.NewBase(errutil.StatusBadRequest, "auth.client.notConfigured")
+	ErrUnsupportedIdentity = errutil.NewBase(errutil.StatusNotImplemented, "auth.identity.unsupported")
+)


### PR DESCRIPTION
**What is this feature?**

When performing authentication there are cases when we wan't a session to be created on a successful request.
To gather all this logic in one place we need a Login function for authn service. This function will perform authentication with desired client and if successful and the identity is of type user we create a session.

**Special notes for your reviewer**:
We should run [login hooks ](https://github.com/grafana/grafana/blob/main/pkg/api/login.go#L183) in this function.
So I plan to add the ability to register post login hooks in another pr
