### PR TITLE
Datasources: Add user_agent header customization for outgoing HTTP requests

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -213,7 +213,7 @@ response_limit = 0
 # Limits the number of rows that Grafana will process from SQL data sources.
 row_limit = 1000000
 
-# Sets a custom value for User-Agent header for outgoing data proxy requests. If empty, default value will be "Grafana/<BuildVersion>" (e.g. "Grafana/9.0.0").
+# Sets a custom value for the `User-Agent` header for outgoing data proxy requests. If empty, the default value is `Grafana/<BuildVersion>` (for example `Grafana/9.0.0`).
 user_agent =
 
 #################################### Analytics ###########################

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -213,6 +213,9 @@ response_limit = 0
 # Limits the number of rows that Grafana will process from SQL data sources.
 row_limit = 1000000
 
+# Sets a custom value for User-Agent header for outgoing data proxy requests. If empty, default value will be "Grafana/<BuildVersion>" (e.g. "Grafana/9.0.0").
+user_agent =
+
 #################################### Analytics ###########################
 [analytics]
 # Server reporting, sends usage counters to stats.grafana.org every 24 hours.

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -220,6 +220,9 @@
 # Limits the number of rows that Grafana will process from SQL data sources.
 ;row_limit = 1000000
 
+# Sets a custom value for User-Agent header for outgoing data proxy requests. If empty, default value will be "Grafana/<BuildVersion>" (e.g. "Grafana/9.0.0").
+;user_agent =
+
 #################################### Analytics ####################################
 [analytics]
 # Server reporting, sends usage counters to stats.grafana.org every 24 hours.

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -220,7 +220,7 @@
 # Limits the number of rows that Grafana will process from SQL data sources.
 ;row_limit = 1000000
 
-# Sets a custom value for User-Agent header for outgoing data proxy requests. If empty, default value will be "Grafana/<BuildVersion>" (e.g. "Grafana/9.0.0").
+# Sets a custom value for the `User-Agent` header for outgoing data proxy requests. If empty, the default value is `Grafana/<BuildVersion>` (for example `Grafana/9.0.0`).
 ;user_agent =
 
 #################################### Analytics ####################################

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -486,7 +486,7 @@ Limits the number of rows that Grafana will process from SQL (relational) data s
 
 ### user_agent
 
-Sets a custom value for `User-Agent` header for outgoing data proxy requests. If empty, default value will be `Grafana/<BuildVersion>` (e.g. `Grafana/9.0.0`).
+Sets a custom value for the `User-Agent` header for outgoing data proxy requests. If empty, the default value is `Grafana/<BuildVersion>` (for example `Grafana/9.0.0`).
 
 <hr />
 

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -484,6 +484,10 @@ Limits the amount of bytes that will be read/accepted from responses of outgoing
 
 Limits the number of rows that Grafana will process from SQL (relational) data sources. Default is `1000000`.
 
+### user_agent
+
+Sets a custom value for `User-Agent` header for outgoing data proxy requests. If empty, default value will be `Grafana/<BuildVersion>` (e.g. `Grafana/9.0.0`).
+
 <hr />
 
 ## [analytics]

--- a/pkg/api/pluginproxy/ds_proxy.go
+++ b/pkg/api/pluginproxy/ds_proxy.go
@@ -225,7 +225,7 @@ func (proxy *DataSourceProxy) director(req *http.Request) {
 	proxyutil.ApplyUserHeader(proxy.cfg.SendUserHeader, req, proxy.ctx.SignedInUser)
 
 	proxyutil.ClearCookieHeader(req, proxy.ds.AllowedCookies(), []string{proxy.cfg.LoginCookieName})
-	req.Header.Set("User-Agent", fmt.Sprintf("Grafana/%s", setting.BuildVersion))
+	req.Header.Set("User-Agent", proxy.cfg.DataProxyUserAgent)
 
 	jsonData := make(map[string]interface{})
 	if proxy.ds.JsonData != nil {

--- a/pkg/infra/httpclient/httpclientprovider/http_client_provider.go
+++ b/pkg/infra/httpclient/httpclientprovider/http_client_provider.go
@@ -1,7 +1,6 @@
 package httpclientprovider
 
 import (
-	"fmt"
 	"net/http"
 	"time"
 
@@ -21,13 +20,12 @@ var newProviderFunc = sdkhttpclient.NewProvider
 // New creates a new HTTP client provider with pre-configured middlewares.
 func New(cfg *setting.Cfg, validator validations.PluginRequestValidator, tracer tracing.Tracer) *sdkhttpclient.Provider {
 	logger := log.New("httpclient")
-	userAgent := fmt.Sprintf("Grafana/%s", cfg.BuildVersion)
 
 	middlewares := []sdkhttpclient.Middleware{
 		TracingMiddleware(logger, tracer),
 		DataSourceMetricsMiddleware(),
 		sdkhttpclient.ContextualMiddleware(),
-		SetUserAgentMiddleware(userAgent),
+		SetUserAgentMiddleware(cfg.DataProxyUserAgent),
 		sdkhttpclient.BasicAuthenticationMiddleware(),
 		sdkhttpclient.CustomHeadersMiddleware(),
 		ResponseLimitMiddleware(cfg.ResponseLimit),

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -341,6 +341,7 @@ type Cfg struct {
 	DataProxyIdleConnTimeout       int
 	ResponseLimit                  int64
 	DataProxyRowLimit              int64
+	DataProxyUserAgent             string
 
 	// DistributedCache
 	RemoteCacheOptions *RemoteCacheOptions

--- a/pkg/setting/setting_data_proxy.go
+++ b/pkg/setting/setting_data_proxy.go
@@ -1,6 +1,10 @@
 package setting
 
-import "gopkg.in/ini.v1"
+import (
+	"fmt"
+
+	"gopkg.in/ini.v1"
+)
 
 const defaultDataProxyRowLimit = int64(1000000)
 
@@ -18,6 +22,11 @@ func readDataProxySettings(iniFile *ini.File, cfg *Cfg) error {
 	cfg.DataProxyIdleConnTimeout = dataproxy.Key("idle_conn_timeout_seconds").MustInt(90)
 	cfg.ResponseLimit = dataproxy.Key("response_limit").MustInt64(0)
 	cfg.DataProxyRowLimit = dataproxy.Key("row_limit").MustInt64(defaultDataProxyRowLimit)
+	cfg.DataProxyUserAgent = dataproxy.Key("user_agent").String()
+
+	if cfg.DataProxyUserAgent == "" {
+		cfg.DataProxyUserAgent = fmt.Sprintf("Grafana/%s", BuildVersion)
+	}
 
 	if cfg.DataProxyRowLimit <= 0 {
 		cfg.DataProxyRowLimit = defaultDataProxyRowLimit

--- a/pkg/tsdb/azuremonitor/resourcegraph/azure-resource-graph-datasource.go
+++ b/pkg/tsdb/azuremonitor/resourcegraph/azure-resource-graph-datasource.go
@@ -19,7 +19,6 @@ import (
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
-	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tsdb/azuremonitor/loganalytics"
 	"github.com/grafana/grafana/pkg/tsdb/azuremonitor/macros"
 	"github.com/grafana/grafana/pkg/tsdb/azuremonitor/types"
@@ -243,7 +242,6 @@ func (e *AzureResourceGraphDatasource) createRequest(ctx context.Context, logger
 	}
 	req.URL.Path = "/"
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("User-Agent", fmt.Sprintf("Grafana/%s", setting.BuildVersion))
 
 	return req, nil
 }

--- a/pkg/tsdb/azuremonitor/resourcegraph/azure-resource-graph-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/resourcegraph/azure-resource-graph-datasource_test.go
@@ -98,7 +98,6 @@ func TestAzureResourceGraphCreateRequest(t *testing.T) {
 			expectedURL: "http://ds/",
 			expectedHeaders: http.Header{
 				"Content-Type": []string{"application/json"},
-				"User-Agent":   []string{"Grafana/"},
 			},
 			Err: require.NoError,
 		},


### PR DESCRIPTION
Fix #63767 based on [comment](https://github.com/grafana/grafana/discussions/58714#discussioncomment-4351906) in the original discussion #58714 