### PR TITLE
RemoteCache: Fix null pointer exception in redis cache

### DIFF
--- a/pkg/infra/remotecache/redis_storage.go
+++ b/pkg/infra/remotecache/redis_storage.go
@@ -107,11 +107,10 @@ func (s *redisStorage) SetByteArray(ctx context.Context, key string, data []byte
 func (s *redisStorage) Get(ctx context.Context, key string) (interface{}, error) {
 	v, err := s.GetByteArray(ctx, key)
 
-	if err.Error() == "EOF" {
-		return nil, ErrCacheItemNotFound
-	}
-
 	if err != nil {
+		if err.Error() == "EOF" {
+			return nil, ErrCacheItemNotFound
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
Reports were failing because a null pointer in redis storage.