### PR TITLE
AuthN: Rebuild Authenticate so we only have to call it once in context handler

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -670,7 +670,7 @@ func (hs *HTTPServer) registerRoutes() {
 		adminRoute.Post("/ldap/sync/:id", authorize(reqGrafanaAdmin, ac.EvalPermission(ac.ActionLDAPUsersSync)), routing.Wrap(hs.PostSyncUserWithLDAP))
 		adminRoute.Get("/ldap/:username", authorize(reqGrafanaAdmin, ac.EvalPermission(ac.ActionLDAPUsersRead)), routing.Wrap(hs.GetUserFromLDAP))
 		adminRoute.Get("/ldap/status", authorize(reqGrafanaAdmin, ac.EvalPermission(ac.ActionLDAPStatusRead)), routing.Wrap(hs.GetLDAPStatus))
-	})
+	}, reqSignedIn)
 
 	// Administering users
 	r.Group("/api/admin/users", func(adminUserRoute routing.RouteRegister) {
@@ -688,7 +688,7 @@ func (hs *HTTPServer) registerRoutes() {
 		adminUserRoute.Post("/:id/logout", authorize(reqGrafanaAdmin, ac.EvalPermission(ac.ActionUsersLogout, userIDScope)), routing.Wrap(hs.AdminLogoutUser))
 		adminUserRoute.Get("/:id/auth-tokens", authorize(reqGrafanaAdmin, ac.EvalPermission(ac.ActionUsersAuthTokenList, userIDScope)), routing.Wrap(hs.AdminGetUserAuthTokens))
 		adminUserRoute.Post("/:id/revoke-auth-token", authorize(reqGrafanaAdmin, ac.EvalPermission(ac.ActionUsersAuthTokenUpdate, userIDScope)), routing.Wrap(hs.AdminRevokeUserAuthToken))
-	})
+	}, reqSignedIn)
 
 	// rendering
 	r.Get("/render/*", reqSignedIn, hs.RenderToPng)

--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"errors"
+	"net/http"
 	"net/url"
 	"regexp"
 	"strconv"
@@ -17,7 +18,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/team"
 	"github.com/grafana/grafana/pkg/setting"
-	"github.com/grafana/grafana/pkg/util/errutil"
 	"github.com/grafana/grafana/pkg/web"
 )
 
@@ -38,13 +38,7 @@ func accessForbidden(c *models.ReqContext) {
 
 func notAuthorized(c *models.ReqContext) {
 	if c.IsApiRequest() {
-		// FIXME: add function to handle this on req context
-		grfErr := &errutil.Error{}
-		if errors.As(c.LookupTokenErr, grfErr) {
-			c.JsonApiErr(grfErr.Reason.Status().HTTPStatus(), grfErr.Public().Message, grfErr)
-			return
-		}
-		c.JsonApiErr(401, "Unauthorized", c.LookupTokenErr)
+		c.WriteErrOrFallback(http.StatusUnauthorized, http.StatusText(http.StatusUnauthorized), c.LookupTokenErr)
 		return
 	}
 

--- a/pkg/services/authn/authn.go
+++ b/pkg/services/authn/authn.go
@@ -52,8 +52,8 @@ type PostAuthHookFn func(ctx context.Context, identity *Identity, r *Request) er
 type PostLoginHookFn func(ctx context.Context, identity *Identity, r *Request, err error)
 
 type Service interface {
-	// Authenticate authenticates a request using the specified client.
-	Authenticate(ctx context.Context, client string, r *Request) (*Identity, bool, error)
+	// Authenticate authenticates a request
+	Authenticate(ctx context.Context, r *Request) (*Identity, error)
 	// RegisterPostAuthHook registers a hook that is called after a successful authentication.
 	RegisterPostAuthHook(hook PostAuthHookFn)
 	// Login authenticates a request and creates a session on successful authentication.
@@ -67,6 +67,11 @@ type Service interface {
 type Client interface {
 	// Authenticate performs the authentication for the request
 	Authenticate(ctx context.Context, r *Request) (*Identity, error)
+}
+
+// FIXME: better name / description
+type ContextAwareClient interface {
+	Client
 	// Test should return true if client can be used to authenticate request
 	Test(ctx context.Context, r *Request) bool
 }

--- a/pkg/services/authn/authn.go
+++ b/pkg/services/authn/authn.go
@@ -71,11 +71,11 @@ type Client interface {
 	Authenticate(ctx context.Context, r *Request) (*Identity, error)
 }
 
-// FIXME: better name / description
 type ContextAwareClient interface {
 	Client
 	// Test should return true if client can be used to authenticate request
 	Test(ctx context.Context, r *Request) bool
+	// Priority for the client, a lower number means higher priority
 	Priority() uint
 }
 

--- a/pkg/services/authn/authn.go
+++ b/pkg/services/authn/authn.go
@@ -137,6 +137,8 @@ type Identity struct {
 	// Namespace* constants. For example, "user:1" or "api-key:1".
 	// If the entity is not found in the DB or this entity is non-persistent, this field will be empty.
 	ID string
+	// IsAnonymous
+	IsAnonymous bool
 	// Login is the short hand identifier of the entity. Should be unique.
 	Login string
 	// Name is the display name of the entity. It is not guaranteed to be unique.
@@ -174,11 +176,6 @@ type Identity struct {
 // Role returns the role of the identity in the active organization.
 func (i *Identity) Role() org.RoleType {
 	return i.OrgRoles[i.OrgID]
-}
-
-// IsAnonymous will return true if no ID is set on the identity
-func (i *Identity) IsAnonymous() bool {
-	return i.ID == ""
 }
 
 // TODO: improve error handling
@@ -227,7 +224,7 @@ func (i *Identity) SignedInUser() *user.SignedInUser {
 		Email:              i.Email,
 		OrgCount:           i.OrgCount,
 		IsGrafanaAdmin:     isGrafanaAdmin,
-		IsAnonymous:        i.IsAnonymous(),
+		IsAnonymous:        i.IsAnonymous,
 		IsDisabled:         i.IsDisabled,
 		HelpFlags1:         i.HelpFlags1,
 		LastSeenAt:         i.LastSeenAt,

--- a/pkg/services/authn/authn.go
+++ b/pkg/services/authn/authn.go
@@ -65,6 +65,8 @@ type Service interface {
 }
 
 type Client interface {
+	// Name returns the name of a client
+	Name() string
 	// Authenticate performs the authentication for the request
 	Authenticate(ctx context.Context, r *Request) (*Identity, error)
 }

--- a/pkg/services/authn/authn.go
+++ b/pkg/services/authn/authn.go
@@ -74,6 +74,7 @@ type ContextAwareClient interface {
 	Client
 	// Test should return true if client can be used to authenticate request
 	Test(ctx context.Context, r *Request) bool
+	Priority() uint
 }
 
 type RedirectClient interface {

--- a/pkg/services/authn/authnimpl/priority_queue.go
+++ b/pkg/services/authn/authnimpl/priority_queue.go
@@ -13,20 +13,21 @@ type queue struct {
 }
 
 func (q *queue) insert(c authn.ContextAwareClient) {
+	// no clients in the queue so we just add it
 	if len(q.clients) == 0 {
 		q.clients = append(q.clients, c)
+		return
 	}
 
+	// find the position in the queue the client should be placed based on priority
 	for i, client := range q.clients {
-		if len(q.clients) == i {
-			q.clients = append(q.clients, client)
-			break
-		}
-
 		if c.Priority() < client.Priority() {
 			q.clients = append(q.clients[:i+1], q.clients[i:]...)
 			q.clients[i] = c
-			break
+			return
 		}
 	}
+
+	// client did not have higher priority then what is in the queue currently, so we need to add it to the end
+	q.clients = append(q.clients, c)
 }

--- a/pkg/services/authn/authnimpl/priority_queue.go
+++ b/pkg/services/authn/authnimpl/priority_queue.go
@@ -1,0 +1,32 @@
+package authnimpl
+
+import (
+	"github.com/grafana/grafana/pkg/services/authn"
+)
+
+func newQueue() *queue {
+	return &queue{clients: []authn.ContextAwareClient{}}
+}
+
+type queue struct {
+	clients []authn.ContextAwareClient
+}
+
+func (q *queue) insert(c authn.ContextAwareClient) {
+	if len(q.clients) == 0 {
+		q.clients = append(q.clients, c)
+	}
+
+	for i, client := range q.clients {
+		if len(q.clients) == i {
+			q.clients = append(q.clients, client)
+			break
+		}
+
+		if c.Priority() < client.Priority() {
+			q.clients = append(q.clients[:i+1], q.clients[i:]...)
+			q.clients[i] = c
+			break
+		}
+	}
+}

--- a/pkg/services/authn/authnimpl/priority_queue.go
+++ b/pkg/services/authn/authnimpl/priority_queue.go
@@ -4,7 +4,7 @@ type priority interface {
 	Priority() uint
 }
 
-func newQueue[T priority]() *queue[T] {
+func newQueue[T any]() *queue[T] {
 	return &queue[T]{items: []T{}}
 }
 

--- a/pkg/services/authn/authnimpl/priority_queue.go
+++ b/pkg/services/authn/authnimpl/priority_queue.go
@@ -18,13 +18,13 @@ type queueItem[T any] struct {
 }
 
 func (q *queue[T]) insert(v T, p uint) {
-	// no clients in the queue so we just add it
+	// no items in the queue so we just add it
 	if len(q.items) == 0 {
 		q.items = append(q.items, queueItem[T]{v, p})
 		return
 	}
 
-	// find the position in the queue the client should be placed based on priority
+	// find the position in the queue the item should be placed based on priority
 	for i, item := range q.items {
 		if p < item.p {
 			q.items = append(q.items[:i+1], q.items[i:]...)
@@ -33,6 +33,6 @@ func (q *queue[T]) insert(v T, p uint) {
 		}
 	}
 
-	// client did not have higher priority then what is in the queue currently, so we need to add it to the end
+	// item did not have higher priority then what is in the queue currently, so we need to add it to the end
 	q.items = append(q.items, queueItem[T]{v, p})
 }

--- a/pkg/services/authn/authnimpl/priority_queue.go
+++ b/pkg/services/authn/authnimpl/priority_queue.go
@@ -12,7 +12,7 @@ type queue[T priority] struct {
 	items []T
 }
 
-func (q *queue[T]) insert(c T) {
+func (q *queue[T]) insert(c T, priority int) {
 	// no clients in the queue so we just add it
 	if len(q.items) == 0 {
 		q.items = append(q.items, c)

--- a/pkg/services/authn/authnimpl/priority_queue.go
+++ b/pkg/services/authn/authnimpl/priority_queue.go
@@ -1,9 +1,5 @@
 package authnimpl
 
-type priority interface {
-	Priority() uint
-}
-
 func newQueue[T any]() *queue[T] {
 	return &queue[T]{items: []queueItem[T]{}}
 }

--- a/pkg/services/authn/authnimpl/priority_queue.go
+++ b/pkg/services/authn/authnimpl/priority_queue.go
@@ -8,7 +8,6 @@ func newQueue[T priority]() *queue[T] {
 	return &queue[T]{items: []T{}}
 }
 
-
 type queue[T priority] struct {
 	items []T
 }
@@ -21,9 +20,9 @@ func (q *queue[T]) insert(c T) {
 	}
 
 	// find the position in the queue the client should be placed based on priority
-	for i, client := range q.items{
+	for i, client := range q.items {
 		if c.Priority() < client.Priority() {
-			q.items= append(q.items[:i+1], q.items[i:]...)
+			q.items = append(q.items[:i+1], q.items[i:]...)
 			q.items[i] = c
 			return
 		}

--- a/pkg/services/authn/authnimpl/priority_queue.go
+++ b/pkg/services/authn/authnimpl/priority_queue.go
@@ -5,29 +5,34 @@ type priority interface {
 }
 
 func newQueue[T any]() *queue[T] {
-	return &queue[T]{items: []T{}}
+	return &queue[T]{items: []queueItem[T]{}}
 }
 
-type queue[T priority] struct {
-	items []T
+type queue[T any] struct {
+	items []queueItem[T]
 }
 
-func (q *queue[T]) insert(c T, priority int) {
+type queueItem[T any] struct {
+	v T
+	p uint
+}
+
+func (q *queue[T]) insert(v T, p uint) {
 	// no clients in the queue so we just add it
 	if len(q.items) == 0 {
-		q.items = append(q.items, c)
+		q.items = append(q.items, queueItem[T]{v, p})
 		return
 	}
 
 	// find the position in the queue the client should be placed based on priority
-	for i, client := range q.items {
-		if c.Priority() < client.Priority() {
+	for i, item := range q.items {
+		if p < item.p {
 			q.items = append(q.items[:i+1], q.items[i:]...)
-			q.items[i] = c
+			q.items[i] = queueItem[T]{v, p}
 			return
 		}
 	}
 
 	// client did not have higher priority then what is in the queue currently, so we need to add it to the end
-	q.items = append(q.items, c)
+	q.items = append(q.items, queueItem[T]{v, p})
 }

--- a/pkg/services/authn/authnimpl/priority_queue_test.go
+++ b/pkg/services/authn/authnimpl/priority_queue_test.go
@@ -1,0 +1,5 @@
+package main
+
+func main() {
+
+}

--- a/pkg/services/authn/authnimpl/priority_queue_test.go
+++ b/pkg/services/authn/authnimpl/priority_queue_test.go
@@ -1,5 +1,46 @@
-package main
+package authnimpl
 
-func main() {
+import (
+	"reflect"
+	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/services/authn/clients"
+)
+
+func TestQueue(t *testing.T) {
+	q := newQueue()
+
+	anonymous := &clients.Anonymous{}
+	q.insert(anonymous)
+	session := &clients.Session{}
+	q.insert(session)
+	proxy := &clients.Proxy{}
+	q.insert(proxy)
+	render := &clients.Render{}
+	q.insert(render)
+	basic := &clients.Basic{}
+	q.insert(basic)
+	jwt := &clients.JWT{}
+	q.insert(jwt)
+
+	expectedOrder := []string{
+		structName(render),
+		structName(jwt),
+		structName(basic),
+		structName(proxy),
+		structName(session),
+		structName(anonymous),
+	}
+
+	require.Len(t, q.clients, len(expectedOrder))
+	for i := range q.clients {
+		assert.Equal(t, structName(q.clients[i]), expectedOrder[i])
+	}
+}
+
+func structName(s any) string {
+	return reflect.TypeOf(s).Elem().Name()
 }

--- a/pkg/services/authn/authnimpl/priority_queue_test.go
+++ b/pkg/services/authn/authnimpl/priority_queue_test.go
@@ -1,9 +1,9 @@
 package authnimpl
 
 import (
-	"reflect"
 	"testing"
 
+	"github.com/grafana/grafana/pkg/services/authn"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -27,20 +27,16 @@ func TestQueue(t *testing.T) {
 	q.insert(jwt)
 
 	expectedOrder := []string{
-		structName(render),
-		structName(jwt),
-		structName(basic),
-		structName(proxy),
-		structName(session),
-		structName(anonymous),
+		authn.ClientRender,
+		authn.ClientJWT,
+		authn.ClientBasic,
+		authn.ClientProxy,
+		authn.ClientSession,
+		authn.ClientAnonymous,
 	}
 
 	require.Len(t, q.clients, len(expectedOrder))
 	for i := range q.clients {
-		assert.Equal(t, structName(q.clients[i]), expectedOrder[i])
+		assert.Equal(t, q.clients[i].Name(), expectedOrder[i])
 	}
-}
-
-func structName(s any) string {
-	return reflect.TypeOf(s).Elem().Name()
 }

--- a/pkg/services/authn/authnimpl/priority_queue_test.go
+++ b/pkg/services/authn/authnimpl/priority_queue_test.go
@@ -3,15 +3,15 @@ package authnimpl
 import (
 	"testing"
 
-	"github.com/grafana/grafana/pkg/services/authn"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/grafana/pkg/services/authn"
 	"github.com/grafana/grafana/pkg/services/authn/clients"
 )
 
 func TestQueue(t *testing.T) {
-	q := newQueue()
+	q := newQueue[authn.ContextAwareClient]()
 
 	anonymous := &clients.Anonymous{}
 	q.insert(anonymous)
@@ -35,8 +35,8 @@ func TestQueue(t *testing.T) {
 		authn.ClientAnonymous,
 	}
 
-	require.Len(t, q.clients, len(expectedOrder))
-	for i := range q.clients {
-		assert.Equal(t, q.clients[i].Name(), expectedOrder[i])
+	require.Len(t, q.items, len(expectedOrder))
+	for i := range q.items {
+		assert.Equal(t, q.items[i].Name(), expectedOrder[i])
 	}
 }

--- a/pkg/services/authn/authnimpl/priority_queue_test.go
+++ b/pkg/services/authn/authnimpl/priority_queue_test.go
@@ -19,7 +19,7 @@ func TestQueue(t *testing.T) {
 
 	tests := []testCase{
 		{
-			desc: "",
+			desc: "expect correct order",
 			clients: []authn.ContextAwareClient{
 				&authntest.FakeClient{ExpectedName: "1", ExpectedPriority: 1},
 				&authntest.FakeClient{ExpectedName: "5", ExpectedPriority: 5},
@@ -35,13 +35,13 @@ func TestQueue(t *testing.T) {
 		t.Run(tt.desc, func(t *testing.T) {
 			q := newQueue[authn.ContextAwareClient]()
 			for _, c := range tt.clients {
-				q.insert(c)
+				q.insert(c, c.Priority())
 			}
 
 			require.Len(t, q.items, len(tt.expectedOrder))
 
 			for i := range q.items {
-				assert.Equal(t, q.items[i].Name(), tt.expectedOrder[i])
+				assert.Equal(t, q.items[i].v.Name(), tt.expectedOrder[i])
 			}
 		})
 	}

--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -151,11 +151,11 @@ func (s *Service) Authenticate(ctx context.Context, r *authn.Request) (*authn.Id
 	defer span.End()
 
 	var authErr error
-	for _, c := range s.clientQueue.items {
-		if c.Test(ctx, r) {
-			identity, err := s.authenticate(ctx, c, r)
+	for _, item := range s.clientQueue.items {
+		if item.v.Test(ctx, r) {
+			identity, err := s.authenticate(ctx, item.v, r)
 			if err != nil {
-				s.log.Warn("failed to authenticate", "client", c.Name(), "err", err)
+				s.log.Warn("failed to authenticate", "client", item.v.Name(), "err", err)
 				authErr = multierror.Append(authErr, err)
 				// try next
 				continue
@@ -264,7 +264,7 @@ func (s *Service) RedirectURL(ctx context.Context, client string, r *authn.Reque
 func (s *Service) RegisterClient(c authn.Client) {
 	s.clients[c.Name()] = c
 	if cac, ok := c.(authn.ContextAwareClient); ok {
-		s.clientQueue.insert(cac)
+		s.clientQueue.insert(cac, cac.Priority())
 	}
 }
 

--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -55,8 +55,8 @@ func ProvideService(
 	s := &Service{
 		log:            log.New("authn.service"),
 		cfg:            cfg,
-		queue:          newQueue(),
 		clients:        make(map[string]authn.Client),
+		clientQueue:    newQueue[authn.ContextAwareClient](),
 		tracer:         tracer,
 		sessionService: sessionService,
 		postAuthHooks:  []authn.PostAuthHookFn{},
@@ -133,8 +133,8 @@ type Service struct {
 	log log.Logger
 	cfg *setting.Cfg
 
-	queue   *queue
-	clients map[string]authn.Client
+	clients     map[string]authn.Client
+	clientQueue *queue[authn.ContextAwareClient]
 
 	tracer         tracing.Tracer
 	sessionService auth.UserTokenService
@@ -150,7 +150,7 @@ func (s *Service) Authenticate(ctx context.Context, r *authn.Request) (*authn.Id
 	defer span.End()
 
 	var latestErr error
-	for _, c := range s.queue.clients {
+	for _, c := range s.clientQueue.items {
 		if c.Test(ctx, r) {
 			identity, err := s.authenticate(ctx, c, r)
 			if err != nil {
@@ -263,7 +263,7 @@ func (s *Service) RedirectURL(ctx context.Context, client string, r *authn.Reque
 func (s *Service) RegisterClient(c authn.Client) {
 	s.clients[c.Name()] = c
 	if cac, ok := c.(authn.ContextAwareClient); ok {
-		s.queue.insert(cac)
+		s.clientQueue.insert(cac)
 	}
 }
 

--- a/pkg/services/authn/authnimpl/service_test.go
+++ b/pkg/services/authn/authnimpl/service_test.go
@@ -24,7 +24,6 @@ func TestService_Authenticate(t *testing.T) {
 	type TestCase struct {
 		desc             string
 		clients          []authn.Client
-		clientErr        error
 		expectedIdentity *authn.Identity
 		expectedErr      error
 	}

--- a/pkg/services/authn/authnimpl/service_test.go
+++ b/pkg/services/authn/authnimpl/service_test.go
@@ -269,10 +269,8 @@ func TestService_RedirectURL(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			service := setupTests(t, func(svc *Service) {
-				svc.clients["redirect"] = authntest.FakeRedirectClient{
-					ExpectedURL: tt.expectedURL,
-				}
-				svc.clients["non-redirect"] = &authntest.FakeClient{}
+				svc.RegisterClient(authntest.FakeRedirectClient{ExpectedName: "redirect", ExpectedURL: tt.expectedURL})
+				svc.RegisterClient(&authntest.FakeClient{ExpectedName: "non-redirect"})
 			})
 
 			u, err := service.RedirectURL(context.Background(), tt.client, nil)

--- a/pkg/services/authn/authnimpl/service_test.go
+++ b/pkg/services/authn/authnimpl/service_test.go
@@ -288,11 +288,11 @@ func setupTests(t *testing.T, opts ...func(svc *Service)) *Service {
 	t.Helper()
 
 	s := &Service{
-		log:     log.NewNopLogger(),
-		cfg:     setting.NewCfg(),
-		queue:   newQueue(),
-		clients: map[string]authn.Client{},
-		tracer:  tracing.InitializeTracerForTest(),
+		log:         log.NewNopLogger(),
+		cfg:         setting.NewCfg(),
+		clientQueue: newQueue[authn.ContextAwareClient](),
+		clients:     map[string]authn.Client{},
+		tracer:      tracing.InitializeTracerForTest(),
 	}
 
 	for _, o := range opts {

--- a/pkg/services/authn/authntest/fake.go
+++ b/pkg/services/authn/authntest/fake.go
@@ -10,12 +10,18 @@ type FakeService struct {
 	authn.Service
 }
 
-var _ authn.Client = new(FakeClient)
+var _ authn.ContextAwareClient = new(FakeClient)
 
 type FakeClient struct {
+	ExpectedName     string
 	ExpectedErr      error
 	ExpectedTest     bool
+	ExpectedPriority uint
 	ExpectedIdentity *authn.Identity
+}
+
+func (f *FakeClient) Name() string {
+	return f.ExpectedName
 }
 
 func (f *FakeClient) Authenticate(ctx context.Context, r *authn.Request) (*authn.Identity, error) {
@@ -24,6 +30,10 @@ func (f *FakeClient) Authenticate(ctx context.Context, r *authn.Request) (*authn
 
 func (f *FakeClient) Test(ctx context.Context, r *authn.Request) bool {
 	return f.ExpectedTest
+}
+
+func (f *FakeClient) Priority() uint {
+	return f.ExpectedPriority
 }
 
 var _ authn.PasswordClient = new(FakePasswordClient)

--- a/pkg/services/authn/authntest/fake.go
+++ b/pkg/services/authn/authntest/fake.go
@@ -52,16 +52,16 @@ var _ authn.RedirectClient = new(FakeRedirectClient)
 type FakeRedirectClient struct {
 	ExpectedErr      error
 	ExpectedURL      string
-	ExpectedOK       bool
+	ExpectedName     string
 	ExpectedIdentity *authn.Identity
+}
+
+func (f FakeRedirectClient) Name() string {
+	return f.ExpectedName
 }
 
 func (f FakeRedirectClient) Authenticate(ctx context.Context, r *authn.Request) (*authn.Identity, error) {
 	return f.ExpectedIdentity, f.ExpectedErr
-}
-
-func (f FakeRedirectClient) Test(ctx context.Context, r *authn.Request) bool {
-	return f.ExpectedOK
 }
 
 func (f FakeRedirectClient) RedirectURL(ctx context.Context, r *authn.Request) (string, error) {

--- a/pkg/services/authn/authntest/mock.go
+++ b/pkg/services/authn/authntest/mock.go
@@ -6,11 +6,20 @@ import (
 	"github.com/grafana/grafana/pkg/services/authn"
 )
 
-var _ authn.Client = new(MockClient)
+var _ authn.ContextAwareClient = new(MockClient)
 
 type MockClient struct {
+	NameFunc         func() string
 	AuthenticateFunc func(ctx context.Context, r *authn.Request) (*authn.Identity, error)
 	TestFunc         func(ctx context.Context, r *authn.Request) bool
+	PriorityFunc     func() uint
+}
+
+func (m MockClient) Name() string {
+	if m.NameFunc != nil {
+		return m.NameFunc()
+	}
+	return ""
 }
 
 func (m MockClient) Authenticate(ctx context.Context, r *authn.Request) (*authn.Identity, error) {
@@ -25,6 +34,13 @@ func (m MockClient) Test(ctx context.Context, r *authn.Request) bool {
 		return m.TestFunc(ctx, r)
 	}
 	return false
+}
+
+func (m MockClient) Priority() uint {
+	if m.PriorityFunc != nil {
+		return m.PriorityFunc()
+	}
+	return 0
 }
 
 var _ authn.ProxyClient = new(MockProxyClient)

--- a/pkg/services/authn/clients/anonymous.go
+++ b/pkg/services/authn/clients/anonymous.go
@@ -9,7 +9,7 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 )
 
-var _ authn.Client = new(Anonymous)
+var _ authn.ContextAwareClient = new(Anonymous)
 
 func ProvideAnonymous(cfg *setting.Cfg, orgService org.Service) *Anonymous {
 	return &Anonymous{
@@ -44,4 +44,8 @@ func (a *Anonymous) Authenticate(ctx context.Context, r *authn.Request) (*authn.
 func (a *Anonymous) Test(ctx context.Context, r *authn.Request) bool {
 	// If anonymous client is register it can always be used for authentication
 	return true
+}
+
+func (a *Anonymous) Priority() uint {
+	return 100
 }

--- a/pkg/services/authn/clients/anonymous.go
+++ b/pkg/services/authn/clients/anonymous.go
@@ -33,6 +33,7 @@ func (a *Anonymous) Authenticate(ctx context.Context, r *authn.Request) (*authn.
 	}
 
 	return &authn.Identity{
+		IsAnonymous:  true,
 		OrgID:        o.ID,
 		OrgName:      o.Name,
 		OrgRoles:     map[int64]org.RoleType{o.ID: org.RoleType(a.cfg.AnonymousOrgRole)},

--- a/pkg/services/authn/clients/anonymous.go
+++ b/pkg/services/authn/clients/anonymous.go
@@ -25,6 +25,10 @@ type Anonymous struct {
 	orgService org.Service
 }
 
+func (a *Anonymous) Name() string {
+	return authn.ClientAnonymous
+}
+
 func (a *Anonymous) Authenticate(ctx context.Context, r *authn.Request) (*authn.Identity, error) {
 	o, err := a.orgService.GetByName(ctx, &org.GetOrgByNameQuery{Name: a.cfg.AnonymousOrgName})
 	if err != nil {

--- a/pkg/services/authn/clients/api_key.go
+++ b/pkg/services/authn/clients/api_key.go
@@ -23,7 +23,7 @@ var (
 	errAPIKeyRevoked = errutil.NewBase(errutil.StatusUnauthorized, "api-key.revoked", errutil.WithPublicMessage("Revoked API key"))
 )
 
-var _ authn.Client = new(APIKey)
+var _ authn.ContextAwareClient = new(APIKey)
 
 func ProvideAPIKey(apiKeyService apikey.Service, userService user.Service) *APIKey {
 	return &APIKey{
@@ -131,6 +131,10 @@ func (s *APIKey) getFromTokenLegacy(ctx context.Context, token string) (*apikey.
 
 func (s *APIKey) Test(ctx context.Context, r *authn.Request) bool {
 	return looksLikeApiKey(getTokenFromRequest(r))
+}
+
+func (s *APIKey) Priority() uint {
+	return 30
 }
 
 func looksLikeApiKey(token string) bool {

--- a/pkg/services/authn/clients/api_key.go
+++ b/pkg/services/authn/clients/api_key.go
@@ -39,6 +39,10 @@ type APIKey struct {
 	apiKeyService apikey.Service
 }
 
+func (s *APIKey) Name() string {
+	return authn.ClientAPIKey
+}
+
 func (s *APIKey) Authenticate(ctx context.Context, r *authn.Request) (*authn.Identity, error) {
 	apiKey, err := s.getAPIKey(ctx, getTokenFromRequest(r))
 	if err != nil {

--- a/pkg/services/authn/clients/basic.go
+++ b/pkg/services/authn/clients/basic.go
@@ -13,7 +13,7 @@ var (
 	errDecodingBasicAuthHeader = errutil.NewBase(errutil.StatusBadRequest, "basic-auth.invalid-header", errutil.WithPublicMessage("Invalid Basic Auth Header"))
 )
 
-var _ authn.Client = new(Basic)
+var _ authn.ContextAwareClient = new(Basic)
 
 func ProvideBasic(client authn.PasswordClient) *Basic {
 	return &Basic{client}
@@ -34,6 +34,10 @@ func (c *Basic) Authenticate(ctx context.Context, r *authn.Request) (*authn.Iden
 
 func (c *Basic) Test(ctx context.Context, r *authn.Request) bool {
 	return looksLikeBasicAuthRequest(r)
+}
+
+func (c *Basic) Priority() uint {
+	return 40
 }
 
 func looksLikeBasicAuthRequest(r *authn.Request) bool {

--- a/pkg/services/authn/clients/basic.go
+++ b/pkg/services/authn/clients/basic.go
@@ -23,6 +23,10 @@ type Basic struct {
 	client authn.PasswordClient
 }
 
+func (c *Basic) Name() string {
+	return authn.ClientBasic
+}
+
 func (c *Basic) Authenticate(ctx context.Context, r *authn.Request) (*authn.Identity, error) {
 	username, password, err := util.DecodeBasicAuthHeader(getBasicAuthHeaderFromRequest(r))
 	if err != nil {

--- a/pkg/services/authn/clients/form.go
+++ b/pkg/services/authn/clients/form.go
@@ -34,9 +34,3 @@ func (f *Form) Authenticate(ctx context.Context, r *authn.Request) (*authn.Ident
 	}
 	return f.client.AuthenticatePassword(ctx, r, form.Username, form.Password)
 }
-
-func (f *Form) Test(ctx context.Context, r *authn.Request) bool {
-	// FIXME: How should we detect this??
-	// Maybe create client test interface and not all clients has to implement this??
-	return true
-}

--- a/pkg/services/authn/clients/form.go
+++ b/pkg/services/authn/clients/form.go
@@ -27,10 +27,14 @@ type loginForm struct {
 	Password string `json:"password" binding:"Required"`
 }
 
-func (f *Form) Authenticate(ctx context.Context, r *authn.Request) (*authn.Identity, error) {
+func (c *Form) Name() string {
+	return authn.ClientForm
+}
+
+func (c *Form) Authenticate(ctx context.Context, r *authn.Request) (*authn.Identity, error) {
 	form := loginForm{}
 	if err := web.Bind(r.HTTPRequest, &form); err != nil {
 		return nil, errBadForm.Errorf("failed to parse request: %w", err)
 	}
-	return f.client.AuthenticatePassword(ctx, r, form.Username, form.Password)
+	return c.client.AuthenticatePassword(ctx, r, form.Username, form.Password)
 }

--- a/pkg/services/authn/clients/jwt.go
+++ b/pkg/services/authn/clients/jwt.go
@@ -45,6 +45,10 @@ type JWT struct {
 	jwtService auth.JWTVerifierService
 }
 
+func (s *JWT) Name() string {
+	return authn.ClientJWT
+}
+
 func (s *JWT) Authenticate(ctx context.Context, r *authn.Request) (*authn.Identity, error) {
 	jwtToken := s.retrieveToken(r.HTTPRequest)
 

--- a/pkg/services/authn/clients/jwt.go
+++ b/pkg/services/authn/clients/jwt.go
@@ -20,7 +20,7 @@ import (
 	"github.com/grafana/grafana/pkg/util/errutil"
 )
 
-var _ authn.Client = new(JWT)
+var _ authn.ContextAwareClient = new(JWT)
 
 var (
 	ErrJWTInvalid = errutil.NewBase(errutil.StatusUnauthorized,
@@ -155,6 +155,10 @@ func (s *JWT) Test(ctx context.Context, r *authn.Request) bool {
 	}
 
 	return true
+}
+
+func (s *JWT) Priority() uint {
+	return 20
 }
 
 const roleGrafanaAdmin = "GrafanaAdmin"

--- a/pkg/services/authn/clients/proxy.go
+++ b/pkg/services/authn/clients/proxy.go
@@ -45,6 +45,10 @@ type Proxy struct {
 	acceptedIPs []*net.IPNet
 }
 
+func (c *Proxy) Name() string {
+	return authn.ClientProxy
+}
+
 func (c *Proxy) Authenticate(ctx context.Context, r *authn.Request) (*authn.Identity, error) {
 	if !c.isAllowedIP(r) {
 		return nil, errNotAcceptedIP.Errorf("request ip is not in the configured accept list")

--- a/pkg/services/authn/clients/proxy.go
+++ b/pkg/services/authn/clients/proxy.go
@@ -29,7 +29,7 @@ var (
 	errInvalidProxyHeader = errutil.NewBase(errutil.StatusInternal, "auth-proxy.invalid-proxy-header")
 )
 
-var _ authn.Client = new(Proxy)
+var _ authn.ContextAwareClient = new(Proxy)
 
 func ProvideProxy(cfg *setting.Cfg, clients ...authn.ProxyClient) (*Proxy, error) {
 	list, err := parseAcceptList(cfg.AuthProxyWhitelist)
@@ -73,6 +73,10 @@ func (c *Proxy) Authenticate(ctx context.Context, r *authn.Request) (*authn.Iden
 
 func (c *Proxy) Test(ctx context.Context, r *authn.Request) bool {
 	return len(getProxyHeader(r, c.cfg.AuthProxyHeaderName, c.cfg.AuthProxyHeadersEncoded)) != 0
+}
+
+func (c *Proxy) Priority() uint {
+	return 50
 }
 
 func (c *Proxy) isAllowedIP(r *authn.Request) bool {

--- a/pkg/services/authn/clients/render.go
+++ b/pkg/services/authn/clients/render.go
@@ -31,6 +31,10 @@ type Render struct {
 	renderService rendering.Service
 }
 
+func (c *Render) Name() string {
+	return authn.ClientRender
+}
+
 func (c *Render) Authenticate(ctx context.Context, r *authn.Request) (*authn.Identity, error) {
 	key := getRenderKey(r)
 	renderUsr, ok := c.renderService.GetRenderUser(ctx, key)

--- a/pkg/services/authn/clients/render.go
+++ b/pkg/services/authn/clients/render.go
@@ -20,7 +20,7 @@ const (
 	renderCookieName = "renderKey"
 )
 
-var _ authn.Client = new(Render)
+var _ authn.ContextAwareClient = new(Render)
 
 func ProvideRender(userService user.Service, renderService rendering.Service) *Render {
 	return &Render{userService, renderService}
@@ -64,6 +64,10 @@ func (c *Render) Test(ctx context.Context, r *authn.Request) bool {
 		return false
 	}
 	return getRenderKey(r) != ""
+}
+
+func (c *Render) Priority() uint {
+	return 10
 }
 
 func getRenderKey(r *authn.Request) string {

--- a/pkg/services/authn/clients/render_test.go
+++ b/pkg/services/authn/clients/render_test.go
@@ -4,14 +4,17 @@ import (
 	"context"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/grafana/grafana/pkg/services/authn"
+	"github.com/grafana/grafana/pkg/services/login"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/rendering"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/services/user/usertest"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestRender_Authenticate(t *testing.T) {
@@ -35,9 +38,10 @@ func TestRender_Authenticate(t *testing.T) {
 				},
 			},
 			expectedIdentity: &authn.Identity{
-				ID:       "user:0",
-				OrgID:    1,
-				OrgRoles: map[int64]org.RoleType{1: org.RoleViewer},
+				ID:         "user:0",
+				OrgID:      1,
+				OrgRoles:   map[int64]org.RoleType{1: org.RoleViewer},
+				AuthModule: login.RenderModule,
 			},
 			expectedRenderUsr: &rendering.RenderUser{
 				OrgID:   1,
@@ -59,6 +63,7 @@ func TestRender_Authenticate(t *testing.T) {
 				OrgName:        "test",
 				OrgRoles:       map[int64]org.RoleType{1: org.RoleAdmin},
 				IsGrafanaAdmin: boolPtr(false),
+				AuthModule:     login.RenderModule,
 			},
 			expectedRenderUsr: &rendering.RenderUser{
 				OrgID:  1,
@@ -97,6 +102,8 @@ func TestRender_Authenticate(t *testing.T) {
 				assert.Nil(t, identity)
 			} else {
 				assert.NoError(t, err)
+				// ignore LastSeenAt
+				identity.LastSeenAt = time.Time{}
 				assert.EqualValues(t, *tt.expectedIdentity, *identity)
 			}
 		})

--- a/pkg/services/authn/clients/session.go
+++ b/pkg/services/authn/clients/session.go
@@ -36,6 +36,10 @@ type Session struct {
 	log              log.Logger
 }
 
+func (s *Session) Name() string {
+	return authn.ClientSession
+}
+
 func (s *Session) Authenticate(ctx context.Context, r *authn.Request) (*authn.Identity, error) {
 	unescapedCookie, err := r.HTTPRequest.Cookie(s.loginCookieName)
 	if err != nil {

--- a/pkg/services/contexthandler/auth_jwt.go
+++ b/pkg/services/contexthandler/auth_jwt.go
@@ -12,8 +12,6 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/models/roletype"
 	authJWT "github.com/grafana/grafana/pkg/services/auth/jwt"
-	"github.com/grafana/grafana/pkg/services/authn"
-	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/user"
 )
@@ -25,27 +23,6 @@ const (
 )
 
 func (h *ContextHandler) initContextWithJWT(ctx *models.ReqContext, orgId int64) bool {
-	if h.features.IsEnabled(featuremgmt.FlagAuthnService) {
-		identity, ok, err := h.authnService.Authenticate(ctx.Req.Context(),
-			authn.ClientJWT,
-			&authn.Request{HTTPRequest: ctx.Req, Resp: ctx.Resp, OrgID: orgId})
-		if !ok {
-			return false
-		}
-
-		newCtx := WithAuthHTTPHeader(ctx.Req.Context(), h.Cfg.JWTAuthHeaderName)
-		*ctx.Req = *ctx.Req.WithContext(newCtx)
-
-		if err != nil {
-			ctx.WriteErr(err)
-			return true
-		}
-
-		ctx.SignedInUser = identity.SignedInUser()
-		ctx.IsSignedIn = true
-		return true
-	}
-
 	if !h.Cfg.JWTAuthEnabled || h.Cfg.JWTAuthHeaderName == "" {
 		return false
 	}

--- a/pkg/services/contexthandler/contexthandler.go
+++ b/pkg/services/contexthandler/contexthandler.go
@@ -143,8 +143,7 @@ func (h *ContextHandler) Middleware(next http.Handler) http.Handler {
 				reqContext.IsSignedIn = true
 				reqContext.UserToken = identity.SessionToken
 				reqContext.SignedInUser = identity.SignedInUser()
-				// FIXME: cannot only depend on empty id
-				reqContext.AllowAnonymous = identity.IsAnonymous()
+				reqContext.AllowAnonymous = identity.IsAnonymous
 				reqContext.IsRenderCall = identity.AuthModule == login.RenderModule
 
 				// Add authentication headers based on what method was used

--- a/pkg/services/contexthandler/contexthandler.go
+++ b/pkg/services/contexthandler/contexthandler.go
@@ -138,6 +138,7 @@ func (h *ContextHandler) Middleware(next http.Handler) http.Handler {
 					// Burn the cookie in case of invalid, expired or missing token
 					reqContext.Resp.Before(h.deleteInvalidCookieEndOfRequestFunc(reqContext))
 				}
+				// set all errors on LookupTokenErr, so we can check it in auth middlewares
 				reqContext.LookupTokenErr = err
 			} else {
 				reqContext.IsSignedIn = true

--- a/pkg/services/login/authinfo.go
+++ b/pkg/services/login/authinfo.go
@@ -22,6 +22,7 @@ const (
 	LDAPAuthModule      = "ldap"
 	AuthProxyAuthModule = "authproxy"
 	JWTModule           = "jwt"
+	RenderModule        = "render"
 )
 
 func GetAuthProviderLabel(authModule string) string {


### PR DESCRIPTION
**What is this feature?**
One of the goals with the new authn.Service is to be able to authenticate a request without having to specify a client.
To achieve this I created a new interface that clients can implement "ContextAwareClient". These type of clients need to be able to test if a request can be authenticated using that client and needs to specify a priority.

When registering new clients we can check if this additional interface is implement and add it to a simple priority list.
Then every time we call service.Authenticate we can go through the list in a consistent order.

The queue is implemented using generics so we can reuse the same structure for post auth hooks and post auth login.


**Special notes for your reviewer**:
* Need to add auth header to context in another pr
