### PR TITLE
Alerting: Create alert link from dashboard alerting panel

### DIFF
--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -1,7 +1,7 @@
-import { createAsyncThunk, AsyncThunk } from '@reduxjs/toolkit';
+import { AsyncThunk, createAsyncThunk } from '@reduxjs/toolkit';
 import { isEmpty } from 'lodash';
 
-import { locationService, config } from '@grafana/runtime';
+import { config, locationService } from '@grafana/runtime';
 import {
   AlertmanagerAlert,
   AlertManagerCortexConfig,
@@ -33,7 +33,7 @@ import {
 
 import { contextSrv } from '../../../../core/core';
 import { backendSrv } from '../../../../core/services/backend_srv';
-import { logInfo, LogMessages, withPerformanceLogging, trackNewAlerRuleFormSaved } from '../Analytics';
+import { logInfo, LogMessages, trackNewAlerRuleFormSaved, withPerformanceLogging } from '../Analytics';
 import {
   addAlertManagers,
   createOrUpdateSilence,

--- a/public/app/features/alerting/unified/utils/rule-id.ts
+++ b/public/app/features/alerting/unified/utils/rule-id.ts
@@ -1,4 +1,4 @@
-import { CombinedRule, Rule, RuleIdentifier, RuleWithLocation } from 'app/types/unified-alerting';
+import { CombinedRule, PromRuleWithLocation, Rule, RuleIdentifier, RuleWithLocation } from 'app/types/unified-alerting';
 import { Annotations, Labels, RulerRuleDTO } from 'app/types/unified-alerting-dto';
 
 import { GRAFANA_RULES_SOURCE_NAME } from './datasource';
@@ -56,6 +56,10 @@ export function fromCombinedRule(ruleSourceName: string, rule: CombinedRule): Ru
 
 export function fromRuleWithLocation(rule: RuleWithLocation): RuleIdentifier {
   return fromRulerRule(rule.ruleSourceName, rule.namespace, rule.group.name, rule.rule);
+}
+
+export function fromPromRuleWithLocation(rule: PromRuleWithLocation): RuleIdentifier {
+  return fromRule(rule.dataSourceName, rule.namespaceName, rule.groupName, rule.rule);
 }
 
 export function equal(a: RuleIdentifier, b: RuleIdentifier) {

--- a/public/app/features/alerting/unified/utils/rule-id.ts
+++ b/public/app/features/alerting/unified/utils/rule-id.ts
@@ -1,4 +1,4 @@
-import { CombinedRule, PromRuleWithLocation, Rule, RuleIdentifier, RuleWithLocation } from 'app/types/unified-alerting';
+import { CombinedRule, Rule, RuleIdentifier, RuleWithLocation } from 'app/types/unified-alerting';
 import { Annotations, Labels, RulerRuleDTO } from 'app/types/unified-alerting-dto';
 
 import { GRAFANA_RULES_SOURCE_NAME } from './datasource';
@@ -56,10 +56,6 @@ export function fromCombinedRule(ruleSourceName: string, rule: CombinedRule): Ru
 
 export function fromRuleWithLocation(rule: RuleWithLocation): RuleIdentifier {
   return fromRulerRule(rule.ruleSourceName, rule.namespace, rule.group.name, rule.rule);
-}
-
-export function fromPromRuleWithLocation(rule: PromRuleWithLocation): RuleIdentifier {
-  return fromRule(rule.dataSourceName, rule.namespaceName, rule.groupName, rule.rule);
 }
 
 export function equal(a: RuleIdentifier, b: RuleIdentifier) {

--- a/public/app/features/alerting/unified/utils/rules.ts
+++ b/public/app/features/alerting/unified/utils/rules.ts
@@ -116,14 +116,14 @@ export const flattenRules = (rules: RuleNamespace[]) => {
 };
 
 export const getAlertingRule = (rule: CombinedRuleWithLocation) =>
-  isAlertingRule(rule.rule.promRule) ? rule.rule.promRule : null;
+  isAlertingRule(rule.promRule) ? rule.promRule : null;
 
 export const flattenCombinedRules = (rules: CombinedRuleNamespace[]) => {
   return rules.reduce<CombinedRuleWithLocation[]>((acc, { rulesSource, name: namespaceName, groups }) => {
     groups.forEach(({ name: groupName, rules }) => {
       rules.forEach((rule) => {
-        if (isAlertingRule(rule.promRule!)) {
-          acc.push({ dataSourceName: getRulesSourceName(rulesSource), namespaceName, groupName, rule });
+        if (rule.promRule && isAlertingRule(rule.promRule)) {
+          acc.push({ dataSourceName: getRulesSourceName(rulesSource), namespaceName, groupName, ...rule });
         }
       });
     });

--- a/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
+++ b/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
@@ -239,13 +239,23 @@ export const getStyles = (theme: GrafanaTheme2) => ({
     border-radius: ${theme.shape.borderRadius(2)};
     margin-bottom: ${theme.spacing(0.5)};
 
-    & > * {
-      margin-right: ${theme.spacing(1)};
-    }
+    gap: ${theme.spacing(2)};
   `,
   alertName: css`
     font-size: ${theme.typography.h6.fontSize};
     font-weight: ${theme.typography.fontWeightBold};
+
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  `,
+  alertNameWrapper: css`
+    display: flex;
+    flex: 1;
+    flex-wrap: nowrap;
+    flex-direction: column;
+
+    min-width: 100px;
   `,
   alertLabels: css`
     > * {

--- a/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
+++ b/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
@@ -134,16 +134,18 @@ function sortRules(sortOrder: SortOrder, rules: CombinedRuleWithLocation[]) {
     return sortBy(rules, (rule) => alertDef.alertStateSortScore[rule.state]);
   } else if (sortOrder === SortOrder.TimeAsc) {
     return sortBy(rules, (rule) => {
+      //at this point rules are all AlertingRule, this check is only needed for Typescript checks
       const alertingRule: AlertingRule | undefined = getAlertingRule(rule) ?? undefined;
       return getFirstActiveAt(alertingRule) || new Date();
     });
   } else if (sortOrder === SortOrder.TimeDesc) {
     return sortBy(rules, (rule) => {
+      //at this point rules are all AlertingRule, this check is only needed for Typescript checks
       const alertingRule: AlertingRule | undefined = getAlertingRule(rule) ?? undefined;
       return getFirstActiveAt(alertingRule) || new Date();
     }).reverse();
   }
-  const result = sortBy(rules, (rule) => rule.rule.name.toLowerCase());
+  const result = sortBy(rules, (rule) => rule.name.toLowerCase());
   if (sortOrder === SortOrder.AlphaDesc) {
     result.reverse();
   }
@@ -157,13 +159,13 @@ function filterRules(props: PanelProps<UnifiedAlertListOptions>, rules: Combined
   let filteredRules = [...rules];
   if (options.dashboardAlerts) {
     const dashboardUid = getDashboardSrv().getCurrent()?.uid;
-    filteredRules = filteredRules.filter(({ rule: { annotations = {} } }) =>
+    filteredRules = filteredRules.filter(({ annotations = {} }) =>
       Object.entries(annotations).some(([key, value]) => key === Annotation.dashboardUID && value === dashboardUid)
     );
   }
   if (options.alertName) {
     const replacedName = replaceVariables(options.alertName);
-    filteredRules = filteredRules.filter(({ rule: { name } }) =>
+    filteredRules = filteredRules.filter(({ name }) =>
       name.toLocaleLowerCase().includes(replacedName.toLocaleLowerCase())
     );
   }
@@ -190,8 +192,7 @@ function filterRules(props: PanelProps<UnifiedAlertListOptions>, rules: Combined
       const filteredAlerts = (alertingRule?.alerts ?? []).filter(({ labels }) => labelsMatchMatchers(labels, matchers));
       if (filteredAlerts.length) {
         const alertRule: AlertingRule | null = getAlertingRule(rule);
-        alertRule &&
-          rules.push({ ...rule, rule: { ...rule.rule, promRule: { ...alertRule, alerts: filteredAlerts } } });
+        alertRule && rules.push({ ...rule, promRule: { ...alertRule, alerts: filteredAlerts } });
       }
       return rules;
     }, []);

--- a/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
+++ b/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
@@ -316,4 +316,8 @@ export const getStyles = (theme: GrafanaTheme2) => ({
   customGroupDetails: css`
     margin-bottom: ${theme.spacing(0.5)};
   `,
+  link: css`
+    word-break: break-all;
+    color: ${theme.colors.primary.text};
+  `,
 });

--- a/public/app/plugins/panel/alertlist/unified-alerting/GroupedView.tsx
+++ b/public/app/plugins/panel/alertlist/unified-alerting/GroupedView.tsx
@@ -2,15 +2,17 @@ import React, { FC, useMemo } from 'react';
 
 import { useStyles2 } from '@grafana/ui';
 import { AlertLabel } from 'app/features/alerting/unified/components/AlertLabel';
-import { Alert, PromRuleWithLocation } from 'app/types/unified-alerting';
+import { getAlertingRule } from 'app/features/alerting/unified/utils/rules';
+import { Alert } from 'app/types/unified-alerting';
 
+import { AlertingRule, CombinedRuleWithLocation } from '../../../../types/unified-alerting';
 import { AlertInstances } from '../AlertInstances';
 import { getStyles } from '../UnifiedAlertList';
 import { GroupedRules, UnifiedAlertListOptions } from '../types';
 import { filterAlerts } from '../util';
 
 type GroupedModeProps = {
-  rules: PromRuleWithLocation[];
+  rules: CombinedRuleWithLocation[];
   options: UnifiedAlertListOptions;
 };
 
@@ -22,12 +24,13 @@ const GroupedModeView: FC<GroupedModeProps> = ({ rules, options }) => {
   const groupedRules = useMemo<GroupedRules>(() => {
     const groupedRules = new Map<string, Alert[]>();
 
-    const hasInstancesWithMatchingLabels = (rule: PromRuleWithLocation) =>
-      groupBy ? alertHasEveryLabel(rule, groupBy) : true;
+    const hasInstancesWithMatchingLabels = (rule: CombinedRuleWithLocation) =>
+      groupBy ? alertHasEveryLabelForCombinedRules(rule, groupBy) : true;
 
     const matchingRules = rules.filter(hasInstancesWithMatchingLabels);
-    matchingRules.forEach((rule: PromRuleWithLocation) => {
-      (rule.rule.alerts ?? []).forEach((alert) => {
+    matchingRules.forEach((rule: CombinedRuleWithLocation) => {
+      const alertingRule: AlertingRule | null = getAlertingRule(rule);
+      (alertingRule?.alerts ?? []).forEach((alert) => {
         const mapKey = createMapKey(groupBy, alert.labels);
         const existingAlerts = groupedRules.get(mapKey) ?? [];
         groupedRules.set(mapKey, [...existingAlerts, alert]);
@@ -75,9 +78,10 @@ function parseMapKey(key: string): Array<[string, string]> {
   return [...new URLSearchParams(key)];
 }
 
-function alertHasEveryLabel(rule: PromRuleWithLocation, groupByKeys: string[]) {
+function alertHasEveryLabelForCombinedRules(rule: CombinedRuleWithLocation, groupByKeys: string[]) {
+  const alertingRule: AlertingRule | null = getAlertingRule(rule);
   return groupByKeys.every((key) => {
-    return (rule.rule.alerts ?? []).some((alert) => alert.labels[key]);
+    return (alertingRule?.alerts ?? []).some((alert) => alert.labels[key]);
   });
 }
 

--- a/public/app/plugins/panel/alertlist/unified-alerting/UngroupedView.tsx
+++ b/public/app/plugins/panel/alertlist/unified-alerting/UngroupedView.tsx
@@ -2,8 +2,10 @@ import { css } from '@emotion/css';
 import React, { FC } from 'react';
 
 import { GrafanaTheme2, intervalToAbbreviatedDurationString } from '@grafana/data';
-import { Icon, useStyles2 } from '@grafana/ui';
+import { Stack } from '@grafana/experimental';
+import { Icon, LinkButton, useStyles2 } from '@grafana/ui';
 import alertDef from 'app/features/alerting/state/alertDef';
+import { Spacer } from 'app/features/alerting/unified/components/Spacer';
 import { alertStateToReadable, alertStateToState, getFirstActiveAt } from 'app/features/alerting/unified/utils/rules';
 import { PromRuleWithLocation } from 'app/types/unified-alerting';
 import { PromAlertingRuleState } from 'app/types/unified-alerting-dto';
@@ -38,11 +40,17 @@ const UngroupedModeView: FC<UngroupedModeProps> = ({ rules, options }) => {
                   size={'lg'}
                 />
               </div>
-              <div>
+              <Stack direction="column" flexGrow={1}>
                 <div className={styles.instanceDetails}>
-                  <div className={styles.alertName} title={rule.name}>
-                    {rule.name}
-                  </div>
+                  <Stack direction="row" gap={1}>
+                    <div className={styles.alertName} title={rule.name}>
+                      {rule.name}
+                    </div>
+                    <Spacer />
+                    <LinkButton href={''} size="sm" icon="external-link-alt">
+                      Alert view
+                    </LinkButton>
+                  </Stack>
                   <div className={styles.alertDuration}>
                     <span className={stateStyle[alertStateToState(rule.state)]}>
                       {alertStateToReadable(rule.state)}
@@ -61,7 +69,7 @@ const UngroupedModeView: FC<UngroupedModeProps> = ({ rules, options }) => {
                   </div>
                 </div>
                 <AlertInstances alerts={ruleWithLocation.rule.alerts ?? []} options={options} />
-              </div>
+              </Stack>
             </li>
           );
         })}

--- a/public/app/plugins/panel/alertlist/unified-alerting/UngroupedView.tsx
+++ b/public/app/plugins/panel/alertlist/unified-alerting/UngroupedView.tsx
@@ -38,10 +38,12 @@ const UngroupedModeView: FC<UngroupedModeProps> = ({ rules, options }) => {
     <>
       <ol className={styles.alertRuleList}>
         {rulesToDisplay.map((ruleWithLocation, index) => {
-          const { rule, namespaceName, groupName, dataSourceName } = ruleWithLocation;
-          const alertingRule: AlertingRule | undefined = isAlertingRule(rule.promRule) ? rule.promRule : undefined;
+          const { namespaceName, groupName, dataSourceName } = ruleWithLocation;
+          const alertingRule: AlertingRule | undefined = isAlertingRule(ruleWithLocation.promRule)
+            ? ruleWithLocation.promRule
+            : undefined;
           const firstActiveAt = getFirstActiveAt(alertingRule);
-          const indentifier = fromCombinedRule(ruleWithLocation.dataSourceName, ruleWithLocation.rule);
+          const indentifier = fromCombinedRule(ruleWithLocation.dataSourceName, ruleWithLocation);
           const strIndentifier = stringifyIdentifier(indentifier);
 
           const href = createUrl(
@@ -50,7 +52,10 @@ const UngroupedModeView: FC<UngroupedModeProps> = ({ rules, options }) => {
           );
           if (alertingRule) {
             return (
-              <li className={styles.alertRuleItem} key={`alert-${namespaceName}-${groupName}-${rule.name}-${index}`}>
+              <li
+                className={styles.alertRuleItem}
+                key={`alert-${namespaceName}-${groupName}-${ruleWithLocation.name}-${index}`}
+              >
                 <div className={stateStyle.icon}>
                   <Icon
                     name={alertDef.getStateDisplayModel(alertingRule.state).iconClass}
@@ -61,8 +66,8 @@ const UngroupedModeView: FC<UngroupedModeProps> = ({ rules, options }) => {
                 <div className={styles.alertNameWrapper}>
                   <div className={styles.instanceDetails}>
                     <Stack direction="row" gap={1} wrap={false}>
-                      <div className={styles.alertName} title={rule.name}>
-                        {rule.name}
+                      <div className={styles.alertName} title={ruleWithLocation.name}>
+                        {ruleWithLocation.name}
                       </div>
                       <Spacer />
                       {href && (

--- a/public/app/plugins/panel/alertlist/unified-alerting/UngroupedView.tsx
+++ b/public/app/plugins/panel/alertlist/unified-alerting/UngroupedView.tsx
@@ -4,7 +4,7 @@ import useLocation from 'react-use/lib/useLocation';
 
 import { GrafanaTheme2, intervalToAbbreviatedDurationString } from '@grafana/data';
 import { Stack } from '@grafana/experimental';
-import { Icon, LinkButton, useStyles2 } from '@grafana/ui';
+import { Icon, useStyles2 } from '@grafana/ui';
 import alertDef from 'app/features/alerting/state/alertDef';
 import { Spacer } from 'app/features/alerting/unified/components/Spacer';
 import { fromCombinedRule, stringifyIdentifier } from 'app/features/alerting/unified/utils/rule-id';
@@ -66,9 +66,12 @@ const UngroupedModeView: FC<UngroupedModeProps> = ({ rules, options }) => {
                       </div>
                       <Spacer />
                       {href && (
-                        <LinkButton target="_blank" rel="noopener" href={href} size="sm" icon="external-link-alt">
-                          Details
-                        </LinkButton>
+                        <a href={href} target="__blank" className={styles.link} rel="noopener">
+                          <Stack alignItems="center" gap={1}>
+                            View alert rule
+                            <Icon name={'external-link-alt'} size="sm" />
+                          </Stack>
+                        </a>
                       )}
                     </Stack>
                     <div className={styles.alertDuration}>

--- a/public/app/plugins/panel/alertlist/unified-alerting/UngroupedView.tsx
+++ b/public/app/plugins/panel/alertlist/unified-alerting/UngroupedView.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import React, { FC } from 'react';
-import useLocation from 'react-use/lib/useLocation';
+import { useLocation } from 'react-use';
 
 import { GrafanaTheme2, intervalToAbbreviatedDurationString } from '@grafana/data';
 import { Stack } from '@grafana/experimental';

--- a/public/app/types/unified-alerting.ts
+++ b/public/app/types/unified-alerting.ts
@@ -3,15 +3,15 @@
 import { AlertState, DataSourceInstanceSettings } from '@grafana/data';
 
 import {
+  Annotations,
+  GrafanaAlertState,
+  GrafanaAlertStateWithReason,
+  Labels,
+  mapStateWithReasonToBaseState,
   PromAlertingRuleState,
   PromRuleType,
   RulerRuleDTO,
-  Labels,
-  Annotations,
   RulerRuleGroupDTO,
-  GrafanaAlertState,
-  GrafanaAlertStateWithReason,
-  mapStateWithReasonToBaseState,
 } from './unified-alerting-dto';
 
 export type Alert = {
@@ -109,6 +109,13 @@ export interface RuleWithLocation<T = RulerRuleDTO> {
   namespace: string;
   group: RulerRuleGroupDTO;
   rule: T;
+}
+
+export interface CombinedRuleWithLocation {
+  rule: CombinedRule;
+  dataSourceName: string;
+  namespaceName: string;
+  groupName: string;
 }
 
 export interface PromRuleWithLocation {

--- a/public/app/types/unified-alerting.ts
+++ b/public/app/types/unified-alerting.ts
@@ -111,8 +111,7 @@ export interface RuleWithLocation<T = RulerRuleDTO> {
   rule: T;
 }
 
-export interface CombinedRuleWithLocation {
-  rule: CombinedRule;
+export interface CombinedRuleWithLocation extends CombinedRule {
   dataSourceName: string;
   namespaceName: string;
   groupName: string;


### PR DESCRIPTION
**What is this feature?**

This PR adds a button on the alerting panel , to link to the details of the alert rule on a new tab.

**Why do we need this feature?**

We want users to be able to go easily to the details of the alert rule directly from the panel.

**Who is this feature for?**

All users.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/63564

**Special notes for your reviewer**:

For being able to create the link to the rule, we need using CombinedRules instead of only PromRules, because for RulerRules we need the uuid that is only included in RulerRules. 

https://user-images.githubusercontent.com/33540275/220942816-322b0c10-8bdb-456f-b566-9f9b3558a46d.mp4


**Last commit uses link instead of a button** 

<img width="258" alt="Screenshot 2023-02-24 at 13 38 48" src="https://user-images.githubusercontent.com/33540275/221181582-9dda498c-280d-4502-96fd-158dfb49b2c9.png">


