### PR TITLE
Alerting docs: updates to alert rules docs for 9.4

### DIFF
--- a/docs/sources/alerting/alerting-rules/create-grafana-managed-rule.md
+++ b/docs/sources/alerting/alerting-rules/create-grafana-managed-rule.md
@@ -31,12 +31,18 @@ Watch this video to learn more about creating alerts: {{< vimeo 720001934 >}}
    - Click **Run queries** to verify that the query is successful.
    - Next, select the query or expression for your alert condition.
 1. In Step 3, specify the alert evaluation interval.
+
    - From the **Condition** drop-down, select the query or expression to trigger the alert rule.
    - For **Evaluate every**, specify the frequency of evaluation. Must be a multiple of 10 seconds. For examples, `1m`, `30s`.
    - For **Evaluate for**, specify the duration for which the condition must be true before an alert fires.
      > **Note:** Once a condition is breached, the alert goes into the Pending state. If the condition remains breached for the duration specified, the alert transitions to the `Firing` state, otherwise it reverts back to the `Normal` state.
    - In **Configure no data and error handling**, configure alerting behavior in the absence of data. Use the guidelines in [No data and error handling](#no-data-and-error-handling).
    - Click **Preview alerts** to check the result of running the query at this moment. Preview excludes no data and error handling.
+
+     **Note:**
+
+     You can pause alert rule evaluation to prevent noisy alerting while tuning your alerts. Pausing stops alert rule evaluation and does not create any alert instances. This is different to mute timings, which stop notifications from being delivered, but still allow for alert rule evaluation and the creation of alert instances.
+
 1. In Step 4, add the storage location, rule group, as well as additional metadata associated with the rule.
    - From the **Folder** drop-down, select the folder where you want to store the rule.
    - For **Group**, specify a pre-defined group. Newly created rules are appended to the end of the group. Rules within a group are run sequentially at a regular interval, with the same evaluation time.

--- a/docs/sources/alerting/alerting-rules/declare-incident-from-alert.md
+++ b/docs/sources/alerting/alerting-rules/declare-incident-from-alert.md
@@ -9,7 +9,7 @@ title: Declare an incident from a firing alert
 weight: 430
 ---
 
-# Declare an incident from a firing alert
+# Declare incidents from firing alerts
 
 Declare an incident from a firing alert to streamline your alert to incident workflow.
 

--- a/docs/sources/alerting/alerting-rules/view-alert-rules.md
+++ b/docs/sources/alerting/alerting-rules/view-alert-rules.md
@@ -20,8 +20,11 @@ The Alerting page lists all existing alert rules. By default, rules are grouped 
 
 The Mimir/Cortex/Loki rules section lists all rules for Mimir, Cortex, or Loki data sources. Cloud alert rules are also listed in this section.
 
+When managing large volumes of alerts, you can use extended alert rule search capabilities to filter on folders, evaluation groups, and rules. Additionally, you can filter alert rules by their properties like labels, state, type, and health.
+
 - [View and filter alert rules](#view-and-filter-alert-rules)
   - [View alert rules](#view-alert-rules)
+  - [Export alert rules](#export-alert-rules)
     - [Grouped view](#grouped-view)
     - [State view](#state-view)
   - [Filter alert rules](#filter-alert-rules)
@@ -35,6 +38,14 @@ To view alerting details:
 1. Expand the rule row to view the rule labels, annotations, data sources the rule queries, and a list of alert instances resulting from this rule.
 
 {{< figure src="/static/img/docs/alerting/unified/rule-details-8-0.png" max-width="650px" caption="Alerting rule details" >}}
+
+From the Alert list page, you can also make copies of alert rules to help you reuse existing alert rules.
+
+## Export alert rules
+
+Click **Export** to create and tune an alert rule in the UI, then export to YAML or JSON, and use in the provisioning API or files. You can also export an entire rule group to review or use.
+
+**Note:** This is supported in both the UI and provisioning API.
 
 ### Grouped view
 

--- a/docs/sources/alerting/alerting-rules/view-alert-rules.md
+++ b/docs/sources/alerting/alerting-rules/view-alert-rules.md
@@ -25,6 +25,7 @@ When managing large volumes of alerts, you can use extended alert rule search ca
 - [View and filter alert rules](#view-and-filter-alert-rules)
   - [View alert rules](#view-alert-rules)
   - [Export alert rules](#export-alert-rules)
+  - [View query definitions for provisioned alerts](#view-query-definitions-for-provisioned-alerts)
     - [Grouped view](#grouped-view)
     - [State view](#state-view)
   - [Filter alert rules](#filter-alert-rules)
@@ -46,6 +47,10 @@ From the Alert list page, you can also make copies of alert rules to help you re
 Click **Export** to create and tune an alert rule in the UI, then export to YAML or JSON, and use in the provisioning API or files. You can also export an entire rule group to review or use.
 
 **Note:** This is supported in both the UI and provisioning API.
+
+## View query definitions for provisioned alerts
+
+View read-only query definitions for provisioned alerts. Check quickly if your alert rule queries are correct, without diving into your "as-code" repository for rule definitions.
 
 ### Grouped view
 

--- a/docs/sources/alerting/fundamentals/contact-points/index.md
+++ b/docs/sources/alerting/fundamentals/contact-points/index.md
@@ -21,6 +21,10 @@ Use contact points to define how your contacts are notified when an alert rule f
 
 You can also use notification templating to customize notification messages for contact point types.
 
+**Note:**
+
+If you've created an OnCall contact point in the Grafana OnCall application, you can view it in the Alerting application.
+
 ## Supported contact point types
 
 The following table lists the contact point types supported by Grafana.


### PR DESCRIPTION
Updates declare incident title to make it plural

Adds 9.4 features to alert rules doc: making copies, export alert rules, and enhanced search.