### PR TITLE
access control api: Correction of typo in list your permissions endpoint

### DIFF
--- a/docs/sources/developers/http_api/access_control.md
+++ b/docs/sources/developers/http_api/access_control.md
@@ -529,7 +529,7 @@ Content-Type: application/json; charset=UTF-8
 
 ### List your permissions
 
-`GET /api/access-control/users/permissions`
+`GET /api/access-control/user/permissions`
 
 Lists the permissions granted to the signed in user.
 


### PR DESCRIPTION
Correction of an API endpoint in 'List your permissions' section. 
https://grafana.com/docs/grafana/latest/developers/http_api/access_control/#list-your-permissions

instead of:    `/api/access-control/users/permissions`
it should be: `/api/access-control/user/permissions`

the extra 's` in "users" causes the API to return a 404 error
