### PR TITLE
Dashboard: remove -Infinity in the dashboard export cleanup

### DIFF
--- a/public/app/core/utils/object.test.ts
+++ b/public/app/core/utils/object.test.ts
@@ -1,4 +1,4 @@
-import { sortedDeepCloneWithoutNulls } from './object';
+import { sortedDeepCloneWithoutJSONNulls } from './object';
 
 describe('objects', () => {
   const value = {
@@ -9,11 +9,12 @@ describe('objects', () => {
       arr: [null, 1, 'hello'],
     },
     bar: undefined,
+    baz: -Infinity,
     simple: 'A',
   };
 
   it('returns a clean copy', () => {
-    const copy = sortedDeepCloneWithoutNulls(value);
+    const copy = sortedDeepCloneWithoutJSONNulls(value);
     expect(copy).toMatchObject({
       world: {
         deeper: 10,

--- a/public/app/core/utils/object.ts
+++ b/public/app/core/utils/object.ts
@@ -1,17 +1,18 @@
 ﻿import { isArray, isPlainObject } from 'lodash';
 
 /** @returns a deep clone of the object, but with any null value removed */
-export function sortedDeepCloneWithoutNulls<T extends {}>(value: T): T {
+export function sortedDeepCloneWithoutJSONNulls<T extends {}>(value: T): T {
   if (isArray(value)) {
-    return value.map(sortedDeepCloneWithoutNulls) as unknown as T;
+    return value.map(sortedDeepCloneWithoutJSONNulls) as unknown as T;
   }
   if (isPlainObject(value)) {
     return Object.keys(value)
       .sort()
       .reduce((acc: any, key) => {
         const v = (value as any)[key];
-        if (v != null) {
-          acc[key] = sortedDeepCloneWithoutNulls(v);
+        if (v != null && v !== -Infinity) {
+          // -Infinity is encoded as null in json
+          acc[key] = sortedDeepCloneWithoutJSONNulls(v);
         }
         return acc;
       }, {});

--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -21,7 +21,7 @@ import { Dashboard } from '@grafana/schema';
 import { DEFAULT_ANNOTATION_COLOR } from '@grafana/ui';
 import { GRID_CELL_HEIGHT, GRID_CELL_VMARGIN, GRID_COLUMN_COUNT, REPEAT_DIR_VERTICAL } from 'app/core/constants';
 import { contextSrv } from 'app/core/services/context_srv';
-import { sortedDeepCloneWithoutNulls } from 'app/core/utils/object';
+import { sortedDeepCloneWithoutJSONNulls } from 'app/core/utils/object';
 import { variableAdapters } from 'app/features/variables/adapters';
 import { onTimeRangeUpdated } from 'app/features/variables/state/actions';
 import { GetVariables, getVariablesByKey } from 'app/features/variables/state/selectors';
@@ -242,7 +242,7 @@ export class DashboardModel implements TimeModel {
     copy.panels = this.getPanelSaveModels();
 
     //  sort by keys
-    copy = sortedDeepCloneWithoutNulls(copy);
+    copy = sortedDeepCloneWithoutJSONNulls(copy);
     copy.getVariables = () => copy.templating.list;
 
     return copy;

--- a/public/app/features/dashboard/utils/panelMerge.ts
+++ b/public/app/features/dashboard/utils/panelMerge.ts
@@ -62,6 +62,11 @@ export function mergePanels(current: PanelModel[], data: IPanelModel[]): PanelMe
     // Check if it is the same type
     if (panel.type === target.type) {
       const save = panel.getSaveModel();
+      const first = save.fieldConfig?.defaults?.thresholds?.steps?.[0];
+      if (first) {
+        first.value = -Infinity;
+      }
+
       let isNoop = true;
       let doUpdate = false;
       for (const [key, value] of Object.entries(target)) {


### PR DESCRIPTION
When exporting dashboards, we remove all null values before saving.  This *mostly* fixes the validation required for themas schema parsing.  However the first value in thresholds is always `-Infinity`, and that gets converted to null after we send it (-Infinity is not supported by json)

This PR strips -Infinity along with the null values while exporting.

This should avoid needing to run `scripts/stripnulls.sh` when updating devenv dashboards :)

Fixes #54126