### PR TITLE
Transformations: Add simple gdev dashboard for extract fields 

### DIFF
--- a/devenv/dev-dashboards/transforms/extract-fields.json
+++ b/devenv/dev-dashboards/transforms/extract-fields.json
@@ -1,0 +1,240 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [
+            "gdev",
+            "transform",
+            "transformation",
+            "extract"
+          ],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "testdata",
+        "uid": "gdev-testdata"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "testdata",
+            "uid": "gdev-testdata"
+          },
+          "rawFrameContent": "[\n  {\n    \"schema\": {\n      \"refId\": \"A\",\n      \"meta\": {\n        \"channel\": \"ds/bHGPS1h4z/1s/test\",\n        \"transformations\": [\n          \"extractFields\",\n          \"extractFields\",\n          \"extractFields\"\n        ]\n      },\n      \"fields\": [\n        {\n          \"name\": \"Time\",\n          \"type\": \"time\",\n          \"config\": {\n            \"custom\": {\n              \"align\": \"auto\",\n              \"displayMode\": \"auto\",\n              \"inspect\": false\n            },\n            \"color\": {\n              \"mode\": \"thresholds\"\n            },\n            \"thresholds\": {\n              \"mode\": \"absolute\",\n              \"steps\": [\n                {\n                  \"color\": \"green\",\n                  \"value\": null\n                },\n                {\n                  \"color\": \"red\",\n                  \"value\": 80\n                }\n              ]\n            }\n          }\n        },\n        {\n          \"name\": \"Value\",\n          \"type\": \"other\",\n          \"config\": {\n            \"custom\": {\n              \"align\": \"auto\",\n              \"displayMode\": \"auto\",\n              \"inspect\": false\n            },\n            \"color\": {\n              \"mode\": \"thresholds\"\n            },\n            \"mappings\": [],\n            \"thresholds\": {\n              \"mode\": \"absolute\",\n              \"steps\": [\n                {\n                  \"color\": \"green\",\n                  \"value\": null\n                },\n                {\n                  \"color\": \"red\",\n                  \"value\": 80\n                }\n              ]\n            }\n          }\n        }\n      ]\n    },\n    \"data\": {\n      \"values\": [\n        [\n          1673543683471,\n          1673543689063,\n          1673543695050\n        ],\n        [\n          [\n          \n            62,\n            141,\n            79,\n            29,\n            79,\n            -29,\n            29\n          ],\n          [\n          \n            62,\n            143,\n            81,\n            29,\n            81,\n            -29,\n            29\n          ],\n          [\n          \n            61,\n            146,\n            80,\n            22,\n            85,\n            -28,\n            28\n          ]\n        ]\n      ]\n    }\n  }\n]\n",
+          "refId": "A",
+          "scenarioId": "raw_frame"
+        }
+      ],
+      "title": "Extract array of values",
+      "transformations": [
+        {
+          "id": "extractFields",
+          "options": {
+            "format": "json",
+            "replace": false,
+            "source": "Time"
+          }
+        },
+        {
+          "id": "extractFields",
+          "options": {
+            "format": "json",
+            "replace": false,
+            "source": "Value"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "testdata",
+        "uid": "gdev-testdata"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "9.4.0-pre",
+      "targets": [
+        {
+          "csvContent": "line\n\"{\"\"a\"\":1,\"\"b\"\":2}\"\n\"{\"\"b\"\":3,\"\"c\"\":4}\"\n",
+          "datasource": {
+            "type": "testdata",
+            "uid": "PD8C576611E62080A"
+          },
+          "refId": "A",
+          "scenarioId": "csv_content"
+        }
+      ],
+      "title": "Extract key value pairs",
+      "transformations": [
+        {
+          "id": "extractFields",
+          "options": {
+            "format": "auto",
+            "replace": false,
+            "source": "line"
+          }
+        }
+      ],
+      "type": "table"
+    }
+  ],
+  "refresh": false,
+  "revision": 1,
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "2023-01-12T17:14:43.471Z",
+    "to": "2023-01-12T17:14:55.050Z"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Transformations: Extract Fields",
+  "uid": "_9yU4fhVz",
+  "version": 4,
+  "weekStart": ""
+}


### PR DESCRIPTION
**What is this feature?**
Adding simple usages of transformation to gdev dashboards.

**Why do we need this feature?**
To highlight known use-cases and provide resources for people exploring use-cases and to help facilitate better manual testing of transformations. 

**Who is this feature for?**
People learning about Grafana transformations, developers

**Special notes for your reviewer**:
This is a low priority review, I noticed while looking at https://github.com/grafana/grafana/pull/59400, that we didn't have any examples of this transformation, which would have saved effort for the community member writing that PR, and for the development team reviewing it.