### PR TITLE
Correlations: Fix flaky integration tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -135,6 +135,7 @@
 /pkg/services/validations/ @grafana/backend-platform
 /pkg/setting/ @grafana/backend-platform
 /pkg/tests/ @grafana/backend-platform
+/pkg/tests/api/correlations/ @grafana/explore-squad
 /pkg/tsdb/grafanads/ @grafana/backend-platform
 /pkg/tsdb/intervalv2/ @grafana/backend-platform
 /pkg/tsdb/legacydata/ @grafana/backend-platform

--- a/pkg/tests/api/correlations/common_test.go
+++ b/pkg/tests/api/correlations/common_test.go
@@ -44,7 +44,7 @@ func NewTestEnv(t *testing.T) TestContext {
 }
 
 type User struct {
-	username string
+	User     user.User
 	password string
 }
 
@@ -122,8 +122,8 @@ func (c TestContext) getURL(url string, user User) string {
 	c.t.Helper()
 
 	baseUrl := fmt.Sprintf("http://%s", c.env.Server.HTTPServer.Listener.Addr())
-	if user.username != "" && user.password != "" {
-		baseUrl = fmt.Sprintf("http://%s:%s@%s", user.username, user.password, c.env.Server.HTTPServer.Listener.Addr())
+	if user.User.Login != "" && user.password != "" {
+		baseUrl = fmt.Sprintf("http://%s:%s@%s", user.User.Login, user.password, c.env.Server.HTTPServer.Listener.Addr())
 	}
 
 	return fmt.Sprintf(
@@ -133,7 +133,7 @@ func (c TestContext) getURL(url string, user User) string {
 	)
 }
 
-func (c TestContext) createUser(cmd user.CreateUserCommand) {
+func (c TestContext) createUser(cmd user.CreateUserCommand) User {
 	c.t.Helper()
 	store := c.env.SQLStore
 	store.Cfg.AutoAssignOrg = true
@@ -145,8 +145,13 @@ func (c TestContext) createUser(cmd user.CreateUserCommand) {
 	usrSvc, err := userimpl.ProvideService(store, orgService, store.Cfg, nil, nil, quotaService, supportbundlestest.NewFakeBundleService())
 	require.NoError(c.t, err)
 
-	_, err = usrSvc.CreateUserForTests(context.Background(), &cmd)
+	user, err := usrSvc.CreateUserForTests(context.Background(), &cmd)
 	require.NoError(c.t, err)
+
+	return User{
+		User:     *user,
+		password: cmd.Password,
+	}
 }
 
 func (c TestContext) createDs(cmd *datasources.AddDataSourceCommand) *datasources.DataSource {

--- a/pkg/tests/api/correlations/correlations_create_test.go
+++ b/pkg/tests/api/correlations/correlations_create_test.go
@@ -21,31 +21,24 @@ func TestIntegrationCreateCorrelation(t *testing.T) {
 	}
 	ctx := NewTestEnv(t)
 
-	adminUser := User{
-		username: "admin",
-		password: "admin",
-	}
-	editorUser := User{
-		username: "editor",
-		password: "editor",
-	}
-
-	ctx.createUser(user.CreateUserCommand{
-		DefaultOrgRole: string(org.RoleEditor),
-		Password:       editorUser.password,
-		Login:          editorUser.username,
-	})
-	ctx.createUser(user.CreateUserCommand{
+	adminUser := ctx.createUser(user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
-		Password:       adminUser.password,
-		Login:          adminUser.username,
+		Password:       "admin",
+		Login:          "admin",
+	})
+
+	editorUser := ctx.createUser(user.CreateUserCommand{
+		DefaultOrgRole: string(org.RoleEditor),
+		Password:       "editor",
+		Login:          "editor",
+		OrgID:          adminUser.User.OrgID,
 	})
 
 	createDsCommand := &datasources.AddDataSourceCommand{
 		Name:     "read-only",
 		Type:     "loki",
 		ReadOnly: true,
-		OrgID:    1,
+		OrgID:    adminUser.User.OrgID,
 	}
 	dataSource := ctx.createDs(createDsCommand)
 	readOnlyDS := dataSource.UID
@@ -53,7 +46,7 @@ func TestIntegrationCreateCorrelation(t *testing.T) {
 	createDsCommand = &datasources.AddDataSourceCommand{
 		Name:  "writable",
 		Type:  "loki",
-		OrgID: 1,
+		OrgID: adminUser.User.OrgID,
 	}
 	dataSource = ctx.createDs(createDsCommand)
 	writableDs := dataSource.UID

--- a/pkg/tests/api/correlations/correlations_delete_test.go
+++ b/pkg/tests/api/correlations/correlations_delete_test.go
@@ -21,31 +21,24 @@ func TestIntegrationDeleteCorrelation(t *testing.T) {
 	}
 	ctx := NewTestEnv(t)
 
-	adminUser := User{
-		username: "admin",
-		password: "admin",
-	}
-	editorUser := User{
-		username: "editor",
-		password: "editor",
-	}
-
-	ctx.createUser(user.CreateUserCommand{
-		DefaultOrgRole: string(org.RoleEditor),
-		Password:       editorUser.password,
-		Login:          editorUser.username,
-	})
-	ctx.createUser(user.CreateUserCommand{
+	adminUser := ctx.createUser(user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
-		Password:       adminUser.password,
-		Login:          adminUser.username,
+		Password:       "admin",
+		Login:          "admin",
+	})
+
+	editorUser := ctx.createUser(user.CreateUserCommand{
+		DefaultOrgRole: string(org.RoleEditor),
+		Password:       "editor",
+		Login:          "editor",
+		OrgID:          adminUser.User.OrgID,
 	})
 
 	createDsCommand := &datasources.AddDataSourceCommand{
 		Name:     "read-only",
 		Type:     "loki",
 		ReadOnly: true,
-		OrgID:    1,
+		OrgID:    adminUser.User.OrgID,
 	}
 	dataSource := ctx.createDs(createDsCommand)
 	readOnlyDS := dataSource.UID
@@ -53,7 +46,7 @@ func TestIntegrationDeleteCorrelation(t *testing.T) {
 	createDsCommand = &datasources.AddDataSourceCommand{
 		Name:  "writable",
 		Type:  "loki",
-		OrgID: 1,
+		OrgID: adminUser.User.OrgID,
 	}
 	dataSource = ctx.createDs(createDsCommand)
 	writableDs := dataSource.UID

--- a/pkg/tests/api/correlations/correlations_read_test.go
+++ b/pkg/tests/api/correlations/correlations_read_test.go
@@ -23,24 +23,17 @@ func TestIntegrationReadCorrelation(t *testing.T) {
 	}
 	ctx := NewTestEnv(t)
 
-	adminUser := User{
-		username: "admin",
-		password: "admin",
-	}
-	viewerUser := User{
-		username: "viewer",
-		password: "viewer",
-	}
-
-	ctx.createUser(user.CreateUserCommand{
-		DefaultOrgRole: string(org.RoleViewer),
-		Password:       viewerUser.password,
-		Login:          viewerUser.username,
-	})
-	ctx.createUser(user.CreateUserCommand{
+	adminUser := ctx.createUser(user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
-		Password:       adminUser.password,
-		Login:          adminUser.username,
+		Password:       "admin",
+		Login:          "admin",
+	})
+
+	viewerUser := ctx.createUser(user.CreateUserCommand{
+		DefaultOrgRole: string(org.RoleViewer),
+		Password:       "viewer",
+		Login:          "viewer",
+		OrgID:          adminUser.User.OrgID,
 	})
 
 	t.Run("Get all correlations", func(t *testing.T) {

--- a/pkg/tests/api/correlations/correlations_update_test.go
+++ b/pkg/tests/api/correlations/correlations_update_test.go
@@ -21,31 +21,24 @@ func TestIntegrationUpdateCorrelation(t *testing.T) {
 	}
 	ctx := NewTestEnv(t)
 
-	adminUser := User{
-		username: "admin",
-		password: "admin",
-	}
-	editorUser := User{
-		username: "editor",
-		password: "editor",
-	}
-
-	ctx.createUser(user.CreateUserCommand{
-		DefaultOrgRole: string(org.RoleEditor),
-		Password:       editorUser.password,
-		Login:          editorUser.username,
-	})
-	ctx.createUser(user.CreateUserCommand{
+	adminUser := ctx.createUser(user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleAdmin),
-		Password:       adminUser.password,
-		Login:          adminUser.username,
+		Password:       "admin",
+		Login:          "admin",
+	})
+
+	editorUser := ctx.createUser(user.CreateUserCommand{
+		DefaultOrgRole: string(org.RoleEditor),
+		Password:       "editor",
+		Login:          "editor",
+		OrgID:          adminUser.User.OrgID,
 	})
 
 	createDsCommand := &datasources.AddDataSourceCommand{
 		Name:     "read-only",
 		Type:     "loki",
 		ReadOnly: true,
-		OrgID:    1,
+		OrgID:    adminUser.User.OrgID,
 	}
 	dataSource := ctx.createDs(createDsCommand)
 	readOnlyDS := dataSource.UID
@@ -53,7 +46,7 @@ func TestIntegrationUpdateCorrelation(t *testing.T) {
 	createDsCommand = &datasources.AddDataSourceCommand{
 		Name:  "writable",
 		Type:  "loki",
-		OrgID: 1,
+		OrgID: adminUser.User.OrgID,
 	}
 	dataSource = ctx.createDs(createDsCommand)
 	writableDs := dataSource.UID


### PR DESCRIPTION
Correlations tests are currently flaky due to hardcoded OrgIDs in generated requests.
This PR is an attempt to fix that by using instead the return value from the generated users on tests setup.
While what we did should have been mostly safe in an isolated env, this decouples the OrgID generation logic from the test itself in case - for instance - the created users' OrgId is different than 1 because of other tests running before this one, which should make the test more reliable. 

(hopefully) Fixes #63958 