### PR TITLE
Add Curl in Alpine to Support Docker Health Check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -100,7 +100,7 @@ WORKDIR $GF_PATHS_HOME
 
 # Install dependencies
 RUN if grep -i -q alpine /etc/issue; then \
-      apk add --no-cache ca-certificates bash tzdata musl-utils && \
+      apk add --no-cache ca-certificates bash curl tzdata musl-utils && \
       apk info -vv | sort; \
     elif grep -i -q ubuntu /etc/issue; then \
       DEBIAN_FRONTEND=noninteractive && \


### PR DESCRIPTION
It is pointed out [here](https://github.com/grafana/grafana/issues/60805) that there's no straightforward way to setup a working health check when running the docker image "grafana/grafana-oss:latest" because curl and wget are not installed in that docker image by default.

However, the image "grafana/grafana-oss:latest-ubuntu" does have curl installed, and so does not have the same issue when using docker or docker-compose.

I propose that we add curl into the alpine build of Grafana to match what's already available in the Ubuntu build, to make for easier docker health checks.


Testing:
My testing strategy was 2 fold, first I verified that there was an issue by doing the following:
1) Save this docker-compose.yml:
 ```
version: '3.7'
services:
  grafana:
    container_name: grafana-test
    image: "grafana/grafana-oss:dev"
    volumes:
      - 'grafana-data:/var/lib/grafana'
    ports:
      - "3000:3000"
    healthcheck:
      test: ["CMD-SHELL", "curl -f localhost:3000/api/health && echo 'ready'"]
      interval: 10s
      retries: 30
volumes:
   grafana-data: {}
```
2) Build grafana locally by running `make build-docker-full`, and then `docker-compose up -d`. 
3) Then, when I looked at the status of the health check with `docker inspect grafana-test`, this is the (truncated) output I see: 
```
"Health": {
                "Status": "unhealthy",
                "FailingStreak": 119,
                "Log": [
                    {
                        "Start": "2023-03-29T03:16:32.048807254Z",
                        "End": "2023-03-29T03:16:32.112830546Z",
                        "ExitCode": 127,
                        "Output": "/bin/sh: curl: not found\n"
                    }
```

Then, I applied my change and ran through the same steps again, and can see that the health check is happy:
```
"Health": {
    "Status": "healthy",
    "FailingStreak": 0,
    "Log": [
        {
            "Start": "2023-03-29T02:32:35.240040422Z",
            "End": "2023-03-29T02:32:35.390225714Z",
            "ExitCode": 0,
            "Output": "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n                                 Dload  Upload   Total   Spent    Left  Speed\n\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0{\n  \"commit\": \"unknown-dev\",\n  \"database\": \"ok\",\n  \"version\": \"9.5.0-pre\"\n\r100    75  100    75    0     0   3964      0 --:--:-- --:--:-- --:--:--  5000\n}ready\n"
        },
```