### PR TITLE
Tempo: Inject status and status.code for tags autocomplete

### DIFF
--- a/public/app/plugins/datasource/tempo/QueryEditor/TagsField/TagsField.tsx
+++ b/public/app/plugins/datasource/tempo/QueryEditor/TagsField/TagsField.tsx
@@ -121,6 +121,11 @@ function useAutocomplete(datasource: TempoDatasource) {
         const tags = datasource.languageProvider.getTags();
 
         if (tags) {
+          // This is needed because the /api/v1/search/tag/${tag}/values API expects "status.code" and the v2 API expects "status"
+          // so Tempo doesn't send anything and we inject it here for the autocomplete
+          if (!tags.find((t) => t === 'status.code')) {
+            tags.push('status.code');
+          }
           providerRef.current.setTags(tags);
         }
       } catch (error) {

--- a/public/app/plugins/datasource/tempo/QueryEditor/TagsField/TagsField.tsx
+++ b/public/app/plugins/datasource/tempo/QueryEditor/TagsField/TagsField.tsx
@@ -121,7 +121,7 @@ function useAutocomplete(datasource: TempoDatasource) {
         const tags = datasource.languageProvider.getTags();
 
         if (tags) {
-          // This is needed because the /api/v1/search/tag/${tag}/values API expects "status.code" and the v2 API expects "status"
+          // This is needed because the /api/search/tag/${tag}/values API expects "status.code" and the v2 API expects "status"
           // so Tempo doesn't send anything and we inject it here for the autocomplete
           if (!tags.find((t) => t === 'status.code')) {
             tags.push('status.code');

--- a/public/app/plugins/datasource/tempo/traceql/TraceQLEditor.tsx
+++ b/public/app/plugins/datasource/tempo/traceql/TraceQLEditor.tsx
@@ -148,6 +148,11 @@ function useAutocomplete(datasource: TempoDatasource) {
         const tags = datasource.languageProvider.getTags();
 
         if (tags) {
+          // This is needed because the /api/v2/search/tag/${tag}/values API expects "status" and the v1 API expects "status.code"
+          // so Tempo doesn't send anything and we inject it here for the autocomplete
+          if (!tags.find((t) => t === 'status')) {
+            tags.push('status');
+          }
           providerRef.current.setTags(tags);
         }
       } catch (error) {


### PR DESCRIPTION
**What is this feature?**

This PR injects `status.code` in the Tags field of the Search tab which uses the v1 of the `/api/search/tag/${tag}/values` API and also injects `status` in the TraceQL editor autocomplete which uses the v2 of the API.

**Why do we need this feature?**

This is needed because Tempo will not send either `status` or `status.code` in the `/api/search/tags` API response, unless they match an existing attribute with those names. Since v1 of the `/api/search/tag/${tag}/values` uses `status.code` and v2 uses `status` we must inject it in the editors to guide the user to the correct tag. 

