### PR TITLE
AuthN: Only mark IsSignedIn if user is not anonymous

### DIFF
--- a/pkg/services/contexthandler/contexthandler.go
+++ b/pkg/services/contexthandler/contexthandler.go
@@ -150,9 +150,9 @@ func (h *ContextHandler) Middleware(next http.Handler) http.Handler {
 				// Hack: set all errors on LookupTokenErr, so we can check it in auth middlewares
 				reqContext.LookupTokenErr = err
 			} else {
-				reqContext.IsSignedIn = true
 				reqContext.UserToken = identity.SessionToken
 				reqContext.SignedInUser = identity.SignedInUser()
+				reqContext.IsSignedIn = !identity.IsAnonymous
 				reqContext.AllowAnonymous = identity.IsAnonymous
 				reqContext.IsRenderCall = identity.AuthModule == login.RenderModule
 			}


### PR DESCRIPTION
**What is this feature?**
I noticed that anonymous users was marked as signed in when using authnService feature toggle.

To keep behaviour IsSignedIn should be false when a user is anonymous https://github.com/grafana/grafana/blob/main/pkg/services/contexthandler/contexthandler.go#L251


Fixes #

**Special notes for your reviewer**:

