### PR TITLE
Alerting: Use a completely isolated context for state history writes

### DIFF
--- a/pkg/infra/tracing/opentelemetry_tracing.go
+++ b/pkg/infra/tracing/opentelemetry_tracing.go
@@ -329,3 +329,7 @@ func (s OpentelemetrySpan) AddEvents(keys []string, values []EventValue) {
 		}
 	}
 }
+
+func (s OpentelemetrySpan) contextWithSpan(ctx context.Context) context.Context {
+	return trace.ContextWithSpan(ctx, s.span)
+}

--- a/pkg/infra/tracing/test_helper.go
+++ b/pkg/infra/tracing/test_helper.go
@@ -92,6 +92,10 @@ func (t *FakeSpan) AddEvents(keys []string, values []EventValue) {
 	}
 }
 
+func (t *FakeSpan) contextWithSpan(ctx context.Context) context.Context {
+	return ctx
+}
+
 type FakeTracer struct {
 	Spans []*FakeSpan
 }

--- a/pkg/infra/tracing/tracing.go
+++ b/pkg/infra/tracing/tracing.go
@@ -76,6 +76,10 @@ type Span interface {
 	//
 	// Panics if the length of keys is shorter than the length of values.
 	AddEvents(keys []string, values []EventValue)
+
+	// contextWithSpan returns a context.Context that holds the parent
+	// context plus a reference to this span.
+	contextWithSpan(ctx context.Context) context.Context
 }
 
 func ProvideService(cfg *setting.Cfg) (Tracer, error) {
@@ -137,26 +141,24 @@ func TraceIDFromContext(c context.Context, requireSampled bool) string {
 }
 
 // SpanFromContext returns the Span previously associated with ctx, or nil, if no such span could be found.
-// It is the equivalent of opentracing.SpanFromContext, adapted to Grafana's Span type.
+// It is the equivalent of opentracing.SpanFromContext and trace.SpanFromContext.
 func SpanFromContext(ctx context.Context) Span {
-	return OpentracingSpan{opentracing.SpanFromContext(ctx)}
+	// Look for both opentracing and opentelemetry spans.
+	if span := opentracing.SpanFromContext(ctx); span != nil {
+		return OpentracingSpan{span: span}
+	}
+	if span := trace.SpanFromContext(ctx); span != nil {
+		return OpentelemetrySpan{span: span}
+	}
+	return nil
 }
 
-// ContextWithSpan reutrns a new context.Context that holds a reference to the given span.
+// ContextWithSpan returns a new context.Context that holds a reference to the given span.
 // If span is nil, a new context without an active span is returned.
-// It is the equivalent of opentracing.ContextWithSpan, adapted to Grafana's Span type.
+// It is the equivalent of opentracing.ContextWithSpan and trace.ContextWithSpan.
 func ContextWithSpan(ctx context.Context, span Span) context.Context {
 	if span != nil {
-		opentracingSpan, ok := span.(OpentracingSpan)
-		if !ok {
-			logger.Error("Failed to cast opentracing span")
-		}
-		ctx = opentracing.ContextWithSpan(ctx, opentracingSpan.span)
-		// Grafana also manages its own separate traceID in the context in addition to what opentracing handles.
-		// It's derived from the span. Ensure that we propagate this too.
-		if sctx, ok := opentracingSpan.span.Context().(jaeger.SpanContext); ok {
-			ctx = context.WithValue(ctx, traceKey{}, traceValue{sctx.TraceID().String(), sctx.IsSampled()})
-		}
+		return span.contextWithSpan(ctx)
 	}
 	return ctx
 }
@@ -337,6 +339,18 @@ func (s OpentracingSpan) AddEvents(keys []string, values []EventValue) {
 		}
 	}
 	s.span.LogFields(fields...)
+}
+
+func (s OpentracingSpan) contextWithSpan(ctx context.Context) context.Context {
+	if s.span != nil {
+		ctx = opentracing.ContextWithSpan(ctx, s.span)
+		// Grafana also manages its own separate traceID in the context in addition to what opentracing handles.
+		// It's derived from the span. Ensure that we propagate this too.
+		if sctx, ok := s.span.Context().(jaeger.SpanContext); ok {
+			ctx = context.WithValue(ctx, traceKey{}, traceValue{sctx.TraceID().String(), sctx.IsSampled()})
+		}
+	}
+	return ctx
 }
 
 func splitTagSettings(input string) map[string]string {

--- a/pkg/services/ngalert/state/historian/annotation.go
+++ b/pkg/services/ngalert/state/historian/annotation.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/annotations"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
@@ -71,6 +72,7 @@ func (h *AnnotationBackend) Record(ctx context.Context, rule history_model.RuleM
 	writeCtx := context.Background()
 	writeCtx, cancel := context.WithTimeout(writeCtx, StateHistoryWriteTimeout)
 	writeCtx = history_model.WithRuleData(writeCtx, rule)
+	writeCtx = tracing.ContextWithSpan(writeCtx, tracing.SpanFromContext(ctx))
 
 	go func(ctx context.Context) {
 		defer cancel()

--- a/pkg/services/ngalert/state/historian/annotation.go
+++ b/pkg/services/ngalert/state/historian/annotation.go
@@ -61,16 +61,16 @@ func (h *AnnotationBackend) Record(ctx context.Context, rule history_model.RuleM
 	annotations := buildAnnotations(rule, states, logger)
 	panel := parsePanelKey(rule, logger)
 
-	// New background job, so start with a completely new context to avoid pollution.
-	writeCtx := context.Background()
-	writeCtx, cancel := context.WithTimeout(writeCtx, StateHistoryWriteTimeout)
-	writeCtx = history_model.WithRuleData(writeCtx, rule)
-
 	errCh := make(chan error, 1)
 	if len(annotations) == 0 {
 		close(errCh)
 		return errCh
 	}
+
+	// New background job, so start with a completely new context to avoid pollution.
+	writeCtx := context.Background()
+	writeCtx, cancel := context.WithTimeout(writeCtx, StateHistoryWriteTimeout)
+	writeCtx = history_model.WithRuleData(writeCtx, rule)
 
 	go func(ctx context.Context) {
 		defer cancel()

--- a/pkg/services/ngalert/state/historian/annotation.go
+++ b/pkg/services/ngalert/state/historian/annotation.go
@@ -68,7 +68,11 @@ func (h *AnnotationBackend) Record(ctx context.Context, rule history_model.RuleM
 		return errCh
 	}
 
-	// New background job, so start with a completely new context to avoid pollution.
+	// This is a new background job, so let's create a brand new context for it.
+	// We want it to be isolated, i.e. we don't want grafana shutdowns to interrupt this work
+	// immediately but rather try to flush writes.
+	// This also prevents timeouts or other lingering objects (like transactions) from being
+	// incorrectly propagated here from other areas.
 	writeCtx := context.Background()
 	writeCtx, cancel := context.WithTimeout(writeCtx, StateHistoryWriteTimeout)
 	writeCtx = history_model.WithRuleData(writeCtx, rule)

--- a/pkg/services/ngalert/state/historian/annotation.go
+++ b/pkg/services/ngalert/state/historian/annotation.go
@@ -63,7 +63,7 @@ func (h *AnnotationBackend) Record(ctx context.Context, rule history_model.RuleM
 
 	// New background job, so start with a completely new context to avoid pollution.
 	writeCtx := context.Background()
-	writeCtx, cancel := context.WithTimeout(writeCtx, 30*time.Second)
+	writeCtx, cancel := context.WithTimeout(writeCtx, StateHistoryWriteTimeout)
 	writeCtx = history_model.WithRuleData(writeCtx, rule)
 
 	errCh := make(chan error, 1)

--- a/pkg/services/ngalert/state/historian/core.go
+++ b/pkg/services/ngalert/state/historian/core.go
@@ -13,7 +13,7 @@ import (
 	history_model "github.com/grafana/grafana/pkg/services/ngalert/state/historian/model"
 )
 
-const StateHistoryWriteTimeout = 30 * time.Second
+const StateHistoryWriteTimeout = time.Minute
 
 func shouldRecord(transition state.StateTransition) bool {
 	if !transition.Changed() {

--- a/pkg/services/ngalert/state/historian/core.go
+++ b/pkg/services/ngalert/state/historian/core.go
@@ -2,6 +2,7 @@ package historian
 
 import (
 	"strings"
+	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 
@@ -11,6 +12,8 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/state"
 	history_model "github.com/grafana/grafana/pkg/services/ngalert/state/historian/model"
 )
+
+const StateHistoryWriteTimeout = 30 * time.Second
 
 func shouldRecord(transition state.StateTransition) bool {
 	if !transition.Changed() {

--- a/pkg/services/ngalert/state/historian/loki.go
+++ b/pkg/services/ngalert/state/historian/loki.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
 	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
@@ -83,6 +84,7 @@ func (h *RemoteLokiBackend) Record(ctx context.Context, rule history_model.RuleM
 	writeCtx := context.Background()
 	writeCtx, cancel := context.WithTimeout(writeCtx, StateHistoryWriteTimeout)
 	writeCtx = history_model.WithRuleData(writeCtx, rule)
+	writeCtx = tracing.ContextWithSpan(writeCtx, tracing.SpanFromContext(ctx))
 
 	go func(ctx context.Context) {
 		defer cancel()

--- a/pkg/services/ngalert/state/historian/loki.go
+++ b/pkg/services/ngalert/state/historian/loki.go
@@ -81,7 +81,7 @@ func (h *RemoteLokiBackend) Record(ctx context.Context, rule history_model.RuleM
 
 	// New background job, so start with a completely new context to avoid pollution.
 	writeCtx := context.Background()
-	writeCtx, cancel := context.WithTimeout(writeCtx, 30*time.Second)
+	writeCtx, cancel := context.WithTimeout(writeCtx, StateHistoryWriteTimeout)
 	writeCtx = history_model.WithRuleData(writeCtx, rule)
 
 	go func(ctx context.Context) {

--- a/pkg/services/ngalert/state/historian/loki.go
+++ b/pkg/services/ngalert/state/historian/loki.go
@@ -80,7 +80,11 @@ func (h *RemoteLokiBackend) Record(ctx context.Context, rule history_model.RuleM
 		return errCh
 	}
 
-	// New background job, so start with a completely new context to avoid pollution.
+	// This is a new background job, so let's create a brand new context for it.
+	// We want it to be isolated, i.e. we don't want grafana shutdowns to interrupt this work
+	// immediately but rather try to flush writes.
+	// This also prevents timeouts or other lingering objects (like transactions) from being
+	// incorrectly propagated here from other areas.
 	writeCtx := context.Background()
 	writeCtx, cancel := context.WithTimeout(writeCtx, StateHistoryWriteTimeout)
 	writeCtx = history_model.WithRuleData(writeCtx, rule)

--- a/pkg/services/ngalert/state/historian/loki_http.go
+++ b/pkg/services/ngalert/state/historian/loki_http.go
@@ -17,11 +17,9 @@ import (
 	"github.com/weaveworks/common/http/client"
 )
 
-const defaultClientTimeout = 30 * time.Second
-
 func NewRequester() client.Requester {
 	return &http.Client{
-		Timeout: defaultClientTimeout,
+		Timeout: StateHistoryWriteTimeout,
 	}
 }
 

--- a/pkg/services/ngalert/state/historian/loki_http.go
+++ b/pkg/services/ngalert/state/historian/loki_http.go
@@ -18,9 +18,7 @@ import (
 )
 
 func NewRequester() client.Requester {
-	return &http.Client{
-		Timeout: StateHistoryWriteTimeout,
-	}
+	return &http.Client{}
 }
 
 // encoder serializes log streams to some byte format.

--- a/pkg/services/ngalert/state/historian/model/rule.go
+++ b/pkg/services/ngalert/state/historian/model/rule.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"context"
 	"strconv"
 
 	"github.com/grafana/grafana/pkg/cmd/grafana-cli/logger"
@@ -43,4 +44,8 @@ func NewRuleMeta(r *models.AlertRule, log log.Logger) RuleMeta {
 		DashboardUID: dashUID,
 		PanelID:      panelID,
 	}
+}
+
+func WithRuleData(ctx context.Context, rule RuleMeta) context.Context {
+	return models.WithRuleKey(ctx, models.AlertRuleKey{OrgID: rule.OrgID, UID: rule.UID})
 }


### PR DESCRIPTION
**What is this feature?**

The background tasks to write state history data currently pass along the main rule evaluation context.

It doesn't make sense to do this. These writes are totally different background jobs. Passing the context along here means that state history writes might inherit polluted context, unrelated timeouts, and other things.

In this PR, we spin up a brand new context for state history writes, and seed it with the things we expect. I analyzed the existing contexts, which contained three things consistently:
- Timeouts - I saw many pre-existing timeouts from other areas. These should not be passed along, this is a bug. Replaced with a fresh timeout just for state history.
- Rule data - used for logging. Added it to the new context.
- Tracing context - Right now, state history writes are **not visible** on the spans we emit anyway. I did not bother to pass these through, since we already aren't getting this data, so we aren't losing anything by dropping it. Tracing for these jobs would be nice admittedly - but adding this is better suited for a future PR.

**Which issue(s) does this PR fix?**:

n/a

**Special notes for your reviewer**:

