### PR TITLE
CommandPalette: Improve section header styling

### DIFF
--- a/public/app/features/commandPalette/CommandPalette.tsx
+++ b/public/app/features/commandPalette/CommandPalette.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { css, cx } from '@emotion/css';
 import { useDialog } from '@react-aria/dialog';
 import { FocusScope } from '@react-aria/focus';
 import { useOverlay } from '@react-aria/overlays';
@@ -83,24 +83,34 @@ const RenderResults = ({ dashboardResults }: RenderResultsProps) => {
     () => dashboardResults.map((dashboard) => new ActionImpl(dashboard, { store: {} })),
     [dashboardResults]
   );
+
   const items = useMemo(
     () => (dashboardResultItems.length > 0 ? [...results, dashboardsSectionTitle, ...dashboardResultItems] : results),
     [results, dashboardsSectionTitle, dashboardResultItems]
   );
 
   return (
-    <div className={styles.resultsContainer}>
-      <KBarResults
-        items={items}
-        onRender={({ item, active }) =>
+    <KBarResults
+      items={items}
+      onRender={({ item, active }) => {
+        // These items are rendered in a container, in a virtual list, so we cannot
+        // use :first/last-child selectors, so we must mimic them in JS
+        const isFirstItem = items[0] === item;
+        const isLastItem = items[items.length - 1] === item;
+
+        const renderedItem =
           typeof item === 'string' ? (
-            <div className={styles.sectionHeader}>{item}</div>
+            <div className={styles.sectionHeader}>
+              <div className={cx(styles.sectionHeaderInner, isFirstItem && styles.sectionHeaderInnerFirst)}>{item}</div>
+            </div>
           ) : (
             <ResultItem action={item} active={active} currentRootActionId={rootActionId!} />
-          )
-        }
-      />
-    </div>
+          );
+
+        // R
+        return isLastItem ? <div className={styles.lastItem}>{renderedItem}</div> : renderedItem;
+      }}
+    />
   );
 };
 
@@ -137,15 +147,30 @@ const getSearchStyles = (theme: GrafanaTheme2) => ({
     border: 'none',
     background: theme.colors.background.canvas,
     color: theme.colors.text.primary,
-    borderBottom: `1px solid ${theme.colors.border.weak}`,
+    borderBottom: `1px solid ${theme.colors.border.medium}`,
   }),
+
+  // We can't use margin because the virtual list measures that incorrectly
+  // so to have padding before and after border, we have outer + inner elements
+  // to split the padding over.
   sectionHeader: css({
-    padding: theme.spacing(1, 2),
+    paddingTop: theme.spacing(2),
     fontSize: theme.typography.h6.fontSize,
     fontWeight: theme.typography.body.fontWeight,
     color: theme.colors.text.secondary,
   }),
-  resultsContainer: css({
-    padding: theme.spacing(2, 0),
+  sectionHeaderInner: css({
+    padding: theme.spacing(1, 2),
+    borderTop: `1px solid ${theme.colors.border.medium}`,
+  }),
+
+  // We don't need the header above the first section
+  sectionHeaderInnerFirst: css({
+    borderTop: 'none',
+    paddingTop: 0,
+  }),
+
+  lastItem: css({
+    paddingBottom: theme.spacing(1),
   }),
 });

--- a/public/app/features/commandPalette/CommandPalette.tsx
+++ b/public/app/features/commandPalette/CommandPalette.tsx
@@ -107,7 +107,6 @@ const RenderResults = ({ dashboardResults }: RenderResultsProps) => {
             <ResultItem action={item} active={active} currentRootActionId={rootActionId!} />
           );
 
-        // R
         return isLastItem ? <div className={styles.lastItem}>{renderedItem}</div> : renderedItem;
       }}
     />
@@ -150,9 +149,8 @@ const getSearchStyles = (theme: GrafanaTheme2) => ({
     borderBottom: `1px solid ${theme.colors.border.medium}`,
   }),
 
-  // We can't use margin because the virtual list measures that incorrectly
-  // so to have padding before and after border, we have outer + inner elements
-  // to split the padding over.
+  // Virtual list measures margin incorrectly, so we need to split padding before/after border
+  // over and inner and outer element
   sectionHeader: css({
     paddingTop: theme.spacing(2),
     fontSize: theme.typography.h6.fontSize,
@@ -170,6 +168,7 @@ const getSearchStyles = (theme: GrafanaTheme2) => ({
     paddingTop: 0,
   }),
 
+  // Last item gets extra padding so it's not clipped by the rounded corners on the container
   lastItem: css({
     paddingBottom: theme.spacing(1),
   }),

--- a/public/app/features/commandPalette/ResultItem.tsx
+++ b/public/app/features/commandPalette/ResultItem.tsx
@@ -78,6 +78,7 @@ const getResultItemStyles = (theme: GrafanaTheme2, isActive: boolean) => {
       alightItems: 'center',
       justifyContent: 'space-between',
       cursor: 'pointer',
+      position: 'relative',
       '&:before': {
         display: isActive ? 'block' : 'none',
         content: '" "',

--- a/public/app/features/commandPalette/ResultItem.tsx
+++ b/public/app/features/commandPalette/ResultItem.tsx
@@ -108,8 +108,8 @@ const getResultItemStyles = (theme: GrafanaTheme2, isActive: boolean) => {
       fontSize: theme.typography.fontSize,
     }),
     breadcrumbAncestor: css({
-      opacity: 0.5,
       marginRight: theme.spacing(1),
+      color: theme.colors.text.secondary,
     }),
     subtitleText: css({
       fontSize: theme.typography.fontSize - 2,


### PR DESCRIPTION
**What is this feature?**

Few minor styling improvements to Command Palette from the mob session https://github.com/grafana/grafana/pull/61503

 - Adds border above section headers (except the first one)
 - Changes breadcrumbs to use secondary text colour

![image](https://user-images.githubusercontent.com/46142/212919615-75513f8d-82ae-401b-80f1-444e041a227f.png)

![image](https://user-images.githubusercontent.com/46142/212919729-8f8465cc-9ef7-442c-8e69-c57bab5258ca.png)


**Why do we need this feature?**

so command palette is easier to understand. previous section headers were not distinct enough

**Who is this feature for?**

everyon :) 

**Which issue(s) does this PR fix?**:
