### PR TITLE
Alerting: Add markdown message type for DingDing for both ngalert and traditional alerting

### DIFF
--- a/pkg/services/alerting/notifiers/dingding.go
+++ b/pkg/services/alerting/notifiers/dingding.go
@@ -41,6 +41,10 @@ func init() {
 						Value: "actionCard",
 						Label: "ActionCard",
 					},
+					{
+						Value: "markdown",
+						Label: "Markdown",
+					},
 				},
 			},
 		},

--- a/pkg/services/alerting/notifiers/dingding.go
+++ b/pkg/services/alerting/notifiers/dingding.go
@@ -142,6 +142,14 @@ func (dd *DingDingNotifier) genBody(evalContext *alerting.EvalContext, messageUR
 				"singleURL":   messageURL,
 			},
 		}
+	} else if dd.MsgType == "markdown" {
+		bodyMsg = map[string]interface{}{
+			"msgtype": "markdown",
+			"markdown": map[string]string{
+				"title": title,
+				"text":  message,
+			},
+		}
 	} else {
 		link := map[string]string{
 			"text":       message,

--- a/pkg/services/ngalert/notifier/channels_config/available_channels.go
+++ b/pkg/services/ngalert/notifier/channels_config/available_channels.go
@@ -135,6 +135,10 @@ func GetAvailableNotifiers() []*NotifierPlugin {
 							Value: "actionCard",
 							Label: "ActionCard",
 						},
+						{
+							Value: "markdown",
+							Label: "Markdown",
+						},
 					},
 				},
 				{ // New in 9.3.


### PR DESCRIPTION
**What is this feature?**
Add support of `Markdown` message type for `DingDing`
`ngalert`'s message body generate implementation is here: [feat: [Alerting] Add markdown body generate for dingding #52
](https://github.com/grafana/alerting/pull/52)

**Why do we need this feature?**
`Markdown` is more flexable than existing `links` and `actionCard`, when using `DingDing`, in some cases, users only want to select some information and then copy them, but `link` and `actionCard` is a type of **click then open browser** action. It will make select-copy operation more complex and more easy to mis-click.

**Who is this feature for?**
Users who using `DingDing` and need more flexability in their alert message, including those who don't use `link` or `actionCard`

**Which issue(s) does this PR fix?**:
None, I searched issues a couple days ago and found nothing, so I just start my PR.


Fixes #
None

**Special notes for your reviewer**:
#### About docs:
This is a completion of `DingDing`'s already existing function, and `grafana`'s old doc already contain all information about it. So I didn't update the docs

#### About testing:
Server tested in macOS 13 and Windows 10, client tested in macOS Safari/Chrome/FireFox, Windows 10 Edge/Chrome/Firefox, Android Chrome/Firefox
