### PR TITLE
Canvas: Support color themes for arrows

### DIFF
--- a/public/app/plugins/panel/canvas/ConnectionSVG.tsx
+++ b/public/app/plugins/panel/canvas/ConnectionSVG.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { useStyles2 } from '@grafana/ui';
+import { config } from 'app/core/config';
 import { CanvasConnection } from 'app/features/canvas/element';
 import { ElementState } from 'app/features/canvas/runtime/element';
 import { Scene } from 'app/features/canvas/runtime/scene';
@@ -23,6 +24,7 @@ export const ConnectionSVG = ({ setSVGRef, setLineRef, scene }: Props) => {
   const CONNECTION_LINE_ID = 'connectionLineId';
   const CONNECTION_HEAD_ID = useMemo(() => `head-${headId}`, [headId]);
   const EDITOR_HEAD_ID = useMemo(() => `editorHead-${headId}`, [headId]);
+  const defaultArrowColor = config.theme2.colors.text.primary;
 
   const [selectedConnection, setSelectedConnection] = useState<CanvasConnection | undefined>(undefined);
 
@@ -142,9 +144,9 @@ export const ConnectionSVG = ({ setSVGRef, setLineRef, scene }: Props) => {
                 refX="10"
                 refY="3.5"
                 orient="auto"
-                stroke="rgb(255,255,255)"
+                stroke={defaultArrowColor}
               >
-                <polygon points="0 0, 10 3.5, 0 7" fill="rgb(255,255,255)" />
+                <polygon points="0 0, 10 3.5, 0 7" fill={defaultArrowColor} />
               </marker>
             </defs>
             <line
@@ -160,7 +162,7 @@ export const ConnectionSVG = ({ setSVGRef, setLineRef, scene }: Props) => {
             />
             <line
               id={CONNECTION_LINE_ID}
-              stroke="rgb(255,255,255)"
+              stroke={defaultArrowColor}
               pointerEvents="auto"
               strokeWidth={2}
               markerEnd={`url(#${CONNECTION_HEAD_ID})`}
@@ -188,12 +190,12 @@ export const ConnectionSVG = ({ setSVGRef, setLineRef, scene }: Props) => {
             refX="10"
             refY="3.5"
             orient="auto"
-            stroke="rgb(255,255,255)"
+            stroke={defaultArrowColor}
           >
-            <polygon points="0 0, 10 3.5, 0 7" fill="rgb(255,255,255)" />
+            <polygon points="0 0, 10 3.5, 0 7" fill={defaultArrowColor} />
           </marker>
         </defs>
-        <line ref={setLineRef} stroke="rgb(255,255,255)" strokeWidth={2} markerEnd={`url(#${EDITOR_HEAD_ID})`} />
+        <line ref={setLineRef} stroke={defaultArrowColor} strokeWidth={2} markerEnd={`url(#${EDITOR_HEAD_ID})`} />
       </svg>
       {renderConnections()}
     </>


### PR DESCRIPTION
What this PR does / why we need it:
Currently in canvas, arrows are white by default. This sets their color based on the color theme.

Before:
![Feb-02-2023 13-35-48](https://user-images.githubusercontent.com/60050885/216455248-4fad6b38-9018-404c-9c0f-810fd54c530f.gif)

After:
![Feb-02-2023 13-37-17](https://user-images.githubusercontent.com/60050885/216455238-03a0c21a-6e30-4d16-93b0-7c851bcc00c5.gif)

Closes #62828