### PR TITLE
Prometheus: Metric encyclopedia

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -90,7 +90,6 @@ Alpha features might be changed or removed without prior notice.
 | `logsContextDatasourceUi`          | Allow datasource to provide custom UI for context view                                                                                                                       |
 | `lokiQuerySplitting`               | Split large interval queries into subqueries with smaller time intervals                                                                                                     |
 | `individualCookiePreferences`      | Support overriding cookie preferences per user                                                                                                                               |
-| `prometheusMetricEncyclopedia`     | Replaces the Prometheus query builder metric select option with a paginated and filterable component                                                                         |
 | `drawerDataSourcePicker`           | Changes the user experience for data source selection to a drawer.                                                                                                           |
 | `traceqlSearch`                    | Enables the 'TraceQL Search' tab for the Tempo datasource which provides a UI to generate TraceQL queries                                                                    |
 | `prometheusMetricEncyclopedia`     | Replaces the Prometheus query builder metric select option with a paginated and filterable component                                                                         |

--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -93,6 +93,7 @@ Alpha features might be changed or removed without prior notice.
 | `drawerDataSourcePicker`           | Changes the user experience for data source selection to a drawer.                                                                                                           |
 | `traceqlSearch`                    | Enables the 'TraceQL Search' tab for the Tempo datasource which provides a UI to generate TraceQL queries                                                                    |
 | `prometheusMetricEncyclopedia`     | Replaces the Prometheus query builder metric select option with a paginated and filterable component                                                                         |
+| `prometheusMetricEncyclopedia`     | Replaces the Prometheus query builder metric select option with a paginated and filterable component                                                                         |
 
 ## Development feature toggles
 

--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -90,6 +90,7 @@ Alpha features might be changed or removed without prior notice.
 | `logsContextDatasourceUi`          | Allow datasource to provide custom UI for context view                                                                                                                       |
 | `lokiQuerySplitting`               | Split large interval queries into subqueries with smaller time intervals                                                                                                     |
 | `individualCookiePreferences`      | Support overriding cookie preferences per user                                                                                                                               |
+| `prometheusMetricEncyclopedia`     | Replaces the Prometheus query builder metric select option with a paginated and filterable component                                                                         |
 | `drawerDataSourcePicker`           | Changes the user experience for data source selection to a drawer.                                                                                                           |
 | `traceqlSearch`                    | Enables the 'TraceQL Search' tab for the Tempo datasource which provides a UI to generate TraceQL queries                                                                    |
 | `prometheusMetricEncyclopedia`     | Replaces the Prometheus query builder metric select option with a paginated and filterable component                                                                         |

--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -92,6 +92,7 @@ Alpha features might be changed or removed without prior notice.
 | `individualCookiePreferences`      | Support overriding cookie preferences per user                                                                                                                               |
 | `drawerDataSourcePicker`           | Changes the user experience for data source selection to a drawer.                                                                                                           |
 | `traceqlSearch`                    | Enables the 'TraceQL Search' tab for the Tempo datasource which provides a UI to generate TraceQL queries                                                                    |
+| `prometheusMetricEncyclopedia`     | Replaces the Prometheus query builder metric select option with a paginated and filterable component                                                                         |
 
 ## Development feature toggles
 

--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -94,7 +94,6 @@ Alpha features might be changed or removed without prior notice.
 | `drawerDataSourcePicker`           | Changes the user experience for data source selection to a drawer.                                                                                                           |
 | `traceqlSearch`                    | Enables the 'TraceQL Search' tab for the Tempo datasource which provides a UI to generate TraceQL queries                                                                    |
 | `prometheusMetricEncyclopedia`     | Replaces the Prometheus query builder metric select option with a paginated and filterable component                                                                         |
-| `prometheusMetricEncyclopedia`     | Replaces the Prometheus query builder metric select option with a paginated and filterable component                                                                         |
 
 ## Development feature toggles
 

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -79,7 +79,7 @@ export interface FeatureToggles {
   logsContextDatasourceUi?: boolean;
   lokiQuerySplitting?: boolean;
   individualCookiePreferences?: boolean;
-  prometheusMetricEncyclopedia?: boolean;
   drawerDataSourcePicker?: boolean;
   traceqlSearch?: boolean;
+  prometheusMetricEncyclopedia?: boolean;
 }

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -79,6 +79,7 @@ export interface FeatureToggles {
   logsContextDatasourceUi?: boolean;
   lokiQuerySplitting?: boolean;
   individualCookiePreferences?: boolean;
+  prometheusMetricEncyclopedia?: boolean;
   drawerDataSourcePicker?: boolean;
   traceqlSearch?: boolean;
 }

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -393,5 +393,11 @@ var (
 			State:        FeatureStateAlpha,
 			FrontendOnly: true,
 		},
+		{
+			Name:         "prometheusMetricEncyclopedia",
+			Description:  "Replaces the Prometheus query builder metric select option with a paginated and filterable component",
+			State:        FeatureStateAlpha,
+			FrontendOnly: true,
+		},
 	}
 )

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -398,6 +398,7 @@ var (
 			Description:  "Replaces the Prometheus query builder metric select option with a paginated and filterable component",
 			State:        FeatureStateAlpha,
 			FrontendOnly: true,
+			Owner:        "O11y-metrics",
 		},
 	}
 )

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -266,7 +266,7 @@ const (
 	// FlagTraceqlSearch
 	// Enables the &#39;TraceQL Search&#39; tab for the Tempo datasource which provides a UI to generate TraceQL queries
 	FlagTraceqlSearch = "traceqlSearch"
-	
+
 	// FlagPrometheusMetricEncyclopedia
 	// Replaces the Prometheus query builder metric select option with a paginated and filterable component
 	FlagPrometheusMetricEncyclopedia = "prometheusMetricEncyclopedia"

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -266,4 +266,8 @@ const (
 	// FlagTraceqlSearch
 	// Enables the &#39;TraceQL Search&#39; tab for the Tempo datasource which provides a UI to generate TraceQL queries
 	FlagTraceqlSearch = "traceqlSearch"
+	
+	// FlagPrometheusMetricEncyclopedia
+	// Replaces the Prometheus query builder metric select option with a paginated and filterable component
+	FlagPrometheusMetricEncyclopedia = "prometheusMetricEncyclopedia"
 )

--- a/public/app/plugins/datasource/prometheus/language_provider.ts
+++ b/public/app/plugins/datasource/prometheus/language_provider.ts
@@ -77,6 +77,20 @@ export function getMetadataString(metric: string, metadata: PromMetricsMetadata)
   return `${type.toUpperCase()}: ${help}`;
 }
 
+export function getMetadataHelp(metric: string, metadata: PromMetricsMetadata): string | undefined {
+  if (!metadata[metric]) {
+    return undefined;
+  }
+  return metadata[metric].help;
+}
+
+export function getMetadataType(metric: string, metadata: PromMetricsMetadata): string | undefined {
+  if (!metadata[metric]) {
+    return undefined;
+  }
+  return metadata[metric].type;
+}
+
 const PREFIX_DELIMITER_REGEX =
   /(="|!="|=~"|!~"|\{|\[|\(|\+|-|\/|\*|%|\^|\band\b|\bor\b|\bunless\b|==|>=|!=|<=|>|<|=|~|,)/;
 

--- a/public/app/plugins/datasource/prometheus/querybuilder/MetricEncyclopediaModal.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/MetricEncyclopediaModal.tsx
@@ -1,0 +1,259 @@
+import { css } from '@emotion/css';
+import React, { useCallback, useEffect, useState } from 'react';
+
+import { GrafanaTheme2, SelectableValue } from '@grafana/data';
+// *** Feature Tracking
+// import { reportInteraction } from '@grafana/runtime';
+import { Button, Card, Collapse, InlineLabel, Input, Modal, Select, useStyles2 } from '@grafana/ui';
+
+import { PrometheusDatasource } from '../datasource';
+import { getMetadataHelp, getMetadataType } from '../language_provider';
+
+import { promQueryModeller } from './PromQueryModeller';
+import { PromVisualQuery } from './types';
+
+type Props = {
+  datasource: PrometheusDatasource;
+  isOpen: boolean;
+  query: PromVisualQuery;
+  onClose: () => void;
+  onChange: (query: PromVisualQuery) => void;
+};
+
+type MetricsData = MetricData[];
+
+type MetricData = {
+  value: string;
+  type?: string;
+  description?: string;
+};
+
+export const MetricEncyclopediaModal = (props: Props) => {
+  const { datasource, isOpen, onClose, onChange, query } = props;
+  const [openTabs, setOpenTabs] = useState<string[]>([]);
+
+  const [metrics, setMetrics] = useState<MetricsData>([]);
+
+  const updateMetricsMetadata = useCallback(async () => {
+    // *** Loading Gif?
+    // Makes sure we loaded the metadata for metrics. Usually this is done in the start() method of the provider but we
+    // don't use it with the visual builder and there is no need to run all the start() setup anyway.
+    if (!datasource.languageProvider.metricsMetadata) {
+      await datasource.languageProvider.loadMetricsMetadata();
+    }
+
+    // Error handling for when metrics metadata returns as undefined
+    // *** There will be no metadata filtering if this happens
+    // *** only metrics filter and pagination !!!
+    if (!datasource.languageProvider.metricsMetadata) {
+      datasource.languageProvider.metricsMetadata = {};
+    }
+
+    // filter by adding the query.labels to the search?
+    // *** do this in the filter???
+    let metrics;
+    if (query.labels.length > 0) {
+      const expr = promQueryModeller.renderLabels(query.labels);
+      metrics = (await datasource.languageProvider.getSeries(expr, true))['__name__'] ?? [];
+    } else {
+      metrics = (await datasource.languageProvider.getLabelValues('__name__')) ?? [];
+    }
+
+    setMetrics(
+      metrics.map((m) => ({
+        value: m,
+        type: getMetadataType(m, datasource.languageProvider.metricsMetadata!),
+        description: getMetadataHelp(m, datasource.languageProvider.metricsMetadata!),
+      }))
+    );
+  }, [datasource.languageProvider, query]);
+
+  useEffect(() => {
+    updateMetricsMetadata();
+  }, [updateMetricsMetadata]);
+
+  const styles = useStyles2(getStyles);
+
+  const functions = ['rate', 'sum', 'histogram_quatile'];
+
+  const promTypes = ['counter', 'gauge', 'histogram', 'summary'];
+
+  const functionOptions: SelectableValue[] = functions.map((f: string) => {
+    return {
+      value: f,
+      label: f,
+    };
+  });
+
+  const typeOptions: SelectableValue[] = promTypes.map((t: string) => {
+    return {
+      value: t,
+      label: t,
+    };
+  });
+
+  // *** Filtering: some metrics have no metadata so cannot be filtered
+
+  return (
+    <Modal data-testid={testIds.metricModal} isOpen={isOpen} title="Select Metric" onDismiss={onClose}>
+      <div className={styles.spacing}>Search metrics by type, function, labels and alphabetically.</div>
+      <div className="gf-form">
+        {/* *** IMPLEMENT FUZZY SEARCH */}
+        <InlineLabel width={10} className="query-keyword">
+          Search
+        </InlineLabel>
+        <Input
+          data-testid={testIds.searchMetric}
+          placeholder="search query"
+          value={''}
+          onChange={(e) => {
+            // *** Filter by text in name, description or type
+          }}
+          onBlur={() => {
+            // *** Filter by text
+          }}
+        />
+      </div>
+      <div className="gf-form">
+        <InlineLabel width={10} className="query-keyword">
+          Type:
+        </InlineLabel>
+        <Select
+          data-testid={testIds.searchType}
+          options={typeOptions}
+          value={''}
+          placeholder="select type"
+          onChange={() => {
+            // *** Filter by type
+            // *** always include metrics without metadata but label it as unknown type
+            // Consider tabs select instead of actual select
+          }}
+        />
+
+        <InlineLabel width={10} className="query-keyword">
+          Functions:
+        </InlineLabel>
+        <Select
+          data-testid={testIds.searchMetric}
+          options={functionOptions}
+          value={''}
+          placeholder="select functions"
+          onChange={() => {
+            // *** Filter by functions(query patterns) available for certain types
+            // Consider tabs select instead of actual select
+          }}
+        />
+      </div>
+      <div className="gf-form">
+        <InlineLabel width={10} className="query-keyword">
+          Page
+        </InlineLabel>
+        <Select
+          data-testid={testIds.searchPage}
+          options={[1, 2, 3, 4, 5, 6].map((p) => {
+            return { value: p, label: '' + p };
+          })}
+          value={1}
+          placeholder="select page"
+          onChange={() => {
+            // *** select page
+            // *** add select amount per page
+          }}
+        />
+      </div>
+      <div className={styles.center}>A|B|C|D|E|F|G|H|I|J|K|L|M|N|O|P|Q|R|S|T|U|V|W|X|Y|Z</div>
+      {metrics &&
+        metrics.map((metric: MetricData, idx) => {
+          return (
+            <Collapse
+              aria-label={`open and close ${metric.value} query starter card`}
+              data-testid={testIds.metricCard}
+              key={metric.value}
+              label={metric.value}
+              isOpen={openTabs.includes(metric.value)}
+              collapsible={true}
+              onToggle={() =>
+                setOpenTabs((tabs) =>
+                  // close tab if it's already open, otherwise open it
+                  tabs.includes(metric.value) ? tabs.filter((t) => t !== metric.value) : [...tabs, metric.value]
+                )
+              }
+            >
+              <div className={styles.cardsContainer}>
+                <Card className={styles.card}>
+                  <Card.Description>
+                    {metric.description && metric.type ? (
+                      <>
+                        <div className={styles.rawQueryContainer}>Description: {metric.description}</div>
+                        <div className={styles.rawQueryContainer}>Type: {metric.type}</div>
+                      </>
+                    ) : (
+                      <i>No metadata available</i>
+                    )}
+                  </Card.Description>
+                  <Card.Actions>
+                    {/* *** Make selecting a metric easier, consider click on text */}
+                    <Button
+                      size="sm"
+                      aria-label="use this metric button"
+                      data-testid={testIds.useMetric}
+                      onClick={() => {
+                        onChange({ ...query, metric: metric.value });
+                        onClose();
+                      }}
+                    >
+                      Use this metric
+                    </Button>
+                  </Card.Actions>
+                </Card>
+              </div>
+            </Collapse>
+          );
+        })}
+      <Button aria-label="close metric encyclopedia modal" variant="secondary" onClick={onClose}>
+        Close
+      </Button>
+    </Modal>
+  );
+};
+
+const getStyles = (theme: GrafanaTheme2) => {
+  return {
+    cardsContainer: css`
+      display: flex;
+      flex-direction: row;
+      flex-wrap: wrap;
+      justify-content: space-between;
+    `,
+    spacing: css`
+      margin-bottom: ${theme.spacing(1)};
+    `,
+    center: css`
+      text-align: center;
+      padding: 10px;
+    `,
+    card: css`
+      width: 49.5%;
+      display: flex;
+      flex-direction: column;
+    `,
+    rawQueryContainer: css`
+      flex-grow: 1;
+    `,
+    rawQuery: css`
+      background-color: ${theme.colors.background.primary};
+      padding: ${theme.spacing(1)};
+      margin-top: ${theme.spacing(1)};
+    `,
+  };
+};
+
+export const testIds = {
+  metricModal: 'metric-modal',
+  searchMetric: 'search-metric',
+  searchType: 'search-type',
+  searchFunction: 'search-function',
+  metricCard: 'metric-card',
+  useMetric: 'use-metric',
+  searchPage: 'search-page',
+};

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.test.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.test.tsx
@@ -10,7 +10,7 @@ import { EmptyLanguageProviderMock } from '../../language_provider.mock';
 import { PromOptions } from '../../types';
 import { PromVisualQuery } from '../types';
 
-import { MetricEncyclopediaModal, testIds } from './MetricEncyclopediaModal';
+import { MetricEncyclopediaModal, testIds, placeholders } from './MetricEncyclopediaModal';
 
 // don't care about interaction tracking in our unit tests
 jest.mock('@grafana/runtime', () => ({
@@ -22,7 +22,7 @@ describe('MetricEncyclopediaModal', () => {
   it('renders the modal', async () => {
     setup(defaultQuery, listOfMetrics);
     await waitFor(() => {
-      expect(screen.getByText('Metric Encyclopedia')).toBeInTheDocument();
+      expect(screen.getByText('Browse Metrics')).toBeInTheDocument();
     });
   });
 
@@ -96,7 +96,7 @@ describe('MetricEncyclopediaModal', () => {
     setup(defaultQuery, listOfMetrics);
 
     await waitFor(() => {
-      const selectType = screen.getByText('Select type');
+      const selectType = screen.getByText(placeholders.type);
       expect(selectType).toBeInTheDocument();
     });
   });
@@ -119,7 +119,7 @@ describe('MetricEncyclopediaModal', () => {
     setup(defaultQuery, listOfMetrics);
 
     await waitFor(() => {
-      const selectType = screen.getByText('Select a template variable');
+      const selectType = screen.getByText(placeholders.variables);
       expect(selectType).toBeInTheDocument();
     });
   });

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.test.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.test.tsx
@@ -10,7 +10,7 @@ import { EmptyLanguageProviderMock } from '../../language_provider.mock';
 import { PromOptions } from '../../types';
 import { PromVisualQuery } from '../types';
 
-import { MetricEncyclopediaModal, testIds } from './MetricEncyclopediaModal';
+import { MetricEncyclopediaModal } from './MetricEncyclopediaModal';
 
 // don't care about interaction tracking in our unit tests
 jest.mock('@grafana/runtime', () => ({

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.test.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
-import { DataSourceInstanceSettings, DataSourcePluginMeta, PanelData } from '@grafana/data';
+import { DataSourceInstanceSettings, DataSourcePluginMeta } from '@grafana/data';
 
 import { PrometheusDatasource } from '../../datasource';
 import PromQlLanguageProvider from '../../language_provider';
@@ -24,14 +24,34 @@ const defaultQuery: PromVisualQuery = {
   operations: [],
 };
 
-function createDatasource(options?: Partial<DataSourceInstanceSettings<PromOptions>>) {
+function createDatasource(withLabels?: boolean) {
   const languageProvider = new EmptyLanguageProviderMock() as unknown as PromQlLanguageProvider;
+
+  // display different results if their oare labels selected in the PromVisualQuery
+  if (withLabels) {
+    languageProvider.getSeries = () => Promise.resolve({ __name__: ['with-labels'] });
+    languageProvider.metricsMetadata = {
+      'with-labels': {
+        type: 'with-labels-type',
+        help: 'with-labels-help',
+      },
+    };
+  } else {
+    // all metrics
+    languageProvider.getLabelValues = () => Promise.resolve(['all-metrics']);
+    languageProvider.metricsMetadata = {
+      'all-metrics': {
+        type: 'all-metrics-type',
+        help: 'all-metrics-help',
+      },
+    };
+  }
+
   const datasource = new PrometheusDatasource(
     {
       url: '',
       jsonData: {},
       meta: {} as DataSourcePluginMeta,
-      ...options,
     } as DataSourceInstanceSettings<PromOptions>,
     undefined,
     undefined,
@@ -40,19 +60,20 @@ function createDatasource(options?: Partial<DataSourceInstanceSettings<PromOptio
   return datasource;
 }
 
-function createProps(datasource: PrometheusDatasource) {
+function createProps(query: PromVisualQuery, datasource: PrometheusDatasource) {
   return {
     datasource,
     isOpen: true,
     onChange: jest.fn(),
     onClose: jest.fn(),
-    query: defaultQuery,
+    query: query,
   };
 }
 
-function setup() {
-  const datasource = createDatasource();
-  const props = createProps(datasource);
+function setup(query: PromVisualQuery, withlabels?: boolean) {
+  const withLabels: boolean = query.labels.length > 0;
+  const datasource = createDatasource(withLabels);
+  const props = createProps(query, datasource);
 
   // render the modal only
   render(<MetricEncyclopediaModal {...props} />);
@@ -60,23 +81,63 @@ function setup() {
 
 describe('MetricEncyclopediaModal', () => {
   it('renders the modal', async () => {
-    setup();
+    setup(defaultQuery);
     await waitFor(() => {
       expect(screen.getByText('Select Metric')).toBeInTheDocument();
     });
   });
 
-  // it('renders a list of metrics', async () => {
+  it('renders a list of metrics', async () => {
+    setup(defaultQuery);
+    await waitFor(() => {
+      expect(screen.getByText('all-metrics')).toBeInTheDocument();
+    });
+  });
 
-  // });
+  it('renders a list of metrics filtered by labels in the PromVisualQuery', async () => {
+    const query: PromVisualQuery = {
+      metric: 'random_metric',
+      labels: [
+        {
+          op: '=',
+          label: 'action',
+          value: 'add_presence',
+        },
+      ],
+      operations: [],
+    };
 
-  // it('displays a type for a metric', async () => {
+    setup(query);
+    await waitFor(() => {
+      expect(screen.getByText('with-labels')).toBeInTheDocument();
+    });
+  });
 
-  // });
+  it('displays a type for a metric when the metric is clicked', async () => {
+    setup(defaultQuery);
+    await waitFor(() => {
+      expect(screen.getByText('all-metrics')).toBeInTheDocument();
+    });
 
-  // it('displays a description for a metric', async () => {
+    const interactiveMetric = screen.getByText('all-metrics');
 
-  // });
+    await userEvent.click(interactiveMetric);
+
+    expect(screen.getByText('all-metrics-type')).toBeInTheDocument();
+  });
+
+  it('displays a description for a metric', async () => {
+    setup(defaultQuery);
+    await waitFor(() => {
+      expect(screen.getByText('all-metrics')).toBeInTheDocument();
+    });
+
+    const interactiveMetric = screen.getByText('all-metrics');
+
+    await userEvent.click(interactiveMetric);
+
+    expect(screen.getByText('all-metrics-help')).toBeInTheDocument();
+  });
 
   // it('paginates the list of metrics', async () => {
 

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.test.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.test.tsx
@@ -110,6 +110,7 @@ describe('MetricEncyclopediaModal', () => {
     setup(defaultQuery, listOfMetrics);
     await waitFor(() => {
       expect(screen.getByText('all-metrics')).toBeInTheDocument();
+      expect(screen.getByText('a_bucket')).toBeInTheDocument();
       expect(screen.getByText('a')).toBeInTheDocument();
       expect(screen.getByText('b')).toBeInTheDocument();
       expect(screen.getByText('c')).toBeInTheDocument();
@@ -118,7 +119,6 @@ describe('MetricEncyclopediaModal', () => {
       expect(screen.getByText('f')).toBeInTheDocument();
       expect(screen.getByText('g')).toBeInTheDocument();
       expect(screen.getByText('h')).toBeInTheDocument();
-      expect(screen.getByText('i')).toBeInTheDocument();
     });
   });
 
@@ -134,7 +134,7 @@ describe('MetricEncyclopediaModal', () => {
   it('shows results metrics per page chosen by the user', async () => {
     setup(defaultQuery, listOfMetrics);
     const resultsPerPageInput = screen.getByTestId('results-per-page');
-    await userEvent.type(resultsPerPageInput, '11');
+    await userEvent.type(resultsPerPageInput, '12');
     const metricInsideRange = screen.getByText('j');
     expect(metricInsideRange).toBeInTheDocument();
   });

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.test.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.test.tsx
@@ -78,19 +78,6 @@ describe('MetricEncyclopediaModal', () => {
     expect(screen.getByText('all-metrics-help')).toBeInTheDocument();
   });
 
-  it('displays suggested functions for a metric', async () => {
-    setup(defaultQuery, listOfMetrics);
-    await waitFor(() => {
-      expect(screen.getByText('a_bucket')).toBeInTheDocument();
-    });
-
-    const interactiveMetric = screen.getByText('a_bucket');
-
-    await userEvent.click(interactiveMetric);
-
-    expect(screen.getByText('histogram_quantile() rate()')).toBeInTheDocument();
-  });
-
   it('displays no metadata for a metric missing metadata when the metric is clicked', async () => {
     setup(defaultQuery, listOfMetrics);
     await waitFor(() => {
@@ -110,15 +97,6 @@ describe('MetricEncyclopediaModal', () => {
 
     await waitFor(() => {
       const selectType = screen.getByText('Select type');
-      expect(selectType).toBeInTheDocument();
-    });
-  });
-
-  it('has a filter for selected functions', async () => {
-    setup(defaultQuery, listOfMetrics);
-
-    await waitFor(() => {
-      const selectType = screen.getByText('Select functions');
       expect(selectType).toBeInTheDocument();
     });
   });

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.test.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+import { DataSourceInstanceSettings, DataSourcePluginMeta, PanelData } from '@grafana/data';
+
+import { PrometheusDatasource } from '../../datasource';
+import PromQlLanguageProvider from '../../language_provider';
+import { EmptyLanguageProviderMock } from '../../language_provider.mock';
+import { PromOptions } from '../../types';
+import { PromVisualQuery } from '../types';
+
+import { MetricEncyclopediaModal } from './MetricEncyclopediaModal';
+
+// don't care about interaction tracking in our unit tests
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  reportInteraction: jest.fn(),
+}));
+
+const defaultQuery: PromVisualQuery = {
+  metric: 'random_metric',
+  labels: [],
+  operations: [],
+};
+
+function createDatasource(options?: Partial<DataSourceInstanceSettings<PromOptions>>) {
+  const languageProvider = new EmptyLanguageProviderMock() as unknown as PromQlLanguageProvider;
+  const datasource = new PrometheusDatasource(
+    {
+      url: '',
+      jsonData: {},
+      meta: {} as DataSourcePluginMeta,
+      ...options,
+    } as DataSourceInstanceSettings<PromOptions>,
+    undefined,
+    undefined,
+    languageProvider
+  );
+  return datasource;
+}
+
+function createProps(datasource: PrometheusDatasource) {
+  return {
+    datasource,
+    isOpen: true,
+    onChange: jest.fn(),
+    onClose: jest.fn(),
+    query: defaultQuery,
+  };
+}
+
+function setup() {
+  const datasource = createDatasource();
+  const props = createProps(datasource);
+
+  // render the modal only
+  render(<MetricEncyclopediaModal {...props} />);
+}
+
+describe('MetricEncyclopediaModal', () => {
+  it('renders the modal', async () => {
+    setup();
+    await waitFor(() => {
+      expect(screen.getByText('Select Metric')).toBeInTheDocument();
+    });
+  });
+
+  // it('renders a list of metrics', async () => {
+
+  // });
+
+  // it('displays a type for a metric', async () => {
+
+  // });
+
+  // it('displays a description for a metric', async () => {
+
+  // });
+
+  // it('paginates the list of metrics', async () => {
+
+  // });
+
+  // it('shows an amount of metrics per page chosen by the user', async () => {
+
+  // });
+});

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.test.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.test.tsx
@@ -46,6 +46,10 @@ function createDatasource(metrics: string[], withLabels?: boolean) {
         type: 'all-metrics-type',
         help: 'all-metrics-help',
       },
+      a: {
+        type: 'counter',
+        help: 'a-metric-help',
+      },
       // missing metadata for other metrics is tested for, see below
     };
   }
@@ -147,10 +151,10 @@ describe('MetricEncyclopediaModal', () => {
   it('displays no metadata for a metric missing metadata when the metric is clicked', async () => {
     setup(defaultQuery, listOfMetrics);
     await waitFor(() => {
-      expect(screen.getByText('a')).toBeInTheDocument();
+      expect(screen.getByText('b')).toBeInTheDocument();
     });
 
-    const interactiveMetric = screen.getByText('a');
+    const interactiveMetric = screen.getByText('b');
 
     await userEvent.click(interactiveMetric);
 
@@ -206,5 +210,37 @@ describe('MetricEncyclopediaModal', () => {
     const metricInsideRange = screen.getByText('10');
     expect(metricInsideRange).toBeInTheDocument();
   });
-  // Filtering
+
+  // // Filtering
+  // it('filters results based on selected type', async () => {
+  //   // default resultsPerPage is 10
+  //   setup(defaultQuery, listOfMetrics);
+  //   // how do you test the MultiSelect?
+  //   // this does not work
+  //   // https://developers.grafana.com/ui/latest/index.html?path=/docs/forms-select--multi-select-basic
+
+  // });
+
+  // it('sorts alphabetically but puts metrics with no metadata last', async () => {
+  //   // default resultsPerPage is 10
+  //   setup(defaultQuery, listOfMetrics);
+  //   // how do you test the MultiSelect?
+  //   // this does not work
+  //   // https://developers.grafana.com/ui/latest/index.html?path=/docs/forms-select--multi-select-basic
+
+  // });
+
+  it('filters by alphebetical letter choice', async () => {
+    setup(defaultQuery, listOfMetrics);
+    // pick the letter J
+    const letterJ = screen.getByTestId('letter-J');
+    await userEvent.click(letterJ);
+
+    // check metrics that start with J
+    const metricStartingWithJ = screen.getByText('j');
+    expect(metricStartingWithJ).toBeInTheDocument();
+    // check metrics that don't start with J
+    const metricStartingWithSomethingElse = screen.queryByText('a');
+    expect(metricStartingWithSomethingElse).toBeNull();
+  });
 });

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.test.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.test.tsx
@@ -153,6 +153,24 @@ describe('MetricEncyclopediaModal', () => {
     expect(metricInsideRange).toBeInTheDocument();
   });
 
+  // Fuzzy search
+  // it('searches by name with a fuzzy search', async () => {
+  //   setup(defaultQuery, listOfMetrics);
+  //   const resultsPerPageInput = screen.getByTestId('search-metric');
+  //   await userEvent.type(resultsPerPageInput, 'a_buck');
+  //   let metricABucket = screen.getByText('a_bucket');
+  //   expect(metricABucket).toBeInTheDocument();
+  // });
+
+  // it('searches by all metadata with a fuzzy search', async () => {
+  //   // set fullMetaSearch true
+  //   setup(defaultQuery, listOfMetrics);
+  //   const resultsPerPageInput = screen.getByTestId('search-metric');
+  //   await userEvent.type(resultsPerPageInput, 'count');
+  //   let metricABucket = screen.getByText('a_bucket');
+  //   expect(metricABucket).toBeInTheDocument();
+  // });
+
   // // Filtering
   // it('filters results based on selected type', async () => {
   //   // default resultsPerPage is 10

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.test.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.test.tsx
@@ -194,6 +194,15 @@ describe('MetricEncyclopediaModal', () => {
     const metricStartingWithSomethingElse = screen.queryByText('a');
     expect(metricStartingWithSomethingElse).toBeNull();
   });
+
+  // it('allows a user to select a template variable', async () => {
+  //   // default resultsPerPage is 10
+  //   setup(defaultQuery, listOfMetrics);
+  //   // how do you test the MultiSelect?
+  //   // this does not work
+  //   // https://developers.grafana.com/ui/latest/index.html?path=/docs/forms-select--multi-select-basic
+
+  // });
 });
 
 const defaultQuery: PromVisualQuery = {

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.tsx
@@ -309,7 +309,8 @@ export const MetricEncyclopediaModal = (props: Props) => {
       aria-label="Metric Encyclopedia"
     >
       <div className={styles.spacing}>
-        Search {metrics.length} metrics by type, function, labels, alphabetically or select a variable.
+        Search {metrics.length} metric{metrics.length > 1 ? 's' : ''} by type, function, labels, alphabetically or
+        select a variable.
       </div>
       {query.labels.length > 0 && (
         <div className={styles.spacing}>

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.tsx
@@ -359,6 +359,7 @@ export const MetricEncyclopediaModal = (props: Props) => {
           autoFocus
           onInput={(e) => {
             const value = e.currentTarget.value ?? '';
+
             setFuzzySearchQuery(value);
 
             if (useBackend && value === '') {

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.tsx
@@ -265,7 +265,7 @@ export const MetricEncyclopediaModal = (props: Props) => {
         </InlineLabel>
         <Input
           data-testid={testIds.searchMetric}
-          placeholder="search query"
+          placeholder="Search metric text"
           value={''}
           onChange={(e) => {
             // *** Filter by text in name, description or type
@@ -416,9 +416,9 @@ export const MetricEncyclopediaModal = (props: Props) => {
             setPageNum(1);
           }
           // selected letter to filter by
-          const selectedClass: string = letterSearch === letter ? styles.bold : '';
+          const selectedClass: string = letterSearch === letter ? styles.selAlpha : '';
           // these letters are represented in the list of metrics
-          const activeClass: string = active ? '' : styles.gray;
+          const activeClass: string = active ? styles.active : styles.gray;
 
           return (
             <span
@@ -496,62 +496,6 @@ export const MetricEncyclopediaModal = (props: Props) => {
   );
 };
 
-const getStyles = (theme: GrafanaTheme2) => {
-  return {
-    cardsContainer: css`
-      display: flex;
-      flex-direction: row;
-      flex-wrap: wrap;
-      justify-content: space-between;
-    `,
-    spacing: css`
-      margin-bottom: ${theme.spacing(1)};
-    `,
-    center: css`
-      text-align: center;
-      padding: 10px;
-    `,
-    card: css`
-      width: 100%;
-      display: flex;
-      flex-direction: column;
-    `,
-    rawQueryContainer: css`
-      flex-grow: 1;
-    `,
-    rawQuery: css`
-      background-color: ${theme.colors.background.primary};
-      padding: ${theme.spacing(1)};
-      margin-top: ${theme.spacing(1)};
-    `,
-    // alphabeticalSearch: css`
-    //   height: 50px;
-    // `,
-    bold: css`
-      font-style: italic;
-      cursor: pointer;
-      color: #6e9fff;
-    `,
-    gray: css`
-      color: grey;
-    `,
-    metadata: css`
-      color: rgb(204, 204, 220);
-    `,
-  };
-};
-
-export const testIds = {
-  metricModal: 'metric-modal',
-  searchMetric: 'search-metric',
-  selectType: 'select-type',
-  searchFunction: 'search-function',
-  metricCard: 'metric-card',
-  useMetric: 'use-metric',
-  searchPage: 'search-page',
-  resultsPerPage: 'results-per-page',
-};
-
 function alphabetically(ascending: boolean, metadataFilters: boolean) {
   return function (a: MetricData, b: MetricData) {
     // equal items sort equally
@@ -626,3 +570,59 @@ function suggestFunctionHints(metric: MetricData) {
   // 1. Check for recording rules expansion
   // 2. For multiple series suggest operator sum() relies on returned query
 }
+
+const getStyles = (theme: GrafanaTheme2) => {
+  return {
+    cardsContainer: css`
+      display: flex;
+      flex-direction: row;
+      flex-wrap: wrap;
+      justify-content: space-between;
+    `,
+    spacing: css`
+      margin-bottom: ${theme.spacing(1)};
+    `,
+    center: css`
+      text-align: center;
+      padding: 10px;
+    `,
+    card: css`
+      width: 100%;
+      display: flex;
+      flex-direction: column;
+    `,
+    rawQueryContainer: css`
+      flex-grow: 1;
+    `,
+    rawQuery: css`
+      background-color: ${theme.colors.background.primary};
+      padding: ${theme.spacing(1)};
+      margin-top: ${theme.spacing(1)};
+    `,
+    selAlpha: css`
+      font-style: italic;
+      cursor: pointer;
+      color: #6e9fff;
+    `,
+    active: css`
+      cursor: pointer;
+    `,
+    gray: css`
+      color: grey;
+    `,
+    metadata: css`
+      color: rgb(204, 204, 220);
+    `,
+  };
+};
+
+export const testIds = {
+  metricModal: 'metric-modal',
+  searchMetric: 'search-metric',
+  selectType: 'select-type',
+  searchFunction: 'search-function',
+  metricCard: 'metric-card',
+  useMetric: 'use-metric',
+  searchPage: 'search-page',
+  resultsPerPage: 'results-per-page',
+};

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.tsx
@@ -348,6 +348,7 @@ export const MetricEncyclopediaModal = (props: Props) => {
             tooltip={<div>{tooltips.metadataSearchSwicth}</div>}
           >
             <InlineSwitch
+              data-testid={testIds.searchWithMetadata}
               showLabel={true}
               value={fullMetaSearch}
               onChange={() => {
@@ -735,6 +736,7 @@ const getStyles = (theme: GrafanaTheme2) => {
 export const testIds = {
   metricModal: 'metric-modal',
   searchMetric: 'search-metric',
+  searchWithMetadata: 'search-with-metadata',
   selectType: 'select-type',
   searchFunction: 'search-function',
   metricCard: 'metric-card',

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.tsx
@@ -67,7 +67,7 @@ const promTypes: PromFilterOption[] = [
   },
 ];
 
-const tooltips = {
+export const placeholders = {
   browse: 'Browse metric names by text',
   metadataSearchSwicth: 'Browse by metadata type and description in addition to metric name',
   type: 'Counter, gauge, histogram, or summary',
@@ -288,7 +288,7 @@ export const MetricEncyclopediaModal = (props: Props) => {
       <div className="gf-form">
         <Input
           data-testid={testIds.searchMetric}
-          placeholder={tooltips.browse}
+          placeholder={placeholders.browse}
           value={fuzzySearchQuery}
           onInput={(e) => {
             const value = e.currentTarget.value ?? '';
@@ -298,7 +298,7 @@ export const MetricEncyclopediaModal = (props: Props) => {
           }}
         />
         {hasMetadata && (
-          <InlineField label="" className={styles.labelColor} tooltip={<div>{tooltips.metadataSearchSwicth}</div>}>
+          <InlineField label="" className={styles.labelColor} tooltip={<div>{placeholders.metadataSearchSwicth}</div>}>
             <InlineSwitch
               data-testid={testIds.searchWithMetadata}
               showLabel={true}
@@ -322,7 +322,7 @@ export const MetricEncyclopediaModal = (props: Props) => {
               inputId="my-select"
               options={typeOptions}
               value={selectedTypes}
-              placeholder={tooltips.type}
+              placeholder={placeholders.type}
               onChange={(v) => {
                 // *** Filter by type
                 // *** always include metrics without metadata but label it as unknown type
@@ -332,7 +332,7 @@ export const MetricEncyclopediaModal = (props: Props) => {
               }}
             />
             {hasMetadata && (
-              <InlineField label="" className={styles.labelColor} tooltip={<div>{tooltips.excludeNoMetadata}</div>}>
+              <InlineField label="" className={styles.labelColor} tooltip={<div>{placeholders.excludeNoMetadata}</div>}>
                 <InlineSwitch
                   showLabel={true}
                   value={excludeNullMetadata}
@@ -354,7 +354,7 @@ export const MetricEncyclopediaModal = (props: Props) => {
           inputId="my-select"
           options={variables}
           value={''}
-          placeholder={tooltips.variables}
+          placeholder={placeholders.variables}
           onChange={(v) => {
             const value: string = v.value ?? '';
             onChange({ ...query, metric: value });

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.tsx
@@ -68,11 +68,11 @@ const promTypes: PromFilterOption[] = [
 ];
 
 const tooltips = {
-  browse: 'Filter metric names by text',
-  metadataSearchSwicth: 'Include all metadata in search by text',
-  type: 'Prometheus supports four types of metrics, they are - Counter - Gauge - Histogram - Summary',
-  variables: 'Select a predefined Grafana template variable for your metric',
-  excludeNoMetadata: 'Exclude all metrics with no metadata when filtering',
+  browse: 'Browse metric names by text',
+  metadataSearchSwicth: 'Browse by metadata type and description in addition to metric name',
+  type: 'Counter, gauge, histogram, or summary',
+  variables: 'Select a template variable for your metric',
+  excludeNoMetadata: 'Exclude results with no metadata when filtering',
 };
 
 export const DEFAULT_RESULTS_PER_PAGE = 10;
@@ -264,7 +264,7 @@ export const MetricEncyclopediaModal = (props: Props) => {
     <Modal
       data-testid={testIds.metricModal}
       isOpen={isOpen}
-      title="Metric Encyclopedia"
+      title="Browse Metrics"
       onDismiss={onClose}
       aria-label="Metric Encyclopedia"
     >
@@ -278,12 +278,9 @@ export const MetricEncyclopediaModal = (props: Props) => {
         </div>
       )}
       <div className="gf-form">
-        <InlineLabel width={15} className="query-keyword" tooltip={<div>{tooltips.browse}</div>}>
-          Browse
-        </InlineLabel>
         <Input
           data-testid={testIds.searchMetric}
-          placeholder="Browse by metric text"
+          placeholder={tooltips.browse}
           value={fuzzySearchQuery}
           onInput={(e) => {
             const value = e.currentTarget.value ?? '';
@@ -293,11 +290,7 @@ export const MetricEncyclopediaModal = (props: Props) => {
           }}
         />
         {hasMetadata && (
-          <InlineField
-            label="Browse all metadata"
-            className={styles.labelColor}
-            tooltip={<div>{tooltips.metadataSearchSwicth}</div>}
-          >
+          <InlineField label="" className={styles.labelColor} tooltip={<div>{tooltips.metadataSearchSwicth}</div>}>
             <InlineSwitch
               data-testid={testIds.searchWithMetadata}
               showLabel={true}
@@ -310,18 +303,18 @@ export const MetricEncyclopediaModal = (props: Props) => {
           </InlineField>
         )}
       </div>
-      <div className="gf-form">
-        {hasMetadata && (
-          <>
-            <InlineLabel htmlFor="my-select" width={15} className="query-keyword" tooltip={<div>{tooltips.type}</div>}>
-              Type
-            </InlineLabel>
+      {hasMetadata && (
+        <>
+          <div className="gf-form">
+            <h6>Filter by Type</h6>
+          </div>
+          <div className="gf-form">
             <MultiSelect
               data-testid={testIds.selectType}
               inputId="my-select"
               options={typeOptions}
               value={selectedTypes}
-              placeholder="Select type"
+              placeholder={tooltips.type}
               onChange={(v) => {
                 // *** Filter by type
                 // *** always include metrics without metadata but label it as unknown type
@@ -330,78 +323,39 @@ export const MetricEncyclopediaModal = (props: Props) => {
                 setPageNum(1);
               }}
             />
-          </>
-        )}
+            {hasMetadata && (
+              <InlineField label="" className={styles.labelColor} tooltip={<div>{tooltips.excludeNoMetadata}</div>}>
+                <InlineSwitch
+                  showLabel={true}
+                  value={excludeNullMetadata}
+                  onChange={() => {
+                    setExcludeNullMetadata(!excludeNullMetadata);
+                    setPageNum(1);
+                  }}
+                />
+              </InlineField>
+            )}
+          </div>
+        </>
+      )}
+      <div className="gf-form">
+        <h6>Variables</h6>
       </div>
       <div className="gf-form">
-        <InlineLabel width={15} className="query-keyword">
-          Page
-        </InlineLabel>
         <Select
-          data-testid={testIds.searchPage}
-          options={calculatePageList(metrics, resultsPerPage).map((p) => {
-            return { value: p, label: '' + p };
-          })}
-          value={pageNum ?? 1}
-          placeholder="select page"
-          onChange={(e) => {
-            const value = e.value ?? 1;
-            setPageNum(value);
-          }}
-        />
-        <InlineLabel width={15} className="query-keyword">
-          # per page
-        </InlineLabel>
-        <Input
-          data-testid={testIds.resultsPerPage}
-          value={resultsPerPage ?? 10}
-          placeholder="results per page"
-          onInput={(e) => {
-            const value = +e.currentTarget.value;
-
-            if (isNaN(value)) {
-              return;
-            }
-
-            setResultsPerPage(value);
-          }}
-        />
-      </div>
-      <div className="gf-form">
-        <InlineLabel width={15} className="query-keyword" tooltip={<div>{tooltips.variables}</div>}>
-          Variables
-        </InlineLabel>
-        <Select
-          // data-testid={testIds.selectType}
           inputId="my-select"
           options={variables}
           value={''}
-          placeholder="Select a template variable"
+          placeholder={tooltips.variables}
           onChange={(v) => {
             const value: string = v.value ?? '';
             onChange({ ...query, metric: value });
             onClose();
           }}
         />
-        {hasMetadata && (
-          <InlineField
-            label="Exclude null metadata"
-            className={styles.labelColor}
-            tooltip={<div>{tooltips.excludeNoMetadata}</div>}
-          >
-            <InlineSwitch
-              showLabel={true}
-              value={excludeNullMetadata}
-              onChange={() => {
-                setExcludeNullMetadata(!excludeNullMetadata);
-                setPageNum(1);
-              }}
-            />
-          </InlineField>
-        )}
       </div>
-
-      <div className={styles.center}>
+      <h5 className={`${styles.center} ${styles.topPadding}`}>Results</h5>
+      <div className={`${styles.center} ${styles.bottomPadding}`}>
         {[
           'A',
           'B',
@@ -522,6 +476,42 @@ export const MetricEncyclopediaModal = (props: Props) => {
             </Collapse>
           );
         })}
+      <br />
+      <div className="gf-form">
+        <InlineLabel width={20} className="query-keyword">
+          Select Page
+        </InlineLabel>
+        <Select
+          data-testid={testIds.searchPage}
+          options={calculatePageList(metrics, resultsPerPage).map((p) => {
+            return { value: p, label: '' + p };
+          })}
+          value={pageNum ?? 1}
+          placeholder="select page"
+          onChange={(e) => {
+            const value = e.value ?? 1;
+            setPageNum(value);
+          }}
+        />
+        <InlineLabel width={20} className="query-keyword">
+          # results per page
+        </InlineLabel>
+        <Input
+          data-testid={testIds.resultsPerPage}
+          value={resultsPerPage ?? 10}
+          placeholder="results per page"
+          onInput={(e) => {
+            const value = +e.currentTarget.value;
+
+            if (isNaN(value)) {
+              return;
+            }
+
+            setResultsPerPage(value);
+          }}
+        />
+      </div>
+      <br />
       <Button aria-label="close metric encyclopedia modal" variant="secondary" onClick={onClose}>
         Close
       </Button>
@@ -587,7 +577,14 @@ const getStyles = (theme: GrafanaTheme2) => {
     `,
     center: css`
       text-align: center;
-      padding: 10px;
+      padding: 4px;
+      width: 100%;
+    `,
+    topPadding: css`
+      padding: 10px 0 0 0;
+    `,
+    bottomPadding: css`
+      padding: 0 0 4px 0;
     `,
     card: css`
       width: 100%;

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.tsx
@@ -7,6 +7,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { GrafanaTheme2, SelectableValue } from '@grafana/data';
 // *** Feature Tracking
 // import { reportInteraction } from '@grafana/runtime';
+import { reportInteraction } from '@grafana/runtime';
 import {
   Button,
   Card,
@@ -556,6 +557,17 @@ export const MetricEncyclopediaModal = (props: Props) => {
                       data-testid={testIds.useMetric}
                       onClick={() => {
                         onChange({ ...query, metric: metric.value });
+                        reportInteraction('grafana_prom_metric_encycopedia_tracking', {
+                          metric: metric.value,
+                          hasVariables: variables.length > 0,
+                          hasMetadata: hasMetadata,
+                          totalMetricCount: metrics.length,
+                          fuzzySearchQuery: fuzzySearchQuery,
+                          fullMetaSearch: fullMetaSearch,
+                          selectedTypes: selectedTypes,
+                          selectedFunctions: selectedFunctions,
+                          letterSearch: letterSearch,
+                        });
                         onClose();
                       }}
                     >

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.tsx
@@ -6,11 +6,10 @@ import { GrafanaTheme2, SelectableValue } from '@grafana/data';
 // import { reportInteraction } from '@grafana/runtime';
 import { Button, Card, Collapse, InlineLabel, Input, Modal, Select, useStyles2 } from '@grafana/ui';
 
-import { PrometheusDatasource } from '../datasource';
-import { getMetadataHelp, getMetadataType } from '../language_provider';
-
-import { promQueryModeller } from './PromQueryModeller';
-import { PromVisualQuery } from './types';
+import { PrometheusDatasource } from '../../datasource';
+import { getMetadataHelp, getMetadataType } from '../../language_provider';
+import { promQueryModeller } from '../PromQueryModeller';
+import { PromVisualQuery } from '../types';
 
 type Props = {
   datasource: PrometheusDatasource;
@@ -95,7 +94,13 @@ export const MetricEncyclopediaModal = (props: Props) => {
   // *** Filtering: some metrics have no metadata so cannot be filtered
 
   return (
-    <Modal data-testid={testIds.metricModal} isOpen={isOpen} title="Select Metric" onDismiss={onClose}>
+    <Modal
+      data-testid={testIds.metricModal}
+      isOpen={isOpen}
+      title="Select Metric"
+      onDismiss={onClose}
+      aria-label="Metric Encyclopedia"
+    >
       <div className={styles.spacing}>Search metrics by type, function, labels and alphabetically.</div>
       <div className="gf-form">
         {/* *** IMPLEMENT FUZZY SEARCH */}

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.tsx
@@ -1,12 +1,9 @@
 import { css } from '@emotion/css';
 import uFuzzy from '@leeoniya/ufuzzy';
-// import debounce from 'lodash'
 import { debounce } from 'lodash';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 import { GrafanaTheme2, SelectableValue } from '@grafana/data';
-// *** Feature Tracking
-// import { reportInteraction } from '@grafana/runtime';
 import { reportInteraction } from '@grafana/runtime';
 import {
   Button,

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.tsx
@@ -82,6 +82,8 @@ export const DEFAULT_RESULTS_PER_PAGE = 10;
 export const MetricEncyclopediaModal = (props: Props) => {
   const { datasource, isOpen, onClose, onChange, query } = props;
 
+  const [variables, setVariables] = useState<Array<SelectableValue<string>>>([]);
+
   // metric list
   const [metrics, setMetrics] = useState<MetricsData>([]);
   const [openTabs, setOpenTabs] = useState<string[]>([]);
@@ -132,7 +134,16 @@ export const MetricEncyclopediaModal = (props: Props) => {
         }),
       }))
     );
-  }, [datasource.languageProvider, query]);
+
+    setVariables(
+      datasource.getVariables().map((v) => {
+        return {
+          value: v,
+          label: v,
+        };
+      })
+    );
+  }, [query, datasource]);
 
   useEffect(() => {
     updateMetricsMetadata();
@@ -244,7 +255,9 @@ export const MetricEncyclopediaModal = (props: Props) => {
       onDismiss={onClose}
       aria-label="Metric Encyclopedia"
     >
-      <div className={styles.spacing}>Search metrics by type, function, labels and alphabetically.</div>
+      <div className={styles.spacing}>
+        Search metrics by type, function, labels, alphabetically or select a variable.
+      </div>
       <div className="gf-form">
         {/* *** IMPLEMENT FUZZY SEARCH */}
         <InlineLabel width={10} className="query-keyword">
@@ -338,6 +351,23 @@ export const MetricEncyclopediaModal = (props: Props) => {
             }
 
             setResultsPerPage(value);
+          }}
+        />
+      </div>
+      <div className="gf-form">
+        <InlineLabel width={10} className="query-keyword">
+          Variables
+        </InlineLabel>
+        <Select
+          // data-testid={testIds.selectType}
+          inputId="my-select"
+          options={variables}
+          value={''}
+          placeholder="Select variable"
+          onChange={(v) => {
+            const value: string = v.value ?? '';
+            onChange({ ...query, metric: value });
+            onClose();
           }}
         />
       </div>

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.tsx
@@ -17,6 +17,7 @@ import {
   Modal,
   MultiSelect,
   Select,
+  Spinner,
   useStyles2,
 } from '@grafana/ui';
 
@@ -87,6 +88,8 @@ export const MetricEncyclopediaModal = (props: Props) => {
 
   const [variables, setVariables] = useState<Array<SelectableValue<string>>>([]);
 
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+
   // metric list
   const [metrics, setMetrics] = useState<MetricsData>([]);
   const [hasMetadata, setHasMetadata] = useState<boolean>(true);
@@ -111,7 +114,8 @@ export const MetricEncyclopediaModal = (props: Props) => {
   const [useBackend, setUseBackend] = useState<boolean>(false);
 
   const updateMetricsMetadata = useCallback(async () => {
-    // *** Loading Gif?
+    // *** Loading Gif
+    setIsLoading(true);
     // Makes sure we loaded the metadata for metrics. Usually this is done in the start() method of the provider but we
     // don't use it with the visual builder and there is no need to run all the start() setup anyway.
     if (!datasource.languageProvider.metricsMetadata) {
@@ -165,6 +169,8 @@ export const MetricEncyclopediaModal = (props: Props) => {
         };
       })
     );
+
+    setIsLoading(false);
   }, [query, datasource]);
 
   useEffect(() => {
@@ -317,6 +323,7 @@ export const MetricEncyclopediaModal = (props: Props) => {
         });
 
         setMetrics(metrics);
+        setIsLoading(false);
       }, 300),
     [datasource, query.labels]
   );
@@ -332,6 +339,11 @@ export const MetricEncyclopediaModal = (props: Props) => {
       <div className={styles.spacing}>
         Browse {metrics.length} metric{metrics.length > 1 ? 's' : ''} by text, by type, alphabetically or select a
         variable.
+        {isLoading && (
+          <div className={styles.inlineSpinner}>
+            <Spinner></Spinner>
+          </div>
+        )}
       </div>
       {query.labels.length > 0 && (
         <div className={styles.spacing}>
@@ -351,6 +363,7 @@ export const MetricEncyclopediaModal = (props: Props) => {
               // get all metrics data if a user erases everything in the input
               updateMetricsMetadata();
             } else if (useBackend) {
+              setIsLoading(true);
               debouncedBackendSearch(value);
             } else {
               // do the search on the frontend
@@ -701,6 +714,9 @@ const getStyles = (theme: GrafanaTheme2) => {
     `,
     labelColor: css`
       color: #6e9fff;
+    `,
+    inlineSpinner: css`
+      display: inline-block;
     `,
   };
 };

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.tsx
@@ -92,6 +92,7 @@ export const MetricEncyclopediaModal = (props: Props) => {
 
   // metric list
   const [metrics, setMetrics] = useState<MetricsData>([]);
+  const [hasMetadata, setHasMetadata] = useState<boolean>(true);
   const [haystack, setHaystack] = useState<string[]>([]);
   const [nameHaystack, setNameHaystack] = useState<string[]>([]);
   const [openTabs, setOpenTabs] = useState<string[]>([]);
@@ -122,6 +123,7 @@ export const MetricEncyclopediaModal = (props: Props) => {
     // *** Will have to handle metadata filtering if this happens
     // *** only display metrics fuzzy search, function filter and pagination
     if (!datasource.languageProvider.metricsMetadata) {
+      setHasMetadata(false);
       datasource.languageProvider.metricsMetadata = {};
     }
 
@@ -159,6 +161,7 @@ export const MetricEncyclopediaModal = (props: Props) => {
     setMetrics(metricsData);
     setHaystack(haystackData);
     setNameHaystack(haystackNameData);
+
     setVariables(
       datasource.getVariables().map((v) => {
         return {
@@ -305,7 +308,7 @@ export const MetricEncyclopediaModal = (props: Props) => {
       aria-label="Metric Encyclopedia"
     >
       <div className={styles.spacing}>
-        Search metrics by type, function, labels, alphabetically or select a variable.
+        Search {metrics.length} metrics by type, function, labels, alphabetically or select a variable.
       </div>
       <div className="gf-form">
         <InlineLabel width={10} className="query-keyword">
@@ -322,39 +325,45 @@ export const MetricEncyclopediaModal = (props: Props) => {
             setPageNum(1);
           }}
         />
-        <InlineField
-          label="Search all metadata"
-          className={styles.labelColor}
-          tooltip={<div>Include all metadata in fuzzy search</div>}
-        >
-          <InlineSwitch
-            showLabel={true}
-            value={fullMetaSearch}
-            onChange={() => {
-              setFullMetaSearch(!fullMetaSearch);
-              setPageNum(1);
-            }}
-          />
-        </InlineField>
+        {hasMetadata && (
+          <InlineField
+            label="Search all metadata"
+            className={styles.labelColor}
+            tooltip={<div>Include all metadata in fuzzy search</div>}
+          >
+            <InlineSwitch
+              showLabel={true}
+              value={fullMetaSearch}
+              onChange={() => {
+                setFullMetaSearch(!fullMetaSearch);
+                setPageNum(1);
+              }}
+            />
+          </InlineField>
+        )}
       </div>
       <div className="gf-form">
-        <InlineLabel htmlFor="my-select" width={10} className="query-keyword">
-          Type:
-        </InlineLabel>
-        <MultiSelect
-          data-testid={testIds.selectType}
-          inputId="my-select"
-          options={typeOptions}
-          value={selectedTypes}
-          placeholder="Select type"
-          onChange={(v) => {
-            // *** Filter by type
-            // *** always include metrics without metadata but label it as unknown type
-            // Consider tabs select instead of actual select or multi select
-            setSelectedTypes(v);
-            setPageNum(1);
-          }}
-        />
+        {hasMetadata && (
+          <>
+            <InlineLabel htmlFor="my-select" width={10} className="query-keyword">
+              Type:
+            </InlineLabel>
+            <MultiSelect
+              data-testid={testIds.selectType}
+              inputId="my-select"
+              options={typeOptions}
+              value={selectedTypes}
+              placeholder="Select type"
+              onChange={(v) => {
+                // *** Filter by type
+                // *** always include metrics without metadata but label it as unknown type
+                // Consider tabs select instead of actual select or multi select
+                setSelectedTypes(v);
+                setPageNum(1);
+              }}
+            />
+          </>
+        )}
 
         <InlineLabel width={10} className="query-keyword">
           Functions:
@@ -422,20 +431,22 @@ export const MetricEncyclopediaModal = (props: Props) => {
             onClose();
           }}
         />
-        <InlineField
-          label="Exclude null metadata"
-          className={styles.labelColor}
-          tooltip={<div>Exclude all metrics with no metadata when filtering</div>}
-        >
-          <InlineSwitch
-            showLabel={true}
-            value={excludeNullMetadata}
-            onChange={() => {
-              setExcludeNullMetadata(!excludeNullMetadata);
-              setPageNum(1);
-            }}
-          />
-        </InlineField>
+        {hasMetadata && (
+          <InlineField
+            label="Exclude null metadata"
+            className={styles.labelColor}
+            tooltip={<div>Exclude all metrics with no metadata when filtering</div>}
+          >
+            <InlineSwitch
+              showLabel={true}
+              value={excludeNullMetadata}
+              onChange={() => {
+                setExcludeNullMetadata(!excludeNullMetadata);
+                setPageNum(1);
+              }}
+            />
+          </InlineField>
+        )}
       </div>
 
       <div className={styles.center}>

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.tsx
@@ -359,7 +359,6 @@ export const MetricEncyclopediaModal = (props: Props) => {
           autoFocus
           onInput={(e) => {
             const value = e.currentTarget.value ?? '';
-
             setFuzzySearchQuery(value);
 
             if (useBackend && value === '') {

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.tsx
@@ -82,6 +82,15 @@ const promTypes: PromFilterOption[] = [
   },
 ];
 
+const tooltips = {
+  search: 'Filter metric names by text',
+  metadataSearchSwicth: 'Include all metadata in search by text',
+  type: 'Prometheus supports four types of metrics, they are - Counter - Gauge - Histogram - Summary',
+  functions: 'These are suggested functions for metrics based on type and name',
+  variables: 'Select a predefined Grafana template variable for your metric',
+  excludeNoMetadata: 'Exclude all metrics with no metadata when filtering',
+};
+
 export const DEFAULT_RESULTS_PER_PAGE = 10;
 
 export const MetricEncyclopediaModal = (props: Props) => {
@@ -304,7 +313,7 @@ export const MetricEncyclopediaModal = (props: Props) => {
     <Modal
       data-testid={testIds.metricModal}
       isOpen={isOpen}
-      title="Select Metric"
+      title="Metric Encyclopedia"
       onDismiss={onClose}
       aria-label="Metric Encyclopedia"
     >
@@ -314,11 +323,11 @@ export const MetricEncyclopediaModal = (props: Props) => {
       </div>
       {query.labels.length > 0 && (
         <div className={styles.spacing}>
-          <i>These metrics have been prefiltered by labels chosen in the label filter</i>
+          <i>These metrics have been pre-filtered by labels chosen in the label filter</i>
         </div>
       )}
       <div className="gf-form">
-        <InlineLabel width={10} className="query-keyword">
+        <InlineLabel width={15} className="query-keyword" tooltip={<div>{tooltips.search}</div>}>
           Search
         </InlineLabel>
         <Input
@@ -336,7 +345,7 @@ export const MetricEncyclopediaModal = (props: Props) => {
           <InlineField
             label="Search all metadata"
             className={styles.labelColor}
-            tooltip={<div>Include all metadata in fuzzy search</div>}
+            tooltip={<div>{tooltips.metadataSearchSwicth}</div>}
           >
             <InlineSwitch
               showLabel={true}
@@ -352,8 +361,8 @@ export const MetricEncyclopediaModal = (props: Props) => {
       <div className="gf-form">
         {hasMetadata && (
           <>
-            <InlineLabel htmlFor="my-select" width={10} className="query-keyword">
-              Type:
+            <InlineLabel htmlFor="my-select" width={15} className="query-keyword" tooltip={<div>{tooltips.type}</div>}>
+              Type
             </InlineLabel>
             <MultiSelect
               data-testid={testIds.selectType}
@@ -372,8 +381,8 @@ export const MetricEncyclopediaModal = (props: Props) => {
           </>
         )}
 
-        <InlineLabel width={10} className="query-keyword">
-          Functions:
+        <InlineLabel width={15} className="query-keyword" tooltip={<div>{tooltips.functions}</div>}>
+          Functions
         </InlineLabel>
         <MultiSelect
           data-testid={testIds.searchFunction}
@@ -389,7 +398,7 @@ export const MetricEncyclopediaModal = (props: Props) => {
         />
       </div>
       <div className="gf-form">
-        <InlineLabel width={10} className="query-keyword">
+        <InlineLabel width={15} className="query-keyword">
           Page
         </InlineLabel>
         <Select
@@ -404,7 +413,7 @@ export const MetricEncyclopediaModal = (props: Props) => {
             setPageNum(value);
           }}
         />
-        <InlineLabel width={10} className="query-keyword">
+        <InlineLabel width={15} className="query-keyword">
           # per page
         </InlineLabel>
         <Input
@@ -423,7 +432,7 @@ export const MetricEncyclopediaModal = (props: Props) => {
         />
       </div>
       <div className="gf-form">
-        <InlineLabel width={10} className="query-keyword">
+        <InlineLabel width={15} className="query-keyword" tooltip={<div>{tooltips.variables}</div>}>
           Variables
         </InlineLabel>
         <Select
@@ -431,7 +440,7 @@ export const MetricEncyclopediaModal = (props: Props) => {
           inputId="my-select"
           options={variables}
           value={''}
-          placeholder="Select variable"
+          placeholder="Select a template variable"
           onChange={(v) => {
             const value: string = v.value ?? '';
             onChange({ ...query, metric: value });
@@ -442,7 +451,7 @@ export const MetricEncyclopediaModal = (props: Props) => {
           <InlineField
             label="Exclude null metadata"
             className={styles.labelColor}
-            tooltip={<div>Exclude all metrics with no metadata when filtering</div>}
+            tooltip={<div>{tooltips.excludeNoMetadata}</div>}
           >
             <InlineSwitch
               showLabel={true}

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.tsx
@@ -311,6 +311,11 @@ export const MetricEncyclopediaModal = (props: Props) => {
       <div className={styles.spacing}>
         Search {metrics.length} metrics by type, function, labels, alphabetically or select a variable.
       </div>
+      {query.labels.length > 0 && (
+        <div className={styles.spacing}>
+          <i>These metrics have been prefiltered by labels chosen in the label filter</i>
+        </div>
+      )}
       <div className="gf-form">
         <InlineLabel width={10} className="query-keyword">
           Search

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.tsx
@@ -116,6 +116,7 @@ export const MetricEncyclopediaModal = (props: Props) => {
   const updateMetricsMetadata = useCallback(async () => {
     // *** Loading Gif
     setIsLoading(true);
+
     // Makes sure we loaded the metadata for metrics. Usually this is done in the start() method of the provider but we
     // don't use it with the visual builder and there is no need to run all the start() setup anyway.
     if (!datasource.languageProvider.metricsMetadata) {
@@ -355,6 +356,7 @@ export const MetricEncyclopediaModal = (props: Props) => {
           data-testid={testIds.searchMetric}
           placeholder={placeholders.browse}
           value={fuzzySearchQuery}
+          autoFocus
           onInput={(e) => {
             const value = e.currentTarget.value ?? '';
             setFuzzySearchQuery(value);

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.tsx
@@ -83,7 +83,7 @@ const promTypes: PromFilterOption[] = [
 ];
 
 const tooltips = {
-  search: 'Filter metric names by text',
+  browse: 'Filter metric names by text',
   metadataSearchSwicth: 'Include all metadata in search by text',
   type: 'Prometheus supports four types of metrics, they are - Counter - Gauge - Histogram - Summary',
   functions: 'These are suggested functions for metrics based on type and name',
@@ -318,7 +318,7 @@ export const MetricEncyclopediaModal = (props: Props) => {
       aria-label="Metric Encyclopedia"
     >
       <div className={styles.spacing}>
-        Search {metrics.length} metric{metrics.length > 1 ? 's' : ''} by type, function, labels, alphabetically or
+        Browse {metrics.length} metric{metrics.length > 1 ? 's' : ''} by type, function, labels, alphabetically or
         select a variable.
       </div>
       {query.labels.length > 0 && (
@@ -327,12 +327,12 @@ export const MetricEncyclopediaModal = (props: Props) => {
         </div>
       )}
       <div className="gf-form">
-        <InlineLabel width={15} className="query-keyword" tooltip={<div>{tooltips.search}</div>}>
-          Search
+        <InlineLabel width={15} className="query-keyword" tooltip={<div>{tooltips.browse}</div>}>
+          Browse
         </InlineLabel>
         <Input
           data-testid={testIds.searchMetric}
-          placeholder="Search metric text"
+          placeholder="Browse by metric text"
           value={fuzzySearchQuery}
           onInput={(e) => {
             const value = e.currentTarget.value ?? '';
@@ -343,7 +343,7 @@ export const MetricEncyclopediaModal = (props: Props) => {
         />
         {hasMetadata && (
           <InlineField
-            label="Search all metadata"
+            label="Browse all metadata"
             className={styles.labelColor}
             tooltip={<div>{tooltips.metadataSearchSwicth}</div>}
           >

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.tsx
@@ -360,7 +360,6 @@ export const MetricEncyclopediaModal = (props: Props) => {
           onInput={(e) => {
             const value = e.currentTarget.value ?? '';
             setFuzzySearchQuery(value);
-
             if (useBackend && value === '') {
               // get all metrics data if a user erases everything in the input
               updateMetricsMetadata();

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.tsx
@@ -189,8 +189,9 @@ export const MetricEncyclopediaModal = (props: Props) => {
                   <Card.Description>
                     {metric.description && metric.type ? (
                       <>
-                        <div className={styles.rawQueryContainer}>Description: {metric.description}</div>
-                        <div className={styles.rawQueryContainer}>Type: {metric.type}</div>
+                        Type: <i>{metric.type}</i>
+                        <br />
+                        Description: <i>{metric.description}</i>
                       </>
                     ) : (
                       <i>No metadata available</i>
@@ -238,7 +239,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       padding: 10px;
     `,
     card: css`
-      width: 49.5%;
+      width: 100%;
       display: flex;
       flex-direction: column;
     `,

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilder.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilder.tsx
@@ -8,7 +8,6 @@ import { Input } from '@grafana/ui';
 import { PrometheusDatasource } from '../../datasource';
 import { getMetadataString } from '../../language_provider';
 import promqlGrammar from '../../promql';
-import { MetricEncyclopediaModal } from '../MetricEncyclopediaModal';
 import { promQueryModeller } from '../PromQueryModeller';
 import { buildVisualQueryFromString } from '../parsing';
 import { OperationExplainedBox } from '../shared/OperationExplainedBox';
@@ -22,6 +21,7 @@ import { QueryBuilderLabelFilter, QueryBuilderOperation } from '../shared/types'
 import { PromVisualQuery } from '../types';
 
 import { LabelFilters } from './LabelFilters';
+import { MetricEncyclopediaModal } from './MetricEncyclopediaModal';
 import { MetricSelect, PROMETHEUS_QUERY_BUILDER_MAX_RESULTS } from './MetricSelect';
 import { NestedQueryList } from './NestedQueryList';
 import { EXPLAIN_LABEL_FILTER_CONTENT } from './PromQueryBuilderExplained';

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilder.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilder.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useState } from 'react';
 import { DataSourceApi, PanelData, SelectableValue } from '@grafana/data';
 import { EditorField, EditorFieldGroup, EditorRow } from '@grafana/experimental';
 import { config } from '@grafana/runtime';
-import { Button, Input } from '@grafana/ui';
+import { Input } from '@grafana/ui';
 
 import { PrometheusDatasource } from '../../datasource';
 import { getMetadataString } from '../../language_provider';

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilder.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilder.tsx
@@ -231,10 +231,7 @@ export const PromQueryBuilder = React.memo<Props>((props) => {
                   onChange({ ...query, metric: '' });
                 }}
                 title="Click to remove metric"
-                className={css({
-                  margin: '10px 0 10px 0',
-                  backgroundColor: '#3D71D9',
-                })}
+                className={styles.metricTag}
               />
             )}
             {metricEncyclopediaModalOpen && (
@@ -356,6 +353,10 @@ const getStyles = (theme: GrafanaTheme2) => {
   return {
     button: css`
       height: auto;
+    `,
+    metricTag: css`
+      margin: '10px 0 10px 0',
+      backgroundColor: '#3D71D9',
     `,
   };
 };

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilder.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilder.tsx
@@ -207,7 +207,7 @@ export const PromQueryBuilder = React.memo<Props>((props) => {
 
   const lang = { grammar: promqlGrammar, name: 'promql' };
   const MetricEncyclopedia = config.featureToggles.prometheusMetricEncyclopedia;
-  // debugger
+
   return (
     <>
       <EditorRow>

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilder.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilder.tsx
@@ -1,9 +1,10 @@
+import { css } from '@emotion/css';
 import React, { useCallback, useState } from 'react';
 
-import { DataSourceApi, PanelData, SelectableValue } from '@grafana/data';
-import { EditorField, EditorFieldGroup, EditorRow } from '@grafana/experimental';
+import { DataSourceApi, GrafanaTheme2, PanelData, SelectableValue } from '@grafana/data';
+import { EditorRow } from '@grafana/experimental';
 import { config } from '@grafana/runtime';
-import { Input } from '@grafana/ui';
+import { Button, Tag, useStyles2 } from '@grafana/ui';
 
 import { PrometheusDatasource } from '../../datasource';
 import { getMetadataString } from '../../language_provider';
@@ -43,6 +44,7 @@ export const PromQueryBuilder = React.memo<Props>((props) => {
     onChange({ ...query, labels });
   };
 
+  const styles = useStyles2(getStyles);
   /**
    * Map metric metadata to SelectableValue for Select component and also adds defined template variables to the list.
    */
@@ -213,15 +215,28 @@ export const PromQueryBuilder = React.memo<Props>((props) => {
       <EditorRow>
         {MetricEncyclopedia ? (
           <>
-            <EditorFieldGroup>
-              <EditorField label="Metric">
-                <Input
-                  value={query.metric}
-                  placeholder="Select metric"
-                  onClick={() => setMetricEncyclopediaModalOpen((prevValue) => !prevValue)}
-                />
-              </EditorField>
-            </EditorFieldGroup>
+            <Button
+              className={styles.button}
+              variant="secondary"
+              size="sm"
+              onClick={() => setMetricEncyclopediaModalOpen((prevValue) => !prevValue)}
+            >
+              Metric Encyclopedia
+            </Button>
+            {query.metric && (
+              <Tag
+                name={query.metric}
+                color="#3D71D9"
+                onClick={() => {
+                  onChange({ ...query, metric: '' });
+                }}
+                title="Click to remove metric"
+                className={css({
+                  margin: '10px 0 10px 0',
+                  backgroundColor: '#3D71D9',
+                })}
+              />
+            )}
             <MetricEncyclopediaModal
               datasource={datasource}
               isOpen={metricEncyclopediaModalOpen}
@@ -334,3 +349,11 @@ async function getMetrics(
 }
 
 PromQueryBuilder.displayName = 'PromQueryBuilder';
+
+const getStyles = (theme: GrafanaTheme2) => {
+  return {
+    button: css`
+      height: auto;
+    `,
+  };
+};

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilder.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilder.tsx
@@ -237,13 +237,15 @@ export const PromQueryBuilder = React.memo<Props>((props) => {
                 })}
               />
             )}
-            <MetricEncyclopediaModal
-              datasource={datasource}
-              isOpen={metricEncyclopediaModalOpen}
-              onClose={() => setMetricEncyclopediaModalOpen(false)}
-              query={query}
-              onChange={onChange}
-            />
+            {metricEncyclopediaModalOpen && (
+              <MetricEncyclopediaModal
+                datasource={datasource}
+                isOpen={metricEncyclopediaModalOpen}
+                onClose={() => setMetricEncyclopediaModalOpen(false)}
+                query={query}
+                onChange={onChange}
+              />
+            )}
           </>
         ) : (
           <MetricSelect


### PR DESCRIPTION
[This work is part of Grafana 10 Getting Started: Prometheus Part II](https://github.com/grafana/grafana/issues/62978)

**What is this feature?**
This feature adds a new way of exploring and selecting a metric in the Prometheus query builder (not implemented for the code editor). This is a modal that displays paginated and filterable metrics with metadata. A fuzzy search can be used to select text in metric metadata. Users can filter by type and functions associated with the metric.
<img width="1337" alt="Screenshot 2023-03-07 at 1 30 51 PM" src="https://user-images.githubusercontent.com/25674746/223516846-e6a39f6c-5dff-4e9c-b072-c4d34bfff6c9.png">

1. Enter text to search metric names.
2. Switch on "Search all metadata" to fuzzy search by name, type, description, and suggested functions.
3. Switch to backend search for instances with millions of series, removes filtering by type
<img width="680" alt="Screenshot 2023-03-07 at 1 30 01 PM" src="https://user-images.githubusercontent.com/25674746/223516990-a963d8dc-6afa-494d-9304-7d9ca1763e28.png">

5. Select types(counter, gauge, histogram, summary) to filter.
~~6. Select suggested functions based on metric names and metadata (similar to query_hints).~~
7. Display metrics by page.
8. Set # metrics per page.
9. Select any template variables.
10. Exclude metrics that are missing metadata.
11. Click the alphabet search to search by first letter.
12. Choose labels from the label filters to filter metrics.
<img width="545" alt="Screenshot 2023-03-07 at 1 34 49 PM" src="https://user-images.githubusercontent.com/25674746/223517663-44896f5d-3c6d-4956-9c01-9e4d484f4456.png">
<img width="1220" alt="Screenshot 2023-03-07 at 1 34 13 PM" src="https://user-images.githubusercontent.com/25674746/223517586-29e57688-5d67-419e-90eb-208bb94dc7d4.png">




**Why do we need this feature?**
The G10 Getting Started: Prometheus research uncovered a need for beginning users to be able to explore their metrics in a meaningful way. This paginated modal also solves the issue of displaying millions of metrics in the frontend.

**Who is this feature for?**
This feature is for beginning Prom users, intermediate users, users of the Prom query builder, and customers with millions of metrics.

### Tasks

#### Testing/Validation
- [x] Feature Tracking (rudderstack event) and testing
- [ ] Merge to main under feature flag
  - [ ] deploy to metrics grafana instance 
  - [ ] Monitor with instrumentation
- [ ] User Interviews

#### Implementation
- [x] Implement Feature toggle 
- [x] Create modal
- [x] Load metrics and metadata
- [x] Select a metric and apply to query
- [x] Allow user to select template variables
- [x] Paginate
  - [x] slice metrics 
  - [x] page select or page number buttons 
  - [x] include alphabetical pagination navigation (A|B|...|Z)
  - [x] user selects # metrics displayed per page
- [x] Filter by type
- [x] Filter by function
- [ ] _On hold_ Filter by labels
  - [ ] implement label select in the encyclopedia? 
  - [x] when user selects filters outside of encyclopedia, metrics are filtered 
- [x] Filter by fuzzy search
- [x] Test with millions of metrics
  - [x] Give users the choice to search on the backend  
  - [x] generating 1,000,000 metrics in the browser it's slow but hasn't broken yet
  - [x] unit tests
  - [X] testing with dev-cortex with 14,000,000+ active series
<img width="486" alt="Screenshot 2023-03-04 at 9 32 32 PM" src="https://user-images.githubusercontent.com/25674746/222938466-208c5f89-3e69-4d1f-a459-22baa1810339.png">

- [x] Fix issue with metrics that are missing metadata
  - [x] display missing metadata
  - [x] include with other metrics filters on type/function as additional unknown
  - [x] if no metadata at all, only display metrics fuzzy search, function filter and pagination 
- [x] Add tests
  - [x] display modal
  - [x] display metrics
  - [x] display type
  - [x] display description
  - [x] pagination
  - [x] filter when query has labels
  - [x] filtering by function
  - [x] filter by type
  - [x] filter with fuzzy search by names
  - [x] filter by fuzzy search by all metadata 
