### PR TITLE
docs: Prevent internal docs on setting up plugin spellcheck from appearing on public website

### DIFF
--- a/docs/sources/developers/plugins/plugin-spellcheck.md
+++ b/docs/sources/developers/plugins/plugin-spellcheck.md
@@ -1,3 +1,9 @@
+---
+title: Configuring plugin spellcheck
+description: Internal docs on how to setup the plugin spellcheck
+draft: true
+---
+
 # Configuring plugin spellcheck
 
 > ℹ️ This process is applicable only for grafana maintained plugins and only if the plugins are activated in drone.grafana.net for CI process.


### PR DESCRIPTION
This page is meant to be used internally, no need to publish it.