### PR TITLE
Build: add the security-extended query suite

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -55,6 +55,7 @@ jobs:
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
+        queries: security-extended
 
     - if: matrix.language == 'go'
       name: Build go files


### PR DESCRIPTION
Adds the "security-extended" query suite to the CodeQL workflow. 

Read more: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/about-code-scanning-alerts#enabling-experimental-alerts