### PR TITLE
Storybook: Remove unused sizes from RadioButtonGroup story

### DIFF
--- a/packages/grafana-ui/src/components/Forms/RadioButtonGroup/RadioButtonGroup.story.tsx
+++ b/packages/grafana-ui/src/components/Forms/RadioButtonGroup/RadioButtonGroup.story.tsx
@@ -21,7 +21,7 @@ const meta: Meta = {
       control: { type: 'select' },
       options: ['', 'graphite', 'prometheus', 'elastic'],
     },
-    size: { control: { type: 'select' }, options: ['xs', 'sm', 'md', 'lg'] },
+    size: { control: { type: 'select' }, options: ['sm', 'md'] },
   },
 };
 


### PR DESCRIPTION
**What is this feature?**

Removed unused xs and lg size options from RadioButtonGroup component

**Which issue(s) does this PR fix?**:

Fixes #64614 

