### PR TITLE
Alerting: Use background context for maintenance function

### DIFF
--- a/pkg/services/ngalert/notifier/alertmanager.go
+++ b/pkg/services/ngalert/notifier/alertmanager.go
@@ -103,7 +103,8 @@ func newAlertmanager(ctx context.Context, orgID int64, cfg *setting.Cfg, store A
 		retention:            retentionNotificationsAndSilences,
 		maintenanceFrequency: silenceMaintenanceInterval,
 		maintenanceFunc: func(state alertingNotify.State) (int64, error) {
-			return fileStore.Persist(ctx, silencesFilename, state)
+			// Detached context here is to make sure that when the service is shut down the persist operation is executed.
+			return fileStore.Persist(context.Background(), silencesFilename, state)
 		},
 	}
 
@@ -112,7 +113,8 @@ func newAlertmanager(ctx context.Context, orgID int64, cfg *setting.Cfg, store A
 		retention:            retentionNotificationsAndSilences,
 		maintenanceFrequency: notificationLogMaintenanceInterval,
 		maintenanceFunc: func(state alertingNotify.State) (int64, error) {
-			return fileStore.Persist(ctx, notificationLogFilename, state)
+			// Detached context here is to make sure that when the service is shut down the persist operation is executed.
+			return fileStore.Persist(context.Background(), notificationLogFilename, state)
 		},
 	}
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
When Grafana Alerting starts it initializes Alertmanagers  by calling [LoadAndSyncAlertmanagersForOrgs](https://github.com/grafana/grafana/blob/7e017790d2ad3c9e614f4364d2202ec9b8a12675/pkg/services/ngalert/ngalert.go#L176-L178). That function loads configuration from the database, initializes alertmanager structure by calling [newalertmanager](https://github.com/grafana/grafana/blob/f066e8cdcd178b783d0c62959bea593d3c0c30b0/pkg/services/ngalert/notifier/multiorg_alertmanager.go#L186) and applies the current configuration to it.  That method is called with a background context that has 30s timeout.

The problem is that this context is propagated down to the function `newalertmanager` that uses this context in maintenance functions that are called by alertmanager during the runtime

https://github.com/grafana/grafana/blob/d6d40975671f44580c5b71d5b997c2968e2d30ab/pkg/services/ngalert/notifier/alertmanager.go#L100-L107

Therefore, after the 30s the context in the maintenance function gets canceled and all operations start failing with error like 
```
ERROR[03-02|12:28:56] Creating shutdown snapshot failed        logger=alertmanager org=1 err="context canceled"
```
(this one happens when Grafana is stopping)

The effect of this bug is that silences are not persisted between Grafana restarts. Also, there is a possibility of duplicated alerts sent  to the notifiers.


This PR fixes the initialization of the alertmanager to use background context for maintenance functions.

Related: https://github.com/grafana/grafana/pull/61979

**Special notes for your reviewer**:

