### PR TITLE
InfluxDB: Fix type assertion panics for interface conversion: interface {} is nil

### DIFF
--- a/pkg/tsdb/influxdb/response_parser.go
+++ b/pkg/tsdb/influxdb/response_parser.go
@@ -89,8 +89,8 @@ func transformRows(rows []Row, query Query) data.Frames {
 
 				var timeArray []time.Time
 				var floatArray []*float64
-				var stringArray []*string
-				var boolArray []*bool
+				var stringArray []string
+				var boolArray []bool
 				valType := typeof(row.Values, colIndex)
 				name := formatFrameName(row, column, query)
 
@@ -100,16 +100,16 @@ func transformRows(rows []Row, query Query) data.Frames {
 					if timestampErr == nil {
 						timeArray = append(timeArray, timestamp)
 						if valType == "string" {
-							value, err := valuePair[colIndex].(*string)
-							if !err {
+							value, chk := valuePair[colIndex].(string)
+							if chk {
 								stringArray = append(stringArray, value)
 							}
 						} else if valType == "json.Number" {
 							value := parseNumber(valuePair[colIndex])
 							floatArray = append(floatArray, value)
 						} else if valType == "bool" {
-							value, err := valuePair[colIndex].(*bool)
-							if !err {
+							value, chk := valuePair[colIndex].(bool)
+							if chk {
 								boolArray = append(boolArray, value)
 							}
 						} else if valType == "null" {

--- a/pkg/tsdb/influxdb/response_parser.go
+++ b/pkg/tsdb/influxdb/response_parser.go
@@ -89,8 +89,8 @@ func transformRows(rows []Row, query Query) data.Frames {
 
 				var timeArray []time.Time
 				var floatArray []*float64
-				var stringArray []string
-				var boolArray []bool
+				var stringArray []*string
+				var boolArray []*bool
 				valType := typeof(row.Values, colIndex)
 				name := formatFrameName(row, column, query)
 
@@ -100,14 +100,18 @@ func transformRows(rows []Row, query Query) data.Frames {
 					if timestampErr == nil {
 						timeArray = append(timeArray, timestamp)
 						if valType == "string" {
-							value := valuePair[colIndex].(string)
-							stringArray = append(stringArray, value)
+							value, err := valuePair[colIndex].(*string)
+							if !err {
+								stringArray = append(stringArray, value)
+							}
 						} else if valType == "json.Number" {
 							value := parseNumber(valuePair[colIndex])
 							floatArray = append(floatArray, value)
 						} else if valType == "bool" {
-							value := valuePair[colIndex].(bool)
-							boolArray = append(boolArray, value)
+							value, err := valuePair[colIndex].(*bool)
+							if !err {
+								boolArray = append(boolArray, value)
+							}
 						} else if valType == "null" {
 							floatArray = append(floatArray, nil)
 						}

--- a/pkg/tsdb/influxdb/response_parser.go
+++ b/pkg/tsdb/influxdb/response_parser.go
@@ -89,8 +89,8 @@ func transformRows(rows []Row, query Query) data.Frames {
 
 				var timeArray []time.Time
 				var floatArray []*float64
-				var stringArray []string
-				var boolArray []bool
+				var stringArray []*string
+				var boolArray []*bool
 				valType := typeof(row.Values, colIndex)
 				name := formatFrameName(row, column, query)
 
@@ -102,7 +102,9 @@ func transformRows(rows []Row, query Query) data.Frames {
 						if valType == "string" {
 							value, chk := valuePair[colIndex].(string)
 							if chk {
-								stringArray = append(stringArray, value)
+								stringArray = append(stringArray, &value)
+							} else {
+								stringArray = append(stringArray, nil)
 							}
 						} else if valType == "json.Number" {
 							value := parseNumber(valuePair[colIndex])
@@ -110,7 +112,9 @@ func transformRows(rows []Row, query Query) data.Frames {
 						} else if valType == "bool" {
 							value, chk := valuePair[colIndex].(bool)
 							if chk {
-								boolArray = append(boolArray, value)
+								boolArray = append(boolArray, &value)
+							} else {
+								boolArray = append(boolArray, nil)
 							}
 						} else if valType == "null" {
 							floatArray = append(floatArray, nil)

--- a/pkg/tsdb/influxdb/response_parser.go
+++ b/pkg/tsdb/influxdb/response_parser.go
@@ -23,6 +23,7 @@ func (rp *ResponseParser) Parse(buf io.ReadCloser, queries []Query) *backend.Que
 	resp := backend.NewQueryDataResponse()
 
 	response, jsonErr := parseJSON(buf)
+
 	if jsonErr != nil {
 		resp.Responses["A"] = backend.DataResponse{Error: jsonErr}
 		return resp
@@ -46,10 +47,12 @@ func (rp *ResponseParser) Parse(buf io.ReadCloser, queries []Query) *backend.Que
 
 func parseJSON(buf io.ReadCloser) (Response, error) {
 	var response Response
+
 	dec := json.NewDecoder(buf)
 	dec.UseNumber()
 
 	err := dec.Decode(&response)
+
 	return response, err
 }
 
@@ -99,24 +102,27 @@ func transformRows(rows []Row, query Query) data.Frames {
 					// we only add this row if the timestamp is valid
 					if timestampErr == nil {
 						timeArray = append(timeArray, timestamp)
-						if valType == "string" {
-							value, chk := valuePair[colIndex].(string)
-							if chk {
-								stringArray = append(stringArray, &value)
-							} else {
-								stringArray = append(stringArray, nil)
+						switch valType {
+						case "string":
+							{
+								value, chk := valuePair[colIndex].(string)
+								if chk {
+									stringArray = append(stringArray, &value)
+								} else {
+									stringArray = append(stringArray, nil)
+								}
 							}
-						} else if valType == "json.Number" {
+						case "json.Number":
 							value := parseNumber(valuePair[colIndex])
 							floatArray = append(floatArray, value)
-						} else if valType == "bool" {
+						case "bool":
 							value, chk := valuePair[colIndex].(bool)
 							if chk {
 								boolArray = append(boolArray, &value)
 							} else {
 								boolArray = append(boolArray, nil)
 							}
-						} else if valType == "null" {
+						case "null":
 							floatArray = append(floatArray, nil)
 						}
 					}

--- a/pkg/tsdb/influxdb/response_parser_test.go
+++ b/pkg/tsdb/influxdb/response_parser_test.go
@@ -84,8 +84,9 @@ func TestInfluxdbResponseParser(t *testing.T) {
 		)
 		floatFrame.Meta = &data.FrameMeta{ExecutedQueryString: "Test raw query"}
 
-		stringField := data.NewField("value", labels, []string{
-			"/usr/path", "/usr/path", "/usr/path",
+		string_test := "/usr/path"
+		stringField := data.NewField("value", labels, []*string{
+			&string_test, &string_test, &string_test,
 		})
 		stringField.Config = &data.FieldConfig{DisplayNameFromDS: "cpu.path { datacenter: America }"}
 		stringFrame := data.NewFrame("cpu.path { datacenter: America }",
@@ -99,8 +100,10 @@ func TestInfluxdbResponseParser(t *testing.T) {
 		)
 		stringFrame.Meta = &data.FrameMeta{ExecutedQueryString: "Test raw query"}
 
-		boolField := data.NewField("value", labels, []bool{
-			true, false, true,
+		bool_true := true
+		bool_false := false
+		boolField := data.NewField("value", labels, []*bool{
+			&bool_true, &bool_false, &bool_true,
 		})
 		boolField.Config = &data.FieldConfig{DisplayNameFromDS: "cpu.isActive { datacenter: America }"}
 		boolFrame := data.NewFrame("cpu.isActive { datacenter: America }",

--- a/pkg/tsdb/influxdb/response_parser_test.go
+++ b/pkg/tsdb/influxdb/response_parser_test.go
@@ -135,36 +135,16 @@ func TestInfluxdbResponseParser(t *testing.T) {
 		parser := &ResponseParser{}
 
 		response := `
-		{
-			"results": [
-				{
-					"series": [
-						{
-							"name": "cpu",
-							"columns": ["time","path"],
-							"tags": {"datacenter": "America"},
-							"values": [
-								[111,null],
-								[111,"/usr/path"],
-								[111,"/usr/path"]
-							]
-						}
-					]
-				}
-			]
-		}
-		`
+		{"results": [{"series": [{"name": "cpu","columns": ["time","path"],"values": [[111,null],[111,"/usr/path"],[111,"/usr/path"]]}]}]}`
 
 		query := &Query{}
-		labels, err := data.LabelsFromString("datacenter=America")
-		require.Nil(t, err)
 
 		string_test := "/usr/path"
-		stringField := data.NewField("value", labels, []*string{
+		stringField := data.NewField("value", nil, []*string{
 			nil, &string_test, &string_test,
 		})
-		stringField.Config = &data.FieldConfig{DisplayNameFromDS: "cpu.path { datacenter: America }"}
-		stringFrame := data.NewFrame("cpu.path { datacenter: America }",
+		stringField.Config = &data.FieldConfig{DisplayNameFromDS: "cpu.path"}
+		stringFrame := data.NewFrame("cpu.path",
 			data.NewField("time", nil,
 				[]time.Time{
 					time.Date(1970, 1, 1, 0, 0, 0, 111000000, time.UTC),
@@ -187,37 +167,17 @@ func TestInfluxdbResponseParser(t *testing.T) {
 		parser := &ResponseParser{}
 
 		response := `
-		{
-			"results": [
-				{
-					"series": [
-						{
-							"name": "cpu",
-							"columns": ["time","isActive"],
-							"tags": {"datacenter": "America"},
-							"values": [
-								[111,null],
-								[111,false],
-								[111,true]
-							]
-						}
-					]
-				}
-			]
-		}
-		`
+		{"results": [{"series": [{"name": "cpu","columns": ["time","isActive"],"values": [[111,null],[111,false],[111,true]]}]}]}`
 
 		query := &Query{}
-		labels, err := data.LabelsFromString("datacenter=America")
-		require.Nil(t, err)
 
 		bool_true := true
 		bool_false := false
-		boolField := data.NewField("value", labels, []*bool{
+		boolField := data.NewField("value", nil, []*bool{
 			nil, &bool_false, &bool_true,
 		})
-		boolField.Config = &data.FieldConfig{DisplayNameFromDS: "cpu.isActive { datacenter: America }"}
-		boolFrame := data.NewFrame("cpu.isActive { datacenter: America }",
+		boolField.Config = &data.FieldConfig{DisplayNameFromDS: "cpu.isActive"}
+		boolFrame := data.NewFrame("cpu.isActive",
 			data.NewField("time", nil,
 				[]time.Time{
 					time.Date(1970, 1, 1, 0, 0, 0, 111000000, time.UTC),


### PR DESCRIPTION
Fixes https://github.com/grafana/support-escalations/issues/5183

**What is this bug fix?**
Type assertions for `string` and `bool` for interface{} nil produced a panic and broke InfluxDB at the response parser `transformRows` function. This checks the type assertion for an error before appending the element.

Notes for the reviewer:
Do we need to include nulls in the arrays? Should we be returning the error of the type assertion?