### PR TITLE
PanelChrome: Slight design improvements to menu button

### DIFF
--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.test.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.test.tsx
@@ -89,8 +89,8 @@ it('renders panel with a header if prop menu', () => {
 it('renders panel with a show-on-hover menu icon if prop menu', () => {
   setup({ menu: <div> Menu </div> });
 
-  expect(screen.getByTestId('menu-icon')).toBeInTheDocument();
-  expect(screen.getByTestId('menu-icon')).not.toBeVisible();
+  expect(screen.getByTestId('panel-menu-button')).toBeInTheDocument();
+  expect(screen.getByTestId('panel-menu-button')).not.toBeVisible();
 });
 
 it.skip('renders states in the panel header if any given', () => {});

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -6,6 +6,7 @@ import { GrafanaTheme2, isIconName, LoadingState } from '@grafana/data';
 
 import { useStyles2, useTheme2 } from '../../themes';
 import { IconName } from '../../types/icon';
+import { Button } from '../Button';
 import { Dropdown } from '../Dropdown/Dropdown';
 import { Icon } from '../Icon/Icon';
 import { IconButton, IconButtonVariant } from '../IconButton/IconButton';
@@ -89,10 +90,12 @@ export function PanelChrome({
   const headerStyles: CSSProperties = {
     height: headerHeight,
   };
+
   const itemStyles: CSSProperties = {
     minHeight: headerHeight,
     minWidth: headerHeight,
   };
+
   const containerStyles: CSSProperties = { width, height };
 
   const isUsingDeprecatedLeftItems = isEmpty(status) && !loadingState;
@@ -153,14 +156,14 @@ export function PanelChrome({
         <div className={styles.rightAligned}>
           {menu && (
             <Dropdown overlay={menu} placement="bottom">
-              <div className={cx(styles.item, styles.menuItem, 'menu-icon')} data-testid="menu-icon" style={itemStyles}>
-                <IconButton
-                  ariaLabel={`Menu for panel with ${title ? `title ${title}` : 'no title'}`}
-                  tooltip="Menu"
-                  name="ellipsis-v"
-                  size="sm"
-                />
-              </div>
+              <Button
+                aria-label={`Menu for panel with ${title ? `title ${title}` : 'no title'}`}
+                tooltip="Menu"
+                icon="ellipsis-v"
+                fill="text"
+                variant="secondary"
+                className={cx(styles.menuItem, 'menu-icon')}
+              />
             </Dropdown>
           )}
 
@@ -252,7 +255,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       label: 'panel-header',
       display: 'flex',
       alignItems: 'center',
-      padding: `0 ${theme.spacing(padding)}`,
+      padding: theme.spacing(0, 0, 0, 1),
     }),
     streaming: css({
       marginRight: 0,

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -11,6 +11,7 @@ import { Dropdown } from '../Dropdown/Dropdown';
 import { Icon } from '../Icon/Icon';
 import { IconButton, IconButtonVariant } from '../IconButton/IconButton';
 import { LoadingBar } from '../LoadingBar/LoadingBar';
+import { ToolbarButton } from '../ToolbarButton';
 import { PopoverContent, Tooltip } from '../Tooltip';
 
 import { PanelStatus } from './PanelStatus';
@@ -156,12 +157,11 @@ export function PanelChrome({
         <div className={styles.rightAligned}>
           {menu && (
             <Dropdown overlay={menu} placement="bottom">
-              <Button
+              <ToolbarButton
                 aria-label={`Menu for panel with ${title ? `title ${title}` : 'no title'}`}
-                tooltip="Menu"
+                title="Menu"
                 icon="ellipsis-v"
-                fill="text"
-                variant="secondary"
+                narrow
                 className={cx(styles.menuItem, 'menu-icon')}
               />
             </Dropdown>
@@ -215,7 +215,7 @@ const getContentStyle = (
 };
 
 const getStyles = (theme: GrafanaTheme2) => {
-  const { padding, background, borderColor } = theme.components.panel;
+  const { background, borderColor } = theme.components.panel;
 
   return {
     container: css({
@@ -283,6 +283,7 @@ const getStyles = (theme: GrafanaTheme2) => {
     }),
     menuItem: css({
       visibility: 'hidden',
+      border: 'none',
     }),
     errorContainer: css({
       label: 'error-container',

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -6,7 +6,6 @@ import { GrafanaTheme2, isIconName, LoadingState } from '@grafana/data';
 
 import { useStyles2, useTheme2 } from '../../themes';
 import { IconName } from '../../types/icon';
-import { Button } from '../Button';
 import { Dropdown } from '../Dropdown/Dropdown';
 import { Icon } from '../Icon/Icon';
 import { IconButton, IconButtonVariant } from '../IconButton/IconButton';

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -162,6 +162,7 @@ export function PanelChrome({
                 title="Menu"
                 icon="ellipsis-v"
                 narrow
+                data-testid="panel-menu-button"
                 className={cx(styles.menuItem, 'menu-icon')}
               />
             </Dropdown>


### PR DESCRIPTION
Tested the new menu as the menu PR was recently merged. 

was not super happy with the look and position of the menu button

* Fix the position of the button so it's in the right corner
* Use ToolbarButton instead (with narrow option). 

Before:
<img width="324" alt="Screenshot 2023-01-12 at 14 55 44" src="https://user-images.githubusercontent.com/10999/212100861-79fbeb32-6847-4de9-91bc-b7b9f947d0aa.png">

After: 
<img width="351" alt="Screenshot 2023-01-12 at 15 22 21" src="https://user-images.githubusercontent.com/10999/212107890-6a951c8a-d7e9-434e-b1b1-1da24ae5a69e.png">


