### PR TITLE
Cloudwatch Logs: Fix log group names not interpolating with multiple variables

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/language/cloudwatch-logs/CloudWatchLogsLanguageProvider.ts
+++ b/public/app/plugins/datasource/cloudwatch/language/cloudwatch-logs/CloudWatchLogsLanguageProvider.ts
@@ -133,6 +133,7 @@ export class CloudWatchLogsLanguageProvider extends LanguageProvider {
     const interpolatedLogGroups = interpolateStringArrayUsingSingleOrMultiValuedVariable(
       getTemplateSrv(),
       logGroups.map((lg) => lg.name),
+      {},
       'text'
     );
     const results = await Promise.all(

--- a/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchLogsQueryRunner.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchLogsQueryRunner.test.ts
@@ -195,7 +195,7 @@ describe('CloudWatchLogsQueryRunner', () => {
 
   const legacyLogGroupNamesQuery: CloudWatchLogsQuery = {
     queryMode: 'Logs',
-    logGroupNames: ['group-A', 'templatedGroup-1', logGroupNamesVariable.name],
+    logGroupNames: ['group-A', 'templatedGroup-1', `$${logGroupNamesVariable.name}`],
     hide: false,
     id: '',
     region: 'us-east-2',
@@ -207,7 +207,7 @@ describe('CloudWatchLogsQueryRunner', () => {
     queryMode: 'Logs',
     logGroups: [
       { arn: 'arn:aws:logs:us-east-2:123456789012:log-group:group-A:*', name: 'group-A' },
-      { arn: logGroupNamesVariable.name, name: logGroupNamesVariable.name },
+      { arn: `$${logGroupNamesVariable.name}`, name: logGroupNamesVariable.name },
     ],
     hide: false,
     id: '',
@@ -237,6 +237,7 @@ describe('CloudWatchLogsQueryRunner', () => {
             logsTimeout: '500ms',
           },
         },
+        mockGetVariableName: false,
       });
       const spy = jest.spyOn(runner, 'makeLogActionRequest');
       await lastValueFrom(

--- a/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchLogsQueryRunner.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchLogsQueryRunner.test.ts
@@ -218,7 +218,7 @@ describe('CloudWatchLogsQueryRunner', () => {
 
   const logsScopedVarQuery: CloudWatchLogsQuery = {
     queryMode: 'Logs',
-    logGroups: [{ arn: logGroupNamesVariable.name, name: logGroupNamesVariable.name }],
+    logGroups: [{ arn: `$${logGroupNamesVariable.name}`, name: logGroupNamesVariable.name }],
     hide: false,
     id: '',
     region: '$' + regionVariable.name,

--- a/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchLogsQueryRunner.ts
+++ b/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchLogsQueryRunner.ts
@@ -85,13 +85,15 @@ export class CloudWatchLogsQueryRunner extends CloudWatchRequest {
     const startQueryRequests: StartQueryRequest[] = validLogQueries.map((target: CloudWatchLogsQuery) => {
       const interpolatedLogGroupArns = interpolateStringArrayUsingSingleOrMultiValuedVariable(
         this.templateSrv,
-        (target.logGroups || this.instanceSettings.jsonData.logGroups || []).map((lg) => lg.arn)
+        (target.logGroups || this.instanceSettings.jsonData.logGroups || []).map((lg) => lg.arn),
+        options.scopedVars
       );
 
       // need to support legacy format variables too
       const interpolatedLogGroupNames = interpolateStringArrayUsingSingleOrMultiValuedVariable(
         this.templateSrv,
         target.logGroupNames || this.instanceSettings.jsonData.defaultLogGroups || [],
+        options.scopedVars,
         'text'
       );
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Interpolates a log group name that has multiple variables in it.

**Why do we need this feature?**
If a cloudwatch logs group name has multiple variables. E.g. $a/$b where $a is foo and $b is bar, only $a is interpolated, so it would be interpolated as `foo`. Previously the behaviour in cloudwatch logs would interpolate this as `foo/bar`. After the logs selector was refactored, it stopped interpolating the variable and only returned the variable value.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #64566

**Special notes for your reviewer**:
You can test this by creating some variables for the provisioned cloudwatch datasources. E.g. $a = `aws/sagemaker` and $b = `Endpoints/DEMO-xgb-churn-pred-model-monitor-2021-02-22-19-09-01,Endpoints/DEMO-xgb-churn-pred-model-monitor-2021-02-20-22-58-21`.

Then in the logs selector modal, go to the bottom where the template variable select input is and manually enter `$a/$b`. Then in the panel option select this to repeat on the variable `b`. Save the dashboard and refresh.
