### PR TITLE
Docs: Add transformations doc link for What's New v9.2

### DIFF
--- a/docs/sources/whatsnew/whats-new-in-v9-2.md
+++ b/docs/sources/whatsnew/whats-new-in-v9-2.md
@@ -140,8 +140,8 @@ For details on using this functionality, see [GitHub pull request #55313](https:
 
 ## Transformations: INNER JOINs
 
-Transformations allow you to shape raw data from data sources, like metrics series or GitHub issues, into a format that's appropriate for the chosen visualization.
-We have extended the Join transformation to support INNER JOINs in addition to OUTER JOINs. These work similarly to SQL JOINs.
+[Transformations](https://grafana.com/docs/grafana/latest/panels-visualizations/query-transform-data/transform-data/) allow you to shape raw data from data sources, like metrics series or GitHub issues, into a format that's appropriate for the chosen visualization.
+We have extended the [Join transformation](https://grafana.com/docs/grafana/latest/panels-visualizations/query-transform-data/transform-data/#join-by-field) to support INNER JOINs in addition to OUTER JOINs. These work similarly to SQL JOINs.
 
 {{< figure src="/static/img/docs/transformations/transform-outer-join-9-2.png" max-width="750px" caption="Query builder groupings for Google Cloud monitoring" >}}
 

--- a/docs/sources/whatsnew/whats-new-in-v9-2.md
+++ b/docs/sources/whatsnew/whats-new-in-v9-2.md
@@ -140,8 +140,8 @@ For details on using this functionality, see [GitHub pull request #55313](https:
 
 ## Transformations: INNER JOINs
 
-[Transformations](https://grafana.com/docs/grafana/latest/panels-visualizations/query-transform-data/transform-data/) allow you to shape raw data from data sources, like metrics series or GitHub issues, into a format that's appropriate for the chosen visualization.
-We have extended the [Join transformation](https://grafana.com/docs/grafana/latest/panels-visualizations/query-transform-data/transform-data/#join-by-field) to support INNER JOINs in addition to OUTER JOINs. These work similarly to SQL JOINs.
+[Transformations]({{< relref "../panels-visualizations/query-transform-data/transform-data/" >}}) allow you to shape raw data from data sources, like metrics series or GitHub issues, into a format that's appropriate for the chosen visualization.
+We have extended the [Join transformation]({{< relref "../panels-visualizations/query-transform-data/transform-data/#join-by-field" >}}) to support INNER JOINs in addition to OUTER JOINs. These work similarly to SQL JOINs.
 
 {{< figure src="/static/img/docs/transformations/transform-outer-join-9-2.png" max-width="750px" caption="Query builder groupings for Google Cloud monitoring" >}}
 


### PR DESCRIPTION
Add transformations doc link to `Transformations: INNER JOINs` section.

Related issue I've uncovered with the fragment URLs for this page: https://github.com/grafana/grafana/issues/65671
