### PR TITLE
Variables: Support for colons in time variables custom format

### DIFF
--- a/docs/sources/dashboards/variables/add-template-variables/index.md
+++ b/docs/sources/dashboards/variables/add-template-variables/index.md
@@ -247,13 +247,13 @@ Grafana has two built-in time range variables: `$__from` and `$__to`. They are c
 
 > **Note:** This special formatting syntax is only available in Grafana 7.1.2+
 
-| Syntax                   | Example result           | Description                                                                                               |
-| ------------------------ | ------------------------ | --------------------------------------------------------------------------------------------------------- |
-| `${__from}`              | 1594671549254            | Unix millisecond epoch                                                                                    |
-| `${__from:date}`         | 2020-07-13T20:19:09.254Z | No args, defaults to ISO 8601/RFC 3339                                                                    |
-| `${__from:date:iso}`     | 2020-07-13T20:19:09.254Z | ISO 8601/RFC 3339                                                                                         |
-| `${__from:date:seconds}` | 1594671549               | Unix seconds epoch                                                                                        |
-| `${__from:date:YYYY-MM}` | 2020-07                  | Any custom [date format](https://momentjs.com/docs/#/displaying/) that does not include the `:` character |
+| Syntax                   | Example result           | Description                                                       |
+| ------------------------ | ------------------------ | ----------------------------------------------------------------- |
+| `${__from}`              | 1594671549254            | Unix millisecond epoch                                            |
+| `${__from:date}`         | 2020-07-13T20:19:09.254Z | No args, defaults to ISO 8601/RFC 3339                            |
+| `${__from:date:iso}`     | 2020-07-13T20:19:09.254Z | ISO 8601/RFC 3339                                                 |
+| `${__from:date:seconds}` | 1594671549               | Unix seconds epoch                                                |
+| `${__from:date:YYYY-MM}` | 2020-07                  | Any custom [date format](https://momentjs.com/docs/#/displaying/) |
 
 The syntax above also works with `${__to}`.
 

--- a/public/app/features/scenes/variables/interpolation/formatRegistry.test.ts
+++ b/public/app/features/scenes/variables/interpolation/formatRegistry.test.ts
@@ -64,5 +64,9 @@ describe('formatRegistry', () => {
     expect(formatValue(FormatRegistryID.date, 1594671549254, 'text', ['seconds'])).toBe('1594671549');
     expect(formatValue(FormatRegistryID.date, 1594671549254, 'text', ['iso'])).toBe('2020-07-13T20:19:09.254Z');
     expect(formatValue(FormatRegistryID.date, 1594671549254, 'text', ['YYYY-MM'])).toBe('2020-07');
+    expect(formatValue(FormatRegistryID.date, 1594671549254, 'text', ['YYYY-MM', 'ss'])).toBe('2020-07:09');
+    expect(formatValue(FormatRegistryID.date, 1594671549254, 'text', ['YYYY-MM', 'ss', 'YYYY', 'something'])).toBe(
+      '2020-07:09:2020:9o191t2ing'
+    );
   });
 });

--- a/public/app/features/scenes/variables/interpolation/formatRegistry.ts
+++ b/public/app/features/scenes/variables/interpolation/formatRegistry.ts
@@ -268,6 +268,9 @@ export const formatRegistry = new Registry<FormatRegistryItem>(() => {
           case 'iso':
             return dateTime(nrValue).toISOString();
           default:
+            if ((args || []).length > 1) {
+              return dateTime(nrValue).format(args.join(':'));
+            }
             return dateTime(nrValue).format(arg);
         }
       },


### PR DESCRIPTION
**What is this feature?**

This feature adds the support for colon in time variables format. Previously this limitation is documented here in https://github.com/grafana/grafana/blob/e7b8b82c14c625a5ef883cc5cf20e797d659cdba/docs/sources/dashboards/variables/add-template-variables/index.md?plain=1#L256. 

**Why do we need this feature?**

To support colons in variables. Before the fix `${__from:date:YYYY-MM:YYYY}` will produce `2023-01` and after the fix it is now `2023-01:2023`

<img width="1064" alt="image" src="https://user-images.githubusercontent.com/153843/212105123-9895bccf-cade-4a5b-bd51-0344db192cd4.png">

