### PR TITLE
Alerting: Switch to snappy-compressed-protobuf for outgoing push requests to Loki

### DIFF
--- a/pkg/services/ngalert/state/historian/encode.go
+++ b/pkg/services/ngalert/state/historian/encode.go
@@ -1,0 +1,106 @@
+package historian
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/golang/snappy"
+	"github.com/grafana/grafana/pkg/components/loki/logproto"
+	"github.com/prometheus/common/model"
+	"golang.org/x/exp/slices"
+)
+
+type JsonEncoder struct{}
+
+func (e JsonEncoder) encode(s []stream) ([]byte, error) {
+	body := struct {
+		Streams []stream `json:"streams"`
+	}{Streams: s}
+	enc, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize Loki payload: %w", err)
+	}
+	return enc, nil
+}
+
+func (e JsonEncoder) headers() map[string]string {
+	return map[string]string{
+		"Content-Type": "application/json",
+	}
+}
+
+type SnappyProtoEncoder struct{}
+
+func (e SnappyProtoEncoder) encode(s []stream) ([]byte, error) {
+	body := logproto.PushRequest{
+		Streams: make([]logproto.Stream, 0, len(s)),
+	}
+
+	for _, str := range s {
+		entries := make([]logproto.Entry, 0, len(str.Values))
+		for _, sample := range str.Values {
+			entries = append(entries, logproto.Entry{
+				Timestamp: sample.T,
+				Line:      sample.V,
+			})
+		}
+		body.Streams = append(body.Streams, logproto.Stream{
+			Labels:  labelsMapToString(str.Stream, ""),
+			Entries: entries,
+			// Hash seems to be mainly used for query responses. Promtail does not seem to calculate this field on push.
+		})
+	}
+
+	buf, err := proto.Marshal(&body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize Loki payload to proto: %w", err)
+	}
+	buf = snappy.Encode(nil, buf)
+	return buf, nil
+}
+
+func (e SnappyProtoEncoder) headers() map[string]string {
+	return map[string]string{
+		"Content-Type":     "application/x-protobuf",
+		"Content-Encoding": "snappy",
+	}
+}
+
+// Copied from promtail.
+// Modified slightly to work in terms of plain map[string]string to avoid some unnecessary copies and type casts.
+// TODO: pkg/components/loki/lokihttp/batch.go contains an older (loki 2.7.4 released) version of this.
+// TODO: Consider replacing that one, with this one.
+func labelsMapToString(ls map[string]string, without model.LabelName) string {
+	var b strings.Builder
+	totalSize := 2
+	lstrs := make([]string, 0, len(ls))
+
+	for l, v := range ls {
+		if l == string(without) {
+			continue
+		}
+
+		lstrs = append(lstrs, l)
+		// guess size increase: 2 for `, ` between labels and 3 for the `=` and quotes around label value
+		totalSize += len(l) + 2 + len(v) + 3
+	}
+
+	b.Grow(totalSize)
+	b.WriteByte('{')
+	slices.Sort(lstrs)
+	for i, l := range lstrs {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+
+		b.WriteString(l)
+		b.WriteString(`=`)
+		b.WriteString(strconv.Quote(ls[l]))
+	}
+	b.WriteByte('}')
+
+	return b.String()
+}

--- a/pkg/services/ngalert/state/historian/encode.go
+++ b/pkg/services/ngalert/state/historian/encode.go
@@ -43,8 +43,8 @@ func (e SnappyProtoEncoder) encode(s []stream) ([]byte, error) {
 		entries := make([]logproto.Entry, 0, len(str.Values))
 		for _, sample := range str.Values {
 			entries = append(entries, logproto.Entry{
-				Timestamp: sample.T,
-				Line:      sample.V,
+				Timestamp: sample.At,
+				Line:      sample.Val,
 			})
 		}
 		body.Streams = append(body.Streams, logproto.Stream{

--- a/pkg/services/ngalert/state/historian/loki_http.go
+++ b/pkg/services/ngalert/state/historian/loki_http.go
@@ -24,6 +24,14 @@ func NewRequester() client.Requester {
 	}
 }
 
+// encoder serializes log streams to some byte format.
+type encoder interface {
+	// encode serializes a set of log streams to bytes.
+	encode(s []stream) ([]byte, error)
+	// headers returns a set of HTTP-style headers that describes the encoding scheme used.
+	headers() map[string]string
+}
+
 type LokiConfig struct {
 	ReadPathURL       *url.URL
 	WritePathURL      *url.URL
@@ -31,6 +39,7 @@ type LokiConfig struct {
 	BasicAuthPassword string
 	TenantID          string
 	ExternalLabels    map[string]string
+	Encoder           encoder
 }
 
 func NewLokiConfig(cfg setting.UnifiedAlertingStateHistorySettings) (LokiConfig, error) {
@@ -64,11 +73,14 @@ func NewLokiConfig(cfg setting.UnifiedAlertingStateHistorySettings) (LokiConfig,
 		BasicAuthUser:     cfg.LokiBasicAuthUsername,
 		BasicAuthPassword: cfg.LokiBasicAuthPassword,
 		TenantID:          cfg.LokiTenantID,
+		// Snappy-compressed protobuf is the default, same goes for Promtail.
+		Encoder: SnappyProtoEncoder{},
 	}, nil
 }
 
 type httpLokiClient struct {
 	client  client.Requester
+	encoder encoder
 	cfg     LokiConfig
 	metrics *metrics.Historian
 	log     log.Logger
@@ -100,6 +112,7 @@ func newLokiClient(cfg LokiConfig, req client.Requester, metrics *metrics.Histor
 	tc := client.NewTimedClient(req, metrics.WriteDuration)
 	return &httpLokiClient{
 		client:  tc,
+		encoder: cfg.Encoder,
 		cfg:     cfg,
 		metrics: metrics,
 		log:     logger.New("protocol", "http"),
@@ -151,12 +164,9 @@ func (r *row) MarshalJSON() ([]byte, error) {
 }
 
 func (c *httpLokiClient) push(ctx context.Context, s []stream) error {
-	body := struct {
-		Streams []stream `json:"streams"`
-	}{Streams: s}
-	enc, err := json.Marshal(body)
+	enc, err := c.encoder.encode(s)
 	if err != nil {
-		return fmt.Errorf("failed to serialize Loki payload: %w", err)
+		return err
 	}
 
 	uri := c.cfg.WritePathURL.JoinPath("/loki/api/v1/push")
@@ -166,7 +176,9 @@ func (c *httpLokiClient) push(ctx context.Context, s []stream) error {
 	}
 
 	c.setAuthAndTenantHeaders(req)
-	req.Header.Add("content-type", "application/json")
+	for k, v := range c.encoder.headers() {
+		req.Header.Add(k, v)
+	}
 
 	c.metrics.BytesWritten.Add(float64(len(enc)))
 	req = req.WithContext(ctx)

--- a/pkg/services/ngalert/state/historian/loki_http_test.go
+++ b/pkg/services/ngalert/state/historian/loki_http_test.go
@@ -85,6 +85,7 @@ func TestLokiHTTPClient_Manual(t *testing.T) {
 		client := newLokiClient(LokiConfig{
 			ReadPathURL:  url,
 			WritePathURL: url,
+			Encoder:      JsonEncoder{},
 		}, NewRequester(), metrics.NewHistorianMetrics(prometheus.NewRegistry()), log.NewNopLogger())
 
 		// Unauthorized request should fail against Grafana Cloud.
@@ -112,6 +113,7 @@ func TestLokiHTTPClient_Manual(t *testing.T) {
 			WritePathURL:      url,
 			BasicAuthUser:     "<your_username>",
 			BasicAuthPassword: "<your_password>",
+			Encoder:           JsonEncoder{},
 		}, NewRequester(), metrics.NewHistorianMetrics(prometheus.NewRegistry()), log.NewNopLogger())
 
 		// When running on prem, you might need to set the tenant id,

--- a/pkg/services/ngalert/state/historian/loki_test.go
+++ b/pkg/services/ngalert/state/historian/loki_test.go
@@ -353,6 +353,7 @@ func createTestLokiBackend(req client.Requester, met *metrics.Historian) *Remote
 	cfg := LokiConfig{
 		WritePathURL: url,
 		ReadPathURL:  url,
+		Encoder:      JsonEncoder{},
 	}
 	return NewRemoteLokiBackend(cfg, req, met)
 }


### PR DESCRIPTION
## Manual backport of https://github.com/grafana/grafana/pull/65077

**What is this feature?**

Loki's HTTP API accepts [exactly two formats](https://grafana.com/docs/loki/latest/api/#push-log-entries-to-loki):
- `snappy`-compressed-`protobuf`
- uncompressed JSON.

Promtail, the canonical Loki client, uses snappy-compressed-protobuf **only**. This is not configurable.
Many "loki-like" tools also seem to **only** accept snappy-compressed-protobuf.

This PR does the same - the default becomes snappy-compressed-protobuf. Right now this is configurable at the code level, when using the client as a library, but not at the grafana configuration level. We can evaluate adding this config option to grafana .ini in the future, but there's precedent to not do so in Promtail.

**Why do we need this feature?**

Consistency with Promtail. Interoperability with other Loki-like tools. Closer to the main code path in Loki.

Also, we send fewer bytes over the network.

**Who is this feature for?**

Operators and users who want to run state history against some Loki-like tools that aren't necessarily Loki.

**Which issue(s) does this PR fix?**:

n/a

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
- [X] There are no known compatibility issues with older supported versions of Grafana, or plugins.
- [X] It passes the [Hosted Grafana feature readiness review](https://docs.google.com/document/d/1QL9Ly8KnXzpb6ISbg49pTODRO5mhA5tkkfIZVX6pqQU/edit) for observability, scalability, performance, and security.