### PR TITLE
Alerting: Fix wrong text in step4

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/DetailsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/DetailsStep.tsx
@@ -9,13 +9,36 @@ import { RuleEditorSection } from './RuleEditorSection';
 
 function getDescription(ruleType: RuleFormType | undefined) {
   if (ruleType === RuleFormType.cloudRecording) {
-    return 'Select the Namespace and Group for your recording rule';
+    return 'Select the Namespace and Group for your recording rule.';
   }
+  const docsLink =
+    'https://grafana.com/docs/grafana/latest/alerting/fundamentals/annotation-label/variables-label-annotation/#the-values-variable';
+  const LinkToDocs = () => (
+    <span>
+      Click{' '}
+      <a href={docsLink} target="_blank" rel="noreferrer">
+        here{' '}
+      </a>
+      for documentation on how to template annotations and labels.
+    </span>
+  );
   if (ruleType === RuleFormType.grafana) {
-    return 'Write a summary to help you better manage your alerts';
+    return (
+      <span>
+        {' '}
+        Write a summary to help you better manage your alerts.
+        <LinkToDocs />
+      </span>
+    );
   }
   if (ruleType === RuleFormType.cloudAlerting) {
-    return 'Select the Namespace and evaluation group for your alert. Write a summary to help you better manage your alerts';
+    return (
+      <span>
+        {' '}
+        Select the Namespace and evaluation group for your alert. Write a summary to help you better manage your alerts.{' '}
+        <LinkToDocs />
+      </span>
+    );
   }
   return '';
 }

--- a/public/app/features/alerting/unified/components/rule-editor/DetailsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/DetailsStep.tsx
@@ -7,6 +7,19 @@ import AnnotationsField from './AnnotationsField';
 import { GroupAndNamespaceFields } from './GroupAndNamespaceFields';
 import { RuleEditorSection } from './RuleEditorSection';
 
+function getDescription(ruleType: RuleFormType | undefined) {
+  if (ruleType === RuleFormType.cloudRecording) {
+    return 'Select the Namespace and Group for your recording rule';
+  }
+  if (ruleType === RuleFormType.grafana) {
+    return 'Write a summary to help you better manage your alerts';
+  }
+  if (ruleType === RuleFormType.cloudAlerting) {
+    return 'Select the Namespace and evaluation group for your alert. Write a summary to help you better manage your alerts';
+  }
+  return '';
+}
+
 export function DetailsStep() {
   const { watch } = useFormContext<RuleFormValues & { location?: string }>();
 
@@ -18,11 +31,7 @@ export function DetailsStep() {
     <RuleEditorSection
       stepNo={type === RuleFormType.cloudRecording ? 3 : 4}
       title={type === RuleFormType.cloudRecording ? 'Folder and group' : 'Add details for your alert rule'}
-      description={
-        type === RuleFormType.cloudRecording
-          ? 'Select the Namespace and Group for your recording rule'
-          : 'Select the folder and evaluation group for your alert. Write a summary to help you better manage your alerts'
-      }
+      description={getDescription(type)}
     >
       {(ruleFormType === RuleFormType.cloudRecording || ruleFormType === RuleFormType.cloudAlerting) &&
         dataSourceName && <GroupAndNamespaceFields rulesSourceName={dataSourceName} />}

--- a/public/app/features/alerting/unified/components/rule-editor/RuleEditorSection.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/RuleEditorSection.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import React from 'react';
+import React, { ReactElement } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { FieldSet, useStyles2 } from '@grafana/ui';
@@ -7,7 +7,7 @@ import { FieldSet, useStyles2 } from '@grafana/ui';
 export interface RuleEditorSectionProps {
   title: string;
   stepNo: number;
-  description?: string;
+  description?: string | ReactElement;
 }
 
 export const RuleEditorSection = ({


### PR DESCRIPTION
**What is this feature?**

This PR fixes a wrong text in step4 of the alert form view.
It also adds a link to annotations documentation in the description of the step.

After the change:

**For grafana alerts:**

https://user-images.githubusercontent.com/33540275/227265042-8df4ad07-7342-4640-9da9-f2c7b56ed3a5.mp4

**For cloud alerts:**

<img width="1526" alt="Screenshot 2023-03-23 at 17 26 47" src="https://user-images.githubusercontent.com/33540275/227270669-6e9f230c-1a69-4dc9-af2f-40a4fbbdc9b8.png">


**For recording rules:** 

<img width="1476" alt="Screenshot 2023-03-23 at 16 24 32" src="https://user-images.githubusercontent.com/33540275/227265320-3b3ee08a-018d-4aff-b6d8-6670d9abf6bf.png">


**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
- [x] There are no known compatibility issues with older supported versions of Grafana, or plugins.
- [ ] It passes the [Hosted Grafana feature readiness review](https://docs.google.com/document/d/1QL9Ly8KnXzpb6ISbg49pTODRO5mhA5tkkfIZVX6pqQU/edit) for observability, scalability, performance, and security.