### PR TITLE
Correlations: Track completion rate for adding correlations

### DIFF
--- a/public/app/features/correlations/CorrelationsPage.tsx
+++ b/public/app/features/correlations/CorrelationsPage.tsx
@@ -40,7 +40,15 @@ const loaderWrapper = css`
 
 export default function CorrelationsPage() {
   const navModel = useNavModel('correlations');
-  const [isAdding, setIsAdding] = useState(false);
+  const [isAdding, setIsAddingValue] = useState(false);
+
+  const setIsAdding = (value: boolean) => {
+    setIsAddingValue(value);
+    if (value) {
+      reportInteraction('grafana_correlations_adding_started');
+    }
+  };
+
   const {
     remove,
     get: { execute: fetchCorrelations, ...get },


### PR DESCRIPTION
Adding tracking to when the adding correlation form is shown to track completion rate to get some rough stats about complexity of creating a correlation.

Fixes #63940

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
