### PR TITLE
Geomap: Ensure options work while in table view

### DIFF
--- a/public/app/plugins/panel/geomap/GeomapPanel.tsx
+++ b/public/app/plugins/panel/geomap/GeomapPanel.tsx
@@ -82,6 +82,8 @@ export class GeomapPanel extends Component<Props, State> {
     for (const lyr of this.layers) {
       lyr.handler.dispose?.();
     }
+    // Ensure map is disposed
+    this.map?.dispose();
   }
 
   shouldComponentUpdate(nextProps: Props) {
@@ -183,15 +185,15 @@ export class GeomapPanel extends Component<Props, State> {
   }
 
   initMapRef = async (div: HTMLDivElement) => {
+    if (!div) {
+      // Do not initialize new map or dispose old map
+      return;
+    }
     this.mapDiv = div;
     if (this.map) {
       this.map.dispose();
     }
 
-    if (!div) {
-      this.map = undefined;
-      return;
-    }
     const { options } = this.props;
 
     const map = getNewOpenLayersMap(this, options, div);


### PR DESCRIPTION
What this PR does / why we need it:
Currently, in Geomap edit panel, while Table view is open, Map Layers and Basemap Layer options are unable to be changed. This can be especially frustrating if a user intends to reference the table view while setting up their layers.

Before:
![Jan-31-2023 12-01-12](https://user-images.githubusercontent.com/60050885/215869716-143e3455-d7ff-4707-a177-beff1b37d786.gif)

After:
![Jan-31-2023 11-57-58](https://user-images.githubusercontent.com/60050885/215869103-fcbcb813-e069-40a3-abeb-359fa2ce0fd4.gif)

Closes #59160