### PR TITLE
Alerting: Use nullable is_paused field in API

### DIFF
--- a/pkg/services/ngalert/api/api_provisioning_test.go
+++ b/pkg/services/ngalert/api/api_provisioning_test.go
@@ -575,6 +575,7 @@ func createTestAlertRule(title string, orgID int64) definitions.ProvisionedAlert
 		For:          model.Duration(60),
 		NoDataState:  models.OK,
 		ExecErrState: models.OkErrState,
+		IsPaused:     false,
 	}
 }
 

--- a/pkg/services/ngalert/api/tooling/api.json
+++ b/pkg/services/ngalert/api/tooling/api.json
@@ -3158,7 +3158,6 @@
    "type": "object"
   },
   "URL": {
-   "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use RawPath, an optional field which only gets\nset if the default encoding is different from Path.\n\nURL's String method uses the EscapedPath method to obtain the path. See the\nEscapedPath method for more details.",
    "properties": {
     "ForceQuery": {
      "type": "boolean"
@@ -3194,7 +3193,7 @@
      "$ref": "#/definitions/Userinfo"
     }
    },
-   "title": "A URL represents a parsed URL (technically, a URI reference).",
+   "title": "URL is a custom URL type that allows validation at configuration load time.",
    "type": "object"
   },
   "Userinfo": {
@@ -3371,6 +3370,7 @@
    "type": "object"
   },
   "alertGroup": {
+   "description": "AlertGroup alert group",
    "properties": {
     "alerts": {
      "description": "alerts",
@@ -3607,6 +3607,7 @@
    "type": "object"
   },
   "gettableSilences": {
+   "description": "GettableSilences gettable silences",
    "items": {
     "$ref": "#/definitions/gettableSilence"
    },
@@ -3795,6 +3796,7 @@
    "type": "object"
   },
   "receiver": {
+   "description": "Receiver receiver",
    "properties": {
     "active": {
      "description": "active",

--- a/pkg/services/ngalert/api/tooling/api.json
+++ b/pkg/services/ngalert/api/tooling/api.json
@@ -2157,6 +2157,10 @@
      "format": "int64",
      "type": "integer"
     },
+    "isPaused": {
+     "example": false,
+     "type": "boolean"
+    },
     "labels": {
      "additionalProperties": {
       "type": "string"
@@ -3158,6 +3162,7 @@
    "type": "object"
   },
   "URL": {
+   "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use RawPath, an optional field which only gets\nset if the default encoding is different from Path.\n\nURL's String method uses the EscapedPath method to obtain the path. See the\nEscapedPath method for more details.",
    "properties": {
     "ForceQuery": {
      "type": "boolean"
@@ -3193,7 +3198,7 @@
      "$ref": "#/definitions/Userinfo"
     }
    },
-   "title": "URL is a custom URL type that allows validation at configuration load time.",
+   "title": "A URL represents a parsed URL (technically, a URI reference).",
    "type": "object"
   },
   "Userinfo": {
@@ -3370,7 +3375,6 @@
    "type": "object"
   },
   "alertGroup": {
-   "description": "AlertGroup alert group",
    "properties": {
     "alerts": {
      "description": "alerts",
@@ -3394,6 +3398,7 @@
    "type": "object"
   },
   "alertGroups": {
+   "description": "AlertGroups alert groups",
    "items": {
     "$ref": "#/definitions/alertGroup"
    },
@@ -3498,6 +3503,7 @@
    "type": "object"
   },
   "gettableAlert": {
+   "description": "GettableAlert gettable alert",
    "properties": {
     "annotations": {
      "$ref": "#/definitions/labelSet"
@@ -3607,14 +3613,12 @@
    "type": "object"
   },
   "gettableSilences": {
-   "description": "GettableSilences gettable silences",
    "items": {
     "$ref": "#/definitions/gettableSilence"
    },
    "type": "array"
   },
   "integration": {
-   "description": "Integration integration",
    "properties": {
     "lastNotifyAttempt": {
      "description": "A timestamp indicating the last attempt to deliver a notification regardless of the outcome.\nFormat: date-time",

--- a/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
+++ b/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
@@ -374,7 +374,7 @@ type PostableGrafanaRule struct {
 	UID          string              `json:"uid" yaml:"uid"`
 	NoDataState  NoDataState         `json:"no_data_state" yaml:"no_data_state"`
 	ExecErrState ExecutionErrorState `json:"exec_err_state" yaml:"exec_err_state"`
-	IsPaused     bool                `json:"is_paused" yaml:"is_paused"`
+	IsPaused     *bool               `json:"is_paused" yaml:"is_paused"`
 }
 
 // swagger:model

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_alert_rules.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_alert_rules.go
@@ -111,6 +111,8 @@ type ProvisionedAlertRule struct {
 	Labels map[string]string `json:"labels,omitempty"`
 	// readonly: true
 	Provenance models.Provenance `json:"provenance,omitempty"`
+	// example: false
+	IsPaused bool `json:"isPaused"`
 }
 
 func (a *ProvisionedAlertRule) UpstreamModel() (models.AlertRule, error) {
@@ -129,6 +131,7 @@ func (a *ProvisionedAlertRule) UpstreamModel() (models.AlertRule, error) {
 		For:          time.Duration(a.For),
 		Annotations:  a.Annotations,
 		Labels:       a.Labels,
+		IsPaused:     &a.IsPaused,
 	}, nil
 }
 
@@ -149,6 +152,7 @@ func NewAlertRule(rule models.AlertRule, provenance models.Provenance) Provision
 		Annotations:  rule.Annotations,
 		Labels:       rule.Labels,
 		Provenance:   provenance,
+		IsPaused:     *rule.IsPaused,
 	}
 }
 

--- a/pkg/services/ngalert/api/tooling/post.json
+++ b/pkg/services/ngalert/api/tooling/post.json
@@ -2157,6 +2157,10 @@
      "format": "int64",
      "type": "integer"
     },
+    "isPaused": {
+     "example": false,
+     "type": "boolean"
+    },
     "labels": {
      "additionalProperties": {
       "type": "string"
@@ -3370,6 +3374,7 @@
    "type": "object"
   },
   "alertGroup": {
+   "description": "AlertGroup alert group",
    "properties": {
     "alerts": {
      "description": "alerts",
@@ -3497,6 +3502,7 @@
    "type": "object"
   },
   "gettableAlert": {
+   "description": "GettableAlert gettable alert",
    "properties": {
     "annotations": {
      "$ref": "#/definitions/labelSet"
@@ -3558,6 +3564,7 @@
    "type": "array"
   },
   "gettableSilence": {
+   "description": "GettableSilence gettable silence",
    "properties": {
     "comment": {
      "description": "comment",
@@ -3612,7 +3619,6 @@
    "type": "array"
   },
   "integration": {
-   "description": "Integration integration",
    "properties": {
     "lastNotifyAttempt": {
      "description": "A timestamp indicating the last attempt to deliver a notification regardless of the outcome.\nFormat: date-time",
@@ -3756,7 +3762,6 @@
    "type": "array"
   },
   "postableSilence": {
-   "description": "PostableSilence postable silence",
    "properties": {
     "comment": {
      "description": "comment",

--- a/pkg/services/ngalert/api/tooling/post.json
+++ b/pkg/services/ngalert/api/tooling/post.json
@@ -3158,7 +3158,6 @@
    "type": "object"
   },
   "URL": {
-   "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use RawPath, an optional field which only gets\nset if the default encoding is different from Path.\n\nURL's String method uses the EscapedPath method to obtain the path. See the\nEscapedPath method for more details.",
    "properties": {
     "ForceQuery": {
      "type": "boolean"
@@ -3194,7 +3193,7 @@
      "$ref": "#/definitions/Userinfo"
     }
    },
-   "title": "A URL represents a parsed URL (technically, a URI reference).",
+   "title": "URL is a custom URL type that allows validation at configuration load time.",
    "type": "object"
   },
   "Userinfo": {
@@ -3371,7 +3370,6 @@
    "type": "object"
   },
   "alertGroup": {
-   "description": "AlertGroup alert group",
    "properties": {
     "alerts": {
      "description": "alerts",
@@ -3395,7 +3393,6 @@
    "type": "object"
   },
   "alertGroups": {
-   "description": "AlertGroups alert groups",
    "items": {
     "$ref": "#/definitions/alertGroup"
    },
@@ -3609,7 +3606,6 @@
    "type": "object"
   },
   "gettableSilences": {
-   "description": "GettableSilences gettable silences",
    "items": {
     "$ref": "#/definitions/gettableSilence"
    },
@@ -3760,6 +3756,7 @@
    "type": "array"
   },
   "postableSilence": {
+   "description": "PostableSilence postable silence",
    "properties": {
     "comment": {
      "description": "comment",

--- a/pkg/services/ngalert/api/tooling/spec.json
+++ b/pkg/services/ngalert/api/tooling/spec.json
@@ -4664,6 +4664,10 @@
           "type": "integer",
           "format": "int64"
         },
+        "isPaused": {
+          "type": "boolean",
+          "example": false
+        },
         "labels": {
           "type": "object",
           "additionalProperties": {
@@ -5865,6 +5869,7 @@
       }
     },
     "alertGroup": {
+      "description": "AlertGroup alert group",
       "type": "object",
       "required": [
         "alerts",
@@ -5994,6 +5999,7 @@
       }
     },
     "gettableAlert": {
+      "description": "GettableAlert gettable alert",
       "type": "object",
       "required": [
         "labels",
@@ -6057,6 +6063,7 @@
       "$ref": "#/definitions/gettableAlerts"
     },
     "gettableSilence": {
+      "description": "GettableSilence gettable silence",
       "type": "object",
       "required": [
         "comment",
@@ -6113,7 +6120,6 @@
       "$ref": "#/definitions/gettableSilences"
     },
     "integration": {
-      "description": "Integration integration",
       "type": "object",
       "required": [
         "name",
@@ -6258,7 +6264,6 @@
       }
     },
     "postableSilence": {
-      "description": "PostableSilence postable silence",
       "type": "object",
       "required": [
         "comment",

--- a/pkg/services/ngalert/api/tooling/spec.json
+++ b/pkg/services/ngalert/api/tooling/spec.json
@@ -5865,7 +5865,6 @@
       }
     },
     "alertGroup": {
-      "description": "AlertGroup alert group",
       "type": "object",
       "required": [
         "alerts",
@@ -6051,7 +6050,6 @@
       "$ref": "#/definitions/gettableAlert"
     },
     "gettableAlerts": {
-      "description": "GettableAlerts gettable alerts",
       "type": "array",
       "items": {
         "$ref": "#/definitions/gettableAlert"
@@ -6059,7 +6057,6 @@
       "$ref": "#/definitions/gettableAlerts"
     },
     "gettableSilence": {
-      "description": "GettableSilence gettable silence",
       "type": "object",
       "required": [
         "comment",
@@ -6109,7 +6106,6 @@
       "$ref": "#/definitions/gettableSilence"
     },
     "gettableSilences": {
-      "description": "GettableSilences gettable silences",
       "type": "array",
       "items": {
         "$ref": "#/definitions/gettableSilence"
@@ -6262,6 +6258,7 @@
       }
     },
     "postableSilence": {
+      "description": "PostableSilence postable silence",
       "type": "object",
       "required": [
         "comment",
@@ -6300,6 +6297,7 @@
       "$ref": "#/definitions/postableSilence"
     },
     "receiver": {
+      "description": "Receiver receiver",
       "type": "object",
       "required": [
         "active",

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -160,7 +160,7 @@ type AlertRule struct {
 	For         time.Duration
 	Annotations map[string]string
 	Labels      map[string]string
-	IsPaused    bool
+	IsPaused    *bool
 }
 
 // GetDashboardUID returns the DashboardUID or "".
@@ -469,6 +469,9 @@ func PatchPartialAlertRule(existingRule *AlertRule, ruleToPatch *AlertRule) {
 	}
 	if ruleToPatch.For == -1 {
 		ruleToPatch.For = existingRule.For
+	}
+	if ruleToPatch.IsPaused == nil {
+		ruleToPatch.IsPaused = existingRule.IsPaused
 	}
 }
 

--- a/pkg/services/ngalert/models/testing.go
+++ b/pkg/services/ngalert/models/testing.go
@@ -258,6 +258,7 @@ func CopyRule(r *AlertRule) *AlertRule {
 		NoDataState:     r.NoDataState,
 		ExecErrState:    r.ExecErrState,
 		For:             r.For,
+		IsPaused:        r.IsPaused,
 	}
 
 	if r.DashboardUID != nil {

--- a/pkg/services/ngalert/models/testing.go
+++ b/pkg/services/ngalert/models/testing.go
@@ -19,6 +19,7 @@ type AlertRuleMutator func(*AlertRule)
 // The mutators arguments allows changing fields of the resulting structure
 func AlertRuleGen(mutators ...AlertRuleMutator) func() *AlertRule {
 	return func() *AlertRule {
+		isPaused := false
 		randNoDataState := func() NoDataState {
 			s := [...]NoDataState{
 				Alerting,
@@ -78,6 +79,7 @@ func AlertRuleGen(mutators ...AlertRuleMutator) func() *AlertRule {
 			For:             forInterval,
 			Annotations:     annotations,
 			Labels:          labels,
+			IsPaused:        &isPaused,
 		}
 
 		for _, mutator := range mutators {

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -310,7 +310,7 @@ func subscribeToFolderChanges(ctx context.Context, logger log.Logger, bus bus.Bu
 			if len(updated) > 0 {
 				logger.Info("Rules that belong to the folder have been updated successfully. Clearing their status", "folderUID", evt.UID, "updatedRules", len(updated))
 				for _, key := range updated {
-					scheduler.UpdateAlertRule(key.AlertRuleKey, key.Version, key.IsPaused)
+					scheduler.UpdateAlertRule(key.AlertRuleKey, key.Version, &key.IsPaused)
 				}
 			} else {
 				logger.Debug("No alert rules found in the folder. nothing to update", "folderUID", evt.UID, "folder", evt.Title)

--- a/pkg/services/ngalert/ngalert_test.go
+++ b/pkg/services/ngalert/ngalert_test.go
@@ -69,6 +69,6 @@ func Test_subscribeToFolderChanges(t *testing.T) {
 	}, time.Second, 10*time.Millisecond, "scheduler was expected to be called %d times but called %d", len(rules), calledTimes)
 
 	for _, rule := range rules {
-		scheduler.AssertCalled(t, "UpdateAlertRule", rule.GetKey(), rule.Version, false)
+		scheduler.AssertCalled(t, "UpdateAlertRule", rule.GetKey(), rule.Version, rules[0].IsPaused)
 	}
 }

--- a/pkg/services/ngalert/provisioning/alert_rules_test.go
+++ b/pkg/services/ngalert/provisioning/alert_rules_test.go
@@ -361,6 +361,7 @@ func dummyRule(title string, orgID int64) models.AlertRule {
 }
 
 func createTestRule(title string, groupTitle string, orgID int64) models.AlertRule {
+	isPaused := false
 	return models.AlertRule{
 		OrgID:           orgID,
 		Title:           title,
@@ -383,6 +384,7 @@ func createTestRule(title string, groupTitle string, orgID int64) models.AlertRu
 		For:          time.Second * 60,
 		NoDataState:  models.OK,
 		ExecErrState: models.OkErrState,
+		IsPaused:     &isPaused,
 	}
 }
 

--- a/pkg/services/ngalert/schedule/registry.go
+++ b/pkg/services/ngalert/schedule/registry.go
@@ -79,7 +79,7 @@ func (r *alertRuleInfoRegistry) keyMap() map[models.AlertRuleKey]struct{} {
 type ruleVersion int64
 type ruleVersionAndPauseStatus struct {
 	Version  ruleVersion
-	IsPaused bool
+	IsPaused *bool
 }
 
 type alertRuleInfo struct {

--- a/pkg/services/ngalert/schedule/schedule_mock.go
+++ b/pkg/services/ngalert/schedule/schedule_mock.go
@@ -36,7 +36,7 @@ func (_m *FakeScheduleService) Run(_a0 context.Context) error {
 }
 
 // UpdateAlertRule provides a mock function with given fields: key, lastVersion
-func (_m *FakeScheduleService) UpdateAlertRule(key models.AlertRuleKey, lastVersion int64, isPaused bool) {
+func (_m *FakeScheduleService) UpdateAlertRule(key models.AlertRuleKey, lastVersion int64, isPaused *bool) {
 	_m.Called(key, lastVersion, isPaused)
 }
 

--- a/pkg/services/ngalert/tests/fakes/rules.go
+++ b/pkg/services/ngalert/tests/fakes/rules.go
@@ -332,7 +332,7 @@ func (f *RuleStore) IncreaseVersionForAllRulesInNamespace(_ context.Context, org
 			rule.Version++
 			rule.Updated = time.Now()
 			result = append(result, models.AlertRuleKeyWithVersionAndPauseStatus{
-				IsPaused: rule.IsPaused,
+				IsPaused: *rule.IsPaused,
 				AlertRuleKeyWithVersion: models.AlertRuleKeyWithVersion{
 					Version:      rule.Version,
 					AlertRuleKey: rule.GetKey(),

--- a/pkg/services/ngalert/tests/util.go
+++ b/pkg/services/ngalert/tests/util.go
@@ -113,6 +113,7 @@ func CreateTestAlertRule(t testing.TB, ctx context.Context, dbstore *store.DBsto
 
 func CreateTestAlertRuleWithLabels(t testing.TB, ctx context.Context, dbstore *store.DBstore, intervalSeconds int64, orgID int64, labels map[string]string) *models.AlertRule {
 	ruleGroup := fmt.Sprintf("ruleGroup-%s", util.GenerateShortUID())
+	isPaused := false
 	folderUID := "namespace"
 	user := &user.SignedInUser{
 		UserID:         1,
@@ -157,6 +158,7 @@ func CreateTestAlertRuleWithLabels(t testing.TB, ctx context.Context, dbstore *s
 			RuleGroup:       ruleGroup,
 			NoDataState:     models.NoData,
 			ExecErrState:    models.AlertingErrState,
+			IsPaused:        &isPaused,
 		},
 	})
 	require.NoError(t, err)

--- a/pkg/services/provisioning/alerting/rules_types.go
+++ b/pkg/services/provisioning/alerting/rules_types.go
@@ -80,6 +80,7 @@ type AlertRuleV1 struct {
 	For          values.StringValue    `json:"for" yaml:"for"`
 	Annotations  values.StringMapValue `json:"annotations" yaml:"annotations"`
 	Labels       values.StringMapValue `json:"labels" yaml:"labels"`
+	IsPaused     values.BoolValue      `json:"paused" yaml:"paused"`
 }
 
 func (rule *AlertRuleV1) mapToModel(orgID int64) (models.AlertRule, error) {
@@ -136,6 +137,8 @@ func (rule *AlertRuleV1) mapToModel(orgID int64) (models.AlertRule, error) {
 	if len(alertRule.Data) == 0 {
 		return models.AlertRule{}, fmt.Errorf("rule '%s' failed to parse: no data set", alertRule.Title)
 	}
+	isPausedValue := rule.IsPaused.Value()
+	alertRule.IsPaused = &isPausedValue
 	return alertRule, nil
 }
 

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -17827,9 +17827,8 @@
       "type": "string"
     },
     "URL": {
-      "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use RawPath, an optional field which only gets\nset if the default encoding is different from Path.\n\nURL's String method uses the EscapedPath method to obtain the path. See the\nEscapedPath method for more details.",
       "type": "object",
-      "title": "A URL represents a parsed URL (technically, a URI reference).",
+      "title": "URL is a custom URL type that allows validation at configuration load time.",
       "properties": {
         "ForceQuery": {
           "type": "boolean"
@@ -18672,6 +18671,7 @@
       }
     },
     "alertGroup": {
+      "description": "AlertGroup alert group",
       "type": "object",
       "required": [
         "alerts",
@@ -18908,6 +18908,7 @@
       }
     },
     "gettableSilences": {
+      "description": "GettableSilences gettable silences",
       "type": "array",
       "items": {
         "$ref": "#/definitions/gettableSilence"


### PR DESCRIPTION
**What is this feature?**

- Makes `IsPaused` field in `AlertRule` model introduced in https://github.com/grafana/grafana/pull/62253 nullable.
- Allow alert rules to be paused from file provisioning and API provisioning.

These two tasks were meant to be in separate PRs but making `isPaused` field nullable in `AlertRule` model introduced braeking changes that made alert rule provisioning tests to FAIL.

Why do we need this feature?

Currently, this addresses 2 issues:
- All rules in call `POST /api/ruler/grafana/api/v1/rules/{Namespace}` without the `is_paused` field would unpause the rule.
- The pausing alert logic is internal to the scheduler but there is no way of pausing alerts from provisioning.

Who is this feature for?

All users that Alerting API or file provisioning/provisioning API for alerting.

Which issue(s) does this PR fix?:

Contributes to https://github.com/grafana/grafana/issues/55519