### PR TITLE
MegaMenu: Fixes mega menu showing scroll indicator when it shouldn't

### DIFF
--- a/public/app/core/components/MegaMenu/NavBarMenu.tsx
+++ b/public/app/core/components/MegaMenu/NavBarMenu.tsx
@@ -131,6 +131,8 @@ const getStyles = (theme: GrafanaTheme2, searchBarHidden?: boolean) => {
       top: searchBarHidden ? 0 : TOP_BAR_LEVEL_HEIGHT,
       backgroundColor: theme.colors.background.primary,
       boxSizing: 'content-box',
+      flex: '1 1 0',
+
       [theme.breakpoints.up('md')]: {
         borderRight: `1px solid ${theme.colors.border.weak}`,
         right: 'unset',
@@ -140,7 +142,8 @@ const getStyles = (theme: GrafanaTheme2, searchBarHidden?: boolean) => {
     content: css({
       display: 'flex',
       flexDirection: 'column',
-      height: '100%',
+      flexGrow: 1,
+      minHeight: 0,
     }),
     mobileHeader: css({
       display: 'flex',

--- a/public/app/core/components/MegaMenu/NavBarMenu.tsx
+++ b/public/app/core/components/MegaMenu/NavBarMenu.tsx
@@ -140,12 +140,14 @@ const getStyles = (theme: GrafanaTheme2, searchBarHidden?: boolean) => {
     content: css({
       display: 'flex',
       flexDirection: 'column',
-      overflow: 'auto',
+      height: '100%',
     }),
     mobileHeader: css({
       display: 'flex',
       justifyContent: 'space-between',
-      padding: theme.spacing(1, 2),
+      padding: theme.spacing(1, 1, 1, 2),
+      borderBottom: `1px solid ${theme.colors.border.weak}`,
+
       [theme.breakpoints.up('md')]: {
         display: 'none',
       },


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/65394

Noticed this hover indicator in the MenuMenu last couple of days. 

This PR fixes 
* Make sure the content expands to full height so we don't show the scroll indicator when we don't need to
* Fixes the position of the close button for mobile views (was not aligned with the topnav top section). Also adds a border bottom to the mega menu mobile header (so that it looks the same as the normal bottom half of topnav) 

This is the bug I am seeing
![Screenshot from 2023-03-28 15-32-50](https://user-images.githubusercontent.com/10999/228258518-9d75b281-1c4c-494c-864e-736a4ba8ab12.png)

Not sure if we should backport this or not? (as topnav is being rolled out more and more to cloud in 9.4.x ?)  