### PR TITLE
Logs: Add millisecond to timestamp in log line

### DIFF
--- a/public/app/features/explore/LogsSample.test.tsx
+++ b/public/app/features/explore/LogsSample.test.tsx
@@ -81,9 +81,9 @@ describe('LogsSamplePanel', () => {
     render(
       <LogsSamplePanel {...createProps({ queryResponse: { data: [sampleDataFrame], state: LoadingState.Done } })} />
     );
-    expect(screen.getByText('2022-02-22 04:28:11')).toBeInTheDocument();
+    expect(screen.getByText('2022-02-22 04:28:11.352')).toBeInTheDocument();
     expect(screen.getByText('line1')).toBeInTheDocument();
-    expect(screen.getByText('2022-02-22 09:42:50')).toBeInTheDocument();
+    expect(screen.getByText('2022-02-22 09:42:50.991')).toBeInTheDocument();
     expect(screen.getByText('line2')).toBeInTheDocument();
   });
 

--- a/public/app/features/logs/components/LogRow.tsx
+++ b/public/app/features/logs/components/LogRow.tsx
@@ -117,6 +117,7 @@ class UnThemedLogRow extends PureComponent<Props, State> {
   renderTimeStamp(epochMs: number) {
     return dateTimeFormat(epochMs, {
       timeZone: this.props.timeZone,
+      defaultWithMS: true,
     });
   }
 


### PR DESCRIPTION
**What is this feature?**

This adds milliseconds to the timestamp displayed in log lines.

<img width="248" alt="image" src="https://user-images.githubusercontent.com/8092184/223658924-c072632d-9072-4b60-85b1-5450d8647eaa.png">

Fixes #64387