### PR TITLE
Instrumentation: Add span for backend datasource requests

### DIFF
--- a/pkg/api/metrics_test.go
+++ b/pkg/api/metrics_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/plugins/backendplugin"
 	"github.com/grafana/grafana/pkg/plugins/config"
@@ -261,7 +262,7 @@ func TestDataSourceQueryError(t *testing.T) {
 					nil,
 					&fakePluginRequestValidator{},
 					&fakeDatasources.FakeDataSourceService{},
-					pluginClient.ProvideService(r, &config.Cfg{}, hs.tracer),
+					pluginClient.ProvideService(r, &config.Cfg{}, tracing.InitializeTracerForTest()),
 				)
 				hs.QuotaService = quotatest.New(false, nil)
 			})

--- a/pkg/api/metrics_test.go
+++ b/pkg/api/metrics_test.go
@@ -261,7 +261,7 @@ func TestDataSourceQueryError(t *testing.T) {
 					nil,
 					&fakePluginRequestValidator{},
 					&fakeDatasources.FakeDataSourceService{},
-					pluginClient.ProvideService(r, &config.Cfg{}),
+					pluginClient.ProvideService(r, &config.Cfg{}, hs.tracer),
 				)
 				hs.QuotaService = quotatest.New(false, nil)
 			})

--- a/pkg/api/plugin_resource_test.go
+++ b/pkg/api/plugin_resource_test.go
@@ -73,7 +73,7 @@ func TestCallResource(t *testing.T) {
 		hs.PluginContextProvider = pcp
 		hs.QuotaService = quotatest.New(false, nil)
 		hs.pluginStore = ps
-		hs.pluginClient = pluginClient.ProvideService(reg, pCfg)
+		hs.pluginClient = pluginClient.ProvideService(reg, pCfg, hs.tracer)
 	})
 
 	t.Run("Test successful response is received for valid request", func(t *testing.T) {

--- a/pkg/api/plugin_resource_test.go
+++ b/pkg/api/plugin_resource_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/localcache"
+	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/plugins/backendplugin/coreplugin"
 	"github.com/grafana/grafana/pkg/plugins/backendplugin/provider"
@@ -73,7 +74,7 @@ func TestCallResource(t *testing.T) {
 		hs.PluginContextProvider = pcp
 		hs.QuotaService = quotatest.New(false, nil)
 		hs.pluginStore = ps
-		hs.pluginClient = pluginClient.ProvideService(reg, pCfg, hs.tracer)
+		hs.pluginClient = pluginClient.ProvideService(reg, pCfg, tracing.InitializeTracerForTest())
 	})
 
 	t.Run("Test successful response is received for valid request", func(t *testing.T) {

--- a/pkg/plugins/backendplugin/instrumentation/instrumentation.go
+++ b/pkg/plugins/backendplugin/instrumentation/instrumentation.go
@@ -93,7 +93,7 @@ func instrumentPluginRequest(ctx context.Context, cfg Cfg, pluginCtx *backend.Pl
 	for key, value := range instrumentationParams {
 		logParams = append(logParams, key, value)
 		if key != "TraceID" {
-			addToTrace(span, key, value)
+			addToSpan(span, key, value)
 		}
 	}
 
@@ -138,7 +138,7 @@ func InstrumentQueryDataRequest(ctx context.Context, req *backend.QueryDataReque
 	})
 }
 
-func addToTrace(span tracing.Span, key string, value interface{}) {
+func addToSpan(span tracing.Span, key string, value interface{}) {
 	switch value.(type) {
 	case string:
 		span.SetAttributes(key, value.(string), attribute.Key(key).String(value.(string)))

--- a/pkg/plugins/backendplugin/instrumentation/instrumentation.go
+++ b/pkg/plugins/backendplugin/instrumentation/instrumentation.go
@@ -103,7 +103,7 @@ func instrumentPluginRequest(ctx context.Context, cfg Cfg, pluginCtx *backend.Pl
 	for key, value := range extraTraceAttributes {
 		span.SetAttributes(key, value, attribute.Key(key).String(value.(string)))
 	}
-	
+
 	return err
 }
 
@@ -126,7 +126,7 @@ func InstrumentCheckHealthRequest(ctx context.Context, req *backend.CheckHealthR
 func InstrumentCallResourceRequest(ctx context.Context, req *backend.CallResourceRequest, cfg Cfg, tracer tracing.Tracer, fn func() error) error {
 	return instrumentPluginRequest(ctx, cfg, &req.PluginContext, "callResource", tracer, fn, map[string]interface{}{
 		"dashboard_uid": req.GetHTTPHeader("X-Dashboard-Uid"),
-		"panel_id":     req.GetHTTPHeader("X-Panel-Id"),
+		"panel_id":      req.GetHTTPHeader("X-Panel-Id"),
 	})
 }
 
@@ -134,21 +134,21 @@ func InstrumentCallResourceRequest(ctx context.Context, req *backend.CallResourc
 func InstrumentQueryDataRequest(ctx context.Context, req *backend.QueryDataRequest, cfg Cfg, tracer tracing.Tracer, fn func() error) error {
 	return instrumentPluginRequest(ctx, cfg, &req.PluginContext, "queryData", tracer, fn, map[string]interface{}{
 		"dashboard_uid": req.GetHTTPHeader("X-Dashboard-Uid"),
-		"panel_id":     req.GetHTTPHeader("X-Panel-Id"),
+		"panel_id":      req.GetHTTPHeader("X-Panel-Id"),
 	})
 }
 
 func addToSpan(span tracing.Span, key string, value interface{}) {
-	switch value.(type) {
+	switch value := value.(type) {
 	case string:
-		span.SetAttributes(key, value.(string), attribute.Key(key).String(value.(string)))
+		span.SetAttributes(key, value, attribute.Key(key).String(value))
 	case int64:
-		span.SetAttributes(key, value.(int64), attribute.Key(key).Int64(value.(int64)))
+		span.SetAttributes(key, value, attribute.Key(key).Int64(value))
 	case int:
-		span.SetAttributes(key, value.(int), attribute.Key(key).Int(value.(int)))
+		span.SetAttributes(key, value, attribute.Key(key).Int(value))
 	case bool:
-		span.SetAttributes(key, value.(bool), attribute.Key(key).Bool(value.(bool)))
+		span.SetAttributes(key, value, attribute.Key(key).Bool(value))
 	case float64:
-		span.SetAttributes(key, value.(float64), attribute.Key(key).Float64(value.(float64)))
+		span.SetAttributes(key, value, attribute.Key(key).Float64(value))
 	}
 }

--- a/pkg/plugins/manager/client/client.go
+++ b/pkg/plugins/manager/client/client.go
@@ -44,7 +44,7 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 	}
 
 	var resp *backend.QueryDataResponse
-	err := instrumentation.InstrumentQueryDataRequest(ctx, &req.PluginContext, instrumentation.Cfg{
+	err := instrumentation.InstrumentQueryDataRequest(ctx, req, instrumentation.Cfg{
 		LogDatasourceRequests: s.cfg.LogDatasourceRequests,
 		Target:                p.Target(),
 	}, s.tracer, func() (innerErr error) {
@@ -89,7 +89,7 @@ func (s *Service) CallResource(ctx context.Context, req *backend.CallResourceReq
 	if !exists {
 		return backendplugin.ErrPluginNotRegistered
 	}
-	err := instrumentation.InstrumentCallResourceRequest(ctx, &req.PluginContext, instrumentation.Cfg{
+	err := instrumentation.InstrumentCallResourceRequest(ctx, req, instrumentation.Cfg{
 		LogDatasourceRequests: s.cfg.LogDatasourceRequests,
 		Target:                p.Target(),
 	}, s.tracer, func() error {
@@ -129,7 +129,7 @@ func (s *Service) CollectMetrics(ctx context.Context, req *backend.CollectMetric
 	}
 
 	var resp *backend.CollectMetricsResult
-	err := instrumentation.InstrumentCollectMetrics(ctx, &req.PluginContext, instrumentation.Cfg{
+	err := instrumentation.InstrumentCollectMetrics(ctx, req, instrumentation.Cfg{
 		LogDatasourceRequests: s.cfg.LogDatasourceRequests,
 		Target:                p.Target(),
 	}, s.tracer, func() (innerErr error) {
@@ -154,7 +154,7 @@ func (s *Service) CheckHealth(ctx context.Context, req *backend.CheckHealthReque
 	}
 
 	var resp *backend.CheckHealthResult
-	err := instrumentation.InstrumentCheckHealthRequest(ctx, &req.PluginContext, instrumentation.Cfg{
+	err := instrumentation.InstrumentCheckHealthRequest(ctx, req, instrumentation.Cfg{
 		LogDatasourceRequests: s.cfg.LogDatasourceRequests,
 		Target:                p.Target(),
 	}, s.tracer, func() (innerErr error) {

--- a/pkg/plugins/manager/client/client_test.go
+++ b/pkg/plugins/manager/client/client_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/plugins/backendplugin"
 	"github.com/grafana/grafana/pkg/plugins/config"
@@ -18,7 +19,7 @@ import (
 func TestQueryData(t *testing.T) {
 	t.Run("Empty registry should return not registered error", func(t *testing.T) {
 		registry := fakes.NewFakePluginRegistry()
-		client := ProvideService(registry, &config.Cfg{})
+		client := ProvideService(registry, &config.Cfg{}, tracing.InitializeTracerForTest())
 		_, err := client.QueryData(context.Background(), &backend.QueryDataRequest{})
 		require.Error(t, err)
 		require.ErrorIs(t, err, plugins.ErrPluginNotRegistered)
@@ -59,7 +60,7 @@ func TestQueryData(t *testing.T) {
 				err := registry.Add(context.Background(), p)
 				require.NoError(t, err)
 
-				client := ProvideService(registry, &config.Cfg{})
+				client := ProvideService(registry, &config.Cfg{}, tracing.InitializeTracerForTest())
 				_, err = client.QueryData(context.Background(), &backend.QueryDataRequest{
 					PluginContext: backend.PluginContext{
 						PluginID: "grafana",
@@ -123,7 +124,7 @@ func TestCallResource(t *testing.T) {
 		err := registry.Add(context.Background(), p)
 		require.NoError(t, err)
 
-		client := ProvideService(registry, &config.Cfg{})
+		client := ProvideService(registry, &config.Cfg{}, tracing.InitializeTracerForTest())
 
 		err = client.CallResource(context.Background(), req, sender)
 		require.NoError(t, err)
@@ -187,7 +188,7 @@ func TestCallResource(t *testing.T) {
 		err := registry.Add(context.Background(), p)
 		require.NoError(t, err)
 
-		client := ProvideService(registry, &config.Cfg{})
+		client := ProvideService(registry, &config.Cfg{}, tracing.InitializeTracerForTest())
 
 		err = client.CallResource(context.Background(), req, sender)
 		require.NoError(t, err)

--- a/pkg/plugins/manager/manager_integration_test.go
+++ b/pkg/plugins/manager/manager_integration_test.go
@@ -128,7 +128,7 @@ func TestIntegrationPluginManager(t *testing.T) {
 	verifyBundledPlugins(t, ctx, ps)
 	verifyPluginStaticRoutes(t, ctx, ps, reg)
 	verifyBackendProcesses(t, reg.Plugins(ctx))
-	verifyPluginQuery(t, ctx, client.ProvideService(reg, pCfg))
+	verifyPluginQuery(t, ctx, client.ProvideService(reg, pCfg, tracing.InitializeTracerForTest()))
 }
 
 func verifyPluginQuery(t *testing.T, ctx context.Context, c plugins.Client) {

--- a/pkg/services/pluginsintegration/pluginsintegration.go
+++ b/pkg/services/pluginsintegration/pluginsintegration.go
@@ -3,6 +3,7 @@ package pluginsintegration
 import (
 	"github.com/google/wire"
 
+	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/plugins/backendplugin/coreplugin"
 	"github.com/grafana/grafana/pkg/plugins/backendplugin/provider"
@@ -74,14 +75,14 @@ var WireExtensionSet = wire.NewSet(
 
 func ProvideClientDecorator(cfg *setting.Cfg, pCfg *config.Cfg,
 	pluginRegistry registry.Service,
-	oAuthTokenService oauthtoken.OAuthTokenService) (*client.Decorator, error) {
-	return NewClientDecorator(cfg, pCfg, pluginRegistry, oAuthTokenService)
+	oAuthTokenService oauthtoken.OAuthTokenService, tracer tracing.Tracer) (*client.Decorator, error) {
+	return NewClientDecorator(cfg, pCfg, pluginRegistry, oAuthTokenService, tracer)
 }
 
 func NewClientDecorator(cfg *setting.Cfg, pCfg *config.Cfg,
 	pluginRegistry registry.Service,
-	oAuthTokenService oauthtoken.OAuthTokenService) (*client.Decorator, error) {
-	c := client.ProvideService(pluginRegistry, pCfg)
+	oAuthTokenService oauthtoken.OAuthTokenService, tracer tracing.Tracer) (*client.Decorator, error) {
+	c := client.ProvideService(pluginRegistry, pCfg, tracer)
 	middlewares := CreateMiddlewares(cfg, oAuthTokenService)
 
 	return client.NewDecorator(c, middlewares...)


### PR DESCRIPTION
**What is this feature?**

We noticed that we don't have a span holding information about the origin of a query. Frontend datasources/requests do that in https://github.com/grafana/grafana/blob/main/pkg/api/pluginproxy/ds_proxy.go#L146-L147 but there is no such thing for backend datasources.

This PR adds a span to the `instrumentation.go` file. It uses a struct (`instrumentationParams`) to use that for both logging and tracing.

![image](https://user-images.githubusercontent.com/8092184/226899114-e4f2880a-65c5-4ad4-a1df-b097403d5d0d.png)

