### PR TITLE
Template Variables: Expose getAdhocFilters and getVariableName

### DIFF
--- a/packages/grafana-runtime/src/services/templateSrv.ts
+++ b/packages/grafana-runtime/src/services/templateSrv.ts
@@ -1,4 +1,4 @@
-import { ScopedVars, TimeRange, TypedVariableModel, VariableMap } from '@grafana/data';
+import { AdHocVariableFilter, ScopedVars, TimeRange, TypedVariableModel, VariableMap } from '@grafana/data';
 
 /**
  * Via the TemplateSrv consumers get access to all the available template variables
@@ -32,6 +32,16 @@ export interface TemplateSrv {
    * Update the current time range to be used when interpolating __from / __to variables.
    */
   updateTimeRange(timeRange: TimeRange): void;
+
+  /**
+   * Lists ad-hoc filters for a specific datasource
+   */
+  getAdhocFilters(datasourceName: string): AdHocVariableFilter[];
+
+  /**
+   * Extracts variable name from an expression like '${example}'
+   */
+  getVariableName(expression: string): string | undefined;
 }
 
 let singletonInstance: TemplateSrv;

--- a/packages/grafana-runtime/src/services/templateSrv.ts
+++ b/packages/grafana-runtime/src/services/templateSrv.ts
@@ -41,7 +41,7 @@ export interface TemplateSrv {
   /**
    * Extracts variable name from an expression like '${example}'
    */
-  getVariableName(expression: string): string | undefined;
+  getVariableName(expression: string): string | undefined | null;
 }
 
 let singletonInstance: TemplateSrv;

--- a/packages/grafana-runtime/src/services/templateSrv.ts
+++ b/packages/grafana-runtime/src/services/templateSrv.ts
@@ -41,7 +41,7 @@ export interface TemplateSrv {
   /**
    * Extracts variable name from an expression like '${example}'
    */
-  getVariableName(expression: string): string | undefined | null;
+  getVariableName(expression: string): string | undefined;
 }
 
 let singletonInstance: TemplateSrv;

--- a/public/app/features/templating/template_srv.mock.ts
+++ b/public/app/features/templating/template_srv.mock.ts
@@ -59,7 +59,7 @@ export class TemplateSrvMock implements TemplateSrv {
     this.regex.lastIndex = 0;
     const match = this.regex.exec(expression);
     if (!match) {
-      return null;
+      return undefined;
     }
     return match.slice(1).find((match) => match !== undefined);
   }

--- a/public/app/features/templating/template_srv.mock.ts
+++ b/public/app/features/templating/template_srv.mock.ts
@@ -1,4 +1,4 @@
-import { ScopedVars, TimeRange, TypedVariableModel } from '@grafana/data';
+import { AdHocVariableFilter, ScopedVars, TimeRange, TypedVariableModel } from '@grafana/data';
 import { TemplateSrv } from '@grafana/runtime';
 
 import { variableRegex } from '../variables/utils';
@@ -13,7 +13,7 @@ import { variableRegex } from '../variables/utils';
  */
 export class TemplateSrvMock implements TemplateSrv {
   private regex = variableRegex;
-  constructor(private variables: Record<string, string>) {}
+  constructor(private variables: Record<string, string>, private adHocFilters?: AdHocVariableFilter[]) {}
 
   getVariables(): TypedVariableModel[] {
     return Object.keys(this.variables).map((key) => {
@@ -75,4 +75,7 @@ export class TemplateSrvMock implements TemplateSrv {
   }
 
   updateTimeRange(timeRange: TimeRange) {}
+  getAdhocFilters(datasoureName: string) {
+    return this.adHocFilters ?? [];
+  }
 }

--- a/public/app/features/templating/template_srv.ts
+++ b/public/app/features/templating/template_srv.ts
@@ -194,7 +194,7 @@ export class TemplateSrv implements BaseTemplateSrv {
     this.regex.lastIndex = 0;
     const match = this.regex.exec(expression);
     if (!match) {
-      return null;
+      return undefined;
     }
     const variableName = match.slice(1).find((match) => match !== undefined);
     return variableName;

--- a/public/app/plugins/datasource/loki/configuration/DebugSection.test.tsx
+++ b/public/app/plugins/datasource/loki/configuration/DebugSection.test.tsx
@@ -45,6 +45,12 @@ describe('DebugSection', () => {
         return false;
       },
       updateTimeRange(timeRange: TimeRange) {},
+      getVariableName(variable: string) {
+        return '';
+      },
+      getAdhocFilters(datasourceName: string) {
+        return [];
+      },
     });
   });
 

--- a/public/app/plugins/datasource/zipkin/datasource.test.ts
+++ b/public/app/plugins/datasource/zipkin/datasource.test.ts
@@ -23,6 +23,8 @@ describe('ZipkinDatasource', () => {
       containsTemplate: jest.fn(),
       getAllVariablesInTarget: jest.fn(),
       updateTimeRange: jest.fn(),
+      getAdhocFilters: jest.fn(),
+      getVariableName: jest.fn(),
     };
 
     it('runs query', async () => {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR exposes two more methods from TemplateSrv in grafana/runtime package. When[ using templateSrv in an external plugin](https://github.com/grafana/iot-sitewise-datasource/pull/172), I noticed it had access to all the methods from [TemplateSrv](https://github.com/grafana/grafana/blob/f8d89eff562dfb7c90b0bb617c639339af30d55c/public/app/features/templating/template_srv.ts), but when using them I got a type error. Not sure why other public methods weren't exposed, so I added just these two to the type because they are the most commonly used in internal plugins, so I assume external plugins are more likely to need them. Technically, though, I only need getVariableName for the Sitewise PR so this is up for discussion. 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
- [ ] There are no known compatibility issues with older supported versions of Grafana, or plugins.
- [ ] It passes the [Hosted Grafana feature readiness review](https://docs.google.com/document/d/1QL9Ly8KnXzpb6ISbg49pTODRO5mhA5tkkfIZVX6pqQU/edit) for observability, scalability, performance, and security.