### PR TITLE
Alerting: Scheduler to check rule's fingerprint to reset state when version is changed 

### DIFF
--- a/pkg/services/ngalert/models/testing.go
+++ b/pkg/services/ngalert/models/testing.go
@@ -78,6 +78,7 @@ func AlertRuleGen(mutators ...AlertRuleMutator) func() *AlertRule {
 			For:             forInterval,
 			Annotations:     annotations,
 			Labels:          labels,
+			IsPaused:        rand.Int()%2 == 0,
 		}
 
 		for _, mutator := range mutators {
@@ -256,6 +257,7 @@ func CopyRule(r *AlertRule) *AlertRule {
 		NoDataState:     r.NoDataState,
 		ExecErrState:    r.ExecErrState,
 		For:             r.For,
+		IsPaused:        r.IsPaused,
 	}
 
 	if r.DashboardUID != nil {

--- a/pkg/services/ngalert/schedule/registry.go
+++ b/pkg/services/ngalert/schedule/registry.go
@@ -2,9 +2,15 @@ package schedule
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
+	"hash/fnv"
+	"math"
+	"sort"
+	"strconv"
 	"sync"
 	"time"
+	"unsafe"
 
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/util"
@@ -230,4 +236,117 @@ func (r *alertRulesRegistry) getDiff(rules map[models.AlertRuleKey]*models.Alert
 		result.updated[key] = struct{}{}
 	}
 	return result
+}
+
+type Fingerprint uint64
+
+func (f Fingerprint) String() string {
+	return strconv.FormatUint(uint64(f), 10)
+}
+
+// fingerprintSeparator used during calculation of Fingerprint to separate different fields. Contains a byte sequence that cannot happen in UTF-8 strings.
+var fingerprintSeparator = []byte{255}
+
+// Fingerprint calculates a fingerprint that includes all fields except rule's Version and Update timestamp.
+func (r ruleWithFolder) Fingerprint() Fingerprint {
+	rule := r.rule
+
+	sum := fnv.New64()
+
+	writeBytes := func(b []byte) {
+		_, _ = sum.Write(b)
+		_, _ = sum.Write(fingerprintSeparator)
+	}
+	writeString := func(s string) {
+		// avoid allocation when converting string to byte slice
+		writeBytes(*(*[]byte)(unsafe.Pointer(&s))) //nolint:gosec
+	}
+	// this temp slice is used to convert ints to bytes.
+	tmp := make([]byte, 8)
+	writeInt := func(u int64) {
+		binary.LittleEndian.PutUint64(tmp, uint64(u))
+		writeBytes(tmp)
+	}
+
+	// allocate a slice that will be used for sorting keys, so we allocate it only once
+	var keys []string
+	maxLen := int(math.Max(math.Max(float64(len(rule.Annotations)), float64(len(rule.Labels))), float64(len(rule.Data))))
+	if maxLen > 0 {
+		keys = make([]string, maxLen)
+	}
+
+	writeLabels := func(lbls map[string]string) {
+		// maps do not guarantee predictable sequence of keys.
+		// Therefore, to make hash stable, we need to sort keys
+		if len(lbls) == 0 {
+			return
+		}
+		idx := 0
+		for labelName := range lbls {
+			keys[idx] = labelName
+			idx++
+		}
+		sub := keys[:idx]
+		sort.Strings(sub)
+		for _, name := range sub {
+			writeString(name)
+			writeString(lbls[name])
+		}
+	}
+	writeQuery := func() {
+		// The order of queries is not important as they represent an expression tree.
+		// Therefore, the order of elements should not change the hash. Sort by RefID because it is the unique key.
+		for i, q := range rule.Data {
+			keys[i] = q.RefID
+		}
+		sub := keys[:len(rule.Data)]
+		sort.Strings(sub)
+		for _, id := range sub {
+			for _, q := range rule.Data {
+				if q.RefID == id {
+					writeString(q.RefID)
+					writeString(q.DatasourceUID)
+					writeString(q.QueryType)
+					writeInt(int64(q.RelativeTimeRange.From))
+					writeInt(int64(q.RelativeTimeRange.To))
+					writeBytes(q.Model)
+					break
+				}
+			}
+		}
+	}
+
+	// fields that determine the rule state
+	writeString(rule.UID)
+	writeString(rule.Title)
+	writeString(rule.NamespaceUID)
+	writeString(r.folderTitle)
+	writeLabels(rule.Labels)
+	writeString(rule.Condition)
+	writeQuery()
+
+	if rule.IsPaused {
+		writeInt(1)
+	} else {
+		writeInt(0)
+	}
+
+	// fields that do not affect the state.
+	// TODO consider removing fields below from the fingerprint
+	writeInt(rule.ID)
+	writeInt(rule.OrgID)
+	writeInt(rule.IntervalSeconds)
+	writeInt(int64(rule.For))
+	writeLabels(rule.Annotations)
+	if rule.DashboardUID != nil {
+		writeString(*rule.DashboardUID)
+	}
+	if rule.PanelID != nil {
+		writeInt(*rule.PanelID)
+	}
+	writeString(rule.RuleGroup)
+	writeInt(int64(rule.RuleGroupIndex))
+	writeString(string(rule.NoDataState))
+	writeString(string(rule.ExecErrState))
+	return Fingerprint(sum.Sum64())
 }

--- a/pkg/services/ngalert/schedule/registry_bench_test.go
+++ b/pkg/services/ngalert/schedule/registry_bench_test.go
@@ -1,0 +1,30 @@
+package schedule
+
+import (
+	"fmt"
+	"io"
+	"math/rand"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+)
+
+func BenchmarkRuleWithFolderFingerprint(b *testing.B) {
+	rules := models.GenerateAlertRules(b.N, models.AlertRuleGen(func(rule *models.AlertRule) {
+		rule.Data = make([]models.AlertQuery, 0, 5)
+		for i := 0; i < rand.Intn(5)+1; i++ {
+			rule.Data = append(rule.Data, models.GenerateAlertQuery())
+		}
+	}))
+	folder := uuid.NewString()
+	b.ReportAllocs()
+	b.ResetTimer()
+	var f Fingerprint
+	for i := 0; i < b.N; i++ {
+		f = ruleWithFolder{rule: rules[i], folderTitle: folder}.Fingerprint()
+	}
+	b.StopTimer()
+	_, _ = fmt.Fprint(io.Discard, f)
+}

--- a/pkg/services/ngalert/schedule/registry_test.go
+++ b/pkg/services/ngalert/schedule/registry_test.go
@@ -2,13 +2,16 @@ package schedule
 
 import (
 	"context"
+	"encoding/json"
 	"math"
 	"math/rand"
+	"reflect"
 	"runtime"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -398,5 +401,150 @@ func TestSchedulableAlertRulesRegistry_set(t *testing.T) {
 		diff := r.set(newRules, map[string]string{})
 		require.Falsef(t, diff.IsEmpty(), "Diff is empty but should not be")
 		require.Equal(t, expectedUpdated, diff.updated)
+	})
+}
+
+func TestRuleWithFolderFingerprint(t *testing.T) {
+	rule := models.AlertRuleGen()()
+	title := uuid.NewString()
+	f := ruleWithFolder{rule: rule, folderTitle: title}.Fingerprint()
+	t.Run("should calculate a fingerprint", func(t *testing.T) {
+		require.NotEqual(t, 0, uint64(f))
+	})
+	t.Run("mirror copy should have the same fingerprint", func(t *testing.T) {
+		f2 := ruleWithFolder{rule: models.CopyRule(rule), folderTitle: title}.Fingerprint()
+		require.Equal(t, f, f2)
+	})
+	t.Run("order of queries should not affect the fingerprint", func(t *testing.T) {
+		cp := models.CopyRule(rule)
+		rand.Shuffle(len(cp.Data), func(i, j int) {
+			cp.Data[i], cp.Data[j] = cp.Data[j], cp.Data[i]
+		})
+		f2 := ruleWithFolder{rule: cp, folderTitle: title}.Fingerprint()
+		require.Equal(t, f, f2)
+	})
+	t.Run("folder name should be used in fingerprint", func(t *testing.T) {
+		f2 := ruleWithFolder{rule: rule, folderTitle: uuid.NewString()}.Fingerprint()
+		require.NotEqual(t, f, f2)
+	})
+	t.Run("Version and Updated should be excluded from fingerprint", func(t *testing.T) {
+		cp := models.CopyRule(rule)
+		cp.Version++
+		cp.Updated = cp.Updated.Add(1 * time.Second)
+
+		f2 := ruleWithFolder{rule: cp, folderTitle: title}.Fingerprint()
+		require.Equal(t, f, f2)
+	})
+
+	t.Run("all other fields should be considered", func(t *testing.T) {
+		r1 := &models.AlertRule{
+			ID:        1,
+			OrgID:     2,
+			Title:     "test",
+			Condition: "A",
+			Data: []models.AlertQuery{
+				{
+					RefID:     "1",
+					QueryType: "323",
+					RelativeTimeRange: models.RelativeTimeRange{
+						From: 1,
+						To:   2,
+					},
+					DatasourceUID: "123",
+					Model:         json.RawMessage(`{"test": "test-model"}`),
+				},
+			},
+			Updated:         time.Now(),
+			IntervalSeconds: 2,
+			Version:         1,
+			UID:             "test-uid",
+			NamespaceUID:    "test-ns",
+			DashboardUID:    func(s string) *string { return &s }("dashboard"),
+			PanelID:         func(i int64) *int64 { return &i }(123),
+			RuleGroup:       "test-group",
+			RuleGroupIndex:  1,
+			NoDataState:     "test-nodata",
+			ExecErrState:    "test-err",
+			For:             12,
+			Annotations: map[string]string{
+				"key-annotation": "value-annotation",
+			},
+			Labels: map[string]string{
+				"key-label": "value-label",
+			},
+			IsPaused: false,
+		}
+		r2 := &models.AlertRule{
+			ID:        2,
+			OrgID:     3,
+			Title:     "test-2",
+			Condition: "B",
+			Data: []models.AlertQuery{
+				{
+					RefID:     "2",
+					QueryType: "12313123",
+					RelativeTimeRange: models.RelativeTimeRange{
+						From: 2,
+						To:   3,
+					},
+					DatasourceUID: "asdasdasd21",
+					Model:         json.RawMessage(`{"test": "test-model-2"}`),
+				},
+			},
+			IntervalSeconds: 23,
+			UID:             "test-uid2",
+			NamespaceUID:    "test-ns2",
+			DashboardUID:    func(s string) *string { return &s }("dashboard-2"),
+			PanelID:         func(i int64) *int64 { return &i }(1222),
+			RuleGroup:       "test-group-2",
+			RuleGroupIndex:  22,
+			NoDataState:     "test-nodata2",
+			ExecErrState:    "test-err2",
+			For:             1141,
+			Annotations: map[string]string{
+				"key-annotation2": "value-annotation",
+			},
+			Labels: map[string]string{
+				"key-label": "value-label23",
+			},
+			IsPaused: true,
+		}
+
+		excludedFields := map[string]struct{}{
+			"Version": {},
+			"Updated": {},
+		}
+
+		tp := reflect.TypeOf(rule).Elem()
+		var nonDiffFields []string
+		// making sure that we get completely different struct
+
+		dif := r1.Diff(r2)
+		nonDiffFields = make([]string, 0)
+		for j := 0; j < tp.NumField(); j++ {
+			name := tp.Field(j).Name
+			if _, ok := excludedFields[name]; ok {
+				continue
+			}
+			if len(dif.GetDiffsForField(tp.Field(j).Name)) == 0 {
+				nonDiffFields = append(nonDiffFields, tp.Field(j).Name)
+			}
+		}
+		require.Emptyf(t, nonDiffFields, "cannot generate completely unique alert rule. Some fields are not randomized")
+
+		r2v := reflect.ValueOf(r2).Elem()
+		for i := 0; i < tp.NumField(); i++ {
+			if _, ok := excludedFields[tp.Field(i).Name]; ok {
+				continue
+			}
+			cp := models.CopyRule(r1)
+			v := reflect.ValueOf(cp).Elem()
+			vf := v.Field(i)
+			vf.Set(r2v.Field(i))
+			f2 := ruleWithFolder{rule: cp, folderTitle: title}.Fingerprint()
+			if f2 == f {
+				t.Fatalf("Field %s does not seem to be used in Fingerprint. Diff: %s", tp.Field(i).Name, r1.Diff(cp))
+			}
+		}
 	})
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
- reactors scheduler, replaces `ruleVersionAndPauseStatus` to `ruleWithFolder` because since https://github.com/grafana/grafana/pull/64780 the updates come from the scheduler only, and update flow can use the AlertRule model instead of pieces from it. Same as the evaluation flow. 
- Creates method Fingerprint for `ruleWithFolder` that calculates a 64-bit FNV-1 hash. The method is optimized to have as few allocations as possible (the current benchmark gives 6 allocations per operation).
- Updates rule evaluation routine to use fingerprint as the second check after the version check. 

[Add a brief description of what the feature or update does.]

**Why do we need this feature?**

This allows the scheduler to not reset the rule's state every time another rule in the same group is changed. See https://github.com/grafana/grafana/issues/64256

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/64843 and https://github.com/grafana/grafana/issues/64256.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
