### PR TITLE
Loki Query Splitting: Rename from "chunk" to "splitting"

### DIFF
--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -77,7 +77,7 @@ enum PluginRequestHeaders {
   DatasourceUID = 'X-Datasource-Uid', // can be used for routing/ load balancing
   DashboardUID = 'X-Dashboard-Uid', // mainly useful for debuging slow queries
   PanelID = 'X-Panel-Id', // mainly useful for debuging slow queries
-  QueryGroupID = 'X-Query-Group-Id', // mainly useful to find related queries with query chunking
+  QueryGroupID = 'X-Query-Group-Id', // mainly useful to find related queries with query splitting
   FromExpression = 'X-Grafana-From-Expr', // used by datasources to identify expression queries
 }
 

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -33,7 +33,7 @@ import { CustomVariableModel } from '../../../features/variables/types';
 
 import { LokiDatasource, REF_ID_DATA_SAMPLES } from './datasource';
 import { createLokiDatasource, createMetadataRequest } from './mocks';
-import { runQueryInChunks } from './queryChunking';
+import { runSplitQuery } from './querySplitting';
 import { parseToNodeNamesArray } from './queryUtils';
 import { LokiOptions, LokiQuery, LokiQueryType, LokiVariableQueryType, SupportingQueryType } from './types';
 import { LokiVariableSupport } from './variables';
@@ -45,7 +45,7 @@ jest.mock('@grafana/runtime', () => {
   };
 });
 
-jest.mock('./queryChunking');
+jest.mock('./querySplitting');
 
 const templateSrvStub = {
   getAdhocFilters: jest.fn(() => [] as unknown[]),
@@ -1127,7 +1127,7 @@ describe('LokiDatasource', () => {
   describe('Query splitting', () => {
     beforeAll(() => {
       config.featureToggles.lokiQuerySplitting = true;
-      jest.mocked(runQueryInChunks).mockReturnValue(
+      jest.mocked(runSplitQuery).mockReturnValue(
         of({
           data: [],
         })
@@ -1153,7 +1153,7 @@ describe('LokiDatasource', () => {
       });
 
       await expect(ds.query(query)).toEmitValuesWith(() => {
-        expect(runQueryInChunks).toHaveBeenCalled();
+        expect(runSplitQuery).toHaveBeenCalled();
       });
     });
   });

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -66,8 +66,8 @@ import {
   findLastPosition,
   getLabelFilterPositions,
 } from './modifyQuery';
-import { runQueryInChunks } from './queryChunking';
 import { getQueryHints } from './queryHints';
+import { runSplitQuery } from './querySplitting';
 import {
   getLogQueryFromMetricsQuery,
   getNormalizedLokiQuery,
@@ -285,7 +285,7 @@ export class LokiDatasource
     }
 
     if (config.featureToggles.lokiQuerySplitting && requestSupporsChunking(fixedRequest.targets)) {
-      return runQueryInChunks(this, fixedRequest);
+      return runSplitQuery(this, fixedRequest);
     }
 
     return this.runQuery(fixedRequest);

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -75,7 +75,7 @@ import {
   getParserFromQuery,
   isLogsQuery,
   isValidQuery,
-  requestSupporsChunking,
+  requestSupportsSplitting,
 } from './queryUtils';
 import { sortDataFrameByTime, SortDirection } from './sortDataFrame';
 import { doLokiChannelStream } from './streaming';
@@ -284,7 +284,7 @@ export class LokiDatasource
       return this.runLiveQueryThroughBackend(fixedRequest);
     }
 
-    if (config.featureToggles.lokiQuerySplitting && requestSupporsChunking(fixedRequest.targets)) {
+    if (config.featureToggles.lokiQuerySplitting && requestSupportsSplitting(fixedRequest.targets)) {
       return runSplitQuery(this, fixedRequest);
     }
 

--- a/public/app/plugins/datasource/loki/logsTimeSplitting.test.ts
+++ b/public/app/plugins/datasource/loki/logsTimeSplitting.test.ts
@@ -1,11 +1,11 @@
-import { getRangePartition } from './logsTimeSplitting';
+import { splitTimeRange } from './logsTimeSplitting';
 
-describe('logs getRangePartition', () => {
+describe('logs splitTimeRange', () => {
   it('should split time range into chunks', () => {
     const start = Date.parse('2022-02-06T14:10:03.234');
     const end = Date.parse('2022-02-06T14:11:03.567');
 
-    expect(getRangePartition(start, end, 10000)).toStrictEqual([
+    expect(splitTimeRange(start, end, 10000)).toStrictEqual([
       [Date.parse('2022-02-06T14:10:03.234'), Date.parse('2022-02-06T14:10:03.567')],
       [Date.parse('2022-02-06T14:10:03.567'), Date.parse('2022-02-06T14:10:13.567')],
       [Date.parse('2022-02-06T14:10:13.567'), Date.parse('2022-02-06T14:10:23.567')],
@@ -20,7 +20,7 @@ describe('logs getRangePartition', () => {
     const start = Date.parse('2022-02-06T14:10:03.567');
     const end = Date.parse('2022-02-06T14:11:03.567');
 
-    expect(getRangePartition(start, end, 20000)).toStrictEqual([
+    expect(splitTimeRange(start, end, 20000)).toStrictEqual([
       [Date.parse('2022-02-06T14:10:03.567'), Date.parse('2022-02-06T14:10:23.567')],
       [Date.parse('2022-02-06T14:10:23.567'), Date.parse('2022-02-06T14:10:43.567')],
       [Date.parse('2022-02-06T14:10:43.567'), Date.parse('2022-02-06T14:11:03.567')],

--- a/public/app/plugins/datasource/loki/logsTimeSplitting.test.ts
+++ b/public/app/plugins/datasource/loki/logsTimeSplitting.test.ts
@@ -1,4 +1,4 @@
-import { getRangeChunks } from './logsTimeChunking';
+import { getRangeChunks } from './logsTimeSplitting';
 
 describe('logs getRangeChunks', () => {
   it('should split time range into chunks', () => {

--- a/public/app/plugins/datasource/loki/logsTimeSplitting.test.ts
+++ b/public/app/plugins/datasource/loki/logsTimeSplitting.test.ts
@@ -1,11 +1,11 @@
-import { getRangeChunks } from './logsTimeSplitting';
+import { getRangePartition } from './logsTimeSplitting';
 
-describe('logs getRangeChunks', () => {
+describe('logs getRangePartition', () => {
   it('should split time range into chunks', () => {
     const start = Date.parse('2022-02-06T14:10:03.234');
     const end = Date.parse('2022-02-06T14:11:03.567');
 
-    expect(getRangeChunks(start, end, 10000)).toStrictEqual([
+    expect(getRangePartition(start, end, 10000)).toStrictEqual([
       [Date.parse('2022-02-06T14:10:03.234'), Date.parse('2022-02-06T14:10:03.567')],
       [Date.parse('2022-02-06T14:10:03.567'), Date.parse('2022-02-06T14:10:13.567')],
       [Date.parse('2022-02-06T14:10:13.567'), Date.parse('2022-02-06T14:10:23.567')],
@@ -20,7 +20,7 @@ describe('logs getRangeChunks', () => {
     const start = Date.parse('2022-02-06T14:10:03.567');
     const end = Date.parse('2022-02-06T14:11:03.567');
 
-    expect(getRangeChunks(start, end, 20000)).toStrictEqual([
+    expect(getRangePartition(start, end, 20000)).toStrictEqual([
       [Date.parse('2022-02-06T14:10:03.567'), Date.parse('2022-02-06T14:10:23.567')],
       [Date.parse('2022-02-06T14:10:23.567'), Date.parse('2022-02-06T14:10:43.567')],
       [Date.parse('2022-02-06T14:10:43.567'), Date.parse('2022-02-06T14:11:03.567')],

--- a/public/app/plugins/datasource/loki/logsTimeSplitting.ts
+++ b/public/app/plugins/datasource/loki/logsTimeSplitting.ts
@@ -16,7 +16,7 @@
 // to the end, so if we do it right in milliseconds, it should be OK in
 // nanoseconds too
 
-export function getRangeChunks(
+export function getRangePartition(
   startTime: number,
   endTime: number,
   idealRangeDuration: number

--- a/public/app/plugins/datasource/loki/logsTimeSplitting.ts
+++ b/public/app/plugins/datasource/loki/logsTimeSplitting.ts
@@ -16,7 +16,7 @@
 // to the end, so if we do it right in milliseconds, it should be OK in
 // nanoseconds too
 
-export function getRangePartition(
+export function splitTimeRange(
   startTime: number,
   endTime: number,
   idealRangeDuration: number

--- a/public/app/plugins/datasource/loki/metricTimeSplitting.test.ts
+++ b/public/app/plugins/datasource/loki/metricTimeSplitting.test.ts
@@ -1,6 +1,6 @@
 import { getRangePartition } from './metricTimeSplitting';
 
-describe('metric getRangeChunks', () => {
+describe('metric getRangePartition', () => {
   it('should split time range into chunks', () => {
     const start = Date.parse('2022-02-06T14:10:03');
     const end = Date.parse('2022-02-06T14:11:03');

--- a/public/app/plugins/datasource/loki/metricTimeSplitting.test.ts
+++ b/public/app/plugins/datasource/loki/metricTimeSplitting.test.ts
@@ -1,4 +1,4 @@
-import { getRangeChunks } from './metricTimeChunking';
+import { getRangePartition } from './metricTimeSplitting';
 
 describe('metric getRangeChunks', () => {
   it('should split time range into chunks', () => {
@@ -6,7 +6,7 @@ describe('metric getRangeChunks', () => {
     const end = Date.parse('2022-02-06T14:11:03');
     const step = 10 * 1000;
 
-    expect(getRangeChunks(start, end, step, 25000)).toStrictEqual([
+    expect(getRangePartition(start, end, step, 25000)).toStrictEqual([
       [Date.parse('2022-02-06T14:10:00'), Date.parse('2022-02-06T14:10:10')],
       [Date.parse('2022-02-06T14:10:20'), Date.parse('2022-02-06T14:10:40')],
       [Date.parse('2022-02-06T14:10:50'), Date.parse('2022-02-06T14:11:10')],
@@ -17,6 +17,6 @@ describe('metric getRangeChunks', () => {
     const start = Date.parse('2022-02-06T14:10:03');
     const end = Date.parse('2022-02-06T14:10:33');
     const step = 10 * 1000;
-    expect(getRangeChunks(start, end, step, 1000)).toEqual([[start, end]]);
+    expect(getRangePartition(start, end, step, 1000)).toEqual([[start, end]]);
   });
 });

--- a/public/app/plugins/datasource/loki/metricTimeSplitting.test.ts
+++ b/public/app/plugins/datasource/loki/metricTimeSplitting.test.ts
@@ -1,12 +1,12 @@
-import { getRangePartition } from './metricTimeSplitting';
+import { splitTimeRange } from './metricTimeSplitting';
 
-describe('metric getRangePartition', () => {
+describe('metric splitTimeRange', () => {
   it('should split time range into chunks', () => {
     const start = Date.parse('2022-02-06T14:10:03');
     const end = Date.parse('2022-02-06T14:11:03');
     const step = 10 * 1000;
 
-    expect(getRangePartition(start, end, step, 25000)).toStrictEqual([
+    expect(splitTimeRange(start, end, step, 25000)).toStrictEqual([
       [Date.parse('2022-02-06T14:10:00'), Date.parse('2022-02-06T14:10:10')],
       [Date.parse('2022-02-06T14:10:20'), Date.parse('2022-02-06T14:10:40')],
       [Date.parse('2022-02-06T14:10:50'), Date.parse('2022-02-06T14:11:10')],
@@ -17,6 +17,6 @@ describe('metric getRangePartition', () => {
     const start = Date.parse('2022-02-06T14:10:03');
     const end = Date.parse('2022-02-06T14:10:33');
     const step = 10 * 1000;
-    expect(getRangePartition(start, end, step, 1000)).toEqual([[start, end]]);
+    expect(splitTimeRange(start, end, step, 1000)).toEqual([[start, end]]);
   });
 });

--- a/public/app/plugins/datasource/loki/metricTimeSplitting.ts
+++ b/public/app/plugins/datasource/loki/metricTimeSplitting.ts
@@ -19,7 +19,7 @@ function expandTimeRange(startTime: number, endTime: number, step: number): [num
   return [newStartTime, newEndTime];
 }
 
-export function getRangePartition(
+export function splitTimeRange(
   startTime: number,
   endTime: number,
   step: number,

--- a/public/app/plugins/datasource/loki/metricTimeSplitting.ts
+++ b/public/app/plugins/datasource/loki/metricTimeSplitting.ts
@@ -19,7 +19,7 @@ function expandTimeRange(startTime: number, endTime: number, step: number): [num
   return [newStartTime, newEndTime];
 }
 
-export function getRangeChunks(
+export function getRangePartition(
   startTime: number,
   endTime: number,
   step: number,

--- a/public/app/plugins/datasource/loki/querySplitting.test.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.test.ts
@@ -5,10 +5,10 @@ import { dateTime } from '@grafana/data';
 import { LoadingState } from '@grafana/schema';
 
 import { LokiDatasource } from './datasource';
-import * as logsTimeSplit from './logsTimeChunking';
-import * as metricTimeSplit from './metricTimeChunking';
+import * as logsTimeSplit from './logsTimeSplitting';
+import * as metricTimeSplit from './metricTimeSplitting';
 import { createLokiDatasource, getMockFrames } from './mocks';
-import { runQueryInChunks } from './queryChunking';
+import { runQueryInChunks } from './querySplitting';
 import { LokiQuery, LokiQueryType } from './types';
 
 describe('runQueryInChunks()', () => {

--- a/public/app/plugins/datasource/loki/querySplitting.test.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.test.ts
@@ -55,17 +55,17 @@ describe('runSplitQuery()', () => {
       range,
     });
     beforeAll(() => {
-      jest.spyOn(logsTimeSplit, 'getRangePartition').mockReturnValue([]);
-      jest.spyOn(metricTimeSplit, 'getRangePartition').mockReturnValue([]);
+      jest.spyOn(logsTimeSplit, 'splitTimeRange').mockReturnValue([]);
+      jest.spyOn(metricTimeSplit, 'splitTimeRange').mockReturnValue([]);
     });
     afterAll(() => {
-      jest.mocked(logsTimeSplit.getRangePartition).mockRestore();
-      jest.mocked(metricTimeSplit.getRangePartition).mockRestore();
+      jest.mocked(logsTimeSplit.splitTimeRange).mockRestore();
+      jest.mocked(metricTimeSplit.splitTimeRange).mockRestore();
     });
     test('Ignores hidden queries', async () => {
       await expect(runSplitQuery(datasource, request)).toEmitValuesWith(() => {
-        expect(logsTimeSplit.getRangePartition).toHaveBeenCalled();
-        expect(metricTimeSplit.getRangePartition).not.toHaveBeenCalled();
+        expect(logsTimeSplit.splitTimeRange).toHaveBeenCalled();
+        expect(metricTimeSplit.splitTimeRange).not.toHaveBeenCalled();
       });
     });
   });

--- a/public/app/plugins/datasource/loki/querySplitting.test.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.test.ts
@@ -191,7 +191,7 @@ describe('runQueryInChunks()', () => {
     });
   });
 
-  describe('Splitting targets based on chunkDuration', () => {
+  describe('Splitting targets based on splitDuration', () => {
     const range1h = {
       from: dateTime('2023-02-08T05:00:00.000Z'),
       to: dateTime('2023-02-08T06:00:00.000Z'),
@@ -203,29 +203,29 @@ describe('runQueryInChunks()', () => {
     beforeEach(() => {
       jest.spyOn(datasource, 'runQuery').mockReturnValue(of({ data: [], refId: 'A' }));
     });
-    test('with 30m chunkDuration runs 2 queries', async () => {
+    test('with 30m splitDuration runs 2 queries', async () => {
       const request = getQueryOptions<LokiQuery>({
-        targets: [{ expr: '{a="b"}', refId: 'A', chunkDuration: '30m' }],
+        targets: [{ expr: '{a="b"}', refId: 'A', splitDuration: '30m' }],
         range: range1h,
       });
       await expect(runQueryInChunks(datasource, request)).toEmitValuesWith(() => {
         expect(datasource.runQuery).toHaveBeenCalledTimes(2);
       });
     });
-    test('with 1h chunkDuration runs 1 queries', async () => {
+    test('with 1h splitDuration runs 1 queries', async () => {
       const request = getQueryOptions<LokiQuery>({
-        targets: [{ expr: '{a="b"}', refId: 'A', chunkDuration: '1h' }],
+        targets: [{ expr: '{a="b"}', refId: 'A', splitDuration: '1h' }],
         range: range1h,
       });
       await expect(runQueryInChunks(datasource, request)).toEmitValuesWith(() => {
         expect(datasource.runQuery).toHaveBeenCalledTimes(1);
       });
     });
-    test('with 1h chunkDuration and 2 targets runs 1 queries', async () => {
+    test('with 1h splitDuration and 2 targets runs 1 queries', async () => {
       const request = getQueryOptions<LokiQuery>({
         targets: [
-          { expr: '{a="b"}', refId: 'A', chunkDuration: '1h' },
-          { expr: '{a="b"}', refId: 'B', chunkDuration: '1h' },
+          { expr: '{a="b"}', refId: 'A', splitDuration: '1h' },
+          { expr: '{a="b"}', refId: 'B', splitDuration: '1h' },
         ],
         range: range1h,
       });
@@ -233,11 +233,11 @@ describe('runQueryInChunks()', () => {
         expect(datasource.runQuery).toHaveBeenCalledTimes(1);
       });
     });
-    test('with 1h/30m chunkDuration and 2 targets runs 3 queries', async () => {
+    test('with 1h/30m splitDuration and 2 targets runs 3 queries', async () => {
       const request = getQueryOptions<LokiQuery>({
         targets: [
-          { expr: '{a="b"}', refId: 'A', chunkDuration: '1h' },
-          { expr: '{a="b"}', refId: 'B', chunkDuration: '30m' },
+          { expr: '{a="b"}', refId: 'A', splitDuration: '1h' },
+          { expr: '{a="b"}', refId: 'B', splitDuration: '30m' },
         ],
         range: range1h,
       });
@@ -246,11 +246,11 @@ describe('runQueryInChunks()', () => {
         expect(datasource.runQuery).toHaveBeenCalledTimes(3);
       });
     });
-    test('with 1h/30m chunkDuration and 1 log and 2 metric target runs 3 queries', async () => {
+    test('with 1h/30m splitDuration and 1 log and 2 metric target runs 3 queries', async () => {
       const request = getQueryOptions<LokiQuery>({
         targets: [
-          { expr: '{a="b"}', refId: 'A', chunkDuration: '1h' },
-          { expr: 'count_over_time({c="d"}[1m])', refId: 'C', chunkDuration: '30m' },
+          { expr: '{a="b"}', refId: 'A', splitDuration: '1h' },
+          { expr: 'count_over_time({c="d"}[1m])', refId: 'C', splitDuration: '30m' },
         ],
         range: range1h,
       });

--- a/public/app/plugins/datasource/loki/querySplitting.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.ts
@@ -83,7 +83,7 @@ function adjustTargetsFromResponseState(targets: LokiQuery[], response: DataQuer
 
 type LokiGroupedRequest = Array<{ request: DataQueryRequest<LokiQuery>; partition: TimeRange[] }>;
 
-export function runGroupedQueriesInChunks(datasource: LokiDatasource, requests: LokiGroupedRequest) {
+export function runSplitGroupedQueries(datasource: LokiDatasource, requests: LokiGroupedRequest) {
   let mergedResponse: DataQueryResponse = { data: [], state: LoadingState.Streaming };
   const totalRequests = Math.max(...requests.map(({ partition }) => partition.length));
 
@@ -176,10 +176,10 @@ export function runSplitQuery(datasource: LokiDatasource, request: DataQueryRequ
 
   const oneDayMs = 24 * 60 * 60 * 1000;
   const rangePartitionedLogQueries = groupBy(logQueries, (query) =>
-    query.chunkDuration ? durationToMilliseconds(parseDuration(query.chunkDuration)) : oneDayMs
+    query.splitDuration ? durationToMilliseconds(parseDuration(query.splitDuration)) : oneDayMs
   );
   const rangePartitionedMetricQueries = groupBy(metricQueries, (query) =>
-    query.chunkDuration ? durationToMilliseconds(parseDuration(query.chunkDuration)) : oneDayMs
+    query.splitDuration ? durationToMilliseconds(parseDuration(query.splitDuration)) : oneDayMs
   );
 
   const requests: LokiGroupedRequest = [];
@@ -222,5 +222,5 @@ export function runSplitQuery(datasource: LokiDatasource, request: DataQueryRequ
     });
   }
 
-  return runGroupedQueriesInChunks(datasource, requests);
+  return runSplitGroupedQueries(datasource, requests);
 }

--- a/public/app/plugins/datasource/loki/querySplitting.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.ts
@@ -13,8 +13,8 @@ import {
 import { LoadingState } from '@grafana/schema';
 
 import { LokiDatasource } from './datasource';
-import { getRangePartition as getLogsRangePartition } from './logsTimeSplitting';
-import { getRangePartition as getMetricRangePartition } from './metricTimeSplitting';
+import { splitTimeRange as splitLogsTimeRange } from './logsTimeSplitting';
+import { splitTimeRange as splitMetricTimeRange } from './metricTimeSplitting';
 import { isLogsQuery } from './queryUtils';
 import { combineResponses } from './responseUtils';
 import { LokiQuery, LokiQueryType } from './types';
@@ -38,8 +38,8 @@ export function partitionTimeRange(
   const step = Math.max(intervalMs * resolution, safeStep);
 
   const ranges = isLogsQuery
-    ? getLogsRangePartition(start, end, duration)
-    : getMetricRangePartition(start, end, step, duration);
+    ? splitLogsTimeRange(start, end, duration)
+    : splitMetricTimeRange(start, end, step, duration);
 
   return ranges.map(([start, end]) => {
     const from = dateTime(start);

--- a/public/app/plugins/datasource/loki/querySplitting.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.ts
@@ -13,8 +13,8 @@ import {
 import { LoadingState } from '@grafana/schema';
 
 import { LokiDatasource } from './datasource';
-import { getRangeChunks as getLogsRangeChunks } from './logsTimeChunking';
-import { getRangeChunks as getMetricRangeChunks } from './metricTimeChunking';
+import { getRangePartition as getLogsRangePartition } from './logsTimeSplitting';
+import { getRangePartition as getMetricRangePartition } from './metricTimeSplitting';
 import { isLogsQuery } from './queryUtils';
 import { combineResponses } from './responseUtils';
 import { LokiQuery, LokiQueryType } from './types';
@@ -38,8 +38,8 @@ export function partitionTimeRange(
   const step = Math.max(intervalMs * resolution, safeStep);
 
   const ranges = isLogsQuery
-    ? getLogsRangeChunks(start, end, duration)
-    : getMetricRangeChunks(start, end, step, duration);
+    ? getLogsRangePartition(start, end, duration)
+    : getMetricRangePartition(start, end, step, duration);
 
   return ranges.map(([start, end]) => {
     const from = dateTime(start);
@@ -167,7 +167,7 @@ function getNextRequestPointers(requests: LokiGroupedRequest, requestGroup: numb
   };
 }
 
-export function runQueryInChunks(datasource: LokiDatasource, request: DataQueryRequest<LokiQuery>) {
+export function runSplitQuery(datasource: LokiDatasource, request: DataQueryRequest<LokiQuery>) {
   const queries = request.targets.filter((query) => !query.hide);
   const [instantQueries, normalQueries] = partition(queries, (query) => query.queryType === LokiQueryType.Instant);
   const [logQueries, metricQueries] = partition(normalQueries, (query) => isLogsQuery(query.expr));

--- a/public/app/plugins/datasource/loki/queryUtils.test.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.test.ts
@@ -8,7 +8,7 @@ import {
   parseToNodeNamesArray,
   getParserFromQuery,
   obfuscate,
-  requestSupporsChunking,
+  requestSupportsSplitting,
 } from './queryUtils';
 import { LokiQuery, LokiQueryType } from './types';
 
@@ -294,7 +294,7 @@ describe('getParserFromQuery', () => {
   });
 });
 
-describe('requestSupporsChunking', () => {
+describe('requestSupportsSplitting', () => {
   it('hidden requests are not partitioned', () => {
     const requests: LokiQuery[] = [
       {
@@ -303,7 +303,7 @@ describe('requestSupporsChunking', () => {
         hide: true,
       },
     ];
-    expect(requestSupporsChunking(requests)).toBe(false);
+    expect(requestSupportsSplitting(requests)).toBe(false);
   });
   it('special requests are not partitioned', () => {
     const requests: LokiQuery[] = [
@@ -312,7 +312,7 @@ describe('requestSupporsChunking', () => {
         refId: 'do-not-chunk',
       },
     ];
-    expect(requestSupporsChunking(requests)).toBe(false);
+    expect(requestSupportsSplitting(requests)).toBe(false);
   });
   it('empty requests are not partitioned', () => {
     const requests: LokiQuery[] = [
@@ -321,7 +321,7 @@ describe('requestSupporsChunking', () => {
         refId: 'A',
       },
     ];
-    expect(requestSupporsChunking(requests)).toBe(false);
+    expect(requestSupportsSplitting(requests)).toBe(false);
   });
   it('all other requests are partitioned', () => {
     const requests: LokiQuery[] = [
@@ -334,6 +334,6 @@ describe('requestSupporsChunking', () => {
         refId: 'B',
       },
     ];
-    expect(requestSupporsChunking(requests)).toBe(true);
+    expect(requestSupportsSplitting(requests)).toBe(true);
   });
 });

--- a/public/app/plugins/datasource/loki/queryUtils.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.ts
@@ -296,7 +296,7 @@ export function getStreamSelectorsFromQuery(query: string): string[] {
   return labelMatchers;
 }
 
-export function requestSupporsChunking(allQueries: LokiQuery[]) {
+export function requestSupportsSplitting(allQueries: LokiQuery[]) {
   const queries = allQueries
     .filter((query) => !query.hide)
     .filter((query) => !query.refId.includes('do-not-chunk'))

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.tsx
@@ -23,7 +23,7 @@ export interface Props {
 
 export const LokiQueryBuilderOptions = React.memo<Props>(
   ({ app, query, onChange, onRunQuery, maxLines, datasource, queryStats }) => {
-    const [chunkRangeValid, setChunkRangeValid] = useState(true);
+    const [splitDurationValid, setsplitDurationValid] = useState(true);
 
     const onQueryTypeChange = (value: LokiQueryType) => {
       onChange({ ...query, queryType: value });
@@ -42,10 +42,10 @@ export const LokiQueryBuilderOptions = React.memo<Props>(
     const onChunkRangeChange = (evt: React.FormEvent<HTMLInputElement>) => {
       const value = evt.currentTarget.value;
       if (!isValidDuration(value)) {
-        setChunkRangeValid(false);
+        setsplitDurationValid(false);
         return;
       }
-      setChunkRangeValid(true);
+      setsplitDurationValid(true);
       onChange({ ...query, splitDuration: value });
       onRunQuery();
     };
@@ -121,7 +121,7 @@ export const LokiQueryBuilderOptions = React.memo<Props>(
                 min={0}
                 defaultValue={query.splitDuration ?? '1d'}
                 onCommitChange={onChunkRangeChange}
-                invalid={!chunkRangeValid}
+                invalid={!splitDurationValid}
               />
             </EditorField>
           )}

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.tsx
@@ -112,8 +112,8 @@ export const LokiQueryBuilderOptions = React.memo<Props>(
           </EditorField>
           {config.featureToggles.lokiQuerySplittingConfig && config.featureToggles.lokiQuerySplitting && (
             <EditorField
-              label="Chunk Duration"
-              tooltip="Defines the duration of a single query chunk when query chunking is used."
+              label="Split Duration"
+              tooltip="Defines the duration of a single query when query splitting is enabled."
             >
               <AutoSizeInput
                 minWidth={14}

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.tsx
@@ -46,7 +46,7 @@ export const LokiQueryBuilderOptions = React.memo<Props>(
         return;
       }
       setChunkRangeValid(true);
-      onChange({ ...query, chunkDuration: value });
+      onChange({ ...query, splitDuration: value });
       onRunQuery();
     };
 
@@ -119,7 +119,7 @@ export const LokiQueryBuilderOptions = React.memo<Props>(
                 minWidth={14}
                 type="string"
                 min={0}
-                defaultValue={query.chunkDuration ?? '1d'}
+                defaultValue={query.splitDuration ?? '1d'}
                 onCommitChange={onChunkRangeChange}
                 invalid={!chunkRangeValid}
               />

--- a/public/app/plugins/datasource/loki/types.ts
+++ b/public/app/plugins/datasource/loki/types.ts
@@ -40,7 +40,7 @@ export interface LokiQuery extends LokiQueryFromSchema {
    * This is a property for the experimental query splitting feature.
    * @experimental
    */
-  chunkDuration?: string;
+  splitDuration?: string;
 }
 
 export interface LokiOptions extends DataSourceJsonData {


### PR DESCRIPTION
Consensus has moved from "chunking" to "splitting", so we're renaming this feature to "query splitting".

Part of https://github.com/grafana/grafana/issues/61768