### PR TITLE
LogContext: Fix border radius to be consistent

### DIFF
--- a/public/app/features/logs/components/LogRowContext.tsx
+++ b/public/app/features/logs/components/LogRowContext.tsx
@@ -98,7 +98,7 @@ const getLogRowContextStyles = (theme: GrafanaTheme2, wrapLogMessage?: boolean, 
       background: ${theme.colors.background.canvas};
     `,
     top: css`
-      border-radius: 0 0 ${theme.shape.borderRadius(2)} ${theme.shape.borderRadius(2)};
+      border-radius: 0 0 ${theme.shape.borderRadius()} ${theme.shape.borderRadius()};
       box-shadow: 0 0 ${theme.spacing(1.25)} ${theme.v1.palette.black};
       clip-path: inset(0px -${theme.spacing(1.25)} -${theme.spacing(1.25)} -${theme.spacing(1.25)});
     `,
@@ -110,7 +110,7 @@ const getLogRowContextStyles = (theme: GrafanaTheme2, wrapLogMessage?: boolean, 
       height: ${headerHeight}px;
       background: ${theme.colors.background.secondary};
       border: 1px solid ${theme.colors.background.secondary};
-      border-radius: ${theme.shape.borderRadius(2)} ${theme.shape.borderRadius(2)} 0 0;
+      border-radius: ${theme.shape.borderRadius()} ${theme.shape.borderRadius()} 0 0;
       box-shadow: 0 0 ${theme.spacing(1.25)} ${theme.v1.palette.black};
       clip-path: inset(-${theme.spacing(1.25)} -${theme.spacing(1.25)} 0px -${theme.spacing(1.25)});
       font-family: ${theme.typography.fontFamily};


### PR DESCRIPTION
Related to https://github.com/grafana/grafana/issues/64423 and https://github.com/grafana/grafana/pull/64510, fixes missing border radius.

Now:
<img width="1155" alt="image" src="https://user-images.githubusercontent.com/8092184/224268602-d4373d86-6dde-4b5f-b07d-bd9b2a11720a.png">

Before:
<img width="1154" alt="image" src="https://user-images.githubusercontent.com/8092184/224268718-006c76fe-0cf5-4b98-8215-e6cc57e0583b.png">
