### PR TITLE
Update technical documentation CODEOWNERS to reflect areas of responsibility

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,23 +30,24 @@
 /UPGRADING_DEPENDENCIES.md @grafana/docs-grafana
 /WORKFLOW.md @torkelo
 /contribute/ @grafana/docs-grafana
-/docs/ @grafana/docs-grafana
-/docs/sources/developers/plugins/ @grafana/docs-grafana @grafana/plugins-platform-frontend @grafana/plugins-platform-backend
-/docs/sources/developers/plugins/backend/ @grafana/docs-grafana @grafana/plugins-platform-backend
 
-
-# Set up, dashboards/visualization, best practices: Chris Moyer
-# Alerting: Brenda Muir
-/docs/sources/administration/ @Eve832 @GrafanaWriter
-/docs/sources/alerting/ @brendamuir
-/docs/sources/dashboards/ @chri2547
-/docs/sources/datasources/ @Eve832 @GrafanaWriter
-/docs/sources/explore/ @Eve832 @GrafanaWriter
-/docs/sources/getting-started/ @chri2547
-/docs/sources/old-alerting/ @brendamuir
-/docs/sources/release-notes/ @Eve832 @GrafanaWriter
-/docs/sources/setup-grafana/ @chri2547
-/docs/sources/whatsnew/ @Eve832 @GrafanaWriter
+# Technical documentation
+/docs/                                    @Eve832 @jdbaldry
+/docs/sources/                            @Eve832
+/docs/sources/administration/             @Eve832 @GrafanaWriter
+/docs/sources/alerting/                   @brendamuir
+/docs/sources/datasources/                @Eve832 @GrafanaWriter
+/docs/sources/explore/                    @Eve832 @GrafanaWriter
+/docs/sources/fundamentals                @chri2547
+/docs/sources/getting-started/            @chri2547
+/docs/sources/introduction/               @chri2547
+/docs/sources/old-alerting/               @brendamuir
+/docs/sources/release-notes/              @Eve832 @GrafanaWriter
+/docs/sources/setup-grafana/              @chri2547
+/docs/sources/upgrade-guide/              @chri2547
+/docs/sources/whatsnew/                   @chri2547
+/docs/sources/developers/plugins/         @Eve832 @grafana/plugins-platform-frontend @grafana/plugins-platform-backend
+/docs/sources/developers/plugins/backend/ @Eve832 @grafana/plugins-platform-backend
 
 # Backend code
 /go.mod @grafana/backend-platform

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,6 +30,7 @@
 /UPGRADING_DEPENDENCIES.md @grafana/docs-grafana
 /WORKFLOW.md @torkelo
 /contribute/ @grafana/docs-grafana
+/devenv/README.md @grafana/docs-grafana
 
 # Technical documentation
 /docs/                                    @Eve832 @jdbaldry

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -47,7 +47,7 @@
 /docs/sources/setup-grafana/              @chri2547
 /docs/sources/upgrade-guide/              @chri2547
 /docs/sources/whatsnew/                   @chri2547
-/docs/sources/developers/plugins/         @Eve832 @grafana/plugins-platform-frontend @grafana/plugins-platform-backend
+/docs/sources/developers/plugins/         @Eve832 @josmperez @grafana/plugins-platform-frontend @grafana/plugins-platform-backend
 /docs/sources/developers/plugins/backend/ @Eve832 @grafana/plugins-platform-backend
 
 # Backend code

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,27 +12,27 @@
 # This should make it easy to add new rules without breaking existing ones.
 
 # Documentation
-/docs/ @grafana/docs-grafana
+/.changelog-archive @grafana/docs-grafana
+/CHANGELOG.md @grafana/docs-grafana
+/CODE_OF_CONDUCT.md @grafana/docs-grafana
+/CONTRIBUTING.md @grafana/docs-grafana
+/GOVERNANCE.md @RichiH
+/HALL_OF_FAME.md @grafana/docs-grafana
+/ISSUE_TRIAGE.md @grafana/grafana-community-support
+/LICENSE @torkelo
+/LICENSING.md @torkelo
+/MAINTAINERS.md @RichiH
+/NOTICE.md @torkelo
+/README.md @grafana/docs-grafana
+/ROADMAP.md @torkelo
+/SECURITY.md @grafana/security-team
+/SUPPORT.md @torkelo
+/UPGRADING_DEPENDENCIES.md @grafana/docs-grafana
+/WORKFLOW.md @torkelo
 /contribute/ @grafana/docs-grafana
+/docs/ @grafana/docs-grafana
 /docs/sources/developers/plugins/ @grafana/docs-grafana @grafana/plugins-platform-frontend @grafana/plugins-platform-backend
 /docs/sources/developers/plugins/backend/ @grafana/docs-grafana @grafana/plugins-platform-backend
-/.changelog-archive @grafana/docs-grafana
-CHANGELOG.md @grafana/docs-grafana
-CODE_OF_CONDUCT.md @grafana/docs-grafana
-CONTRIBUTING.md @grafana/docs-grafana
-GOVERNANCE.md @RichiH
-HALL_OF_FAME.md @grafana/docs-grafana
-ISSUE_TRIAGE.md @grafana/grafana-community-support
-LICENSE @torkelo
-LICENSING.md @torkelo
-MAINTAINERS.md @RichiH
-NOTICE.md @torkelo
-README.md @grafana/docs-grafana
-ROADMAP.md @torkelo
-SECURITY.md @grafana/security-team
-SUPPORT.md @torkelo
-UPGRADING_DEPENDENCIES.md @grafana/docs-grafana
-WORKFLOW.md @torkelo
 
 
 # Set up, dashboards/visualization, best practices: Chris Moyer


### PR DESCRIPTION
@Eve832 is responsible for all docs not owned by another technical
writer.

@Eve832 and @GrafanaWriter are responsible for Administration, Data
sources, Explore, and Release notes.

@eve and the plugins teams are responsible for developer plugins documentation.

@brendamuir is responsible for all alerting documentation.

@chri2547 is responsible for Fundamentals, Getting started,
Introduction, Setup Grafana, Upgrade guide, and What's new.