### PR TITLE
docs: remove confusing singlestat references

### DIFF
--- a/public/app/plugins/panel/stat/README.md
+++ b/public/app/plugins/panel/stat/README.md
@@ -11,7 +11,7 @@ By default, the Stat panel displays one of the following:
 
 The Text mode can be used to control whether the text is displayed or not.
 
-The Stat panel is a replacement for the Singlestat panel, which was deprecated in Grafana v7.0 and removed in Grafana v8.4. Learn more about the now removed Singlestat panel [here](https://grafana.com/docs/grafana/v8.4/visualizations/stat-panel/).
+The Stat panel is a replacement for the Singlestat panel, which was deprecated in Grafana v7.0 and removed in Grafana v8.4.
 
 Read more about Stat panel on the docs page:
 


### PR DESCRIPTION
The removed phrase feels confusing - why would I want to learn more about a removed component? 

Then given the link ends up going to the stat visualization page which replaced singlestat, it seems a redundant link.

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Removes confusing references from the readme for Stat

**Why do we need this feature?**

Currently a user can view stat, singlestat (5.0.0, native, but not), singlestat (2.0.0 deprecated) within the catalog and its all very confusing. 

**Who is this feature for?**

Users of Grafana

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
