### PR TITLE
Loki Query Splitting: Fix bug for mixed split durations

### DIFF
--- a/public/app/plugins/datasource/loki/querySplitting.test.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.test.ts
@@ -246,6 +246,20 @@ describe('runSplitQuery()', () => {
         expect(datasource.runQuery).toHaveBeenCalledTimes(3);
       });
     });
+    test('with mixed splitDuration runs the expected amount of queries', async () => {
+      const request = getQueryOptions<LokiQuery>({
+        targets: [
+          { expr: 'count_over_time({c="d"}[1m])', refId: 'A', splitDuration: '15m' },
+          { expr: '{a="b"}', refId: 'B', splitDuration: '15m' },
+          { expr: '{a="b"}', refId: 'C', splitDuration: '1h' },
+        ],
+        range: range1h,
+      });
+      await expect(runSplitQuery(datasource, request)).toEmitValuesWith(() => {
+        // 4 * 15m + 4 * 15m + 1 * 1h
+        expect(datasource.runQuery).toHaveBeenCalledTimes(9);
+      });
+    });
     test('with 1h/30m splitDuration and 1 log and 2 metric target runs 3 queries', async () => {
       const request = getQueryOptions<LokiQuery>({
         targets: [

--- a/public/app/plugins/datasource/loki/querySplitting.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.ts
@@ -154,11 +154,14 @@ export function runSplitGroupedQueries(datasource: LokiDatasource, requests: Lok
 
 function getNextRequestPointers(requests: LokiGroupedRequest, requestGroup: number, requestN: number) {
   // There's a pending request from the next group:
-  if (requests[requestGroup + 1]?.partition[requestN - 1]) {
-    return {
-      nextRequestGroup: requestGroup + 1,
-      nextRequestN: requestN,
-    };
+  for (let i = requestGroup + 1; i < requests.length; i++) {
+    const group = requests[i];
+    if (group.partition[requestN - 1]) {
+      return {
+        nextRequestGroup: i,
+        nextRequestN: requestN,
+      };
+    }
   }
   return {
     // Find the first group where `[requestN - 1]` is defined


### PR DESCRIPTION
While working in showing the splitting progress of requests, and playing with the configured split durations, I stumbled upon a case where you would have mixed durations for your queries. For example:
- Metric 1h
- Logs 1h
- Logs 1d

This produced groups with mixed partitions, surfacing that the next group calculation was wrong: it assumed that your `group + 1` would have a pending request, or if not, start from the first group with `request number - 1 ` defined. TL;DR it only checked the **next** group, instead of **every other group** for the same `requestN`.

Fixed after these changes.

**Why do we need this feature?**

Because it's otherwise a bug.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana/issues/61768

**Special notes for your reviewer:**

The following query settings reproduce the bug:

![imagen](https://user-images.githubusercontent.com/1069378/229806762-68b9e9fe-5425-4b3a-bf8d-e202875a8aa8.png)

You can see it as missing data in the metric query:

![imagen](https://user-images.githubusercontent.com/1069378/229807077-ba338829-8ba4-40b8-bb82-a0c3d27907a8.png)

I double checked that, without these changes, the test doesn't pass in current main:

![imagen](https://user-images.githubusercontent.com/1069378/229807225-aa19a824-8ab4-4a5c-aaa9-bc42282121c4.png)

