### PR TITLE
VizLegend: Change border radius from default to pill

### DIFF
--- a/packages/grafana-ui/src/components/VizLegend/SeriesIcon.tsx
+++ b/packages/grafana-ui/src/components/VizLegend/SeriesIcon.tsx
@@ -30,7 +30,7 @@ export const SeriesIcon = React.memo(
       background: cssColor,
       width: '14px',
       height: '4px',
-      borderRadius: theme.shape.radius.default,
+      borderRadius: theme.shape.radius.pill,
       display: 'inline-block',
       marginRight: '8px',
     };


### PR DESCRIPTION
**What is this feature?**

For consistency, because the `SeriesIcon` component looks like a pill in the end, we should use the `radius.pill` token.  It makes no difference in this case using `default` (2px) or `pill` because the height of the series icon is 4px.

<img width="333" alt="Screenshot 2023-04-04 at 17 29 47" src="https://user-images.githubusercontent.com/100691367/229857340-9a77929a-7120-41f8-a713-8bd9e78ce51d.png">


**Why do we need this feature?**

For consistency

**Who is this feature for?**

Mostly for us to have everything consistent in terms of using tokens.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
