### PR TITLE
CloudWatch Logs: Revert "Queries in an expression should run synchronously (#64443)"

### DIFF
--- a/pkg/expr/nodes.go
+++ b/pkg/expr/nodes.go
@@ -21,8 +21,6 @@ var (
 	logger = log.New("expr")
 )
 
-const FromExpressionHeaderName = "FromExpression"
-
 type QueryError struct {
 	RefID string
 	Err   error
@@ -229,7 +227,6 @@ func (dn *DSNode) Execute(ctx context.Context, now time.Time, _ mathexp.Vars, s 
 		},
 		Headers: dn.request.Headers,
 	}
-	req.Headers[FromExpressionHeaderName] = "true"
 
 	responseType := "unknown"
 	defer func() {

--- a/pkg/tsdb/cloudwatch/cloudwatch_test.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/datasource"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
-	"github.com/grafana/grafana/pkg/expr"
 	"github.com/grafana/grafana/pkg/infra/httpclient"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	ngalertmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
@@ -193,7 +192,7 @@ func Test_CheckHealth(t *testing.T) {
 		}, resp)
 	})
 }
-func Test_executeSyncLogQuery(t *testing.T) {
+func Test_executeLogAlertQuery(t *testing.T) {
 	origNewCWClient := NewCWClient
 	t.Cleanup(func() {
 		NewCWClient = origNewCWClient
@@ -254,70 +253,6 @@ func Test_executeSyncLogQuery(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.Equal(t, []string{"instance manager's region"}, sess.calledRegions)
-	})
-
-	t.Run("with header", func(t *testing.T) {
-		testcases := []struct {
-			name    string
-			headers map[string]string
-			called  bool
-		}{
-			{
-				"alert header",
-				map[string]string{ngalertmodels.FromAlertHeaderName: "some value"},
-				true,
-			},
-			{
-				"expression header",
-				map[string]string{expr.FromExpressionHeaderName: "some value"},
-				true,
-			},
-			{
-				"no header",
-				map[string]string{},
-				false,
-			},
-		}
-		origExecuteSyncLogQuery := executeSyncLogQuery
-		var syncCalled bool
-		executeSyncLogQuery = func(ctx context.Context, e *cloudWatchExecutor, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
-			syncCalled = true
-			return nil, nil
-		}
-
-		for _, tc := range testcases {
-			t.Run(tc.name, func(t *testing.T) {
-				syncCalled = false
-				cli = fakeCWLogsClient{queryResults: cloudwatchlogs.GetQueryResultsOutput{Status: aws.String("Complete")}}
-				im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-					return DataSource{Settings: models.CloudWatchSettings{AWSDatasourceSettings: awsds.AWSDatasourceSettings{Region: "instance manager's region"}}}, nil
-				})
-				sess := fakeSessionCache{}
-
-				executor := newExecutor(im, newTestConfig(), &sess, featuremgmt.WithFeatures())
-				_, err := executor.QueryData(context.Background(), &backend.QueryDataRequest{
-					Headers:       tc.headers,
-					PluginContext: backend.PluginContext{DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{}},
-					Queries: []backend.DataQuery{
-						{
-							TimeRange: backend.TimeRange{From: time.Unix(0, 0), To: time.Unix(1, 0)},
-							JSON: json.RawMessage(`{
-								"queryMode":    "Logs",
-								"type":        "logAction",
-								"subtype":     "StartQuery",
-								"region":      "default",
-								"queryString": "fields @message"
-							}`),
-						},
-					},
-				})
-
-				assert.NoError(t, err)
-				assert.Equal(t, tc.called, syncCalled)
-			})
-		}
-
-		executeSyncLogQuery = origExecuteSyncLogQuery
 	})
 }
 

--- a/pkg/tsdb/cloudwatch/log_alert.go
+++ b/pkg/tsdb/cloudwatch/log_alert.go
@@ -18,7 +18,7 @@ const (
 	alertPollPeriod  = time.Second
 )
 
-var executeSyncLogQuery = func(ctx context.Context, e *cloudWatchExecutor, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+func (e *cloudWatchExecutor) executeLogAlertQuery(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
 	resp := backend.NewQueryDataResponse()
 
 	for _, q := range req.Queries {
@@ -45,7 +45,7 @@ var executeSyncLogQuery = func(ctx context.Context, e *cloudWatchExecutor, req *
 			return nil, err
 		}
 
-		getQueryResultsOutput, err := e.syncQuery(ctx, logsClient, q, logsQuery)
+		getQueryResultsOutput, err := e.alertQuery(ctx, logsClient, q, logsQuery)
 		if err != nil {
 			return nil, err
 		}
@@ -73,7 +73,7 @@ var executeSyncLogQuery = func(ctx context.Context, e *cloudWatchExecutor, req *
 	return resp, nil
 }
 
-func (e *cloudWatchExecutor) syncQuery(ctx context.Context, logsClient cloudwatchlogsiface.CloudWatchLogsAPI,
+func (e *cloudWatchExecutor) alertQuery(ctx context.Context, logsClient cloudwatchlogsiface.CloudWatchLogsAPI,
 	queryContext backend.DataQuery, logsQuery models.LogsQuery) (*cloudwatchlogs.GetQueryResultsOutput, error) {
 	startQueryOutput, err := e.executeStartQuery(ctx, logsClient, logsQuery, queryContext.TimeRange)
 	if err != nil {


### PR DESCRIPTION
This reverts commit 74436d31de094a7cdd04de7ed7552e77e0f467af.

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Removing a write to the headers maps.

**Why do we need this feature?**

Writing to the headers map has introduced a race condition for all the reads on headers as well.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Will reference the issue internally

