### PR TITLE
Alerting: implement loki query for alert state history

### DIFF
--- a/pkg/services/ngalert/state/historian/loki.go
+++ b/pkg/services/ngalert/state/historian/loki.go
@@ -84,7 +84,8 @@ func (h *RemoteLokiBackend) QueryStates(ctx context.Context, query models.Histor
 	if err != nil {
 		return nil, fmt.Errorf("failed to build the provided selectors: %w", err)
 	}
-	res, err := h.client.query(ctx, selectors, query.From.Unix(), query.To.Unix())
+	// Timestamps are expected in RFC3339Nano.
+	res, err := h.client.query(ctx, selectors, query.From.UnixNano(), query.To.UnixNano())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/ngalert/state/historian/loki.go
+++ b/pkg/services/ngalert/state/historian/loki.go
@@ -292,10 +292,6 @@ func valuesAsDataBlob(state *state.State) *simplejson.Json {
 	return jsonifyValues(state.Values)
 }
 
-func jsonifyLabels(labels map[string]string) (json.RawMessage, error) {
-	return json.Marshal(labels)
-}
-
 func jsonifyRow(line string) (json.RawMessage, error) {
 	// Ser/deser to validate the contents of the log line before shipping it forward.
 	// TODO: We may want to remove this in the future, as we already have the value in the form of a []byte, and json.RawMessage is also a []byte.

--- a/pkg/services/ngalert/state/historian/loki.go
+++ b/pkg/services/ngalert/state/historian/loki.go
@@ -32,7 +32,7 @@ const (
 type remoteLokiClient interface {
 	ping(context.Context) error
 	push(context.Context, []stream) error
-	query(selectors [][3]string, start, end int64) (QueryRes, error)
+	query(ctx context.Context, selectors [][3]string, start, end int64) (QueryRes, error)
 }
 
 type RemoteLokiBackend struct {
@@ -72,7 +72,7 @@ func (h *RemoteLokiBackend) QueryStates(ctx context.Context, query models.Histor
 	if query.RuleUID == "" {
 		return nil, errors.New("the RuleUID is not set but required")
 	}
-	res, err := h.client.query([][3]string{
+	res, err := h.client.query(ctx, [][3]string{
 		{"rule_id", "=", query.RuleUID},
 	}, query.From.Unix(), query.To.Unix())
 	if err != nil {

--- a/pkg/services/ngalert/state/historian/loki.go
+++ b/pkg/services/ngalert/state/historian/loki.go
@@ -87,18 +87,25 @@ func (h *RemoteLokiBackend) QueryStates(ctx context.Context, query models.Histor
 }
 
 func buildSelectors(query models.HistoryQuery) ([]Selector, error) {
-	// +1 as OrgID will always be a selector at the API level.
-	selectors := make([]Selector, len(query.Labels)+1)
+	// +2 as OrgID and the state history label will always be selectors at the API level.
+	selectors := make([]Selector, len(query.Labels)+2)
 
-	// Set the predefined selector org_id
+	// Set the predefined selector orgID.
 	selector, err := NewSelector(OrgIDLabel, "=", fmt.Sprintf("%d", query.OrgID))
 	if err != nil {
 		return nil, err
 	}
 	selectors[0] = selector
 
+	// Set the predefined selector for the state history label.
+	selector, err = NewSelector(StateHistoryLabelKey, "=", StateHistoryLabelValue)
+	if err != nil {
+		return nil, err
+	}
+	selectors[1] = selector
+
 	// Set the label selectors
-	i := 1
+	i := 2
 	for label, val := range query.Labels {
 		selector, err = NewSelector(label, "=", val)
 		if err != nil {

--- a/pkg/services/ngalert/state/historian/loki.go
+++ b/pkg/services/ngalert/state/historian/loki.go
@@ -133,12 +133,8 @@ func merge(res QueryRes, ruleUID string) (*data.Frame, error) {
 	// Create a new slice to store the merged elements.
 	frame := data.NewFrame("states")
 
-	// Since we are guaranteed to have a single rule, we can return it as a single series.
-	// This might change in a later point in time.
-	lbls := data.Labels(map[string]string{
-		"from":    "state-history",
-		"ruleUID": ruleUID,
-	})
+	// We merge all series into a single linear history.
+	lbls := data.Labels(map[string]string{})
 
 	// We represent state history as five vectors:
 	//   1. `time` - when the transition happened

--- a/pkg/services/ngalert/state/historian/loki.go
+++ b/pkg/services/ngalert/state/historian/loki.go
@@ -180,7 +180,10 @@ func merge(res QueryRes, ruleUID string) (*data.Frame, error) {
 			break
 		}
 		var entry lokiEntry
-		json.Unmarshal([]byte(minEl[1]), &entry)
+		err := json.Unmarshal([]byte(minEl[1]), &entry)
+		if err != nil {
+			return nil, fmt.Errorf("failed to unmarshal entry: %w", err)
+		}
 		// Append the minimum element to the merged slice and move the pointer.
 		ts, err := strconv.ParseInt(minEl[0], 10, 64)
 		if err != nil {

--- a/pkg/services/ngalert/state/historian/loki.go
+++ b/pkg/services/ngalert/state/historian/loki.go
@@ -167,7 +167,7 @@ func merge(res QueryRes, ruleUID string) (*data.Frame, error) {
 			}
 			curVal, err := strconv.ParseInt(stream.Values[pointers[i]][0], 10, 64)
 			if err != nil {
-				return nil, fmt.Errorf("failed to parse timestamp from loki repsonse: %w", err)
+				return nil, fmt.Errorf("failed to parse timestamp from loki response: %w", err)
 			}
 			if pointers[i] < len(stream.Values) && curVal < minVal {
 				minVal = curVal

--- a/pkg/services/ngalert/state/historian/loki.go
+++ b/pkg/services/ngalert/state/historian/loki.go
@@ -40,7 +40,7 @@ const (
 type remoteLokiClient interface {
 	ping(context.Context) error
 	push(context.Context, []stream) error
-	query(ctx context.Context, selectors [][3]string, start, end int64) (QueryRes, error)
+	query(ctx context.Context, selectors []Selector, start, end int64) (QueryRes, error)
 }
 
 type RemoteLokiBackend struct {

--- a/pkg/services/ngalert/state/historian/loki_http.go
+++ b/pkg/services/ngalert/state/historian/loki_http.go
@@ -194,6 +194,7 @@ func (c *httpLokiClient) query(ctx context.Context, selectors [][3]string, start
 	}
 
 	req = req.WithContext(ctx)
+	c.setAuthAndTenantHeaders(req)
 
 	client := http.Client{
 		Timeout: time.Second * 30,

--- a/pkg/services/ngalert/state/historian/loki_http.go
+++ b/pkg/services/ngalert/state/historian/loki_http.go
@@ -213,11 +213,7 @@ func (c *httpLokiClient) query(ctx context.Context, selectors []Selector, start,
 	req = req.WithContext(ctx)
 	c.setAuthAndTenantHeaders(req)
 
-	client := http.Client{
-		Timeout: time.Second * 30,
-	}
-
-	res, err := client.Do(req)
+	res, err := c.client.Do(req)
 	if err != nil {
 		return QueryRes{}, fmt.Errorf("error executing request: %w", err)
 	}

--- a/pkg/services/ngalert/state/historian/loki_http.go
+++ b/pkg/services/ngalert/state/historian/loki_http.go
@@ -218,6 +218,10 @@ func (c *httpLokiClient) query(ctx context.Context, selectors []Selector, start,
 		return QueryRes{}, fmt.Errorf("error executing request: %w", err)
 	}
 
+	defer func() {
+		_ = res.Body.Close()
+	}()
+
 	data, err := io.ReadAll(res.Body)
 	if err != nil {
 		return QueryRes{}, fmt.Errorf("error reading request response: %w", err)
@@ -245,7 +249,6 @@ func selectorString(selectors []Selector) string {
 	// Remove the last comma, as we append one to every selector.
 	query = query[:len(query)-1]
 	return "{" + query + "}"
-
 }
 
 func NewSelector(label, op, value string) (Selector, error) {

--- a/pkg/services/ngalert/state/historian/loki_http.go
+++ b/pkg/services/ngalert/state/historian/loki_http.go
@@ -229,7 +229,7 @@ func selectorString(selectors [][3]string) (string, error) {
 		if !isValidOperator(s[1]) {
 			return "", fmt.Errorf("'%s' is not a valid query operator", s[1])
 		}
-		query += fmt.Sprintf("%%%,", s[0], s[1], s[2])
+		query += fmt.Sprintf("%s%s%q,", s[0], s[1], s[2])
 	}
 	// Remove the last comma, as we append one to every selector.
 	query = query[:len(query)-1]
@@ -239,10 +239,7 @@ func selectorString(selectors [][3]string) (string, error) {
 
 func isValidOperator(op string) bool {
 	switch op {
-	case "=":
-	case "!=":
-	case "=~":
-	case "!~":
+	case "=", "!=", "=~", "!~":
 		return true
 	}
 	return false

--- a/pkg/services/ngalert/state/historian/loki_http.go
+++ b/pkg/services/ngalert/state/historian/loki_http.go
@@ -227,6 +227,15 @@ func (c *httpLokiClient) query(ctx context.Context, selectors []Selector, start,
 		return QueryRes{}, fmt.Errorf("error reading request response: %w", err)
 	}
 
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		if len(data) > 0 {
+			c.log.Error("Error response from Loki", "response", string(data), "status", res.StatusCode)
+		} else {
+			c.log.Error("Error response from Loki with an empty body", "status", res.StatusCode)
+		}
+		return QueryRes{}, fmt.Errorf("received a non-200 response from loki, status: %d", res.StatusCode)
+	}
+
 	queryRes := QueryRes{}
 	err = json.Unmarshal(data, &queryRes)
 	if err != nil {

--- a/pkg/services/ngalert/state/historian/loki_http_test.go
+++ b/pkg/services/ngalert/state/historian/loki_http_test.go
@@ -106,7 +106,8 @@ func TestLokiHTTPClient(t *testing.T) {
 		require.NoError(t, err)
 
 		client := newLokiClient(LokiConfig{
-			Url:               url,
+			ReadPathURL:       url,
+			WritePathURL:      url,
 			BasicAuthUser:     "<your_username>",
 			BasicAuthPassword: "<your_password>",
 		}, log.NewNopLogger())

--- a/pkg/services/ngalert/state/historian/loki_http_test.go
+++ b/pkg/services/ngalert/state/historian/loki_http_test.go
@@ -119,12 +119,12 @@ func TestLokiHTTPClient(t *testing.T) {
 		// Create an array of selectors that should be used for the
 		// query.
 		selectors := []Selector{
-			{Label: "", Op: Eq, Value: ""},
+			{Label: "probe", Op: Eq, Value: "Paris"},
 		}
 
 		// Define the query time range
-		start := time.Now().UnixMilli() - 10000
-		end := time.Now().UnixMilli()
+		start := time.Now().Add(-30 * time.Minute).UnixNano()
+		end := time.Now().UnixNano()
 
 		// Authorized request should not fail against Grafana Cloud.
 		res, err := client.query(context.Background(), selectors, start, end)

--- a/pkg/services/ngalert/state/historian/loki_http_test.go
+++ b/pkg/services/ngalert/state/historian/loki_http_test.go
@@ -117,8 +117,8 @@ func TestLokiHTTPClient(t *testing.T) {
 
 		// Create an array of selectors that should be used for the
 		// query.
-		selectors := [][3]string{
-			{"", "", ""},
+		selectors := []Selector{
+			{Label: "", Op: Eq, Value: ""},
 		}
 
 		// Define the query time range
@@ -133,21 +133,24 @@ func TestLokiHTTPClient(t *testing.T) {
 }
 
 func TestSelectorString(t *testing.T) {
-	selectors := [][3]string{{"name", "=", "Bob"}, {"age", "=~", "30"}}
+	selectors := []Selector{{"name", "=", "Bob"}, {"age", "=~", "30"}}
 	expected := "{name=\"Bob\",age=~\"30\"}"
-	result, err := selectorString(selectors)
-	require.NoError(t, err)
+	result := selectorString(selectors)
 	require.Equal(t, expected, result)
 
-	selectors = [][3]string{{"name", "?", "Bob"}}
-	expected = ""
-	result, err = selectorString(selectors)
-	require.Error(t, err)
-	require.Equal(t, expected, result)
-
-	selectors = [][3]string{}
+	selectors = []Selector{}
 	expected = "{}"
-	result, err = selectorString(selectors)
-	require.NoError(t, err)
+	result = selectorString(selectors)
 	require.Equal(t, expected, result)
+}
+
+func TestNewSelector(t *testing.T) {
+	selector, err := NewSelector("label", "=", "value")
+	require.NoError(t, err)
+	require.Equal(t, "label", selector.Label)
+	require.Equal(t, Eq, selector.Op)
+	require.Equal(t, "value", selector.Value)
+
+	selector, err = NewSelector("label", "invalid", "value")
+	require.Error(t, err)
 }

--- a/pkg/services/ngalert/state/historian/loki_http_test.go
+++ b/pkg/services/ngalert/state/historian/loki_http_test.go
@@ -100,3 +100,23 @@ func TestLokiHTTPClient(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
+
+func TestSelectorString(t *testing.T) {
+	selectors := [][3]string{{"name", "=", "Bob"}, {"age", "=~", "30"}}
+	expected := "{name=\"Bob\",age=~\"30\"}"
+	result, err := selectorString(selectors)
+	require.NoError(t, err)
+	require.Equal(t, expected, result)
+
+	selectors = [][3]string{{"name", "?", "Bob"}}
+	expected = ""
+	result, err = selectorString(selectors)
+	require.Error(t, err)
+	require.Equal(t, expected, result)
+
+	selectors = [][3]string{}
+	expected = "{}"
+	result, err = selectorString(selectors)
+	require.NoError(t, err)
+	require.Equal(t, expected, result)
+}

--- a/pkg/services/ngalert/state/historian/loki_http_test.go
+++ b/pkg/services/ngalert/state/historian/loki_http_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/stretchr/testify/require"
@@ -95,9 +96,39 @@ func TestLokiHTTPClient(t *testing.T) {
 		// so the x-scope-orgid header is set.
 		// client.cfg.TenantID = "<your_tenant_id>"
 
-		// Authorized request should fail against Grafana Cloud.
+		// Authorized request should not fail against Grafana Cloud.
 		err = client.ping(context.Background())
 		require.NoError(t, err)
+	})
+
+	t.Run("smoke test querying Loki", func(t *testing.T) {
+		url, err := url.Parse("https://logs-prod-eu-west-0.grafana.net")
+		require.NoError(t, err)
+
+		client := newLokiClient(LokiConfig{
+			Url:               url,
+			BasicAuthUser:     "<your_username>",
+			BasicAuthPassword: "<your_password>",
+		}, log.NewNopLogger())
+
+		// When running on prem, you might need to set the tenant id,
+		// so the x-scope-orgid header is set.
+		// client.cfg.TenantID = "<your_tenant_id>"
+
+		// Create an array of selectors that should be used for the
+		// query.
+		selectors := [][3]string{
+			{"", "", ""},
+		}
+
+		// Define the query time range
+		start := time.Now().UnixMilli() - 10000
+		end := time.Now().UnixMilli()
+
+		// Authorized request should not fail against Grafana Cloud.
+		res, err := client.query(context.Background(), selectors, start, end)
+		require.NoError(t, err)
+		require.NotNil(t, res)
 	})
 }
 

--- a/pkg/services/ngalert/state/historian/loki_test.go
+++ b/pkg/services/ngalert/state/historian/loki_test.go
@@ -143,11 +143,10 @@ func TestRemoteLokiBackend(t *testing.T) {
 
 func TestMerge(t *testing.T) {
 	testCases := []struct {
-		name          string
-		res           QueryRes
-		ruleID        string
-		expectedTime  []time.Time
-		expectedState []string
+		name         string
+		res          QueryRes
+		ruleID       string
+		expectedTime []time.Time
 	}{
 		{
 			name: "Should return values from multiple streams in right order",
@@ -175,12 +174,8 @@ func TestMerge(t *testing.T) {
 			},
 			ruleID: "123456",
 			expectedTime: []time.Time{
-				time.Unix(1, 0),
-				time.Unix(2, 0),
-			},
-			expectedState: []string{
-				"pending",
-				"firing",
+				time.Unix(0, 1),
+				time.Unix(0, 2),
 			},
 		},
 		{
@@ -197,9 +192,8 @@ func TestMerge(t *testing.T) {
 					},
 				},
 			},
-			ruleID:        "123456",
-			expectedTime:  []time.Time{},
-			expectedState: []string{},
+			ruleID:       "123456",
+			expectedTime: []time.Time{},
 		},
 		{
 			name: "Should handle multiple values in one stream",
@@ -228,14 +222,9 @@ func TestMerge(t *testing.T) {
 			},
 			ruleID: "123456",
 			expectedTime: []time.Time{
-				time.Unix(1, 0),
-				time.Unix(2, 0),
-				time.Unix(3, 0),
-			},
-			expectedState: []string{
-				"normal",
-				"normal",
-				"firing",
+				time.Unix(0, 1),
+				time.Unix(0, 2),
+				time.Unix(0, 3),
 			},
 		},
 	}
@@ -245,25 +234,17 @@ func TestMerge(t *testing.T) {
 			m, err := merge(tc.res, tc.ruleID)
 			require.NoError(t, err)
 
-			var (
-				dfTimeColumn  *data.Field
-				dfStateColumn *data.Field
-			)
+			var dfTimeColumn *data.Field
 			for _, f := range m.Fields {
 				if f.Name == dfTime {
 					dfTimeColumn = f
 				}
-				if f.Name == dfNext {
-					dfStateColumn = f
-				}
 			}
 
-			require.NotNil(t, dfStateColumn)
 			require.NotNil(t, dfTimeColumn)
 
 			for i := 0; i < len(tc.expectedTime); i++ {
 				require.Equal(t, tc.expectedTime[i], dfTimeColumn.At(i))
-				require.Equal(t, tc.expectedState[i], dfStateColumn.At(i))
 			}
 		})
 	}

--- a/pkg/services/ngalert/state/historian/loki_test.go
+++ b/pkg/services/ngalert/state/historian/loki_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -138,6 +139,134 @@ func TestRemoteLokiBackend(t *testing.T) {
 			require.InDelta(t, 5.5, entry.Values.Get("B").MustFloat64(), 1e-4)
 		})
 	})
+}
+
+func TestMerge(t *testing.T) {
+	testCases := []struct {
+		name          string
+		res           QueryRes
+		ruleID        string
+		expectedTime  []time.Time
+		expectedState []string
+	}{
+		{
+			name: "Should return values from multiple streams in right order",
+			res: QueryRes{
+				Data: QueryData{
+					Result: []Stream{
+						{
+							Stream: map[string]string{
+								"current": "pending",
+							},
+							Values: [][2]string{
+								{"1", `{"schemaVersion": 1, "previous": "normal", "current": "pending", "values":{"a": "b"}}`},
+							},
+						},
+						{
+							Stream: map[string]string{
+								"current": "firing",
+							},
+							Values: [][2]string{
+								{"2", `{"schemaVersion": 1, "previous": "pending", "current": "firing", "values":{"a": "b"}}`},
+							},
+						},
+					},
+				},
+			},
+			ruleID: "123456",
+			expectedTime: []time.Time{
+				time.Unix(1, 0),
+				time.Unix(2, 0),
+			},
+			expectedState: []string{
+				"pending",
+				"firing",
+			},
+		},
+		{
+			name: "Should handle empty values",
+			res: QueryRes{
+				Data: QueryData{
+					Result: []Stream{
+						{
+							Stream: map[string]string{
+								"current": "normal",
+							},
+							Values: [][2]string{},
+						},
+					},
+				},
+			},
+			ruleID:        "123456",
+			expectedTime:  []time.Time{},
+			expectedState: []string{},
+		},
+		{
+			name: "Should handle multiple values in one stream",
+			res: QueryRes{
+				Data: QueryData{
+					Result: []Stream{
+						{
+							Stream: map[string]string{
+								"current": "normal",
+							},
+							Values: [][2]string{
+								{"1", `{"schemaVersion": 1, "previous": "firing", "current": "normal", "values":{"a": "b"}}`},
+								{"2", `{"schemaVersion": 1, "previous": "firing", "current": "normal", "values":{"a": "b"}}`},
+							},
+						},
+						{
+							Stream: map[string]string{
+								"current": "firing",
+							},
+							Values: [][2]string{
+								{"3", `{"schemaVersion": 1, "previous": "pending", "current": "firing", "values":{"a": "b"}}`},
+							},
+						},
+					},
+				},
+			},
+			ruleID: "123456",
+			expectedTime: []time.Time{
+				time.Unix(1, 0),
+				time.Unix(2, 0),
+				time.Unix(3, 0),
+			},
+			expectedState: []string{
+				"normal",
+				"normal",
+				"firing",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			m, err := merge(tc.res, tc.ruleID)
+			require.NoError(t, err)
+
+			var (
+				dfTimeColumn  *data.Field
+				dfStateColumn *data.Field
+			)
+			for _, f := range m.Fields {
+				if f.Name == dfTime {
+					dfTimeColumn = f
+				}
+				if f.Name == dfNext {
+					dfStateColumn = f
+				}
+			}
+
+			require.NotNil(t, dfStateColumn)
+			require.NotNil(t, dfTimeColumn)
+
+			for i := 0; i < len(tc.expectedTime); i++ {
+				require.Equal(t, tc.expectedTime[i], dfTimeColumn.At(i))
+				require.Equal(t, tc.expectedState[i], dfStateColumn.At(i))
+			}
+		})
+	}
 }
 
 func singleFromNormal(st *state.State) []state.StateTransition {


### PR DESCRIPTION
This PR adds the ability to query loki to get the alert state history.

It is using the range query API to get all the state changes between `start` and `end`, and then merges the state streams into one `dataframe` sorted from the oldest entry to the newest.

The API layer was tested manually against Grafana Cloud.


Rel: https://github.com/grafana/grafana/issues/48359