### PR TITLE
Loki: Add error handling to `CallResource`

### DIFF
--- a/pkg/tsdb/loki/api.go
+++ b/pkg/tsdb/loki/api.go
@@ -111,14 +111,12 @@ func makeLokiError(bytes []byte) error {
 		return fmt.Errorf("%v", string(bytes))
 	}
 
-	errorMessage := data.Message
-
-	if errorMessage == "" {
+	if data.Message == "" {
 		// we got no usable error message, we return the whole text
 		return fmt.Errorf("%v", string(bytes))
 	}
 
-	return fmt.Errorf("%v", errorMessage)
+	return fmt.Errorf("%v", data.Message)
 }
 
 // we know there is an error,

--- a/pkg/tsdb/loki/api.go
+++ b/pkg/tsdb/loki/api.go
@@ -15,6 +15,7 @@ import (
 	jsoniter "github.com/json-iterator/go"
 
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/util/converter"
 )
 
@@ -26,6 +27,7 @@ type LokiAPI struct {
 
 type RawLokiResponse struct {
 	Body     []byte
+	Status   int
 	Encoding string
 }
 
@@ -97,13 +99,32 @@ func makeDataRequest(ctx context.Context, lokiDsUrl string, query lokiQuery) (*h
 }
 
 type lokiError struct {
-	Message string
+	Message string `json:"message"`
+	TraceID string `json:"traceID,omitempty"`
+}
+
+func makeLokiError(bytes []byte) error {
+	var data lokiError
+	err := json.Unmarshal(bytes, &data)
+	if err != nil {
+		// we were unable to convert the bytes to JSON, we return the whole text
+		return fmt.Errorf("%v", string(bytes))
+	}
+
+	errorMessage := data.Message
+
+	if errorMessage == "" {
+		// we got no usable error message, we return the whole text
+		return fmt.Errorf("%v", string(bytes))
+	}
+
+	return fmt.Errorf("%v", errorMessage)
 }
 
 // we know there is an error,
 // based on the http-response-body
 // we have to make an informative error-object
-func makeLokiError(body io.ReadCloser) error {
+func readLokiError(body io.ReadCloser) error {
 	var buf bytes.Buffer
 	_, err := buf.ReadFrom(body)
 	if err != nil {
@@ -122,21 +143,7 @@ func makeLokiError(body io.ReadCloser) error {
 	// - we take the value of the field "message"
 	// - if any of these steps fail, or if "message" is empty, we return the whole text
 
-	var data lokiError
-	err = json.Unmarshal(bytes, &data)
-	if err != nil {
-		// we were unable to convert the bytes to JSON, we return the whole text
-		return fmt.Errorf("%v", string(bytes))
-	}
-
-	errorMessage := data.Message
-
-	if errorMessage == "" {
-		// we got no usable error message, we return the whole text
-		return fmt.Errorf("%v", string(bytes))
-	}
-
-	return fmt.Errorf("%v", errorMessage)
+	return makeLokiError(bytes)
 }
 
 func (api *LokiAPI) DataQuery(ctx context.Context, query lokiQuery) (data.Frames, error) {
@@ -157,7 +164,7 @@ func (api *LokiAPI) DataQuery(ctx context.Context, query lokiQuery) (data.Frames
 	}()
 
 	if resp.StatusCode/100 != 2 {
-		return nil, makeLokiError(resp.Body)
+		return nil, readLokiError(resp.Body)
 	}
 
 	iter := jsoniter.Parse(jsoniter.ConfigDefault, resp.Body, 1024)
@@ -211,8 +218,9 @@ func (api *LokiAPI) RawQuery(ctx context.Context, resourcePath string) (RawLokiR
 		}
 	}()
 
-	if resp.StatusCode/100 != 2 {
-		return RawLokiResponse{}, makeLokiError(resp.Body)
+	// server errors are handled by the plugin-proxy to hide the error message
+	if resp.StatusCode/100 == 5 {
+		return RawLokiResponse{}, readLokiError(resp.Body)
 	}
 
 	body, err := io.ReadAll(resp.Body)
@@ -220,12 +228,26 @@ func (api *LokiAPI) RawQuery(ctx context.Context, resourcePath string) (RawLokiR
 		return RawLokiResponse{}, err
 	}
 
-	encodedBytes := RawLokiResponse{
+	// client errors are passed as a json struct to the client
+	if resp.StatusCode/100 != 2 {
+		lokiErr := lokiError{Message: makeLokiError(body).Error()}
+		traceID := tracing.TraceIDFromContext(ctx, false)
+		if traceID != "" {
+			lokiErr.TraceID = traceID
+		}
+		body, err = json.Marshal(lokiErr)
+		if err != nil {
+			return RawLokiResponse{}, err
+		}
+	}
+
+	rawLokiResponse := RawLokiResponse{
 		Body:     body,
+		Status:   resp.StatusCode,
 		Encoding: resp.Header.Get("Content-Encoding"),
 	}
 
-	return encodedBytes, nil
+	return rawLokiResponse, nil
 }
 
 func getSupportingQueryHeaderValue(req *http.Request, supportingQueryType SupportingQueryType) string {

--- a/pkg/tsdb/loki/api.go
+++ b/pkg/tsdb/loki/api.go
@@ -104,7 +104,7 @@ type lokiResponseError struct {
 }
 
 type lokiError struct {
-	Message string 
+	Message string
 }
 
 func makeLokiError(bytes []byte) error {

--- a/pkg/tsdb/loki/api.go
+++ b/pkg/tsdb/loki/api.go
@@ -98,9 +98,13 @@ func makeDataRequest(ctx context.Context, lokiDsUrl string, query lokiQuery) (*h
 	return req, nil
 }
 
-type lokiError struct {
+type lokiResponseError struct {
 	Message string `json:"message"`
 	TraceID string `json:"traceID,omitempty"`
+}
+
+type lokiError struct {
+	Message string 
 }
 
 func makeLokiError(bytes []byte) error {
@@ -228,12 +232,12 @@ func (api *LokiAPI) RawQuery(ctx context.Context, resourcePath string) (RawLokiR
 
 	// client errors are passed as a json struct to the client
 	if resp.StatusCode/100 != 2 {
-		lokiErr := lokiError{Message: makeLokiError(body).Error()}
+		lokiResponseErr := lokiResponseError{Message: makeLokiError(body).Error()}
 		traceID := tracing.TraceIDFromContext(ctx, false)
 		if traceID != "" {
-			lokiErr.TraceID = traceID
+			lokiResponseErr.TraceID = traceID
 		}
-		body, err = json.Marshal(lokiErr)
+		body, err = json.Marshal(lokiResponseErr)
 		if err != nil {
 			return RawLokiResponse{}, err
 		}

--- a/pkg/tsdb/loki/api_test.go
+++ b/pkg/tsdb/loki/api_test.go
@@ -188,4 +188,46 @@ func TestApiReturnValues(t *testing.T) {
 		require.Equal(t, "gzip", encodedBytes.Encoding)
 		require.Equal(t, []byte("foo"), encodedBytes.Body)
 	})
+
+	t.Run("Loki should return the error as message", func(t *testing.T) {
+		called := false
+		api := makeCompressedMockedAPIWithUrl("http://localhost:3100", 400, "application/json", []byte("foo"), func(req *http.Request) {
+			called = true
+		})
+
+		encodedBytes, err := api.RawQuery(context.Background(), "/loki/api/v1/labels?start=1&end=2")
+		require.NoError(t, err)
+		require.True(t, called)
+		require.Equal(t, "gzip", encodedBytes.Encoding)
+		require.Equal(t, []byte("{\"message\":\"foo\"}"), encodedBytes.Body)
+	})
+
+	t.Run("Loki should return the error as is", func(t *testing.T) {
+		called := false
+		api := makeCompressedMockedAPIWithUrl("http://localhost:3100", 400, "application/json", []byte("{\"message\":\"foo\"}"), func(req *http.Request) {
+			called = true
+		})
+
+		encodedBytes, err := api.RawQuery(context.Background(), "/loki/api/v1/labels?start=1&end=2")
+		require.NoError(t, err)
+		require.True(t, called)
+		require.Equal(t, "gzip", encodedBytes.Encoding)
+		require.Equal(t, []byte("{\"message\":\"foo\"}"), encodedBytes.Body)
+	})
+
+	t.Run("Loki should not return the error on 500", func(t *testing.T) {
+		api := makeCompressedMockedAPIWithUrl("http://localhost:3100", 500, "application/json", []byte("foo"), nil)
+
+		_, err := api.RawQuery(context.Background(), "/loki/api/v1/labels?start=1&end=2")
+		require.Error(t, err)
+		require.ErrorContains(t, err, "foo")
+	})
+
+	t.Run("Loki should not return the error on 500 in JSON", func(t *testing.T) {
+		api := makeCompressedMockedAPIWithUrl("http://localhost:3100", 500, "application/json", []byte("{\"message\":\"foo\"}"), nil)
+
+		_, err := api.RawQuery(context.Background(), "/loki/api/v1/labels?start=1&end=2")
+		require.Error(t, err)
+		require.ErrorContains(t, err, "foo")
+	})
 }


### PR DESCRIPTION
**What is this feature?**

This PR improves error handling in Loki's `CallResource` handler. Previously there were no errors surfaced whereas now there should be error popups like this:
![image](https://user-images.githubusercontent.com/8092184/223770579-5a778f67-72b5-4696-a28d-e91efa9ccb8c.png)

**Which issue(s) does this PR fix?**:

Part of #64411

**Special notes for your reviewer**:

How to reproduce it (as minimally and precisely as possible):

1. Run Grafana in development mode
2. Select a Loki datasource
3. Set the timerange to a long range, like 2 years
4. Failed to call resource error appeared

