### PR TITLE
Plugin: Skip preloading disabled app plugins

### DIFF
--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -402,11 +402,12 @@ func newAppDTO(plugin plugins.PluginDTO, settings pluginsettings.InfoDTO) *plugi
 		ID:      plugin.ID,
 		Version: plugin.Info.Version,
 		Path:    plugin.Module,
-		Preload: plugin.Preload,
+		Preload: false,
 	}
 
 	if settings.Enabled {
 		app.Extensions = plugin.Extensions
+		app.Preload = plugin.Preload
 	}
 
 	return app

--- a/pkg/api/frontendsettings_test.go
+++ b/pkg/api/frontendsettings_test.go
@@ -310,6 +310,76 @@ func TestHTTPServer_GetFrontendSettings_apps(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc: "disabled app with preload",
+			pluginStore: func() plugins.Store {
+				return &plugins.FakePluginStore{
+					PluginList: []plugins.PluginDTO{
+						{
+							Module: fmt.Sprintf("/%s/module.js", "test-app"),
+							JSONData: plugins.JSONData{
+								ID:         "test-app",
+								Info:       plugins.Info{Version: "0.5.0"},
+								Type:       plugins.App,
+								Extensions: []*plugindef.ExtensionsLink{},
+								Preload:    true,
+							},
+						},
+					},
+				}
+			},
+			pluginSettings: func() pluginSettings.Service {
+				return &pluginSettings.FakePluginSettings{
+					Plugins: newAppSettings("test-app", false),
+				}
+			},
+			expected: settings{
+				Apps: map[string]*plugins.AppDTO{
+					"test-app": {
+						ID:         "test-app",
+						Preload:    false,
+						Path:       "/test-app/module.js",
+						Version:    "0.5.0",
+						Extensions: nil,
+					},
+				},
+			},
+		},
+		{
+			desc: "enalbed app with preload",
+			pluginStore: func() plugins.Store {
+				return &plugins.FakePluginStore{
+					PluginList: []plugins.PluginDTO{
+						{
+							Module: fmt.Sprintf("/%s/module.js", "test-app"),
+							JSONData: plugins.JSONData{
+								ID:         "test-app",
+								Info:       plugins.Info{Version: "0.5.0"},
+								Type:       plugins.App,
+								Extensions: []*plugindef.ExtensionsLink{},
+								Preload:    true,
+							},
+						},
+					},
+				}
+			},
+			pluginSettings: func() pluginSettings.Service {
+				return &pluginSettings.FakePluginSettings{
+					Plugins: newAppSettings("test-app", true),
+				}
+			},
+			expected: settings{
+				Apps: map[string]*plugins.AppDTO{
+					"test-app": {
+						ID:         "test-app",
+						Preload:    true,
+						Path:       "/test-app/module.js",
+						Version:    "0.5.0",
+						Extensions: nil,
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
**What is this feature?**
This PR will prevent app plugins from being preloaded if they are disabled. Something that we realized while working on the https://github.com/grafana/grafana/pull/61663 but didn't want to do it within the same PR.

**Why do we need this feature?**
Preloading disabled plugins will only slow down the initial load of Grafana.

**Who is this feature for?**
End users and plugin developers

**Special notes for your reviewer**:
The frontend will only preload app plugins with the `preload: true` value passed in the grafana settings. In this PR we will only return `preload: true` if the app plugin is enabled and has `preload: true` specified in plugin.json.
