### PR TITLE
SearchV2: Fix star query when no stars exist

### DIFF
--- a/public/app/features/search/service/bluge.ts
+++ b/public/app/features/search/service/bluge.ts
@@ -42,7 +42,7 @@ export class BlugeSearcher implements GrafanaSearcher {
     }
     // get the starred dashboards
     const starsUIDS = await getBackendSrv().get('api/user/stars');
-    if (starsUIDS.length) {
+    if (starsUIDS?.length) {
       return this.doSearchQuery({
         uid: starsUIDS,
         query: query.query ?? '*',

--- a/public/app/features/search/service/bluge.ts
+++ b/public/app/features/search/service/bluge.ts
@@ -6,7 +6,6 @@ import {
   getDisplayProcessor,
   SelectableValue,
   toDataFrame,
-  MutableDataFrame,
 } from '@grafana/data';
 import { config, getBackendSrv } from '@grafana/runtime';
 import { TermCount } from 'app/core/components/TagFilter/TagFilter';
@@ -51,7 +50,7 @@ export class BlugeSearcher implements GrafanaSearcher {
     }
     // Nothing is starred
     return {
-      view: new DataFrameView(new MutableDataFrame()),
+      view: new DataFrameView({ length: 0, fields: [] }),
       totalRows: 0,
       loadMoreItems: async (startIndex: number, stopIndex: number): Promise<void> => {
         return;


### PR DESCRIPTION
Avoid making a star query when nothing is starred.

Fixes #61551
