### PR TITLE
Levitate: Only run against the main branch

### DIFF
--- a/.github/workflows/detect-breaking-changes-build-skip.yml
+++ b/.github/workflows/detect-breaking-changes-build-skip.yml
@@ -8,6 +8,8 @@ on:
   pull_request:
     paths-ignore:
       - "packages/**"
+    branches:
+      - 'main'
 
 jobs:
   detect:

--- a/.github/workflows/detect-breaking-changes-build.yml
+++ b/.github/workflows/detect-breaking-changes-build.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     paths:
       - 'packages/**'
+    branches:
+      - 'main'
 
 jobs:
   buildPR:


### PR DESCRIPTION
### What changed?

> The levitate workflow detects breaking changes and this only makes sense on the main branch.
> By removing this workflow we will save around five minutes of contributor and CI CPU time on each backport.

I am a bit unsure how this is going to work out on those branches - I am not sure if the `detect-breaking-changes-build-skip.yml` workflow is going to kick in, so maybe the workflow on backport PRs will show up as pending. I guess it's not critical though (as only effecting backport PRs), so we can just try? 