### PR TITLE
Range splitting: Read errors from the received response and report them

### DIFF
--- a/public/app/plugins/datasource/loki/querySplitting.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.ts
@@ -1,4 +1,4 @@
-import { Subscriber, map, Observable, Subscription } from 'rxjs';
+import { Subscriber, Observable, Subscription } from 'rxjs';
 
 import { DataQueryRequest, DataQueryResponse, dateTime, TimeRange } from '@grafana/data';
 import { LoadingState } from '@grafana/schema';

--- a/public/app/plugins/datasource/loki/querySplitting.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.ts
@@ -139,7 +139,6 @@ export function runPartitionedQuery(datasource: LokiDatasource, request: DataQue
           partialResponse = { data: [] };
         }
         mergedResponse = combineResponses(mergedResponse, partialResponse);
-        subscriber.next(mergedResponse);
       },
       complete: () => {
         nextRequest();

--- a/public/app/plugins/datasource/loki/querySplitting.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.ts
@@ -137,7 +137,6 @@ export function runPartitionedQuery(datasource: LokiDatasource, request: DataQue
       next: (partialResponse) => {
         if (partialResponse.error) {
           subscriber.error(partialResponse.error);
-          partialResponse = { data: [] };
         }
         mergedResponse = combineResponses(mergedResponse, partialResponse);
       },
@@ -146,7 +145,6 @@ export function runPartitionedQuery(datasource: LokiDatasource, request: DataQue
       },
       error: (error) => {
         subscriber.error(error);
-        nextRequest();
       },
     });
   };

--- a/public/app/plugins/datasource/loki/querySplitting.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.ts
@@ -126,6 +126,10 @@ export function runPartitionedQuery(datasource: LokiDatasource, request: DataQue
       .pipe(
         // in case of an empty query, this is somehow run twice. `share()` is no workaround here as the observable is generated from `of()`.
         map((partialResponse) => {
+          if (partialResponse.error) {
+            subscriber.error(partialResponse.error);
+            return mergedResponse || { data: [] };
+          }
           mergedResponse = combineResponses(mergedResponse, partialResponse);
           return mergedResponse;
         })

--- a/public/app/plugins/datasource/loki/querySplitting.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.ts
@@ -103,6 +103,7 @@ export function runPartitionedQuery(datasource: LokiDatasource, request: DataQue
   let smallQuerySubsciption: Subscription | null = null;
   const runNextRequest = (subscriber: Subscriber<DataQueryResponse>, requestN: number) => {
     if (shouldStop) {
+      subscriber.complete();
       return;
     }
 


### PR DESCRIPTION
When splitting, the received response can have an `error` attribute. Before, we were kind of ignoring it, so errors were invisible to the users. Their perception was a silent failure and a missing chunk of data.

Now, we identify these errors and we report them to the upper layers.


**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana/issues/61768

**Special notes for your reviewer**:

Before:
<img width="1432" alt="before" src="https://user-images.githubusercontent.com/1069378/219043160-251c3926-6364-4958-b2ae-00981a36902d.png">

After:
<img width="1456" alt="after" src="https://user-images.githubusercontent.com/1069378/219039460-68bd53cc-37c0-44d6-bae8-4d2e8ec0e44f.png">