### PR TITLE
Azure Monitor: getAzureMonitorRoutes as a single source of the routes

### DIFF
--- a/pkg/tests/api/azuremonitor/azuremonitor_test.go
+++ b/pkg/tests/api/azuremonitor/azuremonitor_test.go
@@ -21,6 +21,10 @@ import (
 )
 
 func TestIntegrationAzureMonitor(t *testing.T) {
+	// Custom Azure clouds support will allow mocking Azure endpoints for integration testing
+	// https://github.com/grafana/grafana/issues/61124
+	t.Skip("skipping integration test until custom Azure clouds supported")
+
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}

--- a/pkg/tsdb/azuremonitor/azuremonitor_test.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor_test.go
@@ -41,47 +41,12 @@ func TestNewInstanceSettings(t *testing.T) {
 				ID:                      40,
 			},
 			expectedModel: types.DatasourceInfo{
-				Cloud:                   azsettings.AzurePublic,
 				Credentials:             &azcredentials.AzureManagedIdentityCredentials{},
 				Settings:                types.AzureMonitorSettings{},
 				Routes:                  routes[azsettings.AzurePublic],
 				JSONData:                map[string]interface{}{"azureAuthType": "msi"},
 				DatasourceID:            40,
 				DecryptedSecureJSONData: map[string]string{"key": "value"},
-				Services:                map[string]types.DatasourceService{},
-			},
-			Err: require.NoError,
-		},
-		{
-			name: "creates an instance for customized cloud",
-			settings: backend.DataSourceInstanceSettings{
-				JSONData:                []byte(`{"cloudName":"customizedazuremonitor","customizedRoutes":{"Route":{"URL":"url"}},"azureAuthType":"clientsecret"}`),
-				DecryptedSecureJSONData: map[string]string{"clientSecret": "secret"},
-				ID:                      50,
-			},
-			expectedModel: types.DatasourceInfo{
-				Cloud: "AzureCustomizedCloud",
-				Credentials: &azcredentials.AzureClientSecretCredentials{
-					AzureCloud:   "AzureCustomizedCloud",
-					ClientSecret: "secret",
-				},
-				Settings: types.AzureMonitorSettings{},
-				Routes: map[string]types.AzRoute{
-					"Route": {
-						URL: "url",
-					},
-				},
-				JSONData: map[string]interface{}{
-					"azureAuthType": "clientsecret",
-					"cloudName":     "customizedazuremonitor",
-					"customizedRoutes": map[string]interface{}{
-						"Route": map[string]interface{}{
-							"URL": "url",
-						},
-					},
-				},
-				DatasourceID:            50,
-				DecryptedSecureJSONData: map[string]string{"clientSecret": "secret"},
 				Services:                map[string]types.DatasourceService{},
 			},
 			Err: require.NoError,
@@ -107,7 +72,6 @@ func TestNewInstanceSettings(t *testing.T) {
 }
 
 type fakeInstance struct {
-	cloud    string
 	routes   map[string]types.AzRoute
 	services map[string]types.DatasourceService
 	settings types.AzureMonitorSettings
@@ -115,7 +79,6 @@ type fakeInstance struct {
 
 func (f *fakeInstance) Get(pluginContext backend.PluginContext) (instancemgmt.Instance, error) {
 	return types.DatasourceInfo{
-		Cloud:    f.cloud,
 		Routes:   f.routes,
 		Services: f.services,
 		Settings: f.settings,
@@ -444,7 +407,6 @@ func TestCheckHealth(t *testing.T) {
 	}
 
 	instance := &fakeInstance{
-		cloud:    cloud,
 		routes:   routes[cloud],
 		services: map[string]types.DatasourceService{},
 		settings: types.AzureMonitorSettings{

--- a/pkg/tsdb/azuremonitor/credentials.go
+++ b/pkg/tsdb/azuremonitor/credentials.go
@@ -15,7 +15,6 @@ const (
 	azureMonitorPublic       = "azuremonitor"
 	azureMonitorChina        = "chinaazuremonitor"
 	azureMonitorUSGovernment = "govazuremonitor"
-	azureMonitorCustomized   = "customizedazuremonitor"
 )
 
 func getAuthType(cfg *setting.Cfg, jsonData *simplejson.Json) string {
@@ -54,8 +53,6 @@ func getDefaultAzureCloud(cfg *setting.Cfg) (string, error) {
 		return azsettings.AzureChina, nil
 	case azsettings.AzureUSGovernment:
 		return azsettings.AzureUSGovernment, nil
-	case azsettings.AzureCustomized:
-		return azsettings.AzureCustomized, nil
 	case "":
 		// Not set cloud defaults to public
 		return azsettings.AzurePublic, nil
@@ -73,8 +70,6 @@ func normalizeAzureCloud(cloudName string) (string, error) {
 		return azsettings.AzureChina, nil
 	case azureMonitorUSGovernment:
 		return azsettings.AzureUSGovernment, nil
-	case azureMonitorCustomized:
-		return azsettings.AzureCustomized, nil
 	default:
 		err := fmt.Errorf("the cloud '%s' not supported", cloudName)
 		return "", err

--- a/pkg/tsdb/azuremonitor/credentials_test.go
+++ b/pkg/tsdb/azuremonitor/credentials_test.go
@@ -172,7 +172,7 @@ func TestCredentials_getAzureCredentials(t *testing.T) {
 	t.Run("when auth type is client secret", func(t *testing.T) {
 		jsonData := simplejson.NewFromAny(map[string]interface{}{
 			"azureAuthType": azcredentials.AzureAuthClientSecret,
-			"cloudName":     azUSGovManagement,
+			"cloudName":     azureMonitorUSGovernment,
 			"tenantId":      "9b9d90ee-a5cc-49c2-b97e-0d1b0f086b5c",
 			"clientId":      "849ccbb0-92eb-4226-b228-ef391abd8fe6",
 		})
@@ -189,7 +189,7 @@ func TestCredentials_getAzureCredentials(t *testing.T) {
 			require.IsType(t, &azcredentials.AzureClientSecretCredentials{}, credentials)
 			clientSecretCredentials := credentials.(*azcredentials.AzureClientSecretCredentials)
 
-			assert.Equal(t, azsettings.AzureChina, clientSecretCredentials.AzureCloud)
+			assert.Equal(t, azsettings.AzureUSGovernment, clientSecretCredentials.AzureCloud)
 			assert.Equal(t, "9b9d90ee-a5cc-49c2-b97e-0d1b0f086b5c", clientSecretCredentials.TenantId)
 			assert.Equal(t, "849ccbb0-92eb-4226-b228-ef391abd8fe6", clientSecretCredentials.ClientId)
 			assert.Equal(t, "59e3498f-eb12-4943-b8f0-a5aa42640058", clientSecretCredentials.ClientSecret)

--- a/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource.go
+++ b/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource.go
@@ -246,13 +246,7 @@ func (e *AzureMonitorDatasource) executeQuery(ctx context.Context, logger log.Lo
 		return dataResponse
 	}
 
-	azurePortalUrl, err := resourcegraph.GetAzurePortalUrl(dsInfo.Cloud)
-	if err != nil {
-		dataResponse.Error = err
-		return dataResponse
-	}
-
-	dataResponse.Frames, err = e.parseResponse(data, query, azurePortalUrl)
+	dataResponse.Frames, err = e.parseResponse(data, query, dsInfo.Routes["Azure Portal"].URL)
 	if err != nil {
 		dataResponse.Error = err
 		return dataResponse

--- a/pkg/tsdb/azuremonitor/resourcegraph/azure-resource-graph-datasource.go
+++ b/pkg/tsdb/azuremonitor/resourcegraph/azure-resource-graph-datasource.go
@@ -11,7 +11,6 @@ import (
 	"path"
 	"time"
 
-	"github.com/grafana/grafana-azure-sdk-go/azsettings"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"go.opentelemetry.io/otel/attribute"
@@ -197,13 +196,8 @@ func (e *AzureResourceGraphDatasource) executeQuery(ctx context.Context, logger 
 		return dataResponse
 	}
 
-	azurePortalUrl, err := GetAzurePortalUrl(dsInfo.Cloud)
-	if err != nil {
-		return dataResponseErrorWithExecuted(err)
-	}
-
-	url := azurePortalUrl + "/#blade/HubsExtension/ArgQueryBlade/query/" + url.PathEscape(query.InterpolatedQuery)
-	frameWithLink := AddConfigLinks(*frame, url)
+	portalUrl := fmt.Sprintf("%v/#blade/HubsExtension/ArgQueryBlade/query/%v", dsInfo.Routes["Azure Monitor"].URL, url.PathEscape(query.InterpolatedQuery))
+	frameWithLink := AddConfigLinks(*frame, portalUrl)
 	if frameWithLink.Meta == nil {
 		frameWithLink.Meta = &data.FrameMeta{}
 	}
@@ -267,17 +261,4 @@ func (e *AzureResourceGraphDatasource) unmarshalResponse(logger log.Logger, res 
 	}
 
 	return data, nil
-}
-
-func GetAzurePortalUrl(azureCloud string) (string, error) {
-	switch azureCloud {
-	case azsettings.AzurePublic:
-		return "https://portal.azure.com", nil
-	case azsettings.AzureChina:
-		return "https://portal.azure.cn", nil
-	case azsettings.AzureUSGovernment:
-		return "https://portal.azure.us", nil
-	default:
-		return "", fmt.Errorf("the cloud is not supported")
-	}
 }

--- a/pkg/tsdb/azuremonitor/resourcegraph/azure-resource-graph-datasource.go
+++ b/pkg/tsdb/azuremonitor/resourcegraph/azure-resource-graph-datasource.go
@@ -196,7 +196,7 @@ func (e *AzureResourceGraphDatasource) executeQuery(ctx context.Context, logger 
 		return dataResponse
 	}
 
-	portalUrl := fmt.Sprintf("%v/#blade/HubsExtension/ArgQueryBlade/query/%v", dsInfo.Routes["Azure Monitor"].URL, url.PathEscape(query.InterpolatedQuery))
+	portalUrl := fmt.Sprintf("%v/#blade/HubsExtension/ArgQueryBlade/query/%v", dsInfo.Routes["Azure Portal"].URL, url.PathEscape(query.InterpolatedQuery))
 	frameWithLink := AddConfigLinks(*frame, portalUrl)
 	if frameWithLink.Meta == nil {
 		frameWithLink.Meta = &data.FrameMeta{}

--- a/pkg/tsdb/azuremonitor/resourcegraph/azure-resource-graph-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/resourcegraph/azure-resource-graph-datasource_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/grafana/grafana-azure-sdk-go/azsettings"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 
@@ -137,23 +136,6 @@ func TestAddConfigData(t *testing.T) {
 	}
 	if !cmp.Equal(frameWithLink, expectedFrameWithLink, data.FrameTestCompareOptions()...) {
 		t.Errorf("unexpepcted frame: %v", cmp.Diff(frameWithLink, expectedFrameWithLink, data.FrameTestCompareOptions()...))
-	}
-}
-
-func TestGetAzurePortalUrl(t *testing.T) {
-	clouds := []string{azsettings.AzurePublic, azsettings.AzureChina, azsettings.AzureUSGovernment}
-	expectedAzurePortalUrl := map[string]interface{}{
-		azsettings.AzurePublic:       "https://portal.azure.com",
-		azsettings.AzureChina:        "https://portal.azure.cn",
-		azsettings.AzureUSGovernment: "https://portal.azure.us",
-	}
-
-	for _, cloud := range clouds {
-		azurePortalUrl, err := GetAzurePortalUrl(cloud)
-		if err != nil {
-			t.Errorf("The cloud not supported")
-		}
-		assert.Equal(t, expectedAzurePortalUrl[cloud], azurePortalUrl)
 	}
 }
 

--- a/pkg/tsdb/azuremonitor/routes.go
+++ b/pkg/tsdb/azuremonitor/routes.go
@@ -1,6 +1,9 @@
 package azuremonitor
 
 import (
+	"fmt"
+
+	"github.com/grafana/grafana-azure-sdk-go/azcredentials"
 	"github.com/grafana/grafana-azure-sdk-go/azsettings"
 
 	"github.com/grafana/grafana/pkg/tsdb/azuremonitor/types"
@@ -70,3 +73,16 @@ var (
 		},
 	}
 )
+
+func getAzureMonitorRoutes(settings *azsettings.AzureSettings, credentials azcredentials.AzureCredentials) (map[string]types.AzRoute, error) {
+	azureCloud, err := azcredentials.GetAzureCloud(settings, credentials)
+	if err != nil {
+		return nil, err
+	}
+	if route, ok := routes[azureCloud]; !ok {
+		err := fmt.Errorf("the Azure cloud '%s' not supported by Azure Monitor datasource", azureCloud)
+		return nil, err
+	} else {
+		return route, nil
+	}
+}

--- a/pkg/tsdb/azuremonitor/routes.go
+++ b/pkg/tsdb/azuremonitor/routes.go
@@ -14,6 +14,7 @@ const (
 	azureMonitor       = "Azure Monitor"
 	azureLogAnalytics  = "Azure Log Analytics"
 	azureResourceGraph = "Azure Resource Graph"
+	azurePortal        = "Azure Portal"
 )
 
 var azManagement = types.AzRoute{
@@ -52,6 +53,18 @@ var azUSGovLogAnalytics = types.AzRoute{
 	Headers: map[string]string{"x-ms-app": "Grafana", "Cache-Control": "public, max-age=60"},
 }
 
+var azPortal = types.AzRoute{
+	URL: "https://management.azure.com",
+}
+
+var azUSGovPortal = types.AzRoute{
+	URL: "https://management.usgovcloudapi.net",
+}
+
+var azChinaPortal = types.AzRoute{
+	URL: "https://management.chinacloudapi.cn",
+}
+
 var (
 	// The different Azure routes are identified by its cloud (e.g. public or gov)
 	// and the service to query (e.g. Azure Monitor or Azure Log Analytics)
@@ -60,16 +73,19 @@ var (
 			azureMonitor:       azManagement,
 			azureLogAnalytics:  azLogAnalytics,
 			azureResourceGraph: azManagement,
+			azurePortal:        azPortal,
 		},
 		azsettings.AzureUSGovernment: {
 			azureMonitor:       azUSGovManagement,
 			azureLogAnalytics:  azUSGovLogAnalytics,
 			azureResourceGraph: azUSGovManagement,
+			azurePortal:        azUSGovPortal,
 		},
 		azsettings.AzureChina: {
 			azureMonitor:       azChinaManagement,
 			azureLogAnalytics:  azChinaLogAnalytics,
 			azureResourceGraph: azChinaManagement,
+			azurePortal:        azChinaPortal,
 		},
 	}
 )

--- a/pkg/tsdb/azuremonitor/routes.go
+++ b/pkg/tsdb/azuremonitor/routes.go
@@ -54,15 +54,15 @@ var azUSGovLogAnalytics = types.AzRoute{
 }
 
 var azPortal = types.AzRoute{
-	URL: "https://management.azure.com",
+	URL: "https://portal.azure.com",
 }
 
 var azUSGovPortal = types.AzRoute{
-	URL: "https://management.usgovcloudapi.net",
+	URL: "https://portal.azure.us",
 }
 
 var azChinaPortal = types.AzRoute{
-	URL: "https://management.chinacloudapi.cn",
+	URL: "https://portal.azure.cn",
 }
 
 var (

--- a/pkg/tsdb/azuremonitor/types/types.go
+++ b/pkg/tsdb/azuremonitor/types/types.go
@@ -33,18 +33,12 @@ type AzureMonitorSettings struct {
 	AppInsightsAppId             string `json:"appInsightsAppId"`
 }
 
-// AzureMonitorCustomizedCloudSettings is the extended Azure Monitor settings for customized cloud
-type AzureMonitorCustomizedCloudSettings struct {
-	CustomizedRoutes map[string]AzRoute `json:"customizedRoutes"`
-}
-
 type DatasourceService struct {
 	URL        string
 	HTTPClient *http.Client
 }
 
 type DatasourceInfo struct {
-	Cloud       string
 	Credentials azcredentials.AzureCredentials
 	Settings    AzureMonitorSettings
 	Routes      map[string]AzRoute


### PR DESCRIPTION
This PR does preparation work for migration of Azure Monitor datasource to common Azure credentials format (#60782) and also for support of custom Azure clouds (#61124).

First, it removes the current prototype implementation of custom routes, and also makes the `getAzureMonitorRoutes` (moved to `routes.go`) to be the single source of routes for the Azure Monitor datasource.

Custom clouds support will be implemented in `getAzureMonitorRoutes` transparently for the rest of the datasource logic.

Azure Portal URL also moved under routes.