### PR TITLE
Alerting: fix users call 403 by calling /user instead of /users/{id}

### DIFF
--- a/public/app/features/alerting/unified/Analytics.test.ts
+++ b/public/app/features/alerting/unified/Analytics.test.ts
@@ -18,10 +18,10 @@ describe('isNewUser', function () {
 
     getBackendSrv().get = jest.fn().mockResolvedValue(newUser);
 
-    const isNew = await isNewUser(1);
+    const isNew = await isNewUser();
     expect(isNew).toBe(true);
     expect(getBackendSrv().get).toHaveBeenCalledTimes(1);
-    expect(getBackendSrv().get).toHaveBeenCalledWith('/api/users/1');
+    expect(getBackendSrv().get).toHaveBeenCalledWith('/api/user');
   });
 
   it('should return false if the user has been created prior to the last two weeks', async () => {
@@ -32,9 +32,9 @@ describe('isNewUser', function () {
 
     getBackendSrv().get = jest.fn().mockResolvedValue(oldUser);
 
-    const isNew = await isNewUser(2);
+    const isNew = await isNewUser();
     expect(isNew).toBe(false);
     expect(getBackendSrv().get).toHaveBeenCalledTimes(1);
-    expect(getBackendSrv().get).toHaveBeenCalledWith('/api/users/2');
+    expect(getBackendSrv().get).toHaveBeenCalledWith('/api/user');
   });
 });

--- a/public/app/features/alerting/unified/Analytics.ts
+++ b/public/app/features/alerting/unified/Analytics.ts
@@ -45,9 +45,9 @@ export function withPerformanceLogging<TFunc extends (...args: any[]) => Promise
   };
 }
 
-export async function isNewUser(userId: number) {
+export async function isNewUser() {
   try {
-    const { createdAt } = await getBackendSrv().get(`/api/users/${userId}`);
+    const { createdAt } = await getBackendSrv().get(`/api/user`);
 
     const limitDateForNewUser = dateTime().subtract(USER_CREATION_MIN_DAYS, 'days');
     const userCreationDate = dateTime(createdAt);
@@ -61,7 +61,7 @@ export async function isNewUser(userId: number) {
 }
 
 export const trackNewAlerRuleFormSaved = async (props: AlertRuleTrackingProps) => {
-  const isNew = await isNewUser(props.user_id);
+  const isNew = await isNewUser();
   if (isNew) {
     return;
   }
@@ -69,7 +69,7 @@ export const trackNewAlerRuleFormSaved = async (props: AlertRuleTrackingProps) =
 };
 
 export const trackNewAlerRuleFormCancelled = async (props: AlertRuleTrackingProps) => {
-  const isNew = await isNewUser(props.user_id);
+  const isNew = await isNewUser();
   if (isNew) {
     return;
   }
@@ -77,7 +77,7 @@ export const trackNewAlerRuleFormCancelled = async (props: AlertRuleTrackingProp
 };
 
 export const trackNewAlerRuleFormError = async (props: AlertRuleTrackingProps & { error: string }) => {
-  const isNew = await isNewUser(props.user_id);
+  const isNew = await isNewUser();
   if (isNew) {
     return;
   }


### PR DESCRIPTION
**What is this feature?**

This avoids a permission error we were getting by calling the `/users/{id}` endpoint which started returning `403` as the permissions for the logged in user don't include `users:read` as required.

**Why do we need this feature?**

Without performing this request we can't tell whether the user is new or not, which is information we need in order to display the user survey.

**Who is this feature for?**

All users.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/alerting-squad/issues/404

**Special notes for your reviewer**:

More info in this [thread](https://raintank-corp.slack.com/archives/C01LU2Y5527/p1678376251968879)

Before:
![image](https://user-images.githubusercontent.com/6271380/224098372-56546613-98e3-4313-971a-5853cf4314e6.png)

After:
![image](https://user-images.githubusercontent.com/6271380/224098285-4db0e781-a71b-411a-87e1-a795ce7aa084.png)
