### PR TITLE
Correlations: Show correct number of variables

### DIFF
--- a/public/app/features/explore/utils/links.test.ts
+++ b/public/app/features/explore/utils/links.test.ts
@@ -671,6 +671,40 @@ describe('explore links utils', () => {
       const dataLinkRtnVal = getVariableUsageInfo(dataLink, scopedVars).allVariablesDefined;
       expect(dataLinkRtnVal).toBe(true);
     });
+
+    it('returns deduplicated list of variables', () => {
+      const dataLink = {
+        url: '',
+        title: '',
+        internal: {
+          datasourceUid: 'uid',
+          datasourceName: 'dsName',
+          query: { query: 'test ${test} ${foo} ${test:raw} $test' },
+        },
+      };
+      const scopedVars = {
+        testVal: { text: '', value: 'val1' },
+      };
+      const variables = getVariableUsageInfo(dataLink, scopedVars).variables;
+      expect(variables).toHaveLength(2);
+    });
+
+    it('returns deduplicated list of variables', () => {
+      const dataLink = {
+        url: '',
+        title: '',
+        internal: {
+          datasourceUid: 'uid',
+          datasourceName: 'dsName',
+          query: { query: 'test ${test} ${foo} ${test:raw} $test' },
+        },
+      };
+      const scopedVars = {
+        testVal: { text: '', value: 'val1' },
+      };
+      const variables = getVariableUsageInfo(dataLink, scopedVars).variables;
+      expect(variables).toHaveLength(2);
+    });
   });
 });
 

--- a/public/app/features/explore/utils/links.test.ts
+++ b/public/app/features/explore/utils/links.test.ts
@@ -688,23 +688,6 @@ describe('explore links utils', () => {
       const variables = getVariableUsageInfo(dataLink, scopedVars).variables;
       expect(variables).toHaveLength(2);
     });
-
-    it('returns deduplicated list of variables', () => {
-      const dataLink = {
-        url: '',
-        title: '',
-        internal: {
-          datasourceUid: 'uid',
-          datasourceName: 'dsName',
-          query: { query: 'test ${test} ${foo} ${test:raw} $test' },
-        },
-      };
-      const scopedVars = {
-        testVal: { text: '', value: 'val1' },
-      };
-      const variables = getVariableUsageInfo(dataLink, scopedVars).variables;
-      expect(variables).toHaveLength(2);
-    });
   });
 });
 

--- a/public/app/features/explore/utils/links.ts
+++ b/public/app/features/explore/utils/links.ts
@@ -1,3 +1,4 @@
+import { uniqBy } from 'lodash';
 import { useCallback } from 'react';
 
 import {
@@ -260,9 +261,10 @@ export function getVariableUsageInfo<T extends DataLink>(
   query: T,
   scopedVars: ScopedVars
 ): { variables: VariableInterpolation[]; allVariablesDefined: boolean } {
-  const variables: VariableInterpolation[] = [];
+  let variables: VariableInterpolation[] = [];
   const replaceFn = getTemplateSrv().replace.bind(getTemplateSrv());
   replaceFn(getStringsFromObject(query), scopedVars, undefined, variables);
+  variables = uniqBy(variables, 'variableName');
   return {
     variables: variables,
     allVariablesDefined: variables.every((variable) => variable.found),


### PR DESCRIPTION
Fixes #66190

(see the issue for more details)

**Special notes for your reviewer:**

| before | after |
|---|---|
| <img width="1246" alt="Screenshot 2023-04-07 at 22 46 39" src="https://user-images.githubusercontent.com/745532/230679313-b8a9a36f-e988-462b-bb2c-7635be4cb739.png"> | <img width="1242" alt="Screenshot 2023-04-07 at 22 47 07" src="https://user-images.githubusercontent.com/745532/230679350-ad011ed2-215f-4b92-af6b-0308b47cf6f2.png"> |

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
