### PR TITLE
Search: Fix alignment of checkbox in folder view

### DIFF
--- a/packages/grafana-ui/src/components/Forms/Checkbox.tsx
+++ b/packages/grafana-ui/src/components/Forms/Checkbox.tsx
@@ -59,7 +59,7 @@ export const getCheckboxStyles = stylesFactory((theme: GrafanaTheme2) => {
 
   return {
     wrapper: css`
-      display: flex;
+      display: inline-flex;
       gap: ${theme.spacing(labelPadding)};
       align-items: baseline;
       position: relative;

--- a/public/app/features/search/page/components/FolderSection.tsx
+++ b/public/app/features/search/page/components/FolderSection.tsx
@@ -173,7 +173,7 @@ export const FolderSection = ({
       label={
         <>
           {selectionToggle && selection && (
-            <div className={styles.checkbox} onClick={onToggleFolder}>
+            <div onClick={onToggleFolder}>
               <Checkbox value={selection(section.kind, section.uid)} aria-label="Select folder" />
             </div>
           )}
@@ -228,9 +228,6 @@ const getSectionHeaderStyles = (theme: GrafanaTheme2, selected = false, editable
     ),
     sectionItems: css`
       margin: 0 24px 0 32px;
-    `,
-    checkbox: css`
-      padding: 0 ${sm} 0 0;
     `,
     icon: css`
       padding: 0 ${sm} 0 ${editable ? 0 : sm};


### PR DESCRIPTION
**What is this feature?**

From [this PR](https://github.com/grafana/grafana/pull/61929) the checkbox alignment in search has been not right, this fixes that alignment.

Before:
<img width="134" alt="Screenshot 2023-02-01 at 12 29 49" src="https://user-images.githubusercontent.com/100691367/216042792-503d462a-7af4-4e9a-b6f8-bb668a9b8284.png">

After:
<img width="144" alt="Screenshot 2023-02-01 at 12 30 04" src="https://user-images.githubusercontent.com/100691367/216042902-c7a7b152-98e6-4220-ae4a-316f5806937a.png">

**Why do we need this feature?**

So that the checkbox is aligned correctly.

**Who is this feature for?**

Everyone
