### PR TITLE
Docs: adds intro to prometheus

### DIFF
--- a/docs/sources/fundamentals/exemplars/index.md
+++ b/docs/sources/fundamentals/exemplars/index.md
@@ -9,7 +9,7 @@ keywords:
   - exemplars
   - prometheus
 title: Exemplars
-weight: 400
+weight: 750
 ---
 
 # Introduction to exemplars

--- a/docs/sources/fundamentals/intro-to-prometheus/index.md
+++ b/docs/sources/fundamentals/intro-to-prometheus/index.md
@@ -81,7 +81,7 @@ For example, a NodeJS application can configure the [prom-client](https://github
 
 The first section of this document introduced the Prometheus as Data concept and how the Prometheus data model and metrics are organized. The second section introduced the concept of Prometheus as Software that is used to collect, process, and store metrics.
 
-This section describes how “Prometheus as Data" and “Prometheus as Software” come together. To explain this further, let's use an example. Suppose a 'MyApp' application uses a Prometheus client to expose metrics. One approach to collecting metrics data is to use a URL in the application that points to an endpoint `http://localhost:3000/metrics` that produces Prometheus metrics data.
+This section describes how Prometheus as Data and Prometheus as Software come together. To explain this further, let's use an example. Suppose a 'MyApp' application uses a Prometheus client to expose metrics. One approach to collecting metrics data is to use a URL in the application that points to an endpoint `http://localhost:3000/metrics` that produces Prometheus metrics data.
 
 The following image shows the two metrics associated with the endpoint. The HELP text explains what the metric means, and the TYPE text indicates what kind of metric it is (in this case, a gauge). `MyAppnodejs_active_request_total` indicates the number of requests (in this case, `1`). `MyAppnodejs_heap_size_total_bytes` indicates the heap size reported in bytes. There are only two numbers because this data shows the value at the moment the data was fetched.
 

--- a/docs/sources/fundamentals/intro-to-prometheus/index.md
+++ b/docs/sources/fundamentals/intro-to-prometheus/index.md
@@ -16,7 +16,7 @@ weight: 300
 
 Observability focuses on understanding the internal state of your systems based on the data they produce, which helps determine if your infrastructure is healthy. Prometheus is a core technology for system observability, but the term "Prometheus" can be confusing because it is used in different contexts. Understanding Prometheus basics, why it’s valuable for system observability, and how people use it in practice will both help you better understand it and help you use Grafana.
 
-Prometheus was started in 2012 at SoundCloud, who found existing technologies such as Graphite insufficient for their observability needs. Prometheus has a robust data model and query language, both of which are addressed in the following sections, and is simple and scalable. In 2018, Prometheus graduated from Cloud Native Computing Foundation (CNCF) incubation, and today has a thriving community.
+Prometheus began in 2012 at SoundCloud because existing technologies were insufficient for their observability needs. Prometheus offers both a robust data model and a query language, which are discussed on this page. Prometheus is also simple and scalable. In 2018, Prometheus graduated from Cloud Native Computing Foundation (CNCF) incubation, and today has a thriving community.
 
 ## Prometheus as data
 
@@ -24,40 +24,40 @@ The following panel in a Grafana dashboard shows how much disk bandwidth on a Ma
 
 {{< figure src="/media/docs/grafana/intro-prometheus/disk-io.png" max-width="750px" caption="Disk I/O dashboard" >}}
 
-Data like these form _time series_. The X-axis is a moment in time, and the Y-axis is a number or measurement, for example, 5 megabytes per second. This kind of time series data appears everywhere in systems monitoring, but also in places like seasonal temperature charts and stock prices. This data is simply some measurement (such as the Tesla stock price, or Disk I/O) through a series of time instants.
+Data like these form _time series_. The X-axis is a moment in time and the Y-axis is a number or measurement; for example, 5 megabytes per second. This type of time series data appears everywhere in systems monitoring, as well as in places such as seasonal temperature charts and stock prices. This data is simply some measurement (such as a company stock price or Disk I/O) through a series of time instants.
 
-Prometheus is a technology used to collect and store time series data. Time series are fundamental to Prometheus; its [data model](https://prometheus.io/docs/concepts/data_model/) is arranged into:
+Prometheus is a technology that collects and stores time series data. Time series are fundamental to Prometheus; its [data model](https://prometheus.io/docs/concepts/data_model/) is arranged into:
 
 - _metrics_ that consist of a _timestamp_ and a _sample_, which is the numeric value, such as how many disk bytes have been read or a stock price
 - a set of labels called _dimensions_
 
 You can store time series data in any relational database, but these kinds of systems are not developed to store and query large volumes of time series data. Prometheus and similar software provide tools to compact and optimize time series data.
 
-### Example
+### Simple dashboard using PromQL
 
-The following Grafana dashboard image shows a disk IO graph of raw data from Prometheus that is derived from a laptop.
+The following Grafana dashboard image shows a Disk I/O graph of raw data from Prometheus derived from a laptop.
 
 The **Metrics browser** field contains the following query:
 
-`node_disk_written_bytes_total{job=”integrations/macos-node”, device!=””}`
+`node_disk_written_bytes_total{job="integrations/macos-node", device!=""}`
 
 In this example, the Y-axis shows the total number of bytes written, and the X-axis shows dates and times. As the laptop runs, the number of bytes written increases over time. Below **Metrics browser** is a counter that counts the number of bytes written over time.
 
 {{< figure src="/media/docs/grafana/intro-prometheus/dashboard-example.png" max-width="750px" caption="Metrics browser and counter" >}}
 
-The query is a simple example of [PromQL](/blog/2020/02/04/introduction-to-promql-the-prometheus-query-language/), the Prometheus Query Language. It identifies the metric of interest (`node_disk_written_bytes_total`) and provides two labels (`job` and `device`). The label selector `job=”integrations/macos-node”` is used to filter metrics. It reduces the scope of the metrics to those coming from the MacOS integration job, and specifies that the “device” label cannot be empty. The result of this query is the raw stream of numbers that the graph shows.
+The query is a simple example of [PromQL](/blog/2020/02/04/introduction-to-promql-the-prometheus-query-language/), the Prometheus Query Language. The query identifies the metric of interest (`node_disk_written_bytes_total`) and provides two labels (`job` and `device`). The label selector `job="integrations/macos-node"` filters metrics. It both reduces the scope of the metrics to those coming from the MacOS integration job and specifies that the “device” label cannot be empty. The result of this query is the raw stream of numbers that the graph displays.
 
-Although this view provides some insight into the performance of the system, it doesn’t provide the full story. For a clearer picture of system performance, it is also important to understand the rate of change that shows _how fast the data being written is changing_. To properly monitor disk performance, it is important to see spikes in activity to understand if and when the system is under load, and whether or not disk performance is at risk. PromQL includes a [rate()](https://prometheus.io/docs/prometheus/latest/querying/functions/#rate) function that shows the per-second average rate of increase over `5m` (5-minute) intervals. This view provides a much better idea of what’s happening with the system.
+Although this view provides some insight into the performance of the system, it doesn’t provide the full story. A clearer picture of system performance requires understanding the rate of change that displays _how fast the data being written is changing_. To properly monitor disk performance, you need to also see spikes in activity that illustrate if and when the system is under load, and whether disk performance is at risk. PromQL includes a [rate()](https://prometheus.io/docs/prometheus/latest/querying/functions/#rate) function that shows the per-second average rate of increase over `5m` (5-minute) intervals. This view provides a much clearer picture of what’s happening with the system.
 
 {{< figure src="/media/docs/grafana/intro-prometheus/rate-function.png" max-width="750px" caption="Prometheus rate function" >}}
 
-A counter metric is just one type of metric. Prometheus [supports several others](https://prometheus.io/docs/concepts/metric_types/). A counter is a number (such as total bytes written) that only goes up. A second metric type is called a `gauge`, which can go up or down.
+A counter metric is just one type of metric; it is a number (such as total bytes written) that only increases. Prometheus [supports several others](https://prometheus.io/docs/concepts/metric_types/), such as the metric type `gauge`, which can increase or decrease.
 
-The following gauge visualization shows the total RAM usage on a computer.
+The following gauge visualization displays the total RAM usage on a computer.
 
 {{< figure src="/media/docs/grafana/intro-prometheus/gauge-example.png" max-width="750px" caption="Gauge visualization" >}}
 
-The third metric type is called a `histogram`, which counts observations and puts them into configurable groups. The following example shows floating-point numbers grouped into ranges that show how often each occurred.
+The third metric type is called a `histogram`, which counts observations and organizes them into configurable groups. The following example displays floating-point numbers grouped into ranges that display how frequently each occurred.
 
 {{< figure src="/media/docs/grafana/intro-prometheus/histogram-example.png" max-width="750px" caption="Historgram visualization" >}}
 
@@ -65,21 +65,23 @@ These core concepts of time series, metrics, labels, and aggregation functions a
 
 ## Why this is valuable
 
-Software and systems are a difficult business. Sometimes things go wrong. Observability helps you understand a system’s state so that future issues can be proactively addressed. And when problems do occur, you can diagnose and solve them within your Service Level Objectives (SLOs). The [three pillars of observability](https://www.oreilly.com/library/view/distributed-systems-observability/9781492033431/ch04.html) are metrics, logs, and traces and Prometheus supports the metric pillar. When software on a computer runs slowly, observability can help identify whether the CPU is saturated, the system is out of memory, or if the disk is writing at maximum speed.
+Software and systems are a difficult business. Sometimes things go wrong. Observability helps you understand a system’s state so that issues can be quickly identified and proactively addressed. And when problems do occur, you can be alerted to them to diagnose and solve them within your Service Level Objectives (SLOs). 
+
+The [three pillars of observability](https://www.oreilly.com/library/view/distributed-systems-observability/9781492033431/ch04.html) are metrics, logs, and traces. Prometheus supports the metrics pillar. When software on a computer runs slowly, observability can help you identify whether CPU is saturated, the system is out of memory, or if the disk is writing at maximum speed so you can proactively respond.
 
 ## Prometheus as software
 
-Prometheus isn’t just a data format; many people refer to it as an [open source systems monitoring and alerting toolkit](https://prometheus.io/docs/introduction/overview/). That’s because Prometheus is software, not just data.
+Prometheus isn’t just a data format; it is also considered an [open source systems monitoring and alerting toolkit](https://prometheus.io/docs/introduction/overview/). That’s because Prometheus is software, not just data.
 
-Prometheus can scrape metric data from software and infrastructure and store it. Scraping means that Prometheus software periodically revisits the same endpoint to check for new data. Prometheus “scrapes” data from a piece of software that is instrumented with a client library.
+Prometheus can scrape metric data from software and infrastructure and store it. Scraping means that Prometheus software periodically revisits the same endpoint to check for new data. Prometheus “scrapes” data from a piece of software instrumented with a client library.
 
-For example, a NodeJS application can configure the [prom-client](https://github.com/siimon/prom-client) to expose metrics easily at an endpoint, and Prometheus can regularly scrape that endpoint. There are a number of other tools available within the Prometheus toolkit that you can use to instrument applications.
+For example, a NodeJS application can configure the [prom-client](https://github.com/siimon/prom-client) to expose metrics easily at an endpoint, and Prometheus can regularly scrape that endpoint. Prometheus includes a number of other tools within the toolkit to instrument your applications.
 
 ## Prometheus as deployment
 
-The first section of this document introduced the _Prometheus as Data_ concept and how the Prometheus data model and metrics are organized. The second section introduced the concept of _Prometheus as Software_ that is used to collect, process, and store metrics.
+The first section of this document introduced the Prometheus as Data concept and how the Prometheus data model and metrics are organized. The second section introduced the concept of Prometheus as Software that is used to collect, process, and store metrics.
 
-This section describes how “Prometheus as Data" and “Prometheus as Software” come together. Suppose an application called `MyApp` uses a Prometheus client to expose metrics. One approach to collecting metrics data is to use a URL in the application that points to an endpoint `http://localhost:3000/metrics` that produces Prometheus metrics data.
+This section describes how “Prometheus as Data" and “Prometheus as Software” come together. To explain this further, let's use an example. Suppose a 'MyApp' application uses a Prometheus client to expose metrics. One approach to collecting metrics data is to use a URL in the application that points to an endpoint `http://localhost:3000/metrics` that produces Prometheus metrics data.
 
 The following image shows the two metrics associated with the endpoint. The HELP text explains what the metric means, and the TYPE text indicates what kind of metric it is (in this case, a gauge). `MyAppnodejs_active_request_total` indicates the number of requests (in this case, `1`). `MyAppnodejs_heap_size_total_bytes` indicates the heap size reported in bytes. There are only two numbers because this data shows the value at the moment the data was fetched.
 
@@ -91,15 +93,15 @@ That’s where you can use either the Prometheus software, or the [Grafana Agent
 
 Telemetry refers to the process of recording and transmitting the readings of an application or piece of infrastructure. Telemetry is critical to observability because it helps you understand exactly what's going on in your infrastructure. Telemetry data is a source of truth.
 
-Those metrics above, for example, `MyAppnodejs_active_requests_total`, is telemetry data. MyApp only makes it available for pull by means of an HTTP request. You can configure the Grafana Agent to pull that data from MyApp every 5 seconds, and send the results to Grafana Cloud.
+The metrics introduced previously, for example, `MyAppnodejs_active_requests_total`, are telemetry data. MyApp only makes it available for pull by means of an HTTP request. You can configure Grafana Agent to pull that data from MyApp every five seconds and send the results to Grafana Cloud.
 
-The following image illustrates how the Grafana Agent works as an intermediary between MyApp and Grafana Cloud.
+The following image illustrates how Grafana Agent works as an intermediary between MyApp and Grafana Cloud.
 
 {{< figure src="/media/docs/grafana/intro-prometheus/grafana-agent.png" max-width="750px" caption="Grafana Agent" >}}
 
 ## Bringing it together
 
-The combination of Prometheus and the Grafana Agent gives you incredible control over the metrics you want to report, where they come from, and where they’re going. Once the data is in Grafana, it can be stored in a Grafana Mimir database. Grafana dashboards consist of visualizations populated by data queried from the Prometheus data source. The PromQL query filters and aggregates the data to provide you the insight you need. With those steps, we’ve gone from raw numbers, generated by software, into Prometheus, delivered to Grafana, queried by PromQL, and visualized by Grafana.
+The combination of Prometheus and Grafana Agent gives you control over the metrics you want to report, where they come from, and where they’re going. Once the data is in Grafana, it can be stored in a Grafana Mimir database. Grafana dashboards consist of visualizations populated by data queried from the Prometheus data source. The PromQL query filters and aggregates the data to provide you the insight you need. With those steps, we’ve gone from raw numbers, generated by software, into Prometheus, delivered to Grafana, queried by PromQL, and visualized by Grafana.
 
 ## What’s next?
 

--- a/docs/sources/fundamentals/intro-to-prometheus/index.md
+++ b/docs/sources/fundamentals/intro-to-prometheus/index.md
@@ -79,23 +79,21 @@ For example, a NodeJS application can configure the [prom-client](https://github
 
 ## Prometheus as deployment
 
-The first section of this document introduced the Prometheus as Data concept and how the Prometheus data model and metrics are organized. The second section introduced the concept of Prometheus as Software that is used to collect, process, and store metrics.
+The first section of this document introduced the Prometheus as Data concept and how the Prometheus data model and metrics are organized. The second section introduced the concept of Prometheus as Software that is used to collect, process, and store metrics. This section describes how Prometheus as Data and Prometheus as Software come together.
 
-This section describes how Prometheus as Data and Prometheus as Software come together. To explain this further, let's use an example. Suppose a 'MyApp' application uses a Prometheus client to expose metrics. One approach to collecting metrics data is to use a URL in the application that points to an endpoint `http://localhost:3000/metrics` that produces Prometheus metrics data.
+Consider the following example. Suppose a 'MyApp' application uses a Prometheus client to expose metrics. One approach to collecting metrics data is to use a URL in the application that points to an endpoint `http://localhost:3000/metrics` that produces Prometheus metrics data.
 
 The following image shows the two metrics associated with the endpoint. The HELP text explains what the metric means, and the TYPE text indicates what kind of metric it is (in this case, a gauge). `MyAppnodejs_active_request_total` indicates the number of requests (in this case, `1`). `MyAppnodejs_heap_size_total_bytes` indicates the heap size reported in bytes. There are only two numbers because this data shows the value at the moment the data was fetched.
 
 {{< figure src="/media/docs/grafana/intro-prometheus/endpoint-data.png" max-width="750px" caption="Endpoint example" >}}
 
-These metrics are available in an HTTP endpoint, but how do they get to Grafana, and subsequently, into a dashboard?
+The 'MyApp' metrics are available in an HTTP endpoint, but how do they get to Grafana, and subsequently, into a dashboard? The process of recording and transmitting the readings of an application or piece of infrastructure is known as _telemetry_. Telemetry is critical to observability because it helps you understand exactly what's going on in your infrastructure. The metrics introduced previously, for example, `MyAppnodejs_active_requests_total`, are telemetry data.
 
-To get these metrics into Grafana, you can use either the Prometheus software or [Grafana Agent](/docs/agent/latest/) to scrape metrics. Grafana Agent collects and forwards telemetry data to open-source deployments of the Grafana Stack, Grafana Cloud, or Grafana Enterprise, where your data can be analyzed. Using Grafana Agent can be a great option because as you scale your observability practices to include logs and traces, which Grafana Agent also supports, you've got a telemetry solution already in place.
+To get metrics into Grafana, you can use either the Prometheus software or [Grafana Agent](/docs/agent/latest/) to scrape metrics. Grafana Agent collects and forwards the telemetry data to open-source deployments of the Grafana Stack, Grafana Cloud, or Grafana Enterprise, where your data can be analyzed. For example, you can configure Grafana Agent to pull the data from 'MyApp' every five seconds and send the results to Grafana Cloud.
 
-Telemetry refers to the process of recording and transmitting the readings of an application or piece of infrastructure. Telemetry is critical to observability because it helps you understand exactly what's going on in your infrastructure. Telemetry data is a source of truth. The metrics data that Prometheus helps us with is only one type of telemetry; the other two kinds of telemetry are logs and traces.
+Metrics data is only one type of telemetry data; the other kinds are logs and traces. Using Grafana Agent can be a great option to send telemetry data because as you scale your observability practices to include logs and traces, which Grafana Agent also supports, you've got a solution already in place.
 
-The metrics introduced previously, for example, `MyAppnodejs_active_requests_total`, are telemetry data. MyApp only makes it available for pull by means of an HTTP request. You can configure Grafana Agent to pull that data from MyApp every five seconds and send the results to Grafana Cloud.
-
-The following image illustrates how Grafana Agent works as an intermediary between MyApp and Grafana Cloud.
+The following image illustrates how Grafana Agent works as an intermediary between 'MyApp' and Grafana Cloud.
 
 {{< figure src="/media/docs/grafana/intro-prometheus/grafana-agent.png" max-width="750px" caption="Grafana Agent" >}}
 

--- a/docs/sources/fundamentals/intro-to-prometheus/index.md
+++ b/docs/sources/fundamentals/intro-to-prometheus/index.md
@@ -89,7 +89,7 @@ The following image shows the two metrics associated with the endpoint. The HELP
 
 These metrics are available in an HTTP endpoint, but how do they get to Grafana, and subsequently, into a dashboard?
 
-That’s where you can use either the Prometheus software, or the [Grafana Agent](/docs/agent/latest/). The Grafana Agent collects and forwards telemetry data to open sourcevdeployments of the Grafana Stack, Grafana Cloud, or Grafana Enterprise, where your data can then be analyzed.
+To get these metrics into Grafana, you can use either the Prometheus software or [Grafana Agent](/docs/agent/latest/) to scrape metrics. Grafana Agent collects and forwards telemetry data to open-source deployments of the Grafana Stack, Grafana Cloud, or Grafana Enterprise, where your data can be analyzed.
 
 Telemetry refers to the process of recording and transmitting the readings of an application or piece of infrastructure. Telemetry is critical to observability because it helps you understand exactly what's going on in your infrastructure. Telemetry data is a source of truth.
 

--- a/docs/sources/fundamentals/intro-to-prometheus/index.md
+++ b/docs/sources/fundamentals/intro-to-prometheus/index.md
@@ -65,7 +65,7 @@ These core concepts of time series, metrics, labels, and aggregation functions a
 
 ## Why this is valuable
 
-Software and systems are a difficult business. Sometimes things go wrong. Observability helps you understand a system’s state so that issues can be quickly identified and proactively addressed. And when problems do occur, you can be alerted to them to diagnose and solve them within your Service Level Objectives (SLOs). 
+Software and systems are a difficult business. Sometimes things go wrong. Observability helps you understand a system’s state so that issues can be quickly identified and proactively addressed. And when problems do occur, you can be alerted to them to diagnose and solve them within your Service Level Objectives (SLOs).
 
 The [three pillars of observability](https://www.oreilly.com/library/view/distributed-systems-observability/9781492033431/ch04.html) are metrics, logs, and traces. Prometheus supports the metrics pillar. When software on a computer runs slowly, observability can help you identify whether CPU is saturated, the system is out of memory, or if the disk is writing at maximum speed so you can proactively respond.
 
@@ -73,7 +73,7 @@ The [three pillars of observability](https://www.oreilly.com/library/view/distri
 
 Prometheus isn’t just a data format; it is also considered an [open source systems monitoring and alerting toolkit](https://prometheus.io/docs/introduction/overview/). That’s because Prometheus is software, not just data.
 
-Prometheus can scrape metric data from software and infrastructure and store it. Scraping means that Prometheus software periodically revisits the same endpoint to check for new data. Prometheus “scrapes” data from a piece of software instrumented with a client library.
+Prometheus can scrape metric data from software and infrastructure and store it. Scraping means that Prometheus software periodically revisits the same endpoint to check for new data. Prometheus scrapes data from a piece of software instrumented with a client library.
 
 For example, a NodeJS application can configure the [prom-client](https://github.com/siimon/prom-client) to expose metrics easily at an endpoint, and Prometheus can regularly scrape that endpoint. Prometheus includes a number of other tools within the toolkit to instrument your applications.
 
@@ -89,7 +89,7 @@ The following image shows the two metrics associated with the endpoint. The HELP
 
 These metrics are available in an HTTP endpoint, but how do they get to Grafana, and subsequently, into a dashboard?
 
-To get these metrics into Grafana, you can use either the Prometheus software or [Grafana Agent](/docs/agent/latest/) to scrape metrics. Grafana Agent collects and forwards telemetry data to open-source deployments of the Grafana Stack, Grafana Cloud, or Grafana Enterprise, where your data can be analyzed.
+To get these metrics into Grafana, you can use either the Prometheus software or [Grafana Agent](/docs/agent/latest/) to scrape metrics. Grafana Agent collects and forwards telemetry data to open-source deployments of the Grafana Stack, Grafana Cloud, or Grafana Enterprise, where your data can be analyzed. Using Grafana Agent can be a great option because as you scale your observability practices to include logs and traces, which Grafana Agent also supports, you've got a telemetry solution already in place.
 
 Telemetry refers to the process of recording and transmitting the readings of an application or piece of infrastructure. Telemetry is critical to observability because it helps you understand exactly what's going on in your infrastructure. Telemetry data is a source of truth. The metrics data that Prometheus helps us with is only one type of telemetry; the other two kinds of telemetry are logs and traces.
 

--- a/docs/sources/fundamentals/intro-to-prometheus/index.md
+++ b/docs/sources/fundamentals/intro-to-prometheus/index.md
@@ -29,7 +29,7 @@ Data like these form _time series_. The X-axis is a moment in time and the Y-axi
 Prometheus is a technology that collects and stores time series data. Time series are fundamental to Prometheus; its [data model](https://prometheus.io/docs/concepts/data_model/) is arranged into:
 
 - _metrics_ that consist of a _timestamp_ and a _sample_, which is the numeric value, such as how many disk bytes have been read or a stock price
-- a set of labels called _dimensions_
+- a set of labels called _dimensions_, for example, `job` and `device`
 
 You can store time series data in any relational database, but these kinds of systems are not developed to store and query large volumes of time series data. Prometheus and similar software provide tools to compact and optimize time series data.
 
@@ -91,7 +91,7 @@ These metrics are available in an HTTP endpoint, but how do they get to Grafana,
 
 To get these metrics into Grafana, you can use either the Prometheus software or [Grafana Agent](/docs/agent/latest/) to scrape metrics. Grafana Agent collects and forwards telemetry data to open-source deployments of the Grafana Stack, Grafana Cloud, or Grafana Enterprise, where your data can be analyzed.
 
-Telemetry refers to the process of recording and transmitting the readings of an application or piece of infrastructure. Telemetry is critical to observability because it helps you understand exactly what's going on in your infrastructure. Telemetry data is a source of truth.
+Telemetry refers to the process of recording and transmitting the readings of an application or piece of infrastructure. Telemetry is critical to observability because it helps you understand exactly what's going on in your infrastructure. Telemetry data is a source of truth. The metrics data that Prometheus helps us with is only one type of telemetry; the other two kinds of telemetry are logs and traces.
 
 The metrics introduced previously, for example, `MyAppnodejs_active_requests_total`, are telemetry data. MyApp only makes it available for pull by means of an HTTP request. You can configure Grafana Agent to pull that data from MyApp every five seconds and send the results to Grafana Cloud.
 
@@ -105,7 +105,7 @@ The combination of Prometheus and Grafana Agent gives you control over the metri
 
 ## What’s next?
 
-Now that you understand the basics of how Prometheus telemetry works, what will you build with it?
+Now that you understand how Prometheus metrics work, what will you build?
 
 - One great next step is to [build a dashboard]({{< relref "../../dashboards/build-dashboards/" >}}) in Grafana and start turning that raw Prometheus telemetry data into insights about what’s going with your services and infrastructure.
 - Another great step is to learn about [Grafana Mimir](/oss/mimir/), which is essentially a database for Prometheus data. If you’re wondering how to make this work for a huge number of metrics with a lot of data and fast querying, check out Grafana Mimir.

--- a/docs/sources/fundamentals/intro-to-prometheus/index.md
+++ b/docs/sources/fundamentals/intro-to-prometheus/index.md
@@ -14,7 +14,7 @@ weight: 300
 
 # What is Prometheus?
 
-Observability focuses on understanding the internal state of systems based on the data they produce, which helps determine if the infrastructure is operating as expected. Prometheus is a core technology for system observability. However, Prometheus can be a confusing term because it is used in different contexts. Understanding Prometheus basics, why it’s valuable, and how people use it in practice will help you use Grafana.
+Observability focuses on understanding the internal state of your systems based on the data they produce, which helps determine if your infrastructure is healthy. Prometheus is a core technology for system observability, but the term "Prometheus" can be confusing because it is used in different contexts. Understanding Prometheus basics, why it’s valuable for system observability, and how people use it in practice will both help you better understand it and help you use Grafana.```
 
 Prometheus was started in 2012 at SoundCloud, who found existing technologies such as Graphite insufficient for their observability needs. Prometheus has a robust data model and query language, both of which are addressed in the following sections, and is simple and scalable. In 2018, Prometheus graduated from Cloud Native Computing Foundation (CNCF) incubation, and today has a thriving community.
 

--- a/docs/sources/fundamentals/intro-to-prometheus/index.md
+++ b/docs/sources/fundamentals/intro-to-prometheus/index.md
@@ -1,0 +1,110 @@
+---
+aliases:
+  - ../basics/timeseries/
+description: Introduction to Prometheus
+keywords:
+  - grafana
+  - intro
+  - Prometheus
+  - metrics
+  - time series
+title: What is Prometheus?
+weight: 400
+---
+
+# What is Prometheus?
+
+Observability focuses on understanding the internal state of systems based on the data they produce, which helps determine if the infrastructure is operating as expected. Prometheus is a core technology for system observability. However, Prometheus can be a confusing term because it is used in different contexts. Understanding Prometheus basics, why it’s valuable, and how people use it in practice will help you use Grafana.
+
+Prometheus was started in 2012 at SoundCloud, who found existing technologies such as Graphite insufficient for their observability needs. Prometheus has a robust data model and query language, both of which are addressed in the following sections, and is simple and scalable. In 2018, Prometheus graduated from Cloud Native Computing Foundation (CNCF) incubation, and today has a thriving community.
+
+## Prometheus as data
+
+The following panel in a Grafana dashboard shows how much disk bandwidth on a Mac laptop is being used. The green line represents disk `reads`, and the yellow line represents `writes`.
+
+{{< figure src="/media/docs/grafana/intro-prometheus/disk-io.png" max-width="750px" caption="Disk I/O dashboard" >}}
+
+Data like these form _time series_. The X-axis is a moment in time, and the Y-axis is a number or measurement, for example, 5 megabytes per second. This kind of time series data appears everywhere in systems monitoring, but also in places like seasonal temperature charts and stock prices. This data is simply some measurement (such as the Tesla stock price, or Disk I/O) through a series of time instants.
+
+Prometheus is a technology used to collect and store time series data. Time series are fundamental to Prometheus; its [data model](https://prometheus.io/docs/concepts/data_model/) is arranged into:
+
+- _metrics_ that consist of a _timestamp_ and a _sample_, which is the numeric value, such as how many disk bytes have been read or a stock price
+- a set of labels called _dimensions_
+
+You can store time series data in any relational database, but these kinds of systems are not developed to store and query large volumes of time series data. Prometheus and similar software provide tools to compact and optimize time series data.
+
+### Example
+
+The following Grafana dashboard image shows a disk IO graph of raw data from Prometheus that is derived from a laptop.
+
+The **Metrics browser** field contains the following query:
+
+`node_disk_written_bytes_total{job=”integrations/macos-node”, device!=””}`
+
+In this example, the Y-axis shows the total number of bytes written, and the X-axis shows dates and times. As the laptop runs, the number of bytes written increases over time. Below **Metrics browser** is a counter that counts the number of bytes written over time.
+
+{{< figure src="/media/docs/grafana/intro-prometheus/dashboard-example.png" max-width="750px" caption="Metrics browser and counter" >}}
+
+The query is a simple example of [PromQL](/blog/2020/02/04/introduction-to-promql-the-prometheus-query-language/), the Prometheus Query Language. It identifies the metric of interest (`node_disk_written_bytes_total`) and provides two labels (`job` and `device`). The label selector `job=”integrations/macos-node”` is used to filter metrics. It reduces the scope of the metrics to those coming from the MacOS integration job, and specifies that the “device” label cannot be empty. The result of this query is the raw stream of numbers that the graph shows.
+
+Although this view provides some insight into the performance of the system, it doesn’t provide the full story. For a clearer picture of system performance, it is also important to understand the rate of change that shows _how fast the data being written is changing_. To properly monitor disk performance, it is important to see spikes in activity to understand if and when the system is under load, and whether or not disk performance is at risk. PromQL includes a [rate()](https://prometheus.io/docs/prometheus/latest/querying/functions/#rate) function that shows the per-second average rate of increase over `5m` (5-minute) intervals. This view provides a much better idea of what’s happening with the system.
+
+{{< figure src="/media/docs/grafana/intro-prometheus/rate-function.png" max-width="750px" caption="Prometheus rate function" >}}
+
+A counter metric is just one type of metric. Prometheus [supports several others](https://prometheus.io/docs/concepts/metric_types/). A counter is a number (such as total bytes written) that only goes up. A second metric type is called a `gauge`, which can go up or down.
+
+The following gauge visualization shows the total RAM usage on a computer.
+
+{{< figure src="/media/docs/grafana/intro-prometheus/gauge-example.png" max-width="750px" caption="Gauge visualization" >}}
+
+The third metric type is called a `histogram`, which counts observations and puts them into configurable groups. The following example shows floating-point numbers grouped into ranges that show how often each occurred.
+
+{{< figure src="/media/docs/grafana/intro-prometheus/histogram-example.png" max-width="750px" caption="Historgram visualization" >}}
+
+These core concepts of time series, metrics, labels, and aggregation functions are foundational to Grafana and observability.
+
+## Why this is valuable
+
+Software and systems are a difficult business. Sometimes things go wrong. Observability helps you understand a system’s state so that future issues can be proactively addressed. And when problems do occur, you can diagnose and solve them within your Service Level Objectives (SLOs). The [three pillars of observability](https://www.oreilly.com/library/view/distributed-systems-observability/9781492033431/ch04.html) are metrics, logs, and traces and Prometheus supports the metric pillar. When software on a computer runs slowly, observability can help identify whether the CPU is saturated, the system is out of memory, or if the disk is writing at maximum speed.
+
+## Prometheus as software
+
+Prometheus isn’t just a data format; many people refer to it as an [open source systems monitoring and alerting toolkit](https://prometheus.io/docs/introduction/overview/). That’s because Prometheus is software, not just data.
+
+Prometheus can scrape metric data from software and infrastructure and store it. Scraping means that Prometheus software periodically revisits the same endpoint to check for new data. Prometheus “scrapes” data from a piece of software that is instrumented with a client library.
+
+For example, a NodeJS application can configure the [prom-client](https://github.com/siimon/prom-client) to expose metrics easily at an endpoint, and Prometheus can regularly scrape that endpoint. There are a number of other tools available within the Prometheus toolkit that you can use to instrument applications.
+
+## Prometheus as deployment
+
+The first section of this document introduced the _Prometheus as Data_ concept and how the Prometheus data model and metrics are organized. The second section introduced the concept of _Prometheus as Software_ that is used to collect, process, and store metrics.
+
+This section describes how “Prometheus as Data" and “Prometheus as Software” come together. Suppose an application called `MyApp` uses a Prometheus client to expose metrics. One approach to collecting metrics data is to use a URL in the application that points to an endpoint `http://localhost:3000/metrics` that produces Prometheus metrics data.
+
+The following image shows the two metrics associated with the endpoint. The HELP text explains what the metric means, and the TYPE text indicates what kind of metric it is (in this case, a gauge). `MyAppnodejs_active_request_total` indicates the number of requests (in this case, `1`). `MyAppnodejs_heap_size_total_bytes` indicates the heap size reported in bytes. There are only two numbers because this data shows the value at the moment the data was fetched.
+
+{{< figure src="/media/docs/grafana/intro-prometheus/endpoint-data.png" max-width="750px" caption="Endpoint example" >}}
+
+These metrics are available in an HTTP endpoint, but how do they get to Grafana, and subsequently, into a dashboard?
+
+That’s where you can use either the Prometheus software, or the [Grafana Agent](/docs/agent/latest/). The Grafana Agent collects and forwards telemetry data to open sourcevdeployments of the Grafana Stack, Grafana Cloud, or Grafana Enterprise, where your data can then be analyzed.
+
+Telemetry refers to the process of recording and transmitting the readings of an application or piece of infrastructure. Telemetry is critical to observability because it helps you understand exactly what's going on in your infrastructure. Telemetry data is a source of truth.
+
+Those metrics above, for example, `MyAppnodejs_active_requests_total`, is telemetry data. MyApp only makes it available for pull by means of an HTTP request. You can configure the Grafana Agent to pull that data from MyApp every 5 seconds, and send the results to Grafana Cloud.
+
+The following image illustrates how the Grafana Agent works as an intermediary between MyApp and Grafana Cloud.
+
+{{< figure src="/media/docs/grafana/intro-prometheus/grafana-agent.png" max-width="750px" caption="Grafana Agent" >}}
+
+## Bringing it together
+
+The combination of Prometheus and the Grafana Agent gives you incredible control over the metrics you want to report, where they come from, and where they’re going. Once the data is in Grafana, it can be stored in a Grafana Mimir database. Grafana dashboards consist of visualizations populated by data queried from the Prometheus data source. The PromQL query filters and aggregates the data to provide you the insight you need. With those steps, we’ve gone from raw numbers, generated by software, into Prometheus, delivered to Grafana, queried by PromQL, and visualized by Grafana.
+
+## What’s next?
+
+Now that you understand the basics of how Prometheus telemetry works, what will you build with it?
+
+- One great next step is to [build a dashboard]({{< relref "../../dashboards/build-dashboards/" >}}) in Grafana and start turning that raw Prometheus telemetry data into insights about what’s going with your services and infrastructure.
+- Another great step is to learn about [Grafana Mimir](/oss/mimir/), which is essentially a database for Prometheus data. If you’re wondering how to make this work for a huge number of metrics with a lot of data and fast querying, check out Grafana Mimir.
+- If you’re interested in working with Prometheus data in Grafana directly, check out the [Prometheus data source]({{< relref "../../datasources/prometheus/" >}}) documentation, or check out [PromQL basics](https://prometheus.io/docs/prometheus/latest/querying/basics/).

--- a/docs/sources/fundamentals/intro-to-prometheus/index.md
+++ b/docs/sources/fundamentals/intro-to-prometheus/index.md
@@ -14,7 +14,7 @@ weight: 300
 
 # What is Prometheus?
 
-Observability focuses on understanding the internal state of your systems based on the data they produce, which helps determine if your infrastructure is healthy. Prometheus is a core technology for system observability, but the term "Prometheus" can be confusing because it is used in different contexts. Understanding Prometheus basics, why it’s valuable for system observability, and how people use it in practice will both help you better understand it and help you use Grafana.```
+Observability focuses on understanding the internal state of your systems based on the data they produce, which helps determine if your infrastructure is healthy. Prometheus is a core technology for system observability, but the term "Prometheus" can be confusing because it is used in different contexts. Understanding Prometheus basics, why it’s valuable for system observability, and how people use it in practice will both help you better understand it and help you use Grafana.
 
 Prometheus was started in 2012 at SoundCloud, who found existing technologies such as Graphite insufficient for their observability needs. Prometheus has a robust data model and query language, both of which are addressed in the following sections, and is simple and scalable. In 2018, Prometheus graduated from Cloud Native Computing Foundation (CNCF) incubation, and today has a thriving community.
 

--- a/docs/sources/fundamentals/intro-to-prometheus/index.md
+++ b/docs/sources/fundamentals/intro-to-prometheus/index.md
@@ -9,7 +9,7 @@ keywords:
   - metrics
   - time series
 title: What is Prometheus?
-weight: 400
+weight: 300
 ---
 
 # What is Prometheus?


### PR DESCRIPTION
This PR adds a topic that introduces Prometheus, metrics, and observability. The intended audience is a newcomer to Grafana who wants to learn the basics before diving in. This topic supports the get started quickly G10 initiative. 