### PR TITLE
Metrics: Distinguish internal and downstream erros in Grafana

### DIFF
--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -581,9 +581,9 @@ func (hs *HTTPServer) addMiddlewaresAndStaticRoutes() {
 	m := hs.web
 
 	m.Use(middleware.RequestTracing(hs.tracer))
-	m.Use(middleware.RequestMetrics(hs.Features))
 
 	m.UseMiddleware(middleware.Logger(hs.Cfg))
+	m.UseMiddleware(middleware.RequestMetrics(hs.Features))
 
 	if hs.Cfg.EnableGzip {
 		m.UseMiddleware(middleware.Gziper())

--- a/pkg/services/contexthandler/contexthandler.go
+++ b/pkg/services/contexthandler/contexthandler.go
@@ -130,6 +130,7 @@ func (h *ContextHandler) Middleware(next http.Handler) http.Handler {
 			AllowAnonymous: false,
 			SkipCache:      false,
 			Logger:         log.New("context"),
+			ErrorSource:    "grafana",
 		}
 
 		// Inject ReqContext into http.Request.Context

--- a/pkg/services/contexthandler/model/model.go
+++ b/pkg/services/contexthandler/model/model.go
@@ -30,6 +30,7 @@ type ReqContext struct {
 	// RequestNonce is a cryptographic request identifier for use with Content Security Policy.
 	RequestNonce          string
 	IsPublicDashboardView bool
+	ErrorSource           string
 
 	PerfmonTimer   prometheus.Summary
 	LookupTokenErr error

--- a/pkg/util/proxyutil/reverse_proxy.go
+++ b/pkg/util/proxyutil/reverse_proxy.go
@@ -108,6 +108,12 @@ func errorHandler(logger glog.Logger) func(http.ResponseWriter, *http.Request, e
 			return
 		}
 
+		// The remaining erros comes from the downstream system and
+		// and not grafana itself.
+		if ctx := contexthandler.FromContext(r.Context()); ctx != nil {
+			ctx.ErrorSource = "downstream"
+		}
+
 		// nolint:errorlint
 		if timeoutErr, ok := err.(timeoutError); ok && timeoutErr.Timeout() {
 			ctxLogger.Error("Proxy request timed out", "err", err)


### PR DESCRIPTION
This is POC of how we can change the errorsource label for `http_metrics` based on where the error came from. 