### PR TITLE
Range Splitting: Process instant queries as an independent query group

### DIFF
--- a/public/app/plugins/datasource/loki/querySplitting.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.ts
@@ -109,7 +109,7 @@ export function runGroupedQueries(datasource: LokiDatasource, requests: LokiGrou
 
     const nextRequest = () => {
       const { nextRequestN, nextRequestGroup } = getNextRequestPointers(requests, requestGroup, requestN);
-      if (nextRequestN > 0) {
+      if (nextRequestN > 0 && nextRequestGroup >= 0) {
         runNextRequest(subscriber, nextRequestN, nextRequestGroup);
         return;
       }
@@ -167,7 +167,8 @@ function getNextRequestPointers(requests: LokiGroupedRequest, requestGroup: numb
     };
   }
   return {
-    nextRequestGroup: 0,
+    // Find the first group where `[requestN - 1]` is defined
+    nextRequestGroup: requests.findIndex((group) => group?.partition[requestN - 1] !== undefined),
     nextRequestN: requestN - 1,
   };
 }

--- a/public/app/plugins/datasource/loki/queryUtils.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.ts
@@ -310,11 +310,6 @@ export function requestSupportsPartitioning(allQueries: LokiQuery[]) {
     .filter((query) => !query.refId.includes('do-not-chunk'))
     .filter((query) => query.expr);
 
-  const instantQueries = queries.some((query) => query.queryType === LokiQueryType.Instant);
-  if (instantQueries) {
-    return false;
-  }
-
   return queries.length > 0;
 }
 


### PR DESCRIPTION
This PR is a follow up to https://github.com/grafana/grafana/pull/63663, where we add instant queries as another group, with its own type of time range, which is the original one, without splitting.

This allows users to send instant queries along with other queries when working with multiple queries.

Additionally, this PR fixes a potential bug where if the first group had a different partition size it could cause an error state in the code by trying to access an undefined array member.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana/issues/61768

**Special notes for your reviewer**:

Add multiple queries, include an instant query. Metric and logs queries should be partitioned in 1 day chunks, while instant queries use the original unsplit time range.

Note that there's currently a bug when sending instant + logs queries, which causes the results from instant queries to not be shown: https://github.com/grafana/grafana/issues/64036