### PR TITLE
Apps: Use plugin description as nav node subtitle

### DIFF
--- a/pkg/services/navtree/navtreeimpl/applinks.go
+++ b/pkg/services/navtree/navtreeimpl/applinks.go
@@ -70,6 +70,7 @@ func (s *ServiceImpl) processAppPlugin(plugin plugins.PluginDTO, c *models.ReqCo
 		Text:       plugin.Name,
 		Id:         "plugin-page-" + plugin.ID,
 		Img:        plugin.Info.Logos.Small,
+		SubTitle:   plugin.Info.Description,
 		Section:    navtree.NavSectionPlugin,
 		SortWeight: navtree.WeightPlugin,
 		IsSection:  true,


### PR DESCRIPTION
Fixes the issue of some nav nodes for auto generated landing pages having no description:

Before
![image](https://user-images.githubusercontent.com/10999/212672491-81a0a331-0ddb-414c-a20f-f0ecb8d1e9b8.png)

After:
![image](https://user-images.githubusercontent.com/10999/212672536-6e72cc2a-c28f-4df1-a78b-63e3fb9c1bd9.png)
