### PR TITLE
Docs: Fix broken links on Plugins index page

### DIFF
--- a/docs/sources/developers/plugins/_index.md
+++ b/docs/sources/developers/plugins/_index.md
@@ -24,8 +24,8 @@ Follow the questions and you will have a starter plugin ready to develop.
 
 If you want a more guided introduction to plugin development, check out our tutorials:
 
-- [Build a panel plugin](/tutorials/build-a-panel-plugin/)
-- [Build a data source plugin](/tutorials/build-a-data-source-plugin/)
+- [Build a panel plugin](../../tutorials/build-a-panel-plugin/)
+- [Build a data source plugin](../../tutorials/build-a-data-source-plugin/)
 
 ## Go further
 
@@ -35,13 +35,13 @@ Learn more about specific areas of plugin development.
 
 If you're looking to build your first plugin, check out these introductory tutorials:
 
-- [Build a panel plugin](/tutorials/build-a-panel-plugin/)
-- [Build a data source plugin](/tutorials/build-a-data-source-plugin/)
-- [Build a data source backend plugin](/tutorials/build-a-data-source-backend-plugin/)
+- [Build a panel plugin](../../tutorials/build-a-panel-plugin/)
+- [Build a data source plugin](../../tutorials/build-a-data-source-plugin/)
+- [Build a data source backend plugin](../../tutorials/build-a-data-source-backend-plugin/)
 
 Ready to learn more? Check out our other tutorials:
 
-- [Build a panel plugin with D3.js](/tutorials/build-a-panel-plugin-with-d3/)
+- [Build a panel plugin with D3.js](../../tutorials/build-a-panel-plugin-with-d3/)
 
 ### Guides
 

--- a/docs/sources/developers/plugins/sign-a-plugin.md
+++ b/docs/sources/developers/plugins/sign-a-plugin.md
@@ -12,9 +12,7 @@ Before you can sign your plugin, you need to decide whether you want to sign it 
 
 If you want to make your plugin publicly available outside of your organization, you need to sign your plugin under a _community_ or _commercial_ [signature level](#plugin-signature-levels). Public plugins are available from [grafana.com/plugins](https://grafana.com/plugins) and can be installed by anyone.
 
-For more information on how to install a public plugin, refer to [Install Grafana plugins]({{< relref "../../administration/plugin-management#install-a-plugin" >}}).
-
-If you intend to only use the plugin within your organization, you can to sign it under a _private_ [signature level](#plugin-signature-levels).
+If you intend to only use the plugin within your organization, you can  sign it under a _private_ [signature level](#plugin-signature-levels).
 
 ## Generate an API key
 

--- a/docs/sources/developers/plugins/sign-a-plugin.md
+++ b/docs/sources/developers/plugins/sign-a-plugin.md
@@ -12,7 +12,7 @@ Before you can sign your plugin, you need to decide whether you want to sign it 
 
 If you want to make your plugin publicly available outside of your organization, you need to sign your plugin under a _community_ or _commercial_ [signature level](#plugin-signature-levels). Public plugins are available from [grafana.com/plugins](https://grafana.com/plugins) and can be installed by anyone.
 
-If you intend to only use the plugin within your organization, you can  sign it under a _private_ [signature level](#plugin-signature-levels).
+If you intend to only use the plugin within your organization, you can sign it under a _private_ [signature level](#plugin-signature-levels).
 
 ## Generate an API key
 


### PR DESCRIPTION


**What is this feature?**

Fixes broken links by fixing relative links which were broken when the Tutorials folder moved.

**Why do we need this feature?**

Links are broken for users.

**Who is this feature for?**

Plugin documentation readers.

**Which issue(s) does this PR fix?**:

None (internal users reported this).

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

