### PR TITLE
Grafana Cloud: Add `VariantLinuxAmd64` in build variants

### DIFF
--- a/pkg/build/config/versions.go
+++ b/pkg/build/config/versions.go
@@ -207,6 +207,8 @@ var Versions = VersionMap{
 	CloudMode: {
 		Variants: []Variant{
 			VariantLinuxAmd64Musl,
+			// We still need this variant to build the .deb file
+			VariantLinuxAmd64,
 		},
 		PluginSignature: PluginSignature{
 			Sign:      true,


### PR DESCRIPTION
**What is this feature?**

We need to build a `linux-amd64` Grafana binary in order to package a `.deb` file from it. Currently the deployment automations for Grafana Cloud fail since the binary is not packaged and published.