### PR TITLE
Fix documentation for notification policy object_matchers

### DIFF
--- a/docs/sources/alerting/set-up/provision-alerting-resources/file-provisioning/index.md
+++ b/docs/sources/alerting/set-up/provision-alerting-resources/file-provisioning/index.md
@@ -522,11 +522,11 @@ policies:
       - alertname = Watchdog
       - service_id_X = serviceX
       - severity =~ "warning|critical"
-    # <list> a list of grafana-like matchers that an alert rule has to fulfill to match the node
+    # <list> a list objects of grafana-like matchers that an alert rule has to fulfill to match the node
     object_matchers:
-      - alertname = CPUUsage
-      - service_id-X = serviceX
-      - severity =~ "warning|critical"
+      - ['alertname', '=', 'CPUUsage']
+      - ['service_id-X', '=', 'serviceX']
+      - ['severity', '=~', 'warning|critical']
     # <list> Times when the route should be muted. These must match the name of a
     #        mute time interval.
     #        Additionally, the root node cannot have any mute times.

--- a/docs/sources/alerting/set-up/provision-alerting-resources/file-provisioning/index.md
+++ b/docs/sources/alerting/set-up/provision-alerting-resources/file-provisioning/index.md
@@ -522,7 +522,7 @@ policies:
       - alertname = Watchdog
       - service_id_X = serviceX
       - severity =~ "warning|critical"
-    # <list> a list of objects of grafana-like matchers that an alert rule has to fulfill to match the node
+    # <list> a list of grafana-like matchers that an alert rule has to fulfill to match the node
     object_matchers:
       - ['alertname', '=', 'CPUUsage']
       - ['service_id-X', '=', 'serviceX']

--- a/docs/sources/alerting/set-up/provision-alerting-resources/file-provisioning/index.md
+++ b/docs/sources/alerting/set-up/provision-alerting-resources/file-provisioning/index.md
@@ -522,7 +522,7 @@ policies:
       - alertname = Watchdog
       - service_id_X = serviceX
       - severity =~ "warning|critical"
-    # <list> a list objects of grafana-like matchers that an alert rule has to fulfill to match the node
+    # <list> a list of objects of grafana-like matchers that an alert rule has to fulfill to match the node
     object_matchers:
       - ['alertname', '=', 'CPUUsage']
       - ['service_id-X', '=', 'serviceX']


### PR DESCRIPTION
**What is this feature?**

This updates and fixes the file provisioning documentation for object_marchers in notification policies.

**Why do we need this feature?**

The examples of how notification policy `object_matchers` are defined were not correct.

**Who is this feature for?**

Any users that are using file provisioning.

**Which issue(s) does this PR fix?**:

Contributes to https://github.com/grafana/support-escalations/issues/4754

**Special notes for your reviewer**:

The sample file for testing was
![Captura de pantalla 2023-01-17 a las 10 43 00](https://user-images.githubusercontent.com/2112640/212865462-58a079ab-1e47-4045-b2ea-66efec966641.png)

And the result was
![Captura de pantalla 2023-01-17 a las 10 43 40](https://user-images.githubusercontent.com/2112640/212865521-01c321f0-da9f-458c-8cd0-97c142fb329a.png)