### PR TITLE
Chore: uPlot 1.6.24

### DIFF
--- a/package.json
+++ b/package.json
@@ -409,7 +409,7 @@
     "tether-drop": "https://github.com/torkelo/drop",
     "tinycolor2": "1.4.2",
     "tslib": "2.4.1",
-    "uplot": "1.6.23",
+    "uplot": "1.6.24",
     "uuid": "9.0.0",
     "vendor": "link:./public/vendor",
     "visjs-network": "4.25.0",

--- a/packages/grafana-data/package.json
+++ b/packages/grafana-data/package.json
@@ -54,7 +54,7 @@
     "rxjs": "7.5.7",
     "tinycolor2": "1.4.2",
     "tslib": "2.4.1",
-    "uplot": "1.6.23",
+    "uplot": "1.6.24",
     "xss": "1.0.14"
   },
   "devDependencies": {

--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -109,7 +109,7 @@
     "slate-react": "0.22.10",
     "tinycolor2": "1.4.2",
     "tslib": "2.4.1",
-    "uplot": "1.6.23",
+    "uplot": "1.6.24",
     "uuid": "9.0.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4640,7 +4640,7 @@ __metadata:
     tinycolor2: 1.4.2
     tslib: 2.4.1
     typescript: 4.8.4
-    uplot: 1.6.23
+    uplot: 1.6.24
     xss: 1.0.14
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
@@ -5170,7 +5170,7 @@ __metadata:
     tinycolor2: 1.4.2
     tslib: 2.4.1
     typescript: 4.8.4
-    uplot: 1.6.23
+    uplot: 1.6.24
     uuid: 9.0.0
     webpack: 5.74.0
   peerDependencies:
@@ -21945,7 +21945,7 @@ __metadata:
     ts-node: 10.9.1
     tslib: 2.4.1
     typescript: 4.8.4
-    uplot: 1.6.23
+    uplot: 1.6.24
     uuid: 9.0.0
     vendor: "link:./public/vendor"
     visjs-network: 4.25.0
@@ -37952,10 +37952,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uplot@npm:1.6.23":
-  version: 1.6.23
-  resolution: "uplot@npm:1.6.23"
-  checksum: 4fd2b6340b09f8cbff5c136238962c4e31621267a17c321e0183d021c72338973ba16fd943858248983edc4cf9307e352f99e806b6ffb5eaff7a132adaff2bff
+"uplot@npm:1.6.24":
+  version: 1.6.24
+  resolution: "uplot@npm:1.6.24"
+  checksum: 253e389dc6db40e1231d1c63913dea1e6987856cfde985da036e70786ef0077afc40f3ed6883c54d95a97ecedc3ea52a7fa815e88f3c3d381b61c15e745f8a40
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
needed to unblock fixes for:

https://github.com/grafana/grafana/pull/60768
https://github.com/grafana/grafana/issues/61866
https://github.com/grafana/grafana/issues/61833

nothing seemed broken in manual gdev testing.

one thing to maybe watch out for is that uPlot now adds a capturing event listener to the plotting area that prevents mouseclick events from occurring at the end of a drag. this could potentially impact some apps that for some reason directly bound `click` listeners to `.u-wrap` or `.u-over` and expected them to occur after drag end. this click prevention can be disabled via opts if it becomes problematic [1].

drag-click related things to test for this is maybe zooming, adding range annotations, dragging alert threshold handles?

[1] https://github.com/leeoniya/uPlot/commit/0322e5feb74fbcc337c2b11bdad31acbab646027