### PR TITLE
Loki: Add descriptions to query builder operations

### DIFF
--- a/public/app/plugins/datasource/loki/querybuilder/operations.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/operations.ts
@@ -352,7 +352,15 @@ Example: \`\`error_level=\`level\` \`\`
       id: LokiOperationId.LineFilterIpMatches,
       name: 'IP line filter expression',
       params: [
-        { name: 'Operator', type: 'string', options: ['|=', '!='] },
+        {
+          name: 'Operator',
+          type: 'string',
+          minWidth: 16,
+          options: [
+            { label: '|=', value: '|=', description: 'Contains' },
+            { label: '!=', value: '!=', description: 'Does not contain' },
+          ],
+        },
         {
           name: 'Pattern',
           type: 'string',
@@ -373,9 +381,23 @@ Example: \`\`error_level=\`level\` \`\`
       id: LokiOperationId.LabelFilter,
       name: 'Label filter expression',
       params: [
-        { name: 'Label', type: 'string' },
-        { name: 'Operator', type: 'string', options: ['=', '!=', ' =~', '!~', '>', '<', '>=', '<='] },
-        { name: 'Value', type: 'string' },
+        { name: 'Label', type: 'string', minWidth: 14 },
+        {
+          name: 'Operator',
+          type: 'string',
+          minWidth: 14,
+          options: [
+            { label: '=', value: '=', description: 'Equals' },
+            { label: '!=', value: '!=', description: 'Does not equal' },
+            { label: '=~', value: '=~', description: 'Matches regex' },
+            { label: '!~', value: '!~', description: 'Does not match regex' },
+            { label: '>', value: '>', description: 'Greater than' },
+            { label: '<', value: '<', description: 'Less than' },
+            { label: '>=', value: '>=', description: 'Greater than or equal to' },
+            { label: '<=', value: '<=', description: 'Less than or equal to' },
+          ],
+        },
+        { name: 'Value', type: 'string', minWidth: 14 },
       ],
       defaultParams: ['', '=', ''],
       alternativesKey: 'label filter',
@@ -389,9 +411,17 @@ Example: \`\`error_level=\`level\` \`\`
       id: LokiOperationId.LabelFilterIpMatches,
       name: 'IP label filter expression',
       params: [
-        { name: 'Label', type: 'string' },
-        { name: 'Operator', type: 'string', options: ['=', '!='] },
-        { name: 'Value', type: 'string' },
+        { name: 'Label', type: 'string', minWidth: 14 },
+        {
+          name: 'Operator',
+          type: 'string',
+          minWidth: 14,
+          options: [
+            { label: '=', value: '=', description: 'Equals' },
+            { label: '!=', value: '!=', description: 'Does not equal' },
+          ],
+        },
+        { name: 'Value', type: 'string', minWidth: 14 },
       ],
       defaultParams: ['', '=', ''],
       alternativesKey: 'label filter',

--- a/public/app/plugins/datasource/loki/querybuilder/operations.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/operations.ts
@@ -15,7 +15,7 @@ import {
   labelFilterRenderer,
   pipelineRenderer,
 } from './operationUtils';
-import { LokiOperationId, LokiOperationOrder, LokiVisualQueryOperationCategory } from './types';
+import { LokiOperationId, LokiOperationOrder, lokiOperators, LokiVisualQueryOperationCategory } from './types';
 
 export function getOperationDefinitions(): QueryBuilderOperationDef[] {
   const aggregations = [
@@ -356,10 +356,7 @@ Example: \`\`error_level=\`level\` \`\`
           name: 'Operator',
           type: 'string',
           minWidth: 16,
-          options: [
-            { label: '|=', value: '|=', description: 'Contains' },
-            { label: '!=', value: '!=', description: 'Does not contain' },
-          ],
+          options: [lokiOperators.contains, lokiOperators.doesNotContain],
         },
         {
           name: 'Pattern',
@@ -387,14 +384,14 @@ Example: \`\`error_level=\`level\` \`\`
           type: 'string',
           minWidth: 14,
           options: [
-            { label: '=', value: '=', description: 'Equals' },
-            { label: '!=', value: '!=', description: 'Does not equal' },
-            { label: '=~', value: '=~', description: 'Matches regex' },
-            { label: '!~', value: '!~', description: 'Does not match regex' },
-            { label: '>', value: '>', description: 'Greater than' },
-            { label: '<', value: '<', description: 'Less than' },
-            { label: '>=', value: '>=', description: 'Greater than or equal to' },
-            { label: '<=', value: '<=', description: 'Less than or equal to' },
+            lokiOperators.equals,
+            lokiOperators.doesNotEqual,
+            lokiOperators.matchesRegex,
+            lokiOperators.doesNotMatchRegex,
+            lokiOperators.greaterThan,
+            lokiOperators.lessThan,
+            lokiOperators.greaterThanOrEqual,
+            lokiOperators.lessThanOrEqual,
           ],
         },
         { name: 'Value', type: 'string', minWidth: 14 },
@@ -416,10 +413,7 @@ Example: \`\`error_level=\`level\` \`\`
           name: 'Operator',
           type: 'string',
           minWidth: 14,
-          options: [
-            { label: '=', value: '=', description: 'Equals' },
-            { label: '!=', value: '!=', description: 'Does not equal' },
-          ],
+          options: [lokiOperators.equals, lokiOperators.doesNotEqual],
         },
         { name: 'Value', type: 'string', minWidth: 14 },
       ],

--- a/public/app/plugins/datasource/loki/querybuilder/types.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/types.ts
@@ -102,3 +102,16 @@ export enum LokiOperationOrder {
   RangeVectorFunction = 5,
   Last = 6,
 }
+
+export const lokiOperators = {
+  equals: { label: '=', value: '=', description: 'Equals', isMultiValue: false },
+  doesNotEqual: { label: '!=', value: '!=', description: 'Does not equal', isMultiValue: false },
+  matchesRegex: { label: '=~', value: '=~', description: 'Matches regex', isMultiValue: true },
+  doesNotMatchRegex: { label: '!~', value: '!~', description: 'Does not match regex', isMultiValue: true },
+  greaterThan: { label: '>', value: '>', description: 'Greater than', isMultiValue: false },
+  greaterThanOrEqual: { label: '>=', value: '>=', description: 'Greater than or equal to', isMultiValue: false },
+  lessThan: { label: '<', value: '<', description: 'Less than', isMultiValue: false },
+  lessThanOrEqual: { label: '<=', value: '<=', description: 'Less than or equal to', isMultiValue: false },
+  contains: { label: '|=', value: '|=', description: 'Contains', isMultiValue: false },
+  doesNotContain: { label: '!=', value: '!=', description: 'Does not contain', isMultiValue: false },
+};

--- a/public/app/plugins/datasource/prometheus/querybuilder/shared/LabelFilterItem.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/shared/LabelFilterItem.tsx
@@ -99,7 +99,7 @@ export function LabelFilterItem({
             aria-label={selectors.components.QueryBuilder.matchOperatorSelect}
             value={toOption(item.op ?? defaultOp)}
             options={operators}
-            width={14}
+            width="auto"
             onChange={(change) => {
               if (change.value != null) {
                 onChange({

--- a/public/app/plugins/datasource/prometheus/querybuilder/shared/LabelFilterItem.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/shared/LabelFilterItem.tsx
@@ -5,6 +5,7 @@ import { SelectableValue, toOption } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { AccessoryButton, InputGroup } from '@grafana/experimental';
 import { InlineField, Select } from '@grafana/ui';
+import { lokiOperators } from 'app/plugins/datasource/loki/querybuilder/types';
 
 import { isConflictingSelector } from './operationUtils';
 import { QueryBuilderLabelFilter } from './types';
@@ -160,8 +161,8 @@ export function LabelFilterItem({
 }
 
 const operators = [
-  { label: '=', value: '=', description: 'Equals', isMultiValue: false },
-  { label: '=~', value: '=~', description: 'Matches regex', isMultiValue: true },
-  { label: '!=', value: '!=', description: 'Does not equal', isMultiValue: false },
-  { label: '!~', value: '!~', description: 'Does not match regex', isMultiValue: true },
+  lokiOperators.equals,
+  lokiOperators.doesNotEqual,
+  lokiOperators.matchesRegex,
+  lokiOperators.doesNotMatchRegex,
 ];

--- a/public/app/plugins/datasource/prometheus/querybuilder/shared/LabelFilterItem.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/shared/LabelFilterItem.tsx
@@ -98,7 +98,7 @@ export function LabelFilterItem({
             aria-label={selectors.components.QueryBuilder.matchOperatorSelect}
             value={toOption(item.op ?? defaultOp)}
             options={operators}
-            width="auto"
+            width={14}
             onChange={(change) => {
               if (change.value != null) {
                 onChange({
@@ -160,8 +160,8 @@ export function LabelFilterItem({
 }
 
 const operators = [
-  { label: '=~', value: '=~', isMultiValue: true },
-  { label: '=', value: '=', isMultiValue: false },
-  { label: '!=', value: '!=', isMultiValue: false },
-  { label: '!~', value: '!~', isMultiValue: true },
+  { label: '=', value: '=', description: 'Equals', isMultiValue: false },
+  { label: '=~', value: '=~', description: 'Matches regex', isMultiValue: true },
+  { label: '!=', value: '!=', description: 'Does not equal', isMultiValue: false },
+  { label: '!~', value: '!~', description: 'Does not match regex', isMultiValue: true },
 ];

--- a/public/app/plugins/datasource/prometheus/querybuilder/shared/OperationEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/shared/OperationEditor.tsx
@@ -147,7 +147,7 @@ export function OperationEditor({
         <InlineField
           error={'You have conflicting label filters'}
           invalid={isInvalid(snapshot.isDragging)}
-          className={styles.error}
+          className={cx(styles.error, styles.cardWrapper)}
         >
           <div
             className={cx(
@@ -245,6 +245,9 @@ function callParamChangedThenOnChange(
 
 const getStyles = (theme: GrafanaTheme2) => {
   return {
+    cardWrapper: css({
+      alignItems: 'stretch',
+    }),
     error: css({
       marginBottom: theme.spacing(1),
     }),
@@ -258,6 +261,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       marginBottom: theme.spacing(1),
       position: 'relative',
       transition: 'all 0.5s ease-in 0s',
+      height: '100%',
     }),
     cardError: css({
       boxShadow: `0px 0px 4px 0px ${theme.colors.warning.main}`,

--- a/public/app/plugins/datasource/prometheus/querybuilder/shared/OperationParamEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/shared/OperationParamEditor.tsx
@@ -105,6 +105,7 @@ function SelectInputParamEditor({
         placeholder={paramDef.placeholder}
         allowCustomValue={true}
         onChange={(value) => onChange(index, value.value!)}
+        width={paramDef.minWidth || 'auto'}
       />
       {paramDef.optional && (
         <Button


### PR DESCRIPTION
**What is this feature?**
adds descriptions to all operators in loki query builder
`= Equals` `!= Does not equal` `...`

there is also a visual bug fix i found whilst working on this feature.

**Why do we need this feature?**
new users to loki and logql may not know what the operators mean, for example:
`=~` or `|=`

**Who is this feature for?**
...

**Which issue(s) does this PR fix?**:
Fixes #63922

**Special notes for your reviewer**:
```
to test:
- paste the following query into the loki ds
- go back to the builder mode
- check all operators have appropriate descriptions

{compose_project=“tns-custom”} |= ip(`123`) | abc = `123` | abc = ip(`123`)
```

**feature (before & after)**
<div>
<img width="246" alt="Screenshot 2023-03-02 at 15 48 50" src="https://user-images.githubusercontent.com/34524710/222478751-10f5f501-61ef-4d13-b7f7-b254c435494e.png">

<img width="244" alt="Screenshot 2023-03-02 at 15 48 14" src="https://user-images.githubusercontent.com/34524710/222478817-a3f25ed3-7f8e-46c0-8ce4-9742c1f99484.png">
</div>

**bug fix (before & after)**
<div>
<img width="49%" alt="Screenshot 2023-03-02 at 15 50 09" src="https://user-images.githubusercontent.com/34524710/222479425-81741171-3e70-45ea-8a9b-b8e7341144ab.png">

<img width="49%" alt="Screenshot 2023-03-02 at 15 50 40" src="https://user-images.githubusercontent.com/34524710/222479484-96e50437-5adc-47a8-9327-e8f9754d3575.png">
</div>