### PR TITLE
A11y: ignore rule since there's a button handling keyboard interaction

### DIFF
--- a/public/app/features/dashboard/components/PanelEditor/OptionsPaneCategory.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/OptionsPaneCategory.tsx
@@ -105,8 +105,12 @@ export const OptionsPaneCategory: FC<OptionsPaneCategoryProps> = React.memo(
         aria-label={selectors.components.OptionsGroup.group(id)}
         ref={ref}
       >
-        <div className={headerStyles} onClick={onToggle} aria-label={selectors.components.OptionsGroup.toggle(id)}>
+        {/* disabling a11y rules here because there's a Button that handles keyboard interaction */}
+        {/* this just provides a better experience for mouse users */}
+        {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
+        <div className={headerStyles} onClick={onToggle}>
           <Button
+            aria-label={selectors.components.OptionsGroup.toggle(id)}
             type="button"
             fill="text"
             size="sm"


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- ignores a11y rule since there's a button inside the element that will handle keyboard interaction
- moves the `aria-label` to the icon button so that it's read out by screenreaders 

**Why do we need this feature?**

- better a11y across grafana

**Who is this feature for?**

- everyone!

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #62855 

**Special notes for your reviewer**:

