### PR TITLE
E2E: Fixed so openPanelMenuItem flow works with new/old panel chrome without breaking changes

### DIFF
--- a/e2e/panels-suite/panelEdit_base.spec.ts
+++ b/e2e/panels-suite/panelEdit_base.spec.ts
@@ -13,7 +13,7 @@ e2e.scenario({
     e2e.flows.openDashboard({ uid: 'TkZXxlNG3' });
     e2e().wait('@query');
 
-    e2e.flows.openPanelMenuItem(e2e.flows.PanelMenuItems.Edit, PANEL_UNDER_TEST, true);
+    e2e.flows.openPanelMenuItem(e2e.flows.PanelMenuItems.Edit, PANEL_UNDER_TEST);
 
     // New panel editor opens when navigating from Panel menu
     e2e.components.PanelEditor.General.content().should('be.visible');

--- a/e2e/various-suite/inspect-drawer.spec.ts
+++ b/e2e/various-suite/inspect-drawer.spec.ts
@@ -37,7 +37,7 @@ e2e.scenario({
     e2e.flows.openDashboard({ uid: 'wfTJJL5Wz' });
 
     // testing opening inspect drawer directly by clicking on Inspect in header menu
-    e2e.flows.openPanelMenuItem(e2e.flows.PanelMenuItems.Inspect, PANEL_UNDER_TEST, true);
+    e2e.flows.openPanelMenuItem(e2e.flows.PanelMenuItems.Inspect, PANEL_UNDER_TEST);
 
     expectDrawerTabsAndContent();
 
@@ -49,7 +49,7 @@ e2e.scenario({
     expectSubMenuScenario('Query');
     expectSubMenuScenario('Panel JSON', 'JSON');
 
-    e2e.flows.openPanelMenuItem(e2e.flows.PanelMenuItems.Edit, PANEL_UNDER_TEST, true);
+    e2e.flows.openPanelMenuItem(e2e.flows.PanelMenuItems.Edit, PANEL_UNDER_TEST);
 
     e2e.components.QueryTab.queryInspectorButton().should('be.visible').click();
 

--- a/packages/grafana-e2e/src/flows/openPanelMenuItem.ts
+++ b/packages/grafana-e2e/src/flows/openPanelMenuItem.ts
@@ -7,26 +7,51 @@ export enum PanelMenuItems {
   Extensions = 'Extensions',
 }
 
-export const openPanelMenuItem = (menu: PanelMenuItems, panelTitle = 'Panel Title', isReactPanel = false) => {
+export const openPanelMenuItem = (menu: PanelMenuItems, panelTitle = 'Panel Title') => {
   // we changed the way we open the panel menu in react panels with the new panel header
-  if (isReactPanel) {
-    e2e.components.Panels.Panel.menu(panelTitle).click({ force: true }); // force click because menu is hidden and show on hover
-    e2e.components.Panels.Panel.menuItems(menu).should('be.visible').click();
-  } else {
-    // this is the old way of opening the panel menu from the title
-    e2e.components.Panels.Panel.title(panelTitle).should('be.visible').click();
-    e2e.components.Panels.Panel.headerItems(menu).should('be.visible').click();
-  }
+  detectPanelType(panelTitle, (isAngularPanel) => {
+    if (isAngularPanel) {
+      e2e.components.Panels.Panel.title(panelTitle).should('be.visible').click();
+      e2e.components.Panels.Panel.headerItems(menu).should('be.visible').click();
+    } else {
+      e2e.components.Panels.Panel.menu(panelTitle).click({ force: true }); // force click because menu is hidden and show on hover
+      e2e.components.Panels.Panel.menuItems(menu).should('be.visible').click();
+    }
+  });
 };
 
 export const openPanelMenuExtension = (extensionTitle: string, panelTitle = 'Panel Title') => {
-  e2e.components.Panels.Panel.title(panelTitle).should('be.visible').click();
-
-  e2e.components.Panels.Panel.headerItems(PanelMenuItems.Extensions)
-    .should('be.visible')
-    .parent()
-    .parent()
-    .invoke('addClass', 'open');
-
-  e2e.components.Panels.Panel.headerItems(extensionTitle).should('be.visible').click();
+  const menuItem = PanelMenuItems.Extensions;
+  // we changed the way we open the panel menu in react panels with the new panel header
+  detectPanelType(panelTitle, (isAngularPanel) => {
+    if (isAngularPanel) {
+      e2e.components.Panels.Panel.title(panelTitle).should('be.visible').click();
+      e2e.components.Panels.Panel.headerItems(menuItem)
+        .should('be.visible')
+        .parent()
+        .parent()
+        .invoke('addClass', 'open');
+      e2e.components.Panels.Panel.headerItems(extensionTitle).should('be.visible').click();
+    } else {
+      e2e.components.Panels.Panel.menu(panelTitle).click({ force: true }); // force click because menu is hidden and show on hover
+      e2e.components.Panels.Panel.menuItems(menuItem).trigger('mouseover', { force: true });
+      e2e.components.Panels.Panel.menuItems(extensionTitle).click({ force: true });
+    }
+  });
 };
+
+function detectPanelType(panelTitle: string, detected: (isAngularPanel: boolean) => void) {
+  e2e.components.Panels.Panel.title(panelTitle).then((el) => {
+    const isAngularPanel = el.find('plugin-component.ng-scope').length > 0;
+
+    if (isAngularPanel) {
+      Cypress.log({
+        name: 'detectPanelType',
+        displayName: 'detector',
+        message: 'Angular panel detected, will use legacy selectors.',
+      });
+    }
+
+    detected(isAngularPanel);
+  });
+}

--- a/public/app/features/dashboard/dashgrid/PanelChromeAngular.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelChromeAngular.tsx
@@ -197,7 +197,11 @@ export class PanelChromeAngularUnconnected extends PureComponent<Props, State> {
     });
 
     return (
-      <div className={containerClassNames} aria-label={selectors.components.Panels.Panel.containerByTitle(panel.title)}>
+      <div
+        className={containerClassNames}
+        data-testid={selectors.components.Panels.Panel.title(panel.title)}
+        aria-label={selectors.components.Panels.Panel.containerByTitle(panel.title)}
+      >
         <PanelHeader
           panel={panel}
           dashboard={dashboard}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

It reverts the `openPanelMenuItem` flow so it has the same signature as before. It also makes it compatible with both the new and the old panel chrome.

**Why do we need this feature?**

In 9.5 we updated the `openPanelMenuItem` to take an optional parameter to indicate if the test was running against an old or a new panel. This made e2e tests written for plugins to break and to make them really tricky to be run against multiple versions of Grafana.

**Who is this feature for?**

Plugin developers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
