### PR TITLE
InfluxDB: Send retention policy with InfluxQL queries if its been specified.

### DIFF
--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -403,6 +403,10 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
       params.db = this.database;
     }
 
+    if (options && options.policy) {
+      params.rp = options.policy;
+    }
+
     const { q } = data;
 
     if (method === 'POST' && has(data, 'q')) {

--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -403,7 +403,7 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
       params.db = this.database;
     }
 
-    if (options && options.policy) {
+    if (options?.policy) {
       params.rp = options.policy;
     }
 

--- a/public/app/plugins/datasource/influxdb/influxQLMetadataQuery.ts
+++ b/public/app/plugins/datasource/influxdb/influxQLMetadataQuery.ts
@@ -11,7 +11,8 @@ const runExploreQuery = (
 ): Promise<Array<{ text: string }>> => {
   const builder = new InfluxQueryBuilder(target, datasource.database);
   const q = builder.buildExploreQuery(type, withKey, withMeasurementFilter);
-  return datasource.metricFindQuery(q);
+  const options = { policy: target.policy };
+  return datasource.metricFindQuery(q, options);
 };
 
 export async function getAllPolicies(datasource: InfluxDatasource): Promise<string[]> {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

In InfluxDB v2, due to technical limitations of the InfluxDB v1 compatibility layer, retention policies in a query (e.g. `<retention policy>.<measurement_name>`) aren't honored and must be specified in the URL query parameter `rp` to be applied. Grafana doesn't send this query parameter which results in all queries resolving to the default retention policy when querying InfluxDB v2 servers using InfluxQL.

This addresses the issue by sending the `rp` query parameter for queries that have specified a retention policy in the `target` given to `runExploreQuery`.

The outcomes are:

1. InfluxQL queries executed against InfluxDB v2 databases will have the necessary retention policy information for queries like `SHOW FIELD KEYS FROM measurement` to function correctly.
2. InfluxQL queries executed against InfluxDB v1 databases will be unaffected, because this `rp` query parameter is unsupported there.

You can read more about the rentention policy mapping behavior of InfluxDB v2 in our documentation:

- https://docs.influxdata.com/influxdb/v2.6/reference/api/influxdb-1x/dbrp/#when-querying-data
- https://docs.influxdata.com/influxdb/v2.6/reference/api/influxdb-1x/query/#query-a-non-default-retention-policy

**Why do we need this feature?**

This ensures field keys only present in the default retention policy aren't displayed in the query builder for non-default retention policies.

**Who is this feature for?**

Anyone using InfluxQL to query against an InfluxDB v2 API (using v1 compatibility).

