### PR TITLE
Chore: Update codeowners to remove barchart from BI squad

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -386,7 +386,7 @@ lerna.json @grafana/frontend-ops
 /public/app/plugins/panel/alertGroups/ @grafana/alerting-squad-frontend
 /public/app/plugins/panel/alertlist/ @grafana/alerting-squad-frontend
 /public/app/plugins/panel/annolist/ @grafana/user-essentials
-/public/app/plugins/panel/barchart/ @grafana/grafana-bi-squad @grafana/dataviz-squad
+/public/app/plugins/panel/barchart/ @grafana/dataviz-squad
 /public/app/plugins/panel/bargauge/ @grafana/dataviz-squad
 /public/app/plugins/panel/dashlist/ @grafana/user-essentials
 /public/app/plugins/panel/debug/ @ryantxu

--- a/pkg/kindsys/report.json
+++ b/pkg/kindsys/report.json
@@ -187,8 +187,7 @@
     "barchartpanelcfg": {
       "category": "composable",
       "codeowners": [
-        "grafana/dataviz-squad",
-        "grafana/grafana-bi-squad"
+        "grafana/dataviz-squad"
       ],
       "currentVersion": [
         0,


### PR DESCRIPTION
This PR removes @grafana/grafana-bi-squad from the barchart as this responsibility has been moved to @grafana/dataviz-squad.

