### PR TITLE
DashboardService: implement BackgroundService

### DIFF
--- a/pkg/server/backgroundsvcs/background_services.go
+++ b/pkg/server/backgroundsvcs/background_services.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/alerting"
 	"github.com/grafana/grafana/pkg/services/auth"
 	"github.com/grafana/grafana/pkg/services/cleanup"
+	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/dashboardsnapshots"
 	"github.com/grafana/grafana/pkg/services/grpcserver"
 	"github.com/grafana/grafana/pkg/services/guardian"
@@ -49,6 +50,7 @@ func ProvideBackgroundServiceRegistry(
 	saService *samanager.ServiceAccountsService, authInfoService *authinfoservice.Implementation,
 	grpcServerProvider grpcserver.Provider, secretMigrationProvider secretsMigrations.SecretMigrationProvider, loginAttemptService *loginattemptimpl.Service,
 	bundleService *supportbundlesimpl.Service,
+	dashboardService dashboards.DashboardService,
 	// Need to make sure these are initialized, is there a better place to put them?
 	_ dashboardsnapshots.Service, _ *alerting.AlertNotificationService,
 	_ serviceaccounts.Service, _ *guardian.Provider,
@@ -85,6 +87,7 @@ func ProvideBackgroundServiceRegistry(
 		secretMigrationProvider,
 		loginAttemptService,
 		bundleService,
+		dashboardService,
 	)
 }
 

--- a/pkg/services/dashboards/dashboard.go
+++ b/pkg/services/dashboards/dashboard.go
@@ -3,6 +3,7 @@ package dashboards
 import (
 	"context"
 
+	"github.com/grafana/grafana/pkg/registry"
 	alertmodels "github.com/grafana/grafana/pkg/services/alerting/models"
 	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/quota"
@@ -12,6 +13,8 @@ import (
 //
 //go:generate mockery --name DashboardService --structname FakeDashboardService --inpackage --filename dashboard_service_mock.go
 type DashboardService interface {
+	registry.BackgroundService
+
 	BuildSaveDashboardCommand(ctx context.Context, dto *SaveDashboardDTO, shouldValidateAlerts bool, validateProvisionedDashboard bool) (*SaveDashboardCommand, error)
 	DeleteDashboard(ctx context.Context, dashboardId int64, orgId int64) error
 	FindDashboards(ctx context.Context, query *FindPersistedDashboardsQuery) ([]DashboardSearchProjection, error)

--- a/pkg/services/dashboards/dashboard_service_mock.go
+++ b/pkg/services/dashboards/dashboard_service_mock.go
@@ -15,6 +15,12 @@ type FakeDashboardService struct {
 	mock.Mock
 }
 
+var _ DashboardService = (*FakeDashboardService)(nil)
+
+func (dr *FakeDashboardService) Run(ctx context.Context) error {
+	return nil // noop
+}
+
 // BuildSaveDashboardCommand provides a mock function with given fields: ctx, dto, shouldValidateAlerts, validateProvisionedDashboard
 func (_m *FakeDashboardService) BuildSaveDashboardCommand(ctx context.Context, dto *SaveDashboardDTO, shouldValidateAlerts bool, validateProvisionedDashboard bool) (*SaveDashboardCommand, error) {
 	ret := _m.Called(ctx, dto, shouldValidateAlerts, validateProvisionedDashboard)

--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -70,6 +70,10 @@ func ProvideDashboardService(
 	}
 }
 
+func (dr *DashboardServiceImpl) Run(ctx context.Context) error {
+	return nil // noop
+}
+
 func (dr *DashboardServiceImpl) GetProvisionedDashboardData(ctx context.Context, name string) ([]*dashboards.DashboardProvisioning, error) {
 	return dr.dashboardStore.GetProvisionedDashboardData(ctx, name)
 }

--- a/pkg/services/dashboards/service/service.go
+++ b/pkg/services/dashboards/service/service.go
@@ -17,7 +17,7 @@ func ProvideSimpleDashboardService(
 		if k8s.GetSystemClient() == nil {
 			panic("k8s dashboards requires the k8s client registered")
 		}
-		return k8saccess.NewDashboardService(svc, store)
+		return k8saccess.NewDashboardService(svc, store, k8s)
 	}
 	return svc
 }

--- a/pkg/services/store/k8saccess/dashboard_service.go
+++ b/pkg/services/store/k8saccess/dashboard_service.go
@@ -26,7 +26,7 @@ func NewDashboardService(orig dashboards.DashboardService, store entity.EntitySt
 }
 
 func (dr *k8sDashboardService) Run(ctx context.Context) error {
-	fmt.Printf("dashbaord control loop")
+	fmt.Printf("TODO: dashboard operator loop")
 	return nil // noop
 }
 

--- a/pkg/services/store/k8saccess/dashboard_service.go
+++ b/pkg/services/store/k8saccess/dashboard_service.go
@@ -10,17 +10,24 @@ import (
 )
 
 type k8sDashboardService struct {
-	orig  dashboards.DashboardService
-	store entity.EntityStoreServer
+	orig   dashboards.DashboardService
+	store  entity.EntityStoreServer
+	access K8SAccess
 }
 
 var _ dashboards.DashboardService = (*k8sDashboardService)(nil)
 
-func NewDashboardService(orig dashboards.DashboardService, store entity.EntityStoreServer) dashboards.DashboardService {
+func NewDashboardService(orig dashboards.DashboardService, store entity.EntityStoreServer, access K8SAccess) dashboards.DashboardService {
 	return &k8sDashboardService{
-		orig:  orig,
-		store: store,
+		orig:   orig,
+		store:  store,
+		access: access,
 	}
+}
+
+func (dr *k8sDashboardService) Run(ctx context.Context) error {
+	fmt.Printf("background service required for ")
+	return nil // noop
 }
 
 func (s *k8sDashboardService) BuildSaveDashboardCommand(ctx context.Context, dto *dashboards.SaveDashboardDTO, shouldValidateAlerts bool, validateProvisionedDashboard bool) (*dashboards.SaveDashboardCommand, error) {

--- a/pkg/services/store/k8saccess/dashboard_service.go
+++ b/pkg/services/store/k8saccess/dashboard_service.go
@@ -26,7 +26,7 @@ func NewDashboardService(orig dashboards.DashboardService, store entity.EntitySt
 }
 
 func (dr *k8sDashboardService) Run(ctx context.Context) error {
-	fmt.Printf("background service required for ")
+	fmt.Printf("dashbaord control loop")
 	return nil // noop
 }
 


### PR DESCRIPTION
**What is this feature?**

This adds a noop background service to the main dashboard service.  See also #62053 -- and a much more complicated https://github.com/grafana/grafana/pull/62400

**Why do we need this feature?**

Adding a controller loop to the dashboard service will simplify the tangle of of dashboard service inter-dependencies.

**Who is this feature for?**

This will simplify exploring k8s integration -- resolving some circular reference issues.