### PR TITLE
Plugins: Added e2e flow for triggering panel menu UI extensions

### DIFF
--- a/e2e/e2e-flow-suite/00-panel-menu-extension.spec.ts
+++ b/e2e/e2e-flow-suite/00-panel-menu-extension.spec.ts
@@ -1,0 +1,17 @@
+import { e2e } from '@grafana/e2e';
+
+e2e.scenario({
+  describeName: 'Panel menu ui extension flow',
+  itName: 'Should be possible to click extension menu item',
+  addScenarioDataSource: false,
+  addScenarioDashBoard: false,
+  skipScenario: false,
+  scenario: () => {
+    const panelTitle = 'Random walk series';
+    const extensionTitle = 'Copy';
+
+    e2e.flows.openDashboard({ uid: '5SdHCasdf' });
+    e2e.flows.openPanelMenuExtension(extensionTitle, panelTitle);
+    e2e.flows.assertSuccessNotification();
+  },
+});

--- a/packages/grafana-e2e/src/flows/openPanelMenuItem.ts
+++ b/packages/grafana-e2e/src/flows/openPanelMenuItem.ts
@@ -3,10 +3,23 @@ import { e2e } from '../index';
 export enum PanelMenuItems {
   Edit = 'Edit',
   Inspect = 'Inspect',
+  More = 'More...',
 }
 
 export const openPanelMenuItem = (menu: PanelMenuItems, panelTitle = 'Panel Title') => {
   e2e.components.Panels.Panel.title(panelTitle).should('be.visible').click();
 
   e2e.components.Panels.Panel.headerItems(menu).should('be.visible').click();
+};
+
+export const openPanelMenuExtension = (extensionTitle: string, panelTitle = 'Panel Title') => {
+  e2e.components.Panels.Panel.title(panelTitle).should('be.visible').click();
+
+  e2e.components.Panels.Panel.headerItems(PanelMenuItems.More)
+    .should('be.visible')
+    .parent()
+    .parent()
+    .invoke('addClass', 'open');
+
+  e2e.components.Panels.Panel.headerItems(extensionTitle).should('be.visible').click();
 };


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
This PR adds a flow that will trigger a click on an UI extension in the dashboard panel menu.

**Why do we need this feature?**
When writing e2e tests for a plugin we don't want to rely on selectors from markup outside of the plugin. For example, to trigger a click on a panel menu UI extension. All markup to perform that action lives in grafana core. If we write selectors in the tests that lives in our plugin and the markup in grafana core, for some reason, change it might break our tests. 

Instead we want to rely on an e2e flow that can be changed at the same time as the grafana core changes.

**Who is this feature for?**
Plugin developers

**Related issue**:
https://github.com/grafana/grafana/issues/61658
