### PR TITLE
EditDataSources: Add EditDataSourceActions to EditDataSourcePages

### DIFF
--- a/public/app/features/connections/pages/EditDataSourcePage.tsx
+++ b/public/app/features/connections/pages/EditDataSourcePage.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { useLocation, useParams } from 'react-router-dom';
 
+import { config } from '@grafana/runtime';
 import { Page } from 'app/core/components/Page/Page';
 import { EditDataSource } from 'app/features/datasources/components/EditDataSource';
 import { EditDataSourceActions } from 'app/features/datasources/components/EditDataSourceActions';
@@ -15,7 +16,11 @@ export function EditDataSourcePage() {
   const { navId, pageNav } = useDataSourceSettingsNav();
 
   return (
-    <Page navId={navId} pageNav={pageNav} actions={<EditDataSourceActions uid={uid} />}>
+    <Page
+      navId={navId}
+      pageNav={pageNav}
+      actions={config.featureToggles.topnav ? <EditDataSourceActions uid={uid} /> : undefined}
+    >
       <Page.Contents>
         <EditDataSource uid={uid} pageId={pageId} />
       </Page.Contents>

--- a/public/app/features/connections/pages/EditDataSourcePage.tsx
+++ b/public/app/features/connections/pages/EditDataSourcePage.tsx
@@ -3,6 +3,7 @@ import { useLocation, useParams } from 'react-router-dom';
 
 import { Page } from 'app/core/components/Page/Page';
 import { EditDataSource } from 'app/features/datasources/components/EditDataSource';
+import { EditDataSourceActions } from 'app/features/datasources/components/EditDataSourceActions';
 
 import { useDataSourceSettingsNav } from '../hooks/useDataSourceSettingsNav';
 
@@ -14,7 +15,7 @@ export function EditDataSourcePage() {
   const { navId, pageNav } = useDataSourceSettingsNav();
 
   return (
-    <Page navId={navId} pageNav={pageNav}>
+    <Page navId={navId} pageNav={pageNav} actions={<EditDataSourceActions uid={uid} />}>
       <Page.Contents>
         <EditDataSource uid={uid} pageId={pageId} />
       </Page.Contents>

--- a/public/app/features/datasources/components/ButtonRow.tsx
+++ b/public/app/features/datasources/components/ButtonRow.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { selectors } from '@grafana/e2e-selectors';
+import { config } from '@grafana/runtime';
 import { Button, LinkButton } from '@grafana/ui';
 import { contextSrv } from 'app/core/core';
 import { AccessControlAction } from 'app/types';
@@ -19,21 +20,25 @@ export function ButtonRow({ canSave, canDelete, onDelete, onSubmit, onTest, expl
 
   return (
     <div className="gf-form-button-row">
-      <Button variant="secondary" fill="solid" type="button" onClick={() => history.back()}>
-        Back
-      </Button>
+      {!config.featureToggles.topnav && (
+        <Button variant="secondary" fill="solid" type="button" onClick={() => history.back()}>
+          Back
+        </Button>
+      )}
       <LinkButton variant="secondary" fill="solid" href={exploreUrl} disabled={!canExploreDataSources}>
         Explore
       </LinkButton>
-      <Button
-        type="button"
-        variant="destructive"
-        disabled={!canDelete}
-        onClick={onDelete}
-        aria-label={selectors.pages.DataSource.delete}
-      >
-        Delete
-      </Button>
+      {!config.featureToggles.topnav && (
+        <Button
+          type="button"
+          variant="destructive"
+          disabled={!canDelete}
+          onClick={onDelete}
+          aria-label={selectors.pages.DataSource.delete}
+        >
+          Delete
+        </Button>
+      )}
       {canSave && (
         <Button
           type="submit"

--- a/public/app/features/datasources/components/EditDataSourceActions.tsx
+++ b/public/app/features/datasources/components/EditDataSourceActions.tsx
@@ -1,0 +1,99 @@
+import { css } from '@emotion/css';
+import React from 'react';
+
+import { GrafanaTheme2 } from '@grafana/data';
+import { config } from '@grafana/runtime';
+import { Button, LinkButton, useStyles2 } from '@grafana/ui';
+import { contextSrv } from 'app/core/core';
+import { AccessControlAction } from 'app/types';
+
+import { useDataSource, useDataSourceRights, useDeleteLoadedDataSource, useUpdateDatasource } from '../state';
+import { trackCreateDashboardClicked, trackExploreClicked } from '../tracking';
+import { constructDataSourceExploreUrl } from '../utils';
+
+const getStyles = (theme: GrafanaTheme2) => {
+  return {
+    button: css({
+      marginLeft: theme.spacing(2),
+    }),
+  };
+};
+
+interface ActionsProps {
+  uid: string;
+}
+
+export function EditDataSourceActions({ uid }: ActionsProps) {
+  const styles = useStyles2(getStyles);
+  const dataSource = useDataSource(uid);
+  const onDelete = useDeleteLoadedDataSource();
+  const onUpdate = useUpdateDatasource();
+
+  const { readOnly, hasWriteRights, hasDeleteRights } = useDataSourceRights(uid);
+  const hasExploreRights = contextSrv.hasPermission(AccessControlAction.DataSourcesExplore);
+
+  const canSave = !readOnly && hasWriteRights;
+  const canDelete = !readOnly && hasDeleteRights;
+
+  const onSubmit = async (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+    e.preventDefault();
+    await onUpdate({ ...dataSource });
+  };
+
+  return (
+    <>
+      <LinkButton
+        icon="apps"
+        fill="outline"
+        variant="secondary"
+        href={`dashboard/new-with-ds/${dataSource.uid}`}
+        onClick={() => {
+          trackCreateDashboardClicked({
+            grafana_version: config.buildInfo.version,
+            datasource_uid: dataSource.uid,
+            plugin_name: dataSource.typeName,
+            path: location.pathname,
+          });
+        }}
+      >
+        Build a dashboard
+      </LinkButton>
+
+      {hasExploreRights && (
+        <LinkButton
+          icon="compass"
+          fill="outline"
+          variant="secondary"
+          className={styles.button}
+          href={constructDataSourceExploreUrl(dataSource)}
+          onClick={() => {
+            trackExploreClicked({
+              grafana_version: config.buildInfo.version,
+              datasource_uid: dataSource.uid,
+              plugin_name: dataSource.typeName,
+              path: location.pathname,
+            });
+          }}
+        >
+          Explore
+        </LinkButton>
+      )}
+
+      <Button type="button" variant="destructive" disabled={!canDelete} onClick={onDelete} className={styles.button}>
+        Delete
+      </Button>
+
+      {canSave && (
+        <Button
+          type="submit"
+          variant="primary"
+          disabled={!canSave}
+          onClick={(event) => onSubmit(event)}
+          className={styles.button}
+        >
+          Save changes
+        </Button>
+      )}
+    </>
+  );
+}

--- a/public/app/features/datasources/components/EditDataSourceActions.tsx
+++ b/public/app/features/datasources/components/EditDataSourceActions.tsx
@@ -7,7 +7,7 @@ import { Button, LinkButton, useStyles2 } from '@grafana/ui';
 import { contextSrv } from 'app/core/core';
 import { AccessControlAction } from 'app/types';
 
-import { useDataSource, useDataSourceRights, useDeleteLoadedDataSource, useUpdateDatasource } from '../state';
+import { useDataSource, useDataSourceRights, useDeleteLoadedDataSource } from '../state';
 import { trackCreateDashboardClicked, trackExploreClicked } from '../tracking';
 import { constructDataSourceExploreUrl } from '../utils';
 
@@ -27,18 +27,11 @@ export function EditDataSourceActions({ uid }: ActionsProps) {
   const styles = useStyles2(getStyles);
   const dataSource = useDataSource(uid);
   const onDelete = useDeleteLoadedDataSource();
-  const onUpdate = useUpdateDatasource();
 
-  const { readOnly, hasWriteRights, hasDeleteRights } = useDataSourceRights(uid);
+  const { readOnly, hasDeleteRights } = useDataSourceRights(uid);
   const hasExploreRights = contextSrv.hasPermission(AccessControlAction.DataSourcesExplore);
 
-  const canSave = !readOnly && hasWriteRights;
   const canDelete = !readOnly && hasDeleteRights;
-
-  const onSubmit = async (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-    e.preventDefault();
-    await onUpdate({ ...dataSource });
-  };
 
   return (
     <>
@@ -82,18 +75,6 @@ export function EditDataSourceActions({ uid }: ActionsProps) {
       <Button type="button" variant="destructive" disabled={!canDelete} onClick={onDelete} className={styles.button}>
         Delete
       </Button>
-
-      {canSave && (
-        <Button
-          type="submit"
-          variant="primary"
-          disabled={!canSave}
-          onClick={(event) => onSubmit(event)}
-          className={styles.button}
-        >
-          Save changes
-        </Button>
-      )}
     </>
   );
 }

--- a/public/app/features/datasources/components/EditDataSourceActions.tsx
+++ b/public/app/features/datasources/components/EditDataSourceActions.tsx
@@ -19,11 +19,11 @@ const getStyles = (theme: GrafanaTheme2) => {
   };
 };
 
-interface ActionsProps {
+interface Props {
   uid: string;
 }
 
-export function EditDataSourceActions({ uid }: ActionsProps) {
+export function EditDataSourceActions({ uid }: Props) {
   const styles = useStyles2(getStyles);
   const dataSource = useDataSource(uid);
   const onDelete = useDeleteLoadedDataSource();

--- a/public/app/features/datasources/pages/EditDataSourcePage.test.tsx
+++ b/public/app/features/datasources/pages/EditDataSourcePage.test.tsx
@@ -5,6 +5,7 @@ import { TestProvider } from 'test/helpers/TestProvider';
 
 import { LayoutModes } from '@grafana/data';
 import { setAngularLoader } from '@grafana/runtime';
+import config from 'app/core/config';
 import { getRouteComponentProps } from 'app/core/navigation/__mocks__/routeProps';
 import { configureStore } from 'app/store/configureStore';
 
@@ -57,6 +58,7 @@ describe('<EditDataSourcePage>', () => {
   const dataSourceMeta = getMockDataSourceMeta();
   const dataSourceSettings = getMockDataSourceSettingsState();
   let store: Store;
+  const topnavValue = config.featureToggles.topnav;
 
   beforeAll(() => {
     setAngularLoader({
@@ -94,7 +96,12 @@ describe('<EditDataSourcePage>', () => {
     });
   });
 
+  afterAll(() => {
+    config.featureToggles.topnav = topnavValue;
+  });
+
   it('should render the edit page without an issue', async () => {
+    config.featureToggles.topnav = false;
     setup(uid, store);
 
     expect(screen.queryByText('Loading ...')).not.toBeInTheDocument();
@@ -104,11 +111,24 @@ describe('<EditDataSourcePage>', () => {
 
     // Buttons
     expect(screen.queryByRole('button', { name: /Back/i })).toBeVisible();
-    expect(screen.queryAllByRole('button', { name: /Delete/i })).toHaveLength(2);
+    expect(screen.queryByRole('button', { name: /Delete/i })).toBeVisible();
     expect(screen.queryByRole('button', { name: /Save (.*) test/i })).toBeVisible();
-    expect(screen.queryAllByText('Explore')).toHaveLength(2);
+    expect(screen.queryByRole('link', { name: /Explore/i })).toBeVisible();
 
     // wait for the rest of the async processes to finish
     expect(await screen.findByText(name)).toBeVisible();
+  });
+
+  it('should show updated action buttons when topnav is on', () => {
+    config.featureToggles.topnav = true;
+
+    setup(uid, store);
+
+    // Buttons
+    expect(screen.queryAllByRole('button', { name: /Back/i })).toHaveLength(0);
+    expect(screen.queryByRole('button', { name: /Delete/i })).toBeVisible();
+    expect(screen.queryByRole('button', { name: /Save (.*) test/i })).toBeVisible();
+    expect(screen.queryByRole('link', { name: /Build a dashboard/i })).toBeVisible();
+    expect(screen.queryAllByRole('link', { name: /Explore/i })).toHaveLength(2);
   });
 });

--- a/public/app/features/datasources/pages/EditDataSourcePage.test.tsx
+++ b/public/app/features/datasources/pages/EditDataSourcePage.test.tsx
@@ -1,4 +1,4 @@
-import { screen, render } from '@testing-library/react';
+import { screen, render, act } from '@testing-library/react';
 import React from 'react';
 import { Store } from 'redux';
 import { TestProvider } from 'test/helpers/TestProvider';
@@ -120,7 +120,9 @@ describe('<EditDataSourcePage>', () => {
   });
 
   it('should show updated action buttons when topnav is on', () => {
-    config.featureToggles.topnav = true;
+    act(() => {
+      config.featureToggles.topnav = true;
+    });
 
     setup(uid, store);
 

--- a/public/app/features/datasources/pages/EditDataSourcePage.test.tsx
+++ b/public/app/features/datasources/pages/EditDataSourcePage.test.tsx
@@ -1,4 +1,4 @@
-import { screen, render, act } from '@testing-library/react';
+import { screen, render, waitFor } from '@testing-library/react';
 import React from 'react';
 import { Store } from 'redux';
 import { TestProvider } from 'test/helpers/TestProvider';
@@ -119,18 +119,17 @@ describe('<EditDataSourcePage>', () => {
     expect(await screen.findByText(name)).toBeVisible();
   });
 
-  it('should show updated action buttons when topnav is on', () => {
-    act(() => {
-      config.featureToggles.topnav = true;
-    });
-
+  it('should show updated action buttons when topnav is on', async () => {
+    config.featureToggles.topnav = true;
     setup(uid, store);
 
-    // Buttons
-    expect(screen.queryAllByRole('button', { name: /Back/i })).toHaveLength(0);
-    expect(screen.queryByRole('button', { name: /Delete/i })).toBeVisible();
-    expect(screen.queryByRole('button', { name: /Save (.*) test/i })).toBeVisible();
-    expect(screen.queryByRole('link', { name: /Build a dashboard/i })).toBeVisible();
-    expect(screen.queryAllByRole('link', { name: /Explore/i })).toHaveLength(2);
+    await waitFor(() => {
+      // Buttons
+      expect(screen.queryAllByRole('button', { name: /Back/i })).toHaveLength(0);
+      expect(screen.queryByRole('button', { name: /Delete/i })).toBeVisible();
+      expect(screen.queryByRole('button', { name: /Save (.*) test/i })).toBeVisible();
+      expect(screen.queryByRole('link', { name: /Build a dashboard/i })).toBeVisible();
+      expect(screen.queryAllByRole('link', { name: /Explore/i })).toHaveLength(2);
+    });
   });
 });

--- a/public/app/features/datasources/pages/EditDataSourcePage.test.tsx
+++ b/public/app/features/datasources/pages/EditDataSourcePage.test.tsx
@@ -104,9 +104,9 @@ describe('<EditDataSourcePage>', () => {
 
     // Buttons
     expect(screen.queryByRole('button', { name: /Back/i })).toBeVisible();
-    expect(screen.queryByRole('button', { name: /Delete/i })).toBeVisible();
+    expect(screen.queryAllByRole('button', { name: /Delete/i })).toHaveLength(2);
     expect(screen.queryByRole('button', { name: /Save (.*) test/i })).toBeVisible();
-    expect(screen.queryByText('Explore')).toBeVisible();
+    expect(screen.queryAllByText('Explore')).toHaveLength(2);
 
     // wait for the rest of the async processes to finish
     expect(await screen.findByText(name)).toBeVisible();

--- a/public/app/features/datasources/pages/EditDataSourcePage.tsx
+++ b/public/app/features/datasources/pages/EditDataSourcePage.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { config } from '@grafana/runtime';
 import { Page } from 'app/core/components/Page/Page';
 import { GrafanaRouteComponentProps } from 'app/core/navigation/types';
 
@@ -16,7 +17,11 @@ export function EditDataSourcePage(props: Props) {
   const nav = useDataSourceSettingsNav(uid, pageId);
 
   return (
-    <Page navId="datasources" pageNav={nav.main} actions={<EditDataSourceActions uid={uid} />}>
+    <Page
+      navId="datasources"
+      pageNav={nav.main}
+      actions={config.featureToggles.topnav ? <EditDataSourceActions uid={uid} /> : undefined}
+    >
       <Page.Contents>
         <EditDataSource uid={uid} pageId={pageId} />
       </Page.Contents>

--- a/public/app/features/datasources/pages/EditDataSourcePage.tsx
+++ b/public/app/features/datasources/pages/EditDataSourcePage.tsx
@@ -4,6 +4,7 @@ import { Page } from 'app/core/components/Page/Page';
 import { GrafanaRouteComponentProps } from 'app/core/navigation/types';
 
 import { EditDataSource } from '../components/EditDataSource';
+import { EditDataSourceActions } from '../components/EditDataSourceActions';
 import { useDataSourceSettingsNav } from '../state';
 
 export interface Props extends GrafanaRouteComponentProps<{ uid: string }> {}
@@ -15,7 +16,7 @@ export function EditDataSourcePage(props: Props) {
   const nav = useDataSourceSettingsNav(uid, pageId);
 
   return (
-    <Page navId="datasources" pageNav={nav.main}>
+    <Page navId="datasources" pageNav={nav.main} actions={<EditDataSourceActions uid={uid} />}>
       <Page.Contents>
         <EditDataSource uid={uid} pageId={pageId} />
       </Page.Contents>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Adding action buttons in the header of EditDataSourcePage at both occurrences, namely under Connections and Admin.
[Screencast from 2023-03-09 09-00-36.webm](https://user-images.githubusercontent.com/13637610/223963567-0e0ac12d-fc45-480c-a3aa-ae85ef9f3ec9.webm)

UPDATE:
[Topnav OFF]
Do not show buttons in the header. Leave buttons as they are in the footer.

![Screenshot from 2023-04-05 11-40-57](https://user-images.githubusercontent.com/13637610/230046398-17476c7b-c566-41ae-a96f-18405e4f2805.png)
![Screenshot from 2023-04-05 11-40-50](https://user-images.githubusercontent.com/13637610/230046405-9d28ab8d-5de1-4d95-84fb-9f3ea6fa62dc.png)

[Topnav ON]
Header:
- build a dashboard
- explore
- delete

![Screenshot from 2023-04-05 11-38-54](https://user-images.githubusercontent.com/13637610/230046410-3a999bd1-a018-48f0-8620-82d176d71869.png)

Footer:
- explore
- save & test

That also means we want to remove the Back button.

![Screenshot from 2023-04-05 11-39-15](https://user-images.githubusercontent.com/13637610/230046408-ef9cce1c-ef9b-4526-9984-e9236946a13f.png)



**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #58311