### PR TITLE
ContextMenu: Consider y coord when determining bottom collision

### DIFF
--- a/packages/grafana-ui/src/components/ContextMenu/ContextMenu.tsx
+++ b/packages/grafana-ui/src/components/ContextMenu/ContextMenu.tsx
@@ -33,7 +33,7 @@ export const ContextMenu: React.FC<ContextMenuProps> = React.memo(
         const OFFSET = 5;
         const collisions = {
           right: window.innerWidth < x + rect.width,
-          bottom: window.innerHeight < rect.bottom + rect.height + OFFSET,
+          bottom: window.innerHeight < y + rect.height + OFFSET,
         };
 
         setPositionStyles({


### PR DESCRIPTION
**What is this feature?**

Use the clicked y coordinate to determine when the menu collides with the bottom of the screen

**Why do we need this feature?**

Menu can expand off the bottom of the screen.

**Special notes for your reviewer**:

Before:
https://user-images.githubusercontent.com/1533128/215202289-cc06c1f8-bd83-47d9-bacd-aad846b85a8b.mov

After:
https://user-images.githubusercontent.com/1533128/215202319-e0b57c99-2c00-4fc9-b4b5-8699929f07e8.mov
