### PR TITLE
Metrics: Expose some metrics already being gathered but not exposed

### DIFF
--- a/pkg/infra/metrics/metrics.go
+++ b/pkg/infra/metrics/metrics.go
@@ -146,6 +146,12 @@ var (
 	// MStatActiveUsers is a metric number of active users
 	MStatActiveUsers prometheus.Gauge
 
+	// MStatDailyActiveUsers is a metric number of daily active users
+	MStatDailyActiveUsers prometheus.Gauge
+
+	// MStatMonthlyActiveUsers is a metric number of monthly active users
+	MStatMonthlyActiveUsers prometheus.Gauge
+
 	// MStatTotalOrgs is a metric total amount of orgs
 	MStatTotalOrgs prometheus.Gauge
 
@@ -195,6 +201,18 @@ var (
 
 	// MStatTotalPublicDashboards is a metric total amount of public dashboards
 	MStatTotalPublicDashboards prometheus.Gauge
+
+	// StatsTotalAuthTokens is a metric total amount of auth tokens
+	StatsTotalAuthTokens prometheus.Gauge
+
+	// StatsTotalAPIKeys is a metric total amount of api keys
+	StatsTotalAPIKeys prometheus.Gauge
+
+	// StatsTotalActiveSessions is a metric total amount of active sessions
+	StatsTotalActiveSessions prometheus.Gauge
+
+	// StatsTotalDailyActiveSessions is a metric total amount of daily active sessions
+	StatsTotalDailyActiveSessions prometheus.Gauge
 )
 
 func init() {
@@ -451,6 +469,18 @@ func init() {
 		Namespace: ExporterName,
 	})
 
+	MStatDailyActiveUsers = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name:      "stat_daily_active_users",
+		Help:      "number of daily active users",
+		Namespace: ExporterName,
+	})
+
+	MStatMonthlyActiveUsers = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name:      "stat_monthly_active_users",
+		Help:      "number of monthly active users",
+		Namespace: ExporterName,
+	})
+
 	MStatTotalOrgs = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name:      "stat_total_orgs",
 		Help:      "total amount of orgs",
@@ -570,6 +600,27 @@ func init() {
 		Help:      "total amount of public dashboards",
 		Namespace: ExporterName,
 	})
+
+	StatsTotalAuthTokens = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name:      "stat_total_auth_tokens",
+		Help:      "total amount of auth tokens",
+		Namespace: ExporterName,
+	})
+	StatsTotalAPIKeys = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name:      "stat_total_api_keys",
+		Help:      "total amount of api keys",
+		Namespace: ExporterName,
+	})
+	StatsTotalActiveSessions = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name:      "stat_active_sessions",
+		Help:      "total amount of active sessions",
+		Namespace: ExporterName,
+	})
+	StatsTotalDailyActiveSessions = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name:      "stat_daily_active_sessions",
+		Help:      "total amount of daily active sessions",
+		Namespace: ExporterName,
+	})
 }
 
 // SetBuildInformation sets the build information for this binary
@@ -662,6 +713,8 @@ func initMetricVars() {
 		MStatTotalFolders,
 		MStatTotalUsers,
 		MStatActiveUsers,
+		MStatDailyActiveUsers,
+		MStatMonthlyActiveUsers,
 		MStatTotalOrgs,
 		MStatTotalPlaylists,
 		StatsTotalViewers,
@@ -681,5 +734,9 @@ func initMetricVars() {
 		MStatTotalPublicDashboards,
 		MPublicDashboardRequestCount,
 		MPublicDashboardDatasourceQuerySuccess,
+		StatsTotalAuthTokens,
+		StatsTotalAPIKeys,
+		StatsTotalActiveSessions,
+		StatsTotalDailyActiveSessions,
 	)
 }

--- a/pkg/infra/usagestats/statscollector/service.go
+++ b/pkg/infra/usagestats/statscollector/service.go
@@ -313,6 +313,8 @@ func (s *Service) updateTotalStats(ctx context.Context) bool {
 	metrics.MStatTotalFolders.Set(float64(statsQuery.Result.Folders))
 	metrics.MStatTotalUsers.Set(float64(statsQuery.Result.Users))
 	metrics.MStatActiveUsers.Set(float64(statsQuery.Result.ActiveUsers))
+	metrics.MStatDailyActiveUsers.Set(float64(statsQuery.Result.DailyActiveUsers))
+	metrics.MStatMonthlyActiveUsers.Set(float64(statsQuery.Result.MonthlyActiveUsers))
 	metrics.MStatTotalPlaylists.Set(float64(statsQuery.Result.Playlists))
 	metrics.MStatTotalOrgs.Set(float64(statsQuery.Result.Orgs))
 	metrics.StatsTotalViewers.Set(float64(statsQuery.Result.Viewers))
@@ -326,6 +328,10 @@ func (s *Service) updateTotalStats(ctx context.Context) bool {
 	metrics.StatsTotalAlertRules.Set(float64(statsQuery.Result.AlertRules))
 	metrics.StatsTotalLibraryPanels.Set(float64(statsQuery.Result.LibraryPanels))
 	metrics.StatsTotalLibraryVariables.Set(float64(statsQuery.Result.LibraryVariables))
+	metrics.StatsTotalAuthTokens.Set(float64(statsQuery.Result.AuthTokens))
+	metrics.StatsTotalAPIKeys.Set(float64(statsQuery.Result.APIKeys))
+	metrics.StatsTotalActiveSessions.Set(float64(statsQuery.Result.ActiveSessions))
+	metrics.StatsTotalDailyActiveSessions.Set(float64(statsQuery.Result.DailyActiveSessions))
 
 	metrics.StatsTotalDataKeys.With(prometheus.Labels{"active": "true"}).Set(float64(statsQuery.Result.ActiveDataKeys))
 	inactiveDataKeys := statsQuery.Result.DataKeys - statsQuery.Result.ActiveDataKeys


### PR DESCRIPTION
- MStatDailyActiveUsers
- MStatMonthlyActiveUsers
- StatsTotalAuthTokens
- StatsTotalAPIKeys
- StatsTotalActiveSessions
- StatsTotalDailyActiveSessions

Is there any particular reason why some metrics start with M and other don't?
There are a few metrics that could be easily exposed as the information is already collected from what I can tell. Should I do that for other metrics as well? (Only did it for the ones I'm particularly interested in.)
Two metrics I'd like to have are: "Number of Service Accounts" and "Number of untagged dashboards". Would it be ok to open PRs with those features?

Thanks in advance.