### PR TITLE
RBAC: fix wildcard check

### DIFF
--- a/pkg/services/sqlstore/permissions/dashboard.go
+++ b/pkg/services/sqlstore/permissions/dashboard.go
@@ -203,16 +203,20 @@ func (f AccessControlDashboardPermissionFilter) Where() (string, []interface{}) 
 
 func actionsToCheck(actions []string, permissions map[string][]string, wildcards ...accesscontrol.Wildcards) []interface{} {
 	toCheck := make([]interface{}, 0, len(actions))
+
 	for _, a := range actions {
 		var hasWildcard bool
+
+	outer:
 		for _, scope := range permissions[a] {
 			for _, w := range wildcards {
 				if w.Contains(scope) {
 					hasWildcard = true
-					break
+					break outer
 				}
 			}
 		}
+
 		if !hasWildcard {
 			toCheck = append(toCheck, a)
 		}


### PR DESCRIPTION
**What is this feature?**
When we have found a matching wildcard we don't have to check other scopes

