### PR TITLE
Alerting: Use displayNameFromDS if available in preview

### DIFF
--- a/public/app/features/alerting/unified/components/expressions/Expression.tsx
+++ b/public/app/features/alerting/unified/components/expressions/Expression.tsx
@@ -135,20 +135,12 @@ interface ExpressionResultProps {
 }
 export const PAGE_SIZE = 20;
 export const ExpressionResult: FC<ExpressionResultProps> = ({ series, isAlertCondition }) => {
-  const { page, pageItems, onPageChange, numberOfPages, pageStart, pageEnd } = usePagination(series, 1, PAGE_SIZE);
+  const { pageItems, previousPage, nextPage, numberOfPages, pageStart, pageEnd } = usePagination(series, 1, PAGE_SIZE);
   const styles = useStyles2(getStyles);
 
   // sometimes we receive results where every value is just "null" when noData occurs
   const emptyResults = isEmptySeries(series);
   const isTimeSeriesResults = !emptyResults && isTimeSeriesFrames(series);
-
-  const previousPage = useCallback(() => {
-    onPageChange(page - 1);
-  }, [page, onPageChange]);
-
-  const nextPage = useCallback(() => {
-    onPageChange(page + 1);
-  }, [page, onPageChange]);
 
   const shouldShowPagination = numberOfPages > 1;
 
@@ -331,8 +323,11 @@ const FrameRow: FC<FrameProps> = ({ frame, index, isAlertCondition }) => {
 const TimeseriesRow: FC<FrameProps & { index: number }> = ({ frame, index }) => {
   const styles = useStyles2(getStyles);
 
-  const hasLabels = frame.fields[1].labels;
-  const name = hasLabels ? formatLabels(frame.fields[1].labels ?? {}) : 'Series ' + index;
+  const valueField = frame.fields[1]; // field 0 is "time", field 1 is "value"
+
+  const hasLabels = valueField.labels;
+  const displayNameFromDS = valueField.config?.displayNameFromDS;
+  const name = displayNameFromDS ?? (hasLabels ? formatLabels(valueField.labels ?? {}) : 'Series ' + index);
 
   const timestamps = frame.fields[0].values.toArray();
 

--- a/public/app/features/alerting/unified/components/expressions/util.test.ts
+++ b/public/app/features/alerting/unified/components/expressions/util.test.ts
@@ -62,6 +62,25 @@ describe('getSeriesName', () => {
   it('should work with NoData frames', () => {
     expect(getSeriesName(EMPTY_FRAME)).toBe('');
   });
+
+  it('should give preference to displayNameFromDS', () => {
+    const frame: DataFrame = {
+      name: 'MyFrame',
+      ...toDataFrame({
+        fields: [
+          {
+            name: 'value',
+            type: FieldType.number,
+            values: [1, 2, 3],
+            labels: { foo: 'bar' },
+            config: { displayNameFromDS: 'series-name-override' },
+          },
+        ],
+      }),
+    };
+
+    expect(getSeriesName(frame)).toBe('series-name-override');
+  });
 });
 
 describe('getSeriesValue', () => {

--- a/public/app/features/alerting/unified/components/expressions/util.ts
+++ b/public/app/features/alerting/unified/components/expressions/util.ts
@@ -10,7 +10,10 @@ import { DataFrame, Labels, roundDecimals } from '@grafana/data';
  */
 
 const getSeriesName = (frame: DataFrame): string => {
-  return frame.name ?? formatLabels(frame.fields[0]?.labels ?? {});
+  const firstField = frame.fields[0];
+
+  const displayNameFromDS = firstField?.config?.displayNameFromDS;
+  return displayNameFromDS ?? frame.name ?? formatLabels(firstField?.labels ?? {});
 };
 
 const getSeriesValue = (frame: DataFrame) => {


### PR DESCRIPTION
**What is this feature?**

Adds support for `displayNameFromDS` in the Alerting preview

**Why do we need this feature?**

Some data sources (such as Graphite) assign a name to a frame field, if this is assigned from the data source we should show that one over a generic `series x`.

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
- [x] There are no known compatibility issues with older supported versions of Grafana, or plugins.
- [ ] It passes the [Hosted Grafana feature readiness review](https://docs.google.com/document/d/1QL9Ly8KnXzpb6ISbg49pTODRO5mhA5tkkfIZVX6pqQU/edit) for observability, scalability, performance, and security.