### PR TITLE
Loki Docker Devenv: Fix undefined variable in error message

### DIFF
--- a/devenv/docker/blocks/loki/data/data.js
+++ b/devenv/docker/blocks/loki/data/data.js
@@ -96,7 +96,7 @@ function escapeLogFmtKey(key) {
 
 function escapeLogFmtValue(value) {
   if (logFmtProblemRe.test(value)) {
-    throw new Error(`invalid logfmt-value: ${key}`)
+    throw new Error(`invalid logfmt-value: ${value}`)
   }
 
   // we must handle the space-character because we have values with spaces :-(


### PR DESCRIPTION
Found while generating test data, the error message produced a ReferenceError due to the variable name.

![error](https://user-images.githubusercontent.com/1069378/214881952-b09c8beb-4cb2-4b45-86af-8af3f62b0b43.png)
