### PR TITLE
API: Fix status code when starring already starred dashboard

### DIFF
--- a/pkg/services/star/starimpl/sqlx_store_test.go
+++ b/pkg/services/star/starimpl/sqlx_store_test.go
@@ -11,6 +11,6 @@ func TestIntegrationSQLxUserStarsDataAccess(t *testing.T) {
 		t.Skip("skipping integration test")
 	}
 	testIntegrationUserStarsDataAccess(t, func(ss db.DB) store {
-		return &sqlxStore{sess: ss.GetSqlxSession()}
+		return &sqlxStore{sess: ss.GetSqlxSession(), db: ss}
 	})
 }

--- a/pkg/services/star/starimpl/star.go
+++ b/pkg/services/star/starimpl/star.go
@@ -18,6 +18,7 @@ func ProvideService(db db.DB, cfg *setting.Cfg) star.Service {
 		return &Service{
 			store: &sqlxStore{
 				sess: db.GetSqlxSession(),
+				db:   db,
 			},
 		}
 	}

--- a/pkg/services/star/starimpl/xorm_store.go
+++ b/pkg/services/star/starimpl/xorm_store.go
@@ -35,6 +35,10 @@ func (s *sqlStore) Insert(ctx context.Context, cmd *star.StarDashboardCommand) e
 		}
 
 		_, err := sess.Insert(&entity)
+		if s.db.GetDialect().IsUniqueConstraintViolation(err) {
+			return nil
+		}
+
 		return err
 	})
 }


### PR DESCRIPTION
**What is this feature?**

Returns 200 instead of an internal server error.

**Why do we need this feature?**

The status code and the error message are misleading.

**Who is this feature for?**

For users who call POST /api/user/stars/dashboard/{:id} or /api/user/stars/dashboard/uid/{:dashboardUID} without Grafana UI

Fixes #63133

**Special notes for your reviewer**:
This is my first PR for Grafana.
I tried to find and add tests for this api. I failed to find the relevant tests.
Thanks!
