### PR TITLE
[v9.2.x] docs: deleted link to moved content

### DIFF
--- a/docs/sources/dashboards/manage-dashboards/index.md
+++ b/docs/sources/dashboards/manage-dashboards/index.md
@@ -36,7 +36,6 @@ This topic includes techniques you can use to manage your Grafana dashboards, in
 
 - [Creating and managing dashboard folders](#create-and-manage-dashboard-folders)
 - [Exporting and importing dashboards](#export-and-import-dashboards)
-- [Configuring dashboard time range controls](#configure-dashboard-time-range-controls)
 - [Organizing dashboards](#organize-a-dashboard)
 - [Troubleshooting dashboards](#troubleshoot-dashboards)
 


### PR DESCRIPTION
Deleting old anchored link to moved content.


Fixes #59515 
