### PR TITLE
Admin: Change permissions to /admin page so org admins don't get redirected

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -102,7 +102,7 @@ func (hs *HTTPServer) registerRoutes() {
 	r.Get("/org/apikeys/", authorize(reqOrgAdmin, ac.EvalPermission(ac.ActionAPIKeyRead)), hs.Index)
 	r.Get("/dashboard/import/", reqSignedIn, hs.Index)
 	r.Get("/configuration", reqGrafanaAdmin, hs.Index)
-	r.Get("/admin", reqGrafanaAdmin, hs.Index)
+	r.Get("/admin", reqOrgAdmin, hs.Index)
 	r.Get("/admin/settings", authorize(reqGrafanaAdmin, ac.EvalPermission(ac.ActionSettingsRead)), hs.Index)
 	// Show the combined users page for org admins if topnav is enabled
 	if hs.Features.IsEnabled(featuremgmt.FlagTopnav) {


### PR DESCRIPTION
**What is this feature?**

Currently if a user is an org admin but not a server admin, they can still visit the `/admin` page, but when they refresh that page they get redirected to the homepage.

**Why do we need this feature?**

So org admins don't get redirected out of the Administration page

**Who is this feature for?**

Org admins

**Which issue(s) does this PR fix?**:

Fixes #62295
