### PR TITLE
CI: Remove `grabpl` dependency from `publish-packages` steps

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4579,12 +4579,6 @@ platform:
 services: []
 steps:
 - commands:
-  - mkdir -p bin
-  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v3.0.30/grabpl
-  - chmod +x bin/grabpl
-  image: byrnedo/alpine-curl:0.1.8
-  name: grabpl
-- commands:
   - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
   depends_on: []
   environment:
@@ -4592,7 +4586,7 @@ steps:
   image: golang:1.20.1
   name: compile-build-cmd
 - depends_on:
-  - grabpl
+  - compile-build-cmd
   image: us.gcr.io/kubernetes-dev/package-publish:latest
   name: publish-linux-packages-deb
   privileged: true
@@ -4613,7 +4607,7 @@ steps:
       from_secret: packages_service_account
     target_bucket: grafana-packages
 - depends_on:
-  - grabpl
+  - compile-build-cmd
   image: us.gcr.io/kubernetes-dev/package-publish:latest
   name: publish-linux-packages-rpm
   privileged: true
@@ -4676,12 +4670,6 @@ platform:
 services: []
 steps:
 - commands:
-  - mkdir -p bin
-  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v3.0.30/grabpl
-  - chmod +x bin/grabpl
-  image: byrnedo/alpine-curl:0.1.8
-  name: grabpl
-- commands:
   - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
   depends_on: []
   environment:
@@ -4689,7 +4677,7 @@ steps:
   image: golang:1.20.1
   name: compile-build-cmd
 - depends_on:
-  - grabpl
+  - compile-build-cmd
   image: us.gcr.io/kubernetes-dev/package-publish:latest
   name: publish-linux-packages-deb
   privileged: true
@@ -4710,7 +4698,7 @@ steps:
       from_secret: packages_service_account
     target_bucket: grafana-packages
 - depends_on:
-  - grabpl
+  - compile-build-cmd
   image: us.gcr.io/kubernetes-dev/package-publish:latest
   name: publish-linux-packages-rpm
   privileged: true
@@ -6670,6 +6658,6 @@ kind: secret
 name: enterprise2_security_prefix
 ---
 kind: signature
-hmac: 84416be2a690d4290d31696b6c6a013d2358ea1b204d86e9b196dca4c5f0b906
+hmac: 19dcb9b6ece5560a19064f2b11d85d83df7872389a16dc333a36d6d92f4fa72b
 
 ...

--- a/scripts/drone/events/release.star
+++ b/scripts/drone/events/release.star
@@ -576,7 +576,6 @@ def publish_packages_pipeline():
         "target": ["public"],
     }
     oss_steps = [
-        download_grabpl_step(),
         compile_build_cmd(),
         publish_linux_packages_step(edition = "oss", package_manager = "deb"),
         publish_linux_packages_step(edition = "oss", package_manager = "rpm"),
@@ -584,7 +583,6 @@ def publish_packages_pipeline():
     ]
 
     enterprise_steps = [
-        download_grabpl_step(),
         compile_build_cmd(),
         publish_linux_packages_step(edition = "enterprise", package_manager = "deb"),
         publish_linux_packages_step(edition = "enterprise", package_manager = "rpm"),

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -1268,7 +1268,7 @@ def publish_linux_packages_step(edition, package_manager = "deb"):
         "name": "publish-linux-packages-{}".format(package_manager),
         # See https://github.com/grafana/deployment_tools/blob/master/docker/package-publish/README.md for docs on that image
         "image": "us.gcr.io/kubernetes-dev/package-publish:latest",
-        "depends_on": ["grabpl"],
+        "depends_on": ["compile-build-cmd"],
         "privileged": True,
         "settings": {
             "access_key_id": from_secret("packages_access_key_id"),


### PR DESCRIPTION
**What is this feature?**

Removes `grabpl` from `publish-packages` dependencies as they are not needed.