### PR TITLE
Logs Volume Timeouts: Add a custom message with options (retry, close) for request timeouts

### DIFF
--- a/public/app/features/explore/Logs.tsx
+++ b/public/app/features/explore/Logs.tsx
@@ -392,6 +392,7 @@ class UnthemedLogs extends PureComponent<Props, State> {
               onLoadLogsVolume={loadLogsVolumeData}
               onHiddenSeriesChanged={this.onToggleLogLevel}
               eventBus={this.logsVolumeEventBus}
+              onClose={() => this.onToggleLogsVolumeCollapse(false)}
             />
           )}
         </Collapse>

--- a/public/app/features/explore/LogsVolumePanelList.test.tsx
+++ b/public/app/features/explore/LogsVolumePanelList.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import { DataQueryResponse, LoadingState, EventBusSrv } from '@grafana/data';
@@ -12,7 +13,7 @@ jest.mock('./Graph/ExploreGraph', () => {
   };
 });
 
-function renderPanel(logsVolumeData?: DataQueryResponse) {
+function renderPanel(logsVolumeData?: DataQueryResponse, onLoadLogsVolume = () => {}) {
   render(
     <LogsVolumePanelList
       absoluteRange={{ from: 0, to: 1 }}
@@ -21,7 +22,7 @@ function renderPanel(logsVolumeData?: DataQueryResponse) {
       width={100}
       onUpdateTimeRange={() => {}}
       logsVolumeData={logsVolumeData}
-      onLoadLogsVolume={() => {}}
+      onLoadLogsVolume={onLoadLogsVolume}
       onHiddenSeriesChanged={() => null}
       eventBus={new EventBusSrv()}
     />
@@ -40,7 +41,7 @@ describe('LogsVolumePanelList', () => {
     expect(screen.getByText('Test error message')).toBeInTheDocument();
   });
 
-  it('shows long warning message', () => {
+  it('shows long warning message', async () => {
     // we make a long message
     const messagePart = 'One two three four five six seven eight nine ten.';
     const message = messagePart + ' ' + messagePart + ' ' + messagePart;
@@ -48,7 +49,22 @@ describe('LogsVolumePanelList', () => {
     renderPanel({ state: LoadingState.Error, error: { data: { message } }, data: [] });
     expect(screen.getByText('Failed to load log volume for this query')).toBeInTheDocument();
     expect(screen.queryByText(message)).not.toBeInTheDocument();
-    fireEvent.click(screen.getByRole('button', { name: 'Show details' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Show details' }));
     expect(screen.getByText(message)).toBeInTheDocument();
+  });
+
+  it('a custom message for timeout errors', async () => {
+    const onLoadCallback = jest.fn();
+    renderPanel(
+      {
+        state: LoadingState.Error,
+        error: { data: { message: '{"status":"error","errorType":"timeout","error":"context deadline exceeded"}' } },
+        data: [],
+      },
+      onLoadCallback
+    );
+    expect(screen.getByText('The logs volume query is taking too long and has timed out')).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    expect(onLoadCallback).toHaveBeenCalled();
   });
 });

--- a/public/app/features/explore/LogsVolumePanelList.tsx
+++ b/public/app/features/explore/LogsVolumePanelList.tsx
@@ -66,6 +66,7 @@ export const LogsVolumePanelList = ({
     return (
       <SupplementaryResultError
         title="The logs volume query is taking too long and has timed out"
+        // Using info to avoid users thinking that the actual query has failed.
         severity="info"
         suggestedAction="Retry"
         onSuggestedAction={onLoadLogsVolume}

--- a/public/app/features/explore/LogsVolumePanelList.tsx
+++ b/public/app/features/explore/LogsVolumePanelList.tsx
@@ -66,6 +66,7 @@ export const LogsVolumePanelList = ({
     return (
       <SupplementaryResultError
         title="The logs volume query is taking too long and has timed out"
+        severity="info"
         suggestedAction="Retry"
         onSuggestedAction={onLoadLogsVolume}
         onRemove={onClose}

--- a/public/app/features/explore/LogsVolumePanelList.tsx
+++ b/public/app/features/explore/LogsVolumePanelList.tsx
@@ -17,6 +17,7 @@ import { Button, InlineField, useStyles2 } from '@grafana/ui';
 
 import { LogsVolumePanel } from './LogsVolumePanel';
 import { SupplementaryResultError } from './SupplementaryResultError';
+import { isTimeoutErrorResponse } from './utils/logsVolumeResponse';
 
 type Props = {
   logsVolumeData: DataQueryResponse | undefined;
@@ -57,10 +58,7 @@ export const LogsVolumePanelList = ({
     return !isLogsVolumeLimited(data) && zoomRatio && zoomRatio < 1;
   });
 
-  const timeoutError = logsVolumeData?.error?.message?.includes('timeout');
-  const retry = () => {
-    onLoadLogsVolume();
-  };
+  const timeoutError = isTimeoutErrorResponse(logsVolumeData);
 
   if (logsVolumeData?.state === LoadingState.Loading) {
     return <span>Loading...</span>;
@@ -68,8 +66,8 @@ export const LogsVolumePanelList = ({
     return (
       <SupplementaryResultError
         title="The logs volume query is taking too long and has timed out"
-        suggestion="Retry"
-        onSuggestion={retry}
+        suggestedAction="Retry"
+        onSuggestedAction={onLoadLogsVolume}
         onRemove={onClose}
       />
     );

--- a/public/app/features/explore/LogsVolumePanelList.tsx
+++ b/public/app/features/explore/LogsVolumePanelList.tsx
@@ -28,6 +28,7 @@ type Props = {
   onLoadLogsVolume: () => void;
   onHiddenSeriesChanged: (hiddenSeries: string[]) => void;
   eventBus: EventBus;
+  onClose?(): void;
 };
 
 export const LogsVolumePanelList = ({
@@ -40,6 +41,7 @@ export const LogsVolumePanelList = ({
   eventBus,
   splitOpen,
   timeZone,
+  onClose,
 }: Props) => {
   const logVolumes = useMemo(
     () => groupBy(logsVolumeData?.data || [], 'meta.custom.sourceQuery.refId'),
@@ -55,10 +57,23 @@ export const LogsVolumePanelList = ({
     return !isLogsVolumeLimited(data) && zoomRatio && zoomRatio < 1;
   });
 
+  const timeoutError = logsVolumeData?.error?.message?.includes('timeout');
+  const retry = () => {
+    onLoadLogsVolume();
+  };
+
   if (logsVolumeData?.state === LoadingState.Loading) {
     return <span>Loading...</span>;
-  }
-  if (logsVolumeData?.error !== undefined) {
+  } else if (timeoutError) {
+    return (
+      <SupplementaryResultError
+        title="The logs volume query is taking too long and has timed out"
+        suggestion="Retry"
+        onSuggestion={retry}
+        onRemove={onClose}
+      />
+    );
+  } else if (logsVolumeData?.error !== undefined) {
     return <SupplementaryResultError error={logsVolumeData.error} title="Failed to load log volume for this query" />;
   }
   return (

--- a/public/app/features/explore/SupplementaryResultError.tsx
+++ b/public/app/features/explore/SupplementaryResultError.tsx
@@ -22,7 +22,7 @@ export function SupplementaryResultError(props: Props) {
 
   return (
     <Alert title={title} severity={severity} onRemove={onRemove}>
-      {showButton && message ? (
+      {showButton ? (
         <Button
           variant="secondary"
           size="xs"

--- a/public/app/features/explore/SupplementaryResultError.tsx
+++ b/public/app/features/explore/SupplementaryResultError.tsx
@@ -36,13 +36,7 @@ export function SupplementaryResultError(props: Props) {
         message
       )}
       {suggestedAction && onSuggestedAction && (
-        <Button
-          variant="primary"
-          size="xs"
-          onClick={() => {
-            onSuggestedAction();
-          }}
-        >
+        <Button variant="primary" size="xs" onClick={onSuggestedAction}>
           {suggestedAction}
         </Button>
       )}

--- a/public/app/features/explore/SupplementaryResultError.tsx
+++ b/public/app/features/explore/SupplementaryResultError.tsx
@@ -1,11 +1,12 @@
 import React, { useState } from 'react';
 
 import { DataQueryError } from '@grafana/data';
-import { Alert, Button } from '@grafana/ui';
+import { Alert, AlertVariant, Button } from '@grafana/ui';
 
 type Props = {
   error?: DataQueryError;
   title: string;
+  severity?: AlertVariant;
   suggestedAction?: string;
   onSuggestedAction?(): void;
   onRemove?(): void;
@@ -13,14 +14,14 @@ type Props = {
 export function SupplementaryResultError(props: Props) {
   const [isOpen, setIsOpen] = useState(false);
   const SHORT_ERROR_MESSAGE_LIMIT = 100;
-  const { error, title, suggestedAction, onSuggestedAction, onRemove } = props;
+  const { error, title, suggestedAction, onSuggestedAction, onRemove, severity = 'warning' } = props;
   // generic get-error-message-logic, taken from
   // /public/app/features/explore/ErrorContainer.tsx
   const message = error?.message || error?.data?.message || '';
   const showButton = !isOpen && message.length > SHORT_ERROR_MESSAGE_LIMIT;
 
   return (
-    <Alert title={title} severity="warning" onRemove={onRemove}>
+    <Alert title={title} severity={severity} onRemove={onRemove}>
       {showButton && message ? (
         <Button
           variant="secondary"

--- a/public/app/features/explore/SupplementaryResultError.tsx
+++ b/public/app/features/explore/SupplementaryResultError.tsx
@@ -4,21 +4,24 @@ import { DataQueryError } from '@grafana/data';
 import { Alert, Button } from '@grafana/ui';
 
 type Props = {
-  error: DataQueryError;
+  error?: DataQueryError;
   title: string;
+  suggestion?: string;
+  onSuggestion?(): void;
+  onRemove?(): void;
 };
 export function SupplementaryResultError(props: Props) {
   const [isOpen, setIsOpen] = useState(false);
   const SHORT_ERROR_MESSAGE_LIMIT = 100;
-  const { error, title } = props;
+  const { error, title, suggestion, onSuggestion, onRemove } = props;
   // generic get-error-message-logic, taken from
   // /public/app/features/explore/ErrorContainer.tsx
-  const message = error.message || error.data?.message || '';
+  const message = error?.message || error?.data?.message || '';
   const showButton = !isOpen && message.length > SHORT_ERROR_MESSAGE_LIMIT;
 
   return (
-    <Alert title={title} severity="warning">
-      {showButton ? (
+    <Alert title={title} severity="warning" onRemove={onRemove}>
+      {showButton && message ? (
         <Button
           variant="secondary"
           size="xs"
@@ -30,6 +33,17 @@ export function SupplementaryResultError(props: Props) {
         </Button>
       ) : (
         message
+      )}
+      {suggestion && onSuggestion && (
+        <Button
+          variant="primary"
+          size="xs"
+          onClick={() => {
+            onSuggestion();
+          }}
+        >
+          {suggestion}
+        </Button>
       )}
     </Alert>
   );

--- a/public/app/features/explore/SupplementaryResultError.tsx
+++ b/public/app/features/explore/SupplementaryResultError.tsx
@@ -6,14 +6,14 @@ import { Alert, Button } from '@grafana/ui';
 type Props = {
   error?: DataQueryError;
   title: string;
-  suggestion?: string;
-  onSuggestion?(): void;
+  suggestedAction?: string;
+  onSuggestedAction?(): void;
   onRemove?(): void;
 };
 export function SupplementaryResultError(props: Props) {
   const [isOpen, setIsOpen] = useState(false);
   const SHORT_ERROR_MESSAGE_LIMIT = 100;
-  const { error, title, suggestion, onSuggestion, onRemove } = props;
+  const { error, title, suggestedAction, onSuggestedAction, onRemove } = props;
   // generic get-error-message-logic, taken from
   // /public/app/features/explore/ErrorContainer.tsx
   const message = error?.message || error?.data?.message || '';
@@ -34,15 +34,15 @@ export function SupplementaryResultError(props: Props) {
       ) : (
         message
       )}
-      {suggestion && onSuggestion && (
+      {suggestedAction && onSuggestedAction && (
         <Button
           variant="primary"
           size="xs"
           onClick={() => {
-            onSuggestion();
+            onSuggestedAction();
           }}
         >
-          {suggestion}
+          {suggestedAction}
         </Button>
       )}
     </Alert>

--- a/public/app/features/explore/utils/logsVolumeResponse.test.ts
+++ b/public/app/features/explore/utils/logsVolumeResponse.test.ts
@@ -1,0 +1,66 @@
+import { DataQueryResponse } from '@grafana/data';
+
+import { isTimeoutErrorResponse } from './logsVolumeResponse';
+
+const errorA =
+  'Get "http://localhost:3100/loki/api/v1/query_range?direction=backward&end=1680001200000000000&limit=1000&query=sum+by+%28level%29+%28count_over_time%28%7Bcontainer_name%3D%22docker-compose-app-1%22%7D%5B1h%5D%29%29&start=1679914800000000000&step=3600000ms": net/http: request canceled (Client.Timeout exceeded while awaiting headers)';
+const errorB = '{"status":"error","errorType":"timeout","error":"context deadline exceeded"}';
+
+describe('isTimeoutErrorResponse', () => {
+  test.each([errorA, errorB])(
+    'identifies timeout errors in the error.message attribute when the message is `%s`',
+    (timeoutError: string) => {
+      const response: DataQueryResponse = {
+        data: [],
+        error: {
+          message: timeoutError,
+        },
+      };
+      expect(isTimeoutErrorResponse(response)).toBe(true);
+    }
+  );
+  test.each([errorA, errorB])(
+    'identifies timeout errors in the errors.message attribute when the message is `%s`',
+    (timeoutError: string) => {
+      const response: DataQueryResponse = {
+        data: [],
+        errors: [
+          {
+            message: 'Something else',
+          },
+          {
+            message: timeoutError,
+          },
+        ],
+      };
+      expect(isTimeoutErrorResponse(response)).toBe(true);
+    }
+  );
+  test.each([errorA, errorB])(
+    'identifies timeout errors in the errors.data.message attribute when the message is `%s`',
+    (timeoutError: string) => {
+      const response: DataQueryResponse = {
+        data: [],
+        errors: [
+          {
+            data: {
+              message: 'Something else',
+            },
+          },
+          {
+            data: {
+              message: timeoutError,
+            },
+          },
+        ],
+      };
+      expect(isTimeoutErrorResponse(response)).toBe(true);
+    }
+  );
+  test('does not report false positives', () => {
+    const response: DataQueryResponse = {
+      data: [],
+    };
+    expect(isTimeoutErrorResponse(response)).toBe(false);
+  });
+});

--- a/public/app/features/explore/utils/logsVolumeResponse.ts
+++ b/public/app/features/explore/utils/logsVolumeResponse.ts
@@ -10,7 +10,7 @@ export function isTimeoutErrorResponse(response: DataQueryResponse | undefined):
     return false;
   }
 
-  const errors = response?.error ? [response?.error] : response?.errors || [];
+  const errors = response.error ? [response.error] : response.errors || [];
 
   return errors.reduce((isTimeoutError: boolean, error: DataQueryError) => {
     const message = `${error.message || error.data?.message}`?.toLowerCase();

--- a/public/app/features/explore/utils/logsVolumeResponse.ts
+++ b/public/app/features/explore/utils/logsVolumeResponse.ts
@@ -1,7 +1,6 @@
 import { DataQueryError, DataQueryResponse } from '@grafana/data';
 
 // Currently we can only infer if an error response is a timeout or not.
-// TODO: add backend support for specifying the type of error.
 export function isTimeoutErrorResponse(response: DataQueryResponse | undefined): boolean {
   if (!response) {
     return false;
@@ -12,8 +11,8 @@ export function isTimeoutErrorResponse(response: DataQueryResponse | undefined):
 
   const errors = response?.error ? [response?.error] : response?.errors || [];
 
-  return errors.reduce((isTimeoutError: boolean, error: DataQueryError) => {
+  return errors.some((error: DataQueryError) => {
     const message = `${error.message || error.data?.message}`?.toLowerCase();
-    return isTimeoutError || message.includes('timeout');
-  }, false);
+    return message.includes('timeout');
+  });
 }

--- a/public/app/features/explore/utils/logsVolumeResponse.ts
+++ b/public/app/features/explore/utils/logsVolumeResponse.ts
@@ -5,7 +5,7 @@ export function isTimeoutErrorResponse(response: DataQueryResponse | undefined):
   if (!response) {
     return false;
   }
-  if (!response?.error && !response?.errors) {
+  if (!response.error && !response.errors) {
     return false;
   }
 

--- a/public/app/features/explore/utils/logsVolumeResponse.ts
+++ b/public/app/features/explore/utils/logsVolumeResponse.ts
@@ -1,4 +1,4 @@
-import { DataQueryResponse } from '@grafana/data';
+import { DataQueryError, DataQueryResponse } from '@grafana/data';
 
 // Currently we can only infer if an error response is a timeout or not.
 // TODO: add backend support for specifying the type of error.
@@ -6,13 +6,13 @@ export function isTimeoutErrorResponse(response: DataQueryResponse | undefined):
   if (!response) {
     return false;
   }
-  if (!response?.error && response?.errors) {
+  if (!response?.error && !response?.errors) {
     return false;
   }
 
   const errors = response?.error ? [response?.error] : response?.errors || [];
 
-  return errors.reduce((isTimeoutError, error) => {
+  return errors.reduce((isTimeoutError: boolean, error: DataQueryError) => {
     const message = `${error.message || error.data?.message}`?.toLowerCase();
     return isTimeoutError || message.includes('timeout');
   }, false);

--- a/public/app/features/explore/utils/logsVolumeResponse.ts
+++ b/public/app/features/explore/utils/logsVolumeResponse.ts
@@ -1,0 +1,27 @@
+// Currently we can only infer if an error response is a timeout or not.
+// TODO: add backend support for specifying the type of error.
+import { DataQueryResponse } from '@grafana/data';
+
+const timeoutKeywords = ['timeout', 'exceeded'];
+
+export function isTimeoutErrorResponse(response: DataQueryResponse | undefined): boolean {
+  if (!response) {
+    return false;
+  }
+  if (!response?.error && response?.errors) {
+    return false;
+  }
+
+  const errors = response?.error ? [response?.error] : response?.errors || [];
+
+  return errors.reduce((isTimeoutError, error) => {
+    if (isTimeoutError) {
+      return true;
+    }
+    return timeoutKeywords.reduce(
+      (timeoutFound, keyword) =>
+        timeoutFound || Boolean(error.message?.includes(keyword) || error.data?.message?.includes(keyword)),
+      false
+    );
+  }, false);
+}

--- a/public/app/features/explore/utils/logsVolumeResponse.ts
+++ b/public/app/features/explore/utils/logsVolumeResponse.ts
@@ -1,9 +1,7 @@
-// Currently we can only infer if an error response is a timeout or not.
-// TODO: add backend support for specifying the type of error.
 import { DataQueryResponse } from '@grafana/data';
 
-const timeoutKeywords = ['timeout', 'exceeded'];
-
+// Currently we can only infer if an error response is a timeout or not.
+// TODO: add backend support for specifying the type of error.
 export function isTimeoutErrorResponse(response: DataQueryResponse | undefined): boolean {
   if (!response) {
     return false;
@@ -15,13 +13,7 @@ export function isTimeoutErrorResponse(response: DataQueryResponse | undefined):
   const errors = response?.error ? [response?.error] : response?.errors || [];
 
   return errors.reduce((isTimeoutError, error) => {
-    if (isTimeoutError) {
-      return true;
-    }
-    return timeoutKeywords.reduce(
-      (timeoutFound, keyword) =>
-        timeoutFound || Boolean(error.message?.includes(keyword) || error.data?.message?.includes(keyword)),
-      false
-    );
+    const message = `${error.message || error.data?.message}`?.toLowerCase();
+    return isTimeoutError || message.includes('timeout');
   }, false);
 }


### PR DESCRIPTION
We have received feedback pointing out that users find the currently displayed message confusing, so these changes are an attempt to improve how we communicate Logs volume timeouts to the user. 

E.g.

> Hi all,
> Part of my PoV on Grafana Cloud Logs, I have encountered the following  warning. Although the query has finished executing, the log display view is failing to show. Any insights on this ?
> Thanks!
> ![imagen](https://user-images.githubusercontent.com/1069378/228214811-0df25d73-9b82-48ec-8ea5-562d1544d043.png)

Now we would be displaying an updated message, with 2 options. 

![imagen](https://user-images.githubusercontent.com/1069378/228217126-acd295b7-ac1f-4370-99b6-dded13186b44.png)

Option 1: retry the request (which might timeout again, although I found that sometimes retrying would result in a faster executed query that doesn't timeout).

![2023-03-28 13 02 11](https://user-images.githubusercontent.com/1069378/228216214-e91863b7-985b-4466-b153-fa975221ef37.gif)

Option 2: dismiss and close.

![2023-03-28 13 03 31](https://user-images.githubusercontent.com/1069378/228216461-526b5ed8-81a8-4c3b-bd5d-b60762cf4241.gif)

It has been suggested to add support for retrying the request without timeout, or to offer [running the same request as a metric query](https://github.com/grafana/grafana/pull/65100#discussion_r1146399411), but that's an open discussion and outside the scope of this PR.

--

After some discussion, we decided to also update the type of the alert to "info" to prevent users to think that the actual query they are running has failed. This is based on several user questions about timeouts.

![imagen](https://user-images.githubusercontent.com/1069378/229068634-5acbb647-bba3-4a39-b7ed-1abb6aaeb246.png)

**Why do we need this feature?**

We currently show a generic error message with the raw response.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana/issues/64627

**Special notes for your reviewer:**

I have identified the two following formats of timeout errors, which are supported by these changes:

> Get "http://localhost:3100/loki/api/v1/query_range?direction=backward&end=1680001200000000000&limit=1000&query=sum+by+%28level%29+%28count_over_time%28%7Bcontainer_name%3D%22docker-compose-app-1%22%7D%5B1h%5D%29%29&start=1679914800000000000&step=3600000ms": net/http: request canceled (Client.Timeout exceeded while awaiting headers)

> {"status":"error","errorType":"timeout","error":"context deadline exceeded"}

While this is far from the ideal implementation, these changes take a small step forward towards doing a better job communicating timeouts to the user.