### PR TITLE
Alerting: Fix General folder being added in alerting FolderPicker

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/RuleFolderPicker.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/RuleFolderPicker.tsx
@@ -51,6 +51,7 @@ export function RuleFolderPicker(props: RuleFolderPickerProps) {
   return (
     <FolderPicker
       showRoot={false}
+      rootName=""
       allowEmpty={true}
       initialTitle={value?.title}
       initialFolderUid={value?.uid}


### PR DESCRIPTION
**What is this feature?**

This PR fixes adding wrongly the 'General' folder in alerting folder picker.

**Why do we need this feature?**

General folder should not appear if it doesn't exists in the alerting folder list.

**Who is this feature for?**

All GF alerting users. 


