### PR TITLE
Alerting: Update state manager to return StateTransitions when Delete or Reset

### DIFF
--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 
 	alertingModels "github.com/grafana/alerting/alerting/models"
+
 	"github.com/grafana/grafana/pkg/services/quota"
 	"github.com/grafana/grafana/pkg/util/cmputil"
 )
@@ -111,6 +112,7 @@ const (
 	StateReasonError         = "Error"
 	StateReasonPaused        = "Paused"
 	StateReasonUpdated       = "Updated"
+	StateReasonRuleDeleted   = "RuleDeleted"
 )
 
 var (

--- a/pkg/services/ngalert/schedule/compat.go
+++ b/pkg/services/ngalert/schedule/compat.go
@@ -15,6 +15,7 @@ import (
 	"github.com/prometheus/common/model"
 
 	alertingModels "github.com/grafana/alerting/alerting/models"
+
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
 	ngModels "github.com/grafana/grafana/pkg/services/ngalert/models"
@@ -152,16 +153,16 @@ func FromStateTransitionToPostableAlerts(firingStates []state.StateTransition, s
 	return alerts
 }
 
-// FromAlertsStateToStoppedAlert converts firingStates that have evaluation state either eval.Alerting or eval.NoData or eval.Error to models.PostableAlert that are accepted by notifiers.
-// Returns a list of alert instances that have expiration time.Now
-func FromAlertsStateToStoppedAlert(firingStates []*state.State, appURL *url.URL, clock clock.Clock) apimodels.PostableAlerts {
+// FromAlertsStateToStoppedAlert selects only transitions from firing states (states eval.Alerting, eval.NoData, eval.Error)
+// and converts them to models.PostableAlert with EndsAt set to time.Now
+func FromAlertsStateToStoppedAlert(firingStates []state.StateTransition, appURL *url.URL, clock clock.Clock) apimodels.PostableAlerts {
 	alerts := apimodels.PostableAlerts{PostableAlerts: make([]models.PostableAlert, 0, len(firingStates))}
 	ts := clock.Now()
-	for _, alertState := range firingStates {
-		if alertState.State == eval.Normal || alertState.State == eval.Pending {
+	for _, transition := range firingStates {
+		if transition.PreviousState == eval.Normal || transition.PreviousState == eval.Pending {
 			continue
 		}
-		postableAlert := stateToPostableAlert(alertState, appURL)
+		postableAlert := stateToPostableAlert(transition.State, appURL)
 		postableAlert.EndsAt = strfmt.DateTime(ts)
 		alerts.PostableAlerts = append(alerts.PostableAlerts, *postableAlert)
 	}


### PR DESCRIPTION

**What is this feature?**
PR #58867 updated state manager's method ProcessEvalResults to return StateTransitions, and skipped method ResetStateByRuleUID because at that time the transition was not needed. However, in PR #60734 we updated that method and introduced a Delete method that returns just State. 
The Reset method was updated to notify the historian about the transition from state X to state Normal with reasons either `Paused` or `Updated`. The Reset method had to copy the state to keep the logic in scheduler intact, and we agreed that we will follow up with a PR to change that.
This PR updates the state manager's method Delete and Reset to return StateTransition from the current state to Normal. Also, it updates the logic that converts the deleted states to an expired alert to use the transition.

