### PR TITLE
Log Row Context: disable false a11y postive 

### DIFF
--- a/public/app/features/logs/components/LogRowContext.tsx
+++ b/public/app/features/logs/components/LogRowContext.tsx
@@ -306,7 +306,9 @@ export const LogRowContext: React.FunctionComponent<LogRowContextProps> = ({
   return (
     <ClickOutsideWrapper onClick={() => onOutsideClick('close_outside_click')}>
       {/* e.stopPropagation is necessary so the log details doesn't open when clicked on log line in context
-       * and/or when context log line is being highlighted */}
+       * and/or when context log line is being highlighted
+       */}
+      {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
       <div onClick={(e) => e.stopPropagation()}>
         {context.after && (
           <LogRowContextGroup


### PR DESCRIPTION
The event listener is there just to stop event propagations, not for user interactions. I don't see anything to fix.

**Which issue(s) does this PR fix?**:

Closes https://github.com/grafana/grafana/issues/59046

**Special notes for your reviewer**:

Double check I'm not wrong.