### PR TITLE
Alerting: Add for-like field to error evaluations

### DIFF
--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -482,9 +482,6 @@ func PatchPartialAlertRule(existingRule *AlertRule, ruleToPatch *AlertRuleWithOp
 	if ruleToPatch.For == -1 {
 		ruleToPatch.For = existingRule.For
 	}
-	if ruleToPatch.ForError == -1 {
-		ruleToPatch.ForError = existingRule.ForError
-	}
 	if !ruleToPatch.HasPause {
 		ruleToPatch.IsPaused = existingRule.IsPaused
 	}

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -157,6 +157,7 @@ type AlertRule struct {
 	// ideally this field should have been apimodels.ApiDuration
 	// but this is currently not possible because of circular dependencies
 	For         time.Duration
+	ForError    time.Duration
 	Annotations map[string]string
 	Labels      map[string]string
 	IsPaused    bool
@@ -353,6 +354,7 @@ type AlertRuleVersion struct {
 	// ideally this field should have been apimodels.ApiDuration
 	// but this is currently not possible because of circular dependencies
 	For         time.Duration
+	ForError    time.Duration
 	Annotations map[string]string
 	Labels      map[string]string
 	IsPaused    bool
@@ -479,6 +481,9 @@ func PatchPartialAlertRule(existingRule *AlertRule, ruleToPatch *AlertRuleWithOp
 	}
 	if ruleToPatch.For == -1 {
 		ruleToPatch.For = existingRule.For
+	}
+	if ruleToPatch.ForError == -1 {
+		ruleToPatch.ForError = existingRule.ForError
 	}
 	if !ruleToPatch.HasPause {
 		ruleToPatch.IsPaused = existingRule.IsPaused

--- a/pkg/services/ngalert/models/alert_rule_test.go
+++ b/pkg/services/ngalert/models/alert_rule_test.go
@@ -200,6 +200,12 @@ func TestPatchPartialAlertRule(t *testing.T) {
 				},
 			},
 			{
+				name: "ForError is -1",
+				mutator: func(r *AlertRuleWithOptionals) {
+					r.ForError = -1
+				},
+			},
+			{
 				name: "IsPaused did not come in request",
 				mutator: func(r *AlertRuleWithOptionals) {
 					r.IsPaused = true
@@ -441,6 +447,13 @@ func TestDiff(t *testing.T) {
 			assert.Len(t, diff, 1)
 			assert.Equal(t, rule1.For, diff[0].Left.Interface())
 			assert.Equal(t, rule2.For, diff[0].Right.Interface())
+			difCnt++
+		}
+		if rule1.ForError != rule2.ForError {
+			diff := diffs.GetDiffsForField("ForError")
+			assert.Len(t, diff, 1)
+			assert.Equal(t, rule1.ForError, diff[0].Left.Interface())
+			assert.Equal(t, rule2.ForError, diff[0].Right.Interface())
 			difCnt++
 		}
 		if rule1.RuleGroupIndex != rule2.RuleGroupIndex {

--- a/pkg/services/ngalert/models/alert_rule_test.go
+++ b/pkg/services/ngalert/models/alert_rule_test.go
@@ -443,6 +443,13 @@ func TestDiff(t *testing.T) {
 			assert.Equal(t, rule2.For, diff[0].Right.Interface())
 			difCnt++
 		}
+		if rule1.ForError != rule2.ForError {
+			diff := diffs.GetDiffsForField("ForError")
+			assert.Len(t, diff, 1)
+			assert.Equal(t, rule1.ForError, diff[0].Left.Interface())
+			assert.Equal(t, rule2.ForError, diff[0].Right.Interface())
+			difCnt++
+		}
 		if rule1.RuleGroupIndex != rule2.RuleGroupIndex {
 			diff := diffs.GetDiffsForField("RuleGroupIndex")
 			assert.Len(t, diff, 1)

--- a/pkg/services/ngalert/models/alert_rule_test.go
+++ b/pkg/services/ngalert/models/alert_rule_test.go
@@ -200,12 +200,6 @@ func TestPatchPartialAlertRule(t *testing.T) {
 				},
 			},
 			{
-				name: "ForError is -1",
-				mutator: func(r *AlertRuleWithOptionals) {
-					r.ForError = -1
-				},
-			},
-			{
 				name: "IsPaused did not come in request",
 				mutator: func(r *AlertRuleWithOptionals) {
 					r.IsPaused = true
@@ -447,13 +441,6 @@ func TestDiff(t *testing.T) {
 			assert.Len(t, diff, 1)
 			assert.Equal(t, rule1.For, diff[0].Left.Interface())
 			assert.Equal(t, rule2.For, diff[0].Right.Interface())
-			difCnt++
-		}
-		if rule1.ForError != rule2.ForError {
-			diff := diffs.GetDiffsForField("ForError")
-			assert.Len(t, diff, 1)
-			assert.Equal(t, rule1.ForError, diff[0].Left.Interface())
-			assert.Equal(t, rule2.ForError, diff[0].Right.Interface())
 			difCnt++
 		}
 		if rule1.RuleGroupIndex != rule2.RuleGroupIndex {

--- a/pkg/services/ngalert/models/instance.go
+++ b/pkg/services/ngalert/models/instance.go
@@ -43,8 +43,8 @@ const (
 type InstanceCauseType string
 
 const (
-	// InstanceNoCause is for any state that does not come from firing or error.
-	InstanceNoCause InstanceCauseType = ""
+	// InstanceCauseNone is for any state that does not come from firing or error.
+	InstanceCauseNone InstanceCauseType = ""
 	// InstanceCauseFiring is to identify states caused by firing states.
 	InstanceCauseFiring InstanceCauseType = "Firing"
 	// InstanceCauseError is to identify states caused by erroring states.
@@ -64,7 +64,7 @@ func (i InstanceStateType) IsValid() bool {
 
 // IsValid checks that the value of InstanceCauseType is a valid string.
 func (i InstanceCauseType) IsValid() bool {
-	return i == InstanceNoCause ||
+	return i == InstanceCauseNone ||
 		i == InstanceCauseFiring ||
 		i == InstanceCauseError ||
 		i == InstanceCauseNoData
@@ -73,7 +73,7 @@ func (i InstanceCauseType) IsValid() bool {
 // validateCurrentStateAndCurrentPendingState checks that the possible combinations of CurrentState and
 // CurrentCause are valid.
 func validateCurrentStateAndCurrentPendingState(cState InstanceStateType, cCause InstanceCauseType) bool {
-	return (cState == InstanceStateNormal && (cCause == InstanceNoCause || cCause == InstanceCauseError || cCause == InstanceCauseNoData)) ||
+	return (cState == InstanceStateNormal && (cCause == InstanceCauseNone || cCause == InstanceCauseError || cCause == InstanceCauseNoData)) ||
 		(cState == InstanceStateFiring && (cCause == InstanceCauseFiring || cCause == InstanceCauseError || cCause == InstanceCauseNoData)) ||
 		(cState == InstanceStateNoData && cCause == InstanceCauseNoData) ||
 		(cState == InstanceStateError && cCause == InstanceCauseError) ||

--- a/pkg/services/ngalert/models/instance_test.go
+++ b/pkg/services/ngalert/models/instance_test.go
@@ -53,37 +53,41 @@ func buildTestInstanceStateTypeIsValidName(instanceType InstanceStateType, expec
 	return fmt.Sprintf("%q should not be valid", instanceType)
 }
 
-func TestInstancePendingStateType_IsValid(t *testing.T) {
+func TestInstanceCauseType_IsValid(t *testing.T) {
 	testCases := []struct {
-		instancePendingType InstancePendingStateType
-		expectedValidity    bool
+		instanceCauseType InstanceCauseType
+		expectedValidity  bool
 	}{
 		{
-			instancePendingType: InstancePendingStateEmpty,
-			expectedValidity:    true,
+			instanceCauseType: InstanceNoCause,
+			expectedValidity:  true,
 		},
 		{
-			instancePendingType: InstancePendingStateFiring,
-			expectedValidity:    true,
+			instanceCauseType: InstanceCauseFiring,
+			expectedValidity:  true,
 		},
 		{
-			instancePendingType: InstancePendingStateError,
-			expectedValidity:    true,
+			instanceCauseType: InstanceCauseError,
+			expectedValidity:  true,
 		},
 		{
-			instancePendingType: InstancePendingStateType("notAValidInstancePendingStateType"),
-			expectedValidity:    false,
+			instanceCauseType: InstanceCauseNoData,
+			expectedValidity:  true,
+		},
+		{
+			instanceCauseType: InstanceCauseType("notAValidInstancePendingStateType"),
+			expectedValidity:  false,
 		},
 	}
 
 	for _, tc := range testCases {
-		t.Run(buildTestInstancePendingStateTypeIsValidName(tc.instancePendingType, tc.expectedValidity), func(t *testing.T) {
-			require.Equal(t, tc.expectedValidity, tc.instancePendingType.IsValid())
+		t.Run(buildTestInstancePendingStateTypeIsValidName(tc.instanceCauseType, tc.expectedValidity), func(t *testing.T) {
+			require.Equal(t, tc.expectedValidity, tc.instanceCauseType.IsValid())
 		})
 	}
 }
 
-func buildTestInstancePendingStateTypeIsValidName(instancePendingType InstancePendingStateType, expectedValidity bool) string {
+func buildTestInstancePendingStateTypeIsValidName(instancePendingType InstanceCauseType, expectedValidity bool) string {
 	if expectedValidity {
 		return fmt.Sprintf("%q should be valid", instancePendingType)
 	}
@@ -93,83 +97,108 @@ func buildTestInstancePendingStateTypeIsValidName(instancePendingType InstancePe
 func TestAlertInstance_AreCurrentStateAndCurrentPendingStateValidTogether(t *testing.T) {
 	testCases := []struct {
 		currentState        InstanceStateType
-		currentPendingState InstancePendingStateType
+		currentPendingState InstanceCauseType
 		expectedValidity    bool
 	}{
 		{
 			currentState:        InstanceStateNormal,
-			currentPendingState: InstancePendingStateEmpty,
+			currentPendingState: InstanceNoCause,
 			expectedValidity:    true,
 		},
 		{
 			currentState:        InstanceStateNormal,
-			currentPendingState: InstancePendingStateFiring,
+			currentPendingState: InstanceCauseFiring,
 			expectedValidity:    false,
 		},
 		{
 			currentState:        InstanceStateNormal,
-			currentPendingState: InstancePendingStateError,
-			expectedValidity:    false,
+			currentPendingState: InstanceCauseError,
+			expectedValidity:    true,
 		},
 		{
-			currentState:        InstanceStateFiring,
-			currentPendingState: InstancePendingStateEmpty,
+			currentState:        InstanceStateNormal,
+			currentPendingState: InstanceCauseNoData,
 			expectedValidity:    true,
 		},
 		{
 			currentState:        InstanceStateFiring,
-			currentPendingState: InstancePendingStateFiring,
+			currentPendingState: InstanceNoCause,
 			expectedValidity:    false,
 		},
 		{
 			currentState:        InstanceStateFiring,
-			currentPendingState: InstancePendingStateError,
-			expectedValidity:    false,
+			currentPendingState: InstanceCauseFiring,
+			expectedValidity:    true,
 		},
 		{
-			currentState:        InstanceStateError,
-			currentPendingState: InstancePendingStateEmpty,
+			currentState:        InstanceStateFiring,
+			currentPendingState: InstanceCauseError,
+			expectedValidity:    true,
+		},
+		{
+			currentState:        InstanceStateFiring,
+			currentPendingState: InstanceCauseNoData,
 			expectedValidity:    true,
 		},
 		{
 			currentState:        InstanceStateError,
-			currentPendingState: InstancePendingStateFiring,
+			currentPendingState: InstanceNoCause,
 			expectedValidity:    false,
 		},
 		{
 			currentState:        InstanceStateError,
-			currentPendingState: InstancePendingStateError,
+			currentPendingState: InstanceCauseFiring,
+			expectedValidity:    false,
+		},
+		{
+			currentState:        InstanceStateError,
+			currentPendingState: InstanceCauseError,
+			expectedValidity:    true,
+		},
+		{
+			currentState:        InstanceStateError,
+			currentPendingState: InstanceCauseNoData,
 			expectedValidity:    false,
 		},
 		{
 			currentState:        InstanceStateNoData,
-			currentPendingState: InstancePendingStateEmpty,
-			expectedValidity:    true,
-		},
-		{
-			currentState:        InstanceStateNoData,
-			currentPendingState: InstancePendingStateFiring,
+			currentPendingState: InstanceNoCause,
 			expectedValidity:    false,
 		},
 		{
 			currentState:        InstanceStateNoData,
-			currentPendingState: InstancePendingStateError,
+			currentPendingState: InstanceCauseFiring,
 			expectedValidity:    false,
 		},
 		{
-			currentState:        InstanceStatePending,
-			currentPendingState: InstancePendingStateEmpty,
+			currentState:        InstanceStateNoData,
+			currentPendingState: InstanceCauseError,
 			expectedValidity:    false,
 		},
 		{
-			currentState:        InstanceStatePending,
-			currentPendingState: InstancePendingStateFiring,
+			currentState:        InstanceStateNoData,
+			currentPendingState: InstanceCauseNoData,
 			expectedValidity:    true,
 		},
 		{
 			currentState:        InstanceStatePending,
-			currentPendingState: InstancePendingStateError,
+			currentPendingState: InstanceNoCause,
+			expectedValidity:    false,
+		},
+		{
+			currentState:        InstanceStatePending,
+			currentPendingState: InstanceCauseFiring,
 			expectedValidity:    true,
+		},
+		{
+			currentState:        InstanceStatePending,
+			currentPendingState: InstanceCauseError,
+			expectedValidity:    true,
+		},
+		{
+			currentState:        InstanceStatePending,
+			currentPendingState: InstanceCauseNoData,
+			expectedValidity:    false,
 		},
 	}
 
@@ -180,11 +209,11 @@ func TestAlertInstance_AreCurrentStateAndCurrentPendingStateValidTogether(t *tes
 	}
 }
 
-func buildTestValidateCurrentStateAndCurrentPendingStateName(cState InstanceStateType, cPendingState InstancePendingStateType, expectedValidity bool) string {
+func buildTestValidateCurrentStateAndCurrentPendingStateName(cState InstanceStateType, cPendingState InstanceCauseType, expectedValidity bool) string {
 	if expectedValidity {
-		return fmt.Sprintf("CurrentState %q and CurrentPendingState %q should be valid", cState, cPendingState)
+		return fmt.Sprintf("CurrentState %q and CurrentCause %q should be valid", cState, cPendingState)
 	}
-	return fmt.Sprintf("CurrentState %q and CurrentPendingState %q should not be valid", cState, cPendingState)
+	return fmt.Sprintf("CurrentState %q and CurrentCause %q should not be valid", cState, cPendingState)
 }
 
 func TestValidateAlertInstance(t *testing.T) {
@@ -193,7 +222,7 @@ func TestValidateAlertInstance(t *testing.T) {
 		orgId               int64
 		uid                 string
 		currentState        InstanceStateType
-		currentPendingState InstancePendingStateType
+		currentPendingState InstanceCauseType
 		err                 error
 	}{
 		{
@@ -201,7 +230,7 @@ func TestValidateAlertInstance(t *testing.T) {
 			orgId:               0,
 			uid:                 "validUid",
 			currentState:        InstanceStateNormal,
-			currentPendingState: InstancePendingStateEmpty,
+			currentPendingState: InstanceNoCause,
 			err:                 errors.New("alert instance is invalid due to missing alert rule organisation"),
 		},
 		{
@@ -209,7 +238,7 @@ func TestValidateAlertInstance(t *testing.T) {
 			orgId:               1,
 			uid:                 "",
 			currentState:        InstanceStateNormal,
-			currentPendingState: InstancePendingStateEmpty,
+			currentPendingState: InstanceNoCause,
 			err:                 errors.New("alert instance is invalid due to missing alert rule uid"),
 		},
 		{
@@ -217,31 +246,31 @@ func TestValidateAlertInstance(t *testing.T) {
 			orgId:               1,
 			uid:                 "validUid",
 			currentState:        InstanceStateType("notAValidType"),
-			currentPendingState: InstancePendingStateEmpty,
+			currentPendingState: InstanceNoCause,
 			err:                 errors.New("alert instance is invalid because the state \"notAValidType\" is invalid"),
 		},
 		{
-			name:                "fails if current pending state is not valid",
+			name:                "fails if current cause is not valid",
 			orgId:               1,
 			uid:                 "validUid",
 			currentState:        InstanceStateNormal,
-			currentPendingState: InstancePendingStateType("notAValidType"),
-			err:                 errors.New("alert instance is invalid because the pending state \"notAValidType\" is invalid"),
+			currentPendingState: InstanceCauseType("notAValidType"),
+			err:                 errors.New("alert instance is invalid because the cause \"notAValidType\" is invalid"),
 		},
 		{
-			name:                "fails if current state and current pending state are not a valid pair",
+			name:                "fails if current state and current cause are not a valid pair",
 			orgId:               1,
 			uid:                 "validUid",
 			currentState:        InstanceStateNormal,
-			currentPendingState: InstancePendingStateFiring,
-			err:                 errors.New("alert instance is invalid because the state \"Normal\" and pending state \"AlertingPending\" are not a valid pair"),
+			currentPendingState: InstanceCauseFiring,
+			err:                 errors.New("alert instance is invalid because the state \"Normal\" and cause \"Firing\" are not a valid pair"),
 		},
 		{
 			name:                "ok if validated fields are correct",
 			orgId:               1,
 			uid:                 "validUid",
 			currentState:        InstanceStateNormal,
-			currentPendingState: InstancePendingStateEmpty,
+			currentPendingState: InstanceNoCause,
 			err:                 nil,
 		},
 	}
@@ -252,7 +281,7 @@ func TestValidateAlertInstance(t *testing.T) {
 				instance.AlertInstanceKey.RuleOrgID = tc.orgId
 				instance.AlertInstanceKey.RuleUID = tc.uid
 				instance.CurrentState = tc.currentState
-				instance.CurrentPendingState = tc.currentPendingState
+				instance.CurrentCause = tc.currentPendingState
 			})
 
 			require.Equal(t, tc.err, ValidateAlertInstance(*instance))

--- a/pkg/services/ngalert/models/instance_test.go
+++ b/pkg/services/ngalert/models/instance_test.go
@@ -53,41 +53,196 @@ func buildTestInstanceStateTypeIsValidName(instanceType InstanceStateType, expec
 	return fmt.Sprintf("%q should not be valid", instanceType)
 }
 
-func TestValidateAlertInstance(t *testing.T) {
+func TestInstancePendingStateType_IsValid(t *testing.T) {
 	testCases := []struct {
-		name         string
-		orgId        int64
-		uid          string
-		currentState InstanceStateType
-		err          error
+		instancePendingType InstancePendingStateType
+		expectedValidity    bool
 	}{
 		{
-			name:         "fails if orgID is empty",
-			orgId:        0,
-			uid:          "validUid",
-			currentState: InstanceStateNormal,
-			err:          errors.New("alert instance is invalid due to missing alert rule organisation"),
+			instancePendingType: InstancePendingStateEmpty,
+			expectedValidity:    true,
 		},
 		{
-			name:         "fails if uid is empty",
-			orgId:        1,
-			uid:          "",
-			currentState: InstanceStateNormal,
-			err:          errors.New("alert instance is invalid due to missing alert rule uid"),
+			instancePendingType: InstancePendingStateFiring,
+			expectedValidity:    true,
 		},
 		{
-			name:         "fails if current state is not valid",
-			orgId:        1,
-			uid:          "validUid",
-			currentState: InstanceStateType("notAValidType"),
-			err:          errors.New("alert instance is invalid because the state 'notAValidType' is invalid"),
+			instancePendingType: InstancePendingStateError,
+			expectedValidity:    true,
 		},
 		{
-			name:         "ok if validated fields are correct",
-			orgId:        1,
-			uid:          "validUid",
-			currentState: InstanceStateNormal,
-			err:          nil,
+			instancePendingType: InstancePendingStateType("notAValidInstancePendingStateType"),
+			expectedValidity:    false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(buildTestInstancePendingStateTypeIsValidName(tc.instancePendingType, tc.expectedValidity), func(t *testing.T) {
+			require.Equal(t, tc.expectedValidity, tc.instancePendingType.IsValid())
+		})
+	}
+}
+
+func buildTestInstancePendingStateTypeIsValidName(instancePendingType InstancePendingStateType, expectedValidity bool) string {
+	if expectedValidity {
+		return fmt.Sprintf("%q should be valid", instancePendingType)
+	}
+	return fmt.Sprintf("%q should not be valid", instancePendingType)
+}
+
+func TestAlertInstance_AreCurrentStateAndCurrentPendingStateValidTogether(t *testing.T) {
+	testCases := []struct {
+		currentState        InstanceStateType
+		currentPendingState InstancePendingStateType
+		expectedValidity    bool
+	}{
+		{
+			currentState:        InstanceStateNormal,
+			currentPendingState: InstancePendingStateEmpty,
+			expectedValidity:    true,
+		},
+		{
+			currentState:        InstanceStateNormal,
+			currentPendingState: InstancePendingStateFiring,
+			expectedValidity:    false,
+		},
+		{
+			currentState:        InstanceStateNormal,
+			currentPendingState: InstancePendingStateError,
+			expectedValidity:    false,
+		},
+		{
+			currentState:        InstanceStateFiring,
+			currentPendingState: InstancePendingStateEmpty,
+			expectedValidity:    true,
+		},
+		{
+			currentState:        InstanceStateFiring,
+			currentPendingState: InstancePendingStateFiring,
+			expectedValidity:    false,
+		},
+		{
+			currentState:        InstanceStateFiring,
+			currentPendingState: InstancePendingStateError,
+			expectedValidity:    false,
+		},
+		{
+			currentState:        InstanceStateError,
+			currentPendingState: InstancePendingStateEmpty,
+			expectedValidity:    true,
+		},
+		{
+			currentState:        InstanceStateError,
+			currentPendingState: InstancePendingStateFiring,
+			expectedValidity:    false,
+		},
+		{
+			currentState:        InstanceStateError,
+			currentPendingState: InstancePendingStateError,
+			expectedValidity:    false,
+		},
+		{
+			currentState:        InstanceStateNoData,
+			currentPendingState: InstancePendingStateEmpty,
+			expectedValidity:    true,
+		},
+		{
+			currentState:        InstanceStateNoData,
+			currentPendingState: InstancePendingStateFiring,
+			expectedValidity:    false,
+		},
+		{
+			currentState:        InstanceStateNoData,
+			currentPendingState: InstancePendingStateError,
+			expectedValidity:    false,
+		},
+		{
+			currentState:        InstanceStatePending,
+			currentPendingState: InstancePendingStateEmpty,
+			expectedValidity:    false,
+		},
+		{
+			currentState:        InstanceStatePending,
+			currentPendingState: InstancePendingStateFiring,
+			expectedValidity:    true,
+		},
+		{
+			currentState:        InstanceStatePending,
+			currentPendingState: InstancePendingStateError,
+			expectedValidity:    true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(buildTestValidateCurrentStateAndCurrentPendingStateName(tc.currentState, tc.currentPendingState, tc.expectedValidity), func(t *testing.T) {
+			require.Equal(t, tc.expectedValidity, validateCurrentStateAndCurrentPendingState(tc.currentState, tc.currentPendingState))
+		})
+	}
+}
+
+func buildTestValidateCurrentStateAndCurrentPendingStateName(cState InstanceStateType, cPendingState InstancePendingStateType, expectedValidity bool) string {
+	if expectedValidity {
+		return fmt.Sprintf("CurrentState %q and CurrentPendingState %q should be valid", cState, cPendingState)
+	}
+	return fmt.Sprintf("CurrentState %q and CurrentPendingState %q should not be valid", cState, cPendingState)
+}
+
+func TestValidateAlertInstance(t *testing.T) {
+	testCases := []struct {
+		name                string
+		orgId               int64
+		uid                 string
+		currentState        InstanceStateType
+		currentPendingState InstancePendingStateType
+		err                 error
+	}{
+		{
+			name:                "fails if orgID is empty",
+			orgId:               0,
+			uid:                 "validUid",
+			currentState:        InstanceStateNormal,
+			currentPendingState: InstancePendingStateEmpty,
+			err:                 errors.New("alert instance is invalid due to missing alert rule organisation"),
+		},
+		{
+			name:                "fails if uid is empty",
+			orgId:               1,
+			uid:                 "",
+			currentState:        InstanceStateNormal,
+			currentPendingState: InstancePendingStateEmpty,
+			err:                 errors.New("alert instance is invalid due to missing alert rule uid"),
+		},
+		{
+			name:                "fails if current state is not valid",
+			orgId:               1,
+			uid:                 "validUid",
+			currentState:        InstanceStateType("notAValidType"),
+			currentPendingState: InstancePendingStateEmpty,
+			err:                 errors.New("alert instance is invalid because the state \"notAValidType\" is invalid"),
+		},
+		{
+			name:                "fails if current pending state is not valid",
+			orgId:               1,
+			uid:                 "validUid",
+			currentState:        InstanceStateNormal,
+			currentPendingState: InstancePendingStateType("notAValidType"),
+			err:                 errors.New("alert instance is invalid because the pending state \"notAValidType\" is invalid"),
+		},
+		{
+			name:                "fails if current state and current pending state are not a valid pair",
+			orgId:               1,
+			uid:                 "validUid",
+			currentState:        InstanceStateNormal,
+			currentPendingState: InstancePendingStateFiring,
+			err:                 errors.New("alert instance is invalid because the state \"Normal\" and pending state \"AlertingPending\" are not a valid pair"),
+		},
+		{
+			name:                "ok if validated fields are correct",
+			orgId:               1,
+			uid:                 "validUid",
+			currentState:        InstanceStateNormal,
+			currentPendingState: InstancePendingStateEmpty,
+			err:                 nil,
 		},
 	}
 
@@ -97,6 +252,7 @@ func TestValidateAlertInstance(t *testing.T) {
 				instance.AlertInstanceKey.RuleOrgID = tc.orgId
 				instance.AlertInstanceKey.RuleUID = tc.uid
 				instance.CurrentState = tc.currentState
+				instance.CurrentPendingState = tc.currentPendingState
 			})
 
 			require.Equal(t, tc.err, ValidateAlertInstance(*instance))

--- a/pkg/services/ngalert/models/instance_test.go
+++ b/pkg/services/ngalert/models/instance_test.go
@@ -2,7 +2,6 @@ package models
 
 import (
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -10,210 +9,223 @@ import (
 
 func TestInstanceStateType_IsValid(t *testing.T) {
 	testCases := []struct {
-		instanceType     InstanceStateType
-		expectedValidity bool
+		name         string
+		instanceType InstanceStateType
+		expected     bool
 	}{
 		{
-			instanceType:     InstanceStateFiring,
-			expectedValidity: true,
+			name:         "\"Alerting\" should be valid",
+			instanceType: InstanceStateFiring,
+			expected:     true,
 		},
 		{
-			instanceType:     InstanceStateNormal,
-			expectedValidity: true,
+			name:         "\"Normal\" should be valid",
+			instanceType: InstanceStateNormal,
+			expected:     true,
 		},
 		{
-			instanceType:     InstanceStatePending,
-			expectedValidity: true,
+			name:         "\"Pending\" should be valid",
+			instanceType: InstanceStatePending,
+			expected:     true,
 		},
 		{
-			instanceType:     InstanceStateNoData,
-			expectedValidity: true,
+			name:         "\"NoData\" should be valid",
+			instanceType: InstanceStateNoData,
+			expected:     true,
 		},
 		{
-			instanceType:     InstanceStateError,
-			expectedValidity: true,
+			name:         "\"Error\" should be valid",
+			instanceType: InstanceStateError,
+			expected:     true,
 		},
 		{
-			instanceType:     InstanceStateType("notAValidInstanceStateType"),
-			expectedValidity: false,
+			name:         "\"notAValidInstanceStateType\" should not be valid",
+			instanceType: InstanceStateType("notAValidInstanceStateType"),
+			expected:     false,
 		},
 	}
 
 	for _, tc := range testCases {
-		t.Run(buildTestInstanceStateTypeIsValidName(tc.instanceType, tc.expectedValidity), func(t *testing.T) {
-			require.Equal(t, tc.expectedValidity, tc.instanceType.IsValid())
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, tc.instanceType.IsValid())
 		})
 	}
-}
-
-func buildTestInstanceStateTypeIsValidName(instanceType InstanceStateType, expectedValidity bool) string {
-	if expectedValidity {
-		return fmt.Sprintf("%q should be valid", instanceType)
-	}
-	return fmt.Sprintf("%q should not be valid", instanceType)
 }
 
 func TestInstanceCauseType_IsValid(t *testing.T) {
 	testCases := []struct {
+		name              string
 		instanceCauseType InstanceCauseType
-		expectedValidity  bool
+		expected          bool
 	}{
 		{
-			instanceCauseType: InstanceNoCause,
-			expectedValidity:  true,
+			name:              "\"\" should be valid",
+			instanceCauseType: InstanceCauseNone,
+			expected:          true,
 		},
 		{
+			name:              "\"Firing\" should be valid",
 			instanceCauseType: InstanceCauseFiring,
-			expectedValidity:  true,
+			expected:          true,
 		},
 		{
+			name:              "\"Error\" should be valid",
 			instanceCauseType: InstanceCauseError,
-			expectedValidity:  true,
+			expected:          true,
 		},
 		{
+			name:              "\"NoData\" should be valid",
 			instanceCauseType: InstanceCauseNoData,
-			expectedValidity:  true,
+			expected:          true,
 		},
 		{
+			name:              "\"notAValidInstancePendingStateType\" should not be valid",
 			instanceCauseType: InstanceCauseType("notAValidInstancePendingStateType"),
-			expectedValidity:  false,
+			expected:          false,
 		},
 	}
 
 	for _, tc := range testCases {
-		t.Run(buildTestInstancePendingStateTypeIsValidName(tc.instanceCauseType, tc.expectedValidity), func(t *testing.T) {
-			require.Equal(t, tc.expectedValidity, tc.instanceCauseType.IsValid())
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, tc.instanceCauseType.IsValid())
 		})
 	}
-}
-
-func buildTestInstancePendingStateTypeIsValidName(instancePendingType InstanceCauseType, expectedValidity bool) string {
-	if expectedValidity {
-		return fmt.Sprintf("%q should be valid", instancePendingType)
-	}
-	return fmt.Sprintf("%q should not be valid", instancePendingType)
 }
 
 func TestAlertInstance_AreCurrentStateAndCurrentPendingStateValidTogether(t *testing.T) {
 	testCases := []struct {
+		name                string
 		currentState        InstanceStateType
 		currentPendingState InstanceCauseType
-		expectedValidity    bool
+		expected            bool
 	}{
 		{
+			name:                "CurrentState \"Normal\" and CurrentCause \"\" should be valid",
 			currentState:        InstanceStateNormal,
-			currentPendingState: InstanceNoCause,
-			expectedValidity:    true,
+			currentPendingState: InstanceCauseNone,
+			expected:            true,
 		},
 		{
+			name:                "CurrentState \"Normal\" and CurrentCause \"Firing\" should not be valid",
 			currentState:        InstanceStateNormal,
 			currentPendingState: InstanceCauseFiring,
-			expectedValidity:    false,
+			expected:            false,
 		},
 		{
+			name:                "CurrentState \"Normal\" and CurrentCause \"Error\" should be valid",
 			currentState:        InstanceStateNormal,
 			currentPendingState: InstanceCauseError,
-			expectedValidity:    true,
+			expected:            true,
 		},
 		{
+			name:                "CurrentState \"Normal\" and CurrentCause \"NoData\" should be valid",
 			currentState:        InstanceStateNormal,
 			currentPendingState: InstanceCauseNoData,
-			expectedValidity:    true,
+			expected:            true,
 		},
 		{
+			name:                "CurrentState \"Alerting\" and CurrentCause \"\" should not be valid",
 			currentState:        InstanceStateFiring,
-			currentPendingState: InstanceNoCause,
-			expectedValidity:    false,
+			currentPendingState: InstanceCauseNone,
+			expected:            false,
 		},
 		{
+			name:                "CurrentState \"Alerting\" and CurrentCause \"Firing\" should be valid",
 			currentState:        InstanceStateFiring,
 			currentPendingState: InstanceCauseFiring,
-			expectedValidity:    true,
+			expected:            true,
 		},
 		{
+			name:                "CurrentState \"Alerting\" and CurrentCause \"Error\" should be valid",
 			currentState:        InstanceStateFiring,
 			currentPendingState: InstanceCauseError,
-			expectedValidity:    true,
+			expected:            true,
 		},
 		{
+			name:                "CurrentState \"Alerting\" and CurrentCause \"NoData\" should be valid",
 			currentState:        InstanceStateFiring,
 			currentPendingState: InstanceCauseNoData,
-			expectedValidity:    true,
+			expected:            true,
 		},
 		{
+			name:                "CurrentState \"Error\" and CurrentCause \"\" should not be valid",
 			currentState:        InstanceStateError,
-			currentPendingState: InstanceNoCause,
-			expectedValidity:    false,
+			currentPendingState: InstanceCauseNone,
+			expected:            false,
 		},
 		{
+			name:                "CurrentState \"Error\" and CurrentCause \"Firing\" should not be valid",
 			currentState:        InstanceStateError,
 			currentPendingState: InstanceCauseFiring,
-			expectedValidity:    false,
+			expected:            false,
 		},
 		{
+			name:                "CurrentState \"Error\" and CurrentCause \"Error\" should be valid",
 			currentState:        InstanceStateError,
 			currentPendingState: InstanceCauseError,
-			expectedValidity:    true,
+			expected:            true,
 		},
 		{
+			name:                "CurrentState \"Error\" and CurrentCause \"NoData\" should not be valid",
 			currentState:        InstanceStateError,
 			currentPendingState: InstanceCauseNoData,
-			expectedValidity:    false,
+			expected:            false,
 		},
 		{
+			name:                "CurrentState \"NoData\" and CurrentCause \"\" should not be valid",
 			currentState:        InstanceStateNoData,
-			currentPendingState: InstanceNoCause,
-			expectedValidity:    false,
+			currentPendingState: InstanceCauseNone,
+			expected:            false,
 		},
 		{
+			name:                "CurrentState \"NoData\" and CurrentCause \"Firing\" should not be valid",
 			currentState:        InstanceStateNoData,
 			currentPendingState: InstanceCauseFiring,
-			expectedValidity:    false,
+			expected:            false,
 		},
 		{
+			name:                "CurrentState \"NoData\" and CurrentCause \"Error\" should not be valid",
 			currentState:        InstanceStateNoData,
 			currentPendingState: InstanceCauseError,
-			expectedValidity:    false,
+			expected:            false,
 		},
 		{
+			name:                "CurrentState \"NoData\" and CurrentCause \"NoData\" should be valid",
 			currentState:        InstanceStateNoData,
 			currentPendingState: InstanceCauseNoData,
-			expectedValidity:    true,
+			expected:            true,
 		},
 		{
+			name:                "CurrentState \"Pending\" and CurrentCause \"\" should not be valid",
 			currentState:        InstanceStatePending,
-			currentPendingState: InstanceNoCause,
-			expectedValidity:    false,
+			currentPendingState: InstanceCauseNone,
+			expected:            false,
 		},
 		{
+			name:                "CurrentState \"Pending\" and CurrentCause \"Firing\" should be valid",
 			currentState:        InstanceStatePending,
 			currentPendingState: InstanceCauseFiring,
-			expectedValidity:    true,
+			expected:            true,
 		},
 		{
+			name:                "CurrentState \"Pending\" and CurrentCause \"Error\" should be valid",
 			currentState:        InstanceStatePending,
 			currentPendingState: InstanceCauseError,
-			expectedValidity:    true,
+			expected:            true,
 		},
 		{
+			name:                "CurrentState \"Pending\" and CurrentCause \"NoData\" should not be valid",
 			currentState:        InstanceStatePending,
 			currentPendingState: InstanceCauseNoData,
-			expectedValidity:    false,
+			expected:            false,
 		},
 	}
 
 	for _, tc := range testCases {
-		t.Run(buildTestValidateCurrentStateAndCurrentPendingStateName(tc.currentState, tc.currentPendingState, tc.expectedValidity), func(t *testing.T) {
-			require.Equal(t, tc.expectedValidity, validateCurrentStateAndCurrentPendingState(tc.currentState, tc.currentPendingState))
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, validateCurrentStateAndCurrentPendingState(tc.currentState, tc.currentPendingState))
 		})
 	}
-}
-
-func buildTestValidateCurrentStateAndCurrentPendingStateName(cState InstanceStateType, cPendingState InstanceCauseType, expectedValidity bool) string {
-	if expectedValidity {
-		return fmt.Sprintf("CurrentState %q and CurrentCause %q should be valid", cState, cPendingState)
-	}
-	return fmt.Sprintf("CurrentState %q and CurrentCause %q should not be valid", cState, cPendingState)
 }
 
 func TestValidateAlertInstance(t *testing.T) {
@@ -230,7 +242,7 @@ func TestValidateAlertInstance(t *testing.T) {
 			orgId:               0,
 			uid:                 "validUid",
 			currentState:        InstanceStateNormal,
-			currentPendingState: InstanceNoCause,
+			currentPendingState: InstanceCauseNone,
 			err:                 errors.New("alert instance is invalid due to missing alert rule organisation"),
 		},
 		{
@@ -238,7 +250,7 @@ func TestValidateAlertInstance(t *testing.T) {
 			orgId:               1,
 			uid:                 "",
 			currentState:        InstanceStateNormal,
-			currentPendingState: InstanceNoCause,
+			currentPendingState: InstanceCauseNone,
 			err:                 errors.New("alert instance is invalid due to missing alert rule uid"),
 		},
 		{
@@ -246,7 +258,7 @@ func TestValidateAlertInstance(t *testing.T) {
 			orgId:               1,
 			uid:                 "validUid",
 			currentState:        InstanceStateType("notAValidType"),
-			currentPendingState: InstanceNoCause,
+			currentPendingState: InstanceCauseNone,
 			err:                 errors.New("alert instance is invalid because the state \"notAValidType\" is invalid"),
 		},
 		{
@@ -270,7 +282,7 @@ func TestValidateAlertInstance(t *testing.T) {
 			orgId:               1,
 			uid:                 "validUid",
 			currentState:        InstanceStateNormal,
-			currentPendingState: InstanceNoCause,
+			currentPendingState: InstanceCauseNone,
 			err:                 nil,
 		},
 	}

--- a/pkg/services/ngalert/models/testing.go
+++ b/pkg/services/ngalert/models/testing.go
@@ -39,6 +39,7 @@ func AlertRuleGen(mutators ...AlertRuleMutator) func() *AlertRule {
 
 		interval := (rand.Int63n(6) + 1) * 10
 		forInterval := time.Duration(interval*rand.Int63n(6)) * time.Second
+		forErrorInterval := time.Duration(interval*rand.Int63n(6)) * time.Second
 
 		var annotations map[string]string = nil
 		if rand.Int63()%2 == 0 {
@@ -76,6 +77,7 @@ func AlertRuleGen(mutators ...AlertRuleMutator) func() *AlertRule {
 			NoDataState:     randNoDataState(),
 			ExecErrState:    randErrState(),
 			For:             forInterval,
+			ForError:        forErrorInterval,
 			Annotations:     annotations,
 			Labels:          labels,
 		}
@@ -256,6 +258,7 @@ func CopyRule(r *AlertRule) *AlertRule {
 		NoDataState:     r.NoDataState,
 		ExecErrState:    r.ExecErrState,
 		For:             r.For,
+		ForError:        r.ForError,
 	}
 
 	if r.DashboardUID != nil {

--- a/pkg/services/ngalert/schedule/schedule_unit_test.go
+++ b/pkg/services/ngalert/schedule/schedule_unit_test.go
@@ -462,6 +462,7 @@ func TestSchedule_ruleRoutine(t *testing.T) {
 	t.Run("when evaluation fails", func(t *testing.T) {
 		rule := models.AlertRuleGen(withQueryForState(t, eval.Error))()
 		rule.ExecErrState = models.ErrorErrState
+		rule.ForError = 0
 
 		evalChan := make(chan *evaluation)
 		evalAppliedChan := make(chan time.Time)

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -188,7 +188,7 @@ func (st *Manager) DeleteStateByRuleUID(ctx context.Context, ruleKey ngModels.Al
 		if s.State != eval.Normal {
 			startsAt = now
 		}
-		s.SetNormal(reason, NoCause, startsAt, now)
+		s.SetNormal(reason, CauseNone, startsAt, now)
 		// Set Resolved property so the scheduler knows to send a postable alert
 		// to Alertmanager.
 		s.Resolved = oldState == eval.Alerting
@@ -279,7 +279,7 @@ func (st *Manager) setNextState(ctx context.Context, alertRule *ngModels.AlertRu
 	switch result.State {
 	case eval.Normal:
 		logger.Debug("Setting next state", "handler", "resultNormal")
-		resultNormal(currentState, alertRule, result, logger, NoCause)
+		resultNormal(currentState, alertRule, result, logger, CauseNone)
 	case eval.Alerting:
 		logger.Debug("Setting next state", "handler", "resultAlerting")
 		resultAlerting(currentState, alertRule, result, logger, CauseFiring, "", nil)
@@ -435,8 +435,8 @@ func translateInstanceState(state ngModels.InstanceStateType) eval.State {
 
 func translateInstanceCause(pendingState ngModels.InstanceCauseType) Cause {
 	switch pendingState {
-	case ngModels.InstanceNoCause:
-		return NoCause
+	case ngModels.InstanceCauseNone:
+		return CauseNone
 	case ngModels.InstanceCauseFiring:
 		return CauseFiring
 	case ngModels.InstanceCauseError:
@@ -444,7 +444,7 @@ func translateInstanceCause(pendingState ngModels.InstanceCauseType) Cause {
 	case ngModels.InstanceCauseNoData:
 		return CauseNoData
 	default:
-		return NoCause
+		return CauseNone
 	}
 }
 

--- a/pkg/services/ngalert/state/manager_test.go
+++ b/pkg/services/ngalert/state/manager_test.go
@@ -48,6 +48,7 @@ func TestWarmStateCache(t *testing.T) {
 			CacheID:      `[["test1","testValue1"]]`,
 			Labels:       data.Labels{"test1": "testValue1"},
 			State:        eval.Normal,
+			PendingState: state.PendingStateEmpty,
 			Results: []state.Evaluation{
 				{EvaluationTime: evaluationTime, EvaluationState: eval.Normal},
 			},
@@ -61,6 +62,7 @@ func TestWarmStateCache(t *testing.T) {
 			CacheID:      `[["test2","testValue2"]]`,
 			Labels:       data.Labels{"test2": "testValue2"},
 			State:        eval.Alerting,
+			PendingState: state.PendingStateEmpty,
 			Results: []state.Evaluation{
 				{EvaluationTime: evaluationTime, EvaluationState: eval.Alerting},
 			},
@@ -75,6 +77,7 @@ func TestWarmStateCache(t *testing.T) {
 			CacheID:      `[["test3","testValue3"]]`,
 			Labels:       data.Labels{"test3": "testValue3"},
 			State:        eval.NoData,
+			PendingState: state.PendingStateEmpty,
 			Results: []state.Evaluation{
 				{EvaluationTime: evaluationTime, EvaluationState: eval.NoData},
 			},
@@ -89,6 +92,7 @@ func TestWarmStateCache(t *testing.T) {
 			CacheID:      `[["test4","testValue4"]]`,
 			Labels:       data.Labels{"test4": "testValue4"},
 			State:        eval.Error,
+			PendingState: state.PendingStateEmpty,
 			Results: []state.Evaluation{
 				{EvaluationTime: evaluationTime, EvaluationState: eval.Error},
 			},
@@ -103,6 +107,22 @@ func TestWarmStateCache(t *testing.T) {
 			CacheID:      `[["test5","testValue5"]]`,
 			Labels:       data.Labels{"test5": "testValue5"},
 			State:        eval.Pending,
+			PendingState: state.PendingStateAlerting,
+			Results: []state.Evaluation{
+				{EvaluationTime: evaluationTime, EvaluationState: eval.Pending},
+			},
+			StartsAt:           evaluationTime.Add(-1 * time.Minute),
+			EndsAt:             evaluationTime.Add(1 * time.Minute),
+			LastEvaluationTime: evaluationTime,
+			Annotations:        map[string]string{"testAnnoKey": "testAnnoValue"},
+		},
+		{
+			AlertRuleUID: rule.UID,
+			OrgID:        rule.OrgID,
+			CacheID:      `[["test6","testValue6"]]`,
+			Labels:       data.Labels{"test6": "testValue6"},
+			State:        eval.Pending,
+			PendingState: state.PendingStateError,
 			Results: []state.Evaluation{
 				{EvaluationTime: evaluationTime, EvaluationState: eval.Pending},
 			},
@@ -121,11 +141,12 @@ func TestWarmStateCache(t *testing.T) {
 			RuleUID:    rule.UID,
 			LabelsHash: hash,
 		},
-		CurrentState:      models.InstanceStateNormal,
-		LastEvalTime:      evaluationTime,
-		CurrentStateSince: evaluationTime.Add(-1 * time.Minute),
-		CurrentStateEnd:   evaluationTime.Add(1 * time.Minute),
-		Labels:            labels,
+		CurrentState:        models.InstanceStateNormal,
+		CurrentPendingState: models.InstancePendingStateEmpty,
+		LastEvalTime:        evaluationTime,
+		CurrentStateSince:   evaluationTime.Add(-1 * time.Minute),
+		CurrentStateEnd:     evaluationTime.Add(1 * time.Minute),
+		Labels:              labels,
 	}
 
 	labels = models.InstanceLabels{"test2": "testValue2"}
@@ -136,11 +157,12 @@ func TestWarmStateCache(t *testing.T) {
 			RuleUID:    rule.UID,
 			LabelsHash: hash,
 		},
-		CurrentState:      models.InstanceStateFiring,
-		LastEvalTime:      evaluationTime,
-		CurrentStateSince: evaluationTime.Add(-1 * time.Minute),
-		CurrentStateEnd:   evaluationTime.Add(1 * time.Minute),
-		Labels:            labels,
+		CurrentState:        models.InstanceStateFiring,
+		CurrentPendingState: models.InstancePendingStateEmpty,
+		LastEvalTime:        evaluationTime,
+		CurrentStateSince:   evaluationTime.Add(-1 * time.Minute),
+		CurrentStateEnd:     evaluationTime.Add(1 * time.Minute),
+		Labels:              labels,
 	}
 
 	labels = models.InstanceLabels{"test3": "testValue3"}
@@ -151,11 +173,12 @@ func TestWarmStateCache(t *testing.T) {
 			RuleUID:    rule.UID,
 			LabelsHash: hash,
 		},
-		CurrentState:      models.InstanceStateNoData,
-		LastEvalTime:      evaluationTime,
-		CurrentStateSince: evaluationTime.Add(-1 * time.Minute),
-		CurrentStateEnd:   evaluationTime.Add(1 * time.Minute),
-		Labels:            labels,
+		CurrentState:        models.InstanceStateNoData,
+		CurrentPendingState: models.InstancePendingStateEmpty,
+		LastEvalTime:        evaluationTime,
+		CurrentStateSince:   evaluationTime.Add(-1 * time.Minute),
+		CurrentStateEnd:     evaluationTime.Add(1 * time.Minute),
+		Labels:              labels,
 	}
 
 	labels = models.InstanceLabels{"test4": "testValue4"}
@@ -166,11 +189,12 @@ func TestWarmStateCache(t *testing.T) {
 			RuleUID:    rule.UID,
 			LabelsHash: hash,
 		},
-		CurrentState:      models.InstanceStateError,
-		LastEvalTime:      evaluationTime,
-		CurrentStateSince: evaluationTime.Add(-1 * time.Minute),
-		CurrentStateEnd:   evaluationTime.Add(1 * time.Minute),
-		Labels:            labels,
+		CurrentState:        models.InstanceStateError,
+		CurrentPendingState: models.InstancePendingStateEmpty,
+		LastEvalTime:        evaluationTime,
+		CurrentStateSince:   evaluationTime.Add(-1 * time.Minute),
+		CurrentStateEnd:     evaluationTime.Add(1 * time.Minute),
+		Labels:              labels,
 	}
 
 	labels = models.InstanceLabels{"test5": "testValue5"}
@@ -181,13 +205,30 @@ func TestWarmStateCache(t *testing.T) {
 			RuleUID:    rule.UID,
 			LabelsHash: hash,
 		},
-		CurrentState:      models.InstanceStatePending,
-		LastEvalTime:      evaluationTime,
-		CurrentStateSince: evaluationTime.Add(-1 * time.Minute),
-		CurrentStateEnd:   evaluationTime.Add(1 * time.Minute),
-		Labels:            labels,
+		CurrentState:        models.InstanceStatePending,
+		CurrentPendingState: models.InstancePendingStateFiring,
+		LastEvalTime:        evaluationTime,
+		CurrentStateSince:   evaluationTime.Add(-1 * time.Minute),
+		CurrentStateEnd:     evaluationTime.Add(1 * time.Minute),
+		Labels:              labels,
 	}
-	_ = dbstore.SaveAlertInstances(ctx, instance1, instance2, instance3, instance4, instance5)
+
+	labels = models.InstanceLabels{"test6": "testValue6"}
+	_, hash, _ = labels.StringAndHash()
+	instance6 := models.AlertInstance{
+		AlertInstanceKey: models.AlertInstanceKey{
+			RuleOrgID:  rule.OrgID,
+			RuleUID:    rule.UID,
+			LabelsHash: hash,
+		},
+		CurrentState:        models.InstanceStatePending,
+		CurrentPendingState: models.InstancePendingStateError,
+		LastEvalTime:        evaluationTime,
+		CurrentStateSince:   evaluationTime.Add(-1 * time.Minute),
+		CurrentStateEnd:     evaluationTime.Add(1 * time.Minute),
+		Labels:              labels,
+	}
+	_ = dbstore.SaveAlertInstances(ctx, instance1, instance2, instance3, instance4, instance5, instance6)
 
 	cfg := state.ManagerCfg{
 		Metrics:       testMetrics.GetStateMetrics(),
@@ -320,8 +361,9 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"instance_label":               "test",
 					},
-					Values: make(map[string]float64),
-					State:  eval.Normal,
+					Values:       make(map[string]float64),
+					State:        eval.Normal,
+					PendingState: state.PendingStateEmpty,
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime,
@@ -399,8 +441,9 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"instance_label_2":             "test",
 					},
-					Values: make(map[string]float64),
-					State:  eval.Alerting,
+					Values:       make(map[string]float64),
+					State:        eval.Alerting,
+					PendingState: state.PendingStateEmpty,
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime,
@@ -457,8 +500,9 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"instance_label":               "test",
 					},
-					Values: make(map[string]float64),
-					State:  eval.Normal,
+					Values:       make(map[string]float64),
+					State:        eval.Normal,
+					PendingState: state.PendingStateEmpty,
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime,
@@ -519,8 +563,9 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"instance_label":               "test",
 					},
-					Values: make(map[string]float64),
-					State:  eval.Alerting,
+					Values:       make(map[string]float64),
+					State:        eval.Alerting,
+					PendingState: state.PendingStateEmpty,
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime,
@@ -592,8 +637,9 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"instance_label":               "test",
 					},
-					Values: make(map[string]float64),
-					State:  eval.Alerting,
+					Values:       make(map[string]float64),
+					State:        eval.Alerting,
+					PendingState: state.PendingStateEmpty,
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime,
@@ -687,8 +733,9 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"instance_label":               "test",
 					},
-					Values: make(map[string]float64),
-					State:  eval.Pending,
+					Values:       make(map[string]float64),
+					State:        eval.Pending,
+					PendingState: state.PendingStateAlerting,
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime.Add(30 * time.Second),
@@ -769,8 +816,9 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"instance_label":               "test",
 					},
-					Values: make(map[string]float64),
-					State:  eval.NoData,
+					Values:       make(map[string]float64),
+					State:        eval.NoData,
+					PendingState: state.PendingStateEmpty,
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime.Add(20 * time.Second),
@@ -834,8 +882,9 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"instance_label":               "test",
 					},
-					Values: make(map[string]float64),
-					State:  eval.Pending,
+					Values:       make(map[string]float64),
+					State:        eval.Pending,
+					PendingState: state.PendingStateAlerting,
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime,
@@ -899,8 +948,9 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"instance_label":               "test",
 					},
-					Values: make(map[string]float64),
-					State:  eval.Pending,
+					Values:       make(map[string]float64),
+					State:        eval.Pending,
+					PendingState: state.PendingStateAlerting,
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime,
@@ -964,9 +1014,10 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"instance_label":               "test",
 					},
-					Values:      make(map[string]float64),
-					State:       eval.Alerting,
-					StateReason: eval.NoData.String(),
+					Values:       make(map[string]float64),
+					State:        eval.Alerting,
+					PendingState: state.PendingStateEmpty,
+					StateReason:  eval.NoData.String(),
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime,
@@ -1030,8 +1081,9 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"instance_label":               "test",
 					},
-					Values: make(map[string]float64),
-					State:  eval.NoData,
+					Values:       make(map[string]float64),
+					State:        eval.NoData,
+					PendingState: state.PendingStateEmpty,
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime,
@@ -1095,8 +1147,9 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"instance_label":               "test",
 					},
-					Values: make(map[string]float64),
-					State:  eval.Normal,
+					Values:       make(map[string]float64),
+					State:        eval.Normal,
+					PendingState: state.PendingStateEmpty,
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime,
@@ -1120,8 +1173,9 @@ func TestProcessEvalResults(t *testing.T) {
 						"alertname":                    "test_title",
 						"label":                        "test",
 					},
-					Values: make(map[string]float64),
-					State:  eval.NoData,
+					Values:       make(map[string]float64),
+					State:        eval.NoData,
+					PendingState: state.PendingStateEmpty,
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime.Add(10 * time.Second),
@@ -1186,8 +1240,9 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"instance_label":               "test-1",
 					},
-					Values: make(map[string]float64),
-					State:  eval.Normal,
+					Values:       make(map[string]float64),
+					State:        eval.Normal,
+					PendingState: state.PendingStateEmpty,
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime,
@@ -1212,8 +1267,9 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"instance_label":               "test-2",
 					},
-					Values: make(map[string]float64),
-					State:  eval.Normal,
+					Values:       make(map[string]float64),
+					State:        eval.Normal,
+					PendingState: state.PendingStateEmpty,
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime,
@@ -1237,8 +1293,9 @@ func TestProcessEvalResults(t *testing.T) {
 						"alertname":                    "test_title",
 						"label":                        "test",
 					},
-					Values: make(map[string]float64),
-					State:  eval.NoData,
+					Values:       make(map[string]float64),
+					State:        eval.NoData,
+					PendingState: state.PendingStateEmpty,
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime.Add(10 * time.Second),
@@ -1305,8 +1362,9 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"instance_label":               "test",
 					},
-					Values: make(map[string]float64),
-					State:  eval.Normal,
+					Values:       make(map[string]float64),
+					State:        eval.Normal,
+					PendingState: state.PendingStateEmpty,
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime,
@@ -1335,8 +1393,9 @@ func TestProcessEvalResults(t *testing.T) {
 						"alertname":                    "test_title",
 						"label":                        "test",
 					},
-					Values: make(map[string]float64),
-					State:  eval.NoData,
+					Values:       make(map[string]float64),
+					State:        eval.NoData,
+					PendingState: state.PendingStateEmpty,
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime.Add(10 * time.Second),
@@ -1395,9 +1454,10 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"instance_label":               "test",
 					},
-					Values:      make(map[string]float64),
-					State:       eval.Normal,
-					StateReason: eval.NoData.String(),
+					Values:       make(map[string]float64),
+					State:        eval.Normal,
+					PendingState: state.PendingStateEmpty,
+					StateReason:  eval.NoData.String(),
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime,
@@ -1462,9 +1522,10 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"instance_label":               "test",
 					},
-					Values:      make(map[string]float64),
-					State:       eval.Alerting,
-					StateReason: eval.NoData.String(),
+					Values:       make(map[string]float64),
+					State:        eval.Alerting,
+					PendingState: state.PendingStateEmpty,
+					StateReason:  eval.NoData.String(),
 
 					Results: []state.Evaluation{
 						{
@@ -1531,10 +1592,11 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"instance_label":               "test",
 					},
-					Values:      make(map[string]float64),
-					State:       eval.Pending,
-					StateReason: eval.Error.String(),
-					Error:       errors.New("test error"),
+					Values:       make(map[string]float64),
+					State:        eval.Pending,
+					PendingState: state.PendingStateAlerting,
+					StateReason:  eval.Error.String(),
+					Error:        errors.New("test error"),
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime,
@@ -1623,9 +1685,10 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"instance_label":               "test",
 					},
-					Values:      make(map[string]float64),
-					State:       eval.Alerting,
-					StateReason: eval.Error.String(),
+					Values:       make(map[string]float64),
+					State:        eval.Alerting,
+					PendingState: state.PendingStateEmpty,
+					StateReason:  eval.Error.String(),
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime.Add(20 * time.Second),
@@ -1703,8 +1766,9 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"instance_label":               "test",
 					},
-					Values: make(map[string]float64),
-					State:  eval.Error,
+					Values:       make(map[string]float64),
+					State:        eval.Error,
+					PendingState: state.PendingStateEmpty,
 					Error: expr.QueryError{
 						RefID: "A",
 						Err:   errors.New("this is an error"),
@@ -1782,9 +1846,10 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"instance_label":               "test",
 					},
-					Values:      make(map[string]float64),
-					State:       eval.Pending,
-					StateReason: "Error",
+					Values:       make(map[string]float64),
+					State:        eval.Pending,
+					PendingState: state.PendingStateError,
+					StateReason:  "Error",
 					Error: expr.QueryError{
 						RefID: "A",
 						Err:   errors.New("this is an error"),
@@ -1861,10 +1926,11 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"instance_label":               "test",
 					},
-					Values:      make(map[string]float64),
-					State:       eval.Normal,
-					StateReason: eval.Error.String(),
-					Error:       nil,
+					Values:       make(map[string]float64),
+					State:        eval.Normal,
+					PendingState: state.PendingStateEmpty,
+					StateReason:  eval.Error.String(),
+					Error:        nil,
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime,
@@ -1935,10 +2001,11 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"instance_label":               "test",
 					},
-					Values:      make(map[string]float64),
-					State:       eval.Normal,
-					StateReason: eval.Error.String(),
-					Error:       nil,
+					Values:       make(map[string]float64),
+					State:        eval.Normal,
+					PendingState: state.PendingStateEmpty,
+					StateReason:  eval.Error.String(),
+					Error:        nil,
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime,
@@ -1970,6 +2037,7 @@ func TestProcessEvalResults(t *testing.T) {
 				Labels:          map[string]string{"label": "test"},
 				IntervalSeconds: 10,
 				For:             20 * time.Second,
+				ForError:        20 * time.Second,
 				ExecErrState:    models.ErrorErrState,
 			},
 			evalResults: []eval.Results{
@@ -2022,7 +2090,7 @@ func TestProcessEvalResults(t *testing.T) {
 					},
 				},
 			},
-			expectedAnnotations: 3,
+			expectedAnnotations: 4,
 			expectedStates: map[string]*state.State{
 				`[["__alert_rule_namespace_uid__","test_namespace_uid"],["__alert_rule_uid__","test_alert_rule_uid_2"],["alertname","test_title"],["instance_label","test"],["label","test"]]`: {
 					AlertRuleUID: "test_alert_rule_uid_2",
@@ -2035,8 +2103,9 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"instance_label":               "test",
 					},
-					Values: make(map[string]float64),
-					State:  eval.Error,
+					Values:       make(map[string]float64),
+					State:        eval.Error,
+					PendingState: state.PendingStateEmpty,
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime.Add(40 * time.Second),
@@ -2049,7 +2118,7 @@ func TestProcessEvalResults(t *testing.T) {
 							Values:          make(map[string]*float64),
 						},
 					},
-					StartsAt:           evaluationTime.Add(30 * time.Second),
+					StartsAt:           evaluationTime.Add(50 * time.Second),
 					EndsAt:             evaluationTime.Add(50 * time.Second).Add(state.ResendDelay * 3),
 					LastEvaluationTime: evaluationTime.Add(50 * time.Second),
 					EvaluationDuration: evaluationDuration,
@@ -2126,9 +2195,10 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"instance_label":               "test",
 					},
-					Values:      make(map[string]float64),
-					State:       eval.Pending,
-					StateReason: models.StateReasonError,
+					Values:       make(map[string]float64),
+					State:        eval.Pending,
+					PendingState: state.PendingStateError,
+					StateReason:  models.StateReasonError,
 					Error: expr.QueryError{
 						RefID: "A",
 						Err:   errors.New("this is an error"),
@@ -2222,8 +2292,9 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"instance_label":               "test",
 					},
-					Values: make(map[string]float64),
-					State:  eval.Pending,
+					Values:       make(map[string]float64),
+					State:        eval.Pending,
+					PendingState: state.PendingStateAlerting,
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime.Add(20 * time.Second),
@@ -2365,8 +2436,9 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"instance_label":               "test",
 					},
-					Values: make(map[string]float64),
-					State:  eval.Alerting,
+					Values:       make(map[string]float64),
+					State:        eval.Alerting,
+					PendingState: state.PendingStateEmpty,
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime.Add(80 * time.Second),
@@ -2447,8 +2519,9 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"instance_label":               "test",
 					},
-					Values: make(map[string]float64),
-					State:  eval.Pending,
+					Values:       make(map[string]float64),
+					State:        eval.Pending,
+					PendingState: state.PendingStateAlerting,
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime.Add(30 * time.Second),
@@ -2535,8 +2608,9 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"instance_label":               "test",
 					},
-					Values: make(map[string]float64),
-					State:  eval.NoData,
+					Values:       make(map[string]float64),
+					State:        eval.NoData,
+					PendingState: state.PendingStateEmpty,
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime.Add(30 * time.Second),
@@ -2598,8 +2672,9 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"job":                          "prod/grafana",
 					},
-					Values: make(map[string]float64),
-					State:  eval.Normal,
+					Values:       make(map[string]float64),
+					State:        eval.Normal,
+					PendingState: state.PendingStateEmpty,
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime,

--- a/pkg/services/ngalert/state/manager_test.go
+++ b/pkg/services/ngalert/state/manager_test.go
@@ -48,7 +48,7 @@ func TestWarmStateCache(t *testing.T) {
 			CacheID:      `[["test1","testValue1"]]`,
 			Labels:       data.Labels{"test1": "testValue1"},
 			State:        eval.Normal,
-			PendingState: state.PendingStateEmpty,
+			Cause:        state.NoCause,
 			Results: []state.Evaluation{
 				{EvaluationTime: evaluationTime, EvaluationState: eval.Normal},
 			},
@@ -56,15 +56,16 @@ func TestWarmStateCache(t *testing.T) {
 			EndsAt:             evaluationTime.Add(1 * time.Minute),
 			LastEvaluationTime: evaluationTime,
 			Annotations:        map[string]string{"testAnnoKey": "testAnnoValue"},
-		}, {
+		},
+		{
 			AlertRuleUID: rule.UID,
 			OrgID:        rule.OrgID,
 			CacheID:      `[["test2","testValue2"]]`,
 			Labels:       data.Labels{"test2": "testValue2"},
-			State:        eval.Alerting,
-			PendingState: state.PendingStateEmpty,
+			State:        eval.Normal,
+			Cause:        state.CauseError,
 			Results: []state.Evaluation{
-				{EvaluationTime: evaluationTime, EvaluationState: eval.Alerting},
+				{EvaluationTime: evaluationTime, EvaluationState: eval.Normal},
 			},
 			StartsAt:           evaluationTime.Add(-1 * time.Minute),
 			EndsAt:             evaluationTime.Add(1 * time.Minute),
@@ -76,10 +77,10 @@ func TestWarmStateCache(t *testing.T) {
 			OrgID:        rule.OrgID,
 			CacheID:      `[["test3","testValue3"]]`,
 			Labels:       data.Labels{"test3": "testValue3"},
-			State:        eval.NoData,
-			PendingState: state.PendingStateEmpty,
+			State:        eval.Normal,
+			Cause:        state.CauseNoData,
 			Results: []state.Evaluation{
-				{EvaluationTime: evaluationTime, EvaluationState: eval.NoData},
+				{EvaluationTime: evaluationTime, EvaluationState: eval.Normal},
 			},
 			StartsAt:           evaluationTime.Add(-1 * time.Minute),
 			EndsAt:             evaluationTime.Add(1 * time.Minute),
@@ -91,10 +92,10 @@ func TestWarmStateCache(t *testing.T) {
 			OrgID:        rule.OrgID,
 			CacheID:      `[["test4","testValue4"]]`,
 			Labels:       data.Labels{"test4": "testValue4"},
-			State:        eval.Error,
-			PendingState: state.PendingStateEmpty,
+			State:        eval.Alerting,
+			Cause:        state.CauseFiring,
 			Results: []state.Evaluation{
-				{EvaluationTime: evaluationTime, EvaluationState: eval.Error},
+				{EvaluationTime: evaluationTime, EvaluationState: eval.Alerting},
 			},
 			StartsAt:           evaluationTime.Add(-1 * time.Minute),
 			EndsAt:             evaluationTime.Add(1 * time.Minute),
@@ -106,10 +107,10 @@ func TestWarmStateCache(t *testing.T) {
 			OrgID:        rule.OrgID,
 			CacheID:      `[["test5","testValue5"]]`,
 			Labels:       data.Labels{"test5": "testValue5"},
-			State:        eval.Pending,
-			PendingState: state.PendingStateAlerting,
+			State:        eval.Alerting,
+			Cause:        state.CauseError,
 			Results: []state.Evaluation{
-				{EvaluationTime: evaluationTime, EvaluationState: eval.Pending},
+				{EvaluationTime: evaluationTime, EvaluationState: eval.Alerting},
 			},
 			StartsAt:           evaluationTime.Add(-1 * time.Minute),
 			EndsAt:             evaluationTime.Add(1 * time.Minute),
@@ -121,8 +122,68 @@ func TestWarmStateCache(t *testing.T) {
 			OrgID:        rule.OrgID,
 			CacheID:      `[["test6","testValue6"]]`,
 			Labels:       data.Labels{"test6": "testValue6"},
+			State:        eval.Alerting,
+			Cause:        state.CauseNoData,
+			Results: []state.Evaluation{
+				{EvaluationTime: evaluationTime, EvaluationState: eval.Alerting},
+			},
+			StartsAt:           evaluationTime.Add(-1 * time.Minute),
+			EndsAt:             evaluationTime.Add(1 * time.Minute),
+			LastEvaluationTime: evaluationTime,
+			Annotations:        map[string]string{"testAnnoKey": "testAnnoValue"},
+		},
+		{
+			AlertRuleUID: rule.UID,
+			OrgID:        rule.OrgID,
+			CacheID:      `[["test7","testValue7"]]`,
+			Labels:       data.Labels{"test7": "testValue7"},
+			State:        eval.NoData,
+			Cause:        state.CauseNoData,
+			Results: []state.Evaluation{
+				{EvaluationTime: evaluationTime, EvaluationState: eval.NoData},
+			},
+			StartsAt:           evaluationTime.Add(-1 * time.Minute),
+			EndsAt:             evaluationTime.Add(1 * time.Minute),
+			LastEvaluationTime: evaluationTime,
+			Annotations:        map[string]string{"testAnnoKey": "testAnnoValue"},
+		},
+		{
+			AlertRuleUID: rule.UID,
+			OrgID:        rule.OrgID,
+			CacheID:      `[["test8","testValue8"]]`,
+			Labels:       data.Labels{"test8": "testValue8"},
+			State:        eval.Error,
+			Cause:        state.CauseError,
+			Results: []state.Evaluation{
+				{EvaluationTime: evaluationTime, EvaluationState: eval.Error},
+			},
+			StartsAt:           evaluationTime.Add(-1 * time.Minute),
+			EndsAt:             evaluationTime.Add(1 * time.Minute),
+			LastEvaluationTime: evaluationTime,
+			Annotations:        map[string]string{"testAnnoKey": "testAnnoValue"},
+		},
+		{
+			AlertRuleUID: rule.UID,
+			OrgID:        rule.OrgID,
+			CacheID:      `[["test9","testValue9"]]`,
+			Labels:       data.Labels{"test9": "testValue9"},
 			State:        eval.Pending,
-			PendingState: state.PendingStateError,
+			Cause:        state.CauseFiring,
+			Results: []state.Evaluation{
+				{EvaluationTime: evaluationTime, EvaluationState: eval.Pending},
+			},
+			StartsAt:           evaluationTime.Add(-1 * time.Minute),
+			EndsAt:             evaluationTime.Add(1 * time.Minute),
+			LastEvaluationTime: evaluationTime,
+			Annotations:        map[string]string{"testAnnoKey": "testAnnoValue"},
+		},
+		{
+			AlertRuleUID: rule.UID,
+			OrgID:        rule.OrgID,
+			CacheID:      `[["test10","testValue10"]]`,
+			Labels:       data.Labels{"test10": "testValue10"},
+			State:        eval.Pending,
+			Cause:        state.CauseError,
 			Results: []state.Evaluation{
 				{EvaluationTime: evaluationTime, EvaluationState: eval.Pending},
 			},
@@ -141,12 +202,12 @@ func TestWarmStateCache(t *testing.T) {
 			RuleUID:    rule.UID,
 			LabelsHash: hash,
 		},
-		CurrentState:        models.InstanceStateNormal,
-		CurrentPendingState: models.InstancePendingStateEmpty,
-		LastEvalTime:        evaluationTime,
-		CurrentStateSince:   evaluationTime.Add(-1 * time.Minute),
-		CurrentStateEnd:     evaluationTime.Add(1 * time.Minute),
-		Labels:              labels,
+		CurrentState:      models.InstanceStateNormal,
+		CurrentCause:      models.InstanceNoCause,
+		LastEvalTime:      evaluationTime,
+		CurrentStateSince: evaluationTime.Add(-1 * time.Minute),
+		CurrentStateEnd:   evaluationTime.Add(1 * time.Minute),
+		Labels:            labels,
 	}
 
 	labels = models.InstanceLabels{"test2": "testValue2"}
@@ -157,12 +218,12 @@ func TestWarmStateCache(t *testing.T) {
 			RuleUID:    rule.UID,
 			LabelsHash: hash,
 		},
-		CurrentState:        models.InstanceStateFiring,
-		CurrentPendingState: models.InstancePendingStateEmpty,
-		LastEvalTime:        evaluationTime,
-		CurrentStateSince:   evaluationTime.Add(-1 * time.Minute),
-		CurrentStateEnd:     evaluationTime.Add(1 * time.Minute),
-		Labels:              labels,
+		CurrentState:      models.InstanceStateNormal,
+		CurrentCause:      models.InstanceCauseError,
+		LastEvalTime:      evaluationTime,
+		CurrentStateSince: evaluationTime.Add(-1 * time.Minute),
+		CurrentStateEnd:   evaluationTime.Add(1 * time.Minute),
+		Labels:            labels,
 	}
 
 	labels = models.InstanceLabels{"test3": "testValue3"}
@@ -173,12 +234,12 @@ func TestWarmStateCache(t *testing.T) {
 			RuleUID:    rule.UID,
 			LabelsHash: hash,
 		},
-		CurrentState:        models.InstanceStateNoData,
-		CurrentPendingState: models.InstancePendingStateEmpty,
-		LastEvalTime:        evaluationTime,
-		CurrentStateSince:   evaluationTime.Add(-1 * time.Minute),
-		CurrentStateEnd:     evaluationTime.Add(1 * time.Minute),
-		Labels:              labels,
+		CurrentState:      models.InstanceStateNormal,
+		CurrentCause:      models.InstanceCauseNoData,
+		LastEvalTime:      evaluationTime,
+		CurrentStateSince: evaluationTime.Add(-1 * time.Minute),
+		CurrentStateEnd:   evaluationTime.Add(1 * time.Minute),
+		Labels:            labels,
 	}
 
 	labels = models.InstanceLabels{"test4": "testValue4"}
@@ -189,12 +250,12 @@ func TestWarmStateCache(t *testing.T) {
 			RuleUID:    rule.UID,
 			LabelsHash: hash,
 		},
-		CurrentState:        models.InstanceStateError,
-		CurrentPendingState: models.InstancePendingStateEmpty,
-		LastEvalTime:        evaluationTime,
-		CurrentStateSince:   evaluationTime.Add(-1 * time.Minute),
-		CurrentStateEnd:     evaluationTime.Add(1 * time.Minute),
-		Labels:              labels,
+		CurrentState:      models.InstanceStateFiring,
+		CurrentCause:      models.InstanceCauseFiring,
+		LastEvalTime:      evaluationTime,
+		CurrentStateSince: evaluationTime.Add(-1 * time.Minute),
+		CurrentStateEnd:   evaluationTime.Add(1 * time.Minute),
+		Labels:            labels,
 	}
 
 	labels = models.InstanceLabels{"test5": "testValue5"}
@@ -205,12 +266,12 @@ func TestWarmStateCache(t *testing.T) {
 			RuleUID:    rule.UID,
 			LabelsHash: hash,
 		},
-		CurrentState:        models.InstanceStatePending,
-		CurrentPendingState: models.InstancePendingStateFiring,
-		LastEvalTime:        evaluationTime,
-		CurrentStateSince:   evaluationTime.Add(-1 * time.Minute),
-		CurrentStateEnd:     evaluationTime.Add(1 * time.Minute),
-		Labels:              labels,
+		CurrentState:      models.InstanceStateFiring,
+		CurrentCause:      models.InstanceCauseError,
+		LastEvalTime:      evaluationTime,
+		CurrentStateSince: evaluationTime.Add(-1 * time.Minute),
+		CurrentStateEnd:   evaluationTime.Add(1 * time.Minute),
+		Labels:            labels,
 	}
 
 	labels = models.InstanceLabels{"test6": "testValue6"}
@@ -221,14 +282,79 @@ func TestWarmStateCache(t *testing.T) {
 			RuleUID:    rule.UID,
 			LabelsHash: hash,
 		},
-		CurrentState:        models.InstanceStatePending,
-		CurrentPendingState: models.InstancePendingStateError,
-		LastEvalTime:        evaluationTime,
-		CurrentStateSince:   evaluationTime.Add(-1 * time.Minute),
-		CurrentStateEnd:     evaluationTime.Add(1 * time.Minute),
-		Labels:              labels,
+		CurrentState:      models.InstanceStateFiring,
+		CurrentCause:      models.InstanceCauseNoData,
+		LastEvalTime:      evaluationTime,
+		CurrentStateSince: evaluationTime.Add(-1 * time.Minute),
+		CurrentStateEnd:   evaluationTime.Add(1 * time.Minute),
+		Labels:            labels,
 	}
-	_ = dbstore.SaveAlertInstances(ctx, instance1, instance2, instance3, instance4, instance5, instance6)
+
+	labels = models.InstanceLabels{"test7": "testValue7"}
+	_, hash, _ = labels.StringAndHash()
+	instance7 := models.AlertInstance{
+		AlertInstanceKey: models.AlertInstanceKey{
+			RuleOrgID:  rule.OrgID,
+			RuleUID:    rule.UID,
+			LabelsHash: hash,
+		},
+		CurrentState:      models.InstanceStateNoData,
+		CurrentCause:      models.InstanceCauseNoData,
+		LastEvalTime:      evaluationTime,
+		CurrentStateSince: evaluationTime.Add(-1 * time.Minute),
+		CurrentStateEnd:   evaluationTime.Add(1 * time.Minute),
+		Labels:            labels,
+	}
+
+	labels = models.InstanceLabels{"test8": "testValue8"}
+	_, hash, _ = labels.StringAndHash()
+	instance8 := models.AlertInstance{
+		AlertInstanceKey: models.AlertInstanceKey{
+			RuleOrgID:  rule.OrgID,
+			RuleUID:    rule.UID,
+			LabelsHash: hash,
+		},
+		CurrentState:      models.InstanceStateError,
+		CurrentCause:      models.InstanceCauseError,
+		LastEvalTime:      evaluationTime,
+		CurrentStateSince: evaluationTime.Add(-1 * time.Minute),
+		CurrentStateEnd:   evaluationTime.Add(1 * time.Minute),
+		Labels:            labels,
+	}
+
+	labels = models.InstanceLabels{"test9": "testValue9"}
+	_, hash, _ = labels.StringAndHash()
+	instance9 := models.AlertInstance{
+		AlertInstanceKey: models.AlertInstanceKey{
+			RuleOrgID:  rule.OrgID,
+			RuleUID:    rule.UID,
+			LabelsHash: hash,
+		},
+		CurrentState:      models.InstanceStatePending,
+		CurrentCause:      models.InstanceCauseFiring,
+		LastEvalTime:      evaluationTime,
+		CurrentStateSince: evaluationTime.Add(-1 * time.Minute),
+		CurrentStateEnd:   evaluationTime.Add(1 * time.Minute),
+		Labels:            labels,
+	}
+
+	labels = models.InstanceLabels{"test10": "testValue10"}
+	_, hash, _ = labels.StringAndHash()
+	instance10 := models.AlertInstance{
+		AlertInstanceKey: models.AlertInstanceKey{
+			RuleOrgID:  rule.OrgID,
+			RuleUID:    rule.UID,
+			LabelsHash: hash,
+		},
+		CurrentState:      models.InstanceStatePending,
+		CurrentCause:      models.InstanceCauseError,
+		LastEvalTime:      evaluationTime,
+		CurrentStateSince: evaluationTime.Add(-1 * time.Minute),
+		CurrentStateEnd:   evaluationTime.Add(1 * time.Minute),
+		Labels:            labels,
+	}
+	_ = dbstore.SaveAlertInstances(ctx, instance1, instance2, instance3, instance4, instance5, instance6, instance7,
+		instance8, instance9, instance10)
 
 	cfg := state.ManagerCfg{
 		Metrics:       testMetrics.GetStateMetrics(),
@@ -361,9 +487,9 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"instance_label":               "test",
 					},
-					Values:       make(map[string]float64),
-					State:        eval.Normal,
-					PendingState: state.PendingStateEmpty,
+					Values: make(map[string]float64),
+					State:  eval.Normal,
+					Cause:  state.NoCause,
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime,
@@ -419,6 +545,7 @@ func TestProcessEvalResults(t *testing.T) {
 					},
 					Values: make(map[string]float64),
 					State:  eval.Normal,
+					Cause:  state.NoCause,
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime,
@@ -441,9 +568,9 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"instance_label_2":             "test",
 					},
-					Values:       make(map[string]float64),
-					State:        eval.Alerting,
-					PendingState: state.PendingStateEmpty,
+					Values: make(map[string]float64),
+					State:  eval.Alerting,
+					Cause:  state.CauseFiring,
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime,
@@ -500,9 +627,9 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"instance_label":               "test",
 					},
-					Values:       make(map[string]float64),
-					State:        eval.Normal,
-					PendingState: state.PendingStateEmpty,
+					Values: make(map[string]float64),
+					State:  eval.Normal,
+					Cause:  state.NoCause,
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime,
@@ -563,9 +690,9 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"instance_label":               "test",
 					},
-					Values:       make(map[string]float64),
-					State:        eval.Alerting,
-					PendingState: state.PendingStateEmpty,
+					Values: make(map[string]float64),
+					State:  eval.Alerting,
+					Cause:  state.CauseFiring,
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime,
@@ -637,9 +764,9 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"instance_label":               "test",
 					},
-					Values:       make(map[string]float64),
-					State:        eval.Alerting,
-					PendingState: state.PendingStateEmpty,
+					Values: make(map[string]float64),
+					State:  eval.Alerting,
+					Cause:  state.CauseFiring,
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime,
@@ -733,9 +860,9 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"instance_label":               "test",
 					},
-					Values:       make(map[string]float64),
-					State:        eval.Pending,
-					PendingState: state.PendingStateAlerting,
+					Values: make(map[string]float64),
+					State:  eval.Pending,
+					Cause:  state.CauseFiring,
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime.Add(30 * time.Second),
@@ -816,9 +943,9 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"instance_label":               "test",
 					},
-					Values:       make(map[string]float64),
-					State:        eval.NoData,
-					PendingState: state.PendingStateEmpty,
+					Values: make(map[string]float64),
+					State:  eval.NoData,
+					Cause:  state.CauseNoData,
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime.Add(20 * time.Second),
@@ -882,9 +1009,9 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"instance_label":               "test",
 					},
-					Values:       make(map[string]float64),
-					State:        eval.Pending,
-					PendingState: state.PendingStateAlerting,
+					Values: make(map[string]float64),
+					State:  eval.Pending,
+					Cause:  state.CauseFiring,
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime,
@@ -948,9 +1075,9 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"instance_label":               "test",
 					},
-					Values:       make(map[string]float64),
-					State:        eval.Pending,
-					PendingState: state.PendingStateAlerting,
+					Values: make(map[string]float64),
+					State:  eval.Pending,
+					Cause:  state.CauseFiring,
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime,
@@ -1014,10 +1141,10 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"instance_label":               "test",
 					},
-					Values:       make(map[string]float64),
-					State:        eval.Alerting,
-					PendingState: state.PendingStateEmpty,
-					StateReason:  eval.NoData.String(),
+					Values:      make(map[string]float64),
+					State:       eval.Alerting,
+					Cause:       state.CauseNoData,
+					StateReason: eval.NoData.String(),
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime,
@@ -1081,9 +1208,9 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"instance_label":               "test",
 					},
-					Values:       make(map[string]float64),
-					State:        eval.NoData,
-					PendingState: state.PendingStateEmpty,
+					Values: make(map[string]float64),
+					State:  eval.NoData,
+					Cause:  state.CauseNoData,
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime,
@@ -1147,9 +1274,9 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"instance_label":               "test",
 					},
-					Values:       make(map[string]float64),
-					State:        eval.Normal,
-					PendingState: state.PendingStateEmpty,
+					Values: make(map[string]float64),
+					State:  eval.Normal,
+					Cause:  state.NoCause,
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime,
@@ -1173,9 +1300,9 @@ func TestProcessEvalResults(t *testing.T) {
 						"alertname":                    "test_title",
 						"label":                        "test",
 					},
-					Values:       make(map[string]float64),
-					State:        eval.NoData,
-					PendingState: state.PendingStateEmpty,
+					Values: make(map[string]float64),
+					State:  eval.NoData,
+					Cause:  state.CauseNoData,
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime.Add(10 * time.Second),
@@ -1240,9 +1367,9 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"instance_label":               "test-1",
 					},
-					Values:       make(map[string]float64),
-					State:        eval.Normal,
-					PendingState: state.PendingStateEmpty,
+					Values: make(map[string]float64),
+					State:  eval.Normal,
+					Cause:  state.NoCause,
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime,
@@ -1267,9 +1394,9 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"instance_label":               "test-2",
 					},
-					Values:       make(map[string]float64),
-					State:        eval.Normal,
-					PendingState: state.PendingStateEmpty,
+					Values: make(map[string]float64),
+					State:  eval.Normal,
+					Cause:  state.NoCause,
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime,
@@ -1293,9 +1420,9 @@ func TestProcessEvalResults(t *testing.T) {
 						"alertname":                    "test_title",
 						"label":                        "test",
 					},
-					Values:       make(map[string]float64),
-					State:        eval.NoData,
-					PendingState: state.PendingStateEmpty,
+					Values: make(map[string]float64),
+					State:  eval.NoData,
+					Cause:  state.CauseNoData,
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime.Add(10 * time.Second),
@@ -1362,9 +1489,9 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"instance_label":               "test",
 					},
-					Values:       make(map[string]float64),
-					State:        eval.Normal,
-					PendingState: state.PendingStateEmpty,
+					Values: make(map[string]float64),
+					State:  eval.Normal,
+					Cause:  state.NoCause,
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime,
@@ -1393,9 +1520,9 @@ func TestProcessEvalResults(t *testing.T) {
 						"alertname":                    "test_title",
 						"label":                        "test",
 					},
-					Values:       make(map[string]float64),
-					State:        eval.NoData,
-					PendingState: state.PendingStateEmpty,
+					Values: make(map[string]float64),
+					State:  eval.NoData,
+					Cause:  state.CauseNoData,
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime.Add(10 * time.Second),
@@ -1454,10 +1581,10 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"instance_label":               "test",
 					},
-					Values:       make(map[string]float64),
-					State:        eval.Normal,
-					PendingState: state.PendingStateEmpty,
-					StateReason:  eval.NoData.String(),
+					Values:      make(map[string]float64),
+					State:       eval.Normal,
+					Cause:       state.CauseNoData,
+					StateReason: eval.NoData.String(),
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime,
@@ -1522,10 +1649,10 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"instance_label":               "test",
 					},
-					Values:       make(map[string]float64),
-					State:        eval.Alerting,
-					PendingState: state.PendingStateEmpty,
-					StateReason:  eval.NoData.String(),
+					Values:      make(map[string]float64),
+					State:       eval.Alerting,
+					Cause:       state.CauseNoData,
+					StateReason: eval.NoData.String(),
 
 					Results: []state.Evaluation{
 						{
@@ -1592,11 +1719,11 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"instance_label":               "test",
 					},
-					Values:       make(map[string]float64),
-					State:        eval.Pending,
-					PendingState: state.PendingStateAlerting,
-					StateReason:  eval.Error.String(),
-					Error:        errors.New("test error"),
+					Values:      make(map[string]float64),
+					State:       eval.Pending,
+					Cause:       state.CauseError,
+					StateReason: eval.Error.String(),
+					Error:       errors.New("test error"),
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime,
@@ -1685,10 +1812,10 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"instance_label":               "test",
 					},
-					Values:       make(map[string]float64),
-					State:        eval.Alerting,
-					PendingState: state.PendingStateEmpty,
-					StateReason:  eval.Error.String(),
+					Values:      make(map[string]float64),
+					State:       eval.Alerting,
+					Cause:       state.CauseError,
+					StateReason: eval.Error.String(),
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime.Add(20 * time.Second),
@@ -1766,9 +1893,9 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"instance_label":               "test",
 					},
-					Values:       make(map[string]float64),
-					State:        eval.Error,
-					PendingState: state.PendingStateEmpty,
+					Values: make(map[string]float64),
+					State:  eval.Error,
+					Cause:  state.CauseError,
 					Error: expr.QueryError{
 						RefID: "A",
 						Err:   errors.New("this is an error"),
@@ -1846,10 +1973,10 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"instance_label":               "test",
 					},
-					Values:       make(map[string]float64),
-					State:        eval.Pending,
-					PendingState: state.PendingStateError,
-					StateReason:  "Error",
+					Values:      make(map[string]float64),
+					State:       eval.Pending,
+					Cause:       state.CauseError,
+					StateReason: "Error",
 					Error: expr.QueryError{
 						RefID: "A",
 						Err:   errors.New("this is an error"),
@@ -1926,11 +2053,11 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"instance_label":               "test",
 					},
-					Values:       make(map[string]float64),
-					State:        eval.Normal,
-					PendingState: state.PendingStateEmpty,
-					StateReason:  eval.Error.String(),
-					Error:        nil,
+					Values:      make(map[string]float64),
+					State:       eval.Normal,
+					Cause:       state.CauseError,
+					StateReason: eval.Error.String(),
+					Error:       nil,
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime,
@@ -1943,6 +2070,8 @@ func TestProcessEvalResults(t *testing.T) {
 							Values:          make(map[string]*float64),
 						},
 					},
+					StartsAt:           evaluationTime.Add(10 * time.Second),
+					EndsAt:             evaluationTime.Add(10 * time.Second),
 					LastEvaluationTime: evaluationTime.Add(10 * time.Second),
 					EvaluationDuration: evaluationDuration,
 					Annotations:        map[string]string{"annotation": "test"},
@@ -2001,11 +2130,11 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"instance_label":               "test",
 					},
-					Values:       make(map[string]float64),
-					State:        eval.Normal,
-					PendingState: state.PendingStateEmpty,
-					StateReason:  eval.Error.String(),
-					Error:        nil,
+					Values:      make(map[string]float64),
+					State:       eval.Normal,
+					Cause:       state.CauseError,
+					StateReason: eval.Error.String(),
+					Error:       nil,
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime,
@@ -2103,9 +2232,9 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"instance_label":               "test",
 					},
-					Values:       make(map[string]float64),
-					State:        eval.Error,
-					PendingState: state.PendingStateEmpty,
+					Values: make(map[string]float64),
+					State:  eval.Error,
+					Cause:  state.CauseError,
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime.Add(40 * time.Second),
@@ -2127,7 +2256,7 @@ func TestProcessEvalResults(t *testing.T) {
 			},
 		},
 		{
-			desc: "pending -> pending error when result is Error and ExecErrorState is Error with For and ForError set",
+			desc: "pending alerting -> pending error when result is Error and ExecErrorState is Error with For and ForError set",
 			alertRule: &models.AlertRule{
 				OrgID:           1,
 				Title:           "test_title",
@@ -2136,7 +2265,7 @@ func TestProcessEvalResults(t *testing.T) {
 				Annotations:     map[string]string{"annotation": "test"},
 				Labels:          map[string]string{"label": "test"},
 				IntervalSeconds: 10,
-				For:             20 * time.Second,
+				For:             10 * time.Second,
 				ForError:        20 * time.Second,
 				ExecErrState:    models.ErrorErrState,
 			},
@@ -2146,14 +2275,6 @@ func TestProcessEvalResults(t *testing.T) {
 						Instance:           data.Labels{"instance_label": "test"},
 						State:              eval.Alerting,
 						EvaluatedAt:        evaluationTime,
-						EvaluationDuration: evaluationDuration,
-					},
-				},
-				{
-					eval.Result{
-						Instance:           data.Labels{"instance_label": "test"},
-						State:              eval.Alerting,
-						EvaluatedAt:        evaluationTime.Add(10 * time.Second),
 						EvaluationDuration: evaluationDuration,
 					},
 				},
@@ -2195,20 +2316,15 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"instance_label":               "test",
 					},
-					Values:       make(map[string]float64),
-					State:        eval.Pending,
-					PendingState: state.PendingStateError,
-					StateReason:  models.StateReasonError,
+					Values:      make(map[string]float64),
+					State:       eval.Pending,
+					Cause:       state.CauseError,
+					StateReason: models.StateReasonError,
 					Error: expr.QueryError{
 						RefID: "A",
 						Err:   errors.New("this is an error"),
 					},
 					Results: []state.Evaluation{
-						{
-							EvaluationTime:  evaluationTime.Add(20 * time.Second),
-							EvaluationState: eval.Error,
-							Values:          make(map[string]*float64),
-						},
 						{
 							EvaluationTime:  evaluationTime.Add(30 * time.Second),
 							EvaluationState: eval.Error,
@@ -2224,7 +2340,7 @@ func TestProcessEvalResults(t *testing.T) {
 			},
 		},
 		{
-			desc: "pending error -> pending when result is Error and ExecErrorState is Error with For and ForError set",
+			desc: "pending error -> pending alerting when result is Error and ExecErrorState is Error with For and ForError set",
 			alertRule: &models.AlertRule{
 				OrgID:           1,
 				Title:           "test_title",
@@ -2234,7 +2350,7 @@ func TestProcessEvalResults(t *testing.T) {
 				Labels:          map[string]string{"label": "test"},
 				IntervalSeconds: 10,
 				For:             20 * time.Second,
-				ForError:        20 * time.Second,
+				ForError:        10 * time.Second,
 				ExecErrState:    models.ErrorErrState,
 			},
 			evalResults: []eval.Results{
@@ -2247,18 +2363,6 @@ func TestProcessEvalResults(t *testing.T) {
 							Err:   errors.New("this is an error"),
 						},
 						EvaluatedAt:        evaluationTime,
-						EvaluationDuration: evaluationDuration,
-					},
-				},
-				{
-					eval.Result{
-						Instance: data.Labels{"instance_label": "test"},
-						State:    eval.Error,
-						Error: expr.QueryError{
-							RefID: "A",
-							Err:   errors.New("this is an error"),
-						},
-						EvaluatedAt:        evaluationTime.Add(10 * time.Second),
 						EvaluationDuration: evaluationDuration,
 					},
 				},
@@ -2292,9 +2396,9 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"instance_label":               "test",
 					},
-					Values:       make(map[string]float64),
-					State:        eval.Pending,
-					PendingState: state.PendingStateAlerting,
+					Values: make(map[string]float64),
+					State:  eval.Pending,
+					Cause:  state.CauseFiring,
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime.Add(20 * time.Second),
@@ -2436,9 +2540,9 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"instance_label":               "test",
 					},
-					Values:       make(map[string]float64),
-					State:        eval.Alerting,
-					PendingState: state.PendingStateEmpty,
+					Values: make(map[string]float64),
+					State:  eval.Alerting,
+					Cause:  state.CauseFiring,
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime.Add(80 * time.Second),
@@ -2519,9 +2623,9 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"instance_label":               "test",
 					},
-					Values:       make(map[string]float64),
-					State:        eval.Pending,
-					PendingState: state.PendingStateAlerting,
+					Values: make(map[string]float64),
+					State:  eval.Pending,
+					Cause:  state.CauseFiring,
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime.Add(30 * time.Second),
@@ -2608,9 +2712,9 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"instance_label":               "test",
 					},
-					Values:       make(map[string]float64),
-					State:        eval.NoData,
-					PendingState: state.PendingStateEmpty,
+					Values: make(map[string]float64),
+					State:  eval.NoData,
+					Cause:  state.CauseNoData,
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime.Add(30 * time.Second),
@@ -2672,9 +2776,9 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"job":                          "prod/grafana",
 					},
-					Values:       make(map[string]float64),
-					State:        eval.Normal,
-					PendingState: state.PendingStateEmpty,
+					Values: make(map[string]float64),
+					State:  eval.Normal,
+					Cause:  state.NoCause,
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime,
@@ -2793,6 +2897,7 @@ func TestStaleResultsHandler(t *testing.T) {
 				LabelsHash: hash1,
 			},
 			CurrentState:      models.InstanceStateNormal,
+			CurrentCause:      models.InstanceNoCause,
 			Labels:            labels1,
 			LastEvalTime:      lastEval,
 			CurrentStateSince: lastEval,
@@ -2805,6 +2910,7 @@ func TestStaleResultsHandler(t *testing.T) {
 				LabelsHash: hash2,
 			},
 			CurrentState:      models.InstanceStateFiring,
+			CurrentCause:      models.InstanceCauseFiring,
 			Labels:            labels2,
 			LastEvalTime:      lastEval,
 			CurrentStateSince: lastEval,
@@ -3048,6 +3154,7 @@ func TestDeleteStateByRuleUID(t *testing.T) {
 				LabelsHash: hash1,
 			},
 			CurrentState: models.InstanceStateNormal,
+			CurrentCause: models.InstanceNoCause,
 			Labels:       labels1,
 		},
 		{
@@ -3057,6 +3164,7 @@ func TestDeleteStateByRuleUID(t *testing.T) {
 				LabelsHash: hash2,
 			},
 			CurrentState: models.InstanceStateFiring,
+			CurrentCause: models.InstanceCauseFiring,
 			Labels:       labels2,
 		},
 	}
@@ -3084,6 +3192,7 @@ func TestDeleteStateByRuleUID(t *testing.T) {
 					CacheID:            `[["test1","testValue1"]]`,
 					Labels:             data.Labels{"test1": "testValue1"},
 					State:              eval.Normal,
+					Cause:              state.NoCause,
 					EvaluationDuration: 0,
 					Annotations:        map[string]string{"testAnnoKey": "testAnnoValue"},
 				},
@@ -3093,6 +3202,7 @@ func TestDeleteStateByRuleUID(t *testing.T) {
 					CacheID:            `[["test2","testValue2"]]`,
 					Labels:             data.Labels{"test2": "testValue2"},
 					State:              eval.Alerting,
+					Cause:              state.CauseFiring,
 					EvaluationDuration: 0,
 					Annotations:        map[string]string{"testAnnoKey": "testAnnoValue"},
 				},
@@ -3182,6 +3292,7 @@ func TestResetStateByRuleUID(t *testing.T) {
 				LabelsHash: hash1,
 			},
 			CurrentState: models.InstanceStateNormal,
+			CurrentCause: models.InstanceNoCause,
 			Labels:       labels1,
 		},
 		{
@@ -3191,6 +3302,7 @@ func TestResetStateByRuleUID(t *testing.T) {
 				LabelsHash: hash2,
 			},
 			CurrentState: models.InstanceStateFiring,
+			CurrentCause: models.InstanceCauseFiring,
 			Labels:       labels2,
 		},
 	}
@@ -3219,6 +3331,7 @@ func TestResetStateByRuleUID(t *testing.T) {
 					CacheID:            `[["test1","testValue1"]]`,
 					Labels:             data.Labels{"test1": "testValue1"},
 					State:              eval.Normal,
+					Cause:              state.NoCause,
 					EvaluationDuration: 0,
 					Annotations:        map[string]string{"testAnnoKey": "testAnnoValue"},
 				},
@@ -3228,6 +3341,7 @@ func TestResetStateByRuleUID(t *testing.T) {
 					CacheID:            `[["test2","testValue2"]]`,
 					Labels:             data.Labels{"test2": "testValue2"},
 					State:              eval.Alerting,
+					Cause:              state.CauseFiring,
 					EvaluationDuration: 0,
 					Annotations:        map[string]string{"testAnnoKey": "testAnnoValue"},
 				},

--- a/pkg/services/ngalert/state/manager_test.go
+++ b/pkg/services/ngalert/state/manager_test.go
@@ -48,7 +48,7 @@ func TestWarmStateCache(t *testing.T) {
 			CacheID:      `[["test1","testValue1"]]`,
 			Labels:       data.Labels{"test1": "testValue1"},
 			State:        eval.Normal,
-			Cause:        state.NoCause,
+			Cause:        state.CauseNone,
 			Results: []state.Evaluation{
 				{EvaluationTime: evaluationTime, EvaluationState: eval.Normal},
 			},
@@ -203,7 +203,7 @@ func TestWarmStateCache(t *testing.T) {
 			LabelsHash: hash,
 		},
 		CurrentState:      models.InstanceStateNormal,
-		CurrentCause:      models.InstanceNoCause,
+		CurrentCause:      models.InstanceCauseNone,
 		LastEvalTime:      evaluationTime,
 		CurrentStateSince: evaluationTime.Add(-1 * time.Minute),
 		CurrentStateEnd:   evaluationTime.Add(1 * time.Minute),
@@ -489,7 +489,7 @@ func TestProcessEvalResults(t *testing.T) {
 					},
 					Values: make(map[string]float64),
 					State:  eval.Normal,
-					Cause:  state.NoCause,
+					Cause:  state.CauseNone,
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime,
@@ -545,7 +545,7 @@ func TestProcessEvalResults(t *testing.T) {
 					},
 					Values: make(map[string]float64),
 					State:  eval.Normal,
-					Cause:  state.NoCause,
+					Cause:  state.CauseNone,
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime,
@@ -629,7 +629,7 @@ func TestProcessEvalResults(t *testing.T) {
 					},
 					Values: make(map[string]float64),
 					State:  eval.Normal,
-					Cause:  state.NoCause,
+					Cause:  state.CauseNone,
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime,
@@ -1276,7 +1276,7 @@ func TestProcessEvalResults(t *testing.T) {
 					},
 					Values: make(map[string]float64),
 					State:  eval.Normal,
-					Cause:  state.NoCause,
+					Cause:  state.CauseNone,
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime,
@@ -1369,7 +1369,7 @@ func TestProcessEvalResults(t *testing.T) {
 					},
 					Values: make(map[string]float64),
 					State:  eval.Normal,
-					Cause:  state.NoCause,
+					Cause:  state.CauseNone,
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime,
@@ -1396,7 +1396,7 @@ func TestProcessEvalResults(t *testing.T) {
 					},
 					Values: make(map[string]float64),
 					State:  eval.Normal,
-					Cause:  state.NoCause,
+					Cause:  state.CauseNone,
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime,
@@ -1491,7 +1491,7 @@ func TestProcessEvalResults(t *testing.T) {
 					},
 					Values: make(map[string]float64),
 					State:  eval.Normal,
-					Cause:  state.NoCause,
+					Cause:  state.CauseNone,
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime,
@@ -2778,7 +2778,7 @@ func TestProcessEvalResults(t *testing.T) {
 					},
 					Values: make(map[string]float64),
 					State:  eval.Normal,
-					Cause:  state.NoCause,
+					Cause:  state.CauseNone,
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime,
@@ -2897,7 +2897,7 @@ func TestStaleResultsHandler(t *testing.T) {
 				LabelsHash: hash1,
 			},
 			CurrentState:      models.InstanceStateNormal,
-			CurrentCause:      models.InstanceNoCause,
+			CurrentCause:      models.InstanceCauseNone,
 			Labels:            labels1,
 			LastEvalTime:      lastEval,
 			CurrentStateSince: lastEval,
@@ -3154,7 +3154,7 @@ func TestDeleteStateByRuleUID(t *testing.T) {
 				LabelsHash: hash1,
 			},
 			CurrentState: models.InstanceStateNormal,
-			CurrentCause: models.InstanceNoCause,
+			CurrentCause: models.InstanceCauseNone,
 			Labels:       labels1,
 		},
 		{
@@ -3192,7 +3192,7 @@ func TestDeleteStateByRuleUID(t *testing.T) {
 					CacheID:            `[["test1","testValue1"]]`,
 					Labels:             data.Labels{"test1": "testValue1"},
 					State:              eval.Normal,
-					Cause:              state.NoCause,
+					Cause:              state.CauseNone,
 					EvaluationDuration: 0,
 					Annotations:        map[string]string{"testAnnoKey": "testAnnoValue"},
 				},
@@ -3292,7 +3292,7 @@ func TestResetStateByRuleUID(t *testing.T) {
 				LabelsHash: hash1,
 			},
 			CurrentState: models.InstanceStateNormal,
-			CurrentCause: models.InstanceNoCause,
+			CurrentCause: models.InstanceCauseNone,
 			Labels:       labels1,
 		},
 		{
@@ -3331,7 +3331,7 @@ func TestResetStateByRuleUID(t *testing.T) {
 					CacheID:            `[["test1","testValue1"]]`,
 					Labels:             data.Labels{"test1": "testValue1"},
 					State:              eval.Normal,
-					Cause:              state.NoCause,
+					Cause:              state.CauseNone,
 					EvaluationDuration: 0,
 					Annotations:        map[string]string{"testAnnoKey": "testAnnoValue"},
 				},

--- a/pkg/services/ngalert/state/manager_test.go
+++ b/pkg/services/ngalert/state/manager_test.go
@@ -1652,7 +1652,7 @@ func TestProcessEvalResults(t *testing.T) {
 			},
 		},
 		{
-			desc: "normal -> error when result is Error and ExecErrState is Error",
+			desc: "normal -> error when result is Error and ExecErrState is Error and ForError is not set",
 			alertRule: &models.AlertRule{
 				OrgID:        1,
 				Title:        "test_title",
@@ -1702,11 +1702,89 @@ func TestProcessEvalResults(t *testing.T) {
 						"alertname":                    "test_title",
 						"label":                        "test",
 						"instance_label":               "test",
-						"datasource_uid":               "datasource_uid_1",
-						"ref_id":                       "A",
 					},
 					Values: make(map[string]float64),
 					State:  eval.Error,
+					Error: expr.QueryError{
+						RefID: "A",
+						Err:   errors.New("this is an error"),
+					},
+					Results: []state.Evaluation{
+						{
+							EvaluationTime:  evaluationTime,
+							EvaluationState: eval.Normal,
+							Values:          make(map[string]*float64),
+						},
+						{
+							EvaluationTime:  evaluationTime.Add(10 * time.Second),
+							EvaluationState: eval.Error,
+							Values:          make(map[string]*float64),
+						},
+					},
+					StartsAt:           evaluationTime.Add(10 * time.Second),
+					EndsAt:             evaluationTime.Add(10 * time.Second).Add(state.ResendDelay * 3),
+					LastEvaluationTime: evaluationTime.Add(10 * time.Second),
+					EvaluationDuration: evaluationDuration,
+					Annotations:        map[string]string{"annotation": "test", "Error": "failed to execute query A: this is an error"},
+				},
+			},
+		},
+		{
+			desc: "normal -> pending error when result is Error and ExecErrState is Error and ForError is set",
+			alertRule: &models.AlertRule{
+				OrgID:        1,
+				Title:        "test_title",
+				UID:          "test_alert_rule_uid_2",
+				NamespaceUID: "test_namespace_uid",
+				Data: []models.AlertQuery{{
+					RefID:         "A",
+					DatasourceUID: "datasource_uid_1",
+				}},
+				Annotations:     map[string]string{"annotation": "test"},
+				Labels:          map[string]string{"label": "test"},
+				IntervalSeconds: 10,
+				For:             1 * time.Minute,
+				ForError:        1 * time.Minute,
+				ExecErrState:    models.ErrorErrState,
+			},
+			evalResults: []eval.Results{
+				{
+					eval.Result{
+						Instance:           data.Labels{"instance_label": "test"},
+						State:              eval.Normal,
+						EvaluatedAt:        evaluationTime,
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+				{
+					eval.Result{
+						Instance: data.Labels{"instance_label": "test"},
+						Error: expr.QueryError{
+							RefID: "A",
+							Err:   errors.New("this is an error"),
+						},
+						State:              eval.Error,
+						EvaluatedAt:        evaluationTime.Add(10 * time.Second),
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+			},
+			expectedAnnotations: 1,
+			expectedStates: map[string]*state.State{
+				`[["__alert_rule_namespace_uid__","test_namespace_uid"],["__alert_rule_uid__","test_alert_rule_uid_2"],["alertname","test_title"],["instance_label","test"],["label","test"]]`: {
+					AlertRuleUID: "test_alert_rule_uid_2",
+					OrgID:        1,
+					CacheID:      `[["__alert_rule_namespace_uid__","test_namespace_uid"],["__alert_rule_uid__","test_alert_rule_uid_2"],["alertname","test_title"],["instance_label","test"],["label","test"]]`,
+					Labels: data.Labels{
+						"__alert_rule_namespace_uid__": "test_namespace_uid",
+						"__alert_rule_uid__":           "test_alert_rule_uid_2",
+						"alertname":                    "test_title",
+						"label":                        "test",
+						"instance_label":               "test",
+					},
+					Values:      make(map[string]float64),
+					State:       eval.Pending,
+					StateReason: "Error",
 					Error: expr.QueryError{
 						RefID: "A",
 						Err:   errors.New("this is an error"),
@@ -1974,6 +2052,336 @@ func TestProcessEvalResults(t *testing.T) {
 					StartsAt:           evaluationTime.Add(30 * time.Second),
 					EndsAt:             evaluationTime.Add(50 * time.Second).Add(state.ResendDelay * 3),
 					LastEvaluationTime: evaluationTime.Add(50 * time.Second),
+					EvaluationDuration: evaluationDuration,
+					Annotations:        map[string]string{"annotation": "test"},
+				},
+			},
+		},
+		{
+			desc: "pending -> pending error when result is Error and ExecErrorState is Error with For and ForError set",
+			alertRule: &models.AlertRule{
+				OrgID:           1,
+				Title:           "test_title",
+				UID:             "test_alert_rule_uid_2",
+				NamespaceUID:    "test_namespace_uid",
+				Annotations:     map[string]string{"annotation": "test"},
+				Labels:          map[string]string{"label": "test"},
+				IntervalSeconds: 10,
+				For:             20 * time.Second,
+				ForError:        20 * time.Second,
+				ExecErrState:    models.ErrorErrState,
+			},
+			evalResults: []eval.Results{
+				{
+					eval.Result{
+						Instance:           data.Labels{"instance_label": "test"},
+						State:              eval.Alerting,
+						EvaluatedAt:        evaluationTime,
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+				{
+					eval.Result{
+						Instance:           data.Labels{"instance_label": "test"},
+						State:              eval.Alerting,
+						EvaluatedAt:        evaluationTime.Add(10 * time.Second),
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+				{
+					eval.Result{
+						Instance: data.Labels{"instance_label": "test"},
+						State:    eval.Error,
+						Error: expr.QueryError{
+							RefID: "A",
+							Err:   errors.New("this is an error"),
+						},
+						EvaluatedAt:        evaluationTime.Add(20 * time.Second),
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+				{
+					eval.Result{
+						Instance: data.Labels{"instance_label": "test"},
+						State:    eval.Error,
+						Error: expr.QueryError{
+							RefID: "A",
+							Err:   errors.New("this is an error"),
+						},
+						EvaluatedAt:        evaluationTime.Add(30 * time.Second),
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+			},
+			expectedAnnotations: 2,
+			expectedStates: map[string]*state.State{
+				`[["__alert_rule_namespace_uid__","test_namespace_uid"],["__alert_rule_uid__","test_alert_rule_uid_2"],["alertname","test_title"],["instance_label","test"],["label","test"]]`: {
+					AlertRuleUID: "test_alert_rule_uid_2",
+					OrgID:        1,
+					CacheID:      `[["__alert_rule_namespace_uid__","test_namespace_uid"],["__alert_rule_uid__","test_alert_rule_uid_2"],["alertname","test_title"],["instance_label","test"],["label","test"]]`,
+					Labels: data.Labels{
+						"__alert_rule_namespace_uid__": "test_namespace_uid",
+						"__alert_rule_uid__":           "test_alert_rule_uid_2",
+						"alertname":                    "test_title",
+						"label":                        "test",
+						"instance_label":               "test",
+					},
+					Values:      make(map[string]float64),
+					State:       eval.Pending,
+					StateReason: models.StateReasonError,
+					Error: expr.QueryError{
+						RefID: "A",
+						Err:   errors.New("this is an error"),
+					},
+					Results: []state.Evaluation{
+						{
+							EvaluationTime:  evaluationTime.Add(20 * time.Second),
+							EvaluationState: eval.Error,
+							Values:          make(map[string]*float64),
+						},
+						{
+							EvaluationTime:  evaluationTime.Add(30 * time.Second),
+							EvaluationState: eval.Error,
+							Values:          make(map[string]*float64),
+						},
+					},
+					StartsAt:           evaluationTime.Add(20 * time.Second),
+					EndsAt:             evaluationTime.Add(20 * time.Second).Add(state.ResendDelay * 3),
+					LastEvaluationTime: evaluationTime.Add(30 * time.Second),
+					EvaluationDuration: evaluationDuration,
+					Annotations:        map[string]string{"annotation": "test"},
+				},
+			},
+		},
+		{
+			desc: "pending error -> pending when result is Error and ExecErrorState is Error with For and ForError set",
+			alertRule: &models.AlertRule{
+				OrgID:           1,
+				Title:           "test_title",
+				UID:             "test_alert_rule_uid_2",
+				NamespaceUID:    "test_namespace_uid",
+				Annotations:     map[string]string{"annotation": "test"},
+				Labels:          map[string]string{"label": "test"},
+				IntervalSeconds: 10,
+				For:             20 * time.Second,
+				ForError:        20 * time.Second,
+				ExecErrState:    models.ErrorErrState,
+			},
+			evalResults: []eval.Results{
+				{
+					eval.Result{
+						Instance: data.Labels{"instance_label": "test"},
+						State:    eval.Error,
+						Error: expr.QueryError{
+							RefID: "A",
+							Err:   errors.New("this is an error"),
+						},
+						EvaluatedAt:        evaluationTime,
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+				{
+					eval.Result{
+						Instance: data.Labels{"instance_label": "test"},
+						State:    eval.Error,
+						Error: expr.QueryError{
+							RefID: "A",
+							Err:   errors.New("this is an error"),
+						},
+						EvaluatedAt:        evaluationTime.Add(10 * time.Second),
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+				{
+					eval.Result{
+						Instance:           data.Labels{"instance_label": "test"},
+						State:              eval.Alerting,
+						EvaluatedAt:        evaluationTime.Add(20 * time.Second),
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+				{
+					eval.Result{
+						Instance:           data.Labels{"instance_label": "test"},
+						State:              eval.Alerting,
+						EvaluatedAt:        evaluationTime.Add(30 * time.Second),
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+			},
+			expectedAnnotations: 2,
+			expectedStates: map[string]*state.State{
+				`[["__alert_rule_namespace_uid__","test_namespace_uid"],["__alert_rule_uid__","test_alert_rule_uid_2"],["alertname","test_title"],["instance_label","test"],["label","test"]]`: {
+					AlertRuleUID: "test_alert_rule_uid_2",
+					OrgID:        1,
+					CacheID:      `[["__alert_rule_namespace_uid__","test_namespace_uid"],["__alert_rule_uid__","test_alert_rule_uid_2"],["alertname","test_title"],["instance_label","test"],["label","test"]]`,
+					Labels: data.Labels{
+						"__alert_rule_namespace_uid__": "test_namespace_uid",
+						"__alert_rule_uid__":           "test_alert_rule_uid_2",
+						"alertname":                    "test_title",
+						"label":                        "test",
+						"instance_label":               "test",
+					},
+					Values: make(map[string]float64),
+					State:  eval.Pending,
+					Results: []state.Evaluation{
+						{
+							EvaluationTime:  evaluationTime.Add(20 * time.Second),
+							EvaluationState: eval.Alerting,
+							Values:          make(map[string]*float64),
+						},
+						{
+							EvaluationTime:  evaluationTime.Add(30 * time.Second),
+							EvaluationState: eval.Alerting,
+							Values:          make(map[string]*float64),
+						},
+					},
+					StartsAt:           evaluationTime.Add(20 * time.Second),
+					EndsAt:             evaluationTime.Add(20 * time.Second).Add(state.ResendDelay * 3),
+					LastEvaluationTime: evaluationTime.Add(30 * time.Second),
+					EvaluationDuration: evaluationDuration,
+					Annotations:        map[string]string{"annotation": "test"},
+				},
+			},
+		},
+		{
+			desc: "normal -> pending -> alerting -> pending error -> error -> pending -> alerting when result is Error and ExecErrorState is Error with For and ForError set",
+			alertRule: &models.AlertRule{
+				OrgID:           1,
+				Title:           "test_title",
+				UID:             "test_alert_rule_uid_2",
+				NamespaceUID:    "test_namespace_uid",
+				Annotations:     map[string]string{"annotation": "test"},
+				Labels:          map[string]string{"label": "test"},
+				IntervalSeconds: 10,
+				For:             20 * time.Second,
+				ForError:        20 * time.Second,
+				ExecErrState:    models.ErrorErrState,
+			},
+			evalResults: []eval.Results{
+				{
+					eval.Result{
+						Instance:           data.Labels{"instance_label": "test"},
+						State:              eval.Normal,
+						EvaluatedAt:        evaluationTime,
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+				{
+					eval.Result{
+						Instance:           data.Labels{"instance_label": "test"},
+						State:              eval.Alerting,
+						EvaluatedAt:        evaluationTime.Add(10 * time.Second),
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+				{
+					eval.Result{
+						Instance:           data.Labels{"instance_label": "test"},
+						State:              eval.Alerting,
+						EvaluatedAt:        evaluationTime.Add(20 * time.Second),
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+				{
+					eval.Result{
+						Instance:           data.Labels{"instance_label": "test"},
+						State:              eval.Alerting,
+						EvaluatedAt:        evaluationTime.Add(30 * time.Second),
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+				{
+					eval.Result{
+						Instance: data.Labels{"instance_label": "test"},
+						State:    eval.Error,
+						Error: expr.QueryError{
+							RefID: "A",
+							Err:   errors.New("this is an error"),
+						},
+						EvaluatedAt:        evaluationTime.Add(40 * time.Second),
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+				{
+					eval.Result{
+						Instance: data.Labels{"instance_label": "test"},
+						State:    eval.Error,
+						Error: expr.QueryError{
+							RefID: "A",
+							Err:   errors.New("this is an error"),
+						},
+						EvaluatedAt:        evaluationTime.Add(50 * time.Second),
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+				{
+					eval.Result{
+						Instance: data.Labels{"instance_label": "test"},
+						State:    eval.Error,
+						Error: expr.QueryError{
+							RefID: "A",
+							Err:   errors.New("this is an error"),
+						},
+						EvaluatedAt:        evaluationTime.Add(60 * time.Second),
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+				{
+					eval.Result{
+						Instance:           data.Labels{"instance_label": "test"},
+						State:              eval.Alerting,
+						EvaluatedAt:        evaluationTime.Add(70 * time.Second),
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+				{
+					eval.Result{
+						Instance:           data.Labels{"instance_label": "test"},
+						State:              eval.Alerting,
+						EvaluatedAt:        evaluationTime.Add(80 * time.Second),
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+				{
+					eval.Result{
+						Instance:           data.Labels{"instance_label": "test"},
+						State:              eval.Alerting,
+						EvaluatedAt:        evaluationTime.Add(90 * time.Second),
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+			},
+			expectedAnnotations: 6,
+			expectedStates: map[string]*state.State{
+				`[["__alert_rule_namespace_uid__","test_namespace_uid"],["__alert_rule_uid__","test_alert_rule_uid_2"],["alertname","test_title"],["instance_label","test"],["label","test"]]`: {
+					AlertRuleUID: "test_alert_rule_uid_2",
+					OrgID:        1,
+					CacheID:      `[["__alert_rule_namespace_uid__","test_namespace_uid"],["__alert_rule_uid__","test_alert_rule_uid_2"],["alertname","test_title"],["instance_label","test"],["label","test"]]`,
+					Labels: data.Labels{
+						"__alert_rule_namespace_uid__": "test_namespace_uid",
+						"__alert_rule_uid__":           "test_alert_rule_uid_2",
+						"alertname":                    "test_title",
+						"label":                        "test",
+						"instance_label":               "test",
+					},
+					Values: make(map[string]float64),
+					State:  eval.Alerting,
+					Results: []state.Evaluation{
+						{
+							EvaluationTime:  evaluationTime.Add(80 * time.Second),
+							EvaluationState: eval.Alerting,
+							Values:          make(map[string]*float64),
+						},
+						{
+							EvaluationTime:  evaluationTime.Add(90 * time.Second),
+							EvaluationState: eval.Alerting,
+							Values:          make(map[string]*float64),
+						},
+					},
+					StartsAt:           evaluationTime.Add(90 * time.Second),
+					EndsAt:             evaluationTime.Add(90 * time.Second).Add(state.ResendDelay * 3),
+					LastEvaluationTime: evaluationTime.Add(90 * time.Second),
 					EvaluationDuration: evaluationDuration,
 					Annotations:        map[string]string{"annotation": "test"},
 				},

--- a/pkg/services/ngalert/state/state.go
+++ b/pkg/services/ngalert/state/state.go
@@ -100,6 +100,15 @@ func (a *State) SetPending(reason string, startsAt, endsAt time.Time) {
 	a.Error = nil
 }
 
+// SetPendingError the state to Pending for Error state. It changes both the start and end time.
+func (a *State) SetPendingError(err error, startsAt, endsAt time.Time) {
+	a.State = eval.Pending
+	a.StateReason = models.StateReasonError
+	a.StartsAt = startsAt
+	a.EndsAt = endsAt
+	a.Error = err
+}
+
 // SetNoData sets the state to NoData. It changes both the start and end time.
 func (a *State) SetNoData(reason string, startsAt, endsAt time.Time) {
 	a.State = eval.NoData
@@ -195,11 +204,11 @@ func resultNormal(state *State, _ *models.AlertRule, result eval.Result, logger 
 }
 
 func resultAlerting(state *State, rule *models.AlertRule, result eval.Result, logger log.Logger) {
-	switch state.State {
-	case eval.Alerting:
+	switch {
+	case state.State == eval.Alerting:
 		logger.Debug("Keeping state", "state", state.State)
 		state.Maintain(rule.IntervalSeconds, result.EvaluatedAt)
-	case eval.Pending:
+	case state.State == eval.Pending && state.Error == nil:
 		// If the previous state is Pending then check if the For duration has been observed
 		if result.EvaluatedAt.Sub(state.StartsAt) >= rule.For {
 			logger.Debug("Changing state", "previous_state", state.State, "next_state", eval.Alerting)
@@ -216,6 +225,7 @@ func resultAlerting(state *State, rule *models.AlertRule, result eval.Result, lo
 		}
 	}
 }
+
 func resultError(state *State, rule *models.AlertRule, result eval.Result, logger log.Logger) {
 	switch rule.ExecErrState {
 	case models.AlertingErrState:
@@ -228,11 +238,14 @@ func resultError(state *State, rule *models.AlertRule, result eval.Result, logge
 		if state.State == eval.Error {
 			logger.Debug("Keeping state", "state", state.State)
 			state.Maintain(rule.IntervalSeconds, result.EvaluatedAt)
+		} else if state.State == eval.Pending && state.Error != nil {
+			// If the previous state is Pending then check if the ForError duration has been observed
+			if result.EvaluatedAt.Sub(state.StartsAt) >= rule.ForError {
+				logger.Debug("Changing state", "previous_state", state.State, "next_state", eval.Error)
+				state.SetError(result.Error, result.EvaluatedAt, nextEndsTime(rule.IntervalSeconds, result.EvaluatedAt))
+			}
 		} else {
 			// This is the first occurrence of an error
-			logger.Debug("Changing state", "previous_state", state.State, "next_state", eval.Error)
-			state.SetError(result.Error, result.EvaluatedAt, nextEndsTime(rule.IntervalSeconds, result.EvaluatedAt))
-
 			if result.Error != nil {
 				state.Annotations["Error"] = result.Error.Error()
 				// If the evaluation failed because a query returned an error then add the Ref ID and
@@ -247,6 +260,14 @@ func resultError(state *State, rule *models.AlertRule, result eval.Result, logge
 						}
 					}
 				}
+			}
+			if rule.ForError > 0 {
+				// If the alert rule has a For duration that should be observed then the state should be set to Pending
+				logger.Debug("Changing state", "previous_state", state.State, "next_state", eval.Pending)
+				state.SetPendingError(result.Error, result.EvaluatedAt, nextEndsTime(rule.IntervalSeconds, result.EvaluatedAt))
+			} else {
+				logger.Debug("Changing state", "previous_state", state.State, "next_state", eval.Alerting)
+				state.SetError(result.Error, result.EvaluatedAt, nextEndsTime(rule.IntervalSeconds, result.EvaluatedAt))
 			}
 		}
 	case models.OkErrState:

--- a/pkg/services/ngalert/state/state.go
+++ b/pkg/services/ngalert/state/state.go
@@ -21,7 +21,7 @@ import (
 type Cause int
 
 const (
-	NoCause Cause = iota
+	CauseNone Cause = iota
 	CauseFiring
 	CauseError
 	CauseNoData
@@ -152,7 +152,7 @@ func (a *State) SetNormal(reason string, cause Cause, startsAt, endsAt time.Time
 // Resolve sets the State to Normal. It updates the StateReason, the end time, and sets Resolved to true.
 func (a *State) Resolve(reason string, endsAt time.Time) {
 	a.State = eval.Normal
-	a.Cause = NoCause
+	a.Cause = CauseNone
 	a.StateReason = reason
 	a.Resolved = true
 	a.EndsAt = endsAt

--- a/pkg/services/ngalert/state/state_test.go
+++ b/pkg/services/ngalert/state/state_test.go
@@ -109,6 +109,54 @@ func TestSetPending(t *testing.T) {
 	}
 }
 
+func TestSetPendingError(t *testing.T) {
+	mock := clock.NewMock()
+	tests := []struct {
+		name     string
+		state    State
+		startsAt time.Time
+		endsAt   time.Time
+		error    error
+		expected State
+	}{{
+		name:     "state is set to Pending with error",
+		error:    errors.New("this is an error"),
+		startsAt: mock.Now(),
+		endsAt:   mock.Now().Add(time.Minute),
+		expected: State{
+			State:       eval.Pending,
+			StateReason: ngmodels.StateReasonError,
+			StartsAt:    mock.Now(),
+			EndsAt:      mock.Now().Add(time.Minute),
+			Error:       errors.New("this is an error"),
+		},
+	}, {
+		name:  "previous state is removed",
+		error: errors.New("this is an error"),
+		state: State{
+			State:       eval.Pending,
+			StateReason: "this is a reason",
+		},
+		startsAt: mock.Now(),
+		endsAt:   mock.Now().Add(time.Minute),
+		expected: State{
+			State:       eval.Pending,
+			StateReason: ngmodels.StateReasonError,
+			StartsAt:    mock.Now(),
+			EndsAt:      mock.Now().Add(time.Minute),
+			Error:       errors.New("this is an error"),
+		},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := test.state
+			actual.SetPendingError(test.error, test.startsAt, test.endsAt)
+			assert.Equal(t, test.expected, actual)
+		})
+	}
+}
+
 func TestNormal(t *testing.T) {
 	mock := clock.NewMock()
 	tests := []struct {

--- a/pkg/services/ngalert/state/state_test.go
+++ b/pkg/services/ngalert/state/state_test.go
@@ -134,7 +134,7 @@ func TestNormal(t *testing.T) {
 		endsAt:   mock.Now().Add(time.Minute),
 		expected: State{
 			State:       eval.Normal,
-			Cause:       NoCause,
+			Cause:       CauseNone,
 			StateReason: "this is a reason",
 			StartsAt:    mock.Now(),
 			EndsAt:      mock.Now().Add(time.Minute),
@@ -150,7 +150,7 @@ func TestNormal(t *testing.T) {
 		endsAt:   mock.Now().Add(time.Minute),
 		expected: State{
 			State:    eval.Normal,
-			Cause:    NoCause,
+			Cause:    CauseNone,
 			StartsAt: mock.Now(),
 			EndsAt:   mock.Now().Add(time.Minute),
 		},
@@ -159,7 +159,7 @@ func TestNormal(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			actual := test.state
-			actual.SetNormal(test.reason, NoCause, test.startsAt, test.endsAt)
+			actual.SetNormal(test.reason, CauseNone, test.startsAt, test.endsAt)
 			assert.Equal(t, test.expected, actual)
 		})
 	}

--- a/pkg/services/ngalert/state/state_test.go
+++ b/pkg/services/ngalert/state/state_test.go
@@ -64,7 +64,7 @@ func TestSetAlerting(t *testing.T) {
 	}
 }
 
-func TestSetPending(t *testing.T) {
+func TestSetPendingAlerting(t *testing.T) {
 	mock := clock.NewMock()
 	tests := []struct {
 		name     string
@@ -79,31 +79,34 @@ func TestSetPending(t *testing.T) {
 		startsAt: mock.Now(),
 		endsAt:   mock.Now().Add(time.Minute),
 		expected: State{
-			State:       eval.Pending,
-			StateReason: "this is a reason",
-			StartsAt:    mock.Now(),
-			EndsAt:      mock.Now().Add(time.Minute),
+			State:        eval.Pending,
+			PendingState: PendingStateAlerting,
+			StateReason:  "this is a reason",
+			StartsAt:     mock.Now(),
+			EndsAt:       mock.Now().Add(time.Minute),
 		},
 	}, {
 		name: "previous state is removed",
 		state: State{
-			State:       eval.Pending,
-			StateReason: "this is a reason",
-			Error:       errors.New("this is an error"),
+			State:        eval.Pending,
+			PendingState: PendingStateAlerting,
+			StateReason:  "this is a reason",
+			Error:        errors.New("this is an error"),
 		},
 		startsAt: mock.Now(),
 		endsAt:   mock.Now().Add(time.Minute),
 		expected: State{
-			State:    eval.Pending,
-			StartsAt: mock.Now(),
-			EndsAt:   mock.Now().Add(time.Minute),
+			State:        eval.Pending,
+			PendingState: PendingStateAlerting,
+			StartsAt:     mock.Now(),
+			EndsAt:       mock.Now().Add(time.Minute),
 		},
 	}}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			actual := test.state
-			actual.SetPending(test.reason, test.startsAt, test.endsAt)
+			actual.SetPendingAlerting(test.reason, test.startsAt, test.endsAt)
 			assert.Equal(t, test.expected, actual)
 		})
 	}
@@ -124,27 +127,30 @@ func TestSetPendingError(t *testing.T) {
 		startsAt: mock.Now(),
 		endsAt:   mock.Now().Add(time.Minute),
 		expected: State{
-			State:       eval.Pending,
-			StateReason: ngmodels.StateReasonError,
-			StartsAt:    mock.Now(),
-			EndsAt:      mock.Now().Add(time.Minute),
-			Error:       errors.New("this is an error"),
+			State:        eval.Pending,
+			PendingState: PendingStateError,
+			StateReason:  ngmodels.StateReasonError,
+			StartsAt:     mock.Now(),
+			EndsAt:       mock.Now().Add(time.Minute),
+			Error:        errors.New("this is an error"),
 		},
 	}, {
 		name:  "previous state is removed",
 		error: errors.New("this is an error"),
 		state: State{
-			State:       eval.Pending,
-			StateReason: "this is a reason",
+			State:        eval.Pending,
+			PendingState: PendingStateError,
+			StateReason:  "this is a reason",
 		},
 		startsAt: mock.Now(),
 		endsAt:   mock.Now().Add(time.Minute),
 		expected: State{
-			State:       eval.Pending,
-			StateReason: ngmodels.StateReasonError,
-			StartsAt:    mock.Now(),
-			EndsAt:      mock.Now().Add(time.Minute),
-			Error:       errors.New("this is an error"),
+			State:        eval.Pending,
+			PendingState: PendingStateError,
+			StateReason:  ngmodels.StateReasonError,
+			StartsAt:     mock.Now(),
+			EndsAt:       mock.Now().Add(time.Minute),
+			Error:        errors.New("this is an error"),
 		},
 	}}
 

--- a/pkg/services/ngalert/store/instance_database.go
+++ b/pkg/services/ngalert/store/instance_database.go
@@ -60,7 +60,7 @@ func (st DBstore) SaveAlertInstances(ctx context.Context, cmd ...models.AlertIns
 		//  per write.
 		keyNames := []string{"rule_org_id", "rule_uid", "labels_hash"}
 		fieldNames := []string{
-			"rule_org_id", "rule_uid", "labels", "labels_hash", "current_state",
+			"rule_org_id", "rule_uid", "labels", "labels_hash", "current_state", "current_pending_state",
 			"current_reason", "current_state_since", "current_state_end", "last_eval_time",
 		}
 		fieldsPerRow := len(fieldNames)
@@ -93,8 +93,9 @@ func (st DBstore) SaveAlertInstances(ctx context.Context, cmd ...models.AlertIns
 
 			args = append(args,
 				alertInstance.RuleOrgID, alertInstance.RuleUID, labelTupleJSON, alertInstance.LabelsHash,
-				alertInstance.CurrentState, alertInstance.CurrentReason, alertInstance.CurrentStateSince.Unix(),
-				alertInstance.CurrentStateEnd.Unix(), alertInstance.LastEvalTime.Unix())
+				alertInstance.CurrentState, alertInstance.CurrentPendingState, alertInstance.CurrentReason,
+				alertInstance.CurrentStateSince.Unix(), alertInstance.CurrentStateEnd.Unix(),
+				alertInstance.LastEvalTime.Unix())
 
 			// If we've reached the maximum batch size, write to the database.
 			if values(args) >= maxArgs {
@@ -146,12 +147,15 @@ func (st DBstore) SaveAlertInstance(ctx context.Context, alertInstance models.Al
 		if err != nil {
 			return err
 		}
-		params := append(make([]interface{}, 0), alertInstance.RuleOrgID, alertInstance.RuleUID, labelTupleJSON, alertInstance.LabelsHash, alertInstance.CurrentState, alertInstance.CurrentReason, alertInstance.CurrentStateSince.Unix(), alertInstance.CurrentStateEnd.Unix(), alertInstance.LastEvalTime.Unix())
+		params := append(make([]interface{}, 0), alertInstance.RuleOrgID, alertInstance.RuleUID, labelTupleJSON,
+			alertInstance.LabelsHash, alertInstance.CurrentState, alertInstance.CurrentPendingState,
+			alertInstance.CurrentReason, alertInstance.CurrentStateSince.Unix(), alertInstance.CurrentStateEnd.Unix(),
+			alertInstance.LastEvalTime.Unix())
 
 		upsertSQL := st.SQLStore.GetDialect().UpsertSQL(
 			"alert_instance",
 			[]string{"rule_org_id", "rule_uid", "labels_hash"},
-			[]string{"rule_org_id", "rule_uid", "labels", "labels_hash", "current_state", "current_reason", "current_state_since", "current_state_end", "last_eval_time"})
+			[]string{"rule_org_id", "rule_uid", "labels", "labels_hash", "current_state", "current_pending_state", "current_reason", "current_state_since", "current_state_end", "last_eval_time"})
 		_, err = sess.SQL(upsertSQL, params...).Query()
 		if err != nil {
 			return err

--- a/pkg/services/ngalert/store/instance_database.go
+++ b/pkg/services/ngalert/store/instance_database.go
@@ -60,7 +60,7 @@ func (st DBstore) SaveAlertInstances(ctx context.Context, cmd ...models.AlertIns
 		//  per write.
 		keyNames := []string{"rule_org_id", "rule_uid", "labels_hash"}
 		fieldNames := []string{
-			"rule_org_id", "rule_uid", "labels", "labels_hash", "current_state", "current_pending_state",
+			"rule_org_id", "rule_uid", "labels", "labels_hash", "current_state", "current_cause",
 			"current_reason", "current_state_since", "current_state_end", "last_eval_time",
 		}
 		fieldsPerRow := len(fieldNames)
@@ -93,7 +93,7 @@ func (st DBstore) SaveAlertInstances(ctx context.Context, cmd ...models.AlertIns
 
 			args = append(args,
 				alertInstance.RuleOrgID, alertInstance.RuleUID, labelTupleJSON, alertInstance.LabelsHash,
-				alertInstance.CurrentState, alertInstance.CurrentPendingState, alertInstance.CurrentReason,
+				alertInstance.CurrentState, alertInstance.CurrentCause, alertInstance.CurrentReason,
 				alertInstance.CurrentStateSince.Unix(), alertInstance.CurrentStateEnd.Unix(),
 				alertInstance.LastEvalTime.Unix())
 
@@ -148,14 +148,14 @@ func (st DBstore) SaveAlertInstance(ctx context.Context, alertInstance models.Al
 			return err
 		}
 		params := append(make([]interface{}, 0), alertInstance.RuleOrgID, alertInstance.RuleUID, labelTupleJSON,
-			alertInstance.LabelsHash, alertInstance.CurrentState, alertInstance.CurrentPendingState,
+			alertInstance.LabelsHash, alertInstance.CurrentState, alertInstance.CurrentCause,
 			alertInstance.CurrentReason, alertInstance.CurrentStateSince.Unix(), alertInstance.CurrentStateEnd.Unix(),
 			alertInstance.LastEvalTime.Unix())
 
 		upsertSQL := st.SQLStore.GetDialect().UpsertSQL(
 			"alert_instance",
 			[]string{"rule_org_id", "rule_uid", "labels_hash"},
-			[]string{"rule_org_id", "rule_uid", "labels", "labels_hash", "current_state", "current_pending_state", "current_reason", "current_state_since", "current_state_end", "last_eval_time"})
+			[]string{"rule_org_id", "rule_uid", "labels", "labels_hash", "current_state", "current_cause", "current_reason", "current_state_since", "current_state_end", "last_eval_time"})
 		_, err = sess.SQL(upsertSQL, params...).Query()
 		if err != nil {
 			return err

--- a/pkg/services/ngalert/store/instance_database_test.go
+++ b/pkg/services/ngalert/store/instance_database_test.go
@@ -38,9 +38,10 @@ func BenchmarkAlertInstanceOperations(b *testing.B) {
 				RuleUID:    alertRule.UID,
 				LabelsHash: labelsHash,
 			},
-			CurrentState:  models.InstanceStateFiring,
-			CurrentReason: string(models.InstanceStateError),
-			Labels:        labels,
+			CurrentState:        models.InstanceStateFiring,
+			CurrentPendingState: models.InstancePendingStateEmpty,
+			CurrentReason:       string(models.InstanceStateError),
+			Labels:              labels,
 		}
 		instances = append(instances, instance)
 		keys = append(keys, instance.AlertInstanceKey)
@@ -78,9 +79,10 @@ func TestIntegrationAlertInstanceBulkWrite(t *testing.T) {
 					RuleUID:    alertRule.UID,
 					LabelsHash: labelsHash,
 				},
-				CurrentState:  models.InstanceStateFiring,
-				CurrentReason: string(models.InstanceStateError),
-				Labels:        labels,
+				CurrentState:        models.InstanceStateFiring,
+				CurrentPendingState: models.InstancePendingStateEmpty,
+				CurrentReason:       string(models.InstanceStateError),
+				Labels:              labels,
 			}
 			instances = append(instances, instance)
 			keys = append(keys, instance.AlertInstanceKey)
@@ -160,9 +162,10 @@ func TestIntegrationAlertInstanceOperations(t *testing.T) {
 				RuleUID:    alertRule1.UID,
 				LabelsHash: hash,
 			},
-			CurrentState:  models.InstanceStateFiring,
-			CurrentReason: string(models.InstanceStateError),
-			Labels:        labels,
+			CurrentState:        models.InstanceStateFiring,
+			CurrentPendingState: models.InstancePendingStateEmpty,
+			CurrentReason:       string(models.InstanceStateError),
+			Labels:              labels,
 		}
 		err := dbstore.SaveAlertInstances(ctx, instance)
 		require.NoError(t, err)
@@ -190,8 +193,9 @@ func TestIntegrationAlertInstanceOperations(t *testing.T) {
 				RuleUID:    alertRule2.UID,
 				LabelsHash: hash,
 			},
-			CurrentState: models.InstanceStateNormal,
-			Labels:       labels,
+			CurrentState:        models.InstanceStateNormal,
+			CurrentPendingState: models.InstancePendingStateEmpty,
+			Labels:              labels,
 		}
 		err := dbstore.SaveAlertInstances(ctx, instance)
 		require.NoError(t, err)
@@ -219,8 +223,9 @@ func TestIntegrationAlertInstanceOperations(t *testing.T) {
 				RuleUID:    alertRule3.UID,
 				LabelsHash: hash,
 			},
-			CurrentState: models.InstanceStateFiring,
-			Labels:       labels,
+			CurrentState:        models.InstanceStateFiring,
+			CurrentPendingState: models.InstancePendingStateEmpty,
+			Labels:              labels,
 		}
 
 		err := dbstore.SaveAlertInstances(ctx, instance1)
@@ -234,8 +239,9 @@ func TestIntegrationAlertInstanceOperations(t *testing.T) {
 				RuleUID:    instance1.RuleUID,
 				LabelsHash: hash,
 			},
-			CurrentState: models.InstanceStateFiring,
-			Labels:       labels,
+			CurrentState:        models.InstanceStateFiring,
+			CurrentPendingState: models.InstancePendingStateEmpty,
+			Labels:              labels,
 		}
 		err = dbstore.SaveAlertInstances(ctx, instance2)
 		require.NoError(t, err)
@@ -270,9 +276,10 @@ func TestIntegrationAlertInstanceOperations(t *testing.T) {
 				RuleUID:    util.GenerateShortUID(),
 				LabelsHash: util.GenerateShortUID(),
 			},
-			CurrentState:  models.InstanceStateNormal,
-			CurrentReason: "",
-			Labels:        labels,
+			CurrentState:        models.InstanceStateNormal,
+			CurrentPendingState: models.InstancePendingStateEmpty,
+			CurrentReason:       "",
+			Labels:              labels,
 		}
 		instance2 := models.AlertInstance{
 			AlertInstanceKey: models.AlertInstanceKey{
@@ -280,9 +287,10 @@ func TestIntegrationAlertInstanceOperations(t *testing.T) {
 				RuleUID:    util.GenerateShortUID(),
 				LabelsHash: util.GenerateShortUID(),
 			},
-			CurrentState:  models.InstanceStateNormal,
-			CurrentReason: models.StateReasonError,
-			Labels:        labels,
+			CurrentState:        models.InstanceStateNormal,
+			CurrentPendingState: models.InstancePendingStateEmpty,
+			CurrentReason:       models.StateReasonError,
+			Labels:              labels,
 		}
 		err := dbstore.SaveAlertInstances(ctx, instance1, instance2)
 		require.NoError(t, err)
@@ -323,8 +331,9 @@ func TestIntegrationAlertInstanceOperations(t *testing.T) {
 				RuleUID:    alertRule4.UID,
 				LabelsHash: hash,
 			},
-			CurrentState: models.InstanceStateFiring,
-			Labels:       labels,
+			CurrentState:        models.InstanceStateFiring,
+			CurrentPendingState: models.InstancePendingStateEmpty,
+			Labels:              labels,
 		}
 
 		err := dbstore.SaveAlertInstances(ctx, instance1)
@@ -336,8 +345,9 @@ func TestIntegrationAlertInstanceOperations(t *testing.T) {
 				RuleUID:    instance1.RuleUID,
 				LabelsHash: instance1.LabelsHash,
 			},
-			CurrentState: models.InstanceStateNormal,
-			Labels:       instance1.Labels,
+			CurrentState:        models.InstanceStateNormal,
+			CurrentPendingState: models.InstancePendingStateEmpty,
+			Labels:              instance1.Labels,
 		}
 		err = dbstore.SaveAlertInstances(ctx, instance2)
 		require.NoError(t, err)
@@ -356,5 +366,6 @@ func TestIntegrationAlertInstanceOperations(t *testing.T) {
 		require.Equal(t, instance2.RuleUID, listQuery.Result[0].RuleUID)
 		require.Equal(t, instance2.Labels, listQuery.Result[0].Labels)
 		require.Equal(t, instance2.CurrentState, listQuery.Result[0].CurrentState)
+		require.Equal(t, instance2.CurrentPendingState, listQuery.Result[0].CurrentPendingState)
 	})
 }

--- a/pkg/services/ngalert/store/instance_database_test.go
+++ b/pkg/services/ngalert/store/instance_database_test.go
@@ -38,10 +38,10 @@ func BenchmarkAlertInstanceOperations(b *testing.B) {
 				RuleUID:    alertRule.UID,
 				LabelsHash: labelsHash,
 			},
-			CurrentState:        models.InstanceStateFiring,
-			CurrentPendingState: models.InstancePendingStateEmpty,
-			CurrentReason:       string(models.InstanceStateError),
-			Labels:              labels,
+			CurrentState:  models.InstanceStateFiring,
+			CurrentCause:  models.InstanceNoCause,
+			CurrentReason: string(models.InstanceStateError),
+			Labels:        labels,
 		}
 		instances = append(instances, instance)
 		keys = append(keys, instance.AlertInstanceKey)
@@ -79,10 +79,10 @@ func TestIntegrationAlertInstanceBulkWrite(t *testing.T) {
 					RuleUID:    alertRule.UID,
 					LabelsHash: labelsHash,
 				},
-				CurrentState:        models.InstanceStateFiring,
-				CurrentPendingState: models.InstancePendingStateEmpty,
-				CurrentReason:       string(models.InstanceStateError),
-				Labels:              labels,
+				CurrentState:  models.InstanceStateFiring,
+				CurrentCause:  models.InstanceCauseFiring,
+				CurrentReason: string(models.InstanceStateError),
+				Labels:        labels,
 			}
 			instances = append(instances, instance)
 			keys = append(keys, instance.AlertInstanceKey)
@@ -162,10 +162,10 @@ func TestIntegrationAlertInstanceOperations(t *testing.T) {
 				RuleUID:    alertRule1.UID,
 				LabelsHash: hash,
 			},
-			CurrentState:        models.InstanceStateFiring,
-			CurrentPendingState: models.InstancePendingStateEmpty,
-			CurrentReason:       string(models.InstanceStateError),
-			Labels:              labels,
+			CurrentState:  models.InstanceStateFiring,
+			CurrentCause:  models.InstanceCauseError,
+			CurrentReason: string(models.InstanceStateError),
+			Labels:        labels,
 		}
 		err := dbstore.SaveAlertInstances(ctx, instance)
 		require.NoError(t, err)
@@ -193,9 +193,9 @@ func TestIntegrationAlertInstanceOperations(t *testing.T) {
 				RuleUID:    alertRule2.UID,
 				LabelsHash: hash,
 			},
-			CurrentState:        models.InstanceStateNormal,
-			CurrentPendingState: models.InstancePendingStateEmpty,
-			Labels:              labels,
+			CurrentState: models.InstanceStateNormal,
+			CurrentCause: models.InstanceNoCause,
+			Labels:       labels,
 		}
 		err := dbstore.SaveAlertInstances(ctx, instance)
 		require.NoError(t, err)
@@ -223,9 +223,9 @@ func TestIntegrationAlertInstanceOperations(t *testing.T) {
 				RuleUID:    alertRule3.UID,
 				LabelsHash: hash,
 			},
-			CurrentState:        models.InstanceStateFiring,
-			CurrentPendingState: models.InstancePendingStateEmpty,
-			Labels:              labels,
+			CurrentState: models.InstanceStateFiring,
+			CurrentCause: models.InstanceCauseFiring,
+			Labels:       labels,
 		}
 
 		err := dbstore.SaveAlertInstances(ctx, instance1)
@@ -239,9 +239,9 @@ func TestIntegrationAlertInstanceOperations(t *testing.T) {
 				RuleUID:    instance1.RuleUID,
 				LabelsHash: hash,
 			},
-			CurrentState:        models.InstanceStateFiring,
-			CurrentPendingState: models.InstancePendingStateEmpty,
-			Labels:              labels,
+			CurrentState: models.InstanceStateFiring,
+			CurrentCause: models.InstanceCauseFiring,
+			Labels:       labels,
 		}
 		err = dbstore.SaveAlertInstances(ctx, instance2)
 		require.NoError(t, err)
@@ -276,10 +276,10 @@ func TestIntegrationAlertInstanceOperations(t *testing.T) {
 				RuleUID:    util.GenerateShortUID(),
 				LabelsHash: util.GenerateShortUID(),
 			},
-			CurrentState:        models.InstanceStateNormal,
-			CurrentPendingState: models.InstancePendingStateEmpty,
-			CurrentReason:       "",
-			Labels:              labels,
+			CurrentState:  models.InstanceStateNormal,
+			CurrentCause:  models.InstanceNoCause,
+			CurrentReason: "",
+			Labels:        labels,
 		}
 		instance2 := models.AlertInstance{
 			AlertInstanceKey: models.AlertInstanceKey{
@@ -287,10 +287,10 @@ func TestIntegrationAlertInstanceOperations(t *testing.T) {
 				RuleUID:    util.GenerateShortUID(),
 				LabelsHash: util.GenerateShortUID(),
 			},
-			CurrentState:        models.InstanceStateNormal,
-			CurrentPendingState: models.InstancePendingStateEmpty,
-			CurrentReason:       models.StateReasonError,
-			Labels:              labels,
+			CurrentState:  models.InstanceStateNormal,
+			CurrentCause:  models.InstanceNoCause,
+			CurrentReason: models.StateReasonError,
+			Labels:        labels,
 		}
 		err := dbstore.SaveAlertInstances(ctx, instance1, instance2)
 		require.NoError(t, err)
@@ -331,9 +331,9 @@ func TestIntegrationAlertInstanceOperations(t *testing.T) {
 				RuleUID:    alertRule4.UID,
 				LabelsHash: hash,
 			},
-			CurrentState:        models.InstanceStateFiring,
-			CurrentPendingState: models.InstancePendingStateEmpty,
-			Labels:              labels,
+			CurrentState: models.InstanceStateFiring,
+			CurrentCause: models.InstanceCauseFiring,
+			Labels:       labels,
 		}
 
 		err := dbstore.SaveAlertInstances(ctx, instance1)
@@ -345,9 +345,9 @@ func TestIntegrationAlertInstanceOperations(t *testing.T) {
 				RuleUID:    instance1.RuleUID,
 				LabelsHash: instance1.LabelsHash,
 			},
-			CurrentState:        models.InstanceStateNormal,
-			CurrentPendingState: models.InstancePendingStateEmpty,
-			Labels:              instance1.Labels,
+			CurrentState: models.InstanceStateNormal,
+			CurrentCause: models.InstanceNoCause,
+			Labels:       instance1.Labels,
 		}
 		err = dbstore.SaveAlertInstances(ctx, instance2)
 		require.NoError(t, err)
@@ -366,6 +366,6 @@ func TestIntegrationAlertInstanceOperations(t *testing.T) {
 		require.Equal(t, instance2.RuleUID, listQuery.Result[0].RuleUID)
 		require.Equal(t, instance2.Labels, listQuery.Result[0].Labels)
 		require.Equal(t, instance2.CurrentState, listQuery.Result[0].CurrentState)
-		require.Equal(t, instance2.CurrentPendingState, listQuery.Result[0].CurrentPendingState)
+		require.Equal(t, instance2.CurrentCause, listQuery.Result[0].CurrentCause)
 	})
 }

--- a/pkg/services/ngalert/store/instance_database_test.go
+++ b/pkg/services/ngalert/store/instance_database_test.go
@@ -39,7 +39,7 @@ func BenchmarkAlertInstanceOperations(b *testing.B) {
 				LabelsHash: labelsHash,
 			},
 			CurrentState:  models.InstanceStateFiring,
-			CurrentCause:  models.InstanceNoCause,
+			CurrentCause:  models.InstanceCauseNone,
 			CurrentReason: string(models.InstanceStateError),
 			Labels:        labels,
 		}
@@ -194,7 +194,7 @@ func TestIntegrationAlertInstanceOperations(t *testing.T) {
 				LabelsHash: hash,
 			},
 			CurrentState: models.InstanceStateNormal,
-			CurrentCause: models.InstanceNoCause,
+			CurrentCause: models.InstanceCauseNone,
 			Labels:       labels,
 		}
 		err := dbstore.SaveAlertInstances(ctx, instance)
@@ -277,7 +277,7 @@ func TestIntegrationAlertInstanceOperations(t *testing.T) {
 				LabelsHash: util.GenerateShortUID(),
 			},
 			CurrentState:  models.InstanceStateNormal,
-			CurrentCause:  models.InstanceNoCause,
+			CurrentCause:  models.InstanceCauseNone,
 			CurrentReason: "",
 			Labels:        labels,
 		}
@@ -288,7 +288,7 @@ func TestIntegrationAlertInstanceOperations(t *testing.T) {
 				LabelsHash: util.GenerateShortUID(),
 			},
 			CurrentState:  models.InstanceStateNormal,
-			CurrentCause:  models.InstanceNoCause,
+			CurrentCause:  models.InstanceCauseNone,
 			CurrentReason: models.StateReasonError,
 			Labels:        labels,
 		}
@@ -346,7 +346,7 @@ func TestIntegrationAlertInstanceOperations(t *testing.T) {
 				LabelsHash: instance1.LabelsHash,
 			},
 			CurrentState: models.InstanceStateNormal,
-			CurrentCause: models.InstanceNoCause,
+			CurrentCause: models.InstanceCauseNone,
 			Labels:       instance1.Labels,
 		}
 		err = dbstore.SaveAlertInstances(ctx, instance2)

--- a/pkg/services/sqlstore/migrations/ualert/tables.go
+++ b/pkg/services/sqlstore/migrations/ualert/tables.go
@@ -188,6 +188,14 @@ func alertInstanceMigration(mg *migrator.Migrator) {
 		migrator.NewAddColumnMigration(alertInstance, &migrator.Column{
 			Name: "current_reason", Type: migrator.DB_NVarchar, Length: DefaultFieldMaxLength, Nullable: true,
 		}))
+
+	mg.AddMigration("add current_pending_state column related to pending current_state",
+		migrator.NewAddColumnMigration(alertInstance, &migrator.Column{
+			Name:     "current_pending_state",
+			Type:     migrator.DB_NVarchar,
+			Length:   DefaultFieldMaxLength,
+			Nullable: true,
+		}))
 }
 
 func addAlertRuleMigrations(mg *migrator.Migrator, defaultIntervalSeconds int64) {

--- a/pkg/services/sqlstore/migrations/ualert/tables.go
+++ b/pkg/services/sqlstore/migrations/ualert/tables.go
@@ -290,6 +290,16 @@ func addAlertRuleMigrations(mg *migrator.Migrator, defaultIntervalSeconds int64)
 			Default:  "false",
 		},
 	))
+
+	mg.AddMigration("add for_error column to alert_rule table", migrator.NewAddColumnMigration(
+		alertRule,
+		&migrator.Column{
+			Name:     "for_error",
+			Type:     migrator.DB_BigInt,
+			Nullable: false,
+			Default:  "0",
+		},
+	))
 }
 
 func addAlertRuleVersionMigrations(mg *migrator.Migrator) {
@@ -352,6 +362,16 @@ func addAlertRuleVersionMigrations(mg *migrator.Migrator) {
 			Type:     migrator.DB_Bool,
 			Nullable: false,
 			Default:  "false",
+		},
+	))
+
+	mg.AddMigration("add for_error column to alert_rule_version table", migrator.NewAddColumnMigration(
+		alertRuleVersion,
+		&migrator.Column{
+			Name:     "for_error",
+			Type:     migrator.DB_BigInt,
+			Nullable: false,
+			Default:  "0",
 		},
 	))
 }

--- a/pkg/services/sqlstore/migrations/ualert/tables.go
+++ b/pkg/services/sqlstore/migrations/ualert/tables.go
@@ -189,9 +189,9 @@ func alertInstanceMigration(mg *migrator.Migrator) {
 			Name: "current_reason", Type: migrator.DB_NVarchar, Length: DefaultFieldMaxLength, Nullable: true,
 		}))
 
-	mg.AddMigration("add current_pending_state column related to pending current_state",
+	mg.AddMigration("add current_cause column related to pending current_state",
 		migrator.NewAddColumnMigration(alertInstance, &migrator.Column{
-			Name:     "current_pending_state",
+			Name:     "current_cause",
 			Type:     migrator.DB_NVarchar,
 			Length:   DefaultFieldMaxLength,
 			Nullable: true,


### PR DESCRIPTION
**What is this feature?**

This feature adds a For-like duration field (called `for_error`) for the error state when it is handled as an error.

It adds a time window where DataSource errors can occur without entering the error state or sending any notifications. Instead, they will enter a pending state until the `for_error` duration is reached.

**Why do we need this feature?**

Currently, if a data source stops responding it will immediately trigger a notification to the user. We don't have a way to have a wait window on errors.

**Who is this feature for?**

All users.

**Which issue(s) does this PR fix?**:

Contributes to https://github.com/grafana/grafana/issues/55320

**Special notes for your reviewer**:

How does this work? I have introduced a new field (`PendingState` in `State` and `CurrentPendingState` in `AlertInstance`) to be able to differentiate between the different pending states:
- Pending for Alerting
- Pending for Error

And it is extensible for the next Pending for NoData

This is only the logic of this feature. Frontend has to be thought out and reworked.

1. A for error field has been set to 30s. An error must be occurring for 30s to be in error state.
2. The alert is normal.
![Captura de pantalla 2023-02-08 a las 17 20 38](https://user-images.githubusercontent.com/2112640/217590145-ebb6b342-e165-400d-bdb3-795914a51fa6.png)
3. We stop the datasource simulating a network partition. The error is detected and it is pending (for 3s). Old instances have not been deleted yet.
![Captura de pantalla 2023-02-08 a las 17 21 02](https://user-images.githubusercontent.com/2112640/217590799-a4f6b806-2aa3-43ef-92be-abc618b12b84.png)
4. The error is still pending (for 23s). Old instances have been deleted.
![Captura de pantalla 2023-02-08 a las 17 21 17](https://user-images.githubusercontent.com/2112640/217591340-e3348090-167c-4ebb-9123-5fa95b2b1186.png)
5. 30 seconds have passed. The alert is in error state now.
![Captura de pantalla 2023-02-08 a las 17 21 38](https://user-images.githubusercontent.com/2112640/217591544-3f237090-efb6-47e7-aab1-f13d30fd81c6.png)
6. We start the datasource simulating the network partition has been resolved. All is coming back to normal.
![Captura de pantalla 2023-02-08 a las 17 22 04](https://user-images.githubusercontent.com/2112640/217591805-5aeae307-1fbc-4cdb-8ef5-ccca6ebdb899.png)
