### PR TITLE
Prometheus: add x icon to selected metrics

### DIFF
--- a/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilder.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilder.tsx
@@ -225,8 +225,9 @@ export const PromQueryBuilder = React.memo<Props>((props) => {
             </Button>
             {query.metric && (
               <Tag
-                name={query.metric}
+                name={' ' + query.metric}
                 color="#3D71D9"
+                icon="times"
                 onClick={() => {
                   onChange({ ...query, metric: '' });
                 }}


### PR DESCRIPTION
**What is this feature?**
adds an `x` icon to selected metrics when using the encyclopedia.

**Why do we need this feature?**
...

**Who is this feature for?**
...

**Which issue(s) does this PR fix?**:
Fixes #64710

**Special notes for your reviewer**:

