### PR TITLE
Docs, update for american English spelling

### DIFF
--- a/docs/sources/alerting/manage-notifications/create-notification-policy.md
+++ b/docs/sources/alerting/manage-notifications/create-notification-policy.md
@@ -36,7 +36,7 @@ You can configure grouping to be `group_by: [alertname]` (take note that the `en
 
 ## Edit root notification policy
 
-> **Note:** Before Grafana v8.2, the configuration of the embedded Alertmanager was shared across organisations. Users of Grafana 8.0 and 8.1 are advised to use the new Grafana 8 Alerts only if they have one organisation. Otherwise, silences for the Grafana managed alerts will be visible by all organizations.
+> **Note:** Before Grafana v8.2, the configuration of the embedded Alertmanager was shared across organizations. Users of Grafana 8.0 and 8.1 are advised to use the new Grafana 8 Alerts only if they have one organization. Otherwise, silences for the Grafana managed alerts will be visible by all organizations.
 
 1. In the Grafana menu, click the **Alerting** (bell) icon to open the Alerting page listing existing alerts.
 1. Click **Notification policies**.


### PR DESCRIPTION
Organisation → Organization

AmE is in the google style guide [^1], and the Writers' Toolkit has an [open issue](https://github.com/grafana/writers-toolkit/issues/187) to add this recommendation to Grafana style guide, too.



[^1]: https://developers.google.com/style/spelling
