### PR TITLE
Alerting: No longer index state history log streams by instance labels

### DIFF
--- a/pkg/services/ngalert/state/historian/loki.go
+++ b/pkg/services/ngalert/state/historian/loki.go
@@ -361,7 +361,7 @@ func buildLogQuery(query models.HistoryQuery) (string, error) {
 
 	labelFilters := ""
 	for k, v := range query.Labels {
-		labelFilters += fmt.Sprintf(" | labels.%s=%q", k, v)
+		labelFilters += fmt.Sprintf(" | labels_%s=%q", k, v)
 	}
 
 	if labelFilters != "" {

--- a/pkg/services/ngalert/state/historian/loki.go
+++ b/pkg/services/ngalert/state/historian/loki.go
@@ -248,7 +248,8 @@ func statesToStreams(rule history_model.RuleMeta, states []state.StateTransition
 			continue
 		}
 
-		labels := mergeLabels(removePrivateLabels(state.State.Labels), externalLabels)
+		labels := mergeLabels(make(map[string]string), externalLabels)
+		// System-defined labels take precedence over user-defined external labels.
 		labels[StateHistoryLabelKey] = StateHistoryLabelValue
 		labels[OrgIDLabel] = fmt.Sprint(rule.OrgID)
 		labels[RuleUIDLabel] = fmt.Sprint(rule.UID)

--- a/pkg/services/ngalert/state/historian/loki.go
+++ b/pkg/services/ngalert/state/historian/loki.go
@@ -120,8 +120,8 @@ func (h *RemoteLokiBackend) Query(ctx context.Context, query models.HistoryQuery
 }
 
 func buildSelectors(query models.HistoryQuery) ([]Selector, error) {
-	// +2 as OrgID and the state history label will always be selectors at the API level.
-	selectors := make([]Selector, len(query.Labels)+2)
+	// OrgID and the state history label are static and will be included in all queries.
+	selectors := make([]Selector, 2)
 
 	// Set the predefined selector orgID.
 	selector, err := NewSelector(OrgIDLabel, "=", fmt.Sprintf("%d", query.OrgID))
@@ -136,17 +136,6 @@ func buildSelectors(query models.HistoryQuery) ([]Selector, error) {
 		return nil, err
 	}
 	selectors[1] = selector
-
-	// Set the label selectors
-	i := 2
-	for label, val := range query.Labels {
-		selector, err = NewSelector(label, "=", val)
-		if err != nil {
-			return nil, err
-		}
-		selectors[i] = selector
-		i++
-	}
 
 	// Set the optional special selector rule_id
 	if query.RuleUID != "" {

--- a/pkg/services/ngalert/state/historian/loki.go
+++ b/pkg/services/ngalert/state/historian/loki.go
@@ -268,7 +268,7 @@ func statesToStreams(rule history_model.RuleMeta, states []state.StateTransition
 			Values:         valuesAsDataBlob(state.State),
 			DashboardUID:   rule.DashboardUID,
 			PanelID:        rule.PanelID,
-			InstanceLabels: state.Labels,
+			InstanceLabels: removePrivateLabels(state.Labels),
 		}
 		if state.State.State == eval.Error {
 			entry.Error = state.Error.Error()

--- a/pkg/services/ngalert/state/historian/loki_http.go
+++ b/pkg/services/ngalert/state/historian/loki_http.go
@@ -102,14 +102,6 @@ const (
 	NeqRegEx Operator = "!~"
 )
 
-type Selector struct {
-	// Label to Select
-	Label string
-	Op    Operator
-	// Value that is expected
-	Value string
-}
-
 func newLokiClient(cfg LokiConfig, req client.Requester, metrics *metrics.Historian, logger log.Logger) *httpLokiClient {
 	tc := client.NewTimedClient(req, metrics.WriteDuration)
 	return &httpLokiClient{
@@ -234,11 +226,8 @@ func (c *httpLokiClient) setAuthAndTenantHeaders(req *http.Request) {
 		req.Header.Add("X-Scope-OrgID", c.cfg.TenantID)
 	}
 }
-func (c *httpLokiClient) rangeQuery(ctx context.Context, selectors []Selector, start, end int64) (queryRes, error) {
+func (c *httpLokiClient) rangeQuery(ctx context.Context, logQL string, start, end int64) (queryRes, error) {
 	// Run the pre-flight checks for the query.
-	if len(selectors) == 0 {
-		return queryRes{}, fmt.Errorf("at least one selector required to query")
-	}
 	if start > end {
 		return queryRes{}, fmt.Errorf("start time cannot be after end time")
 	}
@@ -246,7 +235,7 @@ func (c *httpLokiClient) rangeQuery(ctx context.Context, selectors []Selector, s
 	queryURL := c.cfg.ReadPathURL.JoinPath("/loki/api/v1/query_range")
 
 	values := url.Values{}
-	values.Set("query", selectorString(selectors))
+	values.Set("query", logQL)
 	values.Set("start", fmt.Sprintf("%d", start))
 	values.Set("end", fmt.Sprintf("%d", end))
 
@@ -292,35 +281,6 @@ func (c *httpLokiClient) rangeQuery(ctx context.Context, selectors []Selector, s
 	}
 
 	return result, nil
-}
-
-func selectorString(selectors []Selector) string {
-	if len(selectors) == 0 {
-		return "{}"
-	}
-	// Build the query selector.
-	query := ""
-	for _, s := range selectors {
-		query += fmt.Sprintf("%s%s%q,", s.Label, s.Op, s.Value)
-	}
-	// Remove the last comma, as we append one to every selector.
-	query = query[:len(query)-1]
-	return "{" + query + "}"
-}
-
-func NewSelector(label, op, value string) (Selector, error) {
-	if !isValidOperator(op) {
-		return Selector{}, fmt.Errorf("'%s' is not a valid query operator", op)
-	}
-	return Selector{Label: label, Op: Operator(op), Value: value}, nil
-}
-
-func isValidOperator(op string) bool {
-	switch op {
-	case "=", "!=", "=~", "!~":
-		return true
-	}
-	return false
 }
 
 type queryRes struct {

--- a/pkg/services/ngalert/state/historian/loki_http_test.go
+++ b/pkg/services/ngalert/state/historian/loki_http_test.go
@@ -164,44 +164,17 @@ func TestLokiHTTPClient_Manual(t *testing.T) {
 		// so the x-scope-orgid header is set.
 		// client.cfg.TenantID = "<your_tenant_id>"
 
-		// Create an array of selectors that should be used for the
-		// query.
-		selectors := []Selector{
-			{Label: "probe", Op: Eq, Value: "Paris"},
-		}
+		logQL := `{probe="Paris"}`
 
 		// Define the query time range
 		start := time.Now().Add(-30 * time.Minute).UnixNano()
 		end := time.Now().UnixNano()
 
 		// Authorized request should not fail against Grafana Cloud.
-		res, err := client.rangeQuery(context.Background(), selectors, start, end)
+		res, err := client.rangeQuery(context.Background(), logQL, start, end)
 		require.NoError(t, err)
 		require.NotNil(t, res)
 	})
-}
-
-func TestSelectorString(t *testing.T) {
-	selectors := []Selector{{"name", "=", "Bob"}, {"age", "=~", "30"}}
-	expected := "{name=\"Bob\",age=~\"30\"}"
-	result := selectorString(selectors)
-	require.Equal(t, expected, result)
-
-	selectors = []Selector{}
-	expected = "{}"
-	result = selectorString(selectors)
-	require.Equal(t, expected, result)
-}
-
-func TestNewSelector(t *testing.T) {
-	selector, err := NewSelector("label", "=", "value")
-	require.NoError(t, err)
-	require.Equal(t, "label", selector.Label)
-	require.Equal(t, Eq, selector.Op)
-	require.Equal(t, "value", selector.Value)
-
-	selector, err = NewSelector("label", "invalid", "value")
-	require.Error(t, err)
 }
 
 func TestRow(t *testing.T) {

--- a/pkg/services/ngalert/state/historian/loki_test.go
+++ b/pkg/services/ngalert/state/historian/loki_test.go
@@ -192,7 +192,7 @@ func TestRemoteLokiBackend(t *testing.T) {
 						"labeltwo":    "labelvaluetwo",
 					},
 				},
-				exp: `{orgID="123",from="state-history"} | json | labels.customlabel="customvalue" | labels.labeltwo="labelvaluetwo"`,
+				exp: `{orgID="123",from="state-history"} | json | labels_customlabel="customvalue" | labels_labeltwo="labelvaluetwo"`,
 			},
 		}
 

--- a/pkg/services/ngalert/state/historian/loki_test.go
+++ b/pkg/services/ngalert/state/historian/loki_test.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"sort"
 	"testing"
 	"time"
 
@@ -74,46 +73,8 @@ func TestRemoteLokiBackend(t *testing.T) {
 				"group":              rule.Group,
 				"orgID":              fmt.Sprint(rule.OrgID),
 				"ruleUID":            rule.UID,
-				"a":                  "b",
 			}
 			require.Equal(t, exp, res[0].Stream)
-		})
-
-		t.Run("groups streams based on combined labels", func(t *testing.T) {
-			rule := createTestRule()
-			l := log.NewNopLogger()
-			states := []state.StateTransition{
-				{
-					PreviousState: eval.Normal,
-					State: &state.State{
-						State:  eval.Alerting,
-						Labels: data.Labels{"a": "b"},
-					},
-				},
-				{
-					PreviousState: eval.Normal,
-					State: &state.State{
-						State:  eval.Alerting,
-						Labels: data.Labels{"a": "b"},
-					},
-				},
-				{
-					PreviousState: eval.Normal,
-					State: &state.State{
-						State:  eval.Alerting,
-						Labels: data.Labels{"c": "d"},
-					},
-				},
-			}
-
-			res := statesToStreams(rule, states, nil, l)
-
-			require.Len(t, res, 2)
-			sort.Slice(res, func(i, j int) bool { return len(res[i].Values) > len(res[j].Values) })
-			require.Contains(t, res[0].Stream, "a")
-			require.Len(t, res[0].Values, 2)
-			require.Contains(t, res[1].Stream, "c")
-			require.Len(t, res[1].Values, 1)
 		})
 
 		t.Run("excludes private labels", func(t *testing.T) {

--- a/pkg/services/ngalert/state/historian/loki_test.go
+++ b/pkg/services/ngalert/state/historian/loki_test.go
@@ -356,6 +356,29 @@ grafana_alerting_state_history_writes_total{backend="loki",org="1"} 2
 	})
 }
 
+func TestSelectorString(t *testing.T) {
+	selectors := []Selector{{"name", "=", "Bob"}, {"age", "=~", "30"}}
+	expected := "{name=\"Bob\",age=~\"30\"}"
+	result := selectorString(selectors)
+	require.Equal(t, expected, result)
+
+	selectors = []Selector{}
+	expected = "{}"
+	result = selectorString(selectors)
+	require.Equal(t, expected, result)
+}
+
+func TestNewSelector(t *testing.T) {
+	selector, err := NewSelector("label", "=", "value")
+	require.NoError(t, err)
+	require.Equal(t, "label", selector.Label)
+	require.Equal(t, Eq, selector.Op)
+	require.Equal(t, "value", selector.Value)
+
+	selector, err = NewSelector("label", "invalid", "value")
+	require.Error(t, err)
+}
+
 func createTestLokiBackend(req client.Requester, met *metrics.Historian) *RemoteLokiBackend {
 	url, _ := url.Parse("http://some.url")
 	cfg := LokiConfig{


### PR DESCRIPTION
**What is this feature?**

This is a continuation of https://github.com/grafana/grafana/pull/65403 where we stop merging instance labels into the log stream labels. Going forward, log streams correspond 1:1 to rules.

Queries for labels will rely on the functionality added in https://github.com/grafana/grafana/pull/65403, they now filter the log line itself rather than labels.

**Why do we need this feature?**

1. Big reduction in cardinality.
2. Easier to reason about limits. Number of streams = number of rules, which already has limits.
3. Stream labels are well-known and predictable.

**Which issue(s) does this PR fix?**:

n/a

**Special notes for your reviewer:**

# Consider reviewing this PR commit-by-commit

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
- [x] There are no known compatibility issues with older supported versions of Grafana, or plugins.
- [x] It passes the [Hosted Grafana feature readiness review](https://docs.google.com/document/d/1QL9Ly8KnXzpb6ISbg49pTODRO5mhA5tkkfIZVX6pqQU/edit) for observability, scalability, performance, and security.