### PR TITLE
Geomap: Update readme to include doc link

### DIFF
--- a/public/app/plugins/panel/geomap/README.md
+++ b/public/app/plugins/panel/geomap/README.md
@@ -1,3 +1,3 @@
 # Geomap Panel - Native Plugin
 
-The Geomap is **included** with Grafana.
+The Geomap Panel is **included** with Grafana. Please see [Geomap Panel documentation](https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/geomap/) for information on the latest features.


### PR DESCRIPTION
What this PR does / why we need it:
Add a reference to the latest documentation on the Geomap readme. I believe this should also automatically update https://github.com/grafana/website/blob/master/content/grafana/plugins/geomap.md

https://github.com/grafana/grafana/issues/59424