### PR TITLE
docs revamp: Add new documentation to sidebar index

### DIFF
--- a/docs/sources/auth/_index.md
+++ b/docs/sources/auth/_index.md
@@ -1,1 +1,14 @@
+---
+title: Authentication setup
+menuTitle: Authentication setup
+description: Documentation reference for identity providers and authentication services.
+aliases:
+  - docs/sources/auth/
+weight: 200
+keywords:
+  - IdP
+  - IAM
+  - Auth
+---
+
 # Identity and access management

--- a/docs/sources/auth/_index.md
+++ b/docs/sources/auth/_index.md
@@ -1,9 +1,7 @@
 ---
-title: Authentication setup
+title: Set up Authentication in Grafana
 menuTitle: Authentication setup
 description: Documentation reference for identity providers and authentication services.
-aliases:
-  - docs/sources/auth/
 weight: 200
 keywords:
   - IdP


### PR DESCRIPTION
**What is this feature?**

This includes the new documentation to the sidebar index.

**Special notes for your reviewer:**

In order to run the documentation locally using
```
$ cd docs
$ make docs
```
After the docker image is running, the service should be available at http://localhost:3002

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
