### PR TITLE
Alerting: Document state history config options in default and sample configuration files

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1010,8 +1010,8 @@ disabled_labels =
 # Enable the state history functionality in Unified Alerting. The previous states of alert rules will be visible in panels and in the UI.
 enabled = true
 
-# Choose which pluggable state history backend to use. Either "annotations", "loki", or "multiple"
-# "loki" will write state history to an external Loki instance. "multiple" allows history to be written to mulitple backends at once.
+# Select which pluggable state history backend to use. Either "annotations", "loki", or "multiple"
+# "loki" writes state history to an external Loki instance. "multiple" allows history to be written to multiple backends at once.
 # Defaults to "annotations".
 backend =
 

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1010,6 +1010,54 @@ disabled_labels =
 # Enable the state history functionality in Unified Alerting. The previous states of alert rules will be visible in panels and in the UI.
 enabled = true
 
+# Choose which pluggable state history backend to use. Either "annotations", "loki", or "multiple"
+# "loki" will write state history to an external Loki instance. "multiple" allows history to be written to mulitple backends at once.
+# Defaults to "annotations".
+backend =
+
+# For "multiple" only.
+# Indicates the main backend used to serve state history queries.
+# Either "annotations" or "loki"
+primary =
+
+# For "multiple" only.
+# Comma-separated list of additional backends to write state history data to.
+secondaries =
+
+# For "loki" only.
+# URL of the external Loki instance.
+# Either "loki_remote_url", or both of "loki_remote_read_url" and "loki_remote_write_url" is required for the "loki" backend.
+loki_remote_url =
+
+# For "loki" only.
+# URL of the external Loki's read path. To be used in configurations where Loki has separated read and write URLs.
+# Either "loki_remote_url", or both of "loki_remote_read_url" and "loki_remote_write_url" is required for the "loki" backend.
+loki_remote_read_url =
+
+# For "loki" only.
+# URL of the external Loki's write path. To be used in configurations where Loki has separated read and write URLs.
+# Either "loki_remote_url", or both of "loki_remote_read_url" and "loki_remote_write_url" is required for the "loki" backend.
+loki_remote_write_url =
+
+# For "loki" only.
+# Optional tenant ID to attach to requests sent to Loki.
+loki_tenant_id =
+
+# For "loki" only.
+# Optional username for basic authentication on requests sent to Loki. Can be left blank to disable basic auth.
+loki_basic_auth_username =
+
+# For "loki" only.
+# Optional password for basic authentication on requests sent to Loki. Can be left blank.
+loki_basic_auth_password =
+
+[unified_alerting.state_history.external_labels]
+# Optional extra labels to attach to outbound state history records or log streams.
+# Any number of label key-value-pairs can be provided.
+#
+# ex.
+# mylabelkey = mylabelvalue
+
 #################################### Alerting ############################
 [alerting]
 # Enable the legacy alerting sub-system and interface. If Unified Alerting is already enabled and you try to go back to legacy alerting, all data that is part of Unified Alerting will be deleted. When this configuration section and flag are not defined, the state is defined at runtime. See the documentation for more details.

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -971,8 +971,8 @@
 # Enable the state history functionality in Unified Alerting. The previous states of alert rules will be visible in panels and in the UI.
 ; enabled = true
 
-# Choose which pluggable state history backend to use. Either "annotations", "loki", or "multiple"
-# "loki" will write state history to an external Loki instance. "multiple" allows history to be written to mulitple backends at once.
+# Select which pluggable state history backend to use. Either "annotations", "loki", or "multiple"
+# "loki" writes state history to an external Loki instance. "multiple" allows history to be written to multiple backends at once.
 # Defaults to "annotations".
 ; backend = "multiple"
 

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -967,6 +967,56 @@
 # For example: `disabled_labels=grafana_folder`
 ;disabled_labels =
 
+[unified_alerting.state_history]
+# Enable the state history functionality in Unified Alerting. The previous states of alert rules will be visible in panels and in the UI.
+; enabled = true
+
+# Choose which pluggable state history backend to use. Either "annotations", "loki", or "multiple"
+# "loki" will write state history to an external Loki instance. "multiple" allows history to be written to mulitple backends at once.
+# Defaults to "annotations".
+; backend = "multiple"
+
+# For "multiple" only.
+# Indicates the main backend used to serve state history queries.
+# Either "annotations" or "loki"
+; primary = "loki"
+
+# For "multiple" only.
+# Comma-separated list of additional backends to write state history data to.
+; secondaries = "annotations"
+
+# For "loki" only.
+# URL of the external Loki instance.
+# Either "loki_remote_url", or both of "loki_remote_read_url" and "loki_remote_write_url" is required for the "loki" backend.
+; loki_remote_url = "http://loki:3100"
+
+# For "loki" only.
+# URL of the external Loki's read path. To be used in configurations where Loki has separated read and write URLs.
+# Either "loki_remote_url", or both of "loki_remote_read_url" and "loki_remote_write_url" is required for the "loki" backend.
+; loki_remote_read_url = "http://loki-querier:3100"
+
+# For "loki" only.
+# URL of the external Loki's write path. To be used in configurations where Loki has separated read and write URLs.
+# Either "loki_remote_url", or both of "loki_remote_read_url" and "loki_remote_write_url" is required for the "loki" backend.
+; loki_remote_write_url = "http://loki-distributor:3100"
+
+# For "loki" only.
+# Optional tenant ID to attach to requests sent to Loki.
+; loki_tenant_id = 123
+
+# For "loki" only.
+# Optional username for basic authentication on requests sent to Loki. Can be left blank to disable basic auth.
+; loki_basic_auth_username = "myuser"
+
+# For "loki" only.
+# Optional password for basic authentication on requests sent to Loki. Can be left blank.
+; loki_basic_auth_password = "mypass"
+
+[unified_alerting.state_history.external_labels]
+# Optional extra labels to attach to outbound state history records or log streams.
+# Any number of label key-value-pairs can be provided.
+; mylabelkey = mylabelvalue
+
 #################################### Alerting ############################
 [alerting]
 # Disable legacy alerting engine & UI features


### PR DESCRIPTION
**What is this feature?**

Initially, we used lack of documentation of these options as a pseudo-feature-flag.

We recently added proper feature toggles for alert state history. With that in place, we can now document the configuration options.

**Who is this feature for?**

Administrators, operators, developers

**Which issue(s) does this PR fix?**:

n/a

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
- [x] There are no known compatibility issues with older supported versions of Grafana, or plugins.
- [x] It passes the [Hosted Grafana feature readiness review](https://docs.google.com/document/d/1QL9Ly8KnXzpb6ISbg49pTODRO5mhA5tkkfIZVX6pqQU/edit) for observability, scalability, performance, and security.