### PR TITLE
ErrorView: Better detection of no-data responses

### DIFF
--- a/public/app/features/panel/components/PanelDataErrorView.test.tsx
+++ b/public/app/features/panel/components/PanelDataErrorView.test.tsx
@@ -3,7 +3,7 @@ import { defaultsDeep } from 'lodash';
 import React from 'react';
 import { Provider } from 'react-redux';
 
-import { getDefaultTimeRange, LoadingState } from '@grafana/data';
+import { ArrayVector, FieldType, getDefaultTimeRange, LoadingState } from '@grafana/data';
 import { PanelDataErrorViewProps } from '@grafana/runtime';
 import { configureStore } from 'app/store/configureStore';
 
@@ -12,6 +12,41 @@ import { PanelDataErrorView } from './PanelDataErrorView';
 describe('PanelDataErrorView', () => {
   it('show No data when there is no data', () => {
     renderWithProps();
+
+    expect(screen.getByText('No data')).toBeInTheDocument();
+  });
+
+  it('show No data when there is no data', () => {
+    renderWithProps({
+      data: {
+        state: LoadingState.Done,
+        timeRange: getDefaultTimeRange(),
+        series: [
+          {
+            fields: [
+              {
+                name: 'time',
+                type: FieldType.time,
+                config: {},
+                values: new ArrayVector([]),
+              },
+            ],
+            length: 0,
+          },
+          {
+            fields: [
+              {
+                name: 'value',
+                type: FieldType.number,
+                config: {},
+                values: new ArrayVector([]),
+              },
+            ],
+            length: 0,
+          },
+        ],
+      },
+    });
 
     expect(screen.getByText('No data')).toBeInTheDocument();
   });

--- a/public/app/features/panel/components/PanelDataErrorView.tsx
+++ b/public/app/features/panel/components/PanelDataErrorView.tsx
@@ -66,7 +66,6 @@ function getMessageFor(
     return message;
   }
 
-  // In some cases there is a data frame but with no fields
   if (!data.series || data.series.length === 0 || data.series.every((frame) => frame.length === 0)) {
     return fieldConfig?.defaults.noValue ?? 'No data';
   }

--- a/public/app/features/panel/components/PanelDataErrorView.tsx
+++ b/public/app/features/panel/components/PanelDataErrorView.tsx
@@ -67,7 +67,7 @@ function getMessageFor(
   }
 
   // In some cases there is a data frame but with no fields
-  if (!data.series || data.series.length === 0 || (data.series.length === 1 && data.series[0].length === 0)) {
+  if (!data.series || data.series.length === 0 || data.series.every((frame) => frame.length === 0)) {
     return fieldConfig?.defaults.noValue ?? 'No data';
   }
 


### PR DESCRIPTION
Fixes https://github.com/grafana/support-escalations/issues/5218

@torkelo was there a specific reason for only checking when `data.series.length === 1`?