### PR TITLE
Frontend: Fix broken links in /plugins when pathname has a trailing slash

### DIFF
--- a/public/app/features/plugins/admin/components/PluginList.tsx
+++ b/public/app/features/plugins/admin/components/PluginList.tsx
@@ -18,8 +18,8 @@ interface Props {
 export const PluginList = ({ plugins, displayMode }: Props) => {
   const isList = displayMode === PluginListDisplayMode.List;
   const styles = useStyles2(getStyles);
-  const location = useLocation();
-  const pathName = config.appSubUrl + location.pathname;
+  const { pathname } = useLocation();
+  const pathName = config.appSubUrl + (pathname.endsWith('/') ? pathname.slice(0, -1) : pathname);
 
   return (
     <div className={cx(styles.container, { [styles.list]: isList })} data-testid="plugin-list">


### PR DESCRIPTION
This PR fixes a bug that makes all plugin links in the plugins page 404.

When on `/plugins/` route (with the trailing slash), the links get broken:

![image](https://user-images.githubusercontent.com/35489495/223508326-66a2ea44-5b8b-468b-ace1-0309edb1135f.png)

Which makes every plugin link 404:

![image](https://user-images.githubusercontent.com/35489495/223508420-f6cf31ef-0dc7-4f3d-aee9-8d0c59913ec1.png)