### PR TITLE
Prometheus Metrics: Add missing stat_total_teams metric

### DIFF
--- a/pkg/infra/metrics/metrics.go
+++ b/pkg/infra/metrics/metrics.go
@@ -143,7 +143,7 @@ var (
 	// MStatTotalUsers is a metric total amount of users
 	MStatTotalUsers prometheus.Gauge
 
-	// MStatTotalUsers is a metric total amount of teams
+	// MStatTotalTeams is a metric total amount of teams
 	MStatTotalTeams prometheus.Gauge
 
 	// MStatActiveUsers is a metric number of active users

--- a/pkg/infra/metrics/metrics.go
+++ b/pkg/infra/metrics/metrics.go
@@ -143,6 +143,9 @@ var (
 	// MStatTotalUsers is a metric total amount of users
 	MStatTotalUsers prometheus.Gauge
 
+	// MStatTotalUsers is a metric total amount of users
+	MStatTotalTeams prometheus.Gauge
+
 	// MStatActiveUsers is a metric number of active users
 	MStatActiveUsers prometheus.Gauge
 
@@ -445,6 +448,12 @@ func init() {
 		Namespace: ExporterName,
 	})
 
+	MStatTotalTeams = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name:      "stat_total_teams",
+		Help:      "total amount of teams",
+		Namespace: ExporterName,
+	})
+
 	MStatActiveUsers = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name:      "stat_active_users",
 		Help:      "number of active users",
@@ -661,6 +670,7 @@ func initMetricVars() {
 		MStatTotalDashboards,
 		MStatTotalFolders,
 		MStatTotalUsers,
+		MStatTotalTeams,
 		MStatActiveUsers,
 		MStatTotalOrgs,
 		MStatTotalPlaylists,

--- a/pkg/infra/metrics/metrics.go
+++ b/pkg/infra/metrics/metrics.go
@@ -143,7 +143,7 @@ var (
 	// MStatTotalUsers is a metric total amount of users
 	MStatTotalUsers prometheus.Gauge
 
-	// MStatTotalUsers is a metric total amount of users
+	// MStatTotalUsers is a metric total amount of teams
 	MStatTotalTeams prometheus.Gauge
 
 	// MStatActiveUsers is a metric number of active users

--- a/pkg/infra/usagestats/statscollector/service.go
+++ b/pkg/infra/usagestats/statscollector/service.go
@@ -312,6 +312,7 @@ func (s *Service) updateTotalStats(ctx context.Context) bool {
 	metrics.MStatTotalDashboards.Set(float64(statsQuery.Result.Dashboards))
 	metrics.MStatTotalFolders.Set(float64(statsQuery.Result.Folders))
 	metrics.MStatTotalUsers.Set(float64(statsQuery.Result.Users))
+	metrics.MStatTotalTeams.Set(float64(statsQuery.Result.Teams))
 	metrics.MStatActiveUsers.Set(float64(statsQuery.Result.ActiveUsers))
 	metrics.MStatTotalPlaylists.Set(float64(statsQuery.Result.Playlists))
 	metrics.MStatTotalOrgs.Set(float64(statsQuery.Result.Orgs))


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Seems like we have a stat for counting teams in the [usage report](https://github.com/grafana/grafana/blob/eeec03b2e49245d060fb8cd8f13889054aed9d78/pkg/infra/usagestats/statscollector/service.go#L144), but we don't have the equivalent in the prometheus metrics. This PR intends to add the metric.

**Why do we need this feature?**

**Who is this feature for?**

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
- [x] There are no known compatibility issues with older supported versions of Grafana, or plugins.
- [x] It passes the [Hosted Grafana feature readiness review](https://docs.google.com/document/d/1QL9Ly8KnXzpb6ISbg49pTODRO5mhA5tkkfIZVX6pqQU/edit) for observability, scalability, performance, and security.