### PR TITLE
Plugins: Add optional logger for plugin requests sent to backend plugins

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1218,6 +1218,8 @@ plugin_admin_external_manage_enabled = false
 plugin_catalog_url = https://grafana.com/grafana/plugins/
 # Enter a comma-separated list of plugin identifiers to hide in the plugin catalog.
 plugin_catalog_hidden_plugins =
+# Log all backend requests for core and external plugins.
+log_backend_requests = false
 
 #################################### Grafana Live ##########################################
 [live]

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -1176,6 +1176,8 @@
 ;plugin_catalog_url = https://grafana.com/grafana/plugins/
 # Enter a comma-separated list of plugin identifiers to hide in the plugin catalog.
 ;plugin_catalog_hidden_plugins =
+# Log all backend requests for core and external plugins.
+;log_backend_requests = false
 
 #################################### Grafana Live ##########################################
 [live]

--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -45,7 +45,6 @@ Some stable features are enabled by default. You can disable a stable feature by
 | `validateDashboardsOnSave`        | Validate dashboard JSON POSTed to api/dashboards/db                             |
 | `autoMigrateGraphPanels`          | Replace the angular graph panel with timeseries                                 |
 | `topnav`                          | Displays new top nav and page layouts                                           |
-| `datasourceLogger`                | Logs all datasource requests                                                    |
 | `accessControlOnCall`             | Access control primitives for OnCall                                            |
 | `alertingNoNormalState`           | Stop maintaining state of alerts that are not firing                            |
 | `topNavCommandPalette`            | Launch the Command Palette from the top navigation search box                   |

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -75,7 +75,6 @@ export interface FeatureToggles {
   queryLibrary?: boolean;
   showDashboardValidationWarnings?: boolean;
   mysqlAnsiQuotes?: boolean;
-  datasourceLogger?: boolean;
   accessControlOnCall?: boolean;
   nestedFolders?: boolean;
   accessTokenExpirationCheck?: boolean;

--- a/pkg/plugins/config/config.go
+++ b/pkg/plugins/config/config.go
@@ -6,7 +6,6 @@ import (
 	"github.com/grafana/grafana-azure-sdk-go/azsettings"
 
 	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
@@ -64,7 +63,7 @@ func NewCfg(settingProvider setting.Provider, grafanaCfg *setting.Cfg) *Cfg {
 		AWSAllowedAuthProviders: allowedAuth,
 		AWSAssumeRoleEnabled:    aws.KeyValue("assume_role_enabled").MustBool(grafanaCfg.AWSAssumeRoleEnabled),
 		Azure:                   grafanaCfg.Azure,
-		LogDatasourceRequests:   grafanaCfg.IsFeatureToggleEnabled(featuremgmt.FlagDatasourceLogger),
+		LogDatasourceRequests:   grafanaCfg.PluginLogBackendRequests,
 		PluginsCDNURLTemplate:   grafanaCfg.PluginsCDNURLTemplate,
 	}
 }

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -335,11 +335,6 @@ var (
 			State:       FeatureStateAlpha,
 		},
 		{
-			Name:        "datasourceLogger",
-			Description: "Logs all datasource requests",
-			State:       FeatureStateBeta,
-		},
-		{
 			Name:        "accessControlOnCall",
 			Description: "Access control primitives for OnCall",
 			State:       FeatureStateBeta,

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -243,10 +243,6 @@ const (
 	// Use double quotes to escape keyword in a MySQL query
 	FlagMysqlAnsiQuotes = "mysqlAnsiQuotes"
 
-	// FlagDatasourceLogger
-	// Logs all datasource requests
-	FlagDatasourceLogger = "datasourceLogger"
-
 	// FlagAccessControlOnCall
 	// Access control primitives for OnCall
 	FlagAccessControlOnCall = "accessControlOnCall"

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -276,7 +276,8 @@ type Cfg struct {
 	PluginAdminEnabled               bool
 	PluginAdminExternalManageEnabled bool
 
-	PluginsCDNURLTemplate string
+	PluginsCDNURLTemplate    string
+	PluginLogBackendRequests bool
 
 	// Panels
 	DisableSanitizeHtml bool

--- a/pkg/setting/setting_plugins.go
+++ b/pkg/setting/setting_plugins.go
@@ -50,6 +50,7 @@ func (cfg *Cfg) readPluginSettings(iniFile *ini.File) error {
 
 	// Plugins CDN settings
 	cfg.PluginsCDNURLTemplate = strings.TrimRight(pluginsSection.Key("cdn_base_url").MustString(""), "/")
+	cfg.PluginLogBackendRequests = pluginsSection.Key("log_backend_requests").MustBool(false)
 
 	return nil
 }


### PR DESCRIPTION
Turning this into a setting since we have been using it for a while. 

