### PR TITLE
Alerting: Improve showing nextEvaluationDate for rules

### DIFF
--- a/public/app/features/alerting/unified/components/rules/RulesTable.tsx
+++ b/public/app/features/alerting/unified/components/rules/RulesTable.tsx
@@ -1,6 +1,5 @@
 import { css, cx } from '@emotion/css';
-import { isBefore } from 'date-fns';
-import formatDuration from 'date-fns/formatDuration';
+import { isBefore, formatDuration } from 'date-fns';
 import React, { useCallback, useMemo } from 'react';
 
 import {
@@ -128,8 +127,9 @@ function useColumns(showSummaryColumn: boolean, showGroupColumn: boolean, showNe
     const lastEvaluationDate = Date.parse(rule.promRule?.lastEvaluation || '');
     const nextEvaluationDate = addDurationToDate(lastEvaluationDate, intervalDuration);
 
-    //when `nextEvaluationDate` is a past date it means the `lastEvaluationDate` was inaccurate.
-    //in this case we use the interval value to show a more generic estimate. See https://github.com/grafana/grafana/issues/65125
+    //when `nextEvaluationDate` is a past date it means lastEvaluation was more than one evaluation interval ago.
+    //in this case we use the interval value to show a more generic estimate.
+    //See https://github.com/grafana/grafana/issues/65125
     const isPastDate = isBefore(nextEvaluationDate, new Date());
     if (isPastDate) {
       return {

--- a/public/app/features/alerting/unified/components/rules/RulesTable.tsx
+++ b/public/app/features/alerting/unified/components/rules/RulesTable.tsx
@@ -1,4 +1,6 @@
 import { css, cx } from '@emotion/css';
+import { isBefore } from 'date-fns';
+import formatDuration from 'date-fns/formatDuration';
 import React, { useCallback, useMemo } from 'react';
 
 import {
@@ -17,7 +19,6 @@ import { DEFAULT_PER_PAGE_PAGINATION } from '../../../../../core/constants';
 import { useHasRuler } from '../../hooks/useHasRuler';
 import { Annotation } from '../../utils/constants';
 import { isGrafanaRulerRule, isGrafanaRulerRulePaused } from '../../utils/rules';
-import { isNullDate } from '../../utils/time';
 import { DynamicTable, DynamicTableColumnProps, DynamicTableItemProps } from '../DynamicTable';
 import { DynamicTableWithGuidelines } from '../DynamicTableWithGuidelines';
 import { ProvisioningBadge } from '../Provisioning';
@@ -116,21 +117,29 @@ function useColumns(showSummaryColumn: boolean, showGroupColumn: boolean, showNe
   const { hasRuler, rulerRulesLoaded } = useHasRuler();
 
   const calculateNextEvaluationDate = useCallback((rule: CombinedRule) => {
-    const isValidLastEvaluation =
-      rule.promRule?.lastEvaluation &&
-      !isNullDate(rule.promRule.lastEvaluation) &&
-      isValidDate(rule.promRule.lastEvaluation);
+    const isValidLastEvaluation = rule.promRule?.lastEvaluation && isValidDate(rule.promRule.lastEvaluation);
     const isValidIntervalDuration = rule.group.interval && isValidDuration(rule.group.interval);
 
-    if (!isValidLastEvaluation || !isValidIntervalDuration) {
+    if (!isValidLastEvaluation || !isValidIntervalDuration || isGrafanaRulerRulePaused(rule)) {
       return;
     }
 
-    const lastEvaluationDate = Date.parse(rule.promRule?.lastEvaluation || '');
     const intervalDuration = parseDuration(rule.group.interval!);
+    const lastEvaluationDate = Date.parse(rule.promRule?.lastEvaluation || '');
     const nextEvaluationDate = addDurationToDate(lastEvaluationDate, intervalDuration);
+
+    //when `nextEvaluationDate` is a past date it means the `lastEvaluationDate` was inaccurate.
+    //in this case we use the interval value to show a more generic estimate. See https://github.com/grafana/grafana/issues/65125
+    const isPastDate = isBefore(nextEvaluationDate, new Date());
+    if (isPastDate) {
+      return {
+        humanized: `within ${formatDuration(intervalDuration)}`,
+        fullDate: `within ${formatDuration(intervalDuration)}`,
+      };
+    }
+
     return {
-      humanized: dateTime(nextEvaluationDate).locale('en').fromNow(true),
+      humanized: `in ${dateTime(nextEvaluationDate).locale('en').fromNow(true)}`,
       fullDate: dateTimeFormat(nextEvaluationDate, { format: 'YYYY-MM-DD HH:mm:ss' }),
     };
   }, []);
@@ -211,9 +220,9 @@ function useColumns(showSummaryColumn: boolean, showGroupColumn: boolean, showNe
         renderCell: ({ data: rule }) => {
           const nextEvalInfo = calculateNextEvaluationDate(rule);
           return (
-            nextEvalInfo?.fullDate && (
+            nextEvalInfo && (
               <Tooltip placement="top" content={`${nextEvalInfo?.fullDate}`} theme="info">
-                <span>in {nextEvalInfo?.humanized}</span>
+                <span>{nextEvalInfo?.humanized}</span>
               </Tooltip>
             )
           );


### PR DESCRIPTION
**What is this feature?**

In https://github.com/grafana/grafana/pull/64767 we added the **Next evaluation** column to the rules list view which shows the estimated time where the rule will be evaluated in the future. To calculate this value we use the `lastEvaluationDate` and group `interval` which we receive from the API and we add them up.
This PR improves that implementation taking into account of two extra scenarios:
- When the rule hasn't been evaluated yet and the column is empty
- When the rule has been evaluated in the past, missed some next evaluations due to several posible reasons like the server being down, and ending up in a `nextEvaluationDate` that is earlier than the current time. 

To address these two scenarios, when we don't have a defined/accurate `lastEvaluationDate` we make use of the group's `interval` value to show that the rule will be evaluated in a range between now + interval.

This way we reduce the confusion that might be caused by an empty "Next evaluation" column and also make sure not to display invalid past dates.

**Why do we need this feature?**

To address some specific scenarios when the rule's `lastEvaluationDate` is not accurate.

**Who is this feature for?**

All users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/65125

**Special notes for your reviewer:**

![image](https://user-images.githubusercontent.com/6271380/226973692-596226d8-5929-4efd-b92e-3d8e8e625b55.png)