### PR TITLE
Templating: Optionally save interpolated expressions when replacing variables in a string

### DIFF
--- a/packages/grafana-runtime/src/services/templateSrv.ts
+++ b/packages/grafana-runtime/src/services/templateSrv.ts
@@ -33,6 +33,12 @@ export interface TemplateSrv {
 
   /**
    * Replace the values within the target string.  See also {@link InterpolateFunction}
+   *
+   * Note: interpolations map is being mutated by replace function by adding information about variables that
+   * have been interpolated during replacement. Variables that were specified in the target but not found in
+   * the list of available variables are also added to the map. See {@link VariableInterpolation} for more details.
+   *
+   * @param {VariableInterpolation[]} interpolations an optional map that is updated with interpolated variables
    */
   replace(
     target?: string,

--- a/packages/grafana-runtime/src/services/templateSrv.ts
+++ b/packages/grafana-runtime/src/services/templateSrv.ts
@@ -34,9 +34,9 @@ export interface TemplateSrv {
   /**
    * Replace the values within the target string.  See also {@link InterpolateFunction}
    *
-   * Note: interpolations map is being mutated by replace function by adding information about variables that
+   * Note: interpolations array is being mutated by replace function by adding information about variables that
    * have been interpolated during replacement. Variables that were specified in the target but not found in
-   * the list of available variables are also added to the map. See {@link VariableInterpolation} for more details.
+   * the list of available variables are also added to the array. See {@link VariableInterpolation} for more details.
    *
    * @param {VariableInterpolation[]} interpolations an optional map that is updated with interpolated variables
    */

--- a/packages/grafana-runtime/src/services/templateSrv.ts
+++ b/packages/grafana-runtime/src/services/templateSrv.ts
@@ -1,9 +1,22 @@
 import { ScopedVars, TimeRange, TypedVariableModel } from '@grafana/data';
 
 /**
- * Represents interpolated expressions
+ * Can be used to gain more information about an interpolation operation
  */
-export type InterpolationsMap = Map<string, string | null>;
+export interface VariableInterpolation {
+  /** The full matched expression including, example: ${varName.field:regex} */
+  match: string;
+  /** In the expression ${varName.field:regex} variableName is varName */
+  variableName: string;
+  /** In the expression ${varName.fields[0].name:regex} the fieldPath is fields[0].name */
+  fieldPath?: string;
+  /** In the expression ${varName:regex} the regex part is the format */
+  format?: string;
+  /** The formatted value of the variable expresion. Will equal match when variable not found or scopedVar was undefined or null **/
+  value: string;
+  // When value === match this will be true, meaning the variable was not found
+  found?: boolean;
+}
 
 /**
  * Via the TemplateSrv consumers get access to all the available template variables
@@ -25,7 +38,7 @@ export interface TemplateSrv {
     target?: string,
     scopedVars?: ScopedVars,
     format?: string | Function,
-    interpolations?: InterpolationsMap
+    interpolations?: VariableInterpolation[]
   ): string;
 
   /**

--- a/packages/grafana-runtime/src/services/templateSrv.ts
+++ b/packages/grafana-runtime/src/services/templateSrv.ts
@@ -1,6 +1,11 @@
 import { ScopedVars, TimeRange, TypedVariableModel } from '@grafana/data';
 
 /**
+ * Represents interpolated expressions
+ */
+export type InterpolationsMap = Map<string, string | null>;
+
+/**
  * Via the TemplateSrv consumers get access to all the available template variables
  * that can be used within the current active dashboard.
  *
@@ -16,7 +21,12 @@ export interface TemplateSrv {
   /**
    * Replace the values within the target string.  See also {@link InterpolateFunction}
    */
-  replace(target?: string, scopedVars?: ScopedVars, format?: string | Function): string;
+  replace(
+    target?: string,
+    scopedVars?: ScopedVars,
+    format?: string | Function,
+    interpolations?: InterpolationsMap
+  ): string;
 
   /**
    * Checks if a target contains template variables.

--- a/public/app/features/templating/template_srv.ts
+++ b/public/app/features/templating/template_srv.ts
@@ -316,6 +316,7 @@ export class TemplateSrv implements BaseTemplateSrv {
         const expr = `${variableName}${fieldPath ? `.${fieldPath}` : ''}`;
         const result = this.evaluateVariableExpression(match, variableName, fieldPath, fmt, scopedVars);
         interpolations.set(expr, result === match ? null : result);
+        return result;
       });
     }
 

--- a/public/app/features/templating/template_srv.ts
+++ b/public/app/features/templating/template_srv.ts
@@ -8,7 +8,7 @@ import {
   AdHocVariableModel,
   TypedVariableModel,
 } from '@grafana/data';
-import { getDataSourceSrv, setTemplateSrv, TemplateSrv as BaseTemplateSrv } from '@grafana/runtime';
+import { getDataSourceSrv, setTemplateSrv, TemplateSrv as BaseTemplateSrv, InterpolationsMap } from '@grafana/runtime';
 import { sceneGraph, FormatRegistryID, formatRegistry, VariableCustomFormatterFn } from '@grafana/scenes';
 
 import { variableAdapters } from '../variables/adapters';
@@ -22,11 +22,6 @@ import { getVariableWrapper } from './LegacyVariableWrapper';
 interface FieldAccessorCache {
   [key: string]: (obj: any) => any;
 }
-
-/**
- * Represents interpolated expressions
- */
-export type InterpolationsMap = Map<string, string | null>;
 
 /**
  * Internal regex replace function
@@ -55,9 +50,6 @@ export class TemplateSrv implements BaseTemplateSrv {
 
   constructor(private dependencies: TemplateSrvDependencies = runtimeDependencies) {
     this._variables = [];
-  }
-  getAllVariablesInTarget(target: string, scopedVars: ScopedVars, format?: string | Function | undefined): VariableMap {
-    throw new Error('Method not implemented.');
   }
 
   init(variables: any, timeRange?: TimeRange) {

--- a/public/app/features/templating/template_srv.ts
+++ b/public/app/features/templating/template_srv.ts
@@ -24,6 +24,16 @@ interface FieldAccessorCache {
   [key: string]: (obj: any) => any;
 }
 
+/**
+ * Represents interpolated expressions
+ */
+export type InterpolationsMap = Map<string, string | null>;
+
+/**
+ * Internal regex replace function
+ */
+type ReplaceFunction = (fullMatch: string, variableName: string, fieldPath: string, format: string) => string;
+
 export interface TemplateSrvDependencies {
   getFilteredVariables: typeof getFilteredVariables;
   getVariables: typeof getVariables;
@@ -46,6 +56,9 @@ export class TemplateSrv implements BaseTemplateSrv {
 
   constructor(private dependencies: TemplateSrvDependencies = runtimeDependencies) {
     this._variables = [];
+  }
+  getAllVariablesInTarget(target: string, scopedVars: ScopedVars, format?: string | Function | undefined): VariableMap {
+    throw new Error('Method not implemented.');
   }
 
   init(variables: any, timeRange?: TimeRange) {
@@ -276,7 +289,12 @@ export class TemplateSrv implements BaseTemplateSrv {
     return value;
   }
 
-  replace(target?: string, scopedVars?: ScopedVars, format?: string | Function): string {
+  replace(
+    target?: string,
+    scopedVars?: ScopedVars,
+    format?: string | Function,
+    interpolations?: InterpolationsMap
+  ): string {
     if (scopedVars && scopedVars.__sceneObject) {
       return sceneGraph.interpolate(
         scopedVars.__sceneObject.value,
@@ -292,88 +310,81 @@ export class TemplateSrv implements BaseTemplateSrv {
 
     this.regex.lastIndex = 0;
 
-    return target.replace(this.regex, (match, var1, var2, fmt2, var3, fieldPath, fmt3) => {
-      const variableName = var1 || var2 || var3;
-      const variable = this.getVariableAtIndex(variableName);
-      let fmt = fmt2 || fmt3 || format;
+    // If we get passed this interpolations map we will also record all the expressions that were replaced
+    if (interpolations) {
+      return this._replaceInVariableRegex(target, format, (match, variableName, fieldPath, fmt) => {
+        const expr = `${variableName}${fieldPath ? `.${fieldPath}` : ''}`;
+        const result = this.evaluateVariableExpression(match, variableName, fieldPath, fmt, scopedVars);
+        interpolations.set(expr, result === match ? null : result);
+      });
+    }
 
-      if (scopedVars) {
-        const value = this.getVariableValue(variableName, fieldPath, scopedVars);
-        const text = this.getVariableText(variableName, value, scopedVars);
-
-        if (value !== null && value !== undefined) {
-          if (scopedVars[variableName].skipFormat) {
-            fmt = undefined;
-          }
-
-          return this.formatValue(value, fmt, variable, text);
-        }
-      }
-
-      if (!variable) {
-        return match;
-      }
-
-      if (fmt === FormatRegistryID.queryParam || isAdHoc(variable)) {
-        const value = variableAdapters.get(variable.type).getValueForUrl(variable);
-        const text = isAdHoc(variable) ? variable.id : variable.current.text;
-
-        return this.formatValue(value, fmt, variable, text);
-      }
-
-      const systemValue = this.grafanaVariables.get(variable.current.value);
-      if (systemValue) {
-        return this.formatValue(systemValue, fmt, variable);
-      }
-
-      let value = variable.current.value;
-      let text = variable.current.text;
-
-      if (this.isAllValue(value)) {
-        value = this.getAllValue(variable);
-        text = ALL_VARIABLE_TEXT;
-        // skip formatting of custom all values unless format set to text or percentencode
-        if (variable.allValue && fmt !== FormatRegistryID.text && fmt !== FormatRegistryID.percentEncode) {
-          return this.replace(value);
-        }
-      }
-
-      if (fieldPath) {
-        const fieldValue = this.getVariableValue(variableName, fieldPath, {
-          [variableName]: { value, text },
-        });
-        if (fieldValue !== null && fieldValue !== undefined) {
-          return this.formatValue(fieldValue, fmt, variable, text);
-        }
-      }
-
-      const res = this.formatValue(value, fmt, variable, text);
-      return res;
+    return this._replaceInVariableRegex(target, format, (match, variableName, fieldPath, fmt) => {
+      return this.evaluateVariableExpression(match, variableName, fieldPath, fmt, scopedVars);
     });
   }
 
-  getAllVariablesInTarget(target: string, scopedVars: ScopedVars, format?: string | Function): VariableMap {
-    const values: VariableMap = {};
+  private evaluateVariableExpression(
+    match: string,
+    variableName: string,
+    fieldPath: string,
+    format: string | Function | undefined,
+    scopedVars: ScopedVars | undefined
+  ) {
+    const variable = this.getVariableAtIndex(variableName);
 
-    this.replaceInVariableRegex(target, (match, var1, var2, fmt2, var3, fieldPath, fmt3) => {
-      const variableName = var1 || var2 || var3;
-      const variableDisplayName =
-        var1 || var2 || (var3 !== undefined && fieldPath !== undefined) ? `${var3}.${fieldPath}` : var3;
-      const fmt = fmt2 || fmt3 || format;
+    if (scopedVars) {
       const value = this.getVariableValue(variableName, fieldPath, scopedVars);
+      const text = this.getVariableText(variableName, value, scopedVars);
+
       if (value !== null && value !== undefined) {
-        const variable = this.getVariableAtIndex(variableName);
-        const text = this.getVariableText(variableName, value, scopedVars);
-        values[variableDisplayName] = this.formatValue(value, fmt, variable, text);
-      } else {
-        values[variableDisplayName] = undefined;
+        if (scopedVars[variableName]?.skipFormat) {
+          format = undefined;
+        }
+
+        return this.formatValue(value, format, variable, text);
       }
+    }
 
-      // Don't care about the result anyway
-      return '';
-    });
+    if (!variable) {
+      return match;
+    }
 
-    return values;
+    if (format === FormatRegistryID.queryParam || isAdHoc(variable)) {
+      const value = variableAdapters.get(variable.type).getValueForUrl(variable);
+      const text = isAdHoc(variable) ? variable.id : variable.current.text;
+
+      return this.formatValue(value, format, variable, text);
+    }
+
+    const systemValue = this.grafanaVariables.get(variable.current.value);
+    if (systemValue) {
+      return this.formatValue(systemValue, format, variable);
+    }
+
+    let value = variable.current.value;
+    let text = variable.current.text;
+
+    if (this.isAllValue(value)) {
+      value = this.getAllValue(variable);
+      text = ALL_VARIABLE_TEXT;
+      // skip formatting of custom all values unless format set to text or percentencode
+      if (variable.allValue && format !== FormatRegistryID.text && format !== FormatRegistryID.percentEncode) {
+        return this.replace(value);
+      }
+    }
+
+    if (fieldPath) {
+      const fieldValue = this.getVariableValue(variableName, fieldPath, {
+        [variableName]: { value, text },
+      });
+      if (fieldValue !== null && fieldValue !== undefined) {
+        return this.formatValue(fieldValue, format, variable, text);
+      }
+    }
+
+    const res = this.formatValue(value, format, variable, text);
+    return res;
   }
 
   /**
@@ -382,19 +393,13 @@ export class TemplateSrv implements BaseTemplateSrv {
    *
    * See the definition of this.regex for further comments on the variable definitions.
    */
-  private replaceInVariableRegex(
-    text: string,
-    replace: (
-      fullMatch: string, //     $simpleVarName   [[squareVarName:squareFormat]]   ${curlyVarName.curlyPath:curlyFormat}
-      simpleVarName: string, // simpleVarName                  -                                     -
-      squareVarName: string, //        -                squareVarName                                -
-      squareFormat: string, //         -                squareFormat                                 -
-      curlyVarName: string, //         -                      -                                curlyVarName
-      curlyPath: string, //            -                      -                                  curlyPath
-      curlyFormat: string //           -                      -                                 curlyFormat
-    ) => string
-  ) {
-    return text.replace(this.regex, replace);
+  private _replaceInVariableRegex(text: string, format: string | Function | undefined, replace: ReplaceFunction) {
+    this.regex.lastIndex = 0;
+    return text.replace(this.regex, (match, var1, var2, fmt2, var3, fieldPath, fmt3) => {
+      const variableName = var1 || var2 || var3;
+      const fmt = fmt2 || fmt3 || format;
+      return replace(match, variableName, fieldPath, fmt);
+    });
   }
 
   isAllValue(value: any) {


### PR DESCRIPTION
*Background*

#62926 introduced a new method `getAllVariablesInTarget` that was not working with dashboard variables. The change was reverted in #65315. We've discussed possible options to support getting interpolation results of `replace()` method required by #61782. This PR shows a suggested solution.

*Implementation*

`replace()` method takes an optional argument that will save the results of interpolation to a map.