### PR TITLE
Alerting: Implement template preview for Grafana AlertManager

### DIFF
--- a/public/app/features/alerting/unified/api/onCallApi.ts
+++ b/public/app/features/alerting/unified/api/onCallApi.ts
@@ -16,7 +16,6 @@ export const onCallApi = alertingApi.injectEndpoints({
         const integrations = await fetchOnCallIntegrations();
         return { data: integrations };
       },
-      providesTags: ['AlertmanagerChoice'],
     }),
   }),
 });

--- a/public/app/features/alerting/unified/api/templateApi.ts
+++ b/public/app/features/alerting/unified/api/templateApi.ts
@@ -16,13 +16,13 @@ export interface TemplatePreviewResponse {
   errors?: TemplatePreviewErrors[];
 }
 
-type AnnoField = {
+export interface KeyValueField {
   key: string;
   value: string;
-};
+}
 export interface AlertField {
-  annotations: AnnoField[];
-  labels: AnnoField[];
+  annotations: KeyValueField[];
+  labels: KeyValueField[];
 }
 
 export const templatesApi = alertingApi.injectEndpoints({

--- a/public/app/features/alerting/unified/api/templateApi.ts
+++ b/public/app/features/alerting/unified/api/templateApi.ts
@@ -27,13 +27,15 @@ export interface AlertFields {
 
 export const templatesApi = alertingApi.injectEndpoints({
   endpoints: (build) => ({
-    previewPayload: build.mutation<TemplatesPreviewResponse, { template: string; payload: AlertFields[] }>({
-      query: ({ template, payload }) => ({
-        url: previewTemplateUrl,
-        data: { template: template, data: payload },
-        method: 'POST',
-      }),
-    }),
+    previewPayload: build.mutation<TemplatesPreviewResponse, { template: string; alerts: AlertFields[]; name: string }>(
+      {
+        query: ({ template, alerts, name }) => ({
+          url: previewTemplateUrl,
+          data: { template: template, alerts: alerts, name: name },
+          method: 'POST',
+        }),
+      }
+    ),
   }),
 });
 

--- a/public/app/features/alerting/unified/api/templateApi.ts
+++ b/public/app/features/alerting/unified/api/templateApi.ts
@@ -11,7 +11,7 @@ export interface TemplatePreviewErrors {
   message: string;
   kind: string;
 }
-export interface TemplatesPreviewResponse {
+export interface TemplatePreviewResponse {
   results?: TemplatePreviewResult[];
   errors?: TemplatePreviewErrors[];
 }
@@ -27,7 +27,7 @@ export interface AlertField {
 
 export const templatesApi = alertingApi.injectEndpoints({
   endpoints: (build) => ({
-    previewPayload: build.mutation<TemplatesPreviewResponse, { template: string; alerts: AlertField[]; name: string }>({
+    previewTemplate: build.mutation<TemplatePreviewResponse, { template: string; alerts: AlertField[]; name: string }>({
       query: ({ template, alerts, name }) => ({
         url: previewTemplateUrl,
         data: { template: template, alerts: alerts, name: name },
@@ -37,4 +37,4 @@ export const templatesApi = alertingApi.injectEndpoints({
   }),
 });
 
-export const { usePreviewPayloadMutation } = templatesApi;
+export const { usePreviewTemplateMutation } = templatesApi;

--- a/public/app/features/alerting/unified/api/templateApi.ts
+++ b/public/app/features/alerting/unified/api/templateApi.ts
@@ -1,0 +1,34 @@
+import { alertingApi } from './alertingApi';
+
+export const defaultPayloadUrl = `/api/templates/default`;
+export const previewTemplateUrl = `/api/templates/preview`;
+
+export interface TemplatePreviewResult {
+  name: string;
+  text: string;
+}
+export interface TemplatesPreviewResponse {
+  results?: TemplatePreviewResult[];
+  error?: string;
+}
+
+export interface TemplateDefaultPayloadResponse {
+  defaultPayload: string;
+}
+
+export const templatesApi = alertingApi.injectEndpoints({
+  endpoints: (build) => ({
+    defaultPayload: build.query<TemplateDefaultPayloadResponse, void>({
+      query: () => ({ url: defaultPayloadUrl }),
+    }),
+    previewPayload: build.mutation<TemplatesPreviewResponse, { template: string; payload: string }>({
+      query: ({ template, payload }) => ({
+        url: previewTemplateUrl,
+        data: { template: template, data: payload },
+        method: 'POST',
+      }),
+    }),
+  }),
+});
+
+export const { useDefaultPayloadQuery, usePreviewPayloadMutation } = templatesApi;

--- a/public/app/features/alerting/unified/api/templateApi.ts
+++ b/public/app/features/alerting/unified/api/templateApi.ts
@@ -1,7 +1,6 @@
 import { alertingApi } from './alertingApi';
 
-export const defaultPayloadUrl = `/api/templates/default`;
-export const previewTemplateUrl = `/api/templates/preview`;
+export const previewTemplateUrl = `/api/alertmanager/grafana/config/api/v1/templates/test`;
 
 export interface TemplatePreviewResult {
   name: string;
@@ -16,16 +15,18 @@ export interface TemplatesPreviewResponse {
   errors?: TemplatePreviewErrors[];
 }
 
-export interface TemplateDefaultPayloadResponse {
-  defaultPayload: string;
+type AnnoField = {
+  key: string;
+  value: string;
+};
+export interface AlertFields {
+  annotations: AnnoField[];
+  labels: AnnoField[];
 }
 
 export const templatesApi = alertingApi.injectEndpoints({
   endpoints: (build) => ({
-    defaultPayload: build.query<TemplateDefaultPayloadResponse, void>({
-      query: () => ({ url: defaultPayloadUrl }),
-    }),
-    previewPayload: build.mutation<TemplatesPreviewResponse, { template: string; payload: string }>({
+    previewPayload: build.mutation<TemplatesPreviewResponse, { template: string; payload: AlertFields[] }>({
       query: ({ template, payload }) => ({
         url: previewTemplateUrl,
         data: { template: template, data: payload },
@@ -35,4 +36,4 @@ export const templatesApi = alertingApi.injectEndpoints({
   }),
 });
 
-export const { useDefaultPayloadQuery, usePreviewPayloadMutation } = templatesApi;
+export const { usePreviewPayloadMutation } = templatesApi;

--- a/public/app/features/alerting/unified/api/templateApi.ts
+++ b/public/app/features/alerting/unified/api/templateApi.ts
@@ -7,8 +7,9 @@ export interface TemplatePreviewResult {
   text: string;
 }
 export interface TemplatePreviewErrors {
-  name: string;
-  error: string;
+  name?: string;
+  message: string;
+  kind: string;
 }
 export interface TemplatesPreviewResponse {
   results?: TemplatePreviewResult[];

--- a/public/app/features/alerting/unified/api/templateApi.ts
+++ b/public/app/features/alerting/unified/api/templateApi.ts
@@ -20,22 +20,20 @@ type AnnoField = {
   key: string;
   value: string;
 };
-export interface AlertFields {
+export interface AlertField {
   annotations: AnnoField[];
   labels: AnnoField[];
 }
 
 export const templatesApi = alertingApi.injectEndpoints({
   endpoints: (build) => ({
-    previewPayload: build.mutation<TemplatesPreviewResponse, { template: string; alerts: AlertFields[]; name: string }>(
-      {
-        query: ({ template, alerts, name }) => ({
-          url: previewTemplateUrl,
-          data: { template: template, alerts: alerts, name: name },
-          method: 'POST',
-        }),
-      }
-    ),
+    previewPayload: build.mutation<TemplatesPreviewResponse, { template: string; alerts: AlertField[]; name: string }>({
+      query: ({ template, alerts, name }) => ({
+        url: previewTemplateUrl,
+        data: { template: template, alerts: alerts, name: name },
+        method: 'POST',
+      }),
+    }),
   }),
 });
 

--- a/public/app/features/alerting/unified/api/templateApi.ts
+++ b/public/app/features/alerting/unified/api/templateApi.ts
@@ -7,9 +7,13 @@ export interface TemplatePreviewResult {
   name: string;
   text: string;
 }
+export interface TemplatePreviewErrors {
+  name: string;
+  error: string;
+}
 export interface TemplatesPreviewResponse {
   results?: TemplatePreviewResult[];
-  error?: string;
+  errors?: TemplatePreviewErrors[];
 }
 
 export interface TemplateDefaultPayloadResponse {

--- a/public/app/features/alerting/unified/components/receivers/PayloadEditor.test.tsx
+++ b/public/app/features/alerting/unified/components/receivers/PayloadEditor.test.tsx
@@ -12,7 +12,16 @@ import { DEFAULT_PAYLOAD } from './TemplateForm';
 
 const PayloadEditorWithState = () => {
   const [payload, setPayload] = useState(DEFAULT_PAYLOAD);
-  return <PayloadEditor payload={payload} setPayload={setPayload} defaultPayload={DEFAULT_PAYLOAD} />;
+  return (
+    <PayloadEditor
+      payload={payload}
+      setPayload={setPayload}
+      defaultPayload={DEFAULT_PAYLOAD}
+      setPayloadFormatError={jest.fn()}
+      payloadFormatError={null}
+      onPayloadError={jest.fn()}
+    />
+  );
 };
 const renderWithProvider = () => {
   const store = configureStore();

--- a/public/app/features/alerting/unified/components/receivers/PayloadEditor.test.tsx
+++ b/public/app/features/alerting/unified/components/receivers/PayloadEditor.test.tsx
@@ -1,22 +1,18 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { setupServer } from 'msw/node';
 import { default as React, useState } from 'react';
 import { Provider } from 'react-redux';
 
-import { setBackendSrv } from '@grafana/runtime';
-import { backendSrv } from 'app/core/services/backend_srv';
 import { configureStore } from 'app/store/configureStore';
 
 import 'whatwg-fetch';
-import { TemplateDefaultPayloadResponse } from '../../api/templateApi';
-import { mockDefaultPayloadResponse, mockDefaultPayloadResponseRejected } from '../../mocks/templatesApi';
 
-import { NO_DEFAULT_PAYLOAD, PayloadEditor, RESET_TO_DEFAULT } from './PayloadEditor';
+import { PayloadEditor, RESET_TO_DEFAULT } from './PayloadEditor';
+import { DEFAULT_PAYLOAD } from './TemplateForm';
 
 const PayloadEditorWithState = () => {
-  const [payload, setPayload] = useState('initial payload');
-  return <PayloadEditor payload={payload} setPayload={setPayload} />;
+  const [payload, setPayload] = useState(DEFAULT_PAYLOAD);
+  return <PayloadEditor payload={payload} setPayload={setPayload} defaultPayload={DEFAULT_PAYLOAD} />;
 };
 const renderWithProvider = () => {
   const store = configureStore();
@@ -27,57 +23,30 @@ const renderWithProvider = () => {
   );
 };
 
-const server = setupServer();
-
-beforeAll(() => {
-  setBackendSrv(backendSrv);
-  server.listen({ onUnhandledRequest: 'error' });
-});
-
-beforeEach(() => {
-  server.resetHandlers();
-});
-
-afterAll(() => {
-  server.close();
-});
-
 describe('Payload editor', () => {
-  it('Should render default payload returned by the endpoint', async () => {
-    const payload: TemplateDefaultPayloadResponse = {
-      defaultPayload: '{"receiver": "Discord" ,status:"ok"}',
-    };
-    mockDefaultPayloadResponse(server, payload);
+  it('Should render default payload by default', async () => {
     renderWithProvider();
-    expect(screen.getByTestId('Spinner')).toBeInTheDocument();
     await waitFor(() => {
-      expect(screen.queryByTestId('Spinner')).not.toBeInTheDocument();
-      expect(screen.getByTestId('payloadJSON')).toHaveTextContent(payload.defaultPayload);
+      expect(screen.getByTestId('payloadJSON')).toHaveTextContent(
+        '{ "alerts": [{ "annotations": { "summary": "Instance instance1 has been down for more than 5 minutes" }, "labels": { "instance": "instance1" }, "startsAt": "2023-04-01T00:00:00Z", "endsAt": "2023-04-01T00:05:00Z" }] }'
+      );
     });
   });
-  it('Should render NO_DEFAULT_TEMPLATE message in case the endpoint is not available ', async () => {
-    mockDefaultPayloadResponseRejected(server);
-    renderWithProvider();
-    expect(screen.getByTestId('Spinner')).toBeInTheDocument();
-    await waitFor(() => {
-      expect(screen.queryByTestId('Spinner')).not.toBeInTheDocument();
-      expect(screen.getByTestId('payloadJSON')).toHaveTextContent(NO_DEFAULT_PAYLOAD);
-    });
-  });
+
   it('Should render default payload after clicking reset to default button', async () => {
-    const payload: TemplateDefaultPayloadResponse = {
-      defaultPayload: '{"receiver": "Discord" ,status:"ok"}',
-    };
-    mockDefaultPayloadResponse(server, payload);
     renderWithProvider();
-    expect(screen.getByTestId('Spinner')).toBeInTheDocument();
     await waitFor(() => {
-      expect(screen.queryByTestId('Spinner')).not.toBeInTheDocument();
-      expect(screen.getByTestId('payloadJSON')).toHaveTextContent(payload.defaultPayload);
+      expect(screen.getByTestId('payloadJSON')).toHaveTextContent(
+        '{ "alerts": [{ "annotations": { "summary": "Instance instance1 has been down for more than 5 minutes" }, "labels": { "instance": "instance1" }, "startsAt": "2023-04-01T00:00:00Z", "endsAt": "2023-04-01T00:05:00Z" }] }'
+      );
     });
     await userEvent.type(screen.getByTestId('payloadJSON'), 'this is the something');
     expect(screen.getByTestId('payloadJSON')).toHaveTextContent('this is the something');
     await userEvent.click(screen.getByText(RESET_TO_DEFAULT));
-    await waitFor(() => expect(screen.queryByTestId('payloadJSON')).toHaveTextContent(payload.defaultPayload));
+    await waitFor(() =>
+      expect(screen.queryByTestId('payloadJSON')).toHaveTextContent(
+        '{ "alerts": [{ "annotations": { "summary": "Instance instance1 has been down for more than 5 minutes" }, "labels": { "instance": "instance1" }, "startsAt": "2023-04-01T00:00:00Z", "endsAt": "2023-04-01T00:05:00Z" }] }'
+      )
+    );
   });
 });

--- a/public/app/features/alerting/unified/components/receivers/PayloadEditor.test.tsx
+++ b/public/app/features/alerting/unified/components/receivers/PayloadEditor.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { setupServer } from 'msw/node';
+import { default as React, useState } from 'react';
+import { Provider } from 'react-redux';
+
+import { setBackendSrv } from '@grafana/runtime';
+import { backendSrv } from 'app/core/services/backend_srv';
+import { configureStore } from 'app/store/configureStore';
+
+import 'whatwg-fetch';
+import { TemplateDefaultPayloadResponse } from '../../api/templateApi';
+import { mockDefaultPayloadResponse, mockDefaultPayloadResponseRejected } from '../../mocks/templatesApi';
+
+import { NO_DEFAULT_PAYLOAD, PayloadEditor, RESET_TO_DEFAULT } from './PayloadEditor';
+
+const PayloadEditorWithState = () => {
+  const [payload, setPayload] = useState('initial payload');
+  return <PayloadEditor payload={payload} setPayload={setPayload} />;
+};
+const renderWithProvider = () => {
+  const store = configureStore();
+  render(
+    <Provider store={store}>
+      <PayloadEditorWithState />
+    </Provider>
+  );
+};
+
+const server = setupServer();
+
+beforeAll(() => {
+  setBackendSrv(backendSrv);
+  server.listen({ onUnhandledRequest: 'error' });
+});
+
+beforeEach(() => {
+  server.resetHandlers();
+});
+
+afterAll(() => {
+  server.close();
+});
+
+describe('Payload editor', () => {
+  it('Should render default payload returned by the endpoint', async () => {
+    const payload: TemplateDefaultPayloadResponse = {
+      defaultPayload: '{"receiver": "Discord" ,status:"ok"}',
+    };
+    mockDefaultPayloadResponse(server, payload);
+    renderWithProvider();
+    expect(screen.getByTestId('Spinner')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByTestId('Spinner')).not.toBeInTheDocument();
+      expect(screen.getByTestId('payloadJSON')).toHaveTextContent(payload.defaultPayload);
+    });
+  });
+  it('Should render NO_DEFAULT_TEMPLATE message in case the endpoint is not available ', async () => {
+    mockDefaultPayloadResponseRejected(server);
+    renderWithProvider();
+    expect(screen.getByTestId('Spinner')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByTestId('Spinner')).not.toBeInTheDocument();
+      expect(screen.getByTestId('payloadJSON')).toHaveTextContent(NO_DEFAULT_PAYLOAD);
+    });
+  });
+  it('Should render default payload after clicking reset to default button', async () => {
+    const payload: TemplateDefaultPayloadResponse = {
+      defaultPayload: '{"receiver": "Discord" ,status:"ok"}',
+    };
+    mockDefaultPayloadResponse(server, payload);
+    renderWithProvider();
+    expect(screen.getByTestId('Spinner')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByTestId('Spinner')).not.toBeInTheDocument();
+      expect(screen.getByTestId('payloadJSON')).toHaveTextContent(payload.defaultPayload);
+    });
+    await userEvent.type(screen.getByTestId('payloadJSON'), 'this is the something');
+    expect(screen.getByTestId('payloadJSON')).toHaveTextContent('this is the something');
+    await userEvent.click(screen.getByText(RESET_TO_DEFAULT));
+    await waitFor(() => expect(screen.queryByTestId('payloadJSON')).toHaveTextContent(payload.defaultPayload));
+  });
+});

--- a/public/app/features/alerting/unified/components/receivers/PayloadEditor.test.tsx
+++ b/public/app/features/alerting/unified/components/receivers/PayloadEditor.test.tsx
@@ -28,7 +28,7 @@ describe('Payload editor', () => {
     renderWithProvider();
     await waitFor(() => {
       expect(screen.getByTestId('payloadJSON')).toHaveTextContent(
-        '{ "alerts": [{ "annotations": { "summary": "Instance instance1 has been down for more than 5 minutes" }, "labels": { "instance": "instance1" }, "startsAt": "2023-04-01T00:00:00Z", "endsAt": "2023-04-01T00:05:00Z" }] }'
+        `[ { "annotations": { "summary": "Instance instance1 has been down for more than 5 minutes" }, "labels": { "instance": "instance1" }, "startsAt": "2023-04-01T00:00:00Z", "endsAt": "2023-12-01T00:05:00Z" }]`
       );
     });
   });
@@ -37,7 +37,7 @@ describe('Payload editor', () => {
     renderWithProvider();
     await waitFor(() => {
       expect(screen.getByTestId('payloadJSON')).toHaveTextContent(
-        '{ "alerts": [{ "annotations": { "summary": "Instance instance1 has been down for more than 5 minutes" }, "labels": { "instance": "instance1" }, "startsAt": "2023-04-01T00:00:00Z", "endsAt": "2023-04-01T00:05:00Z" }] }'
+        '[ { "annotations": { "summary": "Instance instance1 has been down for more than 5 minutes" }, "labels": { "instance": "instance1" }, "startsAt": "2023-04-01T00:00:00Z", "endsAt": "2023-12-01T00:05:00Z" }]'
       );
     });
     await userEvent.type(screen.getByTestId('payloadJSON'), 'this is the something');
@@ -45,7 +45,7 @@ describe('Payload editor', () => {
     await userEvent.click(screen.getByText(RESET_TO_DEFAULT));
     await waitFor(() =>
       expect(screen.queryByTestId('payloadJSON')).toHaveTextContent(
-        '{ "alerts": [{ "annotations": { "summary": "Instance instance1 has been down for more than 5 minutes" }, "labels": { "instance": "instance1" }, "startsAt": "2023-04-01T00:00:00Z", "endsAt": "2023-04-01T00:05:00Z" }] }'
+        '[ { "annotations": { "summary": "Instance instance1 has been down for more than 5 minutes" }, "labels": { "instance": "instance1" }, "startsAt": "2023-04-01T00:00:00Z", "endsAt": "2023-12-01T00:05:00Z" }]'
       )
     );
   });

--- a/public/app/features/alerting/unified/components/receivers/PayloadEditor.test.tsx
+++ b/public/app/features/alerting/unified/components/receivers/PayloadEditor.test.tsx
@@ -8,7 +8,18 @@ import { configureStore } from 'app/store/configureStore';
 import 'whatwg-fetch';
 
 import { PayloadEditor, RESET_TO_DEFAULT } from './PayloadEditor';
-import { DEFAULT_PAYLOAD } from './TemplateForm';
+
+const DEFAULT_PAYLOAD = `[
+  {
+    "annotations": {
+      "summary": "Instance instance1 has been down for more than 5 minutes"
+    },
+    "labels": {
+      "instance": "instance1"
+    },
+    "startsAt": "2023-04-25T15:28:56.440Z"
+  }]
+`;
 
 const PayloadEditorWithState = () => {
   const [payload, setPayload] = useState(DEFAULT_PAYLOAD);
@@ -37,7 +48,7 @@ describe('Payload editor', () => {
     renderWithProvider();
     await waitFor(() => {
       expect(screen.getByTestId('payloadJSON')).toHaveTextContent(
-        `[ { "annotations": { "summary": "Instance instance1 has been down for more than 5 minutes" }, "labels": { "instance": "instance1" }, "startsAt": "2023-04-01T00:00:00Z", "endsAt": "2023-12-01T00:05:00Z" }]`
+        `[ { "annotations": { "summary": "Instance instance1 has been down for more than 5 minutes" }, "labels": { "instance": "instance1" }, "startsAt": "2023-04-25T15:28:56.440Z" }]`
       );
     });
   });
@@ -46,7 +57,7 @@ describe('Payload editor', () => {
     renderWithProvider();
     await waitFor(() => {
       expect(screen.getByTestId('payloadJSON')).toHaveTextContent(
-        '[ { "annotations": { "summary": "Instance instance1 has been down for more than 5 minutes" }, "labels": { "instance": "instance1" }, "startsAt": "2023-04-01T00:00:00Z", "endsAt": "2023-12-01T00:05:00Z" }]'
+        ' { "annotations": { "summary": "Instance instance1 has been down for more than 5 minutes" }, "labels": { "instance": "instance1" }, "startsAt": "2023-04-25T15:28:56.440Z" }]'
       );
     });
     await userEvent.type(screen.getByTestId('payloadJSON'), 'this is the something');
@@ -54,7 +65,7 @@ describe('Payload editor', () => {
     await userEvent.click(screen.getByText(RESET_TO_DEFAULT));
     await waitFor(() =>
       expect(screen.queryByTestId('payloadJSON')).toHaveTextContent(
-        '[ { "annotations": { "summary": "Instance instance1 has been down for more than 5 minutes" }, "labels": { "instance": "instance1" }, "startsAt": "2023-04-01T00:00:00Z", "endsAt": "2023-12-01T00:05:00Z" }]'
+        ' { "annotations": { "summary": "Instance instance1 has been down for more than 5 minutes" }, "labels": { "instance": "instance1" }, "startsAt": "2023-04-25T15:28:56.440Z" }]'
       )
     );
   });

--- a/public/app/features/alerting/unified/components/receivers/PayloadEditor.test.tsx
+++ b/public/app/features/alerting/unified/components/receivers/PayloadEditor.test.tsx
@@ -21,6 +21,13 @@ const DEFAULT_PAYLOAD = `[
   }]
 `;
 
+jest.mock('@grafana/ui', () => ({
+  ...jest.requireActual('@grafana/ui'),
+  CodeEditor: function CodeEditor({ value, onBlur }: { value: string; onBlur: (newValue: string) => void }) {
+    return <input data-testid="mockeditor" value={value} onChange={(e) => onBlur(e.currentTarget.value)} />;
+  },
+}));
+
 const PayloadEditorWithState = () => {
   const [payload, setPayload] = useState(DEFAULT_PAYLOAD);
   return (
@@ -47,8 +54,8 @@ describe('Payload editor', () => {
   it('Should render default payload by default', async () => {
     renderWithProvider();
     await waitFor(() => {
-      expect(screen.getByTestId('payloadJSON')).toHaveTextContent(
-        `[ { "annotations": { "summary": "Instance instance1 has been down for more than 5 minutes" }, "labels": { "instance": "instance1" }, "startsAt": "2023-04-25T15:28:56.440Z" }]`
+      expect(screen.getByTestId('mockeditor')).toHaveValue(
+        `[  {    "annotations": {      "summary": "Instance instance1 has been down for more than 5 minutes"    },    "labels": {      "instance": "instance1"    },    "startsAt": "2023-04-25T15:28:56.440Z"  }]`
       );
     });
   });
@@ -56,16 +63,18 @@ describe('Payload editor', () => {
   it('Should render default payload after clicking reset to default button', async () => {
     renderWithProvider();
     await waitFor(() => {
-      expect(screen.getByTestId('payloadJSON')).toHaveTextContent(
-        ' { "annotations": { "summary": "Instance instance1 has been down for more than 5 minutes" }, "labels": { "instance": "instance1" }, "startsAt": "2023-04-25T15:28:56.440Z" }]'
+      expect(screen.getByTestId('mockeditor')).toHaveValue(
+        '[  {    "annotations": {      "summary": "Instance instance1 has been down for more than 5 minutes"    },    "labels": {      "instance": "instance1"    },    "startsAt": "2023-04-25T15:28:56.440Z"  }]'
       );
     });
-    await userEvent.type(screen.getByTestId('payloadJSON'), 'this is the something');
-    expect(screen.getByTestId('payloadJSON')).toHaveTextContent('this is the something');
+    await userEvent.type(screen.getByTestId('mockeditor'), 'this is the something');
+    expect(screen.getByTestId('mockeditor')).toHaveValue(
+      '[  {    "annotations": {      "summary": "Instance instance1 has been down for more than 5 minutes"    },    "labels": {      "instance": "instance1"    },    "startsAt": "2023-04-25T15:28:56.440Z"  }]this is the something'
+    );
     await userEvent.click(screen.getByText(RESET_TO_DEFAULT));
     await waitFor(() =>
-      expect(screen.queryByTestId('payloadJSON')).toHaveTextContent(
-        ' { "annotations": { "summary": "Instance instance1 has been down for more than 5 minutes" }, "labels": { "instance": "instance1" }, "startsAt": "2023-04-25T15:28:56.440Z" }]'
+      expect(screen.queryByTestId('mockeditor')).toHaveValue(
+        '[  {    "annotations": {      "summary": "Instance instance1 has been down for more than 5 minutes"    },    "labels": {      "instance": "instance1"    },    "startsAt": "2023-04-25T15:28:56.440Z"  }]'
       )
     );
   });

--- a/public/app/features/alerting/unified/components/receivers/PayloadEditor.tsx
+++ b/public/app/features/alerting/unified/components/receivers/PayloadEditor.tsx
@@ -67,7 +67,7 @@ export function PayloadEditor({
               type="button"
               variant="secondary"
             >
-              Add alerts
+              Add alerts to this payload
             </Button>
           </Stack>
         </Stack>

--- a/public/app/features/alerting/unified/components/receivers/PayloadEditor.tsx
+++ b/public/app/features/alerting/unified/components/receivers/PayloadEditor.tsx
@@ -1,39 +1,24 @@
 import { css } from '@emotion/css';
-import React, { useEffect } from 'react';
+import React from 'react';
 
 import { Stack } from '@grafana/experimental';
-import { Button, LoadingPlaceholder, TextArea, useStyles2 } from '@grafana/ui';
+import { Button, TextArea, useStyles2 } from '@grafana/ui';
 
-import { useDefaultPayloadQuery } from '../../api/templateApi';
-
-export const NO_DEFAULT_PAYLOAD = 'No default payload found';
 export const RESET_TO_DEFAULT = 'Reset to default payload';
 
 export function PayloadEditor({
   payload,
   setPayload,
+  defaultPayload,
 }: {
   payload: string;
+  defaultPayload: string;
   setPayload: React.Dispatch<React.SetStateAction<string>>;
 }) {
   const styles = useStyles2(getStyles);
-  const { data, isLoading, isError } = useDefaultPayloadQuery();
-  const defaultPayload = data?.defaultPayload;
   const onReset = () => {
-    setPayload(defaultPayload ?? NO_DEFAULT_PAYLOAD);
+    setPayload(defaultPayload);
   };
-
-  useEffect(() => {
-    !isError && defaultPayload && setPayload(defaultPayload);
-  }, [defaultPayload, setPayload, isError]);
-
-  useEffect(() => {
-    isError && setPayload(NO_DEFAULT_PAYLOAD);
-  }, [isError, setPayload]);
-
-  if (isLoading) {
-    return <LoadingPlaceholder text={'Loading default payload'} />;
-  }
 
   return (
     <Stack direction="row" alignItems="center">

--- a/public/app/features/alerting/unified/components/receivers/PayloadEditor.tsx
+++ b/public/app/features/alerting/unified/components/receivers/PayloadEditor.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { Stack } from '@grafana/experimental';
-import { Button, TextArea, useStyles2 } from '@grafana/ui';
+import { Button, Icon, TextArea, Tooltip, useStyles2 } from '@grafana/ui';
 import { TestTemplateAlert } from 'app/plugins/datasource/alertmanager/types';
 
 import { GenerateAlertDataModal } from './form/GenerateAlertDataModal';
@@ -41,54 +41,62 @@ export function PayloadEditor({
   };
 
   return (
-    <Stack direction="row" alignItems="center">
-      <div>
-        <Stack direction="column" gap={1}>
-          <h5> Payload</h5>
-          <TextArea
-            required={true}
-            value={payload}
-            onChange={(e) => {
-              setPayload(e.currentTarget.value);
-            }}
-            data-testid="payloadJSON"
-            className={styles.jsonEditor}
-            rows={10}
-            cols={50}
-          />
-          <Stack>
-            <Button onClick={onReset} className={styles.button} icon="arrow-left" type="button" variant="secondary">
-              {RESET_TO_DEFAULT}
-            </Button>
-            <Button
-              onClick={onOpenEditAlertModal}
-              className={styles.button}
-              icon="plus-circle"
-              type="button"
-              variant="secondary"
-            >
-              Add alert data
-            </Button>
-          </Stack>
-        </Stack>
-        <GenerateAlertDataModal
-          isOpen={isEditingAlertData}
-          onDismiss={onCloseEditAlertModal}
-          onAccept={onAddAlertList}
+    <div className={styles.wrapper}>
+      <Stack direction="column" gap={1}>
+        <div className={styles.title}>
+          Payload data
+          <Tooltip placement="top" content={'This payload data will be sent to the preview'} theme="info">
+            <Icon name="info-circle" className={styles.tooltip} size="xl" />
+          </Tooltip>
+        </div>
+        <TextArea
+          required={true}
+          value={payload}
+          onChange={(e) => {
+            setPayload(e.currentTarget.value);
+          }}
+          data-testid="payloadJSON"
+          className={styles.jsonEditor}
+          rows={10}
+          cols={50}
         />
-      </div>
-    </Stack>
+        <Stack>
+          <Button onClick={onReset} className={styles.button} icon="arrow-up" type="button" variant="secondary">
+            {RESET_TO_DEFAULT}
+          </Button>
+          <Button
+            onClick={onOpenEditAlertModal}
+            className={styles.button}
+            icon="plus-circle"
+            type="button"
+            variant="secondary"
+          >
+            Add alert data
+          </Button>
+        </Stack>
+      </Stack>
+      <GenerateAlertDataModal isOpen={isEditingAlertData} onDismiss={onCloseEditAlertModal} onAccept={onAddAlertList} />
+    </div>
   );
 }
 
 const getStyles = (theme: GrafanaTheme2) => ({
   jsonEditor: css`
     width: 605px;
-    height: 291px;
+    height: 325px;
   `,
   button: css`
     flex: none;
     width: fit-content;
     padding-right: ${theme.spacing(1)};
+  `,
+  title: css`
+    font-weight: ${theme.typography.fontWeightBold};
+  `,
+  wrapper: css`
+    padding-top: ${theme.spacing(1)};
+  `,
+  tooltip: css`
+    padding-left: ${theme.spacing(1)};
   `,
 });

--- a/public/app/features/alerting/unified/components/receivers/PayloadEditor.tsx
+++ b/public/app/features/alerting/unified/components/receivers/PayloadEditor.tsx
@@ -38,7 +38,7 @@ export function PayloadEditor({
   return (
     <Stack direction="row" alignItems="center">
       <div>
-        <Stack direction="column">
+        <Stack direction="column" gap={1}>
           <h5> Payload</h5>
           <TextArea
             required={true}
@@ -51,8 +51,10 @@ export function PayloadEditor({
             rows={10}
             cols={50}
           />
+          <Button onClick={onReset} className={styles.button}>
+            {RESET_TO_DEFAULT}
+          </Button>
         </Stack>
-        <Button onClick={onReset}>{RESET_TO_DEFAULT}</Button>
       </div>
     </Stack>
   );
@@ -62,5 +64,9 @@ const getStyles = () => ({
   jsonEditor: css`
     width: 605px;
     height: 291px;
+  `,
+  button: css`
+    flex: none;
+    width: fit-content;
   `,
 });

--- a/public/app/features/alerting/unified/components/receivers/PayloadEditor.tsx
+++ b/public/app/features/alerting/unified/components/receivers/PayloadEditor.tsx
@@ -2,8 +2,7 @@ import { css } from '@emotion/css';
 import React, { useState } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { Stack } from '@grafana/experimental';
-import { Badge, Button, Icon, TextArea, Tooltip, useStyles2 } from '@grafana/ui';
+import { Badge, Button, CodeEditor, Icon, Tooltip, useStyles2 } from '@grafana/ui';
 import { TestTemplateAlert } from 'app/plugins/datasource/alertmanager/types';
 
 import { GenerateAlertDataModal } from './form/GenerateAlertDataModal';
@@ -36,6 +35,8 @@ export function PayloadEditor({
     setIsEditingAlertData(false);
   };
 
+  const errorInPayloadJson = payloadFormatError !== null;
+
   const onOpenEditAlertModal = () => {
     try {
       JSON.parse(payload);
@@ -56,25 +57,26 @@ export function PayloadEditor({
 
   return (
     <div className={styles.wrapper}>
-      <Stack direction="column" gap={1}>
+      <div className={styles.editor}>
         <div className={styles.title}>
           Payload data
           <Tooltip placement="top" content={'This payload data will be sent to the preview'} theme="info">
             <Icon name="info-circle" className={styles.tooltip} size="xl" />
           </Tooltip>
         </div>
-        <TextArea
-          required={true}
+
+        <CodeEditor
+          width={640}
+          height={363}
+          language={'json'}
+          showLineNumbers={true}
+          showMiniMap={false}
           value={payload}
-          onChange={(e) => {
-            setPayload(e.currentTarget.value);
-          }}
-          data-testid="payloadJSON"
-          className={styles.jsonEditor}
-          rows={10}
-          cols={50}
+          readOnly={false}
+          onBlur={setPayload}
         />
-        <Stack>
+
+        <div className={styles.buttonsWrapper}>
           <Button onClick={onReset} className={styles.button} icon="arrow-up" type="button" variant="secondary">
             {RESET_TO_DEFAULT}
           </Button>
@@ -84,6 +86,7 @@ export function PayloadEditor({
             icon="plus-circle"
             type="button"
             variant="secondary"
+            disabled={errorInPayloadJson}
           >
             Add alert data
           </Button>
@@ -91,12 +94,12 @@ export function PayloadEditor({
             <Badge
               color="orange"
               icon="exclamation-triangle"
-              text={'There are some errors in payload JSON'}
-              tooltip={'Fix errors in existing payload before adding more data'}
+              text={'There are some errors in payload JSON.'}
+              tooltip={'Fix errors in payload, and click Refresh preview button'}
             />
           )}
-        </Stack>
-      </Stack>
+        </div>
+      </div>
       <GenerateAlertDataModal isOpen={isEditingAlertData} onDismiss={onCloseEditAlertModal} onAccept={onAddAlertList} />
     </div>
   );
@@ -105,20 +108,30 @@ export function PayloadEditor({
 const getStyles = (theme: GrafanaTheme2) => ({
   jsonEditor: css`
     width: 605px;
-    height: 325px;
+    height: 363px;
+  `,
+  buttonsWrapper: css`
+    margin-top: ${theme.spacing(1)};
+    display: flex;
   `,
   button: css`
     flex: none;
     width: fit-content;
     padding-right: ${theme.spacing(1)};
+    margin-right: ${theme.spacing(1)};
   `,
   title: css`
     font-weight: ${theme.typography.fontWeightBold};
   `,
   wrapper: css`
-    padding-top: ${theme.spacing(1)};
+    padding-top: 38px;
   `,
   tooltip: css`
     padding-left: ${theme.spacing(1)};
+  `,
+  editor: css`
+    display: flex;
+    flex-direction: column;
+    margin-top: ${theme.spacing(-1)};
   `,
 });

--- a/public/app/features/alerting/unified/components/receivers/PayloadEditor.tsx
+++ b/public/app/features/alerting/unified/components/receivers/PayloadEditor.tsx
@@ -1,0 +1,66 @@
+import { css } from '@emotion/css';
+import React, { useEffect } from 'react';
+
+import { Stack } from '@grafana/experimental';
+import { Button, LoadingPlaceholder, TextArea, useStyles2 } from '@grafana/ui';
+
+import { useDefaultPayloadQuery } from '../../api/templateApi';
+
+export const NO_DEFAULT_PAYLOAD = 'No default payload found';
+export const RESET_TO_DEFAULT = 'Reset to default payload';
+
+export function PayloadEditor({
+  payload,
+  setPayload,
+}: {
+  payload: string;
+  setPayload: React.Dispatch<React.SetStateAction<string>>;
+}) {
+  const styles = useStyles2(getStyles);
+  const { data, isLoading, isError } = useDefaultPayloadQuery();
+  const defaultPayload = data?.defaultPayload;
+  const onReset = () => {
+    setPayload(defaultPayload ?? NO_DEFAULT_PAYLOAD);
+  };
+
+  useEffect(() => {
+    !isError && defaultPayload && setPayload(defaultPayload);
+  }, [defaultPayload, setPayload, isError]);
+
+  useEffect(() => {
+    isError && setPayload(NO_DEFAULT_PAYLOAD);
+  }, [isError, setPayload]);
+
+  if (isLoading) {
+    return <LoadingPlaceholder text={'Loading default payload'} />;
+  }
+
+  return (
+    <Stack direction="row" alignItems="center">
+      <div>
+        <Stack direction="column">
+          <h5> Payload</h5>
+          <TextArea
+            required={true}
+            value={payload}
+            onChange={(e) => {
+              setPayload(e.currentTarget.value);
+            }}
+            data-testid="payloadJSON"
+            className={styles.jsonEditor}
+            rows={10}
+            cols={50}
+          />
+        </Stack>
+        <Button onClick={onReset}>{RESET_TO_DEFAULT}</Button>
+      </div>
+    </Stack>
+  );
+}
+
+const getStyles = () => ({
+  jsonEditor: css`
+    width: 605px;
+    height: 291px;
+  `,
+});

--- a/public/app/features/alerting/unified/components/receivers/PayloadEditor.tsx
+++ b/public/app/features/alerting/unified/components/receivers/PayloadEditor.tsx
@@ -1,8 +1,12 @@
 import { css } from '@emotion/css';
-import React from 'react';
+import React, { useState } from 'react';
 
+import { GrafanaTheme2 } from '@grafana/data';
 import { Stack } from '@grafana/experimental';
 import { Button, TextArea, useStyles2 } from '@grafana/ui';
+import { TestReceiversAlert } from 'app/plugins/datasource/alertmanager/types';
+
+import { GenerateAlertDataModal } from './form/GenerateAlertDataModal';
 
 export const RESET_TO_DEFAULT = 'Reset to default payload';
 
@@ -18,6 +22,22 @@ export function PayloadEditor({
   const styles = useStyles2(getStyles);
   const onReset = () => {
     setPayload(defaultPayload);
+  };
+
+  const [isEditingAlertData, setIsEditingAlertData] = useState(false);
+
+  const onCloseEditAlertModal = () => {
+    setIsEditingAlertData(false);
+  };
+
+  const onOpenEditAlertModal = () => setIsEditingAlertData(true);
+
+  const onAddAlertList = (alerts: TestReceiversAlert[]) => {
+    onCloseEditAlertModal();
+    setPayload((payload) => {
+      const payloadObj = JSON.parse(payload);
+      return JSON.stringify([...payloadObj, ...alerts], undefined, 2);
+    });
   };
 
   return (
@@ -36,16 +56,32 @@ export function PayloadEditor({
             rows={10}
             cols={50}
           />
-          <Button onClick={onReset} className={styles.button}>
-            {RESET_TO_DEFAULT}
-          </Button>
+          <Stack>
+            <Button onClick={onReset} className={styles.button} icon="arrow-left" type="button" variant="secondary">
+              {RESET_TO_DEFAULT}
+            </Button>
+            <Button
+              onClick={onOpenEditAlertModal}
+              className={styles.button}
+              icon="plus-circle"
+              type="button"
+              variant="secondary"
+            >
+              Add alerts
+            </Button>
+          </Stack>
         </Stack>
+        <GenerateAlertDataModal
+          isOpen={isEditingAlertData}
+          onDismiss={onCloseEditAlertModal}
+          onAccept={onAddAlertList}
+        />
       </div>
     </Stack>
   );
 }
 
-const getStyles = () => ({
+const getStyles = (theme: GrafanaTheme2) => ({
   jsonEditor: css`
     width: 605px;
     height: 291px;
@@ -53,5 +89,6 @@ const getStyles = () => ({
   button: css`
     flex: none;
     width: fit-content;
+    padding-right: ${theme.spacing(1)};
   `,
 });

--- a/public/app/features/alerting/unified/components/receivers/PayloadEditor.tsx
+++ b/public/app/features/alerting/unified/components/receivers/PayloadEditor.tsx
@@ -4,7 +4,7 @@ import React, { useState } from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
 import { Stack } from '@grafana/experimental';
 import { Button, TextArea, useStyles2 } from '@grafana/ui';
-import { TestReceiversAlert } from 'app/plugins/datasource/alertmanager/types';
+import { TestTemplateAlert } from 'app/plugins/datasource/alertmanager/types';
 
 import { GenerateAlertDataModal } from './form/GenerateAlertDataModal';
 
@@ -32,7 +32,7 @@ export function PayloadEditor({
 
   const onOpenEditAlertModal = () => setIsEditingAlertData(true);
 
-  const onAddAlertList = (alerts: TestReceiversAlert[]) => {
+  const onAddAlertList = (alerts: TestTemplateAlert[]) => {
     onCloseEditAlertModal();
     setPayload((payload) => {
       const payloadObj = JSON.parse(payload);

--- a/public/app/features/alerting/unified/components/receivers/PayloadEditor.tsx
+++ b/public/app/features/alerting/unified/components/receivers/PayloadEditor.tsx
@@ -40,6 +40,7 @@ export function PayloadEditor({
     try {
       JSON.parse(payload);
       setIsEditingAlertData(true);
+      setPayloadFormatError(null);
     } catch (e) {
       setPayloadFormatError(e instanceof Error ? e.message : 'Invalid JSON.');
       onPayloadError();

--- a/public/app/features/alerting/unified/components/receivers/PayloadEditor.tsx
+++ b/public/app/features/alerting/unified/components/receivers/PayloadEditor.tsx
@@ -8,7 +8,7 @@ import { TestTemplateAlert } from 'app/plugins/datasource/alertmanager/types';
 
 import { GenerateAlertDataModal } from './form/GenerateAlertDataModal';
 
-export const RESET_TO_DEFAULT = 'Reset to default payload';
+export const RESET_TO_DEFAULT = 'Reset to default';
 
 export function PayloadEditor({
   payload,
@@ -67,7 +67,7 @@ export function PayloadEditor({
               type="button"
               variant="secondary"
             >
-              Add alerts to this payload
+              Add alert data
             </Button>
           </Stack>
         </Stack>

--- a/public/app/features/alerting/unified/components/receivers/PayloadEditor.tsx
+++ b/public/app/features/alerting/unified/components/receivers/PayloadEditor.tsx
@@ -113,7 +113,7 @@ const AlertTemplateDataTable = () => {
     <TemplateDataTable
       caption={
         <h4 className={styles.templateDataDocsHeader}>
-          Alert template data <span>This is the list of Alert data fields used in the Preview.</span>
+          Alert template data <span>This is the list of alert data fields used in the preview.</span>
         </h4>
       }
       dataItems={AlertTemplatePreviewData}

--- a/public/app/features/alerting/unified/components/receivers/PayloadEditor.tsx
+++ b/public/app/features/alerting/unified/components/receivers/PayloadEditor.tsx
@@ -5,6 +5,8 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { Badge, Button, CodeEditor, Icon, Tooltip, useStyles2 } from '@grafana/ui';
 import { TestTemplateAlert } from 'app/plugins/datasource/alertmanager/types';
 
+import { AlertTemplatePreviewData } from './TemplateData';
+import { TemplateDataTable } from './TemplateDataDocs';
 import { GenerateAlertDataModal } from './form/GenerateAlertDataModal';
 
 export const RESET_TO_DEFAULT = 'Reset to default';
@@ -60,7 +62,7 @@ export function PayloadEditor({
       <div className={styles.editor}>
         <div className={styles.title}>
           Payload data
-          <Tooltip placement="top" content={'This payload data will be sent to the preview'} theme="info">
+          <Tooltip placement="top" content={<AlertTemplateDataTable />} theme="info">
             <Icon name="info-circle" className={styles.tooltip} size="xl" />
           </Tooltip>
         </div>
@@ -104,7 +106,19 @@ export function PayloadEditor({
     </div>
   );
 }
-
+const AlertTemplateDataTable = () => {
+  const styles = useStyles2(getStyles);
+  return (
+    <TemplateDataTable
+      caption={
+        <h4 className={styles.templateDataDocsHeader}>
+          Alert template data <span>This is the list of Alert data fields used in the Preview.</span>
+        </h4>
+      }
+      dataItems={AlertTemplatePreviewData}
+    />
+  );
+};
 const getStyles = (theme: GrafanaTheme2) => ({
   jsonEditor: css`
     width: 605px;
@@ -133,5 +147,13 @@ const getStyles = (theme: GrafanaTheme2) => ({
     display: flex;
     flex-direction: column;
     margin-top: ${theme.spacing(-1)};
+  `,
+  templateDataDocsHeader: css`
+    color: ${theme.colors.text.primary};
+
+    span {
+      color: ${theme.colors.text.secondary};
+      font-size: ${theme.typography.bodySmall.fontSize};
+    }
   `,
 });

--- a/public/app/features/alerting/unified/components/receivers/PayloadEditor.tsx
+++ b/public/app/features/alerting/unified/components/receivers/PayloadEditor.tsx
@@ -41,7 +41,8 @@ export function PayloadEditor({
 
   const onOpenEditAlertModal = () => {
     try {
-      JSON.parse(payload);
+      const payloadObj = JSON.parse(payload);
+      JSON.stringify([...payloadObj]); // check if it's iterable, in order to be able to add more data
       setIsEditingAlertData(true);
       setPayloadFormatError(null);
     } catch (e) {

--- a/public/app/features/alerting/unified/components/receivers/TemplateData.ts
+++ b/public/app/features/alerting/unified/components/receivers/TemplateData.ts
@@ -59,6 +59,29 @@ export const GlobalTemplateData: TemplateDataItem[] = [
   },
 ];
 
+export const AlertTemplatePreviewData: TemplateDataItem[] = [
+  {
+    name: 'Labels',
+    type: 'KeyValue',
+    notes: 'Set of labels attached to the alert.',
+  },
+  {
+    name: 'Annotations',
+    type: 'KeyValue',
+    notes: 'Set of annotations attached to the alert.',
+  },
+  {
+    name: 'StartsAt',
+    type: 'time.Time',
+    notes: 'Time the alert started firing.',
+  },
+  {
+    name: 'EndsAt',
+    type: 'time.Time',
+    notes: 'Time the alert ends firing.',
+  },
+];
+
 export const AlertTemplateData: TemplateDataItem[] = [
   {
     name: 'Status',

--- a/public/app/features/alerting/unified/components/receivers/TemplateDataDocs.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplateDataDocs.tsx
@@ -72,7 +72,7 @@ interface TemplateDataTableProps {
   typeRenderer?: (type: TemplateDataItem['type']) => React.ReactNode;
 }
 
-function TemplateDataTable({ dataItems, caption, typeRenderer }: TemplateDataTableProps) {
+export function TemplateDataTable({ dataItems, caption, typeRenderer }: TemplateDataTableProps) {
   const styles = useStyles2(getTemplateDataTableStyles);
 
   return (

--- a/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
@@ -316,7 +316,7 @@ function getErrorsToRender(results: TemplatePreviewErrors[]) {
     })
     .join(`\n`);
 }
-export const PREVIEW_NOT_AVAILABLE = 'Preview is not available';
+export const PREVIEW_NOT_AVAILABLE = 'Preview request failed. Check if the payload data has the correct structure.';
 
 function getPreviewTorender(
   isPreviewError: boolean,

--- a/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
@@ -50,9 +50,21 @@ interface Props {
 }
 export const isDuplicating = (location: Location) => location.pathname.endsWith('/duplicate');
 
-export const TemplateForm = ({ existing, alertManagerSourceName, config, provenance }: Props) => {
-  const NO_DEFAULT_TEMPLATE = 'No default template found';
+export const DEFAULT_PAYLOAD = `{
+  "alerts": [{
+    "annotations": {
+      "summary": "Instance instance1 has been down for more than 5 minutes"
+    },
+    "labels": {
+      "instance": "instance1"
+    },
+    "startsAt": "2023-04-01T00:00:00Z",
+    "endsAt": "2023-04-01T00:05:00Z"
+  }]
 
+}`;
+
+export const TemplateForm = ({ existing, alertManagerSourceName, config, provenance }: Props) => {
   const styles = useStyles2(getStyles);
   const dispatch = useDispatch();
 
@@ -63,7 +75,7 @@ export const TemplateForm = ({ existing, alertManagerSourceName, config, provena
   const location = useLocation();
   const isduplicating = isDuplicating(location);
 
-  const [payload, setPayload] = useState(NO_DEFAULT_TEMPLATE);
+  const [payload, setPayload] = useState(DEFAULT_PAYLOAD);
   const [payloadFormatError, setPayloadFormatError] = useState<string | null>(null);
 
   const [isPayloadEditorOpen, toggleIsPayloadEditorOpen] = useToggle(false);
@@ -209,7 +221,7 @@ export const TemplateForm = ({ existing, alertManagerSourceName, config, provena
               <TemplateDataDocs />
             </ExpandableSection>
             <ExpandableSection title="Edit Payload" isOpen={isPayloadEditorOpen} toggleOpen={toggleIsPayloadEditorOpen}>
-              <PayloadEditor payload={payload} setPayload={setPayload} />
+              <PayloadEditor payload={payload} setPayload={setPayload} defaultPayload={DEFAULT_PAYLOAD} />
             </ExpandableSection>
           </>
         )}
@@ -325,7 +337,7 @@ export function TemplatePreview({
   const onPreview = () => {
     try {
       JSON.parse(payload);
-      trigger({ template: templateContent, payload: payload });
+      trigger({ template: templateContent, payload: JSON.parse(payload) });
       setPayloadFormatError(null);
     } catch (e) {
       setPayloadFormatError(e instanceof Error ? e.message : 'Invalid JSON.');

--- a/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
@@ -287,8 +287,16 @@ function getResultsToRender(results: TemplatePreviewResult[]) {
 
   const moreThanOne = filteredResults.length > 1;
 
-  const preview = (result: TemplatePreviewResult) =>
-    moreThanOne ? `Preview for ${result.name}:\n${result.text}` : `${result.text}`;
+  const preview = (result: TemplatePreviewResult) => {
+    const previewForLabel = `Preview for ${result.name}:`;
+    const separatorStart = '='.repeat(previewForLabel.length).concat('>');
+    const separatorEnd = '<'.concat('='.repeat(previewForLabel.length));
+    if (moreThanOne) {
+      return `${previewForLabel}\n${separatorStart}${result.text}${separatorEnd}\n`;
+    } else {
+      return `${separatorStart}${result.text}${separatorEnd}\n`;
+    }
+  };
 
   return filteredResults
     .map((result: TemplatePreviewResult) => {
@@ -301,9 +309,9 @@ function getErrorsToRender(results: TemplatePreviewErrors[]) {
   return results
     .map((result: TemplatePreviewErrors) => {
       if (result.name) {
-        return `ERROR in ${result.name}:\n`.concat(`${result.kind}\n${result.message}`);
+        return `ERROR in ${result.name}:\n`.concat(`${result.kind}\n${result.message}\n`);
       } else {
-        return `ERROR:\n${result.kind}\n${result.message}`;
+        return `ERROR:\n${result.kind}\n${result.message}\n`;
       }
     })
     .join(`\n`);

--- a/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
@@ -14,6 +14,7 @@ import { AlertManagerCortexConfig } from 'app/plugins/datasource/alertmanager/ty
 import { useDispatch } from 'app/types';
 
 import {
+  AlertFields,
   TemplatePreviewErrors,
   TemplatePreviewResult,
   TemplatesPreviewResponse,
@@ -50,8 +51,8 @@ interface Props {
 }
 export const isDuplicating = (location: Location) => location.pathname.endsWith('/duplicate');
 
-export const DEFAULT_PAYLOAD = `{
-  "alerts": [{
+export const DEFAULT_PAYLOAD = `[
+  {
     "annotations": {
       "summary": "Instance instance1 has been down for more than 5 minutes"
     },
@@ -61,8 +62,7 @@ export const DEFAULT_PAYLOAD = `{
     "startsAt": "2023-04-01T00:00:00Z",
     "endsAt": "2023-04-01T00:05:00Z"
   }]
-
-}`;
+`;
 
 export const TemplateForm = ({ existing, alertManagerSourceName, config, provenance }: Props) => {
   const styles = useStyles2(getStyles);
@@ -131,6 +131,7 @@ export const TemplateForm = ({ existing, alertManagerSourceName, config, provena
     formState: { errors },
     getValues,
     setValue,
+    watch,
   } = formApi;
 
   const validateNameIsUnique: Validate<string> = (name: string) => {
@@ -205,6 +206,7 @@ export const TemplateForm = ({ existing, alertManagerSourceName, config, provena
                 payload={payload}
                 payloadFormatError={payloadFormatError}
                 setPayloadFormatError={setPayloadFormatError}
+                templateName={watch('name')}
               />
             ) : (
               <TemplateDataDocs />
@@ -328,9 +330,11 @@ export function TemplatePreview({
   payload,
   setPayloadFormatError,
   payloadFormatError,
+  templateName,
 }: {
   payload: string;
   payloadFormatError: string | null;
+  templateName: string;
   setPayloadFormatError: (value: React.SetStateAction<string | null>) => void;
 }) {
   const styles = useStyles2(getStyles);
@@ -344,8 +348,8 @@ export function TemplatePreview({
 
   const onPreview = () => {
     try {
-      JSON.parse(payload);
-      trigger({ template: templateContent, payload: JSON.parse(payload) });
+      const alertList: AlertFields[] = JSON.parse(payload);
+      trigger({ template: templateContent, alerts: alertList, name: templateName });
       setPayloadFormatError(null);
     } catch (e) {
       setPayloadFormatError(e instanceof Error ? e.message : 'Invalid JSON.');

--- a/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
@@ -283,16 +283,16 @@ function TemplatingGuideline() {
 }
 
 function getResultsToRender(results: TemplatePreviewResult[]) {
-  const moreThanOne = results.length > 1;
-  const preview = (result: TemplatePreviewResult) =>
-    moreThanOne ? `Preview for ${result.name}:\n${result.text}` : `{result.text}`;
+  const filteredResults = results.filter((result) => result.text.trim().length > 0);
 
-  return results
+  const moreThanOne = filteredResults.length > 1;
+
+  const preview = (result: TemplatePreviewResult) =>
+    moreThanOne ? `Preview for ${result.name}:\n${result.text}` : `${result.text}`;
+
+  return filteredResults
     .map((result: TemplatePreviewResult) => {
-      if (result.text.trim().length > 0) {
-        return preview(result);
-      }
-      return '';
+      return preview(result);
     })
     .join(`\n`);
 }

--- a/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
@@ -317,10 +317,12 @@ function getPreviewTorender(
   payloadFormatError: string | null,
   data: TemplatesPreviewResponse | undefined
 ) {
+  // ERRORS IN JSON OR IN REQUEST (endpoint not available, for example)
   const previewErrorRequest = isPreviewError ? PREVIEW_NOT_AVAILABLE : undefined;
   const somethingWasWrong: boolean = isPreviewError || Boolean(payloadFormatError);
   const errorToRender = payloadFormatError || previewErrorRequest;
 
+  //PREVIEW : RESULTS AND ERRORS
   const previewResponseResults = data?.results;
   const previewResponseErrors = data?.errors;
 

--- a/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
@@ -63,7 +63,7 @@ interface Props {
 }
 export const isDuplicating = (location: Location) => location.pathname.endsWith('/duplicate');
 
-export const DEFAULT_PAYLOAD = `[
+const DEFAULT_PAYLOAD = `[
   {
     "annotations": {
       "summary": "Instance instance1 has been down for more than 5 minutes"

--- a/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
@@ -28,9 +28,9 @@ import { useDispatch } from 'app/types';
 import {
   AlertField,
   TemplatePreviewErrors,
+  TemplatePreviewResponse,
   TemplatePreviewResult,
-  TemplatesPreviewResponse,
-  usePreviewPayloadMutation,
+  usePreviewTemplateMutation,
 } from '../../api/templateApi';
 import { useUnifiedAlertingSelector } from '../../hooks/useUnifiedAlertingSelector';
 import { updateAlertManagerConfigAction } from '../../state/actions';
@@ -88,7 +88,6 @@ export const TemplateForm = ({ existing, alertManagerSourceName, config, provena
   const isduplicating = isDuplicating(location);
 
   const [payload, setPayload] = useState(DEFAULT_PAYLOAD);
-  const [payloadFormatError, setPayloadFormatError] = useState<string | null>(null);
 
   const [isTemplateDataDocsOpen, toggleTemplateDataDocsOpen] = useToggle(false);
 
@@ -224,12 +223,7 @@ export const TemplateForm = ({ existing, alertManagerSourceName, config, provena
                     </div>
                   </div>
                 ) : (
-                  <TemplatePreview
-                    payload={payload}
-                    payloadFormatError={payloadFormatError}
-                    setPayloadFormatError={setPayloadFormatError}
-                    templateName={watch('name')}
-                  />
+                  <TemplatePreview payload={payload} templateName={watch('name')} />
                 )}
               </div>
             </div>
@@ -335,7 +329,7 @@ export const PREVIEW_NOT_AVAILABLE = 'Preview is not available';
 function getPreviewTorender(
   isPreviewError: boolean,
   payloadFormatError: string | null,
-  data: TemplatesPreviewResponse | undefined
+  data: TemplatePreviewResponse | undefined
 ) {
   // ERRORS IN JSON OR IN REQUEST (endpoint not available, for example)
   const previewErrorRequest = isPreviewError ? PREVIEW_NOT_AVAILABLE : undefined;
@@ -356,23 +350,14 @@ function getPreviewTorender(
   }
 }
 
-export function TemplatePreview({
-  payload,
-  setPayloadFormatError,
-  payloadFormatError,
-  templateName,
-}: {
-  payload: string;
-  payloadFormatError: string | null;
-  templateName: string;
-  setPayloadFormatError: (value: React.SetStateAction<string | null>) => void;
-}) {
+export function TemplatePreview({ payload, templateName }: { payload: string; templateName: string }) {
   const styles = useStyles2(getStyles);
 
   const { watch } = useFormContext<TemplateFormValues>();
 
   const templateContent = watch('content');
-  const [trigger, { data, isError: isPreviewError, isLoading }] = usePreviewPayloadMutation();
+  const [payloadFormatError, setPayloadFormatError] = useState<string | null>(null);
+  const [trigger, { data, isError: isPreviewError, isLoading }] = usePreviewTemplateMutation();
 
   const previewToRender = getPreviewTorender(isPreviewError, payloadFormatError, data);
 

--- a/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
@@ -358,6 +358,7 @@ export function TemplatePreview({
   const onPreview = useCallback(() => {
     try {
       const alertList: AlertField[] = JSON.parse(payload);
+      JSON.stringify([...alertList]); // check if it's iterable, in order to be able to add more data
       trigger({ template: templateContent, alerts: alertList, name: templateName });
       setPayloadFormatError(null);
     } catch (e) {

--- a/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
@@ -21,6 +21,7 @@ import {
 } from '../../api/templateApi';
 import { useUnifiedAlertingSelector } from '../../hooks/useUnifiedAlertingSelector';
 import { updateAlertManagerConfigAction } from '../../state/actions';
+import { GRAFANA_RULES_SOURCE_NAME } from '../../utils/datasource';
 import { makeAMLink } from '../../utils/misc';
 import { initialAsyncRequestState } from '../../utils/redux';
 import { ensureDefine } from '../../utils/templates';
@@ -187,24 +188,31 @@ export const TemplateForm = ({ existing, alertManagerSourceName, config, provena
                 </LinkButton>
               </div>
             </div>
-            <TemplatePreview
-              payload={payload}
-              payloadFormatError={payloadFormatError}
-              setPayloadFormatError={setPayloadFormatError}
-            />
+            {alertManagerSourceName === GRAFANA_RULES_SOURCE_NAME ? (
+              <TemplatePreview
+                payload={payload}
+                payloadFormatError={payloadFormatError}
+                setPayloadFormatError={setPayloadFormatError}
+              />
+            ) : (
+              <TemplateDataDocs />
+            )}
           </div>
         </FieldSet>
-
-        <ExpandableSection
-          title="Data Cheat sheet"
-          isOpen={isTemplateDataDocsOpen}
-          toggleOpen={toggleTemplateDataDocsOpen}
-        >
-          <TemplateDataDocs />
-        </ExpandableSection>
-        <ExpandableSection title="Edit Payload" isOpen={isPayloadEditorOpen} toggleOpen={toggleIsPayloadEditorOpen}>
-          <PayloadEditor payload={payload} setPayload={setPayload} />
-        </ExpandableSection>
+        {alertManagerSourceName === GRAFANA_RULES_SOURCE_NAME && (
+          <>
+            <ExpandableSection
+              title="Data Cheat sheet"
+              isOpen={isTemplateDataDocsOpen}
+              toggleOpen={toggleTemplateDataDocsOpen}
+            >
+              <TemplateDataDocs />
+            </ExpandableSection>
+            <ExpandableSection title="Edit Payload" isOpen={isPayloadEditorOpen} toggleOpen={toggleIsPayloadEditorOpen}>
+              <PayloadEditor payload={payload} setPayload={setPayload} />
+            </ExpandableSection>
+          </>
+        )}
       </form>
     </FormProvider>
   );

--- a/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
@@ -240,7 +240,7 @@ export const TemplateForm = ({ existing, alertManagerSourceName, config, provena
             )}
           </Stack>
         </FieldSet>
-        <CollapsableSection label="Data cheat sheet" isOpen={false}>
+        <CollapsableSection label="Data cheat sheet" isOpen={false} className={styles.collapsableSection}>
           <TemplateDataDocs />
         </CollapsableSection>
       </form>
@@ -452,4 +452,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
       margin-top: ${theme.spacing(-3)};
     `,
   },
+  collapsableSection: css`
+    width: fit-content;
+  `,
 });

--- a/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
@@ -8,7 +8,7 @@ import AutoSizer from 'react-virtualized-auto-sizer';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { Stack } from '@grafana/experimental';
-import { Alert, Button, Field, FieldSet, Icon, Input, LinkButton, Spinner, TextArea, useStyles2 } from '@grafana/ui';
+import { Alert, Button, Field, FieldSet, Icon, Input, LinkButton, Spinner, useStyles2 } from '@grafana/ui';
 import { useCleanup } from 'app/core/hooks/useCleanup';
 import { AlertManagerCortexConfig } from 'app/plugins/datasource/alertmanager/types';
 import { useDispatch } from 'app/types';
@@ -60,7 +60,7 @@ export const DEFAULT_PAYLOAD = `[
       "instance": "instance1"
     },
     "startsAt": "2023-04-01T00:00:00Z",
-    "endsAt": "2023-04-01T00:05:00Z"
+    "endsAt": "2023-12-01T00:05:00Z"
   }]
 `;
 
@@ -289,8 +289,16 @@ function ExpandableSection({ isOpen, toggleOpen, children, title }: ExpandableSe
 }
 
 function getResultsToRender(results: TemplatePreviewResult[]) {
-  return results.map((result: TemplatePreviewResult) => `Preview for ${result.name}:\n${result.text}`).join(`\n\n`);
+  return results
+    .map((result: TemplatePreviewResult) => {
+      if (result.text.trim().length > 0) {
+        return `Preview for ${result.name}:\n${result.text}`;
+      }
+      return '';
+    })
+    .join(`\n`);
 }
+
 function getErrorsToRender(results: TemplatePreviewErrors[]) {
   return results
     .map((result: TemplatePreviewErrors) => {
@@ -300,7 +308,7 @@ function getErrorsToRender(results: TemplatePreviewErrors[]) {
         return `ERROR:\n${result.kind}\n${result.message}`;
       }
     })
-    .join(`\n\n`);
+    .join(`\n`);
 }
 export const PREVIEW_NOT_AVAILABLE = 'Preview is not available';
 
@@ -322,7 +330,7 @@ function getPreviewTorender(
   if (somethingWasWrong) {
     return errorToRender;
   } else {
-    return `${previewResultsToRender}\n\n${previewErrorsToRender}`;
+    return `${previewResultsToRender}\n${previewErrorsToRender}`;
   }
 }
 
@@ -363,21 +371,14 @@ export function TemplatePreview({
       </Button>
 
       <Stack direction="column">
-        <div className={styles.preview.title}> Preview</div>
         {isLoading && (
           <>
             <Spinner inline={true} /> Loading preview...
           </>
         )}
-        <TextArea
-          required={true}
-          value={previewToRender}
-          disabled={true}
-          className={styles.preview.textArea}
-          rows={10}
-          cols={50}
-          data-testid="payloadJSON"
-        />
+        <pre className={styles.preview.result} data-testid="payloadJSON">
+          {previewToRender}
+        </pre>
       </Stack>
     </Stack>
   );
@@ -437,12 +438,9 @@ const getStyles = (theme: GrafanaTheme2) => ({
     margin: 0,
   }),
   preview: {
-    title: css`
-    fontSize: ${theme.typography.bodySmall.fontSize};,
-    `,
-    textArea: css`
-      width: 605px;
-      height: 291px;
+    result: css`
+      width: 570px;
+      height: 363px;
     `,
   },
 });

--- a/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
@@ -8,7 +8,7 @@ import AutoSizer from 'react-virtualized-auto-sizer';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { Stack } from '@grafana/experimental';
-import { Alert, Button, Field, FieldSet, Icon, Input, LinkButton, TextArea, useStyles2 } from '@grafana/ui';
+import { Alert, Button, Field, FieldSet, Icon, Input, LinkButton, Spinner, TextArea, useStyles2 } from '@grafana/ui';
 import { useCleanup } from 'app/core/hooks/useCleanup';
 import { AlertManagerCortexConfig } from 'app/plugins/datasource/alertmanager/types';
 import { useDispatch } from 'app/types';
@@ -338,7 +338,7 @@ export function TemplatePreview({
   const { watch } = useFormContext<TemplateFormValues>();
 
   const templateContent = watch('content');
-  const [trigger, { data, isError: isPreviewError }] = usePreviewPayloadMutation();
+  const [trigger, { data, isError: isPreviewError, isLoading }] = usePreviewPayloadMutation();
 
   const previewToRender = getPreviewTorender(isPreviewError, payloadFormatError, data);
 
@@ -360,6 +360,11 @@ export function TemplatePreview({
 
       <Stack direction="column">
         <div className={styles.preview.title}> Preview</div>
+        {isLoading && (
+          <>
+            <Spinner inline={true} /> Loading preview...
+          </>
+        )}
         <TextArea
           required={true}
           value={previewToRender}

--- a/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
@@ -290,7 +290,15 @@ function getResultsToRender(results: TemplatePreviewResult[]) {
   return results.map((result: TemplatePreviewResult) => `Preview for ${result.name}:\n${result.text}`).join(`\n\n`);
 }
 function getErrorsToRender(results: TemplatePreviewErrors[]) {
-  return results.map((result: TemplatePreviewErrors) => `ERROR in ${result.name}:\n${result.error}`).join(`\n\n`);
+  return results
+    .map((result: TemplatePreviewErrors) => {
+      if (result.name) {
+        return `ERROR in ${result.name}:\n`.concat(`${result.kind}\n${result.message}`);
+      } else {
+        return `ERROR:\n${result.kind}\n${result.message}`;
+      }
+    })
+    .join(`\n\n`);
 }
 export const PREVIEW_NOT_AVAILABLE = 'Preview is not available';
 

--- a/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
@@ -4,7 +4,6 @@ import { Location } from 'history';
 import React, { useCallback, useEffect, useState } from 'react';
 import { FormProvider, useForm, useFormContext, Validate } from 'react-hook-form';
 import { useLocation } from 'react-router-dom';
-import AutoSizer from 'react-virtualized-auto-sizer';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { Stack } from '@grafana/experimental';
@@ -189,16 +188,12 @@ export const TemplateForm = ({ existing, alertManagerSourceName, config, provena
                   <div>
                     <Field error={errors?.content?.message} invalid={!!errors.content?.message} required>
                       <div className={styles.editWrapper}>
-                        <AutoSizer>
-                          {({ width, height }) => (
-                            <TemplateEditor
-                              value={getValues('content')}
-                              width={width}
-                              height={height}
-                              onBlur={(value) => setValue('content', value)}
-                            />
-                          )}
-                        </AutoSizer>
+                        <TemplateEditor
+                          value={getValues('content')}
+                          width={640}
+                          height={363}
+                          onBlur={(value) => setValue('content', value)}
+                        />
                       </div>
                     </Field>
                     <div className={styles.buttons}>
@@ -379,6 +374,9 @@ export function TemplatePreview({
         <pre className={styles.preview.result} data-testid="payloadJSON">
           {previewToRender}
         </pre>
+        <Button onClick={onPreview} className={styles.preview.button} icon="arrow-up" type="button" variant="secondary">
+          Refresh preview
+        </Button>
       </Stack>
     </Stack>
   );
@@ -387,6 +385,7 @@ export function TemplatePreview({
 const getStyles = (theme: GrafanaTheme2) => ({
   contentContainer: css`
     display: flex;
+    padding-top: 10px;
     gap: ${theme.spacing(2)};
     flex-direction: row;
     align-items: flex-start;
@@ -407,6 +406,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     & > * + * {
       margin-left: ${theme.spacing(1)};
     }
+    margin-top: -7px;
   `,
   textarea: css`
     max-width: 758px;
@@ -415,7 +415,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     display: block;
     position: relative;
     width: 640px;
-    height: 320px;
+    height: 363px;
   `,
   toggle: css({
     color: theme.colors.text.secondary,
@@ -439,8 +439,13 @@ const getStyles = (theme: GrafanaTheme2) => ({
   }),
   preview: {
     result: css`
-      width: 570px;
+      width: 640px;
       height: 363px;
+    `,
+    button: css`
+      flex: none;
+      width: fit-content;
+      margin-top: ${theme.spacing(-3)};
     `,
   },
 });

--- a/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
@@ -240,7 +240,7 @@ export const TemplateForm = ({ existing, alertManagerSourceName, config, provena
         </FieldSet>
         <>
           <ExpandableSection
-            title="Data Cheat sheet"
+            title="Data cheat sheet"
             isOpen={isTemplateDataDocsOpen}
             toggleOpen={toggleTemplateDataDocsOpen}
           >

--- a/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
@@ -90,7 +90,6 @@ export const TemplateForm = ({ existing, alertManagerSourceName, config, provena
   const [payload, setPayload] = useState(DEFAULT_PAYLOAD);
   const [payloadFormatError, setPayloadFormatError] = useState<string | null>(null);
 
-  const [isPayloadEditorOpen, toggleIsPayloadEditorOpen] = useToggle(false);
   const [isTemplateDataDocsOpen, toggleTemplateDataDocsOpen] = useToggle(false);
 
   const [view, setView] = useState<'content' | 'preview'>('content');
@@ -177,61 +176,67 @@ export const TemplateForm = ({ existing, alertManagerSourceName, config, provena
             />
           </Field>
           <TemplatingGuideline />
-
-          <TabsBar>
-            <Tab label="Content" active={view === 'content'} onChangeTab={() => setView('content')} />
-            {alertManagerSourceName === GRAFANA_RULES_SOURCE_NAME && (
-              <Tab label="Preview" active={view === 'preview'} onChangeTab={() => setView('preview')} />
-            )}
-          </TabsBar>
-          <div className={styles.contentContainer}>
-            {view === 'content' ? (
-              <div>
-                <Field error={errors?.content?.message} invalid={!!errors.content?.message} required>
-                  <div className={styles.editWrapper}>
-                    <AutoSizer>
-                      {({ width, height }) => (
-                        <TemplateEditor
-                          value={getValues('content')}
-                          width={width}
-                          height={height}
-                          onBlur={(value) => setValue('content', value)}
-                        />
+          <Stack direction="row" alignItems={'center'}>
+            <div>
+              <TabsBar>
+                <Tab label="Content" active={view === 'content'} onChangeTab={() => setView('content')} />
+                {alertManagerSourceName === GRAFANA_RULES_SOURCE_NAME && (
+                  <Tab label="Preview" active={view === 'preview'} onChangeTab={() => setView('preview')} />
+                )}
+              </TabsBar>
+              <div className={styles.contentContainer}>
+                {view === 'content' ? (
+                  <div>
+                    <Field error={errors?.content?.message} invalid={!!errors.content?.message} required>
+                      <div className={styles.editWrapper}>
+                        <AutoSizer>
+                          {({ width, height }) => (
+                            <TemplateEditor
+                              value={getValues('content')}
+                              width={width}
+                              height={height}
+                              onBlur={(value) => setValue('content', value)}
+                            />
+                          )}
+                        </AutoSizer>
+                      </div>
+                    </Field>
+                    <div className={styles.buttons}>
+                      {loading && (
+                        <Button disabled={true} icon="fa fa-spinner" variant="primary">
+                          Saving...
+                        </Button>
                       )}
-                    </AutoSizer>
+                      {!loading && (
+                        <Button type="submit" variant="primary">
+                          Save template
+                        </Button>
+                      )}
+                      <LinkButton
+                        disabled={loading}
+                        href={makeAMLink('alerting/notifications', alertManagerSourceName)}
+                        variant="secondary"
+                        type="button"
+                        fill="outline"
+                      >
+                        Cancel
+                      </LinkButton>
+                    </div>
                   </div>
-                </Field>
-                <div className={styles.buttons}>
-                  {loading && (
-                    <Button disabled={true} icon="fa fa-spinner" variant="primary">
-                      Saving...
-                    </Button>
-                  )}
-                  {!loading && (
-                    <Button type="submit" variant="primary">
-                      Save template
-                    </Button>
-                  )}
-                  <LinkButton
-                    disabled={loading}
-                    href={makeAMLink('alerting/notifications', alertManagerSourceName)}
-                    variant="secondary"
-                    type="button"
-                    fill="outline"
-                  >
-                    Cancel
-                  </LinkButton>
-                </div>
+                ) : (
+                  <TemplatePreview
+                    payload={payload}
+                    payloadFormatError={payloadFormatError}
+                    setPayloadFormatError={setPayloadFormatError}
+                    templateName={watch('name')}
+                  />
+                )}
               </div>
-            ) : (
-              <TemplatePreview
-                payload={payload}
-                payloadFormatError={payloadFormatError}
-                setPayloadFormatError={setPayloadFormatError}
-                templateName={watch('name')}
-              />
+            </div>
+            {alertManagerSourceName === GRAFANA_RULES_SOURCE_NAME && (
+              <PayloadEditor payload={payload} setPayload={setPayload} defaultPayload={DEFAULT_PAYLOAD} />
             )}
-          </div>
+          </Stack>
         </FieldSet>
         <>
           <ExpandableSection
@@ -240,9 +245,6 @@ export const TemplateForm = ({ existing, alertManagerSourceName, config, provena
             toggleOpen={toggleTemplateDataDocsOpen}
           >
             <TemplateDataDocs />
-          </ExpandableSection>
-          <ExpandableSection title="Edit Payload" isOpen={isPayloadEditorOpen} toggleOpen={toggleIsPayloadEditorOpen}>
-            <PayloadEditor payload={payload} setPayload={setPayload} defaultPayload={DEFAULT_PAYLOAD} />
           </ExpandableSection>
         </>
       </form>

--- a/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
@@ -14,7 +14,7 @@ import { AlertManagerCortexConfig } from 'app/plugins/datasource/alertmanager/ty
 import { useDispatch } from 'app/types';
 
 import {
-  AlertFields,
+  AlertField,
   TemplatePreviewErrors,
   TemplatePreviewResult,
   TemplatesPreviewResponse,
@@ -356,7 +356,7 @@ export function TemplatePreview({
 
   const onPreview = () => {
     try {
-      const alertList: AlertFields[] = JSON.parse(payload);
+      const alertList: AlertField[] = JSON.parse(payload);
       trigger({ template: templateContent, alerts: alertList, name: templateName });
       setPayloadFormatError(null);
     } catch (e) {

--- a/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
@@ -283,10 +283,14 @@ function TemplatingGuideline() {
 }
 
 function getResultsToRender(results: TemplatePreviewResult[]) {
+  const moreThanOne = results.length > 1;
+  const preview = (result: TemplatePreviewResult) =>
+    moreThanOne ? `Preview for ${result.name}:\n${result.text}` : `{result.text}`;
+
   return results
     .map((result: TemplatePreviewResult) => {
       if (result.text.trim().length > 0) {
-        return `Preview for ${result.name}:\n${result.text}`;
+        return preview(result);
       }
       return '';
     })

--- a/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { addDays } from 'date-fns';
+import { subDays } from 'date-fns';
 import { Location } from 'history';
 import React, { useCallback, useEffect, useState } from 'react';
 import { FormProvider, useForm, useFormContext, Validate } from 'react-hook-form';
@@ -70,7 +70,7 @@ const DEFAULT_PAYLOAD = `[
     "labels": {
       "instance": "instance1"
     },
-    "startsAt": "${addDays(new Date(), -1).toISOString()}"
+    "startsAt": "${subDays(new Date(), 1).toISOString()}"
   }]
 `;
 

--- a/public/app/features/alerting/unified/components/receivers/TemplatePreview.test.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplatePreview.test.tsx
@@ -130,7 +130,10 @@ describe('TemplatePreview component', () => {
   it('Should render preview response with some errors, after clicking preview, if payload has correct format after clicking preview button', async () => {
     const response: TemplatesPreviewResponse = {
       results: [{ name: 'template1', text: 'This is the template result bla bla bla' }],
-      errors: [{ name: 'template2', error: 'Unexpected "{" in operand' }],
+      errors: [
+        { name: 'template2', message: 'Unexpected "{" in operand', kind: 'kind_of_error' },
+        { name: 'template3', kind: 'kind_of_error', message: 'Unexpected "{" in operand' },
+      ],
     };
     mockPreviewTemplateResponse(server, response);
     render(
@@ -149,7 +152,7 @@ describe('TemplatePreview component', () => {
     await userEvent.click(within(button).getByText(/preview/i));
     await waitFor(() => {
       expect(screen.getByTestId('payloadJSON')).toHaveTextContent(
-        'Preview for template1: This is the template result bla bla bla ERROR in template2: Unexpected "{" in operand'
+        'Preview for template1: This is the template result bla bla bla ERROR in template2: kind_of_error Unexpected "{" in operand ERROR in template3: kind_of_error Unexpected "{" in operand'
       );
     });
   });

--- a/public/app/features/alerting/unified/components/receivers/TemplatePreview.test.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplatePreview.test.tsx
@@ -1,5 +1,4 @@
-import { render, screen, waitFor, within } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render, screen, waitFor } from '@testing-library/react';
 import { setupServer } from 'msw/node';
 import { default as React } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
@@ -59,7 +58,7 @@ describe('TemplatePreview component', () => {
     });
   });
 
-  it('Should render error if payload has wrong format after clicking preview button', async () => {
+  it('Should render error if payload has wrong format rendering the preview', async () => {
     render(
       <TemplatePreview
         payload={'whatever'}
@@ -69,18 +68,13 @@ describe('TemplatePreview component', () => {
       />,
       { wrapper: getProviderWraper() }
     );
-    const button = screen.getByRole('button', {
-      name: /preview/i,
-    });
 
-    within(button).getByText(/preview/i);
-    await userEvent.click(within(button).getByText(/preview/i));
     await waitFor(() => {
       expect(screen.getByTestId('payloadJSON')).toHaveTextContent('ERROR IN JSON FORMAT');
     });
   });
 
-  it('Should render error in preview response , after clicking preview, if payload has correct format after clicking preview button, but preview request has been rejected', async () => {
+  it('Should render error in preview response , if payload has correct format but preview request has been rejected', async () => {
     mockPreviewTemplateResponseRejected(server);
     render(
       <TemplatePreview
@@ -91,18 +85,13 @@ describe('TemplatePreview component', () => {
       />,
       { wrapper: getProviderWraper() }
     );
-    const button = screen.getByRole('button', {
-      name: /preview/i,
-    });
 
-    within(button).getByText(/preview/i);
-    await userEvent.click(within(button).getByText(/preview/i));
     await waitFor(() => {
       expect(screen.getByTestId('payloadJSON')).toHaveTextContent(PREVIEW_NOT_AVAILABLE);
     });
   });
 
-  it('Should render preview response , after clicking preview, if payload has correct format after clicking preview button', async () => {
+  it('Should render preview response , if payload has correct ', async () => {
     const response: TemplatesPreviewResponse = {
       results: [
         { name: 'template1', text: 'This is the template result bla bla bla' },
@@ -119,19 +108,14 @@ describe('TemplatePreview component', () => {
       />,
       { wrapper: getProviderWraper() }
     );
-    const button = screen.getByRole('button', {
-      name: /preview/i,
-    });
 
-    within(button).getByText(/preview/i);
-    await userEvent.click(within(button).getByText(/preview/i));
     await waitFor(() => {
       expect(screen.getByTestId('payloadJSON')).toHaveTextContent(
         'Preview for template1: This is the template result bla bla bla Preview for template2: This is the template2 result bla bla bla'
       );
     });
   });
-  it('Should render preview response with some errors, after clicking preview, if payload has correct format after clicking preview button', async () => {
+  it('Should render preview response with some errors,  if payload has correct format ', async () => {
     const response: TemplatesPreviewResponse = {
       results: [{ name: 'template1', text: 'This is the template result bla bla bla' }],
       errors: [
@@ -149,12 +133,6 @@ describe('TemplatePreview component', () => {
       />,
       { wrapper: getProviderWraper() }
     );
-    const button = screen.getByRole('button', {
-      name: /preview/i,
-    });
-
-    within(button).getByText(/preview/i);
-    await userEvent.click(within(button).getByText(/preview/i));
     await waitFor(() => {
       expect(screen.getByTestId('payloadJSON')).toHaveTextContent(
         'Preview for template1: This is the template result bla bla bla ERROR in template2: kind_of_error Unexpected "{" in operand ERROR in template3: kind_of_error Unexpected "{" in operand'

--- a/public/app/features/alerting/unified/components/receivers/TemplatePreview.test.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplatePreview.test.tsx
@@ -136,7 +136,7 @@ describe('TemplatePreview component', () => {
     );
     await waitFor(() => {
       expect(screen.getByTestId('payloadJSON')).toHaveTextContent(
-        'Preview for template1: This is the template result bla bla bla ERROR in template2: kind_of_error Unexpected "{" in operand ERROR in template3: kind_of_error Unexpected "{" in operand'
+        'This is the template result bla bla bla ERROR in template2: kind_of_error Unexpected "{" in operand ERROR in template3: kind_of_error Unexpected "{" in operand'
       );
     });
   });

--- a/public/app/features/alerting/unified/components/receivers/TemplatePreview.test.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplatePreview.test.tsx
@@ -50,6 +50,7 @@ describe('TemplatePreview component', () => {
         payload={'whatever'}
         payloadFormatError={'ERROR IN JSON FORMAT'}
         setPayloadFormatError={mockSetPayloadFormatError}
+        templateName="potato"
       />,
       { wrapper: getProviderWraper() }
     );
@@ -64,6 +65,7 @@ describe('TemplatePreview component', () => {
         payload={'whatever'}
         payloadFormatError={'ERROR IN JSON FORMAT'}
         setPayloadFormatError={mockSetPayloadFormatError}
+        templateName="potato"
       />,
       { wrapper: getProviderWraper() }
     );
@@ -85,6 +87,7 @@ describe('TemplatePreview component', () => {
         payload={'{"a":"b"}'}
         payloadFormatError={null}
         setPayloadFormatError={mockSetPayloadFormatError}
+        templateName="potato"
       />,
       { wrapper: getProviderWraper() }
     );
@@ -112,6 +115,7 @@ describe('TemplatePreview component', () => {
         payload={'{"a":"b"}'}
         payloadFormatError={null}
         setPayloadFormatError={mockSetPayloadFormatError}
+        templateName="potato"
       />,
       { wrapper: getProviderWraper() }
     );
@@ -141,6 +145,7 @@ describe('TemplatePreview component', () => {
         payload={'{"a":"b"}'}
         payloadFormatError={null}
         setPayloadFormatError={mockSetPayloadFormatError}
+        templateName="potato"
       />,
       { wrapper: getProviderWraper() }
     );

--- a/public/app/features/alerting/unified/components/receivers/TemplatePreview.test.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplatePreview.test.tsx
@@ -9,12 +9,11 @@ import { backendSrv } from 'app/core/services/backend_srv';
 import { configureStore } from 'app/store/configureStore';
 
 import 'whatwg-fetch';
-import { TemplatesPreviewResponse } from '../../api/templateApi';
+import { TemplatePreviewResponse } from '../../api/templateApi';
 import { mockPreviewTemplateResponse, mockPreviewTemplateResponseRejected } from '../../mocks/templatesApi';
 
 import { defaults, PREVIEW_NOT_AVAILABLE, TemplateFormValues, TemplatePreview } from './TemplateForm';
 
-const mockSetPayloadFormatError = jest.fn();
 const getProviderWraper = () => {
   return function Wrapper({ children }: React.PropsWithChildren<{}>) {
     const store = configureStore();
@@ -44,47 +43,25 @@ afterAll(() => {
 
 describe('TemplatePreview component', () => {
   it('Should render error if payload has wrong format', async () => {
-    render(
-      <TemplatePreview
-        payload={'whatever'}
-        payloadFormatError={'ERROR IN JSON FORMAT'}
-        setPayloadFormatError={mockSetPayloadFormatError}
-        templateName="potato"
-      />,
-      { wrapper: getProviderWraper() }
-    );
+    render(<TemplatePreview payload={'bla bla bla'} templateName="potato" />, { wrapper: getProviderWraper() });
     await waitFor(() => {
-      expect(screen.getByTestId('payloadJSON')).toHaveTextContent('ERROR IN JSON FORMAT');
+      expect(screen.getByTestId('payloadJSON')).toHaveTextContent('Unexpected token b in JSON at position 0');
     });
   });
 
   it('Should render error if payload has wrong format rendering the preview', async () => {
-    render(
-      <TemplatePreview
-        payload={'whatever'}
-        payloadFormatError={'ERROR IN JSON FORMAT'}
-        setPayloadFormatError={mockSetPayloadFormatError}
-        templateName="potato"
-      />,
-      { wrapper: getProviderWraper() }
-    );
+    render(<TemplatePreview payload={'potatos and cherries'} templateName="potato" />, {
+      wrapper: getProviderWraper(),
+    });
 
     await waitFor(() => {
-      expect(screen.getByTestId('payloadJSON')).toHaveTextContent('ERROR IN JSON FORMAT');
+      expect(screen.getByTestId('payloadJSON')).toHaveTextContent('Unexpected token p in JSON at position 0');
     });
   });
 
   it('Should render error in preview response , if payload has correct format but preview request has been rejected', async () => {
     mockPreviewTemplateResponseRejected(server);
-    render(
-      <TemplatePreview
-        payload={'{"a":"b"}'}
-        payloadFormatError={null}
-        setPayloadFormatError={mockSetPayloadFormatError}
-        templateName="potato"
-      />,
-      { wrapper: getProviderWraper() }
-    );
+    render(<TemplatePreview payload={'{"a":"b"}'} templateName="potato" />, { wrapper: getProviderWraper() });
 
     await waitFor(() => {
       expect(screen.getByTestId('payloadJSON')).toHaveTextContent(PREVIEW_NOT_AVAILABLE);
@@ -92,22 +69,14 @@ describe('TemplatePreview component', () => {
   });
 
   it('Should render preview response , if payload has correct ', async () => {
-    const response: TemplatesPreviewResponse = {
+    const response: TemplatePreviewResponse = {
       results: [
         { name: 'template1', text: 'This is the template result bla bla bla' },
         { name: 'template2', text: 'This is the template2 result bla bla bla' },
       ],
     };
     mockPreviewTemplateResponse(server, response);
-    render(
-      <TemplatePreview
-        payload={'{"a":"b"}'}
-        payloadFormatError={null}
-        setPayloadFormatError={mockSetPayloadFormatError}
-        templateName="potato"
-      />,
-      { wrapper: getProviderWraper() }
-    );
+    render(<TemplatePreview payload={'{"a":"b"}'} templateName="potato" />, { wrapper: getProviderWraper() });
 
     await waitFor(() => {
       expect(screen.getByTestId('payloadJSON')).toHaveTextContent(
@@ -116,7 +85,7 @@ describe('TemplatePreview component', () => {
     });
   });
   it('Should render preview response with some errors,  if payload has correct format ', async () => {
-    const response: TemplatesPreviewResponse = {
+    const response: TemplatePreviewResponse = {
       results: [{ name: 'template1', text: 'This is the template result bla bla bla' }],
       errors: [
         { name: 'template2', message: 'Unexpected "{" in operand', kind: 'kind_of_error' },
@@ -124,15 +93,7 @@ describe('TemplatePreview component', () => {
       ],
     };
     mockPreviewTemplateResponse(server, response);
-    render(
-      <TemplatePreview
-        payload={'{"a":"b"}'}
-        payloadFormatError={null}
-        setPayloadFormatError={mockSetPayloadFormatError}
-        templateName="potato"
-      />,
-      { wrapper: getProviderWraper() }
-    );
+    render(<TemplatePreview payload={'{"a":"b"}'} templateName="potato" />, { wrapper: getProviderWraper() });
     await waitFor(() => {
       expect(screen.getByTestId('payloadJSON')).toHaveTextContent(
         'Preview for template1: This is the template result bla bla bla ERROR in template2: kind_of_error Unexpected "{" in operand ERROR in template3: kind_of_error Unexpected "{" in operand'

--- a/public/app/features/alerting/unified/components/receivers/TemplatePreview.test.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplatePreview.test.tsx
@@ -128,7 +128,7 @@ describe('TemplatePreview component', () => {
 
     await waitFor(() => {
       expect(screen.getByTestId('payloadJSON')).toHaveTextContent(
-        'Preview for template1: This is the template result bla bla bla Preview for template2: This is the template2 result bla bla bla'
+        'Preview for template1: ======================>This is the template result bla bla bla<====================== Preview for template2: ======================>This is the template2 result bla bla bla<======================'
       );
     });
   });
@@ -152,7 +152,7 @@ describe('TemplatePreview component', () => {
     );
     await waitFor(() => {
       expect(screen.getByTestId('payloadJSON')).toHaveTextContent(
-        'This is the template result bla bla bla ERROR in template2: kind_of_error Unexpected "{" in operand ERROR in template3: kind_of_error Unexpected "{" in operand'
+        '======================>This is the template result bla bla bla<====================== ERROR in template2: kind_of_error Unexpected "{" in operand ERROR in template3: kind_of_error Unexpected "{" in operand'
       );
     });
   });

--- a/public/app/features/alerting/unified/components/receivers/TemplatePreview.test.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplatePreview.test.tsx
@@ -1,0 +1,130 @@
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { setupServer } from 'msw/node';
+import { default as React } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { Provider } from 'react-redux';
+
+import { setBackendSrv } from '@grafana/runtime';
+import { backendSrv } from 'app/core/services/backend_srv';
+import { configureStore } from 'app/store/configureStore';
+
+import 'whatwg-fetch';
+import { TemplatesPreviewResponse } from '../../api/templateApi';
+import { mockPreviewTemplateResponse, mockPreviewTemplateResponseRejected } from '../../mocks/templatesApi';
+
+import { defaults, PREVIEW_NOT_AVAILABLE, TemplateFormValues, TemplatePreview } from './TemplateForm';
+
+const mockSetPayloadFormatError = jest.fn();
+const getProviderWraper = () => {
+  return function Wrapper({ children }: React.PropsWithChildren<{}>) {
+    const store = configureStore();
+    const formApi = useForm<TemplateFormValues>({ defaultValues: defaults });
+    return (
+      <Provider store={store}>
+        <FormProvider {...formApi}>{children}</FormProvider>
+      </Provider>
+    );
+  };
+};
+
+const server = setupServer();
+
+beforeAll(() => {
+  setBackendSrv(backendSrv);
+  server.listen({ onUnhandledRequest: 'error' });
+});
+
+beforeEach(() => {
+  server.resetHandlers();
+});
+
+afterAll(() => {
+  server.close();
+});
+
+describe('TemplatePreview component', () => {
+  it('Should render error if payload has wrong format', async () => {
+    render(
+      <TemplatePreview
+        payload={'whatever'}
+        payloadFormatError={'ERROR IN JSON FORMAT'}
+        setPayloadFormatError={mockSetPayloadFormatError}
+      />,
+      { wrapper: getProviderWraper() }
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('payloadJSON')).toHaveTextContent('ERROR IN JSON FORMAT');
+    });
+  });
+
+  it('Should render error if payload has wrong format after clicking preview button', async () => {
+    render(
+      <TemplatePreview
+        payload={'whatever'}
+        payloadFormatError={'ERROR IN JSON FORMAT'}
+        setPayloadFormatError={mockSetPayloadFormatError}
+      />,
+      { wrapper: getProviderWraper() }
+    );
+    const button = screen.getByRole('button', {
+      name: /preview/i,
+    });
+
+    within(button).getByText(/preview/i);
+    await userEvent.click(within(button).getByText(/preview/i));
+    await waitFor(() => {
+      expect(screen.getByTestId('payloadJSON')).toHaveTextContent('ERROR IN JSON FORMAT');
+    });
+  });
+
+  it('Should render error in preview response , after clicking preview, if payload has correct format after clicking preview button, but preview request has been rejected', async () => {
+    mockPreviewTemplateResponseRejected(server);
+    render(
+      <TemplatePreview
+        payload={'{"a":"b"}'}
+        payloadFormatError={null}
+        setPayloadFormatError={mockSetPayloadFormatError}
+      />,
+      { wrapper: getProviderWraper() }
+    );
+    const button = screen.getByRole('button', {
+      name: /preview/i,
+    });
+
+    within(button).getByText(/preview/i);
+    await userEvent.click(within(button).getByText(/preview/i));
+    await waitFor(() => {
+      expect(screen.getByTestId('payloadJSON')).toHaveTextContent(PREVIEW_NOT_AVAILABLE);
+    });
+  });
+
+  it('Should render preview response , after clicking preview, if payload has correct format after clicking preview button', async () => {
+    const response: TemplatesPreviewResponse = {
+      results: [
+        { name: 'template1', text: 'This is the template result bla bla bla' },
+        { name: 'template2', text: 'This is the template2 result bla bla bla' },
+      ],
+    };
+    mockPreviewTemplateResponse(server, response);
+    render(
+      <TemplatePreview
+        payload={'{"a":"b"}'}
+        payloadFormatError={null}
+        setPayloadFormatError={mockSetPayloadFormatError}
+      />,
+      { wrapper: getProviderWraper() }
+    );
+    const button = screen.getByRole('button', {
+      name: /preview/i,
+    });
+
+    within(button).getByText(/preview/i);
+    await userEvent.click(within(button).getByText(/preview/i));
+    await waitFor(() => {
+      expect(screen.getByTestId('payloadJSON')).toHaveTextContent(
+        'Template: template1 This is the template result bla bla bla Template: template2 This is the template2 result bla bla bla'
+      );
+    });
+  });
+});

--- a/public/app/features/alerting/unified/components/receivers/TemplatePreview.test.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplatePreview.test.tsx
@@ -123,7 +123,33 @@ describe('TemplatePreview component', () => {
     await userEvent.click(within(button).getByText(/preview/i));
     await waitFor(() => {
       expect(screen.getByTestId('payloadJSON')).toHaveTextContent(
-        'Template: template1 This is the template result bla bla bla Template: template2 This is the template2 result bla bla bla'
+        'Preview for template1: This is the template result bla bla bla Preview for template2: This is the template2 result bla bla bla'
+      );
+    });
+  });
+  it('Should render preview response with some errors, after clicking preview, if payload has correct format after clicking preview button', async () => {
+    const response: TemplatesPreviewResponse = {
+      results: [{ name: 'template1', text: 'This is the template result bla bla bla' }],
+      errors: [{ name: 'template2', error: 'Unexpected "{" in operand' }],
+    };
+    mockPreviewTemplateResponse(server, response);
+    render(
+      <TemplatePreview
+        payload={'{"a":"b"}'}
+        payloadFormatError={null}
+        setPayloadFormatError={mockSetPayloadFormatError}
+      />,
+      { wrapper: getProviderWraper() }
+    );
+    const button = screen.getByRole('button', {
+      name: /preview/i,
+    });
+
+    within(button).getByText(/preview/i);
+    await userEvent.click(within(button).getByText(/preview/i));
+    await waitFor(() => {
+      expect(screen.getByTestId('payloadJSON')).toHaveTextContent(
+        'Preview for template1: This is the template result bla bla bla ERROR in template2: Unexpected "{" in operand'
       );
     });
   });

--- a/public/app/features/alerting/unified/components/receivers/TemplatePreview.test.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplatePreview.test.tsx
@@ -57,6 +57,22 @@ describe('TemplatePreview component', () => {
     });
   });
 
+  it('Should render error if payload is not an iterable', async () => {
+    const setError = jest.fn();
+    render(
+      <TemplatePreview
+        payload={'{"a":"b"}'}
+        templateName="potato"
+        payloadFormatError={'Unexpected token b in JSON at position 0'}
+        setPayloadFormatError={setError}
+      />,
+      { wrapper: getProviderWraper() }
+    );
+    await waitFor(() => {
+      expect(setError).toHaveBeenCalledWith('alertList is not iterable');
+    });
+  });
+
   it('Should render error if payload has wrong format rendering the preview', async () => {
     render(
       <TemplatePreview
@@ -79,7 +95,7 @@ describe('TemplatePreview component', () => {
     mockPreviewTemplateResponseRejected(server);
     render(
       <TemplatePreview
-        payload={'{"a":"b"}'}
+        payload={'[{"a":"b"}]'}
         templateName="potato"
         payloadFormatError={null}
         setPayloadFormatError={jest.fn()}
@@ -102,7 +118,7 @@ describe('TemplatePreview component', () => {
     mockPreviewTemplateResponse(server, response);
     render(
       <TemplatePreview
-        payload={'{"a":"b"}'}
+        payload={'[{"a":"b"}]'}
         templateName="potato"
         payloadFormatError={null}
         setPayloadFormatError={jest.fn()}
@@ -127,7 +143,7 @@ describe('TemplatePreview component', () => {
     mockPreviewTemplateResponse(server, response);
     render(
       <TemplatePreview
-        payload={'{"a":"b"}'}
+        payload={'[{"a":"b"}]'}
         templateName="potato"
         payloadFormatError={null}
         setPayloadFormatError={jest.fn()}

--- a/public/app/features/alerting/unified/components/receivers/TemplatePreview.test.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplatePreview.test.tsx
@@ -43,25 +43,49 @@ afterAll(() => {
 
 describe('TemplatePreview component', () => {
   it('Should render error if payload has wrong format', async () => {
-    render(<TemplatePreview payload={'bla bla bla'} templateName="potato" />, { wrapper: getProviderWraper() });
+    render(
+      <TemplatePreview
+        payload={'bla bla bla'}
+        templateName="potato"
+        payloadFormatError={'Unexpected token b in JSON at position 0'}
+        setPayloadFormatError={jest.fn()}
+      />,
+      { wrapper: getProviderWraper() }
+    );
     await waitFor(() => {
       expect(screen.getByTestId('payloadJSON')).toHaveTextContent('Unexpected token b in JSON at position 0');
     });
   });
 
   it('Should render error if payload has wrong format rendering the preview', async () => {
-    render(<TemplatePreview payload={'potatos and cherries'} templateName="potato" />, {
-      wrapper: getProviderWraper(),
-    });
+    render(
+      <TemplatePreview
+        payload={'potatos and cherries'}
+        templateName="potato"
+        payloadFormatError={'Unexpected token b in JSON at position 0'}
+        setPayloadFormatError={jest.fn()}
+      />,
+      {
+        wrapper: getProviderWraper(),
+      }
+    );
 
     await waitFor(() => {
-      expect(screen.getByTestId('payloadJSON')).toHaveTextContent('Unexpected token p in JSON at position 0');
+      expect(screen.getByTestId('payloadJSON')).toHaveTextContent('Unexpected token b in JSON at position 0');
     });
   });
 
   it('Should render error in preview response , if payload has correct format but preview request has been rejected', async () => {
     mockPreviewTemplateResponseRejected(server);
-    render(<TemplatePreview payload={'{"a":"b"}'} templateName="potato" />, { wrapper: getProviderWraper() });
+    render(
+      <TemplatePreview
+        payload={'{"a":"b"}'}
+        templateName="potato"
+        payloadFormatError={null}
+        setPayloadFormatError={jest.fn()}
+      />,
+      { wrapper: getProviderWraper() }
+    );
 
     await waitFor(() => {
       expect(screen.getByTestId('payloadJSON')).toHaveTextContent(PREVIEW_NOT_AVAILABLE);
@@ -76,7 +100,15 @@ describe('TemplatePreview component', () => {
       ],
     };
     mockPreviewTemplateResponse(server, response);
-    render(<TemplatePreview payload={'{"a":"b"}'} templateName="potato" />, { wrapper: getProviderWraper() });
+    render(
+      <TemplatePreview
+        payload={'{"a":"b"}'}
+        templateName="potato"
+        payloadFormatError={null}
+        setPayloadFormatError={jest.fn()}
+      />,
+      { wrapper: getProviderWraper() }
+    );
 
     await waitFor(() => {
       expect(screen.getByTestId('payloadJSON')).toHaveTextContent(
@@ -93,7 +125,15 @@ describe('TemplatePreview component', () => {
       ],
     };
     mockPreviewTemplateResponse(server, response);
-    render(<TemplatePreview payload={'{"a":"b"}'} templateName="potato" />, { wrapper: getProviderWraper() });
+    render(
+      <TemplatePreview
+        payload={'{"a":"b"}'}
+        templateName="potato"
+        payloadFormatError={null}
+        setPayloadFormatError={jest.fn()}
+      />,
+      { wrapper: getProviderWraper() }
+    );
     await waitFor(() => {
       expect(screen.getByTestId('payloadJSON')).toHaveTextContent(
         'Preview for template1: This is the template result bla bla bla ERROR in template2: kind_of_error Unexpected "{" in operand ERROR in template3: kind_of_error Unexpected "{" in operand'

--- a/public/app/features/alerting/unified/components/receivers/form/GenerateAlertDataModal.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/GenerateAlertDataModal.tsx
@@ -1,6 +1,5 @@
 import { css } from '@emotion/css';
 import addDays from 'date-fns/addDays';
-import pluralize from 'pluralize';
 import React, { useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 
@@ -75,7 +74,7 @@ export const GenerateAlertDataModal = ({ isOpen, onDismiss, onAccept }: Props) =
   };
 
   return (
-    <Modal onDismiss={onDismiss} isOpen={isOpen} title={'Generate alert data'}>
+    <Modal onDismiss={onDismiss} isOpen={isOpen} title={'Add alert data'}>
       <FormProvider {...formMethods}>
         <form
           onSubmit={(e) => {
@@ -96,8 +95,8 @@ export const GenerateAlertDataModal = ({ isOpen, onDismiss, onAccept }: Props) =
                 <div className={styles.flexWrapper}>
                   <Checkbox
                     {...formMethods.register('firing')}
-                    label="Firing"
-                    description="Creates a firing alert in case of checked."
+                    label="Firing alert"
+                    description="It adds firing alert data."
                   />
                   <Button
                     onClick={onAdd}
@@ -107,30 +106,28 @@ export const GenerateAlertDataModal = ({ isOpen, onDismiss, onAccept }: Props) =
                     variant="secondary"
                     disabled={!labelsOrAnnotationsAdded()}
                   >
-                    Add alert
+                    Add alert data
                   </Button>
                 </div>
               </Stack>
             </Card>
           </>
-          <div className={styles.onSubmitWrapper}>
-            <div className={styles.section}>
-              You have created {alerts.length} {pluralize('alert', alerts.length)} in the list.
-            </div>
-            <Modal.ButtonRow>
-              <Button onClick={onSubmit} disabled={alerts.length === 0} className={styles.onSubmitButton}>
-                Add this alert list to the payload
-              </Button>
-            </Modal.ButtonRow>
-          </div>
+          <div className={styles.onSubmitWrapper}></div>
           {alerts.length > 0 && (
             <Stack direction="column" gap={1}>
-              <h5> You have this alert data prepared to be added to the payload:</h5>
+              <h5> Review alert data to add to the payload:</h5>
               <pre className={styles.result} data-testid="payloadJSON">
                 {JSON.stringify(alerts, null, 2)}
               </pre>
             </Stack>
           )}
+          <div className={styles.onSubmitWrapper}>
+            <Modal.ButtonRow>
+              <Button onClick={onSubmit} disabled={alerts.length === 0} className={styles.onSubmitButton}>
+                Add alert data to the payload
+              </Button>
+            </Modal.ButtonRow>
+          </div>
         </form>
       </FormProvider>
     </Modal>

--- a/public/app/features/alerting/unified/components/receivers/form/GenerateAlertDataModal.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/GenerateAlertDataModal.tsx
@@ -36,8 +36,10 @@ const defaultValues: FormFields = {
 
 export const GenerateAlertDataModal = ({ isOpen, onDismiss, onAccept }: Props) => {
   const styles = useStyles2(getStyles);
-  const formMethods = useForm<FormFields>({ defaultValues, mode: 'onBlur' });
+
   const [alerts, setAlerts] = useState<TestTemplateAlert[]>([]);
+
+  const formMethods = useForm<FormFields>({ defaultValues, mode: 'onBlur' });
   const annotations = formMethods.watch('annotations');
   const labels = formMethods.watch('labels');
   const firing = formMethods.watch('firing');
@@ -55,7 +57,7 @@ export const GenerateAlertDataModal = ({ isOpen, onDismiss, onAccept }: Props) =
           return { ...acc, [key]: value };
         }, {}),
       startsAt: '2023-04-01T00:00:00Z',
-      endsAt: firing ? addDays(new Date(), 2).toISOString() : '2023-12-01T00:05:00Z',
+      endsAt: firing ? addDays(new Date(), 1).toISOString() : addDays(new Date(), -1).toISOString(),
     };
     setAlerts((alerts) => [...alerts, alert]);
     formMethods.reset();

--- a/public/app/features/alerting/unified/components/receivers/form/GenerateAlertDataModal.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/GenerateAlertDataModal.tsx
@@ -63,6 +63,7 @@ export const GenerateAlertDataModal = ({ isOpen, onDismiss, onAccept }: Props) =
     onAccept(alerts);
     setAlerts([]);
     formMethods.reset();
+    setStatus('firing');
   };
 
   const labelsOrAnnotationsAdded = () => {

--- a/public/app/features/alerting/unified/components/receivers/form/GenerateAlertDataModal.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/GenerateAlertDataModal.tsx
@@ -91,6 +91,7 @@ export const GenerateAlertDataModal = ({ isOpen, onDismiss, onAccept }: Props) =
             e.preventDefault();
             e.stopPropagation();
             formMethods.reset();
+            setStatus('firing');
           }}
         >
           <>

--- a/public/app/features/alerting/unified/components/receivers/form/GenerateAlertDataModal.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/GenerateAlertDataModal.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import addDays from 'date-fns/addDays';
+import { addDays, subDays } from 'date-fns';
 import React, { useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 
@@ -53,7 +53,7 @@ export const GenerateAlertDataModal = ({ isOpen, onDismiss, onAccept }: Props) =
           return { ...acc, [key]: value };
         }, {}),
       startsAt: '2023-04-01T00:00:00Z',
-      endsAt: status === 'firing' ? addDays(new Date(), 1).toISOString() : addDays(new Date(), -1).toISOString(),
+      endsAt: status === 'firing' ? addDays(new Date(), 1).toISOString() : subDays(new Date(), 1).toISOString(),
     };
     setAlerts((alerts) => [...alerts, alert]);
     formMethods.reset();

--- a/public/app/features/alerting/unified/components/receivers/form/GenerateAlertDataModal.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/GenerateAlertDataModal.tsx
@@ -1,12 +1,13 @@
 import { css } from '@emotion/css';
+import addDays from 'date-fns/addDays';
 import pluralize from 'pluralize';
 import React, { useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { Stack } from '@grafana/experimental';
-import { Button, Card, Modal, useStyles2 } from '@grafana/ui';
-import { TestReceiversAlert } from 'app/plugins/datasource/alertmanager/types';
+import { Button, Card, Checkbox, Modal, useStyles2 } from '@grafana/ui';
+import { TestTemplateAlert } from 'app/plugins/datasource/alertmanager/types';
 
 import AnnotationsField from '../../rule-editor/AnnotationsField';
 import LabelsField from '../../rule-editor/LabelsField';
@@ -14,7 +15,7 @@ import LabelsField from '../../rule-editor/LabelsField';
 interface Props {
   isOpen: boolean;
   onDismiss: () => void;
-  onAccept: (alerts: TestReceiversAlert[]) => void;
+  onAccept: (alerts: TestTemplateAlert[]) => void;
 }
 
 type AnnoField = {
@@ -25,22 +26,25 @@ type AnnoField = {
 interface FormFields {
   annotations: AnnoField[];
   labels: AnnoField[];
+  firing: boolean;
 }
 
 const defaultValues: FormFields = {
   annotations: [{ key: '', value: '' }],
   labels: [{ key: '', value: '' }],
+  firing: true,
 };
 
 export const GenerateAlertDataModal = ({ isOpen, onDismiss, onAccept }: Props) => {
   const styles = useStyles2(getStyles);
   const formMethods = useForm<FormFields>({ defaultValues, mode: 'onBlur' });
-  const [alerts, setAlerts] = useState<TestReceiversAlert[]>([]);
+  const [alerts, setAlerts] = useState<TestTemplateAlert[]>([]);
   const annotations = formMethods.watch('annotations');
   const labels = formMethods.watch('labels');
+  const firing = formMethods.watch('firing');
 
   const onAdd = () => {
-    const alert: TestReceiversAlert = {
+    const alert: TestTemplateAlert = {
       annotations: annotations
         .filter(({ key, value }) => !!key && !!value)
         .reduce((acc, { key, value }) => {
@@ -51,6 +55,8 @@ export const GenerateAlertDataModal = ({ isOpen, onDismiss, onAccept }: Props) =
         .reduce((acc, { key, value }) => {
           return { ...acc, [key]: value };
         }, {}),
+      startsAt: '2023-04-01T00:00:00Z',
+      endsAt: firing ? addDays(new Date(), 2).toISOString() : '2023-12-01T00:05:00Z',
     };
     setAlerts((alerts) => [...alerts, alert]);
     formMethods.reset();
@@ -60,6 +66,9 @@ export const GenerateAlertDataModal = ({ isOpen, onDismiss, onAccept }: Props) =
     onAccept(alerts);
     setAlerts([]);
   };
+
+  const labelsOrAnnotationsAdded =
+    (labels[0]?.key !== '' && labels[0]?.value !== '') || (annotations[0]?.key !== '' && annotations[0]?.value !== '');
 
   return (
     <Modal onDismiss={onDismiss} isOpen={isOpen} title={'Generate alert data'}>
@@ -71,36 +80,44 @@ export const GenerateAlertDataModal = ({ isOpen, onDismiss, onAccept }: Props) =
           }}
         >
           <>
-            <div className={styles.section}>
-              You have created {alerts.length} {pluralize('alert', alerts.length)} in the list.
-            </div>
             <Card>
-              <Stack direction="column">
+              <Stack direction="column" gap={1}>
                 <div className={styles.section}>
                   <AnnotationsField />
                 </div>
                 <div className={styles.section}>
                   <LabelsField />
                 </div>
-                {(annotations.length > 0 || labels.length > 0) && (
+                <div className={styles.flexWrapper}>
+                  <Checkbox
+                    {...formMethods.register('firing')}
+                    label="Firing"
+                    description="Creates a firing alert in case of checked."
+                  />
                   <Button
                     onClick={onAdd}
-                    className={styles.button}
+                    className={styles.onAddButton}
                     icon="plus-circle"
                     type="button"
                     variant="secondary"
+                    disabled={!labelsOrAnnotationsAdded}
                   >
                     Add alert
                   </Button>
-                )}
+                </div>
               </Stack>
             </Card>
           </>
-          {alerts.length > 0 && (
+          <div className={styles.onSubmitWrapper}>
+            <div className={styles.section}>
+              You have created {alerts.length} {pluralize('alert', alerts.length)} in the list.
+            </div>
             <Modal.ButtonRow>
-              <Button onClick={onSubmit}>Add this alert list</Button>
+              <Button onClick={onSubmit} disabled={alerts.length === 0} className={styles.onSubmitButton}>
+                Add this alert list
+              </Button>
             </Modal.ButtonRow>
-          )}
+          </div>
         </form>
       </FormProvider>
     </Modal>
@@ -111,9 +128,24 @@ const getStyles = (theme: GrafanaTheme2) => ({
   section: css`
     margin-bottom: ${theme.spacing(2)};
   `,
-  button: css`
+  onAddButton: css`
     flex: none;
     width: fit-content;
     padding-right: ${theme.spacing(1)};
+    margin-left: auto;
+  `,
+  flexWrapper: css`
+    display: flex;
+    flex-direction: row,
+    justify-content: space-between;
+  `,
+  onSubmitWrapper: css`
+    display: flex;
+    flex-direction: row;
+    align-items: baseline;
+    justify-content: flex-end;
+  `,
+  onSubmitButton: css`
+    margin-left: ${theme.spacing(2)};
   `,
 });

--- a/public/app/features/alerting/unified/components/receivers/form/GenerateAlertDataModal.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/GenerateAlertDataModal.tsx
@@ -65,10 +65,14 @@ export const GenerateAlertDataModal = ({ isOpen, onDismiss, onAccept }: Props) =
   const onSubmit = () => {
     onAccept(alerts);
     setAlerts([]);
+    formMethods.reset();
   };
 
-  const labelsOrAnnotationsAdded =
-    (labels[0]?.key !== '' && labels[0]?.value !== '') || (annotations[0]?.key !== '' && annotations[0]?.value !== '');
+  const labelsOrAnnotationsAdded = () => {
+    const someLabels = labels.some((lb) => lb.key !== '' && lb.value !== '');
+    const someAnnotations = annotations.some((ann) => ann.key !== '' && ann.value !== '');
+    return someLabels || someAnnotations;
+  };
 
   return (
     <Modal onDismiss={onDismiss} isOpen={isOpen} title={'Generate alert data'}>
@@ -77,6 +81,7 @@ export const GenerateAlertDataModal = ({ isOpen, onDismiss, onAccept }: Props) =
           onSubmit={(e) => {
             e.preventDefault();
             e.stopPropagation();
+            formMethods.reset();
           }}
         >
           <>
@@ -100,7 +105,7 @@ export const GenerateAlertDataModal = ({ isOpen, onDismiss, onAccept }: Props) =
                     icon="plus-circle"
                     type="button"
                     variant="secondary"
-                    disabled={!labelsOrAnnotationsAdded}
+                    disabled={!labelsOrAnnotationsAdded()}
                   >
                     Add alert
                   </Button>
@@ -114,10 +119,18 @@ export const GenerateAlertDataModal = ({ isOpen, onDismiss, onAccept }: Props) =
             </div>
             <Modal.ButtonRow>
               <Button onClick={onSubmit} disabled={alerts.length === 0} className={styles.onSubmitButton}>
-                Add this alert list
+                Add this alert list to the payload
               </Button>
             </Modal.ButtonRow>
           </div>
+          {alerts.length > 0 && (
+            <Stack direction="column" gap={1}>
+              <h5> You have this alert data prepared to be added to the payload:</h5>
+              <pre className={styles.result} data-testid="payloadJSON">
+                {JSON.stringify(alerts, null, 2)}
+              </pre>
+            </Stack>
+          )}
         </form>
       </FormProvider>
     </Modal>
@@ -147,5 +160,9 @@ const getStyles = (theme: GrafanaTheme2) => ({
   `,
   onSubmitButton: css`
     margin-left: ${theme.spacing(2)};
+  `,
+  result: css`
+    width: 570px;
+    height: 363px;
   `,
 });

--- a/public/app/features/alerting/unified/components/receivers/form/GenerateAlertDataModal.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/GenerateAlertDataModal.tsx
@@ -1,0 +1,119 @@
+import { css } from '@emotion/css';
+import pluralize from 'pluralize';
+import React, { useState } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+
+import { GrafanaTheme2 } from '@grafana/data';
+import { Stack } from '@grafana/experimental';
+import { Button, Card, Modal, useStyles2 } from '@grafana/ui';
+import { TestReceiversAlert } from 'app/plugins/datasource/alertmanager/types';
+
+import AnnotationsField from '../../rule-editor/AnnotationsField';
+import LabelsField from '../../rule-editor/LabelsField';
+
+interface Props {
+  isOpen: boolean;
+  onDismiss: () => void;
+  onAccept: (alerts: TestReceiversAlert[]) => void;
+}
+
+type AnnoField = {
+  key: string;
+  value: string;
+};
+
+interface FormFields {
+  annotations: AnnoField[];
+  labels: AnnoField[];
+}
+
+const defaultValues: FormFields = {
+  annotations: [{ key: '', value: '' }],
+  labels: [{ key: '', value: '' }],
+};
+
+export const GenerateAlertDataModal = ({ isOpen, onDismiss, onAccept }: Props) => {
+  const styles = useStyles2(getStyles);
+  const formMethods = useForm<FormFields>({ defaultValues, mode: 'onBlur' });
+  const [alerts, setAlerts] = useState<TestReceiversAlert[]>([]);
+  const annotations = formMethods.watch('annotations');
+  const labels = formMethods.watch('labels');
+
+  const onAdd = () => {
+    const alert: TestReceiversAlert = {
+      annotations: annotations
+        .filter(({ key, value }) => !!key && !!value)
+        .reduce((acc, { key, value }) => {
+          return { ...acc, [key]: value };
+        }, {}),
+      labels: labels
+        .filter(({ key, value }) => !!key && !!value)
+        .reduce((acc, { key, value }) => {
+          return { ...acc, [key]: value };
+        }, {}),
+    };
+    setAlerts((alerts) => [...alerts, alert]);
+    formMethods.reset();
+  };
+
+  const onSubmit = () => {
+    onAccept(alerts);
+    setAlerts([]);
+  };
+
+  return (
+    <Modal onDismiss={onDismiss} isOpen={isOpen} title={'Generate alert data'}>
+      <FormProvider {...formMethods}>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+          }}
+        >
+          <>
+            <div className={styles.section}>
+              You have created {alerts.length} {pluralize('alert', alerts.length)} in the list.
+            </div>
+            <Card>
+              <Stack direction="column">
+                <div className={styles.section}>
+                  <AnnotationsField />
+                </div>
+                <div className={styles.section}>
+                  <LabelsField />
+                </div>
+                {(annotations.length > 0 || labels.length > 0) && (
+                  <Button
+                    onClick={onAdd}
+                    className={styles.button}
+                    icon="plus-circle"
+                    type="button"
+                    variant="secondary"
+                  >
+                    Add alert
+                  </Button>
+                )}
+              </Stack>
+            </Card>
+          </>
+          {alerts.length > 0 && (
+            <Modal.ButtonRow>
+              <Button onClick={onSubmit}>Add this alert list</Button>
+            </Modal.ButtonRow>
+          )}
+        </form>
+      </FormProvider>
+    </Modal>
+  );
+};
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  section: css`
+    margin-bottom: ${theme.spacing(2)};
+  `,
+  button: css`
+    flex: none;
+    width: fit-content;
+    padding-right: ${theme.spacing(1)};
+  `,
+});

--- a/public/app/features/alerting/unified/components/receivers/form/GenerateAlertDataModal.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/GenerateAlertDataModal.tsx
@@ -96,7 +96,7 @@ export const GenerateAlertDataModal = ({ isOpen, onDismiss, onAccept }: Props) =
                   <Checkbox
                     {...formMethods.register('firing')}
                     label="Firing alert"
-                    description="It adds firing alert data."
+                    description="Adds firing alert data"
                   />
                   <Button
                     onClick={onAdd}
@@ -124,7 +124,7 @@ export const GenerateAlertDataModal = ({ isOpen, onDismiss, onAccept }: Props) =
           <div className={styles.onSubmitWrapper}>
             <Modal.ButtonRow>
               <Button onClick={onSubmit} disabled={alerts.length === 0} className={styles.onSubmitButton}>
-                Add alert data to the payload
+                Add alert data to payload
               </Button>
             </Modal.ButtonRow>
           </div>

--- a/public/app/features/alerting/unified/mocks/templatesApi.ts
+++ b/public/app/features/alerting/unified/mocks/templatesApi.ts
@@ -1,0 +1,21 @@
+import { rest } from 'msw';
+import { SetupServer } from 'msw/node';
+
+import {
+  defaultPayloadUrl,
+  previewTemplateUrl,
+  TemplateDefaultPayloadResponse,
+  TemplatesPreviewResponse,
+} from '../api/templateApi';
+
+export function mockDefaultPayloadResponse(server: SetupServer, response: TemplateDefaultPayloadResponse) {
+  server.use(rest.get(defaultPayloadUrl, (req, res, ctx) => res(ctx.status(200), ctx.json(response))));
+}
+
+export function mockDefaultPayloadResponseRejected(server: SetupServer) {
+  server.use(rest.get(defaultPayloadUrl, (req, res, ctx) => res(ctx.status(500), ctx.json('error'))));
+}
+
+export function mockPreviewTemplateResponse(server: SetupServer, response: TemplatesPreviewResponse) {
+  server.use(rest.get(previewTemplateUrl, (req, res, ctx) => res(ctx.status(200), ctx.json(response))));
+}

--- a/public/app/features/alerting/unified/mocks/templatesApi.ts
+++ b/public/app/features/alerting/unified/mocks/templatesApi.ts
@@ -1,20 +1,7 @@
 import { rest } from 'msw';
 import { SetupServer } from 'msw/node';
 
-import {
-  defaultPayloadUrl,
-  previewTemplateUrl,
-  TemplateDefaultPayloadResponse,
-  TemplatesPreviewResponse,
-} from '../api/templateApi';
-
-export function mockDefaultPayloadResponse(server: SetupServer, response: TemplateDefaultPayloadResponse) {
-  server.use(rest.get(defaultPayloadUrl, (req, res, ctx) => res(ctx.status(200), ctx.json(response))));
-}
-
-export function mockDefaultPayloadResponseRejected(server: SetupServer) {
-  server.use(rest.get(defaultPayloadUrl, (req, res, ctx) => res(ctx.status(500), ctx.json('error'))));
-}
+import { previewTemplateUrl, TemplatesPreviewResponse } from '../api/templateApi';
 
 export function mockPreviewTemplateResponse(server: SetupServer, response: TemplatesPreviewResponse) {
   server.use(rest.post(previewTemplateUrl, (req, res, ctx) => res(ctx.status(200), ctx.json(response))));

--- a/public/app/features/alerting/unified/mocks/templatesApi.ts
+++ b/public/app/features/alerting/unified/mocks/templatesApi.ts
@@ -1,9 +1,9 @@
 import { rest } from 'msw';
 import { SetupServer } from 'msw/node';
 
-import { previewTemplateUrl, TemplatesPreviewResponse } from '../api/templateApi';
+import { previewTemplateUrl, TemplatePreviewResponse } from '../api/templateApi';
 
-export function mockPreviewTemplateResponse(server: SetupServer, response: TemplatesPreviewResponse) {
+export function mockPreviewTemplateResponse(server: SetupServer, response: TemplatePreviewResponse) {
   server.use(rest.post(previewTemplateUrl, (req, res, ctx) => res(ctx.status(200), ctx.json(response))));
 }
 

--- a/public/app/features/alerting/unified/mocks/templatesApi.ts
+++ b/public/app/features/alerting/unified/mocks/templatesApi.ts
@@ -17,5 +17,9 @@ export function mockDefaultPayloadResponseRejected(server: SetupServer) {
 }
 
 export function mockPreviewTemplateResponse(server: SetupServer, response: TemplatesPreviewResponse) {
-  server.use(rest.get(previewTemplateUrl, (req, res, ctx) => res(ctx.status(200), ctx.json(response))));
+  server.use(rest.post(previewTemplateUrl, (req, res, ctx) => res(ctx.status(200), ctx.json(response))));
+}
+
+export function mockPreviewTemplateResponseRejected(server: SetupServer) {
+  server.use(rest.post(previewTemplateUrl, (req, res, ctx) => res(ctx.status(500), ctx.json('error'))));
 }

--- a/public/app/features/dimensions/editors/ThresholdsEditor/ThresholdsEditor.tsx
+++ b/public/app/features/dimensions/editors/ThresholdsEditor/ThresholdsEditor.tsx
@@ -1,25 +1,25 @@
 import { css } from '@emotion/css';
 import { isNumber } from 'lodash';
-import React, { PureComponent, ChangeEvent } from 'react';
+import React, { ChangeEvent, PureComponent } from 'react';
 
 import {
-  Threshold,
+  GrafanaTheme2,
+  SelectableValue,
   sortThresholds,
+  Threshold,
   ThresholdsConfig,
   ThresholdsMode,
-  SelectableValue,
-  GrafanaTheme2,
 } from '@grafana/data';
 import {
-  Input,
-  colors,
-  ColorPicker,
-  ThemeContext,
   Button,
+  ColorPicker,
+  colors,
+  IconButton,
+  Input,
   Label,
   RadioButtonGroup,
   stylesFactory,
-  IconButton,
+  ThemeContext,
 } from '@grafana/ui';
 
 const modes: Array<SelectableValue<ThresholdsMode>> = [

--- a/public/app/plugins/datasource/alertmanager/types.ts
+++ b/public/app/plugins/datasource/alertmanager/types.ts
@@ -252,6 +252,7 @@ export interface AlertmanagerStatus {
 }
 
 export type TestReceiversAlert = Pick<AlertmanagerAlert, 'annotations' | 'labels'>;
+export type TestTemplateAlert = Pick<AlertmanagerAlert, 'annotations' | 'labels' | 'startsAt' | 'endsAt'>;
 
 export interface TestReceiversPayload {
   receivers?: Receiver[];


### PR DESCRIPTION
**What is this feature?**

This PR adds the preview feature in templates form. This feature is only available for Grafana AlertManager.

**Why do we need this feature?**

This will help users understand the result of the template they are creating, by showing errors directly in the preview. This would prevent a lot of templating issues.
This PR also enables user to create alert data payload for the preview, not only editing it in a JSON editor but having an alert data editor, where user doesn't need to understand the exact JSON format for the payload.

**Who is this feature for?**

All users.

Fixes [#61764](https://github.com/grafana/grafana/issues/61764)

**Special notes for your reviewer:**

https://user-images.githubusercontent.com/33540275/234825458-4d1dc5ef-88ac-4be0-b928-038de35d9d13.mp4






Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
- [ ] There are no known compatibility issues with older supported versions of Grafana, or plugins.
- [ ] It passes the [Hosted Grafana feature readiness review](https://docs.google.com/document/d/1QL9Ly8KnXzpb6ISbg49pTODRO5mhA5tkkfIZVX6pqQU/edit) for observability, scalability, performance, and security.