### PR TITLE
[v9.5.x] Prometheus: Show initial hint on builder mode when metric lookup disabled

### DIFF
--- a/public/app/plugins/datasource/prometheus/querybuilder/components/MetricSelect.test.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/MetricSelect.test.tsx
@@ -7,7 +7,7 @@ import { DataSourceInstanceSettings, MetricFindValue } from '@grafana/data/src';
 import { PrometheusDatasource } from '../../datasource';
 import { PromOptions } from '../../types';
 
-import { MetricSelect } from './MetricSelect';
+import { MetricSelect, Props } from './MetricSelect';
 
 const instanceSettings = {
   url: 'proxied',
@@ -44,7 +44,7 @@ dataSourceMock.metricFindQuery = jest.fn((query: string) => {
   );
 });
 
-const props = {
+const props: Props = {
   labelsFilters: [],
   datasource: dataSourceMock,
   query: {
@@ -54,6 +54,7 @@ const props = {
   },
   onChange: jest.fn(),
   onGetMetrics: jest.fn().mockResolvedValue(mockValues),
+  metricLookupDisabled: false,
 };
 
 describe('MetricSelect', () => {

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilder.test.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilder.test.tsx
@@ -8,6 +8,7 @@ import {
   LoadingState,
   MutableDataFrame,
   PanelData,
+  QueryHint,
   TimeRange,
 } from '@grafana/data';
 
@@ -227,6 +228,45 @@ describe('PromQueryBuilder', () => {
       />
     );
     expect(await screen.queryByText(EXPLAIN_LABEL_FILTER_CONTENT)).not.toBeInTheDocument();
+  });
+
+  it('renders hint if initial hint provided', async () => {
+    const { datasource } = createDatasource();
+    datasource.getInitHints = (): QueryHint[] => [
+      {
+        label: 'Initial hint',
+        type: 'warning',
+      },
+    ];
+    const props = createProps(datasource);
+    render(
+      <PromQueryBuilder
+        {...props}
+        query={{
+          metric: 'histogram_metric_sum',
+          labels: [],
+          operations: [],
+        }}
+      />
+    );
+    expect(await screen.queryByText('Initial hint')).toBeInTheDocument();
+  });
+
+  it('renders no hint if no initial hint provided', async () => {
+    const { datasource } = createDatasource();
+    datasource.getInitHints = (): QueryHint[] => [];
+    const props = createProps(datasource);
+    render(
+      <PromQueryBuilder
+        {...props}
+        query={{
+          metric: 'histogram_metric_sum',
+          labels: [],
+          operations: [],
+        }}
+      />
+    );
+    expect(await screen.queryByText('Initial hint')).not.toBeInTheDocument();
   });
 
   // <ModernPrometheus>

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilder.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilder.tsx
@@ -208,12 +208,14 @@ export const PromQueryBuilder = React.memo<Props>((props) => {
   }, [datasource, query, withTemplateVariableOptions]);
 
   const lang = { grammar: promqlGrammar, name: 'promql' };
-  const MetricEncyclopedia = config.featureToggles.prometheusMetricEncyclopedia;
+  const isMetricEncyclopediaEnabled = config.featureToggles.prometheusMetricEncyclopedia;
+
+  const initHints = datasource.getInitHints();
 
   return (
     <>
       <EditorRow>
-        {MetricEncyclopedia ? (
+        {isMetricEncyclopediaEnabled && !datasource.lookupsDisabled ? (
           <>
             <Button
               className={styles.button}
@@ -252,6 +254,7 @@ export const PromQueryBuilder = React.memo<Props>((props) => {
             onGetMetrics={onGetMetrics}
             datasource={datasource}
             labelsFilters={query.labels}
+            metricLookupDisabled={datasource.lookupsDisabled}
           />
         )}
         <LabelFilters
@@ -264,6 +267,18 @@ export const PromQueryBuilder = React.memo<Props>((props) => {
           onGetLabelValues={(forLabel) => withTemplateVariableOptions(onGetLabelValues(forLabel))}
         />
       </EditorRow>
+      {initHints.length ? (
+        <div className="query-row-break">
+          <div className="prom-query-field-info text-warning">
+            {initHints[0].label}{' '}
+            {initHints[0].fix ? (
+              <button type="button" className={'text-warning'}>
+                {initHints[0].fix.label}
+              </button>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
       {showExplain && (
         <OperationExplainedBox
           stepNumber={1}


### PR DESCRIPTION
Backport https://github.com/grafana/grafana/commit/08727b7d6cb6200432f6f8fb2ce06c5db12e7410 from https://github.com/grafana/grafana/pull/65827