### PR TITLE
Auth: Fix catch both both ErrInvalidAPIKey for context with APIKey

### DIFF
--- a/pkg/services/contexthandler/contexthandler.go
+++ b/pkg/services/contexthandler/contexthandler.go
@@ -306,18 +306,23 @@ func (h *ContextHandler) initContextWithAPIKey(reqContext *models.ReqContext) bo
 	*reqContext.Req = *reqContext.Req.WithContext(ctx)
 
 	var (
-		apikey *apikey.APIKey
+		aKey   *apikey.APIKey
 		errKey error
 	)
 	if strings.HasPrefix(keyString, apikeygenprefix.GrafanaPrefix) {
-		apikey, errKey = h.getPrefixedAPIKey(reqContext.Req.Context(), keyString) // decode prefixed key
+		aKey, errKey = h.getPrefixedAPIKey(reqContext.Req.Context(), keyString) // decode prefixed key
 	} else {
-		apikey, errKey = h.getAPIKey(reqContext.Req.Context(), keyString) // decode legacy api key
+		aKey, errKey = h.getAPIKey(reqContext.Req.Context(), keyString) // decode legacy api key
 	}
 
 	if errKey != nil {
 		status := http.StatusInternalServerError
 		if errors.Is(errKey, apikeygen.ErrInvalidApiKey) {
+			status = http.StatusUnauthorized
+		}
+		// this is when the getPrefixAPIKey return error form the apikey package instead of the apikeygen
+		// when called in the sqlx store methods
+		if errors.Is(errKey, apikey.ErrInvalid) {
 			status = http.StatusUnauthorized
 		}
 		reqContext.JsonApiErr(status, InvalidAPIKey, errKey)
@@ -329,12 +334,12 @@ func (h *ContextHandler) initContextWithAPIKey(reqContext *models.ReqContext) bo
 	if getTime == nil {
 		getTime = time.Now
 	}
-	if apikey.Expires != nil && *apikey.Expires <= getTime().Unix() {
+	if aKey.Expires != nil && *aKey.Expires <= getTime().Unix() {
 		reqContext.JsonApiErr(http.StatusUnauthorized, "Expired API key", nil)
 		return true
 	}
 
-	if apikey.IsRevoked != nil && *apikey.IsRevoked {
+	if aKey.IsRevoked != nil && *aKey.IsRevoked {
 		reqContext.JsonApiErr(http.StatusUnauthorized, "Revoked token", nil)
 
 		return true
@@ -350,15 +355,15 @@ func (h *ContextHandler) initContextWithAPIKey(reqContext *models.ReqContext) bo
 		if err := h.apiKeyService.UpdateAPIKeyLastUsedDate(context.Background(), id); err != nil {
 			reqContext.Logger.Warn("failed to update last use date for api key", "id", id)
 		}
-	}(apikey.Id)
+	}(aKey.Id)
 
-	if apikey.ServiceAccountId == nil || *apikey.ServiceAccountId < 1 { //There is no service account attached to the apikey
+	if aKey.ServiceAccountId == nil || *aKey.ServiceAccountId < 1 { //There is no service account attached to the apikey
 		// Use the old APIkey method.  This provides backwards compatibility.
 		// will probably have to be supported for a long time.
 		reqContext.SignedInUser = &user.SignedInUser{}
-		reqContext.OrgRole = apikey.Role
-		reqContext.ApiKeyID = apikey.Id
-		reqContext.OrgID = apikey.OrgId
+		reqContext.OrgRole = aKey.Role
+		reqContext.ApiKeyID = aKey.Id
+		reqContext.OrgID = aKey.OrgId
 		reqContext.IsSignedIn = true
 		return true
 	}
@@ -366,7 +371,7 @@ func (h *ContextHandler) initContextWithAPIKey(reqContext *models.ReqContext) bo
 	//There is a service account attached to the API key
 
 	//Use service account linked to API key as the signed in user
-	querySignedInUser := user.GetSignedInUserQuery{UserID: *apikey.ServiceAccountId, OrgID: apikey.OrgId}
+	querySignedInUser := user.GetSignedInUserQuery{UserID: *aKey.ServiceAccountId, OrgID: aKey.OrgId}
 	querySignedInUserResult, err := h.userService.GetSignedInUserWithCacheCtx(reqContext.Req.Context(), &querySignedInUser)
 	if err != nil {
 		reqContext.Logger.Error(


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
This is capturing the `apikey.ErrInvalid` error from the storage calls that was not captured before

**Why do we need this feature?**
This causes errors on our side and triggers some alerts. Requests with Invalid API keys should be considered user problems and return 401.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

This is a follow up to the previous refactoring as well - https://github.com/grafana/grafana/pull/61544

A follow up PR will be made to refactor these errors to make use of the errutil package