### PR TITLE
Prometheus: Fix fallback http method when no http method specified in jsonData

### DIFF
--- a/pkg/tsdb/prometheus/resource/resource.go
+++ b/pkg/tsdb/prometheus/resource/resource.go
@@ -30,6 +30,10 @@ func New(
 	}
 	httpMethod, _ := maputil.GetStringOptional(jsonData, "httpMethod")
 
+	if httpMethod == "" {
+		httpMethod = http.MethodPost
+	}
+
 	return &Resource{
 		log:        plog,
 		promClient: client.NewClient(httpClient, httpMethod, settings.URL),


### PR DESCRIPTION
**What is this feature?**

If a provisioned Prometheus datasource has no `httpMethod` defined in `jsonData` the request method fallbacks to `GET`. This causes `414` errors. To prevent this when there is no `httpMethod` defined we fallback to `POST`.
[Add a brief description of what the feature or update does.]

**Why do we need this feature?**

To prevent `414` errors. https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/414

**Who is this feature for?**

Prometheus Users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/support-escalations/issues/5347

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
- [x] There are no known compatibility issues with older supported versions of Grafana, or plugins.
- [x] It passes the [Hosted Grafana feature readiness review](https://docs.google.com/document/d/1QL9Ly8KnXzpb6ISbg49pTODRO5mhA5tkkfIZVX6pqQU/edit) for observability, scalability, performance, and security.