### PR TITLE
Alerting: Inherit new policy grouping from parent

### DIFF
--- a/public/app/features/alerting/unified/components/notification-policies/EditNotificationPolicyForm.tsx
+++ b/public/app/features/alerting/unified/components/notification-policies/EditNotificationPolicyForm.tsx
@@ -43,9 +43,16 @@ export interface AmRoutesExpandedFormProps {
   route?: RouteWithID;
   onSubmit: (route: Partial<FormAmRoute>) => void;
   actionButtons: ReactNode;
+  defaults?: Partial<FormAmRoute>;
 }
 
-export const AmRoutesExpandedForm = ({ actionButtons, receivers, route, onSubmit }: AmRoutesExpandedFormProps) => {
+export const AmRoutesExpandedForm = ({
+  actionButtons,
+  receivers,
+  route,
+  onSubmit,
+  defaults,
+}: AmRoutesExpandedFormProps) => {
   const styles = useStyles2(getStyles);
   const formStyles = useStyles2(getFormStyles);
   const [groupByOptions, setGroupByOptions] = useState(stringsToSelectableValues(route?.group_by));
@@ -53,7 +60,10 @@ export const AmRoutesExpandedForm = ({ actionButtons, receivers, route, onSubmit
 
   const receiversWithOnCallOnTop = receivers.sort(onCallFirst);
 
-  const formAmRoute = amRouteToFormAmRoute(route);
+  const formAmRoute = {
+    ...amRouteToFormAmRoute(route),
+    ...defaults,
+  };
 
   const emptyMatcher = [{ name: '', operator: MatcherOperator.equal, value: '' }];
 

--- a/public/app/features/alerting/unified/components/notification-policies/Modals.tsx
+++ b/public/app/features/alerting/unified/components/notification-policies/Modals.tsx
@@ -55,6 +55,9 @@ const useAddPolicyModal = (
         >
           <AmRoutesExpandedForm
             receivers={AmRouteReceivers}
+            defaults={{
+              groupBy: parentRoute?.group_by,
+            }}
             onSubmit={(newRoute) => parentRoute && handleAdd(newRoute, parentRoute)}
             actionButtons={
               <Modal.ButtonRow>


### PR DESCRIPTION
**What is this feature?**

When creating a new notification policy, the "override grouping" should suggest the parent route's grouping by default.

**Which issue(s) does this PR fix?**:

Fixes #64955

