### PR TITLE
Alerting: Clarify PagerDuty integrationKey format

### DIFF
--- a/docs/sources/alerting/set-up/provision-alerting-resources/file-provisioning/index.md
+++ b/docs/sources/alerting/set-up/provision-alerting-resources/file-provisioning/index.md
@@ -313,7 +313,7 @@ settings:
 ```yaml
 type: pagerduty
 settings:
-  # <string, required>
+  # <string, required> the 32-character Events API key https://support.pagerduty.com/docs/api-access-keys#events-api-keys
   integrationKey: XXX
   # <string> options: critical, error, warning, info
   severity: critical


### PR DESCRIPTION
**What is this feature?**

Simply a documentation update.

**Why do we need this feature?**

Clarify the doc, so people don't waste time integrating the wrong key, e.g. #8979, #9036, https://community.librenms.org/t/19013

**Who is this feature for?**

Developers doing a PagerDuty integration.