### PR TITLE
Elasticsearch: Remove GetMinInterval method that is not used anymore

### DIFF
--- a/pkg/tsdb/elasticsearch/client/client.go
+++ b/pkg/tsdb/elasticsearch/client/client.go
@@ -16,7 +16,6 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 
 	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/tsdb/intervalv2"
 )
 
 type DatasourceInfo struct {
@@ -44,7 +43,6 @@ const loggerName = "tsdb.elasticsearch.client"
 // Client represents a client which can interact with elasticsearch api
 type Client interface {
 	GetConfiguredFields() ConfiguredFields
-	GetMinInterval(queryInterval string) (time.Duration, error)
 	ExecuteMultisearch(r *MultiSearchRequest) (*MultiSearchResponse, error)
 	MultiSearch() *MultiSearchRequestBuilder
 }
@@ -85,11 +83,6 @@ type baseClientImpl struct {
 
 func (c *baseClientImpl) GetConfiguredFields() ConfiguredFields {
 	return c.configuredFields
-}
-
-func (c *baseClientImpl) GetMinInterval(queryInterval string) (time.Duration, error) {
-	timeInterval := c.ds.TimeInterval
-	return intervalv2.GetIntervalFrom(queryInterval, timeInterval, 0, 5*time.Second)
 }
 
 type multiRequest struct {

--- a/pkg/tsdb/elasticsearch/data_query_test.go
+++ b/pkg/tsdb/elasticsearch/data_query_test.go
@@ -1712,10 +1712,6 @@ func (c *fakeClient) GetConfiguredFields() es.ConfiguredFields {
 	return c.configuredFields
 }
 
-func (c *fakeClient) GetMinInterval(queryInterval string) (time.Duration, error) {
-	return 15 * time.Second, nil
-}
-
 func (c *fakeClient) ExecuteMultisearch(r *es.MultiSearchRequest) (*es.MultiSearchResponse, error) {
 	c.multisearchRequests = append(c.multisearchRequests, r)
 	return c.multiSearchResponse, c.multiSearchError


### PR DESCRIPTION
This is not used anywhere anymore. We use interval provided from query, so we don't need to calculate minInterval on backend anymore. This was forgotten during https://github.com/grafana/grafana/commit/772e8cbf6005002a8fa0ee3b622976d440700fa9