### PR TITLE
Log volume: Fix functionality if query has multiple comments

### DIFF
--- a/public/app/plugins/datasource/loki/modifyQuery.test.ts
+++ b/public/app/plugins/datasource/loki/modifyQuery.test.ts
@@ -152,6 +152,7 @@ describe('removeCommentsFromQuery', () => {
     ${'{job="grafana"}#hello'}                                                        | ${'{job="grafana"}'}
     ${'{job="grafana"} | logfmt #hello'}                                              | ${'{job="grafana"} | logfmt '}
     ${'{job="grafana", bar="baz"} |="test" | logfmt | label_format level=lvl #hello'} | ${'{job="grafana", bar="baz"} |="test" | logfmt | label_format level=lvl '}
+    ${`#sum(rate(\n{host="containers"}\n#[1m]))`}                                     | ${`\n{host="containers"}\n`}
   `('strips comments in log query:  {$query}', ({ query, expectedResult }) => {
     expect(removeCommentsFromQuery(query)).toBe(expectedResult);
   });

--- a/public/app/plugins/datasource/loki/modifyQuery.test.ts
+++ b/public/app/plugins/datasource/loki/modifyQuery.test.ts
@@ -153,6 +153,7 @@ describe('removeCommentsFromQuery', () => {
     ${'{job="grafana"} | logfmt #hello'}                                              | ${'{job="grafana"} | logfmt '}
     ${'{job="grafana", bar="baz"} |="test" | logfmt | label_format level=lvl #hello'} | ${'{job="grafana", bar="baz"} |="test" | logfmt | label_format level=lvl '}
     ${`#sum(rate(\n{host="containers"}\n#[1m]))`}                                     | ${`\n{host="containers"}\n`}
+    ${`#sum(rate(\n{host="containers"}\n#| logfmt\n#[1m]))`}                          | ${`\n{host="containers"}\n\n`}
   `('strips comments in log query:  {$query}', ({ query, expectedResult }) => {
     expect(removeCommentsFromQuery(query)).toBe(expectedResult);
   });

--- a/public/app/plugins/datasource/loki/modifyQuery.ts
+++ b/public/app/plugins/datasource/loki/modifyQuery.ts
@@ -128,10 +128,7 @@ export function removeCommentsFromQuery(query: string): string {
   let prev = 0;
 
   for (let lineCommentPosition of lineCommentPositions) {
-    const beforeComment = query.substring(prev, lineCommentPosition.from);
-    const afterComment = query.substring(lineCommentPosition.to);
-
-    newQuery += beforeComment + afterComment;
+    newQuery = newQuery + query.substring(prev, lineCommentPosition.from);
     prev = lineCommentPosition.to;
   }
   return newQuery;


### PR DESCRIPTION
**What is this?**

This PR fixes incorrect logic in `removeCommentsFromQuery`. The implementation was incorrect. It "accidentally" worked for queries with 1 comment, but in a case of multiple comments )(such as in example in https://github.com/grafana/grafana/issues/58838), the produced query was incorrect.

I've also added tests to ensure that functionality is correct. 

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/58838

**Special notes for your reviewer**:

I was thinking if I should be somehow handling those newlines characters, but decided not to, as they don't have effect on functionality and that's how parser is parsing them - as not a comments. But I am open for hearing thoughts on this. 🙂

Before (broken on main):
<img width="1916" alt="image" src="https://user-images.githubusercontent.com/30407135/211852827-35297a13-9f78-4f98-8e62-b3f51dca9491.png">

Now (fixed): 
<img width="1907" alt="image" src="https://user-images.githubusercontent.com/30407135/211852727-276b87b2-c478-49b7-8c31-94bb6b68d087.png">