### PR TITLE
UI/Alert: Infer the `role` property based on the `severity`

### DIFF
--- a/packages/grafana-ui/src/components/Alert/Alert.test.tsx
+++ b/packages/grafana-ui/src/components/Alert/Alert.test.tsx
@@ -4,8 +4,34 @@ import React from 'react';
 import { Alert } from './Alert';
 
 describe('Alert', () => {
-  it('sets the accessible label correctly based on the title', () => {
+  it('sets the accessible label correctly based on the title if there is no aria-label set', () => {
     render(<Alert title="Uh oh spagghettios!" />);
     expect(screen.getByRole('alert', { name: 'Uh oh spagghettios!' })).toBeInTheDocument();
+  });
+
+  it('prefers the aria-label attribute over the title if it is set', () => {
+    render(<Alert title="Uh oh spagghettios!" aria-label="A fancy label" />);
+    expect(screen.queryByRole('alert', { name: 'Uh oh spagghettios!' })).not.toBeInTheDocument();
+    expect(screen.getByRole('alert', { name: 'A fancy label' })).toBeInTheDocument();
+  });
+
+  it('infers the role based on the severity in case it is not set manually', () => {
+    render(<Alert title="Error message" severity="error" />);
+    expect(screen.getByRole('alert', { name: 'Error message' })).toBeInTheDocument();
+
+    render(<Alert title="Warning message" severity="warning" />);
+    expect(screen.getByRole('alert', { name: 'Warning message' })).toBeInTheDocument();
+
+    render(<Alert title="Success message" severity="success" />);
+    expect(screen.getByRole('status', { name: 'Success message' })).toBeInTheDocument();
+
+    render(<Alert title="Info message" severity="info" />);
+    expect(screen.getByRole('status', { name: 'Info message' })).toBeInTheDocument();
+  });
+
+  it('is possible to set the role manually', () => {
+    render(<Alert title="Error message" severity="error" role="status" />);
+    expect(screen.queryByRole('alert', { name: 'Error message' })).not.toBeInTheDocument();
+    expect(screen.getByRole('status', { name: 'Error message' })).toBeInTheDocument();
   });
 });

--- a/packages/grafana-ui/src/components/Alert/Alert.tsx
+++ b/packages/grafana-ui/src/components/Alert/Alert.tsx
@@ -22,7 +22,10 @@ export interface Props extends HTMLAttributes<HTMLDivElement> {
   buttonContent?: React.ReactNode | string;
   bottomSpacing?: number;
   topSpacing?: number;
+  // The role property of the alert component (e.g. 'log', 'status' or 'alert'.) Defaults to 'alert'.
+  // More info: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions#roles_with_implicit_live_region_attributes
   role?: AriaRole;
+  // Specifies the aria-label for the alert. Defaults to use the `title` in case it's not defined.
   ariaLabel?: string;
 }
 

--- a/packages/grafana-ui/src/components/Alert/Alert.tsx
+++ b/packages/grafana-ui/src/components/Alert/Alert.tsx
@@ -66,12 +66,12 @@ export const Alert = React.forwardRef<HTMLDivElement, Props>(
 
     return (
       <div
-        {...restProps}
         ref={ref}
         className={cx(styles.alert, className)}
         data-testid={selectors.components.Alert.alertV2(severity)}
         role={role}
         aria-label={ariaLabel}
+        {...restProps}
       >
         <div className={styles.icon}>
           <Icon size="xl" name={getIconFromSeverity(severity)} />

--- a/packages/grafana-ui/src/components/Alert/Alert.tsx
+++ b/packages/grafana-ui/src/components/Alert/Alert.tsx
@@ -1,6 +1,5 @@
 import { css, cx } from '@emotion/css';
-import { useId } from '@react-aria/utils';
-import React, { HTMLAttributes, ReactNode } from 'react';
+import React, { AriaRole, HTMLAttributes, ReactNode } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
@@ -23,6 +22,8 @@ export interface Props extends HTMLAttributes<HTMLDivElement> {
   buttonContent?: React.ReactNode | string;
   bottomSpacing?: number;
   topSpacing?: number;
+  role?: AriaRole;
+  ariaLabel?: string;
 }
 
 export function getIconFromSeverity(severity: AlertVariant): IconName {
@@ -49,6 +50,8 @@ export const Alert = React.forwardRef<HTMLDivElement, Props>(
       topSpacing,
       className,
       severity = 'error',
+      role = 'alert',
+      ariaLabel,
       ...restProps
     },
     ref
@@ -56,15 +59,14 @@ export const Alert = React.forwardRef<HTMLDivElement, Props>(
     const theme = useTheme2();
     const hasTitle = Boolean(title);
     const styles = getStyles(theme, severity, hasTitle, elevated, bottomSpacing, topSpacing);
-    const titleId = useId();
 
     return (
       <div
         ref={ref}
         className={cx(styles.alert, className)}
         data-testid={selectors.components.Alert.alertV2(severity)}
-        role="alert"
-        aria-labelledby={titleId}
+        role={role}
+        aria-label={ariaLabel || title}
         {...restProps}
       >
         <div className={styles.icon}>
@@ -72,9 +74,7 @@ export const Alert = React.forwardRef<HTMLDivElement, Props>(
         </div>
 
         <div className={styles.body}>
-          <div id={titleId} className={styles.title}>
-            {title}
-          </div>
+          <div className={styles.title}>{title}</div>
           {children && <div className={styles.content}>{children}</div>}
         </div>
 

--- a/packages/grafana-ui/src/components/Alert/Alert.tsx
+++ b/packages/grafana-ui/src/components/Alert/Alert.tsx
@@ -22,11 +22,6 @@ export interface Props extends HTMLAttributes<HTMLDivElement> {
   buttonContent?: React.ReactNode | string;
   bottomSpacing?: number;
   topSpacing?: number;
-  // The role property of the alert component (e.g. 'log', 'status' or 'alert'.) Defaults to 'alert'.
-  // More info: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions#roles_with_implicit_live_region_attributes
-  role?: AriaRole;
-  // Specifies the aria-label for the alert. Defaults to use the `title` in case it's not defined.
-  ariaLabel?: string;
 }
 
 export function getIconFromSeverity(severity: AlertVariant): IconName {
@@ -53,8 +48,6 @@ export const Alert = React.forwardRef<HTMLDivElement, Props>(
       topSpacing,
       className,
       severity = 'error',
-      role = 'alert',
-      ariaLabel,
       ...restProps
     },
     ref
@@ -62,15 +55,23 @@ export const Alert = React.forwardRef<HTMLDivElement, Props>(
     const theme = useTheme2();
     const hasTitle = Boolean(title);
     const styles = getStyles(theme, severity, hasTitle, elevated, bottomSpacing, topSpacing);
+    const rolesBySeverity: Record<AlertVariant, AriaRole> = {
+      error: 'alert',
+      warning: 'alert',
+      info: 'status',
+      success: 'status',
+    };
+    const role = restProps['role'] || rolesBySeverity[severity];
+    const ariaLabel = restProps['aria-label'] || title;
 
     return (
       <div
+        {...restProps}
         ref={ref}
         className={cx(styles.alert, className)}
         data-testid={selectors.components.Alert.alertV2(severity)}
         role={role}
-        aria-label={ariaLabel || title}
-        {...restProps}
+        aria-label={ariaLabel}
       >
         <div className={styles.icon}>
           <Icon size="xl" name={getIconFromSeverity(severity)} />

--- a/public/app/features/correlations/Forms/QueryEditorField.test.tsx
+++ b/public/app/features/correlations/Forms/QueryEditorField.test.tsx
@@ -69,7 +69,7 @@ describe('QueryEditorField', () => {
   it('shows an info alert when no datasource is selected', async () => {
     renderWithContext(<QueryEditorField name="query" />);
 
-    expect(await screen.findByRole('alert', { name: 'No data source selected' })).toBeInTheDocument();
+    expect(await screen.findByRole('status', { name: 'No data source selected' })).toBeInTheDocument();
   });
 
   it('shows an info alert when datasaource does not export a query editor', async () => {


### PR DESCRIPTION
**Related PR:** https://github.com/grafana/grafana/pull/61152

### What changed?
- `aria-label` falls back to use the `title` property in case it's not set manually
- inferring the `role` property based on the `severity` in case it is not set manually

---

### Why?

> The alert role is used to communicate an important and usually time-sensitive message to the user. When this role is added to an element, the browser will send out an accessible alert event to assistive technology products which can then notify the user.

([MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/alert_role#description))

We are using the `<Alert>` component frequently, however I think it's not always used to communicate something critical (e.g. `severity="info"` or `severity="success"`). Although we would probably still like to use the same visuals in these cases, we don't necessarily want to assign an `"alert"` role to them. 


### Note to the reviewer
Although I think `aria-labelledby` is preferred over `aria-label` whenever there is a visual content, I have chosen to use `aria-label` here due to the `title` being sometimes empty (and in those cases the visual content would not be present). It could be implemented to use either-or, however it felt to me a bit too complicated for what we would gain.