### PR TITLE
GHActions: Issues: Add action that makes org members add a label

### DIFF
--- a/.github/commands.json
+++ b/.github/commands.json
@@ -322,5 +322,12 @@
     "addToProject": {
       "url": "https://github.com/orgs/grafana/projects/78"
     }
+  },
+    {
+    "type": "author",
+    "memberOf": { "org": "grafana" },
+    "noLabels": true,
+    "addLabel": "internal",
+    "comment": " Hi there! It looks like you forgot to add any labels to this issue. We ask that members of the Grafana Org avoid filing empty issues because it slows down our triage process. Please add one or more appropriate labels. Here are some tips:\r\n\r\n- if you are making an issue, TODO, or reminder for yourself or your team, please add one descriptive label AND add the issue to your project board. :rocket:\r\n\r\n- if you are making an issue for any other reason (docs typo, you found a bug, etc), please add at least one descriptive label and the triage folks will help place it with the correct team. This really helps us move as fast as possible. :rocket:\r\n\r\nAnd please keep the `internal` tag so we can track issues created by grafanistas. Thank you! :heart:"
   }
 ]

--- a/.github/workflows/commands.yml
+++ b/.github/workflows/commands.yml
@@ -1,7 +1,7 @@
 name: Run commands when issues are labeled or comments added
 on:
   issues:
-    types: [labeled, unlabeled]
+    types: [labeled, unlabeled, opened]
   issue_comment:
     types: [created]
 concurrency:


### PR DESCRIPTION
see https://github.com/grafana/grafana-github-actions/pull/134 for details on the logic.

This new action will check when an issue is opened, if it was opened by a grafanista, and if any labels were added.

If a Grafanista makes an issue but adds no label, the `internal` label will be added and they will be pinged in a comment like this:


![CleanShot 2023-02-08 at 12 58 31@2x](https://user-images.githubusercontent.com/37156449/217670582-8e17a72d-6cde-4d0f-98b7-6be927150490.png)

You can test drive the new action in my private repo. [Make an issue here](https://github.com/zuchka/grafana-action-test/issues/new?assignees=&labels=type%3A+bug&template=1-bug_report.md) but DON'T add any labels.

**why do we need this?**
Lots of internal folks use issues as todos or reminders for themselves but don't add labels. Lots of other internal folks make issues for other teams but don't add labels. This allows the triage team to filter out these personal issues, and to get internally created issues to the proper team faster. Both of these scenarios will help reduce the number of issues we have to triage.

resolves https://github.com/grafana/grafana-community-support-squad/issues/43