### PR TITLE
SQLStore: Enable clientFoundRows for MySQL connections

### DIFF
--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -278,7 +278,7 @@ func (ss *SQLStore) buildConnectionString() (string, error) {
 			protocol = "unix"
 		}
 
-		cnnstr = fmt.Sprintf("%s:%s@%s(%s)/%s?collation=utf8mb4_unicode_ci&allowNativePasswords=true",
+		cnnstr = fmt.Sprintf("%s:%s@%s(%s)/%s?collation=utf8mb4_unicode_ci&allowNativePasswords=true&clientFoundRows=true",
 			ss.dbCfg.User, ss.dbCfg.Pwd, protocol, ss.dbCfg.Host, ss.dbCfg.Name)
 
 		if ss.dbCfg.SslMode == "true" || ss.dbCfg.SslMode == "skip-verify" {


### PR DESCRIPTION
**What is this feature?**

Our MySQL behavior is currently different from that of other databases:

Given a write operation that no-ops (like `UPDATE`s that don't affect anything), MySQL will elide the update and report `0` for number of affected rows - even if there are rows that _would_ have matched the update.

This is in contrast to both sqlite and postgres. Sqlite and postgres both return the number of rows that the update matched, regardless of whether the database chose to optimize out any writes.

This PR sets a connection-level flag that makes MySQL behave like the other two databases that Grafana supports.

**Why do we need this feature?**

MySQL's behavior around this can introduce subtle idempotency bugs, for example, one in Alerting where we're using an `UPDATE ... WHERE ...` clause. It becomes impossible to distinguish on MySQL whether the update made no changes, or matched nothing due to the `WHERE` clause. This makes it difficult to write idempotent APIs against MySQL.

`clientFoundRows` is a flag parsed by the mysql driver:
https://github.com/go-sql-driver/mysql#clientfoundrows

It's translated into the `CLIENT_FOUND_ROWS` MySQL connection flag:
https://dev.mysql.com/doc/dev/mysql-server/latest/group__group__cs__capabilities__flags.html#ga4d108689643f2dfdb9d7fee3e20341af

**Which issue(s) does this PR fix?**:

TODO: issue pending...

**Special notes for your reviewer**:

