### PR TITLE
[v9.2] docs: fix alias and broken link

### DIFF
--- a/docs/sources/datasources/elasticsearch.md
+++ b/docs/sources/datasources/elasticsearch.md
@@ -175,7 +175,7 @@ In the above example, we have a lucene query that filters documents based on the
 a variable in the _Terms_ group by field input box. This allows you to use a variable to quickly change how the data is grouped.
 
 Example dashboard:
-[Elasticsearch Templated Dashboard](https://play.grafana.org/d/CknOEXDMk/elasticsearch-templated?orgId=1d)
+[Elasticsearch Templated Dashboard](https://play.grafana.org/d/z8OZC66nk/elasticsearch-8-2-0-sample-flight-data?orgId=1)
 
 ## Annotations
 

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/enhanced_ldap.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/enhanced_ldap.md
@@ -1,6 +1,7 @@
 ---
 aliases:
   - ../../../enterprise/enhanced_ldap/
+  - ../../../auth/enhanced_ldap/
 description: Grafana Enhanced LDAP Integration Guide
 keywords:
   - grafana


### PR DESCRIPTION
Fixes broken Elasticsearch Grafana Play link and non-working `enhanced ldap` alias.