### PR TITLE
Prometheus: Fix handling errors in streaming client

### DIFF
--- a/pkg/tests/api/prometheus/prometheus_test.go
+++ b/pkg/tests/api/prometheus/prometheus_test.go
@@ -87,7 +87,7 @@ func TestIntegrationPrometheus(t *testing.T) {
 		// nolint:gosec
 		resp, err := http.Post(u, "application/json", buf1)
 		require.NoError(t, err)
-		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
 		t.Cleanup(func() {
 			err := resp.Body.Close()
 			require.NoError(t, err)
@@ -123,7 +123,7 @@ func TestIntegrationPrometheus(t *testing.T) {
 		// nolint:gosec
 		resp, err := http.Post(u, "application/json", buf1)
 		require.NoError(t, err)
-		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
 		t.Cleanup(func() {
 			err := resp.Body.Close()
 			require.NoError(t, err)

--- a/pkg/tests/api/prometheus/prometheus_test.go
+++ b/pkg/tests/api/prometheus/prometheus_test.go
@@ -87,7 +87,7 @@ func TestIntegrationPrometheus(t *testing.T) {
 		// nolint:gosec
 		resp, err := http.Post(u, "application/json", buf1)
 		require.NoError(t, err)
-		require.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 		t.Cleanup(func() {
 			err := resp.Body.Close()
 			require.NoError(t, err)
@@ -123,7 +123,7 @@ func TestIntegrationPrometheus(t *testing.T) {
 		// nolint:gosec
 		resp, err := http.Post(u, "application/json", buf1)
 		require.NoError(t, err)
-		require.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 		t.Cleanup(func() {
 			err := resp.Body.Close()
 			require.NoError(t, err)

--- a/pkg/tsdb/prometheus/querydata/request.go
+++ b/pkg/tsdb/prometheus/querydata/request.go
@@ -124,18 +124,18 @@ func (s *QueryData) fetch(ctx context.Context, client *client.Client, q *models.
 	}
 
 	if q.InstantQuery {
-		res, _ := s.instantQuery(traceCtx, client, q, headers)
-		response.Error = res.Error
+		res, err := s.instantQuery(traceCtx, client, q, headers)
+		response.Error = err
 		response.Frames = res.Frames
 	}
 
 	if q.RangeQuery {
-		res, _ := s.rangeQuery(traceCtx, client, q, headers)
-		if res.Error != nil {
+		res, err := s.rangeQuery(traceCtx, client, q, headers)
+		if err != nil {
 			if response.Error == nil {
-				response.Error = res.Error
+				response.Error = err
 			} else {
-				response.Error = fmt.Errorf("%v %w", response.Error, res.Error) // lovely
+				response.Error = fmt.Errorf("%v %w", response.Error, err)
 			}
 		}
 		response.Frames = append(response.Frames, res.Frames...)

--- a/pkg/tsdb/prometheus/querydata/request.go
+++ b/pkg/tsdb/prometheus/querydata/request.go
@@ -124,19 +124,13 @@ func (s *QueryData) fetch(ctx context.Context, client *client.Client, q *models.
 	}
 
 	if q.InstantQuery {
-		res, err := s.instantQuery(traceCtx, client, q, headers)
-		if err != nil {
-			return nil, err
-		}
+		res, _ := s.instantQuery(traceCtx, client, q, headers)
 		response.Error = res.Error
 		response.Frames = res.Frames
 	}
 
 	if q.RangeQuery {
-		res, err := s.rangeQuery(traceCtx, client, q, headers)
-		if err != nil {
-			return nil, err
-		}
+		res, _ := s.rangeQuery(traceCtx, client, q, headers)
 		if res.Error != nil {
 			if response.Error == nil {
 				response.Error = res.Error

--- a/pkg/tsdb/prometheus/querydata/response.go
+++ b/pkg/tsdb/prometheus/querydata/response.go
@@ -29,6 +29,11 @@ func (s *QueryData) parseResponse(ctx context.Context, q *models.Query, res *htt
 		MatrixWideSeries: s.enableWideSeries,
 		VectorWideSeries: s.enableWideSeries,
 	})
+
+	if r.Error != nil {
+		return r, r.Error
+	}
+
 	if r.Frames == nil {
 		return r, fmt.Errorf("received empty response from prometheus")
 	}

--- a/pkg/tsdb/prometheus/querydata/response.go
+++ b/pkg/tsdb/prometheus/querydata/response.go
@@ -30,21 +30,22 @@ func (s *QueryData) parseResponse(ctx context.Context, q *models.Query, res *htt
 		VectorWideSeries: s.enableWideSeries,
 	})
 
-	if r.Error != nil {
-		return r, r.Error
-	}
-
-	if r.Frames == nil {
-		return r, fmt.Errorf("received empty response from prometheus")
-	}
-
 	// The ExecutedQueryString can be viewed in QueryInspector in UI
+	// Add frame to attach metadata to it
+	if len(r.Frames) == 0 {
+		r.Frames = append(r.Frames, data.NewFrame(""))
+	}
+
 	for _, frame := range r.Frames {
 		if s.enableWideSeries {
 			addMetadataToWideFrame(q, frame)
 		} else {
 			addMetadataToMultiFrame(q, frame)
 		}
+	}
+
+	if r.Error != nil {
+		return r, r.Error
 	}
 
 	r = s.processExemplars(q, r)

--- a/pkg/tsdb/prometheus/testdata/exemplar.result.golden.jsonc
+++ b/pkg/tsdb/prometheus/testdata/exemplar.result.golden.jsonc
@@ -26,6 +26,16 @@
 //  +-----------------------------------+-----------------+--------------------------------------------+----------------+-------------------+-------------------+----------------+----------------+--------------------+----------------+------------------+-----------------+-------------------+----------------------------------+
 //  
 //  
+//  
+//  Frame[1] {
+//      "executedQueryString": "Expr: histogram_quantile(0.99, sum(rate(traces_spanmetrics_duration_seconds_bucket[15s])) by (le))\nStep: 15s"
+//  }
+//  Name: 
+//  Dimensions: 0 Fields by 0 Rows
+//  +
+//  +
+//  
+//  
 //  🌟 This was machine generated.  Do not edit. 🌟
 {
   "status": 200,
@@ -1039,6 +1049,17 @@
             "83bf586cc62842c3187106bb40a6793d"
           ]
         ]
+      }
+    },
+    {
+      "schema": {
+        "meta": {
+          "executedQueryString": "Expr: histogram_quantile(0.99, sum(rate(traces_spanmetrics_duration_seconds_bucket[15s])) by (le))\nStep: 15s"
+        },
+        "fields": []
+      },
+      "data": {
+        "values": []
       }
     }
   ]

--- a/pkg/tsdb/prometheus/testdata/exemplar.result.streaming-wide.golden.jsonc
+++ b/pkg/tsdb/prometheus/testdata/exemplar.result.streaming-wide.golden.jsonc
@@ -26,6 +26,16 @@
 //  +-----------------------------------+-----------------+--------------------------------------------+----------------+-------------------+-------------------+----------------+----------------+--------------------+----------------+------------------+-----------------+-------------------+----------------------------------+
 //  
 //  
+//  
+//  Frame[1] {
+//      "executedQueryString": "Expr: histogram_quantile(0.99, sum(rate(traces_spanmetrics_duration_seconds_bucket[15s])) by (le))\nStep: 15s"
+//  }
+//  Name: 
+//  Dimensions: 0 Fields by 0 Rows
+//  +
+//  +
+//  
+//  
 //  🌟 This was machine generated.  Do not edit. 🌟
 {
   "status": 200,
@@ -1039,6 +1049,17 @@
             "83bf586cc62842c3187106bb40a6793d"
           ]
         ]
+      }
+    },
+    {
+      "schema": {
+        "meta": {
+          "executedQueryString": "Expr: histogram_quantile(0.99, sum(rate(traces_spanmetrics_duration_seconds_bucket[15s])) by (le))\nStep: 15s"
+        },
+        "fields": []
+      },
+      "data": {
+        "values": []
       }
     }
   ]


### PR DESCRIPTION
**What is this feature?**

Since we are returning the result directly from json parser, we failed to handle errors properly. 
See the issue: https://github.com/grafana/grafana/issues/52430

This was a bug that was introduced in the PR https://github.com/grafana/grafana/pull/57209 which was reviewed by me and failed to catch. So this PR is fixing it.

**Why do we need this feature?**

To handle errors properly in the new Prometheus client.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/61507

**Special notes for your reviewer**:
To Reproduce:
- Checkout `main` branch
- In the explore while a Prometheus datasource selected run `asd{` as query
- Observe that no meaningful error message is being displayed

After this fix:
<img width="623" alt="image" src="https://user-images.githubusercontent.com/820946/213015439-588d683b-58c5-4771-9b48-94bc586bf5f9.png">
