### PR TITLE
Draft/error state

### DIFF
--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -565,11 +565,11 @@ export function filterPanelDataToQuery(data: PanelData, refId: string): PanelDat
 
   // Only say this is an error if the error links to the query
   let state = data.state;
-  // @Ida this is an error in the *previous* query, not the new one.
+  // This is an error in the *previous* query, not the new one.
   // (Both results are being merged in runRequest/preProcessPanelData() which results in a combination of data)
   const error = data.error && data.error.refId === refId ? data.error : undefined;
   // An alternative solution is in the comment below, but I feel like it's more dealing with the symptoms and not the cause?
-  // Unless of course the cause, that error here is persisted from the last query, is intended behaviour.
+  // Unless of course that the error here is persisted from the last query, is intended behaviour.
   // if (state !== LoadingState.Loading && error) {
   if (error) {
     state = LoadingState.Error;

--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -10,13 +10,13 @@ import {
   DataQuery,
   DataSourceApi,
   DataSourceInstanceSettings,
+  DataSourcePluginContextProvider,
   EventBusExtended,
   EventBusSrv,
   HistoryItem,
   LoadingState,
   PanelData,
   PanelEvents,
-  DataSourcePluginContextProvider,
   QueryResultMetaNotice,
   TimeRange,
   toLegacyResponseData,
@@ -565,7 +565,9 @@ export function filterPanelDataToQuery(data: PanelData, refId: string): PanelDat
 
   // Only say this is an error if the error links to the query
   let state = data.state;
+  // @Ida this is an error connected to the previous query, not the new one! so this should not change the current status
   const error = data.error && data.error.refId === refId ? data.error : undefined;
+  // if (state !== LoadingState.Loading && error) {
   if (error) {
     state = LoadingState.Error;
   } else if (!error && data.state === LoadingState.Error) {

--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -565,8 +565,11 @@ export function filterPanelDataToQuery(data: PanelData, refId: string): PanelDat
 
   // Only say this is an error if the error links to the query
   let state = data.state;
-  // @Ida this is an error connected to the previous query, not the new one! so this should not change the current status
+  // @Ida this is an error in the *previous* query, not the new one.
+  // (Both results are being merged in runRequest/preProcessPanelData() which results in a combination of data)
   const error = data.error && data.error.refId === refId ? data.error : undefined;
+  // An alternative solution is in the comment below, but I feel like it's more dealing with the symptoms and not the cause?
+  // Unless of course the cause, that error here is persisted from the last query, is intended behaviour.
   // if (state !== LoadingState.Loading && error) {
   if (error) {
     state = LoadingState.Error;

--- a/public/app/features/query/state/mergePanelAndDashData.ts
+++ b/public/app/features/query/state/mergePanelAndDashData.ts
@@ -20,7 +20,7 @@ export function mergePanelAndDashData(
 
         const annotations = panelData.annotations.concat(new ArrayDataFrame(dashData.annotations));
         const alertState = dashData.alertState;
-        return of({ ...panelData, annotations, alertState, error: {} });
+        return of({ ...panelData, annotations, alertState });
       }
 
       return of(panelData);

--- a/public/app/features/query/state/mergePanelAndDashData.ts
+++ b/public/app/features/query/state/mergePanelAndDashData.ts
@@ -20,7 +20,7 @@ export function mergePanelAndDashData(
 
         const annotations = panelData.annotations.concat(new ArrayDataFrame(dashData.annotations));
         const alertState = dashData.alertState;
-        return of({ ...panelData, annotations, alertState });
+        return of({ ...panelData, annotations, alertState, error: {} });
       }
 
       return of(panelData);

--- a/public/app/features/query/state/runRequest.ts
+++ b/public/app/features/query/state/runRequest.ts
@@ -123,7 +123,6 @@ export function runRequest(
       series: [],
       request: request,
       timeRange: request.range,
-      error: undefined,
     },
     packets: {},
   };
@@ -237,7 +236,7 @@ export function preProcessPanelData(data: PanelData, lastResult?: PanelData): Pa
       ...lastResult,
       state: LoadingState.Loading,
       request: data.request,
-      // @Ida maybe?
+      // if the current result doesn't have an error, clear it
       error: data.error,
     };
   }


### PR DESCRIPTION
This PR and the discussion around it is a result of investigation for this bug: 

https://github.com/grafana/redshift-datasource/issues/200 

The debugging process in Redshift is not relevant, just what the intended behaviour would be: 
![gif-redshift](https://user-images.githubusercontent.com/16140639/213491546-26036d44-0afe-4c09-917b-cefd075cbcd2.gif)

This is decidedly not happening, as when you click on "Run" the second time, the button gets stuck.

The underlying cause is the plugin’s QueryEditor not getting a "loading" state when a query is being executed, if it errors out before that query. The cause is that the last query result and the current one are being merged together, which causes the old error to appear along with the loading state:

```
export function preProcessPanelData(data: PanelData, lastResult?: PanelData): PanelData {
  const { series, annotations } = data;

  //  for loading states with no data, use last result
  if (data.state === LoadingState.Loading && series.length === 0) {
    if (!lastResult) {
      lastResult = data;
    }

    return {
      ...lastResult,
      state: LoadingState.Loading,
      request: data.request,
    };
  }
```


This leads to the QueryGroupRow, where, if there is an error in the result data, the state gets overwritten from "Loading", to "Error" (even though the error is the previous, not the currently loading query): 
```
export function filterPanelDataToQuery(data: PanelData, refId: string): PanelData | undefined {
.....

  // Only say this is an error if the error links to the query
  let state = data.state;
  const error = data.error && data.error.refId === refId ? data.error : undefined;
  if (error) {
    state = LoadingState.Error;
  } else if (!error && data.state === LoadingState.Error) {
    state = LoadingState.Done;
  }
```

The plugin unfortunately needs that Loading state passed, as we have introduced the "Run" and "Cancel" query buttons for long-running queries 

There are two solutions that I can see (of course any other suggestions are welcome). 

**1.** To add a condition in QueryEditorRow for checking that the state isn't loading. It's a good and simple solution, if the error being persisted all the way down to that component is intended behaviour. However, it feels more that it's dealing with the symptoms rather than the cause:


```
if (error ***.  && state !== LoadingState.Error  ***) {
    state = LoadingState.Error;
  } else if (!error && data.state === LoadingState.Error) {
    state = LoadingState.Done;
  }
```

**2.** The other solution is to clear the error if the latest data result doesn't contain it. Which is what this PR proposes. 

I've run unit tests and they all pass, but of course it's possible that there aren't unit tests that would catch any possible bugs.


**The question I'd like to get feedback on mainly is: 

- Is there a particular reason that we are keeping the error object in the final results?** 

The one I can think of might be a jumpy ui when the error disappears when “run” is clicked. 
I read a PR comment somewhere about reducing the number of rerenders, but I compared my PR changes and main, and there is no difference that I can see. 


P.S. As I mentioned, this is related to the new[ long-running (async) queries feature](https://github.com/grafana/redshift-datasource#async-query-data-support) and depending on responses to this, we will think about how to deal with and where to put buttons in those panels. 