### PR TITLE
Alerting: Allow downloading alert rules from subpath

### DIFF
--- a/public/app/features/alerting/unified/RuleList.test.tsx
+++ b/public/app/features/alerting/unified/RuleList.test.tsx
@@ -117,7 +117,7 @@ const ui = {
   moreErrorsButton: byRole('button', { name: /more errors/ }),
   editCloudGroupIcon: byTestId('edit-group'),
   newRuleButton: byRole('link', { name: 'Create alert rule' }),
-  exportButton: byRole('button', { name: /export/i }),
+  exportButton: byRole('link', { name: /export/i }),
   editGroupModal: {
     dialog: byRole('dialog'),
     namespaceInput: byRole('textbox', { name: /^Namespace/ }),

--- a/public/app/features/alerting/unified/RuleList.tsx
+++ b/public/app/features/alerting/unified/RuleList.tsx
@@ -27,13 +27,12 @@ import { fetchAllPromAndRulerRulesAction } from './state/actions';
 import { useRulesAccess } from './utils/accessControlHooks';
 import { RULE_LIST_POLL_INTERVAL_MS } from './utils/constants';
 import { getAllRulesSourceNames } from './utils/datasource';
+import { createUrl } from './utils/url';
 
 const VIEWS = {
   groups: RuleListGroupView,
   state: RuleListStateView,
 };
-
-const onExport = () => window.open('/api/v1/provisioning/alert-rules/export?download=true&format=yaml');
 
 const RuleList = withErrorBoundary(
   () => {
@@ -111,9 +110,17 @@ const RuleList = withErrorBoundary(
               </div>
               <Stack direction="row" gap={0.5}>
                 {canReadProvisioning && (
-                  <Button icon="download-alt" type="button" onClick={onExport}>
+                  <LinkButton
+                    href={createUrl('/api/v1/provisioning/alert-rules/export', {
+                      download: 'true',
+                      format: 'yaml',
+                    })}
+                    icon="download-alt"
+                    target="_blank"
+                    rel="noopener"
+                  >
                     Export
-                  </Button>
+                  </LinkButton>
                 )}
                 {(canCreateGrafanaRules || canCreateCloudRules) && (
                   <LinkButton


### PR DESCRIPTION
Allows downloading the exported list of alert rules if Grafana is mounted on a subpath.

I've also changed it to a `<LinkButton>` to be more consistent with the other buttons in the rule list view.