### PR TITLE
Plugins: Case-sensitive routes for standalone pages

### DIFF
--- a/public/app/AppWrapper.tsx
+++ b/public/app/AppWrapper.tsx
@@ -58,6 +58,7 @@ export class AppWrapper extends React.Component<AppWrapperProps, AppWrapperState
     return (
       <Route
         exact={route.exact === undefined ? true : route.exact}
+        sensitive={route.sensitive === undefined ? false : route.sensitive}
         path={route.path}
         key={route.path}
         render={(props) => {

--- a/public/app/core/navigation/types.ts
+++ b/public/app/core/navigation/types.ts
@@ -19,4 +19,5 @@ export interface RouteDescriptor {
   routeName?: string;
   chromeless?: boolean;
   exact?: boolean;
+  sensitive?: boolean;
 }

--- a/public/app/features/plugins/routes.tsx
+++ b/public/app/features/plugins/routes.tsx
@@ -18,10 +18,12 @@ export function getAppPluginRoutes(): RouteDescriptor[] {
       const pluginNavSection = getRootSectionForNode(navItem);
       const appPluginUrl = `/a/${navItem.pluginId}`;
       const path = isStandalonePluginPage(navItem.id) ? navItem.url || appPluginUrl : appPluginUrl; // Only standalone pages can use core URLs, otherwise we fall back to "/a/:pluginId"
+      const isSensitive = isStandalonePluginPage(navItem.id) && !navItem.url?.startsWith('/a'); // Have case-sensitive URLs only for standalone pages that have custom URLs
 
       return {
         path,
         exact: false, // route everything under this path to the plugin, so it can define more routes under this path
+        sensitive: isSensitive,
         component: () => <AppRootPage pluginId={navItem.pluginId} pluginNavSection={pluginNavSection} />,
       };
     });

--- a/public/app/features/plugins/routes.tsx
+++ b/public/app/features/plugins/routes.tsx
@@ -18,7 +18,7 @@ export function getAppPluginRoutes(): RouteDescriptor[] {
       const pluginNavSection = getRootSectionForNode(navItem);
       const appPluginUrl = `/a/${navItem.pluginId}`;
       const path = isStandalonePluginPage(navItem.id) ? navItem.url || appPluginUrl : appPluginUrl; // Only standalone pages can use core URLs, otherwise we fall back to "/a/:pluginId"
-      const isSensitive = isStandalonePluginPage(navItem.id) && !navItem.url?.startsWith('/a'); // Have case-sensitive URLs only for standalone pages that have custom URLs
+      const isSensitive = isStandalonePluginPage(navItem.id) && !navItem.url?.startsWith('/a/'); // Have case-sensitive URLs only for standalone pages that have custom URLs
 
       return {
         path,


### PR DESCRIPTION
### What changed and why?

Using case-sensitive routes for standalone plugin pages that have a custom URL (anything that doesn't start with `/a/`).

We need this for the following reason: anything that doesn't start with `/a/` can be considered as a core URL, which likely has a backend route-guard in [api.go](https://github.com/grafana/grafana/blob/6c5a5737721914cdce87bf27990a89e0fe6d47cb/pkg/api/api.go#L403), and these route-guards are case sensitive. This means that if the page is accessed with a capital letter in the path (e.g. `/Connections` vs `/connections`) then the backend route guards would not kick in and the frontend would still render out the (in this case broken) page.