### PR TITLE
Navigation: Add close button to dashboard settings

### DIFF
--- a/public/app/features/dashboard/components/DashboardSettings/DashboardSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/DashboardSettings.tsx
@@ -58,6 +58,9 @@ export function DashboardSettings({ dashboard, editview, pageNav, sectionNav }: 
   const size = config.featureToggles.topnav ? 'sm' : 'md';
 
   const actions = [
+    <Button variant="secondary" key="close" fill="outline" size={size} onClick={onClose}>
+      Close
+    </Button>,
     canSaveAs && (
       <SaveDashboardAsButton
         dashboard={dashboard}

--- a/public/app/features/dashboard/components/DashboardSettings/DashboardSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/DashboardSettings.tsx
@@ -58,9 +58,11 @@ export function DashboardSettings({ dashboard, editview, pageNav, sectionNav }: 
   const size = config.featureToggles.topnav ? 'sm' : 'md';
 
   const actions = [
-    <Button variant="secondary" key="close" fill="outline" size={size} onClick={onClose}>
-      Close
-    </Button>,
+    config.featureToggles.topnav && (
+      <Button variant="secondary" key="close" fill="outline" size={size} onClick={onClose}>
+        Close
+      </Button>
+    ),
     canSaveAs && (
       <SaveDashboardAsButton
         dashboard={dashboard}


### PR DESCRIPTION
**What is this feature?**

Adding a close button to the dashboard settings page when topnav is enabled.

<img width="1512" alt="Screenshot 2023-01-12 at 11 59 38" src="https://user-images.githubusercontent.com/100691367/212061115-bee2bea8-ebf7-4a07-a533-a144e583cce0.png">

**Why do we need this feature?**

For the users to have a clear way to go back to the dashboard without having to save or click the breadcrumb.

**Who is this feature for?**

Everyone

**Which issue(s) does this PR fix?**:

Fixes #57990

**Special notes for your reviewer**:

