### PR TITLE
Revert "Prometheus: Reduce allocations parsing exemplars"

### DIFF
--- a/pkg/tsdb/prometheus/querydata/framing_bench_test.go
+++ b/pkg/tsdb/prometheus/querydata/framing_bench_test.go
@@ -41,7 +41,6 @@ func BenchmarkExemplarJson(b *testing.B) {
 	tCtx, err := setup(true)
 	require.NoError(b, err)
 	b.ResetTimer()
-	b.ReportAllocs()
 	for n := 0; n < b.N; n++ {
 		res := http.Response{
 			StatusCode: 200,

--- a/pkg/util/converter/prom.go
+++ b/pkg/util/converter/prom.go
@@ -228,8 +228,8 @@ func readArrayData(iter *jsoniter.Iterator) backend.DataResponse {
 }
 
 // For consistent ordering read values to an array not a map
-func readLabelsAsPairs(iter *jsoniter.Iterator, pairs [][2]string) [][2]string {
-	pairs = pairs[:0]
+func readLabelsAsPairs(iter *jsoniter.Iterator) [][2]string {
+	pairs := make([][2]string, 0, 10)
 	for k := iter.ReadObject(); k != ""; k = iter.ReadObject() {
 		pairs = append(pairs, [2]string{k, iter.ReadString()})
 	}
@@ -270,7 +270,7 @@ func readLabelsOrExemplars(iter *jsoniter.Iterator) (*data.Frame, [][2]string) {
 
 					case "labels":
 						max := 0
-						for _, pair := range readLabelsAsPairs(iter, pairs) {
+						for _, pair := range readLabelsAsPairs(iter) {
 							k := pair[0]
 							v := pair[1]
 							f, ok := lookup[k]
@@ -305,7 +305,6 @@ func readLabelsOrExemplars(iter *jsoniter.Iterator) (*data.Frame, [][2]string) {
 			}
 		default:
 			v := fmt.Sprintf("%v", iter.Read())
-			pairs = pairs[:0]
 			pairs = append(pairs, [2]string{l1Field, v})
 		}
 	}


### PR DESCRIPTION
Reverts grafana/grafana#58959

when this PR was merged, the snapshot-tests for this code were disabled (they still are in fact):
https://github.com/grafana/grafana/blob/2eed889ab7224e5910155c386e2816e64652157c/pkg/util/converter/prom_test.go#L19-L21

if i enable the tests, then this PR (that is being reverted) causes a regression in the tests.
it's not trivial to see where the problem is, so my preference is to:
1. revert this performance PR
2. enable tests
3. a fixed version of the original PR can be created

WDYT?