### PR TITLE
Chore: feature toggle ownership for aws plugins, observability metrics squad and backend platform

### DIFF
--- a/pkg/services/featuremgmt/codeowners.go
+++ b/pkg/services/featuremgmt/codeowners.go
@@ -17,6 +17,8 @@ const (
 	grafanaAuthnzSquad                          codeowner = "@grafana/grafana-authnz-team"
 	grafanaObservabilityLogsSquad               codeowner = "@grafana/observability-logs"
 	grafanaObservabilityTracesAndProfilingSquad codeowner = "@grafana/observability-traces-and-profiling"
+	grafanaObservabilityMetricsSquad            codeowner = "@grafana/observability-metrics"
 	grafanaAlertingSquad                        codeowner = "@grafana/alerting-squad"
 	hostedGrafanaTeam                           codeowner = "@grafana/hosted-grafana-team"
+	awsPluginsSquad                             codeowner = "@grafana/aws-plugins"
 )

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -170,6 +170,7 @@ var (
 			Description: "Use dynamic labels instead of alias patterns in CloudWatch datasource",
 			State:       FeatureStateStable,
 			Expression:  "true", // enabled by default
+			Owner:       awsPluginsSquad,
 		},
 		{
 			Name:        "datasourceQueryMultiStatus",
@@ -208,7 +209,7 @@ var (
 			Name:        "prometheusWideSeries",
 			Description: "Enable wide series responses in the Prometheus datasource",
 			State:       FeatureStateAlpha,
-			Owner:       "O11y-metrics",
+			Owner:       grafanaObservabilityMetricsSquad,
 		},
 		{
 			Name:         "canvasPanelNesting",
@@ -275,18 +276,21 @@ var (
 			Description: "Enables cross-account querying in CloudWatch datasources",
 			State:       FeatureStateStable,
 			Expression:  "true", //enabled by default
+			Owner:       awsPluginsSquad,
 		},
 		{
 			Name:         "redshiftAsyncQueryDataSupport",
 			Description:  "Enable async query data support for Redshift",
 			State:        FeatureStateAlpha,
 			FrontendOnly: true,
+			Owner:        awsPluginsSquad,
 		},
 		{
 			Name:         "athenaAsyncQueryDataSupport",
 			Description:  "Enable async query data support for Athena",
 			State:        FeatureStateAlpha,
 			FrontendOnly: true,
+			Owner:        awsPluginsSquad,
 		},
 		{
 			Name:         "newPanelChromeUI",
@@ -358,7 +362,7 @@ var (
 			Name:        "disablePrometheusExemplarSampling",
 			Description: "Disable Prometheus examplar sampling",
 			State:       FeatureStateStable,
-			Owner:       "O11y-metrics",
+			Owner:       grafanaObservabilityMetricsSquad,
 		},
 		{
 			Name:        "alertingBacktesting",
@@ -407,6 +411,7 @@ var (
 			Name:        "individualCookiePreferences",
 			Description: "Support overriding cookie preferences per user",
 			State:       FeatureStateAlpha,
+			Owner:       grafanaBackendPlatformSquad,
 		},
 		{
 			Name:         "drawerDataSourcePicker",
@@ -427,7 +432,7 @@ var (
 			Description:  "Replaces the Prometheus query builder metric select option with a paginated and filterable component",
 			State:        FeatureStateAlpha,
 			FrontendOnly: true,
-			Owner:        "O11y-metrics",
+			Owner:        grafanaObservabilityMetricsSquad,
 		},
 	}
 )

--- a/pkg/services/featuremgmt/toggles_gen_test.go
+++ b/pkg/services/featuremgmt/toggles_gen_test.go
@@ -44,14 +44,9 @@ func TestFeatureToggleFiles(t *testing.T) {
 	ownerlessFeatures := map[string]bool{
 		"prometheusAzureOverrideAudience": true,
 		"tracing":                         true,
-		"cloudWatchDynamicLabels":         true,
-		"cloudWatchCrossAccountQuerying":  true,
-		"redshiftAsyncQueryDataSupport":   true,
-		"athenaAsyncQueryDataSupport":     true,
 		"newPanelChromeUI":                true,
 		"showDashboardValidationWarnings": true,
 		"datasourceOnboarding":            true,
-		"individualCookiePreferences":     true,
 	}
 
 	t.Run("all new features should have an owner", func(t *testing.T) {


### PR DESCRIPTION
AWS:
- cloudWatchDynamicLabels introduced in https://github.com/grafana/grafana/pull/48498
- redshiftAsyncQueryDataSupport introduced in https://github.com/grafana/grafana/pull/54349
- athenaAsyncQueryDataSupport introduced in https://github.com/grafana/grafana/pull/54349
- cloudWatchCrossAccountQuerying introduced in https://github.com/grafana/grafana/pull/59362

Backend platform:
- individualCookiePreferences introduced in https://github.com/grafana/grafana/pull/61566