### PR TITLE
Logs: Fix border radius to be consistent

### DIFF
--- a/public/app/features/logs/components/LogRowContext.tsx
+++ b/public/app/features/logs/components/LogRowContext.tsx
@@ -80,7 +80,7 @@ const getLogRowContextStyles = (theme: GrafanaTheme2, wrapLogMessage?: boolean, 
       background: ${theme.colors.background.primary};
       box-shadow: 0 0 ${theme.spacing(1.25)} ${theme.v1.palette.black};
       border: 1px solid ${theme.colors.background.secondary};
-      border-radius: ${theme.shape.borderRadius(2)};
+      border-radius: ${theme.shape.borderRadius()};
       font-family: ${theme.typography.fontFamily};
     `,
     header: css`

--- a/public/app/features/logs/components/getLogRowStyles.ts
+++ b/public/app/features/logs/components/getLogRowStyles.ts
@@ -143,7 +143,7 @@ export const getLogRowStyles = memoizeOne((theme: GrafanaTheme2) => {
       label: logs-row-details-table;
       border: 1px solid ${theme.colors.border.medium};
       padding: 0 ${theme.spacing(1)} ${theme.spacing(1)};
-      border-radius: ${theme.shape.borderRadius(1.5)};
+      border-radius: ${theme.shape.borderRadius()};
       margin: ${theme.spacing(2.5)} ${theme.spacing(1)} ${theme.spacing(2.5)} ${theme.spacing(2)};
       cursor: default;
     `,


### PR DESCRIPTION
Related to https://github.com/grafana/grafana/issues/64423, fixes border radius to default size in logs codebase to be consistent accross grafana codebase.

Now: 
<img width="835" alt="image" src="https://user-images.githubusercontent.com/30407135/224022767-e1dd2f87-8640-4bbd-8c8f-e17542c020b6.png">
<img width="691" alt="image" src="https://user-images.githubusercontent.com/30407135/224022860-828496b3-aba0-4cde-9953-15c948f1645c.png">

Before:
<img width="875" alt="image" src="https://user-images.githubusercontent.com/30407135/224022996-ba93fc5a-490e-4f3f-8e82-387a06b3da18.png">
<img width="811" alt="image" src="https://user-images.githubusercontent.com/30407135/224023050-36ae78b4-0c67-48bd-b93a-db7382d79516.png">
