### PR TITLE
Logs Navigation: Scroll to first log when using pagination

### DIFF
--- a/public/app/features/explore/Logs.tsx
+++ b/public/app/features/explore/Logs.tsx
@@ -122,6 +122,7 @@ class UnthemedLogs extends PureComponent<Props, State> {
   flipOrderTimer?: number;
   cancelFlippingTimer?: number;
   topLogsRef = createRef<HTMLDivElement>();
+  firstLogRef = createRef<HTMLDivElement>();
   logsVolumeEventBus: EventBus;
 
   state: State = {
@@ -326,6 +327,8 @@ class UnthemedLogs extends PureComponent<Props, State> {
 
   scrollToTopLogs = () => this.topLogsRef.current?.scrollIntoView();
 
+  scrollToFirstLog = () => this.firstLogRef.current?.scrollIntoView();
+
   render() {
     const {
       width,
@@ -483,7 +486,7 @@ class UnthemedLogs extends PureComponent<Props, State> {
             clearDetectedFields={this.clearDetectedFields}
           />
           <div className={styles.logsSection}>
-            <div className={styles.logRows} data-testid="logRows">
+            <div className={styles.logRows} data-testid="logRows" ref={this.firstLogRef}>
               <LogRows
                 logRows={logRows}
                 deduplicatedRows={dedupedRows}
@@ -535,6 +538,7 @@ class UnthemedLogs extends PureComponent<Props, State> {
               loading={loading}
               queries={logsQueries ?? []}
               scrollToTopLogs={this.scrollToTopLogs}
+              scrollToFirstLog={this.scrollToFirstLog}
               addResultsToCache={addResultsToCache}
               clearCache={clearCache}
             />

--- a/public/app/features/explore/Logs.tsx
+++ b/public/app/features/explore/Logs.tsx
@@ -471,6 +471,7 @@ class UnthemedLogs extends PureComponent<Props, State> {
               </InlineField>
             </div>
           </div>
+          <div ref={this.topLogsRef} />
           <LogsMetaRow
             logRows={logRows}
             meta={logsMeta || []}
@@ -482,7 +483,7 @@ class UnthemedLogs extends PureComponent<Props, State> {
             onEscapeNewlines={this.onEscapeNewlines}
             clearDetectedFields={this.clearDetectedFields}
           />
-          <div className={styles.logsSection} ref={this.topLogsRef}>
+          <div className={styles.logsSection}>
             <div className={styles.logRows} data-testid="logRows">
               <LogRows
                 logRows={logRows}

--- a/public/app/features/explore/Logs.tsx
+++ b/public/app/features/explore/Logs.tsx
@@ -485,8 +485,8 @@ class UnthemedLogs extends PureComponent<Props, State> {
             onEscapeNewlines={this.onEscapeNewlines}
             clearDetectedFields={this.clearDetectedFields}
           />
-          <div className={styles.logsSection}>
-            <div className={styles.logRows} data-testid="logRows" ref={this.firstLogRef}>
+          <div className={styles.logsSection} ref={this.firstLogRef}>
+            <div className={styles.logRows} data-testid="logRows">
               <LogRows
                 logRows={logRows}
                 deduplicatedRows={dedupedRows}

--- a/public/app/features/explore/Logs.tsx
+++ b/public/app/features/explore/Logs.tsx
@@ -122,7 +122,6 @@ class UnthemedLogs extends PureComponent<Props, State> {
   flipOrderTimer?: number;
   cancelFlippingTimer?: number;
   topLogsRef = createRef<HTMLDivElement>();
-  firstLogRef = createRef<HTMLDivElement>();
   logsVolumeEventBus: EventBus;
 
   state: State = {
@@ -327,8 +326,6 @@ class UnthemedLogs extends PureComponent<Props, State> {
 
   scrollToTopLogs = () => this.topLogsRef.current?.scrollIntoView();
 
-  scrollToFirstLog = () => this.firstLogRef.current?.scrollIntoView();
-
   render() {
     const {
       width,
@@ -400,7 +397,7 @@ class UnthemedLogs extends PureComponent<Props, State> {
           )}
         </Collapse>
         <Collapse label="Logs" loading={loading} isOpen className={styleOverridesForStickyNavigation}>
-          <div className={styles.logOptions} ref={this.topLogsRef}>
+          <div className={styles.logOptions}>
             <InlineFieldRow>
               <InlineField label="Time" className={styles.horizontalInlineLabel} transparent>
                 <InlineSwitch
@@ -485,7 +482,7 @@ class UnthemedLogs extends PureComponent<Props, State> {
             onEscapeNewlines={this.onEscapeNewlines}
             clearDetectedFields={this.clearDetectedFields}
           />
-          <div className={styles.logsSection} ref={this.firstLogRef}>
+          <div className={styles.logsSection} ref={this.topLogsRef}>
             <div className={styles.logRows} data-testid="logRows">
               <LogRows
                 logRows={logRows}
@@ -538,7 +535,6 @@ class UnthemedLogs extends PureComponent<Props, State> {
               loading={loading}
               queries={logsQueries ?? []}
               scrollToTopLogs={this.scrollToTopLogs}
-              scrollToFirstLog={this.scrollToFirstLog}
               addResultsToCache={addResultsToCache}
               clearCache={clearCache}
             />

--- a/public/app/features/explore/LogsNavigation.test.tsx
+++ b/public/app/features/explore/LogsNavigation.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React, { ComponentProps } from 'react';
 
 import { LogsSortOrder } from '@grafana/data';
@@ -26,7 +27,7 @@ const defaultProps: LogsNavigationProps = {
   clearCache: jest.fn(),
 };
 
-const setup = (propOverrides?: object) => {
+const setup = (propOverrides?: Partial<LogsNavigationProps>) => {
   const props = {
     ...defaultProps,
     ...propOverrides,
@@ -74,10 +75,10 @@ describe('LogsNavigation', () => {
     expect(screen.getByTestId('logsNavigationPages')).toBeInTheDocument();
   });
 
-  it('should correctly request older logs when flipped order', () => {
+  it('should correctly request older logs when flipped order', async () => {
     const onChangeTimeMock = jest.fn();
     const { rerender } = setup({ onChangeTime: onChangeTimeMock });
-    fireEvent.click(screen.getByTestId('olderLogsButton'));
+    await userEvent.click(screen.getByTestId('olderLogsButton'));
     expect(onChangeTimeMock).toHaveBeenCalledWith({ from: 1637319359000, to: 1637322959000 });
 
     rerender(
@@ -89,7 +90,16 @@ describe('LogsNavigation', () => {
         logsSortOrder={LogsSortOrder.Ascending}
       />
     );
-    fireEvent.click(screen.getByTestId('olderLogsButton'));
+    await userEvent.click(screen.getByTestId('olderLogsButton'));
     expect(onChangeTimeMock).toHaveBeenCalledWith({ from: 1637319338000, to: 1637322938000 });
+  });
+
+  it('should reset the scroll when pagination is clic ked', async () => {
+    const scrollToFirstLogMock = jest.fn();
+    setup({ scrollToFirstLog: scrollToFirstLogMock });
+
+    expect(scrollToFirstLogMock).not.toHaveBeenCalled();
+    await userEvent.click(screen.getByTestId('olderLogsButton'));
+    expect(scrollToFirstLogMock).toHaveBeenCalled();
   });
 });

--- a/public/app/features/explore/LogsNavigation.test.tsx
+++ b/public/app/features/explore/LogsNavigation.test.tsx
@@ -21,6 +21,7 @@ const defaultProps: LogsNavigationProps = {
   visibleRange: { from: 1637322959000, to: 1637322981811 },
   onChangeTime: jest.fn(),
   scrollToTopLogs: jest.fn(),
+  scrollToFirstLog: jest.fn(),
   addResultsToCache: jest.fn(),
   clearCache: jest.fn(),
 };

--- a/public/app/features/explore/LogsNavigation.test.tsx
+++ b/public/app/features/explore/LogsNavigation.test.tsx
@@ -22,7 +22,6 @@ const defaultProps: LogsNavigationProps = {
   visibleRange: { from: 1637322959000, to: 1637322981811 },
   onChangeTime: jest.fn(),
   scrollToTopLogs: jest.fn(),
-  scrollToFirstLog: jest.fn(),
   addResultsToCache: jest.fn(),
   clearCache: jest.fn(),
 };
@@ -95,11 +94,11 @@ describe('LogsNavigation', () => {
   });
 
   it('should reset the scroll when pagination is clic ked', async () => {
-    const scrollToFirstLogMock = jest.fn();
-    setup({ scrollToFirstLog: scrollToFirstLogMock });
+    const scrollToTopLogsMock = jest.fn();
+    setup({ scrollToTopLogs: scrollToTopLogsMock });
 
-    expect(scrollToFirstLogMock).not.toHaveBeenCalled();
+    expect(scrollToTopLogsMock).not.toHaveBeenCalled();
     await userEvent.click(screen.getByTestId('olderLogsButton'));
-    expect(scrollToFirstLogMock).toHaveBeenCalled();
+    expect(scrollToTopLogsMock).toHaveBeenCalled();
   });
 });

--- a/public/app/features/explore/LogsNavigation.tsx
+++ b/public/app/features/explore/LogsNavigation.tsx
@@ -19,7 +19,6 @@ type Props = {
   logsSortOrder?: LogsSortOrder | null;
   onChangeTime: (range: AbsoluteTimeRange) => void;
   scrollToTopLogs: () => void;
-  scrollToFirstLog: () => void;
   addResultsToCache: () => void;
   clearCache: () => void;
 };
@@ -36,7 +35,6 @@ function LogsNavigation({
   loading,
   onChangeTime,
   scrollToTopLogs,
-  scrollToFirstLog,
   visibleRange,
   queries,
   clearCache,
@@ -128,7 +126,7 @@ function LogsNavigation({
           //If we are on the last page, create new range
           changeTime({ from: visibleRange.from - rangeSpanRef.current, to: visibleRange.from });
         }
-        scrollToFirstLog();
+        scrollToTopLogs();
       }}
       disabled={loading}
     >
@@ -156,7 +154,7 @@ function LogsNavigation({
             to: pages[currentPageIndex + indexChange].queryRange.to,
           });
         }
-        scrollToFirstLog();
+        scrollToTopLogs();
         //If we are on the first page, button is disabled and we do nothing
       }}
       disabled={loading || onFirstPage}
@@ -176,9 +174,9 @@ function LogsNavigation({
         pageNumber,
       });
       !loading && changeTime({ from: page.queryRange.from, to: page.queryRange.to });
-      scrollToFirstLog();
+      scrollToTopLogs();
     },
-    [changeTime, loading, scrollToFirstLog]
+    [changeTime, loading, scrollToTopLogs]
   );
 
   return (

--- a/public/app/features/explore/LogsNavigation.tsx
+++ b/public/app/features/explore/LogsNavigation.tsx
@@ -19,6 +19,7 @@ type Props = {
   logsSortOrder?: LogsSortOrder | null;
   onChangeTime: (range: AbsoluteTimeRange) => void;
   scrollToTopLogs: () => void;
+  scrollToFirstLog: () => void;
   addResultsToCache: () => void;
   clearCache: () => void;
 };
@@ -35,6 +36,7 @@ function LogsNavigation({
   loading,
   onChangeTime,
   scrollToTopLogs,
+  scrollToFirstLog,
   visibleRange,
   queries,
   clearCache,
@@ -123,6 +125,7 @@ function LogsNavigation({
           //If we are on the last page, create new range
           changeTime({ from: visibleRange.from - rangeSpanRef.current, to: visibleRange.from });
         }
+        scrollToFirstLog();
       }}
       disabled={loading}
     >
@@ -150,6 +153,7 @@ function LogsNavigation({
             to: pages[currentPageIndex + indexChange].queryRange.to,
           });
         }
+        scrollToFirstLog();
         //If we are on the first page, button is disabled and we do nothing
       }}
       disabled={loading || onFirstPage}

--- a/public/app/features/explore/LogsNavigationPages.test.tsx
+++ b/public/app/features/explore/LogsNavigationPages.test.tsx
@@ -44,7 +44,7 @@ describe('LogsNavigationPages', () => {
     expect(screen.getByText(/02:59:11 — 02:59:15/i)).toBeInTheDocument();
     expect(screen.getByText(/02:59:01 — 02:59:05/i)).toBeInTheDocument();
   });
-  it('should render logs pages with correct range if normal order', async () => {
+  it('should invoke the callback when clicked', async () => {
     const onPageClicked = jest.fn();
     setup({ onClick: onPageClicked });
     expect(onPageClicked).not.toHaveBeenCalled();

--- a/public/app/features/explore/LogsNavigationPages.test.tsx
+++ b/public/app/features/explore/LogsNavigationPages.test.tsx
@@ -1,11 +1,12 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React, { ComponentProps } from 'react';
 
 import { LogsNavigationPages } from './LogsNavigationPages';
 
 type LogsNavigationPagesProps = ComponentProps<typeof LogsNavigationPages>;
 
-const setup = (propOverrides?: object) => {
+const setup = (propOverrides?: Partial<LogsNavigationPagesProps>) => {
   const props: LogsNavigationPagesProps = {
     pages: [
       {
@@ -42,5 +43,12 @@ describe('LogsNavigationPages', () => {
     setup({ oldestLogsFirst: true });
     expect(screen.getByText(/02:59:11 — 02:59:15/i)).toBeInTheDocument();
     expect(screen.getByText(/02:59:01 — 02:59:05/i)).toBeInTheDocument();
+  });
+  it('should render logs pages with correct range if normal order', async () => {
+    const onPageClicked = jest.fn();
+    setup({ onClick: onPageClicked });
+    expect(onPageClicked).not.toHaveBeenCalled();
+    await userEvent.click(screen.getByText(/02:59:05 — 02:59:01/i));
+    expect(onPageClicked).toHaveBeenCalled();
   });
 });

--- a/public/app/features/explore/LogsNavigationPages.test.tsx
+++ b/public/app/features/explore/LogsNavigationPages.test.tsx
@@ -21,7 +21,7 @@ const setup = (propOverrides?: object) => {
     oldestLogsFirst: false,
     timeZone: 'local',
     loading: false,
-    changeTime: jest.fn(),
+    onClick: jest.fn(),
     ...propOverrides,
   };
 

--- a/public/app/features/explore/LogsNavigationPages.tsx
+++ b/public/app/features/explore/LogsNavigationPages.tsx
@@ -1,8 +1,7 @@
 import { css, cx } from '@emotion/css';
 import React from 'react';
 
-import { dateTimeFormat, systemDateFormats, TimeZone, AbsoluteTimeRange, GrafanaTheme2 } from '@grafana/data';
-import { reportInteraction } from '@grafana/runtime';
+import { dateTimeFormat, systemDateFormats, TimeZone, GrafanaTheme2 } from '@grafana/data';
 import { CustomScrollbar, Spinner, useTheme2, clearButtonStyles } from '@grafana/ui';
 
 import { LogsPage } from './LogsNavigation';
@@ -13,17 +12,10 @@ type Props = {
   oldestLogsFirst: boolean;
   timeZone: TimeZone;
   loading: boolean;
-  changeTime: (range: AbsoluteTimeRange) => void;
+  onClick: (page: LogsPage, pageNumber: number) => void;
 };
 
-export function LogsNavigationPages({
-  pages,
-  currentPageIndex,
-  oldestLogsFirst,
-  timeZone,
-  loading,
-  changeTime,
-}: Props) {
+export function LogsNavigationPages({ pages, currentPageIndex, oldestLogsFirst, timeZone, loading, onClick }: Props) {
   const formatTime = (time: number) => {
     return `${dateTimeFormat(time, {
       format: systemDateFormats.interval.second,
@@ -54,11 +46,7 @@ export function LogsNavigationPages({
               className={cx(clearButtonStyles(theme), styles.page)}
               key={page.queryRange.to}
               onClick={() => {
-                reportInteraction('grafana_explore_logs_pagination_clicked', {
-                  pageType: 'page',
-                  pageNumber: index + 1,
-                });
-                !loading && changeTime({ from: page.queryRange.from, to: page.queryRange.to });
+                onClick(page, index + 1);
               }}
             >
               <div className={cx(styles.line, { selectedBg: currentPageIndex === index })} />


### PR DESCRIPTION
This PR adds a new behavior when clicking on the logs navigation buttons (newer logs, logs pages, and older logs), to reset the scroll to the first log. This allows users to have a slightly enhanced workflow when looking for logs, by being taken to the first log of the updated log list.

This has been achieved by keeping a new reference to the start of the logs list, and reset the scroll to that position on every pagination change. This was done to keep the viewport focused on the log list, so the user can continuosly see the pagination buttons (newer, older):

![imagen](https://user-images.githubusercontent.com/1069378/230944879-7d157748-ea92-4d1f-bbe5-7e936c995ad0.png)

Otherwise, if we use the original scroll to top reference, the pagination is partially displayed (or partially hidden):

![imagen](https://user-images.githubusercontent.com/1069378/230944998-e9bfe73e-06b7-4504-9b67-1115f941e20b.png)

The other reference remains unchanged for the "scroll to top" button, which scrolls to a slightly higher position.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/61842

**Special notes for your reviewer:**

Old behavior:

In the current version, when the user uses pagination, they have to manually scroll to the top to see the new first log.

https://user-images.githubusercontent.com/1069378/230944627-12562060-7256-4173-a03f-86247a158345.mov

In the update version, when the user uses pagination, the viewport is reset to the start of the list, allowing users to see the first log, while the pagination controls continue to be visible.

New behavior: