### PR TITLE
Dashboard Datasource: Update Query List & Improve UX

### DIFF
--- a/docs/sources/datasources/_index.md
+++ b/docs/sources/datasources/_index.md
@@ -48,9 +48,21 @@ For example, this video demonstrates the visual Prometheus query builder:
 
 For general information about querying in Grafana, and common options and user interface elements across all query editors, refer to [Query and transform data]({{< relref "../panels-visualizations/query-transform-data/" >}}).
 
+## Special data sources
+
+Grafana includes three special data sources:
+
+- **Grafana:** A built-in data source that generates random walk data and can poll the [Testdata]({{< relref "./testdata/" >}}) data source. Additionally, it can list files and get other data from a Grafana installation. This can be helpful for testing visualizations and running experiments.
+- **Mixed:** An abstraction that lets you query multiple data sources in the same panel.
+  When you select Mixed, you can then select a different data source for each new query that you add.
+  - The first query uses the data source that was selected before you selected **Mixed**.
+  - You can't change an existing query to use the **Mixed** data source.
+  - Grafana Play example: [Mixed data sources](https://play.grafana.org/d/000000100/mixed-datasources?orgId=1)
+- **Dashboard:** A data source that uses the result set from another panel in the same dashboard. The dashboard data source can use data either directly from the selected panel or from annotations attached to the selected panel.
+
 ## Built-in core data sources
 
-These built-in core data sources are included in the Grafana documentation:
+These built-in core data sources are also included in the Grafana documentation:
 
 - [Alertmanager]({{< relref "./alertmanager/" >}})
 - [AWS CloudWatch]({{< relref "./aws-cloudwatch/" >}})
@@ -69,15 +81,3 @@ These built-in core data sources are included in the Grafana documentation:
 - [Tempo]({{< relref "./tempo/" >}})
 - [Testdata]({{< relref "./testdata/" >}})
 - [Zipkin]({{< relref "./zipkin/" >}})
-
-## Special data sources
-
-Grafana also includes three special data sources:
-
-- **Grafana:** A built-in data source that generates random walk data and can poll the [Testdata]({{< relref "./testdata/" >}}) data source. Additionally, it can list files and get other data from a Grafana installation. This can be helpful for testing visualizations and running experiments.
-- **Mixed:** An abstraction that lets you query multiple data sources in the same panel.
-  When you select Mixed, you can then select a different data source for each new query that you add.
-  - The first query uses the data source that was selected before you selected **Mixed**.
-  - You can't change an existing query to use the **Mixed** data source.
-  - Grafana Play example: [Mixed data sources](https://play.grafana.org/d/000000100/mixed-datasources?orgId=1)
-- **Dashboard:** A data source that uses the result set from another panel in the same dashboard. The dashboard data source can use data either directly from the selected panel or from annotations attached to the selected panel.

--- a/docs/sources/datasources/_index.md
+++ b/docs/sources/datasources/_index.md
@@ -48,18 +48,6 @@ For example, this video demonstrates the visual Prometheus query builder:
 
 For general information about querying in Grafana, and common options and user interface elements across all query editors, refer to [Query and transform data]({{< relref "../panels-visualizations/query-transform-data/" >}}).
 
-## Special data sources
-
-Grafana includes three special data sources:
-
-- **Grafana:** A built-in data source that generates random walk data and can poll the [Testdata]({{< relref "./testdata/" >}}) data source. Additionally, it can list files and get other data from a Grafana installation. This can be helpful for testing visualizations and running experiments.
-- **Mixed:** An abstraction that lets you query multiple data sources in the same panel.
-  When you select Mixed, you can then select a different data source for each new query that you add.
-  - The first query uses the data source that was selected before you selected **Mixed**.
-  - You can't change an existing query to use the **Mixed** data source.
-  - Grafana Play example: [Mixed data sources](https://play.grafana.org/d/000000100/mixed-datasources?orgId=1)
-- **Dashboard:** A data source that uses the result set from another panel in the same dashboard. The dashboard data source can use data either directly from the selected panel or from annotations attached to the selected panel.
-
 ## Built-in core data sources
 
 These built-in core data sources are included in the Grafana documentation:
@@ -81,3 +69,15 @@ These built-in core data sources are included in the Grafana documentation:
 - [Tempo]({{< relref "./tempo/" >}})
 - [Testdata]({{< relref "./testdata/" >}})
 - [Zipkin]({{< relref "./zipkin/" >}})
+
+## Special data sources
+
+Grafana includes three special data sources:
+
+- **Grafana:** A built-in data source that generates random walk data and can poll the [Testdata]({{< relref "./testdata/" >}}) data source. Additionally, it can list files and get other data from a Grafana installation. This can be helpful for testing visualizations and running experiments.
+- **Mixed:** An abstraction that lets you query multiple data sources in the same panel.
+  When you select Mixed, you can then select a different data source for each new query that you add.
+  - The first query uses the data source that was selected before you selected **Mixed**.
+  - You can't change an existing query to use the **Mixed** data source.
+  - Grafana Play example: [Mixed data sources](https://play.grafana.org/d/000000100/mixed-datasources?orgId=1)
+- **Dashboard:** A data source that uses the result set from another panel in the same dashboard. The dashboard data source can use data either directly from the selected panel or from annotations attached to the selected panel.

--- a/docs/sources/datasources/_index.md
+++ b/docs/sources/datasources/_index.md
@@ -50,13 +50,13 @@ For general information about querying in Grafana, and common options and user i
 
 ## Special data sources
 
-Grafana also includes three special data sources:
+Grafana includes three special data sources:
 
-- **Grafana:** A built-in data source that generates random walk data and can poll the [Testdata]({{< relref "./testdata/" >}}) data source. Additionally it can list files and get other data from a Grafana installation. This can be helpful for testing visualizations and running experiments.
+- **Grafana:** A built-in data source that generates random walk data and can poll the [Testdata]({{< relref "./testdata/" >}}) data source. Additionally, it can list files and get other data from a Grafana installation. This can be helpful for testing visualizations and running experiments.
 - **Mixed:** An abstraction that lets you query multiple data sources in the same panel.
   When you select Mixed, you can then select a different data source for each new query that you add.
   - The first query uses the data source that was selected before you selected **Mixed**.
-  - You can't change an existing query to use the Mixed data source.
+  - You can't change an existing query to use the **Mixed** data source.
   - Grafana Play example: [Mixed data sources](https://play.grafana.org/d/000000100/mixed-datasources?orgId=1)
 - **Dashboard:** A data source that uses the result set from another panel in the same dashboard. The dashboard data source can use data either directly from the selected panel or from annotations attached to the selected panel.
 

--- a/docs/sources/datasources/_index.md
+++ b/docs/sources/datasources/_index.md
@@ -48,6 +48,18 @@ For example, this video demonstrates the visual Prometheus query builder:
 
 For general information about querying in Grafana, and common options and user interface elements across all query editors, refer to [Query and transform data]({{< relref "../panels-visualizations/query-transform-data/" >}}).
 
+## Special data sources
+
+Grafana also includes three special data sources:
+
+- **Grafana:** A built-in data source that generates random walk data and can poll the [Testdata]({{< relref "./testdata/" >}}) data source. Additionally it can list files and get other data from a Grafana installation. This can be helpful for testing visualizations and running experiments.
+- **Mixed:** An abstraction that lets you query multiple data sources in the same panel.
+  When you select Mixed, you can then select a different data source for each new query that you add.
+  - The first query uses the data source that was selected before you selected **Mixed**.
+  - You can't change an existing query to use the Mixed data source.
+  - Grafana Play example: [Mixed data sources](https://play.grafana.org/d/000000100/mixed-datasources?orgId=1)
+- **Dashboard:** A data source that uses the result set from another panel in the same dashboard. The dashboard data source can use data either directly from the selected panel or from annotations attached to the selected panel.
+
 ## Built-in core data sources
 
 These built-in core data sources are included in the Grafana documentation:
@@ -69,16 +81,3 @@ These built-in core data sources are included in the Grafana documentation:
 - [Tempo]({{< relref "./tempo/" >}})
 - [Testdata]({{< relref "./testdata/" >}})
 - [Zipkin]({{< relref "./zipkin/" >}})
-
-## Special data sources
-
-Grafana also includes three special data sources:
-
-- **Grafana:** A built-in data source that generates random walk data and can poll the [Testdata]({{< relref "./testdata/" >}}) data source.
-  This helps you test visualizations and run experiments.
-- **Mixed:** An abstraction that lets you query multiple data sources in the same panel.
-  When you select Mixed, you can then select a different data source for each new query that you add.
-  - The first query uses the data source that was selected before you selected **Mixed**.
-  - You can't change an existing query to use the Mixed data source.
-  - Grafana Play example: [Mixed data sources](https://play.grafana.org/d/000000100/mixed-datasources?orgId=1)
-- **Dashboard:** A data source that uses the result set from another panel in the same dashboard.

--- a/docs/sources/datasources/_index.md
+++ b/docs/sources/datasources/_index.md
@@ -72,7 +72,7 @@ These built-in core data sources are included in the Grafana documentation:
 
 ## Special data sources
 
-Grafana includes three special data sources:
+Grafana also includes three special data sources:
 
 - **Grafana:** A built-in data source that generates random walk data and can poll the [Testdata]({{< relref "./testdata/" >}}) data source. Additionally, it can list files and get other data from a Grafana installation. This can be helpful for testing visualizations and running experiments.
 - **Mixed:** An abstraction that lets you query multiple data sources in the same panel.

--- a/public/app/plugins/datasource/dashboard/DashboardQueryEditor.tsx
+++ b/public/app/plugins/datasource/dashboard/DashboardQueryEditor.tsx
@@ -5,7 +5,17 @@ import React, { useCallback, useMemo } from 'react';
 import { useAsync } from 'react-use';
 
 import { DataQuery, GrafanaTheme2, PanelData, SelectableValue, DataTopic } from '@grafana/data';
-import { Field, Select, useStyles2, VerticalGroup, Spinner, Switch, RadioButtonGroup, Icon } from '@grafana/ui';
+import {
+  Card,
+  Field,
+  Select,
+  useStyles2,
+  VerticalGroup,
+  Spinner,
+  Switch,
+  RadioButtonGroup,
+  IconButton,
+} from '@grafana/ui';
 import config from 'app/core/config';
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
 import { PanelModel } from 'app/features/dashboard/state';
@@ -52,6 +62,7 @@ export function DashboardQueryEditor({ panelData, queries, onChange, onRunQuerie
         return {
           refId: query.refId,
           query: fmt(query),
+          name: ds.name,
           img: ds.meta.info.logos.small,
           data: queryData.series,
           error: queryData.error,
@@ -142,7 +153,8 @@ export function DashboardQueryEditor({ panelData, queries, onChange, onRunQuerie
 
   const selected = panels.find((panel) => panel.value === query.panelId);
   // Same as current URL, but different panelId
-  const editURL = `d/${dashboard.uid}/${dashboard.title}?&editPanel=${query.panelId}`;
+  const encodedTitle = encodeURIComponent(dashboard.title);
+  const editURL = `d/${dashboard.uid}/${encodedTitle}?&editPanel=${query.panelId}`;
   const showTransforms = Boolean(query.withTransforms || panel?.transformations?.length);
 
   return (
@@ -158,33 +170,9 @@ export function DashboardQueryEditor({ panelData, queries, onChange, onRunQuerie
         />
       </Field>
 
-      {loadingResults ? (
-        <Spinner />
-      ) : (
-        <>
-          {results && Boolean(results.length) && (
-            <Field label="Queries">
-              <VerticalGroup spacing="sm">
-                {results.map((target, i) => (
-                  <div className={styles.queryEditorRowHeader} key={`DashboardQueryRow-${i}`}>
-                    <div>
-                      <img src={target.img} alt="" width={16} />
-                      <span className={styles.refId}>{target.refId}:</span>
-                    </div>
-                    <div>
-                      <a href={editURL}>
-                        {target.query}
-                        &nbsp;
-                        <Icon name="external-link-alt" />
-                      </a>
-                    </div>
-                  </div>
-                ))}
-              </VerticalGroup>
-            </Field>
-          )}
-        </>
-      )}
+      <Field label="Data">
+        <RadioButtonGroup options={topics} value={query.topic === DataTopic.Annotations} onChange={onTopicChanged} />
+      </Field>
 
       {showTransforms && (
         <Field label="Transform" description="Apply panel transformations from the source panel">
@@ -192,9 +180,30 @@ export function DashboardQueryEditor({ panelData, queries, onChange, onRunQuerie
         </Field>
       )}
 
-      <Field label="Data">
-        <RadioButtonGroup options={topics} value={query.topic === DataTopic.Annotations} onChange={onTopicChanged} />
-      </Field>
+      {loadingResults ? (
+        <Spinner />
+      ) : (
+        <>
+          {results && Boolean(results.length) && (
+            <Field label="Available queries from panel">
+              <VerticalGroup spacing="sm">
+                {results.map((target, i) => (
+                  <Card key={`DashboardQueryRow-${i}`}>
+                    <Card.Heading>{target.refId}</Card.Heading>
+                    <Card.Figure>
+                      <img src={target.img} alt={target.name} title={target.name} width={40} />
+                    </Card.Figure>
+                    <Card.Meta>{target.query}</Card.Meta>
+                    <Card.SecondaryActions>
+                      <IconButton key="edit" name="edit" tooltip="Edit Query" />
+                    </Card.SecondaryActions>
+                  </Card>
+                ))}
+              </VerticalGroup>
+            </Field>
+          )}
+        </>
+      )}
     </>
   );
 }

--- a/public/app/plugins/datasource/dashboard/DashboardQueryEditor.tsx
+++ b/public/app/plugins/datasource/dashboard/DashboardQueryEditor.tsx
@@ -5,7 +5,17 @@ import React, { useCallback, useMemo } from 'react';
 import { useAsync } from 'react-use';
 
 import { DataQuery, GrafanaTheme2, PanelData, SelectableValue, DataTopic } from '@grafana/data';
-import { Card, Field, Select, useStyles2, VerticalGroup, Spinner, Switch, RadioButtonGroup } from '@grafana/ui';
+import {
+  Card,
+  Field,
+  Select,
+  useStyles2,
+  VerticalGroup,
+  HorizontalGroup,
+  Spinner,
+  Switch,
+  RadioButtonGroup,
+} from '@grafana/ui';
 import config from 'app/core/config';
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
 import { PanelModel } from 'app/features/dashboard/state';
@@ -157,15 +167,21 @@ export function DashboardQueryEditor({ panelData, queries, onChange, onRunQuerie
         />
       </Field>
 
-      <Field label="Data">
-        <RadioButtonGroup options={topics} value={query.topic === DataTopic.Annotations} onChange={onTopicChanged} />
-      </Field>
-
-      {showTransforms && (
-        <Field label="Transform" description="Apply panel transformations from the source panel">
-          <Switch value={Boolean(query.withTransforms)} onChange={onTransformToggle} />
+      <HorizontalGroup height="auto" wrap={true} align="flex-start">
+        <Field
+          label="Data Source"
+          description="Use data or annotations from the panel"
+          className={styles.horizontalField}
+        >
+          <RadioButtonGroup options={topics} value={query.topic === DataTopic.Annotations} onChange={onTopicChanged} />
         </Field>
-      )}
+
+        {showTransforms && (
+          <Field label="Transform" description="Apply panel transformations from the source panel">
+            <Switch value={Boolean(query.withTransforms)} onChange={onTransformToggle} />
+          </Field>
+        )}
+      </HorizontalGroup>
 
       {loadingResults ? (
         <Spinner />
@@ -194,6 +210,9 @@ export function DashboardQueryEditor({ panelData, queries, onChange, onRunQuerie
 
 function getStyles(theme: GrafanaTheme2) {
   return {
+    horizontalField: css({
+      marginRight: theme.spacing(2),
+    }),
     noQueriesText: css({
       padding: theme.spacing(1.25),
     }),

--- a/public/app/plugins/datasource/dashboard/DashboardQueryEditor.tsx
+++ b/public/app/plugins/datasource/dashboard/DashboardQueryEditor.tsx
@@ -194,22 +194,8 @@ export function DashboardQueryEditor({ panelData, queries, onChange, onRunQuerie
 
 function getStyles(theme: GrafanaTheme2) {
   return {
-    results: css({
-      padding: theme.spacing(2),
-    }),
     noQueriesText: css({
       padding: theme.spacing(1.25),
     }),
-    refId: css({
-      padding: theme.spacing(1.25),
-    }),
-    queryEditorRowHeader: css`
-      label: queryEditorRowHeader;
-      display: flex;
-      padding: 4px 8px;
-      flex-flow: row wrap;
-      background: ${theme.colors.background.secondary};
-      align-items: center;
-    `,
   };
 }

--- a/public/app/plugins/datasource/dashboard/DashboardQueryEditor.tsx
+++ b/public/app/plugins/datasource/dashboard/DashboardQueryEditor.tsx
@@ -5,17 +5,7 @@ import React, { useCallback, useMemo } from 'react';
 import { useAsync } from 'react-use';
 
 import { DataQuery, GrafanaTheme2, PanelData, SelectableValue, DataTopic } from '@grafana/data';
-import {
-  Card,
-  Field,
-  Select,
-  useStyles2,
-  VerticalGroup,
-  Spinner,
-  Switch,
-  RadioButtonGroup,
-  IconButton,
-} from '@grafana/ui';
+import { Card, Field, Select, useStyles2, VerticalGroup, Spinner, Switch, RadioButtonGroup } from '@grafana/ui';
 import config from 'app/core/config';
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
 import { PanelModel } from 'app/features/dashboard/state';
@@ -117,6 +107,7 @@ export function DashboardQueryEditor({ panelData, queries, onChange, onRunQuerie
   );
 
   const dashboard = getDashboardSrv().getCurrent();
+  const showTransforms = Boolean(query.withTransforms || panel?.transformations?.length);
   const panels: Array<SelectableValue<number>> = useMemo(
     () =>
       dashboard?.panels
@@ -152,10 +143,6 @@ export function DashboardQueryEditor({ panelData, queries, onChange, onRunQuerie
   }
 
   const selected = panels.find((panel) => panel.value === query.panelId);
-  // Same as current URL, but different panelId
-  const encodedTitle = encodeURIComponent(dashboard.title);
-  const editURL = `d/${dashboard.uid}/${encodedTitle}?&editPanel=${query.panelId}`;
-  const showTransforms = Boolean(query.withTransforms || panel?.transformations?.length);
 
   return (
     <>
@@ -194,9 +181,6 @@ export function DashboardQueryEditor({ panelData, queries, onChange, onRunQuerie
                       <img src={target.img} alt={target.name} title={target.name} width={40} />
                     </Card.Figure>
                     <Card.Meta>{target.query}</Card.Meta>
-                    <Card.SecondaryActions>
-                      <IconButton key="edit" name="edit" tooltip="Edit Query" />
-                    </Card.SecondaryActions>
                   </Card>
                 ))}
               </VerticalGroup>

--- a/public/app/plugins/datasource/dashboard/types.ts
+++ b/public/app/plugins/datasource/dashboard/types.ts
@@ -10,6 +10,7 @@ export interface DashboardQuery extends DataQuery {
 
 export type ResultInfo = {
   img: string; // The Datasource
+  name: string;
   refId: string;
   query: string; // As text
   data: DataFrame[];


### PR DESCRIPTION
**What is this feature?**

This updates the presentation of queries in the dashboard datasource and re-organizes controls to make things more clear.  In particular it moves the annotation and transformation controls above the queries as those can be quite long. Additionally rather than using bespoke HTML it shifts to usage of the card component from `@grafana/ui`.

This also removes the query edit links. The links were both not correct and not working 😬. Because the only change in the URL is the `panelId` parameter, no components are unmounted/mounted so nothing happens in the absence of a `useEffect` hook or something similar. In short, the URL will update but nothing else will happen. This would take more time than is available for me at the moment, however it would be a good follow up 😄.

Finally, this PR updates data source related docs to indicate that annotations can be read from the dashboard data source and moves the "Special Data Sources" section above the list of core data sources as those are already accessible from the menu.

###  New

![Screenshot 2023-03-09 at 4 41 12 PM](https://user-images.githubusercontent.com/199847/223984283-eee66a62-d8f4-4f9a-af7d-e7931156ff2c.png)

### Old

![Screenshot 2023-03-09 at 4 47 18 PM](https://user-images.githubusercontent.com/199847/223984343-7d3c1085-59e4-490b-a5a3-aabdb3b674e6.png)


**Why do we need this feature?**

It improves the clarity and usefulness of the dashboard datasource and removes broken functionality.

**Who is this feature for?**

Users consuming the dashboard datasource.
