### PR TITLE
Chore: Add stat for remote cache config

### DIFF
--- a/pkg/infra/usagestats/statscollector/service.go
+++ b/pkg/infra/usagestats/statscollector/service.go
@@ -173,7 +173,9 @@ func (s *Service) collectSystemStats(ctx context.Context) (map[string]interface{
 	}
 
 	m["stats.avg_auth_token_per_user.count"] = avgAuthTokensPerUser
-	m["stats.remote_cache."+s.cfg.RemoteCacheOptions.Name+".count"] = 1
+	if s.cfg.RemoteCacheOptions != nil && s.cfg.RemoteCacheOptions.Name != "" {
+		m["stats.remote_cache."+s.cfg.RemoteCacheOptions.Name+".count"] = 1
+	}
 	m["stats.packaging."+s.cfg.Packaging+".count"] = 1
 	m["stats.distributor."+s.cfg.ReportingDistributor+".count"] = 1
 

--- a/pkg/infra/usagestats/statscollector/service.go
+++ b/pkg/infra/usagestats/statscollector/service.go
@@ -173,6 +173,7 @@ func (s *Service) collectSystemStats(ctx context.Context) (map[string]interface{
 	}
 
 	m["stats.avg_auth_token_per_user.count"] = avgAuthTokensPerUser
+	m["stats.remote_cache."+s.cfg.RemoteCacheOptions.Name+".count"] = 1
 	m["stats.packaging."+s.cfg.Packaging+".count"] = 1
 	m["stats.distributor."+s.cfg.ReportingDistributor+".count"] = 1
 

--- a/pkg/infra/usagestats/statscollector/service_test.go
+++ b/pkg/infra/usagestats/statscollector/service_test.go
@@ -152,6 +152,9 @@ func TestCollectingUsageStats(t *testing.T) {
 		AuthProxyEnabled:     true,
 		Packaging:            "deb",
 		ReportingDistributor: "hosted-grafana",
+		RemoteCacheOptions: &setting.RemoteCacheOptions{
+			Name: "database",
+		},
 	}, sqlStore, statsService,
 		withDatasources(mockDatasourceService{datasources: expectedDataSources}))
 
@@ -179,6 +182,7 @@ func TestCollectingUsageStats(t *testing.T) {
 	assert.EqualValues(t, 11, metrics["stats.data_keys.count"])
 	assert.EqualValues(t, 3, metrics["stats.active_data_keys.count"])
 	assert.EqualValues(t, 5, metrics["stats.public_dashboards.count"])
+	assert.EqualValues(t, 1, metrics["stats.remote_cache.database.count"])
 
 	assert.InDelta(t, int64(65), metrics["stats.uptime"], 6)
 }


### PR DESCRIPTION
This PR adds a stat to report the type of remote cache that's in use, so we can gauge how popular the different options are.