### PR TITLE
Explore: Run test datasource default selection when mounted

### DIFF
--- a/e2e/various-suite/exemplars.spec.ts
+++ b/e2e/various-suite/exemplars.spec.ts
@@ -32,14 +32,14 @@ describe('Exemplars', () => {
   });
 
   it('should be able to navigate to configured data source', () => {
-    let intercept = 'prometheus';
     e2e().intercept('/api/ds/query', (req) => {
-      if (intercept === 'prometheus') {
-        // For second intercept, we want to send tempo response
-        intercept = 'tempo';
+      const datasourceType = req.body.queries[0].datasource.type;
+      if (datasourceType === 'prometheus') {
         req.reply({ fixture: 'exemplars-query-response.json' });
-      } else {
+      } else if (datasourceType === 'tempo') {
         req.reply({ fixture: 'tempo-response.json' });
+      } else {
+        req.reply({});
       }
     });
 

--- a/e2e/various-suite/explore.spec.ts
+++ b/e2e/various-suite/explore.spec.ts
@@ -11,7 +11,15 @@ e2e.scenario({
     e2e.pages.Explore.General.container().should('have.length', 1);
     e2e.components.RefreshPicker.runButtonV2().should('have.length', 1);
 
+    // delete query history queries that would be unrelated
+    e2e.components.QueryTab.queryHistoryButton().should('be.visible').click();
+    cy.get('button[title="Delete query"]').each((button) => {
+      button.trigger('click');
+    });
+    e2e.components.QueryTab.queryHistoryButton().should('be.visible').click();
+
     e2e.components.DataSource.TestData.QueryTab.scenarioSelectContainer()
+      .scrollIntoView()
       .should('be.visible')
       .within(() => {
         e2e().get('input[id*="test-data-scenario-select-"]').should('be.visible').click();
@@ -46,7 +54,7 @@ e2e.scenario({
 
     // Both queries above should have been run and be shown in the query history
     e2e.components.QueryTab.queryHistoryButton().should('be.visible').click();
-    e2e.components.QueryHistory.queryText().should('have.length', 4).should('contain', 'csv_metric_values');
+    e2e.components.QueryHistory.queryText().should('have.length', 2).should('contain', 'csv_metric_values');
 
     // delete all queries
     cy.get('button[title="Delete query"]').each((button) => {

--- a/e2e/various-suite/explore.spec.ts
+++ b/e2e/various-suite/explore.spec.ts
@@ -46,7 +46,7 @@ e2e.scenario({
 
     // Both queries above should have been run and be shown in the query history
     e2e.components.QueryTab.queryHistoryButton().should('be.visible').click();
-    e2e.components.QueryHistory.queryText().should('have.length', 2).should('contain', 'csv_metric_values');
+    e2e.components.QueryHistory.queryText().should('have.length', 4).should('contain', 'csv_metric_values');
 
     // delete all queries
     cy.get('button[title="Delete query"]').each((button) => {

--- a/public/app/plugins/datasource/grafana/datasource.ts
+++ b/public/app/plugins/datasource/grafana/datasource.ts
@@ -66,6 +66,12 @@ export class GrafanaDatasource extends DataSourceWithBackend<GrafanaQuery> {
     };
   }
 
+  getDefaultQuery(): Partial<GrafanaQuery> {
+    return {
+      queryType: GrafanaQueryType.RandomWalk,
+    };
+  }
+
   query(request: DataQueryRequest<GrafanaQuery>): Observable<DataQueryResponse> {
     const results: Array<Observable<DataQueryResponse>> = [];
     const targets: GrafanaQuery[] = [];

--- a/public/app/plugins/datasource/testdata/QueryEditor.tsx
+++ b/public/app/plugins/datasource/testdata/QueryEditor.tsx
@@ -1,4 +1,4 @@
-import React, { FormEvent, useMemo } from 'react';
+import React, { FormEvent, useEffect, useMemo } from 'react';
 import { useAsync } from 'react-use';
 
 import { QueryEditorProps, SelectableValue } from '@grafana/data';
@@ -62,6 +62,12 @@ export const QueryEditor = ({ query, datasource, onChange, onRunQuery }: Props) 
       ...v,
       hideAliasField: hideAlias.includes(v.id),
     }));
+  }, []);
+
+  // run the query once on mount using default selection
+  useEffect(() => {
+    onUpdate(query);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const onUpdate = (query: TestData) => {

--- a/public/app/plugins/datasource/testdata/QueryEditor.tsx
+++ b/public/app/plugins/datasource/testdata/QueryEditor.tsx
@@ -1,4 +1,4 @@
-import React, { FormEvent, useEffect, useMemo } from 'react';
+import React, { FormEvent, useMemo } from 'react';
 import { useAsync } from 'react-use';
 
 import { QueryEditorProps, SelectableValue } from '@grafana/data';
@@ -62,12 +62,6 @@ export const QueryEditor = ({ query, datasource, onChange, onRunQuery }: Props) 
       ...v,
       hideAliasField: hideAlias.includes(v.id),
     }));
-  }, []);
-
-  // run the query once on mount using default selection
-  useEffect(() => {
-    onUpdate(query);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const onUpdate = (query: TestData) => {

--- a/public/app/plugins/datasource/testdata/datasource.ts
+++ b/public/app/plugins/datasource/testdata/datasource.ts
@@ -37,6 +37,13 @@ export class TestDataDataSource extends DataSourceWithBackend<TestData> {
     this.variables = new TestDataVariableSupport();
   }
 
+  getDefaultQuery(): Partial<TestData> {
+    return {
+      scenarioId: TestDataQueryType.RandomWalk,
+      seriesCount: 1,
+    };
+  }
+
   query(options: DataQueryRequest<TestData>): Observable<DataQueryResponse> {
     const backendQueries: TestData[] = [];
     const streams: Array<Observable<DataQueryResponse>> = [];


### PR DESCRIPTION
**What is this feature?**

When the test datasource is selected, the query editor comes pre-populated with options where it can run without being changed. Because no changes can be made to the form for it to be a valid query, running "Run Queries" without editing anything is seen as an empty query and skipped. This updates the test data query editor on mount so the component picks up the default value.

**Why do we need this feature?**

Because opening the test datasource and finding the run query button to be non-responsive is a bad experience.

**Which issue(s) does this PR fix?**:

Fixes #65426

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
