### PR TITLE
OptionsUI: Enabled settings on the color picker

### DIFF
--- a/public/app/core/components/OptionsUI/color.tsx
+++ b/public/app/core/components/OptionsUI/color.tsx
@@ -2,26 +2,36 @@ import { css } from '@emotion/css';
 import React from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { useTheme2, useStyles2, ColorPicker } from '@grafana/ui';
+import { useTheme2, useStyles2, ColorPicker, IconButton } from '@grafana/ui';
 import { ColorSwatch } from '@grafana/ui/src/components/ColorPicker/ColorSwatch';
+
+export interface ColorValueEditorSettings {
+  placeholder?: string;
+  enableNamedColors?: boolean; // defaults to true
+  isClearable?: boolean; // defaults to false
+}
 
 /**
  * @alpha
  * */
 export interface ColorValueEditorProps {
   value?: string;
-  onChange: (value: string) => void;
+  onChange: (value: string | undefined) => void;
+  settings?: ColorValueEditorSettings;
+
+  // Will show placeholder or details
+  details?: boolean;
 }
 
 /**
  * @alpha
  * */
-export const ColorValueEditor: React.FC<ColorValueEditorProps> = ({ value, onChange }) => {
+export const ColorValueEditor = ({ value, settings, onChange, details }: ColorValueEditorProps) => {
   const theme = useTheme2();
   const styles = useStyles2(getStyles);
 
   return (
-    <ColorPicker color={value ?? ''} onChange={onChange} enableNamedColors={true}>
+    <ColorPicker color={value ?? ''} onChange={onChange} enableNamedColors={settings?.enableNamedColors !== false}>
       {({ ref, showColorPicker, hideColorPicker }) => {
         return (
           <div className={styles.spot}>
@@ -33,6 +43,22 @@ export const ColorValueEditor: React.FC<ColorValueEditorProps> = ({ value, onCha
                 color={value ? theme.visualization.getColorByName(value) : theme.components.input.borderColor}
               />
             </div>
+            {details && (
+              <>
+                {value ? (
+                  <span className={styles.colorText} onClick={showColorPicker}>
+                    {value}
+                  </span>
+                ) : (
+                  <span className={styles.placeholderText} onClick={showColorPicker}>
+                    {settings?.placeholder ?? 'Select color'}
+                  </span>
+                )}
+                {settings?.isClearable && value && (
+                  <IconButton className={styles.trashIcon} name="times" onClick={() => onChange(undefined)} />
+                )}
+              </>
+            )}
           </div>
         );
       }}
@@ -43,6 +69,7 @@ export const ColorValueEditor: React.FC<ColorValueEditorProps> = ({ value, onCha
 const getStyles = (theme: GrafanaTheme2) => {
   return {
     spot: css`
+      cursor: pointer;
       color: ${theme.colors.text};
       background: ${theme.components.input.background};
       padding: 3px;
@@ -51,6 +78,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       display: flex;
       flex-direction: row;
       align-items: center;
+      align-content: flex-end;
       &:hover {
         border: 1px solid ${theme.components.input.borderHover};
       }
@@ -59,15 +87,14 @@ const getStyles = (theme: GrafanaTheme2) => {
       padding: 0 ${theme.spacing(1)};
     `,
     colorText: css`
-      cursor: pointer;
-      flex-grow: 1;
+      flex-grow: 2;
+    `,
+    placeholderText: css`
+      flex-grow: 2;
+      color: ${theme.colors.text.secondary};
     `,
     trashIcon: css`
-      cursor: pointer;
-      color: ${theme.colors.text.secondary};
-      &:hover {
-        color: ${theme.colors.text};
-      }
+      padding: 0 ${theme.spacing(1)};
     `,
   };
 };

--- a/public/app/core/components/OptionsUI/color.tsx
+++ b/public/app/core/components/OptionsUI/color.tsx
@@ -54,9 +54,7 @@ export const ColorValueEditor = ({ value, settings, onChange, details }: ColorVa
                     {settings?.placeholder ?? 'Select color'}
                   </span>
                 )}
-                {settings?.isClearable && value && (
-                  <IconButton className={styles.trashIcon} name="times" onClick={() => onChange(undefined)} />
-                )}
+                {settings?.isClearable && value && <IconButton name="times" onClick={() => onChange(undefined)} />}
               </>
             )}
           </div>
@@ -92,9 +90,6 @@ const getStyles = (theme: GrafanaTheme2) => {
     placeholderText: css`
       flex-grow: 2;
       color: ${theme.colors.text.secondary};
-    `,
-    trashIcon: css`
-      padding: 0 ${theme.spacing(1)};
     `,
   };
 };

--- a/public/app/core/components/OptionsUI/color.tsx
+++ b/public/app/core/components/OptionsUI/color.tsx
@@ -7,8 +7,10 @@ import { ColorSwatch } from '@grafana/ui/src/components/ColorPicker/ColorSwatch'
 
 export interface ColorValueEditorSettings {
   placeholder?: string;
-  enableNamedColors?: boolean; // defaults to true
-  isClearable?: boolean; // defaults to false
+  /** defaults to true */
+  enableNamedColors?: boolean;
+  /** defaults to false */
+  isClearable?: boolean;
 }
 
 interface Props {

--- a/public/app/core/components/OptionsUI/color.tsx
+++ b/public/app/core/components/OptionsUI/color.tsx
@@ -11,10 +11,7 @@ export interface ColorValueEditorSettings {
   isClearable?: boolean; // defaults to false
 }
 
-/**
- * @alpha
- * */
-export interface ColorValueEditorProps {
+interface Props {
   value?: string;
   onChange: (value: string | undefined) => void;
   settings?: ColorValueEditorSettings;
@@ -26,7 +23,7 @@ export interface ColorValueEditorProps {
 /**
  * @alpha
  * */
-export const ColorValueEditor = ({ value, settings, onChange, details }: ColorValueEditorProps) => {
+export const ColorValueEditor = ({ value, settings, onChange, details }: Props) => {
   const theme = useTheme2();
   const styles = useStyles2(getStyles);
 

--- a/public/app/core/components/OptionsUI/registry.tsx
+++ b/public/app/core/components/OptionsUI/registry.tsx
@@ -33,7 +33,7 @@ import { ThresholdsValueEditor } from 'app/features/dimensions/editors/Threshold
 import { ValueMappingsEditor } from 'app/features/dimensions/editors/ValueMappingsEditor/ValueMappingsEditor';
 
 import { DashboardPicker, DashboardPickerOptions } from './DashboardPicker';
-import { ColorValueEditor } from './color';
+import { ColorValueEditor, ColorValueEditorSettings } from './color';
 import { FieldColorEditor } from './fieldColor';
 import { DataLinksValueEditor } from './links';
 import { MultiSelectValueEditor } from './multiSelect';
@@ -117,12 +117,14 @@ export const getAllOptionEditors = () => {
     editor: UnitValueEditor as any,
   };
 
-  const color: StandardEditorsRegistryItem<string> = {
+  const color: StandardEditorsRegistryItem<string, ColorValueEditorSettings> = {
     id: 'color',
     name: 'Color',
     description: 'Allows color selection',
     editor(props) {
-      return <ColorValueEditor value={props.value} onChange={props.onChange} />;
+      return (
+        <ColorValueEditor value={props.value} onChange={props.onChange} settings={props.item.settings} details={true} />
+      );
     },
   };
 

--- a/public/app/features/dashboard/components/AnnotationSettings/AnnotationSettingsEdit.tsx
+++ b/public/app/features/dashboard/components/AnnotationSettings/AnnotationSettingsEdit.tsx
@@ -58,10 +58,10 @@ export const AnnotationSettingsEdit = ({ editIdx, dashboard }: Props) => {
     });
   };
 
-  const onColorChange = (color: string) => {
+  const onColorChange = (color?: string) => {
     onUpdate({
       ...annotation,
-      iconColor: color,
+      iconColor: color!,
     });
   };
 


### PR DESCRIPTION
The current OptionsUI color picker draws a tiny color picker in a wide.  This PR updates the component so it will:
1. Show the color value as text
2. optionally show placeholder text
3. optionally show a clear button

Before:
<img width="482" alt="image" src="https://user-images.githubusercontent.com/705951/223956416-a1a61d96-29a8-4f50-9135-2dbf469c6d0e.png">


Now:
![2023-03-08_23-45-08 (1)](https://user-images.githubusercontent.com/705951/223954726-c4e1b177-7ef1-4c84-b3c2-cc6f94c4ceec.gif)


This can be tested with the heatmap panel exemplar color.
