### PR TITLE
Alerting: Fix creating recording rule when having multiple datasources

### DIFF
--- a/public/app/features/alerting/unified/AlertsFolderView.test.tsx
+++ b/public/app/features/alerting/unified/AlertsFolderView.test.tsx
@@ -58,6 +58,7 @@ describe('AlertsFolderView tests', () => {
             mockCombinedRule({ name: 'Test Alert 2' }),
             mockCombinedRule({ name: 'Test Alert 3' }),
           ],
+          totals: {},
         },
         {
           name: 'group2',
@@ -66,6 +67,7 @@ describe('AlertsFolderView tests', () => {
             mockCombinedRule({ name: 'Test Alert 5' }),
             mockCombinedRule({ name: 'Test Alert 6' }),
           ],
+          totals: {},
         },
       ],
     };
@@ -104,6 +106,7 @@ describe('AlertsFolderView tests', () => {
             mockCombinedRule({ name: 'Test Alert from other folder 1' }),
             mockCombinedRule({ name: 'Test Alert from other folder 2' }),
           ],
+          totals: {},
         },
       ],
     };
@@ -132,6 +135,7 @@ describe('AlertsFolderView tests', () => {
         {
           name: 'default',
           rules: [mockCombinedRule({ name: 'CPU Alert' }), mockCombinedRule({ name: 'RAM usage alert' })],
+          totals: {},
         },
       ],
     };
@@ -166,6 +170,7 @@ describe('AlertsFolderView tests', () => {
             mockCombinedRule({ name: 'CPU Alert', labels: {} }),
             mockCombinedRule({ name: 'RAM usage alert', labels: { severity: 'critical' } }),
           ],
+          totals: {},
         },
       ],
     };

--- a/public/app/features/alerting/unified/PanelAlertTabContent.test.tsx
+++ b/public/app/features/alerting/unified/PanelAlertTabContent.test.tsx
@@ -325,6 +325,8 @@ describe('PanelAlertTabContent', () => {
         dashboardUID: dashboard.uid,
         panelId: panel.id,
       },
+      undefined,
+      undefined,
       undefined
     );
   });

--- a/public/app/features/alerting/unified/PanelAlertTabContent.test.tsx
+++ b/public/app/features/alerting/unified/PanelAlertTabContent.test.tsx
@@ -319,10 +319,14 @@ describe('PanelAlertTabContent', () => {
         panelId: panel.id,
       }
     );
-    expect(mocks.api.fetchRules).toHaveBeenCalledWith(GRAFANA_RULES_SOURCE_NAME, {
-      dashboardUID: dashboard.uid,
-      panelId: panel.id,
-    });
+    expect(mocks.api.fetchRules).toHaveBeenCalledWith(
+      GRAFANA_RULES_SOURCE_NAME,
+      {
+        dashboardUID: dashboard.uid,
+        panelId: panel.id,
+      },
+      undefined
+    );
   });
 
   it('Update NewRuleFromPanel button url when template changes', async () => {

--- a/public/app/features/alerting/unified/RedirectToRuleViewer.test.tsx
+++ b/public/app/features/alerting/unified/RedirectToRuleViewer.test.tsx
@@ -119,6 +119,7 @@ const mockedRules: CombinedRule[] = [
     group: {
       name: 'test',
       rules: [],
+      totals: {},
     },
     promRule: {
       health: 'ok',
@@ -150,6 +151,7 @@ const mockedRules: CombinedRule[] = [
     group: {
       name: 'test',
       rules: [],
+      totals: {},
     },
     promRule: {
       health: 'ok',

--- a/public/app/features/alerting/unified/RedirectToRuleViewer.test.tsx
+++ b/public/app/features/alerting/unified/RedirectToRuleViewer.test.tsx
@@ -140,6 +140,7 @@ const mockedRules: CombinedRule[] = [
         readOnly: false,
       },
     },
+    instanceTotals: {},
   },
   {
     name: 'Cloud test alert',
@@ -170,5 +171,6 @@ const mockedRules: CombinedRule[] = [
         readOnly: false,
       },
     },
+    instanceTotals: {},
   },
 ];

--- a/public/app/features/alerting/unified/RuleList.tsx
+++ b/public/app/features/alerting/unified/RuleList.tsx
@@ -112,7 +112,7 @@ const RuleList = withErrorBoundary(
                     {expandAll ? 'Collapse all' : 'Expand all'}
                   </Button>
                 )}
-                <RuleStats namespaces={filteredNamespaces} includeTotal />
+                <RuleStats namespaces={filteredNamespaces} />
               </div>
               <Stack direction="row" gap={0.5}>
                 {canReadProvisioning && (

--- a/public/app/features/alerting/unified/RuleList.tsx
+++ b/public/app/features/alerting/unified/RuleList.tsx
@@ -72,17 +72,18 @@ const RuleList = withErrorBoundary(
     );
     const allPromEmpty = promRequests.every(([_, state]) => state.dispatched && state?.result?.length === 0);
 
+    const limitAlerts = hasActiveFilters ? undefined : LIMIT_ALERTS;
     // Trigger data refresh only when the RULE_LIST_POLL_INTERVAL_MS elapsed since the previous load FINISHED
     const [_, fetchRules] = useAsyncFn(async () => {
       if (!loading) {
-        await dispatch(fetchAllPromAndRulerRulesAction(false, { limitAlerts: LIMIT_ALERTS }));
+        await dispatch(fetchAllPromAndRulerRulesAction(false, { limitAlerts }));
       }
-    }, [loading]);
+    }, [loading, limitAlerts, dispatch]);
 
     // fetch rules, then poll every RULE_LIST_POLL_INTERVAL_MS
     useEffect(() => {
-      dispatch(fetchAllPromAndRulerRulesAction(false, { limitAlerts: LIMIT_ALERTS }));
-    }, [dispatch]);
+      dispatch(fetchAllPromAndRulerRulesAction(false, { limitAlerts }));
+    }, [dispatch, limitAlerts]);
     useInterval(fetchRules, RULE_LIST_POLL_INTERVAL_MS);
 
     // Show splash only when we loaded all of the data sources and none of them has alerts

--- a/public/app/features/alerting/unified/RuleList.tsx
+++ b/public/app/features/alerting/unified/RuleList.tsx
@@ -15,6 +15,7 @@ import { CombinedRuleNamespace } from '../../../types/unified-alerting';
 import { LogMessages } from './Analytics';
 import { AlertingPageWrapper } from './components/AlertingPageWrapper';
 import { NoRulesSplash } from './components/rules/NoRulesCTA';
+import { INSTANCES_DISPLAY_LIMIT } from './components/rules/RuleDetails';
 import { RuleListErrors } from './components/rules/RuleListErrors';
 import { RuleListGroupView } from './components/rules/RuleListGroupView';
 import { RuleListStateView } from './components/rules/RuleListStateView';
@@ -33,6 +34,9 @@ const VIEWS = {
   groups: RuleListGroupView,
   state: RuleListStateView,
 };
+
+// make sure we ask for 1 more so we show the "show x more" button
+const LIMIT_ALERTS = INSTANCES_DISPLAY_LIMIT + 1;
 
 const RuleList = withErrorBoundary(
   () => {
@@ -71,13 +75,13 @@ const RuleList = withErrorBoundary(
     // Trigger data refresh only when the RULE_LIST_POLL_INTERVAL_MS elapsed since the previous load FINISHED
     const [_, fetchRules] = useAsyncFn(async () => {
       if (!loading) {
-        await dispatch(fetchAllPromAndRulerRulesAction());
+        await dispatch(fetchAllPromAndRulerRulesAction(false, { limitAlerts: LIMIT_ALERTS }));
       }
     }, [loading]);
 
     // fetch rules, then poll every RULE_LIST_POLL_INTERVAL_MS
     useEffect(() => {
-      dispatch(fetchAllPromAndRulerRulesAction());
+      dispatch(fetchAllPromAndRulerRulesAction(false, { limitAlerts: LIMIT_ALERTS }));
     }, [dispatch]);
     useInterval(fetchRules, RULE_LIST_POLL_INTERVAL_MS);
 

--- a/public/app/features/alerting/unified/RuleList.tsx
+++ b/public/app/features/alerting/unified/RuleList.tsx
@@ -73,17 +73,18 @@ const RuleList = withErrorBoundary(
     const allPromEmpty = promRequests.every(([_, state]) => state.dispatched && state?.result?.length === 0);
 
     const limitAlerts = hasActiveFilters ? undefined : LIMIT_ALERTS;
+    const matchers = '';
     // Trigger data refresh only when the RULE_LIST_POLL_INTERVAL_MS elapsed since the previous load FINISHED
     const [_, fetchRules] = useAsyncFn(async () => {
       if (!loading) {
-        await dispatch(fetchAllPromAndRulerRulesAction(false, { limitAlerts }));
+        await dispatch(fetchAllPromAndRulerRulesAction(false, { limitAlerts, matchers }));
       }
-    }, [loading, limitAlerts, dispatch]);
+    }, [loading, limitAlerts, matchers, dispatch]);
 
     // fetch rules, then poll every RULE_LIST_POLL_INTERVAL_MS
     useEffect(() => {
-      dispatch(fetchAllPromAndRulerRulesAction(false, { limitAlerts }));
-    }, [dispatch, limitAlerts]);
+      dispatch(fetchAllPromAndRulerRulesAction(false, { limitAlerts, matchers }));
+    }, [dispatch, limitAlerts, matchers]);
     useInterval(fetchRules, RULE_LIST_POLL_INTERVAL_MS);
 
     // Show splash only when we loaded all of the data sources and none of them has alerts

--- a/public/app/features/alerting/unified/RuleList.tsx
+++ b/public/app/features/alerting/unified/RuleList.tsx
@@ -9,6 +9,7 @@ import { logInfo } from '@grafana/runtime';
 import { Button, LinkButton, useStyles2, withErrorBoundary } from '@grafana/ui';
 import { useQueryParams } from 'app/core/hooks/useQueryParams';
 import { useDispatch } from 'app/types';
+import { GrafanaAlertState } from 'app/types/unified-alerting-dto';
 
 import { CombinedRuleNamespace } from '../../../types/unified-alerting';
 
@@ -74,17 +75,18 @@ const RuleList = withErrorBoundary(
 
     const limitAlerts = hasActiveFilters ? undefined : LIMIT_ALERTS;
     const matchers = '';
+    const state: GrafanaAlertState[] = useMemo(() => [], []);
     // Trigger data refresh only when the RULE_LIST_POLL_INTERVAL_MS elapsed since the previous load FINISHED
     const [_, fetchRules] = useAsyncFn(async () => {
       if (!loading) {
-        await dispatch(fetchAllPromAndRulerRulesAction(false, { limitAlerts, matchers }));
+        await dispatch(fetchAllPromAndRulerRulesAction(false, { limitAlerts, matchers, state }));
       }
-    }, [loading, limitAlerts, matchers, dispatch]);
+    }, [loading, limitAlerts, matchers, state, dispatch]);
 
     // fetch rules, then poll every RULE_LIST_POLL_INTERVAL_MS
     useEffect(() => {
-      dispatch(fetchAllPromAndRulerRulesAction(false, { limitAlerts, matchers }));
-    }, [dispatch, limitAlerts, matchers]);
+      dispatch(fetchAllPromAndRulerRulesAction(false, { limitAlerts, matchers, state }));
+    }, [dispatch, limitAlerts, matchers, state]);
     useInterval(fetchRules, RULE_LIST_POLL_INTERVAL_MS);
 
     // Show splash only when we loaded all of the data sources and none of them has alerts

--- a/public/app/features/alerting/unified/RuleViewer.tsx
+++ b/public/app/features/alerting/unified/RuleViewer.tsx
@@ -199,7 +199,11 @@ export function RuleViewer({ match }: RuleViewerProps) {
           </div>
         </div>
         <div>
-          <RuleDetailsMatchingInstances rule={rule} pagination={{ itemsPerPage: DEFAULT_PER_PAGE_PAGINATION }} />
+          <RuleDetailsMatchingInstances
+            rule={rule}
+            pagination={{ itemsPerPage: DEFAULT_PER_PAGE_PAGINATION }}
+            enableFiltering
+          />
         </div>
       </RuleViewerLayoutContent>
       <Collapse

--- a/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
@@ -162,7 +162,7 @@ function FolderGroupAndEvaluationInterval({
     rulesSource: GRAFANA_RULES_SOURCE_NAME,
     groups: [],
   };
-  const emptyGroup: CombinedRuleGroup = { name: groupName, interval: evaluateEvery, rules: [] };
+  const emptyGroup: CombinedRuleGroup = { name: groupName, interval: evaluateEvery, rules: [], totals: {} };
 
   return (
     <div>

--- a/public/app/features/alerting/unified/components/rule-editor/RecordingRuleEditor.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/RecordingRuleEditor.tsx
@@ -57,17 +57,19 @@ export const RecordingRuleEditor: FC<RecordingRuleEditorProps> = ({
 
   const handleChangedQuery = (changedQuery: DataQuery) => {
     const query = queries[0];
+    const dataSourceId = getDataSourceSrv().getInstanceSettings(dataSourceName)?.uid;
 
-    if (!isPromOrLokiQuery(query.model)) {
+    if (!isPromOrLokiQuery(changedQuery) || !dataSourceId) {
       return;
     }
 
-    const expr = query.model.expr;
+    const expr = changedQuery.expr;
 
     const merged = {
       ...query,
       refId: changedQuery.refId,
-      queryType: query.model.queryType ?? '',
+      queryType: changedQuery.queryType ?? '',
+      datasourceUid: dataSourceId,
       expr,
       model: {
         refId: changedQuery.refId,

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/AlertType.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/AlertType.tsx
@@ -67,6 +67,8 @@ export const AlertType = ({ editingExistingRule }: Props) => {
                   onChange={(ds: DataSourceInstanceSettings) => {
                     // reset location if switching data sources, as different rules source will have different groups and namespaces
                     setValue('location', undefined);
+                    // reset expression as they don't need to persist after changing datasources
+                    setValue('expression', '');
                     onChange(ds?.name ?? null);
                   }}
                 />

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
@@ -198,19 +198,26 @@ export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange }: P
   useEffect(() => {
     setPanelData({});
     if (type === RuleFormType.cloudRecording) {
+      const expr = getValues('expression');
+      const datasourceUid =
+        (editingExistingRule && getDataSourceSrv().getInstanceSettings(dataSourceName)?.uid) ||
+        recordingRuleDefaultDatasource.uid;
+
       const defaultQuery = {
         refId: 'A',
-        datasourceUid: recordingRuleDefaultDatasource.uid,
+        datasourceUid,
         queryType: '',
         relativeTimeRange: getDefaultRelativeTimeRange(),
+        expr,
         model: {
           refId: 'A',
           hide: false,
+          expr,
         },
       };
-      dispatch(setRecordingRulesQueries({ recordingRuleQueries: [defaultQuery], expression: getValues('expression') }));
+      dispatch(setRecordingRulesQueries({ recordingRuleQueries: [defaultQuery], expression: expr }));
     }
-  }, [type, recordingRuleDefaultDatasource, editingExistingRule, getValues]);
+  }, [type, recordingRuleDefaultDatasource, editingExistingRule, getValues, dataSourceName]);
 
   const onDuplicateQuery = useCallback((query: AlertQuery) => {
     dispatch(duplicateQuery(query));

--- a/public/app/features/alerting/unified/components/rules/AlertInstanceStateFilter.tsx
+++ b/public/app/features/alerting/unified/components/rules/AlertInstanceStateFilter.tsx
@@ -27,8 +27,8 @@ export const AlertInstanceStateFilter = ({
 
   const getOptionComponent = (state: InstanceStateFilter) => {
     return function InstanceStateCounter() {
-      return itemPerStateStats && itemPerStateStats[state.toLowerCase()] ? (
-        <Tag name={itemPerStateStats[state.toLowerCase()].toFixed(0)} colorIndex={9} className={styles.tag} />
+      return itemPerStateStats && itemPerStateStats[state] ? (
+        <Tag name={itemPerStateStats[state].toFixed(0)} colorIndex={9} className={styles.tag} />
       ) : null;
     };
   };

--- a/public/app/features/alerting/unified/components/rules/AlertInstanceStateFilter.tsx
+++ b/public/app/features/alerting/unified/components/rules/AlertInstanceStateFilter.tsx
@@ -27,8 +27,8 @@ export const AlertInstanceStateFilter = ({
 
   const getOptionComponent = (state: InstanceStateFilter) => {
     return function InstanceStateCounter() {
-      return itemPerStateStats && itemPerStateStats[state] ? (
-        <Tag name={itemPerStateStats[state].toFixed(0)} colorIndex={9} className={styles.tag} />
+      return itemPerStateStats && itemPerStateStats[state.toLowerCase()] ? (
+        <Tag name={itemPerStateStats[state.toLowerCase()].toFixed(0)} colorIndex={9} className={styles.tag} />
       ) : null;
     };
   };

--- a/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.test.tsx
@@ -60,7 +60,7 @@ describe('EditGroupModal', () => {
     const namespace = mockCombinedRuleNamespace({
       name: 'my-alerts',
       rulesSource: mockDataSource(),
-      groups: [{ name: 'default-group', interval: '90s', rules: [] }],
+      groups: [{ name: 'default-group', interval: '90s', rules: [], totals: {} }],
     });
 
     const group = namespace.groups[0];
@@ -100,7 +100,9 @@ describe('EditGroupModal component on cloud alert rules', () => {
     const promNs = mockCombinedRuleNamespace({
       name: 'prometheus-ns',
       rulesSource: promDsSettings,
-      groups: [{ name: 'default-group', interval: '90s', rules: [alertingRule, recordingRule1, recordingRule2] }],
+      groups: [
+        { name: 'default-group', interval: '90s', rules: [alertingRule, recordingRule1, recordingRule2], totals: {} },
+      ],
     });
 
     const group = promNs.groups[0];
@@ -121,7 +123,7 @@ describe('EditGroupModal component on cloud alert rules', () => {
     const promNs = mockCombinedRuleNamespace({
       name: 'prometheus-ns',
       rulesSource: promDsSettings,
-      groups: [{ name: 'default-group', interval: '90s', rules: [recordingRule1, recordingRule2] }],
+      groups: [{ name: 'default-group', interval: '90s', rules: [recordingRule1, recordingRule2], totals: {} }],
     });
 
     const group = promNs.groups[0];
@@ -154,6 +156,7 @@ describe('EditGroupModal component on grafana-managed alert rules', () => {
             rulerRule: mockRulerAlertingRule({ alert: 'high-memory' }),
           }),
         ],
+        totals: {},
       },
     ],
   };

--- a/public/app/features/alerting/unified/components/rules/RuleDetails.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleDetails.tsx
@@ -25,7 +25,7 @@ interface Props {
 // The limit is set to 15 in order to upkeep the good performance
 // and to encourage users to go to the rule details page to see the rest of the instances
 // We don't want to paginate the instances list on the alert list page
-const INSTANCES_DISPLAY_LIMIT = 15;
+export const INSTANCES_DISPLAY_LIMIT = 15;
 
 export const RuleDetails = ({ rule }: Props) => {
   const styles = useStyles2(getStyles);

--- a/public/app/features/alerting/unified/components/rules/RuleDetailsMatchingInstances.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleDetailsMatchingInstances.test.tsx
@@ -32,7 +32,7 @@ describe('RuleDetailsMatchingInstances', () => {
     it('For Grafana Managed rules instances filter should contain five states', () => {
       const rule = mockCombinedRule();
 
-      render(<RuleDetailsMatchingInstances rule={rule} />);
+      render(<RuleDetailsMatchingInstances rule={rule} enableFiltering />);
 
       const stateFilter = ui.stateFilter.get();
       expect(stateFilter).toBeInTheDocument();
@@ -69,7 +69,7 @@ describe('RuleDetailsMatchingInstances', () => {
         [GrafanaAlertState.Error]: ui.grafanaStateButton.error,
       };
 
-      render(<RuleDetailsMatchingInstances rule={rule} />);
+      render(<RuleDetailsMatchingInstances rule={rule} enableFiltering />);
 
       await userEvent.click(buttons[state].get());
 
@@ -82,7 +82,7 @@ describe('RuleDetailsMatchingInstances', () => {
         namespace: mockPromNamespace(),
       });
 
-      render(<RuleDetailsMatchingInstances rule={rule} />);
+      render(<RuleDetailsMatchingInstances rule={rule} enableFiltering />);
 
       const stateFilter = ui.stateFilter.get();
       expect(stateFilter).toBeInTheDocument();
@@ -108,7 +108,7 @@ describe('RuleDetailsMatchingInstances', () => {
           }),
         });
 
-        render(<RuleDetailsMatchingInstances rule={rule} />);
+        render(<RuleDetailsMatchingInstances rule={rule} enableFiltering />);
 
         await userEvent.click(ui.cloudStateButton[state].get());
 

--- a/public/app/features/alerting/unified/components/rules/RuleDetailsMatchingInstances.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleDetailsMatchingInstances.test.tsx
@@ -122,7 +122,7 @@ describe('RuleDetailsMatchingInstances', () => {
 function mockPromNamespace(): CombinedRuleNamespace {
   return {
     rulesSource: mockDataSource(),
-    groups: [{ name: 'Prom rules group', rules: [] }],
+    groups: [{ name: 'Prom rules group', rules: [], totals: {} }],
     name: 'Prometheus-test',
   };
 }

--- a/public/app/features/alerting/unified/components/rules/RuleDetailsMatchingInstances.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleDetailsMatchingInstances.tsx
@@ -1,5 +1,5 @@
 import { css, cx } from '@emotion/css';
-import { countBy } from 'lodash';
+import { sum } from 'lodash';
 import React, { useMemo, useState } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
@@ -52,7 +52,7 @@ function ShowMoreInstances(props: { ruleViewPageLink: string; stats: ShowMoreSta
 
 export function RuleDetailsMatchingInstances(props: Props): JSX.Element | null {
   const {
-    rule: { promRule, namespace },
+    rule: { promRule, namespace, instanceTotals },
     itemsDisplayLimit = Number.POSITIVE_INFINITY,
     pagination,
   } = props;
@@ -82,17 +82,17 @@ export function RuleDetailsMatchingInstances(props: Props): JSX.Element | null {
 
   const visibleInstances = alerts.slice(0, itemsDisplayLimit);
 
-  const countAllByState = countBy(promRule.alerts, (alert) => mapStateWithReasonToBaseState(alert.state));
-  const hiddenItemsCount = alerts.length - visibleInstances.length;
+  const totalInstancesCount = sum(Object.values(instanceTotals));
+  const hiddenInstancesCount = totalInstancesCount - visibleInstances.length;
 
   const stats: ShowMoreStats = {
-    totalItemsCount: alerts.length,
+    totalItemsCount: totalInstancesCount,
     visibleItemsCount: visibleInstances.length,
   };
 
   const ruleViewPageLink = createViewLink(namespace.rulesSource, props.rule, location.pathname + location.search);
 
-  const footerRow = hiddenItemsCount ? (
+  const footerRow = hiddenInstancesCount ? (
     <ShowMoreInstances stats={stats} ruleViewPageLink={ruleViewPageLink} />
   ) : undefined;
 
@@ -111,7 +111,7 @@ export function RuleDetailsMatchingInstances(props: Props): JSX.Element | null {
             filterType={stateFilterType}
             stateFilter={alertState}
             onStateFilterChange={setAlertState}
-            itemPerStateStats={countAllByState}
+            itemPerStateStats={instanceTotals}
           />
         </div>
       </div>

--- a/public/app/features/alerting/unified/components/rules/RuleListGroupView.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleListGroupView.test.tsx
@@ -116,6 +116,7 @@ function getGrafanaNamespace(): CombinedRuleNamespace {
       {
         name: 'default',
         rules: [mockCombinedRule()],
+        totals: {},
       },
     ],
   };
@@ -129,6 +130,7 @@ function getCloudNamespace(): CombinedRuleNamespace {
       {
         name: 'Prom group',
         rules: [mockCombinedRule()],
+        totals: {},
       },
     ],
   };

--- a/public/app/features/alerting/unified/components/rules/RuleState.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleState.tsx
@@ -30,7 +30,7 @@ export const RuleState = ({ rule, isDeleting, isCreating, isPaused }: Props) => 
       promRule.state !== PromAlertingRuleState.Inactive
     ) {
       // find earliest alert
-      const firstActiveAt = getFirstActiveAt(promRule);
+      const firstActiveAt = promRule.activeAt ? new Date(promRule.activeAt) : getFirstActiveAt(promRule);
 
       // calculate time elapsed from earliest alert
       if (firstActiveAt) {

--- a/public/app/features/alerting/unified/components/rules/RuleStats.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleStats.tsx
@@ -101,6 +101,10 @@ function getComponentsFromStats(stats: Partial<Record<AlertInstanceState | 'paus
     statsComponents.push(<Badge color="red" key="errors" text={`${stats.error} errors`} />);
   }
 
+  if (stats.nodata) {
+    statsComponents.push(<Badge color="blue" key="nodata" text={`${stats.nodata} no data`} />);
+  }
+
   if (stats[AlertInstanceState.Pending]) {
     statsComponents.push(
       <Badge color={'orange'} key="pending" text={`${stats[AlertInstanceState.Pending]} pending`} />

--- a/public/app/features/alerting/unified/components/rules/RuleStats.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleStats.tsx
@@ -1,4 +1,4 @@
-import { sum } from 'lodash';
+import { isUndefined, omitBy, sum } from 'lodash';
 import pluralize from 'pluralize';
 import React, { Fragment } from 'react';
 
@@ -12,7 +12,6 @@ interface Props {
 }
 
 const emptyStats = {
-  total: 0,
   recording: 0,
   alerting: 0,
   [PromAlertingRuleState.Pending]: 0,
@@ -24,16 +23,19 @@ const emptyStats = {
 export const RuleStats = ({ namespaces }: Props) => {
   const stats = { ...emptyStats };
 
+  // sum all totals for all namespaces
+  namespaces.forEach(({ groups }) => {
+    groups.forEach((group) => {
+      const groupTotals = omitBy(group.totals, isUndefined);
+      for (let key in groupTotals) {
+        // @ts-ignore
+        stats[key] += groupTotals[key];
+      }
+    });
+  });
+
   const statsComponents = getComponentsFromStats(stats);
   const hasStats = Boolean(statsComponents.length);
-
-  // sum all totals for all namespaces
-  namespaces.forEach(({ totals }) => {
-    for (let key in totals) {
-      // @ts-ignore
-      stats[key] += totals[key];
-    }
-  });
 
   const total = sum(Object.values(stats));
 

--- a/public/app/features/alerting/unified/components/rules/RuleStats.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleStats.tsx
@@ -6,7 +6,7 @@ import { Stack } from '@grafana/experimental';
 import { Badge } from '@grafana/ui';
 import {
   AlertGroupTotals,
-  AlertInstanceState,
+  AlertInstanceTotalState,
   CombinedRuleGroup,
   CombinedRuleNamespace,
 } from 'app/types/unified-alerting';
@@ -90,11 +90,14 @@ export const RuleGroupStats = ({ group }: RuleGroupStatsProps) => {
     </Stack>
   );
 };
-function getComponentsFromStats(stats: Partial<Record<AlertInstanceState | 'paused' | 'recording', number>>) {
+
+export function getComponentsFromStats(
+  stats: Partial<Record<AlertInstanceTotalState | 'paused' | 'recording', number>>
+) {
   const statsComponents: React.ReactNode[] = [];
 
-  if (stats[AlertInstanceState.Alerting]) {
-    statsComponents.push(<Badge color="red" key="firing" text={`${stats[AlertInstanceState.Alerting]} firing`} />);
+  if (stats[AlertInstanceTotalState.Alerting]) {
+    statsComponents.push(<Badge color="red" key="firing" text={`${stats[AlertInstanceTotalState.Alerting]} firing`} />);
   }
 
   if (stats.error) {
@@ -105,20 +108,26 @@ function getComponentsFromStats(stats: Partial<Record<AlertInstanceState | 'paus
     statsComponents.push(<Badge color="blue" key="nodata" text={`${stats.nodata} no data`} />);
   }
 
-  if (stats[AlertInstanceState.Pending]) {
+  if (stats[AlertInstanceTotalState.Pending]) {
     statsComponents.push(
-      <Badge color={'orange'} key="pending" text={`${stats[AlertInstanceState.Pending]} pending`} />
+      <Badge color={'orange'} key="pending" text={`${stats[AlertInstanceTotalState.Pending]} pending`} />
     );
   }
 
-  if (stats[AlertInstanceState.Normal] && stats.paused) {
+  if (stats[AlertInstanceTotalState.Normal] && stats.paused) {
     statsComponents.push(
-      <Badge color="green" key="paused" text={`${stats[AlertInstanceState.Normal]} normal (${stats.paused} paused)`} />
+      <Badge
+        color="green"
+        key="paused"
+        text={`${stats[AlertInstanceTotalState.Normal]} normal (${stats.paused} paused)`}
+      />
     );
   }
 
-  if (stats[AlertInstanceState.Normal] && !stats.paused) {
-    statsComponents.push(<Badge color="green" key="inactive" text={`${stats[AlertInstanceState.Normal]} normal`} />);
+  if (stats[AlertInstanceTotalState.Normal] && !stats.paused) {
+    statsComponents.push(
+      <Badge color="green" key="inactive" text={`${stats[AlertInstanceTotalState.Normal]} normal`} />
+    );
   }
 
   if (stats.recording) {

--- a/public/app/features/alerting/unified/components/rules/RuleStats.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleStats.tsx
@@ -4,21 +4,28 @@ import React, { Fragment } from 'react';
 
 import { Stack } from '@grafana/experimental';
 import { Badge } from '@grafana/ui';
-import { AlertInstanceState, CombinedRuleGroup, CombinedRuleNamespace } from 'app/types/unified-alerting';
+import {
+  AlertGroupTotals,
+  AlertInstanceState,
+  CombinedRuleGroup,
+  CombinedRuleNamespace,
+} from 'app/types/unified-alerting';
 import { PromAlertingRuleState } from 'app/types/unified-alerting-dto';
 
 interface Props {
   namespaces: CombinedRuleNamespace[];
 }
 
-const emptyStats = {
+// All available states for a rule need to be initialized to prevent NaN values when adding a number and undefined
+const emptyStats: Required<AlertGroupTotals> = {
   recording: 0,
   alerting: 0,
   [PromAlertingRuleState.Pending]: 0,
   [PromAlertingRuleState.Inactive]: 0,
   paused: 0,
   error: 0,
-} as const;
+  nodata: 0,
+};
 
 export const RuleStats = ({ namespaces }: Props) => {
   const stats = { ...emptyStats };

--- a/public/app/features/alerting/unified/components/rules/RulesGroup.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/RulesGroup.test.tsx
@@ -62,6 +62,7 @@ describe('Rules group tests', () => {
     const group: CombinedRuleGroup = {
       name: 'TestGroup',
       rules: [mockCombinedRule()],
+      totals: {},
     };
 
     const namespace: CombinedRuleNamespace = {
@@ -89,6 +90,7 @@ describe('Rules group tests', () => {
     const group: CombinedRuleGroup = {
       name: 'TestGroup',
       rules: [mockCombinedRule()],
+      totals: {},
     };
 
     const namespace: CombinedRuleNamespace = {
@@ -147,6 +149,7 @@ describe('Rules group tests', () => {
     const group: CombinedRuleGroup = {
       name: 'TestGroup',
       rules: [mockCombinedRule()],
+      totals: {},
     };
 
     const namespace: CombinedRuleNamespace = {

--- a/public/app/features/alerting/unified/components/rules/RulesGroup.tsx
+++ b/public/app/features/alerting/unified/components/rules/RulesGroup.tsx
@@ -23,7 +23,7 @@ import { RuleLocation } from '../RuleLocation';
 import { ActionIcon } from './ActionIcon';
 import { EditCloudGroupModal } from './EditRuleGroupModal';
 import { ReorderCloudGroupModal } from './ReorderRuleGroupModal';
-import { RuleStats } from './RuleStats';
+import { RuleGroupStats } from './RuleStats';
 import { RulesTable } from './RulesTable';
 
 type ViewMode = 'grouped' | 'list';
@@ -214,7 +214,7 @@ export const RulesGroup = React.memo(({ group, namespace, expandAll, viewMode }:
         </h6>
         <div className={styles.spacer} />
         <div className={styles.headerStats}>
-          <RuleStats group={group} />
+          <RuleGroupStats group={group} />
         </div>
         {isProvisioned && (
           <>

--- a/public/app/features/alerting/unified/hooks/useCombinedRuleNamespaces.test.ts
+++ b/public/app/features/alerting/unified/hooks/useCombinedRuleNamespaces.test.ts
@@ -8,22 +8,26 @@ describe('flattenGrafanaManagedRules', () => {
     const ungroupedGroup1 = {
       name: 'my-rule',
       rules: [{ name: 'my-rule' }],
+      totals: {},
     } as CombinedRuleGroup;
 
     const ungroupedGroup2 = {
       name: 'another-rule',
       rules: [{ name: 'another-rule' }],
+      totals: {},
     } as CombinedRuleGroup;
 
     // the rules from both these groups should go in their own group name
     const group1 = {
       name: 'group1',
       rules: [{ name: 'rule-1' }, { name: 'rule-2' }],
+      totals: {},
     } as CombinedRuleGroup;
 
     const group2 = {
       name: 'group2',
       rules: [{ name: 'rule-1' }, { name: 'rule-2' }],
+      totals: {},
     } as CombinedRuleGroup;
 
     const namespace1 = {
@@ -45,6 +49,7 @@ describe('flattenGrafanaManagedRules', () => {
       {
         name: 'default',
         rules: sortRulesByName([...ungroupedGroup1.rules, ...ungroupedGroup2.rules, ...group1.rules, ...group2.rules]),
+        totals: {},
       },
     ]);
 
@@ -52,6 +57,7 @@ describe('flattenGrafanaManagedRules', () => {
       {
         name: 'default',
         rules: ungroupedGroup1.rules,
+        totals: {},
       },
     ]);
   });

--- a/public/app/features/alerting/unified/hooks/useCombinedRuleNamespaces.ts
+++ b/public/app/features/alerting/unified/hooks/useCombinedRuleNamespaces.ts
@@ -4,7 +4,7 @@ import { useMemo, useRef } from 'react';
 import {
   AlertGroupTotals,
   AlertingRule,
-  AlertInstanceState,
+  AlertInstanceTotalState,
   AlertInstanceTotals,
   CombinedRule,
   CombinedRuleGroup,
@@ -195,15 +195,16 @@ export function calculateRuleTotals(rule: Pick<AlertingRule, 'alerts' | 'totals'
   const result = countBy(rule.alerts, 'state');
 
   if (rule.totals) {
-    return rule.totals;
+    const { normal, ...totals } = rule.totals;
+    return { ...totals, inactive: normal };
   }
 
   return {
-    alerting: result[AlertInstanceState.Alerting],
-    pending: result[AlertInstanceState.Pending],
-    inactive: result[AlertInstanceState.Normal],
-    nodata: result[AlertInstanceState.NoData],
-    error: result[AlertInstanceState.Error] + result['err'], // Prometheus uses "err" instead of "error"
+    alerting: result[AlertInstanceTotalState.Alerting],
+    pending: result[AlertInstanceTotalState.Pending],
+    inactive: result[AlertInstanceTotalState.Normal],
+    nodata: result[AlertInstanceTotalState.NoData],
+    error: result[AlertInstanceTotalState.Error] + result['err'], // Prometheus uses "err" instead of "error"
   };
 }
 

--- a/public/app/features/alerting/unified/hooks/useCombinedRuleNamespaces.ts
+++ b/public/app/features/alerting/unified/hooks/useCombinedRuleNamespaces.ts
@@ -82,7 +82,6 @@ export function useCombinedRuleNamespaces(rulesSourceName?: string): CombinedRul
             rulesSource,
             name: namespaceName,
             groups: [],
-            totals: {},
           };
           namespaces[namespaceName] = namespace;
           addRulerGroupsToCombinedNamespace(namespace, groups);
@@ -120,7 +119,6 @@ export function flattenGrafanaManagedRules(namespaces: CombinedRuleNamespace[]) 
     newNamespace.groups.push({
       name: 'default',
       rules: sortRulesByName(namespace.groups.flatMap((group) => group.rules)),
-      // TODO – calculate totals here?
       totals: calculateTotalsFromCombinedRuleGroups(namespace.groups),
     });
 

--- a/public/app/features/alerting/unified/hooks/useCombinedRuleNamespaces.ts
+++ b/public/app/features/alerting/unified/hooks/useCombinedRuleNamespaces.ts
@@ -152,9 +152,11 @@ function addRulerGroupsToCombinedNamespace(namespace: CombinedRuleNamespace, gro
 
 function calculateTotalsFromGroup(group: RuleGroup): AlertGroupTotals {
   if (group.totals) {
+    const { firing, ...totals } = group.totals;
+
     return {
-      ...group.totals,
-      alerting: group.totals.firing,
+      ...totals,
+      alerting: firing,
     };
   }
 

--- a/public/app/features/alerting/unified/mocks.ts
+++ b/public/app/features/alerting/unified/mocks.ts
@@ -512,10 +512,11 @@ export const mockCombinedRule = (partial?: Partial<CombinedRule>): CombinedRule 
   group: {
     name: 'mockCombinedRuleGroup',
     rules: [],
+    totals: {},
   },
   namespace: {
     name: 'mockCombinedNamespace',
-    groups: [{ name: 'mockCombinedRuleGroup', rules: [] }],
+    groups: [{ name: 'mockCombinedRuleGroup', rules: [], totals: {} }],
     rulesSource: 'grafana',
   },
   labels: {},
@@ -597,7 +598,7 @@ export function mockAlertQuery(query: Partial<AlertQuery>): AlertQuery {
 }
 
 export function mockCombinedRuleGroup(name: string, rules: CombinedRule[]): CombinedRuleGroup {
-  return { name, rules };
+  return { name, rules, totals: {} };
 }
 
 export function mockCombinedRuleNamespace(namespace: Partial<CombinedRuleNamespace>): CombinedRuleNamespace {

--- a/public/app/features/alerting/unified/mocks.ts
+++ b/public/app/features/alerting/unified/mocks.ts
@@ -522,6 +522,7 @@ export const mockCombinedRule = (partial?: Partial<CombinedRule>): CombinedRule 
   annotations: {},
   promRule: mockPromAlertingRule(),
   rulerRule: mockRulerAlertingRule(),
+  instanceTotals: {},
   ...partial,
 });
 

--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -25,6 +25,7 @@ import {
   StateHistoryItem,
 } from 'app/types/unified-alerting';
 import {
+  GrafanaAlertState,
   PostableRulerRuleGroupDTO,
   PromApplication,
   RulerRuleDTO,
@@ -106,7 +107,14 @@ export const fetchPromRulesAction = createAsyncThunk(
       filter,
       limitAlerts,
       matchers,
-    }: { rulesSourceName: string; filter?: FetchPromRulesFilter; limitAlerts?: number; matchers?: string },
+      state,
+    }: {
+      rulesSourceName: string;
+      filter?: FetchPromRulesFilter;
+      limitAlerts?: number;
+      matchers?: string;
+      state?: GrafanaAlertState[];
+    },
     thunkAPI
   ): Promise<RuleNamespace[]> => {
     await thunkAPI.dispatch(fetchRulesSourceBuildInfoAction({ rulesSourceName }));
@@ -116,7 +124,7 @@ export const fetchPromRulesAction = createAsyncThunk(
       thunk: 'unifiedalerting/fetchPromRules',
     });
 
-    return await withSerializedError(fetchRulesWithLogging(rulesSourceName, filter, limitAlerts, matchers));
+    return await withSerializedError(fetchRulesWithLogging(rulesSourceName, filter, limitAlerts, matchers, state));
   }
 );
 
@@ -348,6 +356,7 @@ interface FetchPromRulesRulesActionProps {
   filter?: FetchPromRulesFilter;
   limitAlerts?: number;
   matchers?: string;
+  state?: GrafanaAlertState[];
 }
 
 export function fetchAllPromAndRulerRulesAction(

--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -1,4 +1,4 @@
-import { AsyncThunk, createAsyncThunk } from '@reduxjs/toolkit';
+import { AsyncThunk, createAction, createAsyncThunk } from '@reduxjs/toolkit';
 import { isEmpty } from 'lodash';
 
 import { config, locationService } from '@grafana/runtime';
@@ -15,6 +15,7 @@ import {
 } from 'app/plugins/datasource/alertmanager/types';
 import { FolderDTO, NotifierDTO, StoreState, ThunkResult } from 'app/types';
 import {
+  AlertGroupTotals,
   CombinedRuleGroup,
   CombinedRuleNamespace,
   PromBasedDataSource,

--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -101,7 +101,11 @@ function getDataSourceRulerConfig(getState: () => unknown, rulesSourceName: stri
 export const fetchPromRulesAction = createAsyncThunk(
   'unifiedalerting/fetchPromRules',
   async (
-    { rulesSourceName, filter }: { rulesSourceName: string; filter?: FetchPromRulesFilter },
+    {
+      rulesSourceName,
+      filter,
+      limitAlerts,
+    }: { rulesSourceName: string; filter?: FetchPromRulesFilter; limitAlerts?: number },
     thunkAPI
   ): Promise<RuleNamespace[]> => {
     await thunkAPI.dispatch(fetchRulesSourceBuildInfoAction({ rulesSourceName }));
@@ -111,7 +115,7 @@ export const fetchPromRulesAction = createAsyncThunk(
       thunk: 'unifiedalerting/fetchPromRules',
     });
 
-    return await withSerializedError(fetchRulesWithLogging(rulesSourceName, filter));
+    return await withSerializedError(fetchRulesWithLogging(rulesSourceName, filter, limitAlerts));
   }
 );
 
@@ -339,7 +343,14 @@ export const fetchRulesSourceBuildInfoAction = createAsyncThunk(
   }
 );
 
-export function fetchAllPromAndRulerRulesAction(force = false): ThunkResult<Promise<void>> {
+interface FetchPromRulesRulesActionProps {
+  limitAlerts?: number;
+}
+
+export function fetchAllPromAndRulerRulesAction(
+  force = false,
+  options: FetchPromRulesRulesActionProps = {}
+): ThunkResult<Promise<void>> {
   return async (dispatch, getStore) => {
     const allStartLoadingTs = performance.now();
 
@@ -359,7 +370,7 @@ export function fetchAllPromAndRulerRulesAction(force = false): ThunkResult<Prom
           (force || !rulerRules[rulesSourceName]?.loading) && Boolean(dataSourceConfig.rulerConfig);
 
         await Promise.allSettled([
-          shouldLoadProm && dispatch(fetchPromRulesAction({ rulesSourceName })),
+          shouldLoadProm && dispatch(fetchPromRulesAction({ rulesSourceName, ...options })),
           shouldLoadRuler && dispatch(fetchRulerRulesAction({ rulesSourceName })),
         ]);
       })

--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -1,4 +1,4 @@
-import { AsyncThunk, createAction, createAsyncThunk } from '@reduxjs/toolkit';
+import { AsyncThunk, createAsyncThunk } from '@reduxjs/toolkit';
 import { isEmpty } from 'lodash';
 
 import { config, locationService } from '@grafana/runtime';
@@ -15,7 +15,6 @@ import {
 } from 'app/plugins/datasource/alertmanager/types';
 import { FolderDTO, NotifierDTO, StoreState, ThunkResult } from 'app/types';
 import {
-  AlertGroupTotals,
   CombinedRuleGroup,
   CombinedRuleNamespace,
   PromBasedDataSource,

--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -344,6 +344,7 @@ export const fetchRulesSourceBuildInfoAction = createAsyncThunk(
 );
 
 interface FetchPromRulesRulesActionProps {
+  filter?: FetchPromRulesFilter;
   limitAlerts?: number;
 }
 

--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -25,7 +25,6 @@ import {
   StateHistoryItem,
 } from 'app/types/unified-alerting';
 import {
-  GrafanaAlertState,
   PostableRulerRuleGroupDTO,
   PromApplication,
   RulerRuleDTO,
@@ -113,7 +112,7 @@ export const fetchPromRulesAction = createAsyncThunk(
       filter?: FetchPromRulesFilter;
       limitAlerts?: number;
       matchers?: string;
-      state?: GrafanaAlertState[];
+      state?: string[];
     },
     thunkAPI
   ): Promise<RuleNamespace[]> => {
@@ -356,7 +355,7 @@ interface FetchPromRulesRulesActionProps {
   filter?: FetchPromRulesFilter;
   limitAlerts?: number;
   matchers?: string;
-  state?: GrafanaAlertState[];
+  state?: string[];
 }
 
 export function fetchAllPromAndRulerRulesAction(

--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -105,7 +105,8 @@ export const fetchPromRulesAction = createAsyncThunk(
       rulesSourceName,
       filter,
       limitAlerts,
-    }: { rulesSourceName: string; filter?: FetchPromRulesFilter; limitAlerts?: number },
+      matchers,
+    }: { rulesSourceName: string; filter?: FetchPromRulesFilter; limitAlerts?: number; matchers?: string },
     thunkAPI
   ): Promise<RuleNamespace[]> => {
     await thunkAPI.dispatch(fetchRulesSourceBuildInfoAction({ rulesSourceName }));
@@ -115,7 +116,7 @@ export const fetchPromRulesAction = createAsyncThunk(
       thunk: 'unifiedalerting/fetchPromRules',
     });
 
-    return await withSerializedError(fetchRulesWithLogging(rulesSourceName, filter, limitAlerts));
+    return await withSerializedError(fetchRulesWithLogging(rulesSourceName, filter, limitAlerts, matchers));
   }
 );
 
@@ -346,6 +347,7 @@ export const fetchRulesSourceBuildInfoAction = createAsyncThunk(
 interface FetchPromRulesRulesActionProps {
   filter?: FetchPromRulesFilter;
   limitAlerts?: number;
+  matchers?: string;
 }
 
 export function fetchAllPromAndRulerRulesAction(

--- a/public/app/features/alerting/unified/utils/query.test.ts
+++ b/public/app/features/alerting/unified/utils/query.test.ts
@@ -16,6 +16,7 @@ describe('alertRuleToQueries', () => {
       group: {
         name: 'Prom up alert',
         rules: [],
+        totals: {},
       },
       namespace: {
         rulesSource: GRAFANA_RULES_SOURCE_NAME,
@@ -44,6 +45,7 @@ describe('alertRuleToQueries', () => {
       group: {
         name: 'test',
         rules: [],
+        totals: {},
       },
       namespace: {
         name: 'prom test alerts',

--- a/public/app/features/alerting/unified/utils/query.test.ts
+++ b/public/app/features/alerting/unified/utils/query.test.ts
@@ -28,6 +28,7 @@ describe('alertRuleToQueries', () => {
         labels: {},
         grafana_alert: grafanaAlert,
       },
+      instanceTotals: {},
     };
 
     const result = alertRuleToQueries(combinedRule);
@@ -58,6 +59,7 @@ describe('alertRuleToQueries', () => {
           readOnly: false,
         },
       },
+      instanceTotals: {},
     };
 
     const result = alertRuleToQueries(combinedRule);

--- a/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
+++ b/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
@@ -32,7 +32,7 @@ import { flattenCombinedRules, getFirstActiveAt } from 'app/features/alerting/un
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
 import { DashboardModel } from 'app/features/dashboard/state';
 import { AccessControlAction, useDispatch } from 'app/types';
-import { PromAlertingRuleState } from 'app/types/unified-alerting-dto';
+import { GrafanaAlertState, PromAlertingRuleState } from 'app/types/unified-alerting-dto';
 
 import { getAlertingRule } from '../../../features/alerting/unified/utils/rules';
 import { AlertingRule, CombinedRuleWithLocation } from '../../../types/unified-alerting';
@@ -63,7 +63,11 @@ export function UnifiedAlertList(props: PanelProps<UnifiedAlertListOptions>) {
   useEffect(() => {
     //we need promRules and rulerRules for getting the uid when creating the alert link in panel in case of being a rulerRule.
     dispatch(
-      fetchAllPromAndRulerRulesAction(false, { limitAlerts: 1, matchers: props.options.alertInstanceLabelFilter })
+      fetchAllPromAndRulerRulesAction(false, {
+        limitAlerts: 1,
+        matchers: props.options.alertInstanceLabelFilter,
+        state: [GrafanaAlertState.Alerting, GrafanaAlertState.Normal],
+      })
     );
     const sub = dashboard?.events.subscribe(TimeRangeUpdatedEvent, () => dispatch(fetchAllPromAndRulerRulesAction()));
     return () => {

--- a/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
+++ b/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
@@ -62,7 +62,7 @@ export function UnifiedAlertList(props: PanelProps<UnifiedAlertListOptions>) {
 
   useEffect(() => {
     //we need promRules and rulerRules for getting the uid when creating the alert link in panel in case of being a rulerRule.
-    dispatch(fetchAllPromAndRulerRulesAction());
+    dispatch(fetchAllPromAndRulerRulesAction(false, { limitAlerts: 1 }));
     const sub = dashboard?.events.subscribe(TimeRangeUpdatedEvent, () => dispatch(fetchAllPromAndRulerRulesAction()));
     return () => {
       sub?.unsubscribe();

--- a/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
+++ b/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
@@ -62,12 +62,14 @@ export function UnifiedAlertList(props: PanelProps<UnifiedAlertListOptions>) {
 
   useEffect(() => {
     //we need promRules and rulerRules for getting the uid when creating the alert link in panel in case of being a rulerRule.
-    dispatch(fetchAllPromAndRulerRulesAction(false, { limitAlerts: 1 }));
+    dispatch(
+      fetchAllPromAndRulerRulesAction(false, { limitAlerts: 1, matchers: props.options.alertInstanceLabelFilter })
+    );
     const sub = dashboard?.events.subscribe(TimeRangeUpdatedEvent, () => dispatch(fetchAllPromAndRulerRulesAction()));
     return () => {
       sub?.unsubscribe();
     };
-  }, [dispatch, dashboard]);
+  }, [dispatch, dashboard, props.options.alertInstanceLabelFilter]);
 
   const { prom, ruler } = useUnifiedAlertingSelector((state) => ({
     prom: state.promRules[GRAFANA_RULES_SOURCE_NAME] || initialAsyncRequestState,

--- a/public/app/plugins/panel/alertlist/types.ts
+++ b/public/app/plugins/panel/alertlist/types.ts
@@ -42,7 +42,7 @@ export interface AlertListOptions {
   folderId: number;
 }
 
-interface StateFilter {
+export interface StateFilter {
   firing: boolean;
   pending: boolean;
   inactive?: boolean; // backwards compat

--- a/public/app/types/unified-alerting-dto.ts
+++ b/public/app/types/unified-alerting-dto.ts
@@ -2,6 +2,8 @@
 
 import { DataQuery, RelativeTimeRange } from '@grafana/data';
 
+import { AlertGroupTotals } from './unified-alerting';
+
 export type Labels = Record<string, string>;
 export type Annotations = Record<string, string>;
 
@@ -153,7 +155,10 @@ export interface PromResponse<T> {
   warnings?: string[];
 }
 
-export type PromRulesResponse = PromResponse<{ groups: PromRuleGroupDTO[] }>;
+export type PromRulesResponse = PromResponse<{
+  groups: PromRuleGroupDTO[];
+  totals?: AlertGroupTotals;
+}>;
 
 // Ruler rule DTOs
 interface RulerRuleBaseDTO {

--- a/public/app/types/unified-alerting.ts
+++ b/public/app/types/unified-alerting.ts
@@ -46,6 +46,7 @@ export interface AlertingRule extends RuleBase {
   state: PromAlertingRuleState;
   type: PromRuleType.Alerting;
   totals?: AlertInstanceTotals;
+  activeAt?: string; // ISO timestamp
 }
 
 export interface RecordingRule extends RuleBase {

--- a/public/app/types/unified-alerting.ts
+++ b/public/app/types/unified-alerting.ts
@@ -45,7 +45,7 @@ export interface AlertingRule extends RuleBase {
   };
   state: PromAlertingRuleState;
   type: PromRuleType.Alerting;
-  totals?: AlertInstanceTotals;
+  totals?: Partial<Record<Lowercase<GrafanaAlertState>, number>>;
   activeAt?: string; // ISO timestamp
 }
 
@@ -61,7 +61,7 @@ export type Rule = AlertingRule | RecordingRule;
 
 export type BaseRuleGroup = { name: string };
 
-type TotalsWithoutAlerting = Exclude<AlertInstanceState, AlertInstanceState.Alerting>;
+type TotalsWithoutAlerting = Exclude<AlertInstanceTotalState, AlertInstanceTotalState.Alerting>;
 enum FiringTotal {
   Firing = 'firing',
 }
@@ -101,7 +101,7 @@ export interface CombinedRule {
 }
 
 // export type AlertInstanceState = PromAlertingRuleState | 'nodata' | 'error';
-export enum AlertInstanceState {
+export enum AlertInstanceTotalState {
   Alerting = 'alerting',
   Pending = 'pending',
   Normal = 'inactive',
@@ -109,10 +109,10 @@ export enum AlertInstanceState {
   Error = 'error',
 }
 
-export type AlertInstanceTotals = Partial<Record<AlertInstanceState, number>>;
+export type AlertInstanceTotals = Partial<Record<AlertInstanceTotalState, number>>;
 
 // AlertGroupTotals also contain the amount of recording and paused rules
-export type AlertGroupTotals = Partial<Record<AlertInstanceState | 'paused' | 'recording', number>>;
+export type AlertGroupTotals = Partial<Record<AlertInstanceTotalState | 'paused' | 'recording', number>>;
 
 export interface CombinedRuleGroup {
   name: string;

--- a/public/app/types/unified-alerting.ts
+++ b/public/app/types/unified-alerting.ts
@@ -60,10 +60,16 @@ export type Rule = AlertingRule | RecordingRule;
 
 export type BaseRuleGroup = { name: string };
 
+type TotalsWithoutAlerting = Exclude<AlertInstanceState, AlertInstanceState.Alerting>;
+enum FiringTotal {
+  Firing = 'firing',
+}
 export interface RuleGroup {
   name: string;
   interval: number;
   rules: Rule[];
+  // totals only exist for Grafana Managed rules
+  totals?: Partial<Record<TotalsWithoutAlerting | FiringTotal, number>>;
 }
 
 export interface RuleNamespace {
@@ -104,17 +110,22 @@ export enum AlertInstanceState {
 
 export type AlertInstanceTotals = Partial<Record<AlertInstanceState, number>>;
 
+// AlertGroupTotals also contain the amount of recording and paused rules
+export type AlertGroupTotals = Partial<Record<AlertInstanceState | 'paused' | 'recording', number>>;
+
 export interface CombinedRuleGroup {
   name: string;
   interval?: string;
   source_tenants?: string[];
   rules: CombinedRule[];
+  totals: AlertGroupTotals;
 }
 
 export interface CombinedRuleNamespace {
   rulesSource: RulesSource;
   name: string;
   groups: CombinedRuleGroup[];
+  totals: AlertGroupTotals;
 }
 
 export interface RuleWithLocation<T = RulerRuleDTO> {

--- a/public/app/types/unified-alerting.ts
+++ b/public/app/types/unified-alerting.ts
@@ -125,7 +125,6 @@ export interface CombinedRuleNamespace {
   rulesSource: RulesSource;
   name: string;
   groups: CombinedRuleGroup[];
-  totals: AlertGroupTotals;
 }
 
 export interface RuleWithLocation<T = RulerRuleDTO> {

--- a/public/app/types/unified-alerting.ts
+++ b/public/app/types/unified-alerting.ts
@@ -45,6 +45,7 @@ export interface AlertingRule extends RuleBase {
   };
   state: PromAlertingRuleState;
   type: PromRuleType.Alerting;
+  totals?: AlertInstanceTotals;
 }
 
 export interface RecordingRule extends RuleBase {
@@ -89,7 +90,19 @@ export interface CombinedRule {
   rulerRule?: RulerRuleDTO;
   group: CombinedRuleGroup;
   namespace: CombinedRuleNamespace;
+  instanceTotals: AlertInstanceTotals;
 }
+
+// export type AlertInstanceState = PromAlertingRuleState | 'nodata' | 'error';
+export enum AlertInstanceState {
+  Alerting = 'alerting',
+  Pending = 'pending',
+  Normal = 'inactive',
+  NoData = 'nodata',
+  Error = 'error',
+}
+
+export type AlertInstanceTotals = Partial<Record<AlertInstanceState, number>>;
 
 export interface CombinedRuleGroup {
   name: string;


### PR DESCRIPTION
**What is this feature?**

Allows the user to create a recording rule when there are several datasources available.

**Why do we need this feature?**

There was a bug that made it always select the first datasource in the list.

**Who is this feature for?**

All users.

**Special notes for your reviewer:**

The problem was happening because the datasource ID was not being updated in the query after changing datasources. This has been fixed as shown in the following screen recordings.

![2023-04-12 15 35 39](https://user-images.githubusercontent.com/6271380/231554325-69b7841e-62a7-4fe2-ab87-1c24cfbf1849.gif)
![2023-04-12 15 36 15](https://user-images.githubusercontent.com/6271380/231554356-05bc6856-4a1d-4586-942a-230e3a1cdd9b.gif)


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
