### PR TITLE
Auth: Remove the session cookie only if it's invalid or revoked

### DIFF
--- a/pkg/services/contexthandler/contexthandler.go
+++ b/pkg/services/contexthandler/contexthandler.go
@@ -481,8 +481,8 @@ func (h *ContextHandler) initContextWithToken(reqContext *contextmodel.ReqContex
 	token, err := h.AuthTokenService.LookupToken(ctx, rawToken)
 	if err != nil {
 		reqContext.Logger.Warn("failed to look up session from cookie", "error", err)
-		if errors.Is(err, auth.ErrUserTokenNotFound) || errors.Is(err, auth.ErrInvalidSessionToken) {
-			// Burn the cookie in case of invalid, expired or missing token
+		if errors.Is(err, auth.ErrInvalidSessionToken) {
+			// Burn the cookie in case of invalid or revoked token
 			reqContext.Resp.Before(h.deleteInvalidCookieEndOfRequestFunc(reqContext))
 		}
 


### PR DESCRIPTION
**What is this feature?**
This PR changes the behaviour of the session cookie removal. The cookie will not be removed when the user_token is not in the database. The cookie will be removed in case of an invalid or revoked token. 

**Why do we need this feature?**
We realised that Grafana logs the user out intermittently in case concurrent requests are rotating the token and one of the requests fails because it contains an old, already rotated token, thus it causes the session cookie removal despite of the latest session cookie has already been sent to the client in one of the precedent requests.

**Who is this feature for?**

**Which issue(s) does this PR fix?**:

Fixes #56994 

**Special notes for your reviewer:**

The previous behaviour was introduced with https://github.com/grafana/grafana/pull/53881 (9.2), and it was improved with https://github.com/grafana/grafana/pull/59556.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
