### PR TITLE
Query Builder: Fix max width of input component to prevent overflows

### DIFF
--- a/packages/grafana-ui/src/components/Input/AutoSizeInput.test.tsx
+++ b/packages/grafana-ui/src/components/Input/AutoSizeInput.test.tsx
@@ -1,13 +1,15 @@
-import { screen, render, fireEvent } from '@testing-library/react';
+import { screen, render, fireEvent, waitFor } from '@testing-library/react';
 import React from 'react';
+
+import { measureText } from '../../utils/measureText';
 
 import { AutoSizeInput } from './AutoSizeInput';
 
 jest.mock('../../utils/measureText', () => {
   // Mocking measureText
-  const measureText = (text: string, fontSize: number) => {
+  const measureText = jest.fn().mockImplementation((text: string, fontSize: number) => {
     return { width: text.length * fontSize };
-  };
+  });
 
   return { measureText };
 });
@@ -93,5 +95,27 @@ describe('AutoSizeInput', () => {
     fireEvent.keyDown(input, { key: 'Enter' });
 
     expect(onCommitChange).toHaveBeenCalled();
+  });
+
+  it('should respect min width', async () => {
+    render(<AutoSizeInput minWidth={4} defaultValue="" />);
+
+    await waitFor(() => expect(measureText).toHaveBeenCalled());
+
+    expect(getComputedStyle(screen.getByTestId('input-wrapper')).width).toBe('32px');
+  });
+
+  it('should respect max width', async () => {
+    render(
+      <AutoSizeInput
+        minWidth={1}
+        maxWidth={4}
+        defaultValue="thisisareallylongvalueandwhenisaylongireallymeanreallylongwithlotsofcharacterscommingfromuserinputwhotookthetimetocomeupwithalongstreamofcharacters"
+      />
+    );
+
+    await waitFor(() => expect(measureText).toHaveBeenCalled());
+
+    expect(getComputedStyle(screen.getByTestId('input-wrapper')).width).toBe('32px');
   });
 });

--- a/packages/grafana-ui/src/components/Input/AutoSizeInput.tsx
+++ b/packages/grafana-ui/src/components/Input/AutoSizeInput.tsx
@@ -63,7 +63,7 @@ function getWidthFor(value: string, minWidth: number, maxWidth: number | undefin
   }
 
   if (maxWidth && realWidth > maxWidth) {
-    return realWidth;
+    return maxWidth;
   }
 
   return realWidth;

--- a/public/app/plugins/datasource/prometheus/querybuilder/shared/OperationParamEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/shared/OperationParamEditor.tsx
@@ -38,6 +38,7 @@ function SimpleInputParamEditor(props: QueryBuilderOperationParamEditorProps) {
       minWidth={props.paramDef.minWidth}
       placeholder={props.paramDef.placeholder}
       title={props.paramDef.description}
+      maxWidth={(props.paramDef.minWidth || 20) * 2}
       onCommitChange={(evt) => {
         props.onChange(props.index, evt.currentTarget.value);
         if (props.paramDef.runQueryOnEnter && evt.type === 'keydown') {

--- a/public/app/plugins/datasource/prometheus/querybuilder/shared/OperationParamEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/shared/OperationParamEditor.tsx
@@ -38,7 +38,7 @@ function SimpleInputParamEditor(props: QueryBuilderOperationParamEditorProps) {
       minWidth={props.paramDef.minWidth}
       placeholder={props.paramDef.placeholder}
       title={props.paramDef.description}
-      maxWidth={(props.paramDef.minWidth || 20) * 2}
+      maxWidth={(props.paramDef.minWidth || 20) * 3}
       onCommitChange={(evt) => {
         props.onChange(props.index, evt.currentTarget.value);
         if (props.paramDef.runQueryOnEnter && evt.type === 'keydown') {


### PR DESCRIPTION
There was a bug in the AutoSize component, preventing it of using the `maxWidth` value. Also, we were not setting a `maxWidth` for the editor, so its value was undefined.


**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/52301

**Special notes for your reviewer**:

Try the query builders, it should respect the max width and not overflow the container.