### PR TITLE
PanelChrome: Add option to show actions on the right side (actions = leftItems)

### DIFF
--- a/packages/grafana-ui/src/components/Forms/commonStyles.ts
+++ b/packages/grafana-ui/src/components/Forms/commonStyles.ts
@@ -115,7 +115,6 @@ export function getPropertiesForButtonSize(size: ComponentSize, theme: GrafanaTh
         padding: 1,
         fontSize: theme.typography.size.sm,
         height: theme.components.height.sm,
-        lineHeight: theme.typography.bodySmall.lineHeight,
       };
 
     case 'lg':

--- a/packages/grafana-ui/src/components/Forms/commonStyles.ts
+++ b/packages/grafana-ui/src/components/Forms/commonStyles.ts
@@ -115,6 +115,7 @@ export function getPropertiesForButtonSize(size: ComponentSize, theme: GrafanaTh
         padding: 1,
         fontSize: theme.typography.size.sm,
         height: theme.components.height.sm,
+        lineHeight: theme.typography.bodySmall.lineHeight,
       };
 
     case 'lg':

--- a/packages/grafana-ui/src/components/PanelChrome/HoverWidget.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/HoverWidget.tsx
@@ -10,7 +10,7 @@ import { PanelMenu } from './PanelMenu';
 
 interface Props {
   children?: React.ReactNode;
-  menu: ReactElement | (() => ReactElement);
+  menu?: ReactElement | (() => ReactElement);
   title?: string;
   offset?: number;
   dragClass?: string;
@@ -51,7 +51,7 @@ export function HoverWidget({ menu, title, dragClass, children, offset = -32 }: 
       </div>
       {!title && <h6 className={cx(styles.untitled, styles.draggable, dragClass)}>Untitled</h6>}
       {children}
-      <div className={styles.square}>
+      {menu && (
         <PanelMenu
           menu={menu}
           title={title}
@@ -59,7 +59,7 @@ export function HoverWidget({ menu, title, dragClass, children, offset = -32 }: 
           menuButtonClass={styles.menuButton}
           onVisibleChange={setMenuOpen}
         />
-      </div>
+      )}
     </div>
   );
 }
@@ -92,7 +92,6 @@ function getStyles(theme: GrafanaTheme2) {
       alignItems: 'center',
       width: theme.spacing(4),
       height: '100%',
-      paddingRight: theme.spacing(0.5),
     }),
     draggable: css({
       cursor: 'move',
@@ -109,12 +108,10 @@ function getStyles(theme: GrafanaTheme2) {
         background: theme.colors.secondary.main,
       },
     }),
-    title: css({
-      padding: theme.spacing(0.75),
-    }),
     untitled: css({
       color: theme.colors.text.disabled,
       fontStyle: 'italic',
+      padding: theme.spacing(0, 1),
       marginBottom: 0,
     }),
     draggableIcon: css({

--- a/packages/grafana-ui/src/components/PanelChrome/HoverWidget.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/HoverWidget.tsx
@@ -41,14 +41,16 @@ export function HoverWidget({ menu, title, dragClass, children, offset = -32 }: 
       style={{ top: `${offset}px` }}
       data-testid="hover-header-container"
     >
-      <div
-        className={cx(styles.square, styles.draggable, dragClass)}
-        onPointerDown={onPointerDown}
-        onPointerUp={onPointerUp}
-        ref={draggableRef}
-      >
-        <Icon name="expand-arrows" className={styles.draggableIcon} />
-      </div>
+      {dragClass && (
+        <div
+          className={cx(styles.square, styles.draggable, dragClass)}
+          onPointerDown={onPointerDown}
+          onPointerUp={onPointerUp}
+          ref={draggableRef}
+        >
+          <Icon name="expand-arrows" className={styles.draggableIcon} />
+        </div>
+      )}
       {!title && <h6 className={cx(styles.untitled, styles.draggable, dragClass)}>Untitled</h6>}
       {children}
       {menu && (

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.mdx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.mdx
@@ -56,7 +56,7 @@ Component used for rendering content wrapped in the same style as grafana panels
           style={{
             width: innerwidth,
             height: innerheight,
-            background: 'gray',
+            background: 'rgba(230,0,0,0.05)',
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',
@@ -133,7 +133,7 @@ Component used for rendering content wrapped in the same style as grafana panels
           style={{
             width: innerwidth,
             height: innerheight,
-            background: 'gray',
+            background: 'rgba(230,0,0,0.05)',
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',
@@ -170,7 +170,7 @@ Component used for rendering content wrapped in the same style as grafana panels
           style={{
             width: innerwidth,
             height: innerheight,
-            background: 'gray',
+            background: 'rgba(230,0,0,0.05)',
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',
@@ -202,7 +202,7 @@ Component used for rendering content wrapped in the same style as grafana panels
         style={{
           width: innerwidth,
           height: innerheight,
-          background: 'white',
+          background: 'rgba(230,0,0,0.05)',
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
@@ -232,7 +232,7 @@ Component used for rendering content wrapped in the same style as grafana panels
           style={{
             width: innerwidth,
             height: innerheight,
-            background: 'gray',
+            background: 'rgba(230,0,0,0.05)',
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',
@@ -258,7 +258,7 @@ Component used for rendering content wrapped in the same style as grafana panels
           style={{
             width: innerwidth,
             height: innerheight,
-            background: 'gray',
+            background: 'rgba(230,0,0,0.05)',
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',
@@ -285,7 +285,7 @@ Component used for rendering content wrapped in the same style as grafana panels
           style={{
             width: innerwidth,
             height: innerheight,
-            background: 'gray',
+            background: 'rgba(230,0,0,0.05)',
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',
@@ -300,7 +300,7 @@ Component used for rendering content wrapped in the same style as grafana panels
 </HorizontalGroup>
 </Canvas>
 
-### Extra options? Title Items
+### Extra options? Title items and actions
 
 ```tsx
 <PanelChrome
@@ -311,8 +311,12 @@ Component used for rendering content wrapped in the same style as grafana panels
       <Button fill="text" icon="sliders-v-alt" variant="secondary" tooltip="extra content2 to render" />
     </div>
   }
-  description="Here I will put a description that explains a bit more this panel"
-  width={400}
+  actions={
+    <Button size="sm" variant="secondary" key="A">
+      Breakdown
+    </Button>
+  }
+  width={500}
   height={200}
 >
   {(innerwidth, innerheight) => {
@@ -321,7 +325,7 @@ Component used for rendering content wrapped in the same style as grafana panels
         style={{
           width: innerwidth,
           height: innerheight,
-          background: 'white',
+          background: 'rgba(230,0,0,0.05)',
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
@@ -337,14 +341,18 @@ Component used for rendering content wrapped in the same style as grafana panels
 <Canvas>
   <PanelChrome
     title="My awesome panel title"
-    description="Here I will put a description that explains a bit more this panel"
     titleItems={
       <div>
         <Button fill="text" icon="github" variant="secondary" tooltip="extra content to render" />
         <Button fill="text" icon="sliders-v-alt" variant="secondary" tooltip="extra content2 to render" />
       </div>
     }
-    width={400}
+    actions={
+      <Button size="sm" variant="secondary" key="A">
+        Breakdown
+      </Button>
+    }
+    width={500}
     height={200}
   >
     {(innerwidth, innerheight) => {
@@ -353,7 +361,7 @@ Component used for rendering content wrapped in the same style as grafana panels
           style={{
             width: innerwidth,
             height: innerheight,
-            background: 'gray',
+            background: 'rgba(230,0,0,0.05)',
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',
@@ -415,7 +423,7 @@ Component used for rendering content wrapped in the same style as grafana panels
           style={{
             width: innerwidth,
             height: innerheight,
-            background: 'gray',
+            background: 'rgba(230,0,0,0.05)',
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',
@@ -470,7 +478,7 @@ Component used for rendering content wrapped in the same style as grafana panels
           style={{
             width: innerwidth,
             height: innerheight,
-            background: 'gray',
+            background: 'rgba(230,0,0,0.05)',
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.story.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.story.tsx
@@ -249,6 +249,7 @@ export const ExamplesHoverHeader = () => {
             description: 'This is a description',
             menu,
             hoverHeader: true,
+            dragClass: 'draggable',
             titleItems: (
               <PanelChrome.TitleItem title="Online">
                 <Icon name="heart" />
@@ -259,6 +260,7 @@ export const ExamplesHoverHeader = () => {
             title: 'Default title',
             menu,
             hoverHeader: true,
+            dragClass: 'draggable',
             titleItems: [
               <PanelChrome.TitleItem title="Online" key="A">
                 <Icon name="heart" />
@@ -272,8 +274,14 @@ export const ExamplesHoverHeader = () => {
             loadingState: LoadingState.Loading,
             hoverHeader: true,
             title: 'I am a hover header',
+            dragClass: 'draggable',
           })}
           {renderPanel('No title, Hover header', {
+            hoverHeader: true,
+            dragClass: 'draggable',
+          })}
+          {renderPanel('Should not have drag icon', {
+            title: 'No drag icon',
             hoverHeader: true,
           })}
           {renderPanel('With action link', {

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.story.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.story.tsx
@@ -5,7 +5,7 @@ import React, { CSSProperties, useState, ReactNode } from 'react';
 import { useInterval } from 'react-use';
 
 import { LoadingState } from '@grafana/data';
-import { Button, PanelChrome, PanelChromeProps, RadioButtonGroup } from '@grafana/ui';
+import { Button, Icon, PanelChrome, PanelChromeProps, RadioButtonGroup } from '@grafana/ui';
 
 import { DashboardStoryCanvas } from '../../utils/storybook/DashboardStoryCanvas';
 import { withCenteredStory } from '../../utils/storybook/withCenteredStory';
@@ -188,15 +188,15 @@ export const Examples = () => {
             displayMode: 'transparent',
             menu,
           })}
-          {renderPanel('With right side buttons no menu', {
-            title: 'Right side buttons',
+          {renderPanel('Actions with button no menu', {
+            title: 'Actions with button no menu',
             actions: [
               <Button size="sm" variant="secondary" key="A">
                 Breakdown
               </Button>,
             ],
           })}
-          {renderPanel('With right side remove action', {
+          {renderPanel('Action sm button with only icon', {
             title: 'Do not remove me!',
             actions: [<Button size="sm" variant="secondary" key="A" icon="times" />],
           })}
@@ -214,7 +214,16 @@ export const Examples = () => {
               />,
             ],
           })}
-          {renderPanel('Action and menu', {
+          {renderPanel('Panel with action link', {
+            title: 'Panel with link action',
+            actions: [
+              <a className="external-link" key="A" href="/some/page">
+                Error details
+                <Icon name="arrow-right" />
+              </a>,
+            ],
+          })}
+          {renderPanel('Action and menu (should be rare)', {
             title: 'Action and menu',
             menu,
             actions: [

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.story.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.story.tsx
@@ -5,7 +5,7 @@ import React, { CSSProperties, useState, ReactNode } from 'react';
 import { useInterval } from 'react-use';
 
 import { LoadingState } from '@grafana/data';
-import { PanelChrome, PanelChromeProps } from '@grafana/ui';
+import { Button, PanelChrome, PanelChromeProps, RadioButtonGroup } from '@grafana/ui';
 
 import { DashboardStoryCanvas } from '../../utils/storybook/DashboardStoryCanvas';
 import { withCenteredStory } from '../../utils/storybook/withCenteredStory';
@@ -183,22 +183,45 @@ export const Examples = () => {
               />,
             ],
           })}
-          {renderPanel('Deprecated error indicator, menu', {
-            title: 'Default title',
-            menu,
-            leftItems: [
-              <PanelChrome.ErrorIndicator
-                key="errorIndicator"
-                error="Error text"
-                onClick={action('ErrorIndicator: onClick fired')}
-              />,
-            ],
-          })}
           {renderPanel('Display mode = transparent', {
             title: 'Default title',
             displayMode: 'transparent',
             menu,
-            leftItems: [],
+          })}
+          {renderPanel('With right side buttons no menu', {
+            title: 'Right side buttons',
+            actions: [
+              <Button size="sm" variant="secondary" key="A">
+                Breakdown
+              </Button>,
+            ],
+          })}
+          {renderPanel('With right side remove action', {
+            title: 'Do not remove me!',
+            actions: [<Button size="sm" variant="secondary" key="A" icon="times" />],
+          })}
+          {renderPanel('With radio button', {
+            title: 'I have options!',
+            actions: [
+              <RadioButtonGroup
+                key="radio-button-group"
+                size="sm"
+                value="A"
+                options={[
+                  { label: 'Graph', value: 'A' },
+                  { label: 'Table', value: 'B' },
+                ]}
+              />,
+            ],
+          })}
+          {renderPanel('Action and menu', {
+            title: 'Action and menu',
+            menu,
+            actions: [
+              <Button size="sm" variant="secondary" key="A">
+                Breakdown
+              </Button>,
+            ],
           })}
         </HorizontalGroup>
       </div>

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.story.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.story.tsx
@@ -190,18 +190,23 @@ export const Examples = () => {
           })}
           {renderPanel('Actions with button no menu', {
             title: 'Actions with button no menu',
+            actions: (
+              <Button size="sm" variant="secondary" key="A">
+                Breakdown
+              </Button>
+            ),
+          })}
+          {renderPanel('Panel with two actions', {
+            title: 'I have two buttons',
             actions: [
               <Button size="sm" variant="secondary" key="A">
                 Breakdown
               </Button>,
+              <Button size="sm" variant="secondary" icon="times" key="B" />,
             ],
           })}
-          {renderPanel('Action sm button with only icon', {
-            title: 'Do not remove me!',
-            actions: [<Button size="sm" variant="secondary" key="A" icon="times" />],
-          })}
           {renderPanel('With radio button', {
-            title: 'I have options!',
+            title: 'I have a radio button',
             actions: [
               <RadioButtonGroup
                 key="radio-button-group"
@@ -216,21 +221,21 @@ export const Examples = () => {
           })}
           {renderPanel('Panel with action link', {
             title: 'Panel with link action',
-            actions: [
-              <a className="external-link" key="A" href="/some/page">
+            actions: (
+              <a className="external-link" href="/some/page">
                 Error details
                 <Icon name="arrow-right" />
-              </a>,
-            ],
+              </a>
+            ),
           })}
           {renderPanel('Action and menu (should be rare)', {
             title: 'Action and menu',
             menu,
-            actions: [
-              <Button size="sm" variant="secondary" key="A">
+            actions: (
+              <Button size="sm" variant="secondary">
                 Breakdown
-              </Button>,
-            ],
+              </Button>
+            ),
           })}
         </HorizontalGroup>
       </div>

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.story.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.story.tsx
@@ -40,7 +40,7 @@ function getContentStyle(): CSSProperties {
 function renderPanel(name: string, overrides?: Partial<PanelChromeProps>) {
   const props: PanelChromeProps = {
     width: 400,
-    height: 130,
+    height: 150,
     children: () => undefined,
   };
 
@@ -131,10 +131,6 @@ export const Examples = () => {
           {renderPanel('No title, streaming loadingState', {
             loadingState: LoadingState.Streaming,
           })}
-          {renderPanel('No title, loading loadingState', {
-            loadingState: LoadingState.Loading,
-          })}
-
           {renderPanel('Error status, menu', {
             title: 'Default title',
             menu,
@@ -220,7 +216,7 @@ export const Examples = () => {
             ],
           })}
           {renderPanel('Panel with action link', {
-            title: 'Panel with link action',
+            title: 'Panel with action link',
             actions: (
               <a className="external-link" href="/some/page">
                 Error details
@@ -235,6 +231,59 @@ export const Examples = () => {
               <Button size="sm" variant="secondary">
                 Breakdown
               </Button>
+            ),
+          })}
+        </HorizontalGroup>
+      </div>
+    </DashboardStoryCanvas>
+  );
+};
+
+export const ExamplesHoverHeader = () => {
+  return (
+    <DashboardStoryCanvas>
+      <div>
+        <HorizontalGroup spacing="md" align="flex-start" wrap>
+          {renderPanel('Title items, menu, hover header', {
+            title: 'Default title',
+            description: 'This is a description',
+            menu,
+            hoverHeader: true,
+            titleItems: (
+              <PanelChrome.TitleItem title="Online">
+                <Icon name="heart" />
+              </PanelChrome.TitleItem>
+            ),
+          })}
+          {renderPanel('Multiple title items', {
+            title: 'Default title',
+            menu,
+            hoverHeader: true,
+            titleItems: [
+              <PanelChrome.TitleItem title="Online" key="A">
+                <Icon name="heart" />
+              </PanelChrome.TitleItem>,
+              <PanelChrome.TitleItem title="Link" key="B" onClick={() => {}}>
+                <Icon name="external-link-alt" />
+              </PanelChrome.TitleItem>,
+            ],
+          })}
+          {renderPanel('Hover header, loading loadingState', {
+            loadingState: LoadingState.Loading,
+            hoverHeader: true,
+            title: 'I am a hover header',
+          })}
+          {renderPanel('No title, Hover header', {
+            hoverHeader: true,
+          })}
+          {renderPanel('With action link', {
+            title: 'With link in hover header',
+            hoverHeader: true,
+            actions: (
+              <a className="external-link" href="/some/page">
+                Error details
+                <Icon name="arrow-right" />
+              </a>
             ),
           })}
         </HorizontalGroup>

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -145,6 +145,9 @@ export function PanelChrome({
           </Tooltip>
         </DelayRender>
       )}
+      <div className={styles.rightAligned}>
+        {actions && <div className={styles.rightActions}>{itemsRenderer(actions, (item) => item)}</div>}
+      </div>
     </>
   );
 
@@ -156,11 +159,10 @@ export function PanelChrome({
 
       {hoverHeader && !isTouchDevice && (
         <>
-          {menu && (
-            <HoverWidget menu={menu} title={title} offset={hoverHeaderOffset} dragClass={dragClass}>
-              {headerContent}
-            </HoverWidget>
-          )}
+          <HoverWidget menu={menu} title={title} offset={hoverHeaderOffset} dragClass={dragClass}>
+            {headerContent}
+          </HoverWidget>
+
           {statusMessage && (
             <div className={styles.errorContainerFloating}>
               <PanelStatus message={statusMessage} onClick={statusMessageOnClick} ariaLabel="Panel status" />
@@ -179,22 +181,19 @@ export function PanelChrome({
 
           {headerContent}
 
-          <div className={styles.rightAligned}>
-            {actions && <div className={styles.rightActions}>{itemsRenderer(actions, (item) => item)}</div>}
-            {menu && (
-              <PanelMenu
-                menu={menu}
-                title={title}
-                placement="bottom-end"
-                menuButtonClass={cx(
-                  { [styles.hiddenMenu]: !isTouchDevice },
-                  styles.menuItem,
-                  dragClassCancel,
-                  showOnHoverClass
-                )}
-              />
-            )}
-          </div>
+          {menu && (
+            <PanelMenu
+              menu={menu}
+              title={title}
+              placement="bottom-end"
+              menuButtonClass={cx(
+                { [styles.hiddenMenu]: !isTouchDevice },
+                styles.menuItem,
+                dragClassCancel,
+                showOnHoverClass
+              )}
+            />
+          )}
         </div>
       )}
 

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -47,13 +47,10 @@ export interface PanelChromeProps {
    */
   statusMessageOnClick?: (e: React.SyntheticEvent) => void;
   /**
-   * @deprecated in favor of props
-   * statusMessage for error messages
-   * and loadingState for loading and streaming data
-   * which will serve the same purpose
-   * of showing/interacting with the panel's state
-   */
+   * @deprecated use `actions' instead
+   **/
   leftItems?: ReactNode[];
+  actions?: ReactNode[];
   displayMode?: 'default' | 'transparent';
   onCancelQuery?: () => void;
 }
@@ -84,6 +81,7 @@ export function PanelChrome({
   statusMessage,
   statusMessageOnClick,
   leftItems,
+  actions,
   onCancelQuery,
 }: PanelChromeProps) {
   const theme = useTheme2();
@@ -109,6 +107,11 @@ export function PanelChrome({
   if (displayMode === 'transparent') {
     containerStyles.backgroundColor = 'transparent';
     containerStyles.border = 'none';
+  }
+
+  /** Old property name now maps to actions */
+  if (leftItems) {
+    actions = leftItems;
   }
 
   const ariaLabel = title ? selectors.components.Panels.Panel.containerByTitle(title) : 'Panel';
@@ -177,6 +180,7 @@ export function PanelChrome({
           {headerContent}
 
           <div className={styles.rightAligned}>
+            {actions && <div className={styles.rightActions}>{itemsRenderer(actions, (item) => item)}</div>}
             {menu && (
               <PanelMenu
                 menu={menu}
@@ -190,8 +194,6 @@ export function PanelChrome({
                 )}
               />
             )}
-
-            {leftItems && <div className={styles.leftItems}>{itemsRenderer(leftItems, (item) => item)}</div>}
           </div>
         </div>
       )}
@@ -339,9 +341,9 @@ const getStyles = (theme: GrafanaTheme2) => {
       top: 0,
       zIndex: theme.zIndex.tooltip,
     }),
-    leftItems: css({
+    rightActions: css({
       display: 'flex',
-      paddingRight: theme.spacing(padding),
+      padding: theme.spacing(0, padding / 2, 0, padding / 2),
     }),
     rightAligned: css({
       label: 'right-aligned-container',

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -50,7 +50,7 @@ export interface PanelChromeProps {
    * @deprecated use `actions' instead
    **/
   leftItems?: ReactNode[];
-  actions?: ReactNode[];
+  actions?: ReactNode;
   displayMode?: 'default' | 'transparent';
   onCancelQuery?: () => void;
 }
@@ -205,7 +205,7 @@ export function PanelChrome({
   );
 }
 
-const itemsRenderer = (items: ReactNode[], renderer: (items: ReactNode[]) => ReactNode): ReactNode => {
+const itemsRenderer = (items: ReactNode[] | ReactNode, renderer: (items: ReactNode[]) => ReactNode): ReactNode => {
   const toRender = React.Children.toArray(items).filter(Boolean);
   return toRender.length > 0 ? renderer(toRender) : null;
 };
@@ -343,7 +343,8 @@ const getStyles = (theme: GrafanaTheme2) => {
     }),
     rightActions: css({
       display: 'flex',
-      padding: theme.spacing(0, padding / 2, 0, padding / 2),
+      padding: theme.spacing(0, padding),
+      gap: theme.spacing(1),
     }),
     rightAligned: css({
       label: 'right-aligned-container',

--- a/packages/grafana-ui/src/components/PanelChrome/PanelDescription.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelDescription.tsx
@@ -31,7 +31,7 @@ export function PanelDescription({ description, className }: Props) {
   return description !== '' ? (
     <Tooltip interactive content={getDescriptionContent}>
       <TitleItem className={cx(className, styles.description)}>
-        <Icon name="info-circle" size="md" title="description" />
+        <Icon name="info-circle" size="md" />
       </TitleItem>
     </Tooltip>
   ) : null;

--- a/packages/grafana-ui/src/utils/storybook/DashboardStoryCanvas.tsx
+++ b/packages/grafana-ui/src/utils/storybook/DashboardStoryCanvas.tsx
@@ -14,6 +14,7 @@ export const DashboardStoryCanvas = ({ children }: Props) => {
     height: 100%;
     padding: 32px;
     background: ${theme.colors.background.canvas};
+    overflow: auto;
   `;
 
   return <div className={style}>{children}</div>;


### PR DESCRIPTION
This is finding a new use for the existing "leftItems" feature (so does not really add anything new, just repurposes it under new name actions). 

* [x] Adds a new actions prop to PanelChrome (practically it's a new name for leftActions, leftActions remain and remain deprecated, but mapped to actions) 
* [x] Moves actions to be to the left of menu (think this looks better, even though it leaves a blank space in the corner). This is not a breaking change for any previous consumer who used leftItems as menu is new in 9.5, so this combination menu + leftItems (ie actions) is new. 
* [x] Changes right side padding of leftItems (now actions) to padding/2 to make it more symmetric (becomes same as top padding) when you place small buttons and radio buttons there. 

Use cases (When used via VizPanel from Scenes)
* To have visible actions (buttons) and links in panel header (I would expect these panel would 90% not have a menu)

![Screenshot from 2023-04-02 19-46-14](https://user-images.githubusercontent.com/10999/229369966-4e2e5e1f-eee7-4d2c-b743-2701434678c4.png)

So I decided to move the menu to the right of actions because I think this looks worse.

![Screenshot from 2023-04-02 18-53-36](https://user-images.githubusercontent.com/10999/229370111-a55c0deb-9e0a-41cb-bff2-c41d7963075c.png)

For consistency, I like that if you have a menu it's always in the corner. I do think this will be a very rare scenario (or a scenario that we never use) 
![Screenshot from 2023-04-02 18-53-23](https://user-images.githubusercontent.com/10999/229370138-a3fb5b2e-bf68-4e2e-bbee-0dfde6cf4fcb.png)
