### PR TITLE
Elasticsearch: Fix using of interval value in histogram

### DIFF
--- a/pkg/tsdb/elasticsearch/client/client.go
+++ b/pkg/tsdb/elasticsearch/client/client.go
@@ -16,7 +16,6 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 
 	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/tsdb/intervalv2"
 )
 
 type DatasourceInfo struct {
@@ -44,7 +43,6 @@ const loggerName = "tsdb.elasticsearch.client"
 // Client represents a client which can interact with elasticsearch api
 type Client interface {
 	GetConfiguredFields() ConfiguredFields
-	GetMinInterval(queryInterval string) (time.Duration, error)
 	ExecuteMultisearch(r *MultiSearchRequest) (*MultiSearchResponse, error)
 	MultiSearch() *MultiSearchRequestBuilder
 }
@@ -85,11 +83,6 @@ type baseClientImpl struct {
 
 func (c *baseClientImpl) GetConfiguredFields() ConfiguredFields {
 	return c.configuredFields
-}
-
-func (c *baseClientImpl) GetMinInterval(queryInterval string) (time.Duration, error) {
-	timeInterval := c.ds.TimeInterval
-	return intervalv2.GetIntervalFrom(queryInterval, timeInterval, 0, 5*time.Second)
 }
 
 type multiRequest struct {

--- a/pkg/tsdb/elasticsearch/client/client.go
+++ b/pkg/tsdb/elasticsearch/client/client.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/tsdb/intervalv2"
 )
 
 type DatasourceInfo struct {
@@ -43,6 +44,7 @@ const loggerName = "tsdb.elasticsearch.client"
 // Client represents a client which can interact with elasticsearch api
 type Client interface {
 	GetConfiguredFields() ConfiguredFields
+	GetMinInterval(queryInterval string) (time.Duration, error)
 	ExecuteMultisearch(r *MultiSearchRequest) (*MultiSearchResponse, error)
 	MultiSearch() *MultiSearchRequestBuilder
 }
@@ -83,6 +85,11 @@ type baseClientImpl struct {
 
 func (c *baseClientImpl) GetConfiguredFields() ConfiguredFields {
 	return c.configuredFields
+}
+
+func (c *baseClientImpl) GetMinInterval(queryInterval string) (time.Duration, error) {
+	timeInterval := c.ds.TimeInterval
+	return intervalv2.GetIntervalFrom(queryInterval, timeInterval, 0, 5*time.Second)
 }
 
 type multiRequest struct {

--- a/pkg/tsdb/elasticsearch/data_query_test.go
+++ b/pkg/tsdb/elasticsearch/data_query_test.go
@@ -561,7 +561,7 @@ func TestExecuteElasticsearchDataQuery(t *testing.T) {
 						"id": "3",
 						"type": "histogram",
 						"field": "bytes",
-						"settings": { "interval": 10, "min_doc_count": 2, "missing": 5 }
+						"settings": { "interval": "10", "min_doc_count": 2, "missing": 5 }
 					}
 				],
 				"metrics": [{"type": "count", "id": "1" }]
@@ -587,7 +587,7 @@ func TestExecuteElasticsearchDataQuery(t *testing.T) {
 						"id": "3",
 						"type": "histogram",
 						"field": "bytes",
-						"settings": { "interval": 10, "min_doc_count": 2 }
+						"settings": { "interval": "10", "min_doc_count": 2 }
 					}
 				],
 				"metrics": [{"type": "count", "id": "1" }]

--- a/pkg/tsdb/elasticsearch/data_query_test.go
+++ b/pkg/tsdb/elasticsearch/data_query_test.go
@@ -1712,10 +1712,6 @@ func (c *fakeClient) GetConfiguredFields() es.ConfiguredFields {
 	return c.configuredFields
 }
 
-func (c *fakeClient) GetMinInterval(queryInterval string) (time.Duration, error) {
-	return 15 * time.Second, nil
-}
-
 func (c *fakeClient) ExecuteMultisearch(r *es.MultiSearchRequest) (*es.MultiSearchResponse, error) {
 	c.multisearchRequests = append(c.multisearchRequests, r)
 	return c.multiSearchResponse, c.multiSearchError

--- a/pkg/tsdb/elasticsearch/data_query_test.go
+++ b/pkg/tsdb/elasticsearch/data_query_test.go
@@ -1712,6 +1712,10 @@ func (c *fakeClient) GetConfiguredFields() es.ConfiguredFields {
 	return c.configuredFields
 }
 
+func (c *fakeClient) GetMinInterval(queryInterval string) (time.Duration, error) {
+	return 15 * time.Second, nil
+}
+
 func (c *fakeClient) ExecuteMultisearch(r *es.MultiSearchRequest) (*es.MultiSearchResponse, error) {
 	c.multisearchRequests = append(c.multisearchRequests, r)
 	return c.multiSearchResponse, c.multiSearchError


### PR DESCRIPTION
This PR fixes parsing of `interval` value for `histogram` queries. The issue was that `interval` is sent from frontend as `string` and not as `int`. This PR fixes it. 

As you can see here interval is sent as `string`.

<img width="1917" alt="image" src="https://user-images.githubusercontent.com/30407135/226970087-88823049-4851-41ad-a51a-b5871ae49e19.png">

To test this:

- With feature toggle `elasticsearchBackendMigration=true` run `make devenv sources=elastic`
- Open Explore and run `histogram` query with changed `interval`
- Use debugger to look into what `interval` in query was used 