### PR TITLE
Search: List nested folders

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -4487,10 +4487,6 @@ exports[`better eslint`] = {
     "public/app/features/search/page/components/SearchResultsGrid.test.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
-    "public/app/features/search/page/components/SearchResultsGrid.tsx:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
-      [0, 0, 0, "Do not use any type assertions.", "1"]
-    ],
     "public/app/features/search/page/components/columns.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"],

--- a/public/app/core/components/FolderFilter/FolderFilter.tsx
+++ b/public/app/core/components/FolderFilter/FolderFilter.tsx
@@ -5,7 +5,7 @@ import React, { useCallback, useMemo, useState } from 'react';
 import { GrafanaTheme2, SelectableValue } from '@grafana/data';
 import { AsyncMultiSelect, Icon, Button, useStyles2 } from '@grafana/ui';
 import { getBackendSrv } from 'app/core/services/backend_srv';
-import { DashboardSearchHit, DashboardSearchItemType } from 'app/features/search/types';
+import { DashboardSearchItemType } from 'app/features/search/types';
 import { FolderInfo, PermissionLevelString } from 'app/types';
 
 export interface FolderFilterProps {
@@ -71,8 +71,7 @@ async function getFoldersAsOptions(
     permission: PermissionLevelString.View,
   };
 
-  // FIXME: stop using id from search and use UID instead
-  const searchHits: DashboardSearchHit[] = await getBackendSrv().search(params);
+  const searchHits = await getBackendSrv().search(params);
   const options = searchHits.map((d) => ({ label: d.title, value: { uid: d.uid, title: d.title } }));
   if (!searchString || 'general'.includes(searchString.toLowerCase())) {
     options.unshift({ label: 'General', value: { uid: 'general', title: 'General' } });

--- a/public/app/core/components/Select/ReadonlyFolderPicker/api.test.ts
+++ b/public/app/core/components/Select/ReadonlyFolderPicker/api.test.ts
@@ -1,13 +1,13 @@
 import { silenceConsoleOutput } from '../../../../../test/core/utils/silenceConsoleOutput';
 import * as api from '../../../../features/manage-dashboards/state/actions';
-import { DashboardSearchItem } from '../../../../features/search/types';
+import { DashboardSearchHit } from '../../../../features/search/types';
 import { PermissionLevelString } from '../../../../types';
 
 import { ALL_FOLDER, GENERAL_FOLDER } from './ReadonlyFolderPicker';
 import { getFolderAsOption, getFoldersAsOptions } from './api';
 
 function getTestContext(
-  searchHits: DashboardSearchItem[] = [],
+  searchHits: DashboardSearchHit[] = [],
   folderById: { id: number; title: string } = { id: 1, title: 'Folder 1' }
 ) {
   jest.clearAllMocks();

--- a/public/app/features/alerting/unified/components/rule-editor/AnnotationsField.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AnnotationsField.test.tsx
@@ -255,6 +255,7 @@ function mockDashboardSearchItem(searchItem: Partial<DashboardSearchItem>) {
     uri: '',
     items: [],
     tags: [],
+    slug: '',
     isStarred: false,
     ...searchItem,
   };

--- a/public/app/features/dashboard/components/DashNav/DashNav.tsx
+++ b/public/app/features/dashboard/components/DashNav/DashNav.tsx
@@ -130,7 +130,7 @@ export const DashNav = React.memo<Props>((props) => {
     const dashboardSrv = getDashboardSrv();
     const { dashboard, setStarred } = props;
 
-    dashboardSrv.starDashboard(dashboard.id, Boolean(dashboard.meta.isStarred)).then((newState) => {
+    dashboardSrv.starDashboard(dashboard.uid, Boolean(dashboard.meta.isStarred)).then((newState) => {
       setStarred({ id: dashboard.uid, title: dashboard.title, url: dashboard.meta.url ?? '', isStarred: newState });
       dashboard.meta.isStarred = newState;
       forceUpdate();

--- a/public/app/features/dashboard/components/SubMenu/DashboardLinksDashboard.test.tsx
+++ b/public/app/features/dashboard/components/SubMenu/DashboardLinksDashboard.test.tsx
@@ -58,7 +58,6 @@ describe('resolveLinks', () => {
         title: 'DashLinks',
         url: '/d/6ieouugGk/DashLinks',
         isStarred: false,
-        items: [],
         tags: [],
         uri: 'db/DashLinks',
         type: DashboardSearchItemType.DashDB,

--- a/public/app/features/dashboard/services/DashboardSrv.ts
+++ b/public/app/features/dashboard/services/DashboardSrv.ts
@@ -92,19 +92,19 @@ export class DashboardSrv {
     );
   }
 
-  starDashboard(dashboardId: string, isStarred: boolean) {
+  starDashboard(dashboardUid: string, isStarred: boolean) {
     const backendSrv = getBackendSrv();
 
     const request = {
       showSuccessAlert: false,
-      url: '/api/user/stars/dashboard/' + dashboardId,
+      url: '/api/user/stars/dashboard/uid/' + dashboardUid,
       method: isStarred ? 'DELETE' : 'POST',
     };
 
     return backendSrv.request(request).then(() => {
       const newIsStarred = !isStarred;
 
-      if (this.dashboard?.id === dashboardId) {
+      if (this.dashboard?.uid === dashboardUid) {
         this.dashboard.meta.isStarred = newIsStarred;
       }
 

--- a/public/app/features/explore/AddToDashboard/index.test.tsx
+++ b/public/app/features/explore/AddToDashboard/index.test.tsx
@@ -201,7 +201,6 @@ describe('AddToDashboardButton', () => {
             {
               uid: 'someUid',
               isStarred: false,
-              items: [],
               title: 'Dashboard Title',
               tags: [],
               type: DashboardSearchItemType.DashDB,
@@ -243,7 +242,6 @@ describe('AddToDashboardButton', () => {
             {
               uid: 'someUid',
               isStarred: false,
-              items: [],
               title: 'Dashboard Title',
               tags: [],
               type: DashboardSearchItemType.DashDB,
@@ -359,7 +357,6 @@ describe('AddToDashboardButton', () => {
         {
           uid: 'someUid',
           isStarred: false,
-          items: [],
           title: 'Dashboard Title',
           tags: [],
           type: DashboardSearchItemType.DashDB,

--- a/public/app/features/search/components/SearchCard.tsx
+++ b/public/app/features/search/components/SearchCard.tsx
@@ -9,7 +9,8 @@ import { selectors } from '@grafana/e2e-selectors';
 import { Icon, Portal, TagList, useTheme2 } from '@grafana/ui';
 import { backendSrv } from 'app/core/services/backend_srv';
 
-import { DashboardSectionItem, OnToggleChecked } from '../types';
+import { NestedFolderItem } from '../service';
+import { OnToggleChecked } from '../types';
 
 import { SearchCardExpanded } from './SearchCardExpanded';
 import { SearchCheckbox } from './SearchCheckbox';
@@ -18,7 +19,8 @@ const DELAY_BEFORE_EXPANDING = 500;
 
 export interface Props {
   editable?: boolean;
-  item: DashboardSectionItem;
+  item: NestedFolderItem;
+  isSelected?: boolean;
   onTagSelected?: (name: string) => any;
   onToggleChecked?: OnToggleChecked;
   onClick?: (event: React.MouseEvent<HTMLAnchorElement>) => void;
@@ -28,7 +30,7 @@ export function getThumbnailURL(uid: string, isLight?: boolean) {
   return `/api/dashboards/uid/${uid}/img/thumb/${isLight ? 'light' : 'dark'}`;
 }
 
-export function SearchCard({ editable, item, onTagSelected, onToggleChecked, onClick }: Props) {
+export function SearchCard({ editable, item, isSelected, onTagSelected, onToggleChecked, onClick }: Props) {
   const [hasImage, setHasImage] = useState(true);
   const [lastUpdated, setLastUpdated] = useState<string | null>(null);
   const [showExpandedView, setShowExpandedView] = useState(false);
@@ -130,7 +132,7 @@ export function SearchCard({ editable, item, onTagSelected, onToggleChecked, onC
           className={styles.checkbox}
           aria-label={`Select dashboard ${item.title}`}
           editable={editable}
-          checked={item.checked}
+          checked={isSelected}
           onClick={onCheckboxClick}
         />
         {hasImage ? (
@@ -153,7 +155,7 @@ export function SearchCard({ editable, item, onTagSelected, onToggleChecked, onC
       </div>
       <div className={styles.info}>
         <div className={styles.title}>{item.title}</div>
-        <TagList displayMax={1} tags={item.tags} onClick={onTagClick} />
+        <TagList displayMax={1} tags={item.tags ?? []} onClick={onTagClick} />
       </div>
       {showExpandedView && (
         <Portal className={styles.portal}>

--- a/public/app/features/search/components/SearchCard.tsx
+++ b/public/app/features/search/components/SearchCard.tsx
@@ -9,8 +9,7 @@ import { selectors } from '@grafana/e2e-selectors';
 import { Icon, Portal, TagList, useTheme2 } from '@grafana/ui';
 import { backendSrv } from 'app/core/services/backend_srv';
 
-import { NestedFolderItem } from '../service';
-import { OnToggleChecked } from '../types';
+import { DashboardViewItem, OnToggleChecked } from '../types';
 
 import { SearchCardExpanded } from './SearchCardExpanded';
 import { SearchCheckbox } from './SearchCheckbox';
@@ -19,7 +18,7 @@ const DELAY_BEFORE_EXPANDING = 500;
 
 export interface Props {
   editable?: boolean;
-  item: NestedFolderItem;
+  item: DashboardViewItem;
   isSelected?: boolean;
   onTagSelected?: (name: string) => any;
   onToggleChecked?: OnToggleChecked;

--- a/public/app/features/search/components/SearchCardExpanded.tsx
+++ b/public/app/features/search/components/SearchCardExpanded.tsx
@@ -6,7 +6,7 @@ import SVG from 'react-inlinesvg';
 import { GrafanaTheme2 } from '@grafana/data';
 import { Icon, Spinner, TagList, useTheme2 } from '@grafana/ui';
 
-import { DashboardSectionItem } from '../types';
+import { NestedFolderItem } from '../service';
 
 import { getThumbnailURL } from './SearchCard';
 
@@ -14,7 +14,7 @@ export interface Props {
   className?: string;
   imageHeight: number;
   imageWidth: number;
-  item: DashboardSectionItem;
+  item: NestedFolderItem;
   lastUpdated?: string | null;
   onClick?: (event: React.MouseEvent<HTMLAnchorElement>) => void;
 }
@@ -66,7 +66,7 @@ export function SearchCardExpanded({ className, imageHeight, imageWidth, item, l
           )}
         </div>
         <div>
-          <TagList className={styles.tagList} tags={item.tags} />
+          <TagList className={styles.tagList} tags={item.tags ?? []} />
         </div>
       </div>
     </a>

--- a/public/app/features/search/components/SearchCardExpanded.tsx
+++ b/public/app/features/search/components/SearchCardExpanded.tsx
@@ -6,7 +6,7 @@ import SVG from 'react-inlinesvg';
 import { GrafanaTheme2 } from '@grafana/data';
 import { Icon, Spinner, TagList, useTheme2 } from '@grafana/ui';
 
-import { NestedFolderItem } from '../service';
+import { DashboardViewItem } from '../types';
 
 import { getThumbnailURL } from './SearchCard';
 
@@ -14,7 +14,7 @@ export interface Props {
   className?: string;
   imageHeight: number;
   imageWidth: number;
-  item: NestedFolderItem;
+  item: DashboardViewItem;
   lastUpdated?: string | null;
   onClick?: (event: React.MouseEvent<HTMLAnchorElement>) => void;
 }

--- a/public/app/features/search/components/SearchItem.test.tsx
+++ b/public/app/features/search/components/SearchItem.test.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import { selectors } from '@grafana/e2e-selectors';
 
-import { NestedFolderItem } from '../service';
+import { DashboardViewItem } from '../types';
 
 import { Props, SearchItem } from './SearchItem';
 
@@ -11,7 +11,7 @@ beforeEach(() => {
   jest.clearAllMocks();
 });
 
-const dashboardResult: NestedFolderItem = {
+const dashboardResult: DashboardViewItem = {
   uid: 'lBdLINUWk',
   title: 'Test 1',
   url: '/d/lBdLINUWk/test1',

--- a/public/app/features/search/components/SearchItem.test.tsx
+++ b/public/app/features/search/components/SearchItem.test.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import { selectors } from '@grafana/e2e-selectors';
 
-import { DashboardSearchItemType } from '../types';
+import { NestedFolderItem } from '../service';
 
 import { Props, SearchItem } from './SearchItem';
 
@@ -11,22 +11,17 @@ beforeEach(() => {
   jest.clearAllMocks();
 });
 
-const data = {
-  id: 1,
+const dashboardResult: NestedFolderItem = {
   uid: 'lBdLINUWk',
   title: 'Test 1',
-  uri: 'db/test1',
   url: '/d/lBdLINUWk/test1',
-  slug: '',
-  type: DashboardSearchItemType.DashDB,
+  kind: 'dashboard',
   tags: ['Tag1', 'Tag2'],
-  isStarred: false,
-  checked: false,
 };
 
 const setup = (propOverrides?: Partial<Props>) => {
   const props: Props = {
-    item: data,
+    item: dashboardResult,
     onTagSelected: jest.fn(),
     editable: false,
   };
@@ -50,11 +45,11 @@ describe('SearchItem', () => {
     expect(checkbox).not.toBeChecked();
     fireEvent.click(checkbox);
     expect(mockedOnToggleChecked).toHaveBeenCalledTimes(1);
-    expect(mockedOnToggleChecked).toHaveBeenCalledWith(data);
+    expect(mockedOnToggleChecked).toHaveBeenCalledWith(dashboardResult);
   });
 
   it('should mark items as checked', () => {
-    setup({ editable: true, item: { ...data, checked: true } });
+    setup({ editable: true, item: { ...dashboardResult }, isSelected: true });
     expect(screen.getByRole('checkbox')).toBeChecked();
   });
 

--- a/public/app/features/search/components/SearchItem.tsx
+++ b/public/app/features/search/components/SearchItem.tsx
@@ -6,12 +6,14 @@ import { selectors as e2eSelectors } from '@grafana/e2e-selectors';
 import { Card, Icon, IconName, TagList, useStyles2 } from '@grafana/ui';
 
 import { SEARCH_ITEM_HEIGHT } from '../constants';
-import { DashboardSearchItemType, DashboardSectionItem, OnToggleChecked } from '../types';
+import { NestedFolderItem } from '../service';
+import { OnToggleChecked } from '../types';
 
 import { SearchCheckbox } from './SearchCheckbox';
 
 export interface Props {
-  item: DashboardSectionItem;
+  item: NestedFolderItem;
+  isSelected?: boolean;
   editable?: boolean;
   onTagSelected: (name: string) => any;
   onToggleChecked?: OnToggleChecked;
@@ -30,7 +32,7 @@ const getIconFromMeta = (meta = ''): IconName => {
 };
 
 /** @deprecated */
-export const SearchItem: FC<Props> = ({ item, editable, onToggleChecked, onTagSelected, onClickItem }) => {
+export const SearchItem: FC<Props> = ({ item, isSelected, editable, onToggleChecked, onTagSelected, onClickItem }) => {
   const styles = useStyles2(getStyles);
   const tagSelected = useCallback(
     (tag: string, event: React.MouseEvent<HTMLElement>) => {
@@ -53,7 +55,6 @@ export const SearchItem: FC<Props> = ({ item, editable, onToggleChecked, onTagSe
     [item, onToggleChecked]
   );
 
-  const folderTitle = item.folderTitle || 'General';
   return (
     <Card
       data-testid={selectors.dashboardItem(item.title)}
@@ -63,21 +64,26 @@ export const SearchItem: FC<Props> = ({ item, editable, onToggleChecked, onTagSe
       onClick={onClickItem}
     >
       <Card.Heading>
-        <KindIcon kind={item.type} /> {item.title}
+        <KindIcon kind={item.kind} /> {item.title}
       </Card.Heading>
+
       <Card.Figure align={'center'} className={styles.checkbox}>
         <SearchCheckbox
           aria-label="Select dashboard"
           editable={editable}
-          checked={item.checked}
+          checked={isSelected}
           onClick={handleCheckboxClick}
         />
       </Card.Figure>
+
       <Card.Meta separator={''}>
-        <span className={styles.metaContainer}>
-          <Icon name={'folder'} aria-hidden />
-          {folderTitle}
-        </span>
+        {item.folderTitle && (
+          <span className={styles.metaContainer}>
+            <Icon name={'folder'} aria-hidden />
+            {item.folderTitle}
+          </span>
+        )}
+
         {item.sortMetaName && (
           <span className={styles.metaContainer}>
             <Icon name={getIconFromMeta(item.sortMetaName)} />
@@ -86,14 +92,14 @@ export const SearchItem: FC<Props> = ({ item, editable, onToggleChecked, onTagSe
         )}
       </Card.Meta>
       <Card.Tags>
-        <TagList tags={item.tags} onClick={tagSelected} getAriaLabel={(tag) => `Filter by tag "${tag}"`} />
+        <TagList tags={item.tags ?? []} onClick={tagSelected} getAriaLabel={(tag) => `Filter by tag "${tag}"`} />
       </Card.Tags>
     </Card>
   );
 };
 
-function KindIcon({ kind }: { kind: DashboardSearchItemType }) {
-  if (kind === DashboardSearchItemType.DashFolder) {
+function KindIcon({ kind }: { kind: NestedFolderItem['kind'] }) {
+  if (kind === 'folder') {
     return <Icon name="folder" />;
   }
 

--- a/public/app/features/search/components/SearchItem.tsx
+++ b/public/app/features/search/components/SearchItem.tsx
@@ -6,13 +6,12 @@ import { selectors as e2eSelectors } from '@grafana/e2e-selectors';
 import { Card, Icon, IconName, TagList, useStyles2 } from '@grafana/ui';
 
 import { SEARCH_ITEM_HEIGHT } from '../constants';
-import { NestedFolderItem } from '../service';
-import { OnToggleChecked } from '../types';
+import { DashboardViewItem, OnToggleChecked } from '../types';
 
 import { SearchCheckbox } from './SearchCheckbox';
 
 export interface Props {
-  item: NestedFolderItem;
+  item: DashboardViewItem;
   isSelected?: boolean;
   editable?: boolean;
   onTagSelected: (name: string) => any;
@@ -98,7 +97,7 @@ export const SearchItem: FC<Props> = ({ item, isSelected, editable, onToggleChec
   );
 };
 
-function KindIcon({ kind }: { kind: NestedFolderItem['kind'] }) {
+function KindIcon({ kind }: { kind: DashboardViewItem['kind'] }) {
   if (kind === 'folder') {
     return <Icon name="folder" />;
   }

--- a/public/app/features/search/components/SearchItem.tsx
+++ b/public/app/features/search/components/SearchItem.tsx
@@ -6,7 +6,7 @@ import { selectors as e2eSelectors } from '@grafana/e2e-selectors';
 import { Card, Icon, IconName, TagList, useStyles2 } from '@grafana/ui';
 
 import { SEARCH_ITEM_HEIGHT } from '../constants';
-import { DashboardSectionItem, OnToggleChecked } from '../types';
+import { DashboardSearchItemType, DashboardSectionItem, OnToggleChecked } from '../types';
 
 import { SearchCheckbox } from './SearchCheckbox';
 
@@ -62,7 +62,9 @@ export const SearchItem: FC<Props> = ({ item, editable, onToggleChecked, onTagSe
       className={styles.container}
       onClick={onClickItem}
     >
-      <Card.Heading>{item.title}</Card.Heading>
+      <Card.Heading>
+        <KindIcon kind={item.type} /> {item.title}
+      </Card.Heading>
       <Card.Figure align={'center'} className={styles.checkbox}>
         <SearchCheckbox
           aria-label="Select dashboard"
@@ -89,6 +91,14 @@ export const SearchItem: FC<Props> = ({ item, editable, onToggleChecked, onTagSe
     </Card>
   );
 };
+
+function KindIcon({ kind }: { kind: DashboardSearchItemType }) {
+  if (kind === DashboardSearchItemType.DashFolder) {
+    return <Icon name="folder" />;
+  }
+
+  return null;
+}
 
 const getStyles = (theme: GrafanaTheme2) => {
   return {

--- a/public/app/features/search/page/components/FolderSection.test.tsx
+++ b/public/app/features/search/page/components/FolderSection.test.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 
 import { ArrayVector, DataFrame, DataFrameView, FieldType } from '@grafana/data';
 
-import { DashboardQueryResult, getGrafanaSearcher, QueryResponse } from '../../service';
+import { DashboardQueryResult, getGrafanaSearcher, NestedFolderItem, QueryResponse } from '../../service';
 import { DashboardSearchItemType } from '../../types';
 
 import { FolderSection } from './FolderSection';
@@ -14,7 +14,7 @@ describe('FolderSection', () => {
   const mockOnTagSelected = jest.fn();
   const mockSelectionToggle = jest.fn();
   const mockSelection = jest.fn();
-  const mockSection = {
+  const mockSection: NestedFolderItem = {
     kind: 'folder',
     uid: 'my-folder',
     title: 'My folder',
@@ -218,7 +218,7 @@ describe('FolderSection', () => {
     });
 
     describe('when in a pseudo-folder (i.e. Starred/Recent)', () => {
-      const mockRecentSection = {
+      const mockRecentSection: NestedFolderItem = {
         kind: 'folder',
         uid: '__recent',
         title: 'Recent',

--- a/public/app/features/search/page/components/FolderSection.test.tsx
+++ b/public/app/features/search/page/components/FolderSection.test.tsx
@@ -4,8 +4,8 @@ import React from 'react';
 
 import { ArrayVector, DataFrame, DataFrameView, FieldType } from '@grafana/data';
 
-import { DashboardQueryResult, getGrafanaSearcher, NestedFolderItem, QueryResponse } from '../../service';
-import { DashboardSearchItemType } from '../../types';
+import { DashboardQueryResult, getGrafanaSearcher, QueryResponse } from '../../service';
+import { DashboardViewItem, DashboardSearchItemType } from '../../types';
 
 import { FolderSection } from './FolderSection';
 
@@ -14,7 +14,7 @@ describe('FolderSection', () => {
   const mockOnTagSelected = jest.fn();
   const mockSelectionToggle = jest.fn();
   const mockSelection = jest.fn();
-  const mockSection: NestedFolderItem = {
+  const mockSection: DashboardViewItem = {
     kind: 'folder',
     uid: 'my-folder',
     title: 'My folder',
@@ -218,7 +218,7 @@ describe('FolderSection', () => {
     });
 
     describe('when in a pseudo-folder (i.e. Starred/Recent)', () => {
-      const mockRecentSection: NestedFolderItem = {
+      const mockRecentSection: DashboardViewItem = {
         kind: 'folder',
         uid: '__recent',
         title: 'Recent',

--- a/public/app/features/search/page/components/FolderSection.tsx
+++ b/public/app/features/search/page/components/FolderSection.tsx
@@ -10,7 +10,8 @@ import { useUniqueId } from 'app/plugins/datasource/influxdb/components/useUniqu
 
 import { SearchItem } from '../..';
 import { GENERAL_FOLDER_UID } from '../../constants';
-import { getGrafanaSearcher, NestedFolderItem } from '../../service';
+import { getGrafanaSearcher } from '../../service';
+import { DashboardViewItem } from '../../types';
 import { SelectionChecker, SelectionToggle } from '../selection';
 
 interface SectionHeaderProps {
@@ -18,7 +19,7 @@ interface SectionHeaderProps {
   selectionToggle?: SelectionToggle;
   onClickItem?: (e: React.MouseEvent<HTMLElement>) => void;
   onTagSelected: (tag: string) => void;
-  section: NestedFolderItem;
+  section: DashboardViewItem;
   renderStandaloneBody?: boolean; // render the body on its own
   tags?: string[];
 }

--- a/public/app/features/search/page/components/FolderSection.tsx
+++ b/public/app/features/search/page/components/FolderSection.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from '@emotion/css';
+import { css } from '@emotion/css';
 import React, { useCallback } from 'react';
 import { useAsync, useLocalStorage } from 'react-use';
 

--- a/public/app/features/search/page/components/FolderView.test.tsx
+++ b/public/app/features/search/page/components/FolderView.test.tsx
@@ -9,7 +9,7 @@ import impressionSrv from '../../../../core/services/impression_srv';
 import { DashboardQueryResult, getGrafanaSearcher, QueryResponse } from '../../service';
 import { DashboardSearchItemType } from '../../types';
 
-import { FolderView } from './FolderView';
+import { RootFolderView } from './RootFolderView';
 
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
@@ -69,7 +69,11 @@ describe('FolderView', () => {
     grafanaSearcherSpy.mockImplementationOnce(() => promise);
 
     render(
-      <FolderView onTagSelected={mockOnTagSelected} selection={mockSelection} selectionToggle={mockSelectionToggle} />
+      <RootFolderView
+        onTagSelected={mockOnTagSelected}
+        selection={mockSelection}
+        selectionToggle={mockSelectionToggle}
+      />
     );
     expect(await screen.findByTestId('Spinner')).toBeInTheDocument();
 
@@ -84,7 +88,11 @@ describe('FolderView', () => {
   it('does not show the starred items if not signed in', async () => {
     contextSrv.isSignedIn = false;
     render(
-      <FolderView onTagSelected={mockOnTagSelected} selection={mockSelection} selectionToggle={mockSelectionToggle} />
+      <RootFolderView
+        onTagSelected={mockOnTagSelected}
+        selection={mockSelection}
+        selectionToggle={mockSelectionToggle}
+      />
     );
     expect((await screen.findAllByTestId(selectors.components.Search.sectionV2))[0]).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Starred' })).not.toBeInTheDocument();
@@ -93,7 +101,11 @@ describe('FolderView', () => {
   it('shows the starred items if signed in', async () => {
     contextSrv.isSignedIn = true;
     render(
-      <FolderView onTagSelected={mockOnTagSelected} selection={mockSelection} selectionToggle={mockSelectionToggle} />
+      <RootFolderView
+        onTagSelected={mockOnTagSelected}
+        selection={mockSelection}
+        selectionToggle={mockSelectionToggle}
+      />
     );
     expect(await screen.findByRole('button', { name: 'Starred' })).toBeInTheDocument();
   });
@@ -101,7 +113,11 @@ describe('FolderView', () => {
   it('does not show the recent items if no dashboards have been opened recently', async () => {
     jest.spyOn(impressionSrv, 'getDashboardOpened').mockResolvedValue([]);
     render(
-      <FolderView onTagSelected={mockOnTagSelected} selection={mockSelection} selectionToggle={mockSelectionToggle} />
+      <RootFolderView
+        onTagSelected={mockOnTagSelected}
+        selection={mockSelection}
+        selectionToggle={mockSelectionToggle}
+      />
     );
     expect((await screen.findAllByTestId(selectors.components.Search.sectionV2))[0]).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Recent' })).not.toBeInTheDocument();
@@ -110,14 +126,22 @@ describe('FolderView', () => {
   it('shows the recent items if any dashboards have recently been opened', async () => {
     jest.spyOn(impressionSrv, 'getDashboardOpened').mockResolvedValue(['7MeksYbmk']);
     render(
-      <FolderView onTagSelected={mockOnTagSelected} selection={mockSelection} selectionToggle={mockSelectionToggle} />
+      <RootFolderView
+        onTagSelected={mockOnTagSelected}
+        selection={mockSelection}
+        selectionToggle={mockSelectionToggle}
+      />
     );
     expect(await screen.findByRole('button', { name: 'Recent' })).toBeInTheDocument();
   });
 
   it('shows the general folder by default', async () => {
     render(
-      <FolderView onTagSelected={mockOnTagSelected} selection={mockSelection} selectionToggle={mockSelectionToggle} />
+      <RootFolderView
+        onTagSelected={mockOnTagSelected}
+        selection={mockSelection}
+        selectionToggle={mockSelectionToggle}
+      />
     );
     expect(await screen.findByRole('button', { name: 'General' })).toBeInTheDocument();
   });
@@ -126,7 +150,7 @@ describe('FolderView', () => {
     it('does not show the starred items even if signed in', async () => {
       contextSrv.isSignedIn = true;
       render(
-        <FolderView
+        <RootFolderView
           hidePseudoFolders
           onTagSelected={mockOnTagSelected}
           selection={mockSelection}
@@ -140,7 +164,7 @@ describe('FolderView', () => {
     it('does not show the recent items even if recent dashboards have been opened', async () => {
       jest.spyOn(impressionSrv, 'getDashboardOpened').mockResolvedValue(['7MeksYbmk']);
       render(
-        <FolderView
+        <RootFolderView
           hidePseudoFolders
           onTagSelected={mockOnTagSelected}
           selection={mockSelection}
@@ -156,7 +180,11 @@ describe('FolderView', () => {
     // reject with a specific Error object
     grafanaSearcherSpy.mockRejectedValueOnce(new Error('Uh oh spagghettios!'));
     render(
-      <FolderView onTagSelected={mockOnTagSelected} selection={mockSelection} selectionToggle={mockSelectionToggle} />
+      <RootFolderView
+        onTagSelected={mockOnTagSelected}
+        selection={mockSelection}
+        selectionToggle={mockSelectionToggle}
+      />
     );
     expect(await screen.findByRole('alert', { name: 'Uh oh spagghettios!' })).toBeInTheDocument();
   });
@@ -165,7 +193,11 @@ describe('FolderView', () => {
     // reject with nothing
     grafanaSearcherSpy.mockRejectedValueOnce(null);
     render(
-      <FolderView onTagSelected={mockOnTagSelected} selection={mockSelection} selectionToggle={mockSelectionToggle} />
+      <RootFolderView
+        onTagSelected={mockOnTagSelected}
+        selection={mockSelection}
+        selectionToggle={mockSelectionToggle}
+      />
     );
     expect(await screen.findByRole('alert', { name: 'Something went wrong' })).toBeInTheDocument();
   });

--- a/public/app/features/search/page/components/FolderView.tsx
+++ b/public/app/features/search/page/components/FolderView.tsx
@@ -31,41 +31,44 @@ export const FolderView = ({
   const styles = useStyles2(getStyles);
 
   const results = useAsync(async () => {
-    const folders: DashboardSection[] = [];
+    // const folders: DashboardSection[] = [];
 
-    if (!hidePseudoFolders) {
-      if (contextSrv.isSignedIn) {
-        const stars = await getBackendSrv().get('api/user/stars');
-        if (stars.length > 0) {
-          folders.push({ title: 'Starred', icon: 'star', kind: 'query-star', uid: '__starred', itemsUIDs: stars });
-        }
-      }
+    // // if (!hidePseudoFolders) {
+    // //   if (contextSrv.isSignedIn) {
+    // //     const stars = await getBackendSrv().get('api/user/stars');
+    // //     if (stars.length > 0) {
+    // //       folders.push({ title: 'Starred', icon: 'star', kind: 'query-star', uid: '__starred', itemsUIDs: stars });
+    // //     }
+    // //   }
 
-      const itemsUIDs = await impressionSrv.getDashboardOpened();
-      if (itemsUIDs.length) {
-        folders.push({ title: 'Recent', icon: 'clock-nine', kind: 'query-recent', uid: '__recent', itemsUIDs });
-      }
-    }
+    // //   const itemsUIDs = await impressionSrv.getDashboardOpened();
+    // //   if (itemsUIDs.length) {
+    // //     folders.push({ title: 'Recent', icon: 'clock-nine', kind: 'query-recent', uid: '__recent', itemsUIDs });
+    // //   }
+    // // }
 
-    folders.push({ title: 'General', url: '/dashboards', kind: 'folder', uid: GENERAL_FOLDER_UID });
+    // folders.push({ title: 'General', url: '/dashboards', kind: 'folder', uid: GENERAL_FOLDER_UID });
+
+    // const searcher = getGrafanaSearcher();
+    // const rsp = await searcher.search({
+    //   query: '*',
+    //   kind: ['folder'],
+    //   sort: searcher.getFolderViewSort(),
+    //   limit: 1000,
+    // });
+    // for (const row of rsp.view) {
+    //   folders.push({
+    //     title: row.name,
+    //     url: row.url,
+    //     uid: row.uid,
+    //     kind: row.kind,
+    //   });
+    // }
+
+    // return folders;
 
     const searcher = getGrafanaSearcher();
-    const rsp = await searcher.search({
-      query: '*',
-      kind: ['folder'],
-      sort: searcher.getFolderViewSort(),
-      limit: 1000,
-    });
-    for (const row of rsp.view) {
-      folders.push({
-        title: row.name,
-        url: row.url,
-        uid: row.uid,
-        kind: row.kind,
-      });
-    }
-
-    return folders;
+    return searcher.getFolderChildren();
   }, []);
 
   const renderResults = () => {

--- a/public/app/features/search/page/components/RootFolderView.tsx
+++ b/public/app/features/search/page/components/RootFolderView.tsx
@@ -11,16 +11,15 @@ import { contextSrv } from '../../../../core/services/context_srv';
 import impressionSrv from '../../../../core/services/impression_srv';
 import { GENERAL_FOLDER_UID } from '../../constants';
 import { getGrafanaSearcher } from '../../service';
-import { SearchResultsProps } from '../components/SearchResultsTable';
 
-import { DashboardSection, FolderSection } from './FolderSection';
+import { FolderSection } from './FolderSection';
+import { SearchResultsProps } from './SearchResultsTable';
 
 type Props = Pick<SearchResultsProps, 'selection' | 'selectionToggle' | 'onTagSelected' | 'onClickItem'> & {
   tags?: string[];
   hidePseudoFolders?: boolean;
 };
-
-export const FolderView = ({
+export const RootFolderView = ({
   selection,
   selectionToggle,
   onTagSelected,
@@ -31,44 +30,26 @@ export const FolderView = ({
   const styles = useStyles2(getStyles);
 
   const results = useAsync(async () => {
-    // const folders: DashboardSection[] = [];
-
-    // // if (!hidePseudoFolders) {
-    // //   if (contextSrv.isSignedIn) {
-    // //     const stars = await getBackendSrv().get('api/user/stars');
-    // //     if (stars.length > 0) {
-    // //       folders.push({ title: 'Starred', icon: 'star', kind: 'query-star', uid: '__starred', itemsUIDs: stars });
-    // //     }
-    // //   }
-
-    // //   const itemsUIDs = await impressionSrv.getDashboardOpened();
-    // //   if (itemsUIDs.length) {
-    // //     folders.push({ title: 'Recent', icon: 'clock-nine', kind: 'query-recent', uid: '__recent', itemsUIDs });
-    // //   }
-    // // }
-
-    // folders.push({ title: 'General', url: '/dashboards', kind: 'folder', uid: GENERAL_FOLDER_UID });
-
-    // const searcher = getGrafanaSearcher();
-    // const rsp = await searcher.search({
-    //   query: '*',
-    //   kind: ['folder'],
-    //   sort: searcher.getFolderViewSort(),
-    //   limit: 1000,
-    // });
-    // for (const row of rsp.view) {
-    //   folders.push({
-    //     title: row.name,
-    //     url: row.url,
-    //     uid: row.uid,
-    //     kind: row.kind,
-    //   });
-    // }
-
-    // return folders;
-
     const searcher = getGrafanaSearcher();
-    return searcher.getFolderChildren();
+    const folders = await searcher.getFolderChildren();
+
+    if (!hidePseudoFolders) {
+      if (contextSrv.isSignedIn) {
+        const stars = await getBackendSrv().get('api/user/stars');
+        if (stars.length > 0) {
+          folders.unshift({ title: 'Starred', icon: 'star', kind: 'folder', uid: '__starred', itemsUIDs: stars });
+        }
+      }
+
+      const itemsUIDs = await impressionSrv.getDashboardOpened();
+      if (itemsUIDs.length) {
+        folders.unshift({ title: 'Recent', icon: 'clock-nine', kind: 'folder', uid: '__recent', itemsUIDs });
+      }
+    }
+
+    folders.unshift({ title: 'General', url: '/dashboards', kind: 'folder', uid: GENERAL_FOLDER_UID });
+
+    return folders;
   }, []);
 
   const renderResults = () => {

--- a/public/app/features/search/page/components/SearchResultsCards.tsx
+++ b/public/app/features/search/page/components/SearchResultsCards.tsx
@@ -9,8 +9,7 @@ import { useStyles2 } from '@grafana/ui';
 
 import { SearchItem } from '../../components/SearchItem';
 import { useSearchKeyboardNavigation } from '../../hooks/useSearchKeyboardSelection';
-import { SearchResultMeta } from '../../service';
-import { DashboardSearchItemType, DashboardSectionItem } from '../../types';
+import { NestedFolderItem, SearchResultMeta } from '../../service';
 
 import { SearchResultsProps } from './SearchResultsTable';
 
@@ -50,37 +49,32 @@ export const SearchResultsCards = React.memo(
         }
 
         const item = response.view.get(rowIndex);
-        let v: DashboardSectionItem = {
+        const searchItem: NestedFolderItem = {
           uid: item.uid,
           title: item.name,
           url: item.url,
-          uri: item.url,
-          type: item.kind === 'folder' ? DashboardSearchItemType.DashFolder : DashboardSearchItemType.DashDB,
-          id: 666, // do not use me!
-          isStarred: false,
+          kind: item.kind === 'folder' ? 'folder' : 'dashboard',
+          // isStarred: false,
           tags: item.tags ?? [],
         };
 
         if (item.location) {
           const first = item.location.split('/')[0];
           const finfo = meta.locationInfo[first];
+
           if (finfo) {
-            v.folderUid = item.location;
-            v.folderTitle = finfo.name;
+            // searchItem.folderUid = item.location;
+            searchItem.folderTitle = finfo.name;
           }
         }
 
         if (selection && selectionToggle) {
-          const type = v.type === DashboardSearchItemType.DashFolder ? 'folder' : 'dashboard';
-          v = {
-            ...v,
-            checked: selection(type, v.uid!),
-          };
+          searchItem.selected = selection(searchItem.kind, searchItem.uid!);
         }
         return (
           <div style={style} key={item.uid} className={className} role="row">
             <SearchItem
-              item={v}
+              item={searchItem}
               onTagSelected={onTagSelected}
               onToggleChecked={(item) => {
                 if (selectionToggle) {

--- a/public/app/features/search/page/components/SearchResultsCards.tsx
+++ b/public/app/features/search/page/components/SearchResultsCards.tsx
@@ -9,7 +9,8 @@ import { useStyles2 } from '@grafana/ui';
 
 import { SearchItem } from '../../components/SearchItem';
 import { useSearchKeyboardNavigation } from '../../hooks/useSearchKeyboardSelection';
-import { NestedFolderItem, SearchResultMeta } from '../../service';
+import { SearchResultMeta } from '../../service';
+import { DashboardViewItem } from '../../types';
 
 import { SearchResultsProps } from './SearchResultsTable';
 
@@ -49,7 +50,7 @@ export const SearchResultsCards = React.memo(
         }
 
         const item = response.view.get(rowIndex);
-        const searchItem: NestedFolderItem = {
+        const searchItem: DashboardViewItem = {
           uid: item.uid,
           title: item.name,
           url: item.url,

--- a/public/app/features/search/page/components/SearchResultsCards.tsx
+++ b/public/app/features/search/page/components/SearchResultsCards.tsx
@@ -54,7 +54,6 @@ export const SearchResultsCards = React.memo(
           title: item.name,
           url: item.url,
           kind: item.kind === 'folder' ? 'folder' : 'dashboard',
-          // isStarred: false,
           tags: item.tags ?? [],
         };
 
@@ -63,14 +62,11 @@ export const SearchResultsCards = React.memo(
           const finfo = meta.locationInfo[first];
 
           if (finfo) {
-            // searchItem.folderUid = item.location;
             searchItem.folderTitle = finfo.name;
           }
         }
 
-        if (selection && selectionToggle) {
-          searchItem.selected = selection(searchItem.kind, searchItem.uid!);
-        }
+        const isSelected = selection && selectionToggle && selection(searchItem.kind, searchItem.uid);
         return (
           <div style={style} key={item.uid} className={className} role="row">
             <SearchItem
@@ -82,6 +78,7 @@ export const SearchResultsCards = React.memo(
                 }
               }}
               editable={Boolean(selection != null)}
+              isSelected={isSelected}
               onClickItem={onClickItem}
             />
           </div>

--- a/public/app/features/search/page/components/SearchResultsGrid.tsx
+++ b/public/app/features/search/page/components/SearchResultsGrid.tsx
@@ -9,8 +9,8 @@ import { useStyles2 } from '@grafana/ui';
 
 import { SearchCard } from '../../components/SearchCard';
 import { useSearchKeyboardNavigation } from '../../hooks/useSearchKeyboardSelection';
+import { NestedFolderItem } from '../../service';
 import { queryResultToNestedFolderItem } from '../../service/utils';
-import { DashboardSearchItemType, DashboardSectionItem } from '../../types';
 
 import { SearchResultsProps } from './SearchResultsTable';
 
@@ -29,11 +29,9 @@ export const SearchResultsGrid = ({
   // Hacked to reuse existing SearchCard (and old DashboardSectionItem)
   const itemProps = {
     editable: selection != null,
-    onToggleChecked: (item: any) => {
-      const d = item as DashboardSectionItem;
-      const t = d.type === DashboardSearchItemType.DashFolder ? 'folder' : 'dashboard';
+    onToggleChecked: (item: NestedFolderItem) => {
       if (selectionToggle) {
-        selectionToggle(t, d.uid!);
+        selectionToggle(item.kind, item.uid);
       }
     },
     onTagSelected,

--- a/public/app/features/search/page/components/SearchResultsGrid.tsx
+++ b/public/app/features/search/page/components/SearchResultsGrid.tsx
@@ -9,8 +9,8 @@ import { useStyles2 } from '@grafana/ui';
 
 import { SearchCard } from '../../components/SearchCard';
 import { useSearchKeyboardNavigation } from '../../hooks/useSearchKeyboardSelection';
-import { NestedFolderItem } from '../../service';
 import { queryResultToNestedFolderItem } from '../../service/utils';
+import { DashboardViewItem } from '../../types';
 
 import { SearchResultsProps } from './SearchResultsTable';
 
@@ -29,7 +29,7 @@ export const SearchResultsGrid = ({
   // Hacked to reuse existing SearchCard (and old DashboardSectionItem)
   const itemProps = {
     editable: selection != null,
-    onToggleChecked: (item: NestedFolderItem) => {
+    onToggleChecked: (item: DashboardViewItem) => {
       if (selectionToggle) {
         selectionToggle(item.kind, item.uid);
       }

--- a/public/app/features/search/page/components/SearchResultsGrid.tsx
+++ b/public/app/features/search/page/components/SearchResultsGrid.tsx
@@ -9,6 +9,7 @@ import { useStyles2 } from '@grafana/ui';
 
 import { SearchCard } from '../../components/SearchCard';
 import { useSearchKeyboardNavigation } from '../../hooks/useSearchKeyboardSelection';
+import { queryResultToNestedFolderItem } from '../../service/utils';
 import { DashboardSearchItemType, DashboardSectionItem } from '../../types';
 
 import { SearchResultsProps } from './SearchResultsTable';
@@ -77,17 +78,7 @@ export const SearchResultsGrid = ({
             const item = view.get(index);
             const kind = item.kind ?? 'dashboard';
 
-            const facade: DashboardSectionItem = {
-              uid: item.uid,
-              title: item.name,
-              url: item.url,
-              uri: item.url,
-              type: kind === 'folder' ? DashboardSearchItemType.DashFolder : DashboardSearchItemType.DashDB,
-              id: 666, // do not use me!
-              isStarred: false,
-              tags: item.tags ?? [],
-              checked: selection ? selection(kind, item.uid) : false,
-            };
+            const facade = queryResultToNestedFolderItem(item, view.dataFrame.meta);
 
             if (kind === 'panel') {
               const type = item.panel_type;
@@ -112,7 +103,12 @@ export const SearchResultsGrid = ({
             // And without this wrapper there is no room for that margin
             return item ? (
               <li style={style} className={className}>
-                <SearchCard key={item.uid} {...itemProps} item={facade} />
+                <SearchCard
+                  {...itemProps}
+                  key={facade.uid}
+                  item={facade}
+                  isSelected={selection ? selection(facade.kind, facade.uid) : false}
+                />
               </li>
             ) : null;
           }}

--- a/public/app/features/search/page/components/SearchView.tsx
+++ b/public/app/features/search/page/components/SearchView.tsx
@@ -10,9 +10,9 @@ import EmptyListCTA from 'app/core/components/EmptyListCTA/EmptyListCTA';
 import { FolderDTO } from 'app/types';
 
 import { PreviewsSystemRequirements } from '../../components/PreviewsSystemRequirements';
-import { getGrafanaSearcher, NestedFolderItem } from '../../service';
+import { getGrafanaSearcher } from '../../service';
 import { getSearchStateManager } from '../../state/SearchStateManager';
-import { SearchLayout } from '../../types';
+import { SearchLayout, DashboardViewItem } from '../../types';
 import { newSearchSelection, updateSearchSelection } from '../selection';
 
 import { ActionRow, getValidQueryLayout } from './ActionRow';
@@ -229,6 +229,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
   `,
 });
 
-function sectionForFolderView(folderDTO: FolderDTO): NestedFolderItem {
+function sectionForFolderView(folderDTO: FolderDTO): DashboardViewItem {
   return { uid: folderDTO.uid, kind: 'folder', title: folderDTO.title };
 }

--- a/public/app/features/search/page/components/SearchView.tsx
+++ b/public/app/features/search/page/components/SearchView.tsx
@@ -10,15 +10,15 @@ import EmptyListCTA from 'app/core/components/EmptyListCTA/EmptyListCTA';
 import { FolderDTO } from 'app/types';
 
 import { PreviewsSystemRequirements } from '../../components/PreviewsSystemRequirements';
-import { getGrafanaSearcher } from '../../service';
+import { getGrafanaSearcher, NestedFolderItem } from '../../service';
 import { getSearchStateManager } from '../../state/SearchStateManager';
 import { SearchLayout } from '../../types';
 import { newSearchSelection, updateSearchSelection } from '../selection';
 
 import { ActionRow, getValidQueryLayout } from './ActionRow';
 import { FolderSection } from './FolderSection';
-import { FolderView } from './FolderView';
 import { ManageActions } from './ManageActions';
+import { RootFolderView } from './RootFolderView';
 import { SearchResultsCards } from './SearchResultsCards';
 import { SearchResultsGrid } from './SearchResultsGrid';
 import { SearchResultsTable, SearchResultsProps } from './SearchResultsTable';
@@ -99,11 +99,12 @@ export const SearchView = ({ showManage, folderDTO, hidePseudoFolders, keyboardE
     }
 
     const selection = showManage ? searchSelection.isSelected : undefined;
+
     if (layout === SearchLayout.Folders) {
       if (folderDTO) {
         return (
           <FolderSection
-            section={{ uid: folderDTO.uid, kind: 'folder', title: folderDTO.title }}
+            section={sectionForFolderView(folderDTO)}
             selection={selection}
             selectionToggle={toggleSelection}
             onTagSelected={stateManager.onAddTag}
@@ -115,7 +116,7 @@ export const SearchView = ({ showManage, folderDTO, hidePseudoFolders, keyboardE
         );
       }
       return (
-        <FolderView
+        <RootFolderView
           key={listKey}
           selection={selection}
           selectionToggle={toggleSelection}
@@ -227,3 +228,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     margin-top: ${theme.v1.spacing.md};
   `,
 });
+
+function sectionForFolderView(folderDTO: FolderDTO): NestedFolderItem {
+  return { uid: folderDTO.uid, kind: 'folder', title: folderDTO.title };
+}

--- a/public/app/features/search/service/bluge.ts
+++ b/public/app/features/search/service/bluge.ts
@@ -10,11 +10,16 @@ import {
 import { config, getBackendSrv } from '@grafana/runtime';
 import { TermCount } from 'app/core/components/TagFilter/TagFilter';
 
-import { DashboardSectionItem } from '../types';
-
 import { replaceCurrentFolderQuery } from './utils';
 
-import { DashboardQueryResult, GrafanaSearcher, QueryResponse, SearchQuery, SearchResultMeta } from '.';
+import {
+  DashboardQueryResult,
+  GrafanaSearcher,
+  NestedFolderItem,
+  QueryResponse,
+  SearchQuery,
+  SearchResultMeta,
+} from '.';
 
 // The backend returns an empty frame with a special name to indicate that the indexing engine is being rebuilt,
 // and that it can not serve any search requests. We are temporarily using the old SQL Search API as a fallback when that happens.
@@ -216,9 +221,9 @@ export class BlugeSearcher implements GrafanaSearcher {
     };
   }
 
-  async getFolderChildren(folderUid?: string): Promise<DashboardSectionItem[]> {
+  async getFolderChildren(folderUid?: string): Promise<NestedFolderItem[]> {
     // PR TODO: fill this out
-    throw new Error('searcher not supported - use sql searcher');
+    throw new Error('PR TODO: Searcher not supported - use sql searcher');
   }
 
   getFolderViewSort(): string {

--- a/public/app/features/search/service/bluge.ts
+++ b/public/app/features/search/service/bluge.ts
@@ -10,6 +10,8 @@ import {
 import { config, getBackendSrv } from '@grafana/runtime';
 import { TermCount } from 'app/core/components/TagFilter/TagFilter';
 
+import { DashboardSectionItem } from '../types';
+
 import { replaceCurrentFolderQuery } from './utils';
 
 import { DashboardQueryResult, GrafanaSearcher, QueryResponse, SearchQuery, SearchResultMeta } from '.';
@@ -212,6 +214,11 @@ export class BlugeSearcher implements GrafanaSearcher {
         return index < view.dataFrame.length;
       },
     };
+  }
+
+  async getFolderChildren(folderUid?: string): Promise<DashboardSectionItem[]> {
+    // PR TODO: fill this out
+    throw new Error('searcher not supported - use sql searcher');
   }
 
   getFolderViewSort(): string {

--- a/public/app/features/search/service/bluge.ts
+++ b/public/app/features/search/service/bluge.ts
@@ -10,16 +10,11 @@ import {
 import { config, getBackendSrv } from '@grafana/runtime';
 import { TermCount } from 'app/core/components/TagFilter/TagFilter';
 
+import { DashboardViewItem } from '../types';
+
 import { replaceCurrentFolderQuery } from './utils';
 
-import {
-  DashboardQueryResult,
-  GrafanaSearcher,
-  NestedFolderItem,
-  QueryResponse,
-  SearchQuery,
-  SearchResultMeta,
-} from '.';
+import { DashboardQueryResult, GrafanaSearcher, QueryResponse, SearchQuery, SearchResultMeta } from '.';
 
 // The backend returns an empty frame with a special name to indicate that the indexing engine is being rebuilt,
 // and that it can not serve any search requests. We are temporarily using the old SQL Search API as a fallback when that happens.
@@ -221,8 +216,7 @@ export class BlugeSearcher implements GrafanaSearcher {
     };
   }
 
-  async getFolderChildren(folderUid?: string): Promise<NestedFolderItem[]> {
-    // PR TODO: fill this out
+  async getFolderChildren(folderUid?: string): Promise<DashboardViewItem[]> {
     throw new Error('PR TODO: Searcher not supported - use sql searcher');
   }
 

--- a/public/app/features/search/service/dummy.ts
+++ b/public/app/features/search/service/dummy.ts
@@ -1,7 +1,9 @@
 import { SelectableValue, DataFrame, DataFrameView } from '@grafana/data';
 import { TermCount } from 'app/core/components/TagFilter/TagFilter';
 
-import { GrafanaSearcher, NestedFolderItem, QueryResponse, SearchQuery } from '.';
+import { DashboardViewItem } from '../types';
+
+import { GrafanaSearcher, QueryResponse, SearchQuery } from '.';
 
 // This is a dummy search useful for tests
 export class DummySearcher implements GrafanaSearcher {
@@ -39,7 +41,7 @@ export class DummySearcher implements GrafanaSearcher {
     return '';
   }
 
-  async getFolderChildren(folderUid?: string): Promise<NestedFolderItem[]> {
+  async getFolderChildren(folderUid?: string): Promise<DashboardViewItem[]> {
     return [];
   }
 }

--- a/public/app/features/search/service/dummy.ts
+++ b/public/app/features/search/service/dummy.ts
@@ -1,7 +1,7 @@
 import { SelectableValue, DataFrame, DataFrameView } from '@grafana/data';
 import { TermCount } from 'app/core/components/TagFilter/TagFilter';
 
-import { GrafanaSearcher, QueryResponse, SearchQuery } from '.';
+import { GrafanaSearcher, NestedFolderItem, QueryResponse, SearchQuery } from '.';
 
 // This is a dummy search useful for tests
 export class DummySearcher implements GrafanaSearcher {
@@ -37,5 +37,9 @@ export class DummySearcher implements GrafanaSearcher {
 
   getFolderViewSort(): string {
     return '';
+  }
+
+  async getFolderChildren(folderUid?: string): Promise<NestedFolderItem[]> {
+    return [];
   }
 }

--- a/public/app/features/search/service/frontend.ts
+++ b/public/app/features/search/service/frontend.ts
@@ -3,9 +3,7 @@ import uFuzzy from '@leeoniya/ufuzzy';
 import { DataFrameView, SelectableValue, ArrayVector } from '@grafana/data';
 import { TermCount } from 'app/core/components/TagFilter/TagFilter';
 
-import { DashboardSectionItem } from '../types';
-
-import { DashboardQueryResult, GrafanaSearcher, QueryResponse, SearchQuery } from '.';
+import { DashboardQueryResult, GrafanaSearcher, NestedFolderItem, QueryResponse, SearchQuery } from '.';
 
 export class FrontendSearcher implements GrafanaSearcher {
   readonly cache = new Map<string, Promise<FullResultCache>>();
@@ -82,9 +80,9 @@ export class FrontendSearcher implements GrafanaSearcher {
     return this.parent.getFolderViewSort();
   }
 
-  async getFolderChildren(folderUid?: string): Promise<DashboardSectionItem[]> {
+  async getFolderChildren(folderUid?: string): Promise<NestedFolderItem[]> {
     // PR TODO: fill this out
-    throw new Error('searcher not supported - use sql searcher');
+    throw new Error('PR TODO: Searcher not supported - use sql searcher');
   }
 }
 

--- a/public/app/features/search/service/frontend.ts
+++ b/public/app/features/search/service/frontend.ts
@@ -3,7 +3,9 @@ import uFuzzy from '@leeoniya/ufuzzy';
 import { DataFrameView, SelectableValue, ArrayVector } from '@grafana/data';
 import { TermCount } from 'app/core/components/TagFilter/TagFilter';
 
-import { DashboardQueryResult, GrafanaSearcher, NestedFolderItem, QueryResponse, SearchQuery } from '.';
+import { DashboardViewItem } from '../types';
+
+import { DashboardQueryResult, GrafanaSearcher, QueryResponse, SearchQuery } from '.';
 
 export class FrontendSearcher implements GrafanaSearcher {
   readonly cache = new Map<string, Promise<FullResultCache>>();
@@ -80,7 +82,7 @@ export class FrontendSearcher implements GrafanaSearcher {
     return this.parent.getFolderViewSort();
   }
 
-  async getFolderChildren(folderUid?: string): Promise<NestedFolderItem[]> {
+  async getFolderChildren(folderUid?: string): Promise<DashboardViewItem[]> {
     // PR TODO: fill this out
     throw new Error('PR TODO: Searcher not supported - use sql searcher');
   }

--- a/public/app/features/search/service/frontend.ts
+++ b/public/app/features/search/service/frontend.ts
@@ -3,6 +3,8 @@ import uFuzzy from '@leeoniya/ufuzzy';
 import { DataFrameView, SelectableValue, ArrayVector } from '@grafana/data';
 import { TermCount } from 'app/core/components/TagFilter/TagFilter';
 
+import { DashboardSectionItem } from '../types';
+
 import { DashboardQueryResult, GrafanaSearcher, QueryResponse, SearchQuery } from '.';
 
 export class FrontendSearcher implements GrafanaSearcher {
@@ -78,6 +80,11 @@ export class FrontendSearcher implements GrafanaSearcher {
 
   getFolderViewSort(): string {
     return this.parent.getFolderViewSort();
+  }
+
+  async getFolderChildren(folderUid?: string): Promise<DashboardSectionItem[]> {
+    // PR TODO: fill this out
+    throw new Error('searcher not supported - use sql searcher');
   }
 }
 

--- a/public/app/features/search/service/sql.ts
+++ b/public/app/features/search/service/sql.ts
@@ -148,7 +148,7 @@ export class SQLSearcher implements GrafanaSearcher {
       const k = hit.type === 'dash-folder' ? 'folder' : 'dashboard';
       kind.push(k);
       name.push(hit.title);
-      uid.push(hit.uid!);
+      uid.push(hit.uid);
       url.push(hit.url);
       tags.push(hit.tags);
       sortBy.push(hit.sortMeta!);
@@ -171,7 +171,7 @@ export class SQLSearcher implements GrafanaSearcher {
           folderId: hit.folderId,
         };
       } else if (k === 'folder') {
-        this.locationInfo[hit.uid!] = {
+        this.locationInfo[hit.uid] = {
           kind: k,
           name: hit.title!,
           url: hit.url,

--- a/public/app/features/search/service/sql.ts
+++ b/public/app/features/search/service/sql.ts
@@ -7,7 +7,7 @@ import { DEFAULT_MAX_VALUES, TYPE_KIND_MAP } from '../constants';
 import { DashboardSearchHit, DashboardSearchItemType } from '../types';
 
 import { LocationInfo, NestedFolderDTO, NestedFolderItem } from './types';
-import { replaceCurrentFolderQuery } from './utils';
+import { queryResultToNestedFolderItem, replaceCurrentFolderQuery } from './utils';
 
 import { DashboardQueryResult, GrafanaSearcher, QueryResponse, SearchQuery } from '.';
 
@@ -244,15 +244,8 @@ export class SQLSearcher implements GrafanaSearcher {
       limit: 1000,
     });
 
-    const dashboardItems: NestedFolderItem[] = dashboardsResults.view.map((item) => {
-      return {
-        kind: 'dashboard',
-        uid: item.uid,
-        title: item.name,
-        url: item.url,
-        tags: item.tags ?? [],
-        folderTitle: dashboardsResults.view.dataFrame.meta?.custom?.locationInfo[item.location].name,
-      };
+    const dashboardItems = dashboardsResults.view.map((item) => {
+      return queryResultToNestedFolderItem(item, dashboardsResults.view.dataFrame.meta);
     });
 
     const folders = await getChildFolders(parentUid);

--- a/public/app/features/search/service/sql.ts
+++ b/public/app/features/search/service/sql.ts
@@ -4,9 +4,9 @@ import { TermCount } from 'app/core/components/TagFilter/TagFilter';
 import { backendSrv } from 'app/core/services/backend_srv';
 
 import { DEFAULT_MAX_VALUES, TYPE_KIND_MAP } from '../constants';
-import { DashboardSearchHit, DashboardSearchItemType } from '../types';
+import { DashboardSearchHit, DashboardSearchItemType, DashboardViewItem } from '../types';
 
-import { LocationInfo, NestedFolderDTO, NestedFolderItem } from './types';
+import { LocationInfo, NestedFolderDTO } from './types';
 import { queryResultToNestedFolderItem, replaceCurrentFolderQuery } from './utils';
 
 import { DashboardQueryResult, GrafanaSearcher, QueryResponse, SearchQuery } from '.';
@@ -225,7 +225,7 @@ export class SQLSearcher implements GrafanaSearcher {
     };
   }
 
-  async getFolderChildren(parentUid?: string): Promise<NestedFolderItem[]> {
+  async getFolderChildren(parentUid?: string): Promise<DashboardViewItem[]> {
     if (!config.featureToggles.nestedFolders) {
       throw new Error('PR TODO: Require nestedFolders enabled');
     }
@@ -259,7 +259,7 @@ export class SQLSearcher implements GrafanaSearcher {
   };
 }
 
-async function getChildFolders(parentUid?: string): Promise<NestedFolderItem[]> {
+async function getChildFolders(parentUid?: string): Promise<DashboardViewItem[]> {
   const folders = await backendSrv.get<NestedFolderDTO[]>('/api/folders', { parentUid });
 
   return folders.map((item) => ({

--- a/public/app/features/search/service/sql.ts
+++ b/public/app/features/search/service/sql.ts
@@ -263,14 +263,9 @@ async function getChildFolders(parentUid?: string): Promise<DashboardViewItem[]>
   const folders = await backendSrv.get<NestedFolderDTO[]>('/api/folders', { parentUid });
 
   return folders.map((item) => ({
-    type: DashboardSearchItemType.DashFolder,
     kind: 'folder',
-
     uid: item.uid,
     title: item.title,
-    isStarred: false,
-    tags: [],
-    uri: `/dashboards/f/${item.uid}/`, // TODO: make url here
-    url: `/dashboards/f/${item.uid}/`, // TODO: make url here
+    url: `/dashboards/f/${item.uid}/`,
   }));
 }

--- a/public/app/features/search/service/sql.ts
+++ b/public/app/features/search/service/sql.ts
@@ -3,8 +3,8 @@ import { config } from '@grafana/runtime';
 import { TermCount } from 'app/core/components/TagFilter/TagFilter';
 import { backendSrv } from 'app/core/services/backend_srv';
 
-import { DEFAULT_MAX_VALUES, GENERAL_FOLDER_UID, TYPE_KIND_MAP } from '../constants';
-import { DashboardSearchHit, DashboardSearchItemType, DashboardSectionItem } from '../types';
+import { DEFAULT_MAX_VALUES, TYPE_KIND_MAP } from '../constants';
+import { DashboardSearchHit, DashboardSearchItemType } from '../types';
 
 import { LocationInfo, NestedFolderDTO, NestedFolderItem } from './types';
 import { replaceCurrentFolderQuery } from './utils';
@@ -227,27 +227,13 @@ export class SQLSearcher implements GrafanaSearcher {
 
   async getFolderChildren(parentUid?: string): Promise<NestedFolderItem[]> {
     if (!config.featureToggles.nestedFolders) {
-      throw new Error('require nestedFolders enabled');
+      throw new Error('PR TODO: Require nestedFolders enabled');
     }
 
     if (!parentUid) {
-      // We don't show dashboards at root in folder view yet - we create a dummy 'General' folder
-      // and FolderSection for General will fetch them
-      const generalFolder: NestedFolderItem = {
-        type: DashboardSearchItemType.DashFolder,
-        kind: 'folder',
-
-        uid: GENERAL_FOLDER_UID,
-        title: 'General',
-        isStarred: false,
-        tags: [],
-        uri: '/dashboards',
-        url: '/dashboards',
-      };
-
+      // We don't show dashboards at root in folder view yet - they're shown under a dummy 'general'
+      // folder that FolderView adds in
       const folders = await getChildFolders();
-      folders.unshift(generalFolder);
-
       return folders;
     }
 
@@ -260,17 +246,11 @@ export class SQLSearcher implements GrafanaSearcher {
 
     const dashboardItems: NestedFolderItem[] = dashboardsResults.view.map((item) => {
       return {
-        type: DashboardSearchItemType.DashDB,
         kind: 'dashboard',
-
         uid: item.uid,
         title: item.name,
         url: item.url,
-        uri: item.url,
-        id: 666, // do not use me!
-        isStarred: false,
         tags: item.tags ?? [],
-        folderUid: parentUid || item.location,
         folderTitle: dashboardsResults.view.dataFrame.meta?.custom?.locationInfo[item.location].name,
       };
     });

--- a/public/app/features/search/service/types.ts
+++ b/public/app/features/search/service/types.ts
@@ -1,8 +1,6 @@
 import { DataFrameView, SelectableValue } from '@grafana/data';
 import { TermCount } from 'app/core/components/TagFilter/TagFilter';
 
-import { DashboardSectionItem } from '../types';
-
 export interface FacetField {
   field: string;
   count?: number;
@@ -88,24 +86,19 @@ export interface NestedFolderDTO {
   title: string;
 }
 
-export interface NestedFolderItem extends DashboardSectionItem {
+export interface NestedFolderItem {
   kind: 'folder' | 'dashboard';
   uid: string;
+  title: string;
+  url?: string;
+  tags?: string[];
+
+  icon?: string;
+  folderTitle?: string; // where does this come from?
+  sortMeta?: string; // PR TODO: test with enterprise
+  sortMetaName?: string; // PR TODO: test with enterprise
+
+  itemsUIDs?: string[];
+
+  // selected?: boolean; // PR TODO: is this the right place for it? I don't think this shape should contain state
 }
-
-// export interface NestedFolder extends NestedFolderDTO {
-//   kind: 'folder';
-// }
-
-// export interface NestedFolderDashboard extends DashboardSectionItem {
-//   kind: 'dashboard';
-
-//   // uid: string;
-//   // title: string;
-//   // url: string;
-//   // uri: string; // ???
-//   // isStarred: boolean;
-//   // tags: string[];
-//   // // folderUid: string;
-//   // // folderTitle: string;
-// }

--- a/public/app/features/search/service/types.ts
+++ b/public/app/features/search/service/types.ts
@@ -1,6 +1,8 @@
 import { DataFrameView, SelectableValue } from '@grafana/data';
 import { TermCount } from 'app/core/components/TagFilter/TagFilter';
 
+import { DashboardSectionItem } from '../types';
+
 export interface FacetField {
   field: string;
   count?: number;
@@ -75,6 +77,35 @@ export interface GrafanaSearcher {
   getSortOptions: () => Promise<SelectableValue[]>;
   sortPlaceholder?: string;
 
+  getFolderChildren: (folderUid?: string) => Promise<NestedFolderItem[]>;
+
   /** Gets the default sort used for the Folder view */
   getFolderViewSort: () => string;
 }
+
+export interface NestedFolderDTO {
+  uid: string;
+  title: string;
+}
+
+export interface NestedFolderItem extends DashboardSectionItem {
+  kind: 'folder' | 'dashboard';
+  uid: string;
+}
+
+// export interface NestedFolder extends NestedFolderDTO {
+//   kind: 'folder';
+// }
+
+// export interface NestedFolderDashboard extends DashboardSectionItem {
+//   kind: 'dashboard';
+
+//   // uid: string;
+//   // title: string;
+//   // url: string;
+//   // uri: string; // ???
+//   // isStarred: boolean;
+//   // tags: string[];
+//   // // folderUid: string;
+//   // // folderTitle: string;
+// }

--- a/public/app/features/search/service/types.ts
+++ b/public/app/features/search/service/types.ts
@@ -1,6 +1,8 @@
 import { DataFrameView, SelectableValue } from '@grafana/data';
 import { TermCount } from 'app/core/components/TagFilter/TagFilter';
 
+import { DashboardViewItem } from '../types';
+
 export interface FacetField {
   field: string;
   count?: number;
@@ -75,7 +77,7 @@ export interface GrafanaSearcher {
   getSortOptions: () => Promise<SelectableValue[]>;
   sortPlaceholder?: string;
 
-  getFolderChildren: (folderUid?: string) => Promise<NestedFolderItem[]>;
+  getFolderChildren: (folderUid?: string) => Promise<DashboardViewItem[]>;
 
   /** Gets the default sort used for the Folder view */
   getFolderViewSort: () => string;
@@ -84,21 +86,4 @@ export interface GrafanaSearcher {
 export interface NestedFolderDTO {
   uid: string;
   title: string;
-}
-
-export interface NestedFolderItem {
-  kind: 'folder' | 'dashboard';
-  uid: string;
-  title: string;
-  url?: string;
-  tags?: string[];
-
-  icon?: string;
-  folderTitle?: string; // where does this come from?
-  sortMeta?: string; // PR TODO: test with enterprise
-  sortMetaName?: string; // PR TODO: test with enterprise
-
-  itemsUIDs?: string[];
-
-  // selected?: boolean; // PR TODO: is this the right place for it? I don't think this shape should contain state
 }

--- a/public/app/features/search/service/utils.ts
+++ b/public/app/features/search/service/utils.ts
@@ -1,6 +1,7 @@
+import { QueryResultMeta } from '@grafana/data';
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
 
-import { SearchQuery } from './types';
+import { DashboardQueryResult, NestedFolderItem, SearchQuery } from './types';
 
 /** prepare the query replacing folder:current */
 export async function replaceCurrentFolderQuery(query: SearchQuery): Promise<SearchQuery> {
@@ -33,4 +34,18 @@ async function getCurrentFolderUID(): Promise<string | undefined> {
 
 function delay(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export function queryResultToNestedFolderItem(
+  item: DashboardQueryResult,
+  queryMeta?: QueryResultMeta
+): NestedFolderItem {
+  return {
+    kind: 'dashboard',
+    uid: item.uid,
+    title: item.name,
+    url: item.url,
+    tags: item.tags ?? [],
+    folderTitle: queryMeta?.custom?.locationInfo[item.location].name,
+  };
 }

--- a/public/app/features/search/service/utils.ts
+++ b/public/app/features/search/service/utils.ts
@@ -1,7 +1,9 @@
 import { QueryResultMeta } from '@grafana/data';
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
 
-import { DashboardQueryResult, NestedFolderItem, SearchQuery } from './types';
+import { DashboardViewItem } from '../types';
+
+import { DashboardQueryResult, SearchQuery } from './types';
 
 /** prepare the query replacing folder:current */
 export async function replaceCurrentFolderQuery(query: SearchQuery): Promise<SearchQuery> {
@@ -39,7 +41,7 @@ function delay(ms: number) {
 export function queryResultToNestedFolderItem(
   item: DashboardQueryResult,
   queryMeta?: QueryResultMeta
-): NestedFolderItem {
+): DashboardViewItem {
   return {
     kind: 'dashboard',
     uid: item.uid,

--- a/public/app/features/search/types.ts
+++ b/public/app/features/search/types.ts
@@ -11,9 +11,9 @@ export enum DashboardSearchItemType {
 }
 
 /**
- * @deprecated
+ * @deprecated Used only in the deprecated
  */
-export interface DashboardSection {
+interface DashboardSection {
   id?: number;
   uid?: string;
   title: string;
@@ -33,7 +33,7 @@ export interface DashboardSection {
 /**
  * @deprecated
  */
-export interface DashboardSectionItem {
+interface DashboardSectionItem {
   checked?: boolean;
   folderId?: number;
   folderTitle?: string;
@@ -52,39 +52,24 @@ export interface DashboardSectionItem {
   sortMeta?: number;
   sortMetaName?: string;
 }
-
-export interface DashboardSearchHitDTO {
-  id: number;
-  uid: string;
-  title: string;
-  uri: string;
-  url: string;
-  slug: string;
-  type: string; // dash-db, dash-home
-  tags: string[];
-  isStarred: boolean;
-
-  sortMeta: number;
-  sortMetaName?: string;
-
-  // Only on dashboards in folders results
-  folderId?: number;
-  folderUid?: string;
-  folderTitle?: string;
-  folderUrl?: string;
-}
-
 /**
  * @deprecated - It uses dashboard ID which is deprecated in favor of dashboard UID. Please, use DashboardSearchItem instead.
  */
 export interface DashboardSearchHit extends DashboardSectionItem, DashboardSection, WithAccessControlMetadata {}
 
-export interface DashboardSearchItem
-  extends Omit<
-    DashboardSearchHit,
-    'id' | 'uid' | 'expanded' | 'selected' | 'checked' | 'folderId' | 'icon' | 'sortMeta' | 'sortMetaName'
-  > {
+export interface DashboardSearchItem {
   uid: string;
+  title: string;
+  uri: string;
+  url: string;
+  type: string; // dash-db, dash-home
+  tags: string[];
+  isStarred: boolean;
+
+  // Only on dashboards in folders results
+  folderUid?: string;
+  folderTitle?: string;
+  folderUrl?: string;
 }
 
 export interface SearchAction extends Action {

--- a/public/app/features/search/types.ts
+++ b/public/app/features/search/types.ts
@@ -2,7 +2,7 @@ import { Action } from 'redux';
 
 import { WithAccessControlMetadata } from '@grafana/data';
 
-import { NestedFolderItem, QueryResponse } from './service';
+import { QueryResponse } from './service';
 
 export enum DashboardSearchItemType {
   DashDB = 'dash-db',
@@ -49,6 +49,24 @@ export interface DashboardSearchItem {
   folderUrl?: string;
 }
 
+/**
+ * Type used in the folder view components
+ */
+export interface DashboardViewItem {
+  kind: 'folder' | 'dashboard';
+  uid: string;
+  title: string;
+  url?: string;
+  tags?: string[];
+
+  icon?: string;
+  folderTitle?: string; // where does this come from?
+  sortMeta?: string; // PR TODO: test with enterprise
+  sortMetaName?: string; // PR TODO: test with enterprise
+
+  itemsUIDs?: string[];
+}
+
 export interface SearchAction extends Action {
   payload?: any;
 }
@@ -71,7 +89,7 @@ export interface SearchState {
   eventTrackingNamespace: EventTrackingNamespace;
 }
 
-export type OnToggleChecked = (item: NestedFolderItem) => void;
+export type OnToggleChecked = (item: DashboardViewItem) => void;
 
 export enum SearchLayout {
   List = 'list',

--- a/public/app/features/search/types.ts
+++ b/public/app/features/search/types.ts
@@ -53,6 +53,27 @@ export interface DashboardSectionItem {
   sortMetaName?: string;
 }
 
+export interface DashboardSearchHitDTO {
+  id: number;
+  uid: string;
+  title: string;
+  uri: string;
+  url: string;
+  slug: string;
+  type: string; // dash-db, dash-home
+  tags: string[];
+  isStarred: boolean;
+
+  sortMeta: number;
+  sortMetaName?: string;
+
+  // Only on dashboards in folders results
+  folderId?: number;
+  folderUid?: string;
+  folderTitle?: string;
+  folderUrl?: string;
+}
+
 /**
  * @deprecated - It uses dashboard ID which is deprecated in favor of dashboard UID. Please, use DashboardSearchItem instead.
  */

--- a/public/app/features/search/types.ts
+++ b/public/app/features/search/types.ts
@@ -24,7 +24,7 @@ export interface DashboardSearchHit extends WithAccessControlMetadata {
   tags: string[];
   title: string;
   type: DashboardSearchItemType;
-  uid?: string;
+  uid: string;
   url: string;
   sortMeta?: number;
   sortMetaName?: string;

--- a/public/app/features/search/types.ts
+++ b/public/app/features/search/types.ts
@@ -11,29 +11,14 @@ export enum DashboardSearchItemType {
 }
 
 /**
- * @deprecated Used only in the deprecated
+ * @deprecated Use DashboardSearchItem and use UIDs instead of IDs
  */
-interface DashboardSection {
-  id?: number;
-  uid?: string;
-  title: string;
+export interface DashboardSearchHit extends WithAccessControlMetadata {
   expanded?: boolean;
-  url: string;
-  icon?: string;
   score?: number;
-  checked?: boolean;
-  items: DashboardSectionItem[];
-  toggle?: (section: DashboardSection) => Promise<DashboardSection>;
-  selected?: boolean;
-  type: DashboardSearchItemType;
   slug?: string;
   itemsFetching?: boolean;
-}
 
-/**
- * @deprecated
- */
-interface DashboardSectionItem {
   checked?: boolean;
   folderId?: number;
   folderTitle?: string;
@@ -45,17 +30,13 @@ interface DashboardSectionItem {
   tags: string[];
   title: string;
   type: DashboardSearchItemType;
-  icon?: string; // used for grid view
+  icon?: string;
   uid?: string;
   uri: string;
   url: string;
   sortMeta?: number;
   sortMetaName?: string;
 }
-/**
- * @deprecated - It uses dashboard ID which is deprecated in favor of dashboard UID. Please, use DashboardSearchItem instead.
- */
-export interface DashboardSearchHit extends DashboardSectionItem, DashboardSection, WithAccessControlMetadata {}
 
 export interface DashboardSearchItem {
   uid: string;

--- a/public/app/features/search/types.ts
+++ b/public/app/features/search/types.ts
@@ -2,7 +2,7 @@ import { Action } from 'redux';
 
 import { WithAccessControlMetadata } from '@grafana/data';
 
-import { QueryResponse } from './service';
+import { NestedFolderItem, QueryResponse } from './service';
 
 export enum DashboardSearchItemType {
   DashDB = 'dash-db',
@@ -88,7 +88,7 @@ export interface SearchState {
   eventTrackingNamespace: EventTrackingNamespace;
 }
 
-export type OnToggleChecked = (item: DashboardSectionItem | DashboardSection) => void;
+export type OnToggleChecked = (item: NestedFolderItem) => void;
 
 export enum SearchLayout {
   List = 'list',

--- a/public/app/features/search/types.ts
+++ b/public/app/features/search/types.ts
@@ -12,32 +12,28 @@ export enum DashboardSearchItemType {
 
 /**
  * @deprecated Use DashboardSearchItem and use UIDs instead of IDs
+ * This type was previously also used heavily for views, so contains lots of
+ * extraneous properties
  */
 export interface DashboardSearchHit extends WithAccessControlMetadata {
-  expanded?: boolean;
-  score?: number;
-  slug?: string;
-  itemsFetching?: boolean;
-
-  checked?: boolean;
   folderId?: number;
   folderTitle?: string;
   folderUid?: string;
   folderUrl?: string;
   id?: number;
-  isStarred: boolean;
-  selected?: boolean;
   tags: string[];
   title: string;
   type: DashboardSearchItemType;
-  icon?: string;
   uid?: string;
-  uri: string;
   url: string;
   sortMeta?: number;
   sortMetaName?: string;
 }
 
+/**
+ * DTO type for search API result items
+ * This should not be used directly - use GrafanaSearcher instead and get a DashboardQueryResult
+ */
 export interface DashboardSearchItem {
   uid: string;
   title: string;

--- a/public/app/plugins/panel/dashlist/DashList.tsx
+++ b/public/app/plugins/panel/dashlist/DashList.tsx
@@ -170,7 +170,7 @@ export function DashList(props: PanelProps<PanelOptions>) {
     <ul className={css.gridContainer}>
       {dashboards.map((dash) => (
         <li key={dash.uid}>
-          <SearchCard item={dash} />
+          <SearchCard item={{ ...dash, kind: 'dashboard' }} />
         </li>
       ))}
     </ul>

--- a/public/app/plugins/panel/dashlist/DashList.tsx
+++ b/public/app/plugins/panel/dashlist/DashList.tsx
@@ -103,8 +103,7 @@ export function DashList(props: PanelProps<PanelOptions>) {
     e.preventDefault();
     e.stopPropagation();
 
-    // FIXME: Do not use dash ID. Use UID to star a dashboard once the backend allows it
-    const isStarred = await getDashboardSrv().starDashboard(dash.id!.toString(), dash.isStarred);
+    const isStarred = await getDashboardSrv().starDashboard(dash.uid, dash.isStarred);
     const updatedDashboards = new Map(dashboards);
     updatedDashboards.set(dash?.uid ?? '', { ...dash, isStarred });
     setDashboards(updatedDashboards);


### PR DESCRIPTION
**What is this feature?**

Heavily work-in-progress for showing nested folders in the existing UI, gated behind the `nestedFolders` feature flag.

 - Remove the deprecated search types `DashboardSection`, `DashboardSectionItem`, `DashboardSearchHit`, and `DashboardSearchItem` in favor of the unified `NestedFolderItem` type
   - This removes a bunch of back-and-forth converting that was happening between the API and other types
   - Goal is that we have two types - there's the `*DTO` types for data that comes over the various APIs. That's then converted to a `NestedFolderItem` which is used in all the views.
   - `NestedFolderItem` will not be the final name - just something I've used for now to easily diferentiate it from the other types
 - Adds a new `getFolderChildren` method to `GrafanaSearcher` classes for use in the folder view components. 
   - It uses Search to list Folders and Folder API to list folders at a specific location in the hierarchy. 
   - I need to double check Search cannot be used to list _just_ folders that are direct children (and not full descendants) of a folder

**Which issue(s) does this PR fix?**:


Part of https://github.com/grafana/grafana/issues/62848

**Special notes for your reviewer**:

***Note:*** _This branch currently does not work when `nestedFolders` is not enabled. Current focus has just been on hooking the right APIs up._ 

