### PR TITLE
Alerting: Add export button for exporting all alert rules in alert list view

### DIFF
--- a/public/app/features/alerting/unified/RuleList.test.tsx
+++ b/public/app/features/alerting/unified/RuleList.test.tsx
@@ -1,12 +1,12 @@
 import { SerializedError } from '@reduxjs/toolkit';
-import { render, waitFor, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { Provider } from 'react-redux';
 import { Router } from 'react-router-dom';
 import { byRole, byTestId, byText } from 'testing-library-selector';
 
-import { locationService, setDataSourceSrv, logInfo, setBackendSrv } from '@grafana/runtime';
+import { locationService, logInfo, setBackendSrv, setDataSourceSrv } from '@grafana/runtime';
 import { backendSrv } from 'app/core/services/backend_srv';
 import { contextSrv } from 'app/core/services/context_srv';
 import * as ruleActionButtons from 'app/features/alerting/unified/components/rules/RuleActionsButtons';
@@ -123,6 +123,7 @@ const ui = {
   editCloudGroupIcon: byTestId('edit-group'),
 
   newRuleButton: byRole('link', { name: 'New alert rule' }),
+  exportButton: byRole('button', { name: /export/i }),
 
   editGroupModal: {
     namespaceInput: byRole('textbox', { hidden: true, name: /namespace/i }),
@@ -681,6 +682,34 @@ describe('RuleList', () => {
   });
 
   describe('RBAC Enabled', () => {
+    describe('Export button', () => {
+      it('Export button should be visible when the user has alert provisioning read permissions', async () => {
+        enableRBAC();
+
+        grantUserPermissions([AccessControlAction.AlertingProvisioningRead]);
+
+        mocks.getAllDataSourcesMock.mockReturnValue([]);
+        setDataSourceSrv(new MockDataSourceSrv({}));
+        mocks.api.fetchRules.mockResolvedValue([]);
+        mocks.api.fetchRulerRules.mockResolvedValue({});
+
+        renderRuleList();
+
+        expect(ui.exportButton.get()).toBeInTheDocument();
+      });
+      it('Export button should not be visible when the user has no alert provisioning read permissions', async () => {
+        enableRBAC();
+
+        mocks.getAllDataSourcesMock.mockReturnValue([]);
+        setDataSourceSrv(new MockDataSourceSrv({}));
+        mocks.api.fetchRules.mockResolvedValue([]);
+        mocks.api.fetchRulerRules.mockResolvedValue({});
+
+        renderRuleList();
+
+        expect(ui.exportButton.query()).not.toBeInTheDocument();
+      });
+    });
     describe('Grafana Managed Alerts', () => {
       it('New alert button should be visible when the user has alert rule create and folder read permissions and no rules exists', async () => {
         enableRBAC();

--- a/public/app/features/alerting/unified/RuleList.tsx
+++ b/public/app/features/alerting/unified/RuleList.tsx
@@ -46,7 +46,7 @@ const RuleList = withErrorBoundary(
     const [queryParams] = useQueryParams();
     const { filterState, hasActiveFilters } = useRulesFilter();
 
-    const { canCreateGrafanaRules, canCreateCloudRules } = useRulesAccess();
+    const { canCreateGrafanaRules, canCreateCloudRules, canReadProvisioning } = useRulesAccess();
 
     const view = VIEWS[queryParams['view'] as keyof typeof VIEWS]
       ? (queryParams['view'] as keyof typeof VIEWS)
@@ -110,9 +110,11 @@ const RuleList = withErrorBoundary(
                 <RuleStats namespaces={filteredNamespaces} includeTotal />
               </div>
               <Stack direction="row" gap={0.5}>
-                <Button icon="download-alt" type="button" onClick={onExport}>
-                  Export
-                </Button>
+                {canReadProvisioning && (
+                  <Button icon="download-alt" type="button" onClick={onExport}>
+                    Export
+                  </Button>
+                )}
                 {(canCreateGrafanaRules || canCreateCloudRules) && (
                   <LinkButton
                     href={urlUtil.renderUrl('alerting/new', { returnTo: location.pathname + location.search })}

--- a/public/app/features/alerting/unified/RuleList.tsx
+++ b/public/app/features/alerting/unified/RuleList.tsx
@@ -4,6 +4,7 @@ import { useLocation } from 'react-router-dom';
 import { useAsyncFn, useInterval } from 'react-use';
 
 import { GrafanaTheme2, urlUtil } from '@grafana/data';
+import { Stack } from '@grafana/experimental';
 import { logInfo } from '@grafana/runtime';
 import { Button, LinkButton, useStyles2, withErrorBoundary } from '@grafana/ui';
 import { useQueryParams } from 'app/core/hooks/useQueryParams';
@@ -31,6 +32,8 @@ const VIEWS = {
   groups: RuleListGroupView,
   state: RuleListStateView,
 };
+
+const onExport = () => window.open(`/api/v1/provisioning/alert-rules/export?download=true`);
 
 const RuleList = withErrorBoundary(
   () => {
@@ -106,15 +109,20 @@ const RuleList = withErrorBoundary(
                 )}
                 <RuleStats namespaces={filteredNamespaces} includeTotal />
               </div>
-              {(canCreateGrafanaRules || canCreateCloudRules) && (
-                <LinkButton
-                  href={urlUtil.renderUrl('alerting/new', { returnTo: location.pathname + location.search })}
-                  icon="plus"
-                  onClick={() => logInfo(LogMessages.alertRuleFromScratch)}
-                >
-                  New alert rule
-                </LinkButton>
-              )}
+              <Stack direction="row" gap={0.5}>
+                <Button icon="download-alt" type="button" onClick={onExport}>
+                  Export
+                </Button>
+                {(canCreateGrafanaRules || canCreateCloudRules) && (
+                  <LinkButton
+                    href={urlUtil.renderUrl('alerting/new', { returnTo: location.pathname + location.search })}
+                    icon="plus"
+                    onClick={() => logInfo(LogMessages.alertRuleFromScratch)}
+                  >
+                    New alert rule
+                  </LinkButton>
+                )}
+              </Stack>
             </div>
           </>
         )}

--- a/public/app/features/alerting/unified/hooks/useFilteredRules.ts
+++ b/public/app/features/alerting/unified/hooks/useFilteredRules.ts
@@ -7,7 +7,7 @@ import { Matcher } from 'app/plugins/datasource/alertmanager/types';
 import { CombinedRuleGroup, CombinedRuleNamespace } from 'app/types/unified-alerting';
 import { isPromAlertingRuleState, PromRuleType, RulerGrafanaRuleDTO } from 'app/types/unified-alerting-dto';
 
-import { getSearchFilterFromQuery, RulesFilter, applySearchFilterToQuery } from '../search/rulesSearchParser';
+import { applySearchFilterToQuery, getSearchFilterFromQuery, RulesFilter } from '../search/rulesSearchParser';
 import { labelsMatchMatchers, matcherToMatcherField, parseMatcher, parseMatchers } from '../utils/alertmanager';
 import { isCloudRulesSource } from '../utils/datasource';
 import { getRuleHealth, isAlertingRule, isGrafanaRulerRule, isPromRuleType } from '../utils/rules';

--- a/public/app/features/alerting/unified/utils/access-control.ts
+++ b/public/app/features/alerting/unified/utils/access-control.ts
@@ -47,6 +47,11 @@ export const notificationsPermissions = {
   },
 };
 
+export const provisioningPermissions = {
+  read: AccessControlAction.AlertingProvisioningRead,
+  write: AccessControlAction.AlertingProvisioningWrite,
+};
+
 const rulesPermissions = {
   read: {
     grafana: AccessControlAction.AlertingRuleRead,
@@ -118,5 +123,6 @@ export function getRulesAccess() {
         rulesSourceName === GRAFANA_RULES_SOURCE_NAME ? contextSrv.hasEditPermissionInFolders : contextSrv.isEditor;
       return contextSrv.hasAccess(getRulesPermissions(rulesSourceName).update, permissionFallback);
     },
+    canReadProvisioning: contextSrv.hasAccess(AccessControlAction.AlertingProvisioningRead, contextSrv.isGrafanaAdmin),
   };
 }

--- a/public/app/features/alerting/unified/utils/access-control.ts
+++ b/public/app/features/alerting/unified/utils/access-control.ts
@@ -123,6 +123,6 @@ export function getRulesAccess() {
         rulesSourceName === GRAFANA_RULES_SOURCE_NAME ? contextSrv.hasEditPermissionInFolders : contextSrv.isEditor;
       return contextSrv.hasAccess(getRulesPermissions(rulesSourceName).update, permissionFallback);
     },
-    canReadProvisioning: contextSrv.hasAccess(AccessControlAction.AlertingProvisioningRead, contextSrv.isGrafanaAdmin),
+    canReadProvisioning: contextSrv.hasAccess(provisioningPermissions.read, contextSrv.isGrafanaAdmin),
   };
 }

--- a/public/app/types/accessControl.ts
+++ b/public/app/types/accessControl.ts
@@ -117,6 +117,10 @@ export enum AccessControlAction {
   AlertingNotificationsExternalWrite = 'alert.notifications.external:write',
   AlertingNotificationsExternalRead = 'alert.notifications.external:read',
 
+  // Alerting provisioning actions
+  AlertingProvisioningRead = 'alert.provisioning:read',
+  AlertingProvisioningWrite = 'alert.provisioning:write',
+
   ActionAPIKeysRead = 'apikeys:read',
   ActionAPIKeysCreate = 'apikeys:create',
   ActionAPIKeysDelete = 'apikeys:delete',


### PR DESCRIPTION
**What is this feature?**

This PR adds an export button in the alert list view for exporting all alert rules.

This button is only visible if user has the necessary [permissions ](https://github.com/grafana/grafana/blob/559da8b3474dee6d966672b7b2cb7b7fa057c8cc/pkg/services/ngalert/api/authorization.go#L195-L209)are **alert.provisioning:read** with RBAC falling back to admin without RBAC.

**Why do we need this feature?**
This feature is intended to facilitate provisioning file creation for alerts as well as allowing for a feature for downloading provisioning file exports directly from the UI.

**Who is this feature for?**

Al users.

**Which issue(s) does this PR fix?**:
Partial: https://github.com/grafana/grafana/issues/48622

**Special notes for your reviewer**:

https://user-images.githubusercontent.com/33540275/215275703-b4ec09dc-a5c2-428b-9f11-0c011a929a96.mp4


<img width="1556" alt="Screenshot 2023-01-31 at 14 44 15" src="https://user-images.githubusercontent.com/33540275/215777075-643634ab-bc3c-422e-8228-f4a1f05e2e98.png">





