### PR TITLE
FieldNamePicker: support the isClearable option

### DIFF
--- a/packages/grafana-data/src/field/overrides/processors.ts
+++ b/packages/grafana-data/src/field/overrides/processors.ts
@@ -195,4 +195,7 @@ export interface FieldNamePickerConfigSettings {
    * Placeholder text to display when nothing is selected.
    */
   placeholderText?: string;
+
+  /** When set to false, the value can not be removed */
+  isClearable?: boolean;
 }

--- a/packages/grafana-ui/src/components/MatchersUI/FieldNamePicker.tsx
+++ b/packages/grafana-ui/src/components/MatchersUI/FieldNamePicker.tsx
@@ -6,13 +6,10 @@ import { Select } from '../Select/Select';
 
 import { useFieldDisplayNames, useSelectOptions, frameHasName } from './utils';
 
+type Props = StandardEditorProps<string, FieldNamePickerConfigSettings>;
+
 // Pick a field name out of the fields
-export const FieldNamePicker: React.FC<StandardEditorProps<string, FieldNamePickerConfigSettings>> = ({
-  value,
-  onChange,
-  context,
-  item,
-}) => {
+export const FieldNamePicker = ({ value, onChange, context, item }: Props) => {
   const settings: FieldNamePickerConfigSettings = item.settings ?? {};
   const names = useFieldDisplayNames(context.data, settings?.filter);
   const selectOptions = useSelectOptions(names, value);
@@ -37,7 +34,7 @@ export const FieldNamePicker: React.FC<StandardEditorProps<string, FieldNamePick
         onChange={onSelectChange}
         noOptionsMessage={settings.noFieldsMessage}
         width={settings.width}
-        isClearable={true}
+        isClearable={settings.isClearable !== false}
       />
     </>
   );

--- a/public/app/features/transformers/editors/ConvertFieldTypeTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/ConvertFieldTypeTransformerEditor.tsx
@@ -18,7 +18,7 @@ import { Button, InlineField, InlineFieldRow, Input, Select } from '@grafana/ui'
 import { FieldNamePicker } from '@grafana/ui/src/components/MatchersUI/FieldNamePicker';
 
 const fieldNamePickerSettings: StandardEditorsRegistryItem<string, FieldNamePickerConfigSettings> = {
-  settings: { width: 24 },
+  settings: { width: 24, isClearable: false },
 } as any;
 
 export const ConvertFieldTypeTransformerEditor = ({


### PR DESCRIPTION
**What is this feature?**

This adds `isClearable` to FieldNamePicker and sets it to false for the field type conversion transformer. 

**Why do we need this feature?**

Some components should not encourage clearing a required field.