### PR TITLE
StatPanel: Add option for plain background with no gradient

### DIFF
--- a/docs/sources/developers/kinds/composable/statpanelcfg/schema-reference.md
+++ b/docs/sources/developers/kinds/composable/statpanelcfg/schema-reference.md
@@ -23,7 +23,7 @@ It extends [SingleStatBaseOptions](#singlestatbaseoptions).
 
 | Property        | Type                                            | Required | Description                                                                                                                                 |
 |-----------------|-------------------------------------------------|----------|---------------------------------------------------------------------------------------------------------------------------------------------|
-| `colorMode`     | string                                          | **Yes**  | TODO docs<br/>Possible values are: `value`, `background`, `none`.                                                                           |
+| `colorMode`     | string                                          | **Yes**  | TODO docs<br/>Possible values are: `value`, `background`, `background_no_gradient`, `none`.                                                 |
 | `graphMode`     | string                                          | **Yes**  | TODO docs<br/>Possible values are: `none`, `line`, `area`.                                                                                  |
 | `justifyMode`   | string                                          | **Yes**  | TODO docs<br/>Possible values are: `auto`, `center`.                                                                                        |
 | `textMode`      | string                                          | **Yes**  | TODO docs<br/>Possible values are: `auto`, `value`, `value_and_name`, `name`, `none`.                                                       |

--- a/packages/grafana-schema/src/common/common.gen.ts
+++ b/packages/grafana-schema/src/common/common.gen.ts
@@ -447,6 +447,7 @@ export interface OptionsWithTextFormatting {
  */
 export enum BigValueColorMode {
   Background = 'background',
+  BackgroundNoGradient = 'background_no_gradient',
   None = 'none',
   Value = 'value',
 }

--- a/packages/grafana-schema/src/common/mudball.cue
+++ b/packages/grafana-schema/src/common/mudball.cue
@@ -178,7 +178,7 @@ OptionsWithTextFormatting: {
 } @cuetsy(kind="interface")
 
 // TODO docs
-BigValueColorMode: "value" | "background" | "none" @cuetsy(kind="enum")
+BigValueColorMode: "value" | "background" | "background_no_gradient" | "none" @cuetsy(kind="enum", memberNames="Value|Background|BackgroundNoGradient|None")
 
 // TODO docs
 BigValueGraphMode: "none" | "line" | "area" @cuetsy(kind="enum")

--- a/packages/grafana-ui/src/components/BigValue/BigValue.tsx
+++ b/packages/grafana-ui/src/components/BigValue/BigValue.tsx
@@ -13,6 +13,7 @@ import { buildLayout } from './BigValueLayout';
 export enum BigValueColorMode {
   Value = 'value',
   Background = 'background',
+  BackgroundNoGradient = 'background_no_gradient',
   None = 'none',
 }
 

--- a/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
+++ b/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
@@ -66,7 +66,10 @@ export abstract class BigValueLayout {
       styles.paddingRight = '0.75ch';
     }
 
-    if (this.props.colorMode === BigValueColorMode.Background) {
+    if (
+      this.props.colorMode === BigValueColorMode.Background ||
+      this.props.colorMode === BigValueColorMode.BackgroundNoGradient
+    ) {
       styles.color = getTextColorForAlphaBackground(this.valueColor, this.props.theme.isDark);
     }
 
@@ -91,6 +94,7 @@ export abstract class BigValueLayout {
         styles.color = this.valueColor;
         break;
       case BigValueColorMode.Background:
+      case BigValueColorMode.BackgroundNoGradient:
         styles.color = getTextColorForAlphaBackground(this.valueColor, this.props.theme.isDark);
         break;
       case BigValueColorMode.None:
@@ -141,6 +145,9 @@ export abstract class BigValueLayout {
           .toRgbString();
         panelStyles.background = `linear-gradient(120deg, ${bgColor2}, ${bgColor3})`;
         break;
+      case BigValueColorMode.BackgroundNoGradient:
+        panelStyles.background = tinycolor(this.valueColor).toString();
+        break;
       case BigValueColorMode.Value:
         panelStyles.background = `transparent`;
         break;
@@ -166,6 +173,7 @@ export abstract class BigValueLayout {
 
     switch (colorMode) {
       case BigValueColorMode.Background:
+      case BigValueColorMode.BackgroundNoGradient:
         fillColor = 'rgba(255,255,255,0.4)';
         lineColor = tinycolor(this.valueColor).brighten(40).toRgbString();
         break;

--- a/public/app/plugins/panel/stat/module.tsx
+++ b/public/app/plugins/panel/stat/module.tsx
@@ -44,7 +44,8 @@ export const plugin = new PanelPlugin<PanelOptions>(StatPanel)
           options: [
             { value: BigValueColorMode.None, label: 'None' },
             { value: BigValueColorMode.Value, label: 'Value' },
-            { value: BigValueColorMode.Background, label: 'Background' },
+            { value: BigValueColorMode.BackgroundNoGradient, label: 'Background' },
+            { value: BigValueColorMode.Background, label: 'Background gradient' },
           ],
         },
       })


### PR DESCRIPTION
**What is this feature?**

Adds an option for having no gradient on the background on the stat panel

**Why do we need this feature?**

Renames the previous background option (in the UI) to background gradient and replaces it with a background that doesn't have a gradient.

**Who is this feature for?**

Users that want to adhere to a strict company branding might not want a gradient to the background on stat panels.
