### PR TITLE
DatasourceVariables: Update query editor when switching datasources from picker

### DIFF
--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -154,7 +154,7 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
 
     this.setState({
       datasource: datasource as unknown as DataSourceApi<TQuery>,
-      loadedDataSourceIdentifier: dataSourceIdentifier,
+      loadedDataSourceIdentifier: this.props.dataSource.rawRef?.uid ?? dataSourceIdentifier,
       hasTextEditMode: has(datasource, 'components.QueryCtrl.prototype.toggleEditorMode'),
     });
   }
@@ -181,8 +181,10 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
       }
     }
 
+    const newDataSourceIdentifier = this.props.dataSource.rawRef?.uid ?? this.getQueryDataSourceIdentifier();
+
     // check if we need to load another datasource
-    if (datasource && loadedDataSourceIdentifier !== this.getQueryDataSourceIdentifier()) {
+    if (datasource && newDataSourceIdentifier !== loadedDataSourceIdentifier) {
       if (this.angularQueryEditor) {
         this.angularQueryEditor.destroy();
         this.angularQueryEditor = null;
@@ -243,7 +245,7 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
   isWaitingForDatasourceToLoad(): boolean {
     // if we not yet have loaded the datasource in state the
     // ds in props and the ds in state will have different values.
-    return this.props.dataSource.uid !== this.state.loadedDataSourceIdentifier;
+    return (this.props.dataSource.rawRef?.uid ?? this.props.dataSource.uid) !== this.state.loadedDataSourceIdentifier;
   }
 
   renderPluginEditor = () => {


### PR DESCRIPTION
Fixes an issue (described here: #52737) where choosing a different instance of a datasource from a datasource variable picker wouldn't refresh the query editor as you might expect.

**Which issue(s) does this PR fix?**:
Closes #52737 #63904
