### PR TITLE
Azure Monitor: Fix autocomplete behaviour in cloud environments

### DIFF
--- a/devenv/local-cdn/README.md
+++ b/devenv/local-cdn/README.md
@@ -1,0 +1,16 @@
+# Local Grafana CDN
+
+Use this docker container when working with the cdn_url config setting.
+
+Set conf/custom.ini:
+
+```
+[server]
+cdn_url = http://localhost:8080
+```
+
+then navigate to this directory and run:
+
+`docker compose up -d`
+
+Assets should now be available on `http://localhost:8080/grafana-oss/10.0.0-pre/public/*`

--- a/devenv/local-cdn/default.conf
+++ b/devenv/local-cdn/default.conf
@@ -1,0 +1,24 @@
+server {
+	root /data;
+	autoindex on;
+
+	location / {
+		if ($request_method = 'OPTIONS') {
+			add_header 'Access-Control-Allow-Origin' '$http_origin' always;
+			add_header 'Access-Control-Allow-Credentials' 'true' always;
+			add_header 'Access-Control-Allow-Headers' '*' always;
+			add_header 'Access-Control-Allow-Methods' '*';
+			# add_header 'Access-Control-Max-Age' 1728000;
+			add_header 'Content-Type' 'text/plain; charset=utf-8';
+			add_header 'Content-Length' 0;
+			return 204;
+		}
+
+		add_header 'Access-Control-Allow-Origin' '$http_origin' always;
+		add_header 'Access-Control-Allow-Methods' '*' always;
+		add_header 'Access-Control-Allow-Headers' '*' always;
+		add_header 'Access-Control-Allow-Credentials' 'true' always;
+
+		rewrite ^/grafana-oss/10.0.0-pre/public(.*)$ $1 last;
+	}
+}

--- a/devenv/local-cdn/docker-compose.yaml
+++ b/devenv/local-cdn/docker-compose.yaml
@@ -1,0 +1,11 @@
+version: '2'
+
+services:
+  grafana_local_cdn:
+    image: nginx:alpine
+    container_name: grafana_local_cdn
+    ports:
+      - "8080:80"
+    volumes:
+      - ../../public:/data
+      - ./default.conf:/etc/nginx/conf.d/default.conf

--- a/public/lib/monaco-languages/kusto.ts
+++ b/public/lib/monaco-languages/kusto.ts
@@ -5,17 +5,6 @@ declare global {
   }
 }
 
-const monacoPath = (window.__grafana_public_path__ ?? 'public/') + 'lib/monaco/min/vs';
-
-const scripts = [
-  [`${monacoPath}/language/kusto/bridge.min.js`],
-  [
-    `${monacoPath}/language/kusto/kusto.javascript.client.min.js`,
-    `${monacoPath}/language/kusto/newtonsoft.json.min.js`,
-    `${monacoPath}/language/kusto/Kusto.Language.Bridge.min.js`,
-  ],
-];
-
 function loadScript(script: HTMLScriptElement | string): Promise<void> {
   return new Promise((resolve, reject) => {
     let scriptEl: HTMLScriptElement;
@@ -47,6 +36,17 @@ const loadMonacoKusto = () => {
 };
 
 export default async function loadKusto() {
+  const monacoPath = (window.__grafana_public_path__ ?? 'public/') + 'lib/monaco/min/vs';
+
+  const scripts = [
+    [`${monacoPath}/language/kusto/bridge.min.js`],
+    [
+      `${monacoPath}/language/kusto/kusto.javascript.client.min.js`,
+      `${monacoPath}/language/kusto/newtonsoft.json.min.js`,
+      `${monacoPath}/language/kusto/Kusto.Language.Bridge.min.js`,
+    ],
+  ];
+
   let promise = Promise.resolve();
 
   for (const parallelScripts of scripts) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- setting a `cdn_url` and running locally, when switching to the code view in explore you can see that whilst monaco itself is loaded from the CDN url, kusto is just loaded from `/public/lib/...`
- thanks @jackw for spotting this - https://raintank-corp.slack.com/archives/C04BERE83D5/p1680102081908319?thread_ts=1680018713.713969&cid=C04BERE83D5 for context
- logging out `window.__grafana_public_path__` at the root of the kusto file shows it's `undefined` at this point
- comparing this to `ReactMonacoEditor` (which loads monaco), you can see this happens in an `initMonaco` function which is called from within a component
- by moving it inside the `loadKusto` function, we guarantee `window.__grafana_public_path__` is defined
  - can log this out and confirm it's now defined correctly 🥳 
- can't find a nice way to test the full thing locally... by setting a `cdn_url` in config, it fetches the built app from there as well so any local changes aren't picked up. any ideas? 🤔 


**Why do we need this feature?**

- so autocomplete works in cloud environments

**Who is this feature for?**

- anyone using the Azure Data Explorer or Azure Monitor data sources

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/support-escalations/issues/5348

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
