### PR TITLE
Chore: Remove expr imports

### DIFF
--- a/pkg/services/sqlstore/migrations/ualert/alert_rule.go
+++ b/pkg/services/sqlstore/migrations/ualert/alert_rule.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
-	"github.com/grafana/grafana/pkg/expr"
 	legacymodels "github.com/grafana/grafana/pkg/services/alerting/models"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/tsdb/graphite"
@@ -180,7 +179,7 @@ func migrateAlertRuleQueries(data []alertQuery) ([]alertQuery, error) {
 	result := make([]alertQuery, 0, len(data))
 	for _, d := range data {
 		// queries that are expression are not relevant, skip them.
-		if d.DatasourceUID == expr.DatasourceType {
+		if d.DatasourceUID == expressionDatasourceUID {
 			result = append(result, d)
 			continue
 		}

--- a/pkg/services/sqlstore/migrations/ualert/cond_trans.go
+++ b/pkg/services/sqlstore/migrations/ualert/cond_trans.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/grafana/grafana/pkg/expr"
 	"github.com/grafana/grafana/pkg/util"
 )
 
@@ -188,7 +187,7 @@ func transConditions(set dashAlertSettings, orgID int64, dsUIDMap dsUIDLookup) (
 	ccAlertQuery := alertQuery{
 		RefID:         ccRefID,
 		Model:         exprModelJSON,
-		DatasourceUID: expr.DatasourceUID,
+		DatasourceUID: expressionDatasourceUID,
 	}
 
 	newCond.Data = append(newCond.Data, ccAlertQuery)

--- a/pkg/services/sqlstore/migrations/ualert/ualert.go
+++ b/pkg/services/sqlstore/migrations/ualert/ualert.go
@@ -43,6 +43,7 @@ var rmMigTitle = "remove unified alerting data"
 const clearMigrationEntryTitle = "clear migration entry %q"
 const codeMigration = "code migration"
 
+// It is defined in pkg/expr/service.go as "DatasourceType"
 const expressionDatasourceUID = "__expr__"
 
 type MigrationError struct {

--- a/pkg/services/sqlstore/migrations/ualert/ualert.go
+++ b/pkg/services/sqlstore/migrations/ualert/ualert.go
@@ -43,6 +43,8 @@ var rmMigTitle = "remove unified alerting data"
 const clearMigrationEntryTitle = "clear migration entry %q"
 const codeMigration = "code migration"
 
+const expressionDatasourceUID = "__expr__"
+
 type MigrationError struct {
 	AlertId int64
 	Err     error


### PR DESCRIPTION
**What is this feature?**
Removing the imports from `expr` package.
From @kylebrandt 
> Generally, we should not import external libraries either, because if those change the migration changes.
> So instead things are copied/duplicated from those packages for the point in time of the migration
