### PR TITLE
Cloudwatch: Add expression field to interpolate variables in Metrics Code Builder

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/datasource.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.test.ts
@@ -338,9 +338,9 @@ describe('datasource', () => {
 
       datasource.interpolateVariablesInQueries([metricsQuery], {});
 
-      // We interpolate `expression`, `region`, `period`, `alias`, `metricName`, and `nameSpace` in CloudWatchMetricsQuery
+      // We interpolate `expression`, `sqlExpression`, `region`, `period`, `alias`, `metricName`, `dimensions`, and `nameSpace` in CloudWatchMetricsQuery
       expect(templateService.replace).toHaveBeenCalledWith(`$${variableName}`, {});
-      expect(templateService.replace).toHaveBeenCalledTimes(7);
+      expect(templateService.replace).toHaveBeenCalledTimes(8);
 
       expect(templateService.getVariableName).toHaveBeenCalledWith(`$${variableName}`);
       expect(templateService.getVariableName).toHaveBeenCalledTimes(1);

--- a/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchMetricsQueryRunner.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchMetricsQueryRunner.test.ts
@@ -694,31 +694,7 @@ describe('CloudWatchMetricsQueryRunner', () => {
       );
     });
   });
-
   describe('interpolateMetricsQueryVariables', () => {
-    it('interpolates dimensions correctly', () => {
-      const testQuery = {
-        id: 'a',
-        refId: 'a',
-        region: 'us-east-2',
-        namespace: '',
-        dimensions: { InstanceId: '$dimension' },
-        expression: '',
-      };
-      const { runner } = setupMockedMetricsQueryRunner({ variables: [dimensionVariable], mockGetVariableName: false });
-      const result = runner.interpolateMetricsQueryVariables(testQuery, {
-        dimension: { text: 'foo', value: 'foo' },
-      });
-      expect(result).toStrictEqual({
-        alias: '',
-        metricName: '',
-        namespace: '',
-        period: '',
-        sqlExpression: '',
-        dimensions: { InstanceId: ['foo'] },
-        expression: '',
-      });
-    });
     it('interpolates values correctly', () => {
       const testQuery = {
         id: 'a',

--- a/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchMetricsQueryRunner.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchMetricsQueryRunner.test.ts
@@ -703,6 +703,7 @@ describe('CloudWatchMetricsQueryRunner', () => {
         region: 'us-east-2',
         namespace: '',
         dimensions: { InstanceId: '$dimension' },
+        expression: '',
       };
       const { runner } = setupMockedMetricsQueryRunner({ variables: [dimensionVariable], mockGetVariableName: false });
       const result = runner.interpolateMetricsQueryVariables(testQuery, {
@@ -714,6 +715,32 @@ describe('CloudWatchMetricsQueryRunner', () => {
         namespace: '',
         period: '',
         sqlExpression: '',
+        dimensions: { InstanceId: ['foo'] },
+        expression: '',
+      });
+    });
+    it('interpolates values correctly', () => {
+      const testQuery = {
+        id: 'a',
+        refId: 'a',
+        region: 'us-east-2',
+        namespace: '',
+        expression: 'ABS($datasource)',
+        sqlExpression: 'select SUM(CPUUtilization) from $datasource',
+        dimensions: { InstanceId: '$dimension' },
+      };
+      const { runner } = setupMockedMetricsQueryRunner({ variables: [dimensionVariable], mockGetVariableName: false });
+      const result = runner.interpolateMetricsQueryVariables(testQuery, {
+        datasource: { text: 'foo', value: 'foo' },
+        dimension: { text: 'foo', value: 'foo' },
+      });
+      expect(result).toStrictEqual({
+        alias: '',
+        metricName: '',
+        namespace: '',
+        period: '',
+        sqlExpression: 'select SUM(CPUUtilization) from foo',
+        expression: 'ABS(foo)',
         dimensions: { InstanceId: ['foo'] },
       });
     });

--- a/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchMetricsQueryRunner.ts
+++ b/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchMetricsQueryRunner.ts
@@ -109,7 +109,7 @@ export class CloudWatchMetricsQueryRunner extends CloudWatchRequest {
       namespace: this.replaceVariableAndDisplayWarningIfMulti(query.namespace, scopedVars),
       period: this.replaceVariableAndDisplayWarningIfMulti(query.period, scopedVars),
       expression: this.templateSrv.replace(query.expression, scopedVars),
-      sqlExpression: this.templateSrv.replace(query.sqlExpression, scopedVars, 'raw'),
+      sqlExpression: this.replaceVariableAndDisplayWarningIfMulti(query.sqlExpression, scopedVars),
       dimensions: this.convertDimensionFormat(query.dimensions ?? {}, scopedVars),
     };
   }

--- a/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchMetricsQueryRunner.ts
+++ b/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchMetricsQueryRunner.ts
@@ -99,13 +99,17 @@ export class CloudWatchMetricsQueryRunner extends CloudWatchRequest {
   interpolateMetricsQueryVariables(
     query: CloudWatchMetricsQuery,
     scopedVars: ScopedVars
-  ): Pick<CloudWatchMetricsQuery, 'alias' | 'metricName' | 'namespace' | 'period' | 'dimensions' | 'sqlExpression'> {
+  ): Pick<
+    CloudWatchMetricsQuery,
+    'alias' | 'metricName' | 'namespace' | 'period' | 'dimensions' | 'sqlExpression' | 'expression'
+  > {
     return {
       alias: this.replaceVariableAndDisplayWarningIfMulti(query.alias, scopedVars),
       metricName: this.replaceVariableAndDisplayWarningIfMulti(query.metricName, scopedVars),
       namespace: this.replaceVariableAndDisplayWarningIfMulti(query.namespace, scopedVars),
       period: this.replaceVariableAndDisplayWarningIfMulti(query.period, scopedVars),
-      sqlExpression: this.replaceVariableAndDisplayWarningIfMulti(query.sqlExpression, scopedVars),
+      expression: this.templateSrv.replace(query.expression, scopedVars),
+      sqlExpression: this.templateSrv.replace(query.sqlExpression, scopedVars, 'raw'),
       dimensions: this.convertDimensionFormat(query.dimensions ?? {}, scopedVars),
     };
   }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**


Adds the expression field in the interpolateVariable that is being called from [ExpressionDatasource.ts](https://github.com/grafana/grafana/blob/91221bc4362e50b9cca6dbff3a8342b2991900d2/public/app/features/expressions/ExpressionDatasource.ts#L46) and makes the function more similar to [replaceMetricQueryVars](https://github.com/grafana/grafana/blob/da4c12b0d6021f3669dd482f9be0ef0584241918/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchMetricsQueryRunner.ts#L181)

These two should probably be combined in a [refactor](https://github.com/grafana/oss-plugin-partnerships/issues/149), but there are mismatching fields and it would require some testing to figure out the source of truth. 

**Why do we need this feature?**
[Original issue](https://github.com/grafana/grafana/issues/64176) reported in support escalations

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #64176
