### PR TITLE
Plugin Extensions: Move PanelMenu links into extensions submenu

### DIFF
--- a/public/app/features/dashboard/utils/getPanelMenu.test.ts
+++ b/public/app/features/dashboard/utils/getPanelMenu.test.ts
@@ -125,8 +125,8 @@ describe('getPanelMenu()', () => {
 
       const panel = new PanelModel({});
       const dashboard = createDashboardModelFixture({});
-      const menuItems = getPanelMenu(dashboard, panel);
-      const moreSubMenu = menuItems.find((i) => i.text === 'More...')?.subMenu;
+      const menuItems = getPanelMenu(dashboard, panel, LoadingState.Loading);
+      const moreSubMenu = menuItems.find((i) => i.text === 'Extensions')?.subMenu;
 
       expect(moreSubMenu).toEqual(
         expect.arrayContaining([
@@ -153,8 +153,8 @@ describe('getPanelMenu()', () => {
 
       const panel = new PanelModel({});
       const dashboard = createDashboardModelFixture({});
-      const menuItems = getPanelMenu(dashboard, panel);
-      const moreSubMenu = menuItems.find((i) => i.text === 'More...')?.subMenu;
+      const menuItems = getPanelMenu(dashboard, panel, LoadingState.Loading);
+      const moreSubMenu = menuItems.find((i) => i.text === 'Extensions')?.subMenu;
 
       expect(moreSubMenu).toEqual(
         expect.arrayContaining([
@@ -192,8 +192,8 @@ describe('getPanelMenu()', () => {
 
       const panel = new PanelModel({});
       const dashboard = createDashboardModelFixture({});
-      const menuItems = getPanelMenu(dashboard, panel);
-      const moreSubMenu = menuItems.find((i) => i.text === 'More...')?.subMenu;
+      const menuItems = getPanelMenu(dashboard, panel, LoadingState.Loading);
+      const moreSubMenu = menuItems.find((i) => i.text === 'Extensions')?.subMenu;
 
       expect(moreSubMenu).toEqual(
         expect.arrayContaining([
@@ -223,8 +223,8 @@ describe('getPanelMenu()', () => {
 
       const panel = new PanelModel({});
       const dashboard = createDashboardModelFixture({});
-      const menuItems = getPanelMenu(dashboard, panel);
-      const moreSubMenu = menuItems.find((i) => i.text === 'More...')?.subMenu;
+      const menuItems = getPanelMenu(dashboard, panel, LoadingState.Loading);
+      const moreSubMenu = menuItems.find((i) => i.text === 'Extensions')?.subMenu;
 
       expect(moreSubMenu).toEqual(
         expect.not.arrayContaining([

--- a/public/app/features/dashboard/utils/getPanelMenu.test.ts
+++ b/public/app/features/dashboard/utils/getPanelMenu.test.ts
@@ -125,7 +125,7 @@ describe('getPanelMenu()', () => {
 
       const panel = new PanelModel({});
       const dashboard = createDashboardModelFixture({});
-      const menuItems = getPanelMenu(dashboard, panel, LoadingState.Loading);
+      const menuItems = getPanelMenu(dashboard, panel);
       const moreSubMenu = menuItems.find((i) => i.text === 'Extensions')?.subMenu;
 
       expect(moreSubMenu).toEqual(
@@ -153,7 +153,7 @@ describe('getPanelMenu()', () => {
 
       const panel = new PanelModel({});
       const dashboard = createDashboardModelFixture({});
-      const menuItems = getPanelMenu(dashboard, panel, LoadingState.Loading);
+      const menuItems = getPanelMenu(dashboard, panel);
       const moreSubMenu = menuItems.find((i) => i.text === 'Extensions')?.subMenu;
 
       expect(moreSubMenu).toEqual(
@@ -192,7 +192,7 @@ describe('getPanelMenu()', () => {
 
       const panel = new PanelModel({});
       const dashboard = createDashboardModelFixture({});
-      const menuItems = getPanelMenu(dashboard, panel, LoadingState.Loading);
+      const menuItems = getPanelMenu(dashboard, panel);
       const moreSubMenu = menuItems.find((i) => i.text === 'Extensions')?.subMenu;
 
       expect(moreSubMenu).toEqual(
@@ -223,7 +223,7 @@ describe('getPanelMenu()', () => {
 
       const panel = new PanelModel({});
       const dashboard = createDashboardModelFixture({});
-      const menuItems = getPanelMenu(dashboard, panel, LoadingState.Loading);
+      const menuItems = getPanelMenu(dashboard, panel);
       const moreSubMenu = menuItems.find((i) => i.text === 'Extensions')?.subMenu;
 
       expect(moreSubMenu).toEqual(

--- a/public/app/features/dashboard/utils/getPanelMenu.ts
+++ b/public/app/features/dashboard/utils/getPanelMenu.ts
@@ -185,40 +185,6 @@ export function getPanelMenu(
     subMenu: inspectMenu,
   });
 
-  const { extensions } = getPluginExtensions({
-    placement: GrafanaExtensions.DashboardPanelMenu,
-    context: createExtensionContext(panel, dashboard),
-  });
-
-  if (extensions.length > 0) {
-    const extensionsMenu: PanelMenuItem[] = [];
-
-    for (const extension of extensions) {
-      if (isPluginExtensionLink(extension)) {
-        extensionsMenu.push({
-          text: truncateTitle(extension.title, 25),
-          href: extension.path,
-        });
-        continue;
-      }
-
-      if (isPluginExtensionCommand(extension)) {
-        extensionsMenu.push({
-          text: truncateTitle(extension.title, 25),
-          onClick: extension.callHandlerWithContext,
-        });
-        continue;
-      }
-    }
-
-    menu.push({
-      text: 'Extensions',
-      iconClassName: 'plug',
-      type: 'submenu',
-      subMenu: extensionsMenu,
-    });
-  }
-
   const subMenu: PanelMenuItem[] = [];
   const canEdit = dashboard.canEditPanel(panel);
 
@@ -299,6 +265,40 @@ export function getPanelMenu(
       iconClassName: 'cube',
       subMenu,
       onClick: onMore,
+    });
+  }
+
+  const { extensions } = getPluginExtensions({
+    placement: PluginExtensionPlacements.DashboardPanelMenu,
+    context: createExtensionContext(panel, dashboard),
+  });
+
+  if (extensions.length > 0) {
+    const extensionsMenu: PanelMenuItem[] = [];
+
+    for (const extension of extensions) {
+      if (isPluginExtensionLink(extension)) {
+        extensionsMenu.push({
+          text: truncateTitle(extension.title, 25),
+          href: extension.path,
+        });
+        continue;
+      }
+
+      if (isPluginExtensionCommand(extension)) {
+        extensionsMenu.push({
+          text: truncateTitle(extension.title, 25),
+          onClick: extension.callHandlerWithContext,
+        });
+        continue;
+      }
+    }
+
+    menu.push({
+      text: 'Extensions',
+      iconClassName: 'plug',
+      type: 'submenu',
+      subMenu: extensionsMenu,
     });
   }
 

--- a/public/app/features/dashboard/utils/getPanelMenu.ts
+++ b/public/app/features/dashboard/utils/getPanelMenu.ts
@@ -185,6 +185,40 @@ export function getPanelMenu(
     subMenu: inspectMenu,
   });
 
+  const { extensions } = getPluginExtensions({
+    placement: GrafanaExtensions.DashboardPanelMenu,
+    context: createExtensionContext(panel, dashboard),
+  });
+
+  if (extensions.length > 0) {
+    const extensionsMenu: PanelMenuItem[] = [];
+
+    for (const extension of extensions) {
+      if (isPluginExtensionLink(extension)) {
+        extensionsMenu.push({
+          text: truncateTitle(extension.title, 25),
+          href: extension.path,
+        });
+        continue;
+      }
+
+      if (isPluginExtensionCommand(extension)) {
+        extensionsMenu.push({
+          text: truncateTitle(extension.title, 25),
+          onClick: extension.callHandlerWithContext,
+        });
+        continue;
+      }
+    }
+
+    menu.push({
+      text: 'Extensions',
+      iconClassName: 'plug',
+      type: 'submenu',
+      subMenu: extensionsMenu,
+    });
+  }
+
   const subMenu: PanelMenuItem[] = [];
   const canEdit = dashboard.canEditPanel(panel);
 
@@ -265,40 +299,6 @@ export function getPanelMenu(
       iconClassName: 'cube',
       subMenu,
       onClick: onMore,
-    });
-  }
-
-  const { extensions } = getPluginExtensions({
-    placement: GrafanaExtensions.DashboardPanelMenu,
-    context: createExtensionContext(panel, dashboard),
-  });
-
-  if (extensions.length > 0) {
-    const extensionsMenu: PanelMenuItem[] = [];
-
-    for (const extension of extensions) {
-      if (isPluginExtensionLink(extension)) {
-        extensionsMenu.push({
-          text: truncateTitle(extension.title, 25),
-          href: extension.path,
-        });
-        continue;
-      }
-
-      if (isPluginExtensionCommand(extension)) {
-        extensionsMenu.push({
-          text: truncateTitle(extension.title, 25),
-          onClick: extension.callHandlerWithContext,
-        });
-        continue;
-      }
-    }
-
-    menu.push({
-      text: 'Extensions',
-      iconClassName: 'plug',
-      type: 'submenu',
-      subMenu: extensionsMenu,
     });
   }
 

--- a/public/app/features/dashboard/utils/getPanelMenu.ts
+++ b/public/app/features/dashboard/utils/getPanelMenu.ts
@@ -268,6 +268,40 @@ export function getPanelMenu(
     });
   }
 
+  const { extensions } = getPluginExtensions({
+    placement: GrafanaExtensions.DashboardPanelMenu,
+    context: createExtensionContext(panel, dashboard),
+  });
+
+  if (extensions.length > 0) {
+    const extensionsMenu: PanelMenuItem[] = [];
+
+    for (const extension of extensions) {
+      if (isPluginExtensionLink(extension)) {
+        extensionsMenu.push({
+          text: truncateTitle(extension.title, 25),
+          href: extension.path,
+        });
+        continue;
+      }
+
+      if (isPluginExtensionCommand(extension)) {
+        extensionsMenu.push({
+          text: truncateTitle(extension.title, 25),
+          onClick: extension.callHandlerWithContext,
+        });
+        continue;
+      }
+    }
+
+    menu.push({
+      text: 'Extensions',
+      iconClassName: 'plug',
+      type: 'submenu',
+      subMenu: extensionsMenu,
+    });
+  }
+
   if (dashboard.canEditPanel(panel) && !panel.isEditing && !panel.isViewing) {
     menu.push({ type: 'divider', text: '' });
 
@@ -277,29 +311,6 @@ export function getPanelMenu(
       onClick: onRemovePanel,
       shortcut: 'p r',
     });
-  }
-
-  const { extensions } = getPluginExtensions({
-    placement: PluginExtensionPlacements.DashboardPanelMenu,
-    context: createExtensionContext(panel, dashboard),
-  });
-
-  for (const extension of extensions) {
-    if (isPluginExtensionLink(extension)) {
-      subMenu.push({
-        text: truncateTitle(extension.title, 25),
-        href: extension.path,
-      });
-      continue;
-    }
-
-    if (isPluginExtensionCommand(extension)) {
-      subMenu.push({
-        text: truncateTitle(extension.title, 25),
-        onClick: extension.callHandlerWithContext,
-      });
-      continue;
-    }
   }
 
   return menu;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR moves the plugin extension links that are registered in the `dashboard/panel/menu` placement out into an Extensions submenu.

This deviates somewhat from the Figma designs where originally we were planning to have an extensions submenu then submenus that group by plugin name. e.g.

```
Panel Menu
├── [...current menu items]
└── Extensions
    └── [Plugin Name]
        └── [...extensionLinks / ...extensionCommands]
```

However having attempted to do this it became apparent the panel menu doesn't currently work for 3 levels (nested submenus). Perhaps someone from @grafana/dashboards-squad could confirm this?

As such we (@leventebalogh and I) have decided to pull them out into their own "Extensions" submenu for now with the idea that as the PanelChrome work is rolled out we'll have the opportunity to introduce a more refined UX for the extensions feature within panel menus.

**What does it look like?**

![image](https://user-images.githubusercontent.com/73201/224310737-39564179-7681-43e9-b4a6-a11edac46774.png)

The alternative to this would be to create submenus per plugin but we felt this could lead to the root panel menu increasing in height too much so settled with this instead.


**Why do we need this feature?**

To improve the UX of plugin extensions in the panel menu.

**Who is this feature for?**

Everyone?

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Related #61658

**Special notes for your reviewer**:

