### PR TITLE
Docs: Fix min time interval URL

### DIFF
--- a/docs/sources/datasources/influxdb/_index.md
+++ b/docs/sources/datasources/influxdb/_index.md
@@ -43,7 +43,7 @@ Set the data source's basic configuration options carefully:
 | **Name**              | Sets the name you use to refer to the data source in panels and queries. We recommend something like `InfluxDB-InfluxQL`.                                                                                    |
 | **Default**           | Sets whether the data source is pre-selected for new panels.                                                                                                                                                 |
 | **URL**               | The HTTP protocol, IP address, and port of your InfluxDB API. InfluxDB's default API port is 8086.                                                                                                           |
-| **Min time interval** | _(Optional)_ Refer to [Min time interval]({{< relref "#configure-min-time-interval" >}}).                                                                                                                    |
+| **Min time interval** | _(Optional)_ Refer to [Min time interval]({{< relref "#min-time-intervall" >}}).                                                                                                                    |
 | **Max series**        | _(Optional)_ Limits the number of series and tables that Grafana processes. Lower this number to prevent abuse, and increase it if you have many small time series and not all are shown. Defaults to 1,000. |
 
 You can also configure settings specific to the InfluxDB data source:


### PR DESCRIPTION
URL for min time interval URL leads to the whole page. This PR corrects the URL to direct to the sub-page Min time interval: https://grafana.com/docs/grafana/latest/datasources/influxdb/#min-time-interval
