### PR TITLE
Utils: Reimplement util.GetRandomString to avoid modulo bias

### DIFF
--- a/pkg/util/encoding.go
+++ b/pkg/util/encoding.go
@@ -13,22 +13,39 @@ import (
 	"golang.org/x/crypto/pbkdf2"
 )
 
-// GetRandomString generate random string by specify chars.
-// source: https://github.com/gogits/gogs/blob/9ee80e3e5426821f03a4e99fad34418f5c736413/modules/base/tool.go#L58
-func GetRandomString(n int, alphabets ...byte) (string, error) {
-	const alphanum = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
-	var bytes = make([]byte, n)
-	if _, err := rand.Read(bytes); err != nil {
-		return "", err
-	}
+const alphanum = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 
-	for i, b := range bytes {
-		if len(alphabets) == 0 {
-			bytes[i] = alphanum[b%byte(len(alphanum))]
-		} else {
-			bytes[i] = alphabets[b%byte(len(alphabets))]
+// GetRandomString generates a random alphanumeric string of the specified length,
+// optionally using only specified characters
+func GetRandomString(n int, alphabets ...byte) (string, error) {
+	chars := alphanum
+	if len(alphabets) > 0 {
+		chars = string(alphabets)
+	}
+	cnt := len(chars)
+	max := 255 / cnt * cnt
+
+	bytes := make([]byte, n)
+
+	randread := n * 5 / 4
+	randbytes := make([]byte, randread)
+
+	for i := 0; i < n; {
+		if _, err := rand.Read(randbytes); err != nil {
+			return "", err
+		}
+
+		for j := 0; i < n && j < randread; j++ {
+			b := int(randbytes[j])
+			if b >= max {
+				continue
+			}
+
+			bytes[i] = chars[b%cnt]
+			i++
 		}
 	}
+
 	return string(bytes), nil
 }
 

--- a/pkg/util/encoding_test.go
+++ b/pkg/util/encoding_test.go
@@ -167,12 +167,12 @@ func TestGetRandomString(t *testing.T) {
 		chiSquared += math.Pow(float64(m[string(char)])-expected, 2) / expected
 	}
 
-	// Ensure there is no more than 5% variance between lowest and highest frequency characters
-	assert.LessOrEqual(t, float64(max-min)/float64(min), 0.05, "Variance between lowest and highest frequency characters must be no more than 5%")
+	// Ensure there is no more than 10% variance between lowest and highest frequency characters
+	assert.LessOrEqual(t, float64(max-min)/float64(min), 0.1, "Variance between lowest and highest frequency characters must be no more than 10%")
 
 	// Ensure chi-squared value is lower than the critical bound
-	// 99.9% probability for 61 degrees of freedom
-	assert.Less(t, chiSquared, 100.888, "Chi squared value must be less than the 99.9% critical bound")
+	// 99.99% probability for 61 degrees of freedom
+	assert.Less(t, chiSquared, 110.8397, "Chi squared value must be less than the 99.99% critical bound")
 }
 
 func TestGetRandomDigits(t *testing.T) {
@@ -210,10 +210,10 @@ func TestGetRandomDigits(t *testing.T) {
 		chiSquared += math.Pow(float64(m[string(char)])-expected, 2) / expected
 	}
 
-	// Ensure there is no more than 5% variance between lowest and highest frequency characters
-	assert.LessOrEqual(t, float64(max-min)/float64(min), 0.05, "Variance between lowest and highest frequency characters must be no more than 5%")
+	// Ensure there is no more than 10% variance between lowest and highest frequency characters
+	assert.LessOrEqual(t, float64(max-min)/float64(min), 0.1, "Variance between lowest and highest frequency characters must be no more than 10%")
 
 	// Ensure chi-squared value is lower than the critical bound
-	// 99.9% probability for 9 degrees of freedom
-	assert.Less(t, chiSquared, 27.877, "Chi squared value must be less than the 99.9% critical bound")
+	// 99.99% probability for 9 degrees of freedom
+	assert.Less(t, chiSquared, 33.7199, "Chi squared value must be less than the 99.99% critical bound")
 }

--- a/pkg/util/encoding_test.go
+++ b/pkg/util/encoding_test.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"math"
 	"strings"
 	"testing"
 
@@ -129,4 +130,90 @@ func TestDecodeQuotedPrintable(t *testing.T) {
 		val := DecodeQuotedPrintable(str_in)
 		assert.Equal(t, str_out, val)
 	})
+}
+
+func TestGetRandomString(t *testing.T) {
+	charset := "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+	chars := len(charset)
+	length := 20
+	rounds := 50_000
+
+	// Generate random strings and count the frequency of each character
+	m := make(map[string]int)
+	for i := 0; i < rounds; i++ {
+		r, err := GetRandomString(length)
+		require.NoError(t, err)
+
+		for _, c := range r {
+			m[string(c)]++
+		}
+	}
+
+	// Find lowest and highest frequencies
+	min := rounds * length
+	max := 0
+
+	// Calculate chi-squared statistic
+	expected := float64(rounds) * float64(length) / float64(chars)
+	chiSquared := 0.0
+
+	for _, char := range charset {
+		if m[string(char)] < min {
+			min = m[string(char)]
+		}
+		if m[string(char)] > max {
+			max = m[string(char)]
+		}
+		chiSquared += math.Pow(float64(m[string(char)])-expected, 2) / expected
+	}
+
+	// Ensure there is no more than 5% variance between lowest and highest frequency characters
+	assert.LessOrEqual(t, float64(max-min)/float64(min), 0.05, "Variance between lowest and highest frequency characters must be no more than 5%")
+
+	// Ensure chi-squared value is lower than the critical bound
+	// 99.9% probability for 61 degrees of freedom
+	assert.Less(t, chiSquared, 100.888, "Chi squared value must be less than the 99.9% critical bound")
+}
+
+func TestGetRandomDigits(t *testing.T) {
+	charset := "0123456789"
+	chars := len(charset)
+	length := 20
+	rounds := 50_000
+
+	// Generate random strings and count the frequency of each character
+	m := make(map[string]int)
+	for i := 0; i < rounds; i++ {
+		r, err := GetRandomString(length, []byte(charset)...)
+		require.NoError(t, err)
+
+		for _, c := range r {
+			m[string(c)]++
+		}
+	}
+
+	// Find lowest and highest frequencies
+	min := rounds * length
+	max := 0
+
+	// Calculate chi-squared statistic
+	expected := float64(rounds) * float64(length) / float64(chars)
+	chiSquared := 0.0
+
+	for _, char := range charset {
+		if m[string(char)] < min {
+			min = m[string(char)]
+		}
+		if m[string(char)] > max {
+			max = m[string(char)]
+		}
+		chiSquared += math.Pow(float64(m[string(char)])-expected, 2) / expected
+	}
+
+	// Ensure there is no more than 5% variance between lowest and highest frequency characters
+	assert.LessOrEqual(t, float64(max-min)/float64(min), 0.05, "Variance between lowest and highest frequency characters must be no more than 5%")
+
+	// Ensure chi-squared value is lower than the critical bound
+	// 99.9% probability for 9 degrees of freedom
+	assert.Less(t, chiSquared, 27.877, "Chi squared value must be less than the 99.9% critical bound")
 }


### PR DESCRIPTION
We discovered that the `util.GetRandomString` function exhibits a bias, and when used to generate alphanumeric strings will produce the characters 0-7 with approximately 25% higher frequency on average than the other characters (8-9, A-Z, a-z) in the allowed character list.

This is due to modulo bias, the fact that when we calculate the value of a random byte with value 0-255 module the number of allowed characters (62 by default), we get 4 input values that will produce each of the numbers 8-61 (mapped to characters 8-9, A-Z and a-z), but 5 inputs that will produce the numbers 0-7 (mapped to characters 0-7).

When we restrict the set of output characters to the numbers 0-9 we see a smaller effect, because there are 25 input values that produce the values 5-9 but 26 input values that map to the values 0-4, creating a 4% bias toward the numbers 0-4.

Further reading on modulo bias:
- [Why do people say there is modulo bias when using a random number generator?](https://stackoverflow.com/questions/10984974/why-do-people-say-there-is-modulo-bias-when-using-a-random-number-generator)
- [The definitive guide to “Modulo Bias and how to avoid it”!](https://research.kudelskisecurity.com/2020/07/28/the-definitive-guide-to-modulo-bias-and-how-to-avoid-it/)

This PR reimplements `util.GetRandomString` following best practices to produce unbiased output regardless of the allowed characters.  It applies the standard method of avoiding modulo bias, by discarding random values that are larger than the largest multiple of the number of characters in the output set that is smaller than 255.

It also adds 2 different tests to verify that the function is working correctly by comparing the relative frequencies of the highest and lowest-frequency characters in the output, and by using a [chi-squared test](https://en.wikipedia.org/wiki/Chi-squared_test).

We generate ~25% more random bytes than output characters to avoid multiple calls to `rand.Read` (which are slow), but if that isn't enough we will read again (and again if needed) until we have enough random bytes to generate the output string. In my testing the performance is very similar to the existing function, in part due to some efficiencies in go offsetting the need to read more bytes with `rand.Read`.

We use `util.GetRandomString` for various purposes including generating random filenames but also for generating cryptographic salt values and api key secrets, so the impact of this bias on the security of Grafana needed to be assessed.

@kelnage performed an analysis of the reduction in entropy of the current generated strings, with the following results:

> I've done an analysis using [this widely used formula](https://www.pleacher.com/mp/mlessons/algebra/entropy.html): E = log_2(R^L), where R is the size of the character space ([a-zA-Z0-9] having 62 possible chars, [0-7] having 8), L is the length of the string, and E is the number of bits of entropy available, and the number of guesses G required can be estimated by G = 2^E.
> 
> Based on that formula, for the 32-character strings, in the worst-case (where the GetRandomString algorithm only selected from [0-7] - very improbable, but possible given the above), the resulting secret would still be expected to have ~96 bits of entropy (compared with the expected case of 190 bits with all 62 chars). This is still well above the common recommendations for passwords (such as Okta, who suggest aiming for [at least 60 bits](https://www.okta.com/uk/identity-101/password-entropy/)), and would require in the order of ~10^28 guesses.
> 
> That drops to ~30 bits of entropy (~1 billion guesses) for a 10-character string - but since those appear to generally be used as salts (where the encryption strength should not depend on the randomness of the salt) or short-lived temporary passwords/IDs and again, this is a worst-case analysis, this is not a cause for concern.

@jmatosgrafana performed analysis on the current and proposed implementations:

> Computing randomness stats on a 10 million series of GetRandomString(20) with the [ent](https://formulae.brew.sh/formula/ent) tool via ent stats_10millions.txt gives:
> 
> > Entropy = 5.942557 bits per byte.
> 
> The expected entropy can be computed in Python with `math.log2(62)`: `5.954196310386875`
> 
> For GetRandomString(20) it means losing only 17% (`pow(2, 20*(5.954196310386875-5.942557))`), and 8% for GetRandomString(10) (`pow(2, 10*(5.954196310386875-5.942557))`).
> 
> Given those numbers, the security impact can be considered insignificant.

> With this PR and a 1 million GetRandom(20) series, ent tool now returns
> 
> > Entropy = 5.954195 bits per byte
> > Arithmetic mean value of data bytes is 86.8884
> 
> This is extremely close to the theoretical numbers: 5.954196310386875 for entropy (math.log2(62)) and 86.88709677419355 for arithmetic mean (5387/62, when adding up the [ascii values](https://www.techonthenet.com/ascii/chart.php) for 0-9,a-z and A-Z)

At this point our assessment is that the current bias does not constitute a security issue as we still have sufficient entropy for the ways we use the generated strings.  This PR improves that entropy value and brings our measured entropy closer to the theoretical values.