### PR TITLE
Alerting: Pause dash alerts on migration

### DIFF
--- a/pkg/services/sqlstore/migrations/ualert/alert_rule.go
+++ b/pkg/services/sqlstore/migrations/ualert/alert_rule.go
@@ -37,6 +37,7 @@ type alertRule struct {
 	Updated         time.Time
 	Annotations     map[string]string
 	Labels          map[string]string
+	IsPaused        bool
 }
 
 type alertRuleVersion struct {
@@ -61,6 +62,7 @@ type alertRuleVersion struct {
 	For         duration
 	Annotations map[string]string
 	Labels      map[string]string
+	IsPaused    bool
 }
 
 func (a *alertRule) makeVersion() *alertRuleVersion {
@@ -84,6 +86,7 @@ func (a *alertRule) makeVersion() *alertRuleVersion {
 		For:             a.For,
 		Annotations:     a.Annotations,
 		Labels:          map[string]string{},
+		IsPaused:        a.IsPaused,
 	}
 }
 
@@ -120,6 +123,11 @@ func (m *migration) makeAlertRule(cond condition, da dashAlert, folderUID string
 
 	name := normalizeRuleName(da.Name, uid)
 
+	isPaused := false
+	if da.State == "paused" {
+		isPaused = true
+	}
+
 	ar := &alertRule{
 		OrgID:           da.OrgId,
 		Title:           name, // TODO: Make sure all names are unique, make new name on constraint insert error.
@@ -135,6 +143,7 @@ func (m *migration) makeAlertRule(cond condition, da dashAlert, folderUID string
 		Annotations:     annotations,
 		Labels:          lbls,
 		RuleGroupIndex:  1,
+		IsPaused:        isPaused,
 	}
 
 	ar.NoDataState, err = transNoData(da.ParsedSettings.NoDataState)

--- a/pkg/services/sqlstore/migrations/ualert/alert_rule_test.go
+++ b/pkg/services/sqlstore/migrations/ualert/alert_rule_test.go
@@ -100,6 +100,27 @@ func TestMakeAlertRule(t *testing.T) {
 			require.Equal(t, ar.Title, ar.RuleGroup)
 		})
 
+		t.Run("alert is not paused", func(t *testing.T) {
+			m := newTestMigration(t)
+			da := createTestDashAlert()
+			cnd := createTestDashAlertCondition()
+
+			ar, err := m.makeAlertRule(cnd, da, "folder")
+			require.NoError(t, err)
+			require.False(t, ar.IsPaused)
+		})
+
+		t.Run("paused dash alert is paused", func(t *testing.T) {
+			m := newTestMigration(t)
+			da := createTestDashAlert()
+			da.State = "paused"
+			cnd := createTestDashAlertCondition()
+
+			ar, err := m.makeAlertRule(cnd, da, "folder")
+			require.NoError(t, err)
+			require.True(t, ar.IsPaused)
+		})
+
 		t.Run("truncates very long names to max length", func(t *testing.T) {
 			m := newTestMigration(t)
 			da := createTestDashAlert()

--- a/pkg/services/sqlstore/migrations/ualert/alert_rule_test.go
+++ b/pkg/services/sqlstore/migrations/ualert/alert_rule_test.go
@@ -100,27 +100,6 @@ func TestMakeAlertRule(t *testing.T) {
 			require.Equal(t, ar.Title, ar.RuleGroup)
 		})
 
-		t.Run("alert is not paused", func(t *testing.T) {
-			m := newTestMigration(t)
-			da := createTestDashAlert()
-			cnd := createTestDashAlertCondition()
-
-			ar, err := m.makeAlertRule(cnd, da, "folder")
-			require.NoError(t, err)
-			require.False(t, ar.IsPaused)
-		})
-
-		t.Run("paused dash alert is paused", func(t *testing.T) {
-			m := newTestMigration(t)
-			da := createTestDashAlert()
-			da.State = "paused"
-			cnd := createTestDashAlertCondition()
-
-			ar, err := m.makeAlertRule(cnd, da, "folder")
-			require.NoError(t, err)
-			require.True(t, ar.IsPaused)
-		})
-
 		t.Run("truncates very long names to max length", func(t *testing.T) {
 			m := newTestMigration(t)
 			da := createTestDashAlert()
@@ -137,6 +116,27 @@ func TestMakeAlertRule(t *testing.T) {
 			require.Equal(t, DefaultFieldMaxLength-1, len(parts[0])+len(parts[1]), "truncated name + underscore + unique identifier should together be DefaultFieldMaxLength")
 			require.Equal(t, ar.Title, ar.RuleGroup)
 		})
+	})
+
+	t.Run("alert is not paused", func(t *testing.T) {
+		m := newTestMigration(t)
+		da := createTestDashAlert()
+		cnd := createTestDashAlertCondition()
+
+		ar, err := m.makeAlertRule(cnd, da, "folder")
+		require.NoError(t, err)
+		require.False(t, ar.IsPaused)
+	})
+
+	t.Run("paused dash alert is paused", func(t *testing.T) {
+		m := newTestMigration(t)
+		da := createTestDashAlert()
+		da.State = "paused"
+		cnd := createTestDashAlertCondition()
+
+		ar, err := m.makeAlertRule(cnd, da, "folder")
+		require.NoError(t, err)
+		require.True(t, ar.IsPaused)
 	})
 }
 

--- a/pkg/services/sqlstore/migrations/ualert/testing.go
+++ b/pkg/services/sqlstore/migrations/ualert/testing.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
+	"github.com/prometheus/alertmanager/silence/silencepb"
 )
 
 // newTestMigration generates an empty migration to use in tests.
@@ -19,5 +20,6 @@ func newTestMigration(t *testing.T) *migration {
 		seenUIDs: uidSet{
 			set: make(map[string]struct{}),
 		},
+		silences: make(map[int64][]*silencepb.MeshSilence),
 	}
 }


### PR DESCRIPTION
**What is this feature?**

This pull request makes sure that dashboard alerts with state `paused` and also paused when migrated to Grafana Alerting.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

