### PR TITLE
dashboards: Mark dashboards team as kind owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -535,9 +535,12 @@ lerna.json @grafana/frontend-ops
 /pkg/infra/httpclient/httpclientprovider/sigv4_middleware.go @grafana/grafana-partnerships-team
 /pkg/infra/httpclient/httpclientprovider/sigv4_middleware_test.go @grafana/grafana-partnerships-team
 
+# Kind definitions
+/kinds/dashboard @grafana/dashboards-squad
+/kinds/ @grafana/grafana-as-code // as-code is fallback owner
+
 # Kind system and code generation
 embed.go @grafana/grafana-as-code
-/kinds/ @grafana/grafana-as-code
 /pkg/kinds/ @grafana/grafana-as-code
 /pkg/cuectx/ @grafana/grafana-as-code
 /pkg/registry/ @grafana/grafana-as-code

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -537,7 +537,7 @@ lerna.json @grafana/frontend-ops
 
 # Kind definitions
 /kinds/dashboard @grafana/dashboards-squad
-/kinds/ @grafana/grafana-as-code // as-code is fallback owner
+/kinds/ @grafana/grafana-as-code
 
 # Kind system and code generation
 embed.go @grafana/grafana-as-code


### PR DESCRIPTION
Formally marks @grafana/dashboards-squad as the owner of the dashboards kind 😄 

cc @ivanortegaalba if nothing else, this should mean you get auto-pinged on PRs against the dashboard schema tomorrow