### PR TITLE
CloudWatch Logs: Document logs data protection

### DIFF
--- a/docs/sources/datasources/aws-cloudwatch/_index.md
+++ b/docs/sources/datasources/aws-cloudwatch/_index.md
@@ -375,3 +375,7 @@ For more information, refer to the AWS documentation for [Service Quotas](https:
 The CloudWatch plugin enables you to monitor and troubleshoot applications across multiple regional accounts. Using cross-account observability, you can seamlessly search, visualize and analyze metrics and logs without worrying about account boundaries.
 
 To use this feature, configure in the [AWS console under Cloudwatch Settings](https://aws.amazon.com/blogs/aws/new-amazon-cloudwatch-cross-account-observability/), a monitoring and source account, and then add the necessary IAM permissions as described above.
+
+## CloudWatch Logs data protection
+
+CloudWatch Logs can safeguard data by using log group data protection policies. If you have data protection enabled for a log group, then any sensitive data that matches the data identifiers you've selected will be masked. In order to view masked data you will need to have the `logs:Unmask` IAM permission enabled. See the AWS documentation on how to [help protect sensitive log data with masking](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/mask-sensitive-log-data.html) to learn more about this.

--- a/public/app/plugins/datasource/cloudwatch/components/LogsCheatSheet.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/LogsCheatSheet.tsx
@@ -216,6 +216,10 @@ const exampleCategory = css`
   margin-top: 5px;
 `;
 
+const link = css`
+  text-decoration: underline;
+`;
+
 export default class LogsCheatSheet extends PureComponent<
   QueryEditorHelpProps<CloudWatchQuery>,
   { userExamples: string[] }
@@ -280,6 +284,18 @@ export default class LogsCheatSheet extends PureComponent<
             ))}
           </div>
         ))}
+        <div>
+          If you are seeing masked data, you may have CloudWatch logs data protection enabled.{' '}
+          <a
+            className={cx(link)}
+            href="https://grafana.com/docs/grafana/latest/datasources/aws-cloudwatch/template-queries-cloudwatch/#cloudwatch-logs-data-protection"
+            target="_blank"
+            rel="noreferrer"
+          >
+            See documentation for details
+          </a>
+          .
+        </div>
       </div>
     );
   }

--- a/public/app/plugins/datasource/cloudwatch/components/LogsCheatSheet.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/LogsCheatSheet.tsx
@@ -288,7 +288,7 @@ export default class LogsCheatSheet extends PureComponent<
           If you are seeing masked data, you may have CloudWatch logs data protection enabled.{' '}
           <a
             className={cx(link)}
-            href="https://grafana.com/docs/grafana/latest/datasources/aws-cloudwatch/template-queries-cloudwatch/#cloudwatch-logs-data-protection"
+            href="https://grafana.com/docs/grafana/latest/datasources/aws-cloudwatch/#cloudwatch-logs-data-protection"
             target="_blank"
             rel="noreferrer"
           >


### PR DESCRIPTION
**What is this feature?**

Adding documentation about CloudWatch logs data protection which masks sensitive data.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #64333

**Special notes for your reviewer:**
The message in the query editor is available through the "Toggle data source help" button

<img width="867" alt="toggle" src="https://user-images.githubusercontent.com/19530599/229927304-c4a147b8-2aca-47ee-97d3-0df42f5cc8e9.png">

The message is rendered in the LogsCheatSheet at the bottom.

<img width="778" alt="message" src="https://user-images.githubusercontent.com/19530599/229927323-0b0a2af4-5d10-4ace-b521-a9c6c78712e2.png">

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
