### PR TITLE
Scenes: Skip instance of check as it it does not work for apps

### DIFF
--- a/public/app/features/plugins/components/AppRootPage.tsx
+++ b/public/app/features/plugins/components/AppRootPage.tsx
@@ -53,13 +53,6 @@ export function AppRootPage({ pluginId, pluginNavSection }: Props) {
     []
   );
 
-  useEffect(() => {
-    console.log('AppRootPage mount');
-    return () => {
-      console.log('AppRootPage unmount');
-    };
-  }, []);
-
   if (!plugin || pluginId !== plugin.meta.id) {
     return <Page navModel={navModel}>{loading && <PageLoader />}</Page>;
   }

--- a/public/app/features/plugins/components/AppRootPage.tsx
+++ b/public/app/features/plugins/components/AppRootPage.tsx
@@ -53,6 +53,13 @@ export function AppRootPage({ pluginId, pluginNavSection }: Props) {
     []
   );
 
+  useEffect(() => {
+    console.log('AppRootPage mount');
+    return () => {
+      console.log('AppRootPage unmount');
+    };
+  }, []);
+
   if (!plugin || pluginId !== plugin.meta.id) {
     return <Page navModel={navModel}>{loading && <PageLoader />}</Page>;
   }

--- a/public/app/features/templating/template_srv.ts
+++ b/public/app/features/templating/template_srv.ts
@@ -9,7 +9,7 @@ import {
   TypedVariableModel,
 } from '@grafana/data';
 import { getDataSourceSrv, setTemplateSrv, TemplateSrv as BaseTemplateSrv } from '@grafana/runtime';
-import { SceneObjectBase, sceneGraph, FormatRegistryID, formatRegistry, CustomFormatterFn } from '@grafana/scenes';
+import { sceneGraph, FormatRegistryID, formatRegistry, CustomFormatterFn } from '@grafana/scenes';
 
 import { variableAdapters } from '../variables/adapters';
 import { ALL_VARIABLE_TEXT, ALL_VARIABLE_VALUE } from '../variables/constants';
@@ -276,7 +276,7 @@ export class TemplateSrv implements BaseTemplateSrv {
   }
 
   replace(target?: string, scopedVars?: ScopedVars, format?: string | Function): string {
-    if (scopedVars && scopedVars.__sceneObject && scopedVars.__sceneObject.value instanceof SceneObjectBase) {
+    if (scopedVars && scopedVars.__sceneObject) {
       return sceneGraph.interpolate(
         scopedVars.__sceneObject.value,
         target,


### PR DESCRIPTION
Fixes issue with interpolating datasource variable from app plugins using scenes.

The instanceof check does not work as the SceneObject bundled in the app is different from the one in core.
