### PR TITLE
Alerting: Improve query types usage to prevent ts-errors

### DIFF
--- a/public/app/features/alerting/unified/RuleEditorRecordingRule.test.tsx
+++ b/public/app/features/alerting/unified/RuleEditorRecordingRule.test.tsx
@@ -32,7 +32,7 @@ jest.mock('./components/rule-editor/RecordingRuleEditor', () => ({
         },
       };
 
-      onChangeQuery([merged], expr);
+      onChangeQuery([merged]);
     };
 
     return <input data-testid="expr" onChange={(e) => onChange(e.target.value)} />;

--- a/public/app/features/alerting/unified/RuleEditorRecordingRule.test.tsx
+++ b/public/app/features/alerting/unified/RuleEditorRecordingRule.test.tsx
@@ -32,7 +32,7 @@ jest.mock('./components/rule-editor/RecordingRuleEditor', () => ({
         },
       };
 
-      onChangeQuery([merged]);
+      onChangeQuery([merged], expr);
     };
 
     return <input data-testid="expr" onChange={(e) => onChange(e.target.value)} />;

--- a/public/app/features/alerting/unified/components/rule-editor/ExpressionEditor.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/ExpressionEditor.tsx
@@ -119,7 +119,7 @@ type QueryMappers<T extends DataQuery = DataQuery> = {
   mapToQuery: (existing: T, value: string | undefined) => T;
 };
 
-function useQueryMappers(dataSourceName: string): QueryMappers {
+export function useQueryMappers(dataSourceName: string): QueryMappers {
   return useMemo(() => {
     const settings = getDataSourceSrv().getInstanceSettings(dataSourceName);
 

--- a/public/app/features/alerting/unified/components/rule-editor/RecordingRuleEditor.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/RecordingRuleEditor.tsx
@@ -13,11 +13,12 @@ import { AlertQuery } from 'app/types/unified-alerting-dto';
 import { TABLE, TIMESERIES } from '../../utils/constants';
 import { SupportedPanelPlugins } from '../PanelPluginsButtonGroup';
 
+import { useQueryMappers } from './ExpressionEditor';
 import { VizWrapper } from './VizWrapper';
 
 export interface RecordingRuleEditorProps {
   queries: AlertQuery[];
-  onChangeQuery: (updatedQueries: AlertQuery[]) => void;
+  onChangeQuery: (updatedQueries: AlertQuery[], expression: string) => void;
   runQueries: (queries: AlertQuery[]) => void;
   panelData: Record<string, PanelData>;
   dataSourceName: string;
@@ -54,23 +55,25 @@ export const RecordingRuleEditor: FC<RecordingRuleEditorProps> = ({
     return getDataSourceSrv().get(dataSourceName);
   }, [dataSourceName]);
 
+  const { mapToValue } = useQueryMappers(dataSourceName);
+
   const handleChangedQuery = (changedQuery: DataQuery) => {
     const query = queries[0];
+
+    const expr = mapToValue(changedQuery);
 
     const merged = {
       ...query,
       refId: changedQuery.refId,
       queryType: query.model.queryType ?? '',
-      //@ts-ignore
-      expr: changedQuery?.expr,
+      expr,
       model: {
         refId: changedQuery.refId,
-        //@ts-ignore
-        expr: changedQuery?.expr,
+        expr,
         editorMode: 'code',
       },
     };
-    onChangeQuery([merged]);
+    onChangeQuery([merged], expr);
   };
 
   if (loading || dataSource?.name !== dataSourceName) {

--- a/public/app/features/alerting/unified/components/rule-editor/RecordingRuleEditor.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/RecordingRuleEditor.tsx
@@ -4,7 +4,7 @@ import { useAsync } from 'react-use';
 
 import { PanelData, CoreApp, GrafanaTheme2 } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
-import { LoadingState } from '@grafana/schema';
+import { DataQuery, LoadingState } from '@grafana/schema';
 import { useStyles2 } from '@grafana/ui';
 import { getTimeSrv } from 'app/features/dashboard/services/TimeSrv';
 import { isExpressionQuery } from 'app/features/expressions/guards';
@@ -55,7 +55,7 @@ export const RecordingRuleEditor: FC<RecordingRuleEditorProps> = ({
     return getDataSourceSrv().get(dataSourceName);
   }, [dataSourceName]);
 
-  const handleChangedQuery = (changedQuery: AlertQuery) => {
+  const handleChangedQuery = (changedQuery: DataQuery) => {
     const query = queries[0];
 
     if (!isPromOrLokiQuery(query.model)) {

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
@@ -13,6 +13,7 @@ import { useRulesSourcesWithRuler } from '../../../hooks/useRuleSourcesWithRuler
 import { AlertingQueryRunner } from '../../../state/AlertingQueryRunner';
 import { RuleFormType, RuleFormValues } from '../../../types/rule-form';
 import { getDefaultOrFirstCompatibleDataSource } from '../../../utils/datasource';
+import { isPromOrLokiQuery } from '../../../utils/rule-form';
 import { ExpressionEditor } from '../ExpressionEditor';
 import { ExpressionsEditor } from '../ExpressionsEditor';
 import { QueryEditor } from '../QueryEditor';
@@ -169,11 +170,19 @@ export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange }: P
   );
 
   const onChangeRecordingRulesQueries = useCallback(
-    (updatedQueries: AlertQuery[], expression: string) => {
-      const dataSourceSettings = getDataSourceSrv().getInstanceSettings(updatedQueries[0].datasourceUid);
+    (updatedQueries: AlertQuery[]) => {
+      const query = updatedQueries[0];
+
+      const dataSourceSettings = getDataSourceSrv().getInstanceSettings(query.datasourceUid);
       if (!dataSourceSettings) {
         throw new Error('The Data source has not been defined.');
       }
+
+      if (!isPromOrLokiQuery(query.model)) {
+        return;
+      }
+
+      const expression = query.model.expr;
 
       setValue('dataSourceName', dataSourceSettings.name);
       setValue('expression', expression);

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
@@ -169,13 +169,11 @@ export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange }: P
   );
 
   const onChangeRecordingRulesQueries = useCallback(
-    (updatedQueries) => {
+    (updatedQueries: AlertQuery[], expression: string) => {
       const dataSourceSettings = getDataSourceSrv().getInstanceSettings(updatedQueries[0].datasourceUid);
       if (!dataSourceSettings) {
         throw new Error('The Data source has not been defined.');
       }
-
-      const expression = updatedQueries[0].model?.expr || '';
 
       setValue('dataSourceName', dataSourceSettings.name);
       setValue('expression', expression);

--- a/public/app/features/alerting/unified/utils/rule-form.ts
+++ b/public/app/features/alerting/unified/utils/rule-form.ts
@@ -15,6 +15,7 @@ import { DataSourceJsonData } from '@grafana/schema';
 import { getNextRefIdChar } from 'app/core/utils/query';
 import { DashboardModel, PanelModel } from 'app/features/dashboard/state';
 import { ExpressionQuery, ExpressionQueryType, ExpressionDatasourceUID } from 'app/features/expressions/types';
+import { LokiQuery } from 'app/plugins/datasource/loki/types';
 import { PromQuery } from 'app/plugins/datasource/prometheus/types';
 import { RuleWithLocation } from 'app/types/unified-alerting';
 import {
@@ -39,6 +40,8 @@ import { getDefaultOrFirstCompatibleDataSource, isGrafanaRulesSource } from './d
 import { arrayToRecord, recordToArray } from './misc';
 import { isAlertingRulerRule, isGrafanaRulerRule, isRecordingRulerRule } from './rules';
 import { parseInterval } from './time';
+
+export type PromOrLokiQuery = PromQuery | LokiQuery;
 
 export const getDefaultFormValues = (): RuleFormValues => {
   const { canCreateGrafanaRules, canCreateCloudRules } = getRulesAccess();
@@ -475,4 +478,8 @@ export function fixBothInstantAndRangeQuery(query: AlertQuery) {
 
 function isPromQuery(model: AlertDataQuery): model is PromQuery {
   return 'expr' in model && 'instant' in model && 'range' in model;
+}
+
+export function isPromOrLokiQuery(model: AlertDataQuery): model is PromOrLokiQuery {
+  return 'expr' in model;
 }


### PR DESCRIPTION
**What is this feature?**

Removes the usage of `ts-ignore` when accessing the `expr` property for recording rules queries after https://github.com/grafana/grafana/pull/63260. Instead of that, proper types are assigned where needed.

**Why do we need this feature?**

To improve code quality.


