### PR TITLE
Geomap: Release night / day layer

### DIFF
--- a/docs/sources/panels-visualizations/visualizations/geomap/index.md
+++ b/docs/sources/panels-visualizations/visualizations/geomap/index.md
@@ -82,7 +82,7 @@ There are three map layer types to choose from in the Geomap visualization.
 
 There are also five alpha layer types.
 
-- [Night / Day (alpha)]({{< relref "#night--day-layer-alpha" >}}) renders a night / day region.
+- [Night / Day layer]({{< relref "#night--day-layer" >}}) renders a night / day region.
 - **Icon at last point (alpha)** renders an icon at the last data point.
 - **Dynamic GeoJSON (alpha)** styles a GeoJSON file based on query results.
 - **Route (alpha)** render data points as a route.
@@ -332,7 +332,7 @@ An ArcGIS layer is a layer from an ESRI ArcGIS MapServer.
 - [**ArcGIS Services**](https://services.arcgisonline.com/arcgis/rest/services)
 - [**About ESRI**](https://www.esri.com/en-us/about/about-esri/overview)
 
-## Night / Day layer (Alpha)
+## Night / Day layer
 
 The Night / Day layer displays night and day regions based on the current time range.
 

--- a/public/app/plugins/panel/geomap/layers/data/dayNightLayer.tsx
+++ b/public/app/plugins/panel/geomap/layers/data/dayNightLayer.tsx
@@ -6,7 +6,6 @@ import {
   EventBus,
   DataHoverEvent,
   DataHoverClearEvent,
-  PluginState,
 } from '@grafana/data';
 import Map from 'ol/Map';
 import VectorLayer from 'ol/layer/Vector';
@@ -58,7 +57,6 @@ export const dayNightLayer: MapLayerRegistryItem<DayNightConfig> = {
   name: 'Night / Day',
   description: 'Show day and night regions',
   isBaseMap: false,
-  state: PluginState.alpha,
 
   /**
    * Function that configures transformation and returns a transformer
@@ -102,7 +100,7 @@ export const dayNightLayer: MapLayerRegistryItem<DayNightConfig> = {
         })
       }),
     });
-    
+
     // Sun circle
     const sunFeature = new Feature({
       geometry: new Point([]),


### PR DESCRIPTION
- Removed the alpha state for Nigh/Day layer
- Removed alpha references from docs

Fixes #63427 


