### PR TITLE
ContextHandler: Always initiate permission map on signed in user

### DIFF
--- a/pkg/services/contexthandler/contexthandler.go
+++ b/pkg/services/contexthandler/contexthandler.go
@@ -122,8 +122,10 @@ func (h *ContextHandler) Middleware(next http.Handler) http.Handler {
 		defer span.End()
 
 		reqContext := &contextmodel.ReqContext{
-			Context:        mContext,
-			SignedInUser:   &user.SignedInUser{},
+			Context: mContext,
+			SignedInUser: &user.SignedInUser{
+				Permissions: map[int64]map[string][]string{},
+			},
 			IsSignedIn:     false,
 			AllowAnonymous: false,
 			SkipCache:      false,


### PR DESCRIPTION
**What is this feature?**
When using authnService flag we now have the permission sync hook instead of the middleware. The middleware always initiated the permission map but with the sync hook the map is only initiated for valid users making a panic when a user is not authenticated.

The fix just initiate an empty permission map in contexthandler

Fixes #

**Special notes for your reviewer**:

