### PR TITLE
Elasticsearch: Fix where name of frame is set

### DIFF
--- a/pkg/tsdb/elasticsearch/response_parser.go
+++ b/pkg/tsdb/elasticsearch/response_parser.go
@@ -382,8 +382,8 @@ func processBuckets(aggs map[string]interface{}, target *Query,
 
 func newTimeSeriesFrame(timeData []time.Time, tags map[string]string, values []*float64) *data.Frame {
 	frame := data.NewFrame("",
-		data.NewField("Time", nil, timeData),
-		data.NewField("Value", tags, values))
+		data.NewField(data.TimeSeriesTimeFieldName, nil, timeData),
+		data.NewField(data.TimeSeriesValueFieldName, tags, values))
 	frame.Meta = &data.FrameMeta{
 		Type: data.FrameTypeTimeSeriesMulti,
 	}

--- a/pkg/tsdb/elasticsearch/response_parser.go
+++ b/pkg/tsdb/elasticsearch/response_parser.go
@@ -382,8 +382,8 @@ func processBuckets(aggs map[string]interface{}, target *Query,
 
 func newTimeSeriesFrame(timeData []time.Time, tags map[string]string, values []*float64) *data.Frame {
 	frame := data.NewFrame("",
-		data.NewField("time", nil, timeData),
-		data.NewField("value", tags, values))
+		data.NewField("Time", nil, timeData),
+		data.NewField("Value", tags, values))
 	frame.Meta = &data.FrameMeta{
 		Type: data.FrameTypeTimeSeriesMulti,
 	}

--- a/pkg/tsdb/elasticsearch/response_parser.go
+++ b/pkg/tsdb/elasticsearch/response_parser.go
@@ -798,7 +798,7 @@ func nameFields(queryResult backend.DataResponse, target *Query) {
 			valueField := frame.Fields[1]
 			fieldName := getFieldName(*valueField, target, metricTypeCount)
 			if fieldName != "" {
-				valueField.SetConfig(&data.FieldConfig{DisplayNameFromDS: fieldName})
+				valueField.SetConfig(&data.FieldConfig{DisplayName: fieldName})
 			}
 		}
 	}

--- a/pkg/tsdb/elasticsearch/response_parser.go
+++ b/pkg/tsdb/elasticsearch/response_parser.go
@@ -82,7 +82,7 @@ func parseResponse(responses []*es.SearchResponse, targets []*Query, configuredF
 			if err != nil {
 				return &backend.QueryDataResponse{}, err
 			}
-			nameFields(queryRes, target)
+			nameFrames(queryRes, target)
 			trimDatapoints(queryRes, target)
 
 			result.Responses[target.RefID] = queryRes
@@ -778,7 +778,7 @@ func getSortedLabelValues(labels data.Labels) []string {
 	return values
 }
 
-func nameFields(queryResult backend.DataResponse, target *Query) {
+func nameFrames(queryResult backend.DataResponse, target *Query) {
 	set := make(map[string]struct{})
 	frames := queryResult.Frames
 	for _, v := range frames {
@@ -797,9 +797,7 @@ func nameFields(queryResult backend.DataResponse, target *Query) {
 			// another is "number"
 			valueField := frame.Fields[1]
 			fieldName := getFieldName(*valueField, target, metricTypeCount)
-			if fieldName != "" {
-				valueField.SetConfig(&data.FieldConfig{DisplayName: fieldName})
-			}
+			frame.Name = fieldName
 		}
 	}
 }

--- a/pkg/tsdb/elasticsearch/response_parser_frontend_test.go
+++ b/pkg/tsdb/elasticsearch/response_parser_frontend_test.go
@@ -60,18 +60,7 @@ func requireFloatAt(t *testing.T, expected float64, field *data.Field, index int
 }
 
 func requireTimeSeriesName(t *testing.T, expected string, frame *data.Frame) {
-	getField := func() *data.Field {
-		for _, field := range frame.Fields {
-			if field.Type() != data.FieldTypeTime {
-				return field
-			}
-		}
-		return nil
-	}
-
-	field := getField()
-	require.NotNil(t, expected, field.Config)
-	require.Equal(t, expected, field.Config.DisplayName)
+	require.Equal(t, expected, frame.Name)
 }
 
 func TestRefIdMatching(t *testing.T) {

--- a/pkg/tsdb/elasticsearch/response_parser_frontend_test.go
+++ b/pkg/tsdb/elasticsearch/response_parser_frontend_test.go
@@ -71,7 +71,7 @@ func requireTimeSeriesName(t *testing.T, expected string, frame *data.Frame) {
 
 	field := getField()
 	require.NotNil(t, expected, field.Config)
-	require.Equal(t, expected, field.Config.DisplayNameFromDS)
+	require.Equal(t, expected, field.Config.DisplayName)
 }
 
 func TestRefIdMatching(t *testing.T) {

--- a/pkg/tsdb/elasticsearch/response_parser_test.go
+++ b/pkg/tsdb/elasticsearch/response_parser_test.go
@@ -63,7 +63,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[0].Len(), 2)
 			require.Equal(t, frame.Fields[1].Name, "value")
 			require.Equal(t, frame.Fields[1].Len(), 2)
-			assert.Equal(t, frame.Fields[1].Config.DisplayNameFromDS, "Count")
+			assert.Equal(t, frame.Fields[1].Config.DisplayName, "Count")
 		})
 
 		t.Run("Simple query count & avg aggregation", func(t *testing.T) {
@@ -112,7 +112,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[0].Len(), 2)
 			require.Equal(t, frame.Fields[1].Name, "value")
 			require.Equal(t, frame.Fields[1].Len(), 2)
-			assert.Equal(t, frame.Fields[1].Config.DisplayNameFromDS, "Count")
+			assert.Equal(t, frame.Fields[1].Config.DisplayName, "Count")
 
 			frame = dataframes[1]
 			require.Len(t, frame.Fields, 2)
@@ -121,7 +121,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[0].Len(), 2)
 			require.Equal(t, frame.Fields[1].Name, "value")
 			require.Equal(t, frame.Fields[1].Len(), 2)
-			assert.Equal(t, frame.Fields[1].Config.DisplayNameFromDS, "Average value")
+			assert.Equal(t, frame.Fields[1].Config.DisplayName, "Average value")
 		})
 
 		t.Run("Single group by query one metric", func(t *testing.T) {
@@ -175,7 +175,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[0].Len(), 2)
 			require.Equal(t, frame.Fields[1].Name, "value")
 			require.Equal(t, frame.Fields[1].Len(), 2)
-			assert.Equal(t, frame.Fields[1].Config.DisplayNameFromDS, "server1")
+			assert.Equal(t, frame.Fields[1].Config.DisplayName, "server1")
 
 			frame = dataframes[1]
 			require.Len(t, frame.Fields, 2)
@@ -183,7 +183,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[0].Len(), 2)
 			require.Equal(t, frame.Fields[1].Name, "value")
 			require.Equal(t, frame.Fields[1].Len(), 2)
-			assert.Equal(t, frame.Fields[1].Config.DisplayNameFromDS, "server2")
+			assert.Equal(t, frame.Fields[1].Config.DisplayName, "server2")
 		})
 
 		t.Run("Single group by query two metrics", func(t *testing.T) {
@@ -244,7 +244,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[0].Len(), 2)
 			require.Equal(t, frame.Fields[1].Name, "value")
 			require.Equal(t, frame.Fields[1].Len(), 2)
-			assert.Equal(t, frame.Fields[1].Config.DisplayNameFromDS, "server1 Count")
+			assert.Equal(t, frame.Fields[1].Config.DisplayName, "server1 Count")
 
 			frame = dataframes[1]
 			require.Len(t, frame.Fields, 2)
@@ -252,7 +252,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[0].Len(), 2)
 			require.Equal(t, frame.Fields[1].Name, "value")
 			require.Equal(t, frame.Fields[1].Len(), 2)
-			assert.Equal(t, frame.Fields[1].Config.DisplayNameFromDS, "server1 Average @value")
+			assert.Equal(t, frame.Fields[1].Config.DisplayName, "server1 Average @value")
 
 			frame = dataframes[2]
 			require.Len(t, frame.Fields, 2)
@@ -260,7 +260,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[0].Len(), 2)
 			require.Equal(t, frame.Fields[1].Name, "value")
 			require.Equal(t, frame.Fields[1].Len(), 2)
-			assert.Equal(t, frame.Fields[1].Config.DisplayNameFromDS, "server2 Count")
+			assert.Equal(t, frame.Fields[1].Config.DisplayName, "server2 Count")
 
 			frame = dataframes[3]
 			require.Len(t, frame.Fields, 2)
@@ -268,7 +268,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[0].Len(), 2)
 			require.Equal(t, frame.Fields[1].Name, "value")
 			require.Equal(t, frame.Fields[1].Len(), 2)
-			assert.Equal(t, frame.Fields[1].Config.DisplayNameFromDS, "server2 Average @value")
+			assert.Equal(t, frame.Fields[1].Config.DisplayName, "server2 Average @value")
 		})
 
 		t.Run("With percentiles", func(t *testing.T) {
@@ -316,7 +316,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[0].Len(), 2)
 			require.Equal(t, frame.Fields[1].Name, "value")
 			require.Equal(t, frame.Fields[1].Len(), 2)
-			assert.Equal(t, frame.Fields[1].Config.DisplayNameFromDS, "p75")
+			assert.Equal(t, frame.Fields[1].Config.DisplayName, "p75")
 
 			frame = dataframes[1]
 			require.Len(t, frame.Fields, 2)
@@ -324,7 +324,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[0].Len(), 2)
 			require.Equal(t, frame.Fields[1].Name, "value")
 			require.Equal(t, frame.Fields[1].Len(), 2)
-			assert.Equal(t, frame.Fields[1].Config.DisplayNameFromDS, "p90")
+			assert.Equal(t, frame.Fields[1].Config.DisplayName, "p90")
 		})
 
 		t.Run("With extended stats", func(t *testing.T) {
@@ -397,7 +397,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[0].Len(), 1)
 			require.Equal(t, frame.Fields[1].Name, "value")
 			require.Equal(t, frame.Fields[1].Len(), 1)
-			assert.Equal(t, frame.Fields[1].Config.DisplayNameFromDS, "server1 Max")
+			assert.Equal(t, frame.Fields[1].Config.DisplayName, "server1 Max")
 
 			frame = dataframes[1]
 			require.Len(t, frame.Fields, 2)
@@ -405,7 +405,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[0].Len(), 1)
 			require.Equal(t, frame.Fields[1].Name, "value")
 			require.Equal(t, frame.Fields[1].Len(), 1)
-			assert.Equal(t, frame.Fields[1].Config.DisplayNameFromDS, "server1 Std Dev Lower")
+			assert.Equal(t, frame.Fields[1].Config.DisplayName, "server1 Std Dev Lower")
 
 			frame = dataframes[2]
 			require.Len(t, frame.Fields, 2)
@@ -413,7 +413,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[0].Len(), 1)
 			require.Equal(t, frame.Fields[1].Name, "value")
 			require.Equal(t, frame.Fields[1].Len(), 1)
-			assert.Equal(t, frame.Fields[1].Config.DisplayNameFromDS, "server1 Std Dev Upper")
+			assert.Equal(t, frame.Fields[1].Config.DisplayName, "server1 Std Dev Upper")
 
 			frame = dataframes[3]
 			require.Len(t, frame.Fields, 2)
@@ -421,7 +421,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[0].Len(), 1)
 			require.Equal(t, frame.Fields[1].Name, "value")
 			require.Equal(t, frame.Fields[1].Len(), 1)
-			assert.Equal(t, frame.Fields[1].Config.DisplayNameFromDS, "server2 Max")
+			assert.Equal(t, frame.Fields[1].Config.DisplayName, "server2 Max")
 
 			frame = dataframes[4]
 			require.Len(t, frame.Fields, 2)
@@ -429,7 +429,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[0].Len(), 1)
 			require.Equal(t, frame.Fields[1].Name, "value")
 			require.Equal(t, frame.Fields[1].Len(), 1)
-			assert.Equal(t, frame.Fields[1].Config.DisplayNameFromDS, "server2 Std Dev Lower")
+			assert.Equal(t, frame.Fields[1].Config.DisplayName, "server2 Std Dev Lower")
 
 			frame = dataframes[5]
 			require.Len(t, frame.Fields, 2)
@@ -437,7 +437,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[0].Len(), 1)
 			require.Equal(t, frame.Fields[1].Name, "value")
 			require.Equal(t, frame.Fields[1].Len(), 1)
-			assert.Equal(t, frame.Fields[1].Config.DisplayNameFromDS, "server2 Std Dev Upper")
+			assert.Equal(t, frame.Fields[1].Config.DisplayName, "server2 Std Dev Upper")
 		})
 
 		t.Run("Single group by with alias pattern", func(t *testing.T) {
@@ -500,7 +500,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[0].Len(), 2)
 			require.Equal(t, frame.Fields[1].Name, "value")
 			require.Equal(t, frame.Fields[1].Len(), 2)
-			assert.Equal(t, frame.Fields[1].Config.DisplayNameFromDS, "server1 Count and {{not_exist}} server1")
+			assert.Equal(t, frame.Fields[1].Config.DisplayName, "server1 Count and {{not_exist}} server1")
 
 			frame = dataframes[1]
 			require.Len(t, frame.Fields, 2)
@@ -508,7 +508,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[0].Len(), 2)
 			require.Equal(t, frame.Fields[1].Name, "value")
 			require.Equal(t, frame.Fields[1].Len(), 2)
-			assert.Equal(t, frame.Fields[1].Config.DisplayNameFromDS, "server2 Count and {{not_exist}} server2")
+			assert.Equal(t, frame.Fields[1].Config.DisplayName, "server2 Count and {{not_exist}} server2")
 
 			frame = dataframes[2]
 			require.Len(t, frame.Fields, 2)
@@ -516,7 +516,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[0].Len(), 2)
 			require.Equal(t, frame.Fields[1].Name, "value")
 			require.Equal(t, frame.Fields[1].Len(), 2)
-			assert.Equal(t, frame.Fields[1].Config.DisplayNameFromDS, "0 Count and {{not_exist}} 0")
+			assert.Equal(t, frame.Fields[1].Config.DisplayName, "0 Count and {{not_exist}} 0")
 		})
 
 		t.Run("Histogram response", func(t *testing.T) {
@@ -602,7 +602,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[0].Len(), 2)
 			require.Equal(t, frame.Fields[1].Name, "value")
 			require.Equal(t, frame.Fields[1].Len(), 2)
-			assert.Equal(t, frame.Fields[1].Config.DisplayNameFromDS, "@metric:cpu")
+			assert.Equal(t, frame.Fields[1].Config.DisplayName, "@metric:cpu")
 
 			frame = dataframes[1]
 			require.Len(t, frame.Fields, 2)
@@ -610,7 +610,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[0].Len(), 2)
 			require.Equal(t, frame.Fields[1].Name, "value")
 			require.Equal(t, frame.Fields[1].Len(), 2)
-			assert.Equal(t, frame.Fields[1].Config.DisplayNameFromDS, "@metric:logins.count")
+			assert.Equal(t, frame.Fields[1].Config.DisplayName, "@metric:logins.count")
 		})
 
 		t.Run("With drop first and last aggregation (numeric)", func(t *testing.T) {
@@ -670,7 +670,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[0].Len(), 1)
 			require.Equal(t, frame.Fields[1].Name, "value")
 			require.Equal(t, frame.Fields[1].Len(), 1)
-			assert.Equal(t, frame.Fields[1].Config.DisplayNameFromDS, "Average")
+			assert.Equal(t, frame.Fields[1].Config.DisplayName, "Average")
 
 			frame = dataframes[1]
 			require.Len(t, frame.Fields, 2)
@@ -678,7 +678,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[0].Len(), 1)
 			require.Equal(t, frame.Fields[1].Name, "value")
 			require.Equal(t, frame.Fields[1].Len(), 1)
-			assert.Equal(t, frame.Fields[1].Config.DisplayNameFromDS, "Count")
+			assert.Equal(t, frame.Fields[1].Config.DisplayName, "Count")
 		})
 
 		t.Run("With drop first and last aggregation (string)", func(t *testing.T) {
@@ -738,7 +738,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[0].Len(), 1)
 			require.Equal(t, frame.Fields[1].Name, "value")
 			require.Equal(t, frame.Fields[1].Len(), 1)
-			assert.Equal(t, frame.Fields[1].Config.DisplayNameFromDS, "Average")
+			assert.Equal(t, frame.Fields[1].Config.DisplayName, "Average")
 
 			frame = dataframes[1]
 			require.Len(t, frame.Fields, 2)
@@ -746,7 +746,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[0].Len(), 1)
 			require.Equal(t, frame.Fields[1].Name, "value")
 			require.Equal(t, frame.Fields[1].Len(), 1)
-			assert.Equal(t, frame.Fields[1].Config.DisplayNameFromDS, "Count")
+			assert.Equal(t, frame.Fields[1].Config.DisplayName, "Count")
 		})
 
 		t.Run("Larger trimEdges value", func(t *testing.T) {
@@ -949,7 +949,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[0].Len(), 2)
 			require.Equal(t, frame.Fields[1].Name, "value")
 			require.Equal(t, frame.Fields[1].Len(), 2)
-			assert.Equal(t, frame.Fields[1].Config.DisplayNameFromDS, "Sum @value")
+			assert.Equal(t, frame.Fields[1].Config.DisplayName, "Sum @value")
 
 			frame = dataframes[1]
 			require.Len(t, frame.Fields, 2)
@@ -957,7 +957,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[0].Len(), 2)
 			require.Equal(t, frame.Fields[1].Name, "value")
 			require.Equal(t, frame.Fields[1].Len(), 2)
-			assert.Equal(t, frame.Fields[1].Config.DisplayNameFromDS, "Max @value")
+			assert.Equal(t, frame.Fields[1].Config.DisplayName, "Max @value")
 
 			frame = dataframes[2]
 			require.Len(t, frame.Fields, 2)
@@ -965,7 +965,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[0].Len(), 2)
 			require.Equal(t, frame.Fields[1].Name, "value")
 			require.Equal(t, frame.Fields[1].Len(), 2)
-			assert.Equal(t, frame.Fields[1].Config.DisplayNameFromDS, "Sum @value * Max @value")
+			assert.Equal(t, frame.Fields[1].Config.DisplayName, "Sum @value * Max @value")
 		})
 
 		t.Run("Terms with two bucket_script", func(t *testing.T) {
@@ -1426,7 +1426,7 @@ func TestResponseParser(t *testing.T) {
 		assert.Len(t, frame.Fields, 2)
 		require.Equal(t, frame.Fields[0].Len(), 2)
 		require.Equal(t, frame.Fields[1].Len(), 2)
-		assert.Equal(t, frame.Fields[1].Config.DisplayNameFromDS, "Top Metrics @value")
+		assert.Equal(t, frame.Fields[1].Config.DisplayName, "Top Metrics @value")
 		v, _ := frame.FloatAt(0, 0)
 		assert.Equal(t, 1609459200000., v)
 		v, _ = frame.FloatAt(1, 0)
@@ -1443,7 +1443,7 @@ func TestResponseParser(t *testing.T) {
 		assert.Len(t, frame.Fields, 2)
 		require.Equal(t, frame.Fields[0].Len(), 2)
 		require.Equal(t, frame.Fields[1].Len(), 2)
-		assert.Equal(t, frame.Fields[1].Config.DisplayNameFromDS, "Top Metrics @anotherValue")
+		assert.Equal(t, frame.Fields[1].Config.DisplayName, "Top Metrics @anotherValue")
 		v, _ = frame.FloatAt(0, 0)
 		assert.Equal(t, 1609459200000., v)
 		v, _ = frame.FloatAt(1, 0)

--- a/pkg/tsdb/elasticsearch/response_parser_test.go
+++ b/pkg/tsdb/elasticsearch/response_parser_test.go
@@ -63,7 +63,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[0].Len(), 2)
 			require.Equal(t, frame.Fields[1].Name, "value")
 			require.Equal(t, frame.Fields[1].Len(), 2)
-			assert.Equal(t, frame.Fields[1].Config.DisplayName, "Count")
+			assert.Equal(t, frame.Name, "Count")
 		})
 
 		t.Run("Simple query count & avg aggregation", func(t *testing.T) {
@@ -112,7 +112,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[0].Len(), 2)
 			require.Equal(t, frame.Fields[1].Name, "value")
 			require.Equal(t, frame.Fields[1].Len(), 2)
-			assert.Equal(t, frame.Fields[1].Config.DisplayName, "Count")
+			assert.Equal(t, frame.Name, "Count")
 
 			frame = dataframes[1]
 			require.Len(t, frame.Fields, 2)
@@ -121,7 +121,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[0].Len(), 2)
 			require.Equal(t, frame.Fields[1].Name, "value")
 			require.Equal(t, frame.Fields[1].Len(), 2)
-			assert.Equal(t, frame.Fields[1].Config.DisplayName, "Average value")
+			assert.Equal(t, frame.Name, "Average value")
 		})
 
 		t.Run("Single group by query one metric", func(t *testing.T) {
@@ -175,7 +175,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[0].Len(), 2)
 			require.Equal(t, frame.Fields[1].Name, "value")
 			require.Equal(t, frame.Fields[1].Len(), 2)
-			assert.Equal(t, frame.Fields[1].Config.DisplayName, "server1")
+			assert.Equal(t, frame.Name, "server1")
 
 			frame = dataframes[1]
 			require.Len(t, frame.Fields, 2)
@@ -183,7 +183,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[0].Len(), 2)
 			require.Equal(t, frame.Fields[1].Name, "value")
 			require.Equal(t, frame.Fields[1].Len(), 2)
-			assert.Equal(t, frame.Fields[1].Config.DisplayName, "server2")
+			assert.Equal(t, frame.Name, "server2")
 		})
 
 		t.Run("Single group by query two metrics", func(t *testing.T) {
@@ -244,7 +244,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[0].Len(), 2)
 			require.Equal(t, frame.Fields[1].Name, "value")
 			require.Equal(t, frame.Fields[1].Len(), 2)
-			assert.Equal(t, frame.Fields[1].Config.DisplayName, "server1 Count")
+			assert.Equal(t, frame.Name, "server1 Count")
 
 			frame = dataframes[1]
 			require.Len(t, frame.Fields, 2)
@@ -252,7 +252,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[0].Len(), 2)
 			require.Equal(t, frame.Fields[1].Name, "value")
 			require.Equal(t, frame.Fields[1].Len(), 2)
-			assert.Equal(t, frame.Fields[1].Config.DisplayName, "server1 Average @value")
+			assert.Equal(t, frame.Name, "server1 Average @value")
 
 			frame = dataframes[2]
 			require.Len(t, frame.Fields, 2)
@@ -260,7 +260,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[0].Len(), 2)
 			require.Equal(t, frame.Fields[1].Name, "value")
 			require.Equal(t, frame.Fields[1].Len(), 2)
-			assert.Equal(t, frame.Fields[1].Config.DisplayName, "server2 Count")
+			assert.Equal(t, frame.Name, "server2 Count")
 
 			frame = dataframes[3]
 			require.Len(t, frame.Fields, 2)
@@ -268,7 +268,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[0].Len(), 2)
 			require.Equal(t, frame.Fields[1].Name, "value")
 			require.Equal(t, frame.Fields[1].Len(), 2)
-			assert.Equal(t, frame.Fields[1].Config.DisplayName, "server2 Average @value")
+			assert.Equal(t, frame.Name, "server2 Average @value")
 		})
 
 		t.Run("With percentiles", func(t *testing.T) {
@@ -316,7 +316,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[0].Len(), 2)
 			require.Equal(t, frame.Fields[1].Name, "value")
 			require.Equal(t, frame.Fields[1].Len(), 2)
-			assert.Equal(t, frame.Fields[1].Config.DisplayName, "p75")
+			assert.Equal(t, frame.Name, "p75")
 
 			frame = dataframes[1]
 			require.Len(t, frame.Fields, 2)
@@ -324,7 +324,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[0].Len(), 2)
 			require.Equal(t, frame.Fields[1].Name, "value")
 			require.Equal(t, frame.Fields[1].Len(), 2)
-			assert.Equal(t, frame.Fields[1].Config.DisplayName, "p90")
+			assert.Equal(t, frame.Name, "p90")
 		})
 
 		t.Run("With extended stats", func(t *testing.T) {
@@ -397,7 +397,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[0].Len(), 1)
 			require.Equal(t, frame.Fields[1].Name, "value")
 			require.Equal(t, frame.Fields[1].Len(), 1)
-			assert.Equal(t, frame.Fields[1].Config.DisplayName, "server1 Max")
+			assert.Equal(t, frame.Name, "server1 Max")
 
 			frame = dataframes[1]
 			require.Len(t, frame.Fields, 2)
@@ -405,7 +405,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[0].Len(), 1)
 			require.Equal(t, frame.Fields[1].Name, "value")
 			require.Equal(t, frame.Fields[1].Len(), 1)
-			assert.Equal(t, frame.Fields[1].Config.DisplayName, "server1 Std Dev Lower")
+			assert.Equal(t, frame.Name, "server1 Std Dev Lower")
 
 			frame = dataframes[2]
 			require.Len(t, frame.Fields, 2)
@@ -413,7 +413,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[0].Len(), 1)
 			require.Equal(t, frame.Fields[1].Name, "value")
 			require.Equal(t, frame.Fields[1].Len(), 1)
-			assert.Equal(t, frame.Fields[1].Config.DisplayName, "server1 Std Dev Upper")
+			assert.Equal(t, frame.Name, "server1 Std Dev Upper")
 
 			frame = dataframes[3]
 			require.Len(t, frame.Fields, 2)
@@ -421,7 +421,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[0].Len(), 1)
 			require.Equal(t, frame.Fields[1].Name, "value")
 			require.Equal(t, frame.Fields[1].Len(), 1)
-			assert.Equal(t, frame.Fields[1].Config.DisplayName, "server2 Max")
+			assert.Equal(t, frame.Name, "server2 Max")
 
 			frame = dataframes[4]
 			require.Len(t, frame.Fields, 2)
@@ -429,7 +429,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[0].Len(), 1)
 			require.Equal(t, frame.Fields[1].Name, "value")
 			require.Equal(t, frame.Fields[1].Len(), 1)
-			assert.Equal(t, frame.Fields[1].Config.DisplayName, "server2 Std Dev Lower")
+			assert.Equal(t, frame.Name, "server2 Std Dev Lower")
 
 			frame = dataframes[5]
 			require.Len(t, frame.Fields, 2)
@@ -437,7 +437,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[0].Len(), 1)
 			require.Equal(t, frame.Fields[1].Name, "value")
 			require.Equal(t, frame.Fields[1].Len(), 1)
-			assert.Equal(t, frame.Fields[1].Config.DisplayName, "server2 Std Dev Upper")
+			assert.Equal(t, frame.Name, "server2 Std Dev Upper")
 		})
 
 		t.Run("Single group by with alias pattern", func(t *testing.T) {
@@ -500,7 +500,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[0].Len(), 2)
 			require.Equal(t, frame.Fields[1].Name, "value")
 			require.Equal(t, frame.Fields[1].Len(), 2)
-			assert.Equal(t, frame.Fields[1].Config.DisplayName, "server1 Count and {{not_exist}} server1")
+			assert.Equal(t, frame.Name, "server1 Count and {{not_exist}} server1")
 
 			frame = dataframes[1]
 			require.Len(t, frame.Fields, 2)
@@ -508,7 +508,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[0].Len(), 2)
 			require.Equal(t, frame.Fields[1].Name, "value")
 			require.Equal(t, frame.Fields[1].Len(), 2)
-			assert.Equal(t, frame.Fields[1].Config.DisplayName, "server2 Count and {{not_exist}} server2")
+			assert.Equal(t, frame.Name, "server2 Count and {{not_exist}} server2")
 
 			frame = dataframes[2]
 			require.Len(t, frame.Fields, 2)
@@ -516,7 +516,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[0].Len(), 2)
 			require.Equal(t, frame.Fields[1].Name, "value")
 			require.Equal(t, frame.Fields[1].Len(), 2)
-			assert.Equal(t, frame.Fields[1].Config.DisplayName, "0 Count and {{not_exist}} 0")
+			assert.Equal(t, frame.Name, "0 Count and {{not_exist}} 0")
 		})
 
 		t.Run("Histogram response", func(t *testing.T) {
@@ -602,7 +602,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[0].Len(), 2)
 			require.Equal(t, frame.Fields[1].Name, "value")
 			require.Equal(t, frame.Fields[1].Len(), 2)
-			assert.Equal(t, frame.Fields[1].Config.DisplayName, "@metric:cpu")
+			assert.Equal(t, frame.Name, "@metric:cpu")
 
 			frame = dataframes[1]
 			require.Len(t, frame.Fields, 2)
@@ -610,7 +610,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[0].Len(), 2)
 			require.Equal(t, frame.Fields[1].Name, "value")
 			require.Equal(t, frame.Fields[1].Len(), 2)
-			assert.Equal(t, frame.Fields[1].Config.DisplayName, "@metric:logins.count")
+			assert.Equal(t, frame.Name, "@metric:logins.count")
 		})
 
 		t.Run("With drop first and last aggregation (numeric)", func(t *testing.T) {
@@ -670,7 +670,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[0].Len(), 1)
 			require.Equal(t, frame.Fields[1].Name, "value")
 			require.Equal(t, frame.Fields[1].Len(), 1)
-			assert.Equal(t, frame.Fields[1].Config.DisplayName, "Average")
+			assert.Equal(t, frame.Name, "Average")
 
 			frame = dataframes[1]
 			require.Len(t, frame.Fields, 2)
@@ -678,7 +678,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[0].Len(), 1)
 			require.Equal(t, frame.Fields[1].Name, "value")
 			require.Equal(t, frame.Fields[1].Len(), 1)
-			assert.Equal(t, frame.Fields[1].Config.DisplayName, "Count")
+			assert.Equal(t, frame.Name, "Count")
 		})
 
 		t.Run("With drop first and last aggregation (string)", func(t *testing.T) {
@@ -738,7 +738,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[0].Len(), 1)
 			require.Equal(t, frame.Fields[1].Name, "value")
 			require.Equal(t, frame.Fields[1].Len(), 1)
-			assert.Equal(t, frame.Fields[1].Config.DisplayName, "Average")
+			assert.Equal(t, frame.Name, "Average")
 
 			frame = dataframes[1]
 			require.Len(t, frame.Fields, 2)
@@ -746,7 +746,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[0].Len(), 1)
 			require.Equal(t, frame.Fields[1].Name, "value")
 			require.Equal(t, frame.Fields[1].Len(), 1)
-			assert.Equal(t, frame.Fields[1].Config.DisplayName, "Count")
+			assert.Equal(t, frame.Name, "Count")
 		})
 
 		t.Run("Larger trimEdges value", func(t *testing.T) {
@@ -949,7 +949,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[0].Len(), 2)
 			require.Equal(t, frame.Fields[1].Name, "value")
 			require.Equal(t, frame.Fields[1].Len(), 2)
-			assert.Equal(t, frame.Fields[1].Config.DisplayName, "Sum @value")
+			assert.Equal(t, frame.Name, "Sum @value")
 
 			frame = dataframes[1]
 			require.Len(t, frame.Fields, 2)
@@ -957,7 +957,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[0].Len(), 2)
 			require.Equal(t, frame.Fields[1].Name, "value")
 			require.Equal(t, frame.Fields[1].Len(), 2)
-			assert.Equal(t, frame.Fields[1].Config.DisplayName, "Max @value")
+			assert.Equal(t, frame.Name, "Max @value")
 
 			frame = dataframes[2]
 			require.Len(t, frame.Fields, 2)
@@ -965,7 +965,7 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[0].Len(), 2)
 			require.Equal(t, frame.Fields[1].Name, "value")
 			require.Equal(t, frame.Fields[1].Len(), 2)
-			assert.Equal(t, frame.Fields[1].Config.DisplayName, "Sum @value * Max @value")
+			assert.Equal(t, frame.Name, "Sum @value * Max @value")
 		})
 
 		t.Run("Terms with two bucket_script", func(t *testing.T) {
@@ -1426,7 +1426,7 @@ func TestResponseParser(t *testing.T) {
 		assert.Len(t, frame.Fields, 2)
 		require.Equal(t, frame.Fields[0].Len(), 2)
 		require.Equal(t, frame.Fields[1].Len(), 2)
-		assert.Equal(t, frame.Fields[1].Config.DisplayName, "Top Metrics @value")
+		assert.Equal(t, frame.Name, "Top Metrics @value")
 		v, _ := frame.FloatAt(0, 0)
 		assert.Equal(t, 1609459200000., v)
 		v, _ = frame.FloatAt(1, 0)
@@ -1443,7 +1443,7 @@ func TestResponseParser(t *testing.T) {
 		assert.Len(t, frame.Fields, 2)
 		require.Equal(t, frame.Fields[0].Len(), 2)
 		require.Equal(t, frame.Fields[1].Len(), 2)
-		assert.Equal(t, frame.Fields[1].Config.DisplayName, "Top Metrics @anotherValue")
+		assert.Equal(t, frame.Name, "Top Metrics @anotherValue")
 		v, _ = frame.FloatAt(0, 0)
 		assert.Equal(t, 1609459200000., v)
 		v, _ = frame.FloatAt(1, 0)

--- a/pkg/tsdb/elasticsearch/response_parser_test.go
+++ b/pkg/tsdb/elasticsearch/response_parser_test.go
@@ -59,9 +59,9 @@ func TestResponseParser(t *testing.T) {
 			frame := dataframes[0]
 			require.Len(t, frame.Fields, 2)
 
-			require.Equal(t, frame.Fields[0].Name, "time")
+			require.Equal(t, frame.Fields[0].Name, "Time")
 			require.Equal(t, frame.Fields[0].Len(), 2)
-			require.Equal(t, frame.Fields[1].Name, "value")
+			require.Equal(t, frame.Fields[1].Name, "Value")
 			require.Equal(t, frame.Fields[1].Len(), 2)
 			assert.Equal(t, frame.Name, "Count")
 		})
@@ -108,18 +108,18 @@ func TestResponseParser(t *testing.T) {
 			frame := dataframes[0]
 			require.Len(t, frame.Fields, 2)
 
-			require.Equal(t, frame.Fields[0].Name, "time")
+			require.Equal(t, frame.Fields[0].Name, "Time")
 			require.Equal(t, frame.Fields[0].Len(), 2)
-			require.Equal(t, frame.Fields[1].Name, "value")
+			require.Equal(t, frame.Fields[1].Name, "Value")
 			require.Equal(t, frame.Fields[1].Len(), 2)
 			assert.Equal(t, frame.Name, "Count")
 
 			frame = dataframes[1]
 			require.Len(t, frame.Fields, 2)
 
-			require.Equal(t, frame.Fields[0].Name, "time")
+			require.Equal(t, frame.Fields[0].Name, "Time")
 			require.Equal(t, frame.Fields[0].Len(), 2)
-			require.Equal(t, frame.Fields[1].Name, "value")
+			require.Equal(t, frame.Fields[1].Name, "Value")
 			require.Equal(t, frame.Fields[1].Len(), 2)
 			assert.Equal(t, frame.Name, "Average value")
 		})
@@ -171,17 +171,17 @@ func TestResponseParser(t *testing.T) {
 
 			frame := dataframes[0]
 			require.Len(t, frame.Fields, 2)
-			require.Equal(t, frame.Fields[0].Name, "time")
+			require.Equal(t, frame.Fields[0].Name, "Time")
 			require.Equal(t, frame.Fields[0].Len(), 2)
-			require.Equal(t, frame.Fields[1].Name, "value")
+			require.Equal(t, frame.Fields[1].Name, "Value")
 			require.Equal(t, frame.Fields[1].Len(), 2)
 			assert.Equal(t, frame.Name, "server1")
 
 			frame = dataframes[1]
 			require.Len(t, frame.Fields, 2)
-			require.Equal(t, frame.Fields[0].Name, "time")
+			require.Equal(t, frame.Fields[0].Name, "Time")
 			require.Equal(t, frame.Fields[0].Len(), 2)
-			require.Equal(t, frame.Fields[1].Name, "value")
+			require.Equal(t, frame.Fields[1].Name, "Value")
 			require.Equal(t, frame.Fields[1].Len(), 2)
 			assert.Equal(t, frame.Name, "server2")
 		})
@@ -240,33 +240,33 @@ func TestResponseParser(t *testing.T) {
 
 			frame := dataframes[0]
 			require.Len(t, frame.Fields, 2)
-			require.Equal(t, frame.Fields[0].Name, "time")
+			require.Equal(t, frame.Fields[0].Name, "Time")
 			require.Equal(t, frame.Fields[0].Len(), 2)
-			require.Equal(t, frame.Fields[1].Name, "value")
+			require.Equal(t, frame.Fields[1].Name, "Value")
 			require.Equal(t, frame.Fields[1].Len(), 2)
 			assert.Equal(t, frame.Name, "server1 Count")
 
 			frame = dataframes[1]
 			require.Len(t, frame.Fields, 2)
-			require.Equal(t, frame.Fields[0].Name, "time")
+			require.Equal(t, frame.Fields[0].Name, "Time")
 			require.Equal(t, frame.Fields[0].Len(), 2)
-			require.Equal(t, frame.Fields[1].Name, "value")
+			require.Equal(t, frame.Fields[1].Name, "Value")
 			require.Equal(t, frame.Fields[1].Len(), 2)
 			assert.Equal(t, frame.Name, "server1 Average @value")
 
 			frame = dataframes[2]
 			require.Len(t, frame.Fields, 2)
-			require.Equal(t, frame.Fields[0].Name, "time")
+			require.Equal(t, frame.Fields[0].Name, "Time")
 			require.Equal(t, frame.Fields[0].Len(), 2)
-			require.Equal(t, frame.Fields[1].Name, "value")
+			require.Equal(t, frame.Fields[1].Name, "Value")
 			require.Equal(t, frame.Fields[1].Len(), 2)
 			assert.Equal(t, frame.Name, "server2 Count")
 
 			frame = dataframes[3]
 			require.Len(t, frame.Fields, 2)
-			require.Equal(t, frame.Fields[0].Name, "time")
+			require.Equal(t, frame.Fields[0].Name, "Time")
 			require.Equal(t, frame.Fields[0].Len(), 2)
-			require.Equal(t, frame.Fields[1].Name, "value")
+			require.Equal(t, frame.Fields[1].Name, "Value")
 			require.Equal(t, frame.Fields[1].Len(), 2)
 			assert.Equal(t, frame.Name, "server2 Average @value")
 		})
@@ -312,17 +312,17 @@ func TestResponseParser(t *testing.T) {
 
 			frame := dataframes[0]
 			require.Len(t, frame.Fields, 2)
-			require.Equal(t, frame.Fields[0].Name, "time")
+			require.Equal(t, frame.Fields[0].Name, "Time")
 			require.Equal(t, frame.Fields[0].Len(), 2)
-			require.Equal(t, frame.Fields[1].Name, "value")
+			require.Equal(t, frame.Fields[1].Name, "Value")
 			require.Equal(t, frame.Fields[1].Len(), 2)
 			assert.Equal(t, frame.Name, "p75")
 
 			frame = dataframes[1]
 			require.Len(t, frame.Fields, 2)
-			require.Equal(t, frame.Fields[0].Name, "time")
+			require.Equal(t, frame.Fields[0].Name, "Time")
 			require.Equal(t, frame.Fields[0].Len(), 2)
-			require.Equal(t, frame.Fields[1].Name, "value")
+			require.Equal(t, frame.Fields[1].Name, "Value")
 			require.Equal(t, frame.Fields[1].Len(), 2)
 			assert.Equal(t, frame.Name, "p90")
 		})
@@ -393,49 +393,49 @@ func TestResponseParser(t *testing.T) {
 
 			frame := dataframes[0]
 			require.Len(t, frame.Fields, 2)
-			require.Equal(t, frame.Fields[0].Name, "time")
+			require.Equal(t, frame.Fields[0].Name, "Time")
 			require.Equal(t, frame.Fields[0].Len(), 1)
-			require.Equal(t, frame.Fields[1].Name, "value")
+			require.Equal(t, frame.Fields[1].Name, "Value")
 			require.Equal(t, frame.Fields[1].Len(), 1)
 			assert.Equal(t, frame.Name, "server1 Max")
 
 			frame = dataframes[1]
 			require.Len(t, frame.Fields, 2)
-			require.Equal(t, frame.Fields[0].Name, "time")
+			require.Equal(t, frame.Fields[0].Name, "Time")
 			require.Equal(t, frame.Fields[0].Len(), 1)
-			require.Equal(t, frame.Fields[1].Name, "value")
+			require.Equal(t, frame.Fields[1].Name, "Value")
 			require.Equal(t, frame.Fields[1].Len(), 1)
 			assert.Equal(t, frame.Name, "server1 Std Dev Lower")
 
 			frame = dataframes[2]
 			require.Len(t, frame.Fields, 2)
-			require.Equal(t, frame.Fields[0].Name, "time")
+			require.Equal(t, frame.Fields[0].Name, "Time")
 			require.Equal(t, frame.Fields[0].Len(), 1)
-			require.Equal(t, frame.Fields[1].Name, "value")
+			require.Equal(t, frame.Fields[1].Name, "Value")
 			require.Equal(t, frame.Fields[1].Len(), 1)
 			assert.Equal(t, frame.Name, "server1 Std Dev Upper")
 
 			frame = dataframes[3]
 			require.Len(t, frame.Fields, 2)
-			require.Equal(t, frame.Fields[0].Name, "time")
+			require.Equal(t, frame.Fields[0].Name, "Time")
 			require.Equal(t, frame.Fields[0].Len(), 1)
-			require.Equal(t, frame.Fields[1].Name, "value")
+			require.Equal(t, frame.Fields[1].Name, "Value")
 			require.Equal(t, frame.Fields[1].Len(), 1)
 			assert.Equal(t, frame.Name, "server2 Max")
 
 			frame = dataframes[4]
 			require.Len(t, frame.Fields, 2)
-			require.Equal(t, frame.Fields[0].Name, "time")
+			require.Equal(t, frame.Fields[0].Name, "Time")
 			require.Equal(t, frame.Fields[0].Len(), 1)
-			require.Equal(t, frame.Fields[1].Name, "value")
+			require.Equal(t, frame.Fields[1].Name, "Value")
 			require.Equal(t, frame.Fields[1].Len(), 1)
 			assert.Equal(t, frame.Name, "server2 Std Dev Lower")
 
 			frame = dataframes[5]
 			require.Len(t, frame.Fields, 2)
-			require.Equal(t, frame.Fields[0].Name, "time")
+			require.Equal(t, frame.Fields[0].Name, "Time")
 			require.Equal(t, frame.Fields[0].Len(), 1)
-			require.Equal(t, frame.Fields[1].Name, "value")
+			require.Equal(t, frame.Fields[1].Name, "Value")
 			require.Equal(t, frame.Fields[1].Len(), 1)
 			assert.Equal(t, frame.Name, "server2 Std Dev Upper")
 		})
@@ -496,25 +496,25 @@ func TestResponseParser(t *testing.T) {
 
 			frame := dataframes[0]
 			require.Len(t, frame.Fields, 2)
-			require.Equal(t, frame.Fields[0].Name, "time")
+			require.Equal(t, frame.Fields[0].Name, "Time")
 			require.Equal(t, frame.Fields[0].Len(), 2)
-			require.Equal(t, frame.Fields[1].Name, "value")
+			require.Equal(t, frame.Fields[1].Name, "Value")
 			require.Equal(t, frame.Fields[1].Len(), 2)
 			assert.Equal(t, frame.Name, "server1 Count and {{not_exist}} server1")
 
 			frame = dataframes[1]
 			require.Len(t, frame.Fields, 2)
-			require.Equal(t, frame.Fields[0].Name, "time")
+			require.Equal(t, frame.Fields[0].Name, "Time")
 			require.Equal(t, frame.Fields[0].Len(), 2)
-			require.Equal(t, frame.Fields[1].Name, "value")
+			require.Equal(t, frame.Fields[1].Name, "Value")
 			require.Equal(t, frame.Fields[1].Len(), 2)
 			assert.Equal(t, frame.Name, "server2 Count and {{not_exist}} server2")
 
 			frame = dataframes[2]
 			require.Len(t, frame.Fields, 2)
-			require.Equal(t, frame.Fields[0].Name, "time")
+			require.Equal(t, frame.Fields[0].Name, "Time")
 			require.Equal(t, frame.Fields[0].Len(), 2)
-			require.Equal(t, frame.Fields[1].Name, "value")
+			require.Equal(t, frame.Fields[1].Name, "Value")
 			require.Equal(t, frame.Fields[1].Len(), 2)
 			assert.Equal(t, frame.Name, "0 Count and {{not_exist}} 0")
 		})
@@ -598,17 +598,17 @@ func TestResponseParser(t *testing.T) {
 
 			frame := dataframes[0]
 			require.Len(t, frame.Fields, 2)
-			require.Equal(t, frame.Fields[0].Name, "time")
+			require.Equal(t, frame.Fields[0].Name, "Time")
 			require.Equal(t, frame.Fields[0].Len(), 2)
-			require.Equal(t, frame.Fields[1].Name, "value")
+			require.Equal(t, frame.Fields[1].Name, "Value")
 			require.Equal(t, frame.Fields[1].Len(), 2)
 			assert.Equal(t, frame.Name, "@metric:cpu")
 
 			frame = dataframes[1]
 			require.Len(t, frame.Fields, 2)
-			require.Equal(t, frame.Fields[0].Name, "time")
+			require.Equal(t, frame.Fields[0].Name, "Time")
 			require.Equal(t, frame.Fields[0].Len(), 2)
-			require.Equal(t, frame.Fields[1].Name, "value")
+			require.Equal(t, frame.Fields[1].Name, "Value")
 			require.Equal(t, frame.Fields[1].Len(), 2)
 			assert.Equal(t, frame.Name, "@metric:logins.count")
 		})
@@ -666,17 +666,17 @@ func TestResponseParser(t *testing.T) {
 
 			frame := dataframes[0]
 			require.Len(t, frame.Fields, 2)
-			require.Equal(t, frame.Fields[0].Name, "time")
+			require.Equal(t, frame.Fields[0].Name, "Time")
 			require.Equal(t, frame.Fields[0].Len(), 1)
-			require.Equal(t, frame.Fields[1].Name, "value")
+			require.Equal(t, frame.Fields[1].Name, "Value")
 			require.Equal(t, frame.Fields[1].Len(), 1)
 			assert.Equal(t, frame.Name, "Average")
 
 			frame = dataframes[1]
 			require.Len(t, frame.Fields, 2)
-			require.Equal(t, frame.Fields[0].Name, "time")
+			require.Equal(t, frame.Fields[0].Name, "Time")
 			require.Equal(t, frame.Fields[0].Len(), 1)
-			require.Equal(t, frame.Fields[1].Name, "value")
+			require.Equal(t, frame.Fields[1].Name, "Value")
 			require.Equal(t, frame.Fields[1].Len(), 1)
 			assert.Equal(t, frame.Name, "Count")
 		})
@@ -734,17 +734,17 @@ func TestResponseParser(t *testing.T) {
 
 			frame := dataframes[0]
 			require.Len(t, frame.Fields, 2)
-			require.Equal(t, frame.Fields[0].Name, "time")
+			require.Equal(t, frame.Fields[0].Name, "Time")
 			require.Equal(t, frame.Fields[0].Len(), 1)
-			require.Equal(t, frame.Fields[1].Name, "value")
+			require.Equal(t, frame.Fields[1].Name, "Value")
 			require.Equal(t, frame.Fields[1].Len(), 1)
 			assert.Equal(t, frame.Name, "Average")
 
 			frame = dataframes[1]
 			require.Len(t, frame.Fields, 2)
-			require.Equal(t, frame.Fields[0].Name, "time")
+			require.Equal(t, frame.Fields[0].Name, "Time")
 			require.Equal(t, frame.Fields[0].Len(), 1)
-			require.Equal(t, frame.Fields[1].Name, "value")
+			require.Equal(t, frame.Fields[1].Name, "Value")
 			require.Equal(t, frame.Fields[1].Len(), 1)
 			assert.Equal(t, frame.Name, "Count")
 		})
@@ -945,25 +945,25 @@ func TestResponseParser(t *testing.T) {
 
 			frame := dataframes[0]
 			require.Len(t, frame.Fields, 2)
-			require.Equal(t, frame.Fields[0].Name, "time")
+			require.Equal(t, frame.Fields[0].Name, "Time")
 			require.Equal(t, frame.Fields[0].Len(), 2)
-			require.Equal(t, frame.Fields[1].Name, "value")
+			require.Equal(t, frame.Fields[1].Name, "Value")
 			require.Equal(t, frame.Fields[1].Len(), 2)
 			assert.Equal(t, frame.Name, "Sum @value")
 
 			frame = dataframes[1]
 			require.Len(t, frame.Fields, 2)
-			require.Equal(t, frame.Fields[0].Name, "time")
+			require.Equal(t, frame.Fields[0].Name, "Time")
 			require.Equal(t, frame.Fields[0].Len(), 2)
-			require.Equal(t, frame.Fields[1].Name, "value")
+			require.Equal(t, frame.Fields[1].Name, "Value")
 			require.Equal(t, frame.Fields[1].Len(), 2)
 			assert.Equal(t, frame.Name, "Max @value")
 
 			frame = dataframes[2]
 			require.Len(t, frame.Fields, 2)
-			require.Equal(t, frame.Fields[0].Name, "time")
+			require.Equal(t, frame.Fields[0].Name, "Time")
 			require.Equal(t, frame.Fields[0].Len(), 2)
-			require.Equal(t, frame.Fields[1].Name, "value")
+			require.Equal(t, frame.Fields[1].Name, "Value")
 			require.Equal(t, frame.Fields[1].Len(), 2)
 			assert.Equal(t, frame.Name, "Sum @value * Max @value")
 		})

--- a/pkg/tsdb/elasticsearch/response_parser_test.go
+++ b/pkg/tsdb/elasticsearch/response_parser_test.go
@@ -59,9 +59,9 @@ func TestResponseParser(t *testing.T) {
 			frame := dataframes[0]
 			require.Len(t, frame.Fields, 2)
 
-			require.Equal(t, frame.Fields[0].Name, "Time")
+			require.Equal(t, frame.Fields[0].Name, data.TimeSeriesTimeFieldName)
 			require.Equal(t, frame.Fields[0].Len(), 2)
-			require.Equal(t, frame.Fields[1].Name, "Value")
+			require.Equal(t, frame.Fields[1].Name, data.TimeSeriesValueFieldName)
 			require.Equal(t, frame.Fields[1].Len(), 2)
 			assert.Equal(t, frame.Name, "Count")
 		})
@@ -108,18 +108,18 @@ func TestResponseParser(t *testing.T) {
 			frame := dataframes[0]
 			require.Len(t, frame.Fields, 2)
 
-			require.Equal(t, frame.Fields[0].Name, "Time")
+			require.Equal(t, frame.Fields[0].Name, data.TimeSeriesTimeFieldName)
 			require.Equal(t, frame.Fields[0].Len(), 2)
-			require.Equal(t, frame.Fields[1].Name, "Value")
+			require.Equal(t, frame.Fields[1].Name, data.TimeSeriesValueFieldName)
 			require.Equal(t, frame.Fields[1].Len(), 2)
 			assert.Equal(t, frame.Name, "Count")
 
 			frame = dataframes[1]
 			require.Len(t, frame.Fields, 2)
 
-			require.Equal(t, frame.Fields[0].Name, "Time")
+			require.Equal(t, frame.Fields[0].Name, data.TimeSeriesTimeFieldName)
 			require.Equal(t, frame.Fields[0].Len(), 2)
-			require.Equal(t, frame.Fields[1].Name, "Value")
+			require.Equal(t, frame.Fields[1].Name, data.TimeSeriesValueFieldName)
 			require.Equal(t, frame.Fields[1].Len(), 2)
 			assert.Equal(t, frame.Name, "Average value")
 		})
@@ -171,17 +171,17 @@ func TestResponseParser(t *testing.T) {
 
 			frame := dataframes[0]
 			require.Len(t, frame.Fields, 2)
-			require.Equal(t, frame.Fields[0].Name, "Time")
+			require.Equal(t, frame.Fields[0].Name, data.TimeSeriesTimeFieldName)
 			require.Equal(t, frame.Fields[0].Len(), 2)
-			require.Equal(t, frame.Fields[1].Name, "Value")
+			require.Equal(t, frame.Fields[1].Name, data.TimeSeriesValueFieldName)
 			require.Equal(t, frame.Fields[1].Len(), 2)
 			assert.Equal(t, frame.Name, "server1")
 
 			frame = dataframes[1]
 			require.Len(t, frame.Fields, 2)
-			require.Equal(t, frame.Fields[0].Name, "Time")
+			require.Equal(t, frame.Fields[0].Name, data.TimeSeriesTimeFieldName)
 			require.Equal(t, frame.Fields[0].Len(), 2)
-			require.Equal(t, frame.Fields[1].Name, "Value")
+			require.Equal(t, frame.Fields[1].Name, data.TimeSeriesValueFieldName)
 			require.Equal(t, frame.Fields[1].Len(), 2)
 			assert.Equal(t, frame.Name, "server2")
 		})
@@ -240,33 +240,33 @@ func TestResponseParser(t *testing.T) {
 
 			frame := dataframes[0]
 			require.Len(t, frame.Fields, 2)
-			require.Equal(t, frame.Fields[0].Name, "Time")
+			require.Equal(t, frame.Fields[0].Name, data.TimeSeriesTimeFieldName)
 			require.Equal(t, frame.Fields[0].Len(), 2)
-			require.Equal(t, frame.Fields[1].Name, "Value")
+			require.Equal(t, frame.Fields[1].Name, data.TimeSeriesValueFieldName)
 			require.Equal(t, frame.Fields[1].Len(), 2)
 			assert.Equal(t, frame.Name, "server1 Count")
 
 			frame = dataframes[1]
 			require.Len(t, frame.Fields, 2)
-			require.Equal(t, frame.Fields[0].Name, "Time")
+			require.Equal(t, frame.Fields[0].Name, data.TimeSeriesTimeFieldName)
 			require.Equal(t, frame.Fields[0].Len(), 2)
-			require.Equal(t, frame.Fields[1].Name, "Value")
+			require.Equal(t, frame.Fields[1].Name, data.TimeSeriesValueFieldName)
 			require.Equal(t, frame.Fields[1].Len(), 2)
 			assert.Equal(t, frame.Name, "server1 Average @value")
 
 			frame = dataframes[2]
 			require.Len(t, frame.Fields, 2)
-			require.Equal(t, frame.Fields[0].Name, "Time")
+			require.Equal(t, frame.Fields[0].Name, data.TimeSeriesTimeFieldName)
 			require.Equal(t, frame.Fields[0].Len(), 2)
-			require.Equal(t, frame.Fields[1].Name, "Value")
+			require.Equal(t, frame.Fields[1].Name, data.TimeSeriesValueFieldName)
 			require.Equal(t, frame.Fields[1].Len(), 2)
 			assert.Equal(t, frame.Name, "server2 Count")
 
 			frame = dataframes[3]
 			require.Len(t, frame.Fields, 2)
-			require.Equal(t, frame.Fields[0].Name, "Time")
+			require.Equal(t, frame.Fields[0].Name, data.TimeSeriesTimeFieldName)
 			require.Equal(t, frame.Fields[0].Len(), 2)
-			require.Equal(t, frame.Fields[1].Name, "Value")
+			require.Equal(t, frame.Fields[1].Name, data.TimeSeriesValueFieldName)
 			require.Equal(t, frame.Fields[1].Len(), 2)
 			assert.Equal(t, frame.Name, "server2 Average @value")
 		})
@@ -312,17 +312,17 @@ func TestResponseParser(t *testing.T) {
 
 			frame := dataframes[0]
 			require.Len(t, frame.Fields, 2)
-			require.Equal(t, frame.Fields[0].Name, "Time")
+			require.Equal(t, frame.Fields[0].Name, data.TimeSeriesTimeFieldName)
 			require.Equal(t, frame.Fields[0].Len(), 2)
-			require.Equal(t, frame.Fields[1].Name, "Value")
+			require.Equal(t, frame.Fields[1].Name, data.TimeSeriesValueFieldName)
 			require.Equal(t, frame.Fields[1].Len(), 2)
 			assert.Equal(t, frame.Name, "p75")
 
 			frame = dataframes[1]
 			require.Len(t, frame.Fields, 2)
-			require.Equal(t, frame.Fields[0].Name, "Time")
+			require.Equal(t, frame.Fields[0].Name, data.TimeSeriesTimeFieldName)
 			require.Equal(t, frame.Fields[0].Len(), 2)
-			require.Equal(t, frame.Fields[1].Name, "Value")
+			require.Equal(t, frame.Fields[1].Name, data.TimeSeriesValueFieldName)
 			require.Equal(t, frame.Fields[1].Len(), 2)
 			assert.Equal(t, frame.Name, "p90")
 		})
@@ -393,49 +393,49 @@ func TestResponseParser(t *testing.T) {
 
 			frame := dataframes[0]
 			require.Len(t, frame.Fields, 2)
-			require.Equal(t, frame.Fields[0].Name, "Time")
+			require.Equal(t, frame.Fields[0].Name, data.TimeSeriesTimeFieldName)
 			require.Equal(t, frame.Fields[0].Len(), 1)
-			require.Equal(t, frame.Fields[1].Name, "Value")
+			require.Equal(t, frame.Fields[1].Name, data.TimeSeriesValueFieldName)
 			require.Equal(t, frame.Fields[1].Len(), 1)
 			assert.Equal(t, frame.Name, "server1 Max")
 
 			frame = dataframes[1]
 			require.Len(t, frame.Fields, 2)
-			require.Equal(t, frame.Fields[0].Name, "Time")
+			require.Equal(t, frame.Fields[0].Name, data.TimeSeriesTimeFieldName)
 			require.Equal(t, frame.Fields[0].Len(), 1)
-			require.Equal(t, frame.Fields[1].Name, "Value")
+			require.Equal(t, frame.Fields[1].Name, data.TimeSeriesValueFieldName)
 			require.Equal(t, frame.Fields[1].Len(), 1)
 			assert.Equal(t, frame.Name, "server1 Std Dev Lower")
 
 			frame = dataframes[2]
 			require.Len(t, frame.Fields, 2)
-			require.Equal(t, frame.Fields[0].Name, "Time")
+			require.Equal(t, frame.Fields[0].Name, data.TimeSeriesTimeFieldName)
 			require.Equal(t, frame.Fields[0].Len(), 1)
-			require.Equal(t, frame.Fields[1].Name, "Value")
+			require.Equal(t, frame.Fields[1].Name, data.TimeSeriesValueFieldName)
 			require.Equal(t, frame.Fields[1].Len(), 1)
 			assert.Equal(t, frame.Name, "server1 Std Dev Upper")
 
 			frame = dataframes[3]
 			require.Len(t, frame.Fields, 2)
-			require.Equal(t, frame.Fields[0].Name, "Time")
+			require.Equal(t, frame.Fields[0].Name, data.TimeSeriesTimeFieldName)
 			require.Equal(t, frame.Fields[0].Len(), 1)
-			require.Equal(t, frame.Fields[1].Name, "Value")
+			require.Equal(t, frame.Fields[1].Name, data.TimeSeriesValueFieldName)
 			require.Equal(t, frame.Fields[1].Len(), 1)
 			assert.Equal(t, frame.Name, "server2 Max")
 
 			frame = dataframes[4]
 			require.Len(t, frame.Fields, 2)
-			require.Equal(t, frame.Fields[0].Name, "Time")
+			require.Equal(t, frame.Fields[0].Name, data.TimeSeriesTimeFieldName)
 			require.Equal(t, frame.Fields[0].Len(), 1)
-			require.Equal(t, frame.Fields[1].Name, "Value")
+			require.Equal(t, frame.Fields[1].Name, data.TimeSeriesValueFieldName)
 			require.Equal(t, frame.Fields[1].Len(), 1)
 			assert.Equal(t, frame.Name, "server2 Std Dev Lower")
 
 			frame = dataframes[5]
 			require.Len(t, frame.Fields, 2)
-			require.Equal(t, frame.Fields[0].Name, "Time")
+			require.Equal(t, frame.Fields[0].Name, data.TimeSeriesTimeFieldName)
 			require.Equal(t, frame.Fields[0].Len(), 1)
-			require.Equal(t, frame.Fields[1].Name, "Value")
+			require.Equal(t, frame.Fields[1].Name, data.TimeSeriesValueFieldName)
 			require.Equal(t, frame.Fields[1].Len(), 1)
 			assert.Equal(t, frame.Name, "server2 Std Dev Upper")
 		})
@@ -496,25 +496,25 @@ func TestResponseParser(t *testing.T) {
 
 			frame := dataframes[0]
 			require.Len(t, frame.Fields, 2)
-			require.Equal(t, frame.Fields[0].Name, "Time")
+			require.Equal(t, frame.Fields[0].Name, data.TimeSeriesTimeFieldName)
 			require.Equal(t, frame.Fields[0].Len(), 2)
-			require.Equal(t, frame.Fields[1].Name, "Value")
+			require.Equal(t, frame.Fields[1].Name, data.TimeSeriesValueFieldName)
 			require.Equal(t, frame.Fields[1].Len(), 2)
 			assert.Equal(t, frame.Name, "server1 Count and {{not_exist}} server1")
 
 			frame = dataframes[1]
 			require.Len(t, frame.Fields, 2)
-			require.Equal(t, frame.Fields[0].Name, "Time")
+			require.Equal(t, frame.Fields[0].Name, data.TimeSeriesTimeFieldName)
 			require.Equal(t, frame.Fields[0].Len(), 2)
-			require.Equal(t, frame.Fields[1].Name, "Value")
+			require.Equal(t, frame.Fields[1].Name, data.TimeSeriesValueFieldName)
 			require.Equal(t, frame.Fields[1].Len(), 2)
 			assert.Equal(t, frame.Name, "server2 Count and {{not_exist}} server2")
 
 			frame = dataframes[2]
 			require.Len(t, frame.Fields, 2)
-			require.Equal(t, frame.Fields[0].Name, "Time")
+			require.Equal(t, frame.Fields[0].Name, data.TimeSeriesTimeFieldName)
 			require.Equal(t, frame.Fields[0].Len(), 2)
-			require.Equal(t, frame.Fields[1].Name, "Value")
+			require.Equal(t, frame.Fields[1].Name, data.TimeSeriesValueFieldName)
 			require.Equal(t, frame.Fields[1].Len(), 2)
 			assert.Equal(t, frame.Name, "0 Count and {{not_exist}} 0")
 		})
@@ -598,17 +598,17 @@ func TestResponseParser(t *testing.T) {
 
 			frame := dataframes[0]
 			require.Len(t, frame.Fields, 2)
-			require.Equal(t, frame.Fields[0].Name, "Time")
+			require.Equal(t, frame.Fields[0].Name, data.TimeSeriesTimeFieldName)
 			require.Equal(t, frame.Fields[0].Len(), 2)
-			require.Equal(t, frame.Fields[1].Name, "Value")
+			require.Equal(t, frame.Fields[1].Name, data.TimeSeriesValueFieldName)
 			require.Equal(t, frame.Fields[1].Len(), 2)
 			assert.Equal(t, frame.Name, "@metric:cpu")
 
 			frame = dataframes[1]
 			require.Len(t, frame.Fields, 2)
-			require.Equal(t, frame.Fields[0].Name, "Time")
+			require.Equal(t, frame.Fields[0].Name, data.TimeSeriesTimeFieldName)
 			require.Equal(t, frame.Fields[0].Len(), 2)
-			require.Equal(t, frame.Fields[1].Name, "Value")
+			require.Equal(t, frame.Fields[1].Name, data.TimeSeriesValueFieldName)
 			require.Equal(t, frame.Fields[1].Len(), 2)
 			assert.Equal(t, frame.Name, "@metric:logins.count")
 		})
@@ -666,17 +666,17 @@ func TestResponseParser(t *testing.T) {
 
 			frame := dataframes[0]
 			require.Len(t, frame.Fields, 2)
-			require.Equal(t, frame.Fields[0].Name, "Time")
+			require.Equal(t, frame.Fields[0].Name, data.TimeSeriesTimeFieldName)
 			require.Equal(t, frame.Fields[0].Len(), 1)
-			require.Equal(t, frame.Fields[1].Name, "Value")
+			require.Equal(t, frame.Fields[1].Name, data.TimeSeriesValueFieldName)
 			require.Equal(t, frame.Fields[1].Len(), 1)
 			assert.Equal(t, frame.Name, "Average")
 
 			frame = dataframes[1]
 			require.Len(t, frame.Fields, 2)
-			require.Equal(t, frame.Fields[0].Name, "Time")
+			require.Equal(t, frame.Fields[0].Name, data.TimeSeriesTimeFieldName)
 			require.Equal(t, frame.Fields[0].Len(), 1)
-			require.Equal(t, frame.Fields[1].Name, "Value")
+			require.Equal(t, frame.Fields[1].Name, data.TimeSeriesValueFieldName)
 			require.Equal(t, frame.Fields[1].Len(), 1)
 			assert.Equal(t, frame.Name, "Count")
 		})
@@ -734,17 +734,17 @@ func TestResponseParser(t *testing.T) {
 
 			frame := dataframes[0]
 			require.Len(t, frame.Fields, 2)
-			require.Equal(t, frame.Fields[0].Name, "Time")
+			require.Equal(t, frame.Fields[0].Name, data.TimeSeriesTimeFieldName)
 			require.Equal(t, frame.Fields[0].Len(), 1)
-			require.Equal(t, frame.Fields[1].Name, "Value")
+			require.Equal(t, frame.Fields[1].Name, data.TimeSeriesValueFieldName)
 			require.Equal(t, frame.Fields[1].Len(), 1)
 			assert.Equal(t, frame.Name, "Average")
 
 			frame = dataframes[1]
 			require.Len(t, frame.Fields, 2)
-			require.Equal(t, frame.Fields[0].Name, "Time")
+			require.Equal(t, frame.Fields[0].Name, data.TimeSeriesTimeFieldName)
 			require.Equal(t, frame.Fields[0].Len(), 1)
-			require.Equal(t, frame.Fields[1].Name, "Value")
+			require.Equal(t, frame.Fields[1].Name, data.TimeSeriesValueFieldName)
 			require.Equal(t, frame.Fields[1].Len(), 1)
 			assert.Equal(t, frame.Name, "Count")
 		})
@@ -945,25 +945,25 @@ func TestResponseParser(t *testing.T) {
 
 			frame := dataframes[0]
 			require.Len(t, frame.Fields, 2)
-			require.Equal(t, frame.Fields[0].Name, "Time")
+			require.Equal(t, frame.Fields[0].Name, data.TimeSeriesTimeFieldName)
 			require.Equal(t, frame.Fields[0].Len(), 2)
-			require.Equal(t, frame.Fields[1].Name, "Value")
+			require.Equal(t, frame.Fields[1].Name, data.TimeSeriesValueFieldName)
 			require.Equal(t, frame.Fields[1].Len(), 2)
 			assert.Equal(t, frame.Name, "Sum @value")
 
 			frame = dataframes[1]
 			require.Len(t, frame.Fields, 2)
-			require.Equal(t, frame.Fields[0].Name, "Time")
+			require.Equal(t, frame.Fields[0].Name, data.TimeSeriesTimeFieldName)
 			require.Equal(t, frame.Fields[0].Len(), 2)
-			require.Equal(t, frame.Fields[1].Name, "Value")
+			require.Equal(t, frame.Fields[1].Name, data.TimeSeriesValueFieldName)
 			require.Equal(t, frame.Fields[1].Len(), 2)
 			assert.Equal(t, frame.Name, "Max @value")
 
 			frame = dataframes[2]
 			require.Len(t, frame.Fields, 2)
-			require.Equal(t, frame.Fields[0].Name, "Time")
+			require.Equal(t, frame.Fields[0].Name, data.TimeSeriesTimeFieldName)
 			require.Equal(t, frame.Fields[0].Len(), 2)
-			require.Equal(t, frame.Fields[1].Name, "Value")
+			require.Equal(t, frame.Fields[1].Name, data.TimeSeriesValueFieldName)
 			require.Equal(t, frame.Fields[1].Len(), 2)
 			assert.Equal(t, frame.Name, "Sum @value * Max @value")
 		})

--- a/pkg/tsdb/elasticsearch/testdata/trimedges_string.golden.jsonc
+++ b/pkg/tsdb/elasticsearch/testdata/trimedges_string.golden.jsonc
@@ -7,7 +7,7 @@
 //          0
 //      ]
 //  }
-//  Name: 
+//  Name: Count
 //  Dimensions: 2 Fields by 3 Rows
 //  +-------------------------------+------------------+
 //  | Name: time                    | Name: value      |
@@ -26,6 +26,7 @@
   "frames": [
     {
       "schema": {
+        "name": "Count",
         "meta": {
           "type": "timeseries-multi",
           "typeVersion": [
@@ -48,10 +49,7 @@
               "frame": "float64",
               "nullable": true
             },
-            "labels": {},
-            "config": {
-              "displayName": "Count"
-            }
+            "labels": {}
           }
         ]
       },

--- a/pkg/tsdb/elasticsearch/testdata/trimedges_string.golden.jsonc
+++ b/pkg/tsdb/elasticsearch/testdata/trimedges_string.golden.jsonc
@@ -50,7 +50,7 @@
             },
             "labels": {},
             "config": {
-              "displayNameFromDS": "Count"
+              "displayName": "Count"
             }
           }
         ]

--- a/pkg/tsdb/elasticsearch/testdata/trimedges_string.golden.jsonc
+++ b/pkg/tsdb/elasticsearch/testdata/trimedges_string.golden.jsonc
@@ -10,7 +10,7 @@
 //  Name: Count
 //  Dimensions: 2 Fields by 3 Rows
 //  +-------------------------------+------------------+
-//  | Name: time                    | Name: value      |
+//  | Name: Time                    | Name: Value      |
 //  | Labels:                       | Labels:          |
 //  | Type: []time.Time             | Type: []*float64 |
 //  +-------------------------------+------------------+
@@ -36,14 +36,14 @@
         },
         "fields": [
           {
-            "name": "time",
+            "name": "Time",
             "type": "time",
             "typeInfo": {
               "frame": "time.Time"
             }
           },
           {
-            "name": "value",
+            "name": "Value",
             "type": "number",
             "typeInfo": {
               "frame": "float64",

--- a/pkg/tsdb/elasticsearch/testdata_response/metric_complex.a.golden.jsonc
+++ b/pkg/tsdb/elasticsearch/testdata_response/metric_complex.a.golden.jsonc
@@ -7,7 +7,7 @@
 //          0
 //      ]
 //  }
-//  Name: 
+//  Name: val3 Max float
 //  Dimensions: 2 Fields by 3 Rows
 //  +-------------------------------+--------------------+
 //  | Name: time                    | Name: value        |
@@ -28,7 +28,7 @@
 //          0
 //      ]
 //  }
-//  Name: 
+//  Name: val3 Min float
 //  Dimensions: 2 Fields by 3 Rows
 //  +-------------------------------+--------------------+
 //  | Name: time                    | Name: value        |
@@ -49,7 +49,7 @@
 //          0
 //      ]
 //  }
-//  Name: 
+//  Name: val2 Max float
 //  Dimensions: 2 Fields by 3 Rows
 //  +-------------------------------+--------------------+
 //  | Name: time                    | Name: value        |
@@ -70,7 +70,7 @@
 //          0
 //      ]
 //  }
-//  Name: 
+//  Name: val2 Min float
 //  Dimensions: 2 Fields by 3 Rows
 //  +-------------------------------+--------------------+
 //  | Name: time                    | Name: value        |
@@ -91,7 +91,7 @@
 //          0
 //      ]
 //  }
-//  Name: 
+//  Name: val1 Max float
 //  Dimensions: 2 Fields by 3 Rows
 //  +-------------------------------+--------------------+
 //  | Name: time                    | Name: value        |
@@ -112,7 +112,7 @@
 //          0
 //      ]
 //  }
-//  Name: 
+//  Name: val1 Min float
 //  Dimensions: 2 Fields by 3 Rows
 //  +-------------------------------+--------------------+
 //  | Name: time                    | Name: value        |
@@ -131,6 +131,7 @@
   "frames": [
     {
       "schema": {
+        "name": "val3 Max float",
         "meta": {
           "type": "timeseries-multi",
           "typeVersion": [
@@ -155,9 +156,6 @@
             },
             "labels": {
               "label": "val3"
-            },
-            "config": {
-              "displayName": "val3 Max float"
             }
           }
         ]
@@ -179,6 +177,7 @@
     },
     {
       "schema": {
+        "name": "val3 Min float",
         "meta": {
           "type": "timeseries-multi",
           "typeVersion": [
@@ -203,9 +202,6 @@
             },
             "labels": {
               "label": "val3"
-            },
-            "config": {
-              "displayName": "val3 Min float"
             }
           }
         ]
@@ -227,6 +223,7 @@
     },
     {
       "schema": {
+        "name": "val2 Max float",
         "meta": {
           "type": "timeseries-multi",
           "typeVersion": [
@@ -251,9 +248,6 @@
             },
             "labels": {
               "label": "val2"
-            },
-            "config": {
-              "displayName": "val2 Max float"
             }
           }
         ]
@@ -275,6 +269,7 @@
     },
     {
       "schema": {
+        "name": "val2 Min float",
         "meta": {
           "type": "timeseries-multi",
           "typeVersion": [
@@ -299,9 +294,6 @@
             },
             "labels": {
               "label": "val2"
-            },
-            "config": {
-              "displayName": "val2 Min float"
             }
           }
         ]
@@ -323,6 +315,7 @@
     },
     {
       "schema": {
+        "name": "val1 Max float",
         "meta": {
           "type": "timeseries-multi",
           "typeVersion": [
@@ -347,9 +340,6 @@
             },
             "labels": {
               "label": "val1"
-            },
-            "config": {
-              "displayName": "val1 Max float"
             }
           }
         ]
@@ -371,6 +361,7 @@
     },
     {
       "schema": {
+        "name": "val1 Min float",
         "meta": {
           "type": "timeseries-multi",
           "typeVersion": [
@@ -395,9 +386,6 @@
             },
             "labels": {
               "label": "val1"
-            },
-            "config": {
-              "displayName": "val1 Min float"
             }
           }
         ]

--- a/pkg/tsdb/elasticsearch/testdata_response/metric_complex.a.golden.jsonc
+++ b/pkg/tsdb/elasticsearch/testdata_response/metric_complex.a.golden.jsonc
@@ -10,7 +10,7 @@
 //  Name: val3 Max float
 //  Dimensions: 2 Fields by 3 Rows
 //  +-------------------------------+--------------------+
-//  | Name: time                    | Name: value        |
+//  | Name: Time                    | Name: Value        |
 //  | Labels:                       | Labels: label=val3 |
 //  | Type: []time.Time             | Type: []*float64   |
 //  +-------------------------------+--------------------+
@@ -31,7 +31,7 @@
 //  Name: val3 Min float
 //  Dimensions: 2 Fields by 3 Rows
 //  +-------------------------------+--------------------+
-//  | Name: time                    | Name: value        |
+//  | Name: Time                    | Name: Value        |
 //  | Labels:                       | Labels: label=val3 |
 //  | Type: []time.Time             | Type: []*float64   |
 //  +-------------------------------+--------------------+
@@ -52,7 +52,7 @@
 //  Name: val2 Max float
 //  Dimensions: 2 Fields by 3 Rows
 //  +-------------------------------+--------------------+
-//  | Name: time                    | Name: value        |
+//  | Name: Time                    | Name: Value        |
 //  | Labels:                       | Labels: label=val2 |
 //  | Type: []time.Time             | Type: []*float64   |
 //  +-------------------------------+--------------------+
@@ -73,7 +73,7 @@
 //  Name: val2 Min float
 //  Dimensions: 2 Fields by 3 Rows
 //  +-------------------------------+--------------------+
-//  | Name: time                    | Name: value        |
+//  | Name: Time                    | Name: Value        |
 //  | Labels:                       | Labels: label=val2 |
 //  | Type: []time.Time             | Type: []*float64   |
 //  +-------------------------------+--------------------+
@@ -94,7 +94,7 @@
 //  Name: val1 Max float
 //  Dimensions: 2 Fields by 3 Rows
 //  +-------------------------------+--------------------+
-//  | Name: time                    | Name: value        |
+//  | Name: Time                    | Name: Value        |
 //  | Labels:                       | Labels: label=val1 |
 //  | Type: []time.Time             | Type: []*float64   |
 //  +-------------------------------+--------------------+
@@ -115,7 +115,7 @@
 //  Name: val1 Min float
 //  Dimensions: 2 Fields by 3 Rows
 //  +-------------------------------+--------------------+
-//  | Name: time                    | Name: value        |
+//  | Name: Time                    | Name: Value        |
 //  | Labels:                       | Labels: label=val1 |
 //  | Type: []time.Time             | Type: []*float64   |
 //  +-------------------------------+--------------------+
@@ -141,14 +141,14 @@
         },
         "fields": [
           {
-            "name": "time",
+            "name": "Time",
             "type": "time",
             "typeInfo": {
               "frame": "time.Time"
             }
           },
           {
-            "name": "value",
+            "name": "Value",
             "type": "number",
             "typeInfo": {
               "frame": "float64",
@@ -187,14 +187,14 @@
         },
         "fields": [
           {
-            "name": "time",
+            "name": "Time",
             "type": "time",
             "typeInfo": {
               "frame": "time.Time"
             }
           },
           {
-            "name": "value",
+            "name": "Value",
             "type": "number",
             "typeInfo": {
               "frame": "float64",
@@ -233,14 +233,14 @@
         },
         "fields": [
           {
-            "name": "time",
+            "name": "Time",
             "type": "time",
             "typeInfo": {
               "frame": "time.Time"
             }
           },
           {
-            "name": "value",
+            "name": "Value",
             "type": "number",
             "typeInfo": {
               "frame": "float64",
@@ -279,14 +279,14 @@
         },
         "fields": [
           {
-            "name": "time",
+            "name": "Time",
             "type": "time",
             "typeInfo": {
               "frame": "time.Time"
             }
           },
           {
-            "name": "value",
+            "name": "Value",
             "type": "number",
             "typeInfo": {
               "frame": "float64",
@@ -325,14 +325,14 @@
         },
         "fields": [
           {
-            "name": "time",
+            "name": "Time",
             "type": "time",
             "typeInfo": {
               "frame": "time.Time"
             }
           },
           {
-            "name": "value",
+            "name": "Value",
             "type": "number",
             "typeInfo": {
               "frame": "float64",
@@ -371,14 +371,14 @@
         },
         "fields": [
           {
-            "name": "time",
+            "name": "Time",
             "type": "time",
             "typeInfo": {
               "frame": "time.Time"
             }
           },
           {
-            "name": "value",
+            "name": "Value",
             "type": "number",
             "typeInfo": {
               "frame": "float64",

--- a/pkg/tsdb/elasticsearch/testdata_response/metric_complex.a.golden.jsonc
+++ b/pkg/tsdb/elasticsearch/testdata_response/metric_complex.a.golden.jsonc
@@ -157,7 +157,7 @@
               "label": "val3"
             },
             "config": {
-              "displayNameFromDS": "val3 Max float"
+              "displayName": "val3 Max float"
             }
           }
         ]
@@ -205,7 +205,7 @@
               "label": "val3"
             },
             "config": {
-              "displayNameFromDS": "val3 Min float"
+              "displayName": "val3 Min float"
             }
           }
         ]
@@ -253,7 +253,7 @@
               "label": "val2"
             },
             "config": {
-              "displayNameFromDS": "val2 Max float"
+              "displayName": "val2 Max float"
             }
           }
         ]
@@ -301,7 +301,7 @@
               "label": "val2"
             },
             "config": {
-              "displayNameFromDS": "val2 Min float"
+              "displayName": "val2 Min float"
             }
           }
         ]
@@ -349,7 +349,7 @@
               "label": "val1"
             },
             "config": {
-              "displayNameFromDS": "val1 Max float"
+              "displayName": "val1 Max float"
             }
           }
         ]
@@ -397,7 +397,7 @@
               "label": "val1"
             },
             "config": {
-              "displayNameFromDS": "val1 Min float"
+              "displayName": "val1 Min float"
             }
           }
         ]

--- a/pkg/tsdb/elasticsearch/testdata_response/metric_multi.a.golden.jsonc
+++ b/pkg/tsdb/elasticsearch/testdata_response/metric_multi.a.golden.jsonc
@@ -10,7 +10,7 @@
 //  Name: Max float
 //  Dimensions: 2 Fields by 3 Rows
 //  +-------------------------------+-------------------+
-//  | Name: time                    | Name: value       |
+//  | Name: Time                    | Name: Value       |
 //  | Labels:                       | Labels:           |
 //  | Type: []time.Time             | Type: []*float64  |
 //  +-------------------------------+-------------------+
@@ -36,14 +36,14 @@
         },
         "fields": [
           {
-            "name": "time",
+            "name": "Time",
             "type": "time",
             "typeInfo": {
               "frame": "time.Time"
             }
           },
           {
-            "name": "value",
+            "name": "Value",
             "type": "number",
             "typeInfo": {
               "frame": "float64",

--- a/pkg/tsdb/elasticsearch/testdata_response/metric_multi.a.golden.jsonc
+++ b/pkg/tsdb/elasticsearch/testdata_response/metric_multi.a.golden.jsonc
@@ -7,7 +7,7 @@
 //          0
 //      ]
 //  }
-//  Name: 
+//  Name: Max float
 //  Dimensions: 2 Fields by 3 Rows
 //  +-------------------------------+-------------------+
 //  | Name: time                    | Name: value       |
@@ -26,6 +26,7 @@
   "frames": [
     {
       "schema": {
+        "name": "Max float",
         "meta": {
           "type": "timeseries-multi",
           "typeVersion": [
@@ -48,10 +49,7 @@
               "frame": "float64",
               "nullable": true
             },
-            "labels": {},
-            "config": {
-              "displayName": "Max float"
-            }
+            "labels": {}
           }
         ]
       },

--- a/pkg/tsdb/elasticsearch/testdata_response/metric_multi.a.golden.jsonc
+++ b/pkg/tsdb/elasticsearch/testdata_response/metric_multi.a.golden.jsonc
@@ -50,7 +50,7 @@
             },
             "labels": {},
             "config": {
-              "displayNameFromDS": "Max float"
+              "displayName": "Max float"
             }
           }
         ]

--- a/pkg/tsdb/elasticsearch/testdata_response/metric_multi.b.golden.jsonc
+++ b/pkg/tsdb/elasticsearch/testdata_response/metric_multi.b.golden.jsonc
@@ -10,7 +10,7 @@
 //  Name: Min float
 //  Dimensions: 2 Fields by 3 Rows
 //  +-------------------------------+---------------------+
-//  | Name: time                    | Name: value         |
+//  | Name: Time                    | Name: Value         |
 //  | Labels:                       | Labels:             |
 //  | Type: []time.Time             | Type: []*float64    |
 //  +-------------------------------+---------------------+
@@ -36,14 +36,14 @@
         },
         "fields": [
           {
-            "name": "time",
+            "name": "Time",
             "type": "time",
             "typeInfo": {
               "frame": "time.Time"
             }
           },
           {
-            "name": "value",
+            "name": "Value",
             "type": "number",
             "typeInfo": {
               "frame": "float64",

--- a/pkg/tsdb/elasticsearch/testdata_response/metric_multi.b.golden.jsonc
+++ b/pkg/tsdb/elasticsearch/testdata_response/metric_multi.b.golden.jsonc
@@ -50,7 +50,7 @@
             },
             "labels": {},
             "config": {
-              "displayNameFromDS": "Min float"
+              "displayName": "Min float"
             }
           }
         ]

--- a/pkg/tsdb/elasticsearch/testdata_response/metric_multi.b.golden.jsonc
+++ b/pkg/tsdb/elasticsearch/testdata_response/metric_multi.b.golden.jsonc
@@ -7,7 +7,7 @@
 //          0
 //      ]
 //  }
-//  Name: 
+//  Name: Min float
 //  Dimensions: 2 Fields by 3 Rows
 //  +-------------------------------+---------------------+
 //  | Name: time                    | Name: value         |
@@ -26,6 +26,7 @@
   "frames": [
     {
       "schema": {
+        "name": "Min float",
         "meta": {
           "type": "timeseries-multi",
           "typeVersion": [
@@ -48,10 +49,7 @@
               "frame": "float64",
               "nullable": true
             },
-            "labels": {},
-            "config": {
-              "displayName": "Min float"
-            }
+            "labels": {}
           }
         ]
       },

--- a/pkg/tsdb/elasticsearch/testdata_response/metric_simple.a.golden.jsonc
+++ b/pkg/tsdb/elasticsearch/testdata_response/metric_simple.a.golden.jsonc
@@ -97,7 +97,7 @@
               "label": "val3"
             },
             "config": {
-              "displayNameFromDS": "val3"
+              "displayName": "val3"
             }
           }
         ]
@@ -147,7 +147,7 @@
               "label": "val2"
             },
             "config": {
-              "displayNameFromDS": "val2"
+              "displayName": "val2"
             }
           }
         ]
@@ -197,7 +197,7 @@
               "label": "val1"
             },
             "config": {
-              "displayNameFromDS": "val1"
+              "displayName": "val1"
             }
           }
         ]

--- a/pkg/tsdb/elasticsearch/testdata_response/metric_simple.a.golden.jsonc
+++ b/pkg/tsdb/elasticsearch/testdata_response/metric_simple.a.golden.jsonc
@@ -7,7 +7,7 @@
 //          0
 //      ]
 //  }
-//  Name: 
+//  Name: val3
 //  Dimensions: 2 Fields by 4 Rows
 //  +-------------------------------+--------------------+
 //  | Name: time                    | Name: value        |
@@ -29,7 +29,7 @@
 //          0
 //      ]
 //  }
-//  Name: 
+//  Name: val2
 //  Dimensions: 2 Fields by 4 Rows
 //  +-------------------------------+--------------------+
 //  | Name: time                    | Name: value        |
@@ -51,7 +51,7 @@
 //          0
 //      ]
 //  }
-//  Name: 
+//  Name: val1
 //  Dimensions: 2 Fields by 4 Rows
 //  +-------------------------------+--------------------+
 //  | Name: time                    | Name: value        |
@@ -71,6 +71,7 @@
   "frames": [
     {
       "schema": {
+        "name": "val3",
         "meta": {
           "type": "timeseries-multi",
           "typeVersion": [
@@ -95,9 +96,6 @@
             },
             "labels": {
               "label": "val3"
-            },
-            "config": {
-              "displayName": "val3"
             }
           }
         ]
@@ -121,6 +119,7 @@
     },
     {
       "schema": {
+        "name": "val2",
         "meta": {
           "type": "timeseries-multi",
           "typeVersion": [
@@ -145,9 +144,6 @@
             },
             "labels": {
               "label": "val2"
-            },
-            "config": {
-              "displayName": "val2"
             }
           }
         ]
@@ -171,6 +167,7 @@
     },
     {
       "schema": {
+        "name": "val1",
         "meta": {
           "type": "timeseries-multi",
           "typeVersion": [
@@ -195,9 +192,6 @@
             },
             "labels": {
               "label": "val1"
-            },
-            "config": {
-              "displayName": "val1"
             }
           }
         ]

--- a/pkg/tsdb/elasticsearch/testdata_response/metric_simple.a.golden.jsonc
+++ b/pkg/tsdb/elasticsearch/testdata_response/metric_simple.a.golden.jsonc
@@ -10,7 +10,7 @@
 //  Name: val3
 //  Dimensions: 2 Fields by 4 Rows
 //  +-------------------------------+--------------------+
-//  | Name: time                    | Name: value        |
+//  | Name: Time                    | Name: Value        |
 //  | Labels:                       | Labels: label=val3 |
 //  | Type: []time.Time             | Type: []*float64   |
 //  +-------------------------------+--------------------+
@@ -32,7 +32,7 @@
 //  Name: val2
 //  Dimensions: 2 Fields by 4 Rows
 //  +-------------------------------+--------------------+
-//  | Name: time                    | Name: value        |
+//  | Name: Time                    | Name: Value        |
 //  | Labels:                       | Labels: label=val2 |
 //  | Type: []time.Time             | Type: []*float64   |
 //  +-------------------------------+--------------------+
@@ -54,7 +54,7 @@
 //  Name: val1
 //  Dimensions: 2 Fields by 4 Rows
 //  +-------------------------------+--------------------+
-//  | Name: time                    | Name: value        |
+//  | Name: Time                    | Name: Value        |
 //  | Labels:                       | Labels: label=val1 |
 //  | Type: []time.Time             | Type: []*float64   |
 //  +-------------------------------+--------------------+
@@ -81,14 +81,14 @@
         },
         "fields": [
           {
-            "name": "time",
+            "name": "Time",
             "type": "time",
             "typeInfo": {
               "frame": "time.Time"
             }
           },
           {
-            "name": "value",
+            "name": "Value",
             "type": "number",
             "typeInfo": {
               "frame": "float64",
@@ -129,14 +129,14 @@
         },
         "fields": [
           {
-            "name": "time",
+            "name": "Time",
             "type": "time",
             "typeInfo": {
               "frame": "time.Time"
             }
           },
           {
-            "name": "value",
+            "name": "Value",
             "type": "number",
             "typeInfo": {
               "frame": "float64",
@@ -177,14 +177,14 @@
         },
         "fields": [
           {
-            "name": "time",
+            "name": "Time",
             "type": "time",
             "typeInfo": {
               "frame": "time.Time"
             }
           },
           {
-            "name": "value",
+            "name": "Value",
             "type": "number",
             "typeInfo": {
               "frame": "float64",


### PR DESCRIPTION
Part of https://github.com/grafana/grafana/issues/54011.

In ES backend, we are setting name of field to `frame.Fields[1].Config.DisplayNameFromDS`. On frontend, the place is `frame.name`. This is because:

- on frontend, we parse results to time series
- we set the name to in [nameSeries](https://github.com/grafana/grafana/blob/main/public/app/plugins/datasource/elasticsearch/ElasticResponse.ts#L582) and set it to [series.target](https://github.com/grafana/grafana/blob/main/public/app/plugins/datasource/elasticsearch/ElasticResponse.ts#L403).
- then we process [time series to data frames ](https://github.com/grafana/grafana/blob/main/public/app/plugins/datasource/elasticsearch/ElasticResponse.ts#L591) and there we use [series.target as data frame name](https://github.com/grafana/grafana/blob/main/packages/grafana-data/src/dataframe/processDataFrame.ts#LL108C7-L108C7)

I know that there were some discussions about which one of `field.name`, `field.config.displayName`, `field.config.displayNameFromDS` should be used and `frame.name` is not even suggested, but to ensure 100% backward compatibility, I have decided to use `frame.name` and we can re-evaluate this again in the future, when backend migration is completed. 

But I am also open for discussion, if `field.name` should be used instead. 