### PR TITLE
ContextMenu: Fix padding and show border based on items

### DIFF
--- a/packages/grafana-ui/src/components/Menu/Menu.tsx
+++ b/packages/grafana-ui/src/components/Menu/Menu.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { css, cx } from '@emotion/css';
 import React, { useImperativeHandle, useRef } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
@@ -39,7 +39,16 @@ const MenuComp = React.forwardRef<HTMLDivElement, MenuProps>(
         aria-label={ariaLabel}
         onKeyDown={handleKeys}
       >
-        {header && <div className={styles.header}>{header}</div>}
+        {header && (
+          <div
+            className={cx(
+              styles.header,
+              Boolean(children) && React.Children.toArray(children).length > 0 && styles.headerBorder
+            )}
+          >
+            {header}
+          </div>
+        )}
         {children}
       </div>
     );
@@ -57,7 +66,9 @@ export const Menu = Object.assign(MenuComp, {
 const getStyles = (theme: GrafanaTheme2) => {
   return {
     header: css({
-      padding: `${theme.spacing(0.5, 0.5, 1, 0.5)}`,
+      padding: `${theme.spacing(0.5, 1, 1, 1)}`,
+    }),
+    headerBorder: css({
       borderBottom: `1px solid ${theme.colors.border.weak}`,
     }),
     wrapper: css({


### PR DESCRIPTION
There were small inconsistencies in ContextMenu component found as part of review here https://github.com/grafana/grafana/pull/60989.

Padding of the header wasn't consistent with other parts of the menu. Made it the same as padding for the groups:
Before:
![Screenshot from 2023-03-01 16-20-10](https://user-images.githubusercontent.com/1014802/222183348-7314f5f3-9975-4b46-aaa0-c413490bf6a2.png)
After:
![Screenshot from 2023-03-01 16-19-09](https://user-images.githubusercontent.com/1014802/222183408-08095642-8525-4720-8aab-4ae300d2225e.png)

Don't show bottom border if there are no clickable items:
Before:
![Screenshot from 2023-03-01 16-20-18](https://user-images.githubusercontent.com/1014802/222183878-26ca466e-99e0-45a0-9726-360752f61053.png)

After:
![Screenshot from 2023-03-01 16-19-21](https://user-images.githubusercontent.com/1014802/222183939-919b8ac2-9dae-4187-913a-73153df092d9.png)

