### PR TITLE
remove incorrect state changes statement

### DIFF
--- a/docs/sources/panels-visualizations/visualizations/alert-list/index.md
+++ b/docs/sources/panels-visualizations/visualizations/alert-list/index.md
@@ -16,7 +16,7 @@ weight: 100
 
 # Alert list
 
-Use Alert list to display your alerts. You can configure the list to show the current state or recent state changes. You can read more about alerts in [Grafana Alerting overview]({{< relref "../../../alerting/" >}}).
+Use Alert list to display your alerts. You can configure the list to show the current state. You can read more about alerts in [Grafana Alerting overview]({{< relref "../../../alerting/" >}}).
 
 {{< figure src="/static/img/docs/alert-list-panel/alert-list-panel.png" max-width="850px" >}}
 


### PR DESCRIPTION
**What is this feature?**

Removed a misleading part of the docs where it said that we could show state changes with the alert panel visualisation