### PR TITLE
Context: add better error message when it panics loading a template

### DIFF
--- a/pkg/web/context.go
+++ b/pkg/web/context.go
@@ -16,6 +16,7 @@ package web
 
 import (
 	"encoding/json"
+	"fmt"
 	"html/template"
 	"net"
 	"net/http"
@@ -103,7 +104,7 @@ func (ctx *Context) HTML(status int, name string, data interface{}) {
 	ctx.Resp.Header().Set(headerContentType, contentTypeHTML)
 	ctx.Resp.WriteHeader(status)
 	if err := ctx.template.ExecuteTemplate(ctx.Resp, name, data); err != nil {
-		panic("Context.HTML:" + err.Error())
+		panic(fmt.Sprintf("Context.HTML - Error rendering template: %s. You may need to build frontend assets \n %s", name, err.Error()))
 	}
 }
 


### PR DESCRIPTION
**What is this feature?**

Adds a better error message to the context when it panics as a result of a template not being available.

**Why do we need this feature?**

The existing error message is cryptic and not obvious.

**Who is this feature for?**

Developers building Grafana