### PR TITLE
Alerting: Configurable externalLabels for Loki state history

### DIFF
--- a/pkg/services/ngalert/state/historian/loki.go
+++ b/pkg/services/ngalert/state/historian/loki.go
@@ -29,15 +29,17 @@ type remoteLokiClient interface {
 }
 
 type RemoteLokiBackend struct {
-	client remoteLokiClient
-	log    log.Logger
+	client         remoteLokiClient
+	externalLabels map[string]string
+	log            log.Logger
 }
 
 func NewRemoteLokiBackend(cfg LokiConfig) *RemoteLokiBackend {
 	logger := log.New("ngalert.state.historian", "backend", "loki")
 	return &RemoteLokiBackend{
-		client: newLokiClient(cfg, logger),
-		log:    logger,
+		client:         newLokiClient(cfg, logger),
+		externalLabels: cfg.ExternalLabels,
+		log:            logger,
 	}
 }
 
@@ -62,7 +64,7 @@ func (h *RemoteLokiBackend) statesToStreams(rule history_model.RuleMeta, states 
 			continue
 		}
 
-		labels := removePrivateLabels(state.State.Labels)
+		labels := h.addExternalLabels(removePrivateLabels(state.State.Labels))
 		labels[OrgIDLabel] = fmt.Sprint(rule.OrgID)
 		labels[RuleUIDLabel] = fmt.Sprint(rule.UID)
 		labels[GroupLabel] = fmt.Sprint(rule.Group)
@@ -122,6 +124,16 @@ func (h *RemoteLokiBackend) recordStreams(ctx context.Context, streams []stream,
 	}
 	logger.Debug("Done saving alert state history batch")
 	return nil
+}
+
+func (h *RemoteLokiBackend) addExternalLabels(labels data.Labels) data.Labels {
+	if h.externalLabels == nil {
+		return labels
+	}
+	for k, v := range h.externalLabels {
+		labels[k] = v
+	}
+	return labels
 }
 
 type lokiEntry struct {

--- a/pkg/services/ngalert/state/historian/loki.go
+++ b/pkg/services/ngalert/state/historian/loki.go
@@ -127,9 +127,6 @@ func (h *RemoteLokiBackend) recordStreams(ctx context.Context, streams []stream,
 }
 
 func (h *RemoteLokiBackend) addExternalLabels(labels data.Labels) data.Labels {
-	if h.externalLabels == nil {
-		return labels
-	}
 	for k, v := range h.externalLabels {
 		labels[k] = v
 	}

--- a/pkg/services/ngalert/state/historian/loki_http.go
+++ b/pkg/services/ngalert/state/historian/loki_http.go
@@ -20,6 +20,7 @@ type LokiConfig struct {
 	BasicAuthUser     string
 	BasicAuthPassword string
 	TenantID          string
+	ExternalLabels    map[string]string
 }
 
 type httpLokiClient struct {

--- a/pkg/setting/setting_unified_alerting.go
+++ b/pkg/setting/setting_unified_alerting.go
@@ -108,6 +108,7 @@ type UnifiedAlertingStateHistorySettings struct {
 	// if one of them is set.
 	LokiBasicAuthPassword string
 	LokiBasicAuthUsername string
+	ExternalLabels        map[string]string
 }
 
 // IsEnabled returns true if UnifiedAlertingSettings.Enabled is either nil or true.
@@ -317,6 +318,7 @@ func (cfg *Cfg) ReadUnifiedAlertingSettings(iniFile *ini.File) error {
 	uaCfg.ReservedLabels = uaCfgReservedLabels
 
 	stateHistory := iniFile.Section("unified_alerting.state_history")
+	stateHistoryLabels := iniFile.Section("unified_alerting.state_history.external_labels")
 	uaCfgStateHistory := UnifiedAlertingStateHistorySettings{
 		Enabled:               stateHistory.Key("enabled").MustBool(stateHistoryDefaultEnabled),
 		Backend:               stateHistory.Key("backend").MustString("annotations"),
@@ -324,6 +326,7 @@ func (cfg *Cfg) ReadUnifiedAlertingSettings(iniFile *ini.File) error {
 		LokiTenantID:          stateHistory.Key("loki_tenant_id").MustString(""),
 		LokiBasicAuthUsername: stateHistory.Key("loki_basic_auth_username").MustString(""),
 		LokiBasicAuthPassword: stateHistory.Key("loki_basic_auth_password").MustString(""),
+		ExternalLabels:        stateHistoryLabels.KeysHash(),
 	}
 	uaCfg.StateHistory = uaCfgStateHistory
 


### PR DESCRIPTION
**What is this feature?**

This adds a new config option, `external_labels`, where the user can provide labels that will be attached to the state history streams in Loki.

**Why do we need this feature?**

This allows systems controlling Grafana to configure and attach any additional labels they like, at the instance level.

**Who is this feature for?**

Users of Grafana helm charts, hosted grafana, HA-mode, or any other context in which an external system controls Grafana instances.

This is also a workaround for HA-mode users who want to deduplicate state history entries at read-time from multiple rulers.

**Which issue(s) does this PR fix?**:

contrib https://github.com/grafana/grafana/issues/48359

**Special notes for your reviewer**:

As the other options, not documented yet, this is acting as our "feature flag."

