### PR TITLE
Fix: DataLinks from data sources override user defined data link

### DIFF
--- a/packages/grafana-data/src/field/fieldOverrides.test.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.test.ts
@@ -441,6 +441,124 @@ describe('setFieldConfigDefaults', () => {
       }
     `);
   });
+
+  it('applies field config defaults correctly when links property exist in field config and no links are defined in panel', () => {
+    const dsFieldConfig: FieldConfig = {
+      links: [
+        {
+          title: 'Google link',
+          url: 'https://google.com',
+        },
+      ],
+    };
+
+    const panelFieldConfig: FieldConfig = {};
+
+    const context: FieldOverrideEnv = {
+      data: [],
+      field: { type: FieldType.number } as Field,
+      dataFrameIndex: 0,
+      fieldConfigRegistry: customFieldRegistry,
+    };
+
+    // we mutate dsFieldConfig
+    // @ts-ignore
+    setFieldConfigDefaults(dsFieldConfig, panelFieldConfig, context);
+
+    expect(dsFieldConfig).toMatchInlineSnapshot(`
+      {
+        "custom": {},
+        "links": [
+          {
+            "title": "Google link",
+            "url": "https://google.com",
+          },
+        ],
+      }
+    `);
+  });
+
+  it('applies field config defaults correctly when links property exist in panel config and no links are defined in ds field config', () => {
+    const dsFieldConfig: FieldConfig = {};
+
+    const panelFieldConfig: FieldConfig = {
+      links: [
+        {
+          title: 'Google link',
+          url: 'https://google.com',
+        },
+      ],
+    };
+
+    const context: FieldOverrideEnv = {
+      data: [],
+      field: { type: FieldType.number } as Field,
+      dataFrameIndex: 0,
+      fieldConfigRegistry: customFieldRegistry,
+    };
+
+    // we mutate dsFieldConfig
+    // @ts-ignore
+    setFieldConfigDefaults(dsFieldConfig, panelFieldConfig, context);
+
+    expect(dsFieldConfig).toMatchInlineSnapshot(`
+      {
+        "custom": {},
+        "links": [
+          {
+            "title": "Google link",
+            "url": "https://google.com",
+          },
+        ],
+      }
+    `);
+  });
+
+  it('applies a merge strategy for links when they exist in ds config and panel', () => {
+    const dsFieldConfig: FieldConfig = {
+      links: [
+        {
+          title: 'Google link',
+          url: 'https://google.com',
+        },
+      ],
+    };
+
+    const panelFieldConfig: FieldConfig = {
+      links: [
+        {
+          title: 'Grafana',
+          url: 'https://grafana.com',
+        },
+      ],
+    };
+
+    const context: FieldOverrideEnv = {
+      data: [],
+      field: { type: FieldType.number } as Field,
+      dataFrameIndex: 0,
+      fieldConfigRegistry: customFieldRegistry,
+    };
+
+    // we mutate dsFieldConfig
+    setFieldConfigDefaults(dsFieldConfig, panelFieldConfig, context);
+
+    expect(dsFieldConfig).toMatchInlineSnapshot(`
+      {
+        "custom": {},
+        "links": [
+          {
+            "title": "Google link",
+            "url": "https://google.com",
+          },
+          {
+            "title": "Grafana",
+            "url": "https://grafana.com",
+          },
+        ],
+      }
+    `);
+  });
 });
 
 describe('setDynamicConfigValue', () => {

--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -294,7 +294,7 @@ export function setDynamicConfigValue(config: FieldConfig, value: DynamicConfigV
  * Merge the links from the data source config and the panel config
  * @param dataSourceLinks coming from the datasource
  * @param defaultLinks coming from the panel config
- * @returns unique merged links
+ * @returns merged links
  */
 
 function mergeLinks(dataSourceLinks: DataLink[], defaultLinks: DataLink[]) {

--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -292,40 +292,24 @@ export function setDynamicConfigValue(config: FieldConfig, value: DynamicConfigV
 
 /**
  * Merge the links from the data source config and the panel config
- * @param configLinks coming from the datasource
+ * @param dataSourceLinks coming from the datasource
  * @param defaultLinks coming from the panel config
  * @returns unique merged links
  */
 
-function mergeLinks(configLinks: DataLink[], defaultLinks: DataLink[]) {
+function mergeLinks(dataSourceLinks: DataLink[], defaultLinks: DataLink[]) {
   // Combine the config links and the default links
-  const combinedLinks = [...configLinks, ...defaultLinks];
-
-  // Deduplicate the combined array of links
-  // note: this is necessary to prevent default links from being displayed multiple times
-  // as setFieldConfigDefaults is called multiple times for each data frame
-
-  const uniqueLinks = combinedLinks.reduce((accumulator: DataLink[], currentLink) => {
-    const existingLink = accumulator.find((link) => JSON.stringify(link) === JSON.stringify(currentLink));
-    if (!existingLink) {
-      accumulator.push(currentLink);
-    }
-
-    return accumulator;
-  }, []);
-
-  return uniqueLinks;
+  return [...dataSourceLinks, ...defaultLinks];
 }
 
 // config -> from DS
 // defaults -> from Panel config
 export function setFieldConfigDefaults(config: FieldConfig, defaults: FieldConfig, context: FieldOverrideEnv) {
+  // For cases where we have links on the datasource config and the panel config, we need to merge them
+  if (config.links && defaults.links) {
+    config.links = mergeLinks(config.links, defaults.links);
+  }
   for (const fieldConfigProperty of context.fieldConfigRegistry.list()) {
-    // For cases where we have links on the datasource config and the panel config, we need to merge them
-    if (config.links && defaults.links) {
-      config.links = mergeLinks(config.links, defaults.links);
-    }
-
     if (fieldConfigProperty.isCustom && !config.custom) {
       config.custom = {};
     }

--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -290,10 +290,42 @@ export function setDynamicConfigValue(config: FieldConfig, value: DynamicConfigV
   }
 }
 
+/**
+ * Merge the links from the ds config and the panel config
+ * @param configLinks coming from the datasource
+ * @param defaultLinks coming from the panel config
+ * @returns unique merged links
+ */
+
+function mergeLinks(configLinks: DataLink[], defaultLinks: DataLink[]) {
+  // Combine the config links and the default links
+  const combinedLinks = [...configLinks, ...defaultLinks];
+
+  // Deduplicate the combined array of links
+  // note: this is necessary to prevent default links from being displayed multiple times
+  // as setFieldConfigDefaults is called multiple times for each data frame
+
+  const uniqueLinks = combinedLinks.reduce((accumulator: DataLink[], currentLink) => {
+    const existingLink = accumulator.find((link) => JSON.stringify(link) === JSON.stringify(currentLink));
+    if (!existingLink) {
+      accumulator.push(currentLink);
+    }
+
+    return accumulator;
+  }, []);
+
+  return uniqueLinks;
+}
+
 // config -> from DS
 // defaults -> from Panel config
 export function setFieldConfigDefaults(config: FieldConfig, defaults: FieldConfig, context: FieldOverrideEnv) {
   for (const fieldConfigProperty of context.fieldConfigRegistry.list()) {
+    // For cases where we have links on the datasource config and the panel config, we need to merge them
+    if (config.links && defaults.links) {
+      config.links = mergeLinks(config.links, defaults.links);
+    }
+
     if (fieldConfigProperty.isCustom && !config.custom) {
       config.custom = {};
     }

--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -290,24 +290,13 @@ export function setDynamicConfigValue(config: FieldConfig, value: DynamicConfigV
   }
 }
 
-/**
- * Merge the links from the data source config and the panel config
- * @param dataSourceLinks coming from the datasource
- * @param defaultLinks coming from the panel config
- * @returns merged links
- */
-
-function mergeLinks(dataSourceLinks: DataLink[], defaultLinks: DataLink[]) {
-  // Combine the config links and the default links
-  return [...dataSourceLinks, ...defaultLinks];
-}
-
 // config -> from DS
 // defaults -> from Panel config
 export function setFieldConfigDefaults(config: FieldConfig, defaults: FieldConfig, context: FieldOverrideEnv) {
   // For cases where we have links on the datasource config and the panel config, we need to merge them
   if (config.links && defaults.links) {
-    config.links = mergeLinks(config.links, defaults.links);
+    // Combine the data source links and the panel default config links
+    config.links = [...config.links, ...defaults.links];
   }
   for (const fieldConfigProperty of context.fieldConfigRegistry.list()) {
     if (fieldConfigProperty.isCustom && !config.custom) {

--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -291,7 +291,7 @@ export function setDynamicConfigValue(config: FieldConfig, value: DynamicConfigV
 }
 
 /**
- * Merge the links from the ds config and the panel config
+ * Merge the links from the data source config and the panel config
  * @param configLinks coming from the datasource
  * @param defaultLinks coming from the panel config
  * @returns unique merged links


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Merge data links when they come from datasource config and panel config

https://user-images.githubusercontent.com/239999/230040963-833fbb1d-2ee4-48ab-9c3a-6f88080f339b.mp4

**How to test this bug?**

Follow the instructions from the escalation https://github.com/grafana/support-escalations/issues/5036 

**Who is this feature for?**

Everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #26762

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
