### PR TITLE
Alerting: Change error log to warning and apply correct format when updating historic config

### DIFF
--- a/pkg/services/ngalert/store/alertmanager.go
+++ b/pkg/services/ngalert/store/alertmanager.go
@@ -154,7 +154,7 @@ func (st *DBstore) MarkConfigurationAsApplied(ctx context.Context, cmd *models.M
 		}
 
 		if rowsAffected != 1 {
-			st.Logger.Warn("Unexpected number of rows updating alert configuration history", "rows", rowsAffected)
+			st.Logger.Warn("Unexpected number of rows updating alert configuration history", "rows", rowsAffected, "org", cmd.OrgID, "hash", cmd.ConfigurationHash)
 		}
 
 		return nil

--- a/pkg/services/ngalert/store/alertmanager.go
+++ b/pkg/services/ngalert/store/alertmanager.go
@@ -154,7 +154,7 @@ func (st *DBstore) MarkConfigurationAsApplied(ctx context.Context, cmd *models.M
 		}
 
 		if rowsAffected != 1 {
-			st.Logger.Error("update statement affected %d alert configuration history records", rowsAffected)
+			st.Logger.Warn("Alert configuration history updated", "rows", rowsAffected)
 		}
 
 		return nil

--- a/pkg/services/ngalert/store/alertmanager.go
+++ b/pkg/services/ngalert/store/alertmanager.go
@@ -154,7 +154,7 @@ func (st *DBstore) MarkConfigurationAsApplied(ctx context.Context, cmd *models.M
 		}
 
 		if rowsAffected != 1 {
-			st.Logger.Warn("Alert configuration history updated", "rows", rowsAffected)
+			st.Logger.Warn("Unexpected number of rows updating alert configuration history", "rows", rowsAffected)
 		}
 
 		return nil


### PR DESCRIPTION
The call to `st.Logger.Error()` was using an incorrect format.
I also changed it to a warning after realizing that some harmless situations could lead to this log line (e.g. starting with an empty history table).