### PR TITLE
Docs: Update default value for geomaps enable_custom_baselayers option

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -2140,7 +2140,7 @@ default_baselayer_config = `{
 
 ### enable_custom_baselayers
 
-Set this to `true` to disable loading other custom base maps and hide them in the Grafana UI. Default is `false`.
+Set this to `false` to disable loading other custom base maps and hide them in the Grafana UI. Default is `true`.
 
 ## [dashboard_previews]
 


### PR DESCRIPTION
Configuration options for the Geomap plugin were introduced in commit 3b0d7fc00b3110225dbbe74177ad8f86a62b003d. The option to enable or disable loading other base map layers was originally named `disable_custom_baselayers`, with a default value of `false`.

The `disable_custom_baselayers` configuration option name and default value were inverted in commit e604e69d937b7c958a6be310651f12375afb701f, but the update to the description in the documentation was missed.