### PR TITLE
Logs Navigation: Fix typo in test description

### DIFF
--- a/public/app/features/explore/LogsNavigation.test.tsx
+++ b/public/app/features/explore/LogsNavigation.test.tsx
@@ -93,7 +93,7 @@ describe('LogsNavigation', () => {
     expect(onChangeTimeMock).toHaveBeenCalledWith({ from: 1637319338000, to: 1637322938000 });
   });
 
-  it('should reset the scroll when pagination is clic ked', async () => {
+  it('should reset the scroll when pagination is clicked', async () => {
     const scrollToTopLogsMock = jest.fn();
     setup({ scrollToTopLogs: scrollToTopLogsMock });
 


### PR DESCRIPTION
Fixing a typo introduced in https://github.com/grafana/grafana/pull/66214