### PR TITLE
Datasources: Fix Proxy by UID Failing for UIDs with a Hyphen

### DIFF
--- a/pkg/services/datasourceproxy/datasourceproxy.go
+++ b/pkg/services/datasourceproxy/datasourceproxy.go
@@ -131,7 +131,7 @@ func (p *DataSourceProxyService) proxyDatasourceRequest(c *models.ReqContext, ds
 	proxy.HandleRequest()
 }
 
-var proxyPathRegexp = regexp.MustCompile(`^\/api\/datasources\/proxy\/([\d]+|uid\/[\w]+)\/?`)
+var proxyPathRegexp = regexp.MustCompile(`^\/api\/datasources\/proxy\/([\d]+|uid\/[\w-]+)\/?`)
 
 func extractProxyPath(originalRawPath string) string {
 	return proxyPathRegexp.ReplaceAllString(originalRawPath, "")

--- a/pkg/services/datasourceproxy/datasourceproxy_test.go
+++ b/pkg/services/datasourceproxy/datasourceproxy_test.go
@@ -33,6 +33,14 @@ func TestDataProxy(t *testing.T) {
 				"some/thing",
 			},
 			{
+				"/api/datasources/proxy/uid/pUWo-no4k/search",
+				"search",
+			},
+			{
+				"/api/datasources/proxy/uid/pUWo_no4k/search",
+				"search",
+			},
+			{
 				"/api/datasources/proxy/uid/26MI0wZ7k/api/services/afsd%2Fafsd/operations",
 				"api/services/afsd%2Fafsd/operations",
 			},


### PR DESCRIPTION
Hyphens are allowed in short IDs but not picked up by the proxyPathRegexp. This caused the end of the uid to be proxied as part of the path to the backing datasource which would usually cause a 404.

Fixes #61722 

