### PR TITLE
NestedFolders: Support moving folders into other folders

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -3292,9 +3292,6 @@ exports[`better eslint`] = {
     "public/app/features/search/hooks/useSearchKeyboardSelection.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
-    "public/app/features/search/page/components/MoveToFolderModal.tsx:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
-    ],
     "public/app/features/search/page/components/columns.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"],

--- a/public/app/features/manage-dashboards/state/actions.ts
+++ b/public/app/features/manage-dashboards/state/actions.ts
@@ -182,20 +182,24 @@ const getDataSourceOptions = (input: { pluginId: string; pluginName: string }, i
   }
 };
 
-export function moveFolders(folderUids: string[], toFolder: FolderInfo) {
-  const tasks = [];
+export async function moveFolders(folderUIDs: string[], toFolder: FolderInfo) {
+  const result = {
+    totalCount: folderUIDs.length,
+    successCount: 0,
+  };
 
-  for (const uid of folderUids) {
-    tasks.push(createTask(moveFolder, true, uid, toFolder));
+  for (const folderUID of folderUIDs) {
+    try {
+      const newFolderDTO = await moveFolder(folderUID, toFolder);
+      if (newFolderDTO !== null) {
+        result.successCount += 1;
+      }
+    } catch (err) {
+      console.error('Failed to move a folder', err);
+    }
   }
 
-  return executeInOrder(tasks).then((result: any) => {
-    return {
-      totalCount: result.length,
-      successCount: result.filter((res: any) => res.succeeded).length,
-      // alreadyInFolderCount: result.filter((res: any) => res.alreadyInFolder).length,
-    };
-  });
+  return result;
 }
 
 export function moveDashboards(dashboardUids: string[], toFolder: FolderInfo) {

--- a/public/app/features/manage-dashboards/state/actions.ts
+++ b/public/app/features/manage-dashboards/state/actions.ts
@@ -182,6 +182,22 @@ const getDataSourceOptions = (input: { pluginId: string; pluginName: string }, i
   }
 };
 
+export function moveFolders(folderUids: string[], toFolder: FolderInfo) {
+  const tasks = [];
+
+  for (const uid of folderUids) {
+    tasks.push(createTask(moveFolder, true, uid, toFolder));
+  }
+
+  return executeInOrder(tasks).then((result: any) => {
+    return {
+      totalCount: result.length,
+      successCount: result.filter((res: any) => res.succeeded).length,
+      // alreadyInFolderCount: result.filter((res: any) => res.alreadyInFolder).length,
+    };
+  });
+}
+
 export function moveDashboards(dashboardUids: string[], toFolder: FolderInfo) {
   const tasks = [];
 
@@ -284,6 +300,13 @@ export function createFolder(payload: any) {
   return getBackendSrv().post('/api/folders', payload);
 }
 
+export function moveFolder(uid: string, toFolder: FolderInfo) {
+  const payload = {
+    parentUid: toFolder.uid,
+  };
+  return getBackendSrv().post(`/api/folders/${uid}/move`, payload);
+}
+
 export const SLICE_FOLDER_RESULTS_TO = 1000;
 
 export function searchFolders(
@@ -311,7 +334,7 @@ export function deleteDashboard(uid: string, showSuccessAlert: boolean) {
   return getBackendSrv().delete<DeleteDashboardResponse>(`/api/dashboards/uid/${uid}`, { showSuccessAlert });
 }
 
-function executeInOrder(tasks: any[]) {
+function executeInOrder(tasks: any[]): Promise<unknown> {
   return tasks.reduce((acc, task) => {
     return Promise.resolve(acc).then(task);
   }, []);

--- a/public/app/features/manage-dashboards/state/actions.ts
+++ b/public/app/features/manage-dashboards/state/actions.ts
@@ -308,7 +308,7 @@ export function moveFolder(uid: string, toFolder: FolderInfo) {
   const payload = {
     parentUid: toFolder.uid,
   };
-  return getBackendSrv().post(`/api/folders/${uid}/move`, payload);
+  return getBackendSrv().post(`/api/folders/${uid}/move`, payload, { showErrorAlert: false });
 }
 
 export const SLICE_FOLDER_RESULTS_TO = 1000;

--- a/public/app/features/search/page/components/ManageActions.test.tsx
+++ b/public/app/features/search/page/components/ManageActions.test.tsx
@@ -51,7 +51,7 @@ describe('ManageActions', () => {
 
       // open Move modal
       await userEvent.click(screen.getByRole('button', { name: 'Move', hidden: true }));
-      expect(screen.getByText(/Move 2 dashboards to the following folder:/i)).toBeInTheDocument();
+      expect(screen.getByText(/Move 2 dashboards to:/i)).toBeInTheDocument();
     });
 
     it('should show delete modal when user click the delete button', async () => {

--- a/public/app/features/search/page/components/ManageActions.test.tsx
+++ b/public/app/features/search/page/components/ManageActions.test.tsx
@@ -51,7 +51,7 @@ describe('ManageActions', () => {
 
       // open Move modal
       await userEvent.click(screen.getByRole('button', { name: 'Move', hidden: true }));
-      expect(screen.getByText(/Move the 2 selected dashboards to the following folder:/i)).toBeInTheDocument();
+      expect(screen.getByText(/Move 2 dashboards to the following folder:/i)).toBeInTheDocument();
     });
 
     it('should show delete modal when user click the delete button', async () => {

--- a/public/app/features/search/page/components/MoveToFolderModal.test.tsx
+++ b/public/app/features/search/page/components/MoveToFolderModal.test.tsx
@@ -1,23 +1,51 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { Provider } from 'react-redux';
 import configureMockStore from 'redux-mock-store';
+import { selectOptionInTest } from 'test/helpers/selectOptionInTest';
+
+import { selectors } from '@grafana/e2e-selectors';
+import config from 'app/core/config';
+import * as api from 'app/features/manage-dashboards/state/actions';
+
+import { DashboardSearchHit, DashboardSearchItemType } from '../../types';
 
 import { MoveToFolderModal } from './MoveToFolderModal';
 
-jest.mock('app/core/components/Select/FolderPicker', () => {
-  return {
-    FolderPicker: () => null,
-  };
-});
+// jest.mock('app/core/components/Select/FolderPicker', () => {
+//   return {
+//     FolderPicker: () => null,
+//   };
+// });
+
+function makeSelections(dashboardUIDs: string[] = [], folderUIDs: string[] = []) {
+  const dashboards = new Set(dashboardUIDs);
+  const folders = new Set(folderUIDs);
+
+  return new Map([
+    ['dashboard', dashboards],
+    ['folder', folders],
+  ]);
+}
+
+function makeDashboardSearchHit(title: string, uid: string, type = DashboardSearchItemType.DashDB): DashboardSearchHit {
+  return { title, uid, tags: [], type, url: `/d/${uid}` };
+}
 
 describe('MoveToFolderModal', () => {
+  jest
+    .spyOn(api, 'searchFolders')
+    .mockResolvedValue([
+      makeDashboardSearchHit('General', '', DashboardSearchItemType.DashFolder),
+      makeDashboardSearchHit('Folder 1', 'folder-uid-1', DashboardSearchItemType.DashFolder),
+      makeDashboardSearchHit('Folder 2', 'folder-uid-1', DashboardSearchItemType.DashFolder),
+      makeDashboardSearchHit('Folder 3', 'folder-uid-3', DashboardSearchItemType.DashFolder),
+    ]);
+
   it('should render correct title, body, dismiss-, cancel- and move-text', async () => {
-    const items = new Map();
-    const dashboardsUIDs = new Set();
-    dashboardsUIDs.add('uid1');
-    dashboardsUIDs.add('uid2');
-    items.set('dashboard', dashboardsUIDs);
+    const items = makeSelections(['dash-uid-1', 'dash-uid-2']);
+
     const mockStore = configureMockStore();
     const store = mockStore({ dashboard: { panels: [] } });
     const onMoveItems = jest.fn();
@@ -28,9 +56,110 @@ describe('MoveToFolderModal', () => {
       </Provider>
     );
 
+    // Wait for folder picker to finish rendering
+    await screen.findByText('General');
+
     expect(screen.getByRole('heading', { name: 'Choose Dashboard Folder' })).toBeInTheDocument();
-    expect(screen.getByText('Move the 2 selected dashboards to the following folder:')).toBeInTheDocument();
+    expect(screen.getByText('Move 2 dashboards to the following folder:')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Move' })).toBeInTheDocument();
+  });
+
+  it('should move dashboards, but not folders', async () => {
+    const moveDashboardsMock = jest.spyOn(api, 'moveDashboards').mockResolvedValue({
+      successCount: 2,
+      totalCount: 2,
+      alreadyInFolderCount: 0,
+    });
+
+    const moveFoldersMock = jest.spyOn(api, 'moveFolders').mockResolvedValue({
+      successCount: 1,
+      totalCount: 1,
+    });
+
+    const items = makeSelections(['dash-uid-1', 'dash-uid-2'], ['folder-uid-1']);
+
+    const mockStore = configureMockStore();
+    const store = mockStore({ dashboard: { panels: [] } });
+    const onMoveItems = jest.fn();
+
+    render(
+      <Provider store={store}>
+        <MoveToFolderModal onMoveItems={onMoveItems} results={items} onDismiss={() => {}} />
+      </Provider>
+    );
+
+    // Wait for folder picker to finish rendering
+    await screen.findByText('General');
+
+    const folderPicker = screen.getByLabelText(selectors.components.FolderPicker.input);
+    await selectOptionInTest(folderPicker, 'Folder 3');
+
+    const moveButton = screen.getByText('Move');
+    await userEvent.click(moveButton);
+
+    expect(moveDashboardsMock).toHaveBeenCalledWith(['dash-uid-1', 'dash-uid-2'], {
+      title: 'Folder 3',
+      uid: 'folder-uid-3',
+    });
+
+    expect(moveFoldersMock).not.toHaveBeenCalled();
+  });
+
+  describe('with nestedFolders feature flag', () => {
+    let originalNestedFoldersValue = config.featureToggles.nestedFolders;
+
+    beforeAll(() => {
+      originalNestedFoldersValue = config.featureToggles.nestedFolders;
+      config.featureToggles.nestedFolders = true;
+    });
+
+    afterAll(() => {
+      config.featureToggles.nestedFolders = originalNestedFoldersValue;
+    });
+
+    it('should move folders and dashboards', async () => {
+      const moveDashboardsMock = jest.spyOn(api, 'moveDashboards').mockResolvedValue({
+        successCount: 2,
+        totalCount: 2,
+        alreadyInFolderCount: 0,
+      });
+
+      const moveFoldersMock = jest.spyOn(api, 'moveFolders').mockResolvedValue({
+        successCount: 1,
+        totalCount: 1,
+      });
+
+      const items = makeSelections(['dash-uid-1', 'dash-uid-2'], ['folder-uid-1']);
+
+      const mockStore = configureMockStore();
+      const store = mockStore({ dashboard: { panels: [] } });
+      const onMoveItems = jest.fn();
+
+      render(
+        <Provider store={store}>
+          <MoveToFolderModal onMoveItems={onMoveItems} results={items} onDismiss={() => {}} />
+        </Provider>
+      );
+
+      // Wait for folder picker to finish rendering
+      await screen.findByText('General');
+
+      const folderPicker = screen.getByLabelText(selectors.components.FolderPicker.input);
+      await selectOptionInTest(folderPicker, 'Folder 3');
+
+      const moveButton = screen.getByRole('button', { name: 'Move' });
+      await userEvent.click(moveButton);
+
+      expect(moveDashboardsMock).toHaveBeenCalledWith(['dash-uid-1', 'dash-uid-2'], {
+        title: 'Folder 3',
+        uid: 'folder-uid-3',
+      });
+
+      expect(moveFoldersMock).toHaveBeenCalledWith(['folder-uid-1'], {
+        title: 'Folder 3',
+        uid: 'folder-uid-3',
+      });
+    });
   });
 });

--- a/public/app/features/search/page/components/MoveToFolderModal.test.tsx
+++ b/public/app/features/search/page/components/MoveToFolderModal.test.tsx
@@ -60,7 +60,7 @@ describe('MoveToFolderModal', () => {
     await screen.findByText('General');
 
     expect(screen.getByRole('heading', { name: 'Choose Dashboard Folder' })).toBeInTheDocument();
-    expect(screen.getByText('Move 2 dashboards to the following folder:')).toBeInTheDocument();
+    expect(screen.getByText('Move 2 dashboards to:')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Move' })).toBeInTheDocument();
   });

--- a/public/app/features/search/page/components/MoveToFolderModal.test.tsx
+++ b/public/app/features/search/page/components/MoveToFolderModal.test.tsx
@@ -51,7 +51,7 @@ describe('MoveToFolderModal', () => {
     );
 
     // Wait for folder picker to finish rendering
-    await screen.findByText('General');
+    await screen.findByText('Choose');
 
     expect(screen.getByRole('heading', { name: 'Choose Dashboard Folder' })).toBeInTheDocument();
     expect(screen.getByText('Move 2 dashboards to:')).toBeInTheDocument();
@@ -84,7 +84,7 @@ describe('MoveToFolderModal', () => {
     );
 
     // Wait for folder picker to finish rendering
-    await screen.findByText('General');
+    await screen.findByText('Choose');
 
     const folderPicker = screen.getByLabelText(selectors.components.FolderPicker.input);
     await selectOptionInTest(folderPicker, 'Folder 3');
@@ -137,7 +137,7 @@ describe('MoveToFolderModal', () => {
       );
 
       // Wait for folder picker to finish rendering
-      await screen.findByText('General');
+      await screen.findByText('Choose');
 
       const folderPicker = screen.getByLabelText(selectors.components.FolderPicker.input);
       await selectOptionInTest(folderPicker, 'Folder 3');

--- a/public/app/features/search/page/components/MoveToFolderModal.test.tsx
+++ b/public/app/features/search/page/components/MoveToFolderModal.test.tsx
@@ -13,12 +13,6 @@ import { DashboardSearchHit, DashboardSearchItemType } from '../../types';
 
 import { MoveToFolderModal } from './MoveToFolderModal';
 
-// jest.mock('app/core/components/Select/FolderPicker', () => {
-//   return {
-//     FolderPicker: () => null,
-//   };
-// });
-
 function makeSelections(dashboardUIDs: string[] = [], folderUIDs: string[] = []) {
   const dashboards = new Set(dashboardUIDs);
   const folders = new Set(folderUIDs);

--- a/public/app/features/search/page/components/MoveToFolderModal.tsx
+++ b/public/app/features/search/page/components/MoveToFolderModal.tsx
@@ -9,6 +9,7 @@ import { useAppNotification } from 'app/core/copy/appNotification';
 import { moveDashboards, moveFolders } from 'app/features/manage-dashboards/state/actions';
 import { FolderInfo } from 'app/types';
 
+import { GENERAL_FOLDER_UID } from '../../constants';
 import { OnMoveOrDeleleSelectedItems } from '../../types';
 
 interface Props {
@@ -26,7 +27,9 @@ export const MoveToFolderModal = ({ results, onMoveItems, onDismiss }: Props) =>
   const nestedFoldersEnabled = config.featureToggles.nestedFolders;
 
   const selectedDashboards = Array.from(results.get('dashboard') ?? []);
-  const selectedFolders = nestedFoldersEnabled ? Array.from(results.get('folder') ?? []) : [];
+  const selectedFolders = nestedFoldersEnabled
+    ? Array.from(results.get('folder') ?? []).filter((v) => v !== GENERAL_FOLDER_UID)
+    : [];
 
   const moveTo = async () => {
     console.log({ folder, selectedDashboards, selectedFolders });
@@ -82,24 +85,28 @@ export const MoveToFolderModal = ({ results, onMoveItems, onDismiss }: Props) =>
   };
 
   return (
-    <Modal className={styles.modal} title="Choose Dashboard Folder" icon="folder-plus" onDismiss={onDismiss}>
+    <Modal
+      className={styles.modal}
+      title={nestedFoldersEnabled ? 'Move' : 'Choose Dashboard Folder'}
+      icon="folder-plus"
+      onDismiss={onDismiss}
+    >
       <>
         <div className={styles.content}>
           {selectedFolders.length > 0 && (
             <>
-              <Alert severity={'warning'} title="Careful!">
-                Moving folders may change it and all {"it's children's"} permissions permissions
+              <Alert severity="warning" title="Careful!">
+                This may change the permission of the folders and all of it&apos;s children
               </Alert>
               <p>
-                Move the {selectedFolders.length} selected folder{selectedFolders.length === 1 ? '' : 's'} to the
-                following folder:
+                Moving {selectedFolders.length} folder{selectedFolders.length === 1 ? '' : 's'}
               </p>
             </>
           )}
+
           {selectedDashboards.length > 0 && (
             <p>
-              Move the {selectedDashboards.length} selected dashboard{selectedDashboards.length === 1 ? '' : 's'} to the
-              following folder:
+              Moving {selectedDashboards.length} dashboard{selectedDashboards.length === 1 ? '' : 's'}
             </p>
           )}
           <FolderPicker allowEmpty={true} enableCreateNew={false} onChange={(f) => setFolder(f)} />

--- a/public/app/features/search/page/components/MoveToFolderModal.tsx
+++ b/public/app/features/search/page/components/MoveToFolderModal.tsx
@@ -174,7 +174,7 @@ function notifyNestedMoveResult(
     } else {
       notifyApp.warning(
         `Partially moved ${objectLower}`,
-        `Moved ${successCount} ${objectLower}, but ${failedCount} had errors`
+        `Failed to move ${failedCount} ${objectLower} to ${destinationName}`
       );
     }
   }

--- a/public/app/features/search/page/components/MoveToFolderModal.tsx
+++ b/public/app/features/search/page/components/MoveToFolderModal.tsx
@@ -111,6 +111,7 @@ export const MoveToFolderModal = ({ results, onMoveItems, onDismiss }: Props) =>
 
   return (
     <Modal
+      isOpen
       className={styles.modal}
       title={nestedFoldersEnabled ? 'Move' : 'Choose Dashboard Folder'}
       icon="folder-plus"

--- a/public/app/features/search/page/components/MoveToFolderModal.tsx
+++ b/public/app/features/search/page/components/MoveToFolderModal.tsx
@@ -31,13 +31,14 @@ export const MoveToFolderModal = ({ results, onMoveItems, onDismiss }: Props) =>
     ? Array.from(results.get('folder') ?? []).filter((v) => v !== GENERAL_FOLDER_UID)
     : [];
 
-  const handleFolderChange = useCallback((newFolder: FolderInfo) => {
-    setFolder(newFolder);
-  }, []);
+  const handleFolderChange = useCallback(
+    (newFolder: FolderInfo) => {
+      setFolder(newFolder);
+    },
+    [setFolder]
+  );
 
   const moveTo = async () => {
-    console.log({ folder, selectedDashboards, selectedFolders });
-
     if (!folder) {
       return;
     }
@@ -141,7 +142,7 @@ export const MoveToFolderModal = ({ results, onMoveItems, onDismiss }: Props) =>
             </>
           )}
 
-          <p>Move the {thingsMoving} to the following folder:</p>
+          <p>Move {thingsMoving} to the following folder:</p>
 
           <FolderPicker allowEmpty={true} enableCreateNew={false} onChange={handleFolderChange} />
         </div>

--- a/public/app/features/search/page/components/MoveToFolderModal.tsx
+++ b/public/app/features/search/page/components/MoveToFolderModal.tsx
@@ -2,10 +2,11 @@ import { css } from '@emotion/css';
 import React, { useState } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { Button, HorizontalGroup, Modal, useStyles2 } from '@grafana/ui';
+import { Alert, Button, HorizontalGroup, Modal, useStyles2 } from '@grafana/ui';
 import { FolderPicker } from 'app/core/components/Select/FolderPicker';
+import config from 'app/core/config';
 import { useAppNotification } from 'app/core/copy/appNotification';
-import { moveDashboards } from 'app/features/manage-dashboards/state/actions';
+import { moveDashboards, moveFolders } from 'app/features/manage-dashboards/state/actions';
 import { FolderInfo } from 'app/types';
 
 import { OnMoveOrDeleleSelectedItems } from '../../types';
@@ -20,14 +21,46 @@ export const MoveToFolderModal = ({ results, onMoveItems, onDismiss }: Props) =>
   const [folder, setFolder] = useState<FolderInfo | null>(null);
   const styles = useStyles2(getStyles);
   const notifyApp = useAppNotification();
-  const selectedDashboards = Array.from(results.get('dashboard') ?? []);
   const [moving, setMoving] = useState(false);
 
-  const moveTo = () => {
-    if (folder && selectedDashboards.length) {
+  const nestedFoldersEnabled = config.featureToggles.nestedFolders;
+
+  const selectedDashboards = Array.from(results.get('dashboard') ?? []);
+  const selectedFolders = nestedFoldersEnabled ? Array.from(results.get('folder') ?? []) : [];
+
+  const moveTo = async () => {
+    console.log({ folder, selectedDashboards, selectedFolders });
+
+    if (!folder) {
+      return;
+    }
+
+    if (nestedFoldersEnabled) {
+      setMoving(true);
+
+      if (selectedDashboards.length) {
+        const moveDashboardsResult = await moveDashboards(selectedDashboards, folder);
+        console.log({ moveDashboardsResult });
+      }
+
+      if (selectedFolders.length) {
+        const moveFoldersResult = await moveFolders(selectedFolders, folder);
+        console.log({ moveFoldersResult });
+      }
+
+      notifyApp.success('something might have happened successfully');
+
+      onMoveItems();
+      setMoving(false);
+      onDismiss();
+
+      return;
+    }
+
+    if (selectedDashboards.length) {
       const folderTitle = folder.title ?? 'General';
       setMoving(true);
-      moveDashboards(selectedDashboards, folder).then((result: any) => {
+      moveDashboards(selectedDashboards, folder).then((result) => {
         if (result.successCount > 0) {
           const ending = result.successCount === 1 ? '' : 's';
           const header = `Dashboard${ending} Moved`;
@@ -49,13 +82,26 @@ export const MoveToFolderModal = ({ results, onMoveItems, onDismiss }: Props) =>
   };
 
   return (
-    <Modal className={styles.modal} title="Choose Dashboard Folder" icon="folder-plus" isOpen onDismiss={onDismiss}>
+    <Modal className={styles.modal} title="Choose Dashboard Folder" icon="folder-plus" onDismiss={onDismiss}>
       <>
         <div className={styles.content}>
-          <p>
-            Move the {selectedDashboards.length} selected dashboard{selectedDashboards.length === 1 ? '' : 's'} to the
-            following folder:
-          </p>
+          {selectedFolders.length > 0 && (
+            <>
+              <Alert severity={'warning'} title="Careful!">
+                Moving folders may change it and all {"it's children's"} permissions permissions
+              </Alert>
+              <p>
+                Move the {selectedFolders.length} selected folder{selectedFolders.length === 1 ? '' : 's'} to the
+                following folder:
+              </p>
+            </>
+          )}
+          {selectedDashboards.length > 0 && (
+            <p>
+              Move the {selectedDashboards.length} selected dashboard{selectedDashboards.length === 1 ? '' : 's'} to the
+              following folder:
+            </p>
+          )}
           <FolderPicker allowEmpty={true} enableCreateNew={false} onChange={(f) => setFolder(f)} />
         </div>
 

--- a/public/test/setupTests.ts
+++ b/public/test/setupTests.ts
@@ -5,11 +5,11 @@ import { initReactI18next } from 'react-i18next';
 
 import { matchers } from './matchers';
 
-expect.extend(matchers);
-
 failOnConsole({
   shouldFailOnLog: true,
 });
+
+expect.extend(matchers);
 
 i18next.use(initReactI18next).init({
   resources: {},

--- a/public/test/setupTests.ts
+++ b/public/test/setupTests.ts
@@ -1,10 +1,15 @@
 import '@testing-library/jest-dom';
 import i18next from 'i18next';
+import failOnConsole from 'jest-fail-on-console';
 import { initReactI18next } from 'react-i18next';
 
 import { matchers } from './matchers';
 
 expect.extend(matchers);
+
+failOnConsole({
+  shouldFailOnLog: true,
+});
 
 i18next.use(initReactI18next).init({
   resources: {},

--- a/public/test/setupTests.ts
+++ b/public/test/setupTests.ts
@@ -1,13 +1,8 @@
 import '@testing-library/jest-dom';
 import i18next from 'i18next';
-import failOnConsole from 'jest-fail-on-console';
 import { initReactI18next } from 'react-i18next';
 
 import { matchers } from './matchers';
-
-failOnConsole({
-  shouldFailOnLog: true,
-});
 
 expect.extend(matchers);
 


### PR DESCRIPTION
Updates MoveToFolderModal to work with moving folders into other folders.

- Move the Move / Cancel buttons to be right aligned, rather than in the centre.

**Behind feature flag:**
 - Changes title of the modal from "Choose Dashboard Folder" to "Move"
 - Shows a warning in the modal if you're moving a folder (i have not paid much attention to the phrasing of this, so im hoping others can offer suggestions :) )
 - Moves dashboards, then folders, sequentially to the destination
 - Shows a message depending on the result of the move:
   - If all moves were successful, the modal will close and a success toast will show
   - If any move had an error, the modal will close and a warning toast will show

**Limitations/known issues:**

When selecting an expanded folder, all it's children will be selected. When you move that selection, the folder and it's children will become _siblings_ at the destination (that is, each selected item will be moved independently to the destination)  
![image](https://user-images.githubusercontent.com/46142/228802211-34e1fa95-a9ca-4625-aa71-94be449f65ca.png)


To move just the folder and preserve it's children's structure, either unselect the children, or collapse the folder first then select it  
![image](https://user-images.githubusercontent.com/46142/228802397-a2073a5c-d367-404f-a6f0-7723d81a09e6.png)



One dashboard selected:  
![4996_2023-03-29-12-37_firefox](https://user-images.githubusercontent.com/46142/228526491-b8f6e659-6f48-47a7-8e0d-2742dce0210f.png)

Multiple dashboards selected:  
![4997_2023-03-29-12-37_firefox](https://user-images.githubusercontent.com/46142/228526495-e1eca568-fc73-4fb5-8826-9b4d052ff014.png)

Moving folders and dashboards:  
![4998_2023-03-29-12-37_firefox](https://user-images.githubusercontent.com/46142/228526501-5641853c-d14e-499b-aeaa-e4991e6b4e7a.png)



Moving multiple dashboards success:  
![5001_2023-03-29-12-39_firefox](https://user-images.githubusercontent.com/46142/228526507-73a3068d-59e4-436f-9d2e-7dceb18acfd2.png)

Moving mixed items success:  
![4999_2023-03-29-12-38_firefox](https://user-images.githubusercontent.com/46142/228526515-1c9f38e4-d8c0-43c7-b0ee-c6a800594e13.png)

One folder failed to move (I tried to move it into itself):  
![5000_2023-03-29-12-38_firefox](https://user-images.githubusercontent.com/46142/228526530-7eb2f51e-e482-4d0c-b157-f04b43311448.png)




Fixes https://github.com/grafana/grafana/issues/65288
