### PR TITLE
Connections: Show a "No access" modal if the user has no permissions

### DIFF
--- a/packages/grafana-ui/src/components/Alert/Alert.tsx
+++ b/packages/grafana-ui/src/components/Alert/Alert.tsx
@@ -59,7 +59,7 @@ export const Alert = React.forwardRef<HTMLDivElement, Props>(
       error: 'alert',
       warning: 'alert',
       info: 'status',
-      success: 'status',
+      success: 'status', // TMP
     };
     const role = restProps['role'] || rolesBySeverity[severity];
     const ariaLabel = restProps['aria-label'] || title;

--- a/packages/grafana-ui/src/components/Alert/Alert.tsx
+++ b/packages/grafana-ui/src/components/Alert/Alert.tsx
@@ -59,7 +59,7 @@ export const Alert = React.forwardRef<HTMLDivElement, Props>(
       error: 'alert',
       warning: 'alert',
       info: 'status',
-      success: 'status', // TMP
+      success: 'status',
     };
     const role = restProps['role'] || rolesBySeverity[severity];
     const ariaLabel = restProps['aria-label'] || title;

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -136,9 +136,10 @@ func (hs *HTTPServer) registerRoutes() {
 	r.Get("/connections/your-connections/datasources", authorize(reqOrgAdmin, datasources.ConfigurationPageAccess), hs.Index)
 	r.Get("/connections/your-connections/datasources/new", authorize(reqOrgAdmin, datasources.NewPageAccess), hs.Index)
 	r.Get("/connections/your-connections/datasources/edit/*", authorize(reqOrgAdmin, datasources.EditPageAccess), hs.Index)
-	r.Get("/connections/connect-data", middleware.CanAdminPlugins(hs.Cfg), hs.Index)
-	r.Get("/connections/connect-data/datasources/:id", middleware.CanAdminPlugins(hs.Cfg), hs.Index)
-	r.Get("/connections/connect-data/datasources/:id/page/:page", middleware.CanAdminPlugins(hs.Cfg), hs.Index)
+	r.Get("/connections", authorize(reqOrgAdmin, datasources.ConfigurationPageAccess), hs.Index)
+	r.Get("/connections/connect-data", authorize(reqOrgAdmin, datasources.ConfigurationPageAccess), hs.Index)
+	r.Get("/connections/datasources/:id", middleware.CanAdminPlugins(hs.Cfg), hs.Index)
+	r.Get("/connections/datasources/:id/page/:page", middleware.CanAdminPlugins(hs.Cfg), hs.Index)
 
 	// App Root Page
 	appPluginIDScope := plugins.ScopeProvider.GetResourceScope(ac.Parameter(":id"))

--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -569,9 +569,8 @@ func (s *ServiceImpl) buildDataConnectionsNavLink(c *models.ReqContext) *navtree
 
 	baseUrl := s.cfg.AppSubURL + "/connections"
 
-	// Connect data
-	// FIXME: while we don't have a permissions for listing plugins the legacy check has to stay as a default
-	if plugins.ReqCanAdminPlugins(s.cfg)(c) || hasAccess(plugins.ReqCanAdminPlugins(s.cfg), plugins.AdminAccessEvaluator) {
+	if hasAccess(ac.ReqOrgAdmin, datasources.ConfigurationPageAccess) {
+		// Connect data
 		children = append(children, &navtree.NavLink{
 			Id:        "connections-connect-data",
 			Text:      "Connect data",
@@ -580,9 +579,7 @@ func (s *ServiceImpl) buildDataConnectionsNavLink(c *models.ReqContext) *navtree
 			Url:       s.cfg.AppSubURL + "/connections/connect-data",
 			Children:  []*navtree.NavLink{},
 		})
-	}
 
-	if hasAccess(ac.ReqOrgAdmin, datasources.ConfigurationPageAccess) {
 		// Your connections
 		children = append(children, &navtree.NavLink{
 			Id:       "connections-your-connections",

--- a/public/app/features/connections/Connections.tsx
+++ b/public/app/features/connections/Connections.tsx
@@ -2,9 +2,8 @@ import * as React from 'react';
 import { Redirect, Route, Switch } from 'react-router-dom';
 
 import { NavLandingPage } from 'app/core/components/AppChrome/NavLandingPage';
-import { contextSrv } from 'app/core/core';
 import { DataSourcesRoutesContext } from 'app/features/datasources/state';
-import { AccessControlAction, StoreState, useSelector } from 'app/types';
+import { StoreState, useSelector } from 'app/types';
 
 import { ROUTES } from './constants';
 import {
@@ -18,7 +17,6 @@ import {
 export default function Connections() {
   const navIndex = useSelector((state: StoreState) => state.navIndex);
   const isConnectDataPageOverriden = Boolean(navIndex['standalone-plugin-page-/connections/connect-data']);
-  const canAdminPlugins = contextSrv.hasPermission(AccessControlAction.PluginsInstall);
 
   return (
     <DataSourcesRoutesContext.Provider
@@ -30,17 +28,7 @@ export default function Connections() {
       }}
     >
       <Switch>
-        <Route
-          exact
-          path={ROUTES.Base}
-          component={() => {
-            if (canAdminPlugins) {
-              return <Redirect to={ROUTES.ConnectData} />;
-            }
-
-            return <Redirect to={ROUTES.DataSources} />;
-          }}
-        />
+        <Route exact path={ROUTES.Base} component={() => <Redirect to={ROUTES.ConnectData} />} />
         <Route
           exact
           path={ROUTES.YourConnections}

--- a/public/app/features/connections/tabs/ConnectData/CardGrid/CardGrid.tsx
+++ b/public/app/features/connections/tabs/ConnectData/CardGrid/CardGrid.tsx
@@ -39,17 +39,28 @@ const getStyles = (theme: GrafanaTheme2) => ({
   `,
 });
 
+export type CardGridItem = { id: string; name: string; description: string; url: string; logo?: string };
 export interface CardGridProps {
-  items: Array<{ id: string; name: string; url: string; logo?: string }>;
+  items: CardGridItem[];
+  onClickItem?: (e: React.MouseEvent<HTMLElement>, item: CardGridItem) => void;
 }
 
-export const CardGrid: FC<CardGridProps> = ({ items }) => {
+export const CardGrid: FC<CardGridProps> = ({ items, onClickItem }) => {
   const styles = useStyles2(getStyles);
 
   return (
     <ul className={styles.sourcesList}>
       {items.map((item) => (
-        <Card key={item.id} className={styles.card} href={item.url}>
+        <Card
+          key={item.id}
+          className={styles.card}
+          href={item.url}
+          onClick={(e) => {
+            if (onClickItem) {
+              onClickItem(e, item);
+            }
+          }}
+        >
           <Card.Heading>
             <div className={styles.cardContent}>
               {item.logo && (

--- a/public/app/features/connections/tabs/ConnectData/ConnectData.tsx
+++ b/public/app/features/connections/tabs/ConnectData/ConnectData.tsx
@@ -3,7 +3,9 @@ import React, { useMemo, useState } from 'react';
 
 import { PluginType } from '@grafana/data';
 import { useStyles2, LoadingPlaceholder } from '@grafana/ui';
+import { contextSrv } from 'app/core/core';
 import { useGetAllWithFilters } from 'app/features/plugins/admin/state/hooks';
+import { AccessControlAction } from 'app/types';
 
 import { ROUTES } from '../../constants';
 
@@ -30,6 +32,7 @@ export function ConnectData() {
   const [isNoAccessModalOpen, setIsNoAccessModalOpen] = useState(false);
   const [focusedItem, setFocusedItem] = useState<CardGridItem | null>(null);
   const styles = useStyles2(getStyles);
+  const canCreateDataSources = contextSrv.hasPermission(AccessControlAction.DataSourcesCreate);
 
   const handleSearchChange = (e: React.FormEvent<HTMLInputElement>) => {
     setSearchTerm(e.currentTarget.value.toLowerCase());
@@ -53,10 +56,16 @@ export function ConnectData() {
     [plugins]
   );
 
-  const openModal = (e: React.MouseEvent<HTMLElement>, item: CardGridItem) => {
-    e.preventDefault();
-    e.stopPropagation();
+  const onClickCardGridItem = (e: React.MouseEvent<HTMLElement>, item: CardGridItem) => {
+    if (!canCreateDataSources) {
+      e.preventDefault();
+      e.stopPropagation();
 
+      openModal(item);
+    }
+  };
+
+  const openModal = (item: CardGridItem) => {
     setIsNoAccessModalOpen(true);
     setFocusedItem(item);
   };
@@ -80,7 +89,7 @@ export function ConnectData() {
       ) : !!error ? (
         <p>Error: {error.message}</p>
       ) : (
-        <CardGrid items={cardGridItems} onClickItem={openModal} />
+        <CardGrid items={cardGridItems} onClickItem={onClickCardGridItem} />
       )}
       {showNoResults && <NoResults />}
     </>

--- a/public/app/features/connections/tabs/ConnectData/NoAccessModal/NoAccessModal.tsx
+++ b/public/app/features/connections/tabs/ConnectData/NoAccessModal/NoAccessModal.tsx
@@ -1,0 +1,117 @@
+import { css } from '@emotion/css';
+import React from 'react';
+
+import { GrafanaTheme2 } from '@grafana/data';
+import { useStyles2, Modal, Icon, Button } from '@grafana/ui';
+
+import { type CardGridItem } from '../CardGrid';
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  modal: css`
+    width: 500px;
+  `,
+  modalContent: css`
+    overflow: visible;
+    color: ${theme.colors.text.secondary};
+
+    a {
+      color: ${theme.colors.text.link};
+    }
+  `,
+  description: css`
+    margin-bottom: ${theme.spacing.gridSize * 2}px;
+  `,
+  bottomSection: css`
+    display: flex;
+    border-top: 1px solid ${theme.colors.border.weak};
+    padding-top: ${theme.spacing.gridSize * 3}px;
+    margin-top: ${theme.spacing.gridSize * 3}px;
+  `,
+  actionsSection: css`
+    display: flex;
+    justify-content: end;
+    margin-top: ${theme.spacing.gridSize * 3}px;
+  `,
+  warningIcon: css`
+    color: ${theme.colors.warning.main};
+    padding-right: ${theme.spacing.gridSize}px;
+    margin-top: ${theme.spacing.gridSize / 4}px;
+  `,
+  header: css`
+    display: flex;
+    align-items: center;
+  `,
+  headerTitle: css`
+    margin: 0;
+  `,
+  headerLogo: css`
+    margin-right: ${theme.spacing.gridSize * 2}px;
+    width: 32px;
+    height: 32px;
+  `,
+});
+
+export type NoAccessModalProps = {
+  item: CardGridItem;
+  isOpen: boolean;
+  onDismiss: () => void;
+};
+
+export function NoAccessModal({ item, isOpen, onDismiss }: NoAccessModalProps) {
+  const styles = useStyles2(getStyles);
+
+  return (
+    <Modal
+      className={styles.modal}
+      contentClassName={styles.modalContent}
+      title={<NoAccessModalHeader item={item} />}
+      isOpen={isOpen}
+      onDismiss={onDismiss}
+    >
+      <div>
+        <div>
+          {item.description && <div className={styles.description}>{item.description}</div>}
+          <div>
+            Links
+            <br />
+            <a
+              href={`https://grafana.com/grafana/plugins/${item.id}`}
+              title={`${item.name} on Grafana.com`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {item.name}
+            </a>
+          </div>
+        </div>
+        <div className={styles.bottomSection}>
+          <div className={styles.warningIcon}>
+            <Icon name="exclamation-triangle" />
+          </div>
+          <div>
+            <p>
+              Editors cannot add new connections. You may check to see if it is already configured in{' '}
+              <a href="/connections/your-connections">Your Connections</a>.
+            </p>
+            <p>To add a new connection, contact your Grafana admin.</p>
+          </div>
+        </div>
+        <div className={styles.actionsSection}>
+          <Button onClick={onDismiss}>Okay</Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+export function NoAccessModalHeader({ item }: { item: CardGridItem }) {
+  const styles = useStyles2(getStyles);
+  return (
+    <div>
+      <div className={styles.header}>
+        {item.logo && <img className={styles.headerLogo} src={item.logo} alt={`logo of ${item.name}`} />}
+        <h4 className={styles.headerTitle}>{item.name}</h4>
+      </div>
+    </div>
+  );
+}

--- a/public/app/features/connections/tabs/ConnectData/NoAccessModal/index.tsx
+++ b/public/app/features/connections/tabs/ConnectData/NoAccessModal/index.tsx
@@ -1,0 +1,1 @@
+export * from './NoAccessModal';


### PR DESCRIPTION
### What changed?
- [x] Redirect Editors as well to "Connect data" when hitting "Connections" directly
- [x] Update the route restriction for datasources details on the backend
- [x] Show a "No access" modal for Editors when they click on a card in the "Connect data" catalog
- [x] Update tests

![Screenshot 2023-01-12 at 15 57 06](https://user-images.githubusercontent.com/9974811/212100233-62b851d7-bd73-4fee-9635-01e54b5cc49b.png)


I have added some screen recordings below that showcase the functionality from the perspective of the different roles.

---

🎥 **System Admin** (can manage plugins)

https://user-images.githubusercontent.com/9974811/212098162-b1de6496-cc8b-4acb-8890-7bbc972fdf40.mov

---

🎥 **Org Admin** (can manage datasources, but cannot manage plugins)

https://user-images.githubusercontent.com/9974811/212098375-e16956ac-5f64-442c-921a-538c30804877.mov

---

🎥 **Editor** (can only explore datasources and edit dashboards)

https://user-images.githubusercontent.com/9974811/212099739-02f7b089-bd13-495e-8510-391c6e424506.mov

