### PR TITLE
Service accounts: Fix service account role picker on reload of profile page

### DIFF
--- a/public/app/features/serviceaccounts/ServiceAccountPage.test.tsx
+++ b/public/app/features/serviceaccounts/ServiceAccountPage.test.tsx
@@ -30,7 +30,6 @@ const setup = (propOverrides: Partial<Props>) => {
     serviceAccount: {} as ServiceAccountDTO,
     tokens: [],
     isLoading: false,
-    roleOptions: [],
     match: {
       params: { id: '1' },
       isExact: true,

--- a/public/app/features/serviceaccounts/ServiceAccountPage.tsx
+++ b/public/app/features/serviceaccounts/ServiceAccountPage.tsx
@@ -6,7 +6,7 @@ import { Button, ConfirmModal, HorizontalGroup } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 import { contextSrv } from 'app/core/core';
 import { GrafanaRouteComponentProps } from 'app/core/navigation/types';
-import { AccessControlAction, ApiKey, Role, ServiceAccountDTO, StoreState } from 'app/types';
+import { AccessControlAction, ApiKey, ServiceAccountDTO, StoreState } from 'app/types';
 
 import { ServiceAccountPermissions } from './ServiceAccountPermissions';
 import { CreateTokenModal, ServiceAccountToken } from './components/CreateTokenModal';
@@ -26,7 +26,6 @@ interface OwnProps extends GrafanaRouteComponentProps<{ id: string }> {
   serviceAccount?: ServiceAccountDTO;
   tokens: ApiKey[];
   isLoading: boolean;
-  roleOptions: Role[];
 }
 
 function mapStateToProps(state: StoreState) {
@@ -34,7 +33,6 @@ function mapStateToProps(state: StoreState) {
     serviceAccount: state.serviceAccountProfile.serviceAccount,
     tokens: state.serviceAccountProfile.tokens,
     isLoading: state.serviceAccountProfile.isLoading,
-    roleOptions: state.serviceAccounts.roleOptions,
     timezone: getTimeZone(state.user),
   };
 }
@@ -58,7 +56,6 @@ export const ServiceAccountPageUnconnected = ({
   tokens,
   timezone,
   isLoading,
-  roleOptions,
   createServiceAccountToken,
   deleteServiceAccount,
   deleteServiceAccountToken,
@@ -171,12 +168,7 @@ export const ServiceAccountPageUnconnected = ({
             </HorizontalGroup>
           )}
           {serviceAccount && (
-            <ServiceAccountProfile
-              serviceAccount={serviceAccount}
-              timeZone={timezone}
-              roleOptions={roleOptions}
-              onChange={onProfileChange}
-            />
+            <ServiceAccountProfile serviceAccount={serviceAccount} timeZone={timezone} onChange={onProfileChange} />
           )}
           <HorizontalGroup justify="space-between" height="auto">
             <h3>Tokens</h3>

--- a/public/app/features/serviceaccounts/components/ServiceAccountProfile.tsx
+++ b/public/app/features/serviceaccounts/components/ServiceAccountProfile.tsx
@@ -28,6 +28,8 @@ export function ServiceAccountProfile({ serviceAccount, timeZone, onChange }: Pr
   const onNameChange = (newValue: string) => {
     onChange({ ...serviceAccount, name: newValue });
   };
+  // TODO: this is a temporary solution to fetch roles for service accounts
+  // until we make use of the state from the serviceaccountspage
   React.useEffect(() => {
     if (contextSrv.licensedAccessControlEnabled()) {
       if (contextSrv.hasPermission(AccessControlAction.ActionRolesList)) {

--- a/public/app/features/serviceaccounts/components/ServiceAccountProfile.tsx
+++ b/public/app/features/serviceaccounts/components/ServiceAccountProfile.tsx
@@ -16,14 +16,13 @@ import { ServiceAccountRoleRow } from './ServiceAccountRoleRow';
 interface Props {
   serviceAccount: ServiceAccountDTO;
   timeZone: TimeZone;
-  roleOptions: Role[];
   onChange: (serviceAccount: ServiceAccountDTO) => void;
 }
 
-export function ServiceAccountProfile({ serviceAccount, timeZone, roleOptions, onChange }: Props): JSX.Element {
+export function ServiceAccountProfile({ serviceAccount, timeZone, onChange }: Props): JSX.Element {
   const styles = useStyles2(getStyles);
   const ableToWrite = contextSrv.hasPermission(AccessControlAction.ServiceAccountsWrite);
-  const [roles, setRoles] = React.useState<Role[]>(roleOptions);
+  const [roles, setRoles] = React.useState<Role[]>([]);
 
   const onRoleChange = (role: OrgRole) => {
     onChange({ ...serviceAccount, role: role });
@@ -33,9 +32,6 @@ export function ServiceAccountProfile({ serviceAccount, timeZone, roleOptions, o
     onChange({ ...serviceAccount, name: newValue });
   };
   React.useEffect(() => {
-    if (roleOptions.length > 0) {
-      return;
-    }
     if (contextSrv.licensedAccessControlEnabled()) {
       if (contextSrv.hasPermission(AccessControlAction.ActionRolesList)) {
         fetchRoleOptions(serviceAccount.orgId)
@@ -48,7 +44,7 @@ export function ServiceAccountProfile({ serviceAccount, timeZone, roleOptions, o
           });
       }
     }
-  }, [roleOptions, serviceAccount.orgId]);
+  }, [serviceAccount.orgId]);
 
   return (
     <div className={styles.section}>

--- a/public/app/features/serviceaccounts/components/ServiceAccountProfile.tsx
+++ b/public/app/features/serviceaccounts/components/ServiceAccountProfile.tsx
@@ -30,6 +30,7 @@ export function ServiceAccountProfile({ serviceAccount, timeZone, onChange }: Pr
   };
   // TODO: this is a temporary solution to fetch roles for service accounts
   // until we make use of the state from the serviceaccountspage
+  // and pass it down to the serviceaccountprofile
   React.useEffect(() => {
     if (contextSrv.licensedAccessControlEnabled()) {
       if (contextSrv.hasPermission(AccessControlAction.ActionRolesList)) {

--- a/public/app/features/serviceaccounts/components/ServiceAccountProfile.tsx
+++ b/public/app/features/serviceaccounts/components/ServiceAccountProfile.tsx
@@ -5,10 +5,7 @@ import { dateTimeFormat, GrafanaTheme2, OrgRole, TimeZone } from '@grafana/data'
 import { useStyles2 } from '@grafana/ui';
 import { fetchRoleOptions } from 'app/core/components/RolePicker/api';
 import { contextSrv } from 'app/core/core';
-import { dispatch } from 'app/store/store';
 import { AccessControlAction, Role, ServiceAccountDTO } from 'app/types';
-
-import { acOptionsLoaded } from '../state/reducers';
 
 import { ServiceAccountProfileRow } from './ServiceAccountProfileRow';
 import { ServiceAccountRoleRow } from './ServiceAccountRoleRow';
@@ -37,7 +34,6 @@ export function ServiceAccountProfile({ serviceAccount, timeZone, onChange }: Pr
         fetchRoleOptions(serviceAccount.orgId)
           .then((roles) => {
             setRoles(roles);
-            dispatch(acOptionsLoaded(roles));
           })
           .catch((err) => {
             console.log('fetchRoleOptions error: ', err);


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Adds a state of roles for the profile page of service accounts, which if empty fetches the roles for the specific service accounts.

Currently this implementation works, but we might want to rework this as a component fetch instead of making it part of the component state.

**Which issue(s) does this PR fix?**:
https://github.com/grafana/grafana-enterprise/issues/4864