### PR TITLE
Fix website build errors both for Grafana and content mounted in Grafana Cloud

### DIFF
--- a/docs/sources/alerting/_index.md
+++ b/docs/sources/alerting/_index.md
@@ -69,8 +69,8 @@ With mute timings, you can specify a time interval when you don’t want new not
 
 ## Useful links
 
-- [Fundamental concepts]({{< relref "fundamentals/" >}}) of Grafana Alerting.
+- [Fundamental concepts]({{< relref "/docs/grafana/latest/alerting/fundamentals/" >}}) of Grafana Alerting.
 
-- [Role-based access control]({{< relref "../administration/roles-and-permissions/access-control/" >}}) in Grafana Enterprise.
+- [Role-based access control]({{< relref "/docs/grafana/latest/administration/roles-and-permissions/access-control" >}}) in Grafana Enterprise.
 
-- [High availability](https://grafana.com/docs/grafana/next/alerting/fundamentals/high-availability/)
+- [High availability]({{< relref "/docs/grafana/latest/alerting/fundamentals/high-availability/" >}})

--- a/docs/sources/alerting/_index.md
+++ b/docs/sources/alerting/_index.md
@@ -69,8 +69,8 @@ With mute timings, you can specify a time interval when you don’t want new not
 
 ## Useful links
 
-- [Fundamental concepts]({{< relref "/docs/grafana/latest/alerting/fundamentals/" >}}) of Grafana Alerting.
+- [Fundamental concepts]({{< relref "/docs/grafana/latest/alerting/fundamentals" >}}) of Grafana Alerting.
 
 - [Role-based access control]({{< relref "/docs/grafana/latest/administration/roles-and-permissions/access-control" >}}) in Grafana Enterprise.
 
-- [High availability]({{< relref "/docs/grafana/latest/alerting/fundamentals/high-availability/" >}})
+- [High availability]({{< relref "/docs/grafana/latest/alerting/fundamentals/high-availability" >}})

--- a/docs/sources/alerting/alerting-rules/create-grafana-managed-rule.md
+++ b/docs/sources/alerting/alerting-rules/create-grafana-managed-rule.md
@@ -26,7 +26,7 @@ Watch this video to learn more about creating alerts: {{< vimeo 720001934 >}}
    - In **Rule name**, add a descriptive name. This name is displayed in the alert rule list. It is also the `alertname` label for every alert instance that is created from this rule.
 1. In Step 2, add queries and expressions to evaluate, and then select the alert condition.
    - For queries, select a data source from the drop-down.
-   - Add one or more [queries]({{< relref "../../panels-visualizations/query-transform-data/#add-a-query/" >}}) or [expressions]({{< relref "../../panels-visualizations/query-transform-data/expression-queries/" >}}).
+   - Add one or more [queries]({{< relref "../../panels-visualizations/query-transform-data/#add-a-query" >}}) or [expressions]({{< relref "../../panels-visualizations/query-transform-data/expression-queries/" >}}).
    - For each expression, select either **Classic condition** to create a single alert rule, or choose from **Math**, **Reduce**, **Resample** options to generate separate alert for each series. For details on these options, see [Single and multi dimensional rule](#single-and-multi-dimensional-rule).
    - Click **Run queries** to verify that the query is successful.
    - Next, select the query or expression for your alert condition.

--- a/docs/sources/alerting/alerting-rules/create-grafana-managed-rule.md
+++ b/docs/sources/alerting/alerting-rules/create-grafana-managed-rule.md
@@ -26,7 +26,7 @@ Watch this video to learn more about creating alerts: {{< vimeo 720001934 >}}
    - In **Rule name**, add a descriptive name. This name is displayed in the alert rule list. It is also the `alertname` label for every alert instance that is created from this rule.
 1. In Step 2, add queries and expressions to evaluate, and then select the alert condition.
    - For queries, select a data source from the drop-down.
-   - Add one or more [queries]({{< relref "../../panels-visualizations/query-transform-data/#add-a-query" >}}) or [expressions]({{< relref "../../panels-visualizations/query-transform-data/expression-queries/" >}}).
+   - Add one or more [queries]({{< relref "/docs/grafana/latest/panels-visualizations/query-transform-data#add-a-query" >}}) or [expressions]({{< relref "/docs/grafana/latest/panels-visualizations/query-transform-data/expression-queries" >}}).
    - For each expression, select either **Classic condition** to create a single alert rule, or choose from **Math**, **Reduce**, **Resample** options to generate separate alert for each series. For details on these options, see [Single and multi dimensional rule](#single-and-multi-dimensional-rule).
    - Click **Run queries** to verify that the query is successful.
    - Next, select the query or expression for your alert condition.
@@ -74,7 +74,7 @@ To generate a separate alert for each series, create a multi-dimensional rule. U
 
 #### Rule with classic condition
 
-For more information, see [expressions documentation]({{< relref "../../panels-visualizations/query-transform-data/expression-queries/" >}}).
+For more information, see [expressions documentation]({{< relref "/docs/grafana/latest/panels-visualizations/query-transform-data/expression-queries" >}}).
 
 ### No data and error handling
 
@@ -87,7 +87,7 @@ Configure alerting behavior in the absence of data using information in the foll
 | Ok             | Set alert rule state to `Normal`.                                                                                                         |
 
 | Error or timeout option | Description                                                                                                                                       |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
 | Alerting                | Set alert rule state to `Alerting`. From Grafana 8.5, the alert rule waits for the entire duration for which the condition is true before firing. |
 | OK                      | Set alert rule state to `Normal`                                                                                                                  |
-| Error                   | Create a new alert `DatasourceError` with the name and UID of the alert rule, and UID of the datasource that returned no data as labels.          |
+| re                      | Error                                                                                                                                             | Create a new alert `DatasourceError` with the name and UID of the alert rule, and UID of the datasource that returned no data as labels. |

--- a/docs/sources/alerting/fundamentals/alert-rules/alert-rule-types.md
+++ b/docs/sources/alerting/fundamentals/alert-rules/alert-rule-types.md
@@ -16,7 +16,7 @@ Grafana supports several alert rule types, the following sections will explain t
 
 Grafana-managed rules are the most flexible alert rule type. They allow you to create alerts that can act on data from any of your existing data sources.
 
-In additional to supporting any datasource you can also add additional [expressions]({{< relref "../../../panels-visualizations/query-transform-data/expression-queries/" >}}) to transform your data and express alert conditions.
+In additional to supporting any datasource you can also add additional [expressions]({{< relref "/docs/grafana/latest/panels-visualizations/query-transform-data/expression-queries" >}}) to transform your data and express alert conditions.
 
 ## Mimir, Loki and Cortex rules
 

--- a/docs/sources/alerting/fundamentals/alert-rules/alert-rule-types.md
+++ b/docs/sources/alerting/fundamentals/alert-rules/alert-rule-types.md
@@ -16,7 +16,7 @@ Grafana supports several alert rule types, the following sections will explain t
 
 Grafana-managed rules are the most flexible alert rule type. They allow you to create alerts that can act on data from any of your existing data sources.
 
-In additional to supporting any datasource you can also add additional [expressions]({{< relref "/docs/grafana/latest/panels-visualizations/query-transform-data/expression-queries" >}}) to transform your data and express alert conditions.
+In addition to supporting any data source, you can add [expressions]({{< relref "/docs/grafana/latest/panels-visualizations/query-transform-data/expression-queries" >}}) to transform your data and express alert conditions.
 
 ## Mimir, Loki and Cortex rules
 

--- a/docs/sources/alerting/fundamentals/annotation-label/how-to-use-labels.md
+++ b/docs/sources/alerting/fundamentals/annotation-label/how-to-use-labels.md
@@ -17,7 +17,7 @@ This topic explains why labels are a fundamental component of alerting.
 - The Alertmanager uses labels to match alerts for silences and alert groups in notification policies.
 - The alerting UI shows labels for every alert instance generated during evaluation of that rule.
 - Contact points can access labels to dynamically generate notifications that contain information specific to the alert that is resulting in a notification.
-- You can add labels to an [alerting rule]({{< relref "../../alerting-rules/" >}}). Labels are manually configurable, use template functions, and can reference other labels. Labels added to an alerting rule take precedence in the event of a collision between labels (except in the case of [Grafana reserved labels](#grafana-reserved-labels)).
+- You can add labels to an [alerting rule]({{< relref "/docs/grafana/latest/alerting/alerting-rules" >}}). Labels are manually configurable, use template functions, and can reference other labels. Labels added to an alerting rule take precedence in the event of a collision between labels (except in the case of [Grafana reserved labels](#grafana-reserved-labels)).
 
 {{< figure src="/static/img/docs/alerting/unified/rule-edit-details-8-0.png" max-width="550px" caption="Alert details" >}}
 
@@ -38,7 +38,7 @@ Example: A label key/value pair `Alert! 🔔="🔥"` will become `Alert_0x1f514=
 # Grafana reserved labels
 
 > **Note:** Labels prefixed with `grafana_` are reserved by Grafana for special use. If a manually configured label is added beginning with `grafana_` it may be overwritten in case of collision.
-> To stop the Grafana Alerting engine from adding a reserved label, you can disable it via the `disabled_labels` option in [unified_alerting.reserved_labels]({{< relref "../../../setup-grafana/configure-grafana/#unified_alertingreserved_labels" >}}) configuration.
+> To stop the Grafana Alerting engine from adding a reserved label, you can disable it via the `disabled_labels` option in [unified_alerting.reserved_labels]({{< relref "/docs/grafana/latest/setup-grafana/configure-grafana#unified_alertingreserved_labels" >}}) configuration.
 
 Grafana reserved labels can be used in the same way as manually configured labels. The current list of available reserved labels are:
 

--- a/docs/sources/alerting/fundamentals/evaluate-grafana-alerts.md
+++ b/docs/sources/alerting/fundamentals/evaluate-grafana-alerts.md
@@ -23,11 +23,11 @@ Grafana managed alerts query the following backend data sources that have alerti
 
 - built-in data sources or those developed and maintained by Grafana: `Graphite`, `Prometheus`, `Loki`, `InfluxDB`, `Elasticsearch`,
   `Google Cloud Monitoring`, `Cloudwatch`, `Azure Monitor`, `MySQL`, `PostgreSQL`, `MSSQL`, `OpenTSDB`, `Oracle`, and `Azure Monitor`
-- community developed backend data sources with alerting enabled (`backend` and `alerting` properties are set in the [plugin.json]({{< relref "../../developers/plugins/metadata/" >}}))
+- community developed backend data sources with alerting enabled (`backend` and `alerting` properties are set in the [plugin.json]({{< relref "/docs/grafana/latest/developers/plugins/metadata" >}}))
 
 ### Metrics from the alerting engine
 
-The alerting engine publishes some internal metrics about itself. You can read more about how Grafana publishes [internal metrics]({{< relref "../../setup-grafana/set-up-grafana-monitoring/" >}}).
+The alerting engine publishes some internal metrics about itself. You can read more about how Grafana publishes [internal metrics]({{< relref "/docs/grafana/latest/setup-grafana/set-up-grafana-monitoring" >}}).
 
 | Metric Name                                       | Type      | Description                                                                              |
 | ------------------------------------------------- | --------- | ---------------------------------------------------------------------------------------- |

--- a/docs/sources/alerting/manage-notifications/images-in-notifications.md
+++ b/docs/sources/alerting/manage-notifications/images-in-notifications.md
@@ -25,9 +25,9 @@ Refer to the table at the end of this page for a list of contact points and thei
 
 ## Requirements
 
-1. To use images in notifications, Grafana must be set up to use [image rendering](https://grafana.com/docs/grafana/next/setup-grafana/image-rendering/). You can either install the image rendering plugin or run it as a remote rendering service.
+1. To use images in notifications, Grafana must be set up to use [image rendering]({{< relref "/docs/grafana/latest/setup-grafana/image-rendering" >}}). You can either install the image rendering plugin or run it as a remote rendering service.
 
-2. When a screenshot is taken it is saved to the [data]({{< relref "../../setup-grafana/configure-grafana/#paths" >}}) folder, even if Grafana is configured to upload screenshots to a cloud storage service. Grafana must have write-access to this folder otherwise screenshots cannot be saved to disk and an error will be logged for each failed screenshot attempt.
+2. When a screenshot is taken it is saved to the [data]({{< relref "/docs/grafana/latest/setup-grafana/configure-grafana#paths" >}}) folder, even if Grafana is configured to upload screenshots to a cloud storage service. Grafana must have write-access to this folder otherwise screenshots cannot be saved to disk and an error will be logged for each failed screenshot attempt.
 
 3. You should use a cloud storage service unless sending alerts to Discord, Email, Pushover, Slack or Telegram. These integrations support either embedding screenshots in the email or attaching screenshots to the notification, while other integrations must link screenshots uploaded to a cloud storage bucket. If a cloud storage service has been configured then integrations that support both will link screenshots from the cloud storage bucket instead of embedding or attaching screenshots to the notification.
 
@@ -43,7 +43,7 @@ Refer to the table at the end of this page for a list of contact points and thei
 
 ## Configuration
 
-> **Note:** Grafana Cloud users can request this feature by [opening a support ticket in the Cloud Portal](https://grafana.com/profile/org#support).
+> **Note:** Grafana Cloud users can request this feature by [opening a support ticket in the Cloud Portal](/profile/org#support).
 
 Having installed either the image rendering plugin, or set up Grafana to use a remote rendering service, set `capture` in `[unified_alerting.screenshots]` to `true`:
 
@@ -59,9 +59,9 @@ If screenshots should be uploaded to cloud storage then `upload_external_image_s
     # will be persisted to disk for up to temp_data_lifetime.
     upload_external_image_storage = false
 
-Please see [`[external_image_storage]`](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#external_image_storage) for instructions on how to configure cloud storage. Grafana will not start if `upload_external_image_storage` is `true` and `[external_image_storage]` contains missing or invalid configuration.
+Please see [`[external_image_storage]`]({{< relref "/docs/grafana/latest/setup-grafana/configure-grafana#external_image_storage" >}}) for instructions on how to configure cloud storage. Grafana will not start if `upload_external_image_storage` is `true` and `[external_image_storage]` contains missing or invalid configuration.
 
-If Grafana is acting as its own cloud storage then `[upload_external_image_storage]` should be set to `true` and the `local` provider should be set in [`[external_image_storage]`](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#external_image_storage).
+If Grafana is acting as its own cloud storage then `[upload_external_image_storage]` should be set to `true` and the `local` provider should be set in [`[external_image_storage]`]({{< relref "/docs/grafana/latest/setup-grafana/configure-grafana#external_image_storage" >}}).
 
 Restart Grafana for the changes to take effect.
 

--- a/docs/sources/alerting/manage-notifications/mute-timings.md
+++ b/docs/sources/alerting/manage-notifications/mute-timings.md
@@ -20,7 +20,7 @@ A mute timing is a recurring interval of time when no new notifications for a po
 
 Similar to silences, mute timings do not prevent alert rules from being evaluated, nor do they stop alert instances from being shown in the user interface. They only prevent notifications from being created.
 
-You can configure Grafana managed mute timings as well as mute timings for an [external Alertmanager data source]({{< relref "../../datasources/alertmanager/" >}}). For more information, refer to [Alertmanager documentation]((https://grafana.com/docs/grafana/next/alerting/manage-notifications/alertmanager/).
+You can configure Grafana managed mute timings as well as mute timings for an [external Alertmanager data source]({{< relref "/docs/grafana/latest/datasources/alertmanager" >}}). For more information, refer to [Alertmanager documentation]({{< relref "/docs/grafana/latest/alerting/manage-notifications/alertmanager" >}}).
 
 ## Mute timings vs silences
 

--- a/docs/sources/developers/http_api/access_control.md
+++ b/docs/sources/developers/http_api/access_control.md
@@ -17,11 +17,11 @@ title: RBAC HTTP API
 
 # RBAC API
 
-> Role-based access control API is only available in Grafana Enterprise. Read more about [Grafana Enterprise]({{< relref "../../introduction/grafana-enterprise/" >}}).
+> Role-based access control API is only available in Grafana Enterprise. Read more about [Grafana Enterprise]({{< relref "/docs/grafana/latest/introduction/grafana-enterprise" >}}).
 
 The API can be used to create, update, delete, get, and list roles.
 
-To check which basic or fixed roles have the required permissions, refer to [RBAC role definitions]({{< ref "../../administration/roles-and-permissions/access-control/rbac-fixed-basic-role-definitions/" >}}).
+To check which basic or fixed roles have the required permissions, refer to [RBAC role definitions]({{< ref "/docs/grafana/latest/administration/roles-and-permissions/access-control/rbac-fixed-basic-role-definitions" >}}).
 
 ## Get status
 
@@ -222,7 +222,7 @@ Content-Type: application/json; charset=UTF-8
 
 `POST /api/access-control/roles`
 
-Creates a new custom role and maps given permissions to that role. Note that roles with the same prefix as [Fixed roles]({{< relref "../../administration/roles-and-permissions/access-control/#fixed-roles" >}}) can't be created.
+Creates a new custom role and maps given permissions to that role. Note that roles with the same prefix as [Fixed roles]({{< relref "/docs/grafana/latest/administration/roles-and-permissions/access-control#fixed-roles" >}}) can't be created.
 
 #### Required permissions
 
@@ -260,24 +260,24 @@ Content-Type: application/json
 
 #### JSON body schema
 
-| Field Name  | Date Type  | Required | Description                                                                                                                                                                                                                                           |
-| ----------- | ---------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| uid         | string     | No       | UID of the role. If not present, the UID will be automatically created for you and returned in response. Refer to the [Custom roles]({{< relref "../../administration/roles-and-permissions/access-control/#custom-roles" >}}) for more information.  |
-| global      | boolean    | No       | A flag indicating if the role is global or not. If set to `false`, the default org ID of the authenticated user will be used from the request.                                                                                                        |
-| version     | number     | No       | Version of the role. If not present, version 0 will be assigned to the role and returned in the response. Refer to the [Custom roles]({{< relref "../../administration/roles-and-permissions/access-control/#custom-roles" >}}) for more information. |
-| name        | string     | Yes      | Name of the role. Refer to [Custom roles]({{< relref "../../administration/roles-and-permissions/access-control/#custom-roles" >}}) for more information.                                                                                             |
-| description | string     | No       | Description of the role.                                                                                                                                                                                                                              |
-| displayName | string     | No       | Display name of the role, visible in the UI.                                                                                                                                                                                                          |
-| group       | string     | No       | The group name the role belongs to.                                                                                                                                                                                                                   |
-| hidden      | boolean    | No       | Specify whether the role is hidden or not. If set to `true`, then the role does not show in the role picker. It will not be listed by API endpoints unless explicitly specified.                                                                      |
-| permissions | Permission | No       | If not present, the role will be created without any permissions.                                                                                                                                                                                     |
+| Field Name  | Date Type  | Required | Description                                                                                                                                                                                                                                                          |
+| ----------- | ---------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| uid         | string     | No       | UID of the role. If not present, the UID will be automatically created for you and returned in response. Refer to the [Custom roles]({{< relref "/docs/grafana/latest/administration/roles-and-permissions/access-control#custom-roles" >}}) for more information.   |
+| global      | boolean    | No       | A flag indicating if the role is global or not. If set to `false`, the default org ID of the authenticated user will be used from the request.                                                                                                                       |
+| version     | number     | No       | Version of the role. If not present, version 0 will be assigned to the role and returned in the response. Refer to the [Custom roles]({{< relref "/docs/grafana/latest/administration/roles-and-permissions/access-control/#custom-roles" >}}) for more information. |
+| name        | string     | Yes      | Name of the role. Refer to [Custom roles]({{< relref "/docs/grafana/latest/administration/roles-and-permissions/access-control#custom-roles" >}}) for more information.                                                                                              |
+| description | string     | No       | Description of the role.                                                                                                                                                                                                                                             |
+| displayName | string     | No       | Display name of the role, visible in the UI.                                                                                                                                                                                                                         |
+| group       | string     | No       | The group name the role belongs to.                                                                                                                                                                                                                                  |
+| hidden      | boolean    | No       | Specify whether the role is hidden or not. If set to `true`, then the role does not show in the role picker. It will not be listed by API endpoints unless explicitly specified.                                                                                     |
+| permissions | Permission | No       | If not present, the role will be created without any permissions.                                                                                                                                                                                                    |
 
 **Permission**
 
-| Field Name | Data Type | Required | Description                                                                                                                                                                                                                                     |
-| ---------- | --------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| action     | string    | Yes      | Refer to [Custom role actions and scopes]({{< relref "../../administration/roles-and-permissions/access-control/custom-role-actions-scopes/" >}}) for full list of available actions.                                                           |
-| scope      | string    | No       | If not present, no scope will be mapped to the permission. Refer to [Custom role actions and scopes]({{< relref "../../administration/roles-and-permissions/access-control/custom-role-actions-scopes/" >}}) for full list of available scopes. |
+| Field Name | Data Type | Required | Description                                                                                                                                                                                                                                                   |
+| ---------- | --------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| action     | string    | Yes      | Refer to [Custom role actions and scopes]({{< relref "/docs/grafana/latest/administration/roles-and-permissions/access-control/custom-role-actions-scopes" >}}) for full list of available actions.                                                           |
+| scope      | string    | No       | If not present, no scope will be mapped to the permission. Refer to [Custom role actions and scopes]({{< relref "/docs/grafana/latest/administration/roles-and-permissions/access-control/custom-role-actions-scopes" >}}) for full list of available scopes. |
 
 #### Example response
 
@@ -375,10 +375,10 @@ Content-Type: application/json
 
 **Permission**
 
-| Field Name | Data Type | Required | Description                                                                                                                                                                                                                                     |
-| ---------- | --------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| action     | string    | Yes      | Refer to [Custom role actions and scopes]({{< relref "../../administration/roles-and-permissions/access-control/custom-role-actions-scopes/" >}}) for full list of available actions.                                                           |
-| scope      | string    | No       | If not present, no scope will be mapped to the permission. Refer to [Custom role actions and scopes]({{< relref "../../administration/roles-and-permissions/access-control/custom-role-actions-scopes/" >}}) for full list of available scopes. |
+| Field Name | Data Type | Required | Description                                                                                                                                                                                                                                                   |
+| ---------- | --------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| action     | string    | Yes      | Refer to [Custom role actions and scopes]({{< relref "/docs/grafana/latest/administration/roles-and-permissions/access-control/custom-role-actions-scopes" >}}) for full list of available actions.                                                           |
+| scope      | string    | No       | If not present, no scope will be mapped to the permission. Refer to [Custom role actions and scopes]({{< relref "/docs/grafana/latest/administration/roles-and-permissions/access-control/custom-role-actions-scopes" >}}) for full list of available scopes. |
 
 #### Example response
 
@@ -448,10 +448,10 @@ Accept: application/json
 
 #### Query parameters
 
-| Param  | Type    | Required | Description                                                                                                                                                                                                                                                               |
-| ------ | ------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| force  | boolean | No       | When set to `true`, the role will be deleted with all it's assignments.                                                                                                                                                                                                   |
-| global | boolean | No       | A flag indicating if the role is global or not. If set to false, the default org ID of the authenticated user will be used from the request. Refer to the [About RBAC]({{< relref "../../administration/roles-and-permissions/access-control/" >}}) for more information. |
+| Param  | Type    | Required | Description                                                                                                                                                                                                                                                                             |
+| ------ | ------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| force  | boolean | No       | When set to `true`, the role will be deleted with all it's assignments.                                                                                                                                                                                                                 |
+| global | boolean | No       | A flag indicating if the role is global or not. If set to false, the default org ID of the authenticated user will be used from the request. Refer to the [About RBAC]({{< relref "/docs/grafana/latest/administration/roles-and-permissions/access-control" >}}) for more information. |
 
 #### Example response
 

--- a/docs/sources/developers/http_api/alerting.md
+++ b/docs/sources/developers/http_api/alerting.md
@@ -19,9 +19,9 @@ title: 'Alerting HTTP API '
 
 This topic is relevant for the [legacy dashboard alerts](https://grafana.com/docs/grafana/v8.5/alerting/old-alerting/) only.
 
-If you are using Grafana Alerting, refer to [Alerting provisioning API](https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/)
+If you are using Grafana Alerting, refer to [Alerting provisioning API]({{< relref "/docs/grafana/latest/developers/http_api/alerting_provisioning" >}})
 
-You can find Grafana Alerting API specification details [here](https://editor.swagger.io/?url=https://raw.githubusercontent.com/grafana/grafana/main/pkg/services/ngalert/api/tooling/post.json). Also, refer to [Grafana Alerting alerts documentation]({{< relref "../../alerting/" >}}) for details on how to create and manage new alerts.
+You can find Grafana Alerting API specification details [here](https://editor.swagger.io/?url=https://raw.githubusercontent.com/grafana/grafana/main/pkg/services/ngalert/api/tooling/post.json). Also, refer to [Grafana Alerting alerts documentation]({{< relref "/docs/grafana/latest/alerting" >}}) for details on how to create and manage new alerts.
 
 You can use the Alerting API to get information about legacy dashboard alerts and their states but this API cannot be used to modify the alert.
 To create new alerts or modify them you need to update the dashboard JSON that contains the alerts.
@@ -167,4 +167,4 @@ Content-Type: application/json
 
 ## Pause all alerts
 
-See [Admin API]({{< relref "admin/#pause-all-alerts" >}}).
+See [Admin API]({{< relref "/docs/grafana/latest/developers/http_api/admin#pause-all-alerts" >}}).

--- a/docs/sources/developers/http_api/alerting_notification_channels.md
+++ b/docs/sources/developers/http_api/alerting_notification_channels.md
@@ -25,7 +25,7 @@ The identifier (id) of a notification channel is an auto-incrementing numeric va
 The unique identifier (uid) of a notification channel can be used for uniquely identify a notification channel between
 multiple Grafana installs. It's automatically generated if not provided when creating a notification channel. The uid
 allows having consistent URLs for accessing notification channels and when syncing notification channels between multiple
-Grafana installations, refer to [alert notification channel provisioning]({{< relref "../../administration/provisioning/#alert-notification-channels" >}}).
+Grafana installations, refer to [alert notification channel provisioning]({{< relref "/docs/grafana/latest/administration/provisioning#alert-notification-channels" >}}).
 
 The uid can have a maximum length of 40 characters.
 

--- a/docs/sources/developers/http_api/annotations.md
+++ b/docs/sources/developers/http_api/annotations.md
@@ -18,7 +18,7 @@ title: Annotations HTTP API
 
 Annotations are saved in the Grafana database (sqlite, mysql or postgres). Annotations can be organization annotations that can be shown on any dashboard by configuring an annotation data source - they are filtered by tags. Or they can be tied to a panel on a dashboard and are then only shown on that panel.
 
-> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "../../administration/roles-and-permissions/access-control/custom-role-actions-scopes/" >}}) for more information.
+> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "/docs/grafana/latest/administration/roles-and-permissions/access-control/custom-role-actions-scopes" >}}) for more information.
 
 ## Find Annotations
 

--- a/docs/sources/developers/http_api/curl-examples.md
+++ b/docs/sources/developers/http_api/curl-examples.md
@@ -22,16 +22,16 @@ The most basic example for a dashboard for which there is no authentication. You
 curl http://localhost:3000/api/search
 ```
 
-Here's a cURL command that works for getting the home dashboard when you are running Grafana locally with [basic authentication]({{< relref "../../setup-grafana/configure-security/configure-authentication/#basic-auth" >}}) enabled using the default admin credentials:
+Here's a cURL command that works for getting the home dashboard when you are running Grafana locally with [basic authentication]({{< relref "/docs/grafana/latest/setup-grafana/configure-security/configure-authentication#basic-auth" >}}) enabled using the default admin credentials:
 
 ```
 curl http://admin:admin@localhost:3000/api/search
 ```
 
-To pass a username and password with [HTTP basic authorization]({{< relref "../../administration/roles-and-permissions/access-control/manage-rbac-roles/" >}}), encode them as base64.
+To pass a username and password with [HTTP basic authorization]({{< relref "/docs/grafana/latest/administration/roles-and-permissions/access-control/manage-rbac-roles" >}}), encode them as base64.
 You can't use authorization tokens in the request.
 
-For example, to [list permissions associated with roles]({{< relref "../../administration/roles-and-permissions/access-control/manage-rbac-roles/" >}}) given a username of `user` and password of `password`, use:
+For example, to [list permissions associated with roles]({{< relref "/docs/grafana/latest/administration/roles-and-permissions/access-control/manage-rbac-roles" >}}) given a username of `user` and password of `password`, use:
 
 ```
 curl --location '<grafana_url>/api/access-control/builtin-roles' --user 'user:password'

--- a/docs/sources/developers/http_api/dashboard.md
+++ b/docs/sources/developers/http_api/dashboard.md
@@ -14,7 +14,7 @@ title: Dashboard HTTP API
 
 # Dashboard API
 
-> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "../../administration/roles-and-permissions/access-control/custom-role-actions-scopes/" >}}) for more information.
+> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "/docs/grafana/latest/administration/roles-and-permissions/access-control/custom-role-actions-scopes" >}}) for more information.
 
 ## Identifier (id) vs unique identifier (uid)
 
@@ -22,7 +22,7 @@ The identifier (id) of a dashboard is an auto-incrementing numeric value and is 
 
 The unique identifier (uid) of a dashboard can be used for uniquely identify a dashboard between multiple Grafana installs.
 It's automatically generated if not provided when creating a dashboard. The uid allows having consistent URLs for accessing
-dashboards and when syncing dashboards between multiple Grafana installs, see [dashboard provisioning]({{< relref "../../administration/provisioning/#dashboards" >}})
+dashboards and when syncing dashboards between multiple Grafana installs, see [dashboard provisioning]({{< relref "/docs/grafana/latest/administration/provisioning#dashboards" >}})
 for more information. This means that changing the title of a dashboard will not break any bookmarked links to that dashboard.
 
 The uid can have a maximum length of 40 characters.
@@ -76,7 +76,7 @@ JSON Body schema:
 - **folderUid** – The UID of the folder to save the dashboard in. Overrides the `folderId`.
 - **overwrite** – Set to true if you want to overwrite existing dashboard with newer version, same dashboard title in folder or same dashboard uid.
 - **message** - Set a commit message for the version history.
-- **refresh** - Set the dashboard refresh interval. If this is lower than [the minimum refresh interval]({{< relref "../../setup-grafana/configure-grafana/#min_refresh_interval" >}}), then Grafana will ignore it and will enforce the minimum refresh interval.
+- **refresh** - Set the dashboard refresh interval. If this is lower than [the minimum refresh interval]({{< relref "/docs/grafana/latest/setup-grafana/configure-grafana#min_refresh_interval" >}}), then Grafana will ignore it and will enforce the minimum refresh interval.
 
 For adding or updating an alert rule for a dashboard panel the user should declare a
 `dashboard.panels.alert` block.

--- a/docs/sources/developers/http_api/dashboard_permissions.md
+++ b/docs/sources/developers/http_api/dashboard_permissions.md
@@ -28,7 +28,7 @@ The permission levels for the permission field:
 - 2 = Edit
 - 4 = Admin
 
-> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "../../administration/roles-and-permissions/access-control/custom-role-actions-scopes/" >}}) for more information.
+> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "/docs/grafana/latest/administration/roles-and-permissions/access-control/custom-role-actions-scopes" >}}) for more information.
 
 ## Get permissions for a dashboard
 

--- a/docs/sources/developers/http_api/data_source.md
+++ b/docs/sources/developers/http_api/data_source.md
@@ -15,7 +15,7 @@ title: Data source HTTP API
 
 # Data source API
 
-> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "../../administration/roles-and-permissions/access-control/custom-role-actions-scopes/" >}}) for more information.
+> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "/docs/grafana/latest/administration/roles-and-permissions/access-control/custom-role-actions-scopes" >}}) for more information.
 
 ## Get all data sources
 

--- a/docs/sources/developers/http_api/datasource_permissions.md
+++ b/docs/sources/developers/http_api/datasource_permissions.md
@@ -19,9 +19,9 @@ title: Datasource Permissions HTTP API
 
 # Data Source Permissions API
 
-> The Data Source Permissions is only available in Grafana Enterprise. Read more about [Grafana Enterprise]({{< relref "../../introduction/grafana-enterprise/" >}}).
+> The Data Source Permissions is only available in Grafana Enterprise. Read more about [Grafana Enterprise]({{< relref "/docs/grafana/latest/introduction/grafana-enterprise" >}}).
 
-> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "../../administration/roles-and-permissions/access-control/custom-role-actions-scopes/" >}}) for more information.
+> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "/docs/grafana/latest/administration/roles-and-permissions/access-control/custom-role-actions-scopes" >}}) for more information.
 
 This API can be used to enable, disable, list, add and remove permissions for a data source.
 

--- a/docs/sources/developers/http_api/external_group_sync.md
+++ b/docs/sources/developers/http_api/external_group_sync.md
@@ -18,9 +18,9 @@ title: External Group Sync HTTP API
 
 # External Group Synchronization API
 
-> External Group Synchronization is only available in Grafana Enterprise. Read more about [Grafana Enterprise]({{< relref "../../introduction/grafana-enterprise/" >}}).
+> External Group Synchronization is only available in Grafana Enterprise. Read more about [Grafana Enterprise]({{< relref "/docs/grafana/latest/introduction/grafana-enterprise" >}}).
 
-> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "../../administration/roles-and-permissions/access-control/custom-role-actions-scopes/" >}}) for more information.
+> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "/docs/grafana/latest/administration/roles-and-permissions/access-control/custom-role-actions-scopes" >}}) for more information.
 
 ## Get External Groups
 

--- a/docs/sources/developers/http_api/folder.md
+++ b/docs/sources/developers/http_api/folder.md
@@ -14,7 +14,7 @@ title: Folder HTTP API
 
 # Folder API
 
-> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "../../administration/roles-and-permissions/access-control/custom-role-actions-scopes/" >}}) for more information.
+> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "/docs/grafana/latest/administration/roles-and-permissions/access-control/custom-role-actions-scopes" >}}) for more information.
 
 ## Identifier (id) vs unique identifier (uid)
 
@@ -280,7 +280,7 @@ Content-Length: 97
 
 Deletes an existing folder identified by UID along with all dashboards (and their alerts) stored in the folder. This operation cannot be reverted.
 
-If [Grafana Alerting]({{< relref "../../alerting/" >}}) is enabled, you can set an optional query parameter `forceDeleteRules=false` so that requests will fail with 400 (Bad Request) error if the folder contains any Grafana alerts. However, if this parameter is set to `true` then it will delete any Grafana alerts under this folder.
+If [Grafana Alerting]({{< relref "/docs/grafana/latest/alerting" >}}) is enabled, you can set an optional query parameter `forceDeleteRules=false` so that requests will fail with 400 (Bad Request) error if the folder contains any Grafana alerts. However, if this parameter is set to `true` then it will delete any Grafana alerts under this folder.
 
 **Required permissions**
 

--- a/docs/sources/developers/http_api/folder_dashboard_search.md
+++ b/docs/sources/developers/http_api/folder_dashboard_search.md
@@ -20,7 +20,7 @@ title: Folder/Dashboard Search HTTP API
 
 `GET /api/search/`
 
-> Note: When using [Role-based access control]({{< relref "../../administration/roles-and-permissions/access-control/" >}}), search results will contain only dashboards and folders which you have access to.
+> Note: When using [Role-based access control]({{< relref "/docs/grafana/latest/administration/roles-and-permissions/access-control" >}}), search results will contain only dashboards and folders which you have access to.
 
 Query parameters:
 

--- a/docs/sources/developers/http_api/folder_permissions.md
+++ b/docs/sources/developers/http_api/folder_permissions.md
@@ -28,7 +28,7 @@ The permission levels for the permission field:
 - 2 = Edit
 - 4 = Admin
 
-> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "../../administration/roles-and-permissions/access-control/custom-role-actions-scopes/" >}}) for more information.
+> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "/docs/grafana/latest/administration/roles-and-permissions/access-control/custom-role-actions-scopes" >}}) for more information.
 
 ## Get permissions for a folder
 

--- a/docs/sources/developers/http_api/licensing.md
+++ b/docs/sources/developers/http_api/licensing.md
@@ -15,9 +15,9 @@ title: Licensing HTTP API
 
 # Enterprise License API
 
-Licensing is only available in Grafana Enterprise. Read more about [Grafana Enterprise]({{< relref "../../introduction/grafana-enterprise/" >}}).
+Licensing is only available in Grafana Enterprise. Read more about [Grafana Enterprise]({{< relref "/docs/grafana/latest/introduction/grafana-enterprise" >}}).
 
-> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "../../administration/roles-and-permissions/access-control/custom-role-actions-scopes/" >}}) for more information.
+> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "/docs/grafana/latest/administration/roles-and-permissions/access-control/custom-role-actions-scopes" >}}) for more information.
 
 ## Check license availability
 

--- a/docs/sources/developers/http_api/org.md
+++ b/docs/sources/developers/http_api/org.md
@@ -19,7 +19,7 @@ The Organization HTTP API is divided in two resources, `/api/org` (current organ
 and `/api/orgs` (admin organizations). One big difference between these are that
 the admin of all organizations API only works with basic authentication, see [Admin Organizations API](#admin-organizations-api) for more information.
 
-> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "../../administration/roles-and-permissions/access-control/custom-role-actions-scopes/" >}}) for more information.
+> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "/docs/grafana/latest/administration/roles-and-permissions/access-control/custom-role-actions-scopes" >}}) for more information.
 
 ## Current Organization API
 

--- a/docs/sources/developers/http_api/reporting.md
+++ b/docs/sources/developers/http_api/reporting.md
@@ -13,13 +13,13 @@ title: Reporting API
 
 # Reporting API
 
-This API allows you to interact programmatically with the [Reporting]({{< relref "../../dashboards/create-reports/" >}}) feature.
+This API allows you to interact programmatically with the [Reporting]({{< relref "/docs/grafana/latest/dashboards/create-reports" >}}) feature.
 
 > The Reporting API is not stabilized yet, it is still in active development and may change without prior notice.
 
-> Reporting is only available in Grafana Enterprise. Read more about [Grafana Enterprise]({{< relref "../../introduction/grafana-enterprise/" >}}).
+> Reporting is only available in Grafana Enterprise. Read more about [Grafana Enterprise]({{< relref "/docs/grafana/latest/introduction/grafana-enterprise" >}}).
 
-> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "../../administration/roles-and-permissions/access-control/custom-role-actions-scopes/" >}}) for more information.
+> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "/docs/grafana/latest/administration/roles-and-permissions/access-control/custom-role-actions-scopes" >}}) for more information.
 
 ## List all reports
 
@@ -99,7 +99,7 @@ Content-Length: 1840
 ### Status Codes
 
 - **200** – OK
-- **401** - Authentication failed, refer to [Authentication API]({{< relref "./auth/" >}}).
+- **401** - Authentication failed, refer to [Authentication API]({{< relref "/docs/grafana/latest/developers/http_api/auth" >}}).
 - **500** – Unexpected error or server misconfiguration. Refer to server logs for more details.
 
 ## Get a report
@@ -183,7 +183,7 @@ Content-Length: 940
 
 - **200** – OK
 - **400** – Bad request (invalid report ID).
-- **401** - Authentication failed, refer to [Authentication API]({{< relref "./auth/" >}}).
+- **401** - Authentication failed, refer to [Authentication API]({{< relref "/docs/grafana/latest/developers/http_api/auth" >}}).
 - **403** – Forbidden (access denied to a report or a dashboard used in the report).
 - **404** – Not found (such report does not exist).
 - **500** – Unexpected error or server misconfiguration. Refer to server logs for more details.
@@ -377,7 +377,7 @@ Content-Length: 28
 
 - **200** – OK
 - **400** – Bad request (invalid json, missing or invalid fields values, etc.).
-- **401** - Authentication failed, refer to [Authentication API]({{< relref "./auth/" >}}).
+- **401** - Authentication failed, refer to [Authentication API]({{< relref "/docs/grafana/latest/developers/http_api/auth" >}}).
 - **403** – Forbidden (access denied to a report or a dashboard used in the report).
 - **404** – Not found (such report does not exist).
 - **500** – Unexpected error or server misconfiguration. Refer to server logs for more details.
@@ -419,7 +419,7 @@ Content-Length: 39
 
 - **200** – OK
 - **400** – Bad request (invalid report ID).
-- **401** - Authentication failed, refer to [Authentication API]({{< relref "./auth/" >}}).
+- **401** - Authentication failed, refer to [Authentication API]({{< relref "/docs/grafana/latest/developers/http_api/auth" >}}).
 - **404** - Not found (report with this ID does not exist).
 - **500** - Unexpected error or server misconfiguration. Refer to server logs for more details
 
@@ -473,7 +473,7 @@ Content-Length: 29
 
 - **200** – Report was sent.
 - **400** – Bad request (invalid json, missing content-type, missing or invalid fields, etc.).
-- **401** - Authentication failed, refer to [Authentication API]({{< relref "./auth/" >}}).
+- **401** - Authentication failed, refer to [Authentication API]({{< relref "/docs/grafana/latest/developers/http_api/auth" >}}).
 - **403** - Forbidden (access denied to a report or a dashboard used in the report).
 - **404** - Report not found.
 - **500** - Unexpected error or server misconfiguration. Refer to server logs for more details.
@@ -525,7 +525,7 @@ Content-Length: 181
 ### Status Codes
 
 - **200** – OK
-- **401** - Authentication failed, refer to [Authentication API]({{< relref "./auth/" >}}).
+- **401** - Authentication failed, refer to [Authentication API]({{< relref "/docs/grafana/latest/developers/http_api/auth" >}}).
 - **500** - Unexpected error or server misconfiguration. Refer to server logs for more detail
 
 ## Save reports branding settings
@@ -587,7 +587,7 @@ Content-Length: 35
 
 - **200** – OK
 - **400** – Bad request (invalid json, missing or invalid fields values, etc.).
-- **401** - Authentication failed, refer to [Authentication API]({{< relref "./auth/" >}}).
+- **401** - Authentication failed, refer to [Authentication API]({{< relref "/docs/grafana/latest/developers/http_api/auth" >}}).
 - **500** - Unexpected error or server misconfiguration. Refer to server logs for more detail
 
 ## Send a test email
@@ -670,6 +670,6 @@ Content-Length: 29
 
 - **200** – OK
 - **400** – Bad request (invalid json, missing or invalid fields values, etc.).
-- **401** - Authentication failed, refer to [Authentication API]({{< relref "./auth/" >}}).
+- **401** - Authentication failed, refer to [Authentication API]({{< relref "/docs/grafana/latest/developers/http_api/auth" >}}).
 - **403** - Forbidden (access denied to a report or a dashboard used in the report).
 - **500** - Unexpected error or server misconfiguration. Refer to server logs for more details

--- a/docs/sources/developers/http_api/reporting.md
+++ b/docs/sources/developers/http_api/reporting.md
@@ -27,7 +27,7 @@ This API allows you to interact programmatically with the [Reporting]({{< relref
 
 #### Required permissions
 
-See note in the [introduction]({{< ref "#reporting-api" >}}) for an explanation.
+See note in the [introduction]({{< relref "./#reporting-api" >}}) for an explanation.
 
 | Action       | Scope                       |
 | ------------ | --------------------------- |
@@ -99,7 +99,7 @@ Content-Length: 1840
 ### Status Codes
 
 - **200** – OK
-- **401** - Authentication failed, refer to [Authentication API]({{< relref "auth/" >}}).
+- **401** - Authentication failed, refer to [Authentication API]({{< relref "./auth/" >}}).
 - **500** – Unexpected error or server misconfiguration. Refer to server logs for more details.
 
 ## Get a report
@@ -108,7 +108,7 @@ Content-Length: 1840
 
 #### Required permissions
 
-See note in the [introduction]({{< ref "#reporting-api" >}}) for an explanation.
+See note in the [introduction]({{< relref "./#reporting-api" >}}) for an explanation.
 
 | Action       | Scope                                                      |
 | ------------ | ---------------------------------------------------------- |
@@ -183,7 +183,7 @@ Content-Length: 940
 
 - **200** – OK
 - **400** – Bad request (invalid report ID).
-- **401** - Authentication failed, refer to [Authentication API]({{< relref "auth/" >}}).
+- **401** - Authentication failed, refer to [Authentication API]({{< relref "./auth/" >}}).
 - **403** – Forbidden (access denied to a report or a dashboard used in the report).
 - **404** – Not found (such report does not exist).
 - **500** – Unexpected error or server misconfiguration. Refer to server logs for more details.
@@ -194,7 +194,7 @@ Content-Length: 940
 
 #### Required permissions
 
-See note in the [introduction]({{< ref "#reporting-api" >}}) for an explanation.
+See note in the [introduction]({{< ref "./#reporting-api" >}}) for an explanation.
 
 | Action         | Scope |
 | -------------- | ----- |
@@ -304,7 +304,7 @@ Content-Length: 35
 
 #### Required permissions
 
-See note in the [introduction]({{< ref "#reporting-api" >}}) for an explanation.
+See note in the [introduction]({{< ref "./#reporting-api" >}}) for an explanation.
 
 | Action        | Scope                                                     |
 | ------------- | --------------------------------------------------------- |
@@ -377,7 +377,7 @@ Content-Length: 28
 
 - **200** – OK
 - **400** – Bad request (invalid json, missing or invalid fields values, etc.).
-- **401** - Authentication failed, refer to [Authentication API]({{< relref "auth/" >}}).
+- **401** - Authentication failed, refer to [Authentication API]({{< relref "./auth/" >}}).
 - **403** – Forbidden (access denied to a report or a dashboard used in the report).
 - **404** – Not found (such report does not exist).
 - **500** – Unexpected error or server misconfiguration. Refer to server logs for more details.
@@ -388,7 +388,7 @@ Content-Length: 28
 
 #### Required permissions
 
-See note in the [introduction]({{< ref "#reporting-api" >}}) for an explanation.
+See note in the [introduction]({{< ref "./#reporting-api" >}}) for an explanation.
 
 | Action         | Scope                                                     |
 | -------------- | --------------------------------------------------------- |
@@ -419,7 +419,7 @@ Content-Length: 39
 
 - **200** – OK
 - **400** – Bad request (invalid report ID).
-- **401** - Authentication failed, refer to [Authentication API]({{< relref "auth/" >}}).
+- **401** - Authentication failed, refer to [Authentication API]({{< relref "./auth/" >}}).
 - **404** - Not found (report with this ID does not exist).
 - **500** - Unexpected error or server misconfiguration. Refer to server logs for more details
 
@@ -431,7 +431,7 @@ Generate and send a report. This API waits for the report to be generated before
 
 #### Required permissions
 
-See note in the [introduction]({{< ref "#reporting-api" >}}) for an explanation.
+See note in the [introduction]({{< ref "./#reporting-api" >}}) for an explanation.
 
 | Action       | Scope |
 | ------------ | ----- |
@@ -473,7 +473,7 @@ Content-Length: 29
 
 - **200** – Report was sent.
 - **400** – Bad request (invalid json, missing content-type, missing or invalid fields, etc.).
-- **401** - Authentication failed, refer to [Authentication API]({{< relref "auth/" >}}).
+- **401** - Authentication failed, refer to [Authentication API]({{< relref "./auth/" >}}).
 - **403** - Forbidden (access denied to a report or a dashboard used in the report).
 - **404** - Report not found.
 - **500** - Unexpected error or server misconfiguration. Refer to server logs for more details.
@@ -486,7 +486,7 @@ Returns reports branding settings that are global and used across all the report
 
 #### Required permissions
 
-See note in the [introduction]({{< ref "#reporting-api" >}}) for an explanation.
+See note in the [introduction]({{< ref "./#reporting-api" >}}) for an explanation.
 
 | Action                | Scope |
 | --------------------- | ----- |
@@ -525,7 +525,7 @@ Content-Length: 181
 ### Status Codes
 
 - **200** – OK
-- **401** - Authentication failed, refer to [Authentication API]({{< relref "auth/" >}}).
+- **401** - Authentication failed, refer to [Authentication API]({{< relref "./auth/" >}}).
 - **500** - Unexpected error or server misconfiguration. Refer to server logs for more detail
 
 ## Save reports branding settings
@@ -536,7 +536,7 @@ Creates settings if they don't exist, otherwise updates them. These settings are
 
 #### Required permissions
 
-See note in the [introduction]({{< ref "#reporting-api" >}}) for an explanation.
+See note in the [introduction]({{< ref "./#reporting-api" >}}) for an explanation.
 
 | Action                 | Scope |
 | ---------------------- | ----- |
@@ -587,7 +587,7 @@ Content-Length: 35
 
 - **200** – OK
 - **400** – Bad request (invalid json, missing or invalid fields values, etc.).
-- **401** - Authentication failed, refer to [Authentication API]({{< relref "auth/" >}}).
+- **401** - Authentication failed, refer to [Authentication API]({{< relref "./auth/" >}}).
 - **500** - Unexpected error or server misconfiguration. Refer to server logs for more detail
 
 ## Send a test email
@@ -598,7 +598,7 @@ Sends a test email with a report without persisting it in the database.
 
 #### Required permissions
 
-See note in the [introduction]({{< ref "#reporting-api" >}}) for an explanation.
+See note in the [introduction]({{< ref "./#reporting-api" >}}) for an explanation.
 
 | Action       | Scope |
 | ------------ | ----- |
@@ -670,6 +670,6 @@ Content-Length: 29
 
 - **200** – OK
 - **400** – Bad request (invalid json, missing or invalid fields values, etc.).
-- **401** - Authentication failed, refer to [Authentication API]({{< relref "auth/" >}}).
+- **401** - Authentication failed, refer to [Authentication API]({{< relref "./auth/" >}}).
 - **403** - Forbidden (access denied to a report or a dashboard used in the report).
 - **500** - Unexpected error or server misconfiguration. Refer to server logs for more details

--- a/docs/sources/developers/http_api/reporting.md
+++ b/docs/sources/developers/http_api/reporting.md
@@ -27,7 +27,7 @@ This API allows you to interact programmatically with the [Reporting]({{< relref
 
 #### Required permissions
 
-See note in the [introduction]({{< relref "./#reporting-api" >}}) for an explanation.
+See note in the [introduction]({{< relref "#reporting-api" >}}) for an explanation.
 
 | Action       | Scope                       |
 | ------------ | --------------------------- |
@@ -108,7 +108,7 @@ Content-Length: 1840
 
 #### Required permissions
 
-See note in the [introduction]({{< relref "./#reporting-api" >}}) for an explanation.
+See note in the [introduction]({{< relref "#reporting-api" >}}) for an explanation.
 
 | Action       | Scope                                                      |
 | ------------ | ---------------------------------------------------------- |
@@ -194,7 +194,7 @@ Content-Length: 940
 
 #### Required permissions
 
-See note in the [introduction]({{< ref "./#reporting-api" >}}) for an explanation.
+See note in the [introduction]({{< ref "#reporting-api" >}}) for an explanation.
 
 | Action         | Scope |
 | -------------- | ----- |
@@ -304,7 +304,7 @@ Content-Length: 35
 
 #### Required permissions
 
-See note in the [introduction]({{< ref "./#reporting-api" >}}) for an explanation.
+See note in the [introduction]({{< ref "#reporting-api" >}}) for an explanation.
 
 | Action        | Scope                                                     |
 | ------------- | --------------------------------------------------------- |
@@ -388,7 +388,7 @@ Content-Length: 28
 
 #### Required permissions
 
-See note in the [introduction]({{< ref "./#reporting-api" >}}) for an explanation.
+See note in the [introduction]({{< ref "#reporting-api" >}}) for an explanation.
 
 | Action         | Scope                                                     |
 | -------------- | --------------------------------------------------------- |
@@ -431,7 +431,7 @@ Generate and send a report. This API waits for the report to be generated before
 
 #### Required permissions
 
-See note in the [introduction]({{< ref "./#reporting-api" >}}) for an explanation.
+See note in the [introduction]({{< ref "#reporting-api" >}}) for an explanation.
 
 | Action       | Scope |
 | ------------ | ----- |
@@ -486,7 +486,7 @@ Returns reports branding settings that are global and used across all the report
 
 #### Required permissions
 
-See note in the [introduction]({{< ref "./#reporting-api" >}}) for an explanation.
+See note in the [introduction]({{< ref "#reporting-api" >}}) for an explanation.
 
 | Action                | Scope |
 | --------------------- | ----- |
@@ -536,7 +536,7 @@ Creates settings if they don't exist, otherwise updates them. These settings are
 
 #### Required permissions
 
-See note in the [introduction]({{< ref "./#reporting-api" >}}) for an explanation.
+See note in the [introduction]({{< ref "#reporting-api" >}}) for an explanation.
 
 | Action                 | Scope |
 | ---------------------- | ----- |
@@ -598,7 +598,7 @@ Sends a test email with a report without persisting it in the database.
 
 #### Required permissions
 
-See note in the [introduction]({{< ref "./#reporting-api" >}}) for an explanation.
+See note in the [introduction]({{< ref "#reporting-api" >}}) for an explanation.
 
 | Action       | Scope |
 | ------------ | ----- |

--- a/docs/sources/developers/http_api/serviceaccount.md
+++ b/docs/sources/developers/http_api/serviceaccount.md
@@ -14,7 +14,7 @@ title: Service account HTTP API
 
 # Service account API
 
-> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "../../administration/roles-and-permissions/access-control/custom-role-actions-scopes/" >}}) for more information.
+> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "/docs/grafana/latest/administration/roles-and-permissions/access-control/custom-role-actions-scopes" >}}) for more information.
 
 ## Search service accounts with Paging
 

--- a/docs/sources/developers/http_api/short_url.md
+++ b/docs/sources/developers/http_api/short_url.md
@@ -37,7 +37,7 @@ Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
 
 JSON body schema:
 
-- **path** – The path to shorten, relative to the Grafana [root_url]({{< relref "../../setup-grafana/configure-grafana/#root_url" >}}).
+- **path** – The path to shorten, relative to the Grafana [root_url]({{< relref "/docs/grafana/latest/setup-grafana/configure-grafana#root_url" >}}).
 
 **Example response:**
 

--- a/docs/sources/developers/http_api/team.md
+++ b/docs/sources/developers/http_api/team.md
@@ -25,7 +25,7 @@ Access to these API endpoints is restricted as follows:
 - If you enable `editors_can_admin` configuration flag, then Organization Editors can create teams and manage teams where they are Admin.
   - If you enable `editors_can_admin` configuration flag, Editors can find out whether a team that they are not members of exists by trying to create a team with the same name.
 
-> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "../../administration/roles-and-permissions/access-control/custom-role-actions-scopes/" >}}) for more information.
+> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "/docs/grafana/latest/administration/roles-and-permissions/access-control/custom-role-actions-scopes" >}}) for more information.
 
 ## Team Search With Paging
 

--- a/docs/sources/developers/http_api/user.md
+++ b/docs/sources/developers/http_api/user.md
@@ -14,7 +14,7 @@ title: User HTTP API
 
 # User API
 
-> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "../../administration/roles-and-permissions/access-control/custom-role-actions-scopes/" >}}) for more information.
+> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "/docs/grafana/latest/administration/roles-and-permissions/access-control/custom-role-actions-scopes" >}}) for more information.
 
 ## Search Users
 

--- a/docs/sources/getting-started/get-started-grafana-influxdb.md
+++ b/docs/sources/getting-started/get-started-grafana-influxdb.md
@@ -10,8 +10,6 @@ weight: 400
 
 {{< docs/shared "influxdb/intro.md" >}}
 
-{{< docs/shared "getting-started/first-step.md" >}}
-
 #### Get InfluxDB
 
 You can [download InfluxDB](https://portal.influxdata.com/downloads/) and install it locally or you can sign up for [InfluxDB Cloud](https://www.influxdata.com/products/influxdb-cloud/). Windows installers are not available for some versions of InfluxDB.

--- a/docs/sources/getting-started/get-started-grafana-ms-sql-server.md
+++ b/docs/sources/getting-started/get-started-grafana-ms-sql-server.md
@@ -12,8 +12,6 @@ weight: 500
 
 Microsoft SQL Server is a popular relational database management system that is widely used in development and production environments. This topic walks you through the steps to create a series of dashboards in Grafana to display metrics from a MS SQL Server database. You can also configure the MS SQL Server data source on a [Grafana Cloud](/docs/grafana-cloud/) instance without having to host Grafana yourself.
 
-{{< docs/shared "getting-started/first-step.md" >}}
-
 > **Note:** You must install Grafana 5.1+ in order to use the integrated MS SQL data source.
 
 #### Download MS SQL Server

--- a/docs/sources/getting-started/get-started-grafana-prometheus.md
+++ b/docs/sources/getting-started/get-started-grafana-prometheus.md
@@ -12,8 +12,6 @@ weight: 300
 
 Prometheus is an open source monitoring system for which Grafana provides out-of-the-box support. This topic walks you through the steps to create a series of dashboards in Grafana to display system metrics for a server monitored by Prometheus.
 
-{{< docs/shared "getting-started/first-step.md" >}}
-
 _Grafana and Prometheus_:
 
 1. Download Prometheus and node_exporter

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/enhanced-ldap/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/enhanced-ldap/index.md
@@ -18,7 +18,7 @@ weight: 900
 
 The enhanced LDAP integration adds additional functionality on top of the [LDAP integration]({{< relref "ldap/" >}}) available in the open source edition of Grafana.
 
-> **Note:** Available in [Grafana Enterprise]({{< relref "../../../../introduction/grafana-enterprise/" >}}) and [Grafana Cloud Advanced]({{< ref "/grafana-cloud" >}}).
+> **Note:** Available in [Grafana Enterprise]({{< relref "../../../../introduction/grafana-enterprise/" >}}) and [Grafana Cloud Advanced]({{< relref "/docs/grafana-cloud" >}}).
 
 > To control user access with role-based permissions, refer to [role-based access control]({{< relref "../../../../administration/roles-and-permissions/access-control/" >}}).
 

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/enhanced-ldap/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/enhanced-ldap/index.md
@@ -18,7 +18,7 @@ weight: 900
 
 The enhanced LDAP integration adds additional functionality on top of the [LDAP integration]({{< relref "ldap/" >}}) available in the open source edition of Grafana.
 
-> **Note:** Available in [Grafana Enterprise]({{< relref "../../../../introduction/grafana-enterprise/" >}}) and [Grafana Cloud Advanced]({{< relref "/docs/grafana-cloud" >}}).
+> **Note:** Available in [Grafana Enterprise]({{< relref "../../../../introduction/grafana-enterprise/" >}}) and [Grafana Cloud Advanced](/docs/grafana-cloud).
 
 > To control user access with role-based permissions, refer to [role-based access control]({{< relref "../../../../administration/roles-and-permissions/access-control/" >}}).
 

--- a/docs/sources/setup-grafana/configure-security/configure-database-encryption/_index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-database-encryption/_index.md
@@ -49,19 +49,19 @@ You can re-encrypt secrets in order to:
 - Move already existing secrets' encryption forward from legacy to envelope encryption.
 - Re-encrypt secrets after a [data keys rotation](#rotate-data-keys).
 
-To re-encrypt secrets, use the [Grafana CLI]({{< ref "/cli" >}}) by running the `grafana-cli admin secrets-migration re-encrypt` command or the `/encryption/reencrypt-secrets` endpoint of the Grafana [Admin API]({{< relref "../../../developers/http_api/admin/#roll-back-secrets" >}}). It's safe to run more than once, more recommended under maintenance mode.
+To re-encrypt secrets, use the [Grafana CLI]({{< relref "../../../cli/" >}}) by running the `grafana-cli admin secrets-migration re-encrypt` command or the `/encryption/reencrypt-secrets` endpoint of the Grafana [Admin API]({{< relref "../../../developers/http_api/admin/#roll-back-secrets" >}}). It's safe to run more than once, more recommended under maintenance mode.
 
 ### Roll back secrets
 
 You can roll back secrets encrypted with envelope encryption to legacy encryption. This might be necessary to downgrade to Grafana versions prior to v9.0 after an unsuccessful upgrade.
 
-To roll back secrets, use the [Grafana CLI]({{< ref "/cli" >}}) by running the `grafana-cli admin secrets-migration rollback` command or the `/encryption/rollback-secrets` endpoint of the Grafana [Admin API]({{< relref "../../../developers/http_api/admin/#re-encrypt-secrets" >}}). It's safe to run more than once, more recommended under maintenance mode.
+To roll back secrets, use the [Grafana CLI]({{< relref "../../../cli/" >}}) by running the `grafana-cli admin secrets-migration rollback` command or the `/encryption/rollback-secrets` endpoint of the Grafana [Admin API]({{< relref "../../../developers/http_api/admin/#re-encrypt-secrets" >}}). It's safe to run more than once, more recommended under maintenance mode.
 
 ### Re-encrypt data keys
 
 You can re-encrypt data keys encrypted with a specific key encryption key (KEK). This allows you to either re-encrypt existing data keys with a new KEK version (see [KMS integration](#kms-integration) rotation) or to re-encrypt them with a completely different KEK.
 
-To re-encrypt data keys, use the [Grafana CLI]({{< ref "/cli" >}}) by running the `grafana-cli admin secrets-migration re-encrypt-data-keys` command or the `/encryption/reencrypt-data-keys` endpoint of the Grafana [Admin API]({{< relref "../../../developers/http_api/admin/#re-encrypt-data-encryption-keys" >}}). It's safe to run more than once, more recommended under maintenance mode.
+To re-encrypt data keys, use the [Grafana CLI]({{< relref "../../../cli/" >}}) by running the `grafana-cli admin secrets-migration re-encrypt-data-keys` command or the `/encryption/reencrypt-data-keys` endpoint of the Grafana [Admin API]({{< relref "../../../developers/http_api/admin/#re-encrypt-data-encryption-keys" >}}). It's safe to run more than once, more recommended under maintenance mode.
 
 ### Rotate data keys
 
@@ -92,4 +92,4 @@ Grafana integrates with the following key management services:
 
 Grafana encrypts secrets using Advanced Encryption Standard in Cipher FeedBack mode (AES-CFB). You might prefer to use AES in Galois/Counter Mode (AES-GCM) instead, to meet your company’s security requirements or in order to maintain consistency with other services.
 
-To change your encryption mode, update the `algorithm` value in the `[security.encryption]` section of your Grafana configuration file. For further details, refer to [Enterprise configuration]({{< relref "../../configure-grafana/enterprise-configuration/#securityencryption" >}}).
+To change your encryption mode, update the `algorithm` value in the `[security.encryption]` section of your Grafana configuration file. For further details, relrefer to/ [Enterprise configuration]({{< relref "../../configure-grafana/enterprise-configuration/#securityencryption" >}}).

--- a/docs/sources/setup-grafana/configure-security/configure-database-encryption/_index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-database-encryption/_index.md
@@ -92,4 +92,4 @@ Grafana integrates with the following key management services:
 
 Grafana encrypts secrets using Advanced Encryption Standard in Cipher FeedBack mode (AES-CFB). You might prefer to use AES in Galois/Counter Mode (AES-GCM) instead, to meet your company’s security requirements or in order to maintain consistency with other services.
 
-To change your encryption mode, update the `algorithm` value in the `[security.encryption]` section of your Grafana configuration file. For further details, relrefer to/ [Enterprise configuration]({{< relref "../../configure-grafana/enterprise-configuration/#securityencryption" >}}).
+To change your encryption mode, update the `algorithm` value in the `[security.encryption]` section of your Grafana configuration file. For further details, refer to [Enterprise configuration]({{< relref "../../configure-grafana/enterprise-configuration#securityencryption" >}}).


### PR DESCRIPTION
[Fix reference to Grafana CLI](https://github.com/grafana/grafana/commit/58edeeaba61383e077ecd11f5b730b2cd7374463) 

- Make relref for relative permalink
- Use relative path for unambiguous resolution
  
[Fix alerting relref anchor format](https://github.com/grafana/grafana/commit/8f1ca7cf8fab19fc768feef791d11d62d01cc0b2) 
  
[Avoid ambiguous relref lookups by forcing relative resolution](https://github.com/grafana/grafana/commit/a3a77b432e7c5b1b414c942cd85f9b68b55880e0) 
  
[Remove reference to non-existent shared page](https://github.com/grafana/grafana/commit/89af5b60f28a0f62fc6753548761f09e1e529e8a) 
  
[Fix links broken in Grafana Cloud using absolute relrefs](https://github.com/grafana/grafana/commit/f811b98c1c48d30664245db40cd5cf663b541b8a) 

By resolving the relref absolutely, it refers to the same location regardless of mounted directory. 
This means mounted content will link back to Grafana docs but I believe this is preferable to 404s.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>

### To test the changes:

#### Prerequisites

Checkout each of the following as a subdirectory of your working directory:
- grafana/grafana branch `jdb/2023-03-fix-website-build-errors`
- grafana/cloud-docs branch `jdb/2023-03-fix-doc-validator`
- grafana/oncall ref `v0.0.39`
- grafana/incident branch `main`
- grafana/mimir branch `release-2.7`
- grafana/technical-documentation branch `main`
- grafana/website branch `jdb/2023-03-zero-docs-build-errors`


1. In the technical-documentation repository, run the `make-docs` script to build all documentation together:

   ```console
   $  ./scripts/make-docs \
        oncall \
        incident \
        mimir:v2.7.x \
        grafana:next \
        grafana:v9.4 \
        grafana-cloud \
        "arbitrary:$(pwd)/../website/scripts/docs/versions.js:/hugo/scripts/docs/versions.js" \
        "arbitrary:$(pwd)/../website/layouts/shortcodes/docs:/hugo/layouts/shortcodes/docs" \
        "arbitrary:$(pwd)/../website/content/docs/grafana/v8.1/packages_api:/hugo/content/docs/grafana/v8.1/packages_api"
   ```

1. Verify that Hugo logs no `WARN` or `ERROR` messages.