### PR TITLE
Docs: Fix of typo and delete of unnecessary sentence in 'Sign a plugin' doc

### DIFF
--- a/docs/sources/developers/plugins/sign-a-plugin.md
+++ b/docs/sources/developers/plugins/sign-a-plugin.md
@@ -12,9 +12,7 @@ Before you can sign your plugin, you need to decide whether you want to sign it 
 
 If you want to make your plugin publicly available outside of your organization, you need to sign your plugin under a _community_ or _commercial_ [signature level](#plugin-signature-levels). Public plugins are available from [grafana.com/plugins](https://grafana.com/plugins) and can be installed by anyone.
 
-For more information on how to install a public plugin, refer to [Install Grafana plugins]({{< relref "../../administration/plugin-management#install-a-plugin" >}}).
-
-If you intend to only use the plugin within your organization, you can to sign it under a _private_ [signature level](#plugin-signature-levels).
+If you intend to only use the plugin within your organization, you can  sign it under a _private_ [signature level](#plugin-signature-levels).
 
 ## Generate an API key
 

--- a/docs/sources/developers/plugins/sign-a-plugin.md
+++ b/docs/sources/developers/plugins/sign-a-plugin.md
@@ -12,7 +12,7 @@ Before you can sign your plugin, you need to decide whether you want to sign it 
 
 If you want to make your plugin publicly available outside of your organization, you need to sign your plugin under a _community_ or _commercial_ [signature level](#plugin-signature-levels). Public plugins are available from [grafana.com/plugins](https://grafana.com/plugins) and can be installed by anyone.
 
-If you intend to only use the plugin within your organization, you can  sign it under a _private_ [signature level](#plugin-signature-levels).
+If you intend to only use the plugin within your organization, you can sign it under a _private_ [signature level](#plugin-signature-levels).
 
 ## Generate an API key
 


### PR DESCRIPTION
**What is this feature?**

Two minor edits to sign-a-plugin.md

**Why do we need this feature?**

Documentation quality: Typo fix. Deleted sentence is not needed, distraction from flow.

**Who is this feature for?**

Plugin developers.

**Which issue(s) does this PR fix?**:

None.

Fixes #

None.

