### PR TITLE
Loki Query Chunking: Group queries by resolution

### DIFF
--- a/public/app/plugins/datasource/loki/queryChunking.test.ts
+++ b/public/app/plugins/datasource/loki/queryChunking.test.ts
@@ -260,4 +260,54 @@ describe('runQueryInChunks()', () => {
       });
     });
   });
+
+  describe('Splitting targets based on resolution', () => {
+    const range1d = {
+      from: dateTime('2023-02-08T05:00:00.000Z'),
+      to: dateTime('2023-02-09T05:00:00.000Z'),
+      raw: {
+        from: dateTime('2023-02-08T05:00:00.000Z'),
+        to: dateTime('2023-02-09T05:00:00.000Z'),
+      },
+    };
+    test('Groups logs queries by resolution', async () => {
+      const request = getQueryOptions<LokiQuery>({
+        targets: [
+          { expr: '{a="b"}', refId: 'A', resolution: 3 },
+          { expr: '{a="b"}', refId: 'B', resolution: 5 },
+        ],
+        range: range1d,
+      });
+      await expect(runQueryInChunks(datasource, request)).toEmitValuesWith(() => {
+        expect(datasource.runQuery).toHaveBeenCalledTimes(2);
+      });
+    });
+    test('Groups metric queries by resolution', async () => {
+      const request = getQueryOptions<LokiQuery>({
+        targets: [
+          { expr: 'count_over_time({a="b"}[1m])', refId: 'A', resolution: 3 },
+          { expr: 'count_over_time{a="b"}[1m])', refId: 'B', resolution: 5 },
+        ],
+        range: range1d,
+      });
+      await expect(runQueryInChunks(datasource, request)).toEmitValuesWith(() => {
+        expect(datasource.runQuery).toHaveBeenCalledTimes(2);
+      });
+    });
+    test('Groups mixed queries by resolution', async () => {
+      const request = getQueryOptions<LokiQuery>({
+        targets: [
+          { expr: '{a="b"}', refId: 'A', resolution: 3 },
+          { expr: '{a="b"}', refId: 'B', resolution: 5 },
+          { expr: 'count_over_time({a="b"}[1m])', refId: 'C', resolution: 3 },
+          { expr: 'count_over_time{a="b"}[1m])', refId: 'D', resolution: 5 },
+          { expr: '{a="b"}', refId: 'B', resolution: 5, queryType: LokiQueryType.Instant },
+        ],
+        range: range1d,
+      });
+      await expect(runQueryInChunks(datasource, request)).toEmitValuesWith(() => {
+        expect(datasource.runQuery).toHaveBeenCalledTimes(5);
+      });
+    });
+  });
 });


### PR DESCRIPTION
In addition to the grouping by query type and chunk duration that we supported, we are now grouping queries by their resolution.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/65103
Part of https://github.com/grafana/grafana/issues/61768

**Special notes for your reviewer:**

Groups before:
Single group with partition based on the resolution of the first query.
![Before](https://user-images.githubusercontent.com/1069378/227957811-893e337d-4ab8-402e-87e6-39496d7f07a1.png)

3 requests per 3 groups: instant, logs, and metrics, even with different resolution:
![imagen](https://user-images.githubusercontent.com/1069378/227958725-86b7e67d-5afb-4315-bd2d-200199c229cc.png)

Groups after:
Two groups, with each partition calculated using the specified resolution.
![After](https://user-images.githubusercontent.com/1069378/227958021-9e6e684c-06a2-47ec-b5c3-f932a55c1725.png)

5 requests per 5 groups: instant, logs resolution 1, logs resolution 1/3, metric resolution 1/3, metric resolution 1/5, instant.
![imagen](https://user-images.githubusercontent.com/1069378/227958896-02c0a24b-b925-493d-a273-bfee7e2f0854.png)

The feature should work as expected, with the addition of grouping by resolution.