### PR TITLE
elasticsearch: more robust field order

### DIFF
--- a/pkg/tsdb/elasticsearch/response_parser.go
+++ b/pkg/tsdb/elasticsearch/response_parser.go
@@ -693,7 +693,7 @@ func processAggregationDocs(esAgg *simplejson.Json, aggDef *BucketAgg, target *Q
 				}
 			case percentilesType:
 				percentiles := bucket.GetPath(metric.ID, "values")
-				for percentileName := range percentiles.MustMap() {
+				for _, percentileName := range getSortedKeys(percentiles.MustMap()) {
 					percentileValue := percentiles.Get(percentileName).MustFloat64()
 					addMetricValue(values, fmt.Sprintf("p%v %v", percentileName, metric.Field), &percentileValue)
 				}
@@ -1128,4 +1128,15 @@ func createFieldsFromPropKeys(frames data.Frames, propKeys []string) []*data.Fie
 		}
 	}
 	return fields
+}
+
+func getSortedKeys(data map[string]interface{}) []string {
+	keys := make([]string, 0, len(data))
+
+	for k := range data {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+	return keys
 }

--- a/pkg/tsdb/elasticsearch/response_parser_frontend_test.go
+++ b/pkg/tsdb/elasticsearch/response_parser_frontend_test.go
@@ -1030,7 +1030,7 @@ func TestPercentilesWithoutDateHistogram(t *testing.T) {
 			  "3": {
 				"buckets": [
 				  {
-					"1": { "values": { "75": 3.3, "90": 5.5 } },
+					"1": { "values": { "90": 5.5, "75": 3.3 } },
 					"doc_count": 10,
 					"key": "id1"
 				  },


### PR DESCRIPTION
in a certain situation, we iterate over keys from a json object. a json object's keys have no defined order, so we should not rely on it being in a certain order.
this PR explicitly string-sorts the keys of the json-object.

i also modified the unit-test to trigger the problem.