### PR TITLE
Alerting: Tiny refactor on the eval and schedule packages

### DIFF
--- a/pkg/services/ngalert/api/api_ruler.go
+++ b/pkg/services/ngalert/api/api_ruler.go
@@ -303,7 +303,7 @@ func (srv RulerSrv) RoutePostNameRulesConfig(c *contextmodel.ReqContext, ruleGro
 	}
 
 	rules, err := validateRuleGroup(&ruleGroupConfig, c.SignedInUser.OrgID, namespace, func(condition ngmodels.Condition) error {
-		return srv.conditionValidator.Validate(eval.Context(c.Req.Context(), c.SignedInUser), condition)
+		return srv.conditionValidator.Validate(eval.NewContext(c.Req.Context(), c.SignedInUser), condition)
 	}, srv.cfg)
 	if err != nil {
 		return ErrResp(http.StatusBadRequest, err, "")

--- a/pkg/services/ngalert/api/api_testing.go
+++ b/pkg/services/ngalert/api/api_testing.go
@@ -52,7 +52,7 @@ func (srv TestingApiSrv) RouteTestGrafanaRuleConfig(c *contextmodel.ReqContext, 
 		Condition: body.GrafanaManagedCondition.Condition,
 		Data:      queries,
 	}
-	ctx := eval.Context(c.Req.Context(), c.SignedInUser)
+	ctx := eval.NewContext(c.Req.Context(), c.SignedInUser)
 
 	conditionEval, err := srv.evaluator.Create(ctx, evalCond)
 	if err != nil {
@@ -128,7 +128,7 @@ func (srv TestingApiSrv) RouteEvalQueries(c *contextmodel.ReqContext, cmd apimod
 	if len(cmd.Data) > 0 {
 		cond.Condition = cmd.Data[0].RefID
 	}
-	evaluator, err := srv.evaluator.Create(eval.Context(c.Req.Context(), c.SignedInUser), cond)
+	evaluator, err := srv.evaluator.Create(eval.NewContext(c.Req.Context(), c.SignedInUser), cond)
 
 	if err != nil {
 		return ErrResp(http.StatusBadRequest, err, "Failed to build evaluator for queries and expressions")

--- a/pkg/services/ngalert/eval/context.go
+++ b/pkg/services/ngalert/eval/context.go
@@ -12,7 +12,7 @@ type EvaluationContext struct {
 	User *user.SignedInUser
 }
 
-func Context(ctx context.Context, user *user.SignedInUser) EvaluationContext {
+func NewContext(ctx context.Context, user *user.SignedInUser) EvaluationContext {
 	return EvaluationContext{
 		Ctx:  ctx,
 		User: user,

--- a/pkg/services/ngalert/eval/eval.go
+++ b/pkg/services/ngalert/eval/eval.go
@@ -220,7 +220,7 @@ func (s State) String() string {
 	return [...]string{"Normal", "Alerting", "Pending", "NoData", "Error"}[s]
 }
 
-func buildDatasourceHeaders(ctx EvaluationContext) map[string]string {
+func buildDatasourceHeaders(ctx context.Context) map[string]string {
 	headers := map[string]string{
 		// Many data sources check this in query method as sometimes alerting needs special considerations.
 		// Several existing systems also compare against the value of this header. Altering this constitutes a breaking change.
@@ -233,7 +233,7 @@ func buildDatasourceHeaders(ctx EvaluationContext) map[string]string {
 		models.CacheSkipHeaderName: "true",
 	}
 
-	key, ok := models.RuleKeyFromContext(ctx.Ctx)
+	key, ok := models.RuleKeyFromContext(ctx)
 	if ok {
 		headers["X-Rule-Uid"] = key.UID
 		headers["X-Grafana-Org-Id"] = strconv.FormatInt(key.OrgID, 10)
@@ -246,7 +246,7 @@ func buildDatasourceHeaders(ctx EvaluationContext) map[string]string {
 func getExprRequest(ctx EvaluationContext, data []models.AlertQuery, dsCacheService datasources.CacheService) (*expr.Request, error) {
 	req := &expr.Request{
 		OrgId:   ctx.User.OrgID,
-		Headers: buildDatasourceHeaders(ctx),
+		Headers: buildDatasourceHeaders(ctx.Ctx),
 	}
 
 	datasources := make(map[string]*datasources.DataSource, len(data))
@@ -295,7 +295,8 @@ func getExprRequest(ctx EvaluationContext, data []models.AlertQuery, dsCacheServ
 type NumberValueCapture struct {
 	Var    string // RefID
 	Labels data.Labels
-	Value  *float64
+
+	Value *float64
 }
 
 func queryDataResponseToExecutionResults(c models.Condition, execResp *backend.QueryDataResponse) ExecutionResults {

--- a/pkg/services/ngalert/eval/eval_test.go
+++ b/pkg/services/ngalert/eval/eval_test.go
@@ -533,7 +533,7 @@ func TestValidate(t *testing.T) {
 			})
 
 			evaluator := NewEvaluatorFactory(setting.UnifiedAlertingSettings{}, cacheService, expr.ProvideService(&setting.Cfg{ExpressionsEnabled: true}, nil, nil), store)
-			evalCtx := Context(context.Background(), u)
+			evalCtx := NewContext(context.Background(), u)
 
 			err := evaluator.Validate(evalCtx, condition)
 			if testCase.error {

--- a/pkg/services/ngalert/models/alert_query.go
+++ b/pkg/services/ngalert/models/alert_query.go
@@ -97,6 +97,10 @@ type AlertQuery struct {
 	modelProps map[string]interface{}
 }
 
+func (aq *AlertQuery) String() string {
+	return fmt.Sprintf("refID: %s, queryType: %s, datasourceUID: %s", aq.RefID, aq.QueryType, aq.DatasourceUID)
+}
+
 func (aq *AlertQuery) setModelProps() error {
 	aq.modelProps = make(map[string]interface{})
 	err := json.Unmarshal(aq.Model, &aq.modelProps)

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -567,7 +567,7 @@ func (sch *schedule) getRuleExtraLabels(evalCtx *evaluation) map[string]string {
 	return extraLabels
 }
 
-func ScheduleUserFor(orgID int64) *user.SignedInUser {
+func SchedulerUserFor(orgID int64) *user.SignedInUser {
 	return &user.SignedInUser{
 		UserID:           -1,
 		IsServiceAccount: true,

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -373,21 +373,7 @@ func (sch *schedule) ruleRoutine(grafanaCtx context.Context, key ngmodels.AlertR
 		logger := logger.New("version", e.rule.Version, "attempt", attempt, "now", e.scheduledAt)
 		start := sch.clock.Now()
 
-		schedulerUser := &user.SignedInUser{
-			UserID:           -1,
-			IsServiceAccount: true,
-			Login:            "grafana_scheduler",
-			OrgID:            e.rule.OrgID,
-			OrgRole:          org.RoleAdmin,
-			Permissions: map[int64]map[string][]string{
-				e.rule.OrgID: {
-					datasources.ActionQuery: []string{
-						datasources.ScopeAll,
-					},
-				},
-			},
-		}
-		evalCtx := eval.Context(ctx, schedulerUser)
+		evalCtx := eval.NewContext(ctx, ScheduleUserFor(e.rule.OrgID))
 		ruleEval, err := sch.evaluatorFactory.Create(evalCtx, e.rule.GetEvalCondition())
 		var results eval.Results
 		var dur time.Duration
@@ -579,4 +565,21 @@ func (sch *schedule) getRuleExtraLabels(evalCtx *evaluation) map[string]string {
 		extraLabels[ngmodels.FolderTitleLabel] = evalCtx.folderTitle
 	}
 	return extraLabels
+}
+
+func ScheduleUserFor(orgID int64) *user.SignedInUser {
+	return &user.SignedInUser{
+		UserID:           -1,
+		IsServiceAccount: true,
+		Login:            "grafana_scheduler",
+		OrgID:            orgID,
+		OrgRole:          org.RoleAdmin,
+		Permissions: map[int64]map[string][]string{
+			orgID: {
+				datasources.ActionQuery: []string{
+					datasources.ScopeAll,
+				},
+			},
+		},
+	}
 }

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -373,7 +373,7 @@ func (sch *schedule) ruleRoutine(grafanaCtx context.Context, key ngmodels.AlertR
 		logger := logger.New("version", e.rule.Version, "attempt", attempt, "now", e.scheduledAt)
 		start := sch.clock.Now()
 
-		evalCtx := eval.NewContext(ctx, ScheduleUserFor(e.rule.OrgID))
+		evalCtx := eval.NewContext(ctx, SchedulerUserFor(e.rule.OrgID))
 		ruleEval, err := sch.evaluatorFactory.Create(evalCtx, e.rule.GetEvalCondition())
 		var results eval.Results
 		var dur time.Duration


### PR DESCRIPTION
two tiny things:

- We had a constructor on something called a `Context` which is not a `context.Context` so let's just name that constructor `NewContext`
- The user that we use to run query evaluations is the same (with some variation) abstract it to a function so that it can be re-used when necessary.