### PR TITLE
Datasources: Rename a UI tracking event property

### DIFF
--- a/public/app/features/datasources/state/actions.test.ts
+++ b/public/app/features/datasources/state/actions.test.ts
@@ -242,7 +242,7 @@ describe('testDataSource', () => {
         datasource_uid: 'CW1234',
         grafana_version: '1.0',
         success: true,
-        editLink: '/datasources/edit/CloudWatch',
+        path: '/datasources/edit/CloudWatch',
       });
     });
 
@@ -279,7 +279,7 @@ describe('testDataSource', () => {
         datasource_uid: 'azM0nit0R',
         grafana_version: '1.0',
         success: false,
-        editLink: '/datasources/edit/Azure Monitor',
+        path: '/datasources/edit/Azure Monitor',
       });
     });
 
@@ -360,7 +360,7 @@ describe('addDataSource', () => {
       plugin_version: '1.2.3',
       datasource_uid: 'azure23',
       grafana_version: '1.0',
-      editLink: DATASOURCES_ROUTES.Edit.replace(':uid', 'azure23'),
+      path: DATASOURCES_ROUTES.Edit.replace(':uid', 'azure23'),
     });
   });
 });

--- a/public/app/features/datasources/state/actions.ts
+++ b/public/app/features/datasources/state/actions.ts
@@ -116,7 +116,7 @@ export const testDataSource = (
           plugin_id: dsApi.type,
           datasource_uid: dsApi.uid,
           success: true,
-          editLink,
+          path: editLink,
         });
       } catch (err) {
         let message: string | undefined;
@@ -137,7 +137,7 @@ export const testDataSource = (
           plugin_id: dsApi.type,
           datasource_uid: dsApi.uid,
           success: false,
-          editLink,
+          path: editLink,
         });
       }
     });
@@ -221,7 +221,7 @@ export function addDataSource(plugin: DataSourcePluginMeta, editRoute = DATASOUR
       plugin_id: plugin.id,
       datasource_uid: result.datasource.uid,
       plugin_version: result.meta?.info?.version,
-      editLink,
+      path: editLink,
     });
 
     locationService.push(editLink);

--- a/public/app/features/datasources/tracking.ts
+++ b/public/app/features/datasources/tracking.ts
@@ -24,8 +24,8 @@ type DataSourceCreatedProps = {
   plugin_id: string;
   /** The plugin version (especially interesting in external plugins - core plugins are aligned with grafana version) */
   plugin_version?: string;
-  /** The URL that points to the edit page for the datasoruce. We are using this to be able to distinguish between the performance of different datasource edit locations. */
-  editLink?: string;
+  /** The URL path that points to the page where the event was triggered. We are using this to be able to distinguish between the performance of different datasource edit locations. */
+  path?: string;
 };
 
 /**
@@ -53,6 +53,6 @@ type DataSourceTestedProps = {
   plugin_version?: string;
   /** Whether or not the datasource test succeeded = the datasource was successfully configured */
   success: boolean;
-  /** The URL that points to the edit page for the datasoruce. We are using this to be able to distinguish between the performance of different datasource edit locations. */
-  editLink?: string;
+  /** The URL path that points to the page where the event was triggered. We are using this to be able to distinguish between the performance of different datasource edit locations. */
+  path?: string;
 };


### PR DESCRIPTION
### What changed?

Renamed the `editLink` property to `path` for the following events to be consistent with how we call this information in other tracking data objects (it's a more generic name).

**This shouldn't be a breaking change**
These `editLink` properties were introduced ~6 days ago ([here](https://github.com/grafana/grafana/pull/62227/files#diff-e68adfa636506ea3223f0d1049cf7e73d6757987f9ce5470f2a90e62c278f759R28) and [here](https://github.com/grafana/grafana/pull/62292/files#diff-e68adfa636506ea3223f0d1049cf7e73d6757987f9ce5470f2a90e62c278f759R57)), and I don't think we are using them anywhere yet.