### PR TITLE
[v8.4.x] CloudWatch: Remove error for multi-value variable in logs runner (#63522)

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/datasource.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.ts
@@ -633,7 +633,7 @@ export class CloudWatchDatasource
                 this.replace(val, options.scopedVars, true, fieldName)
               );
             } else {
-              anyQuery[fieldName] = this.replace(anyQuery[fieldName], options.scopedVars, true, fieldName);
+              anyQuery[fieldName] = this.replace(anyQuery[fieldName], options.scopedVars, false, fieldName);
             }
           }
         }

--- a/public/app/plugins/datasource/cloudwatch/utils/datalinks.ts
+++ b/public/app/plugins/datasource/cloudwatch/utils/datalinks.ts
@@ -18,7 +18,7 @@ export async function addDataLinksToLogsResponse(
   getRegion: (region: string) => string,
   tracingDatasourceUid?: string
 ): Promise<void> {
-  const replace = (target: string, fieldName?: string) => replaceFn(target, request.scopedVars, true, fieldName);
+  const replace = (target: string, fieldName?: string) => replaceFn(target, request.scopedVars, false, fieldName);
 
   for (const dataFrame of response.data as DataFrame[]) {
     const curTarget = request.targets.find((target) => target.refId === dataFrame.refId) as CloudWatchLogsQuery;


### PR DESCRIPTION
Remove error for multi template variable in CW logs runner

(cherry picked from commit 3a57304ef0a11e98818da4747284514f1bfc16b3)

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->
**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #https://github.com/grafana/support-escalations/issues/5067

**Special notes for your reviewer**:
This differs from the cherry-picked commit in that I had to disable the multi-value variable error [on this additional line](https://github.com/grafana/grafana/pull/63551/files#diff-5195d59bff5abb37dceeb2ba37e2e0acb2f73f861fc83e320a72f6e7b2784f18R636).

I was able to test locally on the v8.4.x branch (~v8.4.11) that the error does not display for a similar use case as reported in the original issue. 
Original issue: https://github.com/grafana/grafana/issues/63321
Grafana reviewers: See Special Notes [here](https://github.com/grafana/grafana/pull/63522#issue-1593805634) for testing instructions.

There are other usages of this function which may still misleadingly display the issue's error, but I am reluctant to do anything more than the minimum here. @grafana/aws-plugins cc. @iwysiu let me know what you think