### PR TITLE
Docs: Use correct function in labels and annotations docs

### DIFF
--- a/docs/sources/alerting/fundamentals/annotation-label/variables-label-annotation.md
+++ b/docs/sources/alerting/fundamentals/annotation-label/variables-label-annotation.md
@@ -315,7 +315,7 @@ The `toUpper` function returns all text in uppercase.
 #### Example
 
 ```
-{{ toLower "Hello, world!" }}
+{{ toUpper "Hello, world!" }}
 ```
 
 ```


### PR DESCRIPTION
**What is this feature?**

This PR changes a small error in the docs for the labels and annotations where the `toLower` function was used instead of the correct `toUpper`

