### PR TITLE
Prometheus: reduce memory allocations in readLabelsOrExemplars.

### DIFF
--- a/pkg/util/converter/prom.go
+++ b/pkg/util/converter/prom.go
@@ -260,8 +260,7 @@ func readLabelsOrExemplars(iter *jsoniter.Iterator) (*data.Frame, [][2]string) {
 					switch l2Field {
 					// nolint:goconst
 					case "value":
-						v, _ := strconv.ParseFloat(iter.ReadString(), 64)
-						valueField.Append(v)
+						valueField.Append(iter.ReadFloat64())
 
 					case "timestamp":
 						ts := timeFromFloat(iter.ReadFloat64())


### PR DESCRIPTION
**What is this feature?**
Improve performance of readLabelsOrExemplars by reducing memory allocations.

**Why do we need this feature?**

Parsing float values with `iter.ReadFloat64()` shows a -99% delta in the `BenchmarkExemplarJson` benchmark:

```
$ benchstat before.txt after.txt
name            old time/op    new time/op    delta
ExemplarJson-8    4.16ms ± 1%    0.03ms ± 0%  -99.32%  (p=0.008 n=5+5)

name            old alloc/op   new alloc/op   delta
ExemplarJson-8    3.58MB ± 0%    0.02MB ± 0%  -99.33%  (p=0.008 n=5+5)

name            old allocs/op  new allocs/op  delta
ExemplarJson-8     69.1k ± 0%      0.4k ± 0%  -99.44%  (p=0.008 n=5+5)
```

The benchmark I ran is `BenchmarkExemplarJson` with:

```
go test -count=5 -run=^$ -bench ^BenchmarkExemplarJson$ ./pkg/tsdb/prometheus/querydata
```


**Who is this feature for?**

All users.

**Which issue(s) does this PR fix?**:

n.a.

**Special notes for your reviewer**:

n.a.