### PR TITLE
Query Splitting: Add support for multiple queries

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -33,7 +33,7 @@ import { CustomVariableModel } from '../../../features/variables/types';
 
 import { LokiDatasource, REF_ID_DATA_SAMPLES } from './datasource';
 import { createLokiDatasource, createMetadataRequest } from './mocks';
-import { runPartitionedQuery } from './querySplitting';
+import { runPartitionedQueries } from './querySplitting';
 import { parseToNodeNamesArray } from './queryUtils';
 import { LokiOptions, LokiQuery, LokiQueryType, LokiVariableQueryType, SupportingQueryType } from './types';
 import { LokiVariableSupport } from './variables';
@@ -1105,7 +1105,7 @@ describe('LokiDatasource', () => {
   describe('Query splitting', () => {
     beforeAll(() => {
       config.featureToggles.lokiQuerySplitting = true;
-      jest.mocked(runPartitionedQuery).mockReturnValue(
+      jest.mocked(runPartitionedQueries).mockReturnValue(
         of({
           data: [],
         })
@@ -1131,7 +1131,7 @@ describe('LokiDatasource', () => {
       });
 
       await expect(ds.query(query)).toEmitValuesWith(() => {
-        expect(runPartitionedQuery).toHaveBeenCalled();
+        expect(runPartitionedQueries).toHaveBeenCalled();
       });
     });
   });

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -68,7 +68,7 @@ import {
   getLabelFilterPositions,
 } from './modifyQuery';
 import { getQueryHints } from './queryHints';
-import { runPartitionedQuery } from './querySplitting';
+import { runPartitionedQueries } from './querySplitting';
 import {
   getLogQueryFromMetricsQuery,
   getNormalizedLokiQuery,
@@ -285,7 +285,7 @@ export class LokiDatasource
     }
 
     if (config.featureToggles.lokiQuerySplitting && requestSupportsPartitioning(fixedRequest.targets)) {
-      return runPartitionedQuery(this, fixedRequest);
+      return runPartitionedQueries(this, fixedRequest);
     }
 
     return this.runQuery(fixedRequest);

--- a/public/app/plugins/datasource/loki/querySplitting.test.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.test.ts
@@ -8,10 +8,10 @@ import { LokiDatasource } from './datasource';
 import * as logsTimeSplit from './logsTimeSplit';
 import * as metricTimeSplit from './metricTimeSplit';
 import { createLokiDatasource, getMockFrames } from './mocks';
-import { runPartitionedQuery } from './querySplitting';
+import { runPartitionedQueries } from './querySplitting';
 import { LokiQuery } from './types';
 
-describe('runPartitionedQuery()', () => {
+describe('runPartitionedQueries()', () => {
   let datasource: LokiDatasource;
   const range = {
     from: dateTime('2023-02-08T05:00:00.000Z'),
@@ -31,7 +31,7 @@ describe('runPartitionedQuery()', () => {
   });
 
   test('Splits datasource queries', async () => {
-    await expect(runPartitionedQuery(datasource, request)).toEmitValuesWith(() => {
+    await expect(runPartitionedQueries(datasource, request)).toEmitValuesWith(() => {
       // 3 days, 3 chunks, 3 requests.
       expect(datasource.runQuery).toHaveBeenCalledTimes(3);
     });
@@ -41,7 +41,7 @@ describe('runPartitionedQuery()', () => {
     jest
       .spyOn(datasource, 'runQuery')
       .mockReturnValue(of({ state: LoadingState.Error, error: { refId: 'A', message: 'Error' }, data: [] }));
-    await expect(runPartitionedQuery(datasource, request)).toEmitValuesWith((values) => {
+    await expect(runPartitionedQueries(datasource, request)).toEmitValuesWith((values) => {
       expect(values).toEqual([{ refId: 'A', message: 'Error' }]);
     });
   });
@@ -63,7 +63,7 @@ describe('runPartitionedQuery()', () => {
       jest.mocked(metricTimeSplit.getRangeChunks).mockRestore();
     });
     test('Ignores hidden queries', async () => {
-      await expect(runPartitionedQuery(datasource, request)).toEmitValuesWith(() => {
+      await expect(runPartitionedQueries(datasource, request)).toEmitValuesWith(() => {
         expect(logsTimeSplit.getRangeChunks).toHaveBeenCalled();
         expect(metricTimeSplit.getRangeChunks).not.toHaveBeenCalled();
       });
@@ -80,14 +80,14 @@ describe('runPartitionedQuery()', () => {
       jest.spyOn(datasource, 'runQuery').mockReturnValue(of({ data: [logFrameA], refId: 'A' }));
     });
     test('Stops requesting once maxLines of logs have been received', async () => {
-      await expect(runPartitionedQuery(datasource, request)).toEmitValuesWith(() => {
+      await expect(runPartitionedQueries(datasource, request)).toEmitValuesWith(() => {
         // 3 days, 3 chunks, 2 responses of 2 logs, 2 requests
         expect(datasource.runQuery).toHaveBeenCalledTimes(2);
       });
     });
     test('Performs all the requests if maxLines has not been reached', async () => {
       request.targets[0].maxLines = 9999;
-      await expect(runPartitionedQuery(datasource, request)).toEmitValuesWith(() => {
+      await expect(runPartitionedQueries(datasource, request)).toEmitValuesWith(() => {
         // 3 days, 3 chunks, 3 responses of 2 logs, 3 requests
         expect(datasource.runQuery).toHaveBeenCalledTimes(3);
       });
@@ -95,7 +95,7 @@ describe('runPartitionedQuery()', () => {
     test('Performs all the requests if not a log query', async () => {
       request.targets[0].maxLines = 1;
       request.targets[0].expr = 'count_over_time({a="b"}[1m])';
-      await expect(runPartitionedQuery(datasource, request)).toEmitValuesWith(() => {
+      await expect(runPartitionedQueries(datasource, request)).toEmitValuesWith(() => {
         // 3 days, 3 chunks, 3 responses of 2 logs, 3 requests
         expect(datasource.runQuery).toHaveBeenCalledTimes(3);
       });

--- a/public/app/plugins/datasource/loki/querySplitting.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.ts
@@ -174,8 +174,9 @@ function getNextRequestPointers(requests: LokiGroupedRequest, requestIndex: numb
 }
 
 export function runPartitionedQueries(datasource: LokiDatasource, request: DataQueryRequest<LokiQuery>) {
-  const logQueries = request.targets.filter((query) => isLogsQuery(query.expr));
-  const metricQueries = request.targets.filter((query) => !logQueries.includes(query));
+  const queries = request.targets.filter((query) => !query.hide);
+  const logQueries = queries.filter((query) => isLogsQuery(query.expr));
+  const metricQueries = queries.filter((query) => !logQueries.includes(query));
 
   const requests = [];
   if (logQueries.length) {

--- a/public/app/plugins/datasource/loki/querySplitting.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.ts
@@ -95,7 +95,6 @@ export function runGroupedQueries(datasource: LokiDatasource, requests: LokiGrou
   let shouldStop = false;
   let subquerySubsciption: Subscription | null = null;
   const runNextRequest = (subscriber: Subscriber<DataQueryResponse>, requestN: number, requestIndex: number) => {
-    console.log(requestIndex, requestN);
     if (shouldStop) {
       subscriber.complete();
       return;
@@ -162,7 +161,7 @@ export function runGroupedQueries(datasource: LokiDatasource, requests: LokiGrou
 
 function getNextRequestPointers(requests: LokiGroupedRequest, requestIndex: number, requestN: number) {
   // There's a pending metric request:
-  if (requestIndex === 0 && requests[1].partition[requestN - 1]) {
+  if (requestIndex === 0 && requests[1]?.partition[requestN - 1]) {
     return {
       nextRequestIndex: 1,
       nextRequestN: requestN,

--- a/public/app/plugins/datasource/loki/querySplitting.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.ts
@@ -86,28 +86,20 @@ function adjustTargetsFromResponseState(targets: LokiQuery[], response: DataQuer
     .filter((target) => target.maxLines === undefined || target.maxLines > 0);
 }
 
-export function runPartitionedQuery(datasource: LokiDatasource, request: DataQueryRequest<LokiQuery>) {
+type LokiGroupedRequest = Array<{ request: DataQueryRequest<LokiQuery>; partition: TimeRange[] }>;
+
+export function runGroupedQueries(datasource: LokiDatasource, requests: LokiGroupedRequest) {
   let mergedResponse: DataQueryResponse | null;
-  const query = request.targets[0];
-  const partition = partitionTimeRange(
-    isLogsQuery(query.expr),
-    request.range,
-    request.intervalMs,
-    query.resolution ?? 1
-  );
-  const totalRequests = partition.length;
+  const totalRequests = Math.max(...requests.map(({ partition }) => partition.length));
 
   let shouldStop = false;
   let subquerySubsciption: Subscription | null = null;
-  const runNextRequest = (subscriber: Subscriber<DataQueryResponse>, requestN: number) => {
+  const runNextRequest = (subscriber: Subscriber<DataQueryResponse>, requestN: number, requestIndex: number) => {
+    console.log(requestIndex, requestN);
     if (shouldStop) {
       subscriber.complete();
       return;
     }
-
-    const requestId = `${request.requestId}_${requestN}`;
-    const range = partition[requestN - 1];
-    const targets = adjustTargetsFromResponseState(request.targets, mergedResponse);
 
     const done = (response: DataQueryResponse) => {
       response.state = LoadingState.Done;
@@ -117,38 +109,46 @@ export function runPartitionedQuery(datasource: LokiDatasource, request: DataQue
 
     const nextRequest = () => {
       mergedResponse = mergedResponse || { data: [] };
-      if (requestN > 1) {
+      const { nextRequestN, nextRequestIndex } = getNextRequestPointers(requests, requestIndex, requestN);
+      if (nextRequestN > 0) {
         mergedResponse.state = LoadingState.Streaming;
         subscriber.next(mergedResponse);
-        runNextRequest(subscriber, requestN - 1);
+
+        runNextRequest(subscriber, nextRequestN, nextRequestIndex);
         return;
       }
       done(mergedResponse);
     };
 
+    const requestId = `${requests[requestIndex].request.requestId}_${requestN}`;
+    const range = requests[requestIndex].partition[requestN - 1];
+    const targets = adjustTargetsFromResponseState(requests[requestIndex].request.targets, mergedResponse);
+
     if (!targets.length && mergedResponse) {
-      done(mergedResponse);
+      nextRequest();
       return;
     }
 
-    subquerySubsciption = datasource.runQuery({ ...request, range, requestId, targets }).subscribe({
-      next: (partialResponse) => {
-        if (partialResponse.error) {
-          subscriber.error(partialResponse.error);
-        }
-        mergedResponse = combineResponses(mergedResponse, partialResponse);
-      },
-      complete: () => {
-        nextRequest();
-      },
-      error: (error) => {
-        subscriber.error(error);
-      },
-    });
+    subquerySubsciption = datasource
+      .runQuery({ ...requests[requestIndex].request, range, requestId, targets })
+      .subscribe({
+        next: (partialResponse) => {
+          if (partialResponse.error) {
+            subscriber.error(partialResponse.error);
+          }
+          mergedResponse = combineResponses(mergedResponse, partialResponse);
+        },
+        complete: () => {
+          nextRequest();
+        },
+        error: (error) => {
+          subscriber.error(error);
+        },
+      });
   };
 
   const response = new Observable<DataQueryResponse>((subscriber) => {
-    runNextRequest(subscriber, totalRequests);
+    runNextRequest(subscriber, totalRequests, 0);
     return () => {
       shouldStop = true;
       if (subquerySubsciption != null) {
@@ -160,23 +160,36 @@ export function runPartitionedQuery(datasource: LokiDatasource, request: DataQue
   return response;
 }
 
+function getNextRequestPointers(requests: LokiGroupedRequest, requestIndex: number, requestN: number) {
+  // There's a pending metric request:
+  if (requestIndex === 0 && requests[1].partition[requestN - 1]) {
+    return {
+      nextRequestIndex: 1,
+      nextRequestN: requestN,
+    };
+  }
+  return {
+    nextRequestIndex: 0,
+    nextRequestN: requestN - 1,
+  };
+}
+
 export function runPartitionedQueries(datasource: LokiDatasource, request: DataQueryRequest<LokiQuery>) {
   const logQueries = request.targets.filter((query) => isLogsQuery(query.expr));
   const metricQueries = request.targets.filter((query) => !logQueries.includes(query));
 
-  const queries = [];
+  const requests = [];
   if (logQueries.length) {
-    queries.push({
-      queries: logQueries,
+    requests.push({
+      request: { ...request, targets: logQueries },
       partition: partitionTimeRange(true, request.range, request.intervalMs, logQueries[0].resolution ?? 1),
     });
   }
   if (metricQueries.length) {
-    queries.push({
-      queries: logQueries,
-      partition: partitionTimeRange(false, request.range, request.intervalMs, logQueries[0].resolution ?? 1),
+    requests.push({
+      request: { ...request, targets: metricQueries },
+      partition: partitionTimeRange(false, request.range, request.intervalMs, metricQueries[0].resolution ?? 1),
     });
   }
-  console.log(queries);
-  return runPartitionedQuery(datasource, request);
+  return runGroupedQueries(datasource, requests);
 }

--- a/public/app/plugins/datasource/loki/querySplitting.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.ts
@@ -120,9 +120,10 @@ export function runGroupedQueries(datasource: LokiDatasource, requests: LokiGrou
       done(mergedResponse);
     };
 
-    const requestId = `${requests[requestGroup].request.requestId}_${requestN}`;
-    const range = requests[requestGroup].partition[requestN - 1];
-    const targets = adjustTargetsFromResponseState(requests[requestGroup].request.targets, mergedResponse);
+    const group = requests[requestGroup];
+    const requestId = `${group.request.requestId}_${requestN}`;
+    const range = group.partition[requestN - 1];
+    const targets = adjustTargetsFromResponseState(group.request.targets, mergedResponse);
 
     if (!targets.length && mergedResponse) {
       nextRequest();
@@ -161,10 +162,10 @@ export function runGroupedQueries(datasource: LokiDatasource, requests: LokiGrou
 }
 
 function getNextRequestPointers(requests: LokiGroupedRequest, requestGroup: number, requestN: number) {
-  // There's a pending metric request:
-  if (requestGroup === 0 && requests[1]?.partition[requestN - 1]) {
+  // There's a pending request from the next group:
+  if (requests[requestGroup + 1]?.partition[requestN - 1]) {
     return {
-      nextRequestGroup: 1,
+      nextRequestGroup: requestGroup + 1,
       nextRequestN: requestN,
     };
   }

--- a/public/app/plugins/datasource/loki/querySplitting.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.ts
@@ -1,3 +1,4 @@
+import { partition } from 'lodash';
 import { Subscriber, Observable, Subscription } from 'rxjs';
 
 import { DataQueryRequest, DataQueryResponse, dateTime, TimeRange } from '@grafana/data';
@@ -175,8 +176,7 @@ function getNextRequestPointers(requests: LokiGroupedRequest, requestIndex: numb
 
 export function runPartitionedQueries(datasource: LokiDatasource, request: DataQueryRequest<LokiQuery>) {
   const queries = request.targets.filter((query) => !query.hide);
-  const logQueries = queries.filter((query) => isLogsQuery(query.expr));
-  const metricQueries = queries.filter((query) => !logQueries.includes(query));
+  const [logQueries, metricQueries] = partition(queries, (query) => isLogsQuery(query.expr));
 
   const requests = [];
   if (logQueries.length) {

--- a/public/app/plugins/datasource/loki/queryUtils.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.ts
@@ -305,26 +305,14 @@ export function getStreamSelectorsFromQuery(query: string): string[] {
 }
 
 export function requestSupportsPartitioning(allQueries: LokiQuery[]) {
-  const queries = allQueries.filter((query) => !query.hide);
-  /*
-   * For now, we only split if there is a single query.
-   * - we do not split for zero queries
-   * - we do not split for multiple queries
-   */
-  if (queries.length !== 1) {
-    return false;
-  }
+  const queries = allQueries.filter((query) => !query.hide).filter((query) => !query.refId.includes('do-not-chunk'));
 
   const instantQueries = queries.some((query) => query.queryType === LokiQueryType.Instant);
   if (instantQueries) {
     return false;
   }
 
-  if (queries[0].refId.includes('do-not-chunk')) {
-    return false;
-  }
-
-  return true;
+  return queries.length > 0;
 }
 
 export function combineResponses(currentResult: DataQueryResponse | null, newResult: DataQueryResponse) {


### PR DESCRIPTION
Inspired by https://github.com/grafana/grafana/pull/63336/files.

This PR adds support for query splitting of multiple query targets. This is achieved in the following way:

1. Group metric and query requests.
2. For each group, partition the original `request.range` with its corresponding method.
3. We pass the grouped requests to the runner, starting with the `group = 0`.
4. We run the queries intercalating metrics/logs/metrics/logs.
  a. We run the `N` partition of the `group = 0`.
  b. If there is a `group 1`, we run the `N` partition of the `group 1`.
  c. We run the `N-1` partition of the `group 0 `.
  d. If there is a `group 1`, we run the `N-1` partition of the `group 1`.
  e. Repeat until all the group's partitions have been run.
  f. Done.

**Example**

First, we group:

```javascript
requests = [{
  request: {...}, // request with logs targets
  partitions: [...], // partition for logs queries
},{
  request: {...}, // request with metric targets
  partitions: [...], // partition for metric queries
}]
```

And then we run them in sequence, in an intercalated fashion. First:

```javascript
// 3 chunks ([2], [1], [0])
requests[group].request && requests[group].partition[chunk number];
```

Then:


```javascript
// Start
requests[0].request && requests[0].partition[2];
requests[1].request && requests[1].partition[2];
requests[0].request && requests[0].partition[1];
requests[1].request && requests[1].partition[1];
requests[0].request && requests[0].partition[0];
requests[1].request && requests[1].partition[0];
// End
```

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana/issues/61768

**Special notes for your reviewer**:

A follow up PR will be made to include instant queries.