### PR TITLE
[v9.4.x] Docs: Fix 404 links in build a plugin page (#63006)

### DIFF
--- a/docs/sources/developers/plugins/_index.md
+++ b/docs/sources/developers/plugins/_index.md
@@ -47,22 +47,22 @@ Ready to learn more? Check out our other tutorials:
 
 Improve an existing plugin with one of our guides:
 
-- [Add authentication for data source plugins]({{< relref "add-authentication-for-data-source-plugins/" >}})
-- [Add support for annotations]({{< relref "add-support-for-annotations/" >}})
-- [Add support for Explore queries]({{< relref "add-support-for-explore-queries/" >}})
-- [Add support for variables]({{< relref "add-support-for-variables/" >}})
-- [Add a query editor help component]({{< relref "add-query-editor-help/" >}})
-- [Build a logs data source plugin]({{< relref "build-a-logs-data-source-plugin/" >}})
-- [Build a streaming data source plugin]({{< relref "build-a-streaming-data-source-plugin/" >}})
-- [Error handling]({{< relref "error-handling/" >}})
-- [Working with data frames]({{< relref "working-with-data-frames/" >}})
-- [Development with local Grafana]({{< relref "development-with-local-grafana/" >}})
+- [Add authentication for data source plugins]({{< relref "add-authentication-for-data-source-plugins.md" >}})
+- [Add support for annotations]({{< relref "add-support-for-annotations.md" >}})
+- [Add support for Explore queries]({{< relref "add-support-for-explore-queries.md" >}})
+- [Add support for variables]({{< relref "add-support-for-variables.md" >}})
+- [Add a query editor help component]({{< relref "add-query-editor-help.md" >}})
+- [Build a logs data source plugin]({{< relref "build-a-logs-data-source-plugin.md" >}})
+- [Build a streaming data source plugin]({{< relref "build-a-streaming-data-source-plugin.md" >}}/)
+- [Error handling]({{< relref "error-handling.md" >}})
+- [Working with data frames]({{< relref "working-with-data-frames.md" >}})
+- [Development with local Grafana]({{< relref "development-with-local-grafana.md" >}})
 
 ### Concepts
 
 Deepen your knowledge through a series of high-level overviews of plugin concepts:
 
-- [Data frames]({{< relref "data-frames/" >}})
+- [Data frames]({{< relref "data-frames.md" >}})
 
 ### UI library
 
@@ -74,8 +74,8 @@ For inspiration, check out our [plugin examples](https://github.com/grafana/graf
 
 ### Metadata
 
-- [Plugin metadata]({{< relref "metadata/" >}})
+- [Plugin metadata]({{< relref "metadata.md" >}})
 
 ### SDK
 
-- [Grafana Plugin SDK for Go]({{< relref "backend/grafana-plugin-sdk-for-go/" >}})
+- [Grafana Plugin SDK for Go]({{< relref "backend/grafana-plugin-sdk-for-go.md" >}})


### PR DESCRIPTION
Backports a2f8dd7f1fc23379b6da17339cd03b2b29a95623 from #63006