### PR TITLE
Fix wrong texts in titles when cloning templates

### DIFF
--- a/public/app/features/alerting/unified/Receivers.tsx
+++ b/public/app/features/alerting/unified/Receivers.tsx
@@ -22,6 +22,7 @@ import { GlobalConfigForm } from './components/receivers/GlobalConfigForm';
 import { NewReceiverView } from './components/receivers/NewReceiverView';
 import { NewTemplateView } from './components/receivers/NewTemplateView';
 import { ReceiversAndTemplatesView } from './components/receivers/ReceiversAndTemplatesView';
+import { isDuplicating } from './components/receivers/TemplateForm';
 import { useAlertManagerSourceName } from './hooks/useAlertManagerSourceName';
 import { useAlertManagersByPermission } from './hooks/useAlertManagerSources';
 import { useUnifiedAlertingSelector } from './hooks/useUnifiedAlertingSelector';
@@ -62,7 +63,7 @@ const Receivers = () => {
   const { id, type } = useParams<{ id?: string; type?: PageType }>();
   const location = useLocation();
   const isRoot = location.pathname.endsWith('/alerting/notifications');
-
+  const isduplicatingTemplate = isDuplicating(location);
   const configRequests = useUnifiedAlertingSelector((state) => state.amConfigs);
 
   const {
@@ -96,7 +97,7 @@ const Receivers = () => {
 
   const disableAmSelect = !isRoot;
 
-  let pageNav = getPageNavigationModel(type, id);
+  let pageNav = getPageNavigationModel(type, id, isduplicatingTemplate);
 
   if (!alertManagerSourceName) {
     return isRoot ? (
@@ -181,8 +182,14 @@ const Receivers = () => {
   );
 };
 
-function getPageNavigationModel(type: PageType | undefined, id: string | undefined) {
+function getPageNavigationModel(type: PageType | undefined, id: string | undefined, isDuplicatingTemplates: boolean) {
   let pageNav: NavModelItem | undefined;
+  if (isDuplicatingTemplates) {
+    return {
+      text: `New template`,
+      subTitle: `Create a new template for your notifications`,
+    };
+  }
   if (type === 'receivers' || type === 'templates') {
     const objectText = type === 'receivers' ? 'contact point' : 'notification template';
     if (id) {

--- a/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
@@ -1,6 +1,8 @@
 import { css } from '@emotion/css';
+import { Location } from 'history';
 import React, { FC } from 'react';
 import { useForm, Validate } from 'react-hook-form';
+import { useLocation } from 'react-router-dom';
 import AutoSizer from 'react-virtualized-auto-sizer';
 
 import { GrafanaTheme2 } from '@grafana/data';
@@ -37,6 +39,7 @@ interface Props {
   alertManagerSourceName: string;
   provenance?: string;
 }
+export const isDuplicating = (location: Location) => location.pathname.endsWith('/duplicate');
 
 export const TemplateForm: FC<Props> = ({ existing, alertManagerSourceName, config, provenance }) => {
   const styles = useStyles2(getStyles);
@@ -45,6 +48,9 @@ export const TemplateForm: FC<Props> = ({ existing, alertManagerSourceName, conf
   useCleanup((state) => (state.unifiedAlerting.saveAMConfig = initialAsyncRequestState));
 
   const { loading, error } = useUnifiedAlertingSelector((state) => state.saveAMConfig);
+
+  const location = useLocation();
+  const isduplicating = isDuplicating(location);
 
   const submit = (values: Values) => {
     // wrap content in "define" if it's not already wrapped, in case user did not do it/
@@ -102,10 +108,9 @@ export const TemplateForm: FC<Props> = ({ existing, alertManagerSourceName, conf
       ? true
       : 'Another template with this name already exists.';
   };
-
   return (
     <form onSubmit={handleSubmit(submit)}>
-      <h4>{existing ? 'Edit notification template' : 'Create notification template'}</h4>
+      <h4>{existing && !isduplicating ? 'Edit notification template' : 'Create notification template'}</h4>
       {error && (
         <Alert severity="error" title="Error saving template">
           {error.message || (error as any)?.data?.message || String(error)}


### PR DESCRIPTION
**What is this feature?**

This PR fixes wrong text when cloning a template. The UI should show "Create notification template" instead of "Edit notification template".

**Why do we need this feature?**

UI should show "Create notification template" in the title when cloning a rule.

**Who is this feature for?**

All users.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/63503

**Special notes for your reviewer**:


https://user-images.githubusercontent.com/33540275/222134320-b2d7d271-ce18-480b-808a-512934299299.mp4



