### PR TITLE
Alerting: Add limits and move state and label matching filters to the BE

### DIFF
--- a/public/app/features/alerting/unified/AlertsFolderView.test.tsx
+++ b/public/app/features/alerting/unified/AlertsFolderView.test.tsx
@@ -58,6 +58,7 @@ describe('AlertsFolderView tests', () => {
             mockCombinedRule({ name: 'Test Alert 2' }),
             mockCombinedRule({ name: 'Test Alert 3' }),
           ],
+          totals: {},
         },
         {
           name: 'group2',
@@ -66,6 +67,7 @@ describe('AlertsFolderView tests', () => {
             mockCombinedRule({ name: 'Test Alert 5' }),
             mockCombinedRule({ name: 'Test Alert 6' }),
           ],
+          totals: {},
         },
       ],
     };
@@ -104,6 +106,7 @@ describe('AlertsFolderView tests', () => {
             mockCombinedRule({ name: 'Test Alert from other folder 1' }),
             mockCombinedRule({ name: 'Test Alert from other folder 2' }),
           ],
+          totals: {},
         },
       ],
     };
@@ -132,6 +135,7 @@ describe('AlertsFolderView tests', () => {
         {
           name: 'default',
           rules: [mockCombinedRule({ name: 'CPU Alert' }), mockCombinedRule({ name: 'RAM usage alert' })],
+          totals: {},
         },
       ],
     };
@@ -166,6 +170,7 @@ describe('AlertsFolderView tests', () => {
             mockCombinedRule({ name: 'CPU Alert', labels: {} }),
             mockCombinedRule({ name: 'RAM usage alert', labels: { severity: 'critical' } }),
           ],
+          totals: {},
         },
       ],
     };

--- a/public/app/features/alerting/unified/PanelAlertTabContent.test.tsx
+++ b/public/app/features/alerting/unified/PanelAlertTabContent.test.tsx
@@ -325,6 +325,8 @@ describe('PanelAlertTabContent', () => {
         dashboardUID: dashboard.uid,
         panelId: panel.id,
       },
+      undefined,
+      undefined,
       undefined
     );
   });

--- a/public/app/features/alerting/unified/PanelAlertTabContent.test.tsx
+++ b/public/app/features/alerting/unified/PanelAlertTabContent.test.tsx
@@ -319,10 +319,14 @@ describe('PanelAlertTabContent', () => {
         panelId: panel.id,
       }
     );
-    expect(mocks.api.fetchRules).toHaveBeenCalledWith(GRAFANA_RULES_SOURCE_NAME, {
-      dashboardUID: dashboard.uid,
-      panelId: panel.id,
-    });
+    expect(mocks.api.fetchRules).toHaveBeenCalledWith(
+      GRAFANA_RULES_SOURCE_NAME,
+      {
+        dashboardUID: dashboard.uid,
+        panelId: panel.id,
+      },
+      undefined
+    );
   });
 
   it('Update NewRuleFromPanel button url when template changes', async () => {

--- a/public/app/features/alerting/unified/RedirectToRuleViewer.test.tsx
+++ b/public/app/features/alerting/unified/RedirectToRuleViewer.test.tsx
@@ -119,6 +119,7 @@ const mockedRules: CombinedRule[] = [
     group: {
       name: 'test',
       rules: [],
+      totals: {},
     },
     promRule: {
       health: 'ok',
@@ -150,6 +151,7 @@ const mockedRules: CombinedRule[] = [
     group: {
       name: 'test',
       rules: [],
+      totals: {},
     },
     promRule: {
       health: 'ok',

--- a/public/app/features/alerting/unified/RedirectToRuleViewer.test.tsx
+++ b/public/app/features/alerting/unified/RedirectToRuleViewer.test.tsx
@@ -140,6 +140,7 @@ const mockedRules: CombinedRule[] = [
         readOnly: false,
       },
     },
+    instanceTotals: {},
   },
   {
     name: 'Cloud test alert',
@@ -170,5 +171,6 @@ const mockedRules: CombinedRule[] = [
         readOnly: false,
       },
     },
+    instanceTotals: {},
   },
 ];

--- a/public/app/features/alerting/unified/RedirectToRuleViewer.test.tsx
+++ b/public/app/features/alerting/unified/RedirectToRuleViewer.test.tsx
@@ -10,8 +10,8 @@ import { CombinedRule, Rule } from '../../../types/unified-alerting';
 import { PromRuleType } from '../../../types/unified-alerting-dto';
 
 import { RedirectToRuleViewer } from './RedirectToRuleViewer';
-import { useCombinedRulesMatching } from './hooks/useCombinedRule';
 import * as combinedRuleHooks from './hooks/useCombinedRule';
+import { useCombinedRulesMatching } from './hooks/useCombinedRule';
 import { getRulesSourceByName } from './utils/datasource';
 
 jest.mock('./hooks/useCombinedRule');
@@ -142,6 +142,7 @@ const mockedRules: CombinedRule[] = [
       },
     },
     instanceTotals: {},
+    filteredInstanceTotals: {},
   },
   {
     name: 'Cloud test alert',
@@ -174,5 +175,6 @@ const mockedRules: CombinedRule[] = [
       },
     },
     instanceTotals: {},
+    filteredInstanceTotals: {},
   },
 ];

--- a/public/app/features/alerting/unified/RuleList.tsx
+++ b/public/app/features/alerting/unified/RuleList.tsx
@@ -112,7 +112,7 @@ const RuleList = withErrorBoundary(
                     {expandAll ? 'Collapse all' : 'Expand all'}
                   </Button>
                 )}
-                <RuleStats namespaces={filteredNamespaces} includeTotal />
+                <RuleStats namespaces={filteredNamespaces} />
               </div>
               <Stack direction="row" gap={0.5}>
                 {canReadProvisioning && (

--- a/public/app/features/alerting/unified/RuleList.tsx
+++ b/public/app/features/alerting/unified/RuleList.tsx
@@ -72,17 +72,18 @@ const RuleList = withErrorBoundary(
     );
     const allPromEmpty = promRequests.every(([_, state]) => state.dispatched && state?.result?.length === 0);
 
+    const limitAlerts = hasActiveFilters ? undefined : LIMIT_ALERTS;
     // Trigger data refresh only when the RULE_LIST_POLL_INTERVAL_MS elapsed since the previous load FINISHED
     const [_, fetchRules] = useAsyncFn(async () => {
       if (!loading) {
-        await dispatch(fetchAllPromAndRulerRulesAction(false, { limitAlerts: LIMIT_ALERTS }));
+        await dispatch(fetchAllPromAndRulerRulesAction(false, { limitAlerts }));
       }
-    }, [loading]);
+    }, [loading, limitAlerts, dispatch]);
 
     // fetch rules, then poll every RULE_LIST_POLL_INTERVAL_MS
     useEffect(() => {
-      dispatch(fetchAllPromAndRulerRulesAction(false, { limitAlerts: LIMIT_ALERTS }));
-    }, [dispatch]);
+      dispatch(fetchAllPromAndRulerRulesAction(false, { limitAlerts }));
+    }, [dispatch, limitAlerts]);
     useInterval(fetchRules, RULE_LIST_POLL_INTERVAL_MS);
 
     // Show splash only when we loaded all of the data sources and none of them has alerts

--- a/public/app/features/alerting/unified/RuleList.tsx
+++ b/public/app/features/alerting/unified/RuleList.tsx
@@ -15,6 +15,7 @@ import { CombinedRuleNamespace } from '../../../types/unified-alerting';
 import { LogMessages } from './Analytics';
 import { AlertingPageWrapper } from './components/AlertingPageWrapper';
 import { NoRulesSplash } from './components/rules/NoRulesCTA';
+import { INSTANCES_DISPLAY_LIMIT } from './components/rules/RuleDetails';
 import { RuleListErrors } from './components/rules/RuleListErrors';
 import { RuleListGroupView } from './components/rules/RuleListGroupView';
 import { RuleListStateView } from './components/rules/RuleListStateView';
@@ -33,6 +34,9 @@ const VIEWS = {
   groups: RuleListGroupView,
   state: RuleListStateView,
 };
+
+// make sure we ask for 1 more so we show the "show x more" button
+const LIMIT_ALERTS = INSTANCES_DISPLAY_LIMIT + 1;
 
 const RuleList = withErrorBoundary(
   () => {
@@ -71,13 +75,13 @@ const RuleList = withErrorBoundary(
     // Trigger data refresh only when the RULE_LIST_POLL_INTERVAL_MS elapsed since the previous load FINISHED
     const [_, fetchRules] = useAsyncFn(async () => {
       if (!loading) {
-        await dispatch(fetchAllPromAndRulerRulesAction());
+        await dispatch(fetchAllPromAndRulerRulesAction(false, { limitAlerts: LIMIT_ALERTS }));
       }
     }, [loading]);
 
     // fetch rules, then poll every RULE_LIST_POLL_INTERVAL_MS
     useEffect(() => {
-      dispatch(fetchAllPromAndRulerRulesAction());
+      dispatch(fetchAllPromAndRulerRulesAction(false, { limitAlerts: LIMIT_ALERTS }));
     }, [dispatch]);
     useInterval(fetchRules, RULE_LIST_POLL_INTERVAL_MS);
 

--- a/public/app/features/alerting/unified/RuleList.tsx
+++ b/public/app/features/alerting/unified/RuleList.tsx
@@ -73,17 +73,18 @@ const RuleList = withErrorBoundary(
     const allPromEmpty = promRequests.every(([_, state]) => state.dispatched && state?.result?.length === 0);
 
     const limitAlerts = hasActiveFilters ? undefined : LIMIT_ALERTS;
+    const matchers = '';
     // Trigger data refresh only when the RULE_LIST_POLL_INTERVAL_MS elapsed since the previous load FINISHED
     const [_, fetchRules] = useAsyncFn(async () => {
       if (!loading) {
-        await dispatch(fetchAllPromAndRulerRulesAction(false, { limitAlerts }));
+        await dispatch(fetchAllPromAndRulerRulesAction(false, { limitAlerts, matchers }));
       }
-    }, [loading, limitAlerts, dispatch]);
+    }, [loading, limitAlerts, matchers, dispatch]);
 
     // fetch rules, then poll every RULE_LIST_POLL_INTERVAL_MS
     useEffect(() => {
-      dispatch(fetchAllPromAndRulerRulesAction(false, { limitAlerts }));
-    }, [dispatch, limitAlerts]);
+      dispatch(fetchAllPromAndRulerRulesAction(false, { limitAlerts, matchers }));
+    }, [dispatch, limitAlerts, matchers]);
     useInterval(fetchRules, RULE_LIST_POLL_INTERVAL_MS);
 
     // Show splash only when we loaded all of the data sources and none of them has alerts

--- a/public/app/features/alerting/unified/RuleList.tsx
+++ b/public/app/features/alerting/unified/RuleList.tsx
@@ -9,6 +9,7 @@ import { logInfo } from '@grafana/runtime';
 import { Button, LinkButton, useStyles2, withErrorBoundary } from '@grafana/ui';
 import { useQueryParams } from 'app/core/hooks/useQueryParams';
 import { useDispatch } from 'app/types';
+import { GrafanaAlertState } from 'app/types/unified-alerting-dto';
 
 import { CombinedRuleNamespace } from '../../../types/unified-alerting';
 
@@ -74,17 +75,18 @@ const RuleList = withErrorBoundary(
 
     const limitAlerts = hasActiveFilters ? undefined : LIMIT_ALERTS;
     const matchers = '';
+    const state: GrafanaAlertState[] = useMemo(() => [], []);
     // Trigger data refresh only when the RULE_LIST_POLL_INTERVAL_MS elapsed since the previous load FINISHED
     const [_, fetchRules] = useAsyncFn(async () => {
       if (!loading) {
-        await dispatch(fetchAllPromAndRulerRulesAction(false, { limitAlerts, matchers }));
+        await dispatch(fetchAllPromAndRulerRulesAction(false, { limitAlerts, matchers, state }));
       }
-    }, [loading, limitAlerts, matchers, dispatch]);
+    }, [loading, limitAlerts, matchers, state, dispatch]);
 
     // fetch rules, then poll every RULE_LIST_POLL_INTERVAL_MS
     useEffect(() => {
-      dispatch(fetchAllPromAndRulerRulesAction(false, { limitAlerts, matchers }));
-    }, [dispatch, limitAlerts, matchers]);
+      dispatch(fetchAllPromAndRulerRulesAction(false, { limitAlerts, matchers, state }));
+    }, [dispatch, limitAlerts, matchers, state]);
     useInterval(fetchRules, RULE_LIST_POLL_INTERVAL_MS);
 
     // Show splash only when we loaded all of the data sources and none of them has alerts

--- a/public/app/features/alerting/unified/RuleList.tsx
+++ b/public/app/features/alerting/unified/RuleList.tsx
@@ -74,19 +74,19 @@ const RuleList = withErrorBoundary(
     const allPromEmpty = promRequests.every(([_, state]) => state.dispatched && state?.result?.length === 0);
 
     const limitAlerts = hasActiveFilters ? undefined : LIMIT_ALERTS;
-    const matchers = '';
+    const matcher = '';
     const state: GrafanaAlertState[] = useMemo(() => [], []);
     // Trigger data refresh only when the RULE_LIST_POLL_INTERVAL_MS elapsed since the previous load FINISHED
     const [_, fetchRules] = useAsyncFn(async () => {
       if (!loading) {
-        await dispatch(fetchAllPromAndRulerRulesAction(false, { limitAlerts, matchers, state }));
+        await dispatch(fetchAllPromAndRulerRulesAction(false, { limitAlerts, matcher, state }));
       }
-    }, [loading, limitAlerts, matchers, state, dispatch]);
+    }, [loading, limitAlerts, matcher, state, dispatch]);
 
     // fetch rules, then poll every RULE_LIST_POLL_INTERVAL_MS
     useEffect(() => {
-      dispatch(fetchAllPromAndRulerRulesAction(false, { limitAlerts, matchers, state }));
-    }, [dispatch, limitAlerts, matchers, state]);
+      dispatch(fetchAllPromAndRulerRulesAction(false, { limitAlerts, matcher, state }));
+    }, [dispatch, limitAlerts, matcher, state]);
     useInterval(fetchRules, RULE_LIST_POLL_INTERVAL_MS);
 
     // Show splash only when we loaded all of the data sources and none of them has alerts

--- a/public/app/features/alerting/unified/RuleList.tsx
+++ b/public/app/features/alerting/unified/RuleList.tsx
@@ -9,7 +9,6 @@ import { logInfo } from '@grafana/runtime';
 import { Button, LinkButton, useStyles2, withErrorBoundary } from '@grafana/ui';
 import { useQueryParams } from 'app/core/hooks/useQueryParams';
 import { useDispatch } from 'app/types';
-import { GrafanaAlertState } from 'app/types/unified-alerting-dto';
 
 import { CombinedRuleNamespace } from '../../../types/unified-alerting';
 
@@ -74,19 +73,17 @@ const RuleList = withErrorBoundary(
     const allPromEmpty = promRequests.every(([_, state]) => state.dispatched && state?.result?.length === 0);
 
     const limitAlerts = hasActiveFilters ? undefined : LIMIT_ALERTS;
-    const matcher = '';
-    const state: GrafanaAlertState[] = useMemo(() => [], []);
     // Trigger data refresh only when the RULE_LIST_POLL_INTERVAL_MS elapsed since the previous load FINISHED
     const [_, fetchRules] = useAsyncFn(async () => {
       if (!loading) {
-        await dispatch(fetchAllPromAndRulerRulesAction(false, { limitAlerts, matcher, state }));
+        await dispatch(fetchAllPromAndRulerRulesAction(false, { limitAlerts }));
       }
-    }, [loading, limitAlerts, matcher, state, dispatch]);
+    }, [loading, limitAlerts, dispatch]);
 
     // fetch rules, then poll every RULE_LIST_POLL_INTERVAL_MS
     useEffect(() => {
-      dispatch(fetchAllPromAndRulerRulesAction(false, { limitAlerts, matcher, state }));
-    }, [dispatch, limitAlerts, matcher, state]);
+      dispatch(fetchAllPromAndRulerRulesAction(false, { limitAlerts }));
+    }, [dispatch, limitAlerts]);
     useInterval(fetchRules, RULE_LIST_POLL_INTERVAL_MS);
 
     // Show splash only when we loaded all of the data sources and none of them has alerts

--- a/public/app/features/alerting/unified/RuleViewer.tsx
+++ b/public/app/features/alerting/unified/RuleViewer.tsx
@@ -199,7 +199,11 @@ export function RuleViewer({ match }: RuleViewerProps) {
           </div>
         </div>
         <div>
-          <RuleDetailsMatchingInstances rule={rule} pagination={{ itemsPerPage: DEFAULT_PER_PAGE_PAGINATION }} />
+          <RuleDetailsMatchingInstances
+            rule={rule}
+            pagination={{ itemsPerPage: DEFAULT_PER_PAGE_PAGINATION }}
+            enableFiltering
+          />
         </div>
       </RuleViewerLayoutContent>
       <Collapse

--- a/public/app/features/alerting/unified/api/prometheus.test.ts
+++ b/public/app/features/alerting/unified/api/prometheus.test.ts
@@ -1,9 +1,9 @@
 import { paramsWithMatcherAndState } from './prometheus';
 
 const matcher = [{ name: 'severity', isRegex: false, isEqual: true, value: 'critical' }];
-const matcherToJson = matcher.map((m) => encodeURIComponent(JSON.stringify(m)));
+const matcherToJson = matcher.map((m) => JSON.stringify(m));
 const matchers = [...matcher, { name: 'label1', isRegex: false, isEqual: true, value: 'hello there' }];
-const matchersToJson = matchers.map((m) => encodeURIComponent(JSON.stringify(m)));
+const matchersToJson = matchers.map((m) => JSON.stringify(m));
 
 describe('paramsWithMatcherAndState method', () => {
   it('Should return same params object with no changes if there are no states nor matchers', () => {

--- a/public/app/features/alerting/unified/api/prometheus.test.ts
+++ b/public/app/features/alerting/unified/api/prometheus.test.ts
@@ -1,0 +1,34 @@
+import { paramsWithMatcherAndState } from './prometheus';
+
+describe('paramsWithMatcherAndState method', () => {
+  it('Should return same params object with no changes if there are no states nor matchers', () => {
+    const params: Record<string, string | string[]> = { hello: 'there', bye: 'bye' };
+    expect(paramsWithMatcherAndState(params)).toStrictEqual(params);
+  });
+  it('Should return params object with state if there are states and no matchers', () => {
+    const params: Record<string, string | string[]> = { hello: 'there', bye: 'bye' };
+    const state: string[] = ['firing', 'pending'];
+    expect(paramsWithMatcherAndState(params, state)).toStrictEqual({ ...params, state: state });
+  });
+  it('Should return params object with state if there are matchers and no states', () => {
+    const params: Record<string, string | string[]> = { hello: 'there', bye: 'bye' };
+    expect(paramsWithMatcherAndState(params, undefined, '{severity=critical}')).toStrictEqual({
+      ...params,
+      matcher: ['severity=critical'],
+    });
+    expect(paramsWithMatcherAndState(params, undefined, '{severity=critical,label1=hello there}')).toStrictEqual({
+      ...params,
+      matcher: ['severity=critical', 'label1=hello there'],
+    });
+  });
+  it('Should return params object with stateand matchers if there are states and matchers', () => {
+    const params: Record<string, string | string[]> = { hello: 'there', bye: 'bye' };
+    const state: string[] = ['firing', 'pending'];
+    const matchers = '{severity=critical,label1=hello there}';
+    expect(paramsWithMatcherAndState(params, state, matchers)).toStrictEqual({
+      ...params,
+      state: state,
+      matcher: ['severity=critical', 'label1=hello there'],
+    });
+  });
+});

--- a/public/app/features/alerting/unified/api/prometheus.test.ts
+++ b/public/app/features/alerting/unified/api/prometheus.test.ts
@@ -1,5 +1,10 @@
 import { paramsWithMatcherAndState } from './prometheus';
 
+const matcher = [{ name: 'severity', isRegex: false, isEqual: true, value: 'critical' }];
+const matcherToJson = matcher.map((m) => encodeURIComponent(JSON.stringify(m)));
+const matchers = [...matcher, { name: 'label1', isRegex: false, isEqual: true, value: 'hello there' }];
+const matchersToJson = matchers.map((m) => encodeURIComponent(JSON.stringify(m)));
+
 describe('paramsWithMatcherAndState method', () => {
   it('Should return same params object with no changes if there are no states nor matchers', () => {
     const params: Record<string, string | string[]> = { hello: 'there', bye: 'bye' };
@@ -12,23 +17,22 @@ describe('paramsWithMatcherAndState method', () => {
   });
   it('Should return params object with state if there are matchers and no states', () => {
     const params: Record<string, string | string[]> = { hello: 'there', bye: 'bye' };
-    expect(paramsWithMatcherAndState(params, undefined, ['severity=critical'])).toStrictEqual({
+    expect(paramsWithMatcherAndState(params, undefined, matcher)).toStrictEqual({
       ...params,
-      matcher: ['severity=critical'],
+      matcher: matcherToJson,
     });
-    expect(paramsWithMatcherAndState(params, undefined, ['severity=critical', 'label1=hello there'])).toStrictEqual({
+    expect(paramsWithMatcherAndState(params, undefined, matchers)).toStrictEqual({
       ...params,
-      matcher: ['severity=critical', 'label1=hello there'],
+      matcher: matchersToJson,
     });
   });
   it('Should return params object with stateand matchers if there are states and matchers', () => {
     const params: Record<string, string | string[]> = { hello: 'there', bye: 'bye' };
     const state: string[] = ['firing', 'pending'];
-    const matchers = ['severity=critical', 'label1=hello there'];
     expect(paramsWithMatcherAndState(params, state, matchers)).toStrictEqual({
       ...params,
       state: state,
-      matcher: ['severity=critical', 'label1=hello there'],
+      matcher: matchersToJson,
     });
   });
 });

--- a/public/app/features/alerting/unified/api/prometheus.test.ts
+++ b/public/app/features/alerting/unified/api/prometheus.test.ts
@@ -12,11 +12,11 @@ describe('paramsWithMatcherAndState method', () => {
   });
   it('Should return params object with state if there are matchers and no states', () => {
     const params: Record<string, string | string[]> = { hello: 'there', bye: 'bye' };
-    expect(paramsWithMatcherAndState(params, undefined, '{severity=critical}')).toStrictEqual({
+    expect(paramsWithMatcherAndState(params, undefined, ['severity=critical'])).toStrictEqual({
       ...params,
       matcher: ['severity=critical'],
     });
-    expect(paramsWithMatcherAndState(params, undefined, '{severity=critical,label1=hello there}')).toStrictEqual({
+    expect(paramsWithMatcherAndState(params, undefined, ['severity=critical', 'label1=hello there'])).toStrictEqual({
       ...params,
       matcher: ['severity=critical', 'label1=hello there'],
     });
@@ -24,7 +24,7 @@ describe('paramsWithMatcherAndState method', () => {
   it('Should return params object with stateand matchers if there are states and matchers', () => {
     const params: Record<string, string | string[]> = { hello: 'there', bye: 'bye' };
     const state: string[] = ['firing', 'pending'];
-    const matchers = '{severity=critical,label1=hello there}';
+    const matchers = ['severity=critical', 'label1=hello there'];
     expect(paramsWithMatcherAndState(params, state, matchers)).toStrictEqual({
       ...params,
       state: state,

--- a/public/app/features/alerting/unified/api/prometheus.ts
+++ b/public/app/features/alerting/unified/api/prometheus.ts
@@ -14,12 +14,12 @@ export interface FetchPromRulesFilter {
 export interface PrometheusDataSourceConfig {
   dataSourceName: string;
   limitAlerts?: number;
-  matchers?: string;
+  matcher?: string;
   state?: GrafanaAlertState[];
 }
 
 export function prometheusUrlBuilder(dataSourceConfig: PrometheusDataSourceConfig) {
-  const { dataSourceName, limitAlerts, matchers } = dataSourceConfig;
+  const { dataSourceName, limitAlerts, matcher } = dataSourceConfig;
 
   return {
     rules: (filter?: FetchPromRulesFilter) => {
@@ -30,8 +30,8 @@ export function prometheusUrlBuilder(dataSourceConfig: PrometheusDataSourceConfi
       if (dataSourceName === GRAFANA_RULES_SOURCE_NAME && limitAlerts) {
         searchParams.set('limit_alerts', String(limitAlerts));
       }
-      if (dataSourceName === GRAFANA_RULES_SOURCE_NAME && matchers) {
-        searchParams.set('matchers', matchers);
+      if (dataSourceName === GRAFANA_RULES_SOURCE_NAME && matcher) {
+        searchParams.set('matcher', matcher);
       }
 
       const params = prepareRulesFilterQueryParams(searchParams, filter);
@@ -66,14 +66,14 @@ export async function fetchRules(
   dataSourceName: string,
   filter?: FetchPromRulesFilter,
   limitAlerts?: number,
-  matchers?: string,
+  matcher?: string,
   state?: string[]
 ): Promise<RuleNamespace[]> {
   if (filter?.dashboardUID && dataSourceName !== GRAFANA_RULES_SOURCE_NAME) {
     throw new Error('Filtering by dashboard UID is only supported for Grafana Managed rules.');
   }
 
-  const { url, params } = prometheusUrlBuilder({ dataSourceName, limitAlerts, matchers }).rules(filter);
+  const { url, params } = prometheusUrlBuilder({ dataSourceName, limitAlerts, matcher }).rules(filter);
 
   // adding state param here instead of adding it in prometheusUrlBuilder, for being a possible multiple query param
   const response = await lastValueFrom(

--- a/public/app/features/alerting/unified/api/prometheus.ts
+++ b/public/app/features/alerting/unified/api/prometheus.ts
@@ -21,7 +21,7 @@ export function prometheusUrlBuilder(dataSourceConfig: PrometheusDataSourceConfi
   const { dataSourceName, limitAlerts } = dataSourceConfig;
 
   return {
-    rules: (filter?: FetchPromRulesFilter) => {
+    rules: (filter?: FetchPromRulesFilter, state?: string[], matcher?: Matcher[]) => {
       const searchParams = new URLSearchParams();
 
       // if we're fetching for Grafana managed rules, we should add a limit to the number of alert instances
@@ -34,7 +34,7 @@ export function prometheusUrlBuilder(dataSourceConfig: PrometheusDataSourceConfi
 
       return {
         url: `/api/prometheus/${getDatasourceAPIUid(dataSourceName)}/api/v1/rules`,
-        params: params,
+        params: paramsWithMatcherAndState(params, state, matcher),
       };
     },
   };
@@ -87,13 +87,13 @@ export async function fetchRules(
     throw new Error('Filtering by dashboard UID is only supported for Grafana Managed rules.');
   }
 
-  const { url, params } = prometheusUrlBuilder({ dataSourceName, limitAlerts }).rules(filter);
+  const { url, params } = prometheusUrlBuilder({ dataSourceName, limitAlerts }).rules(filter, state, matcher);
 
   // adding state param here instead of adding it in prometheusUrlBuilder, for being a possible multiple query param
   const response = await lastValueFrom(
     getBackendSrv().fetch<PromRulesResponse>({
       url,
-      params: paramsWithMatcherAndState(params, state, matcher),
+      params: params,
       showErrorAlert: false,
       showSuccessAlert: false,
     })

--- a/public/app/features/alerting/unified/api/prometheus.ts
+++ b/public/app/features/alerting/unified/api/prometheus.ts
@@ -59,7 +59,7 @@ export function prepareRulesFilterQueryParams(
 }
 
 function paramsWithState(state: string[] | undefined, params: Record<string, string>) {
-  return state?.length ? { ...params, state: state } : params;
+  return state?.length ? { ...params, state } : params;
 }
 
 export async function fetchRules(

--- a/public/app/features/alerting/unified/api/prometheus.ts
+++ b/public/app/features/alerting/unified/api/prometheus.ts
@@ -66,7 +66,7 @@ export function paramsWithMatcherAndState(
   }
 
   if (matchers?.length) {
-    const matcherToJsonString: string[] = matchers.map((m) => `${JSON.stringify(m)}`);
+    const matcherToJsonString: string[] = matchers.map((m) => JSON.stringify(m));
     paramsResult = {
       ...paramsResult,
       matcher: matcherToJsonString,

--- a/public/app/features/alerting/unified/api/prometheus.ts
+++ b/public/app/features/alerting/unified/api/prometheus.ts
@@ -66,7 +66,7 @@ export function paramsWithMatcherAndState(
   }
 
   if (matchers?.length) {
-    const matcherToJsonString: string[] = matchers.map((m) => `${encodeURIComponent(JSON.stringify(m))}`);
+    const matcherToJsonString: string[] = matchers.map((m) => `${JSON.stringify(m)}`);
     paramsResult = {
       ...paramsResult,
       matcher: matcherToJsonString,

--- a/public/app/features/alerting/unified/api/prometheus.ts
+++ b/public/app/features/alerting/unified/api/prometheus.ts
@@ -55,10 +55,10 @@ export function prepareRulesFilterQueryParams(
   return Object.fromEntries(params);
 }
 
-function paramsWithMatcherAndState(
-  state: string[] | undefined,
-  matcher: string | undefined,
-  params: Record<string, string | string[]>
+export function paramsWithMatcherAndState(
+  params: Record<string, string | string[]>,
+  state?: string[],
+  matcher?: string
 ) {
   let paramsResult = { ...params };
 
@@ -98,7 +98,7 @@ export async function fetchRules(
   const response = await lastValueFrom(
     getBackendSrv().fetch<PromRulesResponse>({
       url,
-      params: paramsWithMatcherAndState(state, matcher, params),
+      params: paramsWithMatcherAndState(params, state, matcher),
       showErrorAlert: false,
       showSuccessAlert: false,
     })

--- a/public/app/features/alerting/unified/api/prometheus.ts
+++ b/public/app/features/alerting/unified/api/prometheus.ts
@@ -1,6 +1,7 @@
 import { lastValueFrom } from 'rxjs';
 
 import { getBackendSrv } from '@grafana/runtime';
+import { Matcher } from 'app/plugins/datasource/alertmanager/types';
 import { RuleNamespace } from 'app/types/unified-alerting';
 import { PromRulesResponse } from 'app/types/unified-alerting-dto';
 
@@ -56,7 +57,7 @@ export function prepareRulesFilterQueryParams(
 export function paramsWithMatcherAndState(
   params: Record<string, string | string[]>,
   state?: string[],
-  matcher?: string[]
+  matchers?: Matcher[]
 ) {
   let paramsResult = { ...params };
 
@@ -64,10 +65,11 @@ export function paramsWithMatcherAndState(
     paramsResult = { ...paramsResult, state };
   }
 
-  if (matcher?.length) {
+  if (matchers?.length) {
+    const matcherToJsonString: string[] = matchers.map((m) => `${encodeURIComponent(JSON.stringify(m))}`);
     paramsResult = {
       ...paramsResult,
-      matcher,
+      matcher: matcherToJsonString,
     };
   }
 
@@ -78,7 +80,7 @@ export async function fetchRules(
   dataSourceName: string,
   filter?: FetchPromRulesFilter,
   limitAlerts?: number,
-  matcher?: string[],
+  matcher?: Matcher[],
   state?: string[]
 ): Promise<RuleNamespace[]> {
   if (filter?.dashboardUID && dataSourceName !== GRAFANA_RULES_SOURCE_NAME) {

--- a/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
@@ -162,7 +162,7 @@ function FolderGroupAndEvaluationInterval({
     rulesSource: GRAFANA_RULES_SOURCE_NAME,
     groups: [],
   };
-  const emptyGroup: CombinedRuleGroup = { name: groupName, interval: evaluateEvery, rules: [] };
+  const emptyGroup: CombinedRuleGroup = { name: groupName, interval: evaluateEvery, rules: [], totals: {} };
 
   return (
     <div>

--- a/public/app/features/alerting/unified/components/rules/AlertInstanceStateFilter.tsx
+++ b/public/app/features/alerting/unified/components/rules/AlertInstanceStateFilter.tsx
@@ -27,8 +27,8 @@ export const AlertInstanceStateFilter = ({
 
   const getOptionComponent = (state: InstanceStateFilter) => {
     return function InstanceStateCounter() {
-      return itemPerStateStats && itemPerStateStats[state.toLowerCase()] ? (
-        <Tag name={itemPerStateStats[state.toLowerCase()].toFixed(0)} colorIndex={9} className={styles.tag} />
+      return itemPerStateStats && itemPerStateStats[state] ? (
+        <Tag name={itemPerStateStats[state].toFixed(0)} colorIndex={9} className={styles.tag} />
       ) : null;
     };
   };

--- a/public/app/features/alerting/unified/components/rules/AlertInstanceStateFilter.tsx
+++ b/public/app/features/alerting/unified/components/rules/AlertInstanceStateFilter.tsx
@@ -27,8 +27,8 @@ export const AlertInstanceStateFilter = ({
 
   const getOptionComponent = (state: InstanceStateFilter) => {
     return function InstanceStateCounter() {
-      return itemPerStateStats && itemPerStateStats[state] ? (
-        <Tag name={itemPerStateStats[state].toFixed(0)} colorIndex={9} className={styles.tag} />
+      return itemPerStateStats && itemPerStateStats[state.toLowerCase()] ? (
+        <Tag name={itemPerStateStats[state.toLowerCase()].toFixed(0)} colorIndex={9} className={styles.tag} />
       ) : null;
     };
   };

--- a/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.test.tsx
@@ -60,7 +60,7 @@ describe('EditGroupModal', () => {
     const namespace = mockCombinedRuleNamespace({
       name: 'my-alerts',
       rulesSource: mockDataSource(),
-      groups: [{ name: 'default-group', interval: '90s', rules: [] }],
+      groups: [{ name: 'default-group', interval: '90s', rules: [], totals: {} }],
     });
 
     const group = namespace.groups[0];
@@ -100,7 +100,9 @@ describe('EditGroupModal component on cloud alert rules', () => {
     const promNs = mockCombinedRuleNamespace({
       name: 'prometheus-ns',
       rulesSource: promDsSettings,
-      groups: [{ name: 'default-group', interval: '90s', rules: [alertingRule, recordingRule1, recordingRule2] }],
+      groups: [
+        { name: 'default-group', interval: '90s', rules: [alertingRule, recordingRule1, recordingRule2], totals: {} },
+      ],
     });
 
     const group = promNs.groups[0];
@@ -121,7 +123,7 @@ describe('EditGroupModal component on cloud alert rules', () => {
     const promNs = mockCombinedRuleNamespace({
       name: 'prometheus-ns',
       rulesSource: promDsSettings,
-      groups: [{ name: 'default-group', interval: '90s', rules: [recordingRule1, recordingRule2] }],
+      groups: [{ name: 'default-group', interval: '90s', rules: [recordingRule1, recordingRule2], totals: {} }],
     });
 
     const group = promNs.groups[0];
@@ -154,6 +156,7 @@ describe('EditGroupModal component on grafana-managed alert rules', () => {
             rulerRule: mockRulerAlertingRule({ alert: 'high-memory' }),
           }),
         ],
+        totals: {},
       },
     ],
   };

--- a/public/app/features/alerting/unified/components/rules/RuleDetails.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleDetails.tsx
@@ -25,7 +25,7 @@ interface Props {
 // The limit is set to 15 in order to upkeep the good performance
 // and to encourage users to go to the rule details page to see the rest of the instances
 // We don't want to paginate the instances list on the alert list page
-const INSTANCES_DISPLAY_LIMIT = 15;
+export const INSTANCES_DISPLAY_LIMIT = 15;
 
 export const RuleDetails = ({ rule }: Props) => {
   const styles = useStyles2(getStyles);

--- a/public/app/features/alerting/unified/components/rules/RuleDetailsMatchingInstances.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleDetailsMatchingInstances.test.tsx
@@ -32,7 +32,7 @@ describe('RuleDetailsMatchingInstances', () => {
     it('For Grafana Managed rules instances filter should contain five states', () => {
       const rule = mockCombinedRule();
 
-      render(<RuleDetailsMatchingInstances rule={rule} />);
+      render(<RuleDetailsMatchingInstances rule={rule} enableFiltering />);
 
       const stateFilter = ui.stateFilter.get();
       expect(stateFilter).toBeInTheDocument();
@@ -69,7 +69,7 @@ describe('RuleDetailsMatchingInstances', () => {
         [GrafanaAlertState.Error]: ui.grafanaStateButton.error,
       };
 
-      render(<RuleDetailsMatchingInstances rule={rule} />);
+      render(<RuleDetailsMatchingInstances rule={rule} enableFiltering />);
 
       await userEvent.click(buttons[state].get());
 
@@ -82,7 +82,7 @@ describe('RuleDetailsMatchingInstances', () => {
         namespace: mockPromNamespace(),
       });
 
-      render(<RuleDetailsMatchingInstances rule={rule} />);
+      render(<RuleDetailsMatchingInstances rule={rule} enableFiltering />);
 
       const stateFilter = ui.stateFilter.get();
       expect(stateFilter).toBeInTheDocument();
@@ -108,7 +108,7 @@ describe('RuleDetailsMatchingInstances', () => {
           }),
         });
 
-        render(<RuleDetailsMatchingInstances rule={rule} />);
+        render(<RuleDetailsMatchingInstances rule={rule} enableFiltering />);
 
         await userEvent.click(ui.cloudStateButton[state].get());
 

--- a/public/app/features/alerting/unified/components/rules/RuleDetailsMatchingInstances.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleDetailsMatchingInstances.test.tsx
@@ -122,7 +122,7 @@ describe('RuleDetailsMatchingInstances', () => {
 function mockPromNamespace(): CombinedRuleNamespace {
   return {
     rulesSource: mockDataSource(),
-    groups: [{ name: 'Prom rules group', rules: [] }],
+    groups: [{ name: 'Prom rules group', rules: [], totals: {} }],
     name: 'Prometheus-test',
   };
 }

--- a/public/app/features/alerting/unified/components/rules/RuleDetailsMatchingInstances.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleDetailsMatchingInstances.tsx
@@ -1,5 +1,5 @@
 import { css, cx } from '@emotion/css';
-import { countBy } from 'lodash';
+import { sum } from 'lodash';
 import React, { useMemo, useState } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
@@ -52,7 +52,7 @@ function ShowMoreInstances(props: { ruleViewPageLink: string; stats: ShowMoreSta
 
 export function RuleDetailsMatchingInstances(props: Props): JSX.Element | null {
   const {
-    rule: { promRule, namespace },
+    rule: { promRule, namespace, instanceTotals },
     itemsDisplayLimit = Number.POSITIVE_INFINITY,
     pagination,
   } = props;
@@ -82,17 +82,17 @@ export function RuleDetailsMatchingInstances(props: Props): JSX.Element | null {
 
   const visibleInstances = alerts.slice(0, itemsDisplayLimit);
 
-  const countAllByState = countBy(promRule.alerts, (alert) => mapStateWithReasonToBaseState(alert.state));
-  const hiddenItemsCount = alerts.length - visibleInstances.length;
+  const totalInstancesCount = sum(Object.values(instanceTotals));
+  const hiddenInstancesCount = totalInstancesCount - visibleInstances.length;
 
   const stats: ShowMoreStats = {
-    totalItemsCount: alerts.length,
+    totalItemsCount: totalInstancesCount,
     visibleItemsCount: visibleInstances.length,
   };
 
   const ruleViewPageLink = createViewLink(namespace.rulesSource, props.rule, location.pathname + location.search);
 
-  const footerRow = hiddenItemsCount ? (
+  const footerRow = hiddenInstancesCount ? (
     <ShowMoreInstances stats={stats} ruleViewPageLink={ruleViewPageLink} />
   ) : undefined;
 
@@ -111,7 +111,7 @@ export function RuleDetailsMatchingInstances(props: Props): JSX.Element | null {
             filterType={stateFilterType}
             stateFilter={alertState}
             onStateFilterChange={setAlertState}
-            itemPerStateStats={countAllByState}
+            itemPerStateStats={instanceTotals}
           />
         </div>
       </div>

--- a/public/app/features/alerting/unified/components/rules/RuleListGroupView.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleListGroupView.test.tsx
@@ -116,6 +116,7 @@ function getGrafanaNamespace(): CombinedRuleNamespace {
       {
         name: 'default',
         rules: [mockCombinedRule()],
+        totals: {},
       },
     ],
   };
@@ -129,6 +130,7 @@ function getCloudNamespace(): CombinedRuleNamespace {
       {
         name: 'Prom group',
         rules: [mockCombinedRule()],
+        totals: {},
       },
     ],
   };

--- a/public/app/features/alerting/unified/components/rules/RuleState.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleState.tsx
@@ -31,7 +31,7 @@ export const RuleState = ({ rule, isDeleting, isCreating, isPaused }: Props) => 
       promRule.state !== PromAlertingRuleState.Inactive
     ) {
       // find earliest alert
-      const firstActiveAt = getFirstActiveAt(promRule);
+      const firstActiveAt = promRule.activeAt ? new Date(promRule.activeAt) : getFirstActiveAt(promRule);
 
       // calculate time elapsed from earliest alert
       if (firstActiveAt) {

--- a/public/app/features/alerting/unified/components/rules/RuleStats.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleStats.tsx
@@ -101,6 +101,10 @@ function getComponentsFromStats(stats: Partial<Record<AlertInstanceState | 'paus
     statsComponents.push(<Badge color="red" key="errors" text={`${stats.error} errors`} />);
   }
 
+  if (stats.nodata) {
+    statsComponents.push(<Badge color="blue" key="nodata" text={`${stats.nodata} no data`} />);
+  }
+
   if (stats[AlertInstanceState.Pending]) {
     statsComponents.push(
       <Badge color={'orange'} key="pending" text={`${stats[AlertInstanceState.Pending]} pending`} />

--- a/public/app/features/alerting/unified/components/rules/RuleStats.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleStats.tsx
@@ -1,4 +1,4 @@
-import { sum } from 'lodash';
+import { isUndefined, omitBy, sum } from 'lodash';
 import pluralize from 'pluralize';
 import React, { Fragment } from 'react';
 
@@ -12,7 +12,6 @@ interface Props {
 }
 
 const emptyStats = {
-  total: 0,
   recording: 0,
   alerting: 0,
   [PromAlertingRuleState.Pending]: 0,
@@ -24,16 +23,19 @@ const emptyStats = {
 export const RuleStats = ({ namespaces }: Props) => {
   const stats = { ...emptyStats };
 
+  // sum all totals for all namespaces
+  namespaces.forEach(({ groups }) => {
+    groups.forEach((group) => {
+      const groupTotals = omitBy(group.totals, isUndefined);
+      for (let key in groupTotals) {
+        // @ts-ignore
+        stats[key] += groupTotals[key];
+      }
+    });
+  });
+
   const statsComponents = getComponentsFromStats(stats);
   const hasStats = Boolean(statsComponents.length);
-
-  // sum all totals for all namespaces
-  namespaces.forEach(({ totals }) => {
-    for (let key in totals) {
-      // @ts-ignore
-      stats[key] += totals[key];
-    }
-  });
 
   const total = sum(Object.values(stats));
 

--- a/public/app/features/alerting/unified/components/rules/RuleStats.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleStats.tsx
@@ -6,7 +6,7 @@ import { Stack } from '@grafana/experimental';
 import { Badge } from '@grafana/ui';
 import {
   AlertGroupTotals,
-  AlertInstanceState,
+  AlertInstanceTotalState,
   CombinedRuleGroup,
   CombinedRuleNamespace,
 } from 'app/types/unified-alerting';
@@ -90,11 +90,14 @@ export const RuleGroupStats = ({ group }: RuleGroupStatsProps) => {
     </Stack>
   );
 };
-function getComponentsFromStats(stats: Partial<Record<AlertInstanceState | 'paused' | 'recording', number>>) {
+
+export function getComponentsFromStats(
+  stats: Partial<Record<AlertInstanceTotalState | 'paused' | 'recording', number>>
+) {
   const statsComponents: React.ReactNode[] = [];
 
-  if (stats[AlertInstanceState.Alerting]) {
-    statsComponents.push(<Badge color="red" key="firing" text={`${stats[AlertInstanceState.Alerting]} firing`} />);
+  if (stats[AlertInstanceTotalState.Alerting]) {
+    statsComponents.push(<Badge color="red" key="firing" text={`${stats[AlertInstanceTotalState.Alerting]} firing`} />);
   }
 
   if (stats.error) {
@@ -105,20 +108,26 @@ function getComponentsFromStats(stats: Partial<Record<AlertInstanceState | 'paus
     statsComponents.push(<Badge color="blue" key="nodata" text={`${stats.nodata} no data`} />);
   }
 
-  if (stats[AlertInstanceState.Pending]) {
+  if (stats[AlertInstanceTotalState.Pending]) {
     statsComponents.push(
-      <Badge color={'orange'} key="pending" text={`${stats[AlertInstanceState.Pending]} pending`} />
+      <Badge color={'orange'} key="pending" text={`${stats[AlertInstanceTotalState.Pending]} pending`} />
     );
   }
 
-  if (stats[AlertInstanceState.Normal] && stats.paused) {
+  if (stats[AlertInstanceTotalState.Normal] && stats.paused) {
     statsComponents.push(
-      <Badge color="green" key="paused" text={`${stats[AlertInstanceState.Normal]} normal (${stats.paused} paused)`} />
+      <Badge
+        color="green"
+        key="paused"
+        text={`${stats[AlertInstanceTotalState.Normal]} normal (${stats.paused} paused)`}
+      />
     );
   }
 
-  if (stats[AlertInstanceState.Normal] && !stats.paused) {
-    statsComponents.push(<Badge color="green" key="inactive" text={`${stats[AlertInstanceState.Normal]} normal`} />);
+  if (stats[AlertInstanceTotalState.Normal] && !stats.paused) {
+    statsComponents.push(
+      <Badge color="green" key="inactive" text={`${stats[AlertInstanceTotalState.Normal]} normal`} />
+    );
   }
 
   if (stats.recording) {

--- a/public/app/features/alerting/unified/components/rules/RuleStats.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleStats.tsx
@@ -4,21 +4,28 @@ import React, { Fragment } from 'react';
 
 import { Stack } from '@grafana/experimental';
 import { Badge } from '@grafana/ui';
-import { AlertInstanceState, CombinedRuleGroup, CombinedRuleNamespace } from 'app/types/unified-alerting';
+import {
+  AlertGroupTotals,
+  AlertInstanceState,
+  CombinedRuleGroup,
+  CombinedRuleNamespace,
+} from 'app/types/unified-alerting';
 import { PromAlertingRuleState } from 'app/types/unified-alerting-dto';
 
 interface Props {
   namespaces: CombinedRuleNamespace[];
 }
 
-const emptyStats = {
+// All available states for a rule need to be initialized to prevent NaN values when adding a number and undefined
+const emptyStats: Required<AlertGroupTotals> = {
   recording: 0,
   alerting: 0,
   [PromAlertingRuleState.Pending]: 0,
   [PromAlertingRuleState.Inactive]: 0,
   paused: 0,
   error: 0,
-} as const;
+  nodata: 0,
+};
 
 export const RuleStats = ({ namespaces }: Props) => {
   const stats = { ...emptyStats };

--- a/public/app/features/alerting/unified/components/rules/RulesGroup.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/RulesGroup.test.tsx
@@ -62,6 +62,7 @@ describe('Rules group tests', () => {
     const group: CombinedRuleGroup = {
       name: 'TestGroup',
       rules: [mockCombinedRule()],
+      totals: {},
     };
 
     const namespace: CombinedRuleNamespace = {
@@ -89,6 +90,7 @@ describe('Rules group tests', () => {
     const group: CombinedRuleGroup = {
       name: 'TestGroup',
       rules: [mockCombinedRule()],
+      totals: {},
     };
 
     const namespace: CombinedRuleNamespace = {
@@ -147,6 +149,7 @@ describe('Rules group tests', () => {
     const group: CombinedRuleGroup = {
       name: 'TestGroup',
       rules: [mockCombinedRule()],
+      totals: {},
     };
 
     const namespace: CombinedRuleNamespace = {

--- a/public/app/features/alerting/unified/components/rules/RulesGroup.tsx
+++ b/public/app/features/alerting/unified/components/rules/RulesGroup.tsx
@@ -23,7 +23,7 @@ import { RuleLocation } from '../RuleLocation';
 import { ActionIcon } from './ActionIcon';
 import { EditCloudGroupModal } from './EditRuleGroupModal';
 import { ReorderCloudGroupModal } from './ReorderRuleGroupModal';
-import { RuleStats } from './RuleStats';
+import { RuleGroupStats } from './RuleStats';
 import { RulesTable } from './RulesTable';
 
 type ViewMode = 'grouped' | 'list';
@@ -217,7 +217,7 @@ export const RulesGroup = React.memo(({ group, namespace, expandAll, viewMode }:
         }
         <div className={styles.spacer} />
         <div className={styles.headerStats}>
-          <RuleStats group={group} />
+          <RuleGroupStats group={group} />
         </div>
         {isProvisioned && (
           <>

--- a/public/app/features/alerting/unified/hooks/useCombinedRuleNamespaces.test.ts
+++ b/public/app/features/alerting/unified/hooks/useCombinedRuleNamespaces.test.ts
@@ -8,22 +8,26 @@ describe('flattenGrafanaManagedRules', () => {
     const ungroupedGroup1 = {
       name: 'my-rule',
       rules: [{ name: 'my-rule' }],
+      totals: {},
     } as CombinedRuleGroup;
 
     const ungroupedGroup2 = {
       name: 'another-rule',
       rules: [{ name: 'another-rule' }],
+      totals: {},
     } as CombinedRuleGroup;
 
     // the rules from both these groups should go in their own group name
     const group1 = {
       name: 'group1',
       rules: [{ name: 'rule-1' }, { name: 'rule-2' }],
+      totals: {},
     } as CombinedRuleGroup;
 
     const group2 = {
       name: 'group2',
       rules: [{ name: 'rule-1' }, { name: 'rule-2' }],
+      totals: {},
     } as CombinedRuleGroup;
 
     const namespace1 = {
@@ -45,6 +49,7 @@ describe('flattenGrafanaManagedRules', () => {
       {
         name: 'default',
         rules: sortRulesByName([...ungroupedGroup1.rules, ...ungroupedGroup2.rules, ...group1.rules, ...group2.rules]),
+        totals: {},
       },
     ]);
 
@@ -52,6 +57,7 @@ describe('flattenGrafanaManagedRules', () => {
       {
         name: 'default',
         rules: ungroupedGroup1.rules,
+        totals: {},
       },
     ]);
   });

--- a/public/app/features/alerting/unified/hooks/useCombinedRuleNamespaces.ts
+++ b/public/app/features/alerting/unified/hooks/useCombinedRuleNamespaces.ts
@@ -4,7 +4,7 @@ import { useMemo, useRef } from 'react';
 import {
   AlertGroupTotals,
   AlertingRule,
-  AlertInstanceState,
+  AlertInstanceTotalState,
   AlertInstanceTotals,
   CombinedRule,
   CombinedRuleGroup,
@@ -195,15 +195,16 @@ export function calculateRuleTotals(rule: Pick<AlertingRule, 'alerts' | 'totals'
   const result = countBy(rule.alerts, 'state');
 
   if (rule.totals) {
-    return rule.totals;
+    const { normal, ...totals } = rule.totals;
+    return { ...totals, inactive: normal };
   }
 
   return {
-    alerting: result[AlertInstanceState.Alerting],
-    pending: result[AlertInstanceState.Pending],
-    inactive: result[AlertInstanceState.Normal],
-    nodata: result[AlertInstanceState.NoData],
-    error: result[AlertInstanceState.Error] + result['err'], // Prometheus uses "err" instead of "error"
+    alerting: result[AlertInstanceTotalState.Alerting],
+    pending: result[AlertInstanceTotalState.Pending],
+    inactive: result[AlertInstanceTotalState.Normal],
+    nodata: result[AlertInstanceTotalState.NoData],
+    error: result[AlertInstanceTotalState.Error] + result['err'], // Prometheus uses "err" instead of "error"
   };
 }
 

--- a/public/app/features/alerting/unified/hooks/useCombinedRuleNamespaces.ts
+++ b/public/app/features/alerting/unified/hooks/useCombinedRuleNamespaces.ts
@@ -82,7 +82,6 @@ export function useCombinedRuleNamespaces(rulesSourceName?: string): CombinedRul
             rulesSource,
             name: namespaceName,
             groups: [],
-            totals: {},
           };
           namespaces[namespaceName] = namespace;
           addRulerGroupsToCombinedNamespace(namespace, groups);
@@ -120,7 +119,6 @@ export function flattenGrafanaManagedRules(namespaces: CombinedRuleNamespace[]) 
     newNamespace.groups.push({
       name: 'default',
       rules: sortRulesByName(namespace.groups.flatMap((group) => group.rules)),
-      // TODO – calculate totals here?
       totals: calculateTotalsFromCombinedRuleGroups(namespace.groups),
     });
 

--- a/public/app/features/alerting/unified/hooks/useCombinedRuleNamespaces.ts
+++ b/public/app/features/alerting/unified/hooks/useCombinedRuleNamespaces.ts
@@ -152,9 +152,11 @@ function addRulerGroupsToCombinedNamespace(namespace: CombinedRuleNamespace, gro
 
 function calculateTotalsFromGroup(group: RuleGroup): AlertGroupTotals {
   if (group.totals) {
+    const { firing, ...totals } = group.totals;
+
     return {
-      ...group.totals,
-      alerting: group.totals.firing,
+      ...totals,
+      alerting: firing,
     };
   }
 

--- a/public/app/features/alerting/unified/hooks/useCombinedRuleNamespaces.ts
+++ b/public/app/features/alerting/unified/hooks/useCombinedRuleNamespaces.ts
@@ -270,7 +270,7 @@ function promRuleToCombinedRule(rule: Rule, namespace: CombinedRuleNamespace, gr
     namespace: namespace,
     group,
     instanceTotals: isAlertingRule(rule) ? calculateRuleTotals(rule) : {},
-    filteredInstanceTotals: {},
+    filteredInstanceTotals: isAlertingRule(rule) ? calculateRuleFilteredTotals(rule) : {},
   };
 }
 

--- a/public/app/features/alerting/unified/hooks/useFilteredRules.ts
+++ b/public/app/features/alerting/unified/hooks/useFilteredRules.ts
@@ -13,7 +13,7 @@ import { labelsMatchMatchers, matcherToMatcherField, parseMatcher, parseMatchers
 import { isCloudRulesSource } from '../utils/datasource';
 import { getRuleHealth, isAlertingRule, isGrafanaRulerRule, isPromRuleType } from '../utils/rules';
 
-import { calculateRuleTotals, calculateGroupTotals } from './useCombinedRuleNamespaces';
+import { calculateGroupTotals, calculateRuleFilteredTotals, calculateRuleTotals } from './useCombinedRuleNamespaces';
 import { useURLSearchParams } from './useURLSearchParams';
 
 export function useRulesFilter() {
@@ -84,6 +84,7 @@ export const useFilteredRules = (namespaces: CombinedRuleNamespace[], filterStat
         group.rules.forEach((rule) => {
           if (isAlertingRule(rule.promRule)) {
             rule.instanceTotals = calculateRuleTotals(rule.promRule);
+            rule.filteredInstanceTotals = calculateRuleFilteredTotals(rule.promRule);
           }
         });
 

--- a/public/app/features/alerting/unified/mocks.ts
+++ b/public/app/features/alerting/unified/mocks.ts
@@ -512,10 +512,11 @@ export const mockCombinedRule = (partial?: Partial<CombinedRule>): CombinedRule 
   group: {
     name: 'mockCombinedRuleGroup',
     rules: [],
+    totals: {},
   },
   namespace: {
     name: 'mockCombinedNamespace',
-    groups: [{ name: 'mockCombinedRuleGroup', rules: [] }],
+    groups: [{ name: 'mockCombinedRuleGroup', rules: [], totals: {} }],
     rulesSource: 'grafana',
   },
   labels: {},
@@ -597,7 +598,7 @@ export function mockAlertQuery(query: Partial<AlertQuery>): AlertQuery {
 }
 
 export function mockCombinedRuleGroup(name: string, rules: CombinedRule[]): CombinedRuleGroup {
-  return { name, rules };
+  return { name, rules, totals: {} };
 }
 
 export function mockCombinedRuleNamespace(namespace: Partial<CombinedRuleNamespace>): CombinedRuleNamespace {

--- a/public/app/features/alerting/unified/mocks.ts
+++ b/public/app/features/alerting/unified/mocks.ts
@@ -522,6 +522,7 @@ export const mockCombinedRule = (partial?: Partial<CombinedRule>): CombinedRule 
   annotations: {},
   promRule: mockPromAlertingRule(),
   rulerRule: mockRulerAlertingRule(),
+  instanceTotals: {},
   ...partial,
 });
 

--- a/public/app/features/alerting/unified/mocks.ts
+++ b/public/app/features/alerting/unified/mocks.ts
@@ -170,6 +170,7 @@ export const mockPromAlertingRule = (partial: Partial<AlertingRule> = {}): Alert
     },
     state: PromAlertingRuleState.Firing,
     health: 'OK',
+    totalsFiltered: { alerting: 1 },
     ...partial,
   };
 };

--- a/public/app/features/alerting/unified/mocks.ts
+++ b/public/app/features/alerting/unified/mocks.ts
@@ -524,6 +524,7 @@ export const mockCombinedRule = (partial?: Partial<CombinedRule>): CombinedRule 
   promRule: mockPromAlertingRule(),
   rulerRule: mockRulerAlertingRule(),
   instanceTotals: {},
+  filteredInstanceTotals: {},
   ...partial,
 });
 

--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -25,6 +25,7 @@ import {
   StateHistoryItem,
 } from 'app/types/unified-alerting';
 import {
+  GrafanaAlertState,
   PostableRulerRuleGroupDTO,
   PromApplication,
   RulerRuleDTO,
@@ -106,7 +107,14 @@ export const fetchPromRulesAction = createAsyncThunk(
       filter,
       limitAlerts,
       matchers,
-    }: { rulesSourceName: string; filter?: FetchPromRulesFilter; limitAlerts?: number; matchers?: string },
+      state,
+    }: {
+      rulesSourceName: string;
+      filter?: FetchPromRulesFilter;
+      limitAlerts?: number;
+      matchers?: string;
+      state?: GrafanaAlertState[];
+    },
     thunkAPI
   ): Promise<RuleNamespace[]> => {
     await thunkAPI.dispatch(fetchRulesSourceBuildInfoAction({ rulesSourceName }));
@@ -116,7 +124,7 @@ export const fetchPromRulesAction = createAsyncThunk(
       thunk: 'unifiedalerting/fetchPromRules',
     });
 
-    return await withSerializedError(fetchRulesWithLogging(rulesSourceName, filter, limitAlerts, matchers));
+    return await withSerializedError(fetchRulesWithLogging(rulesSourceName, filter, limitAlerts, matchers, state));
   }
 );
 
@@ -348,6 +356,7 @@ interface FetchPromRulesRulesActionProps {
   filter?: FetchPromRulesFilter;
   limitAlerts?: number;
   matchers?: string;
+  state?: GrafanaAlertState[];
 }
 
 export function fetchAllPromAndRulerRulesAction(

--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -1,4 +1,4 @@
-import { AsyncThunk, createAsyncThunk } from '@reduxjs/toolkit';
+import { AsyncThunk, createAction, createAsyncThunk } from '@reduxjs/toolkit';
 import { isEmpty } from 'lodash';
 
 import { config, locationService } from '@grafana/runtime';
@@ -15,6 +15,7 @@ import {
 } from 'app/plugins/datasource/alertmanager/types';
 import { FolderDTO, NotifierDTO, StoreState, ThunkResult } from 'app/types';
 import {
+  AlertGroupTotals,
   CombinedRuleGroup,
   CombinedRuleNamespace,
   PromBasedDataSource,

--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -101,7 +101,11 @@ function getDataSourceRulerConfig(getState: () => unknown, rulesSourceName: stri
 export const fetchPromRulesAction = createAsyncThunk(
   'unifiedalerting/fetchPromRules',
   async (
-    { rulesSourceName, filter }: { rulesSourceName: string; filter?: FetchPromRulesFilter },
+    {
+      rulesSourceName,
+      filter,
+      limitAlerts,
+    }: { rulesSourceName: string; filter?: FetchPromRulesFilter; limitAlerts?: number },
     thunkAPI
   ): Promise<RuleNamespace[]> => {
     await thunkAPI.dispatch(fetchRulesSourceBuildInfoAction({ rulesSourceName }));
@@ -111,7 +115,7 @@ export const fetchPromRulesAction = createAsyncThunk(
       thunk: 'unifiedalerting/fetchPromRules',
     });
 
-    return await withSerializedError(fetchRulesWithLogging(rulesSourceName, filter));
+    return await withSerializedError(fetchRulesWithLogging(rulesSourceName, filter, limitAlerts));
   }
 );
 
@@ -339,7 +343,14 @@ export const fetchRulesSourceBuildInfoAction = createAsyncThunk(
   }
 );
 
-export function fetchAllPromAndRulerRulesAction(force = false): ThunkResult<Promise<void>> {
+interface FetchPromRulesRulesActionProps {
+  limitAlerts?: number;
+}
+
+export function fetchAllPromAndRulerRulesAction(
+  force = false,
+  options: FetchPromRulesRulesActionProps = {}
+): ThunkResult<Promise<void>> {
   return async (dispatch, getStore) => {
     const allStartLoadingTs = performance.now();
 
@@ -359,7 +370,7 @@ export function fetchAllPromAndRulerRulesAction(force = false): ThunkResult<Prom
           (force || !rulerRules[rulesSourceName]?.loading) && Boolean(dataSourceConfig.rulerConfig);
 
         await Promise.allSettled([
-          shouldLoadProm && dispatch(fetchPromRulesAction({ rulesSourceName })),
+          shouldLoadProm && dispatch(fetchPromRulesAction({ rulesSourceName, ...options })),
           shouldLoadRuler && dispatch(fetchRulerRulesAction({ rulesSourceName })),
         ]);
       })

--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -1,4 +1,4 @@
-import { AsyncThunk, createAction, createAsyncThunk } from '@reduxjs/toolkit';
+import { AsyncThunk, createAsyncThunk } from '@reduxjs/toolkit';
 import { isEmpty } from 'lodash';
 
 import { config, locationService } from '@grafana/runtime';
@@ -15,7 +15,6 @@ import {
 } from 'app/plugins/datasource/alertmanager/types';
 import { FolderDTO, NotifierDTO, StoreState, ThunkResult } from 'app/types';
 import {
-  AlertGroupTotals,
   CombinedRuleGroup,
   CombinedRuleNamespace,
   PromBasedDataSource,

--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -344,6 +344,7 @@ export const fetchRulesSourceBuildInfoAction = createAsyncThunk(
 );
 
 interface FetchPromRulesRulesActionProps {
+  filter?: FetchPromRulesFilter;
   limitAlerts?: number;
 }
 

--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -25,7 +25,6 @@ import {
   StateHistoryItem,
 } from 'app/types/unified-alerting';
 import {
-  GrafanaAlertState,
   PostableRulerRuleGroupDTO,
   PromApplication,
   RulerRuleDTO,
@@ -113,7 +112,7 @@ export const fetchPromRulesAction = createAsyncThunk(
       filter?: FetchPromRulesFilter;
       limitAlerts?: number;
       matchers?: string;
-      state?: GrafanaAlertState[];
+      state?: string[];
     },
     thunkAPI
   ): Promise<RuleNamespace[]> => {
@@ -356,7 +355,7 @@ interface FetchPromRulesRulesActionProps {
   filter?: FetchPromRulesFilter;
   limitAlerts?: number;
   matchers?: string;
-  state?: GrafanaAlertState[];
+  state?: string[];
 }
 
 export function fetchAllPromAndRulerRulesAction(

--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -105,7 +105,8 @@ export const fetchPromRulesAction = createAsyncThunk(
       rulesSourceName,
       filter,
       limitAlerts,
-    }: { rulesSourceName: string; filter?: FetchPromRulesFilter; limitAlerts?: number },
+      matchers,
+    }: { rulesSourceName: string; filter?: FetchPromRulesFilter; limitAlerts?: number; matchers?: string },
     thunkAPI
   ): Promise<RuleNamespace[]> => {
     await thunkAPI.dispatch(fetchRulesSourceBuildInfoAction({ rulesSourceName }));
@@ -115,7 +116,7 @@ export const fetchPromRulesAction = createAsyncThunk(
       thunk: 'unifiedalerting/fetchPromRules',
     });
 
-    return await withSerializedError(fetchRulesWithLogging(rulesSourceName, filter, limitAlerts));
+    return await withSerializedError(fetchRulesWithLogging(rulesSourceName, filter, limitAlerts, matchers));
   }
 );
 
@@ -346,6 +347,7 @@ export const fetchRulesSourceBuildInfoAction = createAsyncThunk(
 interface FetchPromRulesRulesActionProps {
   filter?: FetchPromRulesFilter;
   limitAlerts?: number;
+  matchers?: string;
 }
 
 export function fetchAllPromAndRulerRulesAction(

--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -8,6 +8,7 @@ import {
   AlertmanagerGroup,
   ExternalAlertmanagerConfig,
   ExternalAlertmanagersResponse,
+  Matcher,
   Receiver,
   Silence,
   SilenceCreatePayload,
@@ -111,7 +112,7 @@ export const fetchPromRulesAction = createAsyncThunk(
       rulesSourceName: string;
       filter?: FetchPromRulesFilter;
       limitAlerts?: number;
-      matcher?: string[];
+      matcher?: Matcher[];
       state?: string[];
     },
     thunkAPI
@@ -354,7 +355,7 @@ export const fetchRulesSourceBuildInfoAction = createAsyncThunk(
 interface FetchPromRulesRulesActionProps {
   filter?: FetchPromRulesFilter;
   limitAlerts?: number;
-  matcher?: string[];
+  matcher?: Matcher[];
   state?: string[];
 }
 

--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -105,13 +105,13 @@ export const fetchPromRulesAction = createAsyncThunk(
       rulesSourceName,
       filter,
       limitAlerts,
-      matchers,
+      matcher,
       state,
     }: {
       rulesSourceName: string;
       filter?: FetchPromRulesFilter;
       limitAlerts?: number;
-      matchers?: string;
+      matcher?: string;
       state?: string[];
     },
     thunkAPI
@@ -123,7 +123,7 @@ export const fetchPromRulesAction = createAsyncThunk(
       thunk: 'unifiedalerting/fetchPromRules',
     });
 
-    return await withSerializedError(fetchRulesWithLogging(rulesSourceName, filter, limitAlerts, matchers, state));
+    return await withSerializedError(fetchRulesWithLogging(rulesSourceName, filter, limitAlerts, matcher, state));
   }
 );
 
@@ -354,7 +354,7 @@ export const fetchRulesSourceBuildInfoAction = createAsyncThunk(
 interface FetchPromRulesRulesActionProps {
   filter?: FetchPromRulesFilter;
   limitAlerts?: number;
-  matchers?: string;
+  matcher?: string;
   state?: string[];
 }
 

--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -111,7 +111,7 @@ export const fetchPromRulesAction = createAsyncThunk(
       rulesSourceName: string;
       filter?: FetchPromRulesFilter;
       limitAlerts?: number;
-      matcher?: string;
+      matcher?: string[];
       state?: string[];
     },
     thunkAPI
@@ -354,7 +354,7 @@ export const fetchRulesSourceBuildInfoAction = createAsyncThunk(
 interface FetchPromRulesRulesActionProps {
   filter?: FetchPromRulesFilter;
   limitAlerts?: number;
-  matcher?: string;
+  matcher?: string[];
   state?: string[];
 }
 

--- a/public/app/features/alerting/unified/utils/alertmanager.ts
+++ b/public/app/features/alerting/unified/utils/alertmanager.ts
@@ -3,12 +3,12 @@ import { isEqual, uniqWith } from 'lodash';
 import { SelectableValue } from '@grafana/data';
 import {
   AlertManagerCortexConfig,
-  MatcherOperator,
-  Route,
   Matcher,
+  MatcherOperator,
+  ObjectMatcher,
+  Route,
   TimeInterval,
   TimeRange,
-  ObjectMatcher,
 } from 'app/plugins/datasource/alertmanager/types';
 import { Labels } from 'app/types/unified-alerting-dto';
 

--- a/public/app/features/alerting/unified/utils/alertmanager.ts
+++ b/public/app/features/alerting/unified/utils/alertmanager.ts
@@ -10,7 +10,6 @@ import {
   TimeInterval,
   TimeRange,
 } from 'app/plugins/datasource/alertmanager/types';
-import { replaceVariables } from 'app/plugins/datasource/prometheus/querybuilder/shared/parsingUtils';
 import { Labels } from 'app/types/unified-alerting-dto';
 
 import { MatcherFieldValue } from '../types/silence-form';
@@ -133,23 +132,6 @@ const matcherOperators = [
   MatcherOperator.notEqual,
   MatcherOperator.equal,
 ];
-
-// Returns a list of Matchers given a string maqtcher that contains a list
-export function getMatcherListFromString(matcher: string): Matcher[] {
-  //we need to remove curly braces and change the separated-coma format to an array of strings
-  //otherwise the API throws 400
-  if (matcher?.length === 0) {
-    return [];
-  }
-  return matcher
-    ?.replace(/[{}]/g, '')
-    .split(',')
-    .map((value) => value.trim())
-    .map((matcherStr) => {
-      const replacedLabelFilter = replaceVariables(matcherStr);
-      return parseMatcher(replacedLabelFilter);
-    });
-}
 
 export function parseMatcher(matcher: string): Matcher {
   const trimmed = matcher.trim();

--- a/public/app/features/alerting/unified/utils/query.test.ts
+++ b/public/app/features/alerting/unified/utils/query.test.ts
@@ -16,6 +16,7 @@ describe('alertRuleToQueries', () => {
       group: {
         name: 'Prom up alert',
         rules: [],
+        totals: {},
       },
       namespace: {
         rulesSource: GRAFANA_RULES_SOURCE_NAME,
@@ -44,6 +45,7 @@ describe('alertRuleToQueries', () => {
       group: {
         name: 'test',
         rules: [],
+        totals: {},
       },
       namespace: {
         name: 'prom test alerts',

--- a/public/app/features/alerting/unified/utils/query.test.ts
+++ b/public/app/features/alerting/unified/utils/query.test.ts
@@ -28,6 +28,7 @@ describe('alertRuleToQueries', () => {
         labels: {},
         grafana_alert: grafanaAlert,
       },
+      instanceTotals: {},
     };
 
     const result = alertRuleToQueries(combinedRule);
@@ -58,6 +59,7 @@ describe('alertRuleToQueries', () => {
           readOnly: false,
         },
       },
+      instanceTotals: {},
     };
 
     const result = alertRuleToQueries(combinedRule);

--- a/public/app/features/alerting/unified/utils/query.test.ts
+++ b/public/app/features/alerting/unified/utils/query.test.ts
@@ -30,6 +30,7 @@ describe('alertRuleToQueries', () => {
         grafana_alert: grafanaAlert,
       },
       instanceTotals: {},
+      filteredInstanceTotals: {},
     };
 
     const result = alertRuleToQueries(combinedRule);
@@ -62,6 +63,7 @@ describe('alertRuleToQueries', () => {
         },
       },
       instanceTotals: {},
+      filteredInstanceTotals: {},
     };
 
     const result = alertRuleToQueries(combinedRule);

--- a/public/app/plugins/panel/alertlist/AlertInstances.tsx
+++ b/public/app/plugins/panel/alertlist/AlertInstances.tsx
@@ -17,9 +17,10 @@ import { filterAlerts } from './util';
 interface Props {
   alerts: Alert[];
   options: PanelProps<UnifiedAlertListOptions>['options'];
+  grafanaTotalInstances?: number;
 }
 
-export const AlertInstances = ({ alerts, options }: Props) => {
+export const AlertInstances = ({ alerts, options, grafanaTotalInstances }: Props) => {
   // when custom grouping is enabled, we will always uncollapse the list of alert instances
   const defaultShowInstances = options.groupMode === GroupMode.Custom ? true : options.showInstances;
   const [displayInstances, setDisplayInstances] = useState<boolean>(defaultShowInstances);
@@ -37,7 +38,9 @@ export const AlertInstances = ({ alerts, options }: Props) => {
     [alerts, options]
   );
 
-  const hiddenInstances = alerts.length - filteredAlerts.length;
+  const hiddenInstances = grafanaTotalInstances
+    ? grafanaTotalInstances - filteredAlerts.length
+    : alerts.length - filteredAlerts.length;
 
   const uncollapsible = filteredAlerts.length > 0;
   const toggleShowInstances = uncollapsible ? toggleDisplayInstances : noop;

--- a/public/app/plugins/panel/alertlist/AlertInstances.tsx
+++ b/public/app/plugins/panel/alertlist/AlertInstances.tsx
@@ -78,9 +78,16 @@ export const AlertInstances = ({
   const limitStatus = limitInstances ? `Limiting the result to ${INSTANCES_DISPLAY_LIMIT} instances` : `Showing all`;
 
   const limitButtonLabel = limitInstances ? 'Remove limit' : `Limit the result to ${INSTANCES_DISPLAY_LIMIT} instances`;
+
+  const instancesLimitedAndOverflowed =
+    grafanaTotalInstances &&
+    INSTANCES_DISPLAY_LIMIT === filteredAlerts.length &&
+    grafanaTotalInstances > filteredAlerts.length;
+  const instancesNotLimitedAndoverflowed =
+    grafanaTotalInstances && INSTANCES_DISPLAY_LIMIT < filteredAlerts.length && !limitInstances;
+
   const footerRow =
-    (grafanaTotalInstances && grafanaTotalInstances > filteredAlerts.length) ||
-    (grafanaTotalInstances && grafanaTotalInstances === filteredAlerts.length && !limitInstances) ? (
+    instancesLimitedAndOverflowed || instancesNotLimitedAndoverflowed ? (
       <div className={styles.footerRow}>
         <div>{limitStatus}</div>
         {

--- a/public/app/plugins/panel/alertlist/AlertInstances.tsx
+++ b/public/app/plugins/panel/alertlist/AlertInstances.tsx
@@ -19,6 +19,7 @@ interface Props {
   alerts: Alert[];
   options: PanelProps<UnifiedAlertListOptions>['options'];
   grafanaTotalInstances?: number;
+  grafanaFilteredInstancesTotal?: number;
   handleInstancesLimit?: (limit: boolean) => void;
   limitInstances?: boolean;
 }
@@ -29,6 +30,7 @@ export const AlertInstances = ({
   grafanaTotalInstances,
   handleInstancesLimit,
   limitInstances,
+  grafanaFilteredInstancesTotal,
 }: Props) => {
   // when custom grouping is enabled, we will always uncollapse the list of alert instances
   const defaultShowInstances = options.groupMode === GroupMode.Custom ? true : options.showInstances;
@@ -46,9 +48,11 @@ export const AlertInstances = ({
     (): Alert[] => filterAlerts(options, sortAlerts(options.sortOrder, alerts)) ?? [],
     [alerts, options]
   );
-
-  const hiddenInstances = grafanaTotalInstances
-    ? grafanaTotalInstances - filteredAlerts.length
+  const isGrafanaAlert = grafanaTotalInstances !== undefined;
+  const hiddenInstances = isGrafanaAlert
+    ? grafanaTotalInstances && grafanaFilteredInstancesTotal
+      ? grafanaTotalInstances - grafanaFilteredInstancesTotal
+      : 0
     : alerts.length - filteredAlerts.length;
 
   const uncollapsible = filteredAlerts.length > 0;

--- a/public/app/plugins/panel/alertlist/AlertInstances.tsx
+++ b/public/app/plugins/panel/alertlist/AlertInstances.tsx
@@ -19,10 +19,17 @@ interface Props {
   alerts: Alert[];
   options: PanelProps<UnifiedAlertListOptions>['options'];
   grafanaTotalInstances?: number;
-  handleShowAllInstances?: () => void;
+  handleInstancesLimit?: (limit: boolean) => void;
+  limitInstances?: boolean;
 }
 
-export const AlertInstances = ({ alerts, options, grafanaTotalInstances, handleShowAllInstances }: Props) => {
+export const AlertInstances = ({
+  alerts,
+  options,
+  grafanaTotalInstances,
+  handleInstancesLimit,
+  limitInstances,
+}: Props) => {
   // when custom grouping is enabled, we will always uncollapse the list of alert instances
   const defaultShowInstances = options.groupMode === GroupMode.Custom ? true : options.showInstances;
   const [displayInstances, setDisplayInstances] = useState<boolean>(defaultShowInstances);
@@ -54,23 +61,31 @@ export const AlertInstances = ({ alerts, options, grafanaTotalInstances, handleS
   }, [filteredAlerts]);
 
   const onShowAllClick = async () => {
-    if (!handleShowAllInstances) {
+    if (!handleInstancesLimit) {
       return;
     }
-    await handleShowAllInstances();
+    await handleInstancesLimit(false);
     setDisplayInstances(true);
   };
 
+  const onShowLimitedClick = async () => {
+    if (!handleInstancesLimit) {
+      return;
+    }
+    await handleInstancesLimit(true);
+    setDisplayInstances(true);
+  };
+  const limitStatus = limitInstances ? `Limiting the result to ${INSTANCES_DISPLAY_LIMIT} instances` : `Showing all`;
+
+  const limitButtonLabel = limitInstances ? 'Remove limit' : `Limit the result to ${INSTANCES_DISPLAY_LIMIT} instances`;
   const footerRow =
-    hiddenInstances > 0 &&
-    grafanaTotalInstances &&
-    grafanaTotalInstances > INSTANCES_DISPLAY_LIMIT &&
-    filteredAlerts.length <= INSTANCES_DISPLAY_LIMIT ? (
+    (grafanaTotalInstances && grafanaTotalInstances > filteredAlerts.length) ||
+    (grafanaTotalInstances && grafanaTotalInstances === filteredAlerts.length && !limitInstances) ? (
       <div className={styles.footerRow}>
-        <div>Limiting the result to {INSTANCES_DISPLAY_LIMIT} instances</div>
+        <div>{limitStatus}</div>
         {
-          <Button size="sm" variant="secondary" onClick={onShowAllClick}>
-            Remove limit
+          <Button size="sm" variant="secondary" onClick={limitInstances ? onShowAllClick : onShowLimitedClick}>
+            {limitButtonLabel}
           </Button>
         }
       </div>

--- a/public/app/plugins/panel/alertlist/AlertInstances.tsx
+++ b/public/app/plugins/panel/alertlist/AlertInstances.tsx
@@ -49,11 +49,12 @@ export const AlertInstances = ({
     [alerts, options]
   );
   const isGrafanaAlert = grafanaTotalInstances !== undefined;
-  const hiddenInstances = isGrafanaAlert
-    ? grafanaTotalInstances && grafanaFilteredInstancesTotal
-      ? grafanaTotalInstances - grafanaFilteredInstancesTotal
-      : 0
-    : alerts.length - filteredAlerts.length;
+
+  const hiddenInstancesForGrafanaAlerts =
+    grafanaTotalInstances && grafanaFilteredInstancesTotal ? grafanaTotalInstances - grafanaFilteredInstancesTotal : 0;
+  const hiddenInstancesForNonGrafanaAlerts = alerts.length - filteredAlerts.length;
+
+  const hiddenInstances = isGrafanaAlert ? hiddenInstancesForGrafanaAlerts : hiddenInstancesForNonGrafanaAlerts;
 
   const uncollapsible = filteredAlerts.length > 0;
   const toggleShowInstances = uncollapsible ? toggleDisplayInstances : noop;
@@ -68,7 +69,7 @@ export const AlertInstances = ({
     if (!handleInstancesLimit) {
       return;
     }
-    await handleInstancesLimit(false);
+    handleInstancesLimit(false);
     setDisplayInstances(true);
   };
 
@@ -76,7 +77,7 @@ export const AlertInstances = ({
     if (!handleInstancesLimit) {
       return;
     }
-    await handleInstancesLimit(true);
+    handleInstancesLimit(true);
     setDisplayInstances(true);
   };
   const totalInstancesNumber = limitInstances ? grafanaFilteredInstancesTotal : filteredAlerts.length;
@@ -84,7 +85,9 @@ export const AlertInstances = ({
     ? `Showing ${INSTANCES_DISPLAY_LIMIT} of ${grafanaTotalInstances} instances`
     : `Showing all ${grafanaTotalInstances} instances`;
 
-  const limitButtonLabel = limitInstances ? 'Remove limit' : `Limit the result to ${INSTANCES_DISPLAY_LIMIT} instances`;
+  const limitButtonLabel = limitInstances
+    ? 'View all instances'
+    : `Limit the result to ${INSTANCES_DISPLAY_LIMIT} instances`;
 
   const instancesLimitedAndOverflowed =
     grafanaTotalInstances &&

--- a/public/app/plugins/panel/alertlist/AlertInstances.tsx
+++ b/public/app/plugins/panel/alertlist/AlertInstances.tsx
@@ -79,7 +79,10 @@ export const AlertInstances = ({
     await handleInstancesLimit(true);
     setDisplayInstances(true);
   };
-  const limitStatus = limitInstances ? `Limiting the result to ${INSTANCES_DISPLAY_LIMIT} instances` : `Showing all`;
+  const totalInstancesNumber = limitInstances ? grafanaFilteredInstancesTotal : filteredAlerts.length;
+  const limitStatus = limitInstances
+    ? `Showing ${INSTANCES_DISPLAY_LIMIT} of ${grafanaTotalInstances} instances`
+    : `Showing all ${grafanaTotalInstances} instances`;
 
   const limitButtonLabel = limitInstances ? 'Remove limit' : `Limit the result to ${INSTANCES_DISPLAY_LIMIT} instances`;
 
@@ -110,7 +113,7 @@ export const AlertInstances = ({
           onClick={() => toggleShowInstances()}
         >
           {uncollapsible && <Icon name={displayInstances ? 'angle-down' : 'angle-right'} size={'md'} />}
-          <span>{`${filteredAlerts.length} ${pluralize('instance', filteredAlerts.length)}`}</span>
+          <span>{`${totalInstancesNumber} ${pluralize('instance', totalInstancesNumber)}`}</span>
           {hiddenInstances > 0 && <span>, {`${hiddenInstances} hidden by filters`}</span>}
         </button>
       )}

--- a/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
+++ b/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
@@ -32,7 +32,7 @@ import { flattenCombinedRules, getFirstActiveAt } from 'app/features/alerting/un
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
 import { DashboardModel } from 'app/features/dashboard/state';
 import { AccessControlAction, useDispatch } from 'app/types';
-import { PromAlertingRuleState } from 'app/types/unified-alerting-dto';
+import { GrafanaAlertState, PromAlertingRuleState } from 'app/types/unified-alerting-dto';
 
 import { getAlertingRule } from '../../../features/alerting/unified/utils/rules';
 import { AlertingRule, CombinedRuleWithLocation } from '../../../types/unified-alerting';
@@ -63,7 +63,11 @@ export function UnifiedAlertList(props: PanelProps<UnifiedAlertListOptions>) {
   useEffect(() => {
     //we need promRules and rulerRules for getting the uid when creating the alert link in panel in case of being a rulerRule.
     dispatch(
-      fetchAllPromAndRulerRulesAction(false, { limitAlerts: 1, matchers: props.options.alertInstanceLabelFilter })
+      fetchAllPromAndRulerRulesAction(false, {
+        limitAlerts: 1,
+        matchers: props.options.alertInstanceLabelFilter,
+        state: [GrafanaAlertState.Alerting, GrafanaAlertState.Normal],
+      })
     );
     const sub = dashboard?.events.subscribe(TimeRangeUpdatedEvent, () => dispatch(fetchAllPromAndRulerRulesAction()));
     return () => {

--- a/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
+++ b/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
@@ -62,7 +62,7 @@ export function UnifiedAlertList(props: PanelProps<UnifiedAlertListOptions>) {
 
   useEffect(() => {
     //we need promRules and rulerRules for getting the uid when creating the alert link in panel in case of being a rulerRule.
-    dispatch(fetchAllPromAndRulerRulesAction());
+    dispatch(fetchAllPromAndRulerRulesAction(false, { limitAlerts: 1 }));
     const sub = dashboard?.events.subscribe(TimeRangeUpdatedEvent, () => dispatch(fetchAllPromAndRulerRulesAction()));
     return () => {
       sub?.unsubscribe();

--- a/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
+++ b/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
@@ -62,12 +62,14 @@ export function UnifiedAlertList(props: PanelProps<UnifiedAlertListOptions>) {
 
   useEffect(() => {
     //we need promRules and rulerRules for getting the uid when creating the alert link in panel in case of being a rulerRule.
-    dispatch(fetchAllPromAndRulerRulesAction(false, { limitAlerts: 1 }));
+    dispatch(
+      fetchAllPromAndRulerRulesAction(false, { limitAlerts: 1, matchers: props.options.alertInstanceLabelFilter })
+    );
     const sub = dashboard?.events.subscribe(TimeRangeUpdatedEvent, () => dispatch(fetchAllPromAndRulerRulesAction()));
     return () => {
       sub?.unsubscribe();
     };
-  }, [dispatch, dashboard]);
+  }, [dispatch, dashboard, props.options.alertInstanceLabelFilter]);
 
   const { prom, ruler } = useUnifiedAlertingSelector((state) => ({
     prom: state.promRules[GRAFANA_RULES_SOURCE_NAME] || initialAsyncRequestState,

--- a/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
+++ b/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
@@ -78,7 +78,7 @@ export function UnifiedAlertList(props: PanelProps<UnifiedAlertListOptions>) {
     dispatch(
       fetchAllPromAndRulerRulesAction(false, {
         limitAlerts: INSTANCES_DISPLAY_LIMIT,
-        matchers: props.options.alertInstanceLabelFilter,
+        matcher: props.options.alertInstanceLabelFilter,
         state: stateList,
       })
     );
@@ -86,7 +86,7 @@ export function UnifiedAlertList(props: PanelProps<UnifiedAlertListOptions>) {
       dispatch(
         fetchAllPromAndRulerRulesAction(false, {
           limitAlerts: INSTANCES_DISPLAY_LIMIT,
-          matchers: props.options.alertInstanceLabelFilter,
+          matcher: props.options.alertInstanceLabelFilter,
           state: stateList,
         })
       )

--- a/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
+++ b/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
@@ -13,7 +13,7 @@ import {
   BigValueTextMode,
   CustomScrollbar,
   LoadingPlaceholder,
-  useStyles2,
+  useStyles2
 } from '@grafana/ui';
 import { config } from 'app/core/config';
 import { contextSrv } from 'app/core/services/context_srv';
@@ -26,7 +26,7 @@ import { Annotation } from 'app/features/alerting/unified/utils/constants';
 import {
   getAllRulesSourceNames,
   GRAFANA_DATASOURCE_NAME,
-  GRAFANA_RULES_SOURCE_NAME,
+  GRAFANA_RULES_SOURCE_NAME
 } from 'app/features/alerting/unified/utils/datasource';
 import { initialAsyncRequestState } from 'app/features/alerting/unified/utils/redux';
 import { flattenCombinedRules, getFirstActiveAt } from 'app/features/alerting/unified/utils/rules';
@@ -96,6 +96,15 @@ export function UnifiedAlertList(props: PanelProps<UnifiedAlertListOptions>) {
     };
   }, [dispatch, dashboard, props.options.alertInstanceLabelFilter, props.options.stateFilter]);
 
+  const handleRemoveInstancesLimit = () => {
+    dispatch(
+      fetchAllPromAndRulerRulesAction(false, {
+        matcher: props.options.alertInstanceLabelFilter,
+        state: getStateList(props.options.stateFilter),
+      })
+    );
+  };
+
   const { prom, ruler } = useUnifiedAlertingSelector((state) => ({
     prom: state.promRules[GRAFANA_RULES_SOURCE_NAME] || initialAsyncRequestState,
     ruler: state.rulerRules[GRAFANA_RULES_SOURCE_NAME] || initialAsyncRequestState,
@@ -161,7 +170,11 @@ export function UnifiedAlertList(props: PanelProps<UnifiedAlertListOptions>) {
             <GroupedModeView rules={rules} options={parsedOptions} />
           )}
           {props.options.viewMode === ViewMode.List && props.options.groupMode === GroupMode.Default && haveResults && (
-            <UngroupedModeView rules={rules} options={parsedOptions} />
+            <UngroupedModeView
+              rules={rules}
+              options={props.options}
+              handleShowAllInstances={handleRemoveInstancesLimit}
+            />
           )}
         </section>
       </div>
@@ -245,12 +258,12 @@ function filterRules(props: PanelProps<UnifiedAlertListOptions>, rules: Combined
     const alertingRule = getAlertingRule(rule);
     const filteredAlerts = alertingRule
       ? filterAlerts(
-          {
-            stateFilter: options.stateFilter,
-            alertInstanceLabelFilter: replaceVariables(options.alertInstanceLabelFilter),
-          },
-          alertingRule.alerts ?? []
-        )
+        {
+          stateFilter: options.stateFilter,
+          alertInstanceLabelFilter: replaceVariables(options.alertInstanceLabelFilter),
+        },
+        alertingRule.alerts ?? []
+      )
       : [];
     if (filteredAlerts.length) {
       // We intentionally don't set alerts to filteredAlerts

--- a/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
+++ b/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
@@ -84,8 +84,8 @@ export function UnifiedAlertList(props: PanelProps<UnifiedAlertListOptions>) {
   };
 
   const matcherList = useMemo(
-    () => parseMatchers(props.options.alertInstanceLabelFilter),
-    [props.options.alertInstanceLabelFilter]
+    () => parseMatchers(parsedOptions.alertInstanceLabelFilter),
+    [parsedOptions.alertInstanceLabelFilter]
   );
 
   useEffect(() => {

--- a/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
+++ b/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
@@ -22,7 +22,7 @@ import { INSTANCES_DISPLAY_LIMIT } from 'app/features/alerting/unified/component
 import { useCombinedRuleNamespaces } from 'app/features/alerting/unified/hooks/useCombinedRuleNamespaces';
 import { useUnifiedAlertingSelector } from 'app/features/alerting/unified/hooks/useUnifiedAlertingSelector';
 import { fetchAllPromAndRulerRulesAction } from 'app/features/alerting/unified/state/actions';
-import { parseMatcher } from 'app/features/alerting/unified/utils/alertmanager';
+import { getMatcherListFromString } from 'app/features/alerting/unified/utils/alertmanager';
 import { Annotation } from 'app/features/alerting/unified/utils/constants';
 import {
   getAllRulesSourceNames,
@@ -33,7 +33,6 @@ import { initialAsyncRequestState } from 'app/features/alerting/unified/utils/re
 import { flattenCombinedRules, getFirstActiveAt } from 'app/features/alerting/unified/utils/rules';
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
 import { DashboardModel } from 'app/features/dashboard/state';
-import { replaceVariables } from 'app/plugins/datasource/prometheus/querybuilder/shared/parsingUtils';
 import { AccessControlAction, useDispatch } from 'app/types';
 import { PromAlertingRuleState } from 'app/types/unified-alerting-dto';
 
@@ -77,22 +76,6 @@ export function UnifiedAlertList(props: PanelProps<UnifiedAlertListOptions>) {
   });
 
   const stateList = useMemo(() => getStateList(props.options.stateFilter), [props.options.stateFilter]);
-
-  function getMatcherListFromString(matcher: string) {
-    //we need to remove curly braces and change the separated-coma format to an array of strings
-    //otherwise the API throws 400
-    if (matcher?.length === 0) {
-      return [];
-    }
-    return matcher
-      ?.replace(/[{}]/g, '')
-      .split(',')
-      .map((value) => value.trim())
-      .map((matcherStr) => {
-        const replacedLabelFilter = replaceVariables(matcherStr);
-        return parseMatcher(replacedLabelFilter);
-      });
-  }
 
   const matcherList = useMemo(
     () => getMatcherListFromString(props.options.alertInstanceLabelFilter),

--- a/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
+++ b/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
@@ -18,6 +18,7 @@ import {
 import { config } from 'app/core/config';
 import { contextSrv } from 'app/core/services/context_srv';
 import alertDef from 'app/features/alerting/state/alertDef';
+import { INSTANCES_DISPLAY_LIMIT } from 'app/features/alerting/unified/components/rules/RuleDetails';
 import { useCombinedRuleNamespaces } from 'app/features/alerting/unified/hooks/useCombinedRuleNamespaces';
 import { useUnifiedAlertingSelector } from 'app/features/alerting/unified/hooks/useUnifiedAlertingSelector';
 import { fetchAllPromAndRulerRulesAction } from 'app/features/alerting/unified/state/actions';
@@ -76,7 +77,7 @@ export function UnifiedAlertList(props: PanelProps<UnifiedAlertListOptions>) {
     const stateList = getStateList(props.options.stateFilter);
     dispatch(
       fetchAllPromAndRulerRulesAction(false, {
-        limitAlerts: 1,
+        limitAlerts: INSTANCES_DISPLAY_LIMIT,
         matchers: props.options.alertInstanceLabelFilter,
         state: stateList,
       })
@@ -84,7 +85,7 @@ export function UnifiedAlertList(props: PanelProps<UnifiedAlertListOptions>) {
     const sub = dashboard?.events.subscribe(TimeRangeUpdatedEvent, () =>
       dispatch(
         fetchAllPromAndRulerRulesAction(false, {
-          limitAlerts: 1,
+          limitAlerts: INSTANCES_DISPLAY_LIMIT,
           matchers: props.options.alertInstanceLabelFilter,
           state: stateList,
         })

--- a/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
+++ b/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 import { sortBy } from 'lodash';
 import React, { useEffect, useMemo } from 'react';
-import { useEffectOnce, usePrevious, useToggle } from 'react-use';
+import { useEffectOnce, useToggle } from 'react-use';
 
 import { GrafanaTheme2, PanelProps } from '@grafana/data';
 import { TimeRangeUpdatedEvent } from '@grafana/runtime';
@@ -59,7 +59,6 @@ export function UnifiedAlertList(props: PanelProps<UnifiedAlertListOptions>) {
   const dispatch = useDispatch();
   const rulesDataSourceNames = useMemo(getAllRulesSourceNames, []);
   const [limitInstances, toggleLimit] = useToggle(true);
-  const previousMode = usePrevious(props.options.groupMode);
 
   // backwards compat for "Inactive" state filter
   useEffect(() => {
@@ -89,9 +88,7 @@ export function UnifiedAlertList(props: PanelProps<UnifiedAlertListOptions>) {
   );
 
   useEffect(() => {
-    //when coming back from cusom group mode, we restore limits and filters
-    const comingBackFromCustom = previousMode === GroupMode.Custom && props.options.groupMode === GroupMode.Default;
-    if (comingBackFromCustom) {
+    if (props.options.groupMode === GroupMode.Default) {
       dispatch(
         fetchAllPromAndRulerRulesAction(false, {
           limitAlerts: limitInstances ? INSTANCES_DISPLAY_LIMIT : undefined,
@@ -100,7 +97,7 @@ export function UnifiedAlertList(props: PanelProps<UnifiedAlertListOptions>) {
         })
       );
     }
-  }, [props.options.groupMode, limitInstances, dispatch, matcherList, stateList, previousMode]);
+  }, [props.options.groupMode, limitInstances, dispatch, matcherList, stateList]);
 
   useEffect(() => {
     //we need promRules and rulerRules for getting the uid when creating the alert link in panel in case of being a rulerRule.

--- a/public/app/plugins/panel/alertlist/UnifiedalertList.test.tsx
+++ b/public/app/plugins/panel/alertlist/UnifiedalertList.test.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import { byRole, byText } from 'testing-library-selector';
 
-import { getDefaultTimeRange, LoadingState, PanelProps, FieldConfigSource } from '@grafana/data';
+import { FieldConfigSource, getDefaultTimeRange, LoadingState, PanelProps } from '@grafana/data';
 import { TimeRangeUpdatedEvent } from '@grafana/runtime';
 import { DashboardSrv, setDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
 
@@ -19,7 +19,7 @@ import {
 import { GRAFANA_RULES_SOURCE_NAME } from '../../../features/alerting/unified/utils/datasource';
 
 import { UnifiedAlertList } from './UnifiedAlertList';
-import { UnifiedAlertListOptions, SortOrder, GroupMode, ViewMode } from './types';
+import { GroupMode, SortOrder, UnifiedAlertListOptions, ViewMode } from './types';
 import * as utils from './util';
 
 jest.mock('app/features/alerting/unified/api/alertmanager');
@@ -112,6 +112,7 @@ const renderPanel = (options: Partial<UnifiedAlertListOptions> = defaultOptions)
 
 describe('UnifiedAlertList', () => {
   it('subscribes to the dashboard refresh interval', async () => {
+    jest.spyOn(defaultProps, 'replaceVariables').mockReturnValue('severity=critical');
     await renderPanel();
     expect(dashboard.events.subscribe).toHaveBeenCalledTimes(1);
     expect(dashboard.events.subscribe.mock.calls[0][0]).toEqual(TimeRangeUpdatedEvent);

--- a/public/app/plugins/panel/alertlist/UnifiedalertList.test.tsx
+++ b/public/app/plugins/panel/alertlist/UnifiedalertList.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { Provider } from 'react-redux';
@@ -88,6 +88,8 @@ const renderPanel = (options: Partial<UnifiedAlertListOptions> = defaultOptions)
                   mockPromAlertingRule({
                     name: 'rule1',
                     alerts: [mockPromAlert({ labels: { severity: 'critical' } })],
+                    totals: { alerting: 1 },
+                    totalsFiltered: { alerting: 1 },
                   }),
                 ],
               }),
@@ -126,7 +128,7 @@ describe('UnifiedAlertList', () => {
 
     const user = userEvent.setup();
 
-    renderPanel({
+    await renderPanel({
       alertInstanceLabelFilter: '$label',
       dashboardAlerts: false,
       alertName: '',
@@ -135,6 +137,10 @@ describe('UnifiedAlertList', () => {
     });
 
     expect(byText('rule1').get()).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText('1 instance')).toBeInTheDocument();
+    });
 
     const expandElement = byText('1 instance').get();
 

--- a/public/app/plugins/panel/alertlist/types.ts
+++ b/public/app/plugins/panel/alertlist/types.ts
@@ -42,7 +42,7 @@ export interface AlertListOptions {
   folderId: number;
 }
 
-interface StateFilter {
+export interface StateFilter {
   firing: boolean;
   pending: boolean;
   inactive?: boolean; // backwards compat

--- a/public/app/plugins/panel/alertlist/unified-alerting/UngroupedView.tsx
+++ b/public/app/plugins/panel/alertlist/unified-alerting/UngroupedView.tsx
@@ -26,6 +26,7 @@ import { UnifiedAlertListOptions } from '../types';
 type Props = {
   rules: CombinedRuleWithLocation[];
   options: UnifiedAlertListOptions;
+  handleShowAllInstances?: () => void;
 };
 
 function getGrafanaInstancesTotal(totals: Partial<Record<AlertInstanceTotalState, number>>) {
@@ -34,7 +35,7 @@ function getGrafanaInstancesTotal(totals: Partial<Record<AlertInstanceTotalState
     .reduce((total, currentTotal) => total + currentTotal, 0);
 }
 
-const UngroupedModeView = ({ rules, options }: Props) => {
+const UngroupedModeView = ({ rules, options, handleShowAllInstances }: Props) => {
   const styles = useStyles2(getStyles);
   const stateStyle = useStyles2(getStateTagStyles);
   const { href: returnTo } = useLocation();
@@ -112,6 +113,7 @@ const UngroupedModeView = ({ rules, options }: Props) => {
                     alerts={alertingRule.alerts ?? []}
                     options={options}
                     grafanaTotalInstances={grafanaInstancesTotal}
+                    handleShowAllInstances={handleShowAllInstances}
                   />
                 </div>
               </li>

--- a/public/app/plugins/panel/alertlist/unified-alerting/UngroupedView.tsx
+++ b/public/app/plugins/panel/alertlist/unified-alerting/UngroupedView.tsx
@@ -17,7 +17,8 @@ import {
 import { createUrl } from 'app/features/alerting/unified/utils/url';
 import { PromAlertingRuleState } from 'app/types/unified-alerting-dto';
 
-import { AlertingRule, CombinedRuleWithLocation } from '../../../../types/unified-alerting';
+import { GRAFANA_DATASOURCE_NAME } from '../../../../features/alerting/unified/utils/datasource';
+import { AlertingRule, AlertInstanceTotalState, CombinedRuleWithLocation } from '../../../../types/unified-alerting';
 import { AlertInstances } from '../AlertInstances';
 import { getStyles } from '../UnifiedAlertList';
 import { UnifiedAlertListOptions } from '../types';
@@ -26,6 +27,10 @@ type Props = {
   rules: CombinedRuleWithLocation[];
   options: UnifiedAlertListOptions;
 };
+
+function getGrafanaInstancesTotal(totals: Partial<Record<AlertInstanceTotalState, number>>) {
+  return Object.values(totals).reduce((total, currentTotal) => total + currentTotal, 0);
+}
 
 const UngroupedModeView = ({ rules, options }: Props) => {
   const styles = useStyles2(getStyles);
@@ -45,6 +50,11 @@ const UngroupedModeView = ({ rules, options }: Props) => {
           const firstActiveAt = getFirstActiveAt(alertingRule);
           const indentifier = fromCombinedRule(ruleWithLocation.dataSourceName, ruleWithLocation);
           const strIndentifier = stringifyIdentifier(indentifier);
+
+          const grafanaInstancesTotal =
+            ruleWithLocation.dataSourceName === GRAFANA_DATASOURCE_NAME
+              ? getGrafanaInstancesTotal(ruleWithLocation.instanceTotals)
+              : undefined;
 
           const href = createUrl(
             `/alerting/${encodeURIComponent(dataSourceName)}/${encodeURIComponent(strIndentifier)}/view`,
@@ -96,7 +106,11 @@ const UngroupedModeView = ({ rules, options }: Props) => {
                       )}
                     </div>
                   </div>
-                  <AlertInstances alerts={alertingRule.alerts ?? []} options={options} />
+                  <AlertInstances
+                    alerts={alertingRule.alerts ?? []}
+                    options={options}
+                    grafanaTotalInstances={grafanaInstancesTotal}
+                  />
                 </div>
               </li>
             );

--- a/public/app/plugins/panel/alertlist/unified-alerting/UngroupedView.tsx
+++ b/public/app/plugins/panel/alertlist/unified-alerting/UngroupedView.tsx
@@ -26,7 +26,8 @@ import { UnifiedAlertListOptions } from '../types';
 type Props = {
   rules: CombinedRuleWithLocation[];
   options: UnifiedAlertListOptions;
-  handleShowAllInstances?: () => void;
+  handleInstancesLimit?: (limit: boolean) => void;
+  limitInstances: boolean;
 };
 
 function getGrafanaInstancesTotal(totals: Partial<Record<AlertInstanceTotalState, number>>) {
@@ -35,7 +36,7 @@ function getGrafanaInstancesTotal(totals: Partial<Record<AlertInstanceTotalState
     .reduce((total, currentTotal) => total + currentTotal, 0);
 }
 
-const UngroupedModeView = ({ rules, options, handleShowAllInstances }: Props) => {
+const UngroupedModeView = ({ rules, options, handleInstancesLimit, limitInstances }: Props) => {
   const styles = useStyles2(getStyles);
   const stateStyle = useStyles2(getStateTagStyles);
   const { href: returnTo } = useLocation();
@@ -113,7 +114,8 @@ const UngroupedModeView = ({ rules, options, handleShowAllInstances }: Props) =>
                     alerts={alertingRule.alerts ?? []}
                     options={options}
                     grafanaTotalInstances={grafanaInstancesTotal}
-                    handleShowAllInstances={handleShowAllInstances}
+                    handleInstancesLimit={handleInstancesLimit}
+                    limitInstances={limitInstances}
                   />
                 </div>
               </li>

--- a/public/app/plugins/panel/alertlist/unified-alerting/UngroupedView.tsx
+++ b/public/app/plugins/panel/alertlist/unified-alerting/UngroupedView.tsx
@@ -59,6 +59,10 @@ const UngroupedModeView = ({ rules, options, handleInstancesLimit, limitInstance
             ruleWithLocation.dataSourceName === GRAFANA_RULES_SOURCE_NAME
               ? getGrafanaInstancesTotal(ruleWithLocation.instanceTotals)
               : undefined;
+          const grafanaFilteredInstancesTotal =
+            ruleWithLocation.dataSourceName === GRAFANA_RULES_SOURCE_NAME
+              ? getGrafanaInstancesTotal(ruleWithLocation.filteredInstanceTotals)
+              : undefined;
 
           const href = createUrl(
             `/alerting/${encodeURIComponent(dataSourceName)}/${encodeURIComponent(strIndentifier)}/view`,
@@ -114,6 +118,7 @@ const UngroupedModeView = ({ rules, options, handleInstancesLimit, limitInstance
                     alerts={alertingRule.alerts ?? []}
                     options={options}
                     grafanaTotalInstances={grafanaInstancesTotal}
+                    grafanaFilteredInstancesTotal={grafanaFilteredInstancesTotal}
                     handleInstancesLimit={handleInstancesLimit}
                     limitInstances={limitInstances}
                   />

--- a/public/app/plugins/panel/alertlist/unified-alerting/UngroupedView.tsx
+++ b/public/app/plugins/panel/alertlist/unified-alerting/UngroupedView.tsx
@@ -17,7 +17,7 @@ import {
 import { createUrl } from 'app/features/alerting/unified/utils/url';
 import { PromAlertingRuleState } from 'app/types/unified-alerting-dto';
 
-import { GRAFANA_DATASOURCE_NAME } from '../../../../features/alerting/unified/utils/datasource';
+import { GRAFANA_RULES_SOURCE_NAME } from '../../../../features/alerting/unified/utils/datasource';
 import { AlertingRule, AlertInstanceTotalState, CombinedRuleWithLocation } from '../../../../types/unified-alerting';
 import { AlertInstances } from '../AlertInstances';
 import { getStyles } from '../UnifiedAlertList';
@@ -29,7 +29,9 @@ type Props = {
 };
 
 function getGrafanaInstancesTotal(totals: Partial<Record<AlertInstanceTotalState, number>>) {
-  return Object.values(totals).reduce((total, currentTotal) => total + currentTotal, 0);
+  return Object.values(totals)
+    .filter((total) => total !== undefined)
+    .reduce((total, currentTotal) => total + currentTotal, 0);
 }
 
 const UngroupedModeView = ({ rules, options }: Props) => {
@@ -52,7 +54,7 @@ const UngroupedModeView = ({ rules, options }: Props) => {
           const strIndentifier = stringifyIdentifier(indentifier);
 
           const grafanaInstancesTotal =
-            ruleWithLocation.dataSourceName === GRAFANA_DATASOURCE_NAME
+            ruleWithLocation.dataSourceName === GRAFANA_RULES_SOURCE_NAME
               ? getGrafanaInstancesTotal(ruleWithLocation.instanceTotals)
               : undefined;
 

--- a/public/app/types/unified-alerting-dto.ts
+++ b/public/app/types/unified-alerting-dto.ts
@@ -2,6 +2,8 @@
 
 import { DataQuery, RelativeTimeRange } from '@grafana/data';
 
+import { AlertGroupTotals } from './unified-alerting';
+
 export type Labels = Record<string, string>;
 export type Annotations = Record<string, string>;
 
@@ -154,7 +156,10 @@ export interface PromResponse<T> {
   warnings?: string[];
 }
 
-export type PromRulesResponse = PromResponse<{ groups: PromRuleGroupDTO[] }>;
+export type PromRulesResponse = PromResponse<{
+  groups: PromRuleGroupDTO[];
+  totals?: AlertGroupTotals;
+}>;
 
 // Ruler rule DTOs
 interface RulerRuleBaseDTO {

--- a/public/app/types/unified-alerting.ts
+++ b/public/app/types/unified-alerting.ts
@@ -46,6 +46,7 @@ export interface AlertingRule extends RuleBase {
   state: PromAlertingRuleState;
   type: PromRuleType.Alerting;
   totals?: AlertInstanceTotals;
+  activeAt?: string; // ISO timestamp
 }
 
 export interface RecordingRule extends RuleBase {

--- a/public/app/types/unified-alerting.ts
+++ b/public/app/types/unified-alerting.ts
@@ -45,7 +45,7 @@ export interface AlertingRule extends RuleBase {
   };
   state: PromAlertingRuleState;
   type: PromRuleType.Alerting;
-  totals?: AlertInstanceTotals;
+  totals?: Partial<Record<Lowercase<GrafanaAlertState>, number>>;
   activeAt?: string; // ISO timestamp
 }
 
@@ -61,7 +61,7 @@ export type Rule = AlertingRule | RecordingRule;
 
 export type BaseRuleGroup = { name: string };
 
-type TotalsWithoutAlerting = Exclude<AlertInstanceState, AlertInstanceState.Alerting>;
+type TotalsWithoutAlerting = Exclude<AlertInstanceTotalState, AlertInstanceTotalState.Alerting>;
 enum FiringTotal {
   Firing = 'firing',
 }
@@ -101,7 +101,7 @@ export interface CombinedRule {
 }
 
 // export type AlertInstanceState = PromAlertingRuleState | 'nodata' | 'error';
-export enum AlertInstanceState {
+export enum AlertInstanceTotalState {
   Alerting = 'alerting',
   Pending = 'pending',
   Normal = 'inactive',
@@ -109,10 +109,10 @@ export enum AlertInstanceState {
   Error = 'error',
 }
 
-export type AlertInstanceTotals = Partial<Record<AlertInstanceState, number>>;
+export type AlertInstanceTotals = Partial<Record<AlertInstanceTotalState, number>>;
 
 // AlertGroupTotals also contain the amount of recording and paused rules
-export type AlertGroupTotals = Partial<Record<AlertInstanceState | 'paused' | 'recording', number>>;
+export type AlertGroupTotals = Partial<Record<AlertInstanceTotalState | 'paused' | 'recording', number>>;
 
 export interface CombinedRuleGroup {
   name: string;

--- a/public/app/types/unified-alerting.ts
+++ b/public/app/types/unified-alerting.ts
@@ -60,10 +60,16 @@ export type Rule = AlertingRule | RecordingRule;
 
 export type BaseRuleGroup = { name: string };
 
+type TotalsWithoutAlerting = Exclude<AlertInstanceState, AlertInstanceState.Alerting>;
+enum FiringTotal {
+  Firing = 'firing',
+}
 export interface RuleGroup {
   name: string;
   interval: number;
   rules: Rule[];
+  // totals only exist for Grafana Managed rules
+  totals?: Partial<Record<TotalsWithoutAlerting | FiringTotal, number>>;
 }
 
 export interface RuleNamespace {
@@ -104,17 +110,22 @@ export enum AlertInstanceState {
 
 export type AlertInstanceTotals = Partial<Record<AlertInstanceState, number>>;
 
+// AlertGroupTotals also contain the amount of recording and paused rules
+export type AlertGroupTotals = Partial<Record<AlertInstanceState | 'paused' | 'recording', number>>;
+
 export interface CombinedRuleGroup {
   name: string;
   interval?: string;
   source_tenants?: string[];
   rules: CombinedRule[];
+  totals: AlertGroupTotals;
 }
 
 export interface CombinedRuleNamespace {
   rulesSource: RulesSource;
   name: string;
   groups: CombinedRuleGroup[];
+  totals: AlertGroupTotals;
 }
 
 export interface RuleWithLocation<T = RulerRuleDTO> {

--- a/public/app/types/unified-alerting.ts
+++ b/public/app/types/unified-alerting.ts
@@ -125,7 +125,6 @@ export interface CombinedRuleNamespace {
   rulesSource: RulesSource;
   name: string;
   groups: CombinedRuleGroup[];
-  totals: AlertGroupTotals;
 }
 
 export interface RuleWithLocation<T = RulerRuleDTO> {

--- a/public/app/types/unified-alerting.ts
+++ b/public/app/types/unified-alerting.ts
@@ -45,6 +45,7 @@ export interface AlertingRule extends RuleBase {
   };
   state: PromAlertingRuleState;
   type: PromRuleType.Alerting;
+  totals?: AlertInstanceTotals;
 }
 
 export interface RecordingRule extends RuleBase {
@@ -89,7 +90,19 @@ export interface CombinedRule {
   rulerRule?: RulerRuleDTO;
   group: CombinedRuleGroup;
   namespace: CombinedRuleNamespace;
+  instanceTotals: AlertInstanceTotals;
 }
+
+// export type AlertInstanceState = PromAlertingRuleState | 'nodata' | 'error';
+export enum AlertInstanceState {
+  Alerting = 'alerting',
+  Pending = 'pending',
+  Normal = 'inactive',
+  NoData = 'nodata',
+  Error = 'error',
+}
+
+export type AlertInstanceTotals = Partial<Record<AlertInstanceState, number>>;
 
 export interface CombinedRuleGroup {
   name: string;

--- a/public/app/types/unified-alerting.ts
+++ b/public/app/types/unified-alerting.ts
@@ -46,6 +46,7 @@ export interface AlertingRule extends RuleBase {
   state: PromAlertingRuleState;
   type: PromRuleType.Alerting;
   totals?: Partial<Record<Lowercase<GrafanaAlertState>, number>>;
+  totalsFiltered?: Partial<Record<Lowercase<GrafanaAlertState>, number>>;
   activeAt?: string; // ISO timestamp
 }
 
@@ -98,6 +99,7 @@ export interface CombinedRule {
   group: CombinedRuleGroup;
   namespace: CombinedRuleNamespace;
   instanceTotals: AlertInstanceTotals;
+  filteredInstanceTotals: AlertInstanceTotals;
 }
 
 // export type AlertInstanceState = PromAlertingRuleState | 'nodata' | 'error';


### PR DESCRIPTION
This PR adds limits and move filters to the BE instead of implementing them in the FE.

- This **filter** is implemented **only for grafana-managed alerts in the alert list panel**.
- This **limit** is only applied for alert instances.

For more info about the filter : [BE filter](https://github.com/grafana/grafana/pull/65904) 

Fixes https://github.com/grafana/grafana/issues/66834

**Special notes for your reviewer:**

https://user-images.githubusercontent.com/33540275/233026486-da6b4c2f-0de9-4080-916c-82df0738a616.mp4


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
