### PR TITLE
Influxdb: Remove explicit user agent definition

### DIFF
--- a/pkg/tsdb/influxdb/influxdb.go
+++ b/pkg/tsdb/influxdb/influxdb.go
@@ -179,8 +179,6 @@ func (s *Service) createRequest(ctx context.Context, logger log.Logger, dsInfo *
 		return nil, ErrInvalidHttpMode
 	}
 
-	req.Header.Set("User-Agent", "Grafana")
-
 	params := req.URL.Query()
 	params.Set("db", dsInfo.DbName)
 	params.Set("epoch", "ms")


### PR DESCRIPTION
**What is this feature?**
Removes the explicit `user-agent` header definition since it is already handled here: 
https://github.com/grafana/grafana/blob/main/pkg/plugins/repo/client.go#L195
https://github.com/grafana/grafana/blob/main/pkg/infra/httpclient/httpclientprovider/user_agent_middleware.go

And for the `flux`, it is handled in the API and 
https://github.com/influxdata/influxdb-client-go/blob/master/version.go

**Which issue(s) does this PR fix?**:

Fixes/Closes https://github.com/grafana/grafana/issues/27299

