### PR TITLE
Menu: Do not auto focus first item

### DIFF
--- a/packages/grafana-ui/src/components/Menu/Menu.tsx
+++ b/packages/grafana-ui/src/components/Menu/Menu.tsx
@@ -27,7 +27,7 @@ const MenuComp = React.forwardRef<HTMLDivElement, MenuProps>(
     const localRef = useRef<HTMLDivElement>(null);
     useImperativeHandle(forwardedRef, () => localRef.current!);
 
-    const [handleKeys, handleFocus] = useMenuFocus({ localRef, onOpen, onClose, onKeyDown });
+    const [handleKeys] = useMenuFocus({ localRef, onOpen, onClose, onKeyDown });
 
     return (
       <div
@@ -38,7 +38,6 @@ const MenuComp = React.forwardRef<HTMLDivElement, MenuProps>(
         role="menu"
         aria-label={ariaLabel}
         onKeyDown={handleKeys}
-        onFocus={handleFocus}
       >
         {header && <div className={styles.header}>{header}</div>}
         {children}

--- a/packages/grafana-ui/src/components/Menu/hooks.test.tsx
+++ b/packages/grafana-ui/src/components/Menu/hooks.test.tsx
@@ -157,20 +157,6 @@ describe('useMenuFocus', () => {
     expect(setOpenedWithArrow).toHaveBeenCalledWith(false);
   });
 
-  it('focuses on first item when container receives focus', () => {
-    const ref = createRef<HTMLDivElement>();
-    const { result } = renderHook(() => useMenuFocus({ localRef: ref }));
-    const [_, handleFocus] = result.current;
-
-    render(getMenuElement(ref, undefined, handleFocus));
-
-    act(() => {
-      screen.getByTestId(testid).focus();
-    });
-
-    expect(screen.getByText('Item 1').tabIndex).toBe(0);
-  });
-
   it('clicks focused item when Enter key is pressed', () => {
     const ref = createRef<HTMLDivElement>();
     const onClick = jest.fn();

--- a/packages/grafana-ui/src/components/Menu/hooks.ts
+++ b/packages/grafana-ui/src/components/Menu/hooks.ts
@@ -17,7 +17,7 @@ export interface UseMenuFocusProps {
 }
 
 /** @internal */
-export type UseMenuFocusReturn = [(event: React.KeyboardEvent) => void, () => void];
+export type UseMenuFocusReturn = [(event: React.KeyboardEvent) => void];
 
 /** @internal */
 export const useMenuFocus = ({
@@ -112,11 +112,5 @@ export const useMenuFocus = ({
     onKeyDown?.(event);
   };
 
-  const handleFocus = () => {
-    if (focusedItem === UNFOCUSED) {
-      setFocusedItem(0);
-    }
-  };
-
-  return [handleKeys, handleFocus];
+  return [handleKeys];
 };

--- a/packages/grafana-ui/src/components/Menu/hooks.ts
+++ b/packages/grafana-ui/src/components/Menu/hooks.ts
@@ -50,12 +50,6 @@ export const useMenuFocus = ({
   }, [localRef, focusedItem]);
 
   useEffectOnce(() => {
-    const firstMenuItem = localRef?.current?.querySelector<HTMLElement | HTMLButtonElement | HTMLAnchorElement>(
-      '[data-role="menuitem"]:not([data-disabled])'
-    );
-    if (firstMenuItem) {
-      firstMenuItem.tabIndex = 0;
-    }
     onOpen?.(setFocusedItem);
   });
 


### PR DESCRIPTION
When using the menu component it auto focus the first item which can be pretty annoying as it makes the mouse/hover interaction strange as it looks like two items have focus/hover. I cannot find any other component lib that auto-focuses the first item (checked antd, material ui, github profile menu). 

This is what I find buggy: for example after opening panel menu ([with new menu](https://github.com/grafana/grafana/pull/63040)) or  profile menu and start hovering over the second item it looks like this: 

![Screenshot from 2023-02-08 08-58-20](https://user-images.githubusercontent.com/10999/217498004-c1125927-7556-4b15-9d18-1c12643c8f1b.png)

![Screenshot from 2023-02-08 11-02-10](https://user-images.githubusercontent.com/10999/217498168-e4c2d0e8-97b4-4b88-9ac1-ca9aec3a6afd.png)

Removing this auto focus of first item does does not break any a11y features, key down will focus first item and the rest is as normal. 

