### PR TITLE
Storybook: Fix order of buttons on modal story

### DIFF
--- a/packages/grafana-ui/src/components/Modal/Modal.story.tsx
+++ b/packages/grafana-ui/src/components/Modal/Modal.story.tsx
@@ -53,7 +53,9 @@ export const Basic: Story = ({ body, title, ...args }) => {
     <Modal title={title} {...args}>
       {body}
       <Modal.ButtonRow>
-        <Button variant="secondary">Cancel</Button>
+        <Button variant="secondary" fill="outline">
+          Cancel
+        </Button>
         <Button>Button1</Button>
       </Modal.ButtonRow>
     </Modal>

--- a/packages/grafana-ui/src/components/Modal/Modal.story.tsx
+++ b/packages/grafana-ui/src/components/Modal/Modal.story.tsx
@@ -53,8 +53,8 @@ export const Basic: Story = ({ body, title, ...args }) => {
     <Modal title={title} {...args}>
       {body}
       <Modal.ButtonRow>
-        <Button>Button1</Button>
         <Button variant="secondary">Cancel</Button>
+        <Button>Button1</Button>
       </Modal.ButtonRow>
     </Modal>
   );


### PR DESCRIPTION
**What is this feature?**

Previously the storybook Modal story had the "Cancel" button closest to the right which is not the pattern we follow, so I reversed that.

Before:
<img width="560" alt="Screenshot 2023-02-09 at 13 08 05" src="https://user-images.githubusercontent.com/100691367/217821317-8d1ea8fb-c0f6-4aba-9a81-4364d026acfc.png">

After:
<img width="624" alt="Screenshot 2023-02-09 at 13 11 33" src="https://user-images.githubusercontent.com/100691367/217822189-2708fb80-b364-439a-8835-f581ba28ac95.png">

**Why do we need this feature?**

So people are not confused with our button pattern on modals

**Who is this feature for?**

Anyone who designs modals

