### PR TITLE
remotecache: set secret service on encryptionstorage

### DIFF
--- a/pkg/infra/remotecache/remotecache.go
+++ b/pkg/infra/remotecache/remotecache.go
@@ -28,7 +28,7 @@ const (
 
 func ProvideService(cfg *setting.Cfg, sqlStore db.DB, usageStats usagestats.Service,
 	secretsService secrets.Service) (*RemoteCache, error) {
-	client, err := createClient(cfg.RemoteCacheOptions, sqlStore)
+	client, err := createClient(cfg.RemoteCacheOptions, sqlStore, secretsService)
 	if err != nil {
 		return nil, err
 	}
@@ -119,7 +119,7 @@ func (ds *RemoteCache) Run(ctx context.Context) error {
 	return ctx.Err()
 }
 
-func createClient(opts *setting.RemoteCacheOptions, sqlstore db.DB) (cache CacheStorage, err error) {
+func createClient(opts *setting.RemoteCacheOptions, sqlstore db.DB, secretsService secrets.Service) (cache CacheStorage, err error) {
 	switch opts.Name {
 	case redisCacheType:
 		cache, err = newRedisStorage(opts)
@@ -138,7 +138,7 @@ func createClient(opts *setting.RemoteCacheOptions, sqlstore db.DB) (cache Cache
 	}
 
 	if opts.Encryption {
-		cache = &encryptedCacheStorage{cache: cache}
+		cache = &encryptedCacheStorage{cache: cache, secretsService: secretsService}
 	}
 	return cache, nil
 }

--- a/pkg/infra/remotecache/remotecache_test.go
+++ b/pkg/infra/remotecache/remotecache_test.go
@@ -40,7 +40,7 @@ func TestCachedBasedOnConfig(t *testing.T) {
 }
 
 func TestInvalidCacheTypeReturnsError(t *testing.T) {
-	_, err := createClient(&setting.RemoteCacheOptions{Name: "invalid"}, nil)
+	_, err := createClient(&setting.RemoteCacheOptions{Name: "invalid"}, nil, nil)
 	assert.Equal(t, err, ErrInvalidCacheType)
 }
 


### PR DESCRIPTION
This fixes a nil pointer bug when encryption is enabled. 