### PR TITLE
Docker: Allow to get commit sha when using root Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ ARG BINGO="true"
 
 # Install build dependencies
 RUN if grep -i -q alpine /etc/issue; then \
-      apk add --no-cache gcc g++ make; \
+      apk add --no-cache gcc g++ make git; \
     fi
 
 WORKDIR /tmp/grafana
@@ -62,6 +62,7 @@ COPY pkg pkg
 COPY scripts scripts
 COPY conf conf
 COPY .github .github
+COPY .git .git
 
 RUN make build-go GO_BUILD_TAGS=${GO_BUILD_TAGS} WIRE_TAGS=${WIRE_TAGS}
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This feature fixes an issue with images generated with `make docker-build-full` not displaying the correct sha on Grafana.

**Why do we need this feature?**

We need this feature because our cloud partners use the Dockerfile to build their own images and they would need this sha in place instead of "unknown-dev"

**Who is this feature for?**

Cloud Partners

<!--
**Which issue(s) does this PR fix?**:

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"


Fixes #
-->

**Special notes for your reviewer:**

Before:
<img width="329" alt="Screenshot 2023-04-03 at 14 37 44" src="https://user-images.githubusercontent.com/7741292/229585438-726aca0d-e0f3-4512-ad33-3fb6d98201f7.png">

After:
<img width="263" alt="Screenshot 2023-04-03 at 14 38 40" src="https://user-images.githubusercontent.com/7741292/229585640-e292858c-f122-4bd8-8be9-3534d2e10b52.png">

