### PR TITLE
Caching: Introduce feature toggle to caching service refactor

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -34,6 +34,7 @@ Some stable features are enabled by default. You can disable a stable feature by
 | `emptyDashboardPage`                | Enable the redesigned user interface of a dashboard page that includes no panels                                                                                             | Yes                |
 | `disablePrometheusExemplarSampling` | Disable Prometheus exemplar sampling                                                                                                                                         |                    |
 | `logsSampleInExplore`               | Enables access to the logs sample feature in Explore                                                                                                                         | Yes                |
+| `useCachingService`                 | When turned on, the new query and resource caching implementation using a wire service inject will be used in place of the previous middleware implementation                |                    |
 
 ## Beta feature toggles
 

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -96,4 +96,5 @@ export interface FeatureToggles {
   pyroscopeFlameGraph?: boolean;
   externalServiceAuth?: boolean;
   dataplaneFrontendFallback?: boolean;
+  useCachingService?: boolean;
 }

--- a/pkg/api/plugin_resource.go
+++ b/pkg/api/plugin_resource.go
@@ -15,6 +15,7 @@ import (
 	"github.com/grafana/grafana/pkg/plugins/backendplugin"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/datasources"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/util/proxyutil"
 	"github.com/grafana/grafana/pkg/web"
 )
@@ -199,7 +200,9 @@ func (hs *HTTPServer) flushStream(ctx context.Context, req *backend.CallResource
 
 		if _, err := w.Write(resp.Body); err != nil {
 			hs.log.Error("Failed to write resource response", "err", err)
-		} else {
+		} else if hs.Features.IsEnabled(featuremgmt.FlagUseCachingService) {
+			// Placing the new service implementation behind a feature flag until it is known to be stable
+
 			// The enterprise implementation of this function will use the headers and status of the first response,
 			// And append the body of any subsequent responses. It waits for the context to be canceled before caching the cumulative result.
 			hs.cachingService.CacheResourceResponse(ctx, req, resp)

--- a/pkg/api/plugin_resource_test.go
+++ b/pkg/api/plugin_resource_test.go
@@ -108,7 +108,7 @@ func TestCallResource(t *testing.T) {
 			req *backend.CallResourceRequest, sender backend.CallResourceResponseSender) error {
 			return errors.New("something went wrong")
 		}),
-	}, pluginsintegration.CreateMiddlewares(cfg, &oauthtokentest.Service{}, tracing.InitializeTracerForTest(), &caching.OSSCachingService{})...)
+	}, pluginsintegration.CreateMiddlewares(cfg, &oauthtokentest.Service{}, tracing.InitializeTracerForTest(), &caching.OSSCachingService{}, &featuremgmt.FeatureManager{})...)
 	require.NoError(t, err)
 
 	srv = SetupAPITestServer(t, func(hs *HTTPServer) {

--- a/pkg/services/featuremgmt/codeowners.go
+++ b/pkg/services/featuremgmt/codeowners.go
@@ -23,4 +23,5 @@ const (
 	awsPluginsSquad                             codeowner = "@grafana/aws-plugins"
 	appO11ySquad                                codeowner = "@grafana/app-o11y"
 	grafanaPartnerPluginsSquad                  codeowner = "@grafana/partner-plugins"
+	grafanaOperatorExperienceSquad              codeowner = "@grafana/grafana-operator-experience-squad"
 )

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -519,5 +519,13 @@ var (
 			FrontendOnly: true,
 			Owner:        grafanaObservabilityMetricsSquad,
 		},
+		{
+			Name:            "useCachingService",
+			Description:     "When turned on, the new query and resource caching implementation using a wire service inject will be used in place of the previous middleware implementation",
+			State:           FeatureStateStable,
+			Owner:           grafanaOperatorExperienceSquad,
+			RequiresLicense: true,
+			RequiresRestart: true,
+		},
 	}
 )

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -524,7 +524,6 @@ var (
 			Description:     "When turned on, the new query and resource caching implementation using a wire service inject will be used in place of the previous middleware implementation",
 			State:           FeatureStateStable,
 			Owner:           grafanaOperatorExperienceSquad,
-			RequiresLicense: true,
 			RequiresRestart: true,
 		},
 	}

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -77,4 +77,4 @@ renderAuthJWT,beta,@grafana/grafana-as-code,false,false,false,false
 pyroscopeFlameGraph,alpha,@grafana/observability-traces-and-profiling,false,false,false,false
 externalServiceAuth,alpha,@grafana/grafana-authnz-team,true,false,false,false
 dataplaneFrontendFallback,alpha,@grafana/observability-metrics,false,false,false,true
-useCachingService,stable,@grafana/grafana-operator-experience-squad,false,true,true,false
+useCachingService,stable,@grafana/grafana-operator-experience-squad,false,false,true,false

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -77,3 +77,4 @@ renderAuthJWT,beta,@grafana/grafana-as-code,false,false,false,false
 pyroscopeFlameGraph,alpha,@grafana/observability-traces-and-profiling,false,false,false,false
 externalServiceAuth,alpha,@grafana/grafana-authnz-team,true,false,false,false
 dataplaneFrontendFallback,alpha,@grafana/observability-metrics,false,false,false,true
+useCachingService,stable,@grafana/grafana-operator-experience-squad,false,true,true,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -318,4 +318,8 @@ const (
 	// FlagDataplaneFrontendFallback
 	// Support dataplane contract field name change for transformations and field name matchers where the name is different
 	FlagDataplaneFrontendFallback = "dataplaneFrontendFallback"
+
+	// FlagUseCachingService
+	// When turned on, the new query and resource caching implementation using a wire service inject will be used in place of the previous middleware implementation
+	FlagUseCachingService = "useCachingService"
 )

--- a/pkg/services/pluginsintegration/pluginsintegration.go
+++ b/pkg/services/pluginsintegration/pluginsintegration.go
@@ -22,6 +22,7 @@ import (
 	"github.com/grafana/grafana/pkg/plugins/pluginscdn"
 	"github.com/grafana/grafana/pkg/plugins/repo"
 	"github.com/grafana/grafana/pkg/services/caching"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/oauthtoken"
 	"github.com/grafana/grafana/pkg/services/pluginsintegration/clientmiddleware"
 	"github.com/grafana/grafana/pkg/services/pluginsintegration/config"
@@ -84,22 +85,23 @@ func ProvideClientDecorator(
 	oAuthTokenService oauthtoken.OAuthTokenService,
 	tracer tracing.Tracer,
 	cachingService caching.CachingService,
+	features *featuremgmt.FeatureManager,
 ) (*client.Decorator, error) {
-	return NewClientDecorator(cfg, pCfg, pluginRegistry, oAuthTokenService, tracer, cachingService)
+	return NewClientDecorator(cfg, pCfg, pluginRegistry, oAuthTokenService, tracer, cachingService, features)
 }
 
 func NewClientDecorator(
 	cfg *setting.Cfg, pCfg *pCfg.Cfg,
 	pluginRegistry registry.Service, oAuthTokenService oauthtoken.OAuthTokenService,
-	tracer tracing.Tracer, cachingService caching.CachingService,
+	tracer tracing.Tracer, cachingService caching.CachingService, features *featuremgmt.FeatureManager,
 ) (*client.Decorator, error) {
 	c := client.ProvideService(pluginRegistry, pCfg)
-	middlewares := CreateMiddlewares(cfg, oAuthTokenService, tracer, cachingService)
+	middlewares := CreateMiddlewares(cfg, oAuthTokenService, tracer, cachingService, features)
 
 	return client.NewDecorator(c, middlewares...)
 }
 
-func CreateMiddlewares(cfg *setting.Cfg, oAuthTokenService oauthtoken.OAuthTokenService, tracer tracing.Tracer, cachingService caching.CachingService) []plugins.ClientMiddleware {
+func CreateMiddlewares(cfg *setting.Cfg, oAuthTokenService oauthtoken.OAuthTokenService, tracer tracing.Tracer, cachingService caching.CachingService, features *featuremgmt.FeatureManager) []plugins.ClientMiddleware {
 	skipCookiesNames := []string{cfg.LoginCookieName}
 	middlewares := []plugins.ClientMiddleware{
 		clientmiddleware.NewTracingMiddleware(tracer),
@@ -107,7 +109,11 @@ func CreateMiddlewares(cfg *setting.Cfg, oAuthTokenService oauthtoken.OAuthToken
 		clientmiddleware.NewClearAuthHeadersMiddleware(),
 		clientmiddleware.NewOAuthTokenMiddleware(oAuthTokenService),
 		clientmiddleware.NewCookiesMiddleware(skipCookiesNames),
-		clientmiddleware.NewCachingMiddleware(cachingService),
+	}
+
+	// Placing the new service implementation behind a feature flag until it is known to be stable
+	if features.IsEnabled(featuremgmt.FlagUseCachingService) {
+		middlewares = append(middlewares, clientmiddleware.NewCachingMiddleware(cachingService))
 	}
 
 	if cfg.SendUserHeader {


### PR DESCRIPTION
**What is this feature?**

Puts query caching refactor behind a feature toggle.

**Why do we need this feature?**

Ensure stability of new caching code

**Notes**

Original PRs were already approved. Did this on a branch because it's easier to parse the diff.