### PR TITLE
PluginExtensions: Fixed issue in typings for the onClick link callback

### DIFF
--- a/packages/grafana-data/src/types/pluginExtensions.ts
+++ b/packages/grafana-data/src/types/pluginExtensions.ts
@@ -20,7 +20,7 @@ export type PluginExtension = {
 export type PluginExtensionLink = PluginExtension & {
   type: PluginExtensionTypes.link;
   path?: string;
-  onClick?: (event: React.MouseEvent) => void;
+  onClick?: (event?: React.MouseEvent) => void;
 };
 
 // Objects used for registering extensions (in app plugins)

--- a/packages/grafana-data/src/types/pluginExtensions.ts
+++ b/packages/grafana-data/src/types/pluginExtensions.ts
@@ -45,7 +45,7 @@ export type PluginExtensionLinkConfig<Context extends object = object> = PluginE
   Context,
   Pick<PluginExtensionLink, 'path'> & {
     type: PluginExtensionTypes.link;
-    onClick?: (event: React.MouseEvent, helpers: PluginExtensionEventHelpers<Context>) => void;
+    onClick?: (event: React.MouseEvent | undefined, helpers: PluginExtensionEventHelpers<Context>) => void;
   }
 >;
 

--- a/public/app/features/plugins/extensions/getPluginExtensions.ts
+++ b/public/app/features/plugins/extensions/getPluginExtensions.ts
@@ -108,14 +108,14 @@ function getLinkExtensionOverrides(pluginId: string, config: PluginExtensionLink
 function getLinkExtensionOnClick(
   config: PluginExtensionLinkConfig,
   context?: object
-): ((event: React.MouseEvent) => void) | undefined {
+): ((event?: React.MouseEvent) => void) | undefined {
   const { onClick } = config;
 
   if (!onClick) {
     return;
   }
 
-  return function onClickExtensionLink(event: React.MouseEvent) {
+  return function onClickExtensionLink(event?: React.MouseEvent) {
     try {
       const result = onClick(event, getEventHelpers(context));
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
This PR will loosen the typings for the onClick function passed to plugin link extensions.

**Why do we need this feature?**
When implementing an extension point you won't always have a source event triggering the onClick.

**Who is this feature for?**
Plugin developers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #66090

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
