### PR TITLE
QueryStats: Fix comparison of timeranges

### DIFF
--- a/public/app/plugins/datasource/loki/components/stats.test.ts
+++ b/public/app/plugins/datasource/loki/components/stats.test.ts
@@ -1,4 +1,4 @@
-import { TimeRange } from '@grafana/data';
+import { dateTime, getDefaultTimeRange, TimeRange } from '@grafana/data';
 
 import { createLokiDatasource } from '../mocks';
 
@@ -8,23 +8,25 @@ describe('shouldUpdateStats', () => {
   it('should return true if the query has changed', () => {
     const query = '{job="grafana"}';
     const prevQuery = '{job="not-grafana"}';
-    const timerange = { raw: { from: 'now-1h', to: 'now' } } as TimeRange;
-    const prevTimerange = { raw: { from: 'now-1h', to: 'now' } } as TimeRange;
+    const timerange = getDefaultTimeRange();
+    const prevTimerange = timerange;
     expect(shouldUpdateStats(query, prevQuery, timerange, prevTimerange)).toBe(true);
   });
+
   it('should return true if the timerange has changed', () => {
     const query = '{job="grafana"}';
     const prevQuery = '{job="grafana"}';
-    const timerange = { raw: { from: 'now-1h', to: 'now' } } as TimeRange;
-    const prevTimerange = { raw: { from: 'now-2h', to: 'now' } } as TimeRange;
+    const timerange = getDefaultTimeRange();
+    timerange.from = dateTime(Date.now() - 1000000);
+    const prevTimerange = getDefaultTimeRange();
     expect(shouldUpdateStats(query, prevQuery, timerange, prevTimerange)).toBe(true);
   });
 
   it('should return false if the query and timerange have not changed', () => {
     const query = '{job="grafana"}';
     const prevQuery = '{job="grafana"}';
-    const timerange = { raw: { from: 'now-1h', to: 'now' } } as TimeRange;
-    const prevTimerange = { raw: { from: 'now-1h', to: 'now' } } as TimeRange;
+    const timerange = getDefaultTimeRange();
+    const prevTimerange = timerange;
     expect(shouldUpdateStats(query, prevQuery, timerange, prevTimerange)).toBe(false);
   });
 });

--- a/public/app/plugins/datasource/loki/components/stats.test.ts
+++ b/public/app/plugins/datasource/loki/components/stats.test.ts
@@ -1,4 +1,4 @@
-import { dateTime, getDefaultTimeRange, TimeRange } from '@grafana/data';
+import { dateTime, getDefaultTimeRange } from '@grafana/data';
 
 import { createLokiDatasource } from '../mocks';
 

--- a/public/app/plugins/datasource/loki/components/stats.ts
+++ b/public/app/plugins/datasource/loki/components/stats.ts
@@ -18,11 +18,7 @@ export function shouldUpdateStats(
   timerange: TimeRange,
   prevTimerange: TimeRange | undefined
 ): boolean {
-  if (
-    query === prevQuery &&
-    timerange.raw.from === prevTimerange?.raw.from &&
-    timerange.raw.to === prevTimerange?.raw.to
-  ) {
+  if (query === prevQuery && timerange.from.isSame(prevTimerange?.from) && timerange.to.isSame(prevTimerange?.to)) {
     return false;
   }
 


### PR DESCRIPTION
**What is this feature?**

We noticed that the equality comparison with absolute timeranges failed. This PR fixes that.

**Special notes for your reviewer**:

1. Setup Grafana and Loki
2. Make a query using absolute timeranges.
3. Without the fix, notice an endless loop sending `/stats` requests. With the fix, those are not sent.
