### PR TITLE
Cloudwatch Logs: Make mixed type fields fallback to being strings

### DIFF
--- a/pkg/tsdb/cloudwatch/log_query_test.go
+++ b/pkg/tsdb/cloudwatch/log_query_test.go
@@ -33,6 +33,10 @@ func TestLogsResultsToDataframes(t *testing.T) {
 					Value: aws.String("test message 1"),
 				},
 				&cloudwatchlogs.ResultField{
+					Field: aws.String("numberOrString"),
+					Value: aws.String("1"),
+				},
+				&cloudwatchlogs.ResultField{
 					Field: aws.String("@logStream"),
 					Value: aws.String("fakelogstream"),
 				},
@@ -61,6 +65,10 @@ func TestLogsResultsToDataframes(t *testing.T) {
 				&cloudwatchlogs.ResultField{
 					Field: aws.String("line"),
 					Value: aws.String("test message 2"),
+				},
+				&cloudwatchlogs.ResultField{
+					Field: aws.String("numberOrString"),
+					Value: aws.String("not a number"),
 				},
 				&cloudwatchlogs.ResultField{
 					Field: aws.String("@logStream"),
@@ -100,6 +108,10 @@ func TestLogsResultsToDataframes(t *testing.T) {
 				&cloudwatchlogs.ResultField{
 					Field: aws.String("line"),
 					Value: aws.String("test message 3"),
+				},
+				&cloudwatchlogs.ResultField{
+					Field: aws.String("numberOrString"),
+					Value: aws.String("2.000"),
 				},
 				&cloudwatchlogs.ResultField{
 					Field: aws.String("@logStream"),
@@ -147,6 +159,12 @@ func TestLogsResultsToDataframes(t *testing.T) {
 		aws.String("test message 3"),
 	})
 
+	numberOrStringField := data.NewField("numberOrString", nil, []*string{
+		aws.String("1"),
+		aws.String("not a number"),
+		aws.String("2.000"),
+	})
+
 	logStreamField := data.NewField("@logStream", nil, []*string{
 		aws.String("fakelogstream"),
 		aws.String("fakelogstream"),
@@ -186,6 +204,7 @@ func TestLogsResultsToDataframes(t *testing.T) {
 		Fields: []*data.Field{
 			timeField,
 			lineField,
+			numberOrStringField,
 			logStreamField,
 			logField,
 			hiddenLogStreamField,


### PR DESCRIPTION
**What is this feature?**

Fallback to treating a field as a string if we encounter a string value when parsing a field as a number.

**Why do we need this feature?**

When a field in cloudwatch logs is mixed, i.e. it has string and number values, it can cause an error when parsing the values. For example, if the logs returned from the cloudwatch logs API has a field `A`, and the first value we receive for that field is a number, we treat the rest of the values for this field as a number. If a later value of `A` is a string, then an error is thrown. A workaround for this is to force the value to being a string. Instead we can fallback to treating the field as a string instead.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #63979

**Special notes for your reviewer**:

You can test this with the following query. Set time range to `2023-02-28 00:02:00` `2023-02-28 23:59:59` and log groups to `cloudwatch-plugin-logs`.

```
fields @timestamp, @message, coalesce(userIdentity.accountId, "account_id_string") as account_id |
 sort @timestamp desc |
 limit 10
```