### PR TITLE
SearchV2: Set correct batch limit when loading dashboards

### DIFF
--- a/pkg/services/searchV2/index.go
+++ b/pkg/services/searchV2/index.go
@@ -901,7 +901,8 @@ func (l sqlDashboardLoader) LoadDashboards(ctx context.Context, orgID int64, das
 	limit := 1
 
 	if dashboardUID == "" {
-		dashboards = make([]dashboard, 0, l.settings.DashboardLoadingBatchSize)
+		limit = l.settings.DashboardLoadingBatchSize
+		dashboards = make([]dashboard, 0, limit)
 	}
 
 	loadDatasourceCtx, loadDatasourceSpan := l.tracer.Start(ctx, "sqlDashboardLoader LoadDatasourceLookup")


### PR DESCRIPTION
**What is this feature?**
After https://github.com/grafana/grafana/pull/60729 limit is always set to 1 and that messed up batch size for loading dashboards. For a full re-index this generates 1 sql query for every dashboard.

Fixes #

**Special notes for your reviewer**:

