### PR TITLE
Loki: Use `tsdb` index in devenv

### DIFF
--- a/devenv/docker/blocks/loki/loki-config.yaml
+++ b/devenv/docker/blocks/loki/loki-config.yaml
@@ -19,7 +19,7 @@ common:
 schema_config:
   configs:
     - from: 2020-10-24
-      store: boltdb-shipper
+      store: tsdb
       object_store: filesystem
       schema: v11
       index:


### PR DESCRIPTION
Use Loki's new TSDB index in our devenv.