### PR TITLE
GrafanaUI: Indeterminate checkbox

### DIFF
--- a/packages/grafana-ui/src/components/Forms/Checkbox.mdx
+++ b/packages/grafana-ui/src/components/Forms/Checkbox.mdx
@@ -9,22 +9,22 @@ import { Checkbox } from './Checkbox';
 
 Checked represents true, un-checked represent false. So you can use them to select a binary option or multiple options in a set. `Checkbox` can be used in groups, where the single checkboxes have no dependencies. That means that selecting one doesn’t affect any other `Checkbox`. When adding a description to your `Checkbox`, write positive statements so that "checked" means "yes" and not "no". That way, you can avoid confusion.
 
-**DO:** [ ] Hide options
-**DON'T:** [ ] Do not show options
+- **DO:** [ ] Hide options
+- **DON'T:** [ ] Do not show options
 
 Checkboxes typically only trigger changes after sending a form. If your component should trigger a change immediately, it's better to use a toggle switch instead. Furthermore, checkboxes are not mutually exclusive. That means that selecting one will not disable the others or impact them in any other way. If you want to offer a mutually exclusive choice, use `RadioButtonGroup` or a `Select` dropdown.
 
-**DO:**
-Show series
-[ ] A-series
-[ ] B-series
-[ ] C-series
+**DO:** Show series
 
-**DON'T:**
-Show only
-[ ] A-series
-[ ] B-series
-[ ] C-series
+- [ ] A-series
+- [ ] B-series
+- [ ] C-series
+
+**DON'T:** Show only
+
+- [ ] A-series
+- [ ] B-series
+- [ ] C-series
 
 ### Usage
 

--- a/packages/grafana-ui/src/components/Forms/Checkbox.story.tsx
+++ b/packages/grafana-ui/src/components/Forms/Checkbox.story.tsx
@@ -80,4 +80,29 @@ InAField.args = {
   disabled: false,
 };
 
+export const AllStates: ComponentStory<typeof Checkbox> = (args) => {
+  const [checked, setChecked] = useState(false);
+  const onChange = useCallback(
+    (e: React.FormEvent<HTMLInputElement>) => setChecked(e.currentTarget.checked),
+    [setChecked]
+  );
+
+  return (
+    <div>
+      <VerticalGroup>
+        <Checkbox value={checked} onChange={onChange} {...args} />
+        <Checkbox value={true} label="Checked" />
+        <Checkbox value={false} label="Unchecked" />
+        <Checkbox value={false} indeterminate={true} label="Interdeterminate" />
+      </VerticalGroup>
+    </div>
+  );
+};
+
+AllStates.args = {
+  label: 'Props set from controls',
+  description: 'Set to true if you want to skip TLS cert validation',
+  disabled: false,
+};
+
 export default meta;

--- a/packages/grafana-ui/src/components/Forms/Checkbox.tsx
+++ b/packages/grafana-ui/src/components/Forms/Checkbox.tsx
@@ -14,10 +14,11 @@ export interface CheckboxProps extends Omit<HTMLProps<HTMLInputElement>, 'value'
   value?: boolean;
   // htmlValue allows to specify the input "value" attribute
   htmlValue?: string | number;
+  indeterminate?: boolean;
 }
 
 export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
-  ({ label, description, value, htmlValue, onChange, disabled, className, ...inputProps }, ref) => {
+  ({ label, description, value, htmlValue, onChange, disabled, className, indeterminate, ...inputProps }, ref) => {
     const handleOnChange = useCallback(
       (e: React.ChangeEvent<HTMLInputElement>) => {
         if (onChange) {
@@ -28,16 +29,19 @@ export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
     );
     const styles = useStyles2(getCheckboxStyles);
 
+    const ariaChecked = indeterminate ? 'mixed' : undefined;
+
     return (
       <label className={cx(styles.wrapper, className)}>
         <div className={styles.checkboxWrapper}>
           <input
             type="checkbox"
-            className={styles.input}
+            className={cx(styles.input, indeterminate && styles.inputIndeterminate)}
             checked={value}
             disabled={disabled}
             onChange={handleOnChange}
             value={htmlValue}
+            aria-checked={ariaChecked}
             {...inputProps}
             ref={ref}
           />
@@ -88,9 +92,7 @@ export const getCheckboxStyles = stylesFactory((theme: GrafanaTheme2) => {
        * for angular components styling
        * */
       &:checked + span {
-        background: blue;
         background: ${theme.colors.primary.main};
-        border: none;
 
         &:hover {
           background: ${theme.colors.primary.shade};
@@ -123,6 +125,28 @@ export const getCheckboxStyles = stylesFactory((theme: GrafanaTheme2) => {
         }
       }
     `,
+
+    inputIndeterminate: css`
+      & + span {
+        background: ${theme.colors.primary.main};
+
+        &:hover {
+          background: ${theme.colors.primary.shade};
+        }
+
+        &:after {
+          content: '';
+          position: absolute;
+          z-index: 2;
+          left: 2px;
+          right: 2px;
+          top: calc(50% - 1.5px);
+          height: 3px;
+          background-color: ${theme.colors.primary.contrastText};
+        }
+      }
+    `,
+
     checkboxWrapper: css`
       display: flex;
       align-items: center;


### PR DESCRIPTION
Fixes #63335 

**What is this feature?**

Adds indeterminate state to checkboxes.

**Why do we need this feature?**

Indeterminate is a _visual only_ state typically used to show that 'sub options' are in a mixed state. Setting `indeterminate={true}` on a checkbox does not affect the value of the checkbox, but only the visual appearance. 

![image](https://user-images.githubusercontent.com/46142/228293921-f9f65190-f83c-4659-ab10-e849788fbc55.png)
