### PR TITLE
Alerting: Fix width in alerts table columns on EditGroupModal

### DIFF
--- a/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
+++ b/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
@@ -146,11 +146,11 @@ export const RulesForGroupTable = ({ rulesWithoutRecordingRules }: { rulesWithou
         renderCell: ({ data: { forDuration } }) => {
           return <>{forDuration}</>;
         },
-        size: 0.2,
+        size: 0.5,
       },
       {
         id: 'numberEvaluations',
-        label: '#Evaluations',
+        label: '#Eval',
         renderCell: ({ data: { evaluationsToFire: numberEvaluations } }) => {
           if (unknownCurrentInterval) {
             return <ForBadge message="#Evaluations not available." />;
@@ -167,7 +167,7 @@ export const RulesForGroupTable = ({ rulesWithoutRecordingRules }: { rulesWithou
             }
           }
         },
-        size: 0.6,
+        size: 0.4,
       },
     ];
   }, [currentInterval, unknownCurrentInterval]);
@@ -397,7 +397,7 @@ export function EditCloudGroupModal(props: ModalProps): React.ReactElement {
               <>
                 <div>List of rules that belong to this group</div>
                 <div className={styles.evalRequiredLabel}>
-                  #Evaluations column represents the number of evaluations needed before alert starts firing.
+                  #Eval column represents the number of evaluations needed before alert starts firing.
                 </div>
                 <RulesForGroupTable rulesWithoutRecordingRules={rulesWithoutRecordingRules} />
               </>


### PR DESCRIPTION
**What is this feature?**

This PR fixes the width for columns in alerts table on EditGroupModal.

**Why do we need this feature?**

All columns content in the alerts table on EditGroupModal should fit in the column.

**Who is this feature for?**

All users.

**Special notes for your reviewer**:

Before:

<img width="706" alt="Screenshot 2023-02-28 at 11 31 12" src="https://user-images.githubusercontent.com/33540275/221830514-a61d70ac-136e-4538-884f-07c7a47a808f.png">

After:

<img width="716" alt="Screenshot 2023-02-28 at 11 30 43" src="https://user-images.githubusercontent.com/33540275/221830627-a7a4230e-1ef8-4c1a-bc85-ebc64d8733a6.png">
