### PR TITLE
Extensions: Expose an enum for available placements

### DIFF
--- a/packages/grafana-data/src/types/index.ts
+++ b/packages/grafana-data/src/types/index.ts
@@ -61,4 +61,5 @@ export {
   isPluginExtensionCommand,
   assertPluginExtensionCommand,
   PluginExtensionTypes,
+  PluginExtensionPlacements,
 } from './pluginExtensions';

--- a/packages/grafana-data/src/types/pluginExtensions.ts
+++ b/packages/grafana-data/src/types/pluginExtensions.ts
@@ -2,6 +2,10 @@
  * These types are exposed when rendering extension points
  */
 
+export enum PluginExtensionPlacements {
+  DashboardPanelMenu = 'grafana/dashboard/panel/menu',
+}
+
 export enum PluginExtensionTypes {
   link = 'link',
   command = 'command',

--- a/public/app/features/dashboard/utils/getPanelMenu.test.ts
+++ b/public/app/features/dashboard/utils/getPanelMenu.test.ts
@@ -1,4 +1,10 @@
-import { PanelMenuItem, PluginExtension, PluginExtensionLink, PluginExtensionTypes } from '@grafana/data';
+import {
+  PanelMenuItem,
+  PluginExtension,
+  PluginExtensionLink,
+  PluginExtensionTypes,
+  PluginExtensionPlacements,
+} from '@grafana/data';
 import {
   PluginExtensionPanelContext,
   PluginExtensionRegistryItem,
@@ -7,7 +13,6 @@ import {
 import { LoadingState } from '@grafana/schema';
 import config from 'app/core/config';
 import * as actions from 'app/features/explore/state/main';
-import { GrafanaExtensions } from 'app/features/plugins/extensions/placements';
 import { setStore } from 'app/store/store';
 
 import { PanelModel } from '../state';
@@ -138,7 +143,7 @@ describe('getPanelMenu()', () => {
   describe('when extending panel menu from plugins', () => {
     it('should contain menu item from link extension', () => {
       setPluginsExtensionRegistry({
-        [GrafanaExtensions.DashboardPanelMenu]: [
+        [PluginExtensionPlacements.DashboardPanelMenu]: [
           createRegistryItem<PluginExtensionLink>({
             type: PluginExtensionTypes.link,
             title: 'Declare incident',
@@ -166,7 +171,7 @@ describe('getPanelMenu()', () => {
 
     it('should truncate menu item title to 25 chars', () => {
       setPluginsExtensionRegistry({
-        [GrafanaExtensions.DashboardPanelMenu]: [
+        [PluginExtensionPlacements.DashboardPanelMenu]: [
           createRegistryItem<PluginExtensionLink>({
             type: PluginExtensionTypes.link,
             title: 'Declare incident when pressing this amazing menu item',
@@ -202,7 +207,7 @@ describe('getPanelMenu()', () => {
       });
 
       setPluginsExtensionRegistry({
-        [GrafanaExtensions.DashboardPanelMenu]: [
+        [PluginExtensionPlacements.DashboardPanelMenu]: [
           createRegistryItem<PluginExtensionLink>(
             {
               type: PluginExtensionTypes.link,
@@ -233,7 +238,7 @@ describe('getPanelMenu()', () => {
 
     it('should hide menu item if configure function returns undefined', () => {
       setPluginsExtensionRegistry({
-        [GrafanaExtensions.DashboardPanelMenu]: [
+        [PluginExtensionPlacements.DashboardPanelMenu]: [
           createRegistryItem<PluginExtensionLink>(
             {
               type: PluginExtensionTypes.link,
@@ -266,7 +271,7 @@ describe('getPanelMenu()', () => {
       const configure = jest.fn();
 
       setPluginsExtensionRegistry({
-        [GrafanaExtensions.DashboardPanelMenu]: [
+        [PluginExtensionPlacements.DashboardPanelMenu]: [
           createRegistryItem<PluginExtensionLink>(
             {
               type: PluginExtensionTypes.link,
@@ -348,7 +353,7 @@ describe('getPanelMenu()', () => {
       };
 
       setPluginsExtensionRegistry({
-        [GrafanaExtensions.DashboardPanelMenu]: [
+        [PluginExtensionPlacements.DashboardPanelMenu]: [
           createRegistryItem<PluginExtensionLink>(
             {
               type: PluginExtensionTypes.link,

--- a/public/app/features/dashboard/utils/getPanelMenu.ts
+++ b/public/app/features/dashboard/utils/getPanelMenu.ts
@@ -1,4 +1,9 @@
-import { isPluginExtensionCommand, isPluginExtensionLink, PanelMenuItem } from '@grafana/data';
+import {
+  isPluginExtensionCommand,
+  isPluginExtensionLink,
+  PanelMenuItem,
+  PluginExtensionPlacements,
+} from '@grafana/data';
 import {
   AngularComponent,
   getDataSourceSrv,
@@ -26,7 +31,6 @@ import {
 } from 'app/features/dashboard/utils/panel';
 import { InspectTab } from 'app/features/inspector/types';
 import { isPanelModelLibraryPanel } from 'app/features/library-panels/guard';
-import { GrafanaExtensions } from 'app/features/plugins/extensions/placements';
 import { store } from 'app/store/store';
 
 import { navigateToExplore } from '../../explore/state/main';
@@ -287,7 +291,7 @@ export function getPanelMenu(
   }
 
   const { extensions } = getPluginExtensions({
-    placement: GrafanaExtensions.DashboardPanelMenu,
+    placement: PluginExtensionPlacements.DashboardPanelMenu,
     context: createExtensionContext(panel, dashboard),
   });
 

--- a/public/app/features/plugins/extensions/placements.ts
+++ b/public/app/features/plugins/extensions/placements.ts
@@ -1,3 +1,0 @@
-export enum GrafanaExtensions {
-  DashboardPanelMenu = 'grafana/dashboard/panel/menu',
-}


### PR DESCRIPTION
### What changed?

Exposed an enum called `PluginExtensionPlacements` with the available extensions placements inside Grafana. Until now we were using an enum called `GrafanaExtensions`, however that was not exposed publicly, so plugins couldn't depend on it. 