### PR TITLE
CI: Remove `grabpl integration-tests`

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3183,7 +3183,9 @@ steps:
   name: mysql-integration-tests
 - commands:
   - dockerize -wait tcp://redis:6379/0 -timeout 120s
-  - ./bin/grabpl integration-tests
+  - go clean -testcache
+  - go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic
+    -timeout=5m {}'
   depends_on:
   - wire-install
   environment:
@@ -3192,7 +3194,9 @@ steps:
   name: redis-integration-tests
 - commands:
   - dockerize -wait tcp://memcached:11211 -timeout 120s
-  - ./bin/grabpl integration-tests
+  - go clean -testcache
+  - go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic
+    -timeout=5m {}'
   depends_on:
   - wire-install
   environment:
@@ -5831,7 +5835,9 @@ steps:
   name: mysql-integration-tests
 - commands:
   - dockerize -wait tcp://redis:6379/0 -timeout 120s
-  - ./bin/grabpl integration-tests
+  - go clean -testcache
+  - go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic
+    -timeout=5m {}'
   depends_on:
   - wire-install
   environment:
@@ -5840,7 +5846,9 @@ steps:
   name: redis-integration-tests
 - commands:
   - dockerize -wait tcp://memcached:11211 -timeout 120s
-  - ./bin/grabpl integration-tests
+  - go clean -testcache
+  - go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic
+    -timeout=5m {}'
   depends_on:
   - wire-install
   environment:
@@ -6443,6 +6451,6 @@ kind: secret
 name: aws_secret_access_key
 ---
 kind: signature
-hmac: 59d802aec2892f9bdd89caaa68d0a563cf14cedefe9e76646f3b734e69afa40d
+hmac: 5b2831b92627887ebe7ee9963796449981a12a96ea775a331fb84536598536ce
 
 ...

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -943,7 +943,8 @@ def redis_integration_tests_step():
         },
         'commands': [
             'dockerize -wait tcp://redis:6379/0 -timeout 120s',
-            './bin/grabpl integration-tests',
+            'go clean -testcache',
+            "go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic -timeout=5m {}'",
         ],
     }
 
@@ -958,7 +959,8 @@ def memcached_integration_tests_step():
         },
         'commands': [
             'dockerize -wait tcp://memcached:11211 -timeout 120s',
-            './bin/grabpl integration-tests',
+            'go clean -testcache',
+            "go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic -timeout=5m {}'",
         ],
     }
 


### PR DESCRIPTION
**What is this feature?**

The integration tests that are currently triggered through `grabpl integration-tests` can also be triggered without that dependency.

Part of: https://github.com/grafana/grafana-release-engineering/issues/51