### PR TITLE
Elasticsearch: Implement processing of raw document query results in backend

### DIFF
--- a/pkg/tsdb/elasticsearch/response_parser_test.go
+++ b/pkg/tsdb/elasticsearch/response_parser_test.go
@@ -1164,6 +1164,92 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, data.FieldTypeNullableString, frame.Fields[15].Type())
 		})
 
+		t.Run("Raw document query", func(t *testing.T) {
+			targets := map[string]string{
+				"A": `{
+					"metrics": [{ "type": "raw_document" }]
+				}`,
+			}
+
+			response := `{
+  			"responses":[
+  			  {
+  			    "hits":{
+  			      "total":{
+  			        "value":109,
+  			        "relation":"eq"
+  			      },
+  			      "max_score":null,
+  			      "hits":[
+  			        {
+  			          "_index":"logs-2023.02.08",
+  			          "_id":"GB2UMYYBfCQ-FCMjayJa",
+  			          "_score":null,
+									"fields": {
+										"test_field":"A"
+									},
+  			          "_source":{
+  			            "@timestamp":"2023-02-08T15:10:55.830Z",
+  			            "line":"log text  [479231733]",
+  			            "counter":"109",
+  			            "float":58.253758485091,
+  			            "label":"val1",
+  			            "level":"info",
+  			            "location":"17.089705232090438, 41.62861966340297",
+										"nested": {
+											"field": {
+												"double_nested": "value"
+											}
+										}
+									}
+  			        },
+  			        {
+  			          "_index":"logs-2023.02.08",
+  			          "_id":"Fx2UMYYBfCQ-FCMjZyJ_",
+  			          "_score":null,
+									"fields": {
+										"test_field":"A"
+									},
+  			          "_source":{
+  			            "@timestamp":"2023-02-08T15:10:54.835Z",
+  			            "line":"log text with ANSI \u001b[31mpart of the text\u001b[0m [493139080]",
+  			            "counter":"108",
+  			            "float":54.5977098233944,
+  			            "label":"val1",
+  			            "level":"info",
+  			            "location":"19.766305918490463, 40.42639175509792",
+										"nested": {
+											"field": {
+												"double_nested": "value1"
+											}
+										}
+									}
+  			        }
+  			      ]
+  			    },
+  			    "status":200
+  			  }
+  			]
+			}`
+
+			result, err := parseTestResponse(targets, response)
+			require.NoError(t, err)
+			require.Len(t, result.Responses, 1)
+
+			queryRes := result.Responses["A"]
+			require.NotNil(t, queryRes)
+			dataframes := queryRes.Frames
+			require.Len(t, dataframes, 1)
+			frame := dataframes[0]
+
+			require.Equal(t, 1, len(frame.Fields))
+			//Fields have the correct length
+			require.Equal(t, 2, frame.Fields[0].Len())
+			// The only field is the raw document
+			require.Equal(t, data.FieldTypeNullableJSON, frame.Fields[0].Type())
+			require.Equal(t, "A", frame.Fields[0].Name)
+		})
+
 		t.Run("Raw data query", func(t *testing.T) {
 			targets := map[string]string{
 				"A": `{

--- a/pkg/tsdb/elasticsearch/time_series_query.go
+++ b/pkg/tsdb/elasticsearch/time_series_query.go
@@ -312,7 +312,15 @@ func isLogsQuery(query *Query) bool {
 }
 
 func isDocumentQuery(query *Query) bool {
-	return query.Metrics[0].Type == rawDataType || query.Metrics[0].Type == rawDocumentType
+	return isRawDataQuery(query) || isRawDocumentQuery(query)
+}
+
+func isRawDataQuery(query *Query) bool {
+	return query.Metrics[0].Type == rawDataType
+}
+
+func isRawDocumentQuery(query *Query) bool {
+	return query.Metrics[0].Type == rawDocumentType
 }
 
 func processLogsQuery(q *Query, b *es.SearchRequestBuilder, from, to int64, defaultTimeField string) {


### PR DESCRIPTION
Same as https://github.com/grafana/grafana/pull/63803. 

Part of https://github.com/grafana/grafana/issues/54011. This PR adds processing of raw document response to backend. To do this, we have encapsulated all logic into `processRawDocumentResponse`. It is possible that this feature will be removed in v10, but I wanted to make sure that missing processing of `raw_document` wouldn't be a blocker for enabling feature toggle in the future. Also it was easier and faster for me to implement this now, then returning back to it. 

`processRawDocumentResponse` processes response in the same way as it is currently done on frontend. 

When running test data, there might be a slight difference in:

-  ordering (results from backend are alphabetically ordered - this is done automatically while JSON.Marshall. From [docs](https://pkg.go.dev/encoding/json#Marshal):  `...map's key type must either be a string, an integer type, or implement encoding.TextMarshaler. The map keys are sorted`. This shouldn't be an issue at all, as the order of fields in json is not used anywhere.
- In json field (only field),  `@timestamp` is array with value when processed trough backend (compared to just value when processed trough frontend). This is because when we execute query trough backend, we receive `hit["fields"]` which has `@timestamp` with array with timestamp, compared to request trough frontend, where `hit["fields"]` is not present. 

This is because on backend, we are purposefully adding `time field` to ` b.AddDocValueField(defaultTimeField)` https://github.com/grafana/grafana/blob/main/pkg/tsdb/elasticsearch/time_series_query.go#L350 which means, that we are setting it as custom prop in our request to ES. However, this is missing in frontend implementation.

As we have processing for `fields` and we have method `AddDocValueField`, I suspect that not adding `time field` as `value field` is mistake and therefore the change is positive. 

FYI More on fields https://www.elastic.co/guide/en/elasticsearch/reference/current/search-fields.html. 

<img width="1850" alt="image" src="https://user-images.githubusercontent.com/30407135/221602544-736bfc97-d4c3-41c6-a68b-ed0371882b03.png">


**Special notes for your reviewer**:

To test this
1. Run ElasticSearch data source by `make devenv sources=elastic`
2. Use `elasticsearchBackendMigration` feature toggle to toggle if query is run trough frontend/backend
3. Run `Raw document` query
4. Results run trough frontend and backend should be same (with exception of @timestamp and ordering). 