### PR TITLE
Chore: provide `authn.service` rather than `*authnimpl.Service`

### DIFF
--- a/pkg/server/wire.go
+++ b/pkg/server/wire.go
@@ -39,7 +39,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/annotations/annotationsimpl"
 	"github.com/grafana/grafana/pkg/services/apikey/apikeyimpl"
 	"github.com/grafana/grafana/pkg/services/auth/jwt"
-	"github.com/grafana/grafana/pkg/services/authn"
 	"github.com/grafana/grafana/pkg/services/authn/authnimpl"
 	"github.com/grafana/grafana/pkg/services/cleanup"
 	"github.com/grafana/grafana/pkg/services/contexthandler"
@@ -358,7 +357,6 @@ var wireBasicSet = wire.NewSet(
 	tagimpl.ProvideService,
 	wire.Bind(new(tag.Service), new(*tagimpl.Service)),
 	authnimpl.ProvideService,
-	wire.Bind(new(authn.Service), new(*authnimpl.Service)),
 	supportbundlesimpl.ProvideService,
 	modules.WireSet,
 )

--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -62,7 +62,7 @@ func ProvideService(
 	features *featuremgmt.FeatureManager, oauthTokenService oauthtoken.OAuthTokenService,
 	socialService social.Service, cache *remotecache.RemoteCache,
 	ldapService service.LDAP, registerer prometheus.Registerer,
-) *Service {
+) authn.Service {
 	s := &Service{
 		log:            log.New("authn.service"),
 		cfg:            cfg,


### PR DESCRIPTION
I got the following error when running `make run` on a windows machine (with WSL2):

```
wire: /home/artur/projects/grafana/pkg/server/wire.go:361:2: *[github.com/grafana/grafana/pkg/services/authn/authnimpl.Service](http://github.com/grafana/grafana/pkg/services/authn/authnimpl.Service) does not implement [github.com/grafana/grafana/pkg/services/authn.Service](http://github.com/grafana/grafana/pkg/services/authn.Service)
wire: /home/artur/projects/grafana/pkg/server/wire.go:361:2: *[github.com/grafana/grafana/pkg/services/authn/authnimpl.Service](http://github.com/grafana/grafana/pkg/services/authn/authnimpl.Service) does not implement [github.com/grafana/grafana/pkg/services/authn.Service](http://github.com/grafana/grafana/pkg/services/authn.Service)
```

this change resolves the problem - but I am not sure why!