### PR TITLE
Docs: api keys

### DIFF
--- a/docs/sources/auth/planning/index.md
+++ b/docs/sources/auth/planning/index.md
@@ -122,6 +122,10 @@ Service account access tokens inherit permissions from the service account.
 
 ### 🚧 API keys
 
+Grafana API keys can be used to interact with data sources via HTTP APIs. API keys can have a well-defined and limited scope to resources with the help of [Roles].
+
+> **Note:** If you use Grafana v8.5 or newer, use service accounts instead of API keys. For more information, refer to [Grafana service accounts]({{< relref "../service-accounts/" >}}).
+
 ## How to work with roles?
 
 Roles are used to regulate which resources each user or service account can access within Grafana and what actions they're allowed to carry out.

--- a/docs/sources/auth/planning/index.md
+++ b/docs/sources/auth/planning/index.md
@@ -122,9 +122,9 @@ Service account access tokens inherit permissions from the service account.
 
 ### 🚧 API keys
 
-Grafana API keys can be used to interact with data sources via HTTP APIs. API keys can have a well-defined and limited scope to resources with the help of [Roles].
+> **Note:** If you use Grafana v8.5 or newer, you should use service accounts instead of API keys. API keys will be deprecated in the near future. For more information, refer to [Grafana service accounts]({{< relref "../service-accounts/" >}}).
 
-> **Note:** If you use Grafana v8.5 or newer, use service accounts instead of API keys. For more information, refer to [Grafana service accounts]({{< relref "../service-accounts/" >}}).
+You can use Grafana API keys to interact with data sources via HTTP APIs. API keys can have a well-defined and limited scope to resources with the help of [Roles].
 
 ## How to work with roles?
 

--- a/docs/sources/auth/planning/index.md
+++ b/docs/sources/auth/planning/index.md
@@ -120,7 +120,7 @@ Service account access tokens inherit permissions from the service account.
 
 ### 🚧 Personal access tokens
 
-### 🚧 API keys
+### API keys
 
 > **Note:** If you use Grafana v8.5 or newer, you should use service accounts instead of API keys. API keys will be deprecated in the near future. For more information, refer to [Grafana service accounts]({{< relref "../service-accounts/" >}}).
 


### PR DESCRIPTION
**What is this feature?**

Adds planning references for API keys.

**Why do we need this feature?**

Docs revamp work

**Who is this feature for?**

It's a part of a larger authNZ doc refactor.