### PR TITLE
Alerting: allow to change provenance to none through the provisioning update endpoint

### DIFF
--- a/pkg/services/ngalert/provisioning/alert_rules.go
+++ b/pkg/services/ngalert/provisioning/alert_rules.go
@@ -323,7 +323,9 @@ func (service *AlertRuleService) UpdateAlertRule(ctx context.Context, rule model
 	if err != nil {
 		return models.AlertRule{}, err
 	}
-	if storedProvenance != provenance && (storedProvenance == models.ProvenanceFile || storedProvenance == models.ProvenanceAPI && provenance == models.ProvenanceFile) {
+	isFileProvenance := storedProvenance == models.ProvenanceFile
+	isAPItoFileProvenance := storedProvenance == models.ProvenanceAPI && provenance == models.ProvenanceFile
+	if storedProvenance != provenance && (isFileProvenance || isAPItoFileProvenance) {
 		return models.AlertRule{}, fmt.Errorf("cannot changed provenance from '%s' to '%s'", storedProvenance, provenance)
 	}
 	rule.Updated = time.Now()

--- a/pkg/services/ngalert/provisioning/alert_rules.go
+++ b/pkg/services/ngalert/provisioning/alert_rules.go
@@ -315,16 +315,11 @@ func (service *AlertRuleService) ReplaceRuleGroup(ctx context.Context, orgID int
 	})
 }
 
-// CreateAlertRule creates a new alert rule. This function will ignore any
-// interval that is set in the rule struct and fetch the current group interval
-// from database.
+// UpdateAlertRule updates an alert rule.
 func (service *AlertRuleService) UpdateAlertRule(ctx context.Context, rule models.AlertRule, provenance models.Provenance) (models.AlertRule, error) {
-	storedRule, storedProvenance, err := service.GetAlertRule(ctx, rule.OrgID, rule.UID)
+	storedRule, _, err := service.GetAlertRule(ctx, rule.OrgID, rule.UID)
 	if err != nil {
 		return models.AlertRule{}, err
-	}
-	if storedProvenance != provenance && storedProvenance != models.ProvenanceNone {
-		return models.AlertRule{}, fmt.Errorf("cannot changed provenance from '%s' to '%s'", storedProvenance, provenance)
 	}
 	rule.Updated = time.Now()
 	rule.ID = storedRule.ID

--- a/pkg/services/ngalert/provisioning/alert_rules_test.go
+++ b/pkg/services/ngalert/provisioning/alert_rules_test.go
@@ -213,7 +213,7 @@ func TestAlertRuleService(t *testing.T) {
 				errNil: false,
 			},
 			{
-				name:   "should not be able to update from provenance api to none",
+				name:   "should be able to update from provenance api to none",
 				from:   models.ProvenanceAPI,
 				to:     models.ProvenanceNone,
 				errNil: true,

--- a/pkg/services/ngalert/provisioning/alert_rules_test.go
+++ b/pkg/services/ngalert/provisioning/alert_rules_test.go
@@ -216,7 +216,7 @@ func TestAlertRuleService(t *testing.T) {
 				name:   "should not be able to update from provenance api to none",
 				from:   models.ProvenanceAPI,
 				to:     models.ProvenanceNone,
-				errNil: false,
+				errNil: true,
 			},
 			{
 				name:   "should not be able to update from provenance file to api",


### PR DESCRIPTION
**What is this feature?**

Allow update alert rule provenance API to provenance None when `x-disable-provenance` header is set.

**Why do we need this feature?**

Currently, the alert rule update from provenance API to provenance None is not allowed.

**Who is this feature for?**

Provisioning Alerts API users.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/63047

