### PR TITLE
Cloudwatch: Fix log group variable interpolation (#62640)

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/variables.ts
+++ b/public/app/plugins/datasource/cloudwatch/variables.ts
@@ -62,10 +62,11 @@ export class CloudWatchVariableSupport extends CustomVariableSupport<CloudWatchD
     }
   }
   async handleLogGroupsQuery({ region, logGroupPrefix }: VariableQuery) {
+    const interpolatedPrefix = this.api.templateSrv.replace(logGroupPrefix);
     return this.api
       .describeAllLogGroups({
         region,
-        logGroupNamePrefix: logGroupPrefix,
+        logGroupNamePrefix: interpolatedPrefix,
       })
       .then((logGroups) => logGroups.map(selectableValueToMetricFindOption));
   }


### PR DESCRIPTION
Switches getLogGroups -> describeAllLogGroups for the older function calls

