### PR TITLE
Prometheus: Add default editor configuration

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -6356,8 +6356,7 @@ exports[`better eslint`] = {
     ],
     "public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryEditorSelector.test.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "2"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
     ],
     "public/app/plugins/datasource/prometheus/querybuilder/shared/LabelFilterItem.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],

--- a/public/app/plugins/datasource/prometheus/configuration/PromSettings.tsx
+++ b/public/app/plugins/datasource/prometheus/configuration/PromSettings.tsx
@@ -142,8 +142,8 @@ export const PromSettings = (props: Props) => {
   // This update call is typed as void, but it returns a response which we need
   const onUpdate = useUpdateDatasource();
 
-  // We are explicitly adding httpMethod so, it is correctly displayed in dropdown. This way, it is more predictable
-  // for users.
+  // We are explicitly adding httpMethod so, it is correctly displayed in dropdown.
+  // This way, it is more predictable for users.
   if (!options.jsonData.httpMethod) {
     options.jsonData.httpMethod = 'POST';
   }

--- a/public/app/plugins/datasource/prometheus/configuration/PromSettings.tsx
+++ b/public/app/plugins/datasource/prometheus/configuration/PromSettings.tsx
@@ -21,6 +21,7 @@ import {
 
 import { useUpdateDatasource } from '../../../../features/datasources/state';
 import { PromApplication, PromBuildInfoResponse } from '../../../../types/unified-alerting-dto';
+import { QueryEditorMode } from '../querybuilder/shared/types';
 import { PromOptions } from '../types';
 
 import { ExemplarsSettings } from './ExemplarsSettings';
@@ -31,6 +32,11 @@ const { Input, FormField } = LegacyForms;
 const httpOptions = [
   { value: 'POST', label: 'POST' },
   { value: 'GET', label: 'GET' },
+];
+
+const editorOptions = [
+  { value: QueryEditorMode.Builder, label: 'Builder' },
+  { value: QueryEditorMode.Code, label: 'Code' },
 ];
 
 type PrometheusSelectItemsType = Array<{ value: PromApplication; label: PromApplication }>;
@@ -136,7 +142,8 @@ export const PromSettings = (props: Props) => {
   // This update call is typed as void, but it returns a response which we need
   const onUpdate = useUpdateDatasource();
 
-  // We are explicitly adding httpMethod so it is correctly displayed in dropdown. This way, it is more predictable for users.
+  // We are explicitly adding httpMethod so, it is correctly displayed in dropdown. This way, it is more predictable
+  // for users.
   if (!options.jsonData.httpMethod) {
     options.jsonData.httpMethod = 'POST';
   }
@@ -291,6 +298,23 @@ export const PromSettings = (props: Props) => {
               onChange={onUpdateDatasourceJsonDataOptionChecked(props, 'disableMetricsLookup')}
             />
           </InlineField>
+        </div>
+        <div className="gf-form">
+          <FormField
+            label="Default Editor"
+            labelWidth={14}
+            inputEl={
+              <Select
+                aria-label={`Default Editor (Code or Builder)`}
+                options={editorOptions}
+                value={editorOptions.find((o) => o.value === options.jsonData.defaultEditor)}
+                onChange={onChangeHandler('defaultEditor', options, onOptionsChange)}
+                width={20}
+                disabled={options.readOnly}
+              />
+            }
+            tooltip={`Set default editor option (builder/code) for all users of this datasource. If no option was selected, the default editor will be the "builder". If they switch to other option rather than the specified with this setting on the panel we always show the selected editor for that user.`}
+          />
         </div>
         <div className="gf-form-inline">
           <div className="gf-form max-width-30">

--- a/public/app/plugins/datasource/prometheus/datasource.tsx
+++ b/public/app/plugins/datasource/prometheus/datasource.tsx
@@ -50,6 +50,7 @@ import { expandRecordingRules } from './language_utils';
 import { renderLegendFormat } from './legend';
 import PrometheusMetricFindQuery from './metric_find_query';
 import { getInitHints, getQueryHints } from './query_hints';
+import { QueryEditorMode } from './querybuilder/shared/types';
 import { getOriginalMetricName, transform, transformV2 } from './result_transformer';
 import {
   ExemplarTraceIdDestination,
@@ -91,6 +92,7 @@ export class PrometheusDatasource
   customQueryParameters: any;
   datasourceConfigurationPrometheusFlavor?: PromApplication;
   datasourceConfigurationPrometheusVersion?: string;
+  defaultEditor?: QueryEditorMode;
   exemplarsAvailable: boolean;
   subType: PromApplication;
   rulerEnabled: boolean;
@@ -125,6 +127,7 @@ export class PrometheusDatasource
     this.customQueryParameters = new URLSearchParams(instanceSettings.jsonData.customQueryParameters);
     this.datasourceConfigurationPrometheusFlavor = instanceSettings.jsonData.prometheusType;
     this.datasourceConfigurationPrometheusVersion = instanceSettings.jsonData.prometheusVersion;
+    this.defaultEditor = instanceSettings.jsonData.defaultEditor;
     this.variables = new PrometheusVariableSupport(this, this.templateSrv, this.timeSrv);
     this.exemplarsAvailable = true;
 

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryEditorSelector.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryEditorSelector.tsx
@@ -34,12 +34,18 @@ export const INTERVAL_FACTOR_OPTIONS: Array<SelectableValue<number>> = map([1, 2
 type Props = PromQueryEditorProps;
 
 export const PromQueryEditorSelector = React.memo<Props>((props) => {
-  const { onChange, onRunQuery, data, app } = props;
+  const {
+    onChange,
+    onRunQuery,
+    data,
+    app,
+    datasource: { defaultEditor },
+  } = props;
   const [parseModalOpen, setParseModalOpen] = useState(false);
   const [dataIsStale, setDataIsStale] = useState(false);
   const { flag: explain, setFlag: setExplain } = useFlag(promQueryEditorExplainKey);
 
-  const query = getQueryWithDefaults(props.query, app);
+  const query = getQueryWithDefaults(props.query, app, defaultEditor);
   // This should be filled in from the defaults by now.
   const editorMode = query.editorMode!;
 

--- a/public/app/plugins/datasource/prometheus/querybuilder/state.test.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/state.test.ts
@@ -49,4 +49,14 @@ describe('getQueryWithDefaults(', () => {
       QueryEditorMode.Code
     );
   });
+
+  it('should return default editor mode when it is provided', () => {
+    expect(getQueryWithDefaults({ refId: 'A' } as PromQuery, CoreApp.Dashboard, QueryEditorMode.Code)).toEqual({
+      editorMode: 'code',
+      expr: '',
+      legendFormat: '__auto',
+      range: true,
+      refId: 'A',
+    });
+  });
 });

--- a/public/app/plugins/datasource/prometheus/querybuilder/state.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/state.ts
@@ -16,7 +16,7 @@ export function changeEditorMode(query: PromQuery, editorMode: QueryEditorMode, 
   onChange({ ...query, editorMode });
 }
 
-function getDefaultEditorMode(expr: string) {
+function getDefaultEditorMode(expr: string, defaultEditor: QueryEditorMode = QueryEditorMode.Builder): QueryEditorMode {
   // If we already have an expression default to code view
   if (expr != null && expr !== '') {
     return QueryEditorMode.Code;
@@ -28,18 +28,22 @@ function getDefaultEditorMode(expr: string) {
     case QueryEditorMode.Code:
       return value;
     default:
-      return QueryEditorMode.Builder;
+      return defaultEditor;
   }
 }
 
 /**
  * Returns query with defaults, and boolean true/false depending on change was required
  */
-export function getQueryWithDefaults(query: PromQuery, app: CoreApp | undefined): PromQuery {
+export function getQueryWithDefaults(
+  query: PromQuery,
+  app: CoreApp | undefined,
+  defaultEditor?: QueryEditorMode
+): PromQuery {
   let result = query;
 
   if (!query.editorMode) {
-    result = { ...query, editorMode: getDefaultEditorMode(query.expr) };
+    result = { ...query, editorMode: getDefaultEditorMode(query.expr, defaultEditor) };
   }
 
   if (query.expr == null) {

--- a/public/app/plugins/datasource/prometheus/types.ts
+++ b/public/app/plugins/datasource/prometheus/types.ts
@@ -35,6 +35,7 @@ export interface PromOptions extends DataSourceJsonData {
   prometheusType?: PromApplication;
   prometheusVersion?: string;
   enableSecureSocksProxy?: boolean;
+  defaultEditor?: QueryEditorMode;
 }
 
 export type ExemplarTraceIdDestination = {
@@ -116,6 +117,7 @@ export type PromValue = [number, any];
 
 export interface PromMetric {
   __name__?: string;
+
   [index: string]: any;
 }
 


### PR DESCRIPTION
**What is this feature?**

We show builder mode by default for Prometheus. When you switch it to code mode it stays this way for you only. Some of our users want to configure this in the settings of datasource. So this PR adds this functionality. It has backward compatibility so if that setting is not specified nothing will happen. The selection you made while querying will override this setting only for the user. 

![image](https://user-images.githubusercontent.com/820946/212414851-76083f58-8201-411e-86fc-57b2c84e66d9.png)


**Why do we need this feature?**

Some people want to set the default editor option for their datasources. This PR gives that flexibility to them. 

**Who is this feature for?**

Anyone who uses Prometheus and wants to set the default editor for the datasource

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/57366

**Special notes for your reviewer**:

