### PR TITLE
Fix url for publish and sign criteria

### DIFF
--- a/docs/sources/developers/plugins/publish-a-plugin.md
+++ b/docs/sources/developers/plugins/publish-a-plugin.md
@@ -86,7 +86,7 @@ Before you submit your plugin, we ask that you read our guidelines and frequentl
 
 To speed up the time it takes to review your plugin:
 
-- Get familiar with our plugin [publishing and signing criteria](publishing-and-signing-criteria.md)
+- Get familiar with our plugin [publishing and signing criteria]({{< relref ".//publishing-and-signing-criteria" >}})
 - Check that your plugin is ready for review using the [plugin validator](https://github.com/grafana/plugin-validator).
 - Read our [6 tips for improving your Grafana plugin before you publish](https://grafana.com/blog/2021/01/21/6-tips-for-improving-your-grafana-plugin-before-you-publish/).
 - Refer to [plugin-examples](https://github.com/grafana/grafana-plugin-examples) to review best practices for building your plugin.


### PR DESCRIPTION
**What is this feature?**

Fixes a url in the docs.

**Why do we need this feature?**

There's a broken reference to the Publishing and Signing Criteria in the docs.

**Special notes for your reviewer**:

