### PR TITLE
Chore: Fix goimports order in RelEng packages

### DIFF
--- a/pkg/build/cmd/buildbackend.go
+++ b/pkg/build/cmd/buildbackend.go
@@ -4,12 +4,13 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/urfave/cli/v2"
+
 	"github.com/grafana/grafana/pkg/build/compilers"
 	"github.com/grafana/grafana/pkg/build/config"
 	"github.com/grafana/grafana/pkg/build/errutil"
 	"github.com/grafana/grafana/pkg/build/grafana"
 	"github.com/grafana/grafana/pkg/build/syncutil"
-	"github.com/urfave/cli/v2"
 )
 
 func BuildBackend(ctx *cli.Context) error {

--- a/pkg/build/cmd/builddocker.go
+++ b/pkg/build/cmd/builddocker.go
@@ -3,10 +3,11 @@ package main
 import (
 	"log"
 
+	"github.com/urfave/cli/v2"
+
 	"github.com/grafana/grafana/pkg/build/config"
 	"github.com/grafana/grafana/pkg/build/docker"
 	"github.com/grafana/grafana/pkg/build/gcloud"
-	"github.com/urfave/cli/v2"
 )
 
 func BuildDocker(c *cli.Context) error {

--- a/pkg/build/cmd/buildfrontend.go
+++ b/pkg/build/cmd/buildfrontend.go
@@ -3,11 +3,12 @@ package main
 import (
 	"log"
 
+	"github.com/urfave/cli/v2"
+
 	"github.com/grafana/grafana/pkg/build/config"
 	"github.com/grafana/grafana/pkg/build/errutil"
 	"github.com/grafana/grafana/pkg/build/frontend"
 	"github.com/grafana/grafana/pkg/build/syncutil"
-	"github.com/urfave/cli/v2"
 )
 
 func BuildFrontend(c *cli.Context) error {

--- a/pkg/build/cmd/buildfrontendpackages.go
+++ b/pkg/build/cmd/buildfrontendpackages.go
@@ -4,10 +4,11 @@ import (
 	"log"
 	"strings"
 
+	"github.com/urfave/cli/v2"
+
 	"github.com/grafana/grafana/pkg/build/errutil"
 	"github.com/grafana/grafana/pkg/build/frontend"
 	"github.com/grafana/grafana/pkg/build/syncutil"
-	"github.com/urfave/cli/v2"
 )
 
 func BuildFrontendPackages(c *cli.Context) error {

--- a/pkg/build/cmd/buildinternalplugins.go
+++ b/pkg/build/cmd/buildinternalplugins.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"log"
 
+	"github.com/urfave/cli/v2"
+
 	"github.com/grafana/grafana/pkg/build/config"
 	"github.com/grafana/grafana/pkg/build/errutil"
 	"github.com/grafana/grafana/pkg/build/plugins"
 	"github.com/grafana/grafana/pkg/build/syncutil"
-	"github.com/urfave/cli/v2"
 )
 
 func BuildInternalPlugins(c *cli.Context) error {

--- a/pkg/build/cmd/e2etests.go
+++ b/pkg/build/cmd/e2etests.go
@@ -6,8 +6,9 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/grafana/grafana/pkg/build/e2eutil"
 	"github.com/urfave/cli/v2"
+
+	"github.com/grafana/grafana/pkg/build/e2eutil"
 )
 
 func EndToEndTests(c *cli.Context) error {

--- a/pkg/build/cmd/enterprisecheck.go
+++ b/pkg/build/cmd/enterprisecheck.go
@@ -6,9 +6,10 @@ import (
 	"os"
 	"strconv"
 
+	"github.com/urfave/cli/v2"
+
 	"github.com/grafana/grafana/pkg/build/env"
 	"github.com/grafana/grafana/pkg/build/git"
-	"github.com/urfave/cli/v2"
 )
 
 // checkOpts are options used to create a new GitHub check for the enterprise downstream test.

--- a/pkg/build/cmd/exportversion.go
+++ b/pkg/build/cmd/exportversion.go
@@ -4,8 +4,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/grafana/grafana/pkg/build/config"
 	"github.com/urfave/cli/v2"
+
+	"github.com/grafana/grafana/pkg/build/config"
 )
 
 func ExportVersion(c *cli.Context) error {

--- a/pkg/build/cmd/fetchimages.go
+++ b/pkg/build/cmd/fetchimages.go
@@ -6,10 +6,11 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/urfave/cli/v2"
+
 	"github.com/grafana/grafana/pkg/build/config"
 	"github.com/grafana/grafana/pkg/build/docker"
 	"github.com/grafana/grafana/pkg/build/gcloud"
-	"github.com/urfave/cli/v2"
 )
 
 const (

--- a/pkg/build/cmd/grafanacom.go
+++ b/pkg/build/cmd/grafanacom.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-
 	"path"
 	"path/filepath"
 	"strings"

--- a/pkg/build/cmd/main.go
+++ b/pkg/build/cmd/main.go
@@ -5,8 +5,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/grafana/grafana/pkg/build/docker"
 	"github.com/urfave/cli/v2"
+
+	"github.com/grafana/grafana/pkg/build/docker"
 )
 
 func main() {

--- a/pkg/build/cmd/npm.go
+++ b/pkg/build/cmd/npm.go
@@ -6,8 +6,9 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/grafana/grafana/pkg/build/npm"
 	"github.com/urfave/cli/v2"
+
+	"github.com/grafana/grafana/pkg/build/npm"
 )
 
 func NpmRetrieveAction(c *cli.Context) error {

--- a/pkg/build/cmd/package.go
+++ b/pkg/build/cmd/package.go
@@ -5,11 +5,12 @@ import (
 	"log"
 	"strings"
 
+	"github.com/urfave/cli/v2"
+
 	"github.com/grafana/grafana/pkg/build/config"
 	"github.com/grafana/grafana/pkg/build/gpg"
 	"github.com/grafana/grafana/pkg/build/packaging"
 	"github.com/grafana/grafana/pkg/build/syncutil"
-	"github.com/urfave/cli/v2"
 )
 
 func Package(c *cli.Context) error {

--- a/pkg/build/cmd/publishaws.go
+++ b/pkg/build/cmd/publishaws.go
@@ -17,8 +17,9 @@ import (
 	"github.com/aws/aws-sdk-go/service/marketplacecatalog"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
-	"github.com/grafana/grafana/pkg/build/config"
 	"github.com/urfave/cli/v2"
+
+	"github.com/grafana/grafana/pkg/build/config"
 )
 
 const (

--- a/pkg/build/cmd/publishgithub.go
+++ b/pkg/build/cmd/publishgithub.go
@@ -9,9 +9,10 @@ import (
 	"strings"
 
 	"github.com/google/go-github/github"
-	"github.com/grafana/grafana/pkg/build/config"
 	"github.com/urfave/cli/v2"
 	"golang.org/x/oauth2"
+
+	"github.com/grafana/grafana/pkg/build/config"
 )
 
 type githubRepositoryService interface {

--- a/pkg/build/cmd/publishimages_enterprise2.go
+++ b/pkg/build/cmd/publishimages_enterprise2.go
@@ -6,10 +6,11 @@ import (
 	"os"
 	"os/exec"
 
+	"github.com/urfave/cli/v2"
+
 	"github.com/grafana/grafana/pkg/build/config"
 	"github.com/grafana/grafana/pkg/build/docker"
 	"github.com/grafana/grafana/pkg/build/gcloud"
-	"github.com/urfave/cli/v2"
 )
 
 func Enterprise2(c *cli.Context) error {

--- a/pkg/build/cmd/storestorybook.go
+++ b/pkg/build/cmd/storestorybook.go
@@ -4,9 +4,10 @@ import (
 	"log"
 	"path/filepath"
 
+	"github.com/urfave/cli/v2"
+
 	"github.com/grafana/grafana/pkg/build/config"
 	"github.com/grafana/grafana/pkg/build/gcloud/storage"
-	"github.com/urfave/cli/v2"
 )
 
 // StoreStorybook implements the sub-command "store-storybook".

--- a/pkg/build/cmd/uploadcdn.go
+++ b/pkg/build/cmd/uploadcdn.go
@@ -6,9 +6,10 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/urfave/cli/v2"
+
 	"github.com/grafana/grafana/pkg/build/config"
 	"github.com/grafana/grafana/pkg/build/gcloud/storage"
-	"github.com/urfave/cli/v2"
 )
 
 // UploadCDN implements the sub-command "upload-cdn".

--- a/pkg/build/cmd/uploadpackages.go
+++ b/pkg/build/cmd/uploadpackages.go
@@ -9,11 +9,12 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/urfave/cli/v2"
+
 	"github.com/grafana/grafana/pkg/build/config"
 	"github.com/grafana/grafana/pkg/build/droneutil"
 	"github.com/grafana/grafana/pkg/build/gcloud"
 	"github.com/grafana/grafana/pkg/build/packaging"
-	"github.com/urfave/cli/v2"
 )
 
 const releaseFolder = "release"

--- a/pkg/build/cmd/uploadpackages_test.go
+++ b/pkg/build/cmd/uploadpackages_test.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/grafana/grafana/pkg/build/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/build/config"
 )
 
 func Test_getVersionFolder(t *testing.T) {

--- a/pkg/build/cmd/verifydrone.go
+++ b/pkg/build/cmd/verifydrone.go
@@ -10,9 +10,7 @@ import (
 
 	"github.com/drone/drone-cli/drone/lint"
 	"github.com/drone/drone-cli/drone/starlark"
-
 	"github.com/google/go-cmp/cmp"
-
 	cliv1 "github.com/urfave/cli"
 	"github.com/urfave/cli/v2"
 	"gopkg.in/yaml.v3"

--- a/pkg/build/config/genmetadata.go
+++ b/pkg/build/config/genmetadata.go
@@ -5,8 +5,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/grafana/grafana/pkg/build/droneutil"
 	"github.com/urfave/cli/v2"
+
+	"github.com/grafana/grafana/pkg/build/droneutil"
 )
 
 func GenerateMetadata(c *cli.Context) (Metadata, error) {

--- a/pkg/build/droneutil/event_test.go
+++ b/pkg/build/droneutil/event_test.go
@@ -3,8 +3,9 @@ package droneutil_test
 import (
 	"testing"
 
-	"github.com/grafana/grafana/pkg/build/droneutil"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/build/droneutil"
 )
 
 func TestGetDroneEvent(t *testing.T) {

--- a/pkg/build/env/lookup_test.go
+++ b/pkg/build/env/lookup_test.go
@@ -3,9 +3,9 @@ package env_test
 import (
 	"testing"
 
-	"github.com/grafana/grafana/pkg/build/env"
-
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/build/env"
 )
 
 func TestLookup(t *testing.T) {

--- a/pkg/build/frontend/config.go
+++ b/pkg/build/frontend/config.go
@@ -1,8 +1,9 @@
 package frontend
 
 import (
-	"github.com/grafana/grafana/pkg/build/config"
 	"github.com/urfave/cli/v2"
+
+	"github.com/grafana/grafana/pkg/build/config"
 )
 
 const GrafanaDir = "."

--- a/pkg/build/fsutil/copy_test.go
+++ b/pkg/build/fsutil/copy_test.go
@@ -5,9 +5,10 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/grafana/grafana/pkg/build/fsutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/build/fsutil"
 )
 
 func TestCopyFile(t *testing.T) {

--- a/pkg/build/fsutil/exists_test.go
+++ b/pkg/build/fsutil/exists_test.go
@@ -3,8 +3,9 @@ package fsutil_test
 import (
 	"testing"
 
-	"github.com/grafana/grafana/pkg/build/fsutil"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/build/fsutil"
 )
 
 func TestExists_NonExistent(t *testing.T) {

--- a/pkg/build/gcloud/storage/gsutil.go
+++ b/pkg/build/gcloud/storage/gsutil.go
@@ -16,10 +16,11 @@ import (
 	"time"
 
 	"cloud.google.com/go/storage"
-	"github.com/grafana/grafana/pkg/build/fsutil"
-	"github.com/grafana/grafana/pkg/build/gcloud"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
+
+	"github.com/grafana/grafana/pkg/build/fsutil"
+	"github.com/grafana/grafana/pkg/build/gcloud"
 )
 
 var (

--- a/pkg/build/git/git.go
+++ b/pkg/build/git/git.go
@@ -8,8 +8,9 @@ import (
 	"regexp"
 
 	"github.com/google/go-github/v45/github"
-	"github.com/grafana/grafana/pkg/build/stringutil"
 	"golang.org/x/oauth2"
+
+	"github.com/grafana/grafana/pkg/build/stringutil"
 )
 
 const (

--- a/pkg/build/git/git_checks_test.go
+++ b/pkg/build/git/git_checks_test.go
@@ -6,8 +6,9 @@ import (
 	"testing"
 
 	"github.com/google/go-github/v45/github"
-	"github.com/grafana/grafana/pkg/build/git"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/build/git"
 )
 
 type TestChecksService struct {

--- a/pkg/build/git/git_issues_test.go
+++ b/pkg/build/git/git_issues_test.go
@@ -6,8 +6,9 @@ import (
 	"testing"
 
 	"github.com/google/go-github/v45/github"
-	"github.com/grafana/grafana/pkg/build/git"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/build/git"
 )
 
 type TestLabelsService struct {

--- a/pkg/build/git/git_test.go
+++ b/pkg/build/git/git_test.go
@@ -3,8 +3,9 @@ package git_test
 import (
 	"testing"
 
-	"github.com/grafana/grafana/pkg/build/git"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/grafana/grafana/pkg/build/git"
 )
 
 func TestPRCheckRegexp(t *testing.T) {

--- a/pkg/build/metrics/publish.go
+++ b/pkg/build/metrics/publish.go
@@ -5,10 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net/http"
 	"strconv"
 	"time"
-
-	"net/http"
 )
 
 type payload struct {

--- a/pkg/build/packaging/grafana_test.go
+++ b/pkg/build/packaging/grafana_test.go
@@ -3,9 +3,10 @@ package packaging_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/grafana/grafana/pkg/build/config"
 	"github.com/grafana/grafana/pkg/build/packaging"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestPackageRegexp(t *testing.T) {

--- a/pkg/build/packaging/rpm_test.go
+++ b/pkg/build/packaging/rpm_test.go
@@ -5,8 +5,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/grafana/grafana/pkg/build/config"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/build/config"
 )
 
 const pubKey = `-----BEGIN PGP PUBLIC KEY BLOCK-----


### PR DESCRIPTION
This PR deprecates https://github.com/grafana/grafana/pull/60870 and fixes goimports ordering in Release Engineering packages