### PR TITLE
Plugins: Track plugin install and uninstall events

### DIFF
--- a/public/app/features/plugins/admin/components/InstallControls/InstallControlsButton.tsx
+++ b/public/app/features/plugins/admin/components/InstallControls/InstallControlsButton.tsx
@@ -8,6 +8,7 @@ import appEvents from 'app/core/app_events';
 import { useQueryParams } from 'app/core/hooks/useQueryParams';
 
 import { useInstallStatus, useUninstallStatus, useInstall, useUninstall } from '../../state/hooks';
+import { trackPluginInstalled, trackPluginUninstalled } from '../../tracking';
 import { CatalogPlugin, PluginStatus, PluginTabIds, Version } from '../../types';
 
 type InstallControlsButtonProps = {
@@ -27,8 +28,13 @@ export function InstallControlsButton({ plugin, pluginStatus, latestCompatibleVe
   const showConfirmModal = () => setIsConfirmModalVisible(true);
   const hideConfirmModal = () => setIsConfirmModalVisible(false);
   const uninstallBtnText = isUninstalling ? 'Uninstalling' : 'Uninstall';
+  const trackingProps = {
+    plugin_id: plugin.id,
+    path: location.pathname,
+  };
 
   const onInstall = async () => {
+    trackPluginInstalled(trackingProps);
     await install(plugin.id, latestCompatibleVersion?.version);
     if (!errorInstalling) {
       appEvents.emit(AppEvents.alertSuccess, [`Installed ${plugin.name}`]);
@@ -37,6 +43,7 @@ export function InstallControlsButton({ plugin, pluginStatus, latestCompatibleVe
 
   const onUninstall = async () => {
     hideConfirmModal();
+    trackPluginUninstalled(trackingProps);
     await uninstall(plugin.id);
     if (!errorUninstalling) {
       // If an app plugin is uninstalled we need to reset the active tab when the config / dashboards tabs are removed.

--- a/public/app/features/plugins/admin/components/InstallControls/InstallControlsButton.tsx
+++ b/public/app/features/plugins/admin/components/InstallControls/InstallControlsButton.tsx
@@ -30,6 +30,7 @@ export function InstallControlsButton({ plugin, pluginStatus, latestCompatibleVe
   const uninstallBtnText = isUninstalling ? 'Uninstalling' : 'Uninstall';
   const trackingProps = {
     plugin_id: plugin.id,
+    plugin_type: plugin.type,
     path: location.pathname,
   };
 

--- a/public/app/features/plugins/admin/tracking.ts
+++ b/public/app/features/plugins/admin/tracking.ts
@@ -3,6 +3,8 @@ import { reportInteraction } from '@grafana/runtime';
 type PluginTrackingProps = {
   // The ID of the plugin (e.g. grafana-azure-monitor-datasource)
   plugin_id: string;
+  // The type of the plugin (e.g. 'app' or 'datasource')
+  plugin_type?: string;
   // The path where the plugin details page was rendered (e.g. /plugins/grafana-azure-monitor-datasource )
   path: string;
 };

--- a/public/app/features/plugins/admin/tracking.ts
+++ b/public/app/features/plugins/admin/tracking.ts
@@ -1,0 +1,16 @@
+import { reportInteraction } from '@grafana/runtime';
+
+type PluginTrackingProps = {
+  // The ID of the plugin (e.g. grafana-azure-monitor-datasource)
+  plugin_id: string;
+  // The path where the plugin details page was rendered (e.g. /plugins/grafana-azure-monitor-datasource )
+  path: string;
+};
+
+export const trackPluginInstalled = (props: PluginTrackingProps) => {
+  reportInteraction('grafana_plugin_install_clicked', props);
+};
+
+export const trackPluginUninstalled = (props: PluginTrackingProps) => {
+  reportInteraction('grafana_plugin_uninstall_clicked', props);
+};


### PR DESCRIPTION
### What changed?

**These events are only going to be tracked if the backend they are sent to is configured in the Garfana INI.**

Introduced two new events for being being able to see how the new Connections page performs for installing datasources:
- `grafana_plugin_install_clicked`
- `grafana_plugin_uninstall_clicked`