### PR TITLE
Code: Ownership for alerting feature toggles

### DIFF
--- a/pkg/services/featuremgmt/codeowners.go
+++ b/pkg/services/featuremgmt/codeowners.go
@@ -17,4 +17,5 @@ const (
 	grafanaAuthnzSquad                          codeowner = "@grafana/grafana-authnz-team"
 	grafanaObservabilityLogsSquad               codeowner = "@grafana/observability-logs"
 	grafanaObservabilityTracesAndProfilingSquad codeowner = "@grafana/observability-traces-and-profiling"
+	grafanaAlertingSquad                        codeowner = "@grafana/alerting-squad"
 )

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -13,6 +13,7 @@ var (
 			Name:        "alertingBigTransactions",
 			Description: "Use big transactions for alerting database writes",
 			State:       FeatureStateAlpha,
+			Owner:       grafanaAlertingSquad,
 		},
 		{
 			Name:        "trimDefaults",
@@ -353,6 +354,7 @@ var (
 			Name:        "alertingBacktesting",
 			Description: "Rule backtesting API for alerting",
 			State:       FeatureStateAlpha,
+			Owner:       grafanaAlertingSquad,
 		},
 		{
 			Name:         "editPanelCSVDragAndDrop",
@@ -366,6 +368,7 @@ var (
 			Description:     "Stop maintaining state of alerts that are not firing",
 			State:           FeatureStateBeta,
 			RequiresRestart: false,
+			Owner:           grafanaAlertingSquad,
 		},
 		{
 

--- a/pkg/services/featuremgmt/toggles_gen_test.go
+++ b/pkg/services/featuremgmt/toggles_gen_test.go
@@ -42,7 +42,6 @@ func TestFeatureToggleFiles(t *testing.T) {
 	})
 
 	ownerlessFeatures := map[string]bool{
-		"alertingBigTransactions":           true,
 		"trimDefaults":                      true,
 		"database_metrics":                  true,
 		"prometheusAzureOverrideAudience":   true,
@@ -62,8 +61,6 @@ func TestFeatureToggleFiles(t *testing.T) {
 		"datasourceOnboarding":              true,
 		"secureSocksDatasourceProxy":        true,
 		"disablePrometheusExemplarSampling": true,
-		"alertingBacktesting":               true,
-		"alertingNoNormalState":             true,
 		"individualCookiePreferences":       true,
 	}
 


### PR DESCRIPTION
This PR assigns ownership for feature flags  alertingBigTransactions, alertingBacktesting and alertingNoNormalState to `@grafana/alerting-squad`.