### PR TITLE
Tempo: [TraceQL] Do not override the `status` tag name

### DIFF
--- a/public/app/plugins/datasource/tempo/traceql/autocomplete.ts
+++ b/public/app/plugins/datasource/tempo/traceql/autocomplete.ts
@@ -92,15 +92,6 @@ export class CompletionProvider implements monacoTypes.languages.CompletionItemP
     this.registerInteractionCommandId = id;
   }
 
-  private overrideTagName(tagName: string): string {
-    switch (tagName) {
-      case 'status':
-        return 'status.code';
-      default:
-        return tagName;
-    }
-  }
-
   private async getTagValues(tagName: string): Promise<Array<SelectableValue<string>>> {
     let tagValues: Array<SelectableValue<string>>;
 
@@ -148,8 +139,7 @@ export class CompletionProvider implements monacoTypes.languages.CompletionItemP
           type: 'OPERATOR',
         }));
       case 'SPANSET_IN_VALUE':
-        const tagName = this.overrideTagName(situation.tagName);
-        const tagValues = await this.getTagValues(tagName);
+        const tagValues = await this.getTagValues(situation.tagName);
         const items: Completion[] = [];
 
         const getInsertionText = (val: SelectableValue<string>): string => {


### PR DESCRIPTION
Tempo API v1 required a request to be made to `/api/search/tag/status.code/values` to retrieve valid status values.
With v2 of the Tempo API, the request needs to be made to `/api/v2/search/tag/status/values` to retrieve valid status values. 

This PR removes the function that changed the `'status'` string to `'status.code'` before making a request to the API.