### PR TITLE
Explore: Add user login and user email to variables for queries

### DIFF
--- a/public/app/core/utils/explore.ts
+++ b/public/app/core/utils/explore.ts
@@ -153,6 +153,8 @@ export function buildQueryTransaction(
     scopedVars: {
       __interval: { text: interval, value: interval },
       __interval_ms: { text: intervalMs, value: intervalMs },
+      __user_email: { text: config.bootData.user.email, value: config.bootData.user.email },
+      __user_login: { text: config.bootData.user.login, value: config.bootData.user.login },
     },
     maxDataPoints: queryOptions.maxDataPoints,
     liveStreaming: queryOptions.liveStreaming,


### PR DESCRIPTION
This is a draft while we figure out if this is something we would want to introduce to explore.

**What is this feature?**

This adds the current user's email and login as variables in explore.

Note: The variables introduced are `${__user_email}` and not `${__user.email}` because the prometheus datasource (which loki uses) discards anything in the "fieldPath" capture group of the variables regex ([src](https://github.com/grafana/grafana/blob/main/public/app/plugins/datasource/prometheus/querybuilder/shared/parsingUtils.ts#L38)). The email part of `${__user.email}` would be that fieldPath capture group.

**Who is this feature for?**

Someone who would like to query explore with information about the currently logged in user.

**Which issue(s) does this PR fix?**:

Fixes #64328

**Special notes for your reviewer**:
This can be replicated in any datasource by using `${__user_email}` or `${__user_login}`. If you do not have data that would match, you can see if it works by pulling up the query inspector. The logged in user's email or login should show up in the inspector.
