### PR TITLE
Explore: Changed references to DataQuery and DataSourceRef

### DIFF
--- a/public/app/features/explore/AddToDashboard/addToDashboard.test.ts
+++ b/public/app/features/explore/AddToDashboard/addToDashboard.test.ts
@@ -1,5 +1,5 @@
-import { DataQuery, MutableDataFrame } from '@grafana/data';
-import { defaultDashboard } from '@grafana/schema';
+import { MutableDataFrame } from '@grafana/data';
+import { DataQuery, defaultDashboard } from '@grafana/schema';
 import { backendSrv } from 'app/core/services/backend_srv';
 import * as api from 'app/features/dashboard/state/initDashboard';
 import { ExplorePanelData } from 'app/types';

--- a/public/app/features/explore/AddToDashboard/addToDashboard.ts
+++ b/public/app/features/explore/AddToDashboard/addToDashboard.ts
@@ -1,4 +1,5 @@
-import { DataFrame, DataQuery, DataSourceRef } from '@grafana/data';
+import { DataFrame } from '@grafana/data';
+import { DataQuery, DataSourceRef } from '@grafana/schema';
 import { backendSrv } from 'app/core/services/backend_srv';
 import {
   getNewDashboardModelData,

--- a/public/app/features/explore/AddToDashboard/index.test.tsx
+++ b/public/app/features/explore/AddToDashboard/index.test.tsx
@@ -3,9 +3,8 @@ import userEvent from '@testing-library/user-event';
 import React, { ReactNode } from 'react';
 import { Provider } from 'react-redux';
 
-import { DataQuery } from '@grafana/data';
 import { locationService, setEchoSrv } from '@grafana/runtime';
-import { defaultDashboard } from '@grafana/schema';
+import { DataQuery, defaultDashboard } from '@grafana/schema';
 import { backendSrv } from 'app/core/services/backend_srv';
 import { contextSrv } from 'app/core/services/context_srv';
 import { Echo } from 'app/core/services/echo/Echo';

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -8,7 +8,6 @@ import { Unsubscribable } from 'rxjs';
 
 import {
   AbsoluteTimeRange,
-  DataQuery,
   GrafanaTheme2,
   LoadingState,
   QueryFixAction,
@@ -19,6 +18,7 @@ import {
 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { config, getDataSourceSrv, reportInteraction } from '@grafana/runtime';
+import { DataQuery } from '@grafana/schema';
 import {
   CustomScrollbar,
   ErrorBoundaryAlert,

--- a/public/app/features/explore/Logs.tsx
+++ b/public/app/features/explore/Logs.tsx
@@ -16,7 +16,6 @@ import {
   LogsSortOrder,
   LinkModel,
   Field,
-  DataQuery,
   DataFrame,
   GrafanaTheme2,
   LoadingState,
@@ -28,6 +27,7 @@ import {
   EventBus,
 } from '@grafana/data';
 import { reportInteraction } from '@grafana/runtime';
+import { DataQuery } from '@grafana/schema';
 import {
   RadioButtonGroup,
   Button,

--- a/public/app/features/explore/LogsNavigation.tsx
+++ b/public/app/features/explore/LogsNavigation.tsx
@@ -2,8 +2,9 @@ import { css } from '@emotion/css';
 import { isEqual } from 'lodash';
 import React, { memo, useEffect, useRef, useState } from 'react';
 
-import { AbsoluteTimeRange, DataQuery, GrafanaTheme2, LogsSortOrder, TimeZone } from '@grafana/data';
+import { AbsoluteTimeRange, GrafanaTheme2, LogsSortOrder, TimeZone } from '@grafana/data';
 import { reportInteraction } from '@grafana/runtime';
+import { DataQuery } from '@grafana/schema';
 import { Button, Icon, Spinner, useTheme2 } from '@grafana/ui';
 import { TOP_BAR_LEVEL_HEIGHT } from 'app/core/components/AppChrome/types';
 

--- a/public/app/features/explore/QueryRows.test.tsx
+++ b/public/app/features/explore/QueryRows.test.tsx
@@ -2,8 +2,8 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 import { Provider } from 'react-redux';
 
-import { DataQuery } from '@grafana/data';
 import { setDataSourceSrv } from '@grafana/runtime';
+import { DataQuery } from '@grafana/schema';
 import { configureStore } from 'app/store/configureStore';
 import { ExploreId, ExploreState } from 'app/types';
 

--- a/public/app/features/explore/QueryRows.tsx
+++ b/public/app/features/explore/QueryRows.tsx
@@ -1,8 +1,9 @@
 import { createSelector } from '@reduxjs/toolkit';
 import React, { useCallback, useMemo } from 'react';
 
-import { CoreApp, DataQuery, DataSourceInstanceSettings } from '@grafana/data';
+import { CoreApp, DataSourceInstanceSettings } from '@grafana/data';
 import { getDataSourceSrv, reportInteraction } from '@grafana/runtime';
+import { DataQuery } from '@grafana/schema';
 import { getNextRefIdChar } from 'app/core/utils/query';
 import { useDispatch, useSelector } from 'app/types';
 import { ExploreId } from 'app/types/explore';

--- a/public/app/features/explore/RichHistory/RichHistoryCard.test.tsx
+++ b/public/app/features/explore/RichHistory/RichHistoryCard.test.tsx
@@ -1,7 +1,8 @@
 import { render, screen, fireEvent, getByText } from '@testing-library/react';
 import React from 'react';
 
-import { DataSourceApi, DataQuery } from '@grafana/data';
+import { DataSourceApi } from '@grafana/data';
+import { DataQuery } from '@grafana/schema';
 import appEvents from 'app/core/app_events';
 import { mockDataSource } from 'app/features/alerting/unified/mocks';
 import { DataSourceType } from 'app/features/alerting/unified/utils/datasource';

--- a/public/app/features/explore/RichHistory/RichHistoryCard.tsx
+++ b/public/app/features/explore/RichHistory/RichHistoryCard.tsx
@@ -2,8 +2,9 @@ import { css, cx } from '@emotion/css';
 import React, { useState, useEffect } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 
-import { DataSourceApi, DataQuery, GrafanaTheme2 } from '@grafana/data';
+import { DataSourceApi, GrafanaTheme2 } from '@grafana/data';
 import { config, getDataSourceSrv, reportInteraction } from '@grafana/runtime';
+import { DataQuery } from '@grafana/schema';
 import { TextArea, Button, IconButton, useStyles2 } from '@grafana/ui';
 import { notifyApp } from 'app/core/actions';
 import appEvents from 'app/core/app_events';

--- a/public/app/features/explore/TraceView/TraceView.tsx
+++ b/public/app/features/explore/TraceView/TraceView.tsx
@@ -5,7 +5,6 @@ import React, { RefObject, useCallback, useMemo, useState } from 'react';
 import {
   DataFrame,
   DataLink,
-  DataQuery,
   DataSourceApi,
   DataSourceJsonData,
   Field,
@@ -16,6 +15,7 @@ import {
   SplitOpen,
 } from '@grafana/data';
 import { getTemplateSrv } from '@grafana/runtime';
+import { DataQuery } from '@grafana/schema';
 import { useStyles2 } from '@grafana/ui';
 import {
   SpanBarOptionsData,

--- a/public/app/features/explore/TraceView/createSpanLink.tsx
+++ b/public/app/features/explore/TraceView/createSpanLink.tsx
@@ -4,7 +4,6 @@ import React from 'react';
 import {
   DataFrame,
   DataLink,
-  DataQuery,
   DataSourceInstanceSettings,
   DataSourceJsonData,
   dateTime,
@@ -17,6 +16,7 @@ import {
   TimeRange,
 } from '@grafana/data';
 import { getTemplateSrv } from '@grafana/runtime';
+import { DataQuery } from '@grafana/schema';
 import { Icon } from '@grafana/ui';
 import { SpanLinkFunc, TraceSpan } from '@jaegertracing/jaeger-ui-components';
 import { TraceToLogsOptions } from 'app/core/components/TraceToLogs/TraceToLogsSettings';

--- a/public/app/features/explore/spec/helper/setup.tsx
+++ b/public/app/features/explore/spec/helper/setup.tsx
@@ -6,15 +6,9 @@ import { Provider } from 'react-redux';
 import { Route, Router } from 'react-router-dom';
 import { getGrafanaContextMock } from 'test/mocks/getGrafanaContextMock';
 
-import {
-  DataSourceApi,
-  DataSourceInstanceSettings,
-  DataSourceRef,
-  QueryEditorProps,
-  ScopedVars,
-  UrlQueryValue,
-} from '@grafana/data';
+import { DataSourceApi, DataSourceInstanceSettings, QueryEditorProps, ScopedVars, UrlQueryValue } from '@grafana/data';
 import { locationSearchToObject, locationService, setDataSourceSrv, setEchoSrv, config } from '@grafana/runtime';
+import { DataSourceRef } from '@grafana/schema';
 import { GrafanaContext } from 'app/core/context/GrafanaContext';
 import { GrafanaRoute } from 'app/core/navigation/GrafanaRoute';
 import { Echo } from 'app/core/services/echo/Echo';

--- a/public/app/features/explore/state/datasource.test.ts
+++ b/public/app/features/explore/state/datasource.test.ts
@@ -1,4 +1,5 @@
-import { DataQuery, DataSourceApi } from '@grafana/data';
+import { DataSourceApi } from '@grafana/data';
+import { DataQuery } from '@grafana/schema';
 import { ExploreId, ExploreItemState } from 'app/types';
 
 import { updateDatasourceInstanceAction, datasourceReducer } from './datasource';

--- a/public/app/features/explore/state/explorePane.ts
+++ b/public/app/features/explore/state/explorePane.ts
@@ -4,16 +4,15 @@ import { AnyAction } from 'redux';
 
 import {
   EventBusExtended,
-  DataQuery,
   ExploreUrlState,
   TimeRange,
   HistoryItem,
   DataSourceApi,
   ExplorePanelsState,
   PreferredVisualisationType,
-  DataSourceRef,
 } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
+import { DataQuery, DataSourceRef } from '@grafana/schema';
 import {
   DEFAULT_RANGE,
   getQueryKeys,

--- a/public/app/features/explore/state/history.ts
+++ b/public/app/features/explore/state/history.ts
@@ -1,7 +1,8 @@
 import { AnyAction, createAction } from '@reduxjs/toolkit';
 
-import { DataQuery, HistoryItem } from '@grafana/data';
+import { HistoryItem } from '@grafana/data';
 import { config, logError } from '@grafana/runtime';
+import { DataQuery } from '@grafana/schema';
 import { RICH_HISTORY_SETTING_KEYS } from 'app/core/history/richHistoryLocalStorageUtils';
 import store from 'app/core/store';
 import {

--- a/public/app/features/explore/state/main.ts
+++ b/public/app/features/explore/state/main.ts
@@ -1,8 +1,9 @@
 import { createAction } from '@reduxjs/toolkit';
 import { AnyAction } from 'redux';
 
-import { DataQuery, ExploreUrlState, serializeStateToUrlParam, SplitOpenOptions, UrlQueryMap } from '@grafana/data';
+import { ExploreUrlState, serializeStateToUrlParam, SplitOpenOptions, UrlQueryMap } from '@grafana/data';
 import { DataSourceSrv, locationService } from '@grafana/runtime';
+import { DataQuery } from '@grafana/schema';
 import { GetExploreUrlArguments, stopQueryState } from 'app/core/utils/explore';
 import { PanelModel } from 'app/features/dashboard/state';
 import { ExploreId, ExploreItemState, ExploreState } from 'app/types/explore';

--- a/public/app/features/explore/state/query.test.ts
+++ b/public/app/features/explore/state/query.test.ts
@@ -5,7 +5,6 @@ import { assertIsDefined } from 'test/helpers/asserts';
 
 import {
   ArrayVector,
-  DataQuery,
   DataQueryResponse,
   DataSourceApi,
   DataSourceJsonData,
@@ -15,6 +14,7 @@ import {
   RawTimeRange,
   SupplementaryQueryType,
 } from '@grafana/data';
+import { DataQuery } from '@grafana/schema';
 import { ExploreId, ExploreItemState, StoreState, ThunkDispatch } from 'app/types';
 
 import { reducerTester } from '../../../../test/core/redux/reducerTester';

--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -6,7 +6,6 @@ import { mergeMap, throttleTime } from 'rxjs/operators';
 
 import {
   AbsoluteTimeRange,
-  DataQuery,
   DataQueryErrorType,
   DataQueryResponse,
   DataSourceApi,
@@ -22,6 +21,7 @@ import {
   hasLogsVolumeSupport,
 } from '@grafana/data';
 import { config, getDataSourceSrv, reportInteraction } from '@grafana/runtime';
+import { DataQuery } from '@grafana/schema';
 import {
   buildQueryTransaction,
   ensureQueries,

--- a/public/app/features/explore/state/utils.ts
+++ b/public/app/features/explore/state/utils.ts
@@ -3,7 +3,6 @@ import { isEmpty, isObject, mapValues, omitBy } from 'lodash';
 import {
   AbsoluteTimeRange,
   DataSourceApi,
-  DataSourceRef,
   EventBusExtended,
   ExploreUrlState,
   getDefaultTimeRange,
@@ -11,6 +10,7 @@ import {
   LoadingState,
   PanelData,
 } from '@grafana/data';
+import { DataSourceRef } from '@grafana/schema';
 import { ExplorePanelData } from 'app/types';
 import { ExploreItemState } from 'app/types/explore';
 

--- a/public/app/features/explore/utils/decorators.ts
+++ b/public/app/features/explore/utils/decorators.ts
@@ -9,9 +9,9 @@ import {
   getDisplayProcessor,
   PanelData,
   standardTransformers,
-  DataQuery,
 } from '@grafana/data';
 import { config } from '@grafana/runtime';
+import { DataQuery } from '@grafana/schema';
 
 import { dataFrameToLogsModel } from '../../../core/logsModel';
 import { refreshIntervalToSortOrder } from '../../../core/utils/explore';


### PR DESCRIPTION
**What is this feature?**

This PR changes the references to DataQuery and DataSourceRef in the `public/app/features/explore` directory from `@grafana/data` to `@grafana/schema`.

**Why do we need this feature?**

As of #61192, the exported types from `packages/grafana-data/src/types/query.ts` were deprecated in favor of using types from grafana/schema ([src](https://github.com/grafana/grafana/pull/61192/files#diff-2c9e457cb87628517f9e0606e5d774027ff002171070b0d561de1a178bf26e15)). So we are changing the references.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/61946

