### PR TITLE
bug: adjust table footer height calculations

### DIFF
--- a/packages/grafana-ui/src/components/Table/Table.tsx
+++ b/packages/grafana-ui/src/components/Table/Table.tsx
@@ -34,6 +34,7 @@ import {
 } from './utils';
 
 const COLUMN_MIN_WIDTH = 150;
+const FOOTER_ROW_HEIGHT = 36;
 
 export const Table = memo((props: Props) => {
   const {
@@ -63,25 +64,12 @@ export const Table = memo((props: Props) => {
   const [footerItems, setFooterItems] = useState<FooterItem[] | undefined>(footerValues);
 
   const footerHeight = useMemo(() => {
-    const EXTENDED_ROW_HEIGHT = headerHeight;
-    let length = 0;
-
-    if (!footerItems) {
+    if (!footerItems?.length) {
       return 0;
     }
 
-    for (const fv of footerItems) {
-      if (Array.isArray(fv) && fv.length > length) {
-        length = fv.length;
-      }
-    }
-
-    if (length > 1) {
-      return EXTENDED_ROW_HEIGHT * length;
-    }
-
-    return EXTENDED_ROW_HEIGHT;
-  }, [footerItems, headerHeight]);
+    return FOOTER_ROW_HEIGHT;
+  }, [footerItems]);
 
   // React table data array. This data acts just like a dummy array to let react-table know how many rows exist
   // The cells use the field to look up values

--- a/packages/grafana-ui/src/components/Table/Table.tsx
+++ b/packages/grafana-ui/src/components/Table/Table.tsx
@@ -64,11 +64,24 @@ export const Table = memo((props: Props) => {
   const [footerItems, setFooterItems] = useState<FooterItem[] | undefined>(footerValues);
 
   const footerHeight = useMemo(() => {
-    if (!footerItems?.length) {
+    const EXTENDED_ROW_HEIGHT = FOOTER_ROW_HEIGHT;
+    let length = 0;
+
+    if (!footerItems) {
       return 0;
     }
 
-    return FOOTER_ROW_HEIGHT;
+    for (const fv of footerItems) {
+      if (Array.isArray(fv) && fv.length > length) {
+        length = fv.length;
+      }
+    }
+
+    if (length > 1) {
+      return EXTENDED_ROW_HEIGHT * length;
+    }
+
+    return EXTENDED_ROW_HEIGHT;
   }, [footerItems]);
 
   // React table data array. This data acts just like a dummy array to let react-table know how many rows exist


### PR DESCRIPTION
**What is this feature?**

Table height was being incorrectly calculated, and therefore the footer was rendering over table rows. This fixes that.

**Why do we need this feature?**

Bugs are bad, m'kay?

**Who is this feature for?**

Everyone

**Which issue(s) does this PR fix?**:
Fixes #62410

**Special notes for your reviewer**:
<img width="1920" alt="Screenshot 2023-02-01 at 4 32 30 PM (2)" src="https://user-images.githubusercontent.com/46619047/216192120-4ffe27b0-f0ac-4c66-a9a3-ca820ea28786.png">
What it was ^^^

<img width="1920" alt="Screenshot 2023-02-01 at 4 31 54 PM (2)" src="https://user-images.githubusercontent.com/46619047/216192189-1e2e6293-d629-4ef4-ba05-555903faee22.png">
The fix ^^^
