### PR TITLE
Grafana Cloud: Put cloud artifacts to `*/release` dir

### DIFF
--- a/pkg/build/cmd/uploadpackages.go
+++ b/pkg/build/cmd/uploadpackages.go
@@ -141,11 +141,11 @@ func bucketForEnterprise2(releaseModeConfig *config.BuildConfig, event string) (
 
 func getVersionFolder(cfg uploadConfig, event string) (string, error) {
 	switch cfg.versionMode {
-	case config.TagMode:
+	case config.TagMode, config.CloudMode:
 		return releaseFolder, nil
 	case config.MainMode, config.DownstreamMode:
 		return mainFolder, nil
-	case config.ReleaseBranchMode, config.CloudMode:
+	case config.ReleaseBranchMode:
 		return releaseBranchFolder, nil
 	default:
 		// Corner case for custom enterprise2 mode

--- a/pkg/build/cmd/uploadpackages_test.go
+++ b/pkg/build/cmd/uploadpackages_test.go
@@ -27,6 +27,7 @@ func Test_getVersionFolder(t *testing.T) {
 		{"downstream mode", args{uploadConfig{versionMode: config.DownstreamMode}, "", mainFolder}, nil},
 		{"release branch mode", args{uploadConfig{versionMode: config.ReleaseBranchMode}, "", releaseBranchFolder}, nil},
 		{"enterprise pro mode", args{uploadConfig{versionMode: config.Enterprise2Mode}, config.Custom, releaseFolder}, nil},
+		{"cloud mode", args{uploadConfig{versionMode: config.CloudMode}, "", releaseFolder}, nil},
 		{"unrecognised version mode", args{uploadConfig{versionMode: "foo"}, config.Custom, ""}, errors.New("")},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
**What is this feature?**

PR to fix the destination of cloud artifacts. Currently they're being put in `*/prerelease` bucket where they should be in the `*/release` bucket.