### PR TITLE
Alerting: Log error but don't fail initialization if state history connection test fails

### DIFF
--- a/pkg/services/ngalert/ngalert_test.go
+++ b/pkg/services/ngalert/ngalert_test.go
@@ -1,11 +1,14 @@
 package ngalert
 
 import (
+	"bytes"
 	"context"
 	"math/rand"
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
@@ -14,9 +17,11 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/folder"
+	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/schedule"
 	"github.com/grafana/grafana/pkg/services/ngalert/tests/fakes"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
 )
 
@@ -71,4 +76,79 @@ func Test_subscribeToFolderChanges(t *testing.T) {
 	for _, rule := range rules {
 		scheduler.AssertCalled(t, "UpdateAlertRule", rule.GetKey(), rule.Version, false)
 	}
+}
+
+func TestConfigureHistorianBackend(t *testing.T) {
+	t.Run("fail initialization if invalid backend", func(t *testing.T) {
+		met := metrics.NewHistorianMetrics(prometheus.NewRegistry())
+		logger := log.NewNopLogger()
+		cfg := setting.UnifiedAlertingStateHistorySettings{
+			Enabled: true,
+			Backend: "invalid-backend",
+		}
+
+		_, err := configureHistorianBackend(context.Background(), cfg, nil, nil, nil, met, logger)
+
+		require.ErrorContains(t, err, "unrecognized")
+	})
+
+	t.Run("do not fail initialization if pinging Loki fails", func(t *testing.T) {
+		met := metrics.NewHistorianMetrics(prometheus.NewRegistry())
+		logger := log.NewNopLogger()
+		cfg := setting.UnifiedAlertingStateHistorySettings{
+			Enabled: true,
+			Backend: "loki",
+			// Should never resolve at the DNS level: https://www.rfc-editor.org/rfc/rfc6761#section-6.4
+			LokiReadURL:  "http://gone.invalid",
+			LokiWriteURL: "http://gone.invalid",
+		}
+
+		h, err := configureHistorianBackend(context.Background(), cfg, nil, nil, nil, met, logger)
+
+		require.NotNil(t, h)
+		require.NoError(t, err)
+	})
+
+	t.Run("emit metric describing chosen backend", func(t *testing.T) {
+		reg := prometheus.NewRegistry()
+		met := metrics.NewHistorianMetrics(reg)
+		logger := log.NewNopLogger()
+		cfg := setting.UnifiedAlertingStateHistorySettings{
+			Enabled: true,
+			Backend: "annotations",
+		}
+
+		h, err := configureHistorianBackend(context.Background(), cfg, nil, nil, nil, met, logger)
+
+		require.NotNil(t, h)
+		require.NoError(t, err)
+		exp := bytes.NewBufferString(`
+# HELP grafana_alerting_state_history_info Information about the state history store.
+# TYPE grafana_alerting_state_history_info gauge
+grafana_alerting_state_history_info{backend="annotations"} 1
+`)
+		err = testutil.GatherAndCompare(reg, exp, "grafana_alerting_state_history_info")
+		require.NoError(t, err)
+	})
+
+	t.Run("emit special zero metric if state history disabled", func(t *testing.T) {
+		reg := prometheus.NewRegistry()
+		met := metrics.NewHistorianMetrics(reg)
+		logger := log.NewNopLogger()
+		cfg := setting.UnifiedAlertingStateHistorySettings{
+			Enabled: false,
+		}
+
+		h, err := configureHistorianBackend(context.Background(), cfg, nil, nil, nil, met, logger)
+
+		require.NotNil(t, h)
+		require.NoError(t, err)
+		exp := bytes.NewBufferString(`
+# HELP grafana_alerting_state_history_info Information about the state history store.
+# TYPE grafana_alerting_state_history_info gauge
+grafana_alerting_state_history_info{backend="noop"} 0
+`)
+		err = testutil.GatherAndCompare(reg, exp, "grafana_alerting_state_history_info")
+		require.NoError(t, err)
+	})
 }


### PR DESCRIPTION
**What is this feature?**

In the event that Loki is unavailable, the Grafana pod should continue working - it simply shouldn't persist state history any more.

This is true for normal writes to state history, but not at startup when we test the connection. If the connection test fails, we return an initialization error.

This PR makes it so we still log an error if the test fails, but we return a configured Loki backend anyway. That way, if the Loki instance becomes available in the future, state history writes will suddenly start working at that time with no intervention.

Also adds tests for the initialization logic.

**Which issue(s) does this PR fix?**:

contrib https://github.com/grafana/grafana/issues/48359

**Special notes for your reviewer**:

