### PR TITLE
TopNav: Fixes breadcrumb issues and title for apps when topnav is disabled

### DIFF
--- a/public/app/core/components/Breadcrumbs/utils.test.ts
+++ b/public/app/core/components/Breadcrumbs/utils.test.ts
@@ -144,5 +144,22 @@ describe('breadcrumb utils', () => {
         { text: 'My page', href: '/my-page' },
       ]);
     });
+
+    it('Should add breadcrumbs for child pages that have not set parentItem', () => {
+      const pageNav: NavModelItem = {
+        text: 'My page',
+        url: '/my-page',
+        children: [
+          { text: 'A', url: '/a', active: true },
+          { text: 'B', url: '/b' },
+        ],
+      };
+
+      expect(buildBreadcrumbs(mockHomeNav, pageNav, mockHomeNav)).toEqual([
+        { text: 'Home', href: '/home' },
+        { text: 'My page', href: '/my-page' },
+        { text: 'A', href: '/a' },
+      ]);
+    });
   });
 });

--- a/public/app/core/components/Breadcrumbs/utils.ts
+++ b/public/app/core/components/Breadcrumbs/utils.ts
@@ -16,6 +16,7 @@ export function buildBreadcrumbs(sectionNav: NavModelItem, pageNav?: NavModelIte
     if (urlSearchParams.has('editview')) {
       urlToMatch += `?editview=${urlSearchParams.get('editview')}`;
     }
+
     if (!foundHome && !node.hideFromBreadcrumbs) {
       if (homeNav && urlToMatch === homeNav.url) {
         crumbs.unshift({ text: getNavTitle(homeNav.id) ?? homeNav.text, href: node.url ?? '' });
@@ -31,7 +32,18 @@ export function buildBreadcrumbs(sectionNav: NavModelItem, pageNav?: NavModelIte
   }
 
   if (pageNav) {
-    addCrumbs(pageNav);
+    if (pageNav.url && pageNav.children) {
+      const child = pageNav.children.find((child) => child.active);
+      if (child) {
+        addCrumbs(child);
+        // Some pages set up children but they are not connected to parent pageNav
+        if (child.parentItem !== pageNav) {
+          addCrumbs(pageNav);
+        }
+      }
+    } else {
+      addCrumbs(pageNav);
+    }
   }
 
   addCrumbs(sectionNav);

--- a/public/app/features/plugins/components/AppRootPage.tsx
+++ b/public/app/features/plugins/components/AppRootPage.tsx
@@ -112,7 +112,8 @@ const stateSlice = createSlice({
           ...pluginNav,
           node: {
             ...pluginNav.main,
-            hideFromBreadcrumbs: true,
+            // Because breadcumbs code is also used to set title when topnav should only set hideFromBreadcrumbs when topnav is enabled
+            hideFromBreadcrumbs: config.featureToggles.topnav,
           },
         };
       }


### PR DESCRIPTION
This fixes issues with breadcrumbs when used from app plugins, the breadcrumbs for pages with tabs was not done correctly (missing the parent page). 

It also fixes an issue with page title for apps when topnav is disabled (empty title, which resulted in url shown as title). 

