### PR TITLE
Annotation List: Fix panel not updating when variable is changed

### DIFF
--- a/public/app/plugins/panel/annolist/AnnoListPanel.tsx
+++ b/public/app/plugins/panel/annolist/AnnoListPanel.tsx
@@ -74,6 +74,7 @@ export class AnnoListPanel extends PureComponent<Props, State> {
       options !== prevProps.options ||
       this.state.queryTags !== prevState.queryTags ||
       this.state.queryUser !== prevState.queryUser ||
+      prevProps.renderCounter !== this.props.renderCounter ||
       (options.onlyInTimeRange && timeRange !== prevProps.timeRange);
 
     if (needsQuery) {


### PR DESCRIPTION
**What is this feature?**

Currently if you have an annotation list panel that uses a variable to query for tags, updating the variable does not refresh the panel, this fixes that. (see issue #65349 for more detail)

**Why do we need this feature?**

To allow users to use variables to search for annotations with certain tags

**Who is this feature for?**

Users of annotation list panel

**Which issue(s) does this PR fix?**:

Fixes #65349

**Special notes for your reviewer:**

This solution does not seem ideal, to update on every `renderCounter` change (the same as the Dashboard List panel does), we did try to look to subscribe to some type of "variable changed" event, but could not get to work properly. @grafana/dashboards-squad if you have any hints for that let us know.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
