### PR TITLE
Alerting: Update legacy alerting warning

### DIFF
--- a/public/app/features/alerting/components/DeprecationNotice.tsx
+++ b/public/app/features/alerting/components/DeprecationNotice.tsx
@@ -7,8 +7,8 @@ export const LOCAL_STORAGE_KEY = 'grafana.legacyalerting.unifiedalertingpromo';
 const DeprecationNotice = () => (
   <Alert severity="warning" title="Grafana legacy alerting is deprecated and will be removed in a future release.">
     <p>
-      You are using Grafana legacy alerting, which has been deprecated since Grafana 9.0. It will be removed in a future
-      release without further notice.
+      You are using Grafana legacy alerting, which has been deprecated since Grafana 9.0. The codebase is now staying as
+      is and will be removed in Grafana 11.0.
       <br />
       We recommend upgrading to Grafana Alerting as soon as possible.
     </p>

--- a/public/app/features/alerting/components/DeprecationNotice.tsx
+++ b/public/app/features/alerting/components/DeprecationNotice.tsx
@@ -5,23 +5,19 @@ import { Alert } from '@grafana/ui';
 export const LOCAL_STORAGE_KEY = 'grafana.legacyalerting.unifiedalertingpromo';
 
 const DeprecationNotice = () => (
-  <Alert severity="warning" title="Grafana legacy alerting is going away soon">
+  <Alert severity="warning" title="Grafana legacy alerting is deprecated and will be deleted soon">
     <p>
-      You are using Grafana legacy alerting, it has been deprecated and will be removed in the next major version of
-      Grafana.
+      You are using Grafana legacy alerting which is deprecated since Grafana 9.0. Legacy alerting will be removed from
+      Grafana in an upcoming release without further notice.
       <br />
-      We encourage you to upgrade to the new Grafana Alerting experience.
+      We recommend you to upgrade to Grafana Alerting as soon as possible.
     </p>
     <p>
       See{' '}
-      <a href="https://grafana.com/docs/grafana/latest/alerting/unified-alerting/difference-old-new/">
-        What’s New with Grafana Alerting
+      <a href="https://grafana.com/docs/grafana/latest/alerting/migrating-alerts/">
+        how to upgrade to Grafana Alerting
       </a>{' '}
-      to learn more about what&lsquo;s new or learn{' '}
-      <a href="https://grafana.com/docs/grafana/latest/alerting/unified-alerting/opt-in/">
-        how to enable the new Grafana Alerting feature
-      </a>
-      .
+      to learn more.
     </p>
   </Alert>
 );

--- a/public/app/features/alerting/components/DeprecationNotice.tsx
+++ b/public/app/features/alerting/components/DeprecationNotice.tsx
@@ -5,12 +5,12 @@ import { Alert } from '@grafana/ui';
 export const LOCAL_STORAGE_KEY = 'grafana.legacyalerting.unifiedalertingpromo';
 
 const DeprecationNotice = () => (
-  <Alert severity="warning" title="Grafana legacy alerting is deprecated and will be deleted soon">
+  <Alert severity="warning" title="Grafana legacy alerting is deprecated and will be removed in a future release.">
     <p>
-      You are using Grafana legacy alerting which is deprecated since Grafana 9.0. Legacy alerting will be removed from
-      Grafana in an upcoming release without further notice.
+      You are using Grafana legacy alerting, which has been deprecated since Grafana 9.0. It will be removed in a future release without further notice.
+
       <br />
-      We recommend you to upgrade to Grafana Alerting as soon as possible.
+      We recommend upgrading to Grafana Alerting as soon as possible.
     </p>
     <p>
       See{' '}

--- a/public/app/features/alerting/components/DeprecationNotice.tsx
+++ b/public/app/features/alerting/components/DeprecationNotice.tsx
@@ -7,7 +7,8 @@ export const LOCAL_STORAGE_KEY = 'grafana.legacyalerting.unifiedalertingpromo';
 const DeprecationNotice = () => (
   <Alert severity="warning" title="Grafana legacy alerting is deprecated and will be removed in a future release.">
     <p>
-      You are using Grafana legacy alerting, which has been deprecated since Grafana 9.0. It will be removed in a future release without further notice.
+      You are using Grafana legacy alerting, which has been deprecated since Grafana 9.0. It will be removed in a future
+      release without further notice.
       <br />
       We recommend upgrading to Grafana Alerting as soon as possible.
     </p>

--- a/public/app/features/alerting/components/DeprecationNotice.tsx
+++ b/public/app/features/alerting/components/DeprecationNotice.tsx
@@ -8,7 +8,6 @@ const DeprecationNotice = () => (
   <Alert severity="warning" title="Grafana legacy alerting is deprecated and will be removed in a future release.">
     <p>
       You are using Grafana legacy alerting, which has been deprecated since Grafana 9.0. It will be removed in a future release without further notice.
-
       <br />
       We recommend upgrading to Grafana Alerting as soon as possible.
     </p>


### PR DESCRIPTION
**What is this feature?**

Legacy alerting was supposed to be deleted in Grafana 10.0 but we will give it a few more months, we are clarifying our warning to state that the codebase will be deleted soon.