### PR TITLE
Tempo Datasource: Correct TraceQL docs link

### DIFF
--- a/public/app/plugins/datasource/tempo/traceql/QueryEditor.tsx
+++ b/public/app/plugins/datasource/tempo/traceql/QueryEditor.tsx
@@ -25,11 +25,7 @@ export function QueryEditor(props: Props) {
     <>
       <InlineLabel>
         Build complex queries using TraceQL to select a list of traces.{' '}
-        <a
-          rel="noreferrer"
-          target="_blank"
-          href="https://grafana.com/docs/tempo/latest/traceql/"
-        >
+        <a rel="noreferrer" target="_blank" href="https://grafana.com/docs/tempo/latest/traceql/">
           Documentation
         </a>
       </InlineLabel>

--- a/public/app/plugins/datasource/tempo/traceql/QueryEditor.tsx
+++ b/public/app/plugins/datasource/tempo/traceql/QueryEditor.tsx
@@ -28,7 +28,7 @@ export function QueryEditor(props: Props) {
         <a
           rel="noreferrer"
           target="_blank"
-          href="https://github.com/grafana/tempo/blob/main/docs/design-proposals/2022-04%20TraceQL%20Concepts.md"
+          href="https://grafana.com/docs/tempo/latest/traceql/"
         >
           Documentation
         </a>


### PR DESCRIPTION
This PR corrects the Tempo datasource docs link pictured here:

![image](https://user-images.githubusercontent.com/2272392/214080738-2609f8bc-9f83-4aa1-be67-23e034b3081f.png)

The core concepts doc it is currently linked to was an early doc that discussed the basic ideas of TraceQL and includes future features not yet released. The proposed link contains only current TraceQL features and will be updated as the language evolves.