### PR TITLE
SupportBundle: Add count for each support bundle created

### DIFF
--- a/pkg/services/supportbundles/supportbundlesimpl/service.go
+++ b/pkg/services/supportbundles/supportbundlesimpl/service.go
@@ -68,6 +68,8 @@ func ProvideService(cfg *setting.Cfg,
 		serverAdminOnly: section.Key("server_admin_only").MustBool(true),
 	}
 
+	usageStats.RegisterMetricsFunc(s.getUsageStats)
+
 	if !features.IsEnabled(featuremgmt.FlagSupportBundles) || !s.enabled {
 		return s, nil
 	}
@@ -166,4 +168,16 @@ func (s *Service) cleanup(ctx context.Context) {
 			}
 		}
 	}
+}
+
+func (s *Service) getUsageStats(ctx context.Context) (map[string]interface{}, error) {
+	m := map[string]interface{}{}
+
+	count, err := s.store.StatsCount(ctx)
+	if err != nil {
+		s.log.Warn("unable to get support bundle counter", "error", err)
+	}
+
+	m["stats.bundles.count"] = count
+	return m, nil
 }


### PR DESCRIPTION
**What is this feature?**

This will add a new kv_store element to keep track of how many support bundles have been created.

**Why do we need this feature?**

[Design doc](https://docs.google.com/document/d/1SLHNpdTFWWewuLTvOfr2euJ54WNke5SSAXJn1deyt1c/edit#heading=h.c1332oqy1n7s)

**Which issue(s) does this PR fix?**:

Fixes #61052

**Special notes for your reviewer**:

Expect output changes at database and at `api/admin/usage-report-preview` endpoint
