### PR TITLE
Docs: Update curl example to use --user for basic auth

### DIFF
--- a/docs/sources/developers/http_api/curl-examples.md
+++ b/docs/sources/developers/http_api/curl-examples.md
@@ -33,7 +33,5 @@ You can't use authorization tokens in the request.
 For example, to [list permissions associated with roles]({{< relref "../../administration/roles-and-permissions/access-control/manage-rbac-roles/" >}}) given a username of `user` and password of `password`, use:
 
 ```
-curl --location --request GET '<grafana_url>/api/access-control/builtin-roles' --header 'Authorization: Basic dXNlcjpwYXNzd29yZAo='
+curl --location  '<grafana_url>/api/access-control/builtin-roles' --user 'user:password'
 ```
-
-where `dXNlcjpwYXNzd29yZAo=` is the base64 encoding of `user:password`.

--- a/docs/sources/developers/http_api/curl-examples.md
+++ b/docs/sources/developers/http_api/curl-examples.md
@@ -33,5 +33,5 @@ You can't use authorization tokens in the request.
 For example, to [list permissions associated with roles]({{< relref "../../administration/roles-and-permissions/access-control/manage-rbac-roles/" >}}) given a username of `user` and password of `password`, use:
 
 ```
-curl --location  '<grafana_url>/api/access-control/builtin-roles' --user 'user:password'
+curl --location '<grafana_url>/api/access-control/builtin-roles' --user 'user:password'
 ```


### PR DESCRIPTION
**What is this feature?**

There is no need to manually construct a base64 for the Basic auth header, as curl natively supports doing so using `--user` (or by adding the username and password in the URL). I also remove `--request GET` from the same line since that's the default and [curl's maintainer discourages it](https://daniel.haxx.se/blog/2015/09/11/unnecessary-use-of-curl-x/).

We've had users construct invalid base64's due to differing implementations of `echo` in various POSIX systems, so this pretty much removes that particular source of possible user frustration 🙂