### PR TITLE
Datasources: Fix tracking event name

### DIFF
--- a/public/app/features/datasources/tracking.ts
+++ b/public/app/features/datasources/tracking.ts
@@ -72,5 +72,5 @@ export const trackExploreClicked = (props: DataSourceGeneralTrackingProps) => {
 };
 
 export const trackCreateDashboardClicked = (props: DataSourceGeneralTrackingProps) => {
-  reportInteraction('grafana_ds_explore_datasource_clicked', props);
+  reportInteraction('grafana_ds_create_dashboard_clicked', props);
 };


### PR DESCRIPTION
### What changed?

There was a typo in the name of one of the events.