### PR TITLE
Alerting: Correct filtering for NoData and Error states in Alert list panel

### DIFF
--- a/public/app/features/alerting/unified/utils/redux.ts
+++ b/public/app/features/alerting/unified/utils/redux.ts
@@ -162,11 +162,19 @@ export function isAsyncRequestMapSliceFulfilled<T>(slice: AsyncRequestMapSlice<T
 }
 
 export function isAsyncRequestStateFulfilled<T>(state: AsyncRequestState<T>): boolean {
-  return state.dispatched && !state.loading && !state.error;
+  return isAsyncRequestStateSettled(state) && !state.error;
+}
+
+export function isAsyncRequestStateSettled<T>(state: AsyncRequestState<T>): boolean {
+  return state.dispatched && !state.loading;
 }
 
 export function isAsyncRequestMapSlicePending<T>(slice: AsyncRequestMapSlice<T>): boolean {
   return Object.values(slice).some(isAsyncRequestStatePending);
+}
+
+export function isAsyncRequestMapSliceSettled<T>(slice: AsyncRequestMapSlice<T>): boolean {
+  return Object.values(slice).every(isAsyncRequestStateSettled);
 }
 
 export function isAsyncRequestStatePending<T>(state?: AsyncRequestState<T>): boolean {

--- a/public/app/plugins/panel/alertlist/GroupByWithLoading.tsx
+++ b/public/app/plugins/panel/alertlist/GroupByWithLoading.tsx
@@ -7,8 +7,8 @@ import { useUnifiedAlertingSelector } from 'app/features/alerting/unified/hooks/
 import { fetchAllPromRulesAction } from 'app/features/alerting/unified/state/actions';
 import { getAllRulesSourceNames } from 'app/features/alerting/unified/utils/datasource';
 import {
-  isAsyncRequestMapSliceFulfilled,
   isAsyncRequestMapSlicePending,
+  isAsyncRequestMapSliceSettled,
 } from 'app/features/alerting/unified/utils/redux';
 import { useDispatch } from 'app/types';
 import { AlertingRule } from 'app/types/unified-alerting';
@@ -33,7 +33,7 @@ export const GroupBy: FC<Props> = (props) => {
   const promRulesByDatasource = useUnifiedAlertingSelector((state) => state.promRules);
   const rulesDataSourceNames = useMemo(getAllRulesSourceNames, []);
 
-  const allRequestsReady = isAsyncRequestMapSliceFulfilled(promRulesByDatasource);
+  const allRequestsSettled = isAsyncRequestMapSliceSettled(promRulesByDatasource);
   const loading = isAsyncRequestMapSlicePending(promRulesByDatasource);
 
   const labels = useMemo(() => {
@@ -41,7 +41,7 @@ export const GroupBy: FC<Props> = (props) => {
       return [];
     }
 
-    if (!allRequestsReady) {
+    if (!allRequestsSettled) {
       return [];
     }
 
@@ -54,7 +54,7 @@ export const GroupBy: FC<Props> = (props) => {
       .flatMap((labels) => labels.filter(isPrivateLabel));
 
     return uniq(allLabels);
-  }, [allRequestsReady, promRulesByDatasource, rulesDataSourceNames]);
+  }, [allRequestsSettled, promRulesByDatasource, rulesDataSourceNames]);
 
   return (
     <MultiSelect<string>

--- a/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
+++ b/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
@@ -161,13 +161,20 @@ function filterRules(props: PanelProps<UnifiedAlertListOptions>, rules: PromRule
     );
   }
 
-  filteredRules = filteredRules.filter((rule) => {
-    return (
-      (options.stateFilter.firing && rule.rule.state === PromAlertingRuleState.Firing) ||
-      (options.stateFilter.pending && rule.rule.state === PromAlertingRuleState.Pending) ||
-      (options.stateFilter.normal && rule.rule.state === PromAlertingRuleState.Inactive)
-    );
-  });
+  // skip filtering by the alert rule's state if we've selected "nodata" or "error" as a filter condition.
+  // the alert rule state is not reflected if we have any instances matching that state
+  // this means that an instance might be "nodata" or "error" but the alert rule it belongs to will be "normal"
+  const isInstanceStateFilter = options.stateFilter.noData || options.stateFilter.error;
+
+  if (!isInstanceStateFilter) {
+    filteredRules = filteredRules.filter((rule) => {
+      return (
+        (options.stateFilter.firing && rule.rule.state === PromAlertingRuleState.Firing) ||
+        (options.stateFilter.pending && rule.rule.state === PromAlertingRuleState.Pending) ||
+        (options.stateFilter.normal && rule.rule.state === PromAlertingRuleState.Inactive)
+      );
+    });
+  }
 
   if (options.alertInstanceLabelFilter) {
     const replacedLabelFilter = replaceVariables(options.alertInstanceLabelFilter);


### PR DESCRIPTION
After some investigation prompted by [our community forum](https://community.grafana.com/t/alert-list-doesnt-work-right/79418/1) it turns out we're applying some incorrect filtering for `NoData` and `Error` states in the alert list panel.

We were previously applying a first pass filter on the state of the alert rule before proceeding to filter the alert list instances.

However, the `NoData` and `Error` states are exclusive to alert instances and the alert rule state does not reflect the states of these instances. 

This means we have to skip the first filter pass when any of these filters are enabled and only filter the instances for each alert rule. Alert rules with no matching instances will be filtered out of the view anyway.

<img width="1067" alt="image" src="https://user-images.githubusercontent.com/868844/211818014-89a6f072-d5a8-44f1-ade9-04b5ba1abf0f.png">

## Additional changes

This PR also fixes the labels not being fetched if any data source fails to be contacted by checking if all promises have settled rather than being fulfilled.

