### PR TITLE
Alerting: Add Copy action to templates table

### DIFF
--- a/public/app/features/alerting/routes.tsx
+++ b/public/app/features/alerting/routes.tsx
@@ -204,6 +204,16 @@ const unifiedRoutes: RouteDescriptor[] = [
     ),
   },
   {
+    path: '/alerting/notifications/:type/:id/duplicate',
+    roles: evaluateAccess(
+      [AccessControlAction.AlertingNotificationsWrite, AccessControlAction.AlertingNotificationsExternalWrite],
+      ['Editor', 'Admin']
+    ),
+    component: SafeDynamicImport(
+      () => import(/* webpackChunkName: "NotificationsListPage" */ 'app/features/alerting/unified/Receivers')
+    ),
+  },
+  {
     path: '/alerting/notifications/:type',
     roles: evaluateAccess(
       [AccessControlAction.AlertingNotificationsWrite, AccessControlAction.AlertingNotificationsExternalWrite],

--- a/public/app/features/alerting/unified/CloneRuleEditor.test.tsx
+++ b/public/app/features/alerting/unified/CloneRuleEditor.test.tsx
@@ -10,11 +10,10 @@ import { selectors } from '@grafana/e2e-selectors/src';
 import { config, setBackendSrv, setDataSourceSrv } from '@grafana/runtime';
 import { backendSrv } from 'app/core/services/backend_srv';
 import 'whatwg-fetch';
-import { RuleWithLocation } from 'app/types/unified-alerting';
 
 import { RulerGrafanaRuleDTO } from '../../../types/unified-alerting-dto';
 
-import { CloneRuleEditor, generateCopiedRuleTitle } from './CloneRuleEditor';
+import { CloneRuleEditor } from './CloneRuleEditor';
 import { ExpressionEditorProps } from './components/rule-editor/ExpressionEditor';
 import { mockDataSource, MockDataSourceSrv, mockRulerAlertingRule, mockRulerGrafanaRule, mockStore } from './mocks';
 import { mockSearchApiResponse } from './mocks/grafanaApi';
@@ -198,87 +197,5 @@ describe('CloneRuleEditor', function () {
         expect(ui.inputs.annotationValue(0).get()).toHaveTextContent('This is a very important alert rule');
       });
     });
-  });
-});
-
-describe('generateCopiedRuleTitle', () => {
-  it('should generate copy name', () => {
-    const fileName = 'my file';
-    const expectedDuplicateName = 'my file (copy)';
-
-    const ruleWithLocation = {
-      rule: {
-        grafana_alert: {
-          title: fileName,
-        },
-      },
-      group: {
-        rules: [],
-      },
-    } as unknown as RuleWithLocation;
-
-    expect(generateCopiedRuleTitle(ruleWithLocation)).toEqual(expectedDuplicateName);
-  });
-
-  it('should generate copy name and number from original file', () => {
-    const fileName = 'my file';
-    const duplicatedName = 'my file (copy)';
-    const expectedDuplicateName = 'my file (copy 2)';
-
-    const ruleWithLocation = {
-      rule: {
-        grafana_alert: {
-          title: fileName,
-        },
-      },
-      group: {
-        rules: [{ grafana_alert: { title: fileName } }, { grafana_alert: { title: duplicatedName } }],
-      },
-    } as RuleWithLocation;
-
-    expect(generateCopiedRuleTitle(ruleWithLocation)).toEqual(expectedDuplicateName);
-  });
-
-  it('should generate copy name and number from duplicated file', () => {
-    const fileName = 'my file (copy)';
-    const duplicatedName = 'my file (copy 2)';
-    const expectedDuplicateName = 'my file (copy 3)';
-
-    const ruleWithLocation = {
-      rule: {
-        grafana_alert: {
-          title: fileName,
-        },
-      },
-      group: {
-        rules: [{ grafana_alert: { title: fileName } }, { grafana_alert: { title: duplicatedName } }],
-      },
-    } as RuleWithLocation;
-
-    expect(generateCopiedRuleTitle(ruleWithLocation)).toEqual(expectedDuplicateName);
-  });
-
-  it('should generate copy name and number from duplicated file in gap', () => {
-    const fileName = 'my file (copy)';
-    const duplicatedName = 'my file (copy 3)';
-    const expectedDuplicateName = 'my file (copy 2)';
-
-    const ruleWithLocation = {
-      rule: {
-        grafana_alert: {
-          title: fileName,
-        },
-      },
-      group: {
-        rules: [
-          {
-            grafana_alert: { title: fileName },
-          },
-          { grafana_alert: { title: duplicatedName } },
-        ],
-      },
-    } as RuleWithLocation;
-
-    expect(generateCopiedRuleTitle(ruleWithLocation)).toEqual(expectedDuplicateName);
   });
 });

--- a/public/app/features/alerting/unified/CloneRuleEditor.tsx
+++ b/public/app/features/alerting/unified/CloneRuleEditor.tsx
@@ -6,11 +6,12 @@ import { locationService } from '@grafana/runtime/src';
 import { Alert, LoadingPlaceholder } from '@grafana/ui/src';
 
 import { useDispatch } from '../../../types';
-import { RuleIdentifier, RuleWithLocation } from '../../../types/unified-alerting';
+import { RuleIdentifier } from '../../../types/unified-alerting';
 import { RulerRuleDTO } from '../../../types/unified-alerting-dto';
 
 import { AlertRuleForm } from './components/rule-editor/AlertRuleForm';
 import { fetchEditableRuleAction } from './state/actions';
+import { generateCopiedName } from './utils/duplicate';
 import { rulerRuleToFormValues } from './utils/rule-form';
 import { getRuleName, isAlertingRulerRule, isGrafanaRulerRule, isRecordingRulerRule } from './utils/rules';
 import { createUrl } from './utils/url';
@@ -30,7 +31,10 @@ export function CloneRuleEditor({ sourceRuleId }: { sourceRuleId: RuleIdentifier
 
   if (rule) {
     const ruleClone = cloneDeep(rule);
-    changeRuleName(ruleClone.rule, generateCopiedRuleTitle(ruleClone));
+    changeRuleName(
+      ruleClone.rule,
+      generateCopiedName(getRuleName(ruleClone.rule), ruleClone.group.rules.map(getRuleName))
+    );
     const formPrefill = rulerRuleToFormValues(ruleClone);
 
     // Provisioned alert rules have provisioned alert group which cannot be used in UI
@@ -56,21 +60,6 @@ export function CloneRuleEditor({ sourceRuleId }: { sourceRuleId: RuleIdentifier
       onRemove={() => locationService.replace(createUrl('/alerting/list'))}
     />
   );
-}
-
-export function generateCopiedRuleTitle(originRuleWithLocation: RuleWithLocation): string {
-  const originName = getRuleName(originRuleWithLocation.rule);
-  const existingRulesNames = originRuleWithLocation.group.rules.map(getRuleName);
-
-  const nonDuplicateName = originName.replace(/\(copy( [0-9]+)?\)$/, '').trim();
-
-  let newName = `${nonDuplicateName} (copy)`;
-
-  for (let i = 2; existingRulesNames.includes(newName); i++) {
-    newName = `${nonDuplicateName} (copy ${i})`;
-  }
-
-  return newName;
 }
 
 function changeRuleName(rule: RulerRuleDTO, newName: string) {

--- a/public/app/features/alerting/unified/CloneRuleEditor.tsx
+++ b/public/app/features/alerting/unified/CloneRuleEditor.tsx
@@ -55,7 +55,7 @@ export function CloneRuleEditor({ sourceRuleId }: { sourceRuleId: RuleIdentifier
 
   return (
     <Alert
-      title="Cannot duplicate. The rule does not exist"
+      title="Cannot copy the rule. The rule does not exist"
       buttonContent="Go back to alert list"
       onRemove={() => locationService.replace(createUrl('/alerting/list'))}
     />

--- a/public/app/features/alerting/unified/Receivers.tsx
+++ b/public/app/features/alerting/unified/Receivers.tsx
@@ -3,9 +3,9 @@ import pluralize from 'pluralize';
 import React, { useEffect } from 'react';
 import { Redirect, Route, RouteChildrenProps, Switch, useLocation, useParams } from 'react-router-dom';
 
-import { NavModelItem, GrafanaTheme2 } from '@grafana/data';
+import { GrafanaTheme2, NavModelItem } from '@grafana/data';
 import { Stack } from '@grafana/experimental';
-import { Alert, LoadingPlaceholder, withErrorBoundary, useStyles2, Icon } from '@grafana/ui';
+import { Alert, Icon, LoadingPlaceholder, useStyles2, withErrorBoundary } from '@grafana/ui';
 import { useDispatch } from 'app/types';
 
 import { ContactPointsState } from '../../../types';
@@ -16,6 +16,7 @@ import { AlertManagerPicker } from './components/AlertManagerPicker';
 import { AlertingPageWrapper } from './components/AlertingPageWrapper';
 import { GrafanaAlertmanagerDeliveryWarning } from './components/GrafanaAlertmanagerDeliveryWarning';
 import { NoAlertManagerWarning } from './components/NoAlertManagerWarning';
+import { DuplicateTemplateView } from './components/receivers/DuplicateTemplateView';
 import { EditReceiverView } from './components/receivers/EditReceiverView';
 import { EditTemplateView } from './components/receivers/EditTemplateView';
 import { GlobalConfigForm } from './components/receivers/GlobalConfigForm';
@@ -142,6 +143,17 @@ const Receivers = () => {
           </Route>
           <Route exact={true} path="/alerting/notifications/templates/new">
             <NewTemplateView config={config} alertManagerSourceName={alertManagerSourceName} />
+          </Route>
+          <Route exact={true} path="/alerting/notifications/templates/:name/duplicate">
+            {({ match }: RouteChildrenProps<{ name: string }>) =>
+              match?.params.name && (
+                <DuplicateTemplateView
+                  alertManagerSourceName={alertManagerSourceName}
+                  config={config}
+                  templateName={decodeURIComponent(match?.params.name)}
+                />
+              )
+            }
           </Route>
           <Route exact={true} path="/alerting/notifications/templates/:name/edit">
             {({ match }: RouteChildrenProps<{ name: string }>) =>

--- a/public/app/features/alerting/unified/RuleViewer.test.tsx
+++ b/public/app/features/alerting/unified/RuleViewer.test.tsx
@@ -61,7 +61,7 @@ const renderRuleViewer = () => {
 const ui = {
   actionButtons: {
     edit: byRole('link', { name: /edit/i }),
-    clone: byRole('link', { name: /clone/i }),
+    clone: byRole('link', { name: /copy/i }),
     delete: byRole('button', { name: /delete/i }),
     silence: byRole('link', { name: 'Silence' }),
   },

--- a/public/app/features/alerting/unified/components/receivers/DuplicateTemplateView.tsx
+++ b/public/app/features/alerting/unified/components/receivers/DuplicateTemplateView.tsx
@@ -3,6 +3,7 @@ import React, { FC } from 'react';
 import { Alert } from '@grafana/ui';
 import { AlertManagerCortexConfig } from 'app/plugins/datasource/alertmanager/types';
 
+import { generateCopiedName } from '../../utils/duplicate';
 import { updateAndSanitizeDefine } from '../../utils/templates';
 
 import { TemplateForm } from './TemplateForm';
@@ -11,19 +12,6 @@ interface Props {
   templateName: string;
   config: AlertManagerCortexConfig;
   alertManagerSourceName: string;
-}
-
-export function generateCopiedTemplateName(config: AlertManagerCortexConfig, originalTemplateName: string): string {
-  const existingTemplates = Object.keys(config.template_files);
-  const nonDuplicateName = originalTemplateName.replace(/\(copy( [0-9]+)?\)$/, '').trim();
-
-  let newName = `${nonDuplicateName} (copy)`;
-
-  for (let i = 2; existingTemplates.includes(newName); i++) {
-    newName = `${nonDuplicateName} (copy ${i})`;
-  }
-
-  return newName;
 }
 
 export const DuplicateTemplateView: FC<Props> = ({ config, templateName, alertManagerSourceName }) => {
@@ -37,7 +25,7 @@ export const DuplicateTemplateView: FC<Props> = ({ config, templateName, alertMa
     );
   }
 
-  const duplicatedName = generateCopiedTemplateName(config, templateName);
+  const duplicatedName = generateCopiedName(templateName, Object.keys(config.template_files));
 
   return (
     <TemplateForm

--- a/public/app/features/alerting/unified/components/receivers/DuplicateTemplateView.tsx
+++ b/public/app/features/alerting/unified/components/receivers/DuplicateTemplateView.tsx
@@ -4,7 +4,7 @@ import { Alert } from '@grafana/ui';
 import { AlertManagerCortexConfig } from 'app/plugins/datasource/alertmanager/types';
 
 import { generateCopiedName } from '../../utils/duplicate';
-import { updateAndSanitizeDefine } from '../../utils/templates';
+import { updateDefinesWithUniqueValue } from '../../utils/templates';
 
 import { TemplateForm } from './TemplateForm';
 
@@ -31,7 +31,7 @@ export const DuplicateTemplateView: FC<Props> = ({ config, templateName, alertMa
     <TemplateForm
       alertManagerSourceName={alertManagerSourceName}
       config={config}
-      existing={{ name: duplicatedName, content: updateAndSanitizeDefine(duplicatedName, template) }}
+      existing={{ name: duplicatedName, content: updateDefinesWithUniqueValue(template) }}
     />
   );
 };

--- a/public/app/features/alerting/unified/components/receivers/DuplicateTemplateView.tsx
+++ b/public/app/features/alerting/unified/components/receivers/DuplicateTemplateView.tsx
@@ -28,7 +28,6 @@ export function generateCopiedTemplateName(config: AlertManagerCortexConfig, ori
 
 export const DuplicateTemplateView: FC<Props> = ({ config, templateName, alertManagerSourceName }) => {
   const template = config.template_files?.[templateName];
-  const provenance = config.template_file_provenances?.[templateName];
 
   if (!template) {
     return (
@@ -45,7 +44,6 @@ export const DuplicateTemplateView: FC<Props> = ({ config, templateName, alertMa
       alertManagerSourceName={alertManagerSourceName}
       config={config}
       existing={{ name: duplicatedName, content: updateAndSanitizeDefine(duplicatedName, template) }}
-      provenance={provenance}
     />
   );
 };

--- a/public/app/features/alerting/unified/components/receivers/DuplicateTemplateView.tsx
+++ b/public/app/features/alerting/unified/components/receivers/DuplicateTemplateView.tsx
@@ -20,7 +20,7 @@ export const DuplicateTemplateView: FC<Props> = ({ config, templateName, alertMa
   if (!template) {
     return (
       <Alert severity="error" title="Template not found">
-        Sorry, this template does not seem to exit.
+        Sorry, this template does not seem to exists.
       </Alert>
     );
   }

--- a/public/app/features/alerting/unified/components/receivers/DuplicateTemplateView.tsx
+++ b/public/app/features/alerting/unified/components/receivers/DuplicateTemplateView.tsx
@@ -1,0 +1,51 @@
+import React, { FC } from 'react';
+
+import { Alert } from '@grafana/ui';
+import { AlertManagerCortexConfig } from 'app/plugins/datasource/alertmanager/types';
+
+import { updateAndSanitizeDefine } from '../../utils/templates';
+
+import { TemplateForm } from './TemplateForm';
+
+interface Props {
+  templateName: string;
+  config: AlertManagerCortexConfig;
+  alertManagerSourceName: string;
+}
+
+export function generateCopiedTemplateName(config: AlertManagerCortexConfig, originalTemplateName: string): string {
+  const existingTemplates = Object.keys(config.template_files);
+  const nonDuplicateName = originalTemplateName.replace(/\(copy( [0-9]+)?\)$/, '').trim();
+
+  let newName = `${nonDuplicateName} (copy)`;
+
+  for (let i = 2; existingTemplates.includes(newName); i++) {
+    newName = `${nonDuplicateName} (copy ${i})`;
+  }
+
+  return newName;
+}
+
+export const DuplicateTemplateView: FC<Props> = ({ config, templateName, alertManagerSourceName }) => {
+  const template = config.template_files?.[templateName];
+  const provenance = config.template_file_provenances?.[templateName];
+
+  if (!template) {
+    return (
+      <Alert severity="error" title="Template not found">
+        Sorry, this template does not seem to exit.
+      </Alert>
+    );
+  }
+
+  const duplicatedName = generateCopiedTemplateName(config, templateName);
+
+  return (
+    <TemplateForm
+      alertManagerSourceName={alertManagerSourceName}
+      config={config}
+      existing={{ name: duplicatedName, content: updateAndSanitizeDefine(duplicatedName, template) }}
+      provenance={provenance}
+    />
+  );
+};

--- a/public/app/features/alerting/unified/components/receivers/EditTemplateView.tsx
+++ b/public/app/features/alerting/unified/components/receivers/EditTemplateView.tsx
@@ -18,7 +18,7 @@ export const EditTemplateView: FC<Props> = ({ config, templateName, alertManager
   if (!template) {
     return (
       <Alert severity="error" title="Template not found">
-        Sorry, this template does not seem to exit.
+        Sorry, this template does not seem to exists.
       </Alert>
     );
   }

--- a/public/app/features/alerting/unified/components/receivers/EditTemplateView.tsx
+++ b/public/app/features/alerting/unified/components/receivers/EditTemplateView.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react';
 
-import { InfoBox } from '@grafana/ui';
+import { Alert } from '@grafana/ui';
 import { AlertManagerCortexConfig } from 'app/plugins/datasource/alertmanager/types';
 
 import { TemplateForm } from './TemplateForm';
@@ -17,9 +17,9 @@ export const EditTemplateView: FC<Props> = ({ config, templateName, alertManager
 
   if (!template) {
     return (
-      <InfoBox severity="error" title="Template not found">
+      <Alert severity="error" title="Template not found">
         Sorry, this template does not seem to exit.
-      </InfoBox>
+      </Alert>
     );
   }
   return (

--- a/public/app/features/alerting/unified/components/receivers/TemplatesTable.test.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplatesTable.test.tsx
@@ -61,7 +61,7 @@ describe('TemplatesTable', () => {
   it('Should render duplicate template button when having permissions', () => {
     renderWithProvider();
     const rows = screen.getAllByRole('row', { name: /template1/i });
-    expect(within(rows[0]).getByRole('cell', { name: /duplicate template/i })).toBeInTheDocument();
+    expect(within(rows[0]).getByRole('cell', { name: /Copy/i })).toBeInTheDocument();
   });
   it('Should not render duplicate template button when not having write permissions', () => {
     contextSrvMock.hasPermission.mockImplementation((action) => {
@@ -73,6 +73,6 @@ describe('TemplatesTable', () => {
     });
     renderWithProvider();
     const rows = screen.getAllByRole('row', { name: /template1/i });
-    expect(within(rows[0]).queryByRole('cell', { name: /duplicate template/i })).not.toBeInTheDocument();
+    expect(within(rows[0]).queryByRole('cell', { name: /Copy/i })).not.toBeInTheDocument();
   });
 });

--- a/public/app/features/alerting/unified/components/receivers/TemplatesTable.test.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplatesTable.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen, within } from '@testing-library/react';
+import React from 'react';
+import { Provider } from 'react-redux';
+import { Router } from 'react-router-dom';
+
+import { locationService } from '@grafana/runtime';
+import { contextSrv } from 'app/core/services/context_srv';
+import { AlertManagerCortexConfig } from 'app/plugins/datasource/alertmanager/types';
+import { configureStore } from 'app/store/configureStore';
+import { AccessControlAction } from 'app/types';
+
+import { TemplatesTable } from './TemplatesTable';
+
+const defaultConfig: AlertManagerCortexConfig = {
+  template_files: {
+    template1: `{{ define "define1" }}`,
+  },
+  alertmanager_config: {
+    templates: ['template1'],
+  },
+};
+jest.mock('app/types', () => ({
+  ...jest.requireActual('app/types'),
+  useDispatch: () => jest.fn(),
+}));
+
+jest.mock('app/core/services/context_srv');
+const contextSrvMock = jest.mocked(contextSrv);
+
+const renderWithProvider = () => {
+  const store = configureStore();
+
+  render(
+    <Provider store={store}>
+      <Router history={locationService.getHistory()}>
+        <TemplatesTable config={defaultConfig} alertManagerName={'potato'} />
+      </Router>
+    </Provider>
+  );
+};
+
+describe('TemplatesTable', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    contextSrvMock.hasAccess.mockImplementation(() => true);
+    contextSrvMock.hasPermission.mockImplementation((action) => {
+      const permissions = [
+        AccessControlAction.AlertingNotificationsRead,
+        AccessControlAction.AlertingNotificationsWrite,
+        AccessControlAction.AlertingNotificationsExternalRead,
+        AccessControlAction.AlertingNotificationsExternalWrite,
+      ];
+      return permissions.includes(action as AccessControlAction);
+    });
+  });
+  it('Should render templates table with the correct rows', () => {
+    renderWithProvider();
+    const rows = screen.getAllByRole('row', { name: /template1/i });
+    expect(within(rows[0]).getByRole('cell', { name: /template1/i })).toBeInTheDocument();
+  });
+  it('Should render duplicate template button when having permissions', () => {
+    renderWithProvider();
+    const rows = screen.getAllByRole('row', { name: /template1/i });
+    expect(within(rows[0]).getByRole('cell', { name: /duplicate template/i })).toBeInTheDocument();
+  });
+  it('Should not render duplicate template button when not having write permissions', () => {
+    contextSrvMock.hasPermission.mockImplementation((action) => {
+      const permissions = [
+        AccessControlAction.AlertingNotificationsRead,
+        AccessControlAction.AlertingNotificationsExternalRead,
+      ];
+      return permissions.includes(action as AccessControlAction);
+    });
+    renderWithProvider();
+    const rows = screen.getAllByRole('row', { name: /template1/i });
+    expect(within(rows[0]).queryByRole('cell', { name: /duplicate template/i })).not.toBeInTheDocument();
+  });
+});

--- a/public/app/features/alerting/unified/components/receivers/TemplatesTable.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplatesTable.tsx
@@ -119,7 +119,7 @@ export const TemplatesTable: FC<Props> = ({ config, alertManagerName }) => {
                           `/alerting/notifications/templates/${encodeURIComponent(name)}/duplicate`,
                           alertManagerName
                         )}
-                        tooltip="Duplicate template"
+                        tooltip="Copy template"
                         icon="copy"
                       />
                     )}

--- a/public/app/features/alerting/unified/components/receivers/TemplatesTable.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplatesTable.tsx
@@ -101,6 +101,18 @@ export const TemplatesTable: FC<Props> = ({ config, alertManagerName }) => {
                         icon="file-alt"
                       />
                     )}
+                    {!provenance && (
+                      <Authorize actions={[permissions.update]}>
+                        <ActionIcon
+                          to={makeAMLink(
+                            `/alerting/notifications/templates/${encodeURIComponent(name)}/edit`,
+                            alertManagerName
+                          )}
+                          tooltip="edit template"
+                          icon="pen"
+                        />
+                      </Authorize>
+                    )}
                     {contextSrv.hasPermission(permissions.create) && (
                       <ActionIcon
                         to={makeAMLink(
@@ -111,25 +123,14 @@ export const TemplatesTable: FC<Props> = ({ config, alertManagerName }) => {
                         icon="copy"
                       />
                     )}
+
                     {!provenance && (
-                      <Authorize actions={[permissions.update, permissions.delete]}>
-                        <Authorize actions={[permissions.update]}>
-                          <ActionIcon
-                            to={makeAMLink(
-                              `/alerting/notifications/templates/${encodeURIComponent(name)}/edit`,
-                              alertManagerName
-                            )}
-                            tooltip="edit template"
-                            icon="pen"
-                          />
-                        </Authorize>
-                        <Authorize actions={[permissions.delete]}>
-                          <ActionIcon
-                            onClick={() => setTemplateToDelete(name)}
-                            tooltip="delete template"
-                            icon="trash-alt"
-                          />
-                        </Authorize>
+                      <Authorize actions={[permissions.delete]}>
+                        <ActionIcon
+                          onClick={() => setTemplateToDelete(name)}
+                          tooltip="delete template"
+                          icon="trash-alt"
+                        />
                       </Authorize>
                     )}
                   </td>

--- a/public/app/features/alerting/unified/components/receivers/TemplatesTable.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplatesTable.tsx
@@ -101,6 +101,16 @@ export const TemplatesTable: FC<Props> = ({ config, alertManagerName }) => {
                         icon="file-alt"
                       />
                     )}
+                    {contextSrv.hasPermission(permissions.create) && (
+                      <ActionIcon
+                        to={makeAMLink(
+                          `/alerting/notifications/templates/${encodeURIComponent(name)}/duplicate`,
+                          alertManagerName
+                        )}
+                        tooltip="Duplicate template"
+                        icon="copy"
+                      />
+                    )}
                     {!provenance && (
                       <Authorize actions={[permissions.update, permissions.delete]}>
                         <Authorize actions={[permissions.update]}>

--- a/public/app/features/alerting/unified/components/rules/CloneRuleButton.tsx
+++ b/public/app/features/alerting/unified/components/rules/CloneRuleButton.tsx
@@ -28,7 +28,7 @@ export const CloneRuleButton = React.forwardRef<HTMLAnchorElement, CloneRuleButt
     return (
       <>
         <LinkButton
-          title="Clone"
+          title="Copy"
           className={className}
           size="sm"
           key="clone"
@@ -43,19 +43,19 @@ export const CloneRuleButton = React.forwardRef<HTMLAnchorElement, CloneRuleButt
 
         <ConfirmModal
           isOpen={!!provRuleCloneUrl}
-          title="Clone provisioned rule"
+          title="Copy provisioned alert rule"
           body={
             <div>
               <p>
                 The new rule will <span className={styles.bold}>NOT</span> be marked as a provisioned rule.
               </p>
               <p>
-                You will need to set a new alert group for the cloned rule because the original one has been provisioned
+                You will need to set a new alert group for the copied rule because the original one has been provisioned
                 and cannot be used for rules created in the UI.
               </p>
             </div>
           }
-          confirmText="Clone"
+          confirmText="Copy"
           onConfirm={() => provRuleCloneUrl && locationService.push(provRuleCloneUrl)}
           onDismiss={() => setProvRuleCloneUrl(undefined)}
         />

--- a/public/app/features/alerting/unified/components/rules/RuleActionsButtons.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleActionsButtons.tsx
@@ -129,7 +129,7 @@ export const RuleActionsButtons: FC<Props> = ({ rule, rulesSource }) => {
     }
 
     buttons.push(
-      <Tooltip placement="top" content="Clone">
+      <Tooltip placement="top" content="Copy">
         <CloneRuleButton ruleIdentifier={identifier} isProvisioned={isProvisioned} className={style.button} />
       </Tooltip>
     );

--- a/public/app/features/alerting/unified/components/rules/RuleDetailsActionButtons.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleDetailsActionButtons.tsx
@@ -219,7 +219,7 @@ export const RuleDetailsActionButtons: FC<Props> = ({ rule, rulesSource, isViewM
 
     if (hasCreateRulePermission && !isFederated) {
       rightButtons.push(
-        <CloneRuleButton key="clone" text="Clone" ruleIdentifier={identifier} isProvisioned={isProvisioned} />
+        <CloneRuleButton key="clone" text="Copy" ruleIdentifier={identifier} isProvisioned={isProvisioned} />
       );
     }
 

--- a/public/app/features/alerting/unified/utils/duplicate.test.ts
+++ b/public/app/features/alerting/unified/utils/duplicate.test.ts
@@ -1,0 +1,34 @@
+import { generateCopiedName } from './duplicate';
+
+describe('generateCopiedName', () => {
+  it('should generate copy name', () => {
+    const fileName = 'my file';
+    const expectedDuplicateName = 'my file (copy)';
+
+    expect(generateCopiedName(fileName, [])).toEqual(expectedDuplicateName);
+  });
+
+  it('should generate copy name and number from original file', () => {
+    const fileName = 'my file';
+    const duplicatedName = 'my file (copy)';
+    const expectedDuplicateName = 'my file (copy 2)';
+
+    expect(generateCopiedName(fileName, [fileName, duplicatedName])).toEqual(expectedDuplicateName);
+  });
+
+  it('should generate copy name and number from duplicated file', () => {
+    const fileName = 'my file (copy)';
+    const duplicatedName = 'my file (copy 2)';
+    const expectedDuplicateName = 'my file (copy 3)';
+
+    expect(generateCopiedName(fileName, [fileName, duplicatedName])).toEqual(expectedDuplicateName);
+  });
+
+  it('should generate copy name and number from duplicated file in gap', () => {
+    const fileName = 'my file (copy)';
+    const duplicatedName = 'my file (copy 3)';
+    const expectedDuplicateName = 'my file (copy 2)';
+
+    expect(generateCopiedName(fileName, [fileName, duplicatedName])).toEqual(expectedDuplicateName);
+  });
+});

--- a/public/app/features/alerting/unified/utils/duplicate.ts
+++ b/public/app/features/alerting/unified/utils/duplicate.ts
@@ -1,0 +1,11 @@
+export function generateCopiedName(originalName: string, exisitingNames: string[]) {
+  const nonDuplicateName = originalName.replace(/\(copy( [0-9]+)?\)$/, '').trim();
+
+  let newName = `${nonDuplicateName} (copy)`;
+
+  for (let i = 2; exisitingNames.includes(newName); i++) {
+    newName = `${nonDuplicateName} (copy ${i})`;
+  }
+
+  return newName;
+}

--- a/public/app/features/alerting/unified/utils/templates.test.ts
+++ b/public/app/features/alerting/unified/utils/templates.test.ts
@@ -1,27 +1,36 @@
-import { updateAndSanitizeDefine } from './templates';
+import { updateDefinesWithUniqueValue } from './templates';
 
-describe('updateAndSanitizeDefine method', () => {
-  it('Should update the define value with the new one, and remove ( and ), and replace white spaces with a dot', () => {
-    expect(updateAndSanitizeDefine('new value', 'dkjghskdjhgsdf')).toBe('dkjghskdjhgsdf');
-    expect(
-      updateAndSanitizeDefine(
-        'new value',
-        `{{ define "t" }}
-      {{.Alerts.Firing}}
-    {{ end }}`
-      )
-    ).toBe(`{{ define "new.value" }}
-      {{.Alerts.Firing}}
-    {{ end }}`);
-    expect(
-      updateAndSanitizeDefine(
-        '(new) ()value',
-        `{{ define "t" }}
-    {{.Alerts.Firing}}
-  {{ end }}`
-      )
-    ).toBe(`{{ define "new.value" }}
-    {{.Alerts.Firing}}
-  {{ end }}`);
+jest.mock('lodash', () => ({
+  ...jest.requireActual('lodash'),
+  now: jest.fn().mockImplementation(() => 99),
+}));
+describe('updateDefinesWithUniqueValue method', () => {
+  describe('only onw define', () => {
+    it('Should update the define values with a unique new one', () => {
+      expect(updateDefinesWithUniqueValue(`{{ define "t" }}\n{{.Alerts.Firing}}\n{{ end }}`)).toEqual(
+        `{{ define "t_NEW_99" }}\n{{.Alerts.Firing}}\n{{ end }}`
+      );
+    });
+  });
+  describe('more than one define in the template', () => {
+    it('Should update the define values with a unique new one ', () => {
+      expect(
+        updateDefinesWithUniqueValue(
+          `{{ define "t1" }}\n{{.Alerts.Firing}}\n{{ end }}\n{{ define "t2" }}\n{{.Alerts.Firing}}\n{{ end }}\n{{ define "t3" }}\n{{.Alerts.Firing}}\n{{ end }}\n`
+        )
+      ).toEqual(
+        `{{ define "t1_NEW_99" }}\n{{.Alerts.Firing}}\n{{ end }}\n{{ define "t2_NEW_99" }}\n{{.Alerts.Firing}}\n{{ end }}\n{{ define "t3_NEW_99" }}\n{{.Alerts.Firing}}\n{{ end }}\n`
+      );
+    });
+
+    it('Should update the define values with a unique new one, special chars included in the value', () => {
+      expect(
+        updateDefinesWithUniqueValue(
+          `{{ define "t1 /^*;$@" }}\n{{.Alerts.Firing}}\n{{ end }}\n{{ define "t2" }}\n{{.Alerts.Firing}}\n{{ end }}\n{{ define "t3" }}\n{{.Alerts.Firing}}\n{{ end }}\n`
+        )
+      ).toEqual(
+        `{{ define "t1 /^*;$@_NEW_99" }}\n{{.Alerts.Firing}}\n{{ end }}\n{{ define "t2_NEW_99" }}\n{{.Alerts.Firing}}\n{{ end }}\n{{ define "t3_NEW_99" }}\n{{.Alerts.Firing}}\n{{ end }}\n`
+      );
+    });
   });
 });

--- a/public/app/features/alerting/unified/utils/templates.test.ts
+++ b/public/app/features/alerting/unified/utils/templates.test.ts
@@ -1,0 +1,27 @@
+import { updateAndSanitizeDefine } from './templates';
+
+describe('updateAndSanitizeDefine method', () => {
+  it('Should update the define value with the new one, and remove ( and ), and replace white spaces with a dot', () => {
+    expect(updateAndSanitizeDefine('new value', 'dkjghskdjhgsdf')).toBe('dkjghskdjhgsdf');
+    expect(
+      updateAndSanitizeDefine(
+        'new value',
+        `{{ define "t" }}
+      {{.Alerts.Firing}}
+    {{ end }}`
+      )
+    ).toBe(`{{ define "new.value" }}
+      {{.Alerts.Firing}}
+    {{ end }}`);
+    expect(
+      updateAndSanitizeDefine(
+        '(new) ()value',
+        `{{ define "t" }}
+    {{.Alerts.Firing}}
+  {{ end }}`
+      )
+    ).toBe(`{{ define "new.value" }}
+    {{.Alerts.Firing}}
+  {{ end }}`);
+  });
+});

--- a/public/app/features/alerting/unified/utils/templates.ts
+++ b/public/app/features/alerting/unified/utils/templates.ts
@@ -12,3 +12,9 @@ export function ensureDefine(templateName: string, templateContent: string): str
   }
   return content;
 }
+export function updateAndSanitizeDefine(newDefine: string, templateContent: string): string {
+  return templateContent.replace(
+    /\{\{\s*define\s*\"\w*/,
+    `{{ define "${newDefine.replace(/\(/g, '').replace(/\)/g, '').replace(/\s/g, '.')}`
+  );
+}

--- a/public/app/features/alerting/unified/utils/templates.ts
+++ b/public/app/features/alerting/unified/utils/templates.ts
@@ -1,3 +1,5 @@
+import { now } from 'lodash';
+
 export function ensureDefine(templateName: string, templateContent: string): string {
   // notification template content must be wrapped in {{ define "name" }} tag,
   // but this is not obvious because user also has to provide name separately in the form.
@@ -12,9 +14,9 @@ export function ensureDefine(templateName: string, templateContent: string): str
   }
   return content;
 }
-export function updateAndSanitizeDefine(newDefine: string, templateContent: string): string {
-  return templateContent.replace(
-    /\{\{\s*define\s*\"\w*/,
-    `{{ define "${newDefine.replace(/\(/g, '').replace(/\)/g, '').replace(/\s/g, '.')}`
-  );
+export function updateDefinesWithUniqueValue(templateContent: string): string {
+  const getNewValue = (match_: string, originalDefineName: string) => {
+    return `{{ define "${originalDefineName}_NEW_${now()}" }}`;
+  };
+  return templateContent.replace(/\{\{\s*define\s*\"(?<defineName>.*)\"\s*\}\}/g, getNewValue);
 }


### PR DESCRIPTION
**What is this feature?**

This PR adds the `Copy` button in the templates list. When user clicks the button, new template is created with the same content with the original one.

The template name is defined based on the original name and the all the defines values contained in the template are replaced with a new unique value.

This PR also change the `Clone` term in the alert list to `Copy` to keep the UI consistent.

**Why do we need this feature?**

To support duplication of default, provisioned and user-created templates, as this is not possible at present. 

**Who is this feature for?**

All users.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/61763

**Special notes for your reviewer**:


https://user-images.githubusercontent.com/33540275/215754159-01408f90-6f05-4847-ab3c-641bc786eaba.mp4

<img width="1435" alt="Screenshot 2023-01-31 at 14 46 21" src="https://user-images.githubusercontent.com/33540275/215777420-fc8dca3a-8a2a-4981-bb10-ac82224fba58.png">



