### PR TITLE
Dataplane: Prometheus dataplane field name migration

### DIFF
--- a/packages/grafana-data/src/field/fieldState.ts
+++ b/packages/grafana-data/src/field/fieldState.ts
@@ -75,6 +75,20 @@ function calculateFieldDisplayName(field: Field, frame?: DataFrame, allFrames?: 
     return displayName ?? TIME_SERIES_TIME_FIELD_NAME;
   }
 
+  const DATAPLANE_INITIAL_RELEASE = [0, 1];
+  console.log('prometheusDataplane check');
+  console.log('field.name =', field.name);
+  console.log('displayName =', displayName);
+  if (
+    frame?.meta?.typeVersion &&
+    frame?.meta?.typeVersion >= DATAPLANE_INITIAL_RELEASE &&
+    field.labels?.__name__ &&
+    field.labels?.__name__ === field.name
+  ) {
+    console.log('returning TIME_SERIES_VALUE_FIELD_NAME =', TIME_SERIES_VALUE_FIELD_NAME);
+    return TIME_SERIES_VALUE_FIELD_NAME;
+  }
+
   let parts: string[] = [];
   let frameNamesDiffer = false;
 

--- a/packages/grafana-data/src/field/fieldState.ts
+++ b/packages/grafana-data/src/field/fieldState.ts
@@ -55,7 +55,7 @@ export function getFieldDisplayName(field: Field, frame?: DataFrame, allFrames?:
 /**
  * Get an appropriate display name. If the 'displayName' field config is set, use that.
  */
-function calculateFieldDisplayName(field: Field, frame?: DataFrame, allFrames?: DataFrame[]): string {
+export function calculateFieldDisplayName(field: Field, frame?: DataFrame, allFrames?: DataFrame[]): string {
   const hasConfigTitle = field.config?.displayName && field.config?.displayName.length;
 
   let displayName = hasConfigTitle ? field.config!.displayName! : field.name;
@@ -73,11 +73,6 @@ function calculateFieldDisplayName(field: Field, frame?: DataFrame, allFrames?: 
   // But in case it has a join source we should handle it as normal field
   if (field.type === FieldType.time && !field.labels) {
     return displayName ?? TIME_SERIES_TIME_FIELD_NAME;
-  }
-
-  // migration for dataplane with TimeSeriesMulti
-  if (field.labels?.__name__ && field.labels?.__name__ === field.name) {
-    field = { ...field, name: TIME_SERIES_VALUE_FIELD_NAME };
   }
 
   let parts: string[] = [];

--- a/packages/grafana-data/src/field/fieldState.ts
+++ b/packages/grafana-data/src/field/fieldState.ts
@@ -75,13 +75,8 @@ function calculateFieldDisplayName(field: Field, frame?: DataFrame, allFrames?: 
     return displayName ?? TIME_SERIES_TIME_FIELD_NAME;
   }
 
-  const DATAPLANE_INITIAL_RELEASE = [0, 1];
-  if (
-    frame?.meta?.typeVersion &&
-    frame?.meta?.typeVersion >= DATAPLANE_INITIAL_RELEASE &&
-    field.labels?.__name__ &&
-    field.labels?.__name__ === field.name
-  ) {
+  // migration for dataplane with TimeSeriesMulti
+  if (field.labels?.__name__ && field.labels?.__name__ === field.name) {
     field.name = TIME_SERIES_VALUE_FIELD_NAME;
   }
 

--- a/packages/grafana-data/src/field/fieldState.ts
+++ b/packages/grafana-data/src/field/fieldState.ts
@@ -77,7 +77,7 @@ function calculateFieldDisplayName(field: Field, frame?: DataFrame, allFrames?: 
 
   // migration for dataplane with TimeSeriesMulti
   if (field.labels?.__name__ && field.labels?.__name__ === field.name) {
-    field.name = TIME_SERIES_VALUE_FIELD_NAME;
+    field = { ...field, name: TIME_SERIES_VALUE_FIELD_NAME };
   }
 
   let parts: string[] = [];

--- a/packages/grafana-data/src/field/fieldState.ts
+++ b/packages/grafana-data/src/field/fieldState.ts
@@ -76,17 +76,13 @@ function calculateFieldDisplayName(field: Field, frame?: DataFrame, allFrames?: 
   }
 
   const DATAPLANE_INITIAL_RELEASE = [0, 1];
-  console.log('prometheusDataplane check');
-  console.log('field.name =', field.name);
-  console.log('displayName =', displayName);
   if (
     frame?.meta?.typeVersion &&
     frame?.meta?.typeVersion >= DATAPLANE_INITIAL_RELEASE &&
     field.labels?.__name__ &&
     field.labels?.__name__ === field.name
   ) {
-    console.log('returning TIME_SERIES_VALUE_FIELD_NAME =', TIME_SERIES_VALUE_FIELD_NAME);
-    return TIME_SERIES_VALUE_FIELD_NAME;
+    field.name = TIME_SERIES_VALUE_FIELD_NAME;
   }
 
   let parts: string[] = [];

--- a/public/app/plugins/datasource/prometheus/result_transformer.test.ts
+++ b/public/app/plugins/datasource/prometheus/result_transformer.test.ts
@@ -22,6 +22,11 @@ jest.mock('@grafana/runtime', () => ({
       },
     };
   },
+  config: {
+    featureToggles: {
+      prometheusDataplane: true,
+    },
+  },
 }));
 
 const matrixResponse = {

--- a/public/app/plugins/datasource/prometheus/result_transformer.test.ts
+++ b/public/app/plugins/datasource/prometheus/result_transformer.test.ts
@@ -106,6 +106,74 @@ describe('Prometheus Result Transformer', () => {
       });
     });
 
+    it('dataplane handling, adds displayNameFromDs from calculateFieldDisplayName() when __name__ is the field name when legendFormat is auto', () => {
+      const request = {
+        targets: [
+          {
+            format: 'time_series',
+            refId: 'A',
+            legendFormat: '__auto',
+          },
+        ],
+      } as unknown as DataQueryRequest<PromQuery>;
+      const response = {
+        state: 'Done',
+        data: [
+          {
+            fields: [
+              {
+                name: 'Time',
+                type: 'time',
+                values: [1],
+                typeInfo: { frame: 'time.Time' },
+              },
+              {
+                name: 'up',
+                labels: { __name__: 'up' },
+                config: {},
+                values: [1],
+              },
+            ],
+            length: 1,
+            refId: 'A',
+            meta: {
+              type: 'timeseries-multi',
+              typeVersion: [0, 1],
+            },
+          },
+        ],
+      } as unknown as DataQueryResponse;
+      const series = transformV2(response, request, {});
+      expect(series).toEqual({
+        data: [
+          {
+            fields: [
+              {
+                name: 'Time',
+                type: 'time',
+                values: [1],
+                typeInfo: { frame: 'time.Time' },
+              },
+              {
+                config: { displayNameFromDS: 'up' },
+                labels: { __name__: 'up' },
+                name: 'up',
+                values: [1],
+              },
+            ],
+            length: 1,
+            meta: {
+              type: 'timeseries-multi',
+              typeVersion: [0, 1],
+              preferredVisualisationType: 'graph',
+            },
+            refId: 'A',
+          },
+        ],
+        state: 'Done',
+      });
+    });
+
     it('results with table format should be transformed to table dataFrames', () => {
       const request = {
         targets: [

--- a/public/app/plugins/datasource/prometheus/result_transformer.ts
+++ b/public/app/plugins/datasource/prometheus/result_transformer.ts
@@ -23,7 +23,7 @@ import {
   TIME_SERIES_VALUE_FIELD_NAME,
 } from '@grafana/data';
 import { calculateFieldDisplayName } from '@grafana/data/src/field/fieldState';
-import { FetchResponse, getDataSourceSrv, getTemplateSrv } from '@grafana/runtime';
+import { config, FetchResponse, getDataSourceSrv, getTemplateSrv } from '@grafana/runtime';
 
 import { renderLegendFormat } from './legend';
 import {
@@ -73,22 +73,21 @@ export function transformV2(
   options: { exemplarTraceIdDestinations?: ExemplarTraceIdDestination[] }
 ) {
   // migration for dataplane field name issue
-  response.data.forEach((f: DataFrame) => {
-    const refId = f.refId;
-    f.fields.forEach((field) => {
-      const target = request.targets.find((t) => t.refId === refId);
-      if (
-        field.labels?.__name__ &&
-        field.labels?.__name__ === field.name &&
-        // check that the legend is selected as auto
-        target &&
-        target.legendFormat === '__auto'
-      ) {
-        const fieldCopy = { ...field, name: TIME_SERIES_VALUE_FIELD_NAME };
-        field.config.displayNameFromDS = calculateFieldDisplayName(fieldCopy, f, response.data);
+  if (config.featureToggles.prometheusDataplane) {
+    // update displayNameFromDS in the field config
+    response.data.forEach((f: DataFrame) => {
+      const target = request.targets.find((t) => t.refId === f.refId);
+      // check that the legend is selected as auto
+      if (target && target.legendFormat === '__auto') {
+        f.fields.forEach((field) => {
+          if (field.labels?.__name__ && field.labels?.__name__ === field.name) {
+            const fieldCopy = { ...field, name: TIME_SERIES_VALUE_FIELD_NAME };
+            field.config.displayNameFromDS = calculateFieldDisplayName(fieldCopy, f, response.data);
+          }
+        });
       }
     });
-  });
+  }
 
   const [tableFrames, framesWithoutTable] = partition<DataFrame>(response.data, (df) => isTableResult(df, request));
   const processedTableFrames = transformDFToTable(tableFrames);


### PR DESCRIPTION
**What is this?**
Handle the name change for Prometheus due to the dataplane contract for TimeSeriesMulti.

This is along with https://github.com/grafana/grafana/pull/65237 which handles the name change around "Value".

**Why?**
- Frame.Name is moving to field.Name of the first numeric field in TimeSeriesMulti
- Before Dataplane, Prometheus field.Name is “Value”
```
name: “Value”,
labels: { “__name__”: “up”}
```
- Dataplane contract for TimeSeriesMulti and Prometheus will change this to 
```
name: “up”,
labels: { “__name__”: “up”}
```
So this change will return "Value" as the field.name in `getDisplayName` as a migration.

**Who is affected by this?**
Everyone using Prometheus and doing anything where the field name is selected.

**Special notes for your reviewer:**
- Check the dataframe response by Prometheus
- Select a metric like `process_cpu_seconds_total`
- Check the Prometheus option legend, and select `auto`
<img width="565" alt="Screenshot 2023-03-30 at 4 43 33 PM" src="https://user-images.githubusercontent.com/25674746/228959858-185024d1-fe65-4409-8aca-64bf564168ca.png">

- See that the displayed name in the panel is something like 

```
{__name__="process_cpu_seconds_total", instance="localhost:3000", job="go-app"}
``` 
where the name of the metric corresponds to the label `__name__`

- In Grafana config, turn on the feature toggle `prometheusDataplane`
- Perform the same query with the same metric `process_cpu_seconds_total`
- Check the options legend and select `auto`
- See that the displayed name in the panel is the same.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
- [ ] There are no known compatibility issues with older supported versions of Grafana, or plugins.
- [ ] It passes the [Hosted Grafana feature readiness review](https://docs.google.com/document/d/1QL9Ly8KnXzpb6ISbg49pTODRO5mhA5tkkfIZVX6pqQU/edit) for observability, scalability, performance, and security.