### PR TITLE
[DOC] Change APM dashboard to Service Graph view

### DIFF
--- a/docs/sources/datasources/tempo/_index.md
+++ b/docs/sources/datasources/tempo/_index.md
@@ -23,7 +23,7 @@ Administrators can also [configure the data source via YAML]({{< relref "#provis
 
 Once you've added the data source, you can [configure it]({{< relref "#configure-the-data-source" >}}) so that your Grafana instance's users can create queries in its [query editor]({{< relref "./query-editor/" >}}) when they [build dashboards]({{< relref "../../dashboards/build-dashboards/" >}}) and use [Explore]({{< relref "../../explore/" >}}).
 
-You can also [use the service graph]({{< relref "#use-the-service-graph" >}}) to view service relationships, [track Application Performance Management metrics]({{< relref "#view-the-apm-table" >}}), [upload a JSON trace file]({{< relref "#upload-a-json-trace-file" >}}), and [link a trace ID from logs]({{< relref "#link-a-trace-id-from-logs" >}}) in Loki or Elasticsearch.
+You can also [use the service graph]({{< relref "#use-the-service-graph" >}}) to view service relationships, [track RED metrics]({{< relref "#open-the-service-graph-view" >}}), [upload a JSON trace file]({{< relref "#upload-a-json-trace-file" >}}), and [link a trace ID from logs]({{< relref "#link-a-trace-id-from-logs" >}}) in Loki or Elasticsearch.
 
 ## Configure the data source
 
@@ -303,16 +303,15 @@ Each circle's color represents the percentage of requests in each state:
 | **Yellow** | Errors              |
 | **Purple** | Throttled responses |
 
-## View the APM table
+## Open the Service Graph view
 
-The Application Performance Management (APM) table lets you view several APM metrics out of the box.
-The APM table is part of the APM dashboard.
+Service graph view displays a table of request rate, error rate, and duration metrics (RED) calculated from your incoming spans. It also includes a node graph view built from your spans.
 
-{{< figure src="/static/img/docs/tempo/apm-table.png" class="docs-image--no-shadow" max-width="500px" caption="Screenshot of the Tempo APM table" >}}
+{{< figure src="/static/img/docs/tempo/apm-table.png" class="docs-image--no-shadow" max-width="500px" caption="Screenshot of the Service Graph view table" >}}
 
-For details, refer to the [APM dashboard documentation](/docs/tempo/latest/metrics-generator/app-performance-mgmt/).
+For details, refer to the [Service Graph view documentation](/docs/tempo/latest/metrics-generator/service-graph-view/).
 
-**To display the APM table:**
+To open the Service Graph view:
 
 1. Link a Prometheus data source in the Tempo data source settings.
 1. Navigate to [Explore]({{< relref "../../explore/" >}}).

--- a/docs/sources/explore/trace-integration.md
+++ b/docs/sources/explore/trace-integration.md
@@ -79,16 +79,14 @@ You can navigate from a span in a trace view directly to logs relevant for that 
 
 Click the document icon to open a split view in Explore with the configured data source and query relevant logs for the span.
 
-## APM dashboard
+## Service graph view
 
-Application performance management (APM) uses data gathered from services, agents, systems, and microservices to visualize and identify areas of concern.
+The Grafana service graph view visualizes the span metrics (traces data for rates, error rates, and durations (RED)) and service graphs.
+Once the requirements are set up, this pre-configured view is immediately available.
 
-The Grafana APM dashboard visualizes the span metrics (traces data for rates, error rates, and durations (RED)) and service graphs.
-Once the requirements are set up, this pre-configured dashboard is immediately available.
+For more information, refer to the [service graph view table section](https://grafana.com/docs/grafana/latest/datasources/tempo/#service-graph-view-table) of the Tempo data source page and the [service graph view page](https://grafana.com/docs/tempo/latest/metrics-generator/service-graph-view/) in the Tempo documentation.
 
-For more information, refer to the [APM table section](https://grafana.com/docs/grafana/latest/datasources/tempo/#apm-table) of the Tempo data source page and the [APM dashboard page](https://grafana.com/docs/tempo/latest/metrics-generator/app-performance-mgmt/) in the Tempo documentation.
-
-{{< figure src="/static/img/docs/grafana-cloud/apm-overview.png" class="docs-image--no-shadow" max-width= "900px" caption="Screenshot of the APM dashboard" >}}
+{{< figure src="/static/img/docs/grafana-cloud/apm-overview.png" class="docs-image--no-shadow" max-width= "900px" caption="Screenshot of the Service Graph view" >}}
 
 ## Data API
 

--- a/docs/sources/explore/trace-integration.md
+++ b/docs/sources/explore/trace-integration.md
@@ -79,7 +79,7 @@ You can navigate from a span in a trace view directly to logs relevant for that 
 
 Click the document icon to open a split view in Explore with the configured data source and query relevant logs for the span.
 
-## Service graph view
+## Service Graph view
 
 The Grafana service graph view visualizes the span metrics (traces data for rates, error rates, and durations (RED)) and service graphs.
 Once the requirements are set up, this pre-configured view is immediately available.

--- a/docs/sources/explore/trace-integration.md
+++ b/docs/sources/explore/trace-integration.md
@@ -81,7 +81,7 @@ Click the document icon to open a split view in Explore with the configured data
 
 ## Service Graph view
 
-The Grafana service graph view visualizes the span metrics (traces data for rates, error rates, and durations (RED)) and service graphs.
+The Service Graph view visualizes the span metrics (traces data for rates, error rates, and durations (RED)) and service graphs.
 Once the requirements are set up, this pre-configured view is immediately available.
 
 For more information, refer to the [service graph view table section](https://grafana.com/docs/grafana/latest/datasources/tempo/#service-graph-view-table) of the Tempo data source page and the [service graph view page](https://grafana.com/docs/tempo/latest/metrics-generator/service-graph-view/) in the Tempo documentation.

--- a/docs/sources/explore/trace-integration.md
+++ b/docs/sources/explore/trace-integration.md
@@ -84,7 +84,7 @@ Click the document icon to open a split view in Explore with the configured data
 The Service Graph view visualizes the span metrics (traces data for rates, error rates, and durations (RED)) and service graphs.
 Once the requirements are set up, this pre-configured view is immediately available.
 
-For more information, refer to the [service graph view table section](https://grafana.com/docs/grafana/latest/datasources/tempo/#service-graph-view-table) of the Tempo data source page and the [service graph view page](https://grafana.com/docs/tempo/latest/metrics-generator/service-graph-view/) in the Tempo documentation.
+For more information, refer to the [Service Graph view table section](https://grafana.com/docs/grafana/latest/datasources/tempo/#service-graph-view-table) of the Tempo data source page and the [service graph view page](https://grafana.com/docs/tempo/latest/metrics-generator/service-graph-view/) in the Tempo documentation.
 
 {{< figure src="/static/img/docs/grafana-cloud/apm-overview.png" class="docs-image--no-shadow" max-width= "900px" caption="Screenshot of the Service Graph view" >}}
 


### PR DESCRIPTION
**What is this feature?**

Changes the name of the APM dashboard to Service Graph view, to align the UI and documentation. Using APM dashboard as the feature name was misleading since it's not a dashboard Grafana sense of the word. The APM table appears on the Service Graph tab in Explore, so doc has been updated to match Service Graph view. 
