### PR TITLE
Clarify that LDAP will create Grafana users by default when they log in for the first time

### DIFF
--- a/docs/sources/setup-grafana/configure-security/configure-authentication/ldap/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/ldap/index.md
@@ -27,6 +27,8 @@ This means that you should be able to configure LDAP integration using any compl
 In order to use LDAP integration you'll first need to enable LDAP in the [main config file]({{< relref "../../../configure-grafana/" >}}) as well as specify the path to the LDAP
 specific configuration file (default: `/etc/grafana/ldap.toml`).
 
+Once LDAP has been enabled, the default behavior is for Grafana users to be created automatically upon successful LDAP authentication. If you would prefer for only existing Grafana users to be able to sign in, you may change `allow_sign_up` to `true` in the `[auth.ldap]` section.
+
 ```ini
 [auth.ldap]
 # Set to `true` to enable LDAP integration (default: `false`)

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/ldap/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/ldap/index.md
@@ -27,7 +27,7 @@ This means that you should be able to configure LDAP integration using any compl
 In order to use LDAP integration you'll first need to enable LDAP in the [main config file]({{< relref "../../../configure-grafana/" >}}) as well as specify the path to the LDAP
 specific configuration file (default: `/etc/grafana/ldap.toml`).
 
-After enabling LDAP, the default behavior is for Grafana users to be created automatically upon successful LDAP authentication. If you prefer for only existing Grafana users to be able to sign in, you can change `allow_sign_up` to `true` in the `[auth.ldap]` section.
+After enabling LDAP, the default behavior is for Grafana users to be created automatically upon successful LDAP authentication. If you prefer for only existing Grafana users to be able to sign in, you can change `allow_sign_up` to `false` in the `[auth.ldap]` section.
 
 ```ini
 [auth.ldap]

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/ldap/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/ldap/index.md
@@ -27,7 +27,7 @@ This means that you should be able to configure LDAP integration using any compl
 In order to use LDAP integration you'll first need to enable LDAP in the [main config file]({{< relref "../../../configure-grafana/" >}}) as well as specify the path to the LDAP
 specific configuration file (default: `/etc/grafana/ldap.toml`).
 
-Once LDAP has been enabled, the default behavior is for Grafana users to be created automatically upon successful LDAP authentication. If you would prefer for only existing Grafana users to be able to sign in, you may change `allow_sign_up` to `true` in the `[auth.ldap]` section.
+After enabling LDAP, the default behavior is for Grafana users to be created automatically upon successful LDAP authentication. If you prefer for only existing Grafana users to be able to sign in, you can change `allow_sign_up` to `true` in the `[auth.ldap]` section.
 
 ```ini
 [auth.ldap]


### PR DESCRIPTION
This proposed change to the doc was requested by a user in a Grafana support ticket as the docs did not make it clear that the OOTB behavior was for user accounts to be provisioned automatically in Grafana when signing in for the first time via LDAP.

<!--
support ticket: https://grafana.zendesk.com/agent/tickets/79860 
-->
