### PR TITLE
Command palette: section styling tweaks

### DIFF
--- a/public/app/features/commandPalette/CommandPalette.tsx
+++ b/public/app/features/commandPalette/CommandPalette.tsx
@@ -166,14 +166,15 @@ const getSearchStyles = (theme: GrafanaTheme2) => {
       paddingBottom: theme.spacing(1),
     }),
     sectionHeader: css({
-      padding: theme.spacing(1.5, 2, 1, 2),
+      padding: theme.spacing(1.5, 2, 2, 2),
       fontSize: theme.typography.bodySmall.fontSize,
       fontWeight: theme.typography.fontWeightMedium,
-      color: theme.colors.text.primary,
+      color: theme.colors.text.secondary,
       borderTop: `1px solid ${theme.colors.border.weak}`,
       marginTop: theme.spacing(1),
     }),
     sectionHeaderFirst: css({
+      paddingBottom: theme.spacing(1),
       borderTop: 'none',
       marginTop: 0,
     }),


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- fixes the spacing on section headers
  - section headers after the first are too close to the items (see `Pages` in before/after)
- knocks back the section header text to secondary
  - this is more personal preference but i think with primary they're still a little too visually similar to the clickable items. given we already give ancestors secondary color, feels like we can make section headers secondary as well

| | before | after |
| --- | --- | --- |
| dark | ![image](https://user-images.githubusercontent.com/20999846/216035278-81ef7251-5175-40b7-bbc3-2055086a92a6.png) | ![image](https://user-images.githubusercontent.com/20999846/216035120-0dd7dafd-eed2-4c31-a923-0c0abedc3943.png) |
| light | ![image](https://user-images.githubusercontent.com/20999846/216036052-65291a6a-d73b-46ca-b665-dd0b0e8af2b8.png) | ![image](https://user-images.githubusercontent.com/20999846/216036190-bd4c22fa-df46-4b74-ac9b-edd154802d31.png) |


**Why do we need this feature?**

- clearer separation between section headers and clickable items

**Who is this feature for?**

- anyone using command palette

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

