### PR TITLE
AuthN: Fix user sync with multiple client

### DIFF
--- a/pkg/services/authn/authnimpl/sync/user_sync.go
+++ b/pkg/services/authn/authnimpl/sync/user_sync.go
@@ -65,7 +65,7 @@ func (s *UserSync) SyncUserHook(ctx context.Context, id *authn.Identity, _ *auth
 	}
 
 	// Does user exist in the database?
-	usr, _, errUserInDB := s.getUser(ctx, id)
+	usr, userAuth, errUserInDB := s.getUser(ctx, id)
 	if errUserInDB != nil && !errors.Is(errUserInDB, user.ErrUserNotFound) {
 		s.log.Error("error retrieving user", "error", errUserInDB,
 			"auth_module", id.AuthModule, "auth_id", id.AuthID,
@@ -98,8 +98,8 @@ func (s *UserSync) SyncUserHook(ctx context.Context, id *authn.Identity, _ *auth
 	}
 
 	// update user
-	if errUpdate := s.updateUserAttributes(ctx, usr, id); errUpdate != nil {
-		s.log.Error("error creating user", "error", errUpdate,
+	if errUpdate := s.updateUserAttributes(ctx, usr, id, userAuth); errUpdate != nil {
+		s.log.Error("error updating user", "error", errUpdate,
 			"auth_module", id.AuthModule, "auth_id", id.AuthID,
 			"login", usr.Login, "email", usr.Email,
 			"id_login", id.Login, "id_email", id.Email,
@@ -108,15 +108,6 @@ func (s *UserSync) SyncUserHook(ctx context.Context, id *authn.Identity, _ *auth
 	}
 
 	syncUserToIdentity(usr, id)
-
-	// persist the latest auth info token
-	if errAuthInfo := s.updateAuthInfo(ctx, id); errAuthInfo != nil {
-		s.log.Error("error creating user", "error", errAuthInfo,
-			"auth_module", id.AuthModule, "auth_id", id.AuthID,
-		)
-		return errSyncUserInternal.Errorf("unable to update auth info")
-	}
-
 	return nil
 }
 
@@ -168,28 +159,33 @@ func (s *UserSync) SyncLastSeenHook(ctx context.Context, identity *authn.Identit
 	return nil
 }
 
-func (s *UserSync) updateAuthInfo(ctx context.Context, id *authn.Identity) error {
-	if id.AuthModule != "" && id.OAuthToken != nil && id.AuthID != "" {
+func (s *UserSync) upsertAuthConnection(ctx context.Context, userID int64, identity *authn.Identity, createConnection bool) error {
+	if identity.AuthModule == "" {
 		return nil
 	}
 
-	namespace, userID := id.NamespacedID()
-	if namespace != authn.NamespaceUser && userID <= 0 {
-		return fmt.Errorf("invalid namespace %q for user ID %q", namespace, userID)
-	}
-
-	updateCmd := &login.UpdateAuthInfoCommand{
-		AuthModule: id.AuthModule,
-		AuthId:     id.AuthID,
-		UserId:     userID,
-		OAuthToken: id.OAuthToken,
+	// If a user does not a connection to a specific auth module, create it.
+	// This can happen when: using multiple auth client where the same user exists in several or
+	// changing to new auth client
+	if createConnection {
+		return s.authInfoService.SetAuthInfo(ctx, &login.SetAuthInfoCommand{
+			UserId:     userID,
+			AuthModule: identity.AuthModule,
+			AuthId:     identity.AuthID,
+			OAuthToken: identity.OAuthToken,
+		})
 	}
 
 	s.log.Debug("Updating user_auth info", "user_id", userID)
-	return s.authInfoService.UpdateAuthInfo(ctx, updateCmd)
+	return s.authInfoService.UpdateAuthInfo(ctx, &login.UpdateAuthInfoCommand{
+		UserId:     userID,
+		AuthId:     identity.AuthID,
+		AuthModule: identity.AuthModule,
+		OAuthToken: identity.OAuthToken,
+	})
 }
 
-func (s *UserSync) updateUserAttributes(ctx context.Context, usr *user.User, id *authn.Identity) error {
+func (s *UserSync) updateUserAttributes(ctx context.Context, usr *user.User, id *authn.Identity, userAuth *login.UserAuth) error {
 	// sync user info
 	updateCmd := &user.UpdateUserCommand{
 		UserID: usr.ID,
@@ -221,11 +217,13 @@ func (s *UserSync) updateUserAttributes(ctx context.Context, usr *user.User, id 
 		}
 	}
 
+	// FIXME(kalleep): Should this be its own hook?
 	if usr.IsDisabled && id.ClientParams.EnableDisabledUsers {
 		usr.IsDisabled = false
-		if errDisableUser := s.userService.Disable(ctx,
-			&user.DisableUserCommand{
-				UserID: usr.ID, IsDisabled: false}); errDisableUser != nil {
+		if errDisableUser := s.userService.Disable(
+			ctx,
+			&user.DisableUserCommand{UserID: usr.ID, IsDisabled: false},
+		); errDisableUser != nil {
 			return errDisableUser
 		}
 	}
@@ -238,12 +236,12 @@ func (s *UserSync) updateUserAttributes(ctx context.Context, usr *user.User, id 
 		}
 	}
 
-	return nil
+	return s.upsertAuthConnection(ctx, usr.ID, id, userAuth == nil)
 }
 
 func (s *UserSync) createUser(ctx context.Context, id *authn.Identity) (*user.User, error) {
-	// quota check (FIXME: (jguer) this should be done in the user service)
-	// we may insert in both user and org_user tables
+	// FIXME(jguer): this should be done in the user service
+	// quota check: we can have quotas on both global and org level
 	// therefore we need to query check quota for both user and org services
 	for _, srv := range []string{user.QuotaTargetSrv, org.QuotaTargetSrv} {
 		limitReached, errLimit := s.quotaService.CheckQuotaReached(ctx, quota.TargetSrv(srv), nil)
@@ -272,15 +270,9 @@ func (s *UserSync) createUser(ctx context.Context, id *authn.Identity) (*user.Us
 		return nil, errCreateUser
 	}
 
-	if id.AuthModule != "" && id.AuthID != "" {
-		if errSetAuth := s.authInfoService.SetAuthInfo(ctx, &login.SetAuthInfoCommand{
-			UserId:     usr.ID,
-			AuthModule: id.AuthModule,
-			AuthId:     id.AuthID,
-			OAuthToken: id.OAuthToken,
-		}); errSetAuth != nil {
-			return nil, errSetAuth
-		}
+	err := s.upsertAuthConnection(ctx, usr.ID, id, true)
+	if err != nil {
+		return nil, err
 	}
 
 	return usr, nil
@@ -289,10 +281,7 @@ func (s *UserSync) createUser(ctx context.Context, id *authn.Identity) (*user.Us
 func (s *UserSync) getUser(ctx context.Context, identity *authn.Identity) (*user.User, *login.UserAuth, error) {
 	// Check auth info fist
 	if identity.AuthID != "" && identity.AuthModule != "" {
-		query := &login.GetAuthInfoQuery{
-			AuthId:     identity.AuthID,
-			AuthModule: identity.AuthModule,
-		}
+		query := &login.GetAuthInfoQuery{AuthId: identity.AuthID, AuthModule: identity.AuthModule}
 		errGetAuthInfo := s.authInfoService.GetAuthInfo(ctx, query)
 		if errGetAuthInfo == nil {
 			usr, errGetByID := s.userService.GetByID(ctx, &user.GetUserByIDQuery{ID: query.Result.UserId})
@@ -312,7 +301,23 @@ func (s *UserSync) getUser(ctx context.Context, identity *authn.Identity) (*user
 
 	// Check user table to grab existing user
 	usr, err := s.lookupByOneOf(ctx, identity.ClientParams.LookUpParams)
-	return usr, nil, err
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var userAuth *login.UserAuth
+	// Special case for generic oauth: generic oauth does not store authID,
+	// so we need to find the user first then check for the userAuth connection by module and userID
+	if identity.AuthModule == login.GenericOAuthModule {
+		query := &login.GetAuthInfoQuery{AuthModule: identity.AuthModule, UserId: usr.ID}
+		err := s.authInfoService.GetAuthInfo(ctx, query)
+		if err != nil && !errors.Is(err, user.ErrUserNotFound) {
+			return nil, nil, err
+		}
+		userAuth = query.Result
+	}
+
+	return usr, userAuth, nil
 }
 
 func (s *UserSync) lookupByOneOf(ctx context.Context, params login.UserLookupParams) (*user.User, error) {


### PR DESCRIPTION
**What is this feature?**
I noticed when using different clients to authenticate the same user UserSyncHook was not handling that properly.

This pr fixes so that if a new provider is used for the same user a new auth connection is made, also fixed the special case handling for generic oauth

Fixes #

**Special notes for your reviewer**:

