### PR TITLE
ServiceAccounts: Collect usage stat for service account forced expiry

### DIFF
--- a/pkg/services/serviceaccounts/database/stats.go
+++ b/pkg/services/serviceaccounts/database/stats.go
@@ -25,5 +25,7 @@ func (s *ServiceAccountsStoreImpl) GetUsageMetrics(ctx context.Context) (*servic
 		return nil, err
 	}
 
+	sqlStats.ForcedExpiryEnabled = s.cfg.SATokenExpirationDayLimit != 0
+
 	return &sqlStats, nil
 }

--- a/pkg/services/serviceaccounts/database/stats_test.go
+++ b/pkg/services/serviceaccounts/database/stats_test.go
@@ -7,18 +7,20 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/grafana/pkg/components/apikeygen"
+	apikeygenprefix "github.com/grafana/grafana/pkg/components/apikeygenprefixed"
 	"github.com/grafana/grafana/pkg/services/serviceaccounts"
 	"github.com/grafana/grafana/pkg/services/serviceaccounts/tests"
 )
 
-func TestStore_UsageStats(t *testing.T) {
+func TestIntegrationStore_UsageStats(t *testing.T) {
 	saToCreate := tests.TestUser{Login: "servicetestwithTeam@admin", IsServiceAccount: true}
 	db, store := setupTestDatabase(t)
 	sa := tests.SetupUserServiceAccount(t, db, saToCreate)
 
+	db.Cfg.SATokenExpirationDayLimit = 4
+
 	keyName := t.Name()
-	key, err := apikeygen.New(sa.OrgID, keyName)
+	key, err := apikeygenprefix.New(keyName)
 	require.NoError(t, err)
 
 	cmd := serviceaccounts.AddServiceAccountTokenCommand{
@@ -36,4 +38,5 @@ func TestStore_UsageStats(t *testing.T) {
 
 	assert.Equal(t, int64(1), stats.ServiceAccounts)
 	assert.Equal(t, int64(1), stats.Tokens)
+	assert.Equal(t, true, stats.ForcedExpiryEnabled)
 }

--- a/pkg/services/serviceaccounts/manager/stats.go
+++ b/pkg/services/serviceaccounts/manager/stats.go
@@ -42,13 +42,20 @@ func init() {
 func (sa *ServiceAccountsService) getUsageMetrics(ctx context.Context) (map[string]interface{}, error) {
 	stats := map[string]interface{}{}
 
-	sqlStats, err := sa.store.GetUsageMetrics(ctx)
+	storeStats, err := sa.store.GetUsageMetrics(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	stats["stats.serviceaccounts.count"] = sqlStats.ServiceAccounts
-	stats["stats.serviceaccounts.tokens.count"] = sqlStats.Tokens
+	stats["stats.serviceaccounts.count"] = storeStats.ServiceAccounts
+	stats["stats.serviceaccounts.tokens.count"] = storeStats.Tokens
+
+	var forcedExpiryEnabled int64 = 0
+	if storeStats.ForcedExpiryEnabled {
+		forcedExpiryEnabled = 1
+	}
+
+	stats["stats.serviceaccounts.forced_expiry_enabled.count"] = forcedExpiryEnabled
 
 	var secretScanEnabled int64 = 0
 	if sa.secretScanEnabled {
@@ -57,8 +64,8 @@ func (sa *ServiceAccountsService) getUsageMetrics(ctx context.Context) (map[stri
 
 	stats["stats.serviceaccounts.secret_scan.enabled.count"] = secretScanEnabled
 
-	MStatTotalServiceAccountTokens.Set(float64(sqlStats.Tokens))
-	MStatTotalServiceAccounts.Set(float64(sqlStats.ServiceAccounts))
+	MStatTotalServiceAccountTokens.Set(float64(storeStats.Tokens))
+	MStatTotalServiceAccounts.Set(float64(storeStats.ServiceAccounts))
 
 	return stats, nil
 }

--- a/pkg/services/serviceaccounts/manager/stats_test.go
+++ b/pkg/services/serviceaccounts/manager/stats_test.go
@@ -18,13 +18,16 @@ func Test_UsageStats(t *testing.T) {
 	require.NoError(t, err)
 
 	storeMock.ExpectedStats = &serviceaccounts.Stats{
-		ServiceAccounts: 1,
-		Tokens:          1,
+		ServiceAccounts:     1,
+		Tokens:              1,
+		ForcedExpiryEnabled: false,
 	}
 	stats, err := svc.getUsageMetrics(context.Background())
 	require.NoError(t, err)
 
+	assert.Len(t, stats, 4, stats)
 	assert.Equal(t, int64(1), stats["stats.serviceaccounts.count"].(int64))
 	assert.Equal(t, int64(1), stats["stats.serviceaccounts.tokens.count"].(int64))
 	assert.Equal(t, int64(1), stats["stats.serviceaccounts.secret_scan.enabled.count"].(int64))
+	assert.Equal(t, int64(0), stats["stats.serviceaccounts.forced_expiry_enabled.count"].(int64))
 }

--- a/pkg/services/serviceaccounts/models.go
+++ b/pkg/services/serviceaccounts/models.go
@@ -152,8 +152,9 @@ const (
 )
 
 type Stats struct {
-	ServiceAccounts int64 `xorm:"serviceaccounts"`
-	Tokens          int64 `xorm:"serviceaccount_tokens"`
+	ServiceAccounts     int64 `xorm:"serviceaccounts"`
+	Tokens              int64 `xorm:"serviceaccount_tokens"`
+	ForcedExpiryEnabled bool  `xorm:"-"`
 }
 
 // AccessEvaluator is used to protect the "Configuration > Service accounts" page access


### PR DESCRIPTION
**What is this feature?**

Collect usage stat on use of forced expiry

