### PR TITLE
Docs: Added note to contact Support

### DIFF
--- a/docs/sources/setup-grafana/configure-security/configure-authentication/enhanced-ldap/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/enhanced-ldap/index.md
@@ -18,7 +18,7 @@ weight: 900
 
 The enhanced LDAP integration adds additional functionality on top of the [LDAP integration]({{< relref "ldap/" >}}) available in the open source edition of Grafana.
 
-> **Note:** Available in [Grafana Enterprise]({{< relref "../../../../introduction/grafana-enterprise/" >}}) and [Grafana Cloud Advanced](/docs/grafana-cloud). If you are a Grafana Cloud customer, please [open a support ticket in the Cloud Portal](https://github.com/profile/org#support) to request this feature.
+> **Note:** Available in [Grafana Enterprise]({{< relref "../../../../introduction/grafana-enterprise/" >}}) and [Grafana Cloud Advanced](/docs/grafana-cloud). If you are a Grafana Cloud customer, please [open a support ticket in the Cloud Portal](https://grafana.com/orgs/$org/tickets) to request this feature.
 
 > To control user access with role-based permissions, refer to [role-based access control]({{< relref "../../../../administration/roles-and-permissions/access-control/" >}}).
 

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/enhanced-ldap/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/enhanced-ldap/index.md
@@ -18,7 +18,8 @@ weight: 900
 
 The enhanced LDAP integration adds additional functionality on top of the [LDAP integration]({{< relref "ldap/" >}}) available in the open source edition of Grafana.
 
-> **Note:** Available in [Grafana Enterprise]({{< relref "../../../../introduction/grafana-enterprise/" >}}) and [Grafana Cloud Advanced](/docs/grafana-cloud). If you are a Grafana Cloud customer, please contact Support to configure this feature.
+> **Note:** Available in [Grafana Enterprise]({{< relref "../../../../introduction/grafana-enterprise/" >}}) and [Grafana Cloud Advanced](/docs/grafana-cloud). If you are a Grafana Cloud customer, please [open a support ticket in the Cloud Portal](https://github.com/profile/org#support) to request this feature.
+
 
 > To control user access with role-based permissions, refer to [role-based access control]({{< relref "../../../../administration/roles-and-permissions/access-control/" >}}).
 

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/enhanced-ldap/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/enhanced-ldap/index.md
@@ -20,7 +20,6 @@ The enhanced LDAP integration adds additional functionality on top of the [LDAP 
 
 > **Note:** Available in [Grafana Enterprise]({{< relref "../../../../introduction/grafana-enterprise/" >}}) and [Grafana Cloud Advanced](/docs/grafana-cloud). If you are a Grafana Cloud customer, please [open a support ticket in the Cloud Portal](https://github.com/profile/org#support) to request this feature.
 
-
 > To control user access with role-based permissions, refer to [role-based access control]({{< relref "../../../../administration/roles-and-permissions/access-control/" >}}).
 
 ## LDAP group synchronization for teams

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/enhanced-ldap/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/enhanced-ldap/index.md
@@ -18,7 +18,7 @@ weight: 900
 
 The enhanced LDAP integration adds additional functionality on top of the [LDAP integration]({{< relref "ldap/" >}}) available in the open source edition of Grafana.
 
-> **Note:** Available in [Grafana Enterprise]({{< relref "../../../../introduction/grafana-enterprise/" >}}) and [Grafana Cloud Advanced](/docs/grafana-cloud). If you are a Grafana Cloud customer, please contact Support to configure this.
+> **Note:** Available in [Grafana Enterprise]({{< relref "../../../../introduction/grafana-enterprise/" >}}) and [Grafana Cloud Advanced](/docs/grafana-cloud). If you are a Grafana Cloud customer, please contact Support to configure this feature.
 
 > To control user access with role-based permissions, refer to [role-based access control]({{< relref "../../../../administration/roles-and-permissions/access-control/" >}}).
 

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/enhanced-ldap/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/enhanced-ldap/index.md
@@ -18,7 +18,7 @@ weight: 900
 
 The enhanced LDAP integration adds additional functionality on top of the [LDAP integration]({{< relref "ldap/" >}}) available in the open source edition of Grafana.
 
-> **Note:** Available in [Grafana Enterprise]({{< relref "../../../../introduction/grafana-enterprise/" >}}) and [Grafana Cloud Advanced](/docs/grafana-cloud).
+> **Note:** Available in [Grafana Enterprise]({{< relref "../../../../introduction/grafana-enterprise/" >}}) and [Grafana Cloud Advanced](/docs/grafana-cloud). If you are a Grafana Cloud customer, please contact Support to configure this.
 
 > To control user access with role-based permissions, refer to [role-based access control]({{< relref "../../../../administration/roles-and-permissions/access-control/" >}}).
 


### PR DESCRIPTION
This PR clarifies for Grafana Cloud customers to contact the Support team to configure enhanced LDAP.