### PR TITLE
Docker Build: Use `tonistiigi/binfmt` image for cross compilation

### DIFF
--- a/pkg/build/docker/init.go
+++ b/pkg/build/docker/init.go
@@ -18,11 +18,14 @@ func Init() error {
 	}
 
 	// Enable execution of Docker images for other architectures
+	//nolint:gosec
 	cmd := exec.Command("docker", "run", "--privileged", "--rm",
-		"docker/binfmt:a7996909642ee92942dcd6cff44b9b95f08dad64")
+		"tonistiigi/binfmt", "--install", "all")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to enable execution of cross-platform Docker images: %w\n%s", err, output)
 	}
+	fmt.Println("Emulators have been installed successfully!", string(output))
+
 	return nil
 }

--- a/pkg/build/docker/init.go
+++ b/pkg/build/docker/init.go
@@ -10,6 +10,9 @@ import (
 // AllArchs is a list of all supported Docker image architectures.
 var AllArchs = []string{"amd64", "armv7", "arm64"}
 
+// emulatorImage is the docker image used as the cross-platform emulator
+var emulatorImage = "tonistiigi/binfmt:qemu-v7.0.0"
+
 // Init initializes the OS for Docker image building.
 func Init() error {
 	// Necessary for cross-platform builds
@@ -20,12 +23,12 @@ func Init() error {
 	// Enable execution of Docker images for other architectures
 	//nolint:gosec
 	cmd := exec.Command("docker", "run", "--privileged", "--rm",
-		"tonistiigi/binfmt", "--install", "all")
+		emulatorImage, "--install", "all")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to enable execution of cross-platform Docker images: %w\n%s", err, output)
 	}
-	log.Println("emulators have been installed successfully!", string(output))
+	log.Println("emulators have been installed successfully!")
 
 	return nil
 }

--- a/pkg/build/docker/init.go
+++ b/pkg/build/docker/init.go
@@ -25,7 +25,7 @@ func Init() error {
 	if err != nil {
 		return fmt.Errorf("failed to enable execution of cross-platform Docker images: %w\n%s", err, output)
 	}
-	fmt.Println("Emulators have been installed successfully!", string(output))
+	log.Println("emulators have been installed successfully!", string(output))
 
 	return nil
 }


### PR DESCRIPTION
**What is this feature?**

Replacing `docker/binfmt:a7996909642ee92942dcd6cff44b9b95f08dad64` with `tonistiigi/binfmt` ([more info here](https://github.com/tonistiigi/binfmt)).

**Why do we need this feature?**

During our bi-weekly flaky tests analysis, we realised that there were many occasions where `build-docker-images` and `build-docker-images-ubuntu` where flaky, because there was an error when fetching `docker/binfmt:a7996909642ee92942dcd6cff44b9b95f08dad64`. This error couldn't be reproduced locally.

**Which issue(s) does this PR fix?**:

Fixes #64107

**Special notes for your reviewer**:

3/3 times has passed on release builds, let's **hope** this fixes the issue.