### PR TITLE
Alerting: Migration to fix rule group name to not contain slashes + make all groups unique

### DIFF
--- a/pkg/services/sqlstore/migrations/ualert/alert_rule.go
+++ b/pkg/services/sqlstore/migrations/ualert/alert_rule.go
@@ -136,7 +136,7 @@ func (m *migration) makeAlertRule(cond condition, da dashAlert, folderUID string
 		IntervalSeconds: ruleAdjustInterval(da.Frequency),
 		Version:         1,
 		NamespaceUID:    folderUID, // Folder already created, comes from env var.
-		RuleGroup:       name,
+		RuleGroup:       m.groupNameReplacer.Replace(name),
 		For:             duration(da.For),
 		Updated:         time.Now().UTC(),
 		Annotations:     annotations,

--- a/pkg/services/sqlstore/migrations/ualert/alert_rule.go
+++ b/pkg/services/sqlstore/migrations/ualert/alert_rule.go
@@ -303,11 +303,18 @@ func normalizeRuleName(daName string, uid string) string {
 	// If we have to truncate, we're losing data and so there is higher risk of uniqueness conflicts.
 	// Append the UID to the suffix to forcibly break any collisions.
 	if len(daName) > DefaultFieldMaxLength {
-		trunc := DefaultFieldMaxLength - 1 - len(uid)
-		daName = daName[:trunc] + "_" + uid
+		return addSuffixToName(daName, uid)
 	}
-
 	return daName
+}
+
+func addSuffixToName(name, uid string) string {
+	l := len(name) + len(uid) + 1
+	if l > DefaultFieldMaxLength {
+		trunc := len(name) - (l - DefaultFieldMaxLength)
+		name = name[:trunc]
+	}
+	return name + "_" + uid
 }
 
 func extractChannelIDs(d dashAlert) (channelUids []uidOrID) {

--- a/pkg/services/sqlstore/migrations/ualert/alert_rule_test.go
+++ b/pkg/services/sqlstore/migrations/ualert/alert_rule_test.go
@@ -138,6 +138,19 @@ func TestMakeAlertRule(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, ar.IsPaused)
 	})
+
+	t.Run("should normalize group name", func(t *testing.T) {
+		m := newTestMigration(t)
+		da := createTestDashAlert()
+		da.Name = "rule forward/ and back\\"
+		cnd := createTestDashAlertCondition()
+
+		ar, err := m.makeAlertRule(cnd, da, "folder")
+
+		require.NoError(t, err)
+		require.Equal(t, da.Name, ar.Title)
+		require.Equal(t, "rule forward_ and back_", ar.RuleGroup)
+	})
 }
 
 func createTestDashAlert() dashAlert {

--- a/pkg/services/sqlstore/migrations/ualert/alert_rule_test.go
+++ b/pkg/services/sqlstore/migrations/ualert/alert_rule_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
@@ -164,5 +165,15 @@ func createTestDashAlert() dashAlert {
 func createTestDashAlertCondition() condition {
 	return condition{
 		Condition: "A",
+	}
+}
+
+func TestAddSuffixToName(t *testing.T) {
+	uid := uuid.New().String()
+	for i := 1; i <= DefaultFieldMaxLength; i++ {
+		name := strings.Repeat("a", i)
+		newName := addSuffixToName(name, uid)
+		require.LessOrEqualf(t, len(newName), DefaultFieldMaxLength, "name %s exceeds maximum length", newName)
+		require.Equalf(t, uid, newName[len(newName)-len(uid):], "new name %s does not end with UID %s", newName, uid)
 	}
 }

--- a/pkg/services/sqlstore/migrations/ualert/migration_test.go
+++ b/pkg/services/sqlstore/migrations/ualert/migration_test.go
@@ -611,6 +611,20 @@ func TestDashAlertMigration(t *testing.T) {
 			require.Equal(t, expectedFolder.UID, rule.NamespaceUID)
 		}
 	})
+
+	t.Run("when normalized groups intersect make them unique", func(t *testing.T) {
+		defer teardown(t, x)
+		alerts := []*models.Alert{
+			createAlert(t, int64(1), int64(1), int64(1), `alert1 test`, []string{}),
+			createAlert(t, int64(1), int64(1), int64(2), `alert1 test`, []string{}),
+		}
+		setupLegacyAlertsTables(t, x, nil, alerts)
+		runDashAlertMigrationTestRun(t, x)
+
+		rules := getAlertRules(t, x, int64(1))
+		require.Len(t, rules, 2)
+		require.NotEqual(t, rules[0].RuleGroup, rules[1].RuleGroup)
+	})
 }
 
 const (

--- a/pkg/services/sqlstore/migrations/ualert/migration_test.go
+++ b/pkg/services/sqlstore/migrations/ualert/migration_test.go
@@ -576,6 +576,7 @@ func TestDashAlertMigration(t *testing.T) {
 	})
 
 	t.Run("when folder is missing put alert in General folder", func(t *testing.T) {
+		defer teardown(t, x)
 		o := createOrg(t, 1)
 		folder1 := createDashboard(t, 1, o.ID, "folder-1")
 		folder1.IsFolder = true
@@ -809,7 +810,7 @@ func setupLegacyAlertsTables(t *testing.T, x *xorm.Engine, legacyChannels []*mod
 	folder := createDashboard(t, 5, 1, "folder1-1")
 	folder.IsFolder = true
 	dashboard3_1 := createDashboard(t, 6, 1, "dash3-1")
-	dashboard3_1.FolderID = 5
+	dashboard3_1.FolderID = folder.ID
 
 	dashboards = append(dashboards, *folder, *dashboard3_1)
 

--- a/pkg/services/sqlstore/migrations/ualert/testing.go
+++ b/pkg/services/sqlstore/migrations/ualert/testing.go
@@ -3,9 +3,10 @@ package ualert
 import (
 	"testing"
 
+	"github.com/prometheus/alertmanager/silence/silencepb"
+
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
-	"github.com/prometheus/alertmanager/silence/silencepb"
 )
 
 // newTestMigration generates an empty migration to use in tests.
@@ -21,5 +22,7 @@ func newTestMigration(t *testing.T) *migration {
 			set: make(map[string]struct{}),
 		},
 		silences: make(map[int64][]*silencepb.MeshSilence),
+
+		groupNameReplacer: groupNameReplacer(),
 	}
 }

--- a/pkg/services/sqlstore/migrations/ualert/ualert.go
+++ b/pkg/services/sqlstore/migrations/ualert/ualert.go
@@ -431,12 +431,17 @@ func (m *migration) ensureUniqueGroup(rulesPerOrg map[int64]map[*alertRule][]uid
 	// rule group can be normalized and therefore there is a chance that it can be not unique. Also,  rules in a group must have the same evaluation interval.
 	// Therefore, to enforce the rule that each alert rule is migrated to its own group, make sure that all groups are unique
 	for _, rules := range rulesPerOrg {
-		groupNames := make(map[string]struct{}, len(rules))
+		folderByGroupName := make(map[string]map[string]struct{}, len(rules))
 		for rule := range rules {
-			if _, ok := groupNames[rule.RuleGroup]; ok {
+			folderGroups, ok := folderByGroupName[rule.NamespaceUID]
+			if !ok {
+				folderGroups = make(map[string]struct{})
+				folderByGroupName[rule.NamespaceUID] = folderGroups
+			}
+			if _, ok = folderGroups[rule.RuleGroup]; ok {
 				rule.RuleGroup = addSuffixToName(rule.RuleGroup, rule.UID)
 			}
-			groupNames[rule.RuleGroup] = struct{}{}
+			folderGroups[rule.RuleGroup] = struct{}{}
 		}
 	}
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
When Grafana migrates rules from legacy alerting it creates a new rule with title and group name taken from the legacy alert title. There are no restrictions on the rule title in the legacy alerting but there are constraints for the rule group in the new alerting: the name cannot contain forward or backward slashes 
![image](https://user-images.githubusercontent.com/25988953/228980061-0e8dd620-b1b6-47dc-9e3f-ca70170d1bed.png)

This PR fixes migration to normalize group name and replaces slashes with `_`.
This can cause another problem - two rules with names like `rule1 // test` and `rule1 /\ test` will end up in the same group `rule1 __ test` and if rules have different evaluation intervals, the evaluation interval of one rule will override another. Also, it brakes the contract that during migration a rule is placed in its own group.

To make sure that all groups are unique, this PR updates migration to check all rules in the organization for the uniqueness of the group. If group name is not unique, it is modified by appending rule UID at the end of the name (if the concatenated string is longer than the maximum limit of 190 symbols, the group name gets truncated to fit the full UID).

Related: https://github.com/grafana/grafana/issues/55670#issuecomment-1271457001

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
- [x] There are no known compatibility issues with older supported versions of Grafana, or plugins.
- [x] It passes the [Hosted Grafana feature readiness review](https://docs.google.com/document/d/1QL9Ly8KnXzpb6ISbg49pTODRO5mhA5tkkfIZVX6pqQU/edit) for observability, scalability, performance, and security.