### PR TITLE
[9.3.x] CI: Move some build settings (#64491)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -537,8 +537,6 @@ steps:
   - git tag $${TEST_TAG} && git push https://$${GITHUB_TOKEN}@github.com/grafana/grafana.git
     $${TEST_TAG}
   environment:
-    DOWNSTREAM_REPO:
-      from_secret: downstream
     GITHUB_TOKEN:
       from_secret: github_token_pr
     TEST_TAG: v0.0.0-test
@@ -6659,7 +6657,37 @@ get:
 kind: secret
 name: aws_secret_access_key
 ---
+get:
+  name: bucket
+  path: infra/data/ci/grafana-release-eng/security-bucket
+kind: secret
+name: security_dest_bucket
+---
+get:
+  name: static_asset_editions
+  path: infra/data/ci/grafana-release-eng/artifact-publishing
+kind: secret
+name: static_asset_editions
+---
+get:
+  name: security_prefix
+  path: infra/data/ci/grafana-release-eng/enterprise2
+kind: secret
+name: enterprise2_security_prefix
+---
+get:
+  name: cdn_path
+  path: infra/data/ci/grafana-release-eng/enterprise2
+kind: secret
+name: enterprise2-cdn-path
+---
+get:
+  name: security_prefix
+  path: infra/data/ci/grafana-release-eng/enterprise2
+kind: secret
+name: enterprise2_security_prefix
+---
 kind: signature
-hmac: dd9976b462df05928ef9f02730c259c0fd294f72931d104b6bc52173227c0d71
+hmac: 0ed39d3a2175d7193560aa418783e86133e5bfcecfbfc469f40daf36bf4234ed
 
 ...

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -1481,7 +1481,6 @@ def trigger_test_release():
         "image": build_image,
         "environment": {
             "GITHUB_TOKEN": from_secret("github_token_pr"),
-            "DOWNSTREAM_REPO": from_secret("downstream"),
             "TEST_TAG": "v0.0.0-test",
         },
         "commands": [

--- a/scripts/drone/vault.star
+++ b/scripts/drone/vault.star
@@ -94,4 +94,29 @@ def secrets():
             "secret/data/common/aws-marketplace",
             "aws_secret_access_key",
         ),
+        vault_secret(
+            "security_dest_bucket",
+            "infra/data/ci/grafana-release-eng/security-bucket",
+            "bucket",
+        ),
+        vault_secret(
+            "static_asset_editions",
+            "infra/data/ci/grafana-release-eng/artifact-publishing",
+            "static_asset_editions",
+        ),
+        vault_secret(
+            "enterprise2_security_prefix",
+            "infra/data/ci/grafana-release-eng/enterprise2",
+            "security_prefix",
+        ),
+        vault_secret(
+            "enterprise2-cdn-path",
+            "infra/data/ci/grafana-release-eng/enterprise2",
+            "cdn_path",
+        ),
+        vault_secret(
+            "enterprise2_security_prefix",
+            "infra/data/ci/grafana-release-eng/enterprise2",
+            "security_prefix",
+        ),
     ]


### PR DESCRIPTION
Backporting https://github.com/grafana/grafana/pull/64491.

* Move some build settings to Vault

* CI: Remove reference to DOWNSTREAM_REPO as it isn't used

(cherry picked from commit 4b241804b401eed529e41fa775186d8ffe89ea1c)