### PR TITLE
Plugins: Fix bug with copying grafanaData

### DIFF
--- a/pkg/services/datasources/service/datasource.go
+++ b/pkg/services/datasources/service/datasource.go
@@ -424,10 +424,11 @@ func (s *Service) httpClientOptions(ctx context.Context, ds *datasources.DataSou
 	if ds.JsonData != nil {
 		opts.CustomOptions = ds.JsonData.MustMap()
 		// allow the plugin sdk to get the json data in JSONDataFromHTTPClientOptions
-		opts.CustomOptions["grafanaData"] = make(map[string]interface{})
+		copiedMap := make(map[string]interface{})
 		for k, v := range opts.CustomOptions {
-			opts.CustomOptions[k] = v
+			copiedMap[k] = v
 		}
+		opts.CustomOptions["grafanaData"] = copiedMap
 	}
 	if ds.BasicAuth {
 		password, err := s.DecryptedBasicAuthPassword(ctx, ds)

--- a/pkg/services/datasources/service/datasource.go
+++ b/pkg/services/datasources/service/datasource.go
@@ -424,7 +424,7 @@ func (s *Service) httpClientOptions(ctx context.Context, ds *datasources.DataSou
 	if ds.JsonData != nil {
 		opts.CustomOptions = ds.JsonData.MustMap()
 		// allow the plugin sdk to get the json data in JSONDataFromHTTPClientOptions
-		deepJsonDataCopy := make(map[string]interface{})
+		deepJsonDataCopy := make(map[string]interface{}, len(opts.CustomOptions))
 		for k, v := range opts.CustomOptions {
 			deepJsonDataCopy[k] = v
 		}

--- a/pkg/services/datasources/service/datasource.go
+++ b/pkg/services/datasources/service/datasource.go
@@ -424,11 +424,11 @@ func (s *Service) httpClientOptions(ctx context.Context, ds *datasources.DataSou
 	if ds.JsonData != nil {
 		opts.CustomOptions = ds.JsonData.MustMap()
 		// allow the plugin sdk to get the json data in JSONDataFromHTTPClientOptions
-		copiedMap := make(map[string]interface{})
+		deepJsonDataCopy := make(map[string]interface{})
 		for k, v := range opts.CustomOptions {
-			copiedMap[k] = v
+			deepJsonDataCopy[k] = v
 		}
-		opts.CustomOptions["grafanaData"] = copiedMap
+		opts.CustomOptions["grafanaData"] = deepJsonDataCopy
 	}
 	if ds.BasicAuth {
 		password, err := s.DecryptedBasicAuthPassword(ctx, ds)

--- a/pkg/services/datasources/service/datasource_test.go
+++ b/pkg/services/datasources/service/datasource_test.go
@@ -427,6 +427,10 @@ func TestService_GetHttpTransport(t *testing.T) {
 		require.NotNil(t, rt)
 		tr := configuredTransport
 
+		opts, err := dsService.httpClientOptions(context.Background(), &ds)
+		require.NoError(t, err)
+		require.Equal(t, ds.JsonData.MustMap()["grafanaData"], opts.CustomOptions["grafanaData"])
+
 		// make sure we can still marshal the JsonData after httpClientOptions (avoid cycles)
 		_, err = ds.JsonData.MarshalJSON()
 		require.NoError(t, err)


### PR DESCRIPTION
**What is this feature?**

In [this PR](https://github.com/grafana/grafana/pull/61729), functionality was added to enable the plugin sdk to get the json data for all datasources. However, that had a bug in it, that was fixed in [this PR](https://github.com/grafana/grafana/pull/62328). When this bug was fixed, the original functionality was broken. The `grafanaData` is initialized as a map, but then that map isn't used when [setting the values](https://github.com/grafana/grafana/pull/62328/files#diff-e75b2165866a30555409a61945b14cb5ab7b8270b5b4db8b45759a0e606014e4R422) (instead we are overwriting what is done in [this line](https://github.com/grafana/grafana/pull/62328/files#diff-e75b2165866a30555409a61945b14cb5ab7b8270b5b4db8b45759a0e606014e4L418)).

This PR re-introduces the original functionality, while keeping the bug fix.