### PR TITLE
Datasources: Add optional tracking for datasources list viewed

### DIFF
--- a/public/app/features/datasources/components/DataSourcesList.tsx
+++ b/public/app/features/datasources/components/DataSourcesList.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 
 import { DataSourceSettings, GrafanaTheme2 } from '@grafana/data';
@@ -11,7 +11,7 @@ import { contextSrv } from 'app/core/core';
 import { StoreState, AccessControlAction, useSelector } from 'app/types';
 
 import { getDataSources, getDataSourcesCount, useDataSourcesRoutes, useLoadDataSources } from '../state';
-import { trackCreateDashboardClicked, trackExploreClicked } from '../tracking';
+import { trackCreateDashboardClicked, trackExploreClicked, trackDataSourcesListViewed } from '../tracking';
 import { constructDataSourceExploreUrl } from '../utils';
 
 import { DataSourcesListHeader } from './DataSourcesListHeader';
@@ -58,6 +58,13 @@ export function DataSourcesListView({
   const styles = useStyles2(getStyles);
   const dataSourcesRoutes = useDataSourcesRoutes();
   const location = useLocation();
+
+  useEffect(() => {
+    trackDataSourcesListViewed({
+      grafana_version: config.buildInfo.version,
+      path: location.pathname,
+    });
+  }, [location]);
 
   if (isLoading) {
     return <PageLoader />;

--- a/public/app/features/datasources/tracking.ts
+++ b/public/app/features/datasources/tracking.ts
@@ -74,3 +74,7 @@ export const trackExploreClicked = (props: DataSourceGeneralTrackingProps) => {
 export const trackCreateDashboardClicked = (props: DataSourceGeneralTrackingProps) => {
   reportInteraction('grafana_ds_create_dashboard_clicked', props);
 };
+
+export const trackDataSourcesListViewed = (props: { grafana_version?: string; path?: string }) => {
+  reportInteraction('grafana_ds_datasources_list_viewed', props);
+};


### PR DESCRIPTION
### What changed?

Added a new optional UI tracking event that is fired when the list of datasources is viewed. (This is only tracked anywhere in case the tracking service target is set in the grafana INI config.)

**Name of the event:** `grafana_ds_datasources_list_viewed`