### PR TITLE
SQL Datasources: Add back help content

### DIFF
--- a/public/app/plugins/datasource/mssql/CheatSheet.tsx
+++ b/public/app/plugins/datasource/mssql/CheatSheet.tsx
@@ -1,0 +1,91 @@
+import { css } from '@emotion/css';
+import React from 'react';
+
+import { GrafanaTheme2 } from '@grafana/data';
+import { useStyles2 } from '@grafana/ui';
+
+export function CheatSheet() {
+  const styles = useStyles2(getStyles);
+
+  return (
+    <div>
+      <h2>MSSQL cheat sheet</h2>
+      Time series:
+      <ul className={styles.ulPadding}>
+        <li>
+          return column named time (in UTC), as a unix time stamp or any sql native date data type. You can use the
+          macros below.
+        </li>
+        <li>any other columns returned will be the time point values.</li>
+      </ul>
+      Optional:
+      <ul className={styles.ulPadding}>
+        <li>
+          return column named <i>metric</i> to represent the series name.
+        </li>
+        <li>If multiple value columns are returned the metric column is used as prefix.</li>
+        <li>If no column named metric is found the column name of the value column is used as series name</li>
+      </ul>
+      <p>Resultsets of time series queries need to be sorted by time.</p>
+      Table:
+      <ul className={styles.ulPadding}>
+        <li>return any set of columns</li>
+      </ul>
+      Macros:
+      <ul className={styles.ulPadding}>
+        <li>$__time(column) -&gt; column AS time</li>
+        <li>$__timeEpoch(column) -&gt; DATEDIFF(second, &apos;1970-01-01&apos;, column) AS time</li>
+        <li>
+          $__timeFilter(column) -&gt; column BETWEEN &apos;2017-04-21T05:01:17Z&apos; AND
+          &apos;2017-04-21T05:01:17Z&apos;
+        </li>
+        <li>$__unixEpochFilter(column) -&gt; column &gt;= 1492750877 AND column &lt;= 1492750877</li>
+        <li>
+          $__unixEpochNanoFilter(column) -&gt; column &gt;= 1494410783152415214 AND column &lt;= 1494497183142514872
+        </li>
+        <li>
+          $__timeGroup(column, &apos;5m&apos;[, fillvalue]) -&gt; CAST(ROUND(DATEDIFF(second, &apos;1970-01-01&apos;,
+          column)/300.0, 0) as bigint)*300 by setting fillvalue grafana will fill in missing values according to the
+          interval fillvalue can be either a literal value, NULL or previous; previous will fill in the previous seen
+          value or NULL if none has been seen yet
+        </li>
+        <li>
+          $__timeGroupAlias(column, &apos;5m&apos;[, fillvalue]) -&gt; CAST(ROUND(DATEDIFF(second,
+          &apos;1970-01-01&apos;, column)/300.0, 0) as bigint)*300 AS [time]
+        </li>
+        <li>$__unixEpochGroup(column,&apos;5m&apos;) -&gt; FLOOR(column/300)*300</li>
+        <li>$__unixEpochGroupAlias(column,&apos;5m&apos;) -&gt; FLOOR(column/300)*300 AS [time]</li>
+      </ul>
+      <p>Example of group by and order by with $__timeGroup:</p>
+      <pre>
+        <code>
+          SELECT $__timeGroup(date_time_col, &apos;1h&apos;) AS time, sum(value) as value <br />
+          FROM yourtable
+          <br />
+          GROUP BY $__timeGroup(date_time_col, &apos;1h&apos;)
+          <br />
+          ORDER BY 1
+          <br />
+        </code>
+      </pre>
+      Or build your own conditionals using these macros which just return the values:
+      <ul className={styles.ulPadding}>
+        <li>$__timeFrom() -&gt; &apos;2017-04-21T05:01:17Z&apos;</li>
+        <li>$__timeTo() -&gt; &apos;2017-04-21T05:01:17Z&apos;</li>
+        <li>$__unixEpochFrom() -&gt; 1492750877</li>
+        <li>$__unixEpochTo() -&gt; 1492750877</li>
+        <li>$__unixEpochNanoFrom() -&gt; 1494410783152415214</li>
+        <li>$__unixEpochNanoTo() -&gt; 1494497183142514872</li>
+      </ul>
+    </div>
+  );
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    ulPadding: css({
+      margin: theme.spacing(1, 0),
+      paddingLeft: theme.spacing(5),
+    }),
+  };
+}

--- a/public/app/plugins/datasource/mssql/module.ts
+++ b/public/app/plugins/datasource/mssql/module.ts
@@ -2,10 +2,12 @@ import { DataSourcePlugin } from '@grafana/data';
 import { SqlQueryEditor } from 'app/features/plugins/sql/components/QueryEditor';
 import { SQLQuery } from 'app/features/plugins/sql/types';
 
+import { CheatSheet } from './CheatSheet';
 import { ConfigurationEditor } from './configuration/ConfigurationEditor';
 import { MssqlDatasource } from './datasource';
 import { MssqlOptions } from './types';
 
 export const plugin = new DataSourcePlugin<MssqlDatasource, SQLQuery, MssqlOptions>(MssqlDatasource)
   .setQueryEditor(SqlQueryEditor)
+  .setQueryEditorHelp(CheatSheet)
   .setConfigEditor(ConfigurationEditor);

--- a/public/app/plugins/datasource/mysql/CheatSheet.tsx
+++ b/public/app/plugins/datasource/mysql/CheatSheet.tsx
@@ -1,0 +1,88 @@
+import { css } from '@emotion/css';
+import React from 'react';
+
+import { GrafanaTheme2 } from '@grafana/data';
+import { useStyles2 } from '@grafana/ui';
+
+export function CheatSheet() {
+  const styles = useStyles2(getStyles);
+
+  return (
+    <div>
+      <h2>MySQL cheat sheet</h2>
+      Time series:
+      <ul className={styles.ulPadding}>
+        <li>
+          return column named time or time_sec (in UTC), as a unix time stamp or any sql native date data type. You can
+          use the macros below.
+        </li>
+        <li>return column(s) with numeric datatype as values</li>
+      </ul>
+      Optional:
+      <ul className={styles.ulPadding}>
+        <li>
+          return column named <i>metric</i> to represent the series name.
+        </li>
+        <li>If multiple value columns are returned the metric column is used as prefix.</li>
+        <li>If no column named metric is found the column name of the value column is used as series name</li>
+      </ul>
+      <p>Resultsets of time series queries need to be sorted by time.</p>
+      Table:
+      <ul className={styles.ulPadding}>
+        <li>return any set of columns</li>
+      </ul>
+      Macros:
+      <ul className={styles.ulPadding}>
+        <li>$__time(column) -&gt; UNIX_TIMESTAMP(column) as time_sec</li>
+        <li>$__timeEpoch(column) -&gt; UNIX_TIMESTAMP(column) as time_sec</li>
+        <li>$__timeFilter(column) -&gt; column BETWEEN FROM_UNIXTIME(1492750877) AND FROM_UNIXTIME(1492750877)</li>
+        <li>$__unixEpochFilter(column) -&gt; time_unix_epoch &gt; 1492750877 AND time_unix_epoch &lt; 1492750877</li>
+        <li>
+          $__unixEpochNanoFilter(column) -&gt; column &gt;= 1494410783152415214 AND column &lt;= 1494497183142514872
+        </li>
+        <li>
+          $__timeGroup(column,&apos;5m&apos;[, fillvalue]) -&gt; cast(cast(UNIX_TIMESTAMP(column)/(300) as signed)*300
+          as signed) by setting fillvalue grafana will fill in missing values according to the interval fillvalue can be
+          either a literal value, NULL or previous; previous will fill in the previous seen value or NULL if none has
+          been seen yet
+        </li>
+        <li>
+          $__timeGroupAlias(column,&apos;5m&apos;) -&gt; cast(cast(UNIX_TIMESTAMP(column)/(300) as signed)*300 as
+          signed) AS &quote;time&quote;
+        </li>
+        <li>$__unixEpochGroup(column,&apos;5m&apos;) -&gt; column DIV 300 * 300</li>
+        <li>$__unixEpochGroupAlias(column,&apos;5m&apos;) -&gt; column DIV 300 * 300 AS &quote;time&quote;</li>
+      </ul>
+      <p>Example of group by and order by with $__timeGroup:</p>
+      <pre>
+        <code>
+          $__timeGroupAlias(timestamp_col, &apos;1h&apos;), sum(value_double) as value
+          <br />
+          FROM yourtable
+          <br />
+          GROUP BY 1<br />
+          ORDER BY 1
+          <br />
+        </code>
+      </pre>
+      Or build your own conditionals using these macros which just return the values:
+      <ul className={styles.ulPadding}>
+        <li>$__timeFrom() -&gt; FROM_UNIXTIME(1492750877)</li>
+        <li>$__timeTo() -&gt; FROM_UNIXTIME(1492750877)</li>
+        <li>$__unixEpochFrom() -&gt; 1492750877</li>
+        <li>$__unixEpochTo() -&gt; 1492750877</li>
+        <li>$__unixEpochNanoFrom() -&gt; 1494410783152415214</li>
+        <li>$__unixEpochNanoTo() -&gt; 1494497183142514872</li>
+      </ul>
+    </div>
+  );
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    ulPadding: css({
+      margin: theme.spacing(1, 0),
+      paddingLeft: theme.spacing(5),
+    }),
+  };
+}

--- a/public/app/plugins/datasource/mysql/module.ts
+++ b/public/app/plugins/datasource/mysql/module.ts
@@ -2,10 +2,12 @@ import { DataSourcePlugin } from '@grafana/data';
 import { SqlQueryEditor } from 'app/features/plugins/sql/components/QueryEditor';
 import { SQLQuery } from 'app/features/plugins/sql/types';
 
+import { CheatSheet } from './CheatSheet';
 import { MySqlDatasource } from './MySqlDatasource';
 import { ConfigurationEditor } from './configuration/ConfigurationEditor';
 import { MySQLOptions } from './types';
 
 export const plugin = new DataSourcePlugin<MySqlDatasource, SQLQuery, MySQLOptions>(MySqlDatasource)
   .setQueryEditor(SqlQueryEditor)
+  .setQueryEditorHelp(CheatSheet)
   .setConfigEditor(ConfigurationEditor);

--- a/public/app/plugins/datasource/postgres/CheatSheet.tsx
+++ b/public/app/plugins/datasource/postgres/CheatSheet.tsx
@@ -1,0 +1,89 @@
+import { css } from '@emotion/css';
+import React from 'react';
+
+import { GrafanaTheme2 } from '@grafana/data';
+import { useStyles2 } from '@grafana/ui';
+
+export function CheatSheet() {
+  const styles = useStyles2(getStyles);
+
+  return (
+    <div>
+      <h2>PostgreSQL cheat sheet</h2>
+      Time series:
+      <ul className={styles.ulPadding}>
+        <li>
+          return column named <i>time</i> (UTC in seconds or timestamp)
+        </li>
+        <li>return column(s) with numeric datatype as values</li>
+      </ul>
+      Optional:
+      <ul className={styles.ulPadding}>
+        <li>
+          return column named <i>metric</i> to represent the series name.
+        </li>
+        <li>If multiple value columns are returned the metric column is used as prefix.</li>
+        <li>If no column named metric is found the column name of the value column is used as series name</li>
+      </ul>
+      <p>Resultsets of time series queries need to be sorted by time.</p>
+      Table:
+      <ul className={styles.ulPadding}>
+        <li>return any set of columns</li>
+      </ul>
+      Macros:
+      <ul className={styles.ulPadding}>
+        <li>$__time(column) -&gt; column as &quote;time&quote;</li>
+        <li>$__timeEpoch -&gt; extract(epoch from column) as &quote;time&quote;</li>
+        <li>
+          $__timeFilter(column) -&gt; column BETWEEN &apos;2017-04-21T05:01:17Z&apos; AND
+          &apos;2017-04-21T05:01:17Z&apos;
+        </li>
+        <li>$__unixEpochFilter(column) -&gt; column &gt;= 1492750877 AND column &lt;= 1492750877</li>
+        <li>
+          $__unixEpochNanoFilter(column) -&gt; column &gt;= 1494410783152415214 AND column &lt;= 1494497183142514872
+        </li>
+        <li>
+          $__timeGroup(column,&apos;5m&apos;[, fillvalue]) -&gt; (extract(epoch from column)/300)::bigint*300 by setting
+          fillvalue grafana will fill in missing values according to the interval fillvalue can be either a literal
+          value, NULL or previous; previous will fill in the previous seen value or NULL if none has been seen yet
+        </li>
+        <li>
+          $__timeGroupAlias(column,&apos;5m&apos;) -&gt; (extract(epoch from column)/300)::bigint*300 AS
+          &quote;time&quote;
+        </li>
+        <li>$__unixEpochGroup(column,&apos;5m&apos;) -&gt; floor(column/300)*300</li>
+        <li>$__unixEpochGroupAlias(column,&apos;5m&apos;) -&gt; floor(column/300)*300 AS &quote;time&quote;</li>
+      </ul>
+      <p>Example of group by and order by with $__timeGroup:</p>
+      <pre>
+        <code>
+          SELECT $__timeGroup(date_time_col, &apos;1h&apos;), sum(value) as value <br />
+          FROM yourtable
+          <br />
+          GROUP BY time
+          <br />
+          ORDER BY time
+          <br />
+        </code>
+      </pre>
+      Or build your own conditionals using these macros which just return the values:
+      <ul className={styles.ulPadding}>
+        <li>$__timeFrom() -&gt; &apos;2017-04-21T05:01:17Z&apos;</li>
+        <li>$__timeTo() -&gt; &apos;2017-04-21T05:01:17Z&apos;</li>
+        <li>$__unixEpochFrom() -&gt; 1492750877</li>
+        <li>$__unixEpochTo() -&gt; 1492750877</li>
+        <li>$__unixEpochNanoFrom() -&gt; 1494410783152415214</li>
+        <li>$__unixEpochNanoTo() -&gt; 1494497183142514872</li>
+      </ul>
+    </div>
+  );
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    ulPadding: css({
+      margin: theme.spacing(1, 0),
+      paddingLeft: theme.spacing(5),
+    }),
+  };
+}

--- a/public/app/plugins/datasource/postgres/module.ts
+++ b/public/app/plugins/datasource/postgres/module.ts
@@ -1,6 +1,7 @@
 import { DataSourcePlugin } from '@grafana/data';
 import { SQLQuery } from 'app/features/plugins/sql/types';
 
+import { CheatSheet } from './CheatSheet';
 import { QueryEditor } from './QueryEditor';
 import { PostgresConfigEditor } from './configuration/ConfigurationEditor';
 import { PostgresDatasource } from './datasource';
@@ -10,4 +11,5 @@ export const plugin = new DataSourcePlugin<PostgresDatasource, SQLQuery, Postgre
   PostgresDatasource
 )
   .setQueryEditor(QueryEditor)
+  .setQueryEditorHelp(CheatSheet)
   .setConfigEditor(PostgresConfigEditor);


### PR DESCRIPTION
This PR adds back the help for SQL datasources. It is now not in the query editor but instead uses the toolbar as the other datasources.
![Screenshot 2023-03-27 at 18 01 08](https://user-images.githubusercontent.com/13729989/227998231-e0a8861d-9d82-4a7c-8a89-bbe1c291b75c.png)
![Screenshot 2023-03-27 at 18 00 44](https://user-images.githubusercontent.com/13729989/227998265-ad52e6ce-80be-4d0a-a810-b54b6480320e.png)


**Which issue(s) does this PR fix?**:

Fixes #65382

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
- [x] There are no known compatibility issues with older supported versions of Grafana, or plugins.
- [x] It passes the [Hosted Grafana feature readiness review](https://docs.google.com/document/d/1QL9Ly8KnXzpb6ISbg49pTODRO5mhA5tkkfIZVX6pqQU/edit) for observability, scalability, performance, and security.