### PR TITLE
Add using local range for bar gauge cell in table panel

### DIFF
--- a/packages/grafana-schema/src/common/common.gen.ts
+++ b/packages/grafana-schema/src/common/common.gen.ts
@@ -692,9 +692,14 @@ export interface TableImageCellOptions {
  * Gauge cell options
  */
 export interface TableBarGaugeCellOptions {
+  local?: boolean;
   mode?: BarGaugeDisplayMode;
   type: TableCellDisplayMode.Gauge;
 }
+
+export const defaultTableBarGaugeCellOptions: Partial<TableBarGaugeCellOptions> = {
+  local: false,
+};
 
 /**
  * Colored background cell options

--- a/packages/grafana-schema/src/common/table.cue
+++ b/packages/grafana-schema/src/common/table.cue
@@ -52,6 +52,7 @@ TableImageCellOptions: {
 TableBarGaugeCellOptions: {
 	type: TableCellDisplayMode & "gauge"
 	mode?: BarGaugeDisplayMode
+	local?: bool | *false
 } @cuetsy(kind="interface")
 
 // Colored background cell options

--- a/packages/grafana-ui/src/components/Table/BarGaugeCell.tsx
+++ b/packages/grafana-ui/src/components/Table/BarGaugeCell.tsx
@@ -27,22 +27,25 @@ const defaultScale: ThresholdsConfig = {
 export const BarGaugeCell: FC<TableCellProps> = (props) => {
   const { field, innerWidth, tableStyles, cell, cellProps, row } = props;
 
-  let config = getFieldConfigWithMinMax(field, false);
+  const displayValue = field.display!(cell.value);
+
+  // Set default display mode
+  let barGaugeMode: BarGaugeDisplayMode = BarGaugeDisplayMode.Gradient;
+  // Set using local range to false
+  let useLocalRange = false;
+
+  const cellOptions = getCellOptions(field);
+  if (cellOptions.type === TableCellDisplayMode.Gauge) {
+    barGaugeMode = cellOptions.mode ?? BarGaugeDisplayMode.Gradient;
+    useLocalRange = cellOptions.local ?? false;
+  }
+
+  let config = getFieldConfigWithMinMax(field, useLocalRange);
   if (!config.thresholds) {
     config = {
       ...config,
       thresholds: defaultScale,
     };
-  }
-
-  const displayValue = field.display!(cell.value);
-
-  // Set default display mode
-  let barGaugeMode: BarGaugeDisplayMode = BarGaugeDisplayMode.Gradient;
-
-  const cellOptions = getCellOptions(field);
-  if (cellOptions.type === TableCellDisplayMode.Gauge) {
-    barGaugeMode = cellOptions.mode ?? BarGaugeDisplayMode.Gradient;
   }
 
   const getLinks = () => {

--- a/public/app/plugins/panel/table/cells/BarGaugeCellOptionsEditor.tsx
+++ b/public/app/plugins/panel/table/cells/BarGaugeCellOptionsEditor.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { SelectableValue } from '@grafana/data';
 import { BarGaugeDisplayMode, TableBarGaugeCellOptions } from '@grafana/schema';
-import { Field, HorizontalGroup, Select } from '@grafana/ui';
+import { Field, HorizontalGroup, Select, Switch } from '@grafana/ui';
 
 import { TableCellEditorProps } from '../TableCellOptionEditor';
 
@@ -22,11 +22,25 @@ export const BarGaugeCellOptionsEditor = ({
     onChange(cellOptions);
   };
 
+  const onLocalRangeToggle = (e: React.FormEvent<HTMLInputElement>) => {
+    onChange({
+      ...cellOptions,
+      local: e.currentTarget.checked,
+    });
+  };
+
   return (
-    <HorizontalGroup>
-      <Field label="Gauge Display Mode">
-        <Select value={cellOptions?.mode} onChange={onCellOptionsChange} options={barGaugeOpts} />
-      </Field>
-    </HorizontalGroup>
+    <>
+      <HorizontalGroup>
+        <Field label="Gauge Display Mode">
+          <Select value={cellOptions?.mode} onChange={onCellOptionsChange} options={barGaugeOpts} />
+        </Field>
+      </HorizontalGroup>
+      <HorizontalGroup>
+        <Field label="Use local range" description="Use min/max range calculated from field values">
+          <Switch checked={cellOptions?.local} onChange={onLocalRangeToggle} />
+        </Field>
+      </HorizontalGroup>
+    </>
   );
 };


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Adds a new toggle for the bar gauge cell type where the range can be adapted to use local min/max based on field values.

**Why do we need this feature?**

It's quite a highly requested feature for the table panel gauge cell.

**Who is this feature for?**

Everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
This modification only affects the bar gauge cell, leaving other cell types that use range have the same auto one.
