### PR TITLE
AuthN: support priority for post auth and post login hooks

### DIFF
--- a/pkg/services/authn/authn.go
+++ b/pkg/services/authn/authn.go
@@ -60,7 +60,8 @@ type Service interface {
 	// Login authenticates a request and creates a session on successful authentication.
 	Login(ctx context.Context, client string, r *Request) (*Identity, error)
 	// RegisterPostLoginHook registers a hook that that is called after a login request.
-	RegisterPostLoginHook(hook PostLoginHookFn)
+	// A lower number means higher priority.
+	RegisterPostLoginHook(hook PostLoginHookFn, priority uint)
 	// RedirectURL will generate url that we can use to initiate auth flow for supported clients.
 	RedirectURL(ctx context.Context, client string, r *Request) (string, error)
 }

--- a/pkg/services/authn/authn.go
+++ b/pkg/services/authn/authn.go
@@ -54,8 +54,9 @@ type PostLoginHookFn func(ctx context.Context, identity *Identity, r *Request, e
 type Service interface {
 	// Authenticate authenticates a request
 	Authenticate(ctx context.Context, r *Request) (*Identity, error)
-	// RegisterPostAuthHook registers a hook that is called after a successful authentication.
-	RegisterPostAuthHook(hook PostAuthHookFn)
+	// RegisterPostAuthHook registers a hook with a priority that is called after a successful authentication.
+	// A lower number means higher priority.
+	RegisterPostAuthHook(hook PostAuthHookFn, priority uint)
 	// Login authenticates a request and creates a session on successful authentication.
 	Login(ctx context.Context, client string, r *Request) (*Identity, error)
 	// RegisterPostLoginHook registers a hook that that is called after a login request.

--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -70,7 +70,7 @@ func ProvideService(
 	if cfg.LoginCookieName != "" {
 		sessionClient := clients.ProvideSession(sessionService, userService, cfg.LoginCookieName, cfg.LoginMaxLifetime)
 		s.RegisterClient(sessionClient)
-		s.RegisterPostAuthHook(sessionClient.RefreshTokenHook, 10)
+		s.RegisterPostAuthHook(sessionClient.RefreshTokenHook, 20)
 	}
 
 	if s.cfg.AnonymousEnabled {
@@ -119,7 +119,7 @@ func ProvideService(
 	// FIXME (jguer): move to User package
 	userSyncService := sync.ProvideUserSync(userService, userProtectionService, authInfoService, quotaService)
 	orgUserSyncService := sync.ProvideOrgSync(userService, orgService, accessControlService)
-	s.RegisterPostAuthHook(userSyncService.SyncUser, 20)
+	s.RegisterPostAuthHook(userSyncService.SyncUser, 10)
 	s.RegisterPostAuthHook(orgUserSyncService.SyncOrgUser, 30)
 	s.RegisterPostAuthHook(sync.ProvideUserLastSeenSync(userService).SyncLastSeen, 40)
 	s.RegisterPostAuthHook(sync.ProvideAPIKeyLastSeenSync(apikeyService).SyncLastSeen, 50)

--- a/pkg/services/authn/authnimpl/service_test.go
+++ b/pkg/services/authn/authnimpl/service_test.go
@@ -292,12 +292,13 @@ func setupTests(t *testing.T, opts ...func(svc *Service)) *Service {
 	t.Helper()
 
 	s := &Service{
-		log:           log.NewNopLogger(),
-		cfg:           setting.NewCfg(),
-		clients:       map[string]authn.Client{},
-		clientQueue:   newQueue[authn.ContextAwareClient](),
-		tracer:        tracing.InitializeTracerForTest(),
-		postAuthHooks: newQueue[authn.PostAuthHookFn](),
+		log:            log.NewNopLogger(),
+		cfg:            setting.NewCfg(),
+		clients:        map[string]authn.Client{},
+		clientQueue:    newQueue[authn.ContextAwareClient](),
+		tracer:         tracing.InitializeTracerForTest(),
+		postAuthHooks:  newQueue[authn.PostAuthHookFn](),
+		postLoginHooks: newQueue[authn.PostLoginHookFn](),
 	}
 
 	for _, o := range opts {

--- a/pkg/services/authn/authnimpl/service_test.go
+++ b/pkg/services/authn/authnimpl/service_test.go
@@ -292,11 +292,12 @@ func setupTests(t *testing.T, opts ...func(svc *Service)) *Service {
 	t.Helper()
 
 	s := &Service{
-		log:         log.NewNopLogger(),
-		cfg:         setting.NewCfg(),
-		clientQueue: newQueue[authn.ContextAwareClient](),
-		clients:     map[string]authn.Client{},
-		tracer:      tracing.InitializeTracerForTest(),
+		log:           log.NewNopLogger(),
+		cfg:           setting.NewCfg(),
+		clients:       map[string]authn.Client{},
+		clientQueue:   newQueue[authn.ContextAwareClient](),
+		tracer:        tracing.InitializeTracerForTest(),
+		postAuthHooks: newQueue[authn.PostAuthHookFn](),
 	}
 
 	for _, o := range opts {


### PR DESCRIPTION
**What is this feature?**
We want to be able to move out all sync hooks from the authn package and the order could matter for some hooks.

Reuse the priority queue implementation for post auth/login hooks

Fixes #

**Special notes for your reviewer**:

