### PR TITLE
Docs/fix cross account section in cloudwatch doc

### DIFF
--- a/docs/sources/datasources/aws-cloudwatch/_index.md
+++ b/docs/sources/datasources/aws-cloudwatch/_index.md
@@ -84,7 +84,7 @@ You can attach these permissions to the IAM role or IAM user you configured in [
 }
 ```
 
-**Logs-only permissions**
+##### Logs-only permissions
 
 ```json
 {
@@ -234,7 +234,7 @@ For more information about provisioning, and for available configuration options
 
 #### Provisioning examples
 
-**Using AWS SDK (default):**
+##### Using AWS SDK (default)
 
 ```yaml
 apiVersion: 1
@@ -246,7 +246,7 @@ datasources:
       defaultRegion: eu-west-2
 ```
 
-**Using credentials' profile name (non-default):**
+##### Using credentials' profile name (non-default)
 
 ```yaml
 apiVersion: 1
@@ -277,7 +277,7 @@ datasources:
       secretKey: '<your secret key>'
 ```
 
-**Using AWS SDK Default and ARN of IAM Role to Assume:**
+##### Using AWS SDK Default and ARN of IAM Role to Assume
 
 ```yaml
 apiVersion: 1

--- a/docs/sources/datasources/aws-cloudwatch/_index.md
+++ b/docs/sources/datasources/aws-cloudwatch/_index.md
@@ -167,7 +167,7 @@ You can attach these permissions to the IAM role or IAM user you configured in [
 }
 ```
 
-##### Cross-account observability: (see below)
+##### Cross-account observability permissions
 
 ```json
 {

--- a/docs/sources/datasources/aws-cloudwatch/_index.md
+++ b/docs/sources/datasources/aws-cloudwatch/_index.md
@@ -49,7 +49,7 @@ For authentication options and configuration details, refer to [AWS authenticati
 To read CloudWatch metrics and EC2 tags, instances, regions, and alarms, you must grant Grafana permissions via IAM.
 You can attach these permissions to the IAM role or IAM user you configured in [AWS authentication]({{< relref "./aws-authentication/" >}}).
 
-**Metrics-only:**
+##### Metrics-only:
 
 ```json
 {
@@ -84,7 +84,7 @@ You can attach these permissions to the IAM role or IAM user you configured in [
 }
 ```
 
-**Logs-only:**
+##### Logs-only:
 
 ```json
 {
@@ -119,7 +119,7 @@ You can attach these permissions to the IAM role or IAM user you configured in [
 }
 ```
 
-**Metrics and Logs:**
+##### Metrics and Logs:
 
 ```json
 {
@@ -167,7 +167,7 @@ You can attach these permissions to the IAM role or IAM user you configured in [
 }
 ```
 
-**Cross-account observability: (see below) **
+##### Cross-account observability: (see below)
 
 ```json
 {

--- a/docs/sources/datasources/aws-cloudwatch/_index.md
+++ b/docs/sources/datasources/aws-cloudwatch/_index.md
@@ -261,7 +261,7 @@ datasources:
       profile: secondary
 ```
 
-**Using accessKey and secretKey:**
+##### Using accessKey and secretKey
 
 ```yaml
 apiVersion: 1

--- a/docs/sources/datasources/aws-cloudwatch/_index.md
+++ b/docs/sources/datasources/aws-cloudwatch/_index.md
@@ -49,7 +49,7 @@ For authentication options and configuration details, refer to [AWS authenticati
 To read CloudWatch metrics and EC2 tags, instances, regions, and alarms, you must grant Grafana permissions via IAM.
 You can attach these permissions to the IAM role or IAM user you configured in [AWS authentication]({{< relref "./aws-authentication/" >}}).
 
-##### Metrics-only:
+##### Metrics-only permissions
 
 ```json
 {
@@ -84,7 +84,7 @@ You can attach these permissions to the IAM role or IAM user you configured in [
 }
 ```
 
-##### Logs-only:
+**Logs-only permissions**
 
 ```json
 {
@@ -119,7 +119,7 @@ You can attach these permissions to the IAM role or IAM user you configured in [
 }
 ```
 
-##### Metrics and Logs:
+##### Metrics and logs permissions
 
 ```json
 {

--- a/docs/sources/datasources/aws-cloudwatch/query-editor/index.md
+++ b/docs/sources/datasources/aws-cloudwatch/query-editor/index.md
@@ -218,9 +218,19 @@ When making `stats` queries in [Explore]({{< relref "../../../explore/" >}}), ma
 
 {{< figure src="/static/img/docs/v70/explore-mode-switcher.png" max-width="500px" class="docs-image--right" caption="Explore mode switcher" >}}
 
+## Cross-account observability
+
+The CloudWatch plugin provides the ability to monitor and troubleshoot applications that span across multiple accounts within a region. Using cross-account observability, you can seamlessly search, visualize and analyze metrics and logs, without having to worry about account boundaries.
+
+> **Note:** This feature is currently behind the `cloudWatchCrossAccountQuerying` feature toggle.
+
+You can enable feature toggles through the configuration file or environment variables. See [feature toggles](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#feature_toggles) in configuration documentation for details.
+
+Grafana Cloud users can access this feature by [opening a support ticket in the Cloud Portal](https://grafana.com/profile/org#support).
+
 ### Getting started
 
-To enable cross-account observability, first enable it in CloudWatch using the official [CloudWatch docs](http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html), then add [two new API actions]({{< relref "../#cross-account-observability" >}}) to the IAM policy attached to the role/user running the plugin.
+To enable cross-account observability, first enable it in CloudWatch using the official [CloudWatch docs](http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html), then add [two new API actions](https://grafana.com/docs/grafana/latest/datasources/aws-cloudwatch/#cross-account-observability) to the IAM policy attached to the role/user running the plugin.
 
 Cross-account querying is available in the plugin through the `Logs` mode and the `Metric search` mode. Once you have it configured correctly, you'll see a "Monitoring account" badge displayed in the query editor header.
 

--- a/docs/sources/datasources/aws-cloudwatch/query-editor/index.md
+++ b/docs/sources/datasources/aws-cloudwatch/query-editor/index.md
@@ -230,7 +230,7 @@ To enable cross-account observability do the following:
 
 1. Go to the official [CloudWatch docs](http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html) and follow the instructions on enabling cross-account observability.
 
-1. Add [two new API actions](https://grafana.com/docs/grafana/latest/datasources/aws-cloudwatch/#cross-account-observability) to the IAM policy attached to the role/user running the plugin.
+1. Add [two new API actions](/docs/grafana/latest/datasources/aws-cloudwatch/#cross-account-observability-permissions) to the IAM policy attached to the role/user running the plugin.
 
 Cross-account querying is available in the plugin through the `Logs` mode and the `Metric search` mode. Once you have it configured correctly, you'll see a "Monitoring account" badge displayed in the query editor header.
 

--- a/docs/sources/datasources/aws-cloudwatch/query-editor/index.md
+++ b/docs/sources/datasources/aws-cloudwatch/query-editor/index.md
@@ -220,7 +220,7 @@ When making `stats` queries in [Explore]({{< relref "../../../explore/" >}}), ma
 
 ## Cross-account observability
 
-The CloudWatch plugin provides the ability to monitor and troubleshoot applications that span multiple accounts within a region. Using cross-account observability, you can seamlessly search, visualize and analyze metrics and logs without worrying about account boundaries.
+The CloudWatch plugin allows monitoring and troubleshooting applications that span multiple accounts within a region. Using cross-account observability, you can seamlessly search, visualize, and analyze metrics and logs without worrying about account boundaries.
 
 ### Getting started
 

--- a/docs/sources/datasources/aws-cloudwatch/query-editor/index.md
+++ b/docs/sources/datasources/aws-cloudwatch/query-editor/index.md
@@ -224,8 +224,6 @@ The CloudWatch plugin provides the ability to monitor and troubleshoot applicati
 
 ### Getting started
 
-<!-- To enable cross-account observability, first enable it in CloudWatch using the official [CloudWatch docs](http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html), then add [two new API actions](https://grafana.com/docs/grafana/latest/datasources/aws-cloudwatch/#cross-account-observability) to the IAM policy attached to the role/user running the plugin. -->
-
 To enable cross-account observability do the following:
 
 1. Go to the official [CloudWatch docs](http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html) and follow the instructions on enabling cross-account observability.

--- a/docs/sources/datasources/aws-cloudwatch/query-editor/index.md
+++ b/docs/sources/datasources/aws-cloudwatch/query-editor/index.md
@@ -228,7 +228,7 @@ To enable cross-account observability, complete the following steps:
 
 1. Go to the [Amazon CloudWatch docs](http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html) and follow the instructions on enabling cross-account observability.
 
-1. Add [two new API actions](/docs/grafana/latest/datasources/aws-cloudwatch/#cross-account-observability-permissions) to the IAM policy attached to the role/user running the plugin.
+1. Add [two API actions](/docs/grafana/latest/datasources/aws-cloudwatch/#cross-account-observability-permissions) to the IAM policy attached to the role/user running the plugin.
 
 Cross-account querying is available in the plugin through the `Logs` mode and the `Metric search` mode. Once you have it configured correctly, you'll see a "Monitoring account" badge displayed in the query editor header.
 

--- a/docs/sources/datasources/aws-cloudwatch/query-editor/index.md
+++ b/docs/sources/datasources/aws-cloudwatch/query-editor/index.md
@@ -220,7 +220,7 @@ When making `stats` queries in [Explore]({{< relref "../../../explore/" >}}), ma
 
 ## Cross-account observability
 
-The CloudWatch plugin provides the ability to monitor and troubleshoot applications that span across multiple accounts within a region. Using cross-account observability, you can seamlessly search, visualize and analyze metrics and logs, without having to worry about account boundaries.
+The CloudWatch plugin provides the ability to monitor and troubleshoot applications that span across multiple accounts within a region. Using cross-account observability, you can seamlessly search, visualize and analyze metrics and logs without worrying about account boundaries.
 
 
 ### Getting started

--- a/docs/sources/datasources/aws-cloudwatch/query-editor/index.md
+++ b/docs/sources/datasources/aws-cloudwatch/query-editor/index.md
@@ -226,7 +226,7 @@ The CloudWatch plugin provides the ability to monitor and troubleshoot applicati
 
 To enable cross-account observability do the following:
 
-1. Go to the official [CloudWatch docs](http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html) and follow the instructions on enabling cross-account observability.
+1. Go to the [Amazon CloudWatch docs](http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html) and follow the instructions on enabling cross-account observability.
 
 1. Add [two new API actions](/docs/grafana/latest/datasources/aws-cloudwatch/#cross-account-observability-permissions) to the IAM policy attached to the role/user running the plugin.
 

--- a/docs/sources/datasources/aws-cloudwatch/query-editor/index.md
+++ b/docs/sources/datasources/aws-cloudwatch/query-editor/index.md
@@ -222,10 +222,15 @@ When making `stats` queries in [Explore]({{< relref "../../../explore/" >}}), ma
 
 The CloudWatch plugin provides the ability to monitor and troubleshoot applications that span across multiple accounts within a region. Using cross-account observability, you can seamlessly search, visualize and analyze metrics and logs without worrying about account boundaries.
 
-
 ### Getting started
 
-To enable cross-account observability, first enable it in CloudWatch using the official [CloudWatch docs](http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html), then add [two new API actions](https://grafana.com/docs/grafana/latest/datasources/aws-cloudwatch/#cross-account-observability) to the IAM policy attached to the role/user running the plugin.
+<!-- To enable cross-account observability, first enable it in CloudWatch using the official [CloudWatch docs](http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html), then add [two new API actions](https://grafana.com/docs/grafana/latest/datasources/aws-cloudwatch/#cross-account-observability) to the IAM policy attached to the role/user running the plugin. -->
+
+To enable cross-account observability do the following:
+
+1. Go to the official [CloudWatch docs](http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html) and follow the instructions on enabling cross-account observability.
+
+1. Add [two new API actions](https://grafana.com/docs/grafana/latest/datasources/aws-cloudwatch/#cross-account-observability) to the IAM policy attached to the role/user running the plugin.
 
 Cross-account querying is available in the plugin through the `Logs` mode and the `Metric search` mode. Once you have it configured correctly, you'll see a "Monitoring account" badge displayed in the query editor header.
 

--- a/docs/sources/datasources/aws-cloudwatch/query-editor/index.md
+++ b/docs/sources/datasources/aws-cloudwatch/query-editor/index.md
@@ -222,7 +222,7 @@ When making `stats` queries in [Explore]({{< relref "../../../explore/" >}}), ma
 
 The CloudWatch plugin allows monitoring and troubleshooting applications that span multiple accounts within a region. Using cross-account observability, you can seamlessly search, visualize, and analyze metrics and logs without worrying about account boundaries.
 
-### Getting started
+### Get started
 
 To enable cross-account observability, complete the following steps:
 

--- a/docs/sources/datasources/aws-cloudwatch/query-editor/index.md
+++ b/docs/sources/datasources/aws-cloudwatch/query-editor/index.md
@@ -220,7 +220,7 @@ When making `stats` queries in [Explore]({{< relref "../../../explore/" >}}), ma
 
 ## Cross-account observability
 
-The CloudWatch plugin provides the ability to monitor and troubleshoot applications that span across multiple accounts within a region. Using cross-account observability, you can seamlessly search, visualize and analyze metrics and logs without worrying about account boundaries.
+The CloudWatch plugin provides the ability to monitor and troubleshoot applications that span multiple accounts within a region. Using cross-account observability, you can seamlessly search, visualize and analyze metrics and logs without worrying about account boundaries.
 
 ### Getting started
 

--- a/docs/sources/datasources/aws-cloudwatch/query-editor/index.md
+++ b/docs/sources/datasources/aws-cloudwatch/query-editor/index.md
@@ -224,7 +224,7 @@ The CloudWatch plugin allows monitoring and troubleshooting applications that sp
 
 ### Getting started
 
-To enable cross-account observability do the following:
+To enable cross-account observability, complete the following steps:
 
 1. Go to the [Amazon CloudWatch docs](http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html) and follow the instructions on enabling cross-account observability.
 

--- a/docs/sources/datasources/aws-cloudwatch/query-editor/index.md
+++ b/docs/sources/datasources/aws-cloudwatch/query-editor/index.md
@@ -222,11 +222,6 @@ When making `stats` queries in [Explore]({{< relref "../../../explore/" >}}), ma
 
 The CloudWatch plugin provides the ability to monitor and troubleshoot applications that span across multiple accounts within a region. Using cross-account observability, you can seamlessly search, visualize and analyze metrics and logs, without having to worry about account boundaries.
 
-> **Note:** This feature is currently behind the `cloudWatchCrossAccountQuerying` feature toggle.
-
-You can enable feature toggles through the configuration file or environment variables. See [feature toggles](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#feature_toggles) in configuration documentation for details.
-
-Grafana Cloud users can access this feature by [opening a support ticket in the Cloud Portal](https://grafana.com/profile/org#support).
 
 ### Getting started
 

--- a/docs/sources/datasources/aws-cloudwatch/query-editor/index.md
+++ b/docs/sources/datasources/aws-cloudwatch/query-editor/index.md
@@ -92,7 +92,7 @@ For example, to apply arithmetic operations to a metric, apply a unique string i
 
 > **Note:** If you use the expression field to reference another query, like `queryA * 2`, you can't create an alert rule based on that query.
 
-##### Period macro
+#### Period macro
 
 If you're using a CloudWatch [`SEARCH`](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/search-expression-syntax.html) expression, you may want to use the `$__period_auto` macro rather than specifying a period explicitly. The `$__period_auto` macro will resolve to a [CloudWatch period](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_GetMetricData.html) that is suitable for the chosen time range.
 


### PR DESCRIPTION
Fixes issue https://github.com/grafana/grafana/issues/64750

Updated the rel refs with actual links

Added back Cross-account observability section (is in 9.3 documentation, but not 9.4)

made cosmetic updates

