### PR TITLE
Expressions: More robust expression check

### DIFF
--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
@@ -2,16 +2,21 @@ import { of } from 'rxjs';
 import { BackendSrv, BackendSrvRequest, FetchResponse } from 'src/services';
 
 import {
-  DataSourceJsonData,
   DataQuery,
-  DataSourceInstanceSettings,
   DataQueryRequest,
   DataQueryResponseData,
-  MutableDataFrame,
+  DataSourceInstanceSettings,
+  DataSourceJsonData,
   DataSourceRef,
+  MutableDataFrame,
 } from '@grafana/data';
 
-import { DataSourceWithBackend, standardStreamOptionsProvider, toStreamingDataResponse } from './DataSourceWithBackend';
+import {
+  DataSourceWithBackend,
+  isExpressionReference,
+  standardStreamOptionsProvider,
+  toStreamingDataResponse,
+} from './DataSourceWithBackend';
 
 class MyDataSource extends DataSourceWithBackend<DataQuery, DataSourceJsonData> {
   constructor(instanceSettings: DataSourceInstanceSettings<DataSourceJsonData>) {
@@ -237,6 +242,16 @@ describe('DataSourceWithBackend', () => {
       },
       method: 'GET',
       url: '/api/datasources/uid/abc/health',
+    });
+  });
+
+  describe('isExpressionReference', () => {
+    test('check all possible expression references', () => {
+      expect(isExpressionReference('__expr__')).toBeTruthy(); // New UID
+      expect(isExpressionReference('-100')).toBeTruthy(); // Legacy UID
+      expect(isExpressionReference('Expression')).toBeTruthy(); // Name
+      expect(isExpressionReference({ type: '__expr__' })).toBeTruthy();
+      expect(isExpressionReference({ type: '-100' })).toBeTruthy();
     });
   });
 });

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -47,7 +47,7 @@ export function isExpressionReference(ref?: DataSourceRef | string | null): bool
     return false;
   }
   const v = typeof ref === 'string' ? ref : ref.type;
-  return v === ExpressionDatasourceRef.type || v === '-100'; // -100 was a legacy accident that should be removed
+  return v === ExpressionDatasourceRef.type || v === ExpressionDatasourceRef.name || v === '-100'; // -100 was a legacy accident that should be removed
 }
 
 export class HealthCheckError extends Error {

--- a/public/app/features/plugins/datasource_srv.ts
+++ b/public/app/features/plugins/datasource_srv.ts
@@ -7,15 +7,15 @@ import {
   ScopedVars,
 } from '@grafana/data';
 import {
-  GetDataSourceListFilters,
   DataSourceSrv as DataSourceService,
-  getDataSourceSrv as getDataSourceService,
-  TemplateSrv,
-  getTemplateSrv,
-  getLegacyAngularInjector,
   getBackendSrv,
+  GetDataSourceListFilters,
+  getDataSourceSrv as getDataSourceService,
+  getLegacyAngularInjector,
+  getTemplateSrv,
+  TemplateSrv,
 } from '@grafana/runtime';
-import { ExpressionDatasourceRef } from '@grafana/runtime/src/utils/DataSourceWithBackend';
+import { ExpressionDatasourceRef, isExpressionReference } from '@grafana/runtime/src/utils/DataSourceWithBackend';
 import appEvents from 'app/core/app_events';
 import config from 'app/core/config';
 import {
@@ -78,6 +78,13 @@ export class DatasourceSrv implements DataSourceService {
         }
       }
       return this.settingsMapByUid[this.defaultName] ?? this.settingsMapByName[this.defaultName];
+    }
+
+    // Expressions has a new UID as __expr__ See: https://github.com/grafana/grafana/pull/62510/
+    // But we still have dashboards/panels with old expression UID (-100)
+    // To support both UIDs until we migrate them all to new one, this check is necessary
+    if (isExpressionReference(nameOrUid)) {
+      return expressionDatasource.instanceSettings;
     }
 
     // Complex logic to support template variable data source names

--- a/public/app/features/plugins/tests/datasource_srv.test.ts
+++ b/public/app/features/plugins/tests/datasource_srv.test.ts
@@ -5,6 +5,7 @@ import {
   DataSourcePluginMeta,
   ScopedVar,
 } from '@grafana/data';
+import { ExpressionDatasourceRef } from '@grafana/runtime/src/utils/DataSourceWithBackend';
 import { DatasourceSrv } from 'app/features/plugins/datasource_srv';
 
 // Datasource variable $datasource with current value 'BBB'
@@ -198,6 +199,25 @@ describe('datasource_srv', () => {
             "uid": "uid-code-BBB",
           }
         `);
+      });
+
+      it('should return expression settings with either expression UIDs', () => {
+        const exprWithOldUID = dataSourceSrv.getInstanceSettings('-100');
+        expect(exprWithOldUID?.name).toBe('Expression');
+        expect(exprWithOldUID?.uid).toBe(ExpressionDatasourceRef.uid);
+        expect(exprWithOldUID?.type).toBe(ExpressionDatasourceRef.type);
+
+        const exprWithNewUID = dataSourceSrv.getInstanceSettings('__expr__');
+        expect(exprWithNewUID?.name).toBe('Expression');
+        expect(exprWithNewUID?.uid).toBe(ExpressionDatasourceRef.uid);
+        expect(exprWithNewUID?.type).toBe(ExpressionDatasourceRef.type);
+      });
+
+      it('should return expression settings with expression name', () => {
+        const exprWithName = dataSourceSrv.getInstanceSettings('Expression');
+        expect(exprWithName?.name).toBe(ExpressionDatasourceRef.name);
+        expect(exprWithName?.uid).toBe(ExpressionDatasourceRef.uid);
+        expect(exprWithName?.type).toBe(ExpressionDatasourceRef.type);
       });
     });
 


### PR DESCRIPTION
**What is this feature?**
After we update the expressions UID as `__expr__` the expression check logic doesn't perform well with the old UID. Also current logic doesn't support checking expressions with its name. 
This also causes some style problems. Since we are passing the name of the datasource in `QueryEditorRowHeader` https://github.com/grafana/grafana/blob/main/public/app/features/query/components/QueryEditorRowHeader.tsx#L140 we need these checks to send method that returns datasource settings should be supporting these new changes.

Before
![image](https://user-images.githubusercontent.com/820946/226205647-2b6ae8b5-072c-4b4b-855b-3de6ee31851d.png)


After 
![image](https://user-images.githubusercontent.com/820946/226205602-1bbbfce8-0ddd-4cb3-822d-b49cfddbf333.png)


**Why do we need this feature?**

We need a better check for expressions.

**Who is this feature for?**

Anybody who uses expressions

**Which issue(s) does this PR fix?**:

Fixes 
- https://github.com/grafana/grafana/issues/64890
- https://github.com/grafana/grafana/issues/58937


