### PR TITLE
Geomap: Fix default opacity for layers

### DIFF
--- a/public/app/plugins/panel/geomap/layers/data/dayNightLayer.tsx
+++ b/public/app/plugins/panel/geomap/layers/data/dayNightLayer.tsx
@@ -102,7 +102,7 @@ export const dayNightLayer: MapLayerRegistryItem<DayNightConfig> = {
         })
       }),
     });
-    
+
     // Sun circle
     const sunFeature = new Feature({
       geometry: new Point([]),

--- a/public/app/plugins/panel/geomap/utils/actions.ts
+++ b/public/app/plugins/panel/geomap/utils/actions.ts
@@ -4,6 +4,7 @@ import { FrameGeometrySourceMode } from '@grafana/schema';
 
 import { GeomapPanel } from '../GeomapPanel';
 import { geomapLayerRegistry } from '../layers/registry';
+import { defaultStyleConfig } from '../style/types';
 import { GeomapLayerActions, MapLayerState } from '../types';
 
 import { initLayer } from './layers';
@@ -51,6 +52,7 @@ export const getActions = (panel: GeomapPanel) => {
           config: cloneDeep(item.defaultOptions),
           location: item.showLocation ? { mode: FrameGeometrySourceMode.Auto } : undefined,
           tooltip: true,
+          ...(!item.hideOpacity && { opacity: defaultStyleConfig.opacity }),
         },
         false
       ).then((lyr) => {


### PR DESCRIPTION
Added default opacity to `initLayer` options from `defaultStyleConfig`. The issues was happening for all the layers with opacity.

Before:

https://user-images.githubusercontent.com/88068998/220030373-f98c11ac-168d-4c16-b13d-e43f8b5fe782.mov

After:

https://user-images.githubusercontent.com/88068998/220030444-368cc958-9210-4fa9-a0e5-1d05f4825a3f.mov


Fixes: #63334 
