### PR TITLE
Alerting: Update migration to put alerts to the default folder if dashboard folder is missing

### DIFF
--- a/pkg/services/sqlstore/migrations/ualert/migration_test.go
+++ b/pkg/services/sqlstore/migrations/ualert/migration_test.go
@@ -573,6 +573,43 @@ func TestDashAlertMigration(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("when folder is missing put alert in General folder", func(t *testing.T) {
+		o := createOrg(t, 1)
+		folder1 := createDashboard(t, 1, o.ID, "folder-1")
+		folder1.IsFolder = true
+		dash1 := createDashboard(t, 3, o.ID, "dash1")
+		dash1.FolderID = folder1.ID
+		dash2 := createDashboard(t, 4, o.ID, "dash2")
+		dash2.FolderID = 22 // missing folder
+
+		a1 := createAlert(t, o.ID, dash1.ID, int64(1), "alert-1", []string{})
+		a2 := createAlert(t, o.ID, dash2.ID, int64(1), "alert-2", []string{})
+
+		_, err := x.Insert(o, folder1, dash1, dash2, a1, a2)
+		require.NoError(t, err)
+
+		runDashAlertMigrationTestRun(t, x)
+
+		rules := getAlertRules(t, x, o.ID)
+		require.Len(t, rules, 2)
+
+		var generalFolder dashboards.Dashboard
+		_, err = x.Table(&dashboards.Dashboard{}).Where("title = ? AND org_id = ?", ualert.GENERAL_FOLDER, o.ID).Get(&generalFolder)
+		require.NoError(t, err)
+
+		require.NotNil(t, generalFolder)
+
+		for _, rule := range rules {
+			var expectedFolder dashboards.Dashboard
+			if rule.Title == a1.Name {
+				expectedFolder = *folder1
+			} else {
+				expectedFolder = generalFolder
+			}
+			require.Equal(t, expectedFolder.UID, rule.NamespaceUID)
+		}
+	})
 }
 
 const (

--- a/pkg/services/sqlstore/migrations/ualert/ualert.go
+++ b/pkg/services/sqlstore/migrations/ualert/ualert.go
@@ -290,6 +290,7 @@ func (m *migration) Exec(sess *xorm.Session, mg *migrator.Migrator) error {
 	rulesPerOrg := make(map[int64]map[*alertRule][]uidOrID)
 
 	for _, da := range dashAlerts {
+		l := mg.Logger.New("ruleID", da.Id, "ruleName", da.Name, "dashboardUID", da.DashboardUID, "orgID", da.OrgId)
 		newCond, err := transConditions(*da.ParsedSettings, da.OrgId, dsIDMap)
 		if err != nil {
 			return err
@@ -324,7 +325,7 @@ func (m *migration) Exec(sess *xorm.Session, mg *migrator.Migrator) error {
 			folderName := getAlertFolderNameFromDashboard(&dash)
 			f, ok := folderCache[folderName]
 			if !ok {
-				mg.Logger.Info("create a new folder for alerts that belongs to dashboard because it has custom permissions", "org", dash.OrgId, "dashboard_uid", dash.Uid, "folder", folderName)
+				l.Info("create a new folder for alerts that belongs to dashboard because it has custom permissions", "folder", folderName)
 				// create folder and assign the permissions of the dashboard (included default and inherited)
 				f, err = folderHelper.createFolder(dash.OrgId, folderName)
 				if err != nil {

--- a/pkg/services/sqlstore/migrations/ualert/ualert.go
+++ b/pkg/services/sqlstore/migrations/ualert/ualert.go
@@ -355,7 +355,7 @@ func (m *migration) Exec(sess *xorm.Session, mg *migrator.Migrator) error {
 			// get folder if exists
 			f, err := folderHelper.getFolder(dash, da)
 			if err != nil {
-				// if folder does not exist then the dashboard is an orphan and therefore rules can be skipped
+				// If folder does not exist then the dashboard is an orphan and we migrate the alert to the general folder.
 				l.Warn("Failed to find folder for dashboard. Migrate rule to the default folder", "rule_name", da.Name, "dashboard_uid", da.DashboardUID, "missing_folder_id", dash.FolderId)
 				folder, err = gf(dash, da)
 				if err != nil {

--- a/pkg/services/sqlstore/migrations/ualert/ualert.go
+++ b/pkg/services/sqlstore/migrations/ualert/ualert.go
@@ -355,12 +355,15 @@ func (m *migration) Exec(sess *xorm.Session, mg *migrator.Migrator) error {
 			// get folder if exists
 			f, err := folderHelper.getFolder(dash, da)
 			if err != nil {
-				return MigrationError{
-					Err:     err,
-					AlertId: da.Id,
+				// if folder does not exist then the dashboard is an orphan and therefore rules can be skipped
+				l.Warn("Failed to find folder for dashboard. Migrate rule to the default folder", "rule_name", da.Name, "dashboard_uid", da.DashboardUID, "missing_folder_id", dash.FolderId)
+				folder, err = gf(dash, da)
+				if err != nil {
+					return err
 				}
+			} else {
+				folder = &f
 			}
-			folder = &f
 		default:
 			folder, err = gf(dash, da)
 			if err != nil {

--- a/pkg/services/sqlstore/migrations/ualert/ualert.go
+++ b/pkg/services/sqlstore/migrations/ualert/ualert.go
@@ -267,6 +267,11 @@ func (m *migration) Exec(sess *xorm.Session, mg *migrator.Migrator) error {
 	// cache for the general folders
 	generalFolderCache := make(map[int64]*dashboard)
 
+	folderHelper := folderHelper{
+		sess: sess,
+		mg:   mg,
+	}
+
 	gf := func(dash dashboard, da dashAlert) (*dashboard, error) {
 		f, ok := generalFolderCache[dash.OrgId]
 		if !ok {
@@ -312,11 +317,6 @@ func (m *migration) Exec(sess *xorm.Session, mg *migrator.Migrator) error {
 				Err:     fmt.Errorf("dashboard with UID %v under organisation %d not found: %w", da.DashboardUID, da.OrgId, err),
 				AlertId: da.Id,
 			}
-		}
-
-		folderHelper := folderHelper{
-			sess: sess,
-			mg:   mg,
 		}
 
 		var folder *dashboard


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Grafana database is designed a way that constraints are not enforced on the database level (no foreign keys). This may cause inconsistencies with data. During the migration of alert rules to unified alerting, the migration code tries to migrate the rules to the same folder where the dashboard they are extracted from is stored. However, sometimes, due to inconsistencies of the database, the folder can be missing, and this causes the migration to fail.
This PR changes the migration to not fail. Instead, migration will emit a warning message `Failed to find folder for dashboard. Migrate rule to the default folder` and will try to put the alert to the folder `General Alerting`. 

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
- [x] There are no known compatibility issues with older supported versions of Grafana, or plugins.
- [x] It passes the [Hosted Grafana feature readiness review](https://docs.google.com/document/d/1QL9Ly8KnXzpb6ISbg49pTODRO5mhA5tkkfIZVX6pqQU/edit) for observability, scalability, performance, and security.