### PR TITLE
[v9.4.x] CI: Remove variants arg from `package` step (#62858)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -515,7 +515,7 @@ steps:
   name: build-plugins
 - commands:
   - . scripts/build/gpg-test-vars.sh && ./bin/build package --jobs 8 --edition oss
-    --build-id ${DRONE_BUILD_NUMBER} --variants linux-amd64,linux-amd64-musl,darwin-amd64,windows-amd64
+    --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - build-plugins
   - build-backend
@@ -6163,7 +6163,7 @@ steps:
   name: build-backend-enterprise2
 - commands:
   - ./bin/build package --jobs 8 --edition enterprise2 --build-id ${DRONE_BUILD_NUMBER}
-    --variants linux-amd64 --sign
+    --sign
   depends_on:
   - build-plugins
   - build-backend-enterprise2
@@ -6549,6 +6549,6 @@ kind: secret
 name: aws_secret_access_key
 ---
 kind: signature
-hmac: a9051a8245848db0d2bd763f1f80d4103e093053093cf370792c18855d745602
+hmac: 94308d22003a21481161c2875bb3008db353faf2d0053536d521f4be2d7bba22
 
 ...

--- a/pkg/build/cmd/package.go
+++ b/pkg/build/cmd/package.go
@@ -37,14 +37,17 @@ func Package(c *cli.Context) error {
 
 	ctx := context.Background()
 
-	variantStrs := strings.Split(c.String("variants"), ",")
 	variants := []config.Variant{}
-	for _, varStr := range variantStrs {
-		if varStr == "" {
-			continue
+	variantStrs := strings.Split(c.String("variants"), ",")
+	if c.String("variants") != "" {
+		for _, varStr := range variantStrs {
+			if varStr == "" {
+				continue
+			}
+			variants = append(variants, config.Variant(varStr))
 		}
-
-		variants = append(variants, config.Variant(varStr))
+	} else {
+		variants = releaseModeConfig.Variants
 	}
 
 	if len(variants) == 0 {

--- a/scripts/drone/events/release.star
+++ b/scripts/drone/events/release.star
@@ -474,7 +474,6 @@ def enterprise2_pipelines(prefix = "", ver_mode = ver_mode, trigger = release_tr
             package_step(
                 edition = "enterprise2",
                 ver_mode = ver_mode,
-                variants = ["linux-amd64"],
             ),
             upload_cdn,
             copy_packages_for_docker_step(edition = "enterprise2"),

--- a/scripts/drone/pipelines/build.star
+++ b/scripts/drone/pipelines/build.star
@@ -61,7 +61,6 @@ def build_e2e(trigger, ver_mode):
     ]
 
     build_steps = []
-    variants = None
 
     if ver_mode == "pr":
         build_steps.extend(
@@ -71,20 +70,13 @@ def build_e2e(trigger, ver_mode):
             ],
         )
 
-        variants = [
-            "linux-amd64",
-            "linux-amd64-musl",
-            "darwin-amd64",
-            "windows-amd64",
-        ]
-
     build_steps.extend(
         [
             build_backend_step(edition = edition, ver_mode = ver_mode),
             build_frontend_step(edition = edition, ver_mode = ver_mode),
             build_frontend_package_step(edition = edition, ver_mode = ver_mode),
             build_plugins_step(edition = edition, ver_mode = ver_mode),
-            package_step(edition = edition, variants = variants, ver_mode = ver_mode),
+            package_step(edition = edition, ver_mode = ver_mode),
             grafana_server_step(edition = edition),
             e2e_tests_step("dashboards-suite"),
             e2e_tests_step("smoke-tests-suite"),

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -736,7 +736,7 @@ def codespell_step():
         ],
     }
 
-def package_step(edition, ver_mode, variants = None):
+def package_step(edition, ver_mode):
     """Packages Grafana with the Grafana build tool.
 
     Args:
@@ -744,9 +744,6 @@ def package_step(edition, ver_mode, variants = None):
       ver_mode: controls whether the packages are signed for a release.
         If ver_mode != 'release', use the DRONE_BUILD_NUMBER environment
         variable as a build identifier.
-      variants: a list of variants be passed to the package subcommand
-        using the --variants option.
-        Defaults to None.
 
     Returns:
       Drone step.
@@ -757,10 +754,6 @@ def package_step(edition, ver_mode, variants = None):
         "build-frontend",
         "build-frontend-packages",
     ]
-
-    variants_str = ""
-    if variants:
-        variants_str = " --variants {}".format(",".join(variants))
 
     if ver_mode in ("main", "release", "release-branch"):
         sign_args = " --sign"
@@ -788,7 +781,7 @@ def package_step(edition, ver_mode, variants = None):
         build_no = "${DRONE_BUILD_NUMBER}"
         cmds = [
             "{}./bin/build package --jobs 8 --edition {} ".format(test_args, edition) +
-            "--build-id {}{}{}".format(build_no, variants_str, sign_args),
+            "--build-id {}{}".format(build_no, sign_args),
         ]
 
     return {


### PR DESCRIPTION
* Remove variants arg from package step

* Fix starlark lint

* Default to releaseModeConfig.Variants

* Check for empty variants arg

(cherry picked from commit e5c48ac9454a8513d526384751b953ff98d12ecb)

Backports #62858 