### PR TITLE
Adds a description field to plugin.json's pages:role field

### DIFF
--- a/docs/sources/developers/plugins/plugin.schema.json
+++ b/docs/sources/developers/plugins/plugin.schema.json
@@ -79,6 +79,7 @@
           },
           "role": {
             "type": "string",
+            "description": "The minimum role a user must have to see this page in the navigation menu.",
             "enum": ["Admin", "Editor", "Viewer"]
           },
           "path": {
@@ -87,7 +88,7 @@
           },
           "addToNav": {
             "type": "boolean",
-            "description": "Add the include to the side menu."
+            "description": "Add the include to the navigation menu."
           },
           "defaultNav": {
             "type": "boolean",

--- a/pkg/plugins/plugindef/plugindef.cue
+++ b/pkg/plugins/plugindef/plugindef.cue
@@ -86,6 +86,8 @@ seqs: [
 
 					// (Legacy) The Angular component to use for a page.
 					component?: string
+
+					// The minimum role a user must have to see this page in the navigation menu.
 					role?:      "Admin" | "Editor" | "Viewer"
 
 					// RBAC action the user must have to access the route
@@ -94,7 +96,7 @@ seqs: [
 					// Used for app plugins.
 					path?: string
 
-					// Add the include to the side menu.
+					// Add the include to the navigation menu.
 					addToNav?: bool
 
 					// Page or dashboard when user clicks the icon in the side menu.

--- a/pkg/plugins/plugindef/plugindef_types_gen.go
+++ b/pkg/plugins/plugindef/plugindef_types_gen.go
@@ -160,7 +160,7 @@ type Include struct {
 	// RBAC action the user must have to access the route
 	Action *string `json:"action,omitempty"`
 
-	// Add the include to the side menu.
+	// Add the include to the navigation menu.
 	AddToNav *bool `json:"addToNav,omitempty"`
 
 	// (Legacy) The Angular component to use for a page.
@@ -176,7 +176,9 @@ type Include struct {
 	Name *string `json:"name,omitempty"`
 
 	// Used for app plugins.
-	Path *string      `json:"path,omitempty"`
+	Path *string `json:"path,omitempty"`
+
+	// The minimum role a user must have to see this page in the navigation menu.
 	Role *IncludeRole `json:"role,omitempty"`
 
 	// IncludeType is a string identifier of a plugin include type, which is
@@ -187,7 +189,7 @@ type Include struct {
 	Uid *string `json:"uid,omitempty"`
 }
 
-// IncludeRole defines model for Include.Role.
+// The minimum role a user must have to see this page in the navigation menu.
 type IncludeRole string
 
 // IncludeType is a string identifier of a plugin include type, which is


### PR DESCRIPTION
There's no description of what a page object's "role" setting does. It controls whether a page will appear in the navigation menu for a user with a given role.