### PR TITLE
Loki Logs sample: use the selected time range in sample request

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -22,7 +22,6 @@ import {
   DateTime,
   FieldCache,
   FieldType,
-  getDefaultTimeRange,
   Labels,
   LoadingState,
   LogLevel,
@@ -548,11 +547,11 @@ export class LokiDatasource
       expr: query.expr,
       queryType: LokiQueryType.Range,
       refId: REF_ID_DATA_SAMPLES,
+      // For samples we limit the request to 10 lines, so queries are small and fast
       maxLines: 10,
     };
 
-    // For samples, we use defaultTimeRange (now-6h/now) and limit od 10 lines so queries are small and fast
-    const timeRange = getDefaultTimeRange();
+    const timeRange = this.getTimeRange();
     const request = makeRequest(lokiLogsQuery, timeRange, CoreApp.Unknown, REF_ID_DATA_SAMPLES, true);
     return await lastValueFrom(this.query(request).pipe(switchMap((res) => of(res.data))));
   }


### PR DESCRIPTION
For the logs sample request, we were always using the current time-6h to make the request.

![current](https://user-images.githubusercontent.com/1069378/226663721-6fb18d5e-8d8c-4b96-af2d-43a3d072507d.png)

The problem is that there are parts of the query, such as label values, that could only be present during the user selected time interval. If we request using a time range other than the selected one, we are not providing builder suggestions based on the same data that the user is seeing.

The issue was reproduced in OPS, where the request using an absolute time interval would return logs, but the sample request with now-6h did not return any logs.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/64040

**Special notes for your reviewer:**

The sample request should use the time range selected by the user. If the logs request returns logs, the sample request should also see logs, and offer suggestions based on those results.