### PR TITLE
Dashboard: Add value format for requests per minute

### DIFF
--- a/devenv/dev-dashboards-without-uid/panel_tests_polystat.json
+++ b/devenv/dev-dashboards-without-uid/panel_tests_polystat.json
@@ -1776,6 +1776,10 @@
               "value": "opm"
             },
             {
+              "text": "requests/min (rpm)",
+              "value": "reqpm"
+            },
+            {
               "text": "reads/min (rpm)",
               "value": "rpm"
             },

--- a/devenv/dev-dashboards/panel-polystat/polystat_test.json
+++ b/devenv/dev-dashboards/panel-polystat/polystat_test.json
@@ -2867,6 +2867,10 @@
               "value": "opm"
             },
             {
+              "text": "requests/min (rpm)",
+              "value": "reqpm"
+            },
+            {
               "text": "reads/min (rpm)",
               "value": "rpm"
             },

--- a/packages/grafana-data/src/valueFormats/categories.ts
+++ b/packages/grafana-data/src/valueFormats/categories.ts
@@ -383,6 +383,7 @@ export const getCategories = (): ValueFormatCategory[] => [
       { name: 'I/O ops/sec (iops)', id: 'iops', fn: simpleCountUnit('io/s') },
       { name: 'counts/min (cpm)', id: 'cpm', fn: simpleCountUnit('c/m') },
       { name: 'ops/min (opm)', id: 'opm', fn: simpleCountUnit('ops/m') },
+      { name: 'requests/min (rpm)', id: 'reqpm', fn: simpleCountUnit('req/m') },
       { name: 'reads/min (rpm)', id: 'rpm', fn: simpleCountUnit('rd/m') },
       { name: 'writes/min (wpm)', id: 'wpm', fn: simpleCountUnit('wr/m') },
     ],


### PR DESCRIPTION
**What is this feature?**

Add value format for throughput: requests per minute (rpm).

**Why do we need this feature?**

We have a lot of graphs that use `rpm` instead of `rps`. This allows us to use the right formatting.

**Who is this feature for?**

Anyone building dashboards.

**Which issue(s) does this PR fix?**:

N/A