### PR TITLE
Supplementary Query Error: Align buttons to the right / Update timeout message

### DIFF
--- a/public/app/features/explore/LogsVolumePanelList.test.tsx
+++ b/public/app/features/explore/LogsVolumePanelList.test.tsx
@@ -63,7 +63,7 @@ describe('LogsVolumePanelList', () => {
       },
       onLoadCallback
     );
-    expect(screen.getByText('The logs volume query is taking too long and has timed out')).toBeInTheDocument();
+    expect(screen.getByText('The logs volume query has timed out')).toBeInTheDocument();
     await userEvent.click(screen.getByRole('button', { name: 'Retry' }));
     expect(onLoadCallback).toHaveBeenCalled();
   });

--- a/public/app/features/explore/LogsVolumePanelList.tsx
+++ b/public/app/features/explore/LogsVolumePanelList.tsx
@@ -62,7 +62,7 @@ export const LogsVolumePanelList = ({
     return !isLogsVolumeLimited(data) && zoomRatio && zoomRatio < 1;
   });
 
-  const timeoutError = isTimeoutErrorResponse(logsVolumeData) || true;
+  const timeoutError = isTimeoutErrorResponse(logsVolumeData);
 
   if (logsVolumeData?.state === LoadingState.Loading) {
     return <span>Loading...</span>;

--- a/public/app/features/explore/LogsVolumePanelList.tsx
+++ b/public/app/features/explore/LogsVolumePanelList.tsx
@@ -62,14 +62,14 @@ export const LogsVolumePanelList = ({
     return !isLogsVolumeLimited(data) && zoomRatio && zoomRatio < 1;
   });
 
-  const timeoutError = isTimeoutErrorResponse(logsVolumeData);
+  const timeoutError = isTimeoutErrorResponse(logsVolumeData) || true;
 
   if (logsVolumeData?.state === LoadingState.Loading) {
     return <span>Loading...</span>;
   } else if (timeoutError) {
     return (
       <SupplementaryResultError
-        title="The logs volume query is taking too long and has timed out"
+        title="The logs volume query has timed out"
         // Using info to avoid users thinking that the actual query has failed.
         severity="info"
         suggestedAction="Retry"

--- a/public/app/features/explore/SupplementaryResultError.tsx
+++ b/public/app/features/explore/SupplementaryResultError.tsx
@@ -1,7 +1,8 @@
+import { css } from '@emotion/css';
 import React, { useState } from 'react';
 
-import { DataQueryError } from '@grafana/data';
-import { Alert, AlertVariant, Button } from '@grafana/ui';
+import { DataQueryError, GrafanaTheme2 } from '@grafana/data';
+import { Alert, AlertVariant, Button, useTheme2 } from '@grafana/ui';
 
 type Props = {
   error?: DataQueryError;
@@ -19,27 +20,52 @@ export function SupplementaryResultError(props: Props) {
   // /public/app/features/explore/ErrorContainer.tsx
   const message = error?.message || error?.data?.message || '';
   const showButton = !isOpen && message.length > SHORT_ERROR_MESSAGE_LIMIT;
+  const theme = useTheme2();
+  const styles = getStyles(theme);
 
   return (
-    <Alert title={title} severity={severity} onRemove={onRemove}>
-      {showButton ? (
-        <Button
-          variant="secondary"
-          size="xs"
-          onClick={() => {
-            setIsOpen(true);
-          }}
-        >
-          Show details
-        </Button>
-      ) : (
-        message
-      )}
-      {suggestedAction && onSuggestedAction && (
-        <Button variant="primary" size="xs" onClick={onSuggestedAction}>
-          {suggestedAction}
-        </Button>
-      )}
-    </Alert>
+    <div className={styles.supplementaryErrorContainer}>
+      <Alert title={title} severity={severity} onRemove={onRemove}>
+        <div className={styles.suggestedActionWrapper}>
+          {showButton ? (
+            <Button
+              variant="secondary"
+              size="xs"
+              onClick={() => {
+                setIsOpen(true);
+              }}
+            >
+              Show details
+            </Button>
+          ) : (
+            message
+          )}
+          {suggestedAction && onSuggestedAction && (
+            <div className={styles.suggestedActionWrapper}>
+              <Button variant="primary" size="xs" onClick={onSuggestedAction}>
+                {suggestedAction}
+              </Button>
+            </div>
+          )}
+        </div>
+      </Alert>
+    </div>
   );
 }
+
+const getStyles = (theme: GrafanaTheme2) => {
+  return {
+    supplementaryErrorContainer: css`
+      width: 50%;
+      margin: 0 auto;
+    `,
+    suggestedActionWrapper: css`
+      height: ${theme.spacing(6)};
+      button {
+        position: absolute;
+        right: ${theme.spacing(2)};
+        top: ${theme.spacing(7)};
+      }
+    `,
+  };
+};

--- a/public/app/features/explore/SupplementaryResultError.tsx
+++ b/public/app/features/explore/SupplementaryResultError.tsx
@@ -57,6 +57,7 @@ const getStyles = (theme: GrafanaTheme2) => {
   return {
     supplementaryErrorContainer: css`
       width: 50%;
+      min-width: ${theme.breakpoints.values.sm}px;
       margin: 0 auto;
     `,
     suggestedActionWrapper: css`


### PR DESCRIPTION
As agreed with @radiorental , the request was to:

- Update the timeout message to this shorter version.
- Align the buttons within the alert to the right.

An additional change included in these changes is to decrease the width of the alert and center it, because otherwise it would have 100% width, looking like:

![100% width](https://user-images.githubusercontent.com/1069378/229184973-5f67a048-3627-440b-9042-5031fb056df9.png)

**Who is this feature for?**

Users who use explore with the logs volume panel open and experience errors and timeouts. The main goal for all these changes has been to do a better job, clearly communicating to the user what failed. It was reported that the warning and the cryptic message was confusing for users, thinking that the actual logs query failed.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/64627

**Special notes for your reviewer:**

How it looks after these changes:

Other errors:

![Alert](https://user-images.githubusercontent.com/1069378/229186004-f7abbc36-6643-4112-b0fc-f82f02492416.png)

Other errors expanded:

![Expanded alert](https://user-images.githubusercontent.com/1069378/229186009-3ad1e984-90f6-433d-846a-7d152a686af9.png)

Timeout in a small screen:

![Small screen](https://user-images.githubusercontent.com/1069378/229186010-39016eb6-b504-4ba6-8c1e-8a2a5290094b.png)

Timeout in a bigger screen:

![Bigger screen](https://user-images.githubusercontent.com/1069378/229186013-d2867a36-e7d8-4216-91b5-1b62c15a9a8e.png)

** How to test **
Tthe easiest way is to harcode a true here:

https://github.com/grafana/grafana/blob/dc8827a10df28bc647cae0328b50707197c8edd5/public/app/features/explore/LogsVolumePanelList.tsx#L65

```javascript
const timeoutError = isTimeoutErrorResponse(logsVolumeData) || true;
```

A more real-world scenario would be to have a Loki instance with old data, request logs from a long time interval (last 30 days) and have the logs volume panel timeout on you.
