### PR TITLE
Folders: set org ID when converting from dash to a folder

### DIFF
--- a/pkg/services/dashboards/models.go
+++ b/pkg/services/dashboards/models.go
@@ -314,6 +314,7 @@ func FromDashboard(dash *Dashboard) *folder.Folder {
 	return &folder.Folder{
 		ID:        dash.ID,
 		UID:       dash.UID,
+		OrgID:     dash.OrgID,
 		Title:     dash.Title,
 		HasACL:    dash.HasACL,
 		URL:       GetFolderURL(dash.UID, dash.Slug),


### PR DESCRIPTION
**What is this feature?**
A tiny fix to set orgID when converting from dashboards to folders.