### PR TITLE
Alerting: Fix migration pauses all alert rules on PostgreSQL

### DIFF
--- a/pkg/services/sqlstore/migrations/ualert/tables.go
+++ b/pkg/services/sqlstore/migrations/ualert/tables.go
@@ -290,6 +290,11 @@ func addAlertRuleMigrations(mg *migrator.Migrator, defaultIntervalSeconds int64)
 			Default:  "false",
 		},
 	))
+
+	// This migration fixes a bug where "false" for the default value created a column with default "true" in PostgreSQL databases
+	mg.AddMigration("fix is_paused column for alert_rule table", migrator.NewRawSQLMigration("").
+		Postgres(`ALTER TABLE alert_rule ALTER COLUMN is_paused SET DEFAULT false;
+UPDATE alert_rule SET is_paused = false;`))
 }
 
 func addAlertRuleVersionMigrations(mg *migrator.Migrator) {
@@ -354,6 +359,11 @@ func addAlertRuleVersionMigrations(mg *migrator.Migrator) {
 			Default:  "false",
 		},
 	))
+
+	// This migration fixes a bug where "false" for the default value created a column with default "true" in PostgreSQL databases
+	mg.AddMigration("fix is_paused column for alert_rule_version table", migrator.NewRawSQLMigration("").
+		Postgres(`ALTER TABLE alert_rule_version ALTER COLUMN is_paused SET DEFAULT false;
+UPDATE alert_rule_version SET is_paused = false;`))
 }
 
 func addAlertmanagerConfigMigrations(mg *migrator.Migrator) {


### PR DESCRIPTION
**Which issue(s) does this PR fix?**:

This pull request fixes a serious bug in Grafana 9.4.1 where on upgrade a migration would pause all existing alert rules and change the default value of the column to `true`. This bug is confirmed to affect PostgreSQL, and not MySQL or sqlite3. However, I have tested the change in all three databases as I don't want to take any chances.

#63927 

**Special notes for your reviewer**:

I've tested this change in PostgreSQL, MySQL 5.7, and sqlite3.

#### PostgreSQL

```
INFO [03-01|15:28:26] Executing migration                      logger=migrator id="add is_paused column to alert_rule table"
INFO [03-01|15:28:26] Executing migration                      logger=migrator id="fix is_paused column for alert_rule table"
INFO [03-01|15:28:26] Executing migration                      logger=migrator id="add is_paused column to alert_rule_versions table"
INFO [03-01|15:28:26] Executing migration                      logger=migrator id="fix is_paused column for alert_rule_version table"
```

```
postgres=# \d alert_rule;
                                           Table "public.alert_rule"
      Column      |            Type             | Collation | Nullable |                Default
------------------+-----------------------------+-----------+----------+----------------------------------------
 id               | integer                     |           | not null | nextval('alert_rule_id_seq'::regclass)
 org_id           | bigint                      |           | not null |
 title            | character varying(190)      |           | not null |
 condition        | character varying(190)      |           | not null |
 data             | text                        |           | not null |
 updated          | timestamp without time zone |           | not null |
 interval_seconds | bigint                      |           | not null | 60
 version          | integer                     |           | not null | 0
 uid              | character varying(40)       |           | not null | 0
 namespace_uid    | character varying(40)       |           | not null |
 rule_group       | character varying(190)      |           | not null |
 no_data_state    | character varying(15)       |           | not null | 'NoData'::character varying
 exec_err_state   | character varying(15)       |           | not null | 'Alerting'::character varying
 for              | bigint                      |           | not null | 0
 annotations      | text                        |           |          |
 labels           | text                        |           |          |
 dashboard_uid    | character varying(40)       |           |          |
 panel_id         | bigint                      |           |          |
 rule_group_idx   | integer                     |           | not null | 1
 is_paused        | boolean                     |           | not null | false
Indexes:
    "alert_rule_pkey" PRIMARY KEY, btree (id)
    "IDX_alert_rule_org_id_dashboard_uid_panel_id" btree (org_id, dashboard_uid, panel_id)
    "IDX_alert_rule_org_id_namespace_uid_rule_group" btree (org_id, namespace_uid, rule_group)
    "UQE_alert_rule_org_id_namespace_uid_title" UNIQUE, btree (org_id, namespace_uid, title)
    "UQE_alert_rule_org_id_uid" UNIQUE, btree (org_id, uid)

postgres=# SELECT is_paused FROM alert_rule;
 is_paused
-----------
 f
(1 row)

postgres=# \d alert_rule_version;
                                            Table "public.alert_rule_version"
       Column       |            Type             | Collation | Nullable |                    Default
--------------------+-----------------------------+-----------+----------+------------------------------------------------
 id                 | integer                     |           | not null | nextval('alert_rule_version_id_seq'::regclass)
 rule_org_id        | bigint                      |           | not null |
 rule_uid           | character varying(40)       |           | not null | 0
 rule_namespace_uid | character varying(40)       |           | not null |
 rule_group         | character varying(190)      |           | not null |
 parent_version     | integer                     |           | not null |
 restored_from      | integer                     |           | not null |
 version            | integer                     |           | not null |
 created            | timestamp without time zone |           | not null |
 title              | character varying(190)      |           | not null |
 condition          | character varying(190)      |           | not null |
 data               | text                        |           | not null |
 interval_seconds   | bigint                      |           | not null |
 no_data_state      | character varying(15)       |           | not null | 'NoData'::character varying
 exec_err_state     | character varying(15)       |           | not null | 'Alerting'::character varying
 for                | bigint                      |           | not null | 0
 annotations        | text                        |           |          |
 labels             | text                        |           |          |
 rule_group_idx     | integer                     |           | not null | 1
 is_paused          | boolean                     |           | not null | false
Indexes:
    "alert_rule_version_pkey" PRIMARY KEY, btree (id)
    "IDX_alert_rule_version_rule_org_id_rule_namespace_uid_rule_grou" btree (rule_org_id, rule_namespace_uid, rule_group)
    "UQE_alert_rule_version_rule_org_id_rule_uid_version" UNIQUE, btree (rule_org_id, rule_uid, version)

postgres=# SELECT is_paused FROM alert_rule_version;
 is_paused
-----------
 f
(1 row)

```

#### MySQL 5.7

```
INFO [03-01|15:32:35] Executing migration                      logger=migrator id="add is_paused column to alert_rule table"
INFO [03-01|15:32:35] Executing migration                      logger=migrator id="fix is_paused column for alert_rule table"
INFO [03-01|15:32:35] Executing migration                      logger=migrator id="add is_paused column to alert_rule_versions table"
INFO [03-01|15:32:35] Executing migration                      logger=migrator id="fix is_paused column for alert_rule_version table"
```

```
mysql> EXPLAIN alert_rule;
+------------------+--------------+------+-----+----------+----------------+
| Field            | Type         | Null | Key | Default  | Extra          |
+------------------+--------------+------+-----+----------+----------------+
| id               | bigint(20)   | NO   | PRI | NULL     | auto_increment |
| org_id           | bigint(20)   | NO   | MUL | NULL     |                |
| title            | varchar(190) | NO   |     | NULL     |                |
| condition        | varchar(190) | NO   |     | NULL     |                |
| data             | mediumtext   | YES  |     | NULL     |                |
| updated          | datetime     | NO   |     | NULL     |                |
| interval_seconds | bigint(20)   | NO   |     | 60       |                |
| version          | int(11)      | NO   |     | 0        |                |
| uid              | varchar(40)  | NO   |     | 0        |                |
| namespace_uid    | varchar(40)  | NO   |     | NULL     |                |
| rule_group       | varchar(190) | NO   |     | NULL     |                |
| no_data_state    | varchar(15)  | NO   |     | NoData   |                |
| exec_err_state   | varchar(15)  | NO   |     | Alerting |                |
| for              | bigint(20)   | NO   |     | 0        |                |
| annotations      | text         | YES  |     | NULL     |                |
| labels           | text         | YES  |     | NULL     |                |
| dashboard_uid    | varchar(40)  | YES  |     | NULL     |                |
| panel_id         | bigint(20)   | YES  |     | NULL     |                |
| rule_group_idx   | int(11)      | NO   |     | 1        |                |
| is_paused        | tinyint(1)   | NO   |     | 0        |                |
+------------------+--------------+------+-----+----------+----------------+
20 rows in set (0.01 sec)

mysql> SELECT is_paused FROM alert_rule;
+-----------+
| is_paused |
+-----------+
|         0 |
+-----------+
1 row in set (0.00 sec)

mysql> EXPLAIN alert_rule_version;
+--------------------+--------------+------+-----+----------+----------------+
| Field              | Type         | Null | Key | Default  | Extra          |
+--------------------+--------------+------+-----+----------+----------------+
| id                 | bigint(20)   | NO   | PRI | NULL     | auto_increment |
| rule_org_id        | bigint(20)   | NO   | MUL | NULL     |                |
| rule_uid           | varchar(40)  | NO   |     | 0        |                |
| rule_namespace_uid | varchar(40)  | NO   |     | NULL     |                |
| rule_group         | varchar(190) | NO   |     | NULL     |                |
| parent_version     | int(11)      | NO   |     | NULL     |                |
| restored_from      | int(11)      | NO   |     | NULL     |                |
| version            | int(11)      | NO   |     | NULL     |                |
| created            | datetime     | NO   |     | NULL     |                |
| title              | varchar(190) | NO   |     | NULL     |                |
| condition          | varchar(190) | NO   |     | NULL     |                |
| data               | mediumtext   | YES  |     | NULL     |                |
| interval_seconds   | bigint(20)   | NO   |     | NULL     |                |
| no_data_state      | varchar(15)  | NO   |     | NoData   |                |
| exec_err_state     | varchar(15)  | NO   |     | Alerting |                |
| for                | bigint(20)   | NO   |     | 0        |                |
| annotations        | text         | YES  |     | NULL     |                |
| labels             | text         | YES  |     | NULL     |                |
| rule_group_idx     | int(11)      | NO   |     | 1        |                |
| is_paused          | tinyint(1)   | NO   |     | 0        |                |
+--------------------+--------------+------+-----+----------+----------------+
20 rows in set (0.01 sec)

mysql> SELECT is_paused FROM alert_rule_version;
+-----------+
| is_paused |
+-----------+
|         0 |
+-----------+
1 row in set (0.00 sec)
```

#### sqlite3

```
INFO [03-01|15:35:52] Executing migration                      logger=migrator id="add is_paused column to alert_rule table"
INFO [03-01|15:35:52] Executing migration                      logger=migrator id="fix is_paused column for alert_rule table"
INFO [03-01|15:35:52] Executing migration                      logger=migrator id="add is_paused column to alert_rule_versions table"
INFO [03-01|15:35:52] Executing migration                      logger=migrator id="fix is_paused column for alert_rule_version table"
```

```
sqlite> .schema alert_rule
CREATE TABLE `alert_rule` (
`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL
, `org_id` INTEGER NOT NULL
, `title` TEXT NOT NULL
, `condition` TEXT NOT NULL
, `data` TEXT NOT NULL
, `updated` DATETIME NOT NULL
, `interval_seconds` INTEGER NOT NULL DEFAULT 60
, `version` INTEGER NOT NULL DEFAULT 0
, `uid` TEXT NOT NULL DEFAULT 0
, `namespace_uid` TEXT NOT NULL
, `rule_group` TEXT NOT NULL
, `no_data_state` TEXT NOT NULL DEFAULT 'NoData'
, `exec_err_state` TEXT NOT NULL DEFAULT 'Alerting'
, `for` INTEGER NOT NULL DEFAULT 0, `annotations` TEXT NULL, `labels` TEXT NULL, `dashboard_uid` TEXT NULL, `panel_id` INTEGER NULL, `rule_group_idx` INTEGER NOT NULL DEFAULT 1, `is_paused` INTEGER NOT NULL DEFAULT false);
CREATE UNIQUE INDEX `UQE_alert_rule_org_id_uid` ON `alert_rule` (`org_id`,`uid`);
CREATE INDEX `IDX_alert_rule_org_id_namespace_uid_rule_group` ON `alert_rule` (`org_id`,`namespace_uid`,`rule_group`);
CREATE UNIQUE INDEX `UQE_alert_rule_org_id_namespace_uid_title` ON `alert_rule` (`org_id`,`namespace_uid`,`title`);
CREATE INDEX `IDX_alert_rule_org_id_dashboard_uid_panel_id` ON `alert_rule` (`org_id`,`dashboard_uid`,`panel_id`);
sqlite> SELECT is_paused FROM alert_rule;
0
sqlite> .schema alert_rule_version
CREATE TABLE `alert_rule_version` (
`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL
, `rule_org_id` INTEGER NOT NULL
, `rule_uid` TEXT NOT NULL DEFAULT 0
, `rule_namespace_uid` TEXT NOT NULL
, `rule_group` TEXT NOT NULL
, `parent_version` INTEGER NOT NULL
, `restored_from` INTEGER NOT NULL
, `version` INTEGER NOT NULL
, `created` DATETIME NOT NULL
, `title` TEXT NOT NULL
, `condition` TEXT NOT NULL
, `data` TEXT NOT NULL
, `interval_seconds` INTEGER NOT NULL
, `no_data_state` TEXT NOT NULL DEFAULT 'NoData'
, `exec_err_state` TEXT NOT NULL DEFAULT 'Alerting'
, `for` INTEGER NOT NULL DEFAULT 0, `annotations` TEXT NULL, `labels` TEXT NULL, `rule_group_idx` INTEGER NOT NULL DEFAULT 1, `is_paused` INTEGER NOT NULL DEFAULT false);
CREATE UNIQUE INDEX `UQE_alert_rule_version_rule_org_id_rule_uid_version` ON `alert_rule_version` (`rule_org_id`,`rule_uid`,`version`);
CREATE INDEX `IDX_alert_rule_version_rule_org_id_rule_namespace_uid_rule_group` ON `alert_rule_version` (`rule_org_id`,`rule_namespace_uid`,`rule_group`);
sqlite> SELECT is_paused FROM alert_rule_version;
0
```
