### PR TITLE
Profiling: Enable flame graph & Phlare/Parca data sources for all users

### DIFF
--- a/docs/sources/datasources/parca.md
+++ b/docs/sources/datasources/parca.md
@@ -14,10 +14,6 @@ weight: 1110
 
 # Parca data source
 
-> **Note:** This feature is behind the `flameGraph` feature toggle.
-> You can enable feature toggles through configuration file or environment variables. See configuration [docs]({{< relref "../setup-grafana/configure-grafana/#feature_toggles" >}}) for details.
-> Grafana Cloud users can access this feature by [opening a support ticket in the Cloud Portal](https://grafana.com/profile/org#support).
-
 Grafana ships with built-in support for Parca, a continuous profiling OSS database for analysis of CPU and memory usage, down to the line number and throughout time. Add it as a data source, and you are ready to query your profiles in [Explore]({{< relref "../explore" >}}).
 
 ## Configure the Parca data source

--- a/docs/sources/datasources/phlare.md
+++ b/docs/sources/datasources/phlare.md
@@ -14,10 +14,6 @@ weight: 1150
 
 # Phlare data source
 
-> **Note:** This feature is behind the `flameGraph` feature toggle.
-> You can enable feature toggles through configuration file or environment variables. See configuration [docs]({{< relref "../setup-grafana/configure-grafana/#feature_toggles" >}}) for details.
-> Grafana Cloud users can access this feature by [opening a support ticket in the Cloud Portal](https://grafana.com/profile/org#support).
-
 Grafana ships with built-in support for Phlare, a horizontally scalable, highly-available, multi-tenant, OSS, continuous profiling aggregation system from Grafana Labs. Add it as a data source, and you are ready to query your profiles in [Explore]({{< relref "../explore" >}}).
 
 ## Configure the Phlare data source

--- a/docs/sources/panels-visualizations/visualizations/flame-graph/index.md
+++ b/docs/sources/panels-visualizations/visualizations/flame-graph/index.md
@@ -13,8 +13,6 @@ weight: 850
 
 # Flame graph panel
 
-> **Note:** This panel is currently in beta & behind the `flameGraph` feature toggle.
-
 The flame graph takes advantage of the hierarchical nature of profiling data. It condenses data into a format that allows you to easily see which code paths are consuming the most system resources.
 
 These resources are measured through profiles which aggregate that information into a format which is then sent to the flame graph visualization. For example, allocated objects or space when measuring memory.

--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -77,7 +77,6 @@ Alpha features might be changed or removed without prior notice.
 | `disableSecretsCompatibility`      | Disable duplicated secret storage in legacy tables                                                                                                                           |
 | `logRequestsInstrumentedAsUnknown` | Logs the path for requests that are instrumented as unknown                                                                                                                  |
 | `dataConnectionsConsole`           | Enables a new top-level page called Connections. This page is an experiment that provides a better experience when you install and configure data sources and other plugins. |
-| `flameGraph`                       | Show the flame graph                                                                                                                                                         |
 | `redshiftAsyncQueryDataSupport`    | Enable async query data support for Redshift                                                                                                                                 |
 | `athenaAsyncQueryDataSupport`      | Enable async query data support for Athena                                                                                                                                   |
 | `newPanelChromeUI`                 | Show updated look and feel of grafana-ui PanelChrome: panel header, icons, and menu                                                                                          |

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -58,7 +58,6 @@ export interface FeatureToggles {
   topnav?: boolean;
   grpcServer?: boolean;
   entityStore?: boolean;
-  flameGraph?: boolean;
   cloudWatchCrossAccountQuerying?: boolean;
   redshiftAsyncQueryDataSupport?: boolean;
   athenaAsyncQueryDataSupport?: boolean;

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -10,7 +10,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/datasources"
-	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/licensing"
 	"github.com/grafana/grafana/pkg/services/pluginsettings"
 	"github.com/grafana/grafana/pkg/services/secrets/kvstore"
@@ -63,11 +62,6 @@ func (hs *HTTPServer) getFrontendSettings(c *contextmodel.ReqContext) (*dtos.Fro
 			continue
 		}
 
-		hideFromList := panel.HideFromList
-		if panel.ID == "flamegraph" {
-			hideFromList = !hs.Features.IsEnabled(featuremgmt.FlagFlameGraph)
-		}
-
 		panels[panel.ID] = plugins.PanelDTO{
 			ID:            panel.ID,
 			Name:          panel.Name,
@@ -75,7 +69,7 @@ func (hs *HTTPServer) getFrontendSettings(c *contextmodel.ReqContext) (*dtos.Fro
 			Module:        panel.Module,
 			BaseURL:       panel.BaseURL,
 			SkipDataQuery: panel.SkipDataQuery,
-			HideFromList:  hideFromList,
+			HideFromList:  panel.HideFromList,
 			ReleaseState:  string(panel.State),
 			Signature:     string(panel.Signature),
 			Sort:          getPanelSort(panel.ID),

--- a/pkg/api/plugins.go
+++ b/pkg/api/plugins.go
@@ -27,7 +27,6 @@ import (
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/datasources"
-	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/pluginsettings"
 	"github.com/grafana/grafana/pkg/setting"
@@ -114,10 +113,6 @@ func (hs *HTTPServer) GetPluginList(c *contextmodel.ReqContext) response.Respons
 			if enabledFilter == "1" && !pluginSetting.Enabled {
 				continue
 			}
-		}
-
-		if (pluginDef.ID == "parca" || pluginDef.ID == "phlare") && !hs.Features.IsEnabled(featuremgmt.FlagFlameGraph) {
-			continue
 		}
 
 		filteredPluginDefinitions = append(filteredPluginDefinitions, pluginDef)

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -239,11 +239,6 @@ var (
 			RequiresDevMode: true,
 		},
 		{
-			Name:        "flameGraph",
-			Description: "Show the flame graph",
-			State:       FeatureStateAlpha,
-		},
-		{
 			Name:        "cloudWatchCrossAccountQuerying",
 			Description: "Enables cross-account querying in CloudWatch datasources",
 			State:       FeatureStateStable,

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -175,10 +175,6 @@ const (
 	// SQL-based entity store (requires storage flag also)
 	FlagEntityStore = "entityStore"
 
-	// FlagFlameGraph
-	// Show the flame graph
-	FlagFlameGraph = "flameGraph"
-
 	// FlagCloudWatchCrossAccountQuerying
 	// Enables cross-account querying in CloudWatch datasources
 	FlagCloudWatchCrossAccountQuerying = "cloudWatchCrossAccountQuerying"

--- a/pkg/tests/api/plugins/data/expectedListResp.json
+++ b/pkg/tests/api/plugins/data/expectedListResp.json
@@ -458,7 +458,7 @@
     "hasUpdate": false,
     "defaultNavUrl": "/plugins/flamegraph/",
     "category": "",
-    "state": "beta",
+    "state": "",
     "signature": "internal",
     "signatureType": "",
     "signatureOrg": ""
@@ -1097,6 +1097,83 @@
     "hasUpdate": false,
     "defaultNavUrl": "/plugins/opentsdb/",
     "category": "tsdb",
+    "state": "",
+    "signature": "internal",
+    "signatureType": "",
+    "signatureOrg": ""
+  },{
+    "name": "Parca",
+    "type": "datasource",
+    "id": "parca",
+    "enabled": true,
+    "pinned": false,
+    "info": {
+      "author": {
+        "name": "Grafana Labs",
+        "url": "https://www.grafana.com"
+      },
+      "description": "Continuous profiling for analysis of CPU and memory usage, down to the line number and throughout time. Saving infrastructure cost, improving performance, and increasing reliability.",
+      "links": [{
+        "name": "GitHub Project",
+        "url": "https://github.com/parca-dev/parca"
+      }],
+      "logos": {
+        "small": "public/app/plugins/datasource/parca/img/logo-small.svg",
+        "large": "public/app/plugins/datasource/parca/img/logo-small.svg"
+      },
+      "build": {},
+      "screenshots": null,
+      "version": "",
+      "updated": ""
+    },
+    "dependencies": {
+      "grafanaDependency": "",
+      "grafanaVersion": "*",
+      "plugins": []
+    },
+    "latestVersion": "",
+    "hasUpdate": false,
+    "defaultNavUrl": "/plugins/parca/",
+    "category": "profiling",
+    "state": "",
+    "signature": "internal",
+    "signatureType": "",
+    "signatureOrg": ""
+  },
+  {
+    "name": "Phlare",
+    "type": "datasource",
+    "id": "phlare",
+    "enabled": true,
+    "pinned": false,
+    "info": {
+      "author": {
+        "name": "Grafana Labs",
+        "url": "https://www.grafana.com"
+      },
+      "description": "Horizontally-scalable, highly-available, multi-tenant continuous profiling aggregation system. OSS profiling solution from Grafana Labs.",
+      "links": [{
+        "name": "GitHub Project",
+        "url": "https://github.com/grafana/phlare"
+      }],
+      "logos": {
+        "small": "public/app/plugins/datasource/phlare/img/phlare_icon_color.svg",
+        "large": "public/app/plugins/datasource/phlare/img/phlare_icon_color.svg"
+      },
+      "build": {},
+      "screenshots": null,
+      "version": "",
+      "updated": ""
+    },
+    "dependencies": {
+      "grafanaDependency": "",
+      "grafanaVersion": "*",
+      "plugins": []
+    },
+    "latestVersion": "",
+    "hasUpdate": false,
+    "defaultNavUrl": "/plugins/phlare/",
+    "category": "profiling",
     "state": "",
     "signature": "internal",
     "signatureType": "",

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -510,9 +510,7 @@ export class Explore extends React.PureComponent<Props, ExploreState> {
                           {showTable && <ErrorBoundaryAlert>{this.renderTablePanel(width)}</ErrorBoundaryAlert>}
                           {showLogs && <ErrorBoundaryAlert>{this.renderLogsPanel(width)}</ErrorBoundaryAlert>}
                           {showNodeGraph && <ErrorBoundaryAlert>{this.renderNodeGraphPanel()}</ErrorBoundaryAlert>}
-                          {showFlameGraph && config.featureToggles.flameGraph && (
-                            <ErrorBoundaryAlert>{this.renderFlameGraphPanel()}</ErrorBoundaryAlert>
-                          )}
+                          {showFlameGraph && <ErrorBoundaryAlert>{this.renderFlameGraphPanel()}</ErrorBoundaryAlert>}
                           {showTrace && <ErrorBoundaryAlert>{this.renderTraceViewPanel()}</ErrorBoundaryAlert>}
                           {config.featureToggles.logsSampleInExplore && showLogsSample && (
                             <ErrorBoundaryAlert>{this.renderLogsSamplePanel()}</ErrorBoundaryAlert>

--- a/public/app/features/explore/utils/decorators.test.ts
+++ b/public/app/features/explore/utils/decorators.test.ts
@@ -11,7 +11,6 @@ import {
   getDefaultTimeRange,
   toDataFrame,
 } from '@grafana/data';
-import { config } from '@grafana/runtime/src/config';
 import { GraphDrawStyle, StackingMode } from '@grafana/schema';
 import TableModel from 'app/core/TableModel';
 import { ExplorePanelData } from 'app/types';
@@ -114,8 +113,6 @@ describe('decorateWithGraphLogsTraceTableAndFlameGraph', () => {
       state: LoadingState.Done,
       timeRange,
     };
-    // Needed so flamegraph does not fallback to table, will be removed when feature flag no longer necessary
-    config.featureToggles.flameGraph = true;
 
     expect(decorateWithFrameTypeMetadata(panelData)).toEqual({
       series,

--- a/public/app/features/explore/utils/decorators.ts
+++ b/public/app/features/explore/utils/decorators.ts
@@ -56,7 +56,7 @@ export const decorateWithFrameTypeMetadata = (data: PanelData): ExplorePanelData
         nodeGraphFrames.push(frame);
         break;
       case 'flamegraph':
-        config.featureToggles.flameGraph ? flameGraphFrames.push(frame) : tableFrames.push(frame);
+        flameGraphFrames.push(frame);
         break;
       default:
         if (isTimeSeries(frame)) {

--- a/public/app/plugins/panel/flamegraph/components/FlameGraphContainer.tsx
+++ b/public/app/plugins/panel/flamegraph/components/FlameGraphContainer.tsx
@@ -63,54 +63,58 @@ const FlameGraphContainer = (props: Props) => {
   }, [props.data]);
 
   return (
-    <div ref={sizeRef} className={styles.container}>
-      <FlameGraphHeader
-        app={props.app}
-        setTopLevelIndex={setTopLevelIndex}
-        setSelectedBarIndex={setSelectedBarIndex}
-        setRangeMin={setRangeMin}
-        setRangeMax={setRangeMax}
-        search={search}
-        setSearch={setSearch}
-        selectedView={selectedView}
-        setSelectedView={setSelectedView}
-        containerWidth={containerWidth}
-      />
+    <>
+      {props.data && (
+        <div ref={sizeRef} className={styles.container}>
+          <FlameGraphHeader
+            app={props.app}
+            setTopLevelIndex={setTopLevelIndex}
+            setSelectedBarIndex={setSelectedBarIndex}
+            setRangeMin={setRangeMin}
+            setRangeMax={setRangeMax}
+            search={search}
+            setSearch={setSearch}
+            selectedView={selectedView}
+            setSelectedView={setSelectedView}
+            containerWidth={containerWidth}
+          />
 
-      {selectedView !== SelectedView.FlameGraph && (
-        <FlameGraphTopTableContainer
-          data={props.data}
-          app={props.app}
-          totalLevels={levels.length}
-          selectedView={selectedView}
-          search={search}
-          setSearch={setSearch}
-          setTopLevelIndex={setTopLevelIndex}
-          setSelectedBarIndex={setSelectedBarIndex}
-          setRangeMin={setRangeMin}
-          setRangeMax={setRangeMax}
-        />
-      )}
+          {selectedView !== SelectedView.FlameGraph && (
+            <FlameGraphTopTableContainer
+              data={props.data}
+              app={props.app}
+              totalLevels={levels.length}
+              selectedView={selectedView}
+              search={search}
+              setSearch={setSearch}
+              setTopLevelIndex={setTopLevelIndex}
+              setSelectedBarIndex={setSelectedBarIndex}
+              setRangeMin={setRangeMin}
+              setRangeMax={setRangeMax}
+            />
+          )}
 
-      {selectedView !== SelectedView.TopTable && (
-        <FlameGraph
-          data={props.data}
-          app={props.app}
-          flameGraphHeight={props.flameGraphHeight}
-          levels={levels}
-          topLevelIndex={topLevelIndex}
-          selectedBarIndex={selectedBarIndex}
-          rangeMin={rangeMin}
-          rangeMax={rangeMax}
-          search={search}
-          setTopLevelIndex={setTopLevelIndex}
-          setSelectedBarIndex={setSelectedBarIndex}
-          setRangeMin={setRangeMin}
-          setRangeMax={setRangeMax}
-          selectedView={selectedView}
-        />
+          {selectedView !== SelectedView.TopTable && (
+            <FlameGraph
+              data={props.data}
+              app={props.app}
+              flameGraphHeight={props.flameGraphHeight}
+              levels={levels}
+              topLevelIndex={topLevelIndex}
+              selectedBarIndex={selectedBarIndex}
+              rangeMin={rangeMin}
+              rangeMax={rangeMax}
+              search={search}
+              setTopLevelIndex={setTopLevelIndex}
+              setSelectedBarIndex={setSelectedBarIndex}
+              setRangeMin={setRangeMin}
+              setRangeMax={setRangeMax}
+              selectedView={selectedView}
+            />
+          )}
+        </div>
       )}
-    </div>
+    </>
   );
 };
 

--- a/public/app/plugins/panel/flamegraph/plugin.json
+++ b/public/app/plugins/panel/flamegraph/plugin.json
@@ -2,7 +2,6 @@
   "type": "panel",
   "name": "Flame Graph",
   "id": "flamegraph",
-  "state": "beta",
 
   "info": {
     "author": {


### PR DESCRIPTION
**What is this feature?**

This PR removes the flame graph feature toggle.

**Why do we need this feature?**

The toggle is no longer needed.

**Who is this feature for?**

Users of Phlare/Parca/Flame graph.

**Special notes for your reviewer**:

Also removes the beta badge from the flame graph panel in dashboards.

