### PR TITLE
Fix: Grafana/e2e openPanelMenuExtension flow

### DIFF
--- a/packages/grafana-e2e/src/flows/openPanelMenuItem.ts
+++ b/packages/grafana-e2e/src/flows/openPanelMenuItem.ts
@@ -4,6 +4,7 @@ export enum PanelMenuItems {
   Edit = 'Edit',
   Inspect = 'Inspect',
   More = 'More...',
+  Extensions = 'Extensions',
 }
 
 export const openPanelMenuItem = (menu: PanelMenuItems, panelTitle = 'Panel Title') => {
@@ -15,7 +16,7 @@ export const openPanelMenuItem = (menu: PanelMenuItems, panelTitle = 'Panel Titl
 export const openPanelMenuExtension = (extensionTitle: string, panelTitle = 'Panel Title') => {
   e2e.components.Panels.Panel.title(panelTitle).should('be.visible').click();
 
-  e2e.components.Panels.Panel.headerItems(PanelMenuItems.More)
+  e2e.components.Panels.Panel.headerItems(PanelMenuItems.Extensions)
     .should('be.visible')
     .parent()
     .parent()


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

The merge of #64599 broke the new e2e openPanelMenuExtension flow due to moving extension links to their own submenu.

**Why do we need this feature?**

So plugin devs can open extension links in panel menus more easily in e2e tests.

**Who is this feature for?**

Plugin devs

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

