### PR TITLE
Alerting: Skip flaky test in TestIntegrationUpdateAlertRules

### DIFF
--- a/pkg/services/ngalert/store/alert_rule_test.go
+++ b/pkg/services/ngalert/store/alert_rule_test.go
@@ -52,6 +52,7 @@ func TestIntegrationUpdateAlertRules(t *testing.T) {
 	})
 
 	t.Run("should fail due to optimistic locking if version does not match", func(t *testing.T) {
+		t.Skip()
 		rule := createRule(t, store)
 		rule.Version-- // simulate version discrepancy
 

--- a/pkg/services/ngalert/store/alert_rule_test.go
+++ b/pkg/services/ngalert/store/alert_rule_test.go
@@ -52,7 +52,7 @@ func TestIntegrationUpdateAlertRules(t *testing.T) {
 	})
 
 	t.Run("should fail due to optimistic locking if version does not match", func(t *testing.T) {
-		t.Skip()
+		t.Skip() // This test intermittently fails.
 		rule := createRule(t, store)
 		rule.Version-- // simulate version discrepancy
 


### PR DESCRIPTION
**What is this feature?**

Skip an intermittently failing test. This test fails very often seemingly.

Filing an issue to fix and un-skip the test.

**Which issue(s) does this PR fix?**:

n/a

**Special notes for your reviewer**:

