### PR TITLE
CI: Add `PrereleaseBucket` field in `versions.go`

### DIFF
--- a/pkg/build/config/versions.go
+++ b/pkg/build/config/versions.go
@@ -120,6 +120,7 @@ var Versions = VersionMap{
 				Alpine,
 				Ubuntu,
 			},
+			PrereleaseBucket: "grafana-prerelease/artifacts/docker",
 		},
 		Buckets: Buckets{
 			Artifacts:            "grafana-downloads",


### PR DESCRIPTION
**What is this feature?**

Adds a `PrereleaseBucket` field, which defines from which bucket dir the image file should be fetched, for enterprise2 images.

**Why do we need this feature?**

Currently, `v9.4.x` branch is broken. Drone build: https://drone.grafana.net/grafana/grafana/105307/11/18