### PR TITLE
Alerting: Log warning message when screenshot fails

### DIFF
--- a/pkg/services/ngalert/image/service.go
+++ b/pkg/services/ngalert/image/service.go
@@ -165,6 +165,7 @@ func (s *ScreenshotImageService) NewImage(ctx context.Context, r *models.AlertRu
 		// Once deduplicated concurrent screenshots are then rate-limited
 		screenshot, err := s.limiter.Do(screenshotCtx, opts, s.screenshots.Take)
 		if err != nil {
+			logger.Warn("Failed to take screenshot", "error", err)
 			if errors.Is(err, dashboards.ErrDashboardNotFound) {
 				return nil, models.ErrNoDashboard
 			}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Log a warning message when the ScreenshotService fails to create a screenshot.

**Why do we need this feature?**

In case the ScreenshotService cannot return a screenshot (e.g. for a wrong renderer configuration), the log just says "Requesting screenshot" and it does not report errors. Since there are timeouts involved, it get difficult to guess what is happening with the request to the ScreenshotService.

**Who is this feature for?**

Users that are trying to debug issues in image generation in alerts.

**Which issue(s) does this PR fix?**:

Fixes #63791

**Special notes for your reviewer**:

None.