### PR TITLE
a wired little dashboard "getter" service

### DIFF
--- a/pkg/server/wire.go
+++ b/pkg/server/wire.go
@@ -7,8 +7,6 @@ import (
 	"github.com/google/wire"
 	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 
-	"github.com/grafana/grafana/pkg/services/folder"
-
 	"github.com/grafana/grafana/pkg/api"
 	"github.com/grafana/grafana/pkg/api/avatar"
 	"github.com/grafana/grafana/pkg/api/routing"
@@ -61,6 +59,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/encryption"
 	encryptionservice "github.com/grafana/grafana/pkg/services/encryption/service"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/folder/folderimpl"
 	"github.com/grafana/grafana/pkg/services/grpcserver"
 	grpccontext "github.com/grafana/grafana/pkg/services/grpcserver/context"
@@ -295,6 +294,7 @@ var wireBasicSet = wire.NewSet(
 	featuremgmt.ProvideManagerService,
 	featuremgmt.ProvideToggles,
 	dashboardservice.ProvideDashboardService, // DashboardServiceImpl
+	dashboardservice.ProvideGetterService,
 	dashboardstore.ProvideDashboardStore,
 	folderimpl.ProvideService,
 	folderimpl.ProvideDashboardFolderStore,

--- a/pkg/services/accesscontrol/ossaccesscontrol/permissions_services.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/permissions_services.go
@@ -115,12 +115,12 @@ var DashboardAdminActions = append(DashboardEditActions, []string{dashboards.Act
 
 func ProvideDashboardPermissions(
 	cfg *setting.Cfg, router routing.RouteRegister, sql db.DB, ac accesscontrol.AccessControl,
-	license licensing.Licensing, dashboardStore dashboards.Store, folderService folder.Service, service accesscontrol.Service,
+	license licensing.Licensing, dashboardGetter dashboards.GetterService, folderService folder.Service, service accesscontrol.Service,
 	teamService team.Service, userService user.Service,
 ) (*DashboardPermissionsService, error) {
 	getDashboard := func(ctx context.Context, orgID int64, resourceID string) (*dashboards.Dashboard, error) {
 		query := &dashboards.GetDashboardQuery{UID: resourceID, OrgID: orgID}
-		queryResult, err := dashboardStore.GetDashboard(ctx, query)
+		queryResult, err := dashboardGetter.GetDashboard(ctx, query)
 		if err != nil {
 			return nil, err
 		}
@@ -149,7 +149,7 @@ func ProvideDashboardPermissions(
 			}
 			if dashboard.FolderID > 0 {
 				query := &dashboards.GetDashboardQuery{ID: dashboard.FolderID, OrgID: orgID}
-				queryResult, err := dashboardStore.GetDashboard(ctx, query)
+				queryResult, err := dashboardGetter.GetDashboard(ctx, query)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/services/accesscontrol/ossaccesscontrol/permissions_services.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/permissions_services.go
@@ -202,7 +202,7 @@ var FolderAdminActions = append(FolderEditActions, []string{dashboards.ActionFol
 
 func ProvideFolderPermissions(
 	cfg *setting.Cfg, router routing.RouteRegister, sql db.DB, accesscontrol accesscontrol.AccessControl,
-	license licensing.Licensing, dashboardStore dashboards.Store, folderService folder.Service, service accesscontrol.Service,
+	license licensing.Licensing, dashboardService dashboards.GetterService, folderService folder.Service, service accesscontrol.Service,
 	teamService team.Service, userService user.Service,
 ) (*FolderPermissionsService, error) {
 	options := resourcepermissions.Options{
@@ -210,7 +210,7 @@ func ProvideFolderPermissions(
 		ResourceAttribute: "uid",
 		ResourceValidator: func(ctx context.Context, orgID int64, resourceID string) error {
 			query := &dashboards.GetDashboardQuery{UID: resourceID, OrgID: orgID}
-			queryResult, err := dashboardStore.GetDashboard(ctx, query)
+			queryResult, err := dashboardService.GetDashboard(ctx, query)
 			if err != nil {
 				return err
 			}

--- a/pkg/services/comments/commentmodel/permissions.go
+++ b/pkg/services/comments/commentmodel/permissions.go
@@ -17,12 +17,12 @@ type PermissionChecker struct {
 	sqlStore         db.DB
 	features         featuremgmt.FeatureToggles
 	accessControl    accesscontrol.AccessControl
-	dashboardService dashboards.DashboardService
+	dashboardService dashboards.GetterService
 	annotationsRepo  annotations.Repository
 }
 
 func NewPermissionChecker(sqlStore db.DB, features featuremgmt.FeatureToggles,
-	accessControl accesscontrol.AccessControl, dashboardService dashboards.DashboardService,
+	accessControl accesscontrol.AccessControl, dashboardService dashboards.GetterService,
 	annotationsRepo annotations.Repository,
 ) *PermissionChecker {
 	return &PermissionChecker{sqlStore: sqlStore, features: features, accessControl: accessControl, annotationsRepo: annotationsRepo}

--- a/pkg/services/comments/service.go
+++ b/pkg/services/comments/service.go
@@ -25,7 +25,7 @@ type Service struct {
 
 func ProvideService(cfg *setting.Cfg, store db.DB, live *live.GrafanaLive,
 	features featuremgmt.FeatureToggles, accessControl accesscontrol.AccessControl,
-	dashboardService dashboards.DashboardService, userService user.Service, annotationsRepo annotations.Repository) *Service {
+	dashboardService dashboards.GetterService, userService user.Service, annotationsRepo annotations.Repository) *Service {
 	s := &Service{
 		cfg:      cfg,
 		live:     live,

--- a/pkg/services/dashboards/dashboard.go
+++ b/pkg/services/dashboards/dashboard.go
@@ -12,6 +12,7 @@ import (
 //
 //go:generate mockery --name DashboardService --structname FakeDashboardService --inpackage --filename dashboard_service_mock.go
 type DashboardService interface {
+	GetterService
 	BuildSaveDashboardCommand(ctx context.Context, dto *SaveDashboardDTO, shouldValidateAlerts bool, validateProvisionedDashboard bool) (*SaveDashboardCommand, error)
 	DeleteDashboard(ctx context.Context, dashboardId int64, orgId int64) error
 	FindDashboards(ctx context.Context, query *FindPersistedDashboardsQuery) ([]DashboardSearchProjection, error)
@@ -54,13 +55,12 @@ type DashboardProvisioningService interface {
 //
 //go:generate mockery --name Store --structname FakeDashboardStore --inpackage --filename store_mock.go
 type Store interface {
+	GetterStore
 	DeleteDashboard(ctx context.Context, cmd *DeleteDashboardCommand) error
 	DeleteOrphanedProvisionedDashboards(ctx context.Context, cmd *DeleteOrphanedProvisionedDashboardsCommand) error
 	FindDashboards(ctx context.Context, query *FindPersistedDashboardsQuery) ([]DashboardSearchProjection, error)
-	GetDashboard(ctx context.Context, query *GetDashboardQuery) (*Dashboard, error)
 	GetDashboardACLInfoList(ctx context.Context, query *GetDashboardACLInfoListQuery) ([]*DashboardACLInfoDTO, error)
 	GetDashboardUIDByID(ctx context.Context, query *GetDashboardRefByIDQuery) (*DashboardRef, error)
-	GetDashboards(ctx context.Context, query *GetDashboardsQuery) ([]*Dashboard, error)
 	// GetDashboardsByPluginID retrieves dashboards identified by plugin.
 	GetDashboardsByPluginID(ctx context.Context, query *GetDashboardsByPluginIDQuery) ([]*Dashboard, error)
 	GetDashboardTags(ctx context.Context, query *GetDashboardTagsQuery) ([]*DashboardTagCloudItem, error)
@@ -86,6 +86,11 @@ type Store interface {
 }
 
 type GetterService interface {
+	GetDashboard(ctx context.Context, query *GetDashboardQuery) (*Dashboard, error)
+	GetDashboards(ctx context.Context, query *GetDashboardsQuery) ([]*Dashboard, error)
+}
+
+type GetterStore interface {
 	GetDashboard(ctx context.Context, query *GetDashboardQuery) (*Dashboard, error)
 	GetDashboards(ctx context.Context, query *GetDashboardsQuery) ([]*Dashboard, error)
 }

--- a/pkg/services/dashboards/dashboard.go
+++ b/pkg/services/dashboards/dashboard.go
@@ -55,10 +55,11 @@ type DashboardProvisioningService interface {
 //
 //go:generate mockery --name Store --structname FakeDashboardStore --inpackage --filename store_mock.go
 type Store interface {
-	GetterStore
 	DeleteDashboard(ctx context.Context, cmd *DeleteDashboardCommand) error
 	DeleteOrphanedProvisionedDashboards(ctx context.Context, cmd *DeleteOrphanedProvisionedDashboardsCommand) error
 	FindDashboards(ctx context.Context, query *FindPersistedDashboardsQuery) ([]DashboardSearchProjection, error)
+	GetDashboard(ctx context.Context, query *GetDashboardQuery) (*Dashboard, error)
+	GetDashboards(ctx context.Context, query *GetDashboardsQuery) ([]*Dashboard, error)
 	GetDashboardACLInfoList(ctx context.Context, query *GetDashboardACLInfoListQuery) ([]*DashboardACLInfoDTO, error)
 	GetDashboardUIDByID(ctx context.Context, query *GetDashboardRefByIDQuery) (*DashboardRef, error)
 	// GetDashboardsByPluginID retrieves dashboards identified by plugin.
@@ -85,12 +86,15 @@ type Store interface {
 	CountDashboardsInFolder(ctx context.Context, request *CountDashboardsInFolderRequest) (int64, error)
 }
 
+// GetterService is a subset of the DashboardService interface designed for
+// services that need Get methods only. Using this service simplifies
+// inter-service dependencies; the ProvideGetterService method only takes a db.DB
+// argument.
+//
+// This interface is a stepping store towards an EntityAPI-type paradigm, and may
+// be extended (refactored) to include other similar CRUD methods that don't have
+// tightly coupled business logic.
 type GetterService interface {
-	GetDashboard(ctx context.Context, query *GetDashboardQuery) (*Dashboard, error)
-	GetDashboards(ctx context.Context, query *GetDashboardsQuery) ([]*Dashboard, error)
-}
-
-type GetterStore interface {
 	GetDashboard(ctx context.Context, query *GetDashboardQuery) (*Dashboard, error)
 	GetDashboards(ctx context.Context, query *GetDashboardsQuery) ([]*Dashboard, error)
 }

--- a/pkg/services/dashboards/dashboard.go
+++ b/pkg/services/dashboards/dashboard.go
@@ -84,3 +84,8 @@ type Store interface {
 	// the given parent folder ID.
 	CountDashboardsInFolder(ctx context.Context, request *CountDashboardsInFolderRequest) (int64, error)
 }
+
+type GetterService interface {
+	GetDashboard(ctx context.Context, query *GetDashboardQuery) (*Dashboard, error)
+	GetDashboards(ctx context.Context, query *GetDashboardsQuery) ([]*Dashboard, error)
+}

--- a/pkg/services/dashboards/database/database.go
+++ b/pkg/services/dashboards/database/database.go
@@ -847,28 +847,7 @@ func (d *dashboardStore) deleteAlertDefinition(dashboardId int64, sess *db.Sessi
 }
 
 func (d *dashboardStore) GetDashboard(ctx context.Context, query *dashboards.GetDashboardQuery) (*dashboards.Dashboard, error) {
-	var queryResult *dashboards.Dashboard
-	err := d.store.WithDbSession(ctx, func(sess *db.Session) error {
-		if query.ID == 0 && len(query.Slug) == 0 && len(query.UID) == 0 {
-			return dashboards.ErrDashboardIdentifierNotSet
-		}
-
-		dashboard := dashboards.Dashboard{Slug: query.Slug, OrgID: query.OrgID, ID: query.ID, UID: query.UID}
-		has, err := sess.Get(&dashboard)
-
-		if err != nil {
-			return err
-		} else if !has {
-			return dashboards.ErrDashboardNotFound
-		}
-
-		dashboard.SetID(dashboard.ID)
-		dashboard.SetUID(dashboard.UID)
-		queryResult = &dashboard
-		return nil
-	})
-
-	return queryResult, err
+	return GetDashboard(ctx, d.store, query)
 }
 
 func (d *dashboardStore) GetDashboardUIDByID(ctx context.Context, query *dashboards.GetDashboardRefByIDQuery) (*dashboards.DashboardRef, error) {
@@ -1055,4 +1034,29 @@ func readQuotaConfig(cfg *setting.Cfg) (*quota.Map, error) {
 	limits.Set(globalQuotaTag, cfg.Quota.Global.Dashboard)
 	limits.Set(orgQuotaTag, cfg.Quota.Org.Dashboard)
 	return limits, nil
+}
+
+func GetDashboard(ctx context.Context, store db.DB, query *dashboards.GetDashboardQuery) (*dashboards.Dashboard, error) {
+	var queryResult *dashboards.Dashboard
+	err := store.WithDbSession(ctx, func(sess *db.Session) error {
+		if query.ID == 0 && len(query.Slug) == 0 && len(query.UID) == 0 {
+			return dashboards.ErrDashboardIdentifierNotSet
+		}
+
+		dashboard := dashboards.Dashboard{Slug: query.Slug, OrgID: query.OrgID, ID: query.ID, UID: query.UID}
+		has, err := sess.Get(&dashboard)
+
+		if err != nil {
+			return err
+		} else if !has {
+			return dashboards.ErrDashboardNotFound
+		}
+
+		dashboard.SetID(dashboard.ID)
+		dashboard.SetUID(dashboard.UID)
+		queryResult = &dashboard
+		return nil
+	})
+
+	return queryResult, err
 }

--- a/pkg/services/dashboards/errors.go
+++ b/pkg/services/dashboards/errors.go
@@ -122,6 +122,8 @@ var (
 		Status:     "not-found",
 	}
 
+	ErrCommandValidationFailed = errors.New("command missing required fields")
+
 	ErrFolderNotFound           = errors.New("folder not found")
 	ErrFolderVersionMismatch    = errors.New("the folder has been changed by someone else")
 	ErrFolderTitleEmpty         = errors.New("folder title cannot be empty")

--- a/pkg/services/dashboards/service/getter.go
+++ b/pkg/services/dashboards/service/getter.go
@@ -3,13 +3,15 @@ package service
 import (
 	"context"
 
-	"xorm.io/xorm"
-
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/dashboards/database"
 )
 
+// GetterServiceImpl is a very simplified, read-only dashboard service. Only add
+// methods which contain no business logic (auth, cfg, other services) This is a
+// mini-EntityAPI for bare bones CRUD operations where the caller is responsible
+// for everything else.
 type GetterServiceImpl struct {
 	store db.DB
 }
@@ -25,26 +27,5 @@ func (g *GetterServiceImpl) GetDashboard(ctx context.Context, query *dashboards.
 }
 
 func (g *GetterServiceImpl) GetDashboards(ctx context.Context, query *dashboards.GetDashboardsQuery) ([]*dashboards.Dashboard, error) {
-	var ret = make([]*dashboards.Dashboard, 0)
-	err := g.store.WithDbSession(ctx, func(sess *db.Session) error {
-		if len(query.DashboardIDs) == 0 && len(query.DashboardUIDs) == 0 {
-			return dashboards.ErrCommandValidationFailed
-		}
-		var session *xorm.Session
-		if len(query.DashboardIDs) > 0 {
-			session = sess.In("id", query.DashboardIDs)
-		} else {
-			session = sess.In("uid", query.DashboardUIDs)
-		}
-		if query.OrgID > 0 {
-			session = sess.Where("org_id = ?", query.OrgID)
-		}
-
-		err := session.Find(&ret)
-		return err
-	})
-	if err != nil {
-		return nil, err
-	}
-	return ret, nil
+	return database.GetDashboards(ctx, g.store, query)
 }

--- a/pkg/services/dashboards/service/getter.go
+++ b/pkg/services/dashboards/service/getter.go
@@ -1,0 +1,70 @@
+package service
+
+import (
+	"context"
+
+	"xorm.io/xorm"
+
+	"github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/services/dashboards"
+)
+
+type GetterServiceImpl struct {
+	store db.DB
+}
+
+var _ dashboards.GetterService = (*GetterServiceImpl)(nil)
+
+func ProvideGetterService(store db.DB) dashboards.GetterService {
+	return &GetterServiceImpl{store: store}
+}
+
+func (g *GetterServiceImpl) GetDashboard(ctx context.Context, query *dashboards.GetDashboardQuery) (*dashboards.Dashboard, error) {
+	var queryResult *dashboards.Dashboard
+	err := g.store.WithDbSession(ctx, func(sess *db.Session) error {
+		if query.ID == 0 && len(query.Slug) == 0 && len(query.UID) == 0 {
+			return dashboards.ErrDashboardIdentifierNotSet
+		}
+
+		dashboard := dashboards.Dashboard{Slug: query.Slug, OrgID: query.OrgID, ID: query.ID, UID: query.UID}
+		has, err := sess.Get(&dashboard)
+
+		if err != nil {
+			return err
+		} else if !has {
+			return dashboards.ErrDashboardNotFound
+		}
+
+		dashboard.SetID(dashboard.ID)
+		dashboard.SetUID(dashboard.UID)
+		queryResult = &dashboard
+		return nil
+	})
+
+	return queryResult, err
+}
+
+func (g *GetterServiceImpl) GetDashboards(ctx context.Context, query *dashboards.GetDashboardsQuery) ([]*dashboards.Dashboard, error) {
+	var ret = make([]*dashboards.Dashboard, 0)
+	err := g.store.WithDbSession(ctx, func(sess *db.Session) error {
+		if len(query.DashboardIDs) == 0 && len(query.DashboardUIDs) == 0 {
+			return dashboards.ErrCommandValidationFailed
+		}
+		var session *xorm.Session
+		if len(query.DashboardIDs) > 0 {
+			session = sess.In("id", query.DashboardIDs)
+		} else {
+			session = sess.In("uid", query.DashboardUIDs)
+		}
+		if query.OrgID > 0 {
+			session = sess.Where("org_id = ?", query.OrgID)
+		}
+
+		err := session.Find(&ret)
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	return ret, nil
+}

--- a/pkg/services/dashboards/service/getter.go
+++ b/pkg/services/dashboards/service/getter.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/services/dashboards/database"
 )
 
 type GetterServiceImpl struct {
@@ -20,28 +21,7 @@ func ProvideGetterService(store db.DB) dashboards.GetterService {
 }
 
 func (g *GetterServiceImpl) GetDashboard(ctx context.Context, query *dashboards.GetDashboardQuery) (*dashboards.Dashboard, error) {
-	var queryResult *dashboards.Dashboard
-	err := g.store.WithDbSession(ctx, func(sess *db.Session) error {
-		if query.ID == 0 && len(query.Slug) == 0 && len(query.UID) == 0 {
-			return dashboards.ErrDashboardIdentifierNotSet
-		}
-
-		dashboard := dashboards.Dashboard{Slug: query.Slug, OrgID: query.OrgID, ID: query.ID, UID: query.UID}
-		has, err := sess.Get(&dashboard)
-
-		if err != nil {
-			return err
-		} else if !has {
-			return dashboards.ErrDashboardNotFound
-		}
-
-		dashboard.SetID(dashboard.ID)
-		dashboard.SetUID(dashboard.UID)
-		queryResult = &dashboard
-		return nil
-	})
-
-	return queryResult, err
+	return database.GetDashboard(ctx, g.store, query)
 }
 
 func (g *GetterServiceImpl) GetDashboards(ctx context.Context, query *dashboards.GetDashboardsQuery) ([]*dashboards.Dashboard, error) {

--- a/pkg/services/guardian/accesscontrol_guardian.go
+++ b/pkg/services/guardian/accesscontrol_guardian.go
@@ -27,7 +27,7 @@ func NewAccessControlDashboardGuardian(
 	store db.DB, ac accesscontrol.AccessControl,
 	folderPermissionsService accesscontrol.FolderPermissionsService,
 	dashboardPermissionsService accesscontrol.DashboardPermissionsService,
-	dashboardService dashboards.DashboardService,
+	dashboardService dashboards.GetterService,
 ) (*AccessControlDashboardGuardian, error) {
 	var dashboard *dashboards.Dashboard
 	if dashboardId != 0 {
@@ -105,7 +105,7 @@ func NewAccessControlDashboardGuardianByDashboard(
 	store db.DB, ac accesscontrol.AccessControl,
 	folderPermissionsService accesscontrol.FolderPermissionsService,
 	dashboardPermissionsService accesscontrol.DashboardPermissionsService,
-	dashboardService dashboards.DashboardService,
+	dashboardService dashboards.GetterService,
 ) (*AccessControlDashboardGuardian, error) {
 	return &AccessControlDashboardGuardian{
 		ctx:                         ctx,
@@ -129,7 +129,7 @@ type AccessControlDashboardGuardian struct {
 	ac                          accesscontrol.AccessControl
 	folderPermissionsService    accesscontrol.FolderPermissionsService
 	dashboardPermissionsService accesscontrol.DashboardPermissionsService
-	dashboardService            dashboards.DashboardService
+	dashboardService            dashboards.GetterService
 }
 
 func (a *AccessControlDashboardGuardian) CanSave() (bool, error) {

--- a/pkg/services/ngalert/state/historian/annotation.go
+++ b/pkg/services/ngalert/state/historian/annotation.go
@@ -33,7 +33,7 @@ type RuleStore interface {
 	GetAlertRuleByUID(ctx context.Context, query *ngmodels.GetAlertRuleByUIDQuery) error
 }
 
-func NewAnnotationBackend(annotations annotations.Repository, dashboards dashboards.DashboardService, rules RuleStore) *AnnotationBackend {
+func NewAnnotationBackend(annotations annotations.Repository, dashboards dashboards.GetterService, rules RuleStore) *AnnotationBackend {
 	return &AnnotationBackend{
 		annotations: annotations,
 		dashboards:  newDashboardResolver(dashboards, defaultDashboardCacheExpiry),

--- a/pkg/services/ngalert/state/historian/dashboard.go
+++ b/pkg/services/ngalert/state/historian/dashboard.go
@@ -21,13 +21,13 @@ const (
 
 // dashboardResolver resolves dashboard UIDs to IDs with caching.
 type dashboardResolver struct {
-	dashboards   dashboards.DashboardService
+	dashboards   dashboards.GetterService
 	cache        *cache.Cache
 	singleflight singleflight.Group
 	log          log.Logger
 }
 
-func newDashboardResolver(dbs dashboards.DashboardService, expiry time.Duration) *dashboardResolver {
+func newDashboardResolver(dbs dashboards.GetterService, expiry time.Duration) *dashboardResolver {
 	return &dashboardResolver{
 		dashboards:   dbs,
 		cache:        cache.New(expiry, maxDuration(2*expiry, minCleanupInterval)),

--- a/pkg/services/screenshot/screenshot.go
+++ b/pkg/services/screenshot/screenshot.go
@@ -43,7 +43,7 @@ type ScreenshotService interface {
 
 // HeadlessScreenshotService takes screenshots using a headless browser.
 type HeadlessScreenshotService struct {
-	ds dashboards.DashboardService
+	ds dashboards.GetterService
 	rs rendering.Service
 
 	duration  prometheus.Histogram
@@ -51,7 +51,7 @@ type HeadlessScreenshotService struct {
 	successes prometheus.Counter
 }
 
-func NewHeadlessScreenshotService(ds dashboards.DashboardService, rs rendering.Service, r prometheus.Registerer) ScreenshotService {
+func NewHeadlessScreenshotService(ds dashboards.GetterService, rs rendering.Service, r prometheus.Registerer) ScreenshotService {
 	return &HeadlessScreenshotService{
 		ds: ds,
 		rs: rs,


### PR DESCRIPTION
The goal of this PR is to facilitate removing the dashboard _store_ as a dependency to other services, by adding a (temporary) minimal dashboard Getter service which only needs access to the database that the dashboard store is using.  Yes, this is weird: We have some fun dependency cycles between the `folder`, `dashboard`, and `accesscontrol` services when swapping the store dependencies with services. 

This is *hacky*; I am explicitly depending on the fact that it's all one DB under the hood so I can trust the dashboard tables are in place. Having said that, this pattern (direct db access, skipping services) already exists in the code base - at least in this case it's well documented, with a plan for removal. 

This should help (me) with the future of the k8s work, as reducing intra-service dependencies to CRUD operations is going in exactly the right direction, even if this stepping stone looks like a step backwards.

I'm more than happy to rename this, now or later. 