### PR TITLE
Fixes typos

### DIFF
--- a/docs/sources/alerting/manage-notifications/alertmanager.md
+++ b/docs/sources/alerting/manage-notifications/alertmanager.md
@@ -19,7 +19,7 @@ Cloud Alertmanager runs in Grafana Cloud and it can receive alerts from Grafana,
 
 **Grafana Alertmanager**
 
-Grafana Alertmanager is an internal Alertmanager that is pre-configured and available for selection by default if you run Grafana on-premise or open-source.
+Grafana Alertmanager is an internal Alertmanager that is pre-configured and available for selection by default if you run Grafana on-premises or open-source.
 
 The Grafana Alertmanager can receive alerts from Grafana, but it cannot receive alerts from outside Grafana, for example, from Mimir or Loki.
 
@@ -31,9 +31,9 @@ If you want to use a single alertmanager to receive all your Grafana, Loki, Mimi
 
 Here are two examples of when you may want to configure your own external alertmanager and send your alerts there instead of the Grafana Alertmanager:
 
-1. You may already have alertmanagers on-premise in your own Cloud infrastructure that you have set up and still want to use, because you have other alert generators, such as Prometheus.
+1. You may already have alertmanagers on-premises in your own Cloud infrastructure that you have set up and still want to use, because you have other alert generators, such as Prometheus.
 
-2. You want to use both Prometheus on-premise and hosted Grafana to send alerts to the same alertmanager that runs in your Cloud infrastructure.
+2. You want to use both Prometheus on-premises and hosted Grafana to send alerts to the same alertmanager that runs in your Cloud infrastructure.
 
 Alertmanagers are visible from the drop-down menu on the Alerting Contact Points, Notification Policies, and Silences pages.
 

--- a/docs/sources/alerting/meta-monitoring/_index.md
+++ b/docs/sources/alerting/meta-monitoring/_index.md
@@ -12,7 +12,7 @@ weight: 500
 
 # Meta monitoring
 
-Meta monitoring is the process of monitoring your monitoring, and alerting when your monitoring is not working as it should. Whether you use Grafana Managed Alerts or Mimir, meta monitoring is possible both on-premise and in Grafana Cloud.
+Meta monitoring is the process of monitoring your monitoring, and alerting when your monitoring is not working as it should. Whether you use Grafana Managed Alerts or Mimir, meta monitoring is possible both on-premises and in Grafana Cloud.
 
 ## Grafana Managed Alerts
 
@@ -134,7 +134,7 @@ This metric is a gauge. It has a constant value `1`, and contains a label called
 
 This metric is a counter that shows you the number of failed peer connection attempts. In most cases you will want to use the `rate` function to understand how often reconnections fail as this may be indicative of an issue or instability in your network.
 
-> These metrics are not available in Grafana Cloud as it uses a different high availability strategy than on-premise Alertmanagers.
+> These metrics are not available in Grafana Cloud as it uses a different high availability strategy than on-premises Alertmanagers.
 
 <!---
 #### cortex_prometheus_rule_group_last_evaluation_timestamp_seconds


### PR DESCRIPTION
**What is this feature?**

Updates documentation to reflect correct English usage according to Microsoft and Google style guides for the word **on-premise** and replaces with correct usage in Grafana documentation. I have signed the CLA.


**Why do we need this feature?**

Improves proficient use of English.

**Who is this feature for?**

All users

**Which issue(s) does this PR fix?**:

#64480

## References

### Microsoft Style Guide
https://learn.microsoft.com/en-us/style-guide/a-z-word-list-term-collections/term-collections/cloud-computing-terms

**on-premises, off-premises**
Hyphenate in all positions.

Premises is plural. Don't use on-premise, off-premise.

Don't use _on-premises cloud_ or _off-premises cloud_.

### Google Style Guide
https://developers.google.com/style/word-list

**on-premises**; not _on prem_ or _on premise_ or _on-premise_

Use to refer to a customer's resources that they manage in their own facilities. Don't use peer. Hyphenate when used as any part of speech. It can be acceptable to use on-premises as a noun when it would be awkward to repeatedly write out a full phrase like an on-premises environment. However, it's preferable to use the more complete phrase whenever possible.

**Recommended**: An _on-premises_ database
**Recommended**: The database runs _on-premises_
**OK**: Moving data from _on-premises_ to Google Cloud
