### PR TITLE
Loki Query Builder: Fix bug parsing range params

### DIFF
--- a/public/app/plugins/datasource/loki/querybuilder/parsing.test.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.test.ts
@@ -661,6 +661,27 @@ describe('buildVisualQueryFromString', () => {
       })
     );
   });
+
+  it.each(['$__interval', '5m'])('parses query range with unwrap and regex', (range) => {
+    expect(
+      buildVisualQueryFromString(
+        'avg_over_time({test="value"} |= `restart counter is at` | regexp `restart counter is at (?P<restart_counter>[0-9]+)s*.*.*?$` | unwrap restart_counter [' +
+          range +
+          '])'
+      )
+    ).toEqual({
+      errors: [],
+      query: {
+        labels: [{ label: 'test', op: '=', value: 'value' }],
+        operations: [
+          { id: '__line_contains', params: ['restart counter is at'] },
+          { id: 'regexp', params: ['restart counter is at (?P<restart_counter>[0-9]+)s*.*.*?$'] },
+          { id: 'unwrap', params: ['restart_counter', ''] },
+          { id: 'avg_over_time', params: [range] },
+        ],
+      },
+    });
+  });
 });
 
 function noErrors(query: LokiVisualQuery) {

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.ts
@@ -413,10 +413,11 @@ function handleRangeAggregation(expr: string, node: SyntaxNode, context: Context
   const number = node.getChild(NumberLezer);
   const logExpr = node.getChild(LogRangeExpr);
   const params = number !== null && number !== undefined ? [getString(expr, number)] : [];
+  const range = logExpr?.getChild(Range);
+  const rangeValue = range ? getString(expr, range) : null;
 
-  let match = getString(expr, node).match(/\[(.+)\]/);
-  if (match?.[1]) {
-    params.unshift(match[1]);
+  if (rangeValue) {
+    params.unshift(rangeValue.substring(1, rangeValue.length - 1));
   }
 
   const op = {


### PR DESCRIPTION
We were using a regular expression to get the range parameters, which had a high chance of producing erronoeus or unexpected visual queries. We now use Lezer nodes, getting the actual value.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/58133

**Special notes for your reviewer**:

Test different metric queries. You should get the expected visual query from the code query.