### PR TITLE
Plugins: Cloudwatch, adding support for account fields in template variables

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/components/VariableQueryEditor/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/VariableQueryEditor/VariableQueryEditor.tsx
@@ -137,6 +137,15 @@ export const VariableQueryEditor = ({ query, datasource, onChange }: Props) => {
       )}
       {parsedQuery.queryType === VariableQueryType.DimensionValues && (
         <>
+          {accountState.value?.length && config.featureToggles.cloudWatchCrossAccountQuerying && (
+            <VariableQueryField
+              label="Account"
+              value={query.accountId ?? null}
+              onChange={(accountId?: string) => onQueryChange({ ...parsedQuery, accountId })}
+              options={accountState?.value.length ? [ALL_ACCOUNTS_OPTION, ...accountState?.value] : []}
+              allowCustomValue={false}
+            />
+          )}
           <VariableQueryField
             value={metricName || null}
             options={metrics}

--- a/public/app/plugins/datasource/cloudwatch/variables.ts
+++ b/public/app/plugins/datasource/cloudwatch/variables.ts
@@ -96,7 +96,14 @@ export class CloudWatchVariableSupport extends CustomVariableSupport<CloudWatchD
     return this.api.getDimensionKeys({ namespace, region }).then((keys) => keys.map(selectableValueToMetricFindOption));
   }
 
-  async handleDimensionValuesQuery({ namespace, region, dimensionKey, metricName, dimensionFilters }: VariableQuery) {
+  async handleDimensionValuesQuery({
+    namespace,
+    region,
+    dimensionKey,
+    metricName,
+    dimensionFilters,
+    accountId,
+  }: VariableQuery) {
     if (!dimensionKey || !metricName) {
       return [];
     }
@@ -107,6 +114,7 @@ export class CloudWatchVariableSupport extends CustomVariableSupport<CloudWatchD
         metricName,
         dimensionKey,
         dimensionFilters,
+        accountId,
       })
       .then((values) => values.map(selectableValueToMetricFindOption));
   }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Adding support for cloudwatch template variables to provide account ids as selectable fields when the variable type is Query and Query Type is Dimension Values. This will allow getting dimension values from all the accounts when the multi-account feature is enabled via the feature flag cloudWatchCrossAccountQuerying

**Why do we need this feature?**

This makes the cloudwatch dashboard more flexible when using multi-account/monitoring accounts with Cloudwatch

**Who is this feature for?**

Users using cloudwatch data source

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #61450

**Special notes for your reviewer**:

