### PR TITLE
Alerting: Switch to snappy-compressed-protobuf for outgoing push requests to Loki

### DIFF
--- a/pkg/services/ngalert/state/historian/encode.go
+++ b/pkg/services/ngalert/state/historian/encode.go
@@ -69,11 +69,10 @@ func (e SnappyProtoEncoder) headers() map[string]string {
 	}
 }
 
-// TODO: Copied from promtail, main
-// TODO: pkg/components/loki/lokihttp/batch.go contains an older (loki 2.7.4) version of this
-// TODO: Consider replacing that one, with this one
-// TODO: It appears we need this one as it properly quotes label values, thus avoiding problems with "="
-// TODO: Test this before submission!
+// Copied from promtail.
+// Modified slightly to work in terms of plain map[string]string to avoid some unnecessary copies and type casts.
+// TODO: pkg/components/loki/lokihttp/batch.go contains an older (loki 2.7.4 released) version of this.
+// TODO: Consider replacing that one, with this one.
 func labelsMapToString(ls map[string]string, without model.LabelName) string {
 	var b strings.Builder
 	totalSize := 2

--- a/pkg/services/ngalert/state/historian/encode.go
+++ b/pkg/services/ngalert/state/historian/encode.go
@@ -23,3 +23,12 @@ func (e jsonEncoder) headers() map[string]string {
 		"Content-Type": "application/json",
 	}
 }
+
+type snappyProtoEncoder struct{}
+
+func (e snappyProtoEncoder) headers() map[string]string {
+	return map[string]string{
+		"Content-Type":     "application/x-protobuf",
+		"Content-Encoding": "snappy",
+	}
+}

--- a/pkg/services/ngalert/state/historian/encode.go
+++ b/pkg/services/ngalert/state/historian/encode.go
@@ -96,9 +96,9 @@ func labelsMapToString(ls map[string]string, without model.LabelName) string {
 			b.WriteString(", ")
 		}
 
-		b.WriteString(string(l))
+		b.WriteString(l)
 		b.WriteString(`=`)
-		b.WriteString(strconv.Quote(string(ls[l])))
+		b.WriteString(strconv.Quote(ls[l]))
 	}
 	b.WriteByte('}')
 

--- a/pkg/services/ngalert/state/historian/encode.go
+++ b/pkg/services/ngalert/state/historian/encode.go
@@ -13,9 +13,9 @@ import (
 	"golang.org/x/exp/slices"
 )
 
-type jsonEncoder struct{}
+type JsonEncoder struct{}
 
-func (e jsonEncoder) encode(s []stream) ([]byte, error) {
+func (e JsonEncoder) encode(s []stream) ([]byte, error) {
 	body := struct {
 		Streams []stream `json:"streams"`
 	}{Streams: s}
@@ -26,15 +26,15 @@ func (e jsonEncoder) encode(s []stream) ([]byte, error) {
 	return enc, nil
 }
 
-func (e jsonEncoder) headers() map[string]string {
+func (e JsonEncoder) headers() map[string]string {
 	return map[string]string{
 		"Content-Type": "application/json",
 	}
 }
 
-type snappyProtoEncoder struct{}
+type SnappyProtoEncoder struct{}
 
-func (e snappyProtoEncoder) encode(s []stream) ([]byte, error) {
+func (e SnappyProtoEncoder) encode(s []stream) ([]byte, error) {
 	body := logproto.PushRequest{
 		Streams: make([]logproto.Stream, 0, len(s)),
 	}
@@ -62,7 +62,7 @@ func (e snappyProtoEncoder) encode(s []stream) ([]byte, error) {
 	return buf, nil
 }
 
-func (e snappyProtoEncoder) headers() map[string]string {
+func (e SnappyProtoEncoder) headers() map[string]string {
 	return map[string]string{
 		"Content-Type":     "application/x-protobuf",
 		"Content-Encoding": "snappy",

--- a/pkg/services/ngalert/state/historian/encode.go
+++ b/pkg/services/ngalert/state/historian/encode.go
@@ -3,6 +3,11 @@ package historian
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/prometheus/common/model"
+	"golang.org/x/exp/slices"
 )
 
 type jsonEncoder struct{}
@@ -31,4 +36,41 @@ func (e snappyProtoEncoder) headers() map[string]string {
 		"Content-Type":     "application/x-protobuf",
 		"Content-Encoding": "snappy",
 	}
+}
+
+// TODO: Copied from promtail, main
+// TODO: pkg/components/loki/lokihttp/batch.go contains an older (loki 2.7.4) version of this
+// TODO: Consider replacing that one, with this one
+// TODO: It appears we need this one as it properly quotes label values, thus avoiding problems with "="
+// TODO: Test this before submission!
+func labelsMapToString(ls model.LabelSet, without model.LabelName) string {
+	var b strings.Builder
+	totalSize := 2
+	lstrs := make([]model.LabelName, 0, len(ls))
+
+	for l, v := range ls {
+		if l == without {
+			continue
+		}
+
+		lstrs = append(lstrs, l)
+		// guess size increase: 2 for `, ` between labels and 3 for the `=` and quotes around label value
+		totalSize += len(l) + 2 + len(v) + 3
+	}
+
+	b.Grow(totalSize)
+	b.WriteByte('{')
+	slices.Sort(lstrs)
+	for i, l := range lstrs {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+
+		b.WriteString(string(l))
+		b.WriteString(`=`)
+		b.WriteString(strconv.Quote(string(ls[l])))
+	}
+	b.WriteByte('}')
+
+	return b.String()
 }

--- a/pkg/services/ngalert/state/historian/encode.go
+++ b/pkg/services/ngalert/state/historian/encode.go
@@ -1,0 +1,25 @@
+package historian
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type jsonEncoder struct{}
+
+func (e jsonEncoder) encode(s []stream) ([]byte, error) {
+	body := struct {
+		Streams []stream `json:"streams"`
+	}{Streams: s}
+	enc, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize Loki payload: %w", err)
+	}
+	return enc, nil
+}
+
+func (e jsonEncoder) headers() map[string]string {
+	return map[string]string{
+		"Content-Type": "application/json",
+	}
+}

--- a/pkg/services/ngalert/state/historian/loki_http.go
+++ b/pkg/services/ngalert/state/historian/loki_http.go
@@ -40,6 +40,7 @@ type LokiConfig struct {
 	BasicAuthPassword string
 	TenantID          string
 	ExternalLabels    map[string]string
+	Encoder           encoder
 }
 
 func NewLokiConfig(cfg setting.UnifiedAlertingStateHistorySettings) (LokiConfig, error) {
@@ -73,6 +74,8 @@ func NewLokiConfig(cfg setting.UnifiedAlertingStateHistorySettings) (LokiConfig,
 		BasicAuthUser:     cfg.LokiBasicAuthUsername,
 		BasicAuthPassword: cfg.LokiBasicAuthPassword,
 		TenantID:          cfg.LokiTenantID,
+		// Snappy-compressed protobuf is the default, same goes for Promtail.
+		Encoder: snappyProtoEncoder{},
 	}, nil
 }
 
@@ -110,7 +113,7 @@ func newLokiClient(cfg LokiConfig, req client.Requester, metrics *metrics.Histor
 	tc := client.NewTimedClient(req, metrics.WriteDuration)
 	return &httpLokiClient{
 		client:  tc,
-		encoder: snappyProtoEncoder{},
+		encoder: cfg.Encoder,
 		cfg:     cfg,
 		metrics: metrics,
 		log:     logger.New("protocol", "http"),

--- a/pkg/services/ngalert/state/historian/loki_http.go
+++ b/pkg/services/ngalert/state/historian/loki_http.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/golang/snappy"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
 	"github.com/grafana/grafana/pkg/setting"
@@ -176,6 +177,7 @@ func (c *httpLokiClient) push(ctx context.Context, s []stream) error {
 	if err != nil {
 		return fmt.Errorf("failed to serialize Loki payload: %w", err)
 	}
+	enc = snappy.Encode(nil, enc)
 
 	uri := c.cfg.WritePathURL.JoinPath("/loki/api/v1/push")
 	req, err := http.NewRequest(http.MethodPost, uri.String(), bytes.NewBuffer(enc))

--- a/pkg/services/ngalert/state/historian/loki_http.go
+++ b/pkg/services/ngalert/state/historian/loki_http.go
@@ -75,7 +75,7 @@ func NewLokiConfig(cfg setting.UnifiedAlertingStateHistorySettings) (LokiConfig,
 		BasicAuthPassword: cfg.LokiBasicAuthPassword,
 		TenantID:          cfg.LokiTenantID,
 		// Snappy-compressed protobuf is the default, same goes for Promtail.
-		Encoder: snappyProtoEncoder{},
+		Encoder: SnappyProtoEncoder{},
 	}, nil
 }
 

--- a/pkg/services/ngalert/state/historian/loki_http_test.go
+++ b/pkg/services/ngalert/state/historian/loki_http_test.go
@@ -117,6 +117,7 @@ func TestLokiHTTPClient_Manual(t *testing.T) {
 		client := newLokiClient(LokiConfig{
 			ReadPathURL:  url,
 			WritePathURL: url,
+			Encoder:      JsonEncoder{},
 		}, NewRequester(), metrics.NewHistorianMetrics(prometheus.NewRegistry()), log.NewNopLogger())
 
 		// Unauthorized request should fail against Grafana Cloud.
@@ -144,6 +145,7 @@ func TestLokiHTTPClient_Manual(t *testing.T) {
 			WritePathURL:      url,
 			BasicAuthUser:     "<your_username>",
 			BasicAuthPassword: "<your_password>",
+			Encoder:           JsonEncoder{},
 		}, NewRequester(), metrics.NewHistorianMetrics(prometheus.NewRegistry()), log.NewNopLogger())
 
 		// When running on prem, you might need to set the tenant id,
@@ -259,6 +261,7 @@ func createTestLokiClient(req client.Requester) *httpLokiClient {
 	cfg := LokiConfig{
 		WritePathURL: url,
 		ReadPathURL:  url,
+		Encoder:      JsonEncoder{},
 	}
 	met := metrics.NewHistorianMetrics(prometheus.NewRegistry())
 	return newLokiClient(cfg, req, met, log.NewNopLogger())

--- a/pkg/services/ngalert/state/historian/loki_test.go
+++ b/pkg/services/ngalert/state/historian/loki_test.go
@@ -318,6 +318,7 @@ func createTestLokiBackend(req client.Requester, met *metrics.Historian) *Remote
 	cfg := LokiConfig{
 		WritePathURL: url,
 		ReadPathURL:  url,
+		Encoder:      JsonEncoder{},
 	}
 	return NewRemoteLokiBackend(cfg, req, met)
 }


### PR DESCRIPTION
**What is this feature?**

Loki's HTTP API accepts [exactly two formats](https://grafana.com/docs/loki/latest/api/#push-log-entries-to-loki):
- `snappy`-compressed-`protobuf`
- uncompressed JSON.

Promtail, the canonical Loki client, uses snappy-compressed-protobuf **only**. This is not configurable.
Many "loki-like" tools also seem to **only** accept snappy-compressed-protobuf.

This PR does the same - the default becomes snappy-compressed-protobuf. Right now this is configurable at the code level, when using the client as a library, but not at the grafana configuration level. We can evaluate adding this config option to grafana .ini in the future, but there's precedent to not do so in Promtail.

**Why do we need this feature?**

Consistency with Promtail. Interoperability with other Loki-like tools. Closer to the main code path in Loki.

Also, we send fewer bytes over the network.

**Who is this feature for?**

Operators and users who want to run state history against some Loki-like tools that aren't necessarily Loki.

**Which issue(s) does this PR fix?**:

n/a

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
- [X] There are no known compatibility issues with older supported versions of Grafana, or plugins.
- [X] It passes the [Hosted Grafana feature readiness review](https://docs.google.com/document/d/1QL9Ly8KnXzpb6ISbg49pTODRO5mhA5tkkfIZVX6pqQU/edit) for observability, scalability, performance, and security.