### PR TITLE
Theme: Fix wrong code segment in theme.md

### DIFF
--- a/contribute/style-guides/themes.md
+++ b/contribute/style-guides/themes.md
@@ -30,10 +30,10 @@ function Foo(props: FooProps) {
   // Use styles with className
 }
 
-
-const getStyles = (theme: GrafanaTheme2) => css({
-padding: theme.spacing(1,2)
-});
+const getStyles = (theme: GrafanaTheme2) =>
+  css({
+    padding: theme.spacing(1, 2),
+  });
 ```
 
 #### Get the theme object

--- a/contribute/style-guides/themes.md
+++ b/contribute/style-guides/themes.md
@@ -29,11 +29,12 @@ function Foo(props: FooProps) {
   const styles = useStyles2(getStyles);
   // Use styles with className
 }
-```
+
 
 const getStyles = (theme: GrafanaTheme2) => css({
 padding: theme.spacing(1,2)
 });
+```
 
 #### Get the theme object
 


### PR DESCRIPTION
**What is this feature?**

Adding 
```
const getStyles = (theme: GrafanaTheme2) => css({
padding: theme.spacing(1,2)
});
```

to the code paragraph.