### PR TITLE
[v9.2.x] CI: Remove `grabpl` dependency from `publish-packages` steps (#65329)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4486,12 +4486,6 @@ platform:
 services: []
 steps:
 - commands:
-  - mkdir -p bin
-  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v3.0.30/grabpl
-  - chmod +x bin/grabpl
-  image: byrnedo/alpine-curl:0.1.8
-  name: grabpl
-- commands:
   - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
   depends_on: []
   environment:
@@ -4499,7 +4493,7 @@ steps:
   image: golang:1.19.4
   name: compile-build-cmd
 - depends_on:
-  - grabpl
+  - compile-build-cmd
   image: us.gcr.io/kubernetes-dev/package-publish:latest
   name: publish-linux-packages-deb
   privileged: true
@@ -4520,7 +4514,7 @@ steps:
       from_secret: packages_service_account
     target_bucket: grafana-packages
 - depends_on:
-  - grabpl
+  - compile-build-cmd
   image: us.gcr.io/kubernetes-dev/package-publish:latest
   name: publish-linux-packages-rpm
   privileged: true
@@ -4583,12 +4577,6 @@ platform:
 services: []
 steps:
 - commands:
-  - mkdir -p bin
-  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v3.0.30/grabpl
-  - chmod +x bin/grabpl
-  image: byrnedo/alpine-curl:0.1.8
-  name: grabpl
-- commands:
   - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
   depends_on: []
   environment:
@@ -4596,7 +4584,7 @@ steps:
   image: golang:1.19.4
   name: compile-build-cmd
 - depends_on:
-  - grabpl
+  - compile-build-cmd
   image: us.gcr.io/kubernetes-dev/package-publish:latest
   name: publish-linux-packages-deb
   privileged: true
@@ -4617,7 +4605,7 @@ steps:
       from_secret: packages_service_account
     target_bucket: grafana-packages
 - depends_on:
-  - grabpl
+  - compile-build-cmd
   image: us.gcr.io/kubernetes-dev/package-publish:latest
   name: publish-linux-packages-rpm
   privileged: true
@@ -6534,6 +6522,6 @@ kind: secret
 name: enterprise2_security_prefix
 ---
 kind: signature
-hmac: ddbb4b9b753132c24db6de4d57ccd2f5a05ceebe9eaf32a12f34c86372cf37ef
+hmac: 3f77e38d0e3fd91f9a878e40fae2ba397747af28aaf5db7b91625b57fdd75398
 
 ...

--- a/scripts/drone/events/release.star
+++ b/scripts/drone/events/release.star
@@ -574,7 +574,6 @@ def publish_packages_pipeline():
         "target": ["public"],
     }
     oss_steps = [
-        download_grabpl_step(),
         compile_build_cmd(),
         publish_linux_packages_step(edition = "oss", package_manager = "deb"),
         publish_linux_packages_step(edition = "oss", package_manager = "rpm"),
@@ -582,7 +581,6 @@ def publish_packages_pipeline():
     ]
 
     enterprise_steps = [
-        download_grabpl_step(),
         compile_build_cmd(),
         publish_linux_packages_step(edition = "enterprise", package_manager = "deb"),
         publish_linux_packages_step(edition = "enterprise", package_manager = "rpm"),

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -1268,7 +1268,7 @@ def publish_linux_packages_step(edition, package_manager = "deb"):
         "name": "publish-linux-packages-{}".format(package_manager),
         # See https://github.com/grafana/deployment_tools/blob/master/docker/package-publish/README.md for docs on that image
         "image": "us.gcr.io/kubernetes-dev/package-publish:latest",
-        "depends_on": ["grabpl"],
+        "depends_on": ["compile-build-cmd"],
         "privileged": True,
         "settings": {
             "access_key_id": from_secret("packages_access_key_id"),


### PR DESCRIPTION
Remove grabpl dependency from publish packages

(cherry picked from commit 3b00d2c273d5b7622b225ae56381879b60a10c2a)

# Conflicts:
#	.drone.yml

Backports #65329