### PR TITLE
GHActions: add token to publish changelog on forum

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -22,3 +22,4 @@ jobs:
         with:
           token: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
           metricsWriteAPIKey: ${{ secrets.GRAFANA_MISC_STATS_API_KEY }}
+          grafanabotForumKey: ${{ secrets.GRAFANABOT_FORUM_KEY }}


### PR DESCRIPTION
this PR adjusts the config for the Changelog GH action. It passes in a new secret so we can auto-publish the changelog to community.grafana.com

see logic [in this PR](https://github.com/grafana/grafana-github-actions/pull/135)