### PR TITLE
CloudMonitor: Add missing logger to TimeSeriesQuery

### DIFF
--- a/pkg/tsdb/cloudmonitoring/cloudmonitoring.go
+++ b/pkg/tsdb/cloudmonitoring/cloudmonitoring.go
@@ -412,6 +412,7 @@ func (s *Service) buildQueryExecutors(logger log.Logger, req *backend.QueryDataR
 				parameters: q.TimeSeriesQuery,
 				IntervalMS: query.Interval.Milliseconds(),
 				timeRange:  req.Queries[0].TimeRange,
+				logger:     logger,
 			}
 		case sloQueryType:
 			cmslo := &cloudMonitoringSLO{


### PR DESCRIPTION
This PR fixes a bug that was not providing logs for invalid queries for the `TimeSeriesQuery` type - only a 500 error indicating the user should check the logs but no logs are available. 

With the bug:
![Screen Shot 2023-02-08 at 8 46 11 AM](https://user-images.githubusercontent.com/58453566/217579165-5c6d4c0e-b4e8-4aa3-94a8-dd091e042ab0.png)

With the fix:
![Screen Shot 2023-02-08 at 8 32 45 AM](https://user-images.githubusercontent.com/58453566/217579178-d545e816-5e56-49c4-bbac-132454e0a974.png)


**Which issue(s) does this PR fix?**: Fixes #62901 

