### PR TITLE
API keys: Add deprecation to api keys

### DIFF
--- a/docs/sources/administration/api-keys/index.md
+++ b/docs/sources/administration/api-keys/index.md
@@ -17,7 +17,7 @@ An API key is a randomly generated string that external systems use to interact 
 
 When you create an API key, you specify a **Role** that determines the permissions associated with the API key. Role permissions control that actions the API key can perform on Grafana resources.
 
-> **Note:** If you use Grafana v8.5 or newer, use service accounts instead of API keys. For more information, refer to [Grafana service accounts]({{< relref "../service-accounts/" >}}).
+> **Note:** If you use Grafana v9.1 or newer, use service accounts instead of API keys. For more information, refer to [Grafana service accounts]({{< relref "../service-accounts/" >}}).
 
 {{< section >}}
 

--- a/pkg/api/apikey.go
+++ b/pkg/api/apikey.go
@@ -22,7 +22,7 @@ import (
 //
 // Deprecated: true.
 //
-// Deprecated please use GET /api/serviceaccounts and GET /api/serviceaccounts/{id}/tokens instead
+// Deprecated. Please use GET /api/serviceaccounts and GET /api/serviceaccounts/{id}/tokens instead
 // see https://grafana.com/docs/grafana/next/administration/api-keys/#migrate-api-keys-to-grafana-service-accounts-using-the-api.
 //
 // Responses:
@@ -72,7 +72,7 @@ func (hs *HTTPServer) GetAPIKeys(c *contextmodel.ReqContext) response.Response {
 // Delete API key.
 //
 // Deletes an API key.
-// Deprecated see: https://grafana.com/docs/grafana/next/administration/api-keys/#migrate-api-keys-to-grafana-service-accounts-using-the-api.
+// Deprecated. See: https://grafana.com/docs/grafana/next/administration/api-keys/#migrate-api-keys-to-grafana-service-accounts-using-the-api.
 //
 // Deprecated: true
 // Responses:
@@ -109,7 +109,7 @@ func (hs *HTTPServer) DeleteAPIKey(c *contextmodel.ReqContext) response.Response
 // Will return details of the created API key.
 //
 // Deprecated: true
-// Deprecated please use POST /api/serviceaccounts and POST /api/serviceaccounts/{id}/tokens
+// Deprecated. Please use POST /api/serviceaccounts and POST /api/serviceaccounts/{id}/tokens
 //
 // see: https://grafana.com/docs/grafana/next/administration/api-keys/#migrate-api-keys-to-grafana-service-accounts-using-the-api.
 //

--- a/pkg/api/apikey.go
+++ b/pkg/api/apikey.go
@@ -99,7 +99,11 @@ func (hs *HTTPServer) DeleteAPIKey(c *contextmodel.ReqContext) response.Response
 //
 // Will return details of the created API key.
 //
-// Deprecated: This endpoint is deprecated and will be removed in a future version. Please use POST /api/serviceaccounts and POST /api/serviceaccounts/{id}/tokens instead see: https://grafana.com/docs/grafana/next/administration/api-keys/#migrate-api-keys-to-grafana-service-accounts-using-the-api.
+// Please use POST /api/serviceaccounts and POST /api/serviceaccounts/{id}/tokens
+//
+// instead see: https://grafana.com/docs/grafana/next/administration/api-keys/#migrate-api-keys-to-grafana-service-accounts-using-the-api.
+//
+// Deprecated: true
 //
 // Responses:
 // 200: postAPIkeyResponse

--- a/pkg/api/apikey.go
+++ b/pkg/api/apikey.go
@@ -20,6 +20,9 @@ import (
 //
 // Will return auth keys.
 //
+// instead see: https://grafana.com/docs/grafana/next/administration/api-keys/#migrate-api-keys-to-grafana-service-accounts-using-the-api.
+//
+// Deprecated: true
 // Responses:
 // 200: getAPIkeyResponse
 // 401: unauthorisedError
@@ -66,6 +69,9 @@ func (hs *HTTPServer) GetAPIKeys(c *contextmodel.ReqContext) response.Response {
 //
 // Delete API key.
 //
+// instead see: https://grafana.com/docs/grafana/next/administration/api-keys/#migrate-api-keys-to-grafana-service-accounts-using-the-api.
+//
+// Deprecated: true
 // Responses:
 // 200: okResponse
 // 401: unauthorisedError

--- a/pkg/api/apikey.go
+++ b/pkg/api/apikey.go
@@ -20,9 +20,11 @@ import (
 //
 // Will return auth keys.
 //
-// instead see: https://grafana.com/docs/grafana/next/administration/api-keys/#migrate-api-keys-to-grafana-service-accounts-using-the-api.
+// Deprecated: true.
 //
-// Deprecated: true
+// Deprecated please use GET /api/serviceaccounts and GET /api/serviceaccounts/{id}/tokens instead
+// see https://grafana.com/docs/grafana/next/administration/api-keys/#migrate-api-keys-to-grafana-service-accounts-using-the-api.
+//
 // Responses:
 // 200: getAPIkeyResponse
 // 401: unauthorisedError
@@ -69,7 +71,8 @@ func (hs *HTTPServer) GetAPIKeys(c *contextmodel.ReqContext) response.Response {
 //
 // Delete API key.
 //
-// instead see: https://grafana.com/docs/grafana/next/administration/api-keys/#migrate-api-keys-to-grafana-service-accounts-using-the-api.
+// Deletes an API key.
+// Deprecated see: https://grafana.com/docs/grafana/next/administration/api-keys/#migrate-api-keys-to-grafana-service-accounts-using-the-api.
 //
 // Deprecated: true
 // Responses:
@@ -105,11 +108,10 @@ func (hs *HTTPServer) DeleteAPIKey(c *contextmodel.ReqContext) response.Response
 //
 // Will return details of the created API key.
 //
-// Please use POST /api/serviceaccounts and POST /api/serviceaccounts/{id}/tokens
-//
-// instead see: https://grafana.com/docs/grafana/next/administration/api-keys/#migrate-api-keys-to-grafana-service-accounts-using-the-api.
-//
 // Deprecated: true
+// Deprecated please use POST /api/serviceaccounts and POST /api/serviceaccounts/{id}/tokens
+//
+// see: https://grafana.com/docs/grafana/next/administration/api-keys/#migrate-api-keys-to-grafana-service-accounts-using-the-api.
 //
 // Responses:
 // 200: postAPIkeyResponse

--- a/pkg/api/apikey.go
+++ b/pkg/api/apikey.go
@@ -99,6 +99,8 @@ func (hs *HTTPServer) DeleteAPIKey(c *contextmodel.ReqContext) response.Response
 //
 // Will return details of the created API key.
 //
+// Deprecated: This endpoint is deprecated and will be removed in a future version. Please use POST /api/serviceaccounts and POST /api/serviceaccounts/{id}/tokens instead see: https://grafana.com/docs/grafana/next/administration/api-keys/#migrate-api-keys-to-grafana-service-accounts-using-the-api.
+//
 // Responses:
 // 200: postAPIkeyResponse
 // 400: badRequestError


### PR DESCRIPTION
**What is this feature?**
Adds deprecation notice for the create path of API keys w. a link to the new documentation outlining how to migrate your API calls to service accounts.

linking to page -https://grafana.com/docs/grafana/next/administration/api-keys/#migrate-api-keys-to-grafana-service-accounts-using-the-api

**notes**
Part of a bigger sunsetting of API keys - https://github.com/grafana/grafana/issues/53567
