### PR TITLE
Annotations: Improve get tags query performance

### DIFF
--- a/pkg/services/annotations/annotationsimpl/xorm_store.go
+++ b/pkg/services/annotations/annotationsimpl/xorm_store.go
@@ -447,9 +447,10 @@ func (r *xormRepositoryImpl) GetTags(ctx context.Context, query *annotations.Tag
 			count(*) as count
 		FROM tag
 		INNER JOIN annotation_tag ON tag.id = annotation_tag.tag_id
+		INNER JOIN annotation ON annotation.id = annotation_tag.annotation_id
 `)
 
-		sql.WriteString(`WHERE EXISTS(SELECT 1 FROM annotation WHERE annotation.id = annotation_tag.annotation_id AND annotation.org_id = ?)`)
+		sql.WriteString(`WHERE annotation.org_id = ?`)
 		params = append(params, query.OrgID)
 
 		sql.WriteString(` AND (` + tagKey + ` ` + r.db.GetDialect().LikeStr() + ` ? OR ` + tagValue + ` ` + r.db.GetDialect().LikeStr() + ` ?)`)

--- a/pkg/services/annotations/annotationsimpl/xorm_store_test.go
+++ b/pkg/services/annotations/annotationsimpl/xorm_store_test.go
@@ -891,7 +891,7 @@ func benchmarkFindTags(b *testing.B, numAnnotations int) {
 			TagID:        int64(1),
 		})
 	}
-	sql.WithDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
+	err := sql.WithDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
 		batchSize := 1000
 		numOfBatches := numAnnotations / batchSize
 		for i := 0; i < numOfBatches; i++ {
@@ -906,6 +906,7 @@ func benchmarkFindTags(b *testing.B, numAnnotations int) {
 		}
 		return nil
 	})
+	require.NoError(b, err)
 
 	annotationWithTheTag := annotations.Item{
 		ID:          int64(numAnnotations) + 1,
@@ -918,7 +919,7 @@ func benchmarkFindTags(b *testing.B, numAnnotations int) {
 		Tags:        []string{"outage", "error", "type:outage", "server:server-1"},
 		Data:        simplejson.NewFromAny(map[string]interface{}{"data1": "I am a cool data", "data2": "I am another cool data"}),
 	}
-	err := repo.Add(context.Background(), &annotationWithTheTag)
+	err = repo.Add(context.Background(), &annotationWithTheTag)
 	require.NoError(b, err)
 
 	b.ResetTimer()

--- a/pkg/services/annotations/annotationsimpl/xorm_store_test.go
+++ b/pkg/services/annotations/annotationsimpl/xorm_store_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/guardian"
 	"github.com/grafana/grafana/pkg/services/quota/quotatest"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
+	"github.com/grafana/grafana/pkg/services/tag"
 	"github.com/grafana/grafana/pkg/services/tag/tagimpl"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
@@ -846,4 +847,91 @@ func setupRBACPermission(t *testing.T, db *sqlstore.SQLStore, role *accesscontro
 	})
 
 	require.NoError(t, err)
+}
+
+func BenchmarkFindTags_10k(b *testing.B) {
+	benchmarkFindTags(b, 10000)
+}
+
+func BenchmarkFindTags_100k(b *testing.B) {
+	benchmarkFindTags(b, 100000)
+}
+
+func benchmarkFindTags(b *testing.B, numAnnotations int) {
+	sql := db.InitTestDB(b)
+	var maximumTagsLength int64 = 60
+	repo := xormRepositoryImpl{db: sql, cfg: setting.NewCfg(), log: log.New("annotation.test"), tagService: tagimpl.ProvideService(sql, sql.Cfg), maximumTagsLength: maximumTagsLength}
+
+	type annotationTag struct {
+		ID           int64 `xorm:"pk autoincr 'id'"`
+		AnnotationID int64 `xorm:"annotation_id"`
+		TagID        int64 `xorm:"tag_id"`
+	}
+	newAnnotations := make([]annotations.Item, 0, numAnnotations)
+	newTags := make([]tag.Tag, 0, numAnnotations)
+	newAnnotationTags := make([]annotationTag, 0, numAnnotations)
+	for i := 0; i < numAnnotations; i++ {
+		newAnnotations = append(newAnnotations, annotations.Item{
+			ID:          int64(i),
+			OrgID:       1,
+			UserID:      1,
+			DashboardID: int64(i),
+			Text:        "hello",
+			Type:        "alert",
+			Epoch:       10,
+			Data:        simplejson.NewFromAny(map[string]interface{}{"data1": "I am a cool data", "data2": "I am another cool data"}),
+		})
+		newTags = append(newTags, tag.Tag{
+			Id:  int64(i),
+			Key: fmt.Sprintf("tag%d", i),
+		})
+
+		newAnnotationTags = append(newAnnotationTags, annotationTag{
+			AnnotationID: int64(i),
+			TagID:        int64(1),
+		})
+	}
+	sql.WithDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
+		batchSize := 1000
+		numOfBatches := numAnnotations / batchSize
+		for i := 0; i < numOfBatches; i++ {
+			_, err := sess.Insert(newAnnotations[i*batchSize : (i+1)*batchSize-1])
+			require.NoError(b, err)
+
+			_, err = sess.Insert(newTags[i*batchSize : (i+1)*batchSize-1])
+			require.NoError(b, err)
+
+			_, err = sess.Insert(newAnnotationTags[i*batchSize : (i+1)*batchSize-1])
+			require.NoError(b, err)
+		}
+		return nil
+	})
+
+	annotationWithTheTag := annotations.Item{
+		ID:          int64(numAnnotations) + 1,
+		OrgID:       1,
+		UserID:      1,
+		DashboardID: int64(1),
+		Text:        "hello",
+		Type:        "alert",
+		Epoch:       10,
+		Tags:        []string{"outage", "error", "type:outage", "server:server-1"},
+		Data:        simplejson.NewFromAny(map[string]interface{}{"data1": "I am a cool data", "data2": "I am another cool data"}),
+	}
+	err := repo.Add(context.Background(), &annotationWithTheTag)
+	require.NoError(b, err)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		result, err := repo.GetTags(context.Background(), &annotations.TagsQuery{
+			OrgID: 1,
+			Tag:   "outage",
+		})
+		require.NoError(b, err)
+		require.Len(b, result.Tags, 2)
+		require.Equal(b, "outage", result.Tags[0].Tag)
+		require.Equal(b, "type:outage", result.Tags[1].Tag)
+		require.Equal(b, int64(1), result.Tags[0].Count)
+		require.Equal(b, int64(1), result.Tags[1].Count)
+	}
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

It modifies the query for fetching the annotations tags:

<details>
<summary>Execution plan before</summary>

```
mysql> EXPLAIN SELECT
    ->         tag.`key`,
    ->         tag.`value`,
    ->         count(*) as count
    -> FROM tag
    -> INNER JOIN annotation_tag ON tag.id = annotation_tag.tag_id
    -> WHERE EXISTS(SELECT 1 FROM annotation WHERE annotation.id = annotation_tag.annotation_id AND annotation.org_id = 1) AND (tag.`key` LIKE '%outage%' OR tag.`value` LIKE '%outage%') GROUP BY tag.`key`,tag.`value` ORDER BY tag.`key`,tag.`value`  LIMIT 100
    -> ;
+----+--------------------+----------------+------------+--------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------+---------+--------------------------------------------+-------+----------+-----------------------------------------------------------+
| id | select_type        | table          | partitions | type   | possible_keys                                                                                                                                                                                                          | key                                     | key_len | ref                                        | rows  | filtered | Extra                                                     |
+----+--------------------+----------------+------------+--------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------+---------+--------------------------------------------+-------+----------+-----------------------------------------------------------+
|  1 | PRIMARY            | annotation_tag | NULL       | index  | NULL                                                                                                                                                                                                                   | UQE_annotation_tag_annotation_id_tag_id | 16      | NULL                                       | 99960 |   100.00 | Using where; Using index; Using temporary; Using filesort |
|  1 | PRIMARY            | tag            | NULL       | eq_ref | PRIMARY,UQE_tag_key_value                                                                                                                                                                                              | PRIMARY                                 | 8       | grafana_tests.annotation_tag.tag_id        |     1 |    20.99 | Using where                                               |
|  2 | DEPENDENT SUBQUERY | annotation     | NULL       | eq_ref | PRIMARY,IDX_annotation_org_id_alert_id,IDX_annotation_org_id_type,IDX_annotation_org_id_created,IDX_annotation_org_id_updated,IDX_annotation_org_id_dashboard_id_epoch_end_epoch,IDX_annotation_org_id_epoch_end_epoch | PRIMARY                                 | 8       | grafana_tests.annotation_tag.annotation_id |     1 |    50.00 | Using where                                               |
+----+--------------------+----------------+------------+--------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------+---------+--------------------------------------------+-------+----------+-----------------------------------------------------------+
3 rows in set, 2 warnings (0.02 sec)
```
</details>

<details>
<summary>Execution plan after</summary>

```
mysql> EXPLAIN SELECT
    ->         tag.`key`,
    ->         tag.`value`,
    ->         count(*) as count
    -> FROM tag
    -> INNER JOIN annotation_tag ON tag.id = annotation_tag.tag_id
    -> INNER JOIN annotation ON annotation.id = annotation_tag.annotation_id
    -> WHERE annotation.org_id = 1 AND (tag.`key` LIKE '%outage%' OR tag.`value` LIKE '%outage%') GROUP BY tag.`key`,tag.`value` ORDER BY tag.`key`,tag.`value`  LIMIT 100
    -> ;
+----+-------------+----------------+------------+--------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------+---------+-------------------------------------+-------+----------+----------------------------------------------+
| id | select_type | table          | partitions | type   | possible_keys                                                                                                                                                                                                          | key                                     | key_len | ref                                 | rows  | filtered | Extra                                        |
+----+-------------+----------------+------------+--------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------+---------+-------------------------------------+-------+----------+----------------------------------------------+
|  1 | SIMPLE      | annotation     | NULL       | ref    | PRIMARY,IDX_annotation_org_id_alert_id,IDX_annotation_org_id_type,IDX_annotation_org_id_created,IDX_annotation_org_id_updated,IDX_annotation_org_id_dashboard_id_epoch_end_epoch,IDX_annotation_org_id_epoch_end_epoch | IDX_annotation_org_id_alert_id          | 8       | const                               | 49374 |   100.00 | Using index; Using temporary; Using filesort |
|  1 | SIMPLE      | annotation_tag | NULL       | ref    | UQE_annotation_tag_annotation_id_tag_id                                                                                                                                                                                | UQE_annotation_tag_annotation_id_tag_id | 8       | grafana_tests.annotation.id         |     1 |   100.00 | Using index                                  |
|  1 | SIMPLE      | tag            | NULL       | eq_ref | PRIMARY,UQE_tag_key_value                                                                                                                                                                                              | PRIMARY                                 | 8       | grafana_tests.annotation_tag.tag_id |     1 |    20.99 | Using where                                  |
+----+-------------+----------------+------------+--------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------+---------+-------------------------------------+-------+----------+----------------------------------------------+
3 rows in set, 1 warning (0.01 sec)
```
</details>


**Why do we need this feature?**

Improves query performance; benchmark results for MySQL 5.7
`GRAFANA_TEST_DB=mysql go test --count=10 -benchmem -run=^$ -bench . github.com/grafana/grafana/pkg/services/annotations/annotationsimpl`

```
~/go/src/github.com/grafana/grafana: benchstat before.txt after.txt 
goos: darwin
goarch: arm64
pkg: github.com/grafana/grafana/pkg/services/annotations/annotationsimpl
                │ before.txt  │              after.txt              │
                │   sec/op    │   sec/op     vs base                │
FindTags_10k-8    80.83m ± 2%   71.04m ± 1%  -12.11% (p=0.000 n=10)
FindTags_100k-8   838.3m ± 1%   717.4m ± 0%  -14.43% (p=0.000 n=10)
geomean           260.3m        225.7m       -13.28%

                │  before.txt  │              after.txt               │
                │     B/op     │     B/op      vs base                │
FindTags_10k-8    7.136Ki ± 0%   6.788Ki ± 0%   -4.88% (p=0.001 n=10)
FindTags_100k-8   8.117Ki ± 1%   6.875Ki ± 2%  -15.30% (p=0.000 n=10)
geomean           7.611Ki        6.831Ki       -10.24%

                │ before.txt │             after.txt             │
                │ allocs/op  │ allocs/op   vs base               │
FindTags_10k-8    152.0 ± 0%   151.0 ± 0%  -0.66% (p=0.000 n=10)
FindTags_100k-8   157.0 ± 1%   152.0 ± 1%  -3.18% (p=0.000 n=10)
geomean           154.5        151.5       -1.93%
```


**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
