### PR TITLE
Chore: Update @grafana/e2e

### DIFF
--- a/e2e/cloud-plugins-suite/azure-monitor.spec.ts
+++ b/e2e/cloud-plugins-suite/azure-monitor.spec.ts
@@ -50,6 +50,7 @@ function provisionAzureMonitorDatasources(datasources: AzureMonitorProvision[]) 
     expectedAlertMessage: 'Successfully connected to all Azure Monitor endpoints',
     // Reduce the timeout from 30s to error faster when an invalid alert message is presented
     timeout: 10000,
+    awaitHealth: true,
   });
 }
 

--- a/packages/grafana-e2e/src/flows/addDataSource.ts
+++ b/packages/grafana-e2e/src/flows/addDataSource.ts
@@ -14,6 +14,7 @@ export interface AddDataSourceConfig {
   skipTlsVerify: boolean;
   type: string;
   timeout?: number;
+  awaitHealth?: boolean;
 }
 
 // @todo this actually returns type `Cypress.Chainable<AddDaaSourceConfig>`
@@ -40,11 +41,14 @@ export const addDataSource = (config?: Partial<AddDataSourceConfig>) => {
     skipTlsVerify,
     type,
     timeout,
+    awaitHealth,
   } = fullConfig;
 
-  e2e()
-    .intercept(/health/)
-    .as('health');
+  if (awaitHealth) {
+    e2e()
+      .intercept(/health/)
+      .as('health');
+  }
 
   e2e().logToConsole('Adding data source with name:', name);
   e2e.pages.AddDataSource.visit();
@@ -80,7 +84,9 @@ export const addDataSource = (config?: Partial<AddDataSourceConfig>) => {
 
   e2e.pages.DataSource.saveAndTest().click();
 
-  e2e().wait('@health', { timeout: timeout ?? e2e.config().defaultCommandTimeout });
+  if (awaitHealth) {
+    e2e().wait('@health', { timeout: timeout ?? e2e.config().defaultCommandTimeout });
+  }
 
   // use the timeout passed in if it exists, otherwise, continue to use the default
   e2e.pages.DataSource.alert()

--- a/packages/grafana-e2e/src/flows/addDataSource.ts
+++ b/packages/grafana-e2e/src/flows/addDataSource.ts
@@ -42,6 +42,10 @@ export const addDataSource = (config?: Partial<AddDataSourceConfig>) => {
     timeout,
   } = fullConfig;
 
+  e2e()
+    .intercept(/health/)
+    .as('health');
+
   e2e().logToConsole('Adding data source with name:', name);
   e2e.pages.AddDataSource.visit();
   e2e.pages.AddDataSource.dataSourcePluginsV2(type)
@@ -75,6 +79,8 @@ export const addDataSource = (config?: Partial<AddDataSourceConfig>) => {
   form();
 
   e2e.pages.DataSource.saveAndTest().click();
+
+  e2e().wait('@health', { timeout: timeout ?? e2e.config().defaultCommandTimeout });
 
   // use the timeout passed in if it exists, otherwise, continue to use the default
   e2e.pages.DataSource.alert()

--- a/packages/grafana-e2e/src/flows/configurePanel.ts
+++ b/packages/grafana-e2e/src/flows/configurePanel.ts
@@ -34,6 +34,7 @@ interface ConfigurePanelOptional {
   panelTitle?: string;
   timeRange?: TimeRangeConfig;
   visualizationName?: string;
+  timeout?: number;
 }
 
 interface ConfigurePanelRequired {
@@ -80,6 +81,7 @@ export const configurePanel = (config: PartialAddPanelConfig | PartialEditPanelC
       timeRange,
       visitDashboardAtStart,
       visualizationName,
+      timeout,
     } = fullConfig;
 
     if (visitDashboardAtStart) {
@@ -158,7 +160,7 @@ export const configurePanel = (config: PartialAddPanelConfig | PartialEditPanelC
     e2e.components.RefreshPicker.runButtonV2().first().click({ force: true });
 
     // Wait for RxJS
-    e2e().wait(500);
+    e2e().wait(timeout ?? e2e.config().defaultCommandTimeout);
 
     if (matchScreenshot) {
       let visualization;


### PR DESCRIPTION
Trying to reduce flakiness of Azure E2E tests by ensuring that the `health` request is intercepted when adding a datasource. Also added support for configuring a custom timeout when adding panels.