### PR TITLE
A11y: fix keyboard a11y in `FolderSection`

### DIFF
--- a/public/app/features/search/page/components/FolderSection.tsx
+++ b/public/app/features/search/page/components/FolderSection.tsx
@@ -93,7 +93,6 @@ export const FolderSection = ({
   };
 
   const onToggleFolder = (evt: React.FormEvent) => {
-    evt.preventDefault();
     evt.stopPropagation();
     if (selectionToggle && selection) {
       const checked = !selection(section.kind, section.uid);
@@ -173,8 +172,12 @@ export const FolderSection = ({
       label={
         <>
           {selectionToggle && selection && (
-            <div onClick={onToggleFolder}>
-              <Checkbox value={selection(section.kind, section.uid)} aria-label="Select folder" />
+            <div>
+              <Checkbox
+                value={selection(section.kind, section.uid)}
+                aria-label="Select folder"
+                onClick={onToggleFolder}
+              />
             </div>
           )}
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- move `onClick` to the `Checkbox` instead of the wrapping `div`
- remove `preventDefault` from `onToggleFolder` so that the checkbox correctly highlights when using the keyboard

**Why do we need this feature?**

- better keyboard a11y across grafana

**Who is this feature for?**

- everyone! 🙌 

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/62859

**Special notes for your reviewer**:

