### PR TITLE
Alerting: Avoid printing [object][Object] in error message

### DIFF
--- a/public/app/features/alerting/unified/Analytics.ts
+++ b/public/app/features/alerting/unified/Analytics.ts
@@ -14,6 +14,7 @@ export const LogMessages = {
   clickingAlertStateFilters: 'clicking alert state filters',
   cancelSavingAlertRule: 'user canceled alert rule creation',
   successSavingAlertRule: 'alert rule saved successfully',
+  unknownMessageFromError: 'unknown messageFromError',
 };
 
 // logInfo from '@grafana/runtime' should be used, but it doesn't handle Grafana JS Agent and Sentry correctly

--- a/public/app/features/alerting/unified/utils/messageFromError.test.ts
+++ b/public/app/features/alerting/unified/utils/messageFromError.test.ts
@@ -1,0 +1,35 @@
+import { FetchError } from '@grafana/runtime';
+
+import { messageFromError, UNKNOW_ERROR } from './redux';
+
+describe('messageFromError method', () => {
+  it('should return UNKNOW_ERROR message when error is an object and not having neither in the e.data.message and nor in e.message', () => {
+    const error: FetchError = {
+      config: {
+        url: '',
+      },
+      data: { message: '', error: '', response: '' },
+      status: 502,
+      statusText: '',
+    };
+
+    expect(messageFromError(error)).toBe(UNKNOW_ERROR);
+  });
+  it('should return correct message in case of having message info in the e object (in e.data.message or in e.message)', () => {
+    const error: FetchError = {
+      config: {
+        url: '',
+      },
+      data: { message: 'BLA BLA', error: 'this is the error', response: '' },
+      status: 502,
+      statusText: 'BLu BLu',
+    };
+    expect(messageFromError(error)).toBe('BLA BLA; this is the error');
+
+    const error2: Error = {
+      name: 'bla bla',
+      message: 'THIS IS THE MESSAGE ERROR',
+    };
+    expect(messageFromError(error2)).toBe('THIS IS THE MESSAGE ERROR');
+  });
+});

--- a/public/app/features/alerting/unified/utils/redux.ts
+++ b/public/app/features/alerting/unified/utils/redux.ts
@@ -4,6 +4,8 @@ import { AppEvents } from '@grafana/data';
 import { FetchError, isFetchError } from '@grafana/runtime';
 import { appEvents } from 'app/core/core';
 
+import { logInfo, LogMessages } from '../Analytics';
+
 export interface AsyncRequestState<T> {
   result?: T;
   loading: boolean;
@@ -137,6 +139,7 @@ export function withAppEvents<T>(
     });
 }
 
+export const UNKNOW_ERROR = 'Unknown Error';
 export function messageFromError(e: Error | FetchError | SerializedError): string {
   if (isFetchError(e)) {
     if (e.data?.message) {
@@ -154,7 +157,15 @@ export function messageFromError(e: Error | FetchError | SerializedError): strin
       return e.statusText;
     }
   }
-  return (e as Error)?.message || String(e);
+  // message in e object, return message
+  const errorMessage = (e as Error)?.message;
+  if (errorMessage) {
+    return errorMessage;
+  }
+  // for some reason (upstream this code), sometimes we get an object without the message field neither in the e.data and nor in e.message
+  // in this case we want to avoid String(e) printing [object][object]
+  logInfo(LogMessages.unknownMessageFromError, { error: JSON.stringify(e) });
+  return UNKNOW_ERROR;
 }
 
 export function isAsyncRequestMapSliceSettled<T>(slice: AsyncRequestMapSlice<T>): boolean {


### PR DESCRIPTION
**What is this feature?**

When a user creates a Prometheus or Loki datasource without specifying a URL and then goes to the alert list page, an error toast for these datasources shows up.

This PR fixes Error message printing [object][Object]. See issue related in [here](https://github.com/grafana/grafana/issues/41553) 

**Why do we need this feature?**

 [object][Object] is wrong message for an error.

**Who is this feature for?**

All users.
**Which issue(s) does this PR fix?**:

Fix partially this [issue](https://github.com/grafana/grafana/issues/41553)

**Special notes for your reviewer**:

After some investigation, for some reason (upstream this code), sometimes we get an object without the message field neither in the e.data and nor in e.message. In this case String(e) was rendered as [object][object]
As it seems it's not clear why the fetch is returning different information, we think that the best way to fix that problem is rendering a 'Unknown error' instead of [object][Object]

I could only reproduce it in production using Chrome (in FireFox it's not happening)

Chrome:

<img width="576" alt="Screenshot 2023-03-02 at 13 39 12" src="https://user-images.githubusercontent.com/33540275/222431262-8f96d930-daf5-40bd-ac83-7af9f5973192.png">

Firefox:
<img width="655" alt="Screenshot 2023-03-02 at 13 38 54" src="https://user-images.githubusercontent.com/33540275/222431359-48dca581-96cf-42bd-874e-9c6ffc9efa6d.png">




