### PR TITLE
Chore: Use embedded defaults.ini

### DIFF
--- a/embed.go
+++ b/embed.go
@@ -8,3 +8,6 @@ import (
 //
 //go:embed cue.mod/module.cue kinds/*.cue kinds/*/*.cue packages/grafana-schema/src/common/*.cue public/app/plugins/*/*/*.cue public/app/plugins/*/*/plugin.json pkg/plugins/*/*.cue
 var CueSchemaFS embed.FS
+
+//go:embed conf/defaults.ini
+var DefaultsINI []byte

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -809,7 +809,7 @@ func (cfg *Cfg) loadConfiguration(args CommandLineArgs) (parsedFile *ini.File, e
 	configFiles = append(configFiles, defaultConfigFile)
 
 	// load config file if exists; use embedded defaults if does not exist
-	if _, err := os.Stat(defaultConfigFile); os.IsNotExist(err) {
+	if _, err = os.Stat(defaultConfigFile); os.IsNotExist(err) {
 		parsedFile, err = ini.Load(grafana.DefaultsINI)
 	} else {
 		parsedFile, err = ini.Load(defaultConfigFile)

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -25,6 +25,7 @@ import (
 	"github.com/prometheus/common/model"
 	"gopkg.in/ini.v1"
 
+	"github.com/grafana/grafana"
 	"github.com/grafana/grafana-aws-sdk/pkg/awsds"
 	"github.com/grafana/grafana-azure-sdk-go/azsettings"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/gtime"
@@ -802,19 +803,18 @@ func (cfg *Cfg) loadSpecifiedConfigFile(configFile string, masterFile *ini.File)
 	return nil
 }
 
-func (cfg *Cfg) loadConfiguration(args CommandLineArgs) (*ini.File, error) {
+func (cfg *Cfg) loadConfiguration(args CommandLineArgs) (parsedFile *ini.File, err error) {
 	// load config defaults
 	defaultConfigFile := path.Join(HomePath, "conf/defaults.ini")
 	configFiles = append(configFiles, defaultConfigFile)
 
-	// check if config file exists
+	// load config file if exists; use embedded defaults if does not exist
 	if _, err := os.Stat(defaultConfigFile); os.IsNotExist(err) {
-		fmt.Println("Grafana-server Init Failed: Could not find config defaults, make sure homepath command line parameter is set or working directory is homepath")
-		os.Exit(1)
+		parsedFile, err = ini.Load(grafana.DefaultsINI)
+	} else {
+		parsedFile, err = ini.Load(defaultConfigFile)
 	}
 
-	// load defaults
-	parsedFile, err := ini.Load(defaultConfigFile)
 	if err != nil {
 		fmt.Printf("Failed to parse defaults.ini, %v\n", err)
 		os.Exit(1)


### PR DESCRIPTION
Currently Grafana expects `defaults.ini` to be present at a certain location (`../conf` or `../../conf`). Users may remove it or override the defaults there. This PR embeds the original `defaults.ini` and uses that if the file is not present at runtime. Using embedded defaults is still better than exiting with an error.