### PR TITLE
Templating: Allow percent encoding of variable with custom all

### DIFF
--- a/public/app/features/templating/template_srv.test.ts
+++ b/public/app/features/templating/template_srv.test.ts
@@ -309,6 +309,25 @@ describe('templateSrv', () => {
       const target = _templateSrv.replace('${test:queryparam}', {});
       expect(target).toBe('var-test=All');
     });
+
+    describe('percentencode option', () => {
+      beforeEach(() => {
+        _templateSrv = initTemplateSrv(key, [
+          {
+            type: 'query',
+            name: 'test',
+            current: { value: '$__all' },
+            allValue: '.+',
+            options: [{ value: 'value1' }, { value: 'value2' }],
+          },
+        ]);
+      });
+
+      it('should respect percentencode format', () => {
+        const target = _templateSrv.replace('this.${test:percentencode}', {}, 'regex');
+        expect(target).toBe('this.%2B');
+      });
+    });
   });
 
   describe('lucene format', () => {

--- a/public/app/features/templating/template_srv.test.ts
+++ b/public/app/features/templating/template_srv.test.ts
@@ -325,7 +325,7 @@ describe('templateSrv', () => {
 
       it('should respect percentencode format', () => {
         const target = _templateSrv.replace('this.${test:percentencode}', {}, 'regex');
-        expect(target).toBe('this.%2B');
+        expect(target).toBe('this..%2B');
       });
     });
   });

--- a/public/app/features/templating/template_srv.ts
+++ b/public/app/features/templating/template_srv.ts
@@ -332,8 +332,8 @@ export class TemplateSrv implements BaseTemplateSrv {
       if (this.isAllValue(value)) {
         value = this.getAllValue(variable);
         text = ALL_VARIABLE_TEXT;
-        // skip formatting of custom all values
-        if (variable.allValue && fmt !== FormatRegistryID.text) {
+        // skip formatting of custom all values unless format set to text or percentencode
+        if (variable.allValue && fmt !== FormatRegistryID.text && fmt !== FormatRegistryID.percentEncode) {
           return this.replace(value);
         }
       }


### PR DESCRIPTION
Ref https://github.com/grafana/support-escalations/issues/5361
Alternative to https://github.com/grafana/grafana/pull/65175

Explicitly allow `percentencode` format option for variables with custom all value.