### PR TITLE
Dashboard Datasource: Update Language

### DIFF
--- a/public/app/plugins/datasource/dashboard/DashboardQueryEditor.tsx
+++ b/public/app/plugins/datasource/dashboard/DashboardQueryEditor.tsx
@@ -188,7 +188,7 @@ export function DashboardQueryEditor({ panelData, queries, onChange, onRunQuerie
       ) : (
         <>
           {results && Boolean(results.length) && (
-            <Field label="Available queries from panel">
+            <Field label="Queries from panel">
               <VerticalGroup spacing="sm">
                 {results.map((target, i) => (
                   <Card key={`DashboardQueryRow-${i}`}>


### PR DESCRIPTION
This PR make a small language change on the dashboard datasource to say "Queries from panel" instead of "Available queries from panel" as the second phrase implies the ability to make some kind of selection (which isn't the case here).

This is a follow up to the comment [here](https://github.com/grafana/grafana/pull/64429#issuecomment-1497188493)