### PR TITLE
AuthN: Add interface and function to operate on clients that supports redirects

### DIFF
--- a/pkg/services/authn/authn.go
+++ b/pkg/services/authn/authn.go
@@ -60,6 +60,8 @@ type Service interface {
 	Login(ctx context.Context, client string, r *Request) (*Identity, error)
 	// RegisterPostLoginHook registers a hook that that is called after a login request.
 	RegisterPostLoginHook(hook PostLoginHookFn)
+	// RedirectURL will generate url that we can use to initiate auth flow for supported clients.
+	RedirectURL(ctx context.Context, client string, r *Request) (string, error)
 }
 
 type Client interface {
@@ -67,6 +69,11 @@ type Client interface {
 	Authenticate(ctx context.Context, r *Request) (*Identity, error)
 	// Test should return true if client can be used to authenticate request
 	Test(ctx context.Context, r *Request) bool
+}
+
+type RedirectClient interface {
+	Client
+	RedirectURL(ctx context.Context, r *Request) (string, error)
 }
 
 type PasswordClient interface {

--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -29,6 +29,10 @@ import (
 	"github.com/grafana/grafana/pkg/web"
 )
 
+const (
+	attributeKeyClient = "authn.client"
+)
+
 var (
 	errDisabledIdentity = errutil.NewBase(errutil.StatusUnauthorized, "identity.disabled")
 )
@@ -218,6 +222,24 @@ func (s *Service) Login(ctx context.Context, client string, r *authn.Request) (i
 
 func (s *Service) RegisterPostLoginHook(hook authn.PostLoginHookFn) {
 	s.postLoginHooks = append(s.postLoginHooks, hook)
+}
+
+func (s *Service) RedirectURL(ctx context.Context, client string, r *authn.Request) (string, error) {
+	ctx, span := s.tracer.Start(ctx, "authn.RedirectURL")
+	defer span.End()
+	span.SetAttributes(attributeKeyClient, client, attribute.Key(attributeKeyClient).String(client))
+
+	c, ok := s.clients[client]
+	if !ok {
+		return "", authn.ErrClientNotConfigured.Errorf("client not configured: %s", client)
+	}
+
+	redirectClient, ok := c.(authn.RedirectClient)
+	if !ok {
+		return "", authn.ErrUnsupportedClient.Errorf("client does not support generating redirect url: %s", client)
+	}
+
+	return redirectClient.RedirectURL(ctx, r)
 }
 
 func orgIDFromRequest(r *authn.Request) int64 {

--- a/pkg/services/authn/authntest/fake.go
+++ b/pkg/services/authn/authntest/fake.go
@@ -36,3 +36,24 @@ type FakePasswordClient struct {
 func (f FakePasswordClient) AuthenticatePassword(ctx context.Context, r *authn.Request, username, password string) (*authn.Identity, error) {
 	return f.ExpectedIdentity, f.ExpectedErr
 }
+
+var _ authn.RedirectClient = new(FakeRedirectClient)
+
+type FakeRedirectClient struct {
+	ExpectedErr      error
+	ExpectedURL      string
+	ExpectedOK       bool
+	ExpectedIdentity *authn.Identity
+}
+
+func (f FakeRedirectClient) Authenticate(ctx context.Context, r *authn.Request) (*authn.Identity, error) {
+	return f.ExpectedIdentity, f.ExpectedErr
+}
+
+func (f FakeRedirectClient) Test(ctx context.Context, r *authn.Request) bool {
+	return f.ExpectedOK
+}
+
+func (f FakeRedirectClient) RedirectURL(ctx context.Context, r *authn.Request) (string, error) {
+	return f.ExpectedURL, f.ExpectedErr
+}

--- a/pkg/services/authn/error.go
+++ b/pkg/services/authn/error.go
@@ -3,6 +3,7 @@ package authn
 import "github.com/grafana/grafana/pkg/util/errutil"
 
 var (
+	ErrUnsupportedClient   = errutil.NewBase(errutil.StatusBadRequest, "auth.client.unsupported")
 	ErrClientNotConfigured = errutil.NewBase(errutil.StatusBadRequest, "auth.client.notConfigured")
 	ErrUnsupportedIdentity = errutil.NewBase(errutil.StatusNotImplemented, "auth.identity.unsupported")
 )


### PR DESCRIPTION
**What is this feature?**
Some authentication clients, Oauth and SAML, needs to support generating redirect URÖ.

This pr adds a simple extension interface to authn.Client for generating a URL. This would be used in when we wan't too initiate the authentication flow for these kind of clients. 

Fixes #

**Special notes for your reviewer**:

