### PR TITLE
Add canonical URL to all HTTP API docs

### DIFF
--- a/docs/sources/developers/http_api/_index.md
+++ b/docs/sources/developers/http_api/_index.md
@@ -2,6 +2,7 @@
 aliases:
   - ../http_api/
   - ../overview/
+canonical: /docs/grafana/latest/developers/http_api/
 description: Grafana HTTP API
 keywords:
   - grafana

--- a/docs/sources/developers/http_api/access_control.md
+++ b/docs/sources/developers/http_api/access_control.md
@@ -2,6 +2,7 @@
 aliases:
   - ../../http_api/access_control/
   - ../../http_api/accesscontrol/
+canonical: /docs/grafana/latest/developers/http_api/access_control/
 description: ''
 keywords:
   - grafana

--- a/docs/sources/developers/http_api/admin.md
+++ b/docs/sources/developers/http_api/admin.md
@@ -1,6 +1,7 @@
 ---
 aliases:
   - ../../http_api/admin/
+canonical: /docs/grafana/latest/developers/http_api/admin/
 description: Grafana Admin HTTP API
 keywords:
   - grafana

--- a/docs/sources/developers/http_api/alerting.md
+++ b/docs/sources/developers/http_api/alerting.md
@@ -1,6 +1,7 @@
 ---
 aliases:
   - ../../http_api/alerting/
+canonical: /docs/grafana/latest/developers/http_api/alerting/
 description: Grafana Alerts HTTP API
 keywords:
   - grafana

--- a/docs/sources/developers/http_api/alerting_notification_channels.md
+++ b/docs/sources/developers/http_api/alerting_notification_channels.md
@@ -1,6 +1,7 @@
 ---
 aliases:
   - ../../http_api/alerting_notification_channels/
+canonical: /docs/grafana/latest/developers/http_api/alerting_notification_channels/
 description: Grafana Alerting Notification Channel HTTP API
 keywords:
   - grafana

--- a/docs/sources/developers/http_api/alerting_provisioning.md
+++ b/docs/sources/developers/http_api/alerting_provisioning.md
@@ -1,6 +1,7 @@
 ---
 aliases:
   - ../../http_api/alerting_provisioning/
+canonical: /docs/grafana/latest/developers/http_api/alerting_provisioning/
 description: Grafana Alerts HTTP API
 keywords:
   - grafana

--- a/docs/sources/developers/http_api/annotations.md
+++ b/docs/sources/developers/http_api/annotations.md
@@ -1,6 +1,7 @@
 ---
 aliases:
   - ../../http_api/annotations/
+canonical: /docs/grafana/latest/developers/http_api/annotations/
 description: Grafana Annotations HTTP API
 keywords:
   - grafana

--- a/docs/sources/developers/http_api/auth.md
+++ b/docs/sources/developers/http_api/auth.md
@@ -2,6 +2,7 @@
 aliases:
   - ../../http_api/auth/
   - ../../http_api/authentication/
+canonical: /docs/grafana/latest/developers/http_api/auth/
 description: Grafana Authentication HTTP API
 keywords:
   - grafana

--- a/docs/sources/developers/http_api/correlations.md
+++ b/docs/sources/developers/http_api/correlations.md
@@ -1,6 +1,7 @@
 ---
 aliases:
   - ../../http_api/correlations/
+canonical: /docs/grafana/latest/developers/http_api/correlation/
 description: Grafana Correlations HTTP API
 keywords:
   - grafana

--- a/docs/sources/developers/http_api/create-api-tokens-for-org.md
+++ b/docs/sources/developers/http_api/create-api-tokens-for-org.md
@@ -2,6 +2,7 @@
 aliases:
   - ../../http_api/create-api-tokens-for-org/
   - ../../tutorials/api_org_token_howto/
+canonical: /docs/grafana/latest/developers/http_api/create-api-tokens-for-org/
 keywords:
   - grafana
   - tutorials

--- a/docs/sources/developers/http_api/curl-examples.md
+++ b/docs/sources/developers/http_api/curl-examples.md
@@ -1,6 +1,7 @@
 ---
 aliases:
   - ../../http_api/curl-examples/
+canonical: /docs/grafana/latest/developers/http_api/curl-examples/
 description: cURL examples
 keywords:
   - grafana

--- a/docs/sources/developers/http_api/dashboard.md
+++ b/docs/sources/developers/http_api/dashboard.md
@@ -1,6 +1,7 @@
 ---
 aliases:
   - ../../http_api/dashboard/
+canonical: /docs/grafana/latest/developers/http_api/dashboard/
 description: Grafana Dashboard HTTP API
 keywords:
   - grafana

--- a/docs/sources/developers/http_api/dashboard_permissions.md
+++ b/docs/sources/developers/http_api/dashboard_permissions.md
@@ -2,6 +2,7 @@
 aliases:
   - ../../http_api/dashboard_permissions/
   - ../../http_api/dashboardpermissions/
+canonical: /docs/grafana/latest/developers/http_api/dashboard_permissions/
 description: Grafana Dashboard Permissions HTTP API
 keywords:
   - grafana

--- a/docs/sources/developers/http_api/dashboard_versions.md
+++ b/docs/sources/developers/http_api/dashboard_versions.md
@@ -2,6 +2,7 @@
 aliases:
   - ../../http_api/dashboard_versions/
   - ../../http_api/dashboardversions/
+canonical: /docs/grafana/latest/developers/http_api/dashboard_versions/
 description: Grafana Dashboard Versions HTTP API
 keywords:
   - grafana

--- a/docs/sources/developers/http_api/data_source.md
+++ b/docs/sources/developers/http_api/data_source.md
@@ -2,6 +2,7 @@
 aliases:
   - ../../http_api/data_source/
   - ../../http_api/datasource/
+canonical: /docs/grafana/latest/developers/http_api/data_source/
 description: Grafana Data source HTTP API
 keywords:
   - grafana

--- a/docs/sources/developers/http_api/datasource_permissions.md
+++ b/docs/sources/developers/http_api/datasource_permissions.md
@@ -2,6 +2,7 @@
 aliases:
   - ../../http_api/datasource_permissions/
   - ../../http_api/datasourcepermissions/
+canonical: /docs/grafana/latest/developers/http_api/datasource_permissions/
 description: Data Source Permissions API
 keywords:
   - grafana

--- a/docs/sources/developers/http_api/external_group_sync.md
+++ b/docs/sources/developers/http_api/external_group_sync.md
@@ -1,6 +1,7 @@
 ---
 aliases:
   - ../../http_api/external_group_sync/
+canonical: /docs/grafana/latest/developers/http_api/external_group_sync/
 description: Grafana External Group Sync HTTP API
 keywords:
   - grafana

--- a/docs/sources/developers/http_api/folder.md
+++ b/docs/sources/developers/http_api/folder.md
@@ -1,6 +1,7 @@
 ---
 aliases:
   - ../../http_api/folder/
+canonical: /docs/grafana/latest/developers/http_api/folder/
 description: Grafana Folder HTTP API
 keywords:
   - grafana

--- a/docs/sources/developers/http_api/folder_dashboard_search.md
+++ b/docs/sources/developers/http_api/folder_dashboard_search.md
@@ -1,6 +1,7 @@
 ---
 aliases:
   - ../../http_api/folder_dashboard_search/
+canonical: /docs/grafana/latest/developers/http_api/folder_dashboard_search/
 description: Grafana Folder/Dashboard Search HTTP API
 keywords:
   - grafana

--- a/docs/sources/developers/http_api/folder_permissions.md
+++ b/docs/sources/developers/http_api/folder_permissions.md
@@ -2,6 +2,7 @@
 aliases:
   - ../../http_api/dashboardpermissions/
   - ../../http_api/folder_permissions/
+canonical: /docs/grafana/latest/developers/http_api/folder_permissions/
 description: Grafana Folder Permissions HTTP API
 keywords:
   - grafana

--- a/docs/sources/developers/http_api/library_element.md
+++ b/docs/sources/developers/http_api/library_element.md
@@ -1,6 +1,7 @@
 ---
 aliases:
   - ../../http_api/library_element/
+canonical: /docs/grafana/latest/developers/http_api/library_element/
 description: Grafana Library Element HTTP API
 keywords:
   - grafana

--- a/docs/sources/developers/http_api/licensing.md
+++ b/docs/sources/developers/http_api/licensing.md
@@ -1,6 +1,7 @@
 ---
 aliases:
   - ../../http_api/licensing/
+canonical: /docs/grafana/latest/developers/http_api/licensing/
 description: Enterprise Licensing HTTP API
 keywords:
   - grafana

--- a/docs/sources/developers/http_api/org.md
+++ b/docs/sources/developers/http_api/org.md
@@ -2,6 +2,7 @@
 aliases:
   - ../../http_api/org/
   - ../../http_api/organization/
+canonical: /docs/grafana/latest/developers/http_api/org/
 description: Grafana Organization HTTP API
 keywords:
   - grafana

--- a/docs/sources/developers/http_api/other.md
+++ b/docs/sources/developers/http_api/other.md
@@ -1,6 +1,7 @@
 ---
 aliases:
   - ../../http_api/other/
+canonical: /docs/grafana/latest/developers/http_api/other/
 description: Grafana Other HTTP API
 keywords:
   - grafana

--- a/docs/sources/developers/http_api/playlist.md
+++ b/docs/sources/developers/http_api/playlist.md
@@ -1,6 +1,7 @@
 ---
 aliases:
   - ../../http_api/playlist/
+canonical: /docs/grafana/latest/developers/http_api/playlist/
 description: Playlist Admin HTTP API
 keywords:
   - grafana

--- a/docs/sources/developers/http_api/preferences.md
+++ b/docs/sources/developers/http_api/preferences.md
@@ -1,6 +1,7 @@
 ---
 aliases:
   - ../../http_api/preferences/
+canonical: /docs/grafana/latest/developers/http_api/preferences/
 description: Grafana HTTP API
 keywords:
   - grafana

--- a/docs/sources/developers/http_api/query_history.md
+++ b/docs/sources/developers/http_api/query_history.md
@@ -1,6 +1,7 @@
 ---
 aliases:
   - ../../http_api/query_history/
+canonical: /docs/grafana/latest/developers/http_api/query_history/
 description: Grafana Query History HTTP API
 keywords:
   - grafana

--- a/docs/sources/developers/http_api/reporting.md
+++ b/docs/sources/developers/http_api/reporting.md
@@ -1,6 +1,7 @@
 ---
 aliases:
   - ../../http_api/reporting/
+canonical: /docs/grafana/latest/developers/http_api/reporting/
 description: Grafana Enterprise APIs
 keywords:
   - grafana

--- a/docs/sources/developers/http_api/serviceaccount.md
+++ b/docs/sources/developers/http_api/serviceaccount.md
@@ -1,6 +1,7 @@
 ---
 aliases:
   - ../../http_api/serviceaccount/
+canonical: /docs/grafana/latest/developers/http_api/serviceaccount/
 description: Grafana service account HTTP API
 keywords:
   - grafana

--- a/docs/sources/developers/http_api/short_url.md
+++ b/docs/sources/developers/http_api/short_url.md
@@ -1,6 +1,7 @@
 ---
 aliases:
   - ../../http_api/short_url/
+canonical: /docs/grafana/latest/developers/http_api/short_url/
 description: Grafana Short URL HTTP API
 keywords:
   - grafana

--- a/docs/sources/developers/http_api/snapshot.md
+++ b/docs/sources/developers/http_api/snapshot.md
@@ -1,6 +1,7 @@
 ---
 aliases:
   - ../../http_api/snapshot/
+canonical: /docs/grafana/latest/developers/http_api/snapshot/
 description: Grafana HTTP API
 keywords:
   - grafana

--- a/docs/sources/developers/http_api/team.md
+++ b/docs/sources/developers/http_api/team.md
@@ -1,6 +1,7 @@
 ---
 aliases:
   - ../../http_api/team/
+canonical: /docs/grafana/latest/developers/http_api/team/
 description: Grafana Team HTTP API
 keywords:
   - grafana

--- a/docs/sources/developers/http_api/user.md
+++ b/docs/sources/developers/http_api/user.md
@@ -1,6 +1,7 @@
 ---
 aliases:
   - ../../http_api/user/
+canonical: /docs/grafana/latest/developers/http_api/user/
 description: Grafana User HTTP API
 keywords:
   - grafana


### PR DESCRIPTION
Facilitates mounting these docs in the Grafana Cloud documentation set without affecting SEO.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
