### PR TITLE
Alerting: Create query interface for state history along with annotation-based implementation

### DIFF
--- a/pkg/services/ngalert/models/history.go
+++ b/pkg/services/ngalert/models/history.go
@@ -1,0 +1,11 @@
+package models
+
+import "time"
+
+// HistoryQuery represents a query for alert state history.
+type HistoryQuery struct {
+	RuleUID string
+	Labels  map[string]string
+	From    time.Time
+	To      time.Time
+}

--- a/pkg/services/ngalert/models/history.go
+++ b/pkg/services/ngalert/models/history.go
@@ -5,6 +5,7 @@ import "time"
 // HistoryQuery represents a query for alert state history.
 type HistoryQuery struct {
 	RuleUID string
+	OrgID   int64
 	Labels  map[string]string
 	From    time.Time
 	To      time.Time

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -205,7 +205,7 @@ func (ng *AlertNG) init() error {
 		Tracer:               ng.tracer,
 	}
 
-	history, err := configureHistorianBackend(ng.Cfg.UnifiedAlerting.StateHistory, ng.annotationsRepo, ng.dashboardService)
+	history, err := configureHistorianBackend(ng.Cfg.UnifiedAlerting.StateHistory, ng.annotationsRepo, ng.dashboardService, ng.store)
 	if err != nil {
 		return err
 	}
@@ -378,13 +378,13 @@ func readQuotaConfig(cfg *setting.Cfg) (*quota.Map, error) {
 	return limits, nil
 }
 
-func configureHistorianBackend(cfg setting.UnifiedAlertingStateHistorySettings, ar annotations.Repository, ds dashboards.DashboardService) (state.Historian, error) {
+func configureHistorianBackend(cfg setting.UnifiedAlertingStateHistorySettings, ar annotations.Repository, ds dashboards.DashboardService, rs historian.RuleStore) (state.Historian, error) {
 	if !cfg.Enabled {
 		return historian.NewNopHistorian(), nil
 	}
 
 	if cfg.Backend == "annotations" {
-		return historian.NewAnnotationBackend(ar, ds), nil
+		return historian.NewAnnotationBackend(ar, ds, rs), nil
 	}
 	if cfg.Backend == "loki" {
 		baseURL, err := url.Parse(cfg.LokiRemoteURL)

--- a/pkg/services/ngalert/state/historian/annotation.go
+++ b/pkg/services/ngalert/state/historian/annotation.go
@@ -14,7 +14,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/annotations"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
-	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/state"
 )
@@ -49,7 +48,7 @@ func (h *AnnotationBackend) RecordStatesAsync(ctx context.Context, rule *ngmodel
 	go h.recordAnnotationsSync(ctx, panel, annotations, logger)
 }
 
-func (h *AnnotationBackend) QueryStates(ctx context.Context, query models.HistoryQuery) (*data.Frame, error) {
+func (h *AnnotationBackend) QueryStates(ctx context.Context, query ngmodels.HistoryQuery) (*data.Frame, error) {
 	logger := h.log.FromContext(ctx)
 	if query.RuleUID == "" {
 		return nil, fmt.Errorf("ruleUID is required to query annotations")

--- a/pkg/services/ngalert/state/historian/annotation.go
+++ b/pkg/services/ngalert/state/historian/annotation.go
@@ -132,11 +132,6 @@ func (h *AnnotationBackend) QueryStates(ctx context.Context, query models.Histor
 	return frame, nil
 }
 
-func ruleUIDToID(uid string) int64 {
-	// TODO
-	return 0
-}
-
 func (h *AnnotationBackend) buildAnnotations(rule *ngmodels.AlertRule, states []state.StateTransition, logger log.Logger) []annotations.Item {
 	items := make([]annotations.Item, 0, len(states))
 	for _, state := range states {

--- a/pkg/services/ngalert/state/historian/annotation.go
+++ b/pkg/services/ngalert/state/historian/annotation.go
@@ -7,11 +7,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/annotations"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/state"
 )
@@ -38,6 +40,10 @@ func (h *AnnotationBackend) RecordStatesAsync(ctx context.Context, rule *ngmodel
 	annotations := h.buildAnnotations(rule, states, logger)
 	panel := parsePanelKey(rule, logger)
 	go h.recordAnnotationsSync(ctx, panel, annotations, logger)
+}
+
+func (h *AnnotationBackend) QueryStates(ctx context.Context, query models.HistoryQuery) (*data.Frame, error) {
+	return data.NewFrame("states"), nil
 }
 
 func (h *AnnotationBackend) buildAnnotations(rule *ngmodels.AlertRule, states []state.StateTransition, logger log.Logger) []annotations.Item {

--- a/pkg/services/ngalert/state/historian/annotation_test.go
+++ b/pkg/services/ngalert/state/historian/annotation_test.go
@@ -1,0 +1,70 @@
+package historian
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/annotations"
+	"github.com/grafana/grafana/pkg/services/annotations/annotationstest"
+	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/services/ngalert/tests/fakes"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAnnotationHistorian_Integration(t *testing.T) {
+	t.Run("alert annotations are queryable", func(t *testing.T) {
+		anns := createTestAnnotationBackendSut(t)
+		items := []annotations.Item{createAnnotation()}
+		anns.recordAnnotationsSync(context.Background(), nil, items, log.NewNopLogger())
+
+		q := models.HistoryQuery{
+			RuleUID: "my-rule",
+			OrgID:   1,
+		}
+		frame, err := anns.QueryStates(context.Background(), q)
+
+		require.NoError(t, err)
+		require.NotNil(t, frame)
+		require.Len(t, frame.Fields, 5)
+		for i := 0; i < 5; i++ {
+			require.Equal(t, frame.Fields[i].Len(), 1)
+		}
+	})
+}
+
+func createTestAnnotationBackendSut(t *testing.T) *AnnotationBackend {
+	t.Helper()
+	fakeAnnoRepo := annotationstest.NewFakeAnnotationsRepo()
+	rules := fakes.NewRuleStore(t)
+	rules.Rules[1] = []*models.AlertRule{
+		models.AlertRuleGen(withOrgID(1), withUID("my-rule"))(),
+	}
+	return NewAnnotationBackend(fakeAnnoRepo, &dashboards.FakeDashboardService{}, rules)
+}
+
+func createAnnotation() annotations.Item {
+	return annotations.Item{
+		Id:      1,
+		OrgId:   1,
+		AlertId: 1,
+		Text:    "MyAlert {a=b} - No data",
+		Data:    simplejson.New(),
+		Epoch:   time.Now().UnixNano() / int64(time.Millisecond),
+	}
+}
+
+func withOrgID(orgId int64) func(rule *models.AlertRule) {
+	return func(rule *models.AlertRule) {
+		rule.OrgID = orgId
+	}
+}
+
+func withUID(uid string) func(rule *models.AlertRule) {
+	return func(rule *models.AlertRule) {
+		rule.UID = uid
+	}
+}

--- a/pkg/services/ngalert/state/historian/loki.go
+++ b/pkg/services/ngalert/state/historian/loki.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/url"
 
+	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/state"
@@ -33,4 +34,8 @@ func (h *RemoteLokiBackend) TestConnection() error {
 func (h *RemoteLokiBackend) RecordStatesAsync(ctx context.Context, _ *models.AlertRule, _ []state.StateTransition) {
 	logger := h.log.FromContext(ctx)
 	logger.Debug("Remote Loki state history backend was called with states")
+}
+
+func (h *RemoteLokiBackend) QueryStates(ctx context.Context, query models.HistoryQuery) (*data.Frame, error) {
+	return data.NewFrame("states"), nil
 }

--- a/pkg/services/ngalert/state/historian/query.go
+++ b/pkg/services/ngalert/state/historian/query.go
@@ -1,0 +1,15 @@
+package historian
+
+import (
+	"context"
+
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+)
+
+// Querier represents the ability to query state history.
+// TODO: This package also contains implementations of this interface.
+// TODO: This type should be moved to the side of the consumer, when the consumer is created in the future. We add it here temporarily to more clearly define this package's interface.
+type Querier interface {
+	QueryStates(ctx context.Context, query models.HistoryQuery) (*data.Frame, error)
+}

--- a/pkg/services/ngalert/state/historian/sql.go
+++ b/pkg/services/ngalert/state/historian/sql.go
@@ -3,6 +3,7 @@ package historian
 import (
 	"context"
 
+	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/state"
@@ -19,4 +20,8 @@ func NewSqlBackend() *SqlBackend {
 }
 
 func (h *SqlBackend) RecordStatesAsync(ctx context.Context, _ *models.AlertRule, _ []state.StateTransition) {
+}
+
+func (h *SqlBackend) QueryStates(ctx context.Context, query models.HistoryQuery) (*data.Frame, error) {
+	return data.NewFrame("states"), nil
 }

--- a/pkg/services/ngalert/state/manager_test.go
+++ b/pkg/services/ngalert/state/manager_test.go
@@ -219,7 +219,7 @@ func TestDashboardAnnotations(t *testing.T) {
 	_, dbstore := tests.SetupTestEnv(t, 1)
 
 	fakeAnnoRepo := annotationstest.NewFakeAnnotationsRepo()
-	hist := historian.NewAnnotationBackend(fakeAnnoRepo, &dashboards.FakeDashboardService{})
+	hist := historian.NewAnnotationBackend(fakeAnnoRepo, &dashboards.FakeDashboardService{}, nil)
 	cfg := state.ManagerCfg{
 		Metrics:       testMetrics.GetStateMetrics(),
 		ExternalURL:   nil,
@@ -2208,7 +2208,7 @@ func TestProcessEvalResults(t *testing.T) {
 
 	for _, tc := range testCases {
 		fakeAnnoRepo := annotationstest.NewFakeAnnotationsRepo()
-		hist := historian.NewAnnotationBackend(fakeAnnoRepo, &dashboards.FakeDashboardService{})
+		hist := historian.NewAnnotationBackend(fakeAnnoRepo, &dashboards.FakeDashboardService{}, nil)
 		cfg := state.ManagerCfg{
 			Metrics:       testMetrics.GetStateMetrics(),
 			ExternalURL:   nil,


### PR DESCRIPTION
**What is this feature?**

This PR adds a query interface for state history backends.
To keep things sane, we also add an implementation of this to the Annotation backend. Keeping a working implementation of each allows the backends to be trivially swapped out via config.

Annotations have some known limitations when it comes to query - this implementation makes them obvious. The logic that's added here provides all functionality that the UI uses today, when querying annotations directly. Nothing uses it yet - **the focus of this PR is the interface itself, not the reference implementation.**

**Which issue(s) does this PR fix?**:

Completes a couple tasks in: https://github.com/grafana/grafana/issues/48359

**Special notes for your reviewer**:

