### PR TITLE
Table: Fixes issue with pagination summary causing scrollbar 

### DIFF
--- a/packages/grafana-ui/src/components/Table/Table.tsx
+++ b/packages/grafana-ui/src/components/Table/Table.tsx
@@ -326,15 +326,12 @@ export const Table = memo((props: Props) => {
     }
     paginationEl = (
       <div className={tableStyles.paginationWrapper}>
-        {isSmall ? null : <div className={tableStyles.paginationItem} />}
-        <div className={tableStyles.paginationCenterItem}>
-          <Pagination
-            currentPage={state.pageIndex + 1}
-            numberOfPages={pageOptions.length}
-            showSmallVersion={isSmall}
-            onNavigate={onNavigate}
-          />
-        </div>
+        <Pagination
+          currentPage={state.pageIndex + 1}
+          numberOfPages={pageOptions.length}
+          showSmallVersion={isSmall}
+          onNavigate={onNavigate}
+        />
         {isSmall ? null : (
           <div className={tableStyles.paginationSummary}>
             {itemsRangeStart} - {itemsRangeEnd} of {data.length} rows

--- a/packages/grafana-ui/src/components/Table/styles.ts
+++ b/packages/grafana-ui/src/components/Table/styles.ts
@@ -220,8 +220,7 @@ export function useTableStyles(theme: GrafanaTheme2, cellHeightOption: TableCell
       font-size: ${theme.typography.bodySmall.fontSize};
       display: flex;
       justify-content: flex-end;
-      flex: 20%;
-      padding-right: ${theme.spacing(1)};
+      padding: ${theme.spacing(0, 1, 0, 2)};
     `,
 
     tableContentWrapper: (totalColumnsWidth: number) => {

--- a/packages/grafana-ui/src/components/Table/styles.ts
+++ b/packages/grafana-ui/src/components/Table/styles.ts
@@ -207,14 +207,6 @@ export function useTableStyles(theme: GrafanaTheme2, cellHeightOption: TableCell
         margin-bottom: 0;
       }
     `,
-    paginationItem: css`
-      flex: 20%;
-    `,
-    paginationCenterItem: css`
-      flex: 100%;
-      display: flex;
-      justify-content: center;
-    `,
     paginationSummary: css`
       color: ${theme.colors.text.secondary};
       font-size: ${theme.typography.bodySmall.fontSize};


### PR DESCRIPTION
Noticed a scrollbar appearing in some table panels. It's because of the pagination summary. 

* Simplify the CSS so that the full width can be used (20% was dedicated to empty space on the right). To still have everything mostly centered I moved the summary to be on the rigth side of the pagination and centered together with the pagination controls. 

Before :
![Screenshot from 2023-03-22 16-29-05](https://user-images.githubusercontent.com/10999/226955710-cdf75f77-16b0-48e2-b917-1abc7700ea21.png)

After:
![Screenshot from 2023-03-22 16-32-54](https://user-images.githubusercontent.com/10999/226956171-3fdf2140-8807-461f-9549-662e0da80df6.png)
