### PR TITLE
Loki: Track obfuscated query

### DIFF
--- a/public/app/plugins/datasource/loki/queryUtils.test.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.test.ts
@@ -204,18 +204,25 @@ describe('parseToNodeNamesArray', () => {
 
 describe('obfuscate', () => {
   it('obfuscates on invalid query', () => {
-    expect(obfuscate('{job="grafana"')).toEqual('{@@@=@@@@@@@@@');
+    expect(obfuscate('{job="grafana"')).toEqual('{@=@');
   });
   it('obfuscates on valid query', () => {
     expect(
       obfuscate('sum(sum_over_time({test="test"} |= `` | logfmt | __error__=`` | unwrap test | __error__=`` [10m]))')
-    ).toEqual('sum(sum_over_time({@@@@=@@@@@@} |= @@ | logfmt | @@@@@@@@@=@@ | unwrap @@@@ | @@@@@@@@@=@@ [10m]))');
+    ).toEqual('sum(sum_over_time({@=@} |= @ | logfmt | __error__=@ | unwrap @ | __error__=@ [10m]))');
   });
   it('obfuscates on arithmetic operation', () => {
     expect(obfuscate('2 + 3')).toEqual('@ + @');
   });
   it('obfuscates a comment', () => {
-    expect(obfuscate('{job="grafana"} # test comment')).toEqual('{@@@=@@@@@@@@@} @@@@@@@@@@@@@@');
+    expect(obfuscate('{job="grafana"} # test comment')).toEqual('{@=@} @');
+  });
+  it('does not obfuscate interval variables', () => {
+    expect(
+      obfuscate(
+        'sum(quantile_over_time(0.5, {label="$var"} | logfmt | __error__=`` | unwrap latency | __error__=`` [$__interval]))'
+      )
+    ).toEqual('sum(quantile_over_time(@, {@=@} | logfmt | __error__=@ | unwrap @ | __error__=@ [$__interval]))');
   });
 });
 

--- a/public/app/plugins/datasource/loki/queryUtils.test.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.test.ts
@@ -204,25 +204,29 @@ describe('parseToNodeNamesArray', () => {
 
 describe('obfuscate', () => {
   it('obfuscates on invalid query', () => {
-    expect(obfuscate('{job="grafana"')).toEqual('{@=@');
+    expect(obfuscate('{job="grafana"')).toEqual('{Identifier=String');
   });
   it('obfuscates on valid query', () => {
     expect(
       obfuscate('sum(sum_over_time({test="test"} |= `` | logfmt | __error__=`` | unwrap test | __error__=`` [10m]))')
-    ).toEqual('sum(sum_over_time({@=@} |= @ | logfmt | __error__=@ | unwrap @ | __error__=@ [10m]))');
+    ).toEqual(
+      'sum(sum_over_time({Identifier=String} |= String | logfmt | __error__=String | unwrap Identifier | __error__=String [10m]))'
+    );
   });
   it('obfuscates on arithmetic operation', () => {
-    expect(obfuscate('2 + 3')).toEqual('@ + @');
+    expect(obfuscate('2 + 3')).toEqual('Number + Number');
   });
   it('obfuscates a comment', () => {
-    expect(obfuscate('{job="grafana"} # test comment')).toEqual('{@=@} @');
+    expect(obfuscate('{job="grafana"} # test comment')).toEqual('{Identifier=String} LineComment');
   });
   it('does not obfuscate interval variables', () => {
     expect(
       obfuscate(
         'sum(quantile_over_time(0.5, {label="$var"} | logfmt | __error__=`` | unwrap latency | __error__=`` [$__interval]))'
       )
-    ).toEqual('sum(quantile_over_time(@, {@=@} | logfmt | __error__=@ | unwrap @ | __error__=@ [$__interval]))');
+    ).toEqual(
+      'sum(quantile_over_time(Number, {Identifier=String} | logfmt | __error__=String | unwrap Identifier | __error__=String [$__interval]))'
+    );
   });
 });
 

--- a/public/app/plugins/datasource/loki/queryUtils.test.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.test.ts
@@ -7,6 +7,7 @@ import {
   isValidQuery,
   parseToNodeNamesArray,
   getParserFromQuery,
+  obfuscate,
 } from './queryUtils';
 import { LokiQuery, LokiQueryType } from './types';
 
@@ -168,7 +169,7 @@ describe('isValidQuery', () => {
   });
 });
 
-describe('parseToArray', () => {
+describe('parseToNodeNamesArray', () => {
   it('returns on empty query', () => {
     expect(parseToNodeNamesArray('{}')).toEqual(['LogQL', 'Expr', 'LogExpr', 'Selector', '⚠']);
   });
@@ -198,6 +199,17 @@ describe('parseToArray', () => {
       'Eq',
       'String',
     ]);
+  });
+});
+
+describe('obfuscate', () => {
+  it('returns on invalid query', () => {
+    expect(obfuscate('{job="grafana"')).toEqual('{***=*********');
+  });
+  it('returns on valid query', () => {
+    expect(
+      obfuscate('sum(sum_over_time({test="test"} |= `` | logfmt | __error__=`` | unwrap test | __error__=`` [10m]))')
+    ).toEqual('sum(sum_over_time({****=******} |= ** | logfmt | *********=** | unwrap **** | *********=** [10m]))');
   });
 });
 

--- a/public/app/plugins/datasource/loki/queryUtils.test.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.test.ts
@@ -203,13 +203,19 @@ describe('parseToNodeNamesArray', () => {
 });
 
 describe('obfuscate', () => {
-  it('returns on invalid query', () => {
-    expect(obfuscate('{job="grafana"')).toEqual('{***=*********');
+  it('obfuscates on invalid query', () => {
+    expect(obfuscate('{job="grafana"')).toEqual('{@@@=@@@@@@@@@');
   });
-  it('returns on valid query', () => {
+  it('obfuscates on valid query', () => {
     expect(
       obfuscate('sum(sum_over_time({test="test"} |= `` | logfmt | __error__=`` | unwrap test | __error__=`` [10m]))')
-    ).toEqual('sum(sum_over_time({****=******} |= ** | logfmt | *********=** | unwrap **** | *********=** [10m]))');
+    ).toEqual('sum(sum_over_time({@@@@=@@@@@@} |= @@ | logfmt | @@@@@@@@@=@@ | unwrap @@@@ | @@@@@@@@@=@@ [10m]))');
+  });
+  it('obfuscates on arithmetic operation', () => {
+    expect(obfuscate('2 + 3')).toEqual('@ + @');
+  });
+  it('obfuscates a comment', () => {
+    expect(obfuscate('{job="grafana"} # test comment')).toEqual('{@@@=@@@@@@@@@} @@@@@@@@@@@@@@');
   });
 });
 

--- a/public/app/plugins/datasource/loki/queryUtils.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.ts
@@ -108,6 +108,20 @@ export function getNormalizedLokiQuery(query: LokiQuery): LokiQuery {
   return { ...rest, queryType: LokiQueryType.Range };
 }
 
+const tagsToObscure = ['String', 'Identifier'];
+export function obfuscate(query: string): string {
+  let obfuscatedQuery: string = query;
+  const tree = parser.parse(query);
+  tree.iterate({
+    enter: ({ name, from, to }): false | void => {
+      if (tagsToObscure.includes(name)) {
+        obfuscatedQuery = obfuscatedQuery.substring(0, from) + '*'.repeat(to - from) + obfuscatedQuery.substring(to);
+      }
+    },
+  });
+  return obfuscatedQuery;
+}
+
 export function parseToNodeNamesArray(query: string): string[] {
   const queryParts: string[] = [];
   const tree = parser.parse(query);

--- a/public/app/plugins/datasource/loki/queryUtils.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.ts
@@ -109,13 +109,15 @@ export function getNormalizedLokiQuery(query: LokiQuery): LokiQuery {
 }
 
 const tagsToObscure = ['String', 'Identifier', 'LineComment', 'Number'];
+const partsToKeep = ['__error__', '__interval', '__interval_ms'];
 export function obfuscate(query: string): string {
   let obfuscatedQuery: string = query;
   const tree = parser.parse(query);
   tree.iterate({
     enter: ({ name, from, to }): false | void => {
-      if (tagsToObscure.includes(name)) {
-        obfuscatedQuery = obfuscatedQuery.substring(0, from) + '@'.repeat(to - from) + obfuscatedQuery.substring(to);
+      const queryPart = query.substring(from, to);
+      if (tagsToObscure.includes(name) && !partsToKeep.includes(queryPart)) {
+        obfuscatedQuery = obfuscatedQuery.replace(queryPart, '@');
       }
     },
   });

--- a/public/app/plugins/datasource/loki/queryUtils.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.ts
@@ -108,14 +108,14 @@ export function getNormalizedLokiQuery(query: LokiQuery): LokiQuery {
   return { ...rest, queryType: LokiQueryType.Range };
 }
 
-const tagsToObscure = ['String', 'Identifier'];
+const tagsToObscure = ['String', 'Identifier', 'LineComment', 'Number'];
 export function obfuscate(query: string): string {
   let obfuscatedQuery: string = query;
   const tree = parser.parse(query);
   tree.iterate({
     enter: ({ name, from, to }): false | void => {
       if (tagsToObscure.includes(name)) {
-        obfuscatedQuery = obfuscatedQuery.substring(0, from) + '*'.repeat(to - from) + obfuscatedQuery.substring(to);
+        obfuscatedQuery = obfuscatedQuery.substring(0, from) + '@'.repeat(to - from) + obfuscatedQuery.substring(to);
       }
     },
   });

--- a/public/app/plugins/datasource/loki/queryUtils.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.ts
@@ -117,7 +117,7 @@ export function obfuscate(query: string): string {
     enter: ({ name, from, to }): false | void => {
       const queryPart = query.substring(from, to);
       if (tagsToObscure.includes(name) && !partsToKeep.includes(queryPart)) {
-        obfuscatedQuery = obfuscatedQuery.replace(queryPart, '@');
+        obfuscatedQuery = obfuscatedQuery.replace(queryPart, name);
       }
     },
   });

--- a/public/app/plugins/datasource/loki/tracking.ts
+++ b/public/app/plugins/datasource/loki/tracking.ts
@@ -11,7 +11,7 @@ import {
   REF_ID_STARTER_LOG_VOLUME,
 } from './datasource';
 import pluginJson from './plugin.json';
-import { getNormalizedLokiQuery, isLogsQuery, parseToNodeNamesArray } from './queryUtils';
+import { getNormalizedLokiQuery, isLogsQuery, obfuscate, parseToNodeNamesArray } from './queryUtils';
 import { LokiQuery, LokiQueryType } from './types';
 
 type LokiOnDashboardLoadedTrackingEvent = {
@@ -167,6 +167,7 @@ export function trackQuery(
       legend: query.legendFormat,
       line_limit: query.maxLines,
       parsed_query: parseToNodeNamesArray(query.expr).join(','),
+      obfuscated_query: obfuscate(query.expr),
       query_type: isLogsQuery(query.expr) ? 'logs' : 'metric',
       query_vector_type: query.queryType,
       resolution: query.resolution,


### PR DESCRIPTION
**What is this feature?**

Query tracking. Queries in parsed format and not necessarily useful, so we are tracking an obfuscated query. All instances of `['String', 'Identifier', 'LineComment', 'Number']` are replaced with placeholders. 

**Which issue(s) does this PR fix?**:

Fixes #61299

**Special notes for your reviewer**:

`sum(sum_over_time({test="test"} |= `` | logfmt | __error__=`` | unwrap test | __error__=`` [10m]))` -> `sum(sum_over_time({@@@@=@@@@@@} |= @@ | logfmt | @@@@@@@@@=@@ | unwrap @@@@ | @@@@@@@@@=@@ [10m]))`
