### PR TITLE
feat(datasource/phlare): support template variables

### DIFF
--- a/public/app/plugins/datasource/phlare/datasource.ts
+++ b/public/app/plugins/datasource/phlare/datasource.ts
@@ -2,7 +2,7 @@ import Prism, { Grammar } from 'prismjs';
 import { Observable, of } from 'rxjs';
 
 import { AbstractQuery, DataQueryRequest, DataQueryResponse, DataSourceInstanceSettings } from '@grafana/data';
-import { DataSourceWithBackend } from '@grafana/runtime';
+import { DataSourceWithBackend, getTemplateSrv } from '@grafana/runtime';
 
 import { extractLabelMatchers, toPromLikeExpr } from '../prometheus/language_utils';
 
@@ -25,6 +25,7 @@ export class PhlareDataSource extends DataSourceWithBackend<Query, PhlareDataSou
             labelSelector: '{}',
           };
         }
+        t.labelSelector = getTemplateSrv().replace(t.labelSelector);
         return normalizeQuery(t, request.app);
       });
     if (!validTargets.length) {


### PR DESCRIPTION
**What is this feature?**

Add replacement support for dashboard template variables for the phlare datasource plugin

**Related issue**

fixes: https://github.com/grafana/grafana/issues/64186

