### PR TITLE
PublicDashboards: fix annotations when Target is nil

### DIFF
--- a/pkg/services/publicdashboards/service/query.go
+++ b/pkg/services/publicdashboards/service/query.go
@@ -46,14 +46,16 @@ func (pd *PublicDashboardServiceImpl) FindAnnotations(ctx context.Context, reqDT
 			OrgID:        dash.OrgID,
 			DashboardID:  dash.ID,
 			DashboardUID: dash.UID,
-			Limit:        anno.Target.Limit,
-			MatchAny:     anno.Target.MatchAny,
 			SignedInUser: anonymousUser,
 		}
 
-		if anno.Target.Type == "tags" {
-			annoQuery.DashboardID = 0
-			annoQuery.Tags = anno.Target.Tags
+		if anno.Target != nil {
+			annoQuery.Limit = anno.Target.Limit
+			annoQuery.MatchAny = anno.Target.MatchAny
+			if anno.Target.Type == "tags" {
+				annoQuery.DashboardID = 0
+				annoQuery.Tags = anno.Target.Tags
+			}
 		}
 
 		annotationItems, err := pd.AnnotationsRepo.Find(ctx, annoQuery)
@@ -82,7 +84,7 @@ func (pd *PublicDashboardServiceImpl) FindAnnotations(ctx context.Context, reqDT
 
 			// We want events from tag queries to overwrite existing events
 			_, has := uniqueEvents[event.Id]
-			if !has || (has && anno.Target.Type == "tags") {
+			if !has || (has && anno.Target != nil && anno.Target.Type == "tags") {
 				uniqueEvents[event.Id] = event
 			}
 		}

--- a/pkg/services/publicdashboards/service/query_test.go
+++ b/pkg/services/publicdashboards/service/query_test.go
@@ -877,7 +877,6 @@ func TestFindAnnotations(t *testing.T) {
 		assert.Len(t, items, 1)
 		assert.Equal(t, expected, items[0])
 	})
-
 }
 
 func TestGetMetricRequest(t *testing.T) {

--- a/pkg/services/publicdashboards/service/query_test.go
+++ b/pkg/services/publicdashboards/service/query_test.go
@@ -493,7 +493,7 @@ func TestGetQueryDataResponse(t *testing.T) {
 	})
 }
 
-func TestGetAnnotations(t *testing.T) {
+func TestFindAnnotations(t *testing.T) {
 	color := "red"
 	name := "annoName"
 	t.Run("will build anonymous user with correct permissions to get annotations", func(t *testing.T) {
@@ -820,6 +820,64 @@ func TestGetAnnotations(t *testing.T) {
 		require.Error(t, err)
 		require.Nil(t, items)
 	})
+
+	t.Run("Test find annotations does not panics when Target in datasource is nil", func(t *testing.T) {
+		dash := dashboards.NewDashboard("test")
+		grafanaAnnotation := DashAnnotation{
+			Datasource: CreateDatasource("grafana", "grafana"),
+			Enable:     true,
+			Name:       &name,
+			IconColor:  &color,
+			Type:       "dashboard",
+			Target:     nil,
+		}
+
+		annos := []DashAnnotation{grafanaAnnotation}
+		dashboard := AddAnnotationsToDashboard(t, dash, annos)
+
+		annotationsRepo := annotations.FakeAnnotationsRepo{}
+		fakeStore := FakePublicDashboardStore{}
+		service := &PublicDashboardServiceImpl{
+			log:             log.New("test.logger"),
+			store:           &fakeStore,
+			AnnotationsRepo: &annotationsRepo,
+		}
+		pubdash := &PublicDashboard{Uid: "uid1", IsEnabled: true, OrgId: 1, DashboardUid: dashboard.UID, AnnotationsEnabled: true}
+
+		fakeStore.On("FindByAccessToken", mock.Anything, mock.AnythingOfType("string")).Return(pubdash, nil)
+		fakeStore.On("FindDashboard", mock.Anything, mock.Anything, mock.AnythingOfType("string")).Return(dashboard, nil)
+
+		annotationsRepo.On("Find", mock.Anything, mock.Anything).Return([]*annotations.ItemDTO{
+			{
+				ID:          1,
+				DashboardID: 1,
+				PanelID:     1,
+				Tags:        []string{"tag1"},
+				TimeEnd:     2,
+				Time:        2,
+				Text:        "this is an annotation",
+			},
+		}, nil).Maybe()
+
+		items, err := service.FindAnnotations(context.Background(), AnnotationsQueryDTO{}, "abc123")
+
+		expected := AnnotationEvent{
+			Id:          1,
+			DashboardId: 1,
+			PanelId:     1,
+			Tags:        []string{"tag1"},
+			IsRegion:    false,
+			Text:        "this is an annotation",
+			Color:       color,
+			Time:        2,
+			TimeEnd:     2,
+			Source:      grafanaAnnotation,
+		}
+		require.NoError(t, err)
+		assert.Len(t, items, 1)
+		assert.Equal(t, expected, items[0])
+	})
+
 }
 
 func TestGetMetricRequest(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Target in data sources could be empty now when the value is the default. Adding a check in the public dashboards backend to not use `target` data if it is nil.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->
Fixes https://github.com/grafana/grafana/issues/65655

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
- [ ] There are no known compatibility issues with older supported versions of Grafana, or plugins.
- [ ] It passes the [Hosted Grafana feature readiness review](https://docs.google.com/document/d/1QL9Ly8KnXzpb6ISbg49pTODRO5mhA5tkkfIZVX6pqQU/edit) for observability, scalability, performance, and security.