### PR TITLE
NoDataSourcesPage: Trying to use more standard design system components

### DIFF
--- a/public/app/features/datasources/components/EmptyStateNoDatasource.tsx
+++ b/public/app/features/datasources/components/EmptyStateNoDatasource.tsx
@@ -4,7 +4,7 @@ import { useAsync } from 'react-use';
 
 import { DataSourcePluginMeta, GrafanaTheme2, PageLayoutType } from '@grafana/data';
 import { reportInteraction } from '@grafana/runtime';
-import { Icon, useStyles2 } from '@grafana/ui';
+import { Button, Card, Icon, LinkButton, useStyles2 } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 import { useGrafana } from 'app/core/context/GrafanaContext';
 import { contextSrv } from 'app/core/core';
@@ -55,61 +55,65 @@ export function EmptyStateNoDatasource({ onCTAClick, loading = false, title, CTA
   return (
     <Page navId={navId} pageNav={pageNav} layout={PageLayoutType.Canvas}>
       <div className={styles.wrapper}>
-        <h1 className={styles.title}>{title}</h1>
-        <div className={styles.description}>
-          <h4 className={styles.explanation}>
-            {t('datasource-onboarding.explanation', "To visualize your data, you'll need to connect it first.")}
-          </h4>
-        </div>
-        {contextSrv.hasRole('Admin') ? (
-          <>
-            <h4 className={styles.preferredDataSource}>
-              {t('datasource-onboarding.preferred', 'Connect your preferred data source:')}
+        <div className={styles.panel}>
+          <h1 className={styles.title}>{title}</h1>
+          <div className={styles.description}>
+            <h4 className={styles.explanation}>
+              {t('datasource-onboarding.explanation', "To visualize your data, you'll need to connect it first.")}
             </h4>
-            {!loadingDatasources && datasources !== undefined && (
-              <ul className={styles.datasources}>
-                {datasources.map((d) => (
-                  <li key={d.id}>
-                    <button
+          </div>
+          {contextSrv.hasRole('Admin') ? (
+            <>
+              <h4 className={styles.preferredDataSource}>
+                {t('datasource-onboarding.preferred', 'Connect your preferred data source:')}
+              </h4>
+              {!loadingDatasources && datasources !== undefined && (
+                <div className={styles.datasources}>
+                  {datasources.map((d) => (
+                    <Card
                       onClick={() => {
                         reportInteraction('dashboards_connectds_ds_clicked');
                         onAddDatasource(d);
                       }}
+                      key={d.id}
                     >
-                      <img src={d.info.logos.small} alt="" height="16" width="16" className={styles.logo} />
-                      <span className={styles.datasourceName}>{d.name}</span>
-                      <Icon name="arrow-right" size="lg" className={styles.arrowIcon} />
-                    </button>
-                  </li>
-                ))}
-                <li>
-                  <a
+                      <Card.Heading>{d.name}</Card.Heading>
+                      <Card.Figure className={styles.figure} align="center">
+                        <img src={d.info.logos.small} alt="" className={styles.logo} />
+                      </Card.Figure>
+                    </Card>
+                  ))}
+                  <LinkButton
                     href="/datasources/new"
+                    fill="text"
+                    size="lg"
                     className={styles.viewAll}
                     onClick={() => reportInteraction('dashboards_connectds_viewall_clicked')}
                   >
                     <span>{t('datasource-onboarding.viewAll', 'View all')}</span>
                     <Icon name="arrow-right" size="lg" />
-                  </a>
-                </li>
-              </ul>
-            )}
-          </>
-        ) : (
-          <h4>
-            {t('datasource-onboarding.contact-admin', 'Please contact your administrator to configure data sources.')}
-          </h4>
-        )}
-        <button
-          onClick={() => {
-            reportInteraction('dashboards_connectds_sampledata_clicked');
-            onCTAClick?.();
-          }}
-          className={styles.ctaButton}
-        >
-          <span>{CTAText}</span>
-          <Icon name="arrow-right" size="lg" />
-        </button>
+                  </LinkButton>
+                </div>
+              )}
+            </>
+          ) : (
+            <h4>
+              {t('datasource-onboarding.contact-admin', 'Please contact your administrator to configure data sources.')}
+            </h4>
+          )}
+          <Button
+            onClick={() => {
+              reportInteraction('dashboards_connectds_sampledata_clicked');
+              onCTAClick?.();
+            }}
+            variant="secondary"
+            fill="text"
+            className={styles.ctaButton}
+          >
+            <span>{CTAText}</span>
+            <Icon name="arrow-right" size="lg" />
+          </Button>
+        </div>
       </div>
     </Page>
   );
@@ -124,15 +128,22 @@ function getStyles(theme: GrafanaTheme2) {
       alignItems: 'center',
       justifyContent: 'center',
     }),
+    panel: css({
+      display: 'flex',
+      flexDirection: 'column',
+      border: `1px solid ${theme.colors.border.weak}`,
+      background: theme.colors.background.primary,
+      padding: theme.spacing(4),
+    }),
     title: css({
-      textAlign: 'center',
+      //textAlign: 'center',
       fontSize: theme.typography.pxToRem(32),
       fontWeight: theme.typography.fontWeightBold,
     }),
     description: css({
       display: 'flex',
       flexDirection: 'column',
-      alignItems: 'center',
+      //alignItems: 'center',
       gap: theme.spacing(1),
       maxWidth: '50vw',
       marginBottom: theme.spacing(8),
@@ -140,13 +151,18 @@ function getStyles(theme: GrafanaTheme2) {
     }),
     explanation: css({
       marginBottom: '0px',
-      textAlign: 'center',
+      //textAlign: 'center',
       fontSize: theme.typography.pxToRem(19),
     }),
     preferredDataSource: css({
       marginBottom: theme.spacing(3),
       fontSize: theme.typography.pxToRem(19),
       fontWeight: theme.typography.fontWeightRegular,
+    }),
+    logo: css({
+      //margin: theme.spacing(0, 2),
+      width: theme.spacing(5),
+      maxHeight: theme.spacing(5),
     }),
     datasources: css({
       display: 'grid',
@@ -155,60 +171,24 @@ function getStyles(theme: GrafanaTheme2) {
       listStyle: 'none',
       width: '100%',
       maxWidth: theme.spacing(88),
-
-      '> li': {
-        display: 'flex',
-        alignItems: 'center',
-        '> button': {
-          display: 'flex',
-          alignItems: 'center',
-          width: '100%',
-          height: theme.spacing(7),
-          gap: theme.spacing(2),
-          margin: '0px',
-          padding: `calc(${theme.spacing(2)} - 1px)`,
-          lineHeight: theme.spacing(3),
-          border: `1px solid ${theme.colors.border.weak}`,
-          borderRadius: theme.shape.borderRadius(1),
-          background: theme.colors.background.primary,
-          fontSize: theme.typography.pxToRem(19),
-          color: 'inherit',
-        },
+    }),
+    figure: css({
+      width: 'inherit',
+      //marginRight: '0px',
+      '> img': {
+        width: theme.spacing(5),
       },
-    }),
-    logo: css({
-      width: theme.spacing(2),
-      height: theme.spacing(2),
-      objectFit: 'contain',
-    }),
-    datasourceName: css({
-      marginRight: 'auto',
     }),
     arrowIcon: css({
       color: theme.colors.text.link,
     }),
     viewAll: css({
       display: 'flex',
-      flexGrow: 1,
-      alignItems: 'center',
-      justifyContent: 'center',
-      padding: theme.spacing(2),
-      lineHeight: theme.spacing(3),
-      fontSize: theme.typography.pxToRem(19),
-      color: theme.colors.text.link,
       textDecoration: 'underline',
-      textUnderlinePosition: 'under',
+      alignSelf: 'center',
     }),
     ctaButton: css({
-      display: 'flex',
-      alignItems: 'center',
-      gap: theme.spacing(1),
-      margin: '0px',
-      marginTop: theme.spacing(8),
-      padding: theme.spacing(0),
-      border: 'none',
-      background: 'inherit',
-      fontSize: theme.typography.h6.fontSize,
+      marginTop: theme.spacing(4),
       color: theme.colors.text.secondary,
     }),
   };


### PR DESCRIPTION
Just a quick poc of using more of our design system components. But still, lots of custom styling was required. But with some more effort (and maybe a few additions and improvements to design system components this should not require much custom styling at all) 

I think the biggest problem with the design is placing content directly on canvas, as we don't have a Card component for canvas (which is by design, only panels / pages should live on canvas). 

* Use primary background
* Use standard Card component
* Use standard Button components
* Use standard LinkButton component 

Before:
![Screenshot from 2023-03-30 15-41-56](https://user-images.githubusercontent.com/10999/228855330-7f024868-2e2e-4253-9aa8-23b8c9206289.png)

After (needs some love, this is just a quick POC). But by switching to primary background we can actually use our component library (Card) and get more design consistency. 
![Screenshot from 2023-03-30 15-38-45](https://user-images.githubusercontent.com/10999/228854319-ddc9bf3f-defc-4c61-a589-ee1eeafd6d60.png)

I think the "Empty dashboard" state has similar issues of requiring a lot of custom styles, but not as big of an issue as here where we are using panel styles for cards which we don't do in any other place I know off. 