### PR TITLE
Chore: Remove dashboard ACL from models

### DIFF
--- a/pkg/api/annotations_test.go
+++ b/pkg/api/annotations_test.go
@@ -680,9 +680,9 @@ func setUpACL() {
 	store := dbtest.NewFakeDB()
 	teamSvc := &teamtest.FakeService{}
 	dashSvc := &dashboards.FakeDashboardService{}
-	dashSvc.On("GetDashboardACLInfoList", mock.Anything, mock.AnythingOfType("*models.GetDashboardACLInfoListQuery")).Run(func(args mock.Arguments) {
-		q := args.Get(1).(*models.GetDashboardACLInfoListQuery)
-		q.Result = []*models.DashboardACLInfoDTO{
+	dashSvc.On("GetDashboardACLInfoList", mock.Anything, mock.AnythingOfType("*dashboards.GetDashboardACLInfoListQuery")).Run(func(args mock.Arguments) {
+		q := args.Get(1).(*dashboards.GetDashboardACLInfoListQuery)
+		q.Result = []*dashboards.DashboardACLInfoDTO{
 			{Role: &viewerRole, Permission: models.PERMISSION_VIEW},
 			{Role: &editorRole, Permission: models.PERMISSION_EDIT},
 		}

--- a/pkg/api/common_test.go
+++ b/pkg/api/common_test.go
@@ -541,7 +541,7 @@ var (
 )
 
 type setUpConf struct {
-	aclMockResp []*models.DashboardACLInfoDTO
+	aclMockResp []*dashboards.DashboardACLInfoDTO
 }
 
 type mockSearchService struct{ ExpectedResult models.HitList }
@@ -556,7 +556,7 @@ func setUp(confs ...setUpConf) *HTTPServer {
 	store := dbtest.NewFakeDB()
 	hs := &HTTPServer{SQLStore: store, SearchService: &mockSearchService{}}
 
-	aclMockResp := []*models.DashboardACLInfoDTO{}
+	aclMockResp := []*dashboards.DashboardACLInfoDTO{}
 	for _, c := range confs {
 		if c.aclMockResp != nil {
 			aclMockResp = c.aclMockResp
@@ -564,8 +564,8 @@ func setUp(confs ...setUpConf) *HTTPServer {
 	}
 	teamSvc := &teamtest.FakeService{}
 	dashSvc := &dashboards.FakeDashboardService{}
-	dashSvc.On("GetDashboardACLInfoList", mock.Anything, mock.AnythingOfType("*models.GetDashboardACLInfoListQuery")).Run(func(args mock.Arguments) {
-		q := args.Get(1).(*models.GetDashboardACLInfoListQuery)
+	dashSvc.On("GetDashboardACLInfoList", mock.Anything, mock.AnythingOfType("*dashboards.GetDashboardACLInfoListQuery")).Run(func(args mock.Arguments) {
+		q := args.Get(1).(*dashboards.GetDashboardACLInfoListQuery)
 		q.Result = aclMockResp
 	}).Return(nil)
 	guardian.InitLegacyGuardian(store, dashSvc, teamSvc)

--- a/pkg/api/dashboard_permission.go
+++ b/pkg/api/dashboard_permission.go
@@ -71,19 +71,19 @@ func (hs *HTTPServer) GetDashboardPermissionList(c *models.ReqContext) response.
 		return response.Error(500, "Failed to get dashboard permissions", err)
 	}
 
-	filteredACLs := make([]*models.DashboardACLInfoDTO, 0, len(acl))
+	filteredACLs := make([]*dashboards.DashboardACLInfoDTO, 0, len(acl))
 	for _, perm := range acl {
-		if perm.UserId > 0 && dtos.IsHiddenUser(perm.UserLogin, c.SignedInUser, hs.Cfg) {
+		if perm.UserID > 0 && dtos.IsHiddenUser(perm.UserLogin, c.SignedInUser, hs.Cfg) {
 			continue
 		}
 
-		perm.UserAvatarUrl = dtos.GetGravatarUrl(perm.UserEmail)
+		perm.UserAvatarURL = dtos.GetGravatarUrl(perm.UserEmail)
 
-		if perm.TeamId > 0 {
-			perm.TeamAvatarUrl = dtos.GetGravatarUrlWithDefault(perm.TeamEmail, perm.Team)
+		if perm.TeamID > 0 {
+			perm.TeamAvatarURL = dtos.GetGravatarUrlWithDefault(perm.TeamEmail, perm.Team)
 		}
 		if perm.Slug != "" {
-			perm.Url = dashboards.GetDashboardFolderURL(perm.IsFolder, perm.Uid, perm.Slug)
+			perm.URL = dashboards.GetDashboardFolderURL(perm.IsFolder, perm.UID, perm.Slug)
 		}
 
 		filteredACLs = append(filteredACLs, perm)
@@ -156,9 +156,9 @@ func (hs *HTTPServer) UpdateDashboardPermissions(c *models.ReqContext) response.
 		return dashboardGuardianResponse(err)
 	}
 
-	items := make([]*models.DashboardACL, 0, len(apiCmd.Items))
+	items := make([]*dashboards.DashboardACL, 0, len(apiCmd.Items))
 	for _, item := range apiCmd.Items {
-		items = append(items, &models.DashboardACL{
+		items = append(items, &dashboards.DashboardACL{
 			OrgID:       c.OrgID,
 			DashboardID: dashID,
 			UserID:      item.UserID,
@@ -211,7 +211,7 @@ func (hs *HTTPServer) UpdateDashboardPermissions(c *models.ReqContext) response.
 }
 
 // updateDashboardAccessControl is used for api backward compatibility
-func (hs *HTTPServer) updateDashboardAccessControl(ctx context.Context, orgID int64, uid string, isFolder bool, items []*models.DashboardACL, old []*models.DashboardACLInfoDTO) error {
+func (hs *HTTPServer) updateDashboardAccessControl(ctx context.Context, orgID int64, uid string, isFolder bool, items []*dashboards.DashboardACL, old []*dashboards.DashboardACLInfoDTO) error {
 	commands := []accesscontrol.SetResourcePermissionCommand{}
 	for _, item := range items {
 		permissions := item.Permission.String()
@@ -231,11 +231,11 @@ func (hs *HTTPServer) updateDashboardAccessControl(ctx context.Context, orgID in
 	for _, o := range old {
 		shouldRemove := true
 		for _, item := range items {
-			if item.UserID != 0 && item.UserID == o.UserId {
+			if item.UserID != 0 && item.UserID == o.UserID {
 				shouldRemove = false
 				break
 			}
-			if item.TeamID != 0 && item.TeamID == o.TeamId {
+			if item.TeamID != 0 && item.TeamID == o.TeamID {
 				shouldRemove = false
 				break
 			}
@@ -251,8 +251,8 @@ func (hs *HTTPServer) updateDashboardAccessControl(ctx context.Context, orgID in
 			}
 
 			commands = append(commands, accesscontrol.SetResourcePermissionCommand{
-				UserID:      o.UserId,
-				TeamID:      o.TeamId,
+				UserID:      o.UserID,
+				TeamID:      o.TeamID,
 				BuiltinRole: role,
 				Permission:  "",
 			})
@@ -321,5 +321,5 @@ type UpdateDashboardPermissionsByUIDParams struct {
 // swagger:response getDashboardPermissionsListResponse
 type GetDashboardPermissionsResponse struct {
 	// in: body
-	Body []*models.DashboardACLInfoDTO `json:"body"`
+	Body []*dashboards.DashboardACLInfoDTO `json:"body"`
 }

--- a/pkg/api/dashboard_permission_test.go
+++ b/pkg/api/dashboard_permission_test.go
@@ -93,12 +93,12 @@ func TestDashboardPermissionAPIEndpoint(t *testing.T) {
 			guardian.MockDashboardGuardian(&guardian.FakeDashboardGuardian{
 				CanAdminValue:                    true,
 				CheckPermissionBeforeUpdateValue: true,
-				GetACLValue: []*models.DashboardACLInfoDTO{
-					{OrgId: 1, DashboardId: 1, UserId: 2, Permission: models.PERMISSION_VIEW},
-					{OrgId: 1, DashboardId: 1, UserId: 3, Permission: models.PERMISSION_EDIT},
-					{OrgId: 1, DashboardId: 1, UserId: 4, Permission: models.PERMISSION_ADMIN},
-					{OrgId: 1, DashboardId: 1, TeamId: 1, Permission: models.PERMISSION_VIEW},
-					{OrgId: 1, DashboardId: 1, TeamId: 2, Permission: models.PERMISSION_ADMIN},
+				GetACLValue: []*dashboards.DashboardACLInfoDTO{
+					{OrgID: 1, DashboardID: 1, UserID: 2, Permission: models.PERMISSION_VIEW},
+					{OrgID: 1, DashboardID: 1, UserID: 3, Permission: models.PERMISSION_EDIT},
+					{OrgID: 1, DashboardID: 1, UserID: 4, Permission: models.PERMISSION_ADMIN},
+					{OrgID: 1, DashboardID: 1, TeamID: 1, Permission: models.PERMISSION_VIEW},
+					{OrgID: 1, DashboardID: 1, TeamID: 2, Permission: models.PERMISSION_ADMIN},
 				},
 			})
 
@@ -107,12 +107,12 @@ func TestDashboardPermissionAPIEndpoint(t *testing.T) {
 					callGetDashboardPermissions(sc, hs)
 					assert.Equal(t, 200, sc.resp.Code)
 
-					var resp []*models.DashboardACLInfoDTO
+					var resp []*dashboards.DashboardACLInfoDTO
 					err := json.Unmarshal(sc.resp.Body.Bytes(), &resp)
 					require.NoError(t, err)
 
 					assert.Len(t, resp, 5)
-					assert.Equal(t, int64(2), resp[0].UserId)
+					assert.Equal(t, int64(2), resp[0].UserID)
 					assert.Equal(t, models.PERMISSION_VIEW, resp[0].Permission)
 				}, mockSQLStore)
 
@@ -269,19 +269,19 @@ func TestDashboardPermissionAPIEndpoint(t *testing.T) {
 			})
 
 			mockSQLStore := dbtest.NewFakeDB()
-			var resp []*models.DashboardACLInfoDTO
+			var resp []*dashboards.DashboardACLInfoDTO
 			loggedInUserScenarioWithRole(t, "When calling GET on", "GET", "/api/dashboards/id/1/permissions",
 				"/api/dashboards/id/:dashboardId/permissions", org.RoleAdmin, func(sc *scenarioContext) {
 					setUp()
 					guardian.MockDashboardGuardian(&guardian.FakeDashboardGuardian{
 						CanAdminValue:                    true,
 						CheckPermissionBeforeUpdateValue: true,
-						GetACLValue: []*models.DashboardACLInfoDTO{
-							{OrgId: 1, DashboardId: 1, UserId: 2, UserLogin: "hiddenUser", Permission: models.PERMISSION_VIEW},
-							{OrgId: 1, DashboardId: 1, UserId: 3, UserLogin: testUserLogin, Permission: models.PERMISSION_EDIT},
-							{OrgId: 1, DashboardId: 1, UserId: 4, UserLogin: "user_1", Permission: models.PERMISSION_ADMIN},
+						GetACLValue: []*dashboards.DashboardACLInfoDTO{
+							{OrgID: 1, DashboardID: 1, UserID: 2, UserLogin: "hiddenUser", Permission: models.PERMISSION_VIEW},
+							{OrgID: 1, DashboardID: 1, UserID: 3, UserLogin: testUserLogin, Permission: models.PERMISSION_EDIT},
+							{OrgID: 1, DashboardID: 1, UserID: 4, UserLogin: "user_1", Permission: models.PERMISSION_ADMIN},
 						},
-						GetHiddenACLValue: []*models.DashboardACL{
+						GetHiddenACLValue: []*dashboards.DashboardACL{
 							{OrgID: 1, DashboardID: 1, UserID: 2, Permission: models.PERMISSION_VIEW},
 						},
 					})
@@ -293,9 +293,9 @@ func TestDashboardPermissionAPIEndpoint(t *testing.T) {
 					require.NoError(t, err)
 
 					assert.Len(t, resp, 2)
-					assert.Equal(t, int64(3), resp[0].UserId)
+					assert.Equal(t, int64(3), resp[0].UserID)
 					assert.Equal(t, models.PERMISSION_EDIT, resp[0].Permission)
-					assert.Equal(t, int64(4), resp[1].UserId)
+					assert.Equal(t, int64(4), resp[1].UserID)
 					assert.Equal(t, models.PERMISSION_ADMIN, resp[1].Permission)
 				}, mockSQLStore)
 
@@ -306,15 +306,15 @@ func TestDashboardPermissionAPIEndpoint(t *testing.T) {
 			}
 			for _, acl := range resp {
 				cmd.Items = append(cmd.Items, dtos.DashboardACLUpdateItem{
-					UserID:     acl.UserId,
+					UserID:     acl.UserID,
 					Permission: acl.Permission,
 				})
 			}
 			assert.Len(t, cmd.Items, 3)
 
-			var numOfItems []*models.DashboardACL
+			var numOfItems []*dashboards.DashboardACL
 			dashboardStore.On("UpdateDashboardACL", mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
-				items := args.Get(2).([]*models.DashboardACL)
+				items := args.Get(2).([]*dashboards.DashboardACL)
 				numOfItems = items
 			}).Return(nil).Once()
 			updateDashboardPermissionScenario(t, updatePermissionContext{

--- a/pkg/api/dashboard_snapshot_test.go
+++ b/pkg/api/dashboard_snapshot_test.go
@@ -79,7 +79,7 @@ func TestDashboardSnapshotAPIEndpoint_singleSnapshot(t *testing.T) {
 						UID: q.UID,
 					}
 				}).Return(nil).Maybe()
-				dashSvc.On("GetDashboardACLInfoList", mock.Anything, mock.AnythingOfType("*models.GetDashboardACLInfoListQuery")).Return(nil).Maybe()
+				dashSvc.On("GetDashboardACLInfoList", mock.Anything, mock.AnythingOfType("*dashboards.GetDashboardACLInfoListQuery")).Return(nil).Maybe()
 				hs.DashboardService = dashSvc
 
 				guardian.InitLegacyGuardian(sc.sqlStore, dashSvc, teamSvc)
@@ -118,9 +118,9 @@ func TestDashboardSnapshotAPIEndpoint_singleSnapshot(t *testing.T) {
 	t.Run("When user is editor and dashboard has default ACL", func(t *testing.T) {
 		teamSvc := &teamtest.FakeService{}
 		dashSvc := &dashboards.FakeDashboardService{}
-		dashSvc.On("GetDashboardACLInfoList", mock.Anything, mock.AnythingOfType("*models.GetDashboardACLInfoListQuery")).Run(func(args mock.Arguments) {
-			q := args.Get(1).(*models.GetDashboardACLInfoListQuery)
-			q.Result = []*models.DashboardACLInfoDTO{
+		dashSvc.On("GetDashboardACLInfoList", mock.Anything, mock.AnythingOfType("*dashboards.GetDashboardACLInfoListQuery")).Run(func(args mock.Arguments) {
+			q := args.Get(1).(*dashboards.GetDashboardACLInfoListQuery)
+			q.Result = []*dashboards.DashboardACLInfoDTO{
 				{Role: &viewerRole, Permission: models.PERMISSION_VIEW},
 				{Role: &editorRole, Permission: models.PERMISSION_EDIT},
 			}
@@ -141,9 +141,9 @@ func TestDashboardSnapshotAPIEndpoint_singleSnapshot(t *testing.T) {
 						OrgID: q.OrgID,
 					}
 				}).Return(nil).Maybe()
-				dashSvc.On("GetDashboardACLInfoList", mock.Anything, mock.AnythingOfType("*models.GetDashboardACLInfoListQuery")).Run(func(args mock.Arguments) {
-					q := args.Get(1).(*models.GetDashboardACLInfoListQuery)
-					q.Result = []*models.DashboardACLInfoDTO{
+				dashSvc.On("GetDashboardACLInfoList", mock.Anything, mock.AnythingOfType("*dashboards.GetDashboardACLInfoListQuery")).Run(func(args mock.Arguments) {
+					q := args.Get(1).(*dashboards.GetDashboardACLInfoListQuery)
+					q.Result = []*dashboards.DashboardACLInfoDTO{
 						{Role: &viewerRole, Permission: models.PERMISSION_VIEW},
 						{Role: &editorRole, Permission: models.PERMISSION_EDIT},
 					}

--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -157,9 +157,9 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 		setUp := func() {
 			viewerRole := org.RoleViewer
 			editorRole := org.RoleEditor
-			dashboardService.On("GetDashboardACLInfoList", mock.Anything, mock.AnythingOfType("*models.GetDashboardACLInfoListQuery")).Run(func(args mock.Arguments) {
-				q := args.Get(1).(*models.GetDashboardACLInfoListQuery)
-				q.Result = []*models.DashboardACLInfoDTO{
+			dashboardService.On("GetDashboardACLInfoList", mock.Anything, mock.AnythingOfType("*dashboards.GetDashboardACLInfoListQuery")).Run(func(args mock.Arguments) {
+				q := args.Get(1).(*dashboards.GetDashboardACLInfoListQuery)
+				q.Result = []*dashboards.DashboardACLInfoDTO{
 					{Role: &viewerRole, Permission: models.PERMISSION_VIEW},
 					{Role: &editorRole, Permission: models.PERMISSION_EDIT},
 				}
@@ -248,13 +248,13 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 			q := args.Get(1).(*dashboards.GetDashboardQuery)
 			q.Result = fakeDash
 		}).Return(nil)
-		dashboardService.On("GetDashboardACLInfoList", mock.Anything, mock.AnythingOfType("*models.GetDashboardACLInfoListQuery")).Run(func(args mock.Arguments) {
-			q := args.Get(1).(*models.GetDashboardACLInfoListQuery)
-			q.Result = []*models.DashboardACLInfoDTO{
+		dashboardService.On("GetDashboardACLInfoList", mock.Anything, mock.AnythingOfType("*dashboards.GetDashboardACLInfoListQuery")).Run(func(args mock.Arguments) {
+			q := args.Get(1).(*dashboards.GetDashboardACLInfoListQuery)
+			q.Result = []*dashboards.DashboardACLInfoDTO{
 				{
-					DashboardId: 1,
+					DashboardID: 1,
 					Permission:  models.PERMISSION_EDIT,
-					UserId:      200,
+					UserID:      200,
 				},
 			}
 		}).Return(nil)
@@ -380,10 +380,10 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 				setting.ViewersCanEdit = false
 
 				dashboardService := dashboards.NewFakeDashboardService(t)
-				dashboardService.On("GetDashboardACLInfoList", mock.Anything, mock.AnythingOfType("*models.GetDashboardACLInfoListQuery")).Run(func(args mock.Arguments) {
-					q := args.Get(1).(*models.GetDashboardACLInfoListQuery)
-					q.Result = []*models.DashboardACLInfoDTO{
-						{OrgId: 1, DashboardId: 2, UserId: 1, Permission: models.PERMISSION_EDIT},
+				dashboardService.On("GetDashboardACLInfoList", mock.Anything, mock.AnythingOfType("*dashboards.GetDashboardACLInfoListQuery")).Run(func(args mock.Arguments) {
+					q := args.Get(1).(*dashboards.GetDashboardACLInfoListQuery)
+					q.Result = []*dashboards.DashboardACLInfoDTO{
+						{OrgID: 1, DashboardID: 2, UserID: 1, Permission: models.PERMISSION_EDIT},
 					}
 				}).Return(nil)
 				guardian.InitLegacyGuardian(mockSQLStore, dashboardService, teamService)
@@ -442,10 +442,10 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 				setting.ViewersCanEdit = true
 
 				dashboardService := dashboards.NewFakeDashboardService(t)
-				dashboardService.On("GetDashboardACLInfoList", mock.Anything, mock.AnythingOfType("*models.GetDashboardACLInfoListQuery")).Run(func(args mock.Arguments) {
-					q := args.Get(1).(*models.GetDashboardACLInfoListQuery)
-					q.Result = []*models.DashboardACLInfoDTO{
-						{OrgId: 1, DashboardId: 2, UserId: 1, Permission: models.PERMISSION_VIEW},
+				dashboardService.On("GetDashboardACLInfoList", mock.Anything, mock.AnythingOfType("*dashboards.GetDashboardACLInfoListQuery")).Run(func(args mock.Arguments) {
+					q := args.Get(1).(*dashboards.GetDashboardACLInfoListQuery)
+					q.Result = []*dashboards.DashboardACLInfoDTO{
+						{OrgID: 1, DashboardID: 2, UserID: 1, Permission: models.PERMISSION_VIEW},
 					}
 				}).Return(nil)
 				guardian.InitLegacyGuardian(mockSQLStore, dashboardService, teamService)
@@ -482,10 +482,10 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 				setting.ViewersCanEdit = true
 
 				dashboardService := dashboards.NewFakeDashboardService(t)
-				dashboardService.On("GetDashboardACLInfoList", mock.Anything, mock.AnythingOfType("*models.GetDashboardACLInfoListQuery")).Run(func(args mock.Arguments) {
-					q := args.Get(1).(*models.GetDashboardACLInfoListQuery)
-					q.Result = []*models.DashboardACLInfoDTO{
-						{OrgId: 1, DashboardId: 2, UserId: 1, Permission: models.PERMISSION_ADMIN},
+				dashboardService.On("GetDashboardACLInfoList", mock.Anything, mock.AnythingOfType("*dashboards.GetDashboardACLInfoListQuery")).Run(func(args mock.Arguments) {
+					q := args.Get(1).(*dashboards.GetDashboardACLInfoListQuery)
+					q.Result = []*dashboards.DashboardACLInfoDTO{
+						{OrgID: 1, DashboardID: 2, UserID: 1, Permission: models.PERMISSION_ADMIN},
 					}
 				}).Return(nil)
 				guardian.InitLegacyGuardian(mockSQLStore, dashboardService, teamService)
@@ -535,10 +535,10 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 
 			setUpInner := func() {
 				dashboardService := dashboards.NewFakeDashboardService(t)
-				dashboardService.On("GetDashboardACLInfoList", mock.Anything, mock.AnythingOfType("*models.GetDashboardACLInfoListQuery")).Run(func(args mock.Arguments) {
-					q := args.Get(1).(*models.GetDashboardACLInfoListQuery)
-					q.Result = []*models.DashboardACLInfoDTO{
-						{OrgId: 1, DashboardId: 2, UserId: 1, Permission: models.PERMISSION_VIEW},
+				dashboardService.On("GetDashboardACLInfoList", mock.Anything, mock.AnythingOfType("*dashboards.GetDashboardACLInfoListQuery")).Run(func(args mock.Arguments) {
+					q := args.Get(1).(*dashboards.GetDashboardACLInfoListQuery)
+					q.Result = []*dashboards.DashboardACLInfoDTO{
+						{OrgID: 1, DashboardID: 2, UserID: 1, Permission: models.PERMISSION_VIEW},
 					}
 				}).Return(nil)
 				guardian.InitLegacyGuardian(mockSQLStore, dashboardService, teamService)
@@ -807,7 +807,7 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 		setUp := func() {
 			teamSvc := &teamtest.FakeService{}
 			dashSvc := dashboards.NewFakeDashboardService(t)
-			dashSvc.On("GetDashboardACLInfoList", mock.Anything, mock.AnythingOfType("*models.GetDashboardACLInfoListQuery")).Return(nil)
+			dashSvc.On("GetDashboardACLInfoList", mock.Anything, mock.AnythingOfType("*dashboards.GetDashboardACLInfoListQuery")).Return(nil)
 			dashSvc.On("GetDashboard", mock.Anything, mock.AnythingOfType("*dashboards.GetDashboardQuery")).Run(func(args mock.Arguments) {
 				q := args.Get(1).(*dashboards.GetDashboardQuery)
 				q.Result = &dashboards.Dashboard{
@@ -940,9 +940,9 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 			q := args.Get(1).(*dashboards.GetDashboardQuery)
 			q.Result = &dashboards.Dashboard{ID: 1, Data: dataValue}
 		}).Return(nil)
-		dashboardService.On("GetDashboardACLInfoList", mock.Anything, mock.AnythingOfType("*models.GetDashboardACLInfoListQuery")).Run(func(args mock.Arguments) {
-			q := args.Get(1).(*models.GetDashboardACLInfoListQuery)
-			q.Result = []*models.DashboardACLInfoDTO{{OrgId: testOrgID, DashboardId: 1, UserId: testUserID, Permission: models.PERMISSION_EDIT}}
+		dashboardService.On("GetDashboardACLInfoList", mock.Anything, mock.AnythingOfType("*dashboards.GetDashboardACLInfoListQuery")).Run(func(args mock.Arguments) {
+			q := args.Get(1).(*dashboards.GetDashboardACLInfoListQuery)
+			q.Result = []*dashboards.DashboardACLInfoDTO{{OrgID: testOrgID, DashboardID: 1, UserID: testUserID, Permission: models.PERMISSION_EDIT}}
 		}).Return(nil)
 		guardian.InitLegacyGuardian(mockSQLStore, dashboardService, teamService)
 

--- a/pkg/api/folder_permission.go
+++ b/pkg/api/folder_permission.go
@@ -48,23 +48,23 @@ func (hs *HTTPServer) GetFolderPermissionList(c *models.ReqContext) response.Res
 		return response.Error(500, "Failed to get folder permissions", err)
 	}
 
-	filteredACLs := make([]*models.DashboardACLInfoDTO, 0, len(acl))
+	filteredACLs := make([]*dashboards.DashboardACLInfoDTO, 0, len(acl))
 	for _, perm := range acl {
-		if perm.UserId > 0 && dtos.IsHiddenUser(perm.UserLogin, c.SignedInUser, hs.Cfg) {
+		if perm.UserID > 0 && dtos.IsHiddenUser(perm.UserLogin, c.SignedInUser, hs.Cfg) {
 			continue
 		}
 
-		perm.FolderId = folder.ID
-		perm.DashboardId = 0
+		perm.FolderID = folder.ID
+		perm.DashboardID = 0
 
-		perm.UserAvatarUrl = dtos.GetGravatarUrl(perm.UserEmail)
+		perm.UserAvatarURL = dtos.GetGravatarUrl(perm.UserEmail)
 
-		if perm.TeamId > 0 {
-			perm.TeamAvatarUrl = dtos.GetGravatarUrlWithDefault(perm.TeamEmail, perm.Team)
+		if perm.TeamID > 0 {
+			perm.TeamAvatarURL = dtos.GetGravatarUrlWithDefault(perm.TeamEmail, perm.Team)
 		}
 
 		if perm.Slug != "" {
-			perm.Url = dashboards.GetDashboardFolderURL(perm.IsFolder, perm.Uid, perm.Slug)
+			perm.URL = dashboards.GetDashboardFolderURL(perm.IsFolder, perm.UID, perm.Slug)
 		}
 
 		filteredACLs = append(filteredACLs, perm)
@@ -112,9 +112,9 @@ func (hs *HTTPServer) UpdateFolderPermissions(c *models.ReqContext) response.Res
 		return apierrors.ToFolderErrorResponse(dashboards.ErrFolderAccessDenied)
 	}
 
-	items := make([]*models.DashboardACL, 0, len(apiCmd.Items))
+	items := make([]*dashboards.DashboardACL, 0, len(apiCmd.Items))
 	for _, item := range apiCmd.Items {
-		items = append(items, &models.DashboardACL{
+		items = append(items, &dashboards.DashboardACL{
 			OrgID:       c.OrgID,
 			DashboardID: folder.ID,
 			UserID:      item.UserID,
@@ -198,5 +198,5 @@ type UpdateFolderPermissionsParams struct {
 // swagger:response getFolderPermissionListResponse
 type GetFolderPermissionsResponse struct {
 	// in: body
-	Body []*models.DashboardACLInfoDTO `json:"body"`
+	Body []*dashboards.DashboardACLInfoDTO `json:"body"`
 }

--- a/pkg/api/folder_permission_test.go
+++ b/pkg/api/folder_permission_test.go
@@ -122,12 +122,12 @@ func TestFolderPermissionAPIEndpoint(t *testing.T) {
 		guardian.MockDashboardGuardian(&guardian.FakeDashboardGuardian{
 			CanAdminValue:                    true,
 			CheckPermissionBeforeUpdateValue: true,
-			GetACLValue: []*models.DashboardACLInfoDTO{
-				{OrgId: 1, DashboardId: 1, UserId: 2, Permission: models.PERMISSION_VIEW},
-				{OrgId: 1, DashboardId: 1, UserId: 3, Permission: models.PERMISSION_EDIT},
-				{OrgId: 1, DashboardId: 1, UserId: 4, Permission: models.PERMISSION_ADMIN},
-				{OrgId: 1, DashboardId: 1, TeamId: 1, Permission: models.PERMISSION_VIEW},
-				{OrgId: 1, DashboardId: 1, TeamId: 2, Permission: models.PERMISSION_ADMIN},
+			GetACLValue: []*dashboards.DashboardACLInfoDTO{
+				{OrgID: 1, DashboardID: 1, UserID: 2, Permission: models.PERMISSION_VIEW},
+				{OrgID: 1, DashboardID: 1, UserID: 3, Permission: models.PERMISSION_EDIT},
+				{OrgID: 1, DashboardID: 1, UserID: 4, Permission: models.PERMISSION_ADMIN},
+				{OrgID: 1, DashboardID: 1, TeamID: 1, Permission: models.PERMISSION_VIEW},
+				{OrgID: 1, DashboardID: 1, TeamID: 2, Permission: models.PERMISSION_ADMIN},
 			},
 		})
 
@@ -139,12 +139,12 @@ func TestFolderPermissionAPIEndpoint(t *testing.T) {
 			callGetFolderPermissions(sc, hs)
 			assert.Equal(t, 200, sc.resp.Code)
 
-			var resp []*models.DashboardACLInfoDTO
+			var resp []*dashboards.DashboardACLInfoDTO
 			err := json.Unmarshal(sc.resp.Body.Bytes(), &resp)
 			require.NoError(t, err)
 
 			assert.Len(t, resp, 5)
-			assert.Equal(t, int64(2), resp[0].UserId)
+			assert.Equal(t, int64(2), resp[0].UserID)
 			assert.Equal(t, models.PERMISSION_VIEW, resp[0].Permission)
 		}, mockSQLStore)
 
@@ -286,24 +286,24 @@ func TestFolderPermissionAPIEndpoint(t *testing.T) {
 		guardian.MockDashboardGuardian(&guardian.FakeDashboardGuardian{
 			CanAdminValue:                    true,
 			CheckPermissionBeforeUpdateValue: true,
-			GetACLValue: []*models.DashboardACLInfoDTO{
-				{OrgId: 1, DashboardId: 1, UserId: 2, UserLogin: "hiddenUser", Permission: models.PERMISSION_VIEW},
-				{OrgId: 1, DashboardId: 1, UserId: 3, UserLogin: testUserLogin, Permission: models.PERMISSION_EDIT},
-				{OrgId: 1, DashboardId: 1, UserId: 4, UserLogin: "user_1", Permission: models.PERMISSION_ADMIN},
+			GetACLValue: []*dashboards.DashboardACLInfoDTO{
+				{OrgID: 1, DashboardID: 1, UserID: 2, UserLogin: "hiddenUser", Permission: models.PERMISSION_VIEW},
+				{OrgID: 1, DashboardID: 1, UserID: 3, UserLogin: testUserLogin, Permission: models.PERMISSION_EDIT},
+				{OrgID: 1, DashboardID: 1, UserID: 4, UserLogin: "user_1", Permission: models.PERMISSION_ADMIN},
 			},
-			GetHiddenACLValue: []*models.DashboardACL{
+			GetHiddenACLValue: []*dashboards.DashboardACL{
 				{OrgID: 1, DashboardID: 1, UserID: 2, Permission: models.PERMISSION_VIEW},
 			},
 		})
 
-		var gotItems []*models.DashboardACL
+		var gotItems []*dashboards.DashboardACL
 
 		folderService.ExpectedFolder = &folder.Folder{ID: 1, UID: "uid", Title: "Folder"}
 		dashboardStore.On("UpdateDashboardACL", mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
-			gotItems = args.Get(2).([]*models.DashboardACL)
+			gotItems = args.Get(2).([]*dashboards.DashboardACL)
 		}).Return(nil).Once()
 
-		var resp []*models.DashboardACLInfoDTO
+		var resp []*dashboards.DashboardACLInfoDTO
 		mockSQLStore := dbtest.NewFakeDB()
 		loggedInUserScenarioWithRole(t, "When calling GET on", "GET", "/api/folders/uid/permissions", "/api/folders/:uid/permissions", org.RoleAdmin, func(sc *scenarioContext) {
 			callGetFolderPermissions(sc, hs)
@@ -313,9 +313,9 @@ func TestFolderPermissionAPIEndpoint(t *testing.T) {
 			require.NoError(t, err)
 
 			assert.Len(t, resp, 2)
-			assert.Equal(t, int64(3), resp[0].UserId)
+			assert.Equal(t, int64(3), resp[0].UserID)
 			assert.Equal(t, models.PERMISSION_EDIT, resp[0].Permission)
-			assert.Equal(t, int64(4), resp[1].UserId)
+			assert.Equal(t, int64(4), resp[1].UserID)
 			assert.Equal(t, models.PERMISSION_ADMIN, resp[1].Permission)
 		}, mockSQLStore)
 
@@ -326,7 +326,7 @@ func TestFolderPermissionAPIEndpoint(t *testing.T) {
 		}
 		for _, acl := range resp {
 			cmd.Items = append(cmd.Items, dtos.DashboardACLUpdateItem{
-				UserID:     acl.UserId,
+				UserID:     acl.UserID,
 				Permission: acl.Permission,
 			})
 		}

--- a/pkg/api/folder_test.go
+++ b/pkg/api/folder_test.go
@@ -235,11 +235,11 @@ func createFolderScenario(t *testing.T, desc string, url string, routePattern st
 	cmd models.CreateFolderCommand, fn scenarioFunc) {
 	setUpRBACGuardian(t)
 	t.Run(fmt.Sprintf("%s %s", desc, url), func(t *testing.T) {
-		aclMockResp := []*models.DashboardACLInfoDTO{}
+		aclMockResp := []*dashboards.DashboardACLInfoDTO{}
 		teamSvc := &teamtest.FakeService{}
 		dashSvc := &dashboards.FakeDashboardService{}
-		dashSvc.On("GetDashboardACLInfoList", mock.Anything, mock.AnythingOfType("*models.GetDashboardACLInfoListQuery")).Run(func(args mock.Arguments) {
-			q := args.Get(1).(*models.GetDashboardACLInfoListQuery)
+		dashSvc.On("GetDashboardACLInfoList", mock.Anything, mock.AnythingOfType("*dashboards.GetDashboardACLInfoListQuery")).Run(func(args mock.Arguments) {
+			q := args.Get(1).(*dashboards.GetDashboardACLInfoListQuery)
 			q.Result = aclMockResp
 		}).Return(nil)
 		dashSvc.On("GetDashboard", mock.Anything, mock.AnythingOfType("*dashboards.GetDashboardQuery")).Run(func(args mock.Arguments) {

--- a/pkg/api/org_users_test.go
+++ b/pkg/api/org_users_test.go
@@ -219,7 +219,7 @@ func TestOrgUsersAPIEndpoint_LegacyAccessControl_FolderAdmin(t *testing.T) {
 	require.NotNil(t, folder)
 
 	// Grant our test Viewer with permission to admin the folder
-	acls := []*models.DashboardACL{
+	acls := []*dashboards.DashboardACL{
 		{
 			DashboardID: folder.ID,
 			OrgID:       testOrgID,

--- a/pkg/infra/db/sqlbuilder_test.go
+++ b/pkg/infra/db/sqlbuilder_test.go
@@ -259,7 +259,7 @@ func createDummyDashboard(t *testing.T, sqlStore *sqlstore.SQLStore, dashboardPr
 func createDummyACL(t *testing.T, sqlStore *sqlstore.SQLStore, dashboardPermission *DashboardPermission, search Search, dashboardID int64) int64 {
 	t.Helper()
 
-	acl := &models.DashboardACL{
+	acl := &dashboards.DashboardACL{
 		OrgID:       1,
 		Created:     time.Now(),
 		Updated:     time.Now(),
@@ -388,7 +388,7 @@ func insertTestDashboard(t *testing.T, sqlStore *sqlstore.SQLStore, title string
 }
 
 // TODO: Use FakeDashboardStore when org has its own service
-func updateDashboardACL(t *testing.T, sqlStore *sqlstore.SQLStore, dashboardID int64, items ...*models.DashboardACL) error {
+func updateDashboardACL(t *testing.T, sqlStore *sqlstore.SQLStore, dashboardID int64, items ...*dashboards.DashboardACL) error {
 	t.Helper()
 
 	err := sqlStore.WithDbSession(context.Background(), func(sess *Session) error {

--- a/pkg/models/dashboard_acl.go
+++ b/pkg/models/dashboard_acl.go
@@ -2,9 +2,6 @@ package models
 
 import (
 	"errors"
-	"time"
-
-	"github.com/grafana/grafana/pkg/services/org"
 )
 
 type PermissionType int
@@ -33,76 +30,3 @@ var (
 	ErrPermissionsWithRoleNotAllowed        = errors.New("permissions cannot have both a user and team")
 	ErrPermissionsWithUserAndTeamNotAllowed = errors.New("team and user permissions cannot have an associated role")
 )
-
-// Dashboard ACL model
-type DashboardACL struct {
-	// nolint:stylecheck
-	Id          int64
-	OrgID       int64 `xorm:"org_id"`
-	DashboardID int64 `xorm:"dashboard_id"`
-
-	UserID     int64         `xorm:"user_id"`
-	TeamID     int64         `xorm:"team_id"`
-	Role       *org.RoleType // pointer to be nullable
-	Permission PermissionType
-
-	Created time.Time
-	Updated time.Time
-}
-
-type DashboardACLInfoDTO struct {
-	OrgId       int64 `json:"-"`
-	DashboardId int64 `json:"dashboardId,omitempty"`
-	FolderId    int64 `json:"folderId,omitempty"`
-
-	Created time.Time `json:"created"`
-	Updated time.Time `json:"updated"`
-
-	UserId         int64          `json:"userId"`
-	UserLogin      string         `json:"userLogin"`
-	UserEmail      string         `json:"userEmail"`
-	UserAvatarUrl  string         `json:"userAvatarUrl"`
-	TeamId         int64          `json:"teamId"`
-	TeamEmail      string         `json:"teamEmail"`
-	TeamAvatarUrl  string         `json:"teamAvatarUrl"`
-	Team           string         `json:"team"`
-	Role           *org.RoleType  `json:"role,omitempty"`
-	Permission     PermissionType `json:"permission"`
-	PermissionName string         `json:"permissionName"`
-	Uid            string         `json:"uid"`
-	Title          string         `json:"title"`
-	Slug           string         `json:"slug"`
-	IsFolder       bool           `json:"isFolder"`
-	Url            string         `json:"url"`
-	Inherited      bool           `json:"inherited"`
-}
-
-func (dto *DashboardACLInfoDTO) hasSameRoleAs(other *DashboardACLInfoDTO) bool {
-	if dto.Role == nil || other.Role == nil {
-		return false
-	}
-
-	return dto.UserId <= 0 && dto.TeamId <= 0 && dto.UserId == other.UserId && dto.TeamId == other.TeamId && *dto.Role == *other.Role
-}
-
-func (dto *DashboardACLInfoDTO) hasSameUserAs(other *DashboardACLInfoDTO) bool {
-	return dto.UserId > 0 && dto.UserId == other.UserId
-}
-
-func (dto *DashboardACLInfoDTO) hasSameTeamAs(other *DashboardACLInfoDTO) bool {
-	return dto.TeamId > 0 && dto.TeamId == other.TeamId
-}
-
-// IsDuplicateOf returns true if other item has same role, same user or same team
-func (dto *DashboardACLInfoDTO) IsDuplicateOf(other *DashboardACLInfoDTO) bool {
-	return dto.hasSameRoleAs(other) || dto.hasSameUserAs(other) || dto.hasSameTeamAs(other)
-}
-
-// QUERIES
-type GetDashboardACLInfoListQuery struct {
-	DashboardID int64
-	OrgID       int64
-	Result      []*DashboardACLInfoDTO
-}
-
-func (p DashboardACL) TableName() string { return "dashboard_acl" }

--- a/pkg/services/dashboards/dashboard.go
+++ b/pkg/services/dashboards/dashboard.go
@@ -16,7 +16,7 @@ type DashboardService interface {
 	DeleteDashboard(ctx context.Context, dashboardId int64, orgId int64) error
 	FindDashboards(ctx context.Context, query *models.FindPersistedDashboardsQuery) ([]DashboardSearchProjection, error)
 	GetDashboard(ctx context.Context, query *GetDashboardQuery) error
-	GetDashboardACLInfoList(ctx context.Context, query *models.GetDashboardACLInfoListQuery) error
+	GetDashboardACLInfoList(ctx context.Context, query *GetDashboardACLInfoListQuery) error
 	GetDashboards(ctx context.Context, query *GetDashboardsQuery) error
 	GetDashboardTags(ctx context.Context, query *GetDashboardTagsQuery) error
 	GetDashboardUIDByID(ctx context.Context, query *GetDashboardRefByIDQuery) error
@@ -26,7 +26,7 @@ type DashboardService interface {
 	MakeUserAdmin(ctx context.Context, orgID int64, userID, dashboardID int64, setViewAndEditPermissions bool) error
 	SaveDashboard(ctx context.Context, dto *SaveDashboardDTO, allowUiUpdate bool) (*Dashboard, error)
 	SearchDashboards(ctx context.Context, query *models.FindPersistedDashboardsQuery) error
-	UpdateDashboardACL(ctx context.Context, uid int64, items []*models.DashboardACL) error
+	UpdateDashboardACL(ctx context.Context, uid int64, items []*DashboardACL) error
 	DeleteACLByUser(ctx context.Context, userID int64) error
 	CountDashboardsInFolder(ctx context.Context, query *CountDashboardsInFolderQuery) (int64, error)
 }
@@ -58,7 +58,7 @@ type Store interface {
 	DeleteOrphanedProvisionedDashboards(ctx context.Context, cmd *DeleteOrphanedProvisionedDashboardsCommand) error
 	FindDashboards(ctx context.Context, query *models.FindPersistedDashboardsQuery) ([]DashboardSearchProjection, error)
 	GetDashboard(ctx context.Context, query *GetDashboardQuery) (*Dashboard, error)
-	GetDashboardACLInfoList(ctx context.Context, query *models.GetDashboardACLInfoListQuery) error
+	GetDashboardACLInfoList(ctx context.Context, query *GetDashboardACLInfoListQuery) error
 	GetDashboardUIDByID(ctx context.Context, query *GetDashboardRefByIDQuery) error
 	GetDashboards(ctx context.Context, query *GetDashboardsQuery) error
 	// GetDashboardsByPluginID retrieves dashboards identified by plugin.
@@ -74,7 +74,7 @@ type Store interface {
 	SaveDashboard(ctx context.Context, cmd SaveDashboardCommand) (*Dashboard, error)
 	SaveProvisionedDashboard(ctx context.Context, cmd SaveDashboardCommand, provisioning *DashboardProvisioning) (*Dashboard, error)
 	UnprovisionDashboard(ctx context.Context, id int64) error
-	UpdateDashboardACL(ctx context.Context, uid int64, items []*models.DashboardACL) error
+	UpdateDashboardACL(ctx context.Context, uid int64, items []*DashboardACL) error
 	// ValidateDashboardBeforeSave validates a dashboard before save.
 	ValidateDashboardBeforeSave(ctx context.Context, dashboard *Dashboard, overwrite bool) (bool, error)
 	DeleteACLByUser(context.Context, int64) error

--- a/pkg/services/dashboards/dashboard_service_mock.go
+++ b/pkg/services/dashboards/dashboard_service_mock.go
@@ -124,11 +124,11 @@ func (_m *FakeDashboardService) GetDashboard(ctx context.Context, query *GetDash
 }
 
 // GetDashboardACLInfoList provides a mock function with given fields: ctx, query
-func (_m *FakeDashboardService) GetDashboardACLInfoList(ctx context.Context, query *models.GetDashboardACLInfoListQuery) error {
+func (_m *FakeDashboardService) GetDashboardACLInfoList(ctx context.Context, query *GetDashboardACLInfoListQuery) error {
 	ret := _m.Called(ctx, query)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, *models.GetDashboardACLInfoListQuery) error); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, *GetDashboardACLInfoListQuery) error); ok {
 		r0 = rf(ctx, query)
 	} else {
 		r0 = ret.Error(0)
@@ -282,11 +282,11 @@ func (_m *FakeDashboardService) SearchDashboards(ctx context.Context, query *mod
 }
 
 // UpdateDashboardACL provides a mock function with given fields: ctx, uid, items
-func (_m *FakeDashboardService) UpdateDashboardACL(ctx context.Context, uid int64, items []*models.DashboardACL) error {
+func (_m *FakeDashboardService) UpdateDashboardACL(ctx context.Context, uid int64, items []*DashboardACL) error {
 	ret := _m.Called(ctx, uid, items)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, int64, []*models.DashboardACL) error); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, int64, []*DashboardACL) error); ok {
 		r0 = rf(ctx, uid, items)
 	} else {
 		r0 = ret.Error(0)

--- a/pkg/services/dashboards/database/acl.go
+++ b/pkg/services/dashboards/database/acl.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/org"
 )
 
@@ -13,9 +14,9 @@ import (
 // 1) Permissions for the dashboard
 // 2) permissions for its parent folder
 // 3) if no specific permissions have been set for the dashboard or its parent folder then get the default permissions
-func (d *DashboardStore) GetDashboardACLInfoList(ctx context.Context, query *models.GetDashboardACLInfoListQuery) error {
+func (d *DashboardStore) GetDashboardACLInfoList(ctx context.Context, query *dashboards.GetDashboardACLInfoListQuery) error {
 	outerErr := d.store.WithDbSession(ctx, func(dbSession *db.Session) error {
-		query.Result = make([]*models.DashboardACLInfoDTO, 0)
+		query.Result = make([]*dashboards.DashboardACLInfoDTO, 0)
 		falseStr := d.store.GetDialect().BooleanStr(false)
 
 		if query.DashboardID == 0 {

--- a/pkg/services/dashboards/database/acl_test.go
+++ b/pkg/services/dashboards/database/acl_test.go
@@ -42,7 +42,7 @@ func TestIntegrationDashboardACLDataAccess(t *testing.T) {
 
 	t.Run("Dashboard permission with userId and teamId set to 0", func(t *testing.T) {
 		setup(t)
-		err := updateDashboardACL(t, dashboardStore, savedFolder.ID, models.DashboardACL{
+		err := updateDashboardACL(t, dashboardStore, savedFolder.ID, dashboards.DashboardACL{
 			OrgID:       1,
 			DashboardID: savedFolder.ID,
 			Permission:  models.PERMISSION_EDIT,
@@ -52,34 +52,34 @@ func TestIntegrationDashboardACLDataAccess(t *testing.T) {
 
 	t.Run("Folder acl should include default acl", func(t *testing.T) {
 		setup(t)
-		query := models.GetDashboardACLInfoListQuery{DashboardID: savedFolder.ID, OrgID: 1}
+		query := dashboards.GetDashboardACLInfoListQuery{DashboardID: savedFolder.ID, OrgID: 1}
 
 		err := dashboardStore.GetDashboardACLInfoList(context.Background(), &query)
 		require.Nil(t, err)
 
 		require.Equal(t, 2, len(query.Result))
 		defaultPermissionsId := int64(-1)
-		require.Equal(t, defaultPermissionsId, query.Result[0].DashboardId)
+		require.Equal(t, defaultPermissionsId, query.Result[0].DashboardID)
 		require.Equal(t, org.RoleViewer, *query.Result[0].Role)
 		require.False(t, query.Result[0].Inherited)
-		require.Equal(t, defaultPermissionsId, query.Result[1].DashboardId)
+		require.Equal(t, defaultPermissionsId, query.Result[1].DashboardID)
 		require.Equal(t, org.RoleEditor, *query.Result[1].Role)
 		require.False(t, query.Result[1].Inherited)
 	})
 
 	t.Run("Dashboard acl should include acl for parent folder", func(t *testing.T) {
 		setup(t)
-		query := models.GetDashboardACLInfoListQuery{DashboardID: childDash.ID, OrgID: 1}
+		query := dashboards.GetDashboardACLInfoListQuery{DashboardID: childDash.ID, OrgID: 1}
 
 		err := dashboardStore.GetDashboardACLInfoList(context.Background(), &query)
 		require.Nil(t, err)
 
 		require.Equal(t, 2, len(query.Result))
 		defaultPermissionsId := int64(-1)
-		require.Equal(t, defaultPermissionsId, query.Result[0].DashboardId)
+		require.Equal(t, defaultPermissionsId, query.Result[0].DashboardID)
 		require.Equal(t, org.RoleViewer, *query.Result[0].Role)
 		require.True(t, query.Result[0].Inherited)
-		require.Equal(t, defaultPermissionsId, query.Result[1].DashboardId)
+		require.Equal(t, defaultPermissionsId, query.Result[1].DashboardID)
 		require.Equal(t, org.RoleEditor, *query.Result[1].Role)
 		require.True(t, query.Result[1].Inherited)
 	})
@@ -89,7 +89,7 @@ func TestIntegrationDashboardACLDataAccess(t *testing.T) {
 		err := dashboardStore.UpdateDashboardACL(context.Background(), savedFolder.ID, nil)
 		require.Nil(t, err)
 
-		query := models.GetDashboardACLInfoListQuery{DashboardID: childDash.ID, OrgID: 1}
+		query := dashboards.GetDashboardACLInfoListQuery{DashboardID: childDash.ID, OrgID: 1}
 		err = dashboardStore.GetDashboardACLInfoList(context.Background(), &query)
 		require.Nil(t, err)
 
@@ -99,7 +99,7 @@ func TestIntegrationDashboardACLDataAccess(t *testing.T) {
 	t.Run("Given a dashboard folder and a user", func(t *testing.T) {
 		t.Run("Given dashboard folder permission", func(t *testing.T) {
 			setup(t)
-			err := updateDashboardACL(t, dashboardStore, savedFolder.ID, models.DashboardACL{
+			err := updateDashboardACL(t, dashboardStore, savedFolder.ID, dashboards.DashboardACL{
 				OrgID:       1,
 				UserID:      currentUser.ID,
 				DashboardID: savedFolder.ID,
@@ -108,17 +108,17 @@ func TestIntegrationDashboardACLDataAccess(t *testing.T) {
 			require.Nil(t, err)
 
 			t.Run("When reading dashboard acl should include acl for parent folder", func(t *testing.T) {
-				query := models.GetDashboardACLInfoListQuery{DashboardID: childDash.ID, OrgID: 1}
+				query := dashboards.GetDashboardACLInfoListQuery{DashboardID: childDash.ID, OrgID: 1}
 
 				err := dashboardStore.GetDashboardACLInfoList(context.Background(), &query)
 				require.Nil(t, err)
 
 				require.Equal(t, 1, len(query.Result))
-				require.Equal(t, savedFolder.ID, query.Result[0].DashboardId)
+				require.Equal(t, savedFolder.ID, query.Result[0].DashboardID)
 			})
 
 			t.Run("Given child dashboard permission", func(t *testing.T) {
-				err := updateDashboardACL(t, dashboardStore, childDash.ID, models.DashboardACL{
+				err := updateDashboardACL(t, dashboardStore, childDash.ID, dashboards.DashboardACL{
 					OrgID:       1,
 					UserID:      currentUser.ID,
 					DashboardID: childDash.ID,
@@ -127,15 +127,15 @@ func TestIntegrationDashboardACLDataAccess(t *testing.T) {
 				require.Nil(t, err)
 
 				t.Run("When reading dashboard acl should include acl for parent folder and child", func(t *testing.T) {
-					query := models.GetDashboardACLInfoListQuery{OrgID: 1, DashboardID: childDash.ID}
+					query := dashboards.GetDashboardACLInfoListQuery{OrgID: 1, DashboardID: childDash.ID}
 
 					err := dashboardStore.GetDashboardACLInfoList(context.Background(), &query)
 					require.Nil(t, err)
 
 					require.Equal(t, 2, len(query.Result))
-					require.Equal(t, savedFolder.ID, query.Result[0].DashboardId)
+					require.Equal(t, savedFolder.ID, query.Result[0].DashboardID)
 					require.True(t, query.Result[0].Inherited)
-					require.Equal(t, childDash.ID, query.Result[1].DashboardId)
+					require.Equal(t, childDash.ID, query.Result[1].DashboardID)
 					require.False(t, query.Result[1].Inherited)
 				})
 			})
@@ -143,7 +143,7 @@ func TestIntegrationDashboardACLDataAccess(t *testing.T) {
 
 		t.Run("Reading dashboard acl should include default acl for parent folder and the child acl", func(t *testing.T) {
 			setup(t)
-			err := updateDashboardACL(t, dashboardStore, childDash.ID, models.DashboardACL{
+			err := updateDashboardACL(t, dashboardStore, childDash.ID, dashboards.DashboardACL{
 				OrgID:       1,
 				UserID:      currentUser.ID,
 				DashboardID: childDash.ID,
@@ -151,26 +151,26 @@ func TestIntegrationDashboardACLDataAccess(t *testing.T) {
 			})
 			require.Nil(t, err)
 
-			query := models.GetDashboardACLInfoListQuery{OrgID: 1, DashboardID: childDash.ID}
+			query := dashboards.GetDashboardACLInfoListQuery{OrgID: 1, DashboardID: childDash.ID}
 
 			err = dashboardStore.GetDashboardACLInfoList(context.Background(), &query)
 			require.Nil(t, err)
 
 			defaultPermissionsId := int64(-1)
 			require.Equal(t, 3, len(query.Result))
-			require.Equal(t, defaultPermissionsId, query.Result[0].DashboardId)
+			require.Equal(t, defaultPermissionsId, query.Result[0].DashboardID)
 			require.Equal(t, org.RoleViewer, *query.Result[0].Role)
 			require.True(t, query.Result[0].Inherited)
-			require.Equal(t, defaultPermissionsId, query.Result[1].DashboardId)
+			require.Equal(t, defaultPermissionsId, query.Result[1].DashboardID)
 			require.Equal(t, org.RoleEditor, *query.Result[1].Role)
 			require.True(t, query.Result[1].Inherited)
-			require.Equal(t, childDash.ID, query.Result[2].DashboardId)
+			require.Equal(t, childDash.ID, query.Result[2].DashboardID)
 			require.False(t, query.Result[2].Inherited)
 		})
 
 		t.Run("Add and delete dashboard permission", func(t *testing.T) {
 			setup(t)
-			err := updateDashboardACL(t, dashboardStore, savedFolder.ID, models.DashboardACL{
+			err := updateDashboardACL(t, dashboardStore, savedFolder.ID, dashboards.DashboardACL{
 				OrgID:       1,
 				UserID:      currentUser.ID,
 				DashboardID: savedFolder.ID,
@@ -178,21 +178,21 @@ func TestIntegrationDashboardACLDataAccess(t *testing.T) {
 			})
 			require.Nil(t, err)
 
-			q1 := &models.GetDashboardACLInfoListQuery{DashboardID: savedFolder.ID, OrgID: 1}
+			q1 := &dashboards.GetDashboardACLInfoListQuery{DashboardID: savedFolder.ID, OrgID: 1}
 			err = dashboardStore.GetDashboardACLInfoList(context.Background(), q1)
 			require.Nil(t, err)
 
-			require.Equal(t, savedFolder.ID, q1.Result[0].DashboardId)
+			require.Equal(t, savedFolder.ID, q1.Result[0].DashboardID)
 			require.Equal(t, models.PERMISSION_EDIT, q1.Result[0].Permission)
 			require.Equal(t, "Edit", q1.Result[0].PermissionName)
-			require.Equal(t, currentUser.ID, q1.Result[0].UserId)
+			require.Equal(t, currentUser.ID, q1.Result[0].UserID)
 			require.Equal(t, currentUser.Login, q1.Result[0].UserLogin)
 			require.Equal(t, currentUser.Email, q1.Result[0].UserEmail)
 
 			err = updateDashboardACL(t, dashboardStore, savedFolder.ID)
 			require.Nil(t, err)
 
-			q3 := &models.GetDashboardACLInfoListQuery{DashboardID: savedFolder.ID, OrgID: 1}
+			q3 := &dashboards.GetDashboardACLInfoListQuery{DashboardID: savedFolder.ID, OrgID: 1}
 			err = dashboardStore.GetDashboardACLInfoList(context.Background(), q3)
 			require.Nil(t, err)
 			require.Equal(t, 0, len(q3.Result))
@@ -204,7 +204,7 @@ func TestIntegrationDashboardACLDataAccess(t *testing.T) {
 			team1, err := teamSvc.CreateTeam("group1 name", "", 1)
 			require.Nil(t, err)
 
-			err = updateDashboardACL(t, dashboardStore, savedFolder.ID, models.DashboardACL{
+			err = updateDashboardACL(t, dashboardStore, savedFolder.ID, dashboards.DashboardACL{
 				OrgID:       1,
 				TeamID:      team1.ID,
 				DashboardID: savedFolder.ID,
@@ -212,12 +212,12 @@ func TestIntegrationDashboardACLDataAccess(t *testing.T) {
 			})
 			require.Nil(t, err)
 
-			q1 := &models.GetDashboardACLInfoListQuery{DashboardID: savedFolder.ID, OrgID: 1}
+			q1 := &dashboards.GetDashboardACLInfoListQuery{DashboardID: savedFolder.ID, OrgID: 1}
 			err = dashboardStore.GetDashboardACLInfoList(context.Background(), q1)
 			require.Nil(t, err)
-			require.Equal(t, savedFolder.ID, q1.Result[0].DashboardId)
+			require.Equal(t, savedFolder.ID, q1.Result[0].DashboardID)
 			require.Equal(t, models.PERMISSION_EDIT, q1.Result[0].Permission)
-			require.Equal(t, team1.ID, q1.Result[0].TeamId)
+			require.Equal(t, team1.ID, q1.Result[0].TeamID)
 		})
 
 		t.Run("Should be able to update an existing permission for a team", func(t *testing.T) {
@@ -225,7 +225,7 @@ func TestIntegrationDashboardACLDataAccess(t *testing.T) {
 			teamSvc := teamimpl.ProvideService(sqlStore, sqlStore.Cfg)
 			team1, err := teamSvc.CreateTeam("group1 name", "", 1)
 			require.Nil(t, err)
-			err = updateDashboardACL(t, dashboardStore, savedFolder.ID, models.DashboardACL{
+			err = updateDashboardACL(t, dashboardStore, savedFolder.ID, dashboards.DashboardACL{
 				OrgID:       1,
 				TeamID:      team1.ID,
 				DashboardID: savedFolder.ID,
@@ -233,13 +233,13 @@ func TestIntegrationDashboardACLDataAccess(t *testing.T) {
 			})
 			require.Nil(t, err)
 
-			q3 := &models.GetDashboardACLInfoListQuery{DashboardID: savedFolder.ID, OrgID: 1}
+			q3 := &dashboards.GetDashboardACLInfoListQuery{DashboardID: savedFolder.ID, OrgID: 1}
 			err = dashboardStore.GetDashboardACLInfoList(context.Background(), q3)
 			require.Nil(t, err)
 			require.Equal(t, 1, len(q3.Result))
-			require.Equal(t, savedFolder.ID, q3.Result[0].DashboardId)
+			require.Equal(t, savedFolder.ID, q3.Result[0].DashboardID)
 			require.Equal(t, models.PERMISSION_ADMIN, q3.Result[0].Permission)
-			require.Equal(t, team1.ID, q3.Result[0].TeamId)
+			require.Equal(t, team1.ID, q3.Result[0].TeamID)
 		})
 	})
 
@@ -248,17 +248,17 @@ func TestIntegrationDashboardACLDataAccess(t *testing.T) {
 		var rootFolderId int64 = 0
 		//sqlStore := db.InitTestDB(t)
 
-		query := models.GetDashboardACLInfoListQuery{DashboardID: rootFolderId, OrgID: 1}
+		query := dashboards.GetDashboardACLInfoListQuery{DashboardID: rootFolderId, OrgID: 1}
 
 		err := dashboardStore.GetDashboardACLInfoList(context.Background(), &query)
 		require.Nil(t, err)
 
 		require.Equal(t, 2, len(query.Result))
 		defaultPermissionsId := int64(-1)
-		require.Equal(t, defaultPermissionsId, query.Result[0].DashboardId)
+		require.Equal(t, defaultPermissionsId, query.Result[0].DashboardID)
 		require.Equal(t, org.RoleViewer, *query.Result[0].Role)
 		require.False(t, query.Result[0].Inherited)
-		require.Equal(t, defaultPermissionsId, query.Result[1].DashboardId)
+		require.Equal(t, defaultPermissionsId, query.Result[1].DashboardID)
 		require.Equal(t, org.RoleEditor, *query.Result[1].Role)
 		require.False(t, query.Result[1].Inherited)
 	})

--- a/pkg/services/dashboards/database/database.go
+++ b/pkg/services/dashboards/database/database.go
@@ -227,7 +227,7 @@ func (d *DashboardStore) SaveDashboard(ctx context.Context, cmd dashboards.SaveD
 	return cmd.Result, err
 }
 
-func (d *DashboardStore) UpdateDashboardACL(ctx context.Context, dashboardID int64, items []*models.DashboardACL) error {
+func (d *DashboardStore) UpdateDashboardACL(ctx context.Context, dashboardID int64, items []*dashboards.DashboardACL) error {
 	return d.store.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
 		// delete existing items
 		_, err := sess.Exec("DELETE FROM dashboard_acl WHERE dashboard_id=?", dashboardID)

--- a/pkg/services/dashboards/database/database_folder_test.go
+++ b/pkg/services/dashboards/database/database_folder_test.go
@@ -65,7 +65,7 @@ func TestIntegrationDashboardFolderDataAccess(t *testing.T) {
 
 			t.Run("and acl is set for dashboard folder", func(t *testing.T) {
 				var otherUser int64 = 999
-				err := updateDashboardACL(t, dashboardStore, folder.ID, models.DashboardACL{
+				err := updateDashboardACL(t, dashboardStore, folder.ID, dashboards.DashboardACL{
 					DashboardID: folder.ID,
 					OrgID:       1,
 					UserID:      otherUser,
@@ -86,7 +86,7 @@ func TestIntegrationDashboardFolderDataAccess(t *testing.T) {
 				})
 
 				t.Run("when the user is given permission", func(t *testing.T) {
-					err := updateDashboardACL(t, dashboardStore, folder.ID, models.DashboardACL{
+					err := updateDashboardACL(t, dashboardStore, folder.ID, dashboards.DashboardACL{
 						DashboardID: folder.ID, OrgID: 1, UserID: currentUser.ID, Permission: models.PERMISSION_EDIT,
 					})
 					require.NoError(t, err)
@@ -129,7 +129,7 @@ func TestIntegrationDashboardFolderDataAccess(t *testing.T) {
 				var otherUser int64 = 999
 				err := updateDashboardACL(t, dashboardStore, folder.ID)
 				require.NoError(t, err)
-				err = updateDashboardACL(t, dashboardStore, childDash.ID, models.DashboardACL{
+				err = updateDashboardACL(t, dashboardStore, childDash.ID, dashboards.DashboardACL{
 					DashboardID: folder.ID, OrgID: 1, UserID: otherUser, Permission: models.PERMISSION_EDIT,
 				})
 				require.NoError(t, err)
@@ -145,7 +145,7 @@ func TestIntegrationDashboardFolderDataAccess(t *testing.T) {
 				})
 
 				t.Run("when the user is given permission to child", func(t *testing.T) {
-					err := updateDashboardACL(t, dashboardStore, childDash.ID, models.DashboardACL{
+					err := updateDashboardACL(t, dashboardStore, childDash.ID, dashboards.DashboardACL{
 						DashboardID: childDash.ID, OrgID: 1, UserID: currentUser.ID, Permission: models.PERMISSION_EDIT,
 					})
 					require.NoError(t, err)
@@ -224,7 +224,7 @@ func TestIntegrationDashboardFolderDataAccess(t *testing.T) {
 
 			t.Run("and acl is set for one dashboard folder", func(t *testing.T) {
 				const otherUser int64 = 999
-				err := updateDashboardACL(t, dashboardStore, folder1.ID, models.DashboardACL{
+				err := updateDashboardACL(t, dashboardStore, folder1.ID, dashboards.DashboardACL{
 					DashboardID: folder1.ID, OrgID: 1, UserID: otherUser, Permission: models.PERMISSION_EDIT,
 				})
 				require.NoError(t, err)
@@ -265,7 +265,7 @@ func TestIntegrationDashboardFolderDataAccess(t *testing.T) {
 				})
 
 				t.Run("and a dashboard with an acl is moved to the folder without an acl", func(t *testing.T) {
-					err := updateDashboardACL(t, dashboardStore, childDash1.ID, models.DashboardACL{
+					err := updateDashboardACL(t, dashboardStore, childDash1.ID, dashboards.DashboardACL{
 						DashboardID: childDash1.ID, OrgID: 1, UserID: otherUser, Permission: models.PERMISSION_EDIT,
 					})
 					require.NoError(t, err)
@@ -363,7 +363,7 @@ func TestIntegrationDashboardFolderDataAccess(t *testing.T) {
 				})
 
 				t.Run("Should have write access to one dashboard folder if default role changed to view for one folder", func(t *testing.T) {
-					err := updateDashboardACL(t, dashboardStore, folder1.ID, models.DashboardACL{
+					err := updateDashboardACL(t, dashboardStore, folder1.ID, dashboards.DashboardACL{
 						DashboardID: folder1.ID, OrgID: 1, UserID: editorUser.ID, Permission: models.PERMISSION_VIEW,
 					})
 					require.NoError(t, err)
@@ -409,7 +409,7 @@ func TestIntegrationDashboardFolderDataAccess(t *testing.T) {
 				})
 
 				t.Run("Should be able to get one dashboard folder if default role changed to edit for one folder", func(t *testing.T) {
-					err := updateDashboardACL(t, dashboardStore, folder1.ID, models.DashboardACL{
+					err := updateDashboardACL(t, dashboardStore, folder1.ID, dashboards.DashboardACL{
 						DashboardID: folder1.ID, OrgID: 1, UserID: viewerUser.ID, Permission: models.PERMISSION_EDIT,
 					})
 					require.NoError(t, err)
@@ -442,7 +442,7 @@ func TestIntegrationDashboardFolderDataAccess(t *testing.T) {
 				})
 
 				t.Run("and admin permission is given for user with org role viewer in one dashboard folder", func(t *testing.T) {
-					err := updateDashboardACL(t, dashboardStore, folder1.ID, models.DashboardACL{
+					err := updateDashboardACL(t, dashboardStore, folder1.ID, dashboards.DashboardACL{
 						DashboardID: folder1.ID, OrgID: 1, UserID: viewerUser.ID, Permission: models.PERMISSION_ADMIN,
 					})
 					require.NoError(t, err)
@@ -458,7 +458,7 @@ func TestIntegrationDashboardFolderDataAccess(t *testing.T) {
 				})
 
 				t.Run("and edit permission is given for user with org role viewer in one dashboard folder", func(t *testing.T) {
-					err := updateDashboardACL(t, dashboardStore, folder1.ID, models.DashboardACL{
+					err := updateDashboardACL(t, dashboardStore, folder1.ID, dashboards.DashboardACL{
 						DashboardID: folder1.ID, OrgID: 1, UserID: viewerUser.ID, Permission: models.PERMISSION_EDIT,
 					})
 					require.NoError(t, err)

--- a/pkg/services/dashboards/database/database_test.go
+++ b/pkg/services/dashboards/database/database_test.go
@@ -824,10 +824,10 @@ func insertTestDashboardForPlugin(t *testing.T, dashboardStore *DashboardStore, 
 }
 
 func updateDashboardACL(t *testing.T, dashboardStore *DashboardStore, dashboardID int64,
-	items ...models.DashboardACL) error {
+	items ...dashboards.DashboardACL) error {
 	t.Helper()
 
-	var itemPtrs []*models.DashboardACL
+	var itemPtrs []*dashboards.DashboardACL
 	for _, it := range items {
 		item := it
 		item.Created = time.Now()

--- a/pkg/services/dashboards/models.go
+++ b/pkg/services/dashboards/models.go
@@ -8,6 +8,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/slugify"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/folder"
+	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/quota"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
@@ -342,4 +343,81 @@ func FromDashboard(dash *Dashboard) *folder.Folder {
 		Updated:   dash.Updated,
 		UpdatedBy: dash.UpdatedBy,
 	}
+}
+
+//
+// DASHBOARD ACL
+//
+
+// Dashboard ACL model
+type DashboardACL struct {
+	// nolint:stylecheck
+	ID          int64 `xorm:"pk autoincr 'id'"`
+	OrgID       int64 `xorm:"org_id"`
+	DashboardID int64 `xorm:"dashboard_id"`
+
+	UserID     int64         `xorm:"user_id"`
+	TeamID     int64         `xorm:"team_id"`
+	Role       *org.RoleType // pointer to be nullable
+	Permission models.PermissionType
+
+	Created time.Time
+	Updated time.Time
+}
+
+func (p DashboardACL) TableName() string { return "dashboard_acl" }
+
+type DashboardACLInfoDTO struct {
+	OrgID       int64 `json:"-" xorm:"org_id"`
+	DashboardID int64 `json:"dashboardId,omitempty" xorm:"dashboard_id"`
+	FolderID    int64 `json:"folderId,omitempty" xorm:"folder_id"`
+
+	Created time.Time `json:"created"`
+	Updated time.Time `json:"updated"`
+
+	UserID         int64                 `json:"userId" xorm:"user_id"`
+	UserLogin      string                `json:"userLogin"`
+	UserEmail      string                `json:"userEmail"`
+	UserAvatarURL  string                `json:"userAvatarUrl" xorm:"user_avatar_url"`
+	TeamID         int64                 `json:"teamId" xorm:"team_id"`
+	TeamEmail      string                `json:"teamEmail"`
+	TeamAvatarURL  string                `json:"teamAvatarUrl" xorm:"team_avatar_url"`
+	Team           string                `json:"team"`
+	Role           *org.RoleType         `json:"role,omitempty"`
+	Permission     models.PermissionType `json:"permission"`
+	PermissionName string                `json:"permissionName"`
+	UID            string                `json:"uid" xorm:"uid"`
+	Title          string                `json:"title"`
+	Slug           string                `json:"slug"`
+	IsFolder       bool                  `json:"isFolder"`
+	URL            string                `json:"url" xorm:"url"`
+	Inherited      bool                  `json:"inherited"`
+}
+
+func (dto *DashboardACLInfoDTO) hasSameRoleAs(other *DashboardACLInfoDTO) bool {
+	if dto.Role == nil || other.Role == nil {
+		return false
+	}
+
+	return dto.UserID <= 0 && dto.TeamID <= 0 && dto.UserID == other.UserID && dto.TeamID == other.TeamID && *dto.Role == *other.Role
+}
+
+func (dto *DashboardACLInfoDTO) hasSameUserAs(other *DashboardACLInfoDTO) bool {
+	return dto.UserID > 0 && dto.UserID == other.UserID
+}
+
+func (dto *DashboardACLInfoDTO) hasSameTeamAs(other *DashboardACLInfoDTO) bool {
+	return dto.TeamID > 0 && dto.TeamID == other.TeamID
+}
+
+// IsDuplicateOf returns true if other item has same role, same user or same team
+func (dto *DashboardACLInfoDTO) IsDuplicateOf(other *DashboardACLInfoDTO) bool {
+	return dto.hasSameRoleAs(other) || dto.hasSameUserAs(other) || dto.hasSameTeamAs(other)
+}
+
+// QUERIES
+type GetDashboardACLInfoListQuery struct {
+	DashboardID int64
+	OrgID       int64
+	Result      []*DashboardACLInfoDTO
 }

--- a/pkg/services/dashboards/models.go
+++ b/pkg/services/dashboards/models.go
@@ -351,7 +351,6 @@ func FromDashboard(dash *Dashboard) *folder.Folder {
 
 // Dashboard ACL model
 type DashboardACL struct {
-	// nolint:stylecheck
 	ID          int64 `xorm:"pk autoincr 'id'"`
 	OrgID       int64 `xorm:"org_id"`
 	DashboardID int64 `xorm:"dashboard_id"`

--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -183,7 +183,7 @@ func (dr *DashboardServiceImpl) BuildSaveDashboardCommand(ctx context.Context, d
 	return cmd, nil
 }
 
-func (dr *DashboardServiceImpl) UpdateDashboardACL(ctx context.Context, uid int64, items []*models.DashboardACL) error {
+func (dr *DashboardServiceImpl) UpdateDashboardACL(ctx context.Context, uid int64, items []*dashboards.DashboardACL) error {
 	return dr.dashboardStore.UpdateDashboardACL(ctx, uid, items)
 }
 
@@ -390,7 +390,7 @@ func (dr *DashboardServiceImpl) MakeUserAdmin(ctx context.Context, orgID int64, 
 	rtEditor := org.RoleEditor
 	rtViewer := org.RoleViewer
 
-	items := []*models.DashboardACL{
+	items := []*dashboards.DashboardACL{
 		{
 			OrgID:       orgID,
 			DashboardID: dashboardID,
@@ -403,7 +403,7 @@ func (dr *DashboardServiceImpl) MakeUserAdmin(ctx context.Context, orgID int64, 
 
 	if setViewAndEditPermissions {
 		items = append(items,
-			&models.DashboardACL{
+			&dashboards.DashboardACL{
 				OrgID:       orgID,
 				DashboardID: dashboardID,
 				Role:        &rtEditor,
@@ -411,7 +411,7 @@ func (dr *DashboardServiceImpl) MakeUserAdmin(ctx context.Context, orgID int64, 
 				Created:     time.Now(),
 				Updated:     time.Now(),
 			},
-			&models.DashboardACL{
+			&dashboards.DashboardACL{
 				OrgID:       orgID,
 				DashboardID: dashboardID,
 				Role:        &rtViewer,
@@ -597,7 +597,7 @@ func makeQueryResult(query *models.FindPersistedDashboardsQuery, res []dashboard
 	}
 }
 
-func (dr *DashboardServiceImpl) GetDashboardACLInfoList(ctx context.Context, query *models.GetDashboardACLInfoListQuery) error {
+func (dr *DashboardServiceImpl) GetDashboardACLInfoList(ctx context.Context, query *dashboards.GetDashboardACLInfoListQuery) error {
 	return dr.dashboardStore.GetDashboardACLInfoList(ctx, query)
 }
 

--- a/pkg/services/dashboards/service/dashboard_service_integration_test.go
+++ b/pkg/services/dashboards/service/dashboard_service_integration_test.go
@@ -109,7 +109,7 @@ func TestIntegrationIntegratedDashboardService(t *testing.T) {
 					assert.Equal(t, dashboards.ErrDashboardUpdateAccessDenied, err)
 
 					assert.Equal(t, "", sc.dashboardGuardianMock.DashUID)
-					assert.Equal(t, cmd.OrgID, sc.dashboardGuardianMock.OrgId)
+					assert.Equal(t, cmd.OrgID, sc.dashboardGuardianMock.OrgID)
 					assert.Equal(t, cmd.UserID, sc.dashboardGuardianMock.User.UserID)
 				})
 
@@ -129,7 +129,7 @@ func TestIntegrationIntegratedDashboardService(t *testing.T) {
 					require.Equal(t, dashboards.ErrDashboardUpdateAccessDenied, err)
 
 					assert.Equal(t, sc.otherSavedFolder.ID, sc.dashboardGuardianMock.DashID)
-					assert.Equal(t, cmd.OrgID, sc.dashboardGuardianMock.OrgId)
+					assert.Equal(t, cmd.OrgID, sc.dashboardGuardianMock.OrgID)
 					assert.Equal(t, cmd.UserID, sc.dashboardGuardianMock.User.UserID)
 				})
 
@@ -149,7 +149,7 @@ func TestIntegrationIntegratedDashboardService(t *testing.T) {
 					require.Equal(t, dashboards.ErrDashboardUpdateAccessDenied, err)
 
 					assert.Equal(t, sc.savedDashInFolder.UID, sc.dashboardGuardianMock.DashUID)
-					assert.Equal(t, cmd.OrgID, sc.dashboardGuardianMock.OrgId)
+					assert.Equal(t, cmd.OrgID, sc.dashboardGuardianMock.OrgID)
 					assert.Equal(t, cmd.UserID, sc.dashboardGuardianMock.User.UserID)
 				})
 
@@ -170,7 +170,7 @@ func TestIntegrationIntegratedDashboardService(t *testing.T) {
 					require.Equal(t, dashboards.ErrDashboardUpdateAccessDenied, err)
 
 					assert.Equal(t, sc.savedDashInFolder.UID, sc.dashboardGuardianMock.DashUID)
-					assert.Equal(t, cmd.OrgID, sc.dashboardGuardianMock.OrgId)
+					assert.Equal(t, cmd.OrgID, sc.dashboardGuardianMock.OrgID)
 					assert.Equal(t, cmd.UserID, sc.dashboardGuardianMock.User.UserID)
 				})
 
@@ -191,7 +191,7 @@ func TestIntegrationIntegratedDashboardService(t *testing.T) {
 					assert.Equal(t, dashboards.ErrDashboardUpdateAccessDenied, err)
 
 					assert.Equal(t, sc.savedDashInGeneralFolder.UID, sc.dashboardGuardianMock.DashUID)
-					assert.Equal(t, cmd.OrgID, sc.dashboardGuardianMock.OrgId)
+					assert.Equal(t, cmd.OrgID, sc.dashboardGuardianMock.OrgID)
 					assert.Equal(t, cmd.UserID, sc.dashboardGuardianMock.User.UserID)
 				})
 
@@ -212,7 +212,7 @@ func TestIntegrationIntegratedDashboardService(t *testing.T) {
 					require.Equal(t, dashboards.ErrDashboardUpdateAccessDenied, err)
 
 					assert.Equal(t, sc.savedDashInFolder.UID, sc.dashboardGuardianMock.DashUID)
-					assert.Equal(t, cmd.OrgID, sc.dashboardGuardianMock.OrgId)
+					assert.Equal(t, cmd.OrgID, sc.dashboardGuardianMock.OrgID)
 					assert.Equal(t, cmd.UserID, sc.dashboardGuardianMock.User.UserID)
 				})
 
@@ -233,7 +233,7 @@ func TestIntegrationIntegratedDashboardService(t *testing.T) {
 					require.Equal(t, dashboards.ErrDashboardUpdateAccessDenied, err)
 
 					assert.Equal(t, sc.savedDashInGeneralFolder.UID, sc.dashboardGuardianMock.DashUID)
-					assert.Equal(t, cmd.OrgID, sc.dashboardGuardianMock.OrgId)
+					assert.Equal(t, cmd.OrgID, sc.dashboardGuardianMock.OrgID)
 					assert.Equal(t, cmd.UserID, sc.dashboardGuardianMock.User.UserID)
 				})
 
@@ -254,7 +254,7 @@ func TestIntegrationIntegratedDashboardService(t *testing.T) {
 					assert.Equal(t, dashboards.ErrDashboardUpdateAccessDenied, err)
 
 					assert.Equal(t, sc.savedDashInFolder.UID, sc.dashboardGuardianMock.DashUID)
-					assert.Equal(t, cmd.OrgID, sc.dashboardGuardianMock.OrgId)
+					assert.Equal(t, cmd.OrgID, sc.dashboardGuardianMock.OrgID)
 					assert.Equal(t, cmd.UserID, sc.dashboardGuardianMock.User.UserID)
 				})
 
@@ -275,7 +275,7 @@ func TestIntegrationIntegratedDashboardService(t *testing.T) {
 					require.Equal(t, dashboards.ErrDashboardUpdateAccessDenied, err)
 
 					assert.Equal(t, sc.savedDashInGeneralFolder.UID, sc.dashboardGuardianMock.DashUID)
-					assert.Equal(t, cmd.OrgID, sc.dashboardGuardianMock.OrgId)
+					assert.Equal(t, cmd.OrgID, sc.dashboardGuardianMock.OrgID)
 					assert.Equal(t, cmd.UserID, sc.dashboardGuardianMock.User.UserID)
 				})
 
@@ -296,7 +296,7 @@ func TestIntegrationIntegratedDashboardService(t *testing.T) {
 					require.Equal(t, dashboards.ErrDashboardUpdateAccessDenied, err)
 
 					assert.Equal(t, sc.savedDashInFolder.UID, sc.dashboardGuardianMock.DashUID)
-					assert.Equal(t, cmd.OrgID, sc.dashboardGuardianMock.OrgId)
+					assert.Equal(t, cmd.OrgID, sc.dashboardGuardianMock.OrgID)
 					assert.Equal(t, cmd.UserID, sc.dashboardGuardianMock.User.UserID)
 				})
 		})

--- a/pkg/services/dashboards/service/dashboard_service_test.go
+++ b/pkg/services/dashboards/service/dashboard_service_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/appcontext"
 	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/guardian"
@@ -258,9 +257,9 @@ func TestDashboardService(t *testing.T) {
 
 	t.Run("When org user is deleted", func(t *testing.T) {
 		fakeStore := dashboards.FakeDashboardStore{}
-		fakeStore.On("GetDashboardACLInfoList", mock.Anything, mock.AnythingOfType("*models.GetDashboardACLInfoListQuery")).Return(nil)
+		fakeStore.On("GetDashboardACLInfoList", mock.Anything, mock.AnythingOfType("*dashboards.GetDashboardACLInfoListQuery")).Return(nil)
 		t.Run("Should remove dependent permissions for deleted org user", func(t *testing.T) {
-			permQuery := &models.GetDashboardACLInfoListQuery{DashboardID: 1, OrgID: 1, Result: nil}
+			permQuery := &dashboards.GetDashboardACLInfoListQuery{DashboardID: 1, OrgID: 1, Result: nil}
 
 			err := fakeStore.GetDashboardACLInfoList(context.Background(), permQuery)
 			require.NoError(t, err)
@@ -270,8 +269,8 @@ func TestDashboardService(t *testing.T) {
 
 		t.Run("Should not remove dashboard permissions for same user in another org", func(t *testing.T) {
 			fakeStore := dashboards.FakeDashboardStore{}
-			fakeStore.On("GetDashboardACLInfoList", mock.Anything, mock.AnythingOfType("*models.GetDashboardACLInfoListQuery")).Return(nil)
-			permQuery := &models.GetDashboardACLInfoListQuery{DashboardID: 2, OrgID: 3}
+			fakeStore.On("GetDashboardACLInfoList", mock.Anything, mock.AnythingOfType("*dashboards.GetDashboardACLInfoListQuery")).Return(nil)
+			permQuery := &dashboards.GetDashboardACLInfoListQuery{DashboardID: 2, OrgID: 3}
 
 			err := fakeStore.GetDashboardACLInfoList(context.Background(), permQuery)
 			require.NoError(t, err)

--- a/pkg/services/dashboards/store_mock.go
+++ b/pkg/services/dashboards/store_mock.go
@@ -151,11 +151,11 @@ func (_m *FakeDashboardStore) GetDashboard(ctx context.Context, query *GetDashbo
 }
 
 // GetDashboardACLInfoList provides a mock function with given fields: ctx, query
-func (_m *FakeDashboardStore) GetDashboardACLInfoList(ctx context.Context, query *models.GetDashboardACLInfoListQuery) error {
+func (_m *FakeDashboardStore) GetDashboardACLInfoList(ctx context.Context, query *GetDashboardACLInfoListQuery) error {
 	ret := _m.Called(ctx, query)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, *models.GetDashboardACLInfoListQuery) error); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, *GetDashboardACLInfoListQuery) error); ok {
 		r0 = rf(ctx, query)
 	} else {
 		r0 = ret.Error(0)
@@ -461,11 +461,11 @@ func (_m *FakeDashboardStore) UnprovisionDashboard(ctx context.Context, id int64
 }
 
 // UpdateDashboardACL provides a mock function with given fields: ctx, uid, items
-func (_m *FakeDashboardStore) UpdateDashboardACL(ctx context.Context, uid int64, items []*models.DashboardACL) error {
+func (_m *FakeDashboardStore) UpdateDashboardACL(ctx context.Context, uid int64, items []*DashboardACL) error {
 	ret := _m.Called(ctx, uid, items)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, int64, []*models.DashboardACL) error); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, int64, []*DashboardACL) error); ok {
 		r0 = rf(ctx, uid, items)
 	} else {
 		r0 = ret.Error(0)

--- a/pkg/services/folder/folderimpl/folder.go
+++ b/pkg/services/folder/folderimpl/folder.go
@@ -651,7 +651,7 @@ func (s *Service) MakeUserAdmin(ctx context.Context, orgID int64, userID, folder
 	rtEditor := org.RoleEditor
 	rtViewer := org.RoleViewer
 
-	items := []*models.DashboardACL{
+	items := []*dashboards.DashboardACL{
 		{
 			OrgID:       orgID,
 			DashboardID: folderID,
@@ -664,7 +664,7 @@ func (s *Service) MakeUserAdmin(ctx context.Context, orgID int64, userID, folder
 
 	if setViewAndEditPermissions {
 		items = append(items,
-			&models.DashboardACL{
+			&dashboards.DashboardACL{
 				OrgID:       orgID,
 				DashboardID: folderID,
 				Role:        &rtEditor,
@@ -672,7 +672,7 @@ func (s *Service) MakeUserAdmin(ctx context.Context, orgID int64, userID, folder
 				Created:     time.Now(),
 				Updated:     time.Now(),
 			},
-			&models.DashboardACL{
+			&dashboards.DashboardACL{
 				OrgID:       orgID,
 				DashboardID: folderID,
 				Role:        &rtViewer,

--- a/pkg/services/guardian/accesscontrol_guardian.go
+++ b/pkg/services/guardian/accesscontrol_guardian.go
@@ -233,13 +233,13 @@ func (a *AccessControlDashboardGuardian) evaluate(evaluator accesscontrol.Evalua
 	return ok, err
 }
 
-func (a *AccessControlDashboardGuardian) CheckPermissionBeforeUpdate(permission models.PermissionType, updatePermissions []*models.DashboardACL) (bool, error) {
+func (a *AccessControlDashboardGuardian) CheckPermissionBeforeUpdate(permission models.PermissionType, updatePermissions []*dashboards.DashboardACL) (bool, error) {
 	// always true for access control
 	return true, nil
 }
 
 // GetACL translate access control permissions to dashboard acl info
-func (a *AccessControlDashboardGuardian) GetACL() ([]*models.DashboardACLInfoDTO, error) {
+func (a *AccessControlDashboardGuardian) GetACL() ([]*dashboards.DashboardACLInfoDTO, error) {
 	if a.dashboard == nil {
 		return nil, ErrGuardianGetDashboardFailure
 	}
@@ -256,7 +256,7 @@ func (a *AccessControlDashboardGuardian) GetACL() ([]*models.DashboardACLInfoDTO
 		return nil, err
 	}
 
-	acl := make([]*models.DashboardACLInfoDTO, 0, len(permissions))
+	acl := make([]*dashboards.DashboardACLInfoDTO, 0, len(permissions))
 	for _, p := range permissions {
 		if !p.IsManaged {
 			continue
@@ -268,26 +268,26 @@ func (a *AccessControlDashboardGuardian) GetACL() ([]*models.DashboardACLInfoDTO
 			role = &tmp
 		}
 
-		acl = append(acl, &models.DashboardACLInfoDTO{
-			OrgId:          a.dashboard.OrgID,
-			DashboardId:    a.dashboard.ID,
-			FolderId:       a.dashboard.FolderID,
+		acl = append(acl, &dashboards.DashboardACLInfoDTO{
+			OrgID:          a.dashboard.OrgID,
+			DashboardID:    a.dashboard.ID,
+			FolderID:       a.dashboard.FolderID,
 			Created:        p.Created,
 			Updated:        p.Updated,
-			UserId:         p.UserId,
+			UserID:         p.UserId,
 			UserLogin:      p.UserLogin,
 			UserEmail:      p.UserEmail,
-			TeamId:         p.TeamId,
+			TeamID:         p.TeamId,
 			TeamEmail:      p.TeamEmail,
 			Team:           p.Team,
 			Role:           role,
 			Permission:     permissionMap[svc.MapActions(p)],
 			PermissionName: permissionMap[svc.MapActions(p)].String(),
-			Uid:            a.dashboard.UID,
+			UID:            a.dashboard.UID,
 			Title:          a.dashboard.Title,
 			Slug:           a.dashboard.Slug,
 			IsFolder:       a.dashboard.IsFolder,
-			Url:            a.dashboard.GetURL(),
+			URL:            a.dashboard.GetURL(),
 			Inherited:      false,
 		})
 	}
@@ -295,12 +295,12 @@ func (a *AccessControlDashboardGuardian) GetACL() ([]*models.DashboardACLInfoDTO
 	return acl, nil
 }
 
-func (a *AccessControlDashboardGuardian) GetACLWithoutDuplicates() ([]*models.DashboardACLInfoDTO, error) {
+func (a *AccessControlDashboardGuardian) GetACLWithoutDuplicates() ([]*dashboards.DashboardACLInfoDTO, error) {
 	return a.GetACL()
 }
 
-func (a *AccessControlDashboardGuardian) GetHiddenACL(cfg *setting.Cfg) ([]*models.DashboardACL, error) {
-	var hiddenACL []*models.DashboardACL
+func (a *AccessControlDashboardGuardian) GetHiddenACL(cfg *setting.Cfg) ([]*dashboards.DashboardACL, error) {
+	var hiddenACL []*dashboards.DashboardACL
 	if a.user.IsGrafanaAdmin {
 		return hiddenACL, nil
 	}
@@ -316,11 +316,11 @@ func (a *AccessControlDashboardGuardian) GetHiddenACL(cfg *setting.Cfg) ([]*mode
 		}
 
 		if _, hidden := cfg.HiddenUsers[item.UserLogin]; hidden {
-			hiddenACL = append(hiddenACL, &models.DashboardACL{
-				OrgID:       item.OrgId,
-				DashboardID: item.DashboardId,
-				UserID:      item.UserId,
-				TeamID:      item.TeamId,
+			hiddenACL = append(hiddenACL, &dashboards.DashboardACL{
+				OrgID:       item.OrgID,
+				DashboardID: item.DashboardID,
+				UserID:      item.UserID,
+				TeamID:      item.TeamID,
 				Role:        item.Role,
 				Permission:  item.Permission,
 				Created:     item.Created,

--- a/pkg/services/guardian/guardian_test.go
+++ b/pkg/services/guardian/guardian_test.go
@@ -188,7 +188,7 @@ func (sc *scenarioContext) defaultPermissionScenario(pt permissionType, flag per
 	_, callerFile, callerLine, _ := runtime.Caller(1)
 	sc.callerFile = callerFile
 	sc.callerLine = callerLine
-	existingPermissions := []*models.DashboardACLInfoDTO{
+	existingPermissions := []*dashboards.DashboardACLInfoDTO{
 		toDto(newEditorRolePermission(defaultDashboardID, models.PERMISSION_EDIT)),
 		toDto(newViewerRolePermission(defaultDashboardID, models.PERMISSION_VIEW)),
 	}
@@ -207,17 +207,17 @@ func (sc *scenarioContext) dashboardPermissionScenario(pt permissionType, permis
 	_, callerFile, callerLine, _ := runtime.Caller(1)
 	sc.callerFile = callerFile
 	sc.callerLine = callerLine
-	var existingPermissions []*models.DashboardACLInfoDTO
+	var existingPermissions []*dashboards.DashboardACLInfoDTO
 
 	switch pt {
 	case USER:
-		existingPermissions = []*models.DashboardACLInfoDTO{{OrgId: orgID, DashboardId: dashboardID, UserId: userID, Permission: permission}}
+		existingPermissions = []*dashboards.DashboardACLInfoDTO{{OrgID: orgID, DashboardID: dashboardID, UserID: userID, Permission: permission}}
 	case TEAM:
-		existingPermissions = []*models.DashboardACLInfoDTO{{OrgId: orgID, DashboardId: dashboardID, TeamId: teamID, Permission: permission}}
+		existingPermissions = []*dashboards.DashboardACLInfoDTO{{OrgID: orgID, DashboardID: dashboardID, TeamID: teamID, Permission: permission}}
 	case EDITOR:
-		existingPermissions = []*models.DashboardACLInfoDTO{{OrgId: orgID, DashboardId: dashboardID, Role: &editorRole, Permission: permission}}
+		existingPermissions = []*dashboards.DashboardACLInfoDTO{{OrgID: orgID, DashboardID: dashboardID, Role: &editorRole, Permission: permission}}
 	case VIEWER:
-		existingPermissions = []*models.DashboardACLInfoDTO{{OrgId: orgID, DashboardId: dashboardID, Role: &viewerRole, Permission: permission}}
+		existingPermissions = []*dashboards.DashboardACLInfoDTO{{OrgID: orgID, DashboardID: dashboardID, Role: &viewerRole, Permission: permission}}
 	}
 
 	permissionScenario(fmt.Sprintf("and %s has permission to %s dashboard", pt.String(), permission.String()),
@@ -234,20 +234,20 @@ func (sc *scenarioContext) parentFolderPermissionScenario(pt permissionType, per
 	_, callerFile, callerLine, _ := runtime.Caller(1)
 	sc.callerFile = callerFile
 	sc.callerLine = callerLine
-	var folderPermissionList []*models.DashboardACLInfoDTO
+	var folderPermissionList []*dashboards.DashboardACLInfoDTO
 
 	switch pt {
 	case USER:
-		folderPermissionList = []*models.DashboardACLInfoDTO{{OrgId: orgID, DashboardId: parentFolderID,
-			UserId: userID, Permission: permission, Inherited: true}}
+		folderPermissionList = []*dashboards.DashboardACLInfoDTO{{OrgID: orgID, DashboardID: parentFolderID,
+			UserID: userID, Permission: permission, Inherited: true}}
 	case TEAM:
-		folderPermissionList = []*models.DashboardACLInfoDTO{{OrgId: orgID, DashboardId: parentFolderID, TeamId: teamID,
+		folderPermissionList = []*dashboards.DashboardACLInfoDTO{{OrgID: orgID, DashboardID: parentFolderID, TeamID: teamID,
 			Permission: permission, Inherited: true}}
 	case EDITOR:
-		folderPermissionList = []*models.DashboardACLInfoDTO{{OrgId: orgID, DashboardId: parentFolderID,
+		folderPermissionList = []*dashboards.DashboardACLInfoDTO{{OrgID: orgID, DashboardID: parentFolderID,
 			Role: &editorRole, Permission: permission, Inherited: true}}
 	case VIEWER:
-		folderPermissionList = []*models.DashboardACLInfoDTO{{OrgId: orgID, DashboardId: parentFolderID,
+		folderPermissionList = []*dashboards.DashboardACLInfoDTO{{OrgID: orgID, DashboardID: parentFolderID,
 			Role: &viewerRole, Permission: permission, Inherited: true}}
 	}
 
@@ -312,7 +312,7 @@ func (sc *scenarioContext) verifyDuplicatePermissionsShouldNotBeAllowed() {
 
 	tc := "When updating dashboard permissions with duplicate permission for user should not be allowed"
 	sc.t.Run(tc, func(t *testing.T) {
-		p := []*models.DashboardACL{
+		p := []*dashboards.DashboardACL{
 			newDefaultUserPermission(dashboardID, models.PERMISSION_VIEW),
 			newDefaultUserPermission(dashboardID, models.PERMISSION_ADMIN),
 		}
@@ -327,7 +327,7 @@ func (sc *scenarioContext) verifyDuplicatePermissionsShouldNotBeAllowed() {
 
 	tc = "When updating dashboard permissions with duplicate permission for team should not be allowed"
 	sc.t.Run(tc, func(t *testing.T) {
-		p := []*models.DashboardACL{
+		p := []*dashboards.DashboardACL{
 			newDefaultTeamPermission(dashboardID, models.PERMISSION_VIEW),
 			newDefaultTeamPermission(dashboardID, models.PERMISSION_ADMIN),
 		}
@@ -341,7 +341,7 @@ func (sc *scenarioContext) verifyDuplicatePermissionsShouldNotBeAllowed() {
 
 	tc = "When updating dashboard permissions with duplicate permission for editor role should not be allowed"
 	sc.t.Run(tc, func(t *testing.T) {
-		p := []*models.DashboardACL{
+		p := []*dashboards.DashboardACL{
 			newEditorRolePermission(dashboardID, models.PERMISSION_VIEW),
 			newEditorRolePermission(dashboardID, models.PERMISSION_ADMIN),
 		}
@@ -356,7 +356,7 @@ func (sc *scenarioContext) verifyDuplicatePermissionsShouldNotBeAllowed() {
 
 	tc = "When updating dashboard permissions with duplicate permission for viewer role should not be allowed"
 	sc.t.Run(tc, func(t *testing.T) {
-		p := []*models.DashboardACL{
+		p := []*dashboards.DashboardACL{
 			newViewerRolePermission(dashboardID, models.PERMISSION_VIEW),
 			newViewerRolePermission(dashboardID, models.PERMISSION_ADMIN),
 		}
@@ -370,7 +370,7 @@ func (sc *scenarioContext) verifyDuplicatePermissionsShouldNotBeAllowed() {
 
 	tc = "When updating dashboard permissions with duplicate permission for admin role should not be allowed"
 	sc.t.Run(tc, func(t *testing.T) {
-		p := []*models.DashboardACL{
+		p := []*dashboards.DashboardACL{
 			newAdminRolePermission(dashboardID, models.PERMISSION_ADMIN),
 		}
 		sc.updatePermissions = p
@@ -390,24 +390,24 @@ func (sc *scenarioContext) verifyUpdateDashboardPermissionsShouldBeAllowed(pt pe
 	for _, p := range []models.PermissionType{models.PERMISSION_ADMIN, models.PERMISSION_EDIT, models.PERMISSION_VIEW} {
 		tc := fmt.Sprintf("When updating dashboard permissions with %s permissions should be allowed", p.String())
 		sc.t.Run(tc, func(t *testing.T) {
-			permissionList := []*models.DashboardACL{}
+			permissionList := []*dashboards.DashboardACL{}
 			switch pt {
 			case USER:
-				permissionList = []*models.DashboardACL{
+				permissionList = []*dashboards.DashboardACL{
 					newEditorRolePermission(dashboardID, p),
 					newViewerRolePermission(dashboardID, p),
 					newCustomUserPermission(dashboardID, otherUserID, p),
 					newDefaultTeamPermission(dashboardID, p),
 				}
 			case TEAM:
-				permissionList = []*models.DashboardACL{
+				permissionList = []*dashboards.DashboardACL{
 					newEditorRolePermission(dashboardID, p),
 					newViewerRolePermission(dashboardID, p),
 					newDefaultUserPermission(dashboardID, p),
 					newCustomTeamPermission(dashboardID, otherTeamID, p),
 				}
 			case EDITOR, VIEWER:
-				permissionList = []*models.DashboardACL{
+				permissionList = []*dashboards.DashboardACL{
 					newEditorRolePermission(dashboardID, p),
 					newViewerRolePermission(dashboardID, p),
 					newDefaultUserPermission(dashboardID, p),
@@ -436,18 +436,18 @@ func (sc *scenarioContext) verifyUpdateDashboardPermissionsShouldNotBeAllowed(pt
 	for _, p := range []models.PermissionType{models.PERMISSION_ADMIN, models.PERMISSION_EDIT, models.PERMISSION_VIEW} {
 		tc := fmt.Sprintf("When updating dashboard permissions with %s permissions should NOT be allowed", p.String())
 		sc.t.Run(tc, func(t *testing.T) {
-			permissionList := []*models.DashboardACL{
+			permissionList := []*dashboards.DashboardACL{
 				newEditorRolePermission(dashboardID, p),
 				newViewerRolePermission(dashboardID, p),
 			}
 			switch pt {
 			case USER:
-				permissionList = append(permissionList, []*models.DashboardACL{
+				permissionList = append(permissionList, []*dashboards.DashboardACL{
 					newCustomUserPermission(dashboardID, otherUserID, p),
 					newDefaultTeamPermission(dashboardID, p),
 				}...)
 			case TEAM:
-				permissionList = append(permissionList, []*models.DashboardACL{
+				permissionList = append(permissionList, []*dashboards.DashboardACL{
 					newDefaultUserPermission(dashboardID, p),
 					newCustomTeamPermission(dashboardID, otherTeamID, p),
 				}...)
@@ -476,24 +476,24 @@ func (sc *scenarioContext) verifyUpdateChildDashboardPermissionsShouldBeAllowed(
 	for _, p := range []models.PermissionType{models.PERMISSION_ADMIN, models.PERMISSION_EDIT, models.PERMISSION_VIEW} {
 		tc := fmt.Sprintf("When updating child dashboard permissions with %s permissions should be allowed", p.String())
 		sc.t.Run(tc, func(t *testing.T) {
-			permissionList := []*models.DashboardACL{}
+			permissionList := []*dashboards.DashboardACL{}
 			switch pt {
 			case USER:
-				permissionList = []*models.DashboardACL{
+				permissionList = []*dashboards.DashboardACL{
 					newEditorRolePermission(childDashboardID, p),
 					newViewerRolePermission(childDashboardID, p),
 					newCustomUserPermission(childDashboardID, otherUserID, p),
 					newDefaultTeamPermission(childDashboardID, p),
 				}
 			case TEAM:
-				permissionList = []*models.DashboardACL{
+				permissionList = []*dashboards.DashboardACL{
 					newEditorRolePermission(childDashboardID, p),
 					newViewerRolePermission(childDashboardID, p),
 					newDefaultUserPermission(childDashboardID, p),
 					newCustomTeamPermission(childDashboardID, otherTeamID, p),
 				}
 			case EDITOR:
-				permissionList = []*models.DashboardACL{
+				permissionList = []*dashboards.DashboardACL{
 					newViewerRolePermission(childDashboardID, p),
 					newDefaultUserPermission(childDashboardID, p),
 					newDefaultTeamPermission(childDashboardID, p),
@@ -504,7 +504,7 @@ func (sc *scenarioContext) verifyUpdateChildDashboardPermissionsShouldBeAllowed(
 					permissionList = append(permissionList, newEditorRolePermission(childDashboardID, p))
 				}
 			case VIEWER:
-				permissionList = []*models.DashboardACL{
+				permissionList = []*dashboards.DashboardACL{
 					newEditorRolePermission(childDashboardID, p),
 					newDefaultUserPermission(childDashboardID, p),
 					newDefaultTeamPermission(childDashboardID, p),
@@ -537,24 +537,24 @@ func (sc *scenarioContext) verifyUpdateChildDashboardPermissionsShouldNotBeAllow
 	for _, p := range []models.PermissionType{models.PERMISSION_ADMIN, models.PERMISSION_EDIT, models.PERMISSION_VIEW} {
 		tc := fmt.Sprintf("When updating child dashboard permissions with %s permissions should NOT be allowed", p.String())
 		sc.t.Run(tc, func(t *testing.T) {
-			permissionList := []*models.DashboardACL{}
+			permissionList := []*dashboards.DashboardACL{}
 			switch pt {
 			case USER:
-				permissionList = []*models.DashboardACL{
+				permissionList = []*dashboards.DashboardACL{
 					newEditorRolePermission(childDashboardID, p),
 					newViewerRolePermission(childDashboardID, p),
 					newCustomUserPermission(childDashboardID, otherUserID, p),
 					newDefaultTeamPermission(childDashboardID, p),
 				}
 			case TEAM:
-				permissionList = []*models.DashboardACL{
+				permissionList = []*dashboards.DashboardACL{
 					newEditorRolePermission(childDashboardID, p),
 					newViewerRolePermission(childDashboardID, p),
 					newDefaultUserPermission(childDashboardID, p),
 					newCustomTeamPermission(childDashboardID, otherTeamID, p),
 				}
 			case EDITOR:
-				permissionList = []*models.DashboardACL{
+				permissionList = []*dashboards.DashboardACL{
 					newViewerRolePermission(childDashboardID, p),
 					newDefaultUserPermission(childDashboardID, p),
 					newDefaultTeamPermission(childDashboardID, p),
@@ -565,7 +565,7 @@ func (sc *scenarioContext) verifyUpdateChildDashboardPermissionsShouldNotBeAllow
 					permissionList = append(permissionList, newEditorRolePermission(childDashboardID, p))
 				}
 			case VIEWER:
-				permissionList = []*models.DashboardACL{
+				permissionList = []*dashboards.DashboardACL{
 					newEditorRolePermission(childDashboardID, p),
 					newDefaultUserPermission(childDashboardID, p),
 					newDefaultTeamPermission(childDashboardID, p),
@@ -603,22 +603,22 @@ func (sc *scenarioContext) verifyUpdateChildDashboardPermissionsWithOverrideShou
 
 		tc := fmt.Sprintf("When updating child dashboard permissions overriding parent %s permission with %s permission should NOT be allowed", pt.String(), p.String())
 		sc.t.Run(tc, func(t *testing.T) {
-			permissionList := []*models.DashboardACL{}
+			permissionList := []*dashboards.DashboardACL{}
 			switch pt {
 			case USER:
-				permissionList = []*models.DashboardACL{
+				permissionList = []*dashboards.DashboardACL{
 					newDefaultUserPermission(childDashboardID, p),
 				}
 			case TEAM:
-				permissionList = []*models.DashboardACL{
+				permissionList = []*dashboards.DashboardACL{
 					newDefaultTeamPermission(childDashboardID, p),
 				}
 			case EDITOR:
-				permissionList = []*models.DashboardACL{
+				permissionList = []*dashboards.DashboardACL{
 					newEditorRolePermission(childDashboardID, p),
 				}
 			case VIEWER:
-				permissionList = []*models.DashboardACL{
+				permissionList = []*dashboards.DashboardACL{
 					newViewerRolePermission(childDashboardID, p),
 				}
 			}
@@ -649,22 +649,22 @@ func (sc *scenarioContext) verifyUpdateChildDashboardPermissionsWithOverrideShou
 			pt.String(), p.String(),
 		)
 		sc.t.Run(tc, func(t *testing.T) {
-			permissionList := []*models.DashboardACL{}
+			permissionList := []*dashboards.DashboardACL{}
 			switch pt {
 			case USER:
-				permissionList = []*models.DashboardACL{
+				permissionList = []*dashboards.DashboardACL{
 					newDefaultUserPermission(childDashboardID, p),
 				}
 			case TEAM:
-				permissionList = []*models.DashboardACL{
+				permissionList = []*dashboards.DashboardACL{
 					newDefaultTeamPermission(childDashboardID, p),
 				}
 			case EDITOR:
-				permissionList = []*models.DashboardACL{
+				permissionList = []*dashboards.DashboardACL{
 					newEditorRolePermission(childDashboardID, p),
 				}
 			case VIEWER:
-				permissionList = []*models.DashboardACL{
+				permissionList = []*dashboards.DashboardACL{
 					newViewerRolePermission(childDashboardID, p),
 				}
 			}
@@ -690,12 +690,12 @@ func TestGuardianGetHiddenACL(t *testing.T) {
 	t.Run("Get hidden ACL tests", func(t *testing.T) {
 		store := dbtest.NewFakeDB()
 		dashSvc := dashboards.NewFakeDashboardService(t)
-		dashSvc.On("GetDashboardACLInfoList", mock.Anything, mock.AnythingOfType("*models.GetDashboardACLInfoListQuery")).Run(func(args mock.Arguments) {
-			q := args.Get(1).(*models.GetDashboardACLInfoListQuery)
-			q.Result = []*models.DashboardACLInfoDTO{
-				{Inherited: false, UserId: 1, UserLogin: "user1", Permission: models.PERMISSION_EDIT},
-				{Inherited: false, UserId: 2, UserLogin: "user2", Permission: models.PERMISSION_ADMIN},
-				{Inherited: true, UserId: 3, UserLogin: "user3", Permission: models.PERMISSION_VIEW},
+		dashSvc.On("GetDashboardACLInfoList", mock.Anything, mock.AnythingOfType("*dashboards.GetDashboardACLInfoListQuery")).Run(func(args mock.Arguments) {
+			q := args.Get(1).(*dashboards.GetDashboardACLInfoListQuery)
+			q.Result = []*dashboards.DashboardACLInfoDTO{
+				{Inherited: false, UserID: 1, UserLogin: "user1", Permission: models.PERMISSION_EDIT},
+				{Inherited: false, UserID: 2, UserLogin: "user2", Permission: models.PERMISSION_ADMIN},
+				{Inherited: true, UserID: 3, UserLogin: "user3", Permission: models.PERMISSION_VIEW},
 			}
 		}).Return(nil)
 		dashSvc.On("GetDashboard", mock.Anything, mock.AnythingOfType("*dashboards.GetDashboardQuery")).Run(func(args mock.Arguments) {
@@ -756,17 +756,17 @@ func TestGuardianGetACLWithoutDuplicates(t *testing.T) {
 	t.Run("Get hidden ACL tests", func(t *testing.T) {
 		store := dbtest.NewFakeDB()
 		dashSvc := dashboards.NewFakeDashboardService(t)
-		dashSvc.On("GetDashboardACLInfoList", mock.Anything, mock.AnythingOfType("*models.GetDashboardACLInfoListQuery")).Run(func(args mock.Arguments) {
-			q := args.Get(1).(*models.GetDashboardACLInfoListQuery)
-			q.Result = []*models.DashboardACLInfoDTO{
-				{Inherited: true, UserId: 3, UserLogin: "user3", Permission: models.PERMISSION_EDIT},
-				{Inherited: false, UserId: 3, UserLogin: "user3", Permission: models.PERMISSION_VIEW},
-				{Inherited: false, UserId: 2, UserLogin: "user2", Permission: models.PERMISSION_ADMIN},
-				{Inherited: true, UserId: 4, UserLogin: "user4", Permission: models.PERMISSION_ADMIN},
-				{Inherited: false, UserId: 4, UserLogin: "user4", Permission: models.PERMISSION_ADMIN},
-				{Inherited: false, UserId: 5, UserLogin: "user5", Permission: models.PERMISSION_EDIT},
-				{Inherited: true, UserId: 6, UserLogin: "user6", Permission: models.PERMISSION_VIEW},
-				{Inherited: false, UserId: 6, UserLogin: "user6", Permission: models.PERMISSION_EDIT},
+		dashSvc.On("GetDashboardACLInfoList", mock.Anything, mock.AnythingOfType("*dashboards.GetDashboardACLInfoListQuery")).Run(func(args mock.Arguments) {
+			q := args.Get(1).(*dashboards.GetDashboardACLInfoListQuery)
+			q.Result = []*dashboards.DashboardACLInfoDTO{
+				{Inherited: true, UserID: 3, UserLogin: "user3", Permission: models.PERMISSION_EDIT},
+				{Inherited: false, UserID: 3, UserLogin: "user3", Permission: models.PERMISSION_VIEW},
+				{Inherited: false, UserID: 2, UserLogin: "user2", Permission: models.PERMISSION_ADMIN},
+				{Inherited: true, UserID: 4, UserLogin: "user4", Permission: models.PERMISSION_ADMIN},
+				{Inherited: false, UserID: 4, UserLogin: "user4", Permission: models.PERMISSION_ADMIN},
+				{Inherited: false, UserID: 5, UserLogin: "user5", Permission: models.PERMISSION_EDIT},
+				{Inherited: true, UserID: 6, UserLogin: "user6", Permission: models.PERMISSION_VIEW},
+				{Inherited: false, UserID: 6, UserLogin: "user6", Permission: models.PERMISSION_EDIT},
 			}
 		}).Return(nil)
 		dashSvc.On("GetDashboard", mock.Anything, mock.AnythingOfType("*dashboards.GetDashboardQuery")).Run(func(args mock.Arguments) {
@@ -791,13 +791,13 @@ func TestGuardianGetACLWithoutDuplicates(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, acl)
 			require.Len(t, acl, 6)
-			require.ElementsMatch(t, []*models.DashboardACLInfoDTO{
-				{Inherited: true, UserId: 3, UserLogin: "user3", Permission: models.PERMISSION_EDIT},
-				{Inherited: true, UserId: 4, UserLogin: "user4", Permission: models.PERMISSION_ADMIN},
-				{Inherited: true, UserId: 6, UserLogin: "user6", Permission: models.PERMISSION_VIEW},
-				{Inherited: false, UserId: 2, UserLogin: "user2", Permission: models.PERMISSION_ADMIN},
-				{Inherited: false, UserId: 5, UserLogin: "user5", Permission: models.PERMISSION_EDIT},
-				{Inherited: false, UserId: 6, UserLogin: "user6", Permission: models.PERMISSION_EDIT},
+			require.ElementsMatch(t, []*dashboards.DashboardACLInfoDTO{
+				{Inherited: true, UserID: 3, UserLogin: "user3", Permission: models.PERMISSION_EDIT},
+				{Inherited: true, UserID: 4, UserLogin: "user4", Permission: models.PERMISSION_ADMIN},
+				{Inherited: true, UserID: 6, UserLogin: "user6", Permission: models.PERMISSION_VIEW},
+				{Inherited: false, UserID: 2, UserLogin: "user2", Permission: models.PERMISSION_ADMIN},
+				{Inherited: false, UserID: 5, UserLogin: "user5", Permission: models.PERMISSION_EDIT},
+				{Inherited: false, UserID: 6, UserLogin: "user6", Permission: models.PERMISSION_EDIT},
 			}, acl)
 		})
 	})

--- a/pkg/services/guardian/guardian_util_test.go
+++ b/pkg/services/guardian/guardian_util_test.go
@@ -27,9 +27,9 @@ type scenarioContext struct {
 	g                  DashboardGuardian
 	givenUser          *user.SignedInUser
 	givenDashboardID   int64
-	givenPermissions   []*models.DashboardACLInfoDTO
+	givenPermissions   []*dashboards.DashboardACLInfoDTO
 	givenTeams         []*team.TeamDTO
-	updatePermissions  []*models.DashboardACL
+	updatePermissions  []*dashboards.DashboardACL
 	expectedFlags      permissionFlags
 	callerFile         string
 	callerLine         int
@@ -101,21 +101,21 @@ func apiKeyScenario(desc string, t *testing.T, role org.RoleType, fn scenarioFun
 }
 
 func permissionScenario(desc string, dashboardID int64, sc *scenarioContext,
-	permissions []*models.DashboardACLInfoDTO, fn scenarioFunc) {
+	permissions []*dashboards.DashboardACLInfoDTO, fn scenarioFunc) {
 	sc.t.Run(desc, func(t *testing.T) {
 		store := dbtest.NewFakeDB()
 		teams := []*team.TeamDTO{}
 
 		for _, p := range permissions {
-			if p.TeamId > 0 {
-				teams = append(teams, &team.TeamDTO{ID: p.TeamId})
+			if p.TeamID > 0 {
+				teams = append(teams, &team.TeamDTO{ID: p.TeamID})
 			}
 		}
 		teamSvc := &teamtest.FakeService{ExpectedTeamsByUser: teams}
 
 		dashSvc := dashboards.NewFakeDashboardService(t)
-		dashSvc.On("GetDashboardACLInfoList", mock.Anything, mock.AnythingOfType("*models.GetDashboardACLInfoListQuery")).Run(func(args mock.Arguments) {
-			q := args.Get(1).(*models.GetDashboardACLInfoListQuery)
+		dashSvc.On("GetDashboardACLInfoList", mock.Anything, mock.AnythingOfType("*dashboards.GetDashboardACLInfoListQuery")).Run(func(args mock.Arguments) {
+			q := args.Get(1).(*dashboards.GetDashboardACLInfoListQuery)
 			q.Result = permissions
 		}).Return(nil)
 		dashSvc.On("GetDashboard", mock.Anything, mock.AnythingOfType("*dashboards.GetDashboardQuery")).Run(func(args mock.Arguments) {
@@ -243,7 +243,7 @@ func (sc *scenarioContext) reportFailure(desc string, expected interface{}, actu
 		if p.Role != nil {
 			r = string(*p.Role)
 		}
-		buf.WriteString(fmt.Sprintf("\n  Given permission (%d): dashboardId=%d, userId=%d, teamId=%d, role=%v, permission=%s", i, p.DashboardId, p.UserId, p.TeamId, r, p.Permission.String()))
+		buf.WriteString(fmt.Sprintf("\n  Given permission (%d): dashboardId=%d, userId=%d, teamId=%d, role=%v, permission=%s", i, p.DashboardID, p.UserID, p.TeamID, r, p.Permission.String()))
 	}
 
 	for i, t := range sc.givenTeams {
@@ -261,40 +261,40 @@ func (sc *scenarioContext) reportFailure(desc string, expected interface{}, actu
 	sc.t.Fatalf(buf.String())
 }
 
-func newCustomUserPermission(dashboardID int64, userID int64, permission models.PermissionType) *models.DashboardACL {
-	return &models.DashboardACL{OrgID: orgID, DashboardID: dashboardID, UserID: userID, Permission: permission}
+func newCustomUserPermission(dashboardID int64, userID int64, permission models.PermissionType) *dashboards.DashboardACL {
+	return &dashboards.DashboardACL{OrgID: orgID, DashboardID: dashboardID, UserID: userID, Permission: permission}
 }
 
-func newDefaultUserPermission(dashboardID int64, permission models.PermissionType) *models.DashboardACL {
+func newDefaultUserPermission(dashboardID int64, permission models.PermissionType) *dashboards.DashboardACL {
 	return newCustomUserPermission(dashboardID, userID, permission)
 }
 
-func newCustomTeamPermission(dashboardID int64, teamID int64, permission models.PermissionType) *models.DashboardACL {
-	return &models.DashboardACL{OrgID: orgID, DashboardID: dashboardID, TeamID: teamID, Permission: permission}
+func newCustomTeamPermission(dashboardID int64, teamID int64, permission models.PermissionType) *dashboards.DashboardACL {
+	return &dashboards.DashboardACL{OrgID: orgID, DashboardID: dashboardID, TeamID: teamID, Permission: permission}
 }
 
-func newDefaultTeamPermission(dashboardID int64, permission models.PermissionType) *models.DashboardACL {
+func newDefaultTeamPermission(dashboardID int64, permission models.PermissionType) *dashboards.DashboardACL {
 	return newCustomTeamPermission(dashboardID, teamID, permission)
 }
 
-func newAdminRolePermission(dashboardID int64, permission models.PermissionType) *models.DashboardACL {
-	return &models.DashboardACL{OrgID: orgID, DashboardID: dashboardID, Role: &adminRole, Permission: permission}
+func newAdminRolePermission(dashboardID int64, permission models.PermissionType) *dashboards.DashboardACL {
+	return &dashboards.DashboardACL{OrgID: orgID, DashboardID: dashboardID, Role: &adminRole, Permission: permission}
 }
 
-func newEditorRolePermission(dashboardID int64, permission models.PermissionType) *models.DashboardACL {
-	return &models.DashboardACL{OrgID: orgID, DashboardID: dashboardID, Role: &editorRole, Permission: permission}
+func newEditorRolePermission(dashboardID int64, permission models.PermissionType) *dashboards.DashboardACL {
+	return &dashboards.DashboardACL{OrgID: orgID, DashboardID: dashboardID, Role: &editorRole, Permission: permission}
 }
 
-func newViewerRolePermission(dashboardID int64, permission models.PermissionType) *models.DashboardACL {
-	return &models.DashboardACL{OrgID: orgID, DashboardID: dashboardID, Role: &viewerRole, Permission: permission}
+func newViewerRolePermission(dashboardID int64, permission models.PermissionType) *dashboards.DashboardACL {
+	return &dashboards.DashboardACL{OrgID: orgID, DashboardID: dashboardID, Role: &viewerRole, Permission: permission}
 }
 
-func toDto(acl *models.DashboardACL) *models.DashboardACLInfoDTO {
-	return &models.DashboardACLInfoDTO{
-		OrgId:          acl.OrgID,
-		DashboardId:    acl.DashboardID,
-		UserId:         acl.UserID,
-		TeamId:         acl.TeamID,
+func toDto(acl *dashboards.DashboardACL) *dashboards.DashboardACLInfoDTO {
+	return &dashboards.DashboardACLInfoDTO{
+		OrgID:          acl.OrgID,
+		DashboardID:    acl.DashboardID,
+		UserID:         acl.UserID,
+		TeamID:         acl.TeamID,
 		Role:           acl.Role,
 		Permission:     acl.Permission,
 		PermissionName: acl.Permission.String(),

--- a/pkg/services/libraryelements/libraryelements_test.go
+++ b/pkg/services/libraryelements/libraryelements_test.go
@@ -334,11 +334,11 @@ func updateFolderACL(t *testing.T, dashboardStore *database.DashboardStore, fold
 		return
 	}
 
-	var aclItems []*models.DashboardACL
+	var aclItems []*dashboards.DashboardACL
 	for _, item := range items {
 		role := item.roleType
 		permission := item.permission
-		aclItems = append(aclItems, &models.DashboardACL{
+		aclItems = append(aclItems, &dashboards.DashboardACL{
 			DashboardID: folderID,
 			Role:        &role,
 			Permission:  permission,

--- a/pkg/services/librarypanels/librarypanels_test.go
+++ b/pkg/services/librarypanels/librarypanels_test.go
@@ -745,11 +745,11 @@ func updateFolderACL(t *testing.T, dashboardStore *database.DashboardStore, fold
 		return
 	}
 
-	var aclItems []*models.DashboardACL
+	var aclItems []*dashboards.DashboardACL
 	for _, item := range items {
 		role := item.roleType
 		permission := item.permission
-		aclItems = append(aclItems, &models.DashboardACL{
+		aclItems = append(aclItems, &dashboards.DashboardACL{
 			DashboardID: folderID,
 			Role:        &role,
 			Permission:  permission,

--- a/pkg/services/team/teamimpl/store_test.go
+++ b/pkg/services/team/teamimpl/store_test.go
@@ -300,7 +300,7 @@ func TestIntegrationTeamCommandsAndQueries(t *testing.T) {
 				require.NoError(t, err)
 				err = teamSvc.AddTeamMember(userIds[2], testOrgID, groupID, false, 0)
 				require.NoError(t, err)
-				err = updateDashboardACL(t, sqlStore, 1, &models.DashboardACL{
+				err = updateDashboardACL(t, sqlStore, 1, &dashboards.DashboardACL{
 					DashboardID: 1, OrgID: testOrgID, Permission: models.PERMISSION_EDIT, TeamID: groupID,
 				})
 				require.NoError(t, err)
@@ -311,7 +311,7 @@ func TestIntegrationTeamCommandsAndQueries(t *testing.T) {
 				_, err = teamSvc.GetTeamByID(context.Background(), query)
 				require.Equal(t, err, team.ErrTeamNotFound)
 
-				permQuery := &models.GetDashboardACLInfoListQuery{DashboardID: 1, OrgID: testOrgID}
+				permQuery := &dashboards.GetDashboardACLInfoListQuery{DashboardID: 1, OrgID: testOrgID}
 				err = getDashboardACLInfoList(sqlStore, permQuery)
 				require.NoError(t, err)
 
@@ -617,7 +617,7 @@ func hasWildcardScope(user *user.SignedInUser, action string) bool {
 }
 
 // TODO: Use FakeDashboardStore when org has its own service
-func updateDashboardACL(t *testing.T, sqlStore *sqlstore.SQLStore, dashboardID int64, items ...*models.DashboardACL) error {
+func updateDashboardACL(t *testing.T, sqlStore *sqlstore.SQLStore, dashboardID int64, items ...*dashboards.DashboardACL) error {
 	t.Helper()
 
 	err := sqlStore.WithDbSession(context.Background(), func(sess *db.Session) error {
@@ -654,9 +654,9 @@ func updateDashboardACL(t *testing.T, sqlStore *sqlstore.SQLStore, dashboardID i
 // This function was copied from pkg/services/dashboards/database to circumvent
 // import cycles. When this org-related code is refactored into a service the
 // tests can the real GetDashboardACLInfoList functions
-func getDashboardACLInfoList(s *sqlstore.SQLStore, query *models.GetDashboardACLInfoListQuery) error {
+func getDashboardACLInfoList(s *sqlstore.SQLStore, query *dashboards.GetDashboardACLInfoListQuery) error {
 	outerErr := s.WithDbSession(context.Background(), func(dbSession *db.Session) error {
-		query.Result = make([]*models.DashboardACLInfoDTO, 0)
+		query.Result = make([]*dashboards.DashboardACLInfoDTO, 0)
 		falseStr := s.GetDialect().BooleanStr(false)
 
 		if query.DashboardID == 0 {

--- a/pkg/services/user/userimpl/store_test.go
+++ b/pkg/services/user/userimpl/store_test.go
@@ -282,7 +282,7 @@ func TestIntegrationUserDataAccess(t *testing.T) {
 		})
 		require.Nil(t, err)
 
-		err = updateDashboardACL(t, ss, 1, &models.DashboardACL{
+		err = updateDashboardACL(t, ss, 1, &dashboards.DashboardACL{
 			DashboardID: 1, OrgID: users[0].OrgID, UserID: users[1].ID,
 			Permission: models.PERMISSION_EDIT,
 		})
@@ -421,7 +421,7 @@ func TestIntegrationUserDataAccess(t *testing.T) {
 		})
 		require.Nil(t, err)
 
-		err = updateDashboardACL(t, ss, 1, &models.DashboardACL{
+		err = updateDashboardACL(t, ss, 1, &dashboards.DashboardACL{
 			DashboardID: 1, OrgID: users[0].OrgID, UserID: users[1].ID,
 			Permission: models.PERMISSION_EDIT,
 		})
@@ -431,7 +431,7 @@ func TestIntegrationUserDataAccess(t *testing.T) {
 		err = userStore.Delete(context.Background(), users[1].ID)
 		require.Nil(t, err)
 
-		permQuery := &models.GetDashboardACLInfoListQuery{DashboardID: 1, OrgID: users[0].OrgID}
+		permQuery := &dashboards.GetDashboardACLInfoListQuery{DashboardID: 1, OrgID: users[0].OrgID}
 		err = userStore.getDashboardACLInfoList(permQuery)
 		require.Nil(t, err)
 
@@ -455,7 +455,7 @@ func TestIntegrationUserDataAccess(t *testing.T) {
 		})
 		require.Nil(t, err)
 
-		err = updateDashboardACL(t, ss, 1, &models.DashboardACL{
+		err = updateDashboardACL(t, ss, 1, &dashboards.DashboardACL{
 			DashboardID: 1, OrgID: users[0].OrgID, UserID: users[1].ID,
 			Permission: models.PERMISSION_EDIT,
 		})
@@ -487,7 +487,7 @@ func TestIntegrationUserDataAccess(t *testing.T) {
 		err = userStore.Delete(context.Background(), users[1].ID)
 		require.Nil(t, err)
 
-		permQuery = &models.GetDashboardACLInfoListQuery{DashboardID: 1, OrgID: users[0].OrgID}
+		permQuery = &dashboards.GetDashboardACLInfoListQuery{DashboardID: 1, OrgID: users[0].OrgID}
 		err = userStore.getDashboardACLInfoList(permQuery)
 		require.Nil(t, err)
 
@@ -818,7 +818,7 @@ func createFiveTestUsers(t *testing.T, svc user.Service, fn func(i int) *user.Cr
 }
 
 // TODO: Use FakeDashboardStore when org has its own service
-func updateDashboardACL(t *testing.T, sqlStore db.DB, dashboardID int64, items ...*models.DashboardACL) error {
+func updateDashboardACL(t *testing.T, sqlStore db.DB, dashboardID int64, items ...*dashboards.DashboardACL) error {
 	t.Helper()
 
 	err := sqlStore.WithDbSession(context.Background(), func(sess *db.Session) error {
@@ -855,9 +855,9 @@ func updateDashboardACL(t *testing.T, sqlStore db.DB, dashboardID int64, items .
 // This function was copied from pkg/services/dashboards/database to circumvent
 // import cycles. When this org-related code is refactored into a service the
 // tests can the real GetDashboardACLInfoList functions
-func (ss *sqlStore) getDashboardACLInfoList(query *models.GetDashboardACLInfoListQuery) error {
+func (ss *sqlStore) getDashboardACLInfoList(query *dashboards.GetDashboardACLInfoListQuery) error {
 	outerErr := ss.db.WithDbSession(context.Background(), func(dbSession *db.Session) error {
-		query.Result = make([]*models.DashboardACLInfoDTO, 0)
+		query.Result = make([]*dashboards.DashboardACLInfoDTO, 0)
 		falseStr := ss.dialect.BooleanStr(false)
 
 		if query.DashboardID == 0 {


### PR DESCRIPTION
Fix for enterprise: https://github.com/grafana/grafana-enterprise/pull/4344