### PR TITLE
[v9.3.x] Add --init to all podman invocations to ensure ^C works on MacOS (#61745)

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,24 +1,28 @@
 .PHONY: pull docs docs-quick docs-no-pull docs-test docs-local-static
 
+PODMAN = $(shell if command -v podman >/dev/null 2>&1; then echo podman; else echo docker; fi)
 IMAGE = grafana/docs-base:latest
 CONTENT_PATH = /hugo/content/docs/grafana/latest
 LOCAL_STATIC_PATH = ../../website/static
 PORT = 3002:3002
 
 pull:
-	docker pull $(IMAGE)
+	$(PODMAN) pull $(IMAGE)
 
 docs: pull
-	docker run -v $(shell pwd)/sources:$(CONTENT_PATH):Z -p $(PORT) --rm -it $(IMAGE) /bin/bash -c "make server"
-	
+	$(PODMAN) run --init -v $(shell pwd)/sources:$(CONTENT_PATH):Z -p $(PORT) --rm -it $(IMAGE) make server
+
+docs-preview: pull
+	$(PODMAN) run --init -v $(shell pwd)/sources:$(CONTENT_PATH):Z -p $(PORT) --rm -it $(IMAGE) make server BUILD_DRAFTS=true
+
 docs-no-pull:
-	docker run -v $(shell pwd)/sources:$(CONTENT_PATH):Z -p $(PORT) --rm -it $(IMAGE) /bin/bash -c "make server"
+	$(PODMAN) run --init -v $(shell pwd)/sources:$(CONTENT_PATH):Z -p $(PORT) --rm -it $(IMAGE) make server
 
 docs-test: pull
-	docker run -v $(shell pwd)/sources:$(CONTENT_PATH):Z --rm -it $(IMAGE) /bin/bash -c 'make prod'
+	$(PODMAN) run --init -v $(shell pwd)/sources:$(CONTENT_PATH):Z --rm -it $(IMAGE) make prod
 
 # expects that you have grafana/website checked out in same path as the grafana repo.
 docs-local-static: pull
 	if [ ! -d "$(LOCAL_STATIC_PATH)" ]; then echo "local path (website project) $(LOCAL_STATIC_PATH) not found"]; exit 1; fi
-	docker run -v $(shell pwd)/sources:$(CONTENT_PATH):Z \
+	$(PODMAN) run --init -v $(shell pwd)/sources:$(CONTENT_PATH):Z \
 		-v $(shell pwd)/$(LOCAL_STATIC_PATH):/hugo/static:Z -p $(PORT) --rm -it $(IMAGE)


### PR DESCRIPTION
(cherry picked from commit 5f5f51b3bfba1d3b6f04847f15f81d6b78b97ce4)
