### PR TITLE
API: don't re-add /api suffix to grafana.com API URL

### DIFF
--- a/pkg/api/grafana_com_proxy.go
+++ b/pkg/api/grafana_com_proxy.go
@@ -23,15 +23,15 @@ var grafanaComProxyTransport = &http.Transport{
 	TLSHandshakeTimeout: 10 * time.Second,
 }
 
-func ReverseProxyGnetReq(logger log.Logger, proxyPath string, version string, grafanaComUrl string) *httputil.ReverseProxy {
-	url, _ := url.Parse(grafanaComUrl)
+func ReverseProxyGnetReq(logger log.Logger, proxyPath string, version string, grafanaComAPIUrl string) *httputil.ReverseProxy {
+	url, _ := url.Parse(grafanaComAPIUrl)
 
 	director := func(req *http.Request) {
 		req.URL.Scheme = url.Scheme
 		req.URL.Host = url.Host
 		req.Host = url.Host
 
-		req.URL.Path = util.JoinURLFragments(url.Path+"/api", proxyPath)
+		req.URL.Path = util.JoinURLFragments(url.Path, proxyPath)
 
 		// clear cookie headers
 		req.Header.Del("Cookie")


### PR DESCRIPTION
The old GrafanaComURL setting didn't have the /api suffix so needed it
adding on by the proxy director, but the new GrafanaComAPIURL setting is
assumed to already point directly to the API and doesn't need an
additional suffix.

This is the only place in the codebase that GrafanaComAPIURL is used.
