### PR TITLE
SectionNav: Simplify section toggle styling

### DIFF
--- a/public/app/core/components/PageNew/SectionNav.tsx
+++ b/public/app/core/components/PageNew/SectionNav.tsx
@@ -33,13 +33,7 @@ export function SectionNav({ model }: Props) {
           </div>
         </CustomScrollbar>
       </nav>
-      <SectionNavToggle
-        className={cx(styles.collapseIcon, {
-          [styles.collapseIconExpanded]: isExpanded,
-        })}
-        isExpanded={Boolean(isExpanded)}
-        onClick={onToggleSectionNav}
-      />
+      <SectionNavToggle isExpanded={isExpanded} onClick={onToggleSectionNav} />
     </div>
   );
 }
@@ -107,31 +101,6 @@ const getStyles = (theme: GrafanaTheme2) => {
       minWidth: '250px',
       [theme.breakpoints.up('md')]: {
         padding: theme.spacing(4.5, 1, 2, 2),
-      },
-    }),
-    collapseIcon: css({
-      alignSelf: 'center',
-      margin: theme.spacing(1, 0),
-      position: 'relative',
-      top: theme.spacing(0),
-      transform: 'rotate(90deg)',
-      transition: theme.transitions.create('opacity'),
-
-      [theme.breakpoints.up('md')]: {
-        alignSelf: 'flex-start',
-        left: 0,
-        margin: theme.spacing(0, 0, 0, 1),
-        top: theme.spacing(2),
-        transform: 'none',
-      },
-
-      'div:hover > &, &:focus': {
-        opacity: 1,
-      },
-    }),
-    collapseIconExpanded: css({
-      [theme.breakpoints.up('md')]: {
-        opacity: 0,
       },
     }),
   };

--- a/public/app/core/components/PageNew/SectionNavToggle.tsx
+++ b/public/app/core/components/PageNew/SectionNavToggle.tsx
@@ -6,12 +6,11 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { Button, useTheme2 } from '@grafana/ui';
 
 export interface Props {
-  className?: string;
-  isExpanded: boolean;
+  isExpanded?: boolean;
   onClick: () => void;
 }
 
-export const SectionNavToggle = ({ className, isExpanded, onClick }: Props) => {
+export const SectionNavToggle = ({ isExpanded, onClick }: Props) => {
   const theme = useTheme2();
   const styles = getStyles(theme);
 
@@ -20,7 +19,7 @@ export const SectionNavToggle = ({ className, isExpanded, onClick }: Props) => {
       title={'Toggle section navigation'}
       aria-label={isExpanded ? 'Close section navigation' : 'Open section navigation'}
       icon="arrow-to-right"
-      className={classnames(className, styles.icon, {
+      className={classnames(styles.icon, {
         [styles.iconExpanded]: isExpanded,
       })}
       variant="secondary"
@@ -35,11 +34,33 @@ SectionNavToggle.displayName = 'SectionNavToggle';
 
 const getStyles = (theme: GrafanaTheme2) => ({
   icon: css({
+    alignSelf: 'center',
+    margin: theme.spacing(1, 0),
+    top: theme.spacing(0),
+    transform: 'rotate(90deg)',
+    transition: theme.transitions.create('opacity'),
     color: theme.colors.text.secondary,
-    marginRight: 0,
     zIndex: 1,
+
+    [theme.breakpoints.up('md')]: {
+      alignSelf: 'flex-start',
+      position: 'relative',
+      left: 0,
+      margin: theme.spacing(0, 0, 0, 1),
+      top: theme.spacing(2),
+      transform: 'none',
+    },
+
+    'div:hover > &, &:focus': {
+      opacity: 1,
+    },
   }),
   iconExpanded: css({
     rotate: '180deg',
+
+    [theme.breakpoints.up('md')]: {
+      opacity: 0,
+      margin: 0,
+    },
   }),
 });


### PR DESCRIPTION
The section nav toggle added a lot of horizontal space to the section nav (that cannot be used for section page titles), tried to fix
it by making the button absolute but then it overlapps with the current section highlight background (so ended up not doing that)

Instead this PR just refactores the styling which was unnessarily complex and spread out involving multiple merged styles.

Also reducing a margin for the icon in the expanded state which was unnessary and reduces section nav with by 8px
