### PR TITLE
[v9.2.x] Alerting: Fix expression issues in alert rule view and edit pages

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/QueryRows.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryRows.tsx
@@ -202,7 +202,11 @@ export class QueryRows extends PureComponent<Props, State> {
   };
 
   getDataSourceSettings = (query: AlertQuery): DataSourceInstanceSettings | undefined => {
-    return getDataSourceSrv().getInstanceSettings(query.datasourceUid);
+    let uid = query.datasourceUid;
+    if (isExpressionQuery(query.model)) {
+      uid = query.model.datasource?.type ?? query.datasourceUid;
+    }
+    return getDataSourceSrv().getInstanceSettings(uid);
   };
 
   getThresholdsForQueries = (queries: AlertQuery[]): Record<string, ThresholdsConfig> => {

--- a/public/app/features/alerting/unified/components/rule-viewer/RuleViewerVisualization.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/RuleViewerVisualization.tsx
@@ -28,7 +28,11 @@ export function RuleViewerVisualization(props: RuleViewerVisualizationProps): JS
   const { data, query, onChangeQuery } = props;
   const defaultPanel = isExpressionQuery(query.model) ? TABLE : TIMESERIES;
   const [panel, setPanel] = useState<SupportedPanelPlugins>(defaultPanel);
-  const dsSettings = getDataSourceSrv().getInstanceSettings(query.datasourceUid);
+  let uid = query.datasourceUid;
+  if (isExpressionQuery(query.model)) {
+    uid = query.model.datasource?.type ?? query.datasourceUid;
+  }
+  const dsSettings = getDataSourceSrv().getInstanceSettings(uid);
   const relativeTimeRange = query.relativeTimeRange;
   const [options, setOptions] = useState<PanelOptions>({
     frameIndex: 0,

--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -33,6 +33,8 @@ import { getTimeSrv } from 'app/features/dashboard/services/TimeSrv';
 import { DashboardModel } from 'app/features/dashboard/state/DashboardModel';
 import { PanelModel } from 'app/features/dashboard/state/PanelModel';
 
+import { isExpressionQuery } from '../../expressions/guards';
+
 import { RowActionComponents } from './QueryActionComponent';
 import { QueryEditorRowHeader } from './QueryEditorRowHeader';
 import { QueryErrorAlert } from './QueryErrorAlert';
@@ -135,6 +137,9 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
 
   getQueryDataSourceIdentifier(): string | null | undefined {
     const { query, dataSource: dsSettings } = this.props;
+    if (isExpressionQuery(query)) {
+      return query.datasource?.type ?? dsSettings.uid;
+    }
     return query.datasource?.uid ?? dsSettings.uid;
   }
 


### PR DESCRIPTION
**What is this feature?**

Alerting expressions weren't rendered properly especially when they are being upgraded from older versions. 
Because they have old UID `-100`. Since we are using a new UID `__expr__` rendering them is buggy. 
This is addressing those issues.


**Special notes for your reviewer**:
## How to test?
- Check out 378d0095b229fce276a6ef4238ab1e2996fe70f2 in `v9.2.x` branch
- Create an alert rule with expression and save it
- Check out latest `v9.2.x` and check alert rule view/edit pages for the alert rule you just created 
- Observe issues
- Check out this PR
- Visit those pages again and see they are working
