### PR TITLE
Alerting: Improve performance of cache.getOrCreate

### DIFF
--- a/pkg/services/ngalert/state/cache.go
+++ b/pkg/services/ngalert/state/cache.go
@@ -56,12 +56,12 @@ func (c *cache) getOrCreate(ctx context.Context, log log.Logger, alertRule *ngMo
 	return states.getOrAdd(stateCandidate)
 }
 
-func (rs *ruleStates) getOrAdd(stateCandidate *State) *State {
+func (rs *ruleStates) getOrAdd(stateCandidate State) *State {
 	state, ok := rs.states[stateCandidate.CacheID]
 	// Check if the state with this ID already exists.
 	if !ok {
-		rs.states[stateCandidate.CacheID] = stateCandidate
-		return stateCandidate
+		rs.states[stateCandidate.CacheID] = &stateCandidate
+		return &stateCandidate
 	}
 
 	// Annotations can change over time, however we also want to maintain
@@ -81,7 +81,7 @@ func (rs *ruleStates) getOrAdd(stateCandidate *State) *State {
 	return state
 }
 
-func calculateState(ctx context.Context, log log.Logger, alertRule *ngModels.AlertRule, result eval.Result, extraLabels data.Labels, externalURL *url.URL) *State {
+func calculateState(ctx context.Context, log log.Logger, alertRule *ngModels.AlertRule, result eval.Result, extraLabels data.Labels, externalURL *url.URL) State {
 	// Merge both the extra labels and the labels from the evaluation into a common set
 	// of labels that can be expanded in custom labels and annotations.
 	templateData := template.NewData(mergeLabels(extraLabels, result.Instance), result)
@@ -141,7 +141,7 @@ func calculateState(ctx context.Context, log log.Logger, alertRule *ngModels.Ale
 
 	// For new states, we set StartsAt & EndsAt to EvaluatedAt as this is the
 	// expected value for a Normal state during state transition.
-	newState := &State{
+	newState := State{
 		AlertRuleUID:       alertRule.UID,
 		OrgID:              alertRule.OrgID,
 		CacheID:            id,

--- a/pkg/services/ngalert/state/cache.go
+++ b/pkg/services/ngalert/state/cache.go
@@ -34,23 +34,54 @@ func newCache() *cache {
 }
 
 func (c *cache) getOrCreate(ctx context.Context, log log.Logger, alertRule *ngModels.AlertRule, result eval.Result, extraLabels data.Labels, externalURL *url.URL) *State {
+	// Calculation of state ID involves label and annotation expansion, which may be resource intensive operations, and doing it in the context guarded by mtxStates may create a lot of contention.
+	// Instead of just calculating ID we create an entire state - a candidate. If rule states already hold a state with this ID, this candidate will be discarded and the existing one will be returned.
+	// Otherwise, this candidate will be added to the rule states and returned.
+	stateCandidate := calculateState(ctx, log, alertRule, result, extraLabels, externalURL)
+
 	c.mtxStates.Lock()
 	defer c.mtxStates.Unlock()
+
 	var orgStates map[string]*ruleStates
 	var ok bool
-	if orgStates, ok = c.states[alertRule.OrgID]; !ok {
+	if orgStates, ok = c.states[stateCandidate.OrgID]; !ok {
 		orgStates = make(map[string]*ruleStates)
-		c.states[alertRule.OrgID] = orgStates
+		c.states[stateCandidate.OrgID] = orgStates
 	}
 	var states *ruleStates
-	if states, ok = orgStates[alertRule.UID]; !ok {
+	if states, ok = orgStates[stateCandidate.AlertRuleUID]; !ok {
 		states = &ruleStates{states: make(map[string]*State)}
-		c.states[alertRule.OrgID][alertRule.UID] = states
+		c.states[stateCandidate.OrgID][stateCandidate.AlertRuleUID] = states
 	}
-	return states.getOrCreate(ctx, log, alertRule, result, extraLabels, externalURL)
+	return states.getOrAdd(stateCandidate)
 }
 
-func (rs *ruleStates) getOrCreate(ctx context.Context, log log.Logger, alertRule *ngModels.AlertRule, result eval.Result, extraLabels data.Labels, externalURL *url.URL) *State {
+func (rs *ruleStates) getOrAdd(stateCandidate *State) *State {
+	state, ok := rs.states[stateCandidate.CacheID]
+	// Check if the state with this ID already exists.
+	if !ok {
+		rs.states[stateCandidate.CacheID] = stateCandidate
+		return stateCandidate
+	}
+
+	// Annotations can change over time, however we also want to maintain
+	// certain annotations across evaluations
+	for k, v := range state.Annotations {
+		if _, ok := ngModels.InternalAnnotationNameSet[k]; ok {
+			// If the annotation is not present then it should be copied from the
+			// previous state to the next state
+			if _, ok := stateCandidate.Annotations[k]; !ok {
+				stateCandidate.Annotations[k] = v
+			}
+		}
+	}
+	state.Annotations = stateCandidate.Annotations
+	state.Values = stateCandidate.Values
+	rs.states[stateCandidate.CacheID] = state
+	return state
+}
+
+func calculateState(ctx context.Context, log log.Logger, alertRule *ngModels.AlertRule, result eval.Result, extraLabels data.Labels, externalURL *url.URL) *State {
 	// Merge both the extra labels and the labels from the evaluation into a common set
 	// of labels that can be expanded in custom labels and annotations.
 	templateData := template.NewData(mergeLabels(extraLabels, result.Instance), result)
@@ -108,24 +139,6 @@ func (rs *ruleStates) getOrCreate(ctx context.Context, log log.Logger, alertRule
 		log.Error("Error getting cacheId for entry", "error", err)
 	}
 
-	if state, ok := rs.states[id]; ok {
-		// Annotations can change over time, however we also want to maintain
-		// certain annotations across evaluations
-		for k, v := range state.Annotations {
-			if _, ok := ngModels.InternalAnnotationNameSet[k]; ok {
-				// If the annotation is not present then it should be copied from the
-				// previous state to the next state
-				if _, ok := annotations[k]; !ok {
-					annotations[k] = v
-				}
-			}
-		}
-		state.Annotations = annotations
-		state.Values = values
-		rs.states[id] = state
-		return state
-	}
-
 	// For new states, we set StartsAt & EndsAt to EvaluatedAt as this is the
 	// expected value for a Normal state during state transition.
 	newState := &State{
@@ -139,7 +152,6 @@ func (rs *ruleStates) getOrCreate(ctx context.Context, log log.Logger, alertRule
 		StartsAt:           result.EvaluatedAt,
 		EndsAt:             result.EvaluatedAt,
 	}
-	rs.states[id] = newState
 	return newState
 }
 

--- a/pkg/services/ngalert/state/cache_bench_test.go
+++ b/pkg/services/ngalert/state/cache_bench_test.go
@@ -1,0 +1,61 @@
+package state
+
+import (
+	"context"
+	"math/rand"
+	"net/url"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+	ptr "github.com/xorcare/pointer"
+
+	"github.com/grafana/grafana/pkg/infra/log/logtest"
+	"github.com/grafana/grafana/pkg/services/ngalert/eval"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+)
+
+func BenchmarkGetOrCreateTest(b *testing.B) {
+	cache := newCache()
+	rule := models.AlertRuleGen(func(rule *models.AlertRule) {
+		for i := 0; i < 2; i++ {
+			rule.Labels = data.Labels{
+				"label-1": "{{ $value }}",
+				"label-2": "{{ $values.A.Labels.instance }} has value {{ $values.A }}",
+			}
+			rule.Annotations = data.Labels{
+				"anno-1": "{{ $value }}",
+				"anno-2": "{{ $values.A.Labels.instance }} has value {{ $values.A }}",
+			}
+		}
+	})()
+	result := eval.ResultGen(func(r *eval.Result) {
+		r.Values = map[string]eval.NumberValueCapture{
+			"A": {
+				Var:    "A",
+				Labels: data.Labels{"instance": uuid.New().String()},
+				Value:  ptr.Float64(rand.Float64()),
+			},
+		}
+	})()
+
+	ctx := context.Background()
+	log := &logtest.Fake{}
+	u, _ := url.Parse("http://localhost")
+	// values := make([]int64, count)
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_ = cache.getOrCreate(ctx, log, rule, result, nil, u)
+		}
+	})
+}
+
+/* Results
+goos: windows
+goarch: amd64
+pkg: github.com/grafana/grafana/pkg/services/ngalert/state
+cpu: 11th Gen Intel(R) Core(TM) i9-11900H @ 2.50GHz
+BenchmarkGetOrCreateTest
+BenchmarkGetOrCreateTest-16         7894            150920 ns/op
+PASS
+*/

--- a/pkg/services/ngalert/state/cache_bench_test.go
+++ b/pkg/services/ngalert/state/cache_bench_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
-	ptr "github.com/xorcare/pointer"
 
 	"github.com/grafana/grafana/pkg/infra/log/logtest"
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
@@ -34,11 +33,10 @@ func BenchmarkGetOrCreateTest(b *testing.B) {
 			"A": {
 				Var:    "A",
 				Labels: data.Labels{"instance": uuid.New().String()},
-				Value:  ptr.Float64(rand.Float64()),
+				Value:  func(f float64) *float64 { return &f }(rand.Float64()),
 			},
 		}
 	})()
-
 	ctx := context.Background()
 	log := &logtest.Fake{}
 	u, _ := url.Parse("http://localhost")
@@ -56,6 +54,6 @@ goarch: amd64
 pkg: github.com/grafana/grafana/pkg/services/ngalert/state
 cpu: 11th Gen Intel(R) Core(TM) i9-11900H @ 2.50GHz
 BenchmarkGetOrCreateTest
-BenchmarkGetOrCreateTest-16         7894            150920 ns/op
+BenchmarkGetOrCreateTest-16        47805             23895 ns/op
 PASS
 */

--- a/pkg/services/ngalert/state/cache_bench_test.go
+++ b/pkg/services/ngalert/state/cache_bench_test.go
@@ -47,13 +47,3 @@ func BenchmarkGetOrCreateTest(b *testing.B) {
 		}
 	})
 }
-
-/* Results
-goos: windows
-goarch: amd64
-pkg: github.com/grafana/grafana/pkg/services/ngalert/state
-cpu: 11th Gen Intel(R) Core(TM) i9-11900H @ 2.50GHz
-BenchmarkGetOrCreateTest
-BenchmarkGetOrCreateTest-16        47805             23895 ns/op
-PASS
-*/


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Alerting state manager uses a cache to store the current states of all rules. The cache is a trifold map: `orgId -> ruleUID -> stateKey`.  The stateKey is based on a unique set of labels provided by each evaluation result.

Access to that map is guarded by a mutex. When state manager processes results for a rule it calls the cache's method `getOrCreate` that locks mutex and drills down to the rule's states and tries to find an existing state for the result by `stateKey`.

The calculation of the state key is a resource-intensive operation because it requires the rule's labels to be expanded with data from the result and then concatenated with extra labels and the result's labels. 

Currently, that key calculation happens behind the mutex lock, and therefore can affect concurrent access to states of other rules (which are evaluated concurrently).

This PR updates getOrCreate to perform the calculation of the state key before putting the lock on the mutex. The new function creates a state from the rule and result. Then the state is propagated down to `ruleStates.getOrCreate` that checks whether another state with this key exists in the map, and if it does not, adds it to the map. Otherwise, it refreshes the current state's annotations with ones from the new state and discards the candidate.

Note: the logic of creating\updating the current state has not changed. The only changes are: extra struct initialization and calculation of the key outside of the mutex context.

**Why do we need this feature?**
This change improves the performance of method `getOrCreate` at least 5 times. 
I wrote a benchmark before the refactoring and its results were 
```
goos: windows
goarch: amd64
pkg: github.com/grafana/grafana/pkg/services/ngalert/state
cpu: 11th Gen Intel(R) Core(TM) i9-11900H @ 2.50GHz
BenchmarkGetOrCreateTest
BenchmarkGetOrCreateTest-16         7894            150920 ns/op
```
after the refactoring results are 
```
goos: windows
goarch: amd64
pkg: github.com/grafana/grafana/pkg/services/ngalert/state
cpu: 11th Gen Intel(R) Core(TM) i9-11900H @ 2.50GHz
BenchmarkGetOrCreateTest
BenchmarkGetOrCreateTest-16        48218             26160 ns/op
```

I did profiling with using 5000 alert rules that are evaluated every 10 seconds and use test datasource, and compared with the current main. I had to enable mutex profiling in both images (by setting runtime.SetMutexProfileFraction(1) ).

<details><summary>screenshots</summary>

The comparison show clear improvement : 
![image](https://user-images.githubusercontent.com/25988953/234079936-83e9b810-73d8-460a-b091-3835b414f1d0.png)

![image](https://user-images.githubusercontent.com/25988953/234080547-21d4b303-4744-475e-8ee5-eee2df42aa97.png)

</summary>

**Special notes for your reviewer**:
