### PR TITLE
Connections: Fix redirection when creating new DS

### DIFF
--- a/public/app/features/plugins/admin/components/GetStartedWithPlugin/GetStartedWithDataSource.tsx
+++ b/public/app/features/plugins/admin/components/GetStartedWithPlugin/GetStartedWithDataSource.tsx
@@ -2,7 +2,7 @@ import React, { useCallback } from 'react';
 
 import { DataSourcePluginMeta } from '@grafana/data';
 import { Button } from '@grafana/ui';
-import { addDataSource } from 'app/features/datasources/state/actions';
+import { useDataSourcesRoutes, addDataSource } from 'app/features/datasources/state';
 import { useDispatch } from 'app/types';
 
 import { isDataSourceEditor } from '../../permissions';
@@ -14,14 +14,15 @@ type Props = {
 
 export function GetStartedWithDataSource({ plugin }: Props): React.ReactElement | null {
   const dispatch = useDispatch();
+  const dataSourcesRoutes = useDataSourcesRoutes();
   const onAddDataSource = useCallback(() => {
     const meta = {
       name: plugin.name,
       id: plugin.id,
     } as DataSourcePluginMeta;
 
-    dispatch(addDataSource(meta));
-  }, [dispatch, plugin]);
+    dispatch(addDataSource(meta, dataSourcesRoutes.Edit));
+  }, [dispatch, plugin, dataSourcesRoutes]);
 
   if (!isDataSourceEditor()) {
     return null;


### PR DESCRIPTION
### What changed?

Until now when a new datasource was created from "Connections > Connect data > Data source details" it was accidentally redirecting the user to the datasource edit page under "Administration". This PR aims to fix that.

![Screenshot 2023-02-06 at 11 12 25](https://user-images.githubusercontent.com/9974811/216945037-04b91e6e-301b-4382-b39c-ab5dbccd283e.png)
