### PR TITLE
Design System: Remove unused type parameter in `SegmentProps` and `SegmentInput`

### DIFF
--- a/packages/grafana-ui/src/components/Segment/Segment.tsx
+++ b/packages/grafana-ui/src/components/Segment/Segment.tsx
@@ -11,7 +11,7 @@ import { getSegmentStyles } from './styles';
 
 import { SegmentSelect, useExpandableLabel, SegmentProps } from './';
 
-export interface SegmentSyncProps<T> extends SegmentProps<T>, Omit<HTMLProps<HTMLDivElement>, 'value' | 'onChange'> {
+export interface SegmentSyncProps<T> extends SegmentProps, Omit<HTMLProps<HTMLDivElement>, 'value' | 'onChange'> {
   value?: T | SelectableValue<T>;
   onChange: (item: SelectableValue<T>) => void;
   options: Array<SelectableValue<T>>;

--- a/packages/grafana-ui/src/components/Segment/SegmentAsync.tsx
+++ b/packages/grafana-ui/src/components/Segment/SegmentAsync.tsx
@@ -15,7 +15,7 @@ import { getSegmentStyles } from './styles';
 
 import { useExpandableLabel, SegmentProps } from '.';
 
-export interface SegmentAsyncProps<T> extends SegmentProps<T>, Omit<HTMLProps<HTMLDivElement>, 'value' | 'onChange'> {
+export interface SegmentAsyncProps<T> extends SegmentProps, Omit<HTMLProps<HTMLDivElement>, 'value' | 'onChange'> {
   value?: T | SelectableValue<T>;
   loadOptions: (query?: string) => Promise<Array<SelectableValue<T>>>;
   /**

--- a/packages/grafana-ui/src/components/Segment/SegmentInput.story.tsx
+++ b/packages/grafana-ui/src/components/Segment/SegmentInput.story.tsx
@@ -100,12 +100,10 @@ export const InputWithAutoFocus = () => {
   );
 };
 
-export const Basic: ComponentStory<React.ComponentType<SegmentInputProps<string | number>>> = (
-  args: SegmentInputProps<string | number>
-) => {
+export const Basic: ComponentStory<React.ComponentType<SegmentInputProps>> = (args: SegmentInputProps) => {
   const [value, setValue] = useState(args.value);
 
-  const props: SegmentInputProps<string | number> = {
+  const props: SegmentInputProps = {
     ...args,
     value,
     onChange: (value) => {

--- a/packages/grafana-ui/src/components/Segment/SegmentInput.story.tsx
+++ b/packages/grafana-ui/src/components/Segment/SegmentInput.story.tsx
@@ -117,7 +117,7 @@ export const Basic: ComponentStory<React.ComponentType<SegmentInputProps<string 
 
   return (
     <SegmentSection label="Segment:">
-      <SegmentInput<string | number> {...props} />
+      <SegmentInput {...props} />
     </SegmentSection>
   );
 };

--- a/packages/grafana-ui/src/components/Segment/SegmentInput.tsx
+++ b/packages/grafana-ui/src/components/Segment/SegmentInput.tsx
@@ -12,7 +12,7 @@ import { useExpandableLabel, SegmentProps } from '.';
 
 export interface SegmentInputProps
   extends Omit<SegmentProps, 'allowCustomValue' | 'allowEmptyValue'>,
-  Omit<HTMLProps<HTMLInputElement>, 'value' | 'onChange'> {
+    Omit<HTMLProps<HTMLInputElement>, 'value' | 'onChange'> {
   value: string | number;
   onChange: (text: string | number) => void;
 }

--- a/packages/grafana-ui/src/components/Segment/SegmentInput.tsx
+++ b/packages/grafana-ui/src/components/Segment/SegmentInput.tsx
@@ -10,16 +10,16 @@ import { getSegmentStyles } from './styles';
 
 import { useExpandableLabel, SegmentProps } from '.';
 
-export interface SegmentInputProps<T>
-  extends Omit<SegmentProps<T>, 'allowCustomValue' | 'allowEmptyValue'>,
-    Omit<HTMLProps<HTMLInputElement>, 'value' | 'onChange'> {
+export interface SegmentInputProps
+  extends Omit<SegmentProps, 'allowCustomValue' | 'allowEmptyValue'>,
+  Omit<HTMLProps<HTMLInputElement>, 'value' | 'onChange'> {
   value: string | number;
   onChange: (text: string | number) => void;
 }
 
 const FONT_SIZE = 14;
 
-export function SegmentInput<T>({
+export function SegmentInput({
   value: initialValue,
   onChange,
   Component,
@@ -30,7 +30,7 @@ export function SegmentInput<T>({
   autofocus = false,
   onExpandedChange,
   ...rest
-}: React.PropsWithChildren<SegmentInputProps<T>>) {
+}: React.PropsWithChildren<SegmentInputProps>) {
   const ref = useRef<HTMLInputElement>(null);
   const [value, setValue] = useState<number | string>(initialValue);
   const [inputWidth, setInputWidth] = useState<number>(measureText((initialValue || '').toString(), FONT_SIZE).width);

--- a/packages/grafana-ui/src/components/Segment/types.ts
+++ b/packages/grafana-ui/src/components/Segment/types.ts
@@ -1,6 +1,6 @@
 import { ReactElement } from 'react';
 
-export interface SegmentProps<T> {
+export interface SegmentProps {
   Component?: ReactElement;
   className?: string;
   allowCustomValue?: boolean;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What this does?**

[`SegmentProps`](https://github.com/grafana/grafana/blob/main/packages/grafana-ui/src/components/Segment/types.ts) and [`SegmentInput`](https://github.com/grafana/grafana/blob/0e565a2e6cf524605d40f3bdfd92cc1b99b1f1e8/packages/grafana-ui/src/components/Segment/SegmentInput.tsx#L13) both have an unused generic type parameter.

This PR removes the type parameter in `SegmentProps` and `SegmentInput`. Other Segment components retain their type parameters.

**Why do we need this fix?**

These unused type parameters confuse developers who use these components.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #59341

**Special notes for your reviewer**:

These type parameters are not used outside, so they can be safely removed
https://github.com/search?q=repo%3Agrafana%2Fgrafana+segmentInput%3C&type=code
https://github.com/search?q=repo%3Agrafana%2Fgrafana+SegmentProps%3C&type=code
https://github.com/search?q=repo%3Agrafana%2Fgrafana+segmentInputProps%3C&type=code