### PR TITLE
InfluxDB: Fix getting empty response when querying fields with retention policy

### DIFF
--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -403,10 +403,6 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
       params.db = this.database;
     }
 
-    if (options?.policy) {
-      params.rp = options.policy;
-    }
-
     const { q } = data;
 
     if (method === 'POST' && has(data, 'q')) {

--- a/public/app/plugins/datasource/influxdb/influxQLMetadataQuery.ts
+++ b/public/app/plugins/datasource/influxdb/influxQLMetadataQuery.ts
@@ -11,8 +11,7 @@ const runExploreQuery = (
 ): Promise<Array<{ text: string }>> => {
   const builder = new InfluxQueryBuilder(target, datasource.database);
   const q = builder.buildExploreQuery(type, withKey, withMeasurementFilter);
-  const options = { policy: target.policy };
-  return datasource.metricFindQuery(q, options);
+  return datasource.metricFindQuery(q);
 };
 
 export async function getAllPolicies(datasource: InfluxDatasource): Promise<string[]> {


### PR DESCRIPTION
#### What is this feature?
Reverting https://github.com/grafana/grafana/pull/62149

Sending `default` retention policy parameter causes issues so we are reverting it to investigate deeper. 

#### Who is this feature for?

Anyone using InfluxQL to query against an InfluxDB v2 API (using v1 compatibility).
