### PR TITLE
Search: Fix not being able to clear sort value

### DIFF
--- a/public/app/features/search/page/components/ActionRow.tsx
+++ b/public/app/features/search/page/components/ActionRow.tsx
@@ -106,10 +106,10 @@ export const ActionRow: FC<Props> = ({
             />
           )}
           <SortPicker
-            onChange={(change) => onSortChange(change.value)}
+            onChange={(change) => onSortChange(change?.value)}
             value={state.sort}
             getSortOptions={getSortOptions}
-            placeholder={sortPlaceholder}
+            placeholder={sortPlaceholder || 'Sort'}
             isClearable
           />
         </HorizontalGroup>

--- a/public/app/features/search/state/SearchStateManager.ts
+++ b/public/app/features/search/state/SearchStateManager.ts
@@ -171,9 +171,9 @@ export class SearchStateManager extends StateManagerBase<SearchState> {
       q.kind = ['dashboard', 'folder']; // skip panels
     }
 
-    if (q.query === '*' && !q.sort?.length) {
-      q.sort = 'name_sort';
-    }
+    // if (q.query === '*' && !q.sort?.length) {
+    //   q.sort = 'name_sort';
+    // }
 
     return q;
   }

--- a/public/app/features/search/state/SearchStateManager.ts
+++ b/public/app/features/search/state/SearchStateManager.ts
@@ -115,6 +115,8 @@ export class SearchStateManager extends StateManagerBase<SearchState> {
   onSortChange = (sort: string | undefined) => {
     if (sort) {
       localStorage.setItem(SEARCH_SELECTED_SORT, sort);
+    } else {
+      localStorage.removeItem(SEARCH_SELECTED_SORT);
     }
 
     if (this.state.layout === SearchLayout.Folders) {

--- a/public/app/features/search/state/SearchStateManager.ts
+++ b/public/app/features/search/state/SearchStateManager.ts
@@ -171,10 +171,6 @@ export class SearchStateManager extends StateManagerBase<SearchState> {
       q.kind = ['dashboard', 'folder']; // skip panels
     }
 
-    // if (q.query === '*' && !q.sort?.length) {
-    //   q.sort = 'name_sort';
-    // }
-
     return q;
   }
 


### PR DESCRIPTION
**What is this feature?**

 - Fix issue introduced in https://github.com/grafana/grafana/pull/62248 where you're unable to clear the selected sort value
 - Stop setting default sort value in SearchStateManager - individual searchers will set it instead
 - Don't show default sort mode in sort picker