### PR TITLE
elasticsearch: removed code related to removed esVersion field

### DIFF
--- a/pkg/infra/usagestats/statscollector/service.go
+++ b/pkg/infra/usagestats/statscollector/service.go
@@ -2,7 +2,6 @@ package statscollector
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"time"
 
@@ -74,7 +73,6 @@ func ProvideService(
 		s.collectConcurrentUsers,
 		s.collectDatasourceStats,
 		s.collectDatasourceAccess,
-		s.collectElasticStats,
 		s.collectAlertNotifierStats,
 		s.collectPrometheusFlavors,
 		s.collectAdditionalMetrics,
@@ -237,28 +235,6 @@ func (s *Service) collectDatasourceStats(ctx context.Context) (map[string]interf
 	}
 	m["stats.ds.other.count"] = dsOtherCount
 
-	return m, nil
-}
-
-func (s *Service) collectElasticStats(ctx context.Context) (map[string]interface{}, error) {
-	m := map[string]interface{}{}
-	esDataSourcesQuery := datasources.GetDataSourcesByTypeQuery{Type: datasources.DS_ES}
-	dataSources, err := s.datasources.GetDataSourcesByType(ctx, &esDataSourcesQuery)
-	if err != nil {
-		s.log.Error("Failed to get elasticsearch json data", "error", err)
-		return nil, err
-	}
-	for _, data := range dataSources {
-		esVersion, err := data.JsonData.Get("esVersion").String()
-		if err != nil {
-			continue
-		}
-		statName := fmt.Sprintf("stats.ds.elasticsearch.v%s.count", strings.ReplaceAll(esVersion, ".", "_"))
-
-		count, _ := m[statName].(int64)
-
-		m[statName] = count + 1
-	}
 	return m, nil
 }
 

--- a/pkg/infra/usagestats/statscollector/service_test.go
+++ b/pkg/infra/usagestats/statscollector/service_test.go
@@ -128,19 +128,13 @@ func TestCollectingUsageStats(t *testing.T) {
 	statsService := statstest.NewFakeService()
 	expectedDataSources := []*datasources.DataSource{
 		{
-			JsonData: simplejson.NewFromAny(map[string]interface{}{
-				"esVersion": "2.0.0",
-			}),
+			JsonData: simplejson.NewFromAny(map[string]interface{}{}),
 		},
 		{
-			JsonData: simplejson.NewFromAny(map[string]interface{}{
-				"esVersion": "2.0.0",
-			}),
+			JsonData: simplejson.NewFromAny(map[string]interface{}{}),
 		},
 		{
-			JsonData: simplejson.NewFromAny(map[string]interface{}{
-				"esVersion": "70.1.1",
-			}),
+			JsonData: simplejson.NewFromAny(map[string]interface{}{}),
 		},
 	}
 
@@ -187,46 +181,6 @@ func TestCollectingUsageStats(t *testing.T) {
 	assert.InDelta(t, int64(65), metrics["stats.uptime"], 6)
 }
 
-func TestElasticStats(t *testing.T) {
-	sqlStore := dbtest.NewFakeDB()
-	statsService := statstest.NewFakeService()
-
-	expectedDataSources := []*datasources.DataSource{
-		{
-			JsonData: simplejson.NewFromAny(map[string]interface{}{
-				"esVersion": "2.0.0",
-			}),
-		},
-		{
-			JsonData: simplejson.NewFromAny(map[string]interface{}{
-				"esVersion": "2.0.0",
-			}),
-		},
-		{
-			JsonData: simplejson.NewFromAny(map[string]interface{}{
-				"esVersion": "70.1.1",
-			}),
-		},
-	}
-
-	s := createService(t, &setting.Cfg{
-		ReportingEnabled:     true,
-		BuildVersion:         "5.0.0",
-		AnonymousEnabled:     true,
-		BasicAuthEnabled:     true,
-		LDAPAuthEnabled:      true,
-		AuthProxyEnabled:     true,
-		Packaging:            "deb",
-		ReportingDistributor: "hosted-grafana",
-	}, sqlStore, statsService,
-		withDatasources(mockDatasourceService{datasources: expectedDataSources}))
-
-	metrics, err := s.collectElasticStats(context.Background())
-	require.NoError(t, err)
-
-	assert.EqualValues(t, 2, metrics["stats.ds."+datasources.DS_ES+".v2_0_0.count"])
-	assert.EqualValues(t, 1, metrics["stats.ds."+datasources.DS_ES+".v70_1_1.count"])
-}
 func TestDatasourceStats(t *testing.T) {
 	sqlStore := dbtest.NewFakeDB()
 	statsService := statstest.NewFakeService()
@@ -250,24 +204,6 @@ func TestDatasourceStats(t *testing.T) {
 		{
 			Type:  "unknown_ds2",
 			Count: 12,
-		},
-	}
-
-	_ = []*datasources.DataSource{
-		{
-			JsonData: simplejson.NewFromAny(map[string]interface{}{
-				"esVersion": 2,
-			}),
-		},
-		{
-			JsonData: simplejson.NewFromAny(map[string]interface{}{
-				"esVersion": 2,
-			}),
-		},
-		{
-			JsonData: simplejson.NewFromAny(map[string]interface{}{
-				"esVersion": 70,
-			}),
 		},
 	}
 

--- a/pkg/tests/api/elasticsearch/elasticsearch_test.go
+++ b/pkg/tests/api/elasticsearch/elasticsearch_test.go
@@ -47,7 +47,6 @@ func TestIntegrationElasticsearch(t *testing.T) {
 	jsonData := simplejson.NewFromAny(map[string]interface{}{
 		"httpMethod":      "post",
 		"httpHeaderName1": "X-CUSTOM-HEADER",
-		"esVersion":       "8.0.0",
 		"timeField":       "@timestamp",
 	})
 	secureJSONData := map[string]string{


### PR DESCRIPTION
previously, when configuring an Elasticsearch datasource, the user had to set the database's version, and it was stored in `jsonData.esVersion`.

we changed the functionality so that now grafana auto-detects the elasticsearch database version, so we do not need the `jsonData.esVersion` field.

this pull request removes code that users `jsonData.esVersion`, we do not need that anymore.