### PR TITLE
Alerting: Add for error to alerting API

### DIFF
--- a/pkg/services/ngalert/api/api_ruler.go
+++ b/pkg/services/ngalert/api/api_ruler.go
@@ -446,6 +446,7 @@ func toGettableExtendedRuleNode(r ngmodels.AlertRule, namespaceID int64, provena
 	if prov, exists := provenanceRecords[r.ResourceID()]; exists {
 		provenance = prov
 	}
+	forErrorDuration := model.Duration(r.ForError)
 	gettableExtendedRuleNode := apimodels.GettableExtendedRuleNode{
 		GrafanaManagedAlert: &apimodels.GettableGrafanaRule{
 			ID:              r.ID,
@@ -463,6 +464,7 @@ func toGettableExtendedRuleNode(r ngmodels.AlertRule, namespaceID int64, provena
 			NoDataState:     apimodels.NoDataState(r.NoDataState),
 			ExecErrState:    apimodels.ExecutionErrorState(r.ExecErrState),
 			Provenance:      apimodels.Provenance(provenance),
+			ForError:        &forErrorDuration,
 			IsPaused:        r.IsPaused,
 		},
 	}

--- a/pkg/services/ngalert/api/api_ruler_validation.go
+++ b/pkg/services/ngalert/api/api_ruler_validation.go
@@ -105,6 +105,11 @@ func validateRuleNode(
 		return nil, err
 	}
 
+	newAlertRule.ForError, err = validateForErrorInterval(ruleNode)
+	if err != nil {
+		return nil, err
+	}
+
 	if ruleNode.ApiRuleNode != nil {
 		newAlertRule.Annotations = ruleNode.ApiRuleNode.Annotations
 		newAlertRule.Labels = ruleNode.ApiRuleNode.Labels
@@ -144,6 +149,22 @@ func validateForInterval(ruleNode *apimodels.PostableExtendedRuleNode) (time.Dur
 	duration := time.Duration(*ruleNode.ApiRuleNode.For)
 	if duration < 0 {
 		return 0, fmt.Errorf("field `for` cannot be negative [%v]. 0 or any positive duration are allowed", *ruleNode.ApiRuleNode.For)
+	}
+	return duration, nil
+}
+
+// validateForErrorInterval validates GrafanaManagedAlert.ForError and converts it to time.Duration.
+// If the field is not specified returns 0 if GrafanaManagedAlert.UID is empty and -1 if it is not.
+func validateForErrorInterval(ruleNode *apimodels.PostableExtendedRuleNode) (time.Duration, error) {
+	if ruleNode.GrafanaManagedAlert == nil || ruleNode.GrafanaManagedAlert.ForError == nil {
+		if ruleNode.GrafanaManagedAlert.UID != "" {
+			return -1, nil // will be patched later with the real value of the current version of the rule
+		}
+		return 0, nil // if it's a new rule, use the 0 as the default
+	}
+	duration := time.Duration(*ruleNode.GrafanaManagedAlert.ForError)
+	if duration < 0 {
+		return 0, fmt.Errorf("field `forError` cannot be negative [%v]. 0 or any positive duration are allowed", *ruleNode.GrafanaManagedAlert.ForError)
 	}
 	return duration, nil
 }

--- a/pkg/services/ngalert/api/api_ruler_validation_test.go
+++ b/pkg/services/ngalert/api/api_ruler_validation_test.go
@@ -43,6 +43,7 @@ func config(t *testing.T) *setting.UnifiedAlertingSettings {
 
 func validRule() apimodels.PostableExtendedRuleNode {
 	forDuration := model.Duration(rand.Int63n(1000))
+	forErrorDuration := model.Duration(rand.Int63n(2000))
 	return apimodels.PostableExtendedRuleNode{
 		ApiRuleNode: &apimodels.ApiRuleNode{
 			For: &forDuration,
@@ -71,6 +72,7 @@ func validRule() apimodels.PostableExtendedRuleNode {
 			UID:          util.GenerateShortUID(),
 			NoDataState:  allNoData[rand.Intn(len(allNoData))],
 			ExecErrState: allExecError[rand.Intn(len(allExecError))],
+			ForError:     &forErrorDuration,
 		},
 	}
 }
@@ -260,6 +262,7 @@ func TestValidateRuleNode_NoUID(t *testing.T) {
 				require.Equal(t, models.NoDataState(api.GrafanaManagedAlert.NoDataState), alert.NoDataState)
 				require.Equal(t, models.ExecutionErrorState(api.GrafanaManagedAlert.ExecErrState), alert.ExecErrState)
 				require.Equal(t, time.Duration(*api.ApiRuleNode.For), alert.For)
+				require.Equal(t, time.Duration(*api.GrafanaManagedAlert.ForError), alert.ForError)
 				require.Equal(t, api.ApiRuleNode.Annotations, alert.Annotations)
 				require.Equal(t, api.ApiRuleNode.Labels, alert.Labels)
 			},

--- a/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
+++ b/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
@@ -372,6 +372,7 @@ type PostableGrafanaRule struct {
 	UID          string              `json:"uid" yaml:"uid"`
 	NoDataState  NoDataState         `json:"no_data_state" yaml:"no_data_state"`
 	ExecErrState ExecutionErrorState `json:"exec_err_state" yaml:"exec_err_state"`
+	ForError     *model.Duration     `json:"for_error" json:"for_error"`
 	IsPaused     *bool               `json:"is_paused" yaml:"is_paused"`
 }
 
@@ -392,6 +393,7 @@ type GettableGrafanaRule struct {
 	NoDataState     NoDataState         `json:"no_data_state" yaml:"no_data_state"`
 	ExecErrState    ExecutionErrorState `json:"exec_err_state" yaml:"exec_err_state"`
 	Provenance      Provenance          `json:"provenance,omitempty" yaml:"provenance,omitempty"`
+	ForError        *model.Duration     `json:"for_error" json:"for_error"`
 	IsPaused        bool                `json:"is_paused" yaml:"is_paused"`
 }
 

--- a/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
+++ b/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
@@ -372,7 +372,7 @@ type PostableGrafanaRule struct {
 	UID          string              `json:"uid" yaml:"uid"`
 	NoDataState  NoDataState         `json:"no_data_state" yaml:"no_data_state"`
 	ExecErrState ExecutionErrorState `json:"exec_err_state" yaml:"exec_err_state"`
-	ForError     *model.Duration     `json:"for_error" json:"for_error"`
+	ForError     *model.Duration     `json:"for_error" yaml:"for_error"`
 	IsPaused     *bool               `json:"is_paused" yaml:"is_paused"`
 }
 

--- a/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
+++ b/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
@@ -393,7 +393,7 @@ type GettableGrafanaRule struct {
 	NoDataState     NoDataState         `json:"no_data_state" yaml:"no_data_state"`
 	ExecErrState    ExecutionErrorState `json:"exec_err_state" yaml:"exec_err_state"`
 	Provenance      Provenance          `json:"provenance,omitempty" yaml:"provenance,omitempty"`
-	ForError        *model.Duration     `json:"for_error" json:"for_error"`
+	ForError        *model.Duration     `json:"for_error" yaml:"for_error"`
 	IsPaused        bool                `json:"is_paused" yaml:"is_paused"`
 }
 

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -448,11 +448,14 @@ func (c Condition) IsValid() bool {
 	return len(c.Data) != 0
 }
 
-// PatchPartialAlertRule patches `ruleToPatch` by `existingRule` following the rule that if a field of `ruleToPatch` is empty or has the default value, it is populated by the value of the corresponding field from `existingRule`.
+// PatchPartialAlertRule patches `ruleToPatch` by `existingRule` following the rule that if a field of `ruleToPatch` is
+// empty or has the default value, it is populated by the value of the corresponding field from `existingRule`.
 // There are several exceptions:
-// 1. Following fields are not patched and therefore will be ignored: AlertRule.ID, AlertRule.OrgID, AlertRule.Updated, AlertRule.Version, AlertRule.UID, AlertRule.DashboardUID, AlertRule.PanelID, AlertRule.Annotations and AlertRule.Labels
-// 2. There are fields that are patched together:
-//   - AlertRule.Condition and AlertRule.Data
+//  1. Following fields are not patched and therefore will be ignored: AlertRule.ID, AlertRule.OrgID, AlertRule.Updated,
+//     AlertRule.Version, AlertRule.UID, AlertRule.DashboardUID, AlertRule.PanelID, AlertRule.Annotations, and
+//     AlertRule.Labels
+//  2. There are fields that are patched together:
+//     - AlertRule.Condition and AlertRule.Data
 //
 // If either of the pair is specified, neither is patched.
 func PatchPartialAlertRule(existingRule *AlertRule, ruleToPatch *AlertRuleWithOptionals) {

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -484,6 +484,9 @@ func PatchPartialAlertRule(existingRule *AlertRule, ruleToPatch *AlertRuleWithOp
 	if ruleToPatch.For == -1 {
 		ruleToPatch.For = existingRule.For
 	}
+	if ruleToPatch.ForError == -1 {
+		ruleToPatch.ForError = existingRule.ForError
+	}
 	if !ruleToPatch.HasPause {
 		ruleToPatch.IsPaused = existingRule.IsPaused
 	}

--- a/pkg/services/ngalert/models/alert_rule_test.go
+++ b/pkg/services/ngalert/models/alert_rule_test.go
@@ -200,6 +200,12 @@ func TestPatchPartialAlertRule(t *testing.T) {
 				},
 			},
 			{
+				name: "ForError is -1",
+				mutator: func(r *AlertRuleWithOptionals) {
+					r.ForError = -1
+				},
+			},
+			{
 				name: "IsPaused did not come in request",
 				mutator: func(r *AlertRuleWithOptionals) {
 					r.IsPaused = true
@@ -213,6 +219,7 @@ func TestPatchPartialAlertRule(t *testing.T) {
 				for {
 					rule := AlertRuleGen(func(rule *AlertRule) {
 						rule.For = time.Duration(rand.Int63n(1000) + 1)
+						rule.ForError = time.Duration(rand.Int63n(1000) + 1)
 					})()
 					existing = &AlertRuleWithOptionals{AlertRule: *rule}
 					cloned := *existing

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -150,6 +150,7 @@ func (st DBstore) InsertAlertRules(ctx context.Context, rules []ngmodels.AlertRu
 				NoDataState:      r.NoDataState,
 				ExecErrState:     r.ExecErrState,
 				For:              r.For,
+				ForError:         r.ForError,
 				Annotations:      r.Annotations,
 				Labels:           r.Labels,
 			})
@@ -218,6 +219,7 @@ func (st DBstore) UpdateAlertRules(ctx context.Context, rules []ngmodels.UpdateR
 				NoDataState:      r.New.NoDataState,
 				ExecErrState:     r.New.ExecErrState,
 				For:              r.New.For,
+				ForError:         r.New.ForError,
 				Annotations:      r.New.Annotations,
 				Labels:           r.New.Labels,
 			})

--- a/pkg/tests/api/alerting/api_alertmanager_test.go
+++ b/pkg/tests/api/alerting/api_alertmanager_test.go
@@ -774,7 +774,8 @@ func TestIntegrationDeleteFolderWithRules(t *testing.T) {
 								"namespace_id": 1,
 								"rule_group": "arulegroup",
 								"no_data_state": "NoData",
-								"exec_err_state": "Alerting"
+								"exec_err_state": "Alerting",
+								"for_error": "0s"
 							}
 						}
 					]
@@ -1231,7 +1232,8 @@ func TestIntegrationAlertRuleCRUD(t *testing.T) {
 						  "namespace_id":1,
 						  "rule_group":"arulegroup",
 						  "no_data_state":"NoData",
-						  "exec_err_state":"Alerting"
+						  "exec_err_state":"Alerting",
+						  "for_error": "0s"
 					   }
 					},
 					{
@@ -1268,7 +1270,8 @@ func TestIntegrationAlertRuleCRUD(t *testing.T) {
 						  "namespace_id":1,
 						  "rule_group":"arulegroup",
 						  "no_data_state":"Alerting",
-						  "exec_err_state":"Alerting"
+						  "exec_err_state":"Alerting",
+						  "for_error": "0s"
 					   }
 					}
 				 ]
@@ -1576,7 +1579,8 @@ func TestIntegrationAlertRuleCRUD(t *testing.T) {
 		                  "namespace_id":1,
 		                  "rule_group":"arulegroup",
 		                  "no_data_state":"Alerting",
-		                  "exec_err_state":"Alerting"
+		                  "exec_err_state":"Alerting",
+						  "for_error": "0s"
 		               }
 		            }
 		         ]
@@ -1686,7 +1690,8 @@ func TestIntegrationAlertRuleCRUD(t *testing.T) {
 					  "namespace_id":1,
 					  "rule_group":"arulegroup",
 					  "no_data_state":"Alerting",
-					  "exec_err_state":"Alerting"
+					  "exec_err_state":"Alerting",
+					  "for_error": "0s"
 				       }
 				    }
 				 ]
@@ -1772,7 +1777,8 @@ func TestIntegrationAlertRuleCRUD(t *testing.T) {
 					  "namespace_id":1,
 					  "rule_group":"arulegroup",
 					  "no_data_state":"Alerting",
-					  "exec_err_state":"Alerting"
+					  "exec_err_state":"Alerting",
+					  "for_error": "0s"
 				       }
 				    }
 				 ]
@@ -2079,7 +2085,8 @@ func TestIntegrationQuota(t *testing.T) {
 						  "namespace_id":1,
 						  "rule_group":"arulegroup",
 						  "no_data_state":"NoData",
-						  "exec_err_state":"Alerting"
+						  "exec_err_state":"Alerting",
+						  "for_error": "0s"
 					       }
 					    }
 					 ]

--- a/pkg/tests/api/alerting/api_ruler_test.go
+++ b/pkg/tests/api/alerting/api_ruler_test.go
@@ -120,7 +120,8 @@ func TestIntegrationAlertRulePermissions(t *testing.T) {
 						  "namespace_id":1,
 						  "rule_group":"arulegroup",
 						  "no_data_state":"NoData",
-						  "exec_err_state":"Alerting"
+						  "exec_err_state":"Alerting",
+						  "for_error": "0s"
 					   }
 					}
 				 ]
@@ -171,7 +172,8 @@ func TestIntegrationAlertRulePermissions(t *testing.T) {
 						"namespace_id":2,
 						"rule_group":"arulegroup",
 						"no_data_state":"NoData",
-						"exec_err_state":"Alerting"
+						"exec_err_state":"Alerting",
+						"for_error": "0s"
 					 }
 				  }
 			   ]
@@ -245,7 +247,8 @@ func TestIntegrationAlertRulePermissions(t *testing.T) {
 						  "namespace_id":1,
 						  "rule_group":"arulegroup",
 						  "no_data_state":"NoData",
-						  "exec_err_state":"Alerting"
+						  "exec_err_state":"Alerting",
+						  "for_error": "0s"
 					   }
 					}
 				 ]
@@ -520,7 +523,8 @@ func TestIntegrationRulerRulesFilterByDashboard(t *testing.T) {
 				"namespace_id": 1,
 				"rule_group": "anotherrulegroup",
 				"no_data_state": "NoData",
-				"exec_err_state": "Alerting"
+				"exec_err_state": "Alerting",
+				"for_error": "0s"
 			}
 		}, {
 			"expr": "",
@@ -554,7 +558,8 @@ func TestIntegrationRulerRulesFilterByDashboard(t *testing.T) {
 				"namespace_id": 1,
 				"rule_group": "anotherrulegroup",
 				"no_data_state": "Alerting",
-				"exec_err_state": "Alerting"
+				"exec_err_state": "Alerting",
+				"for_error": "0s"
 			}
 		}]
 	}]
@@ -600,7 +605,8 @@ func TestIntegrationRulerRulesFilterByDashboard(t *testing.T) {
 				"namespace_id": 1,
 				"rule_group": "anotherrulegroup",
 				"no_data_state": "NoData",
-				"exec_err_state": "Alerting"
+				"exec_err_state": "Alerting",
+				"for_error": "0s"
 			}
 		}]
 	}]


### PR DESCRIPTION
**What is this feature?**

This PR allows the `for_error` attribute to be fetched and changed from the API.
It adds the `for_error` attribute to the response of the following API endpoints:
- `GET /api/ruler/grafana/api/v1/rules`
- `GET /api/ruler/grafana/api/v1/rules/{Namespace}`
- `GET /api/ruler/grafana/api/v1/rules/{Namespace}/{Groupname}`

It also expects the `for_error` attribute in the body of the following API endpoints:
- `POST /api/ruler/grafana/api/v1/rules/{Namespace}`

**Why do we need this feature?**

This PR is the UI enablement of https://github.com/grafana/grafana/pull/64388.

**Who is this feature for?**

All users.

**Which issue(s) does this PR fix?**:

Contributes to https://github.com/grafana/grafana/issues/55320