### PR TITLE
Alerting: Set error annotation on EvaluationError regardless of underlying error type

### DIFF
--- a/pkg/services/ngalert/state/state.go
+++ b/pkg/services/ngalert/state/state.go
@@ -168,7 +168,9 @@ func (a *State) resultError(alertRule *models.AlertRule, result eval.Result) {
 	case models.AlertingErrState:
 		execErrState = eval.Alerting
 	case models.ErrorErrState:
-		a.Annotations["Error"] = a.Error.Error()
+		if a.Error != nil {
+			a.Annotations["Error"] = a.Error.Error()
+		}
 		// If the evaluation failed because a query returned an error then
 		// update the state with the Datasource UID as a label and the error
 		// message as an annotation so other code can use this metadata to

--- a/pkg/services/ngalert/state/state.go
+++ b/pkg/services/ngalert/state/state.go
@@ -168,6 +168,7 @@ func (a *State) resultError(alertRule *models.AlertRule, result eval.Result) {
 	case models.AlertingErrState:
 		execErrState = eval.Alerting
 	case models.ErrorErrState:
+		a.Annotations["Error"] = a.Error.Error()
 		// If the evaluation failed because a query returned an error then
 		// update the state with the Datasource UID as a label and the error
 		// message as an annotation so other code can use this metadata to
@@ -181,7 +182,6 @@ func (a *State) resultError(alertRule *models.AlertRule, result eval.Result) {
 					break
 				}
 			}
-			a.Annotations["Error"] = queryError.Error()
 		}
 		execErrState = eval.Error
 	case models.OkErrState:


### PR DESCRIPTION
Manual backport of https://github.com/grafana/grafana/pull/61506

**What is this feature?**

Previously we only set the error annotation on a state if the `expr.Result`'s attached error is an `expr.QueryError`. This assumes that the expression engine always wraps its error types consistently. If it fails to do so, there is no Error annotation.

This PR makes it so we always set the Error annotation for all errors, regardless of its type. This appears to be a bug based on the comment, which intends to just add special fields from `expr.QueryError` like `ref_id`/`datasource_uid`

**Which issue(s) does this PR fix?**:

n/a

**Special notes for your reviewer**:

