### PR TITLE
Explore: Remove extra query from core component

### DIFF
--- a/public/app/features/query/components/QueryEditorRows.tsx
+++ b/public/app/features/query/components/QueryEditorRows.tsx
@@ -20,7 +20,7 @@ interface Props {
   dsSettings: DataSourceInstanceSettings;
 
   // Query editing
-  onQueriesChange: (queries: DataQuery[]) => void;
+  onQueriesChange: (queries: DataQuery[], newDatasource?: DataSourceInstanceSettings, index?: number) => void;
   onAddQuery: (query: DataQuery) => void;
   onRunQueries: () => void;
 
@@ -34,7 +34,6 @@ interface Props {
   onQueryCopied?: () => void;
   onQueryRemoved?: () => void;
   onQueryToggled?: (queryStatus?: boolean | undefined) => void;
-  onDatasourceChange?: (dataSource: DataSourceInstanceSettings, query: DataQuery) => void;
 }
 
 export class QueryEditorRows extends PureComponent<Props> {
@@ -58,10 +57,6 @@ export class QueryEditorRows extends PureComponent<Props> {
 
   onDataSourceChange(dataSource: DataSourceInstanceSettings, index: number) {
     const { queries, onQueriesChange } = this.props;
-
-    if (this.props.onDatasourceChange) {
-      this.props.onDatasourceChange(dataSource, queries[index]);
-    }
 
     onQueriesChange(
       queries.map((item, itemIndex) => {
@@ -90,7 +85,9 @@ export class QueryEditorRows extends PureComponent<Props> {
           hide: item.hide,
           datasource: dataSourceRef,
         };
-      })
+      }),
+      dataSource,
+      index
     );
   }
 


### PR DESCRIPTION
**What is this feature?**

In explore, when changing datasources, we run an importQueries function that will try to convert the query from the previous datasource to the selected one. A good example of this is Loki and Prometheus, where you can make a query in one and it will keep the query when you go between them.

Adding mixed datasources to explore meant that we don't just do this at the root level, we will need to be sure query importing happens when changing datasources at the query level. As written, the datasource change in `QueryEditorRows` does some modification of the queries without running any import logic. The previous implementation got around this by adding an optional function that would be called before the modification took place. This could lead to other problems, however, so we need to find a solution that is outside the core component and is smarter about changing queries in state.

The only modification to the core component as part of this change is to pass forward the selected datasource and the index of the query that was changed when a datasource change occurs. These are both important for making sure the correct query is imported to the correct datasource. 

**Why do we need this feature?**

There was [concern](https://github.com/grafana/grafana/commit/38c1f3d054ef7ea1a86b41437004fdbe72505e3e#r98141493) that creating two callbacks that change query state will cause issues. This only works because the timing just so happens to work out, which is not dependable.

With this change, we no longer have two functions that change state, but to be honest the different return parameters defining if the onChange is a result of a datasource change or not (`QueryEditorRows` calls `onQueriesChange` in several places) seems hacky. I'd definitely take any advice on how best to tell the callback that the change was the result of a datasource change.

**Which issue(s) does this PR fix?**:
Fixes #62261

**Special notes for your reviewer**:
Replication steps in Explore. Mixed datasources feature flag must be enabled.

1. Have loki ds, two different queries
1. Change to prom ds, queries both convert
1. Change to loki ds, queries both convert. queries can be imported back and forth from prometheus and loki
1. Change to mixed ds, show two prometheus queries
1. Change top query to loki, without the other `onDatasourceChange` function and without this change, it does not convert.

