### PR TITLE
ErrorHandling: Fixes issues with bad error messages

### DIFF
--- a/packages/grafana-runtime/src/services/backendSrv.ts
+++ b/packages/grafana-runtime/src/services/backendSrv.ts
@@ -118,6 +118,7 @@ export interface FetchError<T = any> {
   status: number;
   statusText?: string;
   data: T;
+  message?: string;
   cancelled?: boolean;
   isHandled?: boolean;
   config: BackendSrvRequest;

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -116,14 +116,6 @@ export function PanelChrome({
 
   const headerContent = (
     <>
-      {statusMessage && (
-        <PanelStatus
-          className={cx(styles.errorContainer, dragClassCancel)}
-          message={statusMessage}
-          onClick={statusMessageOnClick}
-          ariaLabel="Panel status"
-        />
-      )}
       {title && (
         <h6 title={title} className={styles.title}>
           {title}
@@ -181,6 +173,15 @@ export function PanelChrome({
             {leftItems && <div className={styles.leftItems}>{itemsRenderer(leftItems, (item) => item)}</div>}
           </div>
         </div>
+      )}
+
+      {statusMessage && (
+        <PanelStatus
+          className={cx(styles.errorContainer, dragClassCancel)}
+          message={statusMessage}
+          onClick={statusMessageOnClick}
+          ariaLabel="Panel status"
+        />
       )}
 
       <div className={styles.content} style={contentStyle}>

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -116,6 +116,14 @@ export function PanelChrome({
 
   const headerContent = (
     <>
+      {statusMessage && (
+        <PanelStatus
+          className={cx(styles.errorContainer, dragClassCancel)}
+          message={statusMessage}
+          onClick={statusMessageOnClick}
+          ariaLabel="Panel status"
+        />
+      )}
       {title && (
         <h6 title={title} className={styles.title}>
           {title}
@@ -173,15 +181,6 @@ export function PanelChrome({
             {leftItems && <div className={styles.leftItems}>{itemsRenderer(leftItems, (item) => item)}</div>}
           </div>
         </div>
-      )}
-
-      {statusMessage && (
-        <PanelStatus
-          className={cx(styles.errorContainer, dragClassCancel)}
-          message={statusMessage}
-          onClick={statusMessageOnClick}
-          ariaLabel="Panel status"
-        />
       )}
 
       <div className={styles.content} style={contentStyle}>

--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -24,6 +24,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/secrets"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/util"
 	"github.com/grafana/grafana/pkg/web"
 )
 
@@ -188,7 +189,7 @@ func (hs *HTTPServer) tryAutoLogin(c *contextmodel.ReqContext) bool {
 
 func (hs *HTTPServer) LoginAPIPing(c *contextmodel.ReqContext) response.Response {
 	if c.IsSignedIn || c.IsAnonymous {
-		return response.JSON(http.StatusOK, "Logged in")
+		return response.JSON(http.StatusOK, util.DynMap{"message": "Logged in"})
 	}
 
 	return response.Error(401, "Unauthorized", nil)

--- a/public/app/core/services/backend_srv.ts
+++ b/public/app/core/services/backend_srv.ts
@@ -317,6 +317,11 @@ export class BackendSrv implements BackendService {
     let description = '';
     let message = err.data.message;
 
+    // Sometimes we have a better error message on err.message
+    if (message === 'Unexpected error' && err.message) {
+      message = err.message;
+    }
+
     if (message.length > 80) {
       description = message;
       message = 'Error';

--- a/public/app/core/specs/backend_srv.test.ts
+++ b/public/app/core/specs/backend_srv.test.ts
@@ -275,6 +275,26 @@ describe('backendSrv', () => {
             'bogus-trace-id',
           ]);
         });
+
+        it('It should favor error.message for fetch errors when error.data.message is Unexpected error', async () => {
+          const { backendSrv, appEventsMock } = getTestContext({});
+          backendSrv.showErrorAlert(
+            {
+              url: 'api/do/something',
+            } as BackendSrvRequest,
+            {
+              data: {
+                message: 'Unexpected error',
+              },
+              message: 'Failed to fetch',
+              status: 500,
+              config: {
+                url: '',
+              },
+            } as FetchError
+          );
+          expect(appEventsMock.emit).toHaveBeenCalledWith(AppEvents.alertError, ['Failed to fetch', '']);
+        });
       });
     });
 

--- a/public/app/core/utils/errors.ts
+++ b/public/app/core/utils/errors.ts
@@ -1,10 +1,12 @@
 import { isFetchError } from '@grafana/runtime';
 
 export function getMessageFromError(err: unknown): string {
+  if (typeof err === 'string') {
+    return err;
+  }
+
   if (err) {
-    if (typeof err === 'string') {
-      return err;
-    } else if (err instanceof Error) {
+    if (err instanceof Error) {
       return err.message;
     } else if (isFetchError(err)) {
       if (err.data && err.data.message) {
@@ -14,5 +16,6 @@ export function getMessageFromError(err: unknown): string {
       }
     }
   }
+
   return JSON.stringify(err);
 }


### PR DESCRIPTION
Noticed bad error messages, some containing `""` in the description. 

* Bad error message when offline, just says "Unexpected error" (can't find where this is coming from. but err.message is better here with `Failed to fetch`) 
* Noticed error messages like "Unexpected token 'L', "Logged in" is not valid JSON" due to loginPing returning invalid JSON response.  (Backend fix) 
* Fix the notification display when description text just just an empty string (it formatted it to JSON causing a `""` being displayed). 

Before:
![Screenshot from 2023-02-25 11-40-27](https://user-images.githubusercontent.com/10999/221352641-0efbf16d-de14-4b85-9661-51c1ea9c1208.png)

After (when offline): 
![Screenshot from 2023-02-25 11-35-33](https://user-images.githubusercontent.com/10999/221352660-36ab3c2f-86ac-44d2-98a1-1a0d3eeaae87.png)

After (When invalid auth):  (did also just say unexpected error before)
![Screenshot from 2023-02-25 11-32-18](https://user-images.githubusercontent.com/10999/221352672-8635af6d-99e4-4a86-ac40-e51232400254.png)
