### PR TITLE
TemplateVariables: Fix custom variable function support

### DIFF
--- a/public/app/features/query/state/runRequest.ts
+++ b/public/app/features/query/state/runRequest.ts
@@ -24,6 +24,7 @@ import {
 import { toDataQueryError } from '@grafana/runtime';
 import { isExpressionReference } from '@grafana/runtime/src/utils/DataSourceWithBackend';
 import { backendSrv } from 'app/core/services/backend_srv';
+import { queryIsEmpty } from 'app/core/utils/query';
 import { dataSource as expressionDatasource } from 'app/features/expressions/ExpressionDatasource';
 import { ExpressionQuery } from 'app/features/expressions/types';
 
@@ -176,10 +177,14 @@ export function callQueryMethod(
   queryFunction?: typeof datasource.query
 ) {
   // If the datasource has defined a default query, make sure it's applied
-  request.targets = request.targets.map((t) => ({
-    ...datasource?.getDefaultQuery?.(CoreApp.PanelEditor),
-    ...t,
-  }));
+  request.targets = request.targets.map((t) =>
+    queryIsEmpty(t)
+      ? {
+          ...datasource?.getDefaultQuery?.(CoreApp.PanelEditor),
+          ...t,
+        }
+      : t
+  );
 
   // If its a public datasource, just return the result. Expressions will be handled on the backend.
   if (datasource.type === 'public-ds') {


### PR DESCRIPTION
Validates the query fields before spreading the default query.

Fixes #62508 