### PR TITLE
Fix flacky test in RulelList.test.tsx

### DIFF
--- a/public/app/features/alerting/unified/RuleList.test.tsx
+++ b/public/app/features/alerting/unified/RuleList.test.tsx
@@ -324,6 +324,7 @@ describe('RuleList', () => {
     expect(groups).toHaveLength(2);
 
     await waitFor(() => expect(groups[0]).toHaveTextContent(/firing|pending|normal/));
+    await waitFor(() => expect(groups[1]).toHaveTextContent(/firing|pending|normal/));
 
     expect(groups[0]).toHaveTextContent('1 firing');
     expect(groups[1]).toHaveTextContent('1 firing');


### PR DESCRIPTION
This PR, fixes a flaky test in `RuleList.test.tsx`.

The problem was the async nature of this component. We have to wait for some components to be rendered before adding the expect. 