### PR TITLE
Database: Don't sleep 10ms before every request

### DIFF
--- a/pkg/util/retryer/retryer.go
+++ b/pkg/util/retryer/retryer.go
@@ -1,6 +1,7 @@
 package retryer
 
 import (
+	"errors"
 	"time"
 )
 
@@ -36,7 +37,7 @@ func Retry(body func() (RetrySignal, error), maxRetries int, minDelay time.Durat
 		}
 
 		if retries >= maxRetries {
-			return nil
+			return errors.New("max retries exceeded")
 		}
 	}
 

--- a/pkg/util/retryer/retryer.go
+++ b/pkg/util/retryer/retryer.go
@@ -7,8 +7,7 @@ import (
 type RetrySignal = int
 
 const (
-	FuncSuccess RetrySignal = iota
-	FuncFailure
+	FuncFailure RetrySignal = iota
 	FuncComplete
 	FuncError
 )
@@ -28,10 +27,6 @@ func Retry(body func() (RetrySignal, error), maxRetries int, minDelay time.Durat
 		}
 
 		switch response {
-		case FuncSuccess:
-			currentDelay = minDelay
-			ticker.Reset(currentDelay)
-			retries = 0
 		case FuncFailure:
 			currentDelay = minDuration(currentDelay*2, maxDelay)
 			ticker.Reset(currentDelay)

--- a/pkg/util/retryer/retryer.go
+++ b/pkg/util/retryer/retryer.go
@@ -17,31 +17,33 @@ const (
 // `maxDelay` after each failure. Stops when the provided function returns `FuncComplete`, or `maxRetries` is reached.
 func Retry(body func() (RetrySignal, error), maxRetries int, minDelay time.Duration, maxDelay time.Duration) error {
 	currentDelay := minDelay
-	ticker := time.NewTicker(currentDelay)
-	defer ticker.Stop()
+	var ticker *time.Ticker
 
 	retries := 0
-	for range ticker.C {
+	for {
 		response, err := body()
 		if err != nil {
 			return err
 		}
-
-		switch response {
-		case FuncFailure:
-			currentDelay = minDuration(currentDelay*2, maxDelay)
-			ticker.Reset(currentDelay)
-			retries++
-		case FuncComplete:
+		if response == FuncComplete {
 			return nil
 		}
 
+		retries++
 		if retries >= maxRetries {
 			return errors.New("max retries exceeded")
 		}
-	}
 
-	return nil
+		if ticker == nil {
+			ticker = time.NewTicker(currentDelay)
+			defer ticker.Stop()
+		} else {
+			currentDelay = minDuration(currentDelay*2, maxDelay)
+			ticker.Reset(currentDelay)
+		}
+
+		<-ticker.C
+	}
 }
 
 func minDuration(a time.Duration, b time.Duration) time.Duration {

--- a/pkg/util/retryer/retryer_test.go
+++ b/pkg/util/retryer/retryer_test.go
@@ -14,9 +14,7 @@ func TestMaxRetries(t *testing.T) {
 		retryVal++
 		return FuncFailure, nil
 	}, 8, 100*time.Millisecond, 100*time.Millisecond)
-	if err != nil {
-		assert.FailNow(t, "Error while retrying function")
-	}
+	assert.Error(t, err) // Exceeding max-retries is an error.
 
 	assert.Equal(t, 8, retryVal)
 }


### PR DESCRIPTION
**What is this feature?**

Previously every DB operation would wait 10ms before even trying.
Now we try first, and don't create the ticker until we need it.

**Why do we need this feature?**

Makes everything go faster: many user operations in Grafana will do 5-10 database operations so we save 50-100ms.

**Who is this feature for?**

Users.

**Special notes for your reviewer**:

I made a couple of other changes to package `retryer`, which are in separate commits for ease of reviewing.

In particular, I couldn't leave it returning `nil`, no error, if max retries are exceeded.
There is code in `retryOnLocks()` to work round this misfeature, which I left, so my change doesn't have any impact.
 