### PR TITLE
OpenTSDB: suggest_tagv receives prefix on input change

### DIFF
--- a/public/app/plugins/datasource/opentsdb/components/FilterSection.tsx
+++ b/public/app/plugins/datasource/opentsdb/components/FilterSection.tsx
@@ -1,8 +1,18 @@
+import debounce from 'debounce-promise';
 import { size } from 'lodash';
 import React, { useCallback, useState } from 'react';
 
 import { SelectableValue, toOption } from '@grafana/data';
-import { InlineLabel, Select, InlineFormLabel, InlineSwitch, Icon, clearButtonStyles, useStyles2 } from '@grafana/ui';
+import {
+  InlineLabel,
+  Select,
+  InlineFormLabel,
+  InlineSwitch,
+  Icon,
+  clearButtonStyles,
+  useStyles2,
+  AsyncSelect,
+} from '@grafana/ui';
 
 import { OpenTsdbFilter, OpenTsdbQuery } from '../types';
 
@@ -12,7 +22,7 @@ export interface FilterSectionProps {
   onRunQuery: () => void;
   suggestTagKeys: (query: OpenTsdbQuery) => Promise<string[]>;
   filterTypes: string[];
-  suggestTagValues: () => Promise<SelectableValue[]>;
+  suggestTagValues: (value: string) => Promise<SelectableValue[]>;
 }
 
 export function FilterSection({
@@ -27,9 +37,6 @@ export function FilterSection({
 
   const [tagKeys, updTagKeys] = useState<Array<SelectableValue<string>>>();
   const [keyIsLoading, updKeyIsLoading] = useState<boolean>();
-
-  const [tagValues, updTagValues] = useState<Array<SelectableValue<string>>>();
-  const [valueIsLoading, updValueIsLoading] = useState<boolean>();
 
   const [addFilterMode, updAddFilterMode] = useState<boolean>(false);
 
@@ -108,6 +115,8 @@ export function FilterSection({
     return searchWords.reduce((acc, cur) => acc && label.toLowerCase().includes(cur.toLowerCase()), true);
   }, []);
 
+  const tagValueSearch = debounce((query: string) => suggestTagValues(query), 350);
+
   return (
     <div className="gf-form-inline" data-testid={testIds.section}>
       <div className="gf-form">
@@ -185,23 +194,14 @@ export function FilterSection({
           </div>
 
           <div className="gf-form">
-            <Select
+            <AsyncSelect
               inputId="opentsdb-suggested-tagv-select"
               className="gf-form-input"
               value={curFilterValue ? toOption(curFilterValue) : undefined}
               placeholder="filter"
               allowCustomValue
-              filterOption={customFilterOption}
-              onOpenMenu={async () => {
-                if (!tagValues) {
-                  updValueIsLoading(true);
-                  const tVs = await suggestTagValues();
-                  updTagValues(tVs);
-                  updValueIsLoading(false);
-                }
-              }}
-              isLoading={valueIsLoading}
-              options={tagValues}
+              loadOptions={tagValueSearch}
+              defaultOptions={[]}
               onChange={({ value }) => {
                 if (value) {
                   updCurFilterValue(value);

--- a/public/app/plugins/datasource/opentsdb/components/OpenTsdbQueryEditor.tsx
+++ b/public/app/plugins/datasource/opentsdb/components/OpenTsdbQueryEditor.tsx
@@ -80,8 +80,8 @@ export function OpenTsdbQueryEditor({
 
   // previously called as an autocomplete on every input,
   // in this we call it once on init and filter in the MetricSection component
-  async function suggestTagValues(): Promise<Array<{ value: string; description: string }>> {
-    return datasource.metricFindQuery('suggest_tagv()').then(getTextValues);
+  async function suggestTagValues(value: string): Promise<Array<{ value: string; description: string }>> {
+    return datasource.metricFindQuery(`suggest_tagv(${value})`).then(getTextValues);
   }
 
   async function suggestTagKeys(query: OpenTsdbQuery): Promise<string[]> {


### PR DESCRIPTION
Fixes #60350

A previously open [PR](https://github.com/grafana/grafana/pull/62045) restored the default (while using angular components) behaviour by passing along the prefix to the `metrics` query instead of retrieving all and filtering next.

This PR improves in that same way but for tag values, now passing the prefix to the `suggest_tagv` query.