### PR TITLE
Alerting: Use pluginBridge to check if plugin is installed

### DIFF
--- a/public/app/features/alerting/unified/AmRoutes.test.tsx
+++ b/public/app/features/alerting/unified/AmRoutes.test.tsx
@@ -21,6 +21,7 @@ import { AccessControlAction } from 'app/types';
 import AmRoutes from './AmRoutes';
 import { fetchAlertManagerConfig, fetchStatus, updateAlertManagerConfig } from './api/alertmanager';
 import { discoverAlertmanagerFeatures } from './api/buildInfo';
+import * as grafanaApp from './components/receivers/grafanaAppReceivers/grafanaApp';
 import { mockDataSource, MockDataSourceSrv, someCloudAlertManagerConfig, someCloudAlertManagerStatus } from './mocks';
 import { defaultGroupBy } from './utils/amroutes';
 import { getAllDataSources } from './utils/config';
@@ -43,6 +44,7 @@ const mocks = {
   },
   contextSrv: jest.mocked(contextSrv),
 };
+const useGetGrafanaReceiverTypeCheckerMock = jest.spyOn(grafanaApp, 'useGetGrafanaReceiverTypeChecker');
 
 const renderAmRoutes = (alertManagerSourceName?: string) => {
   const store = configureStore();
@@ -199,6 +201,7 @@ describe('AmRoutes', () => {
     mocks.contextSrv.evaluatePermission.mockImplementation(() => []);
     mocks.api.discoverAlertmanagerFeatures.mockResolvedValue({ lazyConfigInit: false });
     setDataSourceSrv(new MockDataSourceSrv(dataSources));
+    useGetGrafanaReceiverTypeCheckerMock.mockReturnValue(() => undefined);
   });
 
   afterEach(() => {

--- a/public/app/features/alerting/unified/components/receivers/grafanaAppReceivers/grafanaApp.ts
+++ b/public/app/features/alerting/unified/components/receivers/grafanaAppReceivers/grafanaApp.ts
@@ -1,29 +1,16 @@
-import { useAsync } from 'react-use';
-
-import { getPluginSettings } from 'app/features/plugins/pluginSettings';
 import { Receiver } from 'app/plugins/datasource/alertmanager/types';
 
 import { useGetOnCallIntegrationsQuery } from '../../../api/onCallApi';
+import { SupportedPlugin, usePluginBridge } from '../../PluginBridge';
 
 import { isOnCallReceiver } from './onCall/onCall';
-import { AmRouteReceiver, GrafanaAppReceiverEnum, GRAFANA_APP_PLUGIN_IDS, ReceiverWithTypes } from './types';
-
-export const useGetAppIsInstalledAndEnabled = (grafanaAppType: GrafanaAppReceiverEnum) => {
-  const {
-    loading,
-    error,
-    value: plugin,
-  } = useAsync(() => getPluginSettings(GRAFANA_APP_PLUGIN_IDS[grafanaAppType], { showErrorAlert: false }));
-  const installed = plugin && !error && !loading;
-  return installed;
-};
+import { AmRouteReceiver, GrafanaAppReceiverEnum, ReceiverWithTypes } from './types';
 
 export const useGetGrafanaReceiverTypeChecker = () => {
-  const isOnCallEnabled = useGetAppIsInstalledAndEnabled(GrafanaAppReceiverEnum.GRAFANA_ONCALL);
+  const { installed: isOnCallEnabled } = usePluginBridge(SupportedPlugin.OnCall);
   const { data } = useGetOnCallIntegrationsQuery(undefined, {
     skip: !isOnCallEnabled,
   });
-
   const getGrafanaReceiverType = (receiver: Receiver): GrafanaAppReceiverEnum | undefined => {
     //CHECK FOR ONCALL PLUGIN
     const onCallIntegrations = data ?? [];

--- a/public/app/features/alerting/unified/components/receivers/grafanaAppReceivers/grafanaApp.ts
+++ b/public/app/features/alerting/unified/components/receivers/grafanaAppReceivers/grafanaApp.ts
@@ -1,5 +1,6 @@
-import { useGetSingleLocalWithoutDetails } from 'app/features/plugins/admin/state/hooks';
-import { CatalogPlugin } from 'app/features/plugins/admin/types';
+import { useAsync } from 'react-use';
+
+import { getPluginSettings } from 'app/features/plugins/pluginSettings';
 import { Receiver } from 'app/plugins/datasource/alertmanager/types';
 
 import { useGetOnCallIntegrationsQuery } from '../../../api/onCallApi';
@@ -8,9 +9,13 @@ import { isOnCallReceiver } from './onCall/onCall';
 import { AmRouteReceiver, GrafanaAppReceiverEnum, GRAFANA_APP_PLUGIN_IDS, ReceiverWithTypes } from './types';
 
 export const useGetAppIsInstalledAndEnabled = (grafanaAppType: GrafanaAppReceiverEnum) => {
-  // fetches the plugin settings for this Grafana instance
-  const plugin: CatalogPlugin | undefined = useGetSingleLocalWithoutDetails(GRAFANA_APP_PLUGIN_IDS[grafanaAppType]);
-  return plugin?.isInstalled && !plugin?.isDisabled && plugin?.type === 'app';
+  const {
+    loading,
+    error,
+    value: plugin,
+  } = useAsync(() => getPluginSettings(GRAFANA_APP_PLUGIN_IDS[grafanaAppType], { showErrorAlert: false }));
+  const installed = plugin && !error && !loading;
+  return installed;
 };
 
 export const useGetGrafanaReceiverTypeChecker = () => {


### PR DESCRIPTION
**What is this feature?**

This PR change the way we check if **onCall** plugin is installed. We were using the `api/plugins` endpoint, but it seems that is RBAC protected,  and only admin users not get the non-core list of plugins.
In this PR we use the `/api/plugins/${pluginId}/settings` (used by `usePluginBridge` hook) that is not RBAC protected.

**Why do we need this feature?**

All users should be able to recognise an onCall contact point or notification policy

**Who is this feature for?**

All users.


