### PR TITLE
Packaging: Remove chkconfig dependency

### DIFF
--- a/pkg/build/packaging/grafana.go
+++ b/pkg/build/packaging/grafana.go
@@ -771,8 +771,7 @@ func realPackageVariant(ctx context.Context, v config.Variant, edition config.Ed
 		defaultFileSrc:         filepath.Join(grafanaDir, "packaging", "rpm", "sysconfig", "grafana-server"),
 		systemdFileSrc:         filepath.Join(grafanaDir, "packaging", "rpm", "systemd", "grafana-server.service"),
 		wrapperFilePath:        filepath.Join(grafanaDir, "packaging", "wrappers"),
-		// chkconfig is depended on since our systemd service wraps a SysV init script, and that requires chkconfig
-		depends: []string{"/sbin/service", "chkconfig", "fontconfig", "freetype", "urw-fonts"},
+		depends:                []string{"/sbin/service", "fontconfig", "freetype", "urw-fonts"},
 	}); err != nil {
 		return err
 	}


### PR DESCRIPTION
This dependency prevents installation on recent opensuse as they no longer provide chkconfig.

As far as I can tell we don't use it anywhere so it shouldn't be required under any modern linux using systemd,