### PR TITLE
Alerting: Fix flaky TestIntegrationUpdateAlertRules

### DIFF
--- a/pkg/services/ngalert/models/testing.go
+++ b/pkg/services/ngalert/models/testing.go
@@ -60,7 +60,7 @@ func AlertRuleGen(mutators ...AlertRuleMutator) func() *AlertRule {
 
 		rule := &AlertRule{
 			ID:              rand.Int63n(1500),
-			OrgID:           rand.Int63n(1500),
+			OrgID:           rand.Int63n(1500) + 1, // Prevent OrgID=0 as this does not pass alert rule validation.
 			Title:           "TEST-ALERT-" + util.GenerateShortUID(),
 			Condition:       "A",
 			Data:            []AlertQuery{GenerateAlertQuery()},

--- a/pkg/services/ngalert/store/alert_rule_test.go
+++ b/pkg/services/ngalert/store/alert_rule_test.go
@@ -52,7 +52,6 @@ func TestIntegrationUpdateAlertRules(t *testing.T) {
 	})
 
 	t.Run("should fail due to optimistic locking if version does not match", func(t *testing.T) {
-		t.Skip() // This test intermittently fails.
 		rule := createRule(t, store)
 		rule.Version-- // simulate version discrepancy
 


### PR DESCRIPTION
**What is this feature?**

Fixes flaky test caused by a random OrgID=0 during test alert generation. OrgID=0 was causing the generated alert rule to fail validation.

**Which issue(s) does this PR fix?**:

Fixes #61628

