### PR TITLE
PanelChrome: Adds display mode to support transparent option

### DIFF
--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.story.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.story.tsx
@@ -9,7 +9,7 @@ import { PanelChrome, PanelChromeProps } from '@grafana/ui';
 
 import { DashboardStoryCanvas } from '../../utils/storybook/DashboardStoryCanvas';
 import { withCenteredStory } from '../../utils/storybook/withCenteredStory';
-import { HorizontalGroup, VerticalGroup } from '../Layout/Layout';
+import { HorizontalGroup } from '../Layout/Layout';
 import { Menu } from '../Menu/Menu';
 
 const meta: ComponentMeta<typeof PanelChrome> = {
@@ -91,8 +91,8 @@ export const Examples = () => {
 
   return (
     <DashboardStoryCanvas>
-      <HorizontalGroup spacing="md" align="flex-start">
-        <VerticalGroup spacing="md">
+      <div>
+        <HorizontalGroup spacing="md" align="flex-start" wrap>
           {renderPanel('Has statusMessage', {
             title: 'Default title',
             statusMessage: 'Error text',
@@ -116,8 +116,7 @@ export const Examples = () => {
             title: 'Default title',
             loadingState: LoadingState.Loading,
           })}
-        </VerticalGroup>
-        <VerticalGroup spacing="md">
+
           {renderPanel('Default panel: no non-required props')}
           {renderPanel('No padding', {
             padding: 'none',
@@ -131,8 +130,7 @@ export const Examples = () => {
           {renderPanel('No title, loading loadingState', {
             loadingState: LoadingState.Loading,
           })}
-        </VerticalGroup>
-        <VerticalGroup spacing="md">
+
           {renderPanel('Error status, menu', {
             title: 'Default title',
             menu,
@@ -155,16 +153,11 @@ export const Examples = () => {
             menu,
             loadingState: LoadingState.Streaming,
           })}
-
           {renderPanel('loadingState is Loading, menu', {
             title: 'Default title',
             menu,
             loadingState: LoadingState.Loading,
           })}
-        </VerticalGroup>
-      </HorizontalGroup>
-      <HorizontalGroup spacing="md" align="flex-start">
-        <VerticalGroup spacing="md">
           {renderPanel('Deprecated error indicator', {
             title: 'Default title',
             leftItems: [
@@ -186,8 +179,6 @@ export const Examples = () => {
               />,
             ],
           })}
-        </VerticalGroup>
-        <VerticalGroup spacing="md">
           {renderPanel('Deprecated error indicator, menu', {
             title: 'Default title',
             menu,
@@ -199,8 +190,14 @@ export const Examples = () => {
               />,
             ],
           })}
-        </VerticalGroup>
-      </HorizontalGroup>
+          {renderPanel('Display mode = transparent', {
+            title: 'Default title',
+            displayMode: 'transparent',
+            menu,
+            leftItems: [],
+          })}
+        </HorizontalGroup>
+      </div>
     </DashboardStoryCanvas>
   );
 };

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -158,7 +158,7 @@ export function PanelChrome({
             </Dropdown>
           )}
 
-          {leftItems && <div className={styles.items}>{itemsRenderer(leftItems, (item) => item)}</div>}
+          {leftItems && <div className={styles.leftItems}>{itemsRenderer(leftItems, (item) => item)}</div>}
         </div>
 
         {statusMessage && (
@@ -214,7 +214,7 @@ const getContentStyle = (
 };
 
 const getStyles = (theme: GrafanaTheme2) => {
-  const { background, borderColor } = theme.components.panel;
+  const { background, borderColor, padding } = theme.components.panel;
 
   return {
     container: css({
@@ -255,7 +255,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       label: 'panel-header',
       display: 'flex',
       alignItems: 'center',
-      padding: theme.spacing(0, 0, 0, 1),
+      padding: theme.spacing(0, 0, 0, padding),
     }),
     streaming: css({
       label: 'panel-streaming',
@@ -294,6 +294,10 @@ const getStyles = (theme: GrafanaTheme2) => {
       position: 'absolute',
       left: '50%',
       transform: 'translateX(-50%)',
+    }),
+    leftItems: css({
+      display: 'flex',
+      paddingRight: theme.spacing(padding),
     }),
     rightAligned: css({
       label: 'right-aligned-container',

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -51,6 +51,7 @@ export interface PanelChromeProps {
    * of showing/interacting with the panel's state
    */
   leftItems?: ReactNode[];
+  displayMode?: 'default' | 'transparent';
 }
 
 /**
@@ -68,6 +69,7 @@ export function PanelChrome({
   padding = 'md',
   title = '',
   description = '',
+  displayMode = 'default',
   titleItems = [],
   menu,
   dragClass,
@@ -86,6 +88,7 @@ export function PanelChrome({
   //
   // Backwards compatibility for having a designated space for the header
 
+  // This logic is not working and needs to be moved outside (into PanelStateWrapper, and sent in as a prop)
   const hasHeader =
     hoverHeader === false &&
     (title.length > 0 ||
@@ -104,6 +107,11 @@ export function PanelChrome({
 
   const containerStyles: CSSProperties = { width, height };
   const ariaLabel = title ? selectors.components.Panels.Panel.containerByTitle(title) : 'Panel';
+
+  if (displayMode === 'transparent') {
+    containerStyles.backgroundColor = 'transparent';
+    containerStyles.border = 'none';
+  }
 
   return (
     <div className={styles.container} style={containerStyles} aria-label={ariaLabel}>

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -88,7 +88,6 @@ export function PanelChrome({
   //
   // Backwards compatibility for having a designated space for the header
 
-  // This logic is not working and needs to be moved outside (into PanelStateWrapper, and sent in as a prop)
   const hasHeader =
     hoverHeader === false &&
     (title.length > 0 ||

--- a/packages/grafana-ui/src/components/PanelChrome/TitleItem.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/TitleItem.tsx
@@ -50,7 +50,6 @@ const getStyles = (theme: GrafanaTheme2) => {
     item: css({
       color: `${theme.colors.text.secondary}`,
       label: 'panel-header-item',
-      backgroundColor: `${theme.colors.background.primary}`,
       cursor: 'auto',
       border: 'none',
       borderRadius: `${theme.shape.borderRadius()}`,

--- a/public/app/features/dashboard/dashgrid/PanelStateWrapper.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelStateWrapper.tsx
@@ -679,6 +679,7 @@ export class PanelStateWrapper extends PureComponent<Props, State> {
           dragClass={dragClass}
           dragClassCancel="grid-drag-cancel"
           padding={padding}
+          displayMode={transparent ? 'transparent' : 'default'}
         >
           {(innerWidth, innerHeight) => (
             <>


### PR DESCRIPTION
Sorry if this is work already started, just wanted to contribute a small thing that people noticed missing on ops. 

Adds
* `displayMode?: 'default' | 'transparent'`  prop (so we could potentially support more display modes with different backgrounds in the future)  
* Fixes issue in storybook where some examples where pushed down a lot (two HorizontalGroup which both had height 100%), changed to a single wrapping horizontal layout (easier to read code and have UI match the order in a horizontal left to right layout)  
* Adds new story example for displayMode transparent
* Fixes position of leftItems (was right at the edge of right side border, missing right side padding it had before)

The other bigger issue on ops is that the no header mode is not working (due to titleItems array always having length 1). think we should just use the hoverHeader prop and move the logic that sets hasHeader outside PanelChrome (but for a different PR) 

Fixes https://github.com/grafana/grafana/issues/61547