### PR TITLE
Elasticsearch: Fix toggle-settings are not shown correctly

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/configuration/ElasticDetails.tsx
+++ b/public/app/plugins/datasource/elasticsearch/configuration/ElasticDetails.tsx
@@ -125,7 +125,7 @@ export const ElasticDetails = ({ value, onChange }: Props) => {
         <InlineField label="X-Pack enabled" labelWidth={26}>
           <InlineSwitch
             id="es_config_xpackEnabled"
-            checked={value.jsonData.xpack || false}
+            value={value.jsonData.xpack || false}
             onChange={jsonDataSwitchChangeHandler('xpack', value, onChange)}
           />
         </InlineField>
@@ -134,7 +134,7 @@ export const ElasticDetails = ({ value, onChange }: Props) => {
           <InlineField label="Include Frozen Indices" labelWidth={26}>
             <InlineSwitch
               id="es_config_frozenIndices"
-              checked={value.jsonData.includeFrozen ?? false}
+              value={value.jsonData.includeFrozen ?? false}
               onChange={jsonDataSwitchChangeHandler('includeFrozen', value, onChange)}
             />
           </InlineField>
@@ -174,7 +174,7 @@ const jsonDataSwitchChangeHandler =
       ...value,
       jsonData: {
         ...value.jsonData,
-        [key]: event.currentTarget.checked,
+        [key]: event.currentTarget.value,
       },
     });
   };

--- a/public/app/plugins/datasource/elasticsearch/configuration/ElasticDetails.tsx
+++ b/public/app/plugins/datasource/elasticsearch/configuration/ElasticDetails.tsx
@@ -174,7 +174,7 @@ const jsonDataSwitchChangeHandler =
       ...value,
       jsonData: {
         ...value.jsonData,
-        [key]: event.currentTarget.value,
+        [key]: event.currentTarget.checked,
       },
     });
   };


### PR DESCRIPTION
**Why do we need this feature?**

As reported in #61665 the toggle settings like `X-Pack enabled` are not shown correctly in the UI. It seems like the `checked` property was deprecated and changing it to `value` seems to fix it.

**Which issue(s) does this PR fix?**:

Fixes #61665

