### PR TITLE
Docs: removes Grafana Cloud CTA

### DIFF
--- a/docs/sources/introduction/grafana-cloud.md
+++ b/docs/sources/introduction/grafana-cloud.md
@@ -6,5 +6,3 @@ weight: 300
 # Grafana Cloud
 
 Grafana Cloud is a highly available, fast, fully-managed OpenSaaS logging and metrics platform. It is everything you love about Grafana, hosted by Grafana Labs.
-
-[Learn more about Grafana Cloud](https://grafana.com/cloud/) and get started with your [free account with Grafana Cloud](https://grafana.com/signup/cloud/connect-account?pg=gsdocs) that includes a robust free tier with access to 10k metrics, 50GB logs, 50GB traces, two-week data retention, and three users.


### PR DESCRIPTION
This PR removes the Grafana Cloud CTA from the Grafana Cloud overview page.