### PR TITLE
Alerting: Add markdown message type for DingDing

### DIFF
--- a/pkg/services/alerting/notifiers/dingding.go
+++ b/pkg/services/alerting/notifiers/dingding.go
@@ -41,10 +41,6 @@ func init() {
 						Value: "actionCard",
 						Label: "ActionCard",
 					},
-					{
-						Value: "markdown",
-						Label: "Markdown",
-					},
 				},
 			},
 		},

--- a/pkg/services/alerting/notifiers/dingding.go
+++ b/pkg/services/alerting/notifiers/dingding.go
@@ -138,14 +138,6 @@ func (dd *DingDingNotifier) genBody(evalContext *alerting.EvalContext, messageUR
 				"singleURL":   messageURL,
 			},
 		}
-	} else if dd.MsgType == "markdown" {
-		bodyMsg = map[string]interface{}{
-			"msgtype": "markdown",
-			"markdown": map[string]string{
-				"title": title,
-				"text":  message,
-			},
-		}
 	} else {
 		link := map[string]string{
 			"text":       message,

--- a/pkg/services/alerting/notifiers/dingding.go
+++ b/pkg/services/alerting/notifiers/dingding.go
@@ -41,6 +41,10 @@ func init() {
 						Value: "actionCard",
 						Label: "ActionCard",
 					},
+					{
+						Value: "markdown",
+						Label: "Markdown",
+					},
 				},
 			},
 		},

--- a/pkg/services/alerting/notifiers/dingding.go
+++ b/pkg/services/alerting/notifiers/dingding.go
@@ -142,6 +142,14 @@ func (dd *DingDingNotifier) genBody(evalContext *alerting.EvalContext, messageUR
 				"singleURL":   messageURL,
 			},
 		}
+	} else if dd.MsgType == "markdown" {
+		bodyMsg = map[string]interface{}{
+			"msgtype": "markdown",
+			"markdown": map[string]string{
+				"title": title,
+				"text":  message,
+			},
+		}
 	} else {
 		link := map[string]string{
 			"text":       message,

--- a/pkg/services/ngalert/notifier/channels_config/available_channels.go
+++ b/pkg/services/ngalert/notifier/channels_config/available_channels.go
@@ -135,6 +135,10 @@ func GetAvailableNotifiers() []*NotifierPlugin {
 							Value: "actionCard",
 							Label: "ActionCard",
 						},
+						{
+							Value: "markdown",
+							Label: "Markdown",
+						},
 					},
 				},
 				{ // New in 9.3.


### PR DESCRIPTION
Same as #62996 , but according to @grobinson-grafana's advice, remove the code about legacy alert, only contains the new ngalert code

`grafana/alerting` has the excat implementation of message body generation, please refer to #62996 to see more