### PR TITLE
Alerting: Rule evaluator to get cached data source info

### DIFF
--- a/pkg/services/ngalert/eval/eval.go
+++ b/pkg/services/ngalert/eval/eval.go
@@ -266,7 +266,7 @@ func getExprRequest(ctx EvaluationContext, data []models.AlertQuery, dsCacheServ
 			if expr.IsDataSource(q.DatasourceUID) {
 				ds = expr.DataSourceModel()
 			} else {
-				ds, err = dsCacheService.GetDatasourceByUID(ctx.Ctx, q.DatasourceUID, ctx.User, true)
+				ds, err = dsCacheService.GetDatasourceByUID(ctx.Ctx, q.DatasourceUID, ctx.User, false /*skipCache*/)
 				if err != nil {
 					return nil, fmt.Errorf("failed to build query '%s': %w", q.RefID, err)
 				}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Makes the alert rule evaluator use the data source cache instead of bypassing it.

**Why do we need this feature?**
Currently, each rule evaluation queries the database for data source info at least once (depends on how many data sources are queried by the rule). That info is provided to the expression engine that queries the corresponding plugin with proper configuration. 
In a situation where there are many thousands of alert rules and a connection is very expensive (because the number is limited and the connection pool can't facilitate all requests for a connection), this creates an unnecessary bottleneck and greatly affects the performance of the entire Grafana (because the connection pool is shared).

![image](https://user-images.githubusercontent.com/25988953/211664665-67c6134b-9693-4f27-a840-611b02c27802.png)


**Special notes for your reviewer**:
NOTE: Currently, the cache TTL is `5 seconds`. Therefore, this PR makes alerting evaluation engine have up to 5 seconds delay in propagating the changes in data sources such as headers, authorization details, and other settings. However, I think this is a sensible trade-off for greatly reducing the usage of the connection pool.

Fixes https://github.com/grafana/grafana/issues/61250