### PR TITLE
Flaky E2E: Wait for the data to be loaded before switch to table view

### DIFF
--- a/e2e/panels-suite/panelEdit_base.spec.ts
+++ b/e2e/panels-suite/panelEdit_base.spec.ts
@@ -79,6 +79,7 @@ e2e.scenario({
     e2e.components.PluginVisualization.current().should((e) => expect(e).to.contain('Time series'));
 
     // Check that table view works
+    e2e.components.Panels.Panel.loadingBar().should('not.exist');
     e2e.components.PanelEditor.toggleTableView().click({ force: true });
     e2e.components.Panels.Visualization.Table.header()
       .should('be.visible')

--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -76,6 +76,7 @@ export const Components = {
       menu: (title: string) => `data-testid Panel menu ${title}`,
       containerByTitle: (title: string) => `${title} panel`,
       headerCornerInfo: (mode: string) => `Panel header ${mode}`,
+      loadingBar: () => `Panel loading bar`,
     },
     Visualization: {
       Graph: {


### PR DESCRIPTION
Wait for the loading bar not to be there before moving into table view.

Fixes #66071 