### PR TITLE
Explore: Avoid changing queries twice when importing a query in mixed mode

### DIFF
--- a/public/app/features/explore/QueryRows.tsx
+++ b/public/app/features/explore/QueryRows.tsx
@@ -51,16 +51,22 @@ export const QueryRows = ({ exploreId }: Props) => {
 
   const onChange = useCallback(
     async (newQueries: DataQuery[]) => {
-      dispatch(changeQueriesAction({ queries: newQueries, exploreId }));
+      let queriesImported = false;
 
       for (const newQuery of newQueries) {
         for (const oldQuery of queries) {
           if (newQuery.refId === oldQuery.refId && newQuery.datasource?.type !== oldQuery.datasource?.type) {
-            const queryDatasource = await getDataSourceSrv().get(newQuery.datasource);
+            const queryDatasource = await getDataSourceSrv().get(oldQuery.datasource);
             const targetDS = await getDataSourceSrv().get({ uid: newQuery.datasource?.uid });
             dispatch(importQueries(exploreId, queries, queryDatasource, targetDS, newQuery.refId));
+            queriesImported = true;
           }
         }
+      }
+
+      // Importing queries changes the same state, therefore if we are importing queries we don't want to change the state again
+      if (!queriesImported) {
+        dispatch(changeQueriesAction({ queries: newQueries, exploreId }));
       }
 
       // if we are removing a query we want to run the remaining ones

--- a/public/app/features/explore/QueryRows.tsx
+++ b/public/app/features/explore/QueryRows.tsx
@@ -2,7 +2,7 @@ import { createSelector } from '@reduxjs/toolkit';
 import React, { useCallback, useMemo } from 'react';
 
 import { CoreApp } from '@grafana/data';
-import { getDataSourceSrv, reportInteraction } from '@grafana/runtime';
+import { reportInteraction } from '@grafana/runtime';
 import { DataQuery } from '@grafana/schema';
 import { getNextRefIdChar } from 'app/core/utils/query';
 import { useDispatch, useSelector } from 'app/types';
@@ -11,7 +11,7 @@ import { ExploreId } from 'app/types/explore';
 import { getDatasourceSrv } from '../plugins/datasource_srv';
 import { QueryEditorRows } from '../query/components/QueryEditorRows';
 
-import { runQueries, changeQueriesAction, importQueries } from './state/query';
+import { runQueries, changeQueries } from './state/query';
 import { getExploreItemSelector } from './state/selectors';
 
 interface Props {
@@ -50,31 +50,10 @@ export const QueryRows = ({ exploreId }: Props) => {
   }, [dispatch, exploreId]);
 
   const onChange = useCallback(
-    async (newQueries: DataQuery[]) => {
-      let queriesImported = false;
-
-      for (const newQuery of newQueries) {
-        for (const oldQuery of queries) {
-          if (newQuery.refId === oldQuery.refId && newQuery.datasource?.type !== oldQuery.datasource?.type) {
-            const queryDatasource = await getDataSourceSrv().get(oldQuery.datasource);
-            const targetDS = await getDataSourceSrv().get({ uid: newQuery.datasource?.uid });
-            dispatch(importQueries(exploreId, queries, queryDatasource, targetDS, newQuery.refId));
-            queriesImported = true;
-          }
-        }
-      }
-
-      // Importing queries changes the same state, therefore if we are importing queries we don't want to change the state again
-      if (!queriesImported) {
-        dispatch(changeQueriesAction({ queries: newQueries, exploreId }));
-      }
-
-      // if we are removing a query we want to run the remaining ones
-      if (newQueries.length < queries.length) {
-        onRunQueries();
-      }
+    (newQueries: DataQuery[]) => {
+      dispatch(changeQueries({ exploreId, queries: newQueries }));
     },
-    [dispatch, exploreId, onRunQueries, queries]
+    [dispatch, exploreId]
   );
 
   const onAddQuery = useCallback(

--- a/public/app/features/explore/state/query.test.ts
+++ b/public/app/features/explore/state/query.test.ts
@@ -16,7 +16,7 @@ import {
   SupplementaryQueryType,
 } from '@grafana/data';
 import { config } from '@grafana/runtime';
-import { DataQuery } from '@grafana/schema';
+import { DataQuery, DataSourceRef } from '@grafana/schema';
 import { ExploreId, ExploreItemState, StoreState, ThunkDispatch } from 'app/types';
 
 import { reducerTester } from '../../../../test/core/redux/reducerTester';
@@ -41,7 +41,9 @@ import {
   setSupplementaryQueryEnabled,
   addQueryRow,
   cleanSupplementaryQueryDataProviderAction,
+  changeQueries,
 } from './query';
+import * as actions from './query';
 import { makeExplorePaneState } from './utils';
 
 const { testRange, defaultInitialState } = createDefaultInitialState();
@@ -58,10 +60,10 @@ const datasources: DataSourceApi[] = [
   } as DataSourceApi<DataQuery, DataSourceJsonData, {}>,
   {
     name: 'testDs2',
-    type: 'postgres',
+    type: 'mysql',
     uid: 'ds2',
     getRef: () => {
-      return { type: 'postgres', uid: 'ds2' };
+      return { type: 'mysql', uid: 'ds2' };
     },
   } as DataSourceApi<DataQuery, DataSourceJsonData, {}>,
 ];
@@ -81,7 +83,15 @@ jest.mock('@grafana/runtime', () => ({
   }),
   getDataSourceSrv: () => {
     return {
-      get: (uid?: string) => datasources.find((ds) => ds.uid === uid) || datasources[0],
+      get: (ref?: DataSourceRef | string) => {
+        if (!ref) {
+          return datasources[0];
+        }
+
+        return (
+          datasources.find((ds) => (typeof ref === 'string' ? ds.uid === ref : ds.uid === ref.uid)) || datasources[0]
+        );
+      },
     };
   },
   config: {
@@ -225,6 +235,70 @@ describe('running queries', () => {
       cleanSupplementaryQueryDataProviderAction({ exploreId, type: SupplementaryQueryType.LogsSample }),
       cleanSupplementaryQueryAction({ exploreId, type: SupplementaryQueryType.LogsSample }),
     ]);
+  });
+});
+
+describe('changeQueries', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+  it('should import queries when datasource is changed', async () => {
+    jest.spyOn(actions, 'importQueries');
+    const originalQueries = [{ refId: 'A', datasource: datasources[0].getRef() }];
+
+    const { dispatch, getState } = configureStore({
+      ...defaultInitialState,
+      explore: {
+        [ExploreId.left]: {
+          ...defaultInitialState.explore[ExploreId.left],
+          datasourceInstance: datasources[0],
+          queries: originalQueries,
+        },
+      },
+    } as unknown as Partial<StoreState>);
+
+    await dispatch(
+      changeQueries({
+        queries: [{ refId: 'A', datasource: datasources[1].getRef() }],
+        exploreId: ExploreId.left,
+      })
+    );
+
+    expect(actions.importQueries).toHaveBeenCalledWith(
+      ExploreId.left,
+      originalQueries,
+      datasources[0],
+      datasources[1],
+      originalQueries[0].refId
+    );
+    expect(getState().explore[ExploreId.left].queries[0]).toHaveProperty('refId', 'A');
+    expect(getState().explore[ExploreId.left].queries[0]).toHaveProperty('datasource', datasources[1].getRef());
+  });
+
+  it('should not import queries when datasource is not changed', async () => {
+    jest.spyOn(actions, 'importQueries');
+
+    const { dispatch, getState } = configureStore({
+      ...defaultInitialState,
+      explore: {
+        [ExploreId.left]: {
+          ...defaultInitialState.explore[ExploreId.left],
+          datasourceInstance: datasources[0],
+          queries: [{ refId: 'A', datasource: datasources[0].getRef() }],
+        },
+      },
+    } as unknown as Partial<StoreState>);
+
+    await dispatch(
+      changeQueries({
+        queries: [{ refId: 'A', datasource: datasources[0].getRef(), queryType: 'someValue' }],
+        exploreId: ExploreId.left,
+      })
+    );
+
+    expect(actions.importQueries).not.toHaveBeenCalled();
+    expect(getState().explore[ExploreId.left].queries[0]).toHaveProperty('refId', 'A');
+    expect(getState().explore[ExploreId.left].queries[0]).toHaveProperty('datasource', datasources[0].getRef());
   });
 });
 

--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -69,11 +69,11 @@ export const addQueryRowAction = createAction<AddQueryRowPayload>('explore/addQu
  * Query change handler for the query row with the given index.
  * If `override` is reset the query modifications and run the queries. Use this to set queries via a link.
  */
-interface ChangeQueriesPayload {
+export interface ChangeQueriesPayload {
   exploreId: ExploreId;
   queries: DataQuery[];
 }
-const changeQueriesAction = createAction<ChangeQueriesPayload>('explore/changeQueries');
+export const changeQueriesAction = createAction<ChangeQueriesPayload>('explore/changeQueries');
 
 /**
  * Cancel running queries.

--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -36,7 +36,7 @@ import { CorrelationData } from 'app/features/correlations/useCorrelations';
 import { getTimeZone } from 'app/features/profile/state/selectors';
 import { MIXED_DATASOURCE_NAME } from 'app/plugins/datasource/mixed/MixedDataSource';
 import { store } from 'app/store/store';
-import { ExploreItemState, ExplorePanelData, ThunkDispatch, ThunkResult } from 'app/types';
+import { createAsyncThunk, ExploreItemState, ExplorePanelData, ThunkDispatch, ThunkResult } from 'app/types';
 import { ExploreId, ExploreState, QueryOptions, SupplementaryQueries } from 'app/types/explore';
 
 import { notifyApp } from '../../../core/actions';
@@ -69,11 +69,11 @@ export const addQueryRowAction = createAction<AddQueryRowPayload>('explore/addQu
  * Query change handler for the query row with the given index.
  * If `override` is reset the query modifications and run the queries. Use this to set queries via a link.
  */
-export interface ChangeQueriesPayload {
+interface ChangeQueriesPayload {
   exploreId: ExploreId;
   queries: DataQuery[];
 }
-export const changeQueriesAction = createAction<ChangeQueriesPayload>('explore/changeQueries');
+const changeQueriesAction = createAction<ChangeQueriesPayload>('explore/changeQueries');
 
 /**
  * Cancel running queries.
@@ -290,6 +290,35 @@ const getImportableQueries = async (
   // add new datasource to queries before returning
   return addDatasourceToQueries(targetDataSource, queriesOut);
 };
+
+export const changeQueries = createAsyncThunk<void, ChangeQueriesPayload>(
+  'explore/changeQueries',
+  async ({ queries, exploreId }, { getState, dispatch }) => {
+    let queriesImported = false;
+    const oldQueries = getState().explore[exploreId]!.queries;
+
+    for (const newQuery of queries) {
+      for (const oldQuery of oldQueries) {
+        if (newQuery.refId === oldQuery.refId && newQuery.datasource?.type !== oldQuery.datasource?.type) {
+          const queryDatasource = await getDataSourceSrv().get(oldQuery.datasource);
+          const targetDS = await getDataSourceSrv().get({ uid: newQuery.datasource?.uid });
+          await dispatch(importQueries(exploreId, oldQueries, queryDatasource, targetDS, newQuery.refId));
+          queriesImported = true;
+        }
+      }
+    }
+
+    // Importing queries changes the same state, therefore if we are importing queries we don't want to change the state again
+    if (!queriesImported) {
+      dispatch(changeQueriesAction({ queries, exploreId }));
+    }
+
+    // if we are removing a query we want to run the remaining ones
+    if (queries.length < queries.length) {
+      dispatch(runQueries(exploreId));
+    }
+  }
+);
 
 /**
  * Import queries from previous datasource if possible eg Loki and Prometheus have similar query language so the


### PR DESCRIPTION

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

When using mixed mode in Explore, changing datasource for a query that can be imported into the selected datasource cause the query to change twice - once as a regular change and once as a result of the import process. This resulted in the result of the import being overridden by the "normal" change. in the mentioned issue, the query row is not collpased, but subsequent query changes form the DS were discarded, and given the import produced an empty query, ES query editor rendered an empty UI.

Additionally the wrong DS was used as the import source, which resulted i queries not being imported at all in mixed mode.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #63780

