### PR TITLE
CloudWatch Logs: Fix to make log queries use a relative time if available

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/__mocks__/LogsQueryRunner.ts
+++ b/public/app/plugins/datasource/cloudwatch/__mocks__/LogsQueryRunner.ts
@@ -2,11 +2,11 @@ import { of } from 'rxjs';
 
 import { CustomVariableModel, DataFrame, DataSourceInstanceSettings } from '@grafana/data';
 import { BackendDataSourceResponse, getBackendSrv, setBackendSrv } from '@grafana/runtime';
-import { getTimeSrv } from 'app/features/dashboard/services/TimeSrv';
+import { getTimeSrv, TimeSrv } from 'app/features/dashboard/services/TimeSrv';
 import { TemplateSrv } from 'app/features/templating/template_srv';
 
 import { CloudWatchLogsQueryRunner } from '../query-runner/CloudWatchLogsQueryRunner';
-import { CloudWatchJsonData, CloudWatchLogsQueryStatus } from '../types';
+import { CloudWatchJsonData, CloudWatchLogsQueryStatus, CloudWatchLogsRequest } from '../types';
 
 import { CloudWatchSettings, setupMockedTemplateService } from './CloudWatchDataSource';
 
@@ -17,11 +17,13 @@ export function setupMockedLogsQueryRunner({
   variables,
   mockGetVariableName = true,
   settings = CloudWatchSettings,
+  timeSrv = getTimeSrv(),
 }: {
   data?: BackendDataSourceResponse;
   variables?: CustomVariableModel[];
   mockGetVariableName?: boolean;
   settings?: DataSourceInstanceSettings<CloudWatchJsonData>;
+  timeSrv?: TimeSrv;
 } = {}) {
   let templateService = new TemplateSrv();
   if (variables) {
@@ -31,7 +33,7 @@ export function setupMockedLogsQueryRunner({
     }
   }
 
-  const runner = new CloudWatchLogsQueryRunner(settings, templateService, getTimeSrv());
+  const runner = new CloudWatchLogsQueryRunner(settings, templateService, timeSrv);
   const fetchMock = jest.fn().mockReturnValue(of({ data }));
   setBackendSrv({
     ...getBackendSrv(),
@@ -65,4 +67,20 @@ export function genMockFrames(numResponses: number): DataFrame[] {
   }
 
   return mockFrames;
+}
+
+export function genMockCloudWatchLogsRequest(overrides: Partial<CloudWatchLogsRequest> = {}) {
+  const request: CloudWatchLogsRequest = {
+    queryString: 'fields @timestamp, @message | sort @timestamp desc',
+    logGroupNames: ['log-group-name-1', 'log-group-name-2'],
+    logGroups: [
+      { arn: 'log-group-arn-1', name: 'log-group-name-1' },
+      { arn: 'log-group-arn-2', name: 'log-group-name-2' },
+    ],
+    refId: 'A',
+    region: 'us-east-1',
+    ...overrides,
+  };
+
+  return request;
 }

--- a/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchLogsQueryRunner.ts
+++ b/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchLogsQueryRunner.ts
@@ -118,7 +118,7 @@ export class CloudWatchLogsQueryRunner extends CloudWatchRequest {
 
     return runWithRetry(
       (targets: StartQueryRequest[]) => {
-        return this.makeLogActionRequest('StartQuery', targets);
+        return this.makeLogActionRequest('StartQuery', targets, options);
       },
       startQueryRequests,
       timeoutFunc
@@ -269,8 +269,12 @@ export class CloudWatchLogsQueryRunner extends CloudWatchRequest {
     }
   }
 
-  makeLogActionRequest(subtype: LogAction, queryParams: CloudWatchLogsRequest[]): Observable<DataFrame[]> {
-    const range = this.timeSrv.timeRange();
+  makeLogActionRequest(
+    subtype: LogAction,
+    queryParams: CloudWatchLogsRequest[],
+    options?: DataQueryRequest<CloudWatchQuery>
+  ): Observable<DataFrame[]> {
+    const range = options?.range || this.timeSrv.timeRange();
 
     const requestParams = {
       from: range.from.valueOf().toString(),


### PR DESCRIPTION
**What is this fix?**

Uses the query option time range for log queries if that's set.

**Why do we need this fix?**

Fixes an issue where if a relative time is set in the query options it's not used when running a logs query.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #62415

**Special notes for your reviewer:**

Can test this with this query `fields @message | stats count() by bin(5m)` on the "cloudwatch-plugins-logs" log group, set the dashboard time range to `Last 6 hours`, set the `Relative time` in the query options to `now/w` (this just needs to be a longer time period than the dashboard time range). The time series should retrieve all of the data for the week so far.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
- [x] There are no known compatibility issues with older supported versions of Grafana, or plugins.
- [ ] It passes the [Hosted Grafana feature readiness review](https://docs.google.com/document/d/1QL9Ly8KnXzpb6ISbg49pTODRO5mhA5tkkfIZVX6pqQU/edit) for observability, scalability, performance, and security.