### PR TITLE
Elasticsearch: Run Explore queries trough data source backend

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -29,24 +29,25 @@ Some stable features are enabled by default. You can disable a stable feature by
 | `internationalization`              | Enables internationalization                                                                                                                                                 | Yes                |
 | `cloudWatchCrossAccountQuerying`    | Enables cross-account querying in CloudWatch datasources                                                                                                                     | Yes                |
 | `accessTokenExpirationCheck`        | Enable OAuth access_token expiration check and token refresh using the refresh_token                                                                                         |                    |
-| `disablePrometheusExemplarSampling` | Disable Prometheus examplar sampling                                                                                                                                         |                    |
+| `disablePrometheusExemplarSampling` | Disable Prometheus exemplar sampling                                                                                                                                         |                    |
 | `logsSampleInExplore`               | Enables access to the logs sample feature in Explore                                                                                                                         | Yes                |
 
 ## Beta feature toggles
 
-| Feature toggle name               | Description                                                                                                                                                                                  |
-| --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `trimDefaults`                    | Use cue schema to remove values that will be applied automatically                                                                                                                           |
-| `panelTitleSearch`                | Search for dashboards using panel title                                                                                                                                                      |
-| `prometheusAzureOverrideAudience` | Experimental. Allow override default AAD audience for Azure Prometheus endpoint                                                                                                              |
-| `migrationLocking`                | Lock database during migrations                                                                                                                                                              |
-| `newDBLibrary`                    | Use jmoiron/sqlx rather than xorm for a few backend services                                                                                                                                 |
-| `validateDashboardsOnSave`        | Validate dashboard JSON POSTed to api/dashboards/db                                                                                                                                          |
-| `autoMigrateOldPanels`            | Migrate old angular panels to supported versions (graph, table-old, worldmap, etc)                                                                                                           |
-| `disableAngular`                  | Dynamic flag to disable angular at runtime. The preferred method is to set `angular_support_enabled` to `false` in the [security] settings, which allows you to change the state at runtime. |
-| `topnav`                          | Displays new top nav and page layouts                                                                                                                                                        |
-| `accessControlOnCall`             | Access control primitives for OnCall                                                                                                                                                         |
-| `alertingNoNormalState`           | Stop maintaining state of alerts that are not firing                                                                                                                                         |
+| Feature toggle name                       | Description                                                                                                                                                                                  |
+| ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `trimDefaults`                            | Use cue schema to remove values that will be applied automatically                                                                                                                           |
+| `panelTitleSearch`                        | Search for dashboards using panel title                                                                                                                                                      |
+| `prometheusAzureOverrideAudience`         | Experimental. Allow override default AAD audience for Azure Prometheus endpoint                                                                                                              |
+| `migrationLocking`                        | Lock database during migrations                                                                                                                                                              |
+| `newDBLibrary`                            | Use jmoiron/sqlx rather than xorm for a few backend services                                                                                                                                 |
+| `validateDashboardsOnSave`                | Validate dashboard JSON POSTed to api/dashboards/db                                                                                                                                          |
+| `autoMigrateOldPanels`                    | Migrate old angular panels to supported versions (graph, table-old, worldmap, etc)                                                                                                           |
+| `disableAngular`                          | Dynamic flag to disable angular at runtime. The preferred method is to set `angular_support_enabled` to `false` in the [security] settings, which allows you to change the state at runtime. |
+| `topnav`                                  | Displays new top nav and page layouts                                                                                                                                                        |
+| `accessControlOnCall`                     | Access control primitives for OnCall                                                                                                                                                         |
+| `alertingNoNormalState`                   | Stop maintaining state of alerts that are not firing                                                                                                                                         |
+| `disableElasticsearchBackendExploreQuery` | Disable executing of Elasticsearch Explore queries trough backend                                                                                                                            |
 
 ## Alpha feature toggles
 

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -84,4 +84,5 @@ export interface FeatureToggles {
   timeSeriesTable?: boolean;
   influxdbBackendMigration?: boolean;
   clientTokenRotation?: boolean;
+  disableElasticsearchBackendExploreQuery?: boolean;
 }

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -334,7 +334,7 @@ var (
 		},
 		{
 			Name:        "disablePrometheusExemplarSampling",
-			Description: "Disable Prometheus examplar sampling",
+			Description: "Disable Prometheus exemplar sampling",
 			State:       FeatureStateStable,
 			Owner:       grafanaObservabilityMetricsSquad,
 		},
@@ -440,6 +440,12 @@ var (
 			Description: "Replaces the current in-request token rotation so that the client initiates the rotation",
 			State:       FeatureStateAlpha,
 			Owner:       grafanaAuthnzSquad,
+		},
+		{
+			Name:        "disableElasticsearchBackendExploreQuery",
+			Description: "Disable executing of Elasticsearch Explore queries trough backend",
+			State:       FeatureStateBeta,
+			Owner:       grafanaObservabilityLogsSquad,
 		},
 	}
 )

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -65,3 +65,4 @@ prometheusMetricEncyclopedia,alpha,@grafana/observability-metrics,false,false,fa
 timeSeriesTable,alpha,@grafana/app-o11y,false,false,false,true
 influxdbBackendMigration,alpha,@grafana/observability-metrics,false,false,false,true
 clientTokenRotation,alpha,@grafana/grafana-authnz-team,false,false,false,false
+disableElasticsearchBackendExploreQuery,beta,@grafana/observability-logs,false,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -208,7 +208,7 @@ const (
 	FlagAuthnService = "authnService"
 
 	// FlagDisablePrometheusExemplarSampling
-	// Disable Prometheus examplar sampling
+	// Disable Prometheus exemplar sampling
 	FlagDisablePrometheusExemplarSampling = "disablePrometheusExemplarSampling"
 
 	// FlagAlertingBacktesting
@@ -270,4 +270,8 @@ const (
 	// FlagClientTokenRotation
 	// Replaces the current in-request token rotation so that the client initiates the rotation
 	FlagClientTokenRotation = "clientTokenRotation"
+
+	// FlagDisableElasticsearchBackendExploreQuery
+	// Disable executing of Elasticsearch Explore queries trough backend
+	FlagDisableElasticsearchBackendExploreQuery = "disableElasticsearchBackendExploreQuery"
 )

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -641,8 +641,12 @@ export class ElasticDatasource
   }
 
   query(request: DataQueryRequest<ElasticsearchQuery>): Observable<DataQueryResponse> {
+    // Run request through backend if it is coming from Explore and disableElasticsearchBackendExploreQuery is not set
+    // or if elasticsearchBackendMigration feature toggle is enabled
+    const { elasticsearchBackendMigration, disableElasticsearchBackendExploreQuery } = config.featureToggles;
     const shouldRunTroughBackend =
-      request.app === CoreApp.Explore && config.featureToggles.elasticsearchBackendMigration;
+      (request.app === CoreApp.Explore && !disableElasticsearchBackendExploreQuery) || elasticsearchBackendMigration;
+
     if (shouldRunTroughBackend) {
       const start = new Date();
       return super.query(request).pipe(tap((response) => trackQuery(response, request, start)));


### PR DESCRIPTION
Part of https://github.com/grafana/grafana/issues/54011. 

In this PR, we are moving running and processing of Elasticsearch queries executed in Explore to backend. We are adding `disableElasticsearchBackendExploreQuery` feature toggle (`defaults to `false`)  to give users to disable this functionality. 

We are also keeping `elasticsearchBackendMigration` (alpha feature flag that defaults to `false`) for development purposes and also in the future, users can use this to enable running of all queries trough backend, if they'd like to try it (currently not recommended). 