### PR TITLE
RBAC: extend `IsInherited` method to work for nested folders

### DIFF
--- a/pkg/services/accesscontrol/resourcepermissions/store.go
+++ b/pkg/services/accesscontrol/resourcepermissions/store.go
@@ -39,11 +39,13 @@ type flatResourcePermission struct {
 }
 
 func (p *flatResourcePermission) IsManaged(scope string) bool {
-	return strings.HasPrefix(p.RoleName, accesscontrol.ManagedRolePrefix) && !p.IsInherited(scope)
+	return strings.HasPrefix(p.RoleName, accesscontrol.ManagedRolePrefix) && p.Scope == scope
 }
 
+// IsInherited returns true for scopes from managed permissions that don't directly match the required scope
+// (ie, managed permissions on a parent resource)
 func (p *flatResourcePermission) IsInherited(scope string) bool {
-	return !strings.HasPrefix(p.Scope, strings.ReplaceAll(scope, "*", ""))
+	return strings.HasPrefix(p.RoleName, accesscontrol.ManagedRolePrefix) && p.Scope != scope
 }
 
 func (s *store) SetUserResourcePermission(

--- a/pkg/services/accesscontrol/resourcepermissions/store.go
+++ b/pkg/services/accesscontrol/resourcepermissions/store.go
@@ -43,7 +43,7 @@ func (p *flatResourcePermission) IsManaged(scope string) bool {
 }
 
 func (p *flatResourcePermission) IsInherited(scope string) bool {
-	return !strings.HasPrefix(p.Scope, strings.Split(strings.ReplaceAll(scope, "*", ""), ":")[0])
+	return !strings.HasPrefix(p.Scope, strings.ReplaceAll(scope, "*", ""))
 }
 
 func (s *store) SetUserResourcePermission(

--- a/pkg/services/accesscontrol/resourcepermissions/store.go
+++ b/pkg/services/accesscontrol/resourcepermissions/store.go
@@ -414,10 +414,12 @@ func groupPermissionsByAssignment(permissions []flatResourcePermission) (map[int
 }
 
 func flatPermissionsToResourcePermissions(scope string, permissions []flatResourcePermission) []accesscontrol.ResourcePermission {
-	var managed, provisioned []flatResourcePermission
+	var managed, inherited, provisioned []flatResourcePermission
 	for _, p := range permissions {
 		if p.IsManaged(scope) {
 			managed = append(managed, p)
+		} else if p.IsInherited(scope) {
+			inherited = append(inherited, p)
 		} else {
 			provisioned = append(provisioned, p)
 		}
@@ -425,6 +427,9 @@ func flatPermissionsToResourcePermissions(scope string, permissions []flatResour
 
 	var result []accesscontrol.ResourcePermission
 	if g := flatPermissionsToResourcePermission(scope, managed); g != nil {
+		result = append(result, *g)
+	}
+	if g := flatPermissionsToResourcePermission(scope, inherited); g != nil {
 		result = append(result, *g)
 	}
 	if g := flatPermissionsToResourcePermission(scope, provisioned); g != nil {


### PR DESCRIPTION
**What is this feature?**

Change the logic of `IsInherited` to return `true` for inherited folder permissions.

**Why do we need this feature?**

To correctly indicate that a particular permission is inherited and is not set directly to the folder.

Inherited permissions are also greyed on in the UI:
<img width="1088" alt="Screenshot 2023-01-30 at 15 36 17" src="https://user-images.githubusercontent.com/9482349/215524177-9a00be2d-85bd-4465-8b59-31facdc3eb17.png">

**Which issue(s) does this PR fix?**:

Related to https://github.com/grafana/grafana-authnz-team/issues/172

**Special notes for your reviewer**:

I _think_ this doesn't break any behaviour for dashboards, but I might be missing something.