### PR TITLE
Datasources: Extend properties for the datasource-test tracking event

### DIFF
--- a/public/app/features/datasources/state/actions.test.ts
+++ b/public/app/features/datasources/state/actions.test.ts
@@ -72,7 +72,7 @@ const failDataSourceTest = async (error: object) => {
   };
   const dispatchedActions = await thunkTester(state)
     .givenThunk(testDataSource)
-    .whenThunkIsDispatched('Azure Monitor', dependencies);
+    .whenThunkIsDispatched('Azure Monitor', DATASOURCES_ROUTES.Edit, dependencies);
 
   return dispatchedActions;
 };
@@ -234,7 +234,7 @@ describe('testDataSource', () => {
       };
       const dispatchedActions = await thunkTester(state)
         .givenThunk(testDataSource)
-        .whenThunkIsDispatched('CloudWatch', dependencies);
+        .whenThunkIsDispatched('CloudWatch', DATASOURCES_ROUTES.Edit, dependencies);
 
       expect(dispatchedActions).toEqual([testDataSourceStarting(), testDataSourceSucceeded(state.testingStatus)]);
       expect(trackDataSourceTested).toHaveBeenCalledWith({
@@ -242,6 +242,7 @@ describe('testDataSource', () => {
         datasource_uid: 'CW1234',
         grafana_version: '1.0',
         success: true,
+        editLink: '/datasources/edit/CloudWatch',
       });
     });
 
@@ -270,7 +271,7 @@ describe('testDataSource', () => {
       };
       const dispatchedActions = await thunkTester(state)
         .givenThunk(testDataSource)
-        .whenThunkIsDispatched('Azure Monitor', dependencies);
+        .whenThunkIsDispatched('Azure Monitor', DATASOURCES_ROUTES.Edit, dependencies);
 
       expect(dispatchedActions).toEqual([testDataSourceStarting(), testDataSourceFailed(result)]);
       expect(trackDataSourceTested).toHaveBeenCalledWith({
@@ -278,6 +279,7 @@ describe('testDataSource', () => {
         datasource_uid: 'azM0nit0R',
         grafana_version: '1.0',
         success: false,
+        editLink: '/datasources/edit/Azure Monitor',
       });
     });
 

--- a/public/app/features/datasources/state/actions.ts
+++ b/public/app/features/datasources/state/actions.ts
@@ -90,6 +90,7 @@ export const initDataSourceSettings = (
 
 export const testDataSource = (
   dataSourceName: string,
+  editRoute = DATASOURCES_ROUTES.Edit,
   dependencies: TestDataSourceDependencies = {
     getDatasourceSrv,
     getBackendSrv,
@@ -97,6 +98,7 @@ export const testDataSource = (
 ): ThunkResult<void> => {
   return async (dispatch: ThunkDispatch, getState) => {
     const dsApi = await dependencies.getDatasourceSrv().get(dataSourceName);
+    const editLink = editRoute.replace(/:uid/gi, dataSourceName);
 
     if (!dsApi.testDatasource) {
       return;
@@ -114,6 +116,7 @@ export const testDataSource = (
           plugin_id: dsApi.type,
           datasource_uid: dsApi.uid,
           success: true,
+          editLink,
         });
       } catch (err) {
         let message: string | undefined;
@@ -134,6 +137,7 @@ export const testDataSource = (
           plugin_id: dsApi.type,
           datasource_uid: dsApi.uid,
           success: false,
+          editLink,
         });
       }
     });

--- a/public/app/features/datasources/state/hooks.ts
+++ b/public/app/features/datasources/state/hooks.ts
@@ -43,8 +43,9 @@ export const useInitDataSourceSettings = (uid: string) => {
 
 export const useTestDataSource = (uid: string) => {
   const dispatch = useDispatch();
+  const dataSourcesRoutes = useDataSourcesRoutes();
 
-  return () => dispatch(testDataSource(uid));
+  return () => dispatch(testDataSource(uid, dataSourcesRoutes.Edit));
 };
 
 export const useLoadDataSources = () => {

--- a/public/app/features/datasources/tracking.ts
+++ b/public/app/features/datasources/tracking.ts
@@ -53,4 +53,6 @@ type DataSourceTestedProps = {
   plugin_version?: string;
   /** Whether or not the datasource test succeeded = the datasource was successfully configured */
   success: boolean;
+  /** The URL that points to the edit page for the datasoruce. We are using this to be able to distinguish between the performance of different datasource edit locations. */
+  editLink?: string;
 };


### PR DESCRIPTION
### What changed?
Extended the `grafana_ds_test_datasource_clicked` event with a `editLink` property.
This was necessary for us to be able to distinguish between tracking events happening under Connections and Administration.

![Screenshot 2023-01-27 at 11 16 10](https://user-images.githubusercontent.com/9974811/215063002-5911f6ac-90d9-4927-a407-190e009584a6.png)
