### PR TITLE
Influxdb: Handle legacy Influxdb influxql annotations with target in migration

### DIFF
--- a/public/app/plugins/datasource/influxdb/migrations.ts
+++ b/public/app/plugins/datasource/influxdb/migrations.ts
@@ -1,3 +1,5 @@
+import { InfluxQueryTag } from './types';
+
 type LegacyAnnotation = {
   query?: string;
   queryType?: string;
@@ -7,16 +9,21 @@ type LegacyAnnotation = {
   timeEndColumn?: string;
   titleColumn?: string;
   name?: string;
-  target: {
-    limit: number;
-    matchAny: boolean;
-    tags: string[];
-    type: string;
+  target?: {
+    limit?: number;
+    matchAny?: boolean;
+    tags?: InfluxQueryTag[];
+    type?: string;
   };
 };
 
 // this becomes the target in the migrated annotations
 const migrateLegacyAnnotation = (json: LegacyAnnotation) => {
+  const limit = json.target ? json.target.limit : 0;
+  const matchAny = json.target ? json.target.matchAny : false;
+  const tags = json.target ? json.target.tags : [];
+  const type = json.target ? json.target.type : '';
+
   return {
     query: json.query ?? '',
     queryType: 'tags',
@@ -27,10 +34,10 @@ const migrateLegacyAnnotation = (json: LegacyAnnotation) => {
     titleColumn: json.titleColumn ?? '',
     name: json.name ?? '',
     // handle json target fields
-    limit: json.target ? json.target.limit : 0,
-    matchAny: json.target ? json.target.matchAny : false,
-    tags: json.target ? json.target.tags : [],
-    type: json.target ? json.target.type : '',
+    limit: limit,
+    matchAny: matchAny,
+    tags: tags,
+    type: type,
   };
 };
 

--- a/public/app/plugins/datasource/influxdb/migrations.ts
+++ b/public/app/plugins/datasource/influxdb/migrations.ts
@@ -1,4 +1,4 @@
-import { InfluxQueryTag } from './types';
+import { InfluxQuery, InfluxQueryTag } from './types';
 
 type LegacyAnnotation = {
   query?: string;
@@ -10,7 +10,7 @@ type LegacyAnnotation = {
   titleColumn?: string;
   name?: string;
   target?: {
-    limit?: number;
+    limit?: string | number | undefined;
     matchAny?: boolean;
     tags?: InfluxQueryTag[];
     type?: string;
@@ -19,12 +19,9 @@ type LegacyAnnotation = {
 
 // this becomes the target in the migrated annotations
 const migrateLegacyAnnotation = (json: LegacyAnnotation) => {
-  const limit = json.target ? json.target.limit : 0;
-  const matchAny = json.target ? json.target.matchAny : false;
-  const tags = json.target ? json.target.tags : [];
-  const type = json.target ? json.target.type : '';
-
-  return {
+  // eslint-ignore-next-line
+  const target: InfluxQuery = {
+    refId: '',
     query: json.query ?? '',
     queryType: 'tags',
     fromAnnotations: true,
@@ -33,12 +30,26 @@ const migrateLegacyAnnotation = (json: LegacyAnnotation) => {
     timeEndColumn: json.timeEndColumn ?? '',
     titleColumn: json.titleColumn ?? '',
     name: json.name ?? '',
-    // handle json target fields
-    limit: limit,
-    matchAny: matchAny,
-    tags: tags,
-    type: type,
   };
+
+  // handle json target fields
+  if (json.target && json.target.limit) {
+    target.limit = json.target.limit;
+  }
+
+  if (json.target && json.target.matchAny) {
+    target.matchAny = json.target.matchAny;
+  }
+
+  if (json.target && json.target.tags) {
+    target.tags = json.target.tags;
+  }
+
+  if (json.target && json.target.type) {
+    target.type = json.target.type;
+  }
+
+  return target;
 };
 
 // eslint-ignore-next-line

--- a/public/app/plugins/datasource/influxdb/migrations.ts
+++ b/public/app/plugins/datasource/influxdb/migrations.ts
@@ -7,6 +7,12 @@ type LegacyAnnotation = {
   timeEndColumn?: string;
   titleColumn?: string;
   name?: string;
+  target: {
+    limit: number;
+    matchAny: boolean;
+    tags: string[];
+    type: string;
+  };
 };
 
 // this becomes the target in the migrated annotations
@@ -20,12 +26,18 @@ const migrateLegacyAnnotation = (json: LegacyAnnotation) => {
     timeEndColumn: json.timeEndColumn ?? '',
     titleColumn: json.titleColumn ?? '',
     name: json.name ?? '',
+    // handle json target fields
+    limit: json.target ? json.target.limit : 0,
+    matchAny: json.target ? json.target.matchAny : false,
+    tags: json.target ? json.target.tags : [],
+    type: json.target ? json.target.type : '',
   };
 };
 
 // eslint-ignore-next-line
 export const prepareAnnotation = (json: any) => {
-  json.target = json.target ?? migrateLegacyAnnotation(json);
+  // make sure that any additional target fields are migrated
+  json.target = json.target && !json.target?.query ? migrateLegacyAnnotation(json) : json.target;
 
   return json;
 };

--- a/public/app/plugins/datasource/influxdb/response_parser.ts
+++ b/public/app/plugins/datasource/influxdb/response_parser.ts
@@ -158,7 +158,7 @@ export default class ResponseParser {
 function colContainsTag(colText: string, tagsColumn: string): boolean {
   const tags = (tagsColumn || '').replace(' ', '').split(',');
   for (const tag of tags) {
-    if (colText.includes(tag)) {
+    if (tag !== '' && colText.includes(tag)) {
       return true;
     }
   }

--- a/public/app/plugins/datasource/influxdb/types.ts
+++ b/public/app/plugins/datasource/influxdb/types.ts
@@ -71,6 +71,9 @@ export interface InfluxQuery extends DataQuery {
   timeEndColumn?: string;
   titleColumn?: string;
   name?: string;
+  matchAny?: boolean;
+  type?: string;
+
   textEditor?: boolean;
   adhocFilters?: AdHocVariableFilter[];
 }


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/57122

**What is this feature?**
This is a bug fix to properly migrate Influxdb annotations to React, from legacy annotations to current annotations. This fix was implemented in v9.2 but did not take into consideration annotations created from dashboards that contained a target attribute in the annoation. This work fixes that and migrates any fields in the target object in the legacy annotation. 

**Why do we need this feature?**
To properly migrate all InfluxDB Influxql annotations from angular to react. 

Before merging this fix, talk with customers who have target objects in their annotations to make sure all target fields are migrated. 

How to test:
- Create a dashboard with gdev-influxdb-influxql with an annotation in v9.1.6
  - example `SELECT * from logs where time >= now() - 60m and time <= now()`
- Save the annotation and go to the dashboard json model
- Add the following to your annotation in the json
```
"target": {
          "limit": 100,
          "matchAny": false,
          "tags": [],
          "type": "dashboard"
        }
``` 
<img width="812" alt="Screen Shot 2023-02-09 at 5 58 11 PM" src="https://user-images.githubusercontent.com/25674746/217958989-36442ac1-dab9-46e1-b7ce-97a199161850.png">

- Save the json model.
- Checkout this branch.
- Start Grafana and check out your dashboard.
- The annotation should be migrated.