### PR TITLE
[POC] Logs Volume: identify timeouts and provide remediation action

### DIFF
--- a/packages/grafana-data/src/types/logs.ts
+++ b/packages/grafana-data/src/types/logs.ts
@@ -182,6 +182,7 @@ export const hasLogsContextSupport = (datasource: unknown): datasource is DataSo
  */
 export enum SupplementaryQueryType {
   LogsVolume = 'LogsVolume',
+  LogsVolumeNoTimeout = 'LogsVolumeNoTimeout',
   LogsSample = 'LogsSample',
 }
 

--- a/public/app/features/explore/Logs.tsx
+++ b/public/app/features/explore/Logs.tsx
@@ -392,6 +392,7 @@ class UnthemedLogs extends PureComponent<Props, State> {
               onLoadLogsVolume={loadLogsVolumeData}
               onHiddenSeriesChanged={this.onToggleLogLevel}
               eventBus={this.logsVolumeEventBus}
+              onClose={() => this.onToggleLogsVolumeCollapse(false)}
             />
           )}
         </Collapse>

--- a/public/app/features/explore/LogsContainer.tsx
+++ b/public/app/features/explore/LogsContainer.tsx
@@ -158,7 +158,9 @@ class LogsContainer extends PureComponent<LogsContainerProps> {
             splitOpen={splitOpenFn}
             loading={loading}
             loadingState={loadingState}
-            loadLogsVolumeData={() => loadSupplementaryQueryData(exploreId, SupplementaryQueryType.LogsVolume)}
+            loadLogsVolumeData={(type = SupplementaryQueryType.LogsVolume) =>
+              loadSupplementaryQueryData(exploreId, type, SupplementaryQueryType.LogsVolume)
+            }
             onChangeTime={this.onChangeTime}
             onClickFilterLabel={onClickFilterLabel}
             onClickFilterOutLabel={onClickFilterOutLabel}

--- a/public/app/features/explore/LogsVolumePanelList.tsx
+++ b/public/app/features/explore/LogsVolumePanelList.tsx
@@ -55,10 +55,22 @@ export const LogsVolumePanelList = ({
     return !isLogsVolumeLimited(data) && zoomRatio && zoomRatio < 1;
   });
 
+  const timeoutError = logsVolumeData?.error?.message?.includes('timeout');
+  const retry = () => {
+    onLoadLogsVolume();
+  };
+
   if (logsVolumeData?.state === LoadingState.Loading) {
     return <span>Loading...</span>;
-  }
-  if (logsVolumeData?.error !== undefined) {
+  } else if (timeoutError) {
+    return (
+      <SupplementaryResultError
+        title="The logs volume query is taking too long"
+        suggestion="Continue executing"
+        onSuggestionClicked={retry}
+      />
+    );
+  } else if (logsVolumeData?.error !== undefined) {
     return <SupplementaryResultError error={logsVolumeData.error} title="Failed to load log volume for this query" />;
   }
   return (

--- a/public/app/features/explore/LogsVolumePanelList.tsx
+++ b/public/app/features/explore/LogsVolumePanelList.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import { groupBy } from 'lodash';
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 
 import {
   AbsoluteTimeRange,
@@ -11,6 +11,7 @@ import {
   isLogsVolumeLimited,
   LoadingState,
   SplitOpen,
+  SupplementaryQueryType,
   TimeZone,
 } from '@grafana/data';
 import { Button, InlineField, useStyles2 } from '@grafana/ui';
@@ -25,7 +26,7 @@ type Props = {
   splitOpen: SplitOpen;
   width: number;
   onUpdateTimeRange: (timeRange: AbsoluteTimeRange) => void;
-  onLoadLogsVolume: () => void;
+  onLoadLogsVolume: (type?: SupplementaryQueryType) => void;
   onHiddenSeriesChanged: (hiddenSeries: string[]) => void;
   eventBus: EventBus;
   onClose?(): void;
@@ -57,10 +58,11 @@ export const LogsVolumePanelList = ({
     return !isLogsVolumeLimited(data) && zoomRatio && zoomRatio < 1;
   });
 
-  const timeoutError = logsVolumeData?.error?.message?.includes('timeout');
-  const retry = () => {
-    onLoadLogsVolume();
-  };
+  const timeoutError =
+    logsVolumeData?.error?.message?.includes('timeout') || logsVolumeData?.error?.message?.includes('exceeded');
+  const retry = useCallback(() => {
+    onLoadLogsVolume(SupplementaryQueryType.LogsVolumeNoTimeout);
+  }, [onLoadLogsVolume]);
 
   if (logsVolumeData?.state === LoadingState.Loading) {
     return <span>Loading...</span>;
@@ -99,7 +101,7 @@ export const LogsVolumePanelList = ({
       {containsZoomed && (
         <div className={styles.extraInfoContainer}>
           <InlineField label="Reload log volume" transparent>
-            <Button size="xs" icon="sync" variant="secondary" onClick={onLoadLogsVolume} id="reload-volume" />
+            <Button size="xs" icon="sync" variant="secondary" onClick={() => onLoadLogsVolume()} id="reload-volume" />
           </InlineField>
         </div>
       )}

--- a/public/app/features/explore/LogsVolumePanelList.tsx
+++ b/public/app/features/explore/LogsVolumePanelList.tsx
@@ -28,6 +28,7 @@ type Props = {
   onLoadLogsVolume: () => void;
   onHiddenSeriesChanged: (hiddenSeries: string[]) => void;
   eventBus: EventBus;
+  onClose?(): void;
 };
 
 export const LogsVolumePanelList = ({
@@ -40,6 +41,7 @@ export const LogsVolumePanelList = ({
   eventBus,
   splitOpen,
   timeZone,
+  onClose,
 }: Props) => {
   const logVolumes = useMemo(
     () => groupBy(logsVolumeData?.data || [], 'meta.custom.sourceQuery.refId'),
@@ -67,7 +69,8 @@ export const LogsVolumePanelList = ({
       <SupplementaryResultError
         title="The logs volume query is taking too long"
         suggestion="Continue executing"
-        onSuggestionClicked={retry}
+        onSuggestion={retry}
+        onRemove={onClose}
       />
     );
   } else if (logsVolumeData?.error !== undefined) {

--- a/public/app/features/explore/LogsVolumePanelList.tsx
+++ b/public/app/features/explore/LogsVolumePanelList.tsx
@@ -67,8 +67,8 @@ export const LogsVolumePanelList = ({
   } else if (timeoutError) {
     return (
       <SupplementaryResultError
-        title="The logs volume query is taking too long"
-        suggestion="Continue executing"
+        title="The logs volume query is taking too long and has timed out"
+        suggestion="Retry"
         onSuggestion={retry}
         onRemove={onClose}
       />

--- a/public/app/features/explore/SupplementaryResultError.tsx
+++ b/public/app/features/explore/SupplementaryResultError.tsx
@@ -4,21 +4,23 @@ import { DataQueryError } from '@grafana/data';
 import { Alert, Button } from '@grafana/ui';
 
 type Props = {
-  error: DataQueryError;
+  error?: DataQueryError;
   title: string;
+  suggestion?: string;
+  onSuggestionClicked?(): void;
 };
 export function SupplementaryResultError(props: Props) {
   const [isOpen, setIsOpen] = useState(false);
   const SHORT_ERROR_MESSAGE_LIMIT = 100;
-  const { error, title } = props;
+  const { error, title, suggestion, onSuggestionClicked } = props;
   // generic get-error-message-logic, taken from
   // /public/app/features/explore/ErrorContainer.tsx
-  const message = error.message || error.data?.message || '';
+  const message = error?.message || error?.data?.message || '';
   const showButton = !isOpen && message.length > SHORT_ERROR_MESSAGE_LIMIT;
 
   return (
     <Alert title={title} severity="warning">
-      {showButton ? (
+      {showButton && message ? (
         <Button
           variant="secondary"
           size="xs"
@@ -30,6 +32,17 @@ export function SupplementaryResultError(props: Props) {
         </Button>
       ) : (
         message
+      )}
+      {suggestion && onSuggestionClicked && (
+        <Button
+          variant="primary"
+          size="xs"
+          onClick={() => {
+            onSuggestionClicked();
+          }}
+        >
+          {suggestion}
+        </Button>
       )}
     </Alert>
   );

--- a/public/app/features/explore/SupplementaryResultError.tsx
+++ b/public/app/features/explore/SupplementaryResultError.tsx
@@ -7,19 +7,20 @@ type Props = {
   error?: DataQueryError;
   title: string;
   suggestion?: string;
-  onSuggestionClicked?(): void;
+  onSuggestion?(): void;
+  onRemove?(): void;
 };
 export function SupplementaryResultError(props: Props) {
   const [isOpen, setIsOpen] = useState(false);
   const SHORT_ERROR_MESSAGE_LIMIT = 100;
-  const { error, title, suggestion, onSuggestionClicked } = props;
+  const { error, title, suggestion, onSuggestion, onRemove } = props;
   // generic get-error-message-logic, taken from
   // /public/app/features/explore/ErrorContainer.tsx
   const message = error?.message || error?.data?.message || '';
   const showButton = !isOpen && message.length > SHORT_ERROR_MESSAGE_LIMIT;
 
   return (
-    <Alert title={title} severity="warning">
+    <Alert title={title} severity="warning" onRemove={onRemove}>
       {showButton && message ? (
         <Button
           variant="secondary"
@@ -33,12 +34,12 @@ export function SupplementaryResultError(props: Props) {
       ) : (
         message
       )}
-      {suggestion && onSuggestionClicked && (
+      {suggestion && onSuggestion && (
         <Button
           variant="primary"
           size="xs"
           onClick={() => {
-            onSuggestionClicked();
+            onSuggestion();
           }}
         >
           {suggestion}

--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -762,22 +762,31 @@ export function clearCache(exploreId: ExploreId): ThunkResult<void> {
 
 /**
  * Initializes loading logs volume data and stores emitted value.
+ * @param exploreId
+ * @param type Type of suplementary query to run
+ * @param displayAsType Optional. Overrde `type` to display the results as other query type
  */
-export function loadSupplementaryQueryData(exploreId: ExploreId, type: SupplementaryQueryType): ThunkResult<void> {
+export function loadSupplementaryQueryData(
+  exploreId: ExploreId,
+  type: SupplementaryQueryType,
+  displayAsType?: SupplementaryQueryType
+): ThunkResult<void> {
   return (dispatch, getState) => {
     const { supplementaryQueries } = getState().explore[exploreId]!;
     const dataProvider = supplementaryQueries[type].dataProvider;
 
+    const payloadType = displayAsType ? displayAsType : type;
+
     if (dataProvider) {
       const dataSubscription = dataProvider.subscribe({
         next: (supplementaryQueryData: DataQueryResponse) => {
-          dispatch(updateSupplementaryQueryDataAction({ exploreId, type, data: supplementaryQueryData }));
+          dispatch(updateSupplementaryQueryDataAction({ exploreId, type: payloadType, data: supplementaryQueryData }));
         },
       });
       dispatch(
         storeSupplementaryQueryDataSubscriptionAction({
           exploreId,
-          type,
+          type: payloadType,
           dataSubscription,
         })
       );

--- a/public/app/features/explore/utils/supplementaryQueries.test.ts
+++ b/public/app/features/explore/utils/supplementaryQueries.test.ts
@@ -31,6 +31,7 @@ class MockDataSourceWithSupplementaryQuerySupport
 {
   private supplementaryQueriesResults: Record<SupplementaryQueryType, DataFrame[] | undefined> = {
     [SupplementaryQueryType.LogsVolume]: undefined,
+    [SupplementaryQueryType.LogsVolumeNoTimeout]: undefined,
     [SupplementaryQueryType.LogsSample]: undefined,
   };
 

--- a/public/app/features/explore/utils/supplementaryQueries.ts
+++ b/public/app/features/explore/utils/supplementaryQueries.ts
@@ -21,6 +21,7 @@ import { ExplorePanelData, SupplementaryQueries } from 'app/types';
 
 export const supplementaryQueryTypes: SupplementaryQueryType[] = [
   SupplementaryQueryType.LogsVolume,
+  SupplementaryQueryType.LogsVolumeNoTimeout,
   SupplementaryQueryType.LogsSample,
 ];
 
@@ -34,6 +35,7 @@ export const loadSupplementaryQueries = (): SupplementaryQueries => {
   // We default to true for all supp queries
   let supplementaryQueries: SupplementaryQueries = {
     [SupplementaryQueryType.LogsVolume]: { enabled: true },
+    [SupplementaryQueryType.LogsVolumeNoTimeout]: { enabled: false },
     [SupplementaryQueryType.LogsSample]: { enabled: false },
   };
 
@@ -213,9 +215,8 @@ export const getSupplementaryQueryProvider = (
       ),
       distinct()
     );
-  } else {
-    // Create a fallback to results based logs volume
-    return getSupplementaryQueryFallback(type, explorePanelData, request.targets, datasourceInstance.name);
   }
-  return undefined;
+
+  // Create a fallback to results based logs volume
+  return getSupplementaryQueryFallback(type, explorePanelData, request.targets, datasourceInstance.name);
 };


### PR DESCRIPTION
This PR proposes an alternative UI for supplementary queries with errors or, in this case, timeouts. In the current implementation, when the logs volume query timeouts we display the following UI state:

![Previous](https://user-images.githubusercontent.com/1069378/226593926-f1c70155-7487-40da-92ec-ab6d5a37eaae.png)

With the changes in this PR, we would identify timeouts and display a friendlier message to the user, with an option to retry the query:

![Retry](https://user-images.githubusercontent.com/1069378/227174949-63a2aebf-31df-4303-8b9d-a554dc92b082.gif)

Additionally, we could also add support to dismiss the alert, which would collapse the Logs volume panel if the user is not interested on its contents and not interested on retrying the request ("x" button, top right corner):

![Dismiss](https://user-images.githubusercontent.com/1069378/227175217-9c894aab-c7b6-4f06-8e67-827ed3c807a3.gif)

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/64627

**Special notes for your reviewer:**

