### PR TITLE
Add: benchmark test output to json for dashboard permissions

### DIFF
--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -305,7 +305,7 @@ def benchmark_ldap_step():
             'go test -benchmem -run=^$ ./pkg/extensions/ldapsync -bench "^(Benchmark50Users)$"',
         ],
     }
-
+    
 def build_storybook_step(ver_mode):
     return {
         "name": "build-storybook",
@@ -610,7 +610,8 @@ def test_backend_step():
             "wire-install",
         ],
         "commands": [
-            "go test -tags requires_buildifer -short -covermode=atomic -timeout=5m ./pkg/...",
+            # "go test -tags requires_buildifer -short -covermode=atomic -timeout=5m ./pkg/...",
+            'go test -json -benchmem -run=^$ ./pkg/services/sqlstore/permissions -bench "^(BenchmarkDashboardPermissionFilter_300_10000)$"',
         ],
     }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
The idea behind this is to run benchmarks tests on a regular basis, TBD. Release or merge to main to evaluate critical code paths for the authnz team.

Either each team would add there own or we run it separately based on some logic. Each benchmark tests would be owned by some team.

```python
def test_dashboard_permissions_backend_step():
    return {
        "name": "test-backend",
        "image": build_image,
       # "owner": "authnz", could add this as part of the step to know which one is owned by a team
        "depends_on": [
            "wire-install",
        ],
        "commands": [
            # "go test -tags requires_buildifer -short -covermode=atomic -timeout=5m ./pkg/...",
            'go test -json -benchmem -run=^$ ./pkg/services/sqlstore/permissions -bench "^(BenchmarkDashboardPermissionFilter_300_10000)$"',
        ],
    }
```

The benchmarks would be run in drone example using:
```bash
go test -json -benchmem -run=\^$ ./pkg/services/sqlstore/permissions -bench "^(BenchmarkDashboardPermissionFilter_300_10000)$"
```

This gives json output to the build pipeline that we can pick up in loki.
```
{filename="/Users/eleijonmarck/dev/grafana/loki/loki-test.log"} | json | line_format "{{.Output}}" |= "ns/op" | pattern `<bench> - - <_>`
```

<img width="1356" alt="image" src="https://user-images.githubusercontent.com/7727602/226951481-acd967d5-0833-4b6c-bb90-54f167e912ad.png">


These numbers would be queryable from Grafana UI to be displayed as part of a SLO or similiar.