### PR TITLE
Alerting: Fix DashboardUID typo in json provisioning api

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -133,6 +133,7 @@
 /pkg/services/playlist/ @grafana/grafana-app-platform-squad
 /pkg/services/preference/ @grafana/grafana-backend-group
 /pkg/services/provisioning/ @grafana/grafana-search-and-storage
+/pkg/services/provisioning/alerting/ @grafana/alerting-backend
 /pkg/services/query/ @grafana/grafana-app-platform-squad
 /pkg/services/queryhistory/ @grafana/explore-squad
 /pkg/services/quota/ @grafana/grafana-search-and-storage

--- a/pkg/services/provisioning/alerting/config_reader_test.go
+++ b/pkg/services/provisioning/alerting/config_reader_test.go
@@ -16,6 +16,7 @@ const (
 	testFileSupportedFiletypes          = "./testdata/common/supported-filetypes"
 	testFileCorrectProperties           = "./testdata/alert_rules/correct-properties"
 	testFileCorrectPropertiesWithOrg    = "./testdata/alert_rules/correct-properties-with-org"
+	testFileDasboardTypoSupport         = "./testdata/alert_rules/dasboard-typo-support"
 	testFileMultipleRules               = "./testdata/alert_rules/multiple-rules"
 	testFileMultipleFiles               = "./testdata/alert_rules/multiple-files"
 	testFileCorrectProperties_cp        = "./testdata/contact_points/correct-properties"
@@ -158,5 +159,33 @@ func TestConfigReader(t *testing.T) {
 		file, err := configReader.readConfig(ctx, testFileMultipleTs)
 		require.NoError(t, err)
 		require.Len(t, file[0].Templates, 2)
+	})
+	t.Run("a rule file with dasboard typo", func(t *testing.T) {
+		ruleFiles, err := configReader.readConfig(ctx, testFileDasboardTypoSupport)
+		require.NoError(t, err)
+		t.Run("only dasboard present", func(t *testing.T) {
+			for _, ruleFile := range ruleFiles {
+				group := ruleFile.Groups[0]
+				t.Run(group.Title, func(t *testing.T) {
+					require.Equal(t, "dasboardUid", *group.Rules[0].DashboardUID)
+				})
+			}
+		})
+		t.Run("only dashboard present", func(t *testing.T) {
+			for _, ruleFile := range ruleFiles {
+				group := ruleFile.Groups[0]
+				t.Run(group.Title, func(t *testing.T) {
+					require.Equal(t, "dashboardUid", *group.Rules[1].DashboardUID)
+				})
+			}
+		})
+		t.Run("both dasboard and dashboard present", func(t *testing.T) {
+			for _, ruleFile := range ruleFiles {
+				group := ruleFile.Groups[0]
+				t.Run(group.Title, func(t *testing.T) {
+					require.Equal(t, "dashboardUid", *group.Rules[2].DashboardUID)
+				})
+			}
+		})
 	})
 }

--- a/pkg/services/provisioning/alerting/rules_types.go
+++ b/pkg/services/provisioning/alerting/rules_types.go
@@ -79,7 +79,7 @@ type AlertRuleV1 struct {
 	Record               *RecordV1               `json:"record" yaml:"record"`
 }
 
-// UnmarshalJSON supports the grandfathered typo dashboardUid. This should be removed in V2.
+// UnmarshalJSON supports the grandfathered typo dasboardUid. TODO: This should be removed in V2.
 func (rule *AlertRuleV1) UnmarshalJSON(b []byte) error {
 	var t struct {
 		AlertRuleV1 `json:",inline" yaml:",inline"`
@@ -97,8 +97,8 @@ func (rule *AlertRuleV1) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// UnmarshalYAML supports the grandfathered typo dashboardUid. Even though the typo only existed in the json tag, we need
-// support in YAML as well since we use yaml.UnmarshalYAML when parsing. This should be removed in V2.
+// UnmarshalYAML supports the grandfathered typo dasboardUid. Even though the typo only existed in the json tag, we need
+// support in YAML as well since we use yaml.UnmarshalYAML when parsing. TODO: This should be removed in V2.
 func (rule *AlertRuleV1) UnmarshalYAML(value *yaml.Node) error {
 	type plain AlertRuleV1
 	var t struct {

--- a/pkg/services/provisioning/alerting/rules_types.go
+++ b/pkg/services/provisioning/alerting/rules_types.go
@@ -90,7 +90,7 @@ func (rule *AlertRuleV1) UnmarshalJSON(b []byte) error {
 	}
 	*rule = t.AlertRuleV1
 
-	if rule.DashboardUID.Value() == "" && t.DasboardUID.Value() != "" {
+	if rule.DashboardUID.Value() == "" {
 		rule.DashboardUID = t.DasboardUID
 	}
 
@@ -111,7 +111,7 @@ func (rule *AlertRuleV1) UnmarshalYAML(value *yaml.Node) error {
 	}
 	*rule = AlertRuleV1(t.plain)
 
-	if rule.DashboardUID.Value() == "" && t.DasboardUID.Value() != "" {
+	if rule.DashboardUID.Value() == "" {
 		rule.DashboardUID = t.DasboardUID
 	}
 

--- a/pkg/services/provisioning/alerting/rules_types_test.go
+++ b/pkg/services/provisioning/alerting/rules_types_test.go
@@ -1,7 +1,6 @@
 package alerting
 
 import (
-	"encoding/json"
 	"testing"
 	"time"
 
@@ -293,54 +292,6 @@ func TestNotificationsSettingsV1MapToModel(t *testing.T) {
 			require.Equal(t, tc.expected, got)
 		})
 	}
-}
-
-// This can be removed when the dasboardUid typo support is removed. TODO: This should be removed in V2.
-func TestRulesDasboardUidTypo(t *testing.T) {
-	t.Run("a rule with dasboardUid json should json unmarshal correctly", func(t *testing.T) {
-		ruleJson := `{"dasboardUid":"test"}`
-		var rule *AlertRuleV1
-		err := json.Unmarshal([]byte(ruleJson), &rule)
-		require.NoError(t, err)
-		require.Equal(t, "test", rule.DashboardUID.Value())
-	})
-	t.Run("a rule with dashboardUid json should json unmarshal correctly", func(t *testing.T) {
-		ruleJson := `{"dashboardUid":"test"}`
-		var rule *AlertRuleV1
-		err := json.Unmarshal([]byte(ruleJson), &rule)
-		require.NoError(t, err)
-		require.Equal(t, "test", rule.DashboardUID.Value())
-	})
-	t.Run("a rule with both dasboardUid and dashboardUid should json unmarshal using dashboardUid", func(t *testing.T) {
-		ruleJson := `{"dasboardUid":"test", "dashboardUid":"test2"}`
-		var rule *AlertRuleV1
-		err := json.Unmarshal([]byte(ruleJson), &rule)
-		require.NoError(t, err)
-		require.Equal(t, "test2", rule.DashboardUID.Value())
-	})
-
-	// Even though the typo only existed in the json tag, we need support in YAML as well since we use yaml.UnmarshalYAML when parsing
-	t.Run("a rule with dasboardUid json should yaml unmarshal correctly", func(t *testing.T) {
-		ruleJson := `{"dasboardUid":"test"}`
-		var rule *AlertRuleV1
-		err := yaml.Unmarshal([]byte(ruleJson), &rule)
-		require.NoError(t, err)
-		require.Equal(t, "test", rule.DashboardUID.Value())
-	})
-	t.Run("a rule with dashboardUid json should yaml unmarshal correctly", func(t *testing.T) {
-		ruleJson := `{"dashboardUid":"test"}`
-		var rule *AlertRuleV1
-		err := yaml.Unmarshal([]byte(ruleJson), &rule)
-		require.NoError(t, err)
-		require.Equal(t, "test", rule.DashboardUID.Value())
-	})
-	t.Run("a rule with both dasboardUid and dashboardUid should yaml unmarshal using dashboardUid", func(t *testing.T) {
-		ruleJson := `{"dasboardUid":"test", "dashboardUid":"test2"}`
-		var rule *AlertRuleV1
-		err := yaml.Unmarshal([]byte(ruleJson), &rule)
-		require.NoError(t, err)
-		require.Equal(t, "test2", rule.DashboardUID.Value())
-	})
 }
 
 func validRuleGroupV1(t *testing.T) AlertRuleGroupV1 {

--- a/pkg/services/provisioning/alerting/rules_types_test.go
+++ b/pkg/services/provisioning/alerting/rules_types_test.go
@@ -295,7 +295,7 @@ func TestNotificationsSettingsV1MapToModel(t *testing.T) {
 	}
 }
 
-// This can be removed when the dasboardUid typo support is removed.
+// This can be removed when the dasboardUid typo support is removed. TODO: This should be removed in V2.
 func TestRulesDasboardUidTypo(t *testing.T) {
 	t.Run("a rule with dasboardUid json should json unmarshal correctly", func(t *testing.T) {
 		ruleJson := `{"dasboardUid":"test"}`

--- a/pkg/services/provisioning/alerting/rules_types_test.go
+++ b/pkg/services/provisioning/alerting/rules_types_test.go
@@ -1,6 +1,7 @@
 package alerting
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -292,6 +293,54 @@ func TestNotificationsSettingsV1MapToModel(t *testing.T) {
 			require.Equal(t, tc.expected, got)
 		})
 	}
+}
+
+// This can be removed when the dasboardUid typo support is removed.
+func TestRulesDasboardUidTypo(t *testing.T) {
+	t.Run("a rule with dasboardUid json should json unmarshal correctly", func(t *testing.T) {
+		ruleJson := `{"dasboardUid":"test"}`
+		var rule *AlertRuleV1
+		err := json.Unmarshal([]byte(ruleJson), &rule)
+		require.NoError(t, err)
+		require.Equal(t, "test", rule.DashboardUID.Value())
+	})
+	t.Run("a rule with dashboardUid json should json unmarshal correctly", func(t *testing.T) {
+		ruleJson := `{"dashboardUid":"test"}`
+		var rule *AlertRuleV1
+		err := json.Unmarshal([]byte(ruleJson), &rule)
+		require.NoError(t, err)
+		require.Equal(t, "test", rule.DashboardUID.Value())
+	})
+	t.Run("a rule with both dasboardUid and dashboardUid should json unmarshal using dashboardUid", func(t *testing.T) {
+		ruleJson := `{"dasboardUid":"test", "dashboardUid":"test2"}`
+		var rule *AlertRuleV1
+		err := json.Unmarshal([]byte(ruleJson), &rule)
+		require.NoError(t, err)
+		require.Equal(t, "test2", rule.DashboardUID.Value())
+	})
+
+	// Even though the typo only existed in the json tag, we need support in YAML as well since we use yaml.UnmarshalYAML when parsing
+	t.Run("a rule with dasboardUid json should yaml unmarshal correctly", func(t *testing.T) {
+		ruleJson := `{"dasboardUid":"test"}`
+		var rule *AlertRuleV1
+		err := yaml.Unmarshal([]byte(ruleJson), &rule)
+		require.NoError(t, err)
+		require.Equal(t, "test", rule.DashboardUID.Value())
+	})
+	t.Run("a rule with dashboardUid json should yaml unmarshal correctly", func(t *testing.T) {
+		ruleJson := `{"dashboardUid":"test"}`
+		var rule *AlertRuleV1
+		err := yaml.Unmarshal([]byte(ruleJson), &rule)
+		require.NoError(t, err)
+		require.Equal(t, "test", rule.DashboardUID.Value())
+	})
+	t.Run("a rule with both dasboardUid and dashboardUid should yaml unmarshal using dashboardUid", func(t *testing.T) {
+		ruleJson := `{"dasboardUid":"test", "dashboardUid":"test2"}`
+		var rule *AlertRuleV1
+		err := yaml.Unmarshal([]byte(ruleJson), &rule)
+		require.NoError(t, err)
+		require.Equal(t, "test2", rule.DashboardUID.Value())
+	})
 }
 
 func validRuleGroupV1(t *testing.T) AlertRuleGroupV1 {

--- a/pkg/services/provisioning/alerting/testdata/alert_rules/dasboard-typo-support/rules.json
+++ b/pkg/services/provisioning/alerting/testdata/alert_rules/dasboard-typo-support/rules.json
@@ -2,7 +2,7 @@
   "apiVersion": 1,
   "groups": [
     {
-      "name": "my_group",
+      "name": "json_group",
       "folder": "my_folder",
       "interval": "10s",
       "rules": [

--- a/pkg/services/provisioning/alerting/testdata/alert_rules/dasboard-typo-support/rules.json
+++ b/pkg/services/provisioning/alerting/testdata/alert_rules/dasboard-typo-support/rules.json
@@ -1,0 +1,49 @@
+{
+  "apiVersion": 1,
+  "groups": [
+    {
+      "name": "my_group",
+      "folder": "my_folder",
+      "interval": "10s",
+      "rules": [
+        {
+          "title": "with_typo",
+          "uid": "with_typo",
+          "dasboardUid": "dasboardUid",
+          "condition": "A",
+          "for": "1m",
+          "data": [
+            {
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "title": "without_typo",
+          "uid": "without_typo",
+          "dashboardUid": "dashboardUid",
+          "condition": "A",
+          "for": "1m",
+          "data": [
+            {
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "title": "with_both",
+          "uid": "with_both",
+          "dashboardUid": "dashboardUid",
+          "dasboardUid": "dasboardUid",
+          "condition": "A",
+          "for": "1m",
+          "data": [
+            {
+              "refId": "A"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/services/provisioning/alerting/testdata/alert_rules/dasboard-typo-support/rules.yml
+++ b/pkg/services/provisioning/alerting/testdata/alert_rules/dasboard-typo-support/rules.yml
@@ -1,0 +1,28 @@
+apiVersion: 1
+groups:
+  - name: yaml_group
+    folder: my_folder
+    interval: 10s
+    rules:
+    - title: with_typo
+      uid: with_typo
+      dasboardUid: dasboardUid
+      condition: A
+      for: 1m
+      data:
+      - refId: A
+    - title: without_typo
+      uid: without_typo
+      dashboardUid: dashboardUid
+      condition: A
+      for: 1m
+      data:
+      - refId: A
+    - title: with_both
+      uid: with_both
+      dashboardUid: dashboardUid
+      dasboardUid: dasboardUid
+      condition: A
+      for: 1m
+      data:
+      - refId: A


### PR DESCRIPTION
The json tag for DashboardUID was incorrectly set to dasboardUid in the provisioning api. This change fixes the typo while keeping backwards compatibility.

Also adds alerting-squad as CODEOWNER for services/provisioning/alerting.