### PR TITLE
QueryHistory: Fix filter strings being regular escaped

### DIFF
--- a/public/app/features/explore/RichHistory/RichHistoryQueriesTab.test.tsx
+++ b/public/app/features/explore/RichHistory/RichHistoryQueriesTab.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, within } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 
 import { DataSourceSrv, setDataSourceSrv } from '@grafana/runtime';

--- a/public/app/features/explore/RichHistory/RichHistoryQueriesTab.test.tsx
+++ b/public/app/features/explore/RichHistory/RichHistoryQueriesTab.test.tsx
@@ -1,0 +1,64 @@
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import React from 'react';
+
+import { DataSourceSrv, setDataSourceSrv } from '@grafana/runtime';
+import { SortOrder } from 'app/core/utils/richHistoryTypes';
+import { ExploreId } from 'app/types';
+
+import { RichHistoryQueriesTab, RichHistoryQueriesTabProps } from './RichHistoryQueriesTab';
+
+const setup = (propOverrides?: Partial<RichHistoryQueriesTabProps>) => {
+  const props: RichHistoryQueriesTabProps = {
+    queries: [],
+    totalQueries: 0,
+    loading: false,
+    activeDatasourceInstance: 'test-ds',
+    updateFilters: jest.fn(),
+    clearRichHistoryResults: jest.fn(),
+    loadMoreRichHistory: jest.fn(),
+    richHistorySearchFilters: {
+      search: '',
+      sortOrder: SortOrder.Descending,
+      datasourceFilters: ['test-ds'],
+      from: 0,
+      to: 30,
+      starred: false,
+    },
+    richHistorySettings: {
+      retentionPeriod: 30,
+      activeDatasourceOnly: false,
+      lastUsedDatasourceFilters: [],
+      starredTabAsFirstTab: false,
+    },
+    exploreId: ExploreId.left,
+    height: 100,
+  };
+
+  Object.assign(props, propOverrides);
+
+  return render(<RichHistoryQueriesTab {...props} />);
+};
+
+describe('RichHistoryQueriesTab', () => {
+  beforeAll(() => {
+    setDataSourceSrv({
+      getList() {
+        return [];
+      },
+    } as unknown as DataSourceSrv);
+  });
+
+  it('should render', () => {
+    setup();
+    expect(screen.queryByText('Filter history')).toBeInTheDocument();
+  });
+
+  it('should not regex escape filter input', () => {
+    const updateFiltersSpy = jest.fn();
+    setup({ updateFilters: updateFiltersSpy });
+    const input = screen.getByPlaceholderText(/search queries/i);
+    fireEvent.change(input, { target: { value: '|=' } });
+
+    expect(updateFiltersSpy).toHaveBeenCalledWith(expect.objectContaining({ search: '|=' }));
+  });
+});

--- a/public/app/features/explore/RichHistory/RichHistoryQueriesTab.tsx
+++ b/public/app/features/explore/RichHistory/RichHistoryQueriesTab.tsx
@@ -17,7 +17,7 @@ import { ExploreId, RichHistoryQuery } from 'app/types/explore';
 import { getSortOrderOptions } from './RichHistory';
 import RichHistoryCard from './RichHistoryCard';
 
-export interface Props {
+export interface RichHistoryQueriesTabProps {
   queries: RichHistoryQuery[];
   totalQueries: number;
   loading: boolean;
@@ -118,7 +118,7 @@ const getStyles = (theme: GrafanaTheme2, height: number) => {
   };
 };
 
-export function RichHistoryQueriesTab(props: Props) {
+export function RichHistoryQueriesTab(props: RichHistoryQueriesTabProps) {
   const {
     queries,
     totalQueries,
@@ -211,6 +211,7 @@ export function RichHistoryQueriesTab(props: Props) {
           )}
           <div className={styles.filterInput}>
             <FilterInput
+              escapeRegex={false}
               placeholder="Search queries"
               value={richHistorySearchFilters.search}
               onChange={(search: string) => updateFilters({ search })}

--- a/public/app/features/explore/RichHistory/RichHistoryStarredTab.tsx
+++ b/public/app/features/explore/RichHistory/RichHistoryStarredTab.tsx
@@ -15,7 +15,7 @@ import { RichHistoryQuery, ExploreId } from 'app/types/explore';
 import { getSortOrderOptions } from './RichHistory';
 import RichHistoryCard from './RichHistoryCard';
 
-export interface Props {
+export interface RichHistoryStarredTabProps {
   queries: RichHistoryQuery[];
   totalQueries: number;
   loading: boolean;
@@ -72,7 +72,7 @@ const getStyles = (theme: GrafanaTheme2) => {
   };
 };
 
-export function RichHistoryStarredTab(props: Props) {
+export function RichHistoryStarredTab(props: RichHistoryStarredTabProps) {
   const {
     updateFilters,
     clearRichHistoryResults,
@@ -136,6 +136,7 @@ export function RichHistoryStarredTab(props: Props) {
           )}
           <div className={styles.filterInput}>
             <FilterInput
+              escapeRegex={false}
               placeholder="Search queries"
               value={richHistorySearchFilters.search}
               onChange={(search: string) => updateFilters({ search })}


### PR DESCRIPTION
**What is this feature?**

I noticed that the FilterInput in QueryHistory is defaulting to escape certain characters. That does not allow to search for strings like `|` or `[`. Since it's a quick fix, I just went with this PR.

**Special notes for your reviewer**:

Test this out by e.g. running Loki queries:
1. Start Grafana
2. `make devenv sources=loki`
3. Configure a Loki DS in Grafana and go to Explore
4. Do e.g. a query like `{job="\"grafana/data\""} |= `f``
5. Open QueryHistory
6. Try to search for `|=`. Not possible without this fix.