### PR TITLE
Loki: Fix labels in LabelBrowser being wrongly cached 

### DIFF
--- a/public/app/plugins/datasource/loki/LanguageProvider.test.ts
+++ b/public/app/plugins/datasource/loki/LanguageProvider.test.ts
@@ -291,7 +291,7 @@ describe('fetchLabels', () => {
     expect(instance.labelKeys).toEqual(['other']);
   });
 
-  it('should return empyt array', async () => {
+  it('should return empty array', async () => {
     const datasourceWithLabels = setup({});
 
     const instance = new LanguageProvider(datasourceWithLabels);

--- a/public/app/plugins/datasource/loki/LanguageProvider.test.ts
+++ b/public/app/plugins/datasource/loki/LanguageProvider.test.ts
@@ -274,6 +274,40 @@ describe('Request URL', () => {
   });
 });
 
+describe('fetchLabels', () => {
+  it('should return labels', async () => {
+    const datasourceWithLabels = setup({ other: [] });
+
+    const instance = new LanguageProvider(datasourceWithLabels);
+    const labels = await instance.fetchLabels();
+    expect(labels).toEqual(['other']);
+  });
+
+  it('should set labels', async () => {
+    const datasourceWithLabels = setup({ other: [] });
+
+    const instance = new LanguageProvider(datasourceWithLabels);
+    await instance.fetchLabels();
+    expect(instance.labelKeys).toEqual(['other']);
+  });
+
+  it('should return empyt array', async () => {
+    const datasourceWithLabels = setup({});
+
+    const instance = new LanguageProvider(datasourceWithLabels);
+    const labels = await instance.fetchLabels();
+    expect(labels).toEqual([]);
+  });
+
+  it('should set empty array', async () => {
+    const datasourceWithLabels = setup({});
+
+    const instance = new LanguageProvider(datasourceWithLabels);
+    await instance.fetchLabels();
+    expect(instance.labelKeys).toEqual([]);
+  });
+});
+
 describe('Query imports', () => {
   const datasource = setup({});
 

--- a/public/app/plugins/datasource/loki/LanguageProvider.ts
+++ b/public/app/plugins/datasource/loki/LanguageProvider.ts
@@ -380,6 +380,7 @@ export default class LokiLanguageProvider extends LanguageProvider {
         .sort()
         .filter((label) => label !== '__name__');
       this.labelKeys = labels;
+      return this.labelKeys;
     }
 
     return [];

--- a/public/app/plugins/datasource/loki/querybuilder/components/LabelBrowserModal.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LabelBrowserModal.tsx
@@ -33,9 +33,9 @@ export const LabelBrowserModal = (props: Props) => {
       return;
     }
 
-    datasource.languageProvider.start().then(() => {
+    datasource.languageProvider.fetchLabels().then((labels) => {
       setLabelsLoaded(true);
-      setHasLogLabels(datasource.languageProvider.getLabelKeys().length > 0);
+      setHasLogLabels(labels.length > 0);
     });
   }, [datasource, isOpen]);
 


### PR DESCRIPTION
**What is this feature?**

The LabelBrowser takes `labelKeys` from the `languageProvider`. However those `labelKeys` are cached. This PR does not change the caching, but simply does not display the LabelBrowser if returned `labelKeys` are empty.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Part of https://github.com/grafana/grafana/issues/64411

**Special notes for your reviewer**:

1. Start Grafana/Loki.
2. Set a timerange to a range which includes logs.
3. Open LabelBrowser and everything is working fine.
4. Set a timerange to a range which would throw an error, e.g. to the last 2 years.
5. Open LabelBrowser. With this fix you would see `No labels found.`. Without the fix you would see a LabelBrowser with cached labels.


With fix:

https://user-images.githubusercontent.com/8092184/223948561-7aa8fda8-bbbc-4f89-90c9-5246982bc50e.mov

Without the fix:


https://user-images.githubusercontent.com/8092184/223948724-947aec89-183c-46ee-b713-bd49f3d2d47f.mov



