### PR TITLE
Change token for parent project action

### DIFF
--- a/.github/workflows/epic-add-to-platform-ux-parent-project.yml
+++ b/.github/workflows/epic-add-to-platform-ux-parent-project.yml
@@ -7,7 +7,7 @@ on:
       - 'type/epic'
       
 env:
-  GITHUB_TOKEN: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
+  GITHUB_TOKEN: ${{ secrets.GH_BOT_PROJECTS_ACCESS_TOKEN }}
   ORGANIZATION: ${{ github.repository_owner }}
   REPO: ${{ github.event.repository.name }}
   PARENT_PROJECT: 304


### PR DESCRIPTION
**What is this feature?**

Change token for epic-add-to-platform-ux-parent-project Gh action.

**Why do we need this feature?**

Current token was changed to fine grained which doesn't work with GraphQL API. Changing to create a specific token for the purpose of project edits via Gh Actions.

