### PR TITLE
Alerting: Fix UI crashing when receiving certain NoData frames

### DIFF
--- a/public/app/features/alerting/unified/components/expressions/util.ts
+++ b/public/app/features/alerting/unified/components/expressions/util.ts
@@ -1,11 +1,20 @@
 import { DataFrame, Labels, roundDecimals } from '@grafana/data';
 
+/**
+ * ⚠️ `frame.fields` could be an empty array ⚠️
+ *
+ * TypeScript will NOT complain about it when accessing items via index signatures.
+ * Make sure to check for empty array or use optional chaining!
+ *
+ * see https://github.com/Microsoft/TypeScript/issues/13778
+ */
+
 const getSeriesName = (frame: DataFrame): string => {
-  return frame.name ?? formatLabels(frame.fields[0].labels ?? {});
+  return frame.name ?? formatLabels(frame.fields[0]?.labels ?? {});
 };
 
 const getSeriesValue = (frame: DataFrame) => {
-  const value = frame.fields[0].values.get(0);
+  const value = frame.fields[0]?.values.get(0);
 
   if (Number.isFinite(value)) {
     return roundDecimals(value, 5);


### PR DESCRIPTION
**What is this feature?**

This prevents the UI from crashing when receiving a particular `NoData` frame response (a data frame with no fields).

**Special notes for your reviewer**:

none

