### PR TITLE
PublicDashboards: Footer alignment fix for Firefox browser

### DIFF
--- a/public/app/features/dashboard/components/PublicDashboardFooter/PublicDashboardsFooter.tsx
+++ b/public/app/features/dashboard/components/PublicDashboardFooter/PublicDashboardsFooter.tsx
@@ -17,11 +17,9 @@ export const PublicDashboardFooter = function () {
 
   return conf.hide ? null : (
     <div className={styles.footer}>
-      <span className={styles.logoText}>
-        <a href={conf.link} target="_blank" rel="noreferrer noopener">
-          {conf.text} <img className={styles.logoImg} alt="" src={conf.logo}></img>
-        </a>
-      </span>
+      <a className={styles.link} href={conf.link} target="_blank" rel="noreferrer noopener">
+        {conf.text} <img className={styles.logoImg} alt="" src={conf.logo}></img>
+      </a>
     </div>
   );
 };
@@ -41,10 +39,13 @@ const getStyles = (theme: GrafanaTheme2) => ({
     display: flex;
     justify-content: end;
     height: 30px;
-    padding: ${theme.spacing(0, 1, 0, 1)};
+    padding: ${theme.spacing(0, 2, 0, 1)};
   `,
-  logoText: css`
-    margin-right: ${theme.spacing(1)};
+  link: css`
+    display: flex;
+    gap: 4px;
+    justify-content: end;
+    align-items: center;
   `,
   logoImg: css`
     height: 100%;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Firefox browser is not rendering the footer well.

**Why do we need this feature?**

The footer is not aligned in the bottom right of the screen.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes [#571]( https://github.com/grafana/grafana-enterprise/issues/4415)

**Special notes for your reviewer**:

**Before**
<img width="1509" alt="image" src="https://user-images.githubusercontent.com/11707172/214574398-0f98ed63-675a-4c7d-8cb9-ff7a1710d236.png">

**Now**
<img width="1511" alt="image" src="https://user-images.githubusercontent.com/11707172/214573448-4f3383a2-5ee1-4807-8d21-48526259e15b.png">

