### PR TITLE
Prometheus: Metric encyclopedia, return results in table format

### DIFF
--- a/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.test.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.test.tsx
@@ -78,19 +78,6 @@ describe('MetricEncyclopediaModal', () => {
     expect(screen.getByText('all-metrics-help')).toBeInTheDocument();
   });
 
-  it('displays no metadata for a metric missing metadata when the metric is clicked', async () => {
-    setup(defaultQuery, listOfMetrics);
-    await waitFor(() => {
-      expect(screen.getByText('b')).toBeInTheDocument();
-    });
-
-    const interactiveMetric = screen.getByText('b');
-
-    await userEvent.click(interactiveMetric);
-
-    expect(screen.getByText('No metadata available')).toBeInTheDocument();
-  });
-
   // Filtering
   it('has a filter for selected type', async () => {
     setup(defaultQuery, listOfMetrics);

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.tsx
@@ -450,7 +450,7 @@ export const MetricEncyclopediaModal = (props: Props) => {
       { id: '', header: ' ', cell: ButtonCell },
     ];
 
-    return <InteractiveTable columns={columns} data={tableData} getRowId={(r) => r.value} />;
+    return <InteractiveTable className={styles.table} columns={columns} data={tableData} getRowId={(r) => r.value} />;
   }
 
   return (
@@ -602,9 +602,7 @@ export const MetricEncyclopediaModal = (props: Props) => {
         </div>
       </div>
 
-      <div className={styles.results}>      
-        {metrics && tableResults(displayedMetrics(metrics))}
-      </div>
+      <div className={styles.results}>{metrics && tableResults(displayedMetrics(metrics))}</div>
 
       <div className={styles.pageSettingsWrapper}>
         <div className={styles.pageSettings}>

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.tsx
@@ -418,6 +418,8 @@ export const MetricEncyclopediaModal = (props: Props) => {
     return (
       <Button
         size="sm"
+        variant={'secondary'}
+        fill={'solid'}
         aria-label="use this metric button"
         data-testid={testIds.useMetric}
         onClick={() => {
@@ -747,17 +749,6 @@ const getStyles = (theme: GrafanaTheme2) => {
       flex-direction: row;
       align-items: center;
     `,
-    cardsContainer: css`
-      display: flex;
-      flex-direction: row;
-      flex-wrap: wrap;
-      justify-content: space-between;
-    `,
-    card: css`
-      width: 100%;
-      display: flex;
-      flex-direction: column;
-    `,
     selAlpha: css`
       cursor: pointer;
       color: #6e9fff;
@@ -767,9 +758,6 @@ const getStyles = (theme: GrafanaTheme2) => {
     `,
     gray: css`
       color: grey;
-    `,
-    metadata: css`
-      color: rgb(204, 204, 220);
     `,
     loadingSpinner: css`
       display: inline-block;


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/64705

What is this change? After collaborating with UX we are now returning metric encyclopedia results in a table format.
<img width="1056" alt="Screenshot 2023-03-15 at 3 05 37 PM" src="https://user-images.githubusercontent.com/25674746/225417076-fecf1b78-c578-40df-bed2-cb410ecd1690.png">


Why do we need it? 
- we have more room now due to widening the modal
- hidden type and description in the previous cards was confusing
- hiding the button added an extra click to select a metric
- now we have the same amount of click to add a metric as with the MetricSelect component.
  - click the button
  - focus in text, type if you want
  - select metric with one click
