### PR TITLE
logs: refactor access to logs-frames

### DIFF
--- a/public/app/features/logs/logsFrame.test.ts
+++ b/public/app/features/logs/logsFrame.test.ts
@@ -1,0 +1,127 @@
+import { ArrayVector, DataFrame, Field, FieldType, QueryResultMeta } from '@grafana/data';
+
+import { parseLogsFrame } from './logsFrame';
+
+const timeField: Field = {
+  name: 'Time',
+  type: FieldType.time,
+  config: {},
+  values: new ArrayVector([1, 2]),
+};
+
+const lineField: Field = {
+  name: 'Line',
+  type: FieldType.string,
+  config: {},
+  values: new ArrayVector(['line1', 'line2']),
+};
+
+const labelsField: Field = {
+  name: 'labels',
+  type: FieldType.other,
+  config: {},
+  values: new ArrayVector([
+    { level: 'info', code: '41' },
+    { level: 'error', code: '42' },
+  ]),
+};
+
+const timeNanosecondField: Field = {
+  name: 'tsNs',
+  type: FieldType.string,
+  config: {},
+  values: new ArrayVector(['1000000', '2000000']),
+};
+
+const idField: Field = {
+  name: 'id',
+  type: FieldType.string,
+  config: {},
+  values: new ArrayVector(['id1', 'id2']),
+};
+
+const logLevelField: Field = {
+  name: 'level',
+  type: FieldType.string,
+  config: {},
+  values: new ArrayVector(['level1', 'level2']),
+};
+
+const meta: QueryResultMeta = {
+  custom: {
+    frameType: 'LabeledTimeValues',
+  },
+};
+
+const length = 2;
+
+describe('logs frame parsing', () => {
+  it('invalid frames should be parsed as null', () => {
+    const f1: DataFrame = { fields: [], length };
+    const f2: DataFrame = { fields: [timeField], length };
+    const f3: DataFrame = { fields: [lineField], length };
+
+    expect(parseLogsFrame(f1)).toBeNull();
+    expect(parseLogsFrame(f2)).toBeNull();
+    expect(parseLogsFrame(f3)).toBeNull();
+  });
+
+  it('minimal frame', () => {
+    const minimalFrame: DataFrame = { meta, fields: [timeField, lineField], length };
+    const p = parseLogsFrame(minimalFrame);
+    expect(p).not.toBeNull();
+    expect(p?.timeField.values.get(1)).toBe(2);
+    expect(p?.lineField.values.get(1)).toBe('line2');
+    expect(p?.idField).toBeUndefined();
+    expect(p?.timeNanosecondField).toBeUndefined();
+    expect(p?.logLevelField).toBeUndefined();
+    expect(p?.getLabels()).toStrictEqual([{}, {}]);
+  });
+
+  it('minimal frame, field-labels attribute', () => {
+    const l: Field = {
+      labels: { l1: 'v1' },
+      ...lineField,
+    };
+    const minimalFrame: DataFrame = { fields: [timeField, l], length };
+    const p = parseLogsFrame(minimalFrame);
+    expect(p).not.toBeNull();
+    expect(p?.timeField.values.get(1)).toBe(2);
+    expect(p?.lineField.values.get(1)).toBe('line2');
+    expect(p?.idField).toBeUndefined();
+    expect(p?.timeNanosecondField).toBeUndefined();
+    expect(p?.logLevelField).toBeUndefined();
+    expect(p?.getLabels()).toStrictEqual([{ l1: 'v1' }, { l1: 'v1' }]);
+  });
+
+  it('minimal frame, missing labels-field, but it should have it', () => {
+    const minimalFrame: DataFrame = { meta, fields: [timeField, lineField], length };
+    const p = parseLogsFrame(minimalFrame);
+    expect(p).not.toBeNull();
+    expect(p?.timeField.values.get(1)).toBe(2);
+    expect(p?.lineField.values.get(1)).toBe('line2');
+    expect(p?.idField).toBeUndefined();
+    expect(p?.timeNanosecondField).toBeUndefined();
+    expect(p?.logLevelField).toBeUndefined();
+    expect(p?.getLabels()).toStrictEqual([{}, {}]);
+  });
+
+  it('complete frame', () => {
+    const minimalFrame: DataFrame = {
+      meta,
+      fields: [timeField, lineField, idField, timeNanosecondField, logLevelField, labelsField],
+      length,
+    };
+    const p = parseLogsFrame(minimalFrame);
+    expect(p).not.toBeNull();
+    expect(p?.timeField.values.get(1)).toBe(2);
+    expect(p?.lineField.values.get(1)).toBe('line2');
+    expect(p?.idField?.values.get(1)).toBe('id2');
+    expect(p?.timeNanosecondField?.values.get(1)).toBe('2000000');
+    expect(p?.logLevelField?.values.get(1)).toBe('level2');
+    expect(p?.getLabels()).toStrictEqual([
+      { level: 'info', code: '41' },
+      { level: 'error', code: '42' },
+    ]);
+  });
+});

--- a/public/app/features/logs/logsFrame.ts
+++ b/public/app/features/logs/logsFrame.ts
@@ -1,0 +1,55 @@
+import { DataFrame, FieldCache, FieldType, FieldWithIndex, Labels } from '@grafana/data';
+
+export type LogsFrame = {
+  timeField: FieldWithIndex;
+  lineField: FieldWithIndex;
+  timeNanosecondField?: FieldWithIndex;
+  logLevelField?: FieldWithIndex;
+  idField?: FieldWithIndex;
+  getLabels: () => Labels[];
+};
+
+export function parseLogsFrame(frame: DataFrame): LogsFrame | null {
+  const cache = new FieldCache(frame);
+  const timeField = cache.getFields(FieldType.time)[0];
+  const lineField = cache.getFields(FieldType.string)[0];
+
+  // these two are mandatory
+  if (timeField === undefined || lineField === undefined) {
+    return null;
+  }
+
+  const timeNanosecondField = cache.getFieldByName('tsNs');
+  const logLevelField = cache.getFieldByName('level');
+  const idField = cache.getFieldByName('id');
+
+  // we only extract the labels when we are asked to do so,
+  // because this is usually not needed
+  const getLabels = (): Labels[] => {
+    // NOTE: this is experimental, please do not use in your code.
+    // we will get this custom-frame-type into the "real" frame-type list soon,
+    // but the name might change, so please do not use it until then.
+    const useLabelsField = frame.meta?.custom?.frameType === 'LabeledTimeValues';
+
+    if (useLabelsField) {
+      const labelsField = cache.getFieldByName('labels');
+      if (labelsField != null) {
+        return labelsField.values.toArray();
+      } else {
+        // this should not really happen, let's return empty-labels
+        return Array(frame.length).fill({});
+      }
+    } else {
+      return Array(lineField.values.length).fill(lineField.labels ?? {});
+    }
+  };
+
+  return {
+    timeField,
+    lineField,
+    timeNanosecondField,
+    logLevelField,
+    idField,
+    getLabels,
+  };
+}


### PR DESCRIPTION
(fixes https://github.com/grafana/grafana/issues/57329)

this pull requests extract the "how to find the correct fields in a logs dataframe" into a separate file.

the only complication there is access to log-row-labels. because we support two approaches to log-row-labels:
1. (the old approach): we find the logline-dataframe-field, and it's `.labels` attribute contains the labels. this means every row in the dataframe has the same labels. (a database-response is represented by multiple dataframes in this case)
2. (the new approach): there is a dataframe-field named `labels`, which contains the `Labels` structure for each row separately.

the calling code should not know about this difference, so we cannot just give the labels-field to the calling code (because it may not exist). the approach here is to just have a function you can call to give you labels-for-every-row. currently only `logsModels.ts` needs this, and that part is happy with such an API. 