### PR TITLE
Scenes: POC of new way to do edit wrappers for scenes 

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -3844,6 +3844,9 @@ exports[`better eslint`] = {
     "public/app/features/sandbox/TestStuffPage.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
+    "public/app/features/scenes/editor/SceneEditButton.tsx:5381": [
+      [0, 0, 0, "Do not use any type assertions.", "0"]
+    ],
     "public/app/features/scenes/editor/SceneObjectTree.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"]

--- a/package.json
+++ b/package.json
@@ -267,7 +267,7 @@
     "@grafana/lezer-logql": "0.1.2",
     "@grafana/monaco-logql": "^0.0.7",
     "@grafana/runtime": "workspace:*",
-    "@grafana/scenes": "^0.0.19",
+    "@grafana/scenes": "portal:/home/torkel/dev/scenes/packages/scenes",
     "@grafana/schema": "workspace:*",
     "@grafana/ui": "workspace:*",
     "@kusto/monaco-kusto": "5.3.6",

--- a/public/app/features/scenes/dashboard/DashboardScene.tsx
+++ b/public/app/features/scenes/dashboard/DashboardScene.tsx
@@ -14,12 +14,17 @@ import { PageToolbar, ToolbarButton, useStyles2 } from '@grafana/ui';
 import { AppChromeUpdate } from 'app/core/components/AppChrome/AppChromeUpdate';
 import { Page } from 'app/core/components/Page/Page';
 
+import { SceneBodyEditWrapper } from '../editor/SceneBodyEditWrapper';
+import { SceneEditManager } from '../editor/SceneEditManager';
+
 interface DashboardSceneState extends SceneObjectStatePlain {
   title: string;
   uid?: string;
   body: SceneObject;
   actions?: SceneObject[];
   controls?: SceneObject[];
+  isEditing?: boolean;
+  editor?: SceneEditManager;
 }
 
 export class DashboardScene extends SceneObjectBase<DashboardSceneState> {
@@ -43,6 +48,20 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> {
 
     if (this.urlSyncManager) {
       this.urlSyncManager!.cleanUp();
+    }
+  }
+
+  public toggleEditMode() {
+    if (!this.state.isEditing) {
+      this.setState({
+        isEditing: !this.state.isEditing,
+        body: new SceneBodyEditWrapper({ body: this.state.body }),
+      });
+    } else if (this.state.body instanceof SceneBodyEditWrapper) {
+      this.setState({
+        isEditing: !this.state.isEditing,
+        body: this.state.body.state.body,
+      });
     }
   }
 }

--- a/public/app/features/scenes/editor/SceneBodyEditWrapper.tsx
+++ b/public/app/features/scenes/editor/SceneBodyEditWrapper.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import { SceneComponentProps, SceneObject, SceneObjectBase, SceneObjectStatePlain } from '@grafana/scenes';
+
+import { SceneComponentEditWrapper } from './SceneComponentEditWrapper';
+
+interface SceneBodyEditWrapperState extends SceneObjectStatePlain {
+  body: SceneObject;
+}
+
+export class SceneBodyEditWrapper extends SceneObjectBase<SceneBodyEditWrapperState> {
+  public componentWrapper = SceneComponentEditWrapper;
+
+  public static Component = ({ model }: SceneComponentProps<SceneBodyEditWrapper>) => {
+    return <model.state.body.Component model={model.state.body} />;
+  };
+}

--- a/public/app/features/scenes/editor/SceneComponentEditWrapper.tsx
+++ b/public/app/features/scenes/editor/SceneComponentEditWrapper.tsx
@@ -2,19 +2,14 @@ import { css } from '@emotion/css';
 import React, { CSSProperties } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { SceneEditor, SceneObject } from '@grafana/scenes';
+import { SceneComponentWrapperProps } from '@grafana/scenes';
 import { useStyles2 } from '@grafana/ui';
 
-export function SceneComponentEditWrapper({
-  model,
-  editor,
-  children,
-}: {
-  model: SceneObject;
-  editor: SceneEditor;
-  children: React.ReactNode;
-}) {
+import { getEditor } from './utils';
+
+export function SceneComponentEditWrapper({ model, children }: SceneComponentWrapperProps) {
   const styles = useStyles2(getStyles);
+  const editor = getEditor(model);
   const { hoverObject, selectedObject } = editor.useState();
 
   const onMouseEnter = () => editor.onMouseEnterObject(model);
@@ -50,6 +45,8 @@ const getStyles = (theme: GrafanaTheme2) => {
       padding: 8,
       border: `1px dashed ${theme.colors.primary.main}`,
       cursor: 'pointer',
+      minHeight: 0,
+      position: 'relative',
     }),
     hover: css({
       border: `1px solid ${theme.colors.primary.border}`,

--- a/public/app/features/scenes/editor/SceneEditButton.tsx
+++ b/public/app/features/scenes/editor/SceneEditButton.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+import { SceneComponentProps, SceneObjectBase, SceneObjectStatePlain } from '@grafana/scenes';
+import { Button } from '@grafana/ui';
+
+import { DashboardScene } from '../dashboard/DashboardScene';
+
+export class SceneEditButton extends SceneObjectBase<SceneObjectStatePlain> {
+  public static Component = SceneEditButtonRender;
+
+  public onToggleEditMode = () => {
+    const parent = this.parent as DashboardScene;
+    parent.toggleEditMode();
+  };
+}
+
+function SceneEditButtonRender({ model }: SceneComponentProps<SceneEditButton>) {
+  return <Button onClick={model.onToggleEditMode}>Edit</Button>;
+}

--- a/public/app/features/scenes/editor/SceneEditManager.tsx
+++ b/public/app/features/scenes/editor/SceneEditManager.tsx
@@ -4,17 +4,30 @@ import React from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
 import {
   SceneObjectBase,
-  SceneEditorState,
-  SceneEditor,
   SceneObject,
   SceneComponentProps,
   SceneComponent,
+  SceneObjectStatePlain,
+  SceneObjectRef,
 } from '@grafana/scenes';
 import { useStyles2 } from '@grafana/ui';
 
 import { SceneComponentEditWrapper } from './SceneComponentEditWrapper';
 import { SceneObjectEditor } from './SceneObjectEditor';
 import { SceneObjectTree } from './SceneObjectTree';
+
+export interface SceneEditorState extends SceneObjectStatePlain {
+  hoverObject?: SceneObjectRef;
+  selectedObject?: SceneObjectRef;
+  isEditing?: boolean;
+}
+
+export interface SceneEditor extends SceneObject<SceneEditorState> {
+  onMouseEnterObject(model: SceneObject): void;
+  onMouseLeaveObject(model: SceneObject): void;
+  onSelectObject(model: SceneObject): void;
+  //getEditComponentWrapper(): React.ComponentType<SceneComponentEditWrapperProps>;
+}
 
 export class SceneEditManager extends SceneObjectBase<SceneEditorState> implements SceneEditor {
   public static Component = SceneEditorRenderer;
@@ -44,13 +57,9 @@ export class SceneEditManager extends SceneObjectBase<SceneEditorState> implemen
   }
 }
 
-function SceneEditorRenderer({ model, isEditing }: SceneComponentProps<SceneEditManager>) {
+function SceneEditorRenderer({ model }: SceneComponentProps<SceneEditManager>) {
   const { selectedObject } = model.useState();
   const styles = useStyles2(getStyles);
-
-  if (!isEditing) {
-    return null;
-  }
 
   return (
     <div className={styles.container}>

--- a/public/app/features/scenes/editor/SceneObjectEditor.tsx
+++ b/public/app/features/scenes/editor/SceneObjectEditor.tsx
@@ -10,7 +10,7 @@ export interface Props {
 export function SceneObjectEditor({ model }: Props) {
   return (
     <OptionsPaneCategory id="props" title="Properties" forceOpen={1}>
-      <model.Editor model={model} key={model.state.key} />
+      {/* <model.Editor model={model} key={model.state.key} /> */}
     </OptionsPaneCategory>
   );
 }

--- a/public/app/features/scenes/editor/SceneObjectTree.tsx
+++ b/public/app/features/scenes/editor/SceneObjectTree.tsx
@@ -2,8 +2,10 @@ import { css, cx } from '@emotion/css';
 import React from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { sceneGraph, SceneObject, isSceneObject, SceneLayoutChild } from '@grafana/scenes';
+import { SceneObject, isSceneObject, SceneLayoutChild } from '@grafana/scenes';
 import { Icon, useStyles2 } from '@grafana/ui';
+
+import { getEditor } from './utils';
 
 export interface Props {
   node: SceneObject;
@@ -30,7 +32,7 @@ export function SceneObjectTree({ node, selectedObject }: Props) {
 
   const name = node.constructor.name;
   const isSelected = selectedObject === node;
-  const onSelectNode = () => sceneGraph.getSceneEditor(node).onSelectObject(node);
+  const onSelectNode = () => getEditor(node).onSelectObject(node);
 
   return (
     <div className={styles.node}>

--- a/public/app/features/scenes/editor/utils.ts
+++ b/public/app/features/scenes/editor/utils.ts
@@ -1,0 +1,17 @@
+import { SceneObject } from '@grafana/scenes';
+
+import { DashboardScene } from '../dashboard/DashboardScene';
+
+import { SceneEditManager } from './SceneEditManager';
+
+export function getEditor(model: SceneObject): SceneEditManager {
+  if (model instanceof DashboardScene && model.state.editor) {
+    return model.state.editor;
+  }
+
+  if (!model.parent) {
+    throw new Error('Could not find editor');
+  }
+
+  return getEditor(model.parent);
+}

--- a/public/app/features/scenes/scenes/demo.tsx
+++ b/public/app/features/scenes/scenes/demo.tsx
@@ -13,6 +13,7 @@ import { TestDataQueryType } from 'app/plugins/datasource/testdata/dataquery.gen
 
 import { panelBuilders } from '../builders/panelBuilders';
 import { DashboardScene } from '../dashboard/DashboardScene';
+import { SceneEditButton } from '../editor/SceneEditButton';
 import { SceneEditManager } from '../editor/SceneEditManager';
 
 import { getQueryRunnerWithRandomWalkQuery } from './queries';
@@ -60,10 +61,10 @@ export function getFlexLayoutTest(): DashboardScene {
         }),
       ],
     }),
-    $editor: new SceneEditManager({}),
+    editor: new SceneEditManager({}),
     $timeRange: new SceneTimeRange(),
     $data: getQueryRunnerWithRandomWalkQuery(),
-    actions: [new SceneTimePicker({})],
+    actions: [new SceneTimePicker({}), new SceneEditButton({})],
   });
 }
 
@@ -112,7 +113,6 @@ export function getScenePanelRepeaterTest(): DashboardScene {
         });
       },
     }),
-    $editor: new SceneEditManager({}),
     $timeRange: new SceneTimeRange(),
     $data: queryRunner,
     actions: [

--- a/public/app/features/scenes/scenes/grid.tsx
+++ b/public/app/features/scenes/scenes/grid.tsx
@@ -1,7 +1,6 @@
 import { VizPanel, SceneTimePicker, SceneFlexLayout, SceneGridLayout, SceneTimeRange } from '@grafana/scenes';
 
 import { DashboardScene } from '../dashboard/DashboardScene';
-import { SceneEditManager } from '../editor/SceneEditManager';
 
 import { getQueryRunnerWithRandomWalkQuery } from './queries';
 
@@ -47,7 +46,6 @@ export function getGridLayoutTest(): DashboardScene {
         }),
       ],
     }),
-    $editor: new SceneEditManager({}),
     $timeRange: new SceneTimeRange(),
     $data: getQueryRunnerWithRandomWalkQuery(),
     actions: [new SceneTimePicker({})],

--- a/public/app/features/scenes/scenes/gridMultiTimeRange.tsx
+++ b/public/app/features/scenes/scenes/gridMultiTimeRange.tsx
@@ -2,7 +2,6 @@ import { VizPanel, SceneGridRow, SceneTimePicker, SceneGridLayout, SceneTimeRang
 import { TestDataQueryType } from 'app/plugins/datasource/testdata/dataquery.gen';
 
 import { DashboardScene } from '../dashboard/DashboardScene';
-import { SceneEditManager } from '../editor/SceneEditManager';
 
 import { getQueryRunnerWithRandomWalkQuery } from './queries';
 
@@ -56,7 +55,6 @@ export function getGridWithMultipleTimeRanges(): DashboardScene {
         }),
       ],
     }),
-    $editor: new SceneEditManager({}),
     $timeRange: globalTimeRange,
     $data: getQueryRunnerWithRandomWalkQuery(),
     actions: [new SceneTimePicker({})],

--- a/public/app/features/scenes/scenes/gridMultiple.tsx
+++ b/public/app/features/scenes/scenes/gridMultiple.tsx
@@ -1,7 +1,6 @@
 import { VizPanel, SceneTimePicker, SceneFlexLayout, SceneGridLayout, SceneTimeRange } from '@grafana/scenes';
 
 import { DashboardScene } from '../dashboard/DashboardScene';
-import { SceneEditManager } from '../editor/SceneEditManager';
 
 import { getQueryRunnerWithRandomWalkQuery } from './queries';
 
@@ -86,8 +85,6 @@ export function getMultipleGridLayoutTest(): DashboardScene {
         }),
       ],
     }),
-
-    $editor: new SceneEditManager({}),
     $timeRange: new SceneTimeRange(),
     $data: getQueryRunnerWithRandomWalkQuery(),
     actions: [new SceneTimePicker({})],

--- a/public/app/features/scenes/scenes/gridWithMultipleData.tsx
+++ b/public/app/features/scenes/scenes/gridWithMultipleData.tsx
@@ -2,7 +2,6 @@ import { VizPanel, SceneGridRow, SceneTimePicker, SceneGridLayout, SceneTimeRang
 import { TestDataQueryType } from 'app/plugins/datasource/testdata/dataquery.gen';
 
 import { DashboardScene } from '../dashboard/DashboardScene';
-import { SceneEditManager } from '../editor/SceneEditManager';
 
 import { getQueryRunnerWithRandomWalkQuery } from './queries';
 
@@ -83,7 +82,6 @@ export function getGridWithMultipleData(): DashboardScene {
         }),
       ],
     }),
-    $editor: new SceneEditManager({}),
     $timeRange: new SceneTimeRange(),
     $data: getQueryRunnerWithRandomWalkQuery(),
     actions: [new SceneTimePicker({})],

--- a/public/app/features/scenes/scenes/gridWithRow.tsx
+++ b/public/app/features/scenes/scenes/gridWithRow.tsx
@@ -1,7 +1,6 @@
 import { VizPanel, SceneGridLayout, SceneGridRow, SceneTimePicker, SceneTimeRange } from '@grafana/scenes';
 
 import { DashboardScene } from '../dashboard/DashboardScene';
-import { SceneEditManager } from '../editor/SceneEditManager';
 
 import { getQueryRunnerWithRandomWalkQuery } from './queries';
 
@@ -65,7 +64,6 @@ export function getGridWithRowLayoutTest(): DashboardScene {
         }),
       ],
     }),
-    $editor: new SceneEditManager({}),
     $timeRange: new SceneTimeRange(),
     $data: getQueryRunnerWithRandomWalkQuery(),
     actions: [new SceneTimePicker({})],

--- a/public/app/features/scenes/scenes/sceneWithRows.tsx
+++ b/public/app/features/scenes/scenes/sceneWithRows.tsx
@@ -1,7 +1,6 @@
 import { VizPanel, NestedScene, SceneTimePicker, SceneFlexLayout, SceneTimeRange } from '@grafana/scenes';
 
 import { DashboardScene } from '../dashboard/DashboardScene';
-import { SceneEditManager } from '../editor/SceneEditManager';
 
 import { getQueryRunnerWithRandomWalkQuery } from './queries';
 
@@ -49,7 +48,6 @@ export function getSceneWithRows(): DashboardScene {
         }),
       ],
     }),
-    $editor: new SceneEditManager({}),
     $timeRange: new SceneTimeRange(),
     $data: getQueryRunnerWithRandomWalkQuery(),
     actions: [new SceneTimePicker({})],

--- a/yarn.lock
+++ b/yarn.lock
@@ -5209,9 +5209,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@grafana/scenes@npm:^0.0.19":
-  version: 0.0.19
-  resolution: "@grafana/scenes@npm:0.0.19"
+"@grafana/scenes@portal:/home/torkel/dev/scenes/packages/scenes::locator=grafana%40workspace%3A.":
+  version: 0.0.0-use.local
+  resolution: "@grafana/scenes@portal:/home/torkel/dev/scenes/packages/scenes::locator=grafana%40workspace%3A."
   dependencies:
     "@grafana/e2e-selectors": ^9.4.3
     "@grafana/experimental": 1.0.1
@@ -5219,9 +5219,8 @@ __metadata:
     react-use: 17.4.0
     react-virtualized-auto-sizer: 1.0.7
     uuid: ^9.0.0
-  checksum: e71451751523c33a72d1fe777ac37795166da44c4316a8c1a00ffff936167d49eca91cbe1557a7ffbbfa220c58112dc5c84d45058725efd5c1bf3ba32c2cfb36
   languageName: node
-  linkType: hard
+  linkType: soft
 
 "@grafana/schema@9.5.0-pre, @grafana/schema@workspace:*, @grafana/schema@workspace:packages/grafana-schema":
   version: 0.0.0-use.local
@@ -22120,7 +22119,7 @@ __metadata:
     "@grafana/lezer-logql": 0.1.2
     "@grafana/monaco-logql": ^0.0.7
     "@grafana/runtime": "workspace:*"
-    "@grafana/scenes": ^0.0.19
+    "@grafana/scenes": "portal:/home/torkel/dev/scenes/packages/scenes"
     "@grafana/schema": "workspace:*"
     "@grafana/toolkit": "workspace:*"
     "@grafana/tsconfig": ^1.2.0-rc1


### PR DESCRIPTION
This is to test a new way to set component wrappers for a future edit mode. This way it requires minimal editing interfaces and components in the scenes core (and not more need for layouts to remember to set isEditing). 