### PR TITLE
Alerting: Fix and re-enable `filters instance labels in log line` test

### DIFF
--- a/pkg/services/ngalert/state/historian/loki.go
+++ b/pkg/services/ngalert/state/historian/loki.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"sort"
 	"strconv"
 	"time"
 
@@ -356,8 +357,14 @@ func buildLogQuery(query models.HistoryQuery) (string, error) {
 	logQL := selectorString(selectors)
 
 	labelFilters := ""
-	for k, v := range query.Labels {
-		labelFilters += fmt.Sprintf(" | labels_%s=%q", k, v)
+	labelKeys := make([]string, 0, len(query.Labels))
+	for k := range query.Labels {
+		labelKeys = append(labelKeys, k)
+	}
+	// Ensure that all queries we build are deterministic.
+	sort.Strings(labelKeys)
+	for _, k := range labelKeys {
+		labelFilters += fmt.Sprintf(" | labels_%s=%q", k, query.Labels[k])
 	}
 
 	if labelFilters != "" {


### PR DESCRIPTION
## Manual backport of https://github.com/grafana/grafana/pull/65618

**What is this feature?**

https://github.com/grafana/grafana/pull/65610 disabled this test. This PR fixes it and re-enables it.

Ran the test 10k times in parallel to repro the intermittent failure. All 10k runs pass after the fix.

**Which issue(s) does this PR fix?**:

n/a

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
- [x] There are no known compatibility issues with older supported versions of Grafana, or plugins.
- [x] It passes the [Hosted Grafana feature readiness review](https://docs.google.com/document/d/1QL9Ly8KnXzpb6ISbg49pTODRO5mhA5tkkfIZVX6pqQU/edit) for observability, scalability, performance, and security.