### PR TITLE
Fix empty value for expiry date

### DIFF
--- a/public/app/features/serviceaccounts/components/CreateTokenModal.tsx
+++ b/public/app/features/serviceaccounts/components/CreateTokenModal.tsx
@@ -38,8 +38,10 @@ export const CreateTokenModal = ({ isOpen, token, serviceAccountLogin, onCreateT
   tomorrow.setDate(tomorrow.getDate() + 1);
 
   const maxExpirationDate = new Date();
-  if (config.tokenExpirationDayLimit !== undefined) {
+  if (config.tokenExpirationDayLimit !== undefined && config.tokenExpirationDayLimit > -1) {
     maxExpirationDate.setDate(maxExpirationDate.getDate() + config.tokenExpirationDayLimit + 1);
+  } else {
+    maxExpirationDate.setDate(8640000000000000);
   }
   const defaultExpirationDate = config.tokenExpirationDayLimit !== undefined && config.tokenExpirationDayLimit > 0;
 


### PR DESCRIPTION
**What is this feature?**

This will change the Service accounts tokens' expiry date to the maximum possible as a default, allowing them to use any date if there is no configuration set as a limit.

**Why do we need this feature?**

Upon using an empty value for Service accounts tokens' expiry date, the user couldn't choose any value they might want.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #64889

**Special notes for your reviewer**:

