### PR TITLE
Logs: Position LogRowMenu sticky to be able to use it in scrollable containers

### DIFF
--- a/public/app/features/logs/components/LogRowMessage.tsx
+++ b/public/app/features/logs/components/LogRowMessage.tsx
@@ -109,7 +109,6 @@ export class LogRowMessage extends PureComponent<Props> {
       wrapLogMessage,
       prettifyLogMessage,
       onToggleContext,
-      app,
       logsSortOrder,
       showContextToggle,
       getLogRowContextUi,
@@ -118,7 +117,6 @@ export class LogRowMessage extends PureComponent<Props> {
     const { hasAnsi, raw } = row;
     const restructuredEntry = restructureLog(raw, prettifyLogMessage);
     const shouldShowContextToggle = showContextToggle ? showContextToggle(row) : false;
-    const inExplore = app === CoreApp.Explore;
 
     return (
       <>

--- a/public/app/features/logs/components/LogRowMessage.tsx
+++ b/public/app/features/logs/components/LogRowMessage.tsx
@@ -161,16 +161,7 @@ export class LogRowMessage extends PureComponent<Props> {
           </div>
         </td>
         {showRowMenu && (
-          <td
-            className={cx('log-row-menu-cell', styles.logRowMenuCell, {
-              [styles.logRowMenuCellDefaultPosition]: !inExplore,
-              [styles.logRowMenuCellExplore]: inExplore && !shouldShowContextToggle && !wrapLogMessage,
-              [styles.logRowMenuCellExploreWithContextButton]: inExplore && shouldShowContextToggle && !wrapLogMessage,
-              [styles.logRowMenuCellExploreWrapped]: inExplore && !shouldShowContextToggle && wrapLogMessage,
-              [styles.logRowMenuCellExploreWithContextButtonWrapped]:
-                inExplore && shouldShowContextToggle && wrapLogMessage,
-            })}
-          >
+          <td className={cx('log-row-menu-cell', styles.logRowMenuCell)}>
             <span
               className={cx('log-row-menu', styles.rowMenu, {
                 [styles.rowMenuWithContextButton]: shouldShowContextToggle,

--- a/public/app/features/logs/components/LogRowMessage.tsx
+++ b/public/app/features/logs/components/LogRowMessage.tsx
@@ -164,8 +164,11 @@ export class LogRowMessage extends PureComponent<Props> {
           <td
             className={cx('log-row-menu-cell', styles.logRowMenuCell, {
               [styles.logRowMenuCellDefaultPosition]: !inExplore,
-              [styles.logRowMenuCellExplore]: inExplore && !shouldShowContextToggle,
-              [styles.logRowMenuCellExploreWithContextButton]: inExplore && shouldShowContextToggle,
+              [styles.logRowMenuCellExplore]: inExplore && !shouldShowContextToggle && !wrapLogMessage,
+              [styles.logRowMenuCellExploreWithContextButton]: inExplore && shouldShowContextToggle && !wrapLogMessage,
+              [styles.logRowMenuCellExploreWrapped]: inExplore && !shouldShowContextToggle && wrapLogMessage,
+              [styles.logRowMenuCellExploreWithContextButtonWrapped]:
+                inExplore && shouldShowContextToggle && wrapLogMessage,
             })}
           >
             <span

--- a/public/app/features/logs/components/getLogRowStyles.ts
+++ b/public/app/features/logs/components/getLogRowStyles.ts
@@ -70,7 +70,7 @@ export const getLogRowStyles = memoizeOne((theme: GrafanaTheme2) => {
       font-family: ${theme.typography.fontFamilyMonospace};
       font-size: ${theme.typography.bodySmall.fontSize};
       width: 100%;
-      margin-bottom: ${theme.spacing(2.25)}; // to make sure the last row is not cut off
+      margin-bottom: ${theme.spacing(2.25)};
     `,
     contextBackground: css`
       background: ${hoverBgColor};

--- a/public/app/features/logs/components/getLogRowStyles.ts
+++ b/public/app/features/logs/components/getLogRowStyles.ts
@@ -245,21 +245,11 @@ export const getLogRowStyles = memoizeOne((theme: GrafanaTheme2) => {
       position: sticky;
       z-index: ${theme.zIndex.dropdown};
       margin-top: -${theme.spacing(0.125)};
-    `,
-    logRowMenuCellDefaultPosition: css`
-      right: 40px;
-    `,
-    logRowMenuCellExplore: css`
-      right: calc(32px + ${theme.spacing(1)});
-    `,
-    logRowMenuCellExploreWithContextButton: css`
-      right: calc(72px + ${theme.spacing(1)});165
-    `,
-    logRowMenuCellExploreWrapped: css`
-      right: calc(124px + ${theme.spacing(1)});
-    `,
-    logRowMenuCellExploreWithContextButtonWrapped: css`
-      right: calc(165px + ${theme.spacing(1)});
+      right: 0px;
+
+      & > span {
+        transform: translateX(-100%);
+      }
     `,
     logLine: css`
       background-color: transparent;

--- a/public/app/features/logs/components/getLogRowStyles.ts
+++ b/public/app/features/logs/components/getLogRowStyles.ts
@@ -70,7 +70,7 @@ export const getLogRowStyles = memoizeOne((theme: GrafanaTheme2) => {
       font-family: ${theme.typography.fontFamilyMonospace};
       font-size: ${theme.typography.bodySmall.fontSize};
       width: 100%;
-      margin-bottom: ${theme.spacing(2.25)};
+      margin-bottom: ${theme.spacing(2.25)}; /* This is to make sure the last row's LogRowMenu is not cut off. */
     `,
     contextBackground: css`
       background: ${hoverBgColor};

--- a/public/app/features/logs/components/getLogRowStyles.ts
+++ b/public/app/features/logs/components/getLogRowStyles.ts
@@ -70,6 +70,7 @@ export const getLogRowStyles = memoizeOne((theme: GrafanaTheme2) => {
       font-family: ${theme.typography.fontFamilyMonospace};
       font-size: ${theme.typography.bodySmall.fontSize};
       width: 100%;
+      margin-bottom: ${theme.spacing(2.25)}; // to make sure the last row is not cut off
     `,
     contextBackground: css`
       background: ${hoverBgColor};
@@ -241,17 +242,24 @@ export const getLogRowStyles = memoizeOne((theme: GrafanaTheme2) => {
       width: ${theme.spacing(10)};
     `,
     logRowMenuCell: css`
-      position: absolute;
+      position: sticky;
+      z-index: ${theme.zIndex.dropdown};
       margin-top: -${theme.spacing(0.125)};
     `,
     logRowMenuCellDefaultPosition: css`
       right: 40px;
     `,
     logRowMenuCellExplore: css`
-      right: calc(115px + ${theme.spacing(1)});
+      right: calc(32px + ${theme.spacing(1)});
     `,
     logRowMenuCellExploreWithContextButton: css`
-      right: calc(155px + ${theme.spacing(1)});
+      right: calc(72px + ${theme.spacing(1)});165
+    `,
+    logRowMenuCellExploreWrapped: css`
+      right: calc(124px + ${theme.spacing(1)});
+    `,
+    logRowMenuCellExploreWithContextButtonWrapped: css`
+      right: calc(165px + ${theme.spacing(1)});
     `,
     logLine: css`
       background-color: transparent;


### PR DESCRIPTION
**What is this feature?**

Due to it's absolute position, some overflow and CSS magic the LogRowMenu was buggy when used in a vertical scrollable component. This is fixed by positioning the menu sticky and not absolute.