### PR TITLE
NPM: Stop using the folder path before the name path

### DIFF
--- a/pkg/build/gcloud/storage/gsutil.go
+++ b/pkg/build/gcloud/storage/gsutil.go
@@ -353,7 +353,7 @@ func (client *Client) DownloadDirectory(ctx context.Context, bucket *storage.Buc
 	}
 
 	for _, file := range files {
-		err = client.downloadFile(ctx, bucket, file.FullPath, filepath.Join(destPath, file.PathTrimmed))
+		err = client.downloadFile(ctx, bucket, file.FullPath, file.PathTrimmed)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
**What is this feature?**

During our latest releases, we saw this failure:

```
os.Create: open npm-artifacts/npm-artifacts/@grafana-data-v9.4.1.tgz: no such file or directory
```

`npm-artifacts` is in the path twice which is a bug. This PR fixes the bug by only using the trimmed local path of the file.

**Why do we need this feature?**

Unblocks the releases.

