### PR TITLE
Alerting: Show 'start typing' message in evaluation group folder in case of empty options.

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
@@ -1,11 +1,11 @@
 import { css } from '@emotion/css';
 import { debounce } from 'lodash';
-import React, { useState, useRef, useEffect, useCallback, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import { GrafanaTheme2, SelectableValue } from '@grafana/data';
 import { Stack } from '@grafana/experimental';
-import { AsyncSelect, Field, InputControl, Label, useStyles2, LoadingPlaceholder } from '@grafana/ui';
+import { AsyncSelect, Field, InputControl, Label, LoadingPlaceholder, useStyles2 } from '@grafana/ui';
 import { FolderPickerFilter } from 'app/core/components/Select/FolderPicker';
 import { contextSrv } from 'app/core/core';
 import { DashboardSearchHit } from 'app/features/search/types';
@@ -235,6 +235,7 @@ export function FolderAndGroup({ initialFolder }: FolderAndGroupProps) {
                 value={selectedGroup}
                 allowCustomValue
                 formatCreateLabel={(_) => '+ Add new '}
+                noOptionsMessage="Start typing to create evaluation group"
               />
             )
           }


### PR DESCRIPTION
**What is this feature?**

This PR shows the message `Start typing to create a new evaluation group` so users are not confused about how to create a new evaluation group in case of not having more options in the drop-down

**Why do we need this feature?**

Users need to clearly know how to create a new group.

**Who is this feature for?**

All users.

**Which issue(s) does this PR fix?**:
Fixes https://github.com/grafana/grafana/issues/62649

**Special notes for your reviewer**:

https://user-images.githubusercontent.com/33540275/215829323-a3fe00b3-756d-40c0-98a1-70cb8e615825.mp4



