### PR TITLE
Chore: Use same JSON tag casing everywhere for parent UID

### DIFF
--- a/pkg/api/dtos/folder.go
+++ b/pkg/api/dtos/folder.go
@@ -31,5 +31,5 @@ type FolderSearchHit struct {
 	Uid           string                 `json:"uid"`
 	Title         string                 `json:"title"`
 	AccessControl accesscontrol.Metadata `json:"accessControl,omitempty"`
-	ParentUID     string                 `json:"parent_uid,omitempty"`
+	ParentUID     string                 `json:"parentUid,omitempty"`
 }

--- a/pkg/api/folder.go
+++ b/pkg/api/folder.go
@@ -39,7 +39,7 @@ func (hs *HTTPServer) GetFolders(c *models.ReqContext) response.Response {
 			OrgID:        c.OrgID,
 			Limit:        c.QueryInt64("limit"),
 			Page:         c.QueryInt64("page"),
-			UID:          c.Query("parent_uid"),
+			UID:          c.Query("parentUid"),
 			SignedInUser: c.SignedInUser,
 		})
 	} else {
@@ -340,7 +340,7 @@ type GetFoldersParams struct {
 	// The parent folder UID
 	// in:query
 	// required:false
-	ParentUID string `json:"parent_uid"`
+	ParentUID string `json:"parentUid"`
 }
 
 // swagger:parameters getFolderByUID

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -3058,7 +3058,7 @@
         "tags": [
           "provisioning"
         ],
-        "summary": "Updates an existing template.",
+        "summary": "Updates an existing notification template.",
         "operationId": "RoutePutTemplate",
         "parameters": [
           {
@@ -5240,7 +5240,7 @@
     },
     "/folders": {
       "get": {
-        "description": "Returns all folders that the authenticated user has permission to view.\nIf nested folders are enabled, it expects an additional query parameter with the parent folder UID.",
+        "description": "Returns all folders that the authenticated user has permission to view.\nIf nested folders are enabled, it expects an additional query parameter with the parent folder UID\nand returns the immediate subfolders.",
         "tags": [
           "folders"
         ],
@@ -5266,7 +5266,7 @@
           {
             "type": "string",
             "description": "The parent folder UID",
-            "name": "parent_uid",
+            "name": "parentUid",
             "in": "query"
           }
         ],
@@ -12218,9 +12218,6 @@
         "hasAcl": {
           "type": "boolean"
         },
-        "hasPublicDashboard": {
-          "type": "boolean"
-        },
         "isFolder": {
           "type": "boolean"
         },
@@ -13179,7 +13176,7 @@
           "type": "integer",
           "format": "int64"
         },
-        "parent_uid": {
+        "parentUid": {
           "type": "string"
         },
         "title": {
@@ -14447,34 +14444,6 @@
         "$ref": "#/definitions/Matcher"
       }
     },
-    "NotificationTemplate": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "provenance": {
-          "$ref": "#/definitions/Provenance"
-        },
-        "template": {
-          "type": "string"
-        }
-      }
-    },
-    "NotificationTemplateContent": {
-      "type": "object",
-      "properties": {
-        "template": {
-          "type": "string"
-        }
-      }
-    },
-    "NotificationTemplates": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/NotificationTemplate"
-      }
-    },
     "Metadata": {
       "description": "Metadata contains user accesses for a given resource\nEx: map[string]bool{\"create\":true, \"delete\": true}",
       "type": "object",
@@ -14646,6 +14615,34 @@
       "type": "integer",
       "format": "int64",
       "title": "NoticeSeverity is a type for the Severity property of a Notice."
+    },
+    "NotificationTemplate": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "provenance": {
+          "$ref": "#/definitions/Provenance"
+        },
+        "template": {
+          "type": "string"
+        }
+      }
+    },
+    "NotificationTemplateContent": {
+      "type": "object",
+      "properties": {
+        "template": {
+          "type": "string"
+        }
+      }
+    },
+    "NotificationTemplates": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/NotificationTemplate"
+      }
     },
     "NotificationTestCommand": {
       "type": "object",
@@ -18578,7 +18575,6 @@
       }
     },
     "alertGroups": {
-      "description": "AlertGroups alert groups",
       "type": "array",
       "items": {
         "$ref": "#/definitions/alertGroup"
@@ -18739,14 +18735,12 @@
       }
     },
     "gettableAlerts": {
-      "description": "GettableAlerts gettable alerts",
       "type": "array",
       "items": {
         "$ref": "#/definitions/gettableAlert"
       }
     },
     "gettableSilence": {
-      "description": "GettableSilence gettable silence",
       "type": "object",
       "required": [
         "comment",
@@ -18795,7 +18789,6 @@
       }
     },
     "gettableSilences": {
-      "description": "GettableSilences gettable silences",
       "type": "array",
       "items": {
         "$ref": "#/definitions/gettableSilence"
@@ -18982,6 +18975,7 @@
       }
     },
     "receiver": {
+      "description": "Receiver receiver",
       "type": "object",
       "required": [
         "active",

--- a/public/api-spec.json
+++ b/public/api-spec.json
@@ -4568,7 +4568,7 @@
     },
     "/folders": {
       "get": {
-        "description": "Returns all folders that the authenticated user has permission to view.\nIf nested folders are enabled, it expects an additional query parameter with the parent folder UID.",
+        "description": "Returns all folders that the authenticated user has permission to view.\nIf nested folders are enabled, it expects an additional query parameter with the parent folder UID\nand returns the immediate subfolders.",
         "tags": [
           "folders"
         ],
@@ -4594,7 +4594,7 @@
           {
             "type": "string",
             "description": "The parent folder UID",
-            "name": "parent_uid",
+            "name": "parentUid",
             "in": "query"
           }
         ],
@@ -11159,9 +11159,6 @@
         "hasAcl": {
           "type": "boolean"
         },
-        "hasPublicDashboard": {
-          "type": "boolean"
-        },
         "isFolder": {
           "type": "boolean"
         },
@@ -11919,7 +11916,7 @@
           "type": "integer",
           "format": "int64"
         },
-        "parent_uid": {
+        "parentUid": {
           "type": "string"
         },
         "title": {

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -3534,9 +3534,6 @@
           "hasAcl": {
             "type": "boolean"
           },
-          "hasPublicDashboard": {
-            "type": "boolean"
-          },
           "isFolder": {
             "type": "boolean"
           },
@@ -4495,7 +4492,7 @@
             "format": "int64",
             "type": "integer"
           },
-          "parent_uid": {
+          "parentUid": {
             "type": "string"
           },
           "title": {
@@ -5764,34 +5761,6 @@
         },
         "type": "array"
       },
-      "NotificationTemplate": {
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "provenance": {
-            "$ref": "#/components/schemas/Provenance"
-          },
-          "template": {
-            "type": "string"
-          }
-        },
-        "type": "object"
-      },
-      "NotificationTemplateContent": {
-        "properties": {
-          "template": {
-            "type": "string"
-          }
-        },
-        "type": "object"
-      },
-      "NotificationTemplates": {
-        "items": {
-          "$ref": "#/components/schemas/NotificationTemplate"
-        },
-        "type": "array"
-      },
       "Metadata": {
         "additionalProperties": {
           "type": "boolean"
@@ -5963,6 +5932,34 @@
         "format": "int64",
         "title": "NoticeSeverity is a type for the Severity property of a Notice.",
         "type": "integer"
+      },
+      "NotificationTemplate": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "provenance": {
+            "$ref": "#/components/schemas/Provenance"
+          },
+          "template": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "NotificationTemplateContent": {
+        "properties": {
+          "template": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "NotificationTemplates": {
+        "items": {
+          "$ref": "#/components/schemas/NotificationTemplate"
+        },
+        "type": "array"
       },
       "NotificationTestCommand": {
         "properties": {
@@ -9893,7 +9890,6 @@
         "type": "object"
       },
       "alertGroups": {
-        "description": "AlertGroups alert groups",
         "items": {
           "$ref": "#/components/schemas/alertGroup"
         },
@@ -10054,14 +10050,12 @@
         "type": "object"
       },
       "gettableAlerts": {
-        "description": "GettableAlerts gettable alerts",
         "items": {
           "$ref": "#/components/schemas/gettableAlert"
         },
         "type": "array"
       },
       "gettableSilence": {
-        "description": "GettableSilence gettable silence",
         "properties": {
           "comment": {
             "description": "comment",
@@ -10110,7 +10104,6 @@
         "type": "object"
       },
       "gettableSilences": {
-        "description": "GettableSilences gettable silences",
         "items": {
           "$ref": "#/components/schemas/gettableSilence"
         },
@@ -10297,6 +10290,7 @@
         "type": "object"
       },
       "receiver": {
+        "description": "Receiver receiver",
         "properties": {
           "active": {
             "description": "active",
@@ -13835,7 +13829,7 @@
             "description": "ValidationError"
           }
         },
-        "summary": "Updates an existing template.",
+        "summary": "Updates an existing notification template.",
         "tags": [
           "provisioning"
         ]
@@ -16131,7 +16125,7 @@
     },
     "/folders": {
       "get": {
-        "description": "Returns all folders that the authenticated user has permission to view.\nIf nested folders are enabled, it expects an additional query parameter with the parent folder UID.",
+        "description": "Returns all folders that the authenticated user has permission to view.\nIf nested folders are enabled, it expects an additional query parameter with the parent folder UID\nand returns the immediate subfolders.",
         "operationId": "getFolders",
         "parameters": [
           {
@@ -16157,7 +16151,7 @@
           {
             "description": "The parent folder UID",
             "in": "query",
-            "name": "parent_uid",
+            "name": "parentUid",
             "schema": {
               "type": "string"
             }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

In the nested folder API we have used both `parentUid` or `parent_uid`. This fix uses `parentUid` everywhere.

This is a breaking change for the nested folder API but this API is not currently used in production (it's behind the feature flag and the respective migration is commented out) so we think it's fine to merge this change now without a notice.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

