### PR TITLE
Docs: Use the correct name for the feedback_links_enabled option

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -550,9 +550,9 @@ Optionally, use this option to override the default endpoint address for Applica
 
 <hr />
 
-### enable_feedback_links
+### feedback_links_enabled
 
-If set to false will remove all feedback links from the UI. Defaults to true.
+Set to `false` to remove all feedback links from the UI. Default is `true`.
 
 ## [security]
 


### PR DESCRIPTION
Also updates the description to be more in line with the style conventions.

The configuration option was introduced in 057ff5bcf53e5e89965913f2195483979502419a. The option name used was the same ("feedback_links_enabled") everywhere except in the documentation page.