### PR TITLE
docs: fix broken annotations link

### DIFF
--- a/docs/sources/dashboards/build-dashboards/view-dashboard-json-model/index.md
+++ b/docs/sources/dashboards/build-dashboards/view-dashboard-json-model/index.md
@@ -144,11 +144,11 @@ Usage of the fields is explained below:
 | --------------------- | -------------------------------------- |
 | **collapse**          | whether timepicker is collapsed or not |
 | **enable**            | whether timepicker is enabled or not   |
-| **notice**            | TODO                                   |
-| **now**               | TODO                                   |
-| **refresh_intervals** | TODO                                   |
-| **status**            | TODO                                   |
-| **type**              | TODO                                   |
+| **notice**            |                                    |
+| **now**               |                                    |
+| **refresh_intervals** |                                    |
+| **status**            |                                    |
+| **type**              |                                    |
 
 ### templating
 
@@ -236,6 +236,6 @@ Usage of the above mentioned fields in the templating section is explained below
 | **name**        | name of variable                                                                                        |
 | **options**     | array of variable text/value pairs available for selection on dashboard                                 |
 | **query**       | data source query used to fetch values for a variable                                                   |
-| **refresh**     | TODO                                                                                                    |
-| **regex**       | TODO                                                                                                    |
+| **refresh**     |                                                                                                     |
+| **regex**       |                                                                                                     |
 | **type**        | type of variable, i.e. `custom`, `query` or `interval`                                                  |

--- a/docs/sources/dashboards/build-dashboards/view-dashboard-json-model/index.md
+++ b/docs/sources/dashboards/build-dashboards/view-dashboard-json-model/index.md
@@ -75,7 +75,7 @@ Each field in the dashboard JSON is explained below with its usage:
 | **time**          | time range for dashboard, i.e. last 6 hours, last 7 days, etc                                                     |
 | **timepicker**    | timepicker metadata, see [timepicker section](#timepicker) for details                                            |
 | **templating**    | templating metadata, see [templating section](#templating) for details                                            |
-| **annotations**   | annotations metadata, see [annotations]({{< relref "../annotate-visualizations" >}}) for how to add them                                         |
+| **annotations**   | annotations metadata, see [annotations]({{< relref "../annotate-visualizations" >}}) for how to add them          |
 | **refresh**       | auto-refresh interval                                                                                             |
 | **schemaVersion** | version of the JSON schema (integer), incremented each time a Grafana update brings changes to said schema        |
 | **version**       | version of the dashboard (integer), incremented each time the dashboard is updated                                |
@@ -144,11 +144,11 @@ Usage of the fields is explained below:
 | --------------------- | -------------------------------------- |
 | **collapse**          | whether timepicker is collapsed or not |
 | **enable**            | whether timepicker is enabled or not   |
-| **notice**            |                                    |
-| **now**               |                                    |
-| **refresh_intervals** |                                    |
-| **status**            |                                    |
-| **type**              |                                    |
+| **notice**            |                                        |
+| **now**               |                                        |
+| **refresh_intervals** |                                        |
+| **status**            |                                        |
+| **type**              |                                        |
 
 ### templating
 
@@ -236,6 +236,6 @@ Usage of the above mentioned fields in the templating section is explained below
 | **name**        | name of variable                                                                                        |
 | **options**     | array of variable text/value pairs available for selection on dashboard                                 |
 | **query**       | data source query used to fetch values for a variable                                                   |
-| **refresh**     |                                                                                                     |
-| **regex**       |                                                                                                     |
+| **refresh**     |                                                                                                         |
+| **regex**       |                                                                                                         |
 | **type**        | type of variable, i.e. `custom`, `query` or `interval`                                                  |

--- a/docs/sources/dashboards/build-dashboards/view-dashboard-json-model/index.md
+++ b/docs/sources/dashboards/build-dashboards/view-dashboard-json-model/index.md
@@ -75,7 +75,7 @@ Each field in the dashboard JSON is explained below with its usage:
 | **time**          | time range for dashboard, i.e. last 6 hours, last 7 days, etc                                                     |
 | **timepicker**    | timepicker metadata, see [timepicker section](#timepicker) for details                                            |
 | **templating**    | templating metadata, see [templating section](#templating) for details                                            |
-| **annotations**   | annotations metadata, see [annotations section](#annotations) for details                                         |
+| **annotations**   | annotations metadata, see [annotations]{{< relref "../annotate-visualizations" >}} for how to add them                                         |
 | **refresh**       | auto-refresh interval                                                                                             |
 | **schemaVersion** | version of the JSON schema (integer), incremented each time a Grafana update brings changes to said schema        |
 | **version**       | version of the dashboard (integer), incremented each time the dashboard is updated                                |

--- a/docs/sources/dashboards/build-dashboards/view-dashboard-json-model/index.md
+++ b/docs/sources/dashboards/build-dashboards/view-dashboard-json-model/index.md
@@ -75,7 +75,7 @@ Each field in the dashboard JSON is explained below with its usage:
 | **time**          | time range for dashboard, i.e. last 6 hours, last 7 days, etc                                                     |
 | **timepicker**    | timepicker metadata, see [timepicker section](#timepicker) for details                                            |
 | **templating**    | templating metadata, see [templating section](#templating) for details                                            |
-| **annotations**   | annotations metadata, see [annotations]{{< relref "../annotate-visualizations" >}} for how to add them                                         |
+| **annotations**   | annotations metadata, see [annotations]({{< relref "../annotate-visualizations" >}}) for how to add them                                         |
 | **refresh**       | auto-refresh interval                                                                                             |
 | **schemaVersion** | version of the JSON schema (integer), incremented each time a Grafana update brings changes to said schema        |
 | **version**       | version of the dashboard (integer), incremented each time the dashboard is updated                                |


### PR DESCRIPTION
Link to annotations section on [this page](https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/view-dashboard-json-model/) is broken because the section was never added. A placeholder for it was removed on [this commit](https://github.com/grafana/grafana/commit/4eec4bfb0534b7a0cfd2babbf262dffd9474d069), but the link wasn't. This seems like the best place to point to, but would definitely like some input from @grafana/dashboards-squad.