### PR TITLE
Logs: Use `DataQuery` from @grafana/schema

### DIFF
--- a/packages/grafana-data/src/types/logs.ts
+++ b/packages/grafana-data/src/types/logs.ts
@@ -1,9 +1,10 @@
 import { Observable } from 'rxjs';
 
+import { DataQuery } from '@grafana/schema';
+
 import { Labels } from './data';
 import { DataFrame } from './dataFrame';
 import { DataQueryRequest, DataQueryResponse } from './datasource';
-import { DataQuery } from './query';
 import { AbsoluteTimeRange } from './time';
 export { LogsDedupStrategy, LogsSortOrder } from '@grafana/schema';
 


### PR DESCRIPTION
**What is this feature?**

`DataQuery` imports from `@grafana/data` are marked as deprecated. This PR migrates to `DataQuery` from `@grafana/schema`.
