### PR TITLE
Vendor errors.Join from Go standard library to avoid version incompatibilities

### DIFF
--- a/pkg/services/ngalert/state/historian/multiple.go
+++ b/pkg/services/ngalert/state/historian/multiple.go
@@ -2,7 +2,6 @@ package historian
 
 import (
 	"context"
-	"errors"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
@@ -45,11 +44,61 @@ func (h *MultipleBackend) Record(ctx context.Context, rule history_model.RuleMet
 				errs = append(errs, err)
 			}
 		}
-		errCh <- errors.Join(errs...)
+		errCh <- Join(errs...)
 	}()
 	return errCh
 }
 
 func (h *MultipleBackend) Query(ctx context.Context, query ngmodels.HistoryQuery) (*data.Frame, error) {
 	return h.primary.Query(ctx, query)
+}
+
+// TODO: This is vendored verbatim from the Go standard library.
+// TODO: The grafana project doesn't support go 1.20 yet, so we can't use errors.Join() directly.
+// TODO: Remove this and replace calls with "errors.Join(...)" when go 1.20 becomes the minimum supported version.
+//
+// Join returns an error that wraps the given errors.
+// Any nil error values are discarded.
+// Join returns nil if errs contains no non-nil values.
+// The error formats as the concatenation of the strings obtained
+// by calling the Error method of each element of errs, with a newline
+// between each string.
+func Join(errs ...error) error {
+	n := 0
+	for _, err := range errs {
+		if err != nil {
+			n++
+		}
+	}
+	if n == 0 {
+		return nil
+	}
+	e := &joinError{
+		errs: make([]error, 0, n),
+	}
+	for _, err := range errs {
+		if err != nil {
+			e.errs = append(e.errs, err)
+		}
+	}
+	return e
+}
+
+type joinError struct {
+	errs []error
+}
+
+func (e *joinError) Error() string {
+	var b []byte
+	for i, err := range e.errs {
+		if i > 0 {
+			b = append(b, '\n')
+		}
+		b = append(b, err.Error()...)
+	}
+	return string(b)
+}
+
+func (e *joinError) Unwrap() []error {
+	return e.errs
 }


### PR DESCRIPTION
**What is this feature?**

`go.mod`'s minimum version is 1.19.

This vendors a call to `errors.Join()` which was introduced in go 1.20, to keep compatibility.

None of the CIs caught this because they all are running a go version that was too advanced. This seems to only affect developer envs who aren't on 1.20 yet.

**Which issue(s) does this PR fix?**:

n/a

**Special notes for your reviewer**:

