### PR TITLE
Create full directory path for testing docs

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -985,7 +985,7 @@ steps:
   image: grafana/build-container:v1.7.1
   name: lint-docs
 - commands:
-  - mkdir -p /hugo/content/docs/grafana
+  - mkdir -p /hugo/content/docs/grafana/latest
   - cp -r docs/sources/* /hugo/content/docs/grafana/latest/
   - cd /hugo && make prod
   image: grafana/docs-base:latest
@@ -1102,7 +1102,7 @@ steps:
   image: grafana/build-container:v1.7.1
   name: lint-docs
 - commands:
-  - mkdir -p /hugo/content/docs/grafana
+  - mkdir -p /hugo/content/docs/grafana/latest
   - cp -r docs/sources/* /hugo/content/docs/grafana/latest/
   - cd /hugo && make prod
   image: grafana/docs-base:latest
@@ -6660,6 +6660,6 @@ kind: secret
 name: aws_secret_access_key
 ---
 kind: signature
-hmac: 57537bd164fcf56d24efb3972e06dc7af094546bf70052a2efd026a018059479
+hmac: 1847568b29364d0ba065b1f65d6536f24f636dbf36ce2cdccf05e8f80e2b9caf
 
 ...

--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -3,7 +3,7 @@ aliases:
   - /docs/grafana/v1.1/
   - /docs/grafana/v3.1/
   - guides/reference/admin/
-description: Guides, Installation, and Feature Documentation
+description: Guides, installation, and feature documentation
 keywords:
   - grafana
   - installation

--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -3,7 +3,7 @@ aliases:
   - /docs/grafana/v1.1/
   - /docs/grafana/v3.1/
   - guides/reference/admin/
-description: Guides, Installation and Feature Documentation
+description: Guides, Installation, and Feature Documentation
 keywords:
   - grafana
   - installation

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -940,7 +940,7 @@ def build_docs_website_step():
         # Use latest revision here, since we want to catch if it breaks
         "image": "grafana/docs-base:latest",
         "commands": [
-            "mkdir -p /hugo/content/docs/grafana",
+            "mkdir -p /hugo/content/docs/grafana/latest",
             "cp -r docs/sources/* /hugo/content/docs/grafana/latest/",
             "cd /hugo && make prod",
         ],


### PR DESCRIPTION
The previous command was useless as the old image already had the `/hugo/content/docs/grafana directory`. The old image also had the `/hugo/content/docs/grafana/latest` directory but the new image does not and the `cp -r` command is broken without this fix. 

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
