### PR TITLE
Chore: Validate batch query refIds

### DIFF
--- a/pkg/services/query/errors.go
+++ b/pkg/services/query/errors.go
@@ -9,4 +9,5 @@ var (
 	ErrInvalidDatasourceID   = errutil.NewBase(errutil.StatusBadRequest, "query.invalidDatasourceId", errutil.WithPublicMessage("Query does not contain a valid data source identifier")).Errorf("invalid data source identifier")
 	ErrMissingDataSourceInfo = errutil.NewBase(errutil.StatusBadRequest, "query.missingDataSourceInfo").MustTemplate("query missing datasource info: {{ .Public.RefId }}", errutil.WithPublic("Query {{ .Public.RefId }} is missing datasource information"))
 	ErrQueryParamMismatch    = errutil.NewBase(errutil.StatusBadRequest, "query.headerMismatch", errutil.WithPublicMessage("The request headers point to a different plugin than is defined in the request body")).Errorf("plugin header/body mismatch")
+	ErrDuplicateRefId        = errutil.NewBase(errutil.StatusBadRequest, "query.duplicateRefId", errutil.WithPublicMessage("The request contains duplicated RefId")).Errorf("duplicated RefId")
 )

--- a/pkg/services/query/errors.go
+++ b/pkg/services/query/errors.go
@@ -9,5 +9,5 @@ var (
 	ErrInvalidDatasourceID   = errutil.NewBase(errutil.StatusBadRequest, "query.invalidDatasourceId", errutil.WithPublicMessage("Query does not contain a valid data source identifier")).Errorf("invalid data source identifier")
 	ErrMissingDataSourceInfo = errutil.NewBase(errutil.StatusBadRequest, "query.missingDataSourceInfo").MustTemplate("query missing datasource info: {{ .Public.RefId }}", errutil.WithPublic("Query {{ .Public.RefId }} is missing datasource information"))
 	ErrQueryParamMismatch    = errutil.NewBase(errutil.StatusBadRequest, "query.headerMismatch", errutil.WithPublicMessage("The request headers point to a different plugin than is defined in the request body")).Errorf("plugin header/body mismatch")
-	ErrDuplicateRefId        = errutil.NewBase(errutil.StatusBadRequest, "query.duplicateRefId", errutil.WithPublicMessage("The request contains duplicated RefId")).Errorf("duplicated RefId")
+	ErrDuplicateRefId        = errutil.NewBase(errutil.StatusBadRequest, "query.duplicateRefId", errutil.WithPublicMessage("Multiple queries using the same RefId is not allowed ")).Errorf("multiple queries using the same RefId is not allowed")
 )

--- a/pkg/services/query/models.go
+++ b/pkg/services/query/models.go
@@ -32,6 +32,21 @@ func (pr parsedRequest) getFlattenedQueries() []parsedQuery {
 }
 
 func (pr parsedRequest) validateRequest(ctx context.Context) error {
+	refIds := make(map[string]bool)
+	for _, pq := range pr.parsedQueries {
+		for _, q := range pq {
+			if refIds[q.query.RefID] {
+				return ErrDuplicateRefId
+			}
+			refIds[q.query.RefID] = true
+		}
+	}
+
+	// Skip header validation. See https://github.com/grafana/grafana/pull/58871
+	if true {
+		return nil
+	}
+
 	reqCtx := contexthandler.FromContext(ctx)
 
 	if reqCtx == nil || reqCtx.Req == nil {

--- a/pkg/services/query/query.go
+++ b/pkg/services/query/query.go
@@ -295,8 +295,7 @@ func (s *Service) parseMetricRequest(ctx context.Context, user *user.SignedInUse
 		})
 	}
 
-	_ = req.validateRequest(ctx)
-	return req, nil // TODO req.validateRequest()
+	return req, req.validateRequest(ctx)
 }
 
 func (s *Service) getDataSourceFromQuery(ctx context.Context, user *user.SignedInUser, skipCache bool, query *simplejson.Json, history map[string]*datasources.DataSource) (*datasources.DataSource, error) {

--- a/pkg/services/query/query_test.go
+++ b/pkg/services/query/query_test.go
@@ -235,6 +235,25 @@ func TestParseMetricRequest(t *testing.T) {
 		_, err = tc.queryService.parseMetricRequest(httpreq.Context(), tc.signedInUser, true, mr)
 		require.NoError(t, err)
 	})
+
+	t.Run("Test a duplicated refId", func(t *testing.T) {
+		tc := setup(t)
+		mr := metricRequestWithQueries(t, `{
+			"refId": "A",
+			"datasource": {
+				"uid": "gIEkMvIVz",
+				"type": "postgres"
+			}
+		}`, `{
+			"refId": "A",
+			"datasource": {
+				"uid": "gIEkMvIVz",
+				"type": "postgres"
+			}
+		}`)
+		_, err := tc.queryService.parseMetricRequest(context.Background(), tc.signedInUser, true, mr)
+		require.Error(t, err)
+	})
 }
 
 func TestQueryDataMultipleSources(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Return an error if a query batch contains multiple queries with the same refID.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #59411
Fixes #59428

**Special notes for your reviewer**:

I am reusing the existing `validateRequest` but maintaining the current behavior of skipping the check that validates headers. Should that be fixed?

Also, I am assuming this does not need to be backported. Is this correct?
