### PR TITLE
CI: Split `/bin/build artifacts *` subcommand

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4171,7 +4171,7 @@ steps:
   image: golang:1.20.1
   name: compile-build-cmd
 - commands:
-  - ./bin/build artifacts publish --security --tag $${DRONE_TAG} --src-bucket $${PRERELEASE_BUCKET}
+  - ./bin/build artifacts packages --security --tag $${DRONE_TAG} --src-bucket $${PRERELEASE_BUCKET}
   depends_on:
   - compile-build-cmd
   environment:
@@ -4183,10 +4183,33 @@ steps:
       from_secret: prerelease_bucket
     SECURITY_DEST_BUCKET:
       from_secret: security_dest_bucket
+  image: grafana/grafana-ci-deploy:1.3.3
+  name: publish-artifacts
+- commands:
+  - ./bin/build artifacts storybook --security --tag $${DRONE_TAG} --src-bucket $${PRERELEASE_BUCKET}
+  depends_on:
+  - compile-build-cmd
+  environment:
+    GCP_KEY:
+      from_secret: gcp_key
+  image: grafana/grafana-ci-deploy:1.3.3
+  name: publish-storybook
+- commands:
+  - ./bin/build artifacts static-assets --security --tag $${DRONE_TAG} --src-bucket
+    $${PRERELEASE_BUCKET}
+  depends_on:
+  - compile-build-cmd
+  environment:
+    GCP_KEY:
+      from_secret: gcp_key
+    PRERELEASE_BUCKET:
+      from_secret: prerelease_bucket
+    SECURITY_DEST_BUCKET:
+      from_secret: security_dest_bucket
     STATIC_ASSET_EDITIONS:
       from_secret: static_asset_editions
   image: grafana/grafana-ci-deploy:1.3.3
-  name: publish-artifacts
+  name: publish-static-assets
 trigger:
   event:
   - promote
@@ -4222,7 +4245,7 @@ steps:
   image: golang:1.20.1
   name: compile-build-cmd
 - commands:
-  - ./bin/build artifacts publish --tag $${DRONE_TAG} --src-bucket $${PRERELEASE_BUCKET}
+  - ./bin/build artifacts packages --tag $${DRONE_TAG} --src-bucket $${PRERELEASE_BUCKET}
   depends_on:
   - compile-build-cmd
   environment:
@@ -4234,10 +4257,32 @@ steps:
       from_secret: prerelease_bucket
     SECURITY_DEST_BUCKET:
       from_secret: security_dest_bucket
+  image: grafana/grafana-ci-deploy:1.3.3
+  name: publish-artifacts
+- commands:
+  - ./bin/build artifacts storybook --tag $${DRONE_TAG} --src-bucket $${PRERELEASE_BUCKET}
+  depends_on:
+  - compile-build-cmd
+  environment:
+    GCP_KEY:
+      from_secret: gcp_key
+  image: grafana/grafana-ci-deploy:1.3.3
+  name: publish-storybook
+- commands:
+  - ./bin/build artifacts static-assets --tag $${DRONE_TAG} --src-bucket $${PRERELEASE_BUCKET}
+  depends_on:
+  - compile-build-cmd
+  environment:
+    GCP_KEY:
+      from_secret: gcp_key
+    PRERELEASE_BUCKET:
+      from_secret: prerelease_bucket
+    SECURITY_DEST_BUCKET:
+      from_secret: security_dest_bucket
     STATIC_ASSET_EDITIONS:
       from_secret: static_asset_editions
   image: grafana/grafana-ci-deploy:1.3.3
-  name: publish-artifacts
+  name: publish-static-assets
 trigger:
   event:
   - promote
@@ -6753,6 +6798,6 @@ kind: secret
 name: enterprise2_security_prefix
 ---
 kind: signature
-hmac: 54bded4dc7c3ffbbf3859a4f8f6364f59f3b6e0696152a0b835211eca7119e50
+hmac: 8aab4d7ca003a3e67102ec7559baf04868aca3569d2971747ebef4eb26d52480
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -2408,7 +2408,7 @@ steps:
   - build-frontend-packages
   environment:
     GCP_KEY:
-      from_secret: gcp_ke
+      from_secret: gcp_key
     PRERELEASE_BUCKET:
       from_secret: prerelease_bucket
   image: grafana/build-container:1.7.2
@@ -6798,6 +6798,6 @@ kind: secret
 name: enterprise2_security_prefix
 ---
 kind: signature
-hmac: 160d9fceeb892082d85090e1e1a83b1e3c92d9856072da8eeda973b8122f5276
+hmac: 8aab4d7ca003a3e67102ec7559baf04868aca3569d2971747ebef4eb26d52480
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -2408,7 +2408,7 @@ steps:
   - build-frontend-packages
   environment:
     GCP_KEY:
-      from_secret: gcp_key
+      from_secret: gcp_ke
     PRERELEASE_BUCKET:
       from_secret: prerelease_bucket
   image: grafana/build-container:1.7.2
@@ -6798,6 +6798,6 @@ kind: secret
 name: enterprise2_security_prefix
 ---
 kind: signature
-hmac: 8aab4d7ca003a3e67102ec7559baf04868aca3569d2971747ebef4eb26d52480
+hmac: 160d9fceeb892082d85090e1e1a83b1e3c92d9856072da8eeda973b8122f5276
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -4186,17 +4186,7 @@ steps:
   image: grafana/grafana-ci-deploy:1.3.3
   name: publish-artifacts
 - commands:
-  - ./bin/build artifacts storybook --security --tag $${DRONE_TAG} --src-bucket $${PRERELEASE_BUCKET}
-  depends_on:
-  - compile-build-cmd
-  environment:
-    GCP_KEY:
-      from_secret: gcp_key
-  image: grafana/grafana-ci-deploy:1.3.3
-  name: publish-storybook
-- commands:
-  - ./bin/build artifacts static-assets --security --tag $${DRONE_TAG} --src-bucket
-    $${PRERELEASE_BUCKET}
+  - ./bin/build artifacts static-assets --tag ${DRONE_TAG}
   depends_on:
   - compile-build-cmd
   environment:
@@ -4204,8 +4194,6 @@ steps:
       from_secret: gcp_key
     PRERELEASE_BUCKET:
       from_secret: prerelease_bucket
-    SECURITY_DEST_BUCKET:
-      from_secret: security_dest_bucket
     STATIC_ASSET_EDITIONS:
       from_secret: static_asset_editions
   image: grafana/grafana-ci-deploy:1.3.3
@@ -4260,16 +4248,7 @@ steps:
   image: grafana/grafana-ci-deploy:1.3.3
   name: publish-artifacts
 - commands:
-  - ./bin/build artifacts storybook --tag $${DRONE_TAG} --src-bucket $${PRERELEASE_BUCKET}
-  depends_on:
-  - compile-build-cmd
-  environment:
-    GCP_KEY:
-      from_secret: gcp_key
-  image: grafana/grafana-ci-deploy:1.3.3
-  name: publish-storybook
-- commands:
-  - ./bin/build artifacts static-assets --tag $${DRONE_TAG} --src-bucket $${PRERELEASE_BUCKET}
+  - ./bin/build artifacts static-assets --tag ${DRONE_TAG}
   depends_on:
   - compile-build-cmd
   environment:
@@ -4277,12 +4256,21 @@ steps:
       from_secret: gcp_key
     PRERELEASE_BUCKET:
       from_secret: prerelease_bucket
-    SECURITY_DEST_BUCKET:
-      from_secret: security_dest_bucket
     STATIC_ASSET_EDITIONS:
       from_secret: static_asset_editions
   image: grafana/grafana-ci-deploy:1.3.3
   name: publish-static-assets
+- commands:
+  - ./bin/build artifacts storybook --tag ${DRONE_TAG}
+  depends_on:
+  - compile-build-cmd
+  environment:
+    GCP_KEY:
+      from_secret: gcp_key
+    PRERELEASE_BUCKET:
+      from_secret: prerelease_bucket
+  image: grafana/grafana-ci-deploy:1.3.3
+  name: publish-storybook
 trigger:
   event:
   - promote
@@ -6798,6 +6786,6 @@ kind: secret
 name: enterprise2_security_prefix
 ---
 kind: signature
-hmac: 8aab4d7ca003a3e67102ec7559baf04868aca3569d2971747ebef4eb26d52480
+hmac: 421b968fc475a71ac3367a4f9d2da3b6ff68208c04d28d5fd1074cf03688a52a
 
 ...

--- a/pkg/build/cmd/flags.go
+++ b/pkg/build/cmd/flags.go
@@ -51,4 +51,22 @@ var (
 		Name:  "tag",
 		Usage: "Grafana version tag",
 	}
+	securityFlag = cli.BoolFlag{
+		Name:  "security",
+		Usage: "Security release",
+	}
+	srcFlag = cli.StringFlag{
+		Name:  "src-bucket",
+		Value: "grafana-prerelease",
+		Usage: "Google Cloud Storage bucket",
+	}
+	securityDestBucketFlag = cli.StringFlag{
+		Name:  "security-dest-bucket",
+		Usage: "Google Cloud Storage bucket for security packages (or $SECURITY_DEST_BUCKET)",
+	}
+	destFlag = cli.StringFlag{
+		Name:  "dest-bucket",
+		Value: "grafana-downloads",
+		Usage: "Google Cloud Storage bucket for published packages",
+	}
 )

--- a/pkg/build/cmd/main.go
+++ b/pkg/build/cmd/main.go
@@ -203,9 +203,13 @@ func main() {
 					Action: PublishStorybookAction,
 					Flags: []cli.Flag{
 						&editionFlag,
-						&securityFlag,
 						&tagFlag,
 						&srcFlag,
+						&cli.StringFlag{
+							Name:  "storybook-bucket",
+							Value: "grafana-storybook",
+							Usage: "Google Cloud Storage bucket for storybooks",
+						},
 					},
 				},
 				{

--- a/pkg/build/cmd/main.go
+++ b/pkg/build/cmd/main.go
@@ -198,8 +198,68 @@ func main() {
 			Usage: "Handle Grafana artifacts",
 			Subcommands: cli.Commands{
 				{
-					Name:   "publish",
-					Usage:  "Publish Grafana artifacts",
+					Name:   "storybook",
+					Usage:  "Publish Grafana storybook",
+					Action: PublishStorybookAction,
+					Flags: []cli.Flag{
+						&editionFlag,
+						&cli.BoolFlag{
+							Name:  "security",
+							Usage: "Security release",
+						},
+						&cli.StringFlag{
+							Name:  "tag",
+							Usage: "Grafana version tag",
+						},
+						&cli.StringFlag{
+							Name:  "src-bucket",
+							Value: "grafana-prerelease",
+							Usage: "Google Cloud Storage bucket",
+						},
+					},
+				},
+				{
+					Name:   "static-assets",
+					Usage:  "Publish Grafana static assets",
+					Action: PublishStaticAssetsAction,
+					Flags: []cli.Flag{
+						&editionFlag,
+						&cli.BoolFlag{
+							Name:  "security",
+							Usage: "Security release",
+						},
+						&cli.StringFlag{
+							Name:  "security-dest-bucket",
+							Usage: "Google Cloud Storage bucket for security packages (or $SECURITY_DEST_BUCKET)",
+						},
+						&cli.StringFlag{
+							Name:  "tag",
+							Usage: "Grafana version tag",
+						},
+						&cli.StringFlag{
+							Name:  "src-bucket",
+							Value: "grafana-prerelease",
+							Usage: "Google Cloud Storage bucket",
+						},
+						&cli.StringFlag{
+							Name:  "dest-bucket",
+							Value: "grafana-downloads",
+							Usage: "Google Cloud Storage bucket for published packages",
+						},
+						&cli.StringFlag{
+							Name:  "static-assets-bucket",
+							Value: "grafana-static-assets",
+							Usage: "Google Cloud Storage bucket for static assets",
+						},
+						&cli.StringSliceFlag{
+							Name:  "static-asset-editions",
+							Usage: "All the editions of the static assets (or $STATIC_ASSET_EDITIONS)",
+						},
+					},
+				},
+				{
+					Name:   "packages",
+					Usage:  "Publish Grafana packages",
 					Action: PublishArtifactsAction,
 					Flags: []cli.Flag{
 						&editionFlag,
@@ -233,20 +293,6 @@ func main() {
 						&cli.StringFlag{
 							Name:  "enterprise2-security-prefix",
 							Usage: "Bucket path prefix for enterprise2 security releases (or $ENTERPRISE2_SECURITY_PREFIX)",
-						},
-						&cli.StringFlag{
-							Name:  "static-assets-bucket",
-							Value: "grafana-static-assets",
-							Usage: "Google Cloud Storage bucket for static assets",
-						},
-						&cli.StringSliceFlag{
-							Name:  "static-asset-editions",
-							Usage: "All the editions of the static assets (or $STATIC_ASSET_EDITIONS)",
-						},
-						&cli.StringFlag{
-							Name:  "storybook-bucket",
-							Value: "grafana-storybook",
-							Usage: "Google Cloud Storage bucket for storybooks",
 						},
 					},
 				},

--- a/pkg/build/cmd/main.go
+++ b/pkg/build/cmd/main.go
@@ -245,6 +245,10 @@ func main() {
 						&tagFlag,
 						&srcFlag,
 						&destFlag,
+						&cli.StringSliceFlag{
+							Name:  "artifacts-editions",
+							Usage: "Editions for which the artifacts should be delivered (oss,enterprise,enterprise2), (or $ARTIFACTS_EDITIONS)",
+						},
 						&cli.StringFlag{
 							Name:  "enterprise2-dest-bucket",
 							Value: "grafana-downloads-enterprise2",

--- a/pkg/build/cmd/main.go
+++ b/pkg/build/cmd/main.go
@@ -203,19 +203,9 @@ func main() {
 					Action: PublishStorybookAction,
 					Flags: []cli.Flag{
 						&editionFlag,
-						&cli.BoolFlag{
-							Name:  "security",
-							Usage: "Security release",
-						},
-						&cli.StringFlag{
-							Name:  "tag",
-							Usage: "Grafana version tag",
-						},
-						&cli.StringFlag{
-							Name:  "src-bucket",
-							Value: "grafana-prerelease",
-							Usage: "Google Cloud Storage bucket",
-						},
+						&securityFlag,
+						&tagFlag,
+						&srcFlag,
 					},
 				},
 				{
@@ -224,28 +214,11 @@ func main() {
 					Action: PublishStaticAssetsAction,
 					Flags: []cli.Flag{
 						&editionFlag,
-						&cli.BoolFlag{
-							Name:  "security",
-							Usage: "Security release",
-						},
-						&cli.StringFlag{
-							Name:  "security-dest-bucket",
-							Usage: "Google Cloud Storage bucket for security packages (or $SECURITY_DEST_BUCKET)",
-						},
-						&cli.StringFlag{
-							Name:  "tag",
-							Usage: "Grafana version tag",
-						},
-						&cli.StringFlag{
-							Name:  "src-bucket",
-							Value: "grafana-prerelease",
-							Usage: "Google Cloud Storage bucket",
-						},
-						&cli.StringFlag{
-							Name:  "dest-bucket",
-							Value: "grafana-downloads",
-							Usage: "Google Cloud Storage bucket for published packages",
-						},
+						&securityFlag,
+						&securityDestBucketFlag,
+						&tagFlag,
+						&srcFlag,
+						&destFlag,
 						&cli.StringFlag{
 							Name:  "static-assets-bucket",
 							Value: "grafana-static-assets",
@@ -263,28 +236,11 @@ func main() {
 					Action: PublishArtifactsAction,
 					Flags: []cli.Flag{
 						&editionFlag,
-						&cli.BoolFlag{
-							Name:  "security",
-							Usage: "Security release",
-						},
-						&cli.StringFlag{
-							Name:  "security-dest-bucket",
-							Usage: "Google Cloud Storage bucket for security packages (or $SECURITY_DEST_BUCKET)",
-						},
-						&cli.StringFlag{
-							Name:  "tag",
-							Usage: "Grafana version tag",
-						},
-						&cli.StringFlag{
-							Name:  "src-bucket",
-							Value: "grafana-prerelease",
-							Usage: "Google Cloud Storage bucket",
-						},
-						&cli.StringFlag{
-							Name:  "dest-bucket",
-							Value: "grafana-downloads",
-							Usage: "Google Cloud Storage bucket for published packages",
-						},
+						&securityFlag,
+						&securityDestBucketFlag,
+						&tagFlag,
+						&srcFlag,
+						&destFlag,
 						&cli.StringFlag{
 							Name:  "enterprise2-dest-bucket",
 							Value: "grafana-downloads-enterprise2",

--- a/pkg/build/cmd/main.go
+++ b/pkg/build/cmd/main.go
@@ -247,6 +247,7 @@ func main() {
 						&destFlag,
 						&cli.StringSliceFlag{
 							Name:  "artifacts-editions",
+							Value: cli.NewStringSlice("oss", "enterprise", "enterprise2"),
 							Usage: "Editions for which the artifacts should be delivered (oss,enterprise,enterprise2), (or $ARTIFACTS_EDITIONS)",
 						},
 						&cli.StringFlag{

--- a/pkg/build/cmd/publishartifacts.go
+++ b/pkg/build/cmd/publishartifacts.go
@@ -2,13 +2,13 @@ package main
 
 import (
 	"fmt"
-	"github.com/grafana/grafana/pkg/build/env"
-	"github.com/grafana/grafana/pkg/build/gcloud/storage"
 	"log"
 	"path/filepath"
 	"strings"
 
+	"github.com/grafana/grafana/pkg/build/env"
 	"github.com/grafana/grafana/pkg/build/gcloud"
+	"github.com/grafana/grafana/pkg/build/gcloud/storage"
 	"github.com/urfave/cli/v2"
 )
 

--- a/pkg/build/cmd/publishartifacts.go
+++ b/pkg/build/cmd/publishartifacts.go
@@ -2,61 +2,17 @@ package main
 
 import (
 	"fmt"
+	"github.com/grafana/grafana/pkg/build/env"
+	"github.com/grafana/grafana/pkg/build/gcloud/storage"
 	"log"
-	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
 	"github.com/grafana/grafana/pkg/build/gcloud"
-	"github.com/grafana/grafana/pkg/build/versions"
 	"github.com/urfave/cli/v2"
 )
 
-type publishConfig struct {
-	tag                       string
-	srcBucket                 string
-	destBucket                string
-	enterprise2DestBucket     string
-	enterprise2SecurityPrefix string
-	staticAssetsBucket        string
-	staticAssetEditions       []string
-	storybookBucket           string
-	security                  bool
-}
-
-// requireListWithEnvFallback first checks the CLI for a flag with the required
-// name. If this is empty, it  falls back to taking the environment variable.
-// Sadly, we cannot use cli.Flag.EnvVars for this due to it potentially leaking
-// environment variables as default values in usage-errors.
-func requireListWithEnvFallback(cctx *cli.Context, name string, envName string) ([]string, error) {
-	result := cctx.StringSlice(name)
-	if len(result) == 0 {
-		for _, v := range strings.Split(os.Getenv(envName), ",") {
-			value := strings.TrimSpace(v)
-			if value != "" {
-				result = append(result, value)
-			}
-		}
-	}
-	if len(result) == 0 {
-		return nil, cli.Exit(fmt.Sprintf("Required flag (%s) or environment variable (%s) not set", name, envName), 1)
-	}
-	return result, nil
-}
-
-func requireStringWithEnvFallback(cctx *cli.Context, name string, envName string) (string, error) {
-	result := cctx.String(name)
-	if result == "" {
-		result = os.Getenv(envName)
-	}
-	if result == "" {
-		return "", cli.Exit(fmt.Sprintf("Required flag (%s) or environment variable (%s) not set", name, envName), 1)
-	}
-	return result, nil
-}
-
-// Action implements the sub-command "publish-artifacts".
+// PublishArtifactsAction Action implements the sub-command "publish-artifacts".
 func PublishArtifactsAction(c *cli.Context) error {
 	if c.NArg() > 0 {
 		if err := cli.ShowSubcommandHelp(c); err != nil {
@@ -65,15 +21,11 @@ func PublishArtifactsAction(c *cli.Context) error {
 		return cli.Exit("", 1)
 	}
 
-	staticAssetEditions, err := requireListWithEnvFallback(c, "static-asset-editions", "STATIC_ASSET_EDITIONS")
+	securityDestBucket, err := env.RequireStringWithEnvFallback(c, "security-dest-bucket", "SECURITY_DEST_BUCKET")
 	if err != nil {
 		return err
 	}
-	securityDestBucket, err := requireStringWithEnvFallback(c, "security-dest-bucket", "SECURITY_DEST_BUCKET")
-	if err != nil {
-		return err
-	}
-	enterprise2SecurityPrefix, err := requireStringWithEnvFallback(c, "enterprise2-security-prefix", "ENTERPRISE2_SECURITY_PREFIX")
+	enterprise2SecurityPrefix, err := env.RequireStringWithEnvFallback(c, "enterprise2-security-prefix", "ENTERPRISE2_SECURITY_PREFIX")
 	if err != nil {
 		return err
 	}
@@ -87,9 +39,6 @@ func PublishArtifactsAction(c *cli.Context) error {
 		destBucket:                c.String("dest-bucket"),
 		enterprise2DestBucket:     c.String("enterprise2-dest-bucket"),
 		enterprise2SecurityPrefix: enterprise2SecurityPrefix,
-		staticAssetsBucket:        c.String("static-assets-bucket"),
-		staticAssetEditions:       staticAssetEditions,
-		storybookBucket:           c.String("storybook-bucket"),
 		security:                  c.Bool("security"),
 		tag:                       strings.TrimPrefix(c.String("tag"), "v"),
 	}
@@ -98,14 +47,6 @@ func PublishArtifactsAction(c *cli.Context) error {
 		cfg.destBucket = securityDestBucket
 	}
 
-	err = copyStaticAssets(cfg)
-	if err != nil {
-		return err
-	}
-	err = copyStorybook(cfg)
-	if err != nil {
-		return err
-	}
 	err = copyDownloads(cfg)
 	if err != nil {
 		return err
@@ -114,54 +55,6 @@ func PublishArtifactsAction(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	return nil
-}
-
-func copyStaticAssets(cfg publishConfig) error {
-	for _, edition := range cfg.staticAssetEditions {
-		log.Printf("Copying static assets for %s", edition)
-		srcURL := fmt.Sprintf("%s/artifacts/static-assets/%s/%s/*", cfg.srcBucket, edition, cfg.tag)
-		destURL := fmt.Sprintf("%s/%s/%s/", cfg.staticAssetsBucket, edition, cfg.tag)
-		err := gcsCopy("static assets", srcURL, destURL)
-		if err != nil {
-			return fmt.Errorf("error copying static assets, %q", err)
-		}
-	}
-	log.Printf("Successfully copied static assets!")
-	return nil
-}
-
-func copyStorybook(cfg publishConfig) error {
-	if cfg.security {
-		log.Printf("skipping storybook copy - not needed for a security release")
-		return nil
-	}
-	log.Printf("Copying storybooks...")
-	srcURL := fmt.Sprintf("%s/artifacts/storybook/v%s/*", cfg.srcBucket, cfg.tag)
-	destURL := fmt.Sprintf("%s/%s", cfg.storybookBucket, cfg.tag)
-	err := gcsCopy("storybook", srcURL, destURL)
-	if err != nil {
-		return fmt.Errorf("error copying storybook. %q", err)
-	}
-	stableVersion, err := versions.GetLatestVersion(versions.LatestStableVersionURL)
-	if err != nil {
-		return err
-	}
-	isLatest, err := versions.IsGreaterThanOrEqual(cfg.tag, stableVersion)
-	if err != nil {
-		return err
-	}
-	if isLatest {
-		log.Printf("Copying storybooks to latest...")
-		srcURL := fmt.Sprintf("%s/artifacts/storybook/v%s/*", cfg.srcBucket, cfg.tag)
-		destURL := fmt.Sprintf("%s/latest", cfg.storybookBucket)
-		err := gcsCopy("storybook (latest)", srcURL, destURL)
-		if err != nil {
-			return fmt.Errorf("error copying storybook to latest. %q", err)
-		}
-	}
-
-	log.Printf("Successfully copied storybook!")
 	return nil
 }
 
@@ -175,7 +68,7 @@ func copyDownloads(cfg publishConfig) error {
 			destURL = filepath.Join(destURL, "release")
 		}
 		log.Printf("Copying downloads for %s, from %s bucket to %s bucket", edition, srcURL, destURL)
-		err := gcsCopy("downloads", srcURL, destURL)
+		err := storage.GCSCopy("downloads", srcURL, destURL)
 		if err != nil {
 			return fmt.Errorf("error copying downloads, %q", err)
 		}
@@ -192,20 +85,9 @@ func copyEnterprise2Downloads(cfg publishConfig) error {
 	srcURL := fmt.Sprintf("%s/artifacts/downloads-enterprise2/v%s/enterprise2/release/*", cfg.srcBucket, cfg.tag)
 	destURL := fmt.Sprintf("%s/enterprise2/%srelease", cfg.enterprise2DestBucket, prefix)
 	log.Printf("Copying downloads for enterprise2, from %s bucket to %s bucket", srcURL, destURL)
-	err := gcsCopy("enterprise2 downloads", srcURL, destURL)
+	err := storage.GCSCopy("enterprise2 downloads", srcURL, destURL)
 	if err != nil {
 		return fmt.Errorf("error copying ")
-	}
-	return nil
-}
-
-func gcsCopy(desc, src, dest string) error {
-	args := strings.Split(fmt.Sprintf("-m cp -r gs://%s gs://%s", src, dest), " ")
-	// nolint:gosec
-	cmd := exec.Command("gsutil", args...)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("failed to publish %s: %w\n%s", desc, err, out)
 	}
 	return nil
 }

--- a/pkg/build/cmd/publishconfig.go
+++ b/pkg/build/cmd/publishconfig.go
@@ -1,0 +1,13 @@
+package main
+
+type publishConfig struct {
+	tag                       string
+	srcBucket                 string
+	destBucket                string
+	enterprise2DestBucket     string
+	enterprise2SecurityPrefix string
+	staticAssetsBucket        string
+	staticAssetEditions       []string
+	storybookBucket           string
+	security                  bool
+}

--- a/pkg/build/cmd/publishstaticassets.go
+++ b/pkg/build/cmd/publishstaticassets.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"fmt"
+	"github.com/grafana/grafana/pkg/build/env"
+	"github.com/grafana/grafana/pkg/build/gcloud/storage"
+	"log"
+	"strings"
+
+	"github.com/grafana/grafana/pkg/build/gcloud"
+	"github.com/urfave/cli/v2"
+)
+
+// PublishStaticAssetsAction Action implements the sub-command "artifacts static-assets".
+func PublishStaticAssetsAction(c *cli.Context) error {
+	if c.NArg() > 0 {
+		if err := cli.ShowSubcommandHelp(c); err != nil {
+			return cli.Exit(err.Error(), 1)
+		}
+		return cli.Exit("", 1)
+	}
+
+	staticAssetEditions, err := env.RequireListWithEnvFallback(c, "static-asset-editions", "STATIC_ASSET_EDITIONS")
+	if err != nil {
+		return err
+	}
+	securityDestBucket, err := env.RequireStringWithEnvFallback(c, "security-dest-bucket", "SECURITY_DEST_BUCKET")
+	if err != nil {
+		return err
+	}
+
+	if err := gcloud.ActivateServiceAccount(); err != nil {
+		return fmt.Errorf("error connecting to gcp, %q", err)
+	}
+
+	cfg := publishConfig{
+		srcBucket:           c.String("src-bucket"),
+		destBucket:          c.String("dest-bucket"),
+		staticAssetsBucket:  c.String("static-assets-bucket"),
+		staticAssetEditions: staticAssetEditions,
+		security:            c.Bool("security"),
+		tag:                 strings.TrimPrefix(c.String("tag"), "v"),
+	}
+
+	if cfg.security {
+		cfg.destBucket = securityDestBucket
+	}
+
+	err = copyStaticAssets(cfg)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func copyStaticAssets(cfg publishConfig) error {
+	for _, edition := range cfg.staticAssetEditions {
+		log.Printf("Copying static assets for %s", edition)
+		srcURL := fmt.Sprintf("%s/artifacts/static-assets/%s/%s/*", cfg.srcBucket, edition, cfg.tag)
+		destURL := fmt.Sprintf("%s/%s/%s/", cfg.staticAssetsBucket, edition, cfg.tag)
+		err := storage.GCSCopy("static assets", srcURL, destURL)
+		if err != nil {
+			return fmt.Errorf("error copying static assets, %q", err)
+		}
+	}
+	log.Printf("Successfully copied static assets!")
+	return nil
+}

--- a/pkg/build/cmd/publishstaticassets.go
+++ b/pkg/build/cmd/publishstaticassets.go
@@ -32,7 +32,6 @@ func PublishStaticAssetsAction(c *cli.Context) error {
 		srcBucket:           c.String("src-bucket"),
 		staticAssetsBucket:  c.String("static-assets-bucket"),
 		staticAssetEditions: staticAssetEditions,
-		security:            c.Bool("security"),
 		tag:                 strings.TrimPrefix(c.String("tag"), "v"),
 	}
 

--- a/pkg/build/cmd/publishstaticassets.go
+++ b/pkg/build/cmd/publishstaticassets.go
@@ -2,12 +2,12 @@ package main
 
 import (
 	"fmt"
-	"github.com/grafana/grafana/pkg/build/env"
-	"github.com/grafana/grafana/pkg/build/gcloud/storage"
 	"log"
 	"strings"
 
+	"github.com/grafana/grafana/pkg/build/env"
 	"github.com/grafana/grafana/pkg/build/gcloud"
+	"github.com/grafana/grafana/pkg/build/gcloud/storage"
 	"github.com/urfave/cli/v2"
 )
 

--- a/pkg/build/cmd/publishstaticassets.go
+++ b/pkg/build/cmd/publishstaticassets.go
@@ -43,7 +43,7 @@ func PublishStaticAssetsAction(c *cli.Context) error {
 	bucket := gcs.Bucket(cfg.staticAssetsBucket)
 
 	for _, edition := range staticAssetEditions {
-		if err := gcs.CopyRemoteDir(c.Context, gcs.Bucket(fmt.Sprintf("%s", cfg.srcBucket)), fmt.Sprintf("artifacts/static-assets/%s/%s", edition, cfg.tag), bucket, fmt.Sprintf("%s/%s", edition, cfg.tag)); err != nil {
+		if err := gcs.CopyRemoteDir(c.Context, gcs.Bucket(cfg.srcBucket), fmt.Sprintf("artifacts/static-assets/%s/%s", edition, cfg.tag), bucket, fmt.Sprintf("%s/%s", edition, cfg.tag)); err != nil {
 			return err
 		}
 	}

--- a/pkg/build/cmd/publishstorybook.go
+++ b/pkg/build/cmd/publishstorybook.go
@@ -25,10 +25,9 @@ func PublishStorybookAction(c *cli.Context) error {
 	}
 
 	cfg := publishConfig{
-		srcBucket:       c.String("src-bucket"),
-		storybookBucket: c.String("storybook-bucket"),
-		security:        c.Bool("security"),
-		tag:             strings.TrimPrefix(c.String("tag"), "v"),
+		srcBucket: c.String("src-bucket"),
+		security:  c.Bool("security"),
+		tag:       strings.TrimPrefix(c.String("tag"), "v"),
 	}
 
 	err := copyStorybook(cfg)

--- a/pkg/build/cmd/publishstorybook.go
+++ b/pkg/build/cmd/publishstorybook.go
@@ -2,11 +2,11 @@ package main
 
 import (
 	"fmt"
-	"github.com/grafana/grafana/pkg/build/gcloud/storage"
 	"log"
 	"strings"
 
 	"github.com/grafana/grafana/pkg/build/gcloud"
+	"github.com/grafana/grafana/pkg/build/gcloud/storage"
 	"github.com/grafana/grafana/pkg/build/versions"
 	"github.com/urfave/cli/v2"
 )

--- a/pkg/build/cmd/publishstorybook.go
+++ b/pkg/build/cmd/publishstorybook.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"fmt"
+	"github.com/grafana/grafana/pkg/build/gcloud/storage"
+	"log"
+	"strings"
+
+	"github.com/grafana/grafana/pkg/build/gcloud"
+	"github.com/grafana/grafana/pkg/build/versions"
+	"github.com/urfave/cli/v2"
+)
+
+// PublishStorybookAction Action implements the sub-command "publish-artifacts".
+func PublishStorybookAction(c *cli.Context) error {
+	if c.NArg() > 0 {
+		if err := cli.ShowSubcommandHelp(c); err != nil {
+			return cli.Exit(err.Error(), 1)
+		}
+		return cli.Exit("", 1)
+	}
+
+	if err := gcloud.ActivateServiceAccount(); err != nil {
+		return fmt.Errorf("error connecting to gcp, %q", err)
+	}
+
+	cfg := publishConfig{
+		srcBucket:       c.String("src-bucket"),
+		storybookBucket: c.String("storybook-bucket"),
+		security:        c.Bool("security"),
+		tag:             strings.TrimPrefix(c.String("tag"), "v"),
+	}
+
+	err := copyStorybook(cfg)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func copyStorybook(cfg publishConfig) error {
+	if cfg.security {
+		log.Printf("skipping storybook copy - not needed for a security release")
+		return nil
+	}
+	log.Printf("Copying storybooks...")
+	srcURL := fmt.Sprintf("%s/artifacts/storybook/v%s/*", cfg.srcBucket, cfg.tag)
+	destURL := fmt.Sprintf("%s/%s", cfg.storybookBucket, cfg.tag)
+	err := storage.GCSCopy("storybook", srcURL, destURL)
+	if err != nil {
+		return fmt.Errorf("error copying storybook. %q", err)
+	}
+	stableVersion, err := versions.GetLatestVersion(versions.LatestStableVersionURL)
+	if err != nil {
+		return err
+	}
+	isLatest, err := versions.IsGreaterThanOrEqual(cfg.tag, stableVersion)
+	if err != nil {
+		return err
+	}
+	if isLatest {
+		log.Printf("Copying storybooks to latest...")
+		srcURL := fmt.Sprintf("%s/artifacts/storybook/v%s/*", cfg.srcBucket, cfg.tag)
+		destURL := fmt.Sprintf("%s/latest", cfg.storybookBucket)
+		err := storage.GCSCopy("storybook (latest)", srcURL, destURL)
+		if err != nil {
+			return fmt.Errorf("error copying storybook to latest. %q", err)
+		}
+	}
+
+	log.Printf("Successfully copied storybook!")
+	return nil
+}

--- a/pkg/build/env/fallback.go
+++ b/pkg/build/env/fallback.go
@@ -2,9 +2,10 @@ package env
 
 import (
 	"fmt"
-	"github.com/urfave/cli/v2"
 	"os"
 	"strings"
+
+	"github.com/urfave/cli/v2"
 )
 
 // RequireListWithEnvFallback first checks the CLI for a flag with the required

--- a/pkg/build/env/fallback.go
+++ b/pkg/build/env/fallback.go
@@ -1,0 +1,39 @@
+package env
+
+import (
+	"fmt"
+	"github.com/urfave/cli/v2"
+	"os"
+	"strings"
+)
+
+// RequireListWithEnvFallback first checks the CLI for a flag with the required
+// name. If this is empty, it  falls back to taking the environment variable.
+// Sadly, we cannot use cli.Flag.EnvVars for this due to it potentially leaking
+// environment variables as default values in usage-errors.
+func RequireListWithEnvFallback(cctx *cli.Context, name string, envName string) ([]string, error) {
+	result := cctx.StringSlice(name)
+	if len(result) == 0 {
+		for _, v := range strings.Split(os.Getenv(envName), ",") {
+			value := strings.TrimSpace(v)
+			if value != "" {
+				result = append(result, value)
+			}
+		}
+	}
+	if len(result) == 0 {
+		return nil, cli.Exit(fmt.Sprintf("Required flag (%s) or environment variable (%s) not set", name, envName), 1)
+	}
+	return result, nil
+}
+
+func RequireStringWithEnvFallback(cctx *cli.Context, name string, envName string) (string, error) {
+	result := cctx.String(name)
+	if result == "" {
+		result = os.Getenv(envName)
+	}
+	if result == "" {
+		return "", cli.Exit(fmt.Sprintf("Required flag (%s) or environment variable (%s) not set", name, envName), 1)
+	}
+	return result, nil
+}

--- a/pkg/build/env/fallback_test.go
+++ b/pkg/build/env/fallback_test.go
@@ -3,10 +3,11 @@ package env
 import (
 	"flag"
 	"fmt"
-	"github.com/stretchr/testify/require"
-	"github.com/urfave/cli/v2"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
 )
 
 const (

--- a/pkg/build/env/fallback_test.go
+++ b/pkg/build/env/fallback_test.go
@@ -1,0 +1,142 @@
+package env
+
+import (
+	"flag"
+	"fmt"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
+	"os"
+	"testing"
+)
+
+const (
+	flag1 = "flag1"
+	flag2 = "flag2"
+)
+
+func TestRequireListWithEnvFallback(t *testing.T) {
+	var app = cli.NewApp()
+	tests := []struct {
+		testName    string
+		ctx         *cli.Context
+		name        string
+		envName     string
+		expected    []string
+		expectedErr error
+	}{
+		{
+			testName:    "string slice present in context",
+			ctx:         cli.NewContext(app, applyFlagSet(t, flag1, "a"), nil),
+			name:        flag1,
+			envName:     "",
+			expected:    []string{"a"},
+			expectedErr: nil,
+		},
+		{
+			testName:    "string slice present in env",
+			ctx:         cli.NewContext(app, flag.NewFlagSet("test", 0), nil),
+			name:        flag1,
+			envName:     setEnv(t, flag1, "a"),
+			expected:    []string{"a"},
+			expectedErr: nil,
+		},
+		{
+			testName:    "string slice absent in both context and env",
+			ctx:         cli.NewContext(app, flag.NewFlagSet("test", 0), nil),
+			name:        flag1,
+			envName:     "",
+			expected:    []string(nil),
+			expectedErr: cli.Exit(fmt.Sprintf("Required flag (flag1) or environment variable () not set"), 1),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			flagList, err := RequireListWithEnvFallback(tt.ctx, tt.name, tt.envName)
+			if tt.expectedErr != nil {
+				require.Error(t, err)
+			}
+			require.Equal(t, tt.expected, flagList)
+		})
+	}
+}
+
+func TestRequireStringWithEnvFallback(t *testing.T) {
+	var app = cli.NewApp()
+	tests := []struct {
+		testName    string
+		ctx         *cli.Context
+		name        string
+		envName     string
+		expected    string
+		expectedErr error
+	}{
+		{
+			testName:    "string present in the context",
+			ctx:         cli.NewContext(app, setFlags(t, flag1, flag2, flag.NewFlagSet("test", flag.ContinueOnError)), nil),
+			name:        flag1,
+			envName:     "",
+			expected:    "a",
+			expectedErr: nil,
+		},
+		{
+			testName:    "string present in env",
+			ctx:         cli.NewContext(app, setFlags(t, "", "", flag.NewFlagSet("test", flag.ContinueOnError)), nil),
+			name:        flag1,
+			envName:     setEnv(t, flag1, "a"),
+			expected:    "a",
+			expectedErr: nil,
+		},
+		{
+			testName:    "string absent from both context and env",
+			ctx:         cli.NewContext(app, setFlags(t, "", flag2, flag.NewFlagSet("test", flag.ContinueOnError)), nil),
+			name:        flag1,
+			envName:     "",
+			expected:    "",
+			expectedErr: cli.Exit(fmt.Sprintf("Required flag (flag1) or environment variable () not set"), 1),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			flagString, err := RequireStringWithEnvFallback(tt.ctx, tt.name, tt.envName)
+			if tt.expectedErr != nil {
+				require.Error(t, err)
+			}
+			require.Equal(t, tt.expected, flagString)
+		})
+	}
+}
+
+func applyFlagSet(t *testing.T, aFlag, aValue string) *flag.FlagSet {
+	t.Helper()
+	var val cli.StringSlice
+	fl := cli.StringSliceFlag{Name: aFlag, EnvVars: []string{"FLAG"}, Value: &val}
+	set := flag.NewFlagSet("test", 0)
+	parseInput := []string{fmt.Sprintf("-%s", aFlag), aValue}
+	err := fl.Apply(set)
+	require.NoError(t, err)
+	err = set.Parse(parseInput)
+	require.NoError(t, err)
+	return set
+}
+
+func setFlags(t *testing.T, flag1, flag2 string, flagSet *flag.FlagSet) *flag.FlagSet {
+	t.Helper()
+	if flag1 != "" {
+		flagSet.StringVar(&flag1, "flag1", "a", "")
+	}
+	if flag2 != "" {
+		flagSet.StringVar(&flag2, "flag2", "b", "")
+	}
+	return flagSet
+}
+
+func setEnv(t *testing.T, key, value string) string {
+	t.Helper()
+	os.Clearenv()
+
+	err := os.Setenv(key, value)
+	if err != nil {
+		require.NoError(t, err)
+	}
+	return key
+}

--- a/pkg/build/env/fallback_test.go
+++ b/pkg/build/env/fallback_test.go
@@ -47,7 +47,7 @@ func TestRequireListWithEnvFallback(t *testing.T) {
 			name:        flag1,
 			envName:     "",
 			expected:    []string(nil),
-			expectedErr: cli.Exit(fmt.Sprintf("Required flag (flag1) or environment variable () not set"), 1),
+			expectedErr: cli.Exit("Required flag (flag1) or environment variable () not set", 1),
 		},
 	}
 	for _, tt := range tests {
@@ -93,7 +93,7 @@ func TestRequireStringWithEnvFallback(t *testing.T) {
 			name:        flag1,
 			envName:     "",
 			expected:    "",
-			expectedErr: cli.Exit(fmt.Sprintf("Required flag (flag1) or environment variable () not set"), 1),
+			expectedErr: cli.Exit("Required flag (flag1) or environment variable () not set", 1),
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/build/gcloud/storage/gsutil.go
+++ b/pkg/build/gcloud/storage/gsutil.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"mime"
 	"os"
+	"os/exec"
 	"path"
 	"path/filepath"
 	"regexp"
@@ -455,4 +456,15 @@ func asChunks(files []File, chunkSize int) [][]File {
 		fileChunks = [][]File{files}
 	}
 	return fileChunks
+}
+
+func GCSCopy(desc, src, dest string) error {
+	args := strings.Split(fmt.Sprintf("-m cp -r gs://%s gs://%s", src, dest), " ")
+	// nolint:gosec
+	cmd := exec.Command("gsutil", args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to publish %s: %w\n%s", desc, err, out)
+	}
+	return nil
 }

--- a/pkg/build/gcloud/storage/gsutil.go
+++ b/pkg/build/gcloud/storage/gsutil.go
@@ -8,7 +8,6 @@ import (
 	"log"
 	"mime"
 	"os"
-	"os/exec"
 	"path"
 	"path/filepath"
 	"regexp"
@@ -208,7 +207,6 @@ func (client *Client) RemoteCopy(ctx context.Context, file File, fromBucket, toB
 		return fmt.Errorf("failed to copy object %s, to %s, err: %w", file.FullPath, dstObject, err)
 	}
 
-	log.Printf("%s was successfully copied to %v bucket!.\n\n", file.FullPath, toBucket)
 	return nil
 }
 
@@ -456,15 +454,4 @@ func asChunks(files []File, chunkSize int) [][]File {
 		fileChunks = [][]File{files}
 	}
 	return fileChunks
-}
-
-func GCSCopy(desc, src, dest string) error {
-	args := strings.Split(fmt.Sprintf("-m cp -r gs://%s gs://%s", src, dest), " ")
-	// nolint:gosec
-	cmd := exec.Command("gsutil", args...)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("failed to publish %s: %w\n%s", desc, err, out)
-	}
-	return nil
 }

--- a/scripts/drone/events/release.star
+++ b/scripts/drone/events/release.star
@@ -576,7 +576,7 @@ def publish_static_assets_step():
             "STATIC_ASSET_EDITIONS": from_secret("static_asset_editions"),
         },
         "commands": [
-            './bin/build artifacts static-assets --tag ${DRONE_TAG}',
+            "./bin/build artifacts static-assets --tag ${DRONE_TAG}",
         ],
         "depends_on": ["compile-build-cmd"],
     }
@@ -590,12 +590,21 @@ def publish_storybook_step():
             "PRERELEASE_BUCKET": from_secret("prerelease_bucket"),
         },
         "commands": [
-            './bin/build artifacts storybook --tag ${DRONE_TAG}',
+            "./bin/build artifacts storybook --tag ${DRONE_TAG}",
         ],
         "depends_on": ["compile-build-cmd"],
     }
 
 def publish_artifacts_pipelines(mode):
+    """Published artifacts after they've been stored and tested in prerelease buckets.
+
+    Args:
+      mode: public or security.
+        Defaults to ''.
+
+    Returns:
+      List of Drone pipelines.
+    """
     trigger = {
         "event": ["promote"],
         "target": [mode],
@@ -606,7 +615,7 @@ def publish_artifacts_pipelines(mode):
         publish_static_assets_step(),
     ]
     if mode != "security":
-        steps.extend([publish_storybook_step(),])
+        steps.extend([publish_storybook_step()])
 
     return [
         pipeline(

--- a/scripts/drone/events/release.star
+++ b/scripts/drone/events/release.star
@@ -557,10 +557,48 @@ def publish_artifacts_step(mode):
             "PRERELEASE_BUCKET": from_secret("prerelease_bucket"),
             "ENTERPRISE2_SECURITY_PREFIX": from_secret("enterprise2_security_prefix"),
             "SECURITY_DEST_BUCKET": from_secret("security_dest_bucket"),
+        },
+        "commands": [
+            "./bin/build artifacts packages {}--tag $${{DRONE_TAG}} --src-bucket $${{PRERELEASE_BUCKET}}".format(
+                security,
+            ),
+        ],
+        "depends_on": ["compile-build-cmd"],
+    }
+
+def publish_static_assets_step(mode):
+    security = ""
+    if mode == "security":
+        security = "--security "
+    return {
+        "name": "publish-static-assets",
+        "image": publish_image,
+        "environment": {
+            "GCP_KEY": from_secret("gcp_key"),
+            "PRERELEASE_BUCKET": from_secret("prerelease_bucket"),
+            "SECURITY_DEST_BUCKET": from_secret("security_dest_bucket"),
             "STATIC_ASSET_EDITIONS": from_secret("static_asset_editions"),
         },
         "commands": [
-            "./bin/build artifacts publish {}--tag $${{DRONE_TAG}} --src-bucket $${{PRERELEASE_BUCKET}}".format(
+            "./bin/build artifacts static-assets {}--tag $${{DRONE_TAG}} --src-bucket $${{PRERELEASE_BUCKET}}".format(
+                security,
+            ),
+        ],
+        "depends_on": ["compile-build-cmd"],
+    }
+
+def publish_storybook_step(mode):
+    security = ""
+    if mode == "security":
+        security = "--security "
+    return {
+        "name": "publish-storybook",
+        "image": publish_image,
+        "environment": {
+            "GCP_KEY": from_secret("gcp_key"),
+        },
+        "commands": [
+            "./bin/build artifacts storybook {}--tag $${{DRONE_TAG}} --src-bucket $${{PRERELEASE_BUCKET}}".format(
                 security,
             ),
         ],
@@ -575,6 +613,8 @@ def publish_artifacts_pipelines(mode):
     steps = [
         compile_build_cmd(),
         publish_artifacts_step(mode),
+        publish_storybook_step(mode),
+        publish_static_assets_step(mode),
     ]
 
     return [


### PR DESCRIPTION
**What is this feature?**

Currently the `/bin/build artifacts *` does too much.
* Publishes artifacts
* Publishes storybook
* Publishes static-assets

There's no easy way to do one at a time using the binary, we need to either comment out pieces of code, add conditions or copy things manually.

This PR makes it easier to work with one thing at a time, and also run the publishing phase on demand.

**Special notes for you reviewer:**
Created 3 standalone commands:
* `./bin/build artifacts packages` which runs in the `publish-artifacts` step.
* `./bin/build artifacts static-assets` which runs in the `publish-static-assets` step.
* `./bin/build artifacts storybook` which runs in the `publish-storybook` step.

Run 2 promotions successfully [here](https://drone.grafana.net/grafana/grafana-ci-sandbox/728/1/4) and [here](https://drone.grafana.net/grafana/grafana-ci-sandbox/729).
Promotion pipeline only copying `enterprise2` artifacts, [here](https://drone.grafana.net/grafana/grafana-ci-sandbox/734).

Also, all three commands now use the GCS lib we created and stopped calling the `gsutil` as a binary from inside go code.

Resolves: https://github.com/grafana/grafana-delivery/issues/100