### PR TITLE
Navigation: Fix broken layout at 544px

### DIFF
--- a/packages/grafana-data/src/themes/breakpoints.ts
+++ b/packages/grafana-data/src/themes/breakpoints.ts
@@ -16,8 +16,8 @@ export interface ThemeBreakpoints {
   values: ThemeBreakpointValues;
   keys: string[];
   unit: string;
-  up: (key: ThemeBreakpointsKey) => string;
-  down: (key: ThemeBreakpointsKey) => string;
+  up: (key: ThemeBreakpointsKey | number) => string;
+  down: (key: ThemeBreakpointsKey | number) => string;
 }
 
 /** @internal */

--- a/public/app/core/components/AppChrome/Organization/OrganizationSwitcher.test.tsx
+++ b/public/app/core/components/AppChrome/Organization/OrganizationSwitcher.test.tsx
@@ -29,6 +29,14 @@ const renderWithProvider = ({ initialState }: { initialState?: Partial<appTypes.
 };
 
 describe('OrganisationSwitcher', () => {
+  beforeEach(() => {
+    (window.matchMedia as jest.Mock).mockImplementation(() => ({
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      matches: true,
+    }));
+  });
+
   it('should only render if more than one organisations', () => {
     renderWithProvider({
       initialState: {
@@ -75,7 +83,7 @@ describe('OrganisationSwitcher', () => {
     (window.matchMedia as jest.Mock).mockImplementation(() => ({
       addEventListener: jest.fn(),
       removeEventListener: jest.fn(),
-      matches: () => true,
+      matches: false,
     }));
     renderWithProvider({
       initialState: {

--- a/public/app/core/components/AppChrome/Organization/OrganizationSwitcher.tsx
+++ b/public/app/core/components/AppChrome/Organization/OrganizationSwitcher.tsx
@@ -31,12 +31,12 @@ export function OrganizationSwitcher() {
 
   const breakpoint = theme.breakpoints.values.sm;
 
-  const [isSmallScreen, setIsSmallScreen] = useState(window.matchMedia(`(max-width: ${breakpoint}px)`).matches);
+  const [isSmallScreen, setIsSmallScreen] = useState(!window.matchMedia(`(min-width: ${breakpoint}px)`).matches);
 
   useMediaQueryChange({
     breakpoint,
     onChange: (e) => {
-      setIsSmallScreen(e.matches);
+      setIsSmallScreen(!e.matches);
     },
   });
 

--- a/public/app/core/components/AppChrome/QuickAdd/QuickAdd.tsx
+++ b/public/app/core/components/AppChrome/QuickAdd/QuickAdd.tsx
@@ -19,13 +19,13 @@ export const QuickAdd = ({}: Props) => {
   const navBarTree = useSelector((state) => state.navBarTree);
   const breakpoint = theme.breakpoints.values.sm;
 
-  const [isSmallScreen, setIsSmallScreen] = useState(window.matchMedia(`(max-width: ${breakpoint}px)`).matches);
+  const [isSmallScreen, setIsSmallScreen] = useState(!window.matchMedia(`(min-width: ${breakpoint}px)`).matches);
   const createActions = useMemo(() => findCreateActions(navBarTree), [navBarTree]);
 
   useMediaQueryChange({
     breakpoint,
     onChange: (e) => {
-      setIsSmallScreen(e.matches);
+      setIsSmallScreen(!e.matches);
     },
   });
 

--- a/public/app/core/components/AppChrome/TopBar/TopSearchBarSection.test.tsx
+++ b/public/app/core/components/AppChrome/TopBar/TopSearchBarSection.test.tsx
@@ -17,7 +17,7 @@ describe('TopSearchBarSection', () => {
     (window.matchMedia as jest.Mock).mockImplementation(() => ({
       addEventListener: jest.fn(),
       removeEventListener: jest.fn(),
-      matches: () => false,
+      matches: true,
     }));
 
     const { container } = renderComponent();
@@ -30,7 +30,7 @@ describe('TopSearchBarSection', () => {
     (window.matchMedia as jest.Mock).mockImplementation(() => ({
       addEventListener: jest.fn(),
       removeEventListener: jest.fn(),
-      matches: () => true,
+      matches: false,
     }));
 
     const { container } = renderComponent();

--- a/public/app/core/components/AppChrome/TopBar/TopSearchBarSection.tsx
+++ b/public/app/core/components/AppChrome/TopBar/TopSearchBarSection.tsx
@@ -15,12 +15,12 @@ export function TopSearchBarSection({ children, align = 'left' }: TopSearchBarSe
   const theme = useTheme2();
   const breakpoint = theme.breakpoints.values.sm;
 
-  const [isSmallScreen, setIsSmallScreen] = useState(window.matchMedia(`(max-width: ${breakpoint}px)`).matches);
+  const [isSmallScreen, setIsSmallScreen] = useState(!window.matchMedia(`(min-width: ${breakpoint}px)`).matches);
 
   useMediaQueryChange({
     breakpoint,
     onChange: (e: MediaQueryListEvent) => {
-      setIsSmallScreen(e.matches);
+      setIsSmallScreen(!e.matches);
     },
   });
 

--- a/public/app/core/components/AppChrome/TopSearchBarCommandPaletteTrigger.tsx
+++ b/public/app/core/components/AppChrome/TopSearchBarCommandPaletteTrigger.tsx
@@ -18,12 +18,12 @@ export function TopSearchBarCommandPaletteTrigger() {
 
   const breakpoint = theme.breakpoints.values.sm;
 
-  const [isSmallScreen, setIsSmallScreen] = useState(window.matchMedia(`(max-width: ${breakpoint}px)`).matches);
+  const [isSmallScreen, setIsSmallScreen] = useState(!window.matchMedia(`(min-width: ${breakpoint}px)`).matches);
 
   useMediaQueryChange({
     breakpoint,
     onChange: (e) => {
-      setIsSmallScreen(e.matches);
+      setIsSmallScreen(!e.matches);
     },
   });
 

--- a/public/app/core/hooks/useMediaQueryChange.ts
+++ b/public/app/core/hooks/useMediaQueryChange.ts
@@ -8,7 +8,7 @@ export function useMediaQueryChange({
   onChange: (e: MediaQueryListEvent) => void;
 }) {
   useEffect(() => {
-    const mediaQuery = window.matchMedia(`(max-width: ${breakpoint}px)`);
+    const mediaQuery = window.matchMedia(`(min-width: ${breakpoint}px)`);
     const onMediaQueryChange = (e: MediaQueryListEvent) => onChange(e);
     mediaQuery.addEventListener('change', onMediaQueryChange);
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- `TopSearchBar` uses the `up` method to change the top search bar layout: https://github.com/grafana/grafana/blob/ash/fix-media-query/public/app/core/components/AppChrome/TopSearchBar.tsx#L74
  - internally this uses a `min-width` media query 
- the current implementation of `useMediaQueryChange` uses a `max-width` media query. 
- this leaves us with the boundary value itself where `useMediaQueryChange` matches but `up` does not, resulting in a broken layout (see screenshots)
- changes `useMediaQueryChange` to use a `min-width` media query and inverts the logic everywhere it's used
  - coincidentally this is just within items in the topnav!
- fixes unit tests

| width | before | after |
| --- | --- | --- |
| 545px | ![image](https://user-images.githubusercontent.com/20999846/221560044-cbb583ba-2ca8-4923-8615-1e70f481e4fc.png) | ![image](https://user-images.githubusercontent.com/20999846/221559591-81061157-8f43-41e9-a847-62246b53dbfe.png) |
| 544px | ![image](https://user-images.githubusercontent.com/20999846/221559972-269f8474-5220-470e-bb5f-b1a019c2d294.png) | ![image](https://user-images.githubusercontent.com/20999846/221559674-1629298d-70dd-49e0-98fc-9e5744ce4ea7.png) |
| 543px | ![image](https://user-images.githubusercontent.com/20999846/221559921-76d22edd-48fe-4737-8bf9-99476e930a30.png) | ![image](https://user-images.githubusercontent.com/20999846/221559751-e7b5eff9-e2a5-443c-bdc5-ecb9454c4d5d.png) |

- updates the theme breakpoint interface to allow for passing numbers to the `up`/`down` methods (this is unrelated to the fix in the PR, i just noticed it whilst in the area)

**Why do we need this feature?**

- so we don't have a broken layout at 544px wide

**Who is this feature for?**

- everyone!

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

