### PR TITLE
Alerting: Fix Classic Conditions $values variable

### DIFF
--- a/pkg/services/ngalert/state/cache.go
+++ b/pkg/services/ngalert/state/cache.go
@@ -52,11 +52,11 @@ func (rs *ruleStates) getOrCreate(ctx context.Context, log log.Logger, alertRule
 	ruleLabels, annotations := rs.expandRuleLabelsAndAnnotations(ctx, log, alertRule, result, extraLabels, externalURL)
 
 	values := make(map[string]float64)
-	for _, v := range result.Values {
+	for refID, v := range result.Values {
 		if v.Value != nil {
-			values[v.Var] = *v.Value
+			values[refID] = *v.Value
 		} else {
-			values[v.Var] = math.NaN()
+			values[refID] = math.NaN()
 		}
 	}
 

--- a/pkg/services/ngalert/state/cache_test.go
+++ b/pkg/services/ngalert/state/cache_test.go
@@ -108,6 +108,7 @@ func Test_getOrCreate(t *testing.T) {
 			assert.Equal(t, expected, state.Labels["rule-"+key])
 		}
 	})
+
 	t.Run("rule annotations should be able to be expanded with result and extra labels", func(t *testing.T) {
 		result := eval.Result{
 			Instance: models.GenerateAlertLabels(5, "result-"),
@@ -133,6 +134,34 @@ func Test_getOrCreate(t *testing.T) {
 		for key, expected := range result.Instance {
 			assert.Equal(t, expected, state.Annotations["rule-"+key])
 		}
+	})
+
+	t.Run("expected Reduce and Math expression values", func(t *testing.T) {
+		result := eval.Result{
+			Instance: models.GenerateAlertLabels(5, "result-"),
+			Values: map[string]eval.NumberValueCapture{
+				"A": eval.NumberValueCapture{Var: "A", Value: util.Pointer(1.0)},
+				"B": eval.NumberValueCapture{Var: "B", Value: util.Pointer(2.0)},
+			},
+		}
+		rule := generateRule()
+
+		state := c.getOrCreate(context.Background(), l, rule, result, nil, url)
+		assert.Equal(t, map[string]float64{"A": 1, "B": 2}, state.Values)
+	})
+
+	t.Run("expected Classic Condition values", func(t *testing.T) {
+		result := eval.Result{
+			Instance: models.GenerateAlertLabels(5, "result-"),
+			Values: map[string]eval.NumberValueCapture{
+				"B0": eval.NumberValueCapture{Var: "A", Value: util.Pointer(1.0)},
+				"B1": eval.NumberValueCapture{Var: "B", Value: util.Pointer(2.0)},
+			},
+		}
+		rule := generateRule()
+
+		state := c.getOrCreate(context.Background(), l, rule, result, nil, url)
+		assert.Equal(t, map[string]float64{"B0": 1, "B1": 2}, state.Values)
 	})
 }
 

--- a/pkg/services/ngalert/state/cache_test.go
+++ b/pkg/services/ngalert/state/cache_test.go
@@ -154,7 +154,7 @@ func Test_getOrCreate(t *testing.T) {
 		result := eval.Result{
 			Instance: models.GenerateAlertLabels(5, "result-"),
 			Values: map[string]eval.NumberValueCapture{
-				"B0": eval.NumberValueCapture{Var: "A", Value: util.Pointer(1.0)},
+				"B0": eval.NumberValueCapture{Var: "B", Value: util.Pointer(1.0)},
 				"B1": eval.NumberValueCapture{Var: "B", Value: util.Pointer(2.0)},
 			},
 		}


### PR DESCRIPTION
**Which issue(s) does this PR fix?**:

This commit fixes a bug in the `$values` variable in notification templates when using Classic Conditions. Since Classic Conditions are not multi-dimensional, the values of each series that exceeded the condition should be available as a RefID and offset. For example, `B0`, `B1`, etc. However, this bug meant that instead just a single condition would be printed as `B`, not `B0`.

<img width="553" alt="Screenshot 2023-03-06 at 16 36 21" src="https://user-images.githubusercontent.com/85952834/223173323-09ca46f2-0584-45f7-af35-1392e7ee20e3.png">

Here is the output of the tests without the fix:

```
--- FAIL: Test_getOrCreate (0.00s)
    --- FAIL: Test_getOrCreate/expected_Classic_Condition_values (0.00s)
        cache_test.go:164:
            	Error Trace:	/Users/grobinson/go/src/github.com/grafana/grafana/pkg/services/ngalert/state/cache_test.go:164
            	Error:      	Not equal:
            	            	expected: map[string]float64{"B0":1, "B1":2}
            	            	actual  : map[string]float64{"B":2}

            	            	Diff:
            	            	--- Expected
            	            	+++ Actual
            	            	@@ -1,4 +1,3 @@
            	            	-(map[string]float64) (len=2) {
            	            	- (string) (len=2) "B0": (float64) 1,
            	            	- (string) (len=2) "B1": (float64) 2
            	            	+(map[string]float64) (len=1) {
            	            	+ (string) (len=1) "B": (float64) 2
            	            	 }
            	Test:       	Test_getOrCreate/expected_Classic_Condition_values
FAIL
```

**Special notes for your reviewer**:

