### PR TITLE
Glue: Fix creating duplicated data links created by Correlations

### DIFF
--- a/packages/grafana-data/src/types/dataLink.ts
+++ b/packages/grafana-data/src/types/dataLink.ts
@@ -13,6 +13,15 @@ export interface DataLinkClickEvent<T = any> {
 }
 
 /**
+ * Data Links can be created by data source plugins or correlations.
+ * Origin is set in DataLink object and indicates where the link was created.
+ */
+export enum DataLinkConfigOrigin {
+  Datasource = 'Datasource',
+  Correlations = 'Correlations',
+}
+
+/**
  * Link configuration. The values may contain variables that need to be
  * processed before showing the link to user.
  *
@@ -39,6 +48,8 @@ export interface DataLink<T extends DataQuery = any> {
   // more custom onClick behaviour if needed.
   // @internal and subject to change in future releases
   internal?: InternalDataLink<T>;
+
+  origin?: DataLinkConfigOrigin;
 }
 
 /** @internal */

--- a/public/app/features/correlations/utils.test.ts
+++ b/public/app/features/correlations/utils.test.ts
@@ -5,57 +5,7 @@ import { attachCorrelationsToDataFrames } from './utils';
 
 describe('correlations utils', () => {
   it('attaches correlations defined in the configuration', () => {
-    const loki = { uid: 'loki-uid', name: 'loki' } as DataSourceInstanceSettings;
-    const elastic = { uid: 'elastic-uid', name: 'elastic' } as DataSourceInstanceSettings;
-    const prometheus = { uid: 'prometheus-uid', name: 'prometheus' } as DataSourceInstanceSettings;
-
-    const refIdMap = {
-      'Loki Query': loki.uid,
-      'Elastic Query': elastic.uid,
-      'Prometheus Query': prometheus.uid,
-    };
-
-    const testDataFrames: DataFrame[] = [
-      toDataFrame({
-        name: 'Loki Logs',
-        refId: 'Loki Query',
-        fields: [
-          { name: 'line', values: [] },
-          { name: 'traceId', values: [] },
-        ],
-      }),
-      toDataFrame({
-        name: 'Elastic Logs',
-        refId: 'Elastic Query',
-        fields: [
-          { name: 'line', values: [] },
-          { name: 'traceId', values: [] },
-        ],
-      }),
-      toDataFrame({
-        name: 'Prometheus Metrics',
-        refId: 'Prometheus Query',
-        fields: [{ name: 'value', type: FieldType.number, values: [1, 2, 3, 4, 5] }],
-      }),
-    ];
-
-    const correlations: CorrelationData[] = [
-      {
-        uid: 'loki-to-prometheus',
-        label: 'logs to metrics',
-        source: loki,
-        target: prometheus,
-        config: { type: 'query', field: 'traceId', target: { expr: 'target Prometheus query' } },
-      },
-      {
-        uid: 'prometheus-to-elastic',
-        label: 'metrics to logs',
-        source: prometheus,
-        target: elastic,
-        config: { type: 'query', field: 'value', target: { expr: 'target Elastic query' } },
-      },
-    ];
-
+    const { testDataFrames, correlations, refIdMap, prometheus, elastic } = setup();
     attachCorrelationsToDataFrames(testDataFrames, correlations, refIdMap);
 
     // Loki line (no links)
@@ -91,4 +41,69 @@ describe('correlations utils', () => {
       },
     });
   });
+
+  it('does not create duplicates when attaching links to the same data frame', () => {
+    const { testDataFrames, correlations, refIdMap } = setup();
+    attachCorrelationsToDataFrames(testDataFrames, correlations, refIdMap);
+    attachCorrelationsToDataFrames(testDataFrames, correlations, refIdMap);
+
+    attachCorrelationsToDataFrames(testDataFrames, correlations, refIdMap);
+    expect(testDataFrames[0].fields[1].config.links).toHaveLength(1);
+    expect(testDataFrames[2].fields[0].config.links).toHaveLength(1);
+  });
 });
+
+function setup() {
+  const loki = { uid: 'loki-uid', name: 'loki' } as DataSourceInstanceSettings;
+  const elastic = { uid: 'elastic-uid', name: 'elastic' } as DataSourceInstanceSettings;
+  const prometheus = { uid: 'prometheus-uid', name: 'prometheus' } as DataSourceInstanceSettings;
+
+  const refIdMap = {
+    'Loki Query': loki.uid,
+    'Elastic Query': elastic.uid,
+    'Prometheus Query': prometheus.uid,
+  };
+
+  const testDataFrames: DataFrame[] = [
+    toDataFrame({
+      name: 'Loki Logs',
+      refId: 'Loki Query',
+      fields: [
+        { name: 'line', values: [] },
+        { name: 'traceId', values: [] },
+      ],
+    }),
+    toDataFrame({
+      name: 'Elastic Logs',
+      refId: 'Elastic Query',
+      fields: [
+        { name: 'line', values: [] },
+        { name: 'traceId', values: [] },
+      ],
+    }),
+    toDataFrame({
+      name: 'Prometheus Metrics',
+      refId: 'Prometheus Query',
+      fields: [{ name: 'value', type: FieldType.number, values: [1, 2, 3, 4, 5] }],
+    }),
+  ];
+
+  const correlations: CorrelationData[] = [
+    {
+      uid: 'loki-to-prometheus',
+      label: 'logs to metrics',
+      source: loki,
+      target: prometheus,
+      config: { type: 'query', field: 'traceId', target: { expr: 'target Prometheus query' } },
+    },
+    {
+      uid: 'prometheus-to-elastic',
+      label: 'metrics to logs',
+      source: prometheus,
+      target: elastic,
+      config: { type: 'query', field: 'value', target: { expr: 'target Elastic query' } },
+    },
+  ];
+
+  return { testDataFrames, correlations, refIdMap, prometheus, elastic };
+}

--- a/public/app/features/correlations/utils.ts
+++ b/public/app/features/correlations/utils.ts
@@ -1,4 +1,4 @@
-import { DataFrame } from '@grafana/data';
+import { DataFrame, DataLinkConfigOrigin } from '@grafana/data';
 
 import { CorrelationData } from './useCorrelations';
 
@@ -33,7 +33,8 @@ const decorateDataFrameWithInternalDataLinks = (dataFrame: DataFrame, correlatio
   dataFrame.fields.forEach((field) => {
     correlations.map((correlation) => {
       if (correlation.config?.field === field.name) {
-        field.config.links = field.config.links || [];
+        field.config.links =
+          field.config.links?.filter((link) => link.origin !== DataLinkConfigOrigin.Correlations) || [];
         field.config.links.push({
           internal: {
             query: correlation.config?.target,
@@ -43,6 +44,7 @@ const decorateDataFrameWithInternalDataLinks = (dataFrame: DataFrame, correlatio
           },
           url: '',
           title: correlation.label || correlation.target.name,
+          origin: DataLinkConfigOrigin.Correlations,
         });
       }
     });

--- a/public/app/features/correlations/utils.ts
+++ b/public/app/features/correlations/utils.ts
@@ -31,11 +31,10 @@ export const attachCorrelationsToDataFrames = (
 
 const decorateDataFrameWithInternalDataLinks = (dataFrame: DataFrame, correlations: CorrelationData[]) => {
   dataFrame.fields.forEach((field) => {
+    field.config.links = field.config.links?.filter((link) => link.origin !== DataLinkConfigOrigin.Correlations) || [];
     correlations.map((correlation) => {
       if (correlation.config?.field === field.name) {
-        field.config.links =
-          field.config.links?.filter((link) => link.origin !== DataLinkConfigOrigin.Correlations) || [];
-        field.config.links.push({
+        field.config.links!.push({
           internal: {
             query: correlation.config?.target,
             datasourceUid: correlation.target.uid,


### PR DESCRIPTION
**Bug**

* Correlations **append** data links to returned data frames
* If the same data frame is processed twice, links are duplicated
* It's easy to reproduce with Loki, just set up a correlation; try adding it to a derived field to compare and test with data source data links:

Derived field configuration:
<img width="1287" alt="Screenshot 2023-03-28 at 22 49 27" src="https://user-images.githubusercontent.com/745532/228363517-fbf1feb1-52bb-449d-8804-6d260144588d.png">

Correlation configuration:
<img width="898" alt="Screenshot 2023-03-28 at 22 49 02" src="https://user-images.githubusercontent.com/745532/228363604-39d56d5d-cd1c-4268-b0a2-5f965400dfd6.png">

| before | after |
|---|---|
|  <img width="927" alt="Screenshot 2023-03-28 at 22 45 03" src="https://user-images.githubusercontent.com/745532/228362731-f35aa377-7e62-4e77-b4ae-a637a1ea58a2.png"> | <img width="1327" alt="Screenshot 2023-03-28 at 22 45 47" src="https://user-images.githubusercontent.com/745532/228362789-3f849c50-02a8-491d-b260-223ad5fb551e.png"> |

Fixes #63447
