### PR TITLE
Alerting: Validate that tags are 100 characters or less

### DIFF
--- a/pkg/services/alerting/extractor.go
+++ b/pkg/services/alerting/extractor.go
@@ -253,7 +253,7 @@ func validateAlertRule(alert *models.Alert) error {
 		return ValidationError{Reason: fmt.Sprintf("Panel id is not correct, alertName=%v, panelId=%v", alert.Name, alert.PanelId)}
 	}
 	if !alert.ValidTags() {
-		return ValidationError{Reason: fmt.Sprintf("Invalid tags, must be less than 100 characters")}
+		return ValidationError{Reason: "Invalid tags, must be less than 100 characters"}
 	}
 	return nil
 }

--- a/pkg/services/alerting/extractor.go
+++ b/pkg/services/alerting/extractor.go
@@ -106,7 +106,7 @@ func UAEnabled(ctx context.Context) bool {
 	return enabled
 }
 
-func (e *DashAlertExtractorService) getAlertFromPanels(ctx context.Context, jsonWithPanels *simplejson.Json, validateAlertFunc func(*models.Alert) bool, logTranslationFailures bool, dashAlertInfo DashAlertInfo) ([]*models.Alert, error) {
+func (e *DashAlertExtractorService) getAlertFromPanels(ctx context.Context, jsonWithPanels *simplejson.Json, validateAlertFunc func(*models.Alert) error, logTranslationFailures bool, dashAlertInfo DashAlertInfo) ([]*models.Alert, error) {
 	ret := make([]*models.Alert, 0)
 
 	for _, panelObj := range jsonWithPanels.Get("panels").MustArray() {
@@ -238,8 +238,8 @@ func (e *DashAlertExtractorService) getAlertFromPanels(ctx context.Context, json
 			return nil, err
 		}
 
-		if !validateAlertFunc(alert) {
-			return nil, ValidationError{Reason: fmt.Sprintf("Panel id is not correct, alertName=%v, panelId=%v", alert.Name, alert.PanelId)}
+		if err := validateAlertFunc(alert); err != nil {
+			return nil, err
 		}
 
 		ret = append(ret, alert)
@@ -248,8 +248,14 @@ func (e *DashAlertExtractorService) getAlertFromPanels(ctx context.Context, json
 	return ret, nil
 }
 
-func validateAlertRule(alert *models.Alert) bool {
-	return alert.ValidToSave()
+func validateAlertRule(alert *models.Alert) error {
+	if !alert.ValidDashboardPanel() {
+		return ValidationError{Reason: fmt.Sprintf("Panel id is not correct, alertName=%v, panelId=%v", alert.Name, alert.PanelId)}
+	}
+	if !alert.ValidTags() {
+		return ValidationError{Reason: fmt.Sprintf("Invalid tags, must be less than 100 characters")}
+	}
+	return nil
 }
 
 // GetAlerts extracts alerts from the dashboard json and does full validation on the alert json data.
@@ -257,7 +263,7 @@ func (e *DashAlertExtractorService) GetAlerts(ctx context.Context, dashAlertInfo
 	return e.extractAlerts(ctx, validateAlertRule, true, dashAlertInfo)
 }
 
-func (e *DashAlertExtractorService) extractAlerts(ctx context.Context, validateFunc func(alert *models.Alert) bool, logTranslationFailures bool, dashAlertInfo DashAlertInfo) ([]*models.Alert, error) {
+func (e *DashAlertExtractorService) extractAlerts(ctx context.Context, validateFunc func(alert *models.Alert) error, logTranslationFailures bool, dashAlertInfo DashAlertInfo) ([]*models.Alert, error) {
 	dashboardJSON, err := copyJSON(dashAlertInfo.Dash.Data)
 	if err != nil {
 		return nil, err
@@ -294,8 +300,8 @@ func (e *DashAlertExtractorService) extractAlerts(ctx context.Context, validateF
 // ValidateAlerts validates alerts in the dashboard json but does not require a valid dashboard id
 // in the first validation pass.
 func (e *DashAlertExtractorService) ValidateAlerts(ctx context.Context, dashAlertInfo DashAlertInfo) error {
-	_, err := e.extractAlerts(ctx, func(alert *models.Alert) bool {
-		return alert.OrgId != 0 && alert.PanelId != 0
+	_, err := e.extractAlerts(ctx, func(alert *models.Alert) error {
+		return validateAlertRule(alert)
 	}, false, dashAlertInfo)
 	return err
 }

--- a/pkg/services/alerting/extractor.go
+++ b/pkg/services/alerting/extractor.go
@@ -301,7 +301,10 @@ func (e *DashAlertExtractorService) extractAlerts(ctx context.Context, validateF
 // in the first validation pass.
 func (e *DashAlertExtractorService) ValidateAlerts(ctx context.Context, dashAlertInfo DashAlertInfo) error {
 	_, err := e.extractAlerts(ctx, func(alert *models.Alert) error {
-		return validateAlertRule(alert)
+		if alert.OrgId == 0 || alert.PanelId == 0 {
+			return errors.New("missing OrgId, PanelId or both")
+		}
+		return nil
 	}, false, dashAlertInfo)
 	return err
 }

--- a/pkg/services/alerting/models/alert.go
+++ b/pkg/services/alerting/models/alert.go
@@ -92,8 +92,17 @@ type Alert struct {
 	Settings *simplejson.Json
 }
 
-func (a *Alert) ValidToSave() bool {
-	return a.DashboardId != 0 && a.OrgId != 0 && a.PanelId != 0
+func (a *Alert) ValidDashboardPanel() bool {
+	return a.OrgId != 0 && a.DashboardId != 0 && a.PanelId != 0
+}
+
+func (a *Alert) ValidTags() bool {
+	for _, tag := range a.GetTagsFromSettings() {
+		if len(tag.Key) > 100 || len(tag.Value) > 100 {
+			return false
+		}
+	}
+	return true
 }
 
 func (a *Alert) ContainsUpdates(other *Alert) bool {

--- a/public/app/core/services/backend_srv.ts
+++ b/public/app/core/services/backend_srv.ts
@@ -314,17 +314,13 @@ export class BackendSrv implements BackendService {
       return;
     }
 
-    let description = '';
-    let message = err.data.message;
-
-    if (message.length > 80) {
-      description = message;
-      message = 'Error';
-    }
+    let data = err.data;
+    let message = 'Error';
+    let description = data.message;
 
     // Validation
     if (err.status === 422) {
-      message = 'Validation failed';
+      message = 'Validation error';
     }
 
     this.dependencies.appEvents.emit(err.status < 500 ? AppEvents.alertWarning : AppEvents.alertError, [

--- a/public/app/core/services/backend_srv.ts
+++ b/public/app/core/services/backend_srv.ts
@@ -304,7 +304,7 @@ export class BackendSrv implements BackendService {
     }
   }
 
-  showErrorAlert<T>(config: BackendSrvRequest, err: FetchError) {
+  showErrorAlert(config: BackendSrvRequest, err: FetchError) {
     if (config.showErrorAlert === false) {
       return;
     }
@@ -314,13 +314,18 @@ export class BackendSrv implements BackendService {
       return;
     }
 
-    let data = err.data;
-    let message = 'Error';
-    let description = data.message;
+    let description = '';
+    let message = err.data.message;
+
+    if (message.length > 80) {
+      description = message;
+      message = 'Error';
+    }
 
     // Validation
     if (err.status === 422) {
-      message = 'Validation error';
+      description = err.data.message;
+      message = 'Validation failed';
     }
 
     this.dependencies.appEvents.emit(err.status < 500 ? AppEvents.alertWarning : AppEvents.alertError, [

--- a/public/app/core/specs/backend_srv.test.ts
+++ b/public/app/core/specs/backend_srv.test.ts
@@ -270,8 +270,8 @@ describe('backendSrv', () => {
             } as FetchError
           );
           expect(appEventsMock.emit).toHaveBeenCalledWith(AppEvents.alertError, [
+            'Error',
             'Something failed',
-            '',
             'bogus-trace-id',
           ]);
         });

--- a/public/app/core/specs/backend_srv.test.ts
+++ b/public/app/core/specs/backend_srv.test.ts
@@ -270,8 +270,8 @@ describe('backendSrv', () => {
             } as FetchError
           );
           expect(appEventsMock.emit).toHaveBeenCalledWith(AppEvents.alertError, [
-            'Error',
             'Something failed',
+            '',
             'bogus-trace-id',
           ]);
         });


### PR DESCRIPTION
**What is this feature?**

This pull request fixes a bug where tags longer than 100 characters would fail due to a column constraint of 100 characters. Instead, a validation error is returned and shown in the UI:

<img width="632" alt="Screenshot 2023-01-27 at 15 04 06" src="https://user-images.githubusercontent.com/85952834/215118401-a2869709-2948-4710-b9a8-8282427644fb.png">

Fixes #

**Special notes for your reviewer**:

