### PR TITLE
devenv: elastic: remove unnecessary console logging

### DIFF
--- a/devenv/docker/blocks/elastic/data/data.js
+++ b/devenv/docker/blocks/elastic/data/data.js
@@ -53,7 +53,6 @@ async function elasticSendLogItem(timestamp, item) {
   const url = new URL(ELASTIC_BASE_URL);
   url.pathname = `/logs-${timestampText}/_doc`;
   await jsonRequest(item, 'POST', url, 201);
-  console.log(`posted to ${url.toString()}`);
 }
 
 async function elasticSetupIndexTemplate() {


### PR DESCRIPTION
the devenv elasticsearch fake-data-generator script outputs a console-log for every log-line it writes to elastic.
this is not needed, and others (like the loki one) does not do it either.