### PR TITLE
Packaging: Use base64 key

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -6385,13 +6385,13 @@ kind: secret
 name: azure_tenant
 ---
 get:
-  name: public-key
+  name: public-key-b64
   path: infra/data/ci/packages-publish/gpg
 kind: secret
 name: packages_gpg_public_key
 ---
 get:
-  name: private-key
+  name: private-key-b64
   path: infra/data/ci/packages-publish/gpg
 kind: secret
 name: packages_gpg_private_key
@@ -6439,6 +6439,6 @@ kind: secret
 name: aws_secret_access_key
 ---
 kind: signature
-hmac: b00c47739d5af79f368c649765e1ac22d89ef4e4539166ad54650642ffc163e0
+hmac: 7f74588652e48e6c51cd54fb9973289c144f09d2f232fe30fe66b5d51b9b317e
 
 ...

--- a/scripts/drone/vault.star
+++ b/scripts/drone/vault.star
@@ -52,12 +52,12 @@ def secrets():
         vault_secret(
             'packages_gpg_public_key',
             'infra/data/ci/packages-publish/gpg',
-            'public-key',
+            'public-key-b64',
         ),
         vault_secret(
             'packages_gpg_private_key',
             'infra/data/ci/packages-publish/gpg',
-            'private-key',
+            'private-key-b64',
         ),
         vault_secret(
             'packages_gpg_passphrase',


### PR DESCRIPTION
The tools in this repo need base64 but not in most other tools. 
I had to revert the change I made to the key I created another key for base64 that we can use here 
Follow-up to https://github.com/grafana/grafana/pull/61784