### PR TITLE
PublicDashboards: Configuration modal UI fixed

### DIFF
--- a/packages/grafana-ui/src/components/Forms/Checkbox.tsx
+++ b/packages/grafana-ui/src/components/Forms/Checkbox.tsx
@@ -14,10 +14,11 @@ export interface CheckboxProps extends Omit<HTMLProps<HTMLInputElement>, 'value'
   value?: boolean;
   // htmlValue allows to specify the input "value" attribute
   htmlValue?: string | number;
+  labelClassName?: string;
 }
 
 export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
-  ({ label, description, value, htmlValue, onChange, disabled, className, ...inputProps }, ref) => {
+  ({ label, description, value, htmlValue, onChange, disabled, className, labelClassName, ...inputProps }, ref) => {
     const handleOnChange = useCallback(
       (e: React.ChangeEvent<HTMLInputElement>) => {
         if (onChange) {
@@ -41,7 +42,7 @@ export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
           ref={ref}
         />
         <span className={styles.checkmark} />
-        {label && <span className={styles.label}>{label}</span>}
+        {label && <span className={cx(styles.label, labelClassName)}>{label}</span>}
         {description && <span className={styles.description}>{description}</span>}
       </label>
     );

--- a/packages/grafana-ui/src/components/Layout/Layout.tsx
+++ b/packages/grafana-ui/src/components/Layout/Layout.tsx
@@ -11,7 +11,7 @@ enum Orientation {
 }
 type Spacing = 'none' | 'xs' | 'sm' | 'md' | 'lg';
 type Justify = 'flex-start' | 'flex-end' | 'space-between' | 'center';
-export type Align = 'normal' | 'flex-start' | 'flex-end' | 'center';
+type Align = 'normal' | 'flex-start' | 'flex-end' | 'center';
 
 export interface LayoutProps extends Omit<HTMLProps<HTMLDivElement>, 'align' | 'children' | 'wrap'> {
   children: React.ReactNode[] | React.ReactNode;

--- a/packages/grafana-ui/src/components/Layout/Layout.tsx
+++ b/packages/grafana-ui/src/components/Layout/Layout.tsx
@@ -11,7 +11,7 @@ enum Orientation {
 }
 type Spacing = 'none' | 'xs' | 'sm' | 'md' | 'lg';
 type Justify = 'flex-start' | 'flex-end' | 'space-between' | 'center';
-type Align = 'normal' | 'flex-start' | 'flex-end' | 'center';
+export type Align = 'normal' | 'flex-start' | 'flex-end' | 'center';
 
 export interface LayoutProps extends Omit<HTMLProps<HTMLDivElement>, 'align' | 'children' | 'wrap'> {
   children: React.ReactNode[] | React.ReactNode;

--- a/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/AcknowledgeCheckboxes.tsx
+++ b/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/AcknowledgeCheckboxes.tsx
@@ -5,7 +5,6 @@ import { UseFormRegister } from 'react-hook-form';
 import { GrafanaTheme2 } from '@grafana/data/src';
 import { selectors as e2eSelectors } from '@grafana/e2e-selectors/src';
 import { Checkbox, FieldSet, HorizontalGroup, LinkButton, useStyles2, VerticalGroup } from '@grafana/ui/src';
-import { Align } from '@grafana/ui/src/components/Layout/Layout';
 
 import { SharePublicDashboardAcknowledgmentInputs, SharePublicDashboardInputs } from './SharePublicDashboard';
 
@@ -13,7 +12,6 @@ type Acknowledge = {
   type: keyof SharePublicDashboardAcknowledgmentInputs;
   description: string;
   testId: string;
-  align?: Align;
   info: {
     href: string;
     tooltip: string;
@@ -42,10 +40,8 @@ const ACKNOWLEDGES: Acknowledge[] = [
   },
   {
     type: 'usageAcknowledgment',
-    description:
-      'Making your dashboard public will cause queries to run each time the dashboard is viewed which may increase costs',
+    description: 'Making a dashboard public causes queries to run each time it is viewed, which may increase costs',
     testId: selectors.CostIncreaseCheckbox,
-    align: 'flex-start',
     info: {
       href: 'https://grafana.com/docs/grafana/latest/enterprise/query-caching/',
       tooltip: 'Learn more about query caching',
@@ -68,7 +64,7 @@ export const AcknowledgeCheckboxes = ({
       <FieldSet disabled={disabled}>
         <VerticalGroup spacing="md">
           {ACKNOWLEDGES.map((acknowledge) => (
-            <HorizontalGroup key={acknowledge.type} spacing="none" align={acknowledge.align || 'flex-end'}>
+            <HorizontalGroup key={acknowledge.type} spacing="none" align="center">
               <Checkbox
                 {...register(acknowledge.type)}
                 label={acknowledge.description}
@@ -102,5 +98,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
     white-space: break-spaces;
     max-width: fit-content;
     line-height: ${theme.typography.bodySmall.lineHeight};
+    margin-bottom: 0;
   `,
 });

--- a/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/AcknowledgeCheckboxes.tsx
+++ b/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/AcknowledgeCheckboxes.tsx
@@ -1,10 +1,57 @@
+import { css } from '@emotion/css';
 import React from 'react';
 import { UseFormRegister } from 'react-hook-form';
 
+import { GrafanaTheme2 } from '@grafana/data/src';
 import { selectors as e2eSelectors } from '@grafana/e2e-selectors/src';
-import { Checkbox, FieldSet, HorizontalGroup, LinkButton, VerticalGroup } from '@grafana/ui/src';
+import { Checkbox, FieldSet, HorizontalGroup, LinkButton, useStyles2, VerticalGroup } from '@grafana/ui/src';
+import { Align } from '@grafana/ui/src/components/Layout/Layout';
 
-import { SharePublicDashboardInputs } from './SharePublicDashboard';
+import { SharePublicDashboardAcknowledgmentInputs, SharePublicDashboardInputs } from './SharePublicDashboard';
+
+type Acknowledge = {
+  type: keyof SharePublicDashboardAcknowledgmentInputs;
+  description: string;
+  testId: string;
+  align?: Align;
+  info: {
+    href: string;
+    tooltip: string;
+  };
+};
+const selectors = e2eSelectors.pages.ShareDashboardModal.PublicDashboard;
+
+const ACKNOWLEDGES: Acknowledge[] = [
+  {
+    type: 'publicAcknowledgment',
+    description: 'Your entire dashboard will be public',
+    testId: selectors.WillBePublicCheckbox,
+    info: {
+      href: 'https://grafana.com/docs/grafana/latest/dashboards/dashboard-public/',
+      tooltip: 'Learn more about public dashboards',
+    },
+  },
+  {
+    type: 'dataSourcesAcknowledgment',
+    description: 'Publishing currently only works with a subset of datasources',
+    testId: selectors.LimitedDSCheckbox,
+    info: {
+      href: 'https://grafana.com/docs/grafana/latest/datasources/',
+      tooltip: 'Learn more about public datasources',
+    },
+  },
+  {
+    type: 'usageAcknowledgment',
+    description:
+      'Making your dashboard public will cause queries to run each time the dashboard is viewed which may increase costs',
+    testId: selectors.CostIncreaseCheckbox,
+    align: 'flex-start',
+    info: {
+      href: 'https://grafana.com/docs/grafana/latest/enterprise/query-caching/',
+      tooltip: 'Learn more about query caching',
+    },
+  },
+];
 
 export const AcknowledgeCheckboxes = ({
   disabled,
@@ -13,64 +60,47 @@ export const AcknowledgeCheckboxes = ({
   disabled: boolean;
   register: UseFormRegister<SharePublicDashboardInputs>;
 }) => {
-  const selectors = e2eSelectors.pages.ShareDashboardModal.PublicDashboard;
+  const styles = useStyles2(getStyles);
 
   return (
     <>
       <p>Before you click Save, please acknowledge the following information:</p>
       <FieldSet disabled={disabled}>
         <VerticalGroup spacing="md">
-          <HorizontalGroup spacing="none">
-            <Checkbox
-              {...register('publicAcknowledgment')}
-              label="Your entire dashboard will be public"
-              data-testid={selectors.WillBePublicCheckbox}
-            />
-
-            <LinkButton
-              variant="primary"
-              href="https://grafana.com/docs/grafana/latest/dashboards/dashboard-public/"
-              target="_blank"
-              fill="text"
-              icon="info-circle"
-              rel="noopener noreferrer"
-              tooltip="Learn more about public dashboards"
-            />
-          </HorizontalGroup>
-          <HorizontalGroup spacing="none">
-            <Checkbox
-              {...register('dataSourcesAcknowledgment')}
-              label="Publishing currently only works with a subset of datasources"
-              data-testid={selectors.LimitedDSCheckbox}
-            />
-            <LinkButton
-              variant="primary"
-              href="https://grafana.com/docs/grafana/latest/datasources/"
-              target="_blank"
-              fill="text"
-              icon="info-circle"
-              rel="noopener noreferrer"
-              tooltip="Learn more about public datasources"
-            />
-          </HorizontalGroup>
-          <HorizontalGroup spacing="none">
-            <Checkbox
-              {...register('usageAcknowledgment')}
-              label="Making your dashboard public will cause queries to run each time the dashboard is viewed which may increase costs"
-              data-testid={selectors.CostIncreaseCheckbox}
-            />
-            <LinkButton
-              variant="primary"
-              href="https://grafana.com/docs/grafana/latest/enterprise/query-caching/"
-              target="_blank"
-              fill="text"
-              icon="info-circle"
-              rel="noopener noreferrer"
-              tooltip="Learn more about query caching"
-            />
-          </HorizontalGroup>
+          {ACKNOWLEDGES.map((acknowledge) => (
+            <HorizontalGroup key={acknowledge.type} spacing="none" align={acknowledge.align || 'flex-end'}>
+              <Checkbox
+                {...register(acknowledge.type)}
+                label={acknowledge.description}
+                data-testid={acknowledge.testId}
+                className={styles.checkbox}
+                labelClassName={styles.checkboxLabel}
+              />
+              <LinkButton
+                variant="primary"
+                href={acknowledge.info.href}
+                target="_blank"
+                fill="text"
+                icon="info-circle"
+                rel="noopener noreferrer"
+                tooltip={acknowledge.info.tooltip}
+              />
+            </HorizontalGroup>
+          ))}
         </VerticalGroup>
       </FieldSet>
     </>
   );
 };
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  checkbox: css`
+    display: flex;
+    align-items: baseline;
+  `,
+  checkboxLabel: css`
+    white-space: break-spaces;
+    max-width: fit-content;
+    line-height: ${theme.typography.bodySmall.lineHeight};
+  `,
+});

--- a/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/SharePublicDashboard.tsx
+++ b/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/SharePublicDashboard.tsx
@@ -45,7 +45,7 @@ import { ShareModal } from '../ShareModal';
 
 interface Props extends ShareModalTabProps {}
 
-type SharePublicDashboardAcknowledgmentInputs = {
+export type SharePublicDashboardAcknowledgmentInputs = {
   publicAcknowledgment: boolean;
   dataSourcesAcknowledgment: boolean;
   usageAcknowledgment: boolean;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

It fixes the alignment of one of the acknowledge checkboxes.

**Why do we need this feature?**

The UI was not good.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes [#60665](https://github.com/grafana/grafana/issues/60665)

**Special notes for your reviewer**:

**Before** 
_Desktop_
<img width="742" alt="image" src="https://user-images.githubusercontent.com/11707172/214040343-3dccd486-01c9-469b-8a10-5760d32300ad.png">

_Mobile_
<img width="429" alt="image" src="https://user-images.githubusercontent.com/11707172/214040537-da42f693-8559-471a-8db6-c2fca1d72d92.png">

**After** 
_Desktop_
<img width="752" alt="image" src="https://user-images.githubusercontent.com/11707172/214040628-37cf4c74-d033-47e2-a61c-bbb0d8c24af7.png">

_Mobile_
<img width="420" alt="image" src="https://user-images.githubusercontent.com/11707172/214040680-fcb46d3b-57d7-469c-b290-b97173319e5b.png">




