### PR TITLE
AuthN: Post login hooks

### DIFF
--- a/pkg/services/authn/authn.go
+++ b/pkg/services/authn/authn.go
@@ -27,11 +27,11 @@ const (
 )
 
 const (
-	MetaKeyUserName   = "username"
+	MetaKeyUsername   = "username"
 	MetaKeyAuthModule = "authModule"
 )
 
-// ClientParams are hints to the auth service about how to handle the identity management
+// ClientParams are hints to the auth serviAuthN: Post login hooksce about how to handle the identity management
 // from the authenticating client.
 type ClientParams struct {
 	// Update the internal representation of the entity from the identity provided

--- a/pkg/services/authn/authn.go
+++ b/pkg/services/authn/authn.go
@@ -47,7 +47,7 @@ type ClientParams struct {
 }
 
 type PostAuthHookFn func(ctx context.Context, identity *Identity, r *Request) error
-type PostLoginHookFn func(ctx context.Context, client string, identity *Identity, r *Request, err error)
+type PostLoginHookFn func(ctx context.Context, identity *Identity, r *Request, err error)
 
 type Service interface {
 	// Authenticate authenticates a request using the specified client.

--- a/pkg/services/authn/authn.go
+++ b/pkg/services/authn/authn.go
@@ -204,6 +204,23 @@ func (i *Identity) SignedInUser() *user.SignedInUser {
 	return u
 }
 
+func (i *Identity) ExternalUserInfo() models.ExternalUserInfo {
+	_, id := i.NamespacedID()
+	return models.ExternalUserInfo{
+		OAuthToken:     i.OAuthToken,
+		AuthModule:     i.AuthModule,
+		AuthId:         i.AuthID,
+		UserId:         id,
+		Email:          i.Email,
+		Login:          i.Login,
+		Name:           i.Name,
+		Groups:         i.Groups,
+		OrgRoles:       i.OrgRoles,
+		IsGrafanaAdmin: i.IsGrafanaAdmin,
+		IsDisabled:     i.IsDisabled,
+	}
+}
+
 // IdentityFromSignedInUser creates an identity from a SignedInUser.
 func IdentityFromSignedInUser(id string, usr *user.SignedInUser, params ClientParams) *Identity {
 	return &Identity{

--- a/pkg/services/authn/authn.go
+++ b/pkg/services/authn/authn.go
@@ -41,7 +41,7 @@ type ClientParams struct {
 }
 
 type PostAuthHookFn func(ctx context.Context, identity *Identity, r *Request) error
-type PostLoginHookFn func(ctx context.Context, identity *Identity, r *Request) error
+type PostLoginHookFn func(ctx context.Context, identity *Identity, r *Request, err error)
 
 type Service interface {
 	// Authenticate authenticates a request using the specified client.

--- a/pkg/services/authn/authn.go
+++ b/pkg/services/authn/authn.go
@@ -62,7 +62,7 @@ type Client interface {
 }
 
 type PasswordClient interface {
-	AuthenticatePassword(ctx context.Context, orgID int64, username, password string) (*Identity, error)
+	AuthenticatePassword(ctx context.Context, r *Request, username, password string) (*Identity, error)
 }
 
 type Request struct {

--- a/pkg/services/authn/authn.go
+++ b/pkg/services/authn/authn.go
@@ -8,12 +8,13 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/oauth2"
+
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/auth"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/web"
-	"golang.org/x/oauth2"
 )
 
 const (
@@ -23,6 +24,11 @@ const (
 	ClientJWT       = "auth.client.jwt"
 	ClientRender    = "auth.client.render"
 	ClientSession   = "auth.client.session"
+)
+
+const (
+	MetaKeyUserName   = "username"
+	MetaKeyAuthModule = "authModule"
 )
 
 // ClientParams are hints to the auth service about how to handle the identity management
@@ -74,6 +80,23 @@ type Request struct {
 	// Resp is the response writer to use for the request
 	// Used to set cookies and headers
 	Resp web.ResponseWriter
+
+	// metadata is additional information about the auth request
+	metadata map[string]string
+}
+
+func (r *Request) SetMeta(k, v string) {
+	if r.metadata == nil {
+		r.metadata = map[string]string{}
+	}
+	r.metadata[k] = v
+}
+
+func (r *Request) GetMeta(k string) string {
+	if r.metadata == nil {
+		r.metadata = map[string]string{}
+	}
+	return r.metadata[k]
 }
 
 const (

--- a/pkg/services/authn/authn.go
+++ b/pkg/services/authn/authn.go
@@ -41,14 +41,17 @@ type ClientParams struct {
 }
 
 type PostAuthHookFn func(ctx context.Context, identity *Identity, r *Request) error
+type PostLoginHookFn func(ctx context.Context, identity *Identity, r *Request) error
 
 type Service interface {
 	// Authenticate authenticates a request using the specified client.
 	Authenticate(ctx context.Context, client string, r *Request) (*Identity, bool, error)
-	// Login authenticates a request and creates a session on successful authentication.
-	Login(ctx context.Context, client string, r *Request) (*Identity, error)
 	// RegisterPostAuthHook registers a hook that is called after a successful authentication.
 	RegisterPostAuthHook(hook PostAuthHookFn)
+	// Login authenticates a request and creates a session on successful authentication.
+	Login(ctx context.Context, client string, r *Request) (*Identity, error)
+	// RegisterPostLoginHook registers a hook that that is called after a login request.
+	RegisterPostLoginHook(hook PostLoginHookFn)
 }
 
 type Client interface {

--- a/pkg/services/authn/authn.go
+++ b/pkg/services/authn/authn.go
@@ -41,7 +41,7 @@ type ClientParams struct {
 }
 
 type PostAuthHookFn func(ctx context.Context, identity *Identity, r *Request) error
-type PostLoginHookFn func(ctx context.Context, identity *Identity, r *Request, err error)
+type PostLoginHookFn func(ctx context.Context, client string, identity *Identity, r *Request, err error)
 
 type Service interface {
 	// Authenticate authenticates a request using the specified client.

--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -145,7 +145,7 @@ func (s *Service) Login(ctx context.Context, client string, r *authn.Request) (i
 
 	defer func() {
 		for _, hook := range s.postLoginHooks {
-			hook(ctx, client, identity, r, err)
+			hook(ctx, identity, r, err)
 		}
 	}()
 

--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -96,6 +96,8 @@ type Service struct {
 
 	// postAuthHooks are called after a successful authentication. They can modify the identity.
 	postAuthHooks []authn.PostAuthHookFn
+	// postLoginHooks are called after a login request is performed, both for failing and successful requests.
+	postLoginHooks []authn.PostLoginHookFn
 }
 
 func (s *Service) Authenticate(ctx context.Context, client string, r *authn.Request) (*authn.Identity, bool, error) {
@@ -128,6 +130,10 @@ func (s *Service) Authenticate(ctx context.Context, client string, r *authn.Requ
 	}
 
 	return identity, true, nil
+}
+
+func (s *Service) RegisterPostAuthHook(hook authn.PostAuthHookFn) {
+	s.postAuthHooks = append(s.postAuthHooks, hook)
 }
 
 func (s *Service) Login(ctx context.Context, client string, r *authn.Request) (*authn.Identity, error) {
@@ -164,8 +170,8 @@ func (s *Service) Login(ctx context.Context, client string, r *authn.Request) (*
 	return identity, nil
 }
 
-func (s *Service) RegisterPostAuthHook(hook authn.PostAuthHookFn) {
-	s.postAuthHooks = append(s.postAuthHooks, hook)
+func (s *Service) RegisterPostLoginHook(hook authn.PostLoginHookFn) {
+	s.postLoginHooks = append(s.postLoginHooks, hook)
 }
 
 func orgIDFromRequest(r *authn.Request) int64 {

--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -145,7 +145,7 @@ func (s *Service) Login(ctx context.Context, client string, r *authn.Request) (i
 
 	defer func() {
 		for _, hook := range s.postLoginHooks {
-			hook(ctx, identity, r, err)
+			hook(ctx, client, identity, r, err)
 		}
 	}()
 

--- a/pkg/services/authn/authntest/fake.go
+++ b/pkg/services/authn/authntest/fake.go
@@ -33,6 +33,6 @@ type FakePasswordClient struct {
 	ExpectedIdentity *authn.Identity
 }
 
-func (f FakePasswordClient) AuthenticatePassword(ctx context.Context, orgID int64, username, password string) (*authn.Identity, error) {
+func (f FakePasswordClient) AuthenticatePassword(ctx context.Context, r *authn.Request, username, password string) (*authn.Identity, error) {
 	return f.ExpectedIdentity, f.ExpectedErr
 }

--- a/pkg/services/authn/clients/basic.go
+++ b/pkg/services/authn/clients/basic.go
@@ -47,7 +47,7 @@ func (c *Basic) Authenticate(ctx context.Context, r *authn.Request) (*authn.Iden
 	}
 
 	for _, pwClient := range c.clients {
-		identity, err := pwClient.AuthenticatePassword(ctx, r.OrgID, username, password)
+		identity, err := pwClient.AuthenticatePassword(ctx, r, username, password)
 		if err != nil {
 			if errors.Is(err, errIdentityNotFound) {
 				// continue to next password client if identity could not be found

--- a/pkg/services/authn/clients/basic.go
+++ b/pkg/services/authn/clients/basic.go
@@ -34,6 +34,8 @@ func (c *Basic) Authenticate(ctx context.Context, r *authn.Request) (*authn.Iden
 		return nil, errDecodingBasicAuthHeader.Errorf("failed to decode basic auth header: %w", err)
 	}
 
+	r.SetMeta(authn.MetaKeyUserName, username)
+
 	ok, err := c.loginAttempts.Validate(ctx, username)
 	if err != nil {
 		return nil, err

--- a/pkg/services/authn/clients/basic.go
+++ b/pkg/services/authn/clients/basic.go
@@ -34,7 +34,7 @@ func (c *Basic) Authenticate(ctx context.Context, r *authn.Request) (*authn.Iden
 		return nil, errDecodingBasicAuthHeader.Errorf("failed to decode basic auth header: %w", err)
 	}
 
-	r.SetMeta(authn.MetaKeyUserName, username)
+	r.SetMeta(authn.MetaKeyUsername, username)
 
 	ok, err := c.loginAttempts.Validate(ctx, username)
 	if err != nil {

--- a/pkg/services/authn/clients/grafana.go
+++ b/pkg/services/authn/clients/grafana.go
@@ -29,6 +29,9 @@ func (c Grafana) AuthenticatePassword(ctx context.Context, r *authn.Request, use
 		return nil, err
 	}
 
+	// user was found so set auth module in req metadata
+	r.SetMeta(authn.MetaKeyAuthModule, "grafana")
+
 	if ok := comparePassword(password, usr.Salt, usr.Password); !ok {
 		return nil, errInvalidPassword.Errorf("invalid password")
 	}

--- a/pkg/services/authn/clients/grafana.go
+++ b/pkg/services/authn/clients/grafana.go
@@ -20,7 +20,7 @@ type Grafana struct {
 	userService user.Service
 }
 
-func (c Grafana) AuthenticatePassword(ctx context.Context, orgID int64, username, password string) (*authn.Identity, error) {
+func (c Grafana) AuthenticatePassword(ctx context.Context, r *authn.Request, username, password string) (*authn.Identity, error) {
 	usr, err := c.userService.GetByLogin(ctx, &user.GetUserByLoginQuery{LoginOrEmail: username})
 	if err != nil {
 		if errors.Is(err, user.ErrUserNotFound) {
@@ -33,7 +33,7 @@ func (c Grafana) AuthenticatePassword(ctx context.Context, orgID int64, username
 		return nil, errInvalidPassword.Errorf("invalid password")
 	}
 
-	signedInUser, err := c.userService.GetSignedInUserWithCacheCtx(ctx, &user.GetSignedInUserQuery{OrgID: orgID, UserID: usr.ID})
+	signedInUser, err := c.userService.GetSignedInUserWithCacheCtx(ctx, &user.GetSignedInUserQuery{OrgID: r.OrgID, UserID: usr.ID})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/authn/clients/grafana_test.go
+++ b/pkg/services/authn/clients/grafana_test.go
@@ -61,7 +61,7 @@ func TestGrafana_AuthenticatePassword(t *testing.T) {
 			}
 
 			c := ProvideGrafana(userService)
-			identity, err := c.AuthenticatePassword(context.Background(), 1, tt.username, tt.password)
+			identity, err := c.AuthenticatePassword(context.Background(), &authn.Request{OrgID: 1}, tt.username, tt.password)
 			assert.ErrorIs(t, err, tt.expectedErr)
 			assert.EqualValues(t, tt.expectedIdentity, identity)
 		})

--- a/pkg/services/authn/clients/ldap.go
+++ b/pkg/services/authn/clients/ldap.go
@@ -27,15 +27,19 @@ func (c *LDAP) AuthenticatePassword(ctx context.Context, r *authn.Request, usern
 		Password: password,
 	})
 
-	if err != nil {
-		// FIXME: disable user in grafana if not found
-		if errors.Is(err, multildap.ErrCouldNotFindUser) {
-			return nil, errIdentityNotFound.Errorf("no user found: %w", err)
-		}
+	if errors.Is(err, multildap.ErrCouldNotFindUser) {
+		return nil, errIdentityNotFound.Errorf("no user found: %w", err)
+	}
 
-		if errors.Is(err, multildap.ErrInvalidCredentials) {
-			return nil, errInvalidPassword.Errorf("invalid password: %w", err)
-		}
+	// user was found so set auth module in req metadata
+	r.SetMeta(authn.MetaKeyAuthModule, "ldap")
+
+	if errors.Is(err, multildap.ErrInvalidCredentials) {
+		// FIXME: disable user in grafana if not found
+		return nil, errInvalidPassword.Errorf("invalid password: %w", err)
+	}
+
+	if err != nil {
 		return nil, err
 	}
 

--- a/pkg/services/authn/clients/ldap_test.go
+++ b/pkg/services/authn/clients/ldap_test.go
@@ -79,7 +79,7 @@ func TestLDAP_AuthenticatePassword(t *testing.T) {
 		t.Run(tt.desc, func(t *testing.T) {
 			c := &LDAP{cfg: setting.NewCfg(), service: fakeLDAPService{ExpectedInfo: tt.expectedInfo, ExpectedErr: tt.expectedLDAPErr}}
 
-			identity, err := c.AuthenticatePassword(context.Background(), 1, tt.username, tt.password)
+			identity, err := c.AuthenticatePassword(context.Background(), &authn.Request{OrgID: 1}, tt.username, tt.password)
 			assert.ErrorIs(t, err, tt.expectedErr)
 			assert.EqualValues(t, tt.expectedIdentity, identity)
 		})


### PR DESCRIPTION
**What is this feature?**
For login we have [login hooks](https://github.com/grafana/grafana/blob/main/pkg/api/login.go#L178-L190) that are called for both successful and failed requests.

We want to centralize these hooks inside the authn login flow so we are sure that they are called every time.
We need a way to pass some metadata about the auth request regardless if the request succeeded or not, these are username that was used and the auth module. 


