### PR TITLE
Stat Panel: Fix issue with clipping text values

### DIFF
--- a/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
+++ b/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
@@ -12,6 +12,7 @@ import { BigValueColorMode, Props, BigValueJustifyMode, BigValueTextMode } from 
 
 const LINE_HEIGHT = 1.2;
 const MAX_TITLE_SIZE = 30;
+const VALUE_FONT_WEIGHT = 500;
 
 export abstract class BigValueLayout {
   titleFontSize: number;
@@ -76,7 +77,7 @@ export abstract class BigValueLayout {
   getValueStyles(): CSSProperties {
     const styles: CSSProperties = {
       fontSize: this.valueFontSize,
-      fontWeight: 500,
+      fontWeight: VALUE_FONT_WEIGHT,
       lineHeight: LINE_HEIGHT,
       position: 'relative',
       zIndex: 1,
@@ -220,7 +221,9 @@ export class WideNoChartLayout extends BigValueLayout {
         this.valueToAlignTo,
         this.maxTextWidth * valueWidthPercent,
         this.maxTextHeight,
-        LINE_HEIGHT
+        LINE_HEIGHT,
+        undefined,
+        VALUE_FONT_WEIGHT
       );
     }
 
@@ -292,7 +295,9 @@ export class WideWithChartLayout extends BigValueLayout {
         this.valueToAlignTo,
         this.maxTextWidth * valueWidthPercent,
         this.maxTextHeight * chartHeightPercent,
-        LINE_HEIGHT
+        LINE_HEIGHT,
+        undefined,
+        VALUE_FONT_WEIGHT
       );
     }
   }
@@ -346,7 +351,9 @@ export class StackedWithChartLayout extends BigValueLayout {
         this.valueToAlignTo,
         this.maxTextWidth,
         this.maxTextHeight - this.chartHeight - titleHeight,
-        LINE_HEIGHT
+        LINE_HEIGHT,
+        undefined,
+        VALUE_FONT_WEIGHT
       );
     }
 
@@ -398,7 +405,9 @@ export class StackedWithNoChartLayout extends BigValueLayout {
         this.valueToAlignTo,
         this.maxTextWidth,
         this.maxTextHeight - titleHeight,
-        LINE_HEIGHT
+        LINE_HEIGHT,
+        undefined,
+        VALUE_FONT_WEIGHT
       );
     }
 

--- a/packages/grafana-ui/src/utils/measureText.ts
+++ b/packages/grafana-ui/src/utils/measureText.ts
@@ -16,7 +16,7 @@ export function getCanvasContext() {
 /**
  * @beta
  */
-export function measureText(text: string, fontSize: number): TextMetrics {
+export function measureText(text: string, fontSize: number, fontWeight: number): TextMetrics {
   const fontStyle = `${fontSize}px 'Inter'`;
   const cacheKey = text + fontStyle;
   const fromCache = cache.get(cacheKey);

--- a/packages/grafana-ui/src/utils/measureText.ts
+++ b/packages/grafana-ui/src/utils/measureText.ts
@@ -45,7 +45,14 @@ export function measureText(text: string, fontSize: number, fontWeight = 400): T
 /**
  * @beta
  */
-export function calculateFontSize(text: string, width: number, height: number, lineHeight: number, maxSize?: number, fontWeight?: number) {
+export function calculateFontSize(
+  text: string,
+  width: number,
+  height: number,
+  lineHeight: number,
+  maxSize?: number,
+  fontWeight?: number
+) {
   // calculate width in 14px
   const textSize = measureText(text, 14, fontWeight);
   // how much bigger than 14px can we make it while staying within our width constraints

--- a/packages/grafana-ui/src/utils/measureText.ts
+++ b/packages/grafana-ui/src/utils/measureText.ts
@@ -16,8 +16,8 @@ export function getCanvasContext() {
 /**
  * @beta
  */
-export function measureText(text: string, fontSize: number, fontWeight: number): TextMetrics {
-  const fontStyle = `${fontSize}px 'Inter'`;
+export function measureText(text: string, fontSize: number, fontWeight = 400): TextMetrics {
+  const fontStyle = `${fontWeight} ${fontSize}px 'Inter'`;
   const cacheKey = text + fontStyle;
   const fromCache = cache.get(cacheKey);
 
@@ -45,9 +45,9 @@ export function measureText(text: string, fontSize: number, fontWeight: number):
 /**
  * @beta
  */
-export function calculateFontSize(text: string, width: number, height: number, lineHeight: number, maxSize?: number) {
+export function calculateFontSize(text: string, width: number, height: number, lineHeight: number, maxSize?: number, fontWeight?: number) {
   // calculate width in 14px
-  const textSize = measureText(text, 14);
+  const textSize = measureText(text, 14, fontWeight);
   // how much bigger than 14px can we make it while staying within our width constraints
   const fontSizeBasedOnWidth = (width / (textSize.width + 2)) * 14;
   const fontSizeBasedOnHeight = height / lineHeight;


### PR DESCRIPTION
**What is this feature?**

Currently the Stat Panel does not always calculate the right font size for a value, it can sometimes clip the text:
<img width="867" alt="Screenshot 2023-03-07 at 11 35 41" src="https://user-images.githubusercontent.com/100691367/223411562-c5321c58-a9dc-4c10-a919-2bcc9d18c099.png">

This is because the calculation for the font size was not taking into consideration that the font weight for that text was different (500 in this case), so we added an extra optional argument to the `measureText` function to pass in a different `fontWeight`, which solves the issue:
<img width="874" alt="Screenshot 2023-03-07 at 11 36 52" src="https://user-images.githubusercontent.com/100691367/223411911-283b3251-00e5-4a84-ad8f-ca53ad7e8167.png">

**Why do we need this feature?**

So text values in Stat Panel are always visible.

**Who is this feature for?**

Anyone using Stat Panel

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #59766

**Special notes for your reviewer**:

We also checked other places that used `measureText` and `calculateFontSize` but those all had 400 as a font-weight.

