### PR TITLE
Provisioning: Parse boolean and numeric values from environment variables

### DIFF
--- a/pkg/services/provisioning/values/values_test.go
+++ b/pkg/services/provisioning/values/values_test.go
@@ -168,6 +168,7 @@ func TestValues(t *testing.T) {
                      Some text with $STRING
                    anchor: &label $INT
                    anchored: *label
+                   boolval: $BOOL
                `
 				unmarshalingTest(t, doc, d)
 
@@ -191,12 +192,13 @@ func TestValues(t *testing.T) {
 					},
 					"four": stringMap{
 						"nested": stringMap{
-							"onemore": "1",
+							"onemore": int64(1),
 						},
 					},
 					"multiline": "Some text with test\n",
-					"anchor":    "1",
-					"anchored":  "1",
+					"anchor":    int64(1),
+					"anchored":  int64(1),
+					"boolval":   true,
 				})
 
 				require.Equal(t, d.Val.Raw, stringMap{
@@ -224,6 +226,7 @@ func TestValues(t *testing.T) {
 					"multiline": "Some text with $STRING\n",
 					"anchor":    "$INT",
 					"anchored":  "$INT",
+					"boolval":   "$BOOL",
 				})
 			})
 		})
@@ -251,12 +254,12 @@ func TestValues(t *testing.T) {
 				require.Equal(t, []stringMap{
 					{
 						"interpolatedString": "test",
-						"interpolatedInt":    "1",
+						"interpolatedInt":    int64(1),
 						"string":             "just a string",
 					},
 					{
 						"interpolatedString": "test",
-						"interpolatedInt":    "1",
+						"interpolatedInt":    int64(1),
 						"string":             "just a string",
 					},
 				}, d.Val.Value())


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

It's been reported multiple times (https://github.com/grafana/grafana/issues/32061, https://github.com/grafana/azure-data-explorer-datasource/issues/442, https://github.com/grafana/clickhouse-datasource/issues/241) that when using environment variables to provision things like ports or flags, the environment variables are parsed as strings rather than integers and booleans, causing failures in the data source.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #32061
Fixes https://github.com/grafana/azure-data-explorer-datasource/issues/442

**Special notes for your reviewer**:

This only applies to environment variables, values like `key: "true"` will still be parsed as a string.

Open question: Can this be considered a breaking change? IMO, this is fixing a bug more than changing the expected behavior.