### PR TITLE
Alerting: Fix ambiguous handling of equals in labels when bucketing Loki state history streams

### DIFF
--- a/pkg/services/ngalert/state/historian/loki.go
+++ b/pkg/services/ngalert/state/historian/loki.go
@@ -238,7 +238,7 @@ func merge(res QueryRes, ruleUID string) (*data.Frame, error) {
 }
 
 func statesToStreams(rule history_model.RuleMeta, states []state.StateTransition, externalLabels map[string]string, logger log.Logger) []stream {
-	buckets := make(map[string][]row) // label repr -> entries
+	buckets := make(map[string][]row) // label repr (JSON) -> entries
 	for _, state := range states {
 		if !shouldRecord(state) {
 			continue
@@ -250,7 +250,12 @@ func statesToStreams(rule history_model.RuleMeta, states []state.StateTransition
 		labels[RuleUIDLabel] = fmt.Sprint(rule.UID)
 		labels[GroupLabel] = fmt.Sprint(rule.Group)
 		labels[FolderUIDLabel] = fmt.Sprint(rule.NamespaceUID)
-		repr := labels.String()
+		lblJsn, err := json.Marshal(labels)
+		if err != nil {
+			logger.Error("Failed to marshal labels to JSON", "error", err)
+			continue
+		}
+		repr := string(lblJsn)
 
 		entry := lokiEntry{
 			SchemaVersion: 1,

--- a/pkg/services/ngalert/state/historian/loki_test.go
+++ b/pkg/services/ngalert/state/historian/loki_test.go
@@ -323,6 +323,29 @@ grafana_alerting_state_history_writes_total{org="1"} 2
 		require.NoError(t, err)
 		require.Nil(t, req.lastRequest)
 	})
+
+	t.Run("succeeds with special chars in labels", func(t *testing.T) {
+		req := NewFakeRequester()
+		loki := createTestLokiBackend(req, metrics.NewHistorianMetrics(prometheus.NewRegistry()))
+		rule := createTestRule()
+		states := singleFromNormal(&state.State{
+			State: eval.Alerting,
+			Labels: data.Labels{
+				"dots":   "contains.dot",
+				"equals": "contains=equals",
+				"emoji":  "contains🤔emoji",
+			},
+		})
+
+		err := <-loki.Record(context.Background(), rule, states)
+
+		require.NoError(t, err)
+		require.Contains(t, "/loki/api/v1/push", req.lastRequest.URL.Path)
+		sent := string(readBody(t, req.lastRequest))
+		require.Contains(t, sent, "contains.dot")
+		require.Contains(t, sent, "contains=equals")
+		require.Contains(t, sent, "contains🤔emoji")
+	})
 }
 
 func createTestLokiBackend(req client.Requester, met *metrics.Historian) *RemoteLokiBackend {
@@ -377,4 +400,12 @@ func badResponse() *http.Response {
 		ContentLength: int64(0),
 		Header:        make(http.Header, 0),
 	}
+}
+
+func readBody(t *testing.T, req *http.Request) []byte {
+	t.Helper()
+
+	val, err := io.ReadAll(req.Body)
+	require.NoError(t, err)
+	return val
 }


### PR DESCRIPTION
## Manual backport of https://github.com/grafana/grafana/pull/65013

**What is this feature?**

`grafana-plugin-sdk`'s `data.Labels` type is the canonical dataframe type for handling labels.

Its `LabelsFromString()` and `String()` methods break on labels containing `=`. The format it uses is ambiguous.

We also can't use prometheus Labels format, its repr is also ambiguous around equals. Grafana's labels are a superset of Prometheus labels.

With this PR, we use a stable representation.

**Why do we need this feature?**

Allow equals to be used without issues.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/65012

**Special notes for your reviewer**:

