### PR TITLE
FeatureFlags: Add "O11y-metrics" as Owner for metrics feature flags

### DIFF
--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -207,6 +207,7 @@ var (
 			Name:        "prometheusWideSeries",
 			Description: "Enable wide series responses in the Prometheus datasource",
 			State:       FeatureStateAlpha,
+			Owner:       "O11y-metrics",
 		},
 		{
 			Name:         "canvasPanelNesting",
@@ -352,6 +353,7 @@ var (
 			Name:        "disablePrometheusExemplarSampling",
 			Description: "Disable Prometheus examplar sampling",
 			State:       FeatureStateStable,
+			Owner:       "O11y-metrics",
 		},
 		{
 			Name:        "alertingBacktesting",

--- a/pkg/services/featuremgmt/toggles_gen_test.go
+++ b/pkg/services/featuremgmt/toggles_gen_test.go
@@ -42,23 +42,21 @@ func TestFeatureToggleFiles(t *testing.T) {
 	})
 
 	ownerlessFeatures := map[string]bool{
-		"database_metrics":                  true,
-		"prometheusAzureOverrideAudience":   true,
-		"tracing":                           true,
-		"cloudWatchDynamicLabels":           true,
-		"prometheusWideSeries":              true,
-		"disableSecretsCompatibility":       true,
-		"logRequestsInstrumentedAsUnknown":  true,
-		"dataConnectionsConsole":            true,
-		"cloudWatchCrossAccountQuerying":    true,
-		"redshiftAsyncQueryDataSupport":     true,
-		"athenaAsyncQueryDataSupport":       true,
-		"newPanelChromeUI":                  true,
-		"showDashboardValidationWarnings":   true,
-		"datasourceOnboarding":              true,
-		"secureSocksDatasourceProxy":        true,
-		"disablePrometheusExemplarSampling": true,
-		"individualCookiePreferences":       true,
+		"database_metrics":                 true,
+		"prometheusAzureOverrideAudience":  true,
+		"tracing":                          true,
+		"cloudWatchDynamicLabels":          true,
+		"disableSecretsCompatibility":      true,
+		"logRequestsInstrumentedAsUnknown": true,
+		"dataConnectionsConsole":           true,
+		"cloudWatchCrossAccountQuerying":   true,
+		"redshiftAsyncQueryDataSupport":    true,
+		"athenaAsyncQueryDataSupport":      true,
+		"newPanelChromeUI":                 true,
+		"showDashboardValidationWarnings":  true,
+		"datasourceOnboarding":             true,
+		"secureSocksDatasourceProxy":       true,
+		"individualCookiePreferences":      true,
 	}
 
 	t.Run("all new features should have an owner", func(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/64422

Feature flags require an `Owner` attribute in `registry.go`. This adds "O11y-metrics" as owner to two prometheus flags.
