### PR TITLE
Loki docs: Use images instead of text description for operation settings

### DIFF
--- a/docs/sources/datasources/loki/query-editor/index.md
+++ b/docs/sources/datasources/loki/query-editor/index.md
@@ -108,11 +108,11 @@ The query editor groups operations into related sections, and you can type while
 The query editor displays a query's operations as boxes in the operations section.
 Each operation's header displays its name, and additional action buttons appear when you hover your cursor over the header:
 
-| Button | Action                                                            |
-| ------ | ----------------------------------------------------------------- |
-| `v`    | Replaces the operation with different operation of the same type. |
-| `info` | Opens the operation's description tooltip.                        |
-| `x`    | Removes the operation.                                            |
+| Button                                                                                                                  | Action                                                            |
+| ----------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| {{< figure src="/static/img/docs/v95/loki_operation_replace.png" class="docs-image--no-shadow" max-width="30px" >}}     | Replaces the operation with different operation of the same type. |
+| {{< figure src="/static/img/docs/v95/loki_operation_description.png" class="docs-image--no-shadow" max-width="30px" >}} | Opens the operation's description tooltip.                        |
+| {{< figure src="/static/img/docs/v95/loki_operation_remove.png" class="docs-image--no-shadow" max-width="30px" >}}      | Removes the operation.                                            |
 
 Some operations have additional parameters under the operation header.
 For details about each operation, use the `info` button to view the operation's description, or refer to the [Loki documentation](/docs/loki/latest/operations/).


### PR DESCRIPTION
**Which issue(s) does this PR fix?**:
Fixes #65366

**Special notes for your reviewer:**
Before & After:

<div>
<img width="49%" alt="Screenshot 2023-04-03 at 14 59 36" src="https://user-images.githubusercontent.com/34524710/229532467-2a952f33-ff95-4a2b-9ad2-c66ca3337a8c.png">
<img width="49%" alt="Screenshot 2023-04-03 at 14 57 10" src="https://user-images.githubusercontent.com/34524710/229532461-b6b0ac8e-496d-42c2-b685-1ce04b7862ba.png">
</div>

