### PR TITLE
Loki Context UI: Do not disable last label

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -6020,6 +6020,9 @@ exports[`better eslint`] = {
     "public/app/plugins/datasource/loki/LiveStreams.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
+    "public/app/plugins/datasource/loki/components/LokiContextUi.test.tsx:5381": [
+      [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
+    ],
     "public/app/plugins/datasource/loki/components/LokiLabelBrowser.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"]

--- a/.betterer.results
+++ b/.betterer.results
@@ -6021,7 +6021,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
     "public/app/plugins/datasource/loki/components/LokiContextUi.test.tsx:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "2"]
     ],
     "public/app/plugins/datasource/loki/components/LokiLabelBrowser.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],

--- a/public/app/plugins/datasource/loki/components/LokiContextUi.test.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiContextUi.test.tsx
@@ -66,7 +66,7 @@ describe('LokiContextUi', () => {
     render(<LokiContextUi {...props} />);
 
     // Initial set of labels is available and not selected
-    expect(await screen.findByText(/Select labels to include in the context query/)).toBeInTheDocument();
+    expect(await screen.findByText(/Select labels to be included in the context query/)).toBeInTheDocument();
   });
 
   it('starts the languageProvider', async () => {

--- a/public/app/plugins/datasource/loki/components/LokiContextUi.test.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiContextUi.test.tsx
@@ -17,8 +17,13 @@ jest.mock('@grafana/runtime', () => ({
 describe('LokiContextUi', () => {
   const savedGlobal = global;
   beforeAll(() => {
-    if (typeof structuredClone !== 'undefined') {
-      (global as any).structuredClone = structuredClone;
+    // TODO: `structuredClone` is not yet in jsdom https://github.com/jsdom/jsdom/issues/3363
+    if (!(global as any).structuredClone) {
+      (global as any).structuredClone = function structuredClone(objectToClone: any) {
+        const stringified = JSON.stringify(objectToClone);
+        const parsed = JSON.parse(stringified);
+        return parsed;
+      };
     }
   });
   afterAll(() => {

--- a/public/app/plugins/datasource/loki/components/LokiContextUi.test.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiContextUi.test.tsx
@@ -15,6 +15,15 @@ jest.mock('@grafana/runtime', () => ({
 }));
 
 describe('LokiContextUi', () => {
+  const savedGlobal = global;
+  beforeAll(() => {
+    if (typeof structuredClone !== 'undefined') {
+      (global as any).structuredClone = structuredClone;
+    }
+  });
+  afterAll(() => {
+    global = savedGlobal;
+  });
   const setupProps = (): LokiContextUiProps => {
     const mockLanguageProvider = {
       start: jest.fn().mockImplementation(() => Promise.resolve()),

--- a/public/app/plugins/datasource/loki/components/LokiContextUi.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiContextUi.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/css';
+import { cloneDeep } from 'lodash';
 import memoizeOne from 'memoize-one';
 import React, { useEffect, useState } from 'react';
 import { useAsync } from 'react-use';
@@ -49,9 +50,11 @@ export function LokiContextUi(props: LokiContextUiProps) {
   const styles = useStyles2(getStyles);
 
   const [contextFilters, setContextFilters] = useState<ContextFilter[]>([]);
+
   const [initialized, setInitialized] = useState(false);
   const timerHandle = React.useRef<number>();
   const previousInitialized = React.useRef<boolean>(false);
+  const previousContextFilters = React.useRef<ContextFilter[]>([]);
   useEffect(() => {
     if (!initialized) {
       return;
@@ -62,6 +65,13 @@ export function LokiContextUi(props: LokiContextUiProps) {
       previousInitialized.current = initialized;
       return;
     }
+
+    if (contextFilters.filter(({ enabled, fromParser }) => enabled && !fromParser).length === 0) {
+      setContextFilters(previousContextFilters.current);
+      return;
+    }
+
+    previousContextFilters.current = cloneDeep(contextFilters);
 
     if (timerHandle.current) {
       clearTimeout(timerHandle.current);

--- a/public/app/plugins/datasource/loki/components/LokiContextUi.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiContextUi.tsx
@@ -1,5 +1,4 @@
 import { css } from '@emotion/css';
-import { cloneDeep } from 'lodash';
 import memoizeOne from 'memoize-one';
 import React, { useEffect, useState } from 'react';
 import { useAsync } from 'react-use';
@@ -71,7 +70,7 @@ export function LokiContextUi(props: LokiContextUiProps) {
       return;
     }
 
-    previousContextFilters.current = cloneDeep(contextFilters);
+    previousContextFilters.current = structuredClone(contextFilters);
 
     if (timerHandle.current) {
       clearTimeout(timerHandle.current);

--- a/public/app/plugins/datasource/loki/components/LokiContextUi.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiContextUi.tsx
@@ -143,7 +143,7 @@ export function LokiContextUi(props: LokiContextUiProps) {
             colorIndex={1}
           />
         </Tooltip>{' '}
-        Select labels to include in the context query:
+        Select labels to be included in the context query:
       </div>
       <div>
         <MultiSelect


### PR DESCRIPTION
**What is this feature?**

This PR improves two things in Loki's experimental context UI:
- description
- can not remove labels if it would be the last enabled one

**Steps to reproduce**

1. Configure Grafana to use the `logsContextDatasourceUi` feature flag
2. Start Grafana and a Loki DB
3. Make any query containing a line filter operation
4. Open the LogContext and try to remove labels

Before:

https://user-images.githubusercontent.com/8092184/217248496-9b78d962-e13f-4233-a531-c5fab72040e9.mov



With the fix:

https://user-images.githubusercontent.com/8092184/217248546-62304e3f-a2da-4aa9-a95c-d7dab62acfd3.mov



