### PR TITLE
Docs: Disambiguate auto_assign_org_role configuration option descriptions

### DIFF
--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -413,7 +413,7 @@
 # Set this value to automatically add new users to the provided organization (if auto_assign_org above is set to true)
 ;auto_assign_org_id = 1
 
-# Default role new users will be automatically assigned (if disabled above is set to true)
+# Default role new users will be automatically assigned (if auto_assign_org above is set to true)
 ;auto_assign_org_role = Viewer
 
 # Require email validation before sign up completes

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -753,7 +753,7 @@ that this organization already exists. Default is 1.
 ### auto_assign_org_role
 
 The role new users will be assigned for the main organization (if the
-above setting is set to true). Defaults to `Viewer`, other valid
+`auto_assign_org` setting is set to true). Defaults to `Viewer`, other valid
 options are `Admin` and `Editor`. e.g.:
 
 `auto_assign_org_role = Viewer`


### PR DESCRIPTION
Makes clear that `auto_assign_org_role` only has an effect when `auto_assign_org` is set to true.