### PR TITLE
Live: Fix `Subscription to the channel already exists` live streaming error

### DIFF
--- a/public/app/features/live/centrifuge/service.ts
+++ b/public/app/features/live/centrifuge/service.ts
@@ -133,7 +133,10 @@ export class CentrifugeService implements CentrifugeSrv {
       return channel;
     }
     channel.shutdownCallback = () => {
-      this.open.delete(id); // remove it from the list of open channels
+      this.open.delete(id);
+
+      // without a call to `removeSubscription`, the subscription will remain in centrifuge's internal registry
+      this.centrifuge.removeSubscription(this.centrifuge.getSubscription(id));
     };
     this.open.set(id, channel);
 


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/60570

In centrifuge v3, the [`centrifuge.newSubscription`](https://github.com/centrifugal/centrifuge-js/blob/559c970ddd69465fd1ab52b43f48ba765216f6bd/src/centrifuge.ts#L157) call throws an error if the subscription to a channel with a given ID already exists in centrifuge's internal registry.

Our internal representation of [a centrifuge channel unsubscribes from the centrifuge's channel](https://github.com/grafana/grafana/blob/0e6a8cc6ac6286aba1a165d7ea2674b557edf59a/public/app/features/live/centrifuge/channel.ts#L186) after a short time (5s) without listeners (aka - without a single panel displaying data from that channel), but that unsubscription alone does not clear centrifuge's internal registry. In order for that to happen, we need to also call [`centrifuge.removeSubscription`](https://github.com/centrifugal/centrifuge-js/blob/559c970ddd69465fd1ab52b43f48ba765216f6bd/src/centrifuge.ts#L173-L181) on channel shutdown

 