### PR TITLE
chore: move entity models into entity store service

### DIFF
--- a/pkg/services/export/entity_store.go
+++ b/pkg/services/export/entity_store.go
@@ -10,7 +10,6 @@ import (
 	"github.com/grafana/grafana/pkg/infra/appcontext"
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/dashboardsnapshots"
 	"github.com/grafana/grafana/pkg/services/playlist"
 	"github.com/grafana/grafana/pkg/services/sqlstore/session"
@@ -105,7 +104,7 @@ func (e *entityStoreJob) start(ctx context.Context) {
 	}
 	ctx = appcontext.WithUser(ctx, rowUser)
 
-	what := models.StandardKindFolder
+	what := entity.StandardKindFolder
 	e.status.Count[what] = 0
 
 	folders := make(map[int64]string)
@@ -133,7 +132,7 @@ func (e *entityStoreJob) start(ctx context.Context) {
 		_, err = e.store.AdminWrite(ctx, &entity.AdminWriteEntityRequest{
 			GRN: &entity.GRN{
 				UID:  dash.UID,
-				Kind: models.StandardKindFolder,
+				Kind: entity.StandardKindFolder,
 			},
 			ClearHistory: true,
 			CreatedAt:    dash.Created.UnixMilli(),
@@ -158,7 +157,7 @@ func (e *entityStoreJob) start(ctx context.Context) {
 		e.broadcaster(e.status)
 	}
 
-	what = models.StandardKindDashboard
+	what = entity.StandardKindDashboard
 	e.status.Count[what] = 0
 
 	// TODO paging etc
@@ -181,7 +180,7 @@ func (e *entityStoreJob) start(ctx context.Context) {
 		_, err = e.store.AdminWrite(ctx, &entity.AdminWriteEntityRequest{
 			GRN: &entity.GRN{
 				UID:  dash.UID,
-				Kind: models.StandardKindDashboard,
+				Kind: entity.StandardKindDashboard,
 			},
 			ClearHistory: true,
 			Version:      fmt.Sprintf("%d", dash.Version),
@@ -208,7 +207,7 @@ func (e *entityStoreJob) start(ctx context.Context) {
 	}
 
 	// Playlists
-	what = models.StandardKindPlaylist
+	what = entity.StandardKindPlaylist
 	e.status.Count[what] = 0
 	rowUser.OrgID = 1
 	rowUser.UserID = 1
@@ -233,7 +232,7 @@ func (e *entityStoreJob) start(ctx context.Context) {
 		_, err = e.store.Write(ctx, &entity.WriteEntityRequest{
 			GRN: &entity.GRN{
 				UID:  playlist.Uid,
-				Kind: models.StandardKindPlaylist,
+				Kind: entity.StandardKindPlaylist,
 			},
 			Body:    prettyJSON(playlist),
 			Comment: "export from playlists",
@@ -297,7 +296,7 @@ func (e *entityStoreJob) start(ctx context.Context) {
 			_, err = e.store.Write(ctx, &entity.WriteEntityRequest{
 				GRN: &entity.GRN{
 					UID:  dto.Key,
-					Kind: models.StandardKindSnapshot,
+					Kind: entity.StandardKindSnapshot,
 				},
 				Body:    prettyJSON(m),
 				Comment: "export from snapshtts",

--- a/pkg/services/export/export_sys_playlists.go
+++ b/pkg/services/export/export_sys_playlists.go
@@ -5,8 +5,8 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/playlist"
+	"github.com/grafana/grafana/pkg/services/store/entity"
 )
 
 func exportSystemPlaylists(helper *commitHelper, job *gitExportJob) error {
@@ -41,7 +41,7 @@ func exportSystemPlaylists(helper *commitHelper, job *gitExportJob) error {
 			fpath: filepath.Join(
 				helper.orgDir,
 				"entity",
-				models.StandardKindPlaylist,
+				entity.StandardKindPlaylist,
 				fmt.Sprintf("%s.json", playlist.Uid)),
 			body: prettyJSON(playlist),
 		})

--- a/pkg/services/playlist/playlistimpl/entity_store.go
+++ b/pkg/services/playlist/playlistimpl/entity_store.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	"github.com/grafana/grafana/pkg/infra/appcontext"
-	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/playlist"
 	"github.com/grafana/grafana/pkg/services/sqlstore/session"
 	"github.com/grafana/grafana/pkg/services/store/entity"
@@ -59,7 +58,7 @@ func (s *entityStoreImpl) sync() {
 			GRN: &entity.GRN{
 				TenantId: info.OrgID,
 				UID:      info.UID,
-				Kind:     models.StandardKindPlaylist,
+				Kind:     entity.StandardKindPlaylist,
 			},
 			Body: body,
 		})
@@ -75,7 +74,7 @@ func (s *entityStoreImpl) Create(ctx context.Context, cmd *playlist.CreatePlayli
 		}
 		_, err = s.store.Write(ctx, &entity.WriteEntityRequest{
 			GRN: &entity.GRN{
-				Kind: models.StandardKindPlaylist,
+				Kind: entity.StandardKindPlaylist,
 				UID:  rsp.UID,
 			},
 			Body: body,
@@ -97,7 +96,7 @@ func (s *entityStoreImpl) Update(ctx context.Context, cmd *playlist.UpdatePlayli
 		_, err = s.store.Write(ctx, &entity.WriteEntityRequest{
 			GRN: &entity.GRN{
 				UID:  rsp.Uid,
-				Kind: models.StandardKindPlaylist,
+				Kind: entity.StandardKindPlaylist,
 			},
 			Body: body,
 		})
@@ -114,7 +113,7 @@ func (s *entityStoreImpl) Delete(ctx context.Context, cmd *playlist.DeletePlayli
 		_, err = s.store.Delete(ctx, &entity.DeleteEntityRequest{
 			GRN: &entity.GRN{
 				UID:  cmd.UID,
-				Kind: models.StandardKindPlaylist,
+				Kind: entity.StandardKindPlaylist,
 			},
 		})
 		if err != nil {
@@ -145,7 +144,7 @@ func (s *entityStoreImpl) Get(ctx context.Context, q *playlist.GetPlaylistByUidQ
 	rsp, err := s.store.Read(ctx, &entity.ReadEntityRequest{
 		GRN: &entity.GRN{
 			UID:  q.UID,
-			Kind: models.StandardKindPlaylist,
+			Kind: entity.StandardKindPlaylist,
 		},
 		WithBody: true,
 	})
@@ -166,7 +165,7 @@ func (s *entityStoreImpl) Search(ctx context.Context, q *playlist.GetPlaylistsQu
 	playlists := make(playlist.Playlists, 0)
 
 	rsp, err := s.store.Search(ctx, &entity.EntitySearchRequest{
-		Kind:     []string{models.StandardKindPlaylist},
+		Kind:     []string{entity.StandardKindPlaylist},
 		WithBody: true,
 		Limit:    1000,
 	})

--- a/pkg/services/searchV2/bluge.go
+++ b/pkg/services/searchV2/bluge.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/slugify"
-	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/store/entity"
 )
 
 const (
@@ -170,7 +170,7 @@ func getNonFolderDashboardDoc(dash dashboard, location string) *bluge.Document {
 	}
 
 	for _, ref := range dash.summary.References {
-		if ref.Kind == models.StandardKindDataSource {
+		if ref.Kind == entity.StandardKindDataSource {
 			if ref.Type != "" {
 				doc.AddField(bluge.NewKeywordField(documentFieldDSType, ref.Type).
 					StoreValue().
@@ -210,7 +210,7 @@ func getDashboardPanelDocs(dash dashboard, location string) []*bluge.Document {
 
 		for _, ref := range dash.summary.References {
 			switch ref.Kind {
-			case models.StandardKindDashboard:
+			case entity.StandardKindDashboard:
 				if ref.Type != "" {
 					doc.AddField(bluge.NewKeywordField(documentFieldDSType, ref.Type).
 						StoreValue().
@@ -223,12 +223,12 @@ func getDashboardPanelDocs(dash dashboard, location string) []*bluge.Document {
 						Aggregatable().
 						SearchTermPositions())
 				}
-			case models.ExternalEntityReferencePlugin:
-				if ref.Type == models.StandardKindPanel && ref.UID != "" {
+			case entity.ExternalEntityReferencePlugin:
+				if ref.Type == entity.StandardKindPanel && ref.UID != "" {
 					doc.AddField(bluge.NewKeywordField(documentFieldPanelType, ref.UID).Aggregatable().StoreValue())
 				}
-			case models.ExternalEntityReferenceRuntime:
-				if ref.Type == models.ExternalEntityReferenceRuntime_Transformer && ref.UID != "" {
+			case entity.ExternalEntityReferenceRuntime:
+				if ref.Type == entity.ExternalEntityReferenceRuntime_Transformer && ref.UID != "" {
 					doc.AddField(bluge.NewKeywordField(documentFieldTransformer, ref.UID).Aggregatable())
 				}
 			}

--- a/pkg/services/searchV2/filter.go
+++ b/pkg/services/searchV2/filter.go
@@ -7,8 +7,9 @@ import (
 	"github.com/blugelabs/bluge/search"
 	"github.com/blugelabs/bluge/search/searcher"
 	"github.com/blugelabs/bluge/search/similarity"
+
 	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/store/entity"
 )
 
 type PermissionFilter struct {
@@ -19,11 +20,11 @@ type PermissionFilter struct {
 type entityKind string
 
 const (
-	entityKindPanel      entityKind = models.StandardKindPanel
-	entityKindDashboard  entityKind = models.StandardKindDashboard
-	entityKindFolder     entityKind = models.StandardKindFolder
-	entityKindDatasource entityKind = models.StandardKindDataSource
-	entityKindQuery      entityKind = models.StandardKindQuery
+	entityKindPanel      entityKind = entity.StandardKindPanel
+	entityKindDashboard  entityKind = entity.StandardKindDashboard
+	entityKindFolder     entityKind = entity.StandardKindFolder
+	entityKindDatasource entityKind = entity.StandardKindDataSource
+	entityKindQuery      entityKind = entity.StandardKindQuery
 )
 
 func (r entityKind) IsValid() bool {

--- a/pkg/services/searchV2/index.go
+++ b/pkg/services/searchV2/index.go
@@ -19,9 +19,9 @@ import (
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
-	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/store"
+	"github.com/grafana/grafana/pkg/services/store/entity"
 	kdash "github.com/grafana/grafana/pkg/services/store/kind/dashboard"
 	"github.com/grafana/grafana/pkg/setting"
 )
@@ -54,7 +54,7 @@ type dashboard struct {
 	updated  time.Time
 
 	// Use generic structure
-	summary *models.EntitySummary
+	summary *entity.EntitySummary
 }
 
 // buildSignal is sent when search index is accessed in organization for which
@@ -912,7 +912,7 @@ func (l sqlDashboardLoader) LoadDashboards(ctx context.Context, orgID int64, das
 			slug:     "",
 			created:  time.Now(),
 			updated:  time.Now(),
-			summary: &models.EntitySummary{
+			summary: &entity.EntitySummary{
 				//ID:    0,
 				Name: "General",
 			},

--- a/pkg/services/searchV2/index_test.go
+++ b/pkg/services/searchV2/index_test.go
@@ -8,9 +8,10 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
+
 	"github.com/grafana/grafana/pkg/infra/tracing"
-	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/store/entity"
 	"github.com/grafana/grafana/pkg/setting"
 
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -113,14 +114,14 @@ var testDashboards = []dashboard{
 	{
 		id:  1,
 		uid: "1",
-		summary: &models.EntitySummary{
+		summary: &entity.EntitySummary{
 			Name: "test",
 		},
 	},
 	{
 		id:  2,
 		uid: "2",
-		summary: &models.EntitySummary{
+		summary: &entity.EntitySummary{
 			Name: "boom",
 		},
 	},
@@ -162,7 +163,7 @@ func TestDashboardIndexUpdates(t *testing.T) {
 		err := index.updateDashboard(context.Background(), testOrgID, orgIdx, dashboard{
 			id:  3,
 			uid: "3",
-			summary: &models.EntitySummary{
+			summary: &entity.EntitySummary{
 				Name: "created",
 			},
 		})
@@ -181,7 +182,7 @@ func TestDashboardIndexUpdates(t *testing.T) {
 		err := index.updateDashboard(context.Background(), testOrgID, orgIdx, dashboard{
 			id:  2,
 			uid: "2",
-			summary: &models.EntitySummary{
+			summary: &entity.EntitySummary{
 				Name: "nginx",
 			},
 		})
@@ -197,14 +198,14 @@ var testSortDashboards = []dashboard{
 	{
 		id:  1,
 		uid: "1",
-		summary: &models.EntitySummary{
+		summary: &entity.EntitySummary{
 			Name: "a-test",
 		},
 	},
 	{
 		id:  2,
 		uid: "2",
-		summary: &models.EntitySummary{
+		summary: &entity.EntitySummary{
 			Name: "z-test",
 		},
 	},
@@ -288,14 +289,14 @@ var testPrefixDashboards = []dashboard{
 	{
 		id:  1,
 		uid: "1",
-		summary: &models.EntitySummary{
+		summary: &entity.EntitySummary{
 			Name: "Archer Data System",
 		},
 	},
 	{
 		id:  2,
 		uid: "2",
-		summary: &models.EntitySummary{
+		summary: &entity.EntitySummary{
 			Name: "Document Sync repo",
 		},
 	},
@@ -366,7 +367,7 @@ var longPrefixDashboards = []dashboard{
 	{
 		id:  1,
 		uid: "1",
-		summary: &models.EntitySummary{
+		summary: &entity.EntitySummary{
 			Name: "Eyjafjallajökull Eruption data",
 		},
 	},
@@ -385,14 +386,14 @@ var scatteredTokensDashboards = []dashboard{
 	{
 		id:  1,
 		uid: "1",
-		summary: &models.EntitySummary{
+		summary: &entity.EntitySummary{
 			Name: "Three can keep a secret, if two of them are dead (Benjamin Franklin)",
 		},
 	},
 	{
 		id:  3,
 		uid: "2",
-		summary: &models.EntitySummary{
+		summary: &entity.EntitySummary{
 			Name: "A secret is powerful when it is empty (Umberto Eco)",
 		},
 	},
@@ -418,7 +419,7 @@ var dashboardsWithFolders = []dashboard{
 		id:       1,
 		uid:      "1",
 		isFolder: true,
-		summary: &models.EntitySummary{
+		summary: &entity.EntitySummary{
 			Name: "My folder",
 		},
 	},
@@ -426,9 +427,9 @@ var dashboardsWithFolders = []dashboard{
 		id:       2,
 		uid:      "2",
 		folderID: 1,
-		summary: &models.EntitySummary{
+		summary: &entity.EntitySummary{
 			Name: "Dashboard in folder 1",
-			Nested: []*models.EntitySummary{
+			Nested: []*entity.EntitySummary{
 				newNestedPanel(1, "Panel 1"),
 				newNestedPanel(2, "Panel 2"),
 			},
@@ -438,9 +439,9 @@ var dashboardsWithFolders = []dashboard{
 		id:       3,
 		uid:      "3",
 		folderID: 1,
-		summary: &models.EntitySummary{
+		summary: &entity.EntitySummary{
 			Name: "Dashboard in folder 2",
-			Nested: []*models.EntitySummary{
+			Nested: []*entity.EntitySummary{
 				newNestedPanel(3, "Panel 3"),
 			},
 		},
@@ -448,9 +449,9 @@ var dashboardsWithFolders = []dashboard{
 	{
 		id:  4,
 		uid: "4",
-		summary: &models.EntitySummary{
+		summary: &entity.EntitySummary{
 			Name: "One more dash",
-			Nested: []*models.EntitySummary{
+			Nested: []*entity.EntitySummary{
 				newNestedPanel(4, "Panel 4"),
 			},
 		},
@@ -505,9 +506,9 @@ var dashboardsWithPanels = []dashboard{
 	{
 		id:  1,
 		uid: "1",
-		summary: &models.EntitySummary{
+		summary: &entity.EntitySummary{
 			Name: "My Dash",
-			Nested: []*models.EntitySummary{
+			Nested: []*entity.EntitySummary{
 				newNestedPanel(1, "Panel 1"),
 				newNestedPanel(2, "Panel 2"),
 			},
@@ -515,8 +516,8 @@ var dashboardsWithPanels = []dashboard{
 	},
 }
 
-func newNestedPanel(id int64, name string) *models.EntitySummary {
-	summary := &models.EntitySummary{
+func newNestedPanel(id int64, name string) *entity.EntitySummary {
+	summary := &entity.EntitySummary{
 		Kind: "panel",
 		UID:  fmt.Sprintf("???#%d", id),
 	}
@@ -553,14 +554,14 @@ var punctuationSplitNgramDashboards = []dashboard{
 	{
 		id:  1,
 		uid: "1",
-		summary: &models.EntitySummary{
+		summary: &entity.EntitySummary{
 			Name: "heat-torkel",
 		},
 	},
 	{
 		id:  2,
 		uid: "2",
-		summary: &models.EntitySummary{
+		summary: &entity.EntitySummary{
 			Name: "topology heatmap",
 		},
 	},
@@ -586,7 +587,7 @@ var camelCaseNgramDashboards = []dashboard{
 	{
 		id:  1,
 		uid: "1",
-		summary: &models.EntitySummary{
+		summary: &entity.EntitySummary{
 			Name: "heatTorkel",
 		},
 	},
@@ -608,7 +609,7 @@ func dashboardsWithTitles(names ...string) []dashboard {
 		out = append(out, dashboard{
 			id:  no,
 			uid: fmt.Sprintf("%d", no),
-			summary: &models.EntitySummary{
+			summary: &entity.EntitySummary{
 				Name: name,
 			},
 		})

--- a/pkg/services/store/entity/models.go
+++ b/pkg/services/store/entity/models.go
@@ -1,4 +1,4 @@
-package models
+package entity
 
 //-----------------------------------------------------------------------------------------------------
 // NOTE: the object store is in heavy development, and the locations will likely continue to move
@@ -20,7 +20,7 @@ const (
 	// Standalone panel is not an object kind yet -- library panel, or nested in dashboard
 	StandardKindPanel = "panel"
 
-	// StandardKindSVG SVG file support
+	// entity.StandardKindSVG SVG file support
 	StandardKindSVG = "svg"
 
 	// StandardKindPNG PNG file support
@@ -108,18 +108,6 @@ type EntitySummary struct {
 
 	// The summary can not be extended
 	_ interface{}
-}
-
-// This will likely get replaced with a more general error framework.
-type EntityErrorInfo struct {
-	// TODO: Match an error code registry?
-	Code int64 `json:"code,omitempty"`
-
-	// Simple error display
-	Message string `json:"message,omitempty"`
-
-	// Error details
-	Details interface{} `json:"details,omitempty"`
 }
 
 // Reference to another object outside itself

--- a/pkg/services/store/entity/sqlstash/folder_support.go
+++ b/pkg/services/store/entity/sqlstash/folder_support.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/sqlstore/session"
 	"github.com/grafana/grafana/pkg/services/store/entity"
 )
@@ -41,7 +40,7 @@ func updateFolderTree(ctx context.Context, tx *session.SessionTx, tenant int64) 
 
 	all := []*folderInfo{}
 	rows, err := tx.Query(ctx, "SELECT uid,folder,name,slug FROM entity WHERE kind=? AND tenant_id=? ORDER BY slug asc;",
-		models.StandardKindFolder, tenant)
+		entity.StandardKindFolder, tenant)
 	if err != nil {
 		return err
 	}
@@ -135,7 +134,7 @@ func setMPTTOrder(folder *folderInfo, stack []*folderInfo, idx int32) (int32, er
 
 func insertFolderInfo(ctx context.Context, tx *session.SessionTx, tenant int64, folder *folderInfo, isDetached bool) error {
 	js, _ := json.Marshal(folder.stack)
-	grn := entity.GRN{TenantId: tenant, Kind: models.StandardKindFolder, UID: folder.UID}
+	grn := entity.GRN{TenantId: tenant, Kind: entity.StandardKindFolder, UID: folder.UID}
 	_, err := tx.Exec(ctx,
 		`INSERT INTO entity_folder `+
 			"(grn, tenant_id, uid, slug_path, tree, depth, left, right, detached) "+

--- a/pkg/services/store/entity/sqlstash/sql_storage_server.go
+++ b/pkg/services/store/entity/sqlstash/sql_storage_server.go
@@ -13,7 +13,6 @@ import (
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/slugify"
-	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/grpcserver"
 	"github.com/grafana/grafana/pkg/services/sqlstore/session"
 	"github.com/grafana/grafana/pkg/services/store"
@@ -447,7 +446,7 @@ func (s *sqlEntityServer) AdminWrite(ctx context.Context, r *entity.AdminWriteEn
 				origin.Source, origin.Key, origin.Time,
 			)
 		}
-		if err == nil && models.StandardKindFolder == r.GRN.Kind {
+		if err == nil && entity.StandardKindFolder == r.GRN.Kind {
 			err = updateFolderTree(ctx, tx, grn.TenantId)
 		}
 		if err == nil {
@@ -663,7 +662,7 @@ func doDelete(ctx context.Context, tx *session.SessionTx, grn *entity.GRN) (bool
 		return false, err
 	}
 
-	if grn.Kind == models.StandardKindFolder {
+	if grn.Kind == entity.StandardKindFolder {
 		err = updateFolderTree(ctx, tx, grn.TenantId)
 	}
 	return rows > 0, err

--- a/pkg/services/store/entity/sqlstash/summary_handler.go
+++ b/pkg/services/store/entity/sqlstash/summary_handler.go
@@ -3,12 +3,11 @@ package sqlstash
 import (
 	"encoding/json"
 
-	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/store/entity"
 )
 
 type summarySupport struct {
-	model       *models.EntitySummary
+	model       *entity.EntitySummary
 	name        string
 	description *string // null or empty
 	slug        *string // null or empty
@@ -23,7 +22,7 @@ type summarySupport struct {
 	isNested   bool // set when this is for a nested item
 }
 
-func newSummarySupport(summary *models.EntitySummary) (*summarySupport, error) {
+func newSummarySupport(summary *entity.EntitySummary) (*summarySupport, error) {
 	var err error
 	var js []byte
 	s := &summarySupport{
@@ -72,9 +71,9 @@ func newSummarySupport(summary *models.EntitySummary) (*summarySupport, error) {
 	return s, err
 }
 
-func (s summarySupport) toEntitySummary() (*models.EntitySummary, error) {
+func (s summarySupport) toEntitySummary() (*entity.EntitySummary, error) {
 	var err error
-	summary := &models.EntitySummary{
+	summary := &entity.EntitySummary{
 		Name: s.name,
 	}
 	if s.description != nil {

--- a/pkg/services/store/entity/tests/server_integration_test.go
+++ b/pkg/services/store/entity/tests/server_integration_test.go
@@ -8,12 +8,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grafana/grafana/pkg/models"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
+
 	"github.com/grafana/grafana/pkg/services/store"
 	"github.com/grafana/grafana/pkg/services/store/entity"
 	"github.com/grafana/grafana/pkg/util"
-	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc/metadata"
 )
 
 var (
@@ -133,7 +133,7 @@ func TestIntegrationEntityServer(t *testing.T) {
 
 	fakeUser := store.GetUserIDString(testCtx.user)
 	firstVersion := "1"
-	kind := models.StandardKindJSONObj
+	kind := entity.StandardKindJSONObj
 	grn := &entity.GRN{
 		Kind: kind,
 		UID:  "my-test-entity",
@@ -314,7 +314,7 @@ func TestIntegrationEntityServer(t *testing.T) {
 		uid2 := "uid2"
 		uid3 := "uid3"
 		uid4 := "uid4"
-		kind2 := models.StandardKindPlaylist
+		kind2 := entity.StandardKindPlaylist
 		w1, err := testCtx.client.Write(ctx, &entity.WriteEntityRequest{
 			GRN:  grn,
 			Body: body,
@@ -394,7 +394,7 @@ func TestIntegrationEntityServer(t *testing.T) {
 	})
 
 	t.Run("should be able to filter objects based on their labels", func(t *testing.T) {
-		kind := models.StandardKindDashboard
+		kind := entity.StandardKindDashboard
 		_, err := testCtx.client.Write(ctx, &entity.WriteEntityRequest{
 			GRN: &entity.GRN{
 				Kind: kind,

--- a/pkg/services/store/kind/dashboard/reference.go
+++ b/pkg/services/store/kind/dashboard/reference.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/store/entity"
 )
 
 // A reference accumulator can combine
@@ -13,24 +13,24 @@ type ReferenceAccumulator interface {
 	Add(kind string, subtype string, uid string)
 
 	// Returns the set of distinct references in a sorted order
-	Get() []*models.EntityExternalReference
+	Get() []*entity.EntityExternalReference
 }
 
 func NewReferenceAccumulator() ReferenceAccumulator {
 	return &referenceAccumulator{
-		refs: make(map[string]*models.EntityExternalReference),
+		refs: make(map[string]*entity.EntityExternalReference),
 	}
 }
 
 type referenceAccumulator struct {
-	refs map[string]*models.EntityExternalReference
+	refs map[string]*entity.EntityExternalReference
 }
 
 func (x *referenceAccumulator) Add(kind string, sub string, uid string) {
 	key := fmt.Sprintf("%s/%s/%s", kind, sub, uid)
 	_, ok := x.refs[key]
 	if !ok {
-		x.refs[key] = &models.EntityExternalReference{
+		x.refs[key] = &entity.EntityExternalReference{
 			Kind: kind,
 			Type: sub,
 			UID:  uid,
@@ -38,14 +38,14 @@ func (x *referenceAccumulator) Add(kind string, sub string, uid string) {
 	}
 }
 
-func (x *referenceAccumulator) Get() []*models.EntityExternalReference {
+func (x *referenceAccumulator) Get() []*entity.EntityExternalReference {
 	keys := make([]string, 0, len(x.refs))
 	for k := range x.refs {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
 
-	refs := make([]*models.EntityExternalReference, len(keys))
+	refs := make([]*entity.EntityExternalReference, len(keys))
 	for i, key := range keys {
 		refs[i] = x.refs[key]
 	}

--- a/pkg/services/store/kind/dashboard/summary.go
+++ b/pkg/services/store/kind/dashboard/summary.go
@@ -6,29 +6,29 @@ import (
 	"encoding/json"
 	"strconv"
 
-	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/plugins"
+	"github.com/grafana/grafana/pkg/services/store/entity"
 )
 
-func GetEntityKindInfo() models.EntityKindInfo {
-	return models.EntityKindInfo{
-		ID:          models.StandardKindDashboard,
+func GetEntityKindInfo() entity.EntityKindInfo {
+	return entity.EntityKindInfo{
+		ID:          entity.StandardKindDashboard,
 		Name:        "Dashboard",
 		Description: "Define a grafana dashboard layout",
 	}
 }
 
 // This summary does not resolve old name as UID
-func GetEntitySummaryBuilder() models.EntitySummaryBuilder {
+func GetEntitySummaryBuilder() entity.EntitySummaryBuilder {
 	builder := NewStaticDashboardSummaryBuilder(&directLookup{}, true)
-	return func(ctx context.Context, uid string, body []byte) (*models.EntitySummary, []byte, error) {
+	return func(ctx context.Context, uid string, body []byte) (*entity.EntitySummary, []byte, error) {
 		return builder(ctx, uid, body)
 	}
 }
 
 // This implementation moves datasources referenced by internal ID or name to UID
-func NewStaticDashboardSummaryBuilder(lookup DatasourceLookup, sanitize bool) models.EntitySummaryBuilder {
-	return func(ctx context.Context, uid string, body []byte) (*models.EntitySummary, []byte, error) {
+func NewStaticDashboardSummaryBuilder(lookup DatasourceLookup, sanitize bool) entity.EntitySummaryBuilder {
+	return func(ctx context.Context, uid string, body []byte) (*entity.EntitySummary, []byte, error) {
 		var parsed map[string]interface{}
 
 		if sanitize {
@@ -42,14 +42,14 @@ func NewStaticDashboardSummaryBuilder(lookup DatasourceLookup, sanitize bool) mo
 			// slug? (derived from title)
 		}
 
-		summary := &models.EntitySummary{
+		summary := &entity.EntitySummary{
 			Labels: make(map[string]string),
 			Fields: make(map[string]interface{}),
 		}
 		stream := bytes.NewBuffer(body)
 		dash, err := readDashboard(stream, lookup)
 		if err != nil {
-			summary.Error = &models.EntityErrorInfo{
+			summary.Error = &entity.EntityErrorInfo{
 				Message: err.Error(),
 			}
 			return summary, body, err
@@ -68,7 +68,7 @@ func NewStaticDashboardSummaryBuilder(lookup DatasourceLookup, sanitize bool) mo
 
 		for _, panel := range dash.Panels {
 			panelRefs := NewReferenceAccumulator()
-			p := &models.EntitySummary{
+			p := &entity.EntitySummary{
 				UID:  uid + "#" + strconv.FormatInt(panel.ID, 10),
 				Kind: "panel",
 			}
@@ -78,19 +78,19 @@ func NewStaticDashboardSummaryBuilder(lookup DatasourceLookup, sanitize bool) mo
 			p.Fields["type"] = panel.Type
 
 			if panel.Type != "row" {
-				panelRefs.Add(models.ExternalEntityReferencePlugin, string(plugins.Panel), panel.Type)
-				dashboardRefs.Add(models.ExternalEntityReferencePlugin, string(plugins.Panel), panel.Type)
+				panelRefs.Add(entity.ExternalEntityReferencePlugin, string(plugins.Panel), panel.Type)
+				dashboardRefs.Add(entity.ExternalEntityReferencePlugin, string(plugins.Panel), panel.Type)
 			}
 			for _, v := range panel.Datasource {
-				dashboardRefs.Add(models.StandardKindDataSource, v.Type, v.UID)
-				panelRefs.Add(models.StandardKindDataSource, v.Type, v.UID)
+				dashboardRefs.Add(entity.StandardKindDataSource, v.Type, v.UID)
+				panelRefs.Add(entity.StandardKindDataSource, v.Type, v.UID)
 				if v.Type != "" {
-					dashboardRefs.Add(models.ExternalEntityReferencePlugin, string(plugins.DataSource), v.Type)
+					dashboardRefs.Add(entity.ExternalEntityReferencePlugin, string(plugins.DataSource), v.Type)
 				}
 			}
 			for _, v := range panel.Transformer {
-				panelRefs.Add(models.ExternalEntityReferenceRuntime, models.ExternalEntityReferenceRuntime_Transformer, v)
-				dashboardRefs.Add(models.ExternalEntityReferenceRuntime, models.ExternalEntityReferenceRuntime_Transformer, v)
+				panelRefs.Add(entity.ExternalEntityReferenceRuntime, entity.ExternalEntityReferenceRuntime_Transformer, v)
+				dashboardRefs.Add(entity.ExternalEntityReferenceRuntime, entity.ExternalEntityReferenceRuntime_Transformer, v)
 			}
 			p.References = panelRefs.Get()
 			summary.Nested = append(summary.Nested, p)

--- a/pkg/services/store/kind/dataframe/summary.go
+++ b/pkg/services/store/kind/dataframe/summary.go
@@ -5,20 +5,21 @@ import (
 	"encoding/json"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
-	"github.com/grafana/grafana/pkg/models"
+
 	"github.com/grafana/grafana/pkg/services/store"
+	"github.com/grafana/grafana/pkg/services/store/entity"
 )
 
-func GetEntityKindInfo() models.EntityKindInfo {
-	return models.EntityKindInfo{
-		ID:          models.StandardKindDataFrame,
+func GetEntityKindInfo() entity.EntityKindInfo {
+	return entity.EntityKindInfo{
+		ID:          entity.StandardKindDataFrame,
 		Name:        "Data frame",
 		Description: "Data frame",
 	}
 }
 
-func GetEntitySummaryBuilder() models.EntitySummaryBuilder {
-	return func(ctx context.Context, uid string, body []byte) (*models.EntitySummary, []byte, error) {
+func GetEntitySummaryBuilder() entity.EntitySummaryBuilder {
+	return func(ctx context.Context, uid string, body []byte) (*entity.EntitySummary, []byte, error) {
 		df := &data.Frame{}
 		err := json.Unmarshal(body, df)
 		if err != nil {
@@ -33,8 +34,8 @@ func GetEntitySummaryBuilder() models.EntitySummaryBuilder {
 		if err != nil {
 			return nil, nil, err
 		}
-		summary := &models.EntitySummary{
-			Kind: models.StandardKindDataFrame,
+		summary := &entity.EntitySummary{
+			Kind: entity.StandardKindDataFrame,
 			Name: df.Name,
 			UID:  uid,
 			Fields: map[string]interface{}{

--- a/pkg/services/store/kind/dummy/summary.go
+++ b/pkg/services/store/kind/dummy/summary.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/store/entity"
 )
 
-func GetEntityKindInfo(kind string) models.EntityKindInfo {
-	return models.EntityKindInfo{
+func GetEntityKindInfo(kind string) entity.EntityKindInfo {
+	return entity.EntityKindInfo{
 		ID:          kind,
 		Name:        kind,
 		Description: "Dummy kind used for testing.",
@@ -17,9 +17,9 @@ func GetEntityKindInfo(kind string) models.EntityKindInfo {
 	}
 }
 
-func GetEntitySummaryBuilder(kind string) models.EntitySummaryBuilder {
-	return func(ctx context.Context, uid string, body []byte) (*models.EntitySummary, []byte, error) {
-		summary := &models.EntitySummary{
+func GetEntitySummaryBuilder(kind string) entity.EntitySummaryBuilder {
+	return func(ctx context.Context, uid string, body []byte) (*entity.EntitySummary, []byte, error) {
+		summary := &entity.EntitySummary{
 			Name:        fmt.Sprintf("Dummy: %s", kind),
 			Kind:        kind,
 			Description: fmt.Sprintf("Wrote at %s", time.Now().Local().String()),
@@ -35,7 +35,7 @@ func GetEntitySummaryBuilder(kind string) models.EntitySummaryBuilder {
 			},
 			Error:  nil, // ignore for now
 			Nested: nil, // ignore for now
-			References: []*models.EntityExternalReference{
+			References: []*entity.EntityExternalReference{
 				{
 					Kind: "ds",
 					Type: "influx",

--- a/pkg/services/store/kind/folder/summary.go
+++ b/pkg/services/store/kind/folder/summary.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/store"
+	"github.com/grafana/grafana/pkg/services/store/entity"
 )
 
 type Model struct {
@@ -13,15 +13,15 @@ type Model struct {
 	Description string `json:"description,omitempty"`
 }
 
-func GetEntityKindInfo() models.EntityKindInfo {
-	return models.EntityKindInfo{
-		ID:   models.StandardKindFolder,
+func GetEntityKindInfo() entity.EntityKindInfo {
+	return entity.EntityKindInfo{
+		ID:   entity.StandardKindFolder,
 		Name: "Folder",
 	}
 }
 
-func GetEntitySummaryBuilder() models.EntitySummaryBuilder {
-	return func(ctx context.Context, uid string, body []byte) (*models.EntitySummary, []byte, error) {
+func GetEntitySummaryBuilder() entity.EntitySummaryBuilder {
+	return func(ctx context.Context, uid string, body []byte) (*entity.EntitySummary, []byte, error) {
 		obj := &Model{}
 		err := json.Unmarshal(body, obj)
 		if err != nil {
@@ -32,8 +32,8 @@ func GetEntitySummaryBuilder() models.EntitySummaryBuilder {
 			obj.Name = store.GuessNameFromUID(uid)
 		}
 
-		summary := &models.EntitySummary{
-			Kind:        models.StandardKindFolder,
+		summary := &entity.EntitySummary{
+			Kind:        entity.StandardKindFolder,
 			Name:        obj.Name,
 			Description: obj.Description,
 			UID:         uid,

--- a/pkg/services/store/kind/geojson/summary.go
+++ b/pkg/services/store/kind/geojson/summary.go
@@ -5,13 +5,13 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/store"
+	"github.com/grafana/grafana/pkg/services/store/entity"
 )
 
-func GetEntityKindInfo() models.EntityKindInfo {
-	return models.EntityKindInfo{
-		ID:            models.StandardKindGeoJSON,
+func GetEntityKindInfo() entity.EntityKindInfo {
+	return entity.EntityKindInfo{
+		ID:            entity.StandardKindGeoJSON,
 		Name:          "GeoJSON",
 		Description:   "JSON formatted spatial data",
 		FileExtension: ".geojson",
@@ -20,8 +20,8 @@ func GetEntityKindInfo() models.EntityKindInfo {
 }
 
 // Very basic geojson validator
-func GetEntitySummaryBuilder() models.EntitySummaryBuilder {
-	return func(ctx context.Context, uid string, body []byte) (*models.EntitySummary, []byte, error) {
+func GetEntitySummaryBuilder() entity.EntitySummaryBuilder {
+	return func(ctx context.Context, uid string, body []byte) (*entity.EntitySummary, []byte, error) {
 		var geojson map[string]interface{}
 		err := json.Unmarshal(body, &geojson)
 		if err != nil {
@@ -38,8 +38,8 @@ func GetEntitySummaryBuilder() models.EntitySummaryBuilder {
 			return nil, nil, err
 		}
 
-		summary := &models.EntitySummary{
-			Kind: models.StandardKindGeoJSON,
+		summary := &entity.EntitySummary{
+			Kind: entity.StandardKindGeoJSON,
 			Name: store.GuessNameFromUID(uid),
 			UID:  uid,
 			Fields: map[string]interface{}{

--- a/pkg/services/store/kind/jsonobj/summary.go
+++ b/pkg/services/store/kind/jsonobj/summary.go
@@ -4,20 +4,20 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/store"
+	"github.com/grafana/grafana/pkg/services/store/entity"
 )
 
-func GetEntityKindInfo() models.EntityKindInfo {
-	return models.EntityKindInfo{
-		ID:          models.StandardKindJSONObj,
+func GetEntityKindInfo() entity.EntityKindInfo {
+	return entity.EntityKindInfo{
+		ID:          entity.StandardKindJSONObj,
 		Name:        "JSON Object",
 		Description: "JSON Object",
 	}
 }
 
-func GetEntitySummaryBuilder() models.EntitySummaryBuilder {
-	return func(ctx context.Context, uid string, body []byte) (*models.EntitySummary, []byte, error) {
+func GetEntitySummaryBuilder() entity.EntitySummaryBuilder {
+	return func(ctx context.Context, uid string, body []byte) (*entity.EntitySummary, []byte, error) {
 		v := make(map[string]interface{})
 		err := json.Unmarshal(body, &v)
 		if err != nil {
@@ -28,8 +28,8 @@ func GetEntitySummaryBuilder() models.EntitySummaryBuilder {
 		if err != nil {
 			return nil, nil, err
 		}
-		return &models.EntitySummary{
-			Kind: models.StandardKindJSONObj,
+		return &entity.EntitySummary{
+			Kind: entity.StandardKindJSONObj,
 			Name: store.GuessNameFromUID(uid),
 			UID:  uid,
 		}, out, err

--- a/pkg/services/store/kind/playlist/summary.go
+++ b/pkg/services/store/kind/playlist/summary.go
@@ -6,22 +6,22 @@ import (
 	"fmt"
 
 	"github.com/grafana/grafana/pkg/kinds/playlist"
-	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/store/entity"
 )
 
-func GetEntityKindInfo() models.EntityKindInfo {
-	return models.EntityKindInfo{
-		ID:          models.StandardKindPlaylist,
+func GetEntityKindInfo() entity.EntityKindInfo {
+	return entity.EntityKindInfo{
+		ID:          entity.StandardKindPlaylist,
 		Name:        "Playlist",
 		Description: "Cycle though a collection of dashboards automatically",
 	}
 }
 
-func GetEntitySummaryBuilder() models.EntitySummaryBuilder {
+func GetEntitySummaryBuilder() entity.EntitySummaryBuilder {
 	return summaryBuilder
 }
 
-func summaryBuilder(ctx context.Context, uid string, body []byte) (*models.EntitySummary, []byte, error) {
+func summaryBuilder(ctx context.Context, uid string, body []byte) (*entity.EntitySummary, []byte, error) {
 	obj := &playlist.Playlist{}
 	err := json.Unmarshal(body, obj)
 	if err != nil {
@@ -35,7 +35,7 @@ func summaryBuilder(ctx context.Context, uid string, body []byte) (*models.Entit
 	}
 
 	obj.Uid = uid // make sure they are consistent
-	summary := &models.EntitySummary{
+	summary := &entity.EntitySummary{
 		UID:         uid,
 		Name:        obj.Name,
 		Description: fmt.Sprintf("%d items, refreshed every %s", len(*obj.Items), obj.Interval),
@@ -44,7 +44,7 @@ func summaryBuilder(ctx context.Context, uid string, body []byte) (*models.Entit
 	for _, item := range *obj.Items {
 		switch item.Type {
 		case playlist.ItemTypeDashboardByUid:
-			summary.References = append(summary.References, &models.EntityExternalReference{
+			summary.References = append(summary.References, &entity.EntityExternalReference{
 				Kind: "dashboard",
 				UID:  item.Value,
 			})
@@ -57,7 +57,7 @@ func summaryBuilder(ctx context.Context, uid string, body []byte) (*models.Entit
 
 		case playlist.ItemTypeDashboardById:
 			// obviously insufficient long term... but good to have an example :)
-			summary.Error = &models.EntityErrorInfo{
+			summary.Error = &entity.EntityErrorInfo{
 				Message: "Playlist uses deprecated internal id system",
 			}
 		}

--- a/pkg/services/store/kind/png/summary.go
+++ b/pkg/services/store/kind/png/summary.go
@@ -5,13 +5,13 @@ import (
 	"context"
 	"image/png"
 
-	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/store"
+	"github.com/grafana/grafana/pkg/services/store/entity"
 )
 
-func GetEntityKindInfo() models.EntityKindInfo {
-	return models.EntityKindInfo{
-		ID:            models.StandardKindPNG,
+func GetEntityKindInfo() entity.EntityKindInfo {
+	return entity.EntityKindInfo{
+		ID:            entity.StandardKindPNG,
 		Name:          "PNG",
 		Description:   "PNG Image file",
 		IsRaw:         true,
@@ -21,16 +21,16 @@ func GetEntityKindInfo() models.EntityKindInfo {
 }
 
 // SVG sanitizer based on the rendering service
-func GetEntitySummaryBuilder() models.EntitySummaryBuilder {
-	return func(ctx context.Context, uid string, body []byte) (*models.EntitySummary, []byte, error) {
+func GetEntitySummaryBuilder() entity.EntitySummaryBuilder {
+	return func(ctx context.Context, uid string, body []byte) (*entity.EntitySummary, []byte, error) {
 		img, err := png.Decode(bytes.NewReader(body))
 		if err != nil {
 			return nil, nil, err
 		}
 
 		size := img.Bounds().Size()
-		summary := &models.EntitySummary{
-			Kind: models.StandardKindSVG,
+		summary := &entity.EntitySummary{
+			Kind: entity.StandardKindSVG,
 			Name: store.GuessNameFromUID(uid),
 			UID:  uid,
 			Fields: map[string]interface{}{

--- a/pkg/services/store/kind/registry.go
+++ b/pkg/services/store/kind/registry.go
@@ -5,8 +5,8 @@ import (
 	"sort"
 	"sync"
 
-	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/rendering"
+	"github.com/grafana/grafana/pkg/services/store/entity"
 	"github.com/grafana/grafana/pkg/services/store/kind/dashboard"
 	"github.com/grafana/grafana/pkg/services/store/kind/dataframe"
 	"github.com/grafana/grafana/pkg/services/store/kind/folder"
@@ -20,44 +20,44 @@ import (
 )
 
 type KindRegistry interface {
-	Register(info models.EntityKindInfo, builder models.EntitySummaryBuilder) error
-	GetSummaryBuilder(kind string) models.EntitySummaryBuilder
-	GetInfo(kind string) (models.EntityKindInfo, error)
-	GetFromExtension(suffix string) (models.EntityKindInfo, error)
-	GetKinds() []models.EntityKindInfo
+	Register(info entity.EntityKindInfo, builder entity.EntitySummaryBuilder) error
+	GetSummaryBuilder(kind string) entity.EntitySummaryBuilder
+	GetInfo(kind string) (entity.EntityKindInfo, error)
+	GetFromExtension(suffix string) (entity.EntityKindInfo, error)
+	GetKinds() []entity.EntityKindInfo
 }
 
 func NewKindRegistry() KindRegistry {
 	kinds := make(map[string]*kindValues)
-	kinds[models.StandardKindPlaylist] = &kindValues{
+	kinds[entity.StandardKindPlaylist] = &kindValues{
 		info:    playlist.GetEntityKindInfo(),
 		builder: playlist.GetEntitySummaryBuilder(),
 	}
-	kinds[models.StandardKindDashboard] = &kindValues{
+	kinds[entity.StandardKindDashboard] = &kindValues{
 		info:    dashboard.GetEntityKindInfo(),
 		builder: dashboard.GetEntitySummaryBuilder(),
 	}
-	kinds[models.StandardKindSnapshot] = &kindValues{
+	kinds[entity.StandardKindSnapshot] = &kindValues{
 		info:    snapshot.GetEntityKindInfo(),
 		builder: snapshot.GetEntitySummaryBuilder(),
 	}
-	kinds[models.StandardKindFolder] = &kindValues{
+	kinds[entity.StandardKindFolder] = &kindValues{
 		info:    folder.GetEntityKindInfo(),
 		builder: folder.GetEntitySummaryBuilder(),
 	}
-	kinds[models.StandardKindPNG] = &kindValues{
+	kinds[entity.StandardKindPNG] = &kindValues{
 		info:    png.GetEntityKindInfo(),
 		builder: png.GetEntitySummaryBuilder(),
 	}
-	kinds[models.StandardKindGeoJSON] = &kindValues{
+	kinds[entity.StandardKindGeoJSON] = &kindValues{
 		info:    geojson.GetEntityKindInfo(),
 		builder: geojson.GetEntitySummaryBuilder(),
 	}
-	kinds[models.StandardKindDataFrame] = &kindValues{
+	kinds[entity.StandardKindDataFrame] = &kindValues{
 		info:    dataframe.GetEntityKindInfo(),
 		builder: dataframe.GetEntitySummaryBuilder(),
 	}
-	kinds[models.StandardKindJSONObj] = &kindValues{
+	kinds[entity.StandardKindJSONObj] = &kindValues{
 		info:    jsonobj.GetEntityKindInfo(),
 		builder: jsonobj.GetEntitySummaryBuilder(),
 	}
@@ -86,20 +86,20 @@ func ProvideService(cfg *setting.Cfg, renderer rendering.Service) KindRegistry {
 }
 
 type kindValues struct {
-	info    models.EntityKindInfo
-	builder models.EntitySummaryBuilder
+	info    entity.EntityKindInfo
+	builder entity.EntitySummaryBuilder
 }
 
 type registry struct {
 	mutex  sync.RWMutex
 	kinds  map[string]*kindValues
-	info   []models.EntityKindInfo
-	suffix map[string]models.EntityKindInfo
+	info   []entity.EntityKindInfo
+	suffix map[string]entity.EntityKindInfo
 }
 
 func (r *registry) updateInfoArray() {
-	suffix := make(map[string]models.EntityKindInfo)
-	info := make([]models.EntityKindInfo, 0, len(r.kinds))
+	suffix := make(map[string]entity.EntityKindInfo)
+	info := make([]entity.EntityKindInfo, 0, len(r.kinds))
 	for _, v := range r.kinds {
 		info = append(info, v.info)
 		if v.info.FileExtension != "" {
@@ -113,7 +113,7 @@ func (r *registry) updateInfoArray() {
 	r.suffix = suffix
 }
 
-func (r *registry) Register(info models.EntityKindInfo, builder models.EntitySummaryBuilder) error {
+func (r *registry) Register(info entity.EntityKindInfo, builder entity.EntitySummaryBuilder) error {
 	if info.ID == "" || builder == nil {
 		return fmt.Errorf("invalid kind")
 	}
@@ -134,7 +134,7 @@ func (r *registry) Register(info models.EntityKindInfo, builder models.EntitySum
 }
 
 // GetSummaryBuilder returns a builder or nil if not found
-func (r *registry) GetSummaryBuilder(kind string) models.EntitySummaryBuilder {
+func (r *registry) GetSummaryBuilder(kind string) entity.EntitySummaryBuilder {
 	r.mutex.RLock()
 	defer r.mutex.RUnlock()
 
@@ -146,7 +146,7 @@ func (r *registry) GetSummaryBuilder(kind string) models.EntitySummaryBuilder {
 }
 
 // GetInfo returns the registered info
-func (r *registry) GetInfo(kind string) (models.EntityKindInfo, error) {
+func (r *registry) GetInfo(kind string) (entity.EntityKindInfo, error) {
 	r.mutex.RLock()
 	defer r.mutex.RUnlock()
 
@@ -154,11 +154,11 @@ func (r *registry) GetInfo(kind string) (models.EntityKindInfo, error) {
 	if ok {
 		return v.info, nil
 	}
-	return models.EntityKindInfo{}, fmt.Errorf("not found")
+	return entity.EntityKindInfo{}, fmt.Errorf("not found")
 }
 
 // GetInfo returns the registered info
-func (r *registry) GetFromExtension(suffix string) (models.EntityKindInfo, error) {
+func (r *registry) GetFromExtension(suffix string) (entity.EntityKindInfo, error) {
 	r.mutex.RLock()
 	defer r.mutex.RUnlock()
 
@@ -166,11 +166,11 @@ func (r *registry) GetFromExtension(suffix string) (models.EntityKindInfo, error
 	if ok {
 		return v, nil
 	}
-	return models.EntityKindInfo{}, fmt.Errorf("not found")
+	return entity.EntityKindInfo{}, fmt.Errorf("not found")
 }
 
 // GetSummaryBuilder returns a builder or nil if not found
-func (r *registry) GetKinds() []models.EntityKindInfo {
+func (r *registry) GetKinds() []entity.EntityKindInfo {
 	r.mutex.RLock()
 	defer r.mutex.RUnlock()
 

--- a/pkg/services/store/kind/registry_test.go
+++ b/pkg/services/store/kind/registry_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/store/entity"
 	"github.com/grafana/grafana/pkg/services/store/kind/dummy"
 )
 
@@ -31,7 +31,7 @@ func TestKindRegistry(t *testing.T) {
 	}, ids)
 
 	// Check playlist exists
-	info, err := registry.GetInfo(models.StandardKindPlaylist)
+	info, err := registry.GetInfo(entity.StandardKindPlaylist)
 	require.NoError(t, err)
 	require.Equal(t, "Playlist", info.Name)
 	require.False(t, info.IsRaw)

--- a/pkg/services/store/kind/snapshot/summary.go
+++ b/pkg/services/store/kind/snapshot/summary.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/store/entity"
 )
 
 // A snapshot is a dashboard with no external queries and a few additional properties
@@ -19,15 +19,15 @@ type Model struct {
 	Snapshot     json.RawMessage `json:"snapshot,omitempty"`
 }
 
-func GetEntityKindInfo() models.EntityKindInfo {
-	return models.EntityKindInfo{
-		ID:   models.StandardKindSnapshot,
+func GetEntityKindInfo() entity.EntityKindInfo {
+	return entity.EntityKindInfo{
+		ID:   entity.StandardKindSnapshot,
 		Name: "Snapshot",
 	}
 }
 
-func GetEntitySummaryBuilder() models.EntitySummaryBuilder {
-	return func(ctx context.Context, uid string, body []byte) (*models.EntitySummary, []byte, error) {
+func GetEntitySummaryBuilder() entity.EntitySummaryBuilder {
+	return func(ctx context.Context, uid string, body []byte) (*entity.EntitySummary, []byte, error) {
 		obj := &Model{}
 		err := json.Unmarshal(body, obj)
 		if err != nil {
@@ -41,8 +41,8 @@ func GetEntitySummaryBuilder() models.EntitySummaryBuilder {
 			return nil, nil, fmt.Errorf("expected delete key")
 		}
 
-		summary := &models.EntitySummary{
-			Kind:        models.StandardKindFolder,
+		summary := &entity.EntitySummary{
+			Kind:        entity.StandardKindFolder,
 			Name:        obj.Name,
 			Description: obj.Description,
 			UID:         uid,
@@ -51,8 +51,8 @@ func GetEntitySummaryBuilder() models.EntitySummaryBuilder {
 				"externalURL": obj.ExternalURL,
 				"expires":     obj.Expires,
 			},
-			References: []*models.EntityExternalReference{
-				{Kind: models.StandardKindDashboard, UID: obj.DashboardUID},
+			References: []*entity.EntityExternalReference{
+				{Kind: entity.StandardKindDashboard, UID: obj.DashboardUID},
 			},
 		}
 

--- a/pkg/services/store/kind/svg/summary.go
+++ b/pkg/services/store/kind/svg/summary.go
@@ -5,13 +5,13 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/rendering"
+	"github.com/grafana/grafana/pkg/services/store/entity"
 )
 
-func GetEntityKindInfo() models.EntityKindInfo {
-	return models.EntityKindInfo{
-		ID:            models.StandardKindSVG,
+func GetEntityKindInfo() entity.EntityKindInfo {
+	return entity.EntityKindInfo{
+		ID:            entity.StandardKindSVG,
 		Name:          "SVG",
 		Description:   "Scalable Vector Graphics",
 		IsRaw:         true,
@@ -21,8 +21,8 @@ func GetEntityKindInfo() models.EntityKindInfo {
 }
 
 // SVG sanitizer based on the rendering service
-func GetEntitySummaryBuilder(allowUnsanitizedSvgUpload bool, renderer rendering.Service) models.EntitySummaryBuilder {
-	return func(ctx context.Context, uid string, body []byte) (*models.EntitySummary, []byte, error) {
+func GetEntitySummaryBuilder(allowUnsanitizedSvgUpload bool, renderer rendering.Service) entity.EntitySummaryBuilder {
+	return func(ctx context.Context, uid string, body []byte) (*entity.EntitySummary, []byte, error) {
 		if !IsSVG(body) {
 			return nil, nil, fmt.Errorf("invalid svg")
 		}
@@ -45,8 +45,8 @@ func GetEntitySummaryBuilder(allowUnsanitizedSvgUpload bool, renderer rendering.
 			sanitized = body
 		}
 
-		return &models.EntitySummary{
-			Kind: models.StandardKindSVG,
+		return &entity.EntitySummary{
+			Kind: entity.StandardKindSVG,
 			Name: guessNameFromUID(uid),
 			UID:  uid,
 		}, sanitized, nil

--- a/pkg/services/store/resolver/service.go
+++ b/pkg/services/store/resolver/service.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/services/datasources"
+	"github.com/grafana/grafana/pkg/services/store/entity"
 )
 
 const (
@@ -28,7 +28,7 @@ type ResolutionInfo struct {
 }
 
 type EntityReferenceResolver interface {
-	Resolve(ctx context.Context, ref *models.EntityExternalReference) (ResolutionInfo, error)
+	Resolve(ctx context.Context, ref *entity.EntityExternalReference) (ResolutionInfo, error)
 }
 
 func ProvideEntityReferenceResolver(ds datasources.DataSourceService, pluginStore plugins.Store) EntityReferenceResolver {
@@ -46,19 +46,19 @@ type standardReferenceResolver struct {
 	ds          dsCache
 }
 
-func (r *standardReferenceResolver) Resolve(ctx context.Context, ref *models.EntityExternalReference) (ResolutionInfo, error) {
+func (r *standardReferenceResolver) Resolve(ctx context.Context, ref *entity.EntityExternalReference) (ResolutionInfo, error) {
 	if ref == nil {
 		return ResolutionInfo{OK: false, Timestamp: getNow()}, fmt.Errorf("ref is nil")
 	}
 
 	switch ref.Kind {
-	case models.StandardKindDataSource:
+	case entity.StandardKindDataSource:
 		return r.resolveDatasource(ctx, ref)
 
-	case models.ExternalEntityReferencePlugin:
+	case entity.ExternalEntityReferencePlugin:
 		return r.resolvePlugin(ctx, ref)
 
-		// case models.ExternalEntityReferenceRuntime:
+		// case entity.ExternalEntityReferenceRuntime:
 		// 	return ResolutionInfo{
 		// 		OK:        false,
 		// 		Timestamp: getNow(),
@@ -73,7 +73,7 @@ func (r *standardReferenceResolver) Resolve(ctx context.Context, ref *models.Ent
 	}, nil
 }
 
-func (r *standardReferenceResolver) resolveDatasource(ctx context.Context, ref *models.EntityExternalReference) (ResolutionInfo, error) {
+func (r *standardReferenceResolver) resolveDatasource(ctx context.Context, ref *entity.EntityExternalReference) (ResolutionInfo, error) {
 	ds, err := r.ds.getDS(ctx, ref.UID)
 	if err != nil || ds == nil || ds.UID == "" {
 		return ResolutionInfo{
@@ -99,7 +99,7 @@ func (r *standardReferenceResolver) resolveDatasource(ctx context.Context, ref *
 	return res, nil
 }
 
-func (r *standardReferenceResolver) resolvePlugin(ctx context.Context, ref *models.EntityExternalReference) (ResolutionInfo, error) {
+func (r *standardReferenceResolver) resolvePlugin(ctx context.Context, ref *entity.EntityExternalReference) (ResolutionInfo, error) {
 	p, ok := r.pluginStore.Plugin(ctx, ref.UID)
 	if !ok {
 		return ResolutionInfo{

--- a/pkg/services/store/resolver/service_test.go
+++ b/pkg/services/store/resolver/service_test.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/grafana/pkg/infra/appcontext"
-	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	fakeDatasources "github.com/grafana/grafana/pkg/services/datasources/fakes"
+	"github.com/grafana/grafana/pkg/services/store/entity"
 	"github.com/grafana/grafana/pkg/services/user"
-	"github.com/stretchr/testify/require"
 )
 
 func TestResolver(t *testing.T) {
@@ -49,15 +50,15 @@ func TestResolver(t *testing.T) {
 
 	scenarios := []struct {
 		name   string
-		given  *models.EntityExternalReference
+		given  *entity.EntityExternalReference
 		expect ResolutionInfo
 		err    string
 		ctx    context.Context
 	}{
 		{
 			name: "Missing datasource without type",
-			given: &models.EntityExternalReference{
-				Kind: models.StandardKindDataSource,
+			given: &entity.EntityExternalReference{
+				Kind: entity.StandardKindDataSource,
 				UID:  "xyz",
 			},
 			expect: ResolutionInfo{OK: false},
@@ -65,8 +66,8 @@ func TestResolver(t *testing.T) {
 		},
 		{
 			name: "OK datasource",
-			given: &models.EntityExternalReference{
-				Kind: models.StandardKindDataSource,
+			given: &entity.EntityExternalReference{
+				Kind: entity.StandardKindDataSource,
 				Type: "influx",
 				UID:  "influx-uid",
 			},
@@ -75,8 +76,8 @@ func TestResolver(t *testing.T) {
 		},
 		{
 			name: "Get the default datasource",
-			given: &models.EntityExternalReference{
-				Kind: models.StandardKindDataSource,
+			given: &entity.EntityExternalReference{
+				Kind: entity.StandardKindDataSource,
 			},
 			expect: ResolutionInfo{
 				OK:      true,
@@ -87,8 +88,8 @@ func TestResolver(t *testing.T) {
 		},
 		{
 			name: "Get the default datasource (with type)",
-			given: &models.EntityExternalReference{
-				Kind: models.StandardKindDataSource,
+			given: &entity.EntityExternalReference{
+				Kind: entity.StandardKindDataSource,
 				Type: "influx",
 			},
 			expect: ResolutionInfo{
@@ -99,8 +100,8 @@ func TestResolver(t *testing.T) {
 		},
 		{
 			name: "Lookup by name",
-			given: &models.EntityExternalReference{
-				Kind: models.StandardKindDataSource,
+			given: &entity.EntityExternalReference{
+				Kind: entity.StandardKindDataSource,
 				UID:  "Influx2",
 			},
 			expect: ResolutionInfo{


### PR DESCRIPTION
This is the result of `git mv ./pkg/models/entity.go ./pkg/services/store/entity/models.go` and some renaming. This was my guess at the best location, so please let me know if this doesn't make sense. 