### PR TITLE
PanelHeader: Add analytics

### DIFF
--- a/public/app/features/dashboard/utils/getPanelMenu.ts
+++ b/public/app/features/dashboard/utils/getPanelMenu.ts
@@ -43,6 +43,7 @@ export function getPanelMenu(
     locationService.partial({
       viewPanel: panel.id,
     });
+    reportInteraction('dashboards_panelheader_view_clicked');
   };
 
   const onEditPanel = (event: React.MouseEvent<any>) => {
@@ -50,21 +51,25 @@ export function getPanelMenu(
     locationService.partial({
       editPanel: panel.id,
     });
+    reportInteraction('dashboards_panelheader_edit_clicked');
   };
 
   const onSharePanel = (event: React.MouseEvent<any>) => {
     event.preventDefault();
     sharePanel(dashboard, panel);
+    reportInteraction('dashboards_panelheader_share_clicked');
   };
 
   const onAddLibraryPanel = (event: React.MouseEvent<any>) => {
     event.preventDefault();
     addLibraryPanel(dashboard, panel);
+    reportInteraction('dashboards_panelheader_createlibrarypanel_clicked');
   };
 
   const onUnlinkLibraryPanel = (event: React.MouseEvent<any>) => {
     event.preventDefault();
     unlinkLibraryPanel(panel);
+    reportInteraction('dashboards_panelheader_unlinklibrarypanel_clicked');
   };
 
   const onInspectPanel = (tab?: InspectTab) => {
@@ -72,10 +77,7 @@ export function getPanelMenu(
       inspect: panel.id,
       inspectTab: tab,
     });
-
-    reportInteraction('grafana_panel_menu_inspect', {
-      tab: tab ?? InspectTab.Data,
-    });
+    reportInteraction('dashboards_panelheader_inspect_clicked', { tab: tab ?? InspectTab.Data });
   };
 
   const onMore = (event: React.MouseEvent<any>) => {
@@ -85,16 +87,19 @@ export function getPanelMenu(
   const onDuplicatePanel = (event: React.MouseEvent<any>) => {
     event.preventDefault();
     duplicatePanel(dashboard, panel);
+    reportInteraction('dashboards_panelheader_duplicate_clicked');
   };
 
   const onCopyPanel = (event: React.MouseEvent<any>) => {
     event.preventDefault();
     copyPanel(panel);
+    reportInteraction('dashboards_panelheader_copy_clicked');
   };
 
   const onRemovePanel = (event: React.MouseEvent<any>) => {
     event.preventDefault();
     removePanel(dashboard, panel, true);
+    reportInteraction('dashboards_panelheader_remove_clicked');
   };
 
   const onNavigateToExplore = (event: React.MouseEvent<any>) => {
@@ -102,16 +107,19 @@ export function getPanelMenu(
     const openInNewWindow =
       event.ctrlKey || event.metaKey ? (url: string) => window.open(`${config.appSubUrl}${url}`) : undefined;
     store.dispatch(navigateToExplore(panel, { getDataSourceSrv, getTimeSrv, getExploreUrl, openInNewWindow }) as any);
+    reportInteraction('dashboards_panelheader_explore_clicked');
   };
 
   const onToggleLegend = (event: React.MouseEvent) => {
     event.preventDefault();
     toggleLegend(panel);
+    reportInteraction('dashboards_panelheader_togglelegend_clicked');
   };
 
   const onCancelStreaming = (event: React.MouseEvent) => {
     event.preventDefault();
     panel.getQueryRunner().cancelQuery();
+    reportInteraction('dashboards_panelheader_cancelstreaming_clicked');
   };
 
   const menu: PanelMenuItem[] = [];


### PR DESCRIPTION
Implement reporting to interactions on the panel menu

<img width="481" alt="Captura de pantalla 2023-03-09 a las 16 20 24" src="https://user-images.githubusercontent.com/5699976/224072344-3e2dfde0-4147-4203-a88a-224c25432b16.png">
<img width="357" alt="Captura de pantalla 2023-03-09 a las 16 20 18" src="https://user-images.githubusercontent.com/5699976/224072349-a83b934e-ecd1-4465-91e9-81ffd5c5cc8e.png">

Those events are reported when the user clicks on those options.

Fixes #63501 

* @thanos-karachalios in the issue we mentioned adding an event when clicking in `More`. But more won't be ever clicked because it opens when hovers as well. Does it make sense to add clicks in `More`? 