### PR TITLE
bug fix: when using custom root_url, we will fail to delete an alert rule whose title contains "/" 

### DIFF
--- a/pkg/web/macaron.go
+++ b/pkg/web/macaron.go
@@ -164,6 +164,7 @@ func (m *Macaron) createContext(rw http.ResponseWriter, req *http.Request) *Cont
 // Be aware that none of middleware will run without registering any router.
 func (m *Macaron) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	req.URL.Path = strings.TrimPrefix(req.URL.Path, m.urlPrefix)
+	req.URL.RawPath = strings.TrimPrefix(req.URL.RawPath, m.urlPrefix)
 	m.Router.ServeHTTP(rw, req)
 }
 


### PR DESCRIPTION
**What is this feature?**

1. When using root_url like https://xxx.com/some_prefix/, we will encounter 404 error when delete an alert rule whose title contains "/".
2. The root cause is, according to the behavior of url.EscapedPath() (which is called in t.Match(req.URL.EscapedPath())), when URL.RawPath and URL.Path differs, the function will escape '%2F' into "/", leading to mismatching between pattern and path. 
3. To fix it, just remove the urlPrefix from RawPath as well.
