### PR TITLE
Codegen: fix jenny_eachmajor.go

### DIFF
--- a/pkg/codegen/jenny_eachmajor.go
+++ b/pkg/codegen/jenny_eachmajor.go
@@ -56,7 +56,13 @@ func (j *lmox) Generate(kind kindsys.Kind) (codejen.Files, error) {
 	}
 
 	var fl codejen.Files
+	major := -1
 	for sch := kind.Lineage().First(); sch != nil; sch = sch.Successor() {
+		if int(sch.Version()[0]) == major {
+			continue
+		}
+		major = int(sch.Version()[0])
+
 		sfg.Schema = sch.LatestInMajor()
 		files, err := do(sfg, fmt.Sprintf("v%v", sch.Version()[0]))
 		if err != nil {


### PR DESCRIPTION
Fix `jenny_eachmajor` to not generate the same major multiple times if there are multiple schemas in the same major. 