### PR TITLE
Loki: Do not chunk when refid contains `do-not-chunk`

### DIFF
--- a/public/app/plugins/datasource/loki/queryUtils.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.ts
@@ -305,6 +305,10 @@ export function requestSupportsPartitioning(queries: LokiQuery[]) {
     return false;
   }
 
+  if (queries[0].refId.includes('do-not-chunk')) {
+    return false;
+  }
+
   return true;
 }
 


### PR DESCRIPTION
**What is this feature?**
I think it's good to compare requests from being chunked and not. By this we would add a rule to not chunk requests containing a `do-not-chunk` in the ref id.