### PR TITLE
[v9.0.x] QueryEditorRow: Fixes issue loading query editor when data source variable selected

### DIFF
--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -57,8 +57,10 @@ interface Props<TQuery extends DataQuery> {
 }
 
 interface State<TQuery extends DataQuery> {
+  /** DatasourceUid or ds variable expression used to resolve current datasource */
   loadedDataSourceIdentifier?: string | null;
   datasource: DataSourceApi<TQuery> | null;
+  datasourceUid?: string | null;
   hasTextEditMode: boolean;
   data?: PanelData;
   isOpen?: boolean;
@@ -222,17 +224,17 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
     }
   }
 
-  waitingForDatasourceToLoad = (): boolean => {
+  isWaitingForDatasourceToLoad(): boolean {
     // if we not yet have loaded the datasource in state the
     // ds in props and the ds in state will have different values.
-    return this.props.dataSource.uid !== this.state.datasource?.uid;
-  };
+    return this.props.dataSource.uid !== this.state.loadedDataSourceIdentifier;
+  }
 
   renderPluginEditor = () => {
     const { query, onChange, queries, onRunQuery, app = CoreApp.PanelEditor, history } = this.props;
     const { datasource, data } = this.state;
 
-    if (this.waitingForDatasourceToLoad()) {
+    if (this.isWaitingForDatasourceToLoad()) {
       return null;
     }
 


### PR DESCRIPTION
Manual 
Backport https://github.com/grafana/grafana/commit/9f7ddf1f0b5234a1fd82e1f92d1444f81a794e45 from https://github.com/grafana/grafana/pull/61927