### PR TITLE
TimePicker: Fixes issues with "Recently used absolute ranges" section

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
 // We set this specifically for 2 reasons.
 // 1. It makes sense for both CI tests and local tests to behave the same so issues are found earlier
 // 2. Any wrong timezone handling could be hidden if we use UTC/GMT local time (which would happen in CI).
-process.env.TZ = 'Pacific/Easter'; // UTC-06:00 or UTC-05:00 depedning on daylight savings
+process.env.TZ = 'Pacific/Easter'; // UTC-06:00 or UTC-05:00 depending on daylight savings
 
 const esModules = ['ol', 'd3', 'd3-color', 'd3-interpolate', 'delaunator', 'internmap', 'robust-predicates'].join('|');
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
 // We set this specifically for 2 reasons.
 // 1. It makes sense for both CI tests and local tests to behave the same so issues are found earlier
 // 2. Any wrong timezone handling could be hidden if we use UTC/GMT local time (which would happen in CI).
-process.env.TZ = 'Pacific/Easter';
+process.env.TZ = 'Pacific/Easter'; // UTC-06:00 or UTC-05:00 depedning on daylight savings
 
 const esModules = ['ol', 'd3', 'd3-color', 'd3-interpolate', 'delaunator', 'internmap', 'robust-predicates'].join('|');
 

--- a/packages/grafana-data/src/datetime/parser.test.ts
+++ b/packages/grafana-data/src/datetime/parser.test.ts
@@ -2,6 +2,11 @@ import { systemDateFormats, SystemDateFormatsState } from './formats';
 import { dateTimeParse } from './parser';
 
 describe('dateTimeParse', () => {
+  it('should parse using the systems configured timezone', () => {
+    const date = dateTimeParse('2020-03-02 15:00:22');
+    expect(date.format()).toEqual('2020-03-02T15:00:22-05:00');
+  });
+
   it('should be able to parse using default format', () => {
     const date = dateTimeParse('2020-03-02 15:00:22', { timeZone: 'utc' });
     expect(date.format()).toEqual('2020-03-02T15:00:22Z');

--- a/packages/grafana-data/src/datetime/rangeutil.test.ts
+++ b/packages/grafana-data/src/datetime/rangeutil.test.ts
@@ -5,7 +5,7 @@ import { timeRangeToRelative } from './rangeutil';
 import { dateTime, rangeUtil } from './index';
 
 describe('Range Utils', () => {
-  // These test probably wraps the dateTimeParser tests to some extent
+  // These tests probably wrap the dateTimeParser tests to some extent
   describe('convertRawToRange', () => {
     const DEFAULT_DATE_VALUE = '1996-07-30 16:00:00'; // Default format YYYY-MM-DD HH:mm:ss
     const DEFAULT_DATE_VALUE_FORMATTED = '1996-07-30T16:00:00-06:00';

--- a/packages/grafana-data/src/datetime/rangeutil.test.ts
+++ b/packages/grafana-data/src/datetime/rangeutil.test.ts
@@ -1,10 +1,57 @@
-import { TimeRange } from '../types/time';
+import { RawTimeRange, TimeRange } from '../types/time';
 
 import { timeRangeToRelative } from './rangeutil';
 
 import { dateTime, rangeUtil } from './index';
 
 describe('Range Utils', () => {
+  // These test probably wraps the dateTimeParser tests to some extent
+  describe('convertRawToRange', () => {
+    const DEFAULT_DATE_VALUE = '1996-07-30 16:00:00'; // Default format YYYY-MM-DD HH:mm:ss
+    const DEFAULT_DATE_VALUE_FORMATTED = '1996-07-30T16:00:00-06:00';
+    const defaultRawTimeRange = {
+      from: DEFAULT_DATE_VALUE,
+      to: '1996-07-30 16:20:00',
+    };
+
+    it('should serialize the default format by default', () => {
+      const serialized = rangeUtil.convertRawToRange(defaultRawTimeRange);
+      expect(serialized.from.format()).toBe(DEFAULT_DATE_VALUE_FORMATTED);
+    });
+
+    it('should serialize using custom formats', () => {
+      const NON_DEFAULT_FORMAT = 'DD-MM-YYYY HH:mm:ss';
+      const nonDefaultRawTimeRange: RawTimeRange = {
+        from: '30-07-1996 16:00:00',
+        to: '30-07-1996 16:20:00',
+      };
+
+      const serializedTimeRange = rangeUtil.convertRawToRange(
+        nonDefaultRawTimeRange,
+        undefined,
+        undefined,
+        NON_DEFAULT_FORMAT
+      );
+      expect(serializedTimeRange.from.format()).toBe(DEFAULT_DATE_VALUE_FORMATTED);
+    });
+
+    it('should take timezone into account', () => {
+      const serializedTimeRange = rangeUtil.convertRawToRange(defaultRawTimeRange, 'UTC');
+      expect(serializedTimeRange.from.format()).toBe('1996-07-30T16:00:00Z');
+    });
+
+    it('should leave the raw part intact if it has calulactions', () => {
+      const timeRange = {
+        from: DEFAULT_DATE_VALUE,
+        to: 'now',
+      };
+
+      const serialized = rangeUtil.convertRawToRange(timeRange);
+      expect(serialized.raw).toStrictEqual(timeRange);
+      expect(serialized.to.toString()).not.toBe(serialized.raw.to);
+    });
+  });
+
   describe('relative time', () => {
     it('should identify absolute vs relative', () => {
       expect(

--- a/packages/grafana-data/src/datetime/rangeutil.test.ts
+++ b/packages/grafana-data/src/datetime/rangeutil.test.ts
@@ -15,8 +15,8 @@ describe('Range Utils', () => {
     };
 
     it('should serialize the default format by default', () => {
-      const serialized = rangeUtil.convertRawToRange(defaultRawTimeRange);
-      expect(serialized.from.format()).toBe(DEFAULT_DATE_VALUE_FORMATTED);
+      const deserialized = rangeUtil.convertRawToRange(defaultRawTimeRange);
+      expect(deserialized.from.format()).toBe(DEFAULT_DATE_VALUE_FORMATTED);
     });
 
     it('should serialize using custom formats', () => {
@@ -26,18 +26,18 @@ describe('Range Utils', () => {
         to: '30-07-1996 16:20:00',
       };
 
-      const serializedTimeRange = rangeUtil.convertRawToRange(
+      const deserializedTimeRange = rangeUtil.convertRawToRange(
         nonDefaultRawTimeRange,
         undefined,
         undefined,
         NON_DEFAULT_FORMAT
       );
-      expect(serializedTimeRange.from.format()).toBe(DEFAULT_DATE_VALUE_FORMATTED);
+      expect(deserializedTimeRange.from.format()).toBe(DEFAULT_DATE_VALUE_FORMATTED);
     });
 
     it('should take timezone into account', () => {
-      const serializedTimeRange = rangeUtil.convertRawToRange(defaultRawTimeRange, 'UTC');
-      expect(serializedTimeRange.from.format()).toBe('1996-07-30T16:00:00Z');
+      const deserializedTimeRange = rangeUtil.convertRawToRange(defaultRawTimeRange, 'UTC');
+      expect(deserializedTimeRange.from.format()).toBe('1996-07-30T16:00:00Z');
     });
 
     it('should leave the raw part intact if it has calulactions', () => {
@@ -46,9 +46,9 @@ describe('Range Utils', () => {
         to: 'now',
       };
 
-      const serialized = rangeUtil.convertRawToRange(timeRange);
-      expect(serialized.raw).toStrictEqual(timeRange);
-      expect(serialized.to.toString()).not.toBe(serialized.raw.to);
+      const deserialized = rangeUtil.convertRawToRange(timeRange);
+      expect(deserialized.raw).toStrictEqual(timeRange);
+      expect(deserialized.to.toString()).not.toBe(deserialized.raw.to);
     });
   });
 

--- a/packages/grafana-data/src/datetime/rangeutil.ts
+++ b/packages/grafana-data/src/datetime/rangeutil.ts
@@ -198,9 +198,14 @@ export const describeTimeRangeAbbreviation = (range: TimeRange, timeZone?: TimeZ
   return parsed ? timeZoneAbbrevation(parsed, { timeZone }) : '';
 };
 
-export const convertRawToRange = (raw: RawTimeRange, timeZone?: TimeZone, fiscalYearStartMonth?: number): TimeRange => {
-  const from = dateTimeParse(raw.from, { roundUp: false, timeZone, fiscalYearStartMonth });
-  const to = dateTimeParse(raw.to, { roundUp: true, timeZone, fiscalYearStartMonth });
+export const convertRawToRange = (
+  raw: RawTimeRange,
+  timeZone?: TimeZone,
+  fiscalYearStartMonth?: number,
+  format?: string
+): TimeRange => {
+  const from = dateTimeParse(raw.from, { roundUp: false, timeZone, fiscalYearStartMonth, format });
+  const to = dateTimeParse(raw.to, { roundUp: true, timeZone, fiscalYearStartMonth, format });
 
   if (dateMath.isMathString(raw.from) || dateMath.isMathString(raw.to)) {
     return { from, to, raw };

--- a/public/app/core/components/TimePicker/TimePickerWithHistory.test.tsx
+++ b/public/app/core/components/TimePicker/TimePickerWithHistory.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
-import { getDefaultTimeRange, systemDateFormats, SystemDateFormatsState } from '@grafana/data';
+import { getDefaultTimeRange, localTimeFormat, systemDateFormats, SystemDateFormatsState } from '@grafana/data';
 
 import { TimePickerWithHistory } from './TimePickerWithHistory';
 
@@ -43,7 +43,7 @@ describe('TimePickerWithHistory', () => {
 
   afterEach(() => {
     window.localStorage.clear();
-    systemDateFormats.useBrowserLocale();
+    //systemDateFormats.useBrowserLocale();
   });
 
   it('Should load with no history', async () => {
@@ -137,16 +137,28 @@ describe('TimePickerWithHistory', () => {
     await clearAndType(getToField(), '2022-12-10 23:59:59');
     await userEvent.click(getApplyButton());
 
+    await userEvent.click(screen.getByLabelText(/Time range selected/));
+
     expect(screen.getByText(/2022-12-10 00:00:00 to 2022-12-10 23:59:59/i)).toBeInTheDocument();
-    expect(screen.queryByText(/2022-12-10 00:00:00 to 2022-12-10 23:59:59/i)).toBeInTheDocument();
   });
 
   it('Should display history correctly with custom time format', async () => {
     const timeRange = getDefaultTimeRange();
+
+    const interval = {
+      millisecond: 'HH:mm:ss.SSS',
+      second: 'HH:mm:ss',
+      minute: 'HH:mm',
+      hour: 'DD-MM HH:mm',
+      day: 'DD-MM',
+      month: 'MM-YYYY',
+      year: 'YYYY',
+    };
+
     systemDateFormats.update({
       fullDate: 'DD-MM-YYYY HH:mm:ss',
-      interval: {} as SystemDateFormatsState['interval'],
-      useBrowserLocale: true,
+      interval: interval,
+      useBrowserLocale: false,
     });
     render(<TimePickerWithHistory value={timeRange} {...props} />);
     await userEvent.click(screen.getByLabelText(/Time range selected/));
@@ -158,7 +170,6 @@ describe('TimePickerWithHistory', () => {
     await userEvent.click(screen.getByLabelText(/Time range selected/));
 
     expect(screen.getByText(/03-12-2022 00:00:00 to 03-12-2022 23:59:59/i)).toBeInTheDocument();
-    expect(screen.queryByText(/03-12-2022 00:00:00 to 03-12-2022 23:59:59/i)).toBeInTheDocument();
   });
 });
 

--- a/public/app/core/components/TimePicker/TimePickerWithHistory.test.tsx
+++ b/public/app/core/components/TimePicker/TimePickerWithHistory.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
-import { getDefaultTimeRange, localTimeFormat, systemDateFormats, SystemDateFormatsState } from '@grafana/data';
+import { getDefaultTimeRange, systemDateFormats } from '@grafana/data';
 
 import { TimePickerWithHistory } from './TimePickerWithHistory';
 

--- a/public/app/core/components/TimePicker/TimePickerWithHistory.test.tsx
+++ b/public/app/core/components/TimePicker/TimePickerWithHistory.test.tsx
@@ -43,7 +43,6 @@ describe('TimePickerWithHistory', () => {
 
   afterEach(() => {
     window.localStorage.clear();
-    //systemDateFormats.useBrowserLocale();
   });
 
   it('Should load with no history', async () => {

--- a/public/app/core/components/TimePicker/TimePickerWithHistory.tsx
+++ b/public/app/core/components/TimePicker/TimePickerWithHistory.tsx
@@ -1,7 +1,7 @@
 import { uniqBy } from 'lodash';
 import React from 'react';
 
-import { TimeRange, isDateTime, rangeUtil, TimeZone } from '@grafana/data';
+import { TimeRange, isDateTime, rangeUtil } from '@grafana/data';
 import { TimeRangePickerProps, TimeRangePicker } from '@grafana/ui';
 
 import { LocalStorageValueProvider } from '../LocalStorageValueProvider';
@@ -24,7 +24,7 @@ export const TimePickerWithHistory = (props: Props) => {
     <LocalStorageValueProvider<LSTimePickerHistoryItem[]> storageKey={LOCAL_STORAGE_KEY} defaultValue={[]}>
       {(rawValues, onSaveToStore) => {
         const values = migrateHistory(rawValues);
-        const history = deserializeHistory(values, props.timeZone);
+        const history = deserializeHistory(values);
 
         return (
           <TimeRangePicker
@@ -41,8 +41,9 @@ export const TimePickerWithHistory = (props: Props) => {
   );
 };
 
-function deserializeHistory(values: TimePickerHistoryItem[], timeZone: TimeZone | undefined): TimeRange[] {
-  return values.map((item) => rangeUtil.convertRawToRange(item, timeZone));
+function deserializeHistory(values: TimePickerHistoryItem[]): TimeRange[] {
+  // The history is saved in UTC and with the default date format, so we need to pass those values to the convertRawToRange
+  return values.map((item) => rangeUtil.convertRawToRange(item, 'utc', undefined));
 }
 
 function migrateHistory(values: LSTimePickerHistoryItem[]): TimePickerHistoryItem[] {

--- a/public/app/core/components/TimePicker/TimePickerWithHistory.tsx
+++ b/public/app/core/components/TimePicker/TimePickerWithHistory.tsx
@@ -43,7 +43,7 @@ export const TimePickerWithHistory = (props: Props) => {
 
 function deserializeHistory(values: TimePickerHistoryItem[]): TimeRange[] {
   // The history is saved in UTC and with the default date format, so we need to pass those values to the convertRawToRange
-  return values.map((item) => rangeUtil.convertRawToRange(item, 'utc', undefined));
+  return values.map((item) => rangeUtil.convertRawToRange(item, 'utc', undefined, 'YYYY-MM-DD HH:mm:ss'));
 }
 
 function migrateHistory(values: LSTimePickerHistoryItem[]): TimePickerHistoryItem[] {


### PR DESCRIPTION
**What is this feature?**

Someone raised an issue where the "Recently used absolute ranges" was giving them nonsensical values for what they have selected:

![229301082-4512ba23-a1b4-407c-beb9-b0c961a28c14](https://user-images.githubusercontent.com/100691367/231175984-f5b4be35-effb-4983-a558-b9d9a1907936.png)

This led us to realise that if you have any other date format than the default one (for instance by setting `full_date = DD-MM-YYYY HH:mm:ss` in the `custom.ini` file) this will happen. Because the format that we save in local storage for this section is still 'YYYY-MM-DD', so it is trying to read a date in that format with the configured one, hence the nonsensical numbers. To fix this we pass in the default date format in order to tell the date parser that that is the format of the current date.

While investigating this we also found an issue with the timezone. Similarly to above, it was assuming that the value stored in local storage is in the selected timezone but it is already in 'utc', so we have to pass that to the parser as well.

**Why do we need this feature?**

To be more confident that the Time picker history section works correctly.

**Who is this feature for?**

Anyone that uses the history section of the time picker

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #65756

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
