### PR TITLE
Canvas: Improve anchor UX

### DIFF
--- a/public/app/plugins/panel/canvas/ConnectionAnchors.tsx
+++ b/public/app/plugins/panel/canvas/ConnectionAnchors.tsx
@@ -14,13 +14,13 @@ type Props = {
 
 export const CONNECTION_ANCHOR_DIV_ID = 'connectionControl';
 export const CONNECTION_ANCHOR_ALT = 'connection anchor';
-const anchorPadding = 3;
-export const connectionAnchorHighlightOffset = 8;
+export const CONNECTION_ANCHOR_HIGHLIGHT_OFFSET = 8;
+
+const ANCHOR_PADDING = 3;
 
 export const ConnectionAnchors = ({ setRef, handleMouseLeave }: Props) => {
   const highlightEllipseRef = useRef<HTMLDivElement>(null);
   const styles = useStyles2(getStyles);
-  // TODO re-evaluate dimensional constants
   const halfSize = 2.5;
   const halfSizeHighlightEllipse = 5.5;
   const anchorImage =
@@ -33,8 +33,8 @@ export const ConnectionAnchors = ({ setRef, handleMouseLeave }: Props) => {
 
     if (highlightEllipseRef.current && event.target.style) {
       highlightEllipseRef.current.style.display = 'block';
-      highlightEllipseRef.current.style.top = `calc(${event.target.style.top} - ${halfSizeHighlightEllipse}px + ${anchorPadding}px)`;
-      highlightEllipseRef.current.style.left = `calc(${event.target.style.left} - ${halfSizeHighlightEllipse}px + ${anchorPadding}px)`;
+      highlightEllipseRef.current.style.top = `calc(${event.target.style.top} - ${halfSizeHighlightEllipse}px + ${ANCHOR_PADDING}px)`;
+      highlightEllipseRef.current.style.left = `calc(${event.target.style.left} - ${halfSizeHighlightEllipse}px + ${ANCHOR_PADDING}px)`;
     }
   };
 
@@ -81,8 +81,8 @@ export const ConnectionAnchors = ({ setRef, handleMouseLeave }: Props) => {
 
       // Convert anchor coords to relative percentage
       const style = {
-        top: `calc(${-anchor.y * 50 + 50}% - ${halfSize}px - ${anchorPadding}px)`,
-        left: `calc(${anchor.x * 50 + 50}% - ${halfSize}px - ${anchorPadding}px)`,
+        top: `calc(${-anchor.y * 50 + 50}% - ${halfSize}px - ${ANCHOR_PADDING}px)`,
+        left: `calc(${anchor.x * 50 + 50}% - ${halfSize}px - ${ANCHOR_PADDING}px)`,
       };
 
       return (
@@ -125,11 +125,11 @@ const getStyles = (theme: GrafanaTheme2) => ({
     height: calc(100% + 60px);
   `,
   anchor: css`
-    padding: ${anchorPadding}px;
+    padding: ${ANCHOR_PADDING}px;
     position: absolute;
     cursor: cursor;
-    width: calc(5px + 2 * ${anchorPadding}px);
-    height: calc(5px + 2 * ${anchorPadding}px);
+    width: calc(5px + 2 * ${ANCHOR_PADDING}px);
+    height: calc(5px + 2 * ${ANCHOR_PADDING}px);
     z-index: 100;
     pointer-events: auto !important;
   `,
@@ -140,8 +140,8 @@ const getStyles = (theme: GrafanaTheme2) => ({
     cursor: cursor;
     position: absolute;
     pointer-events: auto;
-    width: calc(${connectionAnchorHighlightOffset}px * 2);
-    height: calc(${connectionAnchorHighlightOffset}px * 2);
+    width: 16px;
+    height: 16px;
     border-radius: 50%;
     display: none;
     z-index: 110;

--- a/public/app/plugins/panel/canvas/ConnectionAnchors.tsx
+++ b/public/app/plugins/panel/canvas/ConnectionAnchors.tsx
@@ -14,10 +14,13 @@ type Props = {
 
 export const CONNECTION_ANCHOR_DIV_ID = 'connectionControl';
 export const CONNECTION_ANCHOR_ALT = 'connection anchor';
+const anchorPadding = 3;
+export const connectionAnchorHighlightOffset = 8;
 
 export const ConnectionAnchors = ({ setRef, handleMouseLeave }: Props) => {
   const highlightEllipseRef = useRef<HTMLDivElement>(null);
   const styles = useStyles2(getStyles);
+  // TODO re-evaluate dimensional constants
   const halfSize = 2.5;
   const halfSizeHighlightEllipse = 5.5;
   const anchorImage =
@@ -30,8 +33,8 @@ export const ConnectionAnchors = ({ setRef, handleMouseLeave }: Props) => {
 
     if (highlightEllipseRef.current && event.target.style) {
       highlightEllipseRef.current.style.display = 'block';
-      highlightEllipseRef.current.style.top = `calc(${event.target.style.top} - ${halfSizeHighlightEllipse}px)`;
-      highlightEllipseRef.current.style.left = `calc(${event.target.style.left} - ${halfSizeHighlightEllipse}px)`;
+      highlightEllipseRef.current.style.top = `calc(${event.target.style.top} - ${halfSizeHighlightEllipse}px + ${anchorPadding}px)`;
+      highlightEllipseRef.current.style.left = `calc(${event.target.style.left} - ${halfSizeHighlightEllipse}px + ${anchorPadding}px)`;
     }
   };
 
@@ -78,8 +81,8 @@ export const ConnectionAnchors = ({ setRef, handleMouseLeave }: Props) => {
 
       // Convert anchor coords to relative percentage
       const style = {
-        top: `calc(${-anchor.y * 50 + 50}% - ${halfSize}px)`,
-        left: `calc(${anchor.x * 50 + 50}% - ${halfSize}px)`,
+        top: `calc(${-anchor.y * 50 + 50}% - ${halfSize}px - ${anchorPadding}px)`,
+        left: `calc(${anchor.x * 50 + 50}% - ${halfSize}px - ${anchorPadding}px)`,
       };
 
       return (
@@ -122,10 +125,11 @@ const getStyles = (theme: GrafanaTheme2) => ({
     height: calc(100% + 60px);
   `,
   anchor: css`
+    padding: ${anchorPadding}px;
     position: absolute;
     cursor: cursor;
-    width: 5px;
-    height: 5px;
+    width: calc(5px + 2 * ${anchorPadding}px);
+    height: calc(5px + 2 * ${anchorPadding}px);
     z-index: 100;
     pointer-events: auto !important;
   `,
@@ -136,8 +140,8 @@ const getStyles = (theme: GrafanaTheme2) => ({
     cursor: cursor;
     position: absolute;
     pointer-events: auto;
-    width: 16px;
-    height: 16px;
+    width: calc(${connectionAnchorHighlightOffset}px * 2);
+    height: calc(${connectionAnchorHighlightOffset}px * 2);
     border-radius: 50%;
     display: none;
     z-index: 110;

--- a/public/app/plugins/panel/canvas/Connections.tsx
+++ b/public/app/plugins/panel/canvas/Connections.tsx
@@ -4,7 +4,7 @@ import { ConnectionPath } from 'app/features/canvas';
 import { ElementState } from 'app/features/canvas/runtime/element';
 import { Scene } from 'app/features/canvas/runtime/scene';
 
-import { CONNECTION_ANCHOR_ALT, ConnectionAnchors, connectionAnchorHighlightOffset } from './ConnectionAnchors';
+import { CONNECTION_ANCHOR_ALT, ConnectionAnchors, CONNECTION_ANCHOR_HIGHLIGHT_OFFSET } from './ConnectionAnchors';
 import { ConnectionSVG } from './ConnectionSVG';
 
 export class Connections {
@@ -121,7 +121,7 @@ export class Connections {
     const connectionLineY1 = this.connectionLine.y1.baseVal.value;
     if (!this.didConnectionLeaveHighlight) {
       const connectionLength = Math.hypot(x - connectionLineX1, y - connectionLineY1);
-      if (connectionLength > connectionAnchorHighlightOffset && this.connectionSVG) {
+      if (connectionLength > CONNECTION_ANCHOR_HIGHLIGHT_OFFSET && this.connectionSVG) {
         this.didConnectionLeaveHighlight = true;
         this.connectionSVG.style.display = 'block';
         this.isDrawingConnection = true;
@@ -206,8 +206,8 @@ export class Connections {
       const connectionStartTargetBox = selectedTarget.getBoundingClientRect();
       const parentBoundingRect = this.scene.div.parentElement.getBoundingClientRect();
 
-      const x = connectionStartTargetBox.x - parentBoundingRect.x + connectionAnchorHighlightOffset;
-      const y = connectionStartTargetBox.y - parentBoundingRect.y + connectionAnchorHighlightOffset;
+      const x = connectionStartTargetBox.x - parentBoundingRect.x + CONNECTION_ANCHOR_HIGHLIGHT_OFFSET;
+      const y = connectionStartTargetBox.y - parentBoundingRect.y + CONNECTION_ANCHOR_HIGHLIGHT_OFFSET;
 
       const mouseX = clientX - parentBoundingRect.x;
       const mouseY = clientY - parentBoundingRect.y;

--- a/public/app/plugins/panel/canvas/Connections.tsx
+++ b/public/app/plugins/panel/canvas/Connections.tsx
@@ -4,7 +4,7 @@ import { ConnectionPath } from 'app/features/canvas';
 import { ElementState } from 'app/features/canvas/runtime/element';
 import { Scene } from 'app/features/canvas/runtime/scene';
 
-import { CONNECTION_ANCHOR_ALT, ConnectionAnchors } from './ConnectionAnchors';
+import { CONNECTION_ANCHOR_ALT, ConnectionAnchors, connectionAnchorHighlightOffset } from './ConnectionAnchors';
 import { ConnectionSVG } from './ConnectionSVG';
 
 export class Connections {
@@ -15,6 +15,7 @@ export class Connections {
   connectionSource?: ElementState;
   connectionTarget?: ElementState;
   isDrawingConnection?: boolean;
+  didConnectionLeaveHighlight?: boolean;
 
   constructor(scene: Scene) {
     this.scene = scene;
@@ -116,11 +117,19 @@ export class Connections {
     this.connectionLine.setAttribute('x2', `${x}`);
     this.connectionLine.setAttribute('y2', `${y}`);
 
+    const connectionLineX1 = this.connectionLine.x1.baseVal.value;
+    const connectionLineY1 = this.connectionLine.y1.baseVal.value;
+    if (!this.didConnectionLeaveHighlight) {
+      const connectionLength = Math.hypot(x - connectionLineX1, y - connectionLineY1);
+      if (connectionLength > connectionAnchorHighlightOffset && this.connectionSVG) {
+        this.didConnectionLeaveHighlight = true;
+        this.connectionSVG.style.display = 'block';
+        this.isDrawingConnection = true;
+      }
+    }
+
     if (!event.buttons) {
       if (this.connectionSource && this.connectionSource.div && this.connectionSource.div.parentElement) {
-        const connectionLineX1 = this.connectionLine.x1.baseVal.value;
-        const connectionLineY1 = this.connectionLine.y1.baseVal.value;
-
         const sourceRect = this.connectionSource.div.getBoundingClientRect();
         const parentRect = this.connectionSource.div.parentElement.getBoundingClientRect();
 
@@ -172,9 +181,10 @@ export class Connections {
         if (!options.connections) {
           options.connections = [];
         }
-        this.connectionSource.options.connections = [...options.connections, connection];
-
-        this.connectionSource.onChange(this.connectionSource.options);
+        if (this.didConnectionLeaveHighlight) {
+          this.connectionSource.options.connections = [...options.connections, connection];
+          this.connectionSource.onChange(this.connectionSource.options);
+        }
       }
 
       if (this.connectionSVG) {
@@ -196,8 +206,6 @@ export class Connections {
       const connectionStartTargetBox = selectedTarget.getBoundingClientRect();
       const parentBoundingRect = this.scene.div.parentElement.getBoundingClientRect();
 
-      // TODO: Make this not as magic numbery -> related to the height / width of highlight ellipse
-      const connectionAnchorHighlightOffset = 8;
       const x = connectionStartTargetBox.x - parentBoundingRect.x + connectionAnchorHighlightOffset;
       const y = connectionStartTargetBox.y - parentBoundingRect.y + connectionAnchorHighlightOffset;
 
@@ -208,9 +216,7 @@ export class Connections {
       this.connectionLine.setAttribute('y1', `${y}`);
       this.connectionLine.setAttribute('x2', `${mouseX}`);
       this.connectionLine.setAttribute('y2', `${mouseY}`);
-      this.connectionSVG.style.display = 'block';
-
-      this.isDrawingConnection = true;
+      this.didConnectionLeaveHighlight = false;
     }
 
     this.scene.selecto?.rootContainer?.addEventListener('mousemove', this.connectionListener);


### PR DESCRIPTION
What this PR does / why we need it:
Currently in canvas, when a user clicks an anchor to start creating a connection, then mouse-ups before dragging, a small and difficult to delete connection is created. Also, mousing over the anchor is difficult because the hover area is relatively small. This PR addresses:

1. CSS improvements for anchor images to increase mouse hover area by adding padding (and subsequently offsetting their size and positions appropriately)
2. addressing magic number by making most things dependent on connectionAnchorHighlightOffset
3. only create a connection if the length of the arrow being draw is outside of the highlight area

- [x] Set a minimum connection drag distance before displaying and creating a connection
- [x] Make the hover area for anchors larger

After:
![Jan-27-2023 15-24-51](https://user-images.githubusercontent.com/60050885/215224432-09edc021-dbbf-4518-9238-6c1821901153.gif)

Closes #61439