### PR TITLE
Range Splitting: ignore empty queries from splitting and fix result resetting

### DIFF
--- a/public/app/plugins/datasource/loki/queryUtils.test.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.test.ts
@@ -13,6 +13,7 @@ import {
   obfuscate,
   combineResponses,
   cloneQueryResponse,
+  requestSupportsPartitioning,
 } from './queryUtils';
 import { LokiQuery, LokiQueryType } from './types';
 
@@ -521,5 +522,49 @@ describe('combineResponses', () => {
       const responseB = makeResponse();
       expect(combineResponses(responseA, responseB).data[0].meta.stats).toHaveLength(0);
     });
+  });
+});
+
+describe('requestSupportsPartitioning', () => {
+  it('hidden requests are not partitioned', () => {
+    const requests: LokiQuery[] = [
+      {
+        expr: '{a="b"}',
+        refId: 'A',
+        hide: true,
+      },
+    ];
+    expect(requestSupportsPartitioning(requests)).toBe(false);
+  });
+  it('special requests are not partitioned', () => {
+    const requests: LokiQuery[] = [
+      {
+        expr: '{a="b"}',
+        refId: 'do-not-chunk',
+      },
+    ];
+    expect(requestSupportsPartitioning(requests)).toBe(false);
+  });
+  it('empty requests are not partitioned', () => {
+    const requests: LokiQuery[] = [
+      {
+        expr: '',
+        refId: 'A',
+      },
+    ];
+    expect(requestSupportsPartitioning(requests)).toBe(false);
+  });
+  it('all other requests are partitioned', () => {
+    const requests: LokiQuery[] = [
+      {
+        expr: '{a="b"}',
+        refId: 'A',
+      },
+      {
+        expr: 'count_over_time({a="b"}[1h])',
+        refId: 'B',
+      },
+    ];
+    expect(requestSupportsPartitioning(requests)).toBe(true);
   });
 });

--- a/public/app/plugins/datasource/loki/queryUtils.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.ts
@@ -305,7 +305,10 @@ export function getStreamSelectorsFromQuery(query: string): string[] {
 }
 
 export function requestSupportsPartitioning(allQueries: LokiQuery[]) {
-  const queries = allQueries.filter((query) => !query.hide).filter((query) => !query.refId.includes('do-not-chunk'));
+  const queries = allQueries
+    .filter((query) => !query.hide)
+    .filter((query) => !query.refId.includes('do-not-chunk'))
+    .filter((query) => query.expr);
 
   const instantQueries = queries.some((query) => query.queryType === LokiQueryType.Instant);
   if (instantQueries) {


### PR DESCRIPTION
Since splitting was implemented, we were no longer able to reset the displayed results by sending an empty query.

This PR skips empty queries from running through the splitting code, letting the legacy code handling them and corrently reseting the results in display.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana/issues/61768

**Special notes for your reviewer**:

https://user-images.githubusercontent.com/1069378/222489757-9c4e3439-21ea-4317-8c49-81e5db71e6a9.mov
