### PR TITLE
API: Fix  "Updated by" Column in dashboard versions table

### DIFF
--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -695,6 +695,7 @@ func (hs *HTTPServer) GetDashboardVersions(c *contextmodel.ReqContext) response.
 			})
 			if err != nil {
 				hs.log.Debug("failed to get user that has created the dashboard", "err", err, "createdBy", version.CreatedBy, "dashboardUID", version.DashboardUID)
+				continue
 			}
 			hs.CacheService.Set(key, u.Login, time.Second*5)
 			version.CreatedByStr = u.Login

--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -145,16 +145,6 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 		fakeDash.HasACL = false
 		fakeDashboardVersionService := dashvertest.NewDashboardVersionServiceFake()
 		fakeDashboardVersionService.ExpectedDashboardVersion = &dashver.DashboardVersionDTO{}
-		fakeDashboardVersionService.ExpectedListDashboarVersions = []*dashver.DashboardVersionDTO{
-			{
-				Version:   1,
-				CreatedBy: 1,
-			},
-			{
-				Version:   2,
-				CreatedBy: 1,
-			},
-		}
 		teamService := &teamtest.FakeService{}
 		dashboardService := dashboards.NewFakeDashboardService(t)
 		dashboardService.On("GetDashboard", mock.Anything, mock.AnythingOfType("*dashboards.GetDashboardQuery")).Return(fakeDash, nil)

--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -15,6 +16,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/services/publicdashboards"
 	"github.com/grafana/grafana/pkg/services/publicdashboards/api"
+	"github.com/grafana/grafana/pkg/services/user/usertest"
 
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/api/response"
@@ -23,6 +25,7 @@ import (
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/db/dbtest"
+	"github.com/grafana/grafana/pkg/infra/localcache"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/infra/usagestats"
 	"github.com/grafana/grafana/pkg/plugins"
@@ -141,6 +144,17 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 		fakeDash.HasACL = false
 		fakeDashboardVersionService := dashvertest.NewDashboardVersionServiceFake()
 		fakeDashboardVersionService.ExpectedDashboardVersion = &dashver.DashboardVersionDTO{}
+		fakeDashboardVersionService.ExpectedDashboardVersion = &dashver.DashboardVersionDTO{}
+		fakeDashboardVersionService.ExpectedListDashboarVersions = []*dashver.DashboardVersionDTO{
+			{
+				Version:   1,
+				CreatedBy: 1,
+			},
+			{
+				Version:   2,
+				CreatedBy: 1,
+			},
+		}
 		teamService := &teamtest.FakeService{}
 		dashboardService := dashboards.NewFakeDashboardService(t)
 		dashboardService.On("GetDashboard", mock.Anything, mock.AnythingOfType("*dashboards.GetDashboardQuery")).Return(fakeDash, nil)
@@ -156,6 +170,10 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 			dashboardVersionService: fakeDashboardVersionService,
 			Kinds:                   corekind.NewBase(nil),
 			QuotaService:            quotatest.New(false, nil),
+			userService: &usertest.FakeUserService{
+				ExpectedUser: &user.User{ID: 1, Login: "test-user"},
+			},
+			CacheService: localcache.New(5*time.Minute, 10*time.Minute),
 		}
 
 		setUp := func() {
@@ -225,6 +243,10 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 					hs.callGetDashboardVersion(sc)
 
 					assert.Equal(t, 200, sc.resp.Code)
+					var version *dashver.DashboardVersionMeta
+					err := json.NewDecoder(sc.resp.Body).Decode(&version)
+					require.NoError(t, err)
+					assert.NotEmpty(t, version.CreatedBy)
 				}, mockSQLStore)
 
 			loggedInUserScenarioWithRole(t, "When calling GET on", "GET", "/api/dashboards/id/2/versions",
@@ -233,6 +255,12 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 					hs.callGetDashboardVersions(sc)
 
 					assert.Equal(t, 200, sc.resp.Code)
+					var versions []*dashver.DashboardVersionDTO
+					err := json.NewDecoder(sc.resp.Body).Decode(&versions)
+					require.NoError(t, err)
+					for _, v := range versions {
+						assert.NotEmpty(t, v.CreatedByStr)
+					}
 				}, mockSQLStore)
 		})
 	})

--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/db/dbtest"
 	"github.com/grafana/grafana/pkg/infra/localcache"
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/infra/usagestats"
 	"github.com/grafana/grafana/pkg/plugins"
@@ -144,7 +145,6 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 		fakeDash.HasACL = false
 		fakeDashboardVersionService := dashvertest.NewDashboardVersionServiceFake()
 		fakeDashboardVersionService.ExpectedDashboardVersion = &dashver.DashboardVersionDTO{}
-		fakeDashboardVersionService.ExpectedDashboardVersion = &dashver.DashboardVersionDTO{}
 		fakeDashboardVersionService.ExpectedListDashboarVersions = []*dashver.DashboardVersionDTO{
 			{
 				Version:   1,
@@ -170,10 +170,6 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 			dashboardVersionService: fakeDashboardVersionService,
 			Kinds:                   corekind.NewBase(nil),
 			QuotaService:            quotatest.New(false, nil),
-			userService: &usertest.FakeUserService{
-				ExpectedUser: &user.User{ID: 1, Login: "test-user"},
-			},
-			CacheService: localcache.New(5*time.Minute, 10*time.Minute),
 		}
 
 		setUp := func() {
@@ -255,12 +251,6 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 					hs.callGetDashboardVersions(sc)
 
 					assert.Equal(t, 200, sc.resp.Code)
-					var versions []*dashver.DashboardVersionDTO
-					err := json.NewDecoder(sc.resp.Body).Decode(&versions)
-					require.NoError(t, err)
-					for _, v := range versions {
-						assert.NotEmpty(t, v.CreatedByStr)
-					}
 				}, mockSQLStore)
 		})
 	})
@@ -961,6 +951,129 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 			assert.Equal(t, false, dash.Meta.Provisioned)
 		}, mockSQLStore)
 	})
+}
+
+func TestDashboardVersionsAPIEndpoint(t *testing.T) {
+	fakeDash := dashboards.NewDashboard("Child dash")
+	fakeDash.ID = 1
+	fakeDash.FolderID = 1
+	fakeDash.HasACL = false
+
+	fakeDashboardVersionService := dashvertest.NewDashboardVersionServiceFake()
+	dashboardService := dashboards.NewFakeDashboardService(t)
+	dashboardService.On("GetDashboard", mock.Anything, mock.AnythingOfType("*dashboards.GetDashboardQuery")).Return(fakeDash, nil)
+
+	teamService := &teamtest.FakeService{}
+
+	mockSQLStore := dbtest.NewFakeDB()
+
+	cfg := setting.NewCfg()
+
+	getHS := func(userSvc *usertest.FakeUserService) *HTTPServer {
+		return &HTTPServer{
+			Cfg:                     cfg,
+			pluginStore:             &plugins.FakePluginStore{},
+			SQLStore:                mockSQLStore,
+			AccessControl:           accesscontrolmock.New(),
+			Features:                featuremgmt.WithFeatures(),
+			DashboardService:        dashboardService,
+			dashboardVersionService: fakeDashboardVersionService,
+			Kinds:                   corekind.NewBase(nil),
+			QuotaService:            quotatest.New(false, nil),
+			userService:             userSvc,
+			CacheService:            localcache.New(5*time.Minute, 10*time.Minute),
+			log:                     log.New(),
+		}
+	}
+
+	setUp := func() {
+		viewerRole := org.RoleViewer
+		editorRole := org.RoleEditor
+		qResult := []*dashboards.DashboardACLInfoDTO{
+			{Role: &viewerRole, Permission: dashboards.PERMISSION_VIEW},
+			{Role: &editorRole, Permission: dashboards.PERMISSION_EDIT},
+		}
+		dashboardService.On("GetDashboardACLInfoList", mock.Anything, mock.AnythingOfType("*dashboards.GetDashboardACLInfoListQuery")).Return(qResult, nil)
+		guardian.InitLegacyGuardian(cfg, mockSQLStore, dashboardService, teamService)
+	}
+
+	loggedInUserScenarioWithRole(t, "When user exists and calling GET on", "GET", "/api/dashboards/id/2/versions",
+		"/api/dashboards/id/:dashboardId/versions", org.RoleEditor, func(sc *scenarioContext) {
+			setUp()
+			fakeDashboardVersionService.ExpectedListDashboarVersions = []*dashver.DashboardVersionDTO{
+				{
+					Version:   1,
+					CreatedBy: 1,
+				},
+				{
+					Version:   2,
+					CreatedBy: 1,
+				},
+			}
+			getHS(&usertest.FakeUserService{
+				ExpectedUser: &user.User{ID: 1, Login: "test-user"},
+			}).callGetDashboardVersions(sc)
+
+			assert.Equal(t, 200, sc.resp.Code)
+			var versions []*dashver.DashboardVersionDTO
+			err := json.NewDecoder(sc.resp.Body).Decode(&versions)
+			require.NoError(t, err)
+			for _, v := range versions {
+				assert.Equal(t, "test-user", v.CreatedByStr)
+			}
+		}, mockSQLStore)
+
+	loggedInUserScenarioWithRole(t, "When user does not exist and calling GET on", "GET", "/api/dashboards/id/2/versions",
+		"/api/dashboards/id/:dashboardId/versions", org.RoleEditor, func(sc *scenarioContext) {
+			setUp()
+			fakeDashboardVersionService.ExpectedListDashboarVersions = []*dashver.DashboardVersionDTO{
+				{
+					Version:   1,
+					CreatedBy: 1,
+				},
+				{
+					Version:   2,
+					CreatedBy: 1,
+				},
+			}
+			getHS(&usertest.FakeUserService{
+				ExpectedError: user.ErrUserNotFound,
+			}).callGetDashboardVersions(sc)
+
+			assert.Equal(t, 200, sc.resp.Code)
+			var versions []*dashver.DashboardVersionDTO
+			err := json.NewDecoder(sc.resp.Body).Decode(&versions)
+			require.NoError(t, err)
+			for _, v := range versions {
+				assert.Empty(t, v.CreatedByStr)
+			}
+		}, mockSQLStore)
+
+	loggedInUserScenarioWithRole(t, "When failing to get user and calling GET on", "GET", "/api/dashboards/id/2/versions",
+		"/api/dashboards/id/:dashboardId/versions", org.RoleEditor, func(sc *scenarioContext) {
+			setUp()
+			fakeDashboardVersionService.ExpectedListDashboarVersions = []*dashver.DashboardVersionDTO{
+				{
+					Version:   1,
+					CreatedBy: 1,
+				},
+				{
+					Version:   2,
+					CreatedBy: 1,
+				},
+			}
+			getHS(&usertest.FakeUserService{
+				ExpectedError: fmt.Errorf("some error"),
+			}).callGetDashboardVersions(sc)
+
+			assert.Equal(t, 200, sc.resp.Code)
+			var versions []*dashver.DashboardVersionDTO
+			err := json.NewDecoder(sc.resp.Body).Decode(&versions)
+			require.NoError(t, err)
+			for _, v := range versions {
+				assert.Empty(t, v.CreatedByStr)
+			}
+		}, mockSQLStore)
 }
 
 func getDashboardShouldReturn200WithConfig(t *testing.T, sc *scenarioContext, provisioningService provisioning.ProvisioningService, dashboardStore dashboards.Store, dashboardService dashboards.DashboardService, folderStore folder.FolderStore) dtos.DashboardFullWithMeta {

--- a/pkg/services/dashboardversion/model.go
+++ b/pkg/services/dashboardversion/model.go
@@ -66,7 +66,6 @@ type ListDashboardVersionsQuery struct {
 	Limit        int
 	Start        int
 }
-
 type DashboardVersionDTO struct {
 	ID            int64            `json:"id"`
 	DashboardID   int64            `json:"dashboardId"`
@@ -75,8 +74,7 @@ type DashboardVersionDTO struct {
 	RestoredFrom  int              `json:"restoredFrom"`
 	Version       int              `json:"version"`
 	Created       time.Time        `json:"created"`
-	CreatedBy     int64            `json:"-"`
-	CreatedByStr  string           `json:"createdBy"`
+	CreatedBy     int64            `json:"createdBy"`
 	Message       string           `json:"message"`
 	Data          *simplejson.Json `json:"data" db:"data"`
 }

--- a/pkg/services/dashboardversion/model.go
+++ b/pkg/services/dashboardversion/model.go
@@ -75,7 +75,8 @@ type DashboardVersionDTO struct {
 	RestoredFrom  int              `json:"restoredFrom"`
 	Version       int              `json:"version"`
 	Created       time.Time        `json:"created"`
-	CreatedBy     int64            `json:"createdBy"`
+	CreatedBy     int64            `json:"-"`
+	CreatedByStr  string           `json:"createdBy"`
 	Message       string           `json:"message"`
 	Data          *simplejson.Json `json:"data" db:"data"`
 }

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -2534,6 +2534,13 @@
             "description": "Whether to initiate a download of the file or not.",
             "name": "download",
             "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "yaml",
+            "description": "Format of the downloaded file, either yaml or json. Accept header can also be used, but the query parameter will take precedence.",
+            "name": "format",
+            "in": "query"
           }
         ],
         "responses": {
@@ -2669,6 +2676,13 @@
             "default": false,
             "description": "Whether to initiate a download of the file or not.",
             "name": "download",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "yaml",
+            "description": "Format of the downloaded file, either yaml or json. Accept header can also be used, but the query parameter will take precedence.",
+            "name": "format",
             "in": "query"
           }
         ],
@@ -2918,6 +2932,13 @@
             "default": false,
             "description": "Whether to initiate a download of the file or not.",
             "name": "download",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "default": "yaml",
+            "description": "Format of the downloaded file, either yaml or json. Accept header can also be used, but the query parameter will take precedence.",
+            "name": "format",
             "in": "query"
           }
         ],
@@ -5534,7 +5555,6 @@
         }
       },
       "put": {
-        "description": "If nested folders are enabled then it optionally expects a new parent folder UID that moves the folder and\nincludes it into the response.",
         "tags": [
           "folders"
         ],
@@ -11519,6 +11539,10 @@
             "internal",
             "external"
           ]
+        },
+        "numExternalAlertmanagers": {
+          "type": "integer",
+          "format": "int64"
         }
       }
     },
@@ -11560,6 +11584,10 @@
         "id": {
           "type": "integer",
           "format": "int64"
+        },
+        "lastUsedAt": {
+          "type": "string",
+          "format": "date-time"
         },
         "name": {
           "type": "string"
@@ -11857,6 +11885,9 @@
         "$ref": "#/definitions/EmbeddedContactPoint"
       }
     },
+    "CookieType": {
+      "type": "string"
+    },
     "Correlation": {
       "description": "Correlation is the model for correlations definitions",
       "type": "object",
@@ -11912,6 +11943,9 @@
             "expr": "job=app"
           }
         },
+        "transformations": {
+          "$ref": "#/definitions/Transformations"
+        },
         "type": {
           "$ref": "#/definitions/CorrelationConfigType"
         }
@@ -11935,6 +11969,23 @@
           "example": {
             "expr": "job=app"
           }
+        },
+        "transformations": {
+          "description": "Source data transformations",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Transformation"
+          },
+          "example": [
+            {
+              "type": "logfmt"
+            },
+            {
+              "expression": "(Superman|Batman)",
+              "type": "regex",
+              "variable": "name"
+            }
+          ]
         },
         "type": {
           "$ref": "#/definitions/CorrelationConfigType"
@@ -12615,48 +12666,6 @@
         }
       }
     },
-    "DashboardVersionDTO": {
-      "type": "object",
-      "properties": {
-        "created": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "createdBy": {
-          "type": "integer",
-          "format": "int64"
-        },
-        "dashboardId": {
-          "type": "integer",
-          "format": "int64"
-        },
-        "dashboardUid": {
-          "type": "string"
-        },
-        "data": {
-          "$ref": "#/definitions/Json"
-        },
-        "id": {
-          "type": "integer",
-          "format": "int64"
-        },
-        "message": {
-          "type": "string"
-        },
-        "parentVersion": {
-          "type": "integer",
-          "format": "int64"
-        },
-        "restoredFrom": {
-          "type": "integer",
-          "format": "int64"
-        },
-        "version": {
-          "type": "integer",
-          "format": "int64"
-        }
-      }
-    },
     "DashboardVersionMeta": {
       "description": "DashboardVersionMeta extends the DashboardVersionDTO with the names\nassociated with the UserIds, overriding the field with the same name from\nthe DashboardVersionDTO model.",
       "type": "object",
@@ -13117,6 +13126,40 @@
         }
       }
     },
+    "EnumFieldConfig": {
+      "description": "Enum field config\nVector values are used as lookup keys into the enum fields",
+      "type": "object",
+      "properties": {
+        "color": {
+          "description": "Color is the color value for a given index (empty is undefined)",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "description": {
+          "description": "Description of the enum state",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "icon": {
+          "description": "Icon supports setting an icon for a given index value",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "text": {
+          "description": "Value is the string display value for a given index",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "ErrorResponseBody": {
       "type": "object",
       "required": [
@@ -13323,6 +13366,9 @@
         "thresholds": {
           "$ref": "#/definitions/ThresholdsConfig"
         },
+        "type": {
+          "$ref": "#/definitions/FieldTypeConfig"
+        },
         "unit": {
           "description": "Numeric Options",
           "type": "string"
@@ -13330,6 +13376,15 @@
         "writeable": {
           "description": "Writeable indicates that the datasource knows how to update this value",
           "type": "boolean"
+        }
+      }
+    },
+    "FieldTypeConfig": {
+      "description": "FieldTypeConfig has type specific configs, only one should be active at a time",
+      "type": "object",
+      "properties": {
+        "enum": {
+          "$ref": "#/definitions/EnumFieldConfig"
         }
       }
     },
@@ -13430,7 +13485,7 @@
       "title": "Frame is a columnar data structure where each column is a Field.",
       "properties": {
         "Fields": {
-          "description": "Fields are the columns of a frame.\nAll Fields must be of the same the length when marshalling the Frame for transmission.",
+          "description": "Fields are the columns of a frame.\nAll Fields must be of the same the length when marshalling the Frame for transmission.\nThere should be no `nil` entries in the Fields slice (making them pointers was a mistake).",
           "type": "array",
           "items": {
             "$ref": "#/definitions/Field"
@@ -13502,6 +13557,9 @@
         },
         "type": {
           "$ref": "#/definitions/FrameType"
+        },
+        "typeVersion": {
+          "$ref": "#/definitions/FrameTypeVersion"
         }
       }
     },
@@ -13509,8 +13567,16 @@
       "description": "A FrameType string, when present in a frame's metadata, asserts that the\nframe's structure conforms to the FrameType's specification.\nThis property is currently optional, so FrameType may be FrameTypeUnknown even if the properties of\nthe Frame correspond to a defined FrameType.",
       "type": "string"
     },
+    "FrameTypeVersion": {
+      "type": "array",
+      "title": "FrameType is a 2 number version (Major / Minor).",
+      "items": {
+        "type": "integer",
+        "format": "uint64"
+      }
+    },
     "Frames": {
-      "description": "It is the main data container within a backend.DataResponse.",
+      "description": "It is the main data container within a backend.DataResponse.\nThere should be no `nil` entries in the Frames slice (making them pointers was a mistake).",
       "type": "array",
       "title": "Frames is a slice of Frame pointers.",
       "items": {
@@ -14408,7 +14474,7 @@
           "type": "string",
           "format": "date-time"
         },
-        "DashboardId": {
+        "DashboardID": {
           "type": "integer",
           "format": "int64"
         },
@@ -14429,7 +14495,7 @@
           "type": "integer",
           "format": "int64"
         },
-        "Id": {
+        "ID": {
           "type": "integer",
           "format": "int64"
         },
@@ -14443,11 +14509,11 @@
           "type": "string",
           "format": "date-time"
         },
-        "OrgId": {
+        "OrgID": {
           "type": "integer",
           "format": "int64"
         },
-        "PanelId": {
+        "PanelID": {
           "type": "integer",
           "format": "int64"
         },
@@ -15098,6 +15164,9 @@
         "isDisabled": {
           "type": "boolean"
         },
+        "isExternallySynced": {
+          "type": "boolean"
+        },
         "lastSeenAt": {
           "type": "string",
           "format": "date-time"
@@ -15292,6 +15361,12 @@
     "PatchPrefsCmd": {
       "type": "object",
       "properties": {
+        "cookies": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/CookieType"
+          }
+        },
         "homeDashboardId": {
           "description": "The numerical :id of a favorited dashboard",
           "type": "integer",
@@ -15828,7 +15903,7 @@
           "$ref": "#/definitions/QueryHistoryPreference"
         },
         "theme": {
-          "description": "light, dark, empty is default",
+          "description": "Theme light, dark, empty is default",
           "type": "string"
         },
         "timezone": {
@@ -15836,7 +15911,7 @@
           "type": "string"
         },
         "weekStart": {
-          "description": "day of the week (sunday, monday, etc)",
+          "description": "WeekStart day of the week (sunday, monday, etc)",
           "type": "string"
         }
       }
@@ -16242,6 +16317,9 @@
         },
         "thresholds": {
           "$ref": "#/definitions/ThresholdsConfig"
+        },
+        "type": {
+          "$ref": "#/definitions/FieldTypeConfig"
         },
         "unit": {
           "description": "Numeric Options",
@@ -16982,7 +17060,7 @@
         "basicRole": {
           "type": "string"
         },
-        "orgID": {
+        "orgId": {
           "type": "integer",
           "format": "int64"
         },
@@ -16992,11 +17070,11 @@
         "scope": {
           "type": "string"
         },
-        "teamID": {
+        "teamId": {
           "type": "integer",
           "format": "int64"
         },
-        "userID": {
+        "userId": {
           "type": "integer",
           "format": "int64"
         },
@@ -18036,6 +18114,33 @@
       "type": "integer",
       "format": "int64"
     },
+    "Transformation": {
+      "type": "object",
+      "properties": {
+        "expression": {
+          "type": "string"
+        },
+        "field": {
+          "type": "string"
+        },
+        "mapValue": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "regex",
+            "logfmt"
+          ]
+        }
+      }
+    },
+    "Transformations": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Transformation"
+      }
+    },
     "TrimDashboardCommand": {
       "type": "object",
       "properties": {
@@ -18062,8 +18167,9 @@
       "type": "string"
     },
     "URL": {
+      "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use RawPath, an optional field which only gets\nset if the default encoding is different from Path.\n\nURL's String method uses the EscapedPath method to obtain the path. See the\nEscapedPath method for more details.",
       "type": "object",
-      "title": "URL is a custom URL type that allows validation at configuration load time.",
+      "title": "A URL represents a parsed URL (technically, a URI reference).",
       "properties": {
         "ForceQuery": {
           "type": "boolean"
@@ -18391,6 +18497,12 @@
     "UpdatePrefsCmd": {
       "type": "object",
       "properties": {
+        "cookies": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/CookieType"
+          }
+        },
         "homeDashboardId": {
           "description": "The numerical :id of a favorited dashboard",
           "type": "integer",
@@ -18602,6 +18714,9 @@
           "type": "boolean"
         },
         "isExternal": {
+          "type": "boolean"
+        },
+        "isExternallySynced": {
           "type": "boolean"
         },
         "isGrafanaAdmin": {
@@ -18892,7 +19007,6 @@
       }
     },
     "alertGroup": {
-      "description": "AlertGroup alert group",
       "type": "object",
       "required": [
         "alerts",
@@ -18916,6 +19030,7 @@
       }
     },
     "alertGroups": {
+      "description": "AlertGroups alert groups",
       "type": "array",
       "items": {
         "$ref": "#/definitions/alertGroup"
@@ -19020,7 +19135,6 @@
       }
     },
     "gettableAlert": {
-      "description": "GettableAlert gettable alert",
       "type": "object",
       "required": [
         "labels",
@@ -19131,14 +19245,12 @@
       }
     },
     "gettableSilences": {
-      "description": "GettableSilences gettable silences",
       "type": "array",
       "items": {
         "$ref": "#/definitions/gettableSilence"
       }
     },
     "integration": {
-      "description": "Integration integration",
       "type": "object",
       "required": [
         "name",
@@ -19319,7 +19431,6 @@
       }
     },
     "receiver": {
-      "description": "Receiver receiver",
       "type": "object",
       "required": [
         "active",
@@ -19677,7 +19788,7 @@
       "schema": {
         "type": "array",
         "items": {
-          "$ref": "#/definitions/DashboardVersionDTO"
+          "$ref": "#/definitions/DashboardVersionMeta"
         }
       }
     },

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -332,7 +332,7 @@
           "application/json": {
             "schema": {
               "items": {
-                "$ref": "#/components/schemas/DashboardVersionDTO"
+                "$ref": "#/components/schemas/DashboardVersionMeta"
               },
               "type": "array"
             }
@@ -2705,6 +2705,10 @@
               "external"
             ],
             "type": "string"
+          },
+          "numExternalAlertmanagers": {
+            "format": "int64",
+            "type": "integer"
           }
         },
         "type": "object"
@@ -2746,6 +2750,10 @@
           "id": {
             "format": "int64",
             "type": "integer"
+          },
+          "lastUsedAt": {
+            "format": "date-time",
+            "type": "string"
           },
           "name": {
             "type": "string"
@@ -3044,6 +3052,9 @@
         },
         "type": "array"
       },
+      "CookieType": {
+        "type": "string"
+      },
       "Correlation": {
         "description": "Correlation is the model for correlations definitions",
         "properties": {
@@ -3093,6 +3104,9 @@
             },
             "type": "object"
           },
+          "transformations": {
+            "$ref": "#/components/schemas/Transformations"
+          },
           "type": {
             "$ref": "#/components/schemas/CorrelationConfigType"
           }
@@ -3121,6 +3135,23 @@
               "expr": "job=app"
             },
             "type": "object"
+          },
+          "transformations": {
+            "description": "Source data transformations",
+            "example": [
+              {
+                "type": "logfmt"
+              },
+              {
+                "expression": "(Superman|Batman)",
+                "type": "regex",
+                "variable": "name"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/Transformation"
+            },
+            "type": "array"
           },
           "type": {
             "$ref": "#/components/schemas/CorrelationConfigType"
@@ -3802,48 +3833,6 @@
         },
         "type": "object"
       },
-      "DashboardVersionDTO": {
-        "properties": {
-          "created": {
-            "format": "date-time",
-            "type": "string"
-          },
-          "createdBy": {
-            "format": "int64",
-            "type": "integer"
-          },
-          "dashboardId": {
-            "format": "int64",
-            "type": "integer"
-          },
-          "dashboardUid": {
-            "type": "string"
-          },
-          "data": {
-            "$ref": "#/components/schemas/Json"
-          },
-          "id": {
-            "format": "int64",
-            "type": "integer"
-          },
-          "message": {
-            "type": "string"
-          },
-          "parentVersion": {
-            "format": "int64",
-            "type": "integer"
-          },
-          "restoredFrom": {
-            "format": "int64",
-            "type": "integer"
-          },
-          "version": {
-            "format": "int64",
-            "type": "integer"
-          }
-        },
-        "type": "object"
-      },
       "DashboardVersionMeta": {
         "description": "DashboardVersionMeta extends the DashboardVersionDTO with the names\nassociated with the UserIds, overriding the field with the same name from\nthe DashboardVersionDTO model.",
         "properties": {
@@ -4304,6 +4293,40 @@
         ],
         "type": "object"
       },
+      "EnumFieldConfig": {
+        "description": "Enum field config\nVector values are used as lookup keys into the enum fields",
+        "properties": {
+          "color": {
+            "description": "Color is the color value for a given index (empty is undefined)",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "description": {
+            "description": "Description of the enum state",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "icon": {
+            "description": "Icon supports setting an icon for a given index value",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "text": {
+            "description": "Value is the string display value for a given index",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
       "ErrorResponseBody": {
         "properties": {
           "error": {
@@ -4508,6 +4531,9 @@
           "thresholds": {
             "$ref": "#/components/schemas/ThresholdsConfig"
           },
+          "type": {
+            "$ref": "#/components/schemas/FieldTypeConfig"
+          },
           "unit": {
             "description": "Numeric Options",
             "type": "string"
@@ -4518,6 +4544,15 @@
           }
         },
         "title": "FieldConfig represents the display properties for a Field.",
+        "type": "object"
+      },
+      "FieldTypeConfig": {
+        "description": "FieldTypeConfig has type specific configs, only one should be active at a time",
+        "properties": {
+          "enum": {
+            "$ref": "#/components/schemas/EnumFieldConfig"
+          }
+        },
         "type": "object"
       },
       "FindTagsResult": {
@@ -4615,7 +4650,7 @@
         "description": "Each Field is well typed by its FieldType and supports optional Labels.\n\nA Frame is a general data container for Grafana. A Frame can be table data\nor time series data depending on its content and field types.",
         "properties": {
           "Fields": {
-            "description": "Fields are the columns of a frame.\nAll Fields must be of the same the length when marshalling the Frame for transmission.",
+            "description": "Fields are the columns of a frame.\nAll Fields must be of the same the length when marshalling the Frame for transmission.\nThere should be no `nil` entries in the Fields slice (making them pointers was a mistake).",
             "items": {
               "$ref": "#/components/schemas/Field"
             },
@@ -4687,6 +4722,9 @@
           },
           "type": {
             "$ref": "#/components/schemas/FrameType"
+          },
+          "typeVersion": {
+            "$ref": "#/components/schemas/FrameTypeVersion"
           }
         },
         "title": "FrameMeta matches:",
@@ -4696,8 +4734,16 @@
         "description": "A FrameType string, when present in a frame's metadata, asserts that the\nframe's structure conforms to the FrameType's specification.\nThis property is currently optional, so FrameType may be FrameTypeUnknown even if the properties of\nthe Frame correspond to a defined FrameType.",
         "type": "string"
       },
+      "FrameTypeVersion": {
+        "items": {
+          "format": "uint64",
+          "type": "integer"
+        },
+        "title": "FrameType is a 2 number version (Major / Minor).",
+        "type": "array"
+      },
       "Frames": {
-        "description": "It is the main data container within a backend.DataResponse.",
+        "description": "It is the main data container within a backend.DataResponse.\nThere should be no `nil` entries in the Frames slice (making them pointers was a mistake).",
         "items": {
           "$ref": "#/components/schemas/Frame"
         },
@@ -5594,7 +5640,7 @@
             "format": "date-time",
             "type": "string"
           },
-          "DashboardId": {
+          "DashboardID": {
             "format": "int64",
             "type": "integer"
           },
@@ -5615,7 +5661,7 @@
             "format": "int64",
             "type": "integer"
           },
-          "Id": {
+          "ID": {
             "format": "int64",
             "type": "integer"
           },
@@ -5629,11 +5675,11 @@
             "format": "date-time",
             "type": "string"
           },
-          "OrgId": {
+          "OrgID": {
             "format": "int64",
             "type": "integer"
           },
-          "PanelId": {
+          "PanelID": {
             "format": "int64",
             "type": "integer"
           },
@@ -6283,6 +6329,9 @@
           "isDisabled": {
             "type": "boolean"
           },
+          "isExternallySynced": {
+            "type": "boolean"
+          },
           "lastSeenAt": {
             "format": "date-time",
             "type": "string"
@@ -6477,6 +6526,12 @@
       },
       "PatchPrefsCmd": {
         "properties": {
+          "cookies": {
+            "items": {
+              "$ref": "#/components/schemas/CookieType"
+            },
+            "type": "array"
+          },
           "homeDashboardId": {
             "default": 0,
             "description": "The numerical :id of a favorited dashboard",
@@ -7012,7 +7067,7 @@
             "$ref": "#/components/schemas/QueryHistoryPreference"
           },
           "theme": {
-            "description": "light, dark, empty is default",
+            "description": "Theme light, dark, empty is default",
             "type": "string"
           },
           "timezone": {
@@ -7020,7 +7075,7 @@
             "type": "string"
           },
           "weekStart": {
-            "description": "day of the week (sunday, monday, etc)",
+            "description": "WeekStart day of the week (sunday, monday, etc)",
             "type": "string"
           }
         },
@@ -7426,6 +7481,9 @@
           },
           "thresholds": {
             "$ref": "#/components/schemas/ThresholdsConfig"
+          },
+          "type": {
+            "$ref": "#/components/schemas/FieldTypeConfig"
           },
           "unit": {
             "description": "Numeric Options",
@@ -8167,7 +8225,7 @@
           "basicRole": {
             "type": "string"
           },
-          "orgID": {
+          "orgId": {
             "format": "int64",
             "type": "integer"
           },
@@ -8177,11 +8235,11 @@
           "scope": {
             "type": "string"
           },
-          "teamID": {
+          "teamId": {
             "format": "int64",
             "type": "integer"
           },
-          "userID": {
+          "userId": {
             "format": "int64",
             "type": "integer"
           },
@@ -9221,6 +9279,33 @@
         "format": "int64",
         "type": "integer"
       },
+      "Transformation": {
+        "properties": {
+          "expression": {
+            "type": "string"
+          },
+          "field": {
+            "type": "string"
+          },
+          "mapValue": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "regex",
+              "logfmt"
+            ],
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "Transformations": {
+        "items": {
+          "$ref": "#/components/schemas/Transformation"
+        },
+        "type": "array"
+      },
       "TrimDashboardCommand": {
         "properties": {
           "dashboard": {
@@ -9247,6 +9332,7 @@
         "type": "string"
       },
       "URL": {
+        "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use RawPath, an optional field which only gets\nset if the default encoding is different from Path.\n\nURL's String method uses the EscapedPath method to obtain the path. See the\nEscapedPath method for more details.",
         "properties": {
           "ForceQuery": {
             "type": "boolean"
@@ -9282,7 +9368,7 @@
             "$ref": "#/components/schemas/Userinfo"
           }
         },
-        "title": "URL is a custom URL type that allows validation at configuration load time.",
+        "title": "A URL represents a parsed URL (technically, a URI reference).",
         "type": "object"
       },
       "UpdateAlertNotificationCommand": {
@@ -9575,6 +9661,12 @@
       },
       "UpdatePrefsCmd": {
         "properties": {
+          "cookies": {
+            "items": {
+              "$ref": "#/components/schemas/CookieType"
+            },
+            "type": "array"
+          },
           "homeDashboardId": {
             "default": 0,
             "description": "The numerical :id of a favorited dashboard",
@@ -9786,6 +9878,9 @@
             "type": "boolean"
           },
           "isExternal": {
+            "type": "boolean"
+          },
+          "isExternallySynced": {
             "type": "boolean"
           },
           "isGrafanaAdmin": {
@@ -10077,7 +10172,6 @@
         "type": "object"
       },
       "alertGroup": {
-        "description": "AlertGroup alert group",
         "properties": {
           "alerts": {
             "description": "alerts",
@@ -10101,6 +10195,7 @@
         "type": "object"
       },
       "alertGroups": {
+        "description": "AlertGroups alert groups",
         "items": {
           "$ref": "#/components/schemas/alertGroup"
         },
@@ -10205,7 +10300,6 @@
         "type": "object"
       },
       "gettableAlert": {
-        "description": "GettableAlert gettable alert",
         "properties": {
           "annotations": {
             "$ref": "#/components/schemas/labelSet"
@@ -10261,6 +10355,7 @@
         "type": "object"
       },
       "gettableAlerts": {
+        "description": "GettableAlerts gettable alerts",
         "items": {
           "$ref": "#/components/schemas/gettableAlert"
         },
@@ -10315,14 +10410,12 @@
         "type": "object"
       },
       "gettableSilences": {
-        "description": "GettableSilences gettable silences",
         "items": {
           "$ref": "#/components/schemas/gettableSilence"
         },
         "type": "array"
       },
       "integration": {
-        "description": "Integration integration",
         "properties": {
           "lastNotifyAttempt": {
             "description": "A timestamp indicating the last attempt to deliver a notification regardless of the outcome.\nFormat: date-time",
@@ -10503,7 +10596,6 @@
         "type": "object"
       },
       "receiver": {
-        "description": "Receiver receiver",
         "properties": {
           "active": {
             "description": "active",
@@ -13345,6 +13437,15 @@
               "default": false,
               "type": "boolean"
             }
+          },
+          {
+            "description": "Format of the downloaded file, either yaml or json. Accept header can also be used, but the query parameter will take precedence.",
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "default": "yaml",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -13503,6 +13604,15 @@
             "schema": {
               "default": false,
               "type": "boolean"
+            }
+          },
+          {
+            "description": "Format of the downloaded file, either yaml or json. Accept header can also be used, but the query parameter will take precedence.",
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "default": "yaml",
+              "type": "string"
             }
           }
         ],
@@ -13808,6 +13918,15 @@
             "schema": {
               "default": false,
               "type": "boolean"
+            }
+          },
+          {
+            "description": "Format of the downloaded file, either yaml or json. Accept header can also be used, but the query parameter will take precedence.",
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "default": "yaml",
+              "type": "string"
             }
           }
         ],
@@ -16724,7 +16843,6 @@
         ]
       },
       "put": {
-        "description": "If nested folders are enabled then it optionally expects a new parent folder UID that moves the folder and\nincludes it into the response.",
         "operationId": "updateFolder",
         "parameters": [
           {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This fix modifies the `GET /dashboards/uid/{uid}/versions/` endpoint and returns the user login (string) in the `created_by` JSON field - it used to return the user sequential ID (int).
More specifically it changes the returned response to `[]dashver.DashboardVersionMeta` (similarly to the `GET /dashboards/uid/{uid}/versions/{DashboardVersionID}` endpoint)
Also, it caches the result for 5 seconds.

In addition to this, it updates (recreates) the OpenAPI specifications. Note that the specifications contain additional changes for other modifications introduced in the API outside the scope of this but the specifications weren't updated as well.

**Why do we need this feature?**

It populates "Updated by" column in dashboard version table with the user login instead of the user sequential ID

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #60935

**Special notes for your reviewer:**
The implementation slightly differs from `GET /dashboards/uid/{uid}/versions/{DashboardVersionID}` endpoint:
https://github.com/grafana/grafana/blob/54d7e95be19d5f0cbd3c7d697966b27bd8feac20/pkg/api/dashboard.go#L753-L756
that calls the `getUserLogin ()` which in case of error returns the `Anonymous` (regardless of the error) that does not seem right
https://github.com/grafana/grafana/blob/54d7e95be19d5f0cbd3c7d697966b27bd8feac20/pkg/api/dashboard.go#L261-L268
**Updated** 2023-03-29: I have changed my implementation to align with `GET /dashboards/uid/{uid}/versions/{DashboardVersionID}` implementation (we re-consider in a follow up whether defaulting to `Anonymous` is the right option)

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
- [ ] There are no known compatibility issues with older supported versions of Grafana, or plugins.
- [ ] It passes the [Hosted Grafana feature readiness review](https://docs.google.com/document/d/1QL9Ly8KnXzpb6ISbg49pTODRO5mhA5tkkfIZVX6pqQU/edit) for observability, scalability, performance, and security.