### PR TITLE
Loki Range Splitting: Create a new instance for the initial frame

### DIFF
--- a/public/app/plugins/datasource/loki/mocks.ts
+++ b/public/app/plugins/datasource/loki/mocks.ts
@@ -108,157 +108,167 @@ export function createMetadataRequest(
   };
 }
 
-export const logFrameA: DataFrame = {
-  refId: 'A',
-  fields: [
-    {
-      name: 'Time',
-      type: FieldType.time,
-      config: {},
-      values: new ArrayVector([3, 4]),
-    },
-    {
-      name: 'Line',
-      type: FieldType.string,
-      config: {},
-      values: new ArrayVector(['line1', 'line2']),
-    },
-    {
-      name: 'labels',
-      type: FieldType.other,
-      config: {},
-      values: new ArrayVector([
-        {
-          label: 'value',
-        },
-        {
-          otherLabel: 'other value',
-        },
-      ]),
-    },
-    {
-      name: 'tsNs',
-      type: FieldType.string,
-      config: {},
-      values: new ArrayVector(['3000000', '4000000']),
-    },
-    {
-      name: 'id',
-      type: FieldType.string,
-      config: {},
-      values: new ArrayVector(['id1', 'id2']),
-    },
-  ],
-  length: 2,
-};
+export function getMockFrames() {
+  const logFrameA: DataFrame = {
+    refId: 'A',
+    fields: [
+      {
+        name: 'Time',
+        type: FieldType.time,
+        config: {},
+        values: new ArrayVector([3, 4]),
+      },
+      {
+        name: 'Line',
+        type: FieldType.string,
+        config: {},
+        values: new ArrayVector(['line1', 'line2']),
+      },
+      {
+        name: 'labels',
+        type: FieldType.other,
+        config: {},
+        values: new ArrayVector([
+          {
+            label: 'value',
+          },
+          {
+            otherLabel: 'other value',
+          },
+        ]),
+      },
+      {
+        name: 'tsNs',
+        type: FieldType.string,
+        config: {},
+        values: new ArrayVector(['3000000', '4000000']),
+      },
+      {
+        name: 'id',
+        type: FieldType.string,
+        config: {},
+        values: new ArrayVector(['id1', 'id2']),
+      },
+    ],
+    length: 2,
+  };
 
-export const logFrameB: DataFrame = {
-  refId: 'A',
-  fields: [
-    {
-      name: 'Time',
-      type: FieldType.time,
-      config: {},
-      values: new ArrayVector([1, 2]),
+  const logFrameB: DataFrame = {
+    refId: 'A',
+    fields: [
+      {
+        name: 'Time',
+        type: FieldType.time,
+        config: {},
+        values: new ArrayVector([1, 2]),
+      },
+      {
+        name: 'Line',
+        type: FieldType.string,
+        config: {},
+        values: new ArrayVector(['line3', 'line4']),
+      },
+      {
+        name: 'labels',
+        type: FieldType.other,
+        config: {},
+        values: new ArrayVector([
+          {
+            otherLabel: 'other value',
+          },
+        ]),
+      },
+      {
+        name: 'tsNs',
+        type: FieldType.string,
+        config: {},
+        values: new ArrayVector(['1000000', '2000000']),
+      },
+      {
+        name: 'id',
+        type: FieldType.string,
+        config: {},
+        values: new ArrayVector(['id3', 'id4']),
+      },
+    ],
+    meta: {
+      stats: [{ displayName: 'Ingester: total reached', value: 1 }],
     },
-    {
-      name: 'Line',
-      type: FieldType.string,
-      config: {},
-      values: new ArrayVector(['line3', 'line4']),
-    },
-    {
-      name: 'labels',
-      type: FieldType.other,
-      config: {},
-      values: new ArrayVector([
-        {
-          otherLabel: 'other value',
-        },
-      ]),
-    },
-    {
-      name: 'tsNs',
-      type: FieldType.string,
-      config: {},
-      values: new ArrayVector(['1000000', '2000000']),
-    },
-    {
-      name: 'id',
-      type: FieldType.string,
-      config: {},
-      values: new ArrayVector(['id3', 'id4']),
-    },
-  ],
-  meta: {
-    stats: [{ displayName: 'Ingester: total reached', value: 1 }],
-  },
-  length: 2,
-};
+    length: 2,
+  };
 
-export const metricFrameA: DataFrame = {
-  refId: 'A',
-  fields: [
-    {
-      name: 'Time',
-      type: FieldType.time,
-      config: {},
-      values: new ArrayVector([3000000, 4000000]),
+  const metricFrameA: DataFrame = {
+    refId: 'A',
+    fields: [
+      {
+        name: 'Time',
+        type: FieldType.time,
+        config: {},
+        values: new ArrayVector([3000000, 4000000]),
+      },
+      {
+        name: 'Value',
+        type: FieldType.number,
+        config: {},
+        values: new ArrayVector([5, 4]),
+      },
+    ],
+    meta: {
+      stats: [{ displayName: 'Ingester: total reached', value: 1 }],
     },
-    {
-      name: 'Value',
-      type: FieldType.number,
-      config: {},
-      values: new ArrayVector([5, 4]),
-    },
-  ],
-  meta: {
-    stats: [{ displayName: 'Ingester: total reached', value: 1 }],
-  },
-  length: 2,
-};
+    length: 2,
+  };
 
-export const metricFrameB: DataFrame = {
-  refId: 'A',
-  fields: [
-    {
-      name: 'Time',
-      type: FieldType.time,
-      config: {},
-      values: new ArrayVector([1000000, 2000000]),
+  const metricFrameB: DataFrame = {
+    refId: 'A',
+    fields: [
+      {
+        name: 'Time',
+        type: FieldType.time,
+        config: {},
+        values: new ArrayVector([1000000, 2000000]),
+      },
+      {
+        name: 'Value',
+        type: FieldType.number,
+        config: {},
+        values: new ArrayVector([6, 7]),
+      },
+    ],
+    meta: {
+      stats: [{ displayName: 'Ingester: total reached', value: 2 }],
     },
-    {
-      name: 'Value',
-      type: FieldType.number,
-      config: {},
-      values: new ArrayVector([6, 7]),
-    },
-  ],
-  meta: {
-    stats: [{ displayName: 'Ingester: total reached', value: 2 }],
-  },
-  length: 2,
-};
+    length: 2,
+  };
 
-export const metricFrameC: DataFrame = {
-  refId: 'A',
-  name: 'some-time-series',
-  fields: [
-    {
-      name: 'Time',
-      type: FieldType.time,
-      config: {},
-      values: new ArrayVector([3000000, 4000000]),
+  const metricFrameC: DataFrame = {
+    refId: 'A',
+    name: 'some-time-series',
+    fields: [
+      {
+        name: 'Time',
+        type: FieldType.time,
+        config: {},
+        values: new ArrayVector([3000000, 4000000]),
+      },
+      {
+        name: 'Value',
+        type: FieldType.number,
+        config: {},
+        values: new ArrayVector([6, 7]),
+      },
+    ],
+    meta: {
+      stats: [{ displayName: 'Ingester: total reached', value: 2 }],
     },
-    {
-      name: 'Value',
-      type: FieldType.number,
-      config: {},
-      values: new ArrayVector([6, 7]),
-    },
-  ],
-  meta: {
-    stats: [{ displayName: 'Ingester: total reached', value: 2 }],
-  },
-  length: 2,
-};
+    length: 2,
+  };
+
+  return {
+    logFrameA,
+    logFrameB,
+    metricFrameA,
+    metricFrameB,
+    metricFrameC,
+  };
+}

--- a/public/app/plugins/datasource/loki/mocks.ts
+++ b/public/app/plugins/datasource/loki/mocks.ts
@@ -239,3 +239,26 @@ export const metricFrameB: DataFrame = {
   },
   length: 2,
 };
+
+export const metricFrameC: DataFrame = {
+  refId: 'A',
+  name: 'some-time-series',
+  fields: [
+    {
+      name: 'Time',
+      type: FieldType.time,
+      config: {},
+      values: new ArrayVector([3000000, 4000000]),
+    },
+    {
+      name: 'Value',
+      type: FieldType.number,
+      config: {},
+      values: new ArrayVector([6, 7]),
+    },
+  ],
+  meta: {
+    stats: [{ displayName: 'Ingester: total reached', value: 2 }],
+  },
+  length: 2,
+};

--- a/public/app/plugins/datasource/loki/querySplitting.test.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.test.ts
@@ -6,7 +6,7 @@ import { dateTime } from '@grafana/data';
 import { LokiDatasource } from './datasource';
 import * as logsTimeSplit from './logsTimeSplit';
 import * as metricTimeSplit from './metricTimeSplit';
-import { createLokiDatasource, logFrameA } from './mocks';
+import { createLokiDatasource, getMockFrames } from './mocks';
 import { runPartitionedQuery } from './querySplitting';
 import { LokiQuery } from './types';
 
@@ -65,6 +65,7 @@ describe('runPartitionedQuery()', () => {
       targets: [{ expr: '{a="b"}', refId: 'A', maxLines: 4 }],
       range,
     });
+    const { logFrameA } = getMockFrames();
     beforeEach(() => {
       jest.spyOn(datasource, 'runQuery').mockReturnValue(of({ data: [logFrameA], refId: 'A' }));
     });

--- a/public/app/plugins/datasource/loki/querySplitting.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.ts
@@ -100,7 +100,7 @@ export function runPartitionedQuery(datasource: LokiDatasource, request: DataQue
   const totalRequests = partition.length;
 
   let shouldStop = false;
-  let smallQuerySubsciption: Subscription | null = null;
+  let subquerySubsciption: Subscription | null = null;
   const runNextRequest = (subscriber: Subscriber<DataQueryResponse>, requestN: number) => {
     if (shouldStop) {
       return;
@@ -121,7 +121,7 @@ export function runPartitionedQuery(datasource: LokiDatasource, request: DataQue
       return;
     }
 
-    smallQuerySubsciption = datasource
+    subquerySubsciption = datasource
       .runQuery({ ...request, range, requestId, targets })
       .pipe(
         // in case of an empty query, this is somehow run twice. `share()` is no workaround here as the observable is generated from `of()`.
@@ -150,8 +150,8 @@ export function runPartitionedQuery(datasource: LokiDatasource, request: DataQue
     runNextRequest(subscriber, totalRequests);
     return () => {
       shouldStop = true;
-      if (smallQuerySubsciption != null) {
-        smallQuerySubsciption.unsubscribe();
+      if (subquerySubsciption != null) {
+        subquerySubsciption.unsubscribe();
       }
     };
   });

--- a/public/app/plugins/datasource/loki/queryUtils.test.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.test.ts
@@ -1,6 +1,6 @@
 import { ArrayVector, DataQueryResponse } from '@grafana/data';
 
-import { logFrameA, logFrameB, metricFrameA, metricFrameB, metricFrameC } from './mocks';
+import { getMockFrames } from './mocks';
 import {
   getHighlighterExpressionsFromQuery,
   getNormalizedLokiQuery,
@@ -299,6 +299,7 @@ describe('getParserFromQuery', () => {
 });
 
 describe('cloneQueryResponse', () => {
+  const { logFrameA } = getMockFrames();
   const responseA: DataQueryResponse = {
     data: [logFrameA],
   };
@@ -311,6 +312,7 @@ describe('cloneQueryResponse', () => {
 
 describe('combineResponses', () => {
   it('combines logs frames', () => {
+    const { logFrameA, logFrameB } = getMockFrames();
     const responseA: DataQueryResponse = {
       data: [logFrameA],
     };
@@ -378,12 +380,13 @@ describe('combineResponses', () => {
   });
 
   it('combines metric frames', () => {
-    const responseA: DataQueryResponse = cloneQueryResponse({
+    const { metricFrameA, metricFrameB } = getMockFrames();
+    const responseA: DataQueryResponse = {
       data: [metricFrameA],
-    });
-    const responseB: DataQueryResponse = cloneQueryResponse({
+    };
+    const responseB: DataQueryResponse = {
       data: [metricFrameB],
-    });
+    };
     expect(combineResponses(responseA, responseB)).toEqual({
       data: [
         {
@@ -417,12 +420,13 @@ describe('combineResponses', () => {
   });
 
   it('combines and identifies new frames in the response', () => {
-    const responseA: DataQueryResponse = cloneQueryResponse({
+    const { metricFrameA, metricFrameB, metricFrameC } = getMockFrames();
+    const responseA: DataQueryResponse = {
       data: [metricFrameA],
-    });
-    const responseB: DataQueryResponse = cloneQueryResponse({
+    };
+    const responseB: DataQueryResponse = {
       data: [metricFrameB, metricFrameC],
-    });
+    };
     expect(combineResponses(responseA, responseB)).toEqual({
       data: [
         {
@@ -457,6 +461,7 @@ describe('combineResponses', () => {
   });
 
   it('combines frames in a new response instance', () => {
+    const { metricFrameA, metricFrameB } = getMockFrames();
     const responseA: DataQueryResponse = {
       data: [metricFrameA],
     };

--- a/public/app/plugins/datasource/loki/queryUtils.test.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.test.ts
@@ -12,7 +12,7 @@ import {
   getParserFromQuery,
   obfuscate,
   combineResponses,
-  createQueryResponse,
+  cloneQueryResponse,
 } from './queryUtils';
 import { LokiQuery, LokiQueryType } from './types';
 
@@ -298,6 +298,17 @@ describe('getParserFromQuery', () => {
   });
 });
 
+describe('cloneQueryResponse', () => {
+  const responseA: DataQueryResponse = {
+    data: [logFrameA],
+  };
+  it('clones query responses', () => {
+    const clonedA = cloneQueryResponse(responseA);
+    expect(clonedA).not.toBe(responseA);
+    expect(clonedA).toEqual(clonedA);
+  });
+});
+
 describe('combineResponses', () => {
   it('combines logs frames', () => {
     const responseA: DataQueryResponse = {
@@ -367,10 +378,10 @@ describe('combineResponses', () => {
   });
 
   it('combines metric frames', () => {
-    const responseA: DataQueryResponse = createQueryResponse({
+    const responseA: DataQueryResponse = cloneQueryResponse({
       data: [metricFrameA],
     });
-    const responseB: DataQueryResponse = createQueryResponse({
+    const responseB: DataQueryResponse = cloneQueryResponse({
       data: [metricFrameB],
     });
     expect(combineResponses(responseA, responseB)).toEqual({
@@ -406,10 +417,10 @@ describe('combineResponses', () => {
   });
 
   it('combines and identifies new frames in the response', () => {
-    const responseA: DataQueryResponse = createQueryResponse({
+    const responseA: DataQueryResponse = cloneQueryResponse({
       data: [metricFrameA],
     });
-    const responseB: DataQueryResponse = createQueryResponse({
+    const responseB: DataQueryResponse = cloneQueryResponse({
       data: [metricFrameB, metricFrameC],
     });
     expect(combineResponses(responseA, responseB)).toEqual({

--- a/public/app/plugins/datasource/loki/queryUtils.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.ts
@@ -315,7 +315,7 @@ export function requestSupportsPartitioning(allQueries: LokiQuery[]) {
 
 export function combineResponses(currentResult: DataQueryResponse | null, newResult: DataQueryResponse) {
   if (!currentResult) {
-    return createQueryResponse(newResult);
+    return cloneQueryResponse(newResult);
   }
 
   newResult.data.forEach((newFrame) => {
@@ -365,7 +365,7 @@ function combineMetadata(dest: DataQueryResponseData = {}, source: DataQueryResp
 /**
  * Deep clones a DataQueryResponse
  */
-export function createQueryResponse(response: DataQueryResponse): DataQueryResponse {
+export function cloneQueryResponse(response: DataQueryResponse): DataQueryResponse {
   const newResponse = cloneDeep(response);
   newResponse.data.forEach((data: DataQueryResponseData) => {
     data.fields.forEach((field: Field<unknown, ArrayVector>) => {

--- a/public/app/plugins/datasource/loki/queryUtils.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.ts
@@ -321,7 +321,7 @@ export function combineResponses(currentResult: DataQueryResponse | null, newRes
   newResult.data.forEach((newFrame) => {
     const currentFrame = currentResult.data.find((frame) => frame.name === newFrame.name);
     if (!currentFrame) {
-      currentResult.data.push({ ...newFrame });
+      currentResult.data.push(cloneDataFrame(newFrame));
       return;
     }
     combineFrames(currentFrame, newFrame);
@@ -368,13 +368,17 @@ function combineMetadata(dest: DataQueryResponseData = {}, source: DataQueryResp
 export function cloneQueryResponse(response: DataQueryResponse): DataQueryResponse {
   const newResponse = {
     ...response,
-    data: response.data.map((frame) => ({ ...frame })),
+    data: response.data.map(cloneDataFrame),
   };
-
-  newResponse.data.forEach((data: DataQueryResponseData) => {
-    data.fields.forEach((field: Field<unknown, ArrayVector>) => {
-      field.values = new ArrayVector(field.values.buffer);
-    });
-  });
   return newResponse;
+}
+
+function cloneDataFrame(frame: DataQueryResponseData): DataQueryResponseData {
+  return {
+    ...frame,
+    fields: frame.fields.map((field: Field<unknown, ArrayVector>) => ({
+      ...field,
+      values: new ArrayVector(field.values.buffer),
+    })),
+  };
 }

--- a/public/app/plugins/datasource/loki/queryUtils.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.ts
@@ -1,7 +1,7 @@
 import { SyntaxNode } from '@lezer/common';
-import { escapeRegExp } from 'lodash';
+import { cloneDeep, escapeRegExp } from 'lodash';
 
-import { DataQueryResponse, DataQueryResponseData, QueryResultMetaStat } from '@grafana/data';
+import { ArrayVector, DataQueryResponse, DataQueryResponseData, Field, QueryResultMetaStat } from '@grafana/data';
 import {
   parser,
   LineFilter,
@@ -315,7 +315,7 @@ export function requestSupportsPartitioning(allQueries: LokiQuery[]) {
 
 export function combineResponses(currentResult: DataQueryResponse | null, newResult: DataQueryResponse) {
   if (!currentResult) {
-    return newResult;
+    return createQueryResponse(newResult);
   }
 
   newResult.data.forEach((newFrame) => {
@@ -333,7 +333,9 @@ export function combineResponses(currentResult: DataQueryResponse | null, newRes
 function combineFrames(dest: DataQueryResponseData, source: DataQueryResponseData) {
   const totalFields = dest.fields.length;
   for (let i = 0; i < totalFields; i++) {
-    dest.fields[i].values.buffer = [].concat.apply(source.fields[i].values.buffer, dest.fields[i].values.buffer);
+    dest.fields[i].values = new ArrayVector(
+      [].concat.apply(source.fields[i].values.toArray(), dest.fields[i].values.toArray())
+    );
   }
   dest.length += source.length;
   combineMetadata(dest, source);
@@ -358,4 +360,17 @@ function combineMetadata(dest: DataQueryResponseData = {}, source: DataQueryResp
       destStat.value += sourceStat.value;
     }
   });
+}
+
+/**
+ * Deep clones a DataQueryResponse
+ */
+export function createQueryResponse(response: DataQueryResponse): DataQueryResponse {
+  const newResponse = cloneDeep(response);
+  newResponse.data.forEach((data: DataQueryResponseData) => {
+    data.fields.forEach((field: Field<unknown, ArrayVector>) => {
+      field.values = new ArrayVector(field.values.buffer);
+    });
+  });
+  return newResponse;
 }

--- a/public/app/plugins/datasource/loki/queryUtils.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.ts
@@ -1,5 +1,5 @@
 import { SyntaxNode } from '@lezer/common';
-import { cloneDeep, escapeRegExp } from 'lodash';
+import { escapeRegExp } from 'lodash';
 
 import { ArrayVector, DataQueryResponse, DataQueryResponseData, Field, QueryResultMetaStat } from '@grafana/data';
 import {
@@ -321,7 +321,7 @@ export function combineResponses(currentResult: DataQueryResponse | null, newRes
   newResult.data.forEach((newFrame) => {
     const currentFrame = currentResult.data.find((frame) => frame.name === newFrame.name);
     if (!currentFrame) {
-      currentResult.data.push(newFrame);
+      currentResult.data.push({ ...newFrame });
       return;
     }
     combineFrames(currentFrame, newFrame);
@@ -366,7 +366,11 @@ function combineMetadata(dest: DataQueryResponseData = {}, source: DataQueryResp
  * Deep clones a DataQueryResponse
  */
 export function cloneQueryResponse(response: DataQueryResponse): DataQueryResponse {
-  const newResponse = cloneDeep(response);
+  const newResponse = {
+    ...response,
+    data: response.data.map((frame) => ({ ...frame })),
+  };
+
   newResponse.data.forEach((data: DataQueryResponseData) => {
     data.fields.forEach((field: Field<unknown, ArrayVector>) => {
       field.values = new ArrayVector(field.values.buffer);


### PR DESCRIPTION
Following up @gabor 's comment about avoiding mutation, this PR changes the implementation to create a new instance for the initial frame. This new instance is created when `combineResponses()` is called with `null` and the first received response: `combineResponses(null, newResponse);`. The clonning is done with `deepClone` + new `ArrayVector` instances of the values.

Other minor changes:
- Create a new ArrayVector when combining fields.
- Rename variable.
- Added a new test for when we receive a response with more data for a new time series.

Note: I did not use `structuredClone` because it wasn't supported by my node version used by jest, but will gladly use it if we have support in CI and production.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana/issues/61768

**Special notes for your reviewer**:

The feature should continue working as before. The reference inequality is being asserted by test cases.