### PR TITLE
Azure Monitor: Add info about multiple resource selection

### DIFF
--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/LogsQueryEditor/LogsQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/LogsQueryEditor/LogsQueryEditor.test.tsx
@@ -149,6 +149,6 @@ describe('LogsQueryEdiutor', () => {
     await userEvent.click(checkbox);
     expect(checkbox).toBeChecked();
 
-    expect(await screen.findByText('You may only choose items from the same resource type.')).toBeInTheDocument();
+    expect(await screen.findByText('You may only choose items of the same resource type.')).toBeInTheDocument();
   });
 });

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/LogsQueryEditor/LogsQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/LogsQueryEditor/LogsQueryEditor.test.tsx
@@ -118,4 +118,37 @@ describe('LogsQueryEdiutor', () => {
 
     expect(await screen.findByLabelText('web-server_DataDisk')).toBeDisabled();
   });
+
+  it('should show info about multiple selection', async () => {
+    const mockDatasource = createMockDatasource({ resourcePickerData: createMockResourcePickerData() });
+    const query = createMockQuery();
+    delete query?.subscription;
+    delete query?.azureLogAnalytics?.resources;
+    const onChange = jest.fn();
+
+    render(
+      <LogsQueryEditor
+        query={query}
+        datasource={mockDatasource}
+        variableOptionGroup={variableOptionGroup}
+        onChange={onChange}
+        setError={() => {}}
+      />
+    );
+
+    const resourcePickerButton = await screen.findByRole('button', { name: 'Select a resource' });
+    resourcePickerButton.click();
+
+    const subscriptionButton = await screen.findByRole('button', { name: 'Expand Primary Subscription' });
+    subscriptionButton.click();
+
+    const resourceGroupButton = await screen.findByRole('button', { name: 'Expand A Great Resource Group' });
+    resourceGroupButton.click();
+
+    const checkbox = await screen.findByLabelText('web-server');
+    await userEvent.click(checkbox);
+    expect(checkbox).toBeChecked();
+
+    expect(await screen.findByText('You may only choose items from the same resource type.')).toBeInTheDocument();
+  });
 });

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/LogsQueryEditor/LogsQueryEditor.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/LogsQueryEditor/LogsQueryEditor.tsx
@@ -82,6 +82,11 @@ const LogsQueryEditor: React.FC<LogsQueryEditorProps> = ({
                 // eslint-disable-next-line
                 <AdvancedResourcePicker resources={resources as string[]} onChange={onChange} />
               )}
+              selectionNotice={() =>
+                config.featureToggles.azureMultipleResourcePicker
+                  ? 'You may only choose items from the same resource type.'
+                  : ''
+              }
             />
           </EditorFieldGroup>
         </EditorRow>

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/LogsQueryEditor/LogsQueryEditor.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/LogsQueryEditor/LogsQueryEditor.tsx
@@ -84,7 +84,7 @@ const LogsQueryEditor: React.FC<LogsQueryEditorProps> = ({
               )}
               selectionNotice={() =>
                 config.featureToggles.azureMultipleResourcePicker
-                  ? 'You may only choose items from the same resource type.'
+                  ? 'You may only choose items of the same resource type.'
                   : ''
               }
             />

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/MetricsQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/MetricsQueryEditor.test.tsx
@@ -270,6 +270,45 @@ describe('MetricsQueryEditor', () => {
     expect(await screen.findByLabelText('web-server_DataDisk')).toBeDisabled();
   });
 
+  it('should show info about multiple selection', async () => {
+    const mockDatasource = createMockDatasource({ resourcePickerData: createMockResourcePickerData() });
+    const query = createMockQuery();
+    delete query?.subscription;
+    delete query?.azureMonitor?.resources;
+    delete query?.azureMonitor?.metricNamespace;
+    const onChange = jest.fn();
+
+    render(
+      <MetricsQueryEditor
+        data={mockPanelData}
+        query={query}
+        datasource={mockDatasource}
+        variableOptionGroup={variableOptionGroup}
+        onChange={onChange}
+        setError={() => {}}
+      />
+    );
+
+    const resourcePickerButton = await screen.findByRole('button', { name: 'Select a resource' });
+    resourcePickerButton.click();
+
+    const subscriptionButton = await screen.findByRole('button', { name: 'Expand Primary Subscription' });
+    subscriptionButton.click();
+
+    const resourceGroupButton = await screen.findByRole('button', { name: 'Expand A Great Resource Group' });
+    resourceGroupButton.click();
+
+    const checkbox = await screen.findByLabelText('web-server');
+    await userEvent.click(checkbox);
+    expect(checkbox).toBeChecked();
+
+    expect(
+      await screen.findByText(
+        'You can select items of the same resource type and location. To select resources of a different resource type or location, please first uncheck your current selection.'
+      )
+    ).toBeInTheDocument();
+  });
+
   it('should change the metric name when selected', async () => {
     const mockDatasource = createMockDatasource({ resourcePickerData: createMockResourcePickerData() });
     const onChange = jest.fn();

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/MetricsQueryEditor.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/MetricsQueryEditor.tsx
@@ -49,6 +49,11 @@ const MetricsQueryEditor: React.FC<MetricsQueryEditorProps> = ({
       resourceName: r.resourceName,
       region: query.azureMonitor?.region,
     })) ?? [];
+
+  const supportMultipleResource = (namespace?: string) => {
+    return multiResourceCompatibleTypes[namespace?.toLocaleLowerCase() ?? ''] ?? false;
+  };
+
   const disableRow = (row: ResourceRow, selectedRows: ResourceRowGroup) => {
     if (selectedRows.length === 0) {
       // Only if there is some resource(s) selected we should disable rows
@@ -70,8 +75,18 @@ const MetricsQueryEditor: React.FC<MetricsQueryEditorProps> = ({
       rowResource.subscription !== selectedRowSample.subscription ||
       rowResource.region !== selectedRowSample.region ||
       rowResource.metricNamespace?.toLocaleLowerCase() !== selectedRowSample.metricNamespace?.toLocaleLowerCase() ||
-      !multiResourceCompatibleTypes[rowResource.metricNamespace?.toLocaleLowerCase() ?? '']
+      !supportMultipleResource(rowResource.metricNamespace)
     );
+  };
+
+  const selectionNotice = (selectedRows: ResourceRowGroup) => {
+    if (selectedRows.length === 0 || !config.featureToggles.azureMultipleResourcePicker) {
+      return '';
+    }
+    const selectedRowSample = parseResourceDetails(selectedRows[0].uri, selectedRows[0].location);
+    return supportMultipleResource(selectedRowSample.metricNamespace)
+      ? 'You can select items of the same resource type and location. To select resources of a different resource type or location, please first uncheck your current selection.'
+      : '';
   };
 
   return (
@@ -95,6 +110,7 @@ const MetricsQueryEditor: React.FC<MetricsQueryEditorProps> = ({
                 // eslint-disable-next-line
                 <AdvancedResourcePicker resources={resources as AzureMetricResource[]} onChange={onChange} />
               )}
+              selectionNotice={selectionNotice}
             />
             <MetricNamespaceField
               metricNamespaces={metricNamespaces}

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/ResourceField/ResourceField.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/ResourceField/ResourceField.tsx
@@ -21,6 +21,7 @@ interface ResourceFieldProps<T> extends AzureQueryEditorFieldProps {
   labelWidth?: number;
   disableRow: (row: ResourceRow, selectedRows: ResourceRowGroup) => boolean;
   renderAdvanced: (resources: T[], onChange: (resources: T[]) => void) => React.ReactNode;
+  selectionNotice?: (selectedRows: ResourceRowGroup) => string;
 }
 
 const ResourceField: React.FC<ResourceFieldProps<string | AzureMetricResource>> = ({
@@ -34,6 +35,7 @@ const ResourceField: React.FC<ResourceFieldProps<string | AzureMetricResource>> 
   labelWidth,
   disableRow,
   renderAdvanced,
+  selectionNotice,
 }) => {
   const styles = useStyles2(getStyles);
   const [pickerIsOpen, setPickerIsOpen] = useState(false);
@@ -74,6 +76,7 @@ const ResourceField: React.FC<ResourceFieldProps<string | AzureMetricResource>> 
           queryType={queryType}
           disableRow={disableRow}
           renderAdvanced={renderAdvanced}
+          selectionNotice={selectionNotice}
         />
       </Modal>
       <Field label="Resource" inlineField={inlineField} labelWidth={labelWidth}>

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/ResourcePicker/ResourcePicker.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/ResourcePicker/ResourcePicker.tsx
@@ -29,6 +29,7 @@ interface ResourcePickerProps<T> {
   onCancel: () => void;
   disableRow: (row: ResourceRow, selectedRows: ResourceRowGroup) => boolean;
   renderAdvanced: (resources: T[], onChange: (resources: T[]) => void) => React.ReactNode;
+  selectionNotice?: (selectedRows: ResourceRowGroup) => string;
 }
 
 const ResourcePicker = ({
@@ -40,6 +41,7 @@ const ResourcePicker = ({
   queryType,
   disableRow,
   renderAdvanced,
+  selectionNotice,
 }: ResourcePickerProps<string | AzureMetricResource>) => {
   const styles = useStyles2(getStyles);
 
@@ -49,6 +51,7 @@ const ResourcePicker = ({
   const [internalSelected, setInternalSelected] = useState(resources);
   const [errorMessage, setErrorMessage] = useState<string | undefined>(undefined);
   const [shouldShowLimitFlag, setShouldShowLimitFlag] = useState(false);
+  const selectionNoticeText = selectionNotice?.(selectedRows);
 
   // Sync the resourceURI prop to internal state
   useEffect(() => {
@@ -241,6 +244,11 @@ const ResourcePicker = ({
               </table>
             </div>
             <Space v={2} />
+            {selectionNoticeText?.length ? (
+              <Alert title="" severity="info">
+                {selectionNoticeText}
+              </Alert>
+            ) : null}
           </>
         )}
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Adds a info box with details about selection of multiple resources:

![Screenshot from 2023-01-27 14-35-19](https://user-images.githubusercontent.com/4025665/215101080-1cfbf5a9-ea03-4a00-a6cc-b49fe13de9e4.png)

Depending on the selection, the message will change. 

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #62299

**Special notes for your reviewer**:

I chose not to display any message when selecting a metric resource that doesn't have support for multiple selection because I found it too noisy but the Azure Portal does (even though the case is different since there you can upvote to add support for it). Happy to add also text in this case if you think it's helpful.

![Screenshot from 2023-01-27 14-44-37](https://user-images.githubusercontent.com/4025665/215101598-3caf0159-2cf4-4c9c-a7d3-564b82f61eef.png)

