### PR TITLE
Feat: Changing link destination for get more plugins

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -351,7 +351,7 @@ lerna.json @grafana/frontend-ops
 /public/app/features/connections/ @grafana/plugins-platform-frontend
 /public/app/features/correlations/ @grafana/explore-squad
 /public/app/features/dashboard/ @grafana/dashboards-squad
-/public/app/features/datasources/ @grafana/user-essentials
+/public/app/features/datasources/ @grafana/plugins-platform-frontend
 /public/app/features/dimensions/ @grafana/dataviz-squad
 /public/app/features/dataframe-import/ @grafana/grafana-bi-squad
 /public/app/features/explore/ @grafana/explore-squad

--- a/public/app/features/datasources/components/DataSourceCategories.tsx
+++ b/public/app/features/datasources/components/DataSourceCategories.tsx
@@ -5,7 +5,6 @@ import { config } from '@grafana/runtime';
 import { LinkButton } from '@grafana/ui';
 import { DataSourcePluginCategory } from 'app/types';
 
-import { DestinationPage } from '../../connections/components/ConnectionsRedirectNotice';
 import { ROUTES } from '../../connections/constants';
 
 import { DataSourceTypeCardList } from './DataSourceTypeCardList';
@@ -19,12 +18,8 @@ export type Props = {
 };
 
 export function DataSourceCategories({ categories, onClickDataSourceType }: Props) {
-  const destinationLinks = {
-    [DestinationPage.dataSources]: ROUTES.DataSources,
-    [DestinationPage.connectData]: ROUTES.ConnectData,
-  };
   const moreDataSourcesLink = config.featureToggles.dataConnectionsConsole
-    ? `${destinationLinks[DestinationPage.connectData]}?cat=data-source`
+    ? `${ROUTES.ConnectData}?cat=data-source`
     : '/plugins?filterBy=all&filterByType=datasource&utm_source=grafana_add_ds';
 
   return (

--- a/public/app/features/datasources/components/DataSourceCategories.tsx
+++ b/public/app/features/datasources/components/DataSourceCategories.tsx
@@ -1,8 +1,12 @@
 import React from 'react';
 
 import { DataSourcePluginMeta } from '@grafana/data';
+import { config } from '@grafana/runtime';
 import { LinkButton } from '@grafana/ui';
 import { DataSourcePluginCategory } from 'app/types';
+
+import { DestinationPage } from '../../connections/components/ConnectionsRedirectNotice';
+import { ROUTES } from '../../connections/constants';
 
 import { DataSourceTypeCardList } from './DataSourceTypeCardList';
 
@@ -15,6 +19,14 @@ export type Props = {
 };
 
 export function DataSourceCategories({ categories, onClickDataSourceType }: Props) {
+  const destinationLinks = {
+    [DestinationPage.dataSources]: ROUTES.DataSources,
+    [DestinationPage.connectData]: ROUTES.ConnectData,
+  };
+  const moreDataSourcesLink = config.featureToggles.dataConnectionsConsole
+    ? `${destinationLinks[DestinationPage.connectData]}?cat=data-source`
+    : '/plugins?filterBy=all&filterByType=datasource&utm_source=grafana_add_ds';
+
   return (
     <>
       {/* Categories */}
@@ -29,13 +41,8 @@ export function DataSourceCategories({ categories, onClickDataSourceType }: Prop
 
       {/* Find more */}
       <div className="add-data-source-more">
-        <LinkButton
-          variant="secondary"
-          href="https://grafana.com/plugins?type=datasource&utm_source=grafana_add_ds"
-          target="_blank"
-          rel="noopener"
-        >
-          Find more data source plugins on grafana.com
+        <LinkButton variant="secondary" href={moreDataSourcesLink} target="_self" rel="noopener">
+          Find more data source plugins
         </LinkButton>
       </div>
     </>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Changing the link destination for "find more plugins" from external to `internal plugin catalog` or `connections` depending on if the feature flag is active or not.

If feature flag `dataConnectionsConsole` is active it links to `/connections/connect-data?cat=data-source` if not it links to `/plugins?filterBy=all&filterByType=datasource`

**Why do we need this feature?**

Keep users in grafana catalog, less confusion when searching for new plugins

![SCR-20230221-o33](https://user-images.githubusercontent.com/580672/220401499-28a3d702-d7e0-492b-b62a-61c5e42e96f7.png)


