### PR TITLE
SSE/Prom: Undo empty frame change that triggers 500s in SSE

### DIFF
--- a/pkg/tsdb/prometheus/querydata/response.go
+++ b/pkg/tsdb/prometheus/querydata/response.go
@@ -30,12 +30,6 @@ func (s *QueryData) parseResponse(ctx context.Context, q *models.Query, res *htt
 		VectorWideSeries: s.enableWideSeries,
 	})
 
-	// The ExecutedQueryString can be viewed in QueryInspector in UI
-	// Add frame to attach metadata to it
-	if len(r.Frames) == 0 {
-		r.Frames = append(r.Frames, data.NewFrame(""))
-	}
-
 	for _, frame := range r.Frames {
 		if s.enableWideSeries {
 			addMetadataToWideFrame(q, frame)

--- a/pkg/tsdb/prometheus/testdata/exemplar.result.golden.jsonc
+++ b/pkg/tsdb/prometheus/testdata/exemplar.result.golden.jsonc
@@ -26,16 +26,6 @@
 //  +-----------------------------------+-----------------+--------------------------------------------+----------------+-------------------+-------------------+----------------+----------------+--------------------+----------------+------------------+-----------------+-------------------+----------------------------------+
 //  
 //  
-//  
-//  Frame[1] {
-//      "executedQueryString": "Expr: histogram_quantile(0.99, sum(rate(traces_spanmetrics_duration_seconds_bucket[15s])) by (le))\nStep: 15s"
-//  }
-//  Name: 
-//  Dimensions: 0 Fields by 0 Rows
-//  +
-//  +
-//  
-//  
 //  🌟 This was machine generated.  Do not edit. 🌟
 {
   "status": 200,
@@ -1049,17 +1039,6 @@
             "83bf586cc62842c3187106bb40a6793d"
           ]
         ]
-      }
-    },
-    {
-      "schema": {
-        "meta": {
-          "executedQueryString": "Expr: histogram_quantile(0.99, sum(rate(traces_spanmetrics_duration_seconds_bucket[15s])) by (le))\nStep: 15s"
-        },
-        "fields": []
-      },
-      "data": {
-        "values": []
       }
     }
   ]

--- a/pkg/tsdb/prometheus/testdata/exemplar.result.streaming-wide.golden.jsonc
+++ b/pkg/tsdb/prometheus/testdata/exemplar.result.streaming-wide.golden.jsonc
@@ -26,16 +26,6 @@
 //  +-----------------------------------+-----------------+--------------------------------------------+----------------+-------------------+-------------------+----------------+----------------+--------------------+----------------+------------------+-----------------+-------------------+----------------------------------+
 //  
 //  
-//  
-//  Frame[1] {
-//      "executedQueryString": "Expr: histogram_quantile(0.99, sum(rate(traces_spanmetrics_duration_seconds_bucket[15s])) by (le))\nStep: 15s"
-//  }
-//  Name: 
-//  Dimensions: 0 Fields by 0 Rows
-//  +
-//  +
-//  
-//  
 //  🌟 This was machine generated.  Do not edit. 🌟
 {
   "status": 200,
@@ -1049,17 +1039,6 @@
             "83bf586cc62842c3187106bb40a6793d"
           ]
         ]
-      }
-    },
-    {
-      "schema": {
-        "meta": {
-          "executedQueryString": "Expr: histogram_quantile(0.99, sum(rate(traces_spanmetrics_duration_seconds_bucket[15s])) by (le))\nStep: 15s"
-        },
-        "fields": []
-      },
-      "data": {
-        "values": []
       }
     }
   ]


### PR DESCRIPTION
This resolves SSE getting 500s when Exemplars are enabled in a Prometheus query.

Reverts part of what was added in https://github.com/grafana/grafana/pull/61643

We were adding this empty frame to carry the metadata, but the way this currently behaves we end up adding an additional empty frame to a normal response with exemplars. So for now this removes this which fixes the 500 errors.

Other notes:
 - I notice the backend data response status property is coming through as 500 (although that isn't what was causing this)
 - As Ismail and I briefly discussed, setting response.Error while also return an error elsewhere throughout the prom code is confusing, will want to clean this up.
 - Multiple prom DB database (range + exmplar, or range+instant+exemplar etc) going into one ds call and refID is also problematic.