### PR TITLE
Snapshots: Add new snapshot configuration to documentation

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -675,6 +675,10 @@ List of allowed headers to be set by the user. Suggested to use for if authentic
 
 ## [snapshots]
 
+### enabled
+
+Set to `false` to disable snapshot feature (default `true`).
+
 ### external_enabled
 
 Set to `false` to disable external snapshot publish endpoint (default `true`).

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -677,7 +677,7 @@ List of allowed headers to be set by the user. Suggested to use for if authentic
 
 ### enabled
 
-Set to `false` to disable snapshot feature (default `true`).
+Set to `false` to disable the snapshot feature (default `true`).
 
 ### external_enabled
 


### PR DESCRIPTION
**What is this feature?**

Updates documentation for snapshots

Related to https://github.com/grafana/grafana/pull/61587

**Special notes for your reviewer**:
I haven't found any other place to mention this new feature (we are now able to remove the snapshot functionality by configuration). There is a Share section in the Dashboard configuration but it didn't see appropriate to add this configuration there
