### PR TITLE
PanelChrome: Do not show menu when panel is embedded

### DIFF
--- a/public/app/features/dashboard/containers/SoloPanelPage.tsx
+++ b/public/app/features/dashboard/containers/SoloPanelPage.tsx
@@ -123,9 +123,10 @@ export const SoloPanel = ({ dashboard, notFound, panel, panelId, timezone }: Sol
               dashboard={dashboard}
               panel={panel}
               isEditing={false}
-              isViewing={false}
+              isViewing={true}
               lazy={false}
               timezone={timezone}
+              hideMenu={true}
             />
           );
         }}


### PR DESCRIPTION
**What is this feature?**

The panel shouldn't be visible when the panel is embedded into an iframe. No actions can be performed on a panel.

To hide it, we modified the component used to render a solo panel. The property `hideMenu` already hides the menu, but the header still shows the "move cursor" when hovering over the header because the panel is considered draggable. 
I solved that with `isViewing` turned on, since it is a similar case to "view": a single panel out of dashboard context. 

|Before|After|
|-|-|
<img width="1920" alt="Captura de pantalla 2023-03-09 a las 18 57 18" src="https://user-images.githubusercontent.com/5699976/224114581-f6b64f61-a5b7-4f39-ab92-d4f5d593dacc.png">|<img width="1920" alt="Captura de pantalla 2023-03-09 a las 18 56 45" src="https://user-images.githubusercontent.com/5699976/224114587-595f530a-08b1-4282-92c6-3e66689d04ed.png">

**Which issue(s) does this PR fix?**:

Fixes #64542 

**Special notes for your reviewer**:
How to test it:
1. Go to a dashboard, and click on the panel menu on any panel
2. Click in share -> embed
3. You will get an iframe script. Copy the URL and paste it into a new tab
