### PR TITLE
Alerting: Change Data to use Labels instead of map[string]string

### DIFF
--- a/pkg/services/ngalert/state/template/template.go
+++ b/pkg/services/ngalert/state/template/template.go
@@ -70,7 +70,7 @@ func NewValues(caps map[string]eval.NumberValueCapture) map[string]Value {
 }
 
 type Data struct {
-	Labels map[string]string
+	Labels Labels
 	Values map[string]Value
 	Value  string
 }


### PR DESCRIPTION
**What is this feature?**

This commit changes the Data struct in template.go to use `Labels` instead of `map[string]string`. It changes how labels are printed when using `{{ .Labels }}` from `map[foo:bar bar:baz]` to `foo=bar, bar=baz`.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #63349

**Special notes for your reviewer**:

