### PR TITLE
TemplateSrv: Allow core and scene template variables interpolation

### DIFF
--- a/public/app/features/templating/template_srv.ts
+++ b/public/app/features/templating/template_srv.ts
@@ -276,8 +276,10 @@ export class TemplateSrv implements BaseTemplateSrv {
   }
 
   replace(target?: string, scopedVars?: ScopedVars, format?: string | Function): string {
+    let interpolatedTarget = target;
+
     if (scopedVars && scopedVars.__sceneObject) {
-      return sceneGraph.interpolate(
+      interpolatedTarget = sceneGraph.interpolate(
         scopedVars.__sceneObject.value,
         target,
         scopedVars,
@@ -285,13 +287,13 @@ export class TemplateSrv implements BaseTemplateSrv {
       );
     }
 
-    if (!target) {
-      return target ?? '';
+    if (!interpolatedTarget) {
+      return interpolatedTarget ?? '';
     }
 
     this.regex.lastIndex = 0;
 
-    return target.replace(this.regex, (match, var1, var2, fmt2, var3, fieldPath, fmt3) => {
+    return interpolatedTarget.replace(this.regex, (match, var1, var2, fmt2, var3, fieldPath, fmt3) => {
       const variableName = var1 || var2 || var3;
       const variable = this.getVariableAtIndex(variableName);
       const fmt = fmt2 || fmt3 || format;


### PR DESCRIPTION
Discovered an issue with scenes interpolator when applying field overrides- core variables, i.e. in data links, were not correctly interpolated, as scene interpolator only works in the context of scene objects.

This PR, instead of returning result after scene interpolation is applied, it passes the result further to allow core vars interpolation.

Corresponding change in @grafana/scenes: https://github.com/grafana/scenes/pull/12