### PR TITLE
Support bundles: small UX improvements

### DIFF
--- a/pkg/services/supportbundles/supportbundlesimpl/collectors.go
+++ b/pkg/services/supportbundles/supportbundlesimpl/collectors.go
@@ -50,7 +50,7 @@ func basicCollector(cfg *setting.Cfg) supportbundles.Collector {
 			loc, _ := time.LoadLocation("UTC")
 			now := collectionDate.In(loc)
 
-			data, err := json.Marshal(basicInfo{
+			info := basicInfo{
 				Version:         cfg.BuildVersion,
 				Commit:          cfg.BuildCommit,
 				CollectionDate:  now,
@@ -68,7 +68,8 @@ func basicCollector(cfg *setting.Cfg) supportbundles.Collector {
 				GoOS:            runtime.GOOS,
 				GoArch:          runtime.GOARCH,
 				GoCompiler:      runtime.Compiler,
-			})
+			}
+			data, err := json.MarshalIndent(info, "", " ")
 			if err != nil {
 				return nil, err
 			}
@@ -90,7 +91,7 @@ func settingsCollector(settings setting.Provider) supportbundles.Collector {
 		Default:           true,
 		Fn: func(ctx context.Context) (*supportbundles.SupportItem, error) {
 			current := settings.Current()
-			data, err := json.Marshal(current)
+			data, err := json.MarshalIndent(current, "", " ")
 			if err != nil {
 				return nil, err
 			}

--- a/public/app/features/support-bundles/SupportBundlesCreate.tsx
+++ b/public/app/features/support-bundles/SupportBundlesCreate.tsx
@@ -66,20 +66,22 @@ export const SupportBundlesCreateUnconnected = ({
             {({ register, errors }) => {
               return (
                 <>
-                  {collectors.map((component) => {
-                    return (
-                      <Field key={component.uid}>
-                        <Checkbox
-                          {...register(component.uid)}
-                          label={component.displayName}
-                          id={component.uid}
-                          description={component.description}
-                          defaultChecked={component.default}
-                          disabled={component.includedByDefault}
-                        />
-                      </Field>
-                    );
-                  })}
+                  {[...collectors]
+                    .sort((a, b) => a.displayName.localeCompare(b.displayName))
+                    .map((component) => {
+                      return (
+                        <Field key={component.uid}>
+                          <Checkbox
+                            {...register(component.uid)}
+                            label={component.displayName}
+                            id={component.uid}
+                            description={component.description}
+                            defaultChecked={component.default}
+                            disabled={component.includedByDefault}
+                          />
+                        </Field>
+                      );
+                    })}
                   <HorizontalGroup>
                     <Button type="submit">Create</Button>
                     <LinkButton href="/support-bundles" variant="secondary">


### PR DESCRIPTION
**What is this feature?**

Small UX improvements to support bundles:
* auto indent json files returned by the basic and stats collectors;
* sort the collectors alphabetically in the UI for creating a new support bundle.

**Special notes for your reviewer**:

Let me know if the frontend changes look ok. I'm a frontend noob, so there might be a better way 😄 