### PR TITLE
Influxdb: Fix missing columns with raw query

### DIFF
--- a/public/app/plugins/datasource/influxdb/response_parser.ts
+++ b/public/app/plugins/datasource/influxdb/response_parser.ts
@@ -198,6 +198,20 @@ function getTableCols(dfs: DataFrame[], table: TableModel, target: InfluxQuery):
     table.columns.push({ text: selectedParams[i] });
   }
 
+  // ISSUE: https://github.com/grafana/grafana/issues/63842
+  // if rawQuery and
+  // has other selected fields in the query and
+  // dfs field names are in the rawQuery but
+  // the selected params object doesn't exist in the query then
+  // add columns to the table
+  if (target.rawQuery && selectedParams.length === 0 && rawQuerySelectedFieldsInDataframe(target.query, dfs)) {
+    dfs.map((df) => {
+      if (df.name) {
+        table.columns.push({ text: df.name });
+      }
+    });
+  }
+
   return table;
 }
 
@@ -247,4 +261,19 @@ function incrementName(name: string, nameIncremenet: string, params: string[], i
 
 function addUnique(s: Set<string>, value: string | number) {
   s.add(value.toString());
+}
+
+function rawQuerySelectedFieldsInDataframe(query: string | undefined, dfs: DataFrame[]) {
+  const names: Array<string | undefined> = dfs.map((df: DataFrame) => df.name);
+
+  return names.every((name: string | undefined) => {
+    if (name && query) {
+      // table name and field, i.e. cpu.usage_guest_nice becomes ['cpu', 'usage_guest_nice']
+      const nameParts: string[] = name.split('.');
+
+      return nameParts.every((np) => query.includes(np));
+    }
+
+    return false;
+  });
 }

--- a/public/app/plugins/datasource/influxdb/response_parser.ts
+++ b/public/app/plugins/datasource/influxdb/response_parser.ts
@@ -282,7 +282,7 @@ function rawQuerySelectedFieldsInDataframe(query: string | undefined, dfs: DataF
     return false;
   });
 
-  const queryChecks: string[] = ['*', 'SHOW'];
+  const queryChecks = ['*', 'SHOW'];
 
   const otherChecks: boolean = queryChecks.some((qc: string) => {
     if (query) {

--- a/public/app/plugins/datasource/influxdb/response_parser.ts
+++ b/public/app/plugins/datasource/influxdb/response_parser.ts
@@ -204,7 +204,12 @@ function getTableCols(dfs: DataFrame[], table: TableModel, target: InfluxQuery):
   // dfs field names are in the rawQuery but
   // the selected params object doesn't exist in the query then
   // add columns to the table
-  if (target.rawQuery && selectedParams.length === 0 && rawQuerySelectedFieldsInDataframe(target.query, dfs)) {
+  if (
+    target.rawQuery &&
+    selectedParams.length === 0 &&
+    rawQuerySelectedFieldsInDataframe(target.query, dfs) &&
+    dfs[0].refId !== 'metricFindQuery'
+  ) {
     dfs.map((df) => {
       if (df.name) {
         table.columns.push({ text: df.name });

--- a/public/app/plugins/datasource/influxdb/response_parser.ts
+++ b/public/app/plugins/datasource/influxdb/response_parser.ts
@@ -271,7 +271,7 @@ function addUnique(s: Set<string>, value: string | number) {
 function rawQuerySelectedFieldsInDataframe(query: string | undefined, dfs: DataFrame[]) {
   const names: Array<string | undefined> = dfs.map((df: DataFrame) => df.name);
 
-  const colsInRawQuery: boolean = names.every((name: string | undefined) => {
+  const colsInRawQuery = names.every((name: string | undefined) => {
     if (name && query) {
       // table name and field, i.e. cpu.usage_guest_nice becomes ['cpu', 'usage_guest_nice']
       const nameParts = name.split('.');

--- a/public/app/plugins/datasource/influxdb/response_parser.ts
+++ b/public/app/plugins/datasource/influxdb/response_parser.ts
@@ -274,7 +274,7 @@ function rawQuerySelectedFieldsInDataframe(query: string | undefined, dfs: DataF
   const colsInRawQuery: boolean = names.every((name: string | undefined) => {
     if (name && query) {
       // table name and field, i.e. cpu.usage_guest_nice becomes ['cpu', 'usage_guest_nice']
-      const nameParts: string[] = name.split('.');
+      const nameParts = name.split('.');
 
       return nameParts.every((np) => query.toLowerCase().includes(np.toLowerCase()));
     }

--- a/public/app/plugins/datasource/influxdb/response_parser.ts
+++ b/public/app/plugins/datasource/influxdb/response_parser.ts
@@ -266,14 +266,26 @@ function addUnique(s: Set<string>, value: string | number) {
 function rawQuerySelectedFieldsInDataframe(query: string | undefined, dfs: DataFrame[]) {
   const names: Array<string | undefined> = dfs.map((df: DataFrame) => df.name);
 
-  return names.every((name: string | undefined) => {
+  const colsInRawQuery: boolean = names.every((name: string | undefined) => {
     if (name && query) {
       // table name and field, i.e. cpu.usage_guest_nice becomes ['cpu', 'usage_guest_nice']
       const nameParts: string[] = name.split('.');
 
-      return nameParts.every((np) => query.includes(np));
+      return nameParts.every((np) => query.toLowerCase().includes(np.toLowerCase()));
     }
 
     return false;
   });
+
+  const queryChecks: string[] = ['*', 'SHOW'];
+
+  const otherChecks: boolean = queryChecks.some((qc: string) => {
+    if (query) {
+      return query.toLowerCase().includes(qc.toLowerCase());
+    }
+
+    return false;
+  });
+
+  return colsInRawQuery || otherChecks;
 }


### PR DESCRIPTION
Fixes: https://github.com/grafana/support-escalations/issues/5134
Fixes: https://github.com/grafana/grafana/issues/63842
Fixes: https://github.com/grafana/grafana/issues/63923
Fixes: https://github.com/grafana/support-escalations/issues/5242

What is this fix?
This adds selected fields as column names in the table response for Influxdb.

Why?
Say we have a query:
`SELECT "usage_guest_nice", "usage_idle" FROM "cpu" WHERE $timeFilter`
When the selected object is not part of the query model, which happens when a user performs a rawQuery, the selected columns are not added to the table response. In this example, `usage_guest_nice` and `usage_idle` would not be added as columns to the table response and any values wouldn't be shown either. 

Without columns in table response
<img width="1076" alt="Screen Shot 2023-03-02 at 12 36 40 PM" src="https://user-images.githubusercontent.com/25674746/222507638-0e8f0c0b-efee-4973-a15a-617316dc9e69.png">

With columns in table response
<img width="1068" alt="Screen Shot 2023-03-02 at 12 36 19 PM" src="https://user-images.githubusercontent.com/25674746/222507684-7d7598dd-702e-43fc-9986-9b398fc37ba6.png">

So, this fix checks that the columns returned from the query are in the original rawQuery, then adds the field names as column names. 
