### PR TITLE
Chore: add await-thenable eslint rule & fix errors

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -4135,8 +4135,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "3"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "4"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "3"]
     ],
     "public/app/features/org/state/reducers.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,8 @@
 {
   "extends": ["@grafana/eslint-config"],
+  "parserOptions": {
+    "project": ["tsconfig.json", "packages/*/tsconfig.json", "e2e/tsconfig.json"]
+  },
   "root": true,
   "plugins": ["@emotion", "lodash", "jest", "import", "jsx-a11y", "@grafana"],
   "settings": {

--- a/.eslintrc
+++ b/.eslintrc
@@ -41,6 +41,7 @@
         ]
       }
     ],
+    "@typescript-eslint/await-thenable": "error",
 
     // Use typescript's no-redeclare for compatibility with overrides
     "no-redeclare": "off",

--- a/public/app/features/alerting/unified/MuteTimings.test.tsx
+++ b/public/app/features/alerting/unified/MuteTimings.test.tsx
@@ -114,7 +114,7 @@ describe('Mute timings', () => {
 
   it('creates a new mute timing', async () => {
     disableRBAC();
-    await renderMuteTimings();
+    renderMuteTimings();
 
     await waitFor(() => expect(mocks.api.fetchAlertManagerConfig).toHaveBeenCalled());
     expect(ui.nameField.get()).toBeInTheDocument();
@@ -155,9 +155,7 @@ describe('Mute timings', () => {
   });
 
   it('prepoluates the form when editing a mute timing', async () => {
-    await renderMuteTimings(
-      '/alerting/routes/mute-timing/edit' + `?muteName=${encodeURIComponent(muteTimeInterval.name)}`
-    );
+    renderMuteTimings('/alerting/routes/mute-timing/edit' + `?muteName=${encodeURIComponent(muteTimeInterval.name)}`);
 
     await waitFor(() => expect(mocks.api.fetchAlertManagerConfig).toHaveBeenCalled());
     expect(ui.nameField.get()).toBeInTheDocument();
@@ -220,7 +218,7 @@ describe('Mute timings', () => {
   });
 
   it('form is invalid with duplicate mute timing name', async () => {
-    await renderMuteTimings();
+    renderMuteTimings();
 
     await waitFor(() => expect(mocks.api.fetchAlertManagerConfig).toHaveBeenCalled());
     await waitFor(() => expect(ui.nameField.get()).toBeInTheDocument());
@@ -236,9 +234,7 @@ describe('Mute timings', () => {
   });
 
   it('replaces mute timings in routes when the mute timing name is changed', async () => {
-    await renderMuteTimings(
-      '/alerting/routes/mute-timing/edit' + `?muteName=${encodeURIComponent(muteTimeInterval.name)}`
-    );
+    renderMuteTimings('/alerting/routes/mute-timing/edit' + `?muteName=${encodeURIComponent(muteTimeInterval.name)}`);
 
     await waitFor(() => expect(mocks.api.fetchAlertManagerConfig).toHaveBeenCalled());
     expect(ui.nameField.get()).toBeInTheDocument();

--- a/public/app/features/alerting/unified/Receivers.test.tsx
+++ b/public/app/features/alerting/unified/Receivers.test.tsx
@@ -189,7 +189,7 @@ describe('Receivers', () => {
     mocks.api.fetchConfig.mockImplementation((name) =>
       Promise.resolve(name === GRAFANA_RULES_SOURCE_NAME ? someGrafanaAlertManagerConfig : someCloudAlertManagerConfig)
     );
-    await renderReceivers();
+    renderReceivers();
 
     // check that by default grafana templates & receivers are fetched rendered in appropriate tables
     await ui.receiversTable.find();
@@ -234,7 +234,7 @@ describe('Receivers', () => {
 
     mocks.api.fetchConfig.mockResolvedValue(someGrafanaAlertManagerConfig);
 
-    await renderReceivers();
+    renderReceivers();
 
     // go to new contact point page
     await userEvent.click(await ui.newContactPointButton.find());
@@ -292,7 +292,7 @@ describe('Receivers', () => {
 
     mocks.api.fetchConfig.mockResolvedValue(someGrafanaAlertManagerConfig);
     mocks.api.updateConfig.mockResolvedValue();
-    await renderReceivers();
+    renderReceivers();
 
     // go to new contact point page
     await userEvent.click(await ui.newContactPointButton.find());
@@ -372,7 +372,7 @@ describe('Receivers', () => {
 
     mocks.api.fetchConfig.mockResolvedValue(someCloudAlertManagerConfig);
     mocks.api.updateConfig.mockResolvedValue();
-    await renderReceivers('CloudManager');
+    renderReceivers('CloudManager');
 
     // click edit button for the receiver
     await ui.receiversTable.find();
@@ -404,7 +404,7 @@ describe('Receivers', () => {
     // delete a field
     await userEvent.click(byText(/Fields \(2\)/i).get(slackContainer));
     await userEvent.click(byTestId('items.1.settings.fields.0.delete-button').get());
-    await byText(/Fields \(1\)/i).get(slackContainer);
+    byText(/Fields \(1\)/i).get(slackContainer);
 
     // add another channel
     await userEvent.click(ui.newContactPointIntegrationButton.get());
@@ -470,7 +470,7 @@ describe('Receivers', () => {
       ...someCloudAlertManagerStatus,
       config: someCloudAlertManagerConfig.alertmanager_config,
     });
-    await renderReceivers(dataSources.promAlertManager.name);
+    renderReceivers(dataSources.promAlertManager.name);
 
     await ui.receiversTable.find();
     // there's no templates table for vanilla prom, API does not return templates
@@ -510,7 +510,7 @@ describe('Receivers', () => {
       alertmanager_config: {},
     });
     mocks.api.fetchStatus.mockResolvedValue(someCloudAlertManagerStatus);
-    await renderReceivers('CloudManager');
+    renderReceivers('CloudManager');
 
     // check that receiver from the default config is represented
     await ui.receiversTable.find();
@@ -530,7 +530,7 @@ describe('Receivers', () => {
     mocks.api.discoverAlertmanagerFeatures.mockResolvedValue({ lazyConfigInit: true });
     mocks.api.fetchConfig.mockRejectedValue({ message: 'alertmanager storage object not found' });
 
-    await renderReceivers('CloudManager');
+    renderReceivers('CloudManager');
 
     const templatesTable = await ui.templatesTable.find();
     const receiversTable = await ui.receiversTable.find();
@@ -588,7 +588,7 @@ describe('Receivers', () => {
       };
 
       mocks.hooks.useGetContactPointsState.mockReturnValue(receiversMock);
-      await renderReceivers();
+      renderReceivers();
 
       //
       await ui.receiversTable.find();
@@ -660,7 +660,7 @@ describe('Receivers', () => {
       };
 
       mocks.hooks.useGetContactPointsState.mockReturnValue(receiversMock);
-      await renderReceivers();
+      renderReceivers();
 
       //
       await ui.receiversTable.find();
@@ -696,7 +696,7 @@ describe('Receivers', () => {
       mocks.api.updateConfig.mockResolvedValue();
 
       mocks.hooks.useGetContactPointsState.mockReturnValue(emptyContactPointsState);
-      await renderReceivers();
+      renderReceivers();
 
       await ui.receiversTable.find();
       //should not render notification error

--- a/public/app/features/alerting/unified/RuleEditorCloudOnlyAllowed.test.tsx
+++ b/public/app/features/alerting/unified/RuleEditorCloudOnlyAllowed.test.tsx
@@ -168,12 +168,12 @@ describe('RuleEditor cloud: checking editable data sources', () => {
     await waitForElementToBeRemoved(screen.getAllByTestId('Spinner'));
 
     await ui.inputs.name.find();
-    await userEvent.click(await ui.buttons.lotexAlert.get());
+    await userEvent.click(ui.buttons.lotexAlert.get());
 
     // check that only rules sources that have ruler available are there
     const dataSourceSelect = ui.inputs.dataSource.get();
     await userEvent.click(byRole('combobox').get(dataSourceSelect));
-    expect(await byText('loki with ruler').query()).toBeInTheDocument();
+    expect(byText('loki with ruler').query()).toBeInTheDocument();
     expect(byText('cortex with ruler').query()).toBeInTheDocument();
     expect(byText('loki with local rule store').query()).not.toBeInTheDocument();
     expect(byText('prom without ruler api').query()).not.toBeInTheDocument();

--- a/public/app/features/alerting/unified/RuleEditorExisting.test.tsx
+++ b/public/app/features/alerting/unified/RuleEditorExisting.test.tsx
@@ -190,7 +190,7 @@ describe('RuleEditor grafana managed rules', () => {
     //check that '+ Add new' option is in folders drop down even if we don't have values
     const emptyFolderInput = await ui.inputs.folderContainer.find();
     mocks.searchFolders.mockResolvedValue([] as DashboardSearchHit[]);
-    await renderRuleEditor(uid);
+    renderRuleEditor(uid);
     await userEvent.click(within(emptyFolderInput).getByRole('combobox'));
     expect(screen.getByText(ADD_NEW_FOLER_OPTION)).toBeInTheDocument();
 

--- a/public/app/features/alerting/unified/RuleEditorRecordingRule.test.tsx
+++ b/public/app/features/alerting/unified/RuleEditorRecordingRule.test.tsx
@@ -109,7 +109,7 @@ describe('RuleEditor recording rules', () => {
     renderRuleEditor();
     await waitForElementToBeRemoved(screen.getAllByTestId('Spinner'));
     await userEvent.type(await ui.inputs.name.find(), 'my great new recording rule');
-    await userEvent.click(await ui.buttons.lotexRecordingRule.get());
+    await userEvent.click(ui.buttons.lotexRecordingRule.get());
 
     const dataSourceSelect = ui.inputs.dataSource.get();
     await userEvent.click(byRole('combobox').get(dataSourceSelect));

--- a/public/app/features/alerting/unified/RuleList.test.tsx
+++ b/public/app/features/alerting/unified/RuleList.test.tsx
@@ -223,7 +223,7 @@ describe('RuleList', () => {
 
     mocks.api.fetchRulerRules.mockRejectedValue({ status: 500, data: { message: 'Server error' } });
 
-    await renderRuleList();
+    renderRuleList();
 
     await waitFor(() => expect(mocks.api.fetchRules).toHaveBeenCalledTimes(4));
     const groups = await ui.ruleGroup.findAll();
@@ -322,7 +322,7 @@ describe('RuleList', () => {
       }
     });
 
-    await renderRuleList();
+    renderRuleList();
 
     const groups = await ui.ruleGroup.findAll();
     expect(groups).toHaveLength(2);
@@ -492,7 +492,7 @@ describe('RuleList', () => {
       }
     });
 
-    await renderRuleList();
+    renderRuleList();
     const groups = await ui.ruleGroup.findAll();
     expect(groups).toHaveLength(2);
 
@@ -557,7 +557,7 @@ describe('RuleList', () => {
         mocks.api.setRulerRuleGroup.mockResolvedValue();
         mocks.api.deleteNamespace.mockResolvedValue();
 
-        await renderRuleList();
+        renderRuleList();
 
         expect(await ui.rulesFilterInput.find()).toHaveValue('');
 
@@ -566,12 +566,8 @@ describe('RuleList', () => {
 
         // open edit dialog
         await userEvent.click(ui.editCloudGroupIcon.get(groups[0]));
-        await expect(screen.getByRole('textbox', { hidden: true, name: /namespace/i })).toHaveDisplayValue(
-          'namespace1'
-        );
-        await expect(screen.getByRole('textbox', { name: 'Evaluation group', exact: true })).toHaveDisplayValue(
-          'group1'
-        );
+        expect(screen.getByRole('textbox', { hidden: true, name: /namespace/i })).toHaveDisplayValue('namespace1');
+        expect(screen.getByRole('textbox', { name: 'Evaluation group', exact: true })).toHaveDisplayValue('group1');
         await fn();
       });
     }

--- a/public/app/features/alerting/unified/components/admin/AlertmanagerConfig.test.tsx
+++ b/public/app/features/alerting/unified/components/admin/AlertmanagerConfig.test.tsx
@@ -107,7 +107,7 @@ describe('Admin config', () => {
     });
     mocks.api.deleteAlertManagerConfig.mockResolvedValue();
 
-    await renderAdminPage(dataSources.alertManager.name);
+    renderAdminPage(dataSources.alertManager.name);
 
     await userEvent.click(await ui.resetButton.find());
     await userEvent.click(ui.confirmButton.get());
@@ -134,7 +134,7 @@ describe('Admin config', () => {
 
     mocks.api.fetchConfig.mockImplementation(() => Promise.resolve(savedConfig ?? defaultConfig));
     mocks.api.updateAlertManagerConfig.mockResolvedValue();
-    await renderAdminPage(dataSources.alertManager.name);
+    renderAdminPage(dataSources.alertManager.name);
     const input = await ui.configInput.find();
     expect(input.value).toEqual(JSON.stringify(defaultConfig, null, 2));
     await userEvent.clear(input);
@@ -153,7 +153,7 @@ describe('Admin config', () => {
       ...someCloudAlertManagerStatus,
       config: someCloudAlertManagerConfig.alertmanager_config,
     });
-    await renderAdminPage(dataSources.promAlertManager.name);
+    renderAdminPage(dataSources.promAlertManager.name);
 
     await ui.readOnlyConfig.find();
     expect(ui.configInput.query()).not.toBeInTheDocument();

--- a/public/app/features/alerting/unified/components/receivers/ReceiversTable.test.tsx
+++ b/public/app/features/alerting/unified/components/receivers/ReceiversTable.test.tsx
@@ -28,7 +28,7 @@ const renderReceieversTable = async (receivers: Receiver[], notifiers: NotifierD
   };
 
   const store = configureStore();
-  await store.dispatch(fetchGrafanaNotifiersAction.fulfilled(notifiers, 'initial'));
+  store.dispatch(fetchGrafanaNotifiersAction.fulfilled(notifiers, 'initial'));
 
   return render(
     <Provider store={store}>

--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -225,7 +225,11 @@ export const fetchRulerRulesAction = createAsyncThunk(
   }
 );
 
-export function fetchPromAndRulerRulesAction({ rulesSourceName }: { rulesSourceName: string }): ThunkResult<void> {
+export function fetchPromAndRulerRulesAction({
+  rulesSourceName,
+}: {
+  rulesSourceName: string;
+}): ThunkResult<Promise<void>> {
   return async (dispatch, getState) => {
     await dispatch(fetchRulesSourceBuildInfoAction({ rulesSourceName }));
     const dsConfig = getDataSourceConfig(getState, rulesSourceName);

--- a/public/app/features/alerting/unified/utils/rule-form.ts
+++ b/public/app/features/alerting/unified/utils/rule-form.ts
@@ -324,7 +324,7 @@ const dataQueriesToGrafanaQueries = async (
     };
 
     const interpolatedTarget = datasource.interpolateVariablesInQueries
-      ? await datasource.interpolateVariablesInQueries([target], queryVariables)[0]
+      ? datasource.interpolateVariablesInQueries([target], queryVariables)[0]
       : target;
 
     // expressions

--- a/public/app/features/api-keys/state/actions.ts
+++ b/public/app/features/api-keys/state/actions.ts
@@ -20,7 +20,7 @@ export function addApiKey(apiKey: ApiKey, openModal: (key: string) => void): Thu
   };
 }
 
-export function loadApiKeys(): ThunkResult<void> {
+export function loadApiKeys(): ThunkResult<Promise<void>> {
   return async (dispatch) => {
     dispatch(isFetching());
     const [keys, keysIncludingExpired] = await Promise.all([
@@ -68,7 +68,7 @@ export function getApiKeysMigrationStatus(): ThunkResult<void> {
   };
 }
 
-export function hideApiKeys(): ThunkResult<void> {
+export function hideApiKeys(): ThunkResult<Promise<void>> {
   return async (dispatch) => {
     await getBackendSrv().post('/api/serviceaccounts/hideApiKeys');
   };

--- a/public/app/features/dashboard/components/PanelEditor/state/actions.ts
+++ b/public/app/features/dashboard/components/PanelEditor/state/actions.ts
@@ -128,7 +128,7 @@ export function exitPanelEditor(): ThunkResult<void> {
         sourcePanel.plugin = panel.plugin;
         sourcePanel.generateNewKey();
 
-        await dispatch(panelModelAndPluginReady({ key: sourcePanel.key, plugin: panel.plugin! }));
+        dispatch(panelModelAndPluginReady({ key: sourcePanel.key, plugin: panel.plugin! }));
       }
 
       // Resend last query result on source panel query runner

--- a/public/app/features/dashboard/services/PublicDashboardDataSource.test.ts
+++ b/public/app/features/dashboard/services/PublicDashboardDataSource.test.ts
@@ -53,7 +53,7 @@ describe('PublicDashboardDatasource', () => {
     const panelId = 1;
     const publicDashboardAccessToken = undefined;
 
-    await ds.query({
+    ds.query({
       maxDataPoints: 10,
       intervalMs: 5000,
       targets: [
@@ -81,7 +81,7 @@ describe('PublicDashboardDatasource', () => {
     const panelId = 1;
     const publicDashboardAccessToken = 'abc123';
 
-    await ds.query({
+    ds.query({
       maxDataPoints: 10,
       intervalMs: 5000,
       targets: [

--- a/public/app/features/dashboard/state/actions.ts
+++ b/public/app/features/dashboard/state/actions.ts
@@ -13,7 +13,7 @@ import { getTimeSrv } from '../services/TimeSrv';
 
 import { cleanUpDashboard, loadDashboardPermissions } from './reducers';
 
-export function getDashboardPermissions(id: number): ThunkResult<void> {
+export function getDashboardPermissions(id: number): ThunkResult<Promise<void>> {
   return async (dispatch) => {
     const permissions = await getBackendSrv().get(`/api/dashboards/id/${id}/permissions`);
     dispatch(loadDashboardPermissions(permissions));

--- a/public/app/features/dashboard/state/initDashboard.test.ts
+++ b/public/app/features/dashboard/state/initDashboard.test.ts
@@ -236,8 +236,8 @@ function describeInitScenario(description: string, scenarioFn: ScenarioFn) {
       setEchoSrv(new Echo());
 
       const store = mockStore(ctx.storeState);
-      // @ts-ignore
-      await store.dispatch(initDashboard(ctx.args));
+      // @ts-expect-error
+      store.dispatch(initDashboard(ctx.args));
 
       ctx.actions = store.getActions();
     });

--- a/public/app/features/dashboard/state/initDashboard.ts
+++ b/public/app/features/dashboard/state/initDashboard.ts
@@ -149,7 +149,7 @@ const getQueriesByDatasource = (
  * Then it handles the initializing of the old angular services that the dashboard components & panels still depend on
  *
  */
-export function initDashboard(args: InitDashboardArgs): ThunkResult<void> {
+export function initDashboard(args: InitDashboardArgs): ThunkResult<Promise<void>> {
   return async (dispatch, getState) => {
     // set fetching state
     dispatch(dashboardInitFetching());

--- a/public/app/features/datasources/pages/DataSourcesListPage.test.tsx
+++ b/public/app/features/datasources/pages/DataSourcesListPage.test.tsx
@@ -80,7 +80,7 @@ describe('Render', () => {
       setup({ isSortAscending: true });
 
       expect(await screen.findByRole('heading', { name: 'dataSource-0' })).toBeInTheDocument();
-      expect(await screen.queryByRole('link', { name: 'dataSource-0' })).toBeNull();
+      expect(screen.queryByRole('link', { name: 'dataSource-0' })).toBeNull();
     });
   });
 

--- a/public/app/features/datasources/state/actions.ts
+++ b/public/app/features/datasources/state/actions.ts
@@ -144,7 +144,7 @@ export const testDataSource = (
   };
 };
 
-export function loadDataSources(): ThunkResult<void> {
+export function loadDataSources(): ThunkResult<Promise<void>> {
   return async (dispatch) => {
     const response = await api.getDataSources();
     dispatch(dataSourcesLoaded(response));
@@ -176,7 +176,7 @@ export function loadDataSource(uid: string): ThunkResult<Promise<DataSourceSetti
   };
 }
 
-export function loadDataSourceMeta(dataSource: DataSourceSettings): ThunkResult<void> {
+export function loadDataSourceMeta(dataSource: DataSourceSettings): ThunkResult<Promise<void>> {
   return async (dispatch) => {
     const pluginInfo = (await getPluginSettings(dataSource.type)) as DataSourcePluginMeta;
     const plugin = await importDataSourcePlugin(pluginInfo);

--- a/public/app/features/explore/ExplorePage.test.tsx
+++ b/public/app/features/explore/ExplorePage.test.tsx
@@ -275,7 +275,7 @@ describe('ExplorePage', () => {
       fireEvent.click(splitButton);
       await waitForExplore(undefined, true);
       let widenButton = await screen.findAllByLabelText('Widen pane');
-      let narrowButton = await screen.queryAllByLabelText('Narrow pane');
+      let narrowButton = screen.queryAllByLabelText('Narrow pane');
       const panes = screen.getAllByRole('main');
       expect(widenButton.length).toBe(2);
       expect(narrowButton.length).toBe(0);
@@ -286,7 +286,7 @@ describe('ExplorePage', () => {
       fireEvent.mouseMove(resizer, { clientX: -700, buttons: 1 });
       fireEvent.mouseUp(resizer);
       widenButton = await screen.findAllByLabelText('Widen pane');
-      narrowButton = await screen.queryAllByLabelText('Narrow pane');
+      narrowButton = screen.queryAllByLabelText('Narrow pane');
       expect(widenButton.length).toBe(1);
       expect(narrowButton.length).toBe(1);
       // the autosizer is mocked so there is no actual resize here

--- a/public/app/features/explore/ExplorePaneContainer.tsx
+++ b/public/app/features/explore/ExplorePaneContainer.tsx
@@ -111,7 +111,7 @@ class ExplorePaneContainerUnconnected extends React.PureComponent<Props> {
               const datasource = await getDatasourceSrv().get(changeDatasourceUid);
               const datasourceInit = await getDatasourceSrv().get(initialDatasource);
               await this.props.importQueries(exploreId, queries, datasourceInit, datasource);
-              await this.props.stateSave({ replace: true });
+              this.props.stateSave({ replace: true });
               queries = this.props.initialQueries;
             }
           }

--- a/public/app/features/explore/state/datasource.ts
+++ b/public/app/features/explore/state/datasource.ts
@@ -41,7 +41,7 @@ export function changeDatasource(
   exploreId: ExploreId,
   datasourceUid: string,
   options?: { importQueries: boolean }
-): ThunkResult<void> {
+): ThunkResult<Promise<void>> {
   return async (dispatch, getState) => {
     const orgId = getState().user.orgId;
     const { history, instance } = await loadAndInitDatasource(orgId, { uid: datasourceUid });

--- a/public/app/features/explore/state/explorePane.ts
+++ b/public/app/features/explore/state/explorePane.ts
@@ -134,7 +134,7 @@ export function initializeExplore(
   eventBridge: EventBusExtended,
   panelsState?: ExplorePanelsState,
   isFromCompactUrl?: boolean
-): ThunkResult<void> {
+): ThunkResult<Promise<void>> {
   return async (dispatch, getState) => {
     const exploreDatasources = getDataSourceSrv().getList();
     let instance = undefined;
@@ -177,7 +177,7 @@ export function initializeExplore(
  * Reacts to changes in URL state that we need to sync back to our redux state. Computes diff of newUrlQuery vs current
  * state and runs update actions for relevant parts.
  */
-export function refreshExplore(exploreId: ExploreId, newUrlQuery: string): ThunkResult<void> {
+export function refreshExplore(exploreId: ExploreId, newUrlQuery: string): ThunkResult<Promise<void>> {
   return async (dispatch, getState) => {
     const itemState = getState().explore[exploreId];
     if (!itemState?.initialized) {

--- a/public/app/features/explore/state/history.ts
+++ b/public/app/features/explore/state/history.ts
@@ -196,7 +196,7 @@ export const initRichHistory = (): ThunkResult<void> => {
   };
 };
 
-export const updateHistorySettings = (settings: RichHistorySettings): ThunkResult<void> => {
+export const updateHistorySettings = (settings: RichHistorySettings): ThunkResult<Promise<void>> => {
   return async (dispatch) => {
     dispatch(richHistorySettingsUpdatedAction(settings));
     await updateRichHistorySettings(settings);
@@ -211,7 +211,7 @@ export const updateHistorySearchFilters = (
   filters: RichHistorySearchFilters
 ): ThunkResult<void> => {
   return async (dispatch, getState) => {
-    await dispatch(richHistorySearchFiltersUpdatedAction({ exploreId, filters: { ...filters } }));
+    dispatch(richHistorySearchFiltersUpdatedAction({ exploreId, filters: { ...filters } }));
     const currentSettings = getState().explore.richHistorySettings!;
     if (supportedFeatures().lastUsedDataSourcesAvailable) {
       await dispatch(

--- a/public/app/features/explore/state/query.test.ts
+++ b/public/app/features/explore/state/query.test.ts
@@ -142,8 +142,8 @@ describe('runQueries', () => {
   it('should pass dataFrames to state even if there is error in response', async () => {
     const { dispatch, getState } = setupTests();
     setupQueryResponse(getState());
-    await dispatch(saveCorrelationsAction([]));
-    await dispatch(runQueries(ExploreId.left));
+    dispatch(saveCorrelationsAction([]));
+    dispatch(runQueries(ExploreId.left));
     expect(getState().explore[ExploreId.left].showMetrics).toBeTruthy();
     expect(getState().explore[ExploreId.left].graphResult).toBeDefined();
   });
@@ -171,8 +171,8 @@ describe('runQueries', () => {
     const { dispatch, getState } = setupTests();
     const leftDatasourceInstance = assertIsDefined(getState().explore[ExploreId.left].datasourceInstance);
     jest.mocked(leftDatasourceInstance.query).mockReturnValueOnce(EMPTY);
-    await dispatch(saveCorrelationsAction([]));
-    await dispatch(runQueries(ExploreId.left));
+    dispatch(saveCorrelationsAction([]));
+    dispatch(runQueries(ExploreId.left));
     await new Promise((resolve) => setTimeout(() => resolve(''), 500));
     expect(getState().explore[ExploreId.left].queryResponse.state).toBe(LoadingState.Done);
   });
@@ -180,9 +180,9 @@ describe('runQueries', () => {
   it('shows results only after correlations are loaded', async () => {
     const { dispatch, getState } = setupTests();
     setupQueryResponse(getState());
-    await dispatch(runQueries(ExploreId.left));
+    dispatch(runQueries(ExploreId.left));
     expect(getState().explore[ExploreId.left].graphResult).not.toBeDefined();
-    await dispatch(saveCorrelationsAction([]));
+    dispatch(saveCorrelationsAction([]));
     expect(getState().explore[ExploreId.left].graphResult).toBeDefined();
   });
 });
@@ -504,7 +504,7 @@ describe('reducer', () => {
         },
       } as unknown as Partial<StoreState>);
 
-      await dispatch(addResultsToCache(ExploreId.left));
+      dispatch(addResultsToCache(ExploreId.left));
 
       expect(getState().explore[ExploreId.left].cache).toEqual([
         { key: 'from=1621348027000&to=1621348050000', value: { series: [{ name: 'test name' }], state: 'Done' } },
@@ -523,7 +523,7 @@ describe('reducer', () => {
         },
       } as unknown as Partial<StoreState>);
 
-      await dispatch(addResultsToCache(ExploreId.left));
+      dispatch(addResultsToCache(ExploreId.left));
 
       expect(getState().explore[ExploreId.left].cache).toEqual([]);
     });
@@ -549,7 +549,7 @@ describe('reducer', () => {
         },
       } as unknown as Partial<StoreState>);
 
-      await dispatch(addResultsToCache(ExploreId.left));
+      dispatch(addResultsToCache(ExploreId.left));
 
       expect(getState().explore[ExploreId.left].cache).toHaveLength(1);
       expect(getState().explore[ExploreId.left].cache).toEqual([
@@ -573,7 +573,7 @@ describe('reducer', () => {
         },
       } as unknown as Partial<StoreState>);
 
-      await dispatch(clearCache(ExploreId.left));
+      dispatch(clearCache(ExploreId.left));
 
       expect(getState().explore[ExploreId.left].cache).toEqual([]);
     });

--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -223,7 +223,7 @@ export const clearCacheAction = createAction<ClearCachePayload>('explore/clearCa
 /**
  * Adds a query row after the row with the given index.
  */
-export function addQueryRow(exploreId: ExploreId, index: number): ThunkResult<void> {
+export function addQueryRow(exploreId: ExploreId, index: number): ThunkResult<Promise<void>> {
   return async (dispatch, getState) => {
     const queries = getState().explore[exploreId]!.queries;
     let datasourceOverride = undefined;
@@ -305,7 +305,7 @@ export const importQueries = (
   sourceDataSource: DataSourceApi | undefined | null,
   targetDataSource: DataSourceApi,
   singleQueryChangeRef?: string // when changing one query DS to another in a mixed environment, we do not want to change all queries, just the one being changed
-): ThunkResult<void> => {
+): ThunkResult<Promise<void>> => {
   return async (dispatch) => {
     if (!sourceDataSource) {
       // explore not initialized
@@ -411,8 +411,8 @@ async function handleHistory(
   // Because filtering happens in the backend we cannot add a new entry without checking if it matches currently
   // used filters. Instead, we refresh the query history list.
   // TODO: run only if Query History list is opened (#47252)
-  await dispatch(loadRichHistory(ExploreId.left));
-  await dispatch(loadRichHistory(ExploreId.right));
+  dispatch(loadRichHistory(ExploreId.left));
+  dispatch(loadRichHistory(ExploreId.right));
 }
 
 /**

--- a/public/app/features/explore/state/time.test.ts
+++ b/public/app/features/explore/state/time.test.ts
@@ -37,7 +37,7 @@ describe('Explore item reducer', () => {
       const { dispatch } = configureStore({
         ...(createDefaultInitialState() as any),
       });
-      await dispatch(updateTime({ exploreId: ExploreId.left }));
+      dispatch(updateTime({ exploreId: ExploreId.left }));
       expect(mockTimeSrv.init).toBeCalled();
       expect(mockTemplateSrv.updateTimeRange).toBeCalledWith(MOCK_TIME_RANGE);
     });

--- a/public/app/features/folders/state/actions.ts
+++ b/public/app/features/folders/state/actions.ts
@@ -12,7 +12,7 @@ import { DashboardAcl, DashboardAclUpdateDTO, NewDashboardAclItem, PermissionLev
 import { buildNavModel } from './navModel';
 import { loadFolder, loadFolderPermissions, setCanViewFolderPermissions } from './reducers';
 
-export function getFolderByUid(uid: string): ThunkResult<void> {
+export function getFolderByUid(uid: string): ThunkResult<Promise<void>> {
   return async (dispatch) => {
     const folder = await backendSrv.getFolderByUid(uid);
     dispatch(loadFolder(folder));
@@ -20,7 +20,7 @@ export function getFolderByUid(uid: string): ThunkResult<void> {
   };
 }
 
-export function saveFolder(folder: FolderState): ThunkResult<void> {
+export function saveFolder(folder: FolderState): ThunkResult<Promise<void>> {
   return async (dispatch) => {
     const res = await backendSrv.put(`/api/folders/${folder.uid}`, {
       title: folder.title,
@@ -40,7 +40,7 @@ export function deleteFolder(uid: string): ThunkResult<void> {
   };
 }
 
-export function getFolderPermissions(uid: string): ThunkResult<void> {
+export function getFolderPermissions(uid: string): ThunkResult<Promise<void>> {
   return async (dispatch) => {
     const permissions = await backendSrv.get(`/api/folders/${uid}/permissions`);
     dispatch(loadFolderPermissions(permissions));

--- a/public/app/features/manage-dashboards/state/actions.test.ts
+++ b/public/app/features/manage-dashboards/state/actions.test.ts
@@ -81,28 +81,28 @@ describe('importDashboard', () => {
 describe('validateDashboardJson', () => {
   it('Should return true if correct json', async () => {
     const jsonImportCorrectFormat = '{"title": "Correct Format", "tags": ["tag1", "tag2"], "schemaVersion": 36}';
-    const validateDashboardJsonCorrectFormat = await validateDashboardJson(jsonImportCorrectFormat);
+    const validateDashboardJsonCorrectFormat = validateDashboardJson(jsonImportCorrectFormat);
     expect(validateDashboardJsonCorrectFormat).toBe(true);
   });
   it('Should not return true if nested tags', async () => {
     const jsonImportNestedTags =
       '{"title": "Nested tags","tags": ["tag1", "tag2", ["nestedTag1", "nestedTag2"]],"schemaVersion": 36}';
-    const validateDashboardJsonNestedTags = await validateDashboardJson(jsonImportNestedTags);
+    const validateDashboardJsonNestedTags = validateDashboardJson(jsonImportNestedTags);
     expect(validateDashboardJsonNestedTags).toBe('tags expected array of strings');
   });
   it('Should not return true if not an array', async () => {
     const jsonImportNotArray = '{"title": "Not Array","tags": "tag1","schemaVersion":36}';
-    const validateDashboardJsonNotArray = await validateDashboardJson(jsonImportNotArray);
+    const validateDashboardJsonNotArray = validateDashboardJson(jsonImportNotArray);
     expect(validateDashboardJsonNotArray).toBe('tags expected array');
   });
   it('Should not return true if not an array and is blank string', async () => {
     const jsonImportEmptyTags = '{"schemaVersion": 36,"tags": "", "title": "Empty Tags"}';
-    const validateDashboardJsonEmptyTags = await validateDashboardJson(jsonImportEmptyTags);
+    const validateDashboardJsonEmptyTags = validateDashboardJson(jsonImportEmptyTags);
     expect(validateDashboardJsonEmptyTags).toBe('tags expected array');
   });
   it('Should not return true if not valid JSON', async () => {
     const jsonImportInvalidJson = '{"schemaVersion": 36,"tags": {"tag", "nested tag"}, "title": "Nested lists"}';
-    const validateDashboardJsonNotValid = await validateDashboardJson(jsonImportInvalidJson);
+    const validateDashboardJsonNotValid = validateDashboardJson(jsonImportInvalidJson);
     expect(validateDashboardJsonNotValid).toBe('Not valid JSON');
   });
 });

--- a/public/app/features/org/OrgDetailsPage.tsx
+++ b/public/app/features/org/OrgDetailsPage.tsx
@@ -1,26 +1,32 @@
 import React, { PureComponent } from 'react';
-import { connect } from 'react-redux';
+import { connect, ConnectedProps } from 'react-redux';
 
-import { NavModel } from '@grafana/data';
 import { VerticalGroup } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 import SharedPreferences from 'app/core/components/SharedPreferences/SharedPreferences';
 import { appEvents, contextSrv } from 'app/core/core';
 import { getNavModel } from 'app/core/selectors/navModel';
-import { AccessControlAction, Organization, StoreState } from 'app/types';
+import { AccessControlAction, StoreState } from 'app/types';
 import { ShowConfirmModalEvent } from 'app/types/events';
 
 import OrgProfile from './OrgProfile';
 import { loadOrganization, updateOrganization } from './state/actions';
 import { setOrganizationName } from './state/reducers';
 
-export interface Props {
-  navModel: NavModel;
-  organization: Organization;
-  loadOrganization: typeof loadOrganization;
-  setOrganizationName: typeof setOrganizationName;
-  updateOrganization: typeof updateOrganization;
+function mapStateToProps(state: StoreState) {
+  return {
+    navModel: getNavModel(state.navIndex, 'org-settings'),
+    organization: state.organization.organization,
+  };
 }
+
+const mapDispatchToProps = {
+  loadOrganization,
+  setOrganizationName,
+  updateOrganization,
+};
+
+export type Props = ConnectedProps<typeof connector>;
 
 export class OrgDetailsPage extends PureComponent<Props> {
   async componentDidMount() {
@@ -76,17 +82,6 @@ export class OrgDetailsPage extends PureComponent<Props> {
   }
 }
 
-function mapStateToProps(state: StoreState) {
-  return {
-    navModel: getNavModel(state.navIndex, 'org-settings'),
-    organization: state.organization.organization,
-  };
-}
+const connector = connect(mapStateToProps, mapDispatchToProps);
 
-const mapDispatchToProps = {
-  loadOrganization,
-  setOrganizationName,
-  updateOrganization,
-};
-
-export default connect(mapStateToProps, mapDispatchToProps)(OrgDetailsPage);
+export default connector(OrgDetailsPage);

--- a/public/app/features/org/state/actions.ts
+++ b/public/app/features/org/state/actions.ts
@@ -8,7 +8,7 @@ type OrganizationDependencies = { getBackendSrv: typeof getBackendSrv };
 
 export function loadOrganization(
   dependencies: OrganizationDependencies = { getBackendSrv: getBackendSrv }
-): ThunkResult<any> {
+): ThunkResult<Promise<void>> {
   return async (dispatch) => {
     const organizationResponse = await dependencies.getBackendSrv().get('/api/org');
     dispatch(organizationLoaded(organizationResponse));

--- a/public/app/features/panel/state/actions.ts
+++ b/public/app/features/panel/state/actions.ts
@@ -121,7 +121,7 @@ export function changeToLibraryPanel(panel: PanelModel, libraryPanel: LibraryEle
       panel.pluginLoaded(plugin);
       panel.generateNewKey();
 
-      await dispatch(panelModelAndPluginReady({ key: panel.key, plugin }));
+      dispatch(panelModelAndPluginReady({ key: panel.key, plugin }));
     } else {
       // Even if the plugin is the same, we want to change the key
       // to force a rerender

--- a/public/app/features/plugins/admin/pages/PluginDetails.test.tsx
+++ b/public/app/features/plugins/admin/pages/PluginDetails.test.tsx
@@ -134,7 +134,7 @@ describe('Plugin details page', () => {
     it('should display an overview (plugin readme) by default', async () => {
       const { queryByText } = renderPluginDetails({ id });
 
-      expect(await queryByText(/licensed under the apache 2.0 license/i)).toBeInTheDocument();
+      expect(queryByText(/licensed under the apache 2.0 license/i)).toBeInTheDocument();
     });
 
     it('should display an app config page by default for installed app plugins', async () => {
@@ -168,7 +168,7 @@ describe('Plugin details page', () => {
         type: PluginType.app,
       });
 
-      expect(await queryByText(/custom config page/i)).toBeInTheDocument();
+      expect(queryByText(/custom config page/i)).toBeInTheDocument();
     });
 
     it('should display the number of downloads in the header', async () => {
@@ -179,14 +179,14 @@ describe('Plugin details page', () => {
       const expected = new Intl.NumberFormat().format(downloads);
 
       const { queryByText } = renderPluginDetails({ id, downloads });
-      expect(await queryByText(expected, options)).toBeInTheDocument();
+      expect(queryByText(expected, options)).toBeInTheDocument();
     });
 
     it('should display the installed version if a plugin is installed', async () => {
       const installedVersion = '1.3.443';
       const { queryByText } = renderPluginDetails({ id, installedVersion });
 
-      expect(await queryByText(`${installedVersion}`)).toBeInTheDocument();
+      expect(queryByText(`${installedVersion}`)).toBeInTheDocument();
     });
 
     it('should display the latest compatible version in the header if a plugin is not installed', async () => {
@@ -210,31 +210,31 @@ describe('Plugin details page', () => {
       const description = 'This is my description';
       const { queryByText } = renderPluginDetails({ id, description });
 
-      expect(await queryByText(description)).toBeInTheDocument();
+      expect(queryByText(description)).toBeInTheDocument();
     });
 
     it('should display a "Signed" badge if the plugin signature is verified', async () => {
       const { queryByText } = renderPluginDetails({ id, signature: PluginSignatureStatus.valid });
 
-      expect(await queryByText('Signed')).toBeInTheDocument();
+      expect(queryByText('Signed')).toBeInTheDocument();
     });
 
     it('should display a "Missing signature" badge if the plugin signature is missing', async () => {
       const { queryByText } = renderPluginDetails({ id, signature: PluginSignatureStatus.missing });
 
-      expect(await queryByText('Missing signature')).toBeInTheDocument();
+      expect(queryByText('Missing signature')).toBeInTheDocument();
     });
 
     it('should display a "Modified signature" badge if the plugin signature is modified', async () => {
       const { queryByText } = renderPluginDetails({ id, signature: PluginSignatureStatus.modified });
 
-      expect(await queryByText('Modified signature')).toBeInTheDocument();
+      expect(queryByText('Modified signature')).toBeInTheDocument();
     });
 
     it('should display a "Invalid signature" badge if the plugin signature is invalid', async () => {
       const { queryByText } = renderPluginDetails({ id, signature: PluginSignatureStatus.invalid });
 
-      expect(await queryByText('Invalid signature')).toBeInTheDocument();
+      expect(queryByText('Invalid signature')).toBeInTheDocument();
     });
 
     it('should display version history if the plugin is published', async () => {
@@ -292,7 +292,7 @@ describe('Plugin details page', () => {
     it("should display an install button for a plugin that isn't installed", async () => {
       const { queryByRole } = renderPluginDetails({ id, isInstalled: false });
 
-      expect(await queryByRole('button', { name: /^install/i })).toBeInTheDocument();
+      expect(queryByRole('button', { name: /^install/i })).toBeInTheDocument();
       // Does not display "uninstall" button
       expect(queryByRole('button', { name: /uninstall/i })).not.toBeInTheDocument();
     });
@@ -300,7 +300,7 @@ describe('Plugin details page', () => {
     it('should display an uninstall button for an already installed plugin', async () => {
       const { queryByRole } = renderPluginDetails({ id, isInstalled: true });
 
-      expect(await queryByRole('button', { name: /uninstall/i })).toBeInTheDocument();
+      expect(queryByRole('button', { name: /uninstall/i })).toBeInTheDocument();
       // Does not display "install" button
       expect(queryByRole('button', { name: /^install/i })).not.toBeInTheDocument();
     });
@@ -309,7 +309,7 @@ describe('Plugin details page', () => {
       const { queryByRole } = renderPluginDetails({ id, isInstalled: true, hasUpdate: true });
 
       // Displays an "update" button
-      expect(await queryByRole('button', { name: /update/i })).toBeInTheDocument();
+      expect(queryByRole('button', { name: /update/i })).toBeInTheDocument();
       expect(queryByRole('button', { name: /uninstall/i })).toBeInTheDocument();
 
       // Does not display "install" button
@@ -321,7 +321,7 @@ describe('Plugin details page', () => {
 
       const { queryByRole } = renderPluginDetails({ id, isInstalled: false, isEnterprise: true });
 
-      expect(await queryByRole('button', { name: /install/i })).toBeInTheDocument();
+      expect(queryByRole('button', { name: /install/i })).toBeInTheDocument();
     });
 
     it('should not display install button for enterprise plugins if license is invalid', async () => {
@@ -329,7 +329,7 @@ describe('Plugin details page', () => {
 
       const { queryByRole, queryByText } = renderPluginDetails({ id, isInstalled: true, isEnterprise: true });
 
-      expect(await queryByRole('button', { name: /install/i })).not.toBeInTheDocument();
+      expect(queryByRole('button', { name: /install/i })).not.toBeInTheDocument();
       expect(queryByText(/no valid Grafana Enterprise license detected/i)).toBeInTheDocument();
       expect(queryByRole('link', { name: /learn more/i })).toBeInTheDocument();
     });
@@ -337,22 +337,22 @@ describe('Plugin details page', () => {
     it('should not display install / uninstall buttons for core plugins', async () => {
       const { queryByRole } = renderPluginDetails({ id, isInstalled: true, isCore: true });
 
-      expect(await queryByRole('button', { name: /update/i })).not.toBeInTheDocument();
-      expect(await queryByRole('button', { name: /(un)?install/i })).not.toBeInTheDocument();
+      expect(queryByRole('button', { name: /update/i })).not.toBeInTheDocument();
+      expect(queryByRole('button', { name: /(un)?install/i })).not.toBeInTheDocument();
     });
 
     it('should not display install / uninstall buttons for disabled plugins', async () => {
       const { queryByRole } = renderPluginDetails({ id, isInstalled: true, isDisabled: true });
 
-      expect(await queryByRole('button', { name: /update/i })).not.toBeInTheDocument();
-      expect(await queryByRole('button', { name: /(un)?install/i })).not.toBeInTheDocument();
+      expect(queryByRole('button', { name: /update/i })).not.toBeInTheDocument();
+      expect(queryByRole('button', { name: /(un)?install/i })).not.toBeInTheDocument();
     });
 
     it('should not display install / uninstall buttons for renderer plugins', async () => {
       const { queryByRole } = renderPluginDetails({ id, type: PluginType.renderer });
 
-      expect(await queryByRole('button', { name: /update/i })).not.toBeInTheDocument();
-      expect(await queryByRole('button', { name: /(un)?install/i })).not.toBeInTheDocument();
+      expect(queryByRole('button', { name: /update/i })).not.toBeInTheDocument();
+      expect(queryByRole('button', { name: /(un)?install/i })).not.toBeInTheDocument();
     });
 
     it('should display install link with `config.pluginAdminExternalManageEnabled` set to true', async () => {
@@ -360,7 +360,7 @@ describe('Plugin details page', () => {
 
       const { queryByRole } = renderPluginDetails({ id, isInstalled: false });
 
-      expect(await queryByRole('link', { name: /install via grafana.com/i })).toBeInTheDocument();
+      expect(queryByRole('link', { name: /install via grafana.com/i })).toBeInTheDocument();
     });
 
     it('should display uninstall link for an installed plugin with `config.pluginAdminExternalManageEnabled` set to true', async () => {
@@ -368,7 +368,7 @@ describe('Plugin details page', () => {
 
       const { queryByRole } = renderPluginDetails({ id, isInstalled: true });
 
-      expect(await queryByRole('link', { name: /uninstall via grafana.com/i })).toBeInTheDocument();
+      expect(queryByRole('link', { name: /uninstall via grafana.com/i })).toBeInTheDocument();
     });
 
     it('should display update and uninstall links for a plugin with an available update and `config.pluginAdminExternalManageEnabled` set to true', async () => {
@@ -376,7 +376,7 @@ describe('Plugin details page', () => {
 
       const { queryByRole } = renderPluginDetails({ id, isInstalled: true, hasUpdate: true });
 
-      expect(await queryByRole('link', { name: /update via grafana.com/i })).toBeInTheDocument();
+      expect(queryByRole('link', { name: /update via grafana.com/i })).toBeInTheDocument();
       expect(queryByRole('link', { name: /uninstall via grafana.com/i })).toBeInTheDocument();
     });
 
@@ -388,7 +388,7 @@ describe('Plugin details page', () => {
         error: PluginErrorCode.modifiedSignature,
       });
 
-      expect(await queryByLabelText(selectors.pages.PluginPage.disabledInfo)).toBeInTheDocument();
+      expect(queryByLabelText(selectors.pages.PluginPage.disabledInfo)).toBeInTheDocument();
     });
 
     it('should display grafana dependencies for a plugin if they are available', async () => {
@@ -402,7 +402,7 @@ describe('Plugin details page', () => {
       });
 
       // Wait for the dependencies part to be loaded
-      expect(await queryByText('Grafana >=8.0.0')).toBeInTheDocument();
+      expect(queryByText('Grafana >=8.0.0')).toBeInTheDocument();
     });
 
     it('should show a confirm modal when trying to uninstall a plugin', async () => {
@@ -465,17 +465,17 @@ describe('Plugin details page', () => {
 
       // Does not show an Install button
       rendered = renderPluginDetails({ id }, { pluginsStateOverride });
-      expect(await rendered.queryByRole('button', { name: /(un)?install/i })).not.toBeInTheDocument();
+      expect(rendered.queryByRole('button', { name: /(un)?install/i })).not.toBeInTheDocument();
       rendered.unmount();
 
       // Does not show a Uninstall button
       rendered = renderPluginDetails({ id, isInstalled: true }, { pluginsStateOverride });
-      expect(await rendered.queryByRole('button', { name: /(un)?install/i })).not.toBeInTheDocument();
+      expect(rendered.queryByRole('button', { name: /(un)?install/i })).not.toBeInTheDocument();
       rendered.unmount();
 
       // Does not show an Update button
       rendered = renderPluginDetails({ id, isInstalled: true, hasUpdate: true }, { pluginsStateOverride });
-      expect(await rendered.queryByRole('button', { name: /update/i })).not.toBeInTheDocument();
+      expect(rendered.queryByRole('button', { name: /update/i })).not.toBeInTheDocument();
 
       // Shows a message to the user
       // TODO<Import these texts from a single source of truth instead of having them defined in multiple places>
@@ -491,15 +491,15 @@ describe('Plugin details page', () => {
 
       // Should not show an "Install" button
       rendered = renderPluginDetails({ id, isInstalled: false });
-      expect(await rendered.queryByRole('button', { name: /^install/i })).not.toBeInTheDocument();
+      expect(rendered.queryByRole('button', { name: /^install/i })).not.toBeInTheDocument();
 
       // Should not show an "Uninstall" button
       rendered = renderPluginDetails({ id, isInstalled: true });
-      expect(await rendered.queryByRole('button', { name: /^uninstall/i })).not.toBeInTheDocument();
+      expect(rendered.queryByRole('button', { name: /^uninstall/i })).not.toBeInTheDocument();
 
       // Should not show an "Update" button
       rendered = renderPluginDetails({ id, isInstalled: true, hasUpdate: true });
-      expect(await rendered.queryByRole('button', { name: /^update/i })).not.toBeInTheDocument();
+      expect(rendered.queryByRole('button', { name: /^update/i })).not.toBeInTheDocument();
     });
 
     it('should display a "Create" button as a post installation step for installed data source plugins', async () => {
@@ -679,7 +679,7 @@ describe('Plugin details page', () => {
         isPublished: false,
       });
 
-      expect(await queryByRole('tab', { name: `Tab ${PluginTabLabels.VERSIONS}` })).not.toBeInTheDocument();
+      expect(queryByRole('tab', { name: `Tab ${PluginTabLabels.VERSIONS}` })).not.toBeInTheDocument();
     });
 
     it('should not display update for plugins not published to gcom', async () => {
@@ -763,7 +763,7 @@ describe('Plugin details page', () => {
       const { findByRole, queryByRole } = renderPluginDetails({ id, isInstalled: false, isEnterprise: true });
 
       expect(await findByRole('tab', { name: `Tab ${PluginTabLabels.OVERVIEW}` })).toBeInTheDocument();
-      expect(await queryByRole('button', { name: /^install/i })).not.toBeInTheDocument();
+      expect(queryByRole('button', { name: /^install/i })).not.toBeInTheDocument();
     });
   });
 

--- a/public/app/features/plugins/pluginSettings.test.ts
+++ b/public/app/features/plugins/pluginSettings.test.ts
@@ -65,7 +65,7 @@ describe('PluginSettings', () => {
 
     // act
     const response1 = await getPluginSettings('test');
-    await clearPluginSettingsCache('test');
+    clearPluginSettingsCache('test');
     const response2 = await getPluginSettings('test');
 
     // assert
@@ -85,7 +85,7 @@ describe('PluginSettings', () => {
     const getRequestSpy = jest.spyOn(getBackendSrv(), 'get');
     // act
     const response1 = await getPluginSettings('test');
-    await clearPluginSettingsCache('another-test');
+    clearPluginSettingsCache('another-test');
     const response2 = await getPluginSettings('test');
 
     // assert
@@ -106,7 +106,7 @@ describe('PluginSettings', () => {
 
     // act
     const response1 = await getPluginSettings('test');
-    await clearPluginSettingsCache();
+    clearPluginSettingsCache();
     const response2 = await getPluginSettings('test');
 
     // assert

--- a/public/app/features/profile/state/actions.ts
+++ b/public/app/features/profile/state/actions.ts
@@ -33,7 +33,7 @@ export function initUserProfilePage(): ThunkResult<void> {
   };
 }
 
-export function loadUser(): ThunkResult<void> {
+export function loadUser(): ThunkResult<Promise<void>> {
   return async function (dispatch) {
     const user = await api.loadUser();
     dispatch(userLoaded({ user }));

--- a/public/app/features/query/components/QueryGroup.tsx
+++ b/public/app/features/query/components/QueryGroup.tsx
@@ -197,7 +197,7 @@ export class QueryGroup extends PureComponent<Props, State> {
     // We need to pass in newSettings.uid as well here as that can be a variable expression and we want to store that in the query model not the current ds variable value
     const queries = await updateQueries(nextDS, nextDS.uid, savedQuery.queries, currentDS);
 
-    const newDsSettings = await getDataSourceSrv().getInstanceSettings(nextDS.uid);
+    const newDsSettings = getDataSourceSrv().getInstanceSettings(nextDS.uid);
     if (!newDsSettings) {
       throw new Error('TODO error handling');
     }

--- a/public/app/features/teams/TeamPages.tsx
+++ b/public/app/features/teams/TeamPages.tsx
@@ -91,13 +91,12 @@ export class TeamPages extends PureComponent<Props, State> {
   async fetchTeam() {
     const { loadTeam, teamId } = this.props;
     this.setState({ isLoading: true });
-    const team = await loadTeam(teamId);
+    await loadTeam(teamId);
     // With accesscontrol, the TeamPermissions will fetch team members
     if (!contextSrv.accessControlEnabled()) {
       await this.props.loadTeamMembers();
     }
     this.setState({ isLoading: false });
-    return team;
   }
 
   getCurrentPage() {

--- a/public/app/features/teams/state/actions.ts
+++ b/public/app/features/teams/state/actions.ts
@@ -36,7 +36,7 @@ export function loadTeams(initial = false): ThunkResult<void> {
 
 const loadTeamsWithDebounce = debounce((dispatch) => dispatch(loadTeams()), 500);
 
-export function loadTeam(id: number): ThunkResult<void> {
+export function loadTeam(id: number): ThunkResult<Promise<void>> {
   return async (dispatch) => {
     const response = await getBackendSrv().get(`/api/teams/${id}`, accessControlQueryParam());
     dispatch(teamLoaded(response));
@@ -67,7 +67,7 @@ export function changePage(page: number): ThunkResult<void> {
   };
 }
 
-export function loadTeamMembers(): ThunkResult<void> {
+export function loadTeamMembers(): ThunkResult<Promise<void>> {
   return async (dispatch, getStore) => {
     const team = getStore().team.team;
     const response = await getBackendSrv().get(`/api/teams/${team.id}/members`);
@@ -99,7 +99,7 @@ export function updateTeam(name: string, email: string): ThunkResult<void> {
   };
 }
 
-export function loadTeamGroups(): ThunkResult<void> {
+export function loadTeamGroups(): ThunkResult<Promise<void>> {
   return async (dispatch, getStore) => {
     const team = getStore().team.team;
     const response = await getBackendSrv().get(`/api/teams/${team.id}/groups`);

--- a/public/app/features/transformers/configFromQuery/ConfigFromQueryTransformerEditor.test.tsx
+++ b/public/app/features/transformers/configFromQuery/ConfigFromQueryTransformerEditor.test.tsx
@@ -41,7 +41,7 @@ describe('ConfigFromQueryTransformerEditor', () => {
     setup();
 
     let select = (await screen.findByText('Config query')).nextSibling!.firstChild!;
-    await fireEvent.keyDown(select, { keyCode: 40 });
+    fireEvent.keyDown(select, { keyCode: 40 });
     await selectOptionInTest(select as HTMLElement, 'A');
 
     expect(mockOnChange).toHaveBeenCalledWith(

--- a/public/app/features/transformers/fieldToConfigMapping/FieldToConfigMappingEditor.test.tsx
+++ b/public/app/features/transformers/fieldToConfigMapping/FieldToConfigMappingEditor.test.tsx
@@ -47,7 +47,7 @@ describe('FieldToConfigMappingEditor', () => {
     setup();
 
     const select = (await screen.findByTestId('Miiin-config-key')).childNodes[0];
-    await fireEvent.keyDown(select, { keyCode: 40 });
+    fireEvent.keyDown(select, { keyCode: 40 });
     await selectOptionInTest(select as HTMLElement, 'Min');
 
     expect(mockOnChange).toHaveBeenCalledWith(expect.arrayContaining([{ fieldName: 'Miiin', handlerKey: 'min' }]));
@@ -80,9 +80,9 @@ describe('FieldToConfigMappingEditor', () => {
   it('Can change reducer', async () => {
     setup();
 
-    const reducer = await (await screen.findByTestId('max-reducer')).childNodes[0];
+    const reducer = (await screen.findByTestId('max-reducer')).childNodes[0];
 
-    await fireEvent.keyDown(reducer, { keyCode: 40 });
+    fireEvent.keyDown(reducer, { keyCode: 40 });
     await selectOptionInTest(reducer as HTMLElement, 'Last');
 
     expect(mockOnChange).toHaveBeenCalledWith(

--- a/public/app/features/transformers/lookupGazetteer/fieldLookup.test.ts
+++ b/public/app/features/transformers/lookupGazetteer/fieldLookup.test.ts
@@ -33,7 +33,7 @@ describe('Lookup gazetteer', () => {
       ],
     });
     const gaz = frameAsGazetter(frame, { path: 'path/to/gaz.json' });
-    const out = await addFieldsFromGazetteer([data], gaz, matcher)[0];
+    const out = addFieldsFromGazetteer([data], gaz, matcher)[0];
 
     expect(out.fields).toMatchInlineSnapshot(`
       [

--- a/public/app/features/transformers/rowsToFields/RowsToFieldsTransformerEditor.test.tsx
+++ b/public/app/features/transformers/rowsToFields/RowsToFieldsTransformerEditor.test.tsx
@@ -38,7 +38,7 @@ describe('RowsToFieldsTransformerEditor', () => {
     setup();
 
     const select = (await screen.findByTestId('Name-config-key')).childNodes[0];
-    await fireEvent.keyDown(select, { keyCode: 40 });
+    fireEvent.keyDown(select, { keyCode: 40 });
     await selectOptionInTest(select as HTMLElement, 'Field name');
 
     expect(mockOnChange).toHaveBeenCalledWith(
@@ -52,7 +52,7 @@ describe('RowsToFieldsTransformerEditor', () => {
     setup();
 
     const select = (await screen.findByTestId('Value-config-key')).childNodes[0];
-    await fireEvent.keyDown(select, { keyCode: 40 });
+    fireEvent.keyDown(select, { keyCode: 40 });
     await selectOptionInTest(select as HTMLElement, 'Field value');
 
     expect(mockOnChange).toHaveBeenCalledWith(

--- a/public/app/features/variables/adhoc/actions.ts
+++ b/public/app/features/variables/adhoc/actions.ts
@@ -60,7 +60,7 @@ export const applyFilterFromTable = (options: AdHocTableOptions): ThunkResult<vo
 export const changeFilter = (
   identifier: KeyedVariableIdentifier,
   update: AdHocVariabelFilterUpdate
-): ThunkResult<void> => {
+): ThunkResult<Promise<void>> => {
   return async (dispatch, getState) => {
     const variable = getVariable(identifier, getState());
     dispatch(toKeyedAction(identifier.rootStateKey, filterUpdated(toVariablePayload(variable, update))));
@@ -76,7 +76,10 @@ export const removeFilter = (identifier: KeyedVariableIdentifier, index: number)
   };
 };
 
-export const addFilter = (identifier: KeyedVariableIdentifier, filter: AdHocVariableFilter): ThunkResult<void> => {
+export const addFilter = (
+  identifier: KeyedVariableIdentifier,
+  filter: AdHocVariableFilter
+): ThunkResult<Promise<void>> => {
   return async (dispatch, getState) => {
     const variable = getVariable(identifier, getState());
     dispatch(toKeyedAction(identifier.rootStateKey, filterAdded(toVariablePayload(variable, filter))));

--- a/public/app/features/variables/constant/actions.ts
+++ b/public/app/features/variables/constant/actions.ts
@@ -10,7 +10,7 @@ import { createConstantOptionsFromQuery } from './reducer';
 export const updateConstantVariableOptions = (identifier: KeyedVariableIdentifier): ThunkResult<void> => {
   return async (dispatch) => {
     const { rootStateKey } = identifier;
-    await dispatch(toKeyedAction(rootStateKey, createConstantOptionsFromQuery(toVariablePayload(identifier))));
-    await dispatch(validateVariableSelectionState(identifier));
+    dispatch(toKeyedAction(rootStateKey, createConstantOptionsFromQuery(toVariablePayload(identifier))));
+    dispatch(validateVariableSelectionState(identifier));
   };
 };

--- a/public/app/features/variables/custom/actions.ts
+++ b/public/app/features/variables/custom/actions.ts
@@ -10,7 +10,7 @@ import { createCustomOptionsFromQuery } from './reducer';
 export const updateCustomVariableOptions = (identifier: KeyedVariableIdentifier): ThunkResult<void> => {
   return async (dispatch) => {
     const { rootStateKey } = identifier;
-    await dispatch(toKeyedAction(rootStateKey, createCustomOptionsFromQuery(toVariablePayload(identifier))));
-    await dispatch(validateVariableSelectionState(identifier));
+    dispatch(toKeyedAction(rootStateKey, createCustomOptionsFromQuery(toVariablePayload(identifier))));
+    dispatch(validateVariableSelectionState(identifier));
   };
 };

--- a/public/app/features/variables/interval/actions.ts
+++ b/public/app/features/variables/interval/actions.ts
@@ -15,8 +15,8 @@ export const updateIntervalVariableOptions =
   (identifier: KeyedVariableIdentifier): ThunkResult<void> =>
   async (dispatch) => {
     const { rootStateKey } = identifier;
-    await dispatch(toKeyedAction(rootStateKey, createIntervalOptions(toVariablePayload(identifier))));
-    await dispatch(updateAutoValue(identifier));
+    dispatch(toKeyedAction(rootStateKey, createIntervalOptions(toVariablePayload(identifier))));
+    dispatch(updateAutoValue(identifier));
     await dispatch(validateVariableSelectionState(identifier));
   };
 

--- a/public/app/features/variables/pickers/OptionsPicker/actions.test.ts
+++ b/public/app/features/variables/pickers/OptionsPicker/actions.test.ts
@@ -489,7 +489,7 @@ describe('options picker actions', () => {
       const variable = createMultiVariable({ options, current: createOption(['A'], ['A'], true), includeAll: false });
       const clearOthers = false;
 
-      const tester = await reduxTester<RootReducerType>()
+      const tester = reduxTester<RootReducerType>()
         .givenRootReducer(getRootReducer())
         .whenActionIsDispatched(
           toKeyedAction('key', addVariable(toVariablePayload(variable, { global: false, index: 0, model: variable })))
@@ -512,7 +512,7 @@ describe('options picker actions', () => {
       const variable = createMultiVariable({ options, current: createOption(['A'], ['A'], true), includeAll: false });
       const clearOthers = false;
 
-      const tester = await reduxTester<RootReducerType>()
+      const tester = reduxTester<RootReducerType>()
         .givenRootReducer(getRootReducer())
         .whenActionIsDispatched(
           toKeyedAction('key', addVariable(toVariablePayload(variable, { global: false, index: 0, model: variable })))

--- a/public/app/features/variables/pickers/OptionsPicker/actions.ts
+++ b/public/app/features/variables/pickers/OptionsPicker/actions.ts
@@ -83,7 +83,7 @@ const setVariable = async (updated: VariableWithOptions) => {
   return;
 };
 
-export const commitChangesToVariable = (key: string, callback?: (updated: any) => void): ThunkResult<void> => {
+export const commitChangesToVariable = (key: string, callback?: (updated: any) => void): ThunkResult<Promise<void>> => {
   return async (dispatch, getState) => {
     const picker = getVariablesState(key, getState()).optionsPicker;
     const identifier: KeyedVariableIdentifier = { id: picker.id, rootStateKey: key, type: 'query' };

--- a/public/app/features/variables/query/actions.ts
+++ b/public/app/features/variables/query/actions.ts
@@ -66,7 +66,7 @@ export const updateQueryVariableOptions = (
 };
 
 export const initQueryVariableEditor =
-  (identifier: KeyedVariableIdentifier): ThunkResult<void> =>
+  (identifier: KeyedVariableIdentifier): ThunkResult<Promise<void>> =>
   async (dispatch, getState) => {
     const variable = getVariable(identifier, getState());
     if (variable.type !== 'query') {
@@ -79,7 +79,7 @@ export const initQueryVariableEditor =
 export const changeQueryVariableDataSource = (
   identifier: KeyedVariableIdentifier,
   name: DataSourceRef | null
-): ThunkResult<void> => {
+): ThunkResult<Promise<void>> => {
   return async (dispatch, getState) => {
     try {
       const { rootStateKey } = identifier;

--- a/public/app/features/variables/state/actions.test.ts
+++ b/public/app/features/variables/state/actions.test.ts
@@ -188,7 +188,7 @@ describe('shared actions', () => {
         .whenActionIsDispatched(initDashboardTemplating(key, dashboard))
         .whenAsyncActionIsDispatched(processVariables(key), true);
 
-      await tester.thenDispatchedActionsPredicateShouldEqual((dispatchedActions) => {
+      tester.thenDispatchedActionsPredicateShouldEqual((dispatchedActions) => {
         expect(dispatchedActions.length).toEqual(5);
 
         expect(dispatchedActions[0]).toEqual(
@@ -273,7 +273,7 @@ describe('shared actions', () => {
         .whenActionIsDispatched(initDashboardTemplating(key, dashboard))
         .whenAsyncActionIsDispatched(processVariables(key), true);
 
-      await tester.thenDispatchedActionsShouldEqual(
+      tester.thenDispatchedActionsShouldEqual(
         toKeyedAction(key, variableStateFetching(toVariablePayload(stats))),
         toKeyedAction(
           key,
@@ -358,7 +358,7 @@ describe('shared actions', () => {
             true
           );
 
-        await tester.thenDispatchedActionsPredicateShouldEqual((dispatchedActions) => {
+        tester.thenDispatchedActionsPredicateShouldEqual((dispatchedActions) => {
           const expectedActions: AnyAction[] = withOptions
             ? [
                 toKeyedAction(
@@ -420,7 +420,7 @@ describe('shared actions', () => {
               true
             );
 
-          await tester.thenDispatchedActionsPredicateShouldEqual((dispatchedActions) => {
+          tester.thenDispatchedActionsPredicateShouldEqual((dispatchedActions) => {
             const expectedActions: AnyAction[] = withOptions
               ? [
                   toKeyedAction(

--- a/public/app/features/variables/state/actions.ts
+++ b/public/app/features/variables/state/actions.ts
@@ -698,7 +698,7 @@ const timeRangeUpdated =
   };
 
 export const templateVarsChangedInUrl =
-  (key: string, vars: ExtendedUrlQueryMap, events: typeof appEvents = appEvents): ThunkResult<void> =>
+  (key: string, vars: ExtendedUrlQueryMap, events: typeof appEvents = appEvents): ThunkResult<Promise<void>> =>
   async (dispatch, getState) => {
     const update: Array<Promise<any>> = [];
     const dashboard = getState().dashboard.getModel();
@@ -929,7 +929,7 @@ export const completeVariableLoading =
 export function upgradeLegacyQueries(
   identifier: KeyedVariableIdentifier,
   getDatasourceSrvFunc: typeof getDatasourceSrv = getDatasourceSrv
-): ThunkResult<void> {
+): ThunkResult<Promise<void>> {
   return async function (dispatch, getState) {
     const { id, rootStateKey } = identifier;
     if (!hasOngoingTransaction(rootStateKey, getState())) {

--- a/public/app/features/variables/state/processVariable.test.ts
+++ b/public/app/features/variables/state/processVariable.test.ts
@@ -123,9 +123,7 @@ describe('processVariable', () => {
           .whenActionIsDispatched(initDashboardTemplating(key, dashboard))
           .whenAsyncActionIsDispatched(processVariable(toKeyedVariableIdentifier(custom), queryParams), true);
 
-        await tester.thenDispatchedActionsShouldEqual(
-          toKeyedAction(key, variableStateCompleted(toVariablePayload(custom)))
-        );
+        tester.thenDispatchedActionsShouldEqual(toKeyedAction(key, variableStateCompleted(toVariablePayload(custom))));
       });
     });
 
@@ -139,7 +137,7 @@ describe('processVariable', () => {
           .whenActionIsDispatched(initDashboardTemplating(key, dashboard))
           .whenAsyncActionIsDispatched(processVariable(toKeyedVariableIdentifier(custom), queryParams), true);
 
-        await tester.thenDispatchedActionsShouldEqual(
+        tester.thenDispatchedActionsShouldEqual(
           toKeyedAction(
             key,
             setCurrentVariableValue(
@@ -171,7 +169,7 @@ describe('processVariable', () => {
             .whenActionIsDispatched(initDashboardTemplating(key, dashboard))
             .whenAsyncActionIsDispatched(processVariable(toKeyedVariableIdentifier(queryNoDepends), queryParams), true);
 
-          await tester.thenDispatchedActionsShouldEqual(
+          tester.thenDispatchedActionsShouldEqual(
             toKeyedAction(key, variableStateCompleted(toVariablePayload(queryNoDepends)))
           );
         });
@@ -190,7 +188,7 @@ describe('processVariable', () => {
           .whenActionIsDispatched(initDashboardTemplating(key, dashboard))
           .whenAsyncActionIsDispatched(processVariable(toKeyedVariableIdentifier(queryNoDepends), queryParams), true);
 
-        await tester.thenDispatchedActionsShouldEqual(
+        tester.thenDispatchedActionsShouldEqual(
           toKeyedAction(key, variableStateFetching(toVariablePayload({ type: 'query', id: 'queryNoDepends' }))),
           toKeyedAction(
             key,
@@ -236,7 +234,7 @@ describe('processVariable', () => {
             .whenActionIsDispatched(initDashboardTemplating(key, dashboard))
             .whenAsyncActionIsDispatched(processVariable(toKeyedVariableIdentifier(queryNoDepends), queryParams), true);
 
-          await tester.thenDispatchedActionsShouldEqual(
+          tester.thenDispatchedActionsShouldEqual(
             toKeyedAction(
               key,
               setCurrentVariableValue(
@@ -264,7 +262,7 @@ describe('processVariable', () => {
           .whenActionIsDispatched(initDashboardTemplating(key, dashboard))
           .whenAsyncActionIsDispatched(processVariable(toKeyedVariableIdentifier(queryNoDepends), queryParams), true);
 
-        await tester.thenDispatchedActionsShouldEqual(
+        tester.thenDispatchedActionsShouldEqual(
           toKeyedAction(key, variableStateFetching(toVariablePayload({ type: 'query', id: 'queryNoDepends' }))),
           toKeyedAction(
             key,
@@ -327,7 +325,7 @@ describe('processVariable', () => {
             true
           );
 
-          await tester.thenDispatchedActionsShouldEqual(
+          tester.thenDispatchedActionsShouldEqual(
             toKeyedAction(key, variableStateCompleted(toVariablePayload({ type: 'query', id: 'queryDependsOnCustom' })))
           );
         });
@@ -351,7 +349,7 @@ describe('processVariable', () => {
           true
         );
 
-        await tester.thenDispatchedActionsShouldEqual(
+        tester.thenDispatchedActionsShouldEqual(
           toKeyedAction(key, variableStateFetching(toVariablePayload({ type: 'query', id: 'queryDependsOnCustom' }))),
           toKeyedAction(
             key,
@@ -402,7 +400,7 @@ describe('processVariable', () => {
             true
           );
 
-          await tester.thenDispatchedActionsShouldEqual(
+          tester.thenDispatchedActionsShouldEqual(
             toKeyedAction(
               key,
               setCurrentVariableValue(
@@ -435,7 +433,7 @@ describe('processVariable', () => {
           true
         );
 
-        await tester.thenDispatchedActionsShouldEqual(
+        tester.thenDispatchedActionsShouldEqual(
           toKeyedAction(key, variableStateFetching(toVariablePayload({ type: 'query', id: 'queryDependsOnCustom' }))),
           toKeyedAction(
             key,

--- a/public/app/features/variables/state/setOptionFromUrl.test.ts
+++ b/public/app/features/variables/state/setOptionFromUrl.test.ts
@@ -45,7 +45,7 @@ describe('when setOptionFromUrl is dispatched with a custom variable (no refresh
       )
       .whenAsyncActionIsDispatched(setOptionFromUrl(toKeyedVariableIdentifier(custom), urlValue), true);
 
-    await tester.thenDispatchedActionsShouldEqual(
+    tester.thenDispatchedActionsShouldEqual(
       toKeyedAction(
         key,
         setCurrentVariableValue(
@@ -81,7 +81,7 @@ describe('when setOptionFromUrl is dispatched for a variable with a custom all v
       )
       .whenAsyncActionIsDispatched(setOptionFromUrl(toKeyedVariableIdentifier(custom), urlValue), true);
 
-    await tester.thenDispatchedActionsShouldEqual(
+    tester.thenDispatchedActionsShouldEqual(
       toKeyedAction(
         key,
         setCurrentVariableValue(
@@ -115,7 +115,7 @@ describe('when setOptionFromUrl is dispatched for a variable with a custom all v
       )
       .whenAsyncActionIsDispatched(setOptionFromUrl(toKeyedVariableIdentifier(custom), urlValue), true);
 
-    await tester.thenDispatchedActionsShouldEqual(
+    tester.thenDispatchedActionsShouldEqual(
       toKeyedAction(
         key,
         setCurrentVariableValue(
@@ -146,7 +146,7 @@ describe('when setOptionFromUrl is dispatched for a variable with a custom all v
       )
       .whenAsyncActionIsDispatched(setOptionFromUrl(toKeyedVariableIdentifier(custom), urlValue), true);
 
-    await tester.thenDispatchedActionsShouldEqual(
+    tester.thenDispatchedActionsShouldEqual(
       toKeyedAction(
         key,
         setCurrentVariableValue(
@@ -179,7 +179,7 @@ describe('when setOptionFromUrl is dispatched for a variable with a custom all v
       )
       .whenAsyncActionIsDispatched(setOptionFromUrl(toKeyedVariableIdentifier(custom), urlValue), true);
 
-    await tester.thenDispatchedActionsShouldEqual(
+    tester.thenDispatchedActionsShouldEqual(
       toKeyedAction(
         key,
         setCurrentVariableValue(

--- a/public/app/plugins/datasource/cloud-monitoring/components/GroupBy.test.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/GroupBy.test.tsx
@@ -33,7 +33,7 @@ describe('GroupBy', () => {
     const option = 'metadata.system_labels.cloud_account';
 
     expect(screen.queryByText(option)).not.toBeInTheDocument();
-    await openMenu(groupBy);
+    openMenu(groupBy);
     expect(screen.getByText(option)).toBeInTheDocument();
 
     await select(groupBy, option, { container: document.body });

--- a/public/app/plugins/datasource/cloud-monitoring/components/LabelFilter.test.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/LabelFilter.test.tsx
@@ -44,7 +44,7 @@ describe('LabelFilter', () => {
     const filters = ['key_1', '=', 'value_1'];
     render(<LabelFilter labels={labels} filters={filters} onChange={() => {}} variableOptionGroup={[]} />);
 
-    await openMenu(screen.getByLabelText('Filter label key'));
+    openMenu(screen.getByLabelText('Filter label key'));
 
     expect(screen.getByText('Metric Label')).toBeInTheDocument();
     expect(screen.getByText('metric.label.instance_name')).toBeInTheDocument();
@@ -73,7 +73,7 @@ describe('LabelFilter', () => {
     const filters = ['metric.label.instance_name', '=', ''];
     render(<LabelFilter labels={labels} filters={filters} onChange={() => {}} variableOptionGroup={[]} />);
 
-    await openMenu(screen.getByLabelText('Filter label value'));
+    openMenu(screen.getByLabelText('Filter label value'));
     expect(screen.getByText('instance_name_1')).toBeInTheDocument();
     expect(screen.getByText('instance_name_2')).toBeInTheDocument();
     expect(screen.queryByText('instance_id_1')).not.toBeInTheDocument();

--- a/public/app/plugins/datasource/cloud-monitoring/components/QueryHeader.test.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/QueryHeader.test.tsx
@@ -16,7 +16,7 @@ describe('QueryHeader', () => {
     render(<QueryHeader query={query} onChange={onChange} onRunQuery={onRunQuery} />);
 
     const queryType = screen.getByLabelText(/Query type/);
-    await openMenu(queryType);
+    openMenu(queryType);
     await select(screen.getByLabelText('Select options menu'), 'Service Level Objectives (SLO)');
     expect(onChange).toBeCalledWith(expect.objectContaining({ queryType: QueryType.SLO }));
   });
@@ -29,7 +29,7 @@ describe('QueryHeader', () => {
     render(<QueryHeader query={query} onChange={onChange} onRunQuery={onRunQuery} />);
 
     const queryType = screen.getByLabelText(/Query type/);
-    await openMenu(queryType);
+    openMenu(queryType);
     await select(screen.getByLabelText('Select options menu'), 'MQL');
     expect(onChange).toBeCalledWith(expect.objectContaining({ queryType: QueryType.TIME_SERIES_QUERY }));
   });

--- a/public/app/plugins/datasource/cloud-monitoring/components/VisualMetricQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/VisualMetricQueryEditor.test.tsx
@@ -45,7 +45,7 @@ describe('VisualMetricQueryEditor', () => {
     render(<VisualMetricQueryEditor {...defaultProps} onChange={onChange} datasource={datasource} query={query} />);
 
     const service = await screen.findByLabelText('Service');
-    await openMenu(service);
+    openMenu(service);
     await act(async () => {
       await select(service, 'Srv', { container: document.body });
       expect(onChange).toBeCalledWith(
@@ -66,12 +66,12 @@ describe('VisualMetricQueryEditor', () => {
     render(<VisualMetricQueryEditor {...defaultProps} onChange={onChange} datasource={datasource} query={query} />);
 
     const service = await screen.findByLabelText('Service');
-    await openMenu(service);
+    openMenu(service);
     await act(async () => {
       await select(service, 'Srv', { container: document.body });
     });
     const metricName = await screen.findByLabelText('Metric name');
-    await openMenu(metricName);
+    openMenu(metricName);
     await waitFor(() => expect(document.body).toHaveTextContent('metricName_test'));
     await act(async () => {
       await select(metricName, 'metricName_test', { container: document.body });
@@ -114,12 +114,12 @@ describe('VisualMetricQueryEditor', () => {
     render(<VisualMetricQueryEditor {...defaultProps} onChange={onChange} datasource={datasource} query={query} />);
 
     const service = await screen.findByLabelText('Service');
-    await openMenu(service);
+    openMenu(service);
     await act(async () => {
       await select(service, 'Srv A', { container: document.body });
     });
     const metricName = await screen.findByLabelText('Metric name');
-    await openMenu(metricName);
+    openMenu(metricName);
 
     const metricNameOptions = screen.getByLabelText('Select options menu');
     expect(within(metricNameOptions).getByText('description_metric1')).toBeInTheDocument();
@@ -129,7 +129,7 @@ describe('VisualMetricQueryEditor', () => {
     expect(within(metricNameOptions).queryByText('displayName_metric3')).not.toBeInTheDocument();
     expect(within(metricNameOptions).queryByText('description_metric3')).not.toBeInTheDocument();
 
-    await openMenu(service);
+    openMenu(service);
     await act(async () => {
       await select(service, 'Srv B', { container: document.body });
     });
@@ -172,7 +172,7 @@ describe('VisualMetricQueryEditor', () => {
 
     render(<VisualMetricQueryEditor {...defaultProps} onChange={onChange} datasource={datasource} query={query} />);
     const service = await screen.findByLabelText('Service');
-    await openMenu(service);
+    openMenu(service);
     expect(screen.getAllByLabelText('Select option').length).toEqual(2);
   });
 
@@ -233,8 +233,8 @@ describe('VisualMetricQueryEditor', () => {
     );
     expect(query).toEqual(defaultQuery);
     expect(document.body).toHaveTextContent('metric.test_label');
-    expect(await screen.queryByText('Delta')).not.toBeInTheDocument();
-    expect(await screen.queryByText('metric.test_groupby')).not.toBeInTheDocument();
+    expect(screen.queryByText('Delta')).not.toBeInTheDocument();
+    expect(screen.queryByText('metric.test_groupby')).not.toBeInTheDocument();
   });
 
   it('updates labels on time range change', async () => {
@@ -257,18 +257,18 @@ describe('VisualMetricQueryEditor', () => {
     );
 
     const service = await screen.findByLabelText('Service');
-    await openMenu(service);
+    openMenu(service);
     await act(async () => {
       await select(service, 'Srv', { container: document.body });
     });
     const metricName = await screen.findByLabelText('Metric name');
-    await openMenu(metricName);
+    openMenu(metricName);
     await waitFor(() => expect(document.body).toHaveTextContent('metricName'));
     await act(async () => {
       await select(metricName, 'metricName', { container: document.body });
     });
     const groupBy = await screen.findByLabelText('Group by');
-    await openMenu(groupBy);
+    openMenu(groupBy);
     await waitFor(() => expect(document.body).toHaveTextContent('metric.test_groupby'));
     await act(async () => {
       timeSrv.setTime({ from: 'now-12h', to: 'now' });
@@ -279,7 +279,7 @@ describe('VisualMetricQueryEditor', () => {
       rerender(
         <VisualMetricQueryEditor {...defaultProps} onChange={onChange} datasource={datasourceUpdated} query={query} />
       );
-      await openMenu(groupBy);
+      openMenu(groupBy);
       await waitFor(() => expect(document.body).toHaveTextContent('metric.test_groupby_1'));
     });
   });

--- a/public/app/plugins/datasource/cloud-monitoring/specs/datasource.test.ts
+++ b/public/app/plugins/datasource/cloud-monitoring/specs/datasource.test.ts
@@ -94,7 +94,7 @@ describe('CloudMonitoringDataSource', () => {
         const { ds } = getTestcontext();
         await ds.getLabels('cpu', 'a', 'default-proj');
 
-        await expect(fetchMock.mock.calls[0][0].data.queries[0].timeSeriesList).toMatchObject({
+        expect(fetchMock.mock.calls[0][0].data.queries[0].timeSeriesList).toMatchObject({
           crossSeriesReducer: 'REDUCE_NONE',
           groupBys: [],
           filters: ['metric.type', '=', 'cpu'],
@@ -112,7 +112,7 @@ describe('CloudMonitoringDataSource', () => {
           groupBys: ['metadata.system_label.name'],
         });
 
-        await expect(fetchMock.mock.calls[0][0].data.queries[0].timeSeriesList).toMatchObject({
+        expect(fetchMock.mock.calls[0][0].data.queries[0].timeSeriesList).toMatchObject({
           crossSeriesReducer: 'REDUCE_MEAN',
           groupBys: ['metadata.system_label.name'],
           filters: ['metric.type', '=', 'sql'],

--- a/public/app/plugins/datasource/cloudwatch/components/AnnotationQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/AnnotationQueryEditor.test.tsx
@@ -81,6 +81,6 @@ describe('AnnotationQueryEditor', () => {
       .mockResolvedValue([[{ label: 'dimVal1', value: 'dimVal1' }]]);
     (props.query as CloudWatchAnnotationQuery).dimensions = { instanceId: 'instance-123' };
     await waitFor(() => render(<AnnotationQueryEditor {...props} />));
-    expect(await screen.queryByText('Account')).toBeNull();
+    expect(screen.queryByText('Account')).toBeNull();
   });
 });

--- a/public/app/plugins/datasource/cloudwatch/components/ConfigEditor.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/ConfigEditor.test.tsx
@@ -150,7 +150,7 @@ describe('Render', () => {
 
   it('should display log group selector field', async () => {
     setup();
-    await waitFor(async () => expect(await screen.getByText('Select Log Groups')).toBeInTheDocument());
+    await waitFor(async () => expect(screen.getByText('Select Log Groups')).toBeInTheDocument());
   });
 
   it('should only display the first two default log groups and show all of them when clicking "Show all" button', async () => {
@@ -165,13 +165,13 @@ describe('Render', () => {
       },
     });
     await waitFor(async () => {
-      expect(await screen.getByText('logGroup-foo')).toBeInTheDocument();
-      expect(await screen.getByText('logGroup-bar')).toBeInTheDocument();
-      expect(await screen.queryByText('logGroup-baz')).not.toBeInTheDocument();
+      expect(screen.getByText('logGroup-foo')).toBeInTheDocument();
+      expect(screen.getByText('logGroup-bar')).toBeInTheDocument();
+      expect(screen.queryByText('logGroup-baz')).not.toBeInTheDocument();
 
       await userEvent.click(screen.getByText('Show all'));
 
-      expect(await screen.getByText('logGroup-baz')).toBeInTheDocument();
+      expect(screen.getByText('logGroup-baz')).toBeInTheDocument();
     });
   });
 

--- a/public/app/plugins/datasource/cloudwatch/components/LogGroups/LogGroupsSelector.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/LogGroups/LogGroupsSelector.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 // eslint-disable-next-line lodash/import-scope
 import lodash from 'lodash';
@@ -285,7 +285,7 @@ describe('LogGroupsSelector', () => {
       />
     );
     await userEvent.click(screen.getByText('Select Log Groups'));
-    await screen.getByRole('button', { name: 'select-clear-value' }).click();
+    fireEvent.click(screen.getByRole('button', { name: 'select-clear-value' }));
     await userEvent.click(screen.getByText('Add log groups'));
     expect(onChange).toHaveBeenCalledWith([
       {

--- a/public/app/plugins/datasource/cloudwatch/components/MetricStatEditor/MetricStatEditor.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/MetricStatEditor/MetricStatEditor.test.tsx
@@ -243,7 +243,7 @@ describe('MetricStatEditor', () => {
         );
       });
       expect(onChange).toHaveBeenCalledWith({ ...validMetricSearchBuilderQuery, accountId: undefined });
-      expect(await screen.queryByText('Account')).not.toBeInTheDocument();
+      expect(screen.queryByText('Account')).not.toBeInTheDocument();
     });
   });
 });

--- a/public/app/plugins/datasource/cloudwatch/components/MetricsQueryEditor/MetricsQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/MetricsQueryEditor/MetricsQueryEditor.test.tsx
@@ -143,7 +143,7 @@ describe('QueryEditor', () => {
         const expected = 'Period: {{period}} InstanceId: {{InstanceId}}';
         render(<MetricsQueryEditor {...props} query={{ ...props.query, refId: 'A', alias: expected }} />);
 
-        expect(await screen.getByText('Alias')).toBeInTheDocument();
+        expect(screen.getByText('Alias')).toBeInTheDocument();
         expect(screen.queryByText('Label')).toBeNull();
         expect(screen.getByLabelText('Alias - optional')).toHaveValue(expected);
 

--- a/public/app/plugins/datasource/cloudwatch/components/QueryEditor.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryEditor.test.tsx
@@ -194,7 +194,7 @@ describe('QueryEditor should render right editor', () => {
         await act(async () => {
           render(<QueryEditor {...props} datasource={datasourceMock.datasource} query={query} />);
         });
-        expect(await screen.getByText('Monitoring account')).toBeInTheDocument();
+        expect(screen.getByText('Monitoring account')).toBeInTheDocument();
       });
     });
 
@@ -227,7 +227,7 @@ describe('QueryEditor should render right editor', () => {
         await act(async () => {
           render(<QueryEditor {...props} datasource={datasourceMock.datasource} query={query} />);
         });
-        expect(await screen.queryByText('Monitoring account')).toBeNull();
+        expect(screen.queryByText('Monitoring account')).toBeNull();
       });
     });
   });
@@ -319,7 +319,7 @@ describe('QueryEditor should render right editor', () => {
       const builderElement = screen.getByLabelText('Builder');
       expect(builderElement).toBeInTheDocument();
       await act(async () => {
-        await builderElement.click();
+        builderElement.click();
       });
 
       const modalTitleElem = screen.getByText('Are you sure?');
@@ -333,7 +333,7 @@ describe('QueryEditor should render right editor', () => {
       const builderElement = screen.getByLabelText('Builder');
       expect(builderElement).toBeInTheDocument();
       await act(async () => {
-        await builderElement.click();
+        builderElement.click();
       });
       expect(screen.queryByText('Are you sure?')).toBeNull();
     });
@@ -344,7 +344,7 @@ describe('QueryEditor should render right editor', () => {
       const builderElement = screen.getByLabelText('Builder');
       expect(builderElement).toBeInTheDocument();
       await act(async () => {
-        await builderElement.click();
+        builderElement.click();
       });
       expect(screen.queryByText('Are you sure?')).toBeNull();
     });

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/DimensionFields.test.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/DimensionFields.test.tsx
@@ -237,7 +237,7 @@ describe(`Azure Monitor QueryEditor`, () => {
       />
     );
     const labelSelect = screen.getByLabelText('dimension-labels-select');
-    await openMenu(labelSelect);
+    openMenu(labelSelect);
     const options = await screen.findAllByLabelText('Select option');
     expect(options).toHaveLength(2);
     expect(options[0]).toHaveTextContent('testlabel');
@@ -286,7 +286,7 @@ describe(`Azure Monitor QueryEditor`, () => {
     );
     const labelSelect = screen.getByLabelText('dimension-labels-select');
     await user.click(labelSelect);
-    await openMenu(labelSelect);
+    openMenu(labelSelect);
     screen.getByText('testlabel');
     screen.getByText('testlabel2');
     await selectOptionInTest(labelSelect, 'testlabel');
@@ -323,7 +323,7 @@ describe(`Azure Monitor QueryEditor`, () => {
       />
     );
     const labelSelect2 = screen.getByLabelText('dimension-labels-select');
-    await openMenu(labelSelect2);
+    openMenu(labelSelect2);
     const refreshedOptions = await screen.findAllByLabelText('Select options menu');
     expect(refreshedOptions).toHaveLength(1);
     expect(refreshedOptions[0]).toHaveTextContent('testlabel2');

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/ResourcePicker/ResourcePicker.test.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/ResourcePicker/ResourcePicker.test.tsx
@@ -330,7 +330,7 @@ describe('AzureMonitor ResourcePicker', () => {
       />
     );
     const subscriptionExpand = await screen.findByLabelText('Expand Primary Subscription');
-    await subscriptionExpand.click();
+    subscriptionExpand.click();
     const error = await screen.findByRole('alert');
     expect(error).toHaveTextContent('An error occurred while requesting resources from Azure Monitor');
     expect(error).toHaveTextContent(

--- a/public/app/plugins/datasource/graphite/specs/store.test.ts
+++ b/public/app/plugins/datasource/graphite/specs/store.test.ts
@@ -235,7 +235,7 @@ describe('Graphite actions', () => {
     });
 
     it('getAltSegmentsSelectables should handle autocomplete errors', async () => {
-      await expect(async () => {
+      expect(async () => {
         await getAltSegmentsSelectables(ctx.state, 0, 'any');
         expect(mockDispatch).toBeCalledWith(
           expect.objectContaining({
@@ -265,7 +265,7 @@ describe('Graphite actions', () => {
     });
 
     it('getTagsSelectables should handle autocomplete errors', async () => {
-      await expect(async () => {
+      expect(async () => {
         await getTagsSelectables(ctx.state, 0, 'any');
         expect(mockDispatch).toBeCalledWith(
           expect.objectContaining({
@@ -284,7 +284,7 @@ describe('Graphite actions', () => {
     });
 
     it('getTagsAsSegmentsSelectables should handle autocomplete errors', async () => {
-      await expect(async () => {
+      expect(async () => {
         await getTagsAsSegmentsSelectables(ctx.state, 'any');
         expect(mockDispatch).toBeCalledWith(
           expect.objectContaining({

--- a/public/app/plugins/datasource/loki/LanguageProvider.test.ts
+++ b/public/app/plugins/datasource/loki/LanguageProvider.test.ts
@@ -279,7 +279,7 @@ describe('Query imports', () => {
 
   it('returns empty queries', async () => {
     const instance = new LanguageProvider(datasource);
-    const result = await instance.importFromAbstractQuery({ refId: 'bar', labelMatchers: [] });
+    const result = instance.importFromAbstractQuery({ refId: 'bar', labelMatchers: [] });
     expect(result).toEqual({ refId: 'bar', expr: '', queryType: LokiQueryType.Range });
   });
 

--- a/public/app/plugins/datasource/loki/components/LokiQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryEditor.test.tsx
@@ -105,7 +105,7 @@ describe('LokiQueryEditorSelector', () => {
 
   it('hides Run Queries button in Correlations Page', async () => {
     renderWithProps({}, { app: CoreApp.Correlations });
-    await expectNoRunQueriesButton();
+    expectNoRunQueriesButton();
   });
 
   it('changes to builder mode', async () => {

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
@@ -121,7 +121,7 @@ function getLineFilterCompletions(afterPipe: boolean): Completion[] {
 }
 
 async function getAllHistoryCompletions(dataProvider: CompletionDataProvider): Promise<Completion[]> {
-  const history = await dataProvider.getHistory();
+  const history = dataProvider.getHistory();
 
   return history.map((expr) => ({
     type: 'HISTORY',

--- a/public/app/plugins/datasource/prometheus/language_provider.test.ts
+++ b/public/app/plugins/datasource/prometheus/language_provider.test.ts
@@ -719,7 +719,7 @@ describe('Language completion provider', () => {
   describe('Query imports', () => {
     it('returns empty queries', async () => {
       const instance = new LanguageProvider(datasource);
-      const result = await instance.importFromAbstractQuery({ refId: 'bar', labelMatchers: [] });
+      const result = instance.importFromAbstractQuery({ refId: 'bar', labelMatchers: [] });
       expect(result).toEqual({ refId: 'bar', expr: '', range: true });
     });
 

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilder.test.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilder.test.tsx
@@ -226,7 +226,7 @@ describe('PromQueryBuilder', () => {
         }}
       />
     );
-    expect(await screen.queryByText(EXPLAIN_LABEL_FILTER_CONTENT)).not.toBeInTheDocument();
+    expect(screen.queryByText(EXPLAIN_LABEL_FILTER_CONTENT)).not.toBeInTheDocument();
   });
 
   // <ModernPrometheus>

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryCodeEditor.test.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryCodeEditor.test.tsx
@@ -52,6 +52,6 @@ describe('PromQueryCodeEditor', () => {
     const { datasource } = createDatasource();
     const props = createProps(datasource);
     render(<PromQueryCodeEditor {...props} query={{ expr: '', refId: 'refid', interval: '1s' }} />);
-    expect(await screen.queryByText(EXPLAIN_LABEL_FILTER_CONTENT)).not.toBeInTheDocument();
+    expect(screen.queryByText(EXPLAIN_LABEL_FILTER_CONTENT)).not.toBeInTheDocument();
   });
 });

--- a/public/app/plugins/datasource/testdata/QueryEditor.test.tsx
+++ b/public/app/plugins/datasource/testdata/QueryEditor.test.tsx
@@ -40,7 +40,7 @@ describe('Test Datasource Query Editor', () => {
     const { rerender } = setup();
 
     let select = (await screen.findByText('Scenario')).nextSibling!.firstChild!;
-    await fireEvent.keyDown(select, { keyCode: 40 });
+    fireEvent.keyDown(select, { keyCode: 40 });
     const scs = screen.getAllByLabelText('Select option');
 
     expect(scs).toHaveLength(scenarios.length);
@@ -49,7 +49,7 @@ describe('Test Datasource Query Editor', () => {
     expect(mockOnChange).toHaveBeenCalledWith(
       expect.objectContaining({ scenarioId: TestDataQueryType.CSVMetricValues })
     );
-    await rerender(
+    rerender(
       <QueryEditor
         {...props}
         query={{ ...defaultQuery, scenarioId: TestDataQueryType.CSVMetricValues, stringInput: '1,20,90,30,5,0' }}
@@ -58,7 +58,7 @@ describe('Test Datasource Query Editor', () => {
     expect(await screen.findByRole('textbox', { name: /string input/i })).toBeInTheDocument();
     expect(screen.getByRole('textbox', { name: /string input/i })).toHaveValue('1,20,90,30,5,0');
 
-    await fireEvent.keyDown(select, { keyCode: 40 });
+    fireEvent.keyDown(select, { keyCode: 40 });
     await userEvent.click(screen.getByText('Grafana API'));
     expect(mockOnChange).toHaveBeenCalledWith(
       expect.objectContaining({ scenarioId: 'grafana_api', stringInput: 'datasources' })
@@ -72,7 +72,7 @@ describe('Test Datasource Query Editor', () => {
     expect(await screen.findByText('Grafana API')).toBeInTheDocument();
     expect(screen.getByText('Data Sources')).toBeInTheDocument();
 
-    await fireEvent.keyDown(select, { keyCode: 40 });
+    fireEvent.keyDown(select, { keyCode: 40 });
     await userEvent.click(screen.getByText('Streaming Client'));
     expect(mockOnChange).toHaveBeenCalledWith(
       expect.objectContaining({ scenarioId: 'streaming_client', stream: defaultStreamQuery })
@@ -102,7 +102,7 @@ describe('Test Datasource Query Editor', () => {
       },
     });
     let select = (await screen.findByText('Scenario')).nextSibling!.firstChild!;
-    await fireEvent.keyDown(select, { keyCode: 40 });
+    fireEvent.keyDown(select, { keyCode: 40 });
     await userEvent.click(screen.getByText('Grafana API'));
     expect(mockOnChange).toHaveBeenCalledWith(expect.objectContaining({ datasource: mockDatasource }));
   });

--- a/public/app/plugins/panel/alertGroups/AlertGroupsPanel.test.tsx
+++ b/public/app/plugins/panel/alertGroups/AlertGroupsPanel.test.tsx
@@ -114,7 +114,7 @@ describe('AlertGroupsPanel', () => {
   });
 
   it('renders the panel with the groups', async () => {
-    await renderPanel();
+    renderPanel();
 
     await waitFor(() => expect(mocks.api.fetchAlertGroups).toHaveBeenCalled());
     const groups = ui.group.getAll();
@@ -129,7 +129,7 @@ describe('AlertGroupsPanel', () => {
   });
 
   it('renders panel with groups expanded', async () => {
-    await renderPanel({ labels: '', alertmanager: 'Alertmanager', expandAll: true });
+    renderPanel({ labels: '', alertmanager: 'Alertmanager', expandAll: true });
 
     await waitFor(() => expect(mocks.api.fetchAlertGroups).toHaveBeenCalled());
     const alerts = ui.alert.queryAll();
@@ -137,7 +137,7 @@ describe('AlertGroupsPanel', () => {
   });
 
   it('filters alerts by label filter', async () => {
-    await renderPanel({ labels: 'region=US-Central', alertmanager: 'Alertmanager', expandAll: true });
+    renderPanel({ labels: 'region=US-Central', alertmanager: 'Alertmanager', expandAll: true });
 
     await waitFor(() => expect(mocks.api.fetchAlertGroups).toHaveBeenCalled());
     const alerts = ui.alert.queryAll();

--- a/public/app/plugins/panel/alertlist/UnifiedalertList.test.tsx
+++ b/public/app/plugins/panel/alertlist/UnifiedalertList.test.tsx
@@ -78,7 +78,7 @@ const renderPanel = (options: UnifiedAlertListOptions = defaultOptions) => {
 
 describe('UnifiedAlertList', () => {
   it('subscribes to the dashboard refresh interval', async () => {
-    await renderPanel();
+    renderPanel();
     expect(dashboard.events.subscribe).toHaveBeenCalledTimes(1);
     expect(dashboard.events.subscribe.mock.calls[0][0]).toEqual(TimeRangeUpdatedEvent);
   });


### PR DESCRIPTION
# HERE BE DRAGONS

enables `@typescript-eslint/await-thenable` and fixes a few<sup>*</sup> errors. 

`@typescript-eslint/await-thenable` prevents us from awaiting non-thenable values, which may result in a bit of headaches especially when refactoring code and functions are not properly typed. in such cases most editors will soft-complain that what you are trying to `await` is not a promise and suggest to remove the `await`. but if the awaited value was wrongly typed as non thenable it may causes unwanted behaviour changes. ideally by enforcing this rule we'll indirectly force ourselves to use more strict types, especially for thunk, since quite a big chunks of the issues stem from using `ThunkResult<void>` instead of `ThunkResult<Promise<...>>`

Still wip, this is just a first pass. expect noise.

<sup>*</sup>Not really a few