### PR TITLE
switch from github.com/gofrs/uuid to github.com/google/uuid

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -22,6 +22,7 @@ packages = ["io/ioutil"]
 "gopkg.in/yaml.v2" = "Grafana packages are not allowed to depend on gopkg.in/yaml.v2 as gopkg.in/yaml.v3 is now available"
 "github.com/pkg/errors" = "Deprecated: Go 1.13 supports the functionality provided by pkg/errors in the standard library."
 "github.com/xorcare/pointer" = "Use pkg/util.Pointer instead, which is a generic one-liner alternative"
+"github.com/gofrs/uuid" = "Use github.com/google/uuid instead, which we already depend on."
 
 [linters-settings.gocritic]
 enabled-checks = ["ruleguard"]

--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/go-stack/stack v1.8.1
 	github.com/gobwas/glob v0.2.3
-	github.com/gofrs/uuid v4.3.1+incompatible
+	github.com/gofrs/uuid v4.3.1+incompatible // indirect
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/mock v1.6.0
 	github.com/golang/snappy v0.0.4

--- a/go.sum
+++ b/go.sum
@@ -1256,8 +1256,6 @@ github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/ad
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
-github.com/grafana/alerting v0.0.0-20230302124801-c17c23256fba h1:ScqEvk2xPpUIKE+m45meufYlLlediv7Y/hHKcotW/1o=
-github.com/grafana/alerting v0.0.0-20230302124801-c17c23256fba/go.mod h1:NoSLbfmUwE+omWFReFrLtbtOItmvTbuQERJ6XFYp9ME=
 github.com/grafana/alerting v0.0.0-20230315185333-d1e3c68ac064 h1:MtsWzSTav7NGKolO+TaJQUcyR7VY0YpUROVsJX8ktIU=
 github.com/grafana/alerting v0.0.0-20230315185333-d1e3c68ac064/go.mod h1:nHfrSTdV7/l74N5/ezqlQ+JwSvIChhN3G5+PjCfwG/E=
 github.com/grafana/codejen v0.0.3 h1:tAWxoTUuhgmEqxJPOLtJoxlPBbMULFwKFOcRsPRPXDw=

--- a/pkg/infra/slugify/slugify.go
+++ b/pkg/infra/slugify/slugify.go
@@ -36,7 +36,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 )
 
 var (
@@ -53,7 +53,7 @@ func Slugify(value string) string {
 	if s == "" {
 		s = base64.RawURLEncoding.EncodeToString([]byte(value))
 		if len(s) > 50 || s == "" {
-			s = uuid.NewV5(uuid.NamespaceOID, value).String()
+			s = uuid.NewSHA1(uuid.NameSpaceOID, []byte(value)).String()
 		}
 	}
 	return s


### PR DESCRIPTION
Reduces the number of uuid libraries we use internally.

We still include github.com/gofrs/uuid indirectly via:
```
$ go mod why github.com/gofrs/uuid
# github.com/gofrs/uuid
github.com/grafana/grafana/pkg/services/ngalert/api
github.com/grafana/alerting/notify
github.com/prometheus/alertmanager/silence
github.com/gofrs/uuid
```
We could be rid of that if `github.com/prometheus/alertmanager/silence` also switched over to `github.com/google/uuid` (which it already has an indirect dependency along with `github.com/hashicorp/go-uuid` and `github.com/rogpeppe/fastuuid`)