### PR TITLE
Bug: Fix support for Node 18 in grafana/e2e package

### DIFF
--- a/packages/grafana-e2e/cli.js
+++ b/packages/grafana-e2e/cli.js
@@ -1,7 +1,7 @@
 const { program } = require('commander');
 const execa = require('execa');
 const { resolve, sep } = require('path');
-const resolveBin = require('resolve-as-bin');
+const resolveBin = require('resolve-bin');
 
 const cypress = (commandName, { updateScreenshots, browser }) => {
   // Support running an unpublished dev build
@@ -25,7 +25,7 @@ const cypress = (commandName, { updateScreenshots, browser }) => {
     stdio: 'inherit',
   };
 
-  return execa(resolveBin('cypress'), cypressOptions, execaOptions)
+  return execa(resolveBin.sync('cypress'), cypressOptions, execaOptions)
     .then(() => {}) // no return value
     .catch((error) => {
       console.error(error.message);

--- a/packages/grafana-e2e/package.json
+++ b/packages/grafana-e2e/package.json
@@ -76,7 +76,7 @@
     "execa": "5.1.1",
     "lodash": "4.17.21",
     "mocha": "10.2.0",
-    "resolve-as-bin": "2.1.0",
+    "resolve-bin": "1.0.1",
     "rimraf": "4.2.0",
     "tracelib": "1.0.1",
     "ts-loader": "8.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4981,7 +4981,7 @@ __metadata:
     execa: 5.1.1
     lodash: 4.17.21
     mocha: 10.2.0
-    resolve-as-bin: 2.1.0
+    resolve-bin: 1.0.1
     rimraf: 4.2.0
     rollup: 2.79.1
     rollup-plugin-dts: ^5.0.0
@@ -16866,7 +16866,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-spawn@npm:^6.0.0, cross-spawn@npm:^6.0.5":
+"cross-spawn@npm:^6.0.0":
   version: 6.0.5
   resolution: "cross-spawn@npm:6.0.5"
   dependencies:
@@ -20925,6 +20925,13 @@ __metadata:
     make-dir: ^3.0.2
     pkg-dir: ^4.1.0
   checksum: 1e61c2e64f5c0b1c535bd85939ae73b0e5773142713273818cc0b393ee3555fb0fd44e1a5b161b8b6c3e03e98c2fcc9c227d784850a13a90a8ab576869576817
+  languageName: node
+  linkType: hard
+
+"find-parent-dir@npm:~0.3.0":
+  version: 0.3.1
+  resolution: "find-parent-dir@npm:0.3.1"
+  checksum: 55e722584760cfbc6611901c7ced5081345cf629e2ecd6a4f6704b13b5a1876c8d9d9db5fd4965ba23e1ecbc24a8b62af40379cfef1ffa0231719b9d924eebdd
   languageName: node
   linkType: hard
 
@@ -34255,12 +34262,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve-as-bin@npm:2.1.0":
-  version: 2.1.0
-  resolution: "resolve-as-bin@npm:2.1.0"
+"resolve-bin@npm:1.0.1":
+  version: 1.0.1
+  resolution: "resolve-bin@npm:1.0.1"
   dependencies:
-    cross-spawn: ^6.0.5
-  checksum: 38cbdc57d50162a6aabca34762932637e9926a5b28e313e2027aa54132fe9894d57a9df061596b4be684b0320ee7ba0aef4537bb3919ee6df753fdc4a8b38222
+    find-parent-dir: ~0.3.0
+  checksum: 439678433138cbea49b848be68ae24aa2afa1b3bb82c30fa763ebbc5615e8c340debfe635ee902cdbb4be72528e4139e2adb0503370ee755ad3702d03976af4c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Adds support for node LTS (node 18 / npm 9) to `@grafana/e2e` package.

**Why do we need this feature?**

So developers can continue to run e2e tests using the latest stable version of node.

**Who is this feature for?**

Developers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #59425

**Special notes for your reviewer**:
Tested locally using node 18 and 16 across the grafana-plugin-examples integration tests and this change appears to be working well. There are other ways to solve this (`npx` or `yarn resolve`) but I feel like this is less likely to cause trouble with current CI setups or `npx` caching packages.
