### PR TITLE
Alerting: Choose a previous valid AM configuration in case of error (Frontend)

### DIFF
--- a/public/app/features/alerting/unified/api/alertmanager.ts
+++ b/public/app/features/alerting/unified/api/alertmanager.ts
@@ -20,6 +20,8 @@ import {
 
 import { getDatasourceAPIUid, GRAFANA_RULES_SOURCE_NAME } from '../utils/datasource';
 
+const limitToSuccessfullyAppliedAMs = 10;
+
 // "grafana" for grafana-managed, otherwise a datasource name
 export async function fetchAlertManagerConfig(alertManagerSourceName: string): Promise<AlertManagerCortexConfig> {
   try {
@@ -49,6 +51,20 @@ export async function fetchAlertManagerConfig(alertManagerSourceName: string): P
     }
     throw e;
   }
+}
+
+//this is only available for the "grafana" alert manager
+export async function fetchValidAlertManagerConfig(): Promise<AlertManagerCortexConfig[]> {
+  const result = await lastValueFrom(
+    getBackendSrv().fetch<AlertManagerCortexConfig[]>({
+      url: `/api/alertmanager/${getDatasourceAPIUid(
+        GRAFANA_RULES_SOURCE_NAME
+      )}/config/api/v1/alerts/successfully-applied?limit=${limitToSuccessfullyAppliedAMs}`,
+      showErrorAlert: false,
+      showSuccessAlert: false,
+    })
+  );
+  return result.data;
 }
 
 export async function updateAlertManagerConfig(

--- a/public/app/features/alerting/unified/api/alertmanager.ts
+++ b/public/app/features/alerting/unified/api/alertmanager.ts
@@ -20,8 +20,6 @@ import {
 
 import { getDatasourceAPIUid, GRAFANA_RULES_SOURCE_NAME } from '../utils/datasource';
 
-const limitToSuccessfullyAppliedAMs = 10;
-
 // "grafana" for grafana-managed, otherwise a datasource name
 export async function fetchAlertManagerConfig(alertManagerSourceName: string): Promise<AlertManagerCortexConfig> {
   try {

--- a/public/app/features/alerting/unified/api/alertmanager.ts
+++ b/public/app/features/alerting/unified/api/alertmanager.ts
@@ -34,7 +34,7 @@ export async function fetchAlertManagerConfig(alertManagerSourceName: string): P
       template_files: result.data.template_files ?? {},
       template_file_provenances: result.data.template_file_provenances ?? {},
       alertmanager_config: result.data.alertmanager_config ?? {},
-      successfully_applied_at: result.data.successfully_applied_at,
+      last_applied: result.data.last_applied,
     };
   } catch (e) {
     // if no config has been uploaded to grafana, it returns error instead of latest config

--- a/public/app/features/alerting/unified/api/alertmanager.ts
+++ b/public/app/features/alerting/unified/api/alertmanager.ts
@@ -53,20 +53,6 @@ export async function fetchAlertManagerConfig(alertManagerSourceName: string): P
   }
 }
 
-//this is only available for the "grafana" alert manager
-export async function fetchValidAlertManagerConfig(): Promise<AlertManagerCortexConfig[]> {
-  const result = await lastValueFrom(
-    getBackendSrv().fetch<AlertManagerCortexConfig[]>({
-      url: `/api/alertmanager/${getDatasourceAPIUid(
-        GRAFANA_RULES_SOURCE_NAME
-      )}/config/api/v1/alerts/successfully-applied?limit=${limitToSuccessfullyAppliedAMs}`,
-      showErrorAlert: false,
-      showSuccessAlert: false,
-    })
-  );
-  return result.data;
-}
-
 export async function updateAlertManagerConfig(
   alertManagerSourceName: string,
   config: AlertManagerCortexConfig

--- a/public/app/features/alerting/unified/api/alertmanager.ts
+++ b/public/app/features/alerting/unified/api/alertmanager.ts
@@ -34,6 +34,7 @@ export async function fetchAlertManagerConfig(alertManagerSourceName: string): P
       template_files: result.data.template_files ?? {},
       template_file_provenances: result.data.template_file_provenances ?? {},
       alertmanager_config: result.data.alertmanager_config ?? {},
+      successfully_applied_at: result.data.successfully_applied_at,
     };
   } catch (e) {
     // if no config has been uploaded to grafana, it returns error instead of latest config

--- a/public/app/features/alerting/unified/api/alertmanagerApi.ts
+++ b/public/app/features/alerting/unified/api/alertmanagerApi.ts
@@ -43,7 +43,7 @@ export const alertmanagerApi = alertingApi.injectEndpoints({
       query: () => ({
         url: `/api/alertmanager/${getDatasourceAPIUid(
           GRAFANA_RULES_SOURCE_NAME
-        )}/config/api/v1/alerts/successfully-applied?limit=${LIMIT_TO_SUCCESSFULLY_APPLIED_AMS}`,
+        )}/config/history?limit=${LIMIT_TO_SUCCESSFULLY_APPLIED_AMS}`,
       }),
     }),
   }),

--- a/public/app/features/alerting/unified/api/alertmanagerApi.ts
+++ b/public/app/features/alerting/unified/api/alertmanagerApi.ts
@@ -1,11 +1,15 @@
 import {
   AlertmanagerChoice,
+  AlertManagerCortexConfig,
   ExternalAlertmanagerConfig,
   ExternalAlertmanagers,
   ExternalAlertmanagersResponse,
 } from '../../../../plugins/datasource/alertmanager/types';
+import { getDatasourceAPIUid, GRAFANA_RULES_SOURCE_NAME } from '../utils/datasource';
 
 import { alertingApi } from './alertingApi';
+
+const limitToSuccessfullyAppliedAMs = 10;
 
 export interface AlertmanagersChoiceResponse {
   alertmanagersChoice: AlertmanagerChoice;
@@ -32,6 +36,15 @@ export const alertmanagerApi = alertingApi.injectEndpoints({
     saveExternalAlertmanagersConfig: build.mutation<{ message: string }, ExternalAlertmanagerConfig>({
       query: (config) => ({ url: '/api/v1/ngalert/admin_config', method: 'POST', data: config }),
       invalidatesTags: ['AlertmanagerChoice'],
+    }),
+
+    getValidAlertManagersConfig: build.query<AlertManagerCortexConfig[], void>({
+      //this is only available for the "grafana" alert manager
+      query: () => ({
+        url: `/api/alertmanager/${getDatasourceAPIUid(
+          GRAFANA_RULES_SOURCE_NAME
+        )}/config/api/v1/alerts/successfully-applied?limit=${limitToSuccessfullyAppliedAMs}`,
+      }),
     }),
   }),
 });

--- a/public/app/features/alerting/unified/api/alertmanagerApi.ts
+++ b/public/app/features/alerting/unified/api/alertmanagerApi.ts
@@ -9,7 +9,7 @@ import { getDatasourceAPIUid, GRAFANA_RULES_SOURCE_NAME } from '../utils/datasou
 
 import { alertingApi } from './alertingApi';
 
-const limitToSuccessfullyAppliedAMs = 10;
+const LIMIT_TO_SUCCESSFULLY_APPLIED_AMS = 10;
 
 export interface AlertmanagersChoiceResponse {
   alertmanagersChoice: AlertmanagerChoice;
@@ -43,7 +43,7 @@ export const alertmanagerApi = alertingApi.injectEndpoints({
       query: () => ({
         url: `/api/alertmanager/${getDatasourceAPIUid(
           GRAFANA_RULES_SOURCE_NAME
-        )}/config/api/v1/alerts/successfully-applied?limit=${limitToSuccessfullyAppliedAMs}`,
+        )}/config/api/v1/alerts/successfully-applied?limit=${LIMIT_TO_SUCCESSFULLY_APPLIED_AMS}`,
       }),
     }),
   }),

--- a/public/app/features/alerting/unified/components/admin/AlertmanagerConfig.test.tsx
+++ b/public/app/features/alerting/unified/components/admin/AlertmanagerConfig.test.tsx
@@ -18,7 +18,6 @@ import {
   deleteAlertManagerConfig,
   updateAlertManagerConfig,
   fetchStatus,
-  fetchValidAlertManagerConfig,
 } from '../../api/alertmanager';
 import {
   disableRBAC,
@@ -45,7 +44,6 @@ const mocks = {
     deleteAlertManagerConfig: jest.mocked(deleteAlertManagerConfig),
     updateAlertManagerConfig: jest.mocked(updateAlertManagerConfig),
     fetchStatus: jest.mocked(fetchStatus),
-    fetchValidConfig: jest.mocked(fetchValidAlertManagerConfig),
   },
 };
 

--- a/public/app/features/alerting/unified/components/admin/AlertmanagerConfig.test.tsx
+++ b/public/app/features/alerting/unified/components/admin/AlertmanagerConfig.test.tsx
@@ -18,6 +18,7 @@ import {
   deleteAlertManagerConfig,
   updateAlertManagerConfig,
   fetchStatus,
+  fetchValidAlertManagerConfig,
 } from '../../api/alertmanager';
 import {
   disableRBAC,
@@ -44,6 +45,7 @@ const mocks = {
     deleteAlertManagerConfig: jest.mocked(deleteAlertManagerConfig),
     updateAlertManagerConfig: jest.mocked(updateAlertManagerConfig),
     fetchStatus: jest.mocked(fetchStatus),
+    fetchValidConfig: jest.mocked(fetchValidAlertManagerConfig),
   },
 };
 
@@ -100,9 +102,7 @@ describe('Admin config', () => {
       alertmanager_config: {},
     });
     mocks.api.deleteAlertManagerConfig.mockResolvedValue();
-
-    await renderAdminPage(dataSources.alertManager.name);
-
+    renderAdminPage(dataSources.alertManager.name);
     await userEvent.click(await ui.resetButton.find());
     await userEvent.click(ui.confirmButton.get());
     await waitFor(() => expect(mocks.api.deleteAlertManagerConfig).toHaveBeenCalled());
@@ -128,7 +128,7 @@ describe('Admin config', () => {
 
     mocks.api.fetchConfig.mockImplementation(() => Promise.resolve(savedConfig ?? defaultConfig));
     mocks.api.updateAlertManagerConfig.mockResolvedValue();
-    await renderAdminPage(dataSources.alertManager.name);
+    renderAdminPage(dataSources.alertManager.name);
     const input = await ui.configInput.find();
     expect(input.value).toEqual(JSON.stringify(defaultConfig, null, 2));
     await userEvent.clear(input);
@@ -147,7 +147,7 @@ describe('Admin config', () => {
       ...someCloudAlertManagerStatus,
       config: someCloudAlertManagerConfig.alertmanager_config,
     });
-    await renderAdminPage(dataSources.promAlertManager.name);
+    renderAdminPage(dataSources.promAlertManager.name);
 
     await ui.readOnlyConfig.find();
     expect(ui.configInput.query()).not.toBeInTheDocument();

--- a/public/app/features/alerting/unified/components/admin/AlertmanagerConfig.tsx
+++ b/public/app/features/alerting/unified/components/admin/AlertmanagerConfig.tsx
@@ -100,7 +100,10 @@ export default function AlertmanagerConfig(): JSX.Element {
       />
       {loadingError && !loading && (
         <>
-          <Alert severity="error" title="Error loading Alertmanager configuration">
+          <Alert
+            severity="error"
+            title="Your Alertmanager configuration is incorrect. These are the details of the error:"
+          >
             {loadingError.message || 'Unknown error.'}
           </Alert>
 

--- a/public/app/features/alerting/unified/components/admin/AlertmanagerConfig.tsx
+++ b/public/app/features/alerting/unified/components/admin/AlertmanagerConfig.tsx
@@ -107,15 +107,16 @@ export default function AlertmanagerConfig(): JSX.Element {
             {loadingError.message || 'Unknown error.'}
           </Alert>
 
-          <AlertmanagerConfigSelector
-            onChange={setSelectedAmConfig}
-            selectedAmConfig={selectedAmConfig}
-            defaultValues={defaultValidValues}
-            readOnly={readOnly}
-            loading={loading}
-            alertManagerSourceName={alertManagerSourceName}
-            onSubmit={onSubmit}
-          />
+          {alertManagerSourceName === GRAFANA_RULES_SOURCE_NAME && (
+            <AlertmanagerConfigSelector
+              onChange={setSelectedAmConfig}
+              selectedAmConfig={selectedAmConfig}
+              defaultValues={defaultValidValues}
+              readOnly={readOnly}
+              loading={loading}
+              onSubmit={onSubmit}
+            />
+          )}
         </>
       )}
       {isDeleting && alertManagerSourceName !== GRAFANA_RULES_SOURCE_NAME && (

--- a/public/app/features/alerting/unified/components/admin/AlertmanagerConfig.tsx
+++ b/public/app/features/alerting/unified/components/admin/AlertmanagerConfig.tsx
@@ -76,7 +76,11 @@ export default function AlertmanagerConfig(): JSX.Element {
 
   const loading = isDeleting || isLoadingConfig || isSaving;
 
-  const onSubmit = (values: FormValues, fetchLatestConfig: boolean, oldConfig?: AlertManagerCortexConfig) => {
+  const onSubmit = (
+    values: FormValues,
+    checkConflictsWithExistingConfig: boolean,
+    oldConfig?: AlertManagerCortexConfig
+  ) => {
     if (alertManagerSourceName && oldConfig) {
       dispatch(
         updateAlertManagerConfigAction({
@@ -85,7 +89,7 @@ export default function AlertmanagerConfig(): JSX.Element {
           alertManagerSourceName,
           successMessage: 'Alertmanager configuration updated.',
           refetch: true,
-          fetchLatestConfig,
+          checkConflictsWithExistingConfig,
         })
       );
     }

--- a/public/app/features/alerting/unified/components/admin/AlertmanagerConfigSelector.tsx
+++ b/public/app/features/alerting/unified/components/admin/AlertmanagerConfigSelector.tsx
@@ -49,9 +49,7 @@ export default function AlertmanagerConfigSelector({
     }
 
     const configs: ValidAmConfigOption[] = validAmConfigs.map((config) => ({
-      label: config.successfully_applied_at
-        ? `Config from ${new Date(config.successfully_applied_at).toLocaleString()}`
-        : 'Previous config',
+      label: config.last_applied ? `Config from ${new Date(config.last_applied).toLocaleString()}` : 'Previous config',
       value: config,
     }));
     onChange(configs[0]);

--- a/public/app/features/alerting/unified/components/admin/AlertmanagerConfigSelector.tsx
+++ b/public/app/features/alerting/unified/components/admin/AlertmanagerConfigSelector.tsx
@@ -44,8 +44,10 @@ export default function AlertmanagerConfigSelector({
       return [];
     }
 
-    const configs: ValidAmConfigOption[] = validAmConfigs.map((config, index) => ({
-      label: `Config ${index + 1}`,
+    const configs: ValidAmConfigOption[] = validAmConfigs.map((config) => ({
+      label: config.successfully_applied_at
+        ? `Config from ${new Date(config.successfully_applied_at).toLocaleString()}`
+        : 'Previous config',
       value: config,
     }));
     onChange(configs[0]);

--- a/public/app/features/alerting/unified/components/admin/AlertmanagerConfigSelector.tsx
+++ b/public/app/features/alerting/unified/components/admin/AlertmanagerConfigSelector.tsx
@@ -1,0 +1,89 @@
+import { css } from '@emotion/css';
+import React, { useMemo } from 'react';
+
+import { GrafanaTheme2, SelectableValue } from '@grafana/data';
+import { Select, useStyles2 } from '@grafana/ui';
+import { AlertManagerCortexConfig } from 'app/plugins/datasource/alertmanager/types';
+
+import { alertmanagerApi } from '../../api/alertmanagerApi';
+
+import { FormValues } from './AlertmanagerConfig';
+import { ConfigEditor } from './ConfigEditor';
+
+export interface ValidAmConfigOption {
+  label: string;
+  value: AlertManagerCortexConfig;
+}
+
+interface AlertmanagerConfigSelectorProps {
+  onChange: (selectedOption: ValidAmConfigOption) => void;
+  selectedAmConfig?: ValidAmConfigOption;
+  defaultValues: FormValues;
+  onSubmit: (values: FormValues, fetchLatestConfig: boolean, oldConfig?: AlertManagerCortexConfig) => void;
+  readOnly: boolean;
+  loading: boolean;
+  alertManagerSourceName?: string;
+}
+
+export default function AlertmanagerConfigSelector({
+  onChange,
+  selectedAmConfig,
+  defaultValues,
+  onSubmit,
+  readOnly,
+  loading,
+  alertManagerSourceName,
+}: AlertmanagerConfigSelectorProps): JSX.Element {
+  const { useGetValidAlertManagersConfigQuery } = alertmanagerApi;
+
+  const styles = useStyles2(getStyles);
+
+  const { currentData: validAmConfigs, isLoading: isFetchingValidAmConfigs } = useGetValidAlertManagersConfigQuery();
+
+  const validAmConfigsOptions = useMemo(() => {
+    if (!validAmConfigs?.length) {
+      return [];
+    }
+
+    const configs: ValidAmConfigOption[] = validAmConfigs.map((config, index) => ({
+      label: `Config ${index + 1}`,
+      value: config,
+    }));
+    onChange(configs[0]);
+    return configs;
+  }, [validAmConfigs, onChange]);
+
+  return (
+    <>
+      {!isFetchingValidAmConfigs && validAmConfigs && validAmConfigs.length > 0 ? (
+        <>
+          <div>Select a previous working configuration</div>
+
+          <Select
+            className={styles.container}
+            options={validAmConfigsOptions}
+            value={selectedAmConfig}
+            onChange={(value: SelectableValue) => {
+              // @ts-ignore
+              onChange(value);
+            }}
+          />
+
+          <ConfigEditor
+            defaultValues={defaultValues}
+            onSubmit={(values) => onSubmit(values, false, selectedAmConfig?.value)}
+            readOnly={readOnly}
+            loading={loading}
+            alertManagerSourceName={alertManagerSourceName}
+          />
+        </>
+      ) : null}
+    </>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  container: css`
+    margin-bottom: ${theme.spacing(4)};
+  `,
+});

--- a/public/app/features/alerting/unified/components/admin/AlertmanagerConfigSelector.tsx
+++ b/public/app/features/alerting/unified/components/admin/AlertmanagerConfigSelector.tsx
@@ -12,8 +12,8 @@ import { FormValues } from './AlertmanagerConfig';
 import { ConfigEditor } from './ConfigEditor';
 
 export interface ValidAmConfigOption {
-  label: string;
-  value: AlertManagerCortexConfig;
+  label?: string;
+  value?: AlertManagerCortexConfig;
 }
 
 interface AlertmanagerConfigSelectorProps {
@@ -63,7 +63,6 @@ export default function AlertmanagerConfigSelector({
             options={validAmConfigsOptions}
             value={selectedAmConfig}
             onChange={(value: SelectableValue) => {
-              // @ts-ignore
               onChange(value);
             }}
           />

--- a/public/app/features/alerting/unified/components/admin/AlertmanagerConfigSelector.tsx
+++ b/public/app/features/alerting/unified/components/admin/AlertmanagerConfigSelector.tsx
@@ -6,6 +6,7 @@ import { Select, useStyles2 } from '@grafana/ui';
 import { AlertManagerCortexConfig } from 'app/plugins/datasource/alertmanager/types';
 
 import { alertmanagerApi } from '../../api/alertmanagerApi';
+import { GRAFANA_RULES_SOURCE_NAME } from '../../utils/datasource';
 
 import { FormValues } from './AlertmanagerConfig';
 import { ConfigEditor } from './ConfigEditor';
@@ -22,7 +23,6 @@ interface AlertmanagerConfigSelectorProps {
   onSubmit: (values: FormValues, fetchLatestConfig: boolean, oldConfig?: AlertManagerCortexConfig) => void;
   readOnly: boolean;
   loading: boolean;
-  alertManagerSourceName?: string;
 }
 
 export default function AlertmanagerConfigSelector({
@@ -32,7 +32,6 @@ export default function AlertmanagerConfigSelector({
   onSubmit,
   readOnly,
   loading,
-  alertManagerSourceName,
 }: AlertmanagerConfigSelectorProps): JSX.Element {
   const { useGetValidAlertManagersConfigQuery } = alertmanagerApi;
 
@@ -74,7 +73,7 @@ export default function AlertmanagerConfigSelector({
             onSubmit={(values) => onSubmit(values, false, selectedAmConfig?.value)}
             readOnly={readOnly}
             loading={loading}
-            alertManagerSourceName={alertManagerSourceName}
+            alertManagerSourceName={GRAFANA_RULES_SOURCE_NAME}
           />
         </>
       ) : null}

--- a/public/app/features/alerting/unified/components/admin/AlertmanagerConfigSelector.tsx
+++ b/public/app/features/alerting/unified/components/admin/AlertmanagerConfigSelector.tsx
@@ -20,7 +20,11 @@ interface AlertmanagerConfigSelectorProps {
   onChange: (selectedOption: ValidAmConfigOption) => void;
   selectedAmConfig?: ValidAmConfigOption;
   defaultValues: FormValues;
-  onSubmit: (values: FormValues, fetchLatestConfig: boolean, oldConfig?: AlertManagerCortexConfig) => void;
+  onSubmit: (
+    values: FormValues,
+    checkConflictsWithExistingConfig: boolean,
+    oldConfig?: AlertManagerCortexConfig
+  ) => void;
   readOnly: boolean;
   loading: boolean;
 }

--- a/public/app/features/alerting/unified/components/admin/AlertmanagerConfigSelector.tsx
+++ b/public/app/features/alerting/unified/components/admin/AlertmanagerConfigSelector.tsx
@@ -57,7 +57,7 @@ export default function AlertmanagerConfigSelector({
     <>
       {!isFetchingValidAmConfigs && validAmConfigs && validAmConfigs.length > 0 ? (
         <>
-          <div>Select a previous working configuration</div>
+          <div>Select a previous working configuration until you fix this error:</div>
 
           <Select
             className={styles.container}

--- a/public/app/features/alerting/unified/components/admin/ConfigEditor.tsx
+++ b/public/app/features/alerting/unified/components/admin/ConfigEditor.tsx
@@ -34,47 +34,48 @@ export const ConfigEditor = ({
       {({ register, errors }) => (
         <>
           {!readOnly && (
-            <Field
-              disabled={loading}
-              label="Configuration"
-              invalid={!!errors.configJSON}
-              error={errors.configJSON?.message}
-            >
-              <TextArea
-                {...register('configJSON', {
-                  required: { value: true, message: 'Required.' },
-                  validate: (v) => {
-                    try {
-                      JSON.parse(v);
-                      return true;
-                    } catch (e) {
-                      return e instanceof Error ? e.message : 'Invalid JSON.';
-                    }
-                  },
-                })}
-                id="configuration"
-                rows={25}
-              />
-            </Field>
+            <>
+              <Field
+                disabled={loading}
+                label="Configuration"
+                invalid={!!errors.configJSON}
+                error={errors.configJSON?.message}
+              >
+                <TextArea
+                  {...register('configJSON', {
+                    required: { value: true, message: 'Required.' },
+                    validate: (v) => {
+                      try {
+                        JSON.parse(v);
+                        return true;
+                      } catch (e) {
+                        return e instanceof Error ? e.message : 'Invalid JSON.';
+                      }
+                    },
+                  })}
+                  id="configuration"
+                  rows={25}
+                />
+              </Field>
+
+              <HorizontalGroup>
+                <Button type="submit" variant="primary" disabled={loading}>
+                  Save
+                </Button>
+                {onReset && (
+                  <Button type="button" disabled={loading} variant="destructive" onClick={onReset}>
+                    Reset configuration
+                  </Button>
+                )}
+              </HorizontalGroup>
+            </>
           )}
           {readOnly && (
             <Field label="Configuration">
               <pre data-testid="readonly-config">{defaultValues.configJSON}</pre>
             </Field>
           )}
-          {!readOnly && (
-            <HorizontalGroup>
-              <Button type="submit" variant="primary" disabled={loading}>
-                Save
-              </Button>
-              {onReset && (
-                <Button type="button" disabled={loading} variant="destructive" onClick={onReset}>
-                  Reset configuration
-                </Button>
-              )}
-            </HorizontalGroup>
-          )}
-          {!!showConfirmDeleteAMConfig && onConfirmReset && onDismiss && (
+          {Boolean(showConfirmDeleteAMConfig) && onConfirmReset && onDismiss && (
             <ConfirmModal
               isOpen={true}
               title="Reset Alertmanager configuration"

--- a/public/app/features/alerting/unified/components/admin/ConfigEditor.tsx
+++ b/public/app/features/alerting/unified/components/admin/ConfigEditor.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+
+import { Button, ConfirmModal, TextArea, HorizontalGroup, Field, Form } from '@grafana/ui';
+
+import { GRAFANA_RULES_SOURCE_NAME } from '../../utils/datasource';
+
+import { FormValues } from './AlertmanagerConfig';
+
+interface ConfigEditorProps {
+  defaultValues: { configJSON: string };
+  readOnly: boolean;
+  loading: boolean;
+  alertManagerSourceName?: string;
+  onSubmit: (values: FormValues) => void;
+  showConfirmDeleteAMConfig?: boolean;
+  onReset?: () => void;
+  onConfirmReset?: () => void;
+  onDismiss?: () => void;
+}
+
+export const ConfigEditor = ({
+  defaultValues,
+  readOnly,
+  loading,
+  alertManagerSourceName,
+  showConfirmDeleteAMConfig,
+  onSubmit,
+  onReset,
+  onConfirmReset,
+  onDismiss,
+}: ConfigEditorProps) => {
+  return (
+    <Form defaultValues={defaultValues} onSubmit={onSubmit} key={defaultValues.configJSON}>
+      {({ register, errors }) => (
+        <>
+          {!readOnly && (
+            <Field
+              disabled={loading}
+              label="Configuration"
+              invalid={!!errors.configJSON}
+              error={errors.configJSON?.message}
+            >
+              <TextArea
+                {...register('configJSON', {
+                  required: { value: true, message: 'Required.' },
+                  validate: (v) => {
+                    try {
+                      JSON.parse(v);
+                      return true;
+                    } catch (e) {
+                      return e instanceof Error ? e.message : 'Invalid JSON.';
+                    }
+                  },
+                })}
+                id="configuration"
+                rows={25}
+              />
+            </Field>
+          )}
+          {readOnly && (
+            <Field label="Configuration">
+              <pre data-testid="readonly-config">{defaultValues.configJSON}</pre>
+            </Field>
+          )}
+          {!readOnly && (
+            <HorizontalGroup>
+              <Button type="submit" variant="primary" disabled={loading}>
+                Save
+              </Button>
+              {onReset && (
+                <Button type="button" disabled={loading} variant="destructive" onClick={onReset}>
+                  Reset configuration
+                </Button>
+              )}
+            </HorizontalGroup>
+          )}
+          {!!showConfirmDeleteAMConfig && onConfirmReset && onDismiss && (
+            <ConfirmModal
+              isOpen={true}
+              title="Reset Alertmanager configuration"
+              body={`Are you sure you want to reset configuration ${
+                alertManagerSourceName === GRAFANA_RULES_SOURCE_NAME
+                  ? 'for the Grafana Alertmanager'
+                  : `for "${alertManagerSourceName}"`
+              }? Contact points and notification policies will be reset to their defaults.`}
+              confirmText="Yes, reset configuration"
+              onConfirm={onConfirmReset}
+              onDismiss={onDismiss}
+            />
+          )}
+        </>
+      )}
+    </Form>
+  );
+};

--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -162,7 +162,7 @@ export const fetchAlertManagerConfigAction = createAsyncThunk(
                 alertmanager_config: status.config,
                 template_files: {},
                 template_file_provenances: result.template_file_provenances,
-                successfully_applied_at: result.successfully_applied_at,
+                last_applied: result.last_applied,
               }));
             }
             return result;

--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -162,6 +162,7 @@ export const fetchAlertManagerConfigAction = createAsyncThunk(
                 alertmanager_config: status.config,
                 template_files: {},
                 template_file_provenances: result.template_file_provenances,
+                successfully_applied_at: result.successfully_applied_at,
               }));
             }
             return result;

--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -540,19 +540,27 @@ interface UpdateAlertManagerConfigActionOptions {
   successMessage?: string; // show toast on success
   redirectPath?: string; // where to redirect on success
   refetch?: boolean; // refetch config on success
-  fetchLatestConfig?: boolean; //obtain latest config prior to saving it
+  checkConflictsWithExistingConfig?: boolean; //obtain latest config prior to saving it
 }
 
 export const updateAlertManagerConfigAction = createAsyncThunk<void, UpdateAlertManagerConfigActionOptions, {}>(
   'unifiedalerting/updateAMConfig',
   (
-    { alertManagerSourceName, oldConfig, newConfig, successMessage, redirectPath, refetch, fetchLatestConfig = true },
+    {
+      alertManagerSourceName,
+      oldConfig,
+      newConfig,
+      successMessage,
+      redirectPath,
+      refetch,
+      checkConflictsWithExistingConfig = true,
+    },
     thunkAPI
   ): Promise<void> =>
     withAppEvents(
       withSerializedError(
         (async () => {
-          if (fetchLatestConfig) {
+          if (checkConflictsWithExistingConfig) {
             const latestConfig = await thunkAPI
               .dispatch(fetchAlertManagerConfigAction(alertManagerSourceName))
               .unwrap();

--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -556,10 +556,11 @@ export const updateAlertManagerConfigAction = createAsyncThunk<void, UpdateAlert
               .dispatch(fetchAlertManagerConfigAction(alertManagerSourceName))
               .unwrap();
 
-            if (
-              !(isEmpty(latestConfig.alertmanager_config) && isEmpty(latestConfig.template_files)) &&
-              JSON.stringify(latestConfig) !== JSON.stringify(oldConfig)
-            ) {
+            const isLatestConfigEmpty =
+              isEmpty(latestConfig.alertmanager_config) && isEmpty(latestConfig.template_files);
+            const oldLastConfigsDiffer = JSON.stringify(latestConfig) !== JSON.stringify(oldConfig);
+
+            if (!isLatestConfigEmpty && oldLastConfigsDiffer) {
               throw new Error(
                 'It seems configuration has been recently updated. Please reload page and try again to make sure that recent changes are not overwritten.'
               );

--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -46,6 +46,7 @@ import {
   fetchExternalAlertmanagers,
   fetchSilences,
   fetchStatus,
+  fetchValidAlertManagerConfig,
   testReceivers,
   updateAlertManagerConfig,
 } from '../api/alertmanager';
@@ -943,4 +944,9 @@ export const addExternalAlertmanagersAction = createAsyncThunk(
       }
     );
   }
+);
+
+export const fetchValidAlertManagerConfigAction = createAsyncThunk(
+  'unifiedAlerting/fetchValidAlertManagerConfig',
+  (): Promise<AlertManagerCortexConfig[]> => withSerializedError(fetchValidAlertManagerConfig())
 );

--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -540,23 +540,31 @@ interface UpdateAlertManagerConfigActionOptions {
   successMessage?: string; // show toast on success
   redirectPath?: string; // where to redirect on success
   refetch?: boolean; // refetch config on success
+  fetchLatestConfig?: boolean; //obtain latest config prior to saving it
 }
 
 export const updateAlertManagerConfigAction = createAsyncThunk<void, UpdateAlertManagerConfigActionOptions, {}>(
   'unifiedalerting/updateAMConfig',
-  ({ alertManagerSourceName, oldConfig, newConfig, successMessage, redirectPath, refetch }, thunkAPI): Promise<void> =>
+  (
+    { alertManagerSourceName, oldConfig, newConfig, successMessage, redirectPath, refetch, fetchLatestConfig = true },
+    thunkAPI
+  ): Promise<void> =>
     withAppEvents(
       withSerializedError(
         (async () => {
-          const latestConfig = await thunkAPI.dispatch(fetchAlertManagerConfigAction(alertManagerSourceName)).unwrap();
+          if (fetchLatestConfig) {
+            const latestConfig = await thunkAPI
+              .dispatch(fetchAlertManagerConfigAction(alertManagerSourceName))
+              .unwrap();
 
-          if (
-            !(isEmpty(latestConfig.alertmanager_config) && isEmpty(latestConfig.template_files)) &&
-            JSON.stringify(latestConfig) !== JSON.stringify(oldConfig)
-          ) {
-            throw new Error(
-              'It seems configuration has been recently updated. Please reload page and try again to make sure that recent changes are not overwritten.'
-            );
+            if (
+              !(isEmpty(latestConfig.alertmanager_config) && isEmpty(latestConfig.template_files)) &&
+              JSON.stringify(latestConfig) !== JSON.stringify(oldConfig)
+            ) {
+              throw new Error(
+                'It seems configuration has been recently updated. Please reload page and try again to make sure that recent changes are not overwritten.'
+              );
+            }
           }
           await updateAlertManagerConfig(alertManagerSourceName, addDefaultsToAlertmanagerConfig(newConfig));
           if (refetch) {

--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -46,7 +46,6 @@ import {
   fetchExternalAlertmanagers,
   fetchSilences,
   fetchStatus,
-  fetchValidAlertManagerConfig,
   testReceivers,
   updateAlertManagerConfig,
 } from '../api/alertmanager';
@@ -952,9 +951,4 @@ export const addExternalAlertmanagersAction = createAsyncThunk(
       }
     );
   }
-);
-
-export const fetchValidAlertManagerConfigAction = createAsyncThunk(
-  'unifiedAlerting/fetchValidAlertManagerConfig',
-  (): Promise<AlertManagerCortexConfig[]> => withSerializedError(fetchValidAlertManagerConfig())
 );

--- a/public/app/features/alerting/unified/state/reducers.ts
+++ b/public/app/features/alerting/unified/state/reducers.ts
@@ -18,7 +18,6 @@ import {
   fetchRulerRulesAction,
   fetchRulesSourceBuildInfoAction,
   fetchSilencesAction,
-  fetchValidAlertManagerConfigAction,
   saveRuleFormAction,
   testReceiversAction,
   updateAlertManagerConfigAction,
@@ -39,7 +38,6 @@ export const reducer = combineReducers({
     fetchAlertManagerConfigAction,
     (alertManagerSourceName) => alertManagerSourceName
   ).reducer,
-  validAmConfigs: createAsyncSlice('validAmConfigs', fetchValidAlertManagerConfigAction).reducer,
   silences: createAsyncMapSlice('silences', fetchSilencesAction, (alertManagerSourceName) => alertManagerSourceName)
     .reducer,
   ruleForm: combineReducers({

--- a/public/app/features/alerting/unified/state/reducers.ts
+++ b/public/app/features/alerting/unified/state/reducers.ts
@@ -18,6 +18,7 @@ import {
   fetchRulerRulesAction,
   fetchRulesSourceBuildInfoAction,
   fetchSilencesAction,
+  fetchValidAlertManagerConfigAction,
   saveRuleFormAction,
   testReceiversAction,
   updateAlertManagerConfigAction,
@@ -38,6 +39,7 @@ export const reducer = combineReducers({
     fetchAlertManagerConfigAction,
     (alertManagerSourceName) => alertManagerSourceName
   ).reducer,
+  validAmConfigs: createAsyncSlice('validAmConfigs', fetchValidAlertManagerConfigAction).reducer,
   silences: createAsyncMapSlice('silences', fetchSilencesAction, (alertManagerSourceName) => alertManagerSourceName)
     .reducer,
   ruleForm: combineReducers({

--- a/public/app/plugins/datasource/alertmanager/types.ts
+++ b/public/app/plugins/datasource/alertmanager/types.ts
@@ -7,6 +7,7 @@ export type AlertManagerCortexConfig = {
   alertmanager_config: AlertmanagerConfig;
   /** { [name]: provenance } */
   template_file_provenances?: Record<string, string>;
+  successfully_applied_at?: string;
 };
 
 export type TLSConfig = {

--- a/public/app/plugins/datasource/alertmanager/types.ts
+++ b/public/app/plugins/datasource/alertmanager/types.ts
@@ -150,6 +150,7 @@ export type AlertmanagerConfig = {
   mute_time_intervals?: MuteTimeInterval[];
   /** { [name]: provenance } */
   muteTimeProvenances?: Record<string, string>;
+  successfully_applied?: boolean;
 };
 
 export type Matcher = {

--- a/public/app/plugins/datasource/alertmanager/types.ts
+++ b/public/app/plugins/datasource/alertmanager/types.ts
@@ -7,7 +7,7 @@ export type AlertManagerCortexConfig = {
   alertmanager_config: AlertmanagerConfig;
   /** { [name]: provenance } */
   template_file_provenances?: Record<string, string>;
-  successfully_applied_at?: string;
+  last_applied?: string;
 };
 
 export type TLSConfig = {
@@ -151,7 +151,7 @@ export type AlertmanagerConfig = {
   mute_time_intervals?: MuteTimeInterval[];
   /** { [name]: provenance } */
   muteTimeProvenances?: Record<string, string>;
-  successfully_applied?: boolean;
+  last_applied?: boolean;
 };
 
 export type Matcher = {


### PR DESCRIPTION
**What is this feature?**

This PR is based on the backend work from https://github.com/grafana/grafana/pull/63233 and displays a dropdown with valid AM configurations when the current configuration is invalid so that the user can then choose one from the list to start their Alertmanager.

**Why do we need this feature?**

Currently if the Alertmanager fails to start, an error message is displayed and the user is basically locked out of Grafana Alerting. A lot of safeguards were added in order to avoid having bad configs saved in the database, but it's impossible to take into account each and every edge case, so this feature works as a sort of "escape hatch".

**How will this work?**

When there's an invalid configuration, the user is shown an error message and prompted to choose from a list of old, valid configurations 

![image](https://user-images.githubusercontent.com/6271380/228063607-71f2c479-035d-4cc0-868e-cc449ef7dc84.png)


Fixes https://github.com/grafana/grafana/issues/54505


NOTE: All commits here have been cherry-picked from https://github.com/grafana/grafana/pull/59516 which was already approved. The referenced PR was closed in favor of this one because I needed to rebase to `fetch_applied_alert_configs_history` due to backend changes and trying to do so from the original PR would give me backend-code conflicts so this was the simplest solution.
