### PR TITLE
Preferences: Add theme preference to match system theme

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -423,7 +423,7 @@ verify_email_enabled = false
 login_hint = email or username
 password_hint = password
 
-# Default UI theme ("dark" or "light")
+# Default UI theme ("dark" or "light" or "system")
 default_theme = dark
 
 # Default UI language (supported IETF language tag, such as en-US)

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -772,7 +772,9 @@ Text used as placeholder text on login page for password input.
 
 ### default_theme
 
-Set the default UI theme: `dark` or `light`. Default is `dark`.
+Set the default UI theme: `dark` or `light` or `system`. Default is `dark`.
+
+`system` will match the user's system theme.
 
 ### default_language
 

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -772,9 +772,9 @@ Text used as placeholder text on login page for password input.
 
 ### default_theme
 
-Set the default UI theme: `dark` or `light` or `system`. Default is `dark`.
+Sets the default UI theme: `dark`, `light`, or `system`. The default theme is `dark`.
 
-`system` will match the user's system theme.
+`system` matches the user's system theme.
 
 ### default_language
 

--- a/packages/grafana-data/src/types/config.ts
+++ b/packages/grafana-data/src/types/config.ts
@@ -129,6 +129,9 @@ export interface CurrentUserDTO {
   locale: string;
   language: string;
   permissions?: Record<string, boolean>;
+
+  /** @deprecated Use theme instead */
+  lightTheme: boolean;
 }
 
 export interface CurrentUser extends CurrentUserDTO {

--- a/packages/grafana-data/src/types/config.ts
+++ b/packages/grafana-data/src/types/config.ts
@@ -131,12 +131,16 @@ export interface CurrentUserDTO {
   permissions?: Record<string, boolean>;
 }
 
+export interface CurrentUser extends CurrentUserDTO {
+  lightTheme: boolean;
+}
+
 /** Contains essential user and config info
  *
  * @internal
  */
 export interface BootData {
-  user: CurrentUserDTO;
+  user: CurrentUser;
   settings: GrafanaConfig;
   navTree: NavLinkDTO[];
   themePaths: {

--- a/packages/grafana-data/src/types/config.ts
+++ b/packages/grafana-data/src/types/config.ts
@@ -117,7 +117,7 @@ export interface CurrentUserDTO {
   login: string;
   email: string;
   name: string;
-  lightTheme: boolean;
+  theme: string; // dark | light | system
   orgCount: number;
   orgId: number;
   orgName: string;

--- a/packages/grafana-data/src/types/config.ts
+++ b/packages/grafana-data/src/types/config.ts
@@ -134,16 +134,12 @@ export interface CurrentUserDTO {
   lightTheme: boolean;
 }
 
-export interface CurrentUser extends CurrentUserDTO {
-  lightTheme: boolean;
-}
-
 /** Contains essential user and config info
  *
  * @internal
  */
 export interface BootData {
-  user: CurrentUser;
+  user: CurrentUserDTO;
   settings: GrafanaConfig;
   navTree: NavLinkDTO[];
   themePaths: {

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -189,6 +189,23 @@ export class GrafanaBootConfig implements GrafanaConfig {
   }
 }
 
+function getThemeMode(config: GrafanaBootConfig) {
+  let mode: 'light' | 'dark';
+  const themePref = config.bootData.user.theme;
+
+  if (themePref === 'light' || themePref === 'dark') {
+    mode = themePref;
+  } else if (themePref === 'system') {
+    const mediaResult = window.matchMedia('(prefers-color-scheme: dark)');
+    mode = mediaResult.matches ? 'dark' : 'light';
+  } else {
+    // TODO: decide what to do here
+    mode = 'dark';
+  }
+
+  return mode;
+}
+
 function getThemeCustomizations(config: GrafanaBootConfig) {
   let mode: 'light' | 'dark';
   const themePref = config.bootData.user.theme;

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -190,7 +190,19 @@ export class GrafanaBootConfig implements GrafanaConfig {
 }
 
 function getThemeCustomizations(config: GrafanaBootConfig) {
-  const mode = config.bootData.user.lightTheme ? 'light' : 'dark';
+  let mode: 'light' | 'dark';
+  const themePref = config.bootData.user.theme;
+
+  if (themePref === 'light' || themePref === 'dark') {
+    mode = themePref;
+  } else if (themePref === 'system') {
+    const mediaResult = window.matchMedia('(prefers-color-scheme: dark)');
+    mode = mediaResult.matches ? 'dark' : 'light';
+  } else {
+    // TODO: decide what to do here
+    mode = 'dark';
+  }
+
   const themeOptions: NewThemeOptions = {
     colors: { mode },
   };

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -191,7 +191,7 @@ export class GrafanaBootConfig implements GrafanaConfig {
 }
 
 function getThemeMode(config: GrafanaBootConfig) {
-  let mode: 'light' | 'dark';
+  let mode: 'light' | 'dark' = 'dark';
   const themePref = config.bootData.user.theme;
 
   if (themePref === 'light' || themePref === 'dark') {
@@ -199,15 +199,13 @@ function getThemeMode(config: GrafanaBootConfig) {
   } else if (themePref === 'system') {
     const mediaResult = window.matchMedia('(prefers-color-scheme: dark)');
     mode = mediaResult.matches ? 'dark' : 'light';
-  } else {
-    // TODO: decide what to do here
-    mode = 'dark';
   }
 
   return mode;
 }
 
 function getThemeCustomizations(config: GrafanaBootConfig) {
+  // if/when we remove CurrentUserDTO.lightTheme, change this to use getThemeMode instead
   const mode = config.bootData.user.lightTheme ? 'light' : 'dark';
 
   const themeOptions: NewThemeOptions = {

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -149,6 +149,7 @@ export class GrafanaBootConfig implements GrafanaConfig {
 
   constructor(options: GrafanaBootConfig) {
     this.bootData = options.bootData;
+    this.bootData.user.lightTheme = getThemeMode(options) === 'light';
     this.isPublicDashboardView = options.bootData.settings.isPublicDashboardView;
 
     const defaults = {
@@ -207,18 +208,7 @@ function getThemeMode(config: GrafanaBootConfig) {
 }
 
 function getThemeCustomizations(config: GrafanaBootConfig) {
-  let mode: 'light' | 'dark';
-  const themePref = config.bootData.user.theme;
-
-  if (themePref === 'light' || themePref === 'dark') {
-    mode = themePref;
-  } else if (themePref === 'system') {
-    const mediaResult = window.matchMedia('(prefers-color-scheme: dark)');
-    mode = mediaResult.matches ? 'dark' : 'light';
-  } else {
-    // TODO: decide what to do here
-    mode = 'dark';
-  }
+  const mode = config.bootData.user.lightTheme ? 'light' : 'dark';
 
   const themeOptions: NewThemeOptions = {
     colors: { mode },

--- a/pkg/api/dtos/models.go
+++ b/pkg/api/dtos/models.go
@@ -34,6 +34,7 @@ type CurrentUser struct {
 	Email                      string             `json:"email"`
 	Name                       string             `json:"name"`
 	Theme                      string             `json:"theme"`
+	LightTheme                 bool               `json:"lightTheme"` // deprecated, use theme instead
 	OrgCount                   int                `json:"orgCount"`
 	OrgId                      int64              `json:"orgId"`
 	OrgName                    string             `json:"orgName"`

--- a/pkg/api/dtos/models.go
+++ b/pkg/api/dtos/models.go
@@ -33,7 +33,7 @@ type CurrentUser struct {
 	Login                      string             `json:"login"`
 	Email                      string             `json:"email"`
 	Name                       string             `json:"name"`
-	LightTheme                 bool               `json:"lightTheme"`
+	Theme                      string             `json:"theme"`
 	OrgCount                   int                `json:"orgCount"`
 	OrgId                      int64              `json:"orgId"`
 	OrgName                    string             `json:"orgName"`

--- a/pkg/api/dtos/prefs.go
+++ b/pkg/api/dtos/prefs.go
@@ -6,7 +6,7 @@ import (
 
 // swagger:model
 type UpdatePrefsCmd struct {
-	// Enum: light,dark
+	// Enum: light,dark,system
 	Theme string `json:"theme"`
 	// The numerical :id of a favorited dashboard
 	// Default:0

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -102,6 +102,7 @@ func (hs *HTTPServer) setIndexViewData(c *contextmodel.ReqContext) (*dtos.IndexV
 			GravatarUrl:                dtos.GetGravatarUrl(c.Email),
 			IsGrafanaAdmin:             c.IsGrafanaAdmin,
 			Theme:                      prefs.Theme,
+			LightTheme:                 prefs.Theme == lightTheme,
 			Timezone:                   prefs.Timezone,
 			WeekStart:                  weekStart,
 			Locale:                     locale,

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -102,7 +102,7 @@ func (hs *HTTPServer) setIndexViewData(c *contextmodel.ReqContext) (*dtos.IndexV
 			GravatarUrl:                dtos.GetGravatarUrl(c.Email),
 			IsGrafanaAdmin:             c.IsGrafanaAdmin,
 			Theme:                      prefs.Theme,
-			LightTheme:                 prefs.Theme == lightTheme,
+			LightTheme:                 prefs.Theme == lightName,
 			Timezone:                   prefs.Timezone,
 			WeekStart:                  weekStart,
 			Locale:                     locale,

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -151,14 +151,10 @@ func (hs *HTTPServer) setIndexViewData(c *contextmodel.ReqContext) (*dtos.IndexV
 		data.User.Name = data.User.Login
 	}
 
-	// TODO: clean this up :)
 	themeURLParam := c.Query("theme")
-	if themeURLParam == lightName {
-		data.User.Theme = lightName
-		data.Theme = lightName
-	} else if themeURLParam == darkName {
-		data.User.Theme = darkName
-		data.Theme = darkName
+	if themeURLParam == lightName || themeURLParam == darkName || themeURLParam == systemName {
+		data.User.Theme = themeURLParam
+		data.Theme = themeURLParam
 	}
 
 	hs.HooksService.RunIndexDataHooks(&data, c)

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -17,8 +17,9 @@ import (
 
 const (
 	// Themes
-	lightName = "light"
-	darkName  = "dark"
+	lightName  = "light"
+	darkName   = "dark"
+	systemName = "system"
 )
 
 func (hs *HTTPServer) editorInAnyFolder(c *contextmodel.ReqContext) bool {
@@ -100,7 +101,7 @@ func (hs *HTTPServer) setIndexViewData(c *contextmodel.ReqContext) (*dtos.IndexV
 			OrgRole:                    c.OrgRole,
 			GravatarUrl:                dtos.GetGravatarUrl(c.Email),
 			IsGrafanaAdmin:             c.IsGrafanaAdmin,
-			LightTheme:                 prefs.Theme == lightName,
+			Theme:                      prefs.Theme,
 			Timezone:                   prefs.Timezone,
 			WeekStart:                  weekStart,
 			Locale:                     locale,
@@ -149,12 +150,13 @@ func (hs *HTTPServer) setIndexViewData(c *contextmodel.ReqContext) (*dtos.IndexV
 		data.User.Name = data.User.Login
 	}
 
+	// TODO: clean this up :)
 	themeURLParam := c.Query("theme")
 	if themeURLParam == lightName {
-		data.User.LightTheme = true
+		data.User.Theme = lightName
 		data.Theme = lightName
 	} else if themeURLParam == darkName {
-		data.User.LightTheme = false
+		data.User.Theme = darkName
 		data.Theme = darkName
 	}
 

--- a/pkg/api/preferences.go
+++ b/pkg/api/preferences.go
@@ -17,6 +17,7 @@ const (
 	defaultTheme string = ""
 	darkTheme    string = "dark"
 	lightTheme   string = "light"
+	systemTheme  string = "system"
 )
 
 // POST /api/preferences/set-home-dash
@@ -134,7 +135,7 @@ func (hs *HTTPServer) UpdateUserPreferences(c *contextmodel.ReqContext) response
 }
 
 func (hs *HTTPServer) updatePreferencesFor(ctx context.Context, orgID, userID, teamId int64, dtoCmd *dtos.UpdatePrefsCmd) response.Response {
-	if dtoCmd.Theme != lightTheme && dtoCmd.Theme != darkTheme && dtoCmd.Theme != defaultTheme {
+	if dtoCmd.Theme != lightTheme && dtoCmd.Theme != darkTheme && dtoCmd.Theme != defaultTheme && dtoCmd.Theme != systemTheme {
 		return response.Error(400, "Invalid theme", nil)
 	}
 
@@ -191,7 +192,7 @@ func (hs *HTTPServer) PatchUserPreferences(c *contextmodel.ReqContext) response.
 }
 
 func (hs *HTTPServer) patchPreferencesFor(ctx context.Context, orgID, userID, teamId int64, dtoCmd *dtos.PatchPrefsCmd) response.Response {
-	if dtoCmd.Theme != nil && *dtoCmd.Theme != lightTheme && *dtoCmd.Theme != darkTheme && *dtoCmd.Theme != defaultTheme {
+	if dtoCmd.Theme != nil && *dtoCmd.Theme != lightTheme && *dtoCmd.Theme != darkTheme && *dtoCmd.Theme != defaultTheme && *dtoCmd.Theme != systemTheme {
 		return response.Error(400, "Invalid theme", nil)
 	}
 

--- a/public/app/core/components/SharedPreferences/SharedPreferences.tsx
+++ b/public/app/core/components/SharedPreferences/SharedPreferences.tsx
@@ -71,6 +71,7 @@ export class SharedPreferences extends PureComponent<Props, State> {
       { value: '', label: t('shared-preferences.theme.default-label', 'Default') },
       { value: 'dark', label: t('shared-preferences.theme.dark-label', 'Dark') },
       { value: 'light', label: t('shared-preferences.theme.light-label', 'Light') },
+      { value: 'system', label: t('shared-preferences.theme.system-label', 'System') },
     ];
   }
 

--- a/public/app/core/services/context_srv.ts
+++ b/public/app/core/services/context_srv.ts
@@ -14,7 +14,7 @@ export class User implements CurrentUserInternal {
   email: string;
   name: string;
   externalUserId: string;
-  lightTheme: boolean;
+  theme: string;
   orgCount: number;
   orgId: number;
   orgName: string;
@@ -43,7 +43,7 @@ export class User implements CurrentUserInternal {
     this.timezone = '';
     this.fiscalYearStartMonth = 0;
     this.helpFlags1 = 0;
-    this.lightTheme = false;
+    this.theme = 'dark';
     this.hasEditPermissionInFolders = false;
     this.email = '';
     this.name = '';

--- a/public/app/core/services/context_srv.ts
+++ b/public/app/core/services/context_srv.ts
@@ -7,7 +7,7 @@ import { CurrentUserInternal } from 'app/types/config';
 
 import config from '../../core/config';
 
-export class User implements CurrentUserInternal {
+export class User implements Omit<CurrentUserInternal, 'lightTheme'> {
   isSignedIn: boolean;
   id: number;
   login: string;

--- a/public/app/core/services/echo/utils.test.ts
+++ b/public/app/core/services/echo/utils.test.ts
@@ -8,7 +8,7 @@ const baseUser: CurrentUserDTO = {
   login: 'myUsername',
   email: 'email@example.com',
   name: 'My Name',
-  lightTheme: false,
+  theme: 'dark',
   orgCount: 1,
   orgId: 1,
   orgName: 'Main Org.',

--- a/public/app/core/services/echo/utils.test.ts
+++ b/public/app/core/services/echo/utils.test.ts
@@ -9,6 +9,7 @@ const baseUser: CurrentUserDTO = {
   email: 'email@example.com',
   name: 'My Name',
   theme: 'dark',
+  lightTheme: false, // deprecated
   orgCount: 1,
   orgId: 1,
   orgName: 'Main Org.',

--- a/public/locales/de-DE/grafana.json
+++ b/public/locales/de-DE/grafana.json
@@ -489,7 +489,8 @@
     "theme": {
       "dark-label": "Dunkel",
       "default-label": "Standard",
-      "light-label": "Hell"
+      "light-label": "Hell",
+      "system-label": ""
     },
     "title": "Einstellungen"
   },

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -489,7 +489,8 @@
     "theme": {
       "dark-label": "Dark",
       "default-label": "Default",
-      "light-label": "Light"
+      "light-label": "Light",
+      "system-label": "System"
     },
     "title": "Preferences"
   },

--- a/public/locales/es-ES/grafana.json
+++ b/public/locales/es-ES/grafana.json
@@ -489,7 +489,8 @@
     "theme": {
       "dark-label": "Oscuro",
       "default-label": "Por defecto",
-      "light-label": "Claro"
+      "light-label": "Claro",
+      "system-label": ""
     },
     "title": "Preferencias"
   },

--- a/public/locales/fr-FR/grafana.json
+++ b/public/locales/fr-FR/grafana.json
@@ -489,7 +489,8 @@
     "theme": {
       "dark-label": "Sombre",
       "default-label": "Par défaut",
-      "light-label": "Clair"
+      "light-label": "Clair",
+      "system-label": ""
     },
     "title": "Préférences"
   },

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -489,7 +489,8 @@
     "theme": {
       "dark-label": "Đäřĸ",
       "default-label": "Đęƒäūľŧ",
-      "light-label": "Ŀįģĥŧ"
+      "light-label": "Ŀįģĥŧ",
+      "system-label": "Ŝyşŧęm"
     },
     "title": "Přęƒęřęŉčęş"
   },

--- a/public/locales/zh-Hans/grafana.json
+++ b/public/locales/zh-Hans/grafana.json
@@ -489,7 +489,8 @@
     "theme": {
       "dark-label": "深色",
       "default-label": "默认",
-      "light-label": "浅色"
+      "light-label": "浅色",
+      "system-label": ""
     },
     "title": "首选项"
   },

--- a/public/views/index-template.html
+++ b/public/views/index-template.html
@@ -263,9 +263,11 @@
         if (darkQuery.matches) {
           document.body.classList.add("theme-dark");
           cssLink.href = window.grafanaBootData.themePaths.dark;
+          window.grafanaBootData.user.lightTheme = false;
         } else {
           document.body.classList.add("theme-light");
           cssLink.href = window.grafanaBootData.themePaths.light;
+          window.grafanaBootData.user.lightTheme = true;
         }
         document.head.appendChild(cssLink);
       }

--- a/public/views/index-template.html
+++ b/public/views/index-template.html
@@ -14,21 +14,11 @@
     <link rel="apple-touch-icon" sizes="180x180" href="[[.AppleTouchIcon]]" />
     <link rel="mask-icon" href="[[.ContentDeliveryURL]]public/img/grafana_mask_icon.svg" color="#F05A28" />
 
+    <!-- If theme is "system", we inject the stylesheets with javascript further down the page -->
     [[ if eq .Theme "light" ]]
     <link rel="stylesheet" href="[[.ContentDeliveryURL]]public/build/<%= htmlWebpackPlugin.files.cssChunks.light %>" />
     [[ else if eq .Theme "dark" ]]
     <link rel="stylesheet" href="[[.ContentDeliveryURL]]public/build/<%= htmlWebpackPlugin.files.cssChunks.dark %>" />
-    [[ else ]]
-    <link
-      media="(prefers-color-scheme: light)"
-      rel="stylesheet"
-      href="[[.ContentDeliveryURL]]public/build/<%= htmlWebpackPlugin.files.cssChunks.light %>"
-    />
-    <link
-      media="(prefers-color-scheme: dark)"
-      rel="stylesheet"
-      href="[[.ContentDeliveryURL]]public/build/<%= htmlWebpackPlugin.files.cssChunks.dark %>"
-    />
     [[ end ]]
 
     <script nonce="[[.Nonce]]">
@@ -262,6 +252,8 @@
         }
       };
 
+      // Set theme to match system only on startup.
+      // Do not react to changes in system theme after startup.
       if (window.grafanaBootData.user.theme === "system") {
         document.body.classList.remove("theme-system");
         var darkQuery = window.matchMedia("(prefers-color-scheme: dark)");

--- a/public/views/index-template.html
+++ b/public/views/index-template.html
@@ -16,8 +16,19 @@
 
     [[ if eq .Theme "light" ]]
     <link rel="stylesheet" href="[[.ContentDeliveryURL]]public/build/<%= htmlWebpackPlugin.files.cssChunks.light %>" />
-    [[ else ]]
+    [[ else if eq .Theme "dark" ]]
     <link rel="stylesheet" href="[[.ContentDeliveryURL]]public/build/<%= htmlWebpackPlugin.files.cssChunks.dark %>" />
+    [[ else ]]
+    <link
+      media="(prefers-color-scheme: light)"
+      rel="stylesheet"
+      href="[[.ContentDeliveryURL]]public/build/<%= htmlWebpackPlugin.files.cssChunks.light %>"
+    />
+    <link
+      media="(prefers-color-scheme: dark)"
+      rel="stylesheet"
+      href="[[.ContentDeliveryURL]]public/build/<%= htmlWebpackPlugin.files.cssChunks.dark %>"
+    />
     [[ end ]]
 
     <script nonce="[[.Nonce]]">
@@ -250,6 +261,17 @@
           dark: '[[.ContentDeliveryURL]]public/build/<%= htmlWebpackPlugin.files.cssChunks.dark %>'
         }
       };
+
+      if (window.grafanaBootData.user.theme === "system") {
+        document.body.classList.remove("theme-system");
+        var darkQuery = window.matchMedia("(prefers-color-scheme: dark)");
+
+        if (darkQuery.matches) {
+          document.body.classList.add("theme-dark");
+        } else {
+          document.body.classList.add("theme-light");
+        }
+      }
 
       window.__grafana_load_failed = function() {
         var preloader = document.getElementsByClassName("preloader");

--- a/public/views/index-template.html
+++ b/public/views/index-template.html
@@ -265,12 +265,17 @@
       if (window.grafanaBootData.user.theme === "system") {
         document.body.classList.remove("theme-system");
         var darkQuery = window.matchMedia("(prefers-color-scheme: dark)");
+        var cssLink = document.createElement("link");
+        cssLink.rel = 'stylesheet';
 
         if (darkQuery.matches) {
           document.body.classList.add("theme-dark");
+          cssLink.href = window.grafanaBootData.themePaths.dark;
         } else {
           document.body.classList.add("theme-light");
+          cssLink.href = window.grafanaBootData.themePaths.light;
         }
+        document.head.appendChild(cssLink);
       }
 
       window.__grafana_load_failed = function() {


### PR DESCRIPTION
**What is this feature?**

Add's a theme preference to match Grafana's theme to the user's system theme. 

**Why do we need this feature?**

So Grafana matches the rest of the operating system for the user, especially valuable for users who have their system theme change to dark mode automatically at night.

**Who is this feature for?**

Everyone :) 

**Which issue(s) does this PR fix?**:

Fixes #61339

**Special notes for your reviewer**:

 - [x] Currently the sass styles will respond to changes to `prefers-color-scheme`, but the rest of Grafana won't. Perhaps we should only load dark.scss or light.scss on boot, and not have it respond to theme changes?

