### PR TITLE
DateTimePicker: Can now select time correctly

### DIFF
--- a/packages/grafana-ui/src/components/DateTimePickers/DateTimePicker/DateTimePicker.test.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/DateTimePicker/DateTimePicker.test.tsx
@@ -43,17 +43,23 @@ describe('Date time picker', () => {
   it('should be able to select values in TimeOfDayPicker without blurring the element', async () => {
     renderDatetimePicker();
 
+    // open the calendar + time picker
     await userEvent.click(screen.getByLabelText('Time picker'));
+
+    // open the time of day overlay
     await userEvent.click(screen.getAllByRole('textbox')[1]);
 
+    // check the hour element is visible
     const hourElement = screen.getAllByRole('button', {
       name: '00',
     })[0];
     expect(hourElement).toBeVisible();
 
+    // select the hour value and check it's still visible
     await userEvent.click(hourElement);
     expect(hourElement).toBeVisible();
 
+    // click outside the overlay and check the hour element is no longer visible
     await userEvent.click(document.body);
     expect(
       screen.queryByRole('button', {

--- a/packages/grafana-ui/src/components/DateTimePickers/DateTimePicker/DateTimePicker.test.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/DateTimePicker/DateTimePicker.test.tsx
@@ -42,22 +42,19 @@ describe('Date time picker', () => {
 
   it('should be able to select values in TimeOfDayPicker without blurring the element', async () => {
     renderDatetimePicker();
-    await userEvent.click(screen.getByLabelText('Time picker'));
 
+    await userEvent.click(screen.getByLabelText('Time picker'));
     await userEvent.click(screen.getAllByRole('textbox')[1]);
 
     const hourElement = screen.getAllByRole('button', {
       name: '00',
     })[0];
-
     expect(hourElement).toBeVisible();
 
     await userEvent.click(hourElement);
-
     expect(hourElement).toBeVisible();
 
     await userEvent.click(document.body);
-
     expect(
       screen.queryByRole('button', {
         name: '00',

--- a/packages/grafana-ui/src/components/DateTimePickers/DateTimePicker/DateTimePicker.test.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/DateTimePicker/DateTimePicker.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import { dateTime } from '@grafana/data';
@@ -37,5 +38,30 @@ describe('Date time picker', () => {
     fireEvent.blur(dateTimeInput);
 
     expect(dateTimeInput).toHaveDisplayValue('2021-07-31 12:30:30');
+  });
+
+  it('should be able to select values in TimeOfDayPicker without blurring the element', async () => {
+    renderDatetimePicker();
+    await userEvent.click(screen.getByLabelText('Time picker'));
+
+    await userEvent.click(screen.getAllByRole('textbox')[1]);
+
+    const hourElement = screen.getAllByRole('button', {
+      name: '00',
+    })[0];
+
+    expect(hourElement).toBeVisible();
+
+    await userEvent.click(hourElement);
+
+    expect(hourElement).toBeVisible();
+
+    await userEvent.click(document.body);
+
+    expect(
+      screen.queryByRole('button', {
+        name: '00',
+      })
+    ).not.toBeInTheDocument();
   });
 });

--- a/packages/grafana-ui/src/components/DateTimePickers/DateTimePicker/DateTimePicker.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/DateTimePicker/DateTimePicker.tsx
@@ -12,7 +12,7 @@ import { dateTimeFormat, DateTime, dateTime, GrafanaTheme2, isDateTime } from '@
 import { Button, HorizontalGroup, Icon, InlineField, Input, Portal } from '../..';
 import { useStyles2, useTheme2 } from '../../../themes';
 import { getModalStyles } from '../../Modal/getModalStyles';
-import { TimeOfDayPicker } from '../TimeOfDayPicker';
+import { TimeOfDayPicker, POPUP_CLASS_NAME } from '../TimeOfDayPicker';
 import { getBodyStyles } from '../TimeRangePicker/CalendarBody';
 import { isValid } from '../utils';
 
@@ -32,7 +32,15 @@ export const DateTimePicker = ({ date, maxDate, label, onChange }: Props) => {
 
   const ref = useRef<HTMLDivElement>(null);
   const { overlayProps, underlayProps } = useOverlay(
-    { onClose: () => setOpen(false), isDismissable: true, isOpen },
+    {
+      onClose: () => setOpen(false),
+      isDismissable: true,
+      isOpen,
+      shouldCloseOnInteractOutside: (element) => {
+        const popupElement = document.getElementsByClassName(POPUP_CLASS_NAME)[0];
+        return !(popupElement && popupElement.contains(element));
+      },
+    },
     ref
   );
   const { dialogProps } = useDialog({}, ref);

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeOfDayPicker.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeOfDayPicker.tsx
@@ -19,6 +19,8 @@ export interface Props {
   disabled?: boolean;
 }
 
+export const POPUP_CLASS_NAME = 'time-of-day-picker-panel';
+
 export const TimeOfDayPicker = ({
   minuteStep = 1,
   showHour = true,
@@ -33,7 +35,7 @@ export const TimeOfDayPicker = ({
   return (
     <RcTimePicker
       className={cx(inputSizes()[size], styles.input)}
-      popupClassName={styles.picker}
+      popupClassName={cx(styles.picker, POPUP_CLASS_NAME)}
       defaultValue={dateTimeAsMoment()}
       onChange={(value: any) => onChange(dateTime(value))}
       allowEmpty={false}


### PR DESCRIPTION

**What is this feature?**
It allows the user to select time in the `DateTimePicker`.

**Why do we need this feature?**
To be able to select a value on `TimeOfDayPicker` and keep it.

**Who is this feature for?**
Everyone

**Which issue(s) does this PR fix?**:
Fixes #65262

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
- [ ] There are no known compatibility issues with older supported versions of Grafana, or plugins.
- [ ] It passes the [Hosted Grafana feature readiness review](https://docs.google.com/document/d/1QL9Ly8KnXzpb6ISbg49pTODRO5mhA5tkkfIZVX6pqQU/edit) for observability, scalability, performance, and security.