### PR TITLE
Loki: Add autocomplete updates for improved suggestions

### DIFF
--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.test.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.test.ts
@@ -420,13 +420,21 @@ describe('getAfterSelectorCompletions', () => {
     expect(parsersInSuggestions).toStrictEqual(['json', 'logfmt', 'pattern', 'regexp', 'unpack']);
   });
 
-  it('should show label filter options if query has parser', async () => {
+  it('should show label filter options if query has parser and trailing pipeline', async () => {
     const suggestions = await getAfterSelectorCompletions(
       `{job="grafana"} | logfmt | `,
       true,
       true,
       completionProvider
     );
+    const labelFiltersInSuggestions = suggestions
+      .filter((suggestion) => suggestion.type === 'LABEL_NAME')
+      .map((label) => label.label);
+    expect(labelFiltersInSuggestions).toStrictEqual(['abc (detected)', 'def (detected)']);
+  });
+
+  it('should show label filter options if query has parser and no trailing pipeline', async () => {
+    const suggestions = await getAfterSelectorCompletions(`{job="grafana"} | logfmt`, true, true, completionProvider);
     const labelFiltersInSuggestions = suggestions
       .filter((suggestion) => suggestion.type === 'LABEL_NAME')
       .map((label) => label.label);

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.test.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.test.ts
@@ -3,7 +3,7 @@ import { LokiDatasource } from '../../../datasource';
 import { createLokiDatasource } from '../../../mocks';
 
 import { CompletionDataProvider } from './CompletionDataProvider';
-import { getCompletions } from './completions';
+import { getAfterSelectorCompletions, getCompletions } from './completions';
 import { Label, Situation } from './situation';
 
 jest.mock('../../../querybuilder/operations', () => ({
@@ -99,27 +99,6 @@ const afterSelectorCompletions = [
     type: 'PARSER',
   },
   {
-    insertText: '| unwrap extracted',
-    label: 'unwrap extracted',
-    type: 'PIPE_OPERATION',
-  },
-  {
-    insertText: '| unwrap place',
-    label: 'unwrap place',
-    type: 'PIPE_OPERATION',
-  },
-  {
-    insertText: '| unwrap source',
-    label: 'unwrap source',
-    type: 'PIPE_OPERATION',
-  },
-  {
-    insertText: '| unwrap',
-    label: 'unwrap',
-    type: 'PIPE_OPERATION',
-    documentation: 'Operator docs',
-  },
-  {
     insertText: '| line_format "{{.$0}}"',
     isSnippet: true,
     label: 'line_format',
@@ -130,6 +109,12 @@ const afterSelectorCompletions = [
     insertText: '| label_format',
     isSnippet: true,
     label: 'label_format',
+    type: 'PIPE_OPERATION',
+    documentation: 'Operator docs',
+  },
+  {
+    insertText: '| unwrap',
+    label: 'unwrap',
     type: 'PIPE_OPERATION',
     documentation: 'Operator docs',
   },
@@ -333,7 +318,7 @@ describe('getCompletions', () => {
         hasJSON: true,
         hasLogfmt: false,
       });
-      const situation: Situation = { type: 'AFTER_SELECTOR', logQuery: '', afterPipe, hasSpace };
+      const situation: Situation = { type: 'AFTER_SELECTOR', logQuery: '{job="grafana"}', afterPipe, hasSpace };
       const completions = await getCompletions(situation, completionProvider);
 
       const expected = buildAfterSelectorCompletions('json', 'logfmt', afterPipe, hasSpace);
@@ -387,5 +372,72 @@ describe('getCompletions', () => {
       },
     ]);
     expect(functionCompletions).toHaveLength(3);
+  });
+});
+
+describe('getAfterSelectorCompletions', () => {
+  let datasource: LokiDatasource;
+  let languageProvider: LokiLanguageProvider;
+  let completionProvider: CompletionDataProvider;
+
+  beforeEach(() => {
+    datasource = createLokiDatasource();
+    languageProvider = new LokiLanguageProvider(datasource);
+    completionProvider = new CompletionDataProvider(languageProvider, {
+      current: history,
+    });
+
+    jest.spyOn(completionProvider, 'getParserAndLabelKeys').mockResolvedValue({
+      extractedLabelKeys: ['abc', 'def'],
+      unwrapLabelKeys: [],
+      hasJSON: true,
+      hasLogfmt: false,
+    });
+  });
+  it('should remove trailing pipeline from logQuery', () => {
+    getAfterSelectorCompletions(`{job="grafana"} | `, true, true, completionProvider);
+    expect(completionProvider.getParserAndLabelKeys).toHaveBeenCalledWith(`{job="grafana"}`);
+  });
+
+  it('should show detected parser if query has no parser', async () => {
+    const suggestions = await getAfterSelectorCompletions(`{job="grafana"} |  `, true, true, completionProvider);
+    const parsersInSuggestions = suggestions
+      .filter((suggestion) => suggestion.type === 'PARSER')
+      .map((parser) => parser.label);
+    expect(parsersInSuggestions).toStrictEqual(['json (detected)', 'logfmt', 'pattern', 'regexp', 'unpack']);
+  });
+
+  it('should not show detected parser if query already has parser', async () => {
+    const suggestions = await getAfterSelectorCompletions(
+      `{job="grafana"} | logfmt | `,
+      true,
+      true,
+      completionProvider
+    );
+    const parsersInSuggestions = suggestions
+      .filter((suggestion) => suggestion.type === 'PARSER')
+      .map((parser) => parser.label);
+    expect(parsersInSuggestions).toStrictEqual(['json', 'logfmt', 'pattern', 'regexp', 'unpack']);
+  });
+
+  it('should show label filter options if query has parser', async () => {
+    const suggestions = await getAfterSelectorCompletions(
+      `{job="grafana"} | logfmt | `,
+      true,
+      true,
+      completionProvider
+    );
+    const labelFiltersInSuggestions = suggestions
+      .filter((suggestion) => suggestion.type === 'LABEL_NAME')
+      .map((label) => label.label);
+    expect(labelFiltersInSuggestions).toStrictEqual(['abc (detected)', 'def (detected)']);
+  });
+
+  it('should not show label filter options if query has no parser', async () => {
+    const suggestions = await getAfterSelectorCompletions(`{job="grafana"} | `, true, true, completionProvider);
+    const labelFiltersInSuggestions = suggestions
+      .filter((suggestion) => suggestion.type === 'LABEL_NAME')
+      .map((label) => label.label);
+    expect(labelFiltersInSuggestions.length).toBe(0);
   });
 });

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
@@ -233,7 +233,7 @@ export async function getAfterSelectorCompletions(
   if (afterPipe) {
     // If we have space after pipeline, we need to remove it as well
     const trailingPipeline = hasSpace ? '| ' : '|';
-    query = trimEnd(logQuery, trailingPipeline);
+    query = trimEnd(logQuery, '| ');
   }
 
   const { extractedLabelKeys, hasJSON, hasLogfmt } = await dataProvider.getParserAndLabelKeys(query);

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
@@ -1,5 +1,7 @@
+import { trimEnd } from 'lodash';
+
 import { escapeLabelValueInExactSelector } from '../../../languageUtils';
-import { isQueryWithParser, removeTrailingPipelines } from '../../../queryUtils';
+import { isQueryWithParser } from '../../../queryUtils';
 import { explainOperator } from '../../../querybuilder/operations';
 import { LokiOperationId } from '../../../querybuilder/types';
 import { AGGREGATION_OPERATORS, RANGE_VEC_FUNCTIONS, BUILT_IN_FUNCTIONS } from '../../../syntax';
@@ -229,7 +231,9 @@ export async function getAfterSelectorCompletions(
 ): Promise<Completion[]> {
   let query = logQuery;
   if (afterPipe) {
-    query = removeTrailingPipelines(logQuery).trim();
+    // If we have space after pipeline, we need to remove it as well
+    const trailingPipeline = hasSpace ? '| ' : '|';
+    query = trimEnd(logQuery, trailingPipeline);
   }
 
   const { extractedLabelKeys, hasJSON, hasLogfmt } = await dataProvider.getParserAndLabelKeys(query);

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
@@ -231,8 +231,6 @@ export async function getAfterSelectorCompletions(
 ): Promise<Completion[]> {
   let query = logQuery;
   if (afterPipe) {
-    // If we have space after pipeline, we need to remove it as well
-    const trailingPipeline = hasSpace ? '| ' : '|';
     query = trimEnd(logQuery, '| ');
   }
 

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/completions.ts
@@ -1,4 +1,5 @@
 import { escapeLabelValueInExactSelector } from '../../../languageUtils';
+import { isQueryWithParser, removeTrailingPipelines } from '../../../queryUtils';
 import { explainOperator } from '../../../querybuilder/operations';
 import { LokiOperationId } from '../../../querybuilder/types';
 import { AGGREGATION_OPERATORS, RANGE_VEC_FUNCTIONS, BUILT_IN_FUNCTIONS } from '../../../syntax';
@@ -171,15 +172,18 @@ async function getParserCompletions(
   prefix: string,
   hasJSON: boolean,
   hasLogfmt: boolean,
-  extractedLabelKeys: string[]
+  extractedLabelKeys: string[],
+  hasParserInQuery: boolean
 ) {
   const allParsers = new Set(PARSERS);
   const completions: Completion[] = [];
+  // We use this to improve documentation specifically for level label as it is tied to showing color-coded logs volume
   const hasLevelInExtractedLabels = extractedLabelKeys.some((key) => key === 'level');
 
   if (hasJSON) {
     allParsers.delete('json');
-    const extra = hasLevelInExtractedLabels ? '' : ' (detected)';
+    // We show "detected" label only if there is no previous parser in the query
+    const extra = hasParserInQuery ? '' : ' (detected)';
     completions.push({
       type: 'PARSER',
       label: `json${extra}`,
@@ -192,7 +196,8 @@ async function getParserCompletions(
 
   if (hasLogfmt) {
     allParsers.delete('logfmt');
-    const extra = hasLevelInExtractedLabels ? '' : ' (detected)';
+    // We show "detected" label only if there is no previous parser in the query
+    const extra = hasParserInQuery ? '' : ' (detected)';
     completions.push({
       type: 'PARSER',
       label: `logfmt${extra}`,
@@ -216,31 +221,28 @@ async function getParserCompletions(
   return completions;
 }
 
-async function getAfterSelectorCompletions(
+export async function getAfterSelectorCompletions(
   logQuery: string,
   afterPipe: boolean,
   hasSpace: boolean,
   dataProvider: CompletionDataProvider
 ): Promise<Completion[]> {
-  const { extractedLabelKeys, hasJSON, hasLogfmt } = await dataProvider.getParserAndLabelKeys(logQuery);
+  let query = logQuery;
+  if (afterPipe) {
+    query = removeTrailingPipelines(logQuery).trim();
+  }
+
+  const { extractedLabelKeys, hasJSON, hasLogfmt } = await dataProvider.getParserAndLabelKeys(query);
+  const hasQueryParser = isQueryWithParser(query).queryWithParser;
 
   const prefix = `${hasSpace ? '' : ' '}${afterPipe ? '' : '| '}`;
-  const completions: Completion[] = await getParserCompletions(prefix, hasJSON, hasLogfmt, extractedLabelKeys);
-
-  extractedLabelKeys.forEach((key) => {
-    completions.push({
-      type: 'PIPE_OPERATION',
-      label: `unwrap ${key}`,
-      insertText: `${prefix}unwrap ${key}`,
-    });
-  });
-
-  completions.push({
-    type: 'PIPE_OPERATION',
-    label: 'unwrap',
-    insertText: `${prefix}unwrap`,
-    documentation: explainOperator(LokiOperationId.Unwrap),
-  });
+  const completions: Completion[] = await getParserCompletions(
+    prefix,
+    hasJSON,
+    hasLogfmt,
+    extractedLabelKeys,
+    hasQueryParser
+  );
 
   completions.push({
     type: 'PIPE_OPERATION',
@@ -258,10 +260,32 @@ async function getAfterSelectorCompletions(
     documentation: explainOperator(LokiOperationId.LabelFormat),
   });
 
+  completions.push({
+    type: 'PIPE_OPERATION',
+    label: 'unwrap',
+    insertText: `${prefix}unwrap`,
+    documentation: explainOperator(LokiOperationId.Unwrap),
+  });
+
+  // Let's show label options only if query has parser
+  if (hasQueryParser) {
+    extractedLabelKeys.forEach((key) => {
+      completions.push({
+        type: 'LABEL_NAME',
+        label: `${key} (detected)`,
+        insertText: `${prefix}${key}`,
+        documentation: `"${key}" was suggested based on the content of your log lines for the label filter expression.`,
+      });
+    });
+  }
+
+  // If we have parser, we don't need to consider line filters
+  if (hasQueryParser) {
+    return [...completions];
+  }
   // With a space between the pipe and the cursor, we omit line filters
   // E.g. `{label="value"} | `
   const lineFilters = afterPipe && hasSpace ? [] : getLineFilterCompletions(afterPipe);
-
   return [...lineFilters, ...completions];
 }
 

--- a/public/app/plugins/datasource/loki/modifyQuery.ts
+++ b/public/app/plugins/datasource/loki/modifyQuery.ts
@@ -22,7 +22,7 @@ import { unescapeLabelValue } from './languageUtils';
 import { LokiQueryModeller } from './querybuilder/LokiQueryModeller';
 import { buildVisualQueryFromString } from './querybuilder/parsing';
 
-type Position = { from: number; to: number };
+export type Position = { from: number; to: number };
 /**
  * Adds label filter to existing query. Useful for query modification for example for ad hoc filters.
  *

--- a/public/app/plugins/datasource/loki/queryUtils.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.ts
@@ -305,30 +305,6 @@ export function getStreamSelectorsFromQuery(query: string): string[] {
   return labelMatchers;
 }
 
-export function removeTrailingPipelines(query: string): string {
-  const trailingPipelinePositions: Position[] = [];
-  const tree = parser.parse(query);
-  tree.iterate({
-    enter: ({ type, from, to }): false | void => {
-      if (type.id === PipelineStage) {
-        const pipelineExpr = query.substring(from, to).trim();
-        if (pipelineExpr === '|') {
-          trailingPipelinePositions.push({ from, to });
-        }
-      }
-    },
-  });
-
-  let lastFrom = 0;
-  let finalQuery = '';
-  trailingPipelinePositions.forEach((position) => {
-    finalQuery += query.substring(lastFrom, position.from);
-    lastFrom = position.to;
-  });
-
-  return finalQuery;
-}
-
 export function requestSupportsPartitioning(allQueries: LokiQuery[]) {
   const queries = allQueries
     .filter((query) => !query.hide)

--- a/public/app/plugins/datasource/loki/queryUtils.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.ts
@@ -25,12 +25,11 @@ import {
   MetricExpr,
   Matcher,
   Identifier,
-  PipelineStage,
 } from '@grafana/lezer-logql';
 
 import { ErrorId } from '../prometheus/querybuilder/shared/parsingUtils';
 
-import { getStreamSelectorPositions, Position } from './modifyQuery';
+import { getStreamSelectorPositions } from './modifyQuery';
 import { LokiQuery, LokiQueryType } from './types';
 
 export function formatQuery(selector: string | undefined): string {


### PR DESCRIPTION
This PR improves autocomplete suggestion in Loki in following ways:
- It shows detected parser if user types pipeline and then does space. Previously query failed because of trailing pipeline. Also I have added logic to show `detected` next to parser only if there is no parser in the query.
Before: 

https://user-images.githubusercontent.com/30407135/225038786-7af9deaa-3af5-4582-9343-5b42bf7c443b.mov

After:

https://user-images.githubusercontent.com/30407135/225039561-5d70e06f-0a74-4d86-97dc-ace7bcd12fe7.mov


- Removes showing of `line filters` after pipeline operations (after parser is used), as this is not valid logQl
Before: 

https://user-images.githubusercontent.com/30407135/225038832-17d70501-fa82-40cf-bcbd-556a5a9fa43a.mov

After:

https://user-images.githubusercontent.com/30407135/225039761-82b37d7b-f6bd-428f-b113-5012719dc9bd.mov


- Reorders pipeline operations so that line formatting and label formatting is not hidden on the bottom 
Before: 

https://user-images.githubusercontent.com/30407135/225038985-1d7a9875-0276-4c71-b987-d05b32220460.mov

After:

https://user-images.githubusercontent.com/30407135/225040861-88877564-ce33-49e7-b280-278cb69340a2.mov


- Removes `unwrap label` as this is not correct suggestion. We already do correct suggestions (where we check for label values) after user selects `unwrap` (in `AFTER_UNWRAP` situation). I have changed this to show possible labels for label filter and in the future we can add also label values suggestion. Moreover, `unwrap` is valid only in metric queries, so this could have been confusing for user.
Before: 

https://user-images.githubusercontent.com/30407135/225039042-e14e4ee7-24ab-485d-b217-3eb8f4325595.mov

After:

https://user-images.githubusercontent.com/30407135/225041487-dfacfa1b-28f4-45c7-9d90-acdc2b353c64.mov

I have added tests for all of these. 