### PR TITLE
Docs: Mention implicit TLS port requirements for SMTP

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -1096,7 +1096,7 @@ Enable this to allow Grafana to send email. Default is `false`.
 
 ### host
 
-Default is `localhost:25`.
+Default is `localhost:25`. Only 465 port is supported for the smtp proxy server with TLS port enabled.
 
 ### user
 

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -1096,7 +1096,7 @@ Enable this to allow Grafana to send email. Default is `false`.
 
 ### host
 
-Default is `localhost:25`. Only 465 port is supported for the smtp proxy server with TLS port enabled.
+Default is `localhost:25`. Port 465 is only supported for the SMTP proxy server with the TLS port enabled.
 
 ### user
 

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -1096,7 +1096,7 @@ Enable this to allow Grafana to send email. Default is `false`.
 
 ### host
 
-Default is `localhost:25`. Port 465 is only supported for the SMTP proxy server with the TLS port enabled.
+Default is `localhost:25`. Use port 465 for implicit TLS.
 
 ### user
 


### PR DESCRIPTION
Added additional description for smtp configuration.

This is helpful for using the grafana email alert function. 

Especially for developers using smtp proxy servers. 

**To solve this problem, it may be necessary to reconsider the security policy of smtp connection, or to add a new configuration switch.Adding this descriptive information may avoid many enterprise users from encountering the same doubts.**