### PR TITLE
SectionNav: Remove root section right margin

### DIFF
--- a/public/app/core/components/PageNew/SectionNavItem.tsx
+++ b/public/app/core/components/PageNew/SectionNavItem.tsx
@@ -116,8 +116,6 @@ const getStyles = (theme: GrafanaTheme2) => {
       fontSize: theme.typography.h5.fontSize,
       marginTop: theme.spacing(2),
       fontWeight: theme.typography.fontWeightMedium,
-      // To make room for section toggle button when section is active
-      marginRight: theme.spacing(4),
     }),
     noRootMargin: css({
       marginBottom: 0,


### PR DESCRIPTION
Removes the right side margin on root section, it was added to not make the section toggle intersect the section highlight background. But the margin made "Performance testing" wrap. I don't think the margin is needed, it intersects but does not look terrible and using the toggle when the root section is active should be very uncommon. 

![image](https://user-images.githubusercontent.com/10999/228462952-537a807d-6422-4829-b29b-18862a311be9.png)


There is another PR that is also waiting review: https://github.com/grafana/grafana/pull/65082 
