### PR TITLE
Alerting: Paginate result previews

### DIFF
--- a/public/app/features/alerting/unified/components/expressions/Expression.test.tsx
+++ b/public/app/features/alerting/unified/components/expressions/Expression.test.tsx
@@ -1,0 +1,66 @@
+import { screen, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { times } from 'lodash';
+import React from 'react';
+
+import { DataFrame, toDataFrame } from '@grafana/data';
+
+import { ExpressionResult } from './Expression';
+
+describe('TestResult', () => {
+  it('should be able to render', () => {
+    expect(() => {
+      render(<ExpressionResult series={[]} />);
+    }).not.toThrow();
+  });
+
+  it('should not paginate with less than PAGE_SIZE', () => {
+    const series: DataFrame[] = [
+      toDataFrame({
+        fields: [
+          {
+            name: 'temp',
+            values: [23, 11, 10],
+          },
+        ],
+      }),
+    ];
+
+    render(<ExpressionResult series={series} />);
+    expect(screen.queryByTestId('paginate-expression')).not.toBeInTheDocument();
+  });
+
+  it('should paginate with greater than PAGE_SIZE', async () => {
+    const series: DataFrame[] = makeSeries(50);
+
+    render(<ExpressionResult series={series} />);
+    expect(screen.getByTestId('paginate-expression')).toBeInTheDocument();
+    expect(screen.getByText(`1 - 20 of ${50}`)).toBeInTheDocument();
+
+    // click previous page
+    await userEvent.click(screen.getByLabelText('previous-page'));
+    expect(screen.getByText(`1 - 20 of ${50}`)).toBeInTheDocument();
+
+    // keep clicking next page, should clamp
+    await userEvent.click(screen.getByLabelText('next-page'));
+    expect(screen.getByText(`21 - 40 of ${50}`)).toBeInTheDocument();
+    await userEvent.click(screen.getByLabelText('next-page'));
+    expect(screen.getByText(`41 - 50 of ${50}`)).toBeInTheDocument();
+    // click one more time, should still be on the last page
+    await userEvent.click(screen.getByLabelText('next-page'));
+    expect(screen.getByText(`41 - 50 of ${50}`)).toBeInTheDocument();
+  });
+});
+
+function makeSeries(n: number) {
+  return times(n, () =>
+    toDataFrame({
+      fields: [
+        {
+          name: 'temp',
+          values: [1],
+        },
+      ],
+    })
+  );
+}

--- a/public/app/features/alerting/unified/hooks/usePagination.test.tsx
+++ b/public/app/features/alerting/unified/hooks/usePagination.test.tsx
@@ -1,0 +1,93 @@
+// import { chunk, clamp } from 'lodash';
+// import { useCallback, useEffect, useState } from 'react';
+
+import { act, renderHook } from '@testing-library/react-hooks';
+
+import { usePagination } from './usePagination';
+
+// export function usePagination<T>(items: T[], initialPage: number = 1, itemsPerPage: number) {
+//   const [page, setPage] = useState(initialPage);
+
+//   const pages = chunk(items, itemsPerPage);
+//   const numberOfPages = pages.length;
+//   const pageItems = pages[page - 1] ?? [];
+
+//   const pageStart = ((page - 1) * itemsPerPage) + 1;
+//   const pageEnd = clamp(page * itemsPerPage, items.length);
+
+//   const onPageChange = useCallback((newPage: number) => {
+//     setPage(clamp(newPage, 1, pages.length));
+//   }, [setPage, pages]);
+
+//   const nextPage = useCallback(() => onPageChange(page + 1), [onPageChange]);
+//   const previousPage = useCallback(() => onPageChange(page - 1), [onPageChange]);
+
+//   // Reset the current page when number of pages has been changed
+//   useEffect(() => setPage(1), [numberOfPages]);
+
+//   return { page, onPageChange, numberOfPages, pageItems, pageStart, pageEnd, nextPage, previousPage };
+// }
+
+describe('usePagination()', () => {
+  it('should work with no items', () => {
+    const { result } = renderHook(() => {
+      return usePagination([], 1, 20);
+    });
+
+    const { pageItems, numberOfPages, page, pageStart, pageEnd } = result.current;
+
+    expect(pageItems).toStrictEqual([]);
+    expect(numberOfPages).toStrictEqual(0);
+    expect(page).toStrictEqual(1);
+    expect(pageStart).toStrictEqual(1);
+    expect(pageEnd).toStrictEqual(0);
+  });
+
+  it('should work with items < page size', () => {
+    const { result } = renderHook(() => {
+      return usePagination([1, 2, 3], 1, 10);
+    });
+
+    const { pageItems, numberOfPages, page, pageStart, pageEnd } = result.current;
+
+    expect(pageItems).toStrictEqual([1, 2, 3]);
+    expect(numberOfPages).toStrictEqual(1);
+    expect(page).toStrictEqual(1);
+    expect(pageStart).toStrictEqual(1);
+    expect(pageEnd).toStrictEqual(3);
+  });
+
+  it('should work with items > page size', () => {
+    const { result } = renderHook(() => {
+      return usePagination([1, 2, 3], 1, 1);
+    });
+
+    const { pageItems, numberOfPages, page, pageStart, pageEnd } = result.current;
+
+    expect(pageItems).toStrictEqual([1]);
+    expect(numberOfPages).toStrictEqual(3);
+    expect(page).toStrictEqual(1);
+    expect(pageStart).toStrictEqual(1);
+    expect(pageEnd).toStrictEqual(1);
+  });
+
+  it('should clamp pages', () => {
+    const { result } = renderHook(() => {
+      return usePagination([1, 2, 3], 1, 1);
+    });
+
+    expect(result.current.pageItems).toStrictEqual([1]);
+
+    act(() => result.current.previousPage());
+    expect(result.current.pageItems).toStrictEqual([1]);
+
+    act(() => result.current.nextPage());
+    expect(result.current.pageItems).toStrictEqual([2]);
+
+    act(() => result.current.nextPage());
+    expect(result.current.pageItems).toStrictEqual([3]);
+
+    act(() => result.current.nextPage());
+    expect(result.current.pageItems).toStrictEqual([3]);
+  });
+});

--- a/public/app/features/alerting/unified/hooks/usePagination.test.tsx
+++ b/public/app/features/alerting/unified/hooks/usePagination.test.tsx
@@ -1,32 +1,6 @@
-// import { chunk, clamp } from 'lodash';
-// import { useCallback, useEffect, useState } from 'react';
-
 import { act, renderHook } from '@testing-library/react-hooks';
 
 import { usePagination } from './usePagination';
-
-// export function usePagination<T>(items: T[], initialPage: number = 1, itemsPerPage: number) {
-//   const [page, setPage] = useState(initialPage);
-
-//   const pages = chunk(items, itemsPerPage);
-//   const numberOfPages = pages.length;
-//   const pageItems = pages[page - 1] ?? [];
-
-//   const pageStart = ((page - 1) * itemsPerPage) + 1;
-//   const pageEnd = clamp(page * itemsPerPage, items.length);
-
-//   const onPageChange = useCallback((newPage: number) => {
-//     setPage(clamp(newPage, 1, pages.length));
-//   }, [setPage, pages]);
-
-//   const nextPage = useCallback(() => onPageChange(page + 1), [onPageChange]);
-//   const previousPage = useCallback(() => onPageChange(page - 1), [onPageChange]);
-
-//   // Reset the current page when number of pages has been changed
-//   useEffect(() => setPage(1), [numberOfPages]);
-
-//   return { page, onPageChange, numberOfPages, pageItems, pageStart, pageEnd, nextPage, previousPage };
-// }
 
 describe('usePagination()', () => {
   it('should work with no items', () => {

--- a/public/app/features/alerting/unified/hooks/usePagination.ts
+++ b/public/app/features/alerting/unified/hooks/usePagination.ts
@@ -1,25 +1,29 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { chunk, clamp } from 'lodash';
+import { useCallback, useEffect, useState, useMemo } from 'react';
 
-export function usePagination<T>(items: T[], initialPage: number, itemsPerPage: number) {
+export function usePagination<T>(items: T[], initialPage = 1, itemsPerPage: number) {
   const [page, setPage] = useState(initialPage);
 
-  const numberOfPages = Math.ceil(items.length / itemsPerPage);
-  const firstItemOnPageIndex = itemsPerPage * (page - 1);
+  const pages = useMemo(() => chunk(items, itemsPerPage), [items, itemsPerPage]);
 
-  const pageItems = useMemo(
-    () => items.slice(firstItemOnPageIndex, firstItemOnPageIndex + itemsPerPage),
-    [items, firstItemOnPageIndex, itemsPerPage]
-  );
+  const numberOfPages = pages.length;
+  const pageItems = pages[page - 1] ?? [];
+
+  const pageStart = (page - 1) * itemsPerPage + 1;
+  const pageEnd = clamp(page * itemsPerPage, items.length);
 
   const onPageChange = useCallback(
     (newPage: number) => {
-      setPage(newPage);
+      setPage(clamp(newPage, 1, pages.length));
     },
-    [setPage]
+    [setPage, pages]
   );
+
+  const nextPage = useCallback(() => onPageChange(page + 1), [page, onPageChange]);
+  const previousPage = useCallback(() => onPageChange(page - 1), [page, onPageChange]);
 
   // Reset the current page when number of pages has been changed
   useEffect(() => setPage(1), [numberOfPages]);
 
-  return { page, onPageChange, numberOfPages, pageItems };
+  return { page, onPageChange, numberOfPages, pageItems, pageStart, pageEnd, nextPage, previousPage };
 }


### PR DESCRIPTION
**What is this feature?**

Adds a pagination to the bottom of expression results when previewing alerts from a data query with more than 20 series (multi-dimensional alert rule).

<img width="988" alt="image" src="https://user-images.githubusercontent.com/868844/227185855-24a3afc6-b01f-461d-b5cc-457de557c78c.png">

**Why do we need this feature?**

Large query results could crash the browser (10k+)

**Which issue(s) does this PR fix?**:

Fixes #64830

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
- [ ] There are no known compatibility issues with older supported versions of Grafana, or plugins.
- [ ] It passes the [Hosted Grafana feature readiness review](https://docs.google.com/document/d/1QL9Ly8KnXzpb6ISbg49pTODRO5mhA5tkkfIZVX6pqQU/edit) for observability, scalability, performance, and security.