### PR TITLE
sticky variables submenu

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -2928,11 +2928,11 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "3"]
     ],
     "public/app/features/dashboard/containers/DashboardPage.tsx:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
-      [0, 0, 0, "Do not use any type assertions.", "2"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "3"],
-      [0, 0, 0, "Use data-testid for E2E selectors instead of aria-label", "4"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
+      [0, 0, 0, "Do not use any type assertions.", "1"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
+      [0, 0, 0, "Do not use any type assertions.", "3"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "4"]
     ],
     "public/app/features/dashboard/dashgrid/DashboardGrid.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],

--- a/packages/grafana-e2e-selectors/src/selectors/pages.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/pages.ts
@@ -57,7 +57,7 @@ export const Pages = {
       publicDashboardTag: 'data-testid public dashboard tag',
     },
     SubMenu: {
-      submenu: 'Dashboard submenu',
+      submenu: 'data-testid Dashboard submenu',
       submenuItem: 'data-testid template variable',
       submenuItemLabels: (item: string) => `data-testid Dashboard template variables submenu Label ${item}`,
       submenuItemValueDropDownValueLinkTexts: (item: string) =>

--- a/packages/grafana-ui/src/components/CustomScrollbar/CustomScrollbar.tsx
+++ b/packages/grafana-ui/src/components/CustomScrollbar/CustomScrollbar.tsx
@@ -21,6 +21,7 @@ interface Props {
   hideVerticalTrack?: boolean;
   scrollRefCallback?: RefCallback<HTMLDivElement>;
   scrollTop?: number;
+  scrollPos?: (position: number) => void;
   setScrollTop?: (position: ScrollbarPosition) => void;
   showScrollIndicators?: boolean;
   autoHeightMin?: number | string;
@@ -46,7 +47,7 @@ export const CustomScrollbar = ({
   showScrollIndicators = false,
   updateAfterMountMs,
   scrollTop,
-  onScroll,
+  scrollPos,
   children,
 }: React.PropsWithChildren<Props>) => {
   const ref = useRef<Scrollbars & { view: HTMLDivElement; update: () => void }>(null);
@@ -118,8 +119,13 @@ export const CustomScrollbar = ({
     ref.current && setScrollTop && setScrollTop(ref.current.getValues());
   }, [setScrollTop]);
 
+  const handleScroll = useCallback(() => {
+    ref.current && scrollPos && scrollPos(ref.current.getValues().top);
+  }, [ref, scrollPos]);
+
   return (
     <Scrollbars
+      onScroll={handleScroll}
       data-testid={testId}
       ref={ref}
       className={cx(styles.customScrollbar, className, {
@@ -139,7 +145,6 @@ export const CustomScrollbar = ({
       renderThumbHorizontal={renderThumbHorizontal}
       renderThumbVertical={renderThumbVertical}
       renderView={renderView}
-      onScroll={onScroll}
     >
       {showScrollIndicators ? <ScrollIndicators>{children}</ScrollIndicators> : children}
     </Scrollbars>

--- a/public/app/core/components/Page/Page.tsx
+++ b/public/app/core/components/Page/Page.tsx
@@ -24,6 +24,7 @@ export const OldPage: PageType = ({
   children,
   className,
   toolbar,
+  scrollPos,
   scrollRef,
   scrollTop,
   layout = PageLayoutType.Standard,
@@ -56,7 +57,12 @@ export const OldPage: PageType = ({
   return (
     <div className={cx(styles.wrapper, className)} {...otherProps}>
       {layout === PageLayoutType.Standard && (
-        <CustomScrollbar autoHeightMin={'100%'} scrollTop={scrollTop} scrollRefCallback={scrollRef}>
+        <CustomScrollbar
+          autoHeightMin={'100%'}
+          scrollTop={scrollTop}
+          scrollRefCallback={scrollRef}
+          scrollPos={scrollPos}
+        >
           <div className={cx('page-scrollbar-content', className)}>
             {pageHeaderNav && (
               <PageHeader
@@ -76,7 +82,12 @@ export const OldPage: PageType = ({
         <>
           {toolbar}
           <div className={styles.scrollWrapper}>
-            <CustomScrollbar autoHeightMin={'100%'} scrollTop={scrollTop} scrollRefCallback={scrollRef}>
+            <CustomScrollbar
+              autoHeightMin={'100%'}
+              scrollTop={scrollTop}
+              scrollRefCallback={scrollRef}
+              scrollPos={scrollPos}
+            >
               <div className={cx(styles.content, !toolbar && styles.contentWithoutToolbar)}>{children}</div>
             </CustomScrollbar>
           </div>

--- a/public/app/core/components/Page/types.ts
+++ b/public/app/core/components/Page/types.ts
@@ -26,6 +26,8 @@ export interface PageProps extends HTMLAttributes<HTMLDivElement> {
   scrollRef?: RefCallback<HTMLDivElement>;
   /** Can be used to update the current scroll position */
   scrollTop?: number;
+  /** Can be used to infer the current scroll position */
+  scrollPos?: () => void;
 }
 
 export interface PageInfoItem {


### PR DESCRIPTION
**What is this feature?**
Makes the variables toolbar on the dashboard page sticky. In addition to that it's visibility is dependant on mousescrolls. When you are at the top of the page or scroll down the toolbar slides into the view and if you scroll up it disappears, giving you maxium viewspace of the dashboard.

**Why do we need this feature?**
As requested by [Issue #11166](https://github.com/grafana/grafana/issues/11166)