### PR TITLE
TestData: Remove references to TestData "DB"

### DIFF
--- a/devenv/dev-dashboards/feature-templating/templating-textbox-e2e-scenarios.json
+++ b/devenv/dev-dashboards/feature-templating/templating-textbox-e2e-scenarios.json
@@ -5,8 +5,7 @@
       "label": "gdev-testdata",
       "description": "",
       "type": "datasource",
-      "pluginId": "testdata",
-      "pluginName": "TestData"
+      "pluginId": "testdata"
     }
   ],
   "__requires": [

--- a/devenv/dev-dashboards/feature-templating/templating-textbox-e2e-scenarios.json
+++ b/devenv/dev-dashboards/feature-templating/templating-textbox-e2e-scenarios.json
@@ -6,7 +6,7 @@
       "description": "",
       "type": "datasource",
       "pluginId": "testdata",
-      "pluginName": "TestData DB"
+      "pluginName": "TestData"
     }
   ],
   "__requires": [
@@ -19,7 +19,7 @@
     {
       "type": "datasource",
       "id": "testdata",
-      "name": "TestData DB",
+      "name": "TestData",
       "version": "1.0.0"
     },
     {

--- a/docs/sources/datasources/testdata/_index.md
+++ b/docs/sources/datasources/testdata/_index.md
@@ -9,14 +9,14 @@ keywords:
   - troubleshooting
   - panels
   - testdata
-menuTitle: TestData DB
-title: TestData DB data source
+menuTitle: TestData
+title: TestData data source
 weight: 1500
 ---
 
-# TestData DB data source
+# TestData data source
 
-Grafana ships with a TestData DB data source, which creates simulated time series data for any [panel]({{< relref "../../panels-visualizations/" >}}).
+Grafana ships with a TestData data source, which creates simulated time series data for any [panel]({{< relref "../../panels-visualizations/" >}}).
 You can use it to build your own fake and random time series data and render it in any panel, which helps you verify dashboard functionality since you can safely and easily share the data.
 
 For instructions on how to add a data source to Grafana, refer to the [administration documentation]({{< relref "../../administration/data-source-management/" >}}).
@@ -28,7 +28,7 @@ Only users with the organization administrator role can add data sources.
 
 1. Hover the cursor over the **Configuration** (gear) icon.
 1. Select **Data Sources**.
-1. Select the TestData DB data source.
+1. Select the TestData data source.
 
 The data source doesn't provide any settings beyond the most basic options common to all data sources:
 
@@ -41,11 +41,11 @@ The data source doesn't provide any settings beyond the most basic options commo
 
 {{< figure src="/static/img/docs/v41/test_data_add.png" class="docs-image--no-shadow" caption="Adding test data" >}}
 
-Once you've added the TestData DB data source, your Grafana instance's users can use it as a data source in any metric panel.
+Once you've added the TestData data source, your Grafana instance's users can use it as a data source in any metric panel.
 
 ### Choose a scenario
 
-Instead of providing a query editor, the TestData DB data source helps you select a **Scenario** that generates simulated data for panels.
+Instead of providing a query editor, the TestData data source helps you select a **Scenario** that generates simulated data for panels.
 
 You can assign an **Alias** to each scenario, and many have their own options that appear when selected.
 
@@ -81,7 +81,7 @@ You can assign an **Alias** to each scenario, and many have their own options th
 
 ## Import a pre-configured dashboard
 
-TestData DB also provides an example dashboard.
+TestData also provides an example dashboard.
 
 **To import the example dashboard:**
 

--- a/docs/sources/tutorials/build-a-panel-plugin/index.md
+++ b/docs/sources/tutorials/build-a-panel-plugin/index.md
@@ -187,7 +187,7 @@ Now, when you change the color in the panel editor, the fill color of the circle
 
 Most panels visualize dynamic data from a Grafana data source. In this step, you'll create one circle per series, each with a radius equal to the last value in the series.
 
-> To use data from queries in your panel, you need to set up a data source. If you don't have one available, you can use the [TestData DB](/docs/grafana/latest/features/datasources/testdata) data source while developing.
+> To use data from queries in your panel, you need to set up a data source. If you don't have one available, you can use the [TestData](/docs/grafana/latest/features/datasources/testdata) data source while developing.
 
 The results from a data source query within your panel are available in the `data` property inside your panel component.
 

--- a/docs/sources/tutorials/provision-dashboards-and-data-sources/index.md
+++ b/docs/sources/tutorials/provision-dashboards-and-data-sources/index.md
@@ -74,7 +74,7 @@ Each data source provisioning config file contains a _manifest_ that specifies t
 
 At startup, Grafana loads the configuration files and provisions the data sources listed in the manifests.
 
-Let's configure a [TestData DB](/docs/grafana/latest/features/datasources/testdata/) data source that you can use for your dashboards.
+Let's configure a [TestData](/docs/grafana/latest/features/datasources/testdata/) data source that you can use for your dashboards.
 
 #### Create a data source manifest
 
@@ -84,12 +84,12 @@ Let's configure a [TestData DB](/docs/grafana/latest/features/datasources/testda
    apiVersion: 1
 
    datasources:
-     - name: TestData DB
+     - name: TestData
        type: testdata
    ```
 
 1. Restart Grafana to load the new changes.
-1. In the sidebar, hover the cursor over the **Configuration** (gear) icon and click **Data Sources**. The TestData DB appears in the list of data sources.
+1. In the sidebar, hover the cursor over the **Configuration** (gear) icon and click **Data Sources**. TestData appears in the list of data sources.
 
 > The configuration options can vary between different types of data sources. For more information on how to configure a specific data source, refer to [Data sources](/docs/grafana/latest/administration/provisioning/#datasources).
 
@@ -146,7 +146,7 @@ For more information on how to configure dashboard providers, refer to [Dashboar
          "bars": false,
          "dashLength": 10,
          "dashes": false,
-         "datasource": "TestData DB",
+         "datasource": "TestData",
          "fill": 1,
          "gridPos": {
            "h": 8,

--- a/pkg/kindsys/report.go
+++ b/pkg/kindsys/report.go
@@ -299,7 +299,6 @@ var irregularPluginNames = map[string]string{
 	"azuremonitor":          "grafana-azure-monitor-datasource",
 	"microsoftsqlserver":    "mssql",
 	"postgresql":            "postgres",
-	"testdatadb":            "testdata",
 }
 
 func buildComposableLinks(pp plugindef.PluginDef, cp kindsys.ComposableProperties) KindLinks {

--- a/public/app/features/datasources/components/EditDataSource.tsx
+++ b/public/app/features/datasources/components/EditDataSource.tsx
@@ -140,7 +140,7 @@ export function EditDataSourceView({
   if (pageId) {
     return (
       <DataSourcePluginContextProvider instanceSettings={dsi}>
-        <DataSourcePluginConfigPage pageId={pageId} plugin={plugin} />;
+        <DataSourcePluginConfigPage pageId={pageId} plugin={plugin} />
       </DataSourcePluginContextProvider>
     );
   }

--- a/public/app/features/variables/inspect/utils.test.ts
+++ b/public/app/features/variables/inspect/utils.test.ts
@@ -1490,8 +1490,8 @@ const dashWithTemplateDependenciesAndPanels: any = {
       {
         current: {
           selected: false,
-          text: 'TestData DB',
-          value: 'TestData DB',
+          text: 'TestData',
+          value: 'TestData',
         },
         description: null,
         error: null,
@@ -1624,8 +1624,8 @@ const dashWithTemplateDependenciesAndPanels: any = {
         allValue: null,
         current: {
           selected: true,
-          text: 'TestData DB',
-          value: 'TestData DB',
+          text: 'TestData',
+          value: 'TestData',
         },
         description: null,
         error: null,
@@ -1637,8 +1637,8 @@ const dashWithTemplateDependenciesAndPanels: any = {
         options: [
           {
             selected: true,
-            text: 'TestData DB',
-            value: 'TestData DB',
+            text: 'TestData',
+            value: 'TestData',
           },
           {
             selected: false,
@@ -1646,7 +1646,7 @@ const dashWithTemplateDependenciesAndPanels: any = {
             value: 'gdev-testdata',
           },
         ],
-        query: 'TestData DB, gdev-testdata',
+        query: 'TestData, gdev-testdata',
         queryValue: '',
         skipUrlSync: false,
         type: 'custom',

--- a/public/app/plugins/datasource/testdata/dashboards/streaming.json
+++ b/public/app/plugins/datasource/testdata/dashboards/streaming.json
@@ -1,12 +1,11 @@
 {
   "__inputs": [
     {
-      "name": "DS_TESTDATA_DB",
-      "label": "TestData DB",
+      "name": "DS_TESTDATA",
+      "label": "TestData",
       "description": "",
       "type": "datasource",
-      "pluginId": "testdata",
-      "pluginName": "TestData DB"
+      "pluginId": "testdata"
     }
   ],
   "__requires": [
@@ -31,7 +30,7 @@
     {
       "type": "datasource",
       "id": "testdata",
-      "name": "TestData DB",
+      "name": "TestData",
       "version": "1.0.0"
     }
   ],
@@ -146,7 +145,7 @@
       }
     },
     {
-      "datasource": "${DS_TESTDATA_DB}",
+      "datasource": "${DS_TESTDATA}",
       "description": "",
       "gridPos": {
         "h": 6,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Removing stale references to the the old TestData plugin name 

**Why do we need this feature?**
Misleading now that the plugin is renamed. Spotted by @tolzhabayev  https://github.com/grafana/grafana/pull/62130#discussion_r1091954384


**Who is this feature for?**
All users

<!--
[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:



- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"



Fixes #
-->
**Special notes for your reviewer**:

Original PR: https://github.com/grafana/grafana/pull/62130

Also, noticed a trailing semicolon here and @jackw provided the fix ❤️ 

![image](https://user-images.githubusercontent.com/1173299/215814095-24a07041-34e7-436a-8147-6722b9f15c16.png)
