### PR TITLE
Explore: Unsync time ranges when a pane is closed

### DIFF
--- a/public/app/features/explore/state/main.test.ts
+++ b/public/app/features/explore/state/main.test.ts
@@ -9,7 +9,7 @@ import { reducerTester } from '../../../../test/core/redux/reducerTester';
 import { MockDataSourceApi } from '../../../../test/mocks/datasource_srv';
 import { ExploreId, ExploreItemState, ExploreState } from '../../../types';
 
-import { exploreReducer, navigateToExplore, splitCloseAction, splitOpen } from './main';
+import { exploreReducer, navigateToExplore, splitCloseAction } from './main';
 
 const getNavigateToExploreContext = async (openInNewWindow?: (url: string) => void) => {
   const url = '/explore';

--- a/public/app/features/explore/state/main.test.ts
+++ b/public/app/features/explore/state/main.test.ts
@@ -9,7 +9,7 @@ import { reducerTester } from '../../../../test/core/redux/reducerTester';
 import { MockDataSourceApi } from '../../../../test/mocks/datasource_srv';
 import { ExploreId, ExploreItemState, ExploreState } from '../../../types';
 
-import { exploreReducer, navigateToExplore, splitCloseAction } from './main';
+import { exploreReducer, navigateToExplore, splitCloseAction, splitOpen } from './main';
 
 const getNavigateToExploreContext = async (openInNewWindow?: (url: string) => void) => {
   const url = '/explore';
@@ -141,9 +141,10 @@ describe('Explore reducer', () => {
             left: rightItemMock,
             maxedExploreId: undefined,
             right: undefined,
+            syncedTimes: false,
           } as unknown as ExploreState);
       });
-      it('should reset right pane when it is closed ', () => {
+      it('should reset right pane when it is closed', () => {
         const leftItemMock = {
           containerWidth: 100,
         } as unknown as ExploreItemState;
@@ -167,6 +168,29 @@ describe('Explore reducer', () => {
             left: leftItemMock,
             maxedExploreId: undefined,
             right: undefined,
+            syncedTimes: false,
+          } as unknown as ExploreState);
+      });
+
+      it('should unsync time ranges', () => {
+        const itemMock = {
+          containerWidth: 100,
+        } as unknown as ExploreItemState;
+
+        const initialState = {
+          left: itemMock,
+          right: itemMock,
+          syncedTimes: true,
+        } as unknown as ExploreState;
+
+        reducerTester<ExploreState>()
+          .givenReducer(exploreReducer, initialState)
+          .whenActionIsDispatched(splitCloseAction({ itemId: ExploreId.right }))
+          .thenStateShouldEqual({
+            evenSplitPanes: true,
+            left: itemMock,
+            right: undefined,
+            syncedTimes: false,
           } as unknown as ExploreState);
       });
     });

--- a/public/app/features/explore/state/main.ts
+++ b/public/app/features/explore/state/main.ts
@@ -195,6 +195,7 @@ export const exploreReducer = (state = initialExploreState, action: AnyAction): 
       largerExploreId: undefined,
       maxedExploreId: undefined,
       evenSplitPanes: true,
+      syncedTimes: false,
     };
   }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**


Unsyncs time ranges in explore upon closing a pane when in split mode

**Why do we need this feature?**

When not in split mode, having synced time ranges doesn't make sense as there is no other pane to sync with, moreover the time picker in the toolbar stays in an "active" state, but again that doesn't mean anything when not in split mode.


**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #61272


