### PR TITLE
[v9.2.x] Remove `gen-jsonnet` make target from `bra.toml`

### DIFF
--- a/.bra.toml
+++ b/.bra.toml
@@ -1,7 +1,6 @@
 [run]
 init_cmds = [
   ["make", "gen-go"],
-  ["make", "gen-jsonnet"],
   ["GO_BUILD_DEV=1", "make", "build-go"],
   ["./bin/grafana", "server", "-packaging=dev", "cfg:app_mode=development"]
 ]
@@ -17,7 +16,6 @@ ignore_files = [".*_gen.go"]
 build_delay = 1500
 cmds = [
   ["make", "gen-go"],
-  ["make", "gen-jsonnet"],
   ["GO_BUILD_DEV=1", "make", "build-go"],
   ["./bin/grafana", "server", "-packaging=dev", "cfg:app_mode=development"]
 ]


### PR DESCRIPTION
**What is this feature?**

Removes a faulty make target from `.bra.toml`. It was introduced after a backport [here](https://github.com/grafana/grafana/pull/62754), and reported [here](https://github.com/grafana/grafana/pull/63067#issuecomment-1422395265)