### PR TITLE
AzureMonitor: Fix query variable migration

### DIFF
--- a/public/app/plugins/datasource/azuremonitor/utils/migrateQuery.test.ts
+++ b/public/app/plugins/datasource/azuremonitor/utils/migrateQuery.test.ts
@@ -73,8 +73,8 @@ describe('AzureMonitor: migrateQuery', () => {
   it('modern queries should not change', () => {
     const result = migrateQuery(modernMetricsQuery);
 
-    // toEqual here since we deepClone the object at the beginning of the migration
-    expect(modernMetricsQuery).toEqual(result);
+    // MUST use .toBe because we want to assert that the identity of unmigrated queries remains the same
+    expect(modernMetricsQuery).toBe(result);
   });
 
   describe('migrating from a v8 query to the latest query version', () => {

--- a/public/app/plugins/datasource/azuremonitor/utils/migrateQuery.test.ts
+++ b/public/app/plugins/datasource/azuremonitor/utils/migrateQuery.test.ts
@@ -73,8 +73,8 @@ describe('AzureMonitor: migrateQuery', () => {
   it('modern queries should not change', () => {
     const result = migrateQuery(modernMetricsQuery);
 
-    // MUST use .toBe because we want to assert that the identity of unmigrated queries remains the same
-    expect(modernMetricsQuery).toBe(result);
+    // toEqual here since we deepClone the object at the beginning of the migration
+    expect(modernMetricsQuery).toEqual(result);
   });
 
   describe('migrating from a v8 query to the latest query version', () => {

--- a/public/app/plugins/datasource/azuremonitor/utils/migrateQuery.ts
+++ b/public/app/plugins/datasource/azuremonitor/utils/migrateQuery.ts
@@ -1,3 +1,5 @@
+import { cloneDeep } from 'lodash';
+
 import { setKustoQuery } from '../components/LogsQueryEditor/setQueryValue';
 import {
   appendDimensionFilter,
@@ -10,7 +12,7 @@ import { AzureMetricDimension, AzureMonitorQuery, AzureQueryType } from '../type
 const OLD_DEFAULT_DROPDOWN_VALUE = 'select';
 
 export default function migrateQuery(query: AzureMonitorQuery): AzureMonitorQuery {
-  let workingQuery = query;
+  let workingQuery = cloneDeep(query);
 
   if (!workingQuery.queryType) {
     workingQuery = {

--- a/public/app/plugins/datasource/azuremonitor/utils/migrateQuery.ts
+++ b/public/app/plugins/datasource/azuremonitor/utils/migrateQuery.ts
@@ -1,5 +1,3 @@
-import { cloneDeep } from 'lodash';
-
 import { setKustoQuery } from '../components/LogsQueryEditor/setQueryValue';
 import {
   appendDimensionFilter,
@@ -12,7 +10,7 @@ import { AzureMetricDimension, AzureMonitorQuery, AzureQueryType } from '../type
 const OLD_DEFAULT_DROPDOWN_VALUE = 'select';
 
 export default function migrateQuery(query: AzureMonitorQuery): AzureMonitorQuery {
-  let workingQuery = cloneDeep(query);
+  let workingQuery = query;
 
   if (!workingQuery.queryType) {
     workingQuery = {
@@ -35,7 +33,15 @@ export default function migrateQuery(query: AzureMonitorQuery): AzureMonitorQuer
   }
 
   if (workingQuery.azureLogAnalytics?.resource) {
-    workingQuery = migrateLogsResource(workingQuery);
+    workingQuery = {
+      ...workingQuery,
+      azureLogAnalytics: {
+        ...workingQuery.azureLogAnalytics,
+        resources: [workingQuery.azureLogAnalytics.resource],
+      },
+    };
+
+    delete workingQuery.azureLogAnalytics?.resource;
   }
 
   return workingQuery;
@@ -177,18 +183,6 @@ function migrateResourceGroupAndName(query: AzureMonitorQuery): AzureMonitorQuer
 
     delete workingQuery.azureMonitor.resourceGroup;
     delete workingQuery.azureMonitor.resourceName;
-  }
-
-  return workingQuery;
-}
-
-function migrateLogsResource(query: AzureMonitorQuery): AzureMonitorQuery {
-  let workingQuery = query;
-
-  if (workingQuery.azureLogAnalytics && workingQuery.azureLogAnalytics.resource) {
-    workingQuery.azureLogAnalytics.resources = [workingQuery.azureLogAnalytics.resource];
-
-    delete workingQuery.azureLogAnalytics.resource;
   }
 
   return workingQuery;


### PR DESCRIPTION
Somehow the query object becomes "unwriteable" post 9.4. To workaround this I clone the query object before doing any migrations which removes the immutability and allows the migrations to function as they did previously.

Fixes #63943
