### PR TITLE
Prometheus: Fix missing abs operation to query builder

### DIFF
--- a/public/app/plugins/datasource/prometheus/querybuilder/operations.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/operations.ts
@@ -101,6 +101,7 @@ export function getOperationDefinitions(): QueryBuilderOperationDef[] {
       renderer: (model, def, innerExpr) => innerExpr,
       addOperationHandler: addNestedQueryHandler,
     },
+    createFunction({ id: PromOperationId.Abs }),
     createFunction({ id: PromOperationId.Absent }),
     createFunction({
       id: PromOperationId.Acos,


### PR DESCRIPTION
**What is this feature?**

It adds `abs` operation to the Prometheus Query Builder

**Why do we need this feature?**

In the Prometheus query builder `abs` operation was missing.

**Who is this feature for?**

People who use Prometheus Query Buidler

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/62325

**Special notes for your reviewer**:

