### PR TITLE
Alerting: Fix return code on silences (#61966)

### DIFF
--- a/pkg/services/ngalert/api/api_alertmanager.go
+++ b/pkg/services/ngalert/api/api_alertmanager.go
@@ -87,7 +87,7 @@ func (srv AlertmanagerSrv) RouteCreateSilence(c *contextmodel.ReqContext, postab
 
 		return ErrResp(http.StatusInternalServerError, err, "failed to create silence")
 	}
-	return response.JSON(http.StatusCreated, apimodels.PostSilencesOKBody{
+	return response.JSON(http.StatusOK, apimodels.PostSilencesOKBody{
 		SilenceID: silenceID,
 	})
 }

--- a/pkg/services/ngalert/api/api_alertmanager.go
+++ b/pkg/services/ngalert/api/api_alertmanager.go
@@ -87,7 +87,7 @@ func (srv AlertmanagerSrv) RouteCreateSilence(c *contextmodel.ReqContext, postab
 
 		return ErrResp(http.StatusInternalServerError, err, "failed to create silence")
 	}
-	return response.JSON(http.StatusAccepted, apimodels.PostSilencesOKBody{
+	return response.JSON(http.StatusCreated, apimodels.PostSilencesOKBody{
 		SilenceID: silenceID,
 	})
 }

--- a/pkg/services/ngalert/api/api_alertmanager_test.go
+++ b/pkg/services/ngalert/api/api_alertmanager_test.go
@@ -316,7 +316,7 @@ func TestSilenceCreate(t *testing.T) {
 	}{
 		{"Valid Silence",
 			makeSilence("", "tests", dt(now), dt(now.Add(1*time.Second)), matchers),
-			http.StatusAccepted,
+			http.StatusCreated,
 		},
 		{"No Comment Silence",
 			func() amv2.Silence {
@@ -375,7 +375,7 @@ func TestRouteCreateSilence(t *testing.T) {
 					{Action: accesscontrol.ActionAlertingInstanceCreate},
 				})
 			},
-			expectedStatus: http.StatusAccepted,
+			expectedStatus: http.StatusCreated,
 		},
 		{
 			name:    "new silence, role-based access control is disabled, Viewer",
@@ -393,7 +393,7 @@ func TestRouteCreateSilence(t *testing.T) {
 				return acMock.New().WithDisabled()
 			},
 			role:           org.RoleEditor,
-			expectedStatus: http.StatusAccepted,
+			expectedStatus: http.StatusCreated,
 		},
 		{
 			name:    "new silence, role-based access control is disabled, Admin",
@@ -402,7 +402,7 @@ func TestRouteCreateSilence(t *testing.T) {
 				return acMock.New().WithDisabled()
 			},
 			role:           org.RoleAdmin,
-			expectedStatus: http.StatusAccepted,
+			expectedStatus: http.StatusCreated,
 		},
 		{
 			name:    "update silence, role-based access control is enabled, not authorized",
@@ -420,7 +420,7 @@ func TestRouteCreateSilence(t *testing.T) {
 					{Action: accesscontrol.ActionAlertingInstanceUpdate},
 				})
 			},
-			expectedStatus: http.StatusAccepted,
+			expectedStatus: http.StatusCreated,
 		},
 		{
 			name:    "update silence, role-based access control is disabled, Viewer",
@@ -438,7 +438,7 @@ func TestRouteCreateSilence(t *testing.T) {
 				return acMock.New().WithDisabled()
 			},
 			role:           org.RoleEditor,
-			expectedStatus: http.StatusAccepted,
+			expectedStatus: http.StatusCreated,
 		},
 		{
 			name:    "update silence, role-based access control is disabled, Admin",
@@ -447,7 +447,7 @@ func TestRouteCreateSilence(t *testing.T) {
 				return acMock.New().WithDisabled()
 			},
 			role:           org.RoleAdmin,
-			expectedStatus: http.StatusAccepted,
+			expectedStatus: http.StatusCreated,
 		},
 	}
 

--- a/pkg/services/ngalert/api/api_alertmanager_test.go
+++ b/pkg/services/ngalert/api/api_alertmanager_test.go
@@ -316,7 +316,7 @@ func TestSilenceCreate(t *testing.T) {
 	}{
 		{"Valid Silence",
 			makeSilence("", "tests", dt(now), dt(now.Add(1*time.Second)), matchers),
-			http.StatusCreated,
+			http.StatusOK,
 		},
 		{"No Comment Silence",
 			func() amv2.Silence {
@@ -375,7 +375,7 @@ func TestRouteCreateSilence(t *testing.T) {
 					{Action: accesscontrol.ActionAlertingInstanceCreate},
 				})
 			},
-			expectedStatus: http.StatusCreated,
+			expectedStatus: http.StatusOK,
 		},
 		{
 			name:    "new silence, role-based access control is disabled, Viewer",
@@ -393,7 +393,7 @@ func TestRouteCreateSilence(t *testing.T) {
 				return acMock.New().WithDisabled()
 			},
 			role:           org.RoleEditor,
-			expectedStatus: http.StatusCreated,
+			expectedStatus: http.StatusOK,
 		},
 		{
 			name:    "new silence, role-based access control is disabled, Admin",
@@ -402,7 +402,7 @@ func TestRouteCreateSilence(t *testing.T) {
 				return acMock.New().WithDisabled()
 			},
 			role:           org.RoleAdmin,
-			expectedStatus: http.StatusCreated,
+			expectedStatus: http.StatusOK,
 		},
 		{
 			name:    "update silence, role-based access control is enabled, not authorized",
@@ -420,7 +420,7 @@ func TestRouteCreateSilence(t *testing.T) {
 					{Action: accesscontrol.ActionAlertingInstanceUpdate},
 				})
 			},
-			expectedStatus: http.StatusCreated,
+			expectedStatus: http.StatusOK,
 		},
 		{
 			name:    "update silence, role-based access control is disabled, Viewer",
@@ -438,7 +438,7 @@ func TestRouteCreateSilence(t *testing.T) {
 				return acMock.New().WithDisabled()
 			},
 			role:           org.RoleEditor,
-			expectedStatus: http.StatusCreated,
+			expectedStatus: http.StatusOK,
 		},
 		{
 			name:    "update silence, role-based access control is disabled, Admin",
@@ -447,7 +447,7 @@ func TestRouteCreateSilence(t *testing.T) {
 				return acMock.New().WithDisabled()
 			},
 			role:           org.RoleAdmin,
-			expectedStatus: http.StatusCreated,
+			expectedStatus: http.StatusOK,
 		},
 	}
 

--- a/pkg/services/ngalert/api/tooling/api.json
+++ b/pkg/services/ngalert/api/tooling/api.json
@@ -3497,6 +3497,7 @@
    "type": "object"
   },
   "alertGroup": {
+   "description": "AlertGroup alert group",
    "properties": {
     "alerts": {
      "description": "alerts",
@@ -3624,6 +3625,7 @@
    "type": "object"
   },
   "gettableAlert": {
+   "description": "GettableAlert gettable alert",
    "properties": {
     "annotations": {
      "$ref": "#/definitions/labelSet"
@@ -3679,13 +3681,13 @@
    "type": "object"
   },
   "gettableAlerts": {
+   "description": "GettableAlerts gettable alerts",
    "items": {
     "$ref": "#/definitions/gettableAlert"
    },
    "type": "array"
   },
   "gettableSilence": {
-   "description": "GettableSilence gettable silence",
    "properties": {
     "comment": {
      "description": "comment",

--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
@@ -176,7 +176,7 @@ import (
 // create silence
 //
 //     Responses:
-//       201: postSilencesOKBody
+//       200: postSilencesOKBody
 //       400: ValidationError
 
 // swagger:route POST /api/alertmanager/{DatasourceUID}/api/v2/silences alertmanager RouteCreateSilence
@@ -184,7 +184,7 @@ import (
 // create silence
 //
 //     Responses:
-//       201: postSilencesOKBody
+//       200: postSilencesOKBody
 //       400: ValidationError
 //       404: NotFound
 

--- a/pkg/services/ngalert/api/tooling/post.json
+++ b/pkg/services/ngalert/api/tooling/post.json
@@ -3497,7 +3497,6 @@
    "type": "object"
   },
   "alertGroup": {
-   "description": "AlertGroup alert group",
    "properties": {
     "alerts": {
      "description": "alerts",
@@ -3521,7 +3520,6 @@
    "type": "object"
   },
   "alertGroups": {
-   "description": "AlertGroups alert groups",
    "items": {
     "$ref": "#/definitions/alertGroup"
    },
@@ -3626,6 +3624,7 @@
    "type": "object"
   },
   "gettableAlert": {
+   "description": "GettableAlert gettable alert",
    "properties": {
     "annotations": {
      "$ref": "#/definitions/labelSet"
@@ -3681,6 +3680,7 @@
    "type": "object"
   },
   "gettableAlerts": {
+   "description": "GettableAlerts gettable alerts",
    "items": {
     "$ref": "#/definitions/gettableAlert"
    },
@@ -4269,7 +4269,7 @@
      }
     ],
     "responses": {
-     "201": {
+     "200": {
       "description": "postSilencesOKBody",
       "schema": {
        "$ref": "#/definitions/postSilencesOKBody"
@@ -4805,7 +4805,7 @@
      }
     ],
     "responses": {
-     "201": {
+     "200": {
       "description": "postSilencesOKBody",
       "schema": {
        "$ref": "#/definitions/postSilencesOKBody"

--- a/pkg/services/ngalert/api/tooling/spec.json
+++ b/pkg/services/ngalert/api/tooling/spec.json
@@ -247,7 +247,7 @@
           }
         ],
         "responses": {
-          "201": {
+          "200": {
             "description": "postSilencesOKBody",
             "schema": {
               "$ref": "#/definitions/postSilencesOKBody"
@@ -783,7 +783,7 @@
           }
         ],
         "responses": {
-          "201": {
+          "200": {
             "description": "postSilencesOKBody",
             "schema": {
               "$ref": "#/definitions/postSilencesOKBody"
@@ -6112,7 +6112,6 @@
       }
     },
     "alertGroup": {
-      "description": "AlertGroup alert group",
       "type": "object",
       "required": [
         "alerts",
@@ -6137,7 +6136,6 @@
       "$ref": "#/definitions/alertGroup"
     },
     "alertGroups": {
-      "description": "AlertGroups alert groups",
       "type": "array",
       "items": {
         "$ref": "#/definitions/alertGroup"
@@ -6243,6 +6241,7 @@
       }
     },
     "gettableAlert": {
+      "description": "GettableAlert gettable alert",
       "type": "object",
       "required": [
         "labels",
@@ -6299,6 +6298,7 @@
       "$ref": "#/definitions/gettableAlert"
     },
     "gettableAlerts": {
+      "description": "GettableAlerts gettable alerts",
       "type": "array",
       "items": {
         "$ref": "#/definitions/gettableAlert"

--- a/pkg/tests/api/alerting/api_alertmanager_test.go
+++ b/pkg/tests/api/alerting/api_alertmanager_test.go
@@ -242,12 +242,12 @@ func TestIntegrationAMConfigAccess(t *testing.T) {
 			{
 				desc:      "editor request should succeed",
 				url:       "http://editor:editor@%s/api/alertmanager/grafana/api/v2/silences",
-				expStatus: http.StatusAccepted,
+				expStatus: http.StatusCreated,
 			},
 			{
 				desc:      "admin request should succeed",
 				url:       "http://admin:admin@%s/api/alertmanager/grafana/api/v2/silences",
-				expStatus: http.StatusAccepted,
+				expStatus: http.StatusCreated,
 			},
 		}
 

--- a/pkg/tests/api/alerting/api_alertmanager_test.go
+++ b/pkg/tests/api/alerting/api_alertmanager_test.go
@@ -242,12 +242,12 @@ func TestIntegrationAMConfigAccess(t *testing.T) {
 			{
 				desc:      "editor request should succeed",
 				url:       "http://editor:editor@%s/api/alertmanager/grafana/api/v2/silences",
-				expStatus: http.StatusCreated,
+				expStatus: http.StatusOK,
 			},
 			{
 				desc:      "admin request should succeed",
 				url:       "http://admin:admin@%s/api/alertmanager/grafana/api/v2/silences",
-				expStatus: http.StatusCreated,
+				expStatus: http.StatusOK,
 			},
 		}
 

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -11235,6 +11235,9 @@
         "for": {
           "$ref": "#/definitions/Duration"
         },
+        "isPaused": {
+          "type": "boolean"
+        },
         "labels": {
           "type": "object",
           "additionalProperties": {
@@ -16005,7 +16008,7 @@
         },
         "isPaused": {
           "type": "boolean",
-          "example": true
+          "example": false
         },
         "labels": {
           "type": "object",
@@ -18066,8 +18069,9 @@
       "type": "string"
     },
     "URL": {
+      "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use RawPath, an optional field which only gets\nset if the default encoding is different from Path.\n\nURL's String method uses the EscapedPath method to obtain the path. See the\nEscapedPath method for more details.",
       "type": "object",
-      "title": "URL is a custom URL type that allows validation at configuration load time.",
+      "title": "A URL represents a parsed URL (technically, a URI reference).",
       "properties": {
         "ForceQuery": {
           "type": "boolean"
@@ -18910,6 +18914,7 @@
       }
     },
     "alertGroup": {
+      "description": "AlertGroup alert group",
       "type": "object",
       "required": [
         "alerts",
@@ -18933,7 +18938,6 @@
       }
     },
     "alertGroups": {
-      "description": "AlertGroups alert groups",
       "type": "array",
       "items": {
         "$ref": "#/definitions/alertGroup"
@@ -19038,6 +19042,7 @@
       }
     },
     "gettableAlert": {
+      "description": "GettableAlert gettable alert",
       "type": "object",
       "required": [
         "labels",
@@ -19148,13 +19153,13 @@
       }
     },
     "gettableSilences": {
-      "description": "GettableSilences gettable silences",
       "type": "array",
       "items": {
         "$ref": "#/definitions/gettableSilence"
       }
     },
     "integration": {
+      "description": "Integration integration",
       "type": "object",
       "required": [
         "name",


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Currently return code for create silences with POST to /api/alertmanager/grafana/api/v2/silences returns 202 instead of 201 as specified in documentation.
This PR fixes #61966

**Why do we need this feature?**

POST used to create something should use 201 return code which means CREATED.
202 means ACCEPTED and is misleading.

**Who is this feature for?**

Everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #61966

**Special notes for your reviewer**:

Simple change of return code.
