### PR TITLE
Influxdb: migrate from 'time' to Time

### DIFF
--- a/packages/grafana-data/src/transformations/transformers/joinByField.ts
+++ b/packages/grafana-data/src/transformations/transformers/joinByField.ts
@@ -36,6 +36,9 @@ export const joinByFieldTransformer: SynchronousDataTransformerInfo<JoinByFieldO
     return (data: DataFrame[]) => {
       if (data.length > 1) {
         if (options.byField && !joinBy) {
+          if (options.byField.toLowerCase() === 'time') {
+            options.byField = 'Time';
+          }
           joinBy = fieldMatchers.get(FieldMatcherID.byName).get(options.byField);
         }
         const joined = joinDataFrames({ frames: data, joinBy, mode: options.mode });

--- a/packages/grafana-data/src/transformations/transformers/joinByField.ts
+++ b/packages/grafana-data/src/transformations/transformers/joinByField.ts
@@ -36,6 +36,7 @@ export const joinByFieldTransformer: SynchronousDataTransformerInfo<JoinByFieldO
     return (data: DataFrame[]) => {
       if (data.length > 1) {
         if (options.byField && !joinBy) {
+          // Either "time" or "Time" can be saved in the panel JSON from different versions of Grafana, so we need to make sure that they are both treated the same
           if (options.byField.toLowerCase() === 'time') {
             options.byField = 'Time';
           }

--- a/packages/grafana-data/src/transformations/transformers/joinByField.ts
+++ b/packages/grafana-data/src/transformations/transformers/joinByField.ts
@@ -36,10 +36,6 @@ export const joinByFieldTransformer: SynchronousDataTransformerInfo<JoinByFieldO
     return (data: DataFrame[]) => {
       if (data.length > 1) {
         if (options.byField && !joinBy) {
-          // Either "time" or "Time" can be saved in the panel JSON from different versions of Grafana, so we need to make sure that they are both treated the same
-          if (options.byField.toLowerCase() === 'time') {
-            options.byField = 'Time';
-          }
           joinBy = fieldMatchers.get(FieldMatcherID.byName).get(options.byField);
         }
         const joined = joinDataFrames({ frames: data, joinBy, mode: options.mode });

--- a/pkg/tsdb/influxdb/response_parser.go
+++ b/pkg/tsdb/influxdb/response_parser.go
@@ -86,7 +86,7 @@ func transformRows(rows []Row, query Query) data.Frames {
 			frames = append(frames, data.NewFrame(row.Name, field))
 		} else {
 			for colIndex, column := range row.Columns {
-				if column == "time" {
+				if strings.ToLower(column) == "time" {
 					continue
 				}
 

--- a/pkg/tsdb/influxdb/response_parser.go
+++ b/pkg/tsdb/influxdb/response_parser.go
@@ -85,8 +85,13 @@ func transformRows(rows []Row, query Query) data.Frames {
 			field := data.NewField("value", nil, values)
 			frames = append(frames, data.NewFrame(row.Name, field))
 		} else {
+			var (
+				timeIndex string
+			)
+			timeIndex = "Time"
 			for colIndex, column := range row.Columns {
 				if strings.ToLower(column) == "time" {
+					timeIndex = column
 					continue
 				}
 
@@ -128,7 +133,7 @@ func transformRows(rows []Row, query Query) data.Frames {
 					}
 				}
 
-				timeField := data.NewField("Time", nil, timeArray)
+				timeField := data.NewField(timeIndex, nil, timeArray)
 				if valType == "string" {
 					valueField := data.NewField("value", row.Tags, stringArray)
 					valueField.SetConfig(&data.FieldConfig{DisplayNameFromDS: name})

--- a/pkg/tsdb/influxdb/response_parser.go
+++ b/pkg/tsdb/influxdb/response_parser.go
@@ -85,10 +85,8 @@ func transformRows(rows []Row, query Query) data.Frames {
 			field := data.NewField("value", nil, values)
 			frames = append(frames, data.NewFrame(row.Name, field))
 		} else {
-			var (
-				timeIndex string
-			)
-			timeIndex = "Time"
+			timeIndex := "Time"
+
 			for colIndex, column := range row.Columns {
 				if strings.ToLower(column) == "time" {
 					timeIndex = column

--- a/pkg/tsdb/influxdb/response_parser.go
+++ b/pkg/tsdb/influxdb/response_parser.go
@@ -85,11 +85,11 @@ func transformRows(rows []Row, query Query) data.Frames {
 			field := data.NewField("value", nil, values)
 			frames = append(frames, data.NewFrame(row.Name, field))
 		} else {
-			timeIndex := "Time"
+			timeName := "Time"
 
 			for colIndex, column := range row.Columns {
 				if strings.ToLower(column) == "time" {
-					timeIndex = column
+					column = timeName
 					continue
 				}
 
@@ -131,7 +131,7 @@ func transformRows(rows []Row, query Query) data.Frames {
 					}
 				}
 
-				timeField := data.NewField(timeIndex, nil, timeArray)
+				timeField := data.NewField(timeName, nil, timeArray)
 				if valType == "string" {
 					valueField := data.NewField("value", row.Tags, stringArray)
 					valueField.SetConfig(&data.FieldConfig{DisplayNameFromDS: name})

--- a/pkg/tsdb/influxdb/response_parser.go
+++ b/pkg/tsdb/influxdb/response_parser.go
@@ -89,7 +89,6 @@ func transformRows(rows []Row, query Query) data.Frames {
 
 			for colIndex, column := range row.Columns {
 				if strings.ToLower(column) == "time" {
-					column = timeName
 					continue
 				}
 

--- a/pkg/tsdb/influxdb/response_parser.go
+++ b/pkg/tsdb/influxdb/response_parser.go
@@ -128,7 +128,7 @@ func transformRows(rows []Row, query Query) data.Frames {
 					}
 				}
 
-				timeField := data.NewField("time", nil, timeArray)
+				timeField := data.NewField("Time", nil, timeArray)
 				if valType == "string" {
 					valueField := data.NewField("value", row.Tags, stringArray)
 					valueField.SetConfig(&data.FieldConfig{DisplayNameFromDS: name})


### PR DESCRIPTION

**What is this feature?**
Frontend and backend database modes in influx appeared to have been using different capitalizations of the time field. This is introducing bugs in the transformations.

frontend influx
```
"transformations": [
    {
      "id": "joinByField",
      "options": {
        "byField": "time",
        "mode": "outer"
      }
    }
```
backend influx (enforced in 9.3.8?)
```
"transformations": [
    {
      "id": "joinByField",
      "options": {
        "byField": "Time",
        "mode": "outer"
      }
    }
```