### PR TITLE
Search: Remember sorting preference between visits

### DIFF
--- a/public/app/features/search/constants.ts
+++ b/public/app/features/search/constants.ts
@@ -11,6 +11,7 @@ export const GENERAL_FOLDER_UID = 'general';
 export const GENERAL_FOLDER_TITLE = 'General';
 export const SEARCH_PANELS_LOCAL_STORAGE_KEY = 'grafana.search.include.panels';
 export const SEARCH_SELECTED_LAYOUT = 'grafana.search.layout';
+export const SEARCH_SELECTED_SORT = 'grafana.search.sort';
 export const TYPE_KIND_MAP: { [key: string]: DashboardSearchItemType } = {
   dashboard: DashboardSearchItemType.DashDB,
   folder: DashboardSearchItemType.DashFolder,

--- a/public/app/features/search/state/SearchStateManager.ts
+++ b/public/app/features/search/state/SearchStateManager.ts
@@ -6,7 +6,7 @@ import { TermCount } from 'app/core/components/TagFilter/TagFilter';
 import { StateManagerBase } from 'app/core/services/StateManagerBase';
 import store from 'app/core/store';
 
-import { SEARCH_PANELS_LOCAL_STORAGE_KEY, SEARCH_SELECTED_LAYOUT } from '../constants';
+import { SEARCH_PANELS_LOCAL_STORAGE_KEY, SEARCH_SELECTED_LAYOUT, SEARCH_SELECTED_SORT } from '../constants';
 import {
   reportDashboardListViewed,
   reportSearchFailedQueryInteraction,
@@ -113,6 +113,10 @@ export class SearchStateManager extends StateManagerBase<SearchState> {
   };
 
   onSortChange = (sort: string | undefined) => {
+    if (sort) {
+      localStorage.setItem(SEARCH_SELECTED_SORT, sort);
+    }
+
     if (this.state.layout === SearchLayout.Folders) {
       this.setStateAndDoSearch({ sort, layout: SearchLayout.List });
     } else {
@@ -260,13 +264,14 @@ export function getSearchStateManager() {
   if (!stateManager) {
     const selectedLayout = localStorage.getItem(SEARCH_SELECTED_LAYOUT) as SearchLayout;
     const layout = selectedLayout ?? initialState.layout;
+    const sort = localStorage.getItem(SEARCH_SELECTED_SORT) ?? undefined;
 
     let includePanels = store.getBool(SEARCH_PANELS_LOCAL_STORAGE_KEY, true);
     if (includePanels) {
       includePanels = false;
     }
 
-    stateManager = new SearchStateManager({ ...initialState, layout: layout, includePanels });
+    stateManager = new SearchStateManager({ ...initialState, layout, sort, includePanels });
   }
 
   return stateManager;


### PR DESCRIPTION
**What is this feature?**

Persists user's sort preference to local storage so it remembers what they used last time.

**Why do we need this feature?**

For users who frequently use the non-default search preference, it's frustrating to have this reset each time you search for a dashboard.

**Who is this feature for?**

Everyone, but especially enterprise (which has more sorting options) and instalations with lots and lots of dashboards.

**Which issue(s) does this PR fix?**:

Fixes #62023
