### PR TITLE
Reqcontext: Use err status code instead of always fallback

### DIFF
--- a/pkg/services/contexthandler/model/model.go
+++ b/pkg/services/contexthandler/model/model.go
@@ -103,6 +103,8 @@ func (ctx *ReqContext) WriteErrOrFallback(status int, message string, err error)
 
 func (ctx *ReqContext) writeErrOrFallback(status int, message string, err error) {
 	data := make(map[string]interface{})
+	statusResponse := status
+
 	traceID := tracing.TraceIDFromContext(ctx.Req.Context(), false)
 
 	if err != nil {
@@ -121,6 +123,8 @@ func (ctx *ReqContext) writeErrOrFallback(status int, message string, err error)
 			data["message"] = publicErr.Message
 			data["messageId"] = publicErr.MessageID
 			data["statusCode"] = publicErr.StatusCode
+
+			statusResponse = publicErr.StatusCode
 		} else {
 			if message != "" {
 				logMessage = message
@@ -141,7 +145,7 @@ func (ctx *ReqContext) writeErrOrFallback(status int, message string, err error)
 		data["message"] = message
 	}
 
-	ctx.JSON(status, data)
+	ctx.JSON(statusResponse, data)
 }
 
 func (ctx *ReqContext) HasUserRole(role org.RoleType) bool {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
The status code received as a parameter by `writeErrOrFallback` should only be used as a fallback, if the status is available in the `err` this function should use it instead.


