### PR TITLE
Alerting: Make time range query parameters not required when querying Loki

### DIFF
--- a/pkg/services/ngalert/state/historian/loki.go
+++ b/pkg/services/ngalert/state/historian/loki.go
@@ -37,7 +37,7 @@ const (
 type remoteLokiClient interface {
 	ping(context.Context) error
 	push(context.Context, []stream) error
-	query(ctx context.Context, selectors []Selector, start, end int64) (QueryRes, error)
+	rangeQuery(ctx context.Context, selectors []Selector, start, end int64) (QueryRes, error)
 }
 
 type RemoteLokiBackend struct {
@@ -79,7 +79,7 @@ func (h *RemoteLokiBackend) QueryStates(ctx context.Context, query models.Histor
 		return nil, fmt.Errorf("failed to build the provided selectors: %w", err)
 	}
 	// Timestamps are expected in RFC3339Nano.
-	res, err := h.client.query(ctx, selectors, query.From.UnixNano(), query.To.UnixNano())
+	res, err := h.client.rangeQuery(ctx, selectors, query.From.UnixNano(), query.To.UnixNano())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/ngalert/state/historian/loki_http.go
+++ b/pkg/services/ngalert/state/historian/loki_http.go
@@ -199,12 +199,8 @@ func (c *httpLokiClient) rangeQuery(ctx context.Context, selectors []Selector, s
 
 	values := url.Values{}
 	values.Set("query", selectorString(selectors))
-	if start != 0 {
-		values.Set("start", fmt.Sprintf("%d", start))
-	}
-	if end != 0 {
-		values.Set("end", fmt.Sprintf("%d", end))
-	}
+	values.Set("start", fmt.Sprintf("%d", start))
+	values.Set("end", fmt.Sprintf("%d", end))
 
 	queryURL.RawQuery = values.Encode()
 

--- a/pkg/services/ngalert/state/historian/loki_http.go
+++ b/pkg/services/ngalert/state/historian/loki_http.go
@@ -186,7 +186,7 @@ func (c *httpLokiClient) setAuthAndTenantHeaders(req *http.Request) {
 		req.Header.Add("X-Scope-OrgID", c.cfg.TenantID)
 	}
 }
-func (c *httpLokiClient) query(ctx context.Context, selectors []Selector, start, end int64) (QueryRes, error) {
+func (c *httpLokiClient) rangeQuery(ctx context.Context, selectors []Selector, start, end int64) (QueryRes, error) {
 	// Run the pre-flight checks for the query.
 	if len(selectors) == 0 {
 		return QueryRes{}, fmt.Errorf("at least one selector required to query")
@@ -199,8 +199,12 @@ func (c *httpLokiClient) query(ctx context.Context, selectors []Selector, start,
 
 	values := url.Values{}
 	values.Set("query", selectorString(selectors))
-	values.Set("start", fmt.Sprintf("%d", start))
-	values.Set("end", fmt.Sprintf("%d", end))
+	if start != 0 {
+		values.Set("start", fmt.Sprintf("%d", start))
+	}
+	if end != 0 {
+		values.Set("end", fmt.Sprintf("%d", end))
+	}
 
 	queryURL.RawQuery = values.Encode()
 

--- a/pkg/services/ngalert/state/historian/loki_http_test.go
+++ b/pkg/services/ngalert/state/historian/loki_http_test.go
@@ -101,7 +101,7 @@ func TestLokiHTTPClient(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("smoke test querying Loki", func(t *testing.T) {
+	t.Run("smoke test range querying Loki", func(t *testing.T) {
 		url, err := url.Parse("https://logs-prod-eu-west-0.grafana.net")
 		require.NoError(t, err)
 
@@ -127,7 +127,7 @@ func TestLokiHTTPClient(t *testing.T) {
 		end := time.Now().UnixNano()
 
 		// Authorized request should not fail against Grafana Cloud.
-		res, err := client.query(context.Background(), selectors, start, end)
+		res, err := client.rangeQuery(context.Background(), selectors, start, end)
 		require.NoError(t, err)
 		require.NotNil(t, res)
 	})


### PR DESCRIPTION
**What is this feature?**

Now we only forward the `from`/`to` query parameters if they are supplied, rather than all the time. It will fall back to Loki's default time range, which is usually the last hour. Although most of our clients will need to specify a longer time range, this still improves basic usability of the API. Also, such clients only need to specify `from` and can omit `to` most of the time.

Also renames the client method `query` to `rangeQuery` to be clear as to which query type we're using. For some queries, it might be advantageous to use an instant query instead. We can evaluate that in the future.

**Why do we need this feature?**

Nice quality-of-life for clients. UI can omit the `to` parameter when it rolls out. Doesn't affect datasource-based clients. Not compat breaking.

**Which issue(s) does this PR fix?**:

contrib https://github.com/grafana/grafana/issues/48359

**Special notes for your reviewer**:

