### PR TITLE
Connections: Fix minor issues around Your connections/Data sources page

### DIFF
--- a/public/app/features/connections/Connections.test.tsx
+++ b/public/app/features/connections/Connections.test.tsx
@@ -106,4 +106,34 @@ describe('Connections', () => {
     expect(screen.queryByText('Data sources')).not.toBeInTheDocument();
     expect(screen.queryByText('No results matching your query were found.')).not.toBeInTheDocument();
   });
+
+  test('Your connections redirects to Data sources if it has one child', async () => {
+    const navIndexCopy = {
+      ...navIndex,
+      'connections-your-connections': {
+        id: 'connections-your-connections',
+        text: 'Your connections',
+        subTitle: 'Manage your existing connections',
+        url: '/connections/your-connections',
+        children: [
+          {
+            id: 'connections-your-connections-datasources',
+            text: 'Datasources',
+            subTitle: 'Manage your existing datasource connections',
+            url: '/connections/your-connections/datasources',
+          },
+        ],
+      },
+    };
+
+    const store = configureStore({
+      navIndex: navIndexCopy,
+      plugins: getPluginsStateMock([]),
+    });
+
+    renderPage(ROUTES.YourConnections, store);
+
+    expect(await screen.findByPlaceholderText('Search by name or type')).toBeInTheDocument();
+    expect(await screen.queryByRole('link', { name: 'Datasources' })).toBeNull();
+  });
 });

--- a/public/app/features/connections/Connections.tsx
+++ b/public/app/features/connections/Connections.tsx
@@ -19,6 +19,11 @@ export default function Connections() {
   const navIndex = useSelector((state: StoreState) => state.navIndex);
   const isConnectDataPageOverriden = Boolean(navIndex['standalone-plugin-page-/connections/connect-data']);
 
+  const YourConnectionsPage =
+    navIndex['connections-your-connections'].children && navIndex['connections-your-connections'].children?.length > 1
+      ? () => <NavLandingPage navId="connections-your-connections" />
+      : () => <Redirect to={ROUTES.DataSources} />;
+
   return (
     <DataSourcesRoutesContext.Provider
       value={{
@@ -31,12 +36,7 @@ export default function Connections() {
       <Switch>
         {/* Redirect to "Connect data" by default */}
         <Route exact sensitive path={ROUTES.Base} component={() => <Redirect to={ROUTES.ConnectData} />} />
-        <Route
-          exact
-          sensitive
-          path={ROUTES.YourConnections}
-          component={() => <NavLandingPage navId="connections-your-connections" />}
-        />
+        <Route exact sensitive path={ROUTES.YourConnections} component={YourConnectionsPage} />
         <Route exact sensitive path={ROUTES.DataSources} component={DataSourcesListPage} />
         <Route exact sensitive path={ROUTES.DataSourcesDetails} component={DataSourceDetailsPage} />
         <Route exact sensitive path={ROUTES.DataSourcesNew} component={NewDataSourcePage} />

--- a/public/app/features/connections/pages/DataSourcesListPage.tsx
+++ b/public/app/features/connections/pages/DataSourcesListPage.tsx
@@ -4,9 +4,13 @@ import { config } from '@grafana/runtime';
 import { Page } from 'app/core/components/Page/Page';
 import { DataSourceAddButton } from 'app/features/datasources/components/DataSourceAddButton';
 import { DataSourcesList } from 'app/features/datasources/components/DataSourcesList';
+import { getDataSourcesCount } from 'app/features/datasources/state';
+import { StoreState, useSelector } from 'app/types';
 
 export function DataSourcesListPage() {
-  const actions = config.featureToggles.topnav ? <DataSourceAddButton /> : undefined;
+  const dataSourcesCount = useSelector(({ dataSources }: StoreState) => getDataSourcesCount(dataSources));
+
+  const actions = config.featureToggles.topnav && dataSourcesCount > 0 ? <DataSourceAddButton /> : undefined;
   return (
     <Page navId={'connections-your-connections-datasources'} actions={actions}>
       <Page.Contents>

--- a/public/app/features/datasources/pages/DataSourcesListPage.test.tsx
+++ b/public/app/features/datasources/pages/DataSourcesListPage.test.tsx
@@ -49,6 +49,9 @@ describe('Render', () => {
     expect(await screen.findByRole('link', { name: 'Support' })).toBeInTheDocument();
     expect(await screen.findByRole('link', { name: 'Community' })).toBeInTheDocument();
     expect(await screen.findByRole('link', { name: 'Add data source' })).toBeInTheDocument();
+
+    // Should not show button in page header when the list is empty
+    expect(await screen.queryByRole('link', { name: 'Add new data source' })).toBeNull();
   });
 
   describe('when user has no permissions', () => {
@@ -112,6 +115,9 @@ describe('Render', () => {
     expect(await screen.findByRole('heading', { name: 'dataSource-3' })).toBeInTheDocument();
     expect(await screen.findByRole('heading', { name: 'dataSource-4' })).toBeInTheDocument();
     expect(await screen.findAllByRole('img')).toHaveLength(5);
+
+    // Should show button in page header when the list is not empty
+    expect(await screen.findByRole('link', { name: 'Add new data source' })).toBeInTheDocument();
   });
 
   describe('should render elements in sort order', () => {

--- a/public/app/features/datasources/pages/DataSourcesListPage.tsx
+++ b/public/app/features/datasources/pages/DataSourcesListPage.tsx
@@ -6,12 +6,16 @@ import {
   ConnectionsRedirectNotice,
   DestinationPage,
 } from 'app/features/connections/components/ConnectionsRedirectNotice';
+import { StoreState, useSelector } from 'app/types';
 
 import { DataSourceAddButton } from '../components/DataSourceAddButton';
 import { DataSourcesList } from '../components/DataSourcesList';
+import { getDataSourcesCount } from '../state';
 
 export function DataSourcesListPage() {
-  const actions = config.featureToggles.topnav ? <DataSourceAddButton /> : undefined;
+  const dataSourcesCount = useSelector(({ dataSources }: StoreState) => getDataSourcesCount(dataSources));
+
+  const actions = config.featureToggles.topnav && dataSourcesCount > 0 ? <DataSourceAddButton /> : undefined;
   return (
     <Page navId="datasources" actions={actions}>
       <Page.Contents>

--- a/public/app/features/datasources/state/actions.ts
+++ b/public/app/features/datasources/state/actions.ts
@@ -11,6 +11,7 @@ import {
 import { updateNavIndex } from 'app/core/actions';
 import { contextSrv } from 'app/core/core';
 import { getBackendSrv } from 'app/core/services/backend_srv';
+import { ROUTES as CONNECTIONS_ROUTES } from 'app/features/connections/constants';
 import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
 import { getPluginSettings } from 'app/features/plugins/pluginSettings';
 import { importDataSourcePlugin } from 'app/features/plugins/plugin_loader';
@@ -261,6 +262,10 @@ export function deleteLoadedDataSource(): ThunkResult<void> {
     await api.deleteDataSource(uid);
     await getDatasourceSrv().reload();
 
-    locationService.push('/datasources');
+    const datasourcesUrl = config.featureToggles.dataConnectionsConsole
+      ? CONNECTIONS_ROUTES.DataSources
+      : '/datasources';
+
+    locationService.push(datasourcesUrl);
   };
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

The "Your connections" page will now redirect to "Your connections/Data sources" if it has only one child page. Otherwise, we continue to show the `NavLandingPage`. https://github.com/grafana/cloud-onboarding/issues/3298#issuecomment-1446162328

When there were no configured data sources, the `DataSourcesListPage` was actually showing 2 buttons to add a data source. We now removed the one from the page header in this case. 
Fixes: https://github.com/grafana/cloud-onboarding/issues/3297

After deleting a data source, we redirected users to the `DataSourcesListPage` under Administration. After this change, we will redirect them to "Connections/Your connections/Data source", which is functionally the same, but is the preferred location. (Provided that `dataConnectionsConsole` is turned on.)


Before:
![Image](https://user-images.githubusercontent.com/30813233/218165873-af1e4ba7-446f-4b11-826e-87b884ceaf61.png)
After:
![image](https://user-images.githubusercontent.com/13637610/221582484-97918f01-0807-4e1e-8dd2-1ac3b5846956.png)

