### PR TITLE
Refactor: Use data source UID rather than ID

### DIFF
--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
@@ -182,6 +182,57 @@ describe('DataSourceWithBackend', () => {
     obs = toStreamingDataResponse(rsp, request, standardStreamOptionsProvider);
     expect(obs).toBeDefined();
   });
+
+  test('check that getResource uses the data source UID', () => {
+    const { mock, ds } = createMockDatasource();
+    ds.getResource('foo');
+
+    const args = mock.calls[0][0];
+
+    expect(mock.calls.length).toBe(1);
+    expect(args).toMatchObject({
+      headers: {
+        'X-Datasource-Uid': 'abc',
+        'X-Plugin-Id': 'dummy',
+      },
+      method: 'GET',
+      url: '/api/datasources/uid/abc/resources/foo',
+    });
+  });
+
+  test('check that postResource uses the data source UID', () => {
+    const { mock, ds } = createMockDatasource();
+    ds.postResource('foo');
+
+    const args = mock.calls[0][0];
+
+    expect(mock.calls.length).toBe(1);
+    expect(args).toMatchObject({
+      headers: {
+        'X-Datasource-Uid': 'abc',
+        'X-Plugin-Id': 'dummy',
+      },
+      method: 'POST',
+      url: '/api/datasources/uid/abc/resources/foo',
+    });
+  });
+
+  test('check that callHealthCheck uses the data source UID', () => {
+    const { mock, ds } = createMockDatasource();
+    ds.callHealthCheck();
+
+    const args = mock.calls[0][0];
+
+    expect(mock.calls.length).toBe(1);
+    expect(args).toMatchObject({
+      headers: {
+        'X-Datasource-Uid': 'abc',
+        'X-Plugin-Id': 'dummy',
+      },
+      method: 'GET',
+      url: '/api/datasources/uid/abc/health',
+    });
+  });
 });
 
 function createMockDatasource() {

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -281,7 +281,7 @@ class DataSourceWithBackend<
         method: 'GET',
         headers: options?.headers ? { ...options.headers, ...headers } : headers,
         params: params ?? options?.params,
-        url: `/api/datasources/${this.id}/resources/${path}`,
+        url: `/api/datasources/uid/${this.uid}/resources/${path}`,
       })
     );
     return result.data;
@@ -302,7 +302,7 @@ class DataSourceWithBackend<
         method: 'POST',
         headers: options?.headers ? { ...options.headers, ...headers } : headers,
         data: data ?? { ...data },
-        url: `/api/datasources/${this.id}/resources/${path}`,
+        url: `/api/datasources/uid/${this.uid}/resources/${path}`,
       })
     );
     return result.data;
@@ -315,7 +315,7 @@ class DataSourceWithBackend<
     return lastValueFrom(
       getBackendSrv().fetch<HealthCheckResult>({
         method: 'GET',
-        url: `/api/datasources/${this.id}/health`,
+        url: `/api/datasources/uid/${this.uid}/health`,
         showErrorAlert: false,
         headers: this.getRequestHeaders(),
       })

--- a/public/app/features/dashboard/services/DashboardLoaderSrv.ts
+++ b/public/app/features/dashboard/services/DashboardLoaderSrv.ts
@@ -133,7 +133,7 @@ export class DashboardLoaderSrv {
     });
 
     return getBackendSrv()
-      .get(`/api/datasources/${ds.id}/resources/${path}`, queryParams)
+      .get(`/api/datasources/uid/${ds.uid}/resources/${path}`, queryParams)
       .then((data) => {
         return {
           meta: {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Use the data source `UID` rather than the ID (deprecated) for getting/posting resources and other calls.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

More for #61727

**Special notes for your reviewer**:

I am not actually sure if this is a breaking change. Is there any case in which the UID is not set but the ID is? Should we add some fallback logic here?