### PR TITLE
Cloudwatch: Pass refId from query for expression queries

### DIFF
--- a/pkg/tsdb/cloudwatch/cloudwatch_test.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch_test.go
@@ -2,16 +2,11 @@ package cloudwatch
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"testing"
-	"time"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
-	"github.com/aws/aws-sdk-go/service/cloudwatchlogs/cloudwatchlogsiface"
 	"github.com/google/go-cmp/cmp"
 	"github.com/grafana/grafana-aws-sdk/pkg/awsds"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
@@ -19,14 +14,13 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
 	"github.com/grafana/grafana/pkg/infra/httpclient"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
-	ngalertmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
-	"github.com/grafana/grafana/pkg/services/query"
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/mocks"
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/models"
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"testing"
 )
 
 func TestNewInstanceSettings(t *testing.T) {
@@ -191,133 +185,6 @@ func Test_CheckHealth(t *testing.T) {
 			Status:  backend.HealthStatusError,
 			Message: "1. CloudWatch metrics query failed: some sessions error\n2. CloudWatch logs query failed: some sessions error",
 		}, resp)
-	})
-}
-func Test_executeSyncLogQuery(t *testing.T) {
-	origNewCWClient := NewCWClient
-	t.Cleanup(func() {
-		NewCWClient = origNewCWClient
-	})
-
-	var cli fakeCWLogsClient
-	NewCWLogsClient = func(sess *session.Session) cloudwatchlogsiface.CloudWatchLogsAPI {
-		return &cli
-	}
-
-	t.Run("getCWLogsClient is called with region from input JSON", func(t *testing.T) {
-		cli = fakeCWLogsClient{queryResults: cloudwatchlogs.GetQueryResultsOutput{Status: aws.String("Complete")}}
-		im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-			return DataSource{Settings: models.CloudWatchSettings{}}, nil
-		})
-		sess := fakeSessionCache{}
-		executor := newExecutor(im, newTestConfig(), &sess, featuremgmt.WithFeatures())
-
-		_, err := executor.QueryData(context.Background(), &backend.QueryDataRequest{
-			Headers:       map[string]string{ngalertmodels.FromAlertHeaderName: "some value"},
-			PluginContext: backend.PluginContext{DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{}},
-			Queries: []backend.DataQuery{
-				{
-					TimeRange: backend.TimeRange{From: time.Unix(0, 0), To: time.Unix(1, 0)},
-					JSON: json.RawMessage(`{
-						"queryMode":    "Logs",
-						"region": "some region"
-					}`),
-				},
-			},
-		})
-
-		assert.NoError(t, err)
-		assert.Equal(t, []string{"some region"}, sess.calledRegions)
-	})
-
-	t.Run("getCWLogsClient is called with region from instance manager when region is default", func(t *testing.T) {
-		cli = fakeCWLogsClient{queryResults: cloudwatchlogs.GetQueryResultsOutput{Status: aws.String("Complete")}}
-		im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-			return DataSource{Settings: models.CloudWatchSettings{AWSDatasourceSettings: awsds.AWSDatasourceSettings{Region: "instance manager's region"}}}, nil
-		})
-		sess := fakeSessionCache{}
-
-		executor := newExecutor(im, newTestConfig(), &sess, featuremgmt.WithFeatures())
-		_, err := executor.QueryData(context.Background(), &backend.QueryDataRequest{
-			Headers:       map[string]string{ngalertmodels.FromAlertHeaderName: "some value"},
-			PluginContext: backend.PluginContext{DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{}},
-			Queries: []backend.DataQuery{
-				{
-					TimeRange: backend.TimeRange{From: time.Unix(0, 0), To: time.Unix(1, 0)},
-					JSON: json.RawMessage(`{
-						"queryMode":    "Logs",
-						"region": "default"
-					}`),
-				},
-			},
-		})
-
-		assert.NoError(t, err)
-		assert.Equal(t, []string{"instance manager's region"}, sess.calledRegions)
-	})
-
-	t.Run("with header", func(t *testing.T) {
-		testcases := []struct {
-			name    string
-			headers map[string]string
-			called  bool
-		}{
-			{
-				"alert header",
-				map[string]string{ngalertmodels.FromAlertHeaderName: "some value"},
-				true,
-			},
-			{
-				"expression header",
-				map[string]string{fmt.Sprintf("http_%s", query.HeaderFromExpression): "some value"},
-				true,
-			},
-			{
-				"no header",
-				map[string]string{},
-				false,
-			},
-		}
-		origExecuteSyncLogQuery := executeSyncLogQuery
-		var syncCalled bool
-		executeSyncLogQuery = func(ctx context.Context, e *cloudWatchExecutor, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
-			syncCalled = true
-			return nil, nil
-		}
-
-		for _, tc := range testcases {
-			t.Run(tc.name, func(t *testing.T) {
-				syncCalled = false
-				cli = fakeCWLogsClient{queryResults: cloudwatchlogs.GetQueryResultsOutput{Status: aws.String("Complete")}}
-				im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-					return DataSource{Settings: models.CloudWatchSettings{AWSDatasourceSettings: awsds.AWSDatasourceSettings{Region: "instance manager's region"}}}, nil
-				})
-				sess := fakeSessionCache{}
-
-				executor := newExecutor(im, newTestConfig(), &sess, featuremgmt.WithFeatures())
-				_, err := executor.QueryData(context.Background(), &backend.QueryDataRequest{
-					Headers:       tc.headers,
-					PluginContext: backend.PluginContext{DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{}},
-					Queries: []backend.DataQuery{
-						{
-							TimeRange: backend.TimeRange{From: time.Unix(0, 0), To: time.Unix(1, 0)},
-							JSON: json.RawMessage(`{
-								"queryMode":    "Logs",
-								"type":        "logAction",
-								"subtype":     "StartQuery",
-								"region":      "default",
-								"queryString": "fields @message"
-							}`),
-						},
-					},
-				})
-
-				assert.NoError(t, err)
-				assert.Equal(t, tc.called, syncCalled)
-			})
-		}
-
-		executeSyncLogQuery = origExecuteSyncLogQuery
 	})
 }
 

--- a/pkg/tsdb/cloudwatch/cloudwatch_test.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch_test.go
@@ -3,6 +3,8 @@ package cloudwatch
 import (
 	"context"
 	"fmt"
+	"testing"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
@@ -20,7 +22,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestNewInstanceSettings(t *testing.T) {

--- a/pkg/tsdb/cloudwatch/log_sync_query.go
+++ b/pkg/tsdb/cloudwatch/log_sync_query.go
@@ -4,307 +4,110 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"testing"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs/cloudwatchlogsiface"
-	"github.com/grafana/grafana-aws-sdk/pkg/awsds"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
-	"github.com/grafana/grafana-plugin-sdk-go/backend/datasource"
-	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
-	"github.com/grafana/grafana/pkg/services/featuremgmt"
-	ngalertmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
-	"github.com/grafana/grafana/pkg/services/query"
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/models"
-	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/utils"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
 )
 
-func Test_executeSyncLogQuery(t *testing.T) {
-	origNewCWClient := NewCWClient
-	t.Cleanup(func() {
-		NewCWClient = origNewCWClient
-	})
+const (
+	alertMaxAttempts = 8
+	alertPollPeriod  = time.Second
+)
 
-	var cli fakeCWLogsClient
-	NewCWLogsClient = func(sess *session.Session) cloudwatchlogsiface.CloudWatchLogsAPI {
-		return &cli
+var executeSyncLogQuery = func(ctx context.Context, e *cloudWatchExecutor, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+	resp := backend.NewQueryDataResponse()
+
+	for _, q := range req.Queries {
+		var logsQuery models.LogsQuery
+		err := json.Unmarshal(q.JSON, &logsQuery)
+		if err != nil {
+			continue
+		}
+
+		logsQuery.Subtype = "StartQuery"
+		logsQuery.QueryString = logsQuery.Expression
+
+		region := logsQuery.Region
+		if logsQuery.Region == "" || region == defaultRegion {
+			instance, err := e.getInstance(req.PluginContext)
+			if err != nil {
+				return nil, err
+			}
+			logsQuery.Region = instance.Settings.Region
+		}
+
+		logsClient, err := e.getCWLogsClient(req.PluginContext, region)
+		if err != nil {
+			return nil, err
+		}
+
+		getQueryResultsOutput, err := e.syncQuery(ctx, logsClient, q, logsQuery)
+		if err != nil {
+			return nil, err
+		}
+
+		dataframe, err := logsResultsToDataframes(getQueryResultsOutput)
+		if err != nil {
+			return nil, err
+		}
+
+		var frames []*data.Frame
+		if len(logsQuery.StatsGroups) > 0 && len(dataframe.Fields) > 0 {
+			frames, err = groupResults(dataframe, logsQuery.StatsGroups)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			frames = data.Frames{dataframe}
+		}
+
+		refId := "A"
+		if q.RefID != "" {
+			refId = q.RefID
+		}
+
+		respD := resp.Responses[refId]
+		respD.Frames = frames
+		resp.Responses[refId] = respD
 	}
 
-	t.Run("getCWLogsClient is called with region from input JSON", func(t *testing.T) {
-		cli = fakeCWLogsClient{queryResults: cloudwatchlogs.GetQueryResultsOutput{Status: aws.String("Complete")}}
-		im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-			return DataSource{Settings: models.CloudWatchSettings{}}, nil
-		})
-		sess := fakeSessionCache{}
-		executor := newExecutor(im, newTestConfig(), &sess, featuremgmt.WithFeatures())
-
-		_, err := executor.QueryData(context.Background(), &backend.QueryDataRequest{
-			Headers:       map[string]string{ngalertmodels.FromAlertHeaderName: "some value"},
-			PluginContext: backend.PluginContext{DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{}},
-			Queries: []backend.DataQuery{
-				{
-					TimeRange: backend.TimeRange{From: time.Unix(0, 0), To: time.Unix(1, 0)},
-					JSON: json.RawMessage(`{
-						"queryMode":    "Logs",
-						"region": "some region"
-					}`),
-				},
-			},
-		})
-
-		assert.NoError(t, err)
-		assert.Equal(t, []string{"some region"}, sess.calledRegions)
-	})
-
-	t.Run("getCWLogsClient is called with region from instance manager when region is default", func(t *testing.T) {
-		cli = fakeCWLogsClient{queryResults: cloudwatchlogs.GetQueryResultsOutput{Status: aws.String("Complete")}}
-		im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-			return DataSource{Settings: models.CloudWatchSettings{AWSDatasourceSettings: awsds.AWSDatasourceSettings{Region: "instance manager's region"}}}, nil
-		})
-		sess := fakeSessionCache{}
-
-		executor := newExecutor(im, newTestConfig(), &sess, featuremgmt.WithFeatures())
-		_, err := executor.QueryData(context.Background(), &backend.QueryDataRequest{
-			Headers:       map[string]string{ngalertmodels.FromAlertHeaderName: "some value"},
-			PluginContext: backend.PluginContext{DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{}},
-			Queries: []backend.DataQuery{
-				{
-					TimeRange: backend.TimeRange{From: time.Unix(0, 0), To: time.Unix(1, 0)},
-					JSON: json.RawMessage(`{
-						"queryMode":    "Logs",
-						"region": "default"
-					}`),
-				},
-			},
-		})
-
-		assert.NoError(t, err)
-		assert.Equal(t, []string{"instance manager's region"}, sess.calledRegions)
-	})
-
-	t.Run("with header", func(t *testing.T) {
-		testcases := []struct {
-			name    string
-			headers map[string]string
-			called  bool
-		}{
-			{
-				"alert header",
-				map[string]string{ngalertmodels.FromAlertHeaderName: "some value"},
-				true,
-			},
-			{
-				"expression header",
-				map[string]string{fmt.Sprintf("http_%s", query.HeaderFromExpression): "some value"},
-				true,
-			},
-			{
-				"no header",
-				map[string]string{},
-				false,
-			},
-		}
-		origExecuteSyncLogQuery := executeSyncLogQuery
-		var syncCalled bool
-		executeSyncLogQuery = func(ctx context.Context, e *cloudWatchExecutor, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
-			syncCalled = true
-			return nil, nil
-		}
-
-		for _, tc := range testcases {
-			t.Run(tc.name, func(t *testing.T) {
-				syncCalled = false
-				cli = fakeCWLogsClient{queryResults: cloudwatchlogs.GetQueryResultsOutput{Status: aws.String("Complete")}}
-				im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-					return DataSource{Settings: models.CloudWatchSettings{AWSDatasourceSettings: awsds.AWSDatasourceSettings{Region: "instance manager's region"}}}, nil
-				})
-				sess := fakeSessionCache{}
-
-				executor := newExecutor(im, newTestConfig(), &sess, featuremgmt.WithFeatures())
-				_, err := executor.QueryData(context.Background(), &backend.QueryDataRequest{
-					Headers:       tc.headers,
-					PluginContext: backend.PluginContext{DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{}},
-					Queries: []backend.DataQuery{
-						{
-							TimeRange: backend.TimeRange{From: time.Unix(0, 0), To: time.Unix(1, 0)},
-							JSON: json.RawMessage(`{
-								"queryMode":    "Logs",
-								"type":        "logAction",
-								"subtype":     "StartQuery",
-								"region":      "default",
-								"queryString": "fields @message"
-							}`),
-						},
-					},
-				})
-
-				assert.NoError(t, err)
-				assert.Equal(t, tc.called, syncCalled)
-			})
-		}
-
-		executeSyncLogQuery = origExecuteSyncLogQuery
-	})
+	return resp, nil
 }
-func Test_executeSyncLogQueryMocks(t *testing.T) {
-	origNewCWClient := NewCWClient
-	t.Cleanup(func() {
-		NewCWClient = origNewCWClient
-	})
 
-	var cli *mockLogsSyncClient
-	NewCWLogsClient = func(sess *session.Session) cloudwatchlogsiface.CloudWatchLogsAPI {
-		return cli
+func (e *cloudWatchExecutor) syncQuery(ctx context.Context, logsClient cloudwatchlogsiface.CloudWatchLogsAPI,
+	queryContext backend.DataQuery, logsQuery models.LogsQuery) (*cloudwatchlogs.GetQueryResultsOutput, error) {
+	startQueryOutput, err := e.executeStartQuery(ctx, logsClient, logsQuery, queryContext.TimeRange)
+	if err != nil {
+		return nil, err
 	}
 
-	t.Run("when a query refId is not provided, 'A' is assigned by default", func(t *testing.T) {
-		cli = &mockLogsSyncClient{}
-		cli.On("StartQueryWithContext", mock.Anything, mock.Anything, mock.Anything).Return(&cloudwatchlogs.StartQueryOutput{
-			QueryId: aws.String("abcd-efgh-ijkl-mnop"),
-		}, nil)
-		cli.On("GetQueryResultsWithContext", mock.Anything, mock.Anything, mock.Anything).Return(&cloudwatchlogs.GetQueryResultsOutput{Status: aws.String("Complete")}, nil)
-		im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-			return DataSource{Settings: models.CloudWatchSettings{}}, nil
-		})
-		executor := newExecutor(im, newTestConfig(), &fakeSessionCache{}, featuremgmt.WithFeatures())
+	requestParams := models.LogsQuery{
+		Region:  logsQuery.Region,
+		QueryId: *startQueryOutput.QueryId,
+	}
 
-		res, err := executor.QueryData(context.Background(), &backend.QueryDataRequest{
-			Headers:       map[string]string{ngalertmodels.FromAlertHeaderName: "some value"},
-			PluginContext: backend.PluginContext{DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{}},
-			Queries: []backend.DataQuery{
-				{
-					TimeRange: backend.TimeRange{From: time.Unix(0, 0), To: time.Unix(1, 0)},
-					JSON: json.RawMessage(`{
-						"queryMode":    "Logs"
-					}`),
-				},
-			},
-		})
+	ticker := time.NewTicker(alertPollPeriod)
+	defer ticker.Stop()
 
-		assert.NoError(t, err)
-		_, ok := res.Responses["A"]
-		assert.True(t, ok)
-	})
+	attemptCount := 1
+	for range ticker.C {
+		res, err := e.executeGetQueryResults(ctx, logsClient, requestParams)
+		if err != nil {
+			return nil, err
+		}
+		if isTerminated(*res.Status) {
+			return res, err
+		}
+		if attemptCount >= alertMaxAttempts {
+			return res, fmt.Errorf("fetching of query results exceeded max number of attempts")
+		}
 
-	t.Run("when a query refId is provided, it is returned in the response", func(t *testing.T) {
-		cli = &mockLogsSyncClient{}
-		cli.On("StartQueryWithContext", mock.Anything, mock.Anything, mock.Anything).Return(&cloudwatchlogs.StartQueryOutput{
-			QueryId: aws.String("abcd-efgh-ijkl-mnop"),
-		}, nil)
-		cli.On("GetQueryResultsWithContext", mock.Anything, mock.Anything, mock.Anything).Return(&cloudwatchlogs.GetQueryResultsOutput{Status: aws.String("Complete")}, nil)
-		im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-			return DataSource{Settings: models.CloudWatchSettings{}}, nil
-		})
-		executor := newExecutor(im, newTestConfig(), &fakeSessionCache{}, featuremgmt.WithFeatures())
+		attemptCount++
+	}
 
-		res, err := executor.QueryData(context.Background(), &backend.QueryDataRequest{
-			Headers:       map[string]string{ngalertmodels.FromAlertHeaderName: "some value"},
-			PluginContext: backend.PluginContext{DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{}},
-			Queries: []backend.DataQuery{
-				{
-					RefID:     "A",
-					TimeRange: backend.TimeRange{From: time.Unix(0, 0), To: time.Unix(1, 0)},
-					JSON: json.RawMessage(`{
-						"queryMode":    "Logs"
-					}`),
-				},
-				{
-					RefID:     "B",
-					TimeRange: backend.TimeRange{From: time.Unix(0, 0), To: time.Unix(1, 0)},
-					JSON: json.RawMessage(`{
-						"queryMode":    "Logs"
-					}`),
-				},
-			},
-		})
-
-		assert.NoError(t, err)
-		_, ok := res.Responses["A"]
-		assert.True(t, ok)
-		_, ok = res.Responses["B"]
-		assert.True(t, ok)
-	})
-
-	t.Run("when RefIDs are provided, correctly pass them on with the results", func(t *testing.T) {
-		// This test demonstrates that given two queries with different RefIds,
-		// when each query has a different response from AWS API calls, the RefIds are correctly reassigned to the associated response.
-		cli = &mockLogsSyncClient{}
-		// mock.MatchedBy makes sure that the QueryId below will only be returned when the input expression = "query string for A"
-		cli.On("StartQueryWithContext", mock.Anything, mock.MatchedBy(func(input *cloudwatchlogs.StartQueryInput) bool {
-			return *input.QueryString == "fields @timestamp,ltrim(@log) as __log__grafana_internal__,ltrim(@logStream) as __logstream__grafana_internal__|query string for A"
-		}), mock.Anything).Return(&cloudwatchlogs.StartQueryOutput{
-			QueryId: aws.String("queryId for A"),
-		}, nil)
-
-		// mock.MatchedBy makes sure that the QueryId below will only be returned when the input expression = "query string for B"
-		cli.On("StartQueryWithContext", mock.Anything, mock.MatchedBy(func(input *cloudwatchlogs.StartQueryInput) bool {
-			return *input.QueryString == "fields @timestamp,ltrim(@log) as __log__grafana_internal__,ltrim(@logStream) as __logstream__grafana_internal__|query string for B"
-		}), mock.Anything).Return(&cloudwatchlogs.StartQueryOutput{
-			QueryId: aws.String("queryId for B"),
-		}, nil)
-		cli.On("GetQueryResultsWithContext", mock.Anything, mock.MatchedBy(func(input *cloudwatchlogs.GetQueryResultsInput) bool {
-			return *input.QueryId == "queryId for A"
-		}), mock.Anything).Return(&cloudwatchlogs.GetQueryResultsOutput{
-			// this result will only be returned when the argument is QueryId = "query string for A"
-			Results: [][]*cloudwatchlogs.ResultField{{{
-				Field: utils.Pointer("@log"),
-				Value: utils.Pointer("A result"),
-			}}},
-			Status: aws.String("Complete")}, nil)
-		cli.On("GetQueryResultsWithContext", mock.Anything, mock.MatchedBy(func(input *cloudwatchlogs.GetQueryResultsInput) bool {
-			return *input.QueryId == "queryId for B"
-		}), mock.Anything).Return(&cloudwatchlogs.GetQueryResultsOutput{
-			// this result will only be returned when the argument is QueryId = "query string for B"
-			Results: [][]*cloudwatchlogs.ResultField{{{
-				Field: utils.Pointer("@log"),
-				Value: utils.Pointer("B result"),
-			}}},
-			Status: aws.String("Complete")}, nil)
-
-		im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-			return DataSource{Settings: models.CloudWatchSettings{}}, nil
-		})
-		executor := newExecutor(im, newTestConfig(), &fakeSessionCache{}, featuremgmt.WithFeatures())
-
-		res, err := executor.QueryData(context.Background(), &backend.QueryDataRequest{
-			Headers:       map[string]string{ngalertmodels.FromAlertHeaderName: "some value"},
-			PluginContext: backend.PluginContext{DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{}},
-			Queries: []backend.DataQuery{
-				{
-					RefID:     "A",
-					TimeRange: backend.TimeRange{From: time.Unix(0, 0), To: time.Unix(1, 0)},
-					JSON: json.RawMessage(`{
-						"queryMode":    "Logs",
-						"expression": "query string for A"
-					}`),
-				},
-				{
-					RefID:     "B",
-					TimeRange: backend.TimeRange{From: time.Unix(0, 0), To: time.Unix(1, 0)},
-					JSON: json.RawMessage(`{
-						"queryMode":    "Logs",
-						"expression": "query string for B"
-					}`),
-				},
-			},
-		})
-
-		expectedLogFieldFromFirstCall := data.NewField("@log", nil, []*string{utils.Pointer("A result")}) // verifies the response from GetQueryResultsWithContext matches the input RefId A
-		assert.NoError(t, err)
-		respA, ok := res.Responses["A"]
-		require.True(t, ok)
-		assert.Equal(t, []*data.Field{expectedLogFieldFromFirstCall}, respA.Frames[0].Fields)
-
-		expectedLogFieldFromSecondCall := data.NewField("@log", nil, []*string{utils.Pointer("B result")}) // verifies the response from GetQueryResultsWithContext matches the input RefId B
-		respB, ok := res.Responses["B"]
-		require.True(t, ok)
-		assert.Equal(t, []*data.Field{expectedLogFieldFromSecondCall}, respB.Frames[0].Fields)
-	})
+	return nil, nil
 }

--- a/pkg/tsdb/cloudwatch/log_sync_query.go
+++ b/pkg/tsdb/cloudwatch/log_sync_query.go
@@ -65,9 +65,14 @@ var executeSyncLogQuery = func(ctx context.Context, e *cloudWatchExecutor, req *
 			frames = data.Frames{dataframe}
 		}
 
-		respD := resp.Responses["A"]
+		refId := "A"
+		if(q.RefID != "") {
+			refId = q.RefID
+		}
+
+		respD := resp.Responses[refId]
 		respD.Frames = frames
-		resp.Responses["A"] = respD
+		resp.Responses[refId] = respD
 	}
 
 	return resp, nil

--- a/pkg/tsdb/cloudwatch/log_sync_query_test.go
+++ b/pkg/tsdb/cloudwatch/log_sync_query_test.go
@@ -261,7 +261,7 @@ func Test_executeSyncLogQuery_handles_RefId_from_input_queries(t *testing.T) {
 		cli.On("GetQueryResultsWithContext", mock.Anything, mock.MatchedBy(func(input *cloudwatchlogs.GetQueryResultsInput) bool {
 			return *input.QueryId == "queryId for B"
 		}), mock.Anything).Return(&cloudwatchlogs.GetQueryResultsOutput{
-			// this result will only be returned when the argument is QueryId = "query string for B"
+			// this result will only be returned when the argument is QueryId = "queryId for B"
 			Results: [][]*cloudwatchlogs.ResultField{{{
 				Field: utils.Pointer("@log"),
 				Value: utils.Pointer("B result"),

--- a/pkg/tsdb/cloudwatch/log_sync_query_test.go
+++ b/pkg/tsdb/cloudwatch/log_sync_query_test.go
@@ -1,0 +1,310 @@
+package cloudwatch
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
+	"github.com/aws/aws-sdk-go/service/cloudwatchlogs/cloudwatchlogsiface"
+	"github.com/grafana/grafana-aws-sdk/pkg/awsds"
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/datasource"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	ngalertmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/services/query"
+	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/models"
+	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_executeSyncLogQuery(t *testing.T) {
+	origNewCWClient := NewCWClient
+	t.Cleanup(func() {
+		NewCWClient = origNewCWClient
+	})
+
+	var cli fakeCWLogsClient
+	NewCWLogsClient = func(sess *session.Session) cloudwatchlogsiface.CloudWatchLogsAPI {
+		return &cli
+	}
+
+	t.Run("getCWLogsClient is called with region from input JSON", func(t *testing.T) {
+		cli = fakeCWLogsClient{queryResults: cloudwatchlogs.GetQueryResultsOutput{Status: aws.String("Complete")}}
+		im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
+			return DataSource{Settings: models.CloudWatchSettings{}}, nil
+		})
+		sess := fakeSessionCache{}
+		executor := newExecutor(im, newTestConfig(), &sess, featuremgmt.WithFeatures())
+
+		_, err := executor.QueryData(context.Background(), &backend.QueryDataRequest{
+			Headers:       map[string]string{ngalertmodels.FromAlertHeaderName: "some value"},
+			PluginContext: backend.PluginContext{DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{}},
+			Queries: []backend.DataQuery{
+				{
+					TimeRange: backend.TimeRange{From: time.Unix(0, 0), To: time.Unix(1, 0)},
+					JSON: json.RawMessage(`{
+						"queryMode":    "Logs",
+						"region": "some region"
+					}`),
+				},
+			},
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"some region"}, sess.calledRegions)
+	})
+
+	t.Run("getCWLogsClient is called with region from instance manager when region is default", func(t *testing.T) {
+		cli = fakeCWLogsClient{queryResults: cloudwatchlogs.GetQueryResultsOutput{Status: aws.String("Complete")}}
+		im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
+			return DataSource{Settings: models.CloudWatchSettings{AWSDatasourceSettings: awsds.AWSDatasourceSettings{Region: "instance manager's region"}}}, nil
+		})
+		sess := fakeSessionCache{}
+
+		executor := newExecutor(im, newTestConfig(), &sess, featuremgmt.WithFeatures())
+		_, err := executor.QueryData(context.Background(), &backend.QueryDataRequest{
+			Headers:       map[string]string{ngalertmodels.FromAlertHeaderName: "some value"},
+			PluginContext: backend.PluginContext{DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{}},
+			Queries: []backend.DataQuery{
+				{
+					TimeRange: backend.TimeRange{From: time.Unix(0, 0), To: time.Unix(1, 0)},
+					JSON: json.RawMessage(`{
+						"queryMode":    "Logs",
+						"region": "default"
+					}`),
+				},
+			},
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"instance manager's region"}, sess.calledRegions)
+	})
+
+	t.Run("with header", func(t *testing.T) {
+		testcases := []struct {
+			name    string
+			headers map[string]string
+			called  bool
+		}{
+			{
+				"alert header",
+				map[string]string{ngalertmodels.FromAlertHeaderName: "some value"},
+				true,
+			},
+			{
+				"expression header",
+				map[string]string{fmt.Sprintf("http_%s", query.HeaderFromExpression): "some value"},
+				true,
+			},
+			{
+				"no header",
+				map[string]string{},
+				false,
+			},
+		}
+		origExecuteSyncLogQuery := executeSyncLogQuery
+		var syncCalled bool
+		executeSyncLogQuery = func(ctx context.Context, e *cloudWatchExecutor, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+			syncCalled = true
+			return nil, nil
+		}
+
+		for _, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+				syncCalled = false
+				cli = fakeCWLogsClient{queryResults: cloudwatchlogs.GetQueryResultsOutput{Status: aws.String("Complete")}}
+				im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
+					return DataSource{Settings: models.CloudWatchSettings{AWSDatasourceSettings: awsds.AWSDatasourceSettings{Region: "instance manager's region"}}}, nil
+				})
+				sess := fakeSessionCache{}
+
+				executor := newExecutor(im, newTestConfig(), &sess, featuremgmt.WithFeatures())
+				_, err := executor.QueryData(context.Background(), &backend.QueryDataRequest{
+					Headers:       tc.headers,
+					PluginContext: backend.PluginContext{DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{}},
+					Queries: []backend.DataQuery{
+						{
+							TimeRange: backend.TimeRange{From: time.Unix(0, 0), To: time.Unix(1, 0)},
+							JSON: json.RawMessage(`{
+								"queryMode":    "Logs",
+								"type":        "logAction",
+								"subtype":     "StartQuery",
+								"region":      "default",
+								"queryString": "fields @message"
+							}`),
+						},
+					},
+				})
+
+				assert.NoError(t, err)
+				assert.Equal(t, tc.called, syncCalled)
+			})
+		}
+
+		executeSyncLogQuery = origExecuteSyncLogQuery
+	})
+}
+func Test_executeSyncLogQueryMocks(t *testing.T) {
+	origNewCWClient := NewCWClient
+	t.Cleanup(func() {
+		NewCWClient = origNewCWClient
+	})
+
+	var cli *mockLogsSyncClient
+	NewCWLogsClient = func(sess *session.Session) cloudwatchlogsiface.CloudWatchLogsAPI {
+		return cli
+	}
+
+	t.Run("when a query refId is not provided, 'A' is assigned by default", func(t *testing.T) {
+		cli = &mockLogsSyncClient{}
+		cli.On("StartQueryWithContext", mock.Anything, mock.Anything, mock.Anything).Return(&cloudwatchlogs.StartQueryOutput{
+			QueryId: aws.String("abcd-efgh-ijkl-mnop"),
+		}, nil)
+		cli.On("GetQueryResultsWithContext", mock.Anything, mock.Anything, mock.Anything).Return(&cloudwatchlogs.GetQueryResultsOutput{Status: aws.String("Complete")}, nil)
+		im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
+			return DataSource{Settings: models.CloudWatchSettings{}}, nil
+		})
+		executor := newExecutor(im, newTestConfig(), &fakeSessionCache{}, featuremgmt.WithFeatures())
+
+		res, err := executor.QueryData(context.Background(), &backend.QueryDataRequest{
+			Headers:       map[string]string{ngalertmodels.FromAlertHeaderName: "some value"},
+			PluginContext: backend.PluginContext{DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{}},
+			Queries: []backend.DataQuery{
+				{
+					TimeRange: backend.TimeRange{From: time.Unix(0, 0), To: time.Unix(1, 0)},
+					JSON: json.RawMessage(`{
+						"queryMode":    "Logs"
+					}`),
+				},
+			},
+		})
+
+		assert.NoError(t, err)
+		_, ok := res.Responses["A"]
+		assert.True(t, ok)
+	})
+
+	t.Run("when a query refId is provided, it is returned in the response", func(t *testing.T) {
+		cli = &mockLogsSyncClient{}
+		cli.On("StartQueryWithContext", mock.Anything, mock.Anything, mock.Anything).Return(&cloudwatchlogs.StartQueryOutput{
+			QueryId: aws.String("abcd-efgh-ijkl-mnop"),
+		}, nil)
+		cli.On("GetQueryResultsWithContext", mock.Anything, mock.Anything, mock.Anything).Return(&cloudwatchlogs.GetQueryResultsOutput{Status: aws.String("Complete")}, nil)
+		im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
+			return DataSource{Settings: models.CloudWatchSettings{}}, nil
+		})
+		executor := newExecutor(im, newTestConfig(), &fakeSessionCache{}, featuremgmt.WithFeatures())
+
+		res, err := executor.QueryData(context.Background(), &backend.QueryDataRequest{
+			Headers:       map[string]string{ngalertmodels.FromAlertHeaderName: "some value"},
+			PluginContext: backend.PluginContext{DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{}},
+			Queries: []backend.DataQuery{
+				{
+					RefID:     "A",
+					TimeRange: backend.TimeRange{From: time.Unix(0, 0), To: time.Unix(1, 0)},
+					JSON: json.RawMessage(`{
+						"queryMode":    "Logs"
+					}`),
+				},
+				{
+					RefID:     "B",
+					TimeRange: backend.TimeRange{From: time.Unix(0, 0), To: time.Unix(1, 0)},
+					JSON: json.RawMessage(`{
+						"queryMode":    "Logs"
+					}`),
+				},
+			},
+		})
+
+		assert.NoError(t, err)
+		_, ok := res.Responses["A"]
+		assert.True(t, ok)
+		_, ok = res.Responses["B"]
+		assert.True(t, ok)
+	})
+
+	t.Run("when RefIDs are provided, correctly pass them on with the results", func(t *testing.T) {
+		// This test demonstrates that given two queries with different RefIds,
+		// when each query has a different response from AWS API calls, the RefIds are correctly reassigned to the associated response.
+		cli = &mockLogsSyncClient{}
+		// mock.MatchedBy makes sure that the QueryId below will only be returned when the input expression = "query string for A"
+		cli.On("StartQueryWithContext", mock.Anything, mock.MatchedBy(func(input *cloudwatchlogs.StartQueryInput) bool {
+			return *input.QueryString == "fields @timestamp,ltrim(@log) as __log__grafana_internal__,ltrim(@logStream) as __logstream__grafana_internal__|query string for A"
+		}), mock.Anything).Return(&cloudwatchlogs.StartQueryOutput{
+			QueryId: aws.String("queryId for A"),
+		}, nil)
+
+		// mock.MatchedBy makes sure that the QueryId below will only be returned when the input expression = "query string for B"
+		cli.On("StartQueryWithContext", mock.Anything, mock.MatchedBy(func(input *cloudwatchlogs.StartQueryInput) bool {
+			return *input.QueryString == "fields @timestamp,ltrim(@log) as __log__grafana_internal__,ltrim(@logStream) as __logstream__grafana_internal__|query string for B"
+		}), mock.Anything).Return(&cloudwatchlogs.StartQueryOutput{
+			QueryId: aws.String("queryId for B"),
+		}, nil)
+		cli.On("GetQueryResultsWithContext", mock.Anything, mock.MatchedBy(func(input *cloudwatchlogs.GetQueryResultsInput) bool {
+			return *input.QueryId == "queryId for A"
+		}), mock.Anything).Return(&cloudwatchlogs.GetQueryResultsOutput{
+			// this result will only be returned when the argument is QueryId = "query string for A"
+			Results: [][]*cloudwatchlogs.ResultField{{{
+				Field: utils.Pointer("@log"),
+				Value: utils.Pointer("A result"),
+			}}},
+			Status: aws.String("Complete")}, nil)
+		cli.On("GetQueryResultsWithContext", mock.Anything, mock.MatchedBy(func(input *cloudwatchlogs.GetQueryResultsInput) bool {
+			return *input.QueryId == "queryId for B"
+		}), mock.Anything).Return(&cloudwatchlogs.GetQueryResultsOutput{
+			// this result will only be returned when the argument is QueryId = "query string for B"
+			Results: [][]*cloudwatchlogs.ResultField{{{
+				Field: utils.Pointer("@log"),
+				Value: utils.Pointer("B result"),
+			}}},
+			Status: aws.String("Complete")}, nil)
+
+		im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
+			return DataSource{Settings: models.CloudWatchSettings{}}, nil
+		})
+		executor := newExecutor(im, newTestConfig(), &fakeSessionCache{}, featuremgmt.WithFeatures())
+
+		res, err := executor.QueryData(context.Background(), &backend.QueryDataRequest{
+			Headers:       map[string]string{ngalertmodels.FromAlertHeaderName: "some value"},
+			PluginContext: backend.PluginContext{DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{}},
+			Queries: []backend.DataQuery{
+				{
+					RefID:     "A",
+					TimeRange: backend.TimeRange{From: time.Unix(0, 0), To: time.Unix(1, 0)},
+					JSON: json.RawMessage(`{
+						"queryMode":    "Logs",
+						"expression": "query string for A"
+					}`),
+				},
+				{
+					RefID:     "B",
+					TimeRange: backend.TimeRange{From: time.Unix(0, 0), To: time.Unix(1, 0)},
+					JSON: json.RawMessage(`{
+						"queryMode":    "Logs",
+						"expression": "query string for B"
+					}`),
+				},
+			},
+		})
+
+		expectedLogFieldFromFirstCall := data.NewField("@log", nil, []*string{utils.Pointer("A result")}) // verifies the response from GetQueryResultsWithContext matches the input RefId A
+		assert.NoError(t, err)
+		respA, ok := res.Responses["A"]
+		require.True(t, ok)
+		assert.Equal(t, []*data.Field{expectedLogFieldFromFirstCall}, respA.Frames[0].Fields)
+
+		expectedLogFieldFromSecondCall := data.NewField("@log", nil, []*string{utils.Pointer("B result")}) // verifies the response from GetQueryResultsWithContext matches the input RefId B
+		respB, ok := res.Responses["B"]
+		require.True(t, ok)
+		assert.Equal(t, []*data.Field{expectedLogFieldFromSecondCall}, respB.Frames[0].Fields)
+	})
+}

--- a/pkg/tsdb/cloudwatch/log_sync_query_test.go
+++ b/pkg/tsdb/cloudwatch/log_sync_query_test.go
@@ -153,7 +153,7 @@ func Test_executeSyncLogQuery(t *testing.T) {
 		executeSyncLogQuery = origExecuteSyncLogQuery
 	})
 }
-func Test_executeSyncLogQueryMocks(t *testing.T) {
+func Test_executeSyncLogQuery_handles_RefId_from_input_queries(t *testing.T) {
 	origNewCWClient := NewCWClient
 	t.Cleanup(func() {
 		NewCWClient = origNewCWClient

--- a/pkg/tsdb/cloudwatch/log_sync_query_test.go
+++ b/pkg/tsdb/cloudwatch/log_sync_query_test.go
@@ -252,7 +252,7 @@ func Test_executeSyncLogQuery_handles_RefId_from_input_queries(t *testing.T) {
 		cli.On("GetQueryResultsWithContext", mock.Anything, mock.MatchedBy(func(input *cloudwatchlogs.GetQueryResultsInput) bool {
 			return *input.QueryId == "queryId for A"
 		}), mock.Anything).Return(&cloudwatchlogs.GetQueryResultsOutput{
-			// this result will only be returned when the argument is QueryId = "query string for A"
+			// this result will only be returned when the argument is QueryId = "queryId for A"
 			Results: [][]*cloudwatchlogs.ResultField{{{
 				Field: utils.Pointer("@log"),
 				Value: utils.Pointer("A result"),

--- a/pkg/tsdb/cloudwatch/test_utils.go
+++ b/pkg/tsdb/cloudwatch/test_utils.go
@@ -56,6 +56,21 @@ func (m *fakeCWLogsClient) StopQueryWithContext(ctx context.Context, input *clou
 	}, nil
 }
 
+type mockLogsSyncClient struct {
+	cloudwatchlogsiface.CloudWatchLogsAPI
+
+	mock.Mock
+}
+
+func (m *mockLogsSyncClient) GetQueryResultsWithContext(ctx context.Context, input *cloudwatchlogs.GetQueryResultsInput, option ...request.Option) (*cloudwatchlogs.GetQueryResultsOutput, error) {
+	args := m.Called(ctx, input, option)
+	return args.Get(0).(*cloudwatchlogs.GetQueryResultsOutput), args.Error(1)
+}
+func (m *mockLogsSyncClient) StartQueryWithContext(ctx context.Context, input *cloudwatchlogs.StartQueryInput, option ...request.Option) (*cloudwatchlogs.StartQueryOutput, error) {
+	args := m.Called(ctx, input, option)
+	return args.Get(0).(*cloudwatchlogs.StartQueryOutput), args.Error(1)
+}
+
 func (m *fakeCWLogsClient) DescribeLogGroups(input *cloudwatchlogs.DescribeLogGroupsInput) (*cloudwatchlogs.DescribeLogGroupsOutput, error) {
 	m.calls.describeLogGroups = append(m.calls.describeLogGroups, input)
 	output := &m.logGroups[m.logGroupsIndex]


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This fixes a bug first reported in support-escalations [here.](https://github.com/grafana/support-escalations/issues/5241) 
When an expression is added to two or more cloudwatch queries, the BE code for handling this doesn't pass on refId, instead overwriting it with "A". This passes the refId, in case it's defined, otherwise reverts to "A" like before. 

Tested in dashboard and alerts and it looks good. 

**Special notes for your reviewer:**
To help with testing and repro: 

I used these queries with our demo cluster and provisioning creds: 
`fields  @message |
 stats count(*) as qtd_error_1 by bin(5m)`
 and
 `fields  @message | filter level = 'Metadata'
 | stats count(*) as qtd_error_2 by bin(5m)`
 and 
 `$A + $B ` for the Math->Expression query
 
This probably needs a test, but I haven't had time to do them and I'd rather this not wait for me. If anyone wants to add them, you're welcome to push into this branch!  🙏🏻


Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
