### PR TITLE
Alerting: Attach hash of instance labels to state history log lines

### DIFF
--- a/pkg/services/ngalert/state/historian/core.go
+++ b/pkg/services/ngalert/state/historian/core.go
@@ -1,10 +1,12 @@
 package historian
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
+	prometheus "github.com/prometheus/common/model"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
@@ -40,6 +42,12 @@ func removePrivateLabels(labels data.Labels) data.Labels {
 		}
 	}
 	return result
+}
+
+// labelFingerprint calculates a stable Prometheus-style signature for a label set.
+func labelFingerprint(labels data.Labels) string {
+	sig := prometheus.LabelsToSignature(labels)
+	return fmt.Sprintf("%016x", uint64(sig))
 }
 
 // panelKey uniquely identifies a panel.

--- a/pkg/services/ngalert/state/historian/core.go
+++ b/pkg/services/ngalert/state/historian/core.go
@@ -47,7 +47,7 @@ func removePrivateLabels(labels data.Labels) data.Labels {
 // labelFingerprint calculates a stable Prometheus-style signature for a label set.
 func labelFingerprint(labels data.Labels) string {
 	sig := prometheus.LabelsToSignature(labels)
-	return fmt.Sprintf("%016x", uint64(sig))
+	return fmt.Sprintf("%016x", sig)
 }
 
 // panelKey uniquely identifies a panel.

--- a/pkg/services/ngalert/state/historian/loki.go
+++ b/pkg/services/ngalert/state/historian/loki.go
@@ -266,7 +266,7 @@ func statesToStream(rule history_model.RuleMeta, states []state.StateTransition,
 			Condition:      rule.Condition,
 			DashboardUID:   rule.DashboardUID,
 			PanelID:        rule.PanelID,
-			InstanceID:     fmt.Sprintf("%x", md5.Sum(instFingerprint)),
+			Fingerprint:    fmt.Sprintf("%x", md5.Sum(instFingerprint)),
 			InstanceLabels: sanitizedLabels,
 		}
 		if state.State.State == eval.Error {
@@ -310,7 +310,7 @@ type lokiEntry struct {
 	Condition     string           `json:"condition"`
 	DashboardUID  string           `json:"dashboardUID"`
 	PanelID       int64            `json:"panelID"`
-	InstanceID    string           `json:"instanceID"`
+	Fingerprint   string           `json:"fingerprint"`
 	// InstanceLabels is exactly the set of labels associated with the alert instance in Alertmanager.
 	// These should not be conflated with labels associated with log streams.
 	InstanceLabels map[string]string `json:"labels"`

--- a/pkg/services/ngalert/state/historian/loki.go
+++ b/pkg/services/ngalert/state/historian/loki.go
@@ -2,7 +2,6 @@ package historian
 
 import (
 	"context"
-	"crypto/md5"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -257,7 +256,6 @@ func statesToStream(rule history_model.RuleMeta, states []state.StateTransition,
 		}
 
 		sanitizedLabels := removePrivateLabels(state.Labels)
-		instFingerprint, _ := json.Marshal(sanitizedLabels)
 		entry := lokiEntry{
 			SchemaVersion:  1,
 			Previous:       state.PreviousFormatted(),
@@ -266,7 +264,7 @@ func statesToStream(rule history_model.RuleMeta, states []state.StateTransition,
 			Condition:      rule.Condition,
 			DashboardUID:   rule.DashboardUID,
 			PanelID:        rule.PanelID,
-			Fingerprint:    fmt.Sprintf("%x", md5.Sum(instFingerprint)),
+			Fingerprint:    labelFingerprint(sanitizedLabels),
 			InstanceLabels: sanitizedLabels,
 		}
 		if state.State.State == eval.Error {

--- a/pkg/services/ngalert/state/historian/loki_test.go
+++ b/pkg/services/ngalert/state/historian/loki_test.go
@@ -173,7 +173,7 @@ func TestRemoteLokiBackend(t *testing.T) {
 			entry := requireSingleEntry(t, res)
 			lblJsn, _ := json.Marshal(states[0].Labels)
 			exp := fmt.Sprintf("%x", md5.Sum(lblJsn))
-			require.Equal(t, exp, entry.InstanceID)
+			require.Equal(t, exp, entry.Fingerprint)
 		})
 	})
 

--- a/pkg/services/ngalert/state/historian/loki_test.go
+++ b/pkg/services/ngalert/state/historian/loki_test.go
@@ -3,7 +3,6 @@ package historian
 import (
 	"bytes"
 	"context"
-	"crypto/md5"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -171,8 +170,7 @@ func TestRemoteLokiBackend(t *testing.T) {
 			res := statesToStream(rule, states, nil, l)
 
 			entry := requireSingleEntry(t, res)
-			lblJsn, _ := json.Marshal(states[0].Labels)
-			exp := fmt.Sprintf("%x", md5.Sum(lblJsn))
+			exp := labelFingerprint(states[0].Labels)
 			require.Equal(t, exp, entry.Fingerprint)
 		})
 	})


### PR DESCRIPTION
**What is this feature?**

Adds a new field in the log line, `instanceID`, which will be unique based on the alert instance for which the log line is attached. If two lines are associated with the same alert instance, they will have the same instance ID.

**Why do we need this feature?**

This allows for new types of LogQL queries on the data - queries are now able to group by alert instance which allows for new types of analysis.

**Which issue(s) does this PR fix?**:

n/a

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
