### PR TITLE
CloudWatch: Use generated type from schema in backend

### DIFF
--- a/pkg/tsdb/cloudwatch/annotation_query.go
+++ b/pkg/tsdb/cloudwatch/annotation_query.go
@@ -28,15 +28,20 @@ func (e *cloudWatchExecutor) executeAnnotationQuery(pluginCtx backend.PluginCont
 	}
 
 	var period int64
-	if model.Period != "" {
-		p, err := strconv.ParseInt(model.Period, 10, 64)
+
+	if model.Period != nil && *model.Period != "" {
+		p, err := strconv.ParseInt(*model.Period, 10, 64)
 		if err != nil {
 			return nil, err
 		}
 		period = p
 	}
 
-	if period == 0 && !model.PrefixMatching {
+	prefixMatching := false
+	if model.PrefixMatching != nil {
+		prefixMatching = *model.PrefixMatching
+	}
+	if period == 0 && !prefixMatching {
 		period = 300
 	}
 
@@ -49,19 +54,23 @@ func (e *cloudWatchExecutor) executeAnnotationQuery(pluginCtx backend.PluginCont
 	}
 
 	var alarmNames []*string
-	if model.PrefixMatching {
+	metricName := ""
+	if model.MetricName != nil {
+		metricName = *model.MetricName
+	}
+	if prefixMatching {
 		params := &cloudwatch.DescribeAlarmsInput{
 			MaxRecords:      aws.Int64(100),
-			ActionPrefix:    aws.String(actionPrefix),
-			AlarmNamePrefix: aws.String(alarmNamePrefix),
+			ActionPrefix:    actionPrefix,
+			AlarmNamePrefix: alarmNamePrefix,
 		}
 		resp, err := cli.DescribeAlarms(params)
 		if err != nil {
 			return nil, fmt.Errorf("%v: %w", "failed to call cloudwatch:DescribeAlarms", err)
 		}
-		alarmNames = filterAlarms(resp, model.Namespace, model.MetricName, model.Dimensions, statistic, period)
+		alarmNames = filterAlarms(resp, model.Namespace, metricName, model.Dimensions, statistic, period)
 	} else {
-		if model.Region == "" || model.Namespace == "" || model.MetricName == "" || statistic == "" {
+		if model.Region == "" || model.Namespace == "" || metricName == "" || statistic == "" {
 			return result, errors.New("invalid annotations query")
 		}
 
@@ -80,7 +89,7 @@ func (e *cloudWatchExecutor) executeAnnotationQuery(pluginCtx backend.PluginCont
 		}
 		params := &cloudwatch.DescribeAlarmsForMetricInput{
 			Namespace:  aws.String(model.Namespace),
-			MetricName: aws.String(model.MetricName),
+			MetricName: aws.String(metricName),
 			Dimensions: qd,
 			Statistic:  aws.String(statistic),
 			Period:     aws.Int64(period),

--- a/pkg/tsdb/cloudwatch/cloudwatch.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch.go
@@ -27,21 +27,13 @@ import (
 	"github.com/grafana/grafana/pkg/services/query"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/clients"
+	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/kinds/dataquery"
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/models"
 )
 
 type DataQueryJson struct {
-	QueryType       string `json:"type,omitempty"`
-	QueryMode       string
-	PrefixMatching  bool
-	Region          string
-	Namespace       string
-	MetricName      string
-	Dimensions      map[string]interface{}
-	Statistic       *string
-	Period          string
-	ActionPrefix    string
-	AlarmNamePrefix string
+	dataquery.CloudWatchAnnotationQuery
+	Type string `json:"type,omitempty"`
 }
 
 type DataSource struct {
@@ -179,7 +171,7 @@ func (e *cloudWatchExecutor) QueryData(ctx context.Context, req *backend.QueryDa
 	}
 
 	var result *backend.QueryDataResponse
-	switch model.QueryType {
+	switch model.Type {
 	case annotationQuery:
 		result, err = e.executeAnnotationQuery(req.PluginContext, model, q)
 	case logAction:

--- a/pkg/tsdb/cloudwatch/log_actions.go
+++ b/pkg/tsdb/cloudwatch/log_actions.go
@@ -112,7 +112,7 @@ func (e *cloudWatchExecutor) executeLogAction(ctx context.Context, logger log.Lo
 	}
 
 	var data *data.Frame = nil
-	switch logsQuery.SubType {
+	switch logsQuery.Subtype {
 	case "StartQuery":
 		data, err = e.handleStartQuery(ctx, logger, logsClient, logsQuery, query.TimeRange, query.RefID)
 	case "StopQuery":
@@ -123,7 +123,7 @@ func (e *cloudWatchExecutor) executeLogAction(ctx context.Context, logger log.Lo
 		data, err = e.handleGetLogEvents(ctx, logsClient, logsQuery)
 	}
 	if err != nil {
-		return nil, fmt.Errorf("failed to execute log action with subtype: %s: %w", logsQuery.SubType, err)
+		return nil, fmt.Errorf("failed to execute log action with subtype: %s: %w", logsQuery.Subtype, err)
 	}
 
 	return data, nil
@@ -214,7 +214,7 @@ func (e *cloudWatchExecutor) executeStartQuery(ctx context.Context, logsClient c
 	if logsQuery.LogGroups != nil && len(logsQuery.LogGroups) > 0 {
 		var logGroupIdentifiers []string
 		for _, lg := range logsQuery.LogGroups {
-			arn := lg.ARN
+			arn := lg.Arn
 			// due to a bug in the startQuery api, we remove * from the arn, otherwise it throws an error
 			logGroupIdentifiers = append(logGroupIdentifiers, strings.TrimSuffix(arn, "*"))
 		}

--- a/pkg/tsdb/cloudwatch/log_sync_query.go
+++ b/pkg/tsdb/cloudwatch/log_sync_query.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs/cloudwatchlogsiface"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/kinds/dataquery"
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/models"
 )
 
@@ -29,7 +30,11 @@ var executeSyncLogQuery = func(ctx context.Context, e *cloudWatchExecutor, req *
 		}
 
 		logsQuery.Subtype = "StartQuery"
-		logsQuery.QueryString = logsQuery.Expression
+		expression := ""
+		if logsQuery.Expression != nil {
+			expression = *logsQuery.Expression
+		}
+		logsQuery.QueryString = expression
 
 		region := logsQuery.Region
 		if logsQuery.Region == "" || region == defaultRegion {
@@ -86,7 +91,9 @@ func (e *cloudWatchExecutor) syncQuery(ctx context.Context, logsClient cloudwatc
 	}
 
 	requestParams := models.LogsQuery{
-		Region:  logsQuery.Region,
+		CloudWatchLogsQuery: dataquery.CloudWatchLogsQuery{
+			Region: logsQuery.Region,
+		},
 		QueryId: *startQueryOutput.QueryId,
 	}
 

--- a/pkg/tsdb/cloudwatch/log_sync_query.go
+++ b/pkg/tsdb/cloudwatch/log_sync_query.go
@@ -30,11 +30,9 @@ var executeSyncLogQuery = func(ctx context.Context, e *cloudWatchExecutor, req *
 		}
 
 		logsQuery.Subtype = "StartQuery"
-		expression := ""
 		if logsQuery.Expression != nil {
-			expression = *logsQuery.Expression
+			logsQuery.QueryString = *logsQuery.Expression
 		}
-		logsQuery.QueryString = expression
 
 		region := logsQuery.Region
 		if logsQuery.Region == "" || region == defaultRegion {

--- a/pkg/tsdb/cloudwatch/models/cloudwatch_query.go
+++ b/pkg/tsdb/cloudwatch/models/cloudwatch_query.go
@@ -242,18 +242,12 @@ func ParseMetricDataQueries(dataQueries []backend.DataQuery, startTime time.Time
 	result := make([]*CloudWatchQuery, 0, len(metricDataQueries))
 
 	for refId, mdq := range metricDataQueries {
-		metricQueryType := MetricQueryTypeSearch
-		if mdq.MetricQueryType != nil {
-			metricQueryType = *mdq.MetricQueryType
-		}
-
 		cwQuery := &CloudWatchQuery{
 			logger:            logger,
 			RefId:             refId,
 			Id:                mdq.Id,
 			Region:            mdq.Region,
 			Namespace:         mdq.Namespace,
-			MetricQueryType:   metricQueryType,
 			TimezoneUTCOffset: mdq.TimezoneUTCOffset,
 		}
 
@@ -263,6 +257,10 @@ func ParseMetricDataQueries(dataQueries []backend.DataQuery, startTime time.Time
 
 		if mdq.MetricName != nil {
 			cwQuery.MetricName = *mdq.MetricName
+		}
+
+		if mdq.MetricQueryType != nil {
+			cwQuery.MetricQueryType = *mdq.MetricQueryType
 		}
 
 		if mdq.SqlExpression != nil {

--- a/pkg/tsdb/cloudwatch/models/cloudwatch_query.go
+++ b/pkg/tsdb/cloudwatch/models/cloudwatch_query.go
@@ -242,43 +242,35 @@ func ParseMetricDataQueries(dataQueries []backend.DataQuery, startTime time.Time
 	result := make([]*CloudWatchQuery, 0, len(metricDataQueries))
 
 	for refId, mdq := range metricDataQueries {
-		alias := ""
-		if mdq.Alias != nil {
-			alias = *mdq.Alias
-		}
-
-		metricName := ""
-		if mdq.MetricName != nil {
-			metricName = *mdq.MetricName
-		}
-
 		metricQueryType := MetricQueryTypeSearch
 		if mdq.MetricQueryType != nil {
 			metricQueryType = *mdq.MetricQueryType
 		}
 
-		sqlExpression := ""
-		if mdq.SqlExpression != nil {
-			sqlExpression = *mdq.SqlExpression
-		}
-
-		expression := ""
-		if mdq.Expression != nil {
-			expression = *mdq.Expression
-		}
-
 		cwQuery := &CloudWatchQuery{
 			logger:            logger,
-			Alias:             alias,
 			RefId:             refId,
 			Id:                mdq.Id,
 			Region:            mdq.Region,
 			Namespace:         mdq.Namespace,
-			MetricName:        metricName,
 			MetricQueryType:   metricQueryType,
-			SqlExpression:     sqlExpression,
 			TimezoneUTCOffset: mdq.TimezoneUTCOffset,
-			Expression:        expression,
+		}
+
+		if mdq.Alias != nil {
+			cwQuery.Alias = *mdq.Alias
+		}
+
+		if mdq.MetricName != nil {
+			cwQuery.MetricName = *mdq.MetricName
+		}
+
+		if mdq.SqlExpression != nil {
+			cwQuery.SqlExpression = *mdq.SqlExpression
+		}
+
+		if mdq.Expression != nil {
+			cwQuery.Expression = *mdq.Expression
 		}
 
 		if err := cwQuery.validateAndSetDefaults(refId, mdq, startTime, endTime, defaultRegion, crossAccountQueryingEnabled); err != nil {

--- a/pkg/tsdb/cloudwatch/models/cloudwatch_query_test.go
+++ b/pkg/tsdb/cloudwatch/models/cloudwatch_query_test.go
@@ -8,10 +8,12 @@ import (
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/kindsys"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/infra/log/logtest"
+	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/kinds/dataquery"
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/utils"
 )
 
@@ -294,7 +296,7 @@ func TestQueryJSON(t *testing.T) {
 	var res metricsDataQuery
 	err := json.Unmarshal(jsonString, &res)
 	require.NoError(t, err)
-	assert.Equal(t, "timeSeriesQuery", res.QueryType)
+	assert.Equal(t, "timeSeriesQuery", res.Type)
 }
 
 func TestRequestParser(t *testing.T) {
@@ -622,11 +624,11 @@ func Test_ParseMetricDataQueries_periods(t *testing.T) {
 }
 
 func Test_ParseMetricDataQueries_query_type_and_metric_editor_mode_and_GMD_query_api_mode(t *testing.T) {
-	const dummyTestEditorMode MetricEditorMode = 99
+	const dummyTestEditorMode dataquery.CloudWatchMetricsQueryMetricEditorMode = 99
 	testCases := map[string]struct {
 		extraDataQueryJson       string
-		expectedMetricQueryType  MetricQueryType
-		expectedMetricEditorMode MetricEditorMode
+		expectedMetricQueryType  dataquery.CloudWatchMetricsQueryMetricQueryType
+		expectedMetricEditorMode dataquery.CloudWatchMetricsQueryMetricEditorMode
 		expectedGMDApiMode       GMDApiMode
 	}{
 		"no metric query type, no metric editor mode, no expression": {
@@ -930,16 +932,18 @@ func Test_migrateAliasToDynamicLabel_single_query_preserves_old_alias_and_create
 			false := false
 
 			queryToMigrate := metricsDataQuery{
-				Region:     "us-east-1",
-				Namespace:  "ec2",
-				MetricName: "CPUUtilization",
-				Alias:      tc.inputAlias,
-				Dimensions: map[string]interface{}{
-					"InstanceId": []interface{}{"test"},
+				CloudWatchMetricsQuery: dataquery.CloudWatchMetricsQuery{
+					Region:     "us-east-1",
+					Namespace:  "ec2",
+					MetricName: kindsys.Ptr("CPUUtilization"),
+					Alias:      kindsys.Ptr(tc.inputAlias),
+					Dimensions: map[string]interface{}{
+						"InstanceId": []interface{}{"test"},
+					},
+					Statistic: &average,
+					Period:    kindsys.Ptr("600"),
+					Hide:      &false,
 				},
-				Statistic: &average,
-				Period:    "600",
-				Hide:      &false,
 			}
 
 			assert.Equal(t, tc.expectedLabel, getLabel(queryToMigrate, true))

--- a/pkg/tsdb/cloudwatch/models/logs_query.go
+++ b/pkg/tsdb/cloudwatch/models/logs_query.go
@@ -1,28 +1,18 @@
 package models
 
-type LogGroup struct {
-	ARN       string `json:"arn"`
-	Name      string `json:"name"`
-	AccountID string `json:"accountId"`
-}
+import (
+	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/kinds/dataquery"
+)
 
 type LogsQuery struct {
-	LogType            string `json:"type"`
-	SubType            string
-	Limit              *int64
-	Time               int64
-	StartTime          *int64
-	EndTime            *int64
-	LogGroupName       string
-	LogGroupNames      []string
-	LogGroups          []LogGroup `json:"logGroups"`
-	LogGroupNamePrefix string
-	LogStreamName      string
-	StartFromHead      bool
-	Region             string
-	QueryString        string
-	QueryId            string
-	StatsGroups        []string
-	Subtype            string
-	Expression         string
+	dataquery.CloudWatchLogsQuery
+	StartTime     *int64
+	EndTime       *int64
+	Limit         *int64
+	LogGroupName  string
+	LogStreamName string
+	QueryId       string
+	QueryString   string
+	StartFromHead bool
+	Subtype       string
 }

--- a/pkg/tsdb/cloudwatch/time_series_query_test.go
+++ b/pkg/tsdb/cloudwatch/time_series_query_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/kinds/dataquery"
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/mocks"
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/models"
 
@@ -270,16 +271,16 @@ type queryDimensions struct {
 }
 
 type queryParameters struct {
-	MetricQueryType  models.MetricQueryType  `json:"metricQueryType"`
-	MetricEditorMode models.MetricEditorMode `json:"metricEditorMode"`
-	Dimensions       queryDimensions         `json:"dimensions"`
-	Expression       string                  `json:"expression"`
-	Alias            string                  `json:"alias"`
-	Label            *string                 `json:"label"`
-	Statistic        string                  `json:"statistic"`
-	Period           string                  `json:"period"`
-	MatchExact       bool                    `json:"matchExact"`
-	MetricName       string                  `json:"metricName"`
+	MetricQueryType  dataquery.CloudWatchMetricsQueryMetricQueryType  `json:"metricQueryType"`
+	MetricEditorMode dataquery.CloudWatchMetricsQueryMetricEditorMode `json:"metricEditorMode"`
+	Dimensions       queryDimensions                                  `json:"dimensions"`
+	Expression       string                                           `json:"expression"`
+	Alias            string                                           `json:"alias"`
+	Label            *string                                          `json:"label"`
+	Statistic        string                                           `json:"statistic"`
+	Period           string                                           `json:"period"`
+	MatchExact       bool                                             `json:"matchExact"`
+	MetricName       string                                           `json:"metricName"`
 }
 
 var queryId = "query id"
@@ -288,11 +289,11 @@ func newTestQuery(t testing.TB, p queryParameters) json.RawMessage {
 	t.Helper()
 
 	tsq := struct {
-		Type             string                  `json:"type"`
-		MetricQueryType  models.MetricQueryType  `json:"metricQueryType"`
-		MetricEditorMode models.MetricEditorMode `json:"metricEditorMode"`
-		Namespace        string                  `json:"namespace"`
-		MetricName       string                  `json:"metricName"`
+		Type             string                                           `json:"type"`
+		MetricQueryType  dataquery.CloudWatchMetricsQueryMetricQueryType  `json:"metricQueryType"`
+		MetricEditorMode dataquery.CloudWatchMetricsQueryMetricEditorMode `json:"metricEditorMode"`
+		Namespace        string                                           `json:"namespace"`
+		MetricName       string                                           `json:"metricName"`
 		Dimensions       struct {
 			InstanceID []string `json:"InstanceId,omitempty"`
 		} `json:"dimensions"`

--- a/public/app/plugins/datasource/cloudwatch/dataquery.cue
+++ b/public/app/plugins/datasource/cloudwatch/dataquery.cue
@@ -23,7 +23,7 @@ import (
 pfs.GrafanaPlugin
 
 composableKinds: DataQuery: {
-	maturity: "merged"
+	maturity: "experimental"
 
 	lineage: {
 		seqs: [


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Hooks up the generated types in the backend for CloudWatch

**Why do we need this feature?**

Part of schematization

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #66061

**Special notes for your reviewer:**

I compared the sample dashboards for CloudWatch with this branch and `main` and didn't notice any problems.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
