### PR TITLE
VizLayout: Fixes flicking visualization height & re-render

### DIFF
--- a/packages/grafana-ui/src/components/VizLayout/VizLayout.tsx
+++ b/packages/grafana-ui/src/components/VizLayout/VizLayout.tsx
@@ -61,7 +61,7 @@ export const VizLayout: VizLayoutComponentType = ({ width, height, legend, child
       containerStyle.flexDirection = 'column';
       legendStyle.maxHeight = maxHeight;
 
-      if (legendMeasure) {
+      if (legendMeasure.height) {
         size = { width, height: height - legendMeasure.height };
       }
       break;
@@ -69,7 +69,7 @@ export const VizLayout: VizLayoutComponentType = ({ width, height, legend, child
       containerStyle.flexDirection = 'row';
       legendStyle.maxWidth = maxWidth;
 
-      if (legendMeasure) {
+      if (legendMeasure.width) {
         size = { width: width - legendMeasure.width, height };
       }
 

--- a/public/app/plugins/panel/piechart/PieChartPanel.test.tsx
+++ b/public/app/plugins/panel/piechart/PieChartPanel.test.tsx
@@ -16,6 +16,11 @@ import { LegendDisplayMode, SortOrder, TooltipDisplayMode } from '@grafana/schem
 import { PieChartPanel } from './PieChartPanel';
 import { PanelOptions, PieChartType, PieChartLegendValues } from './panelcfg.gen';
 
+jest.mock('react-use', () => ({
+  ...jest.requireActual('react-use'),
+  useMeasure: () => [() => {}, { width: 100, height: 100 }],
+}));
+
 type PieChartPanelProps = ComponentProps<typeof PieChartPanel>;
 
 describe('PieChartPanel', () => {


### PR DESCRIPTION
Noticed flickering height and movement in graphs as you load a dashboard (with fast or cached data). 

I was unable to track this down to any change in either VizLayout, useMeasure or TimeSeries, VizLegend etc. So I am starting to think that this could be introduced by React 18. 

was able to fix the issue by changing the logic in VizLayout. 

[legend-bug2---FolderC---Dashboards---Grafana.webm](https://user-images.githubusercontent.com/10999/231363952-0d69bcab-a0b8-409a-8e6b-dc4b18bb66dd.webm)
