### PR TITLE
Regen cue after conflicting heatmap/table migrations

### DIFF
--- a/pkg/kindsys/report.json
+++ b/pkg/kindsys/report.json
@@ -2008,7 +2008,7 @@
           "zipkindataquery",
           "zipkindatasourcecfg"
         ],
-        "count": 66
+        "count": 67
       },
       "core": {
         "name": "core",


### PR DESCRIPTION
Fixes broken main where `verify-gen-cue` crashed after merging table and heatmap migration one after the other without pull changing in the latter PR and re-running `gen-cue`. 