### PR TITLE
Tracing: Update provisioning docs

### DIFF
--- a/docs/sources/datasources/jaeger/_index.md
+++ b/docs/sources/datasources/jaeger/_index.md
@@ -192,6 +192,10 @@ datasources:
             query: 'sum(rate(traces_spanmetrics_latency_bucket{$__tags}[5m]))'
       nodeGraph:
         enabled: true
+      traceQuery:
+        timeShiftEnabled: true
+        spanStartTimeShift: '1h'
+        spanEndTimeShift: '-1h'
       spanBar:
         type: 'None'
     secureJsonData:

--- a/docs/sources/datasources/tempo/_index.md
+++ b/docs/sources/datasources/tempo/_index.md
@@ -228,13 +228,13 @@ datasources:
         hide: false
       lokiSearch:
         datasourceUid: 'loki'
+      traceQuery:
+        timeShiftEnabled: true
+        spanStartTimeShift: '1h'
+        spanEndTimeShift: '-1h'
       spanBar:
         type: 'Tag'
         tag: 'http.path'
-      traceQuery:
-        timeShiftEnabled: true
-        spanStartTimeShift: 15m
-        spanEndTimeShift: 20m
 ```
 
 ## Query the data source

--- a/docs/sources/datasources/zipkin/_index.md
+++ b/docs/sources/datasources/zipkin/_index.md
@@ -190,6 +190,10 @@ datasources:
             query: 'sum(rate(traces_spanmetrics_latency_bucket{$__tags}[5m]))'
       nodeGraph:
         enabled: true
+      traceQuery:
+        timeShiftEnabled: true
+        spanStartTimeShift: '1h'
+        spanEndTimeShift: '-1h'
       spanBar:
         type: 'None'
     secureJsonData:


### PR DESCRIPTION
**What is this feature?**

Updates the provisioning example for Tempo/Jaeger/Zipkin.

**Why do we need this feature?**

Adds in `traceQuery` for Jaeger/Zipkin and modifies content and position for Tempo.

**Who is this feature for?**

Helps users with provisioning.