### PR TITLE
Explore: Add range option to internal data links

### DIFF
--- a/packages/grafana-data/src/field/fieldOverrides.test.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.test.ts
@@ -1,4 +1,5 @@
 import { ArrayDataFrame, MutableDataFrame, toDataFrame } from '../dataframe';
+import { rangeUtil } from '../datetime';
 import { createTheme } from '../themes';
 import { FieldMatcherID } from '../transformations';
 import {
@@ -655,6 +656,65 @@ describe('getLinksSupplier', () => {
 
     const links = supplier({ valueRowIndex: 0 });
     const encodeURIParams = `{"datasource":"${datasourceUid}","queries":["12345"]}`;
+    expect(links.length).toBe(1);
+    expect(links[0]).toEqual(
+      expect.objectContaining({
+        title: 'testDS',
+        href: `/explore?left=${encodeURIComponent(encodeURIParams)}`,
+        onClick: undefined,
+      })
+    );
+  });
+
+  it('handles time range on internal links', () => {
+    locationUtil.initialize({
+      config: { appSubUrl: '' } as GrafanaConfig,
+      getVariablesUrlParams: () => ({}),
+      getTimeRangeForUrl: () => ({ from: 'now-7d', to: 'now' }),
+    });
+
+    const datasourceUid = '1234';
+    const range = rangeUtil.relativeToTimeRange({ from: 600, to: 0 });
+    const f0 = new MutableDataFrame({
+      name: 'A',
+      fields: [
+        {
+          name: 'message',
+          type: FieldType.string,
+          values: [10, 20],
+          config: {
+            links: [
+              {
+                url: '',
+                title: '',
+                internal: {
+                  datasourceUid: datasourceUid,
+                  datasourceName: 'testDS',
+                  query: '12345',
+                  range,
+                },
+              },
+            ],
+          },
+          display: (v) => ({ numeric: v, text: String(v) }),
+        },
+      ],
+    });
+
+    const supplier = getLinksSupplier(
+      f0,
+      f0.fields[0],
+      {},
+      // We do not need to interpolate anything for this test
+      (value, vars, format) => value
+    );
+
+    const links = supplier({ valueRowIndex: 0 });
+    const rangeStr = JSON.stringify({
+      from: range.from.toISOString(),
+      to: range.to.toISOString(),
+    });
+    const encodeURIParams = `{"range":${rangeStr},"datasource":"${datasourceUid}","queries":["12345"]}`;
     expect(links.length).toBe(1);
     expect(links[0]).toEqual(
       expect.objectContaining({

--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -451,7 +451,7 @@ export const getLinksSupplier =
           internalLink: link.internal,
           scopedVars: variables,
           field,
-          range: {} as any,
+          range: link.internal.range ?? ({} as any),
           replaceVariables,
         });
       }

--- a/packages/grafana-data/src/types/dataLink.ts
+++ b/packages/grafana-data/src/types/dataLink.ts
@@ -1,6 +1,7 @@
 import { ExplorePanelsState } from './explore';
 import { InterpolateFunction } from './panel';
 import { DataQuery } from './query';
+import { TimeRange } from './time';
 
 /**
  * Callback info for DataLink click events
@@ -61,6 +62,7 @@ export interface InternalDataLink<T extends DataQuery = any> {
   datasourceName: string; // used as a title if `DataLink.title` is empty
   panelsState?: ExplorePanelsState;
   transformations?: DataLinkTransformationConfig[];
+  range?: TimeRange;
 }
 
 export type LinkTarget = '_blank' | '_self' | undefined;


### PR DESCRIPTION
**What is this feature?**

Adds an optional range to internal data links and uses it in field overrides if present.

**Why do we need this feature?**

The app o11y plugin links from a dashboard in the plugin to logs in Explore and needs a way to keep the time range the same. This will let us add the time range to the internal link config like so:
```javascript
errorField.config = {
  ...errorField.config,
  unit: 'string',
  links: [
    {
      title: 'Logs',
      url: '',
      targetBlank: true,
      internal: {
        datasourceUid: lokiDs.uid,
        datasourceName: lokiDs.name,
        range: ctx.timeRange,
        query: {
          refId: '',
          expr: `{app="${ctx.appName}"} |~ "\${__value.raw}"`,
          queryType: 'range',
        },
      },
    },
  ],
};
```

Relates to https://github.com/grafana/app-o11y-kwl/issues/174
