### PR TITLE
Loki ds: Interpolation breaks in Loki queries when no scoped vars

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -981,7 +981,7 @@ export class LokiDatasource
   // Used when running queries through backend
   applyTemplateVariables(target: LokiQuery, scopedVars: ScopedVars): LokiQuery {
     // We want to interpolate these variables on backend
-    const { __interval, __interval_ms, ...rest } = scopedVars;
+    const { __interval, __interval_ms, ...rest } = scopedVars || {};
 
     const exprWithAdHoc = this.addAdHocFilters(target.expr);
 


### PR DESCRIPTION
Because `scopedVars` can be undefined, the deconstruction of undefined will trigger an error when interpolating variables.

This broke when replacing babel-loader for esbuild-loader (https://github.com/grafana/grafana/pull/57837).

This issue was not detected earlier because of the lack of typing here.