### PR TITLE
Update _index.md

### DIFF
--- a/docs/sources/getting-started/_index.md
+++ b/docs/sources/getting-started/_index.md
@@ -23,7 +23,10 @@ You have two ways to set up Grafana:
 
 ## Step 2. Connect your first data source
 
-Grafana dashboards work by querying [data sources]({{< relref "../datasources/" >}}) that you connect to Grafana. You will need to [setup a data source]({{< relref "../administration/data-source-management/" >}}) connection before you can visualize data. Data sources are setup by [installing data source plugins]({{< relref "../administration/plugin-management/#install-grafana-plugins" >}})). You can [browse data source plugins](https://grafana.com/grafana/plugins/?type=datasource) from the plugin catalog.
+Grafana dashboards work by querying [data sources]({{< relref "../datasources/" >}}) that you connect to Grafana.
+You will need to [setup a data source]({{< relref "../administration/data-source-management/" >}}) connection before you can visualize data.
+Data sources are setup by [installing data source plugins]({{< relref "../administration/plugin-management/#install-grafana-plugins" >}})).
+You can [browse data source plugins](https://grafana.com/grafana/plugins/?type=datasource) from the plugin catalog.
 
 1. Decide which data source you want to visualize. Browse the (data source plugin catalog](https://grafana.com/grafana/plugins/?type=datasource)) to see what you can connect with Grafana.
 2. Ensure the data source plugin is installed. See ([how to install data source plugins]({{< relref "../administration/data-source-management/" >}})).

--- a/docs/sources/getting-started/_index.md
+++ b/docs/sources/getting-started/_index.md
@@ -9,7 +9,7 @@ weight: 9
 
 Getting started with Grafana involves three steps:
 
-1. Setup Grafana
+1. Set up Grafana
 2. Connect your first data source
 3. Create your first dashboard
 

--- a/docs/sources/getting-started/_index.md
+++ b/docs/sources/getting-started/_index.md
@@ -31,7 +31,8 @@ You can [browse data source plugins](https://grafana.com/grafana/plugins/?type=d
 1. Decide which data source you want to visualize. Browse the (data source plugin catalog](https://grafana.com/grafana/plugins/?type=datasource)) to see what you can connect with Grafana.
 1. Ensure the data source plugin is installed.
    See ([how to install data source plugins]({{< relref "../administration/data-source-management/" >}})).
-3. Connect the data source to Grafana. See ([how to setup a data source]({{< relref "../administration/data-source-management/" >}})), which configures an instance of a connection from Grafana to that data source.
+1. Connect the data source to Grafana.
+   See ([how to setup a data source]({{< relref "../administration/data-source-management/" >}})), which configures an instance of a connection from Grafana to that data source.
 
 ## Step 3. Create your first dashboard
 

--- a/docs/sources/getting-started/_index.md
+++ b/docs/sources/getting-started/_index.md
@@ -17,7 +17,8 @@ Getting started with Grafana involves three steps:
 
 You have two ways to set up Grafana:
 
-* [Setup Grafana on Grafana Cloud]("https://grafana.com/docs/grafana-cloud/quickstart/") without having to install it or run it yourself. This is the fastest way to get started and the easiest way to use Grafana.
+- [Set up Grafana on Grafana Cloud]("https://grafana.com/docs/grafana-cloud/quickstart/") without having to install it or run it yourself.
+  This is the fastest way to get started and the easiest way to use Grafana.
 * [Setup Grafana on your own infrastructure]({{< relref "../setup-grafana/installation/" >}}) such as an operating system, Kubernetes cluster, or Docker container.
 
 ## Step 2. Connect your first data source

--- a/docs/sources/getting-started/_index.md
+++ b/docs/sources/getting-started/_index.md
@@ -10,7 +10,7 @@ weight: 9
 Getting started with Grafana involves three steps:
 
 1. Set up Grafana
-2. Connect your first data source
+1. Connect your first data source
 3. Create your first dashboard
 
 ## Step 1. Setup Grafana

--- a/docs/sources/getting-started/_index.md
+++ b/docs/sources/getting-started/_index.md
@@ -28,17 +28,16 @@ You must [set up a data source]({{< relref "../administration/data-source-manage
 You set up a data source by [installing a data source plugin]({{< relref "../administration/plugin-management/#install-grafana-plugins" >}})).
 From the plugin catalog, you can also [browse data source plugins](https://grafana.com/grafana/plugins/?type=datasource).
 
-1. Decide which data source you want to visualize. Browse the (data source plugin catalog](https://grafana.com/grafana/plugins/?type=datasource)) to see what you can connect with Grafana.
+1. Browse the [data source plugin catalog](https://grafana.com/grafana/plugins/?type=datasource) to decide which data source you want to visualize.
 1. Ensure the data source plugin is installed.
-   See ([how to install data source plugins]({{< relref "../administration/data-source-management/" >}})).
+   See [how to install data source plugins]({{< relref "../administration/data-source-management/" >}}).
 1. Connect the data source to Grafana.
    See [how to set up a data source]({< relref "../administration/data-source-management/" >}}), which configures an instance of a connection from Grafana to that data source.
 
 ## Create your first dashboard
 
 Once you have connected Grafana with one or more data sources, you can create a dashboard to visualize data from those data sources.
-This section provides guidance on how build your first dashboard after you have installed Grafana.
-It also provides step-by-step instructions on how to add a Prometheus, InfluxDB, or an MS SQL Server data source.
-Refer to [Data sources]({{< relref "../administration/data-source-management/" >}}) for a list of all supported data sources.
+
+The following topics provide guidance on how to add a Prometheus, InfluxDB, or an MS SQL Server data source and build your first dashboard.
 
 {{< section >}}

--- a/docs/sources/getting-started/_index.md
+++ b/docs/sources/getting-started/_index.md
@@ -15,7 +15,7 @@ Getting started with Grafana involves three steps:
 
 ## Step 1. Setup Grafana
 
-You have two ways to setup Grafana:
+You have two ways to set up Grafana:
 
 * [Setup Grafana on Grafana Cloud]("https://grafana.com/docs/grafana-cloud/quickstart/") without having to install it or run it yourself. This is the fastest way to get started and the easiest way to use Grafana.
 * [Setup Grafana on your own infrastructure]({{< relref "../setup-grafana/installation/" >}}) such as an operating system, Kubernetes cluster, or Docker container.

--- a/docs/sources/getting-started/_index.md
+++ b/docs/sources/getting-started/_index.md
@@ -36,6 +36,9 @@ You can [browse data source plugins](https://grafana.com/grafana/plugins/?type=d
 
 ## Step 3. Create your first dashboard
 
-Once you have connected Grafana with one or more data sources, you can create a dashboard to visualize data from those data sources. This section provides guidance on how build your first dashboard after you have installed Grafana. It also provides step-by-step instructions on how to add a Prometheus, InfluxDB, or an MS SQL Server data source. Refer to [Data sources]({{< relref "../administration/data-source-management/" >}}) for a list of all supported data sources.
+Once you have connected Grafana with one or more data sources, you can create a dashboard to visualize data from those data sources.
+This section provides guidance on how build your first dashboard after you have installed Grafana.
+It also provides step-by-step instructions on how to add a Prometheus, InfluxDB, or an MS SQL Server data source.
+Refer to [Data sources]({{< relref "../administration/data-source-management/" >}}) for a list of all supported data sources.
 
 {{< section >}}

--- a/docs/sources/getting-started/_index.md
+++ b/docs/sources/getting-started/_index.md
@@ -29,7 +29,8 @@ Data sources are setup by [installing data source plugins]({{< relref "../admini
 You can [browse data source plugins](https://grafana.com/grafana/plugins/?type=datasource) from the plugin catalog.
 
 1. Decide which data source you want to visualize. Browse the (data source plugin catalog](https://grafana.com/grafana/plugins/?type=datasource)) to see what you can connect with Grafana.
-2. Ensure the data source plugin is installed. See ([how to install data source plugins]({{< relref "../administration/data-source-management/" >}})).
+1. Ensure the data source plugin is installed.
+   See ([how to install data source plugins]({{< relref "../administration/data-source-management/" >}})).
 3. Connect the data source to Grafana. See ([how to setup a data source]({{< relref "../administration/data-source-management/" >}})), which configures an instance of a connection from Grafana to that data source.
 
 ## Step 3. Create your first dashboard

--- a/docs/sources/getting-started/_index.md
+++ b/docs/sources/getting-started/_index.md
@@ -7,34 +7,34 @@ weight: 9
 
 # Get started
 
-Getting started with Grafana involves three steps:
+To get started with Grafana you must perform the following tasks:
 
 1. Set up Grafana
 1. Connect your first data source
 1. Create your first dashboard
 
-## Step 1. Set up Grafana
+## Set up Grafana
 
-You have two ways to set up Grafana:
+Choose one of the following methods to set up Grafana:
 
-- [Set up Grafana on Grafana Cloud]("https://grafana.com/docs/grafana-cloud/quickstart/") without having to install it or run it yourself.
+- [Set up Grafana on Grafana Cloud](/docs/grafana-cloud/quickstart/) without having to install it or run it yourself.
   This is the fastest way to get started and the easiest way to use Grafana.
 - [Set up Grafana on your own infrastructure]({{< relref "../setup-grafana/installation/" >}}) such as an operating system, Kubernetes cluster, or Docker container.
 
-## Step 2. Connect your first data source
+## Connect your first data source
 
 Grafana dashboards work by querying [data sources]({{< relref "../datasources/" >}}) that you connect to Grafana.
-You will need to [setup a data source]({{< relref "../administration/data-source-management/" >}}) connection before you can visualize data.
-Data sources are setup by [installing data source plugins]({{< relref "../administration/plugin-management/#install-grafana-plugins" >}})).
-You can [browse data source plugins](https://grafana.com/grafana/plugins/?type=datasource) from the plugin catalog.
+You must [set up a data source]({{< relref "../administration/data-source-management/" >}}) connection before you can visualize data.
+You set up a data source by [installing a data source plugin]({{< relref "../administration/plugin-management/#install-grafana-plugins" >}})).
+From the plugin catalog, you can also [browse data source plugins](https://grafana.com/grafana/plugins/?type=datasource).
 
 1. Decide which data source you want to visualize. Browse the (data source plugin catalog](https://grafana.com/grafana/plugins/?type=datasource)) to see what you can connect with Grafana.
 1. Ensure the data source plugin is installed.
    See ([how to install data source plugins]({{< relref "../administration/data-source-management/" >}})).
 1. Connect the data source to Grafana.
-   See ([how to setup a data source]({{< relref "../administration/data-source-management/" >}})), which configures an instance of a connection from Grafana to that data source.
+   See [how to set up a data source]({< relref "../administration/data-source-management/" >}}), which configures an instance of a connection from Grafana to that data source.
 
-## Step 3. Create your first dashboard
+## Create your first dashboard
 
 Once you have connected Grafana with one or more data sources, you can create a dashboard to visualize data from those data sources.
 This section provides guidance on how build your first dashboard after you have installed Grafana.

--- a/docs/sources/getting-started/_index.md
+++ b/docs/sources/getting-started/_index.md
@@ -13,7 +13,7 @@ Getting started with Grafana involves three steps:
 1. Connect your first data source
 1. Create your first dashboard
 
-## Step 1. Setup Grafana
+## Step 1. Set up Grafana
 
 You have two ways to set up Grafana:
 

--- a/docs/sources/getting-started/_index.md
+++ b/docs/sources/getting-started/_index.md
@@ -19,7 +19,7 @@ You have two ways to set up Grafana:
 
 - [Set up Grafana on Grafana Cloud]("https://grafana.com/docs/grafana-cloud/quickstart/") without having to install it or run it yourself.
   This is the fastest way to get started and the easiest way to use Grafana.
-* [Setup Grafana on your own infrastructure]({{< relref "../setup-grafana/installation/" >}}) such as an operating system, Kubernetes cluster, or Docker container.
+- [Set up Grafana on your own infrastructure]({{< relref "../setup-grafana/installation/" >}}) such as an operating system, Kubernetes cluster, or Docker container.
 
 ## Step 2. Connect your first data source
 

--- a/docs/sources/getting-started/_index.md
+++ b/docs/sources/getting-started/_index.md
@@ -11,7 +11,7 @@ Getting started with Grafana involves three steps:
 
 1. Set up Grafana
 1. Connect your first data source
-3. Create your first dashboard
+1. Create your first dashboard
 
 ## Step 1. Setup Grafana
 

--- a/docs/sources/getting-started/_index.md
+++ b/docs/sources/getting-started/_index.md
@@ -7,6 +7,29 @@ weight: 9
 
 # Get started
 
-This section provides guidance on how build your first dashboard after you have installed Grafana. It also provides step-by-step instructions on how to add a Prometheus, InfluxDB, or an MS SQL Server data source. Refer to [Data sources]({{< relref "../administration/data-source-management/" >}}) for a list of all supported data sources.
+Getting started with Grafana involves three steps:
+
+1. Setup Grafana
+2. Connect your first data source
+3. Create your first dashboard
+
+## Step 1. Setup Grafana
+
+You have two ways to setup Grafana:
+
+* [Setup Grafana on Grafana Cloud]("https://grafana.com/docs/grafana-cloud/quickstart/") without having to install it or run it yourself. This is the fastest way to get started and the easiest way to use Grafana.
+* [Setup Grafana on your own infrastructure]({{< relref "../setup-grafana/installation/" >}}) such as an operating system, Kubernetes cluster, or Docker container.
+
+## Step 2. Connect your first data source
+
+Grafana dashboards work by querying [data sources]({{< relref "../datasources/" >}}) that you connect to Grafana. You will need to [setup a data source]({{< relref "../administration/data-source-management/" >}}) connection before you can visualize data. Data sources are setup by [installing data source plugins]({{< relref "../administration/plugin-management/#install-grafana-plugins" >}})). You can [browse data source plugins](https://grafana.com/grafana/plugins/?type=datasource) from the plugin catalog.
+
+1. Decide which data source you want to visualize. Browse the (data source plugin catalog](https://grafana.com/grafana/plugins/?type=datasource)) to see what you can connect with Grafana.
+2. Ensure the data source plugin is installed. See ([how to install data source plugins]({{< relref "../administration/data-source-management/" >}})).
+3. Connect the data source to Grafana. See ([how to setup a data source]({{< relref "../administration/data-source-management/" >}})), which configures an instance of a connection from Grafana to that data source.
+
+## Step 3. Create your first dashboard
+
+Once you have connected Grafana with one or more data sources, you can create a dashboard to visualize data from those data sources. This section provides guidance on how build your first dashboard after you have installed Grafana. It also provides step-by-step instructions on how to add a Prometheus, InfluxDB, or an MS SQL Server data source. Refer to [Data sources]({{< relref "../administration/data-source-management/" >}}) for a list of all supported data sources.
 
 {{< section >}}


### PR DESCRIPTION
This PR provides more context to the Getting Started page for Grafana.

This is an important page because it's the first actionable page in the Grafana docs and the first page many users will see when Googling "How do I get started with Grafana." Based on how the users may come to this page, I've updated this page to assume that the user might be starting completely from scratch: They haven't installed Grafana, they haven't decided whether they'll use Cloud or self-managed, and they don't know our terminology for plugins, data sources, or dashboards.

Prior to this PR, the page assumed that the user already has Grafana installed and is likely to start with Prometheus, InfluxDB, or MS SQL Server. I think this jumps too quickly into usage without a proper orientation to the prerequisites of getting started, which include: setting up Grafana, setting up a data source plugin, setting up a data source connection, and then setting up a dashboard.