### PR TITLE
panels: Remove redundant import package from cue defs

### DIFF
--- a/public/app/plugins/panel/barchart/panelcfg.cue
+++ b/public/app/plugins/panel/barchart/panelcfg.cue
@@ -15,7 +15,7 @@
 package grafanaplugin
 
 import (
-	ui "github.com/grafana/grafana/packages/grafana-schema/src/common"
+	"github.com/grafana/grafana/packages/grafana-schema/src/common"
 )
 
 composableKinds: PanelCfg: {
@@ -28,16 +28,16 @@ composableKinds: PanelCfg: {
 					// v0.0
 					{
 						PanelOptions: {
-							ui.OptionsWithLegend
-							ui.OptionsWithTooltip
-							ui.OptionsWithTextFormatting
+							common.OptionsWithLegend
+							common.OptionsWithTooltip
+							common.OptionsWithTextFormatting
 
 							// Manually select which field from the dataset to represent the x field.
 							xField?: string
 							// Use the color value for a sibling field to color each bar value.
 							colorByField?: string
 							// Controls the orientation of the bar chart, either vertical or horizontal.
-							orientation: ui.VizOrientation | *"auto"
+							orientation: common.VizOrientation | *"auto"
 							// Controls the radius of each bar.
 							barRadius?: float64 & >=0 & <=0.5 | *0
 							// Controls the rotation of the x axis labels.
@@ -48,9 +48,9 @@ composableKinds: PanelCfg: {
 							// negative values indicate backwards skipping behavior
 							xTickLabelSpacing?: int32 | *0
 							// Controls whether bars are stacked or not, either normally or in percent mode.
-							stacking: ui.StackingMode | *"none"
+							stacking: common.StackingMode | *"none"
 							// This controls whether values are shown on top or to the left of bars.
-							showValue: ui.VisibilityMode | *"auto"
+							showValue: common.VisibilityMode | *"auto"
 							// Controls the width of bars. 1 = Max width, 0 = Min width.
 							barWidth: float64 & >=0 & <=1 | *0.97
 							// Controls the width of groups. 1 = max with, 0 = min width.
@@ -60,8 +60,8 @@ composableKinds: PanelCfg: {
 							fullHighlight: bool | *false
 						} @cuetsy(kind="interface")
 						PanelFieldConfig: {
-							ui.AxisConfig
-							ui.HideableFieldConfig
+							common.AxisConfig
+							common.HideableFieldConfig
 
 							// Controls line width of the bars.
 							lineWidth?: int32 & >=0 & <=10 | *1
@@ -69,9 +69,9 @@ composableKinds: PanelCfg: {
 							fillOpacity?: int32 & >=0 & <=100 | *80
 							// Set the mode of the gradient fill. Fill gradient is based on the line color. To change the color, use the standard color scheme field option.
 							// Gradient appearance is influenced by the Fill opacity setting.
-							gradientMode?: ui.GraphGradientMode | *"none"
+							gradientMode?: common.GraphGradientMode | *"none"
 							// Threshold rendering
-							thresholdsStyle?: ui.GraphThresholdsStyleConfig
+							thresholdsStyle?: common.GraphThresholdsStyleConfig
 						} @cuetsy(kind="interface")
 					},
 				]

--- a/public/app/plugins/panel/barchart/panelcfg.gen.ts
+++ b/public/app/plugins/panel/barchart/panelcfg.gen.ts
@@ -8,11 +8,11 @@
 //
 // Run 'make gen-cue' from repository root to regenerate.
 
-import * as ui from '@grafana/schema';
+import * as common from '@grafana/schema';
 
 export const PanelCfgModelVersion = Object.freeze([0, 0]);
 
-export interface PanelOptions extends ui.OptionsWithLegend, ui.OptionsWithTooltip, ui.OptionsWithTextFormatting {
+export interface PanelOptions extends common.OptionsWithLegend, common.OptionsWithTooltip, common.OptionsWithTextFormatting {
   /**
    * Controls the radius of each bar.
    */
@@ -37,15 +37,15 @@ export interface PanelOptions extends ui.OptionsWithLegend, ui.OptionsWithToolti
   /**
    * Controls the orientation of the bar chart, either vertical or horizontal.
    */
-  orientation: ui.VizOrientation;
+  orientation: common.VizOrientation;
   /**
    * This controls whether values are shown on top or to the left of bars.
    */
-  showValue: ui.VisibilityMode;
+  showValue: common.VisibilityMode;
   /**
    * Controls whether bars are stacked or not, either normally or in percent mode.
    */
-  stacking: ui.StackingMode;
+  stacking: common.StackingMode;
   /**
    * Manually select which field from the dataset to represent the x field.
    */
@@ -70,14 +70,14 @@ export const defaultPanelOptions: Partial<PanelOptions> = {
   barWidth: 0.97,
   fullHighlight: false,
   groupWidth: 0.7,
-  orientation: ui.VizOrientation.Auto,
-  showValue: ui.VisibilityMode.Auto,
-  stacking: ui.StackingMode.None,
+  orientation: common.VizOrientation.Auto,
+  showValue: common.VisibilityMode.Auto,
+  stacking: common.StackingMode.None,
   xTickLabelRotation: 0,
   xTickLabelSpacing: 0,
 };
 
-export interface PanelFieldConfig extends ui.AxisConfig, ui.HideableFieldConfig {
+export interface PanelFieldConfig extends common.AxisConfig, common.HideableFieldConfig {
   /**
    * Controls the fill opacity of the bars.
    */
@@ -86,7 +86,7 @@ export interface PanelFieldConfig extends ui.AxisConfig, ui.HideableFieldConfig 
    * Set the mode of the gradient fill. Fill gradient is based on the line color. To change the color, use the standard color scheme field option.
    * Gradient appearance is influenced by the Fill opacity setting.
    */
-  gradientMode?: ui.GraphGradientMode;
+  gradientMode?: common.GraphGradientMode;
   /**
    * Controls line width of the bars.
    */
@@ -94,11 +94,11 @@ export interface PanelFieldConfig extends ui.AxisConfig, ui.HideableFieldConfig 
   /**
    * Threshold rendering
    */
-  thresholdsStyle?: ui.GraphThresholdsStyleConfig;
+  thresholdsStyle?: common.GraphThresholdsStyleConfig;
 }
 
 export const defaultPanelFieldConfig: Partial<PanelFieldConfig> = {
   fillOpacity: 80,
-  gradientMode: ui.GraphGradientMode.None,
+  gradientMode: common.GraphGradientMode.None,
   lineWidth: 1,
 };

--- a/public/app/plugins/panel/bargauge/panelcfg.cue
+++ b/public/app/plugins/panel/bargauge/panelcfg.cue
@@ -15,7 +15,7 @@
 package grafanaplugin
 
 import (
-	ui "github.com/grafana/grafana/packages/grafana-schema/src/common"
+	"github.com/grafana/grafana/packages/grafana-schema/src/common"
 )
 
 composableKinds: PanelCfg: {
@@ -27,8 +27,8 @@ composableKinds: PanelCfg: {
 				schemas: [
 					{
 						PanelOptions: {
-							ui.SingleStatBaseOptions
-							displayMode:  ui.BarGaugeDisplayMode | *"gradient"
+							common.SingleStatBaseOptions
+							displayMode:  common.BarGaugeDisplayMode | *"gradient"
 							showUnfilled: bool | *true
 							minVizWidth:  uint32 | *0
 							minVizHeight: uint32 | *10

--- a/public/app/plugins/panel/bargauge/panelcfg.gen.ts
+++ b/public/app/plugins/panel/bargauge/panelcfg.gen.ts
@@ -8,19 +8,19 @@
 //
 // Run 'make gen-cue' from repository root to regenerate.
 
-import * as ui from '@grafana/schema';
+import * as common from '@grafana/schema';
 
 export const PanelCfgModelVersion = Object.freeze([0, 0]);
 
-export interface PanelOptions extends ui.SingleStatBaseOptions {
-  displayMode: ui.BarGaugeDisplayMode;
+export interface PanelOptions extends common.SingleStatBaseOptions {
+  displayMode: common.BarGaugeDisplayMode;
   minVizHeight: number;
   minVizWidth: number;
   showUnfilled: boolean;
 }
 
 export const defaultPanelOptions: Partial<PanelOptions> = {
-  displayMode: ui.BarGaugeDisplayMode.Gradient,
+  displayMode: common.BarGaugeDisplayMode.Gradient,
   minVizHeight: 10,
   minVizWidth: 0,
   showUnfilled: true,

--- a/public/app/plugins/panel/gauge/panelcfg.cue
+++ b/public/app/plugins/panel/gauge/panelcfg.cue
@@ -15,7 +15,7 @@
 package grafanaplugin
 
 import (
-	ui "github.com/grafana/grafana/packages/grafana-schema/src/common"
+	"github.com/grafana/grafana/packages/grafana-schema/src/common"
 )
 
 composableKinds: PanelCfg: {
@@ -27,7 +27,7 @@ composableKinds: PanelCfg: {
 				schemas: [
 					{
 						PanelOptions: {
-							ui.SingleStatBaseOptions
+							common.SingleStatBaseOptions
 							showThresholdLabels:  bool | *false
 							showThresholdMarkers: bool | *true
 						} @cuetsy(kind="interface")

--- a/public/app/plugins/panel/gauge/panelcfg.gen.ts
+++ b/public/app/plugins/panel/gauge/panelcfg.gen.ts
@@ -8,11 +8,11 @@
 //
 // Run 'make gen-cue' from repository root to regenerate.
 
-import * as ui from '@grafana/schema';
+import * as common from '@grafana/schema';
 
 export const PanelCfgModelVersion = Object.freeze([0, 0]);
 
-export interface PanelOptions extends ui.SingleStatBaseOptions {
+export interface PanelOptions extends common.SingleStatBaseOptions {
   showThresholdLabels: boolean;
   showThresholdMarkers: boolean;
 }

--- a/public/app/plugins/panel/histogram/panelcfg.cue
+++ b/public/app/plugins/panel/histogram/panelcfg.cue
@@ -15,7 +15,7 @@
 package grafanaplugin
 
 import (
-	ui "github.com/grafana/grafana/packages/grafana-schema/src/common"
+	"github.com/grafana/grafana/packages/grafana-schema/src/common"
 )
 
 composableKinds: PanelCfg: {
@@ -27,8 +27,8 @@ composableKinds: PanelCfg: {
 				schemas: [
 					{
 						PanelOptions: {
-							ui.OptionsWithLegend
-							ui.OptionsWithTooltip
+							common.OptionsWithLegend
+							common.OptionsWithTooltip
 
 							//Size of each bucket
 							bucketSize?: int32
@@ -39,8 +39,8 @@ composableKinds: PanelCfg: {
 						} @cuetsy(kind="interface")
 
 						PanelFieldConfig: {
-							ui.AxisConfig
-							ui.HideableFieldConfig
+							common.AxisConfig
+							common.HideableFieldConfig
 
 							// Controls line width of the bars.
 							lineWidth?: uint32 & <=10 | *1
@@ -48,7 +48,7 @@ composableKinds: PanelCfg: {
 							fillOpacity?: uint32 & <=100 | *80
 							// Set the mode of the gradient fill. Fill gradient is based on the line color. To change the color, use the standard color scheme field option.
 							// Gradient appearance is influenced by the Fill opacity setting.
-							gradientMode?: ui.GraphGradientMode | *"none"
+							gradientMode?: common.GraphGradientMode | *"none"
 						} @cuetsy(kind="interface")
 					},
 				]

--- a/public/app/plugins/panel/histogram/panelcfg.gen.ts
+++ b/public/app/plugins/panel/histogram/panelcfg.gen.ts
@@ -8,11 +8,11 @@
 //
 // Run 'make gen-cue' from repository root to regenerate.
 
-import * as ui from '@grafana/schema';
+import * as common from '@grafana/schema';
 
 export const PanelCfgModelVersion = Object.freeze([0, 0]);
 
-export interface PanelOptions extends ui.OptionsWithLegend, ui.OptionsWithTooltip {
+export interface PanelOptions extends common.OptionsWithLegend, common.OptionsWithTooltip {
   /**
    * Offset buckets by this amount
    */
@@ -31,7 +31,7 @@ export const defaultPanelOptions: Partial<PanelOptions> = {
   bucketOffset: 0,
 };
 
-export interface PanelFieldConfig extends ui.AxisConfig, ui.HideableFieldConfig {
+export interface PanelFieldConfig extends common.AxisConfig, common.HideableFieldConfig {
   /**
    * Controls the fill opacity of the bars.
    */
@@ -40,7 +40,7 @@ export interface PanelFieldConfig extends ui.AxisConfig, ui.HideableFieldConfig 
    * Set the mode of the gradient fill. Fill gradient is based on the line color. To change the color, use the standard color scheme field option.
    * Gradient appearance is influenced by the Fill opacity setting.
    */
-  gradientMode?: ui.GraphGradientMode;
+  gradientMode?: common.GraphGradientMode;
   /**
    * Controls line width of the bars.
    */
@@ -49,6 +49,6 @@ export interface PanelFieldConfig extends ui.AxisConfig, ui.HideableFieldConfig 
 
 export const defaultPanelFieldConfig: Partial<PanelFieldConfig> = {
   fillOpacity: 80,
-  gradientMode: ui.GraphGradientMode.None,
+  gradientMode: common.GraphGradientMode.None,
   lineWidth: 1,
 };

--- a/public/app/plugins/panel/piechart/panelcfg.cue
+++ b/public/app/plugins/panel/piechart/panelcfg.cue
@@ -15,7 +15,7 @@
 package grafanaplugin
 
 import (
-	ui "github.com/grafana/grafana/packages/grafana-schema/src/common"
+	"github.com/grafana/grafana/packages/grafana-schema/src/common"
 )
 
 composableKinds: PanelCfg: {
@@ -39,17 +39,17 @@ composableKinds: PanelCfg: {
 						//  - Value: The raw numerical value.
 						PieChartLegendValues: "value" | "percent" @cuetsy(kind="enum")
 						PieChartLegendOptions: {
-							ui.VizLegendOptions
+							common.VizLegendOptions
 							values: [...PieChartLegendValues]
 						} @cuetsy(kind="interface")
 						PanelOptions: {
-							ui.OptionsWithTooltip
-							ui.SingleStatBaseOptions
+							common.OptionsWithTooltip
+							common.SingleStatBaseOptions
 							pieType: PieChartType
 							displayLabels: [...PieChartLabels]
 							legend: PieChartLegendOptions
 						} @cuetsy(kind="interface")
-						PanelFieldConfig: ui.HideableFieldConfig @cuetsy(kind="interface")
+						PanelFieldConfig: common.HideableFieldConfig @cuetsy(kind="interface")
 					},
 				]
 			},

--- a/public/app/plugins/panel/piechart/panelcfg.gen.ts
+++ b/public/app/plugins/panel/piechart/panelcfg.gen.ts
@@ -8,7 +8,7 @@
 //
 // Run 'make gen-cue' from repository root to regenerate.
 
-import * as ui from '@grafana/schema';
+import * as common from '@grafana/schema';
 
 export const PanelCfgModelVersion = Object.freeze([0, 0]);
 
@@ -42,7 +42,7 @@ export enum PieChartLegendValues {
   Value = 'value',
 }
 
-export interface PieChartLegendOptions extends ui.VizLegendOptions {
+export interface PieChartLegendOptions extends common.VizLegendOptions {
   values: Array<PieChartLegendValues>;
 }
 
@@ -50,7 +50,7 @@ export const defaultPieChartLegendOptions: Partial<PieChartLegendOptions> = {
   values: [],
 };
 
-export interface PanelOptions extends ui.OptionsWithTooltip, ui.SingleStatBaseOptions {
+export interface PanelOptions extends common.OptionsWithTooltip, common.SingleStatBaseOptions {
   displayLabels: Array<PieChartLabels>;
   legend: PieChartLegendOptions;
   pieType: PieChartType;
@@ -60,4 +60,4 @@ export const defaultPanelOptions: Partial<PanelOptions> = {
   displayLabels: [],
 };
 
-export interface PanelFieldConfig extends ui.HideableFieldConfig {}
+export interface PanelFieldConfig extends common.HideableFieldConfig {}

--- a/public/app/plugins/panel/stat/panelcfg.cue
+++ b/public/app/plugins/panel/stat/panelcfg.cue
@@ -15,7 +15,7 @@
 package grafanaplugin
 
 import (
-	ui "github.com/grafana/grafana/packages/grafana-schema/src/common"
+	"github.com/grafana/grafana/packages/grafana-schema/src/common"
 )
 
 composableKinds: PanelCfg: {
@@ -27,11 +27,11 @@ composableKinds: PanelCfg: {
 				schemas: [
 					{
 						PanelOptions: {
-							ui.SingleStatBaseOptions
-							graphMode:   ui.BigValueGraphMode | *"area"
-							colorMode:   ui.BigValueColorMode | *"value"
-							justifyMode: ui.BigValueJustifyMode | *"auto"
-							textMode:    ui.BigValueTextMode | *"auto"
+							common.SingleStatBaseOptions
+							graphMode:   common.BigValueGraphMode | *"area"
+							colorMode:   common.BigValueColorMode | *"value"
+							justifyMode: common.BigValueJustifyMode | *"auto"
+							textMode:    common.BigValueTextMode | *"auto"
 						} @cuetsy(kind="interface")
 					},
 				]

--- a/public/app/plugins/panel/stat/panelcfg.gen.ts
+++ b/public/app/plugins/panel/stat/panelcfg.gen.ts
@@ -8,20 +8,20 @@
 //
 // Run 'make gen-cue' from repository root to regenerate.
 
-import * as ui from '@grafana/schema';
+import * as common from '@grafana/schema';
 
 export const PanelCfgModelVersion = Object.freeze([0, 0]);
 
-export interface PanelOptions extends ui.SingleStatBaseOptions {
-  colorMode: ui.BigValueColorMode;
-  graphMode: ui.BigValueGraphMode;
-  justifyMode: ui.BigValueJustifyMode;
-  textMode: ui.BigValueTextMode;
+export interface PanelOptions extends common.SingleStatBaseOptions {
+  colorMode: common.BigValueColorMode;
+  graphMode: common.BigValueGraphMode;
+  justifyMode: common.BigValueJustifyMode;
+  textMode: common.BigValueTextMode;
 }
 
 export const defaultPanelOptions: Partial<PanelOptions> = {
-  colorMode: ui.BigValueColorMode.Value,
-  graphMode: ui.BigValueGraphMode.Area,
-  justifyMode: ui.BigValueJustifyMode.Auto,
-  textMode: ui.BigValueTextMode.Auto,
+  colorMode: common.BigValueColorMode.Value,
+  graphMode: common.BigValueGraphMode.Area,
+  justifyMode: common.BigValueJustifyMode.Auto,
+  textMode: common.BigValueTextMode.Auto,
 };

--- a/public/app/plugins/panel/state-timeline/panelcfg.cue
+++ b/public/app/plugins/panel/state-timeline/panelcfg.cue
@@ -15,7 +15,7 @@
 package grafanaplugin
 
 import (
-	ui "github.com/grafana/grafana/packages/grafana-schema/src/common"
+	"github.com/grafana/grafana/packages/grafana-schema/src/common"
 )
 
 composableKinds: PanelCfg: {
@@ -29,17 +29,17 @@ composableKinds: PanelCfg: {
 						PanelOptions: {
 							// FIXME ts comments indicate this shouldn't be in the saved model, but currently is emitted
 							mode?: TimelineMode
-							ui.OptionsWithLegend
-							ui.OptionsWithTooltip
-							ui.OptionsWithTimezones
-							showValue:    ui.VisibilityMode | *"auto"
+							common.OptionsWithLegend
+							common.OptionsWithTooltip
+							common.OptionsWithTimezones
+							showValue:    common.VisibilityMode | *"auto"
 							rowHeight:    number | *0.9
 							colWidth?:    number
 							mergeValues?: bool | *true
 							alignValue?:  TimelineValueAlignment | *"left"
 						} @cuetsy(kind="interface")
 						PanelFieldConfig: {
-							ui.HideableFieldConfig
+							common.HideableFieldConfig
 							lineWidth?:   number | *0
 							fillOpacity?: number | *70
 						} @cuetsy(kind="interface")

--- a/public/app/plugins/panel/status-history/panelcfg.cue
+++ b/public/app/plugins/panel/status-history/panelcfg.cue
@@ -15,7 +15,7 @@
 package grafanaplugin
 
 import (
-	ui "github.com/grafana/grafana/packages/grafana-schema/src/common"
+	"github.com/grafana/grafana/packages/grafana-schema/src/common"
 )
 
 composableKinds: PanelCfg: {
@@ -25,16 +25,16 @@ composableKinds: PanelCfg: {
 				schemas: [
 					{
 						PanelOptions: {
-							ui.OptionsWithLegend
-							ui.OptionsWithTooltip
-							ui.OptionsWithTimezones
-							showValue:  ui.VisibilityMode
+							common.OptionsWithLegend
+							common.OptionsWithTooltip
+							common.OptionsWithTimezones
+							showValue:  common.VisibilityMode
 							rowHeight:  number
 							colWidth?:  number
 							alignValue: "center" | *"left" | "right"
 						} @cuetsy(kind="interface")
 						PanelFieldConfig: {
-							ui.HideableFieldConfig
+							common.HideableFieldConfig
 							lineWidth?:   number | *1
 							fillOpacity?: number | *70
 						} @cuetsy(kind="interface")

--- a/public/app/plugins/panel/table/panelcfg.cue
+++ b/public/app/plugins/panel/table/panelcfg.cue
@@ -15,7 +15,7 @@
 package grafanaplugin
 
 import (
-	ui "github.com/grafana/grafana/packages/grafana-schema/src/common"
+	"github.com/grafana/grafana/packages/grafana-schema/src/common"
 )
 
 composableKinds: PanelCfg: {
@@ -28,9 +28,9 @@ composableKinds: PanelCfg: {
 							frameIndex:    number | *0
 							showHeader:    bool | *true
 							showTypeIcons: bool | *false
-							sortBy?: [...ui.TableSortByFieldState]
+							sortBy?: [...common.TableSortByFieldState]
 						} @cuetsy(kind="interface")
-						PanelFieldConfig: ui.TableFieldOptions & {} @cuetsy(kind="interface")
+						PanelFieldConfig: common.TableFieldOptions & {} @cuetsy(kind="interface")
 					},
 				]
 			},

--- a/public/app/plugins/panel/timeseries/panelcfg.cue
+++ b/public/app/plugins/panel/timeseries/panelcfg.cue
@@ -15,7 +15,7 @@
 package grafanaplugin
 
 import (
-	ui "github.com/grafana/grafana/packages/grafana-schema/src/common"
+	"github.com/grafana/grafana/packages/grafana-schema/src/common"
 )
 
 composableKinds: PanelCfg: {
@@ -25,10 +25,10 @@ composableKinds: PanelCfg: {
 				schemas: [
 					{
 						PanelOptions: {
-							legend:  ui.VizLegendOptions
-							tooltip: ui.VizTooltipOptions
+							legend:  common.VizLegendOptions
+							tooltip: common.VizTooltipOptions
 						} @cuetsy(kind="interface")
-						PanelFieldConfig: ui.GraphFieldConfig & {} @cuetsy(kind="interface")
+						PanelFieldConfig: common.GraphFieldConfig & {} @cuetsy(kind="interface")
 					},
 				]
 			},


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Prior to #61795, we had a bug which prevented us from using plain imports in CUE, like this:

```cue
import "github.com/grafana/grafana/packages/grafana-schema/src/common"
```

instead, we had to do this redundant thing:

```cue
import common "github.com/grafana/grafana/packages/grafana-schema/src/common"
```

But now that's fixed. So this PR gets rid of those annoying, pointless bytes!

**Why do we need this feature?**

obvious annoying edges are bad for business

**Who is this feature for?**

anyone writing grafana kinds