### PR TITLE
Datasources: Add the props for the "add datasource" event

### DIFF
--- a/public/app/features/datasources/state/actions.test.ts
+++ b/public/app/features/datasources/state/actions.test.ts
@@ -6,6 +6,7 @@ import { ThunkResult, ThunkDispatch } from 'app/types';
 
 import { getMockDataSource } from '../__mocks__';
 import * as api from '../api';
+import { DATASOURCES_ROUTES } from '../constants';
 import { trackDataSourceCreated, trackDataSourceTested } from '../tracking';
 import { GenericDataSourcePlugin } from '../types';
 
@@ -357,6 +358,7 @@ describe('addDataSource', () => {
       plugin_version: '1.2.3',
       datasource_uid: 'azure23',
       grafana_version: '1.0',
+      editLink: DATASOURCES_ROUTES.Edit.replace(':uid', 'azure23'),
     });
   });
 });

--- a/public/app/features/datasources/state/actions.ts
+++ b/public/app/features/datasources/state/actions.ts
@@ -189,7 +189,7 @@ export function loadDataSourceMeta(dataSource: DataSourceSettings): ThunkResult<
   };
 }
 
-export function addDataSource(plugin: DataSourcePluginMeta, editLink = DATASOURCES_ROUTES.Edit): ThunkResult<void> {
+export function addDataSource(plugin: DataSourcePluginMeta, editRoute = DATASOURCES_ROUTES.Edit): ThunkResult<void> {
   return async (dispatch, getStore) => {
     await dispatch(loadDataSources());
 
@@ -207,6 +207,7 @@ export function addDataSource(plugin: DataSourcePluginMeta, editLink = DATASOURC
     }
 
     const result = await api.createDataSource(newInstance);
+    const editLink = editRoute.replace(/:uid/gi, result.datasource.uid);
 
     await getDatasourceSrv().reload();
     await contextSrv.fetchUserPermissions();
@@ -216,9 +217,10 @@ export function addDataSource(plugin: DataSourcePluginMeta, editLink = DATASOURC
       plugin_id: plugin.id,
       datasource_uid: result.datasource.uid,
       plugin_version: result.meta?.info?.version,
+      editLink,
     });
 
-    locationService.push(editLink.replace(/:uid/gi, result.datasource.uid));
+    locationService.push(editLink);
   };
 }
 

--- a/public/app/features/datasources/tracking.ts
+++ b/public/app/features/datasources/tracking.ts
@@ -24,6 +24,8 @@ type DataSourceCreatedProps = {
   plugin_id: string;
   /** The plugin version (especially interesting in external plugins - core plugins are aligned with grafana version) */
   plugin_version?: string;
+  /** The URL that points to the edit page for the datasoruce. We are using this to be able to distinguish between the performance of different datasource edit locations. */
+  editLink?: string;
 };
 
 /**


### PR DESCRIPTION
### What changed?
Extended the properties for the `grafana_ds_add_datasource_clicked` event with `editLink`. As we are experimenting with a new place for managing datasources (Connections) we would like to be able to distinguish between the metrics that come from the old vs. new (Connections) place.

**Notes for the reviewer**
Probably the property name `editLink` is not the best. I am up for tuning that.