### PR TITLE
Loki: Fix autocomplete situations with multiple escaped quotes

### DIFF
--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.test.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.test.ts
@@ -154,6 +154,12 @@ describe('situation', () => {
       type: 'IN_LABEL_SELECTOR_NO_LABEL_NAME',
       otherLabels: [{ name: 'one', value: 'val\\"1', op: '=' }],
     });
+
+    // double-quoted label-values with escape and multiple quotes
+    assertSituation('{one="val\\"1\\"",^}', {
+      type: 'IN_LABEL_SELECTOR_NO_LABEL_NAME',
+      otherLabels: [{ name: 'one', value: 'val"1"', op: '=' }],
+    });
   });
 
   it('identifies AFTER_UNWRAP autocomplete situations', () => {

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.ts
@@ -63,14 +63,14 @@ function parseStringLiteral(text: string): string {
   if (text.startsWith('"') && text.endsWith('"')) {
     // NOTE: this is not 100% perfect, we only unescape the double-quote,
     // there might be other characters too
-    return inside.replace(/\\"/, '"');
+    return inside.replace(/\\"/gm, '"');
   }
 
   // Single quotes
   if (text.startsWith("'") && text.endsWith("'")) {
     // NOTE: this is not 100% perfect, we only unescape the single-quote,
     // there might be other characters too
-    return inside.replace(/\\'/, "'");
+    return inside.replace(/\\'/gm, "'");
   }
 
   // Backticks


### PR DESCRIPTION
**What is this feature?**

This PR fixes situations where autocomplete was broken for situations with multiple escaped quotes.

**Special notes for your reviewer:**

1. Use Grafana with Loki devevn
2. Start typing the `{job="\"grafana/data\"", ` query.
3. Without the fix no more suggestions are provided.