### PR TITLE
Prometheus: Handle annotation query with empty fields

### DIFF
--- a/public/app/plugins/datasource/prometheus/datasource.test.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.test.ts
@@ -191,6 +191,7 @@ describe('PrometheusDatasource', () => {
 
   describe('customQueryParams', () => {
     const target = { expr: 'test{job="testjob"}', format: 'time_series', refId: '' };
+
     function makeQuery(target: PromQuery) {
       return {
         range: { from: time({ seconds: 63 }), to: time({ seconds: 183 }) },
@@ -975,6 +976,19 @@ describe('PrometheusDatasource2', () => {
     } as unknown as AnnotationQueryRequest<PromQuery>;
 
     const response = createAnnotationResponse();
+    const emptyResponse = createEmptyAnnotationResponse();
+
+    describe('handle result with empty fields', () => {
+      it('should return empty results', async () => {
+        fetchMock.mockImplementation(() => of(emptyResponse));
+
+        await ds.annotationQuery(options).then((data) => {
+          results = data;
+        });
+
+        expect(results.length).toBe(0);
+      });
+    });
 
     describe('when time series query is cancelled', () => {
       it('should return empty results', async () => {
@@ -2389,6 +2403,31 @@ function createAnnotationResponse() {
               },
               data: {
                 values: [[123], [456]],
+              },
+            },
+          ],
+        },
+      },
+    },
+  };
+
+  return { ...response };
+}
+
+function createEmptyAnnotationResponse() {
+  const response = {
+    data: {
+      results: {
+        X: {
+          frames: [
+            {
+              schema: {
+                name: 'bar',
+                refId: 'X',
+                fields: [],
+              },
+              data: {
+                values: [],
               },
             },
           ],

--- a/public/app/plugins/datasource/prometheus/datasource.tsx
+++ b/public/app/plugins/datasource/prometheus/datasource.tsx
@@ -830,6 +830,9 @@ export class PrometheusDatasource
     const eventList: AnnotationEvent[] = [];
 
     for (const frame of frames) {
+      if (frame.fields.length === 0) {
+        continue;
+      }
       const timeField = frame.fields[0];
       const valueField = frame.fields[1];
       const labels = valueField?.labels || {};


### PR DESCRIPTION
**What is this feature?**

If the Prometheus annotation query returns no fields we handle this. Previously it was crashing.

**Who is this feature for?**

Prometheus users who use annotation query.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/63458

**Special notes for your reviewer**:

