### PR TITLE
Remove labeled from backport action

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -3,7 +3,6 @@ on:
   pull_request_target:
     types:
       - closed
-      - labeled
 
 jobs:
   main:


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

I don't see any reason the backport action should run when pull requests are being `labeled` 

If there is, this PR can be closed.

What happens currently is the action is starting and exiting with:
![SCR-20230302-dm2](https://user-images.githubusercontent.com/580672/222378052-e8e1bcbf-f30c-4da7-af87-cfb540d2d804.png)

Example: https://github.com/grafana/grafana/actions/runs/4312124787/jobs/7522298322

