### PR TITLE
Datasources: Add support for getDefaultQuery in Annotations and Variable Query Editors

### DIFF
--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -357,7 +357,13 @@ abstract class DataSourceApi<
    * Optionally, use this method to set default values for a query
    * @alpha -- experimental
    */
-  getDefaultQuery?(app: CoreApp): Partial<TQuery>;
+  getDefaultQuery?(app: CoreApp, dataQueryKind?: DataQueryKind): Partial<TQuery>;
+}
+
+export enum DataQueryKind {
+  STANDARD = 'standard',
+  VARIABLE = 'variable',
+  ANNOTATIONS = 'annotations',
 }
 
 export interface MetadataInspectorProps<
@@ -485,6 +491,7 @@ export interface DataQueryRequest<TQuery extends DataQuery = DataQuery> {
   targets: TQuery[];
   timezone: string;
   app: CoreApp | string;
+  dataQueryKind?: DataQueryKind;
 
   cacheTimeout?: string | null;
   rangeRaw?: RawTimeRange;

--- a/public/app/features/annotations/components/StandardAnnotationQueryEditor.tsx
+++ b/public/app/features/annotations/components/StandardAnnotationQueryEditor.tsx
@@ -5,7 +5,9 @@ import { lastValueFrom } from 'rxjs';
 import {
   AnnotationEventMappings,
   AnnotationQuery,
+  CoreApp,
   DataQuery,
+  DataQueryKind,
   DataSourceApi,
   DataSourceInstanceSettings,
   DataSourcePluginContextProvider,
@@ -186,7 +188,11 @@ export default class StandardAnnotationQueryEditor extends PureComponent<Props, 
       return <div>Annotations are not supported. This datasource needs to export a QueryEditor</div>;
     }
 
-    const query = annotation.target ?? { refId: 'Anno' };
+    const query = {
+      ...datasource.getDefaultQuery?.(CoreApp.Dashboard, DataQueryKind.ANNOTATIONS),
+      ...(annotation.target ?? { refId: 'Anno' }),
+    };
+
     return (
       <>
         <DataSourcePluginContextProvider instanceSettings={datasourceInstanceSettings}>

--- a/public/app/features/annotations/executeAnnotationQuery.ts
+++ b/public/app/features/annotations/executeAnnotationQuery.ts
@@ -1,7 +1,7 @@
 import { Observable, of } from 'rxjs';
 import { map, mergeMap } from 'rxjs/operators';
 
-import { CoreApp, DataQueryRequest, DataSourceApi, rangeUtil, ScopedVars } from '@grafana/data';
+import { CoreApp, DataQueryKind, DataQueryRequest, DataSourceApi, rangeUtil, ScopedVars } from '@grafana/data';
 
 import { runRequest } from '../query/state/runRequest';
 
@@ -23,7 +23,11 @@ export function executeAnnotationQuery(
     ...datasource.annotations,
   };
 
-  const annotation = processor.prepareAnnotation!(savedJsonAnno);
+  const annotationWithDefaults = {
+    ...datasource.getDefaultQuery?.(CoreApp.Dashboard, DataQueryKind.ANNOTATIONS),
+    ...savedJsonAnno,
+  };
+  const annotation = processor.prepareAnnotation!(annotationWithDefaults);
   if (!annotation) {
     return of({});
   }
@@ -53,6 +57,7 @@ export function executeAnnotationQuery(
     scopedVars,
     ...interval,
     app: CoreApp.Dashboard,
+    dataQueryKind: DataQueryKind.ANNOTATIONS,
     publicDashboardAccessToken: options.dashboard.meta.publicDashboardAccessToken,
 
     timezone: options.dashboard.timezone,

--- a/public/app/features/query/state/runRequest.ts
+++ b/public/app/features/query/state/runRequest.ts
@@ -9,6 +9,7 @@ import {
   CoreApp,
   DataFrame,
   DataQueryError,
+  DataQueryKind,
   DataQueryRequest,
   DataQueryResponse,
   DataQueryResponseData,
@@ -24,7 +25,6 @@ import {
 import { toDataQueryError } from '@grafana/runtime';
 import { isExpressionReference } from '@grafana/runtime/src/utils/DataSourceWithBackend';
 import { backendSrv } from 'app/core/services/backend_srv';
-import { queryIsEmpty } from 'app/core/utils/query';
 import { dataSource as expressionDatasource } from 'app/features/expressions/ExpressionDatasource';
 import { ExpressionQuery } from 'app/features/expressions/types';
 
@@ -177,9 +177,10 @@ export function callQueryMethod(
   queryFunction?: typeof datasource.query
 ) {
   // If the datasource has defined a default query, make sure it's applied if the query is empty
-  request.targets = request.targets.map((t) =>
-    queryIsEmpty(t) ? { ...datasource?.getDefaultQuery?.(CoreApp.PanelEditor), ...t } : t
-  );
+  request.targets = request.targets.map((t) => ({
+    ...datasource?.getDefaultQuery?.(CoreApp.PanelEditor, request.dataQueryKind ?? DataQueryKind.STANDARD),
+    ...t,
+  }));
 
   // If its a public datasource, just return the result. Expressions will be handled on the backend.
   if (datasource.type === 'public-ds') {

--- a/public/app/features/query/state/runRequest.ts
+++ b/public/app/features/query/state/runRequest.ts
@@ -176,7 +176,7 @@ export function callQueryMethod(
   request: DataQueryRequest,
   queryFunction?: typeof datasource.query
 ) {
-  // If the datasource has defined a default query, make sure it's applied if the query is empty
+  // If the datasource has defined a default query, make sure it's applied
   request.targets = request.targets.map((t) => ({
     ...datasource?.getDefaultQuery?.(CoreApp.PanelEditor, request.dataQueryKind ?? DataQueryKind.STANDARD),
     ...t,

--- a/public/app/features/variables/query/QueryVariableEditor.tsx
+++ b/public/app/features/variables/query/QueryVariableEditor.tsx
@@ -1,7 +1,14 @@
 import React, { FormEvent, PureComponent } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 
-import { DataSourceInstanceSettings, getDataSourceRef, LoadingState, SelectableValue } from '@grafana/data';
+import {
+  CoreApp,
+  DataQueryKind,
+  DataSourceInstanceSettings,
+  getDataSourceRef,
+  LoadingState,
+  SelectableValue,
+} from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { DataSourcePicker, getTemplateSrv } from '@grafana/runtime';
 import { Field } from '@grafana/ui';
@@ -134,8 +141,19 @@ export class QueryVariableEditorUnConnected extends PureComponent<Props, State> 
       return null;
     }
 
-    const query = variable.query;
     const datasource = extended.dataSource;
+
+    let query;
+
+    if (typeof variable.query === 'string') {
+      query = variable.query ? datasource.getDefaultQuery?.(CoreApp.Dashboard, DataQueryKind.VARIABLE) : '';
+    } else {
+      query = {
+        ...datasource.getDefaultQuery?.(CoreApp.Dashboard, DataQueryKind.VARIABLE),
+        ...variable.query,
+      };
+    }
+
     const VariableQueryEditor = extended.VariableQueryEditor;
 
     if (isLegacyQueryEditor(VariableQueryEditor, datasource)) {

--- a/public/app/features/variables/query/VariableQueryRunner.ts
+++ b/public/app/features/variables/query/VariableQueryRunner.ts
@@ -5,6 +5,7 @@ import { v4 as uuidv4 } from 'uuid';
 import {
   CoreApp,
   DataQuery,
+  DataQueryKind,
   DataQueryRequest,
   DataSourceApi,
   getDefaultTimeRange,
@@ -182,6 +183,7 @@ export class VariableQueryRunner {
 
     const request: DataQueryRequest = {
       app: CoreApp.Dashboard,
+      dataQueryKind: DataQueryKind.VARIABLE,
       requestId: uuidv4(),
       timezone: '',
       range,

--- a/public/app/plugins/datasource/cloudwatch/components/VariableQueryEditor/VariableQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/VariableQueryEditor/VariableQueryEditor.test.tsx
@@ -65,7 +65,7 @@ ds.datasource.api.getEc2InstanceAttribute = jest.fn().mockReturnValue([]);
 const onChange = jest.fn();
 const defaultProps: Props = {
   onChange: onChange,
-  query: null,
+  query: defaultQuery,
   datasource: ds.datasource,
   onRunQuery: () => {},
 };
@@ -87,16 +87,6 @@ describe('VariableEditor', () => {
         // Should not render any fields besides Query Type
         const regionSelect = screen.queryByRole('combobox', { name: 'Region' });
         expect(regionSelect).not.toBeInTheDocument();
-      });
-    });
-    it('should render new query with options from getDefaultQuery', async () => {
-      const props = defaultProps;
-      props.query = defaultQuery;
-      render(<VariableQueryEditor {...props} />);
-
-      await waitFor(() => {
-        const regionSelect = screen.queryByRole('combobox', { name: 'Region' });
-        expect(regionSelect?.innerHTML).toEqual('default');
       });
     });
   });

--- a/public/app/plugins/datasource/cloudwatch/components/VariableQueryEditor/VariableQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/VariableQueryEditor/VariableQueryEditor.test.tsx
@@ -65,7 +65,7 @@ ds.datasource.api.getEc2InstanceAttribute = jest.fn().mockReturnValue([]);
 const onChange = jest.fn();
 const defaultProps: Props = {
   onChange: onChange,
-  query: defaultQuery,
+  query: null,
   datasource: ds.datasource,
   onRunQuery: () => {},
 };
@@ -87,6 +87,16 @@ describe('VariableEditor', () => {
         // Should not render any fields besides Query Type
         const regionSelect = screen.queryByRole('combobox', { name: 'Region' });
         expect(regionSelect).not.toBeInTheDocument();
+      });
+    });
+    it('should render new query with options from getDefaultQuery', async () => {
+      const props = defaultProps;
+      props.query = defaultQuery;
+      render(<VariableQueryEditor {...props} />);
+
+      await waitFor(() => {
+        const regionSelect = screen.queryByRole('combobox', { name: 'Region' });
+        expect(regionSelect?.innerHTML).toEqual('default');
       });
     });
   });

--- a/public/app/plugins/datasource/cloudwatch/datasource.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.test.ts
@@ -376,12 +376,12 @@ describe('datasource', () => {
       );
       expect((datasource.getDefaultQuery(CoreApp.PanelEditor) as CloudWatchDefaultQuery).matchExact).toEqual(true);
     });
-    it('should return annotations query if DataQueryKind is annotation', () => {
+    it('should return the default annotations query if DataQueryKind is annotation', () => {
       const { datasource } = setupMockedDataSource();
       expect(datasource.getDefaultQuery(CoreApp.Unknown, DataQueryKind.ANNOTATIONS).queryMode).toEqual('Annotations');
       expect(datasource.getDefaultQuery(CoreApp.Unknown, DataQueryKind.ANNOTATIONS).region).toEqual('default');
     });
-    it('should return variable query if DataQueryKind is variable', () => {
+    it('should return the default variable query if DataQueryKind is variable', () => {
       const { datasource } = setupMockedDataSource();
       expect(datasource.getDefaultQuery(CoreApp.Unknown, DataQueryKind.VARIABLE).queryType).toEqual(
         VariableQueryType.Regions

--- a/public/app/plugins/datasource/cloudwatch/datasource.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.test.ts
@@ -1,7 +1,7 @@
 import { lastValueFrom } from 'rxjs';
 import { toArray } from 'rxjs/operators';
 
-import { CoreApp, dateTime, Field } from '@grafana/data';
+import { CoreApp, DataQueryKind, dateTime, Field } from '@grafana/data';
 
 import {
   CloudWatchSettings,
@@ -14,12 +14,13 @@ import { setupForLogs } from './__mocks__/logsTestContext';
 import { validLogsQuery, validMetricSearchBuilderQuery } from './__mocks__/queries';
 import { TimeRangeMock } from './__mocks__/timeRange';
 import {
+  CloudWatchDefaultQuery,
   CloudWatchLogsQuery,
   CloudWatchMetricsQuery,
   CloudWatchQuery,
-  CloudWatchDefaultQuery,
   MetricEditorMode,
   MetricQueryType,
+  VariableQueryType,
 } from './types';
 
 describe('datasource', () => {
@@ -374,6 +375,18 @@ describe('datasource', () => {
         MetricEditorMode.Builder
       );
       expect((datasource.getDefaultQuery(CoreApp.PanelEditor) as CloudWatchDefaultQuery).matchExact).toEqual(true);
+    });
+    it('should return annotations query if DataQueryKind is annotation', () => {
+      const { datasource } = setupMockedDataSource();
+      expect(datasource.getDefaultQuery(CoreApp.Unknown, DataQueryKind.ANNOTATIONS).queryMode).toEqual('Annotations');
+      expect(datasource.getDefaultQuery(CoreApp.Unknown, DataQueryKind.ANNOTATIONS).region).toEqual('default');
+    });
+    it('should return variable query if DataQueryKind is variable', () => {
+      const { datasource } = setupMockedDataSource();
+      expect(datasource.getDefaultQuery(CoreApp.Unknown, DataQueryKind.VARIABLE).queryType).toEqual(
+        VariableQueryType.Regions
+      );
+      expect(datasource.getDefaultQuery(CoreApp.Unknown, DataQueryKind.VARIABLE).region).toEqual('default');
     });
   });
 });

--- a/public/app/plugins/datasource/cloudwatch/datasource.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.ts
@@ -4,6 +4,7 @@ import { merge, Observable, of } from 'rxjs';
 import {
   CoreApp,
   DataFrame,
+  DataQueryKind,
   DataQueryRequest,
   DataQueryResponse,
   DataSourceInstanceSettings,
@@ -21,7 +22,12 @@ import { RowContextOptions } from '../../../features/logs/components/LogRowConte
 import { CloudWatchAnnotationSupport } from './annotationSupport';
 import { CloudWatchAPI } from './api';
 import { SQLCompletionItemProvider } from './cloudwatch-sql/completion/CompletionItemProvider';
-import { DEFAULT_METRICS_QUERY, getDefaultLogsQuery } from './defaultQueries';
+import {
+  DEFAULT_ANNOTATIONS_QUERY,
+  DEFAULT_METRICS_QUERY,
+  DEFAULT_VARIABLE_QUERY,
+  getDefaultLogsQuery,
+} from './defaultQueries';
 import { isCloudWatchAnnotationQuery, isCloudWatchLogsQuery, isCloudWatchMetricsQuery } from './guards';
 import { CloudWatchLanguageProvider } from './language_provider';
 import { MetricMathCompletionItemProvider } from './metric-math/completion/CompletionItemProvider';
@@ -177,7 +183,13 @@ export class CloudWatchDatasource
     return region;
   }
 
-  getDefaultQuery(_: CoreApp): Partial<CloudWatchQuery> {
+  getDefaultQuery(_: CoreApp, queryKind?: DataQueryKind): Partial<CloudWatchQuery> {
+    if (queryKind === DataQueryKind.ANNOTATIONS) {
+      return DEFAULT_ANNOTATIONS_QUERY;
+    }
+    if (queryKind === DataQueryKind.VARIABLE) {
+      return DEFAULT_VARIABLE_QUERY;
+    }
     return {
       ...getDefaultLogsQuery(this.instanceSettings.jsonData.logGroups, this.instanceSettings.jsonData.defaultLogGroups),
       ...DEFAULT_METRICS_QUERY,

--- a/public/app/plugins/datasource/cloudwatch/defaultQueries.ts
+++ b/public/app/plugins/datasource/cloudwatch/defaultQueries.ts
@@ -1,4 +1,13 @@
-import { CloudWatchLogsQuery, CloudWatchMetricsQuery, LogGroup, MetricEditorMode, MetricQueryType } from './types';
+import {
+  CloudWatchAnnotationQuery,
+  CloudWatchLogsQuery,
+  CloudWatchMetricsQuery,
+  LogGroup,
+  MetricEditorMode,
+  MetricQueryType,
+  VariableQuery,
+  VariableQueryType,
+} from './types';
 
 export const DEFAULT_METRICS_QUERY: Omit<CloudWatchMetricsQuery, 'refId'> = {
   queryMode: 'Metrics',
@@ -15,7 +24,17 @@ export const DEFAULT_METRICS_QUERY: Omit<CloudWatchMetricsQuery, 'refId'> = {
   sqlExpression: '',
   matchExact: true,
 };
+export const DEFAULT_ANNOTATIONS_QUERY: Omit<CloudWatchAnnotationQuery, 'refId'> = {
+  queryMode: 'Annotations',
+  namespace: '',
+  region: 'default',
+  statistic: 'Average',
+};
 
+export const DEFAULT_VARIABLE_QUERY: Partial<VariableQuery> = {
+  queryType: VariableQueryType.Regions,
+  region: 'default',
+};
 export const getDefaultLogsQuery = (
   defaultLogGroups?: LogGroup[],
   legacyDefaultLogGroups?: string[]


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Adding a call to getDefaultQuery, if it's defined in the datasource, in the Annotations and Variable query editors. As well as adding default annotations and variable queries to Cloudwatch to support it there. 

**Why do we need this feature?**

A continuation of implementing [this](https://github.com/grafana/grafana/pull/49581)


<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

