### PR TITLE
CloudMonitoring: Add project selector for MQL editor[fix]

### DIFF
--- a/public/app/plugins/datasource/cloud-monitoring/components/MetricQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/MetricQueryEditor.test.tsx
@@ -1,8 +1,8 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import React from 'react';
 
 import { createMockDatasource } from '../__mocks__/cloudMonitoringDatasource';
-import { createMockQuery, createMockTimeSeriesQuery } from '../__mocks__/cloudMonitoringQuery';
+import { createMockQuery } from '../__mocks__/cloudMonitoringQuery';
 import { QueryType } from '../types';
 
 import { MetricQueryEditor } from './MetricQueryEditor';

--- a/public/app/plugins/datasource/cloud-monitoring/components/MetricQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/MetricQueryEditor.test.tsx
@@ -1,8 +1,8 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 
 import { createMockDatasource } from '../__mocks__/cloudMonitoringDatasource';
-import { createMockQuery } from '../__mocks__/cloudMonitoringQuery';
+import { createMockQuery, createMockTimeSeriesQuery } from '../__mocks__/cloudMonitoringQuery';
 import { QueryType } from '../types';
 
 import { MetricQueryEditor } from './MetricQueryEditor';
@@ -54,5 +54,14 @@ describe('MetricQueryEditor', () => {
     render(<MetricQueryEditor {...defaultProps} onChange={onChange} query={query} />);
     const l = await screen.findByLabelText('Project');
     expect(l).toBeInTheDocument();
+  });
+
+  it('renders a Project dropdown', async () => {
+    const query = createMockQuery();
+    query.queryType = QueryType.TIME_SERIES_QUERY;
+
+    render(<MetricQueryEditor {...defaultProps} />);
+    const projectDropdown = await screen.findByLabelText('Project');
+    expect(projectDropdown).toBeInTheDocument();
   });
 });

--- a/public/app/plugins/datasource/cloud-monitoring/components/MetricQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/MetricQueryEditor.tsx
@@ -61,9 +61,6 @@ function Editor({
 
   const onChangeTimeSeriesQuery = useCallback(
     (timeSeriesQuery: TimeSeriesQuery) => {
-      if (timeSeriesQuery.projectName !== query.projectName) {
-        query.projectName = timeSeriesQuery.projectName;
-      }
       onQueryChange({ ...query, timeSeriesQuery });
       onRunQuery();
     },
@@ -107,8 +104,8 @@ function Editor({
             refId={refId}
             datasource={datasource}
             onChange={(projectName) => onChangeTimeSeriesQuery({ ...query.timeSeriesQuery!, projectName: projectName })}
-            templateVariableOptions={[]}
-            projectName={query.projectName!}
+            templateVariableOptions={variableOptionGroup.options}
+            projectName={query.timeSeriesQuery.projectName!}
           />
           <MQLQueryEditor
             onChange={(q: string) => onChangeTimeSeriesQuery({ ...query.timeSeriesQuery!, query: q })}

--- a/public/app/plugins/datasource/cloud-monitoring/components/MetricQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/MetricQueryEditor.tsx
@@ -15,6 +15,7 @@ import {
 
 import { GraphPeriod } from './GraphPeriod';
 import { MQLQueryEditor } from './MQLQueryEditor';
+import { Project } from './Project';
 import { VisualMetricQueryEditor } from './VisualMetricQueryEditor';
 
 export interface Props {
@@ -60,6 +61,9 @@ function Editor({
 
   const onChangeTimeSeriesQuery = useCallback(
     (timeSeriesQuery: TimeSeriesQuery) => {
+      if (timeSeriesQuery.projectName !== query.projectName) {
+        query.projectName = timeSeriesQuery.projectName;
+      }
       onQueryChange({ ...query, timeSeriesQuery });
       onRunQuery();
     },
@@ -99,6 +103,13 @@ function Editor({
 
       {query.queryType === QueryType.TIME_SERIES_QUERY && query.timeSeriesQuery && (
         <>
+          <Project
+            refId={refId}
+            datasource={datasource}
+            onChange={(projectName) => onChangeTimeSeriesQuery({ ...query.timeSeriesQuery!, projectName: projectName })}
+            templateVariableOptions={[]}
+            projectName={query.projectName!}
+          />
           <MQLQueryEditor
             onChange={(q: string) => onChangeTimeSeriesQuery({ ...query.timeSeriesQuery!, query: q })}
             onRunQuery={onRunQuery}

--- a/public/app/plugins/datasource/cloud-monitoring/components/Project.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/Project.tsx
@@ -22,7 +22,6 @@ export function Project({ refId, projectName, datasource, onChange, templateVari
 
   const projectsWithTemplateVariables = useMemo(
     () => [
-      projects,
       {
         label: 'Template Variables',
         options: templateVariableOptions,


### PR DESCRIPTION
This PR adds a Project Selector to the MQL editor allowing a user to choose their project from a dropdown instead of defaulting to the first project. It also works with project template variables in the panel view.

MQL Editor:
![Screenshot 2023-03-29 at 6 08 08 PM](https://user-images.githubusercontent.com/58453566/228695434-2f8abf77-c260-4cd1-a12a-178b3c9feda2.png)

Panel with Project Template Variable:
![Screenshot 2023-03-29 at 6 09 32 PM](https://user-images.githubusercontent.com/58453566/228695443-ca93b176-2521-4895-a4a7-ead4cd459078.png)

Fixes #65358 