### PR TITLE
KVStore: Include database field in migration

### DIFF
--- a/pkg/services/secrets/kvstore/migrations/datasource_mig.go
+++ b/pkg/services/secrets/kvstore/migrations/datasource_mig.go
@@ -82,6 +82,7 @@ func (s *DataSourceSecretMigrationService) Migrate(ctx context.Context) error {
 				WithCredentials: ds.WithCredentials,
 				ReadOnly:        ds.ReadOnly,
 				User:            ds.User,
+				Database:        ds.Database,
 			})
 			if err != nil {
 				return err


### PR DESCRIPTION
@gabor found out that when Grafana spins up for the first time the provisioned datasource didn't include database field. It turned out that we run this migration for the very first time and because it didn't have the database field there it was emptied out.

**Which issue(s) does this PR fix?**:

Fixes #61697

