### PR TITLE
AzureMonitor: Fix template variables in ARG subscription field

### DIFF
--- a/public/app/plugins/datasource/azuremonitor/components/ArgQueryEditor/ArgQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/ArgQueryEditor/ArgQueryEditor.test.tsx
@@ -92,4 +92,30 @@ describe('ArgQueryEditor', () => {
     expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ subscriptions: ['foo', 'bar'] }));
     expect(onChange).not.toHaveBeenCalledWith(expect.objectContaining({ subscriptions: ['foo', 'bar', 'foobar'] }));
   });
+
+  it('should keep a template variable if used in the subscription field', async () => {
+    const onChange = jest.fn();
+    const datasource = createMockDatasource({
+      getSubscriptions: jest.fn().mockResolvedValue([{ value: 'foo' }]),
+    });
+    const query = createMockQuery({
+      subscriptions: ['$test'],
+    });
+    render(
+      <ArgQueryEditor
+        {...defaultProps}
+        datasource={datasource}
+        onChange={onChange}
+        query={query}
+        variableOptionGroup={{ label: 'Template Variables', options: [{ label: '$test', value: '$test' }] }}
+      />
+    );
+    expect(
+      await screen.findByTestId(selectors.components.queryEditor.argsQueryEditor.container.input)
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByTestId(selectors.components.queryEditor.argsQueryEditor.subscriptions.input)
+    ).toHaveTextContent('$test');
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ subscriptions: ['$test'] }));
+  });
 });

--- a/public/app/plugins/datasource/azuremonitor/components/ArgQueryEditor/ArgQueryEditor.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/ArgQueryEditor/ArgQueryEditor.tsx
@@ -33,7 +33,9 @@ function selectSubscriptions(
   if (querySubscriptions.length === 0 && fetchedSubscriptions.length) {
     querySubscriptions = [fetchedSubscriptions[0]];
   }
-  const commonSubscriptions = intersection(querySubscriptions, fetchedSubscriptions);
+
+  const templateVars = querySubscriptions.filter((sub) => sub.includes('$'));
+  const commonSubscriptions = intersection(querySubscriptions, fetchedSubscriptions).concat(templateVars);
   if (fetchedSubscriptions.length && querySubscriptions.length > commonSubscriptions.length) {
     // If not all of the query subscriptions are in the list of fetched subscriptions, then
     // select only the ones present (or the first one if none is present)


### PR DESCRIPTION
Ensures template variables are not removed from the ARG subscription field after initially being set.

Fixes #63316 