### PR TITLE
CloudWatch Logs: Fix interpolation of scoped variables in queryString

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/__mocks__/Request.ts
+++ b/public/app/plugins/datasource/cloudwatch/__mocks__/Request.ts
@@ -24,7 +24,7 @@ export const LogsRequestMock: DataQueryRequest<CloudWatchLogsQuery> = {
   requestId: '',
   interval: '',
   intervalMs: 0,
-  scopedVars: {},
+  scopedVars: { __interval: { value: '20s' } },
   timezone: '',
   app: '',
   startTime: 0,

--- a/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchLogsQueryRunner.ts
+++ b/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchLogsQueryRunner.ts
@@ -103,7 +103,7 @@ export class CloudWatchLogsQueryRunner extends CloudWatchRequest {
       return {
         refId: target.refId,
         region: this.templateSrv.replace(this.getActualRegion(target.region)),
-        queryString: this.templateSrv.replace(target.expression || ''),
+        queryString: this.templateSrv.replace(target.expression || '', options.scopedVars),
         logGroups,
         logGroupNames,
       };


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

When the Cloudwatch refactor was done, we removed [the code that replaced variables](https://github.com/grafana/grafana/blob/release-9.3.8/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchLogsQueryRunner.ts#L314) and the code it was replaced with did not pass the scoped vars along.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #64034 

**Special notes for your reviewer**:

