### PR TITLE
Preferences: Changed 'Edit profile' to 'Profile'

### DIFF
--- a/public/app/features/profile/UserProfileEditForm.tsx
+++ b/public/app/features/profile/UserProfileEditForm.tsx
@@ -31,7 +31,7 @@ export const UserProfileEditForm: FC<Props> = ({ user, isSavingUser, updateProfi
     <Form onSubmit={onSubmitProfileUpdate} validateOn="onBlur">
       {({ register, errors }) => {
         return (
-          <FieldSet label={<Trans i18nKey="user-profile.title">Edit profile</Trans>}>
+          <FieldSet label={<Trans i18nKey="user-profile.title">Profile</Trans>}>
             <Field
               label={t('user-profile.fields.name-label', 'Name') + lockMessage}
               invalid={!!errors.name}

--- a/public/app/features/profile/UserProfileEditPage.test.tsx
+++ b/public/app/features/profile/UserProfileEditPage.test.tsx
@@ -130,11 +130,11 @@ describe('UserProfileEditPage', () => {
   });
 
   describe('when user has loaded', () => {
-    it('should show edit profile form', async () => {
+    it('should show profile form', async () => {
       await getTestContext();
 
       const { name, email, username, saveProfile } = getSelectors();
-      expect(screen.getByText(/edit profile/i)).toBeInTheDocument();
+      expect(screen.getByText(/profile/i)).toBeInTheDocument();
       expect(name()).toBeInTheDocument();
       expect(name()).toHaveValue('Test User');
       expect(email()).toBeInTheDocument();

--- a/public/locales/de-DE/grafana.json
+++ b/public/locales/de-DE/grafana.json
@@ -542,7 +542,7 @@
       "name-label": "Name",
       "username-label": "Benutzername"
     },
-    "title": "Profil bearbeiten"
+    "title": "Profil"
   },
   "user-session": {
     "browser-column": "Browser & Betriebssystem",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -542,7 +542,7 @@
       "name-label": "Name",
       "username-label": "Username"
     },
-    "title": "Edit profile"
+    "title": "Profile"
   },
   "user-session": {
     "browser-column": "Browser & OS",

--- a/public/locales/es-ES/grafana.json
+++ b/public/locales/es-ES/grafana.json
@@ -542,7 +542,7 @@
       "name-label": "Nombre",
       "username-label": "Nombre de usuario"
     },
-    "title": "Editar perfil"
+    "title": "Perfil"
   },
   "user-session": {
     "browser-column": "Navegador y sistema operativo",

--- a/public/locales/fr-FR/grafana.json
+++ b/public/locales/fr-FR/grafana.json
@@ -542,7 +542,7 @@
       "name-label": "Nom",
       "username-label": "Nom d’utilisateur"
     },
-    "title": "Modifier le profil"
+    "title": "Profil"
   },
   "user-session": {
     "browser-column": "Navigateur et système d'exploitation",

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -542,7 +542,7 @@
       "name-label": "Ńämę",
       "username-label": "Ůşęřŉämę"
     },
-    "title": "Ēđįŧ přőƒįľę"
+    "title": "Přőƒįľę"
   },
   "user-session": {
     "browser-column": "ßřőŵşęř & ØŜ",

--- a/public/locales/zh-Hans/grafana.json
+++ b/public/locales/zh-Hans/grafana.json
@@ -542,7 +542,7 @@
       "name-label": "姓名",
       "username-label": "用户名"
     },
-    "title": "编辑简介"
+    "title": "用户资料"
   },
   "user-session": {
     "browser-column": "浏览器和操作系统",


### PR DESCRIPTION
The profile is not always editable, e.g. when it is synced via OAuth, and all the other sections of the preferences are titled without a verb.

Before:
<img width="729" alt="SS 2023-01-12 at 14 37 44" src="https://user-images.githubusercontent.com/2117580/212081296-21df7b2b-a1f2-49f9-b4c6-2515c9789427.png">

After:
<img width="680" alt="SS 2023-01-12 at 14 38 01" src="https://user-images.githubusercontent.com/2117580/212081413-be567285-2b2b-412a-84b1-e4819846f891.png">

For references, the other sections:
<img width="642" alt="SS 2023-01-12 at 14 41 29" src="https://user-images.githubusercontent.com/2117580/212082024-bdd665f2-df47-46b2-8ec3-ca947bdd62e9.png">


For the local languages, the only one where I have a doubt is the chinese (simplified) one but I have checked with Google Translate and DeepL.
