### PR TITLE
SQL Engine: Revert session changes

### DIFF
--- a/pkg/tsdb/sqleng/sql_engine.go
+++ b/pkg/tsdb/sqleng/sql_engine.go
@@ -97,7 +97,6 @@ type DataSourceHandler struct {
 	log                    log.Logger
 	dsInfo                 DataSourceInfo
 	rowLimit               int64
-	session                *xorm.Session
 }
 
 type QueryJson struct {
@@ -147,7 +146,6 @@ func NewQueryDataHandler(config DataPluginConfiguration, queryResultTransformer 
 		queryDataHandler.metricColumnTypes = config.MetricColumnTypes
 	}
 
-	// Create the xorm engine
 	engine, err := NewXormEngine(config.DriverName, config.ConnectionString)
 	if err != nil {
 		return nil, err
@@ -158,11 +156,6 @@ func NewQueryDataHandler(config DataPluginConfiguration, queryResultTransformer 
 	engine.SetConnMaxLifetime(time.Duration(config.DSInfo.JsonData.ConnMaxLifetime) * time.Second)
 
 	queryDataHandler.engine = engine
-
-	// Create the xorm session
-	session := engine.NewSession()
-	queryDataHandler.session = session
-
 	return &queryDataHandler, nil
 }
 
@@ -273,7 +266,9 @@ func (e *DataSourceHandler) executeQuery(query backend.DataQuery, wg *sync.WaitG
 		return
 	}
 
-	db := e.session.DB()
+	session := e.engine.NewSession()
+	defer session.Close()
+	db := session.DB()
 
 	rows, err := db.QueryContext(queryContext, interpolatedQuery)
 	if err != nil {


### PR DESCRIPTION
This PR  reverts changes from #63246 which would cause 1 connection per SQL datasource. This is undesirable as it can make it so that there is no concurrency available for queries, which is a large issue in cases where multi users are viewing panels pulling from the same SQL datasource.

It's also unclear if the approach in the PR has performance benefits over the current setup.

This can however prevent situations in which the connection limits are reached or exhausted, however there is likely a better approach to that particular problem.

