### PR TITLE
Instrumentation: measure time until plugin request

### DIFF
--- a/pkg/plugins/backendplugin/instrumentation/instrumentation.go
+++ b/pkg/plugins/backendplugin/instrumentation/instrumentation.go
@@ -36,6 +36,8 @@ func instrumentPluginRequest(ctx context.Context, cfg *config.Cfg, pluginCtx *ba
 
 	start := time.Now()
 
+	timeBeforePluginRequest := log.TimeSinceStart(ctx, time.Now())
+
 	err := fn()
 	if err != nil {
 		status = "error"
@@ -52,8 +54,7 @@ func instrumentPluginRequest(ctx context.Context, cfg *config.Cfg, pluginCtx *ba
 			"pluginId", pluginCtx.PluginID,
 			"endpoint", endpoint,
 			"eventName", "grafana-data-egress",
-			"insight_logs", true,
-			"since_grafana_request_started", log.TimeSinceStart(ctx, time.Now()),
+			"time_before_plugin_request", timeBeforePluginRequest,
 		}
 
 		if pluginCtx.User != nil {

--- a/pkg/plugins/backendplugin/instrumentation/instrumentation.go
+++ b/pkg/plugins/backendplugin/instrumentation/instrumentation.go
@@ -36,7 +36,7 @@ func instrumentPluginRequest(ctx context.Context, cfg *config.Cfg, pluginCtx *ba
 
 	start := time.Now()
 
-	timeBeforePluginRequest := log.TimeSinceStart(ctx, time.Now())
+	timeBeforePluginRequest := log.TimeSinceStart(ctx, start)
 
 	err := fn()
 	if err != nil {


### PR DESCRIPTION
This makes it easier to reason about if time is spent in Grafana or the plugin. 

Signed-off-by: bergquist <carl.bergquist@gmail.com>
