### PR TITLE
Connections: Fix route-guards

### DIFF
--- a/public/app/features/connections/Connections.test.tsx
+++ b/public/app/features/connections/Connections.test.tsx
@@ -103,9 +103,7 @@ describe('Connections', () => {
     renderPage(ROUTES.ConnectData, store);
 
     // We expect not to see the text that would be rendered by the core "Connect data" page
-    // (Instead we expect to see the default route "Datasources")
-    expect(await screen.findByText('Datasources')).toBeVisible();
-    expect(await screen.findByText('Manage your existing datasource connections')).toBeVisible();
+    expect(screen.queryByText('Data sources')).not.toBeInTheDocument();
     expect(screen.queryByText('No results matching your query were found.')).not.toBeInTheDocument();
   });
 });

--- a/public/app/features/connections/Connections.tsx
+++ b/public/app/features/connections/Connections.tsx
@@ -29,21 +29,25 @@ export default function Connections() {
       }}
     >
       <Switch>
-        <Route exact path={ROUTES.Base} component={() => <Redirect to={ROUTES.ConnectData} />} />
+        {/* Redirect to "Connect data" by default */}
+        <Route exact sensitive path={ROUTES.Base} component={() => <Redirect to={ROUTES.ConnectData} />} />
         <Route
           exact
+          sensitive
           path={ROUTES.YourConnections}
           component={() => <NavLandingPage navId="connections-your-connections" />}
         />
-        <Route exact path={ROUTES.DataSources} component={DataSourcesListPage} />
-        <Route exact path={ROUTES.DataSourcesDetails} component={DataSourceDetailsPage} />
-        <Route exact path={ROUTES.DataSourcesNew} component={NewDataSourcePage} />
-        <Route exact path={ROUTES.DataSourcesEdit} component={EditDataSourcePage} />
-        <Route exact path={ROUTES.DataSourcesDashboards} component={DataSourceDashboardsPage} />
-        {!isConnectDataPageOverriden && <Route path={ROUTES.ConnectData} component={ConnectDataPage} />}
+        <Route exact sensitive path={ROUTES.DataSources} component={DataSourcesListPage} />
+        <Route exact sensitive path={ROUTES.DataSourcesDetails} component={DataSourceDetailsPage} />
+        <Route exact sensitive path={ROUTES.DataSourcesNew} component={NewDataSourcePage} />
+        <Route exact sensitive path={ROUTES.DataSourcesEdit} component={EditDataSourcePage} />
+        <Route exact sensitive path={ROUTES.DataSourcesDashboards} component={DataSourceDashboardsPage} />
 
-        {/* Default page */}
-        <Route component={DataSourcesListPage} />
+        {/* "Connect data" page - we don't register a route in case a plugin already registers a standalone page for it */}
+        {!isConnectDataPageOverriden && <Route exact sensitive path={ROUTES.ConnectData} component={ConnectDataPage} />}
+
+        {/* Not found */}
+        <Route component={() => <Redirect to="/notfound" />} />
       </Switch>
     </DataSourcesRoutesContext.Provider>
   );


### PR DESCRIPTION
Fixes https://github.com/grafana/cloud-onboarding/issues/3176

### What changed and why?

The backend route-guards in [api.go](https://github.com/grafana/grafana/blob/6c5a5737721914cdce87bf27990a89e0fe6d47cb/pkg/api/api.go#L133) are case-sensitive, while the frontend routes were case-insensitive. This was causing the FE routes to serve the "protected" routes in case they were accessed with any capital letters in the URL, e.g. `/Connections` vs `/connections`. 

This PR is fixing the issue by adding the `sensitive` prop to the routes, which makes them being case-sensitive.

|  **Before**  |    **After**    |
|--------------|-----------------|
|  ![Screenshot 2023-02-02 at 12 36 39](https://user-images.githubusercontent.com/9974811/216315328-6aa341ae-44b0-4cfb-b710-53fd335ce12c.png) | ![Screenshot 2023-02-02 at 12 36 01](https://user-images.githubusercontent.com/9974811/216315352-e70a1d17-0a5e-465f-b9ca-02c58f86e62f.png) |

**Notes to the reviewer**
When we update `react-router` to `v6.x` we will need to rename this prop to `caseSensitive` ([link](https://reactrouter.com/en/main/route/route#casesensitive)).
