### PR TITLE
Alerting: Fix contact point name being URL-encoded in the title

### DIFF
--- a/public/app/features/alerting/unified/Receivers.tsx
+++ b/public/app/features/alerting/unified/Receivers.tsx
@@ -96,8 +96,7 @@ const Receivers = () => {
   const integrationsErrorCount = contactPointsState?.errorCount ?? 0;
 
   const disableAmSelect = !isRoot;
-
-  let pageNav = getPageNavigationModel(type, id, isduplicatingTemplate);
+  let pageNav = getPageNavigationModel(type, id ? decodeURIComponent(id) : undefined, isduplicatingTemplate);
 
   if (!alertManagerSourceName) {
     return isRoot ? (


### PR DESCRIPTION
**What is this feature?**

This PR fixes contact point name being URL-encoded at the top of the page of contact point view.
This happened because the `id` used came from the query params that are url-encoded.

**Why do we need this feature?**

Name in title should not be uncoded.

**Who is this feature for?**

All users.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/64530

**Special notes for your reviewer**:
<img width="688" alt="Screenshot 2023-03-10 at 10 39 27" src="https://user-images.githubusercontent.com/33540275/224283113-51cd2332-2622-41d0-b43a-5855ddc1a57e.png">

<img width="256" alt="Screenshot 2023-03-10 at 10 58 24" src="https://user-images.githubusercontent.com/33540275/224286563-94a72769-78f1-4b33-b6ca-c082760868ed.png">

