### PR TITLE
align __interval to minInterval so it divides it

### DIFF
--- a/pkg/tsdb/intervalv2/intervalv2.go
+++ b/pkg/tsdb/intervalv2/intervalv2.go
@@ -63,11 +63,13 @@ func (ic *intervalCalculator) Calculate(timerange backend.TimeRange, minInterval
 
 	calculatedInterval := time.Duration((to - from) / resolution)
 
-	if calculatedInterval < minInterval {
-		return Interval{Text: FormatDuration(minInterval), Value: minInterval}
-	}
-
 	rounded := roundInterval(calculatedInterval)
+
+	if calculatedInterval < minInterval {
+		rounded = minInterval
+	} else if minInterval > 0 {
+		rounded = rounded / minInterval * minInterval
+	}
 
 	return Interval{Text: FormatDuration(rounded), Value: rounded}
 }

--- a/pkg/tsdb/intervalv2/intervalv2_test.go
+++ b/pkg/tsdb/intervalv2/intervalv2_test.go
@@ -16,24 +16,30 @@ func TestIntervalCalculator_Calculate(t *testing.T) {
 	timeNow := time.Now()
 
 	testCases := []struct {
-		name       string
-		timeRange  backend.TimeRange
-		resolution int64
-		expected   string
+		name        string
+		timeRange   backend.TimeRange
+		resolution  int64
+		expected    string
+		minInterval time.Duration
 	}{
-		{"from 5m to now and default resolution", backend.TimeRange{From: timeNow, To: timeNow.Add(5 * time.Minute)}, 0, "200ms"},
-		{"from 5m to now and 500 resolution", backend.TimeRange{From: timeNow, To: timeNow.Add(5 * time.Minute)}, 500, "500ms"},
-		{"from 15m to now and default resolution", backend.TimeRange{From: timeNow, To: timeNow.Add(15 * time.Minute)}, 0, "500ms"},
-		{"from 15m to now and 100 resolution", backend.TimeRange{From: timeNow, To: timeNow.Add(15 * time.Minute)}, 100, "10s"},
-		{"from 30m to now and default resolution", backend.TimeRange{From: timeNow, To: timeNow.Add(30 * time.Minute)}, 0, "1s"},
-		{"from 30m to now and 3000 resolution", backend.TimeRange{From: timeNow, To: timeNow.Add(30 * time.Minute)}, 3000, "500ms"},
-		{"from 1h to now and default resolution", backend.TimeRange{From: timeNow, To: timeNow.Add(time.Hour)}, 0, "2s"},
-		{"from 1h to now and 1000 resoluion", backend.TimeRange{From: timeNow, To: timeNow.Add(time.Hour)}, 1000, "5s"},
+		{"from 5m to now and default resolution", backend.TimeRange{From: timeNow, To: timeNow.Add(5 * time.Minute)}, 0, "200ms", time.Millisecond * 1},
+		{"from 5m to now and 500 resolution", backend.TimeRange{From: timeNow, To: timeNow.Add(5 * time.Minute)}, 500, "500ms", time.Millisecond * 1},
+		{"from 15m to now and default resolution", backend.TimeRange{From: timeNow, To: timeNow.Add(15 * time.Minute)}, 0, "500ms", time.Millisecond * 1},
+		{"from 15m to now and 100 resolution", backend.TimeRange{From: timeNow, To: timeNow.Add(15 * time.Minute)}, 100, "10s", time.Millisecond * 1},
+		{"from 30m to now and default resolution", backend.TimeRange{From: timeNow, To: timeNow.Add(30 * time.Minute)}, 0, "1s", time.Millisecond * 1},
+		{"from 30m to now and 3000 resolution", backend.TimeRange{From: timeNow, To: timeNow.Add(30 * time.Minute)}, 3000, "500ms", time.Millisecond * 1},
+		{"from 1h to now and default resolution", backend.TimeRange{From: timeNow, To: timeNow.Add(time.Hour)}, 0, "2s", time.Millisecond * 1},
+		{"from 1h to now and 1000 resoluion", backend.TimeRange{From: timeNow, To: timeNow.Add(time.Hour)}, 1000, "5s", time.Millisecond * 1},
+
+		{"from 5m to now and default resolution and with zero mininterva", backend.TimeRange{From: timeNow, To: timeNow.Add(5 * time.Minute)}, 0, "200ms", 0},
+		{"from 5m to now and 500 resolution and with mininterval", backend.TimeRange{From: timeNow, To: timeNow.Add(5 * time.Minute)}, 500, "354ms", time.Millisecond * 177},
+		{"from 15m to now and default resolution and with mininterval", backend.TimeRange{From: timeNow, To: timeNow.Add(15 * time.Minute)}, 0, "354ms", time.Millisecond * 177},
+		{"from 15m to now and 100 resolution and with mininterval", backend.TimeRange{From: timeNow, To: timeNow.Add(15 * time.Minute)}, 100, "8s", time.Second * 4},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			interval := calculator.Calculate(tc.timeRange, time.Millisecond*1, tc.resolution)
+			interval := calculator.Calculate(tc.timeRange, tc.minInterval, tc.resolution)
 			assert.Equal(t, tc.expected, interval.Text)
 		})
 	}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

It align calculated `$__interval` value onto `minInterval` value.
So `$__interval` divided without remainder on `minInterval` value.

**Why do we need this feature?**

It's recommended to set `minInterval` value to be equal data sending period.
Nevertheless at some combination of screen resolutions and data sending periods  we could get `__interval` not divided on period of data sendings.
Let assume we have data sending every `15s` and `__interval = 20s`
In that case some intervals will get two points of data and some intervals will get one point.
Graph will be broken, or otherwise datasource would need very smart interpolation system.

**Who is this feature for?**

It would be effective for any kind of users with custom data sources which do not have interpolation yet.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

