### PR TITLE
Authn: Add separate context for session tagging 

### DIFF
--- a/pkg/services/authn/clients/anonymous.go
+++ b/pkg/services/authn/clients/anonymous.go
@@ -46,7 +46,7 @@ func (a *Anonymous) Authenticate(ctx context.Context, r *authn.Request) (*authn.
 				a.log.Warn("tag anon session panic", "err", err)
 			}
 		}()
-		if err := a.anonSessionService.TagSession(ctx, r.HTTPRequest); err != nil {
+		if err := a.anonSessionService.TagSession(context.Background(), r.HTTPRequest); err != nil {
 			a.log.Warn("Failed to tag anonymous session", "error", err)
 		}
 	}()

--- a/pkg/services/contexthandler/contexthandler.go
+++ b/pkg/services/contexthandler/contexthandler.go
@@ -243,7 +243,7 @@ func (h *ContextHandler) initContextWithAnonymousUser(reqContext *contextmodel.R
 				reqContext.Logger.Warn("tag anon session panic", "err", err)
 			}
 		}()
-		if err := h.anonSessionService.TagSession(reqContext.Req.Context(), reqContext.Req); err != nil {
+		if err := h.anonSessionService.TagSession(context.Background(), reqContext.Req); err != nil {
 			reqContext.Logger.Warn("Failed to tag anonymous session", "error", err)
 		}
 	}()


### PR DESCRIPTION
Add separate context for session tagging.

Avoid session tagging being cancelled by request finish