### PR TITLE
Logs Panel: Refactor style generation to improve rendering performance

### DIFF
--- a/public/app/features/logs/components/LogDetails.test.tsx
+++ b/public/app/features/logs/components/LogDetails.test.tsx
@@ -5,8 +5,10 @@ import { Field, LogLevel, LogRowModel, MutableDataFrame, createTheme } from '@gr
 
 import { LogDetails, Props } from './LogDetails';
 import { createLogRow } from './__mocks__/logRow';
+import { getLogRowStyles } from './getLogRowStyles';
 
 const setup = (propOverrides?: Partial<Props>, rowOverrides?: Partial<LogRowModel>) => {
+  const theme = createTheme();
   const props: Props = {
     displayedFields: [],
     showDuplicates: false,
@@ -17,7 +19,8 @@ const setup = (propOverrides?: Partial<Props>, rowOverrides?: Partial<LogRowMode
     onClickFilterOutLabel: () => {},
     onClickShowField: () => {},
     onClickHideField: () => {},
-    theme: createTheme(),
+    theme,
+    styles: getLogRowStyles(theme),
     ...(propOverrides || {}),
   };
 

--- a/public/app/features/logs/components/LogDetails.test.tsx
+++ b/public/app/features/logs/components/LogDetails.test.tsx
@@ -5,10 +5,8 @@ import { Field, LogLevel, LogRowModel, MutableDataFrame, createTheme } from '@gr
 
 import { LogDetails, Props } from './LogDetails';
 import { createLogRow } from './__mocks__/logRow';
-import { getLogRowStyles } from './getLogRowStyles';
 
 const setup = (propOverrides?: Partial<Props>, rowOverrides?: Partial<LogRowModel>) => {
-  const theme = createTheme();
   const props: Props = {
     displayedFields: [],
     showDuplicates: false,
@@ -19,8 +17,7 @@ const setup = (propOverrides?: Partial<Props>, rowOverrides?: Partial<LogRowMode
     onClickFilterOutLabel: () => {},
     onClickShowField: () => {},
     onClickHideField: () => {},
-    theme,
-    styles: getLogRowStyles(theme),
+    theme: createTheme(),
     ...(propOverrides || {}),
   };
 

--- a/public/app/features/logs/components/LogDetails.tsx
+++ b/public/app/features/logs/components/LogDetails.tsx
@@ -1,13 +1,13 @@
-import { cx } from '@emotion/css';
+import { css, cx } from '@emotion/css';
 import React, { PureComponent } from 'react';
 
-import { CoreApp, DataFrame, Field, LinkModel, LogRowModel } from '@grafana/data';
+import { CoreApp, DataFrame, Field, GrafanaTheme2, LinkModel, LogRowModel } from '@grafana/data';
 import { Themeable2, withTheme2 } from '@grafana/ui';
 
 import { calculateLogsLabelStats, calculateStats } from '../utils';
 
 import { LogDetailsRow } from './LogDetailsRow';
-import { getLogLevelStyles, LogRowStyles } from './getLogRowStyles';
+import { getLogLevelStyles, getLogRowStyles } from './getLogRowStyles';
 import { getAllFields } from './logParser';
 
 //Components
@@ -20,14 +20,33 @@ export interface Props extends Themeable2 {
   className?: string;
   hasError?: boolean;
   app?: CoreApp;
+
   onClickFilterLabel?: (key: string, value: string) => void;
   onClickFilterOutLabel?: (key: string, value: string) => void;
   getFieldLinks?: (field: Field, rowIndex: number, dataFrame: DataFrame) => Array<LinkModel<Field>>;
   displayedFields?: string[];
   onClickShowField?: (key: string) => void;
   onClickHideField?: (key: string) => void;
-  styles: LogRowStyles;
 }
+
+const getStyles = (theme: GrafanaTheme2) => {
+  return {
+    logsRowLevelDetails: css`
+      label: logs-row__level_details;
+      &::after {
+        top: -3px;
+      }
+    `,
+    logDetails: css`
+      label: logDetailsDefaultCursor;
+      cursor: default;
+
+      &:hover {
+        background-color: ${theme.colors.background.primary};
+      }
+    `,
+  };
+};
 
 class UnThemedLogDetails extends PureComponent<Props> {
   render() {
@@ -46,9 +65,10 @@ class UnThemedLogDetails extends PureComponent<Props> {
       displayedFields,
       getFieldLinks,
       wrapLogMessage,
-      styles,
     } = this.props;
+    const style = getLogRowStyles(theme, row.logLevel);
     const levelStyles = getLogLevelStyles(theme, row.logLevel);
+    const styles = getStyles(theme);
     const labels = row.labels ? row.labels : {};
     const labelsAvailable = Object.keys(labels).length > 0;
     const fieldsAndLinks = getAllFields(row, getFieldLinks);
@@ -65,12 +85,12 @@ class UnThemedLogDetails extends PureComponent<Props> {
         {showDuplicates && <td />}
         <td className={levelClassName} aria-label="Log level" />
         <td colSpan={4}>
-          <div className={styles.logDetailsContainer}>
-            <table className={styles.logDetailsTable}>
+          <div className={style.logDetailsContainer}>
+            <table className={style.logDetailsTable}>
               <tbody>
                 {(labelsAvailable || fieldsAvailable) && (
                   <tr>
-                    <td colSpan={100} className={styles.logDetailsHeading} aria-label="Fields">
+                    <td colSpan={100} className={style.logDetailsHeading} aria-label="Fields">
                       Fields
                     </td>
                   </tr>
@@ -119,7 +139,7 @@ class UnThemedLogDetails extends PureComponent<Props> {
 
                 {linksAvailable && (
                   <tr>
-                    <td colSpan={100} className={styles.logDetailsHeading} aria-label="Data Links">
+                    <td colSpan={100} className={style.logDetailsHeading} aria-label="Data Links">
                       Links
                     </td>
                   </tr>

--- a/public/app/features/logs/components/LogDetails.tsx
+++ b/public/app/features/logs/components/LogDetails.tsx
@@ -1,13 +1,13 @@
-import { css, cx } from '@emotion/css';
+import { cx } from '@emotion/css';
 import React, { PureComponent } from 'react';
 
-import { CoreApp, DataFrame, Field, GrafanaTheme2, LinkModel, LogRowModel } from '@grafana/data';
+import { CoreApp, DataFrame, Field, LinkModel, LogRowModel } from '@grafana/data';
 import { Themeable2, withTheme2 } from '@grafana/ui';
 
 import { calculateLogsLabelStats, calculateStats } from '../utils';
 
 import { LogDetailsRow } from './LogDetailsRow';
-import { getLogLevelStyles, getLogRowStyles } from './getLogRowStyles';
+import { getLogLevelStyles, LogRowStyles } from './getLogRowStyles';
 import { getAllFields } from './logParser';
 
 //Components
@@ -20,33 +20,14 @@ export interface Props extends Themeable2 {
   className?: string;
   hasError?: boolean;
   app?: CoreApp;
-
   onClickFilterLabel?: (key: string, value: string) => void;
   onClickFilterOutLabel?: (key: string, value: string) => void;
   getFieldLinks?: (field: Field, rowIndex: number, dataFrame: DataFrame) => Array<LinkModel<Field>>;
   displayedFields?: string[];
   onClickShowField?: (key: string) => void;
   onClickHideField?: (key: string) => void;
+  styles: LogRowStyles;
 }
-
-const getStyles = (theme: GrafanaTheme2) => {
-  return {
-    logsRowLevelDetails: css`
-      label: logs-row__level_details;
-      &::after {
-        top: -3px;
-      }
-    `,
-    logDetails: css`
-      label: logDetailsDefaultCursor;
-      cursor: default;
-
-      &:hover {
-        background-color: ${theme.colors.background.primary};
-      }
-    `,
-  };
-};
 
 class UnThemedLogDetails extends PureComponent<Props> {
   render() {
@@ -65,10 +46,9 @@ class UnThemedLogDetails extends PureComponent<Props> {
       displayedFields,
       getFieldLinks,
       wrapLogMessage,
+      styles,
     } = this.props;
-    const style = getLogRowStyles(theme, row.logLevel);
     const levelStyles = getLogLevelStyles(theme, row.logLevel);
-    const styles = getStyles(theme);
     const labels = row.labels ? row.labels : {};
     const labelsAvailable = Object.keys(labels).length > 0;
     const fieldsAndLinks = getAllFields(row, getFieldLinks);
@@ -85,12 +65,12 @@ class UnThemedLogDetails extends PureComponent<Props> {
         {showDuplicates && <td />}
         <td className={levelClassName} aria-label="Log level" />
         <td colSpan={4}>
-          <div className={style.logDetailsContainer}>
-            <table className={style.logDetailsTable}>
+          <div className={styles.logDetailsContainer}>
+            <table className={styles.logDetailsTable}>
               <tbody>
                 {(labelsAvailable || fieldsAvailable) && (
                   <tr>
-                    <td colSpan={100} className={style.logDetailsHeading} aria-label="Fields">
+                    <td colSpan={100} className={styles.logDetailsHeading} aria-label="Fields">
                       Fields
                     </td>
                   </tr>
@@ -139,7 +119,7 @@ class UnThemedLogDetails extends PureComponent<Props> {
 
                 {linksAvailable && (
                   <tr>
-                    <td colSpan={100} className={style.logDetailsHeading} aria-label="Data Links">
+                    <td colSpan={100} className={styles.logDetailsHeading} aria-label="Data Links">
                       Links
                     </td>
                   </tr>

--- a/public/app/features/logs/components/LogDetails.tsx
+++ b/public/app/features/logs/components/LogDetails.tsx
@@ -7,7 +7,7 @@ import { Themeable2, withTheme2 } from '@grafana/ui';
 import { calculateLogsLabelStats, calculateStats } from '../utils';
 
 import { LogDetailsRow } from './LogDetailsRow';
-import { getLogRowStyles } from './getLogRowStyles';
+import { getLogLevelStyles, getLogRowStyles } from './getLogRowStyles';
 import { getAllFields } from './logParser';
 
 //Components
@@ -67,6 +67,7 @@ class UnThemedLogDetails extends PureComponent<Props> {
       wrapLogMessage,
     } = this.props;
     const style = getLogRowStyles(theme, row.logLevel);
+    const levelStyles = getLogLevelStyles(theme, row.logLevel);
     const styles = getStyles(theme);
     const labels = row.labels ? row.labels : {};
     const labelsAvailable = Object.keys(labels).length > 0;
@@ -77,7 +78,7 @@ class UnThemedLogDetails extends PureComponent<Props> {
     const linksAvailable = links && links.length > 0;
 
     // If logs with error, we are not showing the level color
-    const levelClassName = cx(!hasError && [style.logsRowLevel, styles.logsRowLevelDetails]);
+    const levelClassName = cx(!hasError && [levelStyles.logsRowLevel, styles.logsRowLevelDetails]);
 
     return (
       <tr className={cx(className, styles.logDetails)}>

--- a/public/app/features/logs/components/LogDetails.tsx
+++ b/public/app/features/logs/components/LogDetails.tsx
@@ -76,9 +76,8 @@ class UnThemedLogDetails extends PureComponent<Props> {
     const linksAvailable = links && links.length > 0;
 
     // If logs with error, we are not showing the level color
-    const levelClassName = !hasError
-      ? `${levelStyles.logsRowLevelColor} ${rowStyles.logsRowLevel} ${styles.logsRowLevelDetails}`
-      : '';
+    const levelClassName = hasError
+      ? '' : `${levelStyles.logsRowLevelColor} ${rowStyles.logsRowLevel} ${styles.logsRowLevelDetails}`;
 
     return (
       <tr className={cx(className, styles.logDetails)}>

--- a/public/app/features/logs/components/LogDetails.tsx
+++ b/public/app/features/logs/components/LogDetails.tsx
@@ -10,8 +10,6 @@ import { LogDetailsRow } from './LogDetailsRow';
 import { getLogLevelStyles, getLogRowStyles } from './getLogRowStyles';
 import { getAllFields } from './logParser';
 
-//Components
-
 export interface Props extends Themeable2 {
   row: LogRowModel;
   showDuplicates: boolean;
@@ -66,7 +64,7 @@ class UnThemedLogDetails extends PureComponent<Props> {
       getFieldLinks,
       wrapLogMessage,
     } = this.props;
-    const style = getLogRowStyles(theme);
+    const rowStyles = getLogRowStyles(theme);
     const levelStyles = getLogLevelStyles(theme, row.logLevel);
     const styles = getStyles(theme);
     const labels = row.labels ? row.labels : {};
@@ -78,19 +76,21 @@ class UnThemedLogDetails extends PureComponent<Props> {
     const linksAvailable = links && links.length > 0;
 
     // If logs with error, we are not showing the level color
-    const levelClassName = cx(!hasError && [levelStyles.logsRowLevel, styles.logsRowLevelDetails]);
+    const levelClassName = !hasError
+      ? `${levelStyles.logsRowLevelColor} ${rowStyles.logsRowLevel} ${styles.logsRowLevelDetails}`
+      : '';
 
     return (
       <tr className={cx(className, styles.logDetails)}>
         {showDuplicates && <td />}
         <td className={levelClassName} aria-label="Log level" />
         <td colSpan={4}>
-          <div className={style.logDetailsContainer}>
-            <table className={style.logDetailsTable}>
+          <div className={rowStyles.logDetailsContainer}>
+            <table className={rowStyles.logDetailsTable}>
               <tbody>
                 {(labelsAvailable || fieldsAvailable) && (
                   <tr>
-                    <td colSpan={100} className={style.logDetailsHeading} aria-label="Fields">
+                    <td colSpan={100} className={rowStyles.logDetailsHeading} aria-label="Fields">
                       Fields
                     </td>
                   </tr>
@@ -139,7 +139,7 @@ class UnThemedLogDetails extends PureComponent<Props> {
 
                 {linksAvailable && (
                   <tr>
-                    <td colSpan={100} className={style.logDetailsHeading} aria-label="Data Links">
+                    <td colSpan={100} className={rowStyles.logDetailsHeading} aria-label="Data Links">
                       Links
                     </td>
                   </tr>

--- a/public/app/features/logs/components/LogDetails.tsx
+++ b/public/app/features/logs/components/LogDetails.tsx
@@ -66,7 +66,7 @@ class UnThemedLogDetails extends PureComponent<Props> {
       getFieldLinks,
       wrapLogMessage,
     } = this.props;
-    const style = getLogRowStyles(theme, row.logLevel);
+    const style = getLogRowStyles(theme);
     const levelStyles = getLogLevelStyles(theme, row.logLevel);
     const styles = getStyles(theme);
     const labels = row.labels ? row.labels : {};

--- a/public/app/features/logs/components/LogDetails.tsx
+++ b/public/app/features/logs/components/LogDetails.tsx
@@ -77,7 +77,8 @@ class UnThemedLogDetails extends PureComponent<Props> {
 
     // If logs with error, we are not showing the level color
     const levelClassName = hasError
-      ? '' : `${levelStyles.logsRowLevelColor} ${rowStyles.logsRowLevel} ${styles.logsRowLevelDetails}`;
+      ? ''
+      : `${levelStyles.logsRowLevelColor} ${rowStyles.logsRowLevel} ${styles.logsRowLevelDetails}`;
 
     return (
       <tr className={cx(className, styles.logDetails)}>

--- a/public/app/features/logs/components/LogRow.tsx
+++ b/public/app/features/logs/components/LogRow.tsx
@@ -247,6 +247,7 @@ class UnThemedLogRow extends PureComponent<Props, State> {
             hasError={hasError}
             displayedFields={displayedFields}
             app={app}
+            styles={styles}
           />
         )}
       </>

--- a/public/app/features/logs/components/LogRow.tsx
+++ b/public/app/features/logs/components/LogRow.tsx
@@ -183,7 +183,7 @@ class UnThemedLogRow extends PureComponent<Props, State> {
               {processedRow.duplicates && processedRow.duplicates > 0 ? `${processedRow.duplicates + 1}x` : null}
             </td>
           )}
-          <td className={cx({ [levelStyles.logsRowLevel]: !hasError })}>
+          <td className={!hasError ? `${levelStyles.logsRowLevelColor} ${styles.logsRowLevel}` : ''}>
             {hasError && (
               <Tooltip content={`Error: ${errorMessage}`} placement="right" theme="error">
                 <Icon className={styles.logIconError} name="exclamation-triangle" size="xs" />

--- a/public/app/features/logs/components/LogRow.tsx
+++ b/public/app/features/logs/components/LogRow.tsx
@@ -30,7 +30,7 @@ import {
 } from './LogRowContextProvider';
 import { LogRowMessage } from './LogRowMessage';
 import { LogRowMessageDisplayedFields } from './LogRowMessageDisplayedFields';
-import { getLogRowStyles } from './getLogRowStyles';
+import { getLogLevelStyles, getLogRowStyles } from './getLogRowStyles';
 
 //Components
 
@@ -175,6 +175,7 @@ class UnThemedLogRow extends PureComponent<Props, State> {
     const { showDetails, showContext } = this.state;
     const style = getLogRowStyles(theme, row.logLevel);
     const styles = getStyles(theme);
+    const levelStyles = getLogLevelStyles(theme, row.logLevel);
     const { errorMessage, hasError } = checkLogsError(row);
     const logRowBackground = cx(style.logsRow, {
       [styles.errorLogRow]: hasError,
@@ -203,7 +204,7 @@ class UnThemedLogRow extends PureComponent<Props, State> {
               {processedRow.duplicates && processedRow.duplicates > 0 ? `${processedRow.duplicates + 1}x` : null}
             </td>
           )}
-          <td className={cx({ [style.logsRowLevel]: !hasError })}>
+          <td className={cx({ [levelStyles.logsRowLevel]: !hasError })}>
             {hasError && (
               <Tooltip content={`Error: ${errorMessage}`} placement="right" theme="error">
                 <Icon className={style.logIconError} name="exclamation-triangle" size="xs" />

--- a/public/app/features/logs/components/LogRow.tsx
+++ b/public/app/features/logs/components/LogRow.tsx
@@ -1,4 +1,4 @@
-import { cx, css } from '@emotion/css';
+import { cx } from '@emotion/css';
 import React, { PureComponent } from 'react';
 
 import {
@@ -9,13 +9,12 @@ import {
   TimeZone,
   DataQueryResponse,
   dateTimeFormat,
-  GrafanaTheme2,
   CoreApp,
   DataFrame,
   DataSourceWithLogsContextSupport,
 } from '@grafana/data';
 import { reportInteraction } from '@grafana/runtime';
-import { styleMixins, withTheme2, Themeable2, Icon, Tooltip } from '@grafana/ui';
+import { withTheme2, Themeable2, Icon, Tooltip } from '@grafana/ui';
 
 import { checkLogsError, escapeUnescapedString } from '../utils';
 
@@ -30,7 +29,7 @@ import {
 } from './LogRowContextProvider';
 import { LogRowMessage } from './LogRowMessage';
 import { LogRowMessageDisplayedFields } from './LogRowMessageDisplayedFields';
-import { getLogLevelStyles, getLogRowStyles } from './getLogRowStyles';
+import { getLogLevelStyles, LogRowStyles } from './getLogRowStyles';
 
 //Components
 
@@ -61,6 +60,7 @@ interface Props extends Themeable2 {
   onClickHideField?: (key: string) => void;
   onLogRowHover?: (row?: LogRowModel) => void;
   toggleContextIsOpen?: () => void;
+  styles: LogRowStyles;
 }
 
 interface State {
@@ -68,24 +68,6 @@ interface State {
   showDetails: boolean;
 }
 
-const getStyles = (theme: GrafanaTheme2) => {
-  return {
-    topVerticalAlign: css`
-      label: topVerticalAlign;
-      margin-top: -${theme.spacing(0.9)};
-      margin-left: -${theme.spacing(0.25)};
-    `,
-    detailsOpen: css`
-      &:hover {
-        background-color: ${styleMixins.hoverColor(theme.colors.background.primary, theme)};
-      }
-    `,
-    errorLogRow: css`
-      label: erroredLogRow;
-      color: ${theme.colors.text.secondary};
-    `,
-  };
-};
 /**
  * Renders a log line.
  *
@@ -171,15 +153,14 @@ class UnThemedLogRow extends PureComponent<Props, State> {
       onLogRowHover,
       app,
       scrollElement,
+      styles,
     } = this.props;
     const { showDetails, showContext } = this.state;
-    const style = getLogRowStyles(theme, row.logLevel);
-    const styles = getStyles(theme);
     const levelStyles = getLogLevelStyles(theme, row.logLevel);
     const { errorMessage, hasError } = checkLogsError(row);
-    const logRowBackground = cx(style.logsRow, {
+    const logRowBackground = cx(styles.logsRow, {
       [styles.errorLogRow]: hasError,
-      [style.contextBackground]: showContext,
+      [styles.contextBackground]: showContext,
     });
 
     const processedRow =
@@ -200,25 +181,25 @@ class UnThemedLogRow extends PureComponent<Props, State> {
           }}
         >
           {showDuplicates && (
-            <td className={style.logsRowDuplicates}>
+            <td className={styles.logsRowDuplicates}>
               {processedRow.duplicates && processedRow.duplicates > 0 ? `${processedRow.duplicates + 1}x` : null}
             </td>
           )}
           <td className={cx({ [levelStyles.logsRowLevel]: !hasError })}>
             {hasError && (
               <Tooltip content={`Error: ${errorMessage}`} placement="right" theme="error">
-                <Icon className={style.logIconError} name="exclamation-triangle" size="xs" />
+                <Icon className={styles.logIconError} name="exclamation-triangle" size="xs" />
               </Tooltip>
             )}
           </td>
           {enableLogDetails && (
-            <td title={showDetails ? 'Hide log details' : 'See log details'} className={style.logsRowToggleDetails}>
+            <td title={showDetails ? 'Hide log details' : 'See log details'} className={styles.logsRowToggleDetails}>
               <Icon className={styles.topVerticalAlign} name={showDetails ? 'angle-down' : 'angle-right'} />
             </td>
           )}
-          {showTime && <td className={style.logsRowLocalTime}>{this.renderTimeStamp(row.timeEpochMs)}</td>}
+          {showTime && <td className={styles.logsRowLocalTime}>{this.renderTimeStamp(row.timeEpochMs)}</td>}
           {showLabels && processedRow.uniqueLabels && (
-            <td className={style.logsRowLabels}>
+            <td className={styles.logsRowLabels}>
               <LogLabels labels={processedRow.uniqueLabels} />
             </td>
           )}

--- a/public/app/features/logs/components/LogRow.tsx
+++ b/public/app/features/logs/components/LogRow.tsx
@@ -6,7 +6,6 @@ import {
   LinkModel,
   LogRowModel,
   LogsSortOrder,
-  TimeZone,
   DataQueryResponse,
   dateTimeFormat,
   CoreApp,
@@ -14,6 +13,7 @@ import {
   DataSourceWithLogsContextSupport,
 } from '@grafana/data';
 import { reportInteraction } from '@grafana/runtime';
+import { TimeZone } from '@grafana/schema';
 import { withTheme2, Themeable2, Icon, Tooltip } from '@grafana/ui';
 
 import { checkLogsError, escapeUnescapedString } from '../utils';

--- a/public/app/features/logs/components/LogRow.tsx
+++ b/public/app/features/logs/components/LogRow.tsx
@@ -229,6 +229,7 @@ class UnThemedLogRow extends PureComponent<Props, State> {
               app={app}
               scrollElement={scrollElement}
               logsSortOrder={logsSortOrder}
+              styles={styles}
             />
           )}
         </tr>

--- a/public/app/features/logs/components/LogRow.tsx
+++ b/public/app/features/logs/components/LogRow.tsx
@@ -183,7 +183,7 @@ class UnThemedLogRow extends PureComponent<Props, State> {
               {processedRow.duplicates && processedRow.duplicates > 0 ? `${processedRow.duplicates + 1}x` : null}
             </td>
           )}
-          <td className={!hasError ? `${levelStyles.logsRowLevelColor} ${styles.logsRowLevel}` : ''}>
+          <td className={hasError ? '' : `${levelStyles.logsRowLevelColor} ${styles.logsRowLevel}`}>
             {hasError && (
               <Tooltip content={`Error: ${errorMessage}`} placement="right" theme="error">
                 <Icon className={styles.logIconError} name="exclamation-triangle" size="xs" />

--- a/public/app/features/logs/components/LogRow.tsx
+++ b/public/app/features/logs/components/LogRow.tsx
@@ -31,8 +31,6 @@ import { LogRowMessage } from './LogRowMessage';
 import { LogRowMessageDisplayedFields } from './LogRowMessageDisplayedFields';
 import { getLogLevelStyles, LogRowStyles } from './getLogRowStyles';
 
-//Components
-
 interface Props extends Themeable2 {
   row: LogRowModel;
   showDuplicates: boolean;

--- a/public/app/features/logs/components/LogRow.tsx
+++ b/public/app/features/logs/components/LogRow.tsx
@@ -247,7 +247,6 @@ class UnThemedLogRow extends PureComponent<Props, State> {
             hasError={hasError}
             displayedFields={displayedFields}
             app={app}
-            styles={styles}
           />
         )}
       </>

--- a/public/app/features/logs/components/LogRowMessage.tsx
+++ b/public/app/features/logs/components/LogRowMessage.tsx
@@ -176,7 +176,7 @@ class UnThemedLogRowMessage extends PureComponent<Props> {
       getLogRowContextUi,
     } = this.props;
 
-    const style = getLogRowStyles(theme, row.logLevel);
+    const style = getLogRowStyles(theme);
     const { hasAnsi, raw } = row;
     const restructuredEntry = restructureLog(raw, prettifyLogMessage);
     const shouldShowContextToggle = showContextToggle ? showContextToggle(row) : false;

--- a/public/app/features/logs/components/LogRowMessage.tsx
+++ b/public/app/features/logs/components/LogRowMessage.tsx
@@ -1,27 +1,25 @@
-import { css, cx } from '@emotion/css';
+import { cx } from '@emotion/css';
 import memoizeOne from 'memoize-one';
 import React, { PureComponent } from 'react';
 import Highlighter from 'react-highlight-words';
-import tinycolor from 'tinycolor2';
 
 import {
   LogRowModel,
   findHighlightChunksInText,
-  GrafanaTheme2,
   LogsSortOrder,
   CoreApp,
   DataSourceWithLogsContextSupport,
 } from '@grafana/data';
-import { withTheme2, Themeable2, IconButton, Tooltip } from '@grafana/ui';
+import { IconButton, Tooltip } from '@grafana/ui';
 
 import { LogMessageAnsi } from './LogMessageAnsi';
 import { LogRowContext } from './LogRowContext';
 import { LogRowContextQueryErrors, HasMoreContextRows, LogRowContextRows } from './LogRowContextProvider';
-import { getLogRowStyles } from './getLogRowStyles';
+import { LogRowStyles } from './getLogRowStyles';
 
 export const MAX_CHARACTERS = 100000;
 
-interface Props extends Themeable2 {
+interface Props {
   row: LogRowModel;
   hasMoreContextRows?: HasMoreContextRows;
   contextIsOpen: boolean;
@@ -39,66 +37,8 @@ interface Props extends Themeable2 {
   updateLimit?: () => void;
   runContextQuery?: () => void;
   logsSortOrder?: LogsSortOrder | null;
+  styles: LogRowStyles;
 }
-
-const getStyles = (theme: GrafanaTheme2, showContextButton: boolean, isInExplore: boolean) => {
-  const outlineColor = tinycolor(theme.components.dashboard.background).setAlpha(0.7).toRgbString();
-
-  return {
-    positionRelative: css`
-      label: positionRelative;
-      position: relative;
-    `,
-    rowWithContext: css`
-      label: rowWithContext;
-      z-index: 1;
-      outline: 9999px solid ${outlineColor};
-      display: inherit;
-    `,
-    horizontalScroll: css`
-      label: horizontalScroll;
-      white-space: pre;
-    `,
-    contextNewline: css`
-      display: block;
-      margin-left: 0px;
-    `,
-    rowMenu: css`
-      display: flex;
-      flex-wrap: nowrap;
-      flex-direction: row;
-      align-content: flex-end;
-      justify-content: space-evenly;
-      align-items: center;
-      position: absolute;
-      top: 0;
-      bottom: auto;
-      height: ${theme.spacing(4.5)};
-      background: ${theme.colors.background.primary};
-      box-shadow: ${theme.shadows.z3};
-      padding: ${theme.spacing(0, 0, 0, 0.5)};
-      z-index: 100;
-      visibility: hidden;
-      width: ${showContextButton ? theme.spacing(10) : theme.spacing(5)};
-    `,
-    logRowMenuCell: css`
-      position: absolute;
-      right: ${!isInExplore ? '40px' : `calc(75px + ${theme.spacing()} + ${showContextButton ? '80px' : '40px'})`};
-      margin-top: -${theme.spacing(0.125)};
-    `,
-    logLine: css`
-      background-color: transparent;
-      border: none;
-      diplay: inline;
-      font-family: ${theme.typography.fontFamilyMonospace};
-      font-size: ${theme.typography.bodySmall.fontSize};
-      letter-spacing: ${theme.typography.bodySmall.letterSpacing};
-      text-align: left;
-      padding: 0;
-      user-select: text;
-    `,
-  };
-};
 
 function renderLogMessage(
   hasAnsi: boolean,
@@ -137,7 +77,7 @@ const restructureLog = memoizeOne((line: string, prettifyLogMessage: boolean): s
   return line;
 });
 
-class UnThemedLogRowMessage extends PureComponent<Props> {
+export class LogRowMessage extends PureComponent<Props> {
   logRowRef: React.RefObject<HTMLTableCellElement> = React.createRef();
 
   onContextToggle = (e: React.SyntheticEvent<HTMLElement>) => {
@@ -159,7 +99,6 @@ class UnThemedLogRowMessage extends PureComponent<Props> {
   render() {
     const {
       row,
-      theme,
       errors,
       hasMoreContextRows,
       updateLimit,
@@ -174,24 +113,23 @@ class UnThemedLogRowMessage extends PureComponent<Props> {
       logsSortOrder,
       showContextToggle,
       getLogRowContextUi,
+      styles,
     } = this.props;
-
-    const style = getLogRowStyles(theme);
     const { hasAnsi, raw } = row;
     const restructuredEntry = restructureLog(raw, prettifyLogMessage);
     const shouldShowContextToggle = showContextToggle ? showContextToggle(row) : false;
-    const styles = getStyles(theme, shouldShowContextToggle, app === CoreApp.Explore);
+    const inExplore = app === CoreApp.Explore;
 
     return (
       <>
         {
           // When context is open, the position has to be NOT relative. // Setting the postion as inline-style to
-          // overwrite the more sepecific style definition from `style.logsRowMessage`.
+          // overwrite the more sepecific style definition from `styles.logsRowMessage`.
         }
         <td
           ref={this.logRowRef}
           style={contextIsOpen ? { position: 'unset' } : undefined}
-          className={style.logsRowMessage}
+          className={styles.logsRowMessage}
         >
           <div
             className={cx(
@@ -218,13 +156,24 @@ class UnThemedLogRowMessage extends PureComponent<Props> {
               />
             )}
             <button className={cx(styles.logLine, styles.positionRelative, { [styles.rowWithContext]: contextIsOpen })}>
-              {renderLogMessage(hasAnsi, restructuredEntry, row.searchWords, style.logsRowMatchHighLight)}
+              {renderLogMessage(hasAnsi, restructuredEntry, row.searchWords, styles.logsRowMatchHighLight)}
             </button>
           </div>
         </td>
         {showRowMenu && (
-          <td className={cx('log-row-menu-cell', styles.logRowMenuCell)}>
-            <span className={cx('log-row-menu', styles.rowMenu)} onClick={(e) => e.stopPropagation()}>
+          <td
+            className={cx('log-row-menu-cell', styles.logRowMenuCell, {
+              [styles.logRowMenuCellDefaultPosition]: !inExplore,
+              [styles.logRowMenuCellExplore]: inExplore && !shouldShowContextToggle,
+              [styles.logRowMenuCellExploreWithContextButton]: inExplore && shouldShowContextToggle,
+            })}
+          >
+            <span
+              className={cx('log-row-menu', styles.rowMenu, {
+                [styles.rowMenuWithContextButton]: shouldShowContextToggle,
+              })}
+              onClick={(e) => e.stopPropagation()}
+            >
               {shouldShowContextToggle && (
                 <Tooltip placement="top" content={'Show context'}>
                   <IconButton size="md" name="gf-show-context" onClick={this.onShowContextClick} />
@@ -240,6 +189,3 @@ class UnThemedLogRowMessage extends PureComponent<Props> {
     );
   }
 }
-
-export const LogRowMessage = withTheme2(UnThemedLogRowMessage);
-LogRowMessage.displayName = 'LogRowMessage';

--- a/public/app/features/logs/components/LogRows.tsx
+++ b/public/app/features/logs/components/LogRows.tsx
@@ -133,7 +133,7 @@ class UnThemedLogRows extends PureComponent<Props, State> {
       getLogRowContextUi,
     } = this.props;
     const { renderAll, contextIsOpen } = this.state;
-    const { logsRowsTable } = getLogRowStyles(theme);
+    const styles = getLogRowStyles(theme);
     const dedupedRows = deduplicatedRows ? deduplicatedRows : logRows;
     const hasData = logRows && logRows.length > 0;
     const dedupCount = dedupedRows
@@ -151,7 +151,7 @@ class UnThemedLogRows extends PureComponent<Props, State> {
     const getRowContext = this.props.getRowContext ? this.props.getRowContext : () => Promise.resolve([]);
 
     return (
-      <table className={logsRowsTable}>
+      <table className={styles.logsRowsTable}>
         <tbody>
           {hasData &&
             firstRows.map((row, index) => (
@@ -182,6 +182,7 @@ class UnThemedLogRows extends PureComponent<Props, State> {
                 onLogRowHover={onLogRowHover}
                 app={app}
                 scrollElement={scrollElement}
+                styles={styles}
               />
             ))}
           {hasData &&
@@ -214,6 +215,7 @@ class UnThemedLogRows extends PureComponent<Props, State> {
                 onLogRowHover={onLogRowHover}
                 app={app}
                 scrollElement={scrollElement}
+                styles={styles}
               />
             ))}
           {hasData && !renderAll && (

--- a/public/app/features/logs/components/getLogRowStyles.ts
+++ b/public/app/features/logs/components/getLogRowStyles.ts
@@ -1,4 +1,5 @@
 import { css } from '@emotion/css';
+import tinycolor from 'tinycolor2';
 
 import { GrafanaTheme2, LogLevel } from '@grafana/data';
 import { styleMixins } from '@grafana/ui';
@@ -50,6 +51,7 @@ export const getLogLevelStyles = (theme: GrafanaTheme2, logLevel?: LogLevel) => 
 
 export const getLogRowStyles = (theme: GrafanaTheme2) => {
   const hoverBgColor = styleMixins.hoverColor(theme.colors.background.secondary, theme);
+  const contextOutlineColor = tinycolor(theme.components.dashboard.background).setAlpha(0.7).toRgbString();
   return {
     logsRowLevel: css``,
     logsRowMatchHighLight: css`
@@ -179,6 +181,7 @@ export const getLogRowStyles = (theme: GrafanaTheme2) => {
         background-color: ${hoverBgColor};
       }
     `,
+    // Log row
     topVerticalAlign: css`
       label: topVerticalAlign;
       margin-top: -${theme.spacing(0.9)};
@@ -192,6 +195,70 @@ export const getLogRowStyles = (theme: GrafanaTheme2) => {
     errorLogRow: css`
       label: erroredLogRow;
       color: ${theme.colors.text.secondary};
+    `,
+    // Log Row Message
+    positionRelative: css`
+      label: positionRelative;
+      position: relative;
+    `,
+    rowWithContext: css`
+      label: rowWithContext;
+      z-index: 1;
+      outline: 9999px solid ${contextOutlineColor};
+      display: inherit;
+    `,
+    horizontalScroll: css`
+      label: horizontalScroll;
+      white-space: pre;
+    `,
+    contextNewline: css`
+      display: block;
+      margin-left: 0px;
+    `,
+    rowMenu: css`
+      display: flex;
+      flex-wrap: nowrap;
+      flex-direction: row;
+      align-content: flex-end;
+      justify-content: space-evenly;
+      align-items: center;
+      position: absolute;
+      top: 0;
+      bottom: auto;
+      height: ${theme.spacing(4.5)};
+      background: ${theme.colors.background.primary};
+      box-shadow: ${theme.shadows.z3};
+      padding: ${theme.spacing(0, 0, 0, 0.5)};
+      z-index: 100;
+      visibility: hidden;
+      width: ${theme.spacing(5)};
+    `,
+    rowMenuWithContextButton: css`
+      width: ${theme.spacing(10)};
+    `,
+    logRowMenuCell: css`
+      position: absolute;
+      margin-top: -${theme.spacing(0.125)};
+    `,
+    logRowMenuCellDefaultPosition: css`
+      right: 40px;
+    `,
+    logRowMenuCellExplore: css`
+      right: calc(115px + ${theme.spacing(1)});
+    `,
+    logRowMenuCellExploreWithContextButton: css`
+      right: calc(155px + ${theme.spacing(1)});
+    `,
+    logLine: css`
+      background-color: transparent;
+      border: none;
+      diplay: inline;
+      font-family: ${theme.typography.fontFamilyMonospace};
+      font-size: ${theme.typography.bodySmall.fontSize};
+      letter-spacing: ${theme.typography.bodySmall.letterSpacing};
+      text-align: left;
+      padding: 0;
+      user-select: text;
     `,
   };
 };

--- a/public/app/features/logs/components/getLogRowStyles.ts
+++ b/public/app/features/logs/components/getLogRowStyles.ts
@@ -3,10 +3,8 @@ import { css } from '@emotion/css';
 import { GrafanaTheme2, LogLevel } from '@grafana/data';
 import { styleMixins } from '@grafana/ui';
 
-export const getLogRowStyles = (theme: GrafanaTheme2, logLevel?: LogLevel) => {
+export const getLogLevelStyles = (theme: GrafanaTheme2, logLevel?: LogLevel) => {
   let logColor = theme.isLight ? theme.v1.palette.gray5 : theme.v1.palette.gray2;
-  const hoverBgColor = styleMixins.hoverColor(theme.colors.background.secondary, theme);
-
   switch (logLevel) {
     case LogLevel.crit:
     case LogLevel.critical:
@@ -32,6 +30,29 @@ export const getLogRowStyles = (theme: GrafanaTheme2, logLevel?: LogLevel) => {
   }
 
   return {
+    logsRowLevel: css`
+      label: logs-row__level;
+      max-width: ${theme.spacing(1.25)};
+      cursor: default;
+      &::after {
+        content: '';
+        display: block;
+        position: absolute;
+        top: 1px;
+        bottom: 1px;
+        width: 3px;
+        left: ${theme.spacing(0.5)};
+        background-color: ${logColor};
+      }
+    `,
+  };
+};
+
+export const getLogRowStyles = (theme: GrafanaTheme2, logLevel?: LogLevel) => {
+  const hoverBgColor = styleMixins.hoverColor(theme.colors.background.secondary, theme);
+
+  return {
+    logsRowLevel: css``,
     logsRowMatchHighLight: css`
       label: logs-row__match-highlight;
       background: inherit;
@@ -80,21 +101,6 @@ export const getLogRowStyles = (theme: GrafanaTheme2, logLevel?: LogLevel) => {
       text-align: right;
       width: 4em;
       cursor: default;
-    `,
-    logsRowLevel: css`
-      label: logs-row__level;
-      max-width: ${theme.spacing(1.25)};
-      cursor: default;
-      &::after {
-        content: '';
-        display: block;
-        position: absolute;
-        top: 1px;
-        bottom: 1px;
-        width: 3px;
-        left: ${theme.spacing(0.5)};
-        background-color: ${logColor};
-      }
     `,
     logIconError: css`
       color: ${theme.colors.warning.main};

--- a/public/app/features/logs/components/getLogRowStyles.ts
+++ b/public/app/features/logs/components/getLogRowStyles.ts
@@ -48,9 +48,8 @@ export const getLogLevelStyles = (theme: GrafanaTheme2, logLevel?: LogLevel) => 
   };
 };
 
-export const getLogRowStyles = (theme: GrafanaTheme2, logLevel?: LogLevel) => {
+export const getLogRowStyles = (theme: GrafanaTheme2) => {
   const hoverBgColor = styleMixins.hoverColor(theme.colors.background.secondary, theme);
-
   return {
     logsRowLevel: css``,
     logsRowMatchHighLight: css`
@@ -180,5 +179,21 @@ export const getLogRowStyles = (theme: GrafanaTheme2, logLevel?: LogLevel) => {
         background-color: ${hoverBgColor};
       }
     `,
+    topVerticalAlign: css`
+      label: topVerticalAlign;
+      margin-top: -${theme.spacing(0.9)};
+      margin-left: -${theme.spacing(0.25)};
+    `,
+    detailsOpen: css`
+      &:hover {
+        background-color: ${styleMixins.hoverColor(theme.colors.background.primary, theme)};
+      }
+    `,
+    errorLogRow: css`
+      label: erroredLogRow;
+      color: ${theme.colors.text.secondary};
+    `,
   };
 };
+
+export type LogRowStyles = ReturnType<typeof getLogRowStyles>;

--- a/public/app/features/logs/components/getLogRowStyles.ts
+++ b/public/app/features/logs/components/getLogRowStyles.ts
@@ -31,6 +31,18 @@ export const getLogLevelStyles = (theme: GrafanaTheme2, logLevel?: LogLevel) => 
   }
 
   return {
+    logsRowLevelColor: css`
+      &::after {
+        background-color: ${logColor};
+      }
+    `,
+  };
+};
+
+export const getLogRowStyles = (theme: GrafanaTheme2) => {
+  const hoverBgColor = styleMixins.hoverColor(theme.colors.background.secondary, theme);
+  const contextOutlineColor = tinycolor(theme.components.dashboard.background).setAlpha(0.7).toRgbString();
+  return {
     logsRowLevel: css`
       label: logs-row__level;
       max-width: ${theme.spacing(1.25)};
@@ -43,17 +55,8 @@ export const getLogLevelStyles = (theme: GrafanaTheme2, logLevel?: LogLevel) => 
         bottom: 1px;
         width: 3px;
         left: ${theme.spacing(0.5)};
-        background-color: ${logColor};
       }
     `,
-  };
-};
-
-export const getLogRowStyles = (theme: GrafanaTheme2) => {
-  const hoverBgColor = styleMixins.hoverColor(theme.colors.background.secondary, theme);
-  const contextOutlineColor = tinycolor(theme.components.dashboard.background).setAlpha(0.7).toRgbString();
-  return {
-    logsRowLevel: css``,
     logsRowMatchHighLight: css`
       label: logs-row__match-highlight;
       background: inherit;

--- a/public/app/features/logs/components/getLogRowStyles.ts
+++ b/public/app/features/logs/components/getLogRowStyles.ts
@@ -193,6 +193,20 @@ export const getLogRowStyles = (theme: GrafanaTheme2) => {
       label: erroredLogRow;
       color: ${theme.colors.text.secondary};
     `,
+    logsRowLevelDetails: css`
+      label: logs-row__level_details;
+      &::after {
+        top: -3px;
+      }
+    `,
+    logDetails: css`
+      label: logDetailsDefaultCursor;
+      cursor: default;
+
+      &:hover {
+        background-color: ${theme.colors.background.primary};
+      }
+    `,
   };
 };
 

--- a/public/app/features/logs/components/getLogRowStyles.ts
+++ b/public/app/features/logs/components/getLogRowStyles.ts
@@ -193,20 +193,6 @@ export const getLogRowStyles = (theme: GrafanaTheme2) => {
       label: erroredLogRow;
       color: ${theme.colors.text.secondary};
     `,
-    logsRowLevelDetails: css`
-      label: logs-row__level_details;
-      &::after {
-        top: -3px;
-      }
-    `,
-    logDetails: css`
-      label: logDetailsDefaultCursor;
-      cursor: default;
-
-      &:hover {
-        background-color: ${theme.colors.background.primary};
-      }
-    `,
   };
 };
 


### PR DESCRIPTION
**What is this feature?**

This PR refactors how we generate and share styles in logs-related components. The main changes are:

- Parse styles shared by rows and other components once in `LogsRow`, then pass them as a prop.
- The dynamic css that sets the row color related with the level of a log has been simplified and delegated to `getLogLevelStyles()`.
- Individual `getStyles()` calls made by children components of a `LogRow` have been moved to `getLogRowStyles()`.

A minor change included in this PR is a `TimeZone` import deprecation fix.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana/issues/60687
Part of https://github.com/grafana/grafana/issues/63030

**Special notes for your reviewer**:

The tests for this PR have been performed in the Explore page.

The changes in this branch have been validated using the browser profiler and the React profiler before submission, to ascertain that there was a performance gain from each change. Individual changes have been also ran through the profiler, including a refactor of `LogRow` using functional components which was not included because it had no impact.

Avoiding the use of `cx()` and calls to `getLogLevelStyles()` have been tested and showed no visible performance improvements.

Measurements in the main branch:

![Main profiler](https://user-images.githubusercontent.com/1069378/215801673-e1778d58-ec8c-4d84-a4b7-5a09ebf3330c.png)

![Scripting main](https://user-images.githubusercontent.com/1069378/215801691-7111054d-d415-4a90-94e8-1b4cd1d94408.png)

Measurements in this feature branch:

![Performance profiler](https://user-images.githubusercontent.com/1069378/215801759-83c1d0b9-bf28-455a-ab4c-5851b61f69b9.png)

![Scripting performance](https://user-images.githubusercontent.com/1069378/215801813-5ed9d308-5a67-472e-a371-a29e821e590c.png)

The underlying functionality should, obviously, remain intact.