### PR TITLE
EventBus: Expose from app.ts

### DIFF
--- a/public/app/angular/GrafanaCtrl.ts
+++ b/public/app/angular/GrafanaCtrl.ts
@@ -3,7 +3,7 @@ import $ from 'jquery';
 import _ from 'lodash'; // eslint-disable-line lodash/import-scope
 
 import { AppEvent } from '@grafana/data';
-import { setLegacyAngularInjector, setAppEvents, setAngularLoader } from '@grafana/runtime';
+import { setLegacyAngularInjector, setAngularLoader } from '@grafana/runtime';
 import { colors } from '@grafana/ui';
 import coreModule from 'app/angular/core_module';
 import { AngularLoader } from 'app/angular/services/AngularLoader';
@@ -31,7 +31,6 @@ export class GrafanaCtrl {
     // make angular loader service available to react components
     setAngularLoader(angularLoader);
     setLegacyAngularInjector($injector);
-    setAppEvents(appEvents);
 
     initGrafanaLive();
 

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -34,6 +34,7 @@ import {
   setRunRequest,
   setPluginImportUtils,
   setPluginsExtensionRegistry,
+  setAppEvents,
 } from '@grafana/runtime';
 import { setPanelDataErrorView } from '@grafana/runtime/src/components/PanelDataErrorView';
 import { setPanelRenderer } from '@grafana/runtime/src/components/PanelRenderer';
@@ -46,6 +47,7 @@ import { getStandardTransformers } from 'app/features/transformers/standardTrans
 import getDefaultMonacoLanguages from '../lib/monaco-languages';
 
 import { AppWrapper } from './AppWrapper';
+import appEvents from './core/app_events';
 import { AppChromeService } from './core/components/AppChrome/AppChromeService';
 import { getAllOptionEditors, getAllStandardFieldConfigs } from './core/components/OptionsUI/registry';
 import { PluginPage } from './core/components/PageNew/PluginPage';
@@ -123,6 +125,9 @@ export class GrafanaApp {
       setPanelDataErrorView(PanelDataErrorView);
       setLocationSrv(locationService);
       setTimeZoneResolver(() => config.bootData.user.timezone);
+
+      // Expose the app-wide eventbus
+      setAppEvents(appEvents);
 
       // We must wait for translations to load because some preloaded store state requires translating
       await initI18nPromise;


### PR DESCRIPTION
### Why?
There are plugins relying on the event bus (was exposed ~1 year ago), however currently it was "initialised" (setting the singleton in `@grafana/runtime`) in the `GrafanaCtrl` angular controller. Since it's not just used by angular plugins (which we are deprecating) I think it makes sense to move it out from there.

**Testing**
Tested it out locally and seemed working (tested with the plugins that rely on `getAppEvents()`, e.g. Loki).

@tolzhabayev for visibility.