### PR TITLE
Alerting: Fix explore link in alert detail view

### DIFF
--- a/public/app/features/alerting/unified/GrafanaRuleQueryViewer.tsx
+++ b/public/app/features/alerting/unified/GrafanaRuleQueryViewer.tsx
@@ -47,44 +47,47 @@ export function GrafanaRuleQueryViewer({
 
   return (
     <Stack gap={2} direction="column">
-      <Stack gap={2}>
-        {dataQueries.map(({ model, relativeTimeRange, refId, datasourceUid }, index) => {
-          const dataSource = dsByUid[datasourceUid];
+      <div style={{ maxWidth: '100%' }}>
+        <Stack gap={2}>
+          {dataQueries.map(({ model, relativeTimeRange, refId, datasourceUid }, index) => {
+            const dataSource = dsByUid[datasourceUid];
 
-          return (
-            <QueryPreview
-              key={index}
-              refId={refId}
-              isAlertCondition={condition === refId}
-              model={model}
-              relativeTimeRange={relativeTimeRange}
-              evalTimeRange={evalTimeRanges[refId]}
-              dataSource={dataSource}
-              queryData={evalDataByQuery[refId]}
-              onEvalTimeRangeChange={(timeRange) => onTimeRangeChange(refId, timeRange)}
-            />
-          );
-        })}
-      </Stack>
-
-      <Stack gap={1}>
-        {expressions.map(({ model, relativeTimeRange, refId, datasourceUid }, index) => {
-          const dataSource = dsByUid[datasourceUid];
-
-          return (
-            isExpressionQuery(model) && (
-              <ExpressionPreview
+            return (
+              <QueryPreview
                 key={index}
                 refId={refId}
                 isAlertCondition={condition === refId}
                 model={model}
+                relativeTimeRange={relativeTimeRange}
+                evalTimeRange={evalTimeRanges[refId]}
                 dataSource={dataSource}
-                evalData={evalDataByQuery[refId]}
+                queryData={evalDataByQuery[refId]}
+                onEvalTimeRangeChange={(timeRange) => onTimeRangeChange(refId, timeRange)}
               />
-            )
-          );
-        })}
-      </Stack>
+            );
+          })}
+        </Stack>
+      </div>
+      <div style={{ maxWidth: '100%' }}>
+        <Stack gap={1}>
+          {expressions.map(({ model, refId, datasourceUid }, index) => {
+            const dataSource = dsByUid[datasourceUid];
+
+            return (
+              isExpressionQuery(model) && (
+                <ExpressionPreview
+                  key={index}
+                  refId={refId}
+                  isAlertCondition={condition === refId}
+                  model={model}
+                  dataSource={dataSource}
+                  evalData={evalDataByQuery[refId]}
+                />
+              )
+            );
+          })}
+        </Stack>
+      </div>
     </Stack>
   );
 }

--- a/public/app/features/alerting/unified/GrafanaRuleQueryViewer.tsx
+++ b/public/app/features/alerting/unified/GrafanaRuleQueryViewer.tsx
@@ -44,10 +44,11 @@ export function GrafanaRuleQueryViewer({
   const dsByUid = keyBy(Object.values(config.datasources), (ds) => ds.uid);
   const dataQueries = queries.filter((q) => !isExpressionQuery(q.model));
   const expressions = queries.filter((q) => isExpressionQuery(q.model));
+  const styles = useStyles2(getExpressionViewerStyles);
 
   return (
     <Stack gap={2} direction="column">
-      <div style={{ maxWidth: '100%' }}>
+      <div className={styles.maxWidthContainer}>
         <Stack gap={2}>
           {dataQueries.map(({ model, relativeTimeRange, refId, datasourceUid }, index) => {
             const dataSource = dsByUid[datasourceUid];
@@ -68,7 +69,7 @@ export function GrafanaRuleQueryViewer({
           })}
         </Stack>
       </div>
-      <div style={{ maxWidth: '100%' }}>
+      <div className={styles.maxWidthContainer}>
         <Stack gap={1}>
           {expressions.map(({ model, refId, datasourceUid }, index) => {
             const dataSource = dsByUid[datasourceUid];
@@ -392,6 +393,9 @@ const getExpressionViewerStyles = (theme: GrafanaTheme2) => {
 
   return {
     ...common,
+    maxWidthContainer: css`
+      max-width: 100%;
+    `,
     container: css`
       padding: ${theme.spacing(1)};
       display: flex;

--- a/public/app/features/alerting/unified/components/rule-viewer/RuleViewerVisualization.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/RuleViewerVisualization.tsx
@@ -142,6 +142,14 @@ function createExploreLink(settings: DataSourceInstanceSettings, model: AlertDat
   const { name } = settings;
   const { refId, ...rest } = model;
 
+  /**
+    In my testing I've found some alerts that don't have a data source embedded inside the model.
+   
+    At this moment in time it is unclear to me why some alert definitions not have a data source embedded in the model.
+    Ideally we'd resolve the datasource name to the proper datasource Ref "{ type: string, uid: string }" and pass that in to the model.
+   
+    I don't think that should happen here, the fact that the datasource ref is sometimes missing here is a symptom of another cause. (Gilles)
+   */
   return urlUtil.renderUrl(`${config.appSubUrl}/explore`, {
     left: JSON.stringify({
       datasource: name,

--- a/public/app/features/alerting/unified/components/rule-viewer/RuleViewerVisualization.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/RuleViewerVisualization.tsx
@@ -141,12 +141,11 @@ export function RuleViewerVisualization({
 function createExploreLink(settings: DataSourceInstanceSettings, model: AlertDataQuery): string {
   const { name } = settings;
   const { refId, ...rest } = model;
-  const queryParams = { ...rest, datasource: name };
 
   return urlUtil.renderUrl(`${config.appSubUrl}/explore`, {
     left: JSON.stringify({
       datasource: name,
-      queries: [{ refId: 'A', ...queryParams }],
+      queries: [{ refId: 'A', ...rest }],
       range: { from: 'now-1h', to: 'now' },
     }),
   });


### PR DESCRIPTION
**What is this feature?**

This fixes the "View in explore" link sometimes not working in the alert detail view for certain data sources.

**Why do we need this feature?**

It looks like we were manually overwriting the datasource of the query when the model already contained a datasource ref `{ datasource: { type: string, uid: string } }` even though the datasource is already correctly set and resolved _outside_ of the query `{ datasource: string, queries: [] }` because the explorer does not support mixing datasources in the same left or right panel.

**Special notes for your reviewer:**

I've also fixed a small CSS issue where previewing alert rules where instances have a lot of labels does not properly render the "explore" button.