### PR TITLE
Router: Fix broken link interception and router navigation

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -2217,6 +2217,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "3"]
     ],
+    "public/app/core/navigation/patch/interceptLinkClicks.ts:5381": [
+      [0, 0, 0, "Do not use any type assertions.", "0"]
+    ],
     "public/app/core/navigation/types.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"]

--- a/.betterer.results
+++ b/.betterer.results
@@ -2217,9 +2217,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "3"]
     ],
-    "public/app/core/navigation/patch/interceptLinkClicks.ts:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"]
-    ],
     "public/app/core/navigation/types.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"]

--- a/public/app/core/navigation/patch/interceptLinkClicks.ts
+++ b/public/app/core/navigation/patch/interceptLinkClicks.ts
@@ -3,7 +3,7 @@ import { locationService, navigationLogger } from '@grafana/runtime';
 import { config } from 'app/core/config';
 
 export function interceptLinkClicks(e: MouseEvent) {
-  const anchor = getParentAnchor(e.target as Element);
+  const anchor = e.target instanceof Element && getParentAnchor(e.target);
 
   // Ignore if opening new tab or already default prevented
   if (e.ctrlKey || e.metaKey || e.defaultPrevented) {

--- a/public/app/core/navigation/patch/interceptLinkClicks.ts
+++ b/public/app/core/navigation/patch/interceptLinkClicks.ts
@@ -3,7 +3,7 @@ import { locationService, navigationLogger } from '@grafana/runtime';
 import { config } from 'app/core/config';
 
 export function interceptLinkClicks(e: MouseEvent) {
-  const anchor = e.target instanceof HTMLElement ? getParentAnchor(e.target) : null;
+  const anchor = getParentAnchor(e.target as Element);
 
   // Ignore if opening new tab or already default prevented
   if (e.ctrlKey || e.metaKey || e.defaultPrevented) {
@@ -43,7 +43,7 @@ export function interceptLinkClicks(e: MouseEvent) {
   }
 }
 
-function getParentAnchor(element: HTMLElement | null): HTMLElement | null {
+function getParentAnchor(element: Element | null): Element | null {
   while (element !== null && element.tagName) {
     if (element.tagName.toUpperCase() === 'A') {
       return element;


### PR DESCRIPTION
https://github.com/grafana/grafana/pull/64675 introduced a instanceof check that does not pass for buttons that contain svg icons, leading to full page reloads for those link buttons.

Example where this happens is the alert rule list and the Edit button.
