### PR TITLE
CloudWatch Logs: Update default timeout to 30m

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/components/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/ConfigEditor.tsx
@@ -76,7 +76,7 @@ export const ConfigEditor: FC<Props> = (props: Props) => {
         >
           <Input
             width={60}
-            placeholder="15m"
+            placeholder="30m"
             value={options.jsonData.logsTimeout || ''}
             onChange={onUpdateDatasourceJsonDataOption(props, 'logsTimeout')}
             title={'The timeout must be a valid duration string, such as "15m" "30s" "2000ms" etc.'}

--- a/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchLogsQueryRunner.ts
+++ b/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchLogsQueryRunner.ts
@@ -67,7 +67,7 @@ export class CloudWatchLogsQueryRunner extends CloudWatchRequest {
     super(instanceSettings, templateSrv);
 
     this.tracingDataSourceUid = instanceSettings.jsonData.tracingDatasourceUid;
-    this.logsTimeout = instanceSettings.jsonData.logsTimeout || '15m';
+    this.logsTimeout = instanceSettings.jsonData.logsTimeout || '30m';
   }
 
   /**


### PR DESCRIPTION
Closes https://github.com/grafana/grafana/issues/63147

Fix: Updated the placeholder for the Timeout InlineField in ConfigEditor.tsx 

[Update] Additional changes for the Timeout Update added https://github.com/grafana/grafana/pull/63155/commits/9c2031e2625072518fd55f8099bd78955cb5e926