### PR TITLE
SupportBundles: Feature flag + access control navtree item

### DIFF
--- a/public/app/core/components/NavBar/utils.ts
+++ b/public/app/core/components/NavBar/utils.ts
@@ -53,8 +53,8 @@ export const enrichConfigItems = (items: NavModelItem[], location: Location<unkn
 
     if (link.id === 'help') {
       link.children = [
+        ...menuItems,
         ...getFooterLinks(),
-        ...getSupportBundleFooterLinks(),
         {
           id: 'keyboard-shortcuts',
           text: t('nav.help/keyboard-shortcuts', 'Keyboard shortcuts'),

--- a/public/app/core/components/NavBar/utils.ts
+++ b/public/app/core/components/NavBar/utils.ts
@@ -79,26 +79,6 @@ export const enrichConfigItems = (items: NavModelItem[], location: Location<unkn
   return items;
 };
 
-export let getSupportBundleFooterLinks = (cfg = config): FooterLink[] => {
-  const hasAccess =
-    contextSrv.hasAccess(AccessControlAction.ActionSupportBundlesCreate, contextSrv.isGrafanaAdmin) ||
-    contextSrv.hasAccess(AccessControlAction.ActionSupportBundlesRead, contextSrv.isGrafanaAdmin);
-
-  if (!cfg.supportBundlesEnabled || !hasAccess) {
-    return [];
-  }
-
-  return [
-    {
-      target: '_self',
-      id: 'support-bundle',
-      text: t('nav.help/support-bundle', 'Support Bundles'),
-      icon: 'question-circle',
-      url: '/support-bundles',
-    },
-  ];
-};
-
 export const enrichWithInteractionTracking = (item: NavModelItem, expandedState: boolean) => {
   const onClick = item.onClick;
   item.onClick = () => {

--- a/public/app/core/components/NavBar/utils.ts
+++ b/public/app/core/components/NavBar/utils.ts
@@ -4,11 +4,10 @@ import { locationUtil, NavModelItem, NavSection } from '@grafana/data';
 import { config, reportInteraction } from '@grafana/runtime';
 import { t } from 'app/core/internationalization';
 import { contextSrv } from 'app/core/services/context_srv';
-import { AccessControlAction } from 'app/types';
 
 import { ShowModalReactEvent } from '../../../types/events';
 import appEvents from '../../app_events';
-import { FooterLink, getFooterLinks } from '../Footer/Footer';
+import { getFooterLinks } from '../Footer/Footer';
 import { OrgSwitcher } from '../OrgSwitcher';
 import { HelpModal } from '../help/HelpModal';
 

--- a/public/locales/de-DE/grafana.json
+++ b/public/locales/de-DE/grafana.json
@@ -229,7 +229,6 @@
     "help/documentation": "Dokumentation",
     "help/keyboard-shortcuts": "Tastaturbefehle",
     "help/support": "Support",
-    "help/support-bundle": "Support Bundles",
     "home": {
       "title": "Home"
     },

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -13,7 +13,7 @@
       "search": "Search"
     },
     "search-box": {
-      "placeholder": "Search or jump to..."
+      "placeholder": "Search Grafana"
     },
     "section": {
       "actions": "Actions",
@@ -229,7 +229,6 @@
     "help/documentation": "Documentation",
     "help/keyboard-shortcuts": "Keyboard shortcuts",
     "help/support": "Support",
-    "help/support-bundle": "Support Bundles",
     "home": {
       "title": "Home"
     },

--- a/public/locales/es-ES/grafana.json
+++ b/public/locales/es-ES/grafana.json
@@ -229,7 +229,6 @@
     "help/documentation": "Documentación",
     "help/keyboard-shortcuts": "Atajos de teclado",
     "help/support": "Asistencia",
-    "help/support-bundle": "Paquetes de apoyo",
     "home": {
       "title": "Inicio"
     },

--- a/public/locales/fr-FR/grafana.json
+++ b/public/locales/fr-FR/grafana.json
@@ -229,7 +229,6 @@
     "help/documentation": "Documentation",
     "help/keyboard-shortcuts": "Raccourcis clavier",
     "help/support": "Assistance",
-    "help/support-bundle": "Packs d’assistance",
     "home": {
       "title": "Accueil"
     },

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -13,7 +13,7 @@
       "search": "Ŝęäřčĥ"
     },
     "search-box": {
-      "placeholder": "Ŝęäřčĥ őř ĵūmp ŧő..."
+      "placeholder": "Ŝęäřčĥ Ğřäƒäŉä"
     },
     "section": {
       "actions": "Åčŧįőŉş",
@@ -229,7 +229,6 @@
     "help/documentation": "Đőčūmęŉŧäŧįőŉ",
     "help/keyboard-shortcuts": "Ķęyþőäřđ şĥőřŧčūŧş",
     "help/support": "Ŝūppőřŧ",
-    "help/support-bundle": "Ŝūppőřŧ ßūŉđľęş",
     "home": {
       "title": "Ħőmę"
     },

--- a/public/locales/zh-Hans/grafana.json
+++ b/public/locales/zh-Hans/grafana.json
@@ -229,7 +229,6 @@
     "help/documentation": "文档",
     "help/keyboard-shortcuts": "快捷键",
     "help/support": "支持",
-    "help/support-bundle": "",
     "home": {
       "title": "首页"
     },


### PR DESCRIPTION
**What is this feature?**


 - Fix support bundles nav tree item not being feature flagged
 - Move support bundles access control checks to backend nav tree
 - Fix Help node children being clobbered by the frontend

**Why do we need this feature?**

So support bundles doesn't show in the command palette and help menu when the feature isnt enabled.

**Who is this feature for?**

everyone :) 

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

TODO:

 - [x] add support bundles translation to public/app/core/components/NavBar/navBarItem-translations.ts

