### PR TITLE
Restructure the org upsert method

### DIFF
--- a/pkg/services/sqlstore/user.go
+++ b/pkg/services/sqlstore/user.go
@@ -146,6 +146,9 @@ func verifyExistingOrg(sess *DBSession, orgId int64) error {
 
 func (ss *SQLStore) getOrCreateOrg(sess *DBSession, orgName string) (int64, error) {
 	var org org.Org
+	org.Created = time.Now()
+	org.Updated = org.Created
+
 	if ss.Cfg.AutoAssignOrg {
 		has, err := sess.Where("id=?", ss.Cfg.AutoAssignOrgId).Get(&org)
 		if err != nil {
@@ -164,18 +167,11 @@ func (ss *SQLStore) getOrCreateOrg(sess *DBSession, orgName string) (int64, erro
 
 		org.Name = mainOrgName
 		org.ID = int64(ss.Cfg.AutoAssignOrgId)
-	} else {
-		org.Name = orgName
-	}
-
-	org.Created = time.Now()
-	org.Updated = time.Now()
-
-	if org.ID != 0 {
 		if err := sess.InsertId(&org, ss.Dialect); err != nil {
 			return 0, err
 		}
 	} else {
+		org.Name = orgName
 		if _, err := sess.InsertOne(&org); err != nil {
 			return 0, err
 		}


### PR DESCRIPTION
**What is this feature?**

After work was done with the org store due to an [issue](https://github.com/grafana/grafana/issues/63562) we found the upsert method `getOrCreateOrg` could be improved.

**Why do we need this feature?**

This small fix restructures the order of the create org functions called to the database according to the org id generation.

**Which issue(s) does this PR fix?**:

Fixes #https://github.com/grafana/grafana-enterprise/issues/4728

**Special notes for your reviewer**:
I couldn't come up with a test scenario since there was no error to reproduce. Any advice is welcome.

