### PR TITLE
Transformers: Row number to field transform (alternative)

### DIFF
--- a/packages/grafana-data/src/transformations/transformers/rowNumberToField.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/rowNumberToField.test.ts
@@ -29,7 +29,7 @@ describe('RowNumberToField Transformer', () => {
       expect(organized.fields).toEqual([
         {
           config: { min: 0, max: 3 },
-          name: 'row_number',
+          name: 'Row',
           type: FieldType.number,
           values: new IndexVector(4),
         },
@@ -48,7 +48,7 @@ describe('RowNumberToField Transformer', () => {
       name: 'A',
       fields: [
         {
-          name: 'row_number',
+          name: 'Row',
           type: FieldType.number,
           values: [0, 1, 2, 3],
         },
@@ -66,7 +66,7 @@ describe('RowNumberToField Transformer', () => {
       expect(organized.fields).toEqual([
         {
           config: { min: 0, max: 3 },
-          name: 'row_number',
+          name: 'Row',
           type: FieldType.number,
           values: new IndexVector(4),
         },
@@ -85,9 +85,9 @@ describe('RowNumberToField Transformer', () => {
       name: 'A',
       fields: [
         {
-          name: 'row_number',
+          name: 'Row',
           type: FieldType.number,
-          values: [0],
+          values: [0], // NOT the index field
         },
         {
           name: 'temperature',
@@ -103,9 +103,15 @@ describe('RowNumberToField Transformer', () => {
       expect(organized.fields).toEqual([
         {
           config: { min: 0, max: 3 },
-          name: 'row_number',
+          name: 'Row',
           type: FieldType.number,
           values: new IndexVector(4),
+        },
+        {
+          config: {},
+          name: 'Row',
+          type: FieldType.number,
+          values: new ArrayVector([0, undefined, undefined, undefined]),
         },
         {
           config: {},

--- a/packages/grafana-data/src/transformations/transformers/rowNumberToField.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/rowNumberToField.test.ts
@@ -1,11 +1,15 @@
 import { toDataFrame } from '../../dataframe';
-import { DataTransformerConfig, FieldType } from '../../types';
+import { DataFrame, DataTransformerConfig, FieldType } from '../../types';
 import { mockTransformationsRegistry } from '../../utils/tests/mockTransformationsRegistry';
 import { ArrayVector, IndexVector } from '../../vector';
 import { transformDataFrame } from '../transformDataFrame';
 
 import { DataTransformerID } from './ids';
-import { rowNumberToFieldTransformer, RowNumberToFieldTransformerOptions } from './rowNumberToField';
+import {
+  getFrameWithRowIndex,
+  rowNumberToFieldTransformer,
+  RowNumberToFieldTransformerOptions,
+} from './rowNumberToField';
 
 describe('RowNumberToField Transformer', () => {
   beforeAll(() => {
@@ -44,26 +48,9 @@ describe('RowNumberToField Transformer', () => {
   });
 
   it('handles repeated transformations correctly', async () => {
-    const inputs = toDataFrame({
+    const frame: DataFrame = {
       name: 'A',
       fields: [
-        {
-          name: 'Row',
-          type: FieldType.number,
-          values: [0, 1, 2, 3],
-        },
-        {
-          name: 'temperature',
-          type: FieldType.number,
-          values: [10.3, 10.4, 10.5, 10.6],
-        },
-      ],
-    });
-
-    await expect(transformDataFrame([cfg], [inputs])).toEmitValuesWith((received) => {
-      const data = received[0];
-      const organized = data[0];
-      expect(organized.fields).toEqual([
         {
           config: { min: 0, max: 3 },
           name: 'Row',
@@ -76,7 +63,13 @@ describe('RowNumberToField Transformer', () => {
           type: FieldType.number,
           values: new ArrayVector([10.3, 10.4, 10.5, 10.6]),
         },
-      ]);
+      ],
+      length: 4,
+    };
+
+    await expect(transformDataFrame([cfg], [frame])).toEmitValuesWith((received) => {
+      const data = received[0];
+      expect(data[0]).toBe(frame); // noop, pass though
     });
   });
 

--- a/packages/grafana-data/src/transformations/transformers/rowNumberToField.ts
+++ b/packages/grafana-data/src/transformations/transformers/rowNumberToField.ts
@@ -30,7 +30,7 @@ export const rowNumberToFieldTransformer: SynchronousDataTransformerInfo<RowNumb
 // This will make sure the first field contains the row value
 function getFrameWithRowIndex(frame: DataFrame): DataFrame {
   const first = frame.fields[0];
-  if (first.values instanceof IndexVector) {
+  if (first?.values instanceof IndexVector) {
     return frame;
   }
   return {


### PR DESCRIPTION
This is an alternate approach to https://github.com/grafana/grafana/pull/64822 that checks the first field rather than depending on the field name.

In general i am skeptical of trying to magically detect and avoid running the xform multiple times (if it is configured multiple times... should it run multiple times?)