### PR TITLE
Design System: Set TextArea to display: block in order to remove spacing below

### DIFF
--- a/packages/grafana-ui/src/components/TextArea/TextArea.tsx
+++ b/packages/grafana-ui/src/components/TextArea/TextArea.tsx
@@ -24,6 +24,7 @@ const getTextAreaStyle = stylesFactory((theme: GrafanaTheme2, invalid = false) =
       sharedInputStyle(theme),
       getFocusStyle(theme),
       css`
+        display: block;
         border-radius: ${theme.shape.borderRadius()};
         padding: ${theme.spacing.gridSize / 4}px ${theme.spacing.gridSize}px;
         width: 100%;

--- a/public/app/features/explore/RichHistory/RichHistoryCard.tsx
+++ b/public/app/features/explore/RichHistory/RichHistoryCard.tsx
@@ -108,6 +108,7 @@ const getStyles = (theme: GrafanaTheme2) => {
     `,
     commentButtonRow: css`
       > * {
+        margin-top: ${theme.spacing(1)};
         margin-right: ${theme.spacing(1)};
       }
     `,


### PR DESCRIPTION
Fixes #55804 

**Examples for affected use cases of `TextArea`:**
- http://localhost:3000/alerting/new => step 4
- http://localhost:3000/explore => Query history => Add comment to a query
- http://localhost:3000/datasources/ => Add datasource => Loki => enable Basic auth and TLS Client Auth 

<details>
<summary>In order to check whether the change breaks the layout I went through the following use cases:</summary>

- packages/grafana-ui/src/components/DataSourceSettings/CertificationKey.tsx
- packages/grafana-ui/src/components/Forms/Form.story.tsx
- public/app/features/plugins/sql/components/configuration/TLSSecretsConfig.tsx
- public/app/features/alerting/unified/components/admin/ConfigEditor.tsx
- public/app/features/alerting/unified/components/silences/SilencesEditor.tsx
- public/app/features/correlations/Forms/ConfigureCorrelationBasicInfoForm.tsx
- public/app/features/dashboard/components/PanelEditor/getPanelFrameOptions.tsx
- public/app/features/dashboard/components/SaveDashboard/forms/SaveDashboardForm.tsx
- public/app/features/dashboard/components/SaveDashboard/forms/SaveProvisionedDashboardForm.tsx
- public/app/features/dashboard/components/ShareModal/ShareEmbed.tsx
- public/app/features/explore/RichHistory/RichHistoryCard.tsx
- public/app/features/manage-dashboards/DashboardImportPage.tsx

</details>

I case there is some use case where the layout breaks please let me know.