### PR TITLE
loki: query splitting: more robust check

### DIFF
--- a/public/app/plugins/datasource/loki/queryUtils.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.ts
@@ -307,9 +307,11 @@ export function getStreamSelectorsFromQuery(query: string): string[] {
 export function requestSupportsPartitioning(allQueries: LokiQuery[]) {
   const queries = allQueries.filter((query) => !query.hide);
   /*
-   * For now, we will not split when more than 1 query is requested.
+   * For now, we only split if there is a single query.
+   * - we do not split for zero queries
+   * - we do not split for multiple queries
    */
-  if (queries.length > 1) {
+  if (queries.length !== 1) {
     return false;
   }
 


### PR DESCRIPTION
when there is only a single query, and it is marked hidden, this line will crash: https://github.com/grafana/grafana/blob/3949706182321cd00dc265efd6e5ec54632363f7/public/app/plugins/datasource/loki/queryUtils.ts#L316 (because the queries-array has zero-length).

this PR fixes this.

how to test:
- make sure the `lokiQuerySplitting` feature-flag is enabled
- go to explore-mode
- add a single query
- run the query
- you should see results
- now hide the query by clicking on the eye icon
- you should now see no results, and the run-queries-button should not be stuck in loading-state
