### PR TITLE
Url encode custom ALL value in dashboard link 

### DIFF
--- a/public/app/features/panel/panellinks/link_srv.ts
+++ b/public/app/features/panel/panellinks/link_srv.ts
@@ -251,7 +251,13 @@ export interface LinkService {
 
 export class LinkSrv implements LinkService {
   getLinkUrl(link: any) {
-    let url = locationUtil.assureBaseUrl(getTemplateSrv().replace(link.url || ''));
+    let url = locationUtil.assureBaseUrl(
+      link.type === 'dashboards'
+        ? getTemplateSrv().replace(link.url || '')
+        : getTemplateSrv().replace(link.url || '', undefined, (value: string | boolean | number) => {
+            return encodeURIComponent(value);
+          })
+    );
     let params: { [key: string]: any } = {};
 
     if (link.keepTime) {

--- a/public/app/features/templating/template_srv.ts
+++ b/public/app/features/templating/template_srv.ts
@@ -327,8 +327,8 @@ export class TemplateSrv implements BaseTemplateSrv {
       if (this.isAllValue(value)) {
         value = this.getAllValue(variable);
         text = ALL_VARIABLE_TEXT;
-        // skip formatting of custom all values
-        if (variable.allValue && fmt !== FormatRegistryID.text) {
+        // skip formatting of custom all values, unless a custom formatter function is specified
+        if (variable.allValue && fmt !== FormatRegistryID.text && typeof fmt !== 'function') {
           return this.replace(value);
         }
       }


### PR DESCRIPTION
A possible fix for https://github.com/grafana/support-escalations/issues/5361

This PR enables dashboard links (that are not pointing to another dashboard!) to have custom ALL value encoded in the URL. It's a hacky solution maybe, but seems to work.

TODO:
- [ ] Add tests