### PR TITLE
RBAC: Rewrite org users rbac tests

### DIFF
--- a/pkg/api/common_test.go
+++ b/pkg/api/common_test.go
@@ -252,14 +252,6 @@ func (s *fakeRenderService) Init() error {
 	return nil
 }
 
-type accessControlTestCase struct {
-	expectedCode int
-	desc         string
-	url          string
-	method       string
-	permissions  []accesscontrol.Permission
-}
-
 // accessControlScenarioContext contains the setups for accesscontrol tests
 type accessControlScenarioContext struct {
 	// server we registered hs routes on.
@@ -288,16 +280,6 @@ type accessControlScenarioContext struct {
 	dashboardPermissionsService *accesscontrolmock.MockPermissionsService
 }
 
-func setAccessControlPermissions(acmock *accesscontrolmock.Mock, perms []accesscontrol.Permission, org int64) {
-	acmock.GetUserPermissionsFunc =
-		func(_ context.Context, u *user.SignedInUser, _ accesscontrol.Options) ([]accesscontrol.Permission, error) {
-			if u.OrgID == org {
-				return perms, nil
-			}
-			return nil, nil
-		}
-}
-
 func userWithPermissions(orgID int64, permissions []accesscontrol.Permission) *user.SignedInUser {
 	return &user.SignedInUser{OrgID: orgID, OrgRole: org.RoleViewer, Permissions: map[int64]map[string][]string{orgID: accesscontrol.GroupScopesByAction(permissions)}}
 }
@@ -306,16 +288,6 @@ func userWithPermissions(orgID int64, permissions []accesscontrol.Permission) *u
 func setInitCtxSignedInUser(initCtx *contextmodel.ReqContext, user user.SignedInUser) {
 	initCtx.IsSignedIn = true
 	initCtx.SignedInUser = &user
-}
-
-func setInitCtxSignedInViewer(initCtx *contextmodel.ReqContext) {
-	initCtx.IsSignedIn = true
-	initCtx.SignedInUser = &user.SignedInUser{UserID: testUserID, OrgID: 1, OrgRole: org.RoleViewer, Login: testUserLogin}
-}
-
-func setInitCtxSignedInOrgAdmin(initCtx *contextmodel.ReqContext) {
-	initCtx.IsSignedIn = true
-	initCtx.SignedInUser = &user.SignedInUser{UserID: testUserID, OrgID: 1, OrgRole: org.RoleAdmin, Login: testUserLogin}
 }
 
 func setupSimpleHTTPServer(features *featuremgmt.FeatureManager) *HTTPServer {

--- a/pkg/services/team/teamtest/team.go
+++ b/pkg/services/team/teamtest/team.go
@@ -10,6 +10,7 @@ import (
 type FakeService struct {
 	ExpectedTeam        team.Team
 	ExpectedIsMember    bool
+	ExpectedIsAdmin     bool
 	ExpectedTeamDTO     *team.TeamDTO
 	ExpectedTeamsByUser []*team.TeamDTO
 	ExpectedMembers     []*team.TeamMemberDTO
@@ -69,5 +70,5 @@ func (s *FakeService) GetTeamMembers(ctx context.Context, query *team.GetTeamMem
 }
 
 func (s *FakeService) IsAdminOfTeams(ctx context.Context, query *team.IsAdminOfTeamsQuery) (bool, error) {
-	return false, s.ExpectedError
+	return s.ExpectedIsAdmin, s.ExpectedError
 }


### PR DESCRIPTION
**What is this feature?**
Rewrite test setups for org users API RBAC tests to not use mocked access control

Fixes #

**Special notes for your reviewer**:

