### PR TITLE
CloudWatch: Fix cachedQueries insights not being updated for metric queries

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/language/cloudwatch-logs/CloudWatchLogsLanguageProvider.ts
+++ b/public/app/plugins/datasource/cloudwatch/language/cloudwatch-logs/CloudWatchLogsLanguageProvider.ts
@@ -2,11 +2,12 @@ import Prism, { Grammar } from 'prismjs';
 import { lastValueFrom } from 'rxjs';
 
 import { AbsoluteTimeRange, HistoryItem, LanguageProvider } from '@grafana/data';
+import { BackendDataSourceResponse, FetchResponse } from '@grafana/runtime';
 import { CompletionItemGroup, SearchFunctionType, Token, TypeaheadInput, TypeaheadOutput } from '@grafana/ui';
 import { getTemplateSrv } from 'app/features/templating/template_srv';
 
 import { CloudWatchDatasource } from '../../datasource';
-import { CloudWatchQuery, LogGroup, TSDBResponse } from '../../types';
+import { CloudWatchQuery, LogGroup } from '../../types';
 import { interpolateStringArrayUsingSingleOrMultiValuedVariable } from '../../utils/templateVariableUtils';
 
 import syntax, {
@@ -49,7 +50,7 @@ export class CloudWatchLogsLanguageProvider extends LanguageProvider {
     return syntax;
   }
 
-  request = (url: string, params?: any): Promise<TSDBResponse> => {
+  request = (url: string, params?: any): Promise<FetchResponse<BackendDataSourceResponse>> => {
     return lastValueFrom(this.datasource.logsQueryRunner.awsRequest(url, params));
   };
 

--- a/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchAnnotationQueryRunner.ts
+++ b/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchAnnotationQueryRunner.ts
@@ -36,7 +36,7 @@ export class CloudWatchAnnotationQueryRunner extends CloudWatchRequest {
       })),
     }).pipe(
       map((r) => {
-        const frames = toDataQueryResponse({ data: r }).data;
+        const frames = toDataQueryResponse(r).data;
         return { data: frames };
       })
     );

--- a/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchLogsQueryRunner.ts
+++ b/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchLogsQueryRunner.ts
@@ -301,7 +301,7 @@ export class CloudWatchLogsQueryRunner extends CloudWatchRequest {
     return this.awsRequest(this.dsQueryEndpoint, requestParams, {
       'X-Cache-Skip': 'true',
     }).pipe(
-      map((response) => resultsToDataFrames({ data: response })),
+      map((response) => resultsToDataFrames(response)),
       catchError((err: FetchError) => {
         if (config.featureToggles.datasourceQueryMultiStatus && err.status === 207) {
           throw err;

--- a/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchMetricsQueryRunner.ts
+++ b/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchMetricsQueryRunner.ts
@@ -117,12 +117,12 @@ export class CloudWatchMetricsQueryRunner extends CloudWatchRequest {
   performTimeSeriesQuery(request: MetricRequest, { from, to }: TimeRange): Observable<DataQueryResponse> {
     return this.awsRequest(this.dsQueryEndpoint, request).pipe(
       map((res) => {
-        const dataframes: DataFrame[] = toDataQueryResponse({ data: res }).data;
+        const dataframes: DataFrame[] = toDataQueryResponse(res).data;
         if (!dataframes || dataframes.length <= 0) {
           return { data: [] };
         }
 
-        const lastError = findLast(res.results, (v) => !!v.error);
+        const lastError = findLast(res.data.results, (v) => !!v.error);
 
         dataframes.forEach((frame) => {
           frame.fields.forEach((field) => {

--- a/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchRequest.ts
+++ b/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchRequest.ts
@@ -1,7 +1,7 @@
-import { Observable, map } from 'rxjs';
+import { Observable } from 'rxjs';
 
 import { DataSourceInstanceSettings, DataSourceRef, getDataSourceRef, ScopedVars } from '@grafana/data';
-import { getBackendSrv } from '@grafana/runtime';
+import { BackendDataSourceResponse, FetchResponse, getBackendSrv } from '@grafana/runtime';
 import { notifyApp } from 'app/core/actions';
 import { createErrorNotification } from 'app/core/copy/appNotification';
 import { TemplateSrv } from 'app/features/templating/template_srv';
@@ -9,7 +9,7 @@ import { store } from 'app/store/store';
 import { AppNotificationTimeout } from 'app/types';
 
 import memoizedDebounce from '../memoizedDebounce';
-import { CloudWatchJsonData, Dimensions, MetricRequest, MultiFilters, TSDBResponse } from '../types';
+import { CloudWatchJsonData, Dimensions, MetricRequest, MultiFilters } from '../types';
 
 export abstract class CloudWatchRequest {
   templateSrv: TemplateSrv;
@@ -25,7 +25,11 @@ export abstract class CloudWatchRequest {
     this.ref = getDataSourceRef(instanceSettings);
   }
 
-  awsRequest(url: string, data: MetricRequest, headers: Record<string, string> = {}): Observable<TSDBResponse> {
+  awsRequest(
+    url: string,
+    data: MetricRequest,
+    headers: Record<string, string> = {}
+  ): Observable<FetchResponse<BackendDataSourceResponse>> {
     const options = {
       method: 'POST',
       url,
@@ -33,9 +37,7 @@ export abstract class CloudWatchRequest {
       headers,
     };
 
-    return getBackendSrv()
-      .fetch<TSDBResponse>(options)
-      .pipe(map((result) => result.data));
+    return getBackendSrv().fetch<BackendDataSourceResponse>(options);
   }
 
   convertDimensionFormat(dimensions: Dimensions, scopedVars: ScopedVars): Dimensions {


### PR DESCRIPTION
**What is this fix?**

Fixes the cached query stats not being updated in the dashboard insights.

**Why do we need this feature?**

Correctly displays the number of times the cache has been used for a dashboard. Also displays the indicator in the header of a panel that the results are from the query cache.

**Who is this fix for?**

Users that have query caching enabled

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #63898

**Special notes for your reviewer:**

This only fixes the cached query stats for CloudWatch metric queries. The query caching docs, only calls out "CloudWatch Metrics" as supporting query caching. Logs queries use an async flow and sets a header to bypass the cache so it will never use the query cache.

Test instructions can be found in the issue description https://github.com/grafana/grafana/issues/63898.

This is the indicator in the panel header that shows the panel is using a cached response.
<img width="222" alt="Screenshot 2023-03-28 at 3 05 12 PM" src="https://user-images.githubusercontent.com/19530599/228377185-91660c83-2935-4e7d-8177-06f73f69735f.png">

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
- [ ] There are no known compatibility issues with older supported versions of Grafana, or plugins.
- [ ] It passes the [Hosted Grafana feature readiness review](https://docs.google.com/document/d/1QL9Ly8KnXzpb6ISbg49pTODRO5mhA5tkkfIZVX6pqQU/edit) for observability, scalability, performance, and security.