### PR TITLE
Plugins: Skip instrumenting plugin build info for core and bundled plugins

### DIFF
--- a/pkg/plugins/manager/loader/loader.go
+++ b/pkg/plugins/manager/loader/loader.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/grafana/grafana/pkg/infra/metrics"
+
 	"github.com/grafana/grafana/pkg/infra/slugify"
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/plugins/config"
@@ -166,8 +167,6 @@ func (l *Loader) loadPlugins(ctx context.Context, src plugins.PluginSource, foun
 		if err != nil {
 			return nil, err
 		}
-		metrics.SetPluginBuildInformation(p.ID, string(p.Type), p.Info.Version, string(p.Signature))
-
 		if errDeclareRoles := l.roleRegistry.DeclarePluginRoles(ctx, p.ID, p.Name, p.Roles); errDeclareRoles != nil {
 			l.log.Warn("Declare plugin roles failed.", "pluginID", p.ID, "err", errDeclareRoles)
 		}
@@ -176,6 +175,10 @@ func (l *Loader) loadPlugins(ctx context.Context, src plugins.PluginSource, foun
 	for _, p := range verifiedPlugins {
 		if err := l.load(ctx, p); err != nil {
 			l.log.Error("Could not start plugin", "pluginId", p.ID, "err", err)
+		}
+
+		if !p.IsCorePlugin() && !p.IsBundledPlugin() {
+			metrics.SetPluginBuildInformation(p.ID, string(p.Type), p.Info.Version, string(p.Signature))
 		}
 	}
 

--- a/pkg/plugins/manager/loader/loader.go
+++ b/pkg/plugins/manager/loader/loader.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/grafana/grafana/pkg/infra/metrics"
-
 	"github.com/grafana/grafana/pkg/infra/slugify"
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/plugins/config"


### PR DESCRIPTION
**What is this feature?**

Ensures we only instrument relevant plugins

**Why do we need this feature?**

Reporting on this information is superfluous

**Who is this feature for?**

Grafana operators

**Special notes for your reviewer:**
Behaviour was incorrectly changed since v8.3.0 - see previous implementation [here](https://github.com/grafana/grafana/blob/v8.2.7/pkg/plugins/manager/manager.go#L174-L178). I think it's also useful to not report on bundled plugins as reporting on them provides little value

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
