### PR TITLE
Badge: Fix alignment and simplify markup and styles

### DIFF
--- a/packages/grafana-ui/src/components/Badge/Badge.tsx
+++ b/packages/grafana-ui/src/components/Badge/Badge.tsx
@@ -7,7 +7,6 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { useStyles2 } from '../../themes/ThemeContext';
 import { IconName } from '../../types';
 import { Icon } from '../Icon/Icon';
-import { HorizontalGroup } from '../Layout/Layout';
 import { Tooltip } from '../Tooltip/Tooltip';
 
 export type BadgeColor = 'blue' | 'red' | 'green' | 'orange' | 'purple';
@@ -23,10 +22,8 @@ export const Badge = React.memo<BadgeProps>(({ icon, color, text, tooltip, class
   const styles = useStyles2(useCallback((theme) => getStyles(theme, color), [color]));
   const badge = (
     <div className={cx(styles.wrapper, className)} {...otherProps}>
-      <HorizontalGroup align="center" spacing="xs">
-        {icon && <Icon name={icon} size="sm" />}
-        <span>{text}</span>
-      </HorizontalGroup>
+      {icon && <Icon name={icon} size="sm" />}
+      {text}
     </div>
   );
 
@@ -59,7 +56,6 @@ const getStyles = (theme: GrafanaTheme2, color: BadgeColor) => {
 
   return {
     wrapper: css`
-      font-size: ${theme.typography.size.sm};
       display: inline-flex;
       padding: 1px 4px;
       border-radius: ${theme.shape.radius.default};
@@ -67,12 +63,10 @@ const getStyles = (theme: GrafanaTheme2, color: BadgeColor) => {
       border: 1px solid ${borderColor};
       color: ${textColor};
       font-weight: ${theme.typography.fontWeightRegular};
-
-      > span {
-        position: relative;
-        top: 1px;
-        margin-left: 2px;
-      }
+      gap: 2px;
+      font-size: ${theme.typography.bodySmall.fontSize};
+      line-height: ${theme.typography.bodySmall.lineHeight};
+      align-items: center;
     `,
   };
 };


### PR DESCRIPTION
Seeing the icon being unaligned in badges drive my OCD crazy :) 

Before (Only happens on ubuntu for me, or could be the non-retina screen) 
![Screenshot from 2023-04-05 09-20-53](https://user-images.githubusercontent.com/10999/230010172-0702dfa2-ec0a-4f14-ba13-aeaed6d046a9.png)

After: 
![Screenshot from 2023-04-05 09-22-06](https://user-images.githubusercontent.com/10999/230010415-be34bc65-fbc9-481b-a508-a58414ea72ed.png)
![Screenshot from 2023-04-05 09-20-44](https://user-images.githubusercontent.com/10999/230010436-175ffe60-1a67-43cf-8f41-bf50bf7c632f.png)

The markup for Badge was unnecessarily complex. And setting the correct line-height and adding "align-items" center fixed the issue 
