### PR TITLE
Plugins: Add cloudwatch support with the secure socks proxy

### DIFF
--- a/pkg/tsdb/cloudwatch/cloudwatch.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch.go
@@ -99,7 +99,12 @@ func NewInstanceSettings(httpClientProvider httpclient.Provider) datasource.Inst
 			return nil, fmt.Errorf("error reading settings: %w", err)
 		}
 
-		httpClient, err := httpClientProvider.New()
+		opts, err := settings.HTTPClientOptions()
+		if err != nil {
+			return nil, err
+		}
+
+		httpClient, err := httpClientProvider.New(opts)
 		if err != nil {
 			return nil, fmt.Errorf("error creating http client: %w", err)
 		}
@@ -245,9 +250,9 @@ func (e *cloudWatchExecutor) newSession(pluginCtx backend.PluginContext, region 
 		region = instance.Settings.Region
 	}
 
-	return e.sessions.GetSession(awsds.SessionConfig{
+	sess, err := e.sessions.GetSession(awsds.SessionConfig{
 		// https://github.com/grafana/grafana/issues/46365
-		// HTTPClient: dsInfo.HTTPClient,
+		// HTTPClient: instance.HTTPClient,
 		Settings: awsds.AWSDatasourceSettings{
 			Profile:       instance.Settings.Profile,
 			Region:        region,
@@ -261,6 +266,17 @@ func (e *cloudWatchExecutor) newSession(pluginCtx backend.PluginContext, region 
 		},
 		UserAgentName: aws.String("Cloudwatch"),
 	})
+	if err != nil {
+		return nil, err
+	}
+
+	// workaround until https://github.com/grafana/grafana/issues/39089 is implemented
+	if e.cfg.SecureSocksDSProxy.Enabled && e.features.IsEnabled(featuremgmt.FlagSecureSocksDatasourceProxy) && instance.Settings.SecureSocksProxyEnabled {
+		// only update the transport to try to avoid the issue mentioned here https://github.com/grafana/grafana/issues/46365
+		sess.Config.HTTPClient.Transport = instance.HTTPClient.Transport
+	}
+
+	return sess, nil
 }
 
 func (e *cloudWatchExecutor) getInstance(pluginCtx backend.PluginContext) (*DataSource, error) {

--- a/pkg/tsdb/cloudwatch/cloudwatch.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch.go
@@ -270,7 +270,7 @@ func (e *cloudWatchExecutor) newSession(pluginCtx backend.PluginContext, region 
 		return nil, err
 	}
 
-	// workaround until https://github.com/grafana/grafana/issues/39089 is implemented
+	// work around until https://github.com/grafana/grafana/issues/39089 is implemented
 	if e.cfg.SecureSocksDSProxy.Enabled && e.features.IsEnabled(featuremgmt.FlagSecureSocksDatasourceProxy) && instance.Settings.SecureSocksProxyEnabled {
 		// only update the transport to try to avoid the issue mentioned here https://github.com/grafana/grafana/issues/46365
 		sess.Config.HTTPClient.Transport = instance.HTTPClient.Transport

--- a/pkg/tsdb/cloudwatch/models/settings.go
+++ b/pkg/tsdb/cloudwatch/models/settings.go
@@ -10,7 +10,8 @@ import (
 
 type CloudWatchSettings struct {
 	awsds.AWSDatasourceSettings
-	Namespace string `json:"customMetricsNamespaces"`
+	Namespace               string `json:"customMetricsNamespaces"`
+	SecureSocksProxyEnabled bool   `json:"enableSecureSocksProxy"`
 }
 
 func LoadCloudWatchSettings(config backend.DataSourceInstanceSettings) (CloudWatchSettings, error) {

--- a/pkg/tsdb/cloudwatch/models/settings.go
+++ b/pkg/tsdb/cloudwatch/models/settings.go
@@ -11,7 +11,7 @@ import (
 type CloudWatchSettings struct {
 	awsds.AWSDatasourceSettings
 	Namespace               string `json:"customMetricsNamespaces"`
-	SecureSocksProxyEnabled bool   `json:"enableSecureSocksProxy"`
+	SecureSocksProxyEnabled bool   `json:"enableSecureSocksProxy"` // this can be removed when https://github.com/grafana/grafana/issues/39089 is implemented
 }
 
 func LoadCloudWatchSettings(config backend.DataSourceInstanceSettings) (CloudWatchSettings, error) {

--- a/public/app/plugins/datasource/cloudwatch/components/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/ConfigEditor.tsx
@@ -67,6 +67,10 @@ export const ConfigEditor = (props: Props) => {
         </InlineField>
       </ConnectionConfig>
 
+      {config.featureToggles.secureSocksDatasourceProxy && (
+        <SecureSocksProxySettings options={options} onOptionsChange={onOptionsChange} />
+      )}
+
       <h3 className="page-heading">CloudWatch Logs</h3>
       <div className="gf-form-group">
         <InlineField
@@ -83,9 +87,6 @@ export const ConfigEditor = (props: Props) => {
             title={'The timeout must be a valid duration string, such as "15m" "30s" "2000ms" etc.'}
           />
         </InlineField>
-        {config.featureToggles.secureSocksDatasourceProxy && (
-          <SecureSocksProxySettings options={options} onOptionsChange={onOptionsChange} />
-        )}
         <InlineField
           label="Default Log Groups"
           labelWidth={28}

--- a/public/app/plugins/datasource/cloudwatch/components/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/ConfigEditor.tsx
@@ -8,8 +8,9 @@ import {
   onUpdateDatasourceJsonDataOption,
   updateDatasourcePluginJsonDataOption,
 } from '@grafana/data';
-import { Input, InlineField, FieldProps } from '@grafana/ui';
+import { Input, InlineField, FieldProps, SecureSocksProxySettings } from '@grafana/ui';
 import { notifyApp } from 'app/core/actions';
+import { config } from 'app/core/config';
 import { createWarningNotification } from 'app/core/copy/appNotification';
 import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
 import { store } from 'app/store/store';
@@ -82,6 +83,9 @@ export const ConfigEditor = (props: Props) => {
             title={'The timeout must be a valid duration string, such as "15m" "30s" "2000ms" etc.'}
           />
         </InlineField>
+        {config.featureToggles.secureSocksDatasourceProxy && (
+          <SecureSocksProxySettings options={options} onOptionsChange={onOptionsChange} />
+        )}
         <InlineField
           label="Default Log Groups"
           labelWidth={28}
@@ -124,7 +128,6 @@ export const ConfigEditor = (props: Props) => {
           />
         </InlineField>
       </div>
-
       <XrayLinkConfig
         onChange={(uid) => updateDatasourcePluginJsonDataOption(props, 'tracingDatasourceUid', uid)}
         datasourceUid={options.jsonData.tracingDatasourceUid}


### PR DESCRIPTION
**What is this feature?**

This PR is a follow up to https://github.com/grafana/grafana/pull/59254, to add Cloudwatch to the supported datasource for the feature toggle, `secureSocksDatasourceProxy`. This feature allows supported datasources to go through a socks5 proxy with TLS if the data source has `enableSecureSocksProxy=true` in the json data.

This is a temporary workaround, until https://github.com/grafana/grafana/issues/39089 is implemented. After this is implemented, the only things that will need to stay are [the addition of the configuration into the http client](https://github.com/grafana/grafana/compare/secure-socks-proxy-enable-on-cloudwatch-workaround?expand=1#diff-ed359d338e3137d184fd19ea8b50a55fbc4070aa8ca09c75abb227c7f24b1f9bR102), and the UI changes.

**Why do we need this feature?**

Grafana users need to be able to connect to datasources that live in different networks than where Grafana is running. In cloudwatch's case, even if it's only connectable via a VPC.

**Who is this feature for?**

Grafana users who are running datasources in multiple networks and cannot open ports up to the public internet.

**Which issue(s) does this PR fix?**:

Directly relates to: https://github.com/grafana/hosted-grafana/issues/2922

**Screenshot of the UI & the connections working**:
![cloudwatch](https://user-images.githubusercontent.com/14365078/227364572-9d085720-3edc-4984-abb3-7f56bcf35753.png)
