### PR TITLE
Dashboards: Filter out expressions when going to Explore

### DIFF
--- a/public/app/core/utils/explore.test.ts
+++ b/public/app/core/utils/explore.test.ts
@@ -197,7 +197,10 @@ describe('getExploreUrl', () => {
   const args = {
     panel: {
       getSavedId: () => 1,
-      targets: [{ refId: 'A', expr: 'query1', legendFormat: 'legendFormat1' }],
+      targets: [
+        { refId: 'A', expr: 'query1', legendFormat: 'legendFormat1' },
+        { refId: 'B', expr: 'query2', datasource: { type: '__expr__', uid: '__expr__' } },
+      ],
     },
     datasourceSrv: {
       get() {
@@ -214,6 +217,9 @@ describe('getExploreUrl', () => {
 
   it('should omit legendFormat in explore url', () => {
     expect(getExploreUrl(args).then((data) => expect(data).not.toMatch(/legendFormat1/g)));
+  });
+  it('should omit expression target in explore url', () => {
+    expect(getExploreUrl(args).then((data) => expect(data).not.toMatch(/__expr__/g)));
   });
 });
 

--- a/public/app/core/utils/explore.ts
+++ b/public/app/core/utils/explore.ts
@@ -30,7 +30,7 @@ import { RefreshPicker } from '@grafana/ui';
 import store from 'app/core/store';
 import { TimeSrv } from 'app/features/dashboard/services/TimeSrv';
 import { PanelModel } from 'app/features/dashboard/state';
-import { ExpressionDatasourceUID } from 'app/features/expressions/ExpressionDatasource';
+import { ExpressionDatasourceUID } from 'app/features/expressions/types';
 import { ExploreId, QueryOptions, QueryTransaction } from 'app/types/explore';
 
 import { config } from '../config';

--- a/public/app/core/utils/explore.ts
+++ b/public/app/core/utils/explore.ts
@@ -30,6 +30,7 @@ import { RefreshPicker } from '@grafana/ui';
 import store from 'app/core/store';
 import { TimeSrv } from 'app/features/dashboard/services/TimeSrv';
 import { PanelModel } from 'app/features/dashboard/state';
+import { ExpressionDatasourceUID } from 'app/features/expressions/ExpressionDatasource';
 import { ExploreId, QueryOptions, QueryTransaction } from 'app/types/explore';
 
 import { config } from '../config';
@@ -67,8 +68,12 @@ export async function getExploreUrl(args: GetExploreUrlArguments): Promise<strin
 
   /** In Explore, we don't have legend formatter and we don't want to keep
    * legend formatting as we can't change it
+   *
+   * We also don't have expressions, so filter those out
    */
-  let exploreTargets: DataQuery[] = panel.targets.map((t) => omit(t, 'legendFormat'));
+  let exploreTargets: DataQuery[] = panel.targets
+    .map((t) => omit(t, 'legendFormat'))
+    .filter((t) => t.datasource?.uid !== ExpressionDatasourceUID);
   let url: string | undefined;
   // if the mixed datasource is not enabled for explore, choose only one datasource
   if (

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/reducer.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/reducer.test.tsx
@@ -1,10 +1,7 @@
 import { getDefaultRelativeTimeRange, RelativeTimeRange } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime/src/services/__mocks__/dataSourceSrv';
-import {
-  dataSource as expressionDatasource,
-  ExpressionDatasourceUID,
-} from 'app/features/expressions/ExpressionDatasource';
-import { ExpressionQuery, ExpressionQueryType } from 'app/features/expressions/types';
+import { dataSource as expressionDatasource } from 'app/features/expressions/ExpressionDatasource';
+import { ExpressionQuery, ExpressionQueryType, ExpressionDatasourceUID } from 'app/features/expressions/types';
 import { defaultCondition } from 'app/features/expressions/utils/expressionTypes';
 import { AlertQuery } from 'app/types/unified-alerting-dto';
 

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/reducer.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/reducer.ts
@@ -3,12 +3,9 @@ import { createAction, createReducer } from '@reduxjs/toolkit';
 import { DataQuery, getDefaultRelativeTimeRange, RelativeTimeRange } from '@grafana/data';
 import { getNextRefIdChar } from 'app/core/utils/query';
 import { findDataSourceFromExpressionRecursive } from 'app/features/alerting/utils/dataSourceFromExpression';
-import {
-  dataSource as expressionDatasource,
-  ExpressionDatasourceUID,
-} from 'app/features/expressions/ExpressionDatasource';
+import { dataSource as expressionDatasource } from 'app/features/expressions/ExpressionDatasource';
 import { isExpressionQuery } from 'app/features/expressions/guards';
-import { ExpressionQuery, ExpressionQueryType } from 'app/features/expressions/types';
+import { ExpressionQuery, ExpressionQueryType, ExpressionDatasourceUID } from 'app/features/expressions/types';
 import { defaultCondition } from 'app/features/expressions/utils/expressionTypes';
 import { AlertQuery } from 'app/types/unified-alerting-dto';
 

--- a/public/app/features/alerting/unified/components/rules/RuleDetailsDataSources.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleDetailsDataSources.tsx
@@ -4,7 +4,7 @@ import React, { useMemo } from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 import { useStyles2 } from '@grafana/ui';
-import { ExpressionDatasourceUID } from 'app/features/expressions/ExpressionDatasource';
+import { ExpressionDatasourceUID } from 'app/features/expressions/types';
 import { CombinedRule, RulesSource } from 'app/types/unified-alerting';
 
 import { isCloudRulesSource } from '../../utils/datasource';

--- a/public/app/features/alerting/unified/utils/query.test.ts
+++ b/public/app/features/alerting/unified/utils/query.test.ts
@@ -1,5 +1,5 @@
 import { DataSourceJsonData, PluginMeta } from '@grafana/data';
-import { ExpressionDatasourceUID } from 'app/features/expressions/ExpressionDatasource';
+import { ExpressionDatasourceUID } from 'app/features/expressions/types';
 import { CombinedRule } from 'app/types/unified-alerting';
 import { GrafanaAlertStateDecision } from 'app/types/unified-alerting-dto';
 

--- a/public/app/features/alerting/unified/utils/rule-form.ts
+++ b/public/app/features/alerting/unified/utils/rule-form.ts
@@ -12,8 +12,7 @@ import { getDataSourceSrv } from '@grafana/runtime';
 import { ExpressionDatasourceRef } from '@grafana/runtime/src/utils/DataSourceWithBackend';
 import { getNextRefIdChar } from 'app/core/utils/query';
 import { DashboardModel, PanelModel } from 'app/features/dashboard/state';
-import { ExpressionDatasourceUID } from 'app/features/expressions/ExpressionDatasource';
-import { ExpressionQuery, ExpressionQueryType } from 'app/features/expressions/types';
+import { ExpressionQuery, ExpressionQueryType, ExpressionDatasourceUID } from 'app/features/expressions/types';
 import { PromQuery } from 'app/plugins/datasource/prometheus/types';
 import { RuleWithLocation } from 'app/types/unified-alerting';
 import {

--- a/public/app/features/alerting/utils/dataSourceFromExpression.ts
+++ b/public/app/features/alerting/utils/dataSourceFromExpression.ts
@@ -1,4 +1,4 @@
-import { ExpressionDatasourceUID } from 'app/features/expressions/ExpressionDatasource';
+import { ExpressionDatasourceUID } from 'app/features/expressions/types';
 import { AlertQuery } from 'app/types/unified-alerting-dto';
 
 export const hasCyclicalReferences = (queries: AlertQuery[]) => {

--- a/public/app/features/expressions/ExpressionDatasource.ts
+++ b/public/app/features/expressions/ExpressionDatasource.ts
@@ -12,7 +12,7 @@ import { DataSourceWithBackend, getDataSourceSrv, getTemplateSrv } from '@grafan
 import { ExpressionDatasourceRef } from '@grafana/runtime/src/utils/DataSourceWithBackend';
 
 import { ExpressionQueryEditor } from './ExpressionQueryEditor';
-import { ExpressionQuery, ExpressionQueryType } from './types';
+import { ExpressionDatasourceUID, ExpressionQuery, ExpressionQueryType } from './types';
 
 /**
  * This is a singleton instance that just pretends to be a DataSource
@@ -59,11 +59,6 @@ export class ExpressionDatasourceApi extends DataSourceWithBackend<ExpressionQue
     };
   }
 }
-
-/**
- * MATCHES a constant in DataSourceWithBackend
- */
-export const ExpressionDatasourceUID = '__expr__';
 
 export const instanceSettings: DataSourceInstanceSettings = {
   id: -100,

--- a/public/app/features/expressions/types.ts
+++ b/public/app/features/expressions/types.ts
@@ -2,6 +2,11 @@ import { DataQuery, ReducerID, SelectableValue } from '@grafana/data';
 
 import { EvalFunction } from '../alerting/state/alertDef';
 
+/**
+ * MATCHES a constant in DataSourceWithBackend
+ */
+export const ExpressionDatasourceUID = '__expr__';
+
 export enum ExpressionQueryType {
   math = 'math',
   reduce = 'reduce',

--- a/public/app/features/plugins/datasource_srv.ts
+++ b/public/app/features/plugins/datasource_srv.ts
@@ -20,9 +20,9 @@ import appEvents from 'app/core/app_events';
 import config from 'app/core/config';
 import {
   dataSource as expressionDatasource,
-  ExpressionDatasourceUID,
   instanceSettings as expressionInstanceSettings,
 } from 'app/features/expressions/ExpressionDatasource';
+import { ExpressionDatasourceUID } from 'app/features/expressions/types';
 
 import { importDataSourcePlugin } from './plugin_loader';
 


### PR DESCRIPTION
**What is this feature?**

This fixes a bug where moving from Dashboards to explore when there is an expression in the query leads to an invalid scenario. If Mixed Datasources is on, the Expression query is moved over but is not valid. If Mixed Datasources is off, it converts the query to the main datasource and causes it to be blank.

This also seemed to require that the expression datasource UID be moved from the Expression Datasource class to a types file. This was to fix an error in the tests ([src]( https://drone.grafana.net/grafana/grafana/105689)). The variable that was exported is outside the class, so I'm not entirely sure why this errors, but having this defined in the types file makes sense to me.

**Why do we need this feature?**

Moving from Dashboards to Explore should work without a confusing empty query.

**Who is this feature for?**

People who use expressions in dashboards and then want to open their query in Explore

**Which issue(s) does this PR fix?**:

Reported by customer

**Special notes for your reviewer**:

Replication Steps:
1. Create a panel with an expression. The expression does not have to actually be functional.
2. Save and from the dashboard, click on the panel menu and go to explore.