### PR TITLE
Docs: Update influxdb provisioning documentation to align with database deprecation

### DIFF
--- a/docs/sources/datasources/influxdb/_index.md
+++ b/docs/sources/datasources/influxdb/_index.md
@@ -114,6 +114,10 @@ Configure these options if you select the Flux query language:
 You can define and configure the data source in YAML files as part of Grafana's provisioning system.
 For more information about provisioning, and for available configuration options, refer to [Provisioning Grafana]({{< relref "../../administration/provisioning/#data-sources" >}}).
 
+> **Note:** `database` [field is deprecated](https://github.com/grafana/grafana/pull/58647).
+> We suggest to use `dbName` field in `jsonData`. Please see the examples below.
+> No need to change existing provisioning settings.
+
 #### Provisioning examples
 
 **InfluxDB 1.x example:**
@@ -125,10 +129,10 @@ datasources:
   - name: InfluxDB_v1
     type: influxdb
     access: proxy
-    database: site
     user: grafana
     url: http://localhost:8086
     jsonData:
+      dbName: site
       httpMode: GET
     secureJsonData:
       password: grafana
@@ -163,9 +167,9 @@ datasources:
     type: influxdb
     access: proxy
     url: http://localhost:8086
-    # This database should be mapped to a bucket
-    database: site
     jsonData:
+      # This database should be mapped to a bucket
+      dbName: site
       httpMode: GET
       httpHeaderName1: 'Authorization'
     secureJsonData:


### PR DESCRIPTION
**What is this feature?**

We deprecated the `database` field. See https://github.com/grafana/grafana/pull/58647
InfluxDB was still using it and we moved away from using it. 
We introduced a new field `dbName` in `jsonData`. See: https://github.com/grafana/grafana/pull/62308
This PR updates the InfluxDB provisioning docs about this change.


Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
- [x] There are no known compatibility issues with older supported versions of Grafana, or plugins.
- [x] It passes the [Hosted Grafana feature readiness review](https://docs.google.com/document/d/1QL9Ly8KnXzpb6ISbg49pTODRO5mhA5tkkfIZVX6pqQU/edit) for observability, scalability, performance, and security.