### PR TITLE
WIP: Do not merge: Github Actions: Auto assign area/backend issue to backend platform board

### DIFF
--- a/.github/commands.json
+++ b/.github/commands.json
@@ -322,5 +322,13 @@
     "addToProject": {
       "url": "https://github.com/orgs/grafana/projects/78"
     }
+  },
+  {
+    "type": "label",
+    "name": "area/backend",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/96"
+    }
   }
 ]


### PR DESCRIPTION
*Why?*
Automatically adding issues to backend platform project when label matches `area/backend`