### PR TITLE
Explore: Make `DataSourcePicker` visible on small screens

### DIFF
--- a/packages/grafana-ui/src/components/PageLayout/PageToolbar.test.tsx
+++ b/packages/grafana-ui/src/components/PageLayout/PageToolbar.test.tsx
@@ -3,11 +3,44 @@ import React from 'react';
 
 import { PageToolbar } from '..';
 
+const resizeWindow = (x: number, y: number) => {
+  global.innerWidth = x;
+  global.innerHeight = y;
+  global.dispatchEvent(new Event('resize'));
+};
+
 describe('PageToolbar', () => {
   it('renders left items when title is not set', () => {
     const leftItemContent = 'Left Item!';
     render(<PageToolbar leftItems={[<div key="left-item">{leftItemContent}</div>]} />);
 
     expect(screen.getByText(leftItemContent)).toBeInTheDocument();
+  });
+
+  describe('On small screens', () => {
+    const windowWidth = global.innerWidth,
+      windowHeight = global.innerHeight;
+
+    beforeAll(() => {
+      resizeWindow(500, 500);
+    });
+
+    afterAll(() => {
+      resizeWindow(windowWidth, windowHeight);
+    });
+
+    it('left items are not visible', () => {
+      const leftItemContent = 'Left Item!';
+      render(<PageToolbar leftItems={[<div key="left-item">{leftItemContent}</div>]} />);
+
+      expect(screen.getByText(leftItemContent)).not.toBeVisible();
+    });
+
+    it('left items are visible when forceShowLeftItems is true', () => {
+      const leftItemContent = 'Left Item!';
+      render(<PageToolbar forceShowLeftItems leftItems={[<div key="left-item">{leftItemContent}</div>]} />);
+
+      expect(screen.getByText(leftItemContent)).toBeVisible();
+    });
   });
 });

--- a/packages/grafana-ui/src/components/PageLayout/PageToolbar.tsx
+++ b/packages/grafana-ui/src/components/PageLayout/PageToolbar.tsx
@@ -1,5 +1,5 @@
 import { css, cx } from '@emotion/css';
-import React, { ReactNode, useCallback } from 'react';
+import React, { ReactNode } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
@@ -25,7 +25,11 @@ export interface Props {
   isFullscreen?: boolean;
   'aria-label'?: string;
   buttonOverflowAlignment?: 'left' | 'right';
-  showLeftItemsOnSmallScreen?: boolean;
+  /**
+   * Forces left items to be visible on small screens.
+   * By default left items are hidden on small screens.
+   */
+  forceShowLeftItems?: boolean;
 }
 
 /** @alpha */
@@ -45,11 +49,9 @@ export const PageToolbar = React.memo(
     /** main nav-container aria-label **/
     'aria-label': ariaLabel,
     buttonOverflowAlignment = 'right',
-    showLeftItemsOnSmallScreen = false,
+    forceShowLeftItems = false,
   }: Props) => {
-    const styles = useStyles2(
-      useCallback((theme) => getStyles(theme, showLeftItemsOnSmallScreen), [showLeftItemsOnSmallScreen])
-    );
+    const styles = useStyles2(getStyles);
 
     /**
      * .page-toolbar css class is used for some legacy css view modes (TV/Kiosk) and
@@ -131,7 +133,10 @@ export const PageToolbar = React.memo(
                 )}
 
                 {leftItems?.map((child, index) => (
-                  <div className={styles.leftActionItem} key={index}>
+                  <div
+                    className={cx(styles.leftActionItem, { [styles.forceShowLeftActionItems]: forceShowLeftItems })}
+                    key={index}
+                  >
                     {child}
                   </div>
                 ))}
@@ -149,16 +154,10 @@ export const PageToolbar = React.memo(
 
 PageToolbar.displayName = 'PageToolbar';
 
-const getStyles = (theme: GrafanaTheme2, showLeftItemsOnSmallScreen: boolean) => {
+const getStyles = (theme: GrafanaTheme2) => {
   const { spacing, typography } = theme;
 
   const focusStyle = getFocusStyles(theme);
-
-  const showLeftItemsStyles = css`
-    align-items: center;
-    display: flex;
-    padding-right: ${spacing(0.5)};
-  `;
 
   return {
     pre: css`
@@ -244,13 +243,16 @@ const getStyles = (theme: GrafanaTheme2, showLeftItemsOnSmallScreen: boolean) =>
         flex: 1;
       }
     `,
-    leftActionItem: showLeftItemsOnSmallScreen
-      ? showLeftItemsStyles
-      : css`
-          display: 'none';
-          ${theme.breakpoints.up('md')} {
-            ${showLeftItemsStyles}
-          }
-        `,
+    leftActionItem: css`
+      display: none;
+      align-items: center;
+      padding-right: ${spacing(0.5)};
+      ${theme.breakpoints.up('md')} {
+        display: flex;
+      }
+    `,
+    forceShowLeftActionItems: css`
+      display: flex;
+    `,
   };
 };

--- a/packages/grafana-ui/src/components/PageLayout/PageToolbar.tsx
+++ b/packages/grafana-ui/src/components/PageLayout/PageToolbar.tsx
@@ -1,5 +1,5 @@
 import { css, cx } from '@emotion/css';
-import React, { ReactNode } from 'react';
+import React, { ReactNode, useCallback } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
@@ -25,6 +25,7 @@ export interface Props {
   isFullscreen?: boolean;
   'aria-label'?: string;
   buttonOverflowAlignment?: 'left' | 'right';
+  showLeftItemsOnSmallScreen?: boolean;
 }
 
 /** @alpha */
@@ -44,8 +45,11 @@ export const PageToolbar = React.memo(
     /** main nav-container aria-label **/
     'aria-label': ariaLabel,
     buttonOverflowAlignment = 'right',
+    showLeftItemsOnSmallScreen = false,
   }: Props) => {
-    const styles = useStyles2(getStyles);
+    const styles = useStyles2(
+      useCallback((theme) => getStyles(theme, showLeftItemsOnSmallScreen), [showLeftItemsOnSmallScreen])
+    );
 
     /**
      * .page-toolbar css class is used for some legacy css view modes (TV/Kiosk) and
@@ -145,10 +149,16 @@ export const PageToolbar = React.memo(
 
 PageToolbar.displayName = 'PageToolbar';
 
-const getStyles = (theme: GrafanaTheme2) => {
+const getStyles = (theme: GrafanaTheme2, showLeftItemsOnSmallScreen: boolean) => {
   const { spacing, typography } = theme;
 
   const focusStyle = getFocusStyles(theme);
+
+  const showLeftItemsStyles = css`
+    align-items: center;
+    display: flex;
+    padding-right: ${spacing(0.5)};
+  `;
 
   return {
     pre: css`
@@ -234,13 +244,13 @@ const getStyles = (theme: GrafanaTheme2) => {
         flex: 1;
       }
     `,
-    leftActionItem: css`
-      display: none;
-      ${theme.breakpoints.up('md')} {
-        align-items: center;
-        display: flex;
-        padding-right: ${spacing(0.5)};
-      }
-    `,
+    leftActionItem: showLeftItemsOnSmallScreen
+      ? showLeftItemsStyles
+      : css`
+          display: 'none';
+          ${theme.breakpoints.up('md')} {
+            ${showLeftItemsStyles}
+          }
+        `,
   };
 };

--- a/packages/grafana-ui/src/components/PageLayout/PageToolbar.tsx
+++ b/packages/grafana-ui/src/components/PageLayout/PageToolbar.tsx
@@ -50,7 +50,7 @@ export const PageToolbar = React.memo(
     /**
      * .page-toolbar css class is used for some legacy css view modes (TV/Kiosk) and
      * media queries for mobile view when toolbar needs left padding to make room
-     * for mobile menu icon. This logic hopefylly can be changed when we move to a full react
+     * for mobile menu icon. This logic hopefully can be changed when we move to a full react
      * app and change how the app side menu & mobile menu is rendered.
      */
     const mainStyle = cx(

--- a/public/app/features/explore/Explore.test.tsx
+++ b/public/app/features/explore/Explore.test.tsx
@@ -11,6 +11,12 @@ import { Explore, Props } from './Explore';
 import { scanStopAction } from './state/query';
 import { createEmptyQueryResponse } from './state/utils';
 
+const resizeWindow = (x: number, y: number) => {
+  window.innerWidth = x;
+  window.innerHeight = y;
+  window.dispatchEvent(new Event('resize'));
+};
+
 const makeEmptyQueryResponse = (loadingState: LoadingState) => {
   const baseEmptyResponse = createEmptyQueryResponse();
 
@@ -142,5 +148,14 @@ describe('Explore', () => {
     await screen.findByText('Explore');
 
     expect(screen.getByTestId('explore-no-data')).toBeInTheDocument();
+  });
+
+  it('should render data source picker on small screens', async () => {
+    setup();
+    resizeWindow(500, 500);
+
+    const dataSourcePicker = await screen.findByLabelText('Data source picker select container');
+
+    expect(dataSourcePicker).toBeInTheDocument();
   });
 });

--- a/public/app/features/explore/Explore.test.tsx
+++ b/public/app/features/explore/Explore.test.tsx
@@ -12,9 +12,9 @@ import { scanStopAction } from './state/query';
 import { createEmptyQueryResponse } from './state/utils';
 
 const resizeWindow = (x: number, y: number) => {
-  window.innerWidth = x;
-  window.innerHeight = y;
-  window.dispatchEvent(new Event('resize'));
+  global.innerWidth = x;
+  global.innerHeight = y;
+  global.dispatchEvent(new Event('resize'));
 };
 
 const makeEmptyQueryResponse = (loadingState: LoadingState) => {
@@ -150,12 +150,24 @@ describe('Explore', () => {
     expect(screen.getByTestId('explore-no-data')).toBeInTheDocument();
   });
 
-  it('should render data source picker on small screens', async () => {
-    setup();
-    resizeWindow(500, 500);
+  describe('On small screens', () => {
+    const windowWidth = global.innerWidth,
+      windowHeight = global.innerHeight;
 
-    const dataSourcePicker = await screen.findByLabelText('Data source picker select container');
+    beforeAll(() => {
+      resizeWindow(500, 500);
+    });
 
-    expect(dataSourcePicker).toBeInTheDocument();
+    afterAll(() => {
+      resizeWindow(windowWidth, windowHeight);
+    });
+
+    it('should render data source picker', async () => {
+      setup();
+
+      const dataSourcePicker = await screen.findByLabelText('Data source picker select container');
+
+      expect(dataSourcePicker).toBeInTheDocument();
+    });
   });
 });

--- a/public/app/features/explore/ExploreToolbar.tsx
+++ b/public/app/features/explore/ExploreToolbar.tsx
@@ -40,6 +40,15 @@ const getStyles = (exploreId: ExploreId, isLargerExploreId: boolean) => {
             : 'none',
       },
     }),
+    /*
+    this selects the `DataSourcePicker`, passed on the `leftItems` prop to `PageToolbar`,
+    it add flex display to override the `leftActionItem` default style
+    */
+    toolbar: css({
+      '> div > nav > div > div:last-child': {
+        display: 'flex',
+      },
+    }),
   };
 };
 
@@ -239,8 +248,18 @@ class UnConnectedExploreToolbar extends PureComponent<Props> {
   };
 
   render() {
-    const { datasourceMissing, exploreId, splitted, containerWidth, topOfViewRef, refreshInterval, loading } =
-      this.props;
+    const {
+      datasourceMissing,
+      exploreId,
+      splitted,
+      containerWidth,
+      topOfViewRef,
+      refreshInterval,
+      loading,
+      largerExploreId,
+    } = this.props;
+    const isLargerExploreId = largerExploreId === exploreId;
+    const styles = getStyles(exploreId, isLargerExploreId);
 
     const showSmallDataSourcePicker = (splitted ? containerWidth < 700 : containerWidth < 800) || false;
     const isTopnav = config.featureToggles.topnav;
@@ -285,6 +304,7 @@ class UnConnectedExploreToolbar extends PureComponent<Props> {
           aria-label="Explore toolbar"
           title={exploreId === ExploreId.left && !isTopnav ? 'Explore' : undefined}
           pageIcon={exploreId === ExploreId.left && !isTopnav ? 'compass' : undefined}
+          className={styles.toolbar}
           leftItems={toolbarLeftItems}
         >
           {this.renderActions()}

--- a/public/app/features/explore/ExploreToolbar.tsx
+++ b/public/app/features/explore/ExploreToolbar.tsx
@@ -286,7 +286,7 @@ class UnConnectedExploreToolbar extends PureComponent<Props> {
           title={exploreId === ExploreId.left && !isTopnav ? 'Explore' : undefined}
           pageIcon={exploreId === ExploreId.left && !isTopnav ? 'compass' : undefined}
           leftItems={toolbarLeftItems}
-          showLeftItemsOnSmallScreen={true}
+          forceShowLeftItems
         >
           {this.renderActions()}
         </PageToolbar>

--- a/public/app/features/explore/ExploreToolbar.tsx
+++ b/public/app/features/explore/ExploreToolbar.tsx
@@ -40,15 +40,6 @@ const getStyles = (exploreId: ExploreId, isLargerExploreId: boolean) => {
             : 'none',
       },
     }),
-    /*
-    this selects the `DataSourcePicker`, passed on the `leftItems` prop to `PageToolbar`,
-    it add flex display to override the `leftActionItem` default style
-    */
-    toolbar: css({
-      '> div > nav > div > div:last-child': {
-        display: 'flex',
-      },
-    }),
   };
 };
 
@@ -248,18 +239,8 @@ class UnConnectedExploreToolbar extends PureComponent<Props> {
   };
 
   render() {
-    const {
-      datasourceMissing,
-      exploreId,
-      splitted,
-      containerWidth,
-      topOfViewRef,
-      refreshInterval,
-      loading,
-      largerExploreId,
-    } = this.props;
-    const isLargerExploreId = largerExploreId === exploreId;
-    const styles = getStyles(exploreId, isLargerExploreId);
+    const { datasourceMissing, exploreId, splitted, containerWidth, topOfViewRef, refreshInterval, loading } =
+      this.props;
 
     const showSmallDataSourcePicker = (splitted ? containerWidth < 700 : containerWidth < 800) || false;
     const isTopnav = config.featureToggles.topnav;
@@ -304,8 +285,8 @@ class UnConnectedExploreToolbar extends PureComponent<Props> {
           aria-label="Explore toolbar"
           title={exploreId === ExploreId.left && !isTopnav ? 'Explore' : undefined}
           pageIcon={exploreId === ExploreId.left && !isTopnav ? 'compass' : undefined}
-          className={styles.toolbar}
           leftItems={toolbarLeftItems}
+          showLeftItemsOnSmallScreen={true}
         >
           {this.renderActions()}
         </PageToolbar>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Previously, whenever the window was less than 768 pixels wide, the `DataSourcePicker` component would be hidden, preventing the user from changing it. This PR solves the issue by overriding the standard collapse function in `PageToolbar` on the Explore page. 

**Who is this feature for?**

People with small screens or window managers

**Which issue(s) does this PR fix?**:


Fixes #64032

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
- [ ] There are no known compatibility issues with older supported versions of Grafana, or plugins.
- [ ] It passes the [Hosted Grafana feature readiness review](https://docs.google.com/document/d/1QL9Ly8KnXzpb6ISbg49pTODRO5mhA5tkkfIZVX6pqQU/edit) for observability, scalability, performance, and security.