### PR TITLE
Support bundles: improve plugin collector

### DIFF
--- a/pkg/services/pluginsettings/models.go
+++ b/pkg/services/pluginsettings/models.go
@@ -74,7 +74,7 @@ type PluginSettingInfo struct {
 	OrgID         int64  `xorm:"org_id"`
 	Enabled       bool   `xorm:"enabled"`
 	Pinned        bool   `xorm:"pinned"`
-	PluginVersion string `xorm:"plugin_id"`
+	PluginVersion string `xorm:"plugin_version"`
 }
 
 // ----------------------

--- a/pkg/services/supportbundles/supportbundlesimpl/service.go
+++ b/pkg/services/supportbundles/supportbundlesimpl/service.go
@@ -86,7 +86,7 @@ func ProvideService(cfg *setting.Cfg,
 	s.bundleRegistry.RegisterSupportItemCollector(basicCollector(cfg))
 	s.bundleRegistry.RegisterSupportItemCollector(settingsCollector(settings))
 	s.bundleRegistry.RegisterSupportItemCollector(dbCollector(sql))
-	s.bundleRegistry.RegisterSupportItemCollector(pluginInfoCollector(pluginStore, pluginSettings))
+	s.bundleRegistry.RegisterSupportItemCollector(pluginInfoCollector(pluginStore, pluginSettings, s.log))
 
 	return s, nil
 }


### PR DESCRIPTION
**What is this feature?**

Several improvements to plugin collector:
* filter out core plugins to reduce the noise;
* organise the information that is collected for each plugin to make it easier to read;
* query plugin settings across all orgs;
* print indented json to make it easier to read.

**Note to reviewers**
I'll move the collector to plugins service in another PR.