### PR TITLE
Dropdown: Stop Dropdown accepting a function as children

### DIFF
--- a/packages/grafana-ui/src/components/Dropdown/Dropdown.tsx
+++ b/packages/grafana-ui/src/components/Dropdown/Dropdown.tsx
@@ -11,7 +11,7 @@ import { TooltipPlacement } from '../Tooltip/types';
 export interface Props {
   overlay: React.ReactElement | (() => React.ReactElement);
   placement?: TooltipPlacement;
-  children: React.ReactElement | ((isOpen: boolean) => React.ReactElement);
+  children: React.ReactElement;
   /** Amount in pixels to nudge the dropdown vertically and horizontally, respectively. */
   offset?: [number, number];
   onVisibleChange?: (state: boolean) => void;
@@ -51,7 +51,7 @@ export const Dropdown = React.memo(({ children, overlay, placement, offset, onVi
 
   return (
     <>
-      {React.cloneElement(typeof children === 'function' ? children(visible) : children, {
+      {React.cloneElement(children, {
         ref: setTriggerRef,
       })}
       {visible && (

--- a/public/app/core/components/AppChrome/QuickAdd/QuickAdd.tsx
+++ b/public/app/core/components/AppChrome/QuickAdd/QuickAdd.tsx
@@ -19,6 +19,7 @@ export const QuickAdd = ({}: Props) => {
   const navBarTree = useSelector((state) => state.navBarTree);
   const breakpoint = theme.breakpoints.values.sm;
 
+  const [isOpen, setIsOpen] = useState(false);
   const [isSmallScreen, setIsSmallScreen] = useState(!window.matchMedia(`(min-width: ${breakpoint}px)`).matches);
   const createActions = useMemo(() => findCreateActions(navBarTree), [navBarTree]);
 
@@ -46,14 +47,13 @@ export const QuickAdd = ({}: Props) => {
 
   return createActions.length > 0 ? (
     <>
-      <Dropdown overlay={MenuActions} placement="bottom-end">
-        {(isOpen) =>
-          isSmallScreen ? (
-            <ToolbarButton iconOnly icon="plus-circle" aria-label="New" />
-          ) : (
-            <ToolbarButton iconOnly icon="plus" isOpen={isOpen} aria-label="New" />
-          )
-        }
+      <Dropdown overlay={MenuActions} placement="bottom-end" onVisibleChange={setIsOpen}>
+        <ToolbarButton
+          iconOnly
+          icon={isSmallScreen ? 'plus-circle' : 'plus'}
+          isOpen={isSmallScreen ? undefined : isOpen}
+          aria-label="New"
+        />
       </Dropdown>
       <NavToolbarSeparator className={styles.separator} />
     </>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- https://github.com/grafana/grafana/pull/61774 added a new prop to Dropdown, `onVisibleChange`
- this makes the function-as-a-child pattern redundant, as you can instead use the `onVisibleChange` prop. think using the new prop is clearer/probably more performant. 👏 
- removes being able to use a function as a child from Dropdown
  - technically this is a breaking change, buuuuuuut...
  - looking at https://ops.grafana-ops.net/d/bML5aAb7k/plugins-imports?orgId=1&var-packageName=@grafana%2Fui there are currently no plugins using `Dropdown`
  - there could be private plugins using it, buuuuuuut...
  - i think the number of people using the function-as-a-child pattern will be vanishingly small and we should just get rid of it now before anyone realises 🤫 
- changes the only place that utilised this (QuickAdd) to use `onVisibleChange` instead

**Why do we need this feature?**

- keep our components tidy

**Who is this feature for?**

- me

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
- [ ] There are no known compatibility issues with older supported versions of Grafana, or plugins.
- [ ] It passes the [Hosted Grafana feature readiness review](https://docs.google.com/document/d/1QL9Ly8KnXzpb6ISbg49pTODRO5mhA5tkkfIZVX6pqQU/edit) for observability, scalability, performance, and security.

# Release notice breaking change

We've removed the ability for functions to be passed as children to the `Dropdown` component. Previously, this was used to access the `isOpen` state of the dropdown. This can be now be achieved with the `onVisibleChange` prop.

Before:
```
return (
  <Dropdown overlay={MenuActions} placement="bottom-end">
    {(isOpen) =>
      <ToolbarButton iconOnly icon="plus" isOpen={isOpen} aria-label="New" />
    }
  </Dropdown>
);
```

After:
```
const [isOpen, setIsOpen] = useState(false);

...

return (
  <Dropdown overlay={MenuActions} placement="bottom-end" onVisibleChange={setIsOpen}>
    <ToolbarButton iconOnly icon="plus" isOpen={isOpen} aria-label="New" />
  </Dropdown>
);
```