### PR TITLE
CI: Exclude cloud related tags from tag events 

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2366,7 +2366,10 @@ trigger:
     exclude:
     - promote
   ref:
-  - refs/tags/v*
+    exclude:
+    - refs/tags/*-cloud*
+    include:
+    - refs/tags/v*
 type: docker
 volumes:
 - host:
@@ -2423,7 +2426,10 @@ trigger:
     exclude:
     - promote
   ref:
-  - refs/tags/v*
+    exclude:
+    - refs/tags/*-cloud*
+    include:
+    - refs/tags/v*
 type: docker
 volumes:
 - host:
@@ -2497,7 +2503,10 @@ trigger:
     exclude:
     - promote
   ref:
-  - refs/tags/v*
+    exclude:
+    - refs/tags/*-cloud*
+    include:
+    - refs/tags/v*
 type: docker
 volumes:
 - host:
@@ -2560,7 +2569,10 @@ trigger:
     exclude:
     - promote
   ref:
-  - refs/tags/v*
+    exclude:
+    - refs/tags/*-cloud*
+    include:
+    - refs/tags/v*
 type: docker
 volumes:
 - host:
@@ -2852,7 +2864,10 @@ trigger:
     exclude:
     - promote
   ref:
-  - refs/tags/v*
+    exclude:
+    - refs/tags/*-cloud*
+    include:
+    - refs/tags/v*
 type: docker
 volumes:
 - host:
@@ -2938,7 +2953,10 @@ trigger:
     exclude:
     - promote
   ref:
-  - refs/tags/v*
+    exclude:
+    - refs/tags/*-cloud*
+    include:
+    - refs/tags/v*
 type: docker
 volumes:
 - host:
@@ -3047,7 +3065,10 @@ trigger:
     exclude:
     - promote
   ref:
-  - refs/tags/v*
+    exclude:
+    - refs/tags/*-cloud*
+    include:
+    - refs/tags/v*
 type: docker
 volumes:
 - host:
@@ -3130,7 +3151,10 @@ trigger:
     exclude:
     - promote
   ref:
-  - refs/tags/v*
+    exclude:
+    - refs/tags/*-cloud*
+    include:
+    - refs/tags/v*
 type: docker
 volumes:
 - host:
@@ -3375,7 +3399,10 @@ trigger:
     exclude:
     - promote
   ref:
-  - refs/tags/v*
+    exclude:
+    - refs/tags/*-cloud*
+    include:
+    - refs/tags/v*
 type: docker
 volumes:
 - host:
@@ -6626,6 +6653,6 @@ kind: secret
 name: enterprise2_security_prefix
 ---
 kind: signature
-hmac: fdd3de326221eb73f644939b750b98b25de8dddbf9b9fc43e7a1db64e9a51088
+hmac: 675c90070f9b68e15f349d079fbafa5288c3e5c30c345a4c9678d69afd1cc5a7
 
 ...

--- a/scripts/drone/events/release.star
+++ b/scripts/drone/events/release.star
@@ -65,12 +65,19 @@ load("scripts/drone/vault.star", "from_secret", "prerelease_bucket")
 
 ver_mode = "release"
 release_trigger = {
-    "event": {"exclude": ["promote"]},
-    "ref": {"include": [
-        "refs/tags/v*",
-    ], "exclude": [
-        "refs/tags/*-cloud*",
-    ]}
+    "event": {
+        "exclude": [
+            "promote",
+        ],
+    },
+    "ref": {
+        "include": [
+            "refs/tags/v*",
+        ],
+        "exclude": [
+            "refs/tags/*-cloud*",
+        ],
+    },
 }
 
 def store_npm_packages_step():

--- a/scripts/drone/events/release.star
+++ b/scripts/drone/events/release.star
@@ -66,9 +66,11 @@ load("scripts/drone/vault.star", "from_secret", "prerelease_bucket")
 ver_mode = "release"
 release_trigger = {
     "event": {"exclude": ["promote"]},
-    "ref": [
+    "ref": {"include": [
         "refs/tags/v*",
-    ],
+    ], "exclude": [
+        "refs/tags/*-cloud*",
+    ]}
 }
 
 def store_npm_packages_step():


### PR DESCRIPTION
**What is this feature?**

This change is to prevent tag events from running, when a `*-cloud*` github tag appears. Every other tag event should run without any problems.