### PR TITLE
Prettify query: use the parser to interpolate and recover the origina…

### DIFF
--- a/public/app/plugins/datasource/loki/formatter.ts
+++ b/public/app/plugins/datasource/loki/formatter.ts
@@ -70,7 +70,7 @@ export function transformForFormatting(
         return;
       }
 
-      // 4. We record a transformation from oringinal to replaced and the node where it happened
+      // 4. We record a transformation from original to replaced and the node where it happened
       transformations.push({
         original,
         replaced,

--- a/public/app/plugins/datasource/loki/formatter.ts
+++ b/public/app/plugins/datasource/loki/formatter.ts
@@ -58,7 +58,7 @@ export function transformForFormatting(
     };
   }
 
-  // 2. We walk throught the parse errors and keep the ones that look like variables.
+  // 2. We walk through the parse errors and keep the ones that look like variables.
   const transformations: Transformation[] = [];
   errors.forEach((parseError, parent) => {
     if (parseError[0].text === '$' && parent) {

--- a/public/app/plugins/datasource/loki/formatter.ts
+++ b/public/app/plugins/datasource/loki/formatter.ts
@@ -1,0 +1,123 @@
+import { SyntaxNode } from '@lezer/common';
+
+import { ScopedVars } from '@grafana/data';
+import { parser } from '@grafana/lezer-logql';
+import { ErrorId } from 'app/plugins/datasource/prometheus/querybuilder/shared/parsingUtils';
+
+import { placeHolderScopedVars } from './components/monaco-query-field/monaco-completion-provider/validation';
+
+type Transformation = {
+  original: string;
+  replaced: string;
+  nodeId: number;
+};
+
+type TransformedQuery = {
+  transformations: Transformation[];
+  query: string;
+};
+
+interface ParseError {
+  text: string;
+  node: SyntaxNode;
+}
+
+// 1. We compile a map of parse errors. Lezer sees variables as parse errors
+function parseQuery(query: string) {
+  const parseErrors = new Map<SyntaxNode | null, ParseError[]>();
+  const tree = parser.parse(query);
+  tree.iterate({
+    enter: (nodeRef): false | void => {
+      if (nodeRef.type.id === ErrorId) {
+        const node = nodeRef.node;
+        const siblings = parseErrors.get(node.parent) || [];
+        parseErrors.set(node.parent, [
+          ...siblings,
+          {
+            node,
+            text: query.substring(node.from, node.to),
+          },
+        ]);
+      }
+    },
+  });
+  return parseErrors;
+}
+
+export function transformForFormatting(
+  query: string,
+  interpolateString: (string: string, scopedVars?: ScopedVars) => string
+): TransformedQuery {
+  // We get the possible variables from the parse errors
+  const errors = parseQuery(query);
+  // Nothing to fix, the query is ready for formatting
+  if (!errors.size) {
+    return {
+      transformations: [],
+      query,
+    };
+  }
+
+  // 2. We walk throught the parse errors and keep the ones that look like variables.
+  const transformations: Transformation[] = [];
+  errors.forEach((parseError, parent) => {
+    if (parseError[0].text === '$' && parent) {
+      const original = query.substring(parseError[0].node.from, parseError[parseError.length - 1].node.to);
+      const replaced = interpolateString(original, placeHolderScopedVars);
+
+      // 3. If it cannot be interpolated, we ignore.
+      if (original === replaced) {
+        return;
+      }
+
+      // 4. We record a transformation from oringinal to replaced and the node where it happened
+      transformations.push({
+        original,
+        replaced,
+        nodeId: parent.type.id,
+      });
+    }
+  });
+
+  // 5. We do a string replacement of every original with replaced
+  let interpolatedQuery = query;
+  transformations.forEach((transformation) => {
+    interpolatedQuery = interpolatedQuery.replace(transformation.original, transformation.replaced);
+  });
+
+  return {
+    transformations,
+    query: interpolatedQuery,
+  };
+}
+
+export function revertTransformations(query: string, transformations: Transformation[]): string {
+  // Avoid unnecessary work
+  if (!transformations.length) {
+    return query;
+  }
+
+  // 6. We parse the formatted query again
+  const tree = parser.parse(query);
+  let recoveredQuery = query;
+  let transformation = transformations.shift();
+  tree.iterate({
+    enter: (nodeRef): false | void => {
+      // 7. We look for a node with the same id
+      if (nodeRef.type.id !== transformation?.nodeId) {
+        return;
+      }
+
+      // 8. We check if it contains the interpolated string
+      const nodeText = query.substring(nodeRef.node.from, nodeRef.node.to);
+      if (!nodeText.includes(transformation.replaced)) {
+        return;
+      }
+
+      // 8. Recover
+      recoveredQuery.replace(transformation.replaced, transformation.original);
+    },
+  });
+
+  return recoveredQuery;
+}


### PR DESCRIPTION
An idea of how we can use the parser to interpolate variables that cause parser errors, send the modified query to be prettified, and recover the original query from the prettified one, replacing the interpolated values with the variable name.

This is a challenging problem because if we do simple string replaces, we might mistakenly replace a valid part of a query with something we thought it was an interpolated variable, since variables can contain any arbitrary value.

In Lezer, variables look like parse errors. What we do in this PR is iterating over error nodes, and keeping the ones whose value starts with `$`, which can potentially be variables. We use a `Map` to group them to associate them with the common parent. We do that to 1) read the variable name (start and end error nodes) and 2) keep the parent ID to use it in the recover process.

![imagen](https://user-images.githubusercontent.com/1069378/224291487-c355ef2f-3815-4c8b-9f4e-30ca226216fd.png)

After that, we return the interpolated query and keep a reference of the transformations, to do the inverse process.

When we receive the prettified query, we parse the query again, looking for nodes that 1) have the same id as the transformed nodes and 2) the transformed node contains the interpolated value. For every node that matches these conditions, we replace the interpolated value with the variable name.

Finally, we return the hypothetically original query.

Note: we do string replacement and don't run`interpolateString` on the whole query, because some variables don't cause parse errors, so they can be prettified without being replaced. For example:

![imagen](https://user-images.githubusercontent.com/1069378/224292294-83fba87c-6b34-45fb-a4b7-72942580ea98.png)

If you want to play with the parser, you can clone this repo and use this tool: https://github.com/grafana/lezer-logql/tree/main/tools