### PR TITLE
TablePanel: Trying to fix sorting and reszing 

### DIFF
--- a/packages/grafana-ui/src/components/Table/Table.tsx
+++ b/packages/grafana-ui/src/components/Table/Table.tsx
@@ -110,11 +110,13 @@ export const Table = memo((props: Props) => {
   );
 
   // React-table column definitions
-  const memoizedColumns = useMemo(
-    () =>
-      getColumns(addRowNumbersFieldToData(data), width, columnMinWidth, !!subData?.length, footerItems, isCountRowsSet),
-    [data, width, columnMinWidth, footerItems, subData, isCountRowsSet]
-  );
+  const memoizedColumns = useMemo(() => {
+    let dataWithMaybeRows = data;
+    if (showRowNums) {
+      dataWithMaybeRows = addRowNumbersFieldToData(data);
+    }
+    return getColumns(dataWithMaybeRows, width, columnMinWidth, !!subData?.length, footerItems, isCountRowsSet);
+  }, [data, width, columnMinWidth, footerItems, subData, isCountRowsSet, showRowNums]);
 
   // Internal react table state reducer
   const stateReducer = useTableStateReducer(props);
@@ -146,15 +148,9 @@ export const Table = memo((props: Props) => {
     gotoPage,
     setPageSize,
     pageOptions,
-    setHiddenColumns,
   } = useTable(options, useFilters, useSortBy, useAbsoluteLayout, useResizeColumns, useExpanded, usePagination);
 
   const extendedState = state as GrafanaTableState;
-
-  // Hide Row Number column on toggle
-  useEffect(() => {
-    !!showRowNums ? setHiddenColumns([]) : setHiddenColumns(['0']);
-  }, [showRowNums, setHiddenColumns]);
 
   /*
     Footer value calculation is being moved in the Table component and the footerValues prop will be deprecated.

--- a/packages/grafana-ui/src/components/Table/Table.tsx
+++ b/packages/grafana-ui/src/components/Table/Table.tsx
@@ -1,4 +1,3 @@
-import { clone } from 'lodash';
 import React, { CSSProperties, memo, useCallback, useEffect, useMemo, useRef, useState, UIEventHandler } from 'react';
 import {
   Cell,
@@ -12,7 +11,7 @@ import {
 } from 'react-table';
 import { VariableSizeList } from 'react-window';
 
-import { DataFrame, Field, ReducerID } from '@grafana/data';
+import { Field, ReducerID } from '@grafana/data';
 import { TableCellHeight } from '@grafana/schema';
 
 import { useTheme2 } from '../../themes';
@@ -33,7 +32,7 @@ import {
   getFooterItems,
   createFooterCalculationValues,
   EXPANDER_WIDTH,
-  buildFieldsForOptionalRowNums,
+  addRowNumbersFieldToData,
 } from './utils';
 
 const COLUMN_MIN_WIDTH = 150;
@@ -278,15 +277,6 @@ export const Table = memo((props: Props) => {
           {/*add the subtable to the DOM first to prevent a 1px border CSS issue on the last cell of the row*/}
           {renderSubTable(rowIndex)}
           {row.cells.map((cell: Cell, index: number) => {
-            /*
-              Here we test if the `row.cell` is of id === "0"; only if the user has toggled ON `Show row numbers` in the panelOptions panel will this cell exist.
-              This cell had already been built, but with undefined values. This is so we can now update our empty/undefined `cell.value` to the current `rowIndex + 1`.
-              This will assure that on sort, our row numbers don't also sort; but instewad stay in their respective rows.
-            */
-            if (cell.column.id === '0') {
-              cell.value = rowIndex + 1;
-            }
-
             return (
               <TableCell
                 key={index}
@@ -335,19 +325,6 @@ export const Table = memo((props: Props) => {
         )}
       </div>
     );
-  }
-
-  // This adds the `Field` data needed to display a column with Row Numbers.
-  function addRowNumbersFieldToData(data: DataFrame): DataFrame {
-    /*
-      The `length` prop in a DataFrame tells us the amount of rows of data that will appear in our table;
-      with that we can build the correct buffered incrementing values for our Row Number column data.
-    */
-    const rowField: Field = buildFieldsForOptionalRowNums(data.length);
-    // Clone data to avoid unwanted mutation.
-    const clonedData = clone(data);
-    clonedData.fields = [rowField, ...data.fields];
-    return clonedData;
   }
 
   const getItemSize = (index: number): number => {

--- a/packages/grafana-ui/src/components/Table/types.ts
+++ b/packages/grafana-ui/src/components/Table/types.ts
@@ -62,6 +62,7 @@ export interface TableFooterCalc {
 export interface GrafanaTableState extends TableState {
   lastExpandedIndex?: number;
   toggleRowExpandedCounter: number;
+  showRowNums?: boolean;
 }
 
 export interface GrafanaTableRow extends Row, UseExpandedRowProps<{}> {}

--- a/packages/grafana-ui/src/components/Table/utils.ts
+++ b/packages/grafana-ui/src/components/Table/utils.ts
@@ -170,18 +170,15 @@ export function getColumns(
   this way, on other column's sort, the row numbers will persist in their proper place.
 */
 export function buildFieldsForOptionalRowNums(totalRows: number): Field {
+  const array = new Array(totalRows);
+  for (let i = 0; i < totalRows; i++) {
+    array[i] = i + 1;
+  }
+
   return {
     ...defaultRowNumberColumnFieldData,
-    values: buildBufferedEmptyValues(totalRows),
+    values: new ArrayVector(array),
   };
-}
-
-/*
-  This gives us an empty buffered ArrayVector of the desired length to match the table data.
-  It is simply a data placeholder for the Row Number column data.
-*/
-export function buildBufferedEmptyValues(totalRows: number): ArrayVector<string> {
-  return new ArrayVector(new Array(totalRows));
 }
 
 export function getCellComponent(displayMode: TableCellDisplayMode, field: Field): CellComponent {
@@ -547,4 +544,17 @@ function addMissingColumnIndex(columns: Array<{ id: string; field?: Field } | un
 
   // Recurse
   addMissingColumnIndex(columns);
+}
+
+// This adds the `Field` data needed to display a column with Row Numbers.
+export function addRowNumbersFieldToData(data: DataFrame): DataFrame {
+  /*
+      The `length` prop in a DataFrame tells us the amount of rows of data that will appear in our table;
+      with that we can build the correct buffered incrementing values for our Row Number column data.
+    */
+  const rowField: Field = buildFieldsForOptionalRowNums(data.length);
+  // Clone data to avoid unwanted mutation.
+  const clonedData = clone(data);
+  clonedData.fields = [rowField, ...data.fields];
+  return clonedData;
 }

--- a/public/app/plugins/panel/table/TablePanel.tsx
+++ b/public/app/plugins/panel/table/TablePanel.tsx
@@ -5,7 +5,6 @@ import { DataFrame, FieldMatcherID, getFrameDisplayName, PanelProps, SelectableV
 import { PanelDataErrorView } from '@grafana/runtime';
 import { Select, Table, usePanelContext, useTheme2 } from '@grafana/ui';
 import { TableSortByFieldState } from '@grafana/ui/src/components/Table/types';
-import { OPTIONAL_ROW_NUMBER_COLUMN_WIDTH } from '@grafana/ui/src/components/Table/utils';
 
 import { PanelOptions } from './panelcfg.gen';
 
@@ -43,7 +42,7 @@ export function TablePanel(props: Props) {
     <Table
       height={tableHeight}
       // This calculation is to accommodate the optionally rendered Row Numbers Column
-      width={options.showRowNums ? width : width + OPTIONAL_ROW_NUMBER_COLUMN_WIDTH}
+      width={width}
       data={main}
       noHeader={!options.showHeader}
       showTypeIcons={options.showTypeIcons}


### PR DESCRIPTION
I think https://github.com/grafana/grafana/pull/62256  broke the table panel pretty badly by adding the row numbers column (always added), and hidding it it always creates a mismatch between field index of the source data and the column indices. 

But there are other problems with that PR, like the row numbers don't change when you paginate (they should mean the results row index, not the display row index I think). And if I filter using column filter I would assume the row number to show the row number for that hit (ie the source row number), I think this is how it works in excel for example. 

Not sure what the best course of action is, revert the PR and rework it. or continue to work on this PR trying to fix these issues. 
