### PR TITLE
Packaging: Make database dependencies optional on systemd

### DIFF
--- a/packaging/deb/systemd/grafana-server.service
+++ b/packaging/deb/systemd/grafana-server.service
@@ -3,6 +3,7 @@ Description=Grafana instance
 Documentation=http://docs.grafana.org
 Wants=network-online.target
 After=network-online.target
+Wants=postgresql.service mariadb.service mysql.service
 After=postgresql.service mariadb.service mysql.service
 
 [Service]

--- a/packaging/rpm/systemd/grafana-server.service
+++ b/packaging/rpm/systemd/grafana-server.service
@@ -3,6 +3,7 @@ Description=Grafana instance
 Documentation=http://docs.grafana.org
 Wants=network-online.target
 After=network-online.target
+Wants=postgresql.service mariadb.service mysqld.service
 After=postgresql.service mariadb.service mysqld.service
 
 [Service]


### PR DESCRIPTION
DB should not be a requirement as it can be externally hosted. Per https://www.freedesktop.org/software/systemd/man/systemd.unit.html making it be an optional dependency.