### PR TITLE
docs: update elasticsearch grafana play link

### DIFF
--- a/docs/sources/datasources/elasticsearch/template-variables/index.md
+++ b/docs/sources/datasources/elasticsearch/template-variables/index.md
@@ -63,4 +63,4 @@ You can alternatively use other sorting criteria, such as **Alphabetical**, to r
 In the above example, a Lucene query filters documents based on the `hostname` property using a variable named `$hostname`.
 The example also uses a variable in the _Terms_ group by field input box, which you can use to quickly change how data is grouped.
 
-To view an example dashboard on Grafana Play, see the [Elasticsearch Templated Dashboard](https://play.grafana.org/d/CknOEXDMk/elasticsearch-templated?orgId=1d).
+To view an example dashboard on Grafana Play, see the [Elasticsearch Templated Dashboard](https://play.grafana.org/d/z8OZC66nk/elasticsearch-8-2-0-sample-flight-data?orgId=1).


### PR DESCRIPTION
Backports set to 9.4 and 9.3. Page was moved during restructuring between 9.3 and 9.2.