### PR TITLE
StatPanel: Fix issue where sparkline chart was not being shown on resize

### DIFF
--- a/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
+++ b/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
@@ -415,6 +415,10 @@ export class StackedWithNoChartLayout extends BigValueLayout {
     return styles;
   }
 
+  renderChart(): JSX.Element | null {
+    return null;
+  }
+
   getPanelStyles() {
     const styles = super.getPanelStyles();
     styles.alignItems = 'center';


### PR DESCRIPTION
**What is this feature?**

Currently the `BigPanelLayout` attempts to render a chart for 3 of the layouts (`WideWithChartLayout`, `StackedWithChartLayout`, `StackedWithNoChartLayout`) and does not render it for `WideNoChartLayout`. Rendering the chart means it will initialize the `Plot` component, but in the case of `StackedWithNoChartLayout` it will initialize it incorrectly and on resize it won't attempt to rerender the chart correctly. This change makes sure the chart is not rendered when it is not needed.

**Why do we need this feature?**

There was an issue with StatPanel where if the panel was initialized in a size that does not display the chart and then you resized it, it still wouldn't display the chart correctly. This guarantees that every time we resize the panel to a size where the chart should be visible it initializes the chart correctly.

Before:

https://user-images.githubusercontent.com/100691367/222169444-5e991ed0-3350-4214-9dc4-ae7e9982622c.mov

After:

https://user-images.githubusercontent.com/100691367/222169491-957f1e77-346a-4799-b16d-71c584f63168.mov

**Who is this feature for?**

Dashboards with Stat panel in them

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #63485


