### PR TITLE
Search: Fix empty folder message showing when by starred dashboards

### DIFF
--- a/public/app/features/search/page/components/SearchView.test.tsx
+++ b/public/app/features/search/page/components/SearchView.test.tsx
@@ -105,6 +105,46 @@ describe('SearchView', () => {
     expect(screen.getByRole('button', { name: 'Clear search and filters' })).toBeInTheDocument();
   });
 
+  it('shows an empty state if no starred dashboard returned', async () => {
+    jest.spyOn(getGrafanaSearcher(), 'search').mockResolvedValue({
+      ...mockSearchResult,
+      totalRows: 0,
+      view: new DataFrameView<DashboardQueryResult>({ fields: [], length: 0 }),
+    });
+
+    setup(undefined, { starred: true });
+
+    await waitFor(() => expect(screen.queryByText('No results found for your query.')).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: 'Clear search and filters' })).toBeInTheDocument();
+  });
+
+  it('shows empty folder cta for empty folder', async () => {
+    jest.spyOn(getGrafanaSearcher(), 'search').mockResolvedValue({
+      ...mockSearchResult,
+      totalRows: 0,
+      view: new DataFrameView<DashboardQueryResult>({ fields: [], length: 0 }),
+    });
+
+    setup(
+      {
+        folderDTO: {
+          id: 1,
+          uid: 'abc',
+          title: 'morning coffee',
+          url: '/morningcoffee',
+          version: 1,
+          canSave: true,
+          canEdit: true,
+          canAdmin: true,
+          canDelete: true,
+        },
+      },
+      undefined
+    );
+
+    await waitFor(() => expect(screen.queryByText("This folder doesn't have any dashboards yet")).toBeInTheDocument());
+  });
+
   describe('include panels', () => {
     it('should be enabled when layout is list', async () => {
       config.featureToggles.panelTitleSearch = true;

--- a/public/app/features/search/page/components/SearchView.tsx
+++ b/public/app/features/search/page/components/SearchView.tsx
@@ -159,7 +159,7 @@ export const SearchView = ({ showManage, folderDTO, hidePseudoFolders, keyboardE
     );
   };
 
-  if (folderDTO && !state.loading && !state.result?.totalRows && !state.query.length) {
+  if (folderDTO && !state.loading && !state.result?.totalRows && !stateManager.hasSearchFilters()) {
     return (
       <EmptyListCTA
         title="This folder doesn't have any dashboards yet"

--- a/public/app/features/search/state/SearchStateManager.ts
+++ b/public/app/features/search/state/SearchStateManager.ts
@@ -136,6 +136,10 @@ export class SearchStateManager extends StateManagerBase<SearchState> {
     store.set(SEARCH_PANELS_LOCAL_STORAGE_KEY, includePanels);
   };
 
+  hasSearchFilters() {
+    return this.state.query || this.state.tag.length || this.state.starred;
+  }
+
   getSearchQuery() {
     const q: SearchQuery = {
       query: this.state.query,


### PR DESCRIPTION
**What is this feature?**

When filtering, by starred dashboards for example, and no match has been found, show that _the current filters do not match any dashboard in the current folder instead_ of '_This folder doesn't have any dashboards yet_' message.

**Why do we need this feature?**

To avoid misleading if the folder does in fact contains dashboards.

**Who is this feature for?**

Everybody.

**Which issue(s) does this PR fix?**:

Fixes #61293

**Special notes for your reviewer**:

