### PR TITLE
Range splitting: remove hardcoded chunk limit

### DIFF
--- a/public/app/plugins/datasource/loki/logsTimeSplit.test.ts
+++ b/public/app/plugins/datasource/loki/logsTimeSplit.test.ts
@@ -28,8 +28,8 @@ describe('querySplit', () => {
   });
 
   it('should return null if too many chunks would be generated', () => {
-    const start = Date.parse('2022-02-06T14:10:03');
-    const end = Date.parse('2022-02-06T14:30:03');
+    const start = Date.parse('1990-02-06T14:10:03');
+    const end = Date.parse('2023-02-06T14:30:03');
     expect(getRangeChunks(start, end, 10000)).toBeNull();
   });
 });

--- a/public/app/plugins/datasource/loki/logsTimeSplit.test.ts
+++ b/public/app/plugins/datasource/loki/logsTimeSplit.test.ts
@@ -26,10 +26,4 @@ describe('querySplit', () => {
       [Date.parse('2022-02-06T14:10:43.567'), Date.parse('2022-02-06T14:11:03.567')],
     ]);
   });
-
-  it('should return null if too many chunks would be generated', () => {
-    const start = Date.parse('1990-02-06T14:10:03');
-    const end = Date.parse('2023-02-06T14:30:03');
-    expect(getRangeChunks(start, end, 10000)).toBeNull();
-  });
 });

--- a/public/app/plugins/datasource/loki/logsTimeSplit.ts
+++ b/public/app/plugins/datasource/loki/logsTimeSplit.ts
@@ -2,7 +2,7 @@
 // like returned by `new Date().getTime()`. this is needed because the "math"
 // has to be done on integer numbers.
 
-const MAX_CHUNK_COUNT = 50;
+const MAX_CHUNK_COUNT = 10000;
 
 // the way loki handles logs-range-queries is that if you specify start & end,
 // one of those will be included, but the other will not. this allows us to

--- a/public/app/plugins/datasource/loki/logsTimeSplit.ts
+++ b/public/app/plugins/datasource/loki/logsTimeSplit.ts
@@ -2,8 +2,6 @@
 // like returned by `new Date().getTime()`. this is needed because the "math"
 // has to be done on integer numbers.
 
-const MAX_CHUNK_COUNT = 10000;
-
 // the way loki handles logs-range-queries is that if you specify start & end,
 // one of those will be included, but the other will not. this allows us to
 // make it easy to split ranges.
@@ -22,7 +20,7 @@ export function getRangeChunks(
   startTime: number,
   endTime: number,
   idealRangeDuration: number
-): Array<[number, number]> | null {
+): Array<[number, number]> {
   if (endTime - startTime <= idealRangeDuration) {
     return [[startTime, endTime]];
   }
@@ -36,10 +34,6 @@ export function getRangeChunks(
     // to cross over the startTime
     const chunkStartTime = Math.max(chunkEndTime - idealRangeDuration, startTime);
     result.push([chunkStartTime, chunkEndTime]);
-
-    if (result.length > MAX_CHUNK_COUNT) {
-      return null;
-    }
   }
 
   // because we walked backwards, we need to reverse the array

--- a/public/app/plugins/datasource/loki/metricTimeSplit.test.ts
+++ b/public/app/plugins/datasource/loki/metricTimeSplit.test.ts
@@ -17,13 +17,6 @@ describe('querySplit', () => {
     const start = Date.parse('1990-02-06T14:10:03');
     const end = Date.parse('2022-02-06T14:35:01');
     const step = 10 * 1000;
-    expect(getRangeChunks(start, end, step, 20000)).toBeNull();
-  });
-
-  it('should return null if requested duration is smaller than step', () => {
-    const start = Date.parse('2022-02-06T14:10:03');
-    const end = Date.parse('2022-02-06T14:10:33');
-    const step = 10 * 1000;
-    expect(getRangeChunks(start, end, step, 1000)).toBeNull();
+    expect(getRangeChunks(start, end, step, 20000)).toEqual([[start, end]]);
   });
 });

--- a/public/app/plugins/datasource/loki/metricTimeSplit.test.ts
+++ b/public/app/plugins/datasource/loki/metricTimeSplit.test.ts
@@ -14,7 +14,7 @@ describe('querySplit', () => {
   });
 
   it('should return null if too many chunks would be generated', () => {
-    const start = Date.parse('2022-02-06T14:10:03');
+    const start = Date.parse('1990-02-06T14:10:03');
     const end = Date.parse('2022-02-06T14:35:01');
     const step = 10 * 1000;
     expect(getRangeChunks(start, end, step, 20000)).toBeNull();

--- a/public/app/plugins/datasource/loki/metricTimeSplit.test.ts
+++ b/public/app/plugins/datasource/loki/metricTimeSplit.test.ts
@@ -13,10 +13,10 @@ describe('querySplit', () => {
     ]);
   });
 
-  it('should return null if too many chunks would be generated', () => {
-    const start = Date.parse('1990-02-06T14:10:03');
-    const end = Date.parse('2022-02-06T14:35:01');
+  it('should return the original interval if requested duration is smaller than step', () => {
+    const start = Date.parse('2022-02-06T14:10:03');
+    const end = Date.parse('2022-02-06T14:10:33');
     const step = 10 * 1000;
-    expect(getRangeChunks(start, end, step, 20000)).toEqual([[start, end]]);
+    expect(getRangeChunks(start, end, step, 1000)).toEqual([[start, end]]);
   });
 });

--- a/public/app/plugins/datasource/loki/metricTimeSplit.ts
+++ b/public/app/plugins/datasource/loki/metricTimeSplit.ts
@@ -19,17 +19,15 @@ function expandTimeRange(startTime: number, endTime: number, step: number): [num
   return [newStartTime, newEndTime];
 }
 
-const MAX_CHUNK_COUNT = 10000;
-
 export function getRangeChunks(
   startTime: number,
   endTime: number,
   step: number,
   idealRangeDuration: number
-): Array<[number, number]> | null {
+): Array<[number, number]> {
   if (idealRangeDuration < step) {
     // we cannot create chunks smaller than `step`
-    return null;
+    return [[startTime, endTime]];
   }
 
   // we make the duration a multiple of `step`, lowering it if necessary
@@ -45,10 +43,6 @@ export function getRangeChunks(
     // to cross over the startTime
     const chunkStartTime = Math.max(chunkEndTime - alignedDuration, alignedStartTime);
     result.push([chunkStartTime, chunkEndTime]);
-
-    if (result.length > MAX_CHUNK_COUNT) {
-      return null;
-    }
   }
 
   // because we walked backwards, we need to reverse the array

--- a/public/app/plugins/datasource/loki/metricTimeSplit.ts
+++ b/public/app/plugins/datasource/loki/metricTimeSplit.ts
@@ -19,7 +19,7 @@ function expandTimeRange(startTime: number, endTime: number, step: number): [num
   return [newStartTime, newEndTime];
 }
 
-const MAX_CHUNK_COUNT = 50;
+const MAX_CHUNK_COUNT = 10000;
 
 export function getRangeChunks(
   startTime: number,

--- a/public/app/plugins/datasource/loki/querySplitting.test.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.test.ts
@@ -190,4 +190,24 @@ describe('runPartitionedQueries()', () => {
       });
     });
   });
+
+  test('Throws when the requested interval is excessively large', async () => {
+    const range = {
+      from: dateTime('1990-02-08T05:00:00.000Z'),
+      to: dateTime('2023-02-10T06:00:00.000Z'),
+      raw: {
+        from: dateTime('1990-02-08T05:00:00.000Z'),
+        to: dateTime('2023-02-10T06:00:00.000Z'),
+      },
+    };
+    const request = getQueryOptions<LokiQuery>({
+      targets: [{ expr: 'count_over_time({a="b"}[1m])', refId: 'A' }],
+      range,
+    });
+
+    await expect(runPartitionedQueries(datasource, request)).toEmitValuesWith((error) => {
+      expect(error[0]).toBeInstanceOf(Error);
+      expect(datasource.runQuery).toHaveBeenCalledTimes(0);
+    });
+  });
 });

--- a/public/app/plugins/datasource/loki/querySplitting.test.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.test.ts
@@ -190,24 +190,4 @@ describe('runPartitionedQueries()', () => {
       });
     });
   });
-
-  test('Throws when the requested interval is excessively large', async () => {
-    const range = {
-      from: dateTime('1990-02-08T05:00:00.000Z'),
-      to: dateTime('2023-02-10T06:00:00.000Z'),
-      raw: {
-        from: dateTime('1990-02-08T05:00:00.000Z'),
-        to: dateTime('2023-02-10T06:00:00.000Z'),
-      },
-    };
-    const request = getQueryOptions<LokiQuery>({
-      targets: [{ expr: 'count_over_time({a="b"}[1m])', refId: 'A' }],
-      range,
-    });
-
-    await expect(runPartitionedQueries(datasource, request)).toEmitValuesWith((error) => {
-      expect(error[0]).toBeInstanceOf(Error);
-      expect(datasource.runQuery).toHaveBeenCalledTimes(0);
-    });
-  });
 });

--- a/public/app/plugins/datasource/loki/querySplitting.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.ts
@@ -41,11 +41,6 @@ export function partitionTimeRange(
     ? getLogsRangeChunks(start, end, duration)
     : getMetricRangeChunks(start, end, step, duration);
 
-  // if the split was not possible, go with the original range
-  if (ranges == null) {
-    throw new Error('The selected time interval exceeds the defined query split limit. Please try a smaller range.');
-  }
-
   return ranges.map(([start, end]) => {
     const from = dateTime(start);
     const to = dateTime(end);

--- a/public/app/plugins/datasource/loki/querySplitting.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.ts
@@ -174,27 +174,23 @@ export function runPartitionedQueries(datasource: LokiDatasource, request: DataQ
   const [logQueries, metricQueries] = partition(normalQueries, (query) => isLogsQuery(query.expr));
 
   const requests: LokiGroupedRequest = [];
-  try {
-    if (logQueries.length) {
-      requests.push({
-        request: { ...request, targets: logQueries },
-        partition: partitionTimeRange(true, request.range, request.intervalMs, logQueries[0].resolution ?? 1),
-      });
-    }
-    if (metricQueries.length) {
-      requests.push({
-        request: { ...request, targets: metricQueries },
-        partition: partitionTimeRange(false, request.range, request.intervalMs, metricQueries[0].resolution ?? 1),
-      });
-    }
-    if (instantQueries.length) {
-      requests.push({
-        request: { ...request, targets: instantQueries },
-        partition: [request.range],
-      });
-    }
-  } catch (error) {
-    return throwError(() => error);
+  if (logQueries.length) {
+    requests.push({
+      request: { ...request, targets: logQueries },
+      partition: partitionTimeRange(true, request.range, request.intervalMs, logQueries[0].resolution ?? 1),
+    });
+  }
+  if (metricQueries.length) {
+    requests.push({
+      request: { ...request, targets: metricQueries },
+      partition: partitionTimeRange(false, request.range, request.intervalMs, metricQueries[0].resolution ?? 1),
+    });
+  }
+  if (instantQueries.length) {
+    requests.push({
+      request: { ...request, targets: instantQueries },
+      partition: [request.range],
+    });
   }
 
   return runGroupedQueries(datasource, requests);

--- a/public/app/plugins/datasource/loki/querySplitting.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.ts
@@ -1,5 +1,5 @@
 import { partition } from 'lodash';
-import { Subscriber, Observable, Subscription, throwError } from 'rxjs';
+import { Subscriber, Observable, Subscription } from 'rxjs';
 
 import { DataQueryRequest, DataQueryResponse, dateTime, TimeRange } from '@grafana/data';
 import { LoadingState } from '@grafana/schema';


### PR DESCRIPTION
This PR removes the hardcoded chunk limit we originally added to prevent indefinitely blocking the browser. The initial implementation was in orders of magnitude slower than the current one, so there doesn't seem to be any reason to have one.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana/issues/61768

**Special notes for your reviewer**:

Users should be able to make larger requests than before.