### PR TITLE
Revert "Chore: Upgrade Go to 1.20.1 and Alpine to 3.17 (#63506)"

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -30,7 +30,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.1
+  image: golang:1.19.4
   name: compile-build-cmd
 - commands:
   - ./bin/build verify-drone
@@ -86,13 +86,13 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.1
+  image: golang:1.19.4
   name: compile-build-cmd
 - commands:
   - ./bin/build verify-starlark .
   depends_on:
   - compile-build-cmd
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: lint-starlark
 trigger:
   event:
@@ -139,13 +139,13 @@ steps:
 - commands:
   - yarn install --immutable
   depends_on: []
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: yarn-install
 - commands:
   - yarn betterer ci
   depends_on:
   - yarn-install
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: betterer-frontend
 - commands:
   - is_fork=$(curl "https://$GITHUB_TOKEN@api.github.com/repos/grafana/grafana/pulls/$DRONE_PULL_REQUEST"
@@ -165,7 +165,7 @@ steps:
     GITHUB_TOKEN:
       from_secret: github_token
   failure: ignore
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: clone-enterprise
 - commands:
   - yarn run ci:test-frontend
@@ -174,7 +174,7 @@ steps:
   - clone-enterprise
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: test-frontend
 trigger:
   event:
@@ -228,7 +228,7 @@ steps:
     GITHUB_TOKEN:
       from_secret: github_token
   failure: ignore
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: clone-enterprise
 - commands:
   - echo $DRONE_RUNNER_NAME
@@ -237,7 +237,7 @@ steps:
 - commands:
   - yarn install --immutable
   depends_on: []
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: yarn-install
 - commands:
   - yarn run prettier:check
@@ -249,7 +249,7 @@ steps:
   - clone-enterprise
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: lint-frontend
 trigger:
   event:
@@ -303,7 +303,7 @@ steps:
     GITHUB_TOKEN:
       from_secret: github_token
   failure: ignore
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: clone-enterprise
 - commands:
   - echo $DRONE_RUNNER_NAME
@@ -314,7 +314,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.1
+  image: golang:1.19.4
   name: compile-build-cmd
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -324,7 +324,7 @@ steps:
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on:
   - clone-enterprise
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -333,25 +333,25 @@ steps:
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on:
   - clone-enterprise
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: verify-gen-jsonnet
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: wire-install
 - commands:
   - go test -tags requires_buildifer -short -covermode=atomic -timeout=5m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: test-backend
 - commands:
   - go test -run Integration -covermode=atomic -timeout=5m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: test-backend-integration
 trigger:
   event:
@@ -400,7 +400,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.1
+  image: golang:1.19.4
   name: compile-build-cmd
 - commands:
   - is_fork=$(curl "https://$GITHUB_TOKEN@api.github.com/repos/grafana/grafana/pulls/$DRONE_PULL_REQUEST"
@@ -420,13 +420,13 @@ steps:
     GITHUB_TOKEN:
       from_secret: github_token
   failure: ignore
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: clone-enterprise
 - commands:
   - make gen-go
   depends_on:
   - clone-enterprise
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: wire-install
 - commands:
   - apt-get update && apt-get install make
@@ -435,7 +435,7 @@ steps:
   - wire-install
   environment:
     CGO_ENABLED: "1"
-  image: golang:1.20.1
+  image: golang:1.19.4
   name: lint-backend
 trigger:
   event:
@@ -490,7 +490,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.1
+  image: golang:1.19.4
   name: compile-build-cmd
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -499,7 +499,7 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -507,18 +507,18 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on: []
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: verify-gen-jsonnet
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on: []
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: yarn-install
 - commands:
   - git clone "https://$${GITHUB_TOKEN}@github.com/grafana/grafana-enterprise.git"
@@ -543,7 +543,7 @@ steps:
       from_secret: github_token_pr
     TEST_TAG: v0.0.0-test
   failure: ignore
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: trigger-test-release
   when:
     paths:
@@ -570,7 +570,7 @@ steps:
   depends_on:
   - wire-install
   - compile-build-cmd
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: build-backend
 - commands:
   - ./bin/build build-frontend --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
@@ -579,7 +579,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: build-frontend
 - commands:
   - ./bin/build build-frontend-packages --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
@@ -588,7 +588,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: build-frontend-packages
 - commands:
   - ./bin/build  build-plugins --jobs 8 --edition oss
@@ -596,7 +596,7 @@ steps:
   - compile-build-cmd
   - yarn-install
   environment: null
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: build-plugins
 - commands:
   - . scripts/build/gpg-test-vars.sh && ./bin/build package --jobs 8 --edition oss
@@ -607,7 +607,7 @@ steps:
   - build-frontend
   - build-frontend-packages
   environment: null
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: package
 - commands:
   - ./scripts/grafana-server/start-server
@@ -620,7 +620,7 @@ steps:
   environment:
     ARCH: linux-amd64
     PORT: 3001
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: grafana-server
 - commands:
   - apt-get install -y netcat
@@ -723,7 +723,7 @@ steps:
   - build-frontend-packages
   environment:
     NODE_OPTIONS: --max_old_space_size=4096
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: build-storybook
   when:
     paths:
@@ -734,7 +734,7 @@ steps:
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: copy-packages-for-docker
 - commands:
   - yarn wait-on http://$HOST:$PORT
@@ -830,7 +830,7 @@ steps:
     GITHUB_TOKEN:
       from_secret: github_token
   failure: ignore
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: clone-enterprise
 - commands:
   - mkdir -p bin
@@ -843,7 +843,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.1
+  image: golang:1.19.4
   name: compile-build-cmd
 - commands:
   - echo $DRONE_RUNNER_NAME
@@ -857,7 +857,7 @@ steps:
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on:
   - clone-enterprise
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -866,13 +866,13 @@ steps:
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on:
   - clone-enterprise
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: verify-gen-jsonnet
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: wire-install
 - commands:
   - apt-get update
@@ -888,7 +888,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -904,7 +904,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: mysql-integration-tests
 trigger:
   event:
@@ -962,7 +962,7 @@ steps:
 - commands:
   - yarn install --immutable
   depends_on: []
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: yarn-install
 - commands:
   - |-
@@ -974,7 +974,7 @@ steps:
     wan" > words_to_ignore.txt
   - codespell -I words_to_ignore.txt docs/
   - rm words_to_ignore.txt
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: codespell
 - commands:
   - yarn run prettier:checkDocs
@@ -982,7 +982,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: lint-docs
 - commands:
   - mkdir -p /hugo/content/docs/grafana/latest
@@ -1026,13 +1026,13 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.1
+  image: golang:1.19.4
   name: compile-build-cmd
 - commands:
   - ./bin/build shellcheck
   depends_on:
   - compile-build-cmd
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: shellcheck
 trigger:
   event:
@@ -1079,7 +1079,7 @@ steps:
 - commands:
   - yarn install --immutable
   depends_on: []
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: yarn-install
 - commands:
   - |-
@@ -1091,7 +1091,7 @@ steps:
     wan" > words_to_ignore.txt
   - codespell -I words_to_ignore.txt docs/
   - rm words_to_ignore.txt
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: codespell
 - commands:
   - yarn run prettier:checkDocs
@@ -1099,7 +1099,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: lint-docs
 - commands:
   - mkdir -p /hugo/content/docs/grafana/latest
@@ -1152,13 +1152,13 @@ steps:
 - commands:
   - yarn install --immutable
   depends_on: []
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: yarn-install
 - commands:
   - yarn betterer ci
   depends_on:
   - yarn-install
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: betterer-frontend
 - commands:
   - yarn run ci:test-frontend
@@ -1166,7 +1166,7 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: test-frontend
 trigger:
   branch: main
@@ -1206,7 +1206,7 @@ steps:
 - commands:
   - yarn install --immutable
   depends_on: []
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: yarn-install
 - commands:
   - yarn run prettier:check
@@ -1217,7 +1217,7 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: lint-frontend
 trigger:
   branch: main
@@ -1259,7 +1259,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.1
+  image: golang:1.19.4
   name: compile-build-cmd
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -1268,7 +1268,7 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -1276,25 +1276,25 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on: []
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: verify-gen-jsonnet
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: wire-install
 - commands:
   - go test -tags requires_buildifer -short -covermode=atomic -timeout=5m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: test-backend
 - commands:
   - go test -run Integration -covermode=atomic -timeout=5m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: test-backend-integration
 trigger:
   branch: main
@@ -1336,12 +1336,12 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.1
+  image: golang:1.19.4
   name: compile-build-cmd
 - commands:
   - make gen-go
   depends_on: []
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: wire-install
 - commands:
   - apt-get update && apt-get install make
@@ -1350,7 +1350,7 @@ steps:
   - wire-install
   environment:
     CGO_ENABLED: "1"
-  image: golang:1.20.1
+  image: golang:1.19.4
   name: lint-backend
 - commands:
   - ./bin/build verify-drone
@@ -1404,7 +1404,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.1
+  image: golang:1.19.4
   name: compile-build-cmd
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -1413,7 +1413,7 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -1421,25 +1421,25 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on: []
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: verify-gen-jsonnet
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on: []
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: yarn-install
 - commands:
   - ./bin/build build-backend --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - wire-install
   - compile-build-cmd
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: build-backend
 - commands:
   - ./bin/build build-frontend --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
@@ -1448,7 +1448,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: build-frontend
 - commands:
   - ./bin/build build-frontend-packages --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
@@ -1457,7 +1457,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: build-frontend-packages
 - commands:
   - ./bin/build  build-plugins --jobs 8 --edition oss
@@ -1467,7 +1467,7 @@ steps:
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: build-plugins
 - commands:
   - ./bin/build package --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER} --sign
@@ -1485,7 +1485,7 @@ steps:
       from_secret: packages_gpg_public_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: package
 - commands:
   - ./scripts/grafana-server/start-server
@@ -1498,7 +1498,7 @@ steps:
   environment:
     ARCH: linux-amd64
     PORT: 3001
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: grafana-server
 - commands:
   - apt-get install -y netcat
@@ -1601,7 +1601,7 @@ steps:
   - build-frontend-packages
   environment:
     NODE_OPTIONS: --max_old_space_size=4096
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: build-storybook
   when:
     paths:
@@ -1612,7 +1612,7 @@ steps:
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: copy-packages-for-docker
 - commands:
   - yarn wait-on http://$HOST:$PORT
@@ -1656,7 +1656,7 @@ steps:
     GRAFANA_MISC_STATS_API_KEY:
       from_secret: grafana_misc_stats_api_key
   failure: ignore
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: publish-frontend-metrics
   when:
     repo:
@@ -1737,7 +1737,7 @@ steps:
   environment:
     NPM_TOKEN:
       from_secret: npm_token
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: release-canary-npm-packages
   when:
     repo:
@@ -1835,7 +1835,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.1
+  image: golang:1.19.4
   name: compile-build-cmd
 - commands:
   - echo $DRONE_RUNNER_NAME
@@ -1848,7 +1848,7 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -1856,13 +1856,13 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on: []
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: verify-gen-jsonnet
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: wire-install
 - commands:
   - apt-get update
@@ -1878,7 +1878,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -1894,7 +1894,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: mysql-integration-tests
 trigger:
   branch: main
@@ -2132,32 +2132,32 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on: []
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: yarn-install
 - commands:
   - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.1
+  image: golang:1.19.4
   name: compile-build-cmd
 - commands:
   - ./bin/build build-backend --jobs 8 --edition oss ${DRONE_TAG}
   depends_on:
   - wire-install
   - compile-build-cmd
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: build-backend
 - commands:
   - ./bin/build build-frontend --jobs 8 --edition oss ${DRONE_TAG}
@@ -2166,7 +2166,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: build-frontend
 - commands:
   - ./bin/build build-frontend-packages --jobs 8 --edition oss ${DRONE_TAG}
@@ -2175,7 +2175,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: build-frontend-packages
 - commands:
   - ./bin/build  build-plugins --jobs 8 --edition oss
@@ -2185,7 +2185,7 @@ steps:
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: build-plugins
 - commands:
   - ./bin/build package --jobs 8 --edition oss  --sign ${DRONE_TAG}
@@ -2203,14 +2203,14 @@ steps:
       from_secret: packages_gpg_public_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: package
 - commands:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: copy-packages-for-docker
 - commands:
   - ./bin/build build-docker --edition oss --shouldSave
@@ -2249,7 +2249,7 @@ steps:
   environment:
     ARCH: linux-amd64
     PORT: 3001
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: grafana-server
 - commands:
   - apt-get install -y netcat
@@ -2326,7 +2326,7 @@ steps:
   - build-frontend-packages
   environment:
     NODE_OPTIONS: --max_old_space_size=4096
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: build-storybook
   when:
     event:
@@ -2385,7 +2385,7 @@ steps:
       from_secret: gcp_key
     PRERELEASE_BUCKET:
       from_secret: prerelease_bucket
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: store-npm-packages
 trigger:
   event:
@@ -2434,13 +2434,13 @@ steps:
 - commands:
   - yarn install --immutable
   depends_on: []
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: yarn-install
 - commands:
   - yarn betterer ci
   depends_on:
   - yarn-install
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: betterer-frontend
 - commands:
   - yarn run ci:test-frontend
@@ -2448,7 +2448,7 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: test-frontend
 trigger:
   event:
@@ -2487,7 +2487,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.1
+  image: golang:1.19.4
   name: compile-build-cmd
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -2496,7 +2496,7 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -2504,25 +2504,25 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on: []
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: verify-gen-jsonnet
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: wire-install
 - commands:
   - go test -tags requires_buildifer -short -covermode=atomic -timeout=5m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: test-backend
 - commands:
   - go test -run Integration -covermode=atomic -timeout=5m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: test-backend-integration
 trigger:
   event:
@@ -2589,7 +2589,7 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -2597,13 +2597,13 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on: []
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: verify-gen-jsonnet
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: wire-install
 - commands:
   - apt-get update
@@ -2619,7 +2619,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -2635,7 +2635,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: mysql-integration-tests
 trigger:
   event:
@@ -2752,7 +2752,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: clone-enterprise
 - commands:
   - mv bin/grabpl /tmp/
@@ -2768,7 +2768,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: init-enterprise
 - commands:
   - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
@@ -2776,19 +2776,19 @@ steps:
   - init-enterprise
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.1
+  image: golang:1.19.4
   name: compile-build-cmd
 - commands:
   - make gen-go
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: yarn-install
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -2798,7 +2798,7 @@ steps:
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -2807,14 +2807,14 @@ steps:
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: verify-gen-jsonnet
 - commands:
   - ./bin/build build-backend --jobs 8 --edition enterprise ${DRONE_TAG}
   depends_on:
   - wire-install
   - compile-build-cmd
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: build-backend
 - commands:
   - ./bin/build build-frontend --jobs 8 --edition enterprise ${DRONE_TAG}
@@ -2823,7 +2823,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: build-frontend
 - commands:
   - ./bin/build build-frontend-packages --jobs 8 --edition enterprise ${DRONE_TAG}
@@ -2832,7 +2832,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: build-frontend-packages
 - commands:
   - ./bin/build  build-plugins --jobs 8 --edition enterprise
@@ -2842,7 +2842,7 @@ steps:
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: build-plugins
 - commands:
   - ./bin/build package --jobs 8 --edition enterprise  --sign ${DRONE_TAG}
@@ -2860,14 +2860,14 @@ steps:
       from_secret: packages_gpg_public_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: package
 - commands:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: copy-packages-for-docker
 - commands:
   - ./bin/build build-docker --edition enterprise --shouldSave
@@ -2907,7 +2907,7 @@ steps:
     ARCH: linux-amd64
     PORT: 3001
     RUNDIR: scripts/grafana-server/tmp-grafana-enterprise
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: grafana-server
 - commands:
   - apt-get install -y netcat
@@ -3039,7 +3039,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: clone-enterprise
 - commands:
   - mv bin/grabpl /tmp/
@@ -3055,7 +3055,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: init-enterprise
 - commands:
   - echo $DRONE_RUNNER_NAME
@@ -3071,14 +3071,14 @@ steps:
   - yarn install --immutable
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: yarn-install
 - commands:
   - yarn betterer ci
   depends_on:
   - init-enterprise
   - yarn-install
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: betterer-frontend
 - commands:
   - yarn run ci:test-frontend
@@ -3087,7 +3087,7 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: test-frontend
 trigger:
   event:
@@ -3124,7 +3124,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: clone-enterprise
 - commands:
   - mkdir -p bin
@@ -3146,7 +3146,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: init-enterprise
 - commands:
   - echo $DRONE_RUNNER_NAME
@@ -3158,7 +3158,7 @@ steps:
   - init-enterprise
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.1
+  image: golang:1.19.4
   name: compile-build-cmd
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -3168,7 +3168,7 @@ steps:
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -3177,25 +3177,25 @@ steps:
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: verify-gen-jsonnet
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: wire-install
 - commands:
   - go test -tags requires_buildifer -short -covermode=atomic -timeout=5m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: test-backend
 - commands:
   - go test -run Integration -covermode=atomic -timeout=5m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: test-backend-integration
 trigger:
   event:
@@ -3268,7 +3268,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: clone-enterprise
 - commands:
   - mv bin/grabpl /tmp/
@@ -3284,7 +3284,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: init-enterprise
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -3294,7 +3294,7 @@ steps:
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -3303,13 +3303,13 @@ steps:
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: verify-gen-jsonnet
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: wire-install
 - commands:
   - apt-get update
@@ -3325,7 +3325,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -3341,7 +3341,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: mysql-integration-tests
 - commands:
   - dockerize -wait tcp://redis:6379/0 -timeout 120s
@@ -3352,7 +3352,7 @@ steps:
   - wire-install
   environment:
     REDIS_URL: redis://redis:6379/0
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: redis-integration-tests
 - commands:
   - dockerize -wait tcp://memcached:11211 -timeout 120s
@@ -3363,7 +3363,7 @@ steps:
   - wire-install
   environment:
     MEMCACHED_HOSTS: memcached:11211
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: memcached-integration-tests
 trigger:
   event:
@@ -3500,7 +3500,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: clone-enterprise
 - commands:
   - mv bin/grabpl /tmp/
@@ -3516,7 +3516,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: init-enterprise
 - commands:
   - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
@@ -3524,19 +3524,19 @@ steps:
   - init-enterprise
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.1
+  image: golang:1.19.4
   name: compile-build-cmd
 - commands:
   - make gen-go
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: yarn-install
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -3546,7 +3546,7 @@ steps:
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: verify-gen-cue
 - commands:
   - ./bin/build build-frontend --jobs 8 --edition enterprise ${DRONE_TAG}
@@ -3555,7 +3555,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: build-frontend
 - commands:
   - ./bin/build build-frontend-packages --jobs 8 --edition enterprise ${DRONE_TAG}
@@ -3564,7 +3564,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: build-frontend-packages
 - commands:
   - ./bin/build  build-plugins --jobs 8 --edition enterprise
@@ -3574,14 +3574,14 @@ steps:
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: build-plugins
 - commands:
   - ./bin/build build-backend --jobs 8 --edition enterprise2 ${DRONE_TAG}
   depends_on:
   - wire-install
   - compile-build-cmd
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: build-backend-enterprise2
 - commands:
   - ./bin/build package --jobs 8 --edition enterprise2  --sign ${DRONE_TAG}
@@ -3599,7 +3599,7 @@ steps:
       from_secret: packages_gpg_public_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: package-enterprise2
 - commands:
   - ./bin/build upload-cdn --edition enterprise2
@@ -3619,7 +3619,7 @@ steps:
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package-enterprise2
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: copy-packages-for-docker
 - commands:
   - ./bin/build build-docker --edition enterprise2 --shouldSave
@@ -3750,7 +3750,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: clone-enterprise
 - commands:
   - mv bin/grabpl /tmp/
@@ -3766,7 +3766,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: init-enterprise
 - commands:
   - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
@@ -3774,19 +3774,19 @@ steps:
   - init-enterprise
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.1
+  image: golang:1.19.4
   name: compile-build-cmd
 - commands:
   - make gen-go
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: yarn-install
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -3796,7 +3796,7 @@ steps:
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: verify-gen-cue
 - commands:
   - ./bin/build build-frontend --jobs 8 --edition enterprise ${DRONE_TAG}
@@ -3805,7 +3805,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: build-frontend
 - commands:
   - ./bin/build build-frontend-packages --jobs 8 --edition enterprise ${DRONE_TAG}
@@ -3814,7 +3814,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: build-frontend-packages
 - commands:
   - ./bin/build  build-plugins --jobs 8 --edition enterprise
@@ -3824,14 +3824,14 @@ steps:
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: build-plugins
 - commands:
   - ./bin/build build-backend --jobs 8 --edition enterprise2 ${DRONE_TAG}
   depends_on:
   - wire-install
   - compile-build-cmd
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: build-backend-enterprise2
 - commands:
   - ./bin/build package --jobs 8 --edition enterprise2  --sign ${DRONE_TAG}
@@ -3849,7 +3849,7 @@ steps:
       from_secret: packages_gpg_public_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: package-enterprise2
 - commands:
   - ./bin/build upload-cdn --edition enterprise2
@@ -3869,7 +3869,7 @@ steps:
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package-enterprise2
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: copy-packages-for-docker
 - commands:
   - ./bin/build build-docker --edition enterprise2 --shouldSave
@@ -3995,7 +3995,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.1
+  image: golang:1.19.4
   name: compile-build-cmd
 - commands:
   - ./bin/build artifacts docker fetch --edition oss
@@ -4091,7 +4091,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.1
+  image: golang:1.19.4
   name: compile-build-cmd
 - commands:
   - ./bin/build artifacts docker fetch --edition enterprise
@@ -4170,7 +4170,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.1
+  image: golang:1.19.4
   name: compile-build-cmd
 - commands:
   - ./bin/build artifacts docker fetch --edition enterprise
@@ -4239,7 +4239,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.1
+  image: golang:1.19.4
   name: compile-build-cmd
 - commands:
   - ./bin/build artifacts docker fetch --edition enterprise2
@@ -4302,7 +4302,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.1
+  image: golang:1.19.4
   name: compile-build-cmd
 - commands:
   - ./bin/build artifacts docker fetch --edition enterprise2
@@ -4366,7 +4366,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.1
+  image: golang:1.19.4
   name: compile-build-cmd
 - commands:
   - ./bin/build artifacts docker fetch --edition enterprise
@@ -4435,7 +4435,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.1
+  image: golang:1.19.4
   name: compile-build-cmd
 - commands:
   - ./bin/build artifacts publish --security --tag $${DRONE_TAG} --src-bucket $${PRERELEASE_BUCKET}
@@ -4486,7 +4486,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.1
+  image: golang:1.19.4
   name: compile-build-cmd
 - commands:
   - ./bin/build artifacts publish --tag $${DRONE_TAG} --src-bucket $${PRERELEASE_BUCKET}
@@ -4537,12 +4537,12 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.1
+  image: golang:1.19.4
   name: compile-build-cmd
 - commands:
   - yarn install --immutable
   depends_on: []
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: yarn-install
 - commands:
   - ./bin/build artifacts npm retrieve --tag ${DRONE_TAG}
@@ -4566,7 +4566,7 @@ steps:
     NPM_TOKEN:
       from_secret: npm_token
   failure: ignore
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: release-npm-packages
 trigger:
   event:
@@ -4609,7 +4609,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.1
+  image: golang:1.19.4
   name: compile-build-cmd
 - depends_on:
   - grabpl
@@ -4706,7 +4706,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.1
+  image: golang:1.19.4
   name: compile-build-cmd
 - depends_on:
   - grabpl
@@ -4802,7 +4802,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: clone-enterprise
 - commands:
   - mv bin/grabpl /tmp/
@@ -4818,7 +4818,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: init-enterprise
 - commands:
   - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
@@ -4826,7 +4826,7 @@ steps:
   - init-enterprise
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.1
+  image: golang:1.19.4
   name: compile-build-cmd
 - commands:
   - ./bin/build artifacts-page
@@ -4835,7 +4835,7 @@ steps:
   environment:
     GCP_KEY:
       from_secret: gcp_key
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: artifacts-page
 trigger:
   event:
@@ -4880,32 +4880,32 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on: []
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: yarn-install
 - commands:
   - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.1
+  image: golang:1.19.4
   name: compile-build-cmd
 - commands:
   - ./bin/build build-backend --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - wire-install
   - compile-build-cmd
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: build-backend
 - commands:
   - ./bin/build build-frontend --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
@@ -4914,7 +4914,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: build-frontend
 - commands:
   - ./bin/build build-frontend-packages --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
@@ -4923,7 +4923,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: build-frontend-packages
 - commands:
   - ./bin/build  build-plugins --jobs 8 --edition oss
@@ -4933,7 +4933,7 @@ steps:
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: build-plugins
 - commands:
   - ./bin/build package --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER} --sign
@@ -4951,14 +4951,14 @@ steps:
       from_secret: packages_gpg_public_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: package
 - commands:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: copy-packages-for-docker
 - commands:
   - ./bin/build build-docker --edition oss --shouldSave
@@ -4997,7 +4997,7 @@ steps:
   environment:
     ARCH: linux-amd64
     PORT: 3001
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: grafana-server
 - commands:
   - apt-get install -y netcat
@@ -5074,7 +5074,7 @@ steps:
   - build-frontend-packages
   environment:
     NODE_OPTIONS: --max_old_space_size=4096
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: build-storybook
   when:
     paths:
@@ -5155,13 +5155,13 @@ steps:
 - commands:
   - yarn install --immutable
   depends_on: []
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: yarn-install
 - commands:
   - yarn betterer ci
   depends_on:
   - yarn-install
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: betterer-frontend
 - commands:
   - yarn run ci:test-frontend
@@ -5169,7 +5169,7 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: test-frontend
 trigger:
   ref:
@@ -5205,7 +5205,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.1
+  image: golang:1.19.4
   name: compile-build-cmd
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -5214,7 +5214,7 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -5222,25 +5222,25 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on: []
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: verify-gen-jsonnet
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: wire-install
 - commands:
   - go test -tags requires_buildifer -short -covermode=atomic -timeout=5m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: test-backend
 - commands:
   - go test -run Integration -covermode=atomic -timeout=5m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: test-backend-integration
 trigger:
   ref:
@@ -5304,7 +5304,7 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -5312,13 +5312,13 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on: []
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: verify-gen-jsonnet
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: wire-install
 - commands:
   - apt-get update
@@ -5334,7 +5334,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -5350,7 +5350,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: mysql-integration-tests
 trigger:
   ref:
@@ -5457,7 +5457,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: clone-enterprise
 - commands:
   - mv bin/grabpl /tmp/
@@ -5472,7 +5472,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: init-enterprise
 - commands:
   - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
@@ -5480,19 +5480,19 @@ steps:
   - init-enterprise
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.1
+  image: golang:1.19.4
   name: compile-build-cmd
 - commands:
   - make gen-go
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: yarn-install
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -5502,7 +5502,7 @@ steps:
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -5511,14 +5511,14 @@ steps:
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: verify-gen-jsonnet
 - commands:
   - ./bin/build build-backend --jobs 8 --edition enterprise --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - wire-install
   - compile-build-cmd
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: build-backend
 - commands:
   - ./bin/build build-frontend --jobs 8 --edition enterprise --build-id ${DRONE_BUILD_NUMBER}
@@ -5527,7 +5527,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: build-frontend
 - commands:
   - ./bin/build build-frontend-packages --jobs 8 --edition enterprise --build-id ${DRONE_BUILD_NUMBER}
@@ -5536,7 +5536,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: build-frontend-packages
 - commands:
   - ./bin/build  build-plugins --jobs 8 --edition enterprise
@@ -5546,7 +5546,7 @@ steps:
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: build-plugins
 - commands:
   - ./bin/build package --jobs 8 --edition enterprise --build-id ${DRONE_BUILD_NUMBER}
@@ -5565,14 +5565,14 @@ steps:
       from_secret: packages_gpg_public_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: package
 - commands:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: copy-packages-for-docker
 - commands:
   - ./bin/build build-docker --edition enterprise --shouldSave
@@ -5612,7 +5612,7 @@ steps:
     ARCH: linux-amd64
     PORT: 3001
     RUNDIR: scripts/grafana-server/tmp-grafana-enterprise
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: grafana-server
 - commands:
   - apt-get install -y netcat
@@ -5747,7 +5747,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: clone-enterprise
 - commands:
   - mv bin/grabpl /tmp/
@@ -5762,7 +5762,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: init-enterprise
 - commands:
   - echo $DRONE_RUNNER_NAME
@@ -5778,14 +5778,14 @@ steps:
   - yarn install --immutable
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: yarn-install
 - commands:
   - yarn betterer ci
   depends_on:
   - init-enterprise
   - yarn-install
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: betterer-frontend
 - commands:
   - yarn run ci:test-frontend
@@ -5794,7 +5794,7 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: test-frontend
 trigger:
   ref:
@@ -5828,7 +5828,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: clone-enterprise
 - commands:
   - mkdir -p bin
@@ -5849,7 +5849,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: init-enterprise
 - commands:
   - echo $DRONE_RUNNER_NAME
@@ -5861,7 +5861,7 @@ steps:
   - init-enterprise
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.1
+  image: golang:1.19.4
   name: compile-build-cmd
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -5871,7 +5871,7 @@ steps:
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -5880,25 +5880,25 @@ steps:
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: verify-gen-jsonnet
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: wire-install
 - commands:
   - go test -tags requires_buildifer -short -covermode=atomic -timeout=5m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: test-backend
 - commands:
   - go test -run Integration -covermode=atomic -timeout=5m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: test-backend-integration
 trigger:
   ref:
@@ -5968,7 +5968,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: clone-enterprise
 - commands:
   - mv bin/grabpl /tmp/
@@ -5983,7 +5983,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: init-enterprise
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -5993,7 +5993,7 @@ steps:
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -6002,13 +6002,13 @@ steps:
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: verify-gen-jsonnet
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: wire-install
 - commands:
   - apt-get update
@@ -6024,7 +6024,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -6040,7 +6040,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: mysql-integration-tests
 - commands:
   - dockerize -wait tcp://redis:6379/0 -timeout 120s
@@ -6051,7 +6051,7 @@ steps:
   - wire-install
   environment:
     REDIS_URL: redis://redis:6379/0
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: redis-integration-tests
 - commands:
   - dockerize -wait tcp://memcached:11211 -timeout 120s
@@ -6062,7 +6062,7 @@ steps:
   - wire-install
   environment:
     MEMCACHED_HOSTS: memcached:11211
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: memcached-integration-tests
 trigger:
   ref:
@@ -6189,7 +6189,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: clone-enterprise
 - commands:
   - mv bin/grabpl /tmp/
@@ -6204,7 +6204,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: init-enterprise
 - commands:
   - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
@@ -6212,19 +6212,19 @@ steps:
   - init-enterprise
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.1
+  image: golang:1.19.4
   name: compile-build-cmd
 - commands:
   - make gen-go
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: yarn-install
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -6234,7 +6234,7 @@ steps:
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: verify-gen-cue
 - commands:
   - ./bin/build build-frontend --jobs 8 --edition enterprise --build-id ${DRONE_BUILD_NUMBER}
@@ -6243,7 +6243,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: build-frontend
 - commands:
   - ./bin/build build-frontend-packages --jobs 8 --edition enterprise --build-id ${DRONE_BUILD_NUMBER}
@@ -6252,7 +6252,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: build-frontend-packages
 - commands:
   - ./bin/build  build-plugins --jobs 8 --edition enterprise
@@ -6262,7 +6262,7 @@ steps:
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: build-plugins
 - commands:
   - ./bin/build build-backend --jobs 8 --edition enterprise2 --build-id ${DRONE_BUILD_NUMBER}
@@ -6270,7 +6270,7 @@ steps:
   depends_on:
   - wire-install
   - compile-build-cmd
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: build-backend-enterprise2
 - commands:
   - ./bin/build package --jobs 8 --edition enterprise2 --build-id ${DRONE_BUILD_NUMBER}
@@ -6289,7 +6289,7 @@ steps:
       from_secret: packages_gpg_public_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: package-enterprise2
 - commands:
   - ./bin/build upload-cdn --edition enterprise2
@@ -6309,7 +6309,7 @@ steps:
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package-enterprise2
-  image: grafana/build-container:1.7.2
+  image: grafana/build-container:v1.7.1
   name: copy-packages-for-docker
 - commands:
   - ./bin/build build-docker --edition enterprise2 --shouldSave
@@ -6539,7 +6539,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.20.1
+  image: golang:1.19.4
   name: compile-build-cmd
 - commands:
   - ./bin/build publish grafana-com --edition oss
@@ -6660,6 +6660,6 @@ kind: secret
 name: aws_secret_access_key
 ---
 kind: signature
-hmac: f7d8c2ffc5017c41f66d2cceda20bbfc94afc46a5669984a83a23419f58d3dee
+hmac: 1847568b29364d0ba065b1f65d6536f24f636dbf36ce2cdccf05e8f80e2b9caf
 
 ...

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # syntax=docker/dockerfile:1
 
-ARG BASE_IMAGE=alpine:3.17
-ARG JS_IMAGE=node:18-alpine3.17
-ARG GO_IMAGE=golang:1.20.1-alpine3.17
+ARG BASE_IMAGE=alpine:3.15
+ARG JS_IMAGE=node:18-alpine3.15
+ARG GO_IMAGE=golang:1.19.4-alpine3.17
 
 ARG GO_SRC=go-builder
 ARG JS_SRC=js-builder
@@ -106,12 +106,11 @@ RUN if grep -i -q alpine /etc/issue; then \
 
 # glibc support for alpine x86_64 only
 RUN if grep -i -q alpine /etc/issue && [ `arch` = "x86_64" ]; then \
-      wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub && \
       wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.35-r0/glibc-2.35-r0.apk \
         -O /tmp/glibc-2.35-r0.apk && \
       wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.35-r0/glibc-bin-2.35-r0.apk \
         -O /tmp/glibc-bin-2.35-r0.apk && \
-      apk add --force-overwrite --no-cache /tmp/glibc-2.35-r0.apk /tmp/glibc-bin-2.35-r0.apk && \
+      apk add --no-cache --allow-untrusted /tmp/glibc-2.35-r0.apk /tmp/glibc-bin-2.35-r0.apk && \
       rm -f /lib64/ld-linux-x86-64.so.2 && \
       ln -s /usr/glibc-compat/lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2 && \
       rm -f /tmp/glibc-2.35-r0.apk && \

--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ build-docker-full-ubuntu: ## Build Docker image based on Ubuntu for development.
 	DOCKER_BUILDKIT=1 \
 	docker build \
 	--build-arg BASE_IMAGE=ubuntu:20.04 \
-	--build-arg GO_IMAGE=golang:1.20.1 \
+	--build-arg GO_IMAGE=golang:1.19.4 \
 	--tag grafana/grafana:dev-ubuntu .
 
 ##@ Services

--- a/scripts/build/ci-build/Dockerfile
+++ b/scripts/build/ci-build/Dockerfile
@@ -108,7 +108,7 @@ RUN rm dockerize-linux-amd64-v${DOCKERIZE_VERSION}.tar.gz
 # Use old Debian (LTS into 2024) in order to ensure binary compatibility with older glibc's.
 FROM debian:buster-20220822
 
-ENV GOVERSION=1.20.1 \
+ENV GOVERSION=1.19.4 \
     PATH=/usr/local/go/bin:$PATH \
     GOPATH=/go \
     NODEVERSION=18.12.0-1nodesource1 \

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -9,14 +9,14 @@ load(
 )
 
 grabpl_version = "v3.0.21"
-build_image = "grafana/build-container:1.7.2"
+build_image = "grafana/build-container:v1.7.1"
 publish_image = "grafana/grafana-ci-deploy:1.3.3"
 deploy_docker_image = "us.gcr.io/kubernetes-dev/drone/plugins/deploy-image"
 alpine_image = "alpine:3.17.1"
 curl_image = "byrnedo/alpine-curl:0.1.8"
 windows_image = "mcr.microsoft.com/windows:1809"
 wix_image = "grafana/ci-wix:0.1.1"
-go_image = "golang:1.20.1"
+go_image = "golang:1.19.4"
 
 trigger_oss = {
     "repo": [


### PR DESCRIPTION
This reverts commit 747ddf7b33e0e74aa2b8875567497b27f5d6a675.

I think the linters broke, so yay.