### PR TITLE
Explore: Display all values in graph's tooltip

### DIFF
--- a/public/app/features/explore/Graph/ExploreGraph.tsx
+++ b/public/app/features/explore/Graph/ExploreGraph.tsx
@@ -69,7 +69,7 @@ export function ExploreGraph({
   onHiddenSeriesChanged,
   splitOpenFn,
   graphStyle,
-  tooltipDisplayMode = TooltipDisplayMode.Single,
+  tooltipDisplayMode = TooltipDisplayMode.Multi,
   anchorToZero = false,
   eventBus,
 }: Props) {

--- a/public/app/features/explore/Graph/ExploreGraph.tsx
+++ b/public/app/features/explore/Graph/ExploreGraph.tsx
@@ -49,7 +49,6 @@ interface Props {
   loadingState: LoadingState;
   annotations?: DataFrame[];
   onHiddenSeriesChanged?: (hiddenSeries: string[]) => void;
-  tooltipDisplayMode?: TooltipDisplayMode;
   splitOpenFn: SplitOpen;
   onChangeTime: (timeRange: AbsoluteTimeRange) => void;
   graphStyle: ExploreGraphStyle;
@@ -69,7 +68,6 @@ export function ExploreGraph({
   onHiddenSeriesChanged,
   splitOpenFn,
   graphStyle,
-  tooltipDisplayMode = TooltipDisplayMode.Multi,
   anchorToZero = false,
   eventBus,
 }: Props) {
@@ -149,18 +147,15 @@ export function ExploreGraph({
     },
   };
 
-  const panelOptions: TimeSeriesOptions = useMemo(
-    () => ({
-      tooltip: { mode: tooltipDisplayMode, sort: SortOrder.None },
-      legend: {
-        displayMode: LegendDisplayMode.List,
-        showLegend: true,
-        placement: 'bottom',
-        calcs: [],
-      },
-    }),
-    [tooltipDisplayMode]
-  );
+  const panelOptions: TimeSeriesOptions = {
+    tooltip: { mode: TooltipDisplayMode.Multi, sort: SortOrder.None },
+    legend: {
+      displayMode: LegendDisplayMode.List,
+      showLegend: true,
+      placement: 'bottom',
+      calcs: [],
+    },
+  };
 
   return (
     <PanelContextProvider value={panelContext}>

--- a/public/app/features/explore/LogsVolumePanel.tsx
+++ b/public/app/features/explore/LogsVolumePanel.tsx
@@ -11,7 +11,7 @@ import {
   TimeZone,
   EventBus,
 } from '@grafana/data';
-import { Alert, Button, Collapse, InlineField, TooltipDisplayMode, useStyles2, useTheme2 } from '@grafana/ui';
+import { Alert, Button, Collapse, InlineField, useStyles2, useTheme2 } from '@grafana/ui';
 
 import { ExploreGraph } from './Graph/ExploreGraph';
 
@@ -130,7 +130,6 @@ export function LogsVolumePanel(props: Props) {
           onChangeTime={onUpdateTimeRange}
           timeZone={timeZone}
           splitOpenFn={splitOpen}
-          tooltipDisplayMode={TooltipDisplayMode.Multi}
           onHiddenSeriesChanged={onHiddenSeriesChanged}
           anchorToZero
           eventBus={props.eventBus}


### PR DESCRIPTION
**What is this feature?**

Currently Explore's graph is showing only 1 value in tooltip (the hovered-over one). However, showing all values is probably more useful, as users can see all values without needing to hover over multiple lines. Moreover, log volume is already using multi tooltip mode.

After (with multimode):

<img width="1499" alt="image" src="https://user-images.githubusercontent.com/30407135/212172287-15af5d20-b1c7-4e71-aab1-a64d2460dfcb.png">

Before (single mode):

<img width="1498" alt="image" src="https://user-images.githubusercontent.com/30407135/212172622-250b54d8-5194-43c2-8138-de0da2c155ff.png">





[Add a brief description of what the feature or update does.]

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

