### PR TITLE
Docs: Update index.md to not escape dollar sign

### DIFF
--- a/docs/sources/datasources/prometheus/template-variables/index.md
+++ b/docs/sources/datasources/prometheus/template-variables/index.md
@@ -99,7 +99,7 @@ For details, refer to the [Grafana blog](/blog/2020/09/28/new-in-grafana-7.2-__r
 
 The Prometheus data source supports two variable syntaxes for use in the **Query** field:
 
-- `$<varname>`, for example `rate(http_requests_total{job=~"\$job"}[$_rate_interval])`, which is easier to read and write but does not allow you to use a variable in the middle of a word.
+- `$<varname>`, for example `rate(http_requests_total{job=~"$job"}[$_rate_interval])`, which is easier to read and write but does not allow you to use a variable in the middle of a word.
 - `[[varname]]`, for example `rate(http_requests_total{job=~"[[job]]"}[$_rate_interval])`
 
 If you've enabled the _Multi-value_ or _Include all value_ options, Grafana converts the labels from plain text to a regex-compatible string, which requires you to use `=~` instead of `=`.


### PR DESCRIPTION
the backslash is useful in json files, but not where most users will see it

**What is this feature?**
fixes a docs bug: 
`{job=~"\$job"}`  
should be 
`{job=~"$job"}`

**Why do we need this feature?**
Current state is misleading and inconsistent with the rest of the page

**Who is this feature for?**
Users reading template variable docs

**Special notes for your reviewer**:
(none)
