### PR TITLE
TimeSeries: fix time comparer not comparing date strings properly

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -113,15 +113,14 @@ exports[`better eslint`] = {
     ],
     "packages/grafana-data/src/datetime/moment_wrapper.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
+      [0, 0, 0, "Do not use any type assertions.", "1"],
       [0, 0, 0, "Do not use any type assertions.", "2"],
       [0, 0, 0, "Do not use any type assertions.", "3"],
       [0, 0, 0, "Do not use any type assertions.", "4"],
       [0, 0, 0, "Do not use any type assertions.", "5"],
       [0, 0, 0, "Do not use any type assertions.", "6"],
       [0, 0, 0, "Do not use any type assertions.", "7"],
-      [0, 0, 0, "Do not use any type assertions.", "8"],
-      [0, 0, 0, "Do not use any type assertions.", "9"]
+      [0, 0, 0, "Do not use any type assertions.", "8"]
     ],
     "packages/grafana-data/src/datetime/parser.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],

--- a/packages/grafana-data/src/datetime/moment_wrapper.ts
+++ b/packages/grafana-data/src/datetime/moment_wrapper.ts
@@ -94,9 +94,9 @@ export const isDateTimeInput = (value: unknown): value is DateTimeInput => {
     value === null ||
     typeof value === 'string' ||
     typeof value === 'number' ||
-    isDateTime(value) ||
     value instanceof Date ||
-    (Array.isArray(value) && value.every((v) => typeof v === 'string' || typeof v === 'number'))
+    (Array.isArray(value) && value.every((v) => typeof v === 'string' || typeof v === 'number')) ||
+    isDateTime(value)
   );
 };
 

--- a/packages/grafana-data/src/datetime/moment_wrapper.ts
+++ b/packages/grafana-data/src/datetime/moment_wrapper.ts
@@ -89,7 +89,18 @@ export const getLocaleData = (): DateTimeLocale => {
   return moment.localeData();
 };
 
-export const isDateTime = (value: any): value is DateTime => {
+export const isDateTimeInput = (value: unknown): value is DateTimeInput => {
+  return (
+    value === null ||
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    isDateTime(value) ||
+    value instanceof Date ||
+    (Array.isArray(value) && value.every((v) => typeof v === 'string' || typeof v === 'number'))
+  );
+};
+
+export const isDateTime = (value: unknown): value is DateTime => {
   return moment.isMoment(value);
 };
 

--- a/packages/grafana-data/src/field/fieldComparers.ts
+++ b/packages/grafana-data/src/field/fieldComparers.ts
@@ -1,6 +1,6 @@
 import { isNumber } from 'lodash';
 
-import { dateTime, isDateTime } from '../datetime';
+import { dateTime, isDateTimeInput } from '../datetime';
 import { Field, FieldType } from '../types/dataFrame';
 import { Vector } from '../types/vector';
 
@@ -34,7 +34,7 @@ export const timeComparer = (a: unknown, b: unknown): number => {
     return numericComparer(a, b);
   }
 
-  if (isDateTime(a) && isDateTime(b)) {
+  if (isDateTimeInput(a) && isDateTimeInput(b)) {
     if (dateTime(a).isBefore(b)) {
       return -1;
     }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- in [a previous PR](https://github.com/grafana/grafana/pull/60009), i mistakenly assumed inputs to the `dateTime` function would have to be valid `DateTime`s. 
- however, the type is actually defined as:
  ```export type DateTimeInput = Date | string | number | Array<string | number> | DateTime | null;```
- because of this, the changes in https://github.com/grafana/grafana/pull/60009 are now excluding many cases which are valid.
- created a new type guard `isDateTimeInput` validating the various types above
- use this instead of `isDateTime` in the `timeComparer` function

**Why do we need this feature?**

- so `timeComparer` works properly

**Who is this feature for?**

- everyone! 🙌 

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

For https://github.com/grafana/support-escalations/issues/5234

**Special notes for your reviewer**:

