### PR TITLE
Elasticsearch: Deprecate raw document mode

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/utils.ts
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/utils.ts
@@ -191,7 +191,7 @@ export const metricAggregationConfig: MetricsConfiguration = {
     },
   },
   raw_document: {
-    label: 'Raw Document (legacy)',
+    label: 'Raw Document (deprecated)',
     requiresField: false,
     isSingleMetric: true,
     isPipelineAgg: false,


### PR DESCRIPTION
fixes https://github.com/grafana/grafana/issues/62197

two and a half years ago we marked the "raw document" mode as legacy and provided the new "raw data" option. we are marking this mode deprecated.

# Deprecation notice

In the elasticsearch data source, the "Raw document" display mode is deprecated. We recommend  using the "Raw Data" mode instead.