### PR TITLE
elastic: remove most of xpack

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/configuration/ElasticDetails.tsx
+++ b/public/app/plugins/datasource/elasticsearch/configuration/ElasticDetails.tsx
@@ -122,23 +122,13 @@ export const ElasticDetails = ({ value, onChange }: Props) => {
           />
         </InlineField>
 
-        <InlineField label="X-Pack enabled" labelWidth={26}>
+        <InlineField label="Include Frozen Indices" labelWidth={26}>
           <InlineSwitch
-            id="es_config_xpackEnabled"
-            value={value.jsonData.xpack || false}
-            onChange={jsonDataSwitchChangeHandler('xpack', value, onChange)}
+            id="es_config_frozenIndices"
+            value={(value.jsonData.xpack ?? false) && (value.jsonData.includeFrozen ?? false)}
+            onChange={(event) => includeFrozenIndicesOnChange(event.currentTarget.checked, value, onChange)}
           />
         </InlineField>
-
-        {value.jsonData.xpack && (
-          <InlineField label="Include Frozen Indices" labelWidth={26}>
-            <InlineSwitch
-              id="es_config_frozenIndices"
-              value={value.jsonData.includeFrozen ?? false}
-              onChange={jsonDataSwitchChangeHandler('includeFrozen', value, onChange)}
-            />
-          </InlineField>
-        )}
       </FieldSet>
     </>
   );
@@ -167,17 +157,20 @@ const jsonDataChangeHandler =
     });
   };
 
-const jsonDataSwitchChangeHandler =
-  (key: keyof ElasticsearchOptions, value: Props['value'], onChange: Props['onChange']) =>
-  (event: React.SyntheticEvent<HTMLInputElement>) => {
-    onChange({
-      ...value,
-      jsonData: {
-        ...value.jsonData,
-        [key]: event.currentTarget.checked,
-      },
-    });
-  };
+const includeFrozenIndicesOnChange = (newValue: boolean, formValue: Props['value'], onChange: Props['onChange']) => {
+  const newJsonData = { ...formValue.jsonData };
+  if (newValue) {
+    newJsonData.xpack = true;
+    newJsonData.includeFrozen = true;
+  } else {
+    delete newJsonData.xpack;
+    delete newJsonData.includeFrozen;
+  }
+  onChange({
+    ...formValue,
+    jsonData: newJsonData,
+  });
+};
 
 const intervalHandler =
   (value: Props['value'], onChange: Props['onChange']) => (option: SelectableValue<Interval | 'none'>) => {


### PR DESCRIPTION
we do not need the `xpack` setting anymore in elasticsearch.
to remove it is slightly complex, so we are doing it iteratively.
this PR removes it from the datasource-config page, but keeps it in the json-database.

we need this to handle the corner-case where `xpack=false && includeFrozen=true` should mean `includeFrozen=false`.

- whenever you enable the includeFrozen-toggle, we set both `xpack`&`includeFrozen` to `true` in the JSON.
- whenever you disable the includeFrozen-toggle, we set both `xpack`&`includeFrozen` to `false` in the JSON (well, we delete them from the JSON to be exact)


how to test:
- note. to be sure things work ok, we will have to look into the contents of the database. so, assuming you are in the grafana folder, run this in a console:
    - `sqlite3 data/grafana.db`
        - inside run `select json_data from data_source where name="<elastic-datasource-name>";`
            - `<elastic-datasource-name>` is the name of your elastic datasource in grafana
        - this will show you the currently stored datasource-json
        - NOTE: turn off `sqlite3` after every this and start again to verify the state of the database
- let's do this:
- (every step in grafana happens on the elasticsearch datasource plugin's config page)
- first, while on main-branch (not on this PR's branch), do this in grafana:
    - enable xpack toggle
    - enable include-frozen toggle
    - disable xpack toggle
    - [save&test]
- verify with sqlite3 that `includeFrozen=true; xpack=false` in the JSON
- switch to this PR
- verify that xpack toggle is not visible in grafana
- verify that include-frozen toggle is OFF in grafana
- enable the include-frozen toggle in grafana
- [save&test]
- verify with sqlite3 that `includeFrozen=true; xpack=true`
- disable the include-frozen toggle in grafana
- [save&test]
- verify with sqlite3 that both `includeFrozen` and `xpack` are not in the JSON