### PR TITLE
Alerting: update API models to user NoDataState and ExecutionErrorState from definitions instead of models

### DIFF
--- a/pkg/services/ngalert/api/api_provisioning_test.go
+++ b/pkg/services/ngalert/api/api_provisioning_test.go
@@ -1034,8 +1034,8 @@ func createTestAlertRule(title string, orgID int64) definitions.ProvisionedAlert
 		RuleGroup:    "my-cool-group",
 		FolderUID:    "folder-uid",
 		For:          model.Duration(60),
-		NoDataState:  models.OK,
-		ExecErrState: models.OkErrState,
+		NoDataState:  definitions.OK,
+		ExecErrState: definitions.OkErrState,
 	}
 }
 

--- a/pkg/services/ngalert/api/compat.go
+++ b/pkg/services/ngalert/api/compat.go
@@ -21,8 +21,8 @@ func AlertRuleFromProvisionedAlertRule(a definitions.ProvisionedAlertRule) (mode
 		Condition:    a.Condition,
 		Data:         a.Data,
 		Updated:      a.Updated,
-		NoDataState:  models.NoDataState(a.NoDataState), // TODO there must be a validation
-		ExecErrState: a.ExecErrState,
+		NoDataState:  models.NoDataState(a.NoDataState),          // TODO there must be a validation
+		ExecErrState: models.ExecutionErrorState(a.ExecErrState), // TODO there must be a validation
 		For:          time.Duration(a.For),
 		Annotations:  a.Annotations,
 		Labels:       a.Labels,
@@ -43,8 +43,8 @@ func ProvisionedAlertRuleFromAlertRule(rule models.AlertRule, provenance models.
 		Condition:    rule.Condition,
 		Data:         rule.Data,
 		Updated:      rule.Updated,
-		NoDataState:  definitions.NoDataState(rule.NoDataState), // TODO there may be a validation
-		ExecErrState: rule.ExecErrState,
+		NoDataState:  definitions.NoDataState(rule.NoDataState),          // TODO there may be a validation
+		ExecErrState: definitions.ExecutionErrorState(rule.ExecErrState), // TODO there may be a validation
 		Annotations:  rule.Annotations,
 		Labels:       rule.Labels,
 		Provenance:   definitions.Provenance(provenance), // TODO validate enum conversion?

--- a/pkg/services/ngalert/api/compat.go
+++ b/pkg/services/ngalert/api/compat.go
@@ -21,7 +21,7 @@ func AlertRuleFromProvisionedAlertRule(a definitions.ProvisionedAlertRule) (mode
 		Condition:    a.Condition,
 		Data:         a.Data,
 		Updated:      a.Updated,
-		NoDataState:  a.NoDataState,
+		NoDataState:  models.NoDataState(a.NoDataState), // TODO there must be a validation
 		ExecErrState: a.ExecErrState,
 		For:          time.Duration(a.For),
 		Annotations:  a.Annotations,
@@ -43,7 +43,7 @@ func ProvisionedAlertRuleFromAlertRule(rule models.AlertRule, provenance models.
 		Condition:    rule.Condition,
 		Data:         rule.Data,
 		Updated:      rule.Updated,
-		NoDataState:  rule.NoDataState,
+		NoDataState:  definitions.NoDataState(rule.NoDataState), // TODO there may be a validation
 		ExecErrState: rule.ExecErrState,
 		Annotations:  rule.Annotations,
 		Labels:       rule.Labels,

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_alert_rules.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_alert_rules.go
@@ -125,7 +125,7 @@ type ProvisionedAlertRule struct {
 	// required: true
 	NoDataState NoDataState `json:"noDataState"`
 	// required: true
-	ExecErrState models.ExecutionErrorState `json:"execErrState"`
+	ExecErrState ExecutionErrorState `json:"execErrState"`
 	// required: true
 	For model.Duration `json:"for"`
 	// example: {"runbook_url": "https://supercoolrunbook.com/page/13"}

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_alert_rules.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_alert_rules.go
@@ -123,7 +123,7 @@ type ProvisionedAlertRule struct {
 	// readonly: true
 	Updated time.Time `json:"updated,omitempty"`
 	// required: true
-	NoDataState models.NoDataState `json:"noDataState"`
+	NoDataState NoDataState `json:"noDataState"`
 	// required: true
 	ExecErrState models.ExecutionErrorState `json:"execErrState"`
 	// required: true


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
This is a continuation of efforts to isolate `definition` package from internal dependencies.
This PR updated models in the `definitions` package to use enums NoDataState and ExecutionErrorState that already exist in definitions package instead of ones from `models` package.


Related to: https://github.com/grafana/grafana/pull/63594
Contributes to:  https://github.com/grafana/grafana/issues/63582
