### PR TITLE
Alerting: Set error annotation on EvaluationError regardless of underlying error type

### DIFF
--- a/pkg/services/ngalert/state/state.go
+++ b/pkg/services/ngalert/state/state.go
@@ -229,6 +229,7 @@ func resultError(state *State, rule *models.AlertRule, result eval.Result, logge
 			state.SetError(result.Error, result.EvaluatedAt, nextEndsTime(rule.IntervalSeconds, result.EvaluatedAt))
 
 			if result.Error != nil {
+				state.Annotations["Error"] = result.Error.Error()
 				// If the evaluation failed because a query returned an error then add the Ref ID and
 				// Datasource UID as labels
 				var queryError expr.QueryError
@@ -240,7 +241,6 @@ func resultError(state *State, rule *models.AlertRule, result eval.Result, logge
 							break
 						}
 					}
-					state.Annotations["Error"] = queryError.Error()
 				}
 			}
 		}


### PR DESCRIPTION
**What is this feature?**

Previously we only set the error annotation on a state if the `expr.Result`'s attached error is an `expr.QueryError`. This assumes that the expression engine always wraps its error types consistently. If it fails to do so, there is no Error annotation.

This PR makes it so we always set the Error annotation for all errors, regardless of its type. This appears to be a bug based on the comment, which intends to just add special fields from `expr.QueryError` like `ref_id`/`datasource_uid`

**Which issue(s) does this PR fix?**:

n/a

**Special notes for your reviewer**:

