### PR TITLE
Logs sample: Fix scrolling for unwrapped log lines

### DIFF
--- a/public/app/features/explore/LogsSamplePanel.tsx
+++ b/public/app/features/explore/LogsSamplePanel.tsx
@@ -95,16 +95,18 @@ export function LogsSamplePanel(props: Props) {
     LogsSamplePanelContent = (
       <>
         <OpenInSplitViewButton />
-        <LogRows
-          logRows={logs.rows}
-          dedupStrategy={LogsDedupStrategy.none}
-          showLabels={store.getBool(SETTINGS_KEYS.showLabels, false)}
-          showTime={store.getBool(SETTINGS_KEYS.showTime, true)}
-          wrapLogMessage={store.getBool(SETTINGS_KEYS.wrapLogMessage, true)}
-          prettifyLogMessage={store.getBool(SETTINGS_KEYS.prettifyLogMessage, false)}
-          timeZone={timeZone}
-          enableLogDetails={true}
-        />
+        <div className={styles.logContainer}>
+          <LogRows
+            logRows={logs.rows}
+            dedupStrategy={LogsDedupStrategy.none}
+            showLabels={store.getBool(SETTINGS_KEYS.showLabels, false)}
+            showTime={store.getBool(SETTINGS_KEYS.showTime, true)}
+            wrapLogMessage={store.getBool(SETTINGS_KEYS.wrapLogMessage, true)}
+            prettifyLogMessage={store.getBool(SETTINGS_KEYS.prettifyLogMessage, false)}
+            timeZone={timeZone}
+            enableLogDetails={true}
+          />
+        </div>
       </>
     );
   }
@@ -121,5 +123,8 @@ const getStyles = (theme: GrafanaTheme2) => ({
     position: absolute;
     top: ${theme.spacing(1)};
     right: ${theme.spacing(1)}; ;
+  `,
+  logContainer: css`
+    overflow-x: scroll;
   `,
 });


### PR DESCRIPTION
When user has unwrapped log lines a opens log sample, the component is not scrollable and therefore user can't access full length of log lines. This PR fixes it. 

Fixes https://github.com/grafana/grafana/issues/64035

See video bellow for how to test this: 

https://user-images.githubusercontent.com/30407135/222767738-65d68914-9fda-4d77-91d1-532203e68b86.mov


