### PR TITLE
CloudWatch Logs: Queries in an expression should run synchronously

### DIFF
--- a/pkg/expr/nodes.go
+++ b/pkg/expr/nodes.go
@@ -21,6 +21,8 @@ var (
 	logger = log.New("expr")
 )
 
+const FromExpressionHeaderName = "FromExpression"
+
 type QueryError struct {
 	RefID string
 	Err   error
@@ -227,6 +229,7 @@ func (dn *DSNode) Execute(ctx context.Context, now time.Time, _ mathexp.Vars, s 
 		},
 		Headers: dn.request.Headers,
 	}
+	req.Headers[FromExpressionHeaderName] = "true"
 
 	responseType := "unknown"
 	defer func() {

--- a/pkg/tsdb/cloudwatch/cloudwatch.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch.go
@@ -20,6 +20,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend/datasource"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/resource/httpadapter"
+	"github.com/grafana/grafana/pkg/expr"
 	"github.com/grafana/grafana/pkg/infra/httpclient"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -155,7 +156,7 @@ func (e *cloudWatchExecutor) QueryData(ctx context.Context, req *backend.QueryDa
 		to the query, but rather an ID is first returned. Following this, a client is expected to send requests along
 		with the ID until the status of the query is complete, receiving (possibly partial) results each time. For
 		queries made via dashboards and Explore, the logic of making these repeated queries is handled on the
-		frontend, but because alerts are executed on the backend the logic needs to be reimplemented here.
+		frontend, but because alerts and expressions are executed on the backend the logic needs to be reimplemented here.
 	*/
 	q := req.Queries[0]
 	var model DataQueryJson
@@ -163,11 +164,12 @@ func (e *cloudWatchExecutor) QueryData(ctx context.Context, req *backend.QueryDa
 	if err != nil {
 		return nil, err
 	}
-	_, fromAlert := req.Headers[ngalertmodels.FromAlertHeaderName]
-	isLogAlertQuery := fromAlert && model.QueryMode == logsQueryMode
 
-	if isLogAlertQuery {
-		return e.executeLogAlertQuery(ctx, req)
+	_, fromAlert := req.Headers[ngalertmodels.FromAlertHeaderName]
+	_, fromExpression := req.Headers[expr.FromExpressionHeaderName]
+	isSyncLogQuery := (fromAlert || fromExpression) && model.QueryMode == logsQueryMode
+	if isSyncLogQuery {
+		return e.executeSyncLogQuery(ctx, req)
 	}
 
 	var result *backend.QueryDataResponse

--- a/pkg/tsdb/cloudwatch/cloudwatch.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch.go
@@ -169,7 +169,7 @@ func (e *cloudWatchExecutor) QueryData(ctx context.Context, req *backend.QueryDa
 	_, fromExpression := req.Headers[expr.FromExpressionHeaderName]
 	isSyncLogQuery := (fromAlert || fromExpression) && model.QueryMode == logsQueryMode
 	if isSyncLogQuery {
-		return e.executeSyncLogQuery(ctx, req)
+		return executeSyncLogQuery(ctx, e, req)
 	}
 
 	var result *backend.QueryDataResponse

--- a/pkg/tsdb/cloudwatch/cloudwatch_test.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/datasource"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
+	"github.com/grafana/grafana/pkg/expr"
 	"github.com/grafana/grafana/pkg/infra/httpclient"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	ngalertmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
@@ -192,7 +193,7 @@ func Test_CheckHealth(t *testing.T) {
 		}, resp)
 	})
 }
-func Test_executeLogAlertQuery(t *testing.T) {
+func Test_executeSyncLogQuery(t *testing.T) {
 	origNewCWClient := NewCWClient
 	t.Cleanup(func() {
 		NewCWClient = origNewCWClient
@@ -253,6 +254,70 @@ func Test_executeLogAlertQuery(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.Equal(t, []string{"instance manager's region"}, sess.calledRegions)
+	})
+
+	t.Run("with header", func(t *testing.T) {
+		testcases := []struct {
+			name    string
+			headers map[string]string
+			called  bool
+		}{
+			{
+				"alert header",
+				map[string]string{ngalertmodels.FromAlertHeaderName: "some value"},
+				true,
+			},
+			{
+				"expression header",
+				map[string]string{expr.FromExpressionHeaderName: "some value"},
+				true,
+			},
+			{
+				"no header",
+				map[string]string{},
+				false,
+			},
+		}
+		origExecuteSyncLogQuery := executeSyncLogQuery
+		var syncCalled bool
+		executeSyncLogQuery = func(ctx context.Context, e *cloudWatchExecutor, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+			syncCalled = true
+			return nil, nil
+		}
+
+		for _, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+				syncCalled = false
+				cli = fakeCWLogsClient{queryResults: cloudwatchlogs.GetQueryResultsOutput{Status: aws.String("Complete")}}
+				im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
+					return DataSource{Settings: models.CloudWatchSettings{AWSDatasourceSettings: awsds.AWSDatasourceSettings{Region: "instance manager's region"}}}, nil
+				})
+				sess := fakeSessionCache{}
+
+				executor := newExecutor(im, newTestConfig(), &sess, featuremgmt.WithFeatures())
+				_, err := executor.QueryData(context.Background(), &backend.QueryDataRequest{
+					Headers:       tc.headers,
+					PluginContext: backend.PluginContext{DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{}},
+					Queries: []backend.DataQuery{
+						{
+							TimeRange: backend.TimeRange{From: time.Unix(0, 0), To: time.Unix(1, 0)},
+							JSON: json.RawMessage(`{
+								"queryMode":    "Logs",
+								"type":        "logAction",
+								"subtype":     "StartQuery",
+								"region":      "default",
+								"queryString": "fields @message"
+							}`),
+						},
+					},
+				})
+
+				assert.NoError(t, err)
+				assert.Equal(t, tc.called, syncCalled)
+			})
+		}
+
+		executeSyncLogQuery = origExecuteSyncLogQuery
 	})
 }
 

--- a/pkg/tsdb/cloudwatch/log_alert.go
+++ b/pkg/tsdb/cloudwatch/log_alert.go
@@ -18,7 +18,7 @@ const (
 	alertPollPeriod  = time.Second
 )
 
-func (e *cloudWatchExecutor) executeLogAlertQuery(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+func (e *cloudWatchExecutor) executeSyncLogQuery(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
 	resp := backend.NewQueryDataResponse()
 
 	for _, q := range req.Queries {

--- a/pkg/tsdb/cloudwatch/log_sync_query.go
+++ b/pkg/tsdb/cloudwatch/log_sync_query.go
@@ -18,7 +18,7 @@ const (
 	alertPollPeriod  = time.Second
 )
 
-func (e *cloudWatchExecutor) executeSyncLogQuery(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+var executeSyncLogQuery = func(ctx context.Context, e *cloudWatchExecutor, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
 	resp := backend.NewQueryDataResponse()
 
 	for _, q := range req.Queries {
@@ -45,7 +45,7 @@ func (e *cloudWatchExecutor) executeSyncLogQuery(ctx context.Context, req *backe
 			return nil, err
 		}
 
-		getQueryResultsOutput, err := e.alertQuery(ctx, logsClient, q, logsQuery)
+		getQueryResultsOutput, err := e.syncQuery(ctx, logsClient, q, logsQuery)
 		if err != nil {
 			return nil, err
 		}
@@ -73,7 +73,7 @@ func (e *cloudWatchExecutor) executeSyncLogQuery(ctx context.Context, req *backe
 	return resp, nil
 }
 
-func (e *cloudWatchExecutor) alertQuery(ctx context.Context, logsClient cloudwatchlogsiface.CloudWatchLogsAPI,
+func (e *cloudWatchExecutor) syncQuery(ctx context.Context, logsClient cloudwatchlogsiface.CloudWatchLogsAPI,
 	queryContext backend.DataQuery, logsQuery models.LogsQuery) (*cloudwatchlogs.GetQueryResultsOutput, error) {
 	startQueryOutput, err := e.executeStartQuery(ctx, logsClient, logsQuery, queryContext.TimeRange)
 	if err != nil {


### PR DESCRIPTION
Cloudwatch Logs queries are generally run asynchronously in parts that are managed by the frontend (the frontend sends separate requests to start the query and then to poll for results). However, when a expression is used, it expects the query results to be returned from the first request. This pr adds a flag to the expression query that signals to the cloudwatch datasource that it should run the entire query synchronously in the backend and return the results (which we already handle for alerting).

The fixed bug can be reproed in the external dev as below:
![Screenshot 2023-03-09 at 2 29 38 PM](https://user-images.githubusercontent.com/5421859/224133839-e096a435-1d9c-4864-b9db-d12087f5e5fb.png)

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #63735 

**Special notes for your reviewer**:
Note that this doesn't solve the separate "wide format" multiple time series issue https://github.com/grafana/grafana/issues/63388, that will still require changing how we create data frames.
Also I suspect that this may be an issue in async redshift/athena.
