### PR TITLE
Docs: Update canvas panel data links section with additional steps 

### DIFF
--- a/docs/sources/panels-visualizations/visualizations/canvas/index.md
+++ b/docs/sources/panels-visualizations/visualizations/canvas/index.md
@@ -88,14 +88,13 @@ Canvas supports [data links](https://grafana.com/docs/grafana/latest/panels-visu
 
 1. Set an element to be tied to a field value.
 1. Turn off the inline editing toggle.
-1  Create an override for **Fields with name** and select the element field name from the list.
+1. Create an override for **Fields with name** and select the element field name from the list.
 1. Click the **+ Add override property** button.
 1. Select `Datalinks > Datalinks` from the list.
 1. Click **+Add link** add a title and URL for the data link.
 1. Hover over the element to display the data link tooltip.
 1. Click on the element to be able to open the data link.
 
-If multiple elements use the same field, you can create a unique field name using the [add field from calculation transform](https://grafana.com/docs/grafana/latest/panels-visualizations/query-transform-data/transform-data/#add-field-from-calculation). The alias you create in the transformation will appear as a field you can use with an element. 
-
+If multiple elements use the same field, you can create a unique field name using the [add field from calculation transform](https://grafana.com/docs/grafana/latest/panels-visualizations/query-transform-data/transform-data/#add-field-from-calculation). The alias you create in the transformation will appear as a field you can use with an element.
 
 {{< video-embed src="/media/docs/grafana/canvas-data-links-9-4-0.mp4" max-width="750px" caption="Data links demo" >}}

--- a/docs/sources/panels-visualizations/visualizations/canvas/index.md
+++ b/docs/sources/panels-visualizations/visualizations/canvas/index.md
@@ -84,11 +84,18 @@ The inline editing toggle enables you to lock or unlock the canvas panel. When t
 
 ### Data links
 
-Canvas supports [data links](https://grafana.com/docs/grafana/latest/panels-visualizations/configure-data-links/). Once you've added a data link to the panel, you can display it by following these steps:
+Canvas supports [data links](https://grafana.com/docs/grafana/latest/panels-visualizations/configure-data-links/). You can create a data link for a metric-value element and display it by following these steps:
 
 1. Set an element to be tied to a field value.
 1. Turn off the inline editing toggle.
+1  Create an override for **Fields with name** and select the element field name from the list.
+1. Click the **+ Add override property** button.
+1. Select `Datalinks > Datalinks` from the list.
+1. Click **+Add link** add a title and URL for the data link.
 1. Hover over the element to display the data link tooltip.
 1. Click on the element to be able to open the data link.
+
+If multiple elements use the same field, you can create a unique field name using the [add field from calculation transform](https://grafana.com/docs/grafana/latest/panels-visualizations/query-transform-data/transform-data/#add-field-from-calculation). The alias you create in the transformation will appear as a field you can use with an element. 
+
 
 {{< video-embed src="/media/docs/grafana/canvas-data-links-9-4-0.mp4" max-width="750px" caption="Data links demo" >}}


### PR DESCRIPTION
Add additional steps to the Data Links section needed to associate a field value with a data link. A dashboard data link (previously referenced) displays for all elements.

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Doc update 

**Why do we need this feature?**

The previous steps created a dashboard datalink that will display on all field/text elements


**Special notes for your reviewer**:

Researched this answering community post: https://community.grafana.com/t/clickable-links-in-canvas-panel-elements/82254

Tested on this demo dashboard: 

https://play.grafana.org/d/canvas-examples/panel-tests-canvas-examples?orgId=1&from=1678219129599&to=1678240729599

