### PR TITLE
Feat: Linking to plugin details page rather than externally for new datasources

### DIFF
--- a/packages/grafana-data/src/types/plugin.ts
+++ b/packages/grafana-data/src/types/plugin.ts
@@ -123,7 +123,7 @@ export interface PluginInclude {
 interface PluginMetaInfoLink {
   name: string;
   url: string;
-  href?: '_blank' | '_self' | '_parent' | '_top';
+  target?: '_blank' | '_self' | '_parent' | '_top';
 }
 
 export interface PluginBuildInfo {

--- a/packages/grafana-data/src/types/plugin.ts
+++ b/packages/grafana-data/src/types/plugin.ts
@@ -123,6 +123,7 @@ export interface PluginInclude {
 interface PluginMetaInfoLink {
   name: string;
   url: string;
+  href?: '_blank' | '_self' | '_parent' | '_top';
 }
 
 export interface PluginBuildInfo {

--- a/public/app/features/datasources/components/DataSourceTypeCard.tsx
+++ b/public/app/features/datasources/components/DataSourceTypeCard.tsx
@@ -14,7 +14,7 @@ export function DataSourceTypeCard({ onClick, dataSourcePlugin }: Props) {
   const isPhantom = dataSourcePlugin.module === 'phantom';
   const isClickable = !isPhantom && !dataSourcePlugin.unlicensed;
   const learnMoreLink = dataSourcePlugin.info?.links?.length > 0 ? dataSourcePlugin.info.links[0] : null;
-  const learnMoreLinkHref = learnMoreLink?.href ?? '_blank';
+  const learnMoreLinkTarget = learnMoreLink?.target ?? '_blank';
 
   const styles = useStyles2(getStyles);
 
@@ -48,10 +48,9 @@ export function DataSourceTypeCard({ onClick, dataSourcePlugin }: Props) {
           <LinkButton
             aria-label={`${dataSourcePlugin.name}, learn more.`}
             href={`${learnMoreLink.url}?utm_source=grafana_add_ds`}
-            icon="external-link-alt"
             onClick={(e) => e.stopPropagation()}
             rel="noopener"
-            target={learnMoreLinkHref}
+            target={learnMoreLinkTarget}
             variant="secondary"
           >
             {learnMoreLink.name}

--- a/public/app/features/datasources/components/DataSourceTypeCard.tsx
+++ b/public/app/features/datasources/components/DataSourceTypeCard.tsx
@@ -14,6 +14,7 @@ export function DataSourceTypeCard({ onClick, dataSourcePlugin }: Props) {
   const isPhantom = dataSourcePlugin.module === 'phantom';
   const isClickable = !isPhantom && !dataSourcePlugin.unlicensed;
   const learnMoreLink = dataSourcePlugin.info?.links?.length > 0 ? dataSourcePlugin.info.links[0] : null;
+  const learnMoreLinkHref = learnMoreLink?.href ?? '_blank';
 
   const styles = useStyles2(getStyles);
 
@@ -50,7 +51,7 @@ export function DataSourceTypeCard({ onClick, dataSourcePlugin }: Props) {
             icon="external-link-alt"
             onClick={(e) => e.stopPropagation()}
             rel="noopener"
-            target="_blank"
+            target={learnMoreLinkHref}
             variant="secondary"
           >
             {learnMoreLink.name}

--- a/public/app/features/datasources/state/buildCategories.ts
+++ b/public/app/features/datasources/state/buildCategories.ts
@@ -246,7 +246,7 @@ function getPhantomPlugin(options: GetPhantomPluginOptions): DataSourcePluginMet
         {
           url: '/plugins/' + options.id,
           name: 'Install now',
-          href: '_self',
+          target: '_self',
         },
       ],
       screenshots: [],

--- a/public/app/features/datasources/state/buildCategories.ts
+++ b/public/app/features/datasources/state/buildCategories.ts
@@ -1,5 +1,5 @@
 import { DataSourcePluginMeta, PluginType } from '@grafana/data';
-import { config, featureEnabled } from '@grafana/runtime';
+import { featureEnabled } from '@grafana/runtime';
 import { DataSourcePluginCategory } from 'app/types';
 
 export function buildCategories(plugins: DataSourcePluginMeta[]): DataSourcePluginCategory[] {
@@ -244,8 +244,9 @@ function getPhantomPlugin(options: GetPhantomPluginOptions): DataSourcePluginMet
       author: { name: 'Grafana Labs' },
       links: [
         {
-          url: config.pluginCatalogURL + options.id,
+          url: '/plugins/' + options.id,
           name: 'Install now',
+          href: '_self',
         },
       ],
       screenshots: [],


### PR DESCRIPTION
**What is this feature?**
This changes the target of the "Install now" buttons from external - grafana.com to an internal plugin details page. This has an advantage that if you have an enterprise license you can install the plugin directly without going to grafana.com

![SCR-20230221-k5c](https://user-images.githubusercontent.com/580672/220358415-83e10d37-1d29-4427-a5e6-3c7d5cfef80e.png)


**Why do we need this feature?**
Easier to install plugins for users with enterprise license.

**Who is this feature for?**

Enterprise license users
