### PR TITLE
RBAC: remove access control mock from org quota tests

### DIFF
--- a/pkg/api/org_test.go
+++ b/pkg/api/org_test.go
@@ -1,8 +1,6 @@
 package api
 
 import (
-	"context"
-	"fmt"
 	"net/http"
 	"strings"
 	"testing"
@@ -14,7 +12,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/accesscontrol/actest"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/org/orgtest"
-	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/services/user/usertest"
 	"github.com/grafana/grafana/pkg/setting"
@@ -620,20 +617,5 @@ func TestAPIEndpoint_GetOrg_RBAC(t *testing.T) {
 			// fetch by name
 			verify("/api/orgs/name/test")
 		})
-	}
-}
-
-// setupOrgsDBForAccessControlTests creates orgs up until orgID and fake user as member of org
-func setupOrgsDBForAccessControlTests(t *testing.T, db *sqlstore.SQLStore, c accessControlScenarioContext, orgID int64) {
-	t.Helper()
-	setInitCtxSignedInViewer(c.initCtx)
-	u := *c.initCtx.SignedInUser
-	u.OrgID = orgID
-	c.userService.(*usertest.FakeUserService).ExpectedSignedInUser = &u
-
-	// Create `orgsCount` orgs
-	for i := 1; i <= int(orgID); i++ {
-		_, err := c.hs.orgService.CreateWithMember(context.Background(), &org.CreateOrgCommand{Name: fmt.Sprintf("TestOrg%v", i), UserID: 0})
-		require.NoError(t, err)
 	}
 }

--- a/pkg/api/quota_test.go
+++ b/pkg/api/quota_test.go
@@ -41,16 +41,16 @@ func TestAPIEndpoint_GetCurrentOrgQuotas_LegacyAccessControl(t *testing.T) {
 		hs.Cfg = cfg
 	})
 
-	t.Run("Viewer can view CurrentOrgQuotas", func(t *testing.T) {
-		req := webtest.RequestWithSignedInUser(server.NewGetRequest(getCurrentOrgQuotasURL), &user.SignedInUser{OrgID: 1, OrgRole: org.RoleViewer})
+	t.Run("Unsigned user cannot view CurrentOrgQuotas", func(t *testing.T) {
+		req := server.NewGetRequest(getCurrentOrgQuotasURL)
 		res, err := server.Send(req)
 		require.NoError(t, err)
-		assert.Equal(t, http.StatusOK, res.StatusCode)
+		assert.Equal(t, http.StatusUnauthorized, res.StatusCode)
 		require.NoError(t, res.Body.Close())
 	})
 
-	t.Run("Unsigned user cannot view CurrentOrgQuotas", func(t *testing.T) {
-		req := server.NewGetRequest(getCurrentOrgQuotasURL)
+	t.Run("Viewer can view CurrentOrgQuotas", func(t *testing.T) {
+		req := webtest.RequestWithSignedInUser(server.NewGetRequest(getCurrentOrgQuotasURL), &user.SignedInUser{OrgID: 1, OrgRole: org.RoleViewer})
 		res, err := server.Send(req)
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, res.StatusCode)

--- a/pkg/api/quota_test.go
+++ b/pkg/api/quota_test.go
@@ -7,9 +7,14 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/org"
+	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/grafana/grafana/pkg/services/user/usertest"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/web/webtest"
 )
 
 var (
@@ -28,57 +33,61 @@ var testOrgQuota = setting.OrgQuota{
 	AlertRule:  10,
 }
 
-// setupDBAndSettingsForAccessControlQuotaTests stores users and create two orgs
-func setupDBAndSettingsForAccessControlQuotaTests(t *testing.T, sc accessControlScenarioContext) {
-	t.Helper()
-
-	// Create two orgs with the context user
-	setupOrgsDBForAccessControlTests(t, sc.db, sc, 2)
-}
-
 func TestAPIEndpoint_GetCurrentOrgQuotas_LegacyAccessControl(t *testing.T) {
 	cfg := setting.NewCfg()
 	cfg.Quota.Enabled = true
 	cfg.RBACEnabled = false
-	sc := setupHTTPServerWithCfg(t, true, cfg)
-	setInitCtxSignedInViewer(sc.initCtx)
-
-	setupDBAndSettingsForAccessControlQuotaTests(t, sc)
-
-	t.Run("Viewer can view CurrentOrgQuotas", func(t *testing.T) {
-		response := callAPI(sc.server, http.MethodGet, getCurrentOrgQuotasURL, nil, t)
-		assert.Equal(t, http.StatusOK, response.Code)
+	server := SetupAPITestServer(t, func(hs *HTTPServer) {
+		hs.Cfg = cfg
 	})
 
-	sc.initCtx.IsSignedIn = false
+	t.Run("Viewer can view CurrentOrgQuotas", func(t *testing.T) {
+		req := webtest.RequestWithSignedInUser(server.NewGetRequest(getCurrentOrgQuotasURL), &user.SignedInUser{OrgID: 1, OrgRole: org.RoleViewer})
+		res, err := server.Send(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, res.StatusCode)
+		require.NoError(t, res.Body.Close())
+	})
+
 	t.Run("Unsigned user cannot view CurrentOrgQuotas", func(t *testing.T) {
-		response := callAPI(sc.server, http.MethodGet, getCurrentOrgQuotasURL, nil, t)
-		assert.Equal(t, http.StatusUnauthorized, response.Code)
+		req := server.NewGetRequest(getCurrentOrgQuotasURL)
+		res, err := server.Send(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, res.StatusCode)
+		require.NoError(t, res.Body.Close())
 	})
 }
 
 func TestAPIEndpoint_GetCurrentOrgQuotas_AccessControl(t *testing.T) {
 	cfg := setting.NewCfg()
 	cfg.Quota.Enabled = true
-	sc := setupHTTPServerWithCfg(t, true, cfg)
-	setInitCtxSignedInViewer(sc.initCtx)
-
-	setupDBAndSettingsForAccessControlQuotaTests(t, sc)
+	server := SetupAPITestServer(t, func(hs *HTTPServer) {
+		hs.Cfg = cfg
+	})
 
 	t.Run("AccessControl allows viewing CurrentOrgQuotas with correct permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []accesscontrol.Permission{{Action: accesscontrol.ActionOrgsQuotasRead}}, sc.initCtx.OrgID)
-		response := callAPI(sc.server, http.MethodGet, getCurrentOrgQuotasURL, nil, t)
-		assert.Equal(t, http.StatusOK, response.Code)
+		req := webtest.RequestWithSignedInUser(server.NewGetRequest(getCurrentOrgQuotasURL), userWithPermissions(1, []accesscontrol.Permission{{Action: accesscontrol.ActionOrgsQuotasRead}}))
+		res, err := server.Send(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, res.StatusCode)
+		require.NoError(t, res.Body.Close())
 	})
 	t.Run("AccessControl prevents viewing CurrentOrgQuotas with correct permissions in another org", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []accesscontrol.Permission{{Action: accesscontrol.ActionOrgsQuotasRead}}, 2)
-		response := callAPI(sc.server, http.MethodGet, getCurrentOrgQuotasURL, nil, t)
-		assert.Equal(t, http.StatusForbidden, response.Code)
+		// Set permissions in org 2, but set current org to org 1
+		user := userWithPermissions(2, []accesscontrol.Permission{{Action: accesscontrol.ActionOrgsQuotasRead}})
+		user.OrgID = 1
+		req := webtest.RequestWithSignedInUser(server.NewGetRequest(getCurrentOrgQuotasURL), user)
+		res, err := server.Send(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusForbidden, res.StatusCode)
+		require.NoError(t, res.Body.Close())
 	})
 	t.Run("AccessControl prevents viewing CurrentOrgQuotas with incorrect permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []accesscontrol.Permission{{Action: "orgs:invalid"}}, sc.initCtx.OrgID)
-		response := callAPI(sc.server, http.MethodGet, getCurrentOrgQuotasURL, nil, t)
-		assert.Equal(t, http.StatusForbidden, response.Code)
+		req := webtest.RequestWithSignedInUser(server.NewGetRequest(getCurrentOrgQuotasURL), userWithPermissions(1, []accesscontrol.Permission{{Action: "orgs:invalid"}}))
+		res, err := server.Send(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusForbidden, res.StatusCode)
+		require.NoError(t, res.Body.Close())
 	})
 }
 
@@ -86,46 +95,60 @@ func TestAPIEndpoint_GetOrgQuotas_LegacyAccessControl(t *testing.T) {
 	cfg := setting.NewCfg()
 	cfg.Quota.Enabled = true
 	cfg.RBACEnabled = false
-	sc := setupHTTPServerWithCfg(t, true, cfg)
-	setInitCtxSignedInViewer(sc.initCtx)
-
-	setupDBAndSettingsForAccessControlQuotaTests(t, sc)
-
-	t.Run("Viewer cannot view another org quotas", func(t *testing.T) {
-		response := callAPI(sc.server, http.MethodGet, fmt.Sprintf(getOrgsQuotasURL, 2), nil, t)
-		assert.Equal(t, http.StatusForbidden, response.Code)
+	server := SetupAPITestServer(t, func(hs *HTTPServer) {
+		hs.Cfg = cfg
 	})
 
-	sc.initCtx.SignedInUser.IsGrafanaAdmin = true
+	t.Run("Viewer cannot view another org quotas", func(t *testing.T) {
+		req := webtest.RequestWithSignedInUser(server.NewGetRequest(fmt.Sprintf(getOrgsQuotasURL, 2)), &user.SignedInUser{OrgID: 1, OrgRole: org.RoleViewer})
+		res, err := server.Send(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusForbidden, res.StatusCode)
+		require.NoError(t, res.Body.Close())
+	})
+
 	t.Run("Grafana admin viewer can view another org quotas", func(t *testing.T) {
-		response := callAPI(sc.server, http.MethodGet, fmt.Sprintf(getOrgsQuotasURL, 2), nil, t)
-		assert.Equal(t, http.StatusOK, response.Code)
+		req := webtest.RequestWithSignedInUser(server.NewGetRequest(fmt.Sprintf(getOrgsQuotasURL, 2)), &user.SignedInUser{OrgID: 1, OrgRole: org.RoleViewer, IsGrafanaAdmin: true})
+		res, err := server.Send(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, res.StatusCode)
+		require.NoError(t, res.Body.Close())
 	})
 }
 
 func TestAPIEndpoint_GetOrgQuotas_AccessControl(t *testing.T) {
 	cfg := setting.NewCfg()
 	cfg.Quota.Enabled = true
-	sc := setupHTTPServerWithCfg(t, true, cfg)
-	setupDBAndSettingsForAccessControlQuotaTests(t, sc)
+	server := SetupAPITestServer(t, func(hs *HTTPServer) {
+		hs.Cfg = cfg
+		hs.userService = &usertest.FakeUserService{
+			ExpectedSignedInUser: &user.SignedInUser{OrgID: 2},
+		}
+	})
 
 	t.Run("AccessControl allows viewing another org quotas with correct permissions", func(t *testing.T) {
-		setInitCtxSignedInViewer(sc.initCtx)
-		setAccessControlPermissions(sc.acmock, []accesscontrol.Permission{{Action: accesscontrol.ActionOrgsQuotasRead}}, 2)
-		response := callAPI(sc.server, http.MethodGet, fmt.Sprintf(getOrgsQuotasURL, 2), nil, t)
-		assert.Equal(t, http.StatusOK, response.Code)
+		req := webtest.RequestWithSignedInUser(server.NewGetRequest(fmt.Sprintf(getOrgsQuotasURL, 2)), userWithPermissions(2, []accesscontrol.Permission{{Action: accesscontrol.ActionOrgsQuotasRead}}))
+		res, err := server.Send(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, res.StatusCode)
+		require.NoError(t, res.Body.Close())
 	})
 	t.Run("AccessControl prevents viewing another org quotas with correct permissions in another org", func(t *testing.T) {
-		setInitCtxSignedInViewer(sc.initCtx)
-		setAccessControlPermissions(sc.acmock, []accesscontrol.Permission{{Action: accesscontrol.ActionOrgsQuotasRead}}, 1)
-		response := callAPI(sc.server, http.MethodGet, fmt.Sprintf(getOrgsQuotasURL, 2), nil, t)
-		assert.Equal(t, http.StatusForbidden, response.Code)
+		// Set correct permissions in org 1 and empty permissions in org 2
+		user := userWithPermissions(1, []accesscontrol.Permission{{Action: accesscontrol.ActionOrgsQuotasRead}})
+		user.Permissions[2] = map[string][]string{}
+		req := webtest.RequestWithSignedInUser(server.NewGetRequest(fmt.Sprintf(getOrgsQuotasURL, 2)), user)
+		res, err := server.Send(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusForbidden, res.StatusCode)
+		require.NoError(t, res.Body.Close())
 	})
 	t.Run("AccessControl prevents viewing another org quotas with incorrect permissions", func(t *testing.T) {
-		setInitCtxSignedInViewer(sc.initCtx)
-		setAccessControlPermissions(sc.acmock, []accesscontrol.Permission{{Action: "orgs:invalid"}}, 2)
-		response := callAPI(sc.server, http.MethodGet, fmt.Sprintf(getOrgsQuotasURL, 2), nil, t)
-		assert.Equal(t, http.StatusForbidden, response.Code)
+		req := webtest.RequestWithSignedInUser(server.NewGetRequest(fmt.Sprintf(getOrgsQuotasURL, 2)), userWithPermissions(2, []accesscontrol.Permission{{Action: "orgs:invalid"}}))
+		res, err := server.Send(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusForbidden, res.StatusCode)
+		require.NoError(t, res.Body.Close())
 	})
 }
 
@@ -133,22 +156,33 @@ func TestAPIEndpoint_PutOrgQuotas_LegacyAccessControl(t *testing.T) {
 	cfg := setting.NewCfg()
 	cfg.Quota.Enabled = true
 	cfg.RBACEnabled = false
-	sc := setupHTTPServerWithCfg(t, true, cfg)
-	setInitCtxSignedInViewer(sc.initCtx)
-
-	setupDBAndSettingsForAccessControlQuotaTests(t, sc)
+	server := SetupAPITestServer(t, func(hs *HTTPServer) {
+		hs.Cfg = cfg
+	})
 
 	input := strings.NewReader(testUpdateOrgQuotaCmd)
 	t.Run("Viewer cannot update another org quotas", func(t *testing.T) {
-		response := callAPI(sc.server, http.MethodPut, fmt.Sprintf(putOrgsQuotasURL, 2, "org_user"), input, t)
-		assert.Equal(t, http.StatusForbidden, response.Code)
+		req := webtest.RequestWithSignedInUser(server.NewRequest(http.MethodPut, fmt.Sprintf(putOrgsQuotasURL, 2, "org_user"), input), &user.SignedInUser{
+			OrgID:   1,
+			OrgRole: org.RoleViewer,
+		})
+		response, err := server.SendJSON(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusForbidden, response.StatusCode)
+		require.NoError(t, response.Body.Close())
 	})
 
-	sc.initCtx.SignedInUser.IsGrafanaAdmin = true
 	input = strings.NewReader(testUpdateOrgQuotaCmd)
 	t.Run("Grafana admin viewer can update another org quotas", func(t *testing.T) {
-		response := callAPI(sc.server, http.MethodPut, fmt.Sprintf(putOrgsQuotasURL, 2, "org_user"), input, t)
-		assert.Equal(t, http.StatusOK, response.Code)
+		req := webtest.RequestWithSignedInUser(server.NewRequest(http.MethodPut, fmt.Sprintf(putOrgsQuotasURL, 2, "org_user"), input), &user.SignedInUser{
+			OrgID:          1,
+			OrgRole:        org.RoleViewer,
+			IsGrafanaAdmin: true,
+		})
+		response, err := server.SendJSON(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, response.StatusCode)
+		require.NoError(t, response.Body.Close())
 	})
 }
 
@@ -166,30 +200,42 @@ func TestAPIEndpoint_PutOrgQuotas_AccessControl(t *testing.T) {
 			Org: 5,
 		},
 	}
-	sc := setupHTTPServerWithCfg(t, true, cfg)
-	setupDBAndSettingsForAccessControlQuotaTests(t, sc)
+	server := SetupAPITestServer(t, func(hs *HTTPServer) {
+		hs.Cfg = cfg
+		hs.userService = &usertest.FakeUserService{
+			ExpectedSignedInUser: &user.SignedInUser{OrgID: 2},
+		}
+	})
 
 	input := strings.NewReader(testUpdateOrgQuotaCmd)
 	t.Run("AccessControl allows updating another org quotas with correct permissions", func(t *testing.T) {
-		setInitCtxSignedInViewer(sc.initCtx)
-		setAccessControlPermissions(sc.acmock, []accesscontrol.Permission{{Action: accesscontrol.ActionOrgsQuotasWrite}}, 2)
-		response := callAPI(sc.server, http.MethodPut, fmt.Sprintf(putOrgsQuotasURL, 2, "org_user"), input, t)
-		assert.Equal(t, http.StatusOK, response.Code)
+		user := userWithPermissions(2, []accesscontrol.Permission{{Action: accesscontrol.ActionOrgsQuotasWrite}})
+		user.OrgID = 1
+		req := webtest.RequestWithSignedInUser(server.NewRequest(http.MethodPut, fmt.Sprintf(putOrgsQuotasURL, 2, "org_user"), input), user)
+		response, err := server.SendJSON(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, response.StatusCode)
+		require.NoError(t, response.Body.Close())
 	})
 
 	input = strings.NewReader(testUpdateOrgQuotaCmd)
 	t.Run("AccessControl prevents updating another org quotas with correct permissions in another org", func(t *testing.T) {
-		setInitCtxSignedInViewer(sc.initCtx)
-		setAccessControlPermissions(sc.acmock, []accesscontrol.Permission{{Action: accesscontrol.ActionOrgsQuotasWrite}}, 1)
-		response := callAPI(sc.server, http.MethodPut, fmt.Sprintf(putOrgsQuotasURL, 2, "org_user"), input, t)
-		assert.Equal(t, http.StatusForbidden, response.Code)
+		user := userWithPermissions(1, []accesscontrol.Permission{{Action: accesscontrol.ActionOrgsQuotasWrite}})
+		user.Permissions[2] = map[string][]string{}
+		req := webtest.RequestWithSignedInUser(server.NewRequest(http.MethodPut, fmt.Sprintf(putOrgsQuotasURL, 2, "org_user"), input), user)
+		response, err := server.SendJSON(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusForbidden, response.StatusCode)
+		require.NoError(t, response.Body.Close())
 	})
 
 	input = strings.NewReader(testUpdateOrgQuotaCmd)
 	t.Run("AccessControl prevents updating another org quotas with incorrect permissions", func(t *testing.T) {
-		setInitCtxSignedInViewer(sc.initCtx)
-		setAccessControlPermissions(sc.acmock, []accesscontrol.Permission{{Action: "orgs:invalid"}}, 2)
-		response := callAPI(sc.server, http.MethodPut, fmt.Sprintf(putOrgsQuotasURL, 2, "org_user"), input, t)
-		assert.Equal(t, http.StatusForbidden, response.Code)
+		user := userWithPermissions(2, []accesscontrol.Permission{{Action: "orgs:invalid"}})
+		req := webtest.RequestWithSignedInUser(server.NewRequest(http.MethodPut, fmt.Sprintf(putOrgsQuotasURL, 2, "org_user"), input), user)
+		response, err := server.SendJSON(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusForbidden, response.StatusCode)
+		require.NoError(t, response.Body.Close())
 	})
 }

--- a/pkg/api/quota_test.go
+++ b/pkg/api/quota_test.go
@@ -48,7 +48,6 @@ func TestAPIEndpoint_GetCurrentOrgQuotas_LegacyAccessControl(t *testing.T) {
 		assert.Equal(t, http.StatusUnauthorized, res.StatusCode)
 		require.NoError(t, res.Body.Close())
 	})
-
 	t.Run("Viewer can view CurrentOrgQuotas", func(t *testing.T) {
 		req := webtest.RequestWithSignedInUser(server.NewGetRequest(getCurrentOrgQuotasURL), &user.SignedInUser{OrgID: 1, OrgRole: org.RoleViewer})
 		res, err := server.Send(req)


### PR DESCRIPTION
**What is this feature?**

Update org quota tests to remove mocked access control.
