### PR TITLE
Elasticsearch: Rename time series query to es data query

### DIFF
--- a/pkg/tsdb/elasticsearch/data_query.go
+++ b/pkg/tsdb/elasticsearch/data_query.go
@@ -16,19 +16,19 @@ const (
 	defaultSize = 500
 )
 
-type timeSeriesQuery struct {
+type elasticsearchDataQuery struct {
 	client      es.Client
 	dataQueries []backend.DataQuery
 }
 
-var newTimeSeriesQuery = func(client es.Client, dataQuery []backend.DataQuery) *timeSeriesQuery {
-	return &timeSeriesQuery{
+var newElasticsearchDataQuery = func(client es.Client, dataQuery []backend.DataQuery) *elasticsearchDataQuery {
+	return &elasticsearchDataQuery{
 		client:      client,
 		dataQueries: dataQuery,
 	}
 }
 
-func (e *timeSeriesQuery) execute() (*backend.QueryDataResponse, error) {
+func (e *elasticsearchDataQuery) execute() (*backend.QueryDataResponse, error) {
 	queries, err := parseQuery(e.dataQueries)
 	if err != nil {
 		return &backend.QueryDataResponse{}, err
@@ -57,7 +57,7 @@ func (e *timeSeriesQuery) execute() (*backend.QueryDataResponse, error) {
 	return parseResponse(res.Responses, queries, e.client.GetConfiguredFields())
 }
 
-func (e *timeSeriesQuery) processQuery(q *Query, ms *es.MultiSearchRequestBuilder, from, to int64) error {
+func (e *elasticsearchDataQuery) processQuery(q *Query, ms *es.MultiSearchRequestBuilder, from, to int64) error {
 	err := isQueryWithError(q)
 	if err != nil {
 		return err

--- a/pkg/tsdb/elasticsearch/data_query_test.go
+++ b/pkg/tsdb/elasticsearch/data_query_test.go
@@ -12,7 +12,7 @@ import (
 	es "github.com/grafana/grafana/pkg/tsdb/elasticsearch/client"
 )
 
-func TestExecuteTimeSeriesQuery(t *testing.T) {
+func TestExecuteElasticsearchDataQuery(t *testing.T) {
 	from := time.Date(2018, 5, 15, 17, 50, 0, 0, time.UTC)
 	to := time.Date(2018, 5, 15, 17, 55, 0, 0, time.UTC)
 	fromMs := from.UnixNano() / int64(time.Millisecond)
@@ -21,7 +21,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 	t.Run("Test execute time series query", func(t *testing.T) {
 		t.Run("With defaults", func(t *testing.T) {
 			c := newFakeClient()
-			_, err := executeTsdbQuery(c, `{
+			_, err := executeElasticsearchDataQuery(c, `{
 				"bucketAggs": [{ "type": "date_histogram", "field": "@timestamp", "id": "2" }],
 				"metrics": [{"type": "count", "id": "0" }]
 			}`, from, to)
@@ -40,7 +40,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 		})
 		t.Run("Should clean settings from null values (from frontend tests)", func(t *testing.T) {
 			c := newFakeClient()
-			_, err := executeTsdbQuery(c, `{
+			_, err := executeElasticsearchDataQuery(c, `{
 				"bucketAggs": [{ "type": "date_histogram", "field": "@timestamp", "id": "1" }],
 				"metrics": [{"type": "avg", "id": "0", "settings": {"missing": "null", "script": "1" } }]
 			}`, from, to)
@@ -54,7 +54,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 
 		t.Run("With multiple bucket aggs", func(t *testing.T) {
 			c := newFakeClient()
-			_, err := executeTsdbQuery(c, `{
+			_, err := executeElasticsearchDataQuery(c, `{
 				"bucketAggs": [
 					{ "type": "terms", "field": "@host", "id": "2", "settings": { "size": "0", "order": "asc" } },
 					{ "type": "date_histogram", "field": "@timestamp", "id": "3" }
@@ -75,7 +75,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 
 		t.Run("With select field", func(t *testing.T) {
 			c := newFakeClient()
-			_, err := executeTsdbQuery(c, `{
+			_, err := executeElasticsearchDataQuery(c, `{
 				"bucketAggs": [
 					{ "type": "date_histogram", "field": "@timestamp", "id": "2" }
 				],
@@ -94,7 +94,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 
 		t.Run("With term agg and order by term (from frontend tests)", func(t *testing.T) {
 			c := newFakeClient()
-			_, err := executeTsdbQuery(c, `{
+			_, err := executeElasticsearchDataQuery(c, `{
 				"bucketAggs": [
 					{
 						"type": "terms",
@@ -117,7 +117,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 
 		t.Run("With term agg and order by metric agg", func(t *testing.T) {
 			c := newFakeClient()
-			_, err := executeTsdbQuery(c, `{
+			_, err := executeElasticsearchDataQuery(c, `{
 				"bucketAggs": [
 					{
 						"type": "terms",
@@ -148,7 +148,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 
 		t.Run("With term agg and order by count metric agg", func(t *testing.T) {
 			c := newFakeClient()
-			_, err := executeTsdbQuery(c, `{
+			_, err := executeElasticsearchDataQuery(c, `{
 				"bucketAggs": [
 					{
 						"type": "terms",
@@ -171,7 +171,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 
 		t.Run("With term agg and order by count agg (from frontend tests)", func(t *testing.T) {
 			c := newFakeClient()
-			_, err := executeTsdbQuery(c, `{
+			_, err := executeElasticsearchDataQuery(c, `{
 				"metrics": [
 					{"type": "count", "id": "1" },
 					{"type": "avg", "field": "@value", "id": "5" }
@@ -197,7 +197,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 
 		t.Run("With term agg and order by percentiles agg", func(t *testing.T) {
 			c := newFakeClient()
-			_, err := executeTsdbQuery(c, `{
+			_, err := executeElasticsearchDataQuery(c, `{
 				"bucketAggs": [
 					{
 						"type": "terms",
@@ -225,7 +225,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 
 		t.Run("With term agg and order by extended stats agg", func(t *testing.T) {
 			c := newFakeClient()
-			_, err := executeTsdbQuery(c, `{
+			_, err := executeElasticsearchDataQuery(c, `{
 				"bucketAggs": [
 					{
 						"type": "terms",
@@ -254,7 +254,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 
 		t.Run("With term agg and order by term", func(t *testing.T) {
 			c := newFakeClient()
-			_, err := executeTsdbQuery(c, `{
+			_, err := executeElasticsearchDataQuery(c, `{
 				"bucketAggs": [
 					{
 						"type": "terms",
@@ -280,7 +280,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 
 		t.Run("With term agg and valid min_doc_count (from frontend tests)", func(t *testing.T) {
 			c := newFakeClient()
-			_, err := executeTsdbQuery(c, `{
+			_, err := executeElasticsearchDataQuery(c, `{
 				"bucketAggs": [
 					{
 						"type": "terms",
@@ -305,7 +305,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 
 		t.Run("With metric percentiles", func(t *testing.T) {
 			c := newFakeClient()
-			_, err := executeTsdbQuery(c, `{
+			_, err := executeElasticsearchDataQuery(c, `{
 				"bucketAggs": [
 					{ "type": "date_histogram", "field": "@timestamp", "id": "3" }
 				],
@@ -338,7 +338,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 
 		t.Run("With filters aggs", func(t *testing.T) {
 			c := newFakeClient()
-			_, err := executeTsdbQuery(c, `{
+			_, err := executeElasticsearchDataQuery(c, `{
 				"bucketAggs": [
 					{
 						"id": "2",
@@ -368,7 +368,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 
 		t.Run("With filters aggs and empty label (from frontend tests)", func(t *testing.T) {
 			c := newFakeClient()
-			_, err := executeTsdbQuery(c, `{
+			_, err := executeElasticsearchDataQuery(c, `{
 				"bucketAggs": [
 					{
 						"id": "2",
@@ -398,7 +398,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 
 		t.Run("With raw document metric size", func(t *testing.T) {
 			c := newFakeClient()
-			_, err := executeTsdbQuery(c, `{
+			_, err := executeElasticsearchDataQuery(c, `{
 				"bucketAggs": [],
 				"metrics": [{ "id": "1", "type": "raw_document", "settings": {}	}]
 			}`, from, to)
@@ -410,7 +410,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 
 		t.Run("With raw document metric query (from frontend tests)", func(t *testing.T) {
 			c := newFakeClient()
-			_, err := executeTsdbQuery(c, `{
+			_, err := executeElasticsearchDataQuery(c, `{
 				"bucketAggs": [],
 				"metrics": [{ "id": "1", "type": "raw_document", "settings": {}	}]
 			}`, from, to)
@@ -431,7 +431,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 
 		t.Run("With raw data metric query (from frontend tests)", func(t *testing.T) {
 			c := newFakeClient()
-			_, err := executeTsdbQuery(c, `{
+			_, err := executeElasticsearchDataQuery(c, `{
 				"bucketAggs": [],
 				"metrics": [{ "id": "1", "type": "raw_data", "settings": {}	}]
 			}`, from, to)
@@ -452,7 +452,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 
 		t.Run("With raw document metric size set", func(t *testing.T) {
 			c := newFakeClient()
-			_, err := executeTsdbQuery(c, `{
+			_, err := executeElasticsearchDataQuery(c, `{
 				"bucketAggs": [],
 				"metrics": [{ "id": "1", "type": "raw_document", "settings": { "size": "1337" }	}]
 			}`, from, to)
@@ -464,7 +464,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 
 		t.Run("With date histogram agg", func(t *testing.T) {
 			c := newFakeClient()
-			_, err := executeTsdbQuery(c, `{
+			_, err := executeElasticsearchDataQuery(c, `{
 				"bucketAggs": [
 					{
 						"id": "2",
@@ -488,7 +488,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 
 			t.Run("Should not include time_zone if not present in the query model (from frontend tests)", func(t *testing.T) {
 				c := newFakeClient()
-				_, err := executeTsdbQuery(c, `{
+				_, err := executeElasticsearchDataQuery(c, `{
 					"bucketAggs": [
 						{
 							"id": "2",
@@ -510,7 +510,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 
 			t.Run("Should not include time_zone when timeZone is utc", func(t *testing.T) {
 				c := newFakeClient()
-				_, err := executeTsdbQuery(c, `{
+				_, err := executeElasticsearchDataQuery(c, `{
 					"bucketAggs": [
 						{
 							"id": "2",
@@ -532,7 +532,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 
 			t.Run("Should include time_zone when timeZone is not utc", func(t *testing.T) {
 				c := newFakeClient()
-				_, err := executeTsdbQuery(c, `{
+				_, err := executeElasticsearchDataQuery(c, `{
 					"bucketAggs": [
 						{
 							"id": "2",
@@ -555,7 +555,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 
 		t.Run("With histogram agg", func(t *testing.T) {
 			c := newFakeClient()
-			_, err := executeTsdbQuery(c, `{
+			_, err := executeElasticsearchDataQuery(c, `{
 				"bucketAggs": [
 					{
 						"id": "3",
@@ -581,7 +581,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 
 		t.Run("With histogram (from frontend tests)", func(t *testing.T) {
 			c := newFakeClient()
-			_, err := executeTsdbQuery(c, `{
+			_, err := executeElasticsearchDataQuery(c, `{
 				"bucketAggs": [
 					{
 						"id": "3",
@@ -606,7 +606,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 
 		t.Run("With geo hash grid agg", func(t *testing.T) {
 			c := newFakeClient()
-			_, err := executeTsdbQuery(c, `{
+			_, err := executeElasticsearchDataQuery(c, `{
 				"bucketAggs": [
 					{
 						"id": "3",
@@ -630,7 +630,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 
 		t.Run("With moving average (from frontend tests)", func(t *testing.T) {
 			c := newFakeClient()
-			_, err := executeTsdbQuery(c, `{
+			_, err := executeElasticsearchDataQuery(c, `{
 				"bucketAggs": [
 					{ "type": "date_histogram", "field": "@timestamp", "id": "4" }
 				],
@@ -664,7 +664,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 
 		t.Run("With moving average", func(t *testing.T) {
 			c := newFakeClient()
-			_, err := executeTsdbQuery(c, `{
+			_, err := executeElasticsearchDataQuery(c, `{
 				"bucketAggs": [
 					{ "type": "date_histogram", "field": "@timestamp", "id": "4" }
 				],
@@ -701,7 +701,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 
 		t.Run("With moving average doc count (from frontend tests)", func(t *testing.T) {
 			c := newFakeClient()
-			_, err := executeTsdbQuery(c, `{
+			_, err := executeElasticsearchDataQuery(c, `{
 				"bucketAggs": [
 					{ "type": "date_histogram", "field": "@timestamp", "id": "4" }
 				],
@@ -731,7 +731,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 
 		t.Run("With moving average doc count", func(t *testing.T) {
 			c := newFakeClient()
-			_, err := executeTsdbQuery(c, `{
+			_, err := executeElasticsearchDataQuery(c, `{
 				"bucketAggs": [
 					{ "type": "date_histogram", "field": "@timestamp", "id": "4" }
 				],
@@ -762,7 +762,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 
 		t.Run("With broken moving average (from frontend tests)", func(t *testing.T) {
 			c := newFakeClient()
-			_, err := executeTsdbQuery(c, `{
+			_, err := executeElasticsearchDataQuery(c, `{
 				"bucketAggs": [
 					{ "type": "date_histogram", "field": "@timestamp", "id": "3" }
 				],
@@ -797,7 +797,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 
 		t.Run("With broken moving average", func(t *testing.T) {
 			c := newFakeClient()
-			_, err := executeTsdbQuery(c, `{
+			_, err := executeElasticsearchDataQuery(c, `{
 				"bucketAggs": [
 					{ "type": "date_histogram", "field": "@timestamp", "id": "5" }
 				],
@@ -832,7 +832,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 
 		t.Run("With top_metrics (from frontend tests)", func(t *testing.T) {
 			c := newFakeClient()
-			_, err := executeTsdbQuery(c, `{
+			_, err := executeElasticsearchDataQuery(c, `{
 				"bucketAggs": [
 					{ "type": "date_histogram", "field": "@timestamp", "id": "3" }
 				],
@@ -855,7 +855,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 
 		t.Run("With cumulative sum", func(t *testing.T) {
 			c := newFakeClient()
-			_, err := executeTsdbQuery(c, `{
+			_, err := executeElasticsearchDataQuery(c, `{
 				"bucketAggs": [
 					{ "type": "date_histogram", "field": "@timestamp", "id": "4" }
 				],
@@ -892,7 +892,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 
 		t.Run("With cumulative sum doc count", func(t *testing.T) {
 			c := newFakeClient()
-			_, err := executeTsdbQuery(c, `{
+			_, err := executeElasticsearchDataQuery(c, `{
 				"bucketAggs": [
 					{ "type": "date_histogram", "field": "@timestamp", "id": "4" }
 				],
@@ -923,7 +923,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 
 		t.Run("With broken cumulative sum", func(t *testing.T) {
 			c := newFakeClient()
-			_, err := executeTsdbQuery(c, `{
+			_, err := executeElasticsearchDataQuery(c, `{
 				"bucketAggs": [
 					{ "type": "date_histogram", "field": "@timestamp", "id": "5" }
 				],
@@ -958,7 +958,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 
 		t.Run("With derivative", func(t *testing.T) {
 			c := newFakeClient()
-			_, err := executeTsdbQuery(c, `{
+			_, err := executeElasticsearchDataQuery(c, `{
 				"bucketAggs": [
 					{ "type": "date_histogram", "field": "@timestamp", "id": "4" }
 				],
@@ -987,7 +987,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 		t.Run("With derivative doc count", func(t *testing.T) {
 			// This test is with pipelineAgg and is passing. Same test without pipelineAgg is failing.
 			c := newFakeClient()
-			_, err := executeTsdbQuery(c, `{
+			_, err := executeElasticsearchDataQuery(c, `{
 				"bucketAggs": [
 					{ "type": "date_histogram", "field": "@timestamp", "id": "4" }
 				],
@@ -1015,7 +1015,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 
 		t.Run("With derivative doc count (from frontend tests)", func(t *testing.T) {
 			c := newFakeClient()
-			_, err := executeTsdbQuery(c, `{
+			_, err := executeElasticsearchDataQuery(c, `{
 				"bucketAggs": [
 					{ "type": "date_histogram", "field": "@timestamp", "id": "4" }
 				],
@@ -1044,7 +1044,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 		t.Run("With serial_diff", func(t *testing.T) {
 			// This test is with pipelineAgg and is passing. Same test without pipelineAgg is failing.
 			c := newFakeClient()
-			_, err := executeTsdbQuery(c, `{
+			_, err := executeElasticsearchDataQuery(c, `{
 				"bucketAggs": [
 					{ "type": "date_histogram", "field": "@timestamp", "id": "4" }
 				],
@@ -1074,7 +1074,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 
 		t.Run("With serial_diff (from frontend tests)", func(t *testing.T) {
 			c := newFakeClient()
-			_, err := executeTsdbQuery(c, `{
+			_, err := executeElasticsearchDataQuery(c, `{
 				"bucketAggs": [
 					{ "type": "date_histogram", "field": "@timestamp", "id": "3" }
 				],
@@ -1103,7 +1103,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 
 		t.Run("With serial_diff doc count", func(t *testing.T) {
 			c := newFakeClient()
-			_, err := executeTsdbQuery(c, `{
+			_, err := executeElasticsearchDataQuery(c, `{
 				"bucketAggs": [
 					{ "type": "date_histogram", "field": "@timestamp", "id": "4" }
 				],
@@ -1131,7 +1131,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 
 		t.Run("With bucket_script", func(t *testing.T) {
 			c := newFakeClient()
-			_, err := executeTsdbQuery(c, `{
+			_, err := executeElasticsearchDataQuery(c, `{
 				"bucketAggs": [
 					{ "type": "date_histogram", "field": "@timestamp", "id": "2" }
 				],
@@ -1167,7 +1167,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 
 		t.Run("With bucket_script (from frontend tests)", func(t *testing.T) {
 			c := newFakeClient()
-			_, err := executeTsdbQuery(c, `{
+			_, err := executeElasticsearchDataQuery(c, `{
 				"bucketAggs": [
 					{ "type": "date_histogram", "field": "@timestamp", "id": "4" }
 				],
@@ -1203,7 +1203,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 
 		t.Run("With bucket_script doc count", func(t *testing.T) {
 			c := newFakeClient()
-			_, err := executeTsdbQuery(c, `{
+			_, err := executeElasticsearchDataQuery(c, `{
 				"bucketAggs": [
 					{ "type": "date_histogram", "field": "@timestamp", "id": "4" }
 				],
@@ -1236,7 +1236,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 
 		t.Run("With bucket_script doc count (from frontend tests)", func(t *testing.T) {
 			c := newFakeClient()
-			_, err := executeTsdbQuery(c, `{
+			_, err := executeElasticsearchDataQuery(c, `{
 				"bucketAggs": [
 					{ "type": "date_histogram", "field": "@timestamp", "id": "2" }
 				],
@@ -1269,7 +1269,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 
 		t.Run("With lucene query should add query_string filter when query is not empty (from frontend tests)", func(t *testing.T) {
 			c := newFakeClient()
-			_, err := executeTsdbQuery(c, `{
+			_, err := executeElasticsearchDataQuery(c, `{
 				"query": "foo",
 				"bucketAggs": [],
 				"metrics": [{ "id": "1", "type": "raw_data", "settings": {}	}]
@@ -1283,7 +1283,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 
 		t.Run("With lucene query should add query_string filter when query is not empty (from frontend tests)", func(t *testing.T) {
 			c := newFakeClient()
-			_, err := executeTsdbQuery(c, `{
+			_, err := executeElasticsearchDataQuery(c, `{
 				"query": "foo",
 				"bucketAggs": [],
 				"metrics": [{ "id": "1", "type": "raw_data", "settings": {}	}]
@@ -1297,7 +1297,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 
 		t.Run("With log query should return query with defaults (from frontend tests)", func(t *testing.T) {
 			c := newFakeClient()
-			_, err := executeTsdbQuery(c, `{
+			_, err := executeElasticsearchDataQuery(c, `{
 				"metrics": [{ "type": "logs", "id": "1"}]
 			}`, from, to)
 			require.NoError(t, err)
@@ -1329,7 +1329,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 
 		t.Run("With log query with limit should return query with correct size", func(t *testing.T) {
 			c := newFakeClient()
-			_, err := executeTsdbQuery(c, `{
+			_, err := executeElasticsearchDataQuery(c, `{
 				"metrics": [{ "type": "logs", "id": "1", "settings": { "limit": "1000" }}]
 			}`, from, to)
 			require.NoError(t, err)
@@ -1339,7 +1339,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 
 		t.Run("With log query should return highlight properties", func(t *testing.T) {
 			c := newFakeClient()
-			_, err := executeTsdbQuery(c, `{
+			_, err := executeElasticsearchDataQuery(c, `{
 				"metrics": [{ "type": "logs", "id": "1" }]
 			}`, from, to)
 			require.NoError(t, err)
@@ -1356,7 +1356,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 
 		t.Run("With invalid query should return error", (func(t *testing.T) {
 			c := newFakeClient()
-			_, err := executeTsdbQuery(c, `{
+			_, err := executeElasticsearchDataQuery(c, `{
 				"query": "foo",
 			}`, from, to)
 			require.Error(t, err)
@@ -1370,7 +1370,7 @@ func TestSettingsCasting(t *testing.T) {
 
 	t.Run("Correctly casts values in moving_avg (from frontend tests)", func(t *testing.T) {
 		c := newFakeClient()
-		_, err := executeTsdbQuery(c, `{
+		_, err := executeElasticsearchDataQuery(c, `{
 				"metrics": [
 					{ "type": "avg", "id" : "2" },
 					{
@@ -1410,7 +1410,7 @@ func TestSettingsCasting(t *testing.T) {
 	t.Run("Correctly transforms moving_average settings", func(t *testing.T) {
 		// This test is with pipelineAgg and is passing. Same test without pipelineAgg is failing.
 		c := newFakeClient()
-		_, err := executeTsdbQuery(c, `{
+		_, err := executeElasticsearchDataQuery(c, `{
 			"bucketAggs": [
 				{ "type": "date_histogram", "field": "@timestamp", "id": "2" }
 			],
@@ -1453,7 +1453,7 @@ func TestSettingsCasting(t *testing.T) {
 
 	t.Run("Correctly transforms serial_diff settings (from frontend tests)", func(t *testing.T) {
 		c := newFakeClient()
-		_, err := executeTsdbQuery(c, `{
+		_, err := executeElasticsearchDataQuery(c, `{
 			"bucketAggs": [
 				{ "type": "date_histogram", "field": "@timestamp", "id": "1" }
 			],
@@ -1478,7 +1478,7 @@ func TestSettingsCasting(t *testing.T) {
 	t.Run("Correctly transforms serial_diff settings", func(t *testing.T) {
 		// This test is with pipelineAgg and is passing. Same test without pipelineAgg is failing.
 		c := newFakeClient()
-		_, err := executeTsdbQuery(c, `{
+		_, err := executeElasticsearchDataQuery(c, `{
 			"bucketAggs": [
 				{ "type": "date_histogram", "field": "@timestamp", "id": "2" }
 			],
@@ -1506,7 +1506,7 @@ func TestSettingsCasting(t *testing.T) {
 	t.Run("Date Histogram Settings", func(t *testing.T) {
 		t.Run("Correctly transforms date_histogram settings", func(t *testing.T) {
 			c := newFakeClient()
-			_, err := executeTsdbQuery(c, `{
+			_, err := executeElasticsearchDataQuery(c, `{
 				"bucketAggs": [
 					{
 						"type": "date_histogram",
@@ -1540,7 +1540,7 @@ func TestSettingsCasting(t *testing.T) {
 
 		t.Run("Correctly uses already int min_doc_count", func(t *testing.T) {
 			c := newFakeClient()
-			_, err := executeTsdbQuery(c, `{
+			_, err := executeElasticsearchDataQuery(c, `{
 				"bucketAggs": [
 					{
 						"type": "date_histogram",
@@ -1575,7 +1575,7 @@ func TestSettingsCasting(t *testing.T) {
 		t.Run("interval parameter", func(t *testing.T) {
 			t.Run("Uses fixed_interval", func(t *testing.T) {
 				c := newFakeClient()
-				_, err := executeTsdbQuery(c, `{
+				_, err := executeElasticsearchDataQuery(c, `{
 					"bucketAggs": [
 						{
 							"type": "date_histogram",
@@ -1603,7 +1603,7 @@ func TestSettingsCasting(t *testing.T) {
 	t.Run("Inline Script", func(t *testing.T) {
 		t.Run("Correctly handles scripts", func(t *testing.T) {
 			c := newFakeClient()
-			_, err := executeTsdbQuery(c, `{
+			_, err := executeElasticsearchDataQuery(c, `{
 				"bucketAggs": [
 					{ "type": "date_histogram", "field": "@timestamp", "id": "2" }
 				],
@@ -1641,7 +1641,7 @@ func TestSettingsCasting(t *testing.T) {
 	t.Run("Field property (from frontend tests)", func(t *testing.T) {
 		t.Run("Should use timeField from datasource when not specified", func(t *testing.T) {
 			c := newFakeClient()
-			_, err := executeTsdbQuery(c, `{
+			_, err := executeElasticsearchDataQuery(c, `{
 				"metrics": [{ "type": "count", "id": "1" }],
 				"bucketAggs": [
 					{ "type": "date_histogram", "id": "2", "settings": { "min_doc_count": "1" } }
@@ -1656,7 +1656,7 @@ func TestSettingsCasting(t *testing.T) {
 
 		t.Run("Should use field from bucket agg when specified", func(t *testing.T) {
 			c := newFakeClient()
-			_, err := executeTsdbQuery(c, `{
+			_, err := executeElasticsearchDataQuery(c, `{
 				"metrics": [{ "type": "count", "id": "1" }],
 				"bucketAggs": [
 					{ "type": "date_histogram", "id": "2", "field": "@time", "settings": { "min_doc_count": "1" } }
@@ -1671,7 +1671,7 @@ func TestSettingsCasting(t *testing.T) {
 
 		t.Run("Should use fixed_interval", func(t *testing.T) {
 			c := newFakeClient()
-			_, err := executeTsdbQuery(c, `{
+			_, err := executeElasticsearchDataQuery(c, `{
 				"metrics": [{ "type": "count", "id": "1" }],
 				"bucketAggs": [
 					{ "type": "date_histogram", "id": "2", "field": "@time", "settings": { "min_doc_count": "1", "interval": "1d" } }
@@ -1737,7 +1737,7 @@ func newDataQuery(body string) (backend.QueryDataRequest, error) {
 	}, nil
 }
 
-func executeTsdbQuery(c es.Client, body string, from, to time.Time) (
+func executeElasticsearchDataQuery(c es.Client, body string, from, to time.Time) (
 	*backend.QueryDataResponse, error) {
 	timeRange := backend.TimeRange{
 		From: from,
@@ -1751,6 +1751,6 @@ func executeTsdbQuery(c es.Client, body string, from, to time.Time) (
 			},
 		},
 	}
-	query := newTimeSeriesQuery(c, dataRequest.Queries)
+	query := newElasticsearchDataQuery(c, dataRequest.Queries)
 	return query.execute()
 }

--- a/pkg/tsdb/elasticsearch/elasticsearch.go
+++ b/pkg/tsdb/elasticsearch/elasticsearch.go
@@ -58,7 +58,7 @@ func queryData(ctx context.Context, queries []backend.DataQuery, dsInfo *es.Data
 	if err != nil {
 		return &backend.QueryDataResponse{}, err
 	}
-	query := newTimeSeriesQuery(client, queries)
+	query := newElasticsearchDataQuery(client, queries)
 	return query.execute()
 }
 


### PR DESCRIPTION
Part of https://github.com/grafana/grafana/issues/54011. We've had a file with name `time_series_query`, but we were running there multiple types of queries - time series, logs, raw data, raw document. Therefore naming here is misleading. This PR renames files, functions, structs to be more inclusive. 