### PR TITLE
Alerting: Fix group select not being filled by selected folder when creating alert from panel

### DIFF
--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -258,7 +258,8 @@ export function fetchRulerRulesIfNotFetchedYet(rulesSourceName: string): ThunkRe
   return (dispatch, getStore) => {
     const { rulerRules } = getStore().unifiedAlerting;
     const resp = rulerRules[rulesSourceName];
-    if (!resp?.result && !(resp && isRulerNotSupportedResponse(resp)) && !resp?.loading) {
+    const emptyResults = isEmpty(resp?.result);
+    if (emptyResults && !(resp && isRulerNotSupportedResponse(resp)) && !resp?.loading) {
       dispatch(fetchRulerRulesAction({ rulesSourceName }));
     }
   };


### PR DESCRIPTION
**What is this feature?**

This PR fix groups not being filled in alert form when user comes from a dashboard panel.

When you create an alert from a dashboard panel, group list is not filled with the list of groups of the select folder.

This is because we rely on the `fetchRulerRulesIfNotFetchedYet` method that was only checking if result was undefined or null, and when user comes from dashboard panel has an empty object.

**Why do we need this feature?**

Groups should be filled with the list of available groups for the selected folder in any case.

**Who is this feature for?**

All users.
**Which issue(s) does this PR fix?**:
Fixes https://github.com/grafana/alerting-squad/issues/399



