### PR TITLE
Plugins: enable the plugin sdk to get the json data for all datasources

### DIFF
--- a/pkg/services/datasources/service/datasource.go
+++ b/pkg/services/datasources/service/datasource.go
@@ -416,6 +416,8 @@ func (s *Service) httpClientOptions(ctx context.Context, ds *datasources.DataSou
 
 	if ds.JsonData != nil {
 		opts.CustomOptions = ds.JsonData.MustMap()
+		// allow the plugin sdk to get the json data in JSONDataFromHTTPClientOptions
+		opts.CustomOptions["grafanaData"] = ds.JsonData.MustMap()
 	}
 	if ds.BasicAuth {
 		password, err := s.DecryptedBasicAuthPassword(ctx, ds)


### PR DESCRIPTION
**What is this feature?**

This PR sets the key, `grafanaData`, in the sdk custom options as the datasource json data so that [JSONDataFromHTTPClientOptions](https://github.com/grafana/grafana-plugin-sdk-go/blob/main/backend/common.go#L172) works for all core plugins.

**Why do we need this feature?**

Most datasources are using [this function](https://github.com/grafana/grafana/blob/main/pkg/services/datasources/service/datasource.go#L383) to get the httpclient options, which just sets the custom options to the datasource json data. The issue is the sdk function, [JSONDataFromHTTPClientOptions](https://github.com/grafana/grafana-plugin-sdk-go/blob/main/backend/common.go#L172), assumes the json data is set as the value of the key `grafanaData`. Some datasources, like Prometheus and Loki, use [this function](https://github.com/grafana/grafana-plugin-sdk-go/blob/main/backend/common.go#L121), which enables the json data to be retrieved through the sdk function, but most do not. Therefore, the sdk function does not work for a majority of core plugins.