### PR TITLE
AuthToken: client token rotation fix

### DIFF
--- a/pkg/api/user_token.go
+++ b/pkg/api/user_token.go
@@ -86,7 +86,7 @@ func (hs *HTTPServer) RotateUserAuthToken(c *contextmodel.ReqContext) response.R
 		}
 
 		if errors.Is(err, auth.ErrUserTokenNotFound) {
-			return response.ErrOrFallback(http.StatusNotFound, http.StatusText(http.StatusFound), err)
+			return response.ErrOrFallback(http.StatusUnauthorized, http.StatusText(http.StatusUnauthorized), err)
 		}
 
 		return response.ErrOrFallback(http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError), err)

--- a/pkg/api/user_token.go
+++ b/pkg/api/user_token.go
@@ -234,7 +234,7 @@ func (hs *HTTPServer) revokeUserAuthTokenInternal(c *contextmodel.ReqContext, us
 		return response.Error(400, "Cannot revoke active user auth token", nil)
 	}
 
-	err = hs.AuthTokenService.RevokeToken(c.Req.Context(), token, true)
+	err = hs.AuthTokenService.RevokeToken(c.Req.Context(), token, false)
 	if err != nil {
 		if errors.Is(err, auth.ErrUserTokenNotFound) {
 			return response.Error(404, "User auth token not found", err)

--- a/pkg/api/user_token_test.go
+++ b/pkg/api/user_token_test.go
@@ -171,10 +171,10 @@ func TestHTTPServer_RotateUserAuthToken(t *testing.T) {
 			expectedStatus:       http.StatusUnauthorized,
 		},
 		{
-			desc:           "Should return 404 and when token s not found",
+			desc:           "Should return 401 and when token not found",
 			cookie:         &http.Cookie{Name: "grafana_session", Value: "123", Path: "/"},
 			rotatedErr:     auth.ErrUserTokenNotFound,
-			expectedStatus: http.StatusNotFound,
+			expectedStatus: http.StatusUnauthorized,
 		},
 		{
 			desc:           "Should return 200 and but not set new cookie if token was not rotated",

--- a/public/app/core/services/backend_srv.ts
+++ b/public/app/core/services/backend_srv.ts
@@ -450,7 +450,7 @@ export class BackendSrv implements BackendService {
   }
 
   rotateToken() {
-    return this.request({ url: '/api/user/auth-tokens/rotate', method: 'POST' });
+    return this.request({ url: '/api/user/auth-tokens/rotate', method: 'POST', retry: 1 });
   }
 
   loginPing() {


### PR DESCRIPTION
**What is this feature?**
Fix the retry behaviour when using client side token rotation. We need to configure the token rotation request with retry: 1 so we don't retry a failed token rotation request.

Also revert the change to soft revoke a token, that resulted in a confusing error.


Fixes #

**Special notes for your reviewer:**
