### PR TITLE
Fix redirect from /setup-grafana/upgrade-grafana/ to /upgrade-guide/

### DIFF
--- a/docs/sources/upgrade-guide/_index.md
+++ b/docs/sources/upgrade-guide/_index.md
@@ -1,7 +1,7 @@
 ---
 aliases:
-  - ../installation/upgrading/
-  - ../setup-grafana/upgrade-grafana
+  - installation/upgrading/
+  - setup-grafana/upgrade-grafana
 description: Guide for upgrading Grafana
 keywords:
   - grafana


### PR DESCRIPTION
Additionally fix redirect from `/installation/upgrading/` to `/setup-grafana/upgrade-grafana/`.

The alias proposed in
https://github.com/grafana/grafana/pull/62402#discussion_r1090526464 was incorrect. It used the `../installation/upgrading/` alias as reference but I did not check the redirect. As this page itself has moved from `/setup-grafana/upgrade-grafana/` to `/upgrade-guide/` the relative alias needed updating also.

To verify that this alias is working as expected:

1. Checkout this branch.
2. Run `make docs`
3. Browse to http://localhost:3002/docs/grafana/latest/setup-grafana/upgrade-grafana/
4. Verify that you have been redirected to http://localhost:3002/docs/grafana/latest/upgrade-guide/
5. Browse to http://localhost:3002/docs/grafana/latest/installation/upgrading/
6. Verify that you have been redirected to http://localhost:3002/docs/grafana/latest/upgrade-guide/
