### PR TITLE
Alerting: Add label query parameters to state history endpoint

### DIFF
--- a/pkg/services/ngalert/api/api_ruler_history.go
+++ b/pkg/services/ngalert/api/api_ruler_history.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
@@ -21,16 +22,27 @@ type HistorySrv struct {
 	hist   Historian
 }
 
+const labelQueryPrefix = "labels_"
+
 func (srv *HistorySrv) RouteQueryStateHistory(c *contextmodel.ReqContext) response.Response {
 	from := c.QueryInt64("from")
 	to := c.QueryInt64("to")
+	ruleUID := c.Query("ruleUID")
+
+	var labels map[string]string
+	for k, v := range c.Req.URL.Query() {
+		if strings.HasPrefix(k, labelQueryPrefix) {
+			labels[k[len(labelQueryPrefix):]] = v[0]
+		}
+	}
+
 	query := models.HistoryQuery{
-		RuleUID:      c.Query("ruleUID"),
+		RuleUID:      ruleUID,
 		OrgID:        c.OrgID,
 		SignedInUser: c.SignedInUser,
 		From:         time.Unix(from, 0),
 		To:           time.Unix(to, 0),
-		Labels:       map[string]string{}, // TODO, not supported by all backends yet.
+		Labels:       labels,
 	}
 	frame, err := srv.hist.QueryStates(c.Req.Context(), query)
 	if err != nil {

--- a/pkg/services/ngalert/api/api_ruler_history.go
+++ b/pkg/services/ngalert/api/api_ruler_history.go
@@ -29,7 +29,7 @@ func (srv *HistorySrv) RouteQueryStateHistory(c *contextmodel.ReqContext) respon
 	to := c.QueryInt64("to")
 	ruleUID := c.Query("ruleUID")
 
-	var labels map[string]string
+	labels := make(map[string]string)
 	for k, v := range c.Req.URL.Query() {
 		if strings.HasPrefix(k, labelQueryPrefix) {
 			labels[k[len(labelQueryPrefix):]] = v[0]


### PR DESCRIPTION
**What is this feature?**

Allows equality-only (for now) querying of arbitrary labels from the state history endpoint.

The annotation backend which does not support this will ignore these params (which is the current behavior) and log a warning.

**Which issue(s) does this PR fix?**:

contrib https://github.com/grafana/grafana/issues/48359

**Special notes for your reviewer**:

