### PR TITLE
InfluxDB: Fix Interpolation when querying variables

### DIFF
--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -539,7 +539,15 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
       });
     }
 
-    const interpolated = this.templateSrv.replace(query, undefined, 'regex');
+    const interpolated = new InfluxQueryModel(
+      {
+        refId: 'metricFindQuery',
+        query,
+        rawQuery: true,
+      },
+      this.templateSrv,
+      options.scopedVars
+    ).render(true);
 
     return lastValueFrom(this._seriesQuery(interpolated, options)).then((resp) => {
       return this.responseParser.parse(query, resp);


### PR DESCRIPTION
**What is this feature?**

Fixes variable interpolation when the variable value is a floating point number.

**Who is this feature for?**

InfluxDB users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/support-escalations/issues/5454

**Special notes for your reviewer:**
- Create a dashboard with InfluxDB v1.x and a variable type text box and give it a default value `9.2`
  - The important thing is we must use the float value
- Create another variable that uses the previous variable and datasource must be influxdb1-influxql
- Run the query and observe that there is query parsing error. (variable interpolated as `9\.2`)
- Create a panel and use the same query see there is no error. (variable interpolated as `9.2` as it should be)
- Switch the this branch
- Run things from the beginning and see there is no parsing error.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
