### PR TITLE
AuthN: User sync info clean up

### DIFF
--- a/pkg/services/authn/authnimpl/sync/user_sync.go
+++ b/pkg/services/authn/authnimpl/sync/user_sync.go
@@ -276,7 +276,12 @@ func (s *UserSync) getUser(ctx context.Context, identity *authn.Identity) (*user
 	if identity.AuthID != "" && identity.AuthModule != "" {
 		query := &login.GetAuthInfoQuery{AuthId: identity.AuthID, AuthModule: identity.AuthModule}
 		errGetAuthInfo := s.authInfoService.GetAuthInfo(ctx, query)
-		if errGetAuthInfo == nil {
+
+		if errGetAuthInfo != nil && !errors.Is(errGetAuthInfo, user.ErrUserNotFound) {
+			return nil, nil, errGetAuthInfo
+		}
+
+		if !errors.Is(errGetAuthInfo, user.ErrUserNotFound) {
 			usr, errGetByID := s.userService.GetByID(ctx, &user.GetUserByIDQuery{ID: query.Result.UserId})
 			if errGetByID == nil {
 				return usr, query.Result, nil
@@ -285,10 +290,13 @@ func (s *UserSync) getUser(ctx context.Context, identity *authn.Identity) (*user
 			if !errors.Is(errGetByID, user.ErrUserNotFound) {
 				return nil, nil, errGetByID
 			}
-		}
 
-		if !errors.Is(errGetAuthInfo, user.ErrUserNotFound) {
-			return nil, nil, errGetAuthInfo
+			// if the user connected to user auth does not exist try to clean it up
+			if errors.Is(errGetByID, user.ErrUserNotFound) {
+				if err := s.authInfoService.DeleteUserAuthInfo(ctx, query.Result.UserId); err != nil {
+					s.log.FromContext(ctx).Error("Failed to clean up user auth", "error", err, "auth_module", identity.AuthModule, "auth_id", identity.AuthID)
+				}
+			}
 		}
 	}
 

--- a/pkg/services/login/authinfo.go
+++ b/pkg/services/login/authinfo.go
@@ -17,6 +17,23 @@ type AuthInfoService interface {
 	DeleteUserAuthInfo(ctx context.Context, userID int64) error
 }
 
+type Store interface {
+	GetExternalUserInfoByLogin(ctx context.Context, query *GetExternalUserInfoByLoginQuery) error
+	GetAuthInfo(ctx context.Context, query *GetAuthInfoQuery) error
+	GetUserLabels(ctx context.Context, query GetUserLabelsQuery) (map[int64]string, error)
+	SetAuthInfo(ctx context.Context, cmd *SetAuthInfoCommand) error
+	UpdateAuthInfo(ctx context.Context, cmd *UpdateAuthInfoCommand) error
+	UpdateAuthInfoDate(ctx context.Context, authInfo *UserAuth) error
+	DeleteAuthInfo(ctx context.Context, cmd *DeleteAuthInfoCommand) error
+	DeleteUserAuthInfo(ctx context.Context, userID int64) error
+	GetUserById(ctx context.Context, id int64) (*user.User, error)
+	GetUserByLogin(ctx context.Context, login string) (*user.User, error)
+	GetUserByEmail(ctx context.Context, email string) (*user.User, error)
+	CollectLoginStats(ctx context.Context) (map[string]interface{}, error)
+	RunMetricsCollection(ctx context.Context) error
+	GetLoginStats(ctx context.Context) (LoginStats, error)
+}
+
 const (
 	// modules
 	SAMLAuthModule      = "auth.saml"

--- a/pkg/services/login/authinfoservice/service.go
+++ b/pkg/services/login/authinfoservice/service.go
@@ -206,7 +206,7 @@ func (s *Implementation) GetExternalUserInfoByLogin(ctx context.Context, query *
 }
 
 func (s *Implementation) DeleteUserAuthInfo(ctx context.Context, userID int64) error {
-	return nil
+	return s.authInfoStore.DeleteUserAuthInfo(ctx, userID)
 }
 
 func (s *Implementation) Run(ctx context.Context) error {

--- a/pkg/services/login/userprotection.go
+++ b/pkg/services/login/userprotection.go
@@ -1,27 +1,9 @@
 package login
 
 import (
-	"context"
-
 	"github.com/grafana/grafana/pkg/services/user"
 )
 
 type UserProtectionService interface {
 	AllowUserMapping(user *user.User, authModule string) error
-}
-
-type Store interface {
-	GetExternalUserInfoByLogin(ctx context.Context, query *GetExternalUserInfoByLoginQuery) error
-	GetAuthInfo(ctx context.Context, query *GetAuthInfoQuery) error
-	GetUserLabels(ctx context.Context, query GetUserLabelsQuery) (map[int64]string, error)
-	SetAuthInfo(ctx context.Context, cmd *SetAuthInfoCommand) error
-	UpdateAuthInfo(ctx context.Context, cmd *UpdateAuthInfoCommand) error
-	UpdateAuthInfoDate(ctx context.Context, authInfo *UserAuth) error
-	DeleteAuthInfo(ctx context.Context, cmd *DeleteAuthInfoCommand) error
-	GetUserById(ctx context.Context, id int64) (*user.User, error)
-	GetUserByLogin(ctx context.Context, login string) (*user.User, error)
-	GetUserByEmail(ctx context.Context, email string) (*user.User, error)
-	CollectLoginStats(ctx context.Context) (map[string]interface{}, error)
-	RunMetricsCollection(ctx context.Context) error
-	GetLoginStats(ctx context.Context) (LoginStats, error)
 }


### PR DESCRIPTION
**What is this feature?**
If a user auth connection exists but the user is no longer present we need to handle it. We try to remove the old connection and then create a new one for the new user.

Also fix issue where DeleteUserAuthInfo was not calling the store

Fixes #

**Special notes for your reviewer**:

