### PR TITLE
color scales, self gutter, remove dataframeview & displayProcessor, s…

### DIFF
--- a/package.json
+++ b/package.json
@@ -300,6 +300,7 @@
     "@types/react-resizable": "3.0.3",
     "@types/webpack-env": "1.18.0",
     "@uiw/codemirror-extensions-langs": "^4.19.9",
+    "@uiw/codemirror-theme-vscode": "^4.19.9",
     "@uiw/codemirror-themes-all": "^4.19.9",
     "@uiw/react-codemirror": "^4.19.9",
     "@visx/event": "3.0.1",

--- a/public/app/plugins/datasource/phlare/types.ts
+++ b/public/app/plugins/datasource/phlare/types.ts
@@ -25,8 +25,8 @@ export interface PhlareDataSourceOptions extends DataSourceJsonData {
 }
 
 export type CodeLocation = {
-  fileName: string;
-  func: string;
+  fileNameIdx: number;
+  funcIdx: number;
   line: number;
 };
 

--- a/public/app/plugins/panel/flamegraph/components/SourceCodeView.tsx
+++ b/public/app/plugins/panel/flamegraph/components/SourceCodeView.tsx
@@ -163,7 +163,7 @@ export function SourceCodeView(props: Props) {
     // should switch to the static gutter.markers: API
     lineMarker(view, line) {
       let lineNum = view.state.doc.lineAt(line.from).number;
-      let rawValue = byLineData.value.get(lineNum) ?? 0;
+      let rawValue = byLineData.self.get(lineNum) ?? 0;
       let heatFactor = rawValue > 0 ? (rawValue - minRawSelf) / (maxRawSelf - minRawSelf) : 0;
       let marker = heatFactor === 0 ? null : new HeatMarker(rawValue, heatFactor);
       return marker;

--- a/public/app/plugins/panel/flamegraph/components/SourceCodeView.tsx
+++ b/public/app/plugins/panel/flamegraph/components/SourceCodeView.tsx
@@ -2,121 +2,201 @@ import { StreamLanguage } from '@codemirror/language';
 import { go } from '@codemirror/legacy-modes/mode/go';
 import { EditorView, gutter, GutterMarker, lineNumbers } from '@codemirror/view';
 import { css, cx } from '@emotion/css';
+import { vscodeDark } from '@uiw/codemirror-theme-vscode';
 import CodeMirror, { minimalSetup, ReactCodeMirrorRef } from '@uiw/react-codemirror';
-import React, { createRef, useEffect, useState } from 'react';
+import React, { createRef, useEffect, useMemo, useState } from 'react';
 
-import { DataFrameView } from '@grafana/data';
+import { createTheme, DataFrame } from '@grafana/data';
+// import { getContrastRatio } from '@grafana/data/src/themes/colorManipulator';
 import { useTheme2 } from '@grafana/ui';
 
 import { PhlareDataSource } from '../../../datasource/phlare/datasource';
-import { CodeLocation } from '../../../datasource/phlare/types';
+// import { CodeLocation } from '../../../datasource/phlare/types';
+import { quantizeScheme } from '../../heatmap/palettes';
 
-import { Item } from './FlameGraph/dataTransform';
+// import { Item } from './FlameGraph/dataTransform';
 
-interface Props {
-  datasource: PhlareDataSource;
-  location: CodeLocation;
-  getLabelValue: (label: string | number) => string;
-  getFileNameValue: (label: string | number) => string;
-  data: DataFrameView<Item>;
-}
-
-const highHeat = cx(
-  css({
-    backgroundColor: 'red',
-    color: 'white',
-  })
+const heatColors = quantizeScheme(
+  { steps: 32, exponent: 1, reverse: true, fill: '#0000', scheme: 'YlOrRd' },
+  createTheme()
 );
 
-const medHeat = cx(
-  css({
-    backgroundColor: 'orange',
-    color: 'black',
-  })
-);
+const heatClasses = heatColors.map((color) => {
+  // why is the range of this fn 1-21?
+  // let contrast = getContrastRatio('#000', color);
+
+  return cx(
+    css({
+      // backgroundColor: color,
+      // color: contrast < 17 ? '#fff' : '#000',
+      color: color + ' !important',
+    })
+  );
+});
 
 const heatGutterClass = cx(
   css({
-    minWidth: 60,
+    minWidth: 80,
     textAlign: 'right',
   })
 );
 
+class HeatMarker extends GutterMarker {
+  rawValue: number;
+
+  constructor(rawValue: number, heatFactor: number) {
+    super();
+    this.rawValue = rawValue;
+
+    // console.log(heatFactor);
+
+    const heatColorIdx = Math.floor(heatFactor * (heatClasses.length - 1));
+
+    this.elementClass = heatClasses[heatColorIdx];
+  }
+
+  eq(other: HeatMarker) {
+    return this.rawValue === other.rawValue;
+  }
+
+  toDOM() {
+    return document.createTextNode(this.rawValue.toPrecision(3));
+  }
+}
+
+// (excluding root)
+export type GloblDataRanges = {
+  value: [min: number, max: number];
+  self: [min: number, max: number];
+};
+
+interface Props {
+  datasource: PhlareDataSource;
+  locationIdx: number;
+  data: DataFrame;
+  globalDataRanges: GloblDataRanges;
+  getLabelValue: (label: string | number) => string;
+}
+
 export function SourceCodeView(props: Props) {
-  const { datasource, location, getLabelValue, getFileNameValue, data } = props;
+  const { datasource, locationIdx, data, globalDataRanges, getLabelValue } = props;
   const [source, setSource] = useState<string>('');
   const editorRef = createRef<ReactCodeMirrorRef>();
   const theme = useTheme2();
 
-  const fileData = data.toArray().filter((d) => d.fileName === location.fileName);
-  const maxRawVal = fileData.reduce((acc, val) => (val.value > acc ? val.value : acc), 0);
+  const { lineData, valueData, selfData, fileNameData, fileNameEnum, labelData } = useMemo(() => {
+    let fileNameField = data.fields.find((f) => f.name === 'fileName')!;
+    let labelField = data.fields.find((f) => f.name === 'label')!;
 
-  // TODO: create pre-defined pallete of heat markers (maybe 32?)
-  class HeatMarker extends GutterMarker {
-    rawValue: number;
+    return {
+      fileNameEnum: fileNameField.config.type!.enum?.text!,
+      fileNameData: fileNameField.values.toArray(),
 
-    // heatPct: number;
+      // labelEnum: labelField.config.type!.enum?.text,
+      labelData: labelField.values.toArray(),
 
-    constructor(rawValue: number /*heatPct: number*/) {
-      super();
-      this.rawValue = rawValue;
-      // this.heatPct = heatPct;
+      lineData: data.fields.find((f) => f.name === 'line')!.values.toArray(),
+      valueData: data.fields.find((f) => f.name === 'value')!.values.toArray(),
+      selfData: data.fields.find((f) => f.name === 'self')!.values.toArray(),
+    };
+  }, [data]);
+
+  // these are the field.values idxs of stuff in this file
+  const dataIdxs = useMemo(() => {
+    let idxs = [];
+
+    let fileIdx = fileNameData[locationIdx];
+
+    for (let i = 0; i < fileNameData.length; i++) {
+      if (fileNameData[i] === fileIdx) {
+        idxs.push(i);
+      }
     }
 
-    eq(other: HeatMarker) {
-      return this.rawValue === other.rawValue;
+    return idxs;
+  }, [locationIdx, fileNameData]);
+
+  const byLineData = useMemo(() => {
+    let byLineData = {
+      value: new Map<number, number>(),
+      self: new Map<number, number>(),
+    };
+
+    for (let i = 0; i < dataIdxs.length; i++) {
+      let idx = dataIdxs[i];
+      let line = lineData[idx];
+      byLineData.value.set(line, valueData[idx]);
+      byLineData.self.set(line, selfData[idx]);
     }
 
-    toDOM() {
-      return document.createTextNode(this.rawValue.toString() + 'ms');
-    }
-  }
+    // console.log(byLineData);
 
-  class HighHeatMarker extends HeatMarker {
-    elementClass = highHeat;
-  }
+    return byLineData;
+  }, [dataIdxs, lineData, valueData, selfData]);
 
-  class MedHeatMarker extends HeatMarker {
-    elementClass = medHeat;
-  }
+  const [minRawVal, maxRawVal] = globalDataRanges.value;
+  const [minRawSelf, maxRawSelf] = globalDataRanges.self;
 
-  const heatGutter = gutter({
+  // console.log({
+  //   minRawVal,
+  //   maxRawVal,
+  // });
+
+  const valueGutter = gutter({
     class: heatGutterClass,
 
-    // TODO: replace this with a pre-computed markers: GutterMarker[] ?
+    // TODO: optimize, this is recreated each time you navigate through source doc
+    // should switch to the static gutter.markers: API
     lineMarker(view, line) {
       let lineNum = view.state.doc.lineAt(line.from).number;
-      let heatRawVal = fileData.find((d) => d.line === lineNum)?.value || 0;
-      let heatPct = heatRawVal / maxRawVal;
-      let marker =
-        heatPct === 0 ? null : heatPct > 0.5 ? new HighHeatMarker(heatRawVal) : new MedHeatMarker(heatRawVal);
+      let rawValue = byLineData.value.get(lineNum) ?? 0;
+      let heatFactor = rawValue > 0 ? (rawValue - minRawVal) / (maxRawVal - minRawVal) : 0;
+      let marker = heatFactor === 0 ? null : new HeatMarker(rawValue, heatFactor);
+      return marker;
+    },
+  });
+
+  const selfGutter = gutter({
+    class: heatGutterClass,
+
+    // TODO: optimize, this is recreated each time you navigate through source doc
+    // should switch to the static gutter.markers: API
+    lineMarker(view, line) {
+      let lineNum = view.state.doc.lineAt(line.from).number;
+      let rawValue = byLineData.value.get(lineNum) ?? 0;
+      let heatFactor = rawValue > 0 ? (rawValue - minRawSelf) / (maxRawSelf - minRawSelf) : 0;
+      let marker = heatFactor === 0 ? null : new HeatMarker(rawValue, heatFactor);
       return marker;
     },
   });
 
   useEffect(() => {
     (async () => {
-      const sourceCode = await datasource.getSource(getLabelValue(location.func), getFileNameValue(location.fileName));
+      const sourceCode = await datasource.getSource(
+        getLabelValue(labelData[locationIdx]),
+        fileNameEnum[fileNameData[locationIdx]]
+      );
       setSource(sourceCode);
     })();
-  }, [editorRef, datasource, location, getLabelValue, getFileNameValue]);
+  }, [editorRef, datasource, locationIdx, fileNameEnum, labelData, fileNameData, getLabelValue]);
 
   useEffect(() => {
-    const line = editorRef.current?.view?.state.doc.line(location.line);
+    const line = editorRef.current?.view?.state.doc.line(lineData[locationIdx]);
+
     editorRef.current?.view?.dispatch({
       selection: { anchor: line?.from || 0 },
       scrollIntoView: true,
-      effects: EditorView.scrollIntoView(line?.from || 0, { y: 'start' }),
+      effects: EditorView.scrollIntoView(line?.from || 0, { y: 'center' }),
     });
-  }, [source]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [source, lineData, editorRef, locationIdx]);
 
   return (
     <CodeMirror
       value={source}
       height={'630px'}
-      extensions={[StreamLanguage.define(go), minimalSetup(), lineNumbers(), heatGutter]}
+      extensions={[StreamLanguage.define(go), minimalSetup(), lineNumbers(), valueGutter, selfGutter]}
       readOnly={true}
-      theme={theme.name === 'Dark' ? 'dark' : 'light'}
+      theme={theme.name === 'Dark' ? vscodeDark : 'light'}
       ref={editorRef}
     />
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -13541,7 +13541,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@uiw/codemirror-theme-vscode@npm:4.19.9":
+"@uiw/codemirror-theme-vscode@npm:4.19.9, @uiw/codemirror-theme-vscode@npm:^4.19.9":
   version: 4.19.9
   resolution: "@uiw/codemirror-theme-vscode@npm:4.19.9"
   dependencies:
@@ -23006,6 +23006,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": 5.42.0
     "@typescript-eslint/parser": 5.42.0
     "@uiw/codemirror-extensions-langs": ^4.19.9
+    "@uiw/codemirror-theme-vscode": ^4.19.9
     "@uiw/codemirror-themes-all": ^4.19.9
     "@uiw/react-codemirror": ^4.19.9
     "@visx/event": 3.0.1


### PR DESCRIPTION
- added a 'self' gutter
- made heat color scales work (relative to largest non-root node)
- auto-scroll-to-line is now to center of editor rather than top, for better context
- switched to vscode theme, still probably not ideal...should see what our query editors use
- refactored stuff to use DataFrame field values and enum configs directly instead of via the displayProcessor and DataFrameView abstractions; location is now referenced directly by index rather than relying on more complex lookup indirection via file name and function name lookups. 

![image](https://user-images.githubusercontent.com/43234/225217838-790a96ef-38aa-4de6-9581-b526cb0fb1d1.png)