### PR TITLE
GenericOAuth: Set sub as auth id

### DIFF
--- a/pkg/login/social/generic_oauth.go
+++ b/pkg/login/social/generic_oauth.go
@@ -76,6 +76,7 @@ func (s *SocialGenericOAuth) IsOrganizationMember(client *http.Client) bool {
 }
 
 type UserInfoJson struct {
+	Sub         string              `json:"sub"`
 	Name        string              `json:"name"`
 	DisplayName string              `json:"display_name"`
 	Login       string              `json:"login"`
@@ -107,6 +108,10 @@ func (s *SocialGenericOAuth) UserInfo(client *http.Client, token *oauth2.Token) 
 	userInfo := &BasicUserInfo{}
 	for _, data := range toCheck {
 		s.log.Debug("Processing external user info", "source", data.source, "data", data)
+
+		if userInfo.Id == "" {
+			userInfo.Id = data.Sub
+		}
 
 		if userInfo.Name == "" {
 			userInfo.Name = s.extractUserName(data)


### PR DESCRIPTION
**What is this feature?**
When connecting with generic oauth we have never set authID in user_auth table.

This leads to some strange edge cases we need to handle to not create a new insert in user_auth table on every login,
see https://github.com/grafana/grafana/blob/main/pkg/services/authn/authnimpl/sync/user_sync.go#L323-L331

This prevents generic oauth to sync a new email because the email is always the primary identifier when using generic oauth. So if a user change their email in IDP a new user is created inside grafana.

If we use id token or userinfo endpoint the sub should always be present and can be used as a unique identifier. This will make it possible to be able to change the email for a user and still resolve it to the same one inside grafana. But in order for this to work properly the user first has to login with this changes in place to the auth id is correctly set.

I opted not to force the present of a sub initially because that can maybe break non oidc compatible idps, but we should enforce this in the future.

If we wan't to enforce it we should start with adding a deprecation log when a login is performed without the present of a sub claim 


Fixes #64688

**Special notes for your reviewer:**
