### PR TITLE
Loki: query splitting: handle stats

### DIFF
--- a/public/app/plugins/datasource/loki/mocks.ts
+++ b/public/app/plugins/datasource/loki/mocks.ts
@@ -150,6 +150,12 @@ export function getMockFrames() {
         values: new ArrayVector(['id1', 'id2']),
       },
     ],
+    meta: {
+      stats: [
+        { displayName: 'Summary: total bytes processed', value: 11 },
+        { displayName: 'Ingester: total reached', value: 1 },
+      ],
+    },
     length: 2,
   };
 
@@ -192,7 +198,10 @@ export function getMockFrames() {
       },
     ],
     meta: {
-      stats: [{ displayName: 'Ingester: total reached', value: 1 }],
+      stats: [
+        { displayName: 'Summary: total bytes processed', value: 22 },
+        { displayName: 'Ingester: total reached', value: 2 },
+      ],
     },
     length: 2,
   };
@@ -214,7 +223,10 @@ export function getMockFrames() {
       },
     ],
     meta: {
-      stats: [{ displayName: 'Ingester: total reached', value: 1 }],
+      stats: [
+        { displayName: 'Ingester: total reached', value: 1 },
+        { displayName: 'Summary: total bytes processed', value: 11 },
+      ],
     },
     length: 2,
   };
@@ -236,7 +248,10 @@ export function getMockFrames() {
       },
     ],
     meta: {
-      stats: [{ displayName: 'Ingester: total reached', value: 2 }],
+      stats: [
+        { displayName: 'Ingester: total reached', value: 2 },
+        { displayName: 'Summary: total bytes processed', value: 22 },
+      ],
     },
     length: 2,
   };
@@ -259,7 +274,10 @@ export function getMockFrames() {
       },
     ],
     meta: {
-      stats: [{ displayName: 'Ingester: total reached', value: 2 }],
+      stats: [
+        { displayName: 'Ingester: total reached', value: 2 },
+        { displayName: 'Summary: total bytes processed', value: 33 },
+      ],
     },
     length: 2,
   };

--- a/public/app/plugins/datasource/loki/queryUtils.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.ts
@@ -345,28 +345,33 @@ function combineFrames(dest: DataFrame, source: DataFrame) {
     );
   }
   dest.length += source.length;
-  combineMetadata(dest, source);
+  dest.meta = {
+    ...dest.meta,
+    stats: getCombinedMetadataStats(dest.meta?.stats ?? [], source.meta?.stats ?? []),
+  };
 }
 
-function combineMetadata(dest: DataFrame, source: DataFrame) {
-  if (!source.meta?.stats) {
-    return;
+const TOTAL_BYTES_STAT = 'Summary: total bytes processed';
+
+function getCombinedMetadataStats(
+  destStats: QueryResultMetaStat[],
+  sourceStats: QueryResultMetaStat[]
+): QueryResultMetaStat[] {
+  // in the current approach, we only handle a single stat
+  const destStat = destStats.find((s) => s.displayName === TOTAL_BYTES_STAT);
+  const sourceStat = sourceStats.find((s) => s.displayName === TOTAL_BYTES_STAT);
+
+  if (sourceStat != null && destStat != null) {
+    return [{ value: sourceStat.value + destStat.value, displayName: TOTAL_BYTES_STAT }];
   }
-  if (!dest.meta?.stats) {
-    if (!dest.meta) {
-      dest.meta = {};
-    }
-    Object.assign(dest.meta, { stats: source.meta.stats });
-    return;
+
+  // maybe one of them exist
+  const eitherStat = sourceStat ?? destStat;
+  if (eitherStat != null) {
+    return [eitherStat];
   }
-  dest.meta.stats.forEach((destStat: QueryResultMetaStat, i: number) => {
-    const sourceStat = source.meta?.stats?.find(
-      (sourceStat: QueryResultMetaStat) => destStat.displayName === sourceStat.displayName
-    );
-    if (sourceStat) {
-      destStat.value += sourceStat.value;
-    }
-  });
+
+  return [];
 }
 
 /**


### PR DESCRIPTION
when combining multiple chunks of dataframes in the loki-query-split scenario, we need to handle the `stats` arriving for every chunk.

these stats are shown at two places:
1. in the logs panel we show the `Total bytes processed:` at the top
2. in the query-inspector's `Stats` section.

this PR correctly updates the `Total bytes processed` value, and removes every other value.

the reason is, there's no generic way to "merge" stats (for example, how do you merge `bytes processed per second` values), so for now we make sure the most important value is correct, and we can add more values, if it becomes necessary.

(i added a note about possible long-term steps about this to https://github.com/grafana/grafana/issues/63174)

how to test:
1. make a logs request using loki so that chunking will happen
2. verify that the value shown at the top of the logs-panel keeps changing
3. verify that the query-inspector only shows the single total-bytes-processed value in the stats section.