### PR TITLE
RBAC: use scope reduction for user permission listing

### DIFF
--- a/pkg/services/accesscontrol/accesscontrol_test.go
+++ b/pkg/services/accesscontrol/accesscontrol_test.go
@@ -43,6 +43,17 @@ func TestReduce(t *testing.T) {
 			},
 		},
 		{
+			name: "specific permissions with repeated scope",
+			ps: []Permission{
+				{Action: "teams:read", Scope: "teams:id:1"},
+				{Action: "teams:read", Scope: "teams:id:2"},
+				{Action: "teams:read", Scope: "teams:id:1"},
+			},
+			want: map[string][]string{
+				"teams:read": {"teams:id:1", "teams:id:2"},
+			},
+		},
+		{
 			name: "wildcard permission",
 			ps: []Permission{
 				{Action: "teams:read", Scope: "teams:id:1"},
@@ -86,6 +97,16 @@ func TestReduce(t *testing.T) {
 			},
 			want: map[string][]string{
 				"dashboards:read": {"*"},
+			},
+		},
+		{
+			name: "non-wilcard scopes with * in them",
+			ps: []Permission{
+				{Action: "dashboards:read", Scope: "dashboards:uid:123"},
+				{Action: "dashboards:read", Scope: "dashboards:uid:1*"},
+			},
+			want: map[string][]string{
+				"dashboards:read": {"dashboards:uid:123", "dashboards:uid:1*"},
 			},
 		},
 	}

--- a/pkg/services/accesscontrol/api/api.go
+++ b/pkg/services/accesscontrol/api/api.go
@@ -91,7 +91,7 @@ func (api *AccessControlAPI) searchUsersPermissions(c *models.ReqContext) respon
 
 	permsByAction := map[int64]map[string][]string{}
 	for userID, userPerms := range permissions {
-		permsByAction[userID] = ac.GroupScopesByAction(userPerms)
+		permsByAction[userID] = ac.Reduce(userPerms)
 	}
 
 	return response.JSON(http.StatusOK, permsByAction)
@@ -121,5 +121,5 @@ func (api *AccessControlAPI) searchUserPermissions(c *models.ReqContext) respons
 		response.Error(http.StatusInternalServerError, "could not search user permissions", err)
 	}
 
-	return response.JSON(http.StatusOK, ac.GroupScopesByAction(permissions))
+	return response.JSON(http.StatusOK, ac.Reduce(permissions))
 }


### PR DESCRIPTION
**What is this feature?**

Reduce scopes using logic introduced in https://github.com/grafana/grafana/pull/58197 before returning user permissions. Also add two new tests cases.

Response returned by calling `GET api/access-control/user/4/permissions/search?actionPrefix=dash` before this change:
```
{
    "dashboards.insights:read": [
        "",
        ""
    ],
   ....
    "dashboards:read": [
        "dashboards:uid:qOT8LUhVk",
        "dashboards:uid:qOT8LUhVk",
        "dashboards:uid:WlDJp6c4z",
        "dashboards:uid:qOT8LUhVk"
    ],
....
}
```

Response returned by calling `GET api/access-control/user/4/permissions/search?actionPrefix=dash` after this change:
```
{
    "dashboards.insights:read": null,
   ....
    "dashboards:read": [
        "dashboards:uid:qOT8LUhVk",
        "dashboards:uid:WlDJp6c4z"
    ],
....
}
```

**Why do we need this feature?**

To make the response returned by the endpoints less confusing and easier to work with.

**Who is this feature for?**

These endpoints are currently only used internally by the OnCall + RBAC PoC, but might be exposed more widely in the future.