### PR TITLE
Datasources: Add support for getDetDefaultQuery in variable editor

### DIFF
--- a/packages/grafana-data/src/types/variables.ts
+++ b/packages/grafana-data/src/types/variables.ts
@@ -35,6 +35,8 @@ export abstract class VariableSupportBase<
   TOptions extends DataSourceJsonData = DataSourceOptionsType<DSType>
 > {
   abstract getType(): VariableSupportType;
+
+  getDefaultQuery?(): Partial<TQuery>;
 }
 
 /**

--- a/packages/grafana-data/src/types/variables.ts
+++ b/packages/grafana-data/src/types/variables.ts
@@ -36,6 +36,9 @@ export abstract class VariableSupportBase<
 > {
   abstract getType(): VariableSupportType;
 
+  /**
+   * Define this method in the config if you want to pre-populate the editor with a default query.
+   */
   getDefaultQuery?(): Partial<TQuery>;
 }
 

--- a/public/app/features/variables/query/QueryVariableEditor.test.tsx
+++ b/public/app/features/variables/query/QueryVariableEditor.test.tsx
@@ -77,7 +77,7 @@ describe('QueryVariableEditor', () => {
         } as unknown as DataSourceApi,
       },
     };
-    it('should pass the query with default values if the datasource config defines it', () => {
+    it('should pass down the query with default values if the datasource config defines it', () => {
       const extended = { ...extendedCustom };
       extended.extended.dataSource.variables!.getDefaultQuery = jest
         .fn()
@@ -90,7 +90,7 @@ describe('QueryVariableEditor', () => {
         expect.anything()
       );
     });
-    it('should not get default query if the datasource config doesnt define it', () => {
+    it('should not pass down a default query if the datasource config doesnt define it', () => {
       extendedCustom.extended.dataSource.variables!.getDefaultQuery = undefined;
       const { props } = setupTestContext(extendedCustom);
       expect(props.extended?.dataSource?.variables?.getDefaultQuery).not.toBeDefined();

--- a/public/app/features/variables/query/QueryVariableEditor.test.tsx
+++ b/public/app/features/variables/query/QueryVariableEditor.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
-import { DataSourceApi } from '@grafana/data';
+import { DataSourceApi, VariableSupportType } from '@grafana/data';
 import { mockDataSource } from 'app/features/alerting/unified/mocks';
 import { DataSourceType } from 'app/features/alerting/unified/utils/datasource';
 
@@ -64,6 +64,42 @@ describe('QueryVariableEditor', () => {
     });
   });
 
+  describe('when the editor is rendered', () => {
+    const extendedCustom = {
+      extended: {
+        VariableQueryEditor: jest.fn().mockImplementation(LegacyVariableQueryEditor),
+        dataSource: {
+          variables: {
+            getType: () => VariableSupportType.Custom,
+            query: jest.fn(),
+            editor: jest.fn(),
+          },
+        } as unknown as DataSourceApi,
+      },
+    };
+    it('should pass the query with default values if the datasource config defines it', () => {
+      const extended = { ...extendedCustom };
+      extended.extended.dataSource.variables!.getDefaultQuery = jest
+        .fn()
+        .mockImplementation(() => 'some default query');
+      const { props } = setupTestContext(extended);
+      expect(props.extended?.dataSource?.variables?.getDefaultQuery).toBeDefined();
+      expect(props.extended?.dataSource?.variables?.getDefaultQuery).toHaveBeenCalledTimes(1);
+      expect(props.extended?.VariableQueryEditor).toHaveBeenCalledWith(
+        expect.objectContaining({ query: 'some default query' }),
+        expect.anything()
+      );
+    });
+    it('should not get default query if the datasource config doesnt define it', () => {
+      extendedCustom.extended.dataSource.variables!.getDefaultQuery = undefined;
+      const { props } = setupTestContext(extendedCustom);
+      expect(props.extended?.dataSource?.variables?.getDefaultQuery).not.toBeDefined();
+      expect(props.extended?.VariableQueryEditor).toHaveBeenCalledWith(
+        expect.objectContaining({ query: '' }),
+        expect.anything()
+      );
+    });
+  });
   describe('when the user changes', () => {
     it.each`
       fieldName  | propName                      | expectedArgs

--- a/public/app/features/variables/query/QueryVariableEditor.tsx
+++ b/public/app/features/variables/query/QueryVariableEditor.tsx
@@ -134,9 +134,19 @@ export class QueryVariableEditorUnConnected extends PureComponent<Props, State> 
       return null;
     }
 
-    const query = variable.query;
     const datasource = extended.dataSource;
     const VariableQueryEditor = extended.VariableQueryEditor;
+
+    let query = variable.query;
+
+    if (typeof query === 'string') {
+      query = query || (datasource.variables?.getDefaultQuery?.() ?? '');
+    } else {
+      query = {
+        ...datasource.variables?.getDefaultQuery?.(),
+        ...variable.query,
+      };
+    }
 
     if (isLegacyQueryEditor(VariableQueryEditor, datasource)) {
       return (

--- a/public/app/plugins/datasource/cloudwatch/defaultQueries.ts
+++ b/public/app/plugins/datasource/cloudwatch/defaultQueries.ts
@@ -1,4 +1,12 @@
-import { CloudWatchLogsQuery, CloudWatchMetricsQuery, LogGroup, MetricEditorMode, MetricQueryType } from './types';
+import {
+  CloudWatchLogsQuery,
+  CloudWatchMetricsQuery,
+  LogGroup,
+  MetricEditorMode,
+  MetricQueryType,
+  VariableQuery,
+  VariableQueryType,
+} from './types';
 
 export const DEFAULT_METRICS_QUERY: Omit<CloudWatchMetricsQuery, 'refId'> = {
   queryMode: 'Metrics',
@@ -29,3 +37,8 @@ export const getDefaultLogsQuery = (
   logGroupNames: legacyDefaultLogGroups,
   logGroups: defaultLogGroups ?? [],
 });
+
+export const DEFAULT_VARIABLE_QUERY: Partial<VariableQuery> = {
+  queryType: VariableQueryType.Regions,
+  region: 'default',
+};

--- a/public/app/plugins/datasource/cloudwatch/variables.ts
+++ b/public/app/plugins/datasource/cloudwatch/variables.ts
@@ -12,6 +12,7 @@ import {
 import { ALL_ACCOUNTS_OPTION } from './components/Account';
 import { VariableQueryEditor } from './components/VariableQueryEditor/VariableQueryEditor';
 import { CloudWatchDatasource } from './datasource';
+import { DEFAULT_VARIABLE_QUERY } from './defaultQueries';
 import { migrateVariableQuery } from './migrations/variableQueryMigrations';
 import { ResourcesAPI } from './resources/ResourcesAPI';
 import { standardStatistics } from './standardStatistics';
@@ -157,6 +158,10 @@ export class CloudWatchVariableSupport extends CustomVariableSupport<CloudWatchD
 
       return metricFindOptions.length ? [this.allMetricFindValue, ...metricFindOptions] : [];
     });
+  }
+
+  getDefaultQuery(): Partial<VariableQuery> {
+    return DEFAULT_VARIABLE_QUERY;
   }
 }
 


### PR DESCRIPTION
…+ its Cloudwatch implementation

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR adds support for datasources to optionally define default queries when the variable editor is defined. 

**Why do we need this feature?**

This feature isn't a fix of a bug or a needed feature, just a nice-to-have, in case datasources want to define some default parameters for a variable query (that may be different from a standard default query needed [elsewhere](https://github.com/grafana/grafana/blob/9aed3648987263a7ad986b38632095abfed872a6/public/app/features/query/components/QueryGroup.tsx)). 

For example, VariableQueryEditor in Cloudwatch Montoring DS defines some default query fields in the component and has an additional step to update the query on mount. When this PR is merged, datasource devs can move the default query to the datasource's variable config and delete this additional step.

Just as info: This is a continuation of implementing https://github.com/grafana/grafana/pull/49581

**Who is this feature for?**

Datasource devs


**Special notes for your reviewer:**

(not crucial, just as info about another approach we decided against)
Originally, the changes were meant to be [in a single PR](https://github.com/grafana/grafana/pull/61402) for both annotations and variables. Also, that PR was using getDefaultQuery arguments to determine which kind of a query to return. However, we decided on another approach presented in this PR that would have dedicated methods for each "Data Query Kind" (standard, annotations, or variable) and split the approach into two PRs.

