### PR TITLE
Plugins: Allow command extensions to open modals

### DIFF
--- a/packages/grafana-data/src/types/app.ts
+++ b/packages/grafana-data/src/types/app.ts
@@ -56,6 +56,17 @@ export interface AppPluginMeta<T extends KeyValue = KeyValue> extends PluginMeta
  */
 export type AppPluginExtensionLink = Pick<PluginExtensionLink, 'description' | 'path' | 'title'>;
 
+// A list of helpers that can be used in the command handler
+export type AppPluginExtensionCommandHelpers = {
+  // Opens a modal dialog and renders the provided React component inside it
+  openModal: (options: {
+    // The title of the modal
+    title: string;
+    // A React element that will be rendered inside the modal
+    body: React.ElementType<{ onDismiss?: () => void }>;
+  }) => void;
+};
+
 export type AppPluginExtensionCommand = Pick<PluginExtensionCommand, 'description' | 'title'>;
 
 export type AppPluginExtensionLinkConfig<C extends object = object> = {
@@ -70,7 +81,7 @@ export type AppPluginExtensionCommandConfig<C extends object = object> = {
   title: string;
   description: string;
   placement: string;
-  handler: (context?: C) => void;
+  handler: (context?: C, helpers?: AppPluginExtensionCommandHelpers) => void;
   configure?: (extension: AppPluginExtensionCommand, context?: C) => Partial<AppPluginExtensionCommand> | undefined;
 };
 

--- a/public/app/features/plugins/extensions/getModalWrapper.tsx
+++ b/public/app/features/plugins/extensions/getModalWrapper.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+import { AppPluginExtensionCommandHelpers } from '@grafana/data';
+import { Modal } from '@grafana/ui';
+
+export type ModalWrapperProps = {
+  onDismiss: () => void;
+};
+
+// Wraps a component with a modal.
+// This way we can make sure that the modal is closable, and we also make the usage simpler.
+export const getModalWrapper = ({
+  // The title of the modal (appears in the header)
+  title,
+  // A component that serves the body of the modal
+  body: Body,
+}: Parameters<AppPluginExtensionCommandHelpers['openModal']>[0]) => {
+  const ModalWrapper = ({ onDismiss }: ModalWrapperProps) => {
+    return (
+      <Modal title={title} isOpen onDismiss={onDismiss} onClickBackdrop={onDismiss}>
+        <Body onDismiss={onDismiss} />
+      </Modal>
+    );
+  };
+
+  return ModalWrapper;
+};


### PR DESCRIPTION
**Related EPIC:** https://github.com/grafana/grafana/issues/61658

### What changed?
Enable plugin authors to open modals from commands.
- [x] Make functionality work
- [x] Add tests 

https://user-images.githubusercontent.com/9974811/222685662-81ba48c0-e841-48db-bc6b-9c5ca1e63d01.mov



### How to use?
```javascript
// OPENING THE MODAL (with the component below)
{
  handler: ({ context, helpers }) => {
    helpers.openModal({ title: "My Modal", body: MyComponent });
  }
}


// MODAL BODY
type Props = {
  onDismiss: () => void;
};

function MyComponent({ onDismiss }: Props) {
  return (
    <div>
      <div onClick={onDismiss}>Close</div>
      <div>{message}</div>
    </div>
  );
}

// ...

```


