### PR TITLE
Dashboards: Avoid adding unused revision property

### DIFF
--- a/devenv/dev-dashboards-without-uid/panel_tests_graph.json
+++ b/devenv/dev-dashboards-without-uid/panel_tests_graph.json
@@ -1629,7 +1629,6 @@
     }
   ],
   "refresh": false,
-  "revision": 8,
   "schemaVersion": 16,
   "style": "dark",
   "tags": ["gdev", "panel-tests"],

--- a/devenv/dev-dashboards/panel-graph/graph_tests.json
+++ b/devenv/dev-dashboards/panel-graph/graph_tests.json
@@ -1629,7 +1629,6 @@
     }
   ],
   "refresh": false,
-  "revision": 8,
   "schemaVersion": 16,
   "style": "dark",
   "tags": ["gdev", "panel-tests", "graph"],

--- a/devenv/dev-dashboards/panel-heatmap/heatmap-x.json
+++ b/devenv/dev-dashboards/panel-heatmap/heatmap-x.json
@@ -305,7 +305,6 @@
         "type": "heatmap"
       }
     ],
-    "revision": 1,
     "schemaVersion": 37,
     "style": "dark",
     "tags": [],

--- a/devenv/dev-dashboards/panel-histogram/histogram_tests.json
+++ b/devenv/dev-dashboards/panel-histogram/histogram_tests.json
@@ -748,7 +748,6 @@
       "type": "histogram"
     }
   ],
-  "revision": 1,
   "schemaVersion": 37,
   "style": "dark",
   "tags": [

--- a/devenv/dev-dashboards/panel-table/table_tests.json
+++ b/devenv/dev-dashboards/panel-table/table_tests.json
@@ -430,7 +430,6 @@
     }
   ],
   "refresh": false,
-  "revision": 8,
   "schemaVersion": 16,
   "style": "dark",
   "tags": ["gdev", "panel-tests"],

--- a/devenv/dev-dashboards/panel-timeline/timeline-thresholds-mappings.json
+++ b/devenv/dev-dashboards/panel-timeline/timeline-thresholds-mappings.json
@@ -736,7 +736,6 @@
     }
   ],
   "refresh": false,
-  "revision": 1,
   "schemaVersion": 38,
   "style": "dark",
   "tags": [

--- a/devenv/dev-dashboards/panel-timeseries/timeseries-yaxis-ticks.json
+++ b/devenv/dev-dashboards/panel-timeseries/timeseries-yaxis-ticks.json
@@ -1343,7 +1343,6 @@
     }
   ],
   "refresh": "",
-  "revision": 1,
   "schemaVersion": 38,
   "style": "dark",
   "tags": [

--- a/pkg/services/dashboardimport/dashboardimport.go
+++ b/pkg/services/dashboardimport/dashboardimport.go
@@ -40,8 +40,8 @@ type ImportDashboardResponse struct {
 	DashboardId      int64  `json:"dashboardId"`
 	FolderId         int64  `json:"folderId"`
 	FolderUID        string `json:"folderUid"`
-	ImportedRevision int64  `json:"importedRevision"`
-	Revision         int64  `json:"revision"`
+	ImportedRevision int64  `json:"importedRevision,omitempty"` // Only used for plugin imports
+	Revision         int64  `json:"revision,omitempty"`         // Only used for plugin imports
 	Description      string `json:"description"`
 	Path             string `json:"path"`
 	Removed          bool   `json:"removed"`

--- a/pkg/services/dashboardimport/service/service.go
+++ b/pkg/services/dashboardimport/service/service.go
@@ -136,17 +136,18 @@ func (s *ImportDashboardService) ImportDashboard(ctx context.Context, req *dashb
 		return nil, err
 	}
 
+	revision := savedDashboard.Data.Get("revision").MustInt64(0)
 	return &dashboardimport.ImportDashboardResponse{
 		UID:              savedDashboard.UID,
 		PluginId:         req.PluginId,
 		Title:            savedDashboard.Title,
 		Path:             req.Path,
-		Revision:         savedDashboard.Data.Get("revision").MustInt64(1),
+		Revision:         revision, // only used for plugin version tracking
 		FolderId:         savedDashboard.FolderID,
 		FolderUID:        req.FolderUid,
 		ImportedUri:      "db/" + savedDashboard.Slug,
 		ImportedUrl:      savedDashboard.GetURL(),
-		ImportedRevision: savedDashboard.Data.Get("revision").MustInt64(1),
+		ImportedRevision: revision,
 		Imported:         true,
 		DashboardId:      savedDashboard.ID,
 		Slug:             savedDashboard.Slug,

--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -90,7 +90,7 @@ export class DashboardModel implements TimeModel {
   snapshot: any;
   schemaVersion: number;
   version: number;
-  revision: number;
+  revision?: number; // Only used for dashboards managed by plugins
   links: DashboardLink[];
   gnetId: any;
   panels: PanelModel[];
@@ -131,7 +131,7 @@ export class DashboardModel implements TimeModel {
     this.id = data.id || null;
     // UID is not there for newly created dashboards
     this.uid = data.uid || null;
-    this.revision = data.revision || 1;
+    this.revision = data.revision ?? undefined;
     this.title = data.title ?? 'No Title';
     this.description = data.description;
     this.tags = data.tags ?? [];

--- a/public/app/features/dashboard/state/__fixtures__/dashboardFixtures.ts
+++ b/public/app/features/dashboard/state/__fixtures__/dashboardFixtures.ts
@@ -22,7 +22,6 @@ export function createDashboardModelFixture(
     editable: true,
     graphTooltip: defaultDashboardCursorSync,
     schemaVersion: 1,
-    revision: 1,
     style: 'dark',
     timezone: '',
     ...dashboardInput,


### PR DESCRIPTION
The dashboard schema has a `version` field and a `revision` field -- the version is incremented on save, and the `revision` is only set explicitly by plugin imports.

However the default dashboard model sets everything to `revision: 1` by default.

Ideally we can remove `revision` and just use `version` as an indication for plugins... but this is a smaller step to stop adding revision.


With k8s, we may also have to deal with `resourceVersion` and `generation` 🤯 