### PR TITLE
Logging: Report error boundary errors to Faro

### DIFF
--- a/packages/grafana-runtime/src/utils/logging.ts
+++ b/packages/grafana-runtime/src/utils/logging.ts
@@ -76,10 +76,7 @@ export function logDebug(message: string, contexts?: Contexts) {
  */
 export function logError(err: Error, contexts?: Contexts) {
   if (config.grafanaJavascriptAgent.enabled) {
-    faro.api.pushLog([err.message], {
-      level: GrafanaLogLevel.ERROR,
-      context: contexts,
-    });
+    faro.api.pushError(err);
   }
   if (config.sentry.enabled) {
     captureException(err, { contexts });

--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -51,6 +51,7 @@
     "@emotion/react": "11.10.6",
     "@grafana/data": "9.5.0-pre",
     "@grafana/e2e-selectors": "9.5.0-pre",
+    "@grafana/faro-web-sdk": "1.0.2",
     "@grafana/schema": "9.5.0-pre",
     "@leeoniya/ufuzzy": "1.0.6",
     "@monaco-editor/react": "4.4.6",

--- a/packages/grafana-ui/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/packages/grafana-ui/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,6 +1,8 @@
 import { captureException } from '@sentry/browser';
 import React, { PureComponent, ReactNode, ComponentType } from 'react';
 
+import { faro } from '@grafana/faro-web-sdk';
+
 import { Alert } from '../Alert/Alert';
 
 import { ErrorWithStack } from './ErrorWithStack';
@@ -37,6 +39,7 @@ export class ErrorBoundary extends PureComponent<Props, State> {
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     captureException(error, { contexts: { react: { componentStack: errorInfo.componentStack } } });
+    faro.api.pushError(error);
     this.setState({ error, errorInfo });
 
     if (this.props.onError) {

--- a/packages/grafana-ui/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/packages/grafana-ui/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -39,7 +39,7 @@ export class ErrorBoundary extends PureComponent<Props, State> {
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     captureException(error, { contexts: { react: { componentStack: errorInfo.componentStack } } });
-    faro.api.pushError(error);
+    faro?.api.pushError(error);
     this.setState({ error, errorInfo });
 
     if (this.props.onError) {

--- a/packages/grafana-ui/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/packages/grafana-ui/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -39,7 +39,7 @@ export class ErrorBoundary extends PureComponent<Props, State> {
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     captureException(error, { contexts: { react: { componentStack: errorInfo.componentStack } } });
-    faro?.api.pushError(error);
+    faro?.api?.pushError(error);
     this.setState({ error, errorInfo });
 
     if (this.props.onError) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5491,6 +5491,7 @@ __metadata:
     "@emotion/react": 11.10.6
     "@grafana/data": 9.5.0-pre
     "@grafana/e2e-selectors": 9.5.0-pre
+    "@grafana/faro-web-sdk": 1.0.2
     "@grafana/schema": 9.5.0-pre
     "@grafana/tsconfig": ^1.2.0-rc1
     "@leeoniya/ufuzzy": 1.0.6


### PR DESCRIPTION
It seems when Faro was added, we neglected to update error boundary component to push errors to Faro. Oops!
Also updates `logError` from `@grafana/runtime` to use newer `faro.api.pushError()` method to capture an error.
