### PR TITLE
Prometheus: Make metrics encyclopedia more responsive for smaller screens

### DIFF
--- a/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.tsx
@@ -834,13 +834,3 @@ const alphabet = [
   'Y',
   'Z',
 ];
-
-// some things i would like to show/discuss in standup. posting here so i don’t forget!
-
-// Encyclopadia improvements:
-// 1. make all components responsive with                     | this improves the visuals on smaller devices
-// 2. move the button to the first position in the table  | on larger screens you no longer have to scroll to “Use this metric”.
-// 3. add a wrap text toggle (?)                                          | this improves the amount of visible results on smaller screens.
-
-// Encyclopadia discussions:
-// 1. how should “Exclude results with no metadata” work? leave as is? disable unless have a type...

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.tsx
@@ -12,7 +12,7 @@ import {
   CellProps,
   Column,
   InlineField,
-  InlineSwitch,
+  Switch,
   Input,
   InteractiveTable,
   Modal,
@@ -543,7 +543,7 @@ export const MetricEncyclopediaModal = (props: Props) => {
         <EditorField label="Search Settings">
           <>
             <div className={styles.selectItem}>
-              <InlineSwitch
+              <Switch
                 data-testid={testIds.searchWithMetadata}
                 value={fullMetaSearch}
                 disabled={useBackend || !hasMetadata}
@@ -555,7 +555,7 @@ export const MetricEncyclopediaModal = (props: Props) => {
               <p className={styles.selectItemLabel}>{placeholders.metadataSearchSwitch}</p>
             </div>
             <div className={styles.selectItem}>
-              <InlineSwitch
+              <Switch
                 data-testid={testIds.setUseBackend}
                 value={useBackend}
                 onChange={() => {
@@ -597,11 +597,11 @@ export const MetricEncyclopediaModal = (props: Props) => {
         <div>{letterSearchComponent()}</div>
         <div className={styles.alphabetRowToggles}>
           <div className={styles.selectItem}>
-            <InlineSwitch value={disableTextWrap} onChange={() => setDisableTextWrap((p) => !p)} />
+            <Switch value={disableTextWrap} onChange={() => setDisableTextWrap((p) => !p)} />
             <p className={styles.selectItemLabel}>Disable text wrap</p>
           </div>
           <div className={styles.selectItem}>
-            <InlineSwitch
+            <Switch
               value={excludeNullMetadata}
               disabled={useBackend || !hasMetadata}
               onChange={() => {
@@ -723,6 +723,7 @@ const getStyles = (theme: GrafanaTheme2, disableTextWrap: boolean) => {
     selectItem: css`
       display: flex;
       flex-direction: row;
+      align-items: center;
     `,
     selectItemLabel: css`
       margin: 0 0 0 ${theme.spacing(1)};
@@ -749,10 +750,12 @@ const getStyles = (theme: GrafanaTheme2, disableTextWrap: boolean) => {
       justify-content: space-between;
       align-items: center;
       column-gap: ${theme.spacing(1)};
+      margin-bottom: ${theme.spacing(1)};
     `,
     alphabetRowToggles: css`
       display: flex;
       flex-direction: row;
+      align-items: center;
       flex-wrap: wrap;
       column-gap: ${theme.spacing(1)};
     `,

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.tsx
@@ -554,10 +554,6 @@ export const MetricEncyclopediaModal = (props: Props) => {
               />
               <p className={styles.selectItemLabel}>{placeholders.metadataSearchSwitch}</p>
             </div>
-            {/* <div className={styles.selectItem}>
-                  <InlineSwitch data-testid={'im not sure what this toggle does.'} value={false} onChange={() => {}} />
-                  <p className={styles.selectItemLabel}>Disable fuzzy search metadata browsing (HELP!)</p>
-                </div> */}
             <div className={styles.selectItem}>
               <InlineSwitch
                 data-testid={testIds.setUseBackend}

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/MetricEncyclopediaModal.tsx
@@ -274,6 +274,12 @@ export const MetricEncyclopediaModal = (props: Props) => {
       });
     }
 
+    if (excludeNullMetadata) {
+      filteredMetrics = filteredMetrics.filter((m: MetricData) => {
+        return m.type !== undefined && m.description !== undefined;
+      });
+    }
+
     return filteredMetrics;
   }
 


### PR DESCRIPTION
**What is this feature?**
1. make all components responsive for smaller screens
2. move the button to the first position in the table
3. add a wrap text toggle
4. "exclude metrics with no metadata" now works without type filter
5. converts all use of InlineSwitch to Switch

**Why do we need this feature?**
...

**Who is this feature for?**
...

**Which issue(s) does this PR fix?**:
Fixes #

**Special notes for your reviewer**:
**Before & After:**
<div>

<img width="49%" alt="Screenshot 2023-03-16 at 15 02 05" src="https://user-images.githubusercontent.com/34524710/225658663-96c40137-b015-463a-aa84-7855ef19c0c6.png">

<img width="49%" alt="Screenshot 2023-03-16 at 14 57 19" src="https://user-images.githubusercontent.com/34524710/225657646-6006c770-3d20-495a-9c28-5d93e05bcf97.png">
</div>