### PR TITLE
Alerting: Use default page size of 5000 when querying Loki for state history

### DIFF
--- a/pkg/services/ngalert/state/historian/loki_http.go
+++ b/pkg/services/ngalert/state/historian/loki_http.go
@@ -17,6 +17,8 @@ import (
 	"github.com/weaveworks/common/http/client"
 )
 
+const defaultPageSize = 5000
+
 func NewRequester() client.Requester {
 	return &http.Client{}
 }
@@ -222,6 +224,7 @@ func (c *httpLokiClient) setAuthAndTenantHeaders(req *http.Request) {
 		req.Header.Add("X-Scope-OrgID", c.cfg.TenantID)
 	}
 }
+
 func (c *httpLokiClient) rangeQuery(ctx context.Context, logQL string, start, end int64) (queryRes, error) {
 	// Run the pre-flight checks for the query.
 	if start > end {
@@ -234,6 +237,7 @@ func (c *httpLokiClient) rangeQuery(ctx context.Context, logQL string, start, en
 	values.Set("query", logQL)
 	values.Set("start", fmt.Sprintf("%d", start))
 	values.Set("end", fmt.Sprintf("%d", end))
+	values.Set("limit", fmt.Sprintf("%d", defaultPageSize))
 
 	queryURL.RawQuery = values.Encode()
 


### PR DESCRIPTION
**What is this feature?**

Previously, we use Loki's default page size for range queries. In some cases, the page size was absurdly low - 100, even. Let's use 5000 as the default page size for now.

**This is a bit of a band-aid solution**. The loki operator can configure `max_entries_limit_per_query` to something really low, and there's not much we can do about it.

I'm posting this PR to widen things for now, but in the future we'll want to handle this limit more gracefully, by either:
- Making this default page size configurable in `config.ini`
- Stitching multiple Loki pages together in the grafana backend, if the max entries limit is extremely low.

**Why do we need this feature?**

This is a more reasonable pagination size for this sort of query.

**Which issue(s) does this PR fix?**:

n/a

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
