### PR TITLE
Loki: query splitting: handle multiple queries

### DIFF
--- a/public/app/plugins/datasource/loki/querySplitting.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.ts
@@ -1,12 +1,13 @@
+import { partition } from 'lodash';
 import { Subscriber, Observable, Subscription } from 'rxjs';
 
-import { DataQueryRequest, DataQueryResponse, dateTime, TimeRange } from '@grafana/data';
+import { DataFrame, DataFrameType, DataQueryRequest, DataQueryResponse, dateTime, TimeRange } from '@grafana/data';
 import { LoadingState } from '@grafana/schema';
 
 import { LokiDatasource } from './datasource';
 import { getRangeChunks as getLogsRangeChunks } from './logsTimeSplit';
 import { getRangeChunks as getMetricRangeChunks } from './metricTimeSplit';
-import { combineResponses, isLogsQuery } from './queryUtils';
+import { combineLogsResponses, combineMetricsResponses, isLogsQuery } from './queryUtils';
 import { LokiQuery } from './types';
 
 /**
@@ -16,44 +17,88 @@ import { LokiQuery } from './types';
  */
 (window as any).lokiChunkDuration = 24 * 60 * 60 * 1000;
 
-export function partitionTimeRange(
-  isLogsQuery: boolean,
+function calculateStep(start: number, end: number, intervalMs: number, resolutions: Array<number | undefined>): number {
+  const safeStep = Math.ceil((end - start) / 11000);
+  // FIXME: for now we just take the first resolution.
+  // we should calculate a "shared" resolution coefficient,
+  // it will be the lowest-common-multiple of the resolutions
+  const resolution = resolutions[0] ?? 1;
+  return Math.max(intervalMs * resolution, safeStep);
+}
+
+type Task = {
+  range: TimeRange;
+  queries: LokiQuery[];
+};
+
+function chunkToRange(start: number, end: number): TimeRange {
+  const from = dateTime(start);
+  const to = dateTime(end);
+  return {
+    from,
+    to,
+    raw: { from, to },
+  };
+}
+
+function createTasks(
+  queries: LokiQuery[],
   originalTimeRange: TimeRange,
   intervalMs: number,
-  resolution: number
-): TimeRange[] {
-  // the `step` value that will be finally sent to Loki is rougly the same as `intervalMs`,
-  // but there are some complications.
-  // we need to replicate this algo:
-  //
-  // https://github.com/grafana/grafana/blob/main/pkg/tsdb/loki/step.go#L23
-
+  durationMs: number
+): Task[] {
   const start = originalTimeRange.from.toDate().getTime();
   const end = originalTimeRange.to.toDate().getTime();
 
-  const safeStep = Math.ceil((end - start) / 11000);
-  const step = Math.max(intervalMs * resolution, safeStep);
+  const [logsQueries, metricsQueries] = partition(queries, (q) => isLogsQuery(q.expr));
 
-  const duration: number = (window as any).lokiChunkDuration;
+  let logsTasks: Task[] = [];
+  let metricsTasks: Task[] = [];
 
-  const ranges = isLogsQuery
-    ? getLogsRangeChunks(start, end, duration)
-    : getMetricRangeChunks(start, end, step, duration);
-
-  // if the split was not possible, go with the original range
-  if (ranges == null) {
-    return [originalTimeRange];
+  if (logsQueries.length > 0) {
+    const chunks = getLogsRangeChunks(start, end, durationMs);
+    // if not possible to chunk, use the original range
+    const ranges = chunks != null ? chunks.map((c) => chunkToRange(c[0], c[1])) : [originalTimeRange];
+    logsTasks = ranges.map((range) => ({
+      type: 'logs',
+      range,
+      queries: logsQueries,
+    }));
   }
 
-  return ranges.map(([start, end]) => {
-    const from = dateTime(start);
-    const to = dateTime(end);
-    return {
-      from,
-      to,
-      raw: { from, to },
-    };
-  });
+  if (metricsQueries.length > 0) {
+    const step = calculateStep(
+      start,
+      end,
+      intervalMs,
+      metricsQueries.map((q) => q.resolution)
+    );
+    const chunks = getMetricRangeChunks(start, end, step, durationMs);
+    // if not possible to chunk, use the original range
+    const ranges = chunks != null ? chunks.map((c) => chunkToRange(c[0], c[1])) : [originalTimeRange];
+    metricsTasks = ranges.map((range) => ({
+      type: 'metrics',
+      range,
+      queries: metricsQueries,
+    }));
+  }
+
+  // we need to join the two tasks-lists, but we should alternatve between the task-types
+  const maxLen = Math.max(metricsTasks.length, logsTasks.length);
+  const tasks: Task[] = [];
+
+  for (let i = 0; i < maxLen; i++) {
+    const logsTask = logsTasks[i];
+    if (logsTask != null) {
+      tasks.push(logsTask);
+    }
+    const metricsTask = metricsTasks[i];
+    if (metricsTask != null) {
+      tasks.push(metricsTask);
+    }
+  }
+
+  return tasks;
 }
 
 /**
@@ -63,17 +108,13 @@ export function partitionTimeRange(
  * becasue, for example, the `maxLines` have been reached.
  */
 
-function adjustTargetsFromResponseState(targets: LokiQuery[], response: DataQueryResponse | null): LokiQuery[] {
-  if (!response) {
-    return targets;
-  }
-
+function adjustTargetsFromResponseState(targets: LokiQuery[], state: State): LokiQuery[] {
   return targets
     .map((target) => {
       if (!target.maxLines || !isLogsQuery(target.expr)) {
         return target;
       }
-      const targetFrame = response.data.find((frame) => frame.refId === target.refId);
+      const targetFrame = state.logsFrames.get(target.refId);
       if (!targetFrame) {
         return target;
       }
@@ -86,18 +127,48 @@ function adjustTargetsFromResponseState(targets: LokiQuery[], response: DataQuer
     .filter((target) => target.maxLines === undefined || target.maxLines > 0);
 }
 
+type State = {
+  metricsFrames: Map<string, DataFrame[]>;
+  logsFrames: Map<string, DataFrame>;
+};
+
+function updateState(state: State, newFrames: DataFrame[]): void {
+  const newLogsFrames: DataFrame[] = [];
+  const newMetricsFrames: DataFrame[] = [];
+
+  // we categorize the new frames
+  newFrames.forEach((frame) => {
+    if (frame.meta?.custom?.frameType === 'LabeledTimeValues') {
+      newLogsFrames.push(frame);
+    } else {
+      if (frame.meta?.type === DataFrameType.TimeSeriesMulti) {
+        newMetricsFrames.push(frame);
+      } else {
+        throw new Error('unknown dataframe');
+      }
+    }
+  });
+
+  combineLogsResponses(state.logsFrames, newLogsFrames);
+  combineMetricsResponses(state.metricsFrames, newMetricsFrames);
+}
+
+function stateToFrames(state: State): DataFrame[] {
+  const metricsFrames = Array.from(state.metricsFrames.values()).flat();
+  const logsFrames = state.logsFrames.values();
+  return [...metricsFrames, ...logsFrames];
+}
+
+function makeEmptyState(): State {
+  return { metricsFrames: new Map(), logsFrames: new Map() };
+}
+
 export function runPartitionedQuery(datasource: LokiDatasource, request: DataQueryRequest<LokiQuery>) {
-  let mergedResponse: DataQueryResponse | null;
+  const state = makeEmptyState();
   const queries = request.targets.filter((query) => !query.hide);
-  // we assume there is just a single query in the request
-  const query = queries[0];
-  const partition = partitionTimeRange(
-    isLogsQuery(query.expr),
-    request.range,
-    request.intervalMs,
-    query.resolution ?? 1
-  );
-  const totalRequests = partition.length;
+
+  const tasks = createTasks(queries, request.range, request.intervalMs, (window as any).lokiChunkDuration);
+  const totalRequests = tasks.length;
 
   let shouldStop = false;
   let subquerySubsciption: Subscription | null = null;
@@ -107,38 +178,40 @@ export function runPartitionedQuery(datasource: LokiDatasource, request: DataQue
       return;
     }
 
-    const requestId = `${request.requestId}_${requestN}`;
-    const range = partition[requestN - 1];
-    const targets = adjustTargetsFromResponseState(request.targets, mergedResponse);
-
-    const done = (response: DataQueryResponse) => {
-      response.state = LoadingState.Done;
-      subscriber.next(response);
+    const done = () => {
+      subscriber.next({
+        data: stateToFrames(state),
+        state: LoadingState.Done,
+      });
       subscriber.complete();
     };
 
+    const requestId = `${request.requestId}_${requestN}`;
+    const task = tasks[requestN - 1];
+    const targets = adjustTargetsFromResponseState(task.queries, state);
+
     const nextRequest = () => {
-      mergedResponse = mergedResponse || { data: [] };
       if (requestN > 1) {
-        mergedResponse.state = LoadingState.Streaming;
-        subscriber.next(mergedResponse);
+        subscriber.next({
+          data: stateToFrames(state),
+          state: LoadingState.Streaming,
+        });
         runNextRequest(subscriber, requestN - 1);
         return;
       }
-      done(mergedResponse);
+      done();
     };
 
-    if (!targets.length && mergedResponse) {
-      done(mergedResponse);
-      return;
-    }
+    // NOTE: we could in theory skip running requests with zero queries,
+    // but that would complicate the logic, and grafana will skip
+    // such requests anyway.
 
-    subquerySubsciption = datasource.runQuery({ ...request, range, requestId, targets }).subscribe({
+    subquerySubsciption = datasource.runQuery({ ...request, range: task.range, requestId, targets }).subscribe({
       next: (partialResponse) => {
         if (partialResponse.error) {
           subscriber.error(partialResponse.error);
         }
-        mergedResponse = combineResponses(mergedResponse, partialResponse);
+        updateState(state, partialResponse.data);
       },
       complete: () => {
         nextRequest();

--- a/public/app/plugins/datasource/loki/queryUtils.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.ts
@@ -306,10 +306,9 @@ export function getStreamSelectorsFromQuery(query: string): string[] {
 
 export function requestSupportsPartitioning(allQueries: LokiQuery[]) {
   const queries = allQueries.filter((query) => !query.hide);
-  /*
-   * For now, we will not split when more than 1 query is requested.
-   */
-  if (queries.length > 1) {
+  // just a sanity check, otherwise scenarios with a single hidden query
+  // will crash the code.
+  if (queries.length === 0) {
     return false;
   }
 
@@ -317,24 +316,38 @@ export function requestSupportsPartitioning(allQueries: LokiQuery[]) {
     return false;
   }
 
+  // do not chunk metrics queries which have a non-default resolution
+  if (queries.some((q) => (q.resolution ?? 1) !== 1)) {
+    return false;
+  }
+
   return true;
 }
 
-export function combineResponses(currentResult: DataQueryResponse | null, newResult: DataQueryResponse) {
-  if (!currentResult) {
-    return cloneQueryResponse(newResult);
-  }
-
-  newResult.data.forEach((newFrame) => {
-    const currentFrame = currentResult.data.find((frame) => frame.name === newFrame.name);
+export function combineMetricsResponses(currentResult: Map<string, DataFrame[]>, newResult: DataFrame[]): void {
+  newResult.forEach((newFrame) => {
+    const refId = newFrame.refId ?? ''; // FIXME: should we just skip frames without a refId?
+    const currentFrames = currentResult.get(refId) ?? [];
+    currentResult.set(refId, currentFrames); // to set the potentially new empty-array
+    const currentFrame = currentFrames.find((frame) => frame.name === newFrame.name);
     if (!currentFrame) {
-      currentResult.data.push(cloneDataFrame(newFrame));
+      currentFrames.push(newFrame);
       return;
     }
     combineFrames(currentFrame, newFrame);
   });
+}
 
-  return currentResult;
+export function combineLogsResponses(currentResult: Map<string, DataFrame>, newResult: DataFrame[]): void {
+  newResult.forEach((newFrame) => {
+    const refId = newFrame.refId ?? ''; // FIXME: should we just skip frames without a refId?
+    const currentFrame = currentResult.get(refId);
+    if (!currentFrame) {
+      currentResult.set(refId, newFrame);
+      return;
+    }
+    combineFrames(currentFrame, newFrame);
+  });
 }
 
 function combineFrames(dest: DataFrame, source: DataFrame) {


### PR DESCRIPTION
work in progress:
- no unit tests
- function names may be bad

this is only here to discuss the current approach, if we like it or not.

what it does:
you can have multiple queries, both logs and metrics queries (exception: metrics-query-resolution-field must stay at default-value for now), and you can run all of them and it will all be chunked.

how it does it:
- first it calculates an array of "tasks". these are simply time-range, with the queries-to-run next to them
    - we calculate tasks separately for metrics queries and separately for logs queries, because the time-ranges are different
    - then we join the two task-arrays by alternating between the two, like `[logs-chunk, metrics-chunk, logs-chunk, metrics-chunk, ....]`
- then we go through these tasks, and execute them in sequence
- there is a new type named `State`, which is basically the state we keep during the whole execution. it contains the already-merged logs and metrics dataframes, grouped by `refId`.


(NOTE: there may be other approaches, like load the metric&logs chunk at the same time, but this is what i came up with, and maybe it's good enough. (any comments welcome!))