### PR TITLE
Create ca cert, authnz client certs and apiserver cert in go in a separate service

### DIFF
--- a/pkg/modules/dependencies.go
+++ b/pkg/modules/dependencies.go
@@ -3,6 +3,8 @@ package modules
 const (
 	All string = "all"
 
+	CertGenerator string = "cert-generator"
+
 	HTTPServer string = "http-server"
 
 	Kine                string = "kine"
@@ -18,10 +20,12 @@ const (
 )
 
 var DependencyMap = map[string][]string{
-	HTTPServer: {KubernetesAPIServer},
+	CertGenerator: {},
+
+	HTTPServer: {CertGenerator},
 
 	Kine:                {},
-	KubernetesAPIServer: {Kine},
+	KubernetesAPIServer: {CertGenerator, Kine},
 	KubernetesClientset: {KubernetesAPIServer},
 	KubernetesCRDs:      {KubernetesClientset},
 	KubernetesInformers: {KubernetesCRDs},

--- a/pkg/modules/registry/registry.go
+++ b/pkg/modules/registry/registry.go
@@ -6,6 +6,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/modules"
 	"github.com/grafana/grafana/pkg/registry/corecrd"
+	"github.com/grafana/grafana/pkg/services/certgenerator"
 	"github.com/grafana/grafana/pkg/services/k8s/apiserver"
 	"github.com/grafana/grafana/pkg/services/k8s/client"
 	"github.com/grafana/grafana/pkg/services/k8s/informer"
@@ -23,6 +24,7 @@ type registry struct {
 func ProvideRegistry(
 	moduleManager modules.Manager,
 	apiServer apiserver.Service,
+	certGenerator certgenerator.Service,
 	crdRegistry *corecrd.Registry,
 	kineService kine.Service,
 	informerService informer.Service,
@@ -34,6 +36,7 @@ func ProvideRegistry(
 	return NewRegistry(
 		moduleManager,
 		apiServer,
+		certGenerator,
 		crdRegistry,
 		kineService,
 		informerService,

--- a/pkg/server/wire.go
+++ b/pkg/server/wire.go
@@ -42,6 +42,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/apikey/apikeyimpl"
 	"github.com/grafana/grafana/pkg/services/auth/jwt"
 	"github.com/grafana/grafana/pkg/services/authn/authnimpl"
+	"github.com/grafana/grafana/pkg/services/certgenerator"
 	"github.com/grafana/grafana/pkg/services/cleanup"
 	"github.com/grafana/grafana/pkg/services/contexthandler"
 	"github.com/grafana/grafana/pkg/services/contexthandler/authproxy"
@@ -205,6 +206,7 @@ var wireBasicSet = wire.NewSet(
 	wire.Bind(new(httpclient.Provider), new(*sdkhttpclient.Provider)),
 	serverlock.ProvideService,
 	annotationsimpl.ProvideCleanupService,
+	certgenerator.WireSet,
 	wire.Bind(new(annotations.Cleaner), new(*annotationsimpl.CleanupServiceImpl)),
 	cleanup.ProvideService,
 	shorturlimpl.ProvideService,

--- a/pkg/services/certgenerator/certutil.go
+++ b/pkg/services/certgenerator/certutil.go
@@ -1,0 +1,278 @@
+package certgenerator
+
+import (
+	"bytes"
+	cryptorand "crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"math/big"
+	"os"
+	"time"
+
+	certutil "k8s.io/client-go/util/cert"
+	"k8s.io/client-go/util/keyutil"
+	"k8s.io/kubernetes/pkg/controlplane"
+	netutils "k8s.io/utils/net"
+	"net"
+	"strings"
+)
+
+type CertUtil struct {
+	K8sDataPath string
+	caKey       *rsa.PrivateKey
+	caCert      *x509.Certificate
+}
+
+func (cu *CertUtil) CACertFile() string {
+	return strings.Join([]string{cu.K8sDataPath, "ca.crt"}, "/")
+}
+
+func (cu *CertUtil) CAKeyFile() string {
+	return strings.Join([]string{cu.K8sDataPath, "ca.key"}, "/")
+}
+
+func (cu *CertUtil) APIServerCertFile() string {
+	return strings.Join([]string{cu.K8sDataPath, "apiserver.crt"}, "/")
+}
+
+func (cu *CertUtil) APIServerKeyFile() string {
+	return strings.Join([]string{cu.K8sDataPath, "apiserver.key"}, "/")
+}
+
+// Lifted from kube-apiserver package as it's a dependency of external cert generation
+// https://github.com/kubernetes/kubernetes/blob/master/cmd/kube-apiserver/app/server.go#L671
+func getServiceIPAndRanges(serviceClusterIPRanges string) (net.IP, net.IPNet, net.IPNet, error) {
+	serviceClusterIPRangeList := make([]string, 0)
+	if serviceClusterIPRanges != "" {
+		serviceClusterIPRangeList = strings.Split(serviceClusterIPRanges, ",")
+	}
+
+	var apiServerServiceIP net.IP
+	var primaryServiceIPRange net.IPNet
+	var secondaryServiceIPRange net.IPNet
+	var err error
+	// nothing provided by user, use default range (only applies to the Primary)
+	if len(serviceClusterIPRangeList) == 0 {
+		var primaryServiceClusterCIDR net.IPNet
+		primaryServiceIPRange, apiServerServiceIP, err = controlplane.ServiceIPRange(primaryServiceClusterCIDR)
+		if err != nil {
+			return net.IP{}, net.IPNet{}, net.IPNet{}, fmt.Errorf("error determining service IP ranges: %v", err)
+		}
+		return apiServerServiceIP, primaryServiceIPRange, net.IPNet{}, nil
+	}
+
+	_, primaryServiceClusterCIDR, err := netutils.ParseCIDRSloppy(serviceClusterIPRangeList[0])
+	if err != nil {
+		return net.IP{}, net.IPNet{}, net.IPNet{}, fmt.Errorf("service-cluster-ip-range[0] is not a valid cidr")
+	}
+
+	primaryServiceIPRange, apiServerServiceIP, err = controlplane.ServiceIPRange(*primaryServiceClusterCIDR)
+	if err != nil {
+		return net.IP{}, net.IPNet{}, net.IPNet{}, fmt.Errorf("error determining service IP ranges for primary service cidr: %v", err)
+	}
+
+	// user provided at least two entries
+	// note: validation asserts that the list is max of two dual stack entries
+	if len(serviceClusterIPRangeList) > 1 {
+		_, secondaryServiceClusterCIDR, err := netutils.ParseCIDRSloppy(serviceClusterIPRangeList[1])
+		if err != nil {
+			return net.IP{}, net.IPNet{}, net.IPNet{}, fmt.Errorf("service-cluster-ip-range[1] is not an ip net")
+		}
+		secondaryServiceIPRange = *secondaryServiceClusterCIDR
+	}
+	return apiServerServiceIP, primaryServiceIPRange, secondaryServiceIPRange, nil
+}
+
+func loadExistingCertPKI(certPath string, keyPath string) (*x509.Certificate, *rsa.PrivateKey, error) {
+	caCertPemBlocks, err := os.ReadFile(certPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error reading existing Cert: %s", err.Error())
+	}
+
+	caKeyPemBytes, err := os.ReadFile(keyPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error reading existing Key: %s", err.Error())
+	}
+
+	certBlock, _ := pem.Decode(caCertPemBlocks)
+
+	caCert, err := x509.ParseCertificate(certBlock.Bytes)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error parsing existing Cert: %s", err.Error())
+	}
+
+	keyBlock, _ := pem.Decode(caKeyPemBytes)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error parsing existing Key into pem: %s", err.Error())
+	}
+
+	caKey, err := x509.ParsePKCS1PrivateKey(keyBlock.Bytes)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error parsing existing Key from pem: %s", err.Error())
+	}
+
+	caKey.PublicKey = *(caCert.PublicKey.(*rsa.PublicKey))
+
+	return caCert, caKey, nil
+}
+
+func createNewCACertPKI() (*x509.Certificate, *rsa.PrivateKey, error) {
+	caKey, err := rsa.GenerateKey(cryptorand.Reader, 2048)
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	caCert, err := certutil.NewSelfSignedCACert(certutil.Config{
+		CommonName:   "embedded-apiserver-ca",
+		Organization: []string{"Grafana Labs"},
+		AltNames: certutil.AltNames{
+			DNSNames: []string{"Grafana Embedded API Server CA"},
+		},
+	}, caKey)
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return caCert, caKey, nil
+}
+
+func persistCertKeyPairToDisk(cert *x509.Certificate, certPath string, key *rsa.PrivateKey, keyPath string, caCerts ...*x509.Certificate) error {
+	keyBuffer := bytes.Buffer{}
+	if err := pem.Encode(&keyBuffer, &pem.Block{Type: keyutil.RSAPrivateKeyBlockType, Bytes: x509.MarshalPKCS1PrivateKey(key)}); err != nil {
+		return err
+	}
+
+	// Generate cert optionally followed by a CA cert
+	certBuffer := bytes.Buffer{}
+	if err := pem.Encode(&certBuffer, &pem.Block{Type: certutil.CertificateBlockType, Bytes: cert.Raw}); err != nil {
+		return err
+	}
+	for _, caCert := range caCerts {
+		if err := pem.Encode(&certBuffer, &pem.Block{Type: certutil.CertificateBlockType, Bytes: caCert.Raw}); err != nil {
+			return err
+		}
+	}
+
+	err := certutil.WriteCert(certPath, certBuffer.Bytes())
+	if err != nil {
+		return fmt.Errorf("error persisting CA Cert: %s", err.Error())
+	}
+	err = keyutil.WriteKey(keyPath, keyBuffer.Bytes())
+	if err != nil {
+		return fmt.Errorf("error persisting CA Key: %s", err.Error())
+	}
+
+	return nil
+}
+
+func (cu *CertUtil) InitializeCACertPKI() error {
+	exists, err := certutil.CanReadCertAndKey(cu.CACertFile(), cu.CAKeyFile())
+
+	if err != nil {
+		return fmt.Errorf("error reading existing CA PKI: %s", err.Error())
+	}
+
+	if exists {
+		cu.caCert, cu.caKey, err = loadExistingCertPKI(cu.CACertFile(), cu.CAKeyFile())
+	} else {
+		cu.caCert, cu.caKey, err = createNewCACertPKI()
+	}
+
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		return persistCertKeyPairToDisk(cu.caCert, cu.CACertFile(), cu.caKey, cu.CAKeyFile())
+	}
+
+	return nil
+}
+
+func verifyServerCertChain(cert *x509.Certificate, caCert *x509.Certificate) error {
+	roots := x509.NewCertPool()
+	roots.AddCert(caCert)
+
+	chain, err := cert.Verify(x509.VerifyOptions{
+		Roots: roots,
+	})
+
+	if len(chain) == 0 {
+		err = errors.New("Could not determine the chain from CA certificate.")
+	}
+
+	if err != nil {
+		return fmt.Errorf("error verifiing existing API server cert for a sanity check: %s "+
+			"Did you delete the original CA cert used for issuing it? "+
+			"Try reseting your PKI to resolve this problem", err.Error())
+	}
+
+	return nil
+}
+
+func (cu *CertUtil) UpsertApiServerPKI(advertiseAddress string, alternateIP net.IP) error {
+	exists, err := certutil.CanReadCertAndKey(cu.APIServerCertFile(), cu.APIServerCertFile())
+
+	if err != nil {
+		return fmt.Errorf("error reading existing CA PKI: %s", err.Error())
+	}
+
+	if exists {
+		// Let's verify that the existing cert in fact verifies against existing CA chain
+		cert, _, err := loadExistingCertPKI(cu.APIServerCertFile(), cu.APIServerKeyFile())
+		if err != nil {
+			return err
+		}
+		return verifyServerCertChain(cert, cu.caCert)
+	}
+
+	validFrom := time.Now().Add(-time.Hour) // valid an hour earlier to avoid flakes due to clock skew
+	maxAge := time.Hour * 24 * 365          // one year self-signed certs
+	alternateIPs := []net.IP{alternateIP}
+	alternateDNS := []string{"kubernetes.default.svc", "kubernetes.default", "kubernetes"}
+
+	priv, err := rsa.GenerateKey(cryptorand.Reader, 2048)
+	if err != nil {
+		return err
+	}
+
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject: pkix.Name{
+			CommonName: fmt.Sprintf("%s@%d", advertiseAddress, time.Now().Unix()),
+		},
+		NotBefore: validFrom,
+		NotAfter:  validFrom.Add(maxAge),
+
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+
+	if ip := netutils.ParseIPSloppy(advertiseAddress); ip != nil {
+		template.IPAddresses = append(template.IPAddresses, ip)
+	} else {
+		template.DNSNames = append(template.DNSNames, advertiseAddress)
+	}
+
+	template.IPAddresses = append(template.IPAddresses, alternateIPs...)
+	template.DNSNames = append(template.DNSNames, alternateDNS...)
+
+	certDerBytes, err := x509.CreateCertificate(cryptorand.Reader, &template, cu.caCert, &priv.PublicKey, cu.caKey)
+	if err != nil {
+		return err
+	}
+
+	cert, err := x509.ParseCertificate(certDerBytes)
+	if err != nil {
+		return err
+	}
+
+	return persistCertKeyPairToDisk(cert, cu.APIServerCertFile(), priv, cu.APIServerKeyFile(), cu.caCert)
+}

--- a/pkg/services/certgenerator/certutil.go
+++ b/pkg/services/certgenerator/certutil.go
@@ -11,6 +11,8 @@ import (
 	"fmt"
 	"math/big"
 	"os"
+	"path/filepath"
+	"strings"
 	"time"
 
 	certutil "k8s.io/client-go/util/cert"
@@ -18,7 +20,6 @@ import (
 	"k8s.io/kubernetes/pkg/controlplane"
 	netutils "k8s.io/utils/net"
 	"net"
-	"strings"
 )
 
 const (
@@ -39,31 +40,31 @@ func (cu *CertUtil) CACertFile() string {
 }
 
 func (cu *CertUtil) CAKeyFile() string {
-	return strings.Join([]string{cu.K8sDataPath, "ca.key"}, "/")
+	return filepath.Join(cu.K8sDataPath, "ca.key")
 }
 
 func (cu *CertUtil) APIServerCertFile() string {
-	return strings.Join([]string{cu.K8sDataPath, "apiserver.crt"}, "/")
+	return filepath.Join(cu.K8sDataPath, "apiserver.crt")
 }
 
 func (cu *CertUtil) APIServerKeyFile() string {
-	return strings.Join([]string{cu.K8sDataPath, "apiserver.key"}, "/")
+	return filepath.Join(cu.K8sDataPath, "apiserver.key")
 }
 
 func (cu *CertUtil) K8sAuthnClientCertFile() string {
-	return strings.Join([]string{cu.K8sDataPath, "embedded-k8s-authn-plugin.crt"}, "/")
+	return filepath.Join(cu.K8sDataPath, "embedded-k8s-authn-plugin.crt")
 }
 
 func (cu *CertUtil) K8sAuthnClientKeyFile() string {
-	return strings.Join([]string{cu.K8sDataPath, "embedded-k8s-authn-plugin.key"}, "/")
+	return filepath.Join(cu.K8sDataPath, "embedded-k8s-authn-plugin.key")
 }
 
 func (cu *CertUtil) K8sAuthzClientCertFile() string {
-	return strings.Join([]string{cu.K8sDataPath, "embedded-k8s-authz-plugin.crt"}, "/")
+	return filepath.Join(cu.K8sDataPath, "embedded-k8s-authz-plugin.crt")
 }
 
 func (cu *CertUtil) K8sAuthzClientKeyFile() string {
-	return strings.Join([]string{cu.K8sDataPath, "embedded-k8s-authz-plugin.key"}, "/")
+	return filepath.Join(cu.K8sDataPath, "embedded-k8s-authz-plugin.key")
 }
 
 // Lifted from kube-apiserver package as it's a dependency of external cert generation

--- a/pkg/services/certgenerator/certutil.go
+++ b/pkg/services/certgenerator/certutil.go
@@ -22,6 +22,7 @@ import (
 )
 
 const (
+	// The CA gets made using a helper in cert package provided in client-go. As such, it picks 0 for the CA serial - hence starting at 1 here.
 	ApiServerCertSerial = iota + 1
 	AuthnClientCertSerial
 	AuthzClientCertSerial

--- a/pkg/services/certgenerator/certutil.go
+++ b/pkg/services/certgenerator/certutil.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -19,7 +20,6 @@ import (
 	"k8s.io/client-go/util/keyutil"
 	"k8s.io/kubernetes/pkg/controlplane"
 	netutils "k8s.io/utils/net"
-	"net"
 )
 
 const (
@@ -117,12 +117,12 @@ func getServiceIPAndRanges(serviceClusterIPRanges string) (net.IP, net.IPNet, ne
 }
 
 func loadExistingCertPKI(certPath string, keyPath string) (*x509.Certificate, *rsa.PrivateKey, error) {
-	caCertPemBlocks, err := os.ReadFile(certPath)
+	caCertPemBlocks, err := os.ReadFile(filepath.Clean(certPath))
 	if err != nil {
 		return nil, nil, fmt.Errorf("error reading existing Cert: %s", err.Error())
 	}
 
-	caKeyPemBytes, err := os.ReadFile(keyPath)
+	caKeyPemBytes, err := os.ReadFile(filepath.Clean(keyPath))
 	if err != nil {
 		return nil, nil, fmt.Errorf("error reading existing Key: %s", err.Error())
 	}
@@ -235,7 +235,7 @@ func verifyCertChain(cert *x509.Certificate, caCert *x509.Certificate, keyUsages
 	})
 
 	if len(chain) == 0 {
-		err = errors.New("Could not determine the chain from CA certificate.")
+		err = errors.New("could not determine the chain from CA certificate")
 	}
 
 	if err != nil {

--- a/pkg/services/certgenerator/certutil.go
+++ b/pkg/services/certgenerator/certutil.go
@@ -34,7 +34,7 @@ type CertUtil struct {
 }
 
 func (cu *CertUtil) CACertFile() string {
-	return strings.Join([]string{cu.K8sDataPath, "ca.crt"}, "/")
+	return filepath.Join(cu.K8sDataPath, "ca.crt")
 }
 
 func (cu *CertUtil) CAKeyFile() string {

--- a/pkg/services/certgenerator/certutil.go
+++ b/pkg/services/certgenerator/certutil.go
@@ -29,6 +29,11 @@ const (
 	AuthzClientCertSerial
 )
 
+const (
+	CannotVerifyErrorMessageFragment = "This is usually caused by only half of the keypair left behind on disk." +
+		"Try clearing the certs and retry"
+)
+
 type CertUtil struct {
 	K8sDataPath string
 	caKey       *rsa.PrivateKey
@@ -201,7 +206,8 @@ func (cu *CertUtil) InitializeCACertPKI() error {
 	exists, err := certutil.CanReadCertAndKey(cu.CACertFile(), cu.CAKeyFile())
 
 	if err != nil {
-		return fmt.Errorf("error reading existing CA PKI: %s", err.Error())
+		return fmt.Errorf("error reading existing CA PKI: %s"+
+			CannotVerifyErrorMessageFragment, err.Error())
 	}
 
 	if exists {
@@ -245,7 +251,8 @@ func (cu *CertUtil) EnsureApiServerPKI(advertiseAddress string, alternateIP net.
 	exists, err := certutil.CanReadCertAndKey(cu.APIServerCertFile(), cu.APIServerCertFile())
 
 	if err != nil {
-		return fmt.Errorf("error reading existing CA PKI: %s", err.Error())
+		return fmt.Errorf("error reading existing CA PKI: %s"+
+			CannotVerifyErrorMessageFragment, err.Error())
 	}
 
 	if exists {
@@ -341,7 +348,8 @@ func (cu *CertUtil) EnsureAuthzClientPKI() error {
 	exists, err := certutil.CanReadCertAndKey(cu.K8sAuthzClientCertFile(), cu.K8sAuthzClientKeyFile())
 
 	if err != nil {
-		return fmt.Errorf("error reading existing authz client PKI: %s", err.Error())
+		return fmt.Errorf("error reading existing authz client PKI: %s"+
+			CannotVerifyErrorMessageFragment, err.Error())
 	}
 
 	if exists {
@@ -365,7 +373,8 @@ func (cu *CertUtil) EnsureAuthnClientPKI() error {
 	exists, err := certutil.CanReadCertAndKey(cu.K8sAuthnClientCertFile(), cu.K8sAuthnClientKeyFile())
 
 	if err != nil {
-		return fmt.Errorf("error reading existing authn client PKI: %s", err.Error())
+		return fmt.Errorf("error reading existing authn client PKI. %s"+
+			CannotVerifyErrorMessageFragment, err.Error())
 	}
 
 	if exists {

--- a/pkg/services/certgenerator/certutil.go
+++ b/pkg/services/certgenerator/certutil.go
@@ -212,7 +212,7 @@ func verifyServerCertChain(cert *x509.Certificate, caCert *x509.Certificate) err
 	return nil
 }
 
-func (cu *CertUtil) UpsertApiServerPKI(advertiseAddress string, alternateIP net.IP) error {
+func (cu *CertUtil) EnsureApiServerPKI(advertiseAddress string, alternateIP net.IP) error {
 	exists, err := certutil.CanReadCertAndKey(cu.APIServerCertFile(), cu.APIServerCertFile())
 
 	if err != nil {

--- a/pkg/services/certgenerator/certutil.go
+++ b/pkg/services/certgenerator/certutil.go
@@ -180,19 +180,15 @@ func (cu *CertUtil) InitializeCACertPKI() error {
 
 	if exists {
 		cu.caCert, cu.caKey, err = loadExistingCertPKI(cu.CACertFile(), cu.CAKeyFile())
+		return err
 	} else {
 		cu.caCert, cu.caKey, err = createNewCACertPKI()
-	}
+		if err != nil {
+			return err
+		}
 
-	if err != nil {
-		return err
-	}
-
-	if !exists {
 		return persistCertKeyPairToDisk(cu.caCert, cu.CACertFile(), cu.caKey, cu.CAKeyFile())
 	}
-
-	return nil
 }
 
 func verifyServerCertChain(cert *x509.Certificate, caCert *x509.Certificate) error {

--- a/pkg/services/certgenerator/service.go
+++ b/pkg/services/certgenerator/service.go
@@ -59,7 +59,19 @@ func (s *service) up(ctx context.Context) error {
 
 	err = s.certUtil.EnsureApiServerPKI(DefaultAPIServerIp, apiServerServiceIP)
 	if err != nil {
-		s.Log.Error("error initializing API Server cert", "error", err)
+		s.Log.Error("error ensuring API Server PKI", "error", err)
+		return err
+	}
+
+	err = s.certUtil.EnsureAuthzClientPKI()
+	if err != nil {
+		s.Log.Error("error ensuring K8s Authz Client PKI", "error", err)
+		return err
+	}
+
+	err = s.certUtil.EnsureAuthnClientPKI()
+	if err != nil {
+		s.Log.Error("error ensuring K8s Authn Client PKI", "error", err)
 		return err
 	}
 

--- a/pkg/services/certgenerator/service.go
+++ b/pkg/services/certgenerator/service.go
@@ -2,12 +2,13 @@ package certgenerator
 
 import (
 	"context"
+	"path/filepath"
+
 	"github.com/grafana/dskit/services"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/modules"
 	"github.com/grafana/grafana/pkg/setting"
 	kubeoptions "k8s.io/kubernetes/pkg/kubeapiserver/options"
-	"path/filepath"
 )
 
 const (

--- a/pkg/services/certgenerator/service.go
+++ b/pkg/services/certgenerator/service.go
@@ -57,7 +57,7 @@ func (s *service) up(ctx context.Context) error {
 		return nil
 	}
 
-	err = s.certUtil.UpsertApiServerPKI(DefaultAPIServerIp, apiServerServiceIP)
+	err = s.certUtil.EnsureApiServerPKI(DefaultAPIServerIp, apiServerServiceIP)
 	if err != nil {
 		s.Log.Error("error initializing API Server cert", "error", err)
 		return err

--- a/pkg/services/certgenerator/service.go
+++ b/pkg/services/certgenerator/service.go
@@ -7,7 +7,7 @@ import (
 	"github.com/grafana/grafana/pkg/modules"
 	"github.com/grafana/grafana/pkg/setting"
 	kubeoptions "k8s.io/kubernetes/pkg/kubeapiserver/options"
-	"strings"
+	"path/filepath"
 )
 
 const (

--- a/pkg/services/certgenerator/service.go
+++ b/pkg/services/certgenerator/service.go
@@ -31,7 +31,7 @@ type service struct {
 
 func ProvideService(cfg *setting.Cfg) (*service, error) {
 	certUtil := &CertUtil{
-		K8sDataPath: strings.Join([]string{cfg.DataPath, "k8s"}, "/"),
+		K8sDataPath: filepath.Join(cfg.DataPath, "k8s"),
 	}
 
 	s := &service{

--- a/pkg/services/certgenerator/wire.go
+++ b/pkg/services/certgenerator/wire.go
@@ -1,0 +1,8 @@
+package certgenerator
+
+import "github.com/google/wire"
+
+var WireSet = wire.NewSet(
+	ProvideService,
+	wire.Bind(new(Service), new(*service)),
+)

--- a/pkg/services/k8s/apiserver/service.go
+++ b/pkg/services/k8s/apiserver/service.go
@@ -2,25 +2,25 @@ package apiserver
 
 import (
 	"context"
-	"net"
-	"path"
-
 	"github.com/go-logr/logr"
 	"github.com/grafana/dskit/services"
 	"github.com/grafana/grafana/pkg/modules"
+	"github.com/grafana/grafana/pkg/services/certgenerator"
 	"github.com/grafana/grafana/pkg/services/k8s/kine"
 	"github.com/grafana/grafana/pkg/setting"
+	serveroptions "k8s.io/apiserver/pkg/server/options"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/cmd/kube-apiserver/app"
 	"k8s.io/kubernetes/cmd/kube-apiserver/app/options"
+	"net"
+	"path"
 )
 
 const (
-	DEFAULT_IP   = "127.0.0.1"
-	DEFAULT_HOST = "https://" + DEFAULT_IP + ":6443"
+	DefaultAPIServerHost = "https://" + certgenerator.DefaultAPIServerIp + ":6443"
 )
 
 var (
@@ -64,10 +64,20 @@ func (s *service) GetRestConfig() *rest.Config {
 }
 
 func (s *service) start(ctx context.Context) error {
+	// Get the util to get the paths to pre-generated certs
+	certUtil := certgenerator.CertUtil{
+		K8sDataPath: s.dataPath,
+	}
+
 	serverRunOptions := options.NewServerRunOptions()
-	serverRunOptions.SecureServing.BindAddress = net.ParseIP(DEFAULT_IP)
-	serverRunOptions.SecureServing.ServerCert.CertDirectory = s.dataPath
-	serverRunOptions.Authentication.ServiceAccounts.Issuers = []string{DEFAULT_HOST}
+	serverRunOptions.SecureServing.BindAddress = net.ParseIP(certgenerator.DefaultAPIServerIp)
+
+	serverRunOptions.SecureServing.ServerCert.CertKey = serveroptions.CertKey{
+		CertFile: certUtil.APIServerCertFile(),
+		KeyFile:  certUtil.APIServerKeyFile(),
+	}
+
+	serverRunOptions.Authentication.ServiceAccounts.Issuers = []string{DefaultAPIServerHost}
 	etcdConfig := s.etcdProvider.GetConfig()
 	serverRunOptions.Etcd.StorageConfig.Transport.ServerList = etcdConfig.Endpoints
 	serverRunOptions.Etcd.StorageConfig.Transport.CertFile = etcdConfig.TLSConfig.CertFile
@@ -89,7 +99,7 @@ func (s *service) start(ctx context.Context) error {
 	}
 
 	s.restConfig = server.GenericAPIServer.LoopbackClientConfig
-	s.restConfig.Host = DEFAULT_HOST
+	s.restConfig.Host = DefaultAPIServerHost
 	err = s.writeKubeConfiguration(s.restConfig)
 	if err != nil {
 		return err


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Adds a new service for cert generation. 

- [x] Ensure it reads existing certs from disk instead of always regenerating

**Why do we need this feature?**

Now that we are running HTTP Server with TLS support on port 2999, but will also be needing this for kube api-server and kube authnz webhooks, the cert generator will be the one-shot place to capture this configuration for development purposes. In future, the components themselves that require such certs will make it completely configurable so that operators can override these secrets and not have to rely on internal generation.

**Who is this feature for?**

A Grafana developer working on the K8s POC.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
- [ ] There are no known compatibility issues with older supported versions of Grafana, or plugins.
- [ ] It passes the [Hosted Grafana feature readiness review](https://docs.google.com/document/d/1QL9Ly8KnXzpb6ISbg49pTODRO5mhA5tkkfIZVX6pqQU/edit) for observability, scalability, performance, and security.