### PR TITLE
<Azure Monitor>: Updated loganalytics endpoint url

### DIFF
--- a/pkg/tsdb/azuremonitor/routes.go
+++ b/pkg/tsdb/azuremonitor/routes.go
@@ -32,7 +32,7 @@ var azChinaManagement = types.AzRoute{
 }
 
 var azLogAnalytics = types.AzRoute{
-	URL:     "https://api.loganalytics.io",
+	URL:     "https://api.loganalytics.azure.com",
 	Scopes:  []string{"https://api.loganalytics.io/.default"},
 	Headers: map[string]string{"x-ms-app": "Grafana", "Cache-Control": "public, max-age=60"},
 }


### PR DESCRIPTION


**What is this feature?**

The `api.loganalytics.io` endpoint is being replaced by `api.loganalytics.azure.com`, as mentioned in the Microsoft documentation here: https://learn.microsoft.com/en-us/azure/azure-monitor/logs/api/access-api

When adding the Azure Monitor data source in my Grafana instance running in AKS, it fails to connect to the Azure Log Analytics endpoint. I have configured it to use a user managed identity which has access to the subscription where my log analytics workspace is. The error I get is this:
`Error connecting to Azure Log Analytics endpoint: health check failed: Post "https://api.loganalytics.io/v1/workspaces/f0632cc0-64b7-4adf-8bcb-e25ded18eb1c/query": EOF`

![Error connecting to Azure Log Analytics endpoint: health check failed: Post "https://api.loganalytics.io/v1/workspaces/f0632cc0-64b7-4adf-8bcb-e25ded18eb1c/query": EOF](https://user-images.githubusercontent.com/79976935/231485582-124f6ad1-b545-4a03-acb9-634fc50f22fe.png)


After some digging I found that Grafana uses the `api.loganalytics.io` endpoint. If I execute into the running Grafana pod and try to query the API through this endpoint, I get these errors:
```
$ wget "https://api.loganalytics.io/v1/workspaces/$default_workspace/query?timespan=P1D" --header="Content-Type: application/json" --post-data='{"query": "AzureActivity | limit 1"}' --header="Authorization: Bearer ${token}" --output-document -
ssl_client: api.loganalytics.io: handshake failed: No error information
wget: error getting response: Connection reset by peer
```
However, if I use the same query but change the endpoint to `api.loganalytics.azure.com`, it works and I get a JSON response with data.


**Why do we need this feature?**

As Microsoft mention in their page, the `api.loganalytics.io` endpoint is being replaced with `api.loganalytics.azure.com`.

**Who is this feature for?**

Users who use the Azure Monitor data source in Grafana.



**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
