### PR TITLE
Chore: Fix cue imports when we don't use an alias

### DIFF
--- a/pkg/plugins/codegen/util_ts.go
+++ b/pkg/plugins/codegen/util_ts.go
@@ -61,7 +61,7 @@ func convertImport(im *ast.ImportSpec) (tsast.ImportSpec, error) {
 	if im.Name != nil && im.Name.String() != "" {
 		tsim.AsName = im.Name.String()
 	} else {
-		sl := strings.Split(im.Path.Value, "/")
+		sl := strings.Split(strings.Trim(im.Path.Value, "\""), "/")
 		final := sl[len(sl)-1]
 		if idx := strings.Index(final, ":"); idx != -1 {
 			tsim.AsName = final[idx:]


### PR DESCRIPTION
It fixes https://github.com/grafana/cuetsy/issues/76.

The issue is that we didn't cleanup the double quotes of the imports before split them. 
So given an import like: `"grafana/pkg/src/schema"`, when we were executing the following:
```go
strings.Split(im.Path.Value, "/")
```
the result was
```go
["grafana pkg src schema"]
```

And its why we were setting this annoying `"`.

_I spent a lot of time thinking that it was a `cuetsy` issue 😒...._