### PR TITLE
NestedFolders: Fix nested folder deletion

### DIFF
--- a/pkg/services/folder/folderimpl/folder.go
+++ b/pkg/services/folder/folderimpl/folder.go
@@ -520,6 +520,9 @@ func (s *Service) Move(ctx context.Context, cmd *folder.MoveFolderCommand) (*fol
 	})
 }
 
+// nestedFolderDelete inspects the folder referenced by the cmd argument, deletes all the entries for
+// its descendant folders (folders which are nested within it either directly or indirectly) from
+// the folder store and returns the UIDs for all its descendants.
 func (s *Service) nestedFolderDelete(ctx context.Context, cmd *folder.DeleteFolderCommand) ([]string, error) {
 	logger := s.log.FromContext(ctx)
 	result := []string{}

--- a/pkg/services/folder/folderimpl/folder_test.go
+++ b/pkg/services/folder/folderimpl/folder_test.go
@@ -46,7 +46,7 @@ func TestIntegrationProvideFolderService(t *testing.T) {
 	})
 }
 
-func TestIntegrationFolderService(t *testing.T) { //have to mock the result of nested folder
+func TestIntegrationFolderService(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
@@ -221,7 +221,7 @@ func TestIntegrationFolderService(t *testing.T) { //have to mock the result of n
 				require.Equal(t, f, reqResult)
 			})
 
-			t.Run("When deleting folder by uid should not return access denied error", func(t *testing.T) { //
+			t.Run("When deleting folder by uid should not return access denied error", func(t *testing.T) {
 				f := folder.NewFolder(util.GenerateShortUID(), "")
 				f.ID = rand.Int63()
 				f.UID = util.GenerateShortUID()
@@ -675,49 +675,6 @@ func TestNestedFolderService(t *testing.T) {
 			require.Nil(t, f)
 		})
 
-		t.Run("create returns error if maximum depth reached", func(t *testing.T) {
-			// This test creates and deletes the dashboard, so needs some extra setup.
-			g := guardian.New
-			guardian.MockDashboardGuardian(&guardian.FakeDashboardGuardian{CanSaveValue: true})
-			t.Cleanup(func() {
-				guardian.New = g
-			})
-
-			// dashboard store commands that should be called.
-			dashStore := &dashboards.FakeDashboardStore{}
-			dashStore.On("ValidateDashboardBeforeSave", mock.Anything, mock.AnythingOfType("*dashboards.Dashboard"), mock.AnythingOfType("bool")).Return(true, nil).Times(2)
-			dashStore.On("SaveDashboard", mock.Anything, mock.AnythingOfType("dashboards.SaveDashboardCommand")).Return(&dashboards.Dashboard{}, nil)
-			var actualCmd *dashboards.DeleteDashboardCommand
-			dashStore.On("DeleteDashboard", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
-				actualCmd = args.Get(1).(*dashboards.DeleteDashboardCommand)
-			}).Return(nil).Once()
-
-			dashboardFolderStore := foldertest.NewFakeFolderStore(t)
-			dashboardFolderStore.On("GetFolderByID", mock.Anything, mock.AnythingOfType("int64"), mock.AnythingOfType("int64")).Return(&folder.Folder{}, nil)
-
-			parents := make([]*folder.Folder, 0, folder.MaxNestedFolderDepth)
-			for i := 0; i < folder.MaxNestedFolderDepth; i++ {
-				parents = append(parents, &folder.Folder{UID: fmt.Sprintf("folder%d", i)})
-			}
-
-			nestedFolderStore := NewFakeStore()
-			//nestedFolderStore.ExpectedFolder = &folder.Folder{UID: "myFolder", ParentUID: "newFolder"}
-			nestedFolderStore.ExpectedParentFolders = parents
-
-			folderSvc := setup(t, dashStore, dashboardFolderStore, nestedFolderStore, featuremgmt.WithFeatures("nestedFolders"), actest.FakeAccessControl{
-				ExpectedEvaluate: true,
-			}, dbtest.NewFakeDB())
-			_, err := folderSvc.Create(context.Background(), &folder.CreateFolderCommand{
-				Title:        "folder",
-				OrgID:        orgID,
-				ParentUID:    parents[len(parents)-1].UID,
-				UID:          util.GenerateShortUID(),
-				SignedInUser: usr,
-			})
-			assert.ErrorIs(t, err, folder.ErrMaximumDepthReached)
-			require.NotNil(t, actualCmd)
-		})
-		// can do 3-4 layers instead of full 8 ; check that when do
 		t.Run("create returns error if maximum depth reached", func(t *testing.T) {
 			// This test creates and deletes the dashboard, so needs some extra setup.
 			g := guardian.New

--- a/pkg/services/folder/folderimpl/folder_test.go
+++ b/pkg/services/folder/folderimpl/folder_test.go
@@ -355,7 +355,7 @@ func TestIntegrationDeleteNestedFolders(t *testing.T) {
 		origNewGuardian := guardian.New
 		guardian.MockDashboardGuardian(&guardian.FakeDashboardGuardian{CanSaveValue: true, CanViewValue: true})
 
-		ancestorUIDs := CreateLegacySubtree(t, nestedFolderStore, serviceWithFlagOn, 3, "", createCmd)
+		ancestorUIDs := CreateSubtreeInStore(t, nestedFolderStore, serviceWithFlagOn, 3, "", createCmd)
 
 		deleteCmd := folder.DeleteFolderCommand{
 			UID:          ancestorUIDs[0],
@@ -397,7 +397,7 @@ func TestIntegrationDeleteNestedFolders(t *testing.T) {
 		origNewGuardian := guardian.New
 		guardian.MockDashboardGuardian(&guardian.FakeDashboardGuardian{CanSaveValue: true, CanViewValue: true})
 
-		ancestorUIDs := CreateLegacySubtree(t, nestedFolderStore, serviceWithFlagOn, 1, "", createCmd)
+		ancestorUIDs := CreateSubtreeInStore(t, nestedFolderStore, serviceWithFlagOn, 1, "", createCmd)
 
 		deleteCmd := folder.DeleteFolderCommand{
 			UID:          ancestorUIDs[0],
@@ -856,7 +856,7 @@ func TestNestedFolderService(t *testing.T) {
 	})
 }
 
-func CreateLegacySubtree(t *testing.T, store *sqlStore, service *Service, depth int, prefix string, cmd folder.CreateFolderCommand) []string {
+func CreateSubtreeInStore(t *testing.T, store *sqlStore, service *Service, depth int, prefix string, cmd folder.CreateFolderCommand) []string {
 	t.Helper()
 
 	ancestorUIDs := []string{}

--- a/pkg/services/folder/folderimpl/sqlstore_test.go
+++ b/pkg/services/folder/folderimpl/sqlstore_test.go
@@ -245,7 +245,7 @@ func TestIntegrationDeleteNestedFolders(t *testing.T) {
 
 		for i, uid := range ancestorUIDs {
 			// dashboard table
-			_, err := serviceWithFlagOn.getFolderByUID(context.Background(), orgID, uid)
+			_, err := serviceWithFlagOn.dashboardFolderStore.GetFolderByUID(context.Background(), orgID, uid)
 			require.ErrorIs(t, err, dashboards.ErrFolderNotFound)
 			// folder table
 			_, err = serviceWithFlagOn.store.Get(context.Background(), folder.GetFolderQuery{UID: &ancestorUIDs[i], OrgID: orgID})
@@ -287,7 +287,7 @@ func TestIntegrationDeleteNestedFolders(t *testing.T) {
 
 		for i, uid := range ancestorUIDs {
 			// dashboard table
-			_, err := serviceWithFlagOff.getFolderByUID(context.Background(), orgID, uid)
+			_, err := serviceWithFlagOff.dashboardFolderStore.GetFolderByUID(context.Background(), orgID, uid)
 			require.ErrorIs(t, err, dashboards.ErrFolderNotFound)
 			// folder table
 			_, err = serviceWithFlagOff.store.Get(context.Background(), folder.GetFolderQuery{UID: &ancestorUIDs[i], OrgID: orgID})

--- a/pkg/services/folder/folderimpl/sqlstore_test.go
+++ b/pkg/services/folder/folderimpl/sqlstore_test.go
@@ -299,6 +299,10 @@ func TestIntegrationDeleteNestedFolders(t *testing.T) {
 		}
 		t.Cleanup(func() {
 			guardian.New = origNewGuardian
+			for _, uid := range ancestorUIDs {
+				err := serviceWithFlagOff.store.Delete(context.Background(), uid, orgID)
+				require.NoError(t, err)
+			}
 		})
 	})
 }

--- a/pkg/services/folder/folderimpl/sqlstore_test.go
+++ b/pkg/services/folder/folderimpl/sqlstore_test.go
@@ -788,7 +788,7 @@ func TestIntegrationNestedFolderDelete(t *testing.T) {
 				err = service.Delete(context.Background(), &deleteCmd)
 				require.NoError(t, err)
 
-				for _, uid := range ancestorUIDs {
+				for i, uid := range ancestorUIDs {
 					// double check that we need both get calls to cover both tables
 					_, err := service.getFolderByUID(context.Background(), orgID, uid)
 					require.ErrorIs(t, err, dashboards.ErrFolderNotFound)

--- a/pkg/services/folder/folderimpl/sqlstore_test.go
+++ b/pkg/services/folder/folderimpl/sqlstore_test.go
@@ -9,21 +9,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/grafana/pkg/bus"
-	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/infra/tracing"
-	"github.com/grafana/grafana/pkg/services/dashboards"
-	"github.com/grafana/grafana/pkg/services/dashboards/database"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/folder"
-	"github.com/grafana/grafana/pkg/services/guardian"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/org/orgimpl"
 	"github.com/grafana/grafana/pkg/services/quota/quotatest"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
-	"github.com/grafana/grafana/pkg/services/tag/tagimpl"
-	"github.com/grafana/grafana/pkg/services/user"
-	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
 )
 
@@ -193,113 +184,6 @@ func TestIntegrationDelete(t *testing.T) {
 		})
 		require.NoError(t, err)
 		assert.Len(t, children, 0)
-	})
-}
-
-func TestIntegrationDeleteNestedFolders(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping integration test")
-	}
-	db := sqlstore.InitTestDB(t)
-	quotaService := quotatest.New(false, nil)
-	folderStore := ProvideDashboardFolderStore(db)
-
-	cfg := setting.NewCfg()
-
-	featuresFlagOn := featuremgmt.WithFeatures("nestedFolders")
-	dashStore, err := database.ProvideDashboardStore(db, db.Cfg, featuresFlagOn, tagimpl.ProvideService(db, db.Cfg), quotaService)
-	require.NoError(t, err)
-	nestedFolderStore := ProvideStore(db, db.Cfg, featuresFlagOn)
-
-	serviceWithFlagOn := &Service{
-		cfg:                  cfg,
-		log:                  log.New("test-folder-service"),
-		dashboardStore:       dashStore,
-		dashboardFolderStore: folderStore,
-		store:                nestedFolderStore,
-		features:             featuresFlagOn,
-		bus:                  bus.ProvideBus(tracing.InitializeTracerForTest()),
-		db:                   db,
-	}
-
-	signedInUser := user.SignedInUser{UserID: 1, OrgID: orgID}
-	createCmd := folder.CreateFolderCommand{
-		OrgID:        orgID,
-		ParentUID:    "",
-		SignedInUser: &signedInUser,
-	}
-
-	t.Run("With nested folder feature flag on", func(t *testing.T) {
-		origNewGuardian := guardian.New
-		guardian.MockDashboardGuardian(&guardian.FakeDashboardGuardian{CanSaveValue: true, CanViewValue: true})
-
-		ancestorUIDs := CreateSubTree(t, nestedFolderStore, serviceWithFlagOn, 3, "", createCmd)
-
-		deleteCmd := folder.DeleteFolderCommand{
-			UID:          ancestorUIDs[0],
-			OrgID:        orgID,
-			SignedInUser: &signedInUser,
-		}
-		err = serviceWithFlagOn.Delete(context.Background(), &deleteCmd)
-		require.NoError(t, err)
-
-		for i, uid := range ancestorUIDs {
-			// dashboard table
-			_, err := serviceWithFlagOn.dashboardFolderStore.GetFolderByUID(context.Background(), orgID, uid)
-			require.ErrorIs(t, err, dashboards.ErrFolderNotFound)
-			// folder table
-			_, err = serviceWithFlagOn.store.Get(context.Background(), folder.GetFolderQuery{UID: &ancestorUIDs[i], OrgID: orgID})
-			require.ErrorIs(t, err, folder.ErrFolderNotFound)
-		}
-		t.Cleanup(func() {
-			guardian.New = origNewGuardian
-		})
-	})
-	t.Run("With feature flag unset", func(t *testing.T) {
-		featuresFlagOff := featuremgmt.WithFeatures()
-		dashStore, err := database.ProvideDashboardStore(db, db.Cfg, featuresFlagOff, tagimpl.ProvideService(db, db.Cfg), quotaService)
-		require.NoError(t, err)
-		nestedFolderStore := ProvideStore(db, db.Cfg, featuresFlagOff)
-
-		serviceWithFlagOff := &Service{
-			cfg:                  cfg,
-			log:                  log.New("test-folder-service"),
-			dashboardStore:       dashStore,
-			dashboardFolderStore: folderStore,
-			store:                nestedFolderStore,
-			features:             featuresFlagOff,
-			bus:                  bus.ProvideBus(tracing.InitializeTracerForTest()),
-			db:                   db,
-		}
-
-		origNewGuardian := guardian.New
-		guardian.MockDashboardGuardian(&guardian.FakeDashboardGuardian{CanSaveValue: true, CanViewValue: true})
-
-		ancestorUIDs := CreateSubTree(t, nestedFolderStore, serviceWithFlagOn, 1, "", createCmd)
-
-		deleteCmd := folder.DeleteFolderCommand{
-			UID:          ancestorUIDs[0],
-			OrgID:        orgID,
-			SignedInUser: &signedInUser,
-		}
-		err = serviceWithFlagOff.Delete(context.Background(), &deleteCmd)
-		require.NoError(t, err)
-
-		for i, uid := range ancestorUIDs {
-			// dashboard table
-			_, err := serviceWithFlagOff.dashboardFolderStore.GetFolderByUID(context.Background(), orgID, uid)
-			require.ErrorIs(t, err, dashboards.ErrFolderNotFound)
-			// folder table
-			_, err = serviceWithFlagOff.store.Get(context.Background(), folder.GetFolderQuery{UID: &ancestorUIDs[i], OrgID: orgID})
-			require.NoError(t, err)
-		}
-		t.Cleanup(func() {
-			guardian.New = origNewGuardian
-			for _, uid := range ancestorUIDs {
-				err := serviceWithFlagOff.store.Delete(context.Background(), uid, orgID)
-				require.NoError(t, err)
-			}
-		})
 	})
 }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

----


**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]
-->

**What is this feature?**

It's a fix for a bug relating to the deletion of nested folders as described in the linked issue.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/63080

**Special notes for your reviewer**:
I (@suntala) still need to try out the fix by reproducing the issue, but hopefully the new integration test ([TestIntegrationDeleteNestedFolders](https://github.com/grafana/grafana/blob/41fb1151fe01eb6ee72529032169674d6b0a33a4/pkg/services/folder/folderimpl/sqlstore_test.go#L199)) makes it clear that the fix works. This integration test has also been intended as a replacement for two test cases ([1](https://github.com/grafana/grafana/blob/main/pkg/services/folder/folderimpl/folder_test.go#L695), [2](https://github.com/grafana/grafana/blob/main/pkg/services/folder/folderimpl/folder_test.go#L381)). 

Additionally, I'd be curious to know if anyone has suggestions for how to better test deletion when the feature flag is off ([old](https://github.com/grafana/grafana/blob/main/pkg/services/folder/folderimpl/folder_test.go#L381) way, [new](https://github.com/grafana/grafana/blob/41fb1151fe01eb6ee72529032169674d6b0a33a4/pkg/services/folder/folderimpl/sqlstore_test.go#L258) way). The new approach is to create a folder with the feature flag on so that it gets added to both the `dashboard` table and the `folder` one. Then we proceed with deletion and check that the entry in the `folder` table hasn't been removed. 

When coming up with this approach, a corner case for this bug became apparent. Someone could theoretically turn the nested folder feature flag on, create some nested folders, turn the flag off and then delete the parent folder. This deletion wouldn't be complete. It would [leave behind entries in the folder table](https://github.com/grafana/grafana/blob/41fb1151fe01eb6ee72529032169674d6b0a33a4/pkg/services/folder/folderimpl/sqlstore_test.go#L293-L294). A fix for this would be to modify the [legacyDelete](https://github.com/grafana/grafana/blob/main/pkg/services/folder/folderimpl/folder.go#L455) method to check the folder table for nested folders when performing a deletion. I didn't implement this because hopefully people wouldn't use the nested folder flag in this way. However, please let me know if you think it would be valuable to do so.

I suggest not going through the commits individually because they aren't well structured and there was a change of approach halfway through.

