### PR TITLE
Alerting: Prevent resetting the form on evaluation group interval change

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/AlertRuleForm.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AlertRuleForm.tsx
@@ -161,10 +161,9 @@ export const AlertRuleForm: FC<Props> = ({ existing, prefill }) => {
         condition: 'C',
         ...defaultsInQueryParamsObject,
         type: RuleFormType.grafana,
-        evaluateEvery: evaluateEvery,
       });
     }
-  }, [defaultDsAndQueries.queries, reset, existing, prefill, defaultsInQueryParamsObject, evaluateEvery]);
+  }, [defaultDsAndQueries.queries, reset, existing, prefill, defaultsInQueryParamsObject]);
 
   const type = watch('type');
   const dataSourceName = watch('dataSourceName');


### PR DESCRIPTION
**What is this feature?**

Fixes a bug where changing the `evaluateEvery` value would reset the Create Rule form.

**Who is this feature for?**

All users.

Before:

https://user-images.githubusercontent.com/6271380/221280185-c9de7fc0-0caf-41eb-beee-e3dd8d504127.mov

After:

![2023-02-24 17 08 34](https://user-images.githubusercontent.com/6271380/221280628-5318b0aa-8b04-423c-8129-d6003c8aa7f3.gif)


Notes for reviewer:

This was introduced after [https://github.com/grafana/grafana/pull/63092](https://github.com/grafana/grafana/pull/63092/files#diff-ceb4d119726108afe1e8b0ee6fdd464fe16e5883e4717455986d3dff5846497bR154) where the form is reset when the default queries for the data source are obtained. The reset of the form depends on this value, but it doesn't seem that `evaluateEvery` belongs in the dependency list.
