### PR TITLE
loki: query chunking: consider refId when merging frames

### DIFF
--- a/public/app/plugins/datasource/loki/queryUtils.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.ts
@@ -315,13 +315,21 @@ export function requestSupportsPartitioning(allQueries: LokiQuery[]) {
   return queries.length > 0;
 }
 
+function shouldCombine(frame1: DataFrame, frame2: DataFrame): boolean {
+  if (frame1.refId !== frame2.refId) {
+    return false;
+  }
+
+  return frame1.name === frame2.name;
+}
+
 export function combineResponses(currentResult: DataQueryResponse | null, newResult: DataQueryResponse) {
   if (!currentResult) {
     return cloneQueryResponse(newResult);
   }
 
   newResult.data.forEach((newFrame) => {
-    const currentFrame = currentResult.data.find((frame) => frame.name === newFrame.name);
+    const currentFrame = currentResult.data.find((frame) => shouldCombine(frame, newFrame));
     if (!currentFrame) {
       currentResult.data.push(cloneDataFrame(newFrame));
       return;


### PR DESCRIPTION
when, in query chunking, new data is merged with current data, the frame `refId` attributes should match.

how to test:
1. `make devenv sources=loki`
2. go to explore, run these two queries for a 7day time range:
    - `count_over_time({place="luna"}[$__interval])`
    - `100 - count_over_time({place="luna"}[$__interval])`
3. verify that the graph shows two lines, where both lines cover the whole time range.

comparison screenshots:

main-branch:
<img width="578" alt="main" src="https://user-images.githubusercontent.com/51989/222667408-946aea5b-729e-4dbb-a6eb-d0f338f69226.png">

this-pr:
<img width="570" alt="pr" src="https://user-images.githubusercontent.com/51989/222667439-28b1d311-765c-4fe2-9f42-1c93eac28911.png">

