### PR TITLE
Laura/standardise border radius in explore

### DIFF
--- a/public/app/features/explore/Graph/ExploreGraph.tsx
+++ b/public/app/features/explore/Graph/ExploreGraph.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from '@emotion/css';
+import { css } from '@emotion/css';
 import { identity } from 'lodash';
 import React, { useEffect, useMemo, useState } from 'react';
 
@@ -159,7 +159,7 @@ export function ExploreGraph({
   return (
     <PanelContextProvider value={panelContext}>
       {data.length > MAX_NUMBER_OF_TIME_SERIES && !showAllTimeSeries && (
-        <div className={cx([style.timeSeriesDisclaimer])}>
+        <div className={style.timeSeriesDisclaimer}>
           <Icon className={style.disclaimerIcon} name="exclamation-triangle" />
           Showing only {MAX_NUMBER_OF_TIME_SERIES} time series.
           <Button
@@ -191,9 +191,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     label: time-series-disclaimer;
     margin: ${theme.spacing(1)} auto;
     padding: 10px 0;
-    border-radius: ${theme.spacing(2)};
     text-align: center;
-    background-color: ${theme.colors.background.primary};
   `,
   disclaimerIcon: css`
     label: disclaimer-icon;

--- a/public/app/features/explore/NoData.tsx
+++ b/public/app/features/explore/NoData.tsx
@@ -20,7 +20,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     label: no-data-card;
     padding: ${theme.spacing(3)};
     background: ${theme.colors.background.primary};
-    border-radius: ${theme.shape.borderRadius(2)};
+    border-radius: ${theme.shape.borderRadius()};
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/public/app/features/explore/TraceView/TraceViewContainer.tsx
+++ b/public/app/features/explore/TraceView/TraceViewContainer.tsx
@@ -28,7 +28,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     background-color: ${theme.colors.background.primary};
     border: 1px solid ${theme.colors.border.medium};
     position: relative;
-    border-radius: 3px;
+    border-radius: ${theme.shape.borderRadius()};
     width: 100%;
     display: flex;
     flex-direction: column;

--- a/public/app/features/explore/TraceView/components/TracePageHeader/TracePageSearchBar.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/TracePageSearchBar.tsx
@@ -38,7 +38,7 @@ export const getStyles = (theme: GrafanaTheme2) => {
       margin-bottom: -48px;
       padding: 8px;
       margin-right: 2px;
-      border-radius: 2px;
+      border-radius: ${theme.shape.borderRadius()};
       box-shadow: ${theme.shadows.z2};
     `,
     TracePageSearchBarBar: css`

--- a/public/app/features/explore/TraceView/components/TracePageHeader/TracePageSearchBar.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/TracePageSearchBar.tsx
@@ -38,7 +38,7 @@ export const getStyles = (theme: GrafanaTheme2) => {
       margin-bottom: -48px;
       padding: 8px;
       margin-right: 2px;
-      border-radius: 4px;
+      border-radius: 2px;
       box-shadow: ${theme.shadows.z2};
     `,
     TracePageSearchBarBar: css`


### PR DESCRIPTION
Fixes #64290 

- **public/app/features/explore/ExploreDrawer.tsx** 
=> unchanged, creates shape
- **public/app/features/explore/Graph/ExploreGraph.tsx** 
=> removed border-radius, not visible due to same background colour than the panel
Before removal:
<img width="1116" alt="Screenshot 2023-03-07 at 11 52 16" src="https://user-images.githubusercontent.com/48948963/223403072-378e57ba-d2d2-4fc3-b1c8-b97ad9b6a111.png">

- **public/app/features/explore/NoData.tsx**
=> removed, see before and after:
<img width="271" alt="Screenshot 2023-03-07 at 12 10 15" src="https://user-images.githubusercontent.com/48948963/223406053-fc710996-e43d-4420-9873-5e72d76a751f.png">

- **public/app/features/explore/TraceView/components/TracePageHeader/TracePageSearchBar.tsx**
=> replaced by standard, see before and after:
<img width="806" alt="Screenshot 2023-03-07 at 15 24 09" src="https://user-images.githubusercontent.com/48948963/223450636-17ca2919-c992-4b76-a7d4-d435fcb60bc2.png">

- **public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanBar.tsx**
=> unchanged, creates shape
- **public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanBarRow.tsx**
=> unchanged, creates shape
- **public/app/features/explore/TraceView/TraceViewContainer.tsx**
=> replaced by standard, see before and after:
<img width="1070" alt="Screenshot 2023-03-07 at 16 33 04" src="https://user-images.githubusercontent.com/48948963/223469920-ef05d05b-b628-47e4-83cf-4e8320beb974.png">

