### PR TITLE
Alerting: Add ForNoData logic

### DIFF
--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -159,6 +159,7 @@ type AlertRule struct {
 	// ideally this field should have been apimodels.ApiDuration
 	// but this is currently not possible because of circular dependencies
 	For         time.Duration
+	ForError    time.Duration
 	Annotations map[string]string
 	Labels      map[string]string
 	IsPaused    bool
@@ -481,6 +482,9 @@ func PatchPartialAlertRule(existingRule *AlertRule, ruleToPatch *AlertRuleWithOp
 	}
 	if ruleToPatch.For == -1 {
 		ruleToPatch.For = existingRule.For
+	}
+	if ruleToPatch.ForError == -1 {
+		ruleToPatch.ForError = existingRule.ForError
 	}
 	if !ruleToPatch.HasPause {
 		ruleToPatch.IsPaused = existingRule.IsPaused

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -450,11 +450,14 @@ func (c Condition) IsValid() bool {
 	return len(c.Data) != 0
 }
 
-// PatchPartialAlertRule patches `ruleToPatch` by `existingRule` following the rule that if a field of `ruleToPatch` is empty or has the default value, it is populated by the value of the corresponding field from `existingRule`.
+// PatchPartialAlertRule patches `ruleToPatch` by `existingRule` following the rule that if a field of `ruleToPatch` is
+// empty or has the default value, it is populated by the value of the corresponding field from `existingRule`.
 // There are several exceptions:
-// 1. Following fields are not patched and therefore will be ignored: AlertRule.ID, AlertRule.OrgID, AlertRule.Updated, AlertRule.Version, AlertRule.UID, AlertRule.DashboardUID, AlertRule.PanelID, AlertRule.Annotations and AlertRule.Labels
-// 2. There are fields that are patched together:
-//   - AlertRule.Condition and AlertRule.Data
+//  1. Following fields are not patched and therefore will be ignored: AlertRule.ID, AlertRule.OrgID, AlertRule.Updated,
+//     AlertRule.Version, AlertRule.UID, AlertRule.DashboardUID, AlertRule.PanelID, AlertRule.Annotations, and
+//     AlertRule.Labels
+//  2. There are fields that are patched together:
+//     - AlertRule.Condition and AlertRule.Data
 //
 // If either of the pair is specified, neither is patched.
 func PatchPartialAlertRule(existingRule *AlertRule, ruleToPatch *AlertRuleWithOptionals) {

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -450,14 +450,11 @@ func (c Condition) IsValid() bool {
 	return len(c.Data) != 0
 }
 
-// PatchPartialAlertRule patches `ruleToPatch` by `existingRule` following the rule that if a field of `ruleToPatch` is
-// empty or has the default value, it is populated by the value of the corresponding field from `existingRule`.
+// PatchPartialAlertRule patches `ruleToPatch` by `existingRule` following the rule that if a field of `ruleToPatch` is empty or has the default value, it is populated by the value of the corresponding field from `existingRule`.
 // There are several exceptions:
-//  1. Following fields are not patched and therefore will be ignored: AlertRule.ID, AlertRule.OrgID, AlertRule.Updated,
-//     AlertRule.Version, AlertRule.UID, AlertRule.DashboardUID, AlertRule.PanelID, AlertRule.Annotations, and
-//     AlertRule.Labels
-//  2. There are fields that are patched together:
-//     - AlertRule.Condition and AlertRule.Data
+// 1. Following fields are not patched and therefore will be ignored: AlertRule.ID, AlertRule.OrgID, AlertRule.Updated, AlertRule.Version, AlertRule.UID, AlertRule.DashboardUID, AlertRule.PanelID, AlertRule.Annotations and AlertRule.Labels
+// 2. There are fields that are patched together:
+//   - AlertRule.Condition and AlertRule.Data
 //
 // If either of the pair is specified, neither is patched.
 func PatchPartialAlertRule(existingRule *AlertRule, ruleToPatch *AlertRuleWithOptionals) {
@@ -485,9 +482,6 @@ func PatchPartialAlertRule(existingRule *AlertRule, ruleToPatch *AlertRuleWithOp
 	}
 	if ruleToPatch.For == -1 {
 		ruleToPatch.For = existingRule.For
-	}
-	if ruleToPatch.ForError == -1 {
-		ruleToPatch.ForError = existingRule.ForError
 	}
 	if !ruleToPatch.HasPause {
 		ruleToPatch.IsPaused = existingRule.IsPaused

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -160,6 +160,7 @@ type AlertRule struct {
 	// but this is currently not possible because of circular dependencies
 	For         time.Duration
 	ForError    time.Duration
+	ForNoData   time.Duration
 	Annotations map[string]string
 	Labels      map[string]string
 	IsPaused    bool
@@ -357,6 +358,7 @@ type AlertRuleVersion struct {
 	// but this is currently not possible because of circular dependencies
 	For         time.Duration
 	ForError    time.Duration
+	ForNoData   time.Duration
 	Annotations map[string]string
 	Labels      map[string]string
 	IsPaused    bool

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -356,6 +356,7 @@ type AlertRuleVersion struct {
 	// ideally this field should have been apimodels.ApiDuration
 	// but this is currently not possible because of circular dependencies
 	For         time.Duration
+	ForError    time.Duration
 	Annotations map[string]string
 	Labels      map[string]string
 	IsPaused    bool

--- a/pkg/services/ngalert/models/alert_rule_test.go
+++ b/pkg/services/ngalert/models/alert_rule_test.go
@@ -200,12 +200,6 @@ func TestPatchPartialAlertRule(t *testing.T) {
 				},
 			},
 			{
-				name: "ForError is -1",
-				mutator: func(r *AlertRuleWithOptionals) {
-					r.ForError = -1
-				},
-			},
-			{
 				name: "IsPaused did not come in request",
 				mutator: func(r *AlertRuleWithOptionals) {
 					r.IsPaused = true
@@ -219,7 +213,6 @@ func TestPatchPartialAlertRule(t *testing.T) {
 				for {
 					rule := AlertRuleGen(func(rule *AlertRule) {
 						rule.For = time.Duration(rand.Int63n(1000) + 1)
-						rule.ForError = time.Duration(rand.Int63n(1000) + 1)
 					})()
 					existing = &AlertRuleWithOptionals{AlertRule: *rule}
 					cloned := *existing

--- a/pkg/services/ngalert/models/alert_rule_test.go
+++ b/pkg/services/ngalert/models/alert_rule_test.go
@@ -200,6 +200,12 @@ func TestPatchPartialAlertRule(t *testing.T) {
 				},
 			},
 			{
+				name: "ForError is -1",
+				mutator: func(r *AlertRuleWithOptionals) {
+					r.ForError = -1
+				},
+			},
+			{
 				name: "IsPaused did not come in request",
 				mutator: func(r *AlertRuleWithOptionals) {
 					r.IsPaused = true
@@ -213,6 +219,7 @@ func TestPatchPartialAlertRule(t *testing.T) {
 				for {
 					rule := AlertRuleGen(func(rule *AlertRule) {
 						rule.For = time.Duration(rand.Int63n(1000) + 1)
+						rule.ForError = time.Duration(rand.Int63n(1000) + 1)
 					})()
 					existing = &AlertRuleWithOptionals{AlertRule: *rule}
 					cloned := *existing
@@ -441,6 +448,13 @@ func TestDiff(t *testing.T) {
 			assert.Len(t, diff, 1)
 			assert.Equal(t, rule1.For, diff[0].Left.Interface())
 			assert.Equal(t, rule2.For, diff[0].Right.Interface())
+			difCnt++
+		}
+		if rule1.ForError != rule2.ForError {
+			diff := diffs.GetDiffsForField("ForError")
+			assert.Len(t, diff, 1)
+			assert.Equal(t, rule1.ForError, diff[0].Left.Interface())
+			assert.Equal(t, rule2.ForError, diff[0].Right.Interface())
 			difCnt++
 		}
 		if rule1.RuleGroupIndex != rule2.RuleGroupIndex {

--- a/pkg/services/ngalert/models/alert_rule_test.go
+++ b/pkg/services/ngalert/models/alert_rule_test.go
@@ -450,6 +450,13 @@ func TestDiff(t *testing.T) {
 			assert.Equal(t, rule2.ForError, diff[0].Right.Interface())
 			difCnt++
 		}
+		if rule1.ForNoData != rule2.ForNoData {
+			diff := diffs.GetDiffsForField("ForNoData")
+			assert.Len(t, diff, 1)
+			assert.Equal(t, rule1.ForNoData, diff[0].Left.Interface())
+			assert.Equal(t, rule2.ForNoData, diff[0].Right.Interface())
+			difCnt++
+		}
 		if rule1.RuleGroupIndex != rule2.RuleGroupIndex {
 			diff := diffs.GetDiffsForField("RuleGroupIndex")
 			assert.Len(t, diff, 1)

--- a/pkg/services/ngalert/models/testing.go
+++ b/pkg/services/ngalert/models/testing.go
@@ -39,6 +39,7 @@ func AlertRuleGen(mutators ...AlertRuleMutator) func() *AlertRule {
 
 		interval := (rand.Int63n(6) + 1) * 10
 		forInterval := time.Duration(interval*rand.Int63n(6)) * time.Second
+		forErrorInterval := time.Duration(interval*rand.Int63n(6)) * time.Second
 
 		var annotations map[string]string = nil
 		if rand.Int63()%2 == 0 {
@@ -76,6 +77,7 @@ func AlertRuleGen(mutators ...AlertRuleMutator) func() *AlertRule {
 			NoDataState:     randNoDataState(),
 			ExecErrState:    randErrState(),
 			For:             forInterval,
+			ForError:        forErrorInterval,
 			Annotations:     annotations,
 			Labels:          labels,
 		}
@@ -256,6 +258,7 @@ func CopyRule(r *AlertRule) *AlertRule {
 		NoDataState:     r.NoDataState,
 		ExecErrState:    r.ExecErrState,
 		For:             r.For,
+		ForError:        r.ForError,
 	}
 
 	if r.DashboardUID != nil {

--- a/pkg/services/ngalert/models/testing.go
+++ b/pkg/services/ngalert/models/testing.go
@@ -40,6 +40,7 @@ func AlertRuleGen(mutators ...AlertRuleMutator) func() *AlertRule {
 		interval := (rand.Int63n(6) + 1) * 10
 		forInterval := time.Duration(interval*rand.Int63n(6)) * time.Second
 		forErrorInterval := time.Duration(interval*rand.Int63n(6)) * time.Second
+		forNoDataInterval := time.Duration(interval*rand.Int63n(6)) * time.Second
 
 		var annotations map[string]string = nil
 		if rand.Int63()%2 == 0 {
@@ -78,6 +79,7 @@ func AlertRuleGen(mutators ...AlertRuleMutator) func() *AlertRule {
 			ExecErrState:    randErrState(),
 			For:             forInterval,
 			ForError:        forErrorInterval,
+			ForNoData:       forNoDataInterval,
 			Annotations:     annotations,
 			Labels:          labels,
 		}
@@ -259,6 +261,7 @@ func CopyRule(r *AlertRule) *AlertRule {
 		ExecErrState:    r.ExecErrState,
 		For:             r.For,
 		ForError:        r.ForError,
+		ForNoData:       r.ForNoData,
 	}
 
 	if r.DashboardUID != nil {

--- a/pkg/services/ngalert/schedule/schedule_unit_test.go
+++ b/pkg/services/ngalert/schedule/schedule_unit_test.go
@@ -587,6 +587,7 @@ func TestSchedule_ruleRoutine(t *testing.T) {
 	t.Run("when evaluation fails", func(t *testing.T) {
 		rule := models.AlertRuleGen(withQueryForState(t, eval.Error))()
 		rule.ExecErrState = models.ErrorErrState
+		rule.ForError = 0
 
 		evalChan := make(chan *evaluation)
 		evalAppliedChan := make(chan time.Time)

--- a/pkg/services/ngalert/state/manager_test.go
+++ b/pkg/services/ngalert/state/manager_test.go
@@ -111,6 +111,81 @@ func TestWarmStateCache(t *testing.T) {
 			LastEvaluationTime: evaluationTime,
 			Annotations:        map[string]string{"testAnnoKey": "testAnnoValue"},
 		},
+		{
+			AlertRuleUID: rule.UID,
+			OrgID:        rule.OrgID,
+			CacheID:      `[["test6","testValue6"]]`,
+			Labels:       data.Labels{"test6": "testValue6"},
+			State:        eval.Alerting,
+			StateReason:  models.StateReasonError,
+			Results: []state.Evaluation{
+				{EvaluationTime: evaluationTime, EvaluationState: eval.Alerting},
+			},
+			StartsAt:           evaluationTime.Add(-1 * time.Minute),
+			EndsAt:             evaluationTime.Add(1 * time.Minute),
+			LastEvaluationTime: evaluationTime,
+			Annotations:        map[string]string{"testAnnoKey": "testAnnoValue"},
+		},
+		{
+			AlertRuleUID: rule.UID,
+			OrgID:        rule.OrgID,
+			CacheID:      `[["test7","testValue7"]]`,
+			Labels:       data.Labels{"test7": "testValue7"},
+			State:        eval.Pending,
+			StateReason:  models.StateReasonError,
+			Results: []state.Evaluation{
+				{EvaluationTime: evaluationTime, EvaluationState: eval.Pending},
+			},
+			StartsAt:           evaluationTime.Add(-1 * time.Minute),
+			EndsAt:             evaluationTime.Add(1 * time.Minute),
+			LastEvaluationTime: evaluationTime,
+			Annotations:        map[string]string{"testAnnoKey": "testAnnoValue"},
+		},
+		{
+			AlertRuleUID: rule.UID,
+			OrgID:        rule.OrgID,
+			CacheID:      `[["test8","testValue8"]]`,
+			Labels:       data.Labels{"test8": "testValue8"},
+			State:        eval.Normal,
+			StateReason:  models.StateReasonError,
+			Results: []state.Evaluation{
+				{EvaluationTime: evaluationTime, EvaluationState: eval.Normal},
+			},
+			StartsAt:           evaluationTime.Add(-1 * time.Minute),
+			EndsAt:             evaluationTime.Add(1 * time.Minute),
+			LastEvaluationTime: evaluationTime,
+			Annotations:        map[string]string{"testAnnoKey": "testAnnoValue"},
+		},
+		{
+			AlertRuleUID: rule.UID,
+			OrgID:        rule.OrgID,
+			CacheID:      `[["test9","testValue9"]]`,
+			Labels:       data.Labels{"test9": "testValue9"},
+			State:        eval.Alerting,
+			StateReason:  models.StateReasonNoData,
+			Results: []state.Evaluation{
+				{EvaluationTime: evaluationTime, EvaluationState: eval.Alerting},
+			},
+			StartsAt:           evaluationTime.Add(-1 * time.Minute),
+			EndsAt:             evaluationTime.Add(1 * time.Minute),
+			LastEvaluationTime: evaluationTime,
+			Annotations:        map[string]string{"testAnnoKey": "testAnnoValue"},
+		},
+		{
+			AlertRuleUID: rule.UID,
+			OrgID:        rule.OrgID,
+			CacheID:      `[["test10","testValue10"]]`,
+			Labels:       data.Labels{"test10": "testValue10"},
+			State:        eval.Normal,
+			StateReason:  models.StateReasonNoData,
+			Results: []state.Evaluation{
+				{EvaluationTime: evaluationTime, EvaluationState: eval.Normal},
+			},
+			StartsAt:           evaluationTime.Add(-1 * time.Minute),
+			EndsAt:             evaluationTime.Add(1 * time.Minute),
+			LastEvaluationTime: evaluationTime,
+			Annotations:        map[string]string{"testAnnoKey": "testAnnoValue"},
+		},
 	}
 
 	labels := models.InstanceLabels{"test1": "testValue1"}
@@ -187,7 +262,88 @@ func TestWarmStateCache(t *testing.T) {
 		CurrentStateEnd:   evaluationTime.Add(1 * time.Minute),
 		Labels:            labels,
 	}
-	_ = dbstore.SaveAlertInstances(ctx, instance1, instance2, instance3, instance4, instance5)
+
+	labels = models.InstanceLabels{"test6": "testValue6"}
+	_, hash, _ = labels.StringAndHash()
+	instance6 := models.AlertInstance{
+		AlertInstanceKey: models.AlertInstanceKey{
+			RuleOrgID:  rule.OrgID,
+			RuleUID:    rule.UID,
+			LabelsHash: hash,
+		},
+		CurrentState:      models.InstanceStateFiring,
+		CurrentReason:     models.StateReasonError,
+		LastEvalTime:      evaluationTime,
+		CurrentStateSince: evaluationTime.Add(-1 * time.Minute),
+		CurrentStateEnd:   evaluationTime.Add(1 * time.Minute),
+		Labels:            labels,
+	}
+
+	labels = models.InstanceLabels{"test7": "testValue7"}
+	_, hash, _ = labels.StringAndHash()
+	instance7 := models.AlertInstance{
+		AlertInstanceKey: models.AlertInstanceKey{
+			RuleOrgID:  rule.OrgID,
+			RuleUID:    rule.UID,
+			LabelsHash: hash,
+		},
+		CurrentState:      models.InstanceStatePending,
+		CurrentReason:     models.StateReasonError,
+		LastEvalTime:      evaluationTime,
+		CurrentStateSince: evaluationTime.Add(-1 * time.Minute),
+		CurrentStateEnd:   evaluationTime.Add(1 * time.Minute),
+		Labels:            labels,
+	}
+
+	labels = models.InstanceLabels{"test8": "testValue8"}
+	_, hash, _ = labels.StringAndHash()
+	instance8 := models.AlertInstance{
+		AlertInstanceKey: models.AlertInstanceKey{
+			RuleOrgID:  rule.OrgID,
+			RuleUID:    rule.UID,
+			LabelsHash: hash,
+		},
+		CurrentState:      models.InstanceStateNormal,
+		CurrentReason:     models.StateReasonError,
+		LastEvalTime:      evaluationTime,
+		CurrentStateSince: evaluationTime.Add(-1 * time.Minute),
+		CurrentStateEnd:   evaluationTime.Add(1 * time.Minute),
+		Labels:            labels,
+	}
+
+	labels = models.InstanceLabels{"test9": "testValue9"}
+	_, hash, _ = labels.StringAndHash()
+	instance9 := models.AlertInstance{
+		AlertInstanceKey: models.AlertInstanceKey{
+			RuleOrgID:  rule.OrgID,
+			RuleUID:    rule.UID,
+			LabelsHash: hash,
+		},
+		CurrentState:      models.InstanceStateFiring,
+		CurrentReason:     models.StateReasonNoData,
+		LastEvalTime:      evaluationTime,
+		CurrentStateSince: evaluationTime.Add(-1 * time.Minute),
+		CurrentStateEnd:   evaluationTime.Add(1 * time.Minute),
+		Labels:            labels,
+	}
+
+	labels = models.InstanceLabels{"test10": "testValue10"}
+	_, hash, _ = labels.StringAndHash()
+	instance10 := models.AlertInstance{
+		AlertInstanceKey: models.AlertInstanceKey{
+			RuleOrgID:  rule.OrgID,
+			RuleUID:    rule.UID,
+			LabelsHash: hash,
+		},
+		CurrentState:      models.InstanceStateNormal,
+		CurrentReason:     models.StateReasonNoData,
+		LastEvalTime:      evaluationTime,
+		CurrentStateSince: evaluationTime.Add(-1 * time.Minute),
+		CurrentStateEnd:   evaluationTime.Add(1 * time.Minute),
+		Labels:            labels,
+	}
+	_ = dbstore.SaveAlertInstances(ctx, instance1, instance2, instance3, instance4, instance5, instance6, instance7,
+		instance8, instance9, instance10)
 
 	cfg := state.ManagerCfg{
 		Metrics:       testMetrics.GetStateMetrics(),
@@ -1653,7 +1809,7 @@ func TestProcessEvalResults(t *testing.T) {
 			},
 		},
 		{
-			desc: "normal -> error when result is Error and ExecErrState is Error",
+			desc: "normal -> error when result is Error and ExecErrState is Error and ForError is the default value",
 			alertRule: &models.AlertRule{
 				OrgID:        1,
 				Title:        "test_title",
@@ -1667,6 +1823,7 @@ func TestProcessEvalResults(t *testing.T) {
 				Labels:          map[string]string{"label": "test"},
 				IntervalSeconds: 10,
 				For:             1 * time.Minute,
+				ForError:        0,
 				ExecErrState:    models.ErrorErrState,
 			},
 			evalResults: []eval.Results{
@@ -1708,6 +1865,88 @@ func TestProcessEvalResults(t *testing.T) {
 					},
 					Values: make(map[string]float64),
 					State:  eval.Error,
+					Error: expr.QueryError{
+						RefID: "A",
+						Err:   errors.New("this is an error"),
+					},
+					Results: []state.Evaluation{
+						{
+							EvaluationTime:  evaluationTime,
+							EvaluationState: eval.Normal,
+							Values:          make(map[string]*float64),
+						},
+						{
+							EvaluationTime:  evaluationTime.Add(10 * time.Second),
+							EvaluationState: eval.Error,
+							Values:          make(map[string]*float64),
+						},
+					},
+					StartsAt:           evaluationTime.Add(10 * time.Second),
+					EndsAt:             evaluationTime.Add(10 * time.Second).Add(state.ResendDelay * 3),
+					LastEvaluationTime: evaluationTime.Add(10 * time.Second),
+					EvaluationDuration: evaluationDuration,
+					Annotations:        map[string]string{"annotation": "test", "Error": "failed to execute query A: this is an error"},
+				},
+			},
+		},
+		{
+			desc: "normal -> pending error when result is Error and ExecErrState is Error and ForError is set",
+			alertRule: &models.AlertRule{
+				OrgID:        1,
+				Title:        "test_title",
+				UID:          "test_alert_rule_uid_2",
+				NamespaceUID: "test_namespace_uid",
+				Data: []models.AlertQuery{{
+					RefID:         "A",
+					DatasourceUID: "datasource_uid_1",
+				}},
+				Annotations:     map[string]string{"annotation": "test"},
+				Labels:          map[string]string{"label": "test"},
+				IntervalSeconds: 10,
+				For:             1 * time.Minute,
+				ForError:        1 * time.Minute,
+				ExecErrState:    models.ErrorErrState,
+			},
+			evalResults: []eval.Results{
+				{
+					eval.Result{
+						Instance:           data.Labels{"instance_label": "test"},
+						State:              eval.Normal,
+						EvaluatedAt:        evaluationTime,
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+				{
+					eval.Result{
+						Instance: data.Labels{"instance_label": "test"},
+						Error: expr.QueryError{
+							RefID: "A",
+							Err:   errors.New("this is an error"),
+						},
+						State:              eval.Error,
+						EvaluatedAt:        evaluationTime.Add(10 * time.Second),
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+			},
+			expectedAnnotations: 1,
+			expectedStates: map[string]*state.State{
+				`[["__alert_rule_namespace_uid__","test_namespace_uid"],["__alert_rule_uid__","test_alert_rule_uid_2"],["alertname","test_title"],["instance_label","test"],["label","test"]]`: {
+					AlertRuleUID: "test_alert_rule_uid_2",
+					OrgID:        1,
+					CacheID:      `[["__alert_rule_namespace_uid__","test_namespace_uid"],["__alert_rule_uid__","test_alert_rule_uid_2"],["alertname","test_title"],["instance_label","test"],["label","test"]]`,
+					Labels: data.Labels{
+						"__alert_rule_namespace_uid__": "test_namespace_uid",
+						"__alert_rule_uid__":           "test_alert_rule_uid_2",
+						"alertname":                    "test_title",
+						"label":                        "test",
+						"instance_label":               "test",
+						"datasource_uid":               "datasource_uid_1",
+						"ref_id":                       "A",
+					},
+					Values:      make(map[string]float64),
+					State:       eval.Pending,
+					StateReason: models.StateReasonError,
 					Error: expr.QueryError{
 						RefID: "A",
 						Err:   errors.New("this is an error"),
@@ -1983,6 +2222,311 @@ func TestProcessEvalResults(t *testing.T) {
 					StartsAt:           evaluationTime.Add(30 * time.Second),
 					EndsAt:             evaluationTime.Add(50 * time.Second).Add(state.ResendDelay * 3),
 					LastEvaluationTime: evaluationTime.Add(50 * time.Second),
+					EvaluationDuration: evaluationDuration,
+					Annotations:        map[string]string{"annotation": "test"},
+				},
+			},
+		},
+		{
+			desc: "pending alerting -> pending error when result is Error and ExecErrorState is Error with For and ForError set",
+			alertRule: &models.AlertRule{
+				OrgID:           1,
+				Title:           "test_title",
+				UID:             "test_alert_rule_uid_2",
+				NamespaceUID:    "test_namespace_uid",
+				Annotations:     map[string]string{"annotation": "test"},
+				Labels:          map[string]string{"label": "test"},
+				IntervalSeconds: 10,
+				For:             10 * time.Second,
+				ForError:        20 * time.Second,
+				ExecErrState:    models.ErrorErrState,
+			},
+			evalResults: []eval.Results{
+				{
+					eval.Result{
+						Instance:           data.Labels{"instance_label": "test"},
+						State:              eval.Alerting,
+						EvaluatedAt:        evaluationTime,
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+				{
+					eval.Result{
+						Instance: data.Labels{"instance_label": "test"},
+						State:    eval.Error,
+						Error: expr.QueryError{
+							RefID: "A",
+							Err:   errors.New("this is an error"),
+						},
+						EvaluatedAt:        evaluationTime.Add(20 * time.Second),
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+				{
+					eval.Result{
+						Instance: data.Labels{"instance_label": "test"},
+						State:    eval.Error,
+						Error: expr.QueryError{
+							RefID: "A",
+							Err:   errors.New("this is an error"),
+						},
+						EvaluatedAt:        evaluationTime.Add(30 * time.Second),
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+			},
+			expectedAnnotations: 2,
+			expectedStates: map[string]*state.State{
+				`[["__alert_rule_namespace_uid__","test_namespace_uid"],["__alert_rule_uid__","test_alert_rule_uid_2"],["alertname","test_title"],["instance_label","test"],["label","test"]]`: {
+					AlertRuleUID: "test_alert_rule_uid_2",
+					OrgID:        1,
+					CacheID:      `[["__alert_rule_namespace_uid__","test_namespace_uid"],["__alert_rule_uid__","test_alert_rule_uid_2"],["alertname","test_title"],["instance_label","test"],["label","test"]]`,
+					Labels: data.Labels{
+						"__alert_rule_namespace_uid__": "test_namespace_uid",
+						"__alert_rule_uid__":           "test_alert_rule_uid_2",
+						"alertname":                    "test_title",
+						"label":                        "test",
+						"instance_label":               "test",
+					},
+					Values:      make(map[string]float64),
+					State:       eval.Pending,
+					StateReason: models.StateReasonError,
+					Error: expr.QueryError{
+						RefID: "A",
+						Err:   errors.New("this is an error"),
+					},
+					Results: []state.Evaluation{
+						{
+							EvaluationTime:  evaluationTime.Add(30 * time.Second),
+							EvaluationState: eval.Error,
+							Values:          make(map[string]*float64),
+						},
+					},
+					StartsAt:           evaluationTime.Add(20 * time.Second),
+					EndsAt:             evaluationTime.Add(20 * time.Second).Add(state.ResendDelay * 3),
+					LastEvaluationTime: evaluationTime.Add(30 * time.Second),
+					EvaluationDuration: evaluationDuration,
+					Annotations:        map[string]string{"annotation": "test"},
+				},
+			},
+		},
+		{
+			desc: "pending error -> pending alerting when result is Error and ExecErrorState is Error with For and ForError set",
+			alertRule: &models.AlertRule{
+				OrgID:           1,
+				Title:           "test_title",
+				UID:             "test_alert_rule_uid_2",
+				NamespaceUID:    "test_namespace_uid",
+				Annotations:     map[string]string{"annotation": "test"},
+				Labels:          map[string]string{"label": "test"},
+				IntervalSeconds: 10,
+				For:             20 * time.Second,
+				ForError:        10 * time.Second,
+				ExecErrState:    models.ErrorErrState,
+			},
+			evalResults: []eval.Results{
+				{
+					eval.Result{
+						Instance: data.Labels{"instance_label": "test"},
+						State:    eval.Error,
+						Error: expr.QueryError{
+							RefID: "A",
+							Err:   errors.New("this is an error"),
+						},
+						EvaluatedAt:        evaluationTime,
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+				{
+					eval.Result{
+						Instance:           data.Labels{"instance_label": "test"},
+						State:              eval.Alerting,
+						EvaluatedAt:        evaluationTime.Add(20 * time.Second),
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+				{
+					eval.Result{
+						Instance:           data.Labels{"instance_label": "test"},
+						State:              eval.Alerting,
+						EvaluatedAt:        evaluationTime.Add(30 * time.Second),
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+			},
+			expectedAnnotations: 2,
+			expectedStates: map[string]*state.State{
+				`[["__alert_rule_namespace_uid__","test_namespace_uid"],["__alert_rule_uid__","test_alert_rule_uid_2"],["alertname","test_title"],["instance_label","test"],["label","test"]]`: {
+					AlertRuleUID: "test_alert_rule_uid_2",
+					OrgID:        1,
+					CacheID:      `[["__alert_rule_namespace_uid__","test_namespace_uid"],["__alert_rule_uid__","test_alert_rule_uid_2"],["alertname","test_title"],["instance_label","test"],["label","test"]]`,
+					Labels: data.Labels{
+						"__alert_rule_namespace_uid__": "test_namespace_uid",
+						"__alert_rule_uid__":           "test_alert_rule_uid_2",
+						"alertname":                    "test_title",
+						"label":                        "test",
+						"instance_label":               "test",
+					},
+					Values: make(map[string]float64),
+					State:  eval.Pending,
+					Results: []state.Evaluation{
+						{
+							EvaluationTime:  evaluationTime.Add(20 * time.Second),
+							EvaluationState: eval.Alerting,
+							Values:          make(map[string]*float64),
+						},
+						{
+							EvaluationTime:  evaluationTime.Add(30 * time.Second),
+							EvaluationState: eval.Alerting,
+							Values:          make(map[string]*float64),
+						},
+					},
+					StartsAt:           evaluationTime.Add(20 * time.Second),
+					EndsAt:             evaluationTime.Add(20 * time.Second).Add(state.ResendDelay * 3),
+					LastEvaluationTime: evaluationTime.Add(30 * time.Second),
+					EvaluationDuration: evaluationDuration,
+					Annotations:        map[string]string{"annotation": "test"},
+				},
+			},
+		},
+		{
+			desc: "normal -> pending -> alerting -> pending error -> error -> pending -> alerting when result is Error and ExecErrorState is Error with For and ForError set",
+			alertRule: &models.AlertRule{
+				OrgID:           1,
+				Title:           "test_title",
+				UID:             "test_alert_rule_uid_2",
+				NamespaceUID:    "test_namespace_uid",
+				Annotations:     map[string]string{"annotation": "test"},
+				Labels:          map[string]string{"label": "test"},
+				IntervalSeconds: 10,
+				For:             20 * time.Second,
+				ForError:        20 * time.Second,
+				ExecErrState:    models.ErrorErrState,
+			},
+			evalResults: []eval.Results{
+				{
+					eval.Result{
+						Instance:           data.Labels{"instance_label": "test"},
+						State:              eval.Normal,
+						EvaluatedAt:        evaluationTime,
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+				{
+					eval.Result{
+						Instance:           data.Labels{"instance_label": "test"},
+						State:              eval.Alerting,
+						EvaluatedAt:        evaluationTime.Add(10 * time.Second),
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+				{
+					eval.Result{
+						Instance:           data.Labels{"instance_label": "test"},
+						State:              eval.Alerting,
+						EvaluatedAt:        evaluationTime.Add(20 * time.Second),
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+				{
+					eval.Result{
+						Instance:           data.Labels{"instance_label": "test"},
+						State:              eval.Alerting,
+						EvaluatedAt:        evaluationTime.Add(30 * time.Second),
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+				{
+					eval.Result{
+						Instance: data.Labels{"instance_label": "test"},
+						State:    eval.Error,
+						Error: expr.QueryError{
+							RefID: "A",
+							Err:   errors.New("this is an error"),
+						},
+						EvaluatedAt:        evaluationTime.Add(40 * time.Second),
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+				{
+					eval.Result{
+						Instance: data.Labels{"instance_label": "test"},
+						State:    eval.Error,
+						Error: expr.QueryError{
+							RefID: "A",
+							Err:   errors.New("this is an error"),
+						},
+						EvaluatedAt:        evaluationTime.Add(50 * time.Second),
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+				{
+					eval.Result{
+						Instance: data.Labels{"instance_label": "test"},
+						State:    eval.Error,
+						Error: expr.QueryError{
+							RefID: "A",
+							Err:   errors.New("this is an error"),
+						},
+						EvaluatedAt:        evaluationTime.Add(60 * time.Second),
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+				{
+					eval.Result{
+						Instance:           data.Labels{"instance_label": "test"},
+						State:              eval.Alerting,
+						EvaluatedAt:        evaluationTime.Add(70 * time.Second),
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+				{
+					eval.Result{
+						Instance:           data.Labels{"instance_label": "test"},
+						State:              eval.Alerting,
+						EvaluatedAt:        evaluationTime.Add(80 * time.Second),
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+				{
+					eval.Result{
+						Instance:           data.Labels{"instance_label": "test"},
+						State:              eval.Alerting,
+						EvaluatedAt:        evaluationTime.Add(90 * time.Second),
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+			},
+			expectedAnnotations: 6,
+			expectedStates: map[string]*state.State{
+				`[["__alert_rule_namespace_uid__","test_namespace_uid"],["__alert_rule_uid__","test_alert_rule_uid_2"],["alertname","test_title"],["instance_label","test"],["label","test"]]`: {
+					AlertRuleUID: "test_alert_rule_uid_2",
+					OrgID:        1,
+					CacheID:      `[["__alert_rule_namespace_uid__","test_namespace_uid"],["__alert_rule_uid__","test_alert_rule_uid_2"],["alertname","test_title"],["instance_label","test"],["label","test"]]`,
+					Labels: data.Labels{
+						"__alert_rule_namespace_uid__": "test_namespace_uid",
+						"__alert_rule_uid__":           "test_alert_rule_uid_2",
+						"alertname":                    "test_title",
+						"label":                        "test",
+						"instance_label":               "test",
+					},
+					Values: make(map[string]float64),
+					State:  eval.Alerting,
+					Results: []state.Evaluation{
+						{
+							EvaluationTime:  evaluationTime.Add(80 * time.Second),
+							EvaluationState: eval.Alerting,
+							Values:          make(map[string]*float64),
+						},
+						{
+							EvaluationTime:  evaluationTime.Add(90 * time.Second),
+							EvaluationState: eval.Alerting,
+							Values:          make(map[string]*float64),
+						},
+					},
+					StartsAt:           evaluationTime.Add(90 * time.Second),
+					EndsAt:             evaluationTime.Add(90 * time.Second).Add(state.ResendDelay * 3),
+					LastEvaluationTime: evaluationTime.Add(90 * time.Second),
 					EvaluationDuration: evaluationDuration,
 					Annotations:        map[string]string{"annotation": "test"},
 				},

--- a/pkg/services/sqlstore/migrations/ualert/tables.go
+++ b/pkg/services/sqlstore/migrations/ualert/tables.go
@@ -295,6 +295,16 @@ func addAlertRuleMigrations(mg *migrator.Migrator, defaultIntervalSeconds int64)
 	mg.AddMigration("fix is_paused column for alert_rule table", migrator.NewRawSQLMigration("").
 		Postgres(`ALTER TABLE alert_rule ALTER COLUMN is_paused SET DEFAULT false;
 UPDATE alert_rule SET is_paused = false;`))
+
+	mg.AddMigration("add for_error column to alert_rule table", migrator.NewAddColumnMigration(
+		alertRule,
+		&migrator.Column{
+			Name:     "for_error",
+			Type:     migrator.DB_BigInt,
+			Nullable: false,
+			Default:  "0",
+		},
+	))
 }
 
 func addAlertRuleVersionMigrations(mg *migrator.Migrator) {
@@ -364,6 +374,16 @@ func addAlertRuleVersionMigrations(mg *migrator.Migrator) {
 	mg.AddMigration("fix is_paused column for alert_rule_version table", migrator.NewRawSQLMigration("").
 		Postgres(`ALTER TABLE alert_rule_version ALTER COLUMN is_paused SET DEFAULT false;
 UPDATE alert_rule_version SET is_paused = false;`))
+
+	mg.AddMigration("add for_error column to alert_rule_version table", migrator.NewAddColumnMigration(
+		alertRuleVersion,
+		&migrator.Column{
+			Name:     "for_error",
+			Type:     migrator.DB_BigInt,
+			Nullable: false,
+			Default:  "0",
+		},
+	))
 }
 
 func addAlertmanagerConfigMigrations(mg *migrator.Migrator) {

--- a/pkg/services/sqlstore/migrations/ualert/tables.go
+++ b/pkg/services/sqlstore/migrations/ualert/tables.go
@@ -291,6 +291,16 @@ func addAlertRuleMigrations(mg *migrator.Migrator, defaultIntervalSeconds int64)
 		},
 	))
 
+	mg.AddMigration("add for_no_data column to alert_rule table", migrator.NewAddColumnMigration(
+		alertRule,
+		&migrator.Column{
+			Name:     "for_no_data",
+			Type:     migrator.DB_BigInt,
+			Nullable: false,
+			Default:  "0",
+		},
+	))
+
 	// This migration fixes a bug where "false" for the default value created a column with default "true" in PostgreSQL databases
 	mg.AddMigration("fix is_paused column for alert_rule table", migrator.NewRawSQLMigration("").
 		Postgres(`ALTER TABLE alert_rule ALTER COLUMN is_paused SET DEFAULT false;
@@ -365,6 +375,16 @@ func addAlertRuleVersionMigrations(mg *migrator.Migrator) {
 		&migrator.Column{
 			Name:     "is_paused",
 			Type:     migrator.DB_Bool,
+			Nullable: false,
+			Default:  "0",
+		},
+	))
+
+	mg.AddMigration("add for_no_data column to alert_rule_version table", migrator.NewAddColumnMigration(
+		alertRuleVersion,
+		&migrator.Column{
+			Name:     "for_no_data",
+			Type:     migrator.DB_BigInt,
 			Nullable: false,
 			Default:  "0",
 		},


### PR DESCRIPTION
**What is this feature?**

This feature adds a For-like duration field (called `for_no_data`) for the nodata state when it is handled as a nodata.

It adds a time window where NoData can occur without entering the NoData state or sending any notifications. Instead, they will enter a pending state until the `for_no_data` duration is reached.

**Why do we need this feature?**

Currently, we don't have a way to have a wait window on NoData state.

**Who is this feature for?**

All users.

**Which issue(s) does this PR fix?**:

Contributes to https://github.com/grafana/grafana/issues/55320

**Special notes for your reviewer**:

How does this work? It uses The StateReason field to differentiate between pending states:

- Pending for Alerting
- Pending for Error

_Testing migration_

_PostgreSQL_

Migration log.

```
INFO [03-14|16:20:33] Executing migration                      logger=migrator id="add for_no_data column to alert_rule table"
INFO [03-14|16:20:33] Executing migration                      logger=migrator id="add for_no_data column to alert_rule_version table"
```

`alert_rule` table description and default for the column.

```
grafana=# \d alert_rule
                                           Table "public.alert_rule"
      Column      |            Type             | Collation | Nullable |                Default                 
------------------+-----------------------------+-----------+----------+----------------------------------------
 id               | integer                     |           | not null | nextval('alert_rule_id_seq'::regclass)
 org_id           | bigint                      |           | not null | 
 title            | character varying(190)      |           | not null | 
 condition        | character varying(190)      |           | not null | 
 data             | text                        |           | not null | 
 updated          | timestamp without time zone |           | not null | 
 interval_seconds | bigint                      |           | not null | 60
 version          | integer                     |           | not null | 0
 uid              | character varying(40)       |           | not null | 0
 namespace_uid    | character varying(40)       |           | not null | 
 rule_group       | character varying(190)      |           | not null | 
 no_data_state    | character varying(15)       |           | not null | 'NoData'::character varying
 exec_err_state   | character varying(15)       |           | not null | 'Alerting'::character varying
 for              | bigint                      |           | not null | 0
 annotations      | text                        |           |          | 
 labels           | text                        |           |          | 
 dashboard_uid    | character varying(40)       |           |          | 
 panel_id         | bigint                      |           |          | 
 rule_group_idx   | integer                     |           | not null | 1
 is_paused        | boolean                     |           | not null | false
 for_error        | bigint                      |           | not null | 0
 for_no_data      | bigint                      |           | not null | 0
Indexes:
    "alert_rule_pkey" PRIMARY KEY, btree (id)
    "IDX_alert_rule_org_id_dashboard_uid_panel_id" btree (org_id, dashboard_uid, panel_id)
    "IDX_alert_rule_org_id_namespace_uid_rule_group" btree (org_id, namespace_uid, rule_group)
    "UQE_alert_rule_org_id_namespace_uid_title" UNIQUE, btree (org_id, namespace_uid, title)
    "UQE_alert_rule_org_id_uid" UNIQUE, btree (org_id, uid)

grafana=# SELECT for_no_data FROM alert_rule;
 for_no_data 
-------------
           0
(1 row)
```

`alert_rule_version` table description and default for the column.

```
grafana=# \d alert_rule_version;
                                            Table "public.alert_rule_version"
       Column       |            Type             | Collation | Nullable |                    Default                     
--------------------+-----------------------------+-----------+----------+------------------------------------------------
 id                 | integer                     |           | not null | nextval('alert_rule_version_id_seq'::regclass)
 rule_org_id        | bigint                      |           | not null | 
 rule_uid           | character varying(40)       |           | not null | 0
 rule_namespace_uid | character varying(40)       |           | not null | 
 rule_group         | character varying(190)      |           | not null | 
 parent_version     | integer                     |           | not null | 
 restored_from      | integer                     |           | not null | 
 version            | integer                     |           | not null | 
 created            | timestamp without time zone |           | not null | 
 title              | character varying(190)      |           | not null | 
 condition          | character varying(190)      |           | not null | 
 data               | text                        |           | not null | 
 interval_seconds   | bigint                      |           | not null | 
 no_data_state      | character varying(15)       |           | not null | 'NoData'::character varying
 exec_err_state     | character varying(15)       |           | not null | 'Alerting'::character varying
 for                | bigint                      |           | not null | 0
 annotations        | text                        |           |          | 
 labels             | text                        |           |          | 
 rule_group_idx     | integer                     |           | not null | 1
 is_paused          | boolean                     |           | not null | false
 for_error          | bigint                      |           | not null | 0
 for_no_data        | bigint                      |           | not null | 0
Indexes:
    "alert_rule_version_pkey" PRIMARY KEY, btree (id)
    "IDX_alert_rule_version_rule_org_id_rule_namespace_uid_rule_grou" btree (rule_org_id, rule_namespace_uid, rule_group)
    "UQE_alert_rule_version_rule_org_id_rule_uid_version" UNIQUE, btree (rule_org_id, rule_uid, version)

grafana=# SELECT for_no_data FROM alert_rule_version;
 for_no_data 
-------------
           0
(1 row)
```

_MySQL_

Migration log.

```
INFO [03-15|11:18:14] Executing migration                      logger=migrator id="add for_no_data column to alert_rule table"
INFO [03-15|11:18:14] Executing migration                      logger=migrator id="add for_no_data column to alert_rule_version table"
```

`alert_rule` table description and default for the column.

```
mysql> EXPLAIN alert_rule;
+------------------+--------------+------+-----+----------+----------------+
| Field            | Type         | Null | Key | Default  | Extra          |
+------------------+--------------+------+-----+----------+----------------+
| id               | bigint       | NO   | PRI | NULL     | auto_increment |
| org_id           | bigint       | NO   | MUL | NULL     |                |
| title            | varchar(190) | NO   |     | NULL     |                |
| condition        | varchar(190) | NO   |     | NULL     |                |
| data             | mediumtext   | YES  |     | NULL     |                |
| updated          | datetime     | NO   |     | NULL     |                |
| interval_seconds | bigint       | NO   |     | 60       |                |
| version          | int          | NO   |     | 0        |                |
| uid              | varchar(40)  | NO   |     | 0        |                |
| namespace_uid    | varchar(40)  | NO   |     | NULL     |                |
| rule_group       | varchar(190) | NO   |     | NULL     |                |
| no_data_state    | varchar(15)  | NO   |     | NoData   |                |
| exec_err_state   | varchar(15)  | NO   |     | Alerting |                |
| for              | bigint       | NO   |     | 0        |                |
| annotations      | text         | YES  |     | NULL     |                |
| labels           | text         | YES  |     | NULL     |                |
| dashboard_uid    | varchar(40)  | YES  |     | NULL     |                |
| panel_id         | bigint       | YES  |     | NULL     |                |
| rule_group_idx   | int          | NO   |     | 1        |                |
| is_paused        | tinyint(1)   | NO   |     | 0        |                |
| for_error        | bigint       | NO   |     | 0        |                |
| for_no_data      | bigint       | NO   |     | 0        |                |
+------------------+--------------+------+-----+----------+----------------+
22 rows in set (0.00 sec)

mysql> SELECT for_no_data FROM alert_rule;
+-------------+
| for_no_data |
+-------------+
|           0 |
+-------------+
1 row in set (0.01 sec)
```

`alert_rule_version` table description and default for the column.

```
mysql> EXPLAIN alert_rule_version;
+--------------------+--------------+------+-----+----------+----------------+
| Field              | Type         | Null | Key | Default  | Extra          |
+--------------------+--------------+------+-----+----------+----------------+
| id                 | bigint       | NO   | PRI | NULL     | auto_increment |
| rule_org_id        | bigint       | NO   | MUL | NULL     |                |
| rule_uid           | varchar(40)  | NO   |     | 0        |                |
| rule_namespace_uid | varchar(40)  | NO   |     | NULL     |                |
| rule_group         | varchar(190) | NO   |     | NULL     |                |
| parent_version     | int          | NO   |     | NULL     |                |
| restored_from      | int          | NO   |     | NULL     |                |
| version            | int          | NO   |     | NULL     |                |
| created            | datetime     | NO   |     | NULL     |                |
| title              | varchar(190) | NO   |     | NULL     |                |
| condition          | varchar(190) | NO   |     | NULL     |                |
| data               | mediumtext   | YES  |     | NULL     |                |
| interval_seconds   | bigint       | NO   |     | NULL     |                |
| no_data_state      | varchar(15)  | NO   |     | NoData   |                |
| exec_err_state     | varchar(15)  | NO   |     | Alerting |                |
| for                | bigint       | NO   |     | 0        |                |
| annotations        | text         | YES  |     | NULL     |                |
| labels             | text         | YES  |     | NULL     |                |
| rule_group_idx     | int          | NO   |     | 1        |                |
| is_paused          | tinyint(1)   | NO   |     | 0        |                |
| for_error          | bigint       | NO   |     | 0        |                |
| for_no_data        | bigint       | NO   |     | 0        |                |
+--------------------+--------------+------+-----+----------+----------------+
22 rows in set (0.03 sec)

mysql> SELECT for_no_data FROM alert_rule_version;
+-------------+
| for_no_data |
+-------------+
|           0 |
+-------------+
1 row in set (0.01 sec)
```

_sqlite3_

Migration log.

```
INFO [03-15|11:25:12] Executing migration                      logger=migrator id="add for_no_data column to alert_rule table"
INFO [03-15|11:25:12] Executing migration                      logger=migrator id="add for_no_data column to alert_rule_version table"
```

`alert_rule` table description and default for the column.

```
sqlite> .schema alert_rule
CREATE TABLE `alert_rule` (
`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL
, `org_id` INTEGER NOT NULL
, `title` TEXT NOT NULL
, `condition` TEXT NOT NULL
, `data` TEXT NOT NULL
, `updated` DATETIME NOT NULL
, `interval_seconds` INTEGER NOT NULL DEFAULT 60
, `version` INTEGER NOT NULL DEFAULT 0
, `uid` TEXT NOT NULL DEFAULT 0
, `namespace_uid` TEXT NOT NULL
, `rule_group` TEXT NOT NULL
, `no_data_state` TEXT NOT NULL DEFAULT 'NoData'
, `exec_err_state` TEXT NOT NULL DEFAULT 'Alerting'
, `for` INTEGER NOT NULL DEFAULT 0, `annotations` TEXT NULL, `labels` TEXT NULL, `dashboard_uid` TEXT NULL, `panel_id` INTEGER NULL, `rule_group_idx` INTEGER NOT NULL DEFAULT 1, `is_paused` INTEGER NOT NULL DEFAULT 0, `for_error` INTEGER NOT NULL DEFAULT 0, `for_no_data` INTEGER NOT NULL DEFAULT 0);
CREATE UNIQUE INDEX `UQE_alert_rule_org_id_uid` ON `alert_rule` (`org_id`,`uid`);
CREATE INDEX `IDX_alert_rule_org_id_namespace_uid_rule_group` ON `alert_rule` (`org_id`,`namespace_uid`,`rule_group`);
CREATE UNIQUE INDEX `UQE_alert_rule_org_id_namespace_uid_title` ON `alert_rule` (`org_id`,`namespace_uid`,`title`);
CREATE INDEX `IDX_alert_rule_org_id_dashboard_uid_panel_id` ON `alert_rule` (`org_id`,`dashboard_uid`,`panel_id`);

sqlite> SELECT for_no_data FROM alert_rule;
0
```

`alert_rule_version` table description and default for the column.

```
sqlite> .schema alert_rule_version
CREATE TABLE `alert_rule_version` (
`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL
, `rule_org_id` INTEGER NOT NULL
, `rule_uid` TEXT NOT NULL DEFAULT 0
, `rule_namespace_uid` TEXT NOT NULL
, `rule_group` TEXT NOT NULL
, `parent_version` INTEGER NOT NULL
, `restored_from` INTEGER NOT NULL
, `version` INTEGER NOT NULL
, `created` DATETIME NOT NULL
, `title` TEXT NOT NULL
, `condition` TEXT NOT NULL
, `data` TEXT NOT NULL
, `interval_seconds` INTEGER NOT NULL
, `no_data_state` TEXT NOT NULL DEFAULT 'NoData'
, `exec_err_state` TEXT NOT NULL DEFAULT 'Alerting'
, `for` INTEGER NOT NULL DEFAULT 0, `annotations` TEXT NULL, `labels` TEXT NULL, `rule_group_idx` INTEGER NOT NULL DEFAULT 1, `is_paused` INTEGER NOT NULL DEFAULT 0, `for_error` INTEGER NOT NULL DEFAULT 0, `for_no_data` INTEGER NOT NULL DEFAULT 0);
CREATE UNIQUE INDEX `UQE_alert_rule_version_rule_org_id_rule_uid_version` ON `alert_rule_version` (`rule_org_id`,`rule_uid`,`version`);
CREATE INDEX `IDX_alert_rule_version_rule_org_id_rule_namespace_uid_rule_group` ON `alert_rule_version` (`rule_org_id`,`rule_namespace_uid`,`rule_group`);

sqlite> SELECT for_no_data FROM alert_rule_version;
0
```