### PR TITLE
Elasticsearch: Fix histogram fields to be filterale when processed trough backend

### DIFF
--- a/pkg/tsdb/elasticsearch/response_parser.go
+++ b/pkg/tsdb/elasticsearch/response_parser.go
@@ -732,14 +732,18 @@ func processAggregationDocs(esAgg *simplejson.Json, aggDef *BucketAgg, target *Q
 }
 
 func extractDataField(name string, v interface{}) *data.Field {
+	var field *data.Field
 	switch v.(type) {
 	case *string:
-		return data.NewField(name, nil, []*string{})
+		field = data.NewField(name, nil, []*string{})
 	case *float64:
-		return data.NewField(name, nil, []*float64{})
+		field = data.NewField(name, nil, []*float64{})
 	default:
-		return &data.Field{}
+		field = &data.Field{}
 	}
+	isFilterable := true
+	field.Config = &data.FieldConfig{Filterable: &isFilterable}
+	return field
 }
 
 func trimDatapoints(queryResult backend.DataResponse, target *Query) {

--- a/pkg/tsdb/elasticsearch/response_parser_frontend_test.go
+++ b/pkg/tsdb/elasticsearch/response_parser_frontend_test.go
@@ -812,24 +812,23 @@ func TestHistogramSimple(t *testing.T) {
 
 	require.Len(t, result.response.Responses, 1)
 	frames := result.response.Responses["A"].Frames
-	// require.Len(t, frames, 3) // FIXME
+	require.Len(t, frames, 1)
 
 	fields := frames[0].Fields
 	require.Len(t, fields, 2)
+	require.Equal(t, fields[0].Len(), 3)
 
 	field1 := fields[0]
 	field2 := fields[1]
 
 	require.Equal(t, "bytes", field1.Name)
 
-	// trueValue := true
-	// filterableConfig := data.FieldConfig{Filterable: &trueValue}
+	trueValue := true
+	filterableConfig := data.FieldConfig{Filterable: &trueValue}
 
 	// we need to test that the only changed setting is `filterable`
-	// require.Equal(t, filterableConfig, *field1.Config) // FIXME
-
+	require.Equal(t, filterableConfig, *field1.Config)
 	require.Equal(t, "Count", field2.Name)
-
 	// we need to test that the fieldConfig is "empty"
 	require.Nil(t, field2.Config)
 }

--- a/pkg/tsdb/elasticsearch/response_parser_frontend_test.go
+++ b/pkg/tsdb/elasticsearch/response_parser_frontend_test.go
@@ -813,10 +813,10 @@ func TestHistogramSimple(t *testing.T) {
 	require.Len(t, result.response.Responses, 1)
 	frames := result.response.Responses["A"].Frames
 	require.Len(t, frames, 1)
+	requireFrameLength(t, frames[0], 3)
 
 	fields := frames[0].Fields
 	require.Len(t, fields, 2)
-	require.Equal(t, fields[0].Len(), 3)
 
 	field1 := fields[0]
 	field2 := fields[1]


### PR DESCRIPTION
Part of https://github.com/grafana/grafana/issues/54011. This PR fixes processing of histograms on backend. The histogram fields were not filterable. Therefore we added a fix that makes them filterable and we uncommented tests that were previously failing.  