### PR TITLE
Update page labels to better reflect contents

### DIFF
--- a/docs/sources/alerting/_index.md
+++ b/docs/sources/alerting/_index.md
@@ -2,6 +2,11 @@
 aliases:
   - about-alerting/
   - unified-alerting/alerting/
+cascade:
+  labels:
+    products:
+      - cloud
+      - oss
 title: Alerting
 weight: 114
 ---

--- a/docs/sources/introduction/grafana-cloud.md
+++ b/docs/sources/introduction/grafana-cloud.md
@@ -1,4 +1,7 @@
 ---
+labels:
+  products:
+    - cloud
 title: Grafana Cloud
 weight: 300
 ---

--- a/docs/sources/introduction/grafana-enterprise.md
+++ b/docs/sources/introduction/grafana-enterprise.md
@@ -1,6 +1,9 @@
 ---
 aliases:
   - ../enterprise/
+labels:
+  products:
+    - enterprise
 description: Grafana Enterprise overview
 title: Grafana Enterprise
 weight: 200


### PR DESCRIPTION
Alerting content is both "Open source" and "Grafana cloud". The Grafana docs default is just "Open source".
The use of cascading front matter is demonstrated in this PR, the labels set in the alerting page "cascade" to all child pages.

The introductions to Grafana Cloud and Grafana Enterprise are "Grafana cloud" and "Enterprise" respectively.

To check:

1. Run `make docs`
1. Browse to http://localhost:3002/docs/grafana/latest/introduction/grafana-cloud/ or http://localhost:3002/docs/grafana/latest/introduction/grafana-enterprise/ or http://localhost:3002/docs/grafana/latest/alerting/