### PR TITLE
[v9.4.x] CD: Remove `fetch-images` dependency from AWS marketplace automation (#65173)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4260,28 +4260,10 @@ steps:
   image: golang:1.20.1
   name: compile-build-cmd
 - commands:
-  - ./bin/build artifacts docker fetch --edition enterprise
-  depends_on:
-  - compile-build-cmd
-  environment:
-    DOCKER_ENTERPRISE2_REPO:
-      from_secret: docker_enterprise2_repo
-    DOCKER_PASSWORD:
-      from_secret: docker_password
-    DOCKER_USER:
-      from_secret: docker_username
-    GCP_KEY:
-      from_secret: gcp_key
-  image: google/cloud-sdk
-  name: fetch-images-enterprise
-  volumes:
-  - name: docker
-    path: /var/run/docker.sock
-- commands:
   - ./bin/build publish aws --image grafana/grafana-enterprise --repo grafana-labs/grafanaenterprise
     --product 422b46fb-bea6-4f27-8bcc-832117bd627e
   depends_on:
-  - fetch-images-enterprise
+  - compile-build-cmd
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: aws_access_key_id
@@ -6581,6 +6563,6 @@ kind: secret
 name: enterprise2_security_prefix
 ---
 kind: signature
-hmac: 20645509028e86a59bd9f70d945881d2f36bdcf9c0bd0f1c74a231c5fdd9842e
+hmac: cefe303c3e3e5b88021174d5b5c66f79076dbc043ae2762c6d6c586cdb96dbf6
 
 ...

--- a/scripts/drone/pipelines/aws_marketplace.star
+++ b/scripts/drone/pipelines/aws_marketplace.star
@@ -5,7 +5,6 @@ This module contains steps and pipelines publishing to AWS Marketplace.
 load(
     "scripts/drone/steps/lib.star",
     "compile_build_cmd",
-    "fetch_images_step",
     "publish_image",
 )
 load("scripts/drone/vault.star", "from_secret")
@@ -19,7 +18,7 @@ def publish_aws_marketplace_step():
         "name": "publish-aws-marketplace",
         "image": publish_image,
         "commands": ["./bin/build publish aws --image grafana/grafana-enterprise --repo grafana-labs/grafanaenterprise --product 422b46fb-bea6-4f27-8bcc-832117bd627e"],
-        "depends_on": ["fetch-images-enterprise"],
+        "depends_on": ["compile-build-cmd"],
         "environment": {
             "AWS_REGION": from_secret("aws_region"),
             "AWS_ACCESS_KEY_ID": from_secret("aws_access_key_id"),
@@ -36,7 +35,7 @@ def publish_aws_marketplace_pipeline(mode):
     return [pipeline(
         name = "publish-aws-marketplace-{}".format(mode),
         trigger = trigger,
-        steps = [compile_build_cmd(), fetch_images_step("enterprise"), publish_aws_marketplace_step()],
+        steps = [compile_build_cmd(), publish_aws_marketplace_step()],
         edition = "",
         depends_on = ["publish-docker-enterprise-public"],
         environment = {"EDITION": "enterprise2"},


### PR DESCRIPTION
* Remove fetch-images dependency

* Fix starlark link

(cherry picked from commit d0be9610f0e22a4571a13c2ebf2aaabe281ecf48)

Backports: #65173
