### PR TITLE
Alerting: Add static label to all state history entries

### DIFF
--- a/pkg/services/ngalert/state/historian/loki.go
+++ b/pkg/services/ngalert/state/historian/loki.go
@@ -16,11 +16,14 @@ import (
 )
 
 const (
-	OrgIDLabel             = "orgID"
-	RuleUIDLabel           = "ruleUID"
-	GroupLabel             = "group"
-	FolderUIDLabel         = "folderUID"
-	StateHistoryLabel      = "from"
+	OrgIDLabel     = "orgID"
+	RuleUIDLabel   = "ruleUID"
+	GroupLabel     = "group"
+	FolderUIDLabel = "folderUID"
+)
+
+const (
+	StateHistoryLabelKey   = "from"
 	StateHistoryLabelValue = "state-history"
 )
 
@@ -74,7 +77,7 @@ func statesToStreams(rule history_model.RuleMeta, states []state.StateTransition
 		}
 
 		labels := mergeLabels(removePrivateLabels(state.State.Labels), externalLabels)
-		labels[StateHistoryLabel] = StateHistoryLabelValue
+		labels[StateHistoryLabelKey] = StateHistoryLabelValue
 		labels[OrgIDLabel] = fmt.Sprint(rule.OrgID)
 		labels[RuleUIDLabel] = fmt.Sprint(rule.UID)
 		labels[GroupLabel] = fmt.Sprint(rule.Group)

--- a/pkg/services/ngalert/state/historian/loki.go
+++ b/pkg/services/ngalert/state/historian/loki.go
@@ -16,10 +16,12 @@ import (
 )
 
 const (
-	OrgIDLabel     = "orgID"
-	RuleUIDLabel   = "ruleUID"
-	GroupLabel     = "group"
-	FolderUIDLabel = "folderUID"
+	OrgIDLabel             = "orgID"
+	RuleUIDLabel           = "ruleUID"
+	GroupLabel             = "group"
+	FolderUIDLabel         = "folderUID"
+	StateHistoryLabel      = "from"
+	StateHistoryLabelValue = "state-history"
 )
 
 type remoteLokiClient interface {
@@ -72,6 +74,7 @@ func statesToStreams(rule history_model.RuleMeta, states []state.StateTransition
 		}
 
 		labels := mergeLabels(removePrivateLabels(state.State.Labels), externalLabels)
+		labels[StateHistoryLabel] = StateHistoryLabelValue
 		labels[OrgIDLabel] = fmt.Sprint(rule.OrgID)
 		labels[RuleUIDLabel] = fmt.Sprint(rule.UID)
 		labels[GroupLabel] = fmt.Sprint(rule.Group)

--- a/pkg/services/ngalert/state/historian/loki_test.go
+++ b/pkg/services/ngalert/state/historian/loki_test.go
@@ -59,11 +59,12 @@ func TestRemoteLokiBackend(t *testing.T) {
 
 			require.Len(t, res, 1)
 			exp := map[string]string{
-				"folderUID": rule.NamespaceUID,
-				"group":     rule.Group,
-				"orgID":     fmt.Sprint(rule.OrgID),
-				"ruleUID":   rule.UID,
-				"a":         "b",
+				StateHistoryLabel: StateHistoryLabelValue,
+				"folderUID":       rule.NamespaceUID,
+				"group":           rule.Group,
+				"orgID":           fmt.Sprint(rule.OrgID),
+				"ruleUID":         rule.UID,
+				"a":               "b",
 			}
 			require.Equal(t, exp, res[0].Stream)
 		})

--- a/pkg/services/ngalert/state/historian/loki_test.go
+++ b/pkg/services/ngalert/state/historian/loki_test.go
@@ -59,12 +59,12 @@ func TestRemoteLokiBackend(t *testing.T) {
 
 			require.Len(t, res, 1)
 			exp := map[string]string{
-				StateHistoryLabel: StateHistoryLabelValue,
-				"folderUID":       rule.NamespaceUID,
-				"group":           rule.Group,
-				"orgID":           fmt.Sprint(rule.OrgID),
-				"ruleUID":         rule.UID,
-				"a":               "b",
+				StateHistoryLabelKey: StateHistoryLabelValue,
+				"folderUID":          rule.NamespaceUID,
+				"group":              rule.Group,
+				"orgID":              fmt.Sprint(rule.OrgID),
+				"ruleUID":            rule.UID,
+				"a":                  "b",
 			}
 			require.Equal(t, exp, res[0].Stream)
 		})


### PR DESCRIPTION
**What is this feature?**

Adds a unique label to all state history entries, so we can differentiate them from other data that might be in Loki.

**Why do we need this feature?**

Creates a simpler default query (no regexes on labels), and allows us to ensure no irrelevant data gets included in queries. easier on-prem usage.

**Which issue(s) does this PR fix?**:

contrib https://github.com/grafana/grafana/issues/48359

**Special notes for your reviewer**:

