### PR TITLE
Alerting: Fix confusing comment about screenshots in default.ini and docs

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -956,7 +956,8 @@ max_attempts = 3
 min_interval = 10s
 
 [unified_alerting.screenshots]
-# Enable screenshots in notifications. This option requires the Grafana Image Renderer plugin.
+# Enable screenshots in notifications. You must have either installed the Grafana image rendering
+# plugin, or set up Grafana to use a remote rendering service.
 # For more information on configuration options, refer to [rendering].
 capture = false
 

--- a/docs/sources/alerting/images-in-notifications.md
+++ b/docs/sources/alerting/images-in-notifications.md
@@ -36,7 +36,8 @@ To use images in notifications, Grafana must be set up to use [image rendering](
 
 If Grafana has been set up to use [image rendering]({{< relref "../setup-grafana/image-rendering/" >}}) images in notifications can be turned on via the `capture` option in `[unified_alerting.screenshots]`:
 
-    # Enable screenshots in notifications. This option requires the Grafana Image Renderer plugin.
+    # Enable screenshots in notifications. You must have either installed the Grafana image rendering
+    # plugin, or set up Grafana to use a remote rendering service.
     # For more information on configuration options, refer to [rendering].
     capture = true
 

--- a/docs/sources/alerting/manage-notifications/images-in-notifications.md
+++ b/docs/sources/alerting/manage-notifications/images-in-notifications.md
@@ -45,7 +45,8 @@ When using Grafana as its own cloud storage service screenshots are copied from 
 
 Having installed either the image rendering plugin, or set up Grafana to use a remote rendering service, set `capture` in `[unified_alerting.screenshots]` to `true`:
 
-    # Enable screenshots in notifications. This option requires the Grafana Image Renderer plugin.
+    # Enable screenshots in notifications. You must have either installed the Grafana image rendering
+    # plugin, or set up Grafana to use a remote rendering service.
     # For more information on configuration options, refer to [rendering].
     capture = false
 


### PR DESCRIPTION
This pull request fixes some confusing language in `default.ini` and the docs around enabling images in notifications. It should now be consistent with the rest of the documentation.