### PR TITLE
Limit issue-add-to-parent-project to only epics

### DIFF
--- a/.github/workflows/epic-add-to-platform-ux-parent-project.yml
+++ b/.github/workflows/epic-add-to-platform-ux-parent-project.yml
@@ -19,6 +19,7 @@ concurrency:
   group: issue-add-to-parent-project-${{ github.event.number }}
 jobs:
   main:
+    if: contains(github.event.issue.labels.*.name, 'type/epic')
     runs-on: ubuntu-latest
     steps:
       - name: Check if issue is in child or parent projects


### PR DESCRIPTION
**What is this feature?**

Add limit to issue-add-to-parent-project action to run only for epics

**Why do we need this feature?**

job assigns parent project to non-epics currently and runs too often

**Special notes for your reviewer:**

Tested [here](https://github.com/grafana/github-actions-testrepo/blob/main/.github/workflows/issue-add-to-parent-project.yml)