### PR TITLE
Plugins: Freeze the context before giving it to the extensions

### DIFF
--- a/packages/grafana-runtime/src/services/pluginExtensions/extensions.test.ts
+++ b/packages/grafana-runtime/src/services/pluginExtensions/extensions.test.ts
@@ -1,6 +1,6 @@
 import { assertPluginExtensionLink, PluginExtensionLink, PluginExtensionTypes } from '@grafana/data';
 
-import { getPluginExtensions } from './extensions';
+import { deepFreeze, getPluginExtensions } from './extensions';
 import { PluginExtensionRegistryItem, setPluginsExtensionRegistry } from './registry';
 
 describe('getPluginExtensions', () => {
@@ -66,6 +66,89 @@ describe('getPluginExtensions', () => {
 
       expect(extensions.length).toBe(0);
     });
+  });
+});
+
+describe('deepFreeze()', () => {
+  test('should not fail when called with primitive values', () => {
+    expect(deepFreeze(1)).toBe(1);
+    expect(deepFreeze('foo')).toBe('foo');
+    expect(deepFreeze(true)).toBe(true);
+    expect(deepFreeze(false)).toBe(false);
+    expect(deepFreeze(undefined)).toBe(undefined);
+    expect(deepFreeze(null)).toBe(null);
+  });
+
+  test('should freeze an object so it cannot be overriden', () => {
+    const obj = {
+      a: 1,
+      b: '2',
+      c: true,
+    };
+    const frozen = deepFreeze(obj);
+
+    expect(() => {
+      frozen = { a: 234 };
+    }).toThrow(TypeError);
+  });
+
+  test('should freeze the primitive properties of an object', () => {
+    const obj = {
+      a: 1,
+      b: '2',
+      c: true,
+    };
+    const frozen = deepFreeze(obj);
+
+    expect(() => {
+      frozen.a = 2;
+      frozen.b = '3';
+      frozen.c = false;
+    }).toThrow(TypeError);
+  });
+
+  test('should freeze the nested object properties', () => {
+    const obj = {
+      a: 1,
+      b: {
+        c: {
+          d: 2,
+          e: {
+            f: 3,
+          },
+        },
+      },
+    };
+    const frozen = deepFreeze(obj);
+
+    // Trying to override a primitive property
+    expect(() => {
+      frozen.a = 2;
+    }).toThrow(TypeError);
+
+    // Trying to override an underlying object
+    expect(() => {
+      frozen.b = {};
+    }).toThrow(TypeError);
+
+    // Trying to override deeply nested properties
+    expect(() => {
+      frozen.b.c.e.f = 12345;
+    }).toThrow(TypeError);
+  });
+
+  test('should not blow up when called with an object that contains cycles', () => {
+    const obj = {
+      a: 1,
+      b: {
+        c: 123,
+      },
+    };
+    obj.b.d = obj;
+
+    expect(() => {
+      deepFreeze(obj);
+    }).not.toThrow();
   });
 });
 

--- a/packages/grafana-runtime/src/services/pluginExtensions/extensions.test.ts
+++ b/packages/grafana-runtime/src/services/pluginExtensions/extensions.test.ts
@@ -71,11 +71,14 @@ describe('getPluginExtensions', () => {
 
 describe('deepFreeze()', () => {
   test('should not fail when called with primitive values', () => {
-    expect(deepFreeze(1)).toBe(1);
-    expect(deepFreeze('foo')).toBe('foo');
-    expect(deepFreeze(true)).toBe(true);
-    expect(deepFreeze(false)).toBe(false);
+    expect(deepFreeze<Number>(1)).toBe(1);
+    expect(deepFreeze<String>('foo')).toBe('foo');
+    expect(deepFreeze<Boolean>(true)).toBe(true);
+    expect(deepFreeze<Boolean>(false)).toBe(false);
+
+    // @ts-ignore
     expect(deepFreeze(undefined)).toBe(undefined);
+    // @ts-ignore
     expect(deepFreeze(null)).toBe(null);
   });
 
@@ -85,10 +88,11 @@ describe('deepFreeze()', () => {
       b: '2',
       c: true,
     };
-    const frozen = deepFreeze(obj);
+    const frozen = deepFreeze<typeof obj>(obj);
 
+    expect(Object.isFrozen(frozen)).toBe(true);
     expect(() => {
-      frozen = { a: 234 };
+      frozen.a = 234;
     }).toThrow(TypeError);
   });
 
@@ -98,8 +102,9 @@ describe('deepFreeze()', () => {
       b: '2',
       c: true,
     };
-    const frozen = deepFreeze(obj);
+    const frozen = deepFreeze<typeof obj>(obj);
 
+    expect(Object.isFrozen(frozen)).toBe(true);
     expect(() => {
       frozen.a = 2;
       frozen.b = '3';
@@ -119,15 +124,20 @@ describe('deepFreeze()', () => {
         },
       },
     };
-    const frozen = deepFreeze(obj);
+    const frozen = deepFreeze<typeof obj>(obj);
+
+    // Check if the object is frozen
+    expect(Object.isFrozen(frozen)).toBe(true);
 
     // Trying to override a primitive property
     expect(() => {
       frozen.a = 2;
     }).toThrow(TypeError);
 
-    // Trying to override an underlying object
+    // Trying to override an underlying object and check if it is frozen
+    expect(Object.isFrozen(frozen.b)).toBe(true);
     expect(() => {
+      // @ts-ignore
       frozen.b = {};
     }).toThrow(TypeError);
 
@@ -144,11 +154,22 @@ describe('deepFreeze()', () => {
         c: 123,
       },
     };
+    // @ts-ignore
     obj.b.d = obj;
+    let frozen: typeof obj;
 
+    // Check if it does not throw due to the cycle in the object
     expect(() => {
-      deepFreeze(obj);
+      frozen = deepFreeze<typeof obj>(obj);
     }).not.toThrow();
+
+    // Check if it did freeze the object
+    // @ts-ignore
+    expect(Object.isFrozen(frozen)).toBe(true);
+    // @ts-ignore
+    expect(Object.isFrozen(frozen.b)).toBe(true);
+    // @ts-ignore
+    expect(Object.isFrozen(frozen.b.d)).toBe(true);
   });
 });
 

--- a/packages/grafana-runtime/src/services/pluginExtensions/extensions.ts
+++ b/packages/grafana-runtime/src/services/pluginExtensions/extensions.ts
@@ -37,7 +37,7 @@ export function getPluginExtensions<T extends object = {}>(
 // (Returns with the frozen object, however it's not a copy, the original object becomes frozen, too.)
 // @param `object` The object to freeze
 // @param `frozenProps` A set of objects that have already been frozen (used to prevent infinite recursion)
-export function deepFreeze<T extends object>(object: T, frozenProps = new Set()): T {
+export function deepFreeze<T extends object = {}>(object: T, frozenProps = new Set()): T {
   if (!object || typeof object !== 'object' || Object.isFrozen(object)) {
     return object;
   }

--- a/packages/grafana-runtime/src/services/pluginExtensions/extensions.ts
+++ b/packages/grafana-runtime/src/services/pluginExtensions/extensions.ts
@@ -35,7 +35,9 @@ export function getPluginExtensions<T extends object = {}>(
 
 // Freezes an object and all its properties recursively
 // (Returns with the frozen object, however it's not a copy, the original object becomes frozen, too.)
-export function deepFreeze(object: object, frozenProps = new Set()) {
+// @param `object` The object to freeze
+// @param `frozenProps` A set of objects that have already been frozen (used to prevent infinite recursion)
+export function deepFreeze<T extends object>(object: T, frozenProps = new Set()): T {
   if (!object || typeof object !== 'object' || Object.isFrozen(object)) {
     return object;
   }


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/64959

### What changed?
Freezing the `context{}` deeply object before giving it to the extensions. (More info on the why in https://github.com/grafana/grafana/issues/64959). 

**Notes to the reviewer**
We probably should move the `deepFreeze()` function somewhere else, but I still couldn't figure out where.