### PR TITLE
Tempo: Encode IDs as hexadecimal when downloading traces

### DIFF
--- a/public/app/plugins/datasource/tempo/mockJsonResponse.json
+++ b/public/app/plugins/datasource/tempo/mockJsonResponse.json
@@ -46,9 +46,9 @@
           "instrumentationLibrary": {},
           "spans": [
             {
-              "traceId": "AAAAAAAAAABguiq7RPE+rg==",
-              "spanId": "cmteMBAvwNA=",
-              "parentSpanId": "OY8PIaPbma4=",
+              "traceId": "000000000000000060ba2abb44f13eae",
+              "spanId": "726b5e30102fc0d0",
+              "parentSpanId": "398f0f21a3db99ae",
               "name": "HTTP GET - root",
               "kind": "SPAN_KIND_SERVER",
               "startTimeUnixNano": "1627471657255809000",
@@ -156,8 +156,8 @@
           "instrumentationLibrary": {},
           "spans": [
             {
-              "traceId": "AAAAAAAAAABguiq7RPE+rg==",
-              "spanId": "GVdnHErYWoo=",
+              "traceId": "000000000000000060ba2abb44f13eae",
+              "spanId": "1957671c4ad85a8a",
               "parentSpanId": "WgdmnUQaoyY=",
               "name": "HTTP Client",
               "startTimeUnixNano": "1627471657251425000",
@@ -214,8 +214,8 @@
           "instrumentationLibrary": {},
           "spans": [
             {
-              "traceId": "AAAAAAAAAABguiq7RPE+rg==",
-              "spanId": "YLoqu0TxPq4=",
+              "traceId": "000000000000000060ba2abb44f13eae",
+              "spanId": "60ba2abb44f13eae",
               "name": "HTTP Client",
               "startTimeUnixNano": "1627471657247632000",
               "endTimeUnixNano": "1627471657260233000",
@@ -285,9 +285,9 @@
           "instrumentationLibrary": {},
           "spans": [
             {
-              "traceId": "AAAAAAAAAABguiq7RPE+rg==",
-              "spanId": "VzhhbsaOedI=",
-              "parentSpanId": "YLoqu0TxPq4=",
+              "traceId": "000000000000000060ba2abb44f13eae",
+              "spanId": "5738616ec68e79d2",
+              "parentSpanId": "60ba2abb44f13eae",
               "name": "HTTP GET",
               "kind": "SPAN_KIND_CLIENT",
               "startTimeUnixNano": "1627471657247674000",
@@ -530,9 +530,9 @@
           "instrumentationLibrary": {},
           "spans": [
             {
-              "traceId": "AAAAAAAAAABguiq7RPE+rg==",
-              "spanId": "OY8PIaPbma4=",
-              "parentSpanId": "GVdnHErYWoo=",
+              "traceId": "000000000000000060ba2abb44f13eae",
+              "spanId": "398f0f21a3db99ae",
+              "parentSpanId": "1957671c4ad85a8a",
               "name": "HTTP GET",
               "kind": "SPAN_KIND_CLIENT",
               "startTimeUnixNano": "1627471657251445000",
@@ -775,9 +775,9 @@
           "instrumentationLibrary": {},
           "spans": [
             {
-              "traceId": "AAAAAAAAAABguiq7RPE+rg==",
-              "spanId": "WgdmnUQaoyY=",
-              "parentSpanId": "VzhhbsaOedI=",
+              "traceId": "000000000000000060ba2abb44f13eae",
+              "spanId": "5a07669d441aa326",
+              "parentSpanId": "5738616ec68e79d2",
               "name": "HTTP GET - root",
               "kind": "SPAN_KIND_SERVER",
               "startTimeUnixNano": "1627471657251228000",

--- a/public/app/plugins/datasource/tempo/resultTransformer.ts
+++ b/public/app/plugins/datasource/tempo/resultTransformer.ts
@@ -274,7 +274,7 @@ export function transformFromOTLP(
       for (const librarySpan of data.instrumentationLibrarySpans) {
         for (const span of librarySpan.spans) {
           frame.add({
-            traceID: span.traceId.length > 16 ? span.traceId.slice(16) : span.traceID,
+            traceID: span.traceId.length > 16 ? span.traceId.slice(16) : span.traceId,
             spanID: span.spanId,
             parentSpanID: span.parentSpanId || '',
             operationName: span.name || '',

--- a/public/app/plugins/datasource/tempo/resultTransformer.ts
+++ b/public/app/plugins/datasource/tempo/resultTransformer.ts
@@ -116,29 +116,6 @@ export function transformTraceList(
   return response;
 }
 
-// Don't forget to change the backend code when the id representation changed
-function transformBase64IDToHexString(base64: string) {
-  const raw = atob(base64);
-  let result = '';
-  for (let i = 0; i < raw.length; i++) {
-    const hex = raw.charCodeAt(i).toString(16);
-    result += hex.length === 2 ? hex : '0' + hex;
-  }
-
-  return result.length > 16 ? result.slice(16) : result;
-}
-
-function transformHexStringToBase64ID(hex: string) {
-  const hexArray = hex.match(/\w{2}/g) || [];
-  return btoa(
-    hexArray
-      .map(function (a) {
-        return String.fromCharCode(parseInt(a, 16));
-      })
-      .join('')
-  );
-}
-
 function getAttributeValue(value: collectorTypes.opentelemetryProto.common.v1.AnyValue): any {
   if (value.stringValue) {
     return value.stringValue;
@@ -297,9 +274,9 @@ export function transformFromOTLP(
       for (const librarySpan of data.instrumentationLibrarySpans) {
         for (const span of librarySpan.spans) {
           frame.add({
-            traceID: transformBase64IDToHexString(span.traceId),
-            spanID: transformBase64IDToHexString(span.spanId),
-            parentSpanID: transformBase64IDToHexString(span.parentSpanId || ''),
+            traceID: span.traceId.length > 16 ? span.traceId.slice(16) : span.traceID,
+            spanID: span.spanId,
+            parentSpanID: span.parentSpanId || '',
             operationName: span.name || '',
             serviceName,
             serviceTags,
@@ -376,10 +353,10 @@ export function transformToOTLP(data: MutableDataFrame): {
     }
 
     result.batches[batchIndex].instrumentationLibrarySpans[0].spans.push({
-      traceId: transformHexStringToBase64ID(span.traceID.padStart(32, '0')),
-      spanId: transformHexStringToBase64ID(span.spanID),
+      traceId: span.traceID.padStart(32, '0'),
+      spanId: span.spanID,
+      parentSpanId: span.parentSpanID || '',
       traceState: '',
-      parentSpanId: transformHexStringToBase64ID(span.parentSpanID || ''),
       name: span.operationName,
       kind: getOTLPSpanKind(span.tags) as any,
       startTimeUnixNano: span.startTime * 1000000,

--- a/public/app/plugins/datasource/tempo/testResponse.ts
+++ b/public/app/plugins/datasource/tempo/testResponse.ts
@@ -2137,9 +2137,9 @@ export const otlpResponse = {
         {
           spans: [
             {
-              traceId: 'AAAAAAAAAABguiq7RPE+rg==',
-              spanId: 'cmteMBAvwNA=',
-              parentSpanId: 'OY8PIaPbma4=',
+              traceId: '000000000000000060ba2abb44f13eae',
+              spanId: '726b5e30102fc0d0',
+              parentSpanId: '398f0f21a3db99ae',
               name: 'HTTP GET - root',
               kind: 'SPAN_KIND_CLIENT',
               startTimeUnixNano: 1627471657255809000,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

While downloading traces as json the ids are getting converted to base64. This change will remove the conversion and export ids in hex format instead. So that encoding remain consistent across.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #63003 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
