### PR TITLE
Alerting: Add support for "normal" as state filter in rule search

### DIFF
--- a/public/app/features/alerting/unified/search/rulesSearchParser.test.ts
+++ b/public/app/features/alerting/unified/search/rulesSearchParser.test.ts
@@ -35,6 +35,7 @@ describe('Alert rules searchParser', () => {
     it.each([
       { query: 'state:firing', expectedFilter: PromAlertingRuleState.Firing },
       { query: 'state:inactive', expectedFilter: PromAlertingRuleState.Inactive },
+      { query: 'state:normal', expectedFilter: PromAlertingRuleState.Inactive },
       { query: 'state:pending', expectedFilter: PromAlertingRuleState.Pending },
     ])('should parse $expectedFilter rule state filter from "$query" query', ({ query, expectedFilter }) => {
       const filter = getSearchFilterFromQuery(query);

--- a/public/app/features/alerting/unified/search/rulesSearchParser.ts
+++ b/public/app/features/alerting/unified/search/rulesSearchParser.ts
@@ -50,7 +50,7 @@ export function getSearchFilterFromQuery(query: string): RulesFilter {
     [terms.GroupToken]: (value) => (filter.groupName = value),
     [terms.RuleToken]: (value) => (filter.ruleName = value),
     [terms.LabelToken]: (value) => filter.labels.push(value),
-    [terms.StateToken]: (value) => (isPromAlertingRuleState(value) ? (filter.ruleState = value) : undefined),
+    [terms.StateToken]: (value) => (filter.ruleState = parseStateToken(value)),
     [terms.TypeToken]: (value) => (isPromRuleType(value) ? (filter.ruleType = value) : undefined),
     [terms.HealthToken]: (value) => (filter.ruleHealth = getRuleHealth(value)),
     [terms.FreeFormExpression]: (value) => filter.freeFormWords.push(value),
@@ -97,4 +97,16 @@ export function applySearchFilterToQuery(query: string, filter: RulesFilter): st
   }
 
   return applyFiltersToQuery(query, filterSupportedTerms, filterStateArray);
+}
+
+function parseStateToken(value: string): PromAlertingRuleState | undefined {
+  if (value === 'normal') {
+    return PromAlertingRuleState.Inactive;
+  }
+
+  if (isPromAlertingRuleState(value)) {
+    return value;
+  }
+
+  return;
 }


### PR DESCRIPTION
The in-product docs were listing "normal" as an accepted state filter instead of "inactive", this change makes it possible to accept both.

<img width="548" alt="image" src="https://user-images.githubusercontent.com/868844/215863813-d6c5e206-ad3b-4d83-95ae-63c41898081e.png">
