### PR TITLE
Chore: Fix goimports grouping 

### DIFF
--- a/pkg/login/social/azuread_oauth.go
+++ b/pkg/login/social/azuread_oauth.go
@@ -8,11 +8,11 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/grafana/grafana/pkg/models/roletype"
-	"github.com/grafana/grafana/pkg/services/org"
-
 	"golang.org/x/oauth2"
 	"gopkg.in/square/go-jose.v2/jwt"
+
+	"github.com/grafana/grafana/pkg/models/roletype"
+	"github.com/grafana/grafana/pkg/services/org"
 )
 
 type SocialAzureAD struct {

--- a/pkg/login/social/generic_oauth_test.go
+++ b/pkg/login/social/generic_oauth_test.go
@@ -7,11 +7,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-kit/log/level"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
 
-	"github.com/go-kit/log/level"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/org"
 )

--- a/pkg/login/social/gitlab_oauth_test.go
+++ b/pkg/login/social/gitlab_oauth_test.go
@@ -6,8 +6,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/services/org"
 )
 
 const (

--- a/pkg/login/social/grafana_com_oauth.go
+++ b/pkg/login/social/grafana_com_oauth.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"net/http"
 
+	"golang.org/x/oauth2"
+
 	"github.com/grafana/grafana/pkg/models/roletype"
 	"github.com/grafana/grafana/pkg/services/org"
-
-	"golang.org/x/oauth2"
 )
 
 type SocialGrafanaCom struct {

--- a/pkg/login/social/social.go
+++ b/pkg/login/social/social.go
@@ -1,6 +1,7 @@
 package social
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
@@ -8,8 +9,6 @@ import (
 	"net/http"
 	"os"
 	"strings"
-
-	"context"
 
 	"golang.org/x/oauth2"
 	"golang.org/x/text/cases"

--- a/pkg/services/accesscontrol/acimpl/accesscontrol_test.go
+++ b/pkg/services/accesscontrol/acimpl/accesscontrol_test.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestAccessControl_Evaluate(t *testing.T) {

--- a/pkg/services/accesscontrol/acimpl/service_bench_test.go
+++ b/pkg/services/accesscontrol/acimpl/service_bench_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
@@ -14,7 +16,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
-	"github.com/stretchr/testify/require"
 )
 
 // setupBenchEnv will create userCount users, userCount managed roles with resourceCount managed permission each

--- a/pkg/services/accesscontrol/api/api_test.go
+++ b/pkg/services/accesscontrol/api/api_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/grafana/pkg/api/routing"
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/actest"
@@ -13,7 +15,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/util"
 	"github.com/grafana/grafana/pkg/web/webtest"
-	"github.com/stretchr/testify/require"
 )
 
 func TestAPI_getUserActions(t *testing.T) {

--- a/pkg/services/accesscontrol/checker_test.go
+++ b/pkg/services/accesscontrol/checker_test.go
@@ -4,8 +4,9 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/grafana/grafana/pkg/services/user"
 )
 
 type testData struct {

--- a/pkg/services/accesscontrol/pluginutils/utils_test.go
+++ b/pkg/services/accesscontrol/pluginutils/utils_test.go
@@ -3,9 +3,10 @@ package pluginutils
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/grafana/pkg/plugins"
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
-	"github.com/stretchr/testify/require"
 )
 
 func TestToRegistrations(t *testing.T) {

--- a/pkg/services/accesscontrol/resolvers_test.go
+++ b/pkg/services/accesscontrol/resolvers_test.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/datasources"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestResolvers_AttributeScope(t *testing.T) {

--- a/pkg/services/auth/authimpl/auth_token_test.go
+++ b/pkg/services/auth/authimpl/auth_token_test.go
@@ -8,12 +8,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grafana/grafana/pkg/services/auth"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/auth"
 	"github.com/grafana/grafana/pkg/services/quota"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"

--- a/pkg/services/auth/jwt/key_sets.go
+++ b/pkg/services/auth/jwt/key_sets.go
@@ -14,9 +14,10 @@ import (
 	"os"
 	"time"
 
+	jose "gopkg.in/square/go-jose.v2"
+
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/remotecache"
-	jose "gopkg.in/square/go-jose.v2"
 )
 
 var ErrFailedToParsePemFile = errors.New("failed to parse pem-encoded file")

--- a/pkg/services/authn/authnimpl/priority_queue_test.go
+++ b/pkg/services/authn/authnimpl/priority_queue_test.go
@@ -3,11 +3,11 @@ package authnimpl
 import (
 	"testing"
 
-	"github.com/grafana/grafana/pkg/services/authn/authntest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/services/authn"
+	"github.com/grafana/grafana/pkg/services/authn/authntest"
 )
 
 func TestQueue(t *testing.T) {

--- a/pkg/services/authn/clients/anonymous_test.go
+++ b/pkg/services/authn/clients/anonymous_test.go
@@ -5,13 +5,14 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/authn"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/org/orgtest"
 	"github.com/grafana/grafana/pkg/setting"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestAnonymous_Authenticate(t *testing.T) {

--- a/pkg/services/authn/clients/basic_test.go
+++ b/pkg/services/authn/clients/basic_test.go
@@ -5,9 +5,10 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/grafana/grafana/pkg/services/authn"
 	"github.com/grafana/grafana/pkg/services/authn/authntest"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestBasic_Authenticate(t *testing.T) {

--- a/pkg/services/authn/clients/password_test.go
+++ b/pkg/services/authn/clients/password_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/grafana/grafana/pkg/services/loginattempt/loginattempttest"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/grafana/grafana/pkg/services/authn"
 	"github.com/grafana/grafana/pkg/services/authn/authntest"
+	"github.com/grafana/grafana/pkg/services/loginattempt/loginattempttest"
 )
 
 func TestPassword_AuthenticatePassword(t *testing.T) {

--- a/pkg/services/authn/clients/proxy_test.go
+++ b/pkg/services/authn/clients/proxy_test.go
@@ -5,11 +5,11 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/grafana/grafana/pkg/services/authn/authntest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/services/authn"
+	"github.com/grafana/grafana/pkg/services/authn/authntest"
 	"github.com/grafana/grafana/pkg/setting"
 )
 

--- a/pkg/services/authn/clients/session_test.go
+++ b/pkg/services/authn/clients/session_test.go
@@ -7,6 +7,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/grafana/pkg/models/roletype"
 	"github.com/grafana/grafana/pkg/models/usertoken"
 	"github.com/grafana/grafana/pkg/services/auth"
@@ -15,8 +18,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/services/user/usertest"
 	"github.com/grafana/grafana/pkg/web"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestSession_Test(t *testing.T) {

--- a/pkg/services/ldap/ldap_login_test.go
+++ b/pkg/services/ldap/ldap_login_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
 	"gopkg.in/ldap.v3"
 
 	"github.com/grafana/grafana/pkg/infra/log"

--- a/pkg/services/ldap/ldap_private_test.go
+++ b/pkg/services/ldap/ldap_private_test.go
@@ -3,10 +3,8 @@ package ldap
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/stretchr/testify/assert"
-
+	"github.com/stretchr/testify/require"
 	"gopkg.in/ldap.v3"
 
 	"github.com/grafana/grafana/pkg/infra/log"

--- a/pkg/services/loginattempt/loginattemptimpl/login_attempt_test.go
+++ b/pkg/services/loginattempt/loginattemptimpl/login_attempt_test.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/grafana/grafana/pkg/setting"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 func TestService_Validate(t *testing.T) {

--- a/pkg/services/multildap/multildap_test.go
+++ b/pkg/services/multildap/multildap_test.go
@@ -4,10 +4,10 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/grafana/pkg/services/ldap"
 	"github.com/grafana/grafana/pkg/services/login"
-
-	"github.com/stretchr/testify/require"
 
 	//TODO(sh0rez): remove once import cycle resolved
 	_ "github.com/grafana/grafana/pkg/api/response"

--- a/pkg/services/serviceaccounts/database/stats_test.go
+++ b/pkg/services/serviceaccounts/database/stats_test.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/grafana/pkg/components/apikeygen"
 	"github.com/grafana/grafana/pkg/services/serviceaccounts"
 	"github.com/grafana/grafana/pkg/services/serviceaccounts/tests"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestStore_UsageStats(t *testing.T) {

--- a/pkg/services/serviceaccounts/database/token_store_test.go
+++ b/pkg/services/serviceaccounts/database/token_store_test.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/grafana/pkg/components/apikeygen"
 	"github.com/grafana/grafana/pkg/services/apikey"
 	"github.com/grafana/grafana/pkg/services/serviceaccounts"
 	"github.com/grafana/grafana/pkg/services/serviceaccounts/tests"
-	"github.com/stretchr/testify/require"
 )
 
 func TestStore_AddServiceAccountToken(t *testing.T) {

--- a/pkg/services/serviceaccounts/manager/service_test.go
+++ b/pkg/services/serviceaccounts/manager/service_test.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/apikey"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/serviceaccounts"
-
-	"github.com/stretchr/testify/require"
 )
 
 type FakeServiceAccountStore struct {

--- a/pkg/services/serviceaccounts/manager/stats_test.go
+++ b/pkg/services/serviceaccounts/manager/stats_test.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/services/serviceaccounts"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/serviceaccounts"
 )
 
 func Test_UsageStats(t *testing.T) {

--- a/pkg/services/serviceaccounts/secretscan/service_test.go
+++ b/pkg/services/serviceaccounts/secretscan/service_test.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/services/apikey"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/apikey"
 )
 
 func TestService_CheckTokens(t *testing.T) {

--- a/pkg/services/supportbundles/supportbundlesimpl/service_test.go
+++ b/pkg/services/supportbundles/supportbundlesimpl/service_test.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/supportbundles"
 	"github.com/grafana/grafana/pkg/setting"
-	"github.com/stretchr/testify/require"
 )
 
 func TestService_RegisterSupportItemCollector(t *testing.T) {

--- a/pkg/services/supportbundles/supportbundlesimpl/store.go
+++ b/pkg/services/supportbundles/supportbundlesimpl/store.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
 	"github.com/grafana/grafana/pkg/infra/kvstore"
 	"github.com/grafana/grafana/pkg/services/supportbundles"
 	"github.com/grafana/grafana/pkg/services/user"

--- a/pkg/services/teamguardian/database/database_mock.go
+++ b/pkg/services/teamguardian/database/database_mock.go
@@ -3,8 +3,9 @@ package database
 import (
 	"context"
 
-	"github.com/grafana/grafana/pkg/services/team"
 	"github.com/stretchr/testify/mock"
+
+	"github.com/grafana/grafana/pkg/services/team"
 )
 
 type TeamGuardianStoreMock struct {

--- a/pkg/services/teamguardian/manager/service_mock.go
+++ b/pkg/services/teamguardian/manager/service_mock.go
@@ -3,8 +3,9 @@ package manager
 import (
 	"context"
 
-	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/stretchr/testify/mock"
+
+	"github.com/grafana/grafana/pkg/services/user"
 )
 
 type TeamGuardianMock struct {


### PR DESCRIPTION
This PR deprecates https://github.com/grafana/grafana/pull/60870 and fixes goimports ordering in AuthNZ packages