### PR TITLE
Plugins: Fix circular reference in customOptions leading to MarshalJSON errors

### DIFF
--- a/pkg/services/datasources/service/datasource.go
+++ b/pkg/services/datasources/service/datasource.go
@@ -417,7 +417,10 @@ func (s *Service) httpClientOptions(ctx context.Context, ds *datasources.DataSou
 	if ds.JsonData != nil {
 		opts.CustomOptions = ds.JsonData.MustMap()
 		// allow the plugin sdk to get the json data in JSONDataFromHTTPClientOptions
-		opts.CustomOptions["grafanaData"] = ds.JsonData.MustMap()
+		opts.CustomOptions["grafanaData"] = make(map[string]interface{})
+		for k, v := range opts.CustomOptions {
+			opts.CustomOptions[k] = v
+		}
 	}
 	if ds.BasicAuth {
 		password, err := s.DecryptedBasicAuthPassword(ctx, ds)

--- a/pkg/services/datasources/service/datasource_test.go
+++ b/pkg/services/datasources/service/datasource_test.go
@@ -429,6 +429,10 @@ func TestService_GetHttpTransport(t *testing.T) {
 		require.NotNil(t, rt)
 		tr := configuredTransport
 
+		// make sure we can still marshal the JsonData after httpClientOptions (avoid cycles)
+		_, err = ds.JsonData.MarshalJSON()
+		require.NoError(t, err)
+
 		require.False(t, tr.TLSClientConfig.InsecureSkipVerify)
 		// Ignoring deprecation, the system will not include the root CA
 		// used in this scenario.


### PR DESCRIPTION
**What is this feature?**
Fixes a bug introduced in https://github.com/grafana/grafana/pull/61729 by creating and assigning a copy to  `opts.CustomOptions["grafanaData"]`

Otherwise this can lead to the following error when trying to `MarshalJSON` the `ds.JsonData`:
```
json: unsupported value: encountered a cycle via map[string]interface {}
```

Affects Grafana 9.3.4 - 9.3.6
