### PR TITLE
Alerting: Elide requests to Loki if nothing should be recorded

### DIFF
--- a/pkg/services/ngalert/state/historian/annotation.go
+++ b/pkg/services/ngalert/state/historian/annotation.go
@@ -62,6 +62,11 @@ func (h *AnnotationBackend) Record(ctx context.Context, rule history_model.RuleM
 	panel := parsePanelKey(rule, logger)
 
 	errCh := make(chan error, 1)
+	if len(annotations) == 0 {
+		close(errCh)
+		return errCh
+	}
+
 	go func() {
 		defer close(errCh)
 		errCh <- h.recordAnnotations(ctx, panel, annotations, rule.OrgID, logger)
@@ -180,10 +185,6 @@ func buildAnnotations(rule history_model.RuleMeta, states []state.StateTransitio
 }
 
 func (h *AnnotationBackend) recordAnnotations(ctx context.Context, panel *panelKey, annotations []annotations.Item, orgID int64, logger log.Logger) error {
-	if len(annotations) == 0 {
-		return nil
-	}
-
 	if panel != nil {
 		dashID, err := h.dashboards.getID(ctx, panel.orgID, panel.dashUID)
 		if err != nil {

--- a/pkg/services/ngalert/state/historian/loki.go
+++ b/pkg/services/ngalert/state/historian/loki.go
@@ -72,7 +72,13 @@ func (h *RemoteLokiBackend) TestConnection(ctx context.Context) error {
 func (h *RemoteLokiBackend) Record(ctx context.Context, rule history_model.RuleMeta, states []state.StateTransition) <-chan error {
 	logger := h.log.FromContext(ctx)
 	streams := statesToStreams(rule, states, h.externalLabels, logger)
+
 	errCh := make(chan error, 1)
+	if len(streams) == 0 {
+		close(errCh)
+		return errCh
+	}
+
 	go func() {
 		defer close(errCh)
 

--- a/pkg/services/ngalert/state/historian/loki_test.go
+++ b/pkg/services/ngalert/state/historian/loki_test.go
@@ -311,6 +311,18 @@ grafana_alerting_state_history_writes_total{org="1"} 2
 		)
 		require.NoError(t, err)
 	})
+
+	t.Run("elides request if nothing to send", func(t *testing.T) {
+		req := NewFakeRequester()
+		loki := createTestLokiBackend(req, metrics.NewHistorianMetrics(prometheus.NewRegistry()))
+		rule := createTestRule()
+		states := []state.StateTransition{}
+
+		err := <-loki.Record(context.Background(), rule, states)
+
+		require.NoError(t, err)
+		require.Nil(t, req.lastRequest)
+	})
 }
 
 func createTestLokiBackend(req client.Requester, met *metrics.Historian) *RemoteLokiBackend {


### PR DESCRIPTION
**What is this feature?**

State history does filtering on state transitions and chooses not to write when nothing has changed.

When this happens, we'd have an empty slice of streams - we'd still attempt to write to Loki in this case, resulting in a pointless empty push request.

Now we exit early when this happens. This PR cuts down on a lot of outgoing loki traffic.

There was a similar change in Annotations to do this same thing, but for the database. Refactored this to exit even earlier. Now we don't even start any goroutines if there's nothing to write.

**Which issue(s) does this PR fix?**:

n/a

**Special notes for your reviewer**:

