### PR TITLE
Prometheus: Make metrics encyclopedia modal wider

### DIFF
--- a/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.tsx
@@ -330,6 +330,7 @@ export const MetricEncyclopediaModal = (props: Props) => {
       title="Browse Metrics"
       onDismiss={onClose}
       aria-label="Metric Encyclopedia"
+      className={styles.modal}
     >
       <div className={styles.spacing}>
         Browse {metrics.length} metric{metrics.length > 1 ? 's' : ''} by text, by type, alphabetically or select a
@@ -658,6 +659,12 @@ function alphabetically(ascending: boolean, metadataFilters: boolean) {
 
 const getStyles = (theme: GrafanaTheme2) => {
   return {
+    modal: css`
+      width: 85vw;
+      ${theme.breakpoints.down('md')} {
+        width: 100%;
+      }
+    `,
     cardsContainer: css`
       display: flex;
       flex-direction: row;


### PR DESCRIPTION
**What is this feature?**
widens the modal for the metrics encyclopedia, keeping consistency with the [label browser modal in loki](https://github.com/grafana/grafana/blob/cde1b5b162c1b7a5da14679c0a2bdd4517512743/public/app/plugins/datasource/loki/querybuilder/components/LabelBrowserModal.tsx#L88). 

**Why do we need this feature?**
...

**Who is this feature for?**
...

**Which issue(s) does this PR fix?**:
Fixes #64711

**Special notes for your reviewer**:
<div>
<img width="49%" alt="Screenshot 2023-03-14 at 15 10 34" src="https://user-images.githubusercontent.com/34524710/225046248-c9446ab2-3853-494c-82a1-b99bd73f958b.png">

<img width="49%" alt="Screenshot 2023-03-14 at 15 10 07" src="https://user-images.githubusercontent.com/34524710/225046292-da1edaed-1a2b-4af8-96f2-a4ccb70ac7f4.png">
</div>

