### PR TITLE
Docs: Add content to what's new 9.4

### DIFF
--- a/docs/sources/whatsnew/whats-new-in-v9-4.md
+++ b/docs/sources/whatsnew/whats-new-in-v9-4.md
@@ -296,7 +296,7 @@ We've added support for JWT authentication.
 
 We've added support for custom session parameters.
 
-## Postgres, MySQL, and MSSQL Datasources
+## Postgres, MySQL, and MSSQL data sources
 
 We've moved the `database` property under the `jsonData` key in the datasource configuration. This change is backwards compatible, and existing configurations will continue to work.
 

--- a/docs/sources/whatsnew/whats-new-in-v9-4.md
+++ b/docs/sources/whatsnew/whats-new-in-v9-4.md
@@ -296,6 +296,10 @@ We've added support for JWT authentication.
 
 We've added support for custom session parameters.
 
+## Postgres, MySQL, and MSSQL Datasources
+
+We've moved the `database` property under the `jsonData` key in the datasource configuration. This change is backwards compatible, and existing configurations will continue to work.
+
 ## Before you upgrade
 
 There are no known breaking changes associated with this version of Grafana.

--- a/docs/sources/whatsnew/whats-new-in-v9-4.md
+++ b/docs/sources/whatsnew/whats-new-in-v9-4.md
@@ -298,7 +298,7 @@ We've added support for custom session parameters.
 
 ## Postgres, MySQL, and MSSQL data sources
 
-We've moved the `database` property under the `jsonData` key in the datasource configuration. This change is backwards compatible, and existing configurations will continue to work.
+The `database` property is now under the `jsonData` key in the data source configuration. This change is backward compatible, and existing configurations will continue to work.
 
 ## Before you upgrade
 


### PR DESCRIPTION
This doc PR refers to this change that was missed in the what's new doc: 
SQL Datasources: Move database setting to jsonData #58649
