### PR TITLE
Alerting: Add join function for custom labels and annotations

### DIFF
--- a/pkg/services/ngalert/state/template_functions.go
+++ b/pkg/services/ngalert/state/template_functions.go
@@ -4,14 +4,18 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"strings"
 	text_template "text/template"
 )
 
 // FuncMap is a map of custom functions we use for templates.
 var FuncMap = text_template.FuncMap{
 	"graphLink": graphLink,
-	"tableLink": tableLink,
+	"join": func(sep string, s []string) string {
+		return strings.Join(s, sep)
+	},
 	"strvalue":  strValue,
+	"tableLink": tableLink,
 }
 
 func graphLink(rawQuery string) string {


### PR DESCRIPTION
**What is this feature?**

This pull request adds the `join` function for custom labels and annotations. It does not use [`DefaultFuncs`](https://github.com/grafana/alerting/commit/c4357109f08934e874c5a931f1b974d2ce272e95) from https://github.com/grafana/alerting as of right now as there are some functions there, such as `SafeHTML`, which might not be appropriate for labels and annotations.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

