### PR TITLE
CloudWatch: Prevent log groups from being removed on query change

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/components/LogsCheatSheet.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/LogsCheatSheet.tsx
@@ -237,6 +237,7 @@ export default class LogsCheatSheet extends PureComponent<
             region: this.props.query.region,
             id: this.props.query.refId ?? 'A',
             logGroupNames: 'logGroupNames' in this.props.query ? this.props.query.logGroupNames : [],
+            logGroups: 'logGroups' in this.props.query ? this.props.query.logGroups : [],
           })
         }
       >


### PR DESCRIPTION
**Which issue(s) does this PR fix?**:
The bug from https://github.com/grafana/grafana/issues/33626 was reintroduced by the log groups refactor, and this makes sure that log groups are preserved when using the hint queries.

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #61890 

**Special notes for your reviewer**:

