### PR TITLE
AuthN: Add auth proxy client

### DIFF
--- a/pkg/services/authn/authn.go
+++ b/pkg/services/authn/authn.go
@@ -73,6 +73,10 @@ type PasswordClient interface {
 	AuthenticatePassword(ctx context.Context, r *Request, username, password string) (*Identity, error)
 }
 
+type ProxyClient interface {
+	AuthenticateProxy(ctx context.Context, r *Request, username string) (*Identity, error)
+}
+
 type Request struct {
 	// OrgID will be populated by authn.Service
 	OrgID int64

--- a/pkg/services/authn/authn.go
+++ b/pkg/services/authn/authn.go
@@ -25,6 +25,7 @@ const (
 	ClientRender    = "auth.client.render"
 	ClientSession   = "auth.client.session"
 	ClientForm      = "auth.client.form"
+	ClientProxy     = "auth.client.proxy"
 )
 
 const (

--- a/pkg/services/authn/authn.go
+++ b/pkg/services/authn/authn.go
@@ -74,7 +74,7 @@ type PasswordClient interface {
 }
 
 type ProxyClient interface {
-	AuthenticateProxy(ctx context.Context, r *Request, username string) (*Identity, error)
+	AuthenticateProxy(ctx context.Context, r *Request, username string, additional map[string]string) (*Identity, error)
 }
 
 type Request struct {

--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -85,7 +85,12 @@ func ProvideService(
 	}
 
 	if s.cfg.AuthProxyEnabled {
-		s.clients[authn.ClientProxy] = clients.ProvideProxy(cfg)
+		proxy, err := clients.ProvideProxy(cfg)
+		if err != nil {
+			s.log.Error("failed to configure auth proxy", "err", err)
+		} else {
+			s.clients[authn.ClientProxy] = proxy
+		}
 	}
 
 	if s.cfg.JWTAuthEnabled {

--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -64,12 +64,17 @@ func ProvideService(
 		s.clients[authn.ClientAnonymous] = clients.ProvideAnonymous(cfg, orgService)
 	}
 
+	var proxyClients []authn.ProxyClient
 	var passwordClients []authn.PasswordClient
 	if !s.cfg.DisableLogin {
-		passwordClients = append(passwordClients, clients.ProvideGrafana(userService))
+		grafana := clients.ProvideGrafana(cfg, userService)
+		proxyClients = append(proxyClients, grafana)
+		passwordClients = append(passwordClients, grafana)
 	}
 	if s.cfg.LDAPEnabled {
-		passwordClients = append(passwordClients, clients.ProvideLDAP(cfg))
+		ldap := clients.ProvideLDAP(cfg)
+		proxyClients = append(proxyClients, ldap)
+		passwordClients = append(passwordClients, ldap)
 	}
 
 	// if we have password clients configure check if basic auth or form auth is enabled
@@ -84,8 +89,8 @@ func ProvideService(
 		}
 	}
 
-	if s.cfg.AuthProxyEnabled {
-		proxy, err := clients.ProvideProxy(cfg)
+	if s.cfg.AuthProxyEnabled && len(proxyClients) > 0 {
+		proxy, err := clients.ProvideProxy(cfg, proxyClients...)
 		if err != nil {
 			s.log.Error("failed to configure auth proxy", "err", err)
 		} else {

--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -66,15 +66,16 @@ func ProvideService(
 
 	var proxyClients []authn.ProxyClient
 	var passwordClients []authn.PasswordClient
-	if !s.cfg.DisableLogin {
-		grafana := clients.ProvideGrafana(cfg, userService)
-		proxyClients = append(proxyClients, grafana)
-		passwordClients = append(passwordClients, grafana)
-	}
 	if s.cfg.LDAPEnabled {
 		ldap := clients.ProvideLDAP(cfg)
 		proxyClients = append(proxyClients, ldap)
 		passwordClients = append(passwordClients, ldap)
+	}
+
+	if !s.cfg.DisableLogin {
+		grafana := clients.ProvideGrafana(cfg, userService)
+		proxyClients = append(proxyClients, grafana)
+		passwordClients = append(passwordClients, grafana)
 	}
 
 	// if we have password clients configure check if basic auth or form auth is enabled

--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -85,7 +85,7 @@ func ProvideService(
 	}
 
 	if s.cfg.AuthProxyEnabled {
-		s.clients[authn.ClientProxy] = clients.ProvideProxy()
+		s.clients[authn.ClientProxy] = clients.ProvideProxy(cfg)
 	}
 
 	if s.cfg.JWTAuthEnabled {

--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -84,6 +84,10 @@ func ProvideService(
 		}
 	}
 
+	if s.cfg.AuthProxyEnabled {
+		s.clients[authn.ClientProxy] = clients.ProvideProxy()
+	}
+
 	if s.cfg.JWTAuthEnabled {
 		s.clients[authn.ClientJWT] = clients.ProvideJWT(jwtService, cfg)
 	}

--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/grafana/grafana/pkg/infra/remotecache"
 	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -43,6 +44,7 @@ func ProvideService(
 	userProtectionService login.UserProtectionService,
 	loginAttempts loginattempt.Service, quotaService quota.Service,
 	authInfoService login.AuthInfoService, renderService rendering.Service,
+	remoteCache *remotecache.RemoteCache,
 ) *Service {
 	s := &Service{
 		log:            log.New("authn.service"),
@@ -91,7 +93,7 @@ func ProvideService(
 	}
 
 	if s.cfg.AuthProxyEnabled && len(proxyClients) > 0 {
-		proxy, err := clients.ProvideProxy(cfg, proxyClients...)
+		proxy, err := clients.ProvideProxy(cfg, remoteCache, proxyClients...)
 		if err != nil {
 			s.log.Error("failed to configure auth proxy", "err", err)
 		} else {

--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/grafana/grafana/pkg/infra/remotecache"
 	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -44,7 +43,6 @@ func ProvideService(
 	userProtectionService login.UserProtectionService,
 	loginAttempts loginattempt.Service, quotaService quota.Service,
 	authInfoService login.AuthInfoService, renderService rendering.Service,
-	remoteCache *remotecache.RemoteCache,
 ) *Service {
 	s := &Service{
 		log:            log.New("authn.service"),
@@ -93,7 +91,7 @@ func ProvideService(
 	}
 
 	if s.cfg.AuthProxyEnabled && len(proxyClients) > 0 {
-		proxy, err := clients.ProvideProxy(cfg, remoteCache, proxyClients...)
+		proxy, err := clients.ProvideProxy(cfg, proxyClients...)
 		if err != nil {
 			s.log.Error("failed to configure auth proxy", "err", err)
 		} else {

--- a/pkg/services/authn/authntest/mock.go
+++ b/pkg/services/authn/authntest/mock.go
@@ -26,3 +26,16 @@ func (m MockClient) Test(ctx context.Context, r *authn.Request) bool {
 	}
 	return false
 }
+
+var _ authn.ProxyClient = new(MockProxyClient)
+
+type MockProxyClient struct {
+	AuthenticateProxyFunc func(ctx context.Context, r *authn.Request, username string, additional map[string]string) (*authn.Identity, error)
+}
+
+func (m MockProxyClient) AuthenticateProxy(ctx context.Context, r *authn.Request, username string, additional map[string]string) (*authn.Identity, error) {
+	if m.AuthenticateProxyFunc != nil {
+		return m.AuthenticateProxyFunc(ctx, r, username, additional)
+	}
+	return nil, nil
+}

--- a/pkg/services/authn/clients/grafana.go
+++ b/pkg/services/authn/clients/grafana.go
@@ -56,7 +56,7 @@ func (c *Grafana) AuthenticateProxy(ctx context.Context, r *authn.Request, usern
 		identity.Login = username
 		identity.Email = username
 	default:
-		return nil, errors.New("some error")
+		return nil, errInvalidProxyHeader.Errorf("invalid auth proxy header property, expected username or email but got: %s", c.cfg.AuthProxyHeaderProperty)
 	}
 
 	if headerName := c.cfg.AuthProxyHeaders[proxyFieldName]; headerName != "" {

--- a/pkg/services/authn/clients/grafana.go
+++ b/pkg/services/authn/clients/grafana.go
@@ -85,7 +85,7 @@ func (c *Grafana) AuthenticateProxy(ctx context.Context, r *authn.Request, usern
 				orgID = int64(c.cfg.AutoAssignOrgId)
 			}
 			identity.OrgID = orgID
-			identity.OrgRoles[orgID] = role
+			identity.OrgRoles = map[int64]org.RoleType{orgID: role}
 		}
 	}
 

--- a/pkg/services/authn/clients/ldap.go
+++ b/pkg/services/authn/clients/ldap.go
@@ -22,7 +22,7 @@ type LDAP struct {
 	service ldapService
 }
 
-func (c *LDAP) AuthenticateProxy(ctx context.Context, r *authn.Request, username string) (*authn.Identity, error) {
+func (c *LDAP) AuthenticateProxy(ctx context.Context, r *authn.Request, username string, _ map[string]string) (*authn.Identity, error) {
 	info, err := c.service.User(username)
 	if errors.Is(err, multildap.ErrDidNotFindUser) {
 		return nil, errIdentityNotFound.Errorf("no user found: %w", err)

--- a/pkg/services/authn/clients/ldap_test.go
+++ b/pkg/services/authn/clients/ldap_test.go
@@ -8,10 +8,73 @@ import (
 	"github.com/grafana/grafana/pkg/services/authn"
 	"github.com/grafana/grafana/pkg/services/ldap"
 	"github.com/grafana/grafana/pkg/services/login"
+	"github.com/grafana/grafana/pkg/services/multildap"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestLDAP_AuthenticateProxy(t *testing.T) {
+	type testCase struct {
+		desc             string
+		username         string
+		expectedLDAPErr  error
+		expectedLDAPInfo *models.ExternalUserInfo
+		expectedErr      error
+		expectedIdentity *authn.Identity
+	}
+
+	tests := []testCase{
+		{
+			desc:     "should return valid identity when found by ldap service",
+			username: "test",
+			expectedLDAPInfo: &models.ExternalUserInfo{
+				AuthModule: login.LDAPAuthModule,
+				AuthId:     "123",
+				Email:      "test@test.com",
+				Login:      "test",
+				Name:       "test test",
+				Groups:     []string{"1", "2"},
+				OrgRoles:   map[int64]org.RoleType{1: org.RoleViewer},
+			},
+			expectedIdentity: &authn.Identity{
+				OrgID:      1,
+				OrgRoles:   map[int64]org.RoleType{1: org.RoleViewer},
+				Login:      "test",
+				Name:       "test test",
+				Email:      "test@test.com",
+				AuthModule: login.LDAPAuthModule,
+				AuthID:     "123",
+				Groups:     []string{"1", "2"},
+				ClientParams: authn.ClientParams{
+					SyncUser:            true,
+					SyncTeamMembers:     true,
+					AllowSignUp:         false,
+					EnableDisabledUsers: true,
+					LookUpParams: models.UserLookupParams{
+						Email: strPtr("test@test.com"),
+						Login: strPtr("test"),
+					},
+				},
+			},
+		},
+		{
+			desc:            "should return error when user is not found",
+			username:        "test",
+			expectedLDAPErr: multildap.ErrDidNotFindUser,
+			expectedErr:     errIdentityNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			c := &LDAP{cfg: setting.NewCfg(), service: fakeLDAPService{ExpectedInfo: tt.expectedLDAPInfo, ExpectedErr: tt.expectedLDAPErr}}
+			identity, err := c.AuthenticateProxy(context.Background(), &authn.Request{OrgID: 1}, tt.username)
+			assert.ErrorIs(t, err, tt.expectedErr)
+			assert.EqualValues(t, tt.expectedIdentity, identity)
+		})
+	}
+}
 
 func TestLDAP_AuthenticatePassword(t *testing.T) {
 	type testCase struct {
@@ -20,7 +83,7 @@ func TestLDAP_AuthenticatePassword(t *testing.T) {
 		password         string
 		expectedErr      error
 		expectedLDAPErr  error
-		expectedInfo     *models.ExternalUserInfo
+		expectedLDAPInfo *models.ExternalUserInfo
 		expectedIdentity *authn.Identity
 	}
 
@@ -29,7 +92,7 @@ func TestLDAP_AuthenticatePassword(t *testing.T) {
 			desc:     "should successfully authenticate with correct username and password",
 			username: "test",
 			password: "test123",
-			expectedInfo: &models.ExternalUserInfo{
+			expectedLDAPInfo: &models.ExternalUserInfo{
 				AuthModule: login.LDAPAuthModule,
 				AuthId:     "123",
 				Email:      "test@test.com",
@@ -77,7 +140,7 @@ func TestLDAP_AuthenticatePassword(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			c := &LDAP{cfg: setting.NewCfg(), service: fakeLDAPService{ExpectedInfo: tt.expectedInfo, ExpectedErr: tt.expectedLDAPErr}}
+			c := &LDAP{cfg: setting.NewCfg(), service: fakeLDAPService{ExpectedInfo: tt.expectedLDAPInfo, ExpectedErr: tt.expectedLDAPErr}}
 
 			identity, err := c.AuthenticatePassword(context.Background(), &authn.Request{OrgID: 1}, tt.username, tt.password)
 			assert.ErrorIs(t, err, tt.expectedErr)
@@ -98,5 +161,9 @@ type fakeLDAPService struct {
 }
 
 func (f fakeLDAPService) Login(query *models.LoginUserQuery) (*models.ExternalUserInfo, error) {
+	return f.ExpectedInfo, f.ExpectedErr
+}
+
+func (f fakeLDAPService) User(username string) (*models.ExternalUserInfo, error) {
 	return f.ExpectedInfo, f.ExpectedErr
 }

--- a/pkg/services/authn/clients/ldap_test.go
+++ b/pkg/services/authn/clients/ldap_test.go
@@ -69,7 +69,7 @@ func TestLDAP_AuthenticateProxy(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			c := &LDAP{cfg: setting.NewCfg(), service: fakeLDAPService{ExpectedInfo: tt.expectedLDAPInfo, ExpectedErr: tt.expectedLDAPErr}}
-			identity, err := c.AuthenticateProxy(context.Background(), &authn.Request{OrgID: 1}, tt.username)
+			identity, err := c.AuthenticateProxy(context.Background(), &authn.Request{OrgID: 1}, tt.username, nil)
 			assert.ErrorIs(t, err, tt.expectedErr)
 			assert.EqualValues(t, tt.expectedIdentity, identity)
 		})

--- a/pkg/services/authn/clients/proxy.go
+++ b/pkg/services/authn/clients/proxy.go
@@ -2,25 +2,54 @@ package clients
 
 import (
 	"context"
+	"fmt"
+	"net"
+	"path"
+	"strings"
 
 	"github.com/grafana/grafana/pkg/services/authn"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
+	"github.com/grafana/grafana/pkg/util/errutil"
+)
+
+var (
+	errNotAcceptedIP = errutil.NewBase(errutil.StatusValidationFailed, "auth-proxy.invalid-ip")
 )
 
 var _ authn.Client = new(Proxy)
 
-func ProvideProxy(cfg *setting.Cfg) *Proxy {
-	return &Proxy{cfg}
+func ProvideProxy(cfg *setting.Cfg, clients ...authn.ProxyClient) (*Proxy, error) {
+	list, err := parseAcceptList(cfg.AuthProxyWhitelist)
+	if err != nil {
+		return nil, err
+	}
+	return &Proxy{cfg, clients, list}, nil
 }
 
 type Proxy struct {
-	cfg *setting.Cfg
+	cfg         *setting.Cfg
+	clients     []authn.ProxyClient
+	acceptedIPs []*net.IPNet
 }
 
 func (p *Proxy) Authenticate(ctx context.Context, r *authn.Request) (*authn.Identity, error) {
-	//TODO implement me
-	panic("implement me")
+	if !p.isAllowedIP(r) {
+		return nil, errNotAcceptedIP.Errorf("request ip is not in the configured accept list")
+	}
+
+	username := p.getHeader(r)
+
+	var clientErr error
+	for _, proxyClient := range p.clients {
+		var identity *authn.Identity
+		identity, clientErr = proxyClient.AuthenticateProxy(ctx, r, username)
+		if identity != nil {
+			return identity, nil
+		}
+	}
+
+	return nil, clientErr
 }
 
 func (p *Proxy) Test(ctx context.Context, r *authn.Request) bool {
@@ -36,4 +65,51 @@ func (p *Proxy) getHeader(r *authn.Request) string {
 		v = util.DecodeQuotedPrintable(v)
 	}
 	return v
+}
+
+func (p *Proxy) isAllowedIP(r *authn.Request) bool {
+	if len(p.acceptedIPs) == 0 {
+		return true
+	}
+
+	host, _, err := net.SplitHostPort(r.HTTPRequest.RemoteAddr)
+	if err != nil {
+		return false
+	}
+
+	ip := net.ParseIP(host)
+	for _, v := range p.acceptedIPs {
+		if v.Contains(ip) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func parseAcceptList(s string) ([]*net.IPNet, error) {
+	addresses := strings.Split(s, ",")
+	list := make([]*net.IPNet, 0, len(addresses))
+	for _, addr := range addresses {
+		result, err := coerceProxyAddress(addr)
+		if err != nil {
+			return nil, err
+		}
+		list = append(list, result)
+	}
+	return list, nil
+}
+
+// coerceProxyAddress gets network of the presented CIDR notation
+func coerceProxyAddress(proxyAddr string) (*net.IPNet, error) {
+	proxyAddr = strings.TrimSpace(proxyAddr)
+	if !strings.Contains(proxyAddr, "/") {
+		proxyAddr = path.Join(proxyAddr, "32")
+	}
+
+	_, network, err := net.ParseCIDR(proxyAddr)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse the network: %w", err)
+	}
+	return network, nil
 }

--- a/pkg/services/authn/clients/proxy.go
+++ b/pkg/services/authn/clients/proxy.go
@@ -1,0 +1,26 @@
+package clients
+
+import (
+	"context"
+
+	"github.com/grafana/grafana/pkg/services/authn"
+)
+
+var _ authn.Client = new(Proxy)
+
+func ProvideProxy() *Proxy {
+	return &Proxy{}
+}
+
+type Proxy struct {
+}
+
+func (p Proxy) Authenticate(ctx context.Context, r *authn.Request) (*authn.Identity, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (p Proxy) Test(ctx context.Context, r *authn.Request) bool {
+	//TODO implement me
+	panic("implement me")
+}

--- a/pkg/services/authn/clients/proxy.go
+++ b/pkg/services/authn/clients/proxy.go
@@ -33,15 +33,15 @@ type Proxy struct {
 	acceptedIPs []*net.IPNet
 }
 
-func (p *Proxy) Authenticate(ctx context.Context, r *authn.Request) (*authn.Identity, error) {
-	if !p.isAllowedIP(r) {
+func (c *Proxy) Authenticate(ctx context.Context, r *authn.Request) (*authn.Identity, error) {
+	if !c.isAllowedIP(r) {
 		return nil, errNotAcceptedIP.Errorf("request ip is not in the configured accept list")
 	}
 
-	username := p.getHeader(r)
+	username := c.getHeader(r)
 
 	var clientErr error
-	for _, proxyClient := range p.clients {
+	for _, proxyClient := range c.clients {
 		var identity *authn.Identity
 		identity, clientErr = proxyClient.AuthenticateProxy(ctx, r, username)
 		if identity != nil {
@@ -52,8 +52,8 @@ func (p *Proxy) Authenticate(ctx context.Context, r *authn.Request) (*authn.Iden
 	return nil, clientErr
 }
 
-func (p *Proxy) Test(ctx context.Context, r *authn.Request) bool {
-	return len(p.getHeader(r)) != 0
+func (c *Proxy) Test(ctx context.Context, r *authn.Request) bool {
+	return len(c.getHeader(r)) != 0
 }
 
 func (p *Proxy) getHeader(r *authn.Request) string {

--- a/pkg/services/authn/clients/proxy.go
+++ b/pkg/services/authn/clients/proxy.go
@@ -4,23 +4,36 @@ import (
 	"context"
 
 	"github.com/grafana/grafana/pkg/services/authn"
+	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/util"
 )
 
 var _ authn.Client = new(Proxy)
 
-func ProvideProxy() *Proxy {
-	return &Proxy{}
+func ProvideProxy(cfg *setting.Cfg) *Proxy {
+	return &Proxy{cfg}
 }
 
 type Proxy struct {
+	cfg *setting.Cfg
 }
 
-func (p Proxy) Authenticate(ctx context.Context, r *authn.Request) (*authn.Identity, error) {
+func (p *Proxy) Authenticate(ctx context.Context, r *authn.Request) (*authn.Identity, error) {
 	//TODO implement me
 	panic("implement me")
 }
 
-func (p Proxy) Test(ctx context.Context, r *authn.Request) bool {
-	//TODO implement me
-	panic("implement me")
+func (p *Proxy) Test(ctx context.Context, r *authn.Request) bool {
+	return len(p.getHeader(r)) != 0
+}
+
+func (p *Proxy) getHeader(r *authn.Request) string {
+	if r.HTTPRequest == nil {
+		return ""
+	}
+	v := r.HTTPRequest.Header.Get(p.cfg.AuthProxyHeaderName)
+	if p.cfg.AuthProxyHeadersEncoded {
+		v = util.DecodeQuotedPrintable(v)
+	}
+	return v
 }

--- a/pkg/services/authn/clients/proxy_test.go
+++ b/pkg/services/authn/clients/proxy_test.go
@@ -1,0 +1,11 @@
+package clients
+
+import "testing"
+
+func TestProxy_Authenticate(t *testing.T) {
+
+}
+
+func TestProxy_Test(t *testing.T) {
+
+}

--- a/pkg/services/authn/clients/proxy_test.go
+++ b/pkg/services/authn/clients/proxy_test.go
@@ -5,25 +5,117 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/grafana/grafana/pkg/services/authn/authntest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/grafana/pkg/services/authn"
 	"github.com/grafana/grafana/pkg/setting"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestProxy_Authenticate(t *testing.T) {
 	type testCase struct {
-		desc string
+		desc               string
+		req                *authn.Request
+		ips                string
+		proxyHeader        string
+		proxyHeaders       map[string]string
+		expectedErr        error
+		expectedUsername   string
+		expectedAdditional map[string]string
 	}
 
 	tests := []testCase{
 		{
-			desc: "",
+			desc: "should authenticate using passed in proxy client",
+			ips:  "127.0.0.1",
+			req: &authn.Request{
+				HTTPRequest: &http.Request{
+					Header: map[string][]string{
+						"X-Username": {"username"},
+						"X-Name":     {"name"},
+						"X-Email":    {"email"},
+						"X-Login":    {"login"},
+						"X-Role":     {"Viewer"},
+						"X-Group":    {"grp1,grp2"},
+					},
+					RemoteAddr: "127.0.0.1:333",
+				},
+			},
+			proxyHeader: "X-Username",
+			proxyHeaders: map[string]string{
+				proxyFieldName:   "X-Name",
+				proxyFieldEmail:  "X-Email",
+				proxyFieldLogin:  "X-Login",
+				proxyFieldRole:   "X-Role",
+				proxyFieldGroups: "X-Group",
+			},
+			expectedUsername: "username",
+			expectedAdditional: map[string]string{
+				proxyFieldName:   "name",
+				proxyFieldEmail:  "email",
+				proxyFieldLogin:  "login",
+				proxyFieldRole:   "Viewer",
+				proxyFieldGroups: "grp1,grp2",
+			},
+		},
+		{
+			desc: "should fail when proxy header is empty",
+			req: &authn.Request{
+				HTTPRequest: &http.Request{Header: map[string][]string{
+					"X-Username": {""},
+					"X-Name":     {"name"},
+					"X-Email":    {"email"},
+					"X-Login":    {"login"},
+					"X-Role":     {"Viewer"},
+					"X-Group":    {"grp1,grp2"},
+				}},
+			},
+			proxyHeader: "X-Username",
+			proxyHeaders: map[string]string{
+				proxyFieldName:   "X-Name",
+				proxyFieldEmail:  "X-Email",
+				proxyFieldLogin:  "X-Login",
+				proxyFieldRole:   "X-Role",
+				proxyFieldGroups: "X-Group",
+			},
+			expectedErr: errEmptyProxyHeader,
+		},
+		{
+			desc: "should fail when caller ip is not in accept list",
+			req: &authn.Request{
+				HTTPRequest: &http.Request{
+					Header:     map[string][]string{},
+					RemoteAddr: "127.0.0.2:333",
+				},
+			},
+			ips:         "127.0.0.1",
+			expectedErr: errNotAcceptedIP,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
+			cfg := setting.NewCfg()
+			cfg.AuthProxyHeaderName = "X-Username"
+			cfg.AuthProxyHeaders = tt.proxyHeaders
+			cfg.AuthProxyWhitelist = tt.ips
 
+			calledUsername := ""
+			var calledAdditional map[string]string
+
+			proxyClient := authntest.MockProxyClient{AuthenticateProxyFunc: func(ctx context.Context, r *authn.Request, username string, additional map[string]string) (*authn.Identity, error) {
+				calledUsername = username
+				calledAdditional = additional
+				return nil, nil
+			}}
+			c, err := ProvideProxy(cfg, proxyClient)
+			require.NoError(t, err)
+
+			_, err = c.Authenticate(context.Background(), tt.req)
+			assert.ErrorIs(t, err, tt.expectedErr)
+			assert.Equal(t, tt.expectedUsername, calledUsername)
+			assert.EqualValues(t, tt.expectedAdditional, calledAdditional)
 		})
 	}
 }

--- a/pkg/services/authn/clients/proxy_test.go
+++ b/pkg/services/authn/clients/proxy_test.go
@@ -1,11 +1,66 @@
 package clients
 
-import "testing"
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/grafana/grafana/pkg/services/authn"
+	"github.com/grafana/grafana/pkg/setting"
+	"github.com/stretchr/testify/assert"
+)
 
 func TestProxy_Authenticate(t *testing.T) {
 
 }
 
 func TestProxy_Test(t *testing.T) {
+	type testCase struct {
+		desc       string
+		req        *authn.Request
+		expectedOK bool
+	}
 
+	tests := []testCase{
+		{
+			desc: "should return true when proxy header exists",
+			req: &authn.Request{
+				HTTPRequest: &http.Request{
+					Header: map[string][]string{"Proxy-Header": {"some value"}},
+				},
+			},
+			expectedOK: true,
+		},
+		{
+			desc: "should return false when proxy header exists but has no value",
+			req: &authn.Request{
+				HTTPRequest: &http.Request{
+					Header: map[string][]string{"Proxy-Header": {""}},
+				},
+			},
+			expectedOK: false,
+		},
+		{
+			desc: "should return false when no proxy header is set on request",
+			req: &authn.Request{
+				HTTPRequest: &http.Request{Header: map[string][]string{}},
+			},
+			expectedOK: false,
+		},
+		{
+			desc:       "should return false when no http request is present",
+			req:        &authn.Request{},
+			expectedOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			cfg := setting.NewCfg()
+			cfg.AuthProxyHeaderName = "Proxy-Header"
+
+			c := ProvideProxy(cfg)
+			assert.Equal(t, tt.expectedOK, c.Test(context.Background(), tt.req))
+		})
+	}
 }

--- a/pkg/services/authn/clients/proxy_test.go
+++ b/pkg/services/authn/clients/proxy_test.go
@@ -11,7 +11,21 @@ import (
 )
 
 func TestProxy_Authenticate(t *testing.T) {
+	type testCase struct {
+		desc string
+	}
 
+	tests := []testCase{
+		{
+			desc: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+
+		})
+	}
 }
 
 func TestProxy_Test(t *testing.T) {
@@ -59,7 +73,7 @@ func TestProxy_Test(t *testing.T) {
 			cfg := setting.NewCfg()
 			cfg.AuthProxyHeaderName = "Proxy-Header"
 
-			c, _ := ProvideProxy(cfg)
+			c, _ := ProvideProxy(cfg, nil)
 			assert.Equal(t, tt.expectedOK, c.Test(context.Background(), tt.req))
 		})
 	}

--- a/pkg/services/authn/clients/proxy_test.go
+++ b/pkg/services/authn/clients/proxy_test.go
@@ -59,7 +59,7 @@ func TestProxy_Test(t *testing.T) {
 			cfg := setting.NewCfg()
 			cfg.AuthProxyHeaderName = "Proxy-Header"
 
-			c := ProvideProxy(cfg)
+			c, _ := ProvideProxy(cfg)
 			assert.Equal(t, tt.expectedOK, c.Test(context.Background(), tt.req))
 		})
 	}

--- a/pkg/services/contexthandler/auth_proxy_test.go
+++ b/pkg/services/contexthandler/auth_proxy_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/auth/authtest"
 	"github.com/grafana/grafana/pkg/services/authn/authntest"
 	"github.com/grafana/grafana/pkg/services/contexthandler/authproxy"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/login/loginservice"
 	"github.com/grafana/grafana/pkg/services/org/orgtest"
 	"github.com/grafana/grafana/pkg/services/rendering"
@@ -106,7 +107,7 @@ func getContextHandler(t *testing.T) *ContextHandler {
 
 	return ProvideService(cfg, userAuthTokenSvc, authJWTSvc, remoteCacheSvc,
 		renderSvc, sqlStore, tracer, authProxy, loginService, nil, authenticator,
-		&userService, orgService, nil, nil, &authntest.FakeService{})
+		&userService, orgService, nil, featuremgmt.WithFeatures(), &authntest.FakeService{})
 }
 
 type fakeAuthenticator struct{}


### PR DESCRIPTION
**What is this feature?**
Add auth proxy client implementation for authn.Service.

This introduce a new interface, ProxyClient, that can be implemented by other clients. Atm ldap and grafana clients implements the ProxyClient inteface.

One feature missing is the ability to cache auth proxy requests so syncs is not happening on every request, will add it in another pr.

**Special notes for your reviewer**:
* Swap order of ldap and grafana clients

