### PR TITLE
Navigation: Fix finding the active nav item for plugins

### DIFF
--- a/public/app/features/plugins/utils.test.ts
+++ b/public/app/features/plugins/utils.test.ts
@@ -69,6 +69,13 @@ describe('buildPluginSectionNav', () => {
     expect(result?.node.text).toBe('page2');
   });
 
+  it('Should only set the most specific match as active (not the parents)', () => {
+    config.featureToggles.topnav = true;
+    const result = buildPluginSectionNav(appsSection, null, '/a/plugin1/page2');
+    expect(result?.main.children![0].children![1].active).toBe(true);
+    expect(result?.main.children![0].active).not.toBe(true); // Parent should not be active
+  });
+
   it('Should set app section to active', () => {
     config.featureToggles.topnav = true;
     const result = buildPluginSectionNav(appsSection, null, '/a/plugin1');

--- a/public/app/features/plugins/utils.ts
+++ b/public/app/features/plugins/utils.ts
@@ -49,6 +49,8 @@ export function buildPluginSectionNav(
       return page;
     }
 
+    // Check if there is already an active page found with with a more specific url (possibly a child of the current page)
+    // (In this case we bail out early and don't mark the parent as active)
     if (activePage && (activePage.url?.length ?? 0) > (page.url?.length ?? 0)) {
       return page;
     }
@@ -58,15 +60,20 @@ export function buildPluginSectionNav(
     }
 
     activePage = { ...page, active: true };
+
     return activePage;
   }
 
   // Find and set active page
   copiedPluginNavSection.children = (copiedPluginNavSection?.children ?? []).map((child) => {
     if (child.children) {
+      // Doing this here to make sure that first we check if any of the children is active
+      // (In case yes, then the check for the parent will not mark it as active)
+      const children = child.children.map((pluginPage) => setPageToActive(pluginPage, currentUrl));
+
       return {
         ...setPageToActive(child, currentUrl),
-        children: child.children.map((pluginPage) => setPageToActive(pluginPage, currentUrl)),
+        children,
       };
     }
 


### PR DESCRIPTION
### What changed?

- [x] Make sure that we only mark the best match (most specific URL) as active.
- [x] Update tests

(As far as I can tell the implementation was depending on the `activeItem` being an object reference and like that updating a the `active` property to `false` on it would work - however as we are using the spread operator on line 62 and 75 I don't think the references are kept, so `activePage.active = false` will not work. In order to overcome this issue I just made sure that the children are checked first, so the parent will never be marked as active if there is an active child found.)

|  **Before**  |    **After**    |
|--------------|-----------------|
|  <img width="358" alt="Screenshot 2023-01-25 at 16 20 20" src="https://user-images.githubusercontent.com/9974811/214603161-18e1b438-2340-49bc-8dac-c1f077e07cda.png"> | <img width="358" alt="Screenshot 2023-01-25 at 16 20 28" src="https://user-images.githubusercontent.com/9974811/214603190-11806b5c-6334-409f-9f68-c54a09932031.png"> |