### PR TITLE
Canvas: Anchor highlight persistance

### DIFF
--- a/public/app/plugins/panel/canvas/ConnectionAnchors.tsx
+++ b/public/app/plugins/panel/canvas/ConnectionAnchors.tsx
@@ -11,7 +11,7 @@ type Props = {
 };
 
 export const CONNECTION_ANCHOR_DIV_ID = 'connectionControl';
-export const connectionAnchorAlt = 'connection anchor';
+export const CONNECTION_ANCHOR_ALT = 'connection anchor';
 
 export const ConnectionAnchors = ({ setRef, handleMouseLeave }: Props) => {
   const highlightEllipseRef = useRef<HTMLDivElement>(null);

--- a/public/app/plugins/panel/canvas/ConnectionAnchors.tsx
+++ b/public/app/plugins/panel/canvas/ConnectionAnchors.tsx
@@ -11,6 +11,7 @@ type Props = {
 };
 
 export const CONNECTION_ANCHOR_DIV_ID = 'connectionControl';
+export const connectionAnchorAlt = 'connection anchor';
 
 export const ConnectionAnchors = ({ setRef, handleMouseLeave }: Props) => {
   const highlightEllipseRef = useRef<HTMLDivElement>(null);
@@ -37,8 +38,6 @@ export const ConnectionAnchors = ({ setRef, handleMouseLeave }: Props) => {
       highlightEllipseRef.current.style.display = 'none';
     }
   };
-
-  const connectionAnchorAlt = 'connection anchor';
 
   // Unit is percentage from the middle of the element
   // 0, 0 middle; -1, -1 bottom left; 1, 1 top right

--- a/public/app/plugins/panel/canvas/ConnectionAnchors.tsx
+++ b/public/app/plugins/panel/canvas/ConnectionAnchors.tsx
@@ -74,7 +74,7 @@ export const ConnectionAnchors = ({ setRef, handleMouseLeave }: Props) => {
         <img
           id={id}
           key={id}
-          alt={connectionAnchorAlt}
+          alt={CONNECTION_ANCHOR_ALT}
           className={styles.anchor}
           style={style}
           src={anchorImage}

--- a/public/app/plugins/panel/canvas/ConnectionAnchors.tsx
+++ b/public/app/plugins/panel/canvas/ConnectionAnchors.tsx
@@ -7,7 +7,9 @@ import { ConnectionCoordinates } from 'app/features/canvas';
 
 type Props = {
   setRef: (anchorElement: HTMLDivElement) => void;
-  handleMouseLeave: (event: React.MouseEvent<Element, MouseEvent> | React.FocusEvent<HTMLDivElement, Element>) => void;
+  handleMouseLeave: (
+    event: React.MouseEvent<Element, MouseEvent> | React.FocusEvent<HTMLDivElement, Element>
+  ) => boolean;
 };
 
 export const CONNECTION_ANCHOR_DIV_ID = 'connectionControl';
@@ -36,6 +38,16 @@ export const ConnectionAnchors = ({ setRef, handleMouseLeave }: Props) => {
   const onMouseLeaveHighlightElement = () => {
     if (highlightEllipseRef.current) {
       highlightEllipseRef.current.style.display = 'none';
+    }
+  };
+
+  const handleMouseLeaveAnchors = (
+    event: React.MouseEvent<Element, MouseEvent> | React.FocusEvent<HTMLDivElement, Element>
+  ) => {
+    const didHideAnchors = handleMouseLeave(event);
+
+    if (didHideAnchors) {
+      onMouseLeaveHighlightElement();
     }
   };
 
@@ -86,7 +98,7 @@ export const ConnectionAnchors = ({ setRef, handleMouseLeave }: Props) => {
 
   return (
     <div className={styles.root} ref={setRef}>
-      <div className={styles.mouseoutDiv} onMouseOut={handleMouseLeave} onBlur={handleMouseLeave} />
+      <div className={styles.mouseoutDiv} onMouseOut={handleMouseLeaveAnchors} onBlur={handleMouseLeaveAnchors} />
       <div
         id={CONNECTION_ANCHOR_DIV_ID}
         ref={highlightEllipseRef}

--- a/public/app/plugins/panel/canvas/Connections.tsx
+++ b/public/app/plugins/panel/canvas/Connections.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { assertInstanceOf } from 'test/helpers/asserts';
 
 import { ConnectionPath } from 'app/features/canvas';
 import { ElementState } from 'app/features/canvas/runtime/element';
@@ -90,13 +89,12 @@ export class Connections {
   };
 
   handleMouseLeave = (event: React.MouseEvent | React.FocusEvent) => {
-    if (event.relatedTarget instanceof HTMLImageElement) {
-      const relatedTarget = event.relatedTarget;
-      assertInstanceOf(relatedTarget, HTMLImageElement);
-      // If mouse is leaving INTO the anchor image, don't remove div
-      if (relatedTarget.getAttribute('alt') === CONNECTION_ANCHOR_ALT) {
-        return;
-      }
+    // If mouse is leaving INTO the anchor image, don't remove div
+    if (
+      event.relatedTarget instanceof HTMLImageElement &&
+      event.relatedTarget.getAttribute('alt') === CONNECTION_ANCHOR_ALT
+    ) {
+      return;
     }
 
     this.connectionAnchorDiv!.style.display = 'none';

--- a/public/app/plugins/panel/canvas/Connections.tsx
+++ b/public/app/plugins/panel/canvas/Connections.tsx
@@ -88,6 +88,7 @@ export class Connections {
     }
   };
 
+  // Return boolean indicates if connection anchors were hidden or not
   handleMouseLeave = (event: React.MouseEvent | React.FocusEvent): boolean => {
     // If mouse is leaving INTO the anchor image, don't remove div
     if (

--- a/public/app/plugins/panel/canvas/Connections.tsx
+++ b/public/app/plugins/panel/canvas/Connections.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
+import { assertInstanceOf } from 'test/helpers/asserts';
 
 import { ConnectionPath } from 'app/features/canvas';
 import { ElementState } from 'app/features/canvas/runtime/element';
 import { Scene } from 'app/features/canvas/runtime/scene';
 
-import { ConnectionAnchors } from './ConnectionAnchors';
+import { connectionAnchorAlt, ConnectionAnchors } from './ConnectionAnchors';
 import { ConnectionSVG } from './ConnectionSVG';
 
 export class Connections {
@@ -89,6 +90,15 @@ export class Connections {
   };
 
   handleMouseLeave = (event: React.MouseEvent | React.FocusEvent) => {
+    if (event.relatedTarget instanceof HTMLImageElement) {
+      const relatedTarget = event.relatedTarget;
+      assertInstanceOf(relatedTarget, HTMLImageElement);
+      // If mouse is leaving INTO the anchor image, don't remove div
+      if (relatedTarget.getAttribute('alt') === connectionAnchorAlt) {
+        return;
+      }
+    }
+
     this.connectionAnchorDiv!.style.display = 'none';
   };
 

--- a/public/app/plugins/panel/canvas/Connections.tsx
+++ b/public/app/plugins/panel/canvas/Connections.tsx
@@ -5,7 +5,7 @@ import { ConnectionPath } from 'app/features/canvas';
 import { ElementState } from 'app/features/canvas/runtime/element';
 import { Scene } from 'app/features/canvas/runtime/scene';
 
-import { connectionAnchorAlt, ConnectionAnchors } from './ConnectionAnchors';
+import { CONNECTION_ANCHOR_ALT, ConnectionAnchors } from './ConnectionAnchors';
 import { ConnectionSVG } from './ConnectionSVG';
 
 export class Connections {
@@ -94,7 +94,7 @@ export class Connections {
       const relatedTarget = event.relatedTarget;
       assertInstanceOf(relatedTarget, HTMLImageElement);
       // If mouse is leaving INTO the anchor image, don't remove div
-      if (relatedTarget.getAttribute('alt') === connectionAnchorAlt) {
+      if (relatedTarget.getAttribute('alt') === CONNECTION_ANCHOR_ALT) {
         return;
       }
     }

--- a/public/app/plugins/panel/canvas/Connections.tsx
+++ b/public/app/plugins/panel/canvas/Connections.tsx
@@ -88,16 +88,17 @@ export class Connections {
     }
   };
 
-  handleMouseLeave = (event: React.MouseEvent | React.FocusEvent) => {
+  handleMouseLeave = (event: React.MouseEvent | React.FocusEvent): boolean => {
     // If mouse is leaving INTO the anchor image, don't remove div
     if (
       event.relatedTarget instanceof HTMLImageElement &&
       event.relatedTarget.getAttribute('alt') === CONNECTION_ANCHOR_ALT
     ) {
-      return;
+      return false;
     }
 
     this.connectionAnchorDiv!.style.display = 'none';
+    return true;
   };
 
   connectionListener = (event: MouseEvent) => {


### PR DESCRIPTION
What this PR does / why we need it:
Currently in canvas, anchors can become highlighted and frozen that way even after mouse leave event.

Before:
![Jan-27-2023 10-14-08](https://user-images.githubusercontent.com/60050885/215163374-caed3985-0ee3-46c5-93cd-cb215273c39d.gif)

After:
![Jan-27-2023 10-13-16](https://user-images.githubusercontent.com/60050885/215163415-4529aecf-e672-4b0c-98cf-46c356a8e34d.gif)

Closes #62126