### PR TITLE
Inspector: Keep data formatting options in local storage

### DIFF
--- a/public/app/features/dashboard/components/Inspector/InspectContent.tsx
+++ b/public/app/features/dashboard/components/Inspector/InspectContent.tsx
@@ -4,6 +4,7 @@ import { CoreApp, DataSourceApi, formattedValueToString, getValueFormat, PanelDa
 import { getTemplateSrv } from '@grafana/runtime';
 import { Drawer, Tab, TabsBar } from '@grafana/ui';
 import { t, Trans } from 'app/core/internationalization';
+import { InspectGetDataOptions } from 'app/features/inspector/InspectDataOptions';
 import { InspectDataTab } from 'app/features/inspector/InspectDataTab';
 import { InspectErrorTab } from 'app/features/inspector/InspectErrorTab';
 import { InspectJSONTab } from 'app/features/inspector/InspectJSONTab';
@@ -12,7 +13,6 @@ import { InspectStatsTab } from 'app/features/inspector/InspectStatsTab';
 import { QueryInspector } from 'app/features/inspector/QueryInspector';
 import { InspectTab } from 'app/features/inspector/types';
 
-import { GetDataOptions } from '../../../query/state/PanelQueryRunner';
 import { DashboardModel, PanelModel } from '../../state';
 
 interface Props {
@@ -24,10 +24,10 @@ interface Props {
   // The last raw response
   data?: PanelData;
   isDataLoading: boolean;
-  dataOptions: GetDataOptions;
+  dataOptions: InspectGetDataOptions;
   // If the datasource supports custom metadata
   metadataDatasource?: DataSourceApi;
-  onDataOptionsChange: (options: GetDataOptions) => void;
+  onDataOptionsChange: (options: InspectGetDataOptions) => void;
   onClose: () => void;
 }
 

--- a/public/app/features/dashboard/components/Inspector/PanelInspector.tsx
+++ b/public/app/features/dashboard/components/Inspector/PanelInspector.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { connect, MapStateToProps } from 'react-redux';
 import { useLocation } from 'react-router-dom';
 
@@ -9,12 +9,11 @@ import { InspectTab } from 'app/features/inspector/types';
 import { getPanelStateForModel } from 'app/features/panel/state/selectors';
 import { StoreState } from 'app/types';
 
-import { GetDataOptions } from '../../../query/state/PanelQueryRunner';
 import { HelpWizard } from '../HelpWizard/HelpWizard';
 import { usePanelLatestData } from '../PanelEditor/usePanelLatestData';
 
 import { InspectContent } from './InspectContent';
-import { useDatasourceMetadata, useInspectTabs } from './hooks';
+import { useDatasourceMetadata, useInspectDataOptions, useInspectTabs } from './hooks';
 
 interface OwnProps {
   dashboard: DashboardModel;
@@ -28,10 +27,7 @@ export interface ConnectedProps {
 export type Props = OwnProps & ConnectedProps;
 
 const PanelInspectorUnconnected = ({ panel, dashboard, plugin }: Props) => {
-  const [dataOptions, setDataOptions] = useState<GetDataOptions>({
-    withTransforms: false,
-    withFieldConfig: true,
-  });
+  const { dataOptions, setDataOptions } = useInspectDataOptions();
 
   const location = useLocation();
   const { data, isLoading, error } = usePanelLatestData(panel, dataOptions, true);

--- a/public/app/features/dashboard/components/Inspector/hooks.ts
+++ b/public/app/features/dashboard/components/Inspector/hooks.ts
@@ -1,10 +1,12 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
+import { useLocalStorage } from 'react-use';
 import useAsync from 'react-use/lib/useAsync';
 
 import { DataQueryError, DataSourceApi, PanelData, PanelPlugin } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 import { t } from 'app/core/internationalization';
 import { DashboardModel, PanelModel } from 'app/features/dashboard/state';
+import { InspectGetDataOptions } from 'app/features/inspector/InspectDataOptions';
 import { InspectTab } from 'app/features/inspector/types';
 
 import { supportsDataQuery } from '../PanelEditor/utils';
@@ -65,4 +67,29 @@ export const useInspectTabs = (
     }
     return tabs;
   }, [plugin, metaDs, dashboard, error]);
+};
+
+export const useInspectDataOptions = () => {
+  const [withTransforms, setWithTransforms] = useLocalStorage<boolean>('grafana.inspector.withTransforms', false);
+  const [withFieldConfig, setWithFieldConfig] = useLocalStorage<boolean>('grafana.inspector.withFieldConfig', true);
+  const [downloadForExcel, setDownloadForExcel] = useLocalStorage<boolean>('grafana.inspector.downloadForExcel', false);
+
+  const dataOptions = useMemo<InspectGetDataOptions>(() => {
+    return {
+      withTransforms: Boolean(withTransforms),
+      withFieldConfig: Boolean(withFieldConfig),
+      downloadForExcel: Boolean(downloadForExcel),
+    };
+  }, [withTransforms, withFieldConfig, downloadForExcel]);
+
+  const setDataOptions = useCallback(
+    (opts: InspectGetDataOptions) => {
+      setWithTransforms(opts.withTransforms);
+      setWithFieldConfig(opts.withFieldConfig);
+      setDownloadForExcel(opts.downloadForExcel);
+    },
+    [setWithTransforms, setWithFieldConfig, setDownloadForExcel]
+  );
+
+  return { dataOptions, setDataOptions };
 };

--- a/public/app/features/inspector/InspectDataOptions.tsx
+++ b/public/app/features/inspector/InspectDataOptions.tsx
@@ -10,18 +10,21 @@ import { GetDataOptions } from 'app/features/query/state/PanelQueryRunner';
 
 import { getPanelInspectorStyles2 } from './styles';
 
+export interface InspectGetDataOptions extends GetDataOptions {
+  downloadForExcel?: boolean;
+}
+
 interface Props {
-  options: GetDataOptions;
+  options: InspectGetDataOptions;
+  onOptionsChange?: (options: InspectGetDataOptions) => void;
+
   dataFrames: DataFrame[];
   transformId: DataTransformerID;
   transformationOptions: Array<SelectableValue<DataTransformerID>>;
   selectedDataFrame: number | DataTransformerID;
-  downloadForExcel: boolean;
   onDataFrameChange: (item: SelectableValue<DataTransformerID | number>) => void;
-  toggleDownloadForExcel: () => void;
   data?: DataFrame[];
   panel?: PanelModel;
-  onOptionsChange?: (options: GetDataOptions) => void;
 }
 
 export const InspectDataOptions = ({
@@ -34,8 +37,6 @@ export const InspectDataOptions = ({
   transformationOptions,
   selectedDataFrame,
   onDataFrameChange,
-  downloadForExcel,
-  toggleDownloadForExcel,
 }: Props) => {
   const styles = useStyles2(getPanelInspectorStyles2);
 
@@ -86,7 +87,7 @@ export const InspectDataOptions = ({
       }
     }
 
-    if (downloadForExcel) {
+    if (options.downloadForExcel) {
       parts.push(t('dashboard.inspect-data.excel-header', 'Excel header'));
     }
 
@@ -116,46 +117,54 @@ export const InspectDataOptions = ({
               </Field>
             )}
 
-            <HorizontalGroup>
-              {showPanelTransformationsOption && onOptionsChange && (
-                <Field
-                  label={t('dashboard.inspect-data.transformations-label', 'Apply panel transformations')}
-                  description={t(
-                    'dashboard.inspect-data.transformations-description',
-                    'Table data is displayed with transformations defined in the panel Transform tab.'
-                  )}
-                >
-                  <Switch
-                    value={!!options.withTransforms}
-                    onChange={() => onOptionsChange({ ...options, withTransforms: !options.withTransforms })}
-                  />
-                </Field>
-              )}
-              {showFieldConfigsOption && onOptionsChange && (
-                <Field
-                  label={t('dashboard.inspect-data.formatted-data-label', 'Formatted data')}
-                  description={t(
-                    'dashboard.inspect-data.formatted-data-description',
-                    'Table data is formatted with options defined in the Field and Override tabs.'
-                  )}
-                >
-                  <Switch
-                    id="formatted-data-toggle"
-                    value={!!options.withFieldConfig}
-                    onChange={() => onOptionsChange({ ...options, withFieldConfig: !options.withFieldConfig })}
-                  />
-                </Field>
-              )}
-              <Field
-                label={t('dashboard.inspect-data.download-excel-label', 'Download for Excel')}
-                description={t(
-                  'dashboard.inspect-data.download-excel-description',
-                  'Adds header to CSV for use with Excel'
+            {onOptionsChange && (
+              <HorizontalGroup>
+                {showPanelTransformationsOption && (
+                  <Field
+                    label={t('dashboard.inspect-data.transformations-label', 'Apply panel transformations')}
+                    description={t(
+                      'dashboard.inspect-data.transformations-description',
+                      'Table data is displayed with transformations defined in the panel Transform tab.'
+                    )}
+                  >
+                    <Switch
+                      value={!!options.withTransforms}
+                      onChange={() => onOptionsChange({ ...options, withTransforms: !options.withTransforms })}
+                    />
+                  </Field>
                 )}
-              >
-                <Switch id="excel-toggle" value={downloadForExcel} onChange={toggleDownloadForExcel} />
-              </Field>
-            </HorizontalGroup>
+                {showFieldConfigsOption && (
+                  <Field
+                    label={t('dashboard.inspect-data.formatted-data-label', 'Formatted data')}
+                    description={t(
+                      'dashboard.inspect-data.formatted-data-description',
+                      'Table data is formatted with options defined in the Field and Override tabs.'
+                    )}
+                  >
+                    <Switch
+                      id="formatted-data-toggle"
+                      value={!!options.withFieldConfig}
+                      onChange={() => onOptionsChange({ ...options, withFieldConfig: !options.withFieldConfig })}
+                    />
+                  </Field>
+                )}
+                <Field
+                  label={t('dashboard.inspect-data.download-excel-label', 'Download for Excel')}
+                  description={t(
+                    'dashboard.inspect-data.download-excel-description',
+                    'Adds header to CSV for use with Excel'
+                  )}
+                >
+                  <Switch
+                    id="excel-toggle"
+                    value={!!options.downloadForExcel}
+                    onChange={() =>
+                      onOptionsChange({ ...options, downloadForExcel: !Boolean(options.downloadForExcel) })
+                    }
+                  />
+                </Field>
+              </HorizontalGroup>
+            )}
           </VerticalGroup>
         </div>
       </QueryOperationRow>

--- a/public/app/features/inspector/InspectDataOptions.tsx
+++ b/public/app/features/inspector/InspectDataOptions.tsx
@@ -122,7 +122,7 @@ export const InspectDataOptions = ({
             )}
 
             <HorizontalGroup>
-              {onOptionsChange && showPanelTransformationsOption && (
+              {showPanelTransformationsOption && onOptionsChange && (
                 <Field
                   label={t('dashboard.inspect-data.transformations-label', 'Apply panel transformations')}
                   description={t(
@@ -136,7 +136,7 @@ export const InspectDataOptions = ({
                   />
                 </Field>
               )}
-              {onOptionsChange && showFieldConfigsOption && (
+              {showFieldConfigsOption && onOptionsChange && (
                 <Field
                   label={t('dashboard.inspect-data.formatted-data-label', 'Formatted data')}
                   description={t(

--- a/public/app/features/inspector/InspectDataOptions.tsx
+++ b/public/app/features/inspector/InspectDataOptions.tsx
@@ -16,6 +16,9 @@ export interface InspectGetDataOptions extends GetDataOptions {
 
 interface Props {
   options: InspectGetDataOptions;
+  toggleDownloadForExcel: () => void;
+
+  // This is not configured when used from explore
   onOptionsChange?: (options: InspectGetDataOptions) => void;
 
   dataFrames: DataFrame[];
@@ -30,6 +33,7 @@ interface Props {
 export const InspectDataOptions = ({
   options,
   onOptionsChange,
+  toggleDownloadForExcel,
   panel,
   data,
   dataFrames,
@@ -117,54 +121,46 @@ export const InspectDataOptions = ({
               </Field>
             )}
 
-            {onOptionsChange && (
-              <HorizontalGroup>
-                {showPanelTransformationsOption && (
-                  <Field
-                    label={t('dashboard.inspect-data.transformations-label', 'Apply panel transformations')}
-                    description={t(
-                      'dashboard.inspect-data.transformations-description',
-                      'Table data is displayed with transformations defined in the panel Transform tab.'
-                    )}
-                  >
-                    <Switch
-                      value={!!options.withTransforms}
-                      onChange={() => onOptionsChange({ ...options, withTransforms: !options.withTransforms })}
-                    />
-                  </Field>
-                )}
-                {showFieldConfigsOption && (
-                  <Field
-                    label={t('dashboard.inspect-data.formatted-data-label', 'Formatted data')}
-                    description={t(
-                      'dashboard.inspect-data.formatted-data-description',
-                      'Table data is formatted with options defined in the Field and Override tabs.'
-                    )}
-                  >
-                    <Switch
-                      id="formatted-data-toggle"
-                      value={!!options.withFieldConfig}
-                      onChange={() => onOptionsChange({ ...options, withFieldConfig: !options.withFieldConfig })}
-                    />
-                  </Field>
-                )}
+            <HorizontalGroup>
+              {onOptionsChange && showPanelTransformationsOption && (
                 <Field
-                  label={t('dashboard.inspect-data.download-excel-label', 'Download for Excel')}
+                  label={t('dashboard.inspect-data.transformations-label', 'Apply panel transformations')}
                   description={t(
-                    'dashboard.inspect-data.download-excel-description',
-                    'Adds header to CSV for use with Excel'
+                    'dashboard.inspect-data.transformations-description',
+                    'Table data is displayed with transformations defined in the panel Transform tab.'
                   )}
                 >
                   <Switch
-                    id="excel-toggle"
-                    value={!!options.downloadForExcel}
-                    onChange={() =>
-                      onOptionsChange({ ...options, downloadForExcel: !Boolean(options.downloadForExcel) })
-                    }
+                    value={!!options.withTransforms}
+                    onChange={() => onOptionsChange({ ...options, withTransforms: !options.withTransforms })}
                   />
                 </Field>
-              </HorizontalGroup>
-            )}
+              )}
+              {onOptionsChange && showFieldConfigsOption && (
+                <Field
+                  label={t('dashboard.inspect-data.formatted-data-label', 'Formatted data')}
+                  description={t(
+                    'dashboard.inspect-data.formatted-data-description',
+                    'Table data is formatted with options defined in the Field and Override tabs.'
+                  )}
+                >
+                  <Switch
+                    id="formatted-data-toggle"
+                    value={!!options.withFieldConfig}
+                    onChange={() => onOptionsChange({ ...options, withFieldConfig: !options.withFieldConfig })}
+                  />
+                </Field>
+              )}
+              <Field
+                label={t('dashboard.inspect-data.download-excel-label', 'Download for Excel')}
+                description={t(
+                  'dashboard.inspect-data.download-excel-description',
+                  'Adds header to CSV for use with Excel'
+                )}
+              >
+                <Switch id="excel-toggle" value={!!options.downloadForExcel} onChange={toggleDownloadForExcel} />
+              </Field>
+            </HorizontalGroup>
           </VerticalGroup>
         </div>
       </QueryOperationRow>

--- a/public/app/features/inspector/InspectDataTab.tsx
+++ b/public/app/features/inspector/InspectDataTab.tsx
@@ -46,6 +46,8 @@ interface State {
   dataFrameIndex: number;
   transformationOptions: Array<SelectableValue<DataTransformerID>>;
   transformedData: DataFrame[];
+
+  // This is kept in sync with options
   downloadForExcel: boolean;
 }
 
@@ -59,7 +61,7 @@ export class InspectDataTab extends PureComponent<Props, State> {
       transformId: DataTransformerID.noop,
       transformationOptions: buildTransformationOptions(),
       transformedData: props.data ?? [],
-      downloadForExcel: false,
+      downloadForExcel: Boolean(props.options.downloadForExcel),
     };
   }
 
@@ -180,9 +182,12 @@ export class InspectDataTab extends PureComponent<Props, State> {
   };
 
   toggleDownloadForExcel = () => {
-    this.setState((prevState) => ({
-      downloadForExcel: !prevState.downloadForExcel,
-    }));
+    const { options, onOptionsChange } = this.props;
+    const downloadForExcel = !options.downloadForExcel;
+    if (onOptionsChange) {
+      onOptionsChange({ ...options, downloadForExcel });
+    }
+    this.setState({ downloadForExcel });
   };
 
   getProcessedData(): DataFrame[] {
@@ -244,6 +249,7 @@ export class InspectDataTab extends PureComponent<Props, State> {
             transformationOptions={transformationOptions}
             selectedDataFrame={selectedDataFrame}
             onOptionsChange={onOptionsChange}
+            toggleDownloadForExcel={this.toggleDownloadForExcel}
             onDataFrameChange={this.onDataFrameChange}
           />
           <Button

--- a/public/app/features/inspector/InspectDataTab.tsx
+++ b/public/app/features/inspector/InspectDataTab.tsx
@@ -185,6 +185,7 @@ export class InspectDataTab extends PureComponent<Props, State> {
     const { options, onOptionsChange } = this.props;
     const downloadForExcel = !options.downloadForExcel;
     if (onOptionsChange) {
+      // keep in sync with the values managed in local storage
       onOptionsChange({ ...options, downloadForExcel });
     }
     this.setState({ downloadForExcel });
@@ -249,8 +250,8 @@ export class InspectDataTab extends PureComponent<Props, State> {
             transformationOptions={transformationOptions}
             selectedDataFrame={selectedDataFrame}
             onOptionsChange={onOptionsChange}
-            toggleDownloadForExcel={this.toggleDownloadForExcel}
             onDataFrameChange={this.onDataFrameChange}
+            toggleDownloadForExcel={this.toggleDownloadForExcel}
           />
           <Button
             variant="primary"

--- a/public/app/features/inspector/InspectDataTab.tsx
+++ b/public/app/features/inspector/InspectDataTab.tsx
@@ -21,23 +21,22 @@ import { config } from 'app/core/config';
 import { t, Trans } from 'app/core/internationalization';
 import { dataFrameToLogsModel } from 'app/core/logsModel';
 import { PanelModel } from 'app/features/dashboard/state';
-import { GetDataOptions } from 'app/features/query/state/PanelQueryRunner';
 import { transformToJaeger } from 'app/plugins/datasource/jaeger/responseTransform';
 import { transformToOTLP } from 'app/plugins/datasource/tempo/resultTransformer';
 import { transformToZipkin } from 'app/plugins/datasource/zipkin/utils/transforms';
 
-import { InspectDataOptions } from './InspectDataOptions';
+import { InspectDataOptions, InspectGetDataOptions } from './InspectDataOptions';
 import { getPanelInspectorStyles } from './styles';
 import { downloadAsJson, downloadDataFrameAsCsv, downloadLogsModelAsTxt } from './utils/download';
 
 interface Props {
   isLoading: boolean;
-  options: GetDataOptions;
+  options: InspectGetDataOptions;
   timeZone: TimeZone;
   app?: CoreApp;
   data?: DataFrame[];
   panel?: PanelModel;
-  onOptionsChange?: (options: GetDataOptions) => void;
+  onOptionsChange?: (options: InspectGetDataOptions) => void;
 }
 
 interface State {
@@ -209,7 +208,7 @@ export class InspectDataTab extends PureComponent<Props, State> {
 
   render() {
     const { isLoading, options, data, panel, onOptionsChange, app } = this.props;
-    const { dataFrameIndex, transformId, transformationOptions, selectedDataFrame, downloadForExcel } = this.state;
+    const { dataFrameIndex, transformId, transformationOptions, selectedDataFrame } = this.state;
     const styles = getPanelInspectorStyles();
 
     if (isLoading) {
@@ -244,10 +243,8 @@ export class InspectDataTab extends PureComponent<Props, State> {
             transformId={transformId}
             transformationOptions={transformationOptions}
             selectedDataFrame={selectedDataFrame}
-            downloadForExcel={downloadForExcel}
             onOptionsChange={onOptionsChange}
             onDataFrameChange={this.onDataFrameChange}
-            toggleDownloadForExcel={this.toggleDownloadForExcel}
           />
           <Button
             variant="primary"


### PR DESCRIPTION
**What is this feature?**

This updates the inspector data options so that they stay the same for users after making changes.

![2023-03-23_19-01-49 (1)](https://user-images.githubusercontent.com/705951/227405446-d87566e9-10f5-4762-91e5-d418f71ae2da.gif)


**Why do we need this feature?**

It is nice to have the settings relevant to how the user actually wants the data.  If they are downloading for excel once... they likely want it again.


**Who is this feature for?**

People using panel inspector

https://community.grafana.com/t/export-to-csv-set-default-value-of-apply-transformations-as-true/82283


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.