### PR TITLE
TablePanel: Switch to radio buttons for some cell options

### DIFF
--- a/packages/grafana-ui/src/components/Table/DefaultCell.tsx
+++ b/packages/grafana-ui/src/components/Table/DefaultCell.tsx
@@ -77,10 +77,12 @@ function getCellStyle(
   if (cellOptions.type === TableCellDisplayMode.ColorText) {
     textColor = displayValue.color;
   } else if (cellOptions.type === TableCellDisplayMode.ColorBackground) {
-    if (cellOptions.mode === TableCellBackgroundDisplayMode.Basic) {
+    const mode = cellOptions.mode ?? TableCellBackgroundDisplayMode.Gradient;
+
+    if (mode === TableCellBackgroundDisplayMode.Basic) {
       textColor = getTextColorForAlphaBackground(displayValue.color!, tableStyles.theme.isDark);
       bgColor = tinycolor(displayValue.color).toRgbString();
-    } else if (cellOptions.mode === TableCellBackgroundDisplayMode.Gradient) {
+    } else if (mode === TableCellBackgroundDisplayMode.Gradient) {
       const bgColor2 = tinycolor(displayValue.color)
         .darken(10 * darkeningFactor)
         .spin(5);

--- a/public/app/plugins/panel/table/cells/BarGaugeCellOptionsEditor.tsx
+++ b/public/app/plugins/panel/table/cells/BarGaugeCellOptionsEditor.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { SelectableValue } from '@grafana/data';
 import { Stack } from '@grafana/experimental';
 import { BarGaugeDisplayMode, BarGaugeValueMode, TableBarGaugeCellOptions } from '@grafana/schema';
-import { Field, RadioButtonGroup, Select } from '@grafana/ui';
+import { Field, RadioButtonGroup } from '@grafana/ui';
 
 import { TableCellEditorProps } from '../TableCellOptionEditor';
 
@@ -11,8 +11,8 @@ type Props = TableCellEditorProps<TableBarGaugeCellOptions>;
 
 export function BarGaugeCellOptionsEditor({ cellOptions, onChange }: Props) {
   // Set the display mode on change
-  const onCellOptionsChange = (v: SelectableValue) => {
-    cellOptions.mode = v.value;
+  const onCellOptionsChange = (v: BarGaugeDisplayMode) => {
+    cellOptions.mode = v;
     onChange(cellOptions);
   };
 
@@ -24,10 +24,18 @@ export function BarGaugeCellOptionsEditor({ cellOptions, onChange }: Props) {
   return (
     <Stack direction="column" gap={0}>
       <Field label="Gauge display mode">
-        <Select value={cellOptions?.mode} onChange={onCellOptionsChange} options={barGaugeOpts} />
+        <RadioButtonGroup
+          value={cellOptions?.mode ?? BarGaugeDisplayMode.Gradient}
+          onChange={onCellOptionsChange}
+          options={barGaugeOpts}
+        />
       </Field>
       <Field label="Value display">
-        <RadioButtonGroup value={cellOptions?.valueDisplayMode} onChange={onValueModeChange} options={valueModes} />
+        <RadioButtonGroup
+          value={cellOptions?.valueDisplayMode ?? BarGaugeValueMode.Text}
+          onChange={onValueModeChange}
+          options={valueModes}
+        />
       </Field>
     </Stack>
   );

--- a/public/app/plugins/panel/table/cells/ColorBackgroundCellOptionsEditor.tsx
+++ b/public/app/plugins/panel/table/cells/ColorBackgroundCellOptionsEditor.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 
 import { SelectableValue } from '@grafana/data';
 import { TableCellBackgroundDisplayMode, TableColoredBackgroundCellOptions } from '@grafana/schema';
-import { Select, Field } from '@grafana/ui';
+import { Field, RadioButtonGroup } from '@grafana/ui';
 
 import { TableCellEditorProps } from '../TableCellOptionEditor';
 
-const colorBackgroundOpts: SelectableValue[] = [
+const colorBackgroundOpts: Array<SelectableValue<TableCellBackgroundDisplayMode>> = [
   { value: TableCellBackgroundDisplayMode.Basic, label: 'Basic' },
   { value: TableCellBackgroundDisplayMode.Gradient, label: 'Gradient' },
 ];
@@ -16,14 +16,14 @@ export const ColorBackgroundCellOptionsEditor = ({
   onChange,
 }: TableCellEditorProps<TableColoredBackgroundCellOptions>) => {
   // Set the display mode on change
-  const onCellOptionsChange = (v: SelectableValue) => {
-    cellOptions.mode = v.value;
+  const onCellOptionsChange = (v: TableCellBackgroundDisplayMode) => {
+    cellOptions.mode = v;
     onChange(cellOptions);
   };
 
   return (
     <Field label="Background display mode">
-      <Select value={cellOptions?.mode} onChange={onCellOptionsChange} options={colorBackgroundOpts} />
+      <RadioButtonGroup value={cellOptions?.mode} onChange={onCellOptionsChange} options={colorBackgroundOpts} />
     </Field>
   );
 };

--- a/public/app/plugins/panel/table/cells/ColorBackgroundCellOptionsEditor.tsx
+++ b/public/app/plugins/panel/table/cells/ColorBackgroundCellOptionsEditor.tsx
@@ -23,7 +23,11 @@ export const ColorBackgroundCellOptionsEditor = ({
 
   return (
     <Field label="Background display mode">
-      <RadioButtonGroup value={cellOptions?.mode} onChange={onCellOptionsChange} options={colorBackgroundOpts} />
+      <RadioButtonGroup
+        value={cellOptions?.mode ?? TableCellBackgroundDisplayMode.Gradient}
+        onChange={onCellOptionsChange}
+        options={colorBackgroundOpts}
+      />
     </Field>
   );
 };


### PR DESCRIPTION
Switches to RadioButtonGroups instead of Select for some of the options that have very few options (2 in case of background mode, 3 for gauge display mode).

Also fixes a bug with "colored background" mode not having default mode (mode is undefined initially) and so you got no colored background unless you also selected the colored background mode. 
