### PR TITLE
Loki: Always fetch for new label keys in the QueryBuilder

### DIFF
--- a/public/app/plugins/datasource/loki/LanguageProvider.ts
+++ b/public/app/plugins/datasource/loki/LanguageProvider.ts
@@ -386,12 +386,6 @@ export default class LokiLanguageProvider extends LanguageProvider {
     return [];
   }
 
-  async refreshLogLabels(forceRefresh?: boolean) {
-    if ((this.labelKeys && Date.now().valueOf() - this.labelFetchTs > LABEL_REFRESH_INTERVAL) || forceRefresh) {
-      await this.fetchLabels();
-    }
-  }
-
   /**
    * Fetch labels for a selector. This is cached by its args but also by the global timeRange currently selected as
    * they can change over requested time.

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilder.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilder.tsx
@@ -49,8 +49,7 @@ export const LokiQueryBuilder = React.memo<Props>(({ datasource, query, onChange
     const labelsToConsider = query.labels.filter((x) => x !== forLabel);
 
     if (labelsToConsider.length === 0) {
-      await datasource.languageProvider.refreshLogLabels();
-      return datasource.languageProvider.getLabelKeys();
+      return await datasource.languageProvider.fetchLabels();
     }
 
     const expr = lokiQueryModeller.renderLabels(labelsToConsider);


### PR DESCRIPTION
**What is this feature?**

Currently labelkeys are not always fetch when trying to select a label.

**Special notes for your reviewer**:

1. Start Grafana and a Loki devenv.
2. Go to Explore and select your Loki datasource.
3. Select a timerange with no logs present.
4. Open the Labels dropdown in the Loki QueryBuilder
5. See `No options found`.
6. Select a timerange with logs present.
7. Without the fix see `No options found`. With the fix see your labels.


With the fix:

https://user-images.githubusercontent.com/8092184/224305904-7648782d-0e34-4c66-8187-72ac71696053.mov

Without the fix:


https://user-images.githubusercontent.com/8092184/224306096-49ba4a24-6b1d-4f9a-af57-5ee1139790f3.mov


