### PR TITLE
Correlations: Don't show Add button in empty call-to-action page when user has no sufficient permissions

### DIFF
--- a/public/app/features/correlations/CorrelationsPage.tsx
+++ b/public/app/features/correlations/CorrelationsPage.tsx
@@ -162,7 +162,9 @@ export default function CorrelationsPage() {
             </div>
           )}
 
-          {showEmptyListCTA && <EmptyCorrelationsCTA onClick={() => setIsAdding(true)} />}
+          {showEmptyListCTA && (
+            <EmptyCorrelationsCTA canWriteCorrelations={canWriteCorrelations} onClick={() => setIsAdding(true)} />
+          )}
 
           {
             // This error is not actionable, it'd be nice to have a recovery button

--- a/public/app/features/correlations/components/EmptyCorrelationsCTA.tsx
+++ b/public/app/features/correlations/components/EmptyCorrelationsCTA.tsx
@@ -1,14 +1,16 @@
 import React from 'react';
 
+import { Card } from '@grafana/ui';
 import EmptyListCTA from 'app/core/components/EmptyListCTA/EmptyListCTA';
 
 interface Props {
   onClick?: () => void;
+  canWriteCorrelations: boolean;
 }
-export const EmptyCorrelationsCTA = ({ onClick }: Props) => {
+export const EmptyCorrelationsCTA = ({ onClick, canWriteCorrelations }: Props) => {
   // TODO: if there are no datasources show a different message
 
-  return (
+  return canWriteCorrelations ? (
     <EmptyListCTA
       title="You haven't defined any correlation yet."
       buttonIcon="gf-glue"
@@ -16,5 +18,10 @@ export const EmptyCorrelationsCTA = ({ onClick }: Props) => {
       buttonTitle="Add correlation"
       proTip="you can also define correlations via datasource provisioning"
     />
+  ) : (
+    <Card>
+      <Card.Heading>There are no correlations configured yet.</Card.Heading>
+      <Card.Description>Please contact your administrator to create new correlations.</Card.Description>
+    </Card>
   );
 };


### PR DESCRIPTION
**What this PR does / why we need it**:

Add button on the Correlations Page is not shown if the user has no permission to write data sources ([code](https://github.com/grafana/grafana/blob/v9.4.7/public/app/features/correlations/CorrelationsPage.tsx#L55)). However, the check for permissions is missing on the empty call-to-action page.

**Which issue(s) this PR fixes**:

Fixes #64157

EmptyCTA page will not show "Add correlation" if the user has no sufficient permissions:

| with permissions to add correlations | without permissions |
|---|---|
|  <img width="1249" alt="Screenshot 2023-04-05 at 12 43 55" src="https://user-images.githubusercontent.com/745532/230060483-86f0ffe9-e299-491d-8014-df4dbf2ae10f.png"> | <img width="1253" alt="Screenshot 2023-04-05 at 12 44 10" src="https://user-images.githubusercontent.com/745532/230060560-d7715428-b1f3-4042-b3f5-ee4feb0f95d4.png"> |


**Special notes for your reviewer**:

Note: The bug happens only if there are no correlations in the database. 

<details><summary>How to test it</summary>

1. If you have some correlations defined -> create a new organization and get an empty list of correlations.
2. Create a new user that belongs only to that new organization with a role Viewer or Editor 
3. Login with the newly created user and go to the Administration/Correlations page
4. There should be no "Add correlation" button that opens a form for adding a correlations

</details>


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
