### PR TITLE
Chore: Let wire inject prometheus.Registerer

### DIFF
--- a/pkg/infra/metrics/service.go
+++ b/pkg/infra/metrics/service.go
@@ -6,6 +6,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/metrics/graphitebridge"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 var metricsLogger log.Logger = log.New("metrics")
@@ -53,3 +54,6 @@ func (im *InternalMetricsService) Run(ctx context.Context) error {
 	<-ctx.Done()
 	return ctx.Err()
 }
+
+func ProvideRegisterer() prometheus.Registerer        { return prometheus.DefaultRegisterer }
+func ProvideRegistererForTest() prometheus.Registerer { return prometheus.NewRegistry() }

--- a/pkg/server/wire.go
+++ b/pkg/server/wire.go
@@ -365,6 +365,7 @@ var wireBasicSet = wire.NewSet(
 
 var wireSet = wire.NewSet(
 	wireBasicSet,
+	metrics.ProvideRegisterer,
 	sqlstore.ProvideService,
 	ngmetrics.ProvideService,
 	wire.Bind(new(notifications.Service), new(*notifications.NotificationService)),
@@ -379,6 +380,7 @@ var wireSet = wire.NewSet(
 var wireTestSet = wire.NewSet(
 	wireBasicSet,
 	ProvideTestEnv,
+	metrics.ProvideRegistererForTest,
 	sqlstore.ProvideServiceForTests,
 	ngmetrics.ProvideServiceForTest,
 


### PR DESCRIPTION
We would want to let services register their own metrics into a `Registerer`. We also don't want to use the global `DefaultRegisterer` everywhere to avoid panics on registering the same metric twice. This provides the default registerer for injection in normal code and `NewRegisterer` every time in tests.