### PR TITLE
Nested folders: don't overwrite existing entries in folder table for sqlite

### DIFF
--- a/pkg/services/folder/folderimpl/folder.go
+++ b/pkg/services/folder/folderimpl/folder.go
@@ -72,7 +72,7 @@ func (s *Service) DBMigration(db db.DB) {
 	err := db.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
 		var err error
 		if db.GetDialect().DriverName() == migrator.SQLite {
-			_, err = sess.Exec("INSERT OR REPLACE INTO folder (id, uid, org_id, title, created, updated) SELECT id, uid, org_id, title, created, updated FROM dashboard WHERE is_folder = 1")
+			_, err = sess.Exec("INSERT OR IGNORE INTO folder (id, uid, org_id, title, created, updated) SELECT id, uid, org_id, title, created, updated FROM dashboard WHERE is_folder = 1")
 		} else if db.GetDialect().DriverName() == migrator.Postgres {
 			_, err = sess.Exec("INSERT INTO folder (id, uid, org_id, title, created, updated) SELECT id, uid, org_id, title, created, updated FROM dashboard WHERE is_folder = true ON CONFLICT DO NOTHING")
 		} else {


### PR DESCRIPTION
**What is this feature?**

Currently, if you use sqlite whenever Grafana is restarted, the existing folder entries in the folder table will lose the link to their parents. This is because we always replace the entries with folder info from the dashboard table (which does not keep track of folder parents).

This PR changes the migration not to overwrite existing folder entries for sqlite. This is also in line with the logic for postgres and mysql migrations.

**Who is this feature for?**

People doing nested folder development.

**Special notes for your reviewer**:

Let me know if there's a reason for the migration being as it is, I might be missing some context.