### PR TITLE
Loki Config: Add missing section header + minor improvements

### DIFF
--- a/e2e/various-suite/loki-editor.spec.ts
+++ b/e2e/various-suite/loki-editor.spec.ts
@@ -5,7 +5,7 @@ const addDataSource = () => {
   e2e.flows.addDataSource({
     type: 'Loki',
     expectedAlertMessage:
-      'Unable to fetch labels from Loki (Failed to call resource), please check the server logs for more details',
+      'Unable to connect with Loki (Failed to call resource). Please check the server logs for more details.',
     name: dataSourceName,
     form: () => {
       e2e.components.DataSource.DataSourceHttpSettings.urlInput().type('http://loki-url:3100');

--- a/e2e/various-suite/loki-query-builder.spec.ts
+++ b/e2e/various-suite/loki-query-builder.spec.ts
@@ -6,7 +6,7 @@ const addDataSource = () => {
   e2e.flows.addDataSource({
     type: 'Loki',
     expectedAlertMessage:
-      'Unable to fetch labels from Loki (Failed to call resource), please check the server logs for more details',
+      'Unable to connect with Loki (Failed to call resource). Please check the server logs for more details.',
     name: dataSourceName,
     form: () => {
       e2e.components.DataSource.DataSourceHttpSettings.urlInput().type('http://loki-url:3100');

--- a/packages/grafana-ui/src/components/DataSourceSettings/AlertingSettings.test.tsx
+++ b/packages/grafana-ui/src/components/DataSourceSettings/AlertingSettings.test.tsx
@@ -44,8 +44,8 @@ describe('Alerting Settings', () => {
     expect(screen.queryByText('Alertmanager data source')).toBeNull();
   });
 
-  it('should show the option to Manage alerts via Alerting UI', () => {
+  it('should show the option to manager alerts', () => {
     setup();
-    expect(screen.getByText('Manage alerts via Alerting UI')).toBeVisible();
+    expect(screen.getByText('Manage alert rules in Alerting UI')).toBeVisible();
   });
 });

--- a/packages/grafana-ui/src/components/DataSourceSettings/AlertingSettings.tsx
+++ b/packages/grafana-ui/src/components/DataSourceSettings/AlertingSettings.tsx
@@ -23,7 +23,7 @@ export function AlertingSettings<T extends AlertingConfig>({ options, onOptionsC
               labelWidth={27}
               label="Manage alerts via Alerting UI"
               disabled={options.readOnly}
-              tooltip="Enable to manage alerting rules for this data source."
+              tooltip="Enable it to manage alerting rules for this data source."
             >
               <InlineSwitch
                 value={options.jsonData.manageAlerts !== false}

--- a/packages/grafana-ui/src/components/DataSourceSettings/AlertingSettings.tsx
+++ b/packages/grafana-ui/src/components/DataSourceSettings/AlertingSettings.tsx
@@ -20,7 +20,7 @@ export function AlertingSettings<T extends AlertingConfig>({ options, onOptionsC
         <div className="gf-form-inline">
           <div className="gf-form">
             <InlineField
-              labelWidth={27}
+              labelWidth={29}
               label="Manage alert rules in Alerting UI"
               disabled={options.readOnly}
               tooltip="Manage alert rules for this data source. To manage other alerting resources, add an Alertmanager data source."

--- a/packages/grafana-ui/src/components/DataSourceSettings/AlertingSettings.tsx
+++ b/packages/grafana-ui/src/components/DataSourceSettings/AlertingSettings.tsx
@@ -23,7 +23,7 @@ export function AlertingSettings<T extends AlertingConfig>({ options, onOptionsC
               labelWidth={27}
               label="Manage alert rules in Alerting UI"
               disabled={options.readOnly}
-              tooltip="Enable it to manage alerting rules for this data source. To manage other alerting objects, you need to add an Alertmanager datasource."
+              tooltip="Manage alert rules for this data source. To manage other alerting resources, add an Alertmanager data source."
             >
               <InlineSwitch
                 value={options.jsonData.manageAlerts !== false}

--- a/packages/grafana-ui/src/components/DataSourceSettings/AlertingSettings.tsx
+++ b/packages/grafana-ui/src/components/DataSourceSettings/AlertingSettings.tsx
@@ -21,9 +21,9 @@ export function AlertingSettings<T extends AlertingConfig>({ options, onOptionsC
           <div className="gf-form">
             <InlineField
               labelWidth={27}
-              label="Manage alerts via Alerting UI"
+              label="Manage alert rules in Alerting UI"
               disabled={options.readOnly}
-              tooltip="Enable it to manage alerting rules for this data source."
+              tooltip="Enable it to manage alerting rules for this data source. To manage other alerting objects, you need to add an Alertmanager datasource."
             >
               <InlineSwitch
                 value={options.jsonData.manageAlerts !== false}

--- a/packages/grafana-ui/src/components/DataSourceSettings/AlertingSettings.tsx
+++ b/packages/grafana-ui/src/components/DataSourceSettings/AlertingSettings.tsx
@@ -19,7 +19,12 @@ export function AlertingSettings<T extends AlertingConfig>({ options, onOptionsC
       <div className="gf-form-group">
         <div className="gf-form-inline">
           <div className="gf-form">
-            <InlineField labelWidth={26} label="Manage alerts via Alerting UI" disabled={options.readOnly}>
+            <InlineField
+              labelWidth={27}
+              label="Manage alerts via Alerting UI"
+              disabled={options.readOnly}
+              tooltip="Enable to manage alerting rules for this data source."
+            >
               <InlineSwitch
                 value={options.jsonData.manageAlerts !== false}
                 onChange={(event) =>

--- a/public/app/plugins/datasource/loki/configuration/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/loki/configuration/ConfigEditor.tsx
@@ -44,16 +44,10 @@ export const ConfigEditor = (props: Props) => {
 
       <AlertingSettings<LokiOptions> options={options} onOptionsChange={onOptionsChange} />
 
-      <div className="gf-form-group">
-        <div className="gf-form-inline">
-          <div className="gf-form">
-            <MaxLinesField
-              value={options.jsonData.maxLines || ''}
-              onChange={(value) => onOptionsChange(setMaxLines(options, value))}
-            />
-          </div>
-        </div>
-      </div>
+      <MaxLinesField
+        value={options.jsonData.maxLines || ''}
+        onChange={(value) => onOptionsChange(setMaxLines(options, value))}
+      />
 
       <DerivedFields
         value={options.jsonData.derivedFields}

--- a/public/app/plugins/datasource/loki/configuration/MaxLinesField.tsx
+++ b/public/app/plugins/datasource/loki/configuration/MaxLinesField.tsx
@@ -11,27 +11,37 @@ type Props = {
 export const MaxLinesField = (props: Props) => {
   const { value, onChange } = props;
   return (
-    <FormField
-      label="Maximum lines"
-      labelWidth={11}
-      inputWidth={20}
-      inputEl={
-        <input
-          type="number"
-          className="gf-form-input width-8 gf-form-input--has-help-icon"
-          value={value}
-          onChange={(event) => onChange(event.currentTarget.value)}
-          spellCheck={false}
-          placeholder="1000"
-        />
-      }
-      tooltip={
-        <>
-          Loki queries must contain a limit of the maximum number of lines returned (default: 1000). Increase this limit
-          to have a bigger result set for ad-hoc analysis. Decrease this limit if your browser becomes sluggish when
-          displaying the log results.
-        </>
-      }
-    />
+    <>
+      <h3 className="page-heading">Queries</h3>
+
+      <div className="gf-form-group">
+        <div className="gf-form-inline">
+          <div className="gf-form">
+            <FormField
+              label="Maximum lines"
+              labelWidth={11}
+              inputWidth={20}
+              inputEl={
+                <input
+                  type="number"
+                  className="gf-form-input width-8 gf-form-input--has-help-icon"
+                  value={value}
+                  onChange={(event) => onChange(event.currentTarget.value)}
+                  spellCheck={false}
+                  placeholder="1000"
+                />
+              }
+              tooltip={
+                <>
+                  Loki queries must contain a limit of the maximum number of lines returned (default: 1000). Increase
+                  this limit to have a bigger result set for ad-hoc analysis. Decrease this limit if your browser
+                  becomes sluggish when displaying the log results.
+                </>
+              }
+            />
+          </div>
+        </div>
+      </div>
+    </>
   );
 };

--- a/public/app/plugins/datasource/loki/configuration/MaxLinesField.tsx
+++ b/public/app/plugins/datasource/loki/configuration/MaxLinesField.tsx
@@ -13,7 +13,6 @@ export const MaxLinesField = (props: Props) => {
   return (
     <>
       <h3 className="page-heading">Queries</h3>
-
       <div className="gf-form-group">
         <div className="gf-form-inline">
           <div className="gf-form">

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -336,7 +336,7 @@ describe('LokiDatasource', () => {
 
       expect(result).toStrictEqual({
         status: 'success',
-        message: 'Data source connected and labels found.',
+        message: 'Data source successfully connected and labels found.',
       });
     });
 
@@ -347,7 +347,8 @@ describe('LokiDatasource', () => {
 
       expect(result).toStrictEqual({
         status: 'error',
-        message: 'Data source connected, but no labels received. Verify that Loki and Promtail is configured properly.',
+        message:
+          'Data source connected, but no labels were received. Verify that Loki and Promtail are correctly configured.',
       });
     });
 
@@ -358,7 +359,7 @@ describe('LokiDatasource', () => {
 
       expect(result).toStrictEqual({
         status: 'error',
-        message: 'Unable to fetch labels from Loki, please check the server logs for more details',
+        message: 'Unable to connect with Loki. Please check the server logs for more details.',
       });
     });
 
@@ -374,7 +375,7 @@ describe('LokiDatasource', () => {
 
       expect(result).toStrictEqual({
         status: 'error',
-        message: 'Unable to fetch labels from Loki (error42), please check the server logs for more details',
+        message: 'Unable to connect with Loki (error42). Please check the server logs for more details.',
       });
     });
   });

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -336,7 +336,7 @@ describe('LokiDatasource', () => {
 
       expect(result).toStrictEqual({
         status: 'success',
-        message: 'Data source successfully connected and labels found.',
+        message: 'Data source successfully connected.',
       });
     });
 

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -735,7 +735,7 @@ export class LokiDatasource
     return this.metadataRequest('labels', params).then(
       (values) => {
         return values.length > 0
-          ? { status: 'success', message: 'Data source successfully connected and labels found.' }
+          ? { status: 'success', message: 'Data source successfully connected.' }
           : {
               status: 'error',
               message:

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -735,11 +735,11 @@ export class LokiDatasource
     return this.metadataRequest('labels', params).then(
       (values) => {
         return values.length > 0
-          ? { status: 'success', message: 'Data source connected and labels found.' }
+          ? { status: 'success', message: 'Data source successfully connected and labels found.' }
           : {
               status: 'error',
               message:
-                'Data source connected, but no labels received. Verify that Loki and Promtail are configured properly.',
+                'Data source connected, but no labels were received. Verify that Loki and Promtail are correctly configured.',
             };
       },
       (err) => {
@@ -750,7 +750,7 @@ export class LokiDatasource
         // because those will only describe how the request between browser<>server failed
         const info: string = err?.data?.message ?? '';
         const infoInParentheses = info !== '' ? ` (${info})` : '';
-        const message = `Unable to connect with Loki${infoInParentheses}. Please check the server logs for more details`;
+        const message = `Unable to connect with Loki${infoInParentheses}. Please check the server logs for more details.`;
         return { status: 'error', message: message };
       }
     );

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -739,7 +739,7 @@ export class LokiDatasource
           : {
               status: 'error',
               message:
-                'Data source connected, but no labels received. Verify that Loki and Promtail is configured properly.',
+                'Data source connected, but no labels received. Verify that Loki and Promtail are configured properly.',
             };
       },
       (err) => {
@@ -750,7 +750,7 @@ export class LokiDatasource
         // because those will only describe how the request between browser<>server failed
         const info: string = err?.data?.message ?? '';
         const infoInParentheses = info !== '' ? ` (${info})` : '';
-        const message = `Unable to fetch labels from Loki${infoInParentheses}, please check the server logs for more details`;
+        const message = `Unable to connect with Loki${infoInParentheses}. Please check the server logs for more details`;
         return { status: 'error', message: message };
       }
     );


### PR DESCRIPTION
First batch of changes, related with the upcoming configuration refactors. Here, we are adding a missing title to an otherwise uncategorized and floating configuration option.

Other changes:
- Added a missing tooltip to Alerting Settings: 
  ![imagen](https://user-images.githubusercontent.com/1069378/230948443-48e21146-8f3a-4a7c-b975-66e843ef73d4.png)
- Improved error and success config messages.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana/issues/65294

**Special notes for your reviewer:**

Nothing in particular to test with these changes. Config should be slightly better now.

Before:

![imagen](https://user-images.githubusercontent.com/1069378/230948673-d468ac00-f60e-4bbc-be6f-b378a7f49bf4.png)

After:

![imagen](https://user-images.githubusercontent.com/1069378/230948607-2d1aa350-3273-4eb5-916b-1e211eff8c99.png)
