### PR TITLE
refactor: add return value for logsSample

### DIFF
--- a/public/app/features/explore/utils/supplementaryQueries.test.ts
+++ b/public/app/features/explore/utils/supplementaryQueries.test.ts
@@ -197,15 +197,9 @@ describe('SupplementaryQueries utils', function () {
         ]);
       });
     });
-    it('Does not use a fallback for logs sample', async () => {
+    it('Returns undefined for logs sample', async () => {
       const testProvider = await setup('no-data-providers', SupplementaryQueryType.LogsSample);
-      await expect(testProvider).toEmitValuesWith((received) => {
-        expect(received).toMatchObject([
-          {
-            state: LoadingState.NotStarted,
-          },
-        ]);
-      });
+      await expect(testProvider).toBe(undefined);
     });
   });
 

--- a/public/app/features/explore/utils/supplementaryQueries.ts
+++ b/public/app/features/explore/utils/supplementaryQueries.ts
@@ -213,6 +213,8 @@ export const getSupplementaryQueryProvider = (
       ),
       distinct()
     );
+  } else if (type === SupplementaryQueryType.LogsSample) {
+    return undefined;
   } else {
     // Create a fallback to results based logs volume
     return getSupplementaryQueryFallback(type, explorePanelData, request.targets, datasourceInstance.name);


### PR DESCRIPTION
Fixes #65041

Logs Sample is currently supposed to be visible only in Loki if there is no log result.
Due to changes for mixed datasources the required default for logsSample.dataProvider was never undefined. 

This PR fixes Logs Sample for all datasources except mixed datasources. That's why there is a follow up issue for the excluded use case: #65360
