### PR TITLE
Loki: Fix misaligned derived fields settings

### DIFF
--- a/public/app/plugins/datasource/loki/configuration/DerivedField.tsx
+++ b/public/app/plugins/datasource/loki/configuration/DerivedField.tsx
@@ -93,9 +93,6 @@ export const DerivedField = (props: Props) => {
             event.preventDefault();
             onDelete();
           }}
-          className={css`
-            margin-left: 8px;
-          `}
         />
       </div>
 

--- a/public/app/plugins/datasource/loki/configuration/DerivedField.tsx
+++ b/public/app/plugins/datasource/loki/configuration/DerivedField.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from '@emotion/css';
+import { css } from '@emotion/css';
 import React, { useEffect, useState } from 'react';
 import { usePrevious } from 'react-use';
 

--- a/public/app/plugins/datasource/loki/configuration/DerivedField.tsx
+++ b/public/app/plugins/datasource/loki/configuration/DerivedField.tsx
@@ -1,16 +1,16 @@
-import { css } from '@emotion/css';
+import { css, cx } from '@emotion/css';
 import React, { useEffect, useState } from 'react';
 import { usePrevious } from 'react-use';
 
-import { VariableSuggestion } from '@grafana/data';
+import { GrafanaTheme2, VariableSuggestion } from '@grafana/data';
 import { DataSourcePicker } from '@grafana/runtime';
-import { Button, DataLinkInput, stylesFactory, LegacyForms } from '@grafana/ui';
+import { Button, DataLinkInput, LegacyForms, useStyles2 } from '@grafana/ui';
 
 import { DerivedFieldConfig } from '../types';
 
 const { Switch, FormField } = LegacyForms;
 
-const getStyles = stylesFactory(() => ({
+const getStyles = (theme: GrafanaTheme2) => ({
   row: css`
     display: flex;
     align-items: baseline;
@@ -23,11 +23,12 @@ const getStyles = stylesFactory(() => ({
   `,
   urlField: css`
     flex: 1;
+    margin-right: ${theme.spacing(0.5)};
   `,
   urlDisplayLabelField: css`
     flex: 1;
   `,
-}));
+});
 
 type Props = {
   value: DerivedFieldConfig;
@@ -38,7 +39,7 @@ type Props = {
 };
 export const DerivedField = (props: Props) => {
   const { value, onChange, onDelete, suggestions, className } = props;
-  const styles = getStyles();
+  const styles = useStyles2(getStyles);
   const [showInternalLink, setShowInternalLink] = useState(!!value.datasourceUid);
   const previousUid = usePrevious(value.datasourceUid);
 
@@ -61,10 +62,10 @@ export const DerivedField = (props: Props) => {
 
   return (
     <div className={className} data-testid="derived-field">
-      <div className={styles.row}>
+      <div className="gf-form">
         <FormField
+          labelWidth={10}
           className={styles.nameField}
-          labelWidth={5}
           // A bit of a hack to prevent using default value for the width from FormField
           inputWidth={null}
           label="Name"
@@ -73,6 +74,7 @@ export const DerivedField = (props: Props) => {
           onChange={handleChange('name')}
         />
         <FormField
+          labelWidth={10}
           className={styles.regexField}
           inputWidth={null}
           label="Regex"
@@ -97,8 +99,9 @@ export const DerivedField = (props: Props) => {
         />
       </div>
 
-      <div className={styles.row}>
+      <div className="gf-form">
         <FormField
+          labelWidth={10}
           label={showInternalLink ? 'Query' : 'URL'}
           inputEl={
             <DataLinkInput
@@ -117,6 +120,7 @@ export const DerivedField = (props: Props) => {
         />
         <FormField
           className={styles.urlDisplayLabelField}
+          labelWidth={10}
           inputWidth={null}
           label="URL Label"
           type="text"


### PR DESCRIPTION

**What is this feature?**

The derived fields settings in Loki were misaligned.

**Why do we need this feature?**

Now:
![image](https://user-images.githubusercontent.com/8092184/212305638-50880805-4540-4baf-a9c3-8f04cab41799.png)

Previously:
![image](https://user-images.githubusercontent.com/8092184/212305717-fd327984-e532-435b-b0ae-a06de1548a4c.png)



