### PR TITLE
PluginsList: Improve layout for smaller screens

### DIFF
--- a/public/app/features/plugins/admin/pages/Browse.tsx
+++ b/public/app/features/plugins/admin/pages/Browse.tsx
@@ -82,7 +82,7 @@ export default function Browse({ route }: GrafanaRouteComponentProps): ReactElem
             {/* Filter by type */}
             <Field label="Type">
               <Select
-                id="plugin-type-filter"
+                aria-label="Plugin type filter"
                 value={filterByType}
                 onChange={onFilterByTypeChange}
                 width={18}

--- a/public/app/features/plugins/admin/pages/Browse.tsx
+++ b/public/app/features/plugins/admin/pages/Browse.tsx
@@ -104,14 +104,16 @@ export default function Browse({ route }: GrafanaRouteComponentProps): ReactElem
                 content="This filter has been disabled because the Grafana server cannot access grafana.com"
                 placement="top"
               >
-                <Field label="State">
-                  <RadioButtonGroup
-                    disabled={true}
-                    value={filterBy}
-                    onChange={onFilterByChange}
-                    options={filterByOptions}
-                  />
-                </Field>
+                <div>
+                  <Field label="State">
+                    <RadioButtonGroup
+                      disabled={true}
+                      value={filterBy}
+                      onChange={onFilterByChange}
+                      options={filterByOptions}
+                    />
+                  </Field>
+                </div>
               </Tooltip>
             )}
 

--- a/public/app/features/plugins/admin/pages/Browse.tsx
+++ b/public/app/features/plugins/admin/pages/Browse.tsx
@@ -4,7 +4,7 @@ import { useLocation } from 'react-router-dom';
 
 import { SelectableValue, GrafanaTheme2 } from '@grafana/data';
 import { config, locationSearchToObject } from '@grafana/runtime';
-import { LoadingPlaceholder, Select, RadioButtonGroup, useStyles2, Tooltip } from '@grafana/ui';
+import { LoadingPlaceholder, Select, RadioButtonGroup, useStyles2, Tooltip, Field } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 import { GrafanaRouteComponentProps } from 'app/core/navigation/types';
 import { getNavModel } from 'app/core/selectors/navModel';
@@ -53,8 +53,8 @@ export default function Browse({ route }: GrafanaRouteComponentProps): ReactElem
     history.push({ query: { filterBy: value } });
   };
 
-  const onFilterByTypeChange = (value: string) => {
-    history.push({ query: { filterByType: value } });
+  const onFilterByTypeChange = (value: SelectableValue<string>) => {
+    history.push({ query: { filterByType: value.value } });
   };
 
   const onSearch = (q: string) => {
@@ -75,13 +75,16 @@ export default function Browse({ route }: GrafanaRouteComponentProps): ReactElem
         )}
 
         <HorizontalGroup wrap>
-          <SearchField value={query} onSearch={onSearch} />
+          <Field label="Search">
+            <SearchField value={query} onSearch={onSearch} />
+          </Field>
           <HorizontalGroup wrap className={styles.actionBar}>
             {/* Filter by type */}
-            <div>
-              <RadioButtonGroup
+            <Field label="Type">
+              <Select
                 value={filterByType}
                 onChange={onFilterByTypeChange}
+                width={18}
                 options={[
                   { value: 'all', label: 'All' },
                   { value: 'datasource', label: 'Data sources' },
@@ -89,48 +92,48 @@ export default function Browse({ route }: GrafanaRouteComponentProps): ReactElem
                   { value: 'app', label: 'Applications' },
                 ]}
               />
-            </div>
+            </Field>
 
             {/* Filter by installed / all */}
             {remotePluginsAvailable ? (
-              <div>
+              <Field label="State">
                 <RadioButtonGroup value={filterBy} onChange={onFilterByChange} options={filterByOptions} />
-              </div>
+              </Field>
             ) : (
               <Tooltip
                 content="This filter has been disabled because the Grafana server cannot access grafana.com"
                 placement="top"
               >
-                <div>
+                <Field label="State">
                   <RadioButtonGroup
                     disabled={true}
                     value={filterBy}
                     onChange={onFilterByChange}
                     options={filterByOptions}
                   />
-                </div>
+                </Field>
               </Tooltip>
             )}
 
             {/* Sorting */}
-            <div>
+            <Field label="Sort">
               <Select
                 aria-label="Sort Plugins List"
                 width={24}
                 value={sortBy}
                 onChange={onSortByChange}
                 options={[
-                  { value: 'nameAsc', label: 'Sort by name (A-Z)' },
-                  { value: 'nameDesc', label: 'Sort by name (Z-A)' },
-                  { value: 'updated', label: 'Sort by updated date' },
-                  { value: 'published', label: 'Sort by published date' },
-                  { value: 'downloads', label: 'Sort by downloads' },
+                  { value: 'nameAsc', label: 'By name (A-Z)' },
+                  { value: 'nameDesc', label: 'By name (Z-A)' },
+                  { value: 'updated', label: 'By updated date' },
+                  { value: 'published', label: 'By published date' },
+                  { value: 'downloads', label: 'By downloads' },
                 ]}
               />
-            </div>
+            </Field>
 
             {/* Display mode */}
-            <div>
+            <Field label="View">
               <RadioButtonGroup<PluginListDisplayMode>
                 className={styles.displayAs}
                 value={displayMode}
@@ -144,7 +147,7 @@ export default function Browse({ route }: GrafanaRouteComponentProps): ReactElem
                   { value: PluginListDisplayMode.List, icon: 'list-ul', description: 'Display plugins in list' },
                 ]}
               />
-            </div>
+            </Field>
           </HorizontalGroup>
         </HorizontalGroup>
         <div className={styles.listWrap}>

--- a/public/app/features/plugins/admin/pages/Browse.tsx
+++ b/public/app/features/plugins/admin/pages/Browse.tsx
@@ -82,6 +82,7 @@ export default function Browse({ route }: GrafanaRouteComponentProps): ReactElem
             {/* Filter by type */}
             <Field label="Type">
               <Select
+                id="plugin-type-filter"
                 value={filterByType}
                 onChange={onFilterByTypeChange}
                 width={18}


### PR DESCRIPTION
Slight design tweak to improve the plugin list view for smaller screens. 

* Use Select for type instead of a radio button with 4 large options (to wide for a radio group, think select is better)
* Adds field labels to all filter inputs to make it a bit more clear what they do

I get triggered a lot by the plugin list having a broken layout on 14" macbooks:

Before:
<img width="1512" alt="Screenshot 2023-01-10 at 15 25 42" src="https://user-images.githubusercontent.com/10999/211591961-92b5a6fb-71be-4735-89ac-d662d598b68a.png">

After: 
<img width="1511" alt="Screenshot 2023-01-10 at 15 24 33" src="https://user-images.githubusercontent.com/10999/211592266-34ffc82d-cd59-4f7d-86b8-8dacaeaac663.png">


