### PR TITLE
Table: Fixes logic for when adhoc filters are shown

### DIFF
--- a/packages/grafana-ui/src/components/Table/CellActions.tsx
+++ b/packages/grafana-ui/src/components/Table/CellActions.tsx
@@ -15,14 +15,14 @@ interface CellActionProps extends TableCellProps {
 
 interface CommonButtonProps {
   size: IconSize;
+  showFilters?: boolean;
   tooltipPlacement: TooltipPlacement;
 }
 
-export function CellActions({ field, cell, previewMode, onCellFilterAdded }: CellActionProps) {
+export function CellActions({ field, cell, previewMode, showFilters, onCellFilterAdded }: CellActionProps) {
   const [isInspecting, setIsInspecting] = useState(false);
 
   const isRightAligned = getTextAlign(field) === 'flex-end';
-  const showFilters = Boolean(field.config.filterable) && cell.value !== undefined;
   const inspectEnabled = Boolean((field.config.custom as TableFieldOptions)?.inspect);
   const commonButtonProps: CommonButtonProps = {
     size: 'sm',

--- a/packages/grafana-ui/src/components/Table/DefaultCell.tsx
+++ b/packages/grafana-ui/src/components/Table/DefaultCell.tsx
@@ -28,7 +28,7 @@ export const DefaultCell: FC<TableCellProps> = (props) => {
     value = formattedValueToString(displayValue);
   }
 
-  const showFilters = field.config.filterable;
+  const showFilters = props.onCellFilterAdded && field.config.filterable;
   const showActions = (showFilters && cell.value !== undefined) || inspectEnabled;
   const cellOptions = getCellOptions(field);
   const cellStyle = getCellStyle(tableStyles, cellOptions, displayValue, inspectEnabled);
@@ -56,7 +56,7 @@ export const DefaultCell: FC<TableCellProps> = (props) => {
         </DataLinksContextMenu>
       )}
 
-      {showActions && <CellActions {...props} previewMode="text" />}
+      {showActions && <CellActions {...props} previewMode="text" showFilters={showFilters} />}
     </div>
   );
 };


### PR DESCRIPTION
Forgot to do this when I made this change https://github.com/grafana/grafana/pull/61360

This makes sure you ad hoc filter actions don't show unless there is a panel context that handles them.

Makes is so that these do not show up in scene apps by default.
