### PR TITLE
Prometheus: Metric encyclopedia modal redesign

### DIFF
--- a/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.test.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.test.tsx
@@ -10,7 +10,7 @@ import { EmptyLanguageProviderMock } from '../../language_provider.mock';
 import { PromOptions } from '../../types';
 import { PromVisualQuery } from '../types';
 
-import { MetricEncyclopediaModal, testIds, placeholders } from './MetricEncyclopediaModal';
+import { MetricEncyclopediaModal, testIds } from './MetricEncyclopediaModal';
 
 // don't care about interaction tracking in our unit tests
 jest.mock('@grafana/runtime', () => ({
@@ -96,7 +96,7 @@ describe('MetricEncyclopediaModal', () => {
     setup(defaultQuery, listOfMetrics);
 
     await waitFor(() => {
-      const selectType = screen.getByText(placeholders.type);
+      const selectType = screen.getByText('Filter by type');
       expect(selectType).toBeInTheDocument();
     });
   });
@@ -119,7 +119,7 @@ describe('MetricEncyclopediaModal', () => {
     setup(defaultQuery, listOfMetrics);
 
     await waitFor(() => {
-      const selectType = screen.getByText(placeholders.variables);
+      const selectType = screen.getByText('Select template variables');
       expect(selectType).toBeInTheDocument();
     });
   });

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.tsx
@@ -419,12 +419,6 @@ export const MetricEncyclopediaModal = (props: Props) => {
       aria-label="Metric Encyclopedia"
       className={styles.modal}
     >
-      {isLoading && (
-        <div className={styles.loadingSpinner}>
-          <Spinner /> Loading metrics...
-        </div>
-      )}
-
       <div className={styles.inputWrapper}>
         <div className={cx(styles.inputItem, styles.inputItemFirst)}>
           <EditorField label="Search metrics">
@@ -541,7 +535,8 @@ export const MetricEncyclopediaModal = (props: Props) => {
       <h4 className={styles.resultsHeading}>Results</h4>
       <div className={styles.resultsData}>
         <p className={styles.resultsDataCount}>
-          Showing {filteredMetricCount} of {totalMetricCount} total metrics.
+          Showing {filteredMetricCount} of {totalMetricCount} total metrics.{' '}
+          {isLoading && <Spinner className={styles.loadingSpinner} />}
         </p>
         {query.labels.length > 0 && (
           <p className={styles.resultsDataFiltered}>
@@ -746,7 +741,7 @@ const getStyles = (theme: GrafanaTheme2) => {
     `,
     resultsDataFiltered: css`
       margin: 0;
-      color: ${theme.colors.text.secondary};
+      color: ${theme.colors.warning.main};
     `,
     alphabetRow: css`
       display: flex;
@@ -795,12 +790,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       color: rgb(204, 204, 220);
     `,
     loadingSpinner: css`
-      margin-bottom: ${theme.spacing(1.5)};
-      padding: ${theme.spacing(0.5)} 0;
-      display: flex;
-      align-items: center;
-      gap: ${theme.spacing(1)};
-      background-color: ${theme.colors.background.secondary};
+      display: inline-block;
     `,
   };
 };

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.tsx
@@ -534,10 +534,10 @@ export const MetricEncyclopediaModal = (props: Props) => {
 
       <h4 className={styles.resultsHeading}>Results</h4>
       <div className={styles.resultsData}>
-        <p className={styles.resultsDataCount}>
+        <div className={styles.resultsDataCount}>
           Showing {filteredMetricCount} of {totalMetricCount} total metrics.{' '}
           {isLoading && <Spinner className={styles.loadingSpinner} />}
-        </p>
+        </div>
         {query.labels.length > 0 && (
           <p className={styles.resultsDataFiltered}>
             These metrics have been pre-filtered by labels chosen in the label filters.


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/64848
Fixes https://github.com/grafana/grafana/issues/64712
Fixes https://github.com/grafana/grafana/issues/64713

What is this? Visual changes to the Metric Encyclopedia based on UX feedback and collaboration. 

**Before & After:**
<div>
<img width="49%" alt="Screenshot 2023-03-15 at 14 14 33" src="https://user-images.githubusercontent.com/34524710/225335990-55002a83-0afe-4dfb-9e18-e7f562b475bd.png">
<img width="49%" alt="Screenshot 2023-03-15 at 14 13 37" src="https://user-images.githubusercontent.com/34524710/225335639-14f1a041-6b5a-47ec-8a6c-26642eca0c3b.png">
</div>

Why is this needed? Collaboration with UX produced some quick wins that make the look and feel of the Metric Encyclopedia much better. See figma board and notes for more info. 
<img width="696" alt="Screenshot 2023-03-15 at 11 59 08 AM" src="https://user-images.githubusercontent.com/25674746/225368024-7ca7023a-52d5-4c83-ae03-20371989fc1c.png">
https://www.figma.com/file/LTsteLk9cH3Z6s0Rx9v8Hb/Metrics-browser?node-id=0%3A1&t=dXMulrWL5NlPYp5X-0
[Metric Encyclopedia Notes](https://docs.google.com/document/d/1_EFZu-W1gdiNT-tAI1vLPHZY1pA2shW7kEvsuwgw4KM/edit#)

**Special notes for your reviewer**:
Edge cases to test: `loading state`, `disabled features`, `preselected labels`.

`loading state`: Use the network tab and select "Slow 3G throttling". You should now see a loading state.
`disabled features`: Enable "Use the backend to browse metrics" and confirm all metadata features are disabled.
`preselected labels`: Select a label and value, confirm the metric results are now pre-filtered.



