### PR TITLE
Table Panel: Fixes inaccessible sorting and filtering when table panel has no title

### DIFF
--- a/packages/grafana-ui/src/components/Table/Table.tsx
+++ b/packages/grafana-ui/src/components/Table/Table.tsx
@@ -379,7 +379,7 @@ export const Table = memo((props: Props) => {
 
   /*
     Currently, in the `TablePanel` component, if no table title is given,
-    the table shifts upwards to take up the space the rendered title used to comprise.
+    the table shifts upwards to take up the space the rendered title used to fill.
     This causes the `PanelHeader` component to then overlay on top of the table headers,
     making sorting and filtering impossible.
   */

--- a/packages/grafana-ui/src/components/Table/Table.tsx
+++ b/packages/grafana-ui/src/components/Table/Table.tsx
@@ -46,7 +46,7 @@ export const Table = memo((props: Props) => {
     data,
     subData,
     height,
-    parentData,
+    parentMetaData,
     maxHeight,
     onCellFilterAdded,
     width,
@@ -385,9 +385,9 @@ export const Table = memo((props: Props) => {
   */
   const adjustTitleMargin = () => {
     // This only currently applies to table being used in the TablePanel.
-    if (parentData?.titleSource === 'tablePanel') {
+    if (parentMetaData?.titleSource === 'tablePanel') {
       // If there is no title, add a margin-top of the title height.
-      return !parentData?.title?.length ? TITLE_HEIGHT / 8 : 0;
+      return !parentMetaData?.title?.length ? TITLE_HEIGHT / 8 : 0;
     }
     return 0;
   };

--- a/packages/grafana-ui/src/components/Table/Table.tsx
+++ b/packages/grafana-ui/src/components/Table/Table.tsx
@@ -385,6 +385,7 @@ export const Table = memo((props: Props) => {
     making sorting and filtering impossible.
   */
   const adjustTitleMargin = () => {
+    // This only currently applies to table being used in the TablePanel.
     if (parentData?.titleSource === 'tablePanel') {
       // If there is no title, add a margin-top of the title height.
       return !parentData?.title?.length ? TITLE_HEIGHT / 8 : 0;

--- a/packages/grafana-ui/src/components/Table/Table.tsx
+++ b/packages/grafana-ui/src/components/Table/Table.tsx
@@ -46,7 +46,7 @@ export const Table = memo((props: Props) => {
     data,
     subData,
     height,
-    hasTitle = false,
+    title,
     maxHeight,
     onCellFilterAdded,
     width,
@@ -61,6 +61,7 @@ export const Table = memo((props: Props) => {
     enablePagination,
     cellHeight = TableCellHeight.Sm,
   } = props;
+  console.log('🚀 ~ file: Table.tsx:64 ~ Table ~ props:', props);
 
   const listRef = useRef<VariableSizeList>(null);
   const tableDivRef = useRef<HTMLDivElement>(null);
@@ -381,7 +382,8 @@ export const Table = memo((props: Props) => {
   return (
     <div {...getTableProps()} className={tableStyles.table} aria-label={ariaLabel} role="table" ref={tableDivRef}>
       <CustomScrollbar hideVerticalTrack={true}>
-        <div className={tableStyles.tableContentWrapper(totalColumnsWidth, hasTitle ? 0 : TITLE_HEIGHT)}>
+        {/* Adjust table's margin-top if nullish title value exists, so as to prevent `PanelHeader` overlap */}
+        <div className={tableStyles.tableContentWrapper(totalColumnsWidth, !!title?.length ? TITLE_HEIGHT : 0)}>
           {!noHeader && (
             <HeaderRow headerGroups={headerGroups} showTypeIcons={showTypeIcons} tableStyles={tableStyles} />
           )}

--- a/packages/grafana-ui/src/components/Table/Table.tsx
+++ b/packages/grafana-ui/src/components/Table/Table.tsx
@@ -38,6 +38,7 @@ import {
 
 const COLUMN_MIN_WIDTH = 150;
 const FOOTER_ROW_HEIGHT = 36;
+const TITLE_HEIGHT = 32;
 
 export const Table = memo((props: Props) => {
   const {
@@ -45,6 +46,7 @@ export const Table = memo((props: Props) => {
     data,
     subData,
     height,
+    hasTitle = false,
     maxHeight,
     onCellFilterAdded,
     width,
@@ -379,7 +381,7 @@ export const Table = memo((props: Props) => {
   return (
     <div {...getTableProps()} className={tableStyles.table} aria-label={ariaLabel} role="table" ref={tableDivRef}>
       <CustomScrollbar hideVerticalTrack={true}>
-        <div className={tableStyles.tableContentWrapper(totalColumnsWidth)}>
+        <div className={tableStyles.tableContentWrapper(totalColumnsWidth, hasTitle ? 0 : TITLE_HEIGHT)}>
           {!noHeader && (
             <HeaderRow headerGroups={headerGroups} showTypeIcons={showTypeIcons} tableStyles={tableStyles} />
           )}

--- a/packages/grafana-ui/src/components/Table/Table.tsx
+++ b/packages/grafana-ui/src/components/Table/Table.tsx
@@ -378,7 +378,7 @@ export const Table = memo((props: Props) => {
   };
 
   /*
-    Currently, in the `TablePanel` component, if no table title is givin,
+    Currently, in the `TablePanel` component, if no table title is given,
     the table shifts upwards to take up the space the rendered title used to comprise.
     This causes the `PanelHeader` component to then overlay on top of the table headers,
     making sorting and filtering impossible.

--- a/packages/grafana-ui/src/components/Table/Table.tsx
+++ b/packages/grafana-ui/src/components/Table/Table.tsx
@@ -34,11 +34,11 @@ import {
   createFooterCalculationValues,
   EXPANDER_WIDTH,
   buildFieldsForOptionalRowNums,
+  TITLE_HEIGHT,
 } from './utils';
 
 const COLUMN_MIN_WIDTH = 150;
 const FOOTER_ROW_HEIGHT = 36;
-const TITLE_HEIGHT = 32;
 
 export const Table = memo((props: Props) => {
   const {
@@ -61,7 +61,6 @@ export const Table = memo((props: Props) => {
     enablePagination,
     cellHeight = TableCellHeight.Sm,
   } = props;
-  console.log('🚀 ~ file: Table.tsx:64 ~ Table ~ props:', props);
 
   const listRef = useRef<VariableSizeList>(null);
   const tableDivRef = useRef<HTMLDivElement>(null);

--- a/packages/grafana-ui/src/components/Table/Table.tsx
+++ b/packages/grafana-ui/src/components/Table/Table.tsx
@@ -46,7 +46,7 @@ export const Table = memo((props: Props) => {
     data,
     subData,
     height,
-    title,
+    parentData,
     maxHeight,
     onCellFilterAdded,
     width,
@@ -279,7 +279,6 @@ export const Table = memo((props: Props) => {
       }
 
       prepareRow(row);
-
       return (
         <div {...row.getRowProps({ style })} className={tableStyles.row}>
           {/*add the subtable to the DOM first to prevent a 1px border CSS issue on the last cell of the row*/}
@@ -379,11 +378,24 @@ export const Table = memo((props: Props) => {
     }
   };
 
+  /*
+    Currently, in the `TablePanel` component, if no table title is givin,
+    the table shifts upwards to take up the space the rendered title used to comprise.
+    This causes the `PanelHeader` component to then overlay on top of the table headers,
+    making sorting and filtering impossible.
+  */
+  const adjustTitleMargin = () => {
+    if (parentData?.titleSource === 'tablePanel') {
+      // If there is no title, add a margin-top of the title height.
+      return !parentData?.title?.length ? TITLE_HEIGHT / 8 : 0;
+    }
+    return 0;
+  };
+
   return (
     <div {...getTableProps()} className={tableStyles.table} aria-label={ariaLabel} role="table" ref={tableDivRef}>
       <CustomScrollbar hideVerticalTrack={true}>
-        {/* Adjust table's margin-top if nullish title value exists, so as to prevent `PanelHeader` overlap */}
-        <div className={tableStyles.tableContentWrapper(totalColumnsWidth, !!title?.length ? TITLE_HEIGHT : 0)}>
+        <div className={tableStyles.tableContentWrapper(totalColumnsWidth, adjustTitleMargin())}>
           {!noHeader && (
             <HeaderRow headerGroups={headerGroups} showTypeIcons={showTypeIcons} tableStyles={tableStyles} />
           )}

--- a/packages/grafana-ui/src/components/Table/styles.ts
+++ b/packages/grafana-ui/src/components/Table/styles.ts
@@ -90,8 +90,6 @@ export function useTableStyles(theme: GrafanaTheme2, cellHeightOption: TableCell
     `;
   };
 
-  console.log(theme.spacing(2), 'spacing');
-
   return {
     theme,
     cellHeight,

--- a/packages/grafana-ui/src/components/Table/styles.ts
+++ b/packages/grafana-ui/src/components/Table/styles.ts
@@ -224,7 +224,7 @@ export function useTableStyles(theme: GrafanaTheme2, cellHeightOption: TableCell
       padding-right: ${theme.spacing(1)};
     `,
 
-    tableContentWrapper: (totalColumnsWidth: number) => {
+    tableContentWrapper: (totalColumnsWidth: number, margin: number) => {
       const width = totalColumnsWidth !== undefined ? `${totalColumnsWidth}px` : '100%';
 
       return css`
@@ -232,6 +232,7 @@ export function useTableStyles(theme: GrafanaTheme2, cellHeightOption: TableCell
         width: ${width};
         display: flex;
         flex-direction: column;
+        margin-top: ${margin}px;
       `;
     },
     row: css`

--- a/packages/grafana-ui/src/components/Table/styles.ts
+++ b/packages/grafana-ui/src/components/Table/styles.ts
@@ -90,6 +90,8 @@ export function useTableStyles(theme: GrafanaTheme2, cellHeightOption: TableCell
     `;
   };
 
+  console.log(theme.spacing(2), 'spacing');
+
   return {
     theme,
     cellHeight,
@@ -232,7 +234,7 @@ export function useTableStyles(theme: GrafanaTheme2, cellHeightOption: TableCell
         width: ${width};
         display: flex;
         flex-direction: column;
-        margin-top: ${margin}px;
+        margin-top: ${theme.spacing(margin)};
       `;
     },
     row: css`

--- a/packages/grafana-ui/src/components/Table/types.ts
+++ b/packages/grafana-ui/src/components/Table/types.ts
@@ -72,6 +72,7 @@ export interface Props {
   width: number;
   height: number;
   maxHeight?: number;
+  hasTitle?: boolean;
   /** Minimal column width specified in pixels */
   columnMinWidth?: number;
   noHeader?: boolean;

--- a/packages/grafana-ui/src/components/Table/types.ts
+++ b/packages/grafana-ui/src/components/Table/types.ts
@@ -72,7 +72,7 @@ export interface Props {
   width: number;
   height: number;
   maxHeight?: number;
-  parentData?: {
+  parentMetaData?: {
     title: string;
     titleSource: string;
   };

--- a/packages/grafana-ui/src/components/Table/types.ts
+++ b/packages/grafana-ui/src/components/Table/types.ts
@@ -66,16 +66,18 @@ export interface GrafanaTableState extends TableState {
 
 export interface GrafanaTableRow extends Row, UseExpandedRowProps<{}> {}
 
+type TableParentMetaData = {
+  title: string;
+  titleSource: string;
+};
+
 export interface Props {
   ariaLabel?: string;
   data: DataFrame;
   width: number;
   height: number;
   maxHeight?: number;
-  parentMetaData?: {
-    title: string;
-    titleSource: string;
-  };
+  parentMetaData?: TableParentMetaData;
   /** Minimal column width specified in pixels */
   columnMinWidth?: number;
   noHeader?: boolean;

--- a/packages/grafana-ui/src/components/Table/types.ts
+++ b/packages/grafana-ui/src/components/Table/types.ts
@@ -72,7 +72,10 @@ export interface Props {
   width: number;
   height: number;
   maxHeight?: number;
-  title?: string;
+  parentData?: {
+    title: string;
+    titleSource: string;
+  };
   /** Minimal column width specified in pixels */
   columnMinWidth?: number;
   noHeader?: boolean;

--- a/packages/grafana-ui/src/components/Table/types.ts
+++ b/packages/grafana-ui/src/components/Table/types.ts
@@ -67,8 +67,7 @@ export interface GrafanaTableState extends TableState {
 export interface GrafanaTableRow extends Row, UseExpandedRowProps<{}> {}
 
 type TableParentMetaData = {
-  title: string;
-  titleSource: string;
+  [key: string]: string;
 };
 
 export interface Props {

--- a/packages/grafana-ui/src/components/Table/types.ts
+++ b/packages/grafana-ui/src/components/Table/types.ts
@@ -72,7 +72,7 @@ export interface Props {
   width: number;
   height: number;
   maxHeight?: number;
-  hasTitle?: boolean;
+  title?: string;
   /** Minimal column width specified in pixels */
   columnMinWidth?: number;
   noHeader?: boolean;

--- a/packages/grafana-ui/src/components/Table/utils.ts
+++ b/packages/grafana-ui/src/components/Table/utils.ts
@@ -44,6 +44,7 @@ import {
 
 export const EXPANDER_WIDTH = 50;
 export const OPTIONAL_ROW_NUMBER_COLUMN_WIDTH = 50;
+export const TITLE_HEIGHT = 32;
 
 export function getTextAlign(field?: Field): Property.JustifyContent {
   if (!field) {

--- a/public/app/plugins/panel/table/TablePanel.tsx
+++ b/public/app/plugins/panel/table/TablePanel.tsx
@@ -53,7 +53,7 @@ export function TablePanel(props: Props) {
       showTypeIcons={options.showTypeIcons}
       resizable={true}
       showRowNums={options.showRowNums}
-      hasTitle={!!title.length}
+      title={title}
       initialSortBy={options.sortBy}
       onSortByChange={(sortBy) => onSortByChange(sortBy, props)}
       onColumnResize={(displayName, resizedWidth) => onColumnResize(displayName, resizedWidth, props)}

--- a/public/app/plugins/panel/table/TablePanel.tsx
+++ b/public/app/plugins/panel/table/TablePanel.tsx
@@ -12,7 +12,7 @@ import { PanelOptions } from './panelcfg.gen';
 interface Props extends PanelProps<PanelOptions> {}
 
 export function TablePanel(props: Props) {
-  const { data, height, width, options, fieldConfig, id } = props;
+  const { data, height, width, options, fieldConfig, id, title } = props;
 
   const theme = useTheme2();
   const panelContext = usePanelContext();
@@ -39,6 +39,10 @@ export function TablePanel(props: Props) {
     subData = subFrames.filter((f) => f.refId === main.refId);
   }
 
+  if (!title.length) {
+    tableHeight = tableHeight - 32;
+  }
+
   const tableElement = (
     <Table
       height={tableHeight}
@@ -49,6 +53,7 @@ export function TablePanel(props: Props) {
       showTypeIcons={options.showTypeIcons}
       resizable={true}
       showRowNums={options.showRowNums}
+      hasTitle={!!title.length}
       initialSortBy={options.sortBy}
       onSortByChange={(sortBy) => onSortByChange(sortBy, props)}
       onColumnResize={(displayName, resizedWidth) => onColumnResize(displayName, resizedWidth, props)}

--- a/public/app/plugins/panel/table/TablePanel.tsx
+++ b/public/app/plugins/panel/table/TablePanel.tsx
@@ -39,7 +39,7 @@ export function TablePanel(props: Props) {
     subData = subFrames.filter((f) => f.refId === main.refId);
   }
 
-  // If the title is removed from the panel, this will adjust the table height accordingly.
+  // If there is an empty title for the panel, this will adjust the table height accordingly.
   if (!title.length) {
     tableHeight = tableHeight - TITLE_HEIGHT;
   }

--- a/public/app/plugins/panel/table/TablePanel.tsx
+++ b/public/app/plugins/panel/table/TablePanel.tsx
@@ -54,7 +54,7 @@ export function TablePanel(props: Props) {
       showTypeIcons={options.showTypeIcons}
       resizable={true}
       showRowNums={options.showRowNums}
-      parentData={{ title, titleSource: 'tablePanel' }}
+      parentMetaData={{ title, titleSource: 'tablePanel' }}
       initialSortBy={options.sortBy}
       onSortByChange={(sortBy) => onSortByChange(sortBy, props)}
       onColumnResize={(displayName, resizedWidth) => onColumnResize(displayName, resizedWidth, props)}

--- a/public/app/plugins/panel/table/TablePanel.tsx
+++ b/public/app/plugins/panel/table/TablePanel.tsx
@@ -5,7 +5,7 @@ import { DataFrame, FieldMatcherID, getFrameDisplayName, PanelProps, SelectableV
 import { PanelDataErrorView } from '@grafana/runtime';
 import { Select, Table, usePanelContext, useTheme2 } from '@grafana/ui';
 import { TableSortByFieldState } from '@grafana/ui/src/components/Table/types';
-import { OPTIONAL_ROW_NUMBER_COLUMN_WIDTH } from '@grafana/ui/src/components/Table/utils';
+import { OPTIONAL_ROW_NUMBER_COLUMN_WIDTH, TITLE_HEIGHT } from '@grafana/ui/src/components/Table/utils';
 
 import { PanelOptions } from './panelcfg.gen';
 
@@ -39,8 +39,9 @@ export function TablePanel(props: Props) {
     subData = subFrames.filter((f) => f.refId === main.refId);
   }
 
+  // If the title is removed from the panel, this will adjust the table height accordingly.
   if (!title.length) {
-    tableHeight = tableHeight - 32;
+    tableHeight = tableHeight - TITLE_HEIGHT;
   }
 
   const tableElement = (

--- a/public/app/plugins/panel/table/TablePanel.tsx
+++ b/public/app/plugins/panel/table/TablePanel.tsx
@@ -53,7 +53,7 @@ export function TablePanel(props: Props) {
       showTypeIcons={options.showTypeIcons}
       resizable={true}
       showRowNums={options.showRowNums}
-      title={title}
+      parentData={{ title, titleSource: 'tablePanel' }}
       initialSortBy={options.sortBy}
       onSortByChange={(sortBy) => onSortByChange(sortBy, props)}
       onColumnResize={(displayName, resizedWidth) => onColumnResize(displayName, resizedWidth, props)}


### PR DESCRIPTION
**What is this feature?**

Fixes a bug in the Table Panel in which when a the title is removed from the Table Panel, the table flexes upward to take up the space the title previously comprised, making clicking on the sorting or filtering options impossible.

**Why do we need this feature?**

So that user can sort and filter in the expected way.

**Who is this feature for?**

All users.

**Which issue(s) does this PR fix?**:

Fixes #64021

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [na] If this is a pre-GA feature, it is behind a feature toggle.
- [na] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
- [x] There are no known compatibility issues with older supported versions of Grafana, or plugins.
- [na] It passes the [Hosted Grafana feature readiness review](https://docs.google.com/document/d/1QL9Ly8KnXzpb6ISbg49pTODRO5mhA5tkkfIZVX6pqQU/edit) for observability, scalability, performance, and security.

Previous behavior when title is remove -> sorting and filtering is inaccessible:

https://user-images.githubusercontent.com/46619047/228036740-05ffc67f-46e0-4c4d-84dd-18e3276c5079.mov

Fixed behavior when title is removed:

https://user-images.githubusercontent.com/46619047/228036796-965bbe00-bd9e-46c8-a359-e5e906c66eaf.mov
