### PR TITLE
Fix MSSQL queries failing because of bad interpolation

### DIFF
--- a/pkg/tsdb/mssql/macros.go
+++ b/pkg/tsdb/mssql/macros.go
@@ -49,9 +49,13 @@ func (m *msSQLMacroEngine) Interpolate(query *backend.DataQuery, timeRange backe
 	// TODO: Return any error
 	rExp, _ := regexp.Compile(sExpr)
 	var macroError error
-	formattedSql, fctCallArgsMap := replaceFunctionCallArgsWithPlaceholders(sql)
+	var fctCallArgsMap map[string]string
 
-	sql = m.ReplaceAllStringSubmatchFunc(rExp, formattedSql, func(groups []string) string {
+	if rExp.FindAllSubmatchIndex([]byte(sql), -1) != nil {
+		sql, fctCallArgsMap = replaceFunctionCallArgsWithPlaceholders(sql)
+	}
+
+	sql = m.ReplaceAllStringSubmatchFunc(rExp, sql, func(groups []string) string {
 		args := strings.Split(groups[2], ",")
 		for i, arg := range args {
 			args[i] = strings.Trim(arg, " ")

--- a/pkg/tsdb/mssql/macros_test.go
+++ b/pkg/tsdb/mssql/macros_test.go
@@ -349,6 +349,20 @@ func TestMacroEngine(t *testing.T) {
 				require.NotNil(t, err)
 			}
 		})
+
+		t.Run("should return unmodified sql if there are no macros present", func(t *testing.T) {
+			sqls := []string{
+				"select * from table",
+				"select count(val) from table",
+				"select col1, col2,col3, col4 from table where col1 = 'val1' and col2 = 'val2' order by col1 asc",
+			}
+
+			for _, sql := range sqls {
+				actual, err := engine.Interpolate(query, timeRange, sql)
+				require.Nil(t, err)
+				require.Equal(t, sql, actual)
+			}
+		})
 	})
 }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Fixes a bug introduced in https://github.com/grafana/grafana/pull/62742

**Why do we need this feature?**

MSSQL fails to retrieve data because queries get interpolated unnecessarily

**Who is this feature for?**

Everyone
