### PR TITLE
GrafanaUI: reset ConfirmModal disabled state on re-open

### DIFF
--- a/packages/grafana-ui/src/components/ConfirmModal/ConfirmModal.tsx
+++ b/packages/grafana-ui/src/components/ConfirmModal/ConfirmModal.tsx
@@ -77,6 +77,12 @@ export const ConfirmModal = ({
     }
   }, [isOpen]);
 
+  useEffect(() => {
+    if (isOpen) {
+      setDisabled(Boolean(confirmationText));
+    }
+  }, [isOpen, confirmationText]);
+
   return (
     <Modal className={cx(styles.modal, modalClass)} title={title} icon={icon} isOpen={isOpen} onDismiss={onDismiss}>
       <div className={styles.modalText}>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

It's a fix for an issue with how `ConfirmModal` and `confirmationText` work:
1. Open [the storybook example](https://developers.grafana.com/ui/latest/index.html?path=/story/overlays-confirmmodal--with-confirmation)
2. Type `Delete` in the text field - the `Delete` button will be enabled
3. Toggle `isOpen` to false and then back to true to close and re-open the modal
4. The text field will be empty, but the `Delete` button will still be enabled

**Why do we need this feature?**

When accidental deletion might be disastrous, we might want the deletion process to have the most friction. This fix ensures the same rule applies, regardless of whether the modal has been opened for the first time or re-opened for the nth time.

**Who is this feature for?**
All users of `@grafana/ui`

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

