### PR TITLE
Re-add RowHeight option to StatusHistory

### DIFF
--- a/docs/sources/developers/kinds/composable/statushistorypanelcfg/schema-reference.md
+++ b/docs/sources/developers/kinds/composable/statushistorypanelcfg/schema-reference.md
@@ -34,6 +34,7 @@ title: StatusHistoryPanelCfg kind
 | Property    | Type   | Required | Description                                               |
 |-------------|--------|----------|-----------------------------------------------------------|
 | `colWidth`  | number | No       | Controls the column width Default: `0.9`.                 |
+| `rowHeight` | number | No       | Set the height of the rows Default: `0.9`.                |
 | `showValue` | string | No       | TODO docs Possible values are: `auto`, `never`, `always`. |
 
 

--- a/public/app/plugins/panel/status-history/module.tsx
+++ b/public/app/plugins/panel/status-history/module.tsx
@@ -57,6 +57,16 @@ export const plugin = new PanelPlugin<PanelOptions, PanelFieldConfig>(StatusHist
         defaultValue: VisibilityMode.Auto,
       })
       .addSliderInput({
+        path: 'rowHeight',
+        name: 'Row height',
+        defaultValue: 0.9,
+        settings: {
+          min: 0,
+          max: 1,
+          step: 0.01,
+        },
+      })
+      .addSliderInput({
         path: 'colWidth',
         name: 'Column width',
         defaultValue: 0.9,

--- a/public/app/plugins/panel/status-history/panelcfg.cue
+++ b/public/app/plugins/panel/status-history/panelcfg.cue
@@ -30,6 +30,8 @@ composableKinds: PanelCfg: {
 							ui.OptionsWithTooltip
 							ui.OptionsWithTimezones
 
+							//Set the height of the rows
+							rowHeight: float32 & >=0 & <=1 | *0.9
 							//Show values on the columns
 							showValue: ui.VisibilityMode | *"auto"
 							//Controls the column width

--- a/public/app/plugins/panel/status-history/panelcfg.gen.ts
+++ b/public/app/plugins/panel/status-history/panelcfg.gen.ts
@@ -18,6 +18,10 @@ export interface PanelOptions extends ui.OptionsWithLegend, ui.OptionsWithToolti
    */
   colWidth?: number;
   /**
+   * Set the height of the rows
+   */
+  rowHeight: number;
+  /**
    * Show values on the columns
    */
   showValue: ui.VisibilityMode;
@@ -25,6 +29,7 @@ export interface PanelOptions extends ui.OptionsWithLegend, ui.OptionsWithToolti
 
 export const defaultPanelOptions: Partial<PanelOptions> = {
   colWidth: 0.9,
+  rowHeight: 0.9,
   showValue: ui.VisibilityMode.Auto,
 };
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

As part of the CUE migration done in https://github.com/grafana/grafana/pull/61631 , the `rowHeight` option was erroneously removed from the status history panel. This PR adds the functionality back

**Why do we need this feature?**

To fix a mistake merged in the previous PR

**Who is this feature for?**

Everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

