### PR TITLE
Logs: Change `detected` to `selected` label

### DIFF
--- a/public/app/features/explore/LogsMetaRow.tsx
+++ b/public/app/features/explore/LogsMetaRow.tsx
@@ -77,7 +77,7 @@ export const LogsMetaRow = React.memo(
     if (displayedFields?.length > 0) {
       logsMetaItem.push(
         {
-          label: 'Showing only detected fields',
+          label: 'Showing only selected fields',
           value: renderMetaItem(displayedFields, LogsMetaKind.LabelsMap),
         },
         {


### PR DESCRIPTION
Followup from #60448 to change the text showing when changing the visibility of a field in LogDetails.