### PR TITLE
Elasticsearch: Fix consistent label order in alerting

### DIFF
--- a/pkg/tsdb/elasticsearch/response_parser.go
+++ b/pkg/tsdb/elasticsearch/response_parser.go
@@ -534,6 +534,24 @@ func trimDatapoints(queryResult backend.DataResponse, target *Query) {
 	}
 }
 
+// we sort the label's pairs by the label-key,
+// and return the label-values
+func getSortedLabelValues(labels data.Labels) []string {
+	var keys []string
+	for key := range labels {
+		keys = append(keys, key)
+	}
+
+	sort.Strings(keys)
+
+	var values []string
+	for _, key := range keys {
+		values = append(values, labels[key])
+	}
+
+	return values
+}
+
 func nameFields(queryResult backend.DataResponse, target *Query) {
 	set := make(map[string]struct{})
 	frames := queryResult.Frames
@@ -645,7 +663,7 @@ func getFieldName(dataField data.Field, target *Query, metricTypeCount int) stri
 	}
 
 	name := ""
-	for _, v := range dataField.Labels {
+	for _, v := range getSortedLabelValues(dataField.Labels) {
 		name += v + " "
 	}
 


### PR DESCRIPTION
fixes https://github.com/grafana/grafana/issues/20435

the current version of the go-code, when building the name of the time-series, it iterates through the values of a `data.Labels` structure, which is a `map[string]string` structure, where iteration-order is random. in this PR, we explicitly sort the label-values by alphabetically sorting the label-keys and picking the values based on those keys.

how to test:
- when using `make devenv sources=elastic`
- (do this on main-branch grafana first)
- go to the alerting section and 
- setup the query-builder like this
<img width="582" alt="terms" src="https://user-images.githubusercontent.com/51989/215521145-21640e78-de97-423b-9300-d2d7cdb486dd.png">

- keep re-running the query, and look at the time-series names in the legend-section of the time-series graph. you will see that sometimes, for some series, the name is label-first-and-loglevel-second, while some others have loglevel-first-and-label-second
- if you switch to this PR's branch now, and repeat the experiment, it will always be label-first-then-loglevel, simply because the word "label" is alphabetically sooner than the word "level"
