### PR TITLE
Navigation: only show the `img` for a section root if both `img` and `icon` are present

### DIFF
--- a/public/app/core/components/PageNew/SectionNavItem.test.tsx
+++ b/public/app/core/components/PageNew/SectionNavItem.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { NavModelItem } from '@grafana/data';
+
+import { SectionNavItem } from './SectionNavItem';
+
+describe('SectionNavItem', () => {
+  it('should only show the img for a section root if both img and icon are present', () => {
+    const item: NavModelItem = {
+      text: 'Test',
+      icon: 'k6',
+      img: 'img',
+      children: [
+        {
+          text: 'Child',
+        },
+      ],
+    };
+
+    render(<SectionNavItem item={item} isSectionRoot />);
+    expect(screen.getByTestId('section-image')).toBeInTheDocument();
+    expect(screen.queryByTestId('section-icon')).not.toBeInTheDocument();
+  });
+});

--- a/public/app/core/components/PageNew/SectionNavItem.tsx
+++ b/public/app/core/components/PageNew/SectionNavItem.tsx
@@ -28,6 +28,14 @@ export function SectionNavItem({ item, isSectionRoot = false }: Props) {
     [styles.noRootMargin]: noRootMargin,
   });
 
+  let icon: React.ReactNode | null = null;
+
+  if (item.img) {
+    icon = <img data-testid="section-image" className={styles.sectionImg} src={item.img} alt="" />;
+  } else if (item.icon) {
+    icon = <Icon data-testid="section-icon" name={item.icon} />;
+  }
+
   return (
     <>
       <a
@@ -37,8 +45,7 @@ export function SectionNavItem({ item, isSectionRoot = false }: Props) {
         role="tab"
         aria-selected={item.active}
       >
-        {isSectionRoot && item.icon && <Icon name={item.icon} />}
-        {isSectionRoot && item.img && <img className={styles.sectionImg} src={item.img} alt={`logo of ${item.text}`} />}
+        {isSectionRoot && icon}
         {getNavTitle(item.id) ?? item.text}
         {item.tabSuffix && <item.tabSuffix className={styles.suffix} />}
       </a>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- as part of https://github.com/grafana/grafana/pull/61160, we enabled overriding icons for any nav item
  - this ensured we could set svg icons for plugins that show their icons in the hamburger menu
- if both an `img` and an `icon` are present, currently `SectionNavItem` will display both of them
  - ![Screenshot 2023-01-25 at 15 31 06](https://user-images.githubusercontent.com/20999846/214605532-0139de9d-4916-4514-aac1-45caaf16d2fa.png)
  - this can happen for e.g. k6 where a plugin `img` is set, but we then also set an `icon` to display in the hamburger menu
- adjust the logic of `SectionNavItem` to only show one and favour the `img`
- adds a unit test to prevent regressions

**Why do we need this feature?**

- double icons are ugly

**Who is this feature for?**

- anyone using either k6 or connections plugin

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

