### PR TITLE
Schema: Fix interfaces with blank spaces

### DIFF
--- a/public/app/plugins/gen.go
+++ b/public/app/plugins/gen.go
@@ -86,7 +86,7 @@ func main() {
 func adaptToPipeline(j codejen.OneToOne[corecodegen.SchemaForGen]) codejen.OneToOne[*pfs.PluginDecl] {
 	return codejen.AdaptOneToOne(j, func(pd *pfs.PluginDecl) corecodegen.SchemaForGen {
 		return corecodegen.SchemaForGen{
-			Name:    pd.PluginMeta.Name,
+			Name:    strings.ReplaceAll(pd.PluginMeta.Name, " ", ""),
 			Schema:  pd.Lineage.Latest(),
 			IsGroup: pd.SchemaInterface.IsGroup(),
 		}


### PR DESCRIPTION
Fixes: https://github.com/grafana/grafana/pull/62018/files#r1086601395

Looks like that we are passing names with spaces and we are generating incorrect names in TS interfaces.