### PR TITLE
CommandPalette: Minor usability improvements

### DIFF
--- a/public/app/features/commandPalette/CommandPalette.tsx
+++ b/public/app/features/commandPalette/CommandPalette.tsx
@@ -56,7 +56,10 @@ export const CommandPalette = () => {
         <KBarAnimator className={styles.animator}>
           <FocusScope contain autoFocus restoreFocus>
             <div {...overlayProps} {...dialogProps}>
-              <KBarSearch className={styles.search} />
+              <KBarSearch
+                defaultPlaceholder={t('command-palette.search-box.placeholder', 'Search Grafana')}
+                className={styles.search}
+              />
               <RenderResults dashboardResults={dashboardResults} />
             </div>
           </FocusScope>

--- a/public/app/features/commandPalette/ResultItem.tsx
+++ b/public/app/features/commandPalette/ResultItem.tsx
@@ -59,15 +59,6 @@ export const ResultItem = React.forwardRef(
           </div>
           {action.subtitle && <span className={styles.subtitleText}>{action.subtitle}</span>}
         </div>
-        {action.shortcut?.length ? (
-          <div aria-hidden className={styles.shortcutContainer}>
-            {action.shortcut.map((sc) => (
-              <kbd key={sc} className={styles.shortcut}>
-                {sc}
-              </kbd>
-            ))}
-          </div>
-        ) : null}
       </div>
     );
   }

--- a/public/app/features/commandPalette/actions/dashboardActions.ts
+++ b/public/app/features/commandPalette/actions/dashboardActions.ts
@@ -36,7 +36,7 @@ export async function getRecentDashboardActions(): Promise<CommandPaletteAction[
     return {
       id: `recent-dashboards/${url}`,
       name: `${name}`,
-      section: t('command-palette.section.recent-dashboards', 'Recently viewed dashboards'),
+      section: t('command-palette.section.recent-dashboards', 'Recent dashboards'),
       priority: RECENT_DASHBOARDS_PRORITY,
       perform: () => {
         locationService.push(locationUtil.stripBaseFromUrl(url));

--- a/public/app/features/commandPalette/actions/staticActions.ts
+++ b/public/app/features/commandPalette/actions/staticActions.ts
@@ -55,7 +55,6 @@ export default (navBarTree: NavModelItem[]): CommandPaletteAction[] => {
       keywords: 'navigate',
       perform: () => locationService.push('?search=open'),
       section: t('command-palette.section.pages', 'Pages'),
-      shortcut: ['s', 'o'],
       priority: DEFAULT_PRIORITY,
     },
     {
@@ -63,7 +62,6 @@ export default (navBarTree: NavModelItem[]): CommandPaletteAction[] => {
       name: t('command-palette.action.change-theme', 'Change theme...'),
       keywords: 'interface color dark light',
       section: t('command-palette.section.preferences', 'Preferences'),
-      shortcut: ['c', 't'],
       priority: PREFERENCES_PRIORITY,
     },
     {

--- a/public/locales/de-DE/grafana.json
+++ b/public/locales/de-DE/grafana.json
@@ -12,6 +12,9 @@
       "light-theme": "",
       "search": ""
     },
+    "search-box": {
+      "placeholder": ""
+    },
     "section": {
       "actions": "",
       "dashboard-search-results": "",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12,12 +12,15 @@
       "light-theme": "Light",
       "search": "Search"
     },
+    "search-box": {
+      "placeholder": "Search Grafana"
+    },
     "section": {
       "actions": "Actions",
       "dashboard-search-results": "Dashboards",
       "pages": "Pages",
       "preferences": "Preferences",
-      "recent-dashboards": "Recently viewed dashboards"
+      "recent-dashboards": "Recent dashboards"
     }
   },
   "common": {

--- a/public/locales/es-ES/grafana.json
+++ b/public/locales/es-ES/grafana.json
@@ -12,6 +12,9 @@
       "light-theme": "",
       "search": ""
     },
+    "search-box": {
+      "placeholder": ""
+    },
     "section": {
       "actions": "",
       "dashboard-search-results": "",

--- a/public/locales/fr-FR/grafana.json
+++ b/public/locales/fr-FR/grafana.json
@@ -12,6 +12,9 @@
       "light-theme": "",
       "search": ""
     },
+    "search-box": {
+      "placeholder": ""
+    },
     "section": {
       "actions": "",
       "dashboard-search-results": "",

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -12,12 +12,15 @@
       "light-theme": "Ŀįģĥŧ",
       "search": "Ŝęäřčĥ"
     },
+    "search-box": {
+      "placeholder": "Ŝęäřčĥ Ğřäƒäŉä"
+    },
     "section": {
       "actions": "Åčŧįőŉş",
       "dashboard-search-results": "Đäşĥþőäřđş",
       "pages": "Päģęş",
       "preferences": "Přęƒęřęŉčęş",
-      "recent-dashboards": "Ŗęčęŉŧľy vįęŵęđ đäşĥþőäřđş"
+      "recent-dashboards": "Ŗęčęŉŧ đäşĥþőäřđş"
     }
   },
   "common": {

--- a/public/locales/zh-Hans/grafana.json
+++ b/public/locales/zh-Hans/grafana.json
@@ -12,6 +12,9 @@
       "light-theme": "",
       "search": ""
     },
+    "search-box": {
+      "placeholder": ""
+    },
     "section": {
       "actions": "",
       "dashboard-search-results": "",


### PR DESCRIPTION
**What is this feature?**

Three quick minor improvements from the mob session https://github.com/grafana/grafana/pull/61503

 - Changes Command Palette search placeholder to "Search Grafana'
 - Change "Recently viewed dashboards" to "Recent dashboards"
 - Remove shortcut display

**Why do we need this feature?**

So Command Palette is more consistent with the rest of Grafana, and doesn't confuse users

**Who is this feature for?**

Everyone!
