### PR TITLE
Alerting: Fix alert form broken coming from panel

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -1,5 +1,5 @@
 // BETTERER RESULTS V2.
-//
+// 
 // If this file contains merge conflicts, use `betterer merge` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //
@@ -2684,9 +2684,6 @@ exports[`better eslint`] = {
     ],
     "public/app/features/alerting/unified/components/rule-editor/RuleInspector.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
-    ],
-    "public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx:5381": [
-      [0, 0, 0, "Use data-testid for E2E selectors instead of aria-label", "0"]
     ],
     "public/app/features/alerting/unified/components/rules/RuleDetailsDataSources.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]

--- a/public/app/features/alerting/unified/components/rule-editor/AlertRuleForm.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AlertRuleForm.tsx
@@ -105,7 +105,7 @@ export const useGetDefaults = (queryParams: UrlQueryMap, existing: RuleWithLocat
     () => ({ ...(defaultsInQueryParams ? JSON.parse(defaultsInQueryParams) : {}) }),
     [defaultsInQueryParams]
   );
-  return { defaultDsAndQueries, defaultsInQueryParamsObject };
+  return { defaultDsAndQueries, defaultsInQueryParamsObject, defaultsInQueryParams };
 };
 
 export const AlertRuleForm: FC<Props> = ({ existing, prefill }) => {
@@ -119,7 +119,10 @@ export const AlertRuleForm: FC<Props> = ({ existing, prefill }) => {
   const returnTo: string = (queryParams['returnTo'] as string | undefined) ?? '/alerting/list';
   const [showDeleteModal, setShowDeleteModal] = useState<boolean>(false);
 
-  const { defaultDsAndQueries, defaultsInQueryParamsObject } = useGetDefaults(queryParams, existing);
+  const { defaultDsAndQueries, defaultsInQueryParamsObject, defaultsInQueryParams } = useGetDefaults(
+    queryParams,
+    existing
+  );
 
   const defaultValues: RuleFormValues = useMemo(() => {
     if (existing) {
@@ -153,7 +156,7 @@ export const AlertRuleForm: FC<Props> = ({ existing, prefill }) => {
 
   // only reset once we get some value in defaultDsAndQueries.queries, adding this value.
   useEffect(() => {
-    const shouldReset = !existing && !prefill && defaultDsAndQueries.queries;
+    const shouldReset = !existing && !prefill && defaultDsAndQueries.queries && !Boolean(defaultsInQueryParams);
     if (shouldReset) {
       reset({
         ...getDefaultFormValues(),
@@ -163,7 +166,7 @@ export const AlertRuleForm: FC<Props> = ({ existing, prefill }) => {
         type: RuleFormType.grafana,
       });
     }
-  }, [defaultDsAndQueries.queries, reset, existing, prefill, defaultsInQueryParamsObject]);
+  }, [defaultDsAndQueries.queries, reset, existing, prefill, defaultsInQueryParamsObject, defaultsInQueryParams]);
 
   const type = watch('type');
   const dataSourceName = watch('dataSourceName');
@@ -300,7 +303,7 @@ export const AlertRuleForm: FC<Props> = ({ existing, prefill }) => {
               <AlertRuleNameInput />
               <QueryAndExpressionsStep
                 editingExistingRule={!!existing}
-                prefill={!!prefill}
+                prefill={Boolean(prefill) || Boolean(defaultsInQueryParams)}
                 onDataChange={checkAlertCondition}
                 asyncDefaultQueries={defaultDsAndQueries.queries}
                 asyncDataSource={defaultDsAndQueries.ds}

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
@@ -267,7 +267,7 @@ export const QueryAndExpressionsStep: FC<Props> = ({
                 icon="plus"
                 onClick={onAddNewQuery}
                 variant="secondary"
-                aria-label={selectors.components.QueryTab.addQuery}
+                data-testid={selectors.components.QueryTab.addQuery}
                 disabled={noCompatibleDataSources}
               >
                 Add query


### PR DESCRIPTION
**What is this feature?**

This PR fixes Alert form when coming from panel.
It was not properly copying over the correct data source and query and was duplicating the expressions. 

The problem was that we were adding defaults over the values from the panel.=> this use case was not taken in account when applying defaults.



