### PR TITLE
Logs: Make `no logs found` text more visible in Explore

### DIFF
--- a/public/app/features/explore/Logs.test.tsx
+++ b/public/app/features/explore/Logs.test.tsx
@@ -7,7 +7,7 @@ import { ExploreId } from 'app/types';
 import { Logs } from './Logs';
 
 describe('Logs', () => {
-  const setup = (propOverrides?: object) => {
+  const setup = (logs?: LogRowModel[]) => {
     const rows = [
       makeLog({ uid: '1', timeEpochMs: 1 }),
       makeLog({ uid: '2', timeEpochMs: 2 }),
@@ -24,7 +24,7 @@ describe('Logs', () => {
         onClickFilterOutLabel={() => null}
         logsVolumeData={undefined}
         loadLogsVolumeData={() => undefined}
-        logRows={rows}
+        logRows={logs ?? rows}
         timeZone={'utc'}
         width={50}
         loading={false}
@@ -59,6 +59,134 @@ describe('Logs', () => {
     expect(logRows.length).toBe(3);
     expect(logRows[0].textContent).toContain('log message 3');
     expect(logRows[2].textContent).toContain('log message 1');
+  });
+
+  it('should render no logs found', () => {
+    setup([]);
+
+    expect(screen.getByText(/no logs found\./i)).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {
+        name: /scan for older logs/i,
+      })
+    ).toBeInTheDocument();
+  });
+
+  it('should render a load more button', () => {
+    const scanningStarted = jest.fn();
+    render(
+      <Logs
+        exploreId={ExploreId.left}
+        splitOpen={() => undefined}
+        logsVolumeEnabled={true}
+        onSetLogsVolumeEnabled={() => null}
+        onClickFilterLabel={() => null}
+        onClickFilterOutLabel={() => null}
+        logsVolumeData={undefined}
+        loadLogsVolumeData={() => undefined}
+        logRows={[]}
+        onStartScanning={scanningStarted}
+        timeZone={'utc'}
+        width={50}
+        loading={false}
+        loadingState={LoadingState.Done}
+        absoluteRange={{
+          from: toUtc('2019-01-01 10:00:00').valueOf(),
+          to: toUtc('2019-01-01 16:00:00').valueOf(),
+        }}
+        addResultsToCache={() => {}}
+        onChangeTime={() => {}}
+        clearCache={() => {}}
+        getFieldLinks={() => {
+          return [];
+        }}
+        eventBus={new EventBusSrv()}
+      />
+    );
+    const button = screen.getByRole('button', {
+      name: /scan for older logs/i,
+    });
+    button.click();
+    expect(scanningStarted).toHaveBeenCalled();
+  });
+
+  it('should render a stop scanning button', () => {
+    render(
+      <Logs
+        exploreId={ExploreId.left}
+        splitOpen={() => undefined}
+        logsVolumeEnabled={true}
+        onSetLogsVolumeEnabled={() => null}
+        onClickFilterLabel={() => null}
+        onClickFilterOutLabel={() => null}
+        logsVolumeData={undefined}
+        loadLogsVolumeData={() => undefined}
+        logRows={[]}
+        scanning={true}
+        timeZone={'utc'}
+        width={50}
+        loading={false}
+        loadingState={LoadingState.Done}
+        absoluteRange={{
+          from: toUtc('2019-01-01 10:00:00').valueOf(),
+          to: toUtc('2019-01-01 16:00:00').valueOf(),
+        }}
+        addResultsToCache={() => {}}
+        onChangeTime={() => {}}
+        clearCache={() => {}}
+        getFieldLinks={() => {
+          return [];
+        }}
+        eventBus={new EventBusSrv()}
+      />
+    );
+
+    expect(
+      screen.getByRole('button', {
+        name: /stop scan/i,
+      })
+    ).toBeInTheDocument();
+  });
+
+  it('should render a stop scanning button', () => {
+    const scanningStopped = jest.fn();
+
+    render(
+      <Logs
+        exploreId={ExploreId.left}
+        splitOpen={() => undefined}
+        logsVolumeEnabled={true}
+        onSetLogsVolumeEnabled={() => null}
+        onClickFilterLabel={() => null}
+        onClickFilterOutLabel={() => null}
+        logsVolumeData={undefined}
+        loadLogsVolumeData={() => undefined}
+        logRows={[]}
+        scanning={true}
+        onStopScanning={scanningStopped}
+        timeZone={'utc'}
+        width={50}
+        loading={false}
+        loadingState={LoadingState.Done}
+        absoluteRange={{
+          from: toUtc('2019-01-01 10:00:00').valueOf(),
+          to: toUtc('2019-01-01 16:00:00').valueOf(),
+        }}
+        addResultsToCache={() => {}}
+        onChangeTime={() => {}}
+        clearCache={() => {}}
+        getFieldLinks={() => {
+          return [];
+        }}
+        eventBus={new EventBusSrv()}
+      />
+    );
+
+    const button = screen.getByRole('button', {
+      name: /stop scan/i,
+    });
+    button.click();
+    expect(scanningStopped).toHaveBeenCalled();
   });
 
   it('should flip the order', () => {

--- a/public/app/features/explore/Logs.tsx
+++ b/public/app/features/explore/Logs.tsx
@@ -507,6 +507,22 @@ class UnthemedLogs extends PureComponent<Props, State> {
                 scrollElement={scrollElement}
                 onLogRowHover={this.onLogRowHover}
               />
+              {!loading && !hasData && !scanning && (
+                <div className={styles.noData}>
+                  No logs found.
+                  <Button size="sm" variant="secondary" onClick={this.onClickScan}>
+                    Scan for older logs
+                  </Button>
+                </div>
+              )}
+              {scanning && (
+                <div className={styles.noData}>
+                  <span>{scanText}</span>
+                  <Button size="sm" variant="secondary" onClick={this.onClickStopScan}>
+                    Stop scan
+                  </Button>
+                </div>
+              )}
             </div>
             <LogsNavigation
               logsSortOrder={logsSortOrder}
@@ -521,22 +537,6 @@ class UnthemedLogs extends PureComponent<Props, State> {
               clearCache={clearCache}
             />
           </div>
-          {!loading && !hasData && !scanning && (
-            <div className={styles.noData}>
-              No logs found.
-              <Button size="xs" fill="text" onClick={this.onClickScan}>
-                Scan for older logs
-              </Button>
-            </div>
-          )}
-          {scanning && (
-            <div className={styles.noData}>
-              <span>{scanText}</span>
-              <Button size="xs" fill="text" onClick={this.onClickStopScan}>
-                Stop scan
-              </Button>
-            </div>
-          )}
         </Collapse>
       </>
     );


### PR DESCRIPTION
**What is this feature?**

If there are no logs found we display a small text. However this text is currently at the bottom of the LogsContainer. This PR moves this text up and aligns the button stylings to the other buttons used.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/support-escalations/issues/4809

**Special notes for your reviewer**:

Before:
<img width="707" alt="image" src="https://user-images.githubusercontent.com/8092184/213090462-b8bf9f48-76cb-4b5a-8590-ba01a1475b6e.png">

Now:
<img width="706" alt="image" src="https://user-images.githubusercontent.com/8092184/213090497-42a0bcb6-4f26-40db-9333-6c5a1abf9d44.png">
