### PR TITLE
Logs: Fix alginment of meta items

### DIFF
--- a/public/app/features/explore/MetaInfoText.tsx
+++ b/public/app/features/explore/MetaInfoText.tsx
@@ -17,7 +17,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     margin-right: ${theme.spacing(2)};
     margin-top: ${theme.spacing(0.5)};
     display: flex;
-    align-items: baseline;
+    align-items: center;
 
     .logs-meta-item__error {
       color: ${theme.colors.error.text};


### PR DESCRIPTION
**What is this feature?**

LogsMetaItems are not correctly aligned if there's a button present.

**Special notes for your reviewer**:

Wrong:
<img width="647" alt="image" src="https://user-images.githubusercontent.com/8092184/212025202-819d156e-6fd1-4400-8fe7-fbf6cd50a09a.png">

Right:
<img width="590" alt="image" src="https://user-images.githubusercontent.com/8092184/212025279-9b280bd4-7e68-49e5-b699-0a3c271ea86b.png">
