### PR TITLE
[v9.0.x] docs: update broken elasticsearch metrics play link

### DIFF
--- a/docs/sources/variables/variable-examples.md
+++ b/docs/sources/variables/variable-examples.md
@@ -14,7 +14,7 @@ weight: 200
 
 This page contains links to dashboards in Grafana Play with examples of template variables.
 
-- [Elasticsearch Metrics](https://play.grafana.org/d/000000014/elasticsearch-metrics?orgId=1) - Uses ad hoc filters, global variables, and a custom variable.
+- [Elasticsearch Metrics](https://play.grafana.org/d/z8OZC66nk/elasticsearch-8-2-0-sample-flight-data?orgId=1) - Uses ad hoc filters, global variables, and a custom variable.
 - [Graphite Templated Nested](https://play.grafana.org/d/000000056/graphite-templated-nested?orgId=1) - Uses query variables, chained query variables, an interval variable, and a repeated panel.
 - [Influx DB Group By Variable](https://play.grafana.org/d/000000137/influxdb-group-by-variable?orgId=1) - Query variable, panel uses the variable results to group the metric data.
 - [InfluxDB Raw Query Template Var](https://play.grafana.org/d/000000083/influxdb-raw-query-template-var?orgId=1) - Uses query variables, chained query variables, and an interval variable.


### PR DESCRIPTION
Fixes link in v9.0, 8.4, and 8.3 to Elasticsearch metrics variable example in Grafana Play.