### PR TITLE
Navigation: Open command palette from search box

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -46,6 +46,7 @@ Some stable features are enabled by default. You can disable a stable feature by
 | `datasourceLogger`                | Logs all datasource requests                                                    |
 | `accessControlOnCall`             | Access control primitives for OnCall                                            |
 | `alertingNoNormalState`           | Stop maintaining state of alerts that are not firing                            |
+| `topNavCommandPalette`            | Launch the Command Palette from top nav search box                              |
 
 ## Alpha feature toggles
 

--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -46,7 +46,7 @@ Some stable features are enabled by default. You can disable a stable feature by
 | `datasourceLogger`                | Logs all datasource requests                                                    |
 | `accessControlOnCall`             | Access control primitives for OnCall                                            |
 | `alertingNoNormalState`           | Stop maintaining state of alerts that are not firing                            |
-| `topNavCommandPalette`            | Launch the Command Palette from top nav search box                              |
+| `topNavCommandPalette`            | Launch the Command Palette from the top navigation search box                   |
 
 ## Alpha feature toggles
 

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -89,4 +89,5 @@ export interface FeatureToggles {
   alertingBacktesting?: boolean;
   alertingNoNormalState?: boolean;
   azureMultipleResourcePicker?: boolean;
+  topNavCommandPalette?: boolean;
 }

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -410,7 +410,7 @@ var (
 		},
 		{
 			Name:         "topNavCommandPalette",
-			Description:  "Launch the Command Palette from top nav search box",
+			Description:  "Launch the Command Palette from the top navigation search box",
 			State:        FeatureStateBeta,
 			FrontendOnly: true,
 		},

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -408,5 +408,11 @@ var (
 			Description: "Azure multiple resource picker",
 			State:       FeatureStateAlpha,
 		},
+		{
+			Name:         "topNavCommandPalette",
+			Description:  "Launch the Command Palette from top nav search box",
+			State:        FeatureStateBeta,
+			FrontendOnly: true,
+		},
 	}
 )

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -298,4 +298,8 @@ const (
 	// FlagAzureMultipleResourcePicker
 	// Azure multiple resource picker
 	FlagAzureMultipleResourcePicker = "azureMultipleResourcePicker"
+
+	// FlagTopNavCommandPalette
+	// Launch the Command Palette from top nav search box
+	FlagTopNavCommandPalette = "topNavCommandPalette"
 )

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -300,6 +300,6 @@ const (
 	FlagAzureMultipleResourcePicker = "azureMultipleResourcePicker"
 
 	// FlagTopNavCommandPalette
-	// Launch the Command Palette from top nav search box
+	// Launch the Command Palette from the top navigation search box
 	FlagTopNavCommandPalette = "topNavCommandPalette"
 )

--- a/public/app/core/components/AppChrome/TopSearchBar.tsx
+++ b/public/app/core/components/AppChrome/TopSearchBar.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { Dropdown, ToolbarButton, useStyles2 } from '@grafana/ui';
+import { config } from 'app/core/config';
 import { contextSrv } from 'app/core/core';
 import { useSelector } from 'app/types';
 
@@ -15,6 +16,7 @@ import { SignInLink } from './TopBar/SignInLink';
 import { TopNavBarMenu } from './TopBar/TopNavBarMenu';
 import { TopSearchBarSection } from './TopBar/TopSearchBarSection';
 import { TopSearchBarCommandPaletteTrigger } from './TopSearchBarCommandPaletteTrigger';
+import { TopSearchBarInput } from './TopSearchBarInput';
 import { TOP_BAR_LEVEL_HEIGHT } from './types';
 
 export function TopSearchBar() {
@@ -23,6 +25,13 @@ export function TopSearchBar() {
 
   const helpNode = navIndex['help'];
   const profileNode = navIndex['profile'];
+
+  const search =
+    config.featureToggles.commandPalette && config.featureToggles.topNavcommandPalette ? (
+      <TopSearchBarCommandPaletteTrigger />
+    ) : (
+      <TopSearchBarInput />
+    );
 
   return (
     <div className={styles.layout}>
@@ -33,9 +42,7 @@ export function TopSearchBar() {
         <OrganizationSwitcher />
       </TopSearchBarSection>
 
-      <TopSearchBarSection>
-        <TopSearchBarCommandPaletteTrigger />
-      </TopSearchBarSection>
+      <TopSearchBarSection>{search}</TopSearchBarSection>
 
       <TopSearchBarSection align="right">
         <QuickAdd />

--- a/public/app/core/components/AppChrome/TopSearchBar.tsx
+++ b/public/app/core/components/AppChrome/TopSearchBar.tsx
@@ -72,7 +72,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     justifyContent: 'space-between',
 
     [theme.breakpoints.up('sm')]: {
-      gridTemplateColumns: '2fr minmax(200px, 1fr) 2fr', // search is .5fr, with a min width of 200px
+      gridTemplateColumns: '2fr minmax(200px, 1fr) 2fr', // search should not be smaller than 200px
       display: 'grid',
 
       justifyContent: 'flex-start',

--- a/public/app/core/components/AppChrome/TopSearchBar.tsx
+++ b/public/app/core/components/AppChrome/TopSearchBar.tsx
@@ -14,7 +14,7 @@ import { QuickAdd } from './QuickAdd/QuickAdd';
 import { SignInLink } from './TopBar/SignInLink';
 import { TopNavBarMenu } from './TopBar/TopNavBarMenu';
 import { TopSearchBarSection } from './TopBar/TopSearchBarSection';
-import { TopSearchBarInput } from './TopSearchBarInput';
+import { TopSearchBarCommandPaletteTrigger } from './TopSearchBarCommandPaletteTrigger';
 import { TOP_BAR_LEVEL_HEIGHT } from './types';
 
 export function TopSearchBar() {
@@ -34,7 +34,7 @@ export function TopSearchBar() {
       </TopSearchBarSection>
 
       <TopSearchBarSection>
-        <TopSearchBarInput />
+        <TopSearchBarCommandPaletteTrigger />
       </TopSearchBarSection>
 
       <TopSearchBarSection align="right">

--- a/public/app/core/components/AppChrome/TopSearchBar.tsx
+++ b/public/app/core/components/AppChrome/TopSearchBar.tsx
@@ -32,9 +32,11 @@ export function TopSearchBar() {
         </a>
         <OrganizationSwitcher />
       </TopSearchBarSection>
+
       <TopSearchBarSection>
         <TopSearchBarInput />
       </TopSearchBarSection>
+
       <TopSearchBarSection align="right">
         <QuickAdd />
         {helpNode && (
@@ -70,7 +72,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     justifyContent: 'space-between',
 
     [theme.breakpoints.up('sm')]: {
-      gridTemplateColumns: '1fr 1fr 1fr',
+      gridTemplateColumns: '2fr minmax(200px, 1fr) 2fr', // search is .5fr, with a min width of 200px
       display: 'grid',
 
       justifyContent: 'flex-start',

--- a/public/app/core/components/AppChrome/TopSearchBarCommandPaletteTrigger.tsx
+++ b/public/app/core/components/AppChrome/TopSearchBarCommandPaletteTrigger.tsx
@@ -8,7 +8,7 @@ import { focusCss } from '@grafana/ui/src/themes/mixins';
 import { useMediaQueryChange } from 'app/core/hooks/useMediaQueryChange';
 import { t } from 'app/core/internationalization';
 
-export function TopSearchBarInput() {
+export function TopSearchBarCommandPaletteTrigger() {
   const theme = useTheme2();
   const { query: kbar } = useKBar((kbarState) => ({
     kbarSearchQuery: kbarState.searchQuery,

--- a/public/app/core/components/AppChrome/TopSearchBarInput.tsx
+++ b/public/app/core/components/AppChrome/TopSearchBarInput.tsx
@@ -1,0 +1,47 @@
+import React, { useState } from 'react';
+
+import { locationService } from '@grafana/runtime';
+import { FilterInput, ToolbarButton, useTheme2 } from '@grafana/ui';
+import { useMediaQueryChange } from 'app/core/hooks/useMediaQueryChange';
+import { t } from 'app/core/internationalization';
+import { getSearchStateManager } from 'app/features/search/state/SearchStateManager';
+
+export function TopSearchBarInput() {
+  const theme = useTheme2();
+  const stateManager = getSearchStateManager();
+  const state = stateManager.useState();
+  const breakpoint = theme.breakpoints.values.sm;
+
+  const [isSmallScreen, setIsSmallScreen] = useState(window.matchMedia(`(max-width: ${breakpoint}px)`).matches);
+
+  useMediaQueryChange({
+    breakpoint,
+    onChange: (e) => {
+      setIsSmallScreen(e.matches);
+    },
+  });
+
+  const onOpenSearch = () => {
+    locationService.partial({ search: 'open' });
+  };
+
+  const onSearchChange = (value: string) => {
+    stateManager.onQueryChange(value);
+    if (value) {
+      onOpenSearch();
+    }
+  };
+
+  if (isSmallScreen) {
+    return <ToolbarButton iconOnly icon="search" aria-label="Search Grafana" onClick={onOpenSearch} />;
+  }
+
+  return (
+    <FilterInput
+      onClick={onOpenSearch}
+      placeholder={t('nav.search.placeholder', 'Search Grafana')}
+      value={state.query ?? ''}
+      onChange={onSearchChange}
+    />
+  );
+}

--- a/public/app/core/components/AppChrome/TopSearchBarInput.tsx
+++ b/public/app/core/components/AppChrome/TopSearchBarInput.tsx
@@ -1,15 +1,20 @@
+import { css } from '@emotion/css';
+import { useKBar, VisualState } from 'kbar';
 import React, { useState } from 'react';
 
-import { locationService } from '@grafana/runtime';
-import { FilterInput, ToolbarButton, useTheme2 } from '@grafana/ui';
+import { GrafanaTheme2 } from '@grafana/data';
+import { getInputStyles, Icon, ToolbarButton, useStyles2, useTheme2 } from '@grafana/ui';
+import { focusCss } from '@grafana/ui/src/themes/mixins';
 import { useMediaQueryChange } from 'app/core/hooks/useMediaQueryChange';
 import { t } from 'app/core/internationalization';
-import { getSearchStateManager } from 'app/features/search/state/SearchStateManager';
 
 export function TopSearchBarInput() {
   const theme = useTheme2();
-  const stateManager = getSearchStateManager();
-  const state = stateManager.useState();
+  const { query: kbar } = useKBar((kbarState) => ({
+    kbarSearchQuery: kbarState.searchQuery,
+    kbarIsOpen: kbarState.visualState === VisualState.showing,
+  }));
+
   const breakpoint = theme.breakpoints.values.sm;
 
   const [isSmallScreen, setIsSmallScreen] = useState(window.matchMedia(`(max-width: ${breakpoint}px)`).matches);
@@ -22,26 +27,83 @@ export function TopSearchBarInput() {
   });
 
   const onOpenSearch = () => {
-    locationService.partial({ search: 'open' });
-  };
-
-  const onSearchChange = (value: string) => {
-    stateManager.onQueryChange(value);
-    if (value) {
-      onOpenSearch();
-    }
+    kbar.toggle();
   };
 
   if (isSmallScreen) {
-    return <ToolbarButton iconOnly icon="search" aria-label="Search Grafana" onClick={onOpenSearch} />;
+    return (
+      <ToolbarButton
+        iconOnly
+        icon="search"
+        aria-label={t('nav.search.placeholder', 'Search Grafana')}
+        onClick={onOpenSearch}
+      />
+    );
   }
 
+  return <PretendTextInput onClick={onOpenSearch} />;
+}
+
+function PretendTextInput({ onClick }: { onClick: () => void }) {
+  const styles = useStyles2(getStyles);
+
+  // We want the desktop command palette trigger to look like a search box,
+  // but it actually behaves like a button - you active it and it performs an
+  // action. You don't actually type into it.
+
   return (
-    <FilterInput
-      onClick={onOpenSearch}
-      placeholder={t('nav.search.placeholder', 'Search Grafana')}
-      value={state.query ?? ''}
-      onChange={onSearchChange}
-    />
+    <div className={styles.wrapper}>
+      <div className={styles.inputWrapper}>
+        <div className={styles.prefix}>
+          <Icon name="search" />
+        </div>
+
+        <button className={styles.fakeInput} onClick={onClick}>
+          {t('nav.search.placeholder', 'Search Grafana')}
+        </button>
+      </div>
+    </div>
   );
 }
+
+const getStyles = (theme: GrafanaTheme2) => {
+  const baseStyles = getInputStyles({ theme });
+
+  return {
+    wrapper: baseStyles.wrapper,
+    inputWrapper: baseStyles.inputWrapper,
+    prefix: baseStyles.prefix,
+    fakeInput: css([
+      baseStyles.input,
+      {
+        textAlign: 'left',
+        paddingLeft: 28,
+        color: theme.colors.text.disabled,
+
+        // We want the focus styles to appear only when tabbing through, not when clicking the button
+        // (and when focus is restored after command palette closes)
+        '&:focus': {
+          outline: 'unset',
+          boxShadow: 'unset',
+        },
+
+        '&:focus-visible': css`
+          ${focusCss(theme)}
+        `,
+      },
+    ]),
+
+    button: css({
+      // height: 32,
+      width: '100%',
+      textAlign: 'center',
+
+      '> *': {
+        width: '100%',
+        textAlign: 'center',
+        justifyContent: 'center',
+        gap: '1ch',
+      },
+    }),
+  };
+};


### PR DESCRIPTION
**What is this feature?**

Opens the command palette from the 'search box' in topnav.

As the trigger functions more like a button - clicking it performs an action, you cannot type into it - I've used the text input styles on a button.

From the mob session https://github.com/grafana/grafana/pull/61503

**Why do we need this feature?**

Because we believe that command palette is more suited for 'quick searches' from the always visible topnav.

**Who is this feature for?**

Everyone!
