### PR TITLE
chore: update folder model (json tags) to match previous model

### DIFF
--- a/pkg/api/folder.go
+++ b/pkg/api/folder.go
@@ -176,12 +176,9 @@ func (hs *HTTPServer) MoveFolder(c *models.ReqContext) response.Response {
 		var theFolder *folder.Folder
 		var err error
 		if cmd.NewParentUID != "" {
-			moveCommand := folder.MoveFolderCommand{
-				UID:          web.Params(c.Req)[":uid"],
-				NewParentUID: cmd.NewParentUID,
-				OrgID:        c.OrgID,
-			}
-			theFolder, err = hs.folderService.Move(c.Req.Context(), &moveCommand)
+			cmd.OrgID = c.OrgID
+			cmd.UID = web.Params(c.Req)[":uid"]
+			theFolder, err = hs.folderService.Move(c.Req.Context(), &cmd)
 			if err != nil {
 				return response.Error(http.StatusInternalServerError, "update folder uid failed", err)
 			}

--- a/pkg/services/folder/model.go
+++ b/pkg/services/folder/model.go
@@ -95,8 +95,8 @@ type UpdateFolderCommand struct {
 // MoveFolderCommand captures the information required by the folder service
 // to move a folder.
 type MoveFolderCommand struct {
-	UID          string `json:"uid"`
-	NewParentUID string `json:"newParentUid"`
+	UID          string `json:"-"`
+	NewParentUID string `json:"parentUid"`
 	OrgID        int64  `json:"-"`
 
 	SignedInUser *user.SignedInUser `json:"-"`


### PR DESCRIPTION
A much smaller version of #62031 that updates the json tags on the `Folder` model, with a small tweak to the API call so weren't not redundantly building a new `MoveFolderCommand`