### PR TITLE
Correlations: Add usage stats about correlations

### DIFF
--- a/pkg/infra/metrics/metrics.go
+++ b/pkg/infra/metrics/metrics.go
@@ -201,6 +201,9 @@ var (
 
 	// MStatTotalPublicDashboards is a metric total amount of public dashboards
 	MStatTotalPublicDashboards prometheus.Gauge
+
+	// MStatTotalCorrelations is a metric total amount of correlations
+	MStatTotalCorrelations prometheus.Gauge
 )
 
 func init() {
@@ -592,6 +595,12 @@ func init() {
 		Help:      "total amount of public dashboards",
 		Namespace: ExporterName,
 	})
+
+	MStatTotalCorrelations = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name:      "stat_totals_correlations",
+		Help:      "total amount of correlations",
+		Namespace: ExporterName,
+	})
 }
 
 // SetBuildInformation sets the build information for this binary
@@ -705,5 +714,6 @@ func initMetricVars() {
 		MStatTotalPublicDashboards,
 		MPublicDashboardRequestCount,
 		MPublicDashboardDatasourceQuerySuccess,
+		MStatTotalCorrelations,
 	)
 }

--- a/pkg/infra/usagestats/statscollector/service.go
+++ b/pkg/infra/usagestats/statscollector/service.go
@@ -315,6 +315,8 @@ func (s *Service) updateTotalStats(ctx context.Context) bool {
 
 	metrics.MStatTotalPublicDashboards.Set(float64(statsResult.PublicDashboards))
 
+	metrics.MStatTotalCorrelations.Set(float64(statsResult.Correlations))
+
 	dsResult, err := s.statsService.GetDataSourceStats(ctx, &stats.GetDataSourceStatsQuery{})
 	if err != nil {
 		s.log.Error("Failed to get datasource stats", "error", err)

--- a/pkg/infra/usagestats/statscollector/service.go
+++ b/pkg/infra/usagestats/statscollector/service.go
@@ -158,6 +158,7 @@ func (s *Service) collectSystemStats(ctx context.Context) (map[string]interface{
 	m["stats.data_keys.count"] = statsResult.DataKeys
 	m["stats.active_data_keys.count"] = statsResult.ActiveDataKeys
 	m["stats.public_dashboards.count"] = statsResult.PublicDashboards
+	m["stats.correlations.count"] = statsResult.Correlations
 
 	ossEditionCount := 1
 	enterpriseEditionCount := 0

--- a/pkg/infra/usagestats/statscollector/service_test.go
+++ b/pkg/infra/usagestats/statscollector/service_test.go
@@ -177,6 +177,7 @@ func TestCollectingUsageStats(t *testing.T) {
 	assert.EqualValues(t, 11, metrics["stats.data_keys.count"])
 	assert.EqualValues(t, 3, metrics["stats.active_data_keys.count"])
 	assert.EqualValues(t, 5, metrics["stats.public_dashboards.count"])
+	assert.EqualValues(t, 3, metrics["stats.correlations.count"])
 
 	assert.InDelta(t, int64(65), metrics["stats.uptime"], 6)
 }
@@ -336,6 +337,7 @@ func mockSystemStats(statsService *statstest.FakeService) {
 		DataKeys:                  11,
 		ActiveDataKeys:            3,
 		PublicDashboards:          5,
+		Correlations:              3,
 	}
 }
 

--- a/pkg/services/correlations/correlationstest/fake.go
+++ b/pkg/services/correlations/correlationstest/fake.go
@@ -1,0 +1,23 @@
+package correlationstest
+
+import (
+	"github.com/grafana/grafana/pkg/api/routing"
+	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
+	"github.com/grafana/grafana/pkg/services/correlations"
+	"github.com/grafana/grafana/pkg/services/datasources"
+	fakeDatasources "github.com/grafana/grafana/pkg/services/datasources/fakes"
+	"github.com/grafana/grafana/pkg/services/quota/quotatest"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+func New(sqlStore *sqlstore.SQLStore) *correlations.CorrelationsService {
+	ds := &fakeDatasources.FakeDataSourceService{
+		DataSources: []*datasources.DataSource{
+			{ID: 1, UID: "graphite", Type: datasources.DS_GRAPHITE},
+		},
+	}
+
+	correlationsSvc, _ := correlations.ProvideService(sqlStore, routing.NewRouteRegister(), ds, acimpl.ProvideAccessControl(setting.NewCfg()), sqlStore.Bus(), quotatest.New(false, nil), sqlStore.Cfg)
+	return correlationsSvc
+}

--- a/pkg/services/stats/models.go
+++ b/pkg/services/stats/models.go
@@ -42,6 +42,7 @@ type SystemStats struct {
 	DataKeys                  int64
 	ActiveDataKeys            int64
 	PublicDashboards          int64
+	Correlations              int64
 }
 
 type DataSourceStats struct {

--- a/pkg/services/stats/statsimpl/stats.go
+++ b/pkg/services/stats/statsimpl/stats.go
@@ -73,6 +73,7 @@ func (ss *sqlStatsService) GetSystemStats(ctx context.Context, query *stats.GetS
 		sb.Write(`(SELECT COUNT(*) FROM ` + dialect.Quote("star") + `) AS stars,`)
 		sb.Write(`(SELECT COUNT(*) FROM ` + dialect.Quote("playlist") + `) AS playlists,`)
 		sb.Write(`(SELECT COUNT(*) FROM ` + dialect.Quote("alert") + `) AS alerts,`)
+		sb.Write(`(SELECT COUNT(*) FROM ` + dialect.Quote("correlation") + `) AS correlations,`)
 
 		now := time.Now()
 		activeUserDeadlineDate := now.Add(-activeUserTimeLimit)

--- a/pkg/services/stats/statsimpl/stats_test.go
+++ b/pkg/services/stats/statsimpl/stats_test.go
@@ -3,13 +3,13 @@ package statsimpl
 import (
 	"context"
 	"fmt"
-	"github.com/grafana/grafana/pkg/services/correlations"
-	"github.com/grafana/grafana/pkg/services/correlations/correlationstest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/grafana/pkg/services/correlations"
+	"github.com/grafana/grafana/pkg/services/correlations/correlationstest"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/org/orgimpl"
 	"github.com/grafana/grafana/pkg/services/quota/quotatest"

--- a/pkg/services/stats/statsimpl/stats_test.go
+++ b/pkg/services/stats/statsimpl/stats_test.go
@@ -3,6 +3,8 @@ package statsimpl
 import (
 	"context"
 	"fmt"
+	"github.com/grafana/grafana/pkg/services/correlations"
+	"github.com/grafana/grafana/pkg/services/correlations/correlationstest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -38,6 +40,7 @@ func TestIntegrationStatsDataAccess(t *testing.T) {
 		assert.Equal(t, int64(0), result.LibraryPanels)
 		assert.Equal(t, int64(0), result.LibraryVariables)
 		assert.Equal(t, int64(0), result.APIKeys)
+		assert.Equal(t, int64(2), result.Correlations)
 	})
 
 	t.Run("Get system user count stats should not results in error", func(t *testing.T) {
@@ -76,6 +79,25 @@ func populateDB(t *testing.T, sqlStore *sqlstore.SQLStore) {
 
 	orgService, _ := orgimpl.ProvideService(sqlStore, sqlStore.Cfg, quotatest.New(false, nil))
 	userSvc, _ := userimpl.ProvideService(sqlStore, orgService, sqlStore.Cfg, nil, nil, &quotatest.FakeQuotaService{}, supportbundlestest.NewFakeBundleService())
+
+	correlationsSvc := correlationstest.New(sqlStore)
+
+	c := make([]correlations.Correlation, 2)
+	for i := range c {
+		cmd := correlations.CreateCorrelationCommand{
+			Label:     fmt.Sprintf("correlation %v", i),
+			SourceUID: "graphite",
+			OrgId:     1,
+			Config: correlations.CorrelationConfig{
+				Field:  "field",
+				Target: map[string]interface{}{},
+				Type:   correlations.ConfigTypeQuery,
+			},
+		}
+		correlation, err := correlationsSvc.CreateCorrelation(context.Background(), cmd)
+		require.NoError(t, err)
+		c[i] = correlation
+	}
 
 	users := make([]user.User, 3)
 	for i := range users {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds collecting usage stats about correlations:

* a new metric `grafana_stat_totals_correlations` is exposed
* anonymous `stats.correlations.count` pushed to the usage report

**Which issue(s) this PR fixes**:

Fixes #64224

**Special notes for your reviewer**:

<details><summary>How to test it</summary>

Total number of correlations should be exposed with a metric at: http://localhost:3000/metrics

```
# HELP grafana_stat_totals_correlations total amount of correlations
# TYPE grafana_stat_totals_correlations gauge
grafana_stat_totals_correlations 29
```

</details>

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
