### PR TITLE
Chore: update lockfile

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -26649,18 +26649,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"loader-utils@npm:^2.0.0":
-  version: 2.0.4
-  resolution: "loader-utils@npm:2.0.4"
-  dependencies:
-    big.js: ^5.2.2
-    emojis-list: ^3.0.0
-    json5: ^2.1.2
-  checksum: a5281f5fff1eaa310ad5e1164095689443630f3411e927f95031ab4fb83b4a98f388185bb1fe949e8ab8d4247004336a625e9255c22122b815bb9a4c5d8fc3b7
-  languageName: node
-  linkType: hard
-
-"loader-utils@npm:^2.0.4":
+"loader-utils@npm:^2.0.0, loader-utils@npm:^2.0.4":
   version: 2.0.4
   resolution: "loader-utils@npm:2.0.4"
   dependencies:


### PR DESCRIPTION
**What is this feature?**

Update lockfile which is currently broken in main. Drone is failing with the following error:

```
➤ YN0000: │ @@ -26648,9 +26648,9 @@
➤ YN0000: │    checksum: e61aea8b6904b8af53d9de6f0484da86c462c0001f4511bedc837cec63deb9475cea813db62f702cd7930420ccb0e75c78112270ca5c8b61b374294f53c0cb3a
➤ YN0000: │    languageName: node
➤ YN0000: │    linkType: hard
➤ YN0000: │  
➤ YN0028: │ -"loader-utils@npm:^2.0.0":
➤ YN0028: │ +"loader-utils@npm:^2.0.0, loader-utils@npm:^2.0.4":
➤ YN0000: │    version: 2.0.4
➤ YN0000: │    resolution: "loader-utils@npm:2.0.4"
➤ YN0000: │    dependencies:
➤ YN0000: │      big.js: ^5.2.2
➤ YN0000: │ @@ -26659,19 +26659,8 @@
➤ YN0000: │    checksum: a5281f5fff1eaa310ad5e1164095689443630f3411e927f95031ab4fb83b4a98f388185bb1fe949e8ab8d4247004336a625e9255c22122b815bb9a4c5d8fc3b7
➤ YN0000: │    languageName: node
➤ YN0000: │    linkType: hard
➤ YN0000: │  
➤ YN0028: │ -"loader-utils@npm:^2.0.4":
➤ YN0028: │ -  version: 2.0.4
➤ YN0028: │ -  resolution: "loader-utils@npm:2.0.4"
➤ YN0028: │ -  dependencies:
➤ YN0028: │ -    big.js: ^5.2.2
➤ YN0028: │ -    emojis-list: ^3.0.0
➤ YN0028: │ -    json5: ^2.1.2
➤ YN0028: │ -  checksum: a5281f5fff1eaa310ad5e1164095689443630f3411e927f95031ab4fb83b4a98f388185bb1fe949e8ab8d4247004336a625e9255c22122b815bb9a4c5d8fc3b7
➤ YN0028: │ -  languageName: node
➤ YN0028: │ -  linkType: hard
➤ YN0028: │ -
➤ YN0000: │  "loader-utils@npm:^3.2.0":
➤ YN0000: │    version: 3.2.1
➤ YN0000: │    resolution: "loader-utils@npm:3.2.1"
➤ YN0000: │    checksum: 4e3ea054cdc8be1ab1f1238f49f42fdf0483039eff920fb1d442039f3f0ad4ebd11fb8e584ccdf2cb7e3c56b3d40c1832416e6408a55651b843da288960cc792
➤ YN0000: │ 
➤ YN0028: │ The lockfile would have been modified by this install, which is explicitly forbidden.
```

**Why do we need this feature?**

To make drone pass again :)
