### PR TITLE
CD: Remove `fetch-images` dependency from AWS marketplace automation

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4367,28 +4367,10 @@ steps:
   image: golang:1.20.1
   name: compile-build-cmd
 - commands:
-  - ./bin/build artifacts docker fetch --edition enterprise
-  depends_on:
-  - compile-build-cmd
-  environment:
-    DOCKER_ENTERPRISE2_REPO:
-      from_secret: docker_enterprise2_repo
-    DOCKER_PASSWORD:
-      from_secret: docker_password
-    DOCKER_USER:
-      from_secret: docker_username
-    GCP_KEY:
-      from_secret: gcp_key
-  image: google/cloud-sdk
-  name: fetch-images-enterprise
-  volumes:
-  - name: docker
-    path: /var/run/docker.sock
-- commands:
   - ./bin/build publish aws --image grafana/grafana-enterprise --repo grafana-labs/grafanaenterprise
     --product 422b46fb-bea6-4f27-8bcc-832117bd627e
   depends_on:
-  - fetch-images-enterprise
+  - compile-build-cmd
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: aws_access_key_id
@@ -6688,6 +6670,6 @@ kind: secret
 name: enterprise2_security_prefix
 ---
 kind: signature
-hmac: c97e54e16b8399bef42b71fda9826579f274c537ced6124682cbd29a986332c9
+hmac: 84416be2a690d4290d31696b6c6a013d2358ea1b204d86e9b196dca4c5f0b906
 
 ...

--- a/scripts/drone/pipelines/aws_marketplace.star
+++ b/scripts/drone/pipelines/aws_marketplace.star
@@ -19,7 +19,7 @@ def publish_aws_marketplace_step():
         "name": "publish-aws-marketplace",
         "image": publish_image,
         "commands": ["./bin/build publish aws --image grafana/grafana-enterprise --repo grafana-labs/grafanaenterprise --product 422b46fb-bea6-4f27-8bcc-832117bd627e"],
-        "depends_on": ["fetch-images-enterprise"],
+        "depends_on": ["compile-build-cmd"],
         "environment": {
             "AWS_REGION": from_secret("aws_region"),
             "AWS_ACCESS_KEY_ID": from_secret("aws_access_key_id"),
@@ -36,7 +36,7 @@ def publish_aws_marketplace_pipeline(mode):
     return [pipeline(
         name = "publish-aws-marketplace-{}".format(mode),
         trigger = trigger,
-        steps = [compile_build_cmd(), fetch_images_step("enterprise"), publish_aws_marketplace_step()],
+        steps = [compile_build_cmd(), publish_aws_marketplace_step()],
         edition = "",
         depends_on = ["publish-docker-enterprise-public"],
         environment = {"EDITION": "enterprise2"},

--- a/scripts/drone/pipelines/aws_marketplace.star
+++ b/scripts/drone/pipelines/aws_marketplace.star
@@ -5,7 +5,6 @@ This module contains steps and pipelines publishing to AWS Marketplace.
 load(
     "scripts/drone/steps/lib.star",
     "compile_build_cmd",
-    "fetch_images_step",
     "publish_image",
 )
 load("scripts/drone/vault.star", "from_secret")


### PR DESCRIPTION
**What is this feature?**

Simplifies CD. `./bin/build publish aws` pulls docker images from DockerHub, so there's no need to fetch the images locally and depend on that.