### PR TITLE
Service accounts: Refactor to make roleOptions act as Users for service accounts

### DIFF
--- a/public/app/features/serviceaccounts/components/ServiceAccountProfile.tsx
+++ b/public/app/features/serviceaccounts/components/ServiceAccountProfile.tsx
@@ -19,7 +19,7 @@ interface Props {
 export function ServiceAccountProfile({ serviceAccount, timeZone, onChange }: Props): JSX.Element {
   const styles = useStyles2(getStyles);
   const ableToWrite = contextSrv.hasPermission(AccessControlAction.ServiceAccountsWrite);
-  const [roles, setRoles] = React.useState<Role[]>([]);
+  const [roles, setRoleOptions] = React.useState<Role[]>([]);
 
   const onRoleChange = (role: OrgRole) => {
     onChange({ ...serviceAccount, role: role });
@@ -28,20 +28,20 @@ export function ServiceAccountProfile({ serviceAccount, timeZone, onChange }: Pr
   const onNameChange = (newValue: string) => {
     onChange({ ...serviceAccount, name: newValue });
   };
-  // TODO: this is a temporary solution to fetch roles for service accounts
-  // until we make use of the state from the serviceaccountspage
-  // and pass it down to the serviceaccountprofile
+
   React.useEffect(() => {
-    if (contextSrv.licensedAccessControlEnabled()) {
-      if (contextSrv.hasPermission(AccessControlAction.ActionRolesList)) {
-        fetchRoleOptions(serviceAccount.orgId)
-          .then((roles) => {
-            setRoles(roles);
-          })
-          .catch((err) => {
-            console.log('fetchRoleOptions error: ', err);
-          });
+    async function fetchOptions() {
+      try {
+        if (contextSrv.hasPermission(AccessControlAction.ActionRolesList)) {
+          let options = await fetchRoleOptions(serviceAccount.orgId);
+          setRoleOptions(options);
+        }
+      } catch (e) {
+        console.error('Error loading options for service account');
       }
+    }
+    if (contextSrv.licensedAccessControlEnabled()) {
+      fetchOptions();
     }
   }, [serviceAccount.orgId]);
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
This mimics the behavior we have for fetching roles for the service accounts according to the userstable.tsx.

https://github.com/grafana/grafana/blob/main/public/app/features/users/UsersTable.tsx#L25

This removes the TODO and reactors to have a potential fallback when licenseEnabled.

Fixes #
https://github.com/grafana/grafana-enterprise/issues/4864
https://github.com/grafana/grafana-enterprise/issues/4868