### PR TITLE
Remotecache: rename setbytearray/getbytearray to set/get and remove codec

### DIFF
--- a/pkg/infra/remotecache/database_storage.go
+++ b/pkg/infra/remotecache/database_storage.go
@@ -14,14 +14,12 @@ const databaseCacheType = "database"
 
 type databaseCache struct {
 	SQLStore db.DB
-	codec    codec
 	log      log.Logger
 }
 
-func newDatabaseCache(sqlstore db.DB, codec codec) *databaseCache {
+func newDatabaseCache(sqlstore db.DB) *databaseCache {
 	dc := &databaseCache{
 		SQLStore: sqlstore,
-		codec:    codec,
 		log:      log.New("remotecache.database"),
 	}
 
@@ -54,7 +52,7 @@ func (dc *databaseCache) internalRunGC() {
 	}
 }
 
-func (dc *databaseCache) GetByteArray(ctx context.Context, key string) ([]byte, error) {
+func (dc *databaseCache) Get(ctx context.Context, key string) ([]byte, error) {
 	cacheHit := CacheData{}
 
 	err := dc.SQLStore.WithDbSession(ctx, func(session *db.Session) error {
@@ -85,7 +83,7 @@ func (dc *databaseCache) GetByteArray(ctx context.Context, key string) ([]byte, 
 	return cacheHit.Data, err
 }
 
-func (dc *databaseCache) SetByteArray(ctx context.Context, key string, data []byte, expire time.Duration) error {
+func (dc *databaseCache) Set(ctx context.Context, key string, data []byte, expire time.Duration) error {
 	return dc.SQLStore.WithDbSession(ctx, func(session *db.Session) error {
 		var expiresInSeconds int64
 		if expire != 0 {

--- a/pkg/infra/remotecache/database_storage.go
+++ b/pkg/infra/remotecache/database_storage.go
@@ -85,20 +85,6 @@ func (dc *databaseCache) GetByteArray(ctx context.Context, key string) ([]byte, 
 	return cacheHit.Data, err
 }
 
-func (dc *databaseCache) Get(ctx context.Context, key string) (interface{}, error) {
-	bytes, err := dc.GetByteArray(ctx, key)
-	if err != nil {
-		return nil, err
-	}
-
-	item := &cachedItem{}
-	if err = dc.codec.Decode(ctx, bytes, item); err != nil {
-		return nil, err
-	}
-
-	return item.Val, err
-}
-
 func (dc *databaseCache) SetByteArray(ctx context.Context, key string, data []byte, expire time.Duration) error {
 	return dc.SQLStore.WithDbSession(ctx, func(session *db.Session) error {
 		var expiresInSeconds int64
@@ -127,16 +113,6 @@ func (dc *databaseCache) SetByteArray(ctx context.Context, key string, data []by
 
 		return err
 	})
-}
-
-func (dc *databaseCache) Set(ctx context.Context, key string, value interface{}, expire time.Duration) error {
-	item := &cachedItem{Val: value}
-	data, err := dc.codec.Encode(ctx, item)
-	if err != nil {
-		return err
-	}
-
-	return dc.SetByteArray(ctx, key, data, expire)
 }
 
 func (dc *databaseCache) Delete(ctx context.Context, key string) error {

--- a/pkg/infra/remotecache/database_storage_test.go
+++ b/pkg/infra/remotecache/database_storage_test.go
@@ -17,7 +17,6 @@ func TestDatabaseStorageGarbageCollection(t *testing.T) {
 
 	db := &databaseCache{
 		SQLStore: sqlstore,
-		codec:    &gobCodec{},
 		log:      log.New("remotecache.database"),
 	}
 
@@ -26,37 +25,37 @@ func TestDatabaseStorageGarbageCollection(t *testing.T) {
 	// set time.now to 2 weeks ago
 	var err error
 	getTime = func() time.Time { return time.Now().AddDate(0, 0, -2) }
-	err = db.SetByteArray(context.Background(), "key1", obj, 1000*time.Second)
+	err = db.Set(context.Background(), "key1", obj, 1000*time.Second)
 	assert.Equal(t, err, nil)
 
-	err = db.SetByteArray(context.Background(), "key2", obj, 1000*time.Second)
+	err = db.Set(context.Background(), "key2", obj, 1000*time.Second)
 	assert.Equal(t, err, nil)
 
-	err = db.SetByteArray(context.Background(), "key3", obj, 1000*time.Second)
+	err = db.Set(context.Background(), "key3", obj, 1000*time.Second)
 	assert.Equal(t, err, nil)
 
 	// insert object that should never expire
-	err = db.SetByteArray(context.Background(), "key4", obj, 0)
+	err = db.Set(context.Background(), "key4", obj, 0)
 	assert.Equal(t, err, nil)
 
 	getTime = time.Now
-	err = db.SetByteArray(context.Background(), "key5", obj, 1000*time.Second)
+	err = db.Set(context.Background(), "key5", obj, 1000*time.Second)
 	assert.Equal(t, err, nil)
 
 	// run GC
 	db.internalRunGC()
 
 	// try to read values
-	_, err = db.GetByteArray(context.Background(), "key1")
+	_, err = db.Get(context.Background(), "key1")
 	assert.Equal(t, err, ErrCacheItemNotFound, "expected cache item not found. got: ", err)
-	_, err = db.GetByteArray(context.Background(), "key2")
+	_, err = db.Get(context.Background(), "key2")
 	assert.Equal(t, err, ErrCacheItemNotFound)
-	_, err = db.GetByteArray(context.Background(), "key3")
+	_, err = db.Get(context.Background(), "key3")
 	assert.Equal(t, err, ErrCacheItemNotFound)
 
-	_, err = db.GetByteArray(context.Background(), "key4")
+	_, err = db.Get(context.Background(), "key4")
 	assert.Equal(t, err, nil)
-	_, err = db.GetByteArray(context.Background(), "key5")
+	_, err = db.Get(context.Background(), "key5")
 	assert.Equal(t, err, nil)
 }
 
@@ -66,16 +65,15 @@ func TestSecondSet(t *testing.T) {
 
 	db := &databaseCache{
 		SQLStore: sqlstore,
-		codec:    &gobCodec{},
 		log:      log.New("remotecache.database"),
 	}
 
 	obj := []byte("hey!")
 
-	err = db.SetByteArray(context.Background(), "killa-gorilla", obj, 0)
+	err = db.Set(context.Background(), "killa-gorilla", obj, 0)
 	assert.Equal(t, err, nil)
 
-	err = db.SetByteArray(context.Background(), "killa-gorilla", obj, 0)
+	err = db.Set(context.Background(), "killa-gorilla", obj, 0)
 	assert.Equal(t, err, nil)
 }
 
@@ -84,7 +82,6 @@ func TestDatabaseStorageCount(t *testing.T) {
 
 	db := &databaseCache{
 		SQLStore: sqlstore,
-		codec:    &gobCodec{},
 		log:      log.New("remotecache.database"),
 	}
 
@@ -93,21 +90,21 @@ func TestDatabaseStorageCount(t *testing.T) {
 	// set time.now to 2 weeks ago
 	var err error
 	getTime = func() time.Time { return time.Now().AddDate(0, 0, -2) }
-	err = db.SetByteArray(context.Background(), "pref-key1", obj, 1000*time.Second)
+	err = db.Set(context.Background(), "pref-key1", obj, 1000*time.Second)
 	require.NoError(t, err)
 
-	err = db.SetByteArray(context.Background(), "pref-key2", obj, 1000*time.Second)
+	err = db.Set(context.Background(), "pref-key2", obj, 1000*time.Second)
 	require.NoError(t, err)
 
-	err = db.SetByteArray(context.Background(), "pref-key3", obj, 1000*time.Second)
+	err = db.Set(context.Background(), "pref-key3", obj, 1000*time.Second)
 	require.NoError(t, err)
 
 	// insert object that should never expire
-	err = db.SetByteArray(context.Background(), "pref-key4", obj, 0)
+	err = db.Set(context.Background(), "pref-key4", obj, 0)
 	require.NoError(t, err)
 
 	getTime = time.Now
-	err = db.SetByteArray(context.Background(), "pref-key5", obj, 1000*time.Second)
+	err = db.Set(context.Background(), "pref-key5", obj, 1000*time.Second)
 	require.NoError(t, err)
 
 	// run GC

--- a/pkg/infra/remotecache/database_storage_test.go
+++ b/pkg/infra/remotecache/database_storage_test.go
@@ -21,42 +21,42 @@ func TestDatabaseStorageGarbageCollection(t *testing.T) {
 		log:      log.New("remotecache.database"),
 	}
 
-	obj := &CacheableStruct{String: "foolbar"}
+	obj := []byte("foolbar")
 
 	// set time.now to 2 weeks ago
 	var err error
 	getTime = func() time.Time { return time.Now().AddDate(0, 0, -2) }
-	err = db.Set(context.Background(), "key1", obj, 1000*time.Second)
+	err = db.SetByteArray(context.Background(), "key1", obj, 1000*time.Second)
 	assert.Equal(t, err, nil)
 
-	err = db.Set(context.Background(), "key2", obj, 1000*time.Second)
+	err = db.SetByteArray(context.Background(), "key2", obj, 1000*time.Second)
 	assert.Equal(t, err, nil)
 
-	err = db.Set(context.Background(), "key3", obj, 1000*time.Second)
+	err = db.SetByteArray(context.Background(), "key3", obj, 1000*time.Second)
 	assert.Equal(t, err, nil)
 
 	// insert object that should never expire
-	err = db.Set(context.Background(), "key4", obj, 0)
+	err = db.SetByteArray(context.Background(), "key4", obj, 0)
 	assert.Equal(t, err, nil)
 
 	getTime = time.Now
-	err = db.Set(context.Background(), "key5", obj, 1000*time.Second)
+	err = db.SetByteArray(context.Background(), "key5", obj, 1000*time.Second)
 	assert.Equal(t, err, nil)
 
 	// run GC
 	db.internalRunGC()
 
 	// try to read values
-	_, err = db.Get(context.Background(), "key1")
+	_, err = db.GetByteArray(context.Background(), "key1")
 	assert.Equal(t, err, ErrCacheItemNotFound, "expected cache item not found. got: ", err)
-	_, err = db.Get(context.Background(), "key2")
+	_, err = db.GetByteArray(context.Background(), "key2")
 	assert.Equal(t, err, ErrCacheItemNotFound)
-	_, err = db.Get(context.Background(), "key3")
+	_, err = db.GetByteArray(context.Background(), "key3")
 	assert.Equal(t, err, ErrCacheItemNotFound)
 
-	_, err = db.Get(context.Background(), "key4")
+	_, err = db.GetByteArray(context.Background(), "key4")
 	assert.Equal(t, err, nil)
-	_, err = db.Get(context.Background(), "key5")
+	_, err = db.GetByteArray(context.Background(), "key5")
 	assert.Equal(t, err, nil)
 }
 
@@ -70,12 +70,12 @@ func TestSecondSet(t *testing.T) {
 		log:      log.New("remotecache.database"),
 	}
 
-	obj := &CacheableStruct{String: "hey!"}
+	obj := []byte("hey!")
 
-	err = db.Set(context.Background(), "killa-gorilla", obj, 0)
+	err = db.SetByteArray(context.Background(), "killa-gorilla", obj, 0)
 	assert.Equal(t, err, nil)
 
-	err = db.Set(context.Background(), "killa-gorilla", obj, 0)
+	err = db.SetByteArray(context.Background(), "killa-gorilla", obj, 0)
 	assert.Equal(t, err, nil)
 }
 
@@ -88,26 +88,26 @@ func TestDatabaseStorageCount(t *testing.T) {
 		log:      log.New("remotecache.database"),
 	}
 
-	obj := &CacheableStruct{String: "foolbar"}
+	obj := []byte("foolbar")
 
 	// set time.now to 2 weeks ago
 	var err error
 	getTime = func() time.Time { return time.Now().AddDate(0, 0, -2) }
-	err = db.Set(context.Background(), "pref-key1", obj, 1000*time.Second)
+	err = db.SetByteArray(context.Background(), "pref-key1", obj, 1000*time.Second)
 	require.NoError(t, err)
 
-	err = db.Set(context.Background(), "pref-key2", obj, 1000*time.Second)
+	err = db.SetByteArray(context.Background(), "pref-key2", obj, 1000*time.Second)
 	require.NoError(t, err)
 
-	err = db.Set(context.Background(), "pref-key3", obj, 1000*time.Second)
+	err = db.SetByteArray(context.Background(), "pref-key3", obj, 1000*time.Second)
 	require.NoError(t, err)
 
 	// insert object that should never expire
-	err = db.Set(context.Background(), "pref-key4", obj, 0)
+	err = db.SetByteArray(context.Background(), "pref-key4", obj, 0)
 	require.NoError(t, err)
 
 	getTime = time.Now
-	err = db.Set(context.Background(), "pref-key5", obj, 1000*time.Second)
+	err = db.SetByteArray(context.Background(), "pref-key5", obj, 1000*time.Second)
 	require.NoError(t, err)
 
 	// run GC

--- a/pkg/infra/remotecache/memcached_storage.go
+++ b/pkg/infra/remotecache/memcached_storage.go
@@ -15,14 +15,12 @@ const memcachedCacheType = "memcached"
 var ErrNotImplemented = errors.New("not implemented")
 
 type memcachedStorage struct {
-	c     *memcache.Client
-	codec codec
+	c *memcache.Client
 }
 
-func newMemcachedStorage(opts *setting.RemoteCacheOptions, codec codec) *memcachedStorage {
+func newMemcachedStorage(opts *setting.RemoteCacheOptions) *memcachedStorage {
 	return &memcachedStorage{
-		c:     memcache.New(opts.ConnStr),
-		codec: codec,
+		c: memcache.New(opts.ConnStr),
 	}
 }
 
@@ -35,7 +33,7 @@ func newItem(sid string, data []byte, expire int32) *memcache.Item {
 }
 
 // SetByteArray stores an byte array in the cache
-func (s *memcachedStorage) SetByteArray(ctx context.Context, key string, data []byte, expires time.Duration) error {
+func (s *memcachedStorage) Set(ctx context.Context, key string, data []byte, expires time.Duration) error {
 	var expiresInSeconds int64
 	if expires != 0 {
 		expiresInSeconds = int64(expires) / int64(time.Second)
@@ -46,7 +44,7 @@ func (s *memcachedStorage) SetByteArray(ctx context.Context, key string, data []
 }
 
 // GetByteArray returns the cached value as an byte array
-func (s *memcachedStorage) GetByteArray(ctx context.Context, key string) ([]byte, error) {
+func (s *memcachedStorage) Get(ctx context.Context, key string) ([]byte, error) {
 	memcachedItem, err := s.c.Get(key)
 	if errors.Is(err, memcache.ErrCacheMiss) {
 		return nil, ErrCacheItemNotFound

--- a/pkg/infra/remotecache/memcached_storage.go
+++ b/pkg/infra/remotecache/memcached_storage.go
@@ -34,17 +34,6 @@ func newItem(sid string, data []byte, expire int32) *memcache.Item {
 	}
 }
 
-// Set sets value to given key in the cache.
-func (s *memcachedStorage) Set(ctx context.Context, key string, val interface{}, expires time.Duration) error {
-	item := &cachedItem{Val: val}
-	bytes, err := s.codec.Encode(ctx, item)
-	if err != nil {
-		return err
-	}
-
-	return s.SetByteArray(ctx, key, bytes, expires)
-}
-
 // SetByteArray stores an byte array in the cache
 func (s *memcachedStorage) SetByteArray(ctx context.Context, key string, data []byte, expires time.Duration) error {
 	var expiresInSeconds int64
@@ -54,22 +43,6 @@ func (s *memcachedStorage) SetByteArray(ctx context.Context, key string, data []
 
 	memcachedItem := newItem(key, data, int32(expiresInSeconds))
 	return s.c.Set(memcachedItem)
-}
-
-// Get gets value by given key in the cache.
-func (s *memcachedStorage) Get(ctx context.Context, key string) (interface{}, error) {
-	bytes, err := s.GetByteArray(ctx, key)
-	if err != nil {
-		return nil, err
-	}
-
-	item := &cachedItem{}
-	err = s.codec.Decode(ctx, bytes, item)
-	if err != nil {
-		return nil, err
-	}
-
-	return item.Val, nil
 }
 
 // GetByteArray returns the cached value as an byte array

--- a/pkg/infra/remotecache/redis_storage.go
+++ b/pkg/infra/remotecache/redis_storage.go
@@ -16,8 +16,7 @@ import (
 const redisCacheType = "redis"
 
 type redisStorage struct {
-	c     *redis.Client
-	codec codec
+	c *redis.Client
 }
 
 // parseRedisConnStr parses k=v pairs in csv and builds a redis Options object
@@ -78,22 +77,22 @@ func parseRedisConnStr(connStr string) (*redis.Options, error) {
 	return options, nil
 }
 
-func newRedisStorage(opts *setting.RemoteCacheOptions, codec codec) (*redisStorage, error) {
+func newRedisStorage(opts *setting.RemoteCacheOptions) (*redisStorage, error) {
 	opt, err := parseRedisConnStr(opts.ConnStr)
 	if err != nil {
 		return nil, err
 	}
-	return &redisStorage{c: redis.NewClient(opt), codec: codec}, nil
+	return &redisStorage{c: redis.NewClient(opt)}, nil
 }
 
 // Set sets value to a given key
-func (s *redisStorage) SetByteArray(ctx context.Context, key string, data []byte, expires time.Duration) error {
+func (s *redisStorage) Set(ctx context.Context, key string, data []byte, expires time.Duration) error {
 	status := s.c.Set(ctx, key, data, expires)
 	return status.Err()
 }
 
 // GetByteArray returns the value as byte array
-func (s *redisStorage) GetByteArray(ctx context.Context, key string) ([]byte, error) {
+func (s *redisStorage) Get(ctx context.Context, key string) ([]byte, error) {
 	return s.c.Get(ctx, key).Bytes()
 }
 

--- a/pkg/infra/remotecache/redis_storage.go
+++ b/pkg/infra/remotecache/redis_storage.go
@@ -86,42 +86,10 @@ func newRedisStorage(opts *setting.RemoteCacheOptions, codec codec) (*redisStora
 	return &redisStorage{c: redis.NewClient(opt), codec: codec}, nil
 }
 
-// Set sets value to given key in session.
-func (s *redisStorage) Set(ctx context.Context, key string, val interface{}, expires time.Duration) error {
-	item := &cachedItem{Val: val}
-	value, err := s.codec.Encode(ctx, item)
-	if err != nil {
-		return err
-	}
-
-	return s.SetByteArray(ctx, key, value, expires)
-}
-
 // Set sets value to a given key
 func (s *redisStorage) SetByteArray(ctx context.Context, key string, data []byte, expires time.Duration) error {
 	status := s.c.Set(ctx, key, data, expires)
 	return status.Err()
-}
-
-// Get gets value by given key in session.
-func (s *redisStorage) Get(ctx context.Context, key string) (interface{}, error) {
-	v, err := s.GetByteArray(ctx, key)
-
-	if err != nil {
-		if err.Error() == "EOF" {
-			return nil, ErrCacheItemNotFound
-		}
-		return nil, err
-	}
-
-	item := &cachedItem{}
-	err = s.codec.Decode(ctx, v, item)
-
-	if err == nil {
-		return item.Val, nil
-	}
-
-	return nil, err
 }
 
 // GetByteArray returns the value as byte array

--- a/pkg/infra/remotecache/remotecache.go
+++ b/pkg/infra/remotecache/remotecache.go
@@ -145,7 +145,12 @@ func createClient(opts *setting.RemoteCacheOptions, sqlstore db.DB) (cache Cache
 
 type encryptedCacheStorage struct {
 	cache          CacheStorage
-	secretsService secrets.Service
+	secretsService encryptionService
+}
+
+type encryptionService interface {
+	Encrypt(ctx context.Context, payload []byte, opt secrets.EncryptionOptions) ([]byte, error)
+	Decrypt(ctx context.Context, payload []byte) ([]byte, error)
 }
 
 func (pcs *encryptedCacheStorage) Get(ctx context.Context, key string) ([]byte, error) {

--- a/pkg/infra/remotecache/remotecache.go
+++ b/pkg/infra/remotecache/remotecache.go
@@ -1,9 +1,7 @@
 package remotecache
 
 import (
-	"bytes"
 	"context"
-	"encoding/gob"
 	"errors"
 	"time"
 
@@ -30,13 +28,7 @@ const (
 
 func ProvideService(cfg *setting.Cfg, sqlStore db.DB, usageStats usagestats.Service,
 	secretsService secrets.Service) (*RemoteCache, error) {
-	var codec codec
-	if cfg.RemoteCacheOptions.Encryption {
-		codec = &encryptionCodec{secretsService}
-	} else {
-		codec = &gobCodec{}
-	}
-	client, err := createClient(cfg.RemoteCacheOptions, sqlStore, codec)
+	client, err := createClient(cfg.RemoteCacheOptions, sqlStore)
 	if err != nil {
 		return nil, err
 	}
@@ -69,11 +61,11 @@ func (ds *RemoteCache) getUsageStats(ctx context.Context) (map[string]interface{
 // so any struct added to the cache needs to be registered with `remotecache.Register`
 // ex `remotecache.Register(CacheableStruct{})`
 type CacheStorage interface {
-	// GetByteArray gets the cache value as an byte array
-	GetByteArray(ctx context.Context, key string) ([]byte, error)
+	// Get gets the cache value as an byte array
+	Get(ctx context.Context, key string) ([]byte, error)
 
-	// SetByteArray saves the value as an byte array. if `expire` is set to zero it will default to 24h
-	SetByteArray(ctx context.Context, key string, value []byte, expire time.Duration) error
+	// Set saves the value as an byte array. if `expire` is set to zero it will default to 24h
+	Set(ctx context.Context, key string, value []byte, expire time.Duration) error
 
 	// Delete object from cache
 	Delete(ctx context.Context, key string) error
@@ -91,18 +83,18 @@ type RemoteCache struct {
 	Cfg      *setting.Cfg
 }
 
-// GetByteArray returns the cached value as an byte array
-func (ds *RemoteCache) GetByteArray(ctx context.Context, key string) ([]byte, error) {
-	return ds.client.GetByteArray(ctx, key)
+// Get returns the cached value as an byte array
+func (ds *RemoteCache) Get(ctx context.Context, key string) ([]byte, error) {
+	return ds.client.Get(ctx, key)
 }
 
-// SetByteArray stored the byte array in the cache
-func (ds *RemoteCache) SetByteArray(ctx context.Context, key string, value []byte, expire time.Duration) error {
+// Set stored the byte array in the cache
+func (ds *RemoteCache) Set(ctx context.Context, key string, value []byte, expire time.Duration) error {
 	if expire == 0 {
 		expire = defaultMaxCacheExpiration
 	}
 
-	return ds.client.SetByteArray(ctx, key, value, expire)
+	return ds.client.Set(ctx, key, value, expire)
 }
 
 // Delete object from cache
@@ -127,14 +119,14 @@ func (ds *RemoteCache) Run(ctx context.Context) error {
 	return ctx.Err()
 }
 
-func createClient(opts *setting.RemoteCacheOptions, sqlstore db.DB, codec codec) (cache CacheStorage, err error) {
+func createClient(opts *setting.RemoteCacheOptions, sqlstore db.DB) (cache CacheStorage, err error) {
 	switch opts.Name {
 	case redisCacheType:
-		cache, err = newRedisStorage(opts, codec)
+		cache, err = newRedisStorage(opts)
 	case memcachedCacheType:
-		cache = newMemcachedStorage(opts, codec)
+		cache = newMemcachedStorage(opts)
 	case databaseCacheType:
-		cache = newDatabaseCache(sqlstore, codec)
+		cache = newDatabaseCache(sqlstore)
 	default:
 		return nil, ErrInvalidCacheType
 	}
@@ -144,61 +136,40 @@ func createClient(opts *setting.RemoteCacheOptions, sqlstore db.DB, codec codec)
 	if opts.Prefix != "" {
 		cache = &prefixCacheStorage{cache: cache, prefix: opts.Prefix}
 	}
+
+	if opts.Encryption {
+		cache = &encryptedCacheStorage{cache: cache}
+	}
 	return cache, nil
 }
 
-// Register records a type, identified by a value for that type, under its
-// internal type name. That name will identify the concrete type of a value
-// sent or received as an interface variable. Only types that will be
-// transferred as implementations of interface values need to be registered.
-// Expecting to be used only during initialization, it panics if the mapping
-// between types and names is not a bijection.
-func Register(value interface{}) {
-	gob.Register(value)
-}
-
-type cachedItem struct {
-	Val interface{}
-}
-
-type codec interface {
-	Encode(context.Context, *cachedItem) ([]byte, error)
-	Decode(context.Context, []byte, *cachedItem) error
-}
-
-type gobCodec struct{}
-
-func (c *gobCodec) Encode(_ context.Context, item *cachedItem) ([]byte, error) {
-	buf := bytes.NewBuffer(nil)
-	err := gob.NewEncoder(buf).Encode(item)
-	return buf.Bytes(), err
-}
-
-func (c *gobCodec) Decode(_ context.Context, data []byte, out *cachedItem) error {
-	buf := bytes.NewBuffer(data)
-	return gob.NewDecoder(buf).Decode(&out)
-}
-
-type encryptionCodec struct {
+type encryptedCacheStorage struct {
+	cache          CacheStorage
 	secretsService secrets.Service
 }
 
-func (c *encryptionCodec) Encode(ctx context.Context, item *cachedItem) ([]byte, error) {
-	buf := bytes.NewBuffer(nil)
-	err := gob.NewEncoder(buf).Encode(item)
+func (pcs *encryptedCacheStorage) Get(ctx context.Context, key string) ([]byte, error) {
+	data, err := pcs.cache.Get(ctx, key)
 	if err != nil {
 		return nil, err
 	}
-	return c.secretsService.Encrypt(ctx, buf.Bytes(), secrets.WithoutScope())
-}
 
-func (c *encryptionCodec) Decode(ctx context.Context, data []byte, out *cachedItem) error {
-	decrypted, err := c.secretsService.Decrypt(ctx, data)
+	return pcs.secretsService.Decrypt(ctx, data)
+}
+func (pcs *encryptedCacheStorage) Set(ctx context.Context, key string, value []byte, expire time.Duration) error {
+	encrypted, err := pcs.secretsService.Encrypt(ctx, value, secrets.WithoutScope())
 	if err != nil {
 		return err
 	}
-	buf := bytes.NewBuffer(decrypted)
-	return gob.NewDecoder(buf).Decode(&out)
+
+	return pcs.cache.Set(ctx, key, encrypted, expire)
+}
+func (pcs *encryptedCacheStorage) Delete(ctx context.Context, key string) error {
+	return pcs.cache.Delete(ctx, key)
+}
+
+func (pcs *encryptedCacheStorage) Count(ctx context.Context, prefix string) (int64, error) {
+	return pcs.cache.Count(ctx, prefix)
 }
 
 type prefixCacheStorage struct {
@@ -206,16 +177,16 @@ type prefixCacheStorage struct {
 	prefix string
 }
 
-func (pcs *prefixCacheStorage) GetByteArray(ctx context.Context, key string) ([]byte, error) {
-	return pcs.cache.GetByteArray(ctx, pcs.prefix+key)
+func (pcs *prefixCacheStorage) Get(ctx context.Context, key string) ([]byte, error) {
+	return pcs.cache.Get(ctx, pcs.prefix+key)
 }
-func (pcs *prefixCacheStorage) SetByteArray(ctx context.Context, key string, value []byte, expire time.Duration) error {
-	return pcs.cache.SetByteArray(ctx, pcs.prefix+key, value, expire)
+func (pcs *prefixCacheStorage) Set(ctx context.Context, key string, value []byte, expire time.Duration) error {
+	return pcs.cache.Set(ctx, pcs.prefix+key, value, expire)
 }
 func (pcs *prefixCacheStorage) Delete(ctx context.Context, key string) error {
 	return pcs.cache.Delete(ctx, pcs.prefix+key)
 }
 
 func (pcs *prefixCacheStorage) Count(ctx context.Context, prefix string) (int64, error) {
-	return pcs.cache.Count(ctx, pcs.prefix)
+	return pcs.cache.Count(ctx, pcs.prefix+prefix)
 }

--- a/pkg/infra/remotecache/remotecache_test.go
+++ b/pkg/infra/remotecache/remotecache_test.go
@@ -160,6 +160,6 @@ func TestCachePrefix(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "bar", string(v))
 	// Get a value directly from the underlying cache without a prefix, should not be there
-	_, err = cache.Get(context.Background(), "foo")
+	_, err = cache.GetByteArray(context.Background(), "foo")
 	require.Error(t, err)
 }

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -615,7 +615,7 @@ func TestMiddlewareContext(t *testing.T) {
 			require.NoError(t, err)
 			key := fmt.Sprintf(authproxy.CachePrefix, h)
 			userIdBytes := []byte(strconv.FormatInt(userID, 10))
-			err = sc.remoteCacheService.SetByteArray(context.Background(), key, userIdBytes, 0)
+			err = sc.remoteCacheService.Set(context.Background(), key, userIdBytes, 0)
 			require.NoError(t, err)
 			sc.fakeReq("GET", "/")
 

--- a/pkg/services/anonymous/anonimpl/impl.go
+++ b/pkg/services/anonymous/anonimpl/impl.go
@@ -96,5 +96,5 @@ func (a *AnonSessionService) TagSession(ctx context.Context, httpReq *http.Reque
 
 	a.localCache.SetDefault(key, struct{}{})
 
-	return a.remoteCache.SetByteArray(ctx, key, []byte(key), thirtyDays)
+	return a.remoteCache.Set(ctx, key, []byte(key), thirtyDays)
 }

--- a/pkg/services/auth/jwt/key_sets.go
+++ b/pkg/services/auth/jwt/key_sets.go
@@ -171,7 +171,7 @@ func (ks *keySetHTTP) getJWKS(ctx context.Context) (keySetJWKS, error) {
 	var jwks keySetJWKS
 
 	if ks.cacheExpiration > 0 {
-		if val, err := ks.cache.GetByteArray(ctx, ks.cacheKey); err == nil {
+		if val, err := ks.cache.Get(ctx, ks.cacheKey); err == nil {
 			err := json.Unmarshal(val, &jwks)
 			return jwks, err
 		}
@@ -200,7 +200,7 @@ func (ks *keySetHTTP) getJWKS(ctx context.Context) (keySetJWKS, error) {
 	}
 
 	if ks.cacheExpiration > 0 {
-		err = ks.cache.SetByteArray(ctx, ks.cacheKey, jsonBuf.Bytes(), ks.cacheExpiration)
+		err = ks.cache.Set(ctx, ks.cacheKey, jsonBuf.Bytes(), ks.cacheExpiration)
 	}
 	return jwks, err
 }

--- a/pkg/services/authn/clients/proxy_test.go
+++ b/pkg/services/authn/clients/proxy_test.go
@@ -181,10 +181,10 @@ type fakeCache struct {
 	expectedItem []byte
 }
 
-func (f fakeCache) GetByteArray(ctx context.Context, key string) ([]byte, error) {
+func (f fakeCache) Get(ctx context.Context, key string) ([]byte, error) {
 	return f.expectedItem, f.expectedErr
 }
 
-func (f fakeCache) SetByteArray(ctx context.Context, key string, value []byte, expire time.Duration) error {
+func (f fakeCache) Set(ctx context.Context, key string, value []byte, expire time.Duration) error {
 	return f.expectedErr
 }

--- a/pkg/services/contexthandler/auth_proxy_test.go
+++ b/pkg/services/contexthandler/auth_proxy_test.go
@@ -58,7 +58,7 @@ func TestInitContextWithAuthProxy_CachedInvalidUserID(t *testing.T) {
 
 	t.Logf("Injecting stale user ID in cache with key %q", key)
 	userIdPayload := []byte(strconv.FormatInt(int64(33), 10))
-	err = svc.RemoteCache.SetByteArray(context.Background(), key, userIdPayload, 0)
+	err = svc.RemoteCache.Set(context.Background(), key, userIdPayload, 0)
 	require.NoError(t, err)
 
 	authEnabled := svc.initContextWithAuthProxy(ctx, orgID)
@@ -67,7 +67,7 @@ func TestInitContextWithAuthProxy_CachedInvalidUserID(t *testing.T) {
 	require.Equal(t, userID, ctx.SignedInUser.UserID)
 	require.True(t, ctx.IsSignedIn)
 
-	cachedByteArray, err := svc.RemoteCache.GetByteArray(context.Background(), key)
+	cachedByteArray, err := svc.RemoteCache.Get(context.Background(), key)
 	require.NoError(t, err)
 
 	cacheUserId, err := strconv.ParseInt(string(cachedByteArray), 10, 64)

--- a/pkg/services/contexthandler/authproxy/authproxy.go
+++ b/pkg/services/contexthandler/authproxy/authproxy.go
@@ -191,7 +191,7 @@ func (auth *AuthProxy) getUserViaCache(reqCtx *contextmodel.ReqContext) (int64, 
 		return 0, err
 	}
 	auth.logger.Debug("Getting user ID via auth cache", "cacheKey", cacheKey)
-	cachedValue, err := auth.remoteCache.GetByteArray(reqCtx.Req.Context(), cacheKey)
+	cachedValue, err := auth.remoteCache.Get(reqCtx.Req.Context(), cacheKey)
 	if err != nil {
 		return 0, err
 	}
@@ -353,7 +353,7 @@ func (auth *AuthProxy) Remember(reqCtx *contextmodel.ReqContext, id int64) error
 	}
 
 	// Check if user already in cache
-	cachedValue, err := auth.remoteCache.GetByteArray(reqCtx.Req.Context(), key)
+	cachedValue, err := auth.remoteCache.Get(reqCtx.Req.Context(), key)
 	if err == nil && len(cachedValue) != 0 {
 		return nil
 	}
@@ -361,7 +361,7 @@ func (auth *AuthProxy) Remember(reqCtx *contextmodel.ReqContext, id int64) error
 	expiration := time.Duration(auth.cfg.AuthProxySyncTTL) * time.Minute
 
 	userIdPayload := []byte(strconv.FormatInt(id, 10))
-	if err := auth.remoteCache.SetByteArray(reqCtx.Req.Context(), key, userIdPayload, expiration); err != nil {
+	if err := auth.remoteCache.Set(reqCtx.Req.Context(), key, userIdPayload, expiration); err != nil {
 		return err
 	}
 

--- a/pkg/services/contexthandler/authproxy/authproxy_test.go
+++ b/pkg/services/contexthandler/authproxy/authproxy_test.go
@@ -61,7 +61,7 @@ func TestMiddlewareContext(t *testing.T) {
 		require.NoError(t, err)
 		key := fmt.Sprintf(CachePrefix, h)
 		userIdPayload := []byte(strconv.FormatInt(id, 10))
-		err = cache.SetByteArray(context.Background(), key, userIdPayload, 0)
+		err = cache.Set(context.Background(), key, userIdPayload, 0)
 		require.NoError(t, err)
 		// Set up the middleware
 		auth, reqCtx := prepareMiddleware(t, cache, nil)
@@ -84,7 +84,7 @@ func TestMiddlewareContext(t *testing.T) {
 		require.NoError(t, err)
 		key := fmt.Sprintf(CachePrefix, h)
 		userIdPayload := []byte(strconv.FormatInt(id, 10))
-		err = cache.SetByteArray(context.Background(), key, userIdPayload, 0)
+		err = cache.Set(context.Background(), key, userIdPayload, 0)
 		require.NoError(t, err)
 
 		auth, reqCtx := prepareMiddleware(t, cache, func(req *http.Request, cfg *setting.Cfg) {

--- a/pkg/services/rendering/auth.go
+++ b/pkg/services/rendering/auth.go
@@ -21,7 +21,7 @@ type RenderUser struct {
 }
 
 func (rs *RenderingService) GetRenderUser(ctx context.Context, key string) (*RenderUser, bool) {
-	val, err := rs.RemoteCacheService.GetByteArray(ctx, fmt.Sprintf(renderKeyPrefix, key))
+	val, err := rs.RemoteCacheService.Get(ctx, fmt.Sprintf(renderKeyPrefix, key))
 	if err != nil {
 		rs.log.Error("Failed to get render key from cache", "error", err)
 	}
@@ -46,7 +46,7 @@ func setRenderKey(cache *remotecache.RemoteCache, ctx context.Context, opts Auth
 		return err
 	}
 
-	return cache.SetByteArray(ctx, fmt.Sprintf(renderKeyPrefix, renderKey), buf.Bytes(), expiry)
+	return cache.Set(ctx, fmt.Sprintf(renderKeyPrefix, renderKey), buf.Bytes(), expiry)
 }
 
 func generateAndSetRenderKey(cache *remotecache.RemoteCache, ctx context.Context, opts AuthOpts, expiry time.Duration) (string, error) {


### PR DESCRIPTION
part 4 o 4 of https://github.com/grafana/grafana/issues/62876

This PR grew more than I expected when I started. When reviewing it I suggest that you review it commit by commit. 

- [x] Remove old set/get functions
- [x] Rename setbytearray and getbytearray to set/get
- [x] Remove the codec
- [x] Tests for the encryptedCacheStorage 

closes https://github.com/grafana/grafana/issues/62876