### PR TITLE
Explore: Add click tracking to data links

### DIFF
--- a/public/app/features/explore/utils/links.test.ts
+++ b/public/app/features/explore/utils/links.test.ts
@@ -59,9 +59,7 @@ describe('explore links utils', () => {
       expect(links[0].title).toBe('external');
       expect(links[0].onClick).toBeDefined();
 
-      if (links[0].onClick) {
-        links[0].onClick({});
-      }
+      links[0].onClick!({});
 
       expect(reportInteraction).toBeCalledWith('grafana_data_link_clicked', {
         app: CoreApp.Explore,

--- a/public/app/features/explore/utils/links.test.ts
+++ b/public/app/features/explore/utils/links.test.ts
@@ -1,5 +1,6 @@
 import {
   ArrayVector,
+  CoreApp,
   DataFrame,
   DataLink,
   DataLinkConfigOrigin,
@@ -35,7 +36,7 @@ describe('explore links utils', () => {
         ])
       );
 
-      window.open = jest.fn();
+      jest.spyOn(window, 'open').mockImplementation();
     });
 
     afterEach(() => {
@@ -63,9 +64,9 @@ describe('explore links utils', () => {
       }
 
       expect(reportInteraction).toBeCalledWith('grafana_data_link_clicked', {
-        app: 'explore',
+        app: CoreApp.Explore,
         internal: false,
-        origin: 'Datasource',
+        origin: DataLinkConfigOrigin.Datasource,
       });
     });
 
@@ -131,9 +132,9 @@ describe('explore links utils', () => {
       });
 
       expect(reportInteraction).toBeCalledWith('grafana_data_link_clicked', {
-        app: 'explore',
+        app: CoreApp.Explore,
         internal: true,
-        origin: 'Datasource',
+        origin: DataLinkConfigOrigin.Datasource,
       });
     });
 
@@ -317,9 +318,9 @@ describe('explore links utils', () => {
       }
 
       expect(reportInteraction).toBeCalledWith('grafana_data_link_clicked', {
-        app: 'explore',
+        app: CoreApp.Explore,
         internal: true,
-        origin: 'Correlations',
+        origin: DataLinkConfigOrigin.Correlations,
       });
 
       expect(links[1]).toHaveLength(1);

--- a/public/app/features/explore/utils/links.ts
+++ b/public/app/features/explore/utils/links.ts
@@ -126,7 +126,7 @@ export const getFieldLinksForExplore = (options: {
         const origOnClick = linkModel.onClick;
 
         linkModel.onClick = (...args) => {
-          reportInteraction('grafana_data_link_clicked', {
+          reportInteraction(DATA_LINK_USAGE_KEY, {
             origin: link.origin || DataLinkConfigOrigin.Datasource,
             app: CoreApp.Explore,
             internal: false,

--- a/public/app/features/explore/utils/links.ts
+++ b/public/app/features/explore/utils/links.ts
@@ -122,7 +122,8 @@ export const getFieldLinksForExplore = (options: {
           linkModel.title = getTitleFromHref(linkModel.href);
         }
 
-        // take over the onClick to report the click, then either call the original onClick or navigate to the URL
+        // Take over the onClick to report the click, then either call the original onClick or navigate to the URL
+        // Note: it is likely that an external link that opens in the same tab will not be reported, as the browser redirect might cancel reporting the interaction
         const origOnClick = linkModel.onClick;
 
         linkModel.onClick = (...args) => {


### PR DESCRIPTION
**What is this feature?**

This adds click tracking to all explore data links so we can see how much data links are used within explore. Specifically, we also now track data links created by correlations vs data links created elsewhere, so we can monitor correlations' usage.

**Why do we need this feature?**

We will be introducing the correlations feature soon, which is powerful yet somewhat complicated. We want to monitor adoption and use that data to drive decisions on what to focus on for future releases.

**Which issue(s) does this PR fix?**:

Fixes #64223

**Special notes for your reviewer:**
The previous PR for this was #64720 but it was easier to re-create the branch. The previous PR is tied to the old version of the branch and cannot be reopened.

The reason for the `onClick` logic in `links` is because `DataLinkButton` runs `preventDefault` if an onClick function is added ([src](https://github.com/grafana/grafana/blob/main/packages/grafana-ui/src/components/DataLinks/DataLinkButton.tsx#L25)), meaning the standard`href` link won't function. Normally with external links, there is no `onClick` defined here so the `href` is what makes the link function. We recreate that behavior with an `onClick` function.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
- [ ] There are no known compatibility issues with older supported versions of Grafana, or plugins.
- [ ] It passes the [Hosted Grafana feature readiness review](https://docs.google.com/document/d/1QL9Ly8KnXzpb6ISbg49pTODRO5mhA5tkkfIZVX6pqQU/edit) for observability, scalability, performance, and security.