### PR TITLE
Alerting: Fix intermittency when seeding database in rule store tests

### DIFF
--- a/pkg/services/ngalert/store/alert_rule_test.go
+++ b/pkg/services/ngalert/store/alert_rule_test.go
@@ -176,7 +176,7 @@ func TestIntegration_CountAlertRules(t *testing.T) {
 }
 
 func createRule(t *testing.T, store *DBstore) *models.AlertRule {
-	rule := models.AlertRuleGen(withIntervalMatching(store.Cfg.BaseInterval))()
+	rule := models.AlertRuleGen(withIntervalMatching(store.Cfg.BaseInterval), models.WithUniqueID())()
 	err := store.SQLStore.WithDbSession(context.Background(), func(sess *db.Session) error {
 		_, err := sess.Table(models.AlertRule{}).InsertOne(rule)
 		if err != nil {


### PR DESCRIPTION
**What is this feature?**

Sometimes the IDs collide because they are randomly chosen. This causes the test to intermittently fail.

Force this to not happen.

**Which issue(s) does this PR fix?**:

n/a

**Special notes for your reviewer**:

