### PR TITLE
AuthN: add metrics for login and authentication

### DIFF
--- a/pkg/services/authn/authnimpl/metrics.go
+++ b/pkg/services/authn/authnimpl/metrics.go
@@ -10,12 +10,27 @@ const (
 )
 
 type metrics struct {
+	failedAuth     prometheus.Counter
+	successfulAuth *prometheus.CounterVec
+
 	failedLogin     *prometheus.CounterVec
 	successfulLogin *prometheus.CounterVec
 }
 
 func newMetrics(reg prometheus.Registerer) *metrics {
 	m := &metrics{
+		failedAuth: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubSystem,
+			Name:      "authn_failed_authentication_total",
+			Help:      "Number of failed authentications",
+		}),
+		successfulAuth: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubSystem,
+			Name:      "authn_successful_authentication_total",
+			Help:      "Number of successful authentications",
+		}, []string{"client"}),
 		failedLogin: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: metricsNamespace,
 			Subsystem: metricsSubSystem,

--- a/pkg/services/authn/authnimpl/metrics.go
+++ b/pkg/services/authn/authnimpl/metrics.go
@@ -1,12 +1,8 @@
 package authnimpl
 
 import (
-	"sync"
-
 	"github.com/prometheus/client_golang/prometheus"
 )
-
-var registerOnce sync.Once
 
 const (
 	metricsSubSystem = "authn"
@@ -50,14 +46,12 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 	}
 
 	if reg != nil {
-		registerOnce.Do(func() {
-			reg.MustRegister(
-				m.failedAuth,
-				m.successfulAuth,
-				m.failedLogin,
-				m.successfulLogin,
-			)
-		})
+		reg.MustRegister(
+			m.failedAuth,
+			m.successfulAuth,
+			m.failedLogin,
+			m.successfulLogin,
+		)
 	}
 
 	return m

--- a/pkg/services/authn/authnimpl/metrics.go
+++ b/pkg/services/authn/authnimpl/metrics.go
@@ -1,8 +1,12 @@
 package authnimpl
 
 import (
+	"sync"
+
 	"github.com/prometheus/client_golang/prometheus"
 )
+
+var registerOnce sync.Once
 
 const (
 	metricsSubSystem = "authn"
@@ -46,12 +50,14 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 	}
 
 	if reg != nil {
-		reg.MustRegister(
-			m.failedAuth,
-			m.successfulAuth,
-			m.failedLogin,
-			m.successfulLogin,
-		)
+		registerOnce.Do(func() {
+			reg.MustRegister(
+				m.failedAuth,
+				m.successfulAuth,
+				m.failedLogin,
+				m.successfulLogin,
+			)
+		})
 	}
 
 	return m

--- a/pkg/services/authn/authnimpl/metrics.go
+++ b/pkg/services/authn/authnimpl/metrics.go
@@ -46,8 +46,12 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 	}
 
 	if reg != nil {
-		reg.MustRegister(m.failedLogin)
-		reg.MustRegister(m.successfulLogin)
+		reg.MustRegister(
+			m.failedAuth,
+			m.successfulAuth,
+			m.failedLogin,
+			m.successfulLogin,
+		)
 	}
 
 	return m

--- a/pkg/services/authn/authnimpl/metrics.go
+++ b/pkg/services/authn/authnimpl/metrics.go
@@ -1,0 +1,39 @@
+package authnimpl
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	metricsSubSystem = "authn"
+	metricsNamespace = "grafana"
+)
+
+type metrics struct {
+	failedLogin     *prometheus.CounterVec
+	successfulLogin *prometheus.CounterVec
+}
+
+func newMetrics(reg prometheus.Registerer) *metrics {
+	m := &metrics{
+		failedLogin: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubSystem,
+			Name:      "authn_failed_login_total",
+			Help:      "Number of failed logins",
+		}, []string{"client"}),
+		successfulLogin: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubSystem,
+			Name:      "authn_successful_login_total",
+			Help:      "Number of successful logins",
+		}, []string{"client"}),
+	}
+
+	if reg != nil {
+		reg.MustRegister(m.failedLogin)
+		reg.MustRegister(m.successfulLogin)
+	}
+
+	return m
+}

--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -193,12 +193,14 @@ func (s *Service) Authenticate(ctx context.Context, r *authn.Request) (*authn.Id
 			}
 
 			if identity != nil {
+				s.metrics.successfulAuth.WithLabelValues(item.v.Name()).Inc()
 				return identity, nil
 			}
 		}
 	}
 
 	if authErr != nil {
+		s.metrics.failedAuth.Inc()
 		return nil, authErr
 	}
 

--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -61,7 +61,7 @@ func ProvideService(
 	authInfoService login.AuthInfoService, renderService rendering.Service,
 	features *featuremgmt.FeatureManager, oauthTokenService oauthtoken.OAuthTokenService,
 	socialService social.Service, cache *remotecache.RemoteCache,
-	ldapService service.LDAP,
+	ldapService service.LDAP, registerer prometheus.Registerer,
 ) *Service {
 	s := &Service{
 		log:            log.New("authn.service"),
@@ -69,7 +69,7 @@ func ProvideService(
 		clients:        make(map[string]authn.Client),
 		clientQueue:    newQueue[authn.ContextAwareClient](),
 		tracer:         tracer,
-		metrics:        newMetrics(prometheus.DefaultRegisterer),
+		metrics:        newMetrics(registerer),
 		sessionService: sessionService,
 		postAuthHooks:  newQueue[authn.PostAuthHookFn](),
 		postLoginHooks: newQueue[authn.PostLoginHookFn](),

--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -63,7 +63,6 @@ func ProvideService(
 	socialService social.Service, cache *remotecache.RemoteCache,
 	ldapService service.LDAP,
 ) *Service {
-
 	s := &Service{
 		log:            log.New("authn.service"),
 		cfg:            cfg,

--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -234,6 +234,10 @@ func (s *Service) RegisterPostAuthHook(hook authn.PostAuthHookFn, priority uint)
 }
 
 func (s *Service) Login(ctx context.Context, client string, r *authn.Request) (identity *authn.Identity, err error) {
+	ctx, span := s.tracer.Start(ctx, "authn.Login")
+	defer span.End()
+	span.SetAttributes(attributeKeyClient, client, attribute.Key(attributeKeyClient).String(client))
+
 	defer func() {
 		for _, hook := range s.postLoginHooks.items {
 			hook.v(ctx, identity, r, err)

--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -274,7 +274,6 @@ func (s *Service) Login(ctx context.Context, client string, r *authn.Request) (i
 	addr := web.RemoteAddr(r.HTTPRequest)
 	ip, err := network.GetIPFromAddress(addr)
 	if err != nil {
-		s.metrics.failedLogin.WithLabelValues(client).Inc()
 		s.log.FromContext(ctx).Debug("Failed to parse ip from address", "client", c.Name(), "id", identity.ID, "addr", addr, "error", err)
 	}
 

--- a/pkg/services/authn/authnimpl/service_test.go
+++ b/pkg/services/authn/authnimpl/service_test.go
@@ -316,6 +316,7 @@ func setupTests(t *testing.T, opts ...func(svc *Service)) *Service {
 		clients:        map[string]authn.Client{},
 		clientQueue:    newQueue[authn.ContextAwareClient](),
 		tracer:         tracing.InitializeTracerForTest(),
+		metrics:        newMetrics(nil),
 		postAuthHooks:  newQueue[authn.PostAuthHookFn](),
 		postLoginHooks: newQueue[authn.PostLoginHookFn](),
 	}


### PR DESCRIPTION
**What is this feature?**
Add metrics for successful and failed authentication/login.

We already have metrics for login, oauth login and saml login but these can be replaced with the new metrics added in the pr

Fixes #

**Special notes for your reviewer**:

