### PR TITLE
Prometheus: Use $__rate_interval for rate queries generated by metric browser

### DIFF
--- a/public/app/plugins/datasource/prometheus/components/PrometheusMetricsBrowser.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PrometheusMetricsBrowser.tsx
@@ -219,7 +219,7 @@ export class UnthemedPrometheusMetricsBrowser extends React.Component<BrowserPro
 
   onClickRunRateQuery = () => {
     const selector = buildSelector(this.state.labels);
-    const query = `rate(${selector}[$__interval])`;
+    const query = `rate(${selector}[$__rate_interval])`;
     this.props.onChange(query);
   };
 


### PR DESCRIPTION
We have `$__rate_interval` variable that is specifically created for prometheus rate queries, but Metrics browser wasn't using it. This PR fixes it. More context https://grafana.com/blog/2020/09/28/new-in-grafana-7.2-__rate_interval-for-prometheus-rate-queries-that-just-work/