### PR TITLE
Trigger PR commands on labeled events

### DIFF
--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -2,6 +2,7 @@ name: PR automation
 on:
   pull_request_target:
     types:
+      - labeled
       - opened
       - synchronize
 concurrency:


### PR DESCRIPTION
This should enable adding PRs to organization project boards similar to with issues.

The work in https://github.com/grafana/grafana/pull/64285 was only part of the solution and was predicated on the mistaken assumption that we were already running this workflow on labeled events.

Closes https://github.com/grafana/grafana/issues/64251.