### PR TITLE
[9.3.x] Loki: Use queries `maxLines` if configured, even if it is zero (#61652)

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -156,6 +156,10 @@ describe('LokiDatasource', () => {
     it('should use query max lines, if both exist, even if it is higher than ds max lines', async () => {
       await runTest(80, '40', 80);
     });
+
+    it('should use query max lines, if both exist, even if it is 0', async () => {
+      await runTest(0, '40', 0);
+    });
   });
 
   describe('When using adhoc filters', () => {

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -162,7 +162,7 @@ export class LokiDatasource
   query(request: DataQueryRequest<LokiQuery>): Observable<DataQueryResponse> {
     const queries = request.targets
       .map(getNormalizedLokiQuery) // "fix" the `.queryType` prop
-      .map((q) => ({ ...q, maxLines: q.maxLines || this.maxLines })); // set maxLines if not set
+      .map((q) => ({ ...q, maxLines: q.maxLines ?? this.maxLines }));
 
     const fixedRequest = {
       ...request,


### PR DESCRIPTION
Backport of #61652