### PR TITLE
Chore: move `sessionId` from Live service

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -3674,10 +3674,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
     ],
-    "public/app/features/live/dashboard/dashboardWatcher.ts:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
-    ],
     "public/app/features/live/index.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],

--- a/.betterer.results
+++ b/.betterer.results
@@ -1,5 +1,5 @@
 // BETTERER RESULTS V2.
-//
+// 
 // If this file contains merge conflicts, use `betterer merge` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //
@@ -3674,10 +3674,12 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
     ],
-    "public/app/features/live/index.ts:5381": [
+    "public/app/features/live/dashboard/dashboardWatcher.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
-      [0, 0, 0, "Do not use any type assertions.", "2"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
+    ],
+    "public/app/features/live/index.ts:5381": [
+      [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
     "public/app/features/live/pages/AddNewRule.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]

--- a/public/app/features/live/centrifuge/service.ts
+++ b/public/app/features/live/centrifuge/service.ts
@@ -29,7 +29,6 @@ export type CentrifugeSrvDeps = {
   appUrl: string;
   orgId: number;
   orgRole: string;
-  sessionId: string;
   liveEnabled: boolean;
   dataStreamSubscriberReadiness: Observable<boolean>;
 };

--- a/public/app/features/live/dashboard/dashboardWatcher.ts
+++ b/public/app/features/live/dashboard/dashboardWatcher.ts
@@ -18,7 +18,8 @@ import { getDashboardSrv } from '../../dashboard/services/DashboardSrv';
 import { DashboardChangedModal } from './DashboardChangedModal';
 import { DashboardEvent, DashboardEventAction } from './types';
 
-// sessionId is used for filtering out events from the same session
+// sessionId is not a security-sensitive value.
+// It is used for filtering out dashboard edit events from the same browsing session
 const sessionId =
   (window as any)?.grafanaBootData?.user?.id +
   '/' +

--- a/public/app/features/live/dashboard/dashboardWatcher.ts
+++ b/public/app/features/live/dashboard/dashboardWatcher.ts
@@ -11,13 +11,20 @@ import {
 } from '@grafana/data';
 import { getGrafanaLiveSrv, locationService } from '@grafana/runtime';
 import { appEvents, contextSrv } from 'app/core/core';
-import { sessionId } from 'app/features/live';
 
 import { ShowModalReactEvent } from '../../../types/events';
 import { getDashboardSrv } from '../../dashboard/services/DashboardSrv';
 
 import { DashboardChangedModal } from './DashboardChangedModal';
 import { DashboardEvent, DashboardEventAction } from './types';
+
+// sessionId is used for filtering out events from the same session
+const sessionId =
+  (window as any)?.grafanaBootData?.user?.id +
+  '/' +
+  Date.now().toString(16) +
+  '/' +
+  Math.random().toString(36).substring(2, 15);
 
 class DashboardWatcher {
   channel?: LiveChannelAddress; // path to the channel

--- a/public/app/features/live/dashboard/dashboardWatcher.ts
+++ b/public/app/features/live/dashboard/dashboardWatcher.ts
@@ -1,4 +1,5 @@
 import { Unsubscribable } from 'rxjs';
+import { v4 as uuidv4 } from 'uuid';
 
 import {
   AppEvents,
@@ -20,12 +21,7 @@ import { DashboardEvent, DashboardEventAction } from './types';
 
 // sessionId is not a security-sensitive value.
 // It is used for filtering out dashboard edit events from the same browsing session
-const sessionId =
-  (window as any)?.grafanaBootData?.user?.id +
-  '/' +
-  Date.now().toString(16) +
-  '/' +
-  Math.random().toString(36).substring(2, 15);
+const sessionId = uuidv4();
 
 class DashboardWatcher {
   channel?: LiveChannelAddress; // path to the channel

--- a/public/app/features/live/index.ts
+++ b/public/app/features/live/index.ts
@@ -8,20 +8,12 @@ import { CentrifugeService } from './centrifuge/service';
 import { CentrifugeServiceWorkerProxy } from './centrifuge/serviceWorkerProxy';
 import { GrafanaLiveService } from './live';
 
-export const sessionId =
-  (window as any)?.grafanaBootData?.user?.id +
-  '/' +
-  Date.now().toString(16) +
-  '/' +
-  Math.random().toString(36).substring(2, 15);
-
 export function initGrafanaLive() {
   const centrifugeServiceDeps = {
     appUrl: `${window.location.origin}${config.appSubUrl}`,
     orgId: contextSrv.user.orgId,
     orgRole: contextSrv.user.orgRole,
     liveEnabled: config.liveEnabled,
-    sessionId,
     dataStreamSubscriberReadiness: liveTimer.ok.asObservable(),
     grafanaAuthToken: loadUrlToken(),
   };


### PR DESCRIPTION
This PR:
- moves `sessionId` to `dashboardWatcher.ts` as it was used only in that file
- adds comment explaining how do we use `sessionId`, and that its not a security-sensitive value (related codeQL https://github.com/grafana/grafana/security/code-scanning/250)