### PR TITLE
Explore: Use DS picker drawer when drawerDataSourcePicker is enabled

### DIFF
--- a/public/app/features/explore/ExploreToolbar.tsx
+++ b/public/app/features/explore/ExploreToolbar.tsx
@@ -14,6 +14,7 @@ import { StoreState } from 'app/types/store';
 
 import { DashNavButton } from '../dashboard/components/DashNav/DashNavButton';
 import { getTimeSrv } from '../dashboard/services/TimeSrv';
+import { DataSourcePickerWithHistory } from '../datasource-drawer/DataSourcePickerWithHistory';
 import { updateFiscalYearStartMonthForSession, updateTimeZoneForSession } from '../profile/state/reducers';
 import { getFiscalYearStartMonth, getTimeZone } from '../profile/state/selectors';
 
@@ -256,7 +257,18 @@ class UnConnectedExploreToolbar extends PureComponent<Props> {
     );
 
     const getDataSourcePicker = () =>
-      !datasourceMissing && (
+      !datasourceMissing &&
+      (config.featureToggles.drawerDataSourcePicker ? (
+        <DataSourcePickerWithHistory
+          key={`${exploreId}-ds-picker`}
+          onChange={this.onChangeDatasource}
+          current={this.props.datasourceRef}
+          mixed={config.featureToggles.exploreMixedDatasource === true}
+          metrics
+          logs
+          tracing
+        />
+      ) : (
         <DataSourcePicker
           key={`${exploreId}-ds-picker`}
           mixed={config.featureToggles.exploreMixedDatasource === true}
@@ -265,7 +277,7 @@ class UnConnectedExploreToolbar extends PureComponent<Props> {
           hideTextValue={showSmallDataSourcePicker}
           width={showSmallDataSourcePicker ? 8 : undefined}
         />
-      );
+      ));
 
     const toolbarLeftItems = [
       // We only want to show the shortened link button in the left Toolbar if topnav is not enabled as with topnav enabled it sits next to the brecrumbs
@@ -304,7 +316,7 @@ const mapStateToProps = (state: StoreState, { exploreId }: OwnProps) => {
 
   return {
     datasourceMissing,
-    datasourceRef: datasourceInstance?.getRef(),
+    datasourceRef: datasourceInstance?.getRef() || null,
     datasourceType: datasourceInstance?.type,
     loading,
     range,


### PR DESCRIPTION
Following what dashboard is doing with the DS picker, this PR enables the drawer picker in Explore when `drawerDataSourcePicker` is enabled.

dashboard: 
![image](https://user-images.githubusercontent.com/1170767/222432917-3e72a4b2-1a18-43aa-98c9-164cb74ac7ca.png)

Drawer DS picker in action in Explore:

https://user-images.githubusercontent.com/1170767/222433327-89e2f99d-356b-423d-837a-13a8ab9f55f4.mov


How to test this?

enable `drawerDataSourcePicker` feature toggle:
```ini
# conf/custom.ini
[feature_toggles]
enable =  drawerDataSourcePicker
```


