### PR TITLE
AuthN: Expose RegisterClient and add client name for saml

### DIFF
--- a/pkg/services/authn/authn.go
+++ b/pkg/services/authn/authn.go
@@ -65,7 +65,7 @@ type Service interface {
 	RegisterPostLoginHook(hook PostLoginHookFn, priority uint)
 	// RedirectURL will generate url that we can use to initiate auth flow for supported clients.
 	RedirectURL(ctx context.Context, client string, r *Request) (*Redirect, error)
-	// RegisterClient that can be used for authentication
+	// RegisterClient will register a new authn.Client that can be used for authentication
 	RegisterClient(c Client)
 }
 

--- a/pkg/services/authn/authn.go
+++ b/pkg/services/authn/authn.go
@@ -64,6 +64,8 @@ type Service interface {
 	RegisterPostLoginHook(hook PostLoginHookFn, priority uint)
 	// RedirectURL will generate url that we can use to initiate auth flow for supported clients.
 	RedirectURL(ctx context.Context, client string, r *Request) (*Redirect, error)
+	// RegisterClient that can be used for authentication
+	RegisterClient(c Client)
 }
 
 type Client interface {

--- a/pkg/services/authn/authn.go
+++ b/pkg/services/authn/authn.go
@@ -26,6 +26,7 @@ const (
 	ClientSession   = "auth.client.session"
 	ClientForm      = "auth.client.form"
 	ClientProxy     = "auth.client.proxy"
+	ClientSAML      = "auth.client.saml"
 )
 
 const (


### PR DESCRIPTION
**What is this feature?**
We need to expose RegisterClient in service interface to allow creating and registering clients in other places.

Fixes #

**Special notes for your reviewer**:

