### PR TITLE
Query Panels: Pass on loading state

### DIFF
--- a/public/app/features/query/components/QueryEditorRow.test.ts
+++ b/public/app/features/query/components/QueryEditorRow.test.ts
@@ -124,6 +124,20 @@ describe('filterPanelDataToQuery', () => {
     const panelDataA = filterPanelDataToQuery(loadingData, 'A');
     expect(panelDataA?.state).toBe(LoadingState.Loading);
   });
+  it('should not set the state to error if a frame has previously returned an error, but is now still loading', () => {
+    const loadingData: PanelData = {
+      state: LoadingState.Loading,
+      series: [],
+      error: {
+        refId: 'A',
+        message: 'Error',
+      },
+      timeRange: { from: dateTime(), to: dateTime(), raw: { from: 'now-1d', to: 'now' } },
+    };
+
+    const panelDataA = filterPanelDataToQuery(loadingData, 'A');
+    expect(panelDataA?.state).toBe(LoadingState.Loading);
+  });
 });
 
 describe('frame results with warnings', () => {

--- a/public/app/features/query/components/QueryEditorRow.test.ts
+++ b/public/app/features/query/components/QueryEditorRow.test.ts
@@ -109,13 +109,12 @@ describe('filterPanelDataToQuery', () => {
     const panelDataA = filterPanelDataToQuery(loadingData, 'A');
     expect(panelDataA?.state).toBe(LoadingState.Loading);
   });
-
-  it('should not set the state to error if the frame is still loading', () => {
+  it('should keep the state in loading until all queries are finished, even if the current query has errored', () => {
     const loadingData: PanelData = {
       state: LoadingState.Loading,
       series: [],
       error: {
-        refId: 'B',
+        refId: 'A',
         message: 'Error',
       },
       timeRange: { from: dateTime(), to: dateTime(), raw: { from: 'now-1d', to: 'now' } },
@@ -124,12 +123,12 @@ describe('filterPanelDataToQuery', () => {
     const panelDataA = filterPanelDataToQuery(loadingData, 'A');
     expect(panelDataA?.state).toBe(LoadingState.Loading);
   });
-  it('should not set the state to error if a frame has previously returned an error, but is now still loading', () => {
+  it('should keep the state in loading until all queries are finished, if another query has errored', () => {
     const loadingData: PanelData = {
       state: LoadingState.Loading,
       series: [],
       error: {
-        refId: 'A',
+        refId: 'B',
         message: 'Error',
       },
       timeRange: { from: dateTime(), to: dateTime(), raw: { from: 'now-1d', to: 'now' } },

--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -571,7 +571,7 @@ export function filterPanelDataToQuery(data: PanelData, refId: string): PanelDat
   if (state !== LoadingState.Loading) {
     if (error) {
       state = LoadingState.Error;
-    } else if (!error && data.state === LoadingState.Error) {
+    } else if (data.state === LoadingState.Error) {
       state = LoadingState.Done;
     }
   }

--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -10,13 +10,13 @@ import {
   DataQuery,
   DataSourceApi,
   DataSourceInstanceSettings,
+  DataSourcePluginContextProvider,
   EventBusExtended,
   EventBusSrv,
   HistoryItem,
   LoadingState,
   PanelData,
   PanelEvents,
-  DataSourcePluginContextProvider,
   QueryResultMetaNotice,
   TimeRange,
   toLegacyResponseData,
@@ -568,10 +568,12 @@ export function filterPanelDataToQuery(data: PanelData, refId: string): PanelDat
   // Only say this is an error if the error links to the query
   let state = data.state;
   const error = data.error && data.error.refId === refId ? data.error : undefined;
-  if (error) {
-    state = LoadingState.Error;
-  } else if (!error && data.state === LoadingState.Error) {
-    state = LoadingState.Done;
+  if (state !== LoadingState.Loading) {
+    if (error) {
+      state = LoadingState.Error;
+    } else if (!error && data.state === LoadingState.Error) {
+      state = LoadingState.Done;
+    }
   }
 
   const timeRange = data.timeRange;


### PR DESCRIPTION
Fixes [Redshift #200](https://github.com/grafana/redshift-datasource/issues/200)

A bit of background [here](https://github.com/grafana/grafana/pull/61635)

Decided to go with the quick fix as assessing the impact of clearing error state would take more time, and knowledge, than I currently have. 
The fix makes sure the loading state is passed to the query editors and not overwritten. This way query editors always have the most updated loading state.



N.B. This doesn't fix the annotations editor, but the buttons shouldn't be there anyway, so [this PR](https://github.com/grafana/redshift-datasource/pull/206) hides them. 

  If anyone that has background knowledge on preProcessPanelData and its impact, wants to take a look, you’re welcome to do so and Im available for questions.