### PR TITLE
[v9.4.x] CI: Cleanup unnecessary `grabpl` dependencies (#65330)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -20,12 +20,6 @@ steps:
   image: alpine:3.17.1
   name: identify-runner
 - commands:
-  - mkdir -p bin
-  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v3.0.30/grabpl
-  - chmod +x bin/grabpl
-  image: byrnedo/alpine-curl:0.1.8
-  name: grabpl
-- commands:
   - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
   depends_on: []
   environment:
@@ -75,12 +69,6 @@ steps:
   - echo $DRONE_RUNNER_NAME
   image: alpine:3.17.1
   name: identify-runner
-- commands:
-  - mkdir -p bin
-  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v3.0.30/grabpl
-  - chmod +x bin/grabpl
-  image: byrnedo/alpine-curl:0.1.8
-  name: grabpl
 - commands:
   - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
   depends_on: []
@@ -841,12 +829,6 @@ platform:
 services: []
 steps:
 - commands:
-  - mkdir -p bin
-  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v3.0.30/grabpl
-  - chmod +x bin/grabpl
-  image: byrnedo/alpine-curl:0.1.8
-  name: grabpl
-- commands:
   - echo $DRONE_RUNNER_NAME
   image: alpine:3.17.1
   name: identify-runner
@@ -957,12 +939,6 @@ platform:
   os: linux
 services: []
 steps:
-- commands:
-  - mkdir -p bin
-  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v3.0.30/grabpl
-  - chmod +x bin/grabpl
-  image: byrnedo/alpine-curl:0.1.8
-  name: grabpl
 - commands:
   - echo $DRONE_RUNNER_NAME
   image: alpine:3.17.1
@@ -6551,6 +6527,6 @@ kind: secret
 name: enterprise2_security_prefix
 ---
 kind: signature
-hmac: 1eed7e78b481de96730fff025aff5c643a7f91c7000fa69f91f30a4493548113
+hmac: b505c7d5b0150fba76ef856d147083bba5c27486123a4109299604e4875f1bc8
 
 ...

--- a/scripts/drone/pipelines/docs.star
+++ b/scripts/drone/pipelines/docs.star
@@ -7,7 +7,6 @@ load(
     "build_docs_website_step",
     "build_image",
     "codespell_step",
-    "download_grabpl_step",
     "identify_runner_step",
     "yarn_install_step",
 )
@@ -28,7 +27,6 @@ docs_paths = {
 def docs_pipelines(ver_mode, trigger):
     environment = {"EDITION": "oss"}
     steps = [
-        download_grabpl_step(),
         identify_runner_step(),
         yarn_install_step(),
         codespell_step(),

--- a/scripts/drone/pipelines/verify_drone.star
+++ b/scripts/drone/pipelines/verify_drone.star
@@ -5,7 +5,6 @@ This module returns the pipeline used for verifying Drone configuration.
 load(
     "scripts/drone/steps/lib.star",
     "compile_build_cmd",
-    "download_grabpl_step",
     "identify_runner_step",
     "lint_drone_step",
 )
@@ -18,7 +17,6 @@ def verify_drone(trigger, ver_mode):
     environment = {"EDITION": "oss"}
     steps = [
         identify_runner_step(),
-        download_grabpl_step(),
         compile_build_cmd(),
         lint_drone_step(),
     ]

--- a/scripts/drone/pipelines/verify_starlark.star
+++ b/scripts/drone/pipelines/verify_starlark.star
@@ -5,7 +5,6 @@ This module returns a Drone pipeline that verifies all Starlark files are linted
 load(
     "scripts/drone/steps/lib.star",
     "compile_build_cmd",
-    "download_grabpl_step",
     "identify_runner_step",
     "lint_starlark_step",
 )
@@ -18,7 +17,6 @@ def verify_starlark(trigger, ver_mode):
     environment = {"EDITION": "oss"}
     steps = [
         identify_runner_step(),
-        download_grabpl_step(),
         compile_build_cmd(),
         lint_starlark_step(),
     ]


### PR DESCRIPTION
* Remove unnecessary grabpl dependencies

* Revert test-frontend change

(cherry picked from commit 89d642e001513c72120aac89be997735717dd174)

# Conflicts:
#	.drone.yml

Backports #65330