### PR TITLE
Chore: Fix goimports grouping

### DIFF
--- a/pkg/infra/appcontext/user_test.go
+++ b/pkg/infra/appcontext/user_test.go
@@ -6,13 +6,14 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/grafana/pkg/infra/appcontext"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/contexthandler/ctxkey"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	grpccontext "github.com/grafana/grafana/pkg/services/grpcserver/context"
 	"github.com/grafana/grafana/pkg/services/user"
-	"github.com/stretchr/testify/require"
 )
 
 func TestUserFromContext(t *testing.T) {

--- a/pkg/infra/log/file_test.go
+++ b/pkg/infra/log/file_test.go
@@ -4,9 +4,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func (w *FileLogWriter) WriteLine(line string) error {

--- a/pkg/infra/metrics/metrics.go
+++ b/pkg/infra/metrics/metrics.go
@@ -3,10 +3,11 @@ package metrics
 import (
 	"runtime"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/grafana/grafana/pkg/infra/metrics/metricutil"
 	pubdash "github.com/grafana/grafana/pkg/services/publicdashboards/models"
 	"github.com/grafana/grafana/pkg/setting"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 // ExporterName is used as namespace for exposing prometheus metrics

--- a/pkg/infra/metrics/settings.go
+++ b/pkg/infra/metrics/settings.go
@@ -5,9 +5,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/grafana/grafana/pkg/infra/metrics/graphitebridge"
 	"github.com/grafana/grafana/pkg/setting"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 func (im *InternalMetricsService) readSettings() error {

--- a/pkg/infra/remotecache/memcached_storage.go
+++ b/pkg/infra/remotecache/memcached_storage.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/bradfitz/gomemcache/memcache"
+
 	"github.com/grafana/grafana/pkg/setting"
 )
 

--- a/pkg/infra/remotecache/redis_storage.go
+++ b/pkg/infra/remotecache/redis_storage.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/go-redis/redis/v8"
+
 	"github.com/grafana/grafana/pkg/setting"
 )
 

--- a/pkg/infra/tracing/optentelemetry_tracing_test.go
+++ b/pkg/infra/tracing/optentelemetry_tracing_test.go
@@ -3,9 +3,10 @@ package tracing
 import (
 	"testing"
 
-	"github.com/grafana/grafana/pkg/setting"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 func TestSplitCustomAttribs(t *testing.T) {

--- a/pkg/infra/tracing/tracing_test.go
+++ b/pkg/infra/tracing/tracing_test.go
@@ -4,9 +4,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/grafana/grafana/pkg/setting"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 func TestGroupSplit(t *testing.T) {

--- a/pkg/infra/usagestats/statscollector/prometheus_flavor_test.go
+++ b/pkg/infra/usagestats/statscollector/prometheus_flavor_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/infra/db/dbtest"

--- a/pkg/infra/usagestats/statscollector/service_test.go
+++ b/pkg/infra/usagestats/statscollector/service_test.go
@@ -7,10 +7,10 @@ import (
 	"testing"
 	"time"
 
+	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/db/dbtest"

--- a/pkg/infra/usagestats/statscollector/service_test.go
+++ b/pkg/infra/usagestats/statscollector/service_test.go
@@ -7,13 +7,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grafana/grafana/pkg/components/simplejson"
-
-	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/db/dbtest"
 	"github.com/grafana/grafana/pkg/infra/httpclient"


### PR DESCRIPTION
This PR deprecates https://github.com/grafana/grafana/pull/60870 and fixes goimports ordering in `pkg/infra`