### PR TITLE
Docs: Update the service account HTTP API documentation

### DIFF
--- a/docs/sources/developers/http_api/serviceaccount.md
+++ b/docs/sources/developers/http_api/serviceaccount.md
@@ -251,6 +251,134 @@ Content-Type: application/json
 
 ---
 
+## Migrate API keys to service accounts
+
+`POST /api/serviceaccounts/migrate`
+
+**Required permissions**
+
+See note in the [introduction]({{< ref "#service-account-api" >}}) for an explanation.
+
+| Action                | Scope              |
+| --------------------- | ------------------ |
+| serviceaccounts:write | serviceaccounts:\* |
+
+**Example Request**:
+
+```http
+POST /api/serviceaccounts/migrate HTTP/1.1
+Accept: application/json
+Content-Type: application/json
+Authorization: Basic YWRtaW46YWRtaW4=
+```
+
+**Example Response**:
+
+```http
+HTTP/1.1 200
+Content-Type: application/json
+
+{
+	"message": "API keys migrated to service accounts"
+}
+```
+
+## Migrate API key to service account
+
+`POST /api/serviceaccounts/migrate/:keyId`
+
+**Required permissions**
+
+See note in the [introduction]({{< ref "#service-account-api" >}}) for an explanation.
+
+| Action                | Scope              |
+| --------------------- | ------------------ |
+| serviceaccounts:write | serviceaccounts:\* |
+
+**Example Request**:
+
+```http
+POST /api/serviceaccounts/migrate/4 HTTP/1.1
+Accept: application/json
+Content-Type: application/json
+Authorization: Basic YWRtaW46YWRtaW4=
+```
+
+**Example Response**:
+
+```http
+HTTP/1.1 200
+Content-Type: application/json
+
+{
+	"message": "Service accounts migrated"
+}
+```
+
+## Get API key to service account migration status
+
+`GET /api/serviceaccounts/migrationstatus`
+
+**Required permissions**
+
+See note in the [introduction]({{< ref "#service-account-api" >}}) for an explanation.
+
+| Action               | Scope              |
+| -------------------- | ------------------ |
+| serviceaccounts:read | serviceaccounts:\* |
+
+**Example Request**:
+
+```http
+POST /api/serviceaccounts/migrationstatus HTTP/1.1
+Accept: application/json
+Content-Type: application/json
+Authorization: Basic YWRtaW46YWRtaW4=
+```
+
+**Example Response**:
+
+```http
+HTTP/1.1 200
+Content-Type: application/json
+
+{
+	"migrated": true
+}
+```
+
+## Hide the API keys tab
+
+`GET /api/serviceaccounts/hideApiKeys`
+
+**Required permissions**
+
+See note in the [introduction]({{< ref "#service-account-api" >}}) for an explanation.
+
+| Action                | Scope              |
+| --------------------- | ------------------ |
+| serviceaccounts:write | serviceaccounts:\* |
+
+**Example Request**:
+
+```http
+POST /api/serviceaccounts/hideApiKeys HTTP/1.1
+Accept: application/json
+Content-Type: application/json
+Authorization: Basic YWRtaW46YWRtaW4=
+```
+
+**Example Response**:
+
+```http
+HTTP/1.1 200
+Content-Type: application/json
+
+{
+	"message": "API keys hidden"
+}
+```
+
 ## Get service account tokens
 
 `GET /api/serviceaccounts/:id/tokens`

--- a/docs/sources/developers/http_api/serviceaccount.md
+++ b/docs/sources/developers/http_api/serviceaccount.md
@@ -217,6 +217,38 @@ Content-Type: application/json
 }
 ```
 
+## Delete service account
+
+`DELETE /api/serviceaccounts/:id`
+
+**Required permissions**
+
+See note in the [introduction]({{< ref "#service-account-api" >}}) for an explanation.
+
+| Action                 | Scope                 |
+| ---------------------- | --------------------- |
+| serviceaccounts:delete | serviceaccounts:id:\* |
+
+**Example Request**:
+
+```http
+DELETE /api/serviceaccounts/2 HTTP/1.1
+Accept: application/json
+Content-Type: application/json
+Authorization: Basic YWRtaW46YWRtaW4=
+```
+
+**Example Response**:
+
+```http
+HTTP/1.1 200
+Content-Type: application/json
+
+{
+	"message": "Service account deleted"
+}
+```
+
 ---
 
 ## Get service account tokens


### PR DESCRIPTION
**What is this feature?**

Update the documentation and add the missing part of the service account deletion.

**Why do we need this feature?**

A good documentation is necessary to call the API correctly.

**Who is this feature for?**

For all people who use the service account API.

**Labels and Milestones:**
I'm an external contributor, so for me, it's not possible to add any related labels or milestones, but I would suggest to back port the documentation change.

backport v9.3.0
backport v9.2.x
backport v9.1.x
backport v9.0.x
backport v8.5.x
no-changelog


