### PR TITLE
[9.2.x] CI: Move some build settings (#64491)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -520,8 +520,6 @@ steps:
   - git tag $${TEST_TAG} && git push https://$${GITHUB_TOKEN}@github.com/grafana/grafana.git
     $${TEST_TAG}
   environment:
-    DOWNSTREAM_REPO:
-      from_secret: downstream
     GITHUB_TOKEN:
       from_secret: github_token_pr
     TEST_TAG: v0.0.0-test
@@ -6523,7 +6521,37 @@ get:
 kind: secret
 name: aws_secret_access_key
 ---
+get:
+  name: bucket
+  path: infra/data/ci/grafana-release-eng/security-bucket
+kind: secret
+name: security_dest_bucket
+---
+get:
+  name: static_asset_editions
+  path: infra/data/ci/grafana-release-eng/artifact-publishing
+kind: secret
+name: static_asset_editions
+---
+get:
+  name: security_prefix
+  path: infra/data/ci/grafana-release-eng/enterprise2
+kind: secret
+name: enterprise2_security_prefix
+---
+get:
+  name: cdn_path
+  path: infra/data/ci/grafana-release-eng/enterprise2
+kind: secret
+name: enterprise2-cdn-path
+---
+get:
+  name: security_prefix
+  path: infra/data/ci/grafana-release-eng/enterprise2
+kind: secret
+name: enterprise2_security_prefix
+---
 kind: signature
-hmac: d77fb0a3aa52ab5e6d17f5626a3988288cc193524a0bbc2d3e1fa98e779ae340
+hmac: aeb60fb4807df0f275d5a54e21154337acd8157bde0c31203e17bd878b327718
 
 ...

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -1469,7 +1469,6 @@ def trigger_test_release():
         "image": build_image,
         "environment": {
             "GITHUB_TOKEN": from_secret("github_token_pr"),
-            "DOWNSTREAM_REPO": from_secret("downstream"),
             "TEST_TAG": "v0.0.0-test",
         },
         "commands": [

--- a/scripts/drone/vault.star
+++ b/scripts/drone/vault.star
@@ -94,4 +94,29 @@ def secrets():
             "secret/data/common/aws-marketplace",
             "aws_secret_access_key",
         ),
+        vault_secret(
+            "security_dest_bucket",
+            "infra/data/ci/grafana-release-eng/security-bucket",
+            "bucket",
+        ),
+        vault_secret(
+            "static_asset_editions",
+            "infra/data/ci/grafana-release-eng/artifact-publishing",
+            "static_asset_editions",
+        ),
+        vault_secret(
+            "enterprise2_security_prefix",
+            "infra/data/ci/grafana-release-eng/enterprise2",
+            "security_prefix",
+        ),
+        vault_secret(
+            "enterprise2-cdn-path",
+            "infra/data/ci/grafana-release-eng/enterprise2",
+            "cdn_path",
+        ),
+        vault_secret(
+            "enterprise2_security_prefix",
+            "infra/data/ci/grafana-release-eng/enterprise2",
+            "security_prefix",
+        ),
     ]


### PR DESCRIPTION
Backporting https://github.com/grafana/grafana/pull/64491.

* Move some build settings to Vault

* CI: Remove reference to DOWNSTREAM_REPO as it isn't used

(cherry picked from commit 4b241804b401eed529e41fa775186d8ffe89ea1c)
