### PR TITLE
Alerting: Fix changing datasource and creating new query not  using defaults.

### DIFF
--- a/packages/grafana-runtime/src/services/__mocks__/dataSourceSrv.ts
+++ b/packages/grafana-runtime/src/services/__mocks__/dataSourceSrv.ts
@@ -19,5 +19,12 @@ export function getDataSourceSrv() {
   return {
     getList: () => [ds1],
     getInstanceSettings: () => ds1,
+    get: () =>
+      Promise.resolve({
+        filterQuery: () => true,
+        getDefaultQuery: () => ({
+          expression: 'vector(1)',
+        }),
+      }),
   };
 }

--- a/packages/grafana-runtime/src/services/__mocks__/dataSourceSrv.ts
+++ b/packages/grafana-runtime/src/services/__mocks__/dataSourceSrv.ts
@@ -23,7 +23,7 @@ export function getDataSourceSrv() {
       Promise.resolve({
         filterQuery: () => true,
         getDefaultQuery: () => ({
-          expression: 'vector(1)',
+          expr: 'vector(1)',
         }),
       }),
   };

--- a/public/app/features/alerting/unified/RuleEditorCloudOnlyAllowed.test.tsx
+++ b/public/app/features/alerting/unified/RuleEditorCloudOnlyAllowed.test.tsx
@@ -2,6 +2,7 @@ import { screen, waitForElementToBeRemoved } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { renderRuleEditor, ui } from 'test/helpers/alertingRuleEditor';
+import { MockDataSourceApi } from 'test/mocks/datasource_srv';
 import { byRole, byText } from 'testing-library-selector';
 
 import { setDataSourceSrv } from '@grafana/runtime';
@@ -160,7 +161,7 @@ describe('RuleEditor cloud: checking editable data sources', () => {
     });
 
     const dsServer = new MockDataSourceSrv(dataSources);
-    jest.spyOn(dsServer, 'get').mockResolvedValue({ id: 1, name: 'prometheus', meta: {} });
+    jest.spyOn(dsServer, 'get').mockResolvedValue(new MockDataSourceApi('ds'));
 
     setDataSourceSrv(dsServer);
     mocks.getAllDataSources.mockReturnValue(Object.values(dataSources));

--- a/public/app/features/alerting/unified/RuleEditorCloudOnlyAllowed.test.tsx
+++ b/public/app/features/alerting/unified/RuleEditorCloudOnlyAllowed.test.tsx
@@ -159,7 +159,10 @@ describe('RuleEditor cloud: checking editable data sources', () => {
       return null;
     });
 
-    setDataSourceSrv(new MockDataSourceSrv(dataSources));
+    const dsServer = new MockDataSourceSrv(dataSources);
+    jest.spyOn(dsServer, 'get').mockResolvedValue({ id: 1, name: 'prometheus', meta: {} });
+
+    setDataSourceSrv(dsServer);
     mocks.getAllDataSources.mockReturnValue(Object.values(dataSources));
     mocks.searchFolders.mockResolvedValue([]);
 

--- a/public/app/features/alerting/unified/RuleEditorCloudRules.test.tsx
+++ b/public/app/features/alerting/unified/RuleEditorCloudRules.test.tsx
@@ -1,4 +1,4 @@
-import { waitFor, screen, within, waitForElementToBeRemoved } from '@testing-library/react';
+import { screen, waitFor, waitForElementToBeRemoved, within } from '@testing-library/react';
 import userEvent, { PointerEventsCheckLevel } from '@testing-library/user-event';
 import React from 'react';
 import { renderRuleEditor, ui } from 'test/helpers/alertingRuleEditor';
@@ -17,6 +17,7 @@ import { ExpressionEditorProps } from './components/rule-editor/ExpressionEditor
 import { disableRBAC, mockDataSource, MockDataSourceSrv } from './mocks';
 import { fetchRulerRulesIfNotFetchedYet } from './state/actions';
 import * as config from './utils/config';
+import * as ruleForm from './utils/rule-form';
 
 jest.mock('./components/rule-editor/ExpressionEditor', () => ({
   // eslint-disable-next-line react/display-name
@@ -37,6 +38,7 @@ jest.mock('app/features/query/components/QueryEditorRow', () => ({
 }));
 
 jest.spyOn(config, 'getAllDataSources');
+jest.spyOn(ruleForm, 'getDefaultQueriesAsync');
 
 // these tests are rather slow because we have to wait for various API calls and mocks to be called
 // and wait for the UI to be in particular states, drone seems to time out quite often so
@@ -47,6 +49,7 @@ jest.setTimeout(60 * 1000);
 const mocks = {
   getAllDataSources: jest.mocked(config.getAllDataSources),
   searchFolders: jest.mocked(searchFolders),
+  getDefaultQueriesAsync: jest.mocked(ruleForm.getDefaultQueriesAsync),
   api: {
     discoverFeatures: jest.mocked(discoverFeatures),
     fetchRulerRulesGroup: jest.mocked(fetchRulerRulesGroup),
@@ -79,7 +82,6 @@ describe('RuleEditor cloud', () => {
         { alerting: true }
       ),
     };
-
     setDataSourceSrv(new MockDataSourceSrv(dataSources));
     mocks.getAllDataSources.mockReturnValue(Object.values(dataSources));
     mocks.api.setRulerRuleGroup.mockResolvedValue();
@@ -109,6 +111,18 @@ describe('RuleEditor cloud', () => {
       features: {
         rulerApiEnabled: true,
       },
+    });
+
+    mocks.getDefaultQueriesAsync.mockResolvedValue({
+      queries: [
+        {
+          refId: 'A',
+          relativeTimeRange: { from: 900, to: 1000 },
+          datasourceUid: '',
+          model: { refId: 'A' },
+          queryType: 'query',
+        },
+      ],
     });
 
     renderRuleEditor();

--- a/public/app/features/alerting/unified/RuleEditorCloudRules.test.tsx
+++ b/public/app/features/alerting/unified/RuleEditorCloudRules.test.tsx
@@ -17,7 +17,6 @@ import { ExpressionEditorProps } from './components/rule-editor/ExpressionEditor
 import { disableRBAC, mockDataSource, MockDataSourceSrv } from './mocks';
 import { fetchRulerRulesIfNotFetchedYet } from './state/actions';
 import * as config from './utils/config';
-import * as ruleForm from './utils/rule-form';
 
 jest.mock('./components/rule-editor/ExpressionEditor', () => ({
   // eslint-disable-next-line react/display-name
@@ -38,7 +37,6 @@ jest.mock('app/features/query/components/QueryEditorRow', () => ({
 }));
 
 jest.spyOn(config, 'getAllDataSources');
-jest.spyOn(ruleForm, 'getDefaultQueriesAsync');
 
 // these tests are rather slow because we have to wait for various API calls and mocks to be called
 // and wait for the UI to be in particular states, drone seems to time out quite often so
@@ -49,7 +47,6 @@ jest.setTimeout(60 * 1000);
 const mocks = {
   getAllDataSources: jest.mocked(config.getAllDataSources),
   searchFolders: jest.mocked(searchFolders),
-  getDefaultQueriesAsync: jest.mocked(ruleForm.getDefaultQueriesAsync),
   api: {
     discoverFeatures: jest.mocked(discoverFeatures),
     fetchRulerRulesGroup: jest.mocked(fetchRulerRulesGroup),
@@ -111,18 +108,6 @@ describe('RuleEditor cloud', () => {
       features: {
         rulerApiEnabled: true,
       },
-    });
-
-    mocks.getDefaultQueriesAsync.mockResolvedValue({
-      queries: [
-        {
-          refId: 'A',
-          relativeTimeRange: { from: 900, to: 1000 },
-          datasourceUid: '',
-          model: { refId: 'A' },
-          queryType: 'query',
-        },
-      ],
     });
 
     renderRuleEditor();

--- a/public/app/features/alerting/unified/RuleEditorCloudRules.test.tsx
+++ b/public/app/features/alerting/unified/RuleEditorCloudRules.test.tsx
@@ -3,6 +3,7 @@ import userEvent, { PointerEventsCheckLevel } from '@testing-library/user-event'
 import React from 'react';
 import { renderRuleEditor, ui } from 'test/helpers/alertingRuleEditor';
 import { clickSelectOption } from 'test/helpers/selectOptionInTest';
+import { MockDataSourceApi } from 'test/mocks/datasource_srv';
 import { byRole } from 'testing-library-selector';
 
 import { setDataSourceSrv } from '@grafana/runtime';
@@ -80,7 +81,7 @@ describe('RuleEditor cloud', () => {
       ),
     };
     const dsServer = new MockDataSourceSrv(dataSources);
-    jest.spyOn(dsServer, 'get').mockResolvedValue({ id: 1, name: 'prometheus', meta: {} });
+    jest.spyOn(dsServer, 'get').mockResolvedValue(new MockDataSourceApi('ds'));
 
     setDataSourceSrv(dsServer);
     mocks.getAllDataSources.mockReturnValue(Object.values(dataSources));

--- a/public/app/features/alerting/unified/RuleEditorCloudRules.test.tsx
+++ b/public/app/features/alerting/unified/RuleEditorCloudRules.test.tsx
@@ -79,7 +79,10 @@ describe('RuleEditor cloud', () => {
         { alerting: true }
       ),
     };
-    setDataSourceSrv(new MockDataSourceSrv(dataSources));
+    const dsServer = new MockDataSourceSrv(dataSources);
+    jest.spyOn(dsServer, 'get').mockResolvedValue({ id: 1, name: 'prometheus', meta: {} });
+
+    setDataSourceSrv(dsServer);
     mocks.getAllDataSources.mockReturnValue(Object.values(dataSources));
     mocks.api.setRulerRuleGroup.mockResolvedValue();
     mocks.api.fetchRulerRulesNamespace.mockResolvedValue([]);

--- a/public/app/features/alerting/unified/RuleEditorExisting.test.tsx
+++ b/public/app/features/alerting/unified/RuleEditorExisting.test.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor, screen, within } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { Route } from 'react-router-dom';
@@ -25,7 +25,7 @@ import { disableRBAC, mockDataSource, MockDataSourceSrv, mockFolder } from './mo
 import { fetchRulerRulesIfNotFetchedYet } from './state/actions';
 import * as config from './utils/config';
 import { GRAFANA_RULES_SOURCE_NAME } from './utils/datasource';
-import { getDefaultQueries } from './utils/rule-form';
+import { getDefaultQueriesAsync } from './utils/rule-form';
 
 jest.mock('./components/rule-editor/ExpressionEditor', () => ({
   // eslint-disable-next-line react/display-name
@@ -119,6 +119,7 @@ describe('RuleEditor grafana managed rules', () => {
     mocks.getAllDataSources.mockReturnValue(Object.values(dataSources));
     mocks.api.setRulerRuleGroup.mockResolvedValue();
     mocks.api.fetchRulerRulesNamespace.mockResolvedValue([]);
+    const defaultQueries = (await getDefaultQueriesAsync()).queries ?? [];
     mocks.api.fetchRulerRules.mockResolvedValue({
       [folder.title]: [
         {
@@ -134,7 +135,7 @@ describe('RuleEditor grafana managed rules', () => {
                 namespace_uid: 'abcd',
                 namespace_id: 1,
                 condition: 'B',
-                data: getDefaultQueries(),
+                data: defaultQueries,
                 exec_err_state: GrafanaAlertStateDecision.Error,
                 no_data_state: GrafanaAlertStateDecision.NoData,
                 title: 'my great new rule',
@@ -203,7 +204,7 @@ describe('RuleEditor grafana managed rules', () => {
             grafana_alert: {
               uid,
               condition: 'B',
-              data: getDefaultQueries(),
+              data: await getDefaultQueriesAsync(),
               exec_err_state: GrafanaAlertStateDecision.Error,
               is_paused: false,
               no_data_state: 'NoData',

--- a/public/app/features/alerting/unified/RuleEditorExisting.test.tsx
+++ b/public/app/features/alerting/unified/RuleEditorExisting.test.tsx
@@ -25,7 +25,7 @@ import { disableRBAC, mockDataSource, MockDataSourceSrv, mockFolder } from './mo
 import { fetchRulerRulesIfNotFetchedYet } from './state/actions';
 import * as config from './utils/config';
 import { GRAFANA_RULES_SOURCE_NAME } from './utils/datasource';
-import { getDefaultQueriesAsync } from './utils/rule-form';
+import * as ruleForm from './utils/rule-form';
 
 jest.mock('./components/rule-editor/ExpressionEditor', () => ({
   // eslint-disable-next-line react/display-name
@@ -46,12 +46,14 @@ jest.mock('app/features/query/components/QueryEditorRow', () => ({
 }));
 
 jest.spyOn(config, 'getAllDataSources');
+jest.spyOn(ruleForm, 'getDefaultQueriesAsync');
 
 jest.setTimeout(60 * 1000);
 
 const mocks = {
   getAllDataSources: jest.mocked(config.getAllDataSources),
   searchFolders: jest.mocked(searchFolders),
+  getDefaultQueriesAsync: jest.mocked(ruleForm.getDefaultQueriesAsync),
   api: {
     discoverFeatures: jest.mocked(discoverFeatures),
     fetchRulerRulesGroup: jest.mocked(fetchRulerRulesGroup),
@@ -119,7 +121,17 @@ describe('RuleEditor grafana managed rules', () => {
     mocks.getAllDataSources.mockReturnValue(Object.values(dataSources));
     mocks.api.setRulerRuleGroup.mockResolvedValue();
     mocks.api.fetchRulerRulesNamespace.mockResolvedValue([]);
-    const defaultQueries = (await getDefaultQueriesAsync()).queries ?? [];
+    mocks.getDefaultQueriesAsync.mockResolvedValue({
+      queries: [
+        {
+          refId: 'A',
+          relativeTimeRange: { from: 900, to: 1000 },
+          datasourceUid: 'dsuid',
+          model: { refId: 'A' },
+          queryType: 'query',
+        },
+      ],
+    });
     mocks.api.fetchRulerRules.mockResolvedValue({
       [folder.title]: [
         {
@@ -134,8 +146,16 @@ describe('RuleEditor grafana managed rules', () => {
                 uid,
                 namespace_uid: 'abcd',
                 namespace_id: 1,
-                condition: 'B',
-                data: defaultQueries,
+                condition: 'A',
+                data: [
+                  {
+                    refId: 'A',
+                    relativeTimeRange: { from: 900, to: 1000 },
+                    datasourceUid: 'dsuid',
+                    model: { refId: 'A' },
+                    queryType: 'query',
+                  },
+                ],
                 exec_err_state: GrafanaAlertStateDecision.Error,
                 no_data_state: GrafanaAlertStateDecision.NoData,
                 title: 'my great new rule',
@@ -203,8 +223,16 @@ describe('RuleEditor grafana managed rules', () => {
             for: '5m',
             grafana_alert: {
               uid,
-              condition: 'B',
-              data: await getDefaultQueriesAsync(),
+              condition: 'A',
+              data: [
+                {
+                  refId: 'A',
+                  relativeTimeRange: { from: 900, to: 1000 },
+                  datasourceUid: 'dsuid',
+                  model: { refId: 'A' },
+                  queryType: 'query',
+                },
+              ],
               exec_err_state: GrafanaAlertStateDecision.Error,
               is_paused: false,
               no_data_state: 'NoData',

--- a/public/app/features/alerting/unified/RuleEditorGrafanaRules.test.tsx
+++ b/public/app/features/alerting/unified/RuleEditorGrafanaRules.test.tsx
@@ -1,4 +1,4 @@
-import { waitFor, screen, within, waitForElementToBeRemoved } from '@testing-library/react';
+import { screen, waitFor, waitForElementToBeRemoved, within } from '@testing-library/react';
 import userEvent, { PointerEventsCheckLevel } from '@testing-library/user-event';
 import React from 'react';
 import { renderRuleEditor, ui } from 'test/helpers/alertingRuleEditor';
@@ -19,7 +19,7 @@ import { disableRBAC, mockDataSource, MockDataSourceSrv } from './mocks';
 import { fetchRulerRulesIfNotFetchedYet } from './state/actions';
 import * as config from './utils/config';
 import { GRAFANA_RULES_SOURCE_NAME } from './utils/datasource';
-import { getDefaultQueries } from './utils/rule-form';
+import { getDefaultQueriesAsync } from './utils/rule-form';
 
 jest.mock('./components/rule-editor/ExpressionEditor', () => ({
   // eslint-disable-next-line react/display-name
@@ -158,7 +158,7 @@ describe('RuleEditor grafana managed rules', () => {
             for: '5m',
             grafana_alert: {
               condition: 'B',
-              data: getDefaultQueries(),
+              data: (await getDefaultQueriesAsync()).queries,
               exec_err_state: GrafanaAlertStateDecision.Error,
               is_paused: false,
               no_data_state: 'NoData',

--- a/public/app/features/alerting/unified/RuleEditorGrafanaRules.test.tsx
+++ b/public/app/features/alerting/unified/RuleEditorGrafanaRules.test.tsx
@@ -3,6 +3,7 @@ import userEvent, { PointerEventsCheckLevel } from '@testing-library/user-event'
 import React from 'react';
 import { renderRuleEditor, ui } from 'test/helpers/alertingRuleEditor';
 import { clickSelectOption } from 'test/helpers/selectOptionInTest';
+import { MockDataSourceApi } from 'test/mocks/datasource_srv';
 import { byRole } from 'testing-library-selector';
 
 import { setDataSourceSrv } from '@grafana/runtime';
@@ -78,7 +79,7 @@ describe('RuleEditor grafana managed rules', () => {
     };
 
     const dsServer = new MockDataSourceSrv(dataSources);
-    jest.spyOn(dsServer, 'get').mockResolvedValue({ id: 1, name: 'prometheus', meta: {} });
+    jest.spyOn(dsServer, 'get').mockResolvedValue(new MockDataSourceApi('ds'));
 
     setDataSourceSrv(dsServer);
     mocks.getAllDataSources.mockReturnValue(Object.values(dataSources));

--- a/public/app/features/alerting/unified/RuleEditorGrafanaRules.test.tsx
+++ b/public/app/features/alerting/unified/RuleEditorGrafanaRules.test.tsx
@@ -8,7 +8,7 @@ import { byRole } from 'testing-library-selector';
 import { setDataSourceSrv } from '@grafana/runtime';
 import { contextSrv } from 'app/core/services/context_srv';
 import { DashboardSearchHit } from 'app/features/search/types';
-import { PromApplication } from 'app/types/unified-alerting-dto';
+import { GrafanaAlertStateDecision, PromApplication } from 'app/types/unified-alerting-dto';
 
 import { searchFolders } from '../../../../app/features/manage-dashboards/state/actions';
 
@@ -171,7 +171,7 @@ describe('RuleEditor grafana managed rules', () => {
               title: 'my great new rule',
               condition: 'B',
               no_data_state: 'NoData',
-              exec_err_state: 'Error',
+              exec_err_state: GrafanaAlertStateDecision.Error,
               data: [
                 {
                   refId: 'A',

--- a/public/app/features/alerting/unified/RuleEditorRecordingRule.test.tsx
+++ b/public/app/features/alerting/unified/RuleEditorRecordingRule.test.tsx
@@ -3,6 +3,7 @@ import userEvent, { PointerEventsCheckLevel } from '@testing-library/user-event'
 import React from 'react';
 import { renderRuleEditor, ui } from 'test/helpers/alertingRuleEditor';
 import { clickSelectOption } from 'test/helpers/selectOptionInTest';
+import { MockDataSourceApi } from 'test/mocks/datasource_srv';
 import { byRole, byText } from 'testing-library-selector';
 
 import { setDataSourceSrv } from '@grafana/runtime';
@@ -76,7 +77,7 @@ describe('RuleEditor recording rules', () => {
     };
 
     const dsServer = new MockDataSourceSrv(dataSources);
-    jest.spyOn(dsServer, 'get').mockResolvedValue({ id: 1, name: 'prometheus', meta: {} });
+    jest.spyOn(dsServer, 'get').mockResolvedValue(new MockDataSourceApi('ds'));
 
     setDataSourceSrv(dsServer);
     mocks.getAllDataSources.mockReturnValue(Object.values(dataSources));

--- a/public/app/features/alerting/unified/RuleEditorRecordingRule.test.tsx
+++ b/public/app/features/alerting/unified/RuleEditorRecordingRule.test.tsx
@@ -1,4 +1,4 @@
-import { waitFor, screen, within, waitForElementToBeRemoved } from '@testing-library/react';
+import { screen, waitFor, waitForElementToBeRemoved, within } from '@testing-library/react';
 import userEvent, { PointerEventsCheckLevel } from '@testing-library/user-event';
 import React from 'react';
 import { renderRuleEditor, ui } from 'test/helpers/alertingRuleEditor';
@@ -75,7 +75,10 @@ describe('RuleEditor recording rules', () => {
       ),
     };
 
-    setDataSourceSrv(new MockDataSourceSrv(dataSources));
+    const dsServer = new MockDataSourceSrv(dataSources);
+    jest.spyOn(dsServer, 'get').mockResolvedValue({ id: 1, name: 'prometheus', meta: {} });
+
+    setDataSourceSrv(dsServer);
     mocks.getAllDataSources.mockReturnValue(Object.values(dataSources));
     mocks.api.setRulerRuleGroup.mockResolvedValue();
     mocks.api.fetchRulerRulesNamespace.mockResolvedValue([]);

--- a/public/app/features/alerting/unified/components/rule-editor/AlertRuleForm.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AlertRuleForm.tsx
@@ -144,9 +144,8 @@ export const AlertRuleForm: FC<Props> = ({ existing, prefill }) => {
 
   // only reset once we get some value in defaultDsAndQueries.queries, adding this value.
   useEffect(() => {
-    !existing &&
-      !prefill &&
-      defaultDsAndQueries.queries &&
+    const shouldReset = !existing && !prefill && defaultDsAndQueries.queries;
+    if (shouldReset) {
       reset({
         ...getDefaultFormValues(),
         queries: defaultDsAndQueries.queries,
@@ -155,6 +154,7 @@ export const AlertRuleForm: FC<Props> = ({ existing, prefill }) => {
         type: RuleFormType.grafana,
         evaluateEvery: evaluateEvery,
       });
+    }
   }, [defaultDsAndQueries.queries, reset, existing, prefill, defaultsInQueryParamsObject, evaluateEvery]);
 
   const type = watch('type');
@@ -294,8 +294,8 @@ export const AlertRuleForm: FC<Props> = ({ existing, prefill }) => {
                 editingExistingRule={!!existing}
                 prefill={!!prefill}
                 onDataChange={checkAlertCondition}
-                lazyDefaultQueries={defaultDsAndQueries.queries}
-                lazyDataSource={defaultDsAndQueries.ds}
+                asyncDefaultQueries={defaultDsAndQueries.queries}
+                asyncDataSource={defaultDsAndQueries.ds}
               />
               {showStep2 && (
                 <>

--- a/public/app/features/alerting/unified/components/rule-editor/AlertRuleForm.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AlertRuleForm.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/css';
 import React, { FC, useEffect, useMemo, useState } from 'react';
 import { DeepMap, FieldError, FormProvider, useForm, useFormContext, UseFormWatch } from 'react-hook-form';
 import { Link } from 'react-router-dom';
+import { useAsync } from 'react-use';
 
 import { DataQuery, DataSourceApi, DataSourceJsonData, GrafanaTheme2, UrlQueryMap } from '@grafana/data';
 import { config, logInfo } from '@grafana/runtime';
@@ -95,12 +96,10 @@ export const useGetDefaults = (queryParams: UrlQueryMap, existing: RuleWithLocat
     ds?: DataSourceApi<DataQuery, DataSourceJsonData, {}>;
   }>({ queries: null });
 
-  useEffect(() => {
-    const getDefaultQueries_ = async () => {
-      setDefaultDsAndQueries(await getDefaultQueriesAsync());
-    };
-    getDefaultQueries_();
+  useAsync(async () => {
+    setDefaultDsAndQueries(await getDefaultQueriesAsync());
   }, [existing]);
+
   const defaultsInQueryParams: string = queryParams['defaults'] as string;
   const defaultsInQueryParamsObject = useMemo(
     () => ({ ...(defaultsInQueryParams ? JSON.parse(defaultsInQueryParams) : {}) }),

--- a/public/app/features/alerting/unified/components/rule-editor/AlertRuleForm.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AlertRuleForm.tsx
@@ -5,7 +5,17 @@ import { Link } from 'react-router-dom';
 
 import { DataQuery, DataSourceApi, DataSourceJsonData, GrafanaTheme2, UrlQueryMap } from '@grafana/data';
 import { config, logInfo } from '@grafana/runtime';
-import { Button, ConfirmModal, CustomScrollbar, Field, HorizontalGroup, Input, Spinner, useStyles2 } from '@grafana/ui';
+import {
+  Button,
+  ConfirmModal,
+  CustomScrollbar,
+  Field,
+  HorizontalGroup,
+  Input,
+  LoadingPlaceholder,
+  Spinner,
+  useStyles2,
+} from '@grafana/ui';
 import { useAppNotification } from 'app/core/copy/appNotification';
 import { contextSrv } from 'app/core/core';
 import { useCleanup } from 'app/core/hooks/useCleanup';
@@ -330,7 +340,9 @@ export const AlertRuleForm: FC<Props> = ({ existing, prefill }) => {
       ) : null}
       {showEditYaml ? <RuleInspector onClose={() => setShowEditYaml(false)} /> : null}
     </FormProvider>
-  ) : null;
+  ) : (
+    <LoadingPlaceholder text={'Loading defaults...'} />
+  );
 };
 
 const isCortexLokiOrRecordingRule = (watch: UseFormWatch<RuleFormValues>) => {

--- a/public/app/features/alerting/unified/components/rule-editor/ExpressionEditor.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/ExpressionEditor.tsx
@@ -1,13 +1,15 @@
 import { css } from '@emotion/css';
 import { noop } from 'lodash';
-import React, { FC, useCallback, useMemo } from 'react';
-import { useAsync } from 'react-use';
+import React, { FC, useCallback, useEffect, useMemo, useState } from 'react';
+import { useAsync, usePrevious } from 'react-use';
 
 import { CoreApp, DataQuery, DataSourcePluginContextProvider, GrafanaTheme2, LoadingState } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 import { Alert, Button, useStyles2 } from '@grafana/ui';
 import { LokiQuery } from 'app/plugins/datasource/loki/types';
 import { PromQuery } from 'app/plugins/datasource/prometheus/types';
+
+import { AlertQuery } from '../../../../../types/unified-alerting-dto';
 
 import { CloudAlertPreview } from './CloudAlertPreview';
 import { usePreview } from './PreviewRule';
@@ -17,6 +19,8 @@ export interface ExpressionEditorProps {
   onChange: (value: string) => void;
   dataSourceName: string; // will be a prometheus or loki datasource
   showPreviewAlertsButton: boolean;
+  lazyDefaultQuery?: AlertQuery;
+  preservePreviousValue: boolean;
 }
 
 export const ExpressionEditor: FC<ExpressionEditorProps> = ({
@@ -24,11 +28,28 @@ export const ExpressionEditor: FC<ExpressionEditorProps> = ({
   onChange,
   dataSourceName,
   showPreviewAlertsButton = true,
+  lazyDefaultQuery,
+  preservePreviousValue,
 }) => {
   const styles = useStyles2(getStyles);
 
   const { mapToValue, mapToQuery } = useQueryMappers(dataSourceName);
-  const dataQuery = mapToQuery({ refId: 'A', hide: false }, value);
+  const [dataQuery, setDataQuery] = useState(mapToQuery({ refId: 'A', hide: false }, value));
+  const defaultModel = lazyDefaultQuery?.model;
+  const previousDataSource = usePrevious(dataSourceName);
+
+  // New alert: update with default query once we have the lazy default
+  useEffect(() => {
+    !preservePreviousValue && defaultModel && setDataQuery((dataQuery) => ({ ...dataQuery, ...{ ...defaultModel } }));
+  }, [defaultModel, preservePreviousValue]);
+  // when data source is changed
+  useEffect(() => {
+    !!previousDataSource &&
+      previousDataSource !== dataSourceName &&
+      Boolean(dataSourceName) &&
+      defaultModel &&
+      setDataQuery((dataQuery) => ({ ...dataQuery, ...{ ...defaultModel } }));
+  }, [dataSourceName, defaultModel, previousDataSource]);
 
   const {
     error,
@@ -71,7 +92,7 @@ export const ExpressionEditor: FC<ExpressionEditorProps> = ({
   // The preview API returns arrays with empty elements when there are no firing alerts
   const previewHasAlerts = previewDataFrame && previewDataFrame.fields.some((field) => field.values.length > 0);
 
-  return (
+  return dataQuery ? (
     <>
       <DataSourcePluginContextProvider instanceSettings={dsi}>
         <QueryEditor
@@ -101,7 +122,7 @@ export const ExpressionEditor: FC<ExpressionEditorProps> = ({
         </div>
       )}
     </>
-  );
+  ) : null;
 };
 
 const getStyles = (theme: GrafanaTheme2) => ({

--- a/public/app/features/alerting/unified/components/rule-editor/QueryRows.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryRows.tsx
@@ -231,7 +231,25 @@ async function newModel(
   item: AlertQuery,
   settings: DataSourceInstanceSettings
 ): Promise<Omit<AlertQuery, 'datasource'>> {
-  const ds = await getDataSourceSrv().get(item.datasourceUid);
+  let ds;
+  try {
+    ds = await getDataSourceSrv().get(settings.uid); // get new ds
+  } catch (e) {
+    return {
+      refId: item.refId,
+      relativeTimeRange: item.relativeTimeRange,
+      queryType: '',
+      datasourceUid: settings.uid,
+      model: {
+        refId: item.refId,
+        hide: false,
+        datasource: {
+          type: settings.type,
+          uid: settings.uid,
+        },
+      },
+    };
+  }
   return {
     refId: item.refId,
     relativeTimeRange: item.relativeTimeRange,

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
@@ -80,10 +80,11 @@ export const QueryAndExpressionsStep: FC<Props> = ({
     runner.current.run(getValues('queries'));
   }, [getValues]);
 
+  const updateWithDefault = !editingExistingRule && !prefill;
   //once default queries is updated
   useEffect(() => {
-    !editingExistingRule && !isDirty && !prefill && lazyDefaultQueries && dispatch(setDataQueries(lazyDefaultQueries));
-  }, [lazyDefaultQueries, editingExistingRule, isDirty, prefill]);
+    updateWithDefault && !isDirty && lazyDefaultQueries && dispatch(setDataQueries(lazyDefaultQueries));
+  }, [lazyDefaultQueries, updateWithDefault, isDirty]);
 
   // whenever we update the queries we have to update the form too
   useEffect(() => {
@@ -211,6 +212,8 @@ export const QueryAndExpressionsStep: FC<Props> = ({
                   {...field}
                   dataSourceName={dataSourceName}
                   showPreviewAlertsButton={!isRecordingRuleType}
+                  lazyDefaultQuery={lazyDefaultQueries?.[0]}
+                  preservePreviousValue={!updateWithDefault}
                 />
               );
             }}

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
@@ -1,10 +1,10 @@
 import React, { FC, useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 
-import { LoadingState, PanelData } from '@grafana/data';
+import { CoreApp, LoadingState, PanelData } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Stack } from '@grafana/experimental';
-import { config } from '@grafana/runtime';
+import { config, getDataSourceSrv } from '@grafana/runtime';
 import { Alert, Button, Field, InputControl, Tooltip } from '@grafana/ui';
 import { isExpressionQuery } from 'app/features/expressions/guards';
 import { AlertQuery } from 'app/types/unified-alerting-dto';
@@ -176,6 +176,15 @@ export const QueryAndExpressionsStep: FC<Props> = ({ editingExistingRule, onData
     }
   }, [condition, queries, handleSetCondition]);
 
+  const onAddNewQuery = async () => {
+    const datasource = getDefaultOrFirstCompatibleDataSource();
+    if (!datasource) {
+      return;
+    }
+    const ds = await getDataSourceSrv().get(datasource.uid);
+    dispatch(addNewDataQuery({ ds: ds, defaultQuery: ds?.getDefaultQuery?.(CoreApp.UnifiedAlerting) }));
+  };
+
   return (
     <RuleEditorSection stepNo={2} title="Set a query and alert condition">
       <AlertType editingExistingRule={editingExistingRule} />
@@ -239,9 +248,7 @@ export const QueryAndExpressionsStep: FC<Props> = ({ editingExistingRule, onData
               <Button
                 type="button"
                 icon="plus"
-                onClick={() => {
-                  dispatch(addNewDataQuery());
-                }}
+                onClick={onAddNewQuery}
                 variant="secondary"
                 aria-label={selectors.components.QueryTab.addQuery}
                 disabled={noCompatibleDataSources}

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/__snapshots__/reducer.test.tsx.snap
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/__snapshots__/reducer.test.tsx.snap
@@ -66,14 +66,24 @@ exports[`Query and expressions reducer should add query 1`] = `
       "refId": "A",
     },
     {
-      "datasourceUid": "c8eceabb-0275-4108-8f03-8f74faf4bf6d",
+      "datasourceUid": "some uid",
       "model": {
         "datasource": {
-          "type": "prometheus",
-          "uid": "c8eceabb-0275-4108-8f03-8f74faf4bf6d",
+          "type": undefined,
+          "uid": "some uid",
         },
+        "datasourceUid": "",
         "hide": false,
+        "model": {
+          "expression": "THIS IS THE DEFAULT EXPRESSION",
+          "refId": "A",
+        },
+        "queryType": "",
         "refId": "B",
+        "relativeTimeRange": {
+          "from": 600,
+          "to": 0,
+        },
       },
       "queryType": "",
       "refId": "B",

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/reducer.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/reducer.test.tsx
@@ -1,4 +1,4 @@
-import { getDefaultRelativeTimeRange, RelativeTimeRange } from '@grafana/data';
+import { DataSourceApi, getDefaultRelativeTimeRange, PluginMeta, RelativeTimeRange } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime/src/services/__mocks__/dataSourceSrv';
 import {
   dataSource as expressionDatasource,
@@ -7,6 +7,9 @@ import {
 import { ExpressionQuery, ExpressionQueryType } from 'app/features/expressions/types';
 import { defaultCondition } from 'app/features/expressions/utils/expressionTypes';
 import { AlertQuery } from 'app/types/unified-alerting-dto';
+
+import { mockDataSource } from '../../../mocks';
+import * as dataSource from '../../../utils/datasource';
 
 import {
   addNewDataQuery,
@@ -48,6 +51,12 @@ const expressionQuery: AlertQuery = {
   refId: 'B',
   queryType: '',
 };
+
+const defaultDataSource = mockDataSource();
+const dataSourceMocked = jest.spyOn(dataSource, 'getDefaultOrFirstCompatibleDataSource');
+beforeAll(() => {
+  return dataSourceMocked.mockReturnValue(defaultDataSource);
+});
 
 describe('Query and expressions reducer', () => {
   it('should return initial state', () => {
@@ -96,7 +105,23 @@ describe('Query and expressions reducer', () => {
       queries: [alertQuery],
     };
 
-    const newState = queriesAndExpressionsReducer(initialState, addNewDataQuery());
+    const newDataSource: DataSourceApi = {
+      meta: { alerting: true } as unknown as PluginMeta,
+      name: 'some name',
+      uid: 'some uid',
+    } as unknown as DataSourceApi;
+
+    const defaultQuery: AlertQuery = {
+      refId: 'A',
+      queryType: '',
+      datasourceUid: '',
+      model: { refId: 'A', expression: 'THIS IS THE DEFAULT EXPRESSION' },
+      relativeTimeRange: getDefaultRelativeTimeRange(),
+    };
+    const newState = queriesAndExpressionsReducer(
+      initialState,
+      addNewDataQuery({ ds: newDataSource, defaultQuery: defaultQuery })
+    );
     expect(newState.queries).toHaveLength(2);
     expect(newState).toMatchSnapshot();
   });

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/reducer.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/reducer.ts
@@ -1,6 +1,12 @@
 import { createAction, createReducer } from '@reduxjs/toolkit';
 
-import { DataQuery, getDefaultRelativeTimeRange, RelativeTimeRange } from '@grafana/data';
+import {
+  DataQuery,
+  DataSourceApi,
+  DataSourceJsonData,
+  getDefaultRelativeTimeRange,
+  RelativeTimeRange,
+} from '@grafana/data';
 import { getNextRefIdChar } from 'app/core/utils/query';
 import { findDataSourceFromExpressionRecursive } from 'app/features/alerting/utils/dataSourceFromExpression';
 import {
@@ -12,7 +18,6 @@ import { ExpressionQuery, ExpressionQueryType } from 'app/features/expressions/t
 import { defaultCondition } from 'app/features/expressions/utils/expressionTypes';
 import { AlertQuery } from 'app/types/unified-alerting-dto';
 
-import { getDefaultOrFirstCompatibleDataSource } from '../../../utils/datasource';
 import { queriesWithUpdatedReferences, refIdExists } from '../util';
 
 export interface QueriesAndExpressionsState {
@@ -33,7 +38,10 @@ const initialState: QueriesAndExpressionsState = {
 };
 
 export const duplicateQuery = createAction<AlertQuery>('duplicateQuery');
-export const addNewDataQuery = createAction('addNewDataQuery');
+export const addNewDataQuery = createAction<{
+  ds: DataSourceApi<DataQuery, DataSourceJsonData, {}>;
+  defaultQuery: Partial<DataQuery> | undefined;
+}>('addNewDataQuery');
 export const setDataQueries = createAction<AlertQuery[]>('setDataQueries');
 
 export const addNewExpression = createAction('addNewExpression');
@@ -51,12 +59,8 @@ export const queriesAndExpressionsReducer = createReducer(initialState, (builder
     .addCase(duplicateQuery, (state, { payload }) => {
       state.queries = addQuery(state.queries, payload);
     })
-    .addCase(addNewDataQuery, (state) => {
-      const datasource = getDefaultOrFirstCompatibleDataSource();
-      if (!datasource) {
-        return;
-      }
-
+    .addCase(addNewDataQuery, (state, { payload }) => {
+      const datasource = payload.ds;
       state.queries = addQuery(state.queries, {
         datasourceUid: datasource.uid,
         model: {
@@ -65,6 +69,7 @@ export const queriesAndExpressionsReducer = createReducer(initialState, (builder
             type: datasource.type,
             uid: datasource.uid,
           },
+          ...payload.defaultQuery,
         },
       });
     })

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/reducer.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/reducer.ts
@@ -64,12 +64,12 @@ export const queriesAndExpressionsReducer = createReducer(initialState, (builder
       state.queries = addQuery(state.queries, {
         datasourceUid: datasource.uid,
         model: {
-          refId: '',
           datasource: {
             type: datasource.type,
             uid: datasource.uid,
           },
           ...payload.defaultQuery,
+          refId: '',
         },
       });
     })

--- a/public/app/features/alerting/unified/utils/rule-form.ts
+++ b/public/app/features/alerting/unified/utils/rule-form.ts
@@ -1,5 +1,8 @@
 import {
+  CoreApp,
   DataQuery,
+  DataSourceApi,
+  DataSourceJsonData,
   DataSourceRef,
   getDefaultRelativeTimeRange,
   IntervalValues,
@@ -199,9 +202,47 @@ export function recordingRulerRuleToRuleForm(
   };
 }
 
-export const getDefaultQueries = (): AlertQuery[] => {
+export const getDefaultQueriesAsync = async (): Promise<{
+  queries: AlertQuery[] | null;
+  ds?: DataSourceApi<DataQuery, DataSourceJsonData, {}>;
+}> => {
   const dataSource = getDefaultOrFirstCompatibleDataSource();
 
+  if (!dataSource) {
+    return { queries: [...getDefaultExpressions('A', 'B')] };
+  }
+  const relativeTimeRange = getDefaultRelativeTimeRange();
+
+  let ds;
+  try {
+    ds = await getDataSourceSrv().get(dataSource.uid);
+  } catch (error) {
+    console.log(error);
+    return { queries: [...getDefaultExpressions('A', 'B')] };
+  }
+
+  return {
+    queries: [
+      {
+        refId: 'A',
+        datasourceUid: dataSource.uid,
+        queryType: '',
+        relativeTimeRange,
+        model: {
+          refId: 'A',
+          hide: false,
+          ...ds?.getDefaultQuery?.(CoreApp.UnifiedAlerting),
+        },
+      },
+      ...getDefaultExpressions('B', 'C'),
+    ],
+    ds: ds,
+  };
+};
+
+// Needed to init default queries before the async call
+export const getInitialDefaultQueries = (): AlertQuery[] => {
+  const dataSource = getDefaultOrFirstCompatibleDataSource();
   if (!dataSource) {
     return [...getDefaultExpressions('A', 'B')];
   }
@@ -218,7 +259,6 @@ export const getDefaultQueries = (): AlertQuery[] => {
         hide: false,
       },
     },
-    ...getDefaultExpressions('B', 'C'),
   ];
 };
 

--- a/public/app/features/alerting/unified/utils/rule-form.ts
+++ b/public/app/features/alerting/unified/utils/rule-form.ts
@@ -217,7 +217,6 @@ export const getDefaultQueriesAsync = async (): Promise<{
   try {
     ds = await getDataSourceSrv().get(dataSource.uid);
   } catch (error) {
-    console.log(error);
     return { queries: [...getDefaultExpressions('A', 'B')] };
   }
 


### PR DESCRIPTION
**What is this feature?**

This PR sets default query from the data source when creating new alert rule, changing data source or adding a new query in the alert rule form.

- When creating a new alert rule => uses default query in case of existing.
- When changing data source => in case of different type => uses default query in case of existing, otherwise, clears the query .
- When creating a new query => uses default query in case of existing

 **Why do we need this feature?**

Data sources can include a default value for query that should be used in the cases described before.

**Who is this feature for?**

All users

**Which issue(s) does this PR fix?**:

Fixes [#61280](https://github.com/grafana/grafana/issues/63585)





