### PR TITLE
[v8.1.x] Fix website build errors reported by Hugo

### DIFF
--- a/.github/workflows/publish-technical-documentation-release.yml
+++ b/.github/workflows/publish-technical-documentation-release.yml
@@ -1,0 +1,68 @@
+name: "publish-technical-documentation-release"
+
+on:
+  push:
+    branches:
+      - v[0-9]+.[0-9]+.x
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+
+    paths:
+      - "docs/sources/**"
+  workflow_dispatch:
+jobs:
+  sync:
+    if: "github.repository == 'grafana/grafana'"
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Checkout Grafana repo"
+        uses: "actions/checkout@v3"
+        with:
+          fetch-depth: 0
+
+      - name: "Checkout Actions library"
+        uses: "actions/checkout@v3"
+        with:
+          repository: "grafana/grafana-github-actions"
+          path: "./actions"
+
+      - name: "Install Actions from library"
+        run: "npm install --production --prefix ./actions"
+
+      - name: "Determine if there is a matching release tag"
+        id: "has-matching-release-tag"
+        uses: "./actions/has-matching-release-tag"
+        with:
+          ref_name: "${{ github.ref_name }}"
+          release_tag_regexp: "^v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$"
+          release_branch_regexp: "^v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.x$"
+
+      - name: "Determine technical documentation version"
+        if: "steps.has-matching-release-tag.outputs.bool == 'true'"
+        uses: "./actions/docs-target"
+        id: "target"
+        with:
+          ref_name: "${{ github.ref_name }}"
+
+      - name: "Clone website-sync Action"
+        if: "steps.has-matching-release-tag.outputs.bool == 'true'"
+        # WEBSITE_SYNC_TOKEN is a fine-grained GitHub Personal Access Token that expires.
+        # It must be regenerated in the grafanabot GitHub account and requires a Grafana organization
+        # GitHub administrator to update the organization secret.
+        # The IT helpdesk can update the organization secret.
+        run: "git clone --single-branch --no-tags --depth 1 -b master https://grafanabot:${{ secrets.WEBSITE_SYNC_TOKEN }}@github.com/grafana/website-sync ./.github/actions/website-sync"
+
+      - name: "Publish to website repository (release)"
+        if: "steps.has-matching-release-tag.outputs.bool == 'true'"
+        uses: "./.github/actions/website-sync"
+        id: "publish-release"
+        with:
+          repository: "grafana/website"
+          branch: "master"
+          host: "github.com"
+          # PUBLISH_TO_WEBSITE_TOKEN is a fine-grained GitHub Personal Access Token that expires.
+          # It must be regenerated in the grafanabot GitHub account and requires a Grafana organization
+          # GitHub administrator to update the organization secret.
+          # The IT helpdesk can update the organization secret.
+          github_pat: "grafanabot:${{ secrets.PUBLISH_TO_WEBSITE_TOKEN }}"
+          source_folder: "docs/sources"
+          target_folder: "content/docs/grafana/${{ steps.target.outputs.target }}"

--- a/.github/workflows/publish-technical-documentation-release.yml
+++ b/.github/workflows/publish-technical-documentation-release.yml
@@ -36,6 +36,27 @@ jobs:
           release_tag_regexp: "^v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$"
           release_branch_regexp: "^v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.x$"
 
+      - name: "Generate packages_api docs"
+        uses: "actions/setup-node@v3.2.0"
+        id: "generate-packages_api-docs"
+        with:
+          node-version: '16'
+
+      - name: "Get yarn cache directory path"
+        id: "yarn-cache-dir-path"
+        run: "echo ::set-output name=dir::$(yarn config get cacheFolder)"
+
+      - uses: "actions/cache@v2.1.7"
+        with:
+          path: "${{ steps.yarn-cache-dir-path.outputs.dir }}"
+          key: "yarn-${{ hashFiles('**/yarn.lock') }}"
+          restore-keys: |
+              yarn-
+
+      - run: "yarn install --immutable"
+
+      - run: "./scripts/ci-reference-docs-build.sh"
+
       - name: "Determine technical documentation version"
         if: "steps.has-matching-release-tag.outputs.bool == 'true'"
         uses: "./actions/docs-target"

--- a/docs/sources/developers/plugins/migration-guide.md
+++ b/docs/sources/developers/plugins/migration-guide.md
@@ -176,7 +176,7 @@ We strongly recommend that you not allow unsigned plugins in your Grafana instal
 
 To sign your plugin, see [Sign a plugin](https://grafana.com/docs/grafana/latest/developers/plugins/sign-a-plugin/#sign-a-plugin).
 
-You can still run and develop an unsigned plugin by running your Grafana instance in [development mode](https://grafana.com/docs/grafana/latest/administration/configuration/#app_mode). Alternatively, you can use the [allow_loading_unsigned_plugins configuration setting.]({{< relref "../administration/#allow_loading_unsigned_plugins" >}})
+You can still run and develop an unsigned plugin by running your Grafana instance in [development mode](https://grafana.com/docs/grafana/latest/administration/configuration/#app_mode). Alternatively, you can use the [allow_loading_unsigned_plugins configuration setting.]({{< relref "../../administration/configuration#allow_loading_unsigned_plugins" >}})
 
 ### Update react-hook-form from v6 to v7
 

--- a/docs/sources/getting-started/_index.md
+++ b/docs/sources/getting-started/_index.md
@@ -8,6 +8,6 @@ aliases = ["/docs/grafana/latest/guides/what-is-grafana"]
 
 This section provides guidance on how to install Grafana and build your first dashboard. It also provides step by step instructions on how to add a Prometheus or an InfluxDB data source. Refer to [Data sources]({{< relref "../datasources/_index.md" >}}) for a list of all supported data sources.
 
-- [Getting started with Grafana]({{< relref "/getting-started.md" >}})
+- [Getting started with Grafana]({{< relref "./getting-started" >}})
 - [Getting started with Grafana and InfuxDB]({{< relref "getting-started-influxdb.md" >}})
 - [Getting started with Grafana and Prometheus]({{< relref "getting-started-prometheus.md" >}})

--- a/docs/sources/linking/panel-links.md
+++ b/docs/sources/linking/panel-links.md
@@ -8,7 +8,7 @@ weight = 300
 
 # Panel links
 
-{{< docs/shared "panels/panel-links-intro.md" >}}
+Each panel can have its own set of links that are shown in the upper left corner of the panel. You can link to any available URL, including dashboards, panels, or external sites. You can even control the time range to ensure the user is zoomed in on the right data in Grafana.
 
 Click the icon on the top left corner of a panel to see available panel links.
 

--- a/docs/sources/panels/panel-options.md
+++ b/docs/sources/panels/panel-options.md
@@ -27,12 +27,8 @@ Toggle the transparent background option on your panel display.
 
 ## Panel links
 
-{{< docs/shared "panels/panel-links-intro.md" >}}
-
 For more information, refer to [Panel links]({{< relref "../linking/panel-links.md" >}}).
 
 ## Repeat options
-
-{{< docs/shared "panels/repeat-panels-intro.md" >}}
 
 For more information, refer to [Repeat panels or rows]({{< relref "./repeat-panels-or-rows.md" >}}).

--- a/docs/sources/panels/repeat-panels-or-rows.md
+++ b/docs/sources/panels/repeat-panels-or-rows.md
@@ -7,7 +7,7 @@ weight = 800
 
 # Repeat panels or rows
 
-{{< docs/shared "panels/repeat-panels-intro.md" >}}
+Grafana lets you create dynamic dashboards using _template variables_. All variables in your queries expand to the current value of the variable before the query is sent to the database. Variables let you reuse a single dashboard for all your services.
 
 Template variables can be very useful to dynamically change your queries across a whole dashboard. If you want
 Grafana to dynamically create new panels or rows based on what values you have selected, you can use the _Repeat_ feature.

--- a/docs/sources/shared/manage-users/view-server-org-list-and-edit.md
+++ b/docs/sources/shared/manage-users/view-server-org-list-and-edit.md
@@ -3,7 +3,9 @@ title: View org list as server admin
 ---
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-org-list.md" >}}
+
+{{< docs/shared lookup="manage-users/view-server-org-list.md" source="grafana" version="v8.1" >}}
 
 1. Click the name of the organization that you want to edit.
-   {{< /docs/list >}}
+
+{{< /docs/list >}}

--- a/docs/sources/shared/manage-users/view-server-user-list-search.md
+++ b/docs/sources/shared/manage-users/view-server-user-list-search.md
@@ -3,7 +3,9 @@ title: View user list and search - list format
 ---
 
 {{< docs/list >}}
-{{< docs/shared "manage-users/view-server-user-list.md" >}}
+
+{{< docs/shared lookup="manage-users/view-server-user-list.md" source="grafana" version="v8.1" >}}
 
 1. Click the user account that you want to edit. If necessary, use the search field to find the account.
-   {{< /docs/list >}}
+
+{{< /docs/list >}}

--- a/docs/sources/shared/panels/panel-links-intro.md
+++ b/docs/sources/shared/panels/panel-links-intro.md
@@ -1,5 +1,0 @@
----
-title: Panel links intro
----
-
-Each panel can have its own set of links that are shown in the upper left corner of the panel. You can link to any available URL, including dashboards, panels, or external sites. You can even control the time range to ensure the user is zoomed in on the right data in Grafana.

--- a/docs/sources/shared/panels/repeat-panel-intro.md
+++ b/docs/sources/shared/panels/repeat-panel-intro.md
@@ -1,5 +1,0 @@
----
-title: Repeat panel intro
----
-
-Grafana lets you create dynamic dashboards using _template variables_. All variables in your queries expand to the current value of the variable before the query is sent to the database. Variables let you reuse a single dashboard for all your services.


### PR DESCRIPTION
See individual commits


### To test the changes:

#### Prerequisites

Checkout each of the following as a subdirectory of your working directory:
- grafana/grafana branch `main`
- grafana/cloud-docs branch `jdb/2023-03-fix-doc-validator`
- grafana/oncall branch `main`
- grafana/incident branch `main`
- grafana/mimir branch `main`
- grafana/technical-documentation branch `main`
- grafana/website branch `jdb/2023-03-zero-docs-build-errors`

1. In the grafana repository, add worktrees for each of the versions:

   ```console
   $ git fetch
   $ for version in v8.{0..5}.x v9{0..4}.x; do git worktree add "${version}" "origin/${version}"; done
   ```

1. In the technical-documentation repository, run the `make-docs` script to build all documentation together:

   ```console
   $  ./scripts/make-docs \
        oncall  \
        incident \
        mimir:v2.7.x \
        grafana:next \
        grafana:v8.0:grafana:v8.0.x/docs/sources \
        grafana:v8.1:grafana:v8.1.x/docs/sources \
        grafana:v8.2:grafana:v8.2.x/docs/sources \
        grafana:v8.3:grafana:v8.3.x/docs/sources \
        grafana:v8.4:grafana:v8.4.x/docs/sources \
        grafana:v8.5:grafana:v8.5.x/docs/sources \
        grafana:v9.0:grafana:v9.0.x/docs/sources \
        grafana:v9.1:grafana:v9.1.x/docs/sources \
        grafana:v9.2:grafana:v9.2.x/docs/sources \
        grafana:v9.3:grafana:v9.3.x/docs/sources \
        grafana:v9.4:grafana:v9.4.x/docs/sources \
        grafana-cloud \
        "arbitrary:$(pwd)/../website/scripts/docs/versions.js:/hugo/scripts/docs/versions.js" \
        "arbitrary:$(pwd)/../website/layouts/shortcodes/docs:/hugo/layouts/shortcodes/docs" \
        "arbitrary:$(pwd)/../website/content/docs/grafana/v8.1/packages_api:/hugo/content/docs/grafana/v8.1/packages_api"
   ```

1. Verify that Hugo logs no `WARN` or `ERROR` messages.