### PR TITLE
NestedFolders: use guardian.NewByUID to check folder permissions

### DIFF
--- a/pkg/services/folder/folderimpl/folder.go
+++ b/pkg/services/folder/folderimpl/folder.go
@@ -166,7 +166,7 @@ func (s *Service) GetChildren(ctx context.Context, cmd *folder.GetChildrenQuery)
 			continue
 		}
 
-		g, err := guardian.New(ctx, f.ID, f.OrgID, cmd.SignedInUser)
+		g, err := guardian.NewByUID(ctx, f.UID, f.OrgID, cmd.SignedInUser)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Currently `GET /api/folders` fails if a folder has a different ID between the dashboard and folder table.

You can reproduce this easily with:

 - Start with a fresh grafana database, with `nestedFolders` feature flag enabled
 - Create a dashboard at the root
 - Create a folder at the root
 - Delete the folder
 - Create a new folder
 - Call `GET /api/folders` - it will error with `[guardian.dashboardNotFound] failed to get dashboard by UID: Dashboard not found`

I think this is because `folder.GetChildren` calls `guardian.New()` with a folder ID instead of `guardian.NewByUID()` a folder UID. This PR changes it `guardian.NewByUID()`. I'm unfamiliar with guardian so I'm happy to close this and someone else fix it :)

I _think_ there's this other call that might also need to be updated, but I'm unsure https://github.com/grafana/grafana/blob/b37657f03090566c921f8db749403ea5f1d263a0/pkg/services/folder/folderimpl/folder.go/#L735-L736