### PR TITLE
Alerting: Fix QueryAndExpressionStep not using the right query

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
@@ -67,8 +67,8 @@ export const QueryAndExpressionsStep: FC<Props> = ({ editingExistingRule }) => {
   }, []);
 
   const runQueries = useCallback(() => {
-    runner.current.run(queries);
-  }, [queries]);
+    runner.current.run(getValues('queries'));
+  }, [getValues]);
 
   // whenever we update the queries we have to update the form too
   useEffect(() => {


### PR DESCRIPTION
**What is this feature?**

This PR is a fix for `QueryAndExpressionStep` not using the right query.


**Why do we need this feature?**

`runQueries` should use the updated query  any time it's changed in the QueryEditor

**Who is this feature for?**

All users.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/61704

**Special notes for your reviewer:**

The source of truth (state for queries) in `QueryAndExpressionStep` is in the `QueryEditor` component that `QueryAndExpressionStep` render as a child.

Any change done by the user is handled by the `QueryEditor`, and `QueryAndExpressionStep` reacts to these changes in the `onChangeQueries` method.

The problem is that the callback passed to the `QueryEditor` contains the method that calls the `runQueries` with the `queries` parameter with the value we have before our `onChangeQueries` has been called.

So `runQueries` will be called internally by the `QueryEditor` before we update the queries in the parent component(QueryAndExpressionStep)

