### PR TITLE
SupportBundles: Fix list response when we don't have any bundles yet

### DIFF
--- a/pkg/services/supportbundles/supportbundlesimpl/store.go
+++ b/pkg/services/supportbundles/supportbundlesimpl/store.go
@@ -101,7 +101,7 @@ func (s *store) List() ([]supportbundles.Bundle, error) {
 		return nil, err
 	}
 
-	res := make([]supportbundles.Bundle, 0, 0)
+	res := make([]supportbundles.Bundle, 0)
 	for _, items := range data {
 		for _, s := range items {
 			var b supportbundles.Bundle

--- a/pkg/services/supportbundles/supportbundlesimpl/store.go
+++ b/pkg/services/supportbundles/supportbundlesimpl/store.go
@@ -101,7 +101,7 @@ func (s *store) List() ([]supportbundles.Bundle, error) {
 		return nil, err
 	}
 
-	var res []supportbundles.Bundle
+	res := make([]supportbundles.Bundle, 0, 0)
 	for _, items := range data {
 		for _, s := range items {
 			var b supportbundles.Bundle


### PR DESCRIPTION
**What is this feature?**
When calling GET /api/support-bundles the response will be null if there are no support bundles stored in the db.
This change makes sure that we will get an empty array in the response
