### PR TITLE
Explore: Keyboard shortcut to go to explore

### DIFF
--- a/public/app/core/components/help/HelpModal.tsx
+++ b/public/app/core/components/help/HelpModal.tsx
@@ -7,6 +7,7 @@ import { Modal, useStyles2 } from '@grafana/ui';
 const shortcuts = {
   Global: [
     { keys: ['g', 'h'], description: 'Go to Home Dashboard' },
+    { keys: ['g', 'e'], description: 'Go to Explore' },
     { keys: ['g', 'p'], description: 'Go to Profile' },
     { keys: ['s', 'o'], description: 'Open search' },
     { keys: ['esc'], description: 'Exit edit/setting views' },

--- a/public/app/core/services/keybindingSrv.ts
+++ b/public/app/core/services/keybindingSrv.ts
@@ -38,6 +38,7 @@ export class KeybindingSrv {
       this.bind('g h', this.goToHome);
       this.bind('g a', this.openAlerting);
       this.bind('g p', this.goToProfile);
+      this.bind('g e', this.goToExplore);
       this.bind('s o', this.openSearch);
       this.bind('t a', this.makeAbsoluteTime);
       this.bind('f', this.openSearch);
@@ -109,6 +110,10 @@ export class KeybindingSrv {
 
   private goToProfile() {
     this.locationService.push('/profile');
+  }
+
+  private goToExplore() {
+    this.locationService.push('/explore');
   }
 
   private makeAbsoluteTime() {


### PR DESCRIPTION

Adds a keyboard shortcut `g e` which will open explore from any page, we have similar shortcuts for `g h` (Go home), and `g p` (Go to profile). I think a go to explore shortcut would be nice welcomed addition. 

