### PR TITLE
Range splitting: Omit instant queries from splitting

### DIFF
--- a/public/app/plugins/datasource/loki/queryUtils.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.ts
@@ -315,6 +315,11 @@ export function requestSupportsPartitioning(allQueries: LokiQuery[]) {
     return false;
   }
 
+  const instantQueries = queries.some((query) => query.queryType === LokiQueryType.Instant);
+  if (instantQueries) {
+    return false;
+  }
+
   if (queries[0].refId.includes('do-not-chunk')) {
     return false;
   }


### PR DESCRIPTION
Omitting instant queries from splitting, as it's producing incorrect results.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana/issues/61768