### PR TITLE
Correlations: Fix parsing create/update response

### DIFF
--- a/public/app/features/correlations/__mocks__/useCorrelations.mocks.ts
+++ b/public/app/features/correlations/__mocks__/useCorrelations.mocks.ts
@@ -1,0 +1,55 @@
+import { merge } from 'lodash';
+import { DeepPartial } from 'react-hook-form';
+
+import { FetchError, FetchResponse } from '@grafana/runtime';
+
+import { Correlation, CreateCorrelationResponse, RemoveCorrelationResponse, UpdateCorrelationResponse } from '../types';
+
+export function createFetchCorrelationsResponse<T>(overrides?: DeepPartial<FetchResponse>): FetchResponse<T> {
+  return merge(
+    {
+      data: undefined,
+      status: 200,
+      url: '',
+      config: { url: '' },
+      type: 'basic',
+      statusText: 'Ok',
+      redirected: false,
+      headers: {} as unknown as Headers,
+      ok: true,
+    },
+    overrides
+  );
+}
+
+export function createFetchCorrelationsError(overrides?: DeepPartial<FetchError>): FetchError {
+  return merge(
+    createFetchCorrelationsResponse(),
+    {
+      status: 500,
+      statusText: 'Internal Server Error',
+      ok: false,
+    },
+    overrides
+  );
+}
+
+export function createCreateCorrelationResponse(correlation: Correlation): CreateCorrelationResponse {
+  return {
+    message: 'Correlation created',
+    result: correlation,
+  };
+}
+
+export function createUpdateCorrelationResponse(correlation: Correlation): UpdateCorrelationResponse {
+  return {
+    message: 'Correlation updated',
+    result: correlation,
+  };
+}
+
+export function createRemoveCorrelationResponse(): RemoveCorrelationResponse {
+  return {
+    message: 'Correlation removed',
+  };
+}

--- a/public/app/features/correlations/types.ts
+++ b/public/app/features/correlations/types.ts
@@ -6,15 +6,25 @@ export interface AddCorrelationResponse {
 
 export type GetCorrelationsResponse = Correlation[];
 
-export type CreateCorrelationResponse = {
+export interface CorrelationsApiResponse {
   message: string;
-  result: Correlation;
-};
+}
 
-export type UpdateCorrelationResponse = {
-  message: string;
+export interface CorrelationsErrorResponse extends CorrelationsApiResponse {
+  error: string;
+}
+
+export interface CreateCorrelationResponse extends CorrelationsApiResponse {
   result: Correlation;
-};
+}
+
+export interface UpdateCorrelationResponse extends CorrelationsApiResponse {
+  result: Correlation;
+}
+
+export interface RemoveCorrelationResponse {
+  message: string;
+}
 
 type CorrelationConfigType = 'query';
 

--- a/public/app/features/correlations/types.ts
+++ b/public/app/features/correlations/types.ts
@@ -6,6 +6,16 @@ export interface AddCorrelationResponse {
 
 export type GetCorrelationsResponse = Correlation[];
 
+export type CreateCorrelationResponse = {
+  message: string;
+  result: Correlation;
+};
+
+export type UpdateCorrelationResponse = {
+  message: string;
+  result: Correlation;
+};
+
 type CorrelationConfigType = 'query';
 
 export interface CorrelationConfig {

--- a/public/app/features/correlations/useCorrelations.ts
+++ b/public/app/features/correlations/useCorrelations.ts
@@ -5,7 +5,14 @@ import { DataSourceInstanceSettings } from '@grafana/data';
 import { getDataSourceSrv, FetchResponse } from '@grafana/runtime';
 import { useGrafana } from 'app/core/context/GrafanaContext';
 
-import { Correlation, CreateCorrelationParams, RemoveCorrelationParams, UpdateCorrelationParams } from './types';
+import {
+  Correlation,
+  CreateCorrelationParams,
+  CreateCorrelationResponse,
+  RemoveCorrelationParams,
+  UpdateCorrelationParams,
+  UpdateCorrelationResponse,
+} from './types';
 
 export interface CorrelationData extends Omit<Correlation, 'sourceUID' | 'targetUID'> {
   source: DataSourceInstanceSettings;
@@ -44,7 +51,9 @@ export const useCorrelations = () => {
 
   const [createInfo, create] = useAsyncFn<(params: CreateCorrelationParams) => Promise<CorrelationData>>(
     ({ sourceUID, ...correlation }) =>
-      backend.post(`/api/datasources/uid/${sourceUID}/correlations`, correlation).then(toEnrichedCorrelationData),
+      backend
+        .post(`/api/datasources/uid/${sourceUID}/correlations`, correlation)
+        .then((response: CreateCorrelationResponse) => toEnrichedCorrelationData(response.result)),
     [backend]
   );
 
@@ -57,7 +66,7 @@ export const useCorrelations = () => {
     ({ sourceUID, uid, ...correlation }) =>
       backend
         .patch(`/api/datasources/uid/${sourceUID}/correlations/${uid}`, correlation)
-        .then(toEnrichedCorrelationData),
+        .then((response: UpdateCorrelationResponse) => toEnrichedCorrelationData(response.result)),
     [backend]
   );
 

--- a/public/app/features/correlations/useCorrelations.ts
+++ b/public/app/features/correlations/useCorrelations.ts
@@ -10,6 +10,7 @@ import {
   CreateCorrelationParams,
   CreateCorrelationResponse,
   RemoveCorrelationParams,
+  RemoveCorrelationResponse,
   UpdateCorrelationParams,
   UpdateCorrelationResponse,
 } from './types';
@@ -52,21 +53,24 @@ export const useCorrelations = () => {
   const [createInfo, create] = useAsyncFn<(params: CreateCorrelationParams) => Promise<CorrelationData>>(
     ({ sourceUID, ...correlation }) =>
       backend
-        .post(`/api/datasources/uid/${sourceUID}/correlations`, correlation)
-        .then((response: CreateCorrelationResponse) => toEnrichedCorrelationData(response.result)),
+        .post<CreateCorrelationResponse>(`/api/datasources/uid/${sourceUID}/correlations`, correlation)
+        .then((response) => {
+          return toEnrichedCorrelationData(response.result);
+        }),
     [backend]
   );
 
   const [removeInfo, remove] = useAsyncFn<(params: RemoveCorrelationParams) => Promise<{ message: string }>>(
-    ({ sourceUID, uid }) => backend.delete(`/api/datasources/uid/${sourceUID}/correlations/${uid}`),
+    ({ sourceUID, uid }) =>
+      backend.delete<RemoveCorrelationResponse>(`/api/datasources/uid/${sourceUID}/correlations/${uid}`),
     [backend]
   );
 
   const [updateInfo, update] = useAsyncFn<(params: UpdateCorrelationParams) => Promise<CorrelationData>>(
     ({ sourceUID, uid, ...correlation }) =>
       backend
-        .patch(`/api/datasources/uid/${sourceUID}/correlations/${uid}`, correlation)
-        .then((response: UpdateCorrelationResponse) => toEnrichedCorrelationData(response.result)),
+        .patch<UpdateCorrelationResponse>(`/api/datasources/uid/${sourceUID}/correlations/${uid}`, correlation)
+        .then((response) => toEnrichedCorrelationData(response.result)),
     [backend]
   );
 


### PR DESCRIPTION
Small change to inconsistent parsing in `useCorrelations` hook (the result is not in use at the moment, so it's not causing issues with current functionality)

Fixes #66192

(see the issue for more details)

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
