### PR TITLE
loki: split time range for metric queries

### DIFF
--- a/public/app/plugins/datasource/loki/metricTimeSplit.test.ts
+++ b/public/app/plugins/datasource/loki/metricTimeSplit.test.ts
@@ -1,0 +1,29 @@
+import { getRanges } from './metricTimeSplit';
+
+describe('querySplit', () => {
+  it('should split time range into chunks', () => {
+    const start = Date.parse('2022-02-06T14:10:03');
+    const end = Date.parse('2022-02-06T14:11:03');
+    const step = 10 * 1000;
+
+    expect(getRanges(start, end, step, 25000)).toStrictEqual([
+      [Date.parse('2022-02-06T14:10:00'), Date.parse('2022-02-06T14:10:10')],
+      [Date.parse('2022-02-06T14:10:20'), Date.parse('2022-02-06T14:10:40')],
+      [Date.parse('2022-02-06T14:10:50'), Date.parse('2022-02-06T14:11:10')],
+    ]);
+  });
+
+  it('should return null if too many chunks would be generated', () => {
+    const start = Date.parse('2022-02-06T14:10:03');
+    const end = Date.parse('2022-02-06T14:35:01');
+    const step = 10 * 1000;
+    expect(getRanges(start, end, step, 20000)).toBeNull();
+  });
+
+  it('should return null if requested duration is smaller than step', () => {
+    const start = Date.parse('2022-02-06T14:10:03');
+    const end = Date.parse('2022-02-06T14:10:33');
+    const step = 10 * 1000;
+    expect(getRanges(start, end, step, 1000)).toBeNull();
+  });
+});

--- a/public/app/plugins/datasource/loki/metricTimeSplit.ts
+++ b/public/app/plugins/datasource/loki/metricTimeSplit.ts
@@ -1,0 +1,58 @@
+// every timestamp in this file is a number which contains an unix-timestamp-in-millisecond format,
+// like returned by `new Date().getTime()`. this is needed because the "math"
+// has to be done on integer numbers.
+
+// we are trying to be compatible with
+// https://github.com/grafana/loki/blob/089ec1b05f5ec15a8851d0e8230153e0eeb4dcec/pkg/querier/queryrange/split_by_interval.go#L327-L336
+
+function expandTimeRange(startTime: number, endTime: number, step: number): [number, number] {
+  // startTime is decreased to the closes multiple-of-step, if necessary
+  const newStartTime = startTime - (startTime % step);
+
+  // endTime is increased to the closed multiple-of-step, if necessary
+  let newEndTime = endTime;
+  const endStepMod = endTime % step;
+  if (endStepMod !== 0) {
+    newEndTime += step - endStepMod;
+  }
+
+  return [newStartTime, newEndTime];
+}
+
+const MAX_CHUNK_COUNT = 50;
+
+export function getRanges(
+  startTime: number,
+  endTime: number,
+  step: number,
+  idealRangeDuration: number
+): Array<[number, number]> | null {
+  if (idealRangeDuration < step) {
+    // we cannot create chunks smaller than `step`
+    return null;
+  }
+
+  // we make the duration a multiple of `step`, lowering it if necessary
+  const alignedDuration = Math.trunc(idealRangeDuration / step) * step;
+
+  const [alignedStartTime, alignedEndTime] = expandTimeRange(startTime, endTime, step);
+
+  const result: Array<[number, number]> = [];
+
+  // we iterate it from the end, because we want to have the potentially smaller chunk at the end, not at the beginning
+  for (let chunkEndTime = alignedEndTime; chunkEndTime > alignedStartTime; chunkEndTime -= alignedDuration + step) {
+    // when we get close to the start of the time range, we need to be sure not
+    // to cross over the startTime
+    const chunkStartTime = Math.max(chunkEndTime - alignedDuration, alignedStartTime);
+    result.push([chunkStartTime, chunkEndTime]);
+
+    if (result.length > MAX_CHUNK_COUNT) {
+      return null;
+    }
+  }
+
+  // because we walked backwards, we need to reverse the array
+  result.reverse();
+
+  return result;
+}

--- a/public/app/plugins/datasource/loki/queryUtils.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.ts
@@ -5,11 +5,8 @@ import {
   DataQueryRequest,
   DataQueryResponse,
   DataQueryResponseData,
-  dateTime,
-  DurationUnit,
   QueryResultMeta,
   QueryResultMetaStat,
-  TimeRange,
 } from '@grafana/data';
 import {
   parser,
@@ -319,37 +316,6 @@ export function getStreamSelectorsFromQuery(query: string): string[] {
   });
 
   return labelMatchers;
-}
-
-const PARTITION_LIMIT = 60;
-export function partitionTimeRange(range: TimeRange, timeShift = 1, unit: DurationUnit = 'm'): TimeRange[] {
-  const partition: TimeRange[] = [];
-  for (let from = dateTime(range.from), to = dateTime(from).add(timeShift, unit); to <= range.to && from < range.to; ) {
-    partition.push({
-      from,
-      to,
-      raw: { from, to },
-    });
-
-    /**
-     * The user can request for any arbitrary time range. If we receive one from too
-     * long ago, this will cause an extremely large loop which could break the app.
-     * Additionally, data retention is limited, so ranges that go above PARTIION_LIMIT
-     * will be ignored.
-     */
-    if (partition.length > PARTITION_LIMIT) {
-      return [range];
-    }
-
-    from = dateTime(to);
-    to = dateTime(to).add(timeShift, unit);
-
-    if (to > range.to) {
-      to = range.to;
-    }
-  }
-
-  return partition;
 }
 
 export function requestSupportsPartitioning(queries: LokiQuery[]) {


### PR DESCRIPTION
this PR adds an algorithm to choose goot sub-time-ranges for metric queries (NOTE: for logs-queries, this will have to be a different algo. a simpler algo, but still, a different algo 😄 ).

the current version of the algo is optimized for being simple, we can later make it faster.
it works like this:

1. we take the specified time-range,and "expand" it, by moving start-time "down" and end-time "up", until they are a multiple of the `step` (also called aligning the time range to `step`)
    - (Loki is also doing this since Loki2.5.0)
2. we calculate an array of every timestamp that will be returnd by the loki-query
    - (this is a simple start-at-start-time, and walk by `step` amount... note that every timestamp is an integer number, because we aligned things in [1])
    - result is like `a` `b` `c` `d` `e` `f` `g` `h`
3. now we group those timestamps into groups with the right size (based on the requested chunk-size)
    - let's assume the range is 3timestamps, result is like `[a b]` `[c d e]` `[f g h]` (we have the maybe-smaller group at the start, not at the end)
4. from the grouped results, for every group we take the first and last timestamp, giving us the time-ranges
    - result is like `[a b]` `[c e]` `[f h]`