### PR TITLE
Undraft and unlist kinds documentation 

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,27 +1,28 @@
 .PHONY: pull docs docs-quick docs-no-pull docs-test docs-local-static
 
+PODMAN = $(shell if command -v podman &>/dev/null; then echo podman; else echo docker; fi)
 IMAGE = grafana/grafana-docs-dev:latest
 CONTENT_PATH = /hugo/content/docs/grafana/next
 LOCAL_STATIC_PATH = ../../website/static
 PORT = 3002:3002
 
 pull:
-	docker pull $(IMAGE)
+	$(PODMAN) pull $(IMAGE)
 
 docs: pull
-	docker run -v $(shell pwd)/sources:$(CONTENT_PATH):Z -p $(PORT) --rm -it $(IMAGE) /bin/bash -c "make server"
+	$(PODMAN) run -v $(shell pwd)/sources:$(CONTENT_PATH):Z -p $(PORT) --rm -it $(IMAGE) /bin/bash -c "make server"
 
 docs-quick: pull
-	docker run -v $(shell pwd)/sources:$(CONTENT_PATH):Z -p $(PORT) --rm -it $(IMAGE) /bin/bash -c "make server-quick"
+	$(PODMAN) run -v $(shell pwd)/sources:$(CONTENT_PATH):Z -p $(PORT) --rm -it $(IMAGE) /bin/bash -c "make server-quick"
 
 docs-no-pull:
-	docker run -v $(shell pwd)/sources:$(CONTENT_PATH):Z -p $(PORT) --rm -it $(IMAGE) /bin/bash -c "make server"
+	$(PODMAN) run -v $(shell pwd)/sources:$(CONTENT_PATH):Z -p $(PORT) --rm -it $(IMAGE) /bin/bash -c "make server"
 
 docs-test: pull
-	docker run -v $(shell pwd)/sources:$(CONTENT_PATH):Z --rm -it $(IMAGE) /bin/bash -c 'make prod'
+	$(PODMAN) run -v $(shell pwd)/sources:$(CONTENT_PATH):Z --rm -it $(IMAGE) /bin/bash -c 'make prod'
 
 # expects that you have grafana/website checked out in same path as the grafana repo.
 docs-local-static: pull
 	if [ ! -d "$(LOCAL_STATIC_PATH)" ]; then echo "local path (website project) $(LOCAL_STATIC_PATH) not found"]; exit 1; fi
-	docker run -v $(shell pwd)/sources:$(CONTENT_PATH):Z \
+	$(PODMAN) run -v $(shell pwd)/sources:$(CONTENT_PATH):Z \
 		-v $(shell pwd)/$(LOCAL_STATIC_PATH):/hugo/static:Z -p $(PORT) --rm -it $(IMAGE)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -12,6 +12,9 @@ pull:
 docs: pull
 	$(PODMAN) run -v $(shell pwd)/sources:$(CONTENT_PATH):Z -p $(PORT) --rm -it $(IMAGE) /bin/bash -c "make server"
 
+docs-preview: pull
+	$(PODMAN) run -v $(shell pwd)/sources:$(CONTENT_PATH):Z -p $(PORT) --rm -it $(IMAGE) /bin/bash -c "make server BUILD_DRAFTS=true"
+
 docs-quick: pull
 	$(PODMAN) run -v $(shell pwd)/sources:$(CONTENT_PATH):Z -p $(PORT) --rm -it $(IMAGE) /bin/bash -c "make server-quick"
 

--- a/docs/sources/developers/kinds/_index.md
+++ b/docs/sources/developers/kinds/_index.md
@@ -6,4 +6,4 @@ weight: 200
 
 # Grafana schema
 
-[Core kinds]({{< relref "core/_index.md" >}})
+{{< section >}}

--- a/docs/sources/developers/kinds/_index.md
+++ b/docs/sources/developers/kinds/_index.md
@@ -1,7 +1,8 @@
 ---
-draft: true
 title: Grafana schema
 weight: 200
+_build:
+  list: false
 ---
 
 # Grafana schema

--- a/docs/sources/developers/kinds/core/_index.md
+++ b/docs/sources/developers/kinds/core/_index.md
@@ -1,5 +1,4 @@
 ---
-draft: true
 title: Core kinds
 weight: 200
 ---

--- a/docs/sources/developers/kinds/core/_index.md
+++ b/docs/sources/developers/kinds/core/_index.md
@@ -8,6 +8,4 @@ weight: 200
 
 Kinds that define Grafana’s core schematized object types - dashboards, datasources, users, etc.
 
-- [Dashboard]({{< relref "dashboard/schema-reference.md" >}})
-- [Playlist]({{< relref "playlist/schema-reference.md" >}})
-- [Team]({{< relref "team/schema-reference.md" >}})
+{{< section >}}


### PR DESCRIPTION
This page and child pages are directly accessible but are not listed
in the table of contents.

> **Note:** as the kind pages are drafted with `draft: true` you need to run `make docs-preview` to see them.

If we want to publish these pages on the website you need to set `draft: false` on those pages.

To manually verify:
1. Run `make docs-preview` from the `docs/sources/` directory.
1. Browse to http://localhost:3002/docs/grafana/next/developers/ and verify that no kinds pages are listed in the table of contents.
1. Browse to http://localhost:3002/docs/grafana/next/developers/kinds/ and verify that "Core kinds" is listed in the page content but still no kinds pages are listed in the table of contents.
1. Browse to http://localhost:3002/docs/grafana/next/developers/kinds/core/playlist/schema-reference/ to view drafted generated content.