### PR TITLE
AppChrome: fix mounting Grafana app twice

### DIFF
--- a/public/app/core/components/AppChrome/AppChrome.tsx
+++ b/public/app/core/components/AppChrome/AppChrome.tsx
@@ -50,7 +50,9 @@ export function AppChrome({ children }: Props) {
   if (state.chromeless) {
     return (
       <main className="main-view">
-        <div className={contentClass}>{children}</div>
+        <div key="content-container" className={contentClass}>
+          {children}
+        </div>
       </main>
     );
   }
@@ -69,7 +71,9 @@ export function AppChrome({ children }: Props) {
           onToggleKioskMode={chrome.onToggleKioskMode}
         />
       </div>
-      <div className={contentClass}>{children}</div>
+      <div key="content-container" className={contentClass}>
+        {children}
+      </div>
       <MegaMenu searchBarHidden={searchBarHidden} onClose={() => chrome.setMegaMenu(false)} />
       <CommandPalette />
     </main>

--- a/public/app/core/components/AppChrome/AppChromeUpdate.tsx
+++ b/public/app/core/components/AppChrome/AppChromeUpdate.tsx
@@ -11,10 +11,14 @@ export interface AppChromeUpdateProps {
  */
 export const AppChromeUpdate = React.memo<AppChromeUpdateProps>(({ actions }: AppChromeUpdateProps) => {
   const { chrome } = useGrafana();
+  const state = chrome.useState();
 
   useEffect(() => {
     chrome.update({ actions });
-  });
+    // update when chrome service state changes, but ignore actions change
+    // components don't memoize actions resulting in new ref every render, but they are static in practice
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [chrome, state]);
   return null;
 });
 


### PR DESCRIPTION
Was working PoC of instrumenting dashboard rendering with traces for the hackathon. Traces showed that `initializeDashboard()` is being called twice on new page load, resulting in multiple duplicate requests to backend to fetch dashboard, load annotations and etc. Traced the problem to `<AppChrome/>`.  As it's `state.chromeless` updates, it renders `children` node in a different position, causing react to fully unmount, destroy & recreate the component. Adding a `key` prop as a hint that it's the same node fixes this.