### PR TITLE
Alerting: Add alert instance labels to Loki log lines in addition to stream labels

### DIFF
--- a/pkg/services/ngalert/state/historian/loki.go
+++ b/pkg/services/ngalert/state/historian/loki.go
@@ -262,12 +262,13 @@ func statesToStreams(rule history_model.RuleMeta, states []state.StateTransition
 		repr := string(lblJsn)
 
 		entry := lokiEntry{
-			SchemaVersion: 1,
-			Previous:      state.PreviousFormatted(),
-			Current:       state.Formatted(),
-			Values:        valuesAsDataBlob(state.State),
-			DashboardUID:  rule.DashboardUID,
-			PanelID:       rule.PanelID,
+			SchemaVersion:  1,
+			Previous:       state.PreviousFormatted(),
+			Current:        state.Formatted(),
+			Values:         valuesAsDataBlob(state.State),
+			DashboardUID:   rule.DashboardUID,
+			PanelID:        rule.PanelID,
+			InstanceLabels: state.Labels,
 		}
 		if state.State.State == eval.Error {
 			entry.Error = state.Error.Error()
@@ -319,6 +320,9 @@ type lokiEntry struct {
 	Values        *simplejson.Json `json:"values"`
 	DashboardUID  string           `json:"dashboardUID"`
 	PanelID       int64            `json:"panelID"`
+	// InstanceLabels is exactly the set of labels associated with the alert instance in Alertmanager.
+	// These should not be conflated with labels associated with log streams.
+	InstanceLabels map[string]string `json:"labels"`
 }
 
 func valuesAsDataBlob(state *state.State) *simplejson.Json {


### PR DESCRIPTION
**What is this feature?**

Right now, we merge instance labels with a few pre-defined stream labels like `ruleUID` and `from="state-history"`.

A consequence of this, is that it becomes impossible to calculate the exact set of labels attached to the corresponding alert instance. For example, the user might have created labels with keys called `from`, which collides with the stream labels. Then, it's impossible to disambiguate stream labels from what the underlying instance labels were, so it's hard to track the entry back to the original instance.

This PR puts the instance labels, on their own, into the log lines too, under a block called `labels`. You can query it like 
```
{arbitrary="labels"} | json | labels.myLabelKey="myLabelValue"
```

**Why do we need this feature?**

The data that Loki indexes should be separate from the semantics of what actually gets recorded. Helps with querying. This also allows the UI to link an ASH entry back to an instance, which could be useful in the future.

**Who is this feature for?**

More clear queries of state history rows.

**Which issue(s) does this PR fix?**:

n/a

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
- [x] There are no known compatibility issues with older supported versions of Grafana, or plugins.
- [x] It passes the [Hosted Grafana feature readiness review](https://docs.google.com/document/d/1QL9Ly8KnXzpb6ISbg49pTODRO5mhA5tkkfIZVX6pqQU/edit) for observability, scalability, performance, and security.