### PR TITLE
Logs: Only display prettify json toggle if logs are json

### DIFF
--- a/public/app/features/explore/Logs.tsx
+++ b/public/app/features/explore/Logs.tsx
@@ -41,6 +41,7 @@ import {
 } from '@grafana/ui';
 import { dedupLogRows, filterLogLevels } from 'app/core/logsModel';
 import store from 'app/core/store';
+import { isLogLineJSON } from 'app/plugins/datasource/loki/lineParser';
 import { ExploreId } from 'app/types/explore';
 
 import { RowContextOptions } from '../logs/components/LogRowContextProvider';
@@ -372,6 +373,7 @@ class UnthemedLogs extends PureComponent<Props, State> {
     const navigationRange = this.createNavigationRange(logRows);
 
     const scanText = scanRange ? `Scanning ${rangeUtil.describeTimeRange(scanRange)}` : 'Scanning...';
+    let hasJsonLogs = logRows.some((row) => isLogLineJSON(row.raw));
 
     return (
       <>
@@ -429,15 +431,17 @@ class UnthemedLogs extends PureComponent<Props, State> {
                   id={`wrap-lines_${exploreId}`}
                 />
               </InlineField>
-              <InlineField label="Prettify JSON" className={styles.horizontalInlineLabel} transparent>
-                <InlineSwitch
-                  value={prettifyLogMessage}
-                  onChange={this.onChangePrettifyLogMessage}
-                  className={styles.horizontalInlineSwitch}
-                  transparent
-                  id={`prettify_${exploreId}`}
-                />
-              </InlineField>
+              {hasJsonLogs && (
+                <InlineField label="Prettify JSON" className={styles.horizontalInlineLabel} transparent>
+                  <InlineSwitch
+                    value={prettifyLogMessage}
+                    onChange={this.onChangePrettifyLogMessage}
+                    className={styles.horizontalInlineSwitch}
+                    transparent
+                    id={`prettify_${exploreId}`}
+                  />
+                </InlineField>
+              )}
               <InlineField label="Dedup" className={styles.horizontalInlineLabel} transparent>
                 <RadioButtonGroup
                   options={Object.values(LogsDedupStrategy).map((dedupType) => ({


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
currently the `Prettify JSON` toggle is always displayed. this pr changes that so it is only displayed if the logs are in json format.

**Why do we need this feature?**
...

**Who is this feature for?**
...

**Which issue(s) does this PR fix?**:
Fixes #62872

**Special notes for your reviewer**:

