### PR TITLE
Core: Update components to have standard radii

### DIFF
--- a/packages/grafana-ui/src/components/Logs/LogDetailsRow.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogDetailsRow.tsx
@@ -58,7 +58,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       position: absolute;
       top: 0px;
       justify-content: center;
-      border-radius: 20px;
+      border-radius: ${theme.shape.radius.circle};
       width: 26px;
       height: 26px;
     `,

--- a/packages/grafana-ui/src/components/Switch/Switch.tsx
+++ b/packages/grafana-ui/src/components/Switch/Switch.tsx
@@ -118,7 +118,7 @@ const getSwitchStyles = stylesFactory((theme: GrafanaTheme2, transparent?: boole
         height: 100%;
         cursor: pointer;
         border: none;
-        border-radius: 50px;
+        border-radius: ${theme.shape.radius.pill};
         background: ${theme.components.input.background};
         border: 1px solid ${theme.components.input.borderColor};
         transition: all 0.3s ease;
@@ -133,7 +133,7 @@ const getSwitchStyles = stylesFactory((theme: GrafanaTheme2, transparent?: boole
           content: '';
           width: 12px;
           height: 12px;
-          border-radius: 6px;
+          border-radius: ${theme.shape.radius.circle};
           background: ${theme.colors.text.secondary};
           box-shadow: ${theme.shadows.z1};
           top: 50%;

--- a/packages/grafana-ui/src/themes/mixins.ts
+++ b/packages/grafana-ui/src/themes/mixins.ts
@@ -10,7 +10,7 @@ export function cardChrome(theme: GrafanaTheme2): string {
       background: ${hoverColor(theme.colors.background.secondary, theme)};
     }
     box-shadow: ${theme.components.panel.boxShadow};
-    border-radius: ${theme.shape.borderRadius(2)};
+    border-radius: ${theme.shape.radius.default};
 `;
 }
 
@@ -25,7 +25,7 @@ export function listItem(theme: GrafanaTheme2): string {
     background: ${hoverColor(theme.colors.background.secondary, theme)};
   }
   box-shadow: ${theme.components.panel.boxShadow};
-  border-radius: ${theme.shape.borderRadius(2)};
+  border-radius: ${theme.shape.radius.default};
 `;
 }
 
@@ -80,6 +80,6 @@ export const getTooltipContainerStyles = (theme: GrafanaTheme2) => `
   box-shadow: ${theme.shadows.z2};
   max-width: 800px;
   padding: ${theme.spacing(1)};
-  border-radius: ${theme.shape.borderRadius()};
+  border-radius: ${theme.shape.radius.default};
   z-index: ${theme.zIndex.tooltip};
 `;

--- a/public/app/core/components/Login/LoginLayout.tsx
+++ b/public/app/core/components/Login/LoginLayout.tsx
@@ -127,7 +127,7 @@ export const getLoginStyles = (theme: GrafanaTheme2) => {
       justify-content: flex-start;
       z-index: 1;
       min-height: 320px;
-      border-radius: ${theme.shape.borderRadius(4)};
+      border-radius: ${theme.shape.radius.default};
       padding: ${theme.spacing(2, 0)};
       opacity: 0;
       transition: opacity 0.5s ease-in-out;

--- a/public/app/core/components/Login/LoginLayout.tsx
+++ b/public/app/core/components/Login/LoginLayout.tsx
@@ -127,7 +127,7 @@ export const getLoginStyles = (theme: GrafanaTheme2) => {
       justify-content: flex-start;
       z-index: 1;
       min-height: 320px;
-      border-radius: ${theme.shape.radius.default};
+      border-radius: ${theme.shape.borderRadius(4)};
       padding: ${theme.spacing(2, 0)};
       opacity: 0;
       transition: opacity 0.5s ease-in-out;

--- a/public/app/core/components/PageNew/SectionNavItem.tsx
+++ b/public/app/core/components/PageNew/SectionNavItem.tsx
@@ -69,7 +69,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       padding: ${theme.spacing(1, 0, 1, 1.5)};
       display: flex;
       align-items: center;
-      border-radius: ${theme.shape.borderRadius(2)};
+      border-radius: ${theme.shape.radius.default};
       gap: ${theme.spacing(1)};
       height: 100%;
       position: relative;
@@ -94,7 +94,7 @@ const getStyles = (theme: GrafanaTheme2) => {
         width: 4px;
         bottom: 2px;
         top: 2px;
-        border-radius: 2px;
+        border-radius: ${theme.shape.radius.default};
         background-image: ${theme.colors.gradients.brandVertical};
       }
     `,

--- a/public/app/core/components/QueryOperationRow/QueryOperationAction.tsx
+++ b/public/app/core/components/QueryOperationRow/QueryOperationAction.tsx
@@ -48,7 +48,7 @@ const getStyles = (theme: GrafanaTheme2) => {
         left: -1px;
         right: 2px;
         height: 3px;
-        border-radius: 2px;
+        border-radius: ${theme.shape.radius.default};
         bottom: -8px;
         background-image: ${theme.colors.gradients.brandHorizontal} !important;
       }

--- a/public/app/core/components/SplitPaneWrapper/SplitPaneWrapper.tsx
+++ b/public/app/core/components/SplitPaneWrapper/SplitPaneWrapper.tsx
@@ -126,7 +126,7 @@ const getStyles = (theme: GrafanaTheme2, hasSplit: boolean) => {
       top: 50%;
       transition: 0.2s background ease-in-out;
       transform: translate(-50%, -50%);
-      border-radius: 4px;
+      border-radius: ${theme.shape.radius.default};
     }
 
     &:hover {

--- a/public/app/features/commandPalette/CommandPalette.tsx
+++ b/public/app/features/commandPalette/CommandPalette.tsx
@@ -156,7 +156,7 @@ const getSearchStyles = (theme: GrafanaTheme2) => {
       width: '100%',
       background: theme.colors.background.primary,
       color: theme.colors.text.primary,
-      borderRadius: theme.shape.borderRadius(2),
+      borderRadius: theme.shape.radius.default,
       border: `1px solid ${theme.colors.border.weak}`,
       overflow: 'hidden',
       boxShadow: theme.shadows.z3,

--- a/public/app/features/commandPalette/ResultItem.tsx
+++ b/public/app/features/commandPalette/ResultItem.tsx
@@ -79,7 +79,7 @@ const getResultItemStyles = (theme: GrafanaTheme2) => {
       justifyContent: 'space-between',
       cursor: 'pointer',
       position: 'relative',
-      borderRadius: theme.shape.borderRadius(2),
+      borderRadius: theme.shape.radius.default,
       margin: theme.spacing(0, 1),
     }),
     activeRow: css({
@@ -93,7 +93,7 @@ const getResultItemStyles = (theme: GrafanaTheme2) => {
         top: 0,
         bottom: 0,
         width: theme.spacing(0.5),
-        borderRadius: theme.shape.borderRadius(2),
+        borderRadius: theme.shape.radius.default,
         backgroundImage: theme.colors.gradients.brandVertical,
       },
     }),

--- a/public/app/features/search/components/DashboardSearchModal.tsx
+++ b/public/app/features/search/components/DashboardSearchModal.tsx
@@ -169,7 +169,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       z-index: ${theme.zIndex.modal};
 
       ${theme.breakpoints.up('md')} {
-        border-radius: ${theme.shape.borderRadius(2)};
+        border-radius: ${theme.shape.radius.default};
         box-shadow: ${theme.shadows.z3};
         left: 0;
         margin: ${theme.spacing(0.5, 'auto', 0)};

--- a/public/app/features/search/components/SearchCard.tsx
+++ b/public/app/features/search/components/SearchCard.tsx
@@ -181,7 +181,7 @@ const getStyles = (theme: GrafanaTheme2, markerWidth = 0, popperWidth = 0) => {
     card: css`
       background-color: ${theme.colors.background.secondary};
       border: 1px solid ${theme.colors.border.medium};
-      border-radius: 4px;
+      border-radius: ${theme.shape.radius.default};
       display: flex;
       flex-direction: column;
 
@@ -241,8 +241,8 @@ const getStyles = (theme: GrafanaTheme2, markerWidth = 0, popperWidth = 0) => {
     info: css`
       align-items: center;
       background-color: ${theme.colors.background.canvas};
-      border-bottom-left-radius: 4px;
-      border-bottom-right-radius: 4px;
+      border-bottom-left-radius: ${theme.shape.radius.default};
+      border-bottom-right-radius: ${theme.shape.radius.default};
       display: flex;
       height: ${theme.spacing(7)};
       gap: ${theme.spacing(1)};

--- a/public/app/plugins/panel/news/component/News.tsx
+++ b/public/app/plugins/panel/news/component/News.tsx
@@ -73,7 +73,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     margin-bottom: ${theme.spacing(1)};
     > img {
       width: 100%;
-      border-radius: ${theme.shape.borderRadius(2)} ${theme.shape.borderRadius(2)} 0 0;
+      border-radius: ${theme.shape.radius.default} ${theme.shape.radius.default} 0 0;
     }
   `,
   socialImageWide: css`
@@ -81,7 +81,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     margin-bottom: 0;
     > img {
       width: 250px;
-      border-radius: ${theme.shape.borderRadius()};
+      border-radius: ${theme.shape.radius.default};
     }
   `,
   link: css`
@@ -106,7 +106,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
   date: css`
     margin-bottom: ${theme.spacing(0.5)};
     font-weight: 500;
-    border-radius: 0 0 0 3px;
+    border-radius: 0 0 0 ${theme.shape.radius.default};
     color: ${theme.colors.text.secondary};
   `,
 });


### PR DESCRIPTION

**What is this feature?**
Reference the theme variable for border-radius.

**Why do we need this feature?**

Standardization

**Who is this feature for?**

Users :bust_in_silhouette: 

**Which issue(s) does this PR fix?**:

Fixes #64408

**Special notes for your reviewer**:

Please have a look at the login page. I do not think it should use the default border radius.

4xdefault
![image](https://user-images.githubusercontent.com/1438972/226406920-abca907f-1329-4a34-85a3-925f37cba123.png)
default
![image](https://user-images.githubusercontent.com/1438972/226406952-335fe040-7e75-4a8b-b2c8-417ba48184e6.png)

