### PR TITLE
Docs: Fix example port shown in [caching.redis] configuration

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/enterprise-configuration/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/enterprise-configuration/index.md
@@ -456,13 +456,13 @@ The default is `25`.
 
 ### url
 
-The full Redis URL of your Redis server. For example: `redis://username:password@localhost:6739/0`. To enable TLS, use the `redis` scheme.
+The full Redis URL of your Redis server. For example: `redis://username:password@localhost:6379`. To enable TLS, use the `redis` scheme.
 
 The default is `"redis://localhost:6379"`.
 
 ### cluster
 
-A comma-separated list of Redis cluster members, either in `host:port` format or using the full Redis URLs (`redis://username:password@localhost:6739`). For example, `localhost:7000, localhost: 7001, localhost:7002`.
+A comma-separated list of Redis cluster members, either in `host:port` format or using the full Redis URLs (`redis://username:password@localhost:6379`). For example, `localhost:7000, localhost: 7001, localhost:7002`.
 If you use the full Redis URLs, then you can specify the scheme, username, and password only once. For example, `redis://username:password@localhost:0000,localhost:1111,localhost:2222`. You cannot specify a different username and password for each URL.
 
 > **Note:** If you have specify `cluster`, the value for `url` is ignored.


### PR DESCRIPTION
**What is this feature?**

Docs have a typo of `6739` vs `6379` (which is the default). Led to some confusion when copy pasting from the docs. 

