### PR TITLE
Plugins: Fixed issue for plugin extensions in link validator

### DIFF
--- a/public/app/features/plugins/extensions/validateLink.test.ts
+++ b/public/app/features/plugins/extensions/validateLink.test.ts
@@ -30,6 +30,17 @@ describe('extension link validator', () => {
     });
   });
 
+  it('should return link configuration if path is not specified', () => {
+    const configureWithValidation = validator(() => {
+      return {
+        title: 'Go to page two',
+      };
+    });
+
+    const configured = configureWithValidation(extension, context);
+    expect(configured).toEqual({ title: 'Go to page two' });
+  });
+
   it('should return undefined if path is invalid', () => {
     const configureWithValidation = validator(() => {
       return {

--- a/public/app/features/plugins/extensions/validateLink.ts
+++ b/public/app/features/plugins/extensions/validateLink.ts
@@ -1,3 +1,5 @@
+import { isString } from 'lodash';
+
 import type { AppPluginExtensionLink } from '@grafana/data';
 
 import type { ConfigureFunc } from './types';
@@ -14,6 +16,10 @@ export function createLinkValidator(options: Options) {
   return (configure: ConfigureFunc<AppPluginExtensionLink>): ConfigureFunc<AppPluginExtensionLink> => {
     return function validateLink(link, context) {
       const configured = configure(link, context);
+
+      if (!isString(configured?.path)) {
+        return configured;
+      }
 
       if (!isValidLinkPath(pluginId, configured?.path)) {
         logger(


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
This fixes an issue with the plugin extension link validator where we marked a configured link without any specified path as invalid. We should only validate the path if it is specified.

