### PR TITLE
Loki: query splitting: better error handling

### DIFF
--- a/public/app/plugins/datasource/loki/queryUtils.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.ts
@@ -313,11 +313,7 @@ export function requestSupportsPartitioning(allQueries: LokiQuery[]) {
   return true;
 }
 
-export function combineResponses(currentResult: DataQueryResponse | null, newResult: DataQueryResponse) {
-  if (!currentResult) {
-    return newResult;
-  }
-
+export function combineResponses(currentResult: DataQueryResponse, newResult: DataQueryResponse) {
   newResult.data.forEach((newFrame) => {
     const currentFrame = currentResult.data.find((frame) => frame.name === newFrame.name);
     if (!currentFrame) {


### PR DESCRIPTION
NOTE: let's handle https://github.com/grafana/grafana/pull/63368 first.

this PR improves the subscription-logic in a couple ways to improve the error-handling. the change is not large, but because parts had to be re-ordered and moved, it looks larger, sorry. we do two things mainly:
1. we do the "start next step" in `complete()` instead of `next()`. `next()` might get called multiple times in some strange situations, so we would start too many `runNextRequest`
2. there are two ways we receive errors:
    - the `error` callback is called. this was handled already
    - the `DataQueryResponse.error` field is set. this PR adds code to handle this situation. we do the same to the "upstream" subscription, we set it's `.error`.

how to test:
to test the [2] scenario:
1. add this line of code to `loki.go` at line `175`: `queryRes.Error = fmt.Errorf("hi, i'm a very serious error")` . this will set the error-field for every response.
2. `make devenv sources=loki`
3. run a loki query that should trigger multiple ajax-request-chunks
4. verify that the error message is displayed and no further ajax-requests happen
