### PR TITLE
Alerting: validate alert condition on saving rule

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/AlertRuleForm.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AlertRuleForm.tsx
@@ -112,7 +112,7 @@ export const AlertRuleForm: FC<Props> = ({ existing, prefill }) => {
     shouldFocusError: true,
   });
 
-  const { handleSubmit, watch } = formAPI;
+  const { handleSubmit, watch, getValues } = formAPI;
 
   const type = watch('type');
   const dataSourceName = watch('dataSourceName');
@@ -122,7 +122,18 @@ export const AlertRuleForm: FC<Props> = ({ existing, prefill }) => {
   const submitState = useUnifiedAlertingSelector((state) => state.ruleForm.saveRule) || initialAsyncRequestState;
   useCleanup((state) => (state.unifiedAlerting.ruleForm.saveRule = initialAsyncRequestState));
 
+  const [conditionErrorMsg, setConditionErrorMsg] = useState('');
+
+  const checkAlertCondition = (msg = '') => {
+    setConditionErrorMsg(msg);
+  };
+
   const submit = (values: RuleFormValues, exitOnSave: boolean) => {
+    if (conditionErrorMsg !== '') {
+      notifyApp.error(conditionErrorMsg);
+      return;
+    }
+
     dispatch(
       saveRuleFormAction({
         values: {
@@ -236,7 +247,7 @@ export const AlertRuleForm: FC<Props> = ({ existing, prefill }) => {
           <CustomScrollbar autoHeightMin="100%" hideHorizontalTrack={true}>
             <div className={styles.contentInner}>
               <AlertRuleNameInput />
-              <QueryAndExpressionsStep editingExistingRule={!!existing} />
+              <QueryAndExpressionsStep editingExistingRule={!!existing} onDataChange={checkAlertCondition} />
               {showStep2 && (
                 <>
                   {type === RuleFormType.grafana ? (

--- a/public/app/features/alerting/unified/components/rule-editor/AlertRuleForm.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AlertRuleForm.tsx
@@ -112,7 +112,7 @@ export const AlertRuleForm: FC<Props> = ({ existing, prefill }) => {
     shouldFocusError: true,
   });
 
-  const { handleSubmit, watch, getValues } = formAPI;
+  const { handleSubmit, watch } = formAPI;
 
   const type = watch('type');
   const dataSourceName = watch('dataSourceName');


### PR DESCRIPTION
**What is this feature?**

This PR prevents alert rules to be created with invalid conditions, such as when the result of the query/expression results in timeseries data.

**Why do we need this feature?**

We need to improve the alert rule creation process, making errors more obvious to the user.

**Who is this feature for?**

All users.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/61832

**Special notes for your reviewer**:
![2023-01-23 17 52 04](https://user-images.githubusercontent.com/6271380/214147528-f2887de5-f7ce-4de4-a7da-1a2605a604c8.gif)

![2023-01-23 17 52 59](https://user-images.githubusercontent.com/6271380/214147647-ad2a2a66-7a48-44b8-82a9-88a1c086344c.gif)

