### PR TITLE
Kindsys: Generate plugin Go types under a kinds/ dir

### DIFF
--- a/pkg/plugins/codegen/jenny_plugingotypes.go
+++ b/pkg/plugins/codegen/jenny_plugingotypes.go
@@ -5,20 +5,24 @@ import (
 	"path/filepath"
 	"strings"
 
+	copenapi "cuelang.org/go/encoding/openapi"
+	"github.com/dave/dst/dstutil"
 	"github.com/grafana/codejen"
+	corecodegen "github.com/grafana/grafana/pkg/codegen"
 	"github.com/grafana/grafana/pkg/plugins/pfs"
+	"github.com/grafana/thema/encoding/gocode"
+	"github.com/grafana/thema/encoding/openapi"
 )
 
-func PluginGoTypesJenny(root string, inner codejen.OneToOne[*pfs.PluginDecl]) codejen.OneToOne[*pfs.PluginDecl] {
+// TODO this is duplicative of other Go type jennies. Remove it in favor of a better-abstracted version in thema itself
+func PluginGoTypesJenny(root string) codejen.OneToOne[*pfs.PluginDecl] {
 	return &pgoJenny{
-		inner: inner,
-		root:  root,
+		root: root,
 	}
 }
 
 type pgoJenny struct {
-	inner codejen.OneToOne[*pfs.PluginDecl]
-	root  string
+	root string
 }
 
 func (j *pgoJenny) JennyName() string {
@@ -31,16 +35,22 @@ func (j *pgoJenny) Generate(decl *pfs.PluginDecl) (*codejen.File, error) {
 		return nil, nil
 	}
 
-	f, err := j.inner.Generate(decl)
+	slotname := strings.ToLower(decl.SchemaInterface.Name())
+	byt, err := gocode.GenerateTypesOpenAPI(decl.Lineage.Latest(), &gocode.TypeConfigOpenAPI{
+		Config: &openapi.Config{
+			Group: decl.SchemaInterface.IsGroup(),
+			Config: &copenapi.Config{
+				ExpandReferences: true,
+			},
+		},
+		PackageName: slotname,
+		ApplyFuncs:  []dstutil.ApplyFunc{corecodegen.PrefixDropper(decl.Lineage.Name()), corecodegen.DecoderCompactor()},
+	})
 	if err != nil {
 		return nil, err
 	}
 
 	pluginfolder := filepath.Base(decl.PluginPath)
-	slotname := strings.ToLower(decl.SchemaInterface.Name())
 	filename := fmt.Sprintf("types_%s_gen.go", slotname)
-	f.RelativePath = filepath.Join(j.root, pluginfolder, filename)
-	f.From = append(f.From, j)
-
-	return f, nil
+	return codejen.NewFile(filepath.Join(j.root, pluginfolder, "kinds", slotname, filename), byt, j), nil
 }

--- a/public/app/plugins/gen.go
+++ b/public/app/plugins/gen.go
@@ -54,7 +54,7 @@ func main() {
 
 	pluginKindGen.Append(
 		codegen.PluginTreeListJenny(),
-		codegen.PluginGoTypesJenny("pkg/tsdb", adaptToPipeline(corecodegen.GoTypesJenny{ExpandReferences: true})),
+		codegen.PluginGoTypesJenny("pkg/tsdb"),
 		codegen.PluginTSTypesJenny("public/app/plugins", adaptToPipeline(corecodegen.TSTypesJenny{})),
 	)
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This changes the output directory for generated Go types corresponding to composable kinds (currently only generated for the `DataQuery` and `DataSourceCfg` schema interfaces that datasource plugins are generally expected to implement) such that instead of being generated in e.g. `pkg/tsdb/prometheus/types_dataquery_gen.go`, it appears in `pkg/tsdb/prometheus/kinds/dataquery/types_dataquery_gen.go`.

This basically guarantees generated code will not cohabit with any existing packages, thereby precluding the possibility of import cycles such as were encountered by prometheus folks in #61872.

It also fixes the `package` name for generated code to align with this directory structure.

**Why do we need this feature?**

Without this, many datasource plugins won't be able to meaningfully schematize their plugins.

**Who is this feature for?**

Core datasource plugin authors.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

