### PR TITLE
Alerting: support basic auth for the state history loki client

### DIFF
--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -392,9 +392,10 @@ func configureHistorianBackend(cfg setting.UnifiedAlertingStateHistorySettings, 
 			return nil, fmt.Errorf("failed to parse remote loki URL: %w", err)
 		}
 		backend := historian.NewRemoteLokiBackend(historian.LokiConfig{
-			Url:            baseURL,
-			TenantID:       cfg.LokiTenantID,
-			TenantPassword: cfg.LokiPassword,
+			Url:               baseURL,
+			BasicAuthUser:     cfg.LokiBasicAuthUsername,
+			BasicAuthPassword: cfg.LokiBasicAuthPassword,
+			TenentID:          cfg.LokiTenantID,
 		})
 		if err := backend.TestConnection(); err != nil {
 			return nil, fmt.Errorf("failed to ping the remote loki historian: %w", err)

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -395,7 +395,7 @@ func configureHistorianBackend(cfg setting.UnifiedAlertingStateHistorySettings, 
 			Url:               baseURL,
 			BasicAuthUser:     cfg.LokiBasicAuthUsername,
 			BasicAuthPassword: cfg.LokiBasicAuthPassword,
-			TenentID:          cfg.LokiTenantID,
+			TenantID:          cfg.LokiTenantID,
 		})
 		if err := backend.TestConnection(); err != nil {
 			return nil, fmt.Errorf("failed to ping the remote loki historian: %w", err)

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -391,7 +391,11 @@ func configureHistorianBackend(cfg setting.UnifiedAlertingStateHistorySettings, 
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse remote loki URL: %w", err)
 		}
-		backend := historian.NewRemoteLokiBackend(baseURL)
+		backend := historian.NewRemoteLokiBackend(historian.LokiConfig{
+			Url:            baseURL,
+			TenantID:       cfg.LokiTenantID,
+			TenantPassword: cfg.LokiPassword,
+		})
 		if err := backend.TestConnection(); err != nil {
 			return nil, fmt.Errorf("failed to ping the remote loki historian: %w", err)
 		}

--- a/pkg/services/ngalert/state/historian/loki.go
+++ b/pkg/services/ngalert/state/historian/loki.go
@@ -2,7 +2,6 @@ package historian
 
 import (
 	"context"
-	"net/url"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
@@ -18,10 +17,10 @@ type RemoteLokiBackend struct {
 	log    log.Logger
 }
 
-func NewRemoteLokiBackend(url *url.URL) *RemoteLokiBackend {
+func NewRemoteLokiBackend(cfg LokiConfig) *RemoteLokiBackend {
 	logger := log.New("ngalert.state.historian", "backend", "loki")
 	return &RemoteLokiBackend{
-		client: newLokiClient(url, logger),
+		client: newLokiClient(cfg, logger),
 		log:    logger,
 	}
 }

--- a/pkg/services/ngalert/state/historian/loki_http.go
+++ b/pkg/services/ngalert/state/historian/loki_http.go
@@ -11,25 +11,36 @@ import (
 
 const defaultClientTimeout = 30 * time.Second
 
+type LokiConfig struct {
+	Url            *url.URL
+	TenantID       string
+	TenantPassword string
+}
+
 type httpLokiClient struct {
 	client http.Client
-	url    *url.URL
+	cfg    LokiConfig
 	log    log.Logger
 }
 
-func newLokiClient(u *url.URL, logger log.Logger) *httpLokiClient {
+func newLokiClient(cfg LokiConfig, logger log.Logger) *httpLokiClient {
 	return &httpLokiClient{
 		client: http.Client{
 			Timeout: defaultClientTimeout,
 		},
-		url: u,
+		cfg: cfg,
 		log: logger.New("protocol", "http"),
 	}
 }
 
 func (c *httpLokiClient) ping() error {
-	uri := c.url.JoinPath("/loki/api/v1/status/buildinfo")
+	uri := c.cfg.Url.JoinPath("/loki/api/v1/labels")
 	req, err := http.NewRequest(http.MethodGet, uri.String(), nil)
+
+	if c.cfg.TenantID != "" && c.cfg.TenantPassword != "" {
+		req.SetBasicAuth(c.cfg.TenantID, c.cfg.TenantPassword)
+	}
+
 	if err != nil {
 		return fmt.Errorf("error creating request: %w", err)
 	}
@@ -47,8 +58,8 @@ func (c *httpLokiClient) ping() error {
 	}
 
 	if res.StatusCode < 200 || res.StatusCode >= 300 {
-		return fmt.Errorf("request to the loki buildinfo endpoint returned a non-200 status code: %d", res.StatusCode)
+		return fmt.Errorf("ping request to loki endpoint returned a non-200 status code: %d", res.StatusCode)
 	}
-	c.log.Debug("Request to Loki buildinfo endpoint succeeded", "status", res.StatusCode)
+	c.log.Debug("Ping request to Loki endpoint succeeded", "status", res.StatusCode)
 	return nil
 }

--- a/pkg/services/ngalert/state/historian/loki_http.go
+++ b/pkg/services/ngalert/state/historian/loki_http.go
@@ -12,9 +12,10 @@ import (
 const defaultClientTimeout = 30 * time.Second
 
 type LokiConfig struct {
-	Url            *url.URL
-	TenantID       string
-	TenantPassword string
+	Url               *url.URL
+	BasicAuthUser     string
+	BasicAuthPassword string
+	TenentID          string
 }
 
 type httpLokiClient struct {
@@ -37,8 +38,12 @@ func (c *httpLokiClient) ping() error {
 	uri := c.cfg.Url.JoinPath("/loki/api/v1/labels")
 	req, err := http.NewRequest(http.MethodGet, uri.String(), nil)
 
-	if c.cfg.TenantID != "" && c.cfg.TenantPassword != "" {
-		req.SetBasicAuth(c.cfg.TenantID, c.cfg.TenantPassword)
+	if c.cfg.BasicAuthUser != "" || c.cfg.BasicAuthPassword != "" {
+		req.SetBasicAuth(c.cfg.BasicAuthUser, c.cfg.BasicAuthPassword)
+	}
+
+	if c.cfg.TenentID != "" {
+		req.Header.Add("X-Scope-OrgID", c.cfg.TenentID)
 	}
 
 	if err != nil {

--- a/pkg/services/ngalert/state/historian/loki_http.go
+++ b/pkg/services/ngalert/state/historian/loki_http.go
@@ -15,7 +15,7 @@ type LokiConfig struct {
 	Url               *url.URL
 	BasicAuthUser     string
 	BasicAuthPassword string
-	TenentID          string
+	TenantID          string
 }
 
 type httpLokiClient struct {
@@ -42,8 +42,8 @@ func (c *httpLokiClient) ping() error {
 		req.SetBasicAuth(c.cfg.BasicAuthUser, c.cfg.BasicAuthPassword)
 	}
 
-	if c.cfg.TenentID != "" {
-		req.Header.Add("X-Scope-OrgID", c.cfg.TenentID)
+	if c.cfg.TenantID != "" {
+		req.Header.Add("X-Scope-OrgID", c.cfg.TenantID)
 	}
 
 	if err != nil {

--- a/pkg/services/ngalert/state/historian/loki_http_test.go
+++ b/pkg/services/ngalert/state/historian/loki_http_test.go
@@ -28,7 +28,7 @@ func TestLokiHTTPClient(t *testing.T) {
 
 	// When running on prem, you might need to set the tenant id,
 	// so the x-scope-orgid header is set.
-	// client.cfg.TenentID = "<your_tenant_id>"
+	// client.cfg.TenantID = "<your_tenant_id>"
 
 	// Authorized request should fail against Grafana Cloud.
 	err = client.ping()

--- a/pkg/services/ngalert/state/historian/loki_http_test.go
+++ b/pkg/services/ngalert/state/historian/loki_http_test.go
@@ -23,8 +23,12 @@ func TestLokiHTTPClient(t *testing.T) {
 	err = client.ping()
 	require.Error(t, err)
 
-	client.cfg.TenantID = "<your_tenant_id>"
-	client.cfg.TenantPassword = "<your_password>"
+	client.cfg.BasicAuthUser = "<your_username>"
+	client.cfg.BasicAuthPassword = "<your_password>"
+
+	// When running on prem, you might need to set the tenant id,
+	// so the x-scope-orgid header is set.
+	// client.cfg.TenentID = "<your_tenant_id>"
 
 	// Authorized request should fail against Grafana Cloud.
 	err = client.ping()

--- a/pkg/services/ngalert/state/historian/loki_http_test.go
+++ b/pkg/services/ngalert/state/historian/loki_http_test.go
@@ -1,0 +1,33 @@
+package historian
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/stretchr/testify/require"
+)
+
+// This function can be used for local testing, just remove the skip call.
+func TestLokiHTTPClient(t *testing.T) {
+
+	t.Skip()
+
+	url, err := url.Parse("https://logs-prod-eu-west-0.grafana.net")
+	require.NoError(t, err)
+
+	client := newLokiClient(LokiConfig{
+		Url: url,
+	}, log.NewNopLogger())
+
+	// Unauthorized request should fail against Grafana Cloud.
+	err = client.ping()
+	require.Error(t, err)
+
+	client.cfg.TenantID = "<your_tenant_id>"
+	client.cfg.TenantPassword = "<your_password>"
+
+	// Authorized request should fail against Grafana Cloud.
+	err = client.ping()
+	require.NoError(t, err)
+}

--- a/pkg/services/ngalert/state/historian/loki_http_test.go
+++ b/pkg/services/ngalert/state/historian/loki_http_test.go
@@ -10,7 +10,6 @@ import (
 
 // This function can be used for local testing, just remove the skip call.
 func TestLokiHTTPClient(t *testing.T) {
-
 	t.Skip()
 
 	url, err := url.Parse("https://logs-prod-eu-west-0.grafana.net")

--- a/pkg/setting/setting_unified_alerting.go
+++ b/pkg/setting/setting_unified_alerting.go
@@ -104,6 +104,10 @@ type UnifiedAlertingStateHistorySettings struct {
 	Enabled       bool
 	Backend       string
 	LokiRemoteURL string
+	// LokiTenantID and LokiPassword are used for basic auth if both
+	// are set.
+	LokiTenantID string
+	LokiPassword string
 }
 
 // IsEnabled returns true if UnifiedAlertingSettings.Enabled is either nil or true.
@@ -317,6 +321,8 @@ func (cfg *Cfg) ReadUnifiedAlertingSettings(iniFile *ini.File) error {
 		Enabled:       stateHistory.Key("enabled").MustBool(stateHistoryDefaultEnabled),
 		Backend:       stateHistory.Key("backend").MustString("annotations"),
 		LokiRemoteURL: stateHistory.Key("loki_remote_url").MustString(""),
+		LokiTenantID:  stateHistory.Key("loki_tenant_id").MustString(""),
+		LokiPassword:  stateHistory.Key("loki_password").MustString(""),
 	}
 	uaCfg.StateHistory = uaCfgStateHistory
 

--- a/pkg/setting/setting_unified_alerting.go
+++ b/pkg/setting/setting_unified_alerting.go
@@ -104,10 +104,11 @@ type UnifiedAlertingStateHistorySettings struct {
 	Enabled       bool
 	Backend       string
 	LokiRemoteURL string
-	// LokiTenantID and LokiPassword are used for basic auth if both
-	// are set.
-	LokiTenantID string
-	LokiPassword string
+	LokiTenantID  string
+	// LokiBasicAuthUsername and LokiBasicAuthPassword are used for basic auth
+	// if one of them is set.
+	LokiBasicAuthPassword string
+	LokiBasicAuthUsername string
 }
 
 // IsEnabled returns true if UnifiedAlertingSettings.Enabled is either nil or true.
@@ -318,11 +319,12 @@ func (cfg *Cfg) ReadUnifiedAlertingSettings(iniFile *ini.File) error {
 
 	stateHistory := iniFile.Section("unified_alerting.state_history")
 	uaCfgStateHistory := UnifiedAlertingStateHistorySettings{
-		Enabled:       stateHistory.Key("enabled").MustBool(stateHistoryDefaultEnabled),
-		Backend:       stateHistory.Key("backend").MustString("annotations"),
-		LokiRemoteURL: stateHistory.Key("loki_remote_url").MustString(""),
-		LokiTenantID:  stateHistory.Key("loki_tenant_id").MustString(""),
-		LokiPassword:  stateHistory.Key("loki_password").MustString(""),
+		Enabled:               stateHistory.Key("enabled").MustBool(stateHistoryDefaultEnabled),
+		Backend:               stateHistory.Key("backend").MustString("annotations"),
+		LokiRemoteURL:         stateHistory.Key("loki_remote_url").MustString(""),
+		LokiTenantID:          stateHistory.Key("loki_tenant_id").MustString(""),
+		LokiBasicAuthUsername: stateHistory.Key("loki_basic_auth_username").MustString(""),
+		LokiBasicAuthPassword: stateHistory.Key("loki_basic_auth_password").MustString(""),
 	}
 	uaCfg.StateHistory = uaCfgStateHistory
 


### PR DESCRIPTION
This PR adds support for basic auth in the new Loki client used by the alert state history so that we can use it for Loki instances that have auth setup, i.e. Grafana Cloud.