### PR TITLE
Dashboard: Update query group options

### DIFF
--- a/public/app/features/query/components/QueryGroupOptions.tsx
+++ b/public/app/features/query/components/QueryGroupOptions.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import React, { PureComponent, ChangeEvent, FocusEvent } from 'react';
 
 import { rangeUtil, PanelData, DataSourceApi } from '@grafana/data';
-import { Switch, Input, InlineField, InlineFormLabel, stylesFactory } from '@grafana/ui';
+import { Switch, Input, InlineFormLabel, stylesFactory } from '@grafana/ui';
 import { QueryOperationRow } from 'app/core/components/QueryOperationRow/QueryOperationRow';
 import { config } from 'app/core/config';
 import { QueryGroupOptions } from 'app/types';
@@ -28,6 +28,7 @@ export class QueryGroupOptionsEditor extends PureComponent<Props, State> {
     super(props);
 
     const { options } = props;
+    console.log({ options });
 
     this.state = {
       timeRangeFrom: options.timeRange?.from || '',
@@ -358,11 +359,21 @@ export class QueryGroupOptionsEditor extends PureComponent<Props, State> {
         {this.renderQueryCachingTTLOption()}
 
         <div className="gf-form">
-          <InlineFormLabel width={9}>Relative time</InlineFormLabel>
+          <InlineFormLabel
+            width={9}
+            tooltip={
+              <>
+                Overrides the relative time range for individual panels, which causes them to be different than what is
+                selected in the dashboard time picker in the top-right corner of the dashboard.
+              </>
+            }
+          >
+            Relative time
+          </InlineFormLabel>
           <Input
             type="text"
             className="width-6"
-            placeholder="1h"
+            placeholder="No override"
             onChange={this.onRelativeTimeChange}
             onBlur={this.onOverrideTime}
             invalid={!relativeTimeIsValid}
@@ -371,11 +382,21 @@ export class QueryGroupOptionsEditor extends PureComponent<Props, State> {
         </div>
 
         <div className="gf-form">
-          <span className="gf-form-label width-9">Time shift</span>
+          <InlineFormLabel
+            width={9}
+            tooltip={
+              <>
+                Overrides the time range for individual panels by shifting its start and end relative to the time
+                picker.
+              </>
+            }
+          >
+            Time shift
+          </InlineFormLabel>
           <Input
             type="text"
             className="width-6"
-            placeholder="1h"
+            placeholder="0h"
             onChange={this.onTimeShiftChange}
             onBlur={this.onTimeShift}
             invalid={!timeShiftIsValid}
@@ -383,10 +404,9 @@ export class QueryGroupOptionsEditor extends PureComponent<Props, State> {
           />
         </div>
         {(timeShift || relativeTime) && (
-          <div className="gf-form-inline">
-            <InlineField label="Hide time info" labelWidth={18}>
-              <Switch value={hideTimeOverride} onChange={this.onToggleTimeOverride} />
-            </InlineField>
+          <div className="gf-form-inline align-items-center">
+            <InlineFormLabel width={9}>Hide time info</InlineFormLabel>
+            <Switch value={hideTimeOverride} onChange={this.onToggleTimeOverride} />
           </div>
         )}
       </QueryOperationRow>

--- a/public/app/features/query/components/QueryGroupOptions.tsx
+++ b/public/app/features/query/components/QueryGroupOptions.tsx
@@ -399,7 +399,7 @@ export class QueryGroupOptionsEditor extends PureComponent<Props, State> {
           <Input
             type="text"
             className="width-6"
-            placeholder="0h"
+            placeholder="1h"
             onChange={this.onTimeShiftChange}
             onBlur={this.onTimeShift}
             invalid={!timeShiftIsValid}

--- a/public/app/features/query/components/QueryGroupOptions.tsx
+++ b/public/app/features/query/components/QueryGroupOptions.tsx
@@ -363,7 +363,9 @@ export class QueryGroupOptionsEditor extends PureComponent<Props, State> {
             tooltip={
               <>
                 Overrides the relative time range for individual panels, which causes them to be different than what is
-                selected in the dashboard time picker in the top-right corner of the dashboard.
+                selected in the dashboard time picker in the top-right corner of the dashboard. For example to configure
+                the Last 5 minutes the Relative time should be <code>now-5m</code> and <code>5m</code>, or variables
+                like <code>$_relativeTime</code>.
               </>
             }
           >
@@ -386,7 +388,8 @@ export class QueryGroupOptionsEditor extends PureComponent<Props, State> {
             tooltip={
               <>
                 Overrides the time range for individual panels by shifting its start and end relative to the time
-                picker.
+                picker. For example to configure the Last 1h the Time shift should be <code>now-1h</code> and{' '}
+                <code>1h</code>, or variables like <code>$_timeShift</code>.
               </>
             }
           >
@@ -395,7 +398,7 @@ export class QueryGroupOptionsEditor extends PureComponent<Props, State> {
           <Input
             type="text"
             className="width-6"
-            placeholder="1h"
+            placeholder="0h"
             onChange={this.onTimeShiftChange}
             onBlur={this.onTimeShift}
             invalid={!timeShiftIsValid}

--- a/public/app/features/query/components/QueryGroupOptions.tsx
+++ b/public/app/features/query/components/QueryGroupOptions.tsx
@@ -395,7 +395,7 @@ export class QueryGroupOptionsEditor extends PureComponent<Props, State> {
           <Input
             type="text"
             className="width-6"
-            placeholder="0h"
+            placeholder="1h"
             onChange={this.onTimeShiftChange}
             onBlur={this.onTimeShift}
             invalid={!timeShiftIsValid}

--- a/public/app/features/query/components/QueryGroupOptions.tsx
+++ b/public/app/features/query/components/QueryGroupOptions.tsx
@@ -28,7 +28,6 @@ export class QueryGroupOptionsEditor extends PureComponent<Props, State> {
     super(props);
 
     const { options } = props;
-    console.log({ options });
 
     this.state = {
       timeRangeFrom: options.timeRange?.from || '',

--- a/public/app/features/query/components/QueryGroupOptions.tsx
+++ b/public/app/features/query/components/QueryGroupOptions.tsx
@@ -375,7 +375,7 @@ export class QueryGroupOptionsEditor extends PureComponent<Props, State> {
           <Input
             type="text"
             className="width-6"
-            placeholder="No override"
+            placeholder="1h"
             onChange={this.onRelativeTimeChange}
             onBlur={this.onOverrideTime}
             invalid={!relativeTimeIsValid}

--- a/public/app/features/query/components/QueryGroupOptions.tsx
+++ b/public/app/features/query/components/QueryGroupOptions.tsx
@@ -288,7 +288,8 @@ export class QueryGroupOptionsEditor extends PureComponent<Props, State> {
               tooltip={
                 <>
                   The evaluated interval that is sent to data source and is used in <code>$__interval</code> and{' '}
-                  <code>$__interval_ms</code>
+                  <code>$__interval_ms</code>. This value is not exactly equal to{' '}
+                  <code>Time range / max data points</code>, it will approximate a series of magic number.
                 </>
               }
             >


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
- In the dashboard, tooltips have been added to some of the options in <QueryGroupOptions />, see Grafana's documentation for a description of these options
- Minutiae: The switch component is centered in the row
- Modified the placeholder for `Relative time` and `Time shift`, **the exact values may need to be discussed, my modifications are what I think is appropriate.**

**Why do we need this feature?**

 **Modified the placeholder**

`Max data points` and `Min interval` (or all fields except for the time-related field) are real values, otherwise, they are a null text description (`No limit` is displayed when `Min interval` is missing)

So two fields about time originally set to `1h` may lead to the interpretation that they take exactly `1h` (but are null) in this context, and such a placeholder setting may lead to misunderstandings, so it can be set to a null literal like `No limit`.

For `Time shift` set to `0h` because it runs as `0h` when it is null, and also implies the format of the input (math string)

Before:

<img width="811" alt="image" src="https://user-images.githubusercontent.com/47357585/217627453-6c73d370-dac6-4e68-9d47-b62cce60264f.png">
After:

<img width="698" alt="image" src="https://user-images.githubusercontent.com/47357585/217627485-f5755313-2471-4d8f-9b78-5a57f3ebfe1d.png">

**tooltip and center styles**

Other fields have corresponding descriptions, while the meaning of the time-related fields is not quite easy to understand, so some of the descriptions are quoted from the documentation.



