### PR TITLE
Bump coverage versions

### DIFF
--- a/.github/workflows/cloud-data-sources-code-coverage.yml
+++ b/.github/workflows/cloud-data-sources-code-coverage.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   workflow-call:
-    uses: grafana/code-coverage/.github/workflows/code-coverage.yml@v0.1.17
+    uses: grafana/code-coverage/.github/workflows/code-coverage.yml@v0.1.18
     with:
       frontend-path-regexp: public\/app\/plugins\/datasource\/(azuremonitor|cloud-monitoring|cloudwatch)
       backend-path-regexp: pkg\/tsdb\/(azuremonitor|cloudmonitoring|cloudwatch)

--- a/.github/workflows/ox-code-coverage.yml
+++ b/.github/workflows/ox-code-coverage.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   workflow-call:
-    uses: grafana/code-coverage/.github/workflows/code-coverage.yml@v0.1.17
+    uses: grafana/code-coverage/.github/workflows/code-coverage.yml@v0.1.18
     with:
       frontend-path-regexp: public\/app\/features\/(explore|correlations)|public\/app\/plugins\/datasource\/(loki|elasticsearch)
       backend-path-regexp: pkg\/services\/(queryhistory)|pkg\/tsdb\/(loki|elasticsearch)


### PR DESCRIPTION
Needed fix on v9.4.x branch to avoid generating coverage for `json` files which breaks the coverage step.