### PR TITLE
Annotation cleanup job: rollback on error

### DIFF
--- a/pkg/services/annotations/annotationsimpl/cleanup_test.go
+++ b/pkg/services/annotations/annotationsimpl/cleanup_test.go
@@ -185,8 +185,8 @@ func TestAnnotationCleanUp_Timeout(t *testing.T) {
 		require.ErrorIs(t, err, context.DeadlineExceeded)
 	}()
 
-	// unfortunately we can't assert on the expected annotation counts here:
-	// occasional deletions succeed (one or more of the annotation "types").
+	// nothing should have been deleted!
+	assertAnnotationCount(t, fakeSQL, "", int64(annotationCount))
 }
 
 func assertAnnotationCount(t *testing.T, fakeSQL db.DB, sql string, expectedCount int64) {

--- a/pkg/services/annotations/annotationsimpl/cleanup_test.go
+++ b/pkg/services/annotations/annotationsimpl/cleanup_test.go
@@ -169,7 +169,7 @@ func TestAnnotationCleanUp_Timeout(t *testing.T) {
 	cfg := setting.NewCfg()
 	cfg.AnnotationCleanupJobBatchSize = 100 // batch size > total number of annotations
 	createTestAnnotations(t, fakeSQL, annotationCount, 6)
-	cleaner := ProvideCleanupService(fakeSQL, cfg)
+	cleaner := ProvideCleanupService(fakeSQL, cfg, &featuremgmt.FeatureManager{})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
 	defer cancel()

--- a/pkg/services/annotations/annotationsimpl/cleanup_test.go
+++ b/pkg/services/annotations/annotationsimpl/cleanup_test.go
@@ -179,8 +179,11 @@ func TestAnnotationCleanUp_Timeout(t *testing.T) {
 	cfg.DashboardAnnotationCleanupSettings = settingsFn(0, 1)
 	cfg.APIAnnotationCleanupSettings = settingsFn(0, 1)
 
-	_, _, err := cleaner.Run(ctx, cfg)
-	require.ErrorIs(t, err, context.DeadlineExceeded)
+	go func() {
+		time.Sleep(1 * time.Second)
+		_, _, err := cleaner.Run(ctx, cfg)
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+	}()
 
 	// unfortunately we can't assert on the expected annotation counts here:
 	// occasional deletions succeed (one or more of the annotation "types").

--- a/pkg/services/annotations/annotationsimpl/xorm_store.go
+++ b/pkg/services/annotations/annotationsimpl/xorm_store.go
@@ -515,10 +515,10 @@ func (r *xormRepositoryImpl) CleanAnnotations(ctx context.Context, cfg setting.A
 		sql := fmt.Sprintf(deleteQuery, annotationType, cutoffDate, r.db.GetDialect().Limit(r.cfg.AnnotationCleanupJobBatchSize))
 
 		affected, err := r.executeUntilDoneOrCancelled(ctx, sql)
-		totalAffected += affected
 		if err != nil {
 			return totalAffected, err
 		}
+		totalAffected += affected
 	}
 
 	if cfg.MaxCount > 0 {

--- a/pkg/services/annotations/annotationsimpl/xorm_store.go
+++ b/pkg/services/annotations/annotationsimpl/xorm_store.go
@@ -546,7 +546,7 @@ func (r *xormRepositoryImpl) executeUntilDoneOrCancelled(ctx context.Context, sq
 			return totalAffected, ctx.Err()
 		default:
 			var affected int64
-			err := r.db.WithDbSession(ctx, func(session *db.Session) error {
+			err := r.db.WithTransactionalDbSession(ctx, func(session *db.Session) error {
 				res, err := session.Exec(sql)
 				if err != nil {
 					return err


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/37580 

I stripped out some of the unused logic from `executeUntilDoneOrCancelled` and wrapped the sql statement in a transaction, so it would roll back on error. The service methods themselves still may return a partial cleanup job, since each annotation "type" is deleted in a separate sql statement (each using the same - not cumulative - timeout). 
