### PR TITLE
CI: Make `init-enterprise` depend on `grabpl`

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2613,6 +2613,7 @@ steps:
   - mv /tmp/grabpl bin/
   depends_on:
   - clone-enterprise
+  - grabpl
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
@@ -2875,6 +2876,12 @@ platform:
 services: []
 steps:
 - commands:
+  - mkdir -p bin
+  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v3.0.30/grabpl
+  - chmod +x bin/grabpl
+  image: byrnedo/alpine-curl:0.1.8
+  name: grabpl
+- commands:
   - git clone "https://$${GITHUB_TOKEN}@github.com/grafana/grafana-enterprise.git"
   - cd grafana-enterprise
   - git checkout ${DRONE_TAG}
@@ -2894,6 +2901,7 @@ steps:
   - mv /tmp/grabpl bin/
   depends_on:
   - clone-enterprise
+  - grabpl
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
@@ -2903,12 +2911,6 @@ steps:
   - echo $DRONE_RUNNER_NAME
   image: alpine:3.17.1
   name: identify-runner
-- commands:
-  - mkdir -p bin
-  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v3.0.30/grabpl
-  - chmod +x bin/grabpl
-  image: byrnedo/alpine-curl:0.1.8
-  name: grabpl
 - commands:
   - yarn install --immutable
   depends_on:
@@ -2985,6 +2987,7 @@ steps:
   - mv /tmp/grabpl bin/
   depends_on:
   - clone-enterprise
+  - grabpl
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
@@ -3180,6 +3183,7 @@ steps:
   - mv /tmp/grabpl bin/
   depends_on:
   - clone-enterprise
+  - grabpl
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
@@ -3430,6 +3434,7 @@ steps:
   - mv /tmp/grabpl bin/
   depends_on:
   - clone-enterprise
+  - grabpl
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
@@ -4452,6 +4457,7 @@ steps:
   - mv /tmp/grabpl bin/
   depends_on:
   - clone-enterprise
+  - grabpl
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
@@ -5105,6 +5111,7 @@ steps:
   - mv /tmp/grabpl bin/
   depends_on:
   - clone-enterprise
+  - grabpl
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
@@ -5377,6 +5384,12 @@ platform:
 services: []
 steps:
 - commands:
+  - mkdir -p bin
+  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v3.0.30/grabpl
+  - chmod +x bin/grabpl
+  image: byrnedo/alpine-curl:0.1.8
+  name: grabpl
+- commands:
   - git clone "https://$${GITHUB_TOKEN}@github.com/grafana/grafana-enterprise.git"
   - cd grafana-enterprise
   - git checkout ${DRONE_BRANCH}
@@ -5395,6 +5408,7 @@ steps:
   - mv /tmp/grabpl bin/
   depends_on:
   - clone-enterprise
+  - grabpl
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
@@ -5404,12 +5418,6 @@ steps:
   - echo $DRONE_RUNNER_NAME
   image: alpine:3.17.1
   name: identify-runner
-- commands:
-  - mkdir -p bin
-  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v3.0.30/grabpl
-  - chmod +x bin/grabpl
-  image: byrnedo/alpine-curl:0.1.8
-  name: grabpl
 - commands:
   - yarn install --immutable
   depends_on:
@@ -5482,6 +5490,7 @@ steps:
   - mv /tmp/grabpl bin/
   depends_on:
   - clone-enterprise
+  - grabpl
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
@@ -5616,6 +5625,7 @@ steps:
   - mv /tmp/grabpl bin/
   depends_on:
   - clone-enterprise
+  - grabpl
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
@@ -5836,6 +5846,7 @@ steps:
   - mv /tmp/grabpl bin/
   depends_on:
   - clone-enterprise
+  - grabpl
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
@@ -6228,6 +6239,7 @@ steps:
   - mv /tmp/grabpl bin/
   depends_on:
   - clone-enterprise
+  - grabpl
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
@@ -6614,6 +6626,6 @@ kind: secret
 name: enterprise2_security_prefix
 ---
 kind: signature
-hmac: 5854eba6447f784a354210984cb34a52f0d04a2df8387d2df1a24731e2838e9d
+hmac: fdd3de326221eb73f644939b750b98b25de8dddbf9b9fc43e7a1db64e9a51088
 
 ...

--- a/scripts/drone/pipelines/test_frontend.star
+++ b/scripts/drone/pipelines/test_frontend.star
@@ -78,10 +78,10 @@ def test_frontend_enterprise(trigger, ver_mode, source, edition = "enterprise"):
     environment = {"EDITION": edition}
     steps = (
         [
+            download_grabpl_step(),
             clone_enterprise_step(source),
             init_enterprise_step(ver_mode),
             identify_runner_step(),
-            download_grabpl_step(),
         ] +
         with_deps([yarn_install_step()], ["init-enterprise"]) +
         [

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -171,6 +171,7 @@ def init_enterprise_step(ver_mode):
         "image": build_image,
         "depends_on": [
             "clone-enterprise",
+            "grabpl",
         ],
         "environment": environment,
         "commands": [


### PR DESCRIPTION
**What is this feature?**

Makes `init-enterprise` depend on `grabpl`. This change is needed since `init-enterprise` depends only on `clone-enterprise` but used `grabpl`. The failure is intermittent, since the case is that `clone-enterprise` runs the at the same time as `grabpl` step does, but most of the times `grabpl` finishes first, and thus `init-enterprise` runs without problems.

There are some cases though (caught from our periodic CI runs) that `grabpl` is delayed to get fetched from GCS and thus `init-enterprise` step fails and breaks the build.
This change should fix that.