### PR TITLE
Alerting: Alertmanager cluster metrics changed from `alertmanager_cluster_*` to `grafana_alerting_alertmanager_cluster_*`

### DIFF
--- a/pkg/services/ngalert/notifier/multiorg_alertmanager.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager.go
@@ -76,9 +76,10 @@ func NewMultiOrgAlertmanager(cfg *setting.Cfg, configStore AlertingStore, orgSto
 	clusterLogger := l.New("component", "cluster")
 	moa.peer = &NilPeer{}
 	if len(cfg.UnifiedAlerting.HAPeers) > 0 {
+		wr := prometheus.WrapRegistererWithPrefix(fmt.Sprintf("%s_%s_", metrics.Namespace, metrics.Subsystem), m.Registerer)
 		peer, err := cluster.Create(
 			clusterLogger,
-			m.Registerer,
+			wr,
 			cfg.UnifiedAlerting.HAListenAddr,
 			cfg.UnifiedAlerting.HAAdvertiseAddr,
 			cfg.UnifiedAlerting.HAPeers, // peers


### PR DESCRIPTION
Changes metrics such as `grafana_alerting_alertmanager_cluster_alive_messages_total`

from `alertmanager_cluster_alive_messages_total` to `grafana_alerting_alertmanager_cluster_alive_messages_total`


Here's a list of the metrics changed:

```
 HELP grafana_alerting_alertmanager_cluster_alive_messages_total Total number of received alive messages.
# TYPE grafana_alerting_alertmanager_cluster_alive_messages_total counter
grafana_alerting_alertmanager_cluster_alive_messages_total{peer="01GQMPW4ZM5G62ZXMP2J2N1D4B"} 79
# HELP grafana_alerting_alertmanager_cluster_failed_peers Number indicating the current number of failed peers in the cluster.
# TYPE grafana_alerting_alertmanager_cluster_failed_peers gauge
grafana_alerting_alertmanager_cluster_failed_peers 1
# HELP grafana_alerting_alertmanager_cluster_health_score Health score of the cluster. Lower values are better and zero means 'totally healthy'.
# TYPE grafana_alerting_alertmanager_cluster_health_score gauge
grafana_alerting_alertmanager_cluster_health_score 0
# HELP grafana_alerting_alertmanager_cluster_members Number indicating current number of members in cluster.
# TYPE grafana_alerting_alertmanager_cluster_members gauge
grafana_alerting_alertmanager_cluster_members 1
# HELP grafana_alerting_alertmanager_cluster_messages_pruned_total Total number of cluster messages pruned.
# TYPE grafana_alerting_alertmanager_cluster_messages_pruned_total counter
grafana_alerting_alertmanager_cluster_messages_pruned_total 0
# HELP grafana_alerting_alertmanager_cluster_messages_queued Number of cluster messages which are queued.
# TYPE grafana_alerting_alertmanager_cluster_messages_queued gauge
grafana_alerting_alertmanager_cluster_messages_queued 2
# HELP grafana_alerting_alertmanager_cluster_messages_received_size_total Total size of cluster messages received.
# TYPE grafana_alerting_alertmanager_cluster_messages_received_size_total counter
grafana_alerting_alertmanager_cluster_messages_received_size_total{msg_type="full_state"} 11878
grafana_alerting_alertmanager_cluster_messages_received_size_total{msg_type="update"} 0
# HELP grafana_alerting_alertmanager_cluster_messages_received_total Total number of cluster messages received.
# TYPE grafana_alerting_alertmanager_cluster_messages_received_total counter
grafana_alerting_alertmanager_cluster_messages_received_total{msg_type="full_state"} 76
grafana_alerting_alertmanager_cluster_messages_received_total{msg_type="update"} 0
# HELP grafana_alerting_alertmanager_cluster_messages_sent_size_total Total size of cluster messages sent.
# TYPE grafana_alerting_alertmanager_cluster_messages_sent_size_total counter
grafana_alerting_alertmanager_cluster_messages_sent_size_total{msg_type="full_state"} 11878
grafana_alerting_alertmanager_cluster_messages_sent_size_total{msg_type="update"} 0
# HELP grafana_alerting_alertmanager_cluster_messages_sent_total Total number of cluster messages sent.
# TYPE grafana_alerting_alertmanager_cluster_messages_sent_total counter
grafana_alerting_alertmanager_cluster_messages_sent_total{msg_type="full_state"} 78
grafana_alerting_alertmanager_cluster_messages_sent_total{msg_type="update"} 0
# HELP grafana_alerting_alertmanager_cluster_peer_info A metric with a constant '1' value labeled by peer name.
# TYPE grafana_alerting_alertmanager_cluster_peer_info gauge
grafana_alerting_alertmanager_cluster_peer_info{peer="01GQMPW4ZM5G62ZXMP2J2N1D4B"} 1
# HELP grafana_alerting_alertmanager_cluster_peers_joined_total A counter of the number of peers that have joined.
# TYPE grafana_alerting_alertmanager_cluster_peers_joined_total counter
grafana_alerting_alertmanager_cluster_peers_joined_total 1
# HELP grafana_alerting_alertmanager_cluster_peers_left_total A counter of the number of peers that have left.
# TYPE grafana_alerting_alertmanager_cluster_peers_left_total counter
grafana_alerting_alertmanager_cluster_peers_left_total 0
# HELP grafana_alerting_alertmanager_cluster_peers_update_total A counter of the number of peers that have updated metadata.
# TYPE grafana_alerting_alertmanager_cluster_peers_update_total counter
grafana_alerting_alertmanager_cluster_peers_update_total 0
# HELP grafana_alerting_alertmanager_cluster_reconnections_failed_total A counter of the number of failed cluster peer reconnection attempts.
# TYPE grafana_alerting_alertmanager_cluster_reconnections_failed_total counter
grafana_alerting_alertmanager_cluster_reconnections_failed_total 0
# HELP grafana_alerting_alertmanager_cluster_reconnections_total A counter of the number of cluster peer reconnections.
# TYPE grafana_alerting_alertmanager_cluster_reconnections_total counter
grafana_alerting_alertmanager_cluster_reconnections_total 23
# HELP grafana_alerting_alertmanager_cluster_refresh_join_failed_total A counter of the number of failed cluster peer joined attempts via refresh.
# TYPE grafana_alerting_alertmanager_cluster_refresh_join_failed_total counter
grafana_alerting_alertmanager_cluster_refresh_join_failed_total 0
# HELP grafana_alerting_alertmanager_cluster_refresh_join_total A counter of the number of cluster peer joined via refresh.
# TYPE grafana_alerting_alertmanager_cluster_refresh_join_total counter
grafana_alerting_alertmanager_cluster_refresh_join_total 15
# HELP grafana_alerting_alertmanager_peer_position Position the Alertmanager instance believes it's in. The position determines a peer's behavior in the cluster.
# TYPE grafana_alerting_alertmanager_peer_position gauge
grafana_alerting_alertmanager_peer_position 0
```