### PR TITLE
Chore: assign ownership of tracing feature flag to user essentials

### DIFF
--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -151,6 +151,7 @@ var (
 			Description:  "Adds trace ID to error notifications",
 			State:        FeatureStateAlpha,
 			FrontendOnly: true,
+			Owner:        grafanaUserEssentialsSquad,
 		},
 		{
 			Name:         "newTraceView",

--- a/pkg/services/featuremgmt/toggles_gen_test.go
+++ b/pkg/services/featuremgmt/toggles_gen_test.go
@@ -43,7 +43,6 @@ func TestFeatureToggleFiles(t *testing.T) {
 
 	ownerlessFeatures := map[string]bool{
 		"prometheusAzureOverrideAudience": true,
-		"tracing":                         true,
 	}
 
 	t.Run("all new features should have an owner", func(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- assigns ownership of the `tracing` feature flag to user essentials

**Why do we need this feature?**

- to ensure all toggles have an owner

**Who is this feature for?**

- grafana devs

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

