### PR TITLE
Kindsys: parse maturity string

### DIFF
--- a/pkg/kindsys/kind.go
+++ b/pkg/kindsys/kind.go
@@ -16,6 +16,21 @@ const (
 	MaturityMature       Maturity = "mature"
 )
 
+func NewMaturity(str string) Maturity {
+	switch str {
+	case "merged":
+		return MaturityMerged
+	case "experimental":
+		return MaturityExperimental
+	case "stable":
+		return MaturityStable
+	case "mature":
+		return MaturityMature
+	default:
+		return MaturityExperimental
+	}
+}
+
 func maturityIdx(m Maturity) int {
 	// icky to do this globally, this is effectively setting a default
 	if string(m) == "" {


### PR DESCRIPTION
**What is this feature?**
Parse string to a `kindsys.Maturity`.

**Why do we need this feature?**

External tools that want to take a maturity string as input for filtering.
