### PR TITLE
Prometheus: Fix "-Instant" string showing up in prometheus instant query UI 

### DIFF
--- a/public/app/features/explore/PrometheusListView/ItemLabels.tsx
+++ b/public/app/features/explore/PrometheusListView/ItemLabels.tsx
@@ -4,6 +4,8 @@ import React from 'react';
 import { Field, GrafanaTheme2 } from '@grafana/data/';
 import { useStyles2 } from '@grafana/ui/';
 
+import { InstantQueryRefIdIndex } from '../../../plugins/datasource/prometheus/datasource';
+
 import { rawListItemColumnWidth } from './RawListItem';
 
 const getItemLabelsStyles = (theme: GrafanaTheme2, expanded: boolean) => {
@@ -22,14 +24,22 @@ const getItemLabelsStyles = (theme: GrafanaTheme2, expanded: boolean) => {
   };
 };
 
+const formatValueName = (name: string): string => {
+  if (name.includes(InstantQueryRefIdIndex)) {
+    return name.replace(InstantQueryRefIdIndex, '');
+  }
+  return name;
+};
+
 export const ItemLabels = ({ valueLabels, expanded }: { valueLabels: Field[]; expanded: boolean }) => {
   const styles = useStyles2((theme) => getItemLabelsStyles(theme, expanded));
+
   return (
     <div className={styles.itemLabelsWrap}>
       <div className={styles.valueNavigationWrapper}>
         {valueLabels.map((value, index) => (
           <span className={styles.valueNavigation} key={value.name}>
-            {value.name}
+            {formatValueName(value.name)}
           </span>
         ))}
       </div>

--- a/public/app/plugins/datasource/prometheus/datasource.tsx
+++ b/public/app/plugins/datasource/prometheus/datasource.tsx
@@ -70,6 +70,8 @@ import { PrometheusVariableSupport } from './variables';
 const ANNOTATION_QUERY_STEP_DEFAULT = '60s';
 const GET_AND_POST_METADATA_ENDPOINTS = ['api/v1/query', 'api/v1/query_range', 'api/v1/series', 'api/v1/labels'];
 
+export const InstantQueryRefIdIndex = '-Instant';
+
 export class PrometheusDatasource
   extends DataSourceWithBackend<PromQuery, PromOptions>
   implements DataSourceWithQueryImportSupport<PromQuery>, DataSourceWithQueryExportSupport<PromQuery>
@@ -430,7 +432,7 @@ export class PrometheusDatasource
         },
         {
           ...processedTarget,
-          refId: processedTarget.refId + '-Instant',
+          refId: processedTarget.refId + InstantQueryRefIdIndex,
           range: false,
         }
       );


### PR DESCRIPTION
**What is this feature?**
Unintended consequence of https://github.com/grafana/grafana/pull/60928.
Removes "-Instant" string from showing up in Prometheus Explore UI.

**Why do we need this feature?**
This string wasn't meant to show in the UI, unnecessarily taking up space and cluttering UI.

**Who is this feature for?**
Prometheus Explore users making instant queries. 

**Which issue(s) does this PR fix?**:
TBD
Fixes 

**Special notes for your reviewer**:

