### PR TITLE
TopNav: Wrap TopSearchBar in memo to prevent unnecessary re-renders

### DIFF
--- a/public/app/core/components/AppChrome/TopSearchBar.tsx
+++ b/public/app/core/components/AppChrome/TopSearchBar.tsx
@@ -19,7 +19,7 @@ import { TopSearchBarSection } from './TopBar/TopSearchBarSection';
 import { TopSearchBarCommandPaletteTrigger } from './TopSearchBarCommandPaletteTrigger';
 import { TOP_BAR_LEVEL_HEIGHT } from './types';
 
-export function TopSearchBar() {
+export const TopSearchBar = React.memo(function TopSearchBar() {
   const styles = useStyles2(getStyles);
   const navIndex = useSelector((state) => state.navIndex);
   const location = useLocation();
@@ -67,7 +67,7 @@ export function TopSearchBar() {
       </TopSearchBarSection>
     </div>
   );
-}
+});
 
 const getStyles = (theme: GrafanaTheme2) => ({
   layout: css({


### PR DESCRIPTION
Troubleshooted some issues where OrganizationSelect opens when visiting some plugin config pages,
not figured out why that is yet. But did discover that the TopSearchBar is rendered 2-3 times
every url/query change and hence all components in it (including the Select).


