### PR TITLE
Alerting: Introduce proper feature toggles for common state history backend combinations

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -99,9 +99,9 @@ Alpha features might be changed or removed without prior notice.
 | `influxdbBackendMigration`         | Query InfluxDB InfluxQL without the proxy                                                                                                                                                           |
 | `clientTokenRotation`              | Replaces the current in-request token rotation so that the client initiates the rotation                                                                                                            |
 | `prometheusDataplane`              | Changes responses to from Prometheus to be compliant with the dataplane specification. In particular it sets the numeric Field.Name from 'Value' to the value of the `__name__` label when present. |
-| `alertStateHistoryLokiSecondary`   | Enable alert state history to be written to an external loki instance in addition to Grafana annotations.                                                                                           |
-| `alertStateHistoryLokiPrimary`     | Enable usage of a remote Loki instance as the primary source for state history reads.                                                                                                               |
-| `alertStateHistoryLokiOnly`        | Allow Grafana annotations emitted by alerting to be disabled completely when remote Loki is in place.                                                                                               |
+| `alertStateHistoryLokiSecondary`   | Enable Grafana to write alert state history to an external Loki instance in addition to Grafana annotations.                                                                                        |
+| `alertStateHistoryLokiPrimary`     | Enable a remote Loki instance as the primary source for state history reads.                                                                                                                        |
+| `alertStateHistoryLokiOnly`        | Disable Grafana alerts from emitting annotations when a remote Loki instance is available.                                                                                                          |
 
 ## Development feature toggles
 

--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -99,6 +99,9 @@ Alpha features might be changed or removed without prior notice.
 | `influxdbBackendMigration`         | Query InfluxDB InfluxQL without the proxy                                                                                                                                                           |
 | `clientTokenRotation`              | Replaces the current in-request token rotation so that the client initiates the rotation                                                                                                            |
 | `prometheusDataplane`              | Changes responses to from Prometheus to be compliant with the dataplane specification. In particular it sets the numeric Field.Name from 'Value' to the value of the `__name__` label when present. |
+| `alertStateHistoryLokiSecondary`   | Enable alert state history to be written to an external loki instance in addition to Grafana annotations.                                                                                           |
+| `alertStateHistoryLokiPrimary`     | Enable usage of a remote Loki instance as the primary source for state history reads.                                                                                                               |
+| `alertStateHistoryLokiOnly`        | Allow Grafana annotations emitted by alerting to be disabled completely when remote Loki is in place.                                                                                               |
 
 ## Development feature toggles
 

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -87,4 +87,7 @@ export interface FeatureToggles {
   clientTokenRotation?: boolean;
   disableElasticsearchBackendExploreQuery?: boolean;
   prometheusDataplane?: boolean;
+  alertStateHistoryLokiSecondary?: boolean;
+  alertStateHistoryLokiPrimary?: boolean;
+  alertStateHistoryLokiOnly?: boolean;
 }

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -461,7 +461,7 @@ var (
 			Owner:       grafanaObservabilityMetricsSquad,
 		},
 		{
-			Name:        "alertStateHistoryDualWrites",
+			Name:        "alertStateHistoryLokiSecondary",
 			Description: "Enable alert state history to be written to an external loki instance in addition to Grafana annotations.",
 			State:       FeatureStateAlpha,
 			Owner:       grafanaAlertingSquad,
@@ -473,7 +473,7 @@ var (
 			Owner:       grafanaAlertingSquad,
 		},
 		{
-			Name:        "alertStateHistoryDisableAnnotations",
+			Name:        "alertStateHistoryLokiOnly",
 			Description: "Allow Grafana annotations emitted by alerting to be disabled completely when remote Loki is in place.",
 			State:       FeatureStateAlpha,
 			Owner:       grafanaAlertingSquad,

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -460,5 +460,23 @@ var (
 			State:       FeatureStateAlpha,
 			Owner:       grafanaObservabilityMetricsSquad,
 		},
+		{
+			Name:        "alertStateHistoryDualWrites",
+			Description: "Enable alert state history to be written to an external loki instance in addition to Grafana annotations.",
+			State:       FeatureStateAlpha,
+			Owner:       grafanaAlertingSquad,
+		},
+		{
+			Name:        "alertStateHistoryLokiPrimary",
+			Description: "Enable usage of a remote Loki instance as the primary source for state history reads.",
+			State:       FeatureStateAlpha,
+			Owner:       grafanaAlertingSquad,
+		},
+		{
+			Name:        "alertStateHistoryDisableAnnotations",
+			Description: "Allow Grafana annotations emitted by alerting to be disabled completely when remote Loki is in place.",
+			State:       FeatureStateAlpha,
+			Owner:       grafanaAlertingSquad,
+		},
 	}
 )

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -462,19 +462,19 @@ var (
 		},
 		{
 			Name:        "alertStateHistoryLokiSecondary",
-			Description: "Enable alert state history to be written to an external loki instance in addition to Grafana annotations.",
+			Description: "Enable Grafana to write alert state history to an external Loki instance in addition to Grafana annotations.",
 			State:       FeatureStateAlpha,
 			Owner:       grafanaAlertingSquad,
 		},
 		{
 			Name:        "alertStateHistoryLokiPrimary",
-			Description: "Enable usage of a remote Loki instance as the primary source for state history reads.",
+			Description: "Enable a remote Loki instance as the primary source for state history reads.",
 			State:       FeatureStateAlpha,
 			Owner:       grafanaAlertingSquad,
 		},
 		{
 			Name:        "alertStateHistoryLokiOnly",
-			Description: "Allow Grafana annotations emitted by alerting to be disabled completely when remote Loki is in place.",
+			Description: "Disable Grafana alerts from emitting annotations when a remote Loki instance is available.",
 			State:       FeatureStateAlpha,
 			Owner:       grafanaAlertingSquad,
 		},

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -68,3 +68,6 @@ influxdbBackendMigration,alpha,@grafana/observability-metrics,false,false,false,
 clientTokenRotation,alpha,@grafana/grafana-authnz-team,false,false,false,false
 disableElasticsearchBackendExploreQuery,beta,@grafana/observability-logs,false,false,false,false
 prometheusDataplane,alpha,@grafana/observability-metrics,false,false,false,false
+alertStateHistoryLokiSecondary,alpha,@grafana/alerting-squad,false,false,false,false
+alertStateHistoryLokiPrimary,alpha,@grafana/alerting-squad,false,false,false,false
+alertStateHistoryLokiOnly,alpha,@grafana/alerting-squad,false,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -282,4 +282,16 @@ const (
 	// FlagPrometheusDataplane
 	// Changes responses to from Prometheus to be compliant with the dataplane specification. In particular it sets the numeric Field.Name from &#39;Value&#39; to the value of the `__name__` label when present.
 	FlagPrometheusDataplane = "prometheusDataplane"
+
+	// FlagAlertStateHistoryLokiSecondary
+	// Enable alert state history to be written to an external loki instance in addition to Grafana annotations.
+	FlagAlertStateHistoryLokiSecondary = "alertStateHistoryLokiSecondary"
+
+	// FlagAlertStateHistoryLokiPrimary
+	// Enable usage of a remote Loki instance as the primary source for state history reads.
+	FlagAlertStateHistoryLokiPrimary = "alertStateHistoryLokiPrimary"
+
+	// FlagAlertStateHistoryLokiOnly
+	// Allow Grafana annotations emitted by alerting to be disabled completely when remote Loki is in place.
+	FlagAlertStateHistoryLokiOnly = "alertStateHistoryLokiOnly"
 )

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -284,14 +284,14 @@ const (
 	FlagPrometheusDataplane = "prometheusDataplane"
 
 	// FlagAlertStateHistoryLokiSecondary
-	// Enable alert state history to be written to an external loki instance in addition to Grafana annotations.
+	// Enable Grafana to write alert state history to an external Loki instance in addition to Grafana annotations.
 	FlagAlertStateHistoryLokiSecondary = "alertStateHistoryLokiSecondary"
 
 	// FlagAlertStateHistoryLokiPrimary
-	// Enable usage of a remote Loki instance as the primary source for state history reads.
+	// Enable a remote Loki instance as the primary source for state history reads.
 	FlagAlertStateHistoryLokiPrimary = "alertStateHistoryLokiPrimary"
 
 	// FlagAlertStateHistoryLokiOnly
-	// Allow Grafana annotations emitted by alerting to be disabled completely when remote Loki is in place.
+	// Disable Grafana alerts from emitting annotations when a remote Loki instance is available.
 	FlagAlertStateHistoryLokiOnly = "alertStateHistoryLokiOnly"
 )

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -453,7 +453,7 @@ func applyStateHistoryFeatureToggles(cfg *setting.UnifiedAlertingStateHistorySet
 		// If we cannot even treat Loki as a secondary, we must use annotations only.
 		if backend == historian.BackendTypeMultiple || backend == historian.BackendTypeLoki {
 			logger.Info("Forcing Annotation backend due to state history feature toggles")
-			cfg.Backend = "annotations"
+			cfg.Backend = historian.BackendTypeAnnotations.String()
 			cfg.MultiPrimary = ""
 			cfg.MultiSecondaries = make([]string, 0)
 		}
@@ -463,15 +463,15 @@ func applyStateHistoryFeatureToggles(cfg *setting.UnifiedAlertingStateHistorySet
 		// If we're using multiple backends, Loki must be the secondary.
 		if backend == historian.BackendTypeMultiple {
 			logger.Info("Coercing Loki to a secondary backend due to state history feature toggles")
-			cfg.MultiPrimary = "annotations"
-			cfg.MultiSecondaries = []string{"loki"}
+			cfg.MultiPrimary = historian.BackendTypeAnnotations.String()
+			cfg.MultiSecondaries = []string{historian.BackendTypeLoki.String()}
 		}
 		// If we're using loki, we are only allowed to use it as a secondary. Dual write to it, plus annotations.
 		if backend == historian.BackendTypeLoki {
 			logger.Info("Coercing Loki to dual writes with a secondary backend due to state history feature toggles")
-			cfg.Backend = "multiple"
-			cfg.MultiPrimary = "annotations"
-			cfg.MultiSecondaries = []string{"loki"}
+			cfg.Backend = historian.BackendTypeMultiple.String()
+			cfg.MultiPrimary = historian.BackendTypeAnnotations.String()
+			cfg.MultiSecondaries = []string{historian.BackendTypeLoki.String()}
 		}
 		return
 	}
@@ -479,9 +479,9 @@ func applyStateHistoryFeatureToggles(cfg *setting.UnifiedAlertingStateHistorySet
 		// If we're not allowed to use Loki only, make it the primary but keep the annotation writes.
 		if backend == historian.BackendTypeLoki {
 			logger.Info("Forcing dual writes to Loki and Annotations due to state history feature toggles")
-			cfg.Backend = "multiple"
-			cfg.MultiPrimary = "loki"
-			cfg.MultiSecondaries = []string{"annotations"}
+			cfg.Backend = historian.BackendTypeMultiple.String()
+			cfg.MultiPrimary = historian.BackendTypeLoki.String()
+			cfg.MultiSecondaries = []string{historian.BackendTypeAnnotations.String()}
 		}
 		return
 	}

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -449,7 +449,7 @@ func applyStateHistoryFeatureToggles(cfg *setting.UnifiedAlertingStateHistorySet
 	// If all toggles are enabled, we listen to the state history config as written.
 	// If any of them are disabled, we ignore the configured backend and treat the toggles as an override.
 	// If multiple toggles are disabled, we go with the most "restrictive" one.
-	if !ft.IsEnabled("alertStateHistoryLokiSecondary") {
+	if !ft.IsEnabled(featuremgmt.FlagAlertStateHistoryLokiSecondary) {
 		// If we cannot even treat Loki as a secondary, we must use annotations only.
 		if backend == historian.BackendTypeMultiple || backend == historian.BackendTypeLoki {
 			logger.Info("Forcing Annotation backend due to state history feature toggles")
@@ -459,7 +459,7 @@ func applyStateHistoryFeatureToggles(cfg *setting.UnifiedAlertingStateHistorySet
 		}
 		return
 	}
-	if !ft.IsEnabled("alertStateHistoryLokiPrimary") {
+	if !ft.IsEnabled(featuremgmt.FlagAlertStateHistoryLokiPrimary) {
 		// If we're using multiple backends, Loki must be the secondary.
 		if backend == historian.BackendTypeMultiple {
 			logger.Info("Coercing Loki to a secondary backend due to state history feature toggles")
@@ -475,7 +475,7 @@ func applyStateHistoryFeatureToggles(cfg *setting.UnifiedAlertingStateHistorySet
 		}
 		return
 	}
-	if !ft.IsEnabled("alertStateHistoryLokiOnly") {
+	if !ft.IsEnabled(featuremgmt.FlagAlertStateHistoryLokiOnly) {
 		// If we're not allowed to use Loki only, make it the primary but keep the annotation writes.
 		if backend == historian.BackendTypeLoki {
 			logger.Info("Forcing dual writes to Loki and Annotations due to state history feature toggles")

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -210,7 +210,10 @@ func (ng *AlertNG) init() error {
 		Tracer:               ng.tracer,
 	}
 
-	history, err := configureHistorianBackend(initCtx, ng.Cfg.UnifiedAlerting.StateHistory, ng.FeatureToggles, ng.annotationsRepo, ng.dashboardService, ng.store, ng.Metrics.GetHistorianMetrics(), ng.Log)
+	// There are a set of feature toggles available that act as short-circuits for common configurations.
+	// If any are set, override the config accordingly.
+	applyStateHistoryFeatureToggles(&ng.Cfg.UnifiedAlerting.StateHistory, ng.FeatureToggles, ng.Log)
+	history, err := configureHistorianBackend(initCtx, ng.Cfg.UnifiedAlerting.StateHistory, ng.annotationsRepo, ng.dashboardService, ng.store, ng.Metrics.GetHistorianMetrics(), ng.Log)
 	if err != nil {
 		return err
 	}
@@ -380,15 +383,11 @@ type Historian interface {
 	state.Historian
 }
 
-func configureHistorianBackend(ctx context.Context, cfg setting.UnifiedAlertingStateHistorySettings, ft featuremgmt.FeatureToggles, ar annotations.Repository, ds dashboards.DashboardService, rs historian.RuleStore, met *metrics.Historian, l log.Logger) (Historian, error) {
+func configureHistorianBackend(ctx context.Context, cfg setting.UnifiedAlertingStateHistorySettings, ar annotations.Repository, ds dashboards.DashboardService, rs historian.RuleStore, met *metrics.Historian, l log.Logger) (Historian, error) {
 	if !cfg.Enabled {
 		met.Info.WithLabelValues("noop").Set(0)
 		return historian.NewNopHistorian(), nil
 	}
-
-	// There are a set of feature toggles available that act as short-circuits for common configurations.
-	// If any are set, override the config accordingly.
-	applyFeatureToggleOverrides(&cfg, ft)
 
 	backend, err := historian.ParseBackendType(cfg.Backend)
 	if err != nil {
@@ -399,7 +398,7 @@ func configureHistorianBackend(ctx context.Context, cfg setting.UnifiedAlertingS
 	if backend == historian.BackendTypeMultiple {
 		primaryCfg := cfg
 		primaryCfg.Backend = cfg.MultiPrimary
-		primary, err := configureHistorianBackend(ctx, primaryCfg, ft, ar, ds, rs, met, l)
+		primary, err := configureHistorianBackend(ctx, primaryCfg, ar, ds, rs, met, l)
 		if err != nil {
 			return nil, fmt.Errorf("multi-backend target \"%s\" was misconfigured: %w", cfg.MultiPrimary, err)
 		}
@@ -408,7 +407,7 @@ func configureHistorianBackend(ctx context.Context, cfg setting.UnifiedAlertingS
 		for _, b := range cfg.MultiSecondaries {
 			secCfg := cfg
 			secCfg.Backend = b
-			sec, err := configureHistorianBackend(ctx, secCfg, ft, ar, ds, rs, met, l)
+			sec, err := configureHistorianBackend(ctx, secCfg, ar, ds, rs, met, l)
 			if err != nil {
 				return nil, fmt.Errorf("multi-backend target \"%s\" was miconfigured: %w", b, err)
 			}
@@ -443,7 +442,8 @@ func configureHistorianBackend(ctx context.Context, cfg setting.UnifiedAlertingS
 	return nil, fmt.Errorf("unrecognized state history backend: %s", backend)
 }
 
-func applyFeatureToggleOverrides(cfg *setting.UnifiedAlertingStateHistorySettings, ft featuremgmt.FeatureToggles) {
+// applyStateHistoryFeatureToggles edits state history configuration to comply with currently active feature toggles.
+func applyStateHistoryFeatureToggles(cfg *setting.UnifiedAlertingStateHistorySettings, ft featuremgmt.FeatureToggles, logger log.Logger) {
 	// These feature toggles represent specific, common backend configurations.
 	// If all toggles are enabled, we listen to the state history config as written.
 	// If any of them are disabled, we ignore the configured backend and treat the toggles as an override.

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -391,6 +391,12 @@ func configureHistorianBackend(ctx context.Context, cfg setting.UnifiedAlertingS
 		return nil, err
 	}
 
+	ftMsg := "Alternate state history backend was configured but feature flag is not yet enabled, ignoring"
+	if !ft.IsEnabled("alertStateHistoryDualWrites") {
+		backend = historian.BackendTypeAnnotations
+		l.Warn(ftMsg, "toggle", "alertStateHistoryDualWrites", "configured", cfg.Backend, "actual", historian.BackendTypeAnnotations)
+	}
+
 	met.Info.WithLabelValues(backend.String()).Set(1)
 	if backend == historian.BackendTypeMultiple {
 		primaryCfg := cfg

--- a/pkg/services/ngalert/ngalert_test.go
+++ b/pkg/services/ngalert/ngalert_test.go
@@ -192,7 +192,7 @@ grafana_alerting_state_history_info{backend="noop"} 0
 }
 
 func ashTogglesOn() featuremgmt.FeatureToggles {
-	return toggles("alertStateHistoryDualWrites", "alertStateHistoryLokiPrimary", "alertStateHistoryDisableAnnotations")
+	return toggles("alertStateHistoryLokiSecondary", "alertStateHistoryLokiPrimary", "alertStateHistoryLokiOnly")
 }
 
 func toggles(ns ...string) featuremgmt.FeatureToggles {

--- a/pkg/setting/setting_unified_alerting.go
+++ b/pkg/setting/setting_unified_alerting.go
@@ -137,7 +137,7 @@ func (cfg *Cfg) readUnifiedAlertingEnabledSetting(section *ini.Section) (*bool, 
 	// than disable it. This issue can be found here
 	hasEnabled := section.Key("enabled").Value() != ""
 	if !hasEnabled {
-		// TODO: Remove in Grafana v9
+		// TODO: Remove in Grafana v10
 		if cfg.IsFeatureToggleEnabled("ngalert") {
 			cfg.Logger.Warn("ngalert feature flag is deprecated: use unified alerting enabled setting instead")
 			// feature flag overrides the legacy alerting setting


### PR DESCRIPTION
**What is this feature?**

Some operators prefer to control Grafana using the proper feature toggle system rather than plain configuration.

This PR adds 3 first-class feature toggles for state history, that represent a typical progression of enablement:
1. Toggle 1 allows Loki as a secondary backend
2. Toggle 2 allows Loki to be primarily used for queries, with backup writes to annotations
3. Toggle 3 allows full control of the backend.

Depending on the level of restrictiveness chosen, backend types may be coerced to the closest allowable thing. When multiple toggles are disabled, we respect the most restrictive one.

**Why do we need this feature?**

Helps operators test out the system better, as a staged rollout.

Grafana now ships with smarter presets for "suggested" configurations.

**Who is this feature for?**

Grafana Operators wishing to configure Loki-based state history.

**Which issue(s) does this PR fix?**:

n/a

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
- [x] There are no known compatibility issues with older supported versions of Grafana, or plugins.
- [x] It passes the [Hosted Grafana feature readiness review](https://docs.google.com/document/d/1QL9Ly8KnXzpb6ISbg49pTODRO5mhA5tkkfIZVX6pqQU/edit) for observability, scalability, performance, and security.