### PR TITLE
Plugins: add UI toggle for additional datasources for secure socks proxy

### DIFF
--- a/public/app/plugins/datasource/azuremonitor/components/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/ConfigEditor.tsx
@@ -2,7 +2,8 @@ import React, { PureComponent } from 'react';
 
 import { DataSourcePluginOptionsEditorProps, SelectableValue, updateDatasourcePluginOption } from '@grafana/data';
 import { getBackendSrv, getTemplateSrv, isFetchError, TemplateSrv } from '@grafana/runtime';
-import { Alert } from '@grafana/ui';
+import { Alert, SecureSocksProxySettings } from '@grafana/ui';
+import { config } from 'app/core/config';
 
 import ResponseParser from '../azure_monitor/response_parser';
 import { AzureDataSourceJsonData, AzureDataSourceSecureJsonData, AzureDataSourceSettings } from '../types';
@@ -84,7 +85,7 @@ export class ConfigEditor extends PureComponent<Props, State> {
   };
 
   render() {
-    const { options } = this.props;
+    const { options, onOptionsChange } = this.props;
     const { error } = this.state;
 
     return (
@@ -95,6 +96,9 @@ export class ConfigEditor extends PureComponent<Props, State> {
             <p>{error.description}</p>
             {error.details && <details style={{ whiteSpace: 'pre-wrap' }}>{error.details}</details>}
           </Alert>
+        )}
+        {config.featureToggles.secureSocksDatasourceProxy && (
+          <SecureSocksProxySettings options={options} onOptionsChange={onOptionsChange} />
         )}
       </>
     );

--- a/public/app/plugins/datasource/cloud-monitoring/components/ConfigEditor/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/ConfigEditor/ConfigEditor.tsx
@@ -2,6 +2,8 @@ import React, { PureComponent } from 'react';
 
 import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
 import { ConnectionConfig } from '@grafana/google-sdk';
+import { SecureSocksProxySettings } from '@grafana/ui';
+import { config } from 'app/core/config';
 
 import { CloudMonitoringOptions, CloudMonitoringSecureJsonData } from '../../types';
 
@@ -9,9 +11,13 @@ export type Props = DataSourcePluginOptionsEditorProps<CloudMonitoringOptions, C
 
 export class ConfigEditor extends PureComponent<Props> {
   render() {
+    const { options, onOptionsChange } = this.props;
     return (
       <>
         <ConnectionConfig {...this.props}></ConnectionConfig>
+        {config.featureToggles.secureSocksDatasourceProxy && (
+          <SecureSocksProxySettings options={options} onOptionsChange={onOptionsChange} />
+        )}
       </>
     );
   }

--- a/public/app/plugins/datasource/parca/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/parca/ConfigEditor.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 
 import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
-import { DataSourceHttpSettings } from '@grafana/ui';
+import { DataSourceHttpSettings, SecureSocksProxySettings } from '@grafana/ui';
+import { config } from 'app/core/config';
 
 import { ParcaDataSourceOptions } from './types';
 
@@ -18,6 +19,9 @@ export const ConfigEditor = (props: Props) => {
         showAccessOptions={false}
         onChange={onOptionsChange}
       />
+      {config.featureToggles.secureSocksDatasourceProxy && (
+        <SecureSocksProxySettings options={options} onOptionsChange={onOptionsChange} />
+      )}
     </>
   );
 };

--- a/public/app/plugins/datasource/phlare/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/phlare/ConfigEditor.tsx
@@ -1,7 +1,14 @@
 import React from 'react';
 
 import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
-import { DataSourceHttpSettings, EventsWithValidation, LegacyForms, regexValidation } from '@grafana/ui';
+import {
+  DataSourceHttpSettings,
+  EventsWithValidation,
+  LegacyForms,
+  regexValidation,
+  SecureSocksProxySettings,
+} from '@grafana/ui';
+import { config } from 'app/core/config';
 
 import { PhlareDataSourceOptions } from './types';
 
@@ -19,6 +26,9 @@ export const ConfigEditor = (props: Props) => {
         onChange={onOptionsChange}
       />
 
+      {config.featureToggles.secureSocksDatasourceProxy && (
+        <SecureSocksProxySettings options={options} onOptionsChange={onOptionsChange} />
+      )}
       <h3 className="page-heading">Querying</h3>
       <div className="gf-form-group">
         <div className="gf-form-inline">


### PR DESCRIPTION
**What is this feature?**

This PR is a follow up to https://github.com/grafana/grafana/pull/59254, to add the UI for the datasources that already work with the feature toggle, `secureSocksDatasourceProxy`. This feature allows datasources to go through a socks5 proxy with TLS if the data source has `enableSecureSocksProxy=true` in the json data.

**Why do we need this feature?**

Grafana users need to be able to connect to datasources that live in different networks than where Grafana is running.

**Who is this feature for?**

Grafana users who are running datasources in multiple networks and cannot open ports up to the public internet.

**Which issue(s) does this PR fix?**:
https://github.com/grafana/hosted-grafana/issues/2922

**Screenshots of the UI**:
![azure monitoring](https://user-images.githubusercontent.com/14365078/225753211-663d6dbd-1778-481d-8d50-f7ae59698ea9.png)
![cloud monitoring](https://user-images.githubusercontent.com/14365078/225753216-8de5b52d-4b6d-4008-b720-19dab9e24680.png)
![phlare](https://user-images.githubusercontent.com/14365078/225753214-61b3bd3c-de5d-4326-8461-fefdb26efee0.png)
![parca](https://user-images.githubusercontent.com/14365078/225753217-361f2b11-f0d6-48ae-a0f0-cc1de3bee48d.png)