### PR TITLE
Alerting: Create benchmarking test for state.ProcessEvalResults

### DIFF
--- a/pkg/services/ngalert/state/manager_bench_test.go
+++ b/pkg/services/ngalert/state/manager_bench_test.go
@@ -1,0 +1,121 @@
+package state_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"runtime/trace"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana/pkg/services/annotations"
+	"github.com/grafana/grafana/pkg/services/ngalert/eval"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/services/ngalert/state"
+	"github.com/grafana/grafana/pkg/services/ngalert/state/historian"
+	"github.com/stretchr/testify/mock"
+)
+
+func BenchmarkProcessEvalResults(b *testing.B) {
+	as := annotations.FakeAnnotationsRepo{}
+	as.On("SaveMany", mock.Anything, mock.Anything).Return(nil)
+	hist := historian.NewAnnotationBackend(&as, nil, nil)
+	cfg := state.ManagerCfg{
+		Historian: hist,
+	}
+	sut := state.NewManager(cfg)
+	now := time.Now().UTC()
+	rule := makeBenchRule()
+	results := makeBenchResults(10)
+	labels := map[string]string{}
+
+	tfile, err := os.Create("rcopy.out")
+	if err != nil {
+		panic(err)
+	}
+	defer tfile.Close()
+
+	err = trace.Start(tfile)
+	if err != nil {
+		panic(err)
+	}
+
+	var ans []state.StateTransition
+	for i := 0; i < b.N; i++ {
+		ans = sut.ProcessEvalResults(context.Background(), now, &rule, results, labels)
+	}
+
+	trace.Stop()
+
+	b.StopTimer()
+
+	_ = fmt.Sprintf("%v", len(ans))
+}
+
+func makeBenchRule() models.AlertRule {
+	dashUID := "my-dash"
+	panelID := int64(14)
+	return models.AlertRule{
+		ID:              5,
+		OrgID:           1,
+		Title:           "some rule",
+		Condition:       "A",
+		Data:            []models.AlertQuery{},
+		Updated:         time.Now().UTC(),
+		IntervalSeconds: 60,
+		Version:         2,
+		UID:             "abcd-efg",
+		NamespaceUID:    "my-folder",
+		DashboardUID:    &dashUID,
+		PanelID:         &panelID,
+		RuleGroup:       "my-group",
+		RuleGroupIndex:  2,
+		NoDataState:     models.NoData,
+		ExecErrState:    models.ErrorErrState,
+		For:             5 * time.Minute,
+		Annotations: map[string]string{
+			"text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+			"url":  "https://grafana.com",
+		},
+		Labels: map[string]string{
+			"alertname": "some rule",
+			"a":         "b",
+			"cluster":   "prod-eu-west-123",
+			"namespace": "coolthings",
+		},
+	}
+}
+
+func makeBenchResults(count int) eval.Results {
+	labels := map[string]string{
+		"alertname": "some rule",
+		"a":         "b",
+		"cluster":   "prod-eu-west-123",
+		"namespace": "coolthings",
+	}
+	one := 1.0
+	results := make([]eval.Result, 0, count)
+	for i := 0; i < count; i++ {
+		results = append(results, eval.Result{
+			Instance:           labels,
+			State:              eval.Alerting,
+			EvaluatedAt:        time.Now().UTC(),
+			EvaluationDuration: 5 * time.Second,
+			Values: map[string]eval.NumberValueCapture{
+				"A": eval.NumberValueCapture{
+					Var:   "A",
+					Value: &one,
+				},
+				"B": eval.NumberValueCapture{
+					Var:   "B",
+					Value: &one,
+				},
+				"C": eval.NumberValueCapture{
+					Var:   "C",
+					Value: &one,
+				},
+			},
+		})
+	}
+	return results
+}

--- a/pkg/services/ngalert/state/manager_bench_test.go
+++ b/pkg/services/ngalert/state/manager_bench_test.go
@@ -3,8 +3,6 @@ package state_test
 import (
 	"context"
 	"fmt"
-	"os"
-	"runtime/trace"
 	"testing"
 	"time"
 
@@ -26,26 +24,13 @@ func BenchmarkProcessEvalResults(b *testing.B) {
 	sut := state.NewManager(cfg)
 	now := time.Now().UTC()
 	rule := makeBenchRule()
-	results := makeBenchResults(10)
+	results := makeBenchResults(100)
 	labels := map[string]string{}
-
-	tfile, err := os.Create("rcopy.out")
-	if err != nil {
-		panic(err)
-	}
-	defer tfile.Close()
-
-	err = trace.Start(tfile)
-	if err != nil {
-		panic(err)
-	}
 
 	var ans []state.StateTransition
 	for i := 0; i < b.N; i++ {
 		ans = sut.ProcessEvalResults(context.Background(), now, &rule, results, labels)
 	}
-
-	trace.Stop()
 
 	b.StopTimer()
 


### PR DESCRIPTION
**What is this feature?**

This pull request adds a benchmark for `ProcessEvalResults`. It uses one rule, and a 100-dimensional evaluation attached to that rule. It stubs out most of the external writes like the instance table, annotations, etc. and focuses on the logic of the manager itself.

**Why do we need this feature?**

This is a nice tool to have on hand for a critical piece of our infrastructure.

You can use it like:
```
go test ./pkg/services/ngalert/state -run='^$' -bench=BenchmarkProcessEvalResults -benchmem -run=^$ -count=20
```

It's nice to combine this with [benchstat](https://pkg.go.dev/golang.org/x/perf/cmd/benchstat), so you can do:
```
go test ./pkg/services/ngalert/state -run='^$' -bench=BenchmarkProcessEvalResults -benchmem -run=^$ -count=20 > some-intermediary-file.txt
```
then
```
benchstat some-intermediary-file.txt
```
to get nice reports on time and memory usage.

**Which issue(s) does this PR fix?**:

n/a

**Special notes for your reviewer**:

