### PR TITLE
Tabs: Avoid whitespace wrapping

### DIFF
--- a/packages/grafana-ui/src/components/Tabs/Tab.tsx
+++ b/packages/grafana-ui/src/components/Tabs/Tab.tsx
@@ -67,6 +67,7 @@ const getTabStyles = stylesFactory((theme: GrafanaTheme2) => {
       list-style: none;
       position: relative;
       display: flex;
+      white-space: nowrap;
     `,
     link: css`
       color: ${theme.colors.text.secondary};


### PR DESCRIPTION
Before:
![2023-03-15_08-16-44 (1)](https://user-images.githubusercontent.com/705951/225356120-62fb6ea7-93d9-488e-9957-d1944345cdcf.gif)

The same behavior can be seen on:
https://developers.grafana.com/ui/latest/index.html?path=/story/layout-tabs--simple

After:
![2023-03-15_08-20-28 (1)](https://user-images.githubusercontent.com/705951/225356587-14b53b94-9be7-4e24-a39a-b3dfcda1cd23.gif)

Fixes https://github.com/grafana/grafana/issues/58549