### PR TITLE
loki: query splitting: better stats

### DIFF
--- a/public/app/plugins/datasource/loki/mocks.ts
+++ b/public/app/plugins/datasource/loki/mocks.ts
@@ -152,7 +152,7 @@ export function getMockFrames() {
     ],
     meta: {
       stats: [
-        { displayName: 'Summary: total bytes processed', value: 11 },
+        { displayName: 'Summary: total bytes processed', unit: 'decbytes', value: 11 },
         { displayName: 'Ingester: total reached', value: 1 },
       ],
     },
@@ -199,7 +199,7 @@ export function getMockFrames() {
     ],
     meta: {
       stats: [
-        { displayName: 'Summary: total bytes processed', value: 22 },
+        { displayName: 'Summary: total bytes processed', unit: 'decbytes', value: 22 },
         { displayName: 'Ingester: total reached', value: 2 },
       ],
     },
@@ -225,7 +225,7 @@ export function getMockFrames() {
     meta: {
       stats: [
         { displayName: 'Ingester: total reached', value: 1 },
-        { displayName: 'Summary: total bytes processed', value: 11 },
+        { displayName: 'Summary: total bytes processed', unit: 'decbytes', value: 11 },
       ],
     },
     length: 2,
@@ -250,7 +250,7 @@ export function getMockFrames() {
     meta: {
       stats: [
         { displayName: 'Ingester: total reached', value: 2 },
-        { displayName: 'Summary: total bytes processed', value: 22 },
+        { displayName: 'Summary: total bytes processed', unit: 'decbytes', value: 22 },
       ],
     },
     length: 2,
@@ -276,7 +276,7 @@ export function getMockFrames() {
     meta: {
       stats: [
         { displayName: 'Ingester: total reached', value: 2 },
-        { displayName: 'Summary: total bytes processed', value: 33 },
+        { displayName: 'Summary: total bytes processed', unit: 'decbytes', value: 33 },
       ],
     },
     length: 2,

--- a/public/app/plugins/datasource/loki/queryUtils.test.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.test.ts
@@ -369,6 +369,7 @@ describe('combineResponses', () => {
             stats: [
               {
                 displayName: 'Summary: total bytes processed',
+                unit: 'decbytes',
                 value: 33,
               },
             ],
@@ -409,6 +410,7 @@ describe('combineResponses', () => {
             stats: [
               {
                 displayName: 'Summary: total bytes processed',
+                unit: 'decbytes',
                 value: 33,
               },
             ],
@@ -449,6 +451,7 @@ describe('combineResponses', () => {
             stats: [
               {
                 displayName: 'Summary: total bytes processed',
+                unit: 'decbytes',
                 value: 33,
               },
             ],
@@ -488,31 +491,31 @@ describe('combineResponses', () => {
     it('two values', () => {
       const responseA = makeResponse([
         { displayName: 'Ingester: total reached', value: 1 },
-        { displayName: 'Summary: total bytes processed', value: 11 },
+        { displayName: 'Summary: total bytes processed', unit: 'decbytes', value: 11 },
       ]);
       const responseB = makeResponse([
         { displayName: 'Ingester: total reached', value: 2 },
-        { displayName: 'Summary: total bytes processed', value: 22 },
+        { displayName: 'Summary: total bytes processed', unit: 'decbytes', value: 22 },
       ]);
 
       expect(combineResponses(responseA, responseB).data[0].meta.stats).toStrictEqual([
-        { displayName: 'Summary: total bytes processed', value: 33 },
+        { displayName: 'Summary: total bytes processed', unit: 'decbytes', value: 33 },
       ]);
     });
 
     it('one value', () => {
       const responseA = makeResponse([
         { displayName: 'Ingester: total reached', value: 1 },
-        { displayName: 'Summary: total bytes processed', value: 11 },
+        { displayName: 'Summary: total bytes processed', unit: 'decbytes', value: 11 },
       ]);
       const responseB = makeResponse();
 
       expect(combineResponses(responseA, responseB).data[0].meta.stats).toStrictEqual([
-        { displayName: 'Summary: total bytes processed', value: 11 },
+        { displayName: 'Summary: total bytes processed', unit: 'decbytes', value: 11 },
       ]);
 
       expect(combineResponses(responseB, responseA).data[0].meta.stats).toStrictEqual([
-        { displayName: 'Summary: total bytes processed', value: 11 },
+        { displayName: 'Summary: total bytes processed', unit: 'decbytes', value: 11 },
       ]);
     });
 

--- a/public/app/plugins/datasource/loki/queryUtils.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.ts
@@ -357,7 +357,7 @@ function getCombinedMetadataStats(
   const sourceStat = sourceStats.find((s) => s.displayName === TOTAL_BYTES_STAT);
 
   if (sourceStat != null && destStat != null) {
-    return [{ value: sourceStat.value + destStat.value, displayName: TOTAL_BYTES_STAT }];
+    return [{ value: sourceStat.value + destStat.value, displayName: TOTAL_BYTES_STAT, unit: destStat.unit }];
   }
 
   // maybe one of them exist


### PR DESCRIPTION
when we merge the total-bytes-processed stats from multiple chunks, we did not set the `unit` attribute for the stat.
the reason is, such an attribute is not in the typs 😿 : 
https://github.com/grafana/grafana/blob/061e6d556fd92ef497f2c0161718bf203e5dd94e/packages/grafana-data/src/types/data.ts#L99-L102

but, it is used by the code that formats the stats. 
so i added it.

i'll try to get the typescript-type updated in a separate PR, because that might need a larger discussion.

screenshots:
before:
<img width="498" alt="before" src="https://user-images.githubusercontent.com/51989/222671138-217efcf2-7d0e-4d83-892a-55290676c7bb.png">

after:
<img width="508" alt="after" src="https://user-images.githubusercontent.com/51989/222671165-4e6118f0-e351-471a-9c04-f8e2c8256c92.png">

how to test:
1. `make devenv sourcs=loki`
2. go to explore, run a query for a time-range of more than 1 day
3. open the query inspector, stats-tab, and verify that the total-bytes-processed value is nicely formatted.