### PR TITLE
add workaround for intercom iframe background being non-transparent in dark mode

### DIFF
--- a/packages/grafana-ui/src/themes/GlobalStyles/GlobalStyles.tsx
+++ b/packages/grafana-ui/src/themes/GlobalStyles/GlobalStyles.tsx
@@ -6,6 +6,7 @@ import { useTheme2 } from '..';
 import { getAgularPanelStyles } from './angularPanelStyles';
 import { getCardStyles } from './card';
 import { getElementStyles } from './elements';
+import { getExtraStyles } from './extra';
 import { getFormElementStyles } from './forms';
 import { getMarkdownStyles } from './markdownStyles';
 import { getPageStyles } from './page';
@@ -18,6 +19,7 @@ export function GlobalStyles() {
     <Global
       styles={[
         getElementStyles(theme),
+        getExtraStyles(theme),
         getFormElementStyles(theme),
         getPageStyles(theme),
         getCardStyles(theme),

--- a/packages/grafana-ui/src/themes/GlobalStyles/extra.ts
+++ b/packages/grafana-ui/src/themes/GlobalStyles/extra.ts
@@ -1,0 +1,12 @@
+import { css } from '@emotion/react';
+
+import { GrafanaTheme2 } from '@grafana/data';
+
+export function getExtraStyles(theme: GrafanaTheme2) {
+  return css`
+    // fix white background on intercom in dark mode
+    iframe.intercom-borderless-frame {
+      color-scheme: ${theme.colors.mode};
+    }
+  `;
+}


### PR DESCRIPTION
Intercom uses an iframe to render a floating chat window. Under the light theme the background is transparent, but when using the dark theme the browser adds a white background because the iframe does not specify a color-scheme.

This hack simply adds a css rule targeting that iframe to set the color-scheme to "light dark" so that it renders properly.

We could potentially make this a broader rule, but I wanted to keep this as minimal as possible.

- https://github.com/grafana/grafana/blob/main/public/app/features/alerting/unified/Home.tsx#L70-L73
- https://github.com/w3c/csswg-drafts/issues/4772