### PR TITLE
API: Change how Cache-Control and related headers are set

### DIFF
--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -69,9 +69,9 @@ func addSecurityHeaders(w web.ResponseWriter, cfg *setting.Cfg) {
 }
 
 func addNoCacheHeaders(w web.ResponseWriter) {
-	w.Header().Set("Cache-Control", "no-cache")
-	w.Header().Set("Pragma", "no-cache")
-	w.Header().Set("Expires", "-1")
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Del("Pragma")
+	w.Header().Del("Expires")
 }
 
 func addXFrameOptionsDenyHeader(w web.ResponseWriter) {

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -148,8 +148,8 @@ func TestMiddlewareContext(t *testing.T) {
 	middlewareScenario(t, "middleware should add Cache-Control header for requests to API", func(t *testing.T, sc *scenarioContext) {
 		sc.fakeReq("GET", "/api/search").exec()
 		assert.Equal(t, noStore, sc.resp.Header().Get("Cache-Control"))
-		assert.Equal(t, "", sc.resp.Header().Get("Pragma"))
-		assert.Equal(t, "", sc.resp.Header().Get("Expires"))
+		assert.Empty(t, sc.resp.Header().Get("Pragma"))
+		assert.Empty(t, sc.resp.Header().Get("Expires"))
 	})
 
 	middlewareScenario(t, "middleware should not add Cache-Control header for requests to datasource proxy API", func(
@@ -176,8 +176,8 @@ func TestMiddlewareContext(t *testing.T) {
 		sc.fakeReq("GET", "/").exec()
 		require.Equal(t, 200, sc.resp.Code)
 		assert.Equal(t, noStore, sc.resp.Header().Get("Cache-Control"))
-		assert.Equal(t, "", sc.resp.Header().Get("Pragma"))
-		assert.Equal(t, "", sc.resp.Header().Get("Expires"))
+		assert.Empty(t, sc.resp.Header().Get("Pragma"))
+		assert.Empty(t, sc.resp.Header().Get("Expires"))
 	})
 
 	middlewareScenario(t, "middleware should add X-Frame-Options header with deny for request when not allowing embedding", func(

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -128,7 +128,7 @@ func TestMiddleWareContentSecurityPolicyHeaders(t *testing.T) {
 }
 
 func TestMiddlewareContext(t *testing.T) {
-	const noCache = "no-cache"
+	const noStore = "no-store"
 
 	configureJWTAuthHeader := func(cfg *setting.Cfg) {
 		cfg.JWTAuthEnabled = true
@@ -147,9 +147,9 @@ func TestMiddlewareContext(t *testing.T) {
 
 	middlewareScenario(t, "middleware should add Cache-Control header for requests to API", func(t *testing.T, sc *scenarioContext) {
 		sc.fakeReq("GET", "/api/search").exec()
-		assert.Equal(t, noCache, sc.resp.Header().Get("Cache-Control"))
-		assert.Equal(t, noCache, sc.resp.Header().Get("Pragma"))
-		assert.Equal(t, "-1", sc.resp.Header().Get("Expires"))
+		assert.Equal(t, noStore, sc.resp.Header().Get("Cache-Control"))
+		assert.Equal(t, "", sc.resp.Header().Get("Pragma"))
+		assert.Equal(t, "", sc.resp.Header().Get("Expires"))
 	})
 
 	middlewareScenario(t, "middleware should not add Cache-Control header for requests to datasource proxy API", func(
@@ -175,9 +175,9 @@ func TestMiddlewareContext(t *testing.T) {
 		}
 		sc.fakeReq("GET", "/").exec()
 		require.Equal(t, 200, sc.resp.Code)
-		assert.Equal(t, noCache, sc.resp.Header().Get("Cache-Control"))
-		assert.Equal(t, noCache, sc.resp.Header().Get("Pragma"))
-		assert.Equal(t, "-1", sc.resp.Header().Get("Expires"))
+		assert.Equal(t, noStore, sc.resp.Header().Get("Cache-Control"))
+		assert.Equal(t, "", sc.resp.Header().Get("Pragma"))
+		assert.Equal(t, "", sc.resp.Header().Get("Expires"))
 	})
 
 	middlewareScenario(t, "middleware should add X-Frame-Options header with deny for request when not allowing embedding", func(


### PR DESCRIPTION
**What is this feature?**
Changes the `Cache-Control`, `Pragma`, and `Expires` headers set on API responses.

This is in order to to update to modern http usage (Pragma is old, Expires not needed with Cache-Control), and I believe `no-store` matches the intent behind this older issue https://github.com/grafana/grafana/issues/16845 more than `no-cache`.

**Other Notes:**

- Intend to follow this up with a PR to allow cache headers through from data source resource calls (Cache-Control being `private` will be required to pass through.
- Reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control 
- Could keep expires, but http/1.1 has been out for a bit now ...





