### PR TITLE
CloudMonitoring: Fix crash when inspecting data for MQL queries

### DIFF
--- a/pkg/tsdb/cloudmonitoring/cloudmonitoring.go
+++ b/pkg/tsdb/cloudmonitoring/cloudmonitoring.go
@@ -481,7 +481,11 @@ func calculateAlignmentPeriod(alignmentPeriod string, intervalMs int64, duration
 func formatLegendKeys(metricType string, defaultMetricName string, labels map[string]string,
 	additionalLabels map[string]string, query cloudMonitoringQueryExecutor) string {
 	if query.getAliasBy() == "" {
-		return defaultMetricName
+		if defaultMetricName != "" {
+			return defaultMetricName
+		}
+
+		return metricType
 	}
 
 	result := legendKeyFormat.ReplaceAllFunc([]byte(query.getAliasBy()), func(in []byte) []byte {

--- a/pkg/tsdb/cloudmonitoring/test-data/10-series-response-mql-no-labels.json
+++ b/pkg/tsdb/cloudmonitoring/test-data/10-series-response-mql-no-labels.json
@@ -1,0 +1,39 @@
+{
+  "timeSeriesDescriptor": {
+    "pointDescriptors": [
+      {
+        "key": "value_utilization_sum",
+        "valueType": "DOUBLE",
+        "metricKind": "GAUGE"
+      }
+    ]
+  },
+  "timeSeriesData": [
+    {
+      "pointData": [
+        {
+          "values": [
+            {
+              "int64Value": "0"
+            }
+          ],
+          "timeInterval": {
+            "startTime": "2020-05-18T09:47:00Z",
+            "endTime": "2020-05-18T09:48:00Z"
+          }
+        },
+        {
+          "values": [
+            {
+              "int64Value": "0"
+            }
+          ],
+          "timeInterval": {
+            "startTime": "2020-05-18T09:46:00Z",
+            "endTime": "2020-05-18T09:47:00Z"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/tsdb/cloudmonitoring/time_series_filter_test.go
+++ b/pkg/tsdb/cloudmonitoring/time_series_filter_test.go
@@ -396,6 +396,25 @@ func TestTimeSeriesFilter(t *testing.T) {
 		})
 	})
 
+	t.Run("field name is filled in for agg statement", func(t *testing.T) {
+		data, err := loadTestFile("./test-data/10-series-response-mql-no-labels.json")
+		require.NoError(t, err)
+		assert.Equal(t, 0, len(data.TimeSeries))
+		assert.Equal(t, 1, len(data.TimeSeriesData))
+
+		res := &backend.DataResponse{}
+		query := &cloudMonitoringTimeSeriesQuery{
+			parameters: &timeSeriesQuery{
+				Query:       "fetch gce_instance::compute.googleapis.com/instance/cpu/utilization | sum",
+				ProjectName: "test",
+				GraphPeriod: "60s",
+			},
+		}
+		err = query.parseResponse(res, data, "")
+		require.NoError(t, err)
+		assert.Equal(t, "value_utilization_sum", res.Frames[0].Fields[1].Name)
+	})
+
 	t.Run("Parse labels", func(t *testing.T) {
 		data, err := loadTestFile("./test-data/5-series-response-meta-data.json")
 		require.NoError(t, err)


### PR DESCRIPTION
This happened for MQL queries that used an [aggregate function][1], e.g. `sum`.

[1]: https://cloud.google.com/monitoring/mql/reference#aggr-function-group

**Which issue(s) does this PR fix?**:

Fixes #63744

