### PR TITLE
FalconLogScale: Traces to logs support

### DIFF
--- a/public/app/core/components/TraceToLogs/TraceToLogsSettings.tsx
+++ b/public/app/core/components/TraceToLogs/TraceToLogsSettings.tsx
@@ -75,6 +75,7 @@ export function TraceToLogsSettings({ options, onOptionsChange }: Props) {
     'elasticsearch',
     'grafana-splunk-datasource', // external
     'grafana-opensearch-datasource', // external
+    'grafana-falconlogscale-datasource', // external
   ];
 
   const traceToLogs = useMemo(

--- a/public/app/features/explore/TraceView/createSpanLink.test.ts
+++ b/public/app/features/explore/TraceView/createSpanLink.test.ts
@@ -864,14 +864,14 @@ describe('createSpanLinkFactory', () => {
     });
   });
 
-  describe('should return humio link', () => {
-    const humioUID = 'humioUID';
+  describe('should return falconLogScale link', () => {
+    const falconLogScaleUID = 'falconLogScaleUID';
 
     beforeAll(() => {
       setDataSourceSrv({
         getInstanceSettings() {
           return {
-            uid: humioUID,
+            uid: falconLogScaleUID,
             name: 'FalconLogScale',
             type: 'grafana-falconlogscale-datasource',
           } as unknown as DataSourceInstanceSettings;
@@ -884,18 +884,18 @@ describe('createSpanLinkFactory', () => {
 
     it('the `lsql` keyword is used in the link', () => {
       const createLink = setupSpanLinkFactory({
-        datasourceUid: humioUID,
+        datasourceUid: falconLogScaleUID,
       });
       const links = createLink!(createTraceSpan());
 
       const linkDef = links?.logLinks?.[0];
       expect(linkDef).toBeDefined();
-      expect(linkDef!.href).toContain(`${encodeURIComponent('datasource":"humioUID","queries":[{"lsql"')}`);
+      expect(linkDef!.href).toContain(`${encodeURIComponent('datasource":"falconLogScaleUID","queries":[{"lsql"')}`);
     });
 
     it('formats query correctly if filterByTraceID and or filterBySpanID is true', () => {
       const createLink = setupSpanLinkFactory({
-        datasourceUid: humioUID,
+        datasourceUid: falconLogScaleUID,
         filterByTraceID: true,
         filterBySpanID: true,
       });
@@ -907,7 +907,7 @@ describe('createSpanLinkFactory', () => {
       expect(linkDef).toBeDefined();
       expect(linkDef!.href).toBe(
         `/explore?left=${encodeURIComponent(
-          '{"range":{"from":"2020-10-14T01:00:00.000Z","to":"2020-10-14T01:00:01.000Z"},"datasource":"humioUID","queries":[{"lsql":"cluster=\\"cluster1\\" OR hostname=\\"hostname1\\" or \\"7946b05c2e2e4e5a\\" or \\"6605c7b08e715d6c\\"","refId":""}]}'
+          '{"range":{"from":"2020-10-14T01:00:00.000Z","to":"2020-10-14T01:00:01.000Z"},"datasource":"falconLogScaleUID","queries":[{"lsql":"cluster=\\"cluster1\\" OR hostname=\\"hostname1\\" or \\"7946b05c2e2e4e5a\\" or \\"6605c7b08e715d6c\\"","refId":""}]}'
         )}`
       );
     });
@@ -930,7 +930,7 @@ describe('createSpanLinkFactory', () => {
       expect(linkDef).toBeDefined();
       expect(linkDef!.href).toBe(
         `/explore?left=${encodeURIComponent(
-          '{"range":{"from":"2020-10-14T01:00:00.000Z","to":"2020-10-14T01:00:01.000Z"},"datasource":"humioUID","queries":[{"lsql":"ip=\\"192.168.0.1\\"","refId":""}]}'
+          '{"range":{"from":"2020-10-14T01:00:00.000Z","to":"2020-10-14T01:00:01.000Z"},"datasource":"falconLogScaleUID","queries":[{"lsql":"ip=\\"192.168.0.1\\"","refId":""}]}'
         )}`
       );
     });
@@ -956,7 +956,7 @@ describe('createSpanLinkFactory', () => {
       expect(linkDef).toBeDefined();
       expect(linkDef!.href).toBe(
         `/explore?left=${encodeURIComponent(
-          '{"range":{"from":"2020-10-14T01:00:00.000Z","to":"2020-10-14T01:00:01.000Z"},"datasource":"humioUID","queries":[{"lsql":"hostname=\\"hostname1\\" OR ip=\\"192.168.0.1\\"","refId":""}]}'
+          '{"range":{"from":"2020-10-14T01:00:00.000Z","to":"2020-10-14T01:00:01.000Z"},"datasource":"falconLogScaleUID","queries":[{"lsql":"hostname=\\"hostname1\\" OR ip=\\"192.168.0.1\\"","refId":""}]}'
         )}`
       );
     });
@@ -985,7 +985,7 @@ describe('createSpanLinkFactory', () => {
       expect(linkDef).toBeDefined();
       expect(linkDef!.href).toBe(
         `/explore?left=${encodeURIComponent(
-          '{"range":{"from":"2020-10-14T01:00:00.000Z","to":"2020-10-14T01:00:01.000Z"},"datasource":"humioUID","queries":[{"lsql":"service=\\"serviceName\\" OR pod=\\"podName\\"","refId":""}]}'
+          '{"range":{"from":"2020-10-14T01:00:00.000Z","to":"2020-10-14T01:00:01.000Z"},"datasource":"falconLogScaleUID","queries":[{"lsql":"service=\\"serviceName\\" OR pod=\\"podName\\"","refId":""}]}'
         )}`
       );
     });

--- a/public/app/features/explore/TraceView/createSpanLink.test.ts
+++ b/public/app/features/explore/TraceView/createSpanLink.test.ts
@@ -863,6 +863,133 @@ describe('createSpanLinkFactory', () => {
       expect(links?.logLinks).toBeUndefined();
     });
   });
+
+  describe('should return humio link', () => {
+    const humioUID = 'humioUID';
+
+    beforeAll(() => {
+      setDataSourceSrv({
+        getInstanceSettings() {
+          return {
+            uid: humioUID,
+            name: 'FalconLogScale',
+            type: 'grafana-falconlogscale-datasource',
+          } as unknown as DataSourceInstanceSettings;
+        },
+      } as unknown as DataSourceSrv);
+
+      setLinkSrv(new LinkSrv());
+      setTemplateSrv(new TemplateSrv());
+    });
+
+    it('the `lsql` keyword is used in the link', () => {
+      const createLink = setupSpanLinkFactory({
+        datasourceUid: humioUID,
+      });
+      const links = createLink!(createTraceSpan());
+
+      const linkDef = links?.logLinks?.[0];
+      expect(linkDef).toBeDefined();
+      expect(linkDef!.href).toContain(`${encodeURIComponent('datasource":"humioUID","queries":[{"lsql"')}`);
+    });
+
+    it('formats query correctly if filterByTraceID and or filterBySpanID is true', () => {
+      const createLink = setupSpanLinkFactory({
+        datasourceUid: humioUID,
+        filterByTraceID: true,
+        filterBySpanID: true,
+      });
+
+      expect(createLink).toBeDefined();
+      const links = createLink!(createTraceSpan());
+
+      const linkDef = links?.logLinks?.[0];
+      expect(linkDef).toBeDefined();
+      expect(linkDef!.href).toBe(
+        `/explore?left=${encodeURIComponent(
+          '{"range":{"from":"2020-10-14T01:00:00.000Z","to":"2020-10-14T01:00:01.000Z"},"datasource":"humioUID","queries":[{"lsql":"cluster=\\"cluster1\\" OR hostname=\\"hostname1\\" or \\"7946b05c2e2e4e5a\\" or \\"6605c7b08e715d6c\\"","refId":""}]}'
+        )}`
+      );
+    });
+
+    it('should format one tag correctly', () => {
+      const createLink = setupSpanLinkFactory({
+        tags: [{ key: 'ip' }],
+      });
+      expect(createLink).toBeDefined();
+      const links = createLink!(
+        createTraceSpan({
+          process: {
+            serviceName: 'service',
+            tags: [{ key: 'ip', value: '192.168.0.1' }],
+          },
+        })
+      );
+
+      const linkDef = links?.logLinks?.[0];
+      expect(linkDef).toBeDefined();
+      expect(linkDef!.href).toBe(
+        `/explore?left=${encodeURIComponent(
+          '{"range":{"from":"2020-10-14T01:00:00.000Z","to":"2020-10-14T01:00:01.000Z"},"datasource":"humioUID","queries":[{"lsql":"ip=\\"192.168.0.1\\"","refId":""}]}'
+        )}`
+      );
+    });
+
+    it('should format multiple tags correctly', () => {
+      const createLink = setupSpanLinkFactory({
+        tags: [{ key: 'ip' }, { key: 'hostname' }],
+      });
+      expect(createLink).toBeDefined();
+      const links = createLink!(
+        createTraceSpan({
+          process: {
+            serviceName: 'service',
+            tags: [
+              { key: 'hostname', value: 'hostname1' },
+              { key: 'ip', value: '192.168.0.1' },
+            ],
+          },
+        })
+      );
+
+      const linkDef = links?.logLinks?.[0];
+      expect(linkDef).toBeDefined();
+      expect(linkDef!.href).toBe(
+        `/explore?left=${encodeURIComponent(
+          '{"range":{"from":"2020-10-14T01:00:00.000Z","to":"2020-10-14T01:00:01.000Z"},"datasource":"humioUID","queries":[{"lsql":"hostname=\\"hostname1\\" OR ip=\\"192.168.0.1\\"","refId":""}]}'
+        )}`
+      );
+    });
+
+    it('handles renamed tags', () => {
+      const createLink = setupSpanLinkFactory({
+        tags: [
+          { key: 'service.name', value: 'service' },
+          { key: 'k8s.pod.name', value: 'pod' },
+        ],
+      });
+      expect(createLink).toBeDefined();
+      const links = createLink!(
+        createTraceSpan({
+          process: {
+            serviceName: 'service',
+            tags: [
+              { key: 'service.name', value: 'serviceName' },
+              { key: 'k8s.pod.name', value: 'podName' },
+            ],
+          },
+        })
+      );
+
+      const linkDef = links?.logLinks?.[0];
+      expect(linkDef).toBeDefined();
+      expect(linkDef!.href).toBe(
+        `/explore?left=${encodeURIComponent(
+          '{"range":{"from":"2020-10-14T01:00:00.000Z","to":"2020-10-14T01:00:01.000Z"},"datasource":"humioUID","queries":[{"lsql":"service=\\"serviceName\\" OR pod=\\"podName\\"","refId":""}]}'
+        )}`
+      );
+    });
+  });
 });
 
 function setupSpanLinkFactory(options: Partial<TraceToLogsOptionsV2> = {}, datasourceUid = 'lokiUid') {

--- a/public/app/features/explore/TraceView/createSpanLink.tsx
+++ b/public/app/features/explore/TraceView/createSpanLink.tsx
@@ -164,6 +164,9 @@ function legacyCreateSpanLinkFactory(
           tags = getFormattedTags(span, tagsToUse, { labelValueSign: ':', joinBy: ' AND ' });
           query = getQueryForElasticsearchOrOpensearch(span, traceToLogsOptions, tags, customQuery);
           break;
+        case 'grafana-falconlogscale-datasource':
+          tags = getFormattedTags(span, tagsToUse);
+          query = getQueryForHumio(span, traceToLogsOptions, tags, customQuery);
       }
 
       // query can be false in case the simple UI tag mapping is used but none of them are present in the span.
@@ -401,6 +404,35 @@ function getQueryForSplunk(span: TraceSpan, options: TraceToLogsOptionsV2, tags:
 
   return {
     query: query,
+    refId: '',
+  };
+}
+
+function getQueryForHumio(span: TraceSpan, options: TraceToLogsOptionsV2, tags: string, customQuery?: string) {
+  const { filterByTraceID, filterBySpanID } = options;
+
+  if (customQuery) {
+    return {
+      lsql: customQuery,
+      refId: '',
+    };
+  }
+
+  if (!tags) {
+    return undefined;
+  }
+
+  let lsql = '${__tags}';
+  if (filterByTraceID && span.traceID) {
+    lsql += ' or "${__span.traceId}"';
+  }
+
+  if (filterBySpanID && span.spanID) {
+    lsql += ' or "${__span.spanId}"';
+  }
+
+  return {
+    lsql,
     refId: '',
   };
 }

--- a/public/app/features/explore/TraceView/createSpanLink.tsx
+++ b/public/app/features/explore/TraceView/createSpanLink.tsx
@@ -165,7 +165,7 @@ function legacyCreateSpanLinkFactory(
           query = getQueryForElasticsearchOrOpensearch(span, traceToLogsOptions, tags, customQuery);
           break;
         case 'grafana-falconlogscale-datasource':
-          tags = getFormattedTags(span, tagsToUse);
+          tags = getFormattedTags(span, tagsToUse, { joinBy: ' OR ' });
           query = getQueryForHumio(span, traceToLogsOptions, tags, customQuery);
       }
 

--- a/public/app/features/explore/TraceView/createSpanLink.tsx
+++ b/public/app/features/explore/TraceView/createSpanLink.tsx
@@ -166,7 +166,7 @@ function legacyCreateSpanLinkFactory(
           break;
         case 'grafana-falconlogscale-datasource':
           tags = getFormattedTags(span, tagsToUse, { joinBy: ' OR ' });
-          query = getQueryForHumio(span, traceToLogsOptions, tags, customQuery);
+          query = getQueryForFalconLogScale(span, traceToLogsOptions, tags, customQuery);
       }
 
       // query can be false in case the simple UI tag mapping is used but none of them are present in the span.
@@ -408,7 +408,7 @@ function getQueryForSplunk(span: TraceSpan, options: TraceToLogsOptionsV2, tags:
   };
 }
 
-function getQueryForHumio(span: TraceSpan, options: TraceToLogsOptionsV2, tags: string, customQuery?: string) {
+function getQueryForFalconLogScale(span: TraceSpan, options: TraceToLogsOptionsV2, tags: string, customQuery?: string) {
   const { filterByTraceID, filterBySpanID } = options;
 
   if (customQuery) {


### PR DESCRIPTION
Adds support for querying logs in a FalconLogScale datasource.
![LogScale mov](https://user-images.githubusercontent.com/15019026/223467472-c7c48707-486f-4df1-9b29-1d4439294580.gif)

Closes grafana/falconlogscale-datasource#29, grafana/falconlogscale-datasource#31, grafana/falconlogscale-datasource#32, grafana/falconlogscale-datasource#37. 
