### PR TITLE
Chore: Rename LookupTokenErr to AuthErr

### DIFF
--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -85,7 +85,7 @@ func (hs *HTTPServer) CookieOptionsFromCfg() cookies.CookieOptions {
 
 func (hs *HTTPServer) LoginView(c *contextmodel.ReqContext) {
 	if hs.Features.IsEnabled(featuremgmt.FlagClientTokenRotation) {
-		if errors.Is(c.LookupTokenErr, authn.ErrTokenNeedsRotation) {
+		if errors.Is(c.AuthErr, authn.ErrTokenNeedsRotation) {
 			c.Redirect(hs.Cfg.AppSubURL + "/")
 			return
 		}

--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -39,13 +39,13 @@ func accessForbidden(c *contextmodel.ReqContext) {
 
 func notAuthorized(c *contextmodel.ReqContext) {
 	if c.IsApiRequest() {
-		c.WriteErrOrFallback(http.StatusUnauthorized, http.StatusText(http.StatusUnauthorized), c.LookupTokenErr)
+		c.WriteErrOrFallback(http.StatusUnauthorized, http.StatusText(http.StatusUnauthorized), c.AuthErr)
 		return
 	}
 
 	writeRedirectCookie(c)
 
-	if errors.Is(c.LookupTokenErr, authn.ErrTokenNeedsRotation) {
+	if errors.Is(c.AuthErr, authn.ErrTokenNeedsRotation) {
 		c.Redirect(setting.AppSubUrl + "/user/auth-tokens/rotate")
 		return
 	}
@@ -140,7 +140,7 @@ func Auth(options *AuthOptions) web.Handler {
 
 		if !c.IsSignedIn && options.ReqSignedIn && requireLogin {
 			var revokedErr *auth.TokenRevokedError
-			if errors.As(c.LookupTokenErr, &revokedErr) {
+			if errors.As(c.AuthErr, &revokedErr) {
 				tokenRevoked(c, revokedErr)
 				return
 			}

--- a/pkg/services/accesscontrol/middleware.go
+++ b/pkg/services/accesscontrol/middleware.go
@@ -44,14 +44,14 @@ func Middleware(ac AccessControl) func(web.Handler, Evaluator) web.Handler {
 				}
 			}
 
-			if c.LookupTokenErr != nil {
+			if c.AuthErr != nil {
 				var revokedErr *usertoken.TokenRevokedError
-				if errors.As(c.LookupTokenErr, &revokedErr) {
+				if errors.As(c.AuthErr, &revokedErr) {
 					tokenRevoked(c, revokedErr)
 					return
 				}
 
-				unauthorized(c, c.LookupTokenErr)
+				unauthorized(c, c.AuthErr)
 				return
 			}
 
@@ -115,12 +115,12 @@ func deny(c *contextmodel.ReqContext, evaluator Evaluator, err error) {
 
 func unauthorized(c *contextmodel.ReqContext, err error) {
 	if c.IsApiRequest() {
-		c.WriteErrOrFallback(http.StatusUnauthorized, http.StatusText(http.StatusUnauthorized), c.LookupTokenErr)
+		c.WriteErrOrFallback(http.StatusUnauthorized, http.StatusText(http.StatusUnauthorized), c.AuthErr)
 		return
 	}
 
 	writeRedirectCookie(c)
-	if errors.Is(c.LookupTokenErr, authn.ErrTokenNeedsRotation) {
+	if errors.Is(c.AuthErr, authn.ErrTokenNeedsRotation) {
 		c.Redirect(setting.AppSubUrl + "/user/auth-tokens/rotate")
 		return
 	}

--- a/pkg/services/contexthandler/contexthandler.go
+++ b/pkg/services/contexthandler/contexthandler.go
@@ -145,8 +145,8 @@ func (h *ContextHandler) Middleware(next http.Handler) http.Handler {
 					reqContext.Resp.Before(h.deleteInvalidCookieEndOfRequestFunc(reqContext))
 				}
 
-				// Hack: set all errors on LookupTokenErr, so we can check it in auth middlewares
-				reqContext.LookupTokenErr = err
+				// Hack: set AuthErr, so we can check it in auth middlewares and reject the request from there
+				reqContext.AuthErr = err
 			} else {
 				reqContext.UserToken = identity.SessionToken
 				reqContext.SignedInUser = identity.SignedInUser()
@@ -484,14 +484,14 @@ func (h *ContextHandler) initContextWithToken(reqContext *contextmodel.ReqContex
 			reqContext.Resp.Before(h.deleteInvalidCookieEndOfRequestFunc(reqContext))
 		}
 
-		reqContext.LookupTokenErr = err
+		reqContext.AuthErr = err
 
 		return false
 	}
 
 	if h.features.IsEnabled(featuremgmt.FlagClientTokenRotation) {
 		if token.NeedsRotation(time.Duration(h.Cfg.TokenRotationIntervalMinutes) * time.Minute) {
-			reqContext.LookupTokenErr = authn.ErrTokenNeedsRotation.Errorf("token needs rotation")
+			reqContext.AuthErr = authn.ErrTokenNeedsRotation.Errorf("token needs rotation")
 			return true
 		}
 	}

--- a/pkg/services/contexthandler/contexthandler.go
+++ b/pkg/services/contexthandler/contexthandler.go
@@ -11,8 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/sync/singleflight"
-
 	"github.com/grafana/grafana/pkg/components/apikeygen"
 	apikeygenprefix "github.com/grafana/grafana/pkg/components/apikeygenprefixed"
 	"github.com/grafana/grafana/pkg/infra/db"
@@ -73,7 +71,6 @@ func ProvideService(cfg *setting.Cfg, tokenService auth.UserTokenService, jwtSer
 		features:           features,
 		authnService:       authnService,
 		anonSessionService: anonSessionService,
-		singleflight:       new(singleflight.Group),
 	}
 }
 
@@ -95,7 +92,6 @@ type ContextHandler struct {
 	oauthTokenService  oauthtoken.OAuthTokenService
 	features           *featuremgmt.FeatureManager
 	authnService       authn.Service
-	singleflight       *singleflight.Group
 	anonSessionService anonymous.Service
 	// GetTime returns the current time.
 	// Stubbable by tests.

--- a/pkg/services/contexthandler/model/model.go
+++ b/pkg/services/contexthandler/model/model.go
@@ -31,8 +31,8 @@ type ReqContext struct {
 	RequestNonce          string
 	IsPublicDashboardView bool
 
-	PerfmonTimer   prometheus.Summary
-	LookupTokenErr error
+	PerfmonTimer prometheus.Summary
+	AuthErr      error
 }
 
 // Handle handles and logs error by given status.

--- a/pkg/web/webtest/webtest.go
+++ b/pkg/web/webtest/webtest.go
@@ -143,7 +143,7 @@ func requestContextMiddleware() web.Middleware {
 				c.SkipCache = ctx.SkipCache
 				c.RequestNonce = ctx.RequestNonce
 				c.PerfmonTimer = ctx.PerfmonTimer
-				c.LookupTokenErr = ctx.LookupTokenErr
+				c.AuthErr = ctx.AuthErr
 			}
 
 			next.ServeHTTP(w, r)


### PR DESCRIPTION
**What is this feature?**
With authn.Service and ClientTokenRotation flag we started to use LookupTokenErr from ReqContext as a way to pass authentication errors to auth middlewares so we can reject request from there.

It makes more sense to rename this to AuthErr.

Fixes #

**Special notes for your reviewer:**
