### PR TITLE
Explore: Cancel loading queries if closing split pane

### DIFF
--- a/public/app/features/explore/ExploreToolbar.tsx
+++ b/public/app/features/explore/ExploreToolbar.tsx
@@ -88,7 +88,10 @@ class UnConnectedExploreToolbar extends PureComponent<Props> {
   };
 
   onCloseSplitView = () => {
-    const { closeSplit, exploreId } = this.props;
+    const { closeSplit, cancelQueries, exploreId, loading } = this.props;
+    if (loading) {
+      cancelQueries(exploreId);
+    }
     closeSplit(exploreId);
     reportInteraction('grafana_explore_split_view_closed');
   };


### PR DESCRIPTION
**What is this feature?**

This fixes a bug where a query does not get cancelled when the pane it is running in is closed. In the case of a slow query, if the pane is closed before the query is finished, it will put result data into state after the pane is hidden, which will cause some parts of the UI to act as though both panes are open.

This logic cancels the query being ran when the pane is closed.

Fixes #61422 

**Special notes for your reviewer**:
Replication Steps:

1. Use testdata datasource
2. Under Scenario, use Slow Query
3. Open a split pane, then hit close on the newly opened right pane before the slow query has finished. Wait for the slow query on the now hidden right pane to finish.

Before fix: The states of both the left and right panes will have data when the query finishes. This will trigger the split button on the left pane to show "Close" and behave as though the right pane is now showing when it is not.

After fix: After closing, the right pane query will be cancelled and no behavior change will take place.

Testing note: There are currently no tests in place for ExploreToolbar, where this fix is located. I recommend a separate effort to add tests around this logic rather than delay this bug fix.