### PR TITLE
Prometheus: Handle jsonnet strings in variables.ts and fix types

### DIFF
--- a/public/app/plugins/datasource/prometheus/types.ts
+++ b/public/app/plugins/datasource/prometheus/types.ts
@@ -22,7 +22,6 @@ export interface PromQuery extends DataQuery {
   showingTable?: boolean;
   /** Code, Builder or Explain */
   editorMode?: QueryEditorMode;
-  query?: string;
 }
 
 export interface PromOptions extends DataSourceJsonData {


### PR DESCRIPTION
Fixes issue where jsonnet kubernetes dashboards refresh were clearing out prom variables on dashboard time refresh

Previously, when using StandardVariableSupport the variable query string was changed to be on the expr attribute. Now, using CustomVariableSupport, the variable query is changed to the query attribute. So, without standard variable support changing the query string to the expr attribute, the variable query string is coming in as it is written in jsonnet, where it is just a string. We are now handling that in variables.ts
