### PR TITLE
[WIP & POC] Loki Query Splitting: Display progress of split requests

### DIFF
--- a/public/app/features/explore/QueryRows.tsx
+++ b/public/app/features/explore/QueryRows.tsx
@@ -89,6 +89,7 @@ export const QueryRows = ({ exploreId }: Props) => {
       app={CoreApp.Explore}
       history={history}
       eventBus={eventBridge}
+      exploreId={exploreId}
     />
   );
 };

--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -33,6 +33,7 @@ import {
 import { getTimeSrv } from 'app/features/dashboard/services/TimeSrv';
 import { DashboardModel } from 'app/features/dashboard/state/DashboardModel';
 import { PanelModel } from 'app/features/dashboard/state/PanelModel';
+import { ExploreId } from 'app/types';
 
 import { RowActionComponents } from './QueryActionComponent';
 import { QueryEditorRowHeader } from './QueryEditorRowHeader';
@@ -57,6 +58,7 @@ interface Props<TQuery extends DataQuery> {
   history?: Array<HistoryItem<TQuery>>;
   eventBus?: EventBusExtended;
   alerting?: boolean;
+  exploreId?: ExploreId;
   onQueryCopied?: () => void;
   onQueryRemoved?: () => void;
   onQueryToggled?: (queryStatus?: boolean | undefined) => void;
@@ -257,7 +259,16 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
   }
 
   renderPluginEditor = () => {
-    const { query, onChange, queries, onRunQuery, onAddQuery, app = CoreApp.PanelEditor, history } = this.props;
+    const {
+      query,
+      onChange,
+      queries,
+      onRunQuery,
+      onAddQuery,
+      app = CoreApp.PanelEditor,
+      history,
+      exploreId,
+    } = this.props;
     const { datasource, data } = this.state;
 
     if (this.isWaitingForDatasourceToLoad()) {
@@ -286,6 +297,7 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
               queries={queries}
               app={app}
               history={history}
+              exploreId={exploreId}
             />
           </DataSourcePluginContextProvider>
         );

--- a/public/app/features/query/components/QueryEditorRows.tsx
+++ b/public/app/features/query/components/QueryEditorRows.tsx
@@ -11,6 +11,7 @@ import {
   PanelData,
 } from '@grafana/data';
 import { getDataSourceSrv, reportInteraction } from '@grafana/runtime';
+import { ExploreId } from 'app/types';
 
 import { QueryEditorRow } from './QueryEditorRow';
 
@@ -31,6 +32,7 @@ export interface Props {
   app?: CoreApp;
   history?: Array<HistoryItem<DataQuery>>;
   eventBus?: EventBusExtended;
+  exploreId?: ExploreId;
   onQueryCopied?: () => void;
   onQueryRemoved?: () => void;
   onQueryToggled?: (queryStatus?: boolean | undefined) => void;
@@ -139,6 +141,7 @@ export class QueryEditorRows extends PureComponent<Props> {
       app,
       history,
       eventBus,
+      exploreId,
       onAddQuery,
       onRunQueries,
       onQueryCopied,
@@ -178,6 +181,7 @@ export class QueryEditorRows extends PureComponent<Props> {
                       app={app}
                       history={history}
                       eventBus={eventBus}
+                      exploreId={exploreId}
                     />
                   );
                 })}

--- a/public/app/plugins/datasource/loki/components/ChunkProgressDisplay.tsx
+++ b/public/app/plugins/datasource/loki/components/ChunkProgressDisplay.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { connect, ConnectedProps } from 'react-redux';
+
+import { StoreState, ExploreItemState, ExploreId } from 'app/types';
+
+export function ChunkProgressDisplay({ loading, queryResponse }: ConnectedProps<typeof connector>) {
+  const dataFrames = queryResponse?.series || [];
+
+  console.log(loading, dataFrames);
+
+  return <p>13%</p>;
+}
+
+function mapStateToProps(state: StoreState, { exploreId }: { exploreId: ExploreId }) {
+  const explore = state.explore;
+  const item: ExploreItemState = explore[exploreId]!;
+  const { loading, queryResponse } = item;
+
+  return {
+    loading,
+    queryResponse,
+  };
+}
+
+const connector = connect(mapStateToProps);
+
+export default connector(ChunkProgressDisplay);

--- a/public/app/plugins/datasource/loki/components/LokiQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryEditor.tsx
@@ -202,7 +202,7 @@ export const LokiQueryEditor = React.memo<LokiQueryEditorProps>((props) => {
           maxLines={datasource.maxLines}
           queryStats={queryStats}
         />
-        <SplittingProgressDisplay exploreId={exploreId} />
+        <SplittingProgressDisplay exploreId={exploreId} refId={query?.refId} />
       </EditorRows>
     </>
   );

--- a/public/app/plugins/datasource/loki/components/LokiQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryEditor.tsx
@@ -199,7 +199,6 @@ export const LokiQueryEditor = React.memo<LokiQueryEditorProps>((props) => {
           onRunQuery={onRunQuery}
           app={app}
           maxLines={datasource.maxLines}
-          datasource={datasource}
           queryStats={queryStats}
         />
       </EditorRows>

--- a/public/app/plugins/datasource/loki/components/LokiQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryEditor.tsx
@@ -21,6 +21,7 @@ import { buildVisualQueryFromString } from '../querybuilder/parsing';
 import { changeEditorMode, getQueryWithDefaults } from '../querybuilder/state';
 import { LokiQuery, QueryStats } from '../types';
 
+import ChunkProgressDisplay from './ChunkProgressDisplay';
 import { getStats, shouldUpdateStats } from './stats';
 import { LokiQueryEditorProps } from './types';
 
@@ -29,7 +30,7 @@ export const testIds = {
 };
 
 export const LokiQueryEditor = React.memo<LokiQueryEditorProps>((props) => {
-  const { onChange, onRunQuery, onAddQuery, data, app, queries, datasource } = props;
+  const { onChange, onRunQuery, onAddQuery, data, app, queries, datasource, exploreId } = props;
   const [parseModalOpen, setParseModalOpen] = useState(false);
   const [queryPatternsModalOpen, setQueryPatternsModalOpen] = useState(false);
   const [dataIsStale, setDataIsStale] = useState(false);
@@ -201,6 +202,7 @@ export const LokiQueryEditor = React.memo<LokiQueryEditorProps>((props) => {
           maxLines={datasource.maxLines}
           queryStats={queryStats}
         />
+        <ChunkProgressDisplay exploreId={exploreId} />
       </EditorRows>
     </>
   );

--- a/public/app/plugins/datasource/loki/components/LokiQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryEditor.tsx
@@ -21,7 +21,7 @@ import { buildVisualQueryFromString } from '../querybuilder/parsing';
 import { changeEditorMode, getQueryWithDefaults } from '../querybuilder/state';
 import { LokiQuery, QueryStats } from '../types';
 
-import ChunkProgressDisplay from './ChunkProgressDisplay';
+import SplittingProgressDisplay from './SplittingProgressDisplay';
 import { getStats, shouldUpdateStats } from './stats';
 import { LokiQueryEditorProps } from './types';
 
@@ -202,7 +202,7 @@ export const LokiQueryEditor = React.memo<LokiQueryEditorProps>((props) => {
           maxLines={datasource.maxLines}
           queryStats={queryStats}
         />
-        <ChunkProgressDisplay exploreId={exploreId} />
+        <SplittingProgressDisplay exploreId={exploreId} />
       </EditorRows>
     </>
   );

--- a/public/app/plugins/datasource/loki/components/SplittingProgressDisplay.tsx
+++ b/public/app/plugins/datasource/loki/components/SplittingProgressDisplay.tsx
@@ -10,11 +10,18 @@ export function SplittingProgressDisplay({ queryResponse, refId }: Props) {
     return null;
   }
   const dataFrame = (queryResponse?.series || []).find((frame) => frame.refId === refId);
-  if (!dataFrame || dataFrame.meta?.custom?.progress === undefined) {
+  if (!dataFrame || !dataFrame.meta?.custom) {
     return null;
   }
 
-  return <p>{dataFrame.meta?.custom?.progress * 100}%</p>;
+  const { requestNumber, totalRequests } = dataFrame.meta?.custom;
+  const percentage = Math.round((requestNumber / totalRequests) * 100);
+
+  return (
+    <p>
+      {requestNumber}/{totalRequests} | {percentage}%
+    </p>
+  );
 }
 
 function mapStateToProps(state: StoreState, { exploreId }: { exploreId: ExploreId }) {

--- a/public/app/plugins/datasource/loki/components/SplittingProgressDisplay.tsx
+++ b/public/app/plugins/datasource/loki/components/SplittingProgressDisplay.tsx
@@ -3,21 +3,26 @@ import { connect, ConnectedProps } from 'react-redux';
 
 import { StoreState, ExploreItemState, ExploreId } from 'app/types';
 
-export function SplittingProgressDisplay({ loading, queryResponse }: ConnectedProps<typeof connector>) {
-  const dataFrames = queryResponse?.series || [];
+type Props = { refId?: string } & ConnectedProps<typeof connector>;
 
-  console.log(loading, dataFrames);
+export function SplittingProgressDisplay({ queryResponse, refId }: Props) {
+  if (!refId) {
+    return null;
+  }
+  const dataFrame = (queryResponse?.series || []).find((frame) => frame.refId === refId);
+  if (!dataFrame || dataFrame.meta?.custom?.progress === undefined) {
+    return null;
+  }
 
-  return <p>13%</p>;
+  return <p>{dataFrame.meta?.custom?.progress * 100}%</p>;
 }
 
 function mapStateToProps(state: StoreState, { exploreId }: { exploreId: ExploreId }) {
   const explore = state.explore;
   const item: ExploreItemState = explore[exploreId]!;
-  const { loading, queryResponse } = item;
+  const { queryResponse } = item;
 
   return {
-    loading,
     queryResponse,
   };
 }

--- a/public/app/plugins/datasource/loki/components/SplittingProgressDisplay.tsx
+++ b/public/app/plugins/datasource/loki/components/SplittingProgressDisplay.tsx
@@ -3,7 +3,7 @@ import { connect, ConnectedProps } from 'react-redux';
 
 import { StoreState, ExploreItemState, ExploreId } from 'app/types';
 
-export function ChunkProgressDisplay({ loading, queryResponse }: ConnectedProps<typeof connector>) {
+export function SplittingProgressDisplay({ loading, queryResponse }: ConnectedProps<typeof connector>) {
   const dataFrames = queryResponse?.series || [];
 
   console.log(loading, dataFrames);
@@ -24,4 +24,4 @@ function mapStateToProps(state: StoreState, { exploreId }: { exploreId: ExploreI
 
 const connector = connect(mapStateToProps);
 
-export default connector(ChunkProgressDisplay);
+export default connector(SplittingProgressDisplay);

--- a/public/app/plugins/datasource/loki/components/SplittingProgressDisplay.tsx
+++ b/public/app/plugins/datasource/loki/components/SplittingProgressDisplay.tsx
@@ -5,8 +5,8 @@ import { StoreState, ExploreItemState, ExploreId } from 'app/types';
 
 type Props = { refId?: string } & ConnectedProps<typeof connector>;
 
-export function SplittingProgressDisplay({ queryResponse, refId }: Props) {
-  if (!refId) {
+export function SplittingProgressDisplay({ queryResponse, refId, loading }: Props) {
+  if (!refId || !loading) {
     return null;
   }
   const dataFrame = (queryResponse?.series || []).find((frame) => frame.refId === refId);
@@ -27,10 +27,11 @@ export function SplittingProgressDisplay({ queryResponse, refId }: Props) {
 function mapStateToProps(state: StoreState, { exploreId }: { exploreId: ExploreId }) {
   const explore = state.explore;
   const item: ExploreItemState = explore[exploreId]!;
-  const { queryResponse } = item;
+  const { queryResponse, loading } = item;
 
   return {
     queryResponse,
+    loading,
   };
 }
 

--- a/public/app/plugins/datasource/loki/querySplitting.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.ts
@@ -16,7 +16,7 @@ import { LokiDatasource } from './datasource';
 import { splitTimeRange as splitLogsTimeRange } from './logsTimeSplitting';
 import { splitTimeRange as splitMetricTimeRange } from './metricTimeSplitting';
 import { isLogsQuery } from './queryUtils';
-import { addProgressMetadata, combineResponses } from './responseUtils';
+import { addProgressMetadata, cleanUpProgressMetadata, combineResponses } from './responseUtils';
 import { LokiQuery, LokiQueryType } from './types';
 
 export function partitionTimeRange(
@@ -97,6 +97,7 @@ export function runSplitGroupedQueries(datasource: LokiDatasource, requests: Lok
 
     const done = () => {
       mergedResponse.state = LoadingState.Done;
+      cleanUpProgressMetadata(mergedResponse);
       subscriber.next(mergedResponse);
       subscriber.complete();
     };

--- a/public/app/plugins/datasource/loki/querySplitting.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.ts
@@ -123,9 +123,11 @@ export function runSplitGroupedQueries(datasource: LokiDatasource, requests: Lok
     subquerySubsciption = datasource
       .runQuery({ ...requests[requestGroup].request, range, requestId, targets })
       .subscribe({
-        next: (response) => {
-          const partialResponse = addResponseMetadata(response, { progress: requestN / totalRequests });
+        next: (partialResponse) => {
           mergedResponse = combineResponses(mergedResponse, partialResponse);
+          mergedResponse = addResponseMetadata(mergedResponse, {
+            progress: (totalRequests - requestN) / totalRequests,
+          });
           if ((mergedResponse.errors ?? []).length > 0 || mergedResponse.error != null) {
             shouldStop = true;
           }

--- a/public/app/plugins/datasource/loki/querySplitting.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.ts
@@ -16,7 +16,7 @@ import { LokiDatasource } from './datasource';
 import { splitTimeRange as splitLogsTimeRange } from './logsTimeSplitting';
 import { splitTimeRange as splitMetricTimeRange } from './metricTimeSplitting';
 import { isLogsQuery } from './queryUtils';
-import { combineResponses } from './responseUtils';
+import { addResponseMetadata, combineResponses } from './responseUtils';
 import { LokiQuery, LokiQueryType } from './types';
 
 export function partitionTimeRange(
@@ -123,7 +123,8 @@ export function runSplitGroupedQueries(datasource: LokiDatasource, requests: Lok
     subquerySubsciption = datasource
       .runQuery({ ...requests[requestGroup].request, range, requestId, targets })
       .subscribe({
-        next: (partialResponse) => {
+        next: (response) => {
+          const partialResponse = addResponseMetadata(response, { progress: requestN / totalRequests });
           mergedResponse = combineResponses(mergedResponse, partialResponse);
           if ((mergedResponse.errors ?? []).length > 0 || mergedResponse.error != null) {
             shouldStop = true;

--- a/public/app/plugins/datasource/loki/querySplitting.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.ts
@@ -16,7 +16,7 @@ import { LokiDatasource } from './datasource';
 import { splitTimeRange as splitLogsTimeRange } from './logsTimeSplitting';
 import { splitTimeRange as splitMetricTimeRange } from './metricTimeSplitting';
 import { isLogsQuery } from './queryUtils';
-import { addResponseMetadata, combineResponses } from './responseUtils';
+import { addProgressMetadata, combineResponses } from './responseUtils';
 import { LokiQuery, LokiQueryType } from './types';
 
 export function partitionTimeRange(
@@ -125,10 +125,12 @@ export function runSplitGroupedQueries(datasource: LokiDatasource, requests: Lok
       .subscribe({
         next: (partialResponse) => {
           mergedResponse = combineResponses(mergedResponse, partialResponse);
-          mergedResponse = addResponseMetadata(mergedResponse, {
-            requestNumber: totalRequests - requestN + 1,
-            totalRequests,
-          });
+          mergedResponse = addProgressMetadata(
+            mergedResponse,
+            requests[requestGroup].request.targets,
+            totalRequests - requestN + 1,
+            totalRequests
+          );
           if ((mergedResponse.errors ?? []).length > 0 || mergedResponse.error != null) {
             shouldStop = true;
           }

--- a/public/app/plugins/datasource/loki/querySplitting.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.ts
@@ -126,7 +126,8 @@ export function runSplitGroupedQueries(datasource: LokiDatasource, requests: Lok
         next: (partialResponse) => {
           mergedResponse = combineResponses(mergedResponse, partialResponse);
           mergedResponse = addResponseMetadata(mergedResponse, {
-            progress: (totalRequests - requestN) / totalRequests,
+            requestNumber: totalRequests - requestN + 1,
+            totalRequests,
           });
           if ((mergedResponse.errors ?? []).length > 0 || mergedResponse.error != null) {
             shouldStop = true;

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.tsx
@@ -7,7 +7,6 @@ import { AutoSizeInput, RadioButtonGroup, Select } from '@grafana/ui';
 import { QueryOptionGroup } from 'app/plugins/datasource/prometheus/querybuilder/shared/QueryOptionGroup';
 
 import { preprocessMaxLines, queryTypeOptions, RESOLUTION_OPTIONS } from '../../components/LokiOptionFields';
-import { LokiDatasource } from '../../datasource';
 import { isLogsQuery } from '../../queryUtils';
 import { LokiQuery, LokiQueryType, QueryStats } from '../../types';
 
@@ -17,12 +16,11 @@ export interface Props {
   onRunQuery: () => void;
   maxLines: number;
   app?: CoreApp;
-  datasource: LokiDatasource;
   queryStats: QueryStats | undefined;
 }
 
 export const LokiQueryBuilderOptions = React.memo<Props>(
-  ({ app, query, onChange, onRunQuery, maxLines, datasource, queryStats }) => {
+  ({ app, query, onChange, onRunQuery, maxLines, queryStats }) => {
     const [splitDurationValid, setsplitDurationValid] = useState(true);
 
     const onQueryTypeChange = (value: LokiQueryType) => {

--- a/public/app/plugins/datasource/loki/responseUtils.ts
+++ b/public/app/plugins/datasource/loki/responseUtils.ts
@@ -245,3 +245,13 @@ export function addProgressMetadata(
 
   return response;
 }
+
+export function cleanUpProgressMetadata(response: DataQueryResponse) {
+  response.data.forEach((frame: DataFrame) => {
+    frame.meta = {
+      ...frame.meta,
+      custom: undefined,
+    };
+  });
+  return response;
+}

--- a/public/app/plugins/datasource/loki/responseUtils.ts
+++ b/public/app/plugins/datasource/loki/responseUtils.ts
@@ -216,3 +216,14 @@ function cloneDataFrame(frame: DataQueryResponseData): DataQueryResponseData {
     })),
   };
 }
+
+export function addResponseMetadata(response: DataQueryResponse, metadata: Record<string, unknown>) {
+  response.data.forEach((frame: DataFrame) => {
+    frame.meta = {
+      ...frame.meta,
+      custom: metadata,
+    };
+  });
+
+  return response;
+}

--- a/public/app/plugins/datasource/loki/responseUtils.ts
+++ b/public/app/plugins/datasource/loki/responseUtils.ts
@@ -221,7 +221,9 @@ export function addResponseMetadata(response: DataQueryResponse, metadata: Recor
   response.data.forEach((frame: DataFrame) => {
     frame.meta = {
       ...frame.meta,
-      custom: metadata,
+      custom: {
+        ...metadata,
+      },
     };
   });
 


### PR DESCRIPTION
**What is this feature?**

This PR is an attempt to add support for displaying request progress for users with query splitting enabled.

To add data about the current request number and the total amount of requests, we use the `QueryResultMeta.custom` attribute, which is an arbitrary key => value field for data source specific values.

https://github.com/grafana/grafana/blob/main/packages/grafana-data/src/types/data.ts#L48

The advantages of using this field to report progress are:
- We don't need to change any type definition.
- We can report progress for each target. This is important for log queries which have a line limit, and can potentially end before all the subrequests are made. I.e. we get 10 logs on the first 1 or 2 requests, whereas metric queries run for every range chunk.

We still need to find a good way to communicate this progress to the user.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana/issues/65104

**Special notes for your reviewer:**

![Demo gif](https://user-images.githubusercontent.com/1069378/229780106-f7f3392f-b9e8-43c4-80b1-5aa4f821843f.gif)

https://user-images.githubusercontent.com/1069378/229842902-bc54c52b-2fc3-45e8-9923-459f12867860.mov

