### PR TITLE
Add to Docs squad project when PRs are labelled with type/docs

### DIFF
--- a/.github/pr-commands.json
+++ b/.github/pr-commands.json
@@ -190,5 +190,13 @@
     "ignoreList": ["renovate[bot]","dependabot[bot]"],
     "action": "updateLabel",
     "addLabel": "pr/external"
+  },
+  {
+    "type":"label",
+    "name":"type/docs",
+    "action":"addToProject",
+    "addToProject":{
+      "url":"https://github.com/orgs/grafana/projects/69"
+    }
   }
 ]


### PR DESCRIPTION
This adds all docs PRs to the project https://github.com/orgs/grafana/projects/69 used for triage by @Eve832 and @GrafanaWriter.

Closes #64251