### PR TITLE
SSE: Fix math expression to support NoData results

### DIFF
--- a/pkg/expr/mathexp/exp.go
+++ b/pkg/expr/mathexp/exp.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
+
 	"github.com/grafana/grafana/pkg/expr/mathexp/parse"
 )
 
@@ -201,6 +202,11 @@ func union(aResults, bResults Results) []*Union {
 	}
 	if aValueLen == 1 || bValueLen == 1 {
 		if aResults.Values[0].Type() == parse.TypeNoData || bResults.Values[0].Type() == parse.TypeNoData {
+			unions = append(unions, &Union{
+				Labels: nil,
+				A:      aResults.Values[0],
+				B:      bResults.Values[0],
+			})
 			return unions
 		}
 	}
@@ -285,6 +291,8 @@ func (e *State) walkBinary(node *parse.BinaryNode) (Results, error) {
 			// Scalar op Series
 			case Series:
 				value, err = e.biSeriesNumber(uni.Labels, node.OpStr, bt, aFloat, false)
+			case NoData:
+				value = uni.B
 			default:
 				return res, fmt.Errorf("not implemented: binary %v on %T and %T", node.OpStr, uni.A, uni.B)
 			}
@@ -301,6 +309,8 @@ func (e *State) walkBinary(node *parse.BinaryNode) (Results, error) {
 			// case Series op Series
 			case Series:
 				value, err = e.biSeriesSeries(uni.Labels, node.OpStr, at, bt)
+			case NoData:
+				value = uni.B
 			default:
 				return res, fmt.Errorf("not implemented: binary %v on %T and %T", node.OpStr, uni.A, uni.B)
 			}
@@ -315,9 +325,13 @@ func (e *State) walkBinary(node *parse.BinaryNode) (Results, error) {
 				value, err = e.biScalarNumber(uni.Labels, node.OpStr, at, bFloat, true)
 			case Series:
 				value, err = e.biSeriesNumber(uni.Labels, node.OpStr, bt, aFloat, false)
+			case NoData:
+				value = uni.B
 			default:
 				return res, fmt.Errorf("not implemented: binary %v on %T and %T", node.OpStr, uni.A, uni.B)
 			}
+		case NoData:
+			value = uni.A
 		default:
 			return res, fmt.Errorf("not implemented: binary %v on %T and %T", node.OpStr, uni.A, uni.B)
 		}

--- a/pkg/expr/mathexp/funcs.go
+++ b/pkg/expr/mathexp/funcs.go
@@ -229,6 +229,9 @@ func perFloat(e *State, val Value, floatF func(x float64) float64) (Value, error
 			newSeries.SetPoint(i, t, &nF)
 		}
 		newVal = newSeries
+	case parse.TypeNoData:
+		nodata := val.(NoData)
+		newVal = nodata.New()
 	default:
 		// TODO: Should we deal with TypeString, TypeVariantSet?
 	}

--- a/pkg/expr/mathexp/funcs.go
+++ b/pkg/expr/mathexp/funcs.go
@@ -230,8 +230,7 @@ func perFloat(e *State, val Value, floatF func(x float64) float64) (Value, error
 		}
 		newVal = newSeries
 	case parse.TypeNoData:
-		nodata := val.(NoData)
-		newVal = nodata.New()
+		newVal = NewNoData()
 	default:
 		// TODO: Should we deal with TypeString, TypeVariantSet?
 	}
@@ -261,6 +260,8 @@ func perNullableFloat(e *State, val Value, floatF func(x *float64) *float64) (Va
 			newSeries.SetPoint(i, t, floatF(f))
 		}
 		newVal = newSeries
+	case parse.TypeNoData:
+		newVal = NewNoData()
 	default:
 		// TODO: Should we deal with TypeString, TypeVariantSet?
 	}

--- a/pkg/expr/mathexp/types.go
+++ b/pkg/expr/mathexp/types.go
@@ -212,5 +212,9 @@ func (s NoData) AddNotice(notice data.Notice) {
 func (s NoData) AsDataFrame() *data.Frame { return s.Frame }
 
 func (s NoData) New() NoData {
+	return NewNoData()
+}
+
+func NewNoData() NoData {
 	return NoData{data.NewFrame("no data")}
 }

--- a/pkg/expr/mathexp/union_test.go
+++ b/pkg/expr/mathexp/union_test.go
@@ -103,7 +103,13 @@ func Test_union(t *testing.T) {
 				},
 			},
 			unionsAre: assert.EqualValues,
-			unions:    []*Union{},
+			unions: []*Union{
+				{
+					Labels: nil,
+					A:      makeSeries("a", data.Labels{"id": "1"}),
+					B:      NewNoData(),
+				},
+			},
 		},
 		{
 			name: "incompatible tags of different length with will result in no unions when len(A) != 1 && len(B) != 1",
@@ -256,6 +262,30 @@ func Test_union(t *testing.T) {
 				{
 					Labels: data.Labels{"id": "1", "fish": "red snapper"},
 					A:      makeSeries("bb", data.Labels{"id": "1", "fish": "red snapper"}),
+					B:      makeSeries("a", data.Labels{"id": "1"}),
+				},
+			},
+		},
+		{
+			name: "A is no-data and B is anything makes no-data",
+			// Is this the behavior we want? A result within the results will no longer
+			// be uniquely identifiable.
+			aResults: Results{
+				Values: Values{
+					NewNoData(),
+				},
+			},
+			bResults: Results{
+				Values: Values{
+					makeSeries("a", data.Labels{"id": "1"}),
+					makeSeries("aa", data.Labels{"id": "1", "fish": "herring"}),
+				},
+			},
+			unionsAre: assert.EqualValues,
+			unions: []*Union{
+				{
+					Labels: nil,
+					A:      NewNoData(),
 					B:      makeSeries("a", data.Labels{"id": "1"}),
 				},
 			},


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Currently, when NoData result is passed to any unary operator it returns a slice `[]Value{nil}` which causes panic in subsequent operations because `switch` statements that analyze the type of the Value do not expect nil. 

This PR updates all unary operations to return NoData if the input argument has type NoData.

A union operation produces an empty `Union` when either of the results is NoData. This makes the math expression result in empty values slice. This PR updates the union operation to return a non empty union where at least one of values is NoData and any binary operation that uses the union to return NoData when either of the arguments is NoData.


**Why do we need this feature?**

This will make NoData be correctly propagated through the pipeline

**Who is this feature for?**

Grafana Alerting users are the primary beneficiary of this change

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/61304

**Special notes for your reviewer**:

