### PR TITLE
CI: Move some build settings

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -537,8 +537,6 @@ steps:
   - git tag $${TEST_TAG} && git push https://$${GITHUB_TOKEN}@github.com/grafana/grafana.git
     $${TEST_TAG}
   environment:
-    DOWNSTREAM_REPO:
-      from_secret: downstream
     GITHUB_TOKEN:
       from_secret: github_token_pr
     TEST_TAG: v0.0.0-test
@@ -6690,6 +6688,6 @@ kind: secret
 name: enterprise2_security_prefix
 ---
 kind: signature
-hmac: 3c6a942f7e8e4472be0e7d46f00871612d0c40071085417947e8bb5ef47fa28c
+hmac: 9b743a1d8808c69cba9497ca9f2015a2cf82d6f82568a04516c006a56dbec0ae
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -6659,7 +6659,37 @@ get:
 kind: secret
 name: aws_secret_access_key
 ---
+get:
+  name: bucket
+  path: infra/data/ci/grafana-release-eng/security-bucket
+kind: secret
+name: security_dest_bucket
+---
+get:
+  name: static_asset_editions
+  path: infra/data/ci/grafana-release-eng/artifact-publishing
+kind: secret
+name: static_asset_editions
+---
+get:
+  name: security_prefix
+  path: infra/data/ci/grafana-release-eng/enterprise2
+kind: secret
+name: enterprise2_security_prefix
+---
+get:
+  name: cdn_path
+  path: infra/data/ci/grafana-release-eng/enterprise2
+kind: secret
+name: enterprise2-cdn-path
+---
+get:
+  name: security_prefix
+  path: infra/data/ci/grafana-release-eng/enterprise2
+kind: secret
+name: enterprise2_security_prefix
+---
 kind: signature
-hmac: f7d8c2ffc5017c41f66d2cceda20bbfc94afc46a5669984a83a23419f58d3dee
+hmac: 3c6a942f7e8e4472be0e7d46f00871612d0c40071085417947e8bb5ef47fa28c
 
 ...

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -1481,7 +1481,6 @@ def trigger_test_release():
         "image": build_image,
         "environment": {
             "GITHUB_TOKEN": from_secret("github_token_pr"),
-            "DOWNSTREAM_REPO": from_secret("downstream"),
             "TEST_TAG": "v0.0.0-test",
         },
         "commands": [

--- a/scripts/drone/vault.star
+++ b/scripts/drone/vault.star
@@ -94,4 +94,29 @@ def secrets():
             "secret/data/common/aws-marketplace",
             "aws_secret_access_key",
         ),
+        vault_secret(
+            "security_dest_bucket",
+            "infra/data/ci/grafana-release-eng/security-bucket",
+            "bucket",
+        ),
+        vault_secret(
+            "static_asset_editions",
+            "infra/data/ci/grafana-release-eng/artifact-publishing",
+            "static_asset_editions",
+        ),
+        vault_secret(
+            "enterprise2_security_prefix",
+            "infra/data/ci/grafana-release-eng/enterprise2",
+            "security_prefix",
+        ),
+        vault_secret(
+            "enterprise2-cdn-path",
+            "infra/data/ci/grafana-release-eng/enterprise2",
+            "cdn_path",
+        ),
+        vault_secret(
+            "enterprise2_security_prefix",
+            "infra/data/ci/grafana-release-eng/enterprise2",
+            "security_prefix",
+        ),
     ]


### PR DESCRIPTION
**What is this feature?**

This moves some of the build settings that are currently stored Drone into a central store.

**Why do we need this feature?**

This is part of an effort to move settings into a single place to allow reuse and easier management by the releng team.

**Who is this feature for?**

The release-engineering team