### PR TITLE
Plugins: Fix plugin signature calculation not working on Windows

### DIFF
--- a/pkg/plugins/manager/signature/manifest.go
+++ b/pkg/plugins/manager/signature/manifest.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -194,6 +195,9 @@ func Calculate(ctx context.Context, mlog log.Logger, src plugins.PluginSource, p
 	// Track files missing from the manifest
 	var unsignedFiles []string
 	for _, f := range plugin.FS.Files() {
+		// Ensure slashes are used, because MANIFEST.txt always uses slashes regardless of the filesystem
+		f = filepath.ToSlash(f)
+
 		// Ignoring unsigned Chromium debug.log so it doesn't invalidate the signature for Renderer plugin running on Windows
 		if runningWindows && plugin.JSONData.Type == plugins.Renderer && f == "chrome-win/debug.log" {
 			continue

--- a/pkg/plugins/manager/signature/manifest.go
+++ b/pkg/plugins/manager/signature/manifest.go
@@ -12,7 +12,6 @@ import (
 	"net/url"
 	"os"
 	"path"
-	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -196,7 +195,7 @@ func Calculate(ctx context.Context, mlog log.Logger, src plugins.PluginSource, p
 	var unsignedFiles []string
 	for _, f := range plugin.FS.Files() {
 		// Ensure slashes are used, because MANIFEST.txt always uses slashes regardless of the filesystem
-		f = filepath.ToSlash(f)
+		f = strings.ReplaceAll(f, "\\", "/")
 
 		// Ignoring unsigned Chromium debug.log so it doesn't invalidate the signature for Renderer plugin running on Windows
 		if runningWindows && plugin.JSONData.Type == plugins.Renderer && f == "chrome-win/debug.log" {

--- a/pkg/plugins/manager/signature/manifest.go
+++ b/pkg/plugins/manager/signature/manifest.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -55,7 +56,12 @@ N1c5v9v/4h6qeA==
 -----END PGP PUBLIC KEY BLOCK-----
 `
 
-var runningWindows = runtime.GOOS == "windows"
+var (
+	runningWindows = runtime.GOOS == "windows"
+
+	// toSlash is filepath.ToSlash, but can be overwritten in tests path separators cross-platform
+	toSlash = filepath.ToSlash
+)
 
 // PluginManifest holds details for the file manifest
 type PluginManifest struct {
@@ -195,7 +201,7 @@ func Calculate(ctx context.Context, mlog log.Logger, src plugins.PluginSource, p
 	var unsignedFiles []string
 	for _, f := range plugin.FS.Files() {
 		// Ensure slashes are used, because MANIFEST.txt always uses slashes regardless of the filesystem
-		f = strings.ReplaceAll(f, "\\", "/")
+		f = toSlash(f)
 
 		// Ignoring unsigned Chromium debug.log so it doesn't invalidate the signature for Renderer plugin running on Windows
 		if runningWindows && plugin.JSONData.Type == plugins.Renderer && f == "chrome-win/debug.log" {

--- a/pkg/plugins/manager/signature/manifest_test.go
+++ b/pkg/plugins/manager/signature/manifest_test.go
@@ -210,6 +210,97 @@ func TestCalculate(t *testing.T) {
 			SigningOrg: "Grafana Labs",
 		}, sig)
 	})
+
+	t.Run("Signature verification should work with any path separator", func(t *testing.T) {
+		for _, tc := range []struct {
+			name string
+			sep  string
+		}{
+			{"unix", "/"},
+			{"windows", "\\"},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				basePath := "../testdata/app-with-child/dist"
+
+				sig, err := Calculate(context.Background(), log.NewTestLogger(), &fakes.FakePluginSource{
+					PluginClassFunc: func(ctx context.Context) plugins.Class {
+						return plugins.External
+					},
+				}, plugins.FoundPlugin{
+					JSONData: plugins.JSONData{
+						ID:   "myorgid-simple-app",
+						Type: plugins.App,
+						Info: plugins.Info{
+							Version: "%VERSION%",
+						},
+					},
+					FS: newPathSeparatorOverrideFS(tc.sep, map[string]struct{}{
+						filepath.Join(basePath, "MANIFEST.txt"):      {},
+						filepath.Join(basePath, "plugin.json"):       {},
+						filepath.Join(basePath, "child/plugin.json"): {},
+					}, basePath),
+				})
+				require.NoError(t, err)
+				require.Equal(t, plugins.Signature{
+					Status:     plugins.SignatureValid,
+					Type:       plugins.GrafanaSignature,
+					SigningOrg: "Grafana Labs",
+				}, sig)
+			})
+		}
+	})
+}
+
+// fsPathSeparatorFiles embeds plugins.LocalFS and overrides the Files() behaviour so all the returned elements
+// have the specified path separator. This can be used to test Files() behaviour cross-platform.
+type fsPathSeparatorFiles struct {
+	plugins.LocalFS
+
+	separator string
+}
+
+// newPathSeparatorOverrideFS returns a new fsPathSeparatorFiles. Sep is the separator that will be used ONLY for
+// the elements returned by Files(). Files and basePath MUST use the os-specific path separator (filepath.Separator)
+// if Open() is required to work for the test case.
+func newPathSeparatorOverrideFS(sep string, files map[string]struct{}, basePath string) fsPathSeparatorFiles {
+	return fsPathSeparatorFiles{
+		LocalFS:   plugins.NewLocalFS(files, basePath),
+		separator: sep,
+	}
+}
+
+// Files returns LocalFS.Files(), but all path separators (filepath.Separator) are replaced with f.separator.
+func (f fsPathSeparatorFiles) Files() []string {
+	files := f.LocalFS.Files()
+	const osSepStr = string(filepath.Separator)
+	for i := 0; i < len(files); i++ {
+		files[i] = strings.ReplaceAll(files[i], osSepStr, f.separator)
+	}
+	return files
+}
+
+func TestFSPathSeparatorFiles(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		sep  string
+	}{
+		{"unix", "/"},
+		{"windows", "\\"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fs := newPathSeparatorOverrideFS("/", map[string]struct{}{
+				"a": {},
+				strings.Join([]string{"a", "b", "c"}, tc.sep): {},
+			}, ".")
+			files := fs.Files()
+			filesMap := make(map[string]struct{}, len(files))
+			// Re-convert to map as the key order is not stable
+			for _, f := range files {
+				filesMap[f] = struct{}{}
+			}
+			require.Equal(t, filesMap, map[string]struct{}{"a": {}, strings.Join([]string{"a", "b", "c"}, tc.sep): {}})
+		})
+	}
 }
 
 func fileList(manifest *PluginManifest) []string {

--- a/pkg/plugins/manager/signature/manifest_test.go
+++ b/pkg/plugins/manager/signature/manifest_test.go
@@ -213,7 +213,7 @@ func TestCalculate(t *testing.T) {
 
 	t.Run("Signature verification should work with any path separator", func(t *testing.T) {
 		var toSlashUnix = newToSlash('/')
-		var windowsToSlash = newToSlash('\\')
+		var toSlashWindows = newToSlash('\\')
 
 		for _, tc := range []struct {
 			name    string
@@ -221,7 +221,7 @@ func TestCalculate(t *testing.T) {
 			toSlash func(string) string
 		}{
 			{"unix", "/", toSlashUnix},
-			{"windows", "\\", windowsToSlash},
+			{"windows", "\\", toSlashWindows},
 		} {
 			t.Run(tc.name, func(t *testing.T) {
 				// Replace toSlash for cross-platform testing
@@ -275,18 +275,18 @@ func newToSlash(sep rune) func(string) string {
 
 func TestNewToSlash(t *testing.T) {
 	t.Run("unix", func(t *testing.T) {
-		unixToSlash := newToSlash('/')
-		require.Equal(t, "folder", unixToSlash("folder"))
-		require.Equal(t, "/folder", unixToSlash("/folder"))
-		require.Equal(t, "/folder/file", unixToSlash("/folder/file"))
-		require.Equal(t, "/folder/other\\file", unixToSlash("/folder/other\\file"))
+		toSlashUnix := newToSlash('/')
+		require.Equal(t, "folder", toSlashUnix("folder"))
+		require.Equal(t, "/folder", toSlashUnix("/folder"))
+		require.Equal(t, "/folder/file", toSlashUnix("/folder/file"))
+		require.Equal(t, "/folder/other\\file", toSlashUnix("/folder/other\\file"))
 	})
 
 	t.Run("windows", func(t *testing.T) {
-		windowsToSlash := newToSlash('\\')
-		require.Equal(t, "folder", windowsToSlash("folder"))
-		require.Equal(t, "C:/folder", windowsToSlash("C:\\folder"))
-		require.Equal(t, "folder/file.exe", windowsToSlash("folder\\file.exe"))
+		toSlashWindows := newToSlash('\\')
+		require.Equal(t, "folder", toSlashWindows("folder"))
+		require.Equal(t, "C:/folder", toSlashWindows("C:\\folder"))
+		require.Equal(t, "folder/file.exe", toSlashWindows("folder\\file.exe"))
 	})
 }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Fixes a bug introduced with plugin fs refactoring where NTFS path separators are not handled correctly when comparing MANIFEST.txt with the files present on the filesystem.

**Why do we need this feature?**

Windows bugfix

**Who is this feature for?**

Windows users

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Related to #66235

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
