### PR TITLE
copy .github folder into golang build container since we rely on codeowners

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,7 +2,6 @@
 .dockerignore
 .git
 .gitignore
-.github
 .vscode
 bin
 data*

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,7 @@ COPY public/api-spec.json public/api-spec.json
 COPY pkg pkg
 COPY scripts scripts
 COPY conf conf
+COPY .github .github
 
 RUN make build-go
 


### PR DESCRIPTION
the change in #61978 means that we rely on `.github/CODEOWNERS` to be able to build the grafana binary, so we need to copy that into the docker build container