### PR TITLE
docs revamp: synchronisation planning

### DIFF
--- a/docs/sources/auth/planning/index.md
+++ b/docs/sources/auth/planning/index.md
@@ -178,4 +178,8 @@ Grafana will keep the users in sync by actively querying for any changes. No nee
 
 > **Note:** Available in Grafana version 7.0 and later.
 
-Organization sync happens upon configuration with an Identity Provider. With the proper configuration, the roles defined with the Identity Provider will be mapped to Grafana roles upon logging in for the first time.
+Organization sync is possible with the configuration for each Identity Provider. With the correct configuration, users will be synced from the Identity Provider into the Grafana user database upon logging in.
+
+> **Note:** When syncing users with Organization sync, you don't need to invite them through Grafana.
+
+> **Note:** Currently, only mapping of basic roles can be achieved via Organization sync.

--- a/docs/sources/auth/planning/index.md
+++ b/docs/sources/auth/planning/index.md
@@ -160,8 +160,22 @@ You can assign these roles to users, teams and service accounts.
 
 Moreover, RBAC allows you to create your own custom roles and edit permissions granted by Grafana's basic roles.
 
-## 🚧 Will I need synchronization?
+## User synchronization between Grafana and Identity Providers
 
-### 🚧 Team sync
+When integrating Grafana with an Identity Provider, besides the initial authentication configuration, we might want to consider user base and role synchronization. This will allow the users within a group to share the same configuration, thus preventing setting permissions for each user.
 
-### 🚧 Organization sync
+### Team sync
+
+Team sync lets you set up synchronization between your auth providers teams and teams in Grafana. This enables LDAP, OAuth, or SAML users who are members of certain teams or groups to automatically be added or removed as members of certain teams in Grafana.
+
+Grafana will keep the users in sync by actively querying for any changes. No need to worry to remove the user from accessing Grafana once he has been removed from the Identity Provider. The users will be labeled according to their Identity Provider for easy tracking.
+
+> **Note:** Available in [Grafana Enterprise]({{< relref "../../introduction/grafana-enterprise/" >}}) and [Grafana Cloud Advanced](/docs/grafana-cloud/).
+
+> **Note:** Currently the synchronization only happens when a user logs in, unless LDAP is used with the active background synchronization that was added in Grafana 6.3.
+
+### Organization sync
+
+> **Note:** Available in Grafana version 7.0 and later.
+
+Organization sync happens upon configuration with an Identity Provider. With the proper configuration, the roles defined with the Identity Provider will be mapped to Grafana roles upon logging in for the first time.

--- a/docs/sources/auth/planning/index.md
+++ b/docs/sources/auth/planning/index.md
@@ -166,9 +166,9 @@ When integrating Grafana with an Identity Provider, besides the initial authenti
 
 ### Team sync
 
-Team sync lets you set up synchronization between your auth providers teams and teams in Grafana. This enables LDAP, OAuth, or SAML users who are members of certain teams or groups to automatically be added or removed as members of certain teams in Grafana.
+Team sync lets you set up synchronization between your auth providers teams and teams in Grafana. This enables LDAP, OAuth, or SAML users who are members of certain IdP teams or groups to automatically be added or removed as members of certain teams in Grafana.
 
-Grafana will keep the users in sync by actively querying for any changes. No need to worry to remove the user from accessing Grafana once he has been removed from the Identity Provider. The users will be labeled according to their Identity Provider for easy tracking.
+Grafana will keep users in sync by querying for any IdP team or group changes upon user login, and adding or removing the user from teams accordingly.
 
 > **Note:** Available in [Grafana Enterprise]({{< relref "../../introduction/grafana-enterprise/" >}}) and [Grafana Cloud Advanced](/docs/grafana-cloud/).
 

--- a/docs/sources/auth/planning/index.md
+++ b/docs/sources/auth/planning/index.md
@@ -162,7 +162,7 @@ Moreover, RBAC allows you to create your own custom roles and edit permissions g
 
 ## User synchronization between Grafana and Identity Providers
 
-When integrating Grafana with an Identity Provider, besides the initial authentication configuration, we might want to consider user base and role synchronization. This will allow the users within a group to share the same configuration, thus preventing setting permissions for each user.
+When connecting Grafana to an Identity Provider, it's important to think beyond just the initial authentication setup. You should also think about synchronizing user bases and roles. Doing so will enable users within a group to share the same configuration, so you won't have to set individual permissions for each user.
 
 ### Team sync
 

--- a/docs/sources/auth/planning/index.md
+++ b/docs/sources/auth/planning/index.md
@@ -166,19 +166,21 @@ When integrating Grafana with an Identity Provider, besides the initial authenti
 
 ### Team sync
 
-Team sync lets you set up synchronization between your auth providers teams and teams in Grafana. This enables LDAP, OAuth, or SAML users who are members of certain IdP teams or groups to automatically be added or removed as members of certain teams in Grafana.
-
-Grafana will keep users in sync by querying for any IdP team or group changes upon user login, and adding or removing the user from teams accordingly.
+Team sync is a feature that allows you to synchronize teams or groups from your authentication provider with teams in Grafana. This means that users who are part of specific teams or groups in LDAP, OAuth, or SAML will be automatically added or removed as members of corresponding teams in Grafana. Whenever a user logs in, Grafana will check for any changes in the teams or groups of the authentication provider and update the user's teams in Grafana accordingly. This makes it easy to manage user permissions across multiple systems.
 
 > **Note:** Available in [Grafana Enterprise]({{< relref "../../introduction/grafana-enterprise/" >}}) and [Grafana Cloud Advanced](/docs/grafana-cloud/).
 
-> **Note:** Currently the synchronization only happens when a user logs in, unless LDAP is used with the active background synchronization that was added in Grafana 6.3.
+> **Note:** Currently, team synchronization occurs only when a user logs in. However, if you are using LDAP, it is possible to enable active background synchronization, which was added to Grafana 6.3. This allows for the continuous synchronization of teams.
 
 ### Organization sync
 
 > **Note:** Available in Grafana version 7.0 and later.
 
-Organization sync is possible with the configuration for each Identity Provider. With the correct configuration, users will be synced from the Identity Provider into the Grafana user database upon logging in.
+Organization sync is the process of binding all the users from an organization in Grafana. This allows to delegate the role of managing users to the IdP. This way, there's no need to manage user access from Grafana since the IdP will be queried eveytime a new user tries to log in.
+
+Organization sync allows mapping users from IdP groups to Grafana organizations. It works similarly as role sync, but in addition allows specifying Grafana organization that a user who belongs to a specific IdP group should be added to. This feature can only be used in self-hosted Grafana instances, as Cloud Grafana instances are limited to one organization.
+
+> **Note:** Organization sync is currently only supported for SAML and LDAP.
 
 > **Note:** When syncing users with Organization sync, you don't need to invite them through Grafana.
 


### PR DESCRIPTION
**What is this feature?**

This adds planning documentation for the org and team synchronization.

**Special notes for your reviewer:**

In order to run the documentation locally using
```
$ cd docs
$ make docs
```
After the docker image is running, the service should be available at http://localhost:3002

@IevaVasiljeva 🙏 Please, can you help me corroborate the information is accurate? I want to make sure I understand the organization sync perfectly.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
