### PR TITLE
Geomap: Maintain consistent control styling

### DIFF
--- a/public/app/plugins/panel/geomap/globalStyles.ts
+++ b/public/app/plugins/panel/geomap/globalStyles.ts
@@ -66,9 +66,11 @@ export function getGlobalStyles(theme: GrafanaTheme2) {
       background-color: ${theme.colors.secondary.main}; // rgba(0,60,136,0.5);
     }
     .ol-control button:hover {
+      color: ${theme.colors.secondary.text};
       background-color: ${theme.colors.secondary.shade}; // rgba(0,60,136,0.5);
     }
     .ol-control button:focus {
+      color: ${theme.colors.secondary.text};
       background-color: ${theme.colors.secondary.main}; // rgba(0,60,136,0.5);
     }
     .ol-attribution ul {


### PR DESCRIPTION
What this PR does / why we need it:
When a user hovers or focuses a control in Geomap, the color becomes dark and potentially difficult to read depending on the theme.

Before:
![Jan-30-2023 12-28-45](https://user-images.githubusercontent.com/60050885/215587972-0c3e8d43-7200-4d29-a6ab-278f5edcbea0.gif)
![Jan-30-2023 12-29-00](https://user-images.githubusercontent.com/60050885/215587993-594edb1e-cb69-414a-80cd-71c773654fb6.gif)

After:
![Jan-30-2023 12-27-23](https://user-images.githubusercontent.com/60050885/215588009-05669d60-4d68-4414-ac3b-4dd59c845469.gif)
![Jan-30-2023 12-27-51](https://user-images.githubusercontent.com/60050885/215588027-0b848721-0d2e-4935-a156-7b488185213b.gif)


Closes #55194