### PR TITLE
CommandPalette: Move quick add actions to top level

### DIFF
--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -440,7 +440,7 @@ func (s *ServiceImpl) buildDashboardNavLinks(c *contextmodel.ReqContext, hasEdit
 	if hasEditPerm {
 		if hasAccess(hasEditPermInAnyFolder, ac.EvalPermission(dashboards.ActionDashboardsCreate)) {
 			dashboardChildNavs = append(dashboardChildNavs, &navtree.NavLink{
-				Text: "New dashboard", Icon: "plus", Url: s.cfg.AppSubURL + "/dashboard/new", HideFromTabs: true, Id: "dashboards/new", ShowIconInNavbar: true, IsCreateAction: true,
+				Text: "Create dashboard", Icon: "plus", Url: s.cfg.AppSubURL + "/dashboard/new", HideFromTabs: true, Id: "dashboards/new", ShowIconInNavbar: true, IsCreateAction: true,
 			})
 		}
 	}
@@ -448,7 +448,7 @@ func (s *ServiceImpl) buildDashboardNavLinks(c *contextmodel.ReqContext, hasEdit
 	if hasEditPerm && !s.features.IsEnabled(featuremgmt.FlagTopnav) {
 		if hasAccess(ac.ReqOrgAdminOrEditor, ac.EvalPermission(dashboards.ActionFoldersCreate)) {
 			dashboardChildNavs = append(dashboardChildNavs, &navtree.NavLink{
-				Text: "New folder", SubTitle: "Create a new folder to organize your dashboards", Id: "dashboards/folder/new",
+				Text: "Create folder", SubTitle: "Create a new folder to organize your dashboards", Id: "dashboards/folder/new",
 				Icon: "plus", Url: s.cfg.AppSubURL + "/dashboards/folder/new", HideFromTabs: true, ShowIconInNavbar: true,
 			})
 		}

--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -545,7 +545,7 @@ func (s *ServiceImpl) buildAlertNavLinks(c *contextmodel.ReqContext, hasEditPerm
 		}
 
 		alertChildNavs = append(alertChildNavs, &navtree.NavLink{
-			Text: "New alert rule", SubTitle: "Create an alert rule", Id: "alert",
+			Text: "Create alert rule", SubTitle: "Create an alert rule", Id: "alert",
 			Icon: "plus", Url: s.cfg.AppSubURL + "/alerting/new", HideFromTabs: true, ShowIconInNavbar: true, IsCreateAction: true,
 		})
 	}

--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -440,7 +440,7 @@ func (s *ServiceImpl) buildDashboardNavLinks(c *contextmodel.ReqContext, hasEdit
 	if hasEditPerm {
 		if hasAccess(hasEditPermInAnyFolder, ac.EvalPermission(dashboards.ActionDashboardsCreate)) {
 			dashboardChildNavs = append(dashboardChildNavs, &navtree.NavLink{
-				Text: "Create dashboard", Icon: "plus", Url: s.cfg.AppSubURL + "/dashboard/new", HideFromTabs: true, Id: "dashboards/new", ShowIconInNavbar: true, IsCreateAction: true,
+				Text: "New dashboard", Icon: "plus", Url: s.cfg.AppSubURL + "/dashboard/new", HideFromTabs: true, Id: "dashboards/new", ShowIconInNavbar: true, IsCreateAction: true,
 			})
 		}
 	}
@@ -448,7 +448,7 @@ func (s *ServiceImpl) buildDashboardNavLinks(c *contextmodel.ReqContext, hasEdit
 	if hasEditPerm && !s.features.IsEnabled(featuremgmt.FlagTopnav) {
 		if hasAccess(ac.ReqOrgAdminOrEditor, ac.EvalPermission(dashboards.ActionFoldersCreate)) {
 			dashboardChildNavs = append(dashboardChildNavs, &navtree.NavLink{
-				Text: "Create folder", SubTitle: "Create a new folder to organize your dashboards", Id: "dashboards/folder/new",
+				Text: "New folder", SubTitle: "Create a new folder to organize your dashboards", Id: "dashboards/folder/new",
 				Icon: "plus", Url: s.cfg.AppSubURL + "/dashboards/folder/new", HideFromTabs: true, ShowIconInNavbar: true,
 			})
 		}
@@ -545,7 +545,7 @@ func (s *ServiceImpl) buildAlertNavLinks(c *contextmodel.ReqContext, hasEditPerm
 		}
 
 		alertChildNavs = append(alertChildNavs, &navtree.NavLink{
-			Text: "Create alert rule", SubTitle: "Create an alert rule", Id: "alert",
+			Text: "New alert rule", SubTitle: "Create an alert rule", Id: "alert",
 			Icon: "plus", Url: s.cfg.AppSubURL + "/alerting/new", HideFromTabs: true, ShowIconInNavbar: true, IsCreateAction: true,
 		})
 	}

--- a/public/app/core/components/NavBar/navBarItem-translations.ts
+++ b/public/app/core/components/NavBar/navBarItem-translations.ts
@@ -5,7 +5,7 @@
 import { config } from '@grafana/runtime';
 import { t } from 'app/core/internationalization';
 
-// The keys of the TRANSLATED_MENU_ITEMS object (NOT the id inside the defineMessage function)
+// The keys of the TRANSLATED_MENU_ITEMS object ((NOT the id inside the defineMessage function)
 // must match the ID of the navigation item, as defined in the backend nav model
 
 // see pkg/api/index.go
@@ -42,9 +42,9 @@ export function getNavTitle(navId: string | undefined) {
     case 'dashboards/library-panels':
       return t('nav.library-panels.title', 'Library panels');
     case 'dashboards/new':
-      return t('nav.new-dashboard.title', 'Create dashboard');
+      return t('nav.new-dashboard.title', 'New dashboard');
     case 'dashboards/folder/new':
-      return t('nav.new-folder.title', 'Create folder');
+      return t('nav.new-folder.title', 'New folder');
     case 'dashboards/import':
       return t('nav.create-import.title', 'Import');
     case 'scenes':

--- a/public/app/core/components/NavBar/navBarItem-translations.ts
+++ b/public/app/core/components/NavBar/navBarItem-translations.ts
@@ -5,11 +5,8 @@
 import { config } from '@grafana/runtime';
 import { t } from 'app/core/internationalization';
 
-// The keys of the TRANSLATED_MENU_ITEMS object ((NOT the id inside the defineMessage function)
-// must match the ID of the navigation item, as defined in the backend nav model
-
-// see pkg/api/index.go
 export function getNavTitle(navId: string | undefined) {
+  // the switch cases must match the ID of the navigation item, as defined in the backend nav model
   switch (navId) {
     case 'home':
       return t('nav.home.title', 'Home');

--- a/public/app/core/components/NavBar/navBarItem-translations.ts
+++ b/public/app/core/components/NavBar/navBarItem-translations.ts
@@ -42,9 +42,9 @@ export function getNavTitle(navId: string | undefined) {
     case 'dashboards/library-panels':
       return t('nav.library-panels.title', 'Library panels');
     case 'dashboards/new':
-      return t('nav.new-dashboard.title', 'New dashboard');
+      return t('nav.new-dashboard.title', 'Create dashboard');
     case 'dashboards/folder/new':
-      return t('nav.new-folder.title', 'New folder');
+      return t('nav.new-folder.title', 'Create folder');
     case 'dashboards/import':
       return t('nav.create-import.title', 'Import');
     case 'scenes':

--- a/public/app/core/components/NavBar/navBarItem-translations.ts
+++ b/public/app/core/components/NavBar/navBarItem-translations.ts
@@ -21,7 +21,7 @@ export function getNavTitle(navId: string | undefined) {
     case 'import':
       return t('nav.create-import.title', 'Import');
     case 'alert':
-      return t('nav.create-alert.title', 'New alert rule');
+      return t('nav.create-alert.title', 'Create alert rule');
     case 'starred':
       return t('nav.starred.title', 'Starred');
     case 'starred-empty':

--- a/public/app/features/commandPalette/actions/staticActions.ts
+++ b/public/app/features/commandPalette/actions/staticActions.ts
@@ -4,10 +4,7 @@ import { t } from 'app/core/internationalization';
 import { changeTheme } from 'app/core/services/theme';
 
 import { CommandPaletteAction } from '../types';
-import { DEFAULT_PRIORITY, PREFERENCES_PRIORITY } from '../values';
-
-// We reuse this, but translations cannot be in module scope (t must be called after i18n has set up,)
-const getPagesSectionTranslation = () => t('command-palette.section.pages', 'Pages');
+import { ACTIONS_PRIORITY, DEFAULT_PRIORITY, PREFERENCES_PRIORITY } from '../values';
 
 // TODO: Clean this once ID is mandatory on nav items
 function idForNavItem(navItem: NavModelItem) {
@@ -25,15 +22,19 @@ function navTreeToActions(navTree: NavModelItem[], parent?: NavModelItem): Comma
       continue;
     }
 
-    const section = isCreateAction ? t('command-palette.section.actions', 'Actions') : getPagesSectionTranslation();
+    const section = isCreateAction
+      ? t('command-palette.section.actions', 'Actions')
+      : t('command-palette.section.pages', 'Pages');
+
+    const priority = isCreateAction ? ACTIONS_PRIORITY : DEFAULT_PRIORITY;
 
     const action = {
       id: idForNavItem(navItem),
       name: text, // TODO: translate
       section: section,
       url: url && locationUtil.stripBaseFromUrl(url),
-      parent: parent && idForNavItem(parent),
-      priority: DEFAULT_PRIORITY,
+      parent: parent && !isCreateAction && idForNavItem(parent),
+      priority: priority,
     };
 
     navActions.push(action);

--- a/public/app/features/commandPalette/values.ts
+++ b/public/app/features/commandPalette/values.ts
@@ -1,4 +1,5 @@
-export const RECENT_DASHBOARDS_PRORITY = 4;
+export const RECENT_DASHBOARDS_PRORITY = 5;
+export const ACTIONS_PRIORITY = 4;
 export const DEFAULT_PRIORITY = 3;
 export const PREFERENCES_PRIORITY = 2;
 export const SEARCH_RESULTS_PRORITY = 1; // Dynamic actions should be below static ones so the list doesn't 'jump' when they come in

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -259,10 +259,10 @@
       "title": "New"
     },
     "new-dashboard": {
-      "title": "Create dashboard"
+      "title": "New dashboard"
     },
     "new-folder": {
-      "title": "Create folder"
+      "title": "New folder"
     },
     "org-settings": {
       "subtitle": "Manage preferences across an organization",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -191,7 +191,7 @@
       "title": "Create"
     },
     "create-alert": {
-      "title": "New alert rule"
+      "title": "Create alert rule"
     },
     "create-dashboard": {
       "title": "Dashboard"

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -13,7 +13,7 @@
       "search": "Search"
     },
     "search-box": {
-      "placeholder": "Search Grafana"
+      "placeholder": "Search or jump to..."
     },
     "section": {
       "actions": "Actions",
@@ -160,7 +160,7 @@
       "title": "Alert rules"
     },
     "alerting-receivers": {
-      "subtitle": "Choose how to notify your  contact points when an alert instance fires",
+      "subtitle": "Choose how to notify your contact points when an alert instance fires",
       "title": "Contact points"
     },
     "alerting-silences": {
@@ -191,7 +191,7 @@
       "title": "Create"
     },
     "create-alert": {
-      "title": "Create alert rule"
+      "title": "New alert rule"
     },
     "create-dashboard": {
       "title": "Dashboard"
@@ -259,10 +259,10 @@
       "title": "New"
     },
     "new-dashboard": {
-      "title": "New dashboard"
+      "title": "Create dashboard"
     },
     "new-folder": {
-      "title": "New folder"
+      "title": "Create folder"
     },
     "org-settings": {
       "subtitle": "Manage preferences across an organization",

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -13,7 +13,7 @@
       "search": "Ŝęäřčĥ"
     },
     "search-box": {
-      "placeholder": "Ŝęäřčĥ Ğřäƒäŉä"
+      "placeholder": "Ŝęäřčĥ őř ĵūmp ŧő..."
     },
     "section": {
       "actions": "Åčŧįőŉş",
@@ -160,7 +160,7 @@
       "title": "Åľęřŧ řūľęş"
     },
     "alerting-receivers": {
-      "subtitle": "Đęčįđę ĥőŵ yőūř čőŉŧäčŧş äřę ŉőŧįƒįęđ ŵĥęŉ äŉ äľęřŧ ƒįřęş",
+      "subtitle": "Cĥőőşę ĥőŵ ŧő ŉőŧįƒy yőūř čőŉŧäčŧ pőįŉŧş ŵĥęŉ äŉ äľęřŧ įŉşŧäŉčę ƒįřęş",
       "title": "Cőŉŧäčŧ pőįŉŧş"
     },
     "alerting-silences": {
@@ -259,10 +259,10 @@
       "title": "Ńęŵ"
     },
     "new-dashboard": {
-      "title": "Ńęŵ đäşĥþőäřđ"
+      "title": "Cřęäŧę đäşĥþőäřđ"
     },
     "new-folder": {
-      "title": "Ńęŵ ƒőľđęř"
+      "title": "Cřęäŧę ƒőľđęř"
     },
     "org-settings": {
       "subtitle": "Mäŉäģę přęƒęřęŉčęş äčřőşş äŉ őřģäŉįžäŧįőŉ",

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -259,10 +259,10 @@
       "title": "Ńęŵ"
     },
     "new-dashboard": {
-      "title": "Cřęäŧę đäşĥþőäřđ"
+      "title": "Ńęŵ đäşĥþőäřđ"
     },
     "new-folder": {
-      "title": "Cřęäŧę ƒőľđęř"
+      "title": "Ńęŵ ƒőľđęř"
     },
     "org-settings": {
       "subtitle": "Mäŉäģę přęƒęřęŉčęş äčřőşş äŉ őřģäŉįžäŧįőŉ",

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -191,7 +191,7 @@
       "title": "Cřęäŧę"
     },
     "create-alert": {
-      "title": "Ńęŵ äľęřŧ řūľę"
+      "title": "Cřęäŧę äľęřŧ řūľę"
     },
     "create-dashboard": {
       "title": "Đäşĥþőäřđ"


### PR DESCRIPTION
**What is this feature?**

Quick add actions incorrectly had a parent set to their position in navtree. 

This changes quick add actions to move the to the top level of the command palette so they're easily visible.

~~Additionally, it changes "New Folder" and "New Dashboard" to use the 'Create' verb for consistency. Happy to change "Create alert rule" to "New" instead, or back out this change entirely.~~ I've backed out this change - we can do this indepedently to make sure we change to the correct thing.

**Why do we need this feature?**

So the actions are visible, rather than hidden behind command palette search

**Who is this feature for?**

People who want to create things!

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

