### PR TITLE
Chore: fix EmptyStateNoDatasource flaky test

### DIFF
--- a/public/app/features/datasources/components/EmptyStateNoDatasource.test.tsx
+++ b/public/app/features/datasources/components/EmptyStateNoDatasource.test.tsx
@@ -7,7 +7,6 @@ import { TestProvider } from 'test/helpers/TestProvider';
 
 import { DataSourcePluginMeta } from '@grafana/data';
 import * as runtime from '@grafana/runtime';
-import { backendSrv } from 'app/core/services/backend_srv';
 import { contextSrv } from 'app/core/services/context_srv';
 import 'whatwg-fetch';
 
@@ -27,8 +26,6 @@ afterEach(() => {
 });
 
 beforeAll(() => {
-  runtime.setBackendSrv(backendSrv);
-
   server.listen({ onUnhandledRequest: 'bypass' });
 });
 

--- a/public/app/features/datasources/components/EmptyStateNoDatasource.tsx
+++ b/public/app/features/datasources/components/EmptyStateNoDatasource.tsx
@@ -3,9 +3,10 @@ import React, { ComponentProps } from 'react';
 import { useAsync } from 'react-use';
 
 import { DataSourcePluginMeta, GrafanaTheme2, PageLayoutType } from '@grafana/data';
-import { getBackendSrv, reportInteraction } from '@grafana/runtime';
+import { reportInteraction } from '@grafana/runtime';
 import { Icon, useStyles2 } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
+import { useGrafana } from 'app/core/context/GrafanaContext';
 import { contextSrv } from 'app/core/core';
 import { t } from 'app/core/internationalization';
 import { useAddDatasource } from 'app/features/datasources/state';
@@ -30,8 +31,9 @@ interface Props extends Pick<ComponentProps<typeof Page>, 'navId' | 'pageNav'> {
 
 export function EmptyStateNoDatasource({ onCTAClick, loading = false, title, CTAText, navId, pageNav }: Props) {
   const styles = useStyles2(getStyles);
+  const { backend } = useGrafana();
   const { value: datasources, loading: loadingDatasources } = useAsync(async () => {
-    const datasourceMeta: DataSourcePluginMeta[] = await getBackendSrv().get('/api/plugins', {
+    const datasourceMeta: DataSourcePluginMeta[] = await backend.get('/api/plugins', {
       enabled: 1,
       type: 'datasource',
     });

--- a/public/test/mocks/getGrafanaContextMock.ts
+++ b/public/test/mocks/getGrafanaContextMock.ts
@@ -1,15 +1,15 @@
 import { GrafanaConfig } from '@grafana/data';
-import { BackendSrv, LocationService } from '@grafana/runtime';
+import { LocationService } from '@grafana/runtime';
 import { AppChromeService } from 'app/core/components/AppChrome/AppChromeService';
 import { GrafanaContextType } from 'app/core/context/GrafanaContext';
+import { backendSrv } from 'app/core/services/backend_srv';
 import { KeybindingSrv } from 'app/core/services/keybindingSrv';
 
 /** Not sure what this should evolve into, just a starting point */
 export function getGrafanaContextMock(overrides: Partial<GrafanaContextType> = {}): GrafanaContextType {
   return {
     chrome: new AppChromeService(),
-    // eslint-disable-next-line
-    backend: {} as BackendSrv,
+    backend: backendSrv,
     // eslint-disable-next-line
     location: {} as LocationService,
     // eslint-disable-next-line


### PR DESCRIPTION
(tries to) Fixes #64402 

in theory the executed test code is the same, this PR just makes the edependency on backendSrv in tests more explicit by:
- using `backend` from grafana context in the component
- use `backendSrv` from core in the test context setup