### PR TITLE
Alerting: Usability adjustments to Loki representation of state history values

### DIFF
--- a/pkg/services/ngalert/state/historian/core.go
+++ b/pkg/services/ngalert/state/historian/core.go
@@ -57,3 +57,10 @@ func parsePanelKey(rule history_model.RuleMeta, logger log.Logger) *panelKey {
 	}
 	return nil
 }
+
+func mergeLabels(base, into data.Labels) data.Labels {
+	for k, v := range into {
+		base[k] = v
+	}
+	return base
+}

--- a/pkg/services/ngalert/state/historian/loki.go
+++ b/pkg/services/ngalert/state/historian/loki.go
@@ -72,7 +72,7 @@ func (h *RemoteLokiBackend) statesToStreams(rule history_model.RuleMeta, states 
 			continue
 		}
 
-		labels := h.addExternalLabels(removePrivateLabels(state.State.Labels))
+		labels := mergeLabels(removePrivateLabels(state.State.Labels), h.externalLabels)
 		labels[OrgIDLabel] = fmt.Sprint(rule.OrgID)
 		labels[RuleUIDLabel] = fmt.Sprint(rule.UID)
 		labels[GroupLabel] = fmt.Sprint(rule.Group)
@@ -120,13 +120,6 @@ func (h *RemoteLokiBackend) recordStreams(ctx context.Context, streams []stream,
 	}
 	logger.Debug("Done saving alert state history batch")
 	return nil
-}
-
-func (h *RemoteLokiBackend) addExternalLabels(labels data.Labels) data.Labels {
-	for k, v := range h.externalLabels {
-		labels[k] = v
-	}
-	return labels
 }
 
 type lokiEntry struct {

--- a/pkg/services/ngalert/state/historian/loki.go
+++ b/pkg/services/ngalert/state/historian/loki.go
@@ -89,9 +89,6 @@ func statesToStreams(rule history_model.RuleMeta, states []state.StateTransition
 		if state.State.State == eval.Error {
 			entry.Error = state.Error.Error()
 		}
-		if state.State.State == eval.NoData {
-			entry.NoData = true
-		}
 
 		jsn, err := json.Marshal(entry)
 		if err != nil {
@@ -135,7 +132,6 @@ type lokiEntry struct {
 	Previous      string           `json:"previous"`
 	Current       string           `json:"current"`
 	Error         string           `json:"error,omitempty"`
-	NoData        bool             `json:"noData"`
 	Values        *simplejson.Json `json:"values"`
 	DashboardUID  string           `json:"dashboardUID"`
 	PanelID       int64            `json:"panelID"`

--- a/pkg/services/ngalert/state/historian/loki.go
+++ b/pkg/services/ngalert/state/historian/loki.go
@@ -83,6 +83,8 @@ func (h *RemoteLokiBackend) statesToStreams(rule history_model.RuleMeta, states 
 			Previous:      state.PreviousFormatted(),
 			Current:       state.Formatted(),
 			Values:        valuesAsDataBlob(state.State),
+			DashboardUID:  rule.DashboardUID,
+			PanelID:       rule.PanelID,
 		}
 		if state.State.State == eval.Error {
 			entry.Error = state.Error.Error()
@@ -132,9 +134,11 @@ type lokiEntry struct {
 	SchemaVersion int              `json:"schemaVersion"`
 	Previous      string           `json:"previous"`
 	Current       string           `json:"current"`
-	Error         string           `json:"error"`
+	Error         string           `json:"error,omitempty"`
 	NoData        bool             `json:"noData"`
 	Values        *simplejson.Json `json:"values"`
+	DashboardUID  string           `json:"dashboardUID"`
+	PanelID       int64            `json:"panelID"`
 }
 
 func valuesAsDataBlob(state *state.State) *simplejson.Json {

--- a/pkg/services/ngalert/state/historian/loki_test.go
+++ b/pkg/services/ngalert/state/historian/loki_test.go
@@ -1,0 +1,1 @@
+package historian

--- a/pkg/services/ngalert/state/historian/loki_test.go
+++ b/pkg/services/ngalert/state/historian/loki_test.go
@@ -1,1 +1,176 @@
 package historian
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/ngalert/eval"
+	"github.com/grafana/grafana/pkg/services/ngalert/state"
+	history_model "github.com/grafana/grafana/pkg/services/ngalert/state/historian/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRemoteLokiBackend(t *testing.T) {
+	t.Run("statesToStreams", func(t *testing.T) {
+		t.Run("skips non-transitory states", func(t *testing.T) {
+			rule := createTestRule()
+			l := log.NewNopLogger()
+			states := singleFromNormal(&state.State{State: eval.Normal})
+
+			res := statesToStreams(rule, states, nil, l)
+
+			require.Empty(t, res)
+		})
+
+		t.Run("maps evaluation errors", func(t *testing.T) {
+			rule := createTestRule()
+			l := log.NewNopLogger()
+			states := singleFromNormal(&state.State{State: eval.Error, Error: fmt.Errorf("oh no")})
+
+			res := statesToStreams(rule, states, nil, l)
+
+			entry := requireSingleEntry(t, res)
+			require.Contains(t, entry.Error, "oh no")
+		})
+
+		t.Run("maps NoData results", func(t *testing.T) {
+			rule := createTestRule()
+			l := log.NewNopLogger()
+			states := singleFromNormal(&state.State{State: eval.NoData})
+
+			res := statesToStreams(rule, states, nil, l)
+
+			entry := requireSingleEntry(t, res)
+			require.True(t, entry.NoData)
+		})
+
+		t.Run("produces expected stream identifier", func(t *testing.T) {
+			rule := createTestRule()
+			l := log.NewNopLogger()
+			states := singleFromNormal(&state.State{
+				State:  eval.Alerting,
+				Labels: data.Labels{"a": "b"},
+			})
+
+			res := statesToStreams(rule, states, nil, l)
+
+			require.Len(t, res, 1)
+			exp := map[string]string{
+				"folderUID": rule.NamespaceUID,
+				"group":     rule.Group,
+				"orgID":     fmt.Sprint(rule.OrgID),
+				"ruleUID":   rule.UID,
+				"a":         "b",
+			}
+			require.Equal(t, exp, res[0].Stream)
+		})
+
+		t.Run("groups streams based on combined labels", func(t *testing.T) {
+			rule := createTestRule()
+			l := log.NewNopLogger()
+			states := []state.StateTransition{
+				{
+					PreviousState: eval.Normal,
+					State: &state.State{
+						State:  eval.Alerting,
+						Labels: data.Labels{"a": "b"},
+					},
+				},
+				{
+					PreviousState: eval.Normal,
+					State: &state.State{
+						State:  eval.Alerting,
+						Labels: data.Labels{"a": "b"},
+					},
+				},
+				{
+					PreviousState: eval.Normal,
+					State: &state.State{
+						State:  eval.Alerting,
+						Labels: data.Labels{"c": "d"},
+					},
+				},
+			}
+
+			res := statesToStreams(rule, states, nil, l)
+
+			require.Len(t, res, 2)
+			sort.Slice(res, func(i, j int) bool { return len(res[i].Values) > len(res[j].Values) })
+			require.Contains(t, res[0].Stream, "a")
+			require.Len(t, res[0].Values, 2)
+			require.Contains(t, res[1].Stream, "c")
+			require.Len(t, res[1].Values, 1)
+		})
+
+		t.Run("excludes private labels", func(t *testing.T) {
+			rule := createTestRule()
+			l := log.NewNopLogger()
+			states := singleFromNormal(&state.State{
+				State:  eval.Alerting,
+				Labels: data.Labels{"__private__": "b"},
+			})
+
+			res := statesToStreams(rule, states, nil, l)
+
+			require.Len(t, res, 1)
+			require.NotContains(t, res[0].Stream, "__private__")
+		})
+
+		t.Run("serializes values when regular", func(t *testing.T) {
+			rule := createTestRule()
+			l := log.NewNopLogger()
+			states := singleFromNormal(&state.State{
+				State:  eval.Alerting,
+				Values: map[string]float64{"A": 2.0, "B": 5.5},
+			})
+
+			res := statesToStreams(rule, states, nil, l)
+
+			entry := requireSingleEntry(t, res)
+			require.NotNil(t, entry.Values)
+			require.NotNil(t, entry.Values.Get("A"))
+			require.NotNil(t, entry.Values.Get("B"))
+			require.InDelta(t, 2.0, entry.Values.Get("A").MustFloat64(), 1e-4)
+			require.InDelta(t, 5.5, entry.Values.Get("B").MustFloat64(), 1e-4)
+		})
+	})
+}
+
+func singleFromNormal(st *state.State) []state.StateTransition {
+	return []state.StateTransition{
+		{
+			PreviousState: eval.Normal,
+			State:         st,
+		},
+	}
+}
+
+func createTestRule() history_model.RuleMeta {
+	return history_model.RuleMeta{
+		OrgID:        1,
+		UID:          "rule-uid",
+		Group:        "my-group",
+		NamespaceUID: "my-folder",
+		DashboardUID: "dash-uid",
+		PanelID:      123,
+	}
+}
+
+func requireSingleEntry(t *testing.T, res []stream) lokiEntry {
+	require.Len(t, res, 1)
+	require.Len(t, res[0].Values, 1)
+	return requireEntry(t, res[0].Values[0])
+}
+
+func requireEntry(t *testing.T, row row) lokiEntry {
+	t.Helper()
+
+	var entry lokiEntry
+	err := json.Unmarshal([]byte(row.Val), &entry)
+	require.NoError(t, err)
+	return entry
+}

--- a/pkg/services/ngalert/state/historian/loki_test.go
+++ b/pkg/services/ngalert/state/historian/loki_test.go
@@ -44,8 +44,7 @@ func TestRemoteLokiBackend(t *testing.T) {
 
 			res := statesToStreams(rule, states, nil, l)
 
-			entry := requireSingleEntry(t, res)
-			require.True(t, entry.NoData)
+			_ = requireSingleEntry(t, res)
 		})
 
 		t.Run("produces expected stream identifier", func(t *testing.T) {


### PR DESCRIPTION
**What is this feature?**

These are a few minor changes to how we store data in state history that make querying easier.
- First-class NoData field rather than embedding it in values - NoData queries are more obvious.
- First-class Error field rather than embedding it in values - Queries for errors, and **filtering by specific errors** (!) are much easier.
- First-class dashUID and panelID fields to support the Dashboards query.
- Drop a layer of unnecessary nesting in the values blob.

Also adds tests covering this whole area.

**Why do we need this feature?**

Makes several common queries easier, more obvious, with more succinct LogQL.

**Who is this feature for?**

Users writing queries against state history + simplified canned queries for dashboards.

**Which issue(s) does this PR fix?**:

contrib: https://github.com/grafana/grafana/issues/48359

**Special notes for your reviewer**:

