### PR TITLE
github: update the /duplicate slash command action

### DIFF
--- a/.github/commands.json
+++ b/.github/commands.json
@@ -11,7 +11,7 @@
     "type":"comment",
     "name":"duplicate",
     "allowUsers":[],
-    "action":"updateLabels",
+    "action":"close",
     "addLabel":"type/duplicate"
   },
   {


### PR DESCRIPTION

**What is this feature?**

an update of the GitHub slash command `/duplicate`  to perform "action":"close",

**Why do we need this feature?**

currently the above command adds the label `type/duplicate` but **it does not close the issue**
Reference:  https://github.com/grafana/grafana/issues/61700#issuecomment-1400559701

**Who is this feature for?**

Anyone triaging issues

**Which issue(s) does this PR fix?**:

https://github.com/grafana/grafana/issues/61942
<!--


