### PR TITLE
k8s: Do not create a client when the feature is not enabled

### DIFF
--- a/pkg/services/k8s/client/clientset.go
+++ b/pkg/services/k8s/client/clientset.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/wire"
 	"github.com/grafana/grafana/pkg/kindsys/k8ssys"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -48,7 +49,10 @@ type Clientset struct {
 	lock sync.RWMutex
 }
 
-func ProvideClientset() (*Clientset, error) {
+func ProvideClientset(toggles featuremgmt.FeatureToggles) (*Clientset, error) {
+	if !toggles.IsEnabled(featuremgmt.FlagK8s) {
+		return &Clientset{}, nil
+	}
 	cfg, err := GetRESTConfig()
 	if err != nil {
 		return nil, err

--- a/pkg/services/k8s/client/clientset.go
+++ b/pkg/services/k8s/client/clientset.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/wire"
 	"github.com/grafana/grafana/pkg/kindsys/k8ssys"
+	"github.com/grafana/grafana/pkg/registry"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -48,6 +49,8 @@ type Clientset struct {
 	crds map[k8schema.GroupVersion]apiextensionsv1.CustomResourceDefinition
 	lock sync.RWMutex
 }
+
+var _ registry.CanBeDisabled = (*Clientset)(nil)
 
 func ProvideClientset(toggles featuremgmt.FeatureToggles) (*Clientset, error) {
 	if !toggles.IsEnabled(featuremgmt.FlagK8s) {
@@ -104,6 +107,10 @@ func NewClientset(
 		crds: make(map[k8schema.GroupVersion]apiextensionsv1.CustomResourceDefinition),
 		lock: sync.RWMutex{},
 	}, nil
+}
+
+func (c *Clientset) IsDisabled() bool {
+	return c.config == nil
 }
 
 // RegisterSchema registers a k8ssys.Kind with the Kubernetes API.

--- a/pkg/services/k8s/resources/dashboards/resource.go
+++ b/pkg/services/k8s/resources/dashboards/resource.go
@@ -22,6 +22,10 @@ type Resource struct {
 }
 
 func ProvideResource(clientset *client.Clientset, reg *corecrd.Registry, kinds *corekind.Base) (*Resource, error) {
+	if clientset.IsDisabled() {
+		return &Resource{}, nil // something better
+	}
+
 	err := clientset.RegisterKind(context.Background(), reg.Dashboard())
 	if err != nil {
 		return nil, err

--- a/pkg/services/k8s/resources/dashboards/service.go
+++ b/pkg/services/k8s/resources/dashboards/service.go
@@ -13,7 +13,6 @@ import (
 	"github.com/grafana/grafana/pkg/kinds/dashboard"
 	"github.com/grafana/grafana/pkg/kindsys/k8ssys"
 	"github.com/grafana/grafana/pkg/services/dashboards"
-	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
 )
 
@@ -23,7 +22,6 @@ import (
 type Service struct {
 	dashboards.DashboardService
 
-	cfg *setting.Cfg
 	log log.Logger
 
 	dashboardResource *Resource
@@ -31,12 +29,8 @@ type Service struct {
 
 var _ dashboards.DashboardService = (*Service)(nil)
 
-func ProvideService(
-	cfg *setting.Cfg,
-	dashboardResource *Resource,
-) *Service {
+func ProvideService(dashboardResource *Resource) *Service {
 	return &Service{
-		cfg:               cfg,
 		log:               log.New("k8s.dashboards.service"),
 		dashboardResource: dashboardResource,
 	}


### PR DESCRIPTION
Avoid creating a (real) client when k8s feature flag is not enabled