### PR TITLE
Dataplane: Support timeSeriesLong without transform

### DIFF
--- a/public/app/features/dashboard/dashgrid/PanelStateWrapper.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelStateWrapper.tsx
@@ -41,6 +41,7 @@ import { applyPanelTimeOverrides } from 'app/features/dashboard/utils/panel';
 import { InspectTab } from 'app/features/inspector/types';
 import { getPanelLinksSupplier } from 'app/features/panel/panellinks/linkSuppliers';
 import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
+import { partitionByValuesTransformer } from 'app/features/transformers/partitionByValues/partitionByValues';
 import { applyFilterFromTable } from 'app/features/variables/adhoc/actions';
 import { changeSeriesColorConfigFactory } from 'app/plugins/panel/timeseries/overrides/colorSeriesConfigFactory';
 import { dispatch } from 'app/store/store';
@@ -488,6 +489,27 @@ export class PanelStateWrapper extends PureComponent<Props, State> {
     // Yes this is called ever render for a function that is triggered on every mouse move
     this.eventFilter.onlyLocal = dashboard.graphTooltip === 0;
 
+    if (PanelComponent.name === 'TimeSeriesPanel' && data.series.every((df) => df.meta?.type === 'timeseries-long')) {
+      const stringFields = data.series[0].fields.filter((field) => field.type === 'string').map((field) => field.name);
+
+      const options = {
+        fields: stringFields,
+        naming: {
+          asLabels: true,
+          append: false,
+          withNames: false,
+          separator1: '=',
+          separator2: ' ',
+        },
+      };
+
+      const ctx = {
+        interpolate: (value: string) => value,
+      };
+
+      data.series = partitionByValuesTransformer.transformer(options, ctx)(data.series);
+    }
+
     return (
       <>
         <PanelContextProvider value={this.state.context}>
@@ -548,6 +570,27 @@ export class PanelStateWrapper extends PureComponent<Props, State> {
     this.eventFilter.onlyLocal = dashboard.graphTooltip === 0;
 
     const timeZone = this.props.timezone || this.props.dashboard.getTimezone();
+
+    if (PanelComponent.name === 'TimeSeriesPanel' && data.series.every((df) => df.meta?.type === 'timeseries-long')) {
+      const stringFields = data.series[0].fields.filter((field) => field.type === 'string').map((field) => field.name);
+
+      const options = {
+        fields: stringFields,
+        naming: {
+          asLabels: true,
+          append: false,
+          withNames: false,
+          separator1: '=',
+          separator2: ' ',
+        },
+      };
+
+      const ctx = {
+        interpolate: (value: string) => value,
+      };
+
+      data.series = partitionByValuesTransformer.transformer(options, ctx)(data.series);
+    }
 
     return (
       <>

--- a/public/app/features/dashboard/dashgrid/PanelStateWrapper.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelStateWrapper.tsx
@@ -41,7 +41,6 @@ import { applyPanelTimeOverrides } from 'app/features/dashboard/utils/panel';
 import { InspectTab } from 'app/features/inspector/types';
 import { getPanelLinksSupplier } from 'app/features/panel/panellinks/linkSuppliers';
 import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
-import { partitionByValuesTransformer } from 'app/features/transformers/partitionByValues/partitionByValues';
 import { applyFilterFromTable } from 'app/features/variables/adhoc/actions';
 import { changeSeriesColorConfigFactory } from 'app/plugins/panel/timeseries/overrides/colorSeriesConfigFactory';
 import { dispatch } from 'app/store/store';
@@ -489,27 +488,6 @@ export class PanelStateWrapper extends PureComponent<Props, State> {
     // Yes this is called ever render for a function that is triggered on every mouse move
     this.eventFilter.onlyLocal = dashboard.graphTooltip === 0;
 
-    if (PanelComponent.name === 'TimeSeriesPanel' && data.series.every((df) => df.meta?.type === 'timeseries-long')) {
-      const stringFields = data.series[0].fields.filter((field) => field.type === 'string').map((field) => field.name);
-
-      const options = {
-        fields: stringFields,
-        naming: {
-          asLabels: true,
-          append: false,
-          withNames: false,
-          separator1: '=',
-          separator2: ' ',
-        },
-      };
-
-      const ctx = {
-        interpolate: (value: string) => value,
-      };
-
-      data.series = partitionByValuesTransformer.transformer(options, ctx)(data.series);
-    }
-
     return (
       <>
         <PanelContextProvider value={this.state.context}>
@@ -570,27 +548,6 @@ export class PanelStateWrapper extends PureComponent<Props, State> {
     this.eventFilter.onlyLocal = dashboard.graphTooltip === 0;
 
     const timeZone = this.props.timezone || this.props.dashboard.getTimezone();
-
-    if (PanelComponent.name === 'TimeSeriesPanel' && data.series.every((df) => df.meta?.type === 'timeseries-long')) {
-      const stringFields = data.series[0].fields.filter((field) => field.type === 'string').map((field) => field.name);
-
-      const options = {
-        fields: stringFields,
-        naming: {
-          asLabels: true,
-          append: false,
-          withNames: false,
-          separator1: '=',
-          separator2: ' ',
-        },
-      };
-
-      const ctx = {
-        interpolate: (value: string) => value,
-      };
-
-      data.series = partitionByValuesTransformer.transformer(options, ctx)(data.series);
-    }
 
     return (
       <>

--- a/public/app/plugins/panel/timeseries/utils.ts
+++ b/public/app/plugins/panel/timeseries/utils.ts
@@ -189,16 +189,7 @@ export function prepareTimeSeriesLong(series: DataFrame[]): DataFrame[] {
 
     // transform one dataFrame at a time and concat into DataFrame[]
     const transformedSeries = partitionByValuesTransformer.transformer(
-      {
-        fields: stringFields,
-        naming: {
-          asLabels: true,
-          append: false,
-          withNames: false,
-          separator1: '=',
-          separator2: ' ',
-        },
-      },
+      { fields: stringFields },
       { interpolate: (value: string) => value }
     )([dataFrame]);
 

--- a/public/app/plugins/panel/timeseries/utils.ts
+++ b/public/app/plugins/panel/timeseries/utils.ts
@@ -1,6 +1,7 @@
 import {
   ArrayVector,
   DataFrame,
+  DataFrameType,
   Field,
   FieldType,
   getDisplayProcessor,
@@ -28,7 +29,7 @@ export function prepareGraphableFields(
     return null;
   }
 
-  if (series.every((df) => df.meta?.type === 'timeseries-long')) {
+  if (series.every((df) => df.meta?.type === DataFrameType.TimeSeriesLong)) {
     series = prepareTimeSeriesLong(series);
   }
 
@@ -180,22 +181,23 @@ export function regenerateLinksSupplier(
 }
 
 export function prepareTimeSeriesLong(series: DataFrame[]): DataFrame[] {
-  const stringFields = series[0].fields.filter((field) => field.type === 'string').map((field) => field.name);
-
-  const options = {
-    fields: stringFields,
-    naming: {
-      asLabels: true,
-      append: false,
-      withNames: false,
-      separator1: '=',
-      separator2: ' ',
-    },
-  };
+  const stringFields = series[0].fields.filter((field) => field.type === FieldType.string).map((field) => field.name);
 
   const ctx = {
     interpolate: (value: string) => value,
   };
 
-  return partitionByValuesTransformer.transformer(options, ctx)(series);
+  return partitionByValuesTransformer.transformer(
+    {
+      fields: stringFields,
+      naming: {
+        asLabels: true,
+        append: false,
+        withNames: false,
+        separator1: '=',
+        separator2: ' ',
+      },
+    },
+    ctx
+  )(series);
 }


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/57543

This work is part of the Dataplane project and is a WIP.

**What is this feature?**
This work applies a transform automatically to data of type [TimeSeriesLong](https://github.com/grafana/grafana-plugin-sdk-go/blob/main/data/contract_docs/timeseries.md#time-series-long-format-timeserieslong-sql-like) when viewed in a Time Series panel. The transformation applied partitions rows based on fields of type string and uses these as labels for the numeric fields.

**Who is this feature for?**
This feature is for anyone who is using a tabular datasource like SQL and is applying a transform to visualize the data as time series.

**Why do we need this feature?**
If a series is of type [TimeSeriesLong](https://github.com/grafana/grafana-plugin-sdk-go/blob/main/data/contract_docs/timeseries.md#time-series-long-format-timeserieslong-sql-like) it requires a transformation. If it has fields of type string these fields could be represented as labels for fields of numeric data. We don't want users to have to apply a transformation themselves.

TimeSeriesLong not supported
<img width="1285" alt="Screen Shot 2023-02-01 at 5 04 39 PM" src="https://user-images.githubusercontent.com/25674746/216176108-28ee5336-b822-42e0-af80-1322a2e6cc1f.png">

TimeSeriesLong, supported, partitioned with labels
<img width="1329" alt="Screen Shot 2023-02-01 at 5 01 50 PM" src="https://user-images.githubusercontent.com/25674746/216176081-591ec706-2925-4b3c-bcec-5f045b550909.png">

Use this debug snapshot to test
[debug-Panel Title-2023-02-24 17_37_52.json.txt](https://github.com/grafana/grafana/files/10829255/debug-Panel.Title-2023-02-24.17_37_52.json.txt)
