### PR TITLE
fix: create temp user no longer sets ID to 0 for all users

### DIFF
--- a/pkg/services/temp_user/model.go
+++ b/pkg/services/temp_user/model.go
@@ -24,7 +24,7 @@ const (
 
 // TempUser holds data for org invites and unconfirmed sign ups
 type TempUser struct {
-	ID              int64
+	ID              int64 `xorm:"pk autoincr 'id'"`
 	OrgID           int64 `xorm:"org_id"`
 	Version         int
 	Email           string

--- a/pkg/services/temp_user/model.go
+++ b/pkg/services/temp_user/model.go
@@ -24,7 +24,7 @@ const (
 
 // TempUser holds data for org invites and unconfirmed sign ups
 type TempUser struct {
-	ID              int64 `xorm:"id"`
+	ID              int64
 	OrgID           int64 `xorm:"org_id"`
 	Version         int
 	Email           string

--- a/pkg/services/temp_user/tempuserimpl/store_test.go
+++ b/pkg/services/temp_user/tempuserimpl/store_test.go
@@ -32,6 +32,13 @@ func TestIntegrationTempUserCommandsAndQueries(t *testing.T) {
 		require.Nil(t, err)
 	}
 
+	t.Run("Can create multiple temp users", func(t *testing.T) {
+		setup(t)
+		created, err := store.CreateTempUser(context.Background(), &cmd)
+		require.Nil(t, err)
+		require.Equal(t, int64(2), created.ID)
+	})
+
 	t.Run("Should be able to get temp users by org id", func(t *testing.T) {
 		setup(t)
 		query := tempuser.GetTempUsersQuery{OrgID: 2256, Status: tempuser.TmpUserInvitePending}


### PR DESCRIPTION
The xorm tag added to the tempuser ID field caused xorm to create all temp users with ID 0. Removing that tag allows xorm to set the ID based on the database result instead. I also added a test which was failing before this.

Fixes #63995