### PR TITLE
Docs: Updates default template link

### DIFF
--- a/docs/sources/alerting/fundamentals/alert-rules/message-templating.md
+++ b/docs/sources/alerting/fundamentals/alert-rules/message-templating.md
@@ -16,7 +16,9 @@ weight: 415
 
 # Notification templating
 
-Notifications sent via contact points are built using notification templates. Grafana's default templates are based on the [Go templating system](https://golang.org/pkg/text/template) where some fields are evaluated as text, while others are evaluated as HTML (which can affect escaping). The default template, defined in [default_template.go](https://github.com/grafana/alerting/blob/main/templates/default_template.go), is a useful reference for custom templates.
+Notifications sent via contact points are built using notification templates. Grafana's default templates are based on the [Go templating system](https://golang.org/pkg/text/template) where some fields are evaluated as text, while others are evaluated as HTML (which can affect escaping).
+
+The default template [default_template.go](https://github.com/grafana/alerting/blob/main/templates/default_template.go) is a useful reference for custom templates.
 
 Since most of the contact point fields can be templated, you can create reusable custom templates and use them in multiple contact points.
 


### PR DESCRIPTION
default template link was broken in /latest but fine in /next, so changed some text in the topic and hope that it updates there.