### PR TITLE
TrendPanel: use isLikelyAscendingVector rather than brute force

### DIFF
--- a/public/app/plugins/panel/trend/TrendPanel.tsx
+++ b/public/app/plugins/panel/trend/TrendPanel.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react';
 
 import { FieldType, PanelProps } from '@grafana/data';
+import { isLikelyAscendingVector } from '@grafana/data/src/transformations/transformers/joinDataFrames';
 import { config, PanelDataErrorView } from '@grafana/runtime';
 import { KeyboardPlugin, TimeSeries, TooltipDisplayMode, TooltipPlugin, usePanelContext } from '@grafana/ui';
 import { findFieldIndex } from 'app/features/dimensions';
@@ -56,20 +57,11 @@ export const TrendPanel = ({
     // Make sure values are ascending
     if (xFieldIdx != null) {
       const field = frames[0].fields[xFieldIdx];
-      if (field.type === FieldType.number) {
-        // we may support ordinal soon
-        let last = Number.NEGATIVE_INFINITY;
-        const values = field.values.toArray();
-        for (let i = 0; i < values.length; i++) {
-          const v = values[i];
-          if (last > v) {
-            return {
-              warning: `Values must be in ascending order (index: ${i}, ${last} > ${v})`,
-              frames,
-            };
-          }
-          last = v;
-        }
+      if (field.type === FieldType.number && !isLikelyAscendingVector(field.values)) {
+        return {
+          warning: `Values must be in ascending order`,
+          frames,
+        };
       }
     }
 


### PR DESCRIPTION
Use the isLikelyAscendingVector function as a fast check rather than exhaustive check