### PR TITLE
Fix scenario where tooltip shows wrong value

### DIFF
--- a/public/app/plugins/panel/barchart/BarChartPanel.tsx
+++ b/public/app/plugins/panel/barchart/BarChartPanel.tsx
@@ -173,7 +173,7 @@ export const BarChartPanel: React.FunctionComponent<Props> = ({
     const tooltipMode =
       options.fullHighlight && options.stacking !== StackingMode.None ? TooltipDisplayMode.Multi : options.tooltip.mode;
 
-    const tooltipSort = options.tooltip.mode === TooltipDisplayMode.Single ? SortOrder.None : options.tooltip.sort;
+    const tooltipSort = options.tooltip.mode === TooltipDisplayMode.Multi ? options.tooltip.sort : SortOrder.None;
 
     return (
       <>

--- a/public/app/plugins/panel/barchart/BarChartPanel.tsx
+++ b/public/app/plugins/panel/barchart/BarChartPanel.tsx
@@ -13,6 +13,7 @@ import {
   VizOrientation,
 } from '@grafana/data';
 import { PanelDataErrorView } from '@grafana/runtime';
+import { SortOrder } from '@grafana/schema';
 import {
   GraphGradientMode,
   GraphNG,
@@ -172,6 +173,8 @@ export const BarChartPanel: React.FunctionComponent<Props> = ({
     const tooltipMode =
       options.fullHighlight && options.stacking !== StackingMode.None ? TooltipDisplayMode.Multi : options.tooltip.mode;
 
+    const tooltipSort = options.tooltip.mode === TooltipDisplayMode.Single ? SortOrder.None : options.tooltip.sort;
+
     return (
       <>
         {shouldDisplayCloseButton && (
@@ -197,7 +200,7 @@ export const BarChartPanel: React.FunctionComponent<Props> = ({
           data={info.aligned}
           rowIndex={datapointIdx}
           columnIndex={seriesIdx}
-          sortOrder={options.tooltip.sort}
+          sortOrder={tooltipSort}
           mode={tooltipMode}
         />
       </>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Fixes a bug discussed [here](https://github.com/grafana/grafana/issues/52329) where the tooltip sort order would remain set and affect the shown tooltip value even when the tooltip mode was set to `single`

**Why do we need this feature?**

To show the proper tooltip value when tooltip mode single

**Who is this feature for?**

Everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #52329

**Special notes for your reviewer**:

