### PR TITLE
Geomap: Update documentation for 9.4

### DIFF
--- a/docs/sources/panels-visualizations/visualizations/geomap/index.md
+++ b/docs/sources/panels-visualizations/visualizations/geomap/index.md
@@ -85,7 +85,7 @@ There are also five alpha layer types.
 - [Night / Day (alpha)]({{< relref "#night--day-layer-alpha" >}}) renders a night / day region.
 - **Icon at last point (alpha)** renders an icon at the last data point.
 - **Dynamic GeoJSON (alpha)** styles a GeoJSON file based on query results.
-- **Route (alpha)** render data points as a route.
+- [Route layer (Alpha)]({{< relref "#route-layer-alpha" >}}) render data points as a route.
 - [Photos layer (Alpha)]({{< relref "#photos-layer-alpha" >}}) renders a photo at each data point.
 
 > **Note:** [Basemap layer types]({{< relref "#types-1" >}}) can also be added as layers. You can specify an opacity.
@@ -350,6 +350,27 @@ The Night / Day layer displays night and day regions based on the current time r
 ### More information
 
 - [**Extensions for OpenLayers - DayNight**](https://viglino.github.io/ol-ext/examples/layer/map.daynight.html)
+
+## Route layer (Alpha)
+
+The Route layer renders data points as a route.
+
+{{< figure src="/media/docs/grafana/geomap-route-layer-basic-9-4-0.png" max-width="1200px" caption="Geomap panel Route" >}}
+
+### Options
+
+- **Size** route thickness, Fixed by default or Min and Max range of selected field
+- **Color** route color, Fixed by default or Standard Options color scheme on selected field
+- **Arrow** arrow styling to display along route, in order of data
+  - **None**
+  - **Forward**
+  - **Reverse**
+
+{{< figure src="/media/docs/grafana/geomap-route-layer-arrow-size-9-4-0.png" max-width="1200px" caption="Geomap panel Route arrows with size" >}}
+
+### More information
+
+- [**Extensions for OpenLayers - Flow Line Style**](http://viglino.github.io/ol-ext/examples/style/map.style.gpxline.html)
 
 ## Photos layer (Alpha)
 

--- a/docs/sources/panels-visualizations/visualizations/geomap/index.md
+++ b/docs/sources/panels-visualizations/visualizations/geomap/index.md
@@ -359,9 +359,9 @@ The Route layer renders data points as a route.
 
 ### Options
 
-- **Size** route thickness, Fixed by default or Min and Max range of selected field
-- **Color** route color, Fixed by default or Standard Options color scheme on selected field
-- **Arrow** arrow styling to display along route, in order of data
+- **Size** sets the route thickness. Fixed by default, or Min and Max range of selected field.
+- **Color** sets the route color. Fixed by default or Standard Options color scheme on selected field.
+- **Arrow** sets the arrow styling to display along route, in order of data.
   - **None**
   - **Forward**
   - **Reverse**


### PR DESCRIPTION
Update docs for 9.4 for Geomap.

Images being referenced:
1. https://grafana.com/media/docs/grafana/geomap-route-layer-basic-9-4-0.png
2. https://grafana.com/media/docs/grafana/geomap-route-layer-arrow-size-9-4-0.png