### PR TITLE
elasticsearch: query builder: make settings optional

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/BucketAggregationEditor.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/BucketAggregationEditor.tsx
@@ -8,7 +8,12 @@ import { useDispatch } from '../../../hooks/useStatelessReducer';
 import { segmentStyles } from '../styles';
 
 import { SettingsEditor } from './SettingsEditor';
-import { BucketAggregation, BucketAggregationType, isBucketAggregationWithField } from './aggregations';
+import {
+  BucketAggregation,
+  BucketAggregationType,
+  isBucketAggregationWithField,
+  isBucketAggregationWithSettings,
+} from './aggregations';
 import { changeBucketAggregationField, changeBucketAggregationType } from './state/actions';
 import { bucketAggregationConfig } from './utils';
 
@@ -53,7 +58,7 @@ export const BucketAggregationEditor = ({ value }: QueryMetricEditorProps) => {
         )}
       </InlineSegmentGroup>
 
-      <SettingsEditor bucketAgg={value} />
+      {isBucketAggregationWithSettings(value) && <SettingsEditor bucketAgg={value} />}
     </>
   );
 };

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/state/actions.ts
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/state/actions.ts
@@ -1,6 +1,11 @@
 import { createAction } from '@reduxjs/toolkit';
 
-import { BucketAggregation, BucketAggregationType, BucketAggregationWithField } from '../aggregations';
+import {
+  BucketAggregation,
+  BucketAggregationType,
+  BucketAggregationWithField,
+  BucketAggregationWithSettings,
+} from '../aggregations';
 
 export const addBucketAggregation = createAction<BucketAggregation['id']>('@bucketAggs/add');
 export const removeBucketAggregation = createAction<BucketAggregation['id']>('@bucketAggs/remove');
@@ -9,11 +14,11 @@ export const changeBucketAggregationType = createAction<{
   newType: BucketAggregationType;
 }>('@bucketAggs/change_type');
 export const changeBucketAggregationField = createAction<{
-  id: BucketAggregation['id'];
+  id: BucketAggregationWithField['id'];
   newField: BucketAggregationWithField['field'];
 }>('@bucketAggs/change_field');
 export const changeBucketAggregationSetting = createAction<{
-  bucketAgg: BucketAggregation;
+  bucketAgg: BucketAggregationWithSettings;
   settingName: string;
   newValue: any;
 }>('@bucketAggs/change_setting');

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/state/reducer.ts
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/state/reducer.ts
@@ -6,7 +6,7 @@ import { removeEmpty } from '../../../../utils';
 import { changeMetricType } from '../../MetricAggregationsEditor/state/actions';
 import { metricAggregationConfig } from '../../MetricAggregationsEditor/utils';
 import { initQuery } from '../../state';
-import { BucketAggregation, Terms } from '../aggregations';
+import { BucketAggregation, isBucketAggregationWithSettings, Terms } from '../aggregations';
 import { bucketAggregationConfig } from '../utils';
 
 import {
@@ -89,7 +89,7 @@ export const createReducer =
 
     if (changeBucketAggregationSetting.match(action)) {
       return state!.map((bucketAgg) => {
-        if (bucketAgg.id !== action.payload.bucketAgg.id) {
+        if (bucketAgg.id !== action.payload.bucketAgg.id || !isBucketAggregationWithSettings(bucketAgg)) {
           return bucketAgg;
         }
 

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/utils.ts
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/utils.ts
@@ -8,6 +8,7 @@ export const bucketAggregationConfig: BucketsConfiguration = {
   terms: {
     label: 'Terms',
     requiresField: true,
+    hasSettings: true,
     defaultSettings: {
       min_doc_count: '1',
       size: '10',
@@ -17,6 +18,7 @@ export const bucketAggregationConfig: BucketsConfiguration = {
   },
   filters: {
     label: 'Filters',
+    hasSettings: true,
     requiresField: false,
     defaultSettings: {
       filters: [defaultFilter()],
@@ -24,6 +26,7 @@ export const bucketAggregationConfig: BucketsConfiguration = {
   },
   geohash_grid: {
     label: 'Geo Hash Grid',
+    hasSettings: true,
     requiresField: true,
     defaultSettings: {
       precision: '3',
@@ -31,6 +34,7 @@ export const bucketAggregationConfig: BucketsConfiguration = {
   },
   date_histogram: {
     label: 'Date Histogram',
+    hasSettings: true,
     requiresField: true,
     defaultSettings: {
       interval: 'auto',
@@ -41,6 +45,7 @@ export const bucketAggregationConfig: BucketsConfiguration = {
   },
   histogram: {
     label: 'Histogram',
+    hasSettings: true,
     requiresField: true,
     defaultSettings: {
       interval: '1000',
@@ -49,8 +54,8 @@ export const bucketAggregationConfig: BucketsConfiguration = {
   },
   nested: {
     label: 'Nested (experimental)',
+    hasSettings: false,
     requiresField: true,
-    defaultSettings: {},
   },
 };
 

--- a/public/app/plugins/datasource/elasticsearch/types.ts
+++ b/public/app/plugins/datasource/elasticsearch/types.ts
@@ -3,6 +3,8 @@ import { DataQuery, DataSourceJsonData } from '@grafana/data';
 import {
   BucketAggregation,
   BucketAggregationType,
+  BucketAggregationWithSettings,
+  BucketAggregationWithSettingsType,
 } from './components/QueryEditor/BucketAggregationsEditor/aggregations';
 import {
   MetricAggregation,
@@ -43,10 +45,13 @@ interface MetricConfiguration<T extends MetricAggregationType> {
   defaults: Omit<Extract<MetricAggregation, { type: T }>, 'id' | 'type'>;
 }
 
-type BucketConfiguration<T extends BucketAggregationType> = {
+type BucketConfiguration<T extends BucketAggregationType | BucketAggregationWithSettingsType> = {
   label: string;
   requiresField: boolean;
-  defaultSettings: Extract<BucketAggregation, { type: T }>['settings'];
+  hasSettings: boolean;
+  defaultSettings?: T extends BucketAggregationWithSettingsType
+    ? Extract<BucketAggregationWithSettings, { type: T }>['settings']
+    : never;
 };
 
 export type MetricsConfiguration = {
@@ -54,7 +59,7 @@ export type MetricsConfiguration = {
 };
 
 export type BucketsConfiguration = {
-  [P in BucketAggregationType]: BucketConfiguration<P>;
+  [P in BucketAggregationType | BucketAggregationWithSettingsType]: BucketConfiguration<P>;
 };
 
 export interface ElasticsearchAggregation {


### PR DESCRIPTION
in the elasticsearch query editor, if you choose the `nested` aggregation, it's `settings` block does not contain anything:

<img width="697" alt="nested-settings" src="https://github.com/grafana/grafana/assets/51989/7bf36cc4-13b4-4e40-9568-43dba4a534ba">

we could just not show it, but the way the code is currently, the settings-block is always there.

@Elfo404 made a proof of concept PR that makes this optional (  https://github.com/grafana/grafana/pull/54965) ) , and i cherry-picked the commit from it into this PR
the settings-section is not needed for the nested-aggregation, so we adjust the code to allow for such behavior.

this PR is just that single cherry-picked commit, not a production-ready PR.