### PR TITLE
cloud monitor is returning floats and we are trying to parse as strings

### DIFF
--- a/pkg/tsdb/cloudmonitoring/cloudmonitoring.go
+++ b/pkg/tsdb/cloudmonitoring/cloudmonitoring.go
@@ -548,7 +548,7 @@ func calcBucketBound(bucketOptions cloudMonitoringBucketOptions, n int) string {
 
 	switch {
 	case bucketOptions.LinearBuckets != nil:
-		bucketBound = strconv.FormatInt(bucketOptions.LinearBuckets.Offset+(bucketOptions.LinearBuckets.Width*int64(n-1)), 10)
+		bucketBound = strconv.FormatFloat(bucketOptions.LinearBuckets.Offset+(bucketOptions.LinearBuckets.Width*float64(n-1)), 'f', 2, 64)
 	case bucketOptions.ExponentialBuckets != nil:
 		bucketBound = strconv.FormatInt(int64(bucketOptions.ExponentialBuckets.Scale*math.Pow(bucketOptions.ExponentialBuckets.GrowthFactor, float64(n-1))), 10)
 	case bucketOptions.ExplicitBuckets != nil:

--- a/pkg/tsdb/cloudmonitoring/types.go
+++ b/pkg/tsdb/cloudmonitoring/types.go
@@ -107,9 +107,9 @@ type (
 
 	cloudMonitoringBucketOptions struct {
 		LinearBuckets *struct {
-			NumFiniteBuckets int64 `json:"numFiniteBuckets"`
-			Width            int64 `json:"width"`
-			Offset           int64 `json:"offset"`
+			NumFiniteBuckets int64   `json:"numFiniteBuckets"`
+			Width            float64 `json:"width"`
+			Offset           float64 `json:"offset"`
 		} `json:"linearBuckets"`
 		ExponentialBuckets *struct {
 			NumFiniteBuckets int64   `json:"numFiniteBuckets"`


### PR DESCRIPTION
selecting Run and Container Memory Utilization returns a failed to unmarshal error. It is trying to marshal a float to an int64.

This relates to https://github.com/grafana/support-escalations/issues/5228

