### PR TITLE
[v9.4.x] fix link to explore with logs and headings (#63665)

### DIFF
--- a/docs/sources/explore/logs-integration.md
+++ b/docs/sources/explore/logs-integration.md
@@ -21,7 +21,7 @@ During an infrastructure monitoring and incident response, you can dig deeper in
 1. Drill down and examine metrics.
 1. Drill down again and search logs related to the metric and time interval (and in the future, distributed traces).
 
-### Logs visualization
+## Logs visualization
 
 Results of log queries are shown as histograms in the graph and individual logs are explained in the following sections.
 
@@ -31,7 +31,7 @@ If the data source supports a full range log volume histogram, the graph with lo
 
 If the data source does not support loading full range log volume histogram, the logs model computes a time series based on the log row counts bucketed by an automatically calculated time interval, and the first log row's timestamp then anchors the start of the histogram from the result. The end of the time series is anchored to the time picker's **To** range.
 
-#### Log level
+### Log level
 
 For logs where a level label is specified, we use the value of the label to determine the log level and update color accordingly. If the log doesn't have a level label specified, we try to find out if its content matches any of the supported expressions (see below for more information). The log level is always determined by the first match. In case Grafana is not able to determine a log level, it will be visualized with an unknown log level.
 
@@ -59,33 +59,33 @@ For logs where a level label is specified, we use the value of the label to dete
 | trace                 |   trace   | light blue |
 | \*                    |  unknown  |       grey |
 
-### Logs navigation
+## Logs navigation
 
 Logs navigation next to the log lines can be used to request more logs. You can do this by clicking on Older logs button on the bottom of navigation. This is especially useful when you hit the line limit and you want to see more logs. Each request that is run from the navigation is then displayed in the navigation as separate page. Every page is showing from and to timestamp of the incoming log lines. You can see previous results by clicking on the page. Explore is caching last five requests run from the logs navigation, so you are not re-running the same queries when clicking on the pages.
 
 ![Navigate logs in Explore](/static/img/docs/explore/navigate-logs-8-0.png)
 
-### Visualization options
+## Visualization options
 
 You can customize how logs are displayed and select which columns are shown.
 
-#### Time
+### Time
 
 Shows or hides the time column. This is the timestamp associated with the log line as reported from the data source.
 
-#### Unique labels
+### Unique labels
 
 Shows or hides the unique labels column that includes only non-common labels. All common labels are displayed above.
 
-#### Wrap lines
+### Wrap lines
 
 Set this to True if you want the display to use line wrapping. If set to False, it will result in horizontal scrolling.
 
-#### Prettify JSON
+### Prettify JSON
 
 Set this to `true` to pretty print all JSON logs. This setting does not affect logs in any format other than JSON.
 
-#### Deduplication
+### Deduplication
 
 Log data can be very repetitive and Explore can help by hiding duplicate log lines. There are a few different deduplication algorithms that you can use:
 
@@ -93,15 +93,15 @@ Log data can be very repetitive and Explore can help by hiding duplicate log lin
 - **Numbers -** Matches on the line after stripping out numbers such as durations, IP addresses, and so on.
 - **Signature -** The most aggressive deduplication, this strips all letters and numbers and matches on the remaining whitespace and punctuation.
 
-#### Flip results order
+### Flip results order
 
 You can change the order of received logs from the default descending order (newest first) to ascending order (oldest first).
 
-### Labels and detected fields
+## Labels and detected fields
 
 Each log row has an extendable area with its labels and detected fields, for more robust interaction. For all labels we have added the ability to filter for (positive filter) and filter out (negative filter) selected labels. Each field or label also has a stats icon to display ad-hoc statistics in relation to all displayed logs.
 
-### Escaping newlines
+## Escaping newlines
 
 Explore automatically detects some incorrectly escaped sequences in log lines, such as newlines (`\n`, `\r`) or tabs (`\t`). When it detects such sequences, Explore provides an "Escape newlines" option.
 
@@ -112,24 +112,24 @@ To automatically fix incorrectly escaped sequences that Explore has detected:
 
 Explore replaces these sequences. When it does so, the option will change from "Escape newlines" to "Remove escaping". Evaluate the changes as the parsing may not be accurate based on the input received. You can revert the replacements by clicking "Remove escaping".
 
-#### Data links
+### Data links
 
 By using data links, you can turn any part of a log message into an internal or external link. The created link is visible as a button in the **Links** section inside the **Log details** view.
 {{< figure src="/static/img/docs/explore/data-link-9-4.png" max-width="800px" caption="Data link in Explore" >}}
 
-#### Toggle field visibility
+### Toggle field visibility
 
 Expand a log line and click the eye icon to show or hide fields.
 
 {{< figure src="/static/img/docs/explore/toggle-fields-9-4.gif" max-width="800px" caption="Toggling detected fields in Explore" >}}
 
-### Loki-specific features
+## Loki-specific features
 
 As mentioned, one of the log integrations is for the new open source log aggregation system from Grafana Labs - [Loki](https://github.com/grafana/loki). Loki is designed to be very cost effective, as it does not index the contents of the logs, but rather a set of labels for each log stream. The logs from Loki are queried in a similar way to querying with label selectors in Prometheus. It uses labels to group log streams which can be made to match up with your Prometheus labels. For more information about Grafana Loki, refer to [Grafana Loki](https://github.com/grafana/loki) or the Grafana Labs hosted variant: [Grafana Cloud Logs](https://grafana.com/loki).
 
 For more information, refer to [Loki's data source documentation]({{< relref "../datasources/loki/" >}}) on how to query for log data.
 
-#### Switch from metrics to logs
+### Switch from metrics to logs
 
 If you switch from a Prometheus query to a logs query (you can do a split first to have your metrics and logs side by side) then it will keep the labels from your query that exist in the logs and use those to query the log streams. For example, the following Prometheus query:
 
@@ -141,11 +141,11 @@ after switching to the Logs data source, the query changes to:
 
 This will return a chunk of logs in the selected time range that can be grepped/text searched.
 
-### Logs sample
+## Logs sample
 
 If the selected data source implements logs sample, and supports both log and metric queries, then for metric queries you will be able to automatically see samples of log lines that contributed to visualized metrics. This feature is currently supported by Loki data sources.
 
-#### Live tailing
+### Live tailing
 
 Use the Live tailing feature to see real-time logs on supported data sources.
 

--- a/docs/sources/explore/logs-integration.md
+++ b/docs/sources/explore/logs-integration.md
@@ -85,13 +85,13 @@ Set this to True if you want the display to use line wrapping. If set to False, 
 
 Set this to `true` to pretty print all JSON logs. This setting does not affect logs in any format other than JSON.
 
-#### Deduping
+#### Deduplication
 
 Log data can be very repetitive and Explore can help by hiding duplicate log lines. There are a few different deduplication algorithms that you can use:
 
 - **Exact -** Exact matches are done on the whole line except for date fields.
 - **Numbers -** Matches on the line after stripping out numbers such as durations, IP addresses, and so on.
-- **Signature -** The most aggressive deduping, this strips all letters and numbers and matches on the remaining whitespace and punctuation.
+- **Signature -** The most aggressive deduplication, this strips all letters and numbers and matches on the remaining whitespace and punctuation.
 
 #### Flip results order
 

--- a/docs/sources/panels-visualizations/visualizations/logs/index.md
+++ b/docs/sources/panels-visualizations/visualizations/logs/index.md
@@ -26,7 +26,7 @@ To limit the number of lines rendered, you can use the **Max data points** setti
 
 ## Log level
 
-For logs where a **level** label is specified, we use the value of the label to determine the log level and update color accordingly. If the log doesn't have a level label specified, we try to find out if its content matches any of the supported expressions (see below for more information). The log level is always determined by the first match. In case Grafana is not able to determine a log level, it will be visualized with **unknown** log level. See [supported log levels and mappings of log level abbreviation and expressions]({{< relref "../../../explore/#log-level" >}}).
+For logs where a **level** label is specified, we use the value of the label to determine the log level and update color accordingly. If the log doesn't have a level label specified, we try to find out if its content matches any of the supported expressions (see below for more information). The log level is always determined by the first match. In case Grafana is not able to determine a log level, it will be visualized with **unknown** log level. See [supported log levels and mappings of log level abbreviation and expressions]({{< relref "../../../explore/logs-integration/#log-level" >}}).
 
 ## Log details
 

--- a/public/app/features/explore/Logs.tsx
+++ b/public/app/features/explore/Logs.tsx
@@ -438,7 +438,7 @@ class UnthemedLogs extends PureComponent<Props, State> {
                   id={`prettify_${exploreId}`}
                 />
               </InlineField>
-              <InlineField label="Dedup" className={styles.horizontalInlineLabel} transparent>
+              <InlineField label="Deduplication" className={styles.horizontalInlineLabel} transparent>
                 <RadioButtonGroup
                   options={Object.values(LogsDedupStrategy).map((dedupType) => ({
                     label: capitalize(dedupType),

--- a/public/app/features/explore/LogsMetaRow.tsx
+++ b/public/app/features/explore/LogsMetaRow.tsx
@@ -80,7 +80,7 @@ export const LogsMetaRow = React.memo(
     // Add deduplication info
     if (dedupStrategy !== LogsDedupStrategy.none) {
       logsMetaItem.push({
-        label: 'Dedup count',
+        label: 'Deduplication count',
         value: dedupCount,
         kind: LogsMetaKind.Number,
       });


### PR DESCRIPTION
Additionally backport [[v9.4.x] Logs: Rename dedup to deduplication (#62944)](https://github.com/grafana/grafana/commit/5fcc9b5e7e2ec0775241b4fb739dd24139ca3c99) to resolve conflict.