### PR TITLE
Chore: Assign ownership to the Connections feature

### DIFF
--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -233,6 +233,7 @@ var (
 			Name:        "dataConnectionsConsole",
 			Description: "Enables a new top-level page called Connections. This page is an experiment that provides a better experience when you install and configure data sources and other plugins.",
 			State:       FeatureStateAlpha,
+			Owner:       grafanaPluginsPlatformSquad,
 		},
 		{
 			Name:        "internationalization",

--- a/pkg/services/featuremgmt/toggles_gen_test.go
+++ b/pkg/services/featuremgmt/toggles_gen_test.go
@@ -53,7 +53,6 @@ func TestFeatureToggleFiles(t *testing.T) {
 		"prometheusWideSeries":              true,
 		"disableSecretsCompatibility":       true,
 		"logRequestsInstrumentedAsUnknown":  true,
-		"dataConnectionsConsole":            true,
 		"cloudWatchCrossAccountQuerying":    true,
 		"redshiftAsyncQueryDataSupport":     true,
 		"athenaAsyncQueryDataSupport":       true,


### PR DESCRIPTION
### What changed?

As the Plugins Platform squad was responsible for implementing the grafana-core related parts of the new Connections page, it probably makes sense to assign the team as an owner to the `dataConnectionsConsole` feature flag.