### PR TITLE
Alerting: Unify structs in Loki client and make them more consistent with Prometheus

### DIFF
--- a/pkg/services/ngalert/state/historian/loki.go
+++ b/pkg/services/ngalert/state/historian/loki.go
@@ -164,7 +164,7 @@ func merge(res queryRes, ruleUID string) (*data.Frame, error) {
 	pointers := make([]int, len(res.Data.Result))
 	for {
 		minTime := int64(math.MaxInt64)
-		minEl := row{}
+		minEl := sample{}
 		minElStreamIdx := -1
 		// Find the element with the earliest time among all arrays.
 		for i, stream := range res.Data.Result {
@@ -215,7 +215,7 @@ func merge(res queryRes, ruleUID string) (*data.Frame, error) {
 }
 
 func statesToStreams(rule history_model.RuleMeta, states []state.StateTransition, externalLabels map[string]string, logger log.Logger) []stream {
-	buckets := make(map[string][]row) // label repr -> entries
+	buckets := make(map[string][]sample) // label repr -> entries
 	for _, state := range states {
 		if !shouldRecord(state) {
 			continue
@@ -248,7 +248,7 @@ func statesToStreams(rule history_model.RuleMeta, states []state.StateTransition
 		}
 		line := string(jsn)
 
-		buckets[repr] = append(buckets[repr], row{
+		buckets[repr] = append(buckets[repr], sample{
 			T: state.State.LastEvaluationTime,
 			V: line,
 		})

--- a/pkg/services/ngalert/state/historian/loki.go
+++ b/pkg/services/ngalert/state/historian/loki.go
@@ -38,7 +38,7 @@ const defaultQueryRange = 6 * time.Hour
 type remoteLokiClient interface {
 	ping(context.Context) error
 	push(context.Context, []stream) error
-	rangeQuery(ctx context.Context, selectors []Selector, start, end int64) (QueryRes, error)
+	rangeQuery(ctx context.Context, selectors []Selector, start, end int64) (queryRes, error)
 }
 
 type RemoteLokiBackend struct {
@@ -138,7 +138,7 @@ func buildSelectors(query models.HistoryQuery) ([]Selector, error) {
 }
 
 // merge will put all the results in one array sorted by timestamp.
-func merge(res QueryRes, ruleUID string) (*data.Frame, error) {
+func merge(res queryRes, ruleUID string) (*data.Frame, error) {
 	// Find the total number of elements in all arrays.
 	totalLen := 0
 	for _, arr := range res.Data.Result {

--- a/pkg/services/ngalert/state/historian/loki.go
+++ b/pkg/services/ngalert/state/historian/loki.go
@@ -172,7 +172,7 @@ func merge(res queryRes, ruleUID string) (*data.Frame, error) {
 			if len(stream.Values) == pointers[i] {
 				continue
 			}
-			curTime := stream.Values[pointers[i]].At.UnixNano()
+			curTime := stream.Values[pointers[i]].T.UnixNano()
 			if pointers[i] < len(stream.Values) && curTime < minTime {
 				minTime = curTime
 				minEl = stream.Values[pointers[i]]
@@ -184,19 +184,19 @@ func merge(res queryRes, ruleUID string) (*data.Frame, error) {
 			break
 		}
 		var entry lokiEntry
-		err := json.Unmarshal([]byte(minEl.Val), &entry)
+		err := json.Unmarshal([]byte(minEl.V), &entry)
 		if err != nil {
 			return nil, fmt.Errorf("failed to unmarshal entry: %w", err)
 		}
 		// Append the minimum element to the merged slice and move the pointer.
-		tsNano := minEl.At.UnixNano()
+		tsNano := minEl.T.UnixNano()
 		// TODO: In general, perhaps we should omit the offending line and log, rather than failing the request entirely.
 		streamLbls := res.Data.Result[minElStreamIdx].Stream
 		lblsJson, err := json.Marshal(streamLbls)
 		if err != nil {
 			return nil, fmt.Errorf("failed to serialize stream labels: %w", err)
 		}
-		line, err := jsonifyRow(minEl.Val)
+		line, err := jsonifyRow(minEl.V)
 		if err != nil {
 			return nil, fmt.Errorf("a line was in an invalid format: %w", err)
 		}
@@ -249,8 +249,8 @@ func statesToStreams(rule history_model.RuleMeta, states []state.StateTransition
 		line := string(jsn)
 
 		buckets[repr] = append(buckets[repr], row{
-			At:  state.State.LastEvaluationTime,
-			Val: line,
+			T: state.State.LastEvaluationTime,
+			V: line,
 		})
 	}
 

--- a/pkg/services/ngalert/state/historian/loki_http.go
+++ b/pkg/services/ngalert/state/historian/loki_http.go
@@ -125,13 +125,13 @@ type stream struct {
 }
 
 type row struct {
-	At  time.Time
-	Val string
+	T time.Time
+	V string
 }
 
 func (r *row) MarshalJSON() ([]byte, error) {
 	return json.Marshal([2]string{
-		fmt.Sprintf("%d", r.At.UnixNano()), r.Val,
+		fmt.Sprintf("%d", r.T.UnixNano()), r.V,
 	})
 }
 
@@ -147,8 +147,8 @@ func (r *row) UnmarshalJSON(b []byte) error {
 	if err != nil {
 		return fmt.Errorf("timestamp in Loki sample not convertible to nanosecond epoch: %v", tuple[0])
 	}
-	r.At = time.Unix(0, nano)
-	r.Val = tuple[1]
+	r.T = time.Unix(0, nano)
+	r.V = tuple[1]
 	return nil
 }
 

--- a/pkg/services/ngalert/state/historian/loki_http.go
+++ b/pkg/services/ngalert/state/historian/loki_http.go
@@ -293,16 +293,11 @@ func isValidOperator(op string) bool {
 	return false
 }
 
-type Stream struct {
-	Stream map[string]string `json:"stream"`
-	Values []row             `json:"values"`
-}
-
 type QueryRes struct {
 	Status string    `json:"status"`
 	Data   QueryData `json:"data"`
 }
 
 type QueryData struct {
-	Result []Stream `json:"result"`
+	Result []stream `json:"result"`
 }

--- a/pkg/services/ngalert/state/historian/loki_http.go
+++ b/pkg/services/ngalert/state/historian/loki_http.go
@@ -294,8 +294,7 @@ func isValidOperator(op string) bool {
 }
 
 type QueryRes struct {
-	Status string    `json:"status"`
-	Data   QueryData `json:"data"`
+	Data QueryData `json:"data"`
 }
 
 type QueryData struct {

--- a/pkg/services/ngalert/state/historian/loki_http.go
+++ b/pkg/services/ngalert/state/historian/loki_http.go
@@ -121,21 +121,21 @@ func (c *httpLokiClient) ping(ctx context.Context) error {
 
 type stream struct {
 	Stream map[string]string `json:"stream"`
-	Values []row             `json:"values"`
+	Values []sample          `json:"values"`
 }
 
-type row struct {
+type sample struct {
 	T time.Time
 	V string
 }
 
-func (r *row) MarshalJSON() ([]byte, error) {
+func (r *sample) MarshalJSON() ([]byte, error) {
 	return json.Marshal([2]string{
 		fmt.Sprintf("%d", r.T.UnixNano()), r.V,
 	})
 }
 
-func (r *row) UnmarshalJSON(b []byte) error {
+func (r *sample) UnmarshalJSON(b []byte) error {
 	// A Loki stream sample is formatted like a list with two elements, [At, Val]
 	// At is a string wrapping a timestamp, in nanosecond unix epoch.
 	// Val is a string containing the log line.

--- a/pkg/services/ngalert/state/historian/loki_http_test.go
+++ b/pkg/services/ngalert/state/historian/loki_http_test.go
@@ -160,8 +160,8 @@ func TestNewSelector(t *testing.T) {
 func TestRow(t *testing.T) {
 	t.Run("marshal", func(t *testing.T) {
 		row := row{
-			At:  time.Unix(0, 1234),
-			Val: "some sample",
+			T: time.Unix(0, 1234),
+			V: "some sample",
 		}
 
 		jsn, err := json.Marshal(&row)
@@ -177,8 +177,8 @@ func TestRow(t *testing.T) {
 		err := json.Unmarshal(jsn, &row)
 
 		require.NoError(t, err)
-		require.Equal(t, int64(1234), row.At.UnixNano())
-		require.Equal(t, "some sample", row.Val)
+		require.Equal(t, int64(1234), row.T.UnixNano())
+		require.Equal(t, "some sample", row.V)
 	})
 
 	t.Run("unmarshal invalid", func(t *testing.T) {
@@ -205,8 +205,8 @@ func TestStream(t *testing.T) {
 		stream := stream{
 			Stream: map[string]string{"a": "b"},
 			Values: []row{
-				{At: time.Unix(0, 1), Val: "one"},
-				{At: time.Unix(0, 2), Val: "two"},
+				{T: time.Unix(0, 1), V: "one"},
+				{T: time.Unix(0, 2), V: "two"},
 			},
 		}
 

--- a/pkg/services/ngalert/state/historian/loki_http_test.go
+++ b/pkg/services/ngalert/state/historian/loki_http_test.go
@@ -159,7 +159,7 @@ func TestNewSelector(t *testing.T) {
 
 func TestRow(t *testing.T) {
 	t.Run("marshal", func(t *testing.T) {
-		row := row{
+		row := sample{
 			T: time.Unix(0, 1234),
 			V: "some sample",
 		}
@@ -173,7 +173,7 @@ func TestRow(t *testing.T) {
 	t.Run("unmarshal", func(t *testing.T) {
 		jsn := []byte(`["1234", "some sample"]`)
 
-		row := row{}
+		row := sample{}
 		err := json.Unmarshal(jsn, &row)
 
 		require.NoError(t, err)
@@ -184,7 +184,7 @@ func TestRow(t *testing.T) {
 	t.Run("unmarshal invalid", func(t *testing.T) {
 		jsn := []byte(`{"key": "wrong shape"}`)
 
-		row := row{}
+		row := sample{}
 		err := json.Unmarshal(jsn, &row)
 
 		require.ErrorContains(t, err, "failed to deserialize sample")
@@ -193,7 +193,7 @@ func TestRow(t *testing.T) {
 	t.Run("unmarshal bad timestamp", func(t *testing.T) {
 		jsn := []byte(`["not-unix-nano", "some sample"]`)
 
-		row := row{}
+		row := sample{}
 		err := json.Unmarshal(jsn, &row)
 
 		require.ErrorContains(t, err, "timestamp in Loki sample")
@@ -204,7 +204,7 @@ func TestStream(t *testing.T) {
 	t.Run("marshal", func(t *testing.T) {
 		stream := stream{
 			Stream: map[string]string{"a": "b"},
-			Values: []row{
+			Values: []sample{
 				{T: time.Unix(0, 1), V: "one"},
 				{T: time.Unix(0, 2), V: "two"},
 			},

--- a/pkg/services/ngalert/state/historian/loki_http_test.go
+++ b/pkg/services/ngalert/state/historian/loki_http_test.go
@@ -2,6 +2,7 @@ package historian
 
 import (
 	"context"
+	"encoding/json"
 	"net/url"
 	"testing"
 	"time"
@@ -154,4 +155,68 @@ func TestNewSelector(t *testing.T) {
 
 	selector, err = NewSelector("label", "invalid", "value")
 	require.Error(t, err)
+}
+
+func TestRow(t *testing.T) {
+	t.Run("marshal", func(t *testing.T) {
+		row := row{
+			At:  time.Unix(0, 1234),
+			Val: "some sample",
+		}
+
+		jsn, err := json.Marshal(&row)
+
+		require.NoError(t, err)
+		require.JSONEq(t, `["1234", "some sample"]`, string(jsn))
+	})
+
+	t.Run("unmarshal", func(t *testing.T) {
+		jsn := []byte(`["1234", "some sample"]`)
+
+		row := row{}
+		err := json.Unmarshal(jsn, &row)
+
+		require.NoError(t, err)
+		require.Equal(t, int64(1234), row.At.UnixNano())
+		require.Equal(t, "some sample", row.Val)
+	})
+
+	t.Run("unmarshal invalid", func(t *testing.T) {
+		jsn := []byte(`{"key": "wrong shape"}`)
+
+		row := row{}
+		err := json.Unmarshal(jsn, &row)
+
+		require.ErrorContains(t, err, "failed to deserialize sample")
+	})
+
+	t.Run("unmarshal bad timestamp", func(t *testing.T) {
+		jsn := []byte(`["not-unix-nano", "some sample"]`)
+
+		row := row{}
+		err := json.Unmarshal(jsn, &row)
+
+		require.ErrorContains(t, err, "timestamp in Loki sample")
+	})
+}
+
+func TestStream(t *testing.T) {
+	t.Run("marshal", func(t *testing.T) {
+		stream := stream{
+			Stream: map[string]string{"a": "b"},
+			Values: []row{
+				{At: time.Unix(0, 1), Val: "one"},
+				{At: time.Unix(0, 2), Val: "two"},
+			},
+		}
+
+		jsn, err := json.Marshal(stream)
+
+		require.NoError(t, err)
+		require.JSONEq(
+			t,
+			`{"stream": {"a": "b"}, "values": [["1", "one"], ["2", "two"]]}`,
+			string(jsn),
+		)
+	})
 }

--- a/pkg/services/ngalert/state/historian/loki_test.go
+++ b/pkg/services/ngalert/state/historian/loki_test.go
@@ -144,14 +144,14 @@ func TestRemoteLokiBackend(t *testing.T) {
 func TestMerge(t *testing.T) {
 	testCases := []struct {
 		name         string
-		res          QueryRes
+		res          queryRes
 		ruleID       string
 		expectedTime []time.Time
 	}{
 		{
 			name: "Should return values from multiple streams in right order",
-			res: QueryRes{
-				Data: QueryData{
+			res: queryRes{
+				Data: queryData{
 					Result: []stream{
 						{
 							Stream: map[string]string{
@@ -180,8 +180,8 @@ func TestMerge(t *testing.T) {
 		},
 		{
 			name: "Should handle empty values",
-			res: QueryRes{
-				Data: QueryData{
+			res: queryRes{
+				Data: queryData{
 					Result: []stream{
 						{
 							Stream: map[string]string{
@@ -197,8 +197,8 @@ func TestMerge(t *testing.T) {
 		},
 		{
 			name: "Should handle multiple values in one stream",
-			res: QueryRes{
-				Data: QueryData{
+			res: queryRes{
+				Data: queryData{
 					Result: []stream{
 						{
 							Stream: map[string]string{

--- a/pkg/services/ngalert/state/historian/loki_test.go
+++ b/pkg/services/ngalert/state/historian/loki_test.go
@@ -157,16 +157,16 @@ func TestMerge(t *testing.T) {
 							Stream: map[string]string{
 								"current": "pending",
 							},
-							Values: [][2]string{
-								{"1", `{"schemaVersion": 1, "previous": "normal", "current": "pending", "values":{"a": "b"}}`},
+							Values: []row{
+								{time.Unix(0, 1), `{"schemaVersion": 1, "previous": "normal", "current": "pending", "values":{"a": "b"}}`},
 							},
 						},
 						{
 							Stream: map[string]string{
 								"current": "firing",
 							},
-							Values: [][2]string{
-								{"2", `{"schemaVersion": 1, "previous": "pending", "current": "firing", "values":{"a": "b"}}`},
+							Values: []row{
+								{time.Unix(0, 2), `{"schemaVersion": 1, "previous": "pending", "current": "firing", "values":{"a": "b"}}`},
 							},
 						},
 					},
@@ -187,7 +187,7 @@ func TestMerge(t *testing.T) {
 							Stream: map[string]string{
 								"current": "normal",
 							},
-							Values: [][2]string{},
+							Values: []row{},
 						},
 					},
 				},
@@ -204,17 +204,17 @@ func TestMerge(t *testing.T) {
 							Stream: map[string]string{
 								"current": "normal",
 							},
-							Values: [][2]string{
-								{"1", `{"schemaVersion": 1, "previous": "firing", "current": "normal", "values":{"a": "b"}}`},
-								{"2", `{"schemaVersion": 1, "previous": "firing", "current": "normal", "values":{"a": "b"}}`},
+							Values: []row{
+								{time.Unix(0, 1), `{"schemaVersion": 1, "previous": "firing", "current": "normal", "values":{"a": "b"}}`},
+								{time.Unix(0, 2), `{"schemaVersion": 1, "previous": "firing", "current": "normal", "values":{"a": "b"}}`},
 							},
 						},
 						{
 							Stream: map[string]string{
 								"current": "firing",
 							},
-							Values: [][2]string{
-								{"3", `{"schemaVersion": 1, "previous": "pending", "current": "firing", "values":{"a": "b"}}`},
+							Values: []row{
+								{time.Unix(0, 3), `{"schemaVersion": 1, "previous": "pending", "current": "firing", "values":{"a": "b"}}`},
 							},
 						},
 					},

--- a/pkg/services/ngalert/state/historian/loki_test.go
+++ b/pkg/services/ngalert/state/historian/loki_test.go
@@ -280,7 +280,7 @@ func requireEntry(t *testing.T, row row) lokiEntry {
 	t.Helper()
 
 	var entry lokiEntry
-	err := json.Unmarshal([]byte(row.Val), &entry)
+	err := json.Unmarshal([]byte(row.V), &entry)
 	require.NoError(t, err)
 	return entry
 }

--- a/pkg/services/ngalert/state/historian/loki_test.go
+++ b/pkg/services/ngalert/state/historian/loki_test.go
@@ -157,7 +157,7 @@ func TestMerge(t *testing.T) {
 							Stream: map[string]string{
 								"current": "pending",
 							},
-							Values: []row{
+							Values: []sample{
 								{time.Unix(0, 1), `{"schemaVersion": 1, "previous": "normal", "current": "pending", "values":{"a": "b"}}`},
 							},
 						},
@@ -165,7 +165,7 @@ func TestMerge(t *testing.T) {
 							Stream: map[string]string{
 								"current": "firing",
 							},
-							Values: []row{
+							Values: []sample{
 								{time.Unix(0, 2), `{"schemaVersion": 1, "previous": "pending", "current": "firing", "values":{"a": "b"}}`},
 							},
 						},
@@ -187,7 +187,7 @@ func TestMerge(t *testing.T) {
 							Stream: map[string]string{
 								"current": "normal",
 							},
-							Values: []row{},
+							Values: []sample{},
 						},
 					},
 				},
@@ -204,7 +204,7 @@ func TestMerge(t *testing.T) {
 							Stream: map[string]string{
 								"current": "normal",
 							},
-							Values: []row{
+							Values: []sample{
 								{time.Unix(0, 1), `{"schemaVersion": 1, "previous": "firing", "current": "normal", "values":{"a": "b"}}`},
 								{time.Unix(0, 2), `{"schemaVersion": 1, "previous": "firing", "current": "normal", "values":{"a": "b"}}`},
 							},
@@ -213,7 +213,7 @@ func TestMerge(t *testing.T) {
 							Stream: map[string]string{
 								"current": "firing",
 							},
-							Values: []row{
+							Values: []sample{
 								{time.Unix(0, 3), `{"schemaVersion": 1, "previous": "pending", "current": "firing", "values":{"a": "b"}}`},
 							},
 						},
@@ -276,7 +276,7 @@ func requireSingleEntry(t *testing.T, res []stream) lokiEntry {
 	return requireEntry(t, res[0].Values[0])
 }
 
-func requireEntry(t *testing.T, row row) lokiEntry {
+func requireEntry(t *testing.T, row sample) lokiEntry {
 	t.Helper()
 
 	var entry lokiEntry

--- a/pkg/services/ngalert/state/historian/loki_test.go
+++ b/pkg/services/ngalert/state/historian/loki_test.go
@@ -152,7 +152,7 @@ func TestMerge(t *testing.T) {
 			name: "Should return values from multiple streams in right order",
 			res: QueryRes{
 				Data: QueryData{
-					Result: []Stream{
+					Result: []stream{
 						{
 							Stream: map[string]string{
 								"current": "pending",
@@ -182,7 +182,7 @@ func TestMerge(t *testing.T) {
 			name: "Should handle empty values",
 			res: QueryRes{
 				Data: QueryData{
-					Result: []Stream{
+					Result: []stream{
 						{
 							Stream: map[string]string{
 								"current": "normal",
@@ -199,7 +199,7 @@ func TestMerge(t *testing.T) {
 			name: "Should handle multiple values in one stream",
 			res: QueryRes{
 				Data: QueryData{
-					Result: []Stream{
+					Result: []stream{
 						{
 							Stream: map[string]string{
 								"current": "normal",


### PR DESCRIPTION
**What is this feature?**

The loki client had some duplicated structs, `Stream` and `stream` for example, that were nearly identical but used separately in the read and write paths.

This PR unifies the definitions of loki streams and samples.

- Read path's `Stream` got merged into the write path's `stream`
- The read path now uses the type safe struct for samples over `[2]string`.
- Stop exporting some types that didn't need to be exported
- Rename `row` to `sample` for terminology consistency between prometheus and loki docs
- Rename `sample.At` and `sample.Val` to `sample.T` and `sample.V` for [prometheus consistency](https://github.com/prometheus/prometheus/blob/c70d85baed260f6013afd18d6cd0ffcac4339861/promql/value.go#L50-L53)

**Which issue(s) does this PR fix?**:

contrib https://github.com/grafana/grafana/issues/48359

**Special notes for your reviewer**:

## Consider reviewing this PR commit-by-commit
