### PR TITLE
LokiContext: Fix wrong queries being run when reopened

### DIFF
--- a/public/app/plugins/datasource/loki/components/LokiContextUi.test.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiContextUi.test.tsx
@@ -55,6 +55,7 @@ describe('LokiContextUi', () => {
           label3: 'value3',
         },
       } as unknown as LogRowModel,
+      onClose: jest.fn(),
     };
 
     return defaults;
@@ -112,5 +113,15 @@ describe('LokiContextUi', () => {
     expect(props.updateFilter).toHaveBeenCalled();
 
     jest.useRealTimers();
+  });
+
+  it('unmounts and calls onClose', async () => {
+    const props = setupProps();
+    const comp = render(<LokiContextUi {...props} />);
+    comp.unmount();
+
+    await waitFor(() => {
+      expect(props.onClose).toHaveBeenCalled();
+    });
   });
 });

--- a/public/app/plugins/datasource/loki/components/LokiContextUi.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiContextUi.tsx
@@ -13,6 +13,7 @@ export interface LokiContextUiProps {
   languageProvider: LokiLanguageProvider;
   row: LogRowModel;
   updateFilter: (value: ContextFilter[]) => void;
+  onClose: () => void;
 }
 
 function getStyles(theme: GrafanaTheme2) {
@@ -43,7 +44,7 @@ const formatOptionLabel = memoizeOne(({ label, description }: SelectableValue<st
 ));
 
 export function LokiContextUi(props: LokiContextUiProps) {
-  const { row, languageProvider, updateFilter } = props;
+  const { row, languageProvider, updateFilter, onClose } = props;
   const styles = useStyles2(getStyles);
 
   const [contextFilters, setContextFilters] = useState<ContextFilter[]>([]);
@@ -73,6 +74,13 @@ export function LokiContextUi(props: LokiContextUiProps) {
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [contextFilters, initialized]);
+
+  useEffect(() => {
+    return () => {
+      clearTimeout(timerHandle.current);
+      onClose();
+    };
+  }, [onClose]);
 
   useAsync(async () => {
     await languageProvider.start();

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -746,7 +746,7 @@ export class LokiDatasource
   }
 
   async prepareContextExpr(row: LogRowModel, origQuery?: DataQuery): Promise<string> {
-    return await this.prepareContextExprWithoutParsedLabes(row, origQuery);
+    return await this.prepareContextExprWithoutParsedLabels(row, origQuery);
   }
 
   getLogRowContextUi(row: LogRowModel, runContextQuery: () => void): React.ReactNode {

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -728,7 +728,7 @@ export class LokiDatasource
     };
   };
 
-  async prepareContextExprWithoutParsedLabes(row: LogRowModel, origQuery?: DataQuery): Promise<string> {
+  async prepareContextExprWithoutParsedLabels(row: LogRowModel, origQuery?: DataQuery): Promise<string> {
     await this.languageProvider.start();
     const labels = this.languageProvider.getLabelKeys();
     const expr = Object.keys(row.labels)
@@ -754,7 +754,7 @@ export class LokiDatasource
       row,
       languageProvider: this.languageProvider,
       onClose: () => {
-        this.prepareContextExpr = this.prepareContextExprWithoutParsedLabes;
+        this.prepareContextExpr = this.prepareContextExprWithoutParsedLabels;
       },
       updateFilter: (contextFilters: ContextFilter[]) => {
         this.prepareContextExpr = async (row: LogRowModel, origQuery?: DataQuery) => {

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -728,7 +728,7 @@ export class LokiDatasource
     };
   };
 
-  async prepareContextExpr(row: LogRowModel, origQuery?: DataQuery): Promise<string> {
+  async prepareContextExprWithoutParsedLabes(row: LogRowModel, origQuery?: DataQuery): Promise<string> {
     await this.languageProvider.start();
     const labels = this.languageProvider.getLabelKeys();
     const expr = Object.keys(row.labels)
@@ -745,10 +745,17 @@ export class LokiDatasource
     return `{${expr}}`;
   }
 
+  async prepareContextExpr(row: LogRowModel, origQuery?: DataQuery): Promise<string> {
+    return await this.prepareContextExprWithoutParsedLabes(row, origQuery);
+  }
+
   getLogRowContextUi(row: LogRowModel, runContextQuery: () => void): React.ReactNode {
     return LokiContextUi({
       row,
       languageProvider: this.languageProvider,
+      onClose: () => {
+        this.prepareContextExpr = this.prepareContextExprWithoutParsedLabes;
+      },
       updateFilter: (contextFilters: ContextFilter[]) => {
         this.prepareContextExpr = async (row: LogRowModel, origQuery?: DataQuery) => {
           await this.languageProvider.start();


### PR DESCRIPTION
**What is this feature?**

With the current approach of overwriting `prepareContextExpr` the context will run a wrong query if closed and reopened. This PR fixes that by just having a copy of the "original" context query.

**Notes for reviewers**:

The whole process of overwriting `prepareContextExpr` is just for this exploration and will change in the future to make it more error proof.