### PR TITLE
Add object_matchers example

### DIFF
--- a/docs/sources/alerting/set-up/provision-alerting-resources/file-provisioning/index.md
+++ b/docs/sources/alerting/set-up/provision-alerting-resources/file-provisioning/index.md
@@ -516,9 +516,15 @@ policies:
     #        a very low alert volume or your upstream notification system performs
     #        its own grouping.
     group_by: ['...']
-    # <list> a list of matchers that an alert has to fulfill to match the node
+    # <list> a list of prometheus-like matchers that an alert has to fulfill to match the node (allowed chars [a-zA-Z_:])
     matchers:
       - alertname = Watchdog
+      - service_id_X = serviceX
+      - severity =~ "warning|critical"
+    # <list> a list of grafana-like matchers that an alert has to fulfill to match the node
+    object_matchers:
+      - alertname = CPUUsage
+      - service_id-X = serviceX
       - severity =~ "warning|critical"
     # <list> Times when the route should be muted. These must match the name of a
     #        mute time interval.

--- a/docs/sources/alerting/set-up/provision-alerting-resources/file-provisioning/index.md
+++ b/docs/sources/alerting/set-up/provision-alerting-resources/file-provisioning/index.md
@@ -516,12 +516,13 @@ policies:
     #        a very low alert volume or your upstream notification system performs
     #        its own grouping.
     group_by: ['...']
-    # <list> a list of prometheus-like matchers that an alert has to fulfill to match the node (allowed chars [a-zA-Z_:])
+    # <list> a list of prometheus-like matchers that an alert rule has to fulfill to match the node (allowed chars
+    #        [a-zA-Z_:])
     matchers:
       - alertname = Watchdog
       - service_id_X = serviceX
       - severity =~ "warning|critical"
-    # <list> a list of grafana-like matchers that an alert has to fulfill to match the node
+    # <list> a list of grafana-like matchers that an alert rule has to fulfill to match the node
     object_matchers:
       - alertname = CPUUsage
       - service_id-X = serviceX


### PR DESCRIPTION
**What is this feature?**

This updates the file provisioning documentation to clarify `matchers` and `object_marchers` in notification policies.

**Why do we need this feature?**

There has been some problems regarding the creation of matchers in notification policies due to the fact that `matchers` only permits a subset of characters to create label names (prometheus-like, allowed characters `[a-zA-Z_:]`) in contrast of `object_matchers` that allows a wider range of characters.

**Who is this feature for?**

Any users that is using file provisioning.

**Which issue(s) does this PR fix?**:

Contributes to https://github.com/grafana/support-escalations/issues/4754