### PR TITLE
Elasticsearch: Fix using of correct size for log and document queries on backend

### DIFF
--- a/pkg/tsdb/elasticsearch/time_series_query.go
+++ b/pkg/tsdb/elasticsearch/time_series_query.go
@@ -195,16 +195,8 @@ func addTermsAgg(aggBuilder es.AggBuilder, bucketAgg *BucketAgg, metrics []*Metr
 	aggBuilder.Terms(bucketAgg.ID, bucketAgg.Field, func(a *es.TermsAggregation, b es.AggBuilder) {
 		if size, err := bucketAgg.Settings.Get("size").Int(); err == nil {
 			a.Size = size
-		} else if size, err := bucketAgg.Settings.Get("size").String(); err == nil {
-			a.Size, err = strconv.Atoi(size)
-			if err != nil {
-				a.Size = defaultSize
-			}
 		} else {
-			a.Size = defaultSize
-		}
-		if a.Size == 0 {
-			a.Size = defaultSize
+			a.Size = getSizeFromString(bucketAgg.Settings.Get("size").MustString(), defaultSize)
 		}
 
 		if minDocCount, err := bucketAgg.Settings.Get("min_doc_count").Int(); err == nil {
@@ -328,10 +320,7 @@ func processLogsQuery(q *Query, b *es.SearchRequestBuilder, from, to int64, defa
 	b.SortDesc(defaultTimeField, "boolean")
 	b.SortDesc("_doc", "")
 	b.AddDocValueField(defaultTimeField)
-	b.Size(metric.Settings.Get("size").MustInt(defaultSize))
-
-	// Add additional defaults for log query
-	b.Size(metric.Settings.Get("limit").MustInt(defaultSize))
+	b.Size(getSizeFromString(metric.Settings.Get("limit").MustString(), defaultSize)) 
 	b.AddHighlight()
 
 	// For log query, we add a date histogram aggregation
@@ -356,7 +345,7 @@ func processDocumentQuery(q *Query, b *es.SearchRequestBuilder, from, to int64, 
 	b.SortDesc(defaultTimeField, "boolean")
 	b.SortDesc("_doc", "")
 	b.AddDocValueField(defaultTimeField)
-	b.Size(metric.Settings.Get("size").MustInt(defaultSize))
+	b.Size(getSizeFromString(metric.Settings.Get("size").MustString(), defaultSize))
 }
 
 func processTimeSeriesQuery(q *Query, b *es.SearchRequestBuilder, from, to int64, defaultTimeField string) {
@@ -450,4 +439,15 @@ func processTimeSeriesQuery(q *Query, b *es.SearchRequestBuilder, from, to int64
 			})
 		}
 	}
+}
+
+func getSizeFromString(sizeStr string, defaultSize int) int {
+	size, err := strconv.Atoi(sizeStr)
+	if err != nil {
+		size = defaultSize
+	}
+	if size == 0 {
+		size = defaultSize
+	}
+	return size
 }

--- a/pkg/tsdb/elasticsearch/time_series_query.go
+++ b/pkg/tsdb/elasticsearch/time_series_query.go
@@ -320,7 +320,7 @@ func processLogsQuery(q *Query, b *es.SearchRequestBuilder, from, to int64, defa
 	b.SortDesc(defaultTimeField, "boolean")
 	b.SortDesc("_doc", "")
 	b.AddDocValueField(defaultTimeField)
-	b.Size(getSizeFromString(metric.Settings.Get("limit").MustString(), defaultSize)) 
+	b.Size(getSizeFromString(metric.Settings.Get("limit").MustString(), defaultSize))
 	b.AddHighlight()
 
 	// For log query, we add a date histogram aggregation

--- a/pkg/tsdb/elasticsearch/time_series_query_test.go
+++ b/pkg/tsdb/elasticsearch/time_series_query_test.go
@@ -454,7 +454,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 			c := newFakeClient()
 			_, err := executeTsdbQuery(c, `{
 				"bucketAggs": [],
-				"metrics": [{ "id": "1", "type": "raw_document", "settings": { "size": 1337 }	}]
+				"metrics": [{ "id": "1", "type": "raw_document", "settings": { "size": "1337" }	}]
 			}`, from, to)
 			require.NoError(t, err)
 			sr := c.multisearchRequests[0].Requests[0]
@@ -1330,7 +1330,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 		t.Run("With log query with limit should return query with correct size", func(t *testing.T) {
 			c := newFakeClient()
 			_, err := executeTsdbQuery(c, `{
-				"metrics": [{ "type": "logs", "id": "1", "settings": { "limit": 1000 }}]
+				"metrics": [{ "type": "logs", "id": "1", "settings": { "limit": "1000" }}]
 			}`, from, to)
 			require.NoError(t, err)
 			sr := c.multisearchRequests[0].Requests[0]


### PR DESCRIPTION
Part of https://github.com/grafana/grafana/issues/54011
In logic on backend, we assumed that `limit` and `size` for `logs` and `document` queries is `int`.  But the type is actually string:

- https://github.com/grafana/grafana/blob/main/public/app/plugins/datasource/elasticsearch/dataquery.gen.ts#L222
- https://github.com/grafana/grafana/blob/main/public/app/plugins/datasource/elasticsearch/dataquery.gen.ts#L215
- https://github.com/grafana/grafana/blob/main/public/app/plugins/datasource/elasticsearch/dataquery.gen.ts#L208

This PR fixes it and uses correct size set in query editor. 

How to test this:

1. Run `make devenv sources=elastic` (you need to have `elasticsearchBackendMigration` feature toggle set to `true`)
2. Open Explore
3. Run `Logs`, `Raw data`, `Raw document` queries and change the size/limit to e.g. 10
4. Observe if only 10 results were correctly returned


<img width="1918" alt="image" src="https://user-images.githubusercontent.com/30407135/222758642-a494f15e-a7d2-43b2-bf76-fa9985f30188.png">


