### PR TITLE
logs: dedup strategy: fixed order

### DIFF
--- a/public/app/features/explore/Logs.tsx
+++ b/public/app/features/explore/Logs.tsx
@@ -110,6 +110,14 @@ const styleOverridesForStickyNavigation = css`
   }
 `;
 
+// we need to define the order of these explicitly
+const DEDUP_OPTIONS = [
+  LogsDedupStrategy.none,
+  LogsDedupStrategy.exact,
+  LogsDedupStrategy.numbers,
+  LogsDedupStrategy.signature,
+];
+
 class UnthemedLogs extends PureComponent<Props, State> {
   flipOrderTimer?: number;
   cancelFlippingTimer?: number;
@@ -428,7 +436,7 @@ class UnthemedLogs extends PureComponent<Props, State> {
               </InlineField>
               <InlineField label="Deduplication" className={styles.horizontalInlineLabel} transparent>
                 <RadioButtonGroup
-                  options={Object.values(LogsDedupStrategy).map((dedupType) => ({
+                  options={DEDUP_OPTIONS.map((dedupType) => ({
                     label: capitalize(dedupType),
                     value: dedupType,
                     description: LogsDedupDescription[dedupType],


### PR DESCRIPTION
when https://github.com/grafana/grafana/pull/63716 happened, the order of items in the `LogsDedupStrategy` enum has changed, which caused the list of items in the radio-buttons change it's order.

this PR explicitly defines the required order.

how to test:
1. go to explore, produce some logs
2. verify that the first dedup-option is `none`