### PR TITLE
Docs: Fix redaction error in notification policies docs

### DIFF
--- a/docs/sources/alerting/manage-notifications/create-notification-policy.md
+++ b/docs/sources/alerting/manage-notifications/create-notification-policy.md
@@ -16,7 +16,7 @@ weight: 300
 
 # Manage notification policies
 
-Notification policies determine how alerts are routed to contact points. Policies have a tree structure, where each policy can have one or more child policies. Each policy, except for the root policy, can also match specific alert labels. Each alert is evaluated by the root policy and subsequently by each child policy. If you enable the `Continue matching subsequent sibling nodes` option is enabled for a specific policy, then evaluation continues even after one or more matches. A parent policy’s configuration settings and contact point information govern the behavior of an alert that does not match any of the child policies. A root policy governs any alert that does not match a specific policy.
+Notification policies determine how alerts are routed to contact points. Policies have a tree structure, where each policy can have one or more child policies. Each policy, except for the root policy, can also match specific alert labels. Each alert is evaluated by the root policy and subsequently by each child policy. If the `Continue matching subsequent sibling nodes` option is enabled for a specific policy, then evaluation continues even after one or more matches. A parent policy’s configuration settings and contact point information govern the behavior of an alert that does not match any of the child policies. A root policy governs any alert that does not match a specific policy.
 
 You can configure Grafana managed notification policies as well as notification policies for an external Alertmanager data source.
 


### PR DESCRIPTION
This PR fixes a small error in out docs.

```
If you enable the `Continue matching subsequent sibling nodes` option is enabled...

If you enable the `Continue matching subsequent sibling nodes` option...
```