### PR TITLE
Fixes for overlaying an BarGauge on text

### DIFF
--- a/packages/grafana-ui/src/components/Table/styles.ts
+++ b/packages/grafana-ui/src/components/Table/styles.ts
@@ -29,7 +29,7 @@ export function useTableStyles(theme: GrafanaTheme2, cellHeightOption: TableCell
       width: 'auto !important',
       boxShadow: `0 0 2px ${theme.colors.primary.main}`,
       background: background ?? rowHoverBg,
-      zIndex: 1,
+      zIndex: 2,
     };
 
     return css`


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Style fixes.

Before:
![image](https://user-images.githubusercontent.com/17812651/229958737-be9a2c0e-fcfe-4436-ba2a-fd1ffdb5cbd4.png)

**Why do we need this feature?**

These are fixes for overlaying an BarGauge on text.

After:
![image](https://user-images.githubusercontent.com/17812651/229959330-06f46d64-a768-4bb0-a5d6-ee23ecb93832.png)

**Who is this feature for?**

For everyone.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes similar zIndex. Since two elements have the same zIndex, the one after that is considered important and overlaying on text.
https://github.com/AdvTechnoKing/grafana/blob/main/packages/grafana-ui/src/components/BarGauge/BarGauge.tsx#L493
https://github.com/AdvTechnoKing/grafana/blob/main/packages/grafana-ui/src/components/Table/styles.ts#L32

Or you can decrease zIndex for BarGauge.

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
