### PR TITLE
loki: query splitting: stricter types

### DIFF
--- a/public/app/plugins/datasource/loki/queryUtils.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.ts
@@ -1,7 +1,14 @@
 import { SyntaxNode } from '@lezer/common';
 import { escapeRegExp } from 'lodash';
 
-import { ArrayVector, DataQueryResponse, DataQueryResponseData, Field, QueryResultMetaStat } from '@grafana/data';
+import {
+  ArrayVector,
+  DataFrame,
+  DataQueryResponse,
+  DataQueryResponseData,
+  Field,
+  QueryResultMetaStat,
+} from '@grafana/data';
 import {
   parser,
   LineFilter,
@@ -330,7 +337,7 @@ export function combineResponses(currentResult: DataQueryResponse | null, newRes
   return currentResult;
 }
 
-function combineFrames(dest: DataQueryResponseData, source: DataQueryResponseData) {
+function combineFrames(dest: DataFrame, source: DataFrame) {
   const totalFields = dest.fields.length;
   for (let i = 0; i < totalFields; i++) {
     dest.fields[i].values = new ArrayVector(
@@ -341,7 +348,7 @@ function combineFrames(dest: DataQueryResponseData, source: DataQueryResponseDat
   combineMetadata(dest, source);
 }
 
-function combineMetadata(dest: DataQueryResponseData = {}, source: DataQueryResponseData = {}) {
+function combineMetadata(dest: DataFrame, source: DataFrame) {
   if (!source.meta?.stats) {
     return;
   }
@@ -353,7 +360,7 @@ function combineMetadata(dest: DataQueryResponseData = {}, source: DataQueryResp
     return;
   }
   dest.meta.stats.forEach((destStat: QueryResultMetaStat, i: number) => {
-    const sourceStat = source.meta.stats?.find(
+    const sourceStat = source.meta?.stats?.find(
       (sourceStat: QueryResultMetaStat) => destStat.displayName === sourceStat.displayName
     );
     if (sourceStat) {


### PR DESCRIPTION
### short version:
this PR adjusts the typescript-types to become more helpful for us.

### long version:
when we get a DataQueryResponse, it contains, in it's `data` field an array of objects, which can be, based on the type-definition at 
https://github.com/grafana/grafana/blob/99316f1fb69ef24713d1945bafe711cad090f1b3/packages/grafana-data/src/types/datasource.ts#L436

one of 3 different types.
the problem is, one of those 3,  `LegacyResponseData` is defined as:
https://github.com/grafana/grafana/blob/99316f1fb69ef24713d1945bafe711cad090f1b3/packages/grafana-data/src/types/datasource.ts#L434

so there's the possibility of `any`, which causes everything to become `any`. in short,
from typescript's perspective, 
`DataQueryResponse.data` is `any[]`.

so no checking is done on any code which handles it.

but we do know, that we deal with dataframes here, so we can assume `data : DataFrame[]`. 
i adjusted the code like that, so now we get helpful typescript-checking for our code.