### PR TITLE
Elasticsearch: Improve query type selection

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/MetricEditor.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/MetricEditor.tsx
@@ -48,6 +48,7 @@ const getTypeOptions = (
 
   return (
     Object.entries(metricAggregationConfig)
+      .filter(([_, config]) => !config.isSingleMetric)
       // Only showing metrics type supported by the version of ES.
       // if we cannot determine the version, we assume it is suitable.
       .filter(([_, { versionRange = '*' }]) => (esVersion != null ? satisfies(esVersion, versionRange) : true))

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/index.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/index.tsx
@@ -25,12 +25,13 @@ export const MetricAggregationsEditor = ({ nextId }: Props) => {
       {metrics?.map((metric, index) => {
         switch (metric.type) {
           case 'logs':
-            return <QueryEditorSpecialMetricRow name="Logs" metric={metric} />;
+            return <QueryEditorSpecialMetricRow key={`${metric.type}-${metric.id}`} name="Logs" metric={metric} />;
           case 'raw_data':
-            return <QueryEditorSpecialMetricRow name="Raw Data" metric={metric} />;
+            return <QueryEditorSpecialMetricRow key={`${metric.type}-${metric.id}`} name="Raw Data" metric={metric} />;
           case 'raw_document':
             return (
               <QueryEditorSpecialMetricRow
+                key={`${metric.type}-${metric.id}`}
                 name="Raw Document"
                 metric={metric}
                 info="(NOTE: Raw document query type is deprecated)"

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/index.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/index.tsx
@@ -4,6 +4,7 @@ import { useDispatch } from '../../../hooks/useStatelessReducer';
 import { IconButton } from '../../IconButton';
 import { useQuery } from '../ElasticsearchQueryContext';
 import { QueryEditorRow } from '../QueryEditorRow';
+import { QueryEditorSpecialMetricRow } from '../QueryEditorSpecialMetricRow';
 
 import { MetricAggregation } from './../../../types';
 import { MetricEditor } from './MetricEditor';
@@ -21,21 +22,38 @@ export const MetricAggregationsEditor = ({ nextId }: Props) => {
 
   return (
     <>
-      {metrics?.map((metric, index) => (
-        <QueryEditorRow
-          key={`${metric.type}-${metric.id}`}
-          label={`Metric (${metric.id})`}
-          hidden={metric.hide}
-          onHideClick={() => dispatch(toggleMetricVisibility(metric.id))}
-          onRemoveClick={totalMetrics > 1 && (() => dispatch(removeMetric(metric.id)))}
-        >
-          <MetricEditor value={metric} />
+      {metrics?.map((metric, index) => {
+        switch (metric.type) {
+          case 'logs':
+            return <QueryEditorSpecialMetricRow name="Logs" metric={metric} />;
+          case 'raw_data':
+            return <QueryEditorSpecialMetricRow name="Raw Data" metric={metric} />;
+          case 'raw_document':
+            return (
+              <QueryEditorSpecialMetricRow
+                name="Raw Document"
+                metric={metric}
+                info="(NOTE: Raw document query type is deprecated)"
+              />
+            );
+          default:
+            return (
+              <QueryEditorRow
+                key={`${metric.type}-${metric.id}`}
+                label={`Metric (${metric.id})`}
+                hidden={metric.hide}
+                onHideClick={() => dispatch(toggleMetricVisibility(metric.id))}
+                onRemoveClick={totalMetrics > 1 && (() => dispatch(removeMetric(metric.id)))}
+              >
+                <MetricEditor value={metric} />
 
-          {!metricAggregationConfig[metric.type].isSingleMetric && index === 0 && (
-            <IconButton iconName="plus" onClick={() => dispatch(addMetric(nextId))} label="add" />
-          )}
-        </QueryEditorRow>
-      ))}
+                {!metricAggregationConfig[metric.type].isSingleMetric && index === 0 && (
+                  <IconButton iconName="plus" onClick={() => dispatch(addMetric(nextId))} label="add" />
+                )}
+              </QueryEditorRow>
+            );
+        }
+      })}
     </>
   );
 };

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/QueryEditorSpecialMetricRow.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/QueryEditorSpecialMetricRow.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+import { InlineFieldRow, InlineLabel, InlineSegmentGroup } from '@grafana/ui';
+
+import { MetricAggregation } from '../../types';
+
+import { SettingsEditor } from './MetricAggregationsEditor/SettingsEditor';
+
+type Props = {
+  name: string;
+  metric: MetricAggregation;
+  info?: string;
+};
+
+export const QueryEditorSpecialMetricRow = ({ name, metric, info }: Props) => {
+  // this widget is only used in scenarios when there is only a single
+  // metric, so the array of "previousMetrics" (meaning all the metrics
+  // before the current metric), is an ampty-array
+  const previousMetrics: MetricAggregation[] = [];
+
+  return (
+    <InlineFieldRow>
+      <InlineSegmentGroup>
+        <InlineLabel width={17} as="div">
+          <span>{name}</span>
+        </InlineLabel>
+      </InlineSegmentGroup>
+      <SettingsEditor metric={metric} previousMetrics={previousMetrics} />
+      {info != null && (
+        <InlineSegmentGroup>
+          <InlineLabel>{info}</InlineLabel>
+        </InlineSegmentGroup>
+      )}
+    </InlineFieldRow>
+  );
+};

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/QueryTypeSelector.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/QueryTypeSelector.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+
+import { SelectableValue } from '@grafana/data';
+import { RadioButtonGroup } from '@grafana/ui';
+
+import { useDispatch } from '../../hooks/useStatelessReducer';
+import { MetricAggregation } from '../../types';
+
+import { useQuery } from './ElasticsearchQueryContext';
+import { changeMetricType } from './MetricAggregationsEditor/state/actions';
+
+type QueryType = 'metrics' | 'logs' | 'raw_data' | 'raw_document';
+
+const OPTIONS: Array<SelectableValue<QueryType>> = [
+  { value: 'metrics', label: 'Metrics' },
+  { value: 'logs', label: 'Logs' },
+  { value: 'raw_data', label: 'Raw Data' },
+  { value: 'raw_document', label: 'Raw Document' },
+];
+
+function metricTypeToQueryType(type: MetricAggregation['type']): QueryType {
+  switch (type) {
+    case 'logs':
+    case 'raw_data':
+    case 'raw_document':
+      return type;
+    default:
+      return 'metrics';
+  }
+}
+
+function queryTypeToMetricType(type: QueryType): MetricAggregation['type'] {
+  switch (type) {
+    case 'logs':
+    case 'raw_data':
+    case 'raw_document':
+      return type;
+    case 'metrics':
+      return 'count';
+    default:
+      // should never happen
+      throw new Error(`invalid query type: ${type}`);
+  }
+}
+
+export const QueryTypeSelector = () => {
+  const query = useQuery();
+  const dispatch = useDispatch();
+
+  const firstMetric = query.metrics?.[0];
+
+  if (firstMetric == null) {
+    // not sure if this can really happen, but we should handle it anyway
+    return null;
+  }
+
+  const queryType = metricTypeToQueryType(firstMetric.type);
+
+  const onChange = (newQueryType: QueryType) => {
+    dispatch(changeMetricType({ id: firstMetric.id, type: queryTypeToMetricType(newQueryType) }));
+  };
+
+  return <RadioButtonGroup<QueryType> fullWidth={false} options={OPTIONS} value={queryType} onChange={onChange} />;
+};

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/index.test.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/index.test.tsx
@@ -22,10 +22,15 @@ describe('QueryEditor', () => {
         metrics: [
           {
             id: '1',
-            type: 'raw_data',
+            type: 'count',
           },
         ],
-        bucketAggs: [],
+        bucketAggs: [
+          {
+            type: 'date_histogram',
+            id: '2',
+          },
+        ],
       };
 
       const onChange = jest.fn<void, [ElasticsearchQuery]>();

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/index.test.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/index.test.tsx
@@ -56,7 +56,7 @@ describe('QueryEditor', () => {
       expect(onChange.mock.calls[0][0].alias).toBe(newAlias);
     });
 
-    it('Should be disabled if last bucket aggregation is not Date Histogram', () => {
+    it('Should not be shown if last bucket aggregation is not Date Histogram', () => {
       const query: ElasticsearchQuery = {
         refId: 'A',
         query: '',
@@ -74,7 +74,7 @@ describe('QueryEditor', () => {
       expect(screen.queryByLabelText('Alias')).toBeNull();
     });
 
-    it('Should be enabled if last bucket aggregation is Date Histogram', () => {
+    it('Should be shown if last bucket aggregation is Date Histogram', () => {
       const query: ElasticsearchQuery = {
         refId: 'A',
         query: '',

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/index.test.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/index.test.tsx
@@ -71,7 +71,7 @@ describe('QueryEditor', () => {
 
       render(<QueryEditor query={query} datasource={datasourceMock} onChange={noop} onRunQuery={noop} />);
 
-      expect(screen.getByLabelText('Alias')).toBeDisabled();
+      expect(screen.queryByLabelText('Alias')).toBeNull();
     });
 
     it('Should be enabled if last bucket aggregation is Date Histogram', () => {

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/index.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/index.tsx
@@ -15,6 +15,7 @@ import { BucketAggregationsEditor } from './BucketAggregationsEditor';
 import { ElasticsearchProvider } from './ElasticsearchQueryContext';
 import { MetricAggregationsEditor } from './MetricAggregationsEditor';
 import { metricAggregationConfig } from './MetricAggregationsEditor/utils';
+import { QueryTypeSelector } from './QueryTypeSelector';
 import { changeAliasPattern, changeQuery } from './state';
 
 export type ElasticQueryEditorProps = QueryEditorProps<ElasticDatasource, ElasticsearchQuery, ElasticsearchOptions>;
@@ -66,7 +67,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
   root: css`
     display: flex;
   `,
-  queryFieldWrapper: css`
+  queryItem: css`
     flex-grow: 1;
     margin: 0 ${theme.spacing(0.5)} ${theme.spacing(0.5)} 0;
   `,
@@ -80,14 +81,14 @@ export const ElasticSearchQueryField = ({ value, onChange }: { value?: string; o
   const styles = useStyles2(getStyles);
 
   return (
-    <div className={styles.queryFieldWrapper}>
+    <div className={styles.queryItem}>
       <QueryField
         query={value}
         // By default QueryField calls onChange if onBlur is not defined, this will trigger a rerender
         // And slate will claim the focus, making it impossible to leave the field.
         onBlur={() => {}}
         onChange={onChange}
-        placeholder="Lucene Query"
+        placeholder="Enter a lucene query"
         portalOrigin="elasticsearch"
       />
     </div>
@@ -109,22 +110,29 @@ const QueryEditorForm = ({ value }: Props) => {
   return (
     <>
       <div className={styles.root}>
-        <InlineLabel width={17}>Query</InlineLabel>
+        <InlineLabel width={17}>Query type</InlineLabel>
+        <div className={styles.queryItem}>
+          <QueryTypeSelector />
+        </div>
+      </div>
+      <div className={styles.root}>
+        <InlineLabel width={17}>Lucene Query</InlineLabel>
         <ElasticSearchQueryField onChange={(query) => dispatch(changeQuery(query))} value={value?.query} />
 
-        <InlineField
-          label="Alias"
-          labelWidth={15}
-          disabled={!isTimeSeriesQuery}
-          tooltip="Aliasing only works for timeseries queries (when the last group is 'Date Histogram'). For all other query types this field is ignored."
-        >
-          <Input
-            id={`ES-query-${value.refId}_alias`}
-            placeholder="Alias Pattern"
-            onBlur={(e) => dispatch(changeAliasPattern(e.currentTarget.value))}
-            defaultValue={value.alias}
-          />
-        </InlineField>
+        {isTimeSeriesQuery && (
+          <InlineField
+            label="Alias"
+            labelWidth={15}
+            tooltip="Aliasing only works for timeseries queries (when the last group is 'Date Histogram'). For all other query types this field is ignored."
+          >
+            <Input
+              id={`ES-query-${value.refId}_alias`}
+              placeholder="Alias Pattern"
+              onBlur={(e) => dispatch(changeAliasPattern(e.currentTarget.value))}
+              defaultValue={value.alias}
+            />
+          </InlineField>
+        )}
       </div>
 
       <MetricAggregationsEditor nextId={nextId} />


### PR DESCRIPTION
( fixes https://github.com/grafana/grafana/issues/62216 )

in the elasticsearch query editor, currently, when you want to run a logs-query or a raw-data-query or a raw-document-query, you choose it by finding the right option in the "metric" select-box. this is hard to discover.

this pull request moves the 4 query types (metric, logs, raw-data, raw-doc) to the top of the query editor. and makes sure the logs, raw-data and raw-doc options do not show up in the metric-list anymore.

please note, this is purely a visual change, the underlying `ElasticQuery` data model does not change.

additional changes:
- we hide the alias-field when it is not used
- renamed `query` to `lucene query`, and adjusted the text-field placeholder-text


future work: to decide which metric-options to hide we use the already existing `isSingleMetric` boolean. it already exists, because the reducers needed to know that when one of these (logs, raw-data, raw-doc) is chosen, all existing bucket-aggregations should be removed in the user-interface. i think we should rename it to something more descriptive, perhaps `isSpecialMetric` (naming ideas very welcome 👍 )... but did not want to make the PR more complex, so will do in a separate PR later.

how to test:
- use the elastic query builder
- make sure the 4 new radio-buttons work correctly
- make sure the metric-list does not contain logs, raw-data and raw-doc
- make sure, when choosing raw-doc, you get a notification that it is obsolete