### PR TITLE
New Panel Header: Fix when clicking submenu item the parent menu item onClick get's triggered 

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -2658,7 +2658,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "12"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "13"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "14"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "15"]
+      [0, 0, 0, "Do not use any type assertions.", "15"]
     ],
     "public/app/features/dashboard/utils/panelMerge.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],

--- a/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeaderMenuItem.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeaderMenuItem.tsx
@@ -25,7 +25,7 @@ export const PanelHeaderMenuItem = (props: Props & PanelMenuItem) => {
       ref={setRef}
       data-testid={selectors.components.Panels.Panel.menuItems(props.text)}
     >
-      <a onClick={props.onClick} href={props.href}>
+      <a onClick={props.onClick} href={props.href} role="menuitem">
         {icon && <Icon name={icon} className={styles.menuIconClassName} />}
         <span className="dropdown-item-text" aria-label={selectors.components.Panels.Panel.headerItems(props.text)}>
           {props.text}

--- a/public/app/features/dashboard/utils/getPanelMenu.ts
+++ b/public/app/features/dashboard/utils/getPanelMenu.ts
@@ -180,7 +180,12 @@ export function getPanelMenu(
     type: 'submenu',
     text: t('panel.header-menu.inspect', `Inspect`),
     iconClassName: 'info-circle',
-    onClick: (e: React.MouseEvent<any>) => onInspectPanel(),
+    onClick: (e: React.MouseEvent<any>) => {
+      // Only calls function if click is not on a submenu item (i.e Panel JSON)
+      if (e.target === e.currentTarget) {
+        onInspectPanel();
+      }
+    },
     shortcut: 'i',
     subMenu: inspectMenu,
   });

--- a/public/app/features/dashboard/utils/getPanelMenu.ts
+++ b/public/app/features/dashboard/utils/getPanelMenu.ts
@@ -180,9 +180,12 @@ export function getPanelMenu(
     type: 'submenu',
     text: t('panel.header-menu.inspect', `Inspect`),
     iconClassName: 'info-circle',
-    onClick: (e: React.MouseEvent<any>) => {
-      // Only calls function if click is not on a submenu item (i.e Panel JSON)
-      if (e.target === e.currentTarget) {
+    onClick: (e: React.MouseEvent<HTMLElement>) => {
+      const currentTarget = e.currentTarget;
+      const target = e.target as HTMLElement;
+      const closestMenuItem = target.closest('[role="menuitem"]');
+
+      if (target === currentTarget || closestMenuItem === currentTarget) {
         onInspectPanel();
       }
     },


### PR DESCRIPTION


<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Add a condition to skip calling `onInspectPanel` if the click is coming from one of the submenus

**Why do we need this feature?**

Because clicking ` Panel menu / Inspect / JSON ` does not work

**Who is this feature for?**

everyone that is using new panel header

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #65590

**Special notes for your reviewer:**

While debugging this problem, I observed that the issue is not present in the old menu because we used different components. For the new panel header, we used the `Menu` component from Grafana UI library, which does not prevent event propagation when clicking on any child elements. As changing this behavior could potentially break existing functionality, I opted to add a fix by modifying the `onClick` function for the `Inspect` option.

Please check that:
- [ ] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
- [x] There are no known compatibility issues with older supported versions of Grafana, or plugins.
- [ ] It passes the [Hosted Grafana feature readiness review](https://docs.google.com/document/d/1QL9Ly8KnXzpb6ISbg49pTODRO5mhA5tkkfIZVX6pqQU/edit) for observability, scalability, performance, and security.