### PR TITLE
elasticsearch: more tests

### DIFF
--- a/pkg/tsdb/elasticsearch/snapshot_test.go
+++ b/pkg/tsdb/elasticsearch/snapshot_test.go
@@ -131,6 +131,10 @@ func TestResponseSnapshots(t *testing.T) {
 		{name: "simple metric test", path: "metric_simple"},
 		{name: "complex metric test", path: "metric_complex"},
 		{name: "multi metric test", path: "metric_multi"},
+		{name: "metric avg test", path: "metric_avg"},
+		{name: "metric percentiles test", path: "metric_percentiles"},
+		{name: "metric top_metrics test", path: "metric_top_metrics"},
+		{name: "metric extended_stats test", path: "metric_extended_stats"},
 		{name: "raw data test", path: "raw_data"},
 		{name: "logs test", path: "logs"},
 	}

--- a/pkg/tsdb/elasticsearch/snapshot_test.go
+++ b/pkg/tsdb/elasticsearch/snapshot_test.go
@@ -165,7 +165,7 @@ func TestResponseSnapshots(t *testing.T) {
 			require.Len(t, result.response.Responses, expectedResponseCount)
 
 			for refId, dataRes := range result.response.Responses {
-				goldenFileName := fmt.Sprintf("%v.%v.golden", test.path, refId)
+				goldenFileName := fmt.Sprintf("%v.%v.golden", test.path, strings.ToLower(refId))
 				// we make a copy of the variable to avoid this linter-warning:
 				// "G601: Implicit memory aliasing in for loop."
 				dataResCopy := dataRes

--- a/pkg/tsdb/elasticsearch/testdata_response/metric_avg.a.golden.jsonc
+++ b/pkg/tsdb/elasticsearch/testdata_response/metric_avg.a.golden.jsonc
@@ -1,0 +1,72 @@
+//  🌟 This was machine generated.  Do not edit. 🌟
+//  
+//  Frame[0] {
+//      "type": "timeseries-multi",
+//      "typeVersion": [
+//          0,
+//          0
+//      ]
+//  }
+//  Name: Average counter
+//  Dimensions: 2 Fields by 3 Rows
+//  +-------------------------------+------------------+
+//  | Name: Time                    | Name: Value      |
+//  | Labels:                       | Labels:          |
+//  | Type: []time.Time             | Type: []*float64 |
+//  +-------------------------------+------------------+
+//  | 2023-03-17 13:53:00 +0000 UTC | 39.5             |
+//  | 2023-03-17 13:54:00 +0000 UTC | 78.5             |
+//  | 2023-03-17 13:55:00 +0000 UTC | 143.5            |
+//  +-------------------------------+------------------+
+//  
+//  
+//  🌟 This was machine generated.  Do not edit. 🌟
+{
+  "status": 200,
+  "frames": [
+    {
+      "schema": {
+        "name": "Average counter",
+        "meta": {
+          "type": "timeseries-multi",
+          "typeVersion": [
+            0,
+            0
+          ]
+        },
+        "fields": [
+          {
+            "name": "Time",
+            "type": "time",
+            "typeInfo": {
+              "frame": "time.Time"
+            }
+          },
+          {
+            "name": "Value",
+            "type": "number",
+            "typeInfo": {
+              "frame": "float64",
+              "nullable": true
+            },
+            "labels": {}
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            1679061180000,
+            1679061240000,
+            1679061300000
+          ],
+          [
+            39.5,
+            78.5,
+            143.5
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/pkg/tsdb/elasticsearch/testdata_response/metric_avg.queries.json
+++ b/pkg/tsdb/elasticsearch/testdata_response/metric_avg.queries.json
@@ -1,0 +1,16 @@
+[{
+  "alias": "",
+  "bucketAggs": [
+    {
+      "field": "@timestamp",
+      "id": "2",
+      "settings": { "interval": "1m" },
+      "type": "date_histogram"
+    }
+  ],
+  "datasource": { "type": "elasticsearch", "uid": "uid" },
+  "datasourceId": 42,
+  "metrics": [{ "field": "counter", "id": "1", "type": "avg" }],
+  "query": "",
+  "refId": "A"
+}]

--- a/pkg/tsdb/elasticsearch/testdata_response/metric_avg.response.json
+++ b/pkg/tsdb/elasticsearch/testdata_response/metric_avg.response.json
@@ -1,0 +1,54 @@
+{
+  "took": 6,
+  "responses": [
+    {
+      "took": 5,
+      "timed_out": false,
+      "_shards": {
+        "total": 1,
+        "successful": 1,
+        "skipped": 0,
+        "failed": 0
+      },
+      "hits": {
+        "total": {
+          "value": 142,
+          "relation": "eq"
+        },
+        "max_score": null,
+        "hits": []
+      },
+      "aggregations": {
+        "2": {
+          "buckets": [
+            {
+              "key_as_string": "1679061180000",
+              "key": 1679061180000,
+              "doc_count": 12,
+              "1": {
+                "value": 39.5
+              }
+            },
+            {
+              "key_as_string": "1679061240000",
+              "key": 1679061240000,
+              "doc_count": 66,
+              "1": {
+                "value": 78.5
+              }
+            },
+            {
+              "key_as_string": "1679061300000",
+              "key": 1679061300000,
+              "doc_count": 64,
+              "1": {
+                "value": 143.5
+              }
+            }
+          ]
+        }
+      },
+      "status": 200
+    }
+  ]
+}

--- a/pkg/tsdb/elasticsearch/testdata_response/metric_extended_stats.a.golden.jsonc
+++ b/pkg/tsdb/elasticsearch/testdata_response/metric_extended_stats.a.golden.jsonc
@@ -1,0 +1,137 @@
+//  🌟 This was machine generated.  Do not edit. 🌟
+//  
+//  Frame[0] {
+//      "type": "timeseries-multi",
+//      "typeVersion": [
+//          0,
+//          0
+//      ]
+//  }
+//  Name: Std Dev Lower counter
+//  Dimensions: 2 Fields by 3 Rows
+//  +-------------------------------+--------------------+
+//  | Name: Time                    | Name: Value        |
+//  | Labels:                       | Labels:            |
+//  | Type: []time.Time             | Type: []*float64   |
+//  +-------------------------------+--------------------+
+//  | 2023-03-17 13:53:00 +0000 UTC | 32.59589494093068  |
+//  | 2023-03-17 13:54:00 +0000 UTC | 40.39925635021454  |
+//  | 2023-03-17 13:55:00 +0000 UTC | 106.55409359617767 |
+//  +-------------------------------+--------------------+
+//  
+//  
+//  
+//  Frame[1] {
+//      "type": "timeseries-multi",
+//      "typeVersion": [
+//          0,
+//          0
+//      ]
+//  }
+//  Name: Std Dev Upper counter
+//  Dimensions: 2 Fields by 3 Rows
+//  +-------------------------------+--------------------+
+//  | Name: Time                    | Name: Value        |
+//  | Labels:                       | Labels:            |
+//  | Type: []time.Time             | Type: []*float64   |
+//  +-------------------------------+--------------------+
+//  | 2023-03-17 13:53:00 +0000 UTC | 46.40410505906932  |
+//  | 2023-03-17 13:54:00 +0000 UTC | 116.60074364978546 |
+//  | 2023-03-17 13:55:00 +0000 UTC | 180.44590640382233 |
+//  +-------------------------------+--------------------+
+//  
+//  
+//  🌟 This was machine generated.  Do not edit. 🌟
+{
+  "status": 200,
+  "frames": [
+    {
+      "schema": {
+        "name": "Std Dev Lower counter",
+        "meta": {
+          "type": "timeseries-multi",
+          "typeVersion": [
+            0,
+            0
+          ]
+        },
+        "fields": [
+          {
+            "name": "Time",
+            "type": "time",
+            "typeInfo": {
+              "frame": "time.Time"
+            }
+          },
+          {
+            "name": "Value",
+            "type": "number",
+            "typeInfo": {
+              "frame": "float64",
+              "nullable": true
+            },
+            "labels": {}
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            1679061180000,
+            1679061240000,
+            1679061300000
+          ],
+          [
+            32.59589494093068,
+            40.39925635021454,
+            106.55409359617767
+          ]
+        ]
+      }
+    },
+    {
+      "schema": {
+        "name": "Std Dev Upper counter",
+        "meta": {
+          "type": "timeseries-multi",
+          "typeVersion": [
+            0,
+            0
+          ]
+        },
+        "fields": [
+          {
+            "name": "Time",
+            "type": "time",
+            "typeInfo": {
+              "frame": "time.Time"
+            }
+          },
+          {
+            "name": "Value",
+            "type": "number",
+            "typeInfo": {
+              "frame": "float64",
+              "nullable": true
+            },
+            "labels": {}
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            1679061180000,
+            1679061240000,
+            1679061300000
+          ],
+          [
+            46.40410505906932,
+            116.60074364978546,
+            180.44590640382233
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/pkg/tsdb/elasticsearch/testdata_response/metric_extended_stats.queries.json
+++ b/pkg/tsdb/elasticsearch/testdata_response/metric_extended_stats.queries.json
@@ -1,0 +1,33 @@
+[
+  {
+    "alias": "",
+    "bucketAggs": [
+      {
+        "field": "@timestamp",
+        "id": "2",
+        "settings": {
+          "interval": "1m"
+        },
+        "type": "date_histogram"
+      }
+    ],
+    "datasource": {
+      "type": "elasticsearch",
+      "uid": "uid"
+    },
+    "datasourceId": 42,
+    "metrics": [
+      {
+        "field": "counter",
+        "id": "1",
+        "meta": {
+          "std_deviation_bounds_lower": true,
+          "std_deviation_bounds_upper": true
+        },
+        "type": "extended_stats"
+      }
+    ],
+    "query": "",
+    "refId": "A"
+  }
+]

--- a/pkg/tsdb/elasticsearch/testdata_response/metric_extended_stats.response.json
+++ b/pkg/tsdb/elasticsearch/testdata_response/metric_extended_stats.response.json
@@ -1,0 +1,111 @@
+{
+  "took": 8,
+  "responses": [
+    {
+      "took": 8,
+      "timed_out": false,
+      "_shards": {
+        "total": 1,
+        "successful": 1,
+        "skipped": 0,
+        "failed": 0
+      },
+      "hits": {
+        "total": {
+          "value": 142,
+          "relation": "eq"
+        },
+        "max_score": null,
+        "hits": []
+      },
+      "aggregations": {
+        "2": {
+          "buckets": [
+            {
+              "key_as_string": "1679061180000",
+              "key": 1679061180000,
+              "doc_count": 12,
+              "1": {
+                "count": 12,
+                "min": 34,
+                "max": 45,
+                "avg": 39.5,
+                "sum": 474,
+                "sum_of_squares": 18866,
+                "variance": 11.916666666666666,
+                "variance_population": 11.916666666666666,
+                "variance_sampling": 13,
+                "std_deviation": 3.452052529534663,
+                "std_deviation_population": 3.452052529534663,
+                "std_deviation_sampling": 3.605551275463989,
+                "std_deviation_bounds": {
+                  "upper": 46.40410505906932,
+                  "lower": 32.59589494093068,
+                  "upper_population": 46.40410505906932,
+                  "lower_population": 32.59589494093068,
+                  "upper_sampling": 46.711102550927976,
+                  "lower_sampling": 32.288897449072024
+                }
+              }
+            },
+            {
+              "key_as_string": "1679061240000",
+              "key": 1679061240000,
+              "doc_count": 66,
+              "1": {
+                "count": 66,
+                "min": 46,
+                "max": 111,
+                "avg": 78.5,
+                "sum": 5181,
+                "sum_of_squares": 430661,
+                "variance": 362.9166666666667,
+                "variance_population": 362.9166666666667,
+                "variance_sampling": 368.5,
+                "std_deviation": 19.05037182489273,
+                "std_deviation_population": 19.05037182489273,
+                "std_deviation_sampling": 19.196353820452465,
+                "std_deviation_bounds": {
+                  "upper": 116.60074364978546,
+                  "lower": 40.39925635021454,
+                  "upper_population": 116.60074364978546,
+                  "lower_population": 40.39925635021454,
+                  "upper_sampling": 116.89270764090493,
+                  "lower_sampling": 40.10729235909507
+                }
+              }
+            },
+            {
+              "key_as_string": "1679061300000",
+              "key": 1679061300000,
+              "doc_count": 64,
+              "1": {
+                "count": 64,
+                "min": 112,
+                "max": 175,
+                "avg": 143.5,
+                "sum": 9184,
+                "sum_of_squares": 1339744,
+                "variance": 341.25,
+                "variance_population": 341.25,
+                "variance_sampling": 346.6666666666667,
+                "std_deviation": 18.472953201911167,
+                "std_deviation_population": 18.472953201911167,
+                "std_deviation_sampling": 18.618986725025255,
+                "std_deviation_bounds": {
+                  "upper": 180.44590640382233,
+                  "lower": 106.55409359617767,
+                  "upper_population": 180.44590640382233,
+                  "lower_population": 106.55409359617767,
+                  "upper_sampling": 180.7379734500505,
+                  "lower_sampling": 106.2620265499495
+                }
+              }
+            }
+          ]
+        }
+      },
+      "status": 200
+    }
+  ]
+}

--- a/pkg/tsdb/elasticsearch/testdata_response/metric_percentiles.a.golden.jsonc
+++ b/pkg/tsdb/elasticsearch/testdata_response/metric_percentiles.a.golden.jsonc
@@ -1,0 +1,137 @@
+//  🌟 This was machine generated.  Do not edit. 🌟
+//  
+//  Frame[0] {
+//      "type": "timeseries-multi",
+//      "typeVersion": [
+//          0,
+//          0
+//      ]
+//  }
+//  Name: p25.0 counter
+//  Dimensions: 2 Fields by 3 Rows
+//  +-------------------------------+------------------+
+//  | Name: Time                    | Name: Value      |
+//  | Labels:                       | Labels:          |
+//  | Type: []time.Time             | Type: []*float64 |
+//  +-------------------------------+------------------+
+//  | 2023-03-17 13:53:00 +0000 UTC | 36.5             |
+//  | 2023-03-17 13:54:00 +0000 UTC | 62               |
+//  | 2023-03-17 13:55:00 +0000 UTC | 127.5            |
+//  +-------------------------------+------------------+
+//  
+//  
+//  
+//  Frame[1] {
+//      "type": "timeseries-multi",
+//      "typeVersion": [
+//          0,
+//          0
+//      ]
+//  }
+//  Name: p75.0 counter
+//  Dimensions: 2 Fields by 3 Rows
+//  +-------------------------------+------------------+
+//  | Name: Time                    | Name: Value      |
+//  | Labels:                       | Labels:          |
+//  | Type: []time.Time             | Type: []*float64 |
+//  +-------------------------------+------------------+
+//  | 2023-03-17 13:53:00 +0000 UTC | 42.5             |
+//  | 2023-03-17 13:54:00 +0000 UTC | 95               |
+//  | 2023-03-17 13:55:00 +0000 UTC | 159.5            |
+//  +-------------------------------+------------------+
+//  
+//  
+//  🌟 This was machine generated.  Do not edit. 🌟
+{
+  "status": 200,
+  "frames": [
+    {
+      "schema": {
+        "name": "p25.0 counter",
+        "meta": {
+          "type": "timeseries-multi",
+          "typeVersion": [
+            0,
+            0
+          ]
+        },
+        "fields": [
+          {
+            "name": "Time",
+            "type": "time",
+            "typeInfo": {
+              "frame": "time.Time"
+            }
+          },
+          {
+            "name": "Value",
+            "type": "number",
+            "typeInfo": {
+              "frame": "float64",
+              "nullable": true
+            },
+            "labels": {}
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            1679061180000,
+            1679061240000,
+            1679061300000
+          ],
+          [
+            36.5,
+            62,
+            127.5
+          ]
+        ]
+      }
+    },
+    {
+      "schema": {
+        "name": "p75.0 counter",
+        "meta": {
+          "type": "timeseries-multi",
+          "typeVersion": [
+            0,
+            0
+          ]
+        },
+        "fields": [
+          {
+            "name": "Time",
+            "type": "time",
+            "typeInfo": {
+              "frame": "time.Time"
+            }
+          },
+          {
+            "name": "Value",
+            "type": "number",
+            "typeInfo": {
+              "frame": "float64",
+              "nullable": true
+            },
+            "labels": {}
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            1679061180000,
+            1679061240000,
+            1679061300000
+          ],
+          [
+            42.5,
+            95,
+            159.5
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/pkg/tsdb/elasticsearch/testdata_response/metric_percentiles.queries.json
+++ b/pkg/tsdb/elasticsearch/testdata_response/metric_percentiles.queries.json
@@ -1,0 +1,35 @@
+[
+  {
+    "alias": "",
+    "bucketAggs": [
+      {
+        "field": "testtime",
+        "id": "2",
+        "settings": {
+          "interval": "1m"
+        },
+        "type": "date_histogram"
+      }
+    ],
+    "datasource": {
+      "type": "elasticsearch",
+      "uid": "uid"
+    },
+    "datasourceId": 42,
+    "metrics": [
+      {
+        "field": "counter",
+        "id": "1",
+        "settings": {
+          "percents": [
+            "25",
+            " 75"
+          ]
+        },
+        "type": "percentiles"
+      }
+    ],
+    "query": "",
+    "refId": "A"
+  }
+]

--- a/pkg/tsdb/elasticsearch/testdata_response/metric_percentiles.response.json
+++ b/pkg/tsdb/elasticsearch/testdata_response/metric_percentiles.response.json
@@ -1,0 +1,63 @@
+{
+  "took": 5,
+  "responses": [
+    {
+      "took": 5,
+      "timed_out": false,
+      "_shards": {
+        "total": 1,
+        "successful": 1,
+        "skipped": 0,
+        "failed": 0
+      },
+      "hits": {
+        "total": {
+          "value": 142,
+          "relation": "eq"
+        },
+        "max_score": null,
+        "hits": []
+      },
+      "aggregations": {
+        "2": {
+          "buckets": [
+            {
+              "key_as_string": "1679061180000",
+              "key": 1679061180000,
+              "doc_count": 12,
+              "1": {
+                "values": {
+                  "25.0": 36.5,
+                  "75.0": 42.5
+                }
+              }
+            },
+            {
+              "key_as_string": "1679061240000",
+              "key": 1679061240000,
+              "doc_count": 66,
+              "1": {
+                "values": {
+                  "25.0": 62,
+                  "75.0": 95
+                }
+              }
+            },
+            {
+              "key_as_string": "1679061300000",
+              "key": 1679061300000,
+              "doc_count": 64,
+              "1": {
+                "values": {
+                  "25.0": 127.5,
+                  "75.0": 159.5
+                }
+              }
+            }
+          ]
+        }
+      },
+      "status": 200
+    }
+  ]
+}

--- a/pkg/tsdb/elasticsearch/testdata_response/metric_top_metrics.a.golden.jsonc
+++ b/pkg/tsdb/elasticsearch/testdata_response/metric_top_metrics.a.golden.jsonc
@@ -1,0 +1,72 @@
+//  🌟 This was machine generated.  Do not edit. 🌟
+//  
+//  Frame[0] {
+//      "type": "timeseries-multi",
+//      "typeVersion": [
+//          0,
+//          0
+//      ]
+//  }
+//  Name: Top Metrics float
+//  Dimensions: 2 Fields by 3 Rows
+//  +-------------------------------+-------------------+
+//  | Name: Time                    | Name: Value       |
+//  | Labels:                       | Labels:           |
+//  | Type: []time.Time             | Type: []*float64  |
+//  +-------------------------------+-------------------+
+//  | 2023-03-17 13:53:00 +0000 UTC | 97.16779327392578 |
+//  | 2023-03-17 13:54:00 +0000 UTC | 99.32247161865234 |
+//  | 2023-03-17 13:55:00 +0000 UTC | 98.62533569335938 |
+//  +-------------------------------+-------------------+
+//  
+//  
+//  🌟 This was machine generated.  Do not edit. 🌟
+{
+  "status": 200,
+  "frames": [
+    {
+      "schema": {
+        "name": "Top Metrics float",
+        "meta": {
+          "type": "timeseries-multi",
+          "typeVersion": [
+            0,
+            0
+          ]
+        },
+        "fields": [
+          {
+            "name": "Time",
+            "type": "time",
+            "typeInfo": {
+              "frame": "time.Time"
+            }
+          },
+          {
+            "name": "Value",
+            "type": "number",
+            "typeInfo": {
+              "frame": "float64",
+              "nullable": true
+            },
+            "labels": {}
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            1679061180000,
+            1679061240000,
+            1679061300000
+          ],
+          [
+            97.16779327392578,
+            99.32247161865234,
+            98.62533569335938
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/pkg/tsdb/elasticsearch/testdata_response/metric_top_metrics.queries.json
+++ b/pkg/tsdb/elasticsearch/testdata_response/metric_top_metrics.queries.json
@@ -1,0 +1,35 @@
+[
+  {
+    "alias": "",
+    "bucketAggs": [
+      {
+        "field": "@timestamp",
+        "id": "2",
+        "settings": {
+          "interval": "1m"
+        },
+        "type": "date_histogram"
+      }
+    ],
+    "datasource": {
+      "type": "elasticsearch",
+      "uid": "uid"
+    },
+    "datasourceId": 42,
+    "metrics": [
+      {
+        "id": "1",
+        "settings": {
+          "metrics": [
+            "float"
+          ],
+          "order": "desc",
+          "orderBy": "float"
+        },
+        "type": "top_metrics"
+      }
+    ],
+    "query": "",
+    "refId": "A"
+  }
+]

--- a/pkg/tsdb/elasticsearch/testdata_response/metric_top_metrics.response.json
+++ b/pkg/tsdb/elasticsearch/testdata_response/metric_top_metrics.response.json
@@ -1,0 +1,81 @@
+{
+  "took": 10,
+  "responses": [
+    {
+      "took": 9,
+      "timed_out": false,
+      "_shards": {
+        "total": 1,
+        "successful": 1,
+        "skipped": 0,
+        "failed": 0
+      },
+      "hits": {
+        "total": {
+          "value": 142,
+          "relation": "eq"
+        },
+        "max_score": null,
+        "hits": []
+      },
+      "aggregations": {
+        "2": {
+          "buckets": [
+            {
+              "key_as_string": "1679061180000",
+              "key": 1679061180000,
+              "doc_count": 12,
+              "1": {
+                "top": [
+                  {
+                    "sort": [
+                      97.16779327392578
+                    ],
+                    "metrics": {
+                      "float": 97.16779327392578
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "key_as_string": "1679061240000",
+              "key": 1679061240000,
+              "doc_count": 66,
+              "1": {
+                "top": [
+                  {
+                    "sort": [
+                      99.32247161865234
+                    ],
+                    "metrics": {
+                      "float": 99.32247161865234
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "key_as_string": "1679061300000",
+              "key": 1679061300000,
+              "doc_count": 64,
+              "1": {
+                "top": [
+                  {
+                    "sort": [
+                      98.62533569335938
+                    ],
+                    "metrics": {
+                      "float": 98.62533569335938
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "status": 200
+    }
+  ]
+}


### PR DESCRIPTION
we add more snapshot tests to elasticsearch's response parser code.

(this is created so that all branches of https://github.com/grafana/grafana/blob/7261c6f7cd46f29ba205b43b83dca45214ae0a2b/pkg/tsdb/elasticsearch/response_parser.go#L413

are covered)