### PR TITLE
SSE: Resample command to support NoData

### DIFF
--- a/pkg/expr/commands_test.go
+++ b/pkg/expr/commands_test.go
@@ -14,6 +14,7 @@ import (
 	ptr "github.com/xorcare/pointer"
 
 	"github.com/grafana/grafana/pkg/expr/mathexp"
+	"github.com/grafana/grafana/pkg/expr/mathexp/parse"
 	"github.com/grafana/grafana/pkg/util"
 )
 
@@ -169,4 +170,55 @@ func TestReduceExecute(t *testing.T) {
 func randomReduceFunc() string {
 	res := mathexp.GetSupportedReduceFuncs()
 	return res[rand.Intn(len(res)-1)]
+}
+
+func TestResampleCommand_Execute(t *testing.T) {
+	varToReduce := util.GenerateShortUID()
+	tr := RelativeTimeRange{
+		From: -10 * time.Second,
+		To:   0,
+	}
+	cmd, err := NewResampleCommand(util.GenerateShortUID(), "1s", varToReduce, "sum", "pad", tr)
+	require.NoError(t, err)
+
+	var tests = []struct {
+		name         string
+		vals         mathexp.Value
+		isError      bool
+		expectedType parse.ReturnType
+	}{
+		{
+			name:         "should resample when input Series",
+			vals:         mathexp.NewSeries(varToReduce, nil, 100),
+			expectedType: parse.TypeSeriesSet,
+		},
+		{
+			name:         "should return NoData when input NoData",
+			vals:         mathexp.NoData{},
+			expectedType: parse.TypeNoData,
+		}, {
+			name:    "should return error when input Number",
+			vals:    mathexp.NewNumber("test", nil),
+			isError: true,
+		}, {
+			name:    "should return error when input Scalar",
+			vals:    mathexp.NewScalar("test", ptr.Float64(rand.Float64())),
+			isError: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := cmd.Execute(context.Background(), time.Now(), mathexp.Vars{
+				varToReduce: mathexp.Results{Values: mathexp.Values{test.vals}},
+			})
+			if test.isError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Len(t, result.Values, 1)
+				res := result.Values[0]
+				require.Equal(t, test.expectedType, res.Type())
+			}
+		})
+	}
 }

--- a/pkg/expr/commands_test.go
+++ b/pkg/expr/commands_test.go
@@ -221,4 +221,12 @@ func TestResampleCommand_Execute(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("should return empty result if input is nil Value", func(t *testing.T) {
+		result, err := cmd.Execute(context.Background(), time.Now(), mathexp.Vars{
+			varToReduce: mathexp.Results{Values: mathexp.Values{nil}},
+		})
+		require.Empty(t, result.Values)
+		require.NoError(t, err)
+	})
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
During updating DSNode I stumbled upon a bug in a test that was caused by the bug in ResampleCommand that returned error when the input argument is NoData.
This PR updates ResampleCommand to support no data. Also, it adds check for `nil`, Although it does not seem to be possible, semantically it is.

Related to: https://github.com/grafana/grafana/pull/61644
