### PR TITLE
Cloudwatch: Fix log group variable interpolation

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/variables.ts
+++ b/public/app/plugins/datasource/cloudwatch/variables.ts
@@ -63,10 +63,11 @@ export class CloudWatchVariableSupport extends CustomVariableSupport<CloudWatchD
     }
   }
   async handleLogGroupsQuery({ region, logGroupPrefix }: VariableQuery) {
+    const interpolatedPrefix = this.resources.templateSrv.replace(logGroupPrefix);
     return this.resources
       .getLogGroups({
         region,
-        logGroupNamePrefix: logGroupPrefix,
+        logGroupNamePrefix: interpolatedPrefix,
         listAllLogGroups: true,
       })
       .then((logGroups) =>


### PR DESCRIPTION
Fixes a bug introduced in 9.2.0 where the LogGroupPrefix for a variable Log Group query isn't interpolated.


**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #62484 

**Special notes for your reviewer**:

