### PR TITLE
GHActions: add issue type to each query

### DIFF
--- a/.github/metrics-collector.json
+++ b/.github/metrics-collector.json
@@ -2,23 +2,23 @@
   "queries": [
     {
       "name": "type_bug",
-      "query": "label:\"type/bug\" is:open"
+      "query": "label:\"type/bug\" is:issue is:open"
     },
     {
       "name": "type_docs",
-      "query": "label:\"type/docs\" is:open"
+      "query": "label:\"type/docs\" is:issue is:open"
     },
     {
       "name": "needs_investigation",
-      "query": "label:\"needs investigation\" is:open"
+      "query": "label:\"needs investigation\" is:issue is:open"
     },
     {
       "name": "needs_more_info",
-      "query": "label:\"needs more info\" is:open"
+      "query": "label:\"needs more info\" is:issue is:open"
     },
     {
       "name": "triage_needs_confirmation",
-      "query": "label:\"triage/needs-confirmation\" is:open"
+      "query": "label:\"triage/needs-confirmation\" is:issue is:open"
     },
     {
       "name": "unlabeled",
@@ -26,7 +26,7 @@
     },
     {
       "name": "open_prs",
-      "query": "is:open is:pr"
+      "query": "is:open is:pull-request"
     }
   ]
 }


### PR DESCRIPTION
the metrics collector action partially broke on 1/6.

Once the action [tries iterating over the queries](https://github.com/grafana/grafana-github-actions/blob/9213d0859152bcd90af8dd3b17ffde7a5f55d297/metrics-collector/index.ts#L49-L61) that we store in this config file, the logs say:

```
...
Constructor OctoKit init
Constructor OctoKit end
trackMetric repo.stargazers 54159
trackMetric repo.watchers 54159
trackMetric repo.size 735765
trackMetric repo.forks 10554
trackMetric repo.open_issues_count 3153
Querying for label:"type/bug" is:open repo:grafana/grafana:
Error when running action:  RequestError [HttpError]: Query must include 'is:issue' or 'is:pull-request'
```

This PR updates each query to include 'is:issue' or 'is:pull-request'