### PR TITLE
Packages: Fix `upload-packages` case for Enterprise2 mode

### DIFF
--- a/pkg/build/cmd/uploadpackages.go
+++ b/pkg/build/cmd/uploadpackages.go
@@ -103,19 +103,6 @@ func UploadPackages(c *cli.Context) error {
 		}
 	}
 
-	// Corner case for custom enterprise2 mode
-	event, err := droneutil.GetDroneEventFromEnv()
-	if err != nil {
-		return err
-	}
-	if event == config.Custom && cfg.edition == config.EditionEnterprise2 {
-		buildConfig, err := config.GetBuildConfig(config.ReleaseBranchMode)
-		if err != nil {
-			return err
-		}
-		cfg.Bucket = buildConfig.Buckets.ArtifactsEnterprise2
-	}
-
 	if err := uploadPackages(cfg); err != nil {
 		return cli.Exit(err.Error(), 1)
 	}
@@ -160,6 +147,19 @@ func uploadPackages(cfg uploadConfig) error {
 		fpaths = append(fpaths, fpath)
 	}
 
+	// Corner case for custom enterprise2 mode
+	event, err := droneutil.GetDroneEventFromEnv()
+	if err != nil {
+		return err
+	}
+	if event == config.Custom && cfg.edition == config.EditionEnterprise2 {
+		buildConfig, err := config.GetBuildConfig(config.ReleaseBranchMode)
+		if err != nil {
+			return err
+		}
+		cfg.Bucket = buildConfig.Buckets.ArtifactsEnterprise2
+	}
+
 	var versionFolder string
 	switch cfg.versionMode {
 	case config.TagMode:
@@ -169,6 +169,11 @@ func uploadPackages(cfg uploadConfig) error {
 	case config.ReleaseBranchMode:
 		versionFolder = releaseBranchFolder
 	default:
+		// Corner case for custom enterprise2 mode
+		if event == config.Custom && cfg.versionMode == config.Enterprise2Mode {
+			versionFolder = releaseFolder
+			break
+		}
 		panic(fmt.Sprintf("Unrecognized version mode: %s", cfg.versionMode))
 	}
 

--- a/pkg/build/cmd/uploadpackages.go
+++ b/pkg/build/cmd/uploadpackages.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/base64"
 	"fmt"
+	"github.com/grafana/grafana/pkg/build/droneutil"
 	"log"
 	"os"
 	"os/exec"
@@ -100,6 +101,19 @@ func UploadPackages(c *cli.Context) error {
 		} else {
 			return fmt.Errorf("enterprise2 bucket var doesn't exist")
 		}
+	}
+
+	// Corner case for custom enterprise2 mode
+	event, err := droneutil.GetDroneEventFromEnv()
+	if err != nil {
+		return err
+	}
+	if event == config.Custom && cfg.edition == config.EditionEnterprise2 {
+		buildConfig, err := config.GetBuildConfig(config.ReleaseBranchMode)
+		if err != nil {
+			return err
+		}
+		cfg.Bucket = buildConfig.Buckets.ArtifactsEnterprise2
 	}
 
 	if err := uploadPackages(cfg); err != nil {

--- a/pkg/build/cmd/uploadpackages.go
+++ b/pkg/build/cmd/uploadpackages.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/base64"
 	"fmt"
-	"github.com/grafana/grafana/pkg/build/droneutil"
 	"log"
 	"os"
 	"os/exec"
@@ -11,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/grafana/grafana/pkg/build/config"
+	"github.com/grafana/grafana/pkg/build/droneutil"
 	"github.com/grafana/grafana/pkg/build/gcloud"
 	"github.com/grafana/grafana/pkg/build/packaging"
 	"github.com/urfave/cli/v2"

--- a/pkg/build/cmd/uploadpackages.go
+++ b/pkg/build/cmd/uploadpackages.go
@@ -108,7 +108,10 @@ func UploadPackages(c *cli.Context) error {
 		}
 	}
 
-	cfg.versionFolder = getVersionFolder(cfg, event)
+	cfg.versionFolder, err = getVersionFolder(cfg, event)
+	if err != nil {
+		return err
+	}
 
 	if err := uploadPackages(cfg); err != nil {
 		return cli.Exit(err.Error(), 1)
@@ -135,20 +138,20 @@ func bucketForEnterprise2(releaseModeConfig *config.BuildConfig, event string) (
 	return "", fmt.Errorf("enterprise2 bucket var doesn't exist")
 }
 
-func getVersionFolder(cfg uploadConfig, event string) string {
+func getVersionFolder(cfg uploadConfig, event string) (string, error) {
 	switch cfg.versionMode {
 	case config.TagMode:
-		return releaseFolder
+		return releaseFolder, nil
 	case config.MainMode, config.DownstreamMode:
-		return mainFolder
+		return mainFolder, nil
 	case config.ReleaseBranchMode:
-		return releaseBranchFolder
+		return releaseBranchFolder, nil
 	default:
 		// Corner case for custom enterprise2 mode
 		if event == config.Custom && cfg.versionMode == config.Enterprise2Mode {
-			return releaseFolder
+			return releaseFolder, nil
 		}
-		panic(fmt.Sprintf("Unrecognized version mode: %s", cfg.versionMode))
+		return "", fmt.Errorf("Unrecognized version mode: %s", cfg.versionMode)
 	}
 }
 

--- a/pkg/build/cmd/uploadpackages.go
+++ b/pkg/build/cmd/uploadpackages.go
@@ -133,7 +133,6 @@ func bucketForEnterprise2(releaseModeConfig *config.BuildConfig, event string) (
 	}
 
 	return "", fmt.Errorf("enterprise2 bucket var doesn't exist")
-
 }
 
 func getVersionFolder(cfg uploadConfig, event string) string {
@@ -151,7 +150,6 @@ func getVersionFolder(cfg uploadConfig, event string) string {
 		}
 		panic(fmt.Sprintf("Unrecognized version mode: %s", cfg.versionMode))
 	}
-	return ""
 }
 
 func uploadPackages(cfg uploadConfig) error {

--- a/pkg/build/cmd/uploadpackages.go
+++ b/pkg/build/cmd/uploadpackages.go
@@ -151,7 +151,7 @@ func getVersionFolder(cfg uploadConfig, event string) (string, error) {
 		if event == config.Custom && cfg.versionMode == config.Enterprise2Mode {
 			return releaseFolder, nil
 		}
-		return "", fmt.Errorf("Unrecognized version mode: %s", cfg.versionMode)
+		return "", fmt.Errorf("unrecognized version mode: %s", cfg.versionMode)
 	}
 }
 

--- a/pkg/build/cmd/uploadpackages.go
+++ b/pkg/build/cmd/uploadpackages.go
@@ -148,7 +148,6 @@ func getVersionFolder(cfg uploadConfig, event string) string {
 		// Corner case for custom enterprise2 mode
 		if event == config.Custom && cfg.versionMode == config.Enterprise2Mode {
 			return releaseFolder
-			break
 		}
 		panic(fmt.Sprintf("Unrecognized version mode: %s", cfg.versionMode))
 	}

--- a/pkg/build/cmd/uploadpackages_test.go
+++ b/pkg/build/cmd/uploadpackages_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -18,16 +19,21 @@ func Test_getVersionFolder(t *testing.T) {
 	tests := []struct {
 		name string
 		args args
+		err  error
 	}{
-		{"tag mode", args{uploadConfig{versionMode: config.TagMode}, "", releaseFolder}},
-		{"main mode", args{uploadConfig{versionMode: config.MainMode}, "", mainFolder}},
-		{"downstream mode", args{uploadConfig{versionMode: config.DownstreamMode}, "", mainFolder}},
-		{"release branch mode", args{uploadConfig{versionMode: config.ReleaseBranchMode}, "", releaseBranchFolder}},
-		{"enterprise pro mode", args{uploadConfig{versionMode: config.Enterprise2Mode}, config.Custom, releaseFolder}},
+		{"tag mode", args{uploadConfig{versionMode: config.TagMode}, "", releaseFolder}, nil},
+		{"main mode", args{uploadConfig{versionMode: config.MainMode}, "", mainFolder}, nil},
+		{"downstream mode", args{uploadConfig{versionMode: config.DownstreamMode}, "", mainFolder}, nil},
+		{"release branch mode", args{uploadConfig{versionMode: config.ReleaseBranchMode}, "", releaseBranchFolder}, nil},
+		{"enterprise pro mode", args{uploadConfig{versionMode: config.Enterprise2Mode}, config.Custom, releaseFolder}, nil},
+		{"unrecognised version mode", args{uploadConfig{versionMode: "foo"}, config.Custom, ""}, errors.New("")},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			versionMode := getVersionFolder(tt.args.cfg, tt.args.event)
+			versionMode, err := getVersionFolder(tt.args.cfg, tt.args.event)
+			if tt.err != nil {
+				require.Error(t, err)
+			}
 			require.Equal(t, versionMode, tt.args.versionFolder)
 		})
 	}

--- a/pkg/build/cmd/uploadpackages_test.go
+++ b/pkg/build/cmd/uploadpackages_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/grafana/grafana/pkg/build/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_getVersionFolder(t *testing.T) {
+	type args struct {
+		cfg           uploadConfig
+		event         string
+		versionFolder string
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{"tag mode", args{uploadConfig{versionMode: config.TagMode}, "", releaseFolder}},
+		{"main mode", args{uploadConfig{versionMode: config.MainMode}, "", mainFolder}},
+		{"downstream mode", args{uploadConfig{versionMode: config.DownstreamMode}, "", mainFolder}},
+		{"release branch mode", args{uploadConfig{versionMode: config.ReleaseBranchMode}, "", releaseBranchFolder}},
+		{"enterprise pro mode", args{uploadConfig{versionMode: config.Enterprise2Mode}, config.Custom, releaseFolder}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			versionMode := getVersionFolder(tt.args.cfg, tt.args.event)
+			require.Equal(t, versionMode, tt.args.versionFolder)
+		})
+	}
+}
+
+func Test_checkForEnterprise2Edition(t *testing.T) {
+	type args struct {
+		releaseModeConfig *config.BuildConfig
+		event             string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+		err  error
+	}{
+		{"event is not custom", args{releaseModeConfig: &config.BuildConfig{Buckets: config.Buckets{ArtifactsEnterprise2: "dummy"}}}, "dummy", nil},
+		{"event is not custom and string is empty", args{releaseModeConfig: &config.BuildConfig{Buckets: config.Buckets{ArtifactsEnterprise2: ""}}}, "", fmt.Errorf("enterprise2 bucket var doesn't exist")},
+		{"event is custom", args{releaseModeConfig: nil, event: "custom"}, "grafana-downloads-enterprise2", nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := bucketForEnterprise2(tt.args.releaseModeConfig, tt.args.event)
+			if tt.err != nil {
+				require.Error(t, err)
+			}
+			assert.Equalf(t, tt.want, got, "bucketForEnterprise2(%v, %v)", tt.args.releaseModeConfig, tt.args.event)
+		})
+	}
+}


### PR DESCRIPTION
**What is this feature?**

Enterprise2 mode is a bit broken when it comes to storing artifacts to bucket. This is a quick solution to address the issue.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana-release-engineering/issues/52
