### PR TITLE
docs: panel header updates

### DIFF
--- a/docs/sources/dashboards/build-dashboards/manage-dashboard-links/index.md
+++ b/docs/sources/dashboards/build-dashboards/manage-dashboard-links/index.md
@@ -110,11 +110,11 @@ To delete an existing dashboard link, click the trash icon next to the duplicate
 
 ## Panel links
 
-Each panel can have its own set of links that are shown in the upper left corner of the panel. You can link to any available URL, including dashboards, panels, or external sites. You can even control the time range to ensure the user is zoomed in on the right data in Grafana.
+Each panel can have its own set of links that are shown in the upper left of the panel after the panel title. You can link to any available URL, including dashboards, panels, or external sites. You can even control the time range to ensure the user is zoomed in on the right data in Grafana.
 
-Click the icon on the top left corner of a panel to see available panel links.
+Click the icon next to the panel title to see available panel links.
 
-{{< figure src="/static/img/docs/linking/panel-links.png" width="200px" >}}
+{{< figure src="/media/docs/grafana/screenshot-panel-links.png" width="200px" >}}
 
 ### Add a panel link
 

--- a/docs/sources/dashboards/build-dashboards/manage-dashboard-links/index.md
+++ b/docs/sources/dashboards/build-dashboards/manage-dashboard-links/index.md
@@ -118,7 +118,11 @@ Click the icon next to the panel title to see available panel links.
 
 ### Add a panel link
 
-1. Hover over any part of the panel to which you want to add the link to display the actions menu on the top right corner. Click the menu and select **Edit**. To use a keyboard shortcut to open the panel, hover over the panel and press `e`.
+1. Hover over any part of the panel to which you want to add the link to display the actions menu on the top right corner.
+1. Click the menu and select **Edit**.
+
+   To use a keyboard shortcut to open the panel, hover over the panel and press `e`.
+
 1. Expand the **Panel options** section, scroll down to Panel links.
 1. Click **Add link**.
 1. Enter a **Title**. **Title** is a human-readable label for the link that will be displayed in the UI.
@@ -133,7 +137,11 @@ Click the icon next to the panel title to see available panel links.
 
 ### Update a panel link
 
-1. Hover over any part of the panel to display the actions menu on the top right corner. Click the menu and select **Edit**. To use a keyboard shortcut to open the panel, hover over the panel and press `e`.
+1. Hover over any part of the panel to display the actions menu on the top right corner.
+1. Click the menu and select **Edit**.
+
+   To use a keyboard shortcut to open the panel, hover over the panel and press `e`.
+
 1. Expand the **Panel options** section, scroll down to Panel links.
 1. Find the link that you want to make changes to.
 1. Click the Edit (pencil) icon to open the Edit link window.
@@ -143,7 +151,11 @@ Click the icon next to the panel title to see available panel links.
 
 ### Delete a panel link
 
-1. Hover over any part of the panel to display the actions menu on the top right corner. Click the menu and select **Edit**. To use a keyboard shortcut to open the panel, hover over the panel and press `e`.
+1. Hover over any part of the panel to display the actions menu on the top right corner.
+1. Click the menu and select **Edit**.
+
+   To use a keyboard shortcut to open the panel, hover over the panel and press `e`.
+
 1. Expand the **Panel options** section, scroll down to Panel links.
 1. Find the link that you want to delete.
 1. Click the **X** icon next to the link you want to delete.

--- a/docs/sources/dashboards/build-dashboards/manage-dashboard-links/index.md
+++ b/docs/sources/dashboards/build-dashboards/manage-dashboard-links/index.md
@@ -24,7 +24,7 @@ weight: 500
 
 You can use links to navigate between commonly-used dashboards or to connect others to your visualizations. Links let you create shortcuts to other dashboards, panels, and even external websites.
 
-Grafana supports dashboard links, panel links, and data links. Dashboard links are displayed at the top of the dashboard. Panel links are accessible by clicking an icon on the top left corner of the panel.
+Grafana supports dashboard links, panel links, and data links. Dashboard links are displayed at the top of the dashboard. Panel links are accessible by clicking the icon next to the panel title.
 
 ## Which link should you use?
 

--- a/docs/sources/dashboards/build-dashboards/manage-dashboard-links/index.md
+++ b/docs/sources/dashboards/build-dashboards/manage-dashboard-links/index.md
@@ -118,9 +118,9 @@ Click the icon on the top left corner of a panel to see available panel links.
 
 ### Add a panel link
 
-1. Hover your cursor over the panel that you want to add a link to and then press `e`. Or click the dropdown arrow next to the panel title and then click **Edit**.
-1. On the Panel tab, scroll down to the Links section.
-1. Expand Links and then click **Add link**.
+1. Hover over any part of the panel to which you want to add the link to display the actions menu on the top right corner. Click the menu and select **Edit**. To use a keyboard shortcut to open the panel, hover over the panel and press `e`.
+1. Expand the **Panel options** section, scroll down to Panel links.
+1. Click **Add link**.
 1. Enter a **Title**. **Title** is a human-readable label for the link that will be displayed in the UI.
 1. Enter the **URL** you want to link to.
    You can even add one of the template variables defined in the dashboard. Press Ctrl+Space or Cmd+Space and click in the **URL** field to see the available variables. By adding template variables to your panel link, the link sends the user to the right context, with the relevant variables already set. You can also use time variables:
@@ -133,7 +133,9 @@ Click the icon on the top left corner of a panel to see available panel links.
 
 ### Update a panel link
 
-1. On the Panel tab, find the link that you want to make changes to.
+1. Hover over any part of the panel to display the actions menu on the top right corner. Click the menu and select **Edit**. To use a keyboard shortcut to open the panel, hover over the panel and press `e`.
+1. Expand the **Panel options** section, scroll down to Panel links.
+1. Find the link that you want to make changes to.
 1. Click the Edit (pencil) icon to open the Edit link window.
 1. Make any necessary changes.
 1. Click **Save** to save changes and close the window.
@@ -141,6 +143,8 @@ Click the icon on the top left corner of a panel to see available panel links.
 
 ### Delete a panel link
 
-1. On the Panel tab, find the link that you want to delete.
+1. Hover over any part of the panel to display the actions menu on the top right corner. Click the menu and select **Edit**. To use a keyboard shortcut to open the panel, hover over the panel and press `e`.
+1. Expand the **Panel options** section, scroll down to Panel links.
+1. Find the link that you want to delete.
 1. Click the **X** icon next to the link you want to delete.
 1. Click **Save** in the upper right to save your changes to the dashboard.

--- a/docs/sources/datasources/influxdb/query-editor/index.md
+++ b/docs/sources/datasources/influxdb/query-editor/index.md
@@ -27,8 +27,8 @@ The InfluxQL query editor helps you select metrics and tags to create InfluxQL q
 
 **To enter edit mode:**
 
-1. Click the panel title.
-1. Click **Edit**.
+1. Hover over any part of the panel to display the actions menu on the top right corner.
+1. Click the menu and select **Edit**.
 
 ![InfluxQL query editor](/static/img/docs/influxdb/influxql-query-editor-8-0.png)
 

--- a/docs/sources/panels-visualizations/configure-data-links/index.md
+++ b/docs/sources/panels-visualizations/configure-data-links/index.md
@@ -93,7 +93,11 @@ When creating or updating a data link, press Cmd+Space or Ctrl+Space on your key
 
 ### Add a data link
 
-1. Hover over any part of the panel you want to which you want to add the data link to display the actions menu on the top right corner. Click the menu and select **Edit**. To use a keyboard shortcut to open the panel, hover over the panel and press `e`.
+1. Hover over any part of the panel you want to which you want to add the data link to display the actions menu on the top right corner.
+1. Click the menu and select **Edit**.
+
+   To use a keyboard shortcut to open the panel, hover over the panel and press `e`.
+
 1. Scroll down to the Data links section and expand it.
 1. Click **Add link**.
 1. Enter a **Title**. **Title** is a human-readable label for the link that will be displayed in the UI.

--- a/docs/sources/panels-visualizations/configure-data-links/index.md
+++ b/docs/sources/panels-visualizations/configure-data-links/index.md
@@ -93,9 +93,9 @@ When creating or updating a data link, press Cmd+Space or Ctrl+Space on your key
 
 ### Add a data link
 
-1. Hover your cursor over the panel that you want to add a link to and then press `e`. Or click the dropdown arrow next to the panel title and then click **Edit**.
-1. On the Field tab, scroll down to the Data links section.
-1. Expand Data links and then click **Add link**.
+1. Hover over any part of the panel you want to which you want to add the data link to display the actions menu on the top right corner. Click the menu and select **Edit**. To use a keyboard shortcut to open the panel, hover over the panel and press `e`.
+1. Scroll down to the Data links section and expand it.
+1. Click **Add link**.
 1. Enter a **Title**. **Title** is a human-readable label for the link that will be displayed in the UI.
 1. Enter the **URL** you want to link to.
 
@@ -107,7 +107,7 @@ When creating or updating a data link, press Cmd+Space or Ctrl+Space on your key
 
 ### Update a data link
 
-1. On the Field tab, find the link that you want to make changes to.
+1. Scroll down to the Data links section, expand it, and find the link that you want to make changes to.
 1. Click the Edit (pencil) icon to open the Edit link window.
 1. Make any necessary changes.
 1. Click **Save** to save changes and close the window.
@@ -115,6 +115,6 @@ When creating or updating a data link, press Cmd+Space or Ctrl+Space on your key
 
 ### Delete a data link
 
-1. On the Field tab, find the link that you want to delete.
+1. Scroll down to the Data links section, expand it, and find the link that you want to delete.
 1. Click the **X** icon next to the link you want to delete.
 1. Click **Save** in the upper right to save your changes to the dashboard.

--- a/docs/sources/panels-visualizations/configure-panel-options/index.md
+++ b/docs/sources/panels-visualizations/configure-panel-options/index.md
@@ -36,11 +36,13 @@ After you add a panel to a dashboard, you can open it at any time to change chan
 
 1. Open the dashboard that contains the panel you want to edit.
 
-1. Hover over any part of the panel to display the actions menu on the top right corner. Click the menu and select **Edit**. To use a keyboard shortcut to open the panel, hover over the panel and press `e`.
+1. Hover over any part of the panel to display the actions menu on the top right corner. Click the menu and select **Edit**.
 
-   The panel opens in edit mode.
+![Panel with menu displayed](/media/docs/grafana/screenshot-panel-menu.png)
 
-   <!-- add screenshot here? -->
+To use a keyboard shortcut to open the panel, hover over the panel and press `e`.
+
+The panel opens in edit mode.
 
 ## Add a title and description to a panel
 

--- a/docs/sources/panels-visualizations/configure-panel-options/index.md
+++ b/docs/sources/panels-visualizations/configure-panel-options/index.md
@@ -36,7 +36,9 @@ After you add a panel to a dashboard, you can open it at any time to change chan
 
 1. Open the dashboard that contains the panel you want to edit.
 
-1. Hover over any part of the panel to display the actions menu on the top right corner. Click the menu and select **Edit**.
+1. Hover over any part of the panel to display the actions menu on the top right corner.
+
+1. Click the menu and select **Edit**.
 
    ![Panel with menu displayed](/media/docs/grafana/screenshot-panel-menu.png)
 
@@ -70,8 +72,8 @@ Explore and export panel, panel data, and data frame JSON models.
 
 1. Open the dashboard that contains the panel.
 
-1. Hover over any part of the panel to display the actions menu on the top right corner. Click the menu and select **Inspect > Panel JSON**.
-
+1. Hover over any part of the panel to display the actions menu on the top right corner.
+1. Click the menu and select **Inspect > Panel JSON**.
 1. In the **Select source** field, select one of the following options:
 
    - **Panel JSON:** Displays a JSON object representing the panel.

--- a/docs/sources/panels-visualizations/configure-panel-options/index.md
+++ b/docs/sources/panels-visualizations/configure-panel-options/index.md
@@ -36,9 +36,11 @@ After you add a panel to a dashboard, you can open it at any time to change chan
 
 1. Open the dashboard that contains the panel you want to edit.
 
-1. Click in the panel title and select **Edit**. To use a keyboard shortcut to open the panel, hover over the panel and press `e`.
+1. Hover over any part of the panel to display the actions menu on the top right corner. Click the menu and select **Edit**. To use a keyboard shortcut to open the panel, hover over the panel and press `e`.
 
    The panel opens in edit mode.
+
+   <!-- add screenshot here? -->
 
 ## Add a title and description to a panel
 
@@ -66,7 +68,7 @@ Explore and export panel, panel data, and data frame JSON models.
 
 1. Open the dashboard that contains the panel.
 
-1. Click in the panel title and select **Inspect > Panel JSON**.
+1. Hover over any part of the panel to display the actions menu on the top right corner. Click the menu and select **Inspect > Panel JSON**.
 
 1. In the **Select source** field, select one of the following options:
 

--- a/docs/sources/panels-visualizations/configure-panel-options/index.md
+++ b/docs/sources/panels-visualizations/configure-panel-options/index.md
@@ -38,11 +38,11 @@ After you add a panel to a dashboard, you can open it at any time to change chan
 
 1. Hover over any part of the panel to display the actions menu on the top right corner. Click the menu and select **Edit**.
 
-![Panel with menu displayed](/media/docs/grafana/screenshot-panel-menu.png)
+   ![Panel with menu displayed](/media/docs/grafana/screenshot-panel-menu.png)
 
-To use a keyboard shortcut to open the panel, hover over the panel and press `e`.
+   To use a keyboard shortcut to open the panel, hover over the panel and press `e`.
 
-The panel opens in edit mode.
+   The panel opens in edit mode.
 
 ## Add a title and description to a panel
 

--- a/docs/sources/panels-visualizations/configure-standard-options/index.md
+++ b/docs/sources/panels-visualizations/configure-standard-options/index.md
@@ -27,10 +27,9 @@ For a complete list of field formatting options, refer to [Standard options defi
 
 > You can apply standard options to most built-in Grafana panels. Some older panels and community panels that have not updated to the new panel and data model will be missing either all or some of these field options.
 
-1. Open a dashboard. Hover over any part of the panel to display the actions menu on the top right corner. Click the menu and select **Edit**.
-
+1. Open a dashboard. Hover over any part of the panel to display the actions menu on the top right corner.
+1. Click the menu and select **Edit**.
 1. In the panel display options pane, locate the **Standard options** section.
-
 1. Select the standard options you want to apply.
 
    For more information about standard options, refer to [Standard options definitions]({{< relref "#standard-options-definitions" >}}).

--- a/docs/sources/panels-visualizations/configure-standard-options/index.md
+++ b/docs/sources/panels-visualizations/configure-standard-options/index.md
@@ -27,7 +27,7 @@ For a complete list of field formatting options, refer to [Standard options defi
 
 > You can apply standard options to most built-in Grafana panels. Some older panels and community panels that have not updated to the new panel and data model will be missing either all or some of these field options.
 
-1. Open a dashboard, click the panel title, and click **Edit**.
+1. Open a dashboard. Hover over any part of the panel to display the actions menu on the top right corner. Click the menu and select **Edit**.
 
 1. In the panel display options pane, locate the **Standard options** section.
 

--- a/docs/sources/panels-visualizations/panel-editor-overview/index.md
+++ b/docs/sources/panels-visualizations/panel-editor-overview/index.md
@@ -23,9 +23,7 @@ weight: 1
 
 # Panel editor overview
 
-{{< figure src="/static/img/docs/panel-editor/panel-editor-8-0.png" class="docs-image--no-shadow" max-width="1500px" >}}
-
-<!-- replace screenshot -->
+![Panel editor](/media/docs/grafana/panels-visualizations/screenshot-panel-editor-view.png)
 
 This section describes the areas of the Grafana panel editor.
 

--- a/docs/sources/panels-visualizations/panel-editor-overview/index.md
+++ b/docs/sources/panels-visualizations/panel-editor-overview/index.md
@@ -30,7 +30,6 @@ weight: 1
 This section describes the areas of the Grafana panel editor.
 
 1. Panel header: The header section lists the dashboard in which the panel appears and the following controls:
-   <!-- what we refer to as the panel header here is not what we mean when we talk about in terms of the feature internally -->
 
    - **Discard:** Discards changes you have made to the panel since you last saved the dashboard.
    - **Save:** Saves changes you made to the panel.
@@ -53,9 +52,9 @@ This section describes the areas of the Grafana panel editor.
 
 ## Open the panel inspect drawer
 
-<!-- does this content belong here? The only way to get to the Inspect drawer from the panel editor view is via the Query inspector which seems weird -->
-
 The inspect drawer helps you understand and troubleshoot your panels. You can view the raw data for any panel, export that data to a comma-separated values (CSV) file, view query requests, and export panel and data JSON.
+
+To access the panel inspect drawer from the edit view, hover over any part of the panel to display the actions menu on the top right corner. Click the menu and select **Inspect**.
 
 > **Note:** Not all panel types include all tabs. For example, dashboard list panels do not have raw data to inspect, so they do not display the Stats, Data, or Query tabs.
 

--- a/docs/sources/panels-visualizations/panel-editor-overview/index.md
+++ b/docs/sources/panels-visualizations/panel-editor-overview/index.md
@@ -25,11 +25,13 @@ weight: 1
 
 {{< figure src="/static/img/docs/panel-editor/panel-editor-8-0.png" class="docs-image--no-shadow" max-width="1500px" >}}
 
+<!-- replace screenshot -->
+
 This section describes the areas of the Grafana panel editor.
 
 1. Panel header: The header section lists the dashboard in which the panel appears and the following controls:
+   <!-- what we refer to as the panel header here is not what we mean when we talk about in terms of the feature internally -->
 
-   - **Dashboard settings (gear) icon:** Click to access the dashboard settings.
    - **Discard:** Discards changes you have made to the panel since you last saved the dashboard.
    - **Save:** Saves changes you made to the panel.
    - **Apply:** Applies changes you made and closes the panel editor, returning you to the dashboard. You will have to save the dashboard to persist the applied changes.
@@ -50,6 +52,8 @@ This section describes the areas of the Grafana panel editor.
 1. Panel display options: The display options section contains tabs where you configure almost every aspect of your data visualization.
 
 ## Open the panel inspect drawer
+
+<!-- does this content belong here? The only way to get to the Inspect drawer from the panel editor view is via the Query inspector which seems weird -->
 
 The inspect drawer helps you understand and troubleshoot your panels. You can view the raw data for any panel, export that data to a comma-separated values (CSV) file, view query requests, and export panel and data JSON.
 

--- a/docs/sources/panels-visualizations/query-transform-data/transform-data/index.md
+++ b/docs/sources/panels-visualizations/query-transform-data/transform-data/index.md
@@ -47,7 +47,8 @@ The order in which Grafana applies transformations directly impacts the results.
 The following steps guide you in adding a transformation to data. This documentation does not include steps for each type of transformation. For a complete list of transformations, refer to [Transformation functions]({{< relref "#transformation-functions" >}}).
 
 1. Navigate to the panel where you want to add one or more transformations.
-1. Hover over any part of the panel to display the actions menu on the top right corner. Click the menu and select **Edit**.
+1. Hover over any part of the panel to display the actions menu on the top right corner.
+1. Click the menu and select **Edit**.
 1. Click the **Transform** tab.
 1. Click a transformation.
    A transformation row appears where you configure the transformation options. For more information about how to configure a transformation, refer to [Transformation functions]({{< relref "#transformation-functions" >}}).

--- a/docs/sources/panels-visualizations/query-transform-data/transform-data/index.md
+++ b/docs/sources/panels-visualizations/query-transform-data/transform-data/index.md
@@ -47,7 +47,7 @@ The order in which Grafana applies transformations directly impacts the results.
 The following steps guide you in adding a transformation to data. This documentation does not include steps for each type of transformation. For a complete list of transformations, refer to [Transformation functions]({{< relref "#transformation-functions" >}}).
 
 1. Navigate to the panel where you want to add one or more transformations.
-1. Click the panel title and then click **Edit**.
+1. Hover over any part of the panel to display the actions menu on the top right corner. Click the menu and select **Edit**.
 1. Click the **Transform** tab.
 1. Click a transformation.
    A transformation row appears where you configure the transformation options. For more information about how to configure a transformation, refer to [Transformation functions]({{< relref "#transformation-functions" >}}).

--- a/docs/sources/setup-grafana/image-rendering/_index.md
+++ b/docs/sources/setup-grafana/image-rendering/_index.md
@@ -22,7 +22,7 @@ While an image is being rendered, the PNG image is temporarily written to the fi
 
 A background job runs every 10 minutes and removes temporary images. You can configure how long an image should be stored before being removed by configuring the [temp_data_lifetime]({{< relref "../configure-grafana/#temp_data_lifetime" >}}) setting.
 
-You can also render a PNG by clicking the dropdown arrow next to a panel title, then clicking **Share > Direct link rendered image**.
+You can also render a PNG by clicking hovering over the panel to display the actions menu in the top right corner, and then clicking **Share > Direct link rendered image** in the Link tab.
 
 ## Alerting and render limits
 

--- a/docs/sources/shared/panels/panel-links-intro.md
+++ b/docs/sources/shared/panels/panel-links-intro.md
@@ -2,4 +2,4 @@
 title: Panel links intro
 ---
 
-Each panel can have its own set of links that are shown in the upper left corner of the panel. You can link to any available URL, including dashboards, panels, or external sites. You can even control the time range to ensure the user is zoomed in on the right data in Grafana.
+Each panel can have its own set of links that are shown in top left of a panel after the panel title. You can link to any available URL, including dashboards, panels, or external sites. You can even control the time range to ensure the user is zoomed in on the right data in Grafana.

--- a/docs/sources/troubleshooting/send-panel-to-grafana-support/index.md
+++ b/docs/sources/troubleshooting/send-panel-to-grafana-support/index.md
@@ -18,7 +18,7 @@ The panel that you send includes all query response data and all visualizations 
 
 1. Open the dashboard that contains the panel you want to send to Grafana Labs.
 
-1. Hover your mouse cursor over the panel title and click **More > Get help**.
+1. Hover over any part of the panel to display the actions menu on the top right corner. Click the menu and select **More > Get help**.
 
    Grafana opens a standalone support dashboard that contains the data you are sending to Grafana Labs Technical Support.
 
@@ -28,9 +28,9 @@ The panel that you send includes all query response data and all visualizations 
 
 1. To send the panel data to Grafana Labs via Github:
 
-   a. Click **Copy for Github**.
+   a. Click **Copy to clipboard**.
 
-   b. In the [Grafana/Grafana](https://github.com/grafana/grafana) repository, create an issue and paste the contents of the support dashboard.
+   b. In the [Grafana/Grafana](https://github.com/grafana/grafana) repository, create an issue, and paste the contents of the support dashboard.
 
 1. To send the panel data to Grafana Labs via a support ticket:
 

--- a/docs/sources/troubleshooting/send-panel-to-grafana-support/index.md
+++ b/docs/sources/troubleshooting/send-panel-to-grafana-support/index.md
@@ -18,7 +18,9 @@ The panel that you send includes all query response data and all visualizations 
 
 1. Open the dashboard that contains the panel you want to send to Grafana Labs.
 
-1. Hover over any part of the panel to display the actions menu on the top right corner. Click the menu and select **More > Get help**.
+1. Hover over any part of the panel to display the actions menu on the top right corner.
+
+1. Click the menu and select **More > Get help**.
 
    Grafana opens a standalone support dashboard that contains the data you are sending to Grafana Labs Technical Support.
 


### PR DESCRIPTION
Updates pages that specifically document the "click panel title" interaction since that's no longer how users get to the actions menu. 

TO DO
- [x] Update main image on Panel editor overview page