### PR TITLE
Loki Range Splitting: Calculate dynamic maxLines per target based on the current response state

### DIFF
--- a/public/app/plugins/datasource/loki/querySplitting.test.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.test.ts
@@ -4,22 +4,23 @@ import { getQueryOptions } from 'test/helpers/getQueryOptions';
 import { dateTime } from '@grafana/data';
 
 import { LokiDatasource } from './datasource';
-import { createLokiDatasource } from './mocks';
+import { createLokiDatasource, logFrameA } from './mocks';
 import { runPartitionedQuery } from './querySplitting';
 import { LokiQuery } from './types';
 
 describe('runPartitionedQuery()', () => {
   let datasource: LokiDatasource;
-  const request = getQueryOptions<LokiQuery>({
-    targets: [{ expr: 'count_over_time({a="b"}[1m])', refId: 'A' }],
-    range: {
+  const range = {
+    from: dateTime('2023-02-08T05:00:00.000Z'),
+    to: dateTime('2023-02-10T06:00:00.000Z'),
+    raw: {
       from: dateTime('2023-02-08T05:00:00.000Z'),
       to: dateTime('2023-02-10T06:00:00.000Z'),
-      raw: {
-        from: dateTime('2023-02-08T05:00:00.000Z'),
-        to: dateTime('2023-02-10T06:00:00.000Z'),
-      },
     },
+  };
+  const request = getQueryOptions<LokiQuery>({
+    targets: [{ expr: 'count_over_time({a="b"}[1m])', refId: 'A' }],
+    range,
   });
   beforeEach(() => {
     datasource = createLokiDatasource();
@@ -30,6 +31,29 @@ describe('runPartitionedQuery()', () => {
     await expect(runPartitionedQuery(datasource, request)).toEmitValuesWith(() => {
       // 3 days, 3 chunks, 3 requests.
       expect(datasource.runQuery).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('Dynamic maxLines for logs requests', () => {
+    const request = getQueryOptions<LokiQuery>({
+      targets: [{ expr: '{a="b"}', refId: 'A', maxLines: 4 }],
+      range,
+    });
+    beforeEach(() => {
+      jest.spyOn(datasource, 'runQuery').mockReturnValue(of({ data: [logFrameA], refId: 'A' }));
+    });
+    test('Stops requesting once maxLines of logs have been received', async () => {
+      await expect(runPartitionedQuery(datasource, request)).toEmitValuesWith(() => {
+        // 3 days, 3 chunks, 2 responses of 2 logs, 2 requests
+        expect(datasource.runQuery).toHaveBeenCalledTimes(2);
+      });
+    });
+    test('Performs all the requests if maxLines has not been reached', async () => {
+      request.targets[0].maxLines = 9999;
+      await expect(runPartitionedQuery(datasource, request)).toEmitValuesWith(() => {
+        // 3 days, 3 chunks, 3 responses of 2 logs, 3 requests
+        expect(datasource.runQuery).toHaveBeenCalledTimes(3);
+      });
     });
   });
 });

--- a/public/app/plugins/datasource/loki/querySplitting.test.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.test.ts
@@ -55,5 +55,13 @@ describe('runPartitionedQuery()', () => {
         expect(datasource.runQuery).toHaveBeenCalledTimes(3);
       });
     });
+    test('Performs all the requests if not a log query', async () => {
+      request.targets[0].maxLines = 1;
+      request.targets[0].expr = 'count_over_time({a="b"}[1m])';
+      await expect(runPartitionedQuery(datasource, request)).toEmitValuesWith(() => {
+        // 3 days, 3 chunks, 3 responses of 2 logs, 3 requests
+        expect(datasource.runQuery).toHaveBeenCalledTimes(3);
+      });
+    });
   });
 });

--- a/public/app/plugins/datasource/loki/querySplitting.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.ts
@@ -70,7 +70,7 @@ function adjustTargetsFromResponseState(targets: LokiQuery[], response: DataQuer
 
   return targets
     .map((target) => {
-      if (!target.maxLines) {
+      if (!target.maxLines || !isLogsQuery(target.expr)) {
         return target;
       }
       const targetFrame = response.data.find((frame) => frame.refId === target.refId);

--- a/public/app/plugins/datasource/loki/querySplitting.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.ts
@@ -6,7 +6,7 @@ import { LoadingState } from '@grafana/schema';
 import { LokiDatasource } from './datasource';
 import { getRangeChunks as getLogsRangeChunks } from './logsTimeSplit';
 import { getRangeChunks as getMetricRangeChunks } from './metricTimeSplit';
-import { combineResponses, isLogsQuery, resultLimitReached } from './queryUtils';
+import { combineResponses, isLogsQuery } from './queryUtils';
 import { LokiQuery } from './types';
 
 /**
@@ -56,6 +56,36 @@ export function partitionTimeRange(
   });
 }
 
+/**
+ * Based in the state of the current response, if any, adjust target parameters such as `maxLines`.
+ * For `maxLines`, we will update it as `maxLines - current amount of lines`.
+ * At the end, we will filter the targets that don't need to be executed in the next request batch,
+ * becasue, for example, the `maxLines` have been reached.
+ */
+
+function adjustTargetsFromResponseState(targets: LokiQuery[], response: DataQueryResponse | null): LokiQuery[] {
+  if (!response) {
+    return targets;
+  }
+
+  return targets
+    .map((target) => {
+      if (!target.maxLines) {
+        return target;
+      }
+      const targetFrame = response.data.find((frame) => frame.refId === target.refId);
+      if (!targetFrame) {
+        return target;
+      }
+      const updatedMaxLines = target.maxLines - targetFrame.length;
+      return {
+        ...target,
+        maxLines: updatedMaxLines < 0 ? 0 : updatedMaxLines,
+      };
+    })
+    .filter((target) => target.maxLines === undefined || target.maxLines > 0);
+}
+
 export function runPartitionedQuery(datasource: LokiDatasource, request: DataQueryRequest<LokiQuery>) {
   let mergedResponse: DataQueryResponse | null;
   const queries = request.targets.filter((query) => !query.hide);
@@ -72,8 +102,21 @@ export function runPartitionedQuery(datasource: LokiDatasource, request: DataQue
   const runNextRequest = (subscriber: Subscriber<DataQueryResponse>, requestN: number) => {
     const requestId = `${request.requestId}_${requestN}`;
     const range = partition[requestN - 1];
+    const targets = adjustTargetsFromResponseState(request.targets, mergedResponse);
+
+    const done = (response: DataQueryResponse) => {
+      response.state = LoadingState.Done;
+      subscriber.next(response);
+      subscriber.complete();
+    };
+
+    if (!targets.length && mergedResponse) {
+      done(mergedResponse);
+      return;
+    }
+
     datasource
-      .runQuery({ ...request, range, requestId })
+      .runQuery({ ...request, range, requestId, targets })
       .pipe(
         // in case of an empty query, this is somehow run twice. `share()` is no workaround here as the observable is generated from `of()`.
         map((partialResponse) => {
@@ -83,15 +126,13 @@ export function runPartitionedQuery(datasource: LokiDatasource, request: DataQue
       )
       .subscribe({
         next: (response) => {
-          if (requestN > 1 && resultLimitReached(request, response) === false) {
+          if (requestN > 1) {
             response.state = LoadingState.Streaming;
             subscriber.next(response);
             runNextRequest(subscriber, requestN - 1);
             return;
           }
-          response.state = LoadingState.Done;
-          subscriber.next(response);
-          subscriber.complete();
+          done(response);
         },
         error: (error) => {
           subscriber.error(error);

--- a/public/app/plugins/datasource/loki/queryUtils.test.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.test.ts
@@ -1,6 +1,4 @@
-import { getQueryOptions } from 'test/helpers/getQueryOptions';
-
-import { ArrayVector, DataQueryResponse, FieldType } from '@grafana/data';
+import { ArrayVector, DataQueryResponse } from '@grafana/data';
 
 import { logFrameA, logFrameB, metricFrameA, metricFrameB } from './mocks';
 import {

--- a/public/app/plugins/datasource/loki/queryUtils.test.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.test.ts
@@ -13,7 +13,6 @@ import {
   parseToNodeNamesArray,
   getParserFromQuery,
   obfuscate,
-  resultLimitReached,
   combineResponses,
 } from './queryUtils';
 import { LokiQuery, LokiQueryType } from './types';
@@ -297,52 +296,6 @@ describe('getParserFromQuery', () => {
     expect(getParserFromQuery(`sum(count_over_time({place="luna"} | ${parser} | unwrap counter )) by (place)`)).toBe(
       parser
     );
-  });
-});
-
-describe('resultLimitReached', () => {
-  const result = {
-    data: [
-      {
-        name: 'test',
-        fields: [
-          {
-            name: 'Time',
-            type: FieldType.time,
-            config: {},
-            values: new ArrayVector([1, 2]),
-          },
-          {
-            name: 'Line',
-            type: FieldType.string,
-            config: {},
-            values: new ArrayVector(['line1', 'line2']),
-          },
-        ],
-        length: 2,
-      },
-    ],
-  };
-  it('returns false for non-logs queries', () => {
-    const request = getQueryOptions<LokiQuery>({
-      targets: [{ expr: 'count_over_time({a="b"}[1m])', refId: 'A', maxLines: 0 }],
-    });
-
-    expect(resultLimitReached(request, result)).toBe(false);
-  });
-  it('returns false when the limit is not reached', () => {
-    const request = getQueryOptions<LokiQuery>({
-      targets: [{ expr: '{a="b"}', refId: 'A', maxLines: 3 }],
-    });
-
-    expect(resultLimitReached(request, result)).toBe(false);
-  });
-  it('returns true when the limit is reached', () => {
-    const request = getQueryOptions<LokiQuery>({
-      targets: [{ expr: '{a="b"}', refId: 'A', maxLines: 2 }],
-    });
-
-    expect(resultLimitReached(request, result)).toBe(true);
   });
 });
 

--- a/public/app/plugins/datasource/loki/queryUtils.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.ts
@@ -359,25 +359,3 @@ function combineMetadata(dest: DataQueryResponseData = {}, source: DataQueryResp
     }
   });
 }
-
-/**
- * Checks if the current response has reached the requested amount of results or not.
- * For log queries, we will ensure that the current amount of results doesn't go beyond `maxLines`.
- */
-export function resultLimitReached(request: DataQueryRequest<LokiQuery>, result: DataQueryResponse) {
-  const logRequests = request.targets.filter((target) => isLogsQuery(target.expr));
-
-  if (logRequests.length === 0) {
-    return false;
-  }
-
-  for (const request of logRequests) {
-    for (const frame of result.data) {
-      if (request.maxLines && frame?.fields[0].values.length >= request.maxLines) {
-        return true;
-      }
-    }
-  }
-
-  return false;
-}

--- a/public/app/plugins/datasource/loki/queryUtils.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.ts
@@ -1,7 +1,7 @@
 import { SyntaxNode } from '@lezer/common';
 import { escapeRegExp } from 'lodash';
 
-import { DataQueryRequest, DataQueryResponse, DataQueryResponseData, QueryResultMetaStat } from '@grafana/data';
+import { DataQueryResponse, DataQueryResponseData, QueryResultMetaStat } from '@grafana/data';
 import {
   parser,
   LineFilter,


### PR DESCRIPTION
Problem: when we split log requests, every request has an expected max amount of lines, and we don't know how many lines of logs are going to be returned with every request. In the current behavior, you could be expecting `1000` lines split into 2 requests. If one returns `700` and the other returns `500`, you ended up with `1300` lines of logs instead of the expected `1000`.

This PR updates the `target` property on every `runNextRequest()` iteration, so we request less logs as results are being returned, until we reach the `maxLines` limit. Once the limit is reached, we stop sending further requests.

For example:

- maxLines is 3000
- runNextRequest 3000 logs
- First request returns 1000 logs
- runNextRequest 2000 logs
- Second request returns 2000 logs
- done()

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana/issues/63174
Part of https://github.com/grafana/grafana/issues/61768

**Special notes for your reviewer**:

Run log requests, use different `maxLines` values, over time intervals that will produce subrequests.

Expected result: you should never see more than `maxLines` logs.

Demo:

https://user-images.githubusercontent.com/1069378/218093373-6de1cfad-f640-43d8-b9c2-f5dbf9676faa.mov
