### PR TITLE
Logs: Fix variant of `Download logs` button

### DIFF
--- a/public/app/features/explore/LogsMetaRow.tsx
+++ b/public/app/features/explore/LogsMetaRow.tsx
@@ -147,7 +147,7 @@ export const LogsMetaRow = React.memo(
               })}
             />
             <Dropdown overlay={downloadMenu}>
-              <ToolbarButton isOpen={false} variant="default" icon="download-alt">
+              <ToolbarButton isOpen={false} variant="canvas" icon="download-alt">
                 Download
               </ToolbarButton>
             </Dropdown>


### PR DESCRIPTION
**What is this feature?**

Fixes the variant of the `Download logs` button.

**Special notes for your reviewer**:

Before:

![image](https://user-images.githubusercontent.com/8092184/225931893-f8ee32d3-a56e-4df1-9594-7aab3098e181.png)
![image](https://user-images.githubusercontent.com/8092184/225931941-265390d6-8476-4c98-8400-81a986c7cd3a.png)

After:

![image](https://user-images.githubusercontent.com/8092184/225932027-808e3679-3481-43b9-b546-68ba2fbd3bb4.png)
![image](https://user-images.githubusercontent.com/8092184/225931989-69521c1f-a1ad-4d09-9c61-d807aaac42b6.png)
