### PR TITLE
Prometheus: Reorder the components for query builder 

### DIFF
--- a/public/app/plugins/datasource/prometheus/querybuilder/components/LabelFilters.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/LabelFilters.tsx
@@ -54,7 +54,7 @@ export function LabelFilters({
   return (
     <EditorFieldGroup>
       <EditorField
-        label="Label filters"
+        label="2. Label filters"
         error={MISSING_LABEL_FILTER_ERROR_MESSAGE}
         invalid={labelFilterRequired && !hasLabelFilter}
       >

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilder.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilder.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import React, { useCallback, useState } from 'react';
 
 import { DataSourceApi, GrafanaTheme2, PanelData, SelectableValue } from '@grafana/data';
-import { EditorRow } from '@grafana/experimental';
+import { EditorField, EditorRow, Stack } from '@grafana/experimental';
 import { config } from '@grafana/runtime';
 import { Button, Tag, useStyles2 } from '@grafana/ui';
 
@@ -16,7 +16,6 @@ import { OperationList } from '../shared/OperationList';
 import { OperationListExplained } from '../shared/OperationListExplained';
 import { OperationsEditorRow } from '../shared/OperationsEditorRow';
 import { QueryBuilderHints } from '../shared/QueryBuilderHints';
-import { RawQuery } from '../shared/RawQuery';
 import { regexifyLabelValuesQueryString } from '../shared/parsingUtils';
 import { QueryBuilderLabelFilter, QueryBuilderOperation } from '../shared/types';
 import { PromVisualQuery } from '../types';
@@ -25,7 +24,6 @@ import { LabelFilters } from './LabelFilters';
 import { MetricEncyclopediaModal } from './MetricEncyclopediaModal';
 import { MetricSelect, PROMETHEUS_QUERY_BUILDER_MAX_RESULTS } from './MetricSelect';
 import { NestedQueryList } from './NestedQueryList';
-import { EXPLAIN_LABEL_FILTER_CONTENT } from './PromQueryBuilderExplained';
 
 export interface Props {
   query: PromVisualQuery;
@@ -214,37 +212,39 @@ export const PromQueryBuilder = React.memo<Props>((props) => {
     <>
       <EditorRow>
         {MetricEncyclopedia ? (
-          <>
-            <Button
-              className={styles.button}
-              variant="secondary"
-              size="sm"
-              onClick={() => setMetricEncyclopediaModalOpen((prevValue) => !prevValue)}
-            >
-              Metric Encyclopedia
-            </Button>
-            {query.metric && (
-              <Tag
-                name={' ' + query.metric}
-                color="#3D71D9"
-                icon="times"
-                onClick={() => {
-                  onChange({ ...query, metric: '' });
-                }}
-                title="Click to remove metric"
-                className={styles.metricTag}
-              />
-            )}
-            {metricEncyclopediaModalOpen && (
-              <MetricEncyclopediaModal
-                datasource={datasource}
-                isOpen={metricEncyclopediaModalOpen}
-                onClose={() => setMetricEncyclopediaModalOpen(false)}
-                query={query}
-                onChange={onChange}
-              />
-            )}
-          </>
+          <EditorField label="1. Metric select">
+            <Stack gap={1}>
+              <Button
+                className={styles.button}
+                variant="secondary"
+                size="sm"
+                onClick={() => setMetricEncyclopediaModalOpen((prevValue) => !prevValue)}
+              >
+                Metric Encyclopedia
+              </Button>
+              {query.metric && (
+                <Tag
+                  name={' ' + query.metric}
+                  color="#3D71D9"
+                  icon="times"
+                  onClick={() => {
+                    onChange({ ...query, metric: '' });
+                  }}
+                  title="Click to remove metric"
+                  className={styles.metricTag}
+                />
+              )}
+              {metricEncyclopediaModalOpen && (
+                <MetricEncyclopediaModal
+                  datasource={datasource}
+                  isOpen={metricEncyclopediaModalOpen}
+                  onClose={() => setMetricEncyclopediaModalOpen(false)}
+                  query={query}
+                  onChange={onChange}
+                />
+              )}
+            </Stack>
+          </EditorField>
         ) : (
           <MetricSelect
             query={query}
@@ -254,6 +254,13 @@ export const PromQueryBuilder = React.memo<Props>((props) => {
             labelsFilters={query.labels}
           />
         )}
+      </EditorRow>
+      {showExplain && (
+        <OperationExplainedBox stepNumber={1} title={'Add a meaningful title here.'}>
+          Add a description of what this section of the query builder does.
+        </OperationExplainedBox>
+      )}
+      <EditorRow>
         <LabelFilters
           getLabelValuesAutofillSuggestions={getLabelValuesAutocompleteSuggestions}
           labelsFilters={query.labels}
@@ -264,42 +271,52 @@ export const PromQueryBuilder = React.memo<Props>((props) => {
         />
       </EditorRow>
       {showExplain && (
-        <OperationExplainedBox
-          stepNumber={1}
-          title={<RawQuery query={`${query.metric} ${promQueryModeller.renderLabels(query.labels)}`} lang={lang} />}
-        >
-          {EXPLAIN_LABEL_FILTER_CONTENT}
+        <OperationExplainedBox stepNumber={2} title={'Add a meaningful title here.'}>
+          Add a description of what this section of the query builder does.
         </OperationExplainedBox>
       )}
       <OperationsEditorRow>
-        <OperationList<PromVisualQuery>
-          queryModeller={promQueryModeller}
-          // eslint-ignore
-          datasource={datasource as DataSourceApi}
-          query={query}
-          onChange={onChange}
-          onRunQuery={onRunQuery}
-          highlightedOp={highlightedOp}
-        />
-        <QueryBuilderHints<PromVisualQuery>
-          datasource={datasource}
-          query={query}
-          onChange={onChange}
-          data={data}
-          queryModeller={promQueryModeller}
-          buildVisualQueryFromString={buildVisualQueryFromString}
-        />
+        <EditorField label="3. Operations">
+          <OperationList<PromVisualQuery>
+            queryModeller={promQueryModeller}
+            // eslint-ignore
+            datasource={datasource as DataSourceApi}
+            query={query}
+            onChange={onChange}
+            onRunQuery={onRunQuery}
+            highlightedOp={highlightedOp}
+          />
+        </EditorField>
       </OperationsEditorRow>
+      {showExplain && (
+        <OperationExplainedBox stepNumber={3} title={'Add a meaningful title here.'}>
+          Add a description of what this section of the query builder does.
+        </OperationExplainedBox>
+      )}
       {showExplain && (
         <OperationListExplained<PromVisualQuery>
           lang={lang}
           query={query}
-          stepNumber={2}
+          stepNumber={4}
           queryModeller={promQueryModeller}
           onMouseEnter={(op) => setHighlightedOp(op)}
           onMouseLeave={() => setHighlightedOp(undefined)}
         />
       )}
+
+      <EditorRow>
+        <EditorField label="4. Hints">
+          <QueryBuilderHints<PromVisualQuery>
+            datasource={datasource}
+            query={query}
+            onChange={onChange}
+            data={data}
+            queryModeller={promQueryModeller}
+            buildVisualQueryFromString={buildVisualQueryFromString}
+          />
+        </EditorField>
+      </EditorRow>
+
       {query.binaryQueries && query.binaryQueries.length > 0 && (
         <NestedQueryList
           query={query}

--- a/public/app/plugins/datasource/prometheus/querybuilder/shared/OperationList.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/shared/OperationList.tsx
@@ -126,9 +126,7 @@ export function OperationList<T extends QueryWithOperations>({
               placeholder={'Search'}
             />
           ) : (
-            <Button icon={'plus'} variant={'secondary'} onClick={() => setCascaderOpen(true)} title={'Add operation'}>
-              Operations
-            </Button>
+            <Button icon={'plus'} variant={'secondary'} onClick={() => setCascaderOpen(true)} title={'Add operation'} />
           )}
         </div>
       </Stack>

--- a/public/app/plugins/datasource/prometheus/querybuilder/shared/QueryBuilderHints.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/shared/QueryBuilderHints.tsx
@@ -62,7 +62,7 @@ export const QueryBuilderHints = <T extends PromLokiVisualQuery>({
                   size="sm"
                   className={styles.hint}
                 >
-                  hint: {hint.fix?.title || hint.fix?.action?.type.toLowerCase().replace('_', ' ')}
+                  {hint.fix?.title || hint.fix?.action?.type.toLowerCase().replace('_', ' ')}
                 </Button>
               </Tooltip>
             );


### PR DESCRIPTION
## This is a Work in Progress / Proof of Concept. (not ready for a review)
**What is this feature?**
this adds more structure to the query building experience by showing the user they should start by `1. selecting a metric` and then moving on to `2. selecting a label` and so on ...

**Why do we need this feature?**
...

**Who is this feature for?**
...

**Which issue(s) does this PR fix?**:
Fixes #
Related #64704

**Special notes for your reviewer:**
[63423 (comment)](https://github.com/grafana/grafana/pull/63423#issuecomment-1458651930)
[64704 (issue)](https://github.com/grafana/grafana/issues/64704)

**Before & After**
<img width="1705" alt="Screenshot 2023-03-16 at 16 44 39" src="https://user-images.githubusercontent.com/34524710/225691788-fb4ebdcf-e25b-4d90-88db-b1f9bf8bec00.png">

<img width="1707" alt="Screenshot 2023-03-16 at 16 43 09" src="https://user-images.githubusercontent.com/34524710/225691397-5b910ad0-c13b-43db-a660-d174340dbfde.png">


