### PR TITLE
Loki Range splitting: Ignore hidden queries

### DIFF
--- a/public/app/plugins/datasource/loki/querySplitting.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.ts
@@ -58,8 +58,9 @@ export function partitionTimeRange(
 
 export function runPartitionedQuery(datasource: LokiDatasource, request: DataQueryRequest<LokiQuery>) {
   let mergedResponse: DataQueryResponse | null;
+  const queries = request.targets.filter((query) => !query.hide);
   // we assume there is just a single query in the request
-  const query = request.targets[0];
+  const query = queries[0];
   const partition = partitionTimeRange(
     isLogsQuery(query.expr),
     request.range,

--- a/public/app/plugins/datasource/loki/queryUtils.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.ts
@@ -297,9 +297,10 @@ export function getStreamSelectorsFromQuery(query: string): string[] {
   return labelMatchers;
 }
 
-export function requestSupportsPartitioning(queries: LokiQuery[]) {
+export function requestSupportsPartitioning(allQueries: LokiQuery[]) {
+  const queries = allQueries.filter((query) => !query.hide);
   /*
-   * For now, we would not split when more than 1 query is requested.
+   * For now, we will not split when more than 1 query is requested.
    */
   if (queries.length > 1) {
     return false;


### PR DESCRIPTION
Follow up to a comment in a PR: https://github.com/grafana/grafana/pull/62767#discussion_r1101863456

We could potentially be making decisions based on hidden queries, so we are ignoring them in the request splitting code.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana/issues/61768

**Special notes for your reviewer**:

Hidden queries in the UI should not affect the behavior of the splitting code.