### PR TITLE
ElasticSearch: Improve ES error handling message

### DIFF
--- a/pkg/tsdb/elasticsearch/response_parser.go
+++ b/pkg/tsdb/elasticsearch/response_parser.go
@@ -711,12 +711,15 @@ func getErrorFromElasticResponse(response *es.SearchResponse) string {
 	json := simplejson.NewFromAny(response.Error)
 	reason := json.Get("reason").MustString()
 	rootCauseReason := json.Get("root_cause").GetIndex(0).Get("reason").MustString()
+	causedByReason := json.Get("caused_by").Get("reason").MustString()
 
 	switch {
 	case rootCauseReason != "":
 		errorString = rootCauseReason
 	case reason != "":
 		errorString = reason
+	case causedByReason != "":
+		errorString = causedByReason
 	default:
 		errorString = "Unknown elasticsearch error response"
 	}


### PR DESCRIPTION
**What is this feature?**

The ElasticSearch response that I got from my query was not supported in the "getErrorFromElasticResponse" method. This method looks for `.reason` or `root_cause[0].reason`, but my error response had `caused_by.reason`. This was not supported.

**Why do we need this feature?**

As reported in the issue, I had an "Unknown elasticsearch error response" error, which didn't help me to figure out what I was doing wrong.

**Who is this feature for?**

Users with ES Datasource who get an error.

**Which issue(s) does this PR fix?**:

Fixes #61246
