### PR TITLE
Log Details: Display all field options and remove "show more"

### DIFF
--- a/public/app/features/logs/components/LogDetailsRow.tsx
+++ b/public/app/features/logs/components/LogDetailsRow.tsx
@@ -5,7 +5,7 @@ import React, { PureComponent } from 'react';
 
 import { CoreApp, Field, GrafanaTheme2, LinkModel, LogLabelStatsModel, LogRowModel } from '@grafana/data';
 import { reportInteraction } from '@grafana/runtime';
-import { ClipboardButton, DataLinkButton, Themeable2, ToolbarButton, ToolbarButtonRow, withTheme2 } from '@grafana/ui';
+import { ClipboardButton, DataLinkButton, IconButton, Themeable2, withTheme2 } from '@grafana/ui';
 
 import { LogLabelStats } from './LogLabelStats';
 import { getLogRowStyles } from './getLogRowStyles';
@@ -36,22 +36,9 @@ interface State {
 
 const getStyles = memoizeOne((theme: GrafanaTheme2) => {
   return {
-    noHoverBackground: css`
-      label: noHoverBackground;
-      :hover {
-        background-color: transparent;
-      }
-    `,
-    hoverCursor: css`
-      label: hoverCursor;
-      cursor: pointer;
-    `,
     wordBreakAll: css`
       label: wordBreakAll;
       word-break: break-all;
-    `,
-    showingField: css`
-      color: ${theme.colors.primary.text};
     `,
     copyButton: css`
       & > button {
@@ -77,37 +64,6 @@ const getStyles = memoizeOne((theme: GrafanaTheme2) => {
       label: wrapLine;
       white-space: pre-wrap;
     `,
-    toolbarButtonRow: css`
-      label: toolbarButtonRow;
-      gap: ${theme.spacing(0.5)};
-
-      & > div {
-        height: ${theme.spacing(theme.components.height.sm)};
-        width: ${theme.spacing(theme.components.height.sm)};
-        & > button {
-          border: 0;
-          background-color: transparent;
-          height: inherit;
-
-          &:hover {
-            box-shadow: none;
-            border-radius: 50%;
-          }
-        }
-      }
-    `,
-    toolbarButtonRowActive: css`
-      & div:last-child > button:not(.stats-button) {
-        color: ${theme.v1.palette.orangeDark};
-        border-color: ${theme.v1.palette.orangeDark};
-        background-color: transparent;
-
-        &:hover {
-          color: ${theme.colors.text.primary};
-          background: ${theme.colors.emphasize(theme.colors.background.canvas, 0.03)};
-        }
-      }
-    `,
     logDetailsStats: css`
       padding: 0 ${theme.spacing(1)};
     `,
@@ -125,6 +81,12 @@ const getStyles = memoizeOne((theme: GrafanaTheme2) => {
           visibility: visible;
         }
       }
+    `,
+    buttonRow: css`
+      display: flex;
+      flex-direction: row;
+      gap: ${theme.spacing(0.5)};
+      margin-left: ${theme.spacing(0.5)};
     `,
   };
 });
@@ -241,61 +203,37 @@ class UnThemedLogDetailsRow extends PureComponent<Props, State> {
       onClickFilterOutLabel,
     } = this.props;
     const { showFieldsStats, fieldStats, fieldCount } = this.state;
-    const activeButton = displayedFields?.includes(parsedKey) || showFieldsStats;
     const styles = getStyles(theme);
     const style = getLogRowStyles(theme);
     const hasFilteringFunctionality = onClickFilterLabel && onClickFilterOutLabel;
 
     const toggleFieldButton =
       displayedFields && displayedFields.includes(parsedKey) ? (
-        <ToolbarButton variant="active" tooltip="Hide this field" iconOnly narrow icon="eye" onClick={this.hideField} />
+        <IconButton variant="primary" tooltip="Hide this field" name="eye" onClick={this.hideField} />
       ) : (
-        <ToolbarButton
-          tooltip="Show this field instead of the message"
-          iconOnly
-          narrow
-          icon="eye"
-          onClick={this.showField}
-        />
+        <IconButton tooltip="Show this field instead of the message" name="eye" onClick={this.showField} />
       );
 
     return (
       <>
         <tr className={cx(style.logDetailsValue)}>
           <td className={style.logsDetailsIcon}>
-            <ToolbarButtonRow
-              alignment="left"
-              className={cx(styles.toolbarButtonRow, activeButton && styles.toolbarButtonRowActive)}
-            >
+            <div className={styles.buttonRow}>
               {hasFilteringFunctionality && (
-                <ToolbarButton
-                  iconOnly
-                  narrow
-                  icon="search-plus"
-                  tooltip="Filter for value"
-                  onClick={this.filterLabel}
-                />
+                <IconButton name="search-plus" tooltip="Filter for value" onClick={this.filterLabel} />
               )}
               {hasFilteringFunctionality && (
-                <ToolbarButton
-                  iconOnly
-                  narrow
-                  icon="search-minus"
-                  tooltip="Filter out value"
-                  onClick={this.filterOutLabel}
-                />
+                <IconButton name="search-minus" tooltip="Filter out value" onClick={this.filterOutLabel} />
               )}
               {displayedFields && toggleFieldButton}
-              <ToolbarButton
-                iconOnly
-                variant={showFieldsStats ? 'active' : 'default'}
-                narrow
-                icon="signal"
+              <IconButton
+                variant={showFieldsStats ? 'primary' : 'secondary'}
+                name="signal"
                 tooltip="Ad-hoc statistics"
                 className="stats-button"
                 onClick={this.showStats}
               />
-            </ToolbarButtonRow>
+            </div>
           </td>
 
           {/* Key - value columns */}
@@ -327,16 +265,12 @@ class UnThemedLogDetailsRow extends PureComponent<Props, State> {
         {showFieldsStats && (
           <tr>
             <td>
-              <ToolbarButtonRow alignment="left" className={styles.toolbarButtonRow}>
-                <ToolbarButton
-                  iconOnly
-                  variant={showFieldsStats ? 'active' : 'default'}
-                  narrow
-                  icon="signal"
-                  tooltip="Hide ad-hoc statistics"
-                  onClick={this.showStats}
-                />
-              </ToolbarButtonRow>
+              <IconButton
+                variant={showFieldsStats ? 'primary' : 'secondary'}
+                name="signal"
+                tooltip="Hide ad-hoc statistics"
+                onClick={this.showStats}
+              />
             </td>
             <td colSpan={2}>
               <div className={styles.logDetailsStats}>

--- a/public/app/features/logs/components/LogDetailsRow.tsx
+++ b/public/app/features/logs/components/LogDetailsRow.tsx
@@ -81,7 +81,6 @@ const getStyles = memoizeOne((theme: GrafanaTheme2) => {
       label: toolbarButtonRow;
       gap: ${theme.spacing(0.5)};
 
-      max-width: calc(3 * ${theme.spacing(theme.components.height.sm)});
       & > div {
         height: ${theme.spacing(theme.components.height.sm)};
         width: ${theme.spacing(theme.components.height.sm)};


### PR DESCRIPTION
During a user interview, we realized that the "eye" icon for the feature "Show this field instead of the message" was not known by the user, which brought back something I recently thought while working with those components: why are we collapsing 2 options behind a "show more" toggle when there is space for all the options? This not only hides the fature, but makes interacting with it a lot more complicated than it should be.

Current implementation:

![current](https://user-images.githubusercontent.com/1069378/223475215-edac87bc-a40b-4d44-8369-6f697f20bfd9.gif)

After these changes:

![after](https://user-images.githubusercontent.com/1069378/223471859-5aa5a275-ffd0-4577-8f3a-bab28c85ece1.gif)

**Why do we need this feature?**

To improve visibility of this option and improve the experience of interacting with it with a really simple change.

**Which issue(s) does this PR fix?**:

Can be part of https://github.com/grafana/grafana/issues/61769

**Special notes for your reviewer**:

What do you think? It's a simple change which seems very beneficial for users.