### PR TITLE
Flamegraph: Fix rendering on contextMenu click and improve rendering perf

### DIFF
--- a/public/app/plugins/panel/flamegraph/components/FlameGraphContainer.tsx
+++ b/public/app/plugins/panel/flamegraph/components/FlameGraphContainer.tsx
@@ -2,8 +2,8 @@ import { css } from '@emotion/css';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useMeasure } from 'react-use';
 
-import { DataFrame, DataFrameView, CoreApp, getEnumDisplayProcessor, createTheme } from '@grafana/data';
-import { useStyles2 } from '@grafana/ui';
+import { DataFrame, DataFrameView, CoreApp, getEnumDisplayProcessor } from '@grafana/data';
+import { useStyles2, useTheme2 } from '@grafana/ui';
 
 import { MIN_WIDTH_TO_SHOW_BOTH_TOPTABLE_AND_FLAMEGRAPH, PIXELS_PER_LEVEL } from '../constants';
 
@@ -33,6 +33,8 @@ const FlameGraphContainer = (props: Props) => {
 
   const labelField = props.data?.fields.find((f) => f.name === 'label');
 
+  const theme = useTheme2();
+
   // Label can actually be an enum field so depending on that we have to access it through display processor. This is
   // both a backward compatibility but also to allow using a simple dataFrame without enum config. This would allow
   // users to use this panel with correct query from data sources that do not return profiles natively.
@@ -40,12 +42,12 @@ const FlameGraphContainer = (props: Props) => {
     (label: string | number) => {
       const enumConfig = labelField?.config?.type?.enum;
       if (enumConfig) {
-        return getEnumDisplayProcessor(createTheme(), enumConfig)(label).text;
+        return getEnumDisplayProcessor(theme, enumConfig)(label).text;
       } else {
         return label.toString();
       }
     },
-    [labelField]
+    [labelField, theme]
   );
 
   // Transform dataFrame with nested set format to array of levels. Each level contains all the bars for a particular

--- a/public/app/plugins/panel/flamegraph/components/TopTable/FlameGraphTopTableContainer.tsx
+++ b/public/app/plugins/panel/flamegraph/components/TopTable/FlameGraphTopTableContainer.tsx
@@ -2,8 +2,8 @@ import { css } from '@emotion/css';
 import React, { useCallback, useEffect, useState } from 'react';
 import AutoSizer from 'react-virtualized-auto-sizer';
 
-import { CoreApp, createTheme, DataFrame, Field, FieldType, getDisplayProcessor } from '@grafana/data';
-import { useStyles2 } from '@grafana/ui';
+import { CoreApp, DataFrame, Field, FieldType, getDisplayProcessor } from '@grafana/data';
+import { useStyles2, useTheme2 } from '@grafana/ui';
 
 import { PIXELS_PER_LEVEL } from '../../constants';
 import { SampleUnit, SelectedView, TableData, TopTableData } from '../types';
@@ -38,6 +38,7 @@ const FlameGraphTopTableContainer = ({
   getLabelValue,
 }: Props) => {
   const styles = useStyles2(() => getStyles(selectedView, app));
+  const theme = useTheme2();
   const [topTable, setTopTable] = useState<TopTableData[]>();
   const valueField =
     data.fields.find((f) => f.name === 'value') ?? data.fields.find((f) => f.type === FieldType.number);
@@ -67,26 +68,29 @@ const FlameGraphTopTableContainer = ({
     return table;
   }, [getLabelValue, selfField, valueField, labelsField]);
 
-  const getTopTableData = (field: Field, value: number) => {
-    const processor = getDisplayProcessor({ field, theme: createTheme() /* theme does not matter for us here */ });
-    const displayValue = processor(value);
-    let unitValue = displayValue.text + displayValue.suffix;
+  const getTopTableData = useCallback(
+    (field: Field, value: number) => {
+      const processor = getDisplayProcessor({ field, theme });
+      const displayValue = processor(value);
+      let unitValue = displayValue.text + displayValue.suffix;
 
-    switch (field.config.unit) {
-      case SampleUnit.Bytes:
-        break;
-      case SampleUnit.Nanoseconds:
-        break;
-      default:
-        if (!displayValue.suffix) {
-          // Makes sure we don't show 123undefined or something like that if suffix isn't defined
-          unitValue = displayValue.text;
-        }
-        break;
-    }
+      switch (field.config.unit) {
+        case SampleUnit.Bytes:
+          break;
+        case SampleUnit.Nanoseconds:
+          break;
+        default:
+          if (!displayValue.suffix) {
+            // Makes sure we don't show 123undefined or something like that if suffix isn't defined
+            unitValue = displayValue.text;
+          }
+          break;
+      }
 
-    return unitValue;
-  };
+      return unitValue;
+    },
+    [theme]
+  );
 
   useEffect(() => {
     const table = sortLevelsIntoTable();
@@ -104,7 +108,7 @@ const FlameGraphTopTableContainer = ({
     }
 
     setTopTable(topTable);
-  }, [data.fields, selfField, sortLevelsIntoTable, valueField]);
+  }, [data.fields, selfField, sortLevelsIntoTable, valueField, getTopTableData]);
 
   return (
     <>


### PR DESCRIPTION
Rendering of the flamegraph was coupled to the mouse click and move handlers, which needed to change on every click and opening of the contextMenu. This PR decouples that as the handlers don't actually need the FlameGraph to be rendered.

Also removes some calls to createTheme which was used inside the rendering loop for both flamegraph and the top table which was slowing both down significantly.