### PR TITLE
Nav: Handle app plugin installation/uninstallation

### DIFF
--- a/public/app/core/reducers/navBarTree.ts
+++ b/public/app/core/reducers/navBarTree.ts
@@ -63,8 +63,14 @@ const navTreeSlice = createSlice({
         }
       }
     },
+    removePluginFromNavTree: (state, action: PayloadAction<{ id: string }>) => {
+      const pluginItemIndex = state.findIndex((navItem) => navItem.id === action.payload.id);
+      if (pluginItemIndex > -1) {
+        state.splice(pluginItemIndex, 1);
+      }
+    },
   },
 });
 
-export const { setStarred, updateDashboardName } = navTreeSlice.actions;
+export const { setStarred, removePluginFromNavTree, updateDashboardName } = navTreeSlice.actions;
 export const navTreeReducer = navTreeSlice.reducer;

--- a/public/app/core/reducers/navBarTree.ts
+++ b/public/app/core/reducers/navBarTree.ts
@@ -63,8 +63,9 @@ const navTreeSlice = createSlice({
         }
       }
     },
-    removePluginFromNavTree: (state, action: PayloadAction<{ id: string }>) => {
-      const pluginItemIndex = state.findIndex((navItem) => navItem.id === action.payload.id);
+    removePluginFromNavTree: (state, action: PayloadAction<{ pluginID: string }>) => {
+      const navID = 'plugin-page-' + action.payload.pluginID;
+      const pluginItemIndex = state.findIndex((navItem) => navItem.id === navID);
       if (pluginItemIndex > -1) {
         state.splice(pluginItemIndex, 1);
       }

--- a/public/app/features/plugins/admin/components/InstallControls/InstallControlsButton.tsx
+++ b/public/app/features/plugins/admin/components/InstallControls/InstallControlsButton.tsx
@@ -67,7 +67,7 @@ export function InstallControlsButton({
       }
       appEvents.emit(AppEvents.alertSuccess, [`Uninstalled ${plugin.name}`]);
       if (plugin.type === 'app') {
-        dispatch(removePluginFromNavTree({ id: plugin.id }));
+        dispatch(removePluginFromNavTree({ pluginID: plugin.id }));
         setNeedReload(false);
       }
     }

--- a/public/app/features/plugins/admin/components/InstallControls/InstallControlsButton.tsx
+++ b/public/app/features/plugins/admin/components/InstallControls/InstallControlsButton.tsx
@@ -6,6 +6,8 @@ import { locationService } from '@grafana/runtime';
 import { Button, HorizontalGroup, ConfirmModal } from '@grafana/ui';
 import appEvents from 'app/core/app_events';
 import { useQueryParams } from 'app/core/hooks/useQueryParams';
+import { removePluginFromNavTree } from 'app/core/reducers/navBarTree';
+import { useDispatch } from 'app/types';
 
 import { useInstallStatus, useUninstallStatus, useInstall, useUninstall } from '../../state/hooks';
 import { trackPluginInstalled, trackPluginUninstalled } from '../../tracking';
@@ -15,9 +17,16 @@ type InstallControlsButtonProps = {
   plugin: CatalogPlugin;
   pluginStatus: PluginStatus;
   latestCompatibleVersion?: Version;
+  setNeedReload: (needReload: boolean) => void;
 };
 
-export function InstallControlsButton({ plugin, pluginStatus, latestCompatibleVersion }: InstallControlsButtonProps) {
+export function InstallControlsButton({
+  plugin,
+  pluginStatus,
+  latestCompatibleVersion,
+  setNeedReload,
+}: InstallControlsButtonProps) {
+  const dispatch = useDispatch();
   const [queryParams] = useQueryParams();
   const location = useLocation();
   const { isInstalling, error: errorInstalling } = useInstallStatus();
@@ -39,6 +48,9 @@ export function InstallControlsButton({ plugin, pluginStatus, latestCompatibleVe
     await install(plugin.id, latestCompatibleVersion?.version);
     if (!errorInstalling) {
       appEvents.emit(AppEvents.alertSuccess, [`Installed ${plugin.name}`]);
+      if (plugin.type === 'app') {
+        setNeedReload(true);
+      }
     }
   };
 
@@ -54,6 +66,10 @@ export function InstallControlsButton({ plugin, pluginStatus, latestCompatibleVe
         locationService.replace(`${location.pathname}?page=${PluginTabIds.OVERVIEW}`);
       }
       appEvents.emit(AppEvents.alertSuccess, [`Uninstalled ${plugin.name}`]);
+      if (plugin.type === 'app') {
+        dispatch(removePluginFromNavTree({ id: plugin.id }));
+        setNeedReload(false);
+      }
     }
   };
 

--- a/public/app/features/plugins/admin/components/PluginActions.tsx
+++ b/public/app/features/plugins/admin/components/PluginActions.tsx
@@ -1,6 +1,9 @@
-import React from 'react';
+import { css } from '@emotion/css';
+import React, { useState } from 'react';
 
+import { GrafanaTheme2 } from '@grafana/data';
 import { config } from '@grafana/runtime';
+import { HorizontalGroup, Icon, useStyles2, VerticalGroup } from '@grafana/ui';
 
 import { GetStartedWithPlugin } from '../components/GetStartedWithPlugin';
 import { InstallControlsButton } from '../components/InstallControls';
@@ -14,8 +17,10 @@ interface Props {
 }
 
 export const PluginActions = ({ plugin }: Props) => {
+  const styles = useStyles2(getStyles);
   const isRemotePluginsAvailable = useIsRemotePluginsAvailable();
   const latestCompatibleVersion = getLatestCompatibleVersion(plugin?.details?.versions);
+  const [needReload, setNeedReload] = useState(false);
 
   if (!plugin) {
     return null;
@@ -32,21 +37,38 @@ export const PluginActions = ({ plugin }: Props) => {
     plugin.isCore || plugin.isDisabled || !isInstallControlsEnabled() || hasInstallWarning;
 
   return (
-    <>
-      {!isInstallControlsDisabled && (
-        <>
-          {isExternallyManaged ? (
-            <ExternallyManagedButton pluginId={plugin.id} pluginStatus={pluginStatus} />
-          ) : (
-            <InstallControlsButton
-              plugin={plugin}
-              latestCompatibleVersion={latestCompatibleVersion}
-              pluginStatus={pluginStatus}
-            />
-          )}
-        </>
+    <VerticalGroup>
+      <HorizontalGroup>
+        {!isInstallControlsDisabled && (
+          <>
+            {isExternallyManaged ? (
+              <ExternallyManagedButton pluginId={plugin.id} pluginStatus={pluginStatus} />
+            ) : (
+              <InstallControlsButton
+                plugin={plugin}
+                latestCompatibleVersion={latestCompatibleVersion}
+                pluginStatus={pluginStatus}
+                setNeedReload={setNeedReload}
+              />
+            )}
+          </>
+        )}
+        <GetStartedWithPlugin plugin={plugin} />
+      </HorizontalGroup>
+      {needReload && (
+        <HorizontalGroup>
+          <Icon name="exclamation-triangle" />
+          <span className={styles.message}>Refresh the page to see the changes</span>
+        </HorizontalGroup>
       )}
-      <GetStartedWithPlugin plugin={plugin} />
-    </>
+    </VerticalGroup>
   );
+};
+
+const getStyles = (theme: GrafanaTheme2) => {
+  return {
+    message: css`
+      color: ${theme.colors.text.secondary};
+    `,
+  };
 };


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- When uninstalling an app plugin, remove it from the navigation.
- When installing one, show a notice that the page needs to be refreshed.

[Screencast from 24-02-23 10:57:36.webm](https://user-images.githubusercontent.com/4025665/221149711-6db5cb79-5a2e-4a5c-bcdf-87965e94e9c0.webm)

**Why do we need this feature?**

At the moment, the navigation item for uninstalled app plugins are not removed when ethe plugin is uninstalled. There is also no feedback of what's needed when you install one.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #47276

**Special notes for your reviewer**:

My original idea was to also add the plugin navigation item when installing it without having to refresh but the navigation tree is generated at boot time (saved at  `window.grafanaBootData`) and as far as I can see, there is no easy way to regenerate it  from a component. Let me know if you know a way of doing that.

cc/ @wbrowne 