### PR TITLE
prometheus: slightly different approach for dataplane compatibility

### DIFF
--- a/pkg/util/converter/prom.go
+++ b/pkg/util/converter/prom.go
@@ -400,11 +400,6 @@ func readMatrixOrVectorWide(iter *jsoniter.Iterator, resultType string, opt Opti
 			switch l1Field {
 			case "metric":
 				iter.ReadVal(&valueField.Labels)
-				if opt.Dataplane {
-					if n, ok := valueField.Labels["__name__"]; ok {
-						valueField.Name = n
-					}
-				}
 
 			case "value":
 				timeMap, rowIdx = addValuePairToFrame(frame, timeMap, rowIdx, iter)
@@ -503,11 +498,6 @@ func readMatrixOrVectorMulti(iter *jsoniter.Iterator, resultType string, opt Opt
 			switch l1Field {
 			case "metric":
 				iter.ReadVal(&valueField.Labels)
-				if opt.Dataplane {
-					if n, ok := valueField.Labels["__name__"]; ok {
-						valueField.Name = n
-					}
-				}
 
 			case "value":
 				t, v, err := readTimeValuePair(iter)


### PR DESCRIPTION
this PR changes the dataplane-approach a little, and moves the "compatibility" code from `converter/prom.go` to the prometheus-part.
the reason is that the `__name__` handling is not really compatible with Loki.

- when dataplane=enabled
    - we do not set the `frame.Name`. (i think this is an acceptable change. in theory there may be transforms that do something based on the frame-name, but i don't expect a lot of it. also, there will be the feature-flag to turn it off... i can also remove this change, if you don't like it 😄 )
    - the Name of the valueField will be the value of the `__name__` label, if it exists, otherwise it is `Value`


Note: visually, in a timeseries panel, nothing will change. the reason is, that the prom-datasource also sets the `valueField.config.DisplayNameFromDS` value, and that one overrides all other possible sources of the name (frame.name, valueField.name, etc.).

(technically, i think we could only set DisplayNameFromDS when the `alias` functionality is used in the prom-datasource, but i did not want to complicate the PR)