### PR TITLE
Add documentation for private data source connect using kubernetes

### DIFF
--- a/docs/sources/setup-grafana/configure-security/configure-private-datasource-connect/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-private-datasource-connect/index.md
@@ -93,7 +93,7 @@ To set up a private data source connection, follow these steps:
 
 1. Connect to Grafana Cloud using the ssh or the pdc agent in the same directory as your private key, and the certificate and known_hosts file Grafana Labs provided to you.
 
-   There are three options for connecting: using Kubernetes, SSH, or the PDC Agent Docker image.
+   There are three connecting options: Kubernetes, SSH, or the PDC Agent Docker image.
    
    - **Option 1:** Using Kubernetes
 

--- a/docs/sources/setup-grafana/configure-security/configure-private-datasource-connect/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-private-datasource-connect/index.md
@@ -106,7 +106,7 @@ To set up a private data source connection, follow these steps:
      --from-file=cert.pub=./${SLUG}-cert.pub
      ```
 
-     Generate a kubernetes deployment to deploy the agent.
+     Generate a Kubernetes deployment to deploy the agent.
 
      ```
      SLUG=${SLUG} PDC_GATEWAY=${PDC_GATEWAY}  NAMESPACE=${NAMESPACE} /bin/sh -c "$(curl -fsSL https://raw.githubusercontent.com/grafana/pdc-agent/main/production/kubernetes/install-agent.sh)"

--- a/docs/sources/setup-grafana/configure-security/configure-private-datasource-connect/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-private-datasource-connect/index.md
@@ -113,7 +113,7 @@ To set up a private data source connection, follow these steps:
      kubectl apply -f deployment.yaml
      ```
 
-     The environment variables used in the previous commands are as follows:
+     The following list contains the environment variables used in the previous commands:
 
      - ${PDC_GATEWAY}: The URL of the private data source connect in Grafana Cloud. The Grafana team will give you this URL. The URL follows the format `grafana-private-datasource-connect-<cluster>.grafana.net`
      - ${SLUG}: The name of the stack you want to connect to your data source. For example, the stack `test.grafana.net` has the slug `test.`

--- a/docs/sources/setup-grafana/configure-security/configure-private-datasource-connect/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-private-datasource-connect/index.md
@@ -138,6 +138,30 @@ To set up a private data source connection, follow these steps:
      - -v (optional): Sets the verbosity to debug.
      - -o [PermitRemoteOpen](https://man.openbsd.org/ssh_config.5#PermitRemoteOpen) (optional): This can be specified to restrict the destinations reachable by Grafana Cloud over this connection.
 
+   - **Option 3:** Using Kubernetes
+
+     Create a kubernetes secret with the private key, and the certificate and known_hosts file Grafana Labs provided to you.
+
+     ```
+     $ kubectl create secret generic -n ${NAMESPACE} grafana-pdc-agent \
+     --from-file=key=./${SLUG} \
+     --from-file=known_hosts=./known_hosts \
+     --from-file=cert.pub=./${SLUG}-cert.pub
+     ```
+
+     Generate a kubernetes deployment to deploy the agent.
+
+     ```
+     SLUG=${SLUG} PDC_GATEWAY=${PDC_GATEWAY}  NAMESPACE=${NAMESPACE} /bin/sh -c "$(curl -fsSL https://raw.githubusercontent.com/grafana/pdc-agent/main/production/kubernetes/install-agent.sh)"
+     kubectl apply -f deployment.yaml
+     ```
+
+     The environment variables used in the previous commands are as follows:
+
+     - ${PDC_GATEWAY}: The URL of the private data source connect in Grafana Cloud. The Grafana team will give you this URL. The URL follows the format `grafana-private-datasource-connect-<cluster>.grafana.net`
+     - ${SLUG}: The name of the stack you want to connect to your data source. For example, the stack `test.grafana.net` has the slug `test.`
+     - ${NAMESPACE}: The kubernetes namespace for the pdc-agent.
+
 1. (Optional) For high availability, you can install additional instances of the agent on your network with the same configuration.
 
    These can be deployed to different regions, data centers, or providers as long as they are on the same network.

--- a/docs/sources/setup-grafana/configure-security/configure-private-datasource-connect/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-private-datasource-connect/index.md
@@ -97,7 +97,7 @@ To set up a private data source connection, follow these steps:
    
    - **Option 1:** Using Kubernetes
 
-     Create a kubernetes secret with the private key, and the certificate and known_hosts file Grafana Labs provided to you.
+     Create a Kubernetes secret with the private key and the certificate and known_hosts file Grafana Labs provided.
 
      ```
      $ kubectl create secret generic -n ${NAMESPACE} grafana-pdc-agent \

--- a/docs/sources/setup-grafana/configure-security/configure-private-datasource-connect/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-private-datasource-connect/index.md
@@ -94,7 +94,7 @@ To set up a private data source connection, follow these steps:
 1. Connect to Grafana Cloud using the ssh or the pdc agent in the same directory as your private key, and the certificate and known_hosts file Grafana Labs provided to you.
 
    There are three connecting options: Kubernetes, SSH, or the PDC Agent Docker image.
-   
+
    - **Option 1:** Using Kubernetes
 
      Create a Kubernetes secret with the private key and the certificate and known_hosts file Grafana Labs provided.

--- a/docs/sources/setup-grafana/configure-security/configure-private-datasource-connect/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-private-datasource-connect/index.md
@@ -93,52 +93,9 @@ To set up a private data source connection, follow these steps:
 
 1. Connect to Grafana Cloud using the ssh or the pdc agent in the same directory as your private key, and the certificate and known_hosts file Grafana Labs provided to you.
 
-   There are two options for connecting: SSH, or the PDC Agent Docker image.
-
-   - **Option 1:** Using SSH
-
-     ```
-     $ ssh -i ${SLUG} ${SLUG}@${PDC_GATEWAY} -p 22 -o UserKnownHostsFile=./known_hosts -o CertificateFile=${SLUG}-cert.pub -R 0 -vv
-     ```
-
-     The flags used in the ssh command are as follows:
-
-     - -i ${SLUG}: The private key
-     - -p 22: The port to connect to
-     - -o [UserKnownHostsFile](https://man.openbsd.org/ssh_config.5#UserKnownHostsFile): The list of Grafana PDC servers to trust when establishing a connection for the first time
-     - -o [CertificateFile](https://man.openbsd.org/ssh_config.5#CertificateFile): Your public certificate
-     - -R 0: Runs ssh with remote port forwarding, which enables it to act as a socks server
-     - -vv (optional): Sets the verbosity to debug2, so hostnames can be seen. It can be set to -v, if this is not desired.
-     - -o [PermitRemoteOpen](https://man.openbsd.org/ssh_config.5#PermitRemoteOpen) (optional): This can be specified to restrict the destinations reachable by Grafana Cloud over this connection.
-
-     Refer to the [OpenSSH documentation](https://linux.die.net/man/1/ssh) for a complete list of available ssh command flags.
-
-     Additionally:
-
-     - ${PDC_GATEWAY}: The URL of the private data source connect in Grafana Cloud. The Grafana team will give you this URL. The URL follows the format `grafana-private-datasource-connect-&lt;cluster>.grafana.net`
-     - ${SLUG}: The name of the stack you want to connect to your data source. For example, the stack `test.grafana.net` has the slug `test.`
-
-   - **Option 2:** Using the [pdc-agent](https://github.com/grafana/pdc-agent) docker [image](https://hub.docker.com/r/grafana/pdc-agent/tags)
-
-     ```
-     docker run --rm --name pdc-agent -v $(pwd):/etc/keys grafana/pdc-agent:latest -i /etc/keys/${SLUG} ${SLUG}@host.docker.internal -p 2222 -o BatchMode=yes -o UserKnownHostsFile=/etc/keys/known_hosts -o CertificateFile=/etc/keys/${SLUG}-cert.pub -R 0 -v
-     ```
-
-     The flags used on this are a combination of:
-
-     - –-rm: Remove the docker container when it exits
-     - --name pdc-agent: This names the docker process pdc-agent
-     - -v $(pwd):/etc/keys: Copies the working directory into the /etc/keys directory in the Docker container
-     - -i /etc/keys/${SLUG}: The private key
-     - -p 2222: The docker container port
-     - -o [BatchMode](https://man.openbsd.org/ssh_config.5#BatchMode): Skips the passphrase checking
-     - -o [UserKnownHostsFile](https://man.openbsd.org/ssh_config.5#UserKnownHostsFile): The list of Grafana PDC servers to trust when establishing a connection for the first time
-     - -o [CertificateFile](https://man.openbsd.org/ssh_config.5#CertificateFile): Your public certificate
-     - -R 0: Runs ssh with remote port forwarding (which allows it to act as a socks server)
-     - -v (optional): Sets the verbosity to debug.
-     - -o [PermitRemoteOpen](https://man.openbsd.org/ssh_config.5#PermitRemoteOpen) (optional): This can be specified to restrict the destinations reachable by Grafana Cloud over this connection.
-
-   - **Option 3:** Using Kubernetes
+   There are three options for connecting: using Kubernetes, SSH, or the PDC Agent Docker image.
+   
+   - **Option 1:** Using Kubernetes
 
      Create a kubernetes secret with the private key, and the certificate and known_hosts file Grafana Labs provided to you.
 
@@ -161,6 +118,49 @@ To set up a private data source connection, follow these steps:
      - ${PDC_GATEWAY}: The URL of the private data source connect in Grafana Cloud. The Grafana team will give you this URL. The URL follows the format `grafana-private-datasource-connect-<cluster>.grafana.net`
      - ${SLUG}: The name of the stack you want to connect to your data source. For example, the stack `test.grafana.net` has the slug `test.`
      - ${NAMESPACE}: The kubernetes namespace for the pdc-agent.
+
+   - **Option 2:** Using SSH
+
+     ```
+     $ ssh -i ${SLUG} ${SLUG}@${PDC_GATEWAY} -p 22 -o UserKnownHostsFile=./known_hosts -o CertificateFile=${SLUG}-cert.pub -R 0 -vv
+     ```
+
+     The flags used in the ssh command are as follows:
+
+     - -i ${SLUG}: The private key
+     - -p 22: The port to connect to
+     - -o [UserKnownHostsFile](https://man.openbsd.org/ssh_config.5#UserKnownHostsFile): The list of Grafana PDC servers to trust when establishing a connection for the first time
+     - -o [CertificateFile](https://man.openbsd.org/ssh_config.5#CertificateFile): Your public certificate
+     - -R 0: Runs ssh with remote port forwarding, which enables it to act as a socks server
+     - -vv (optional): Sets the verbosity to debug2, so hostnames can be seen. It can be set to -v, if this is not desired.
+     - -o [PermitRemoteOpen](https://man.openbsd.org/ssh_config.5#PermitRemoteOpen) (optional): This can be specified to restrict the destinations reachable by Grafana Cloud over this connection.
+
+     Refer to the [OpenSSH documentation](https://linux.die.net/man/1/ssh) for a complete list of available ssh command flags.
+
+     Additionally:
+
+     - ${PDC_GATEWAY}: The URL of the private data source connect in Grafana Cloud. The Grafana team will give you this URL. The URL follows the format `grafana-private-datasource-connect-&lt;cluster>.grafana.net`
+     - ${SLUG}: The name of the stack you want to connect to your data source. For example, the stack `test.grafana.net` has the slug `test.`
+
+   - **Option 3:** Using the [pdc-agent](https://github.com/grafana/pdc-agent) docker [image](https://hub.docker.com/r/grafana/pdc-agent/tags)
+
+     ```
+     docker run --rm --name pdc-agent -v $(pwd):/etc/keys grafana/pdc-agent:latest -i /etc/keys/${SLUG} ${SLUG}@host.docker.internal -p 2222 -o BatchMode=yes -o UserKnownHostsFile=/etc/keys/known_hosts -o CertificateFile=/etc/keys/${SLUG}-cert.pub -R 0 -v
+     ```
+
+     The flags used on this are a combination of:
+
+     - –-rm: Remove the docker container when it exits
+     - --name pdc-agent: This names the docker process pdc-agent
+     - -v $(pwd):/etc/keys: Copies the working directory into the /etc/keys directory in the Docker container
+     - -i /etc/keys/${SLUG}: The private key
+     - -p 2222: The docker container port
+     - -o [BatchMode](https://man.openbsd.org/ssh_config.5#BatchMode): Skips the passphrase checking
+     - -o [UserKnownHostsFile](https://man.openbsd.org/ssh_config.5#UserKnownHostsFile): The list of Grafana PDC servers to trust when establishing a connection for the first time
+     - -o [CertificateFile](https://man.openbsd.org/ssh_config.5#CertificateFile): Your public certificate
+     - -R 0: Runs ssh with remote port forwarding (which allows it to act as a socks server)
+     - -v (optional): Sets the verbosity to debug.
+     - -o [PermitRemoteOpen](https://man.openbsd.org/ssh_config.5#PermitRemoteOpen) (optional): This can be specified to restrict the destinations reachable by Grafana Cloud over this connection.
 
 1. (Optional) For high availability, you can install additional instances of the agent on your network with the same configuration.
 

--- a/docs/sources/setup-grafana/configure-security/configure-private-datasource-connect/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-private-datasource-connect/index.md
@@ -117,7 +117,7 @@ To set up a private data source connection, follow these steps:
 
      - ${PDC_GATEWAY}: The URL of the private data source connect in Grafana Cloud. The Grafana team will give you this URL. The URL follows the format `grafana-private-datasource-connect-<cluster>.grafana.net`
      - ${SLUG}: The name of the stack you want to connect to your data source. For example, the stack `test.grafana.net` has the slug `test.`
-     - ${NAMESPACE}: The kubernetes namespace for the pdc-agent.
+     - ${NAMESPACE}: The Kubernetes namespace for the pdc-agent.
 
    - **Option 2:** Using SSH
 


### PR DESCRIPTION
Add kubernetes deployment documentation for private data source connect, available in Cloud Pro and Advanced in closed preview. 

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Add kubernetes deployment documentation for private data source connect, available in Cloud Pro and Advanced in closed preview. These docs should be public, but not indexed or searchable. 

**Who is this feature for?**

Closed preview customers, who will all be given a link to the docs.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

I think this is a reasonable place to put these docs, but this feature is only available in Grafana Cloud, so I wonder if this doc should go into Grafana Cloud documentation...