### PR TITLE
Alerting: Copy rule definitions into state history

### DIFF
--- a/pkg/services/ngalert/state/historian/annotation.go
+++ b/pkg/services/ngalert/state/historian/annotation.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/state"
+	history_model "github.com/grafana/grafana/pkg/services/ngalert/state/historian/model"
 )
 
 // AnnotationBackend is an implementation of state.Historian that uses Grafana Annotations as the backing datastore.
@@ -40,7 +41,7 @@ func NewAnnotationBackend(annotations annotations.Repository, dashboards dashboa
 }
 
 // RecordStates writes a number of state transitions for a given rule to state history.
-func (h *AnnotationBackend) RecordStatesAsync(ctx context.Context, rule state.RuleMeta, states []state.StateTransition) <-chan error {
+func (h *AnnotationBackend) RecordStatesAsync(ctx context.Context, rule history_model.RuleMeta, states []state.StateTransition) <-chan error {
 	logger := h.log.FromContext(ctx)
 	// Build annotations before starting goroutine, to make sure all data is copied and won't mutate underneath us.
 	annotations := h.buildAnnotations(rule, states, logger)
@@ -136,7 +137,7 @@ func (h *AnnotationBackend) QueryStates(ctx context.Context, query ngmodels.Hist
 	return frame, nil
 }
 
-func (h *AnnotationBackend) buildAnnotations(rule state.RuleMeta, states []state.StateTransition, logger log.Logger) []annotations.Item {
+func (h *AnnotationBackend) buildAnnotations(rule history_model.RuleMeta, states []state.StateTransition, logger log.Logger) []annotations.Item {
 	items := make([]annotations.Item, 0, len(states))
 	for _, state := range states {
 		if !shouldRecord(state) {
@@ -184,7 +185,7 @@ func (h *AnnotationBackend) recordAnnotationsSync(ctx context.Context, panel *pa
 	return nil
 }
 
-func buildAnnotationTextAndData(rule state.RuleMeta, currentState *state.State) (string, *simplejson.Json) {
+func buildAnnotationTextAndData(rule history_model.RuleMeta, currentState *state.State) (string, *simplejson.Json) {
 	jsonData := simplejson.New()
 	var value string
 

--- a/pkg/services/ngalert/state/historian/annotation.go
+++ b/pkg/services/ngalert/state/historian/annotation.go
@@ -40,7 +40,7 @@ func NewAnnotationBackend(annotations annotations.Repository, dashboards dashboa
 }
 
 // RecordStates writes a number of state transitions for a given rule to state history.
-func (h *AnnotationBackend) RecordStatesAsync(ctx context.Context, rule ngmodels.AlertRule, states []state.StateTransition) <-chan error {
+func (h *AnnotationBackend) RecordStatesAsync(ctx context.Context, rule state.RuleMeta, states []state.StateTransition) <-chan error {
 	logger := h.log.FromContext(ctx)
 	// Build annotations before starting goroutine, to make sure all data is copied and won't mutate underneath us.
 	annotations := h.buildAnnotations(rule, states, logger)
@@ -136,7 +136,7 @@ func (h *AnnotationBackend) QueryStates(ctx context.Context, query ngmodels.Hist
 	return frame, nil
 }
 
-func (h *AnnotationBackend) buildAnnotations(rule ngmodels.AlertRule, states []state.StateTransition, logger log.Logger) []annotations.Item {
+func (h *AnnotationBackend) buildAnnotations(rule state.RuleMeta, states []state.StateTransition, logger log.Logger) []annotations.Item {
 	items := make([]annotations.Item, 0, len(states))
 	for _, state := range states {
 		if !shouldRecord(state) {
@@ -184,7 +184,7 @@ func (h *AnnotationBackend) recordAnnotationsSync(ctx context.Context, panel *pa
 	return nil
 }
 
-func buildAnnotationTextAndData(rule ngmodels.AlertRule, currentState *state.State) (string, *simplejson.Json) {
+func buildAnnotationTextAndData(rule state.RuleMeta, currentState *state.State) (string, *simplejson.Json) {
 	jsonData := simplejson.New()
 	var value string
 

--- a/pkg/services/ngalert/state/historian/annotation.go
+++ b/pkg/services/ngalert/state/historian/annotation.go
@@ -40,7 +40,7 @@ func NewAnnotationBackend(annotations annotations.Repository, dashboards dashboa
 }
 
 // RecordStates writes a number of state transitions for a given rule to state history.
-func (h *AnnotationBackend) RecordStatesAsync(ctx context.Context, rule *ngmodels.AlertRule, states []state.StateTransition) <-chan error {
+func (h *AnnotationBackend) RecordStatesAsync(ctx context.Context, rule ngmodels.AlertRule, states []state.StateTransition) <-chan error {
 	logger := h.log.FromContext(ctx)
 	// Build annotations before starting goroutine, to make sure all data is copied and won't mutate underneath us.
 	annotations := h.buildAnnotations(rule, states, logger)
@@ -136,7 +136,7 @@ func (h *AnnotationBackend) QueryStates(ctx context.Context, query ngmodels.Hist
 	return frame, nil
 }
 
-func (h *AnnotationBackend) buildAnnotations(rule *ngmodels.AlertRule, states []state.StateTransition, logger log.Logger) []annotations.Item {
+func (h *AnnotationBackend) buildAnnotations(rule ngmodels.AlertRule, states []state.StateTransition, logger log.Logger) []annotations.Item {
 	items := make([]annotations.Item, 0, len(states))
 	for _, state := range states {
 		if !shouldRecord(state) {
@@ -184,7 +184,7 @@ func (h *AnnotationBackend) recordAnnotationsSync(ctx context.Context, panel *pa
 	return nil
 }
 
-func buildAnnotationTextAndData(rule *ngmodels.AlertRule, currentState *state.State) (string, *simplejson.Json) {
+func buildAnnotationTextAndData(rule ngmodels.AlertRule, currentState *state.State) (string, *simplejson.Json) {
 	jsonData := simplejson.New()
 	var value string
 

--- a/pkg/services/ngalert/state/historian/core.go
+++ b/pkg/services/ngalert/state/historian/core.go
@@ -8,6 +8,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/state"
+	history_model "github.com/grafana/grafana/pkg/services/ngalert/state/historian/model"
 )
 
 func shouldRecord(transition state.StateTransition) bool {
@@ -36,7 +37,7 @@ type panelKey struct {
 }
 
 // panelKey attempts to get the key of the panel attached to the given rule. Returns nil if the rule is not attached to a panel.
-func parsePanelKey(rule state.RuleMeta, logger log.Logger) *panelKey {
+func parsePanelKey(rule history_model.RuleMeta, logger log.Logger) *panelKey {
 	if rule.DashboardUID != "" {
 		return &panelKey{
 			orgID:   rule.OrgID,

--- a/pkg/services/ngalert/state/historian/core.go
+++ b/pkg/services/ngalert/state/historian/core.go
@@ -37,7 +37,7 @@ type panelKey struct {
 }
 
 // panelKey attempts to get the key of the panel attached to the given rule. Returns nil if the rule is not attached to a panel.
-func parsePanelKey(rule *models.AlertRule, logger log.Logger) *panelKey {
+func parsePanelKey(rule models.AlertRule, logger log.Logger) *panelKey {
 	dashUID, ok := rule.Annotations[models.DashboardUIDAnnotation]
 	if ok {
 		panelAnno := rule.Annotations[models.PanelIDAnnotation]

--- a/pkg/services/ngalert/state/historian/core.go
+++ b/pkg/services/ngalert/state/historian/core.go
@@ -1,7 +1,6 @@
 package historian
 
 import (
-	"strconv"
 	"strings"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
@@ -37,19 +36,12 @@ type panelKey struct {
 }
 
 // panelKey attempts to get the key of the panel attached to the given rule. Returns nil if the rule is not attached to a panel.
-func parsePanelKey(rule models.AlertRule, logger log.Logger) *panelKey {
-	dashUID, ok := rule.Annotations[models.DashboardUIDAnnotation]
-	if ok {
-		panelAnno := rule.Annotations[models.PanelIDAnnotation]
-		panelID, err := strconv.ParseInt(panelAnno, 10, 64)
-		if err != nil {
-			logger.Error("Error parsing panelUID for alert annotation", "actual", panelAnno, "error", err)
-			return nil
-		}
+func parsePanelKey(rule state.RuleMeta, logger log.Logger) *panelKey {
+	if rule.DashboardUID != "" {
 		return &panelKey{
 			orgID:   rule.OrgID,
-			dashUID: dashUID,
-			panelID: panelID,
+			dashUID: rule.DashboardUID,
+			panelID: rule.PanelID,
 		}
 	}
 	return nil

--- a/pkg/services/ngalert/state/historian/core_test.go
+++ b/pkg/services/ngalert/state/historian/core_test.go
@@ -214,7 +214,8 @@ func TestParsePanelKey(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			res := parsePanelKey(tc.in, logger)
+			m := state.NewRuleMeta(&tc.in, logger)
+			res := parsePanelKey(m, logger)
 			require.Equal(t, tc.exp, res)
 		})
 	}

--- a/pkg/services/ngalert/state/historian/core_test.go
+++ b/pkg/services/ngalert/state/historian/core_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/state"
+	history_model "github.com/grafana/grafana/pkg/services/ngalert/state/historian/model"
 )
 
 func TestShouldRecord(t *testing.T) {
@@ -214,7 +215,7 @@ func TestParsePanelKey(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			m := state.NewRuleMeta(&tc.in, logger)
+			m := history_model.NewRuleMeta(&tc.in, logger)
 			res := parsePanelKey(m, logger)
 			require.Equal(t, tc.exp, res)
 		})

--- a/pkg/services/ngalert/state/historian/core_test.go
+++ b/pkg/services/ngalert/state/historian/core_test.go
@@ -214,7 +214,7 @@ func TestParsePanelKey(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			res := parsePanelKey(&tc.in, logger)
+			res := parsePanelKey(tc.in, logger)
 			require.Equal(t, tc.exp, res)
 		})
 	}

--- a/pkg/services/ngalert/state/historian/core_test.go
+++ b/pkg/services/ngalert/state/historian/core_test.go
@@ -7,11 +7,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
-	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/state"
-	history_model "github.com/grafana/grafana/pkg/services/ngalert/state/historian/model"
 )
 
 func TestShouldRecord(t *testing.T) {
@@ -150,73 +148,6 @@ func TestRemovePrivateLabels(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			res := removePrivateLabels(tc.in)
-			require.Equal(t, tc.exp, res)
-		})
-	}
-}
-
-func TestParsePanelKey(t *testing.T) {
-	logger := log.NewNopLogger()
-
-	type testCase struct {
-		name string
-		in   models.AlertRule
-		exp  *panelKey
-	}
-
-	cases := []testCase{
-		{
-			name: "no dash UID",
-			in: models.AlertRule{
-				OrgID: 1,
-				Annotations: map[string]string{
-					models.PanelIDAnnotation: "123",
-				},
-			},
-			exp: nil,
-		},
-		{
-			name: "no panel ID",
-			in: models.AlertRule{
-				OrgID: 1,
-				Annotations: map[string]string{
-					models.DashboardUIDAnnotation: "abcd-uid",
-				},
-			},
-			exp: nil,
-		},
-		{
-			name: "invalid panel ID",
-			in: models.AlertRule{
-				OrgID: 1,
-				Annotations: map[string]string{
-					models.DashboardUIDAnnotation: "abcd-uid",
-					models.PanelIDAnnotation:      "bad-id",
-				},
-			},
-			exp: nil,
-		},
-		{
-			name: "success",
-			in: models.AlertRule{
-				OrgID: 1,
-				Annotations: map[string]string{
-					models.DashboardUIDAnnotation: "abcd-uid",
-					models.PanelIDAnnotation:      "123",
-				},
-			},
-			exp: &panelKey{
-				orgID:   1,
-				dashUID: "abcd-uid",
-				panelID: 123,
-			},
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			m := history_model.NewRuleMeta(&tc.in, logger)
-			res := parsePanelKey(m, logger)
 			require.Equal(t, tc.exp, res)
 		})
 	}

--- a/pkg/services/ngalert/state/historian/loki.go
+++ b/pkg/services/ngalert/state/historian/loki.go
@@ -43,7 +43,7 @@ func (h *RemoteLokiBackend) TestConnection() error {
 	return h.client.ping()
 }
 
-func (h *RemoteLokiBackend) RecordStatesAsync(ctx context.Context, rule *models.AlertRule, states []state.StateTransition) <-chan error {
+func (h *RemoteLokiBackend) RecordStatesAsync(ctx context.Context, rule models.AlertRule, states []state.StateTransition) <-chan error {
 	logger := h.log.FromContext(ctx)
 	streams := h.statesToStreams(rule, states, logger)
 	return h.recordStreamsAsync(ctx, streams, logger)
@@ -53,7 +53,7 @@ func (h *RemoteLokiBackend) QueryStates(ctx context.Context, query models.Histor
 	return data.NewFrame("states"), nil
 }
 
-func (h *RemoteLokiBackend) statesToStreams(rule *models.AlertRule, states []state.StateTransition, logger log.Logger) []stream {
+func (h *RemoteLokiBackend) statesToStreams(rule models.AlertRule, states []state.StateTransition, logger log.Logger) []stream {
 	buckets := make(map[string][]row) // label repr -> entries
 	for _, state := range states {
 		if !shouldRecord(state) {

--- a/pkg/services/ngalert/state/historian/loki.go
+++ b/pkg/services/ngalert/state/historian/loki.go
@@ -43,7 +43,7 @@ func (h *RemoteLokiBackend) TestConnection() error {
 	return h.client.ping()
 }
 
-func (h *RemoteLokiBackend) RecordStatesAsync(ctx context.Context, rule models.AlertRule, states []state.StateTransition) <-chan error {
+func (h *RemoteLokiBackend) RecordStatesAsync(ctx context.Context, rule state.RuleMeta, states []state.StateTransition) <-chan error {
 	logger := h.log.FromContext(ctx)
 	streams := h.statesToStreams(rule, states, logger)
 	return h.recordStreamsAsync(ctx, streams, logger)
@@ -53,7 +53,7 @@ func (h *RemoteLokiBackend) QueryStates(ctx context.Context, query models.Histor
 	return data.NewFrame("states"), nil
 }
 
-func (h *RemoteLokiBackend) statesToStreams(rule models.AlertRule, states []state.StateTransition, logger log.Logger) []stream {
+func (h *RemoteLokiBackend) statesToStreams(rule state.RuleMeta, states []state.StateTransition, logger log.Logger) []stream {
 	buckets := make(map[string][]row) // label repr -> entries
 	for _, state := range states {
 		if !shouldRecord(state) {
@@ -63,7 +63,7 @@ func (h *RemoteLokiBackend) statesToStreams(rule models.AlertRule, states []stat
 		labels := removePrivateLabels(state.State.Labels)
 		labels[OrgIDLabel] = fmt.Sprint(rule.OrgID)
 		labels[RuleUIDLabel] = fmt.Sprint(rule.UID)
-		labels[GroupLabel] = fmt.Sprint(rule.RuleGroup)
+		labels[GroupLabel] = fmt.Sprint(rule.Group)
 		labels[FolderUIDLabel] = fmt.Sprint(rule.NamespaceUID)
 		repr := labels.String()
 

--- a/pkg/services/ngalert/state/historian/loki.go
+++ b/pkg/services/ngalert/state/historian/loki.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/state"
+	history_model "github.com/grafana/grafana/pkg/services/ngalert/state/historian/model"
 )
 
 const (
@@ -43,7 +44,7 @@ func (h *RemoteLokiBackend) TestConnection() error {
 	return h.client.ping()
 }
 
-func (h *RemoteLokiBackend) RecordStatesAsync(ctx context.Context, rule state.RuleMeta, states []state.StateTransition) <-chan error {
+func (h *RemoteLokiBackend) RecordStatesAsync(ctx context.Context, rule history_model.RuleMeta, states []state.StateTransition) <-chan error {
 	logger := h.log.FromContext(ctx)
 	streams := h.statesToStreams(rule, states, logger)
 	return h.recordStreamsAsync(ctx, streams, logger)
@@ -53,7 +54,7 @@ func (h *RemoteLokiBackend) QueryStates(ctx context.Context, query models.Histor
 	return data.NewFrame("states"), nil
 }
 
-func (h *RemoteLokiBackend) statesToStreams(rule state.RuleMeta, states []state.StateTransition, logger log.Logger) []stream {
+func (h *RemoteLokiBackend) statesToStreams(rule history_model.RuleMeta, states []state.StateTransition, logger log.Logger) []stream {
 	buckets := make(map[string][]row) // label repr -> entries
 	for _, state := range states {
 		if !shouldRecord(state) {

--- a/pkg/services/ngalert/state/historian/model/rule.go
+++ b/pkg/services/ngalert/state/historian/model/rule.go
@@ -29,6 +29,7 @@ func NewRuleMeta(r *models.AlertRule, log log.Logger) RuleMeta {
 		if err != nil {
 			logger.Error("Error parsing panelUID for alert annotation", "ruleID", r.ID, "dash", dashUID, "actual", panelAnno, "error", err)
 			pid = 0
+			dashUID = ""
 		}
 		panelID = pid
 	}

--- a/pkg/services/ngalert/state/historian/model/rule.go
+++ b/pkg/services/ngalert/state/historian/model/rule.go
@@ -1,0 +1,45 @@
+package model
+
+import (
+	"strconv"
+
+	"github.com/grafana/grafana/pkg/cmd/grafana-cli/logger"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+)
+
+// RuleMeta is the metadata about a rule that is needed by state history.
+type RuleMeta struct {
+	ID           int64
+	OrgID        int64
+	UID          string
+	Title        string
+	Group        string
+	NamespaceUID string
+	DashboardUID string
+	PanelID      int64
+}
+
+func NewRuleMeta(r *models.AlertRule, log log.Logger) RuleMeta {
+	dashUID, ok := r.Annotations[models.DashboardUIDAnnotation]
+	var panelID int64
+	if ok {
+		panelAnno := r.Annotations[models.PanelIDAnnotation]
+		pid, err := strconv.ParseInt(panelAnno, 10, 64)
+		if err != nil {
+			logger.Error("Error parsing panelUID for alert annotation", "ruleID", r.ID, "dash", dashUID, "actual", panelAnno, "error", err)
+			pid = 0
+		}
+		panelID = pid
+	}
+	return RuleMeta{
+		ID:           r.ID,
+		OrgID:        r.OrgID,
+		UID:          r.UID,
+		Title:        r.Title,
+		Group:        r.RuleGroup,
+		NamespaceUID: r.NamespaceUID,
+		DashboardUID: dashUID,
+		PanelID:      panelID,
+	}
+}

--- a/pkg/services/ngalert/state/historian/model/rule_test.go
+++ b/pkg/services/ngalert/state/historian/model/rule_test.go
@@ -1,0 +1,77 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRuleMeta(t *testing.T) {
+	logger := log.NewNopLogger()
+
+	type testCase struct {
+		name     string
+		in       models.AlertRule
+		expDash  string
+		expPanel int64
+	}
+
+	cases := []testCase{
+		{
+			name: "no dash UID",
+			in: models.AlertRule{
+				OrgID: 1,
+				Annotations: map[string]string{
+					models.PanelIDAnnotation: "123",
+				},
+			},
+			expDash:  "",
+			expPanel: 0,
+		},
+		{
+			name: "no panel ID",
+			in: models.AlertRule{
+				OrgID: 1,
+				Annotations: map[string]string{
+					models.DashboardUIDAnnotation: "abcd-uid",
+				},
+			},
+			expDash:  "",
+			expPanel: 0,
+		},
+		{
+			name: "invalid panel ID",
+			in: models.AlertRule{
+				OrgID: 1,
+				Annotations: map[string]string{
+					models.DashboardUIDAnnotation: "abcd-uid",
+					models.PanelIDAnnotation:      "bad-id",
+				},
+			},
+			expDash:  "",
+			expPanel: 0,
+		},
+		{
+			name: "success",
+			in: models.AlertRule{
+				OrgID: 1,
+				Annotations: map[string]string{
+					models.DashboardUIDAnnotation: "abcd-uid",
+					models.PanelIDAnnotation:      "123",
+				},
+			},
+			expDash:  "abcd-uid",
+			expPanel: 123,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := NewRuleMeta(&tc.in, logger)
+			require.Equal(t, tc.expDash, res.DashboardUID)
+			require.Equal(t, tc.expPanel, res.PanelID)
+		})
+	}
+}

--- a/pkg/services/ngalert/state/historian/noop.go
+++ b/pkg/services/ngalert/state/historian/noop.go
@@ -14,7 +14,7 @@ func NewNopHistorian() *NoOpHistorian {
 	return &NoOpHistorian{}
 }
 
-func (f *NoOpHistorian) RecordStatesAsync(ctx context.Context, _ *models.AlertRule, _ []state.StateTransition) <-chan error {
+func (f *NoOpHistorian) RecordStatesAsync(ctx context.Context, _ models.AlertRule, _ []state.StateTransition) <-chan error {
 	errCh := make(chan error)
 	close(errCh)
 	return errCh

--- a/pkg/services/ngalert/state/historian/noop.go
+++ b/pkg/services/ngalert/state/historian/noop.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/grafana/grafana/pkg/services/ngalert/state"
+	history_model "github.com/grafana/grafana/pkg/services/ngalert/state/historian/model"
 )
 
 // NoOpHistorian is a state.Historian that does nothing with the resulting data, to be used in contexts where history is not needed.
@@ -13,7 +14,7 @@ func NewNopHistorian() *NoOpHistorian {
 	return &NoOpHistorian{}
 }
 
-func (f *NoOpHistorian) RecordStatesAsync(ctx context.Context, _ state.RuleMeta, _ []state.StateTransition) <-chan error {
+func (f *NoOpHistorian) RecordStatesAsync(ctx context.Context, _ history_model.RuleMeta, _ []state.StateTransition) <-chan error {
 	errCh := make(chan error)
 	close(errCh)
 	return errCh

--- a/pkg/services/ngalert/state/historian/noop.go
+++ b/pkg/services/ngalert/state/historian/noop.go
@@ -3,7 +3,6 @@ package historian
 import (
 	"context"
 
-	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/state"
 )
 
@@ -14,7 +13,7 @@ func NewNopHistorian() *NoOpHistorian {
 	return &NoOpHistorian{}
 }
 
-func (f *NoOpHistorian) RecordStatesAsync(ctx context.Context, _ models.AlertRule, _ []state.StateTransition) <-chan error {
+func (f *NoOpHistorian) RecordStatesAsync(ctx context.Context, _ state.RuleMeta, _ []state.StateTransition) <-chan error {
 	errCh := make(chan error)
 	close(errCh)
 	return errCh

--- a/pkg/services/ngalert/state/historian/sql.go
+++ b/pkg/services/ngalert/state/historian/sql.go
@@ -19,7 +19,7 @@ func NewSqlBackend() *SqlBackend {
 	}
 }
 
-func (h *SqlBackend) RecordStatesAsync(ctx context.Context, _ models.AlertRule, _ []state.StateTransition) <-chan error {
+func (h *SqlBackend) RecordStatesAsync(ctx context.Context, _ state.RuleMeta, _ []state.StateTransition) <-chan error {
 	errCh := make(chan error)
 	close(errCh)
 	return errCh

--- a/pkg/services/ngalert/state/historian/sql.go
+++ b/pkg/services/ngalert/state/historian/sql.go
@@ -19,7 +19,7 @@ func NewSqlBackend() *SqlBackend {
 	}
 }
 
-func (h *SqlBackend) RecordStatesAsync(ctx context.Context, _ *models.AlertRule, _ []state.StateTransition) <-chan error {
+func (h *SqlBackend) RecordStatesAsync(ctx context.Context, _ models.AlertRule, _ []state.StateTransition) <-chan error {
 	errCh := make(chan error)
 	close(errCh)
 	return errCh

--- a/pkg/services/ngalert/state/historian/sql.go
+++ b/pkg/services/ngalert/state/historian/sql.go
@@ -7,6 +7,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/state"
+	history_model "github.com/grafana/grafana/pkg/services/ngalert/state/historian/model"
 )
 
 type SqlBackend struct {
@@ -19,7 +20,7 @@ func NewSqlBackend() *SqlBackend {
 	}
 }
 
-func (h *SqlBackend) RecordStatesAsync(ctx context.Context, _ state.RuleMeta, _ []state.StateTransition) <-chan error {
+func (h *SqlBackend) RecordStatesAsync(ctx context.Context, _ history_model.RuleMeta, _ []state.StateTransition) <-chan error {
 	errCh := make(chan error)
 	close(errCh)
 	return errCh

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
 	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
 	ngModels "github.com/grafana/grafana/pkg/services/ngalert/models"
+	history_model "github.com/grafana/grafana/pkg/services/ngalert/state/historian/model"
 )
 
 var (
@@ -197,7 +198,7 @@ func (st *Manager) ProcessEvalResults(ctx context.Context, evaluatedAt time.Time
 
 	allChanges := append(states, staleStates...)
 	if st.historian != nil {
-		st.historian.RecordStatesAsync(ctx, NewRuleMeta(alertRule, logger), allChanges)
+		st.historian.RecordStatesAsync(ctx, history_model.NewRuleMeta(alertRule, logger), allChanges)
 	}
 	return allChanges
 }

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -197,7 +197,7 @@ func (st *Manager) ProcessEvalResults(ctx context.Context, evaluatedAt time.Time
 
 	allChanges := append(states, staleStates...)
 	if st.historian != nil {
-		st.historian.RecordStatesAsync(ctx, *ngModels.CopyRule(alertRule), allChanges)
+		st.historian.RecordStatesAsync(ctx, NewRuleMeta(alertRule, logger), allChanges)
 	}
 	return allChanges
 }

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -197,7 +197,7 @@ func (st *Manager) ProcessEvalResults(ctx context.Context, evaluatedAt time.Time
 
 	allChanges := append(states, staleStates...)
 	if st.historian != nil {
-		st.historian.RecordStatesAsync(ctx, alertRule, allChanges)
+		st.historian.RecordStatesAsync(ctx, *alertRule, allChanges)
 	}
 	return allChanges
 }

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -197,7 +197,7 @@ func (st *Manager) ProcessEvalResults(ctx context.Context, evaluatedAt time.Time
 
 	allChanges := append(states, staleStates...)
 	if st.historian != nil {
-		st.historian.RecordStatesAsync(ctx, *alertRule, allChanges)
+		st.historian.RecordStatesAsync(ctx, *ngModels.CopyRule(alertRule), allChanges)
 	}
 	return allChanges
 }

--- a/pkg/services/ngalert/state/persist.go
+++ b/pkg/services/ngalert/state/persist.go
@@ -2,11 +2,9 @@ package state
 
 import (
 	"context"
-	"strconv"
 
-	"github.com/grafana/grafana/pkg/cmd/grafana-cli/logger"
-	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	history_model "github.com/grafana/grafana/pkg/services/ngalert/state/historian/model"
 )
 
 // InstanceStore represents the ability to fetch and write alert instances.
@@ -23,48 +21,12 @@ type RuleReader interface {
 	ListAlertRules(ctx context.Context, query *models.ListAlertRulesQuery) error
 }
 
-// RuleMeta is the metadata about a rule that is needed by state history.
-type RuleMeta struct {
-	ID           int64
-	OrgID        int64
-	UID          string
-	Title        string
-	Group        string
-	NamespaceUID string
-	DashboardUID string
-	PanelID      int64
-}
-
-func NewRuleMeta(r *models.AlertRule, log log.Logger) RuleMeta {
-	dashUID, ok := r.Annotations[models.DashboardUIDAnnotation]
-	var panelID int64
-	if ok {
-		panelAnno := r.Annotations[models.PanelIDAnnotation]
-		pid, err := strconv.ParseInt(panelAnno, 10, 64)
-		if err != nil {
-			logger.Error("Error parsing panelUID for alert annotation", "ruleID", r.ID, "dash", dashUID, "actual", panelAnno, "error", err)
-			pid = 0
-		}
-		panelID = pid
-	}
-	return RuleMeta{
-		ID:           r.ID,
-		OrgID:        r.OrgID,
-		UID:          r.UID,
-		Title:        r.Title,
-		Group:        r.RuleGroup,
-		NamespaceUID: r.NamespaceUID,
-		DashboardUID: dashUID,
-		PanelID:      panelID,
-	}
-}
-
 // Historian maintains an audit log of alert state history.
 type Historian interface {
 	// RecordStates writes a number of state transitions for a given rule to state history. It returns a channel that
 	// is closed when writing the state transitions has completed. If an error has occurred, the channel will contain a
 	// non-nil error.
-	RecordStatesAsync(ctx context.Context, rule RuleMeta, states []StateTransition) <-chan error
+	RecordStatesAsync(ctx context.Context, rule history_model.RuleMeta, states []StateTransition) <-chan error
 }
 
 // ImageCapturer captures images.

--- a/pkg/services/ngalert/state/persist.go
+++ b/pkg/services/ngalert/state/persist.go
@@ -2,7 +2,10 @@ package state
 
 import (
 	"context"
+	"strconv"
 
+	"github.com/grafana/grafana/pkg/cmd/grafana-cli/logger"
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 )
 
@@ -20,12 +23,48 @@ type RuleReader interface {
 	ListAlertRules(ctx context.Context, query *models.ListAlertRulesQuery) error
 }
 
+// RuleMeta is the metadata about a rule that is needed by state history.
+type RuleMeta struct {
+	ID           int64
+	OrgID        int64
+	UID          string
+	Title        string
+	Group        string
+	NamespaceUID string
+	DashboardUID string
+	PanelID      int64
+}
+
+func NewRuleMeta(r *models.AlertRule, log log.Logger) RuleMeta {
+	dashUID, ok := r.Annotations[models.DashboardUIDAnnotation]
+	var panelID int64
+	if ok {
+		panelAnno := r.Annotations[models.PanelIDAnnotation]
+		pid, err := strconv.ParseInt(panelAnno, 10, 64)
+		if err != nil {
+			logger.Error("Error parsing panelUID for alert annotation", "ruleID", r.ID, "dash", dashUID, "actual", panelAnno, "error", err)
+			pid = 0
+		}
+		panelID = pid
+	}
+	return RuleMeta{
+		ID:           r.ID,
+		OrgID:        r.OrgID,
+		UID:          r.UID,
+		Title:        r.Title,
+		Group:        r.RuleGroup,
+		NamespaceUID: r.NamespaceUID,
+		DashboardUID: dashUID,
+		PanelID:      panelID,
+	}
+}
+
 // Historian maintains an audit log of alert state history.
 type Historian interface {
 	// RecordStates writes a number of state transitions for a given rule to state history. It returns a channel that
 	// is closed when writing the state transitions has completed. If an error has occurred, the channel will contain a
 	// non-nil error.
-	RecordStatesAsync(ctx context.Context, rule models.AlertRule, states []StateTransition) <-chan error
+	RecordStatesAsync(ctx context.Context, rule RuleMeta, states []StateTransition) <-chan error
 }
 
 // ImageCapturer captures images.

--- a/pkg/services/ngalert/state/persist.go
+++ b/pkg/services/ngalert/state/persist.go
@@ -25,7 +25,7 @@ type Historian interface {
 	// RecordStates writes a number of state transitions for a given rule to state history. It returns a channel that
 	// is closed when writing the state transitions has completed. If an error has occurred, the channel will contain a
 	// non-nil error.
-	RecordStatesAsync(ctx context.Context, rule *models.AlertRule, states []StateTransition) <-chan error
+	RecordStatesAsync(ctx context.Context, rule models.AlertRule, states []StateTransition) <-chan error
 }
 
 // ImageCapturer captures images.

--- a/pkg/services/ngalert/state/testing.go
+++ b/pkg/services/ngalert/state/testing.go
@@ -62,7 +62,7 @@ func (f *FakeRuleReader) ListAlertRules(_ context.Context, q *models.ListAlertRu
 
 type FakeHistorian struct{}
 
-func (f *FakeHistorian) RecordStatesAsync(ctx context.Context, rule models.AlertRule, states []StateTransition) <-chan error {
+func (f *FakeHistorian) RecordStatesAsync(ctx context.Context, rule RuleMeta, states []StateTransition) <-chan error {
 	errCh := make(chan error)
 	close(errCh)
 	return errCh

--- a/pkg/services/ngalert/state/testing.go
+++ b/pkg/services/ngalert/state/testing.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	history_model "github.com/grafana/grafana/pkg/services/ngalert/state/historian/model"
 	"github.com/grafana/grafana/pkg/services/screenshot"
 )
 
@@ -62,7 +63,7 @@ func (f *FakeRuleReader) ListAlertRules(_ context.Context, q *models.ListAlertRu
 
 type FakeHistorian struct{}
 
-func (f *FakeHistorian) RecordStatesAsync(ctx context.Context, rule RuleMeta, states []StateTransition) <-chan error {
+func (f *FakeHistorian) RecordStatesAsync(ctx context.Context, rule history_model.RuleMeta, states []StateTransition) <-chan error {
 	errCh := make(chan error)
 	close(errCh)
 	return errCh

--- a/pkg/services/ngalert/state/testing.go
+++ b/pkg/services/ngalert/state/testing.go
@@ -62,7 +62,7 @@ func (f *FakeRuleReader) ListAlertRules(_ context.Context, q *models.ListAlertRu
 
 type FakeHistorian struct{}
 
-func (f *FakeHistorian) RecordStatesAsync(ctx context.Context, rule *models.AlertRule, states []StateTransition) <-chan error {
+func (f *FakeHistorian) RecordStatesAsync(ctx context.Context, rule models.AlertRule, states []StateTransition) <-chan error {
 	errCh := make(chan error)
 	close(errCh)
 	return errCh


### PR DESCRIPTION
**What is this feature?**

Historian now accepts a copy of the rule, rather than the rule ptr from the scheduler. This prevents data races where the rule gets modified out from underneath us by external systems.

**Why do we need this feature?**

The way we do concurrency in this area is changing lately, and we'd eventually like to lift the point where we start the goroutine to be higher up in the call stack.

But, the current implementation is **extremely** sensitive to such changes, because it accepts both rules and states as pointers, and they can be concurrently modified out from underneath the goroutine.

This change makes us now copy rules when sending them to the historian, ensuring that the data stays frozen. **This problem still exists** for the state object (StateTransition contains a *State), but the surface is reduced.

I created a benchmark environment, and this copy is a completely negligible change performance and memory-wise:
```
└──>benchstat pointer.txt
goos: linux
goarch: amd64
pkg: github.com/grafana/grafana/pkg/services/ngalert/state/historian
cpu: AMD Ryzen 7 PRO 5850U with Radeon Graphics
               │ pointer.txt │
               │   sec/op    │
PointerRule-16   400.8µ ± 5%

               │ pointer.txt  │
               │     B/op     │
PointerRule-16   171.3Ki ± 0%

               │ pointer.txt │
               │  allocs/op  │
PointerRule-16   3.001k ± 0%
```

```
└──>benchstat copy.txt
goos: linux
goarch: amd64
pkg: github.com/grafana/grafana/pkg/services/ngalert/state/historian
cpu: AMD Ryzen 7 PRO 5850U with Radeon Graphics
            │  copy.txt   │
            │   sec/op    │
CopyRule-16   401.6µ ± 7%

            │   copy.txt   │
            │     B/op     │
CopyRule-16   171.3Ki ± 0%

            │  copy.txt   │
            │  allocs/op  │
CopyRule-16   3.001k ± 0%
```

No detectable difference in allocations, especially with high dimensionality rules, and 1 microsecond difference in CPU time over 20 iterations of the benchmark.

The benchmark test, and results, can be seen here:
https://github.com/grafana/grafana/compare/main...alexweav/demo/benchmark-rule-historian-copy

**Which issue(s) does this PR fix?**:

n/a

**Special notes for your reviewer**:

