### PR TITLE
Tempo: Set default limit if none is provided for traceql queries

### DIFF
--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -205,7 +205,7 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
           subQueries.push(
             this._request('/api/search', {
               q: queryValue,
-              limit: options.targets[0].limit,
+              limit: options.targets[0].limit ?? DEFAULT_LIMIT,
               start: options.range.from.unix(),
               end: options.range.to.unix(),
             }).pipe(
@@ -236,7 +236,7 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
         subQueries.push(
           this._request('/api/search', {
             q: queryValue,
-            limit: options.targets[0].limit,
+            limit: options.targets[0].limit ?? DEFAULT_LIMIT,
             start: options.range.from.unix(),
             end: options.range.to.unix(),
           }).pipe(


### PR DESCRIPTION
If tempo `datasource.query()` is called but no limit is provided, it sends query with `"limit": undefined,` to tempo data source. It then fails to parse this and returns 400.  This PR sets limit to default if none is provided 

