### PR TITLE
AuthN: support sync cache for proxy client

### DIFF
--- a/pkg/services/authn/authn.go
+++ b/pkg/services/authn/authn.go
@@ -47,6 +47,8 @@ type ClientParams struct {
 	EnableDisabledUsers bool
 	// FetchSyncedUser ensure that all required information is added to the identity
 	FetchSyncedUser bool
+	// CacheAuthProxyKey  if this key is set we will try to cache the user id for proxy client
+	CacheAuthProxyKey string
 	// LookUpParams are the arguments used to look up the entity in the DB.
 	LookUpParams login.UserLookupParams
 }

--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -110,7 +110,6 @@ func ProvideService(
 			s.log.Error("failed to configure auth proxy", "err", err)
 		} else {
 			s.RegisterClient(proxy)
-			s.RegisterPostAuthHook(proxy.CacheProxyUserHook, 100)
 		}
 	}
 

--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/grafana/grafana/pkg/infra/remotecache"
 	"github.com/hashicorp/go-multierror"
 	"go.opentelemetry.io/otel/attribute"
 
@@ -53,7 +54,7 @@ func ProvideService(
 	loginAttempts loginattempt.Service, quotaService quota.Service,
 	authInfoService login.AuthInfoService, renderService rendering.Service,
 	features *featuremgmt.FeatureManager, oauthTokenService oauthtoken.OAuthTokenService,
-	socialService social.Service,
+	socialService social.Service, cache *remotecache.RemoteCache,
 ) *Service {
 	s := &Service{
 		log:            log.New("authn.service"),
@@ -104,11 +105,12 @@ func ProvideService(
 	}
 
 	if s.cfg.AuthProxyEnabled && len(proxyClients) > 0 {
-		proxy, err := clients.ProvideProxy(cfg, proxyClients...)
+		proxy, err := clients.ProvideProxy(cfg, cache, userService, proxyClients...)
 		if err != nil {
 			s.log.Error("failed to configure auth proxy", "err", err)
 		} else {
 			s.RegisterClient(proxy)
+			s.RegisterPostAuthHook(proxy.CacheProxyUserHook, 100)
 		}
 	}
 

--- a/pkg/services/authn/clients/proxy.go
+++ b/pkg/services/authn/clients/proxy.go
@@ -2,12 +2,18 @@ package clients
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
+	"hash/fnv"
 	"net"
 	"path"
 	"strings"
+	"time"
 
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/infra/remotecache"
 	"github.com/grafana/grafana/pkg/services/authn"
+	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
 	"github.com/grafana/grafana/pkg/util/errutil"
@@ -19,6 +25,7 @@ const (
 	proxyFieldLogin  = "Login"
 	proxyFieldRole   = "Role"
 	proxyFieldGroups = "Groups"
+	proxyCachePrefix = "auth-proxy-sync-ttl:"
 )
 
 var proxyFields = [...]string{proxyFieldName, proxyFieldEmail, proxyFieldLogin, proxyFieldRole, proxyFieldGroups}
@@ -31,16 +38,19 @@ var (
 
 var _ authn.ContextAwareClient = new(Proxy)
 
-func ProvideProxy(cfg *setting.Cfg, clients ...authn.ProxyClient) (*Proxy, error) {
+func ProvideProxy(cfg *setting.Cfg, cache *remotecache.RemoteCache, userSrv user.Service, clients ...authn.ProxyClient) (*Proxy, error) {
 	list, err := parseAcceptList(cfg.AuthProxyWhitelist)
 	if err != nil {
 		return nil, err
 	}
-	return &Proxy{cfg, clients, list}, nil
+	return &Proxy{log.New(authn.ClientProxy), cfg, cache, userSrv, clients, list}, nil
 }
 
 type Proxy struct {
+	log         log.Logger
 	cfg         *setting.Cfg
+	cache       *remotecache.RemoteCache
+	userSrv     user.Service
 	clients     []authn.ProxyClient
 	acceptedIPs []*net.IPNet
 }
@@ -61,13 +71,36 @@ func (c *Proxy) Authenticate(ctx context.Context, r *authn.Request) (*authn.Iden
 
 	additional := getAdditionalProxyHeaders(r, c.cfg)
 
-	// FIXME: add cache to prevent sync on every request
+	cacheKey, ok := getProxyCacheKey(username, additional)
+	if ok {
+		// See if we have cached the user id, in that case we can fetch the signed-in user and skip sync.
+		// Error here means that we could not find anything in cache, so we can proceed as usual
+		if entry, err := c.cache.Get(ctx, cacheKey); err == nil {
+			usr, err := c.userSrv.GetSignedInUserWithCacheCtx(ctx, &user.GetSignedInUserQuery{
+				UserID: entry.(int64),
+				OrgID:  r.OrgID,
+			})
 
+			if err != nil {
+				c.log.Warn("could not resolved cached user", "error", err, "userId", entry.(int64))
+			}
+
+			// if we for some reason cannot find the user we proceed with the normal flow, authenticate with ProxyClient
+			// and perform syncs
+			if usr != nil {
+				// skip all syncs
+				c.log.Debug("user was loaded from cache, skip syncs", "userId", usr.UserID)
+				return authn.IdentityFromSignedInUser(authn.NamespacedID(authn.NamespaceUser, usr.UserID), usr, authn.ClientParams{}), nil
+			}
+		}
+
+	}
 	var clientErr error
 	for _, proxyClient := range c.clients {
 		var identity *authn.Identity
 		identity, clientErr = proxyClient.AuthenticateProxy(ctx, r, username, additional)
 		if identity != nil {
+			identity.ClientParams.CacheAuthProxyKey = cacheKey
 			return identity, nil
 		}
 	}
@@ -81,6 +114,24 @@ func (c *Proxy) Test(ctx context.Context, r *authn.Request) bool {
 
 func (c *Proxy) Priority() uint {
 	return 50
+}
+
+func (c *Proxy) CacheProxyUserHook(ctx context.Context, identity *authn.Identity, r *authn.Request) error {
+	if identity.ClientParams.CacheAuthProxyKey != "" {
+		return nil
+	}
+
+	namespace, id := identity.NamespacedID()
+	if namespace != authn.NamespaceUser {
+		return nil
+	}
+
+	c.log.Debug("cache proxy user", "userId", id)
+	if err := c.cache.Set(ctx, identity.ClientParams.CacheAuthProxyKey, id, time.Duration(c.cfg.AuthProxySyncTTL)*time.Minute); err != nil {
+		c.log.Warn("failed to cache proxy user", "error", err, "userId", id)
+	}
+
+	return nil
 }
 
 func (c *Proxy) isAllowedIP(r *authn.Request) bool {
@@ -152,4 +203,22 @@ func getAdditionalProxyHeaders(r *authn.Request, cfg *setting.Cfg) map[string]st
 		}
 	}
 	return additional
+}
+
+func getProxyCacheKey(username string, additional map[string]string) (string, bool) {
+	key := strings.Builder{}
+	key.WriteString(proxyCachePrefix)
+	key.WriteString(username)
+	for _, k := range proxyFields {
+		if v, ok := additional[k]; ok {
+			key.WriteString(v)
+		}
+	}
+
+	hash := fnv.New128a()
+	if _, err := hash.Write([]byte(key.String())); err != nil {
+		return "", false
+	}
+
+	return hex.EncodeToString(hash.Sum(nil)), true
 }

--- a/pkg/services/authn/clients/proxy.go
+++ b/pkg/services/authn/clients/proxy.go
@@ -36,7 +36,10 @@ var (
 	errInvalidProxyHeader = errutil.NewBase(errutil.StatusInternal, "auth-proxy.invalid-proxy-header")
 )
 
-var _ authn.ContextAwareClient = new(Proxy)
+var (
+	_ authn.HookClient         = new(Proxy)
+	_ authn.ContextAwareClient = new(Proxy)
+)
 
 func ProvideProxy(cfg *setting.Cfg, cache *remotecache.RemoteCache, userSrv user.Service, clients ...authn.ProxyClient) (*Proxy, error) {
 	list, err := parseAcceptList(cfg.AuthProxyWhitelist)
@@ -116,7 +119,7 @@ func (c *Proxy) Priority() uint {
 	return 50
 }
 
-func (c *Proxy) CacheProxyUserHook(ctx context.Context, identity *authn.Identity, r *authn.Request) error {
+func (c *Proxy) Hook(ctx context.Context, identity *authn.Identity, r *authn.Request) error {
 	if identity.ClientParams.CacheAuthProxyKey != "" {
 		return nil
 	}

--- a/pkg/services/authn/clients/proxy_test.go
+++ b/pkg/services/authn/clients/proxy_test.go
@@ -109,7 +109,7 @@ func TestProxy_Authenticate(t *testing.T) {
 				calledAdditional = additional
 				return nil, nil
 			}}
-			c, err := ProvideProxy(cfg, proxyClient)
+			c, err := ProvideProxy(cfg, nil, nil, proxyClient)
 			require.NoError(t, err)
 
 			_, err = c.Authenticate(context.Background(), tt.req)
@@ -165,7 +165,7 @@ func TestProxy_Test(t *testing.T) {
 			cfg := setting.NewCfg()
 			cfg.AuthProxyHeaderName = "Proxy-Header"
 
-			c, _ := ProvideProxy(cfg, nil)
+			c, _ := ProvideProxy(cfg, nil, nil, nil)
 			assert.Equal(t, tt.expectedOK, c.Test(context.Background(), tt.req))
 		})
 	}

--- a/pkg/services/authn/clients/proxy_test.go
+++ b/pkg/services/authn/clients/proxy_test.go
@@ -7,12 +7,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grafana/grafana/pkg/services/user/usertest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/services/authn"
 	"github.com/grafana/grafana/pkg/services/authn/authntest"
+	"github.com/grafana/grafana/pkg/services/user/usertest"
 	"github.com/grafana/grafana/pkg/setting"
 )
 


### PR DESCRIPTION
**What is this feature?**
This is the missing feature that auth proxy has outside of authn.Service.

In order to not perform syncs on each request we use the remote cache to store the id for user. Then we can check if they cache key that is based on auth proxy header resolves to a user id. In that case we can just return the identity based on that user and skip all syncs.

Otherwise we proceed with the normal flow, run all auth hooks and lastly cache the user id using a client hook

