### PR TITLE
Panel: Show multiple query errors

### DIFF
--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -7,7 +7,7 @@ import { selectors } from '@grafana/e2e-selectors';
 import { useStyles2, useTheme2 } from '../../themes';
 import { Icon } from '../Icon/Icon';
 import { LoadingBar } from '../LoadingBar/LoadingBar';
-import { Tooltip } from '../Tooltip';
+import { PopoverContent, Tooltip } from '../Tooltip';
 
 import { HoverWidget } from './HoverWidget';
 import { PanelDescription } from './PanelDescription';
@@ -39,7 +39,7 @@ export interface PanelChromeProps {
   /**
    * Used to display status message (used for panel errors currently)
    */
-  statusMessage?: string;
+  statusMessage?: PopoverContent;
   /**
    * Handle opening error details view (like inspect / error tab)
    */

--- a/packages/grafana-ui/src/components/PanelChrome/PanelStatus.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelStatus.tsx
@@ -5,10 +5,11 @@ import { GrafanaTheme2 } from '@grafana/data';
 
 import { useStyles2 } from '../../themes';
 import { ToolbarButton } from '../ToolbarButton/ToolbarButton';
+import { PopoverContent } from '../Tooltip';
 
 export interface Props {
   className?: string;
-  message?: string;
+  message?: PopoverContent;
   onClick?: (e: React.SyntheticEvent) => void;
   ariaLabel?: string;
 }

--- a/packages/grafana-ui/src/components/ToolbarButton/ToolbarButton.tsx
+++ b/packages/grafana-ui/src/components/ToolbarButton/ToolbarButton.tsx
@@ -9,7 +9,7 @@ import { getFocusStyles, getMouseFocusStyles } from '../../themes/mixins';
 import { IconSize } from '../../types/icon';
 import { getPropertiesForVariant } from '../Button';
 import { Icon } from '../Icon/Icon';
-import { Tooltip } from '../Tooltip';
+import { PopoverContent, Tooltip } from '../Tooltip';
 
 type CommonProps = {
   /** Icon name */
@@ -17,7 +17,7 @@ type CommonProps = {
   /** Icon size */
   iconSize?: IconSize;
   /** Tooltip */
-  tooltip?: string;
+  tooltip?: PopoverContent;
   /** For image icons */
   imgSrc?: string;
   /** Alt text for imgSrc */
@@ -108,8 +108,12 @@ export const ToolbarButton = forwardRef<HTMLButtonElement, ToolbarButtonProps>(
 
 ToolbarButton.displayName = 'ToolbarButton';
 
-function getButtonAriaLabel(ariaLabel: string | undefined, tooltip: string | undefined) {
-  return ariaLabel ? ariaLabel : tooltip ? selectors.components.PageToolbar.item(tooltip) : undefined;
+function getButtonAriaLabel(ariaLabel: string | undefined, tooltip?: PopoverContent) {
+  return ariaLabel
+    ? ariaLabel
+    : typeof tooltip === 'string'
+    ? selectors.components.PageToolbar.item(tooltip)
+    : undefined;
 }
 
 function renderIcon(icon: IconName | React.ReactNode, iconSize?: IconSize) {

--- a/public/app/features/dashboard/components/PanelEditor/PanelEditorTableView.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelEditorTableView.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useState } from 'react';
 
+import { PanelData } from '@grafana/data';
 import { RefreshEvent } from '@grafana/runtime';
-import { PanelChrome } from '@grafana/ui';
+import { PanelChrome, PopoverContent } from '@grafana/ui';
 import { applyPanelTimeOverrides } from 'app/features/dashboard/utils/panel';
 import { PanelRenderer } from 'app/features/panel/components/PanelRenderer';
 import { PanelOptions } from 'app/plugins/panel/table/panelcfg.gen';
@@ -17,6 +18,28 @@ export interface Props {
   height: number;
   panel: PanelModel;
   dashboard: DashboardModel;
+}
+
+export function panelError(data: PanelData) {
+  let errorMessage: PopoverContent | undefined = undefined;
+  const { error, errors } = data;
+  if (errors?.length) {
+    if (errors.length > 1) {
+      errorMessage = (
+        <>
+          <b>Multiple errors found:</b>
+          {errors.map((e, i) => (
+            <li key={`query-error-${i}`}>{e.message}</li>
+          ))}
+        </>
+      );
+    } else {
+      errorMessage = errors[0].message;
+    }
+  } else if (error) {
+    errorMessage = error.message;
+  }
+  return errorMessage;
 }
 
 export function PanelEditorTableView({ width, height, panel, dashboard }: Props) {
@@ -53,7 +76,7 @@ export function PanelEditorTableView({ width, height, panel, dashboard }: Props)
     <PanelChrome width={width} height={height} padding="none">
       {(innerWidth, innerHeight) => (
         <>
-          <PanelHeaderCorner panel={panel} error={data?.error?.message} />
+          <PanelHeaderCorner panel={panel} error={panelError(data)} />
           <PanelRenderer
             title="Raw data"
             pluginId="table"

--- a/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeader.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeader.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import { DataLink, GrafanaTheme2, PanelData } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
-import { Icon, useStyles2, ClickOutsideWrapper } from '@grafana/ui';
+import { Icon, useStyles2, ClickOutsideWrapper, PopoverContent } from '@grafana/ui';
 import { DashboardModel } from 'app/features/dashboard/state/DashboardModel';
 import { PanelModel } from 'app/features/dashboard/state/PanelModel';
 import { getPanelLinksSupplier } from 'app/features/panel/panellinks/linkSuppliers';
@@ -20,7 +20,7 @@ export interface Props {
   title?: string;
   description?: string;
   links?: DataLink[];
-  error?: string;
+  error?: PopoverContent;
   alertState?: string;
   isViewing: boolean;
   isEditing: boolean;

--- a/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeaderCorner.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeaderCorner.tsx
@@ -20,7 +20,7 @@ export interface Props {
   description?: string;
   scopedVars?: ScopedVars;
   links?: LinkModelSupplier<PanelModel>;
-  error?: string;
+  error?: PopoverContent;
 }
 
 export class PanelHeaderCorner extends Component<Props> {

--- a/public/app/features/dashboard/dashgrid/PanelStateWrapper.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelStateWrapper.tsx
@@ -34,6 +34,7 @@ import {
   PanelPadding,
   SeriesVisibilityChangeMode,
   AdHocFilterItem,
+  PopoverContent,
 } from '@grafana/ui';
 import { PANEL_BORDER } from 'app/core/constants';
 import { profiler } from 'app/core/profiler';
@@ -49,6 +50,7 @@ import { RenderEvent } from 'app/types/events';
 import { isSoloRoute } from '../../../routes/utils';
 import { deleteAnnotation, saveAnnotation, updateAnnotation } from '../../annotations/api';
 import { getDashboardQueryRunner } from '../../query/state/DashboardQueryRunner/DashboardQueryRunner';
+import { panelError } from '../components/PanelEditor/PanelEditorTableView';
 import { getTimeSrv, TimeSrv } from '../services/TimeSrv';
 import { DashboardModel, PanelModel } from '../state';
 import { loadSnapshotData } from '../utils/loadSnapshotData';
@@ -78,7 +80,7 @@ export interface Props {
 export interface State {
   isFirstLoad: boolean;
   renderCounter: number;
-  errorMessage?: string;
+  errorMessage?: PopoverContent;
   refreshWhenInView: boolean;
   context: PanelContext;
   data: PanelData;
@@ -289,7 +291,7 @@ export class PanelStateWrapper extends PureComponent<Props, State> {
     }
 
     let { isFirstLoad } = this.state;
-    let errorMessage: string | undefined;
+    let errorMessage: PopoverContent | undefined;
 
     switch (data.state) {
       case LoadingState.Loading:
@@ -300,13 +302,7 @@ export class PanelStateWrapper extends PureComponent<Props, State> {
         }
         break;
       case LoadingState.Error:
-        const { error } = data;
-        if (error) {
-          if (errorMessage !== error.message) {
-            errorMessage = error.message;
-          }
-        }
-        break;
+        errorMessage = panelError(data);
       case LoadingState.Done:
         // If we are doing a snapshot save data in panel model
         if (dashboard.snapshot) {

--- a/public/app/features/dashboard/dashgrid/PanelStateWrapper.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelStateWrapper.tsx
@@ -303,6 +303,7 @@ export class PanelStateWrapper extends PureComponent<Props, State> {
         break;
       case LoadingState.Error:
         errorMessage = panelError(data);
+        break;
       case LoadingState.Done:
         // If we are doing a snapshot save data in panel model
         if (dashboard.snapshot) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Show all query errors (as a list) if there are multiple of them.

Before (only shows the first error):

![Screenshot from 2023-03-02 13-23-19](https://user-images.githubusercontent.com/4025665/222428134-758a8eca-46e3-41d0-a7b8-4bdcafe0a4ce.png)

Now:

![Screenshot from 2023-03-02 12-27-38](https://user-images.githubusercontent.com/4025665/222428324-44901acb-6286-43cc-af59-051caca57fe0.png)

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #54665

**Special notes for your reviewer**:

Happy to hear any feedback related to the format or the wording.