### PR TITLE
Units: Format currency with negative before the symbol

### DIFF
--- a/packages/grafana-data/src/valueFormats/symbolFormatters.test.ts
+++ b/packages/grafana-data/src/valueFormats/symbolFormatters.test.ts
@@ -7,25 +7,25 @@ describe('currency', () => {
     const fmtFunc = currency(symbol);
 
     it.each`
-      value               | expectedSuffix | expectedText
-      ${0}                | ${''}          | ${'0'}
-      ${999}              | ${''}          | ${'999'}
-      ${1000}             | ${'K'}         | ${'1'}
-      ${1000000}          | ${'M'}         | ${'1'}
-      ${1000000000}       | ${'B'}         | ${'1'}
-      ${1000000000000}    | ${'T'}         | ${'1'}
-      ${1000000000000000} | ${'T'}         | ${'1000'}
-      ${-1000000000000}   | ${'T'}         | ${'-1'}
-      ${-1000000000}      | ${'B'}         | ${'-1'}
-      ${-1000000}         | ${'M'}         | ${'-1'}
-      ${-1000}            | ${'K'}         | ${'-1'}
-      ${-999}             | ${''}          | ${'-999'}
-    `('when called with value:{$value}', ({ value, expectedSuffix, expectedText }) => {
+      value               | expectedPrefix | expectedSuffix | expectedText
+      ${0}                | ${'@'}         | ${''}          | ${'0'}
+      ${999}              | ${'@'}         | ${''}          | ${'999'}
+      ${1000}             | ${'@'}         | ${'K'}         | ${'1'}
+      ${1000000}          | ${'@'}         | ${'M'}         | ${'1'}
+      ${1000000000}       | ${'@'}         | ${'B'}         | ${'1'}
+      ${1000000000000}    | ${'@'}         | ${'T'}         | ${'1'}
+      ${1000000000000000} | ${'@'}         | ${'T'}         | ${'1000'}
+      ${-1000000000000}   | ${'-@'}        | ${'T'}         | ${'1'}
+      ${-1000000000}      | ${'-@'}        | ${'B'}         | ${'1'}
+      ${-1000000}         | ${'-@'}        | ${'M'}         | ${'1'}
+      ${-1000}            | ${'-@'}        | ${'K'}         | ${'1'}
+      ${-999}             | ${'-@'}        | ${''}          | ${'999'}
+    `('when called with value:{$value}', ({ value, expectedPrefix, expectedText, expectedSuffix }) => {
       const { prefix, suffix, text } = fmtFunc(value);
 
-      expect(prefix).toEqual(symbol);
-      expect(suffix).toEqual(expectedSuffix);
+      expect(prefix).toEqual(expectedPrefix);
       expect(text).toEqual(expectedText);
+      expect(suffix).toEqual(expectedSuffix);
     });
   });
 
@@ -33,25 +33,25 @@ describe('currency', () => {
     const fmtFunc = currency(symbol, true);
 
     it.each`
-      value               | expectedSuffix | expectedText
-      ${0}                | ${'@'}         | ${'0'}
-      ${999}              | ${'@'}         | ${'999'}
-      ${1000}             | ${'K@'}        | ${'1'}
-      ${1000000}          | ${'M@'}        | ${'1'}
-      ${1000000000}       | ${'B@'}        | ${'1'}
-      ${1000000000000}    | ${'T@'}        | ${'1'}
-      ${1000000000000000} | ${'T@'}        | ${'1000'}
-      ${-1000000000000}   | ${'T@'}        | ${'-1'}
-      ${-1000000000}      | ${'B@'}        | ${'-1'}
-      ${-1000000}         | ${'M@'}        | ${'-1'}
-      ${-1000}            | ${'K@'}        | ${'-1'}
-      ${-999}             | ${'@'}         | ${'-999'}
-    `('when called with value:{$value}', ({ value, expectedSuffix, expectedText }) => {
+      value               | expectedPrefix | expectedSuffix | expectedText
+      ${0}                | ${undefined}   | ${'@'}         | ${'0'}
+      ${999}              | ${undefined}   | ${'@'}         | ${'999'}
+      ${1000}             | ${undefined}   | ${'K@'}        | ${'1'}
+      ${1000000}          | ${undefined}   | ${'M@'}        | ${'1'}
+      ${1000000000}       | ${undefined}   | ${'B@'}        | ${'1'}
+      ${1000000000000}    | ${undefined}   | ${'T@'}        | ${'1'}
+      ${1000000000000000} | ${undefined}   | ${'T@'}        | ${'1000'}
+      ${-1000000000000}   | ${'-'}         | ${'T@'}        | ${'1'}
+      ${-1000000000}      | ${'-'}         | ${'B@'}        | ${'1'}
+      ${-1000000}         | ${'-'}         | ${'M@'}        | ${'1'}
+      ${-1000}            | ${'-'}         | ${'K@'}        | ${'1'}
+      ${-999}             | ${'-'}         | ${'@'}         | ${'999'}
+    `('when called with value:{$value}', ({ value, expectedPrefix, expectedText, expectedSuffix }) => {
       const { prefix, suffix, text } = fmtFunc(value);
 
-      expect(prefix).toEqual(undefined);
-      expect(suffix).toEqual(expectedSuffix);
+      expect(prefix).toEqual(expectedPrefix);
       expect(text).toEqual(expectedText);
+      expect(suffix).toEqual(expectedSuffix);
     });
   });
 });

--- a/packages/grafana-data/src/valueFormats/symbolFormatters.ts
+++ b/packages/grafana-data/src/valueFormats/symbolFormatters.ts
@@ -9,7 +9,7 @@ export function currency(symbol: string, asSuffix?: boolean): ValueFormatter {
     if (value == null) {
       return { text: '' };
     }
-    const neg = value < 0;
+    const isNegative = value < 0;
     if (neg) {
       value = Math.abs(value);
     }

--- a/packages/grafana-data/src/valueFormats/symbolFormatters.ts
+++ b/packages/grafana-data/src/valueFormats/symbolFormatters.ts
@@ -10,7 +10,7 @@ export function currency(symbol: string, asSuffix?: boolean): ValueFormatter {
       return { text: '' };
     }
     const isNegative = value < 0;
-    if (neg) {
+    if (isNegative) {
       value = Math.abs(value);
     }
     const scaled = scaler(value, decimals, scaledDecimals);
@@ -19,7 +19,7 @@ export function currency(symbol: string, asSuffix?: boolean): ValueFormatter {
     } else {
       scaled.prefix = symbol;
     }
-    if (neg) {
+    if (isNegative) {
       scaled.prefix = `-${scaled.prefix?.length ? scaled.prefix : ''}`;
     }
     return scaled;

--- a/packages/grafana-data/src/valueFormats/symbolFormatters.ts
+++ b/packages/grafana-data/src/valueFormats/symbolFormatters.ts
@@ -5,15 +5,22 @@ import { scaledUnits, ValueFormatter } from './valueFormats';
 export function currency(symbol: string, asSuffix?: boolean): ValueFormatter {
   const units = ['', 'K', 'M', 'B', 'T'];
   const scaler = scaledUnits(1000, units);
-  return (size: number, decimals?: DecimalCount, scaledDecimals?: DecimalCount) => {
-    if (size === null) {
+  return (value: number, decimals?: DecimalCount, scaledDecimals?: DecimalCount) => {
+    if (value == null) {
       return { text: '' };
     }
-    const scaled = scaler(size, decimals, scaledDecimals);
+    const neg = value < 0;
+    if (neg) {
+      value = Math.abs(value);
+    }
+    const scaled = scaler(value, decimals, scaledDecimals);
     if (asSuffix) {
       scaled.suffix = scaled.suffix !== undefined ? `${scaled.suffix}${symbol}` : undefined;
     } else {
       scaled.prefix = symbol;
+    }
+    if (neg) {
+      scaled.prefix = `-${scaled.prefix?.length ? scaled.prefix : ''}`;
     }
     return scaled;
   };


### PR DESCRIPTION
**What is this feature?**

We currently format  negative monies as `$-100` and it should be `-$100`

**Why do we need this feature?**

to be more normal

<img width="676" alt="image" src="https://user-images.githubusercontent.com/705951/226830005-6c973820-7561-4efa-a357-2a088916d956.png">


**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

Fixes #65123

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
- [ ] There are no known compatibility issues with older supported versions of Grafana, or plugins.
- [ ] It passes the [Hosted Grafana feature readiness review](https://docs.google.com/document/d/1QL9Ly8KnXzpb6ISbg49pTODRO5mhA5tkkfIZVX6pqQU/edit) for observability, scalability, performance, and security.