### PR TITLE
elasticsearch: metrics rate and top_metrics do not need xpack

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/MetricEditor.test.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/MetricEditor.test.tsx
@@ -1,11 +1,11 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import React, { ReactNode, PropsWithChildren } from 'react';
+import React, { PropsWithChildren } from 'react';
 import { from } from 'rxjs';
 
 import { getDefaultTimeRange } from '@grafana/data';
 
 import { ElasticDatasource } from '../../../datasource';
-import { defaultBucketAgg, defaultMetricAgg } from '../../../queryDef';
+import { defaultBucketAgg } from '../../../queryDef';
 import { ElasticsearchQuery } from '../../../types';
 import { ElasticsearchProvider } from '../ElasticsearchQueryContext';
 
@@ -84,48 +84,5 @@ describe('Metric Editor', () => {
 
     expect(await screen.findByText('No options found')).toBeInTheDocument();
     expect(screen.queryByText('None')).not.toBeInTheDocument();
-  });
-
-  describe('Top Metrics Aggregation', () => {
-    const setupTopMetricsScreen = (xpack: boolean) => {
-      const query: ElasticsearchQuery = {
-        refId: 'A',
-        query: '',
-        metrics: [defaultMetricAgg('1')],
-        bucketAggs: [defaultBucketAgg('2')],
-      };
-
-      const getFields: ElasticDatasource['getFields'] = jest.fn(() => from([[]]));
-
-      const esVersion = '7.7.0';
-
-      const wrapper = ({ children }: { children?: ReactNode }) => (
-        <ElasticsearchProvider
-          datasource={{ getFields, esVersion, xpack } as ElasticDatasource}
-          query={query}
-          range={getDefaultTimeRange()}
-          onChange={() => {}}
-          onRunQuery={() => {}}
-        >
-          {children}
-        </ElasticsearchProvider>
-      );
-
-      render(<MetricEditor value={defaultMetricAgg('1')} />, { wrapper });
-
-      act(() => {
-        fireEvent.click(screen.getByText('Count'));
-      });
-    };
-
-    it('Should include top metrics aggregation when X-Pack is enabled', () => {
-      setupTopMetricsScreen(true);
-      expect(screen.getByText('Top Metrics')).toBeInTheDocument();
-    });
-
-    it('Should NOT include top metrics aggregation where X-Pack is disabled', () => {
-      setupTopMetricsScreen(false);
-      expect(screen.queryByText('Top Metrics')).toBe(null);
-    });
   });
 });

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/MetricEditor.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/MetricEditor.tsx
@@ -41,8 +41,7 @@ const isBasicAggregation = (metric: MetricAggregation) => !metricAggregationConf
 
 const getTypeOptions = (
   previousMetrics: MetricAggregation[],
-  esVersion: string,
-  xpack = false
+  esVersion: string
 ): Array<SelectableValue<MetricAggregationType>> => {
   // we'll include Pipeline Aggregations only if at least one previous metric is a "Basic" one
   const includePipelineAggregations = previousMetrics.some(isBasicAggregation);
@@ -53,8 +52,6 @@ const getTypeOptions = (
       .filter(([_, { versionRange = '*' }]) => satisfies(esVersion, versionRange))
       // Filtering out Pipeline Aggregations if there's no basic metric selected before
       .filter(([_, config]) => includePipelineAggregations || !config.isPipelineAgg)
-      // Filtering out X-Pack plugins if X-Pack is disabled
-      .filter(([_, config]) => (config.xpack ? xpack : true))
       .map(([key, { label }]) => ({
         label,
         value: key as MetricAggregationType,
@@ -90,7 +87,7 @@ export const MetricEditor = ({ value }: Props) => {
       <InlineSegmentGroup>
         <Segment
           className={cx(styles.color, segmentStyles)}
-          options={getTypeOptions(previousMetrics, datasource.esVersion, datasource.xpack)}
+          options={getTypeOptions(previousMetrics, datasource.esVersion)}
           onChange={(e) => dispatch(changeMetricType({ id: value.id, type: e.value! }))}
           value={toOption(value)}
         />

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/utils.ts
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/utils.ts
@@ -235,7 +235,6 @@ export const metricAggregationConfig: MetricsConfiguration = {
   },
   top_metrics: {
     label: 'Top Metrics',
-    xpack: true,
     requiresField: false,
     isPipelineAgg: false,
     supportsMissing: false,
@@ -251,7 +250,6 @@ export const metricAggregationConfig: MetricsConfiguration = {
   },
   rate: {
     label: 'Rate',
-    xpack: true,
     requiresField: true,
     isPipelineAgg: false,
     supportsMissing: false,

--- a/public/app/plugins/datasource/elasticsearch/types.ts
+++ b/public/app/plugins/datasource/elasticsearch/types.ts
@@ -123,7 +123,6 @@ interface MetricConfiguration<T extends MetricAggregationType> {
   supportsInlineScript: boolean;
   supportsMissing: boolean;
   isPipelineAgg: boolean;
-  xpack?: boolean;
   /**
    * A valid semver range for which the metric is known to be available.
    * If omitted defaults to '*'.


### PR DESCRIPTION
(part of https://github.com/grafana/grafana/issues/62201)

For elasticsearch 7.x (the versions we support) and 8.x, both `rate` and `top_metrics` work in the basic elasticsearch version, there's no need to show them conditionally.

in fact, the whole xpack thing may not be needed anymore ( see https://www.elastic.co/what-is/open-x-pack ).

how to test:
1. `make devenv sources=elastic`
    - note that this sets `xpack.license.self_generated.type=basic`, so we configure the elastic database to only offer the "basic" features.
2. try the above-mentioned two metrics, verify that they do not return an error
    - note that for `top_metrics` you will have to choose values for:
        - options/order_by => choose `@timestamp`
        - options/metrics => choose `counter`

NOTE: there is still some xpack-related code remaining, they will be removed un a later pull request.