### PR TITLE
Alerting: Querying state history with annotations enabled will map annotation data to a format that looks like Loki

### DIFF
--- a/pkg/services/ngalert/state/historian/annotation.go
+++ b/pkg/services/ngalert/state/historian/annotation.go
@@ -97,7 +97,7 @@ func (h *AnnotationBackend) QueryStates(ctx context.Context, query ngmodels.Hist
 	// Also, annotations don't store labels in a strongly defined format. They are formatted into the label's text.
 	// We are not guaranteed that a given annotation has parseable text, so we instead use the entire text as an opaque value.
 
-	lbls := data.Labels(map[string]string{
+	columnLbls := data.Labels(map[string]string{
 		StateHistoryLabelKey: StateHistoryLabelValue,
 		LabelRuleUID:         fmt.Sprint(query.RuleUID),
 	})
@@ -113,6 +113,7 @@ func (h *AnnotationBackend) QueryStates(ctx context.Context, query ngmodels.Hist
 	//   3. `prev` - the previous state and reason
 	//   4. `next` - the next state and reason
 	//   5. `data` - a JSON string, containing the annotation's contents. analogous to item.Data
+
 	times := make([]time.Time, 0, len(items))
 	texts := make([]string, 0, len(items))
 	prevStates := make([]string, 0, len(items))
@@ -131,11 +132,11 @@ func (h *AnnotationBackend) QueryStates(ctx context.Context, query ngmodels.Hist
 		values = append(values, string(data))
 	}
 
-	frame.Fields = append(frame.Fields, data.NewField("time", lbls, times))
-	frame.Fields = append(frame.Fields, data.NewField("text", lbls, texts))
-	frame.Fields = append(frame.Fields, data.NewField("prev", lbls, prevStates))
-	frame.Fields = append(frame.Fields, data.NewField("next", lbls, nextStates))
-	frame.Fields = append(frame.Fields, data.NewField("data", lbls, values))
+	frame.Fields = append(frame.Fields, data.NewField(dfTime, columnLbls, times))
+	frame.Fields = append(frame.Fields, data.NewField("text", columnLbls, texts))
+	frame.Fields = append(frame.Fields, data.NewField("prev", columnLbls, prevStates))
+	frame.Fields = append(frame.Fields, data.NewField("next", columnLbls, nextStates))
+	frame.Fields = append(frame.Fields, data.NewField("data", columnLbls, values))
 
 	return frame, nil
 }

--- a/pkg/services/ngalert/state/historian/annotation.go
+++ b/pkg/services/ngalert/state/historian/annotation.go
@@ -90,7 +90,7 @@ func (h *AnnotationBackend) QueryStates(ctx context.Context, query ngmodels.Hist
 		return nil, fmt.Errorf("failed to query annotations for state history: %w", err)
 	}
 
-	frame := data.NewFrame("states")
+	frame := data.NewFrame(dfStreamTitle)
 
 	// Annotations only support querying for a single rule's history.
 	// Since we are guaranteed to have a single rule, we can return it as a single series.
@@ -98,8 +98,8 @@ func (h *AnnotationBackend) QueryStates(ctx context.Context, query ngmodels.Hist
 	// We are not guaranteed that a given annotation has parseable text, so we instead use the entire text as an opaque value.
 
 	lbls := data.Labels(map[string]string{
-		"from":    "state-history",
-		"ruleUID": fmt.Sprint(query.RuleUID),
+		StateHistoryLabelKey: StateHistoryLabelValue,
+		LabelRuleUID:         fmt.Sprint(query.RuleUID),
 	})
 
 	// TODO: In the future, we probably want to have one series per unique text string, instead. For simplicity, let's just make it a new column.

--- a/pkg/services/ngalert/state/historian/core.go
+++ b/pkg/services/ngalert/state/historian/core.go
@@ -12,6 +12,27 @@ import (
 	history_model "github.com/grafana/grafana/pkg/services/ngalert/state/historian/model"
 )
 
+const (
+	StateHistoryLabelKey   = "from"
+	StateHistoryLabelValue = "state-history"
+)
+
+const (
+	LabelOrgID     = "orgID"
+	LabelRuleUID   = "ruleUID"
+	LabelGroup     = "group"
+	LabelFolderUID = "folderUID"
+)
+
+const dfStreamTitle = "states"
+
+const (
+	// Name of the columns used in the dataframe.
+	dfTime   = "time"
+	dfLine   = "line"
+	dfLabels = "labels"
+)
+
 func shouldRecord(transition state.StateTransition) bool {
 	if !transition.Changed() {
 		return false

--- a/pkg/services/ngalert/state/historian/loki.go
+++ b/pkg/services/ngalert/state/historian/loki.go
@@ -18,22 +18,6 @@ import (
 	history_model "github.com/grafana/grafana/pkg/services/ngalert/state/historian/model"
 )
 
-const (
-	OrgIDLabel     = "orgID"
-	RuleUIDLabel   = "ruleUID"
-	GroupLabel     = "group"
-	FolderUIDLabel = "folderUID"
-	// Name of the columns used in the dataframe.
-	dfTime   = "time"
-	dfLine   = "line"
-	dfLabels = "labels"
-)
-
-const (
-	StateHistoryLabelKey   = "from"
-	StateHistoryLabelValue = "state-history"
-)
-
 const defaultQueryRange = 6 * time.Hour
 
 type remoteLokiClient interface {
@@ -102,7 +86,7 @@ func buildSelectors(query models.HistoryQuery) ([]Selector, error) {
 	selectors := make([]Selector, len(query.Labels)+2)
 
 	// Set the predefined selector orgID.
-	selector, err := NewSelector(OrgIDLabel, "=", fmt.Sprintf("%d", query.OrgID))
+	selector, err := NewSelector(LabelOrgID, "=", fmt.Sprintf("%d", query.OrgID))
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +112,7 @@ func buildSelectors(query models.HistoryQuery) ([]Selector, error) {
 
 	// Set the optional special selector rule_id
 	if query.RuleUID != "" {
-		rsel, err := NewSelector(RuleUIDLabel, "=", query.RuleUID)
+		rsel, err := NewSelector(LabelRuleUID, "=", query.RuleUID)
 		if err != nil {
 			return nil, err
 		}
@@ -147,7 +131,7 @@ func merge(res QueryRes, ruleUID string) (*data.Frame, error) {
 	}
 
 	// Create a new slice to store the merged elements.
-	frame := data.NewFrame("states")
+	frame := data.NewFrame(dfStreamTitle)
 
 	// We merge all series into a single linear history.
 	lbls := data.Labels(map[string]string{})
@@ -230,10 +214,10 @@ func statesToStreams(rule history_model.RuleMeta, states []state.StateTransition
 
 		labels := mergeLabels(removePrivateLabels(state.State.Labels), externalLabels)
 		labels[StateHistoryLabelKey] = StateHistoryLabelValue
-		labels[OrgIDLabel] = fmt.Sprint(rule.OrgID)
-		labels[RuleUIDLabel] = fmt.Sprint(rule.UID)
-		labels[GroupLabel] = fmt.Sprint(rule.Group)
-		labels[FolderUIDLabel] = fmt.Sprint(rule.NamespaceUID)
+		labels[LabelOrgID] = fmt.Sprint(rule.OrgID)
+		labels[LabelRuleUID] = fmt.Sprint(rule.UID)
+		labels[LabelGroup] = fmt.Sprint(rule.Group)
+		labels[LabelFolderUID] = fmt.Sprint(rule.NamespaceUID)
 		repr := labels.String()
 
 		entry := lokiEntry{

--- a/pkg/services/ngalert/state/historian/loki.go
+++ b/pkg/services/ngalert/state/historian/loki.go
@@ -134,7 +134,7 @@ func merge(res QueryRes, ruleUID string) (*data.Frame, error) {
 	frame := data.NewFrame(dfStreamTitle)
 
 	// We merge all series into a single linear history.
-	lbls := data.Labels(map[string]string{})
+	columnLbls := data.Labels(map[string]string{})
 
 	// We represent state history as a single merged history, that roughly corresponds to what you get in the Grafana Explore tab when querying Loki directly.
 	// The format is composed of the following vectors:
@@ -198,9 +198,9 @@ func merge(res QueryRes, ruleUID string) (*data.Frame, error) {
 		pointers[minElStreamIdx]++
 	}
 
-	frame.Fields = append(frame.Fields, data.NewField(dfTime, lbls, times))
-	frame.Fields = append(frame.Fields, data.NewField(dfLine, lbls, lines))
-	frame.Fields = append(frame.Fields, data.NewField(dfLabels, lbls, labels))
+	frame.Fields = append(frame.Fields, data.NewField(dfTime, columnLbls, times))
+	frame.Fields = append(frame.Fields, data.NewField(dfLine, columnLbls, lines))
+	frame.Fields = append(frame.Fields, data.NewField(dfLabels, columnLbls, labels))
 
 	return frame, nil
 }


### PR DESCRIPTION
**What is this feature?**

When using the new state history api _without_ Loki enabled, you'll still get some data back (even though some filter options cannot be fulfilled).

This PR makes this data look much more similar to the Loki format. This allows new UI elements consuming the API to switch away from the raw annotation API early, without synchronization around any backend toggles, as they can use the endpoint as an abstraction no matter which backend is enabled.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

