### PR TITLE
loki: query chunking: better error handling

### DIFF
--- a/public/app/plugins/datasource/loki/querySplitting.test.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.test.ts
@@ -42,7 +42,7 @@ describe('runPartitionedQueries()', () => {
       .spyOn(datasource, 'runQuery')
       .mockReturnValue(of({ state: LoadingState.Error, error: { refId: 'A', message: 'Error' }, data: [] }));
     await expect(runPartitionedQueries(datasource, request)).toEmitValuesWith((values) => {
-      expect(values).toEqual([{ refId: 'A', message: 'Error' }]);
+      expect(values).toEqual([{ error: { refId: 'A', message: 'Error' }, data: [], state: LoadingState.Streaming }]);
     });
   });
 

--- a/public/app/plugins/datasource/loki/querySplitting.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.ts
@@ -7,7 +7,7 @@ import { LoadingState } from '@grafana/schema';
 import { LokiDatasource } from './datasource';
 import { getRangeChunks as getLogsRangeChunks } from './logsTimeSplit';
 import { getRangeChunks as getMetricRangeChunks } from './metricTimeSplit';
-import { combineResponses, isLogsQuery, responseHasErrors } from './queryUtils';
+import { combineResponses, isLogsQuery } from './queryUtils';
 import { LokiQuery, LokiQueryType } from './types';
 
 declare global {

--- a/public/app/plugins/datasource/loki/querySplitting.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.ts
@@ -132,7 +132,7 @@ export function runGroupedQueries(datasource: LokiDatasource, requests: LokiGrou
       .subscribe({
         next: (partialResponse) => {
           mergedResponse = combineResponses(mergedResponse, partialResponse);
-          if (responseHasErrors(mergedResponse)) {
+          if ((mergedResponse.errors ?? []).length > 0 || mergedResponse.error != null) {
             shouldStop = true;
           }
         },

--- a/public/app/plugins/datasource/loki/queryUtils.test.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.test.ts
@@ -476,38 +476,73 @@ describe('combineResponses', () => {
     expect(combineResponses(null, responseB)).not.toBe(responseB);
   });
 
-  it('does not combine when first param has errors', () => {
+  it('combine when first param has errors', () => {
     const { metricFrameA, metricFrameB } = getMockFrames();
+    const errorA = {
+      message: 'errorA',
+    };
     const responseA: DataQueryResponse = {
-      data: [metricFrameA, metricFrameA, metricFrameA],
-      error: {
-        message: 'errorA',
-      },
+      data: [metricFrameA],
+      error: errorA,
+      errors: [errorA],
     };
     const responseB: DataQueryResponse = {
-      data: [metricFrameB, metricFrameB],
+      data: [metricFrameB],
     };
 
     const combined = combineResponses(responseA, responseB);
-    expect(combined.data).toHaveLength(3);
+    expect(combined.data[0].length).toBe(4);
     expect(combined.error?.message).toBe('errorA');
+    expect(combined.errors).toHaveLength(1);
+    expect(combined.errors?.[0]?.message).toBe('errorA');
   });
 
-  it('does not combine when second param has errors', () => {
+  it('combine when second param has errors', () => {
     const { metricFrameA, metricFrameB } = getMockFrames();
     const responseA: DataQueryResponse = {
-      data: [metricFrameA, metricFrameA, metricFrameA],
+      data: [metricFrameA],
+    };
+    const errorB = {
+      message: 'errorB',
     };
     const responseB: DataQueryResponse = {
-      data: [metricFrameB, metricFrameB],
-      error: {
-        message: 'errorB',
-      },
+      data: [metricFrameB],
+      error: errorB,
+      errors: [errorB],
     };
 
     const combined = combineResponses(responseA, responseB);
-    expect(combined.data).toHaveLength(2);
+    expect(combined.data[0].length).toBe(4);
     expect(combined.error?.message).toBe('errorB');
+    expect(combined.errors).toHaveLength(1);
+    expect(combined.errors?.[0]?.message).toBe('errorB');
+  });
+
+  it('combine when both params have errors', () => {
+    const { metricFrameA, metricFrameB } = getMockFrames();
+    const errorA = {
+      message: 'errorA',
+    };
+    const errorB = {
+      message: 'errorB',
+    };
+    const responseA: DataQueryResponse = {
+      data: [metricFrameA],
+      error: errorA,
+      errors: [errorA],
+    };
+    const responseB: DataQueryResponse = {
+      data: [metricFrameB],
+      error: errorB,
+      errors: [errorB],
+    };
+
+    const combined = combineResponses(responseA, responseB);
+    expect(combined.data[0].length).toBe(4);
+    expect(combined.error?.message).toBe('errorA');
+    expect(combined.errors).toHaveLength(2);
+    expect(combined.errors?.[0]?.message).toBe('errorA');
+    expect(combined.errors?.[1]?.message).toBe('errorB');
   });
 
   describe('combine stats', () => {

--- a/public/app/plugins/datasource/loki/queryUtils.test.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.test.ts
@@ -476,6 +476,40 @@ describe('combineResponses', () => {
     expect(combineResponses(null, responseB)).not.toBe(responseB);
   });
 
+  it('does not combine when first param has errors', () => {
+    const { metricFrameA, metricFrameB } = getMockFrames();
+    const responseA: DataQueryResponse = {
+      data: [metricFrameA, metricFrameA, metricFrameA],
+      error: {
+        message: 'errorA',
+      },
+    };
+    const responseB: DataQueryResponse = {
+      data: [metricFrameB, metricFrameB],
+    };
+
+    const combined = combineResponses(responseA, responseB);
+    expect(combined.data).toHaveLength(3);
+    expect(combined.error?.message).toBe('errorA');
+  });
+
+  it('does not combine when second param has errors', () => {
+    const { metricFrameA, metricFrameB } = getMockFrames();
+    const responseA: DataQueryResponse = {
+      data: [metricFrameA, metricFrameA, metricFrameA],
+    };
+    const responseB: DataQueryResponse = {
+      data: [metricFrameB, metricFrameB],
+      error: {
+        message: 'errorB',
+      },
+    };
+
+    const combined = combineResponses(responseA, responseB);
+    expect(combined.data).toHaveLength(2);
+    expect(combined.error?.message).toBe('errorB');
+  });
+
   describe('combine stats', () => {
     const { metricFrameA } = getMockFrames();
     const makeResponse = (stats?: QueryResultMetaStat[]): DataQueryResponse => ({

--- a/public/app/plugins/datasource/loki/queryUtils.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.ts
@@ -335,7 +335,7 @@ export function combineResponses(currentResult: DataQueryResponse | null, newRes
   // if either current or new result
   // has errors, we use that result,
   // and we do not merge anything into them.
-  // (we do not want to merge responses-with-errors
+  // (we do not want to merge responses with errors
   // with responses-without-errors)
 
   if (responseHasErrors(currentResult)) {

--- a/public/app/plugins/datasource/loki/queryUtils.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.ts
@@ -336,7 +336,7 @@ export function combineResponses(currentResult: DataQueryResponse | null, newRes
   // has errors, we use that result,
   // and we do not merge anything into them.
   // (we do not want to merge responses with errors
-  // with responses-without-errors)
+  // with responses without errors)
 
   if (responseHasErrors(currentResult)) {
     return currentResult;

--- a/public/app/plugins/datasource/loki/queryUtils.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.ts
@@ -321,8 +321,28 @@ function shouldCombine(frame1: DataFrame, frame2: DataFrame): boolean {
   return frame1.name === frame2.name;
 }
 
+export function responseHasErrors(response: DataQueryResponse): boolean {
+  return (response.errors ?? []).length > 0 || response.error != null;
+}
+
 export function combineResponses(currentResult: DataQueryResponse | null, newResult: DataQueryResponse) {
   if (!currentResult) {
+    return cloneQueryResponse(newResult);
+  }
+
+  // we need to handle responses with errors.
+  // our current approach is very conservative,
+  // if either current or new result
+  // has errors, we use that result,
+  // and we do not merge anything into them.
+  // (we do not want to merge responses-with-errors
+  // with responses-without-errors)
+
+  if (responseHasErrors(currentResult)) {
+    return currentResult;
+  }
+
+  if (responseHasErrors(newResult)) {
     return cloneQueryResponse(newResult);
   }
 

--- a/public/app/plugins/datasource/loki/queryUtils.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.ts
@@ -321,10 +321,6 @@ function shouldCombine(frame1: DataFrame, frame2: DataFrame): boolean {
   return frame1.name === frame2.name;
 }
 
-export function responseHasErrors(response: DataQueryResponse): boolean {
-  return (response.errors ?? []).length > 0 || response.error != null;
-}
-
 export function combineResponses(currentResult: DataQueryResponse | null, newResult: DataQueryResponse) {
   if (!currentResult) {
     return cloneQueryResponse(newResult);


### PR DESCRIPTION
while working something different, i've had a problem with Loki query chunking. the problem was caused by this code:
```js
next: (partialResponse) => {
          if (partialResponse.error) {
            subscriber.error(partialResponse.error);
          }
        ...
        },
```

the problem here is that we take data that is coming in the `next` mode (meaning we are in the "success" branch of rxjs processing), and emit the data in `error` of the main subscription  (meaning we put it in the "failed" branch of rxjs processing).

this looses some data from the `partialResponse`.

the solution is to not special case this situation, to keep submitting the data in the `subscriber.next`.

but the problem becomes: we had an error... now:
question1: should we continue with the following chunks?
question2: should we combine this response-with-errors with our already received respones-without-errors?

imagine we need to run a Loki query, we calculated 5 chunks.
we ran two chunks, both succeeded.
now we run the third chunk, it fails.
here are our options:
1. we do not run the remaining two chunks, and the result of the whole operation will be the third failed chunk only 
2. we do not run the remaining two chunks, and the result of the whole operation will be the combined response of the first 3 chunks (meaning we take the dataframes from all 3 chunks, and the errors from the failed third chunk to create a response) (this is what this PR does)
3. we continue running the two remaining chunks, and the result of the whole operation will be the combined response of all 5 chunks (meaning we take the dataframes from all 5 chunks, and the errors from the failed third chunk to create the response)

this PR does [2] currently. [1] could be OK too, more robust but less user-friendly.
i do not recommend approach [3], because ... imagine that you calculate 5 chunks, and run a query with a syntax error. now we will run that query 5 times, always getting the syntax error 😄 


to see this in action, i recommend applying this diff to `loki.go` 's `queryData` function, around line `178`:
```diff
                if err != nil {
                        queryRes.Error = err
                } else {
                        queryRes.Frames = frames
+                       if rand.Float64() > 0.5 {
+                               queryRes.Error = fmt.Errorf("simulated error happened")
+                       }
                }

                result.Responses[query.RefID] = queryRes
```

and then run metric logql queries which make multiple chunks. you can observe them how it behaves.