### PR TITLE
Only run workflows if they might be able to work

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   main:
+    if: github.repository == 'grafana/grafana'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Actions

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -9,6 +9,7 @@ env:
   YARN_ENABLE_IMMUTABLE_INSTALLS: false
 jobs:
   main:
+    if: github.repository == 'grafana/grafana'
     runs-on: ubuntu-latest
     steps:
       # This is a basic workflow to help you get started with Actions

--- a/.github/workflows/close-milestone.yml
+++ b/.github/workflows/close-milestone.yml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   main:
+    if: github.repository == 'grafana/grafana'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Actions

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -18,6 +18,9 @@ on:
   schedule:
     - cron: '0 4 * * 6'
 
+permissions:
+  security-events: write
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/commands.yml
+++ b/.github/workflows/commands.yml
@@ -7,7 +7,22 @@ on:
 concurrency:
   group: issue-commands-${{ github.event.issue.number }}
 jobs:
+  config:
+    runs-on: "ubuntu-latest"
+    outputs:
+      has-secrets: ${{ steps.check.outputs.has-secrets }}
+    steps:
+      - name: "Check for secrets"
+        id: check
+        shell: bash
+        run: |
+          if [ -n "${{ (secrets.GRAFANA_MISC_STATS_API_KEY != '' && secrets.GH_BOT_ACCESS_TOKEN != '') || '' }}" ]; then
+            echo "has-secrets=1" >> "$GITHUB_OUTPUT"
+          fi
+
   main:
+    needs: config
+    if: needs.config.outputs.has-secrets
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Actions

--- a/.github/workflows/detect-breaking-changes-report.yml
+++ b/.github/workflows/detect-breaking-changes-report.yml
@@ -15,6 +15,11 @@ jobs:
     env:
       ARTIFACT_NAME: 'levitate' # The name of the artifact that we would like to download
       ARTIFACT_FOLDER: '${{ github.workspace }}/tmp' # The name of the folder where we will download the artifact to
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+      artifacts: read
 
     steps:
     - uses: actions/checkout@v3
@@ -119,7 +124,7 @@ jobs:
     # Posts a notification to Slack if a PR has a breaking change and it did not have a breaking change before
     - name: Post to Slack
       id: slack
-      if: steps.levitate-run.outputs.exit_code == 1 && steps.does-label-exist.outputs.result == 0 && steps.levitate-run.outputs.shouldSkip != 'true'
+      if: steps.levitate-run.outputs.exit_code == 1 && steps.does-label-exist.outputs.result == 0 && steps.levitate-run.outputs.shouldSkip != 'true' && env.HAS_SECRETS
       uses: slackapi/slack-github-action@v1.24.0
       with:
         payload: |
@@ -132,13 +137,15 @@ jobs:
           }
       env:
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_LEVITATE_WEBHOOK_URL }}
+        HAS_SECRETS: ${{ (github.repository == "grafana/grafana" || secrets.SLACK_LEVITATE_WEBHOOK_URL != '') || '' }}
 
     # Add the label
     - name: Add "levitate breaking change" label
-      if: steps.levitate-run.outputs.exit_code == 1 && steps.does-label-exist.outputs.result == 0 && steps.levitate-run.outputs.shouldSkip != 'true'
+      if: steps.levitate-run.outputs.exit_code == 1 && steps.does-label-exist.outputs.result == 0 && steps.levitate-run.outputs.shouldSkip != 'true' && env.HAS_SECRETS
       uses: actions/github-script@v6
       env:
         PR_NUMBER: ${{ steps.levitate-run.outputs.pr_number }}
+        HAS_SECRETS: ${{ (secrets.GH_BOT_ACCESS_TOKEN != '') || '' }}
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
@@ -151,10 +158,11 @@ jobs:
 
     # Remove label (no more breaking changes)
     - name: Remove "levitate breaking change" label
-      if: steps.levitate-run.outputs.exit_code == 0 && steps.does-label-exist.outputs.result == 1 && steps.levitate-run.outputs.shouldSkip != 'true'
+      if: steps.levitate-run.outputs.exit_code == 0 && steps.does-label-exist.outputs.result == 1 && steps.levitate-run.outputs.shouldSkip != 'true' && env.HAS_SECRETS
       uses: actions/github-script@v6
       env:
         PR_NUMBER: ${{ steps.levitate-run.outputs.pr_number }}
+        HAS_SECRETS: ${{ (secrets.GH_BOT_ACCESS_TOKEN != '') || '' }}
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
@@ -169,10 +177,11 @@ jobs:
     # This is very weird, the actual request goes through (comes back with a 201), but does not assign the team.
     # Related issue: https://github.com/renovatebot/renovate/issues/1908
     - name: Add "grafana/plugins-platform-frontend" as a reviewer
-      if: steps.levitate-run.outputs.exit_code && steps.levitate-run.outputs.shouldSkip != 'true'
+      if: steps.levitate-run.outputs.exit_code && steps.levitate-run.outputs.shouldSkip != 'true' && env.HAS_SECRETS
       uses: actions/github-script@v6
       env:
         PR_NUMBER: ${{ steps.levitate-run.outputs.pr_number }}
+        HAS_SECRETS: ${{ (secrets.GH_BOT_ACCESS_TOKEN != '') || '' }}
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
@@ -186,10 +195,11 @@ jobs:
 
     # Remove reviewers (no more breaking changes)
     - name: Remove "grafana/plugins-platform-frontend" from the list of reviewers
-      if: steps.levitate-run.outputs.exit_code == 0 && steps.levitate-run.outputs.shouldSkip != 'true'
+      if: steps.levitate-run.outputs.exit_code == 0 && steps.levitate-run.outputs.shouldSkip != 'true' && env.HAS_SECRETS
       uses: actions/github-script@v6
       env:
         PR_NUMBER: ${{ steps.levitate-run.outputs.pr_number }}
+        HAS_SECRETS: ${{ (secrets.GH_BOT_ACCESS_TOKEN != '') || '' }}
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |

--- a/.github/workflows/epic-add-to-platform-ux-parent-project.yml
+++ b/.github/workflows/epic-add-to-platform-ux-parent-project.yml
@@ -5,21 +5,35 @@ on:
     types: [opened, closed, edited, reopened, assigned, unassigned, labeled, unlabeled]
     labels:
       - 'type/epic'
-      
+
 env:
-  GITHUB_TOKEN: ${{ secrets.GH_BOT_PROJECTS_ACCESS_TOKEN }}
+  GH_TOKEN: ${{ secrets.GH_BOT_PROJECTS_ACCESS_TOKEN }}
   ORGANIZATION: ${{ github.repository_owner }}
   REPO: ${{ github.event.repository.name }}
   PARENT_PROJECT: 304
   CHILD_PROJECT_1: 78
   CHILD_PROJECT_2: 111
   CHILD_PROJECT_3: 202
-    
+
 concurrency:
   group: issue-add-to-parent-project-${{ github.event.number }}
 jobs:
+  config:
+    runs-on: "ubuntu-latest"
+    outputs:
+      has-secrets: ${{ steps.check.outputs.has-secrets }}
+    steps:
+      - name: "Check for secrets"
+        id: check
+        shell: bash
+        run: |
+          if [ -n "${{ (secrets.GH_BOT_PROJECTS_ACCESS_TOKEN != '') || '' }}" ]; then
+            echo "has-secrets=1" >> "$GITHUB_OUTPUT"
+          fi
+
   main:
-    if: contains(github.event.issue.labels.*.name, 'type/epic')
+    needs: config
+    if: needs.config.outputs.has-secrets && contains(github.event.issue.labels.*.name, 'type/epic')
     runs-on: ubuntu-latest
     steps:
       - name: Check if issue is in child or parent projects
@@ -46,7 +60,7 @@ jobs:
                 }
               }
             }' -f org=$ORGANIZATION -f repo=$REPO > projects_data.json
-            
+
             echo 'IN_PARENT_PROJ='$(jq '.data.repository.issue.projectItems.nodes[] | select(.project.number==${{ env.PARENT_PROJECT }}) | .project != null' projects_data.json) >> $GITHUB_ENV
             echo 'PARENT_PROJ_STATUS_ID='$(jq '.data.repository.issue.projectItems.nodes[] | select(.project.number==${{ env.PARENT_PROJECT }}) | select(.fieldValueByName != null) | .fieldValueByName.optionId' projects_data.json) >> $GITHUB_ENV
             echo 'ITEM_ID='$(jq '.data.repository.issue.projectItems.nodes[] | select(.project.number==${{ env.PARENT_PROJECT }}) | .id' projects_data.json) >> $GITHUB_ENV
@@ -96,7 +110,7 @@ jobs:
                 }
               }
             }' -f project=$PROJECT_ID -f issue=${{ github.event.issue.node_id }} --jq '.data.addProjectV2ItemById.item.id')"
- 
+
             echo 'ITEM_ID='$item_id >> $GITHUB_ENV
       - name: Set parent project status Done
         if: contains(env.CHILD_PROJ_STATUS, 'Done')
@@ -124,7 +138,7 @@ jobs:
                 projectId: $project
                 itemId: $item
                 fieldId: $status_field
-                value: { 
+                value: {
                   singleSelectOptionId: $status_value
                   }
               }) {

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -9,7 +9,22 @@ on:
         required: false
         description: Mark this release as latest (`1`) or not (`0`, default)
 jobs:
+  config:
+    runs-on: "ubuntu-latest"
+    outputs:
+      has-secrets: ${{ steps.check.outputs.has-secrets }}
+    steps:
+      - name: "Check for secrets"
+        id: check
+        shell: bash
+        run: |
+          if [ -n "${{ (secrets.GRAFANA_MISC_STATS_API_KEY != '' && secrets.GH_BOT_ACCESS_TOKEN != '') || '' }}" ]; then
+            echo "has-secrets=1" >> "$GITHUB_OUTPUT"
+          fi
+
   main:
+    needs: config
+    if: needs.config.outputs.has-secrets
     runs-on: ubuntu-latest
     steps:
       - name: "Generate token"

--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -5,7 +5,22 @@ on:
     types: [labeled]
 
 jobs:
+  config:
+    runs-on: "ubuntu-latest"
+    outputs:
+      has-secrets: ${{ steps.check.outputs.has-secrets }}
+    steps:
+      - name: "Check for secrets"
+        id: check
+        shell: bash
+        run: |
+          if [ -n "${{ (secrets.SLACK_WEBHOOK_URL != '') || '' }}" ]; then
+            echo "has-secrets=1" >> "$GITHUB_OUTPUT"
+          fi
+
   notify:
+    needs: config
+    if: needs.config.outputs.has-secrets
     runs-on: ubuntu-latest
     steps:
       - name: "Download teams.yml to know which label is for which team"

--- a/.github/workflows/metrics-collector.yml
+++ b/.github/workflows/metrics-collector.yml
@@ -16,7 +16,22 @@ on:
     types: [opened, closed]
 
 jobs:
+  config:
+    runs-on: "ubuntu-latest"
+    outputs:
+      has-secrets: ${{ steps.check.outputs.has-secrets }}
+    steps:
+      - name: "Check for secrets"
+        id: check
+        shell: bash
+        run: |
+          if [ -n "${{ (secrets.GRAFANA_MISC_STATS_API_KEY != '' && secrets.GH_BOT_ACCESS_TOKEN != '') || '' }}" ]; then
+            echo "has-secrets=1" >> "$GITHUB_OUTPUT"
+          fi
+
   main:
+    needs: config
+    if: needs.config.outputs.has-secrets
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Actions

--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -6,12 +6,28 @@ on:
         description: 'The version to be released please respect: major.minor.patch, major.minor.patch-preview or major.minor.patch-preview<number> format. example: 7.4.3, 7.4.3-preview or 7.4.3-preview1'
         required: true
 jobs:
+  config:
+    runs-on: "ubuntu-latest"
+    outputs:
+      has-secrets: ${{ steps.check.outputs.has-secrets }}
+    steps:
+      - name: "Check for secrets"
+        id: check
+        shell: bash
+        run: |
+          if [ -n "${{ (secrets.GH_BOT_ACCESS_TOKEN != '') || '' }}" ]; then
+            echo "has-secrets=1" >> "$GITHUB_OUTPUT"
+          fi
+
   call-remove-milestone:
+    needs: config
+    if: needs.config.outputs.has-secrets
     uses: grafana/grafana/.github/workflows/remove-milestone.yml@main
     with:
       version_call: ${{ github.event.inputs.version_input }}
     secrets: inherit
   call-close-milestone:
+    if: needs.config.outputs.has-secrets
     uses: grafana/grafana/.github/workflows/close-milestone.yml@main
     with:
       version_call: ${{ github.event.inputs.version_input }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -15,8 +15,13 @@ on:
       - demilestoned
 concurrency:
   group: pr-checks-${{ github.event.number }}
+permissions:
+  contents: write
 jobs:
   main:
+    permissions:
+      actions: write
+      contents: read
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
     steps:

--- a/.github/workflows/pr-codeql-analysis-go.yml
+++ b/.github/workflows/pr-codeql-analysis-go.yml
@@ -7,6 +7,9 @@ on:
     paths:
       - '**/*.go'
 
+permissions:
+  security-events: write
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/pr-codeql-analysis-javascript.yml
+++ b/.github/workflows/pr-codeql-analysis-javascript.yml
@@ -9,6 +9,9 @@ on:
       - '**/*.ts'
       - '**/*.tsx'
 
+permissions:
+  security-events: write
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/pr-codeql-analysis-python.yml
+++ b/.github/workflows/pr-codeql-analysis-python.yml
@@ -7,6 +7,9 @@ on:
     paths:
       - '**/*.py'
 
+permissions:
+  security-events: write
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/pr-commands-closed.yml
+++ b/.github/workflows/pr-commands-closed.yml
@@ -2,11 +2,13 @@ name: Run when PRs are closed
 on:
   pull_request:
     types:
-      - closed      
+      - closed
 concurrency:
   group: pr-commands-closed-${{ github.event.number }}
 jobs:
   close_job:
+    permissions:
+      pull-requests: write
     # this job will only run if the PR has been closed without being merged
     if: github.event.pull_request.merged == false
     runs-on: ubuntu-latest
@@ -15,4 +17,4 @@ jobs:
         echo PR #${{ github.event.number }} has been closed without being merged, removing milestone.
         gh pr edit ${{ github.event.number }} --milestone "" --repo $GITHUB_REPOSITORY
       env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -8,7 +8,22 @@ on:
 concurrency:
   group: pr-commands-${{ github.event.number }}
 jobs:
+  config:
+    runs-on: "ubuntu-latest"
+    outputs:
+      has-secrets: ${{ steps.check.outputs.has-secrets }}
+    steps:
+      - name: "Check for secrets"
+        id: check
+        shell: bash
+        run: |
+          if [ -n "${{ (secrets.GRAFANA_MISC_STATS_API_KEY != '' && secrets.GH_BOT_ACCESS_TOKEN != '') || '' }}" ]; then
+            echo "has-secrets=1" >> "$GITHUB_OUTPUT"
+          fi
+
   main:
+    needs: config
+    if: needs.config.outputs.has-secrets
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Actions

--- a/.github/workflows/publish-technical-documentation-next.yml
+++ b/.github/workflows/publish-technical-documentation-next.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 jobs:
   sync:
-    if: "github.repository == 'grafana/grafana'"
+    if: github.repository == 'grafana/grafana'
     runs-on: "ubuntu-latest"
     steps:
       - name: "Checkout Grafana repo"

--- a/.github/workflows/publish-technical-documentation-release.yml
+++ b/.github/workflows/publish-technical-documentation-release.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 jobs:
   sync:
-    if: "github.repository == 'grafana/grafana'"
+    if: github.repository == 'grafana/grafana'
     runs-on: "ubuntu-latest"
     steps:
       - name: "Checkout Grafana repo"

--- a/.github/workflows/remove-milestone.yml
+++ b/.github/workflows/remove-milestone.yml
@@ -13,7 +13,24 @@ on:
         type: string
 
 jobs:
+  config:
+    runs-on: "ubuntu-latest"
+    outputs:
+      has-secrets: ${{ steps.check.outputs.has-secrets }}
+    steps:
+      - name: "Check for secrets"
+        id: check
+        shell: bash
+        run: |
+          if [ -n "${{ (secrets.GH_BOT_ACCESS_TOKEN != '') || '' }}" ]; then
+            echo "has-secrets=1" >> "$GITHUB_OUTPUT"
+          fi
+
   main:
+    needs: config
+    if: needs.config.outputs.has-secrets
+    permissions:
+      issues: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Actions

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,7 +7,22 @@ permissions:
   pull-requests: write
 
 jobs:
+  config:
+    runs-on: "ubuntu-latest"
+    outputs:
+      has-secrets: ${{ steps.check.outputs.has-secrets }}
+    steps:
+      - name: "Check for secrets"
+        id: check
+        shell: bash
+        run: |
+          if [ -n "${{ (secrets.GH_BOT_ACCESS_TOKEN != '') || '' }}" ]; then
+            echo "has-secrets=1" >> "$GITHUB_OUTPUT"
+          fi
+
   stale:
+    needs: config
+    if: needs.config.outputs.has-secrets
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v8


### PR DESCRIPTION
**What is this feature?**

Add permissions to workflows that need permissions and check for secrets in workflows that use secrets

**Why do we need this feature?**

Otherwise forks get lots of failures

**Who is this feature for?**

Contributors who aren't members of the grafana organization and thus need to use forks where github actions may run, and especially those who run those forks in organizations that are moderately concerned about security (and thus have restricted the github_token's default permissions)

**Which issue(s) does this PR fix?**:

Fixes #63163

**Special notes for your reviewer**:

You'll want to test this in your own organization or repository. I ran through each workflow that I changed and made sure it ran at least once without secrets and then I ran at least one with some mock secrets to confirm that the run case works.