### PR TITLE
Snapshots: Add snapshot enable config

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -366,6 +366,9 @@ data_keys_cache_cleanup_interval = 1m
 
 #################################### Snapshots ###########################
 [snapshots]
+# set to false to remove snapshot functionality
+enabled = true
+
 # snapshot sharing options
 external_enabled = true
 external_snapshot_url = https://snapshots.raintank.io

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -372,6 +372,9 @@
 
 #################################### Snapshots ###########################
 [snapshots]
+# set to false to remove snapshot functionality
+;enabled = true
+
 # snapshot sharing options
 ;external_enabled = true
 ;external_snapshot_url = https://snapshots.raintank.io

--- a/packages/grafana-data/src/types/config.ts
+++ b/packages/grafana-data/src/types/config.ts
@@ -152,6 +152,7 @@ export interface BootData {
  */
 export interface GrafanaConfig {
   isPublicDashboardView: boolean;
+  snapshotEnabled: boolean;
   datasources: { [str: string]: DataSourceInstanceSettings };
   panels: { [key: string]: PanelPluginMeta };
   auth: AuthSettings;

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -27,6 +27,7 @@ export interface AzureSettings {
 
 export class GrafanaBootConfig implements GrafanaConfig {
   isPublicDashboardView: boolean;
+  snapshotEnabled = true;
   datasources: { [str: string]: DataSourceInstanceSettings } = {};
   panels: { [key: string]: PanelPluginMeta } = {};
   auth: AuthSettings = {};

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -701,7 +701,7 @@ func (hs *HTTPServer) registerRoutes() {
 
 	// Snapshots
 	r.Post("/api/snapshots/", reqSnapshotPublicModeOrSignedIn, hs.CreateDashboardSnapshot)
-	r.Get("/api/snapshot/shared-options/", reqSignedIn, GetSharingOptions)
+	r.Get("/api/snapshot/shared-options/", reqSignedIn, hs.GetSharingOptions)
 	r.Get("/api/snapshots/:key", routing.Wrap(hs.GetDashboardSnapshot))
 	r.Get("/api/snapshots-delete/:deleteKey", reqSnapshotPublicModeOrSignedIn, routing.Wrap(hs.DeleteDashboardSnapshotByDeleteKey))
 	r.Delete("/api/snapshots/:key", reqSignedIn, routing.Wrap(hs.DeleteDashboardSnapshot))

--- a/pkg/api/dashboard_snapshot.go
+++ b/pkg/api/dashboard_snapshot.go
@@ -120,9 +120,9 @@ func (hs *HTTPServer) CreateDashboardSnapshot(c *models.ReqContext) response.Res
 	}
 
 	var snapshotUrl string
-	cmd.ExternalUrl = ""
-	cmd.OrgId = c.OrgID
-	cmd.UserId = c.UserID
+	cmd.ExternalURL = ""
+	cmd.OrgID = c.OrgID
+	cmd.UserID = c.UserID
 	originalDashboardURL, err := createOriginalDashboardURL(&cmd)
 	if err != nil {
 		return response.Error(http.StatusInternalServerError, "Invalid app URL", err)

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -209,6 +209,7 @@ func (hs *HTTPServer) getFrontendSettingsMap(c *models.ReqContext) (map[string]i
 		"samlEnabled":             hs.samlEnabled(),
 		"samlName":                hs.samlName(),
 		"tokenExpirationDayLimit": hs.Cfg.SATokenExpirationDayLimit,
+		"snapshotEnabled":         setting.SnapshotEnabled,
 	}
 
 	if hs.ThumbService != nil {

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -209,7 +209,7 @@ func (hs *HTTPServer) getFrontendSettingsMap(c *models.ReqContext) (map[string]i
 		"samlEnabled":             hs.samlEnabled(),
 		"samlName":                hs.samlName(),
 		"tokenExpirationDayLimit": hs.Cfg.SATokenExpirationDayLimit,
-		"snapshotEnabled":         setting.SnapshotEnabled,
+		"snapshotEnabled":         hs.Cfg.SnapshotEnabled,
 	}
 
 	if hs.ThumbService != nil {

--- a/pkg/services/dashboardsnapshots/database/database.go
+++ b/pkg/services/dashboardsnapshots/database/database.go
@@ -15,13 +15,14 @@ import (
 type DashboardSnapshotStore struct {
 	store db.DB
 	log   log.Logger
+	cfg   *setting.Cfg
 }
 
 // DashboardStore implements the Store interface
 var _ dashboardsnapshots.Store = (*DashboardSnapshotStore)(nil)
 
-func ProvideStore(db db.DB) *DashboardSnapshotStore {
-	return &DashboardSnapshotStore{store: db, log: log.New("dashboardsnapshot.store")}
+func ProvideStore(db db.DB, cfg *setting.Cfg) *DashboardSnapshotStore {
+	return &DashboardSnapshotStore{store: db, log: log.New("dashboardsnapshot.store"), cfg: cfg}
 }
 
 // DeleteExpiredSnapshots removes snapshots with old expiry dates.
@@ -29,7 +30,7 @@ func ProvideStore(db db.DB) *DashboardSnapshotStore {
 // Snapshot expiry is decided by the user when they share the snapshot.
 func (d *DashboardSnapshotStore) DeleteExpiredSnapshots(ctx context.Context, cmd *dashboardsnapshots.DeleteExpiredSnapshotsCommand) error {
 	return d.store.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
-		if !setting.SnapShotRemoveExpired {
+		if !d.cfg.SnapShotRemoveExpired {
 			d.log.Warn("[Deprecated] The snapshot_remove_expired setting is outdated. Please remove from your config.")
 			return nil
 		}

--- a/pkg/services/dashboardsnapshots/database/database_test.go
+++ b/pkg/services/dashboardsnapshots/database/database_test.go
@@ -23,7 +23,7 @@ func TestIntegrationDashboardSnapshotDBAccess(t *testing.T) {
 		t.Skip("skipping integration test")
 	}
 	sqlstore := db.InitTestDB(t)
-	dashStore := ProvideStore(sqlstore)
+	dashStore := ProvideStore(sqlstore, setting.NewCfg())
 
 	origSecret := setting.SecretKey
 	setting.SecretKey = "dashboard_snapshot_testing"
@@ -154,10 +154,10 @@ func TestIntegrationDeleteExpiredSnapshots(t *testing.T) {
 		t.Skip("skipping integration test")
 	}
 	sqlstore := db.InitTestDB(t)
-	dashStore := ProvideStore(sqlstore)
+	dashStore := ProvideStore(sqlstore, setting.NewCfg())
 
 	t.Run("Testing dashboard snapshots clean up", func(t *testing.T) {
-		setting.SnapShotRemoveExpired = true
+		dashStore.cfg.SnapShotRemoveExpired = true
 
 		nonExpiredSnapshot := createTestSnapshot(t, dashStore, "key1", 48000)
 		createTestSnapshot(t, dashStore, "key2", -1200)

--- a/pkg/services/dashboardsnapshots/service/service_test.go
+++ b/pkg/services/dashboardsnapshots/service/service_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestDashboardSnapshotsService(t *testing.T) {
 	sqlStore := db.InitTestDB(t)
-	dsStore := dashsnapdb.ProvideStore(sqlStore)
+	dsStore := dashsnapdb.ProvideStore(sqlStore, setting.NewCfg())
 	secretsService := secretsManager.SetupTestService(t, database.ProvideSecretsStore(sqlStore))
 	s := ProvideService(dsStore, secretsService)
 

--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -376,7 +376,7 @@ func (s *ServiceImpl) buildDashboardNavLinks(c *models.ReqContext, hasEditPerm b
 	})
 
 	if c.IsSignedIn {
-		if setting.SnapshotEnabled {
+		if s.cfg.SnapshotEnabled {
 			dashboardChildNavs = append(dashboardChildNavs, &navtree.NavLink{
 				Text:     "Snapshots",
 				SubTitle: "Interactive, publically available, point-in-time representations of dashboards",

--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -376,13 +376,15 @@ func (s *ServiceImpl) buildDashboardNavLinks(c *models.ReqContext, hasEditPerm b
 	})
 
 	if c.IsSignedIn {
-		dashboardChildNavs = append(dashboardChildNavs, &navtree.NavLink{
-			Text:     "Snapshots",
-			SubTitle: "Interactive, publically available, point-in-time representations of dashboards",
-			Id:       "dashboards/snapshots",
-			Url:      s.cfg.AppSubURL + "/dashboard/snapshots",
-			Icon:     "camera",
-		})
+		if setting.SnapshotEnabled {
+			dashboardChildNavs = append(dashboardChildNavs, &navtree.NavLink{
+				Text:     "Snapshots",
+				SubTitle: "Interactive, publically available, point-in-time representations of dashboards",
+				Id:       "dashboards/snapshots",
+				Url:      s.cfg.AppSubURL + "/dashboard/snapshots",
+				Icon:     "camera",
+			})
+		}
 
 		dashboardChildNavs = append(dashboardChildNavs, &navtree.NavLink{
 			Text:     "Library panels",

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -87,13 +87,6 @@ var (
 	CookieSameSiteDisabled bool
 	CookieSameSiteMode     http.SameSite
 
-	// Snapshots
-	SnapshotEnabled       bool
-	ExternalSnapshotUrl   string
-	ExternalSnapshotName  string
-	ExternalEnabled       bool
-	SnapShotRemoveExpired bool
-
 	// Dashboard history
 	DashboardVersionsToKeep int
 	MinRefreshInterval      string
@@ -408,6 +401,12 @@ type Cfg struct {
 	DataSourceLimit int
 
 	// Snapshots
+	SnapshotEnabled       bool
+	ExternalSnapshotUrl   string
+	ExternalSnapshotName  string
+	ExternalEnabled       bool
+	SnapShotRemoveExpired bool
+
 	SnapshotPublicMode bool
 
 	ErrTemplateName string
@@ -1703,14 +1702,13 @@ func IsLegacyAlertingEnabled() bool {
 func readSnapshotsSettings(cfg *Cfg, iniFile *ini.File) error {
 	snapshots := iniFile.Section("snapshots")
 
-	// TODO LND Check if we want to disable external snapshot if this is false
-	SnapshotEnabled = snapshots.Key("enabled").MustBool(true)
+	cfg.SnapshotEnabled = snapshots.Key("enabled").MustBool(true)
 
-	ExternalSnapshotUrl = valueAsString(snapshots, "external_snapshot_url", "")
-	ExternalSnapshotName = valueAsString(snapshots, "external_snapshot_name", "")
+	cfg.ExternalSnapshotUrl = valueAsString(snapshots, "external_snapshot_url", "")
+	cfg.ExternalSnapshotName = valueAsString(snapshots, "external_snapshot_name", "")
 
-	ExternalEnabled = snapshots.Key("external_enabled").MustBool(true)
-	SnapShotRemoveExpired = snapshots.Key("snapshot_remove_expired").MustBool(true)
+	cfg.ExternalEnabled = snapshots.Key("external_enabled").MustBool(true)
+	cfg.SnapShotRemoveExpired = snapshots.Key("snapshot_remove_expired").MustBool(true)
 	cfg.SnapshotPublicMode = snapshots.Key("public_mode").MustBool(false)
 
 	return nil

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -88,6 +88,7 @@ var (
 	CookieSameSiteMode     http.SameSite
 
 	// Snapshots
+	SnapshotEnabled       bool
 	ExternalSnapshotUrl   string
 	ExternalSnapshotName  string
 	ExternalEnabled       bool
@@ -1701,6 +1702,9 @@ func IsLegacyAlertingEnabled() bool {
 
 func readSnapshotsSettings(cfg *Cfg, iniFile *ini.File) error {
 	snapshots := iniFile.Section("snapshots")
+
+	// TODO LND Check if we want to disable external snapshot if this is false
+	SnapshotEnabled = snapshots.Key("enabled").MustBool(true)
 
 	ExternalSnapshotUrl = valueAsString(snapshots, "external_snapshot_url", "")
 	ExternalSnapshotName = valueAsString(snapshots, "external_snapshot_name", "")

--- a/public/app/features/dashboard/components/ShareModal/ShareModal.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareModal.tsx
@@ -69,6 +69,7 @@ interface Props {
   dashboard: DashboardModel;
   panel?: PanelModel;
   activeTab?: string;
+
   onDismiss(): void;
 }
 

--- a/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/SharePublicDashboard.test.tsx
+++ b/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/SharePublicDashboard.test.tsx
@@ -72,6 +72,12 @@ beforeAll(() => {
 });
 
 beforeEach(() => {
+  server.use(
+    rest.get('/api/snapshot/shared-options', (req, res, ctx) => {
+      return res(ctx.status(200), ctx.json({ snapshotEnabled: true }));
+    })
+  );
+
   config.featureToggles.publicDashboards = true;
   mockDashboard = createDashboardModelFixture({
     uid: 'mockDashboardUid',

--- a/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/SharePublicDashboard.test.tsx
+++ b/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/SharePublicDashboard.test.tsx
@@ -68,7 +68,7 @@ beforeAll(() => {
     ],
   } as BootData;
 
-  server.listen({ onUnhandledRequest: 'error' });
+  server.listen({ onUnhandledRequest: 'bypass' });
 });
 
 beforeEach(() => {
@@ -345,6 +345,7 @@ describe('SharePublic - Already persisted', () => {
     expect(enableTimeRangeSwitch).toBeEnabled();
     expect(enableTimeRangeSwitch).toBeChecked();
   });
+
   it('when modal is opened, then time range switch is enabled and not checked when its not checked in the db', async () => {
     server.use(
       rest.get('/api/dashboards/uid/:dashboardUid/public-dashboards', (req, res, ctx) => {

--- a/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/SharePublicDashboard.test.tsx
+++ b/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/SharePublicDashboard.test.tsx
@@ -72,20 +72,6 @@ beforeAll(() => {
 });
 
 beforeEach(() => {
-  server.use(
-    rest.get('/api/snapshot/shared-options', (req, res, ctx) => {
-      return res(
-        ctx.status(200),
-        ctx.json({
-          externalEnabled: false,
-          externalSnapshotName: 'Publish to snapshots.raintank.io',
-          externalSnapshotURL: 'https://snapshots.raintank.io',
-          snapshotEnabled: true,
-        })
-      );
-    })
-  );
-
   config.featureToggles.publicDashboards = true;
   mockDashboard = createDashboardModelFixture({
     uid: 'mockDashboardUid',

--- a/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/SharePublicDashboard.test.tsx
+++ b/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/SharePublicDashboard.test.tsx
@@ -38,7 +38,6 @@ const renderSharePublicDashboard = async (props: React.ComponentProps<typeof Sha
   );
 
   await waitFor(() => screen.getByText('Link'));
-  await waitForElementToBeRemoved(screen.getByTestId('Spinner'));
   isEnabled && fireEvent.click(screen.getByText('Public dashboard'));
 };
 


### PR DESCRIPTION
**What is this feature?**
 Adds a flag in the ini config file which will disable (hiding in the frontend and returning an error in the backend) the dashboard snapshot functionality

**Why do we need this feature?**

Some customers requested this feature to be able to disable the snapshot functionality

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/61493

**Special notes for your reviewer**:
* The validation was added to the backend services, returning a forbidden error code if it is not enabled
* In the frontend, the menus for snapshots are hidden if the feature is disabled.
* Example of share modal with snapshot disabled, Snapshot tab is not show (usually is located next to Link)
![image](https://user-images.githubusercontent.com/34773040/214287915-108f3dcf-2016-4aa2-b409-73e1a2e4fc6b.png)


