### PR TITLE
Chore: cleanup entity api from CodeQL scan

### DIFF
--- a/pkg/services/store/entity/sqlstash/querybuilder.go
+++ b/pkg/services/store/entity/sqlstash/querybuilder.go
@@ -5,7 +5,7 @@ import "strings"
 type selectQuery struct {
 	fields   []string // SELECT xyz
 	from     string   // FROM object
-	limit    int
+	limit    int64
 	oneExtra bool
 
 	where []string

--- a/pkg/services/store/entity/sqlstash/sql_storage_server.go
+++ b/pkg/services/store/entity/sqlstash/sql_storage_server.go
@@ -749,7 +749,7 @@ func (s *sqlEntityServer) Search(ctx context.Context, r *entity.EntitySearchRequ
 		fields:   fields,
 		from:     "entity", // the table
 		args:     []interface{}{},
-		limit:    int(r.Limit),
+		limit:    r.Limit,
 		oneExtra: true, // request one more than the limit (and show next token if it exists)
 	}
 	entityQuery.addWhere("tenant_id", user.OrgID)
@@ -779,11 +779,6 @@ func (s *sqlEntityServer) Search(ctx context.Context, r *entity.EntitySearchRequ
 	}
 
 	query, args := entityQuery.toQuery()
-
-	fmt.Printf("\n\n-------------\n")
-	fmt.Printf("%s\n", query)
-	fmt.Printf("%v\n", args)
-	fmt.Printf("\n-------------\n\n")
 
 	rows, err := s.sess.Query(ctx, query, args...)
 	if err != nil {
@@ -820,7 +815,7 @@ func (s *sqlEntityServer) Search(ctx context.Context, r *entity.EntitySearchRequ
 		}
 
 		// found one more than requested
-		if len(rsp.Results) >= entityQuery.limit {
+		if int64(len(rsp.Results)) >= entityQuery.limit {
 			// TODO? should this encode start+offset?
 			rsp.NextPageToken = oid
 			break


### PR DESCRIPTION
This fixes a few minor issues from a CodeQL scan 