### PR TITLE
Chore: Update alerting to commit 518e63bb07c5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/google/wire v0.5.0
 	github.com/gorilla/websocket v1.5.0
-	github.com/grafana/alerting v0.0.0-20230209203114-508391225cd4
+	github.com/grafana/alerting v0.0.0-20230328192025-518e63bb07c5
 	github.com/grafana/cuetsy v0.1.5
 	github.com/grafana/grafana-aws-sdk v0.12.0
 	github.com/grafana/grafana-azure-sdk-go v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -1396,6 +1396,8 @@ github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWm
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grafana/alerting v0.0.0-20230209203114-508391225cd4 h1:5/+He0gIt2Rr2EVijLEj+E2T6lhbEYsDoOP61qyBwM8=
 github.com/grafana/alerting v0.0.0-20230209203114-508391225cd4/go.mod h1:NoSLbfmUwE+omWFReFrLtbtOItmvTbuQERJ6XFYp9ME=
+github.com/grafana/alerting v0.0.0-20230328192025-518e63bb07c5 h1:mGAFon+7Vq5a/eiGIUBSzvbMyUJuY0qr3YFHVsOGNb8=
+github.com/grafana/alerting v0.0.0-20230328192025-518e63bb07c5/go.mod h1:NoSLbfmUwE+omWFReFrLtbtOItmvTbuQERJ6XFYp9ME=
 github.com/grafana/codejen v0.0.3 h1:tAWxoTUuhgmEqxJPOLtJoxlPBbMULFwKFOcRsPRPXDw=
 github.com/grafana/codejen v0.0.3/go.mod h1:zmwwM/DRyQB7pfuBjTWII3CWtxcXh8LTwAYGfDfpR6s=
 github.com/grafana/cuetsy v0.1.5 h1:mnFwAXdbqCsyL8r7kkdUMJ4kOAR26cxIPmrZj7JzTeY=

--- a/pkg/tests/api/alerting/api_notification_channel_test.go
+++ b/pkg/tests/api/alerting/api_notification_channel_test.go
@@ -17,10 +17,11 @@ import (
 	"time"
 
 	"github.com/grafana/alerting/alerting/notifier/channels"
-	"github.com/grafana/grafana/pkg/expr"
 	"github.com/prometheus/alertmanager/template"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/expr"
 
 	"github.com/grafana/grafana/pkg/infra/db"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
@@ -1050,6 +1051,7 @@ func (nc *mockNotificationChannel) ServeHTTP(res http.ResponseWriter, req *http.
 
 	nc.receivedNotifications[key] = append(nc.receivedNotifications[key], body)
 	res.WriteHeader(http.StatusOK)
+	res.Header().Set("Content-Type", "application/json")
 	fmt.Fprint(res, nc.responses[paths[0]])
 }
 


### PR DESCRIPTION
**What is this feature?**
This PR updates alerting module to commit 518e63bb07c5 that only includes a fix for the bug https://github.com/grafana/grafana/issues/64079. The PR that fixed the bug is https://github.com/grafana/alerting/pull/67 and its backport https://github.com/grafana/alerting/pull/72.

Diff between [508391225cd4 and 518e63bb07c5](https://github.com/grafana/alerting/compare/508391225cd4...518e63b)

Also, it fixes the integration test that validates slack integration. The bug was that the mock server responded with empty Content-Type, and it stopped working because in PR above the change requires the content type to be JSON so the response is treated as JSON.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
- [x] There are no known compatibility issues with older supported versions of Grafana, or plugins.
- [x] It passes the [Hosted Grafana feature readiness review](https://docs.google.com/document/d/1QL9Ly8KnXzpb6ISbg49pTODRO5mhA5tkkfIZVX6pqQU/edit) for observability, scalability, performance, and security.

# Change Log
Slack integration is updated to treat responses as text unless Content-Type is specified as `application/json`