### PR TITLE
Docs: Fix links to `default_template.go` in alert template reference file

### DIFF
--- a/docs/sources/alerting/fundamentals/alert-rules/message-templating.md
+++ b/docs/sources/alerting/fundamentals/alert-rules/message-templating.md
@@ -16,9 +16,9 @@ weight: 415
 
 # Message templating
 
-Notifications sent via contact points are built using messaging templates. Grafana's default templates are based on the [Go templating system](https://golang.org/pkg/text/template) where some fields are evaluated as text, while others are evaluated as HTML (which can affect escaping). The default template, defined in [default_template.go](https://github.com/grafana/grafana/blob/main/pkg/services/ngalert/notifier/channels/default_template.go), is a useful reference for custom templates.
+Notifications sent via contact points are built using messaging templates. Grafana's default templates are based on the [Go templating system](https://golang.org/pkg/text/template) where some fields are evaluated as text, while others are evaluated as HTML (which can affect escaping). The default template, defined in [default_template.go](https://github.com/grafana/alerting/blob/main/alerting/notifier/channels/default_template.go), is a useful reference for custom templates.
 
-Since most of the contact point fields can be templated, you can create reusable custom templates and use them in multiple contact points. The default template is defined in [default_template.go](https://github.com/grafana/grafana/blob/main/pkg/services/ngalert/notifier/channels/default_template.go) which can serve as a useful reference or starting point for custom templates.
+Since most of the contact point fields can be templated, you can create reusable custom templates and use them in multiple contact points. The default template is defined in [default_template.go](https://github.com/grafana/alerting/blob/main/alerting/notifier/channels/default_template.go) which can serve as a useful reference or starting point for custom templates.
 
 ### Using templates
 


### PR DESCRIPTION
**What is this feature?**

Commit #60655 moved the `default_template.go` file from `grafana/grafana` => `grafana/alerting` (matching commit in the alerting repo [here](https://github.com/grafana/alerting/commit/2e90dab4aeb42959b7c8e913d901a7a70ce6e09b)).

That file is linked a few times in the [Message Templating](https://grafana.com/docs/grafana/latest/alerting/fundamentals/alert-rules/message-templating/) docs page.

This commit fixes those links.

I have searched across the `grafana/grafana` repo for any other links, but it looks like these are the only ones.

