### PR TITLE
TraceView: Don't require preferredVisualisationType to render

### DIFF
--- a/public/app/features/explore/TraceView/TraceView.tsx
+++ b/public/app/features/explore/TraceView/TraceView.tsx
@@ -139,7 +139,7 @@ export function TraceView(props: Props) {
 
   return (
     <>
-      {props.dataFrames?.length && props.dataFrames[0]?.meta?.preferredVisualisationType === 'trace' && traceProp ? (
+      {props.dataFrames?.length && traceProp ? (
         <>
           {config.featureToggles.newTraceView ? (
             <NewTracePageHeader

--- a/public/app/plugins/panel/traces/TracesPanel.tsx
+++ b/public/app/plugins/panel/traces/TracesPanel.tsx
@@ -40,7 +40,7 @@ export const TracesPanel = ({ data }: PanelProps) => {
   return (
     <div className={styles.wrapper}>
       <div ref={topOfViewRef}></div>
-      {data.series[0]?.meta?.preferredVisualisationType === 'trace' && !config.featureToggles.newTraceView ? (
+      {!config.featureToggles.newTraceView ? (
         <TracePageSearchBar
           navigable={true}
           searchValue={search}


### PR DESCRIPTION
Fixes: https://github.com/grafana/grafana/issues/62417