### PR TITLE
Use standard border-radius as 2px

### DIFF
--- a/public/app/plugins/datasource/graphite/components/MetricTankMetaInspector.tsx
+++ b/public/app/plugins/datasource/graphite/components/MetricTankMetaInspector.tsx
@@ -6,8 +6,8 @@ import { stylesFactory } from '@grafana/ui';
 import { config } from 'app/core/config';
 
 import { GraphiteDatasource } from '../datasource';
-import { parseSchemaRetentions, getRollupNotice, getRuntimeConsolidationNotice } from '../meta';
-import { GraphiteQuery, GraphiteOptions, MetricTankSeriesMeta } from '../types';
+import { getRollupNotice, getRuntimeConsolidationNotice, parseSchemaRetentions } from '../meta';
+import { GraphiteOptions, GraphiteQuery, MetricTankSeriesMeta } from '../types';
 
 export type Props = MetadataInspectorProps<GraphiteDatasource, GraphiteQuery, GraphiteOptions>;
 
@@ -163,7 +163,7 @@ const getStyles = stylesFactory(() => {
     bucket: css`
       display: flex;
       margin-bottom: ${theme.spacing.sm};
-      border-radius: ${theme.border.radius.md};
+      border-radius: ${theme.border.radius.sm};
     `,
     bucketInterval: css`
       flex-grow: 0;
@@ -174,7 +174,7 @@ const getStyles = stylesFactory(() => {
       text-align: center;
       color: ${theme.palette.white};
       margin-right: ${theme.spacing.md};
-      border-radius: ${theme.border.radius.md};
+      border-radius: ${theme.border.radius.sm};
     `,
     bucketRetentionActive: css`
       background: linear-gradient(0deg, ${theme.palette.greenBase}, ${theme.palette.greenShade});


### PR DESCRIPTION
We are standardising border radius as 2px. 
The base values are defined here: `packages/grafana-data/src/themes/createV1Theme.ts`
https://github.com/grafana/grafana/blob/main/packages/grafana-data/src/themes/createV1Theme.ts