### PR TITLE
MSSQL/Postgres: List views in table dropdown as well

### DIFF
--- a/public/app/plugins/datasource/mssql/MSSqlMetaQuery.ts
+++ b/public/app/plugins/datasource/mssql/MSSqlMetaQuery.ts
@@ -5,8 +5,7 @@ export function showDatabases() {
 
 export function getSchemaAndName(database?: string) {
   return `SELECT TABLE_SCHEMA + '.' + TABLE_NAME as schemaAndName
-    FROM [${database}].INFORMATION_SCHEMA.TABLES
-    WHERE TABLE_TYPE = 'BASE TABLE'`;
+    FROM [${database}].INFORMATION_SCHEMA.TABLES`;
 }
 
 export function getSchema(database?: string, table?: string) {

--- a/public/app/plugins/datasource/postgres/postgresMetaQuery.ts
+++ b/public/app/plugins/datasource/postgres/postgresMetaQuery.ts
@@ -16,7 +16,7 @@ export function showTables() {
                              '_timescaledb_config',
                              'timescaledb_information',
                              'timescaledb_experimental')
-      and table_type = 'BASE TABLE' and ${buildSchemaConstraint()}`;
+      and ${buildSchemaConstraint()}`;
 }
 
 export function getSchema(table?: string) {


### PR DESCRIPTION
This PR fixes an issue that the table dropdown for the MSSQL and Postgres datasource only showed tables and not views. This pr fixes it by removing the constraint in the table query.

**Which issue(s) does this PR fix?**:

Fixes #59775 #62674

**Special notes for your reviewer**:

