### PR TITLE
Flame graph: Search with uFuzzy

### DIFF
--- a/public/app/plugins/panel/flamegraph/components/FlameGraph/FlameGraph.tsx
+++ b/public/app/plugins/panel/flamegraph/components/FlameGraph/FlameGraph.tsx
@@ -17,6 +17,7 @@
 // TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 // THIS SOFTWARE.
 import { css } from '@emotion/css';
+import uFuzzy from '@leeoniya/ufuzzy';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useMeasure } from 'react-use';
 
@@ -107,6 +108,11 @@ const FlameGraph = ({
         theme: createTheme() /* theme does not matter for us here */,
       });
 
+      const ufuzzy = new uFuzzy({
+        intraMode: 0,
+        intraIns: 0,
+      });
+
       for (let levelIndex = 0; levelIndex < levels.length; levelIndex++) {
         const level = levels[levelIndex];
         // Get all the dimensions of the rectangles for the level. We do this by level instead of per rectangle, because
@@ -114,7 +120,7 @@ const FlameGraph = ({
         const dimensions = getRectDimensionsForLevel(level, levelIndex, totalTicks, rangeMin, pixelsPerTick, processor);
         for (const rect of dimensions) {
           // Render each rectangle based on the computed dimensions
-          renderRect(ctx, rect, totalTicks, rangeMin, rangeMax, search, levelIndex, topLevelIndex);
+          renderRect(ctx, rect, totalTicks, rangeMin, rangeMax, search, levelIndex, topLevelIndex, ufuzzy);
         }
       }
     },

--- a/public/app/plugins/panel/flamegraph/components/FlameGraph/rendering.ts
+++ b/public/app/plugins/panel/flamegraph/components/FlameGraph/rendering.ts
@@ -85,7 +85,8 @@ export function renderRect(
   rangeMax: number,
   query: string,
   levelIndex: number,
-  topLevelIndex: number
+  topLevelIndex: number,
+  ufuzzy: uFuzzy
 ) {
   if (rect.width < HIDE_THRESHOLD) {
     return;
@@ -100,7 +101,8 @@ export function renderRect(
   const l = 65 + 7 * intensity;
 
   const name = rect.label;
-  const queryResult = query && name.toLowerCase().includes(query.toLowerCase());
+  const idxs = ufuzzy.filter([name], query);
+  const queryResult = query && idxs.length > 0;
 
   if (!rect.collapsed) {
     ctx.stroke();


### PR DESCRIPTION
**What is this feature?**

Adds fuzzy search ([uFuzzy](https://github.com/leeoniya/uFuzzy)) to the flame graph search input.

**Why do we need this feature?**

So users of the flame graph can search easier.

**Who is this feature for?**

Flame graph users.

**Special notes for your reviewer**:

![Screenshot 2023-01-19 at 10 07 18](https://user-images.githubusercontent.com/90795735/213418388-da76408a-a9b2-44bf-b9ad-3ee993872a83.png)
![Screenshot 2023-01-19 at 10 07 52](https://user-images.githubusercontent.com/90795735/213418394-11884f72-7248-4c08-a354-5346d8e6ff99.png)
![Screenshot 2023-01-19 at 10 24 10](https://user-images.githubusercontent.com/90795735/213418399-902a9f89-9f01-4fcc-b900-2e2e9b05d2eb.png)


