### PR TITLE
Alerting: Adds a default value to the last_applied column

### DIFF
--- a/pkg/services/sqlstore/migrations/ualert/tables.go
+++ b/pkg/services/sqlstore/migrations/ualert/tables.go
@@ -22,7 +22,7 @@ func AddTablesMigrations(mg *migrator.Migrator) {
 	historicalTableMigrations(mg)
 
 	mg.AddMigration("add last_applied column to alert_configuration_history", migrator.NewAddColumnMigration(migrator.Table{Name: "alert_configuration_history"}, &migrator.Column{
-		Name: "last_applied", Type: migrator.DB_Int, Nullable: false,
+		Name: "last_applied", Type: migrator.DB_Int, Nullable: false, Default: "0",
 	}))
 }
 


### PR DESCRIPTION
My local instance was refusing to boot with the following exception.

```
INFO [02-02|19:50:00] Connecting to DB                         logger=sqlstore dbtype=sqlite3
INFO [02-02|19:50:00] Starting DB migrations                   logger=migrator
INFO [02-02|19:50:00] Executing migration                      logger=migrator id="add last_applied column to alert_configuration_history"
ERROR[02-02|19:50:00] Executing migration failed               logger=migrator id="add last_applied column to alert_configuration_history" error="Cannot add a NOT NULL column with default value NULL"
ERROR[02-02|19:50:00] Exec failed                              logger=migrator error="Cannot add a NOT NULL column with default value NULL" sql="alter table `alert_configuration_history` ADD COLUMN `last_applied` INTEGER NOT NULL "
Error: ✗ migration failed (id = add last_applied column to alert_configuration_history): Cannot add a NOT NULL column with default value NULL
```

This may have been a result of a local database being in a weird state but regardless the changes in this PR do allow the instance to boot and seems harmless.