### PR TITLE
Elasticsearch: Detect Elasticsearch version

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/MetricEditor.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/MetricEditor.tsx
@@ -1,9 +1,9 @@
 import { cx } from '@emotion/css';
 import React, { useCallback } from 'react';
-import { satisfies } from 'semver';
+import { satisfies, SemVer } from 'semver';
 
 import { SelectableValue } from '@grafana/data';
-import { InlineSegmentGroup, Segment, SegmentAsync, useTheme2 } from '@grafana/ui';
+import { InlineSegmentGroup, SegmentAsync, useTheme2 } from '@grafana/ui';
 
 import { useFields } from '../../../hooks/useFields';
 import { useDispatch } from '../../../hooks/useStatelessReducer';
@@ -41,15 +41,16 @@ const isBasicAggregation = (metric: MetricAggregation) => !metricAggregationConf
 
 const getTypeOptions = (
   previousMetrics: MetricAggregation[],
-  esVersion: string
+  esVersion: SemVer | null
 ): Array<SelectableValue<MetricAggregationType>> => {
   // we'll include Pipeline Aggregations only if at least one previous metric is a "Basic" one
   const includePipelineAggregations = previousMetrics.some(isBasicAggregation);
 
   return (
     Object.entries(metricAggregationConfig)
-      // Only showing metrics type supported by the configured version of ES
-      .filter(([_, { versionRange = '*' }]) => satisfies(esVersion, versionRange))
+      // Only showing metrics type supported by the version of ES.
+      // if we cannot determine the version, we assume it is suitable.
+      .filter(([_, { versionRange = '*' }]) => (esVersion != null ? satisfies(esVersion, versionRange) : true))
       // Filtering out Pipeline Aggregations if there's no basic metric selected before
       .filter(([_, config]) => includePipelineAggregations || !config.isPipelineAgg)
       .map(([key, { label }]) => ({
@@ -65,6 +66,11 @@ export const MetricEditor = ({ value }: Props) => {
   const query = useQuery();
   const dispatch = useDispatch();
   const getFields = useFields(value.type);
+
+  const getTypeOptionsAsync = async (previousMetrics: MetricAggregation[]) => {
+    const dbVersion = await datasource.getDatabaseVersion();
+    return getTypeOptions(previousMetrics, dbVersion);
+  };
 
   const loadOptions = useCallback(async () => {
     const remoteFields = await getFields();
@@ -85,9 +91,9 @@ export const MetricEditor = ({ value }: Props) => {
   return (
     <>
       <InlineSegmentGroup>
-        <Segment
+        <SegmentAsync
           className={cx(styles.color, segmentStyles)}
-          options={getTypeOptions(previousMetrics, datasource.esVersion)}
+          loadOptions={() => getTypeOptionsAsync(previousMetrics)}
           onChange={(e) => dispatch(changeMetricType({ id: value.id, type: e.value! }))}
           value={toOption(value)}
         />

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/index.test.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/index.test.tsx
@@ -9,6 +9,7 @@ import { QueryEditor } from '.';
 const noop = () => void 0;
 const datasourceMock = {
   esVersion: '7.10.0',
+  getDatabaseVersion: () => Promise.resolve(null),
 } as ElasticDatasource;
 
 describe('QueryEditor', () => {

--- a/public/app/plugins/datasource/elasticsearch/configuration/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/elasticsearch/configuration/ConfigEditor.tsx
@@ -6,7 +6,6 @@ import { Alert, DataSourceHttpSettings, SecureSocksProxySettings } from '@grafan
 import { config } from 'app/core/config';
 
 import { ElasticsearchOptions } from '../types';
-import { isSupportedVersion } from '../utils';
 
 import { DataLinks } from './DataLinks';
 import { ElasticDetails } from './ElasticDetails';
@@ -34,18 +33,11 @@ export const ConfigEditor = (props: Props) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const supportedVersion = isSupportedVersion(options.jsonData.esVersion);
-
   return (
     <>
       {options.access === 'direct' && (
         <Alert title="Error" severity="error">
           Browser access mode in the Elasticsearch datasource is no longer available. Switch to server access mode.
-        </Alert>
-      )}
-      {!supportedVersion && (
-        <Alert title="Deprecation notice" severity="error">
-          {`Support for Elasticsearch versions after their end-of-life (currently versions < 7.10) was removed`}
         </Alert>
       )}
       <DataSourceHttpSettings

--- a/public/app/plugins/datasource/elasticsearch/datasource.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.test.ts
@@ -181,14 +181,14 @@ describe('ElasticDatasource', () => {
   });
 
   describe('When testing datasource with index pattern', () => {
-    it('should translate index pattern to current day', () => {
+    it('should translate index pattern to current day', async () => {
       const { ds, fetchMock } = getTestContext({ jsonData: { interval: 'Daily', esVersion: '7.10.0' } });
 
-      ds.testDatasource();
+      await ds.testDatasource();
 
       const today = toUtc().format('YYYY.MM.DD');
-      expect(fetchMock).toHaveBeenCalledTimes(1);
-      expect(fetchMock.mock.calls[0][0].url).toBe(`${ELASTICSEARCH_MOCK_URL}/test-${today}/_mapping`);
+      const lastCall = fetchMock.mock.calls[fetchMock.mock.calls.length - 1];
+      expect(lastCall[0].url).toBe(`${ELASTICSEARCH_MOCK_URL}/test-${today}/_mapping`);
     });
   });
 

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -1,6 +1,7 @@
 import { cloneDeep, find, first as _first, isNumber, isObject, isString, map as _map } from 'lodash';
 import { generate, lastValueFrom, Observable, of, throwError } from 'rxjs';
 import { catchError, first, map, mergeMap, skipWhile, throwIfEmpty, tap } from 'rxjs/operators';
+import { SemVer } from 'semver';
 
 import {
   DataFrame,
@@ -49,7 +50,7 @@ import { metricAggregationConfig } from './components/QueryEditor/MetricAggregat
 import { defaultBucketAgg, hasMetricOfType } from './queryDef';
 import { trackQuery } from './tracking';
 import { Logs, BucketAggregation, DataLinkConfig, ElasticsearchOptions, ElasticsearchQuery, TermsQuery } from './types';
-import { coerceESVersion, getScriptValue, isSupportedVersion } from './utils';
+import { coerceESVersion, getScriptValue, isSupportedVersion, unsupportedVersionMessage } from './utils';
 
 export const REF_ID_STARTER_LOG_VOLUME = 'log-volume-';
 // Those are metadata fields as defined in https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-fields.html#_identity_metadata_fields.
@@ -92,6 +93,7 @@ export class ElasticDatasource
   includeFrozen: boolean;
   isProxyAccess: boolean;
   timeSrv: TimeSrv;
+  databaseVersion: SemVer | null;
 
   constructor(
     instanceSettings: DataSourceInstanceSettings<ElasticsearchOptions>,
@@ -119,6 +121,7 @@ export class ElasticDatasource
     this.logLevelField = settingsData.logLevelField || '';
     this.dataLinks = settingsData.dataLinks || [];
     this.includeFrozen = settingsData.includeFrozen ?? false;
+    this.databaseVersion = null;
     this.annotations = {
       QueryEditor: ElasticsearchAnnotationsQueryEditor,
     };
@@ -143,13 +146,6 @@ export class ElasticDatasource
     if (!this.isProxyAccess) {
       const error = new Error(
         'Browser access mode in the Elasticsearch datasource is no longer available. Switch to server access mode.'
-      );
-      return throwError(() => error);
-    }
-
-    if (!isSupportedVersion(this.esVersion)) {
-      const error = new Error(
-        'Support for Elasticsearch versions after their end-of-life (currently versions < 7.10) was removed.'
       );
       return throwError(() => error);
     }
@@ -395,16 +391,24 @@ export class ElasticDatasource
     return queries.map((q) => this.applyTemplateVariables(q, scopedVars));
   }
 
-  testDatasource() {
+  async testDatasource() {
+    // we explicitly ask for uncached, "fresh" data here
+    const dbVersion = await this.getDatabaseVersion(false);
+    // if we are not able to determine the elastic-version, we assume it is a good version.
+    const isSupported = dbVersion != null ? isSupportedVersion(dbVersion) : true;
+    const versionMessage = isSupported ? '' : `WARNING: ${unsupportedVersionMessage} `;
     // validate that the index exist and has date field
     return lastValueFrom(
       this.getFields(['date']).pipe(
         mergeMap((dateFields) => {
           const timeField: any = find(dateFields, { text: this.timeField });
           if (!timeField) {
-            return of({ status: 'error', message: 'No date field named ' + this.timeField + ' found' });
+            return of({
+              status: 'error',
+              message: 'No date field named ' + this.timeField + ' found',
+            });
           }
-          return of({ status: 'success', message: 'Index OK. Time field name OK.' });
+          return of({ status: 'success', message: `${versionMessage}Index OK. Time field name OK` });
         }),
         catchError((err) => {
           console.error(err);
@@ -1035,6 +1039,41 @@ export class ElasticDatasource
 
     const finalQuery = JSON.parse(this.templateSrv.replace(JSON.stringify(expandedQuery), scopedVars));
     return finalQuery;
+  }
+
+  private getDatabaseVersionUncached(): Promise<SemVer | null> {
+    // we want this function to never fail
+    return lastValueFrom(this.request('GET', '/')).then(
+      (data) => {
+        const versionNumber = data?.version?.number;
+        if (typeof versionNumber !== 'string') {
+          return null;
+        }
+        try {
+          return new SemVer(versionNumber);
+        } catch (error) {
+          console.error(error);
+          return null;
+        }
+      },
+      (error) => {
+        console.error(error);
+        return null;
+      }
+    );
+  }
+
+  async getDatabaseVersion(useCachedData = true): Promise<SemVer | null> {
+    if (useCachedData) {
+      const cached = this.databaseVersion;
+      if (cached != null) {
+        return cached;
+      }
+    }
+
+    const freshDatabaseVersion = await this.getDatabaseVersionUncached();
+    this.databaseVersion = freshDatabaseVersion;
+    return freshDatabaseVersion;
   }
 }
 

--- a/public/app/plugins/datasource/elasticsearch/utils.ts
+++ b/public/app/plugins/datasource/elasticsearch/utils.ts
@@ -1,4 +1,4 @@
-import { valid, gte } from 'semver';
+import { valid, gte, SemVer } from 'semver';
 
 import { isMetricAggregationWithField } from './components/QueryEditor/MetricAggregationsEditor/aggregations';
 import { metricAggregationConfig } from './components/QueryEditor/MetricAggregationsEditor/utils';
@@ -117,10 +117,13 @@ export const coerceESVersion = (version: string | number | undefined): string =>
   }
 };
 
-export const isSupportedVersion = (version: string): boolean => {
+export const isSupportedVersion = (version: SemVer): boolean => {
   if (gte(version, '7.10.0')) {
     return true;
   }
 
   return false;
 };
+
+export const unsupportedVersionMessage =
+  'Support for Elasticsearch versions after their end-of-life (currently versions < 7.10) was removed. Using unsupported version of Elasticsearch may lead to unexpected and incorrect results.';


### PR DESCRIPTION
in elasticsearch datasource config, the user has to specify the elasticsearch-database-version.
the only reason for this is that, when we show the list of metrics, we can only show the metric `moving_avg`, when the user is using elastic7.x.y.
(this metric was removed in elastic8).

this PR adjusts the code to detect the elasticsearch-database-version.

NOTE: one change is, that now we need to handle the case where we are not able to get the database-version. in that case currently we assume all checks are good (best would be to assume an "infinitely large" es-version in that case, but i cannot express that with `semver` 😄 )

how to test:
1. `make devenv sources=elastic elastic_version=7.9.1`
2. go to the datasource's config page, press [save&test].
3. you should get a green info-box, informing you that your elastic version is too old.
4. go to explore-page, choose the elasticsearch datasource, you should see a red message-box saying your elastic version is too old. but you should still be able to use the query-builder
5. on the same explore-page, set the `metric` to `count`, add one more metric, look at the list of options offered for this second metric, it should offer `moving average`
6. go to dashboard-page, make a panel with elastic, again, in the query-builder, you should see the red message-box, but the query builder itself, and the panel should work without producing any errors.
7. `make devenv sources=elastic elastic_version=7.10.0`
8. go to the datasource's config page, press [save&test].
9. you should get a green info-box, with no elastic-too-old message
10. go to explore-page, choose the elasticsearch datasource, you should not see the elastic-too-old message, things should work.
11. on the same explore-page, set the `metric` to `count`, add one more metric, look at the list of options offered for this second metric, it should offer `moving average`
12. go to dashboard-page, make a panel with elastic, again, in the query-builder, you should not see the red message-box, all should work.
13. `make devenv sources=elastic elastic_version=8.6.2`
14. go to the datasource's config page, press [save&test].
15. you should get a green info-box, with no elastic-too-old message
16. go to explore-page, choose the elasticsearch datasource, you should not see the elastic-too-old message, things should work.
17. on the same explore-page, set the `metric` to `count`, add one more metric, look at the list of options offered for this second metric, it should NOT offer `moving average`
18. go to dashboard-page, make a panel with elastic, again, in the query-builder, you should not see the red message-box, all should work.
