### PR TITLE
[opentsdb] Allow custom tag key in OpenTSDB Query editor

### DIFF
--- a/public/app/plugins/datasource/opentsdb/components/TagSection.tsx
+++ b/public/app/plugins/datasource/opentsdb/components/TagSection.tsx
@@ -149,6 +149,7 @@ export function TagSection({
               className="gf-form-input"
               value={curTagKey ? toOption('' + curTagKey) : undefined}
               placeholder="key"
+              allowCustomValue
               onOpenMenu={async () => {
                 updKeyIsLoading(true);
                 const tKs = await suggestTagKeys(query);


### PR DESCRIPTION
**What is this feature?**

BUGFIX in OpenTSDB tags query editor. 

**Why do we need this feature?**

Before angular to react rewrite of the OpenTSDB editor, a custom value for tag key was allowed. This PR restore this behavior

**Who is this feature for?**

OpenTSDB query editor users

