### PR TITLE
FrontendLogging: A very basic frontend logging lib

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -813,7 +813,9 @@ exports[`better eslint`] = {
     "packages/grafana-runtime/src/config.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "2"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
+      [0, 0, 0, "Do not use any type assertions.", "3"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "4"]
     ],
     "packages/grafana-runtime/src/services/AngularLoader.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],

--- a/packages/grafana-data/src/index.ts
+++ b/packages/grafana-data/src/index.ts
@@ -16,6 +16,7 @@ export * from './events';
 export * from './themes';
 export * from './monaco';
 export * from './geo/layer';
+export * from './logging';
 export {
   type ValueMatcherOptions,
   type BasicValueMatcherOptions,

--- a/packages/grafana-data/src/logging/Appenders.ts
+++ b/packages/grafana-data/src/logging/Appenders.ts
@@ -1,0 +1,29 @@
+import { Logger } from './Logger';
+import { LogAppender, LogLevel } from './types';
+
+export class CompositeAppender implements LogAppender {
+  private _appenders: LogAppender[] = [];
+
+  add(appender: LogAppender) {
+    this._appenders.push(appender);
+  }
+
+  remove(appender: LogAppender) {
+    this._appenders = this._appenders.filter((a) => a !== appender);
+  }
+
+  append(logger: Logger, level: LogLevel, args: unknown[]): void {
+    for (let i = 0; i < this._appenders.length; i++) {
+      this._appenders[i].append(logger, level, args);
+    }
+  }
+}
+
+export class ConsoleAppender implements LogAppender {
+  append(logger: Logger, level: LogLevel, args: unknown[]): void {
+    if (level === LogLevel.Debug) {
+      // eslint-disable-next-line no-console
+      console.debug(`[${logger.name}]`, ...args);
+    }
+  }
+}

--- a/packages/grafana-data/src/logging/LogManager.ts
+++ b/packages/grafana-data/src/logging/LogManager.ts
@@ -1,0 +1,112 @@
+import { ConsoleAppender, CompositeAppender } from './Appenders';
+import { Logger } from './Logger';
+import { LogAppender, LoggingConfig, LogLevel } from './types';
+
+export class LogManager {
+  private _root = new Logger('', new ConsoleAppender(), null);
+  private _loggers: Record<string, Logger> = {};
+  private _loggerNameSeparator = '/';
+  private _compositeAppender = new CompositeAppender();
+  private _appenders: Record<string, LogAppender> = {};
+
+  constructor() {
+    this.registerAppender('console', new ConsoleAppender());
+  }
+
+  private _config: LoggingConfig = {
+    loggers: {},
+  };
+
+  getLogger(name: string) {
+    return this._loggers[name] || this._createLogger(name);
+  }
+
+  private _createLogger(name: string) {
+    const parent = this._getParentLogger(name);
+    const logger = new Logger(name, this._compositeAppender, parent);
+
+    this._configureLogger(logger);
+    this._loggers[name] = logger;
+
+    return logger;
+  }
+
+  private _getParentLogger(childName: string): Logger {
+    const parentName = this._getParentLoggerName(childName);
+    return parentName ? this.getLogger(parentName) : this._root;
+  }
+
+  private _getParentLoggerName(childName: string): string | null {
+    const path = childName.split(this._loggerNameSeparator);
+    path.pop();
+
+    if (path.length === 0) {
+      return null;
+    }
+
+    return path.join(this._loggerNameSeparator);
+  }
+
+  private _configureLogger(logger: Logger) {
+    logger.setLevel(this._config.loggers[logger.name] ?? null);
+  }
+
+  registerAppender(name: string, appender: LogAppender) {
+    this._compositeAppender.add(appender);
+    this._appenders[name] = appender;
+  }
+
+  removeAppender(name: string) {
+    const appender = this._appenders[name];
+    if (!appender) {
+      throw new Error(`Appender not found ${name}`);
+    }
+
+    this._compositeAppender.remove(appender);
+  }
+
+  /**
+   * Useful from the command line.
+   * Example: window.grafanaLogging.setLoggerLevel("grafana", "debug")
+   */
+  setLoggerLevel(name: string, level: LogLevel | string) {
+    if (typeof level === 'string') {
+      level = getLogLevelFromName(level);
+    }
+
+    this._config.loggers[name] = level;
+
+    const logger = this.getLogger(name);
+
+    if (logger) {
+      this._configureLogger(logger);
+    }
+  }
+
+  updateConfig(config: LoggingConfig) {
+    this._config = config;
+
+    for (const logger of Object.values(this._loggers)) {
+      this._configureLogger(logger);
+    }
+  }
+}
+
+export function getLogLevelFromName(name: string): LogLevel {
+  switch (name.toLowerCase()) {
+    case 'debug':
+      return LogLevel.Debug;
+    case 'info':
+      return LogLevel.Info;
+    case 'warn':
+      return LogLevel.Warn;
+    case 'error':
+      return LogLevel.Error;
+    case 'off':
+      return LogLevel.Off;
+  }
+
+  throw new Error('Unknown log level: ' + name);
+}
+
+export const frontendLogging = new LogManager();

--- a/packages/grafana-data/src/logging/LogManager.ts
+++ b/packages/grafana-data/src/logging/LogManager.ts
@@ -3,11 +3,11 @@ import { Logger } from './Logger';
 import { LogAppender, LoggingConfig, LogLevel } from './types';
 
 export class LogManager {
-  private _root = new Logger('', new ConsoleAppender(), null);
   private _loggers: Record<string, Logger> = {};
   private _loggerNameSeparator = '/';
   private _compositeAppender = new CompositeAppender();
   private _appenders: Record<string, LogAppender> = {};
+  private _root = new Logger('', this._compositeAppender, null);
 
   constructor() {
     this.registerAppender('console', new ConsoleAppender());

--- a/packages/grafana-data/src/logging/Logger.ts
+++ b/packages/grafana-data/src/logging/Logger.ts
@@ -1,0 +1,37 @@
+import { LogLevel, LogAppender } from './types';
+
+export class Logger {
+  private _level: LogLevel | null = null;
+
+  constructor(public name: string, private _appender: LogAppender, private _parent: Logger | null) {}
+
+  setLevel(level: LogLevel) {
+    this._level = level;
+  }
+
+  debug(...args: unknown[]) {
+    this._log(LogLevel.Debug, args);
+  }
+
+  isDebugEnabled() {
+    return this.getInheritedLevel() >= LogLevel.Debug;
+  }
+
+  private getInheritedLevel(): LogLevel {
+    if (this._level !== null) {
+      return this._level;
+    } else if (this._parent) {
+      return this._parent.getInheritedLevel();
+    }
+
+    return LogLevel.Off;
+  }
+
+  private _log(level: LogLevel, args: unknown[]) {
+    if (level < this.getInheritedLevel()) {
+      return;
+    }
+
+    this._appender.append(this, level, args);
+  }
+}

--- a/packages/grafana-data/src/logging/index.ts
+++ b/packages/grafana-data/src/logging/index.ts
@@ -1,0 +1,3 @@
+export { frontendLogging } from './LogManager';
+export { LogLevel as LoggerLevel, type LogAppender } from './types';
+export { Logger } from './Logger';

--- a/packages/grafana-data/src/logging/logging.test.ts
+++ b/packages/grafana-data/src/logging/logging.test.ts
@@ -1,0 +1,59 @@
+import { frontendLogging } from './LogManager';
+import { ArrayAppender, LogLevel } from './types';
+
+let testAppender = new ArrayAppender();
+frontendLogging.registerAppender('test', testAppender);
+frontendLogging.removeAppender('console');
+
+describe('Logging', () => {
+  beforeEach(() => {
+    frontendLogging.updateConfig({ loggers: {} });
+    testAppender.clear();
+  });
+
+  it('Should not log by default', () => {
+    const logger = frontendLogging.getLogger('test');
+    logger.debug('hello');
+
+    expect(testAppender.logs.length).toBe(0);
+
+    // Update config to enable debug logging
+    frontendLogging.updateConfig({ loggers: { ['test']: LogLevel.Debug } });
+
+    logger.debug('hello');
+
+    expect(testAppender.logs[0]).toEqual('[DEBUG] test: hello');
+
+    // Test that we can clear the config
+    frontendLogging.updateConfig({ loggers: {} });
+
+    logger.debug('hello');
+
+    expect(testAppender.logs.length).toBe(1);
+  });
+
+  it('Should inherit log level', () => {
+    const parent = frontendLogging.getLogger('parent');
+    const child = frontendLogging.getLogger('parent/child');
+
+    parent.setLevel(LogLevel.Debug);
+
+    child.debug('hello');
+
+    expect(testAppender.logs.length).toBe(1);
+
+    child.setLevel(LogLevel.Off);
+    child.debug('hello');
+
+    expect(testAppender.logs.length).toBe(1);
+  });
+
+  it('Can set logger level using string', () => {
+    const logger = frontendLogging.getLogger('logger');
+    frontendLogging.setLoggerLevel('logger', 'debug');
+
+    logger.debug('hello');
+
+    expect(testAppender.logs.length).toBe(1);
+  });
+});

--- a/packages/grafana-data/src/logging/types.ts
+++ b/packages/grafana-data/src/logging/types.ts
@@ -1,0 +1,40 @@
+import { Logger } from './Logger';
+
+export const enum LogLevel {
+  Debug = 1,
+  Info = 2,
+  Warn = 3,
+  Error = 4,
+  Off = 5,
+}
+
+const levelNames = {
+  [LogLevel.Debug]: 'DEBUG',
+  [LogLevel.Info]: 'INFO',
+  [LogLevel.Warn]: 'WARN',
+  [LogLevel.Error]: 'ERROR',
+  [LogLevel.Off]: 'OFF',
+};
+
+export interface LogAppender {
+  append(logger: Logger, level: LogLevel, args: unknown[]): void;
+}
+
+export interface LoggingConfig {
+  loggers: Record<string, LogLevel>;
+}
+
+/**
+ * Usefull for unit tests
+ */
+export class ArrayAppender implements LogAppender {
+  logs: string[] = [];
+
+  append(logger: Logger, level: LogLevel, args: unknown[]): void {
+    this.logs.push(`[${levelNames[level]}] ${logger.name}: ${args.join(' ')}`);
+  }
+
+  clear() {
+    this.logs = [];
+  }
+}

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -17,6 +17,7 @@ import {
   systemDateFormats,
   SystemDateFormatSettings,
   NewThemeOptions,
+  frontendLogging,
 } from '@grafana/data';
 
 export interface AzureSettings {
@@ -251,6 +252,8 @@ function overrideFeatureTogglesFromUrl(config: GrafanaBootConfig) {
     }
   });
 }
+
+(window as any).grafanaLogging = frontendLogging;
 
 const bootData = (window as any).grafanaBootData || {
   settings: {},

--- a/packages/grafana-runtime/src/services/LocationService.ts
+++ b/packages/grafana-runtime/src/services/LocationService.ts
@@ -1,7 +1,6 @@
 import * as H from 'history';
 
-import { deprecationWarning, UrlQueryMap, urlUtil } from '@grafana/data';
-import { attachDebugger, createLogger } from '@grafana/ui';
+import { deprecationWarning, frontendLogging, UrlQueryMap, urlUtil } from '@grafana/data';
 
 import { config } from '../config';
 
@@ -155,10 +154,5 @@ export const setLocationService = (location: LocationService) => {
   locationService = location;
 };
 
-const navigationLog = createLogger('Router');
-
 /** @internal */
-export const navigationLogger = navigationLog.logger;
-
-// For debugging purposes the location service is attached to global _debug variable
-attachDebugger('location', locationService, navigationLog);
+export const navigationLogger = frontendLogging.getLogger('navigation');

--- a/public/app/AppWrapper.tsx
+++ b/public/app/AppWrapper.tsx
@@ -62,8 +62,6 @@ export class AppWrapper extends React.Component<AppWrapperProps, AppWrapperState
         path={route.path}
         key={route.path}
         render={(props) => {
-          navigationLogger('AppWrapper', false, 'Rendering route', route, 'with match', props.location);
-          // TODO[Router]: test this logic
           if (roles?.length) {
             if (!roles.some((r: string) => contextSrv.hasRole(r))) {
               return <Redirect to="/" />;
@@ -84,7 +82,7 @@ export class AppWrapper extends React.Component<AppWrapperProps, AppWrapperState
     const { app } = this.props;
     const { ready } = this.state;
 
-    navigationLogger('AppWrapper', false, 'rendering');
+    navigationLogger.debug('AppWrapper', false, 'rendering');
 
     const commandPaletteActionSelected = (action: Action) => {
       reportInteraction('command_palette_action_selected', {

--- a/public/app/angular/AngularLocationWrapper.ts
+++ b/public/app/angular/AngularLocationWrapper.ts
@@ -32,7 +32,7 @@ export class AngularLocationWrapper {
   }
 
   hash(newHash?: string | null) {
-    navigationLogger('AngularLocationWrapper', false, 'Angular compat layer: hash');
+    navigationLogger.debug('AngularLocationWrapper', false, 'Angular compat layer: hash');
 
     if (!newHash) {
       return locationService.getLocation().hash.slice(1);
@@ -46,7 +46,7 @@ export class AngularLocationWrapper {
   }
 
   path(pathname?: any) {
-    navigationLogger('AngularLocationWrapper', false, 'Angular compat layer: path');
+    navigationLogger.debug('AngularLocationWrapper', false, 'Angular compat layer: path');
 
     const location = locationService.getLocation();
 
@@ -85,7 +85,7 @@ export class AngularLocationWrapper {
   }
 
   search(search?: any, paramValue?: any) {
-    navigationLogger('AngularLocationWrapper', false, 'Angular compat layer: search');
+    navigationLogger.debug('AngularLocationWrapper', false, 'Angular compat layer: search');
     if (!search) {
       return locationService.getSearchObject();
     }
@@ -122,12 +122,12 @@ export class AngularLocationWrapper {
   }
 
   state(state?: any) {
-    navigationLogger('AngularLocationWrapper', false, 'Angular compat layer: state');
+    navigationLogger.debug('AngularLocationWrapper', false, 'Angular compat layer: state');
     throw new Error('AngularLocationWrapper method not implemented.');
   }
 
   url(newUrl?: any) {
-    navigationLogger('AngularLocationWrapper', false, 'Angular compat layer: url');
+    navigationLogger.debug('AngularLocationWrapper', false, 'Angular compat layer: url');
 
     if (newUrl !== undefined) {
       if (newUrl.startsWith('#')) {

--- a/public/app/core/navigation/GrafanaRoute.tsx
+++ b/public/app/core/navigation/GrafanaRoute.tsx
@@ -2,7 +2,8 @@ import React, { Suspense, useEffect, useLayoutEffect } from 'react';
 // @ts-ignore
 import Drop from 'tether-drop';
 
-import { locationSearchToObject, navigationLogger, reportPageview } from '@grafana/runtime';
+import { frontendLogging } from '@grafana/data';
+import { locationSearchToObject, reportPageview } from '@grafana/runtime';
 import { ErrorBoundary } from '@grafana/ui';
 
 import { useGrafana } from '../context/GrafanaContext';
@@ -12,6 +13,8 @@ import { GrafanaRouteLoading } from './GrafanaRouteLoading';
 import { GrafanaRouteComponentProps, RouteDescriptor } from './types';
 
 export interface Props extends Omit<GrafanaRouteComponentProps, 'queryParams'> {}
+
+const navigationLogger = frontendLogging.getLogger('navigation');
 
 export function GrafanaRoute(props: Props) {
   const { chrome, keybindings } = useGrafana();
@@ -25,10 +28,10 @@ export function GrafanaRoute(props: Props) {
   useEffect(() => {
     updateBodyClassNames(props.route);
     cleanupDOM();
-    navigationLogger('GrafanaRoute', false, 'Mounted', props.match);
+    navigationLogger.debug('GrafanaRoute', false, 'Mounted', props.match);
 
     return () => {
-      navigationLogger('GrafanaRoute', false, 'Unmounted', props.route);
+      navigationLogger.debug('GrafanaRoute', false, 'Unmounted', props.route);
       updateBodyClassNames(props.route, true);
     };
     // props.match instance change even though only query params changed so to make this effect only trigger on route mount we have to disable exhaustive-deps
@@ -38,10 +41,10 @@ export function GrafanaRoute(props: Props) {
   useEffect(() => {
     cleanupDOM();
     reportPageview();
-    navigationLogger('GrafanaRoute', false, 'Updated', props);
+    navigationLogger.debug('GrafanaRoute', false, 'Updated', props);
   });
 
-  navigationLogger('GrafanaRoute', false, 'Rendered', props.route);
+  navigationLogger.debug('GrafanaRoute', false, 'Rendered', props.route);
 
   return (
     <ErrorBoundary>

--- a/public/app/core/navigation/patch/RouteParamsProvider.ts
+++ b/public/app/core/navigation/patch/RouteParamsProvider.ts
@@ -5,7 +5,7 @@ import { navigationLogger } from '@grafana/runtime';
 
 export class RouteParamsProvider {
   constructor() {
-    navigationLogger('Patch angular', false, 'RouteParamsProvider');
+    navigationLogger.debug('Patch angular', false, 'RouteParamsProvider');
   }
   $get = () => {
     // throw new Error('TODO: Refactor $routeParams');

--- a/public/app/core/navigation/patch/RouteProvider.ts
+++ b/public/app/core/navigation/patch/RouteProvider.ts
@@ -1,11 +1,11 @@
 // This is empty for now, as I think it's not going to be necessary.
 // This replaces Angular RouteProvider implementation with a dummy one to keep the ball rolling
 
-import { navigationLogger } from '@grafana/runtime';
+import { frontendLogging } from '@grafana/data';
 
 export class RouteProvider {
   constructor() {
-    navigationLogger('Patch angular', false, 'RouteProvider');
+    frontendLogging.getLogger('navigation').debug('Patch angular', false, 'RouteProvider');
   }
 
   $get() {

--- a/public/app/core/navigation/patch/interceptLinkClicks.ts
+++ b/public/app/core/navigation/patch/interceptLinkClicks.ts
@@ -17,7 +17,7 @@ export function interceptLinkClicks(e: MouseEvent) {
     if (href && !target) {
       const params = urlUtil.parseKeyValue(href.split('?')[1]);
       const orgIdChange = params.orgId && Number(params.orgId) !== config.bootData.user.orgId;
-      navigationLogger('utils', false, 'intercepting link click', e);
+      navigationLogger.debug('utils', false, 'intercepting link click', e);
       e.preventDefault();
 
       href = locationUtil.stripBaseFromUrl(href);

--- a/public/app/features/dashboard/dashgrid/PanelStateWrapper.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelStateWrapper.tsx
@@ -10,6 +10,7 @@ import {
   DashboardCursorSync,
   EventFilterOptions,
   FieldConfigSource,
+  frontendLogging,
   getDataSourceRef,
   getDefaultTimeRange,
   LinkModel,
@@ -60,6 +61,7 @@ import { seriesVisibilityConfigFactory } from './SeriesVisibilityConfigFactory';
 import { liveTimer } from './liveTimer';
 
 const DEFAULT_PLUGIN_ERROR = 'Error in plugin';
+const panelLogger = frontendLogging.getLogger('dashboard/panel');
 
 export interface Props {
   panel: PanelModel;
@@ -317,6 +319,8 @@ export class PanelStateWrapper extends PureComponent<Props, State> {
         }
         break;
     }
+
+    panelLogger.debug('onDataUpdate', this.props.panel.id, 'data', data);
 
     this.setState({ isFirstLoad, errorMessage, data, liveTime: undefined });
   }
@@ -623,6 +627,10 @@ export class PanelStateWrapper extends PureComponent<Props, State> {
     const { dashboard, panel, isViewing, isEditing, width, height, plugin } = this.props;
     const { errorMessage, data } = this.state;
     const { transparent } = panel;
+
+    if (panelLogger.isDebugEnabled()) {
+      panelLogger.debug('Rendering panel', this.props.panel.id, 'state', this.state);
+    }
 
     const alertState = data.alertState?.state;
 


### PR DESCRIPTION
This explores a super basic logging frontend lib that would allow us to add some debug logging to complex & async processes and enable in both dev & prod builds. 

Goals
* [x] As lightweight as possible with minimal runtime perf impact when disabled
* [x] Support hierarchical loggers & level config 
* [x] easy runtime config change (Example:  `window.grafanaLogging.setLoggerLevel("navigation", "debug"); ` console 
* [x] Support for multiple appenders (So we can in the future add a custom appender to include these in Inspect/Help tabs or support bundles)  
* [x] Skip levels per appender for now 

Future additions
* [ ]  Enable loggers via URL flags (important if we want to capture a process that only happens on first load) 