### PR TITLE
SectionNav: Make section toggle not take up horizontal space

### DIFF
--- a/public/app/core/components/PageNew/SectionNav.tsx
+++ b/public/app/core/components/PageNew/SectionNav.tsx
@@ -68,6 +68,7 @@ const getStyles = (theme: GrafanaTheme2) => {
     navContainer: css({
       display: 'flex',
       flexDirection: 'column',
+      position: 'relative',
 
       [theme.breakpoints.up('md')]: {
         flexDirection: 'row',

--- a/public/app/core/components/PageNew/SectionNavItem.tsx
+++ b/public/app/core/components/PageNew/SectionNavItem.tsx
@@ -84,6 +84,7 @@ const getStyles = (theme: GrafanaTheme2) => {
     activeStyle: css`
       label: activeTabStyle;
       color: ${theme.colors.text.primary};
+      font-weight: ${theme.typography.fontWeightMedium};
       background: ${theme.colors.emphasize(theme.colors.background.canvas, 0.03)};
 
       &::before {
@@ -115,6 +116,8 @@ const getStyles = (theme: GrafanaTheme2) => {
       fontSize: theme.typography.h5.fontSize,
       marginTop: theme.spacing(2),
       fontWeight: theme.typography.fontWeightMedium,
+      // To make room for section toggle button when section is active
+      marginRight: theme.spacing(4),
     }),
     noRootMargin: css({
       marginBottom: 0,

--- a/public/app/core/components/PageNew/SectionNavToggle.tsx
+++ b/public/app/core/components/PageNew/SectionNavToggle.tsx
@@ -36,7 +36,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
   icon: css({
     alignSelf: 'center',
     margin: theme.spacing(1, 0),
-    top: theme.spacing(0),
     transform: 'rotate(90deg)',
     transition: theme.transitions.create('opacity'),
     color: theme.colors.text.secondary,
@@ -61,6 +60,9 @@ const getStyles = (theme: GrafanaTheme2) => ({
     [theme.breakpoints.up('md')]: {
       opacity: 0,
       margin: 0,
+      position: 'absolute',
+      right: 0,
+      left: 'initial',
     },
   }),
 });


### PR DESCRIPTION
Problem I am trying to solve

* The section nav is a bit too wide taking up precious horizontal space on small screens. The SectionToggle is taking up 32px that cannot be used and just add unnecessary margin/padding
* The scrollbar for section nav looks unaligned/bad as it shows to the left of the section toggle 

Example:
![image](https://user-images.githubusercontent.com/10999/225620200-51bc1332-fcaf-47a3-a586-e9b3bbd08c99.png)

This PR:
* A: Makes the section toggle absolutely position (floating)
* B: To fix the problem of SectionToggle intersecting with the section heading (when it is active, see below) I added a right margin to section heading. 
![image](https://user-images.githubusercontent.com/10999/225620376-7a71ae70-41c2-4017-aa6b-c59740366dd1.png)
* C: Make active section item font-weight medium (just looks good, and I think with this change we could potentially skip the background highlight) 

Not in this PR yet but could be a good idea: 
* Remove Section nav item active background highlight (making no need for change B)

