### PR TITLE
Timeseries: Align tooltip values to the right

### DIFF
--- a/packages/grafana-ui/src/components/VizTooltip/SeriesTable.tsx
+++ b/packages/grafana-ui/src/components/VizTooltip/SeriesTable.tsx
@@ -37,6 +37,7 @@ const getSeriesTableRowStyles = (theme: GrafanaTheme2) => {
     `,
     value: css`
       padding-left: ${theme.spacing(2)};
+      text-align: right;
     `,
     activeSeries: css`
       font-weight: ${theme.typography.fontWeightBold};


### PR DESCRIPTION
Fixes #64095. I don't know what else uses this component.
