### PR TITLE
Azure Monitor: Customized Azure Routes Support

### DIFF
--- a/pkg/tsdb/azuremonitor/azuremonitor.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor.go
@@ -151,19 +151,18 @@ func getCustomizedCloudSettings(cloud string, jsonData json.RawMessage) (types.A
 }
 
 func getAzureRoutes(cloud string, jsonData json.RawMessage) (map[string]types.AzRoute, error) {
-	if cloud == azsettings.AzureCustomized {
-		customizedCloudSettings, err := getCustomizedCloudSettings(cloud, jsonData)
-		if err != nil {
-			return nil, err
-		}
-		if customizedCloudSettings.CustomizedRoutes == nil {
-			return nil, fmt.Errorf("unable to instantiate routes, customizedRoutes must be set")
-		}
-		azureRoutes := customizedCloudSettings.CustomizedRoutes
-		return azureRoutes, nil
-	} else {
+	customizedCloudSettings, err := getCustomizedCloudSettings(cloud, jsonData)
+	if err != nil {
+		return nil, err
+	}
+	if customizedCloudSettings.CustomizedRoutes == nil && cloud == azsettings.AzureCustomized {
+		return nil, fmt.Errorf("unable to instantiate routes, customizedRoutes must be set")
+	}
+	if customizedCloudSettings.CustomizedRoutes == nil && cloud != azsettings.AzureCustomized {
 		return routes[cloud], nil
 	}
+	azureRoutes := customizedCloudSettings.CustomizedRoutes
+	return azureRoutes, nil
 }
 
 type azDatasourceExecutor interface {

--- a/pkg/tsdb/azuremonitor/azuremonitor_test.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor_test.go
@@ -86,6 +86,40 @@ func TestNewInstanceSettings(t *testing.T) {
 			},
 			Err: require.NoError,
 		},
+		{
+			name: "creates a customized route instance for Public cloud",
+			settings: backend.DataSourceInstanceSettings{
+				JSONData:                []byte(`{"cloudName":"azuremonitor","customizedRoutes":{"Route":{"URL":"url"}},"azureAuthType":"clientsecret"}`),
+				DecryptedSecureJSONData: map[string]string{"clientSecret": "secret"},
+				ID:                      50,
+			},
+			expectedModel: types.DatasourceInfo{
+				Cloud: "AzureCloud",
+				Credentials: &azcredentials.AzureClientSecretCredentials{
+					AzureCloud:   "AzureCloud",
+					ClientSecret: "secret",
+				},
+				Settings: types.AzureMonitorSettings{},
+				Routes: map[string]types.AzRoute{
+					"Route": {
+						URL: "url",
+					},
+				},
+				JSONData: map[string]interface{}{
+					"azureAuthType": "clientsecret",
+					"cloudName":     "azuremonitor",
+					"customizedRoutes": map[string]interface{}{
+						"Route": map[string]interface{}{
+							"URL": "url",
+						},
+					},
+				},
+				DatasourceID:            50,
+				DecryptedSecureJSONData: map[string]string{"clientSecret": "secret"},
+				Services:                map[string]types.DatasourceService{},
+			},
+			Err: require.NoError,
+		},
 	}
 
 	cfg := &setting.Cfg{


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Add support to customize Azure portal URL for customized cloud.

**Why do we need this feature?**

The current implementation has gaps to support customized Routes discussed in #59857. The PR intends to provide an alternative solution to attempted PR #60308. This unblocks us without any impact on current implementation.

**Who is this feature for?**

Users who want to provision a datasource for customized Azure cloud.

**Which issue(s) does this PR fix?**:


<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #59857

**Special notes for your reviewer**:
The changes are tested on with and without customized routes on azure.
