### PR TITLE
Loki Query Editor: Increase autocomplete suggestions window with to 50%

### DIFF
--- a/public/app/plugins/datasource/loki/components/monaco-query-field/MonacoQueryField.tsx
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/MonacoQueryField.tsx
@@ -79,6 +79,9 @@ const getStyles = (theme: GrafanaTheme2, placeholder: string) => {
       border-radius: ${theme.shape.borderRadius()};
       border: 1px solid ${theme.components.input.borderColor};
       width: 100%;
+      .monaco-editor .suggest-widget {
+        min-width: 50%;
+      }
     `,
     placeholder: css`
       ::after {


### PR DESCRIPTION
This PR increases the minimum width of the suggestions component to 50%. It is not possible to set the width without using `!important` (AFAIK), so the workaround was to use min-width, which allows the user to resize the window using the handle.

![2023-04-05 17 18 36](https://user-images.githubusercontent.com/1069378/230126619-6535899e-2da4-4b88-822a-f9699f2b991a.gif)

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/65250

**Special notes for your reviewer:**

Before:

![Before](https://user-images.githubusercontent.com/1069378/230126743-f9a06434-9be0-4b73-82c8-16d1110a729b.png)

After:

![After](https://user-images.githubusercontent.com/1069378/230126746-89fe5ead-3aac-4d85-b78e-f35409e4aca5.png)
