### PR TITLE
Team sync: Fix apply query string instead of param

### DIFF
--- a/public/app/features/teams/state/actions.ts
+++ b/public/app/features/teams/state/actions.ts
@@ -118,7 +118,8 @@ export function addTeamGroup(groupId: string): ThunkResult<void> {
 export function removeTeamGroup(groupId: string): ThunkResult<void> {
   return async (dispatch, getStore) => {
     const team = getStore().team.team;
-    await getBackendSrv().delete(`/api/teams/${team.id}/groups/${encodeURIComponent(groupId)}`);
+    // need to use query parameter due to escaped characters in the request, see issue: https://github.com/grafana/grafana-enterprise/issues/4840
+    await getBackendSrv().delete(`/api/teams/${team.id}/groups?groupId=${encodeURIComponent(groupId)}`);
     dispatch(loadTeamGroups());
   };
 }

--- a/public/app/features/teams/state/actions.ts
+++ b/public/app/features/teams/state/actions.ts
@@ -118,7 +118,7 @@ export function addTeamGroup(groupId: string): ThunkResult<void> {
 export function removeTeamGroup(groupId: string): ThunkResult<void> {
   return async (dispatch, getStore) => {
     const team = getStore().team.team;
-    // need to use query parameter due to escaped characters in the request, see issue: https://github.com/grafana/grafana-enterprise/issues/4840
+    // need to use query parameter due to escaped characters in the request
     await getBackendSrv().delete(`/api/teams/${team.id}/groups?groupId=${encodeURIComponent(groupId)}`);
     dispatch(loadTeamGroups());
   };


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
This applies a query string for the request to delete a team group from a team.

- sends a query string instead of a parameters string to the backend for a fix on HG for redirects happening from envoy that unescapes strings.

Fixes #
https://github.com/grafana/grafana-enterprise/issues/4840

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] tested in ops.grafana.net