### PR TITLE
Loki: Add option to define chunk duration per query

### DIFF
--- a/public/app/plugins/datasource/loki/components/LokiQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryEditor.tsx
@@ -172,7 +172,6 @@ export const LokiQueryEditor = React.memo<LokiQueryEditorProps>((props) => {
           app={app}
           maxLines={datasource.maxLines}
           datasource={datasource}
-          experimentalChunkRange={query.experimentalChunkRange}
         />
       </EditorRows>
     </>

--- a/public/app/plugins/datasource/loki/components/LokiQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryEditor.tsx
@@ -172,6 +172,7 @@ export const LokiQueryEditor = React.memo<LokiQueryEditorProps>((props) => {
           app={app}
           maxLines={datasource.maxLines}
           datasource={datasource}
+          experimentalChunkRange={query.experimentalChunkRange}
         />
       </EditorRows>
     </>

--- a/public/app/plugins/datasource/loki/querySplitting.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.ts
@@ -6,7 +6,6 @@ import {
   DataQueryResponse,
   dateTime,
   durationToMilliseconds,
-  isValidDuration,
   parseDuration,
   TimeRange,
 } from '@grafana/data';
@@ -175,14 +174,10 @@ export function runPartitionedQueries(datasource: LokiDatasource, request: DataQ
 
   const oneDayMs = 24 * 60 * 60 * 1000;
   const rangePartitionedLogQueries = groupBy(logQueries, (query) =>
-    query.experimentalChunkRange && isValidDuration(query.experimentalChunkRange)
-      ? durationToMilliseconds(parseDuration(query.experimentalChunkRange!))
-      : oneDayMs
+    query.experimentalChunkRange ? durationToMilliseconds(parseDuration(query.experimentalChunkRange)) : oneDayMs
   );
   const rangePartitionedMetricQueries = groupBy(metricQueries, (query) =>
-    query.experimentalChunkRange && isValidDuration(query.experimentalChunkRange)
-      ? durationToMilliseconds(parseDuration(query.experimentalChunkRange!))
-      : oneDayMs
+    query.experimentalChunkRange ? durationToMilliseconds(parseDuration(query.experimentalChunkRange)) : oneDayMs
   );
 
   const requests: LokiGroupedRequest = [];

--- a/public/app/plugins/datasource/loki/querySplitting.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.ts
@@ -1,7 +1,15 @@
-import { partition } from 'lodash';
-import { Subscriber, Observable, Subscription } from 'rxjs';
+import { groupBy, partition } from 'lodash';
+import { Observable, Subscriber, Subscription } from 'rxjs';
 
-import { DataQueryRequest, DataQueryResponse, dateTime, TimeRange } from '@grafana/data';
+import {
+  DataQueryRequest,
+  DataQueryResponse,
+  dateTime,
+  durationToMilliseconds,
+  isValidDuration,
+  parseDuration,
+  TimeRange,
+} from '@grafana/data';
 import { LoadingState } from '@grafana/schema';
 
 import { LokiDatasource } from './datasource';
@@ -10,24 +18,12 @@ import { getRangeChunks as getMetricRangeChunks } from './metricTimeSplit';
 import { combineResponses, isLogsQuery } from './queryUtils';
 import { LokiQuery, LokiQueryType } from './types';
 
-declare global {
-  interface Window {
-    lokiChunkDuration: number;
-  }
-}
-
-/**
- * Purposely exposing it to support doing tests without needing to update the repo.
- * TODO: remove.
- * Hardcoded to 1 day.
- */
-window.lokiChunkDuration = 24 * 60 * 60 * 1000;
-
 export function partitionTimeRange(
   isLogsQuery: boolean,
   originalTimeRange: TimeRange,
   intervalMs: number,
-  resolution: number
+  resolution: number,
+  duration: number
 ): TimeRange[] {
   // the `step` value that will be finally sent to Loki is rougly the same as `intervalMs`,
   // but there are some complications.
@@ -40,8 +36,6 @@ export function partitionTimeRange(
 
   const safeStep = Math.ceil((end - start) / 11000);
   const step = Math.max(intervalMs * resolution, safeStep);
-
-  const duration = window.lokiChunkDuration;
 
   const ranges = isLogsQuery
     ? getLogsRangeChunks(start, end, duration)
@@ -179,19 +173,45 @@ export function runPartitionedQueries(datasource: LokiDatasource, request: DataQ
   const [instantQueries, normalQueries] = partition(queries, (query) => query.queryType === LokiQueryType.Instant);
   const [logQueries, metricQueries] = partition(normalQueries, (query) => isLogsQuery(query.expr));
 
+  const oneDayMs = 24 * 60 * 60 * 1000;
+  const rangePartitionedLogQueries = groupBy(logQueries, (query) =>
+    query.experimentalChunkRange && isValidDuration(query.experimentalChunkRange)
+      ? durationToMilliseconds(parseDuration(query.experimentalChunkRange!))
+      : oneDayMs
+  );
+  const rangePartitionedMetricQueries = groupBy(metricQueries, (query) =>
+    query.experimentalChunkRange && isValidDuration(query.experimentalChunkRange)
+      ? durationToMilliseconds(parseDuration(query.experimentalChunkRange!))
+      : oneDayMs
+  );
+
   const requests: LokiGroupedRequest = [];
-  if (logQueries.length) {
+  for (const [chunkRangeMs, queries] of Object.entries(rangePartitionedLogQueries)) {
     requests.push({
-      request: { ...request, targets: logQueries },
-      partition: partitionTimeRange(true, request.range, request.intervalMs, logQueries[0].resolution ?? 1),
+      request: { ...request, targets: queries },
+      partition: partitionTimeRange(
+        true,
+        request.range,
+        request.intervalMs,
+        queries[0].resolution ?? 1,
+        Number(chunkRangeMs)
+      ),
     });
   }
-  if (metricQueries.length) {
+
+  for (const [chunkRangeMs, queries] of Object.entries(rangePartitionedMetricQueries)) {
     requests.push({
-      request: { ...request, targets: metricQueries },
-      partition: partitionTimeRange(false, request.range, request.intervalMs, metricQueries[0].resolution ?? 1),
+      request: { ...request, targets: queries },
+      partition: partitionTimeRange(
+        false,
+        request.range,
+        request.intervalMs,
+        queries[0].resolution ?? 1,
+        Number(chunkRangeMs)
+      ),
     });
   }
+
   if (instantQueries.length) {
     requests.push({
       request: { ...request, targets: instantQueries },

--- a/public/app/plugins/datasource/loki/querySplitting.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.ts
@@ -174,10 +174,10 @@ export function runPartitionedQueries(datasource: LokiDatasource, request: DataQ
 
   const oneDayMs = 24 * 60 * 60 * 1000;
   const rangePartitionedLogQueries = groupBy(logQueries, (query) =>
-    query.experimentalChunkRange ? durationToMilliseconds(parseDuration(query.experimentalChunkRange)) : oneDayMs
+    query.chunkDuration ? durationToMilliseconds(parseDuration(query.chunkDuration)) : oneDayMs
   );
   const rangePartitionedMetricQueries = groupBy(metricQueries, (query) =>
-    query.experimentalChunkRange ? durationToMilliseconds(parseDuration(query.experimentalChunkRange)) : oneDayMs
+    query.chunkDuration ? durationToMilliseconds(parseDuration(query.chunkDuration)) : oneDayMs
   );
 
   const requests: LokiGroupedRequest = [];

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.tsx
@@ -135,7 +135,7 @@ export const LokiQueryBuilderOptions = React.memo<Props>(
           {config.featureToggles.lokiQuerySplitting && (
             <EditorField
               label="Chunk Range"
-              tooltip="Experimental: Defines the range of a single query chunk when query chunking is used."
+              tooltip="Defines the range of a single query chunk when query chunking is used."
             >
               <AutoSizeInput
                 minWidth={14}

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.tsx
@@ -19,11 +19,10 @@ export interface Props {
   maxLines: number;
   app?: CoreApp;
   datasource: LokiDatasource;
-  experimentalChunkRange?: string;
 }
 
 export const LokiQueryBuilderOptions = React.memo<Props>(
-  ({ app, query, onChange, onRunQuery, maxLines, datasource, experimentalChunkRange }) => {
+  ({ app, query, onChange, onRunQuery, maxLines, datasource }) => {
     const [queryStats, setQueryStats] = useState<QueryStats>();
     const [chunkRangeValid, setChunkRangeValid] = useState(true);
     const prevQuery = usePrevious(query);
@@ -49,7 +48,7 @@ export const LokiQueryBuilderOptions = React.memo<Props>(
         return;
       }
       setChunkRangeValid(true);
-      onChange({ ...query, experimentalChunkRange: value });
+      onChange({ ...query, chunkDuration: value });
       onRunQuery();
     };
 
@@ -134,14 +133,14 @@ export const LokiQueryBuilderOptions = React.memo<Props>(
           </EditorField>
           {config.featureToggles.lokiQuerySplitting && (
             <EditorField
-              label="Chunk Range"
-              tooltip="Defines the range of a single query chunk when query chunking is used."
+              label="Chunk Duration"
+              tooltip="Defines the duration of a single query chunk when query chunking is used."
             >
               <AutoSizeInput
                 minWidth={14}
                 type="string"
                 min={0}
-                defaultValue={query.experimentalChunkRange?.toString() ?? '1d'}
+                defaultValue={query.chunkDuration?.toString() ?? '1d'}
                 onCommitChange={onChunkRangeChange}
                 invalid={!chunkRangeValid}
               />

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.tsx
@@ -140,7 +140,7 @@ export const LokiQueryBuilderOptions = React.memo<Props>(
                 minWidth={14}
                 type="string"
                 min={0}
-                defaultValue={query.chunkDuration?.toString() ?? '1d'}
+                defaultValue={query.chunkDuration ?? '1d'}
                 onCommitChange={onChunkRangeChange}
                 invalid={!chunkRangeValid}
               />

--- a/public/app/plugins/datasource/loki/types.ts
+++ b/public/app/plugins/datasource/loki/types.ts
@@ -35,6 +35,12 @@ export interface LokiQuery extends LokiQueryFromSchema {
   // the temporary fix (until this gets improved in the codegen), is to
   // override it here
   queryType?: LokiQueryType;
+
+  /**
+   * This is a property for the experimental query splitting feature.
+   * @experimental
+   */
+  experimentalChunkRange?: string;
 }
 
 export interface LokiOptions extends DataSourceJsonData {

--- a/public/app/plugins/datasource/loki/types.ts
+++ b/public/app/plugins/datasource/loki/types.ts
@@ -40,7 +40,7 @@ export interface LokiQuery extends LokiQueryFromSchema {
    * This is a property for the experimental query splitting feature.
    * @experimental
    */
-  experimentalChunkRange?: string;
+  chunkDuration?: string;
 }
 
 export interface LokiOptions extends DataSourceJsonData {


### PR DESCRIPTION
**What is this feature?**

This PR adds the possibility to define chunk ranges per query. 

**Special notes for your reviewer**:

It was not as straight forward as I thought, because you can now have multiple queries with different chunk ranges. I used `groupBy` to now group even further - not just by metrics and logs - but also by their configured chunk ranges.

**How to test**:
Add multiple queries with different chunk ranges.

https://user-images.githubusercontent.com/8092184/225385504-f39198c2-cd9b-4949-bbac-a62f2c1d589e.mov
