### PR TITLE
AuthN: add utility functions for different type of login responses

### DIFF
--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -208,22 +208,8 @@ func (hs *HTTPServer) LoginPost(c *contextmodel.ReqContext) response.Response {
 			return response.Err(err)
 		}
 
-		cookies.WriteSessionCookie(c, hs.Cfg, identity.SessionToken.UnhashedToken, hs.Cfg.LoginMaxLifetime)
-		result := map[string]interface{}{
-			"message": "Logged in",
-		}
-
-		if redirectTo := c.GetCookie("redirect_to"); len(redirectTo) > 0 {
-			if err := hs.ValidateRedirectTo(redirectTo); err == nil {
-				result["redirectUrl"] = redirectTo
-			} else {
-				c.Logger.Info("Ignored invalid redirect_to cookie value.", "url", redirectTo)
-			}
-			cookies.DeleteCookie(c.Resp, "redirect_to", hs.CookieOptionsFromCfg)
-		}
-
 		metrics.MApiLoginPost.Inc()
-		return response.JSON(http.StatusOK, result)
+		return authn.HandleLoginResponse(c.Req, c.Resp, hs.Cfg, identity, hs.ValidateRedirectTo)
 	}
 
 	cmd := dtos.LoginCommand{}

--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -114,15 +114,7 @@ func (hs *HTTPServer) OAuthLogin(ctx *contextmodel.ReqContext) {
 		}
 
 		metrics.MApiLoginOAuth.Inc()
-		cookies.WriteSessionCookie(ctx, hs.Cfg, identity.SessionToken.UnhashedToken, hs.Cfg.LoginMaxLifetime)
-
-		redirectURL := setting.AppSubUrl + "/"
-		if redirectTo := ctx.GetCookie("redirect_to"); len(redirectTo) > 0 && hs.ValidateRedirectTo(redirectTo) == nil {
-			redirectURL = redirectTo
-			cookies.DeleteCookie(ctx.Resp, "redirect_to", hs.CookieOptionsFromCfg)
-		}
-
-		ctx.Redirect(redirectURL)
+		authn.HandleLoginRedirect(ctx.Req, ctx.Resp, hs.Cfg, identity, hs.ValidateRedirectTo)
 		return
 	}
 

--- a/pkg/services/authn/authn.go
+++ b/pkg/services/authn/authn.go
@@ -377,5 +377,5 @@ func WriteSessionCookie(w http.ResponseWriter, cfg *setting.Cfg, identity *Ident
 		maxAge = -1
 	}
 
-	cookies.WriteCookie(w, cfg.LoginCookieName, identity.SessionToken.UnhashedToken, maxAge, nil)
+	cookies.WriteCookie(w, cfg.LoginCookieName, url.QueryEscape(identity.SessionToken.UnhashedToken), maxAge, nil)
 }

--- a/pkg/services/authn/authn.go
+++ b/pkg/services/authn/authn.go
@@ -338,7 +338,7 @@ func HandleLoginResponse(r *http.Request, w http.ResponseWriter, cfg *setting.Cf
 	}
 	cookies.DeleteCookie(w, "redirect_to", nil)
 
-	writeSessionCookie(w, cfg, identity)
+	WriteSessionCookie(w, cfg, identity)
 	return response.JSON(http.StatusOK, result)
 }
 
@@ -350,7 +350,7 @@ func HandleLoginRedirect(r *http.Request, w http.ResponseWriter, cfg *setting.Cf
 		redirectURL = redirectTo
 	}
 
-	writeSessionCookie(w, cfg, identity)
+	WriteSessionCookie(w, cfg, identity)
 	http.Redirect(w, r, redirectURL, http.StatusFound)
 }
 
@@ -364,12 +364,10 @@ func getRedirectURL(r *http.Request) string {
 	return v
 }
 
-func writeSessionCookie(w http.ResponseWriter, cfg *setting.Cfg, identity *Identity) {
-	var maxAge int
+func WriteSessionCookie(w http.ResponseWriter, cfg *setting.Cfg, identity *Identity) {
+	maxAge := int(cfg.LoginMaxLifetime.Seconds())
 	if cfg.LoginMaxLifetime <= 0 {
 		maxAge = -1
-	} else {
-		maxAge = int(cfg.LoginMaxLifetime.Seconds())
 	}
 
 	cookies.WriteCookie(w, cfg.LoginCookieName, identity.SessionToken.UnhashedToken, maxAge, nil)

--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -79,7 +79,7 @@ func ProvideService(
 	s.RegisterClient(clients.ProvideAPIKey(apikeyService, userService))
 
 	if cfg.LoginCookieName != "" {
-		s.RegisterClient(clients.ProvideSession(sessionService, userService, cfg.LoginCookieName, cfg.LoginMaxLifetime))
+		s.RegisterClient(clients.ProvideSession(sessionService, userService, cfg))
 	}
 
 	if s.cfg.AnonymousEnabled {

--- a/pkg/services/authn/clients/session_test.go
+++ b/pkg/services/authn/clients/session_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -27,13 +28,15 @@ func TestSession_Test(t *testing.T) {
 		Header: map[string][]string{},
 	}
 	validHTTPReq.AddCookie(&http.Cookie{Name: cookieName, Value: "bob-the-high-entropy-token"})
-
-	s := ProvideSession(&authtest.FakeUserAuthTokenService{}, &usertest.FakeUserService{}, "", 20*time.Second)
+	cfg := setting.NewCfg()
+	cfg.LoginCookieName = ""
+	cfg.LoginMaxLifetime = 20 * time.Second
+	s := ProvideSession(&authtest.FakeUserAuthTokenService{}, &usertest.FakeUserService{}, cfg)
 
 	disabled := s.Test(context.Background(), &authn.Request{HTTPRequest: validHTTPReq})
 	assert.False(t, disabled)
 
-	s.loginCookieName = cookieName
+	s.cfg.LoginCookieName = cookieName
 
 	good := s.Test(context.Background(), &authn.Request{HTTPRequest: validHTTPReq})
 	assert.True(t, good)
@@ -111,7 +114,10 @@ func TestSession_Authenticate(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := ProvideSession(tt.fields.sessionService, tt.fields.userService, cookieName, 20*time.Second)
+			cfg := setting.NewCfg()
+			cfg.LoginCookieName = cookieName
+			cfg.LoginMaxLifetime = 20 * time.Second
+			s := ProvideSession(tt.fields.sessionService, tt.fields.userService, cfg)
 
 			got, err := s.Authenticate(context.Background(), tt.args.r)
 			require.True(t, (err != nil) == tt.wantErr, err)
@@ -142,12 +148,15 @@ func (f *fakeResponseWriter) WriteHeader(statusCode int) {
 }
 
 func TestSession_Hook(t *testing.T) {
+	cfg := setting.NewCfg()
+	cfg.LoginCookieName = "grafana-session"
+	cfg.LoginMaxLifetime = 20 * time.Second
 	s := ProvideSession(&authtest.FakeUserAuthTokenService{
 		TryRotateTokenProvider: func(ctx context.Context, token *auth.UserToken, clientIP net.IP, userAgent string) (bool, *auth.UserToken, error) {
 			token.UnhashedToken = "new-token"
 			return true, token, nil
 		},
-	}, &usertest.FakeUserService{}, "grafana-session", 20*time.Second)
+	}, &usertest.FakeUserService{}, cfg)
 
 	sampleID := &authn.Identity{
 		SessionToken: &auth.UserToken{


### PR DESCRIPTION
**What is this feature?**
On a successful login there a common operations we always do:

1. Write session cookie
2. Check if we have a redirect cookie and redirect in that case
3. Remove the redirect cookie

I created utility functions for these to be used when authnService flag is enabled


Fixes #

**Special notes for your reviewer**:

