### PR TITLE
DataLinks: Fixes interpolation (formatting) of __all_variables and __url_time_range

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -312,8 +312,7 @@ exports[`better eslint`] = {
     ],
     "packages/grafana-data/src/types/ScopedVars.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "2"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
     ],
     "packages/grafana-data/src/types/annotations.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],

--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -413,7 +413,7 @@ export const getLinksSupplier =
         }
       }
 
-      const variables = {
+      const variables: ScopedVars = {
         ...fieldScopedVars,
         __value: {
           text: 'Value',
@@ -423,10 +423,12 @@ export const getLinksSupplier =
         [DataLinkBuiltInVars.keepTime]: {
           text: timeRangeUrl,
           value: timeRangeUrl,
+          skipFormat: true,
         },
         [DataLinkBuiltInVars.includeVars]: {
           text: variablesQuery,
           value: variablesQuery,
+          skipFormat: true,
         },
       };
 

--- a/packages/grafana-data/src/types/ScopedVars.ts
+++ b/packages/grafana-data/src/types/ScopedVars.ts
@@ -1,7 +1,8 @@
 export interface ScopedVar<T = any> {
   text?: any;
   value: T;
-  [key: string]: any;
+  skipUrlSync?: boolean;
+  skipFormat?: boolean;
 }
 
 export interface ScopedVars extends Record<string, ScopedVar> {}

--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -647,11 +647,13 @@ export class PanelModel implements DataConfigSource, IPanelModel {
     vars[DataLinkBuiltInVars.keepTime] = {
       text: timeRangeUrl,
       value: timeRangeUrl,
+      skipFormat: true,
     };
 
     vars[DataLinkBuiltInVars.includeVars] = {
       text: variablesQuery,
       value: variablesQuery,
+      skipFormat: true,
     };
 
     return getTemplateSrv().replace(value, vars, format);

--- a/public/app/features/plugins/tests/datasource_srv.test.ts
+++ b/public/app/features/plugins/tests/datasource_srv.test.ts
@@ -3,7 +3,7 @@ import {
   DataSourceInstanceSettings,
   DataSourcePlugin,
   DataSourcePluginMeta,
-  ScopedVar,
+  ScopedVars,
 } from '@grafana/data';
 import { DatasourceSrv } from 'app/features/plugins/datasource_srv';
 
@@ -25,7 +25,7 @@ const templateSrv: any = {
       },
     },
   ],
-  replace: (v: string, scopedVars: ScopedVar) => {
+  replace: (v: string, scopedVars: ScopedVars) => {
     if (scopedVars && scopedVars.datasource) {
       return v.replace('${datasource}', scopedVars.datasource.value);
     }

--- a/public/app/features/templating/template_srv.test.ts
+++ b/public/app/features/templating/template_srv.test.ts
@@ -821,6 +821,15 @@ describe('templateSrv', () => {
       const target = _templateSrv.replace('${adhoc}', { adhoc: { value: 'value2', text: 'value2' } }, 'queryparam');
       expect(target).toBe('var-adhoc=value2');
     });
+
+    it('Variable named ${__all_variables} is already formatted so skip any formatting', () => {
+      const target = _templateSrv.replace(
+        '${__all_variables}',
+        { __all_variables: { value: 'var-server=server+name+with+plus%2B', skipFormat: true } },
+        'percentencode'
+      );
+      expect(target).toBe('var-server=server+name+with+plus%2B');
+    });
   });
 
   describe('scenes compatibility', () => {

--- a/public/app/features/templating/template_srv.ts
+++ b/public/app/features/templating/template_srv.ts
@@ -294,13 +294,17 @@ export class TemplateSrv implements BaseTemplateSrv {
     return target.replace(this.regex, (match, var1, var2, fmt2, var3, fieldPath, fmt3) => {
       const variableName = var1 || var2 || var3;
       const variable = this.getVariableAtIndex(variableName);
-      const fmt = fmt2 || fmt3 || format;
+      let fmt = fmt2 || fmt3 || format;
 
       if (scopedVars) {
         const value = this.getVariableValue(variableName, fieldPath, scopedVars);
         const text = this.getVariableText(variableName, value, scopedVars);
 
         if (value !== null && value !== undefined) {
+          if (scopedVars[variableName] && scopedVars[variableName].skipFormat) {
+            fmt = undefined;
+          }
+
           return this.formatValue(value, fmt, variable, text);
         }
       }

--- a/public/app/features/templating/template_srv.ts
+++ b/public/app/features/templating/template_srv.ts
@@ -301,7 +301,7 @@ export class TemplateSrv implements BaseTemplateSrv {
         const text = this.getVariableText(variableName, value, scopedVars);
 
         if (value !== null && value !== undefined) {
-          if (scopedVars[variableName] && scopedVars[variableName].skipFormat) {
+          if (scopedVars[variableName].skipFormat) {
             fmt = undefined;
           }
 

--- a/public/app/features/variables/getAllVariableValuesForUrl.test.ts
+++ b/public/app/features/variables/getAllVariableValuesForUrl.test.ts
@@ -107,7 +107,7 @@ describe('getAllVariableValuesForUrl', () => {
 
     it('should not set scoped value as url params', () => {
       const params = getVariablesUrlParams({
-        test: { name: 'test', value: 'val1', text: 'val1text', skipUrlSync: true },
+        test: { value: 'val1', text: 'val1text', skipUrlSync: true },
       });
       expect(params['var-test']).toBe(undefined);
     });

--- a/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchMetricsQueryRunner.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchMetricsQueryRunner.test.ts
@@ -513,8 +513,8 @@ describe('CloudWatchMetricsQueryRunner', () => {
           runner.handleMetricQueries(queries, {
             ...request,
             scopedVars: {
-              var1: { selected: true, value: 'var1-foo', text: '' },
-              var2: { selected: true, value: 'var2-foo', text: '' },
+              var1: { value: 'var1-foo', text: '' },
+              var2: { value: 'var2-foo', text: '' },
             },
           })
         ).toEmitValuesWith(() => {
@@ -579,7 +579,7 @@ describe('CloudWatchMetricsQueryRunner', () => {
           runner.handleMetricQueries(queries, {
             ...request,
             scopedVars: {
-              var1: { selected: true, value: 'var1-foo', text: '' },
+              var1: { value: 'var1-foo', text: '' },
             },
           })
         ).toEmitValuesWith(() => {


### PR DESCRIPTION
I forget when reviewing https://github.com/grafana/grafana/pull/64841 (that sets url encoding to default for data link urls) that there was a reason we could not do that, as it would make `$__all__variables` and
`__url_time_range` variables stop working as they contain multiple url variables already and cannot be url encoded again.

But instead of reverting the PR I added skipFormat property to ScopedVar so that we can ignore formatting these special scoped vars.
