### PR TITLE
Replace ambiguous relrefs with partial URIs to prevent 404s

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 
 PODMAN = $(shell if command -v podman &>/dev/null; then echo podman; else echo docker; fi)
 IMAGE = grafana/docs-base:latest
-CONTENT_PATH = /hugo/content/docs/grafana/next
+CONTENT_PATH = /hugo/content/docs/grafana/latest
 LOCAL_STATIC_PATH = ../../website/static
 PORT = 3002:3002
 

--- a/docs/sources/developers/plugins/_index.md
+++ b/docs/sources/developers/plugins/_index.md
@@ -24,8 +24,8 @@ Follow the questions and you will have a starter plugin ready to develop.
 
 If you want a more guided introduction to plugin development, check out our tutorials:
 
-- [Build a panel plugin]({{< ref "build-a-panel-plugin.md" >}})
-- [Build a data source plugin]({{< ref "build-a-data-source-plugin.md" >}})
+- [Build a panel plugin](/tutorials/build-a-panel-plugin/)
+- [Build a data source plugin](/tutorials/build-a-data-source-plugin/)
 
 ## Go further
 
@@ -35,47 +35,47 @@ Learn more about specific areas of plugin development.
 
 If you're looking to build your first plugin, check out these introductory tutorials:
 
-- [Build a panel plugin]({{< ref "build-a-panel-plugin.md" >}})
-- [Build a data source plugin]({{< ref "build-a-data-source-plugin.md" >}})
-- [Build a data source backend plugin]({{< ref "build-a-data-source-backend-plugin.md" >}})
+- [Build a panel plugin](/tutorials/build-a-panel-plugin/)
+- [Build a data source plugin](/tutorials/build-a-data-source-plugin/)
+- [Build a data source backend plugin](/tutorials/build-a-data-source-backend-plugin/)
 
 Ready to learn more? Check out our other tutorials:
 
-- [Build a panel plugin with D3.js]({{< ref "build-a-panel-plugin-with-d3.md" >}})
+- [Build a panel plugin with D3.js](/tutorials/build-a-panel-plugin-with-d3/)
 
 ### Guides
 
 Improve an existing plugin with one of our guides:
 
-- [Add authentication for data source plugins]({{< relref "add-authentication-for-data-source-plugins/" >}})
-- [Add support for annotations]({{< relref "add-support-for-annotations/" >}})
-- [Add support for Explore queries]({{< relref "add-support-for-explore-queries/" >}})
-- [Add support for variables]({{< relref "add-support-for-variables/" >}})
-- [Add a query editor help component]({{< relref "add-query-editor-help/" >}})
-- [Build a logs data source plugin]({{< relref "build-a-logs-data-source-plugin/" >}})
-- [Build a streaming data source plugin]({{< relref "build-a-streaming-data-source-plugin/" >}})
-- [Error handling]({{< relref "error-handling/" >}})
-- [Working with data frames]({{< relref "working-with-data-frames/" >}})
-- [Development with local Grafana]({{< relref "development-with-local-grafana/" >}})
+- [Add authentication for data source plugins](/tutorials/add-authentication-for-data-source-plugins/)
+- [Add support for annotations](/tutorials/add-support-for-annotations/)
+- [Add support for Explore queries](/tutorials/add-support-for-explore-queries/)
+- [Add support for variables](/tutorials/add-support-for-variables/)
+- [Add a query editor help component](/tutorials/add-query-editor-help/)
+- [Build a logs data source plugin](/tutorials/build-a-logs-data-source-plugin/)
+- [Build a streaming data source plugin](/tutorials/build-a-streaming-data-source-plugin/)
+- [Error handling](/tutorials/error-handling/)
+- [Working with data frames](/tutorials/working-with-data-frames/)
+- [Development with local Grafana](/tutorials/development-with-local-grafana/)
 
 ### Concepts
 
 Deepen your knowledge through a series of high-level overviews of plugin concepts:
 
-- [Data frames]({{< relref "data-frames/" >}})
+- [Data frames](/tutorials/data-frames/)
 
 ### UI library
 
-Explore the many UI components in our [Grafana UI library](https://developers.grafana.com/ui).
+Explore the many UI components in our [Grafana UI library](/ui).
 
 ### Examples
 
-For inspiration, check out our [plugin examples](https://github.com/grafana/grafana-plugin-examples).
+For inspiration, check out our [plugin examples](/grafana/grafana-plugin-examples).
 
 ### Metadata
 
-- [Plugin metadata]({{< relref "metadata/" >}})
+- [Plugin metadata](/tutorials/metadata/)
 
 ### SDK
 
-- [Grafana Plugin SDK for Go]({{< relref "backend/grafana-plugin-sdk-for-go/" >}})
+- [Grafana Plugin SDK for Go](/tutorials/backend/grafana-plugin-sdk-for-go/)

--- a/docs/sources/developers/plugins/add-support-for-annotations.md
+++ b/docs/sources/developers/plugins/add-support-for-annotations.md
@@ -6,7 +6,7 @@ title: Add support for annotations
 
 This guide explains how to add support for [annotations]({{< relref "../../dashboards/build-dashboards/annotate-visualizations" >}}) to an existing data source plugin.
 
-This guide assumes that you're already familiar with how to [Build a data source plugin]({{< ref "build-a-data-source-plugin.md" >}}).
+This guide assumes that you're already familiar with how to [Build a data source plugin](/tutorials/build-a-data-source-plugin/).
 
 > **Note:** Annotation support for React plugins was released in Grafana 7.2. To support earlier versions, refer to [Add support for annotation for Grafana 7.1](https://grafana.com/docs/grafana/v7.1/developers/plugins/add-support-for-annotations/).
 

--- a/docs/sources/developers/plugins/add-support-for-explore-queries.md
+++ b/docs/sources/developers/plugins/add-support-for-explore-queries.md
@@ -6,7 +6,7 @@ title: Add support for Explore queries
 
 This guide explains how to improve support for [Explore]({{< relref "../../explore/" >}}) in an existing data source plugin.
 
-This guide assumes that you're already familiar with how to [Build a data source plugin]({{< ref "build-a-data-source-plugin.md" >}}).
+This guide assumes that you're already familiar with how to [Build a data source plugin](/tutorials/build-a-data-source-plugin/).
 
 With Explore, users can make ad-hoc queries without the use of a dashboard. This is useful when users want to troubleshoot or to learn more about the data.
 

--- a/docs/sources/developers/plugins/build-a-logs-data-source-plugin.md
+++ b/docs/sources/developers/plugins/build-a-logs-data-source-plugin.md
@@ -6,7 +6,7 @@ title: Build a logs data source plugin
 
 This guide explains how to build a logs data source plugin.
 
-Data sources in Grafana supports both metrics and log data. The steps to build a logs data source plugin are largely the same as for a metrics data source. This guide assumes that you're already familiar with how to [Build a data source plugin]({{< ref "build-a-data-source-plugin.md" >}}) for metrics.
+Data sources in Grafana supports both metrics and log data. The steps to build a logs data source plugin are largely the same as for a metrics data source. This guide assumes that you're already familiar with how to [Build a data source plugin](/tutorials/build-a-data-source-plugin/) for metrics.
 
 ## Add logs support to your data source
 

--- a/docs/sources/developers/plugins/build-a-streaming-data-source-plugin.md
+++ b/docs/sources/developers/plugins/build-a-streaming-data-source-plugin.md
@@ -6,7 +6,7 @@ title: Build a streaming data source plugin
 
 This guide explains how to build a streaming data source plugin.
 
-This guide assumes that you're already familiar with how to [Build a data source plugin]({{< ref "build-a-data-source-plugin.md" >}}).
+This guide assumes that you're already familiar with how to [Build a data source plugin](/tutorials/build-a-data-source-plugin/).
 
 When monitoring critical applications, you want your dashboard to refresh as soon as your data does. In Grafana, you can set your dashboards to automatically refresh at a certain interval, no matter what data source you use. Unfortunately, this means that your queries are requesting all the data to be sent again, regardless of whether the data has actually changed.
 

--- a/docs/sources/developers/plugins/sign-a-plugin.md
+++ b/docs/sources/developers/plugins/sign-a-plugin.md
@@ -32,7 +32,7 @@ To verify ownership of your plugin, you need to generate an API key that you'll 
 
 Public plugins need to be reviewed by the Grafana team before you can sign them.
 
-1. Submit your plugin for [review]({{< relref "package-a-plugin/#publishing-your-plugin-for-the-first-time" >}})
+1. Submit your plugin for [review]({{< relref "publish-a-plugin/#publishing-your-plugin-for-the-first-time" >}})
 2. When your plugin is approved, you're granted a plugin signature level. **Without a plugin signature level, you won't be able to sign your plugin**.
 3. In your plugin directory, sign the plugin with the API key you just created. Grafana Sign Plugin creates a [MANIFEST.txt](#plugin-manifest) file in the `dist` directory of your plugin.
 


### PR DESCRIPTION
**Special notes for your reviewer**:

This also changes the local docs build to mount to the `latest` directory which is required for correct tutorials mounting behavior.

The local development URL is now https://localhost:3002/docs/grafana/latest/.