### PR TITLE
Docs: Deprecate dashboard previews

### DIFF
--- a/docs/sources/search/dashboard-previews/index.md
+++ b/docs/sources/search/dashboard-previews/index.md
@@ -17,7 +17,7 @@ weight: 9
 
 Dashboard previews provide an overview of all available dashboards. They help you quickly find the right dashboard when the dashboard names aren't enough on their own.
 
-> **Warning:** The Dashboard previews feature is deprecated and will be removed in Grafana v10
+> **Warning:** The dashboard previews feature is deprecated and will be removed in Grafana v10.
 
 The dashboard previews feature is an opt-in feature that is disabled by default. You can view dashboard previews after an administrator enables the feature, and after you select the new grid layout. The feature-enablement procedure is outlined in the following section.
 

--- a/docs/sources/search/dashboard-previews/index.md
+++ b/docs/sources/search/dashboard-previews/index.md
@@ -17,7 +17,7 @@ weight: 9
 
 Dashboard previews provide an overview of all available dashboards. They help you quickly find the right dashboard when the dashboard names aren't enough on their own.
 
-> **Note:** Dashboard previews are available in Grafana 9.0+ as an opt-in beta feature. Data source permissions are not yet taken into the account when displaying the dashboard previews - refer to the [permissions]({{< relref "#preview-visibility">}}) to learn more before enabling the feature.
+> **Warning:** The Dashboard previews feature is deprecated and will be removed in Grafana v10
 
 The dashboard previews feature is an opt-in feature that is disabled by default. You can view dashboard previews after an administrator enables the feature, and after you select the new grid layout. The feature-enablement procedure is outlined in the following section.
 


### PR DESCRIPTION
Part of https://github.com/grafana/grafana/issues/65693, add deprecation notice to docs for v9.5