### PR TITLE
Alerting: Capture refID of rule's condition expression in Loki state history entries

### DIFF
--- a/pkg/services/ngalert/state/historian/loki.go
+++ b/pkg/services/ngalert/state/historian/loki.go
@@ -260,6 +260,7 @@ func statesToStream(rule history_model.RuleMeta, states []state.StateTransition,
 			Previous:       state.PreviousFormatted(),
 			Current:        state.Formatted(),
 			Values:         valuesAsDataBlob(state.State),
+			Condition:      rule.Condition,
 			DashboardUID:   rule.DashboardUID,
 			PanelID:        rule.PanelID,
 			InstanceLabels: removePrivateLabels(state.Labels),
@@ -302,6 +303,7 @@ type lokiEntry struct {
 	Current       string           `json:"current"`
 	Error         string           `json:"error,omitempty"`
 	Values        *simplejson.Json `json:"values"`
+	Condition     string           `json:"condition"`
 	DashboardUID  string           `json:"dashboardUID"`
 	PanelID       int64            `json:"panelID"`
 	// InstanceLabels is exactly the set of labels associated with the alert instance in Alertmanager.

--- a/pkg/services/ngalert/state/historian/loki_test.go
+++ b/pkg/services/ngalert/state/historian/loki_test.go
@@ -139,6 +139,21 @@ func TestRemoteLokiBackend(t *testing.T) {
 			require.InDelta(t, 2.0, entry.Values.Get("A").MustFloat64(), 1e-4)
 			require.InDelta(t, 5.5, entry.Values.Get("B").MustFloat64(), 1e-4)
 		})
+
+		t.Run("captures condition from rule", func(t *testing.T) {
+			rule := createTestRule()
+			rule.Condition = "some-condition"
+			l := log.NewNopLogger()
+			states := singleFromNormal(&state.State{
+				State:  eval.Alerting,
+				Labels: data.Labels{"a": "b"},
+			})
+
+			res := statesToStream(rule, states, nil, l)
+
+			entry := requireSingleEntry(t, res)
+			require.Equal(t, rule.Condition, entry.Condition)
+		})
 	})
 
 	t.Run("selector string", func(t *testing.T) {

--- a/pkg/services/ngalert/state/historian/model/rule.go
+++ b/pkg/services/ngalert/state/historian/model/rule.go
@@ -19,6 +19,7 @@ type RuleMeta struct {
 	NamespaceUID string
 	DashboardUID string
 	PanelID      int64
+	Condition    string
 }
 
 func NewRuleMeta(r *models.AlertRule, log log.Logger) RuleMeta {
@@ -43,6 +44,7 @@ func NewRuleMeta(r *models.AlertRule, log log.Logger) RuleMeta {
 		NamespaceUID: r.NamespaceUID,
 		DashboardUID: dashUID,
 		PanelID:      panelID,
+		Condition:    r.Condition,
 	}
 }
 


### PR DESCRIPTION
**What is this feature?**

We now capture the refID of the expression block being used as the condition.

This can be used by user interfaces consuming the data, to determine which entry in `values` corresponds to the alert condition.


**Which issue(s) does this PR fix?**:

n/a

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
