### PR TITLE
feat: add option to declare an incident from panel if installed

### DIFF
--- a/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeaderMenuProvider.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeaderMenuProvider.tsx
@@ -1,6 +1,8 @@
 import { ReactElement, useEffect, useState } from 'react';
 
 import { LoadingState, PanelMenuItem } from '@grafana/data';
+import { usePluginBridge } from 'app/features/alerting/unified/hooks/usePluginBridge';
+import { SupportedPlugin } from 'app/features/alerting/unified/types/pluginBridges';
 import { getPanelStateForModel } from 'app/features/panel/state/selectors';
 import { useSelector } from 'app/types';
 
@@ -21,10 +23,11 @@ interface Props {
 export function PanelHeaderMenuProvider({ panel, dashboard, loadingState, children }: Props) {
   const [items, setItems] = useState<PanelMenuItem[]>([]);
   const angularComponent = useSelector((state) => getPanelStateForModel(state, panel)?.angularComponent);
+  const { installed: isIncidentPluginInstalled } = usePluginBridge(SupportedPlugin.Incident);
 
   useEffect(() => {
-    setItems(getPanelMenu(dashboard, panel, loadingState, angularComponent));
-  }, [dashboard, panel, angularComponent, loadingState, setItems]);
+    setItems(getPanelMenu(dashboard, panel, loadingState, angularComponent, isIncidentPluginInstalled));
+  }, [dashboard, panel, angularComponent, loadingState, setItems, isIncidentPluginInstalled]);
 
   return children({ items });
 }

--- a/public/app/features/dashboard/utils/getPanelMenu.ts
+++ b/public/app/features/dashboard/utils/getPanelMenu.ts
@@ -6,6 +6,8 @@ import config from 'app/core/config';
 import { t } from 'app/core/internationalization';
 import { contextSrv } from 'app/core/services/context_srv';
 import { getExploreUrl } from 'app/core/utils/explore';
+import { createBridgeURL } from 'app/features/alerting/unified/components/PluginBridge';
+import { SupportedPlugin } from 'app/features/alerting/unified/types/pluginBridges';
 import { DashboardModel } from 'app/features/dashboard/state/DashboardModel';
 import { PanelModel } from 'app/features/dashboard/state/PanelModel';
 import {
@@ -28,7 +30,8 @@ export function getPanelMenu(
   dashboard: DashboardModel,
   panel: PanelModel,
   loadingState?: LoadingState,
-  angularComponent?: AngularComponent | null
+  angularComponent?: AngularComponent | null,
+  isIncidentPluginInstalled?: boolean
 ): PanelMenuItem[] {
   const onViewPanel = (event: React.MouseEvent<any>) => {
     event.preventDefault();
@@ -104,6 +107,16 @@ export function getPanelMenu(
   const onCancelStreaming = (event: React.MouseEvent) => {
     event.preventDefault();
     panel.getQueryRunner().cancelQuery();
+  };
+
+  const onClickDeclareIncidnet = (event: React.MouseEvent) => {
+    event.preventDefault();
+    const bridgeURL = createBridgeURL(SupportedPlugin.Incident, '/incidents/declare', {
+      title: panel.title,
+      panelID: panel.id.toString(),
+      dashboardURL: dashboard.meta.url ?? '',
+    });
+    locationService.push(bridgeURL);
   };
 
   const menu: PanelMenuItem[] = [];
@@ -275,6 +288,16 @@ export function getPanelMenu(
       iconClassName: 'trash-alt',
       onClick: onRemovePanel,
       shortcut: 'p r',
+    });
+  }
+
+  if (isIncidentPluginInstalled) {
+    menu.push({ type: 'divider', text: '' });
+    menu.push({
+      text: t('panel.header-menu.remove', `Declare an incident`),
+      iconClassName: 'fire',
+      onClick: onClickDeclareIncidnet,
+      shortcut: 'p i',
     });
   }
 

--- a/public/sass/components/_dropdown.scss
+++ b/public/sass/components/_dropdown.scss
@@ -110,6 +110,7 @@
       display: flex;
       padding: 5px 10px;
       border-left: 2px solid transparent;
+      align-items: center;
 
       &:hover {
         color: $link-hover-color;


### PR DESCRIPTION

**What is this feature?**

added a button to declare an incident from panel options iif the plugin is installed

**Why do we need this feature?**

To enhance the ease of use and the user flow for grafana and plugins

**Who is this feature for?**

users who already have incidents installed


