### PR TITLE
Loki Autocomplete: Update Lezer LogQL and update labels autocomplete after the upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -262,7 +262,7 @@
     "@grafana/faro-core": "1.0.2",
     "@grafana/faro-web-sdk": "1.0.2",
     "@grafana/google-sdk": "0.1.1",
-    "@grafana/lezer-logql": "0.1.2",
+    "@grafana/lezer-logql": "0.1.3",
     "@grafana/monaco-logql": "^0.0.7",
     "@grafana/runtime": "workspace:*",
     "@grafana/scenes": "^0.3.0",

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.test.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.test.ts
@@ -115,6 +115,13 @@ describe('situation', () => {
       type: 'IN_LABEL_SELECTOR_NO_LABEL_NAME',
       otherLabels: [],
     });
+
+    ['sum({label="value",^})', '{label="value",^}', '{label="value", ^}'].forEach((query) => {
+      assertSituation(query, {
+        type: 'IN_LABEL_SELECTOR_NO_LABEL_NAME',
+        otherLabels: [{ name: 'label', value: 'value', op: '=' }],
+      });
+    });
   });
 
   it('identifies labels from queries', () => {

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/situation.ts
@@ -144,6 +144,10 @@ const RESOLVERS: Resolver[] = [
     fun: resolveSelector,
   },
   {
+    path: [ERROR_NODE_ID, Matchers, Selector],
+    fun: resolveSelector,
+  },
+  {
     path: [LogQL],
     fun: resolveTopLevel,
   },
@@ -244,14 +248,11 @@ function getLabels(selectorNode: SyntaxNode, text: string): Label[] {
 
   while (listNode !== null) {
     const matcherNode = walk(listNode, [['lastChild', Matcher]]);
-    if (matcherNode === null) {
-      // unexpected, we stop
-      return [];
-    }
-
-    const label = getLabel(matcherNode, text);
-    if (label !== null) {
-      labels.push(label);
+    if (matcherNode !== null) {
+      const label = getLabel(matcherNode, text);
+      if (label !== null) {
+        labels.push(label);
+      }
     }
 
     // there might be more labels
@@ -469,14 +470,24 @@ function resolveSelector(node: SyntaxNode, text: string, pos: number): Situation
     // to be able to suggest adding the next label.
     // the area between the end-of-the-child-node and the cursor-pos
     // must contain a `,` in this case.
-    const textToCheck = text.slice(child.to, pos);
-
-    if (!textToCheck.includes(',')) {
+    const textToCheck = text.slice(child.from, pos);
+    if (!textToCheck.trim().endsWith(',')) {
       return null;
     }
   }
 
-  const otherLabels = getLabels(node, text);
+  const selectorNode =
+    node.type.id === ERROR_NODE_ID
+      ? walk(node, [
+          ['parent', Matchers],
+          ['parent', Selector],
+        ])
+      : node;
+  if (!selectorNode) {
+    return null;
+  }
+
+  const otherLabels = getLabels(selectorNode, text);
 
   return {
     type: 'IN_LABEL_SELECTOR_NO_LABEL_NAME',

--- a/yarn.lock
+++ b/yarn.lock
@@ -3262,12 +3262,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grafana/lezer-logql@npm:0.1.2":
-  version: 0.1.2
-  resolution: "@grafana/lezer-logql@npm:0.1.2"
+"@grafana/lezer-logql@npm:0.1.3":
+  version: 0.1.3
+  resolution: "@grafana/lezer-logql@npm:0.1.3"
   peerDependencies:
     "@lezer/lr": ^1.0.0
-  checksum: 4b62fda9c2c7e29c48f7485df19573b96bfd34539529283980f24e9931f81b44c86b1e655bae5f50730d9d7b37bae87e6f7f7773dafaf4f6acef90b2c2cb776f
+  checksum: 160e4039ce7dd0cd304d37608c0764c24d61030a84636161161bb7cd5cd2d6f064cd3156e8814ed4cb5b8ddebeb4dbae77120f9a3eaea6afe889d99f6dd23543
   languageName: node
   linkType: hard
 
@@ -20134,7 +20134,7 @@ __metadata:
     "@grafana/faro-core": 1.0.2
     "@grafana/faro-web-sdk": 1.0.2
     "@grafana/google-sdk": 0.1.1
-    "@grafana/lezer-logql": 0.1.2
+    "@grafana/lezer-logql": 0.1.3
     "@grafana/monaco-logql": ^0.0.7
     "@grafana/runtime": "workspace:*"
     "@grafana/scenes": ^0.3.0


### PR DESCRIPTION
With Lezer LogQL 0.1.3, a selector with a trailing comma `{label="value",}` will be considered invalid. We need to update the labels autocomplete to support the parsing changes that this produces.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/65436

**Special notes for your reviewer:**

Test different situations where labels should be autocompleted. The suggestions should not include labels that are currently in use.

![imagen](https://user-images.githubusercontent.com/1069378/231192552-aeac47d7-6fac-4c31-bd6f-75b83faed82f.png)
