### PR TITLE
MultiSelect: Fix `actionMeta` not available in `onChange` callback

### DIFF
--- a/packages/grafana-ui/src/components/Select/types.ts
+++ b/packages/grafana-ui/src/components/Select/types.ts
@@ -119,7 +119,7 @@ export interface VirtualizedSelectAsyncProps<T>
 
 export interface MultiSelectCommonProps<T> extends Omit<SelectCommonProps<T>, 'onChange' | 'isMulti' | 'value'> {
   value?: Array<SelectableValue<T>> | T[];
-  onChange: (item: Array<SelectableValue<T>>) => {} | void;
+  onChange: (item: Array<SelectableValue<T>>, actionMeta: ActionMeta) => {} | void;
 }
 
 // This is the type of *our* SelectBase component, not ReactSelect's prop, although


### PR DESCRIPTION
**What is this feature?**

The `actionMeta` was not available on the type of the `onChange` callback used by the `MultiSelect` component.
