### PR TITLE
chore: move models/licensing into licensing service

### DIFF
--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/auth"
 	"github.com/grafana/grafana/pkg/services/authn"
 	"github.com/grafana/grafana/pkg/services/folder"
+	"github.com/grafana/grafana/pkg/services/licensing"
 	"github.com/grafana/grafana/pkg/services/oauthtoken"
 	"github.com/grafana/grafana/pkg/services/querylibrary"
 	"github.com/grafana/grafana/pkg/services/searchV2"
@@ -129,7 +130,7 @@ type HTTPServer struct {
 	RemoteCacheService           *remotecache.RemoteCache
 	ProvisioningService          provisioning.ProvisioningService
 	Login                        login.Service
-	License                      models.Licensing
+	License                      licensing.Licensing
 	AccessControl                accesscontrol.AccessControl
 	DataProxy                    *datasourceproxy.DataSourceProxyService
 	PluginRequestValidator       models.PluginRequestValidator
@@ -220,7 +221,7 @@ type ServerOptions struct {
 }
 
 func ProvideHTTPServer(opts ServerOptions, cfg *setting.Cfg, routeRegister routing.RouteRegister, bus bus.Bus,
-	renderService rendering.Service, licensing models.Licensing, hooksService *hooks.HooksService,
+	renderService rendering.Service, licensing licensing.Licensing, hooksService *hooks.HooksService,
 	cacheService *localcache.CacheService, sqlStore *sqlstore.SQLStore, alertEngine *alerting.AlertEngine,
 	pluginRequestValidator models.PluginRequestValidator, pluginStaticRouteResolver plugins.StaticRouteResolver,
 	pluginDashboardService plugindashboards.Service, pluginStore plugins.Store, pluginClient plugins.Client,

--- a/pkg/cmd/grafana-cli/runner/wireexts_oss.go
+++ b/pkg/cmd/grafana-cli/runner/wireexts_oss.go
@@ -41,7 +41,7 @@ var wireExtsSet = wire.NewSet(
 	wireSet,
 	migrations.ProvideOSSMigrations,
 	licensing.ProvideService,
-	wire.Bind(new(models.Licensing), new(*licensing.OSSLicensingService)),
+	wire.Bind(new(licensing.Licensing), new(*licensing.OSSLicensingService)),
 	wire.Bind(new(registry.DatabaseMigrator), new(*migrations.OSSMigrations)),
 	setting.ProvideProvider,
 	wire.Bind(new(setting.Provider), new(*setting.OSSImpl)),

--- a/pkg/plugins/licensing/licensing.go
+++ b/pkg/plugins/licensing/licensing.go
@@ -3,16 +3,16 @@ package licensing
 import (
 	"fmt"
 
-	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/licensing"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
 type Service struct {
 	licensePath string
-	license     models.Licensing
+	license     licensing.Licensing
 }
 
-func ProvideLicensing(cfg *setting.Cfg, l models.Licensing) *Service {
+func ProvideLicensing(cfg *setting.Cfg, l licensing.Licensing) *Service {
 	return &Service{
 		licensePath: cfg.EnterpriseLicensePath,
 		license:     l,
@@ -21,7 +21,7 @@ func ProvideLicensing(cfg *setting.Cfg, l models.Licensing) *Service {
 
 func (l Service) Environment() []string {
 	var env []string
-	if envProvider, ok := l.license.(models.LicenseEnvironment); ok {
+	if envProvider, ok := l.license.(licensing.LicenseEnvironment); ok {
 		for k, v := range envProvider.Environment() {
 			env = append(env, fmt.Sprintf("%s=%s", k, v))
 		}

--- a/pkg/server/wireexts_oss.go
+++ b/pkg/server/wireexts_oss.go
@@ -43,7 +43,7 @@ var wireExtsBasicSet = wire.NewSet(
 	wire.Bind(new(auth.UserTokenService), new(*authimpl.UserAuthTokenService)),
 	wire.Bind(new(auth.UserTokenBackgroundService), new(*authimpl.UserAuthTokenService)),
 	licensing.ProvideService,
-	wire.Bind(new(models.Licensing), new(*licensing.OSSLicensingService)),
+	wire.Bind(new(licensing.Licensing), new(*licensing.OSSLicensingService)),
 	setting.ProvideProvider,
 	wire.Bind(new(setting.Provider), new(*setting.OSSImpl)),
 	acimpl.ProvideService,

--- a/pkg/services/accesscontrol/acimpl/service_test.go
+++ b/pkg/services/accesscontrol/acimpl/service_test.go
@@ -11,13 +11,13 @@ import (
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/localcache"
 	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/models/roletype"
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/actest"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/database"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/licensing"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 )
@@ -278,7 +278,7 @@ func TestService_DeclarePluginRoles(t *testing.T) {
 func TestService_RegisterFixedRoles(t *testing.T) {
 	tests := []struct {
 		name          string
-		token         models.Licensing
+		token         licensing.Licensing
 		registrations []accesscontrol.RoleRegistration
 		wantErr       bool
 	}{

--- a/pkg/services/accesscontrol/ossaccesscontrol/permissions_services.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/permissions_services.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/resourcepermissions"
 	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/services/licensing"
 	"github.com/grafana/grafana/pkg/services/serviceaccounts"
 	"github.com/grafana/grafana/pkg/services/serviceaccounts/retriever"
 	"github.com/grafana/grafana/pkg/services/team"
@@ -40,7 +41,7 @@ var (
 
 func ProvideTeamPermissions(
 	cfg *setting.Cfg, router routing.RouteRegister, sql db.DB,
-	ac accesscontrol.AccessControl, license models.Licensing, service accesscontrol.Service,
+	ac accesscontrol.AccessControl, license licensing.Licensing, service accesscontrol.Service,
 	teamService team.Service, userService user.Service,
 ) (*TeamPermissionsService, error) {
 	options := resourcepermissions.Options{
@@ -114,7 +115,7 @@ var DashboardAdminActions = append(DashboardEditActions, []string{dashboards.Act
 
 func ProvideDashboardPermissions(
 	cfg *setting.Cfg, router routing.RouteRegister, sql db.DB, ac accesscontrol.AccessControl,
-	license models.Licensing, dashboardStore dashboards.Store, service accesscontrol.Service,
+	license licensing.Licensing, dashboardStore dashboards.Store, service accesscontrol.Service,
 	teamService team.Service, userService user.Service,
 ) (*DashboardPermissionsService, error) {
 	getDashboard := func(ctx context.Context, orgID int64, resourceID string) (*dashboards.Dashboard, error) {
@@ -193,7 +194,7 @@ var FolderAdminActions = append(FolderEditActions, []string{dashboards.ActionFol
 
 func ProvideFolderPermissions(
 	cfg *setting.Cfg, router routing.RouteRegister, sql db.DB, accesscontrol accesscontrol.AccessControl,
-	license models.Licensing, dashboardStore dashboards.Store, service accesscontrol.Service,
+	license licensing.Licensing, dashboardStore dashboards.Store, service accesscontrol.Service,
 	teamService team.Service, userService user.Service,
 ) (*FolderPermissionsService, error) {
 	options := resourcepermissions.Options{
@@ -284,7 +285,7 @@ type ServiceAccountPermissionsService struct {
 
 func ProvideServiceAccountPermissions(
 	cfg *setting.Cfg, router routing.RouteRegister, sql db.DB, ac accesscontrol.AccessControl,
-	license models.Licensing, serviceAccountRetrieverService *retriever.Service, service accesscontrol.Service,
+	license licensing.Licensing, serviceAccountRetrieverService *retriever.Service, service accesscontrol.Service,
 	teamService team.Service, userService user.Service,
 ) (*ServiceAccountPermissionsService, error) {
 	options := resourcepermissions.Options{

--- a/pkg/services/accesscontrol/resourcepermissions/service.go
+++ b/pkg/services/accesscontrol/resourcepermissions/service.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/infra/db"
-	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/licensing"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/team"
 	"github.com/grafana/grafana/pkg/services/user"
@@ -49,7 +49,7 @@ type Store interface {
 }
 
 func New(
-	options Options, cfg *setting.Cfg, router routing.RouteRegister, license models.Licensing,
+	options Options, cfg *setting.Cfg, router routing.RouteRegister, license licensing.Licensing,
 	ac accesscontrol.AccessControl, service accesscontrol.Service, sqlStore db.DB,
 	teamService team.Service, userService user.Service,
 ) (*Service, error) {
@@ -104,7 +104,7 @@ type Service struct {
 	service accesscontrol.Service
 	store   Store
 	api     *api
-	license models.Licensing
+	license licensing.Licensing
 
 	options     Options
 	permissions []string

--- a/pkg/services/featuremgmt/manager.go
+++ b/pkg/services/featuremgmt/manager.go
@@ -6,10 +6,10 @@ import (
 	"net/http"
 	"reflect"
 
-	"github.com/grafana/grafana/pkg/infra/log"
-
 	"github.com/grafana/grafana/pkg/api/response"
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/licensing"
 )
 
 var (
@@ -18,7 +18,7 @@ var (
 
 type FeatureManager struct {
 	isDevMod  bool
-	licensing models.Licensing
+	licensing licensing.Licensing
 	flags     map[string]*FeatureFlag
 	enabled   map[string]bool // only the "on" values
 	config    string          // path to config file

--- a/pkg/services/featuremgmt/service.go
+++ b/pkg/services/featuremgmt/service.go
@@ -5,12 +5,12 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/grafana/grafana/pkg/infra/log"
-
-	"github.com/grafana/grafana/pkg/models"
-	"github.com/grafana/grafana/pkg/setting"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/licensing"
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 var (
@@ -22,7 +22,7 @@ var (
 	}, []string{"name"})
 )
 
-func ProvideManagerService(cfg *setting.Cfg, licensing models.Licensing) (*FeatureManager, error) {
+func ProvideManagerService(cfg *setting.Cfg, licensing licensing.Licensing) (*FeatureManager, error) {
 	mgmt := &FeatureManager{
 		isDevMod:  setting.Env != setting.Prod,
 		licensing: licensing,

--- a/pkg/services/featuremgmt/service_test.go
+++ b/pkg/services/featuremgmt/service_test.go
@@ -3,9 +3,10 @@ package featuremgmt
 import (
 	"testing"
 
-	"github.com/grafana/grafana/pkg/models"
-	"github.com/grafana/grafana/pkg/setting"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/services/licensing"
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 func TestFeatureService(t *testing.T) {
@@ -47,7 +48,7 @@ func TestFeatureService(t *testing.T) {
 }
 
 var (
-	_ models.Licensing = (*stubLicenseServier)(nil)
+	_ licensing.Licensing = (*stubLicenseServier)(nil)
 )
 
 type stubLicenseServier struct {

--- a/pkg/services/licensing/licensingtest/fake.go
+++ b/pkg/services/licensing/licensingtest/fake.go
@@ -3,10 +3,10 @@ package licensingtest
 import (
 	"github.com/stretchr/testify/mock"
 
-	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/licensing"
 )
 
-var _ models.Licensing = new(FakeLicensing)
+var _ licensing.Licensing = new(FakeLicensing)
 
 func NewFakeLicensing() *FakeLicensing {
 	return &FakeLicensing{&mock.Mock{}}

--- a/pkg/services/licensing/models.go
+++ b/pkg/services/licensing/models.go
@@ -1,4 +1,4 @@
-package models
+package licensing
 
 type Licensing interface {
 	// Expiry returns the unix epoch timestamp when the license expires, or 0 if no valid license is provided

--- a/pkg/services/thumbs/service.go
+++ b/pkg/services/thumbs/service.go
@@ -10,9 +10,6 @@ import (
 
 	"github.com/segmentio/encoding/json"
 
-	"github.com/grafana/grafana/pkg/services/datasources/permissions"
-	"github.com/grafana/grafana/pkg/services/searchV2"
-
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -20,10 +17,13 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/registry"
 	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/services/datasources/permissions"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/guardian"
+	"github.com/grafana/grafana/pkg/services/licensing"
 	"github.com/grafana/grafana/pkg/services/live"
 	"github.com/grafana/grafana/pkg/services/rendering"
+	"github.com/grafana/grafana/pkg/services/searchV2"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/web"
 )
@@ -60,7 +60,7 @@ type thumbService struct {
 	dashboardService           dashboards.DashboardService
 	dsUidsLookup               getDatasourceUidsForDashboard
 	dsPermissionsService       permissions.DatasourcePermissionsService
-	licensing                  models.Licensing
+	licensing                  licensing.Licensing
 	searchService              searchV2.SearchService
 }
 
@@ -78,7 +78,7 @@ func ProvideService(cfg *setting.Cfg, features featuremgmt.FeatureToggles,
 	lockService *serverlock.ServerLockService, renderService rendering.Service,
 	gl *live.GrafanaLive, store db.DB, authSetupService CrawlerAuthSetupService,
 	dashboardService dashboards.DashboardService, dashboardThumbsService DashboardThumbService, searchService searchV2.SearchService,
-	dsPermissionsService permissions.DatasourcePermissionsService, licensing models.Licensing) Service {
+	dsPermissionsService permissions.DatasourcePermissionsService, licensing licensing.Licensing) Service {
 	if !features.IsEnabled(featuremgmt.FlagDashboardPreviews) {
 		return &dummyService{}
 	}


### PR DESCRIPTION
Part of the backend platform squad's project to move models from the `models` package to their owning services:

* `models.Licensing` -> `licensing.Licensing` 

enterprise PR to follow