### PR TITLE
loki: split: fix off-by-one error

### DIFF
--- a/public/app/plugins/datasource/loki/queryUtils.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.ts
@@ -390,7 +390,7 @@ function combineFrames(dest: DataQueryResponseData, source: DataQueryResponseDat
   dest.fields[0].values.reverse();
   dest.fields[1].values.reverse();
 
-  for (let j = source.fields[0].values.length - 1; j > 0; j--) {
+  for (let j = source.fields[0].values.length - 1; j >= 0; j--) {
     dest.fields[0].values.add(source.fields[0].values.get(j));
     dest.fields[1].values.add(source.fields[1].values.get(j));
   }


### PR DESCRIPTION
the loop goes from end-of-array to the beginning-of-array, so it should also handle `index=0`