### PR TITLE
AccessControl: Allow editors to access GET /api/datasources

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -392,7 +392,7 @@ func (hs *HTTPServer) registerRoutes() {
 			idScope := datasources.ScopeProvider.GetResourceScope(ac.Parameter(":id"))
 			uidScope := datasources.ScopeProvider.GetResourceScopeUID(ac.Parameter(":uid"))
 			nameScope := datasources.ScopeProvider.GetResourceScopeName(ac.Parameter(":name"))
-			datasourceRoute.Get("/", authorize(reqOrgAdmin, ac.EvalPermission(datasources.ActionRead)), routing.Wrap(hs.GetDataSources))
+			datasourceRoute.Get("/", authorize(reqEditorRole, ac.EvalPermission(datasources.ActionRead)), routing.Wrap(hs.GetDataSources))
 			datasourceRoute.Post("/", authorize(reqOrgAdmin, ac.EvalPermission(datasources.ActionCreate)), quota(string(datasources.QuotaTargetSrv)), routing.Wrap(hs.AddDataSource))
 			datasourceRoute.Put("/:id", authorize(reqOrgAdmin, ac.EvalPermission(datasources.ActionWrite, idScope)), routing.Wrap(hs.UpdateDataSourceByID))
 			datasourceRoute.Put("/uid/:uid", authorize(reqOrgAdmin, ac.EvalPermission(datasources.ActionWrite, uidScope)), routing.Wrap(hs.UpdateDataSourceByUID))


### PR DESCRIPTION
**What is this feature?**
This PR changes the required user role for `GET /api/datasources` to allow Editors to call it when RBAC is disabled.

**Why do we need this feature?**
Currently Editors get the `datasources:read` permission by default when RBAC is enabled, thus the previously mentioned endpoint is accessible to them.

**Who is this feature for?**

**Which issue(s) does this PR fix?**:

Fixes #66181

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
