### PR TITLE
Actions: Update pr-commands.yml

### DIFF
--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -22,5 +22,5 @@ jobs:
         uses: ./actions/commands
         with:
           metricsWriteAPIKey: ${{secrets.GRAFANA_MISC_STATS_API_KEY}}
-          token: ${{secrets.GH_BOT_ACCESS_TOKEN}}
+          token: ${{secrets.GITHUB_TOKEN}}
           configPath: pr-commands


### PR DESCRIPTION
We're using 'GITHUB_TOKEN' in PR checks but not in PR commands, causing it to fail (and assign pr/external to everything?)