### PR TITLE
AuthN: Add in-memory cache for oauth token refresh hook

### DIFF
--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -148,7 +148,7 @@ func ProvideService(
 	s.RegisterPostAuthHook(userSyncService.SyncLastSeenHook, 40)
 
 	if features.IsEnabled(featuremgmt.FlagAccessTokenExpirationCheck) {
-		s.RegisterPostAuthHook(sync.ProvideOauthTokenSync(oauthTokenService, sessionService).SyncOauthTokenHook, 60)
+		s.RegisterPostAuthHook(sync.ProvideOAuthTokenSync(oauthTokenService, sessionService).SyncOauthTokenHook, 60)
 	}
 
 	s.RegisterPostAuthHook(userSyncService.FetchSyncedUserHook, 100)

--- a/pkg/services/authn/authnimpl/sync/oauth_token_sync.go
+++ b/pkg/services/authn/authnimpl/sync/oauth_token_sync.go
@@ -98,7 +98,7 @@ func getOAuthTokenCacheTTL(t time.Time) time.Duration {
 		return maxOAuthTokenCacheTTL
 	}
 
-	ttl := t.Sub(time.Now())
+	ttl := time.Until(t)
 	if ttl > maxOAuthTokenCacheTTL {
 		return maxOAuthTokenCacheTTL
 	}

--- a/pkg/services/authn/authnimpl/sync/oauth_token_sync.go
+++ b/pkg/services/authn/authnimpl/sync/oauth_token_sync.go
@@ -18,8 +18,8 @@ var (
 	errExpiredAccessToken = errutil.NewBase(errutil.StatusUnauthorized, "oauth.expired-token")
 )
 
-func ProvideOauthTokenSync(service oauthtoken.OAuthTokenService, sessionService auth.UserTokenService) *OauthTokenSync {
-	return &OauthTokenSync{
+func ProvideOAuthTokenSync(service oauthtoken.OAuthTokenService, sessionService auth.UserTokenService) *OAuthTokenSync {
+	return &OAuthTokenSync{
 		log.New("oauth_token.sync"),
 		localcache.New(10*time.Minute, 15*time.Minute),
 		service,
@@ -27,14 +27,14 @@ func ProvideOauthTokenSync(service oauthtoken.OAuthTokenService, sessionService 
 	}
 }
 
-type OauthTokenSync struct {
+type OAuthTokenSync struct {
 	log            log.Logger
 	cache          *localcache.CacheService
 	service        oauthtoken.OAuthTokenService
 	sessionService auth.UserTokenService
 }
 
-func (s *OauthTokenSync) SyncOauthTokenHook(ctx context.Context, identity *authn.Identity, _ *authn.Request) error {
+func (s *OAuthTokenSync) SyncOauthTokenHook(ctx context.Context, identity *authn.Identity, _ *authn.Request) error {
 	namespace, id := identity.NamespacedID()
 	// only perform oauth token check if identity is a user
 	if namespace != authn.NamespaceUser {

--- a/pkg/services/authn/authnimpl/sync/oauth_token_sync.go
+++ b/pkg/services/authn/authnimpl/sync/oauth_token_sync.go
@@ -21,7 +21,7 @@ var (
 func ProvideOAuthTokenSync(service oauthtoken.OAuthTokenService, sessionService auth.UserTokenService) *OAuthTokenSync {
 	return &OAuthTokenSync{
 		log.New("oauth_token.sync"),
-		localcache.New(10*time.Minute, 15*time.Minute),
+		localcache.New(maxOAuthTokenCacheTTL, 15*time.Minute),
 		service,
 		sessionService,
 	}

--- a/pkg/services/authn/authnimpl/sync/oauth_token_sync_test.go
+++ b/pkg/services/authn/authnimpl/sync/oauth_token_sync_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/user"
 )
 
-func TestOauthTokenSync_SyncOauthTokenHook(t *testing.T) {
+func TestOauthTokenSync_SyncOAuthTokenHook(t *testing.T) {
 	type testCase struct {
 		desc     string
 		identity *authn.Identity
@@ -118,7 +118,7 @@ func TestOauthTokenSync_SyncOauthTokenHook(t *testing.T) {
 				},
 			}
 
-			sync := &OauthTokenSync{
+			sync := &OAuthTokenSync{
 				log:            log.NewNopLogger(),
 				cache:          localcache.New(0, 0),
 				service:        service,

--- a/pkg/services/authn/authnimpl/sync/oauth_token_sync_test.go
+++ b/pkg/services/authn/authnimpl/sync/oauth_token_sync_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/grafana/grafana/pkg/infra/localcache"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/auth"
 	"github.com/grafana/grafana/pkg/services/auth/authtest"
@@ -119,6 +120,7 @@ func TestOauthTokenSync_SyncOauthTokenHook(t *testing.T) {
 
 			sync := &OauthTokenSync{
 				log:            log.NewNopLogger(),
+				cache:          localcache.New(0, 0),
 				service:        service,
 				sessionService: sessionService,
 			}


### PR DESCRIPTION
**What is this feature?**
Add cache support for SyncOauthTokenHook so we don't perform the check on every request.

If the token has no expire time we cache it for maxOAuthTokenCacheTTL, currently set to 10 minutes. If we have a expire time we cache it for the time remaning if it is less than maxOAuthTokenCacheTTL otherwise we use maxOAuthTokenCacheTTL

**Special notes for your reviewer**:

