### PR TITLE
Dashboard: remove unused submenuEnabled property

### DIFF
--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -1045,14 +1045,8 @@ export class DashboardModel implements TimeModel {
 
     const navbarHeight = 55;
     const margin = 20;
-    const submenuHeight = 50;
 
     let visibleHeight = viewHeight - navbarHeight - margin;
-
-    // Remove submenu height if visible
-    if (this.meta.submenuEnabled && !kioskMode) {
-      visibleHeight -= submenuHeight;
-    }
 
     // add back navbar height
     if (kioskMode && kioskMode !== KioskMode.TV) {

--- a/public/app/types/dashboard.ts
+++ b/public/app/types/dashboard.ts
@@ -23,7 +23,6 @@ export interface DashboardMeta {
   folderId?: number;
   folderUid?: string;
   canMakeEditable?: boolean;
-  submenuEnabled?: boolean;
   provisioned?: boolean;
   provisionedExternalId?: string;
   isStarred?: boolean;


### PR DESCRIPTION
Stumbled into this while trying to understand existing dashboard metadata.  This appears to be an old (4 years?) property that is not referenced anywhere.