### PR TITLE
Alerting: Fix creating a recording rule when having multiple datasources

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/RecordingRuleEditor.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/RecordingRuleEditor.tsx
@@ -57,17 +57,19 @@ export const RecordingRuleEditor: FC<RecordingRuleEditorProps> = ({
 
   const handleChangedQuery = (changedQuery: DataQuery) => {
     const query = queries[0];
+    const dataSourceId = getDataSourceSrv().getInstanceSettings(dataSourceName)?.uid;
 
-    if (!isPromOrLokiQuery(query.model)) {
+    if (!isPromOrLokiQuery(changedQuery) || !dataSourceId) {
       return;
     }
 
-    const expr = query.model.expr;
+    const expr = changedQuery.expr;
 
     const merged = {
       ...query,
       refId: changedQuery.refId,
-      queryType: query.model.queryType ?? '',
+      queryType: changedQuery.queryType ?? '',
+      datasourceUid: dataSourceId,
       expr,
       model: {
         refId: changedQuery.refId,

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/AlertType.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/AlertType.tsx
@@ -67,6 +67,8 @@ export const AlertType = ({ editingExistingRule }: Props) => {
                   onChange={(ds: DataSourceInstanceSettings) => {
                     // reset location if switching data sources, as different rules source will have different groups and namespaces
                     setValue('location', undefined);
+                    // reset expression as they don't need to persist after changing datasources
+                    setValue('expression', '');
                     onChange(ds?.name ?? null);
                   }}
                 />

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
@@ -198,19 +198,26 @@ export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange }: P
   useEffect(() => {
     setPanelData({});
     if (type === RuleFormType.cloudRecording) {
+      const expr = getValues('expression');
+      const datasourceUid =
+        (editingExistingRule && getDataSourceSrv().getInstanceSettings(dataSourceName)?.uid) ||
+        recordingRuleDefaultDatasource.uid;
+
       const defaultQuery = {
         refId: 'A',
-        datasourceUid: recordingRuleDefaultDatasource.uid,
+        datasourceUid,
         queryType: '',
         relativeTimeRange: getDefaultRelativeTimeRange(),
+        expr,
         model: {
           refId: 'A',
           hide: false,
+          expr,
         },
       };
-      dispatch(setRecordingRulesQueries({ recordingRuleQueries: [defaultQuery], expression: getValues('expression') }));
+      dispatch(setRecordingRulesQueries({ recordingRuleQueries: [defaultQuery], expression: expr }));
     }
-  }, [type, recordingRuleDefaultDatasource, editingExistingRule, getValues]);
+  }, [type, recordingRuleDefaultDatasource, editingExistingRule, getValues, dataSourceName]);
 
   const onDuplicateQuery = useCallback((query: AlertQuery) => {
     dispatch(duplicateQuery(query));


### PR DESCRIPTION
**What is this feature?**

Allows the user to create a recording rule when there are several datasources available.

**Why do we need this feature?**

There was a bug that made it always select the first datasource in the list.

**Who is this feature for?**

All users.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/support-escalations/issues/5558

**Special notes for your reviewer:**

The problem was happening because the datasource ID was not being updated in the query after changing datasources. This has been fixed as shown in the following screen recordings.

![2023-04-12 15 35 39](https://user-images.githubusercontent.com/6271380/231554325-69b7841e-62a7-4fe2-ab87-1c24cfbf1849.gif)
![2023-04-12 15 36 15](https://user-images.githubusercontent.com/6271380/231554356-05bc6856-4a1d-4586-942a-230e3a1cdd9b.gif)


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
