### PR TITLE
[Navigation] Add user events for quick actions/dashboard actions

### DIFF
--- a/public/app/core/components/AppChrome/QuickAdd/QuickAdd.tsx
+++ b/public/app/core/components/AppChrome/QuickAdd/QuickAdd.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/css';
 import React, { useMemo, useState } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
+import { reportInteraction } from '@grafana/runtime';
 import { Menu, Dropdown, useStyles2, useTheme2, ToolbarButton } from '@grafana/ui';
 import { useMediaQueryChange } from 'app/core/hooks/useMediaQueryChange';
 import { useSelector } from 'app/types';
@@ -32,7 +33,12 @@ export const QuickAdd = ({}: Props) => {
     return (
       <Menu>
         {createActions.map((createAction, index) => (
-          <Menu.Item key={index} url={createAction.url} label={createAction.text} />
+          <Menu.Item
+            key={index}
+            url={createAction.url}
+            label={createAction.text}
+            onClick={() => reportInteraction('grafana_menu_item_clicked', { url: createAction.url, from: 'quickadd' })}
+          />
         ))}
       </Menu>
     );

--- a/public/app/features/search/components/DashboardActions.tsx
+++ b/public/app/features/search/components/DashboardActions.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react';
 
-import { config } from '@grafana/runtime';
+import { config, reportInteraction } from '@grafana/runtime';
 import { Menu, Dropdown, Button, Icon } from '@grafana/ui';
 import { t } from 'app/core/internationalization';
 
@@ -30,13 +30,31 @@ export const DashboardActions: FC<Props> = ({ folderUid, canCreateFolders = fals
     return (
       <Menu>
         {canCreateDashboards && (
-          <Menu.Item url={actionUrl('new')} label={t('search.dashboard-actions.new-dashboard', 'New Dashboard')} />
+          <Menu.Item
+            url={actionUrl('new')}
+            label={t('search.dashboard-actions.new-dashboard', 'New Dashboard')}
+            onClick={() =>
+              reportInteraction('grafana_menu_item_clicked', { url: actionUrl('new'), from: '/dashboards' })
+            }
+          />
         )}
         {canCreateFolders && (config.featureToggles.nestedFolders || !folderUid) && (
-          <Menu.Item url={actionUrl('new_folder')} label={t('search.dashboard-actions.new-folder', 'New Folder')} />
+          <Menu.Item
+            url={actionUrl('new_folder')}
+            label={t('search.dashboard-actions.new-folder', 'New Folder')}
+            onClick={() =>
+              reportInteraction('grafana_menu_item_clicked', { url: actionUrl('new_folder'), from: '/dashboards' })
+            }
+          />
         )}
         {canCreateDashboards && (
-          <Menu.Item url={actionUrl('import')} label={t('search.dashboard-actions.import', 'Import')} />
+          <Menu.Item
+            url={actionUrl('import')}
+            label={t('search.dashboard-actions.import', 'Import')}
+            onClick={() =>
+              reportInteraction('grafana_menu_item_clicked', { url: actionUrl('import'), from: '/dashboards' })
+            }
+          />
         )}
       </Menu>
     );


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Adding tracking to compare compare "new dashboard" clicks on old navigation and "quick action" ones in topnav.
I also added a few events for the same actions coming from the `/dashboard` page.

**Why do we need this feature?**

We are planning a gradual rollout of Topnav, monitoring its impacton the instances we switched on. This event gives us visibility.

**Who is this feature for?**

internal

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

Should this be added to changelog? Always confused about tracking stuff ;)

I will we should add events for secondary nav items too. Could be done in a separate PR