### PR TITLE
[v9.0.x] Update publishing workflows to use PATs with fine-grained access control (#61098)

### DIFF
--- a/.github/workflows/publish-technical-documentation-next.yml
+++ b/.github/workflows/publish-technical-documentation-next.yml
@@ -1,0 +1,34 @@
+name: "publish-technical-documentation-next"
+
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - "docs/sources/**"
+  workflow_dispatch:
+jobs:
+  sync:
+    if: "github.repository == 'grafana/grafana'"
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Checkout Grafana repo"
+        uses: "actions/checkout@v3"
+
+      - name: "Clone website-sync Action"
+        # WEBSITE_SYNC_GRAFANA is a fine-grained GitHub Personal Access Token that expires.
+        # It must be updated in the grafanabot GitHub account.
+        run: "git clone --single-branch --no-tags --depth 1 -b master https://grafanabot:${{ secrets.WEBSITE_SYNC_GRAFANA }}@github.com/grafana/website-sync ./.github/actions/website-sync"
+
+      - name: "Publish to website repository (next)"
+        uses: "./.github/actions/website-sync"
+        id: "publish-next"
+        with:
+          repository: "grafana/website"
+          branch: "master"
+          host: "github.com"
+          # PUBLISH_TO_WEBSITE_GRAFANA is a fine-grained GitHub Personal Access Token that expires.
+          # It must be updated in the grafanabot GitHub account.
+          github_pat: "grafanabot:${{ secrets.PUBLISH_TO_WEBSITE_GRAFANA }}"
+          source_folder: "docs/sources"
+          target_folder: "content/docs/grafana/next"

--- a/.github/workflows/publish-technical-documentation-release.yml
+++ b/.github/workflows/publish-technical-documentation-release.yml
@@ -1,0 +1,64 @@
+name: "publish-technical-documentation-release"
+
+on:
+  push:
+    branches:
+      - v[0-9]+.[0-9]+.x
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+
+    paths:
+      - "docs/sources/**"
+  workflow_dispatch:
+jobs:
+  sync:
+    if: "github.repository == 'grafana/grafana'"
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Checkout Grafana repo"
+        uses: "actions/checkout@v3"
+        with:
+          fetch-depth: 0
+
+      - name: "Checkout Actions library"
+        uses: "actions/checkout@v3"
+        with:
+          repository: "grafana/grafana-github-actions"
+          path: "./actions"
+
+      - name: "Install Actions from library"
+        run: "npm install --production --prefix ./actions"
+
+      - name: "Determine if there is a matching release tag"
+        id: "has-matching-release-tag"
+        uses: "./actions/has-matching-release-tag"
+        with:
+          ref_name: "${{ github.ref_name }}"
+          release_tag_regexp: "^v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$"
+          release_branch_regexp: "^v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.x$"
+
+      - name: "Determine technical documentation version"
+        if: "steps.has-matching-release-tag.outputs.bool == 'true'"
+        uses: "./actions/docs-target"
+        id: "target"
+        with:
+          ref_name: "${{ github.ref_name }}"
+
+      - name: "Clone website-sync Action"
+        if: "steps.has-matching-release-tag.outputs.bool == 'true'"
+        # WEBSITE_SYNC_GRAFANA is a fine-grained GitHub Personal Access Token that expires.
+        # It must be updated in the grafanabot GitHub account.
+        run: "git clone --single-branch --no-tags --depth 1 -b master https://grafanabot:${{ secrets.WEBSITE_SYNC_GRAFANA }}@github.com/grafana/website-sync ./.github/actions/website-sync"
+
+      - name: "Publish to website repository (release)"
+        if: "steps.has-matching-release-tag.outputs.bool == 'true'"
+        uses: "./.github/actions/website-sync"
+        id: "publish-release"
+        with:
+          repository: "grafana/website"
+          branch: "master"
+          host: "github.com"
+          # PUBLISH_TO_WEBSITE_GRAFANA is a fine-grained GitHub Personal Access Token that expires.
+          # It must be updated in the grafanabot GitHub account.
+          github_pat: "grafanabot:${{ secrets.PUBLISH_TO_WEBSITE_GRAFANA }}"
+          source_folder: "docs/sources"
+          target_folder: "content/docs/grafana/${{ steps.target.outputs.target }}"


### PR DESCRIPTION
(cherry picked from commit 87ccf10ffe9adf8cf9aee48d27964a6c704ee8ac)
Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
