### PR TITLE
Canvas: Update metric value text for no data

### DIFF
--- a/public/app/features/canvas/elements/metricValue.tsx
+++ b/public/app/features/canvas/elements/metricValue.tsx
@@ -22,20 +22,27 @@ const dummyFieldSettings: StandardEditorsRegistryItem<string, FieldNamePickerCon
 } as StandardEditorsRegistryItem<string, FieldNamePickerConfigSettings>;
 
 const MetricValueDisplay = (props: CanvasElementProps<TextConfig, TextData>) => {
-  const { data, isSelected } = props;
+  const { data, isSelected, config } = props;
   const styles = useStyles2(getStyles(data));
 
   const context = usePanelContext();
   const scene = context.instanceState?.scene;
+  let panelData: DataFrame[];
+  panelData = context.instanceState?.scene?.data.series;
 
   const isEditMode = useObservable<boolean>(scene?.editModeEnabled ?? of(false));
 
   const getDisplayValue = () => {
-    if (!data || !data.text) {
-      return 'NA';
+    if (panelData && config.text?.field && fieldNotFound()) {
+      return 'Field not found';
     }
 
-    return data.text ?? 'Double click to set field';
+    return data?.text ? data.text : 'Double click to set field';
+  };
+
+  const fieldNotFound = () => {
+    const field = panelData.filter((series) => series.fields.find((field) => field.name === config.text?.field));
+    return !field.length;
   };
 
   if (isEditMode && isSelected) {
@@ -57,6 +64,7 @@ const MetricValueEdit = (props: CanvasElementProps<TextConfig, TextData>) => {
 
   const onFieldChange = useCallback(
     (field) => {
+      console.log('onfieldchange', field);
       let selectedElement: ElementState;
       selectedElement = context.instanceState?.selected[0];
       if (selectedElement) {

--- a/public/app/features/canvas/elements/metricValue.tsx
+++ b/public/app/features/canvas/elements/metricValue.tsx
@@ -30,12 +30,21 @@ const MetricValueDisplay = (props: CanvasElementProps<TextConfig, TextData>) => 
 
   const isEditMode = useObservable<boolean>(scene?.editModeEnabled ?? of(false));
 
+  const getDisplayValue = () => {
+    if (!data || !data.text) {
+      return 'NA';
+    }
+
+    return data.text ?? 'Double click to set field';
+  };
+
   if (isEditMode && isSelected) {
     return <MetricValueEdit {...props} />;
   }
+
   return (
     <div className={styles.container}>
-      <span className={styles.span}>{data?.text ? data.text : 'Double click to set field'}</span>
+      <span className={styles.span}>{getDisplayValue()}</span>
     </div>
   );
 };


### PR DESCRIPTION
https://user-images.githubusercontent.com/88068998/227975912-2cfe97be-2144-4e53-b57a-131906df16e8.mov


Fixes #63760 

**Special notes for your reviewer:**
Not sure how to reproduce broken datasource..

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
- [ ] There are no known compatibility issues with older supported versions of Grafana, or plugins.
- [ ] It passes the [Hosted Grafana feature readiness review](https://docs.google.com/document/d/1QL9Ly8KnXzpb6ISbg49pTODRO5mhA5tkkfIZVX6pqQU/edit) for observability, scalability, performance, and security.