### PR TITLE
Table Panel: Fix panel migration for options cell type

### DIFF
--- a/public/app/features/dashboard/state/DashboardMigrator.test.ts
+++ b/public/app/features/dashboard/state/DashboardMigrator.test.ts
@@ -3,6 +3,7 @@ import { each, map } from 'lodash';
 import { DataLinkBuiltInVars, MappingType } from '@grafana/data';
 import { getPanelPlugin } from '@grafana/data/test/__mocks__/pluginMocks';
 import { setDataSourceSrv } from '@grafana/runtime';
+import { FieldConfigSource } from '@grafana/schema';
 import { config } from 'app/core/config';
 import { GRID_CELL_HEIGHT, GRID_CELL_VMARGIN } from 'app/core/constants';
 import { mockDataSource, MockDataSourceSrv } from 'app/features/alerting/unified/mocks';
@@ -2196,8 +2197,7 @@ describe('when migrating table cell display mode to cell options', () => {
                 inspect: false,
               },
             },
-            overrides: [],
-          },
+          } as unknown as FieldConfigSource, // missing overrides
         },
         // @ts-expect-error
         {

--- a/public/app/features/dashboard/state/DashboardMigrator.ts
+++ b/public/app/features/dashboard/state/DashboardMigrator.ts
@@ -825,9 +825,8 @@ export class DashboardMigrator {
           }
 
           // Update any overrides referencing the cell display mode
-          const overrides = panel.fieldConfig.overrides;
-          if (overrides?.length) {
-            for (const override of overrides) {
+          if (panel.fieldConfig?.overrides) {
+            for (const override of panel.fieldConfig.overrides) {
               for (let j = 0; j < override.properties?.length ?? 0; j++) {
                 let overrideDisplayMode = override.properties[j].value;
                 if (override.properties[j].id === 'custom.displayMode') {

--- a/public/app/features/dashboard/state/DashboardMigrator.ts
+++ b/public/app/features/dashboard/state/DashboardMigrator.ts
@@ -825,14 +825,15 @@ export class DashboardMigrator {
           }
 
           // Update any overrides referencing the cell display mode
-          for (let i = 0; i < panel.fieldConfig.overrides.length; i++) {
-            for (let j = 0; j < panel.fieldConfig.overrides[i].properties.length; j++) {
-              let overrideDisplayMode = panel.fieldConfig.overrides[i].properties[j].value;
-
-              if (panel.fieldConfig.overrides[i].properties[j].id === 'custom.displayMode') {
-                panel.fieldConfig.overrides[i].properties[j].id = 'custom.cellOptions';
-                panel.fieldConfig.overrides[i].properties[j].value =
-                  migrateTableDisplayModeToCellOptions(overrideDisplayMode);
+          const overrides = panel.fieldConfig.overrides;
+          if (overrides?.length) {
+            for (const override of overrides) {
+              for (let j = 0; j < override.properties?.length ?? 0; j++) {
+                let overrideDisplayMode = override.properties[j].value;
+                if (override.properties[j].id === 'custom.displayMode') {
+                  override.properties[j].id = 'custom.cellOptions';
+                  override.properties[j].value = migrateTableDisplayModeToCellOptions(overrideDisplayMode);
+                }
               }
             }
           }


### PR DESCRIPTION
https://github.com/grafana/grafana/pull/59363 will cause dashboards to fail that have fieldConfig and no overrides.

Without this fix, I get this for many dashboards:
<img width="1483" alt="image" src="https://user-images.githubusercontent.com/705951/231230969-d455f96d-d2a9-45c5-bc18-2ca98baa277e.png">

