### PR TITLE
TestData: Fix bug when selecting "Log" streaming

### DIFF
--- a/public/app/plugins/datasource/testdata/QueryEditor.tsx
+++ b/public/app/plugins/datasource/testdata/QueryEditor.tsx
@@ -139,7 +139,7 @@ export const QueryEditor = ({ query, datasource, onChange, onRunQuery }: Props) 
   };
 
   const onFieldChange = (field: string) => (e: ChangeEvent<HTMLInputElement>) => {
-    const { name, value, type } = e.currentTarget;
+    const { name, value, type } = e.target;
     let newValue: any = value;
 
     if (type === 'number') {

--- a/public/app/plugins/datasource/testdata/QueryEditor.tsx
+++ b/public/app/plugins/datasource/testdata/QueryEditor.tsx
@@ -138,7 +138,7 @@ export const QueryEditor = ({ query, datasource, onChange, onRunQuery }: Props) 
     onUpdate({ ...query, [name]: newValue });
   };
 
-  const onFieldChange = (field: string) => (e: ChangeEvent<HTMLInputElement>) => {
+  const onFieldChange = (field: string) => (e: { target: { name: string; value: string; type: string } }) => {
     const { name, value, type } = e.target;
     let newValue: any = value;
 

--- a/public/app/plugins/datasource/testdata/QueryEditor.tsx
+++ b/public/app/plugins/datasource/testdata/QueryEditor.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, FormEvent, useMemo } from 'react';
+import React, { FormEvent, useMemo } from 'react';
 import { useAsync } from 'react-use';
 
 import { QueryEditorProps, SelectableValue } from '@grafana/data';

--- a/public/app/plugins/datasource/testdata/runStreams.ts
+++ b/public/app/plugins/datasource/testdata/runStreams.ts
@@ -151,8 +151,8 @@ export function runLogsStream(
     let timeoutId: ReturnType<typeof setTimeout>;
 
     const pushNextEvent = () => {
-      data.fields[0].values.add(Date.now());
-      data.fields[1].values.add(getRandomLine());
+      data.fields[0].values.add(getRandomLine());
+      data.fields[1].values.add(Date.now());
 
       subscriber.next({
         data: [data],


### PR DESCRIPTION
**What is this feature?**

This PR fixes two bugs:

1. When streaming logs the DataFrame got populated in the wrong fields. Timedata landed in the logs field, log-data went to the time field. This is reproducible here:

https://play.grafana.org/goto/ZP2ICC0Vz?orgId=1

2. Not being able to select `Log` when `Streaming Client` is selected
In https://github.com/grafana/grafana/pull/58667/files#diff-c8e01be7c14f771667fcb5cf704d758ae25f9a8ae4c07363ab657269f7469fe5R142 we changed `target` to `currentTarget` thinking we are handling with `ChangeEvents`, but in fact we are not.

Reproduction:
1. With Grafana 9.4. select a TestDB Datasource
2. Select "streaming client"
3. Try to select "Logs"



