### PR TITLE
Alerting: Show paused status in rules group accordion

### DIFF
--- a/public/app/features/alerting/unified/components/rules/RuleStats.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleStats.tsx
@@ -34,9 +34,8 @@ export const RuleStats: FC<Props> = ({ group, namespaces, includeTotal }) => {
       if (rule.promRule && isAlertingRule(rule.promRule)) {
         if (isGrafanaRulerRulePaused(rule)) {
           stats.paused += 1;
-        } else {
-          stats[rule.promRule.state] += 1;
         }
+        stats[rule.promRule.state] += 1;
       }
       if (ruleHasError(rule)) {
         stats.error += 1;
@@ -87,14 +86,20 @@ export const RuleStats: FC<Props> = ({ group, namespaces, includeTotal }) => {
     );
   }
 
-  if (calculated[PromAlertingRuleState.Inactive]) {
+  if (calculated[PromAlertingRuleState.Inactive] && calculated.paused) {
     statsComponents.push(
-      <Badge color="green" key="inactive" text={`${calculated[PromAlertingRuleState.Inactive]} normal`} />
+      <Badge
+        color="green"
+        key="paused"
+        text={`${calculated[PromAlertingRuleState.Inactive]} normal (${calculated.paused} paused)`}
+      />
     );
   }
 
-  if (calculated.paused) {
-    statsComponents.push(<Badge color="green" key="paused" text={`${calculated.paused} paused`} />);
+  if (calculated[PromAlertingRuleState.Inactive] && !calculated.paused) {
+    statsComponents.push(
+      <Badge color="green" key="inactive" text={`${calculated[PromAlertingRuleState.Inactive]} normal`} />
+    );
   }
 
   if (calculated.recording) {

--- a/public/app/features/alerting/unified/components/rules/RuleStats.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleStats.tsx
@@ -6,13 +6,7 @@ import { Badge } from '@grafana/ui';
 import { CombinedRule, CombinedRuleGroup, CombinedRuleNamespace } from 'app/types/unified-alerting';
 import { PromAlertingRuleState } from 'app/types/unified-alerting-dto';
 
-import {
-  isAlertingRule,
-  isRecordingRule,
-  isRecordingRulerRule,
-  isGrafanaRulerRule,
-  isGrafanaRulerRulePaused,
-} from '../../utils/rules';
+import { isAlertingRule, isRecordingRule, isRecordingRulerRule, isGrafanaRulerRulePaused } from '../../utils/rules';
 
 interface Props {
   includeTotal?: boolean;

--- a/public/app/features/alerting/unified/components/rules/RulesTable.tsx
+++ b/public/app/features/alerting/unified/components/rules/RulesTable.tsx
@@ -8,7 +8,7 @@ import { CombinedRule } from 'app/types/unified-alerting';
 import { DEFAULT_PER_PAGE_PAGINATION } from '../../../../../core/constants';
 import { useHasRuler } from '../../hooks/useHasRuler';
 import { Annotation } from '../../utils/constants';
-import { isGrafanaRulerRule } from '../../utils/rules';
+import { isGrafanaRulerRule, isGrafanaRulerRulePaused } from '../../utils/rules';
 import { DynamicTable, DynamicTableColumnProps, DynamicTableItemProps } from '../DynamicTable';
 import { DynamicTableWithGuidelines } from '../DynamicTableWithGuidelines';
 import { ProvisioningBadge } from '../Provisioning';
@@ -117,8 +117,7 @@ function useColumns(showSummaryColumn: boolean, showGroupColumn: boolean) {
 
           const isDeleting = !!(hasRuler(rulesSource) && rulerRulesLoaded(rulesSource) && promRule && !rulerRule);
           const isCreating = !!(hasRuler(rulesSource) && rulerRulesLoaded(rulesSource) && rulerRule && !promRule);
-          const isGrafanaManagedRule = isGrafanaRulerRule(rulerRule);
-          const isPaused = isGrafanaManagedRule && Boolean(rulerRule.grafana_alert.is_paused);
+          const isPaused = isGrafanaRulerRulePaused(rule);
 
           return <RuleState rule={rule} isDeleting={isDeleting} isCreating={isCreating} isPaused={isPaused} />;
         },

--- a/public/app/features/alerting/unified/utils/rules.ts
+++ b/public/app/features/alerting/unified/utils/rules.ts
@@ -5,6 +5,7 @@ import {
   Alert,
   AlertingRule,
   CloudRuleIdentifier,
+  CombinedRule,
   CombinedRuleGroup,
   CombinedRuleWithLocation,
   GrafanaRuleIdentifier,
@@ -53,6 +54,10 @@ export function isRecordingRulerRule(rule?: RulerRuleDTO): rule is RulerRecordin
 
 export function isGrafanaRulerRule(rule?: RulerRuleDTO): rule is RulerGrafanaRuleDTO {
   return typeof rule === 'object' && 'grafana_alert' in rule;
+}
+
+export function isGrafanaRulerRulePaused(rule: CombinedRule) {
+  return rule.rulerRule && isGrafanaRulerRule(rule.rulerRule) && Boolean(rule.rulerRule.grafana_alert.is_paused);
 }
 
 export function alertInstanceKey(alert: Alert): string {


### PR DESCRIPTION
**What is this feature?**

Shows the alert instance paused status in the group stats badges.

**Why do we need this feature?**

Adds more clarity to paused alerts.

**Who is this feature for?**

All users. 

**Which issue(s) does this PR fix?**:

Reported in [Slack](https://raintank-corp.slack.com/archives/C035H7HNJDR/p1677770183658739) 

**Special notes for your reviewer**:

![image](https://user-images.githubusercontent.com/6271380/222721761-b90c4193-6b30-4ae7-b007-2f28839d4db2.png)


