### PR TITLE
Alerting: Disable "Declare Incident" button for open-source editions

### DIFF
--- a/public/app/features/alerting/unified/components/rules/RuleDetailsActionButtons.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleDetailsActionButtons.tsx
@@ -3,6 +3,7 @@ import React, { FC, Fragment, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 
 import { GrafanaTheme2, textUtil, urlUtil } from '@grafana/data';
+import { GrafanaEdition } from '@grafana/data/src/types/config';
 import { config } from '@grafana/runtime';
 import { Button, ClipboardButton, ConfirmModal, HorizontalGroup, LinkButton, useStyles2 } from '@grafana/ui';
 import { useAppNotification } from 'app/core/copy/appNotification';
@@ -177,7 +178,7 @@ export const RuleDetailsActionButtons: FC<Props> = ({ rule, rulesSource, isViewM
     );
   }
 
-  if (isFiringRule) {
+  if (isFiringRule && shouldShowDeclareIncidentButton()) {
     buttons.push(
       <Fragment key="declare-incident">
         <DeclareIncident title={rule.name} url={buildShareUrl()} />
@@ -265,6 +266,18 @@ export const RuleDetailsActionButtons: FC<Props> = ({ rule, rulesSource, isViewM
   }
   return null;
 };
+
+/**
+ * Since Incident isn't available as an open-source product we shouldn't show it for Open-Source licenced editions of Grafana.
+ * We should show it in development mode
+ */
+function shouldShowDeclareIncidentButton() {
+  const buildInfo = config.buildInfo;
+  const isOpenSourceEdition = buildInfo.edition === GrafanaEdition.OpenSource;
+  const isDevelopment = buildInfo.env === 'development';
+
+  return !isOpenSourceEdition || isDevelopment;
+}
 
 /**
  * We don't want to show the silence button if either


### PR DESCRIPTION
**What is this feature?**

This PR disables the "Declare Incident" button for the open-source editions of Grafana.

**Why do we need this feature?**

Grafana Incident is currently not open-source, the current implementation of the "Declare Incident" button does not take that into account and prompted the user to install or configure Grafana Incident.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/64093

**Special notes for your reviewer**:

There might be alternative implementations but I felt like a feature flag was not the best way forward since

1. It would require an override for all Hosted Grafana and Enterprise flavors of Grafana if the flag was disabled by default
2. It would be unfair to our open-source users of Grafana to ask them the disable it manually if the flag was enabled by default

I've also opted _not_ to include the business logic in the `DeclareIncidentButton` component since we'd have to use conditional hooks (which isn't allowed) and refactoring the current hooks to defer the async HTTP call would add additional complexity.
