### PR TITLE
Alerting: Fix docs link when creating or editing rules

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/DetailsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/DetailsStep.tsx
@@ -12,7 +12,7 @@ function getDescription(ruleType: RuleFormType | undefined) {
     return 'Select the Namespace and Group for your recording rule.';
   }
   const docsLink =
-    'https://grafana.com/docs/grafana/latest/alerting/fundamentals/annotation-label/variables-label-annotation/#the-values-variable';
+    'https://grafana.com/docs/grafana/latest/alerting/fundamentals/annotation-label/variables-label-annotation';
   const LinkToDocs = () => (
     <span>
       Click{' '}

--- a/public/app/features/alerting/unified/components/rule-editor/DetailsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/DetailsStep.tsx
@@ -26,8 +26,7 @@ function getDescription(ruleType: RuleFormType | undefined) {
     return (
       <span>
         {' '}
-        Write a summary to help you better manage your alerts.
-        <LinkToDocs />
+        Write a summary to help you better manage your alerts. <LinkToDocs />
       </span>
     );
   }
@@ -36,7 +35,6 @@ function getDescription(ruleType: RuleFormType | undefined) {
       <span>
         {' '}
         Select the Namespace and evaluation group for your alert. Write a summary to help you better manage your alerts.{' '}
-        <LinkToDocs />
       </span>
     );
   }


### PR DESCRIPTION
**What is this feature?**

Removes the `#` from the docs link. Fixes a missing space, and removes link to GMA docs from Mimir and Loki.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
