### PR TITLE
Admin/Plugins: Set category filter in connections link

### DIFF
--- a/public/app/features/connections/components/ConnectionsRedirectNotice/ConnectionsRedirectNotice.tsx
+++ b/public/app/features/connections/components/ConnectionsRedirectNotice/ConnectionsRedirectNotice.tsx
@@ -28,7 +28,8 @@ export enum DestinationPage {
 
 const destinationLinks = {
   [DestinationPage.dataSources]: ROUTES.DataSources,
-  [DestinationPage.connectData]: ROUTES.ConnectData,
+  // Set category filter for the cloud version of ConnectData page
+  [DestinationPage.connectData]: `${ROUTES.ConnectData}?cat=data-source`,
 };
 
 export function ConnectionsRedirectNotice({ destinationPage }: { destinationPage: DestinationPage }) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

On top of the Admin/Plugins page there is a banner with a LinkButton "See data sources in Connections". Its job is to inform users that data sources have been moved (or rather copied) to this new page, Connections/ConnectData.
![image](https://user-images.githubusercontent.com/13637610/223700000-2643da5f-63be-4069-bbdc-823591a2698e.png)

In the cloud version, where the ConnectData page is served by the cloud-onboarding plugin, there is a catalog shown with many different types of connections.
![image](https://user-images.githubusercontent.com/13637610/223700305-8e7b47c8-819a-44a0-87c0-459b8b212d65.png)

This PR sets a category filter in this link, so that when users click on it in cloud, they'll arrive to a page, where only data sources can be seen.
![image](https://user-images.githubusercontent.com/13637610/223700556-cef51737-bd26-488a-b8e3-10cd98b5c639.png)

This does not affect the experience outside of cloud, since Grafana core's ConnectData page ignores this URL parameter.
![image](https://user-images.githubusercontent.com/13637610/223700751-998e3d70-382c-4cd3-a04f-6b258e90d1bf.png)

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #https://github.com/grafana/cloud-onboarding/issues/3404
