### PR TITLE
Elasticsearch: Unify adhoc variables processing

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -4618,13 +4618,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "7"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "8"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "9"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "10"],
+      [0, 0, 0, "Do not use any type assertions.", "10"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "11"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "12"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "13"],
-      [0, 0, 0, "Do not use any type assertions.", "14"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "15"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "16"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "12"]
     ],
     "public/app/plugins/datasource/elasticsearch/components/AddRemove.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]

--- a/public/app/plugins/datasource/elasticsearch/QueryBuilder.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/QueryBuilder.test.ts
@@ -604,36 +604,6 @@ describe('ElasticQueryBuilder', () => {
     expect(firstLevel.nested.path).toBe('nested_field');
   });
 
-  // This test wasn't migrated, as adhoc variables are going to be interpolated before
-  // Or we need to add this to backend query builder (TBD)
-  it('with adhoc filters', () => {
-    const query = builder.build(
-      {
-        refId: 'A',
-        metrics: [{ type: 'count', id: '0' }],
-        timeField: '@timestamp',
-        bucketAggs: [{ type: 'date_histogram', field: '@timestamp', id: '3' }],
-      },
-      [
-        { key: 'key1', operator: '=', value: 'value1', condition: '' },
-        { key: 'key2', operator: '=', value: 'value2', condition: '' },
-        { key: 'key2', operator: '!=', value: 'value2', condition: '' },
-        { key: 'key3', operator: '<', value: 'value3', condition: '' },
-        { key: 'key4', operator: '>', value: 'value4', condition: '' },
-        { key: 'key5', operator: '=~', value: 'value5', condition: '' },
-        { key: 'key6', operator: '!~', value: 'value6', condition: '' },
-      ]
-    );
-
-    expect(query.query.bool.must[0].match_phrase['key1'].query).toBe('value1');
-    expect(query.query.bool.must[1].match_phrase['key2'].query).toBe('value2');
-    expect(query.query.bool.must_not[0].match_phrase['key2'].query).toBe('value2');
-    expect(query.query.bool.filter[1].range['key3'].lt).toBe('value3');
-    expect(query.query.bool.filter[2].range['key4'].gt).toBe('value4');
-    expect(query.query.bool.filter[3].regexp['key5']).toBe('value5');
-    expect(query.query.bool.filter[4].bool.must_not.regexp['key6']).toBe('value6');
-  });
-
   describe('getTermsQuery', () => {
     function testGetTermsQuery(queryDef: TermsQuery) {
       const query = builder.getTermsQuery(queryDef);
@@ -768,26 +738,6 @@ describe('ElasticQueryBuilder', () => {
           query.query.bool.filter.find((filter: object) => Object.keys(filter).includes('query_string'))
         ).toBeFalsy();
       });
-    });
-
-    it('with adhoc filters', () => {
-      // TODO: Types for AdHocFilters
-      const adhocFilters = [
-        { key: 'key1', operator: '=', value: 'value1', condition: '' },
-        { key: 'key2', operator: '!=', value: 'value2', condition: '' },
-        { key: 'key3', operator: '<', value: 'value3', condition: '' },
-        { key: 'key4', operator: '>', value: 'value4', condition: '' },
-        { key: 'key5', operator: '=~', value: 'value5', condition: '' },
-        { key: 'key6', operator: '!~', value: 'value6', condition: '' },
-      ];
-      const query = builder.getLogsQuery({ refId: 'A' }, 500, adhocFilters);
-
-      expect(query.query.bool.must[0].match_phrase['key1'].query).toBe('value1');
-      expect(query.query.bool.must_not[0].match_phrase['key2'].query).toBe('value2');
-      expect(query.query.bool.filter[1].range['key3'].lt).toBe('value3');
-      expect(query.query.bool.filter[2].range['key4'].gt).toBe('value4');
-      expect(query.query.bool.filter[3].regexp['key5']).toBe('value5');
-      expect(query.query.bool.filter[4].bool.must_not.regexp['key6']).toBe('value6');
     });
   });
 

--- a/public/app/plugins/datasource/elasticsearch/QueryBuilder.ts
+++ b/public/app/plugins/datasource/elasticsearch/QueryBuilder.ts
@@ -1,4 +1,4 @@
-import { AdHocVariableFilter, InternalTimeZones } from '@grafana/data';
+import { InternalTimeZones } from '@grafana/data';
 
 import {
   isMetricAggregationWithField,
@@ -154,54 +154,7 @@ export class ElasticQueryBuilder {
     return query;
   }
 
-  addAdhocFilters(query: any, adhocFilters: any) {
-    if (!adhocFilters) {
-      return;
-    }
-
-    let i, filter, condition: any, queryCondition: any;
-
-    for (i = 0; i < adhocFilters.length; i++) {
-      filter = adhocFilters[i];
-      condition = {};
-      condition[filter.key] = filter.value;
-      queryCondition = {};
-      queryCondition[filter.key] = { query: filter.value };
-
-      switch (filter.operator) {
-        case '=':
-          if (!query.query.bool.must) {
-            query.query.bool.must = [];
-          }
-          query.query.bool.must.push({ match_phrase: queryCondition });
-          break;
-        case '!=':
-          if (!query.query.bool.must_not) {
-            query.query.bool.must_not = [];
-          }
-          query.query.bool.must_not.push({ match_phrase: queryCondition });
-          break;
-        case '<':
-          condition[filter.key] = { lt: filter.value };
-          query.query.bool.filter.push({ range: condition });
-          break;
-        case '>':
-          condition[filter.key] = { gt: filter.value };
-          query.query.bool.filter.push({ range: condition });
-          break;
-        case '=~':
-          query.query.bool.filter.push({ regexp: condition });
-          break;
-        case '!~':
-          query.query.bool.filter.push({
-            bool: { must_not: { regexp: condition } },
-          });
-          break;
-      }
-    }
-  }
-
-  build(target: ElasticsearchQuery, adhocFilters?: AdHocVariableFilter[]) {
+  build(target: ElasticsearchQuery) {
     // make sure query has defaults;
     target.metrics = target.metrics || [defaultMetricAgg()];
     target.bucketAggs = target.bucketAggs || [defaultBucketAgg()];
@@ -229,8 +182,6 @@ export class ElasticQueryBuilder {
         },
       ];
     }
-
-    this.addAdhocFilters(query, adhocFilters);
 
     // If target doesn't have bucketAggs and type is not raw_document, it is invalid query.
     if (target.bucketAggs.length === 0) {
@@ -483,7 +434,7 @@ export class ElasticQueryBuilder {
     return query;
   }
 
-  getLogsQuery(target: ElasticsearchQuery, limit: number, adhocFilters?: AdHocVariableFilter[]) {
+  getLogsQuery(target: ElasticsearchQuery, limit: number) {
     let query: any = {
       size: 0,
       query: {
@@ -492,8 +443,6 @@ export class ElasticQueryBuilder {
         },
       },
     };
-
-    this.addAdhocFilters(query, adhocFilters);
 
     if (target.query) {
       query.query.bool.filter.push({


### PR DESCRIPTION
Currently, there are 2 ways how ad-hoc filters are applied to queries:

- as `match_phrase`/`range`/`regexp` 
- as `query_string`

Here are more docs on what are the changes between these: 

- https://stackoverflow.com/questions/26001002/elasticsearch-difference-between-term-match-phrase-and-query-string
- https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query.html#_phrase
- https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#query-dsl-query-string-query

The main difference/similarity is pointed out here (we use quotes around the input) : 

```
As the match_phrase queries, the input is analyzed according to the analyzer set on the queried field.

Unlike the match_phrase, the terms obtained after analysis don't have to be in the same order, unless the user has used quotes around the input.
```

The main problem/possible source of confusion could be that in different parts of Grafana, the same activities lead to different queries. For example:

-  clicking at `add ad hoc filter in table` in dashboard will produce new `match_phrase`, while in Explore it will create new `query_string`
- In dashboard, ad hoc filters are applied as `match_phrase` **and actually there is a bug/duplication - we add adhoc filter as both `match_phrase` and `query_string`**, which means this PR only removes `match_phrase` while `query_string` is kept as before) , but when jumping to Explore, they are added to lucene query `query_string`

I think that unifying is important and when deciding on which one to select, it seems that `query_string` would be preferred solution, as its content can be displayed as lucene query, and therefore we don't need any new UI for other places (such as in Explore or in query editor), to display applied filters. 

So in this PR, we are moving all (already working) ad-hoc filtering logic to single place `applyTemplateVariables` and use it as a single source of truth. 

We already have tests in place, so this PR focuses on removing adhoc filter adding where it is not needed, and refactoring logic so we have single source of truth - `applyTemplateVariables`. 

How to test:
1.  Run ES  `make devenv sources=elastic`
2.  In Dashboard run "Raw data" query with table panel and click on filet for/filter out interactions in table. Make sure that executed query (using query inspector) has filters as `query_string`
<img width="1017" alt="image" src="https://user-images.githubusercontent.com/30407135/227235810-078db74d-2e5f-4e42-9be6-573bb3974d5d.png">
3. Switch to Explore and make sure query is correctly interpolated with ad hoc filter. Using inspector, make sure query is the same as in dashboard. 
<img width="1497" alt="image" src="https://user-images.githubusercontent.com/30407135/227236101-80265b17-f2ec-4004-b645-f940f0fc26ab.png">

Part of #54011
