### PR TITLE
InfluxDB: Flux return frames as nil for no data response

### DIFF
--- a/pkg/tsdb/influxdb/flux/executor.go
+++ b/pkg/tsdb/influxdb/flux/executor.go
@@ -52,15 +52,16 @@ func executeQuery(ctx context.Context, logger log.Logger, query queryModel, runn
 		}
 	}
 
-	// Make sure there is at least one frame
-	if len(dr.Frames) == 0 {
-		dr.Frames = append(dr.Frames, data.NewFrame(""))
+	// add the metadata if there are frames
+	// otherwise it is a no data response and Frames are nil
+	if len(dr.Frames) != 0 {
+		firstFrame := dr.Frames[0]
+		if firstFrame.Meta == nil {
+			firstFrame.SetMeta(&data.FrameMeta{})
+		}
+		firstFrame.Meta.ExecutedQueryString = flux
 	}
-	firstFrame := dr.Frames[0]
-	if firstFrame.Meta == nil {
-		firstFrame.SetMeta(&data.FrameMeta{})
-	}
-	firstFrame.Meta.ExecutedQueryString = flux
+
 	return dr
 }
 

--- a/pkg/tsdb/influxdb/flux/executor_test.go
+++ b/pkg/tsdb/influxdb/flux/executor_test.go
@@ -305,3 +305,8 @@ func TestTimestampFirst(t *testing.T) {
 	require.Equal(t, "Time", dr.Frames[0].Fields[0].Name)
 	require.Equal(t, "Value", dr.Frames[0].Fields[1].Name)
 }
+
+func TestNoDataResponse(t *testing.T) {
+	dr := verifyGoldenResponse(t, "no_data")
+	require.Len(t, dr.Frames, 0)
+}

--- a/pkg/tsdb/influxdb/flux/testdata/no_data.csv
+++ b/pkg/tsdb/influxdb/flux/testdata/no_data.csv
@@ -1,0 +1,3 @@
+#group
+#default
+

--- a/pkg/tsdb/influxdb/flux/testdata/no_data.golden.jsonc
+++ b/pkg/tsdb/influxdb/flux/testdata/no_data.golden.jsonc
@@ -1,0 +1,5 @@
+//  🌟 This was machine generated.  Do not edit. 🌟
+//  🌟 This was machine generated.  Do not edit. 🌟
+{
+  "status": 200
+}


### PR DESCRIPTION
Fixes https://github.com/grafana/support-escalations/issues/5218
Fixes https://github.com/grafana/grafana/issues/39711

**What is this feature?**
<img width="797" alt="Screenshot 2023-03-23 at 4 40 06 PM" src="https://user-images.githubusercontent.com/25674746/227351925-a3cb32e3-92ea-4485-88a3-ae4c1dc80cdf.png">
This is a bug fix to return a "No Data" response for InfluxDB Flux by returning Frames as nil when the influx response has no data. 

**Why do we need this feature?**
Previously the influx response showed an error in the time series panel for two queries that return no data, "Data is missing a number field." This fixes that issue and shows the correct info, "No Data."

**Who is this feature for?**
InfluxDB Flux users who are returning responses with no data.

**Special notes for your reviewer:**
To test this fix create two InfluxDB Flux queries that return no data using the gdev datasource `gdev-influxdb-flux`.
Examples
```
from(bucket: "mybucket")
  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
  |> filter(fn: (r) => r["_measurement"] == "cpu")
  |> filter(fn: (r) => r["_field"] == "usage_guest_nice" and r.value < 1)
```
and
```
from(bucket: "mybucket")
  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
  |> filter(fn: (r) => r["_measurement"] == "cpu")
  |> filter(fn: (r) => r["_field"] == "usage_guest_idle" and r.value < 1)
```

Previously we would see the error "Data is missing a number field" in the time series panel for two queries that return no data.

Now we should see "No data."

Please check that:
- [x] It works as expected from a user's perspective.
- [x] N/A ~~If this is a pre-GA feature, it is behind a feature toggle.~~
- [x] N/A ~~The docs are updated~~
- [x] There are no known compatibility issues with older supported versions of Grafana, or plugins.
- [x] N/A ~~It passes the [Hosted Grafana feature readiness review](https://docs.google.com/document/d/1QL9Ly8KnXzpb6ISbg49pTODRO5mhA5tkkfIZVX6pqQU/edit) for observability, scalability, performance, and security.~~