### PR TITLE
docs: Updates installation instruction for Debian/Ubuntu

### DIFF
--- a/docs/sources/administration/enterprise-licensing/_index.md
+++ b/docs/sources/administration/enterprise-licensing/_index.md
@@ -99,7 +99,7 @@ GF_SERVER_ROOT_URL=https://grafana.example.com/
 
 ### Step 4. Restart Grafana
 
-To finalize the installation of Grafana Enterprise, restart Grafana to enable all Grafana Enterprise features. Refer to [restart Grafana]({{< relref "../../setup-grafana/restart-grafana/" >}}) for more information.
+To finalize the installation of Grafana Enterprise, restart Grafana to enable all Grafana Enterprise features. Refer to [restart Grafana]({{< relref "../../setup-grafana/start-restart-grafana/" >}}) for more information.
 
 ## License expiration
 
@@ -121,7 +121,7 @@ If your license has expired, most of Grafana keeps working as normal. Some enter
 2. Log in to your [Grafana Cloud Account](/login) and make sure you're in the correct organization in the dropdown at the top of the page.
 3. Under the **Grafana Enterprise** section in the menu bar to the left, choose licenses and download the currently valid license with which you want to run Grafana. If you cannot see a valid license on Grafana.com, please contact your account manager at Grafana Labs to renew your subscription.
 4. Replace the current `license.jwt`-file with the one you've just downloaded.
-5. [Restart Grafana]({{< relref "../../setup-grafana/restart-grafana/" >}}).
+5. [Restart Grafana]({{< relref "../../setup-grafana/start-restart-grafana/" >}}).
 
 ### If your license expires
 

--- a/docs/sources/administration/enterprise-licensing/activate-aws-marketplace-license/activate-license-on-eks/index.md
+++ b/docs/sources/administration/enterprise-licensing/activate-aws-marketplace-license/activate-license-on-eks/index.md
@@ -121,6 +121,6 @@ To restart Grafana on a Kubernetes cluster,
 
 1. After you update the service, navigate to your Grafana instance, sign in with Grafana Admin credentials, and navigate to the Statistics and Licensing page to validate that your license is active.
 
-For more information about restarting Grafana, refer to [Restart Grafana]({{< relref "../../../../setup-grafana/restart-grafana/" >}}).
+For more information about restarting Grafana, refer to [Restart Grafana]({{< relref "../../../../setup-grafana/start-restart-grafana/" >}}).
 
 > If you experience issues when you update the EKS cluster, refer to [Amazon EKS troubleshooting](https://docs.aws.amazon.com/eks/latest/userguide/troubleshooting.html).

--- a/docs/sources/administration/enterprise-licensing/activate-aws-marketplace-license/activate-license-on-instance-outside-aws/index.md
+++ b/docs/sources/administration/enterprise-licensing/activate-aws-marketplace-license/activate-license-on-instance-outside-aws/index.md
@@ -127,4 +127,4 @@ Choose one of the following options to update the [license_validation_type]({{< 
 
 To activate Grafana Enterprise features, start (or restart) Grafana.
 
-For information about restarting Grafana, refer to [Restart Grafana]({{< relref "../../../../setup-grafana/restart-grafana/" >}}).
+For information about restarting Grafana, refer to [Restart Grafana]({{< relref "../../../../setup-grafana/start-restart-grafana/" >}}).

--- a/docs/sources/setup-grafana/installation/debian/index.md
+++ b/docs/sources/setup-grafana/installation/debian/index.md
@@ -3,17 +3,18 @@ aliases:
   - ../../installation/debian/
   - ../../installation/installation/debian/
 description: Install guide for Grafana on Debian or Ubuntu
-title: Install on Debian or Ubuntu
+title: Install Grafana on Debian or Ubuntu
+menutitle: Debian or Ubuntu
 weight: 100
 ---
 
-# Install on Debian or Ubuntu
+# Install Grafana on Debian or Ubuntu
 
 This topic explains how to install Grafana dependencies, install Grafana on Linux Debian or Ubuntu, and start the Grafana server on your Debian or Ubuntu system.
 
-You can install Grafana using the Grafana Labs APT repository, by downloading a `.deb` package, or by downloading a binary `.tar.gz` file.
+There are multiple ways to install Grafana: using the Grafana Labs APT repository, by downloading a `.deb` package, or by downloading a binary `.tar.gz` file. Choose only one of the methods below that best suits your needs.
 
-If you install via the `.deb` package or `.tar.gz` file, then you must manually update Grafana for each new version.
+> **Note:** If you install via the `.deb` package or `.tar.gz` file, then you must manually update Grafana for each new version.
 
 ## Install from APT repository
 
@@ -27,8 +28,6 @@ If you install from the APT repository, Grafana automatically updates when you r
 | Grafana OSS (Beta)        | grafana            | `https://apt.grafana.com beta main`   |
 
 > **Note:** Grafana Enterprise is the recommended and default edition. It is available for free and includes all the features of the OSS edition. You can also upgrade to the [full Enterprise feature set](https://grafana.com/products/enterprise/?utm_source=grafana-install-page), which has support for [Enterprise plugins](https://grafana.com/grafana/plugins/?enterprise=1&utcm_source=grafana-install-page).
-
-### Steps
 
 Complete the following steps to install Grafana from the APT repository:
 
@@ -69,8 +68,6 @@ Complete the following steps to install Grafana from the APT repository:
 
 If you choose not to install Grafana using APT, you can download and install Grafana using the deb package or as a standalone binary.
 
-### Steps
-
 Complete the following steps to install Grafana using DEB or the standalone binaries:
 
 1. Navigate to the [Grafana download page](https://grafana.com/grafana/download).
@@ -88,6 +85,8 @@ Complete the following steps to install Grafana using DEB or the standalone bina
 The following sections provide instructions for starting the `grafana-server` process as the `grafana` user, which was created during the package installation.
 
 If you installed with the APT repository or `.deb` package, then you can start the server using `systemd` or `init.d`. If you installed a binary `.tar.gz` file, then you need to execute the binary.
+
+> **Note:** The following subsections describe three methods of starting the Grafana server: with systemd, initd, or by directly running the binary. You should follow only one set of instructions, depending on how your machine is configured.
 
 ### Start the Grafana server with systemd
 

--- a/docs/sources/setup-grafana/installation/debian/index.md
+++ b/docs/sources/setup-grafana/installation/debian/index.md
@@ -152,7 +152,7 @@ To start the Grafana server, run the following command:
 
 ## Upgrade Grafana
 
-While the process for upgrading Grafana is very similar to installing Grafana, there are important backup tasks you should perform. Refer to [Upgrade Grafana]({{< relref "../../../upgrade-guide/" >}}) for guidance on updating an existing installation.
+While the process for upgrading Grafana is similar to installing Grafana, there are important backup tasks you should perform. Refer to [Upgrade Grafana]({{< relref "../../../upgrade-guide/" >}}) for guidance on updating an existing installation.
 
 ## Next steps
 

--- a/docs/sources/setup-grafana/installation/debian/index.md
+++ b/docs/sources/setup-grafana/installation/debian/index.md
@@ -21,7 +21,7 @@ Complete the following steps to download and install Grafana:
 
 1. On the [Grafana download page](https://grafana.com/grafana/download), select the Grafana version you want to install.
    - The most recent Grafana version is selected by default.
-   - The **Version** field displays only finished releases. If you want to install a beta version, click **Nightly Builds** and then select a version.
+   - The **Version** field displays only tagged releases. If you want to install a nightly build, click **Nightly Builds** and then select a version.
 1. Select an **Edition**.
    - **Enterprise:** This is the recommended version. It is functionally identical to the open source version, but includes features you can unlock with a license if you so choose.
    - **Open Source:** This version is functionally identical to the Enterprise version, but you will need to download the Enterprise version if you want Enterprise features.

--- a/docs/sources/setup-grafana/installation/debian/index.md
+++ b/docs/sources/setup-grafana/installation/debian/index.md
@@ -46,7 +46,7 @@ Complete the following steps to install Grafana from the APT repository:
    echo "deb [signed-by=/usr/share/keyrings/grafana.key] https://apt.grafana.com stable main" | sudo tee -a /etc/apt/sources.list.d/grafana.list
    ```
 
-1. To add a respository for beta releases, run the following command:
+1. To add a repository for beta releases, run the following command:
 
    ```bash
    echo "deb [signed-by=/usr/share/keyrings/grafana.key] https://apt.grafana.com beta main" | sudo tee -a /etc/apt/sources.list.d/grafana.list

--- a/docs/sources/setup-grafana/installation/debian/index.md
+++ b/docs/sources/setup-grafana/installation/debian/index.md
@@ -147,7 +147,7 @@ The `grafana-server` binary .tar.gz needs the working directory to be the root i
 To start the Grafana server, run the following command:
 
 ```bash
-./bin/grafana-server web
+./bin/grafana-server
 ```
 
 ## Upgrade Grafana

--- a/docs/sources/setup-grafana/installation/debian/index.md
+++ b/docs/sources/setup-grafana/installation/debian/index.md
@@ -11,17 +11,24 @@ weight: 100
 
 This page explains how to install Grafana dependencies, download and install Grafana, get the service up and running on your Debian or Ubuntu system, and also describes the installation package details.
 
-## Repository migration (November 8th 2022)
-
-From that date, Grafana packages will be served from a new repository (<packages.grafana.com/deb/{product}> -> <apt.grafana.com>). The new repository serves, from a single APT configuration, all Grafana OSS products, as well as Grafana Enterprise.
-
-The old URLs will still work, serving the content from the new repository, but you may encounter warnings about some repository attributes changing (e.g. `Origin` and `Label`).
-
 ## Note on upgrading
 
 While the process for upgrading Grafana is very similar to installing Grafana, there are some key backup steps you should perform. Read [Upgrading Grafana]({{< relref "../../../upgrade-guide/" >}}) for tips and guidance on updating an existing installation.
 
-## 1. Download and install
+## Download and install Grafana
+
+Complete the following steps to download and install Grafana:
+
+1. On the [Grafana download page](https://grafana.com/grafana/download), select the Grafana version you want to install.
+   - The most recent Grafana version is selected by default.
+   - The **Version** field displays only finished releases. If you want to install a beta version, click **Nightly Builds** and then select a version.
+1. Select an **Edition**.
+   - **Enterprise:** This is the recommended version. It is functionally identical to the open source version, but includes features you can unlock with a license if you so choose.
+   - **Open Source:** This version is functionally identical to the Enterprise version, but you will need to download the Enterprise version if you want Enterprise features.
+1. Depending on which system you are running, click the **Linux** or **ARM** tab on the download page.
+1. Copy and paste the code from the installation page into your command line and run.
+
+---
 
 You can install Grafana using our official APT repository, by downloading a `.deb` package, or by downloading a binary `.tar.gz` file.
 
@@ -98,7 +105,9 @@ wget <tar.gz package url>
 sudo tar -zxvf <tar.gz package>
 ```
 
-## 2. Start the server
+---
+
+## Start the server
 
 This starts the `grafana-server` process as the `grafana` user, which was created during the package installation.
 

--- a/docs/sources/setup-grafana/installation/debian/index.md
+++ b/docs/sources/setup-grafana/installation/debian/index.md
@@ -39,7 +39,7 @@ To follow these instructions, you need:
 
 Complete the following steps to install Grafana from the APT repository:
 
-1. To install the latest release, run the following commands:
+1. To install required packages and download the Grafana repository signing key, run the following commands:
 
    ```bash
    sudo apt-get install -y apt-transport-https
@@ -59,9 +59,10 @@ Complete the following steps to install Grafana from the APT repository:
    echo "deb [signed-by=/usr/share/keyrings/grafana.key] https://apt.grafana.com beta main" | sudo tee -a /etc/apt/sources.list.d/grafana.list
    ```
 
-1. After you add the repository, run one of the following commands:
+1. After you add the repository, run the following commands to install the OSS or Enterprise release:
 
    ```bash
+   # Update the list of available packages
    sudo apt-get update
 
    # Install the latest OSS release:
@@ -71,9 +72,9 @@ Complete the following steps to install Grafana from the APT repository:
    sudo apt-get install grafana-enterprise
    ```
 
-## Install Grafana using DEB or the standalone binaries
+## Install Grafana using a deb package or as a standalone binary
 
-If you choose not to install Grafana using APT, you can download and install Grafana using DEB or the standalone binaries.
+If you choose not to install Grafana using APT, you can download and install Grafana using the deb package or as a standalone binary.
 
 ### Before you begin
 
@@ -117,7 +118,7 @@ Complete the following steps to start the Grafana server with systemd and verify
 1. To verify that the service is running, run the following command:
 
    ```
-   Need input here
+   sudo systemctl status grafana-server
    ```
 
 1. To configure the Grafana server to start at boot, run the following command:
@@ -144,7 +145,7 @@ Complete the following steps to start the Grafana service and verify that it is 
 1. To verify that the service is running, run the following command:
 
    ```
-   Need input here
+   sudo service grafana-server status
    ```
 
 1. To configure the Grafana server to start at boot, run the following command:

--- a/docs/sources/setup-grafana/installation/debian/index.md
+++ b/docs/sources/setup-grafana/installation/debian/index.md
@@ -9,7 +9,7 @@ weight: 100
 
 # Install on Debian or Ubuntu
 
-This topic explains how to install Grafana dependencies, install Grafana on Linux Debian or Ubuntu, and start the Grafana server on your Debian or Ubuntu system. This topic also describes the contents of the installation package.
+This topic explains how to install Grafana dependencies, install Grafana on Linux Debian or Ubuntu, and start the Grafana server on your Debian or Ubuntu system.
 
 You can install Grafana using the Grafana Labs APT repository, by downloading a `.deb` package, or by downloading a binary `.tar.gz` file.
 
@@ -17,7 +17,7 @@ If you install via the `.deb` package or `.tar.gz` file, then you must manually 
 
 ## Install from APT repository
 
-If you install from the APT repository, Grafana automatically updates every time you run `apt-get update`.
+If you install from the APT repository, Grafana automatically updates when you run `apt-get update`.
 
 | Grafana Version           | Package            | Repository                            |
 | ------------------------- | ------------------ | ------------------------------------- |
@@ -27,13 +27,6 @@ If you install from the APT repository, Grafana automatically updates every time
 | Grafana OSS (Beta)        | grafana            | `https://apt.grafana.com beta main`   |
 
 > **Note:** Grafana Enterprise is the recommended and default edition. It is available for free and includes all the features of the OSS edition. You can also upgrade to the [full Enterprise feature set](https://grafana.com/products/enterprise/?utm_source=grafana-install-page), which has support for [Enterprise plugins](https://grafana.com/grafana/plugins/?enterprise=1&utcm_source=grafana-install-page).
-
-### Before you begin
-
-To follow these instructions, you need:
-
-- xxx
-- xxx
 
 ### Steps
 
@@ -47,13 +40,13 @@ Complete the following steps to install Grafana from the APT repository:
    sudo wget -q -O /usr/share/keyrings/grafana.key https://apt.grafana.com/gpg.key
    ```
 
-1. To add a repository for stable releases, run the following commands:
+1. To add a repository for stable releases, run the following command:
 
    ```bash
    echo "deb [signed-by=/usr/share/keyrings/grafana.key] https://apt.grafana.com stable main" | sudo tee -a /etc/apt/sources.list.d/grafana.list
    ```
 
-1. To add a respository for beta releases, run the following commands:
+1. To add a respository for beta releases, run the following command:
 
    ```bash
    echo "deb [signed-by=/usr/share/keyrings/grafana.key] https://apt.grafana.com beta main" | sudo tee -a /etc/apt/sources.list.d/grafana.list
@@ -75,13 +68,6 @@ Complete the following steps to install Grafana from the APT repository:
 ## Install Grafana using a deb package or as a standalone binary
 
 If you choose not to install Grafana using APT, you can download and install Grafana using the deb package or as a standalone binary.
-
-### Before you begin
-
-To follow these instructions, you need:
-
-- xxx
-- xxx
 
 ### Steps
 
@@ -164,21 +150,10 @@ To start the Grafana server, run the following command:
 ./bin/grafana-server web
 ```
 
-## Package details
-
-- Installs binary to `/usr/sbin/grafana-server`
-- Installs Init.d script to `/etc/init.d/grafana-server`
-- Creates default file (environment vars) to `/etc/default/grafana-server`
-- Installs configuration file to `/etc/grafana/grafana.ini`
-- Installs systemd service (if systemd is available) name `grafana-server.service`
-- The default configuration sets the log file at `/var/log/grafana/grafana.log`
-- The default configuration specifies a SQLite3 db at `/var/lib/grafana/grafana.db`
-- Installs HTML/JS/CSS and other Grafana files at `/usr/share/grafana`
-
 ## Upgrade Grafana
 
 While the process for upgrading Grafana is very similar to installing Grafana, there are important backup tasks you should perform. Refer to [Upgrade Grafana]({{< relref "../../../upgrade-guide/" >}}) for guidance on updating an existing installation.
 
 ## Next steps
 
-- [Start the Grafana server]({{< relref "../../../restart-grafana/" >}})
+- [Start the Grafana server]({{< relref "../../start-restart-grafana/" >}})

--- a/docs/sources/setup-grafana/installation/debian/index.md
+++ b/docs/sources/setup-grafana/installation/debian/index.md
@@ -13,6 +13,8 @@ This topic explains how to install Grafana dependencies, install Grafana on Linu
 
 You can install Grafana using the Grafana Labs APT repository, by downloading a `.deb` package, or by downloading a binary `.tar.gz` file.
 
+If you install via the `.deb` package or `.tar.gz` file, then you will need to manually update Grafana for each new version.
+
 ## Download and install Grafana
 
 Complete the following steps to download and install Grafana on Debian or Ubuntu:

--- a/docs/sources/setup-grafana/installation/debian/index.md
+++ b/docs/sources/setup-grafana/installation/debian/index.md
@@ -9,15 +9,82 @@ weight: 100
 
 # Install on Debian or Ubuntu
 
-This topic explains how to install Grafana dependencies, install Grafana on Linux Debian or Ubuntu, get the service up and running on your Debian or Ubuntu system, and describes the contents of the installation package.
+This topic explains how to install Grafana dependencies, install Grafana on Linux Debian or Ubuntu, and start the Grafana server on your Debian or Ubuntu system. This topic also describes the contents of the installation package.
 
 You can install Grafana using the Grafana Labs APT repository, by downloading a `.deb` package, or by downloading a binary `.tar.gz` file.
 
-If you install via the `.deb` package or `.tar.gz` file, then you will need to manually update Grafana for each new version.
+If you install via the `.deb` package or `.tar.gz` file, then you must manually update Grafana for each new version.
 
-## Download and install Grafana
+## Install from APT repository
 
-Complete the following steps to download and install Grafana on Debian or Ubuntu:
+If you install from the APT repository, Grafana automatically updates every time you run `apt-get update`.
+
+| Grafana Version           | Package            | Repository                            |
+| ------------------------- | ------------------ | ------------------------------------- |
+| Grafana Enterprise        | grafana-enterprise | `https://apt.grafana.com stable main` |
+| Grafana Enterprise (Beta) | grafana-enterprise | `https://apt.grafana.com beta main`   |
+| Grafana OSS               | grafana            | `https://apt.grafana.com stable main` |
+| Grafana OSS (Beta)        | grafana            | `https://apt.grafana.com beta main`   |
+
+> **Note:** Grafana Enterprise is the recommended and default edition. It is available for free and includes all the features of the OSS edition. You can also upgrade to the [full Enterprise feature set](https://grafana.com/products/enterprise/?utm_source=grafana-install-page), which has support for [Enterprise plugins](https://grafana.com/grafana/plugins/?enterprise=1&utcm_source=grafana-install-page).
+
+### Before you begin
+
+To follow these instructions, you need:
+
+- xxx
+- xxx
+
+### Steps
+
+Complete the following steps to install Grafana from the APT repository:
+
+1. To install the latest release, run the following commands:
+
+   ```bash
+   sudo apt-get install -y apt-transport-https
+   sudo apt-get install -y software-properties-common wget
+   sudo wget -q -O /usr/share/keyrings/grafana.key https://apt.grafana.com/gpg.key
+   ```
+
+1. To add a repository for stable releases, run the following commands:
+
+   ```bash
+   echo "deb [signed-by=/usr/share/keyrings/grafana.key] https://apt.grafana.com stable main" | sudo tee -a /etc/apt/sources.list.d/grafana.list
+   ```
+
+1. To add a respository for beta releases, run the following commands:
+
+   ```bash
+   echo "deb [signed-by=/usr/share/keyrings/grafana.key] https://apt.grafana.com beta main" | sudo tee -a /etc/apt/sources.list.d/grafana.list
+   ```
+
+1. After you add the repository, run one of the following commands:
+
+   ```bash
+   sudo apt-get update
+
+   # Install the latest OSS release:
+   sudo apt-get install grafana
+
+   # Install the latest Enterprise release:
+   sudo apt-get install grafana-enterprise
+   ```
+
+## Install Grafana using DEB or the standalone binaries
+
+If you choose not to install Grafana using APT, you can download and install Grafana using DEB or the standalone binaries.
+
+### Before you begin
+
+To follow these instructions, you need:
+
+- xxx
+- xxx
+
+### Steps
+
+Complete the following steps to install Grafana using DEB or the standalone binaries:
 
 1. Navigate to the [Grafana download page](https://grafana.com/grafana/download).
 1. Select the Grafana version you want to install.
@@ -29,97 +96,68 @@ Complete the following steps to download and install Grafana on Debian or Ubuntu
 1. Depending on which system you are running, click the **Linux** or **ARM** tab on the download page.
 1. Copy and paste the code from the installation page into your command line and run.
 
-### Install from APT repository
+## 2. Start the server
 
-If you install from the APT repository, then Grafana is automatically updated every time you run `apt-get update`.
-
-| Grafana Version           | Package            | Repository                            |
-| ------------------------- | ------------------ | ------------------------------------- |
-| Grafana Enterprise        | grafana-enterprise | `https://apt.grafana.com stable main` |
-| Grafana Enterprise (Beta) | grafana-enterprise | `https://apt.grafana.com beta main`   |
-| Grafana OSS               | grafana            | `https://apt.grafana.com stable main` |
-| Grafana OSS (Beta)        | grafana            | `https://apt.grafana.com beta main`   |
-
-> **Note:** Grafana Enterprise is the recommended and default edition. It is available for free and includes all the features of the OSS edition. You can also upgrade to the [full Enterprise feature set](https://grafana.com/products/enterprise/?utm_source=grafana-install-page), which has support for [Enterprise plugins](https://grafana.com/grafana/plugins/?enterprise=1&utcm_source=grafana-install-page).
-
-#### To install the latest release:
-
-```bash
-sudo apt-get install -y apt-transport-https
-sudo apt-get install -y software-properties-common wget
-sudo wget -q -O /usr/share/keyrings/grafana.key https://apt.grafana.com/gpg.key
-```
-
-Add this repository for stable releases:
-
-```bash
-echo "deb [signed-by=/usr/share/keyrings/grafana.key] https://apt.grafana.com stable main" | sudo tee -a /etc/apt/sources.list.d/grafana.list
-```
-
-Add this repository if you want beta releases:
-
-```bash
-echo "deb [signed-by=/usr/share/keyrings/grafana.key] https://apt.grafana.com beta main" | sudo tee -a /etc/apt/sources.list.d/grafana.list
-```
-
-After you add the repository:
-
-```bash
-sudo apt-get update
-
-# Install the latest OSS release:
-sudo apt-get install grafana
-
-# Install the latest Enterprise release:
-sudo apt-get install grafana-enterprise
-```
-
-## Start the Grafana server
-
-This starts the `grafana-server` process as the `grafana` user, which was created during the package installation.
+The following sections provide instructions for starting the `grafana-server` process as the `grafana` user, which was created during the package installation.
 
 If you installed with the APT repository or `.deb` package, then you can start the server using `systemd` or `init.d`. If you installed a binary `.tar.gz` file, then you need to execute the binary.
 
-### Start the server with systemd
+### Start the Grafana server with systemd
 
-To start the service and verify that the service has started:
+Complete the following steps to start the Grafana server with systemd and verify that it is running:
 
-```bash
-sudo systemctl daemon-reload
-sudo systemctl start grafana-server
-sudo systemctl status grafana-server
-```
+1. To start the service, run the following commands:
 
-Configure the Grafana server to start at boot:
+   ```bash
+   sudo systemctl daemon-reload
+   sudo systemctl start grafana-server
+   sudo systemctl status grafana-server
+   ```
 
-```bash
-sudo systemctl enable grafana-server.service
-```
+1. To verify that the service is running, run the following command:
 
-#### Serving Grafana on a port < 1024
+   ```
+   Need input here
+   ```
+
+1. To configure the Grafana server to start at boot, run the following command:
+
+   ```bash
+   sudo systemctl enable grafana-server.service
+   ```
+
+#### Serve Grafana on a port < 1024
 
 {{< docs/shared "systemd/bind-net-capabilities.md" >}}
 
 ### Start the server with init.d
 
-To start the service and verify that the service has started:
+Complete the following steps to start the Grafana service and verify that it is running:
 
-```bash
-sudo service grafana-server start
-sudo service grafana-server status
-```
+1. To start the Grafana server, run the following commands:
 
-Configure the Grafana server to start at boot:
+   ```bash
+   sudo service grafana-server start
+   sudo service grafana-server status
+   ```
 
-```bash
-sudo update-rc.d grafana-server defaults
-```
+1. To verify that the service is running, run the following command:
 
-### Execute the binary
+   ```
+   Need input here
+   ```
+
+1. To configure the Grafana server to start at boot, run the following command:
+
+   ```bash
+   sudo update-rc.d grafana-server defaults
+   ```
+
+### Start the server using the binary
 
 The `grafana-server` binary .tar.gz needs the working directory to be the root install directory where the binary and the `public` folder are located.
 
-Start Grafana by running:
+To start the Grafana server, run the following command:
 
 ```bash
 ./bin/grafana-server web

--- a/docs/sources/setup-grafana/installation/debian/index.md
+++ b/docs/sources/setup-grafana/installation/debian/index.md
@@ -9,28 +9,23 @@ weight: 100
 
 # Install on Debian or Ubuntu
 
-This page explains how to install Grafana dependencies, download and install Grafana, get the service up and running on your Debian or Ubuntu system, and also describes the installation package details.
+This topic explains how to install Grafana dependencies, install Grafana on Linux Debian or Ubuntu, get the service up and running on your Debian or Ubuntu system, and describes the contents of the installation package.
 
-## Note on upgrading
-
-While the process for upgrading Grafana is very similar to installing Grafana, there are some key backup steps you should perform. Read [Upgrading Grafana]({{< relref "../../../upgrade-guide/" >}}) for tips and guidance on updating an existing installation.
+You can install Grafana using the Grafana Labs APT repository, by downloading a `.deb` package, or by downloading a binary `.tar.gz` file.
 
 ## Download and install Grafana
 
-Complete the following steps to download and install Grafana:
+Complete the following steps to download and install Grafana on Debian or Ubuntu:
 
-1. On the [Grafana download page](https://grafana.com/grafana/download), select the Grafana version you want to install.
+1. Navigate to the [Grafana download page](https://grafana.com/grafana/download).
+1. Select the Grafana version you want to install.
    - The most recent Grafana version is selected by default.
    - The **Version** field displays only tagged releases. If you want to install a nightly build, click **Nightly Builds** and then select a version.
 1. Select an **Edition**.
-   - **Enterprise:** This is the recommended version. It is functionally identical to the open source version, but includes features you can unlock with a license if you so choose.
+   - **Enterprise:** This is the recommended version. It is functionally identical to the open source version, but includes features you can unlock with a license, if you so choose.
    - **Open Source:** This version is functionally identical to the Enterprise version, but you will need to download the Enterprise version if you want Enterprise features.
 1. Depending on which system you are running, click the **Linux** or **ARM** tab on the download page.
 1. Copy and paste the code from the installation page into your command line and run.
-
----
-
-You can install Grafana using our official APT repository, by downloading a `.deb` package, or by downloading a binary `.tar.gz` file.
 
 ### Install from APT repository
 
@@ -77,37 +72,7 @@ sudo apt-get install grafana
 sudo apt-get install grafana-enterprise
 ```
 
-### Install .deb package
-
-If you install the `.deb` package, then you will need to manually update Grafana for each new version.
-
-1. On the [Grafana download page](https://grafana.com/grafana/download), select the Grafana version you want to install.
-   - The most recent Grafana version is selected by default.
-   - The **Version** field displays only finished releases. If you want to install a beta version, click **Nightly Builds** and then select a version.
-1. Select an **Edition**.
-   - **Enterprise** - Recommended download. Functionally identical to the open source version, but includes features you can unlock with a license if you so choose.
-   - **Open Source** - Functionally identical to the Enterprise version, but you will need to download the Enterprise version if you want Enterprise features.
-1. Depending on which system you are running, click **Linux** or **ARM**.
-1. Copy and paste the code from the installation page into your command line and run. It follows the pattern shown below.
-
-```bash
-sudo apt-get install -y adduser
-wget <.deb package url>
-sudo dpkg -i grafana<edition>_<version>_amd64.deb
-```
-
-## Install from binary .tar.gz file
-
-Download the latest [`.tar.gz` file](https://grafana.com/grafana/download?platform=linux) and extract it. The files extract into a folder named after the Grafana version downloaded. This folder contains all files required to run Grafana. There are no init scripts or install scripts in this package.
-
-```bash
-wget <tar.gz package url>
-sudo tar -zxvf <tar.gz package>
-```
-
----
-
-## Start the server
+## Start the Grafana server
 
 This starts the `grafana-server` process as the `grafana` user, which was created during the package installation.
 
@@ -169,10 +134,10 @@ Start Grafana by running:
 - The default configuration specifies a SQLite3 db at `/var/lib/grafana/grafana.db`
 - Installs HTML/JS/CSS and other Grafana files at `/usr/share/grafana`
 
+## Upgrade Grafana
+
+While the process for upgrading Grafana is very similar to installing Grafana, there are important backup tasks you should perform. Refer to [Upgrade Grafana]({{< relref "../../../upgrade-guide/" >}}) for guidance on updating an existing installation.
+
 ## Next steps
 
-Refer to the [Getting Started]({{< relref "../../../getting-started/build-first-dashboard/" >}}) guide for information about logging in, setting up data sources, and so on.
-
-## Configure Grafana
-
-Refer to the [Configuration]({{< relref "../../configure-grafana/" >}}) page for details on options for customizing your environment, logging, database, and so on.
+- [Start the Grafana server]({{< relref "../../../restart-grafana/" >}})

--- a/docs/sources/setup-grafana/installation/windows/index.md
+++ b/docs/sources/setup-grafana/installation/windows/index.md
@@ -37,8 +37,8 @@ To run Grafana, open your browser and go to the Grafana port (http://localhost:3
 
 1. Extract this folder to anywhere you want Grafana to run from.
 
-1. Start Grafana by executing `grafana-server.exe`, located in the `bin` directory, preferably from the command line. If you want to run Grafana as a Windows service, then download
-   [NSSM](https://nssm.cc/). It is very easy to add Grafana as a Windows service using that tool.
+Start Grafana by executing `grafana-server.exe`, located in the `bin` directory, preferably from the command line. If you want to run Grafana as a Windows service, then download
+[NSSM](https://nssm.cc/). It is very easy to add Grafana as a Windows service using that tool.
 
 To run Grafana, open your browser and go to the Grafana port (http://localhost:3000/ is default) and then follow the instructions in [Getting Started]({{< relref "../../../getting-started/build-first-dashboard/" >}}).
 

--- a/docs/sources/setup-grafana/restart-grafana.md
+++ b/docs/sources/setup-grafana/restart-grafana.md
@@ -9,7 +9,7 @@ weight: 300
 
 # Start the Grafana server
 
-This topic includes instructions for starting the Grafana server. For certain configuration changes, you might have to restart the Grafana server for them to take affect.
+This topic includes instructions for starting the Grafana server. For certain configuration changes, you might have to restart the Grafana server for them to take effect.
 
 The following instructions start the `grafana-server` process as the `grafana` user, which was created during the package installation.
 
@@ -19,44 +19,46 @@ If you installed with the APT repository or `.deb` package, then you can start t
 
 Starting and restarting the Grafana server depends on whether your Linux system uses `systemd` or `init.d`.
 
-### Start the server with systemd
+### Start the Grafana server with systemd
 
-Run the following commands to start the Grafana server with systemd.
+Complete the following steps to start the Grafana server with systemd and verify that it is running:
 
-#### Start the service
+1. To start the service, run the following commands:
 
-```bash
-sudo systemctl daemon-reload
-sudo systemctl start grafana-server
-sudo systemctl status grafana-server
-```
+   ```bash
+   sudo systemctl daemon-reload
+   sudo systemctl start grafana-server
+   sudo systemctl status grafana-server
+   ```
 
-#### Configure the Grafana server to start at boot
+1. To verify that the service is running, run the following command:
 
-```bash
-sudo systemctl enable grafana-server.service
-```
+   ```
+   Need input here
+   ```
 
-#### Verify the Grafana server status
+1. To configure the Grafana server to start at boot, run the following command:
 
-```bash
-sudo service grafana-server status
-```
+   ```bash
+   sudo systemctl enable grafana-server.service
+   ```
 
 #### Restart the server
 
-To restart the service, run the following commands:
+Complete the following steps to restart the Grafana server:
 
-```bash
-sudo systemctl restart grafana-server
-sudo systemctl status grafana-server
-```
+1. To restart the Grafana server, run the following commands:
 
-Alternately, you can configure the Grafana server to restart at boot:
+   ```bash
+   sudo systemctl restart grafana-server
+   sudo systemctl status grafana-server
+   ```
 
-```bash
-sudo systemctl enable grafana-server.service
-```
+1. To configure the Grafana server to restart at boot, run the following command:
+
+   ```bash
+   sudo systemctl enable grafana-server.service
+   ```
 
 > **Note:** SUSE or OpenSUSE users might need to start the server with the systemd method, then use the init.d method to configure Grafana to start at boot.
 
@@ -64,26 +66,34 @@ sudo systemctl enable grafana-server.service
 
 {{< docs/shared "systemd/bind-net-capabilities.md" >}}
 
-### Start the Grafana server with init.d
+### Start the server with init.d
 
-Run the following commands to start the Grafana server with init.d:
+Complete the following steps to start the Grafana service and verify that it is running:
 
-```bash
-sudo service grafana-server start
-sudo service grafana-server status
-```
+1. To start the Grafana server, run the following commands:
 
-Configure the Grafana server to start at boot:
+   ```bash
+   sudo service grafana-server start
+   sudo service grafana-server status
+   ```
 
-```bash
-sudo update-rc.d grafana-server defaults
-```
+1. To verify that the service is running, run the following command:
 
-### Execute the Grafana server binary
+   ```
+   Need input here
+   ```
+
+1. To configure the Grafana server to start at boot, run the following command:
+
+   ```bash
+   sudo update-rc.d grafana-server defaults
+   ```
+
+### Start the server using the binary
 
 The `grafana-server` binary .tar.gz needs the working directory to be the root install directory where the binary and the `public` folder are located.
 
-Run the following command to start Grafana:
+To start the Grafana server, run the following command:
 
 ```bash
 ./bin/grafana-server web

--- a/docs/sources/setup-grafana/restart-grafana.md
+++ b/docs/sources/setup-grafana/restart-grafana.md
@@ -1,58 +1,51 @@
 ---
 aliases:
   - ../installation/restart-grafana/
-description: Instructions for restarting Grafana
-title: Restart Grafana
+description: How to start the Grafana server
+title: Start the Grafana server
+menuTitle: Start Grafana
 weight: 300
 ---
 
-# Restart Grafana
+# Start the Grafana server
 
-Users often need to restart Grafana after they have made configuration changes. This topic provides detailed instructions on how to restart Grafana supported operating systems.
+This topic includes instructions for starting the Grafana server. For certain configuration changes, you might have to restart the Grafana server for them to take affect.
 
-- [Windows](#windows)
-- [MacOS](#macos)
-- [Linux](#linux)
-- [Docker](#docker)
+The following instructions start the `grafana-server` process as the `grafana` user, which was created during the package installation.
 
-## Windows
-
-To restart Grafana:
-
-1. Open the Services app.
-1. Right-click on the **Grafana** service.
-1. In the context menu, click **Restart**.
-
-## macOS
-
-Restart methods differ depending on whether you installed Grafana using Homebrew or as standalone macOS binaries.
-
-### Restart Grafana using Homebrew
-
-Use the [Homebrew](http://brew.sh/) restart command:
-
-```bash
-brew services restart grafana
-```
-
-### Restart standalone macOS binaries
-
-To restart Grafana:
-
-1. Open a terminal and go to the directory where you copied the install setup files.
-1. Run the command:
-
-```bash
-./bin/grafana-server web
-```
+If you installed with the APT repository or `.deb` package, then you can start the server using `systemd` or `init.d`. If you installed a binary `.tar.gz` file, then you execute the binary.
 
 ## Linux
 
-Restart methods differ depending on whether your Linux system uses `systemd` or `init.d`.
+Starting and restarting the Grafana server depends on whether your Linux system uses `systemd` or `init.d`.
 
-### Restart the server with systemd
+### Start the server with systemd
 
-To restart the service and verify that the service has started, run the following commands:
+Run the following commands to start the Grafana server with systemd.
+
+#### Start the service
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl start grafana-server
+sudo systemctl status grafana-server
+```
+
+#### Configure the Grafana server to start at boot
+
+```bash
+sudo systemctl enable grafana-server.service
+```
+
+#### Verify the Grafana server status
+
+```bash
+sudo service grafana-server status
+```
+
+#### Restart the server
+
+To restart the service, run the following commands:
 
 ```bash
 sudo systemctl restart grafana-server
@@ -65,38 +58,35 @@ Alternately, you can configure the Grafana server to restart at boot:
 sudo systemctl enable grafana-server.service
 ```
 
-> **Note:** SUSE or OpenSUSE users may need to start the server with the systemd method, then use the init.d method to configure Grafana to start at boot.
+> **Note:** SUSE or OpenSUSE users might need to start the server with the systemd method, then use the init.d method to configure Grafana to start at boot.
 
-### Restart the server with init.d
+#### Serve Grafana on a port < 1024
 
-To restart the service, run the following command:
+{{< docs/shared "systemd/bind-net-capabilities.md" >}}
 
-```bash
-sudo service grafana-server restart
-```
+### Start the Grafana server with init.d
 
-or
+Run the following commands to start the Grafana server with init.d:
 
 ```bash
-sudo /etc/init.d/grafana-server restart
-```
-
-Verify the status:
-
-```bash
+sudo service grafana-server start
 sudo service grafana-server status
 ```
 
-or
-
-```bash
-sudo /etc/init.d/grafana-server status
-```
-
-Alternately, you can configure the Grafana server to restart at boot:
+Configure the Grafana server to start at boot:
 
 ```bash
 sudo update-rc.d grafana-server defaults
+```
+
+### Execute the Grafana server binary
+
+The `grafana-server` binary .tar.gz needs the working directory to be the root install directory where the binary and the `public` folder are located.
+
+Run the following command to start Grafana:
+
+```bash
+./bin/grafana-server web
 ```
 
 ## Docker
@@ -130,3 +120,61 @@ This starts the Grafana server along with the three plugins specified in the YAM
 To restart the running container, use this command:
 
 `docker-compose restart grafana`
+
+## Windows
+
+Complete the following steps to start the Grafana server on Windows:
+
+1. Execute `grafana-server.exe`, which is located in the `bin` directory.
+
+   We recommend that you run `grafana-server.exe` from the command line.
+
+   If you want to run Grafana as a Windows service, you can download [NSSM](https://nssm.cc/).
+
+1. To run Grafana, open your browser and go to the Grafana port (http://localhost:3000/ is default).
+
+   > **Note:** The default Grafana port is `3000`. This port might require extra permissions on Windows. If it does not appear in the default port, you can try changing to a different port.
+
+1. If you need to change the port, complete the following steps:
+
+   a. In the `conf` directory, copy `sample.ini` to `custom.ini`.
+
+   > **Note:** You should edit `custom.ini`, never `defaults.ini`.
+
+   b. Edit `custom.ini` and uncomment the `http_port` configuration option (`;` is the comment character in ini files) and change it to something similar to `8080`, which should not require extra Windows privileges.
+
+To restart the Grafana server, complete the following steps:
+
+1. Open the **Services** app.
+1. Right-click on the **Grafana** service.
+1. In the context menu, click **Restart**.
+
+## macOS
+
+Restart methods differ depending on whether you installed Grafana using Homebrew or as standalone macOS binaries.
+
+### Restart Grafana using Homebrew
+
+Use the [Homebrew](http://brew.sh/) restart command:
+
+```bash
+brew services restart grafana
+```
+
+### Restart standalone macOS binaries
+
+To restart Grafana:
+
+1. Open a terminal and go to the directory where you copied the install setup files.
+1. Run the command:
+
+```bash
+./bin/grafana-server web
+```
+
+## Next steps
+
+After the Grafana server is up and running, consider taking the next steps:
+
+- Refer to [Get Started]({{< relref "../getting-started/" >}}) to learn how to build your first dashboard.
+- Refer to [Configuration]({{< relref "./configure-grafana/" >}}) to learn about how you can customize your environment.

--- a/docs/sources/setup-grafana/start-restart-grafana.md
+++ b/docs/sources/setup-grafana/start-restart-grafana.md
@@ -1,7 +1,7 @@
 ---
 aliases:
   - ../installation/restart-grafana/
-  - ../setup/restart-grafana/
+  - ../setup-grafana/restart-grafana/
 description: How to start the Grafana server
 title: Start the Grafana server
 menuTitle: Start Grafana

--- a/docs/sources/setup-grafana/start-restart-grafana.md
+++ b/docs/sources/setup-grafana/start-restart-grafana.md
@@ -21,7 +21,7 @@ Starting and restarting the Grafana server depends on whether your Linux system 
 
 ### Start the Grafana server with systemd
 
-Complete the following steps to start the Grafana server with systemd and verify that it is running:
+Complete the following steps to start the Grafana server using systemd and verify that it is running:
 
 1. To start the service, run the following commands:
 
@@ -34,41 +34,34 @@ Complete the following steps to start the Grafana server with systemd and verify
 1. To verify that the service is running, run the following command:
 
    ```
-   Need input here
-   ```
-
-1. To configure the Grafana server to start at boot, run the following command:
-
-   ```bash
-   sudo systemctl enable grafana-server.service
-   ```
-
-#### Restart the server
-
-Complete the following steps to restart the Grafana server:
-
-1. To restart the Grafana server, run the following commands:
-
-   ```bash
-   sudo systemctl restart grafana-server
    sudo systemctl status grafana-server
    ```
 
-1. To configure the Grafana server to restart at boot, run the following command:
+### Configure the Grafana server to start at boot using systemd
 
-   ```bash
-   sudo systemctl enable grafana-server.service
-   ```
+To configure the Grafana server to start at boot, run the following command:
 
-> **Note:** SUSE or OpenSUSE users might need to start the server with the systemd method, then use the init.d method to configure Grafana to start at boot.
+```bash
+sudo systemctl enable grafana-server.service
+```
 
 #### Serve Grafana on a port < 1024
 
 {{< docs/shared "systemd/bind-net-capabilities.md" >}}
 
-### Start the server with init.d
+### Restart the Grafana server using systemd
 
-Complete the following steps to start the Grafana service and verify that it is running:
+To restart the Grafana server, run the following commands:
+
+```bash
+sudo systemctl restart grafana-server
+```
+
+> **Note:** SUSE or OpenSUSE users might need to start the server with the systemd method, then use the init.d method to configure Grafana to start at boot.
+
+### Start the Grafana server using init.d
+
+Complete the following steps to start the Grafana server using init.d and verify that it is running:
 
 1. To start the Grafana server, run the following commands:
 
@@ -80,14 +73,24 @@ Complete the following steps to start the Grafana service and verify that it is 
 1. To verify that the service is running, run the following command:
 
    ```
-   Need input here
+   sudo service grafana-server status
    ```
 
-1. To configure the Grafana server to start at boot, run the following command:
+### Configure the Grafana server to start at boot using init.d
 
-   ```bash
-   sudo update-rc.d grafana-server defaults
-   ```
+To configure the Grafana server to start at boot, run the following command:
+
+```bash
+sudo update-rc.d grafana-server defaults
+```
+
+#### Restart the Grafana server using init.d
+
+To restart the Grafana server, run the following commands:
+
+```bash
+Need input
+```
 
 ### Start the server using the binary
 

--- a/docs/sources/setup-grafana/start-restart-grafana.md
+++ b/docs/sources/setup-grafana/start-restart-grafana.md
@@ -17,7 +17,7 @@ If you installed with the APT repository or `.deb` package, then you can start t
 
 ## Linux
 
-Starting and restarting the Grafana server depends on whether your Linux system uses `systemd` or `init.d`.
+The following subsections describe three methods of starting and restarting the Grafana server: with systemd, initd, or by directly running the binary. You should follow only one set of instructions, depending on how your machine is configured.
 
 ### Start the Grafana server with systemd
 

--- a/docs/sources/setup-grafana/start-restart-grafana.md
+++ b/docs/sources/setup-grafana/start-restart-grafana.md
@@ -1,7 +1,7 @@
 ---
 aliases:
   - ../installation/restart-grafana/
-  - ../setup-grafana/restart-grafana/
+  - ./restart-grafana/
 description: How to start the Grafana server
 title: Start the Grafana server
 menuTitle: Start Grafana

--- a/docs/sources/setup-grafana/start-restart-grafana.md
+++ b/docs/sources/setup-grafana/start-restart-grafana.md
@@ -1,6 +1,7 @@
 ---
 aliases:
   - ../installation/restart-grafana/
+  - ../setup/restart-grafana/
 description: How to start the Grafana server
 title: Start the Grafana server
 menuTitle: Start Grafana

--- a/docs/sources/setup-grafana/start-restart-grafana.md
+++ b/docs/sources/setup-grafana/start-restart-grafana.md
@@ -89,7 +89,7 @@ sudo update-rc.d grafana-server defaults
 To restart the Grafana server, run the following commands:
 
 ```bash
-Need input
+sudo service grafana-server restart
 ```
 
 ### Start the server using the binary
@@ -99,7 +99,7 @@ The `grafana-server` binary .tar.gz needs the working directory to be the root i
 To start the Grafana server, run the following command:
 
 ```bash
-./bin/grafana-server web
+./bin/grafana-server
 ```
 
 ## Docker
@@ -182,7 +182,7 @@ To restart Grafana:
 1. Run the command:
 
 ```bash
-./bin/grafana-server web
+./bin/grafana-server
 ```
 
 ## Next steps

--- a/docs/sources/shared/systemd/bind-net-capabilities.md
+++ b/docs/sources/shared/systemd/bind-net-capabilities.md
@@ -4,22 +4,24 @@ title: Serving Grafana on a port < 1024
 
 If you are using `systemd` and want to start Grafana on a port that is less than 1024, then you must add a `systemd` unit override.
 
-1. The following command creates an override file in your configured editor:
+1. Run the following command to create an override file in your configured editor.
 
-```bash
-# Alternatively, create a file in /etc/systemd/system/grafana-server.service.d/override.conf
-systemctl edit grafana-server.service
-```
+   ```bash
+   # Alternatively, create a file in /etc/systemd/system/grafana-server.service.d/override.conf
+   systemctl edit grafana-server.service
+   ```
 
-1 Add these additional settings to grant the `CAP_NET_BIND_SERVICE` capability. To read more about capabilities, see [the manual page on capabilities.](https://man7.org/linux/man-pages/man7/capabilities.7.html)
+1. Add the following additional settings to grant the `CAP_NET_BIND_SERVICE` capability.
 
-```
-[Service]
-# Give the CAP_NET_BIND_SERVICE capability
-CapabilityBoundingSet=CAP_NET_BIND_SERVICE
-AmbientCapabilities=CAP_NET_BIND_SERVICE
+   To learn more about capabilities, refer to [capabilities(7) — Linux manual page](https://man7.org/linux/man-pages/man7/capabilities.7.html).
 
-# A private user cannot have process capabilities on the host's user
-# namespace and thus CAP_NET_BIND_SERVICE has no effect.
-PrivateUsers=false
-```
+   ```
+   [Service]
+   # Give the CAP_NET_BIND_SERVICE capability
+   CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+   AmbientCapabilities=CAP_NET_BIND_SERVICE
+
+   # A private user cannot have process capabilities on the host's user
+   # namespace and thus CAP_NET_BIND_SERVICE has no effect.
+   PrivateUsers=false
+   ```

--- a/docs/sources/shared/systemd/bind-net-capabilities.md
+++ b/docs/sources/shared/systemd/bind-net-capabilities.md
@@ -2,7 +2,7 @@
 title: Serving Grafana on a port < 1024
 ---
 
-If you are using `systemd` and want to start Grafana on a port that is less than 1024, then you must add a `systemd` unit override.
+If you are using `systemd` and want to start Grafana on a port that is lower than 1024, you must add a `systemd` unit override.
 
 1. Run the following command to create an override file in your configured editor.
 


### PR DESCRIPTION
This PR makes updates to the Debian/Ubuntu installation instructions which attempts to rectify a disconnect between the instructions and the options available on the Grafana download page. 