### PR TITLE
Connections: update the style of the cards

### DIFF
--- a/public/app/features/connections/tabs/ConnectData/CardGrid/CardGrid.tsx
+++ b/public/app/features/connections/tabs/ConnectData/CardGrid/CardGrid.tsx
@@ -15,7 +15,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
   card: css`
     height: 90px;
     padding: 0px 24px;
-    box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.6);
+    margin-bottom: 0;
   `,
   cardContent: css`
     display: flex;


### PR DESCRIPTION
Fixes https://github.com/grafana/cloud-onboarding/issues/3078

### What changed?
- [x] remove the box shadow from the cards under Connect Data
- [x] use the same gap everywhere between the elements in the grid

|  **Before**  |    **After**    |
|--------------|-----------------|
| ![Screenshot 2023-01-24 at 13 52 25](https://user-images.githubusercontent.com/9974811/214297808-16b30cd1-b1af-42bf-99c0-a30d9b645932.png) |![Screenshot 2023-01-24 at 13 56 08](https://user-images.githubusercontent.com/9974811/214297827-33f0235b-e933-4176-8ac1-a11f5e74c68f.png)|