### PR TITLE
Chore: Fix goimports grouping

### DIFF
--- a/pkg/bus/bus_test.go
+++ b/pkg/bus/bus_test.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/infra/tracing"
 )
 
 type testQuery struct {

--- a/pkg/cmd/grafana-cli/commands/cli.go
+++ b/pkg/cmd/grafana-cli/commands/cli.go
@@ -4,10 +4,11 @@ import (
 	"os"
 	"runtime"
 
+	"github.com/urfave/cli/v2"
+
 	"github.com/grafana/grafana/pkg/cmd/grafana-cli/logger"
 	"github.com/grafana/grafana/pkg/cmd/grafana-cli/services"
 	"github.com/grafana/grafana/pkg/cmd/grafana-cli/utils"
-	"github.com/urfave/cli/v2"
 )
 
 // RunCLI is the entrypoint for the grafana-cli command. It returns the exit code for the grafana-cli program.

--- a/pkg/cmd/grafana-cli/commands/commandstest/context.go
+++ b/pkg/cmd/grafana-cli/commands/commandstest/context.go
@@ -3,8 +3,9 @@ package commandstest
 import (
 	"flag"
 
-	"github.com/grafana/grafana/pkg/cmd/grafana-cli/utils"
 	"github.com/urfave/cli/v2"
+
+	"github.com/grafana/grafana/pkg/cmd/grafana-cli/utils"
 )
 
 // NewCliContext creates a new CLI context with a certain set of flags.

--- a/pkg/cmd/grafana-cli/commands/ls_command.go
+++ b/pkg/cmd/grafana-cli/commands/ls_command.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"github.com/fatih/color"
+
 	"github.com/grafana/grafana/pkg/cmd/grafana-cli/logger"
 	"github.com/grafana/grafana/pkg/cmd/grafana-cli/models"
 	"github.com/grafana/grafana/pkg/cmd/grafana-cli/services"

--- a/pkg/cmd/grafana-cli/commands/upgrade_all_command.go
+++ b/pkg/cmd/grafana-cli/commands/upgrade_all_command.go
@@ -3,11 +3,12 @@ package commands
 import (
 	"context"
 
+	"github.com/hashicorp/go-version"
+
 	"github.com/grafana/grafana/pkg/cmd/grafana-cli/logger"
 	"github.com/grafana/grafana/pkg/cmd/grafana-cli/models"
 	"github.com/grafana/grafana/pkg/cmd/grafana-cli/services"
 	"github.com/grafana/grafana/pkg/cmd/grafana-cli/utils"
-	"github.com/hashicorp/go-version"
 )
 
 func shouldUpgrade(installed string, remote *models.Plugin) bool {

--- a/pkg/cmd/grafana-cli/commands/upgrade_all_command_test.go
+++ b/pkg/cmd/grafana-cli/commands/upgrade_all_command_test.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/grafana/grafana/pkg/cmd/grafana-cli/models"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/grafana/grafana/pkg/cmd/grafana-cli/models"
 )
 
 func TestVersionComparison(t *testing.T) {

--- a/pkg/cmd/grafana-cli/commands/upgrade_command.go
+++ b/pkg/cmd/grafana-cli/commands/upgrade_command.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/fatih/color"
+
 	"github.com/grafana/grafana/pkg/cmd/grafana-cli/logger"
 	"github.com/grafana/grafana/pkg/cmd/grafana-cli/services"
 	"github.com/grafana/grafana/pkg/cmd/grafana-cli/utils"

--- a/pkg/cmd/grafana-cli/runner/wire.go
+++ b/pkg/cmd/grafana-cli/runner/wire.go
@@ -7,8 +7,8 @@ import (
 	"context"
 
 	"github.com/google/wire"
-
 	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+
 	"github.com/grafana/grafana/pkg/api"
 	"github.com/grafana/grafana/pkg/api/avatar"
 	"github.com/grafana/grafana/pkg/api/routing"

--- a/pkg/cmd/grafana-cli/runner/wire.go
+++ b/pkg/cmd/grafana-cli/runner/wire.go
@@ -7,8 +7,8 @@ import (
 	"context"
 
 	"github.com/google/wire"
-	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 
+	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/grafana/grafana/pkg/api"
 	"github.com/grafana/grafana/pkg/api/avatar"
 	"github.com/grafana/grafana/pkg/api/routing"

--- a/pkg/cmd/grafana-cli/utils/command_line.go
+++ b/pkg/cmd/grafana-cli/utils/command_line.go
@@ -3,8 +3,9 @@ package utils
 import (
 	"os"
 
-	"github.com/grafana/grafana/pkg/cmd/grafana-cli/models"
 	"github.com/urfave/cli/v2"
+
+	"github.com/grafana/grafana/pkg/cmd/grafana-cli/models"
 )
 
 type CommandLine interface {

--- a/pkg/cmd/grafana-server/commands/cli.go
+++ b/pkg/cmd/grafana-server/commands/cli.go
@@ -15,6 +15,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/urfave/cli/v2"
+
 	"github.com/grafana/grafana/pkg/api"
 	"github.com/grafana/grafana/pkg/extensions"
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -24,7 +26,6 @@ import (
 	_ "github.com/grafana/grafana/pkg/services/alerting/conditions"
 	_ "github.com/grafana/grafana/pkg/services/alerting/notifiers"
 	"github.com/grafana/grafana/pkg/setting"
-	"github.com/urfave/cli/v2"
 )
 
 type ServerOptions struct {

--- a/pkg/cmd/grafana/main.go
+++ b/pkg/cmd/grafana/main.go
@@ -5,9 +5,10 @@ import (
 	"os"
 
 	"github.com/fatih/color"
+	"github.com/urfave/cli/v2"
+
 	gcli "github.com/grafana/grafana/pkg/cmd/grafana-cli/commands"
 	gsrv "github.com/grafana/grafana/pkg/cmd/grafana-server/commands"
-	"github.com/urfave/cli/v2"
 )
 
 // The following variables cannot be constants, since they can be overridden through the -X link flag

--- a/pkg/middleware/logger_test.go
+++ b/pkg/middleware/logger_test.go
@@ -3,9 +3,10 @@ package middleware
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/grafana/grafana/pkg/infra/log"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_sanitizeURL(t *testing.T) {

--- a/pkg/middleware/middleware_basic_auth_test.go
+++ b/pkg/middleware/middleware_basic_auth_test.go
@@ -4,6 +4,9 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/grafana/pkg/login"
 	"github.com/grafana/grafana/pkg/services/apikey"
 	"github.com/grafana/grafana/pkg/services/contexthandler"
@@ -12,8 +15,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestMiddlewareBasicAuth(t *testing.T) {

--- a/pkg/middleware/middleware_jwt_auth_test.go
+++ b/pkg/middleware/middleware_jwt_auth_test.go
@@ -9,9 +9,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/services/auth/jwt"
-	"github.com/grafana/grafana/pkg/services/org"
-
 	"github.com/grafana/grafana/pkg/services/contexthandler"
+	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 )

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -13,10 +13,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/grafana-plugin-sdk-go/backend/gtime"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/grafana-plugin-sdk-go/backend/gtime"
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/infra/db/dbtest"
 	"github.com/grafana/grafana/pkg/infra/fs"

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -13,10 +13,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grafana/grafana-plugin-sdk-go/backend/gtime"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/grafana-plugin-sdk-go/backend/gtime"
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/infra/db/dbtest"
 	"github.com/grafana/grafana/pkg/infra/fs"

--- a/pkg/middleware/request_metrics.go
+++ b/pkg/middleware/request_metrics.go
@@ -6,12 +6,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/metrics"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/web"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 var (

--- a/pkg/mocks/mock_gcsifaces/mocks.go
+++ b/pkg/mocks/mock_gcsifaces/mocks.go
@@ -10,9 +10,10 @@ import (
 
 	storage "cloud.google.com/go/storage"
 	gomock "github.com/golang/mock/gomock"
-	gcsifaces "github.com/grafana/grafana/pkg/ifaces/gcsifaces"
 	google "golang.org/x/oauth2/google"
 	jwt "golang.org/x/oauth2/jwt"
+
+	gcsifaces "github.com/grafana/grafana/pkg/ifaces/gcsifaces"
 )
 
 // MockStorageClient is a mock of StorageClient interface

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -11,18 +11,17 @@ import (
 	"strconv"
 	"sync"
 
-	"github.com/grafana/grafana/pkg/infra/usagestats/statscollector"
-	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/grafana/grafana/pkg/api"
 	_ "github.com/grafana/grafana/pkg/extensions"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/metrics"
+	"github.com/grafana/grafana/pkg/infra/usagestats/statscollector"
 	"github.com/grafana/grafana/pkg/registry"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/provisioning"
-
 	"github.com/grafana/grafana/pkg/setting"
-	"golang.org/x/sync/errgroup"
 )
 
 // Options contains parameters for the New function.

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -7,11 +7,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/grafana/pkg/registry"
 	"github.com/grafana/grafana/pkg/server/backgroundsvcs"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
 	"github.com/grafana/grafana/pkg/setting"
-	"github.com/stretchr/testify/require"
 )
 
 type testService struct {

--- a/pkg/server/wire.go
+++ b/pkg/server/wire.go
@@ -5,8 +5,8 @@ package server
 
 import (
 	"github.com/google/wire"
-
 	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+
 	"github.com/grafana/grafana/pkg/api"
 	"github.com/grafana/grafana/pkg/api/avatar"
 	"github.com/grafana/grafana/pkg/api/routing"

--- a/pkg/server/wire.go
+++ b/pkg/server/wire.go
@@ -5,8 +5,8 @@ package server
 
 import (
 	"github.com/google/wire"
-	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 
+	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/grafana/grafana/pkg/api"
 	"github.com/grafana/grafana/pkg/api/avatar"
 	"github.com/grafana/grafana/pkg/api/routing"

--- a/pkg/setting/date_formats_test.go
+++ b/pkg/setting/date_formats_test.go
@@ -3,10 +3,9 @@ package setting
 import (
 	"testing"
 
-	"gopkg.in/ini.v1"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/ini.v1"
 )
 
 func TestValueAsTimezone(t *testing.T) {

--- a/pkg/setting/expanders_test.go
+++ b/pkg/setting/expanders_test.go
@@ -7,9 +7,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestExpandVar_EnvSuccessful(t *testing.T) {

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -21,16 +21,15 @@ import (
 	"strings"
 	"time"
 
-	"github.com/grafana/grafana-aws-sdk/pkg/awsds"
-	"github.com/grafana/grafana-azure-sdk-go/azsettings"
-	"github.com/grafana/grafana-plugin-sdk-go/backend/gtime"
-
-	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/util"
-
 	"github.com/gobwas/glob"
 	"github.com/prometheus/common/model"
 	"gopkg.in/ini.v1"
+
+	"github.com/grafana/grafana-aws-sdk/pkg/awsds"
+	"github.com/grafana/grafana-azure-sdk-go/azsettings"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/gtime"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/util"
 )
 
 type Scheme string

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -22,12 +22,12 @@ import (
 	"time"
 
 	"github.com/gobwas/glob"
-	"github.com/prometheus/common/model"
-	"gopkg.in/ini.v1"
-
 	"github.com/grafana/grafana-aws-sdk/pkg/awsds"
 	"github.com/grafana/grafana-azure-sdk-go/azsettings"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/gtime"
+	"github.com/prometheus/common/model"
+	"gopkg.in/ini.v1"
+
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/util"
 )

--- a/pkg/setting/setting_azure_test.go
+++ b/pkg/setting/setting_azure_test.go
@@ -3,10 +3,10 @@ package setting
 import (
 	"testing"
 
-	"github.com/grafana/grafana-azure-sdk-go/azsettings"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana-azure-sdk-go/azsettings"
 )
 
 func TestAzureSettings(t *testing.T) {

--- a/pkg/setting/setting_azure_test.go
+++ b/pkg/setting/setting_azure_test.go
@@ -3,10 +3,9 @@ package setting
 import (
 	"testing"
 
+	"github.com/grafana/grafana-azure-sdk-go/azsettings"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/grafana/grafana-azure-sdk-go/azsettings"
 )
 
 func TestAzureSettings(t *testing.T) {

--- a/pkg/setting/setting_feature_toggles.go
+++ b/pkg/setting/setting_feature_toggles.go
@@ -3,8 +3,9 @@ package setting
 import (
 	"strconv"
 
-	"github.com/grafana/grafana/pkg/util"
 	"gopkg.in/ini.v1"
+
+	"github.com/grafana/grafana/pkg/util"
 )
 
 // @deprecated -- should use `featuremgmt.FeatureToggles`

--- a/pkg/setting/setting_session_test.go
+++ b/pkg/setting/setting_session_test.go
@@ -4,9 +4,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/grafana/grafana/pkg/infra/log/logtest"
-
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/infra/log/logtest"
 )
 
 func TestSessionSettings(t *testing.T) {

--- a/pkg/setting/setting_test.go
+++ b/pkg/setting/setting_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
 	"gopkg.in/ini.v1"
 )
 

--- a/pkg/setting/setting_unified_alerting.go
+++ b/pkg/setting/setting_unified_alerting.go
@@ -7,12 +7,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/grafana/grafana-plugin-sdk-go/backend/gtime"
-
-	"github.com/grafana/grafana/pkg/util"
-
 	"github.com/prometheus/alertmanager/cluster"
 	"gopkg.in/ini.v1"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/gtime"
+	"github.com/grafana/grafana/pkg/util"
 )
 
 const (

--- a/pkg/setting/setting_unified_alerting.go
+++ b/pkg/setting/setting_unified_alerting.go
@@ -7,10 +7,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/grafana/grafana-plugin-sdk-go/backend/gtime"
 	"github.com/prometheus/alertmanager/cluster"
 	"gopkg.in/ini.v1"
 
-	"github.com/grafana/grafana-plugin-sdk-go/backend/gtime"
 	"github.com/grafana/grafana/pkg/util"
 )
 

--- a/pkg/tests/api/azuremonitor/azuremonitor_test.go
+++ b/pkg/tests/api/azuremonitor/azuremonitor_test.go
@@ -10,13 +10,14 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/tests/testinfra"
-	"github.com/stretchr/testify/require"
 )
 
 func TestIntegrationAzureMonitor(t *testing.T) {

--- a/pkg/tests/api/correlations/correlations_create_test.go
+++ b/pkg/tests/api/correlations/correlations_create_test.go
@@ -7,11 +7,12 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/grafana/pkg/services/correlations"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/user"
-	"github.com/stretchr/testify/require"
 )
 
 func TestIntegrationCreateCorrelation(t *testing.T) {

--- a/pkg/tests/api/correlations/correlations_delete_test.go
+++ b/pkg/tests/api/correlations/correlations_delete_test.go
@@ -7,11 +7,12 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/grafana/pkg/services/correlations"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/user"
-	"github.com/stretchr/testify/require"
 )
 
 func TestIntegrationDeleteCorrelation(t *testing.T) {

--- a/pkg/tests/api/correlations/correlations_update_test.go
+++ b/pkg/tests/api/correlations/correlations_update_test.go
@@ -7,11 +7,12 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/grafana/pkg/services/correlations"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/user"
-	"github.com/stretchr/testify/require"
 )
 
 func TestIntegrationUpdateCorrelation(t *testing.T) {

--- a/pkg/tests/api/elasticsearch/elasticsearch_test.go
+++ b/pkg/tests/api/elasticsearch/elasticsearch_test.go
@@ -10,13 +10,14 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/tests/testinfra"
-	"github.com/stretchr/testify/require"
 )
 
 func TestIntegrationElasticsearch(t *testing.T) {

--- a/pkg/tests/api/graphite/graphite_test.go
+++ b/pkg/tests/api/graphite/graphite_test.go
@@ -10,13 +10,14 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/tests/testinfra"
-	"github.com/stretchr/testify/require"
 )
 
 func TestIntegrationGraphite(t *testing.T) {

--- a/pkg/tests/api/influxdb/influxdb_test.go
+++ b/pkg/tests/api/influxdb/influxdb_test.go
@@ -10,13 +10,14 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/tests/testinfra"
-	"github.com/stretchr/testify/require"
 )
 
 func TestIntegrationInflux(t *testing.T) {

--- a/pkg/tests/api/loki/loki_test.go
+++ b/pkg/tests/api/loki/loki_test.go
@@ -10,13 +10,14 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/tests/testinfra"
-	"github.com/stretchr/testify/require"
 )
 
 func TestIntegrationLoki(t *testing.T) {

--- a/pkg/tests/api/opentdsb/opentdsb_test.go
+++ b/pkg/tests/api/opentdsb/opentdsb_test.go
@@ -10,13 +10,14 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/tests/testinfra"
-	"github.com/stretchr/testify/require"
 )
 
 func TestIntegrationOpenTSDB(t *testing.T) {

--- a/pkg/tests/api/plugins/api_plugins_test.go
+++ b/pkg/tests/api/plugins/api_plugins_test.go
@@ -11,15 +11,15 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/grafana/pkg/services/org/orgimpl"
 	"github.com/grafana/grafana/pkg/services/quota/quotaimpl"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/services/user/userimpl"
 	"github.com/grafana/grafana/pkg/tests/testinfra"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 const (

--- a/pkg/tests/api/plugins/backendplugin/backendplugin_test.go
+++ b/pkg/tests/api/plugins/backendplugin/backendplugin_test.go
@@ -11,10 +11,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
 
-	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/log"

--- a/pkg/tests/api/plugins/backendplugin/backendplugin_test.go
+++ b/pkg/tests/api/plugins/backendplugin/backendplugin_test.go
@@ -11,6 +11,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/components/simplejson"
@@ -22,8 +25,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/tests/testinfra"
-	"github.com/stretchr/testify/require"
-	"golang.org/x/oauth2"
 )
 
 const loginCookieName = "grafana_session"

--- a/pkg/tests/api/prometheus/prometheus_test.go
+++ b/pkg/tests/api/prometheus/prometheus_test.go
@@ -10,13 +10,14 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/tests/testinfra"
-	"github.com/stretchr/testify/require"
 )
 
 func TestIntegrationPrometheus(t *testing.T) {

--- a/pkg/tests/web/index_view_test.go
+++ b/pkg/tests/web/index_view_test.go
@@ -7,9 +7,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/grafana/grafana/pkg/tests/testinfra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/tests/testinfra"
 )
 
 // TestIntegrationIndexView tests the Grafana index view.


### PR DESCRIPTION
This PR deprecates https://github.com/grafana/grafana/pull/60870 and fixes goimports ordering in several packages